### PR TITLE
Reorganize and expand documentation for architecture, presence, and multi-agent systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Intendant
 
-A Rust runtime for autonomous AI agents with process lifecycle management. Intendant executes commands on behalf of AI agents, tracks process state in memory, and persists structured session logs. The CLI supports OpenAI, Anthropic, and Gemini APIs with native tool calling, a ratatui TUI, configurable autonomy, MCP server/client, and multi-agent orchestration.
+A Rust runtime for autonomous AI agents with process lifecycle management. Intendant executes commands on behalf of AI agents, tracks process state in memory, and persists structured session logs. It supports OpenAI, Anthropic, and Gemini APIs with native tool calling, streaming, a ratatui TUI, configurable autonomy and approval gates, MCP server/client, multi-agent orchestration, a conversational presence layer, browser-based voice interaction, and session resume.
 
 ## Architecture
 
@@ -8,7 +8,7 @@ A Rust runtime for autonomous AI agents with process lifecycle management. Inten
                           ┌─────────────────────────────┐
                           │     intendant (caller)       │
                           │                             │
-  TUI / MCP / Live ◄─────┤  presence ── agent loop ──┐ │
+  TUI / MCP / Web ◄─────┤  presence ── agent loop ──┐ │
                           │     │           │         │ │
                           │     │      ┌────┴────┐    │ │
                           │     │      │ sub-agents│   │ │
@@ -21,7 +21,8 @@ A Rust runtime for autonomous AI agents with process lifecycle management. Inten
                       Gemini + streaming)       execution, stdin/stdout)
 ```
 
-**Presence layer** mediates between the user and agent loop — handles conversation, dispatches tasks, narrates events.
+**Presence layer** mediates between the user and agent loop — handles conversation, dispatches tasks, narrates events. Runs as server-side text or browser-side voice (Gemini Live / OpenAI Realtime), with mutual exclusion.
+
 Three execution modes: *direct* (single agent), *user* (orchestrator + sub-agents), *sub-agent* (scoped child task).
 
 ## Quick Start
@@ -48,19 +49,32 @@ echo 'OPENAI_API_KEY=sk-...' > .env
 # Run as MCP server
 ./target/release/intendant --mcp "Deploy the application"
 
-# Live gateway (voice/text from browser)
-./target/release/intendant --live
+# Web gateway (remote TUI + optional voice from browser)
+./target/release/intendant --web
+
+# JSONL structured output
+./target/release/intendant --json "echo hello"
+
+# Resume most recent session
+./target/release/intendant --continue "fix that bug"
+
+# Force single-agent mode (skip orchestrator)
+./target/release/intendant --direct "simple task"
+
+# Enable filesystem sandboxing (Landlock, Linux 5.13+)
+./target/release/intendant --sandbox "run tests"
 ```
 
 ## Testing
 
 ```bash
-cargo test
+cargo test --bins         # Unit tests (fast, no API keys needed)
+cargo test -- --list      # List all test names
 ```
 
 ## Documentation
 
-**[Read the full documentation](https://lovon-spec.github.io/intendant/)** — covers configuration, runtime protocol, TUI & autonomy, MCP server, integrations, and session logging.
+**[Read the full documentation](https://lovon-spec.github.io/intendant/)** — covers architecture, configuration, runtime protocol, TUI & autonomy, multi-agent orchestration, the presence layer, MCP server, integrations, and session logging.
 
 Or build locally with [mdBook](https://rust-lang.github.io/mdBook/):
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,6 +5,8 @@
 - [Configuration](./configuration.md)
 - [Runtime Protocol](./runtime-protocol.md)
 - [TUI & Autonomy](./tui.md)
+- [Multi-Agent Orchestration](./multi-agent.md)
+- [Presence Layer](./presence.md)
 - [MCP Server](./mcp-server.md)
 - [Integrations](./integrations.md)
 - [Session Logging](./session-logging.md)

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -1,5 +1,9 @@
 # Architecture
 
+## Overview
+
+Intendant is a two-binary system: a command **runtime** that executes work, and a **caller** that drives it via AI model APIs.
+
 ```
 stdin (JSON) --> intendant-runtime --> executes commands sequentially (blocking)
                   |
@@ -14,6 +18,7 @@ intendant (3 modes) --> detects project root (git) --> loads memory/knowledge
   +--> Sub-Agent Mode:  scoped task, writes results/progress, isolated context
   +--> Direct Mode:     single-loop execution for simple tasks
   |
+  +--> Presence layer:  conversational mediator between user and agent loop
   +--> Native tool calling (OpenAI/Anthropic/Gemini) with text extraction fallback
   +--> Streaming output:  SSE-based token streaming for all 3 providers
   +--> Ratatui TUI:     status bar, scrollable log, approval panel, askHuman input
@@ -23,31 +28,36 @@ intendant (3 modes) --> detects project root (git) --> loads memory/knowledge
   +--> Landlock sandbox: filesystem restrictions on agent runtime (Linux)
   +--> Prompt caching:  Anthropic cache_control, OpenAI/Gemini implicit caching
   +--> Auto-compaction: triggers at 90% context usage, preserves system+tail messages
-  +--> Optional control socket (--control-socket): /tmp/intendant-<pid>.sock (JSON-line protocol)
-  |       status (with session_id, task), usage, usage_update events
-  +--> Web gateway (--web): WebSocket server for remote TUI + browser-side live model (voice/text)
+  +--> Control socket:  /tmp/intendant-<pid>.sock (JSON-line protocol)
+  +--> Web gateway:     WebSocket server for remote TUI + browser-side voice (Gemini Live / OpenAI Realtime)
   +--> Token budget tracking (context-window-aware loop termination)
-  +--> Sub-agent spawning via env vars (INTENDANT_ROLE, INTENDANT_ID, etc.)
+  +--> Session resume:  --continue (most recent) or --resume <id> (specific session)
   +--> Git worktree isolation for implementation agents
   +--> Tagged knowledge store with pub/sub channels between agents
-  +--> Presence layer: conversational mediator between user and agent loop
 ```
 
-- **Process State:** In-memory `HashMap<u64, ProcessInfo>` tracking nonce, PID, status, exit code, and timestamp. Ephemeral — does not survive binary restarts.
-- **Session Directory (`~/.intendant/logs/<uuid>/`):** Per-session directory with UUID-based naming. Contains per-nonce stdout/stderr log files, structured session logs, conversation history, and askHuman IPC files. The log directory is passed to the runtime via `INTENDANT_LOG_DIR`.
-- **Execution Model:** Commands are processed sequentially. Each command blocks until completion and returns its result directly (exit code, stdout tail, stderr tail). The runtime exits after processing all commands.
+## Process State
+
+In-memory `HashMap<u64, ProcessInfo>` tracking nonce, PID, status, exit code, and timestamp. Ephemeral — does not survive binary restarts. Each runtime invocation starts with an empty process map.
+
+## Session Directory
+
+Per-session directory at `~/.intendant/logs/<uuid>/` with UUID-based naming. Contains per-nonce stdout/stderr log files, structured session logs (`session.jsonl`), conversation history (`conversation.jsonl`), and askHuman IPC files. The log directory is passed to the runtime via `INTENDANT_LOG_DIR`.
+
+## Execution Model
+
+Commands are processed sequentially. Each command blocks until completion and returns its result directly (exit code, stdout tail, stderr tail). The runtime exits after processing all commands. Daemons backgrounded in bash continue after the tool returns.
 
 ## Execution Modes
 
-`intendant` operates in one of three modes, selected automatically:
+`intendant` operates in one of three modes, selected automatically based on task complexity and environment:
 
-### Sub-Agent Mode
+### Direct Mode
 
-Activated when `INTENDANT_ROLE` env var is set:
-- Runs as a child agent with a scoped task
-- Writes periodic progress to `INTENDANT_PROGRESS_FILE`
-- Writes final results (summary, findings, artifacts, token usage) to `INTENDANT_RESULT_FILE`
-- Uses role-specific system prompts (`SysPrompt_research.md`, `SysPrompt_implementation.md`, etc.)
+Activated for simple tasks, or forced with `--direct`:
+- Single-loop execution with the selected model
+- Budget-aware loop: stops at context exhaustion, `done` signal, or 500-turn safety cap
+- Used for short tasks that don't need multi-agent orchestration
 
 ### User Mode
 
@@ -58,41 +68,15 @@ Activated for complex tasks without `INTENDANT_ROLE`:
 - Reads the orchestrator's result file on exit; synthesizes a failure if the process crashes
 - `kill_on_drop(true)` ensures the orchestrator is terminated if the user quits the TUI
 
-### Direct Mode
+### Sub-Agent Mode
 
-Activated for simple tasks without `INTENDANT_ROLE`:
-- Single-loop execution similar to the original behavior
-- Used for short, single-line tasks that don't need orchestration
+Activated when `INTENDANT_ROLE` env var is set:
+- Runs as a child agent with a scoped task
+- Writes periodic progress to `INTENDANT_PROGRESS_FILE`
+- Writes final results (summary, findings, artifacts, token usage) to `INTENDANT_RESULT_FILE`
+- Uses role-specific system prompts (`SysPrompt_research.md`, `SysPrompt_implementation.md`, etc.)
 
-### Presence Mode
-
-When the presence layer is enabled (default, disable with `--no-presence` or `[presence] enabled = false`):
-- A small/fast model (configurable via `[presence]` in `intendant.toml`) acts as the conversational front-end
-- The user talks to the presence layer, which delegates coding tasks to the agent loop via `submit_task`
-- The presence layer narrates agent events (phase changes, approvals, completions) in first person
-- Handles status queries, memory recall, and autonomy changes directly without involving the agent loop
-- Uses its own system prompt (`SysPrompt_presence.md`) — standalone, not appended to the base prompt
-- Follow-up input in the TUI is routed through the presence layer when active
-
-Presence can run in two modes, but only one is active at a time (mutual exclusion):
-
-#### Server-Side Text Presence
-
-The default mode. A text model (e.g. `gemini-2.5-flash`) runs server-side inside `PresenceLayer`, processing events and generating narration text displayed in the TUI.
-
-#### Browser-Side Live Presence
-
-When `--web` is used and a browser connects a live model (Gemini Live / OpenAI Realtime), the browser sends a `live_connected` message over WebSocket. This sets a shared `AtomicBool` flag that pauses server-side presence — `PresenceLayer::handle_event()` returns `Ok(None)` while paused. The browser's live model takes over as the conversational front-end, using the same 9 tools via the WebSocket tool request/response protocol.
-
-When the browser's live model disconnects (page close, error), a `live_disconnected` message is sent and server-side presence resumes automatically.
-
-Both modes share the same tool implementations via standalone query functions (`query_detail()`, `recall_memory()`, `handle_tool_query()`) in `presence.rs`.
-
-### Orchestrator Checkpointing
-
-The orchestrator writes project state checkpoints after each sub-agent completes, using `storeMemory` with a `project_state` channel. Checkpoints capture completed/active tasks, architectural decisions, and constraints. This preserves essential context across auto-compaction boundaries — when context is compacted at ~60% usage, the orchestrator can recover state via `recallMemory`.
-
-Checkpoints are also written to disk as both `project_state.json` (machine-readable) and `project_state.md` (human-readable) in the sub-agent directory.
+See [Multi-Agent Orchestration](./multi-agent.md) for the full sub-agent architecture.
 
 ## How It Works (Direct Mode)
 
@@ -102,48 +86,84 @@ Checkpoints are also written to disk as both `project_state.json` (machine-reada
 4. Resolves role-appropriate system prompt via cascade: project root → `~/.config/intendant/` → compiled-in default. When native tools are enabled, uses the condensed `SysPrompt_tools.md` (tool docs live in API tool definitions instead of prose)
 5. Injects the project working directory into the conversation so the model knows which project to work in
 6. Loads knowledge from `<project>/.intendant/memory.json`, injects into conversation
-7. Logs the full messages array to `turn_NNN_messages.json` before each API call
-8. Sends the task to the chat API via streaming (`chat_stream()`), with `max_tokens`/`max_output_tokens`, optional `reasoning`, optional JSON format, and native tool definitions when enabled. API requests use exponential backoff retry (up to 5 retries) for rate-limit (429) and server errors (5xx). Text deltas are forwarded to the TUI in real-time
-9. Logs reasoning content (both summary and full text) to `turn_NNN_reasoning.txt` when available
-10. Processes the model's response via one of two paths:
+7. Loads `INTENDANT.md` project instructions (global then project-local), injects into conversation
+8. Logs the full messages array to `turn_NNN_messages.json` before each API call
+9. Sends the task to the chat API via streaming (`chat_stream()`), with `max_tokens`/`max_output_tokens`, optional `reasoning`, optional JSON format, and native tool definitions when enabled. API requests use exponential backoff retry (up to 5 retries) for rate-limit (429) and server errors (5xx). Text deltas are forwarded to the TUI in real-time
+10. Logs reasoning content (both summary and full text) to `turn_NNN_reasoning.txt` when available
+11. Processes the model's response via one of two paths:
     - **Native tool call path** (when response contains tool calls): Collects individual tool calls, assembles them into an `AgentInput` batch, pipes to the runtime, maps results back to per-tool-call responses. Handles `manage_context` and `signal_done` tool calls caller-side. Raw API output items (reasoning + function_call) are preserved for verbatim echo-back in subsequent requests, which reasoning models (GPT-5, o3, o4) require
     - **Legacy text extraction path** (fallback): Extracts JSON from the response text (handles structured output, code fences, and bare JSON), checks for explicit `done` signal (`{"done": true}`)
-11. Applies context directives (`drop_turns`, `summarize`) to the conversation
-12. Injects project context (`memory_file`) into relevant commands
-13. Classifies commands by action category (file read/write/delete, exec, network, destructive) and checks autonomy rules
-14. If approval is required:
+12. Applies context directives (`drop_turns`, `summarize`) to the conversation
+13. Injects project context (`memory_file`) into relevant commands
+14. Classifies commands by action category (file read/write/delete, exec, network, destructive) and checks autonomy rules
+15. If approval is required:
     - TUI mode: emits an approval request and waits for user response
     - Headless mode: denies execution (no implicit auto-approve fallback)
-15. Pipes the JSON to the `intendant-runtime` binary and waits for completion with a hard timeout (120s default, 600s for `askHuman`)
-16. Feeds the agent output back as the next user message (text path) or as individual tool results (tool call path), appending a token budget summary
-17. Repeats until the model signals done, responds with no JSON, or the context budget is exhausted
-18. In headless mode, if the model emits `askHuman`, the loop now sends a recovery prompt back to the model (continue with explicit assumptions) instead of blocking on human-input timeout
+16. Pipes the JSON to the `intendant-runtime` binary and waits for completion with a hard timeout (120s default, 600s for `askHuman`)
+17. Feeds the agent output back as the next user message (text path) or as individual tool results (tool call path), appending a token budget summary
+18. Repeats until the model signals done, responds with no JSON, or the context budget is exhausted
+19. In headless mode, if the model emits `askHuman`, the loop sends a recovery prompt back to the model (continue with explicit assumptions) instead of blocking on human-input timeout
 
 ## askHuman Behavior
 
 - In **TUI mode**, `askHuman` opens the input panel and writes your answer to the session-scoped response file.
 - Empty submit is rejected in the TUI; you must provide non-empty input or press `Esc` to cancel.
-- In **headless mode** (`--no-tui` or non-interactive stdin), `askHuman` cannot be answered interactively. The loop now tells the model to continue with explicit assumptions instead of waiting for the runtime timeout.
-- Runtime-level timeout for unanswered `askHuman` remains `5 minutes`.
+- In **headless mode** (`--no-tui` or non-interactive stdin), `askHuman` cannot be answered interactively. The loop tells the model to continue with explicit assumptions instead of waiting for the runtime timeout.
+- Runtime-level timeout for unanswered `askHuman` remains 5 minutes.
 
-## Environment
+## Streaming
 
-- **OS:** Debian 12+
-- **Runtime:** Tokio async
-- **Display:** Xvfb is auto-launched lazily on the first turn containing an `execAsAgent` or `captureScreen` command when no accessible X display exists (checked via `xdpyinfo`). Display allocation prefers `:99` for a predictable VNC port (5999). An `x11vnc` server is co-launched alongside Xvfb for remote VNC observation (port = `5900 + display_id`); if `x11vnc` is not installed, the display works normally. Orphaned Xvfb processes from crashed sessions are detected via `/proc/<pid>/cmdline` and automatically reclaimed. The guard is kept for the session lifetime so subsequent calls reuse the same display. At startup the runtime discovers active X displays and merges their xauth cookies (from `~/.Xauthority` and `/var/run/lightdm/root/:N` via `sudo -n`) into a session-scoped `session.Xauthority` file, which is passed as `XAUTHORITY` to all spawned commands.
-- **Permissions:** Runs as unprivileged user with passwordless sudo
+All three providers support streaming via `chat_stream()` on the `ChatProvider` trait:
 
-## VNC Remote Observation
+- **Anthropic**: `stream: true` on Messages API, parses `content_block_delta`, `content_block_start/stop`, `message_delta`
+- **OpenAI**: `stream: true` on Responses API, parses `response.output_text.delta`, `response.function_call_arguments.delta`, `response.completed`
+- **Gemini**: `streamGenerateContent?alt=sse` endpoint, parses chunked JSON candidates
 
-When running intendant in a VM (or any headless machine), you can watch the agent's GUI activity in real time via VNC.
+Text deltas are forwarded to the TUI via `AppEvent::ModelResponseDelta` and accumulated in `App::streaming_buffer`, which is cleared when the full `ModelResponse` arrives.
+
+## Rate-Limit Retry
+
+API requests use `send_with_retry()` with exponential backoff (1s × 2^attempt + jitter, up to 5 retries) for HTTP 429 and 5xx responses. Non-retryable errors (400, 401, etc.) fail immediately. API keys in error messages are masked via `mask_api_keys()`.
+
+## Prompt Caching
+
+- **Anthropic**: Uses `anthropic-beta: prompt-caching-2024-07-31` header with structured system content containing `cache_control: {"type": "ephemeral"}`
+- **OpenAI**: Automatic server-side caching for prompts >1024 tokens (no API changes needed)
+- **Gemini**: Implicit context caching (no API changes needed)
+
+## Auto-Compaction
+
+When context usage reaches 90% (`usage_fraction() >= 0.90`), `conversation.auto_compact()` triggers:
+- Keeps: system message, first 2 context messages, last 4 messages
+- Summarizes: oldest half of remaining middle messages via `summarize_turns()`
+- Emits `ContextManagement` event to TUI/MCP
+
+## Vision / Display Management
+
+Xvfb is auto-launched lazily on the first turn containing an `execAsAgent` or `captureScreen` command when no accessible X display exists (checked via `xdpyinfo`). The detection flow:
+
+1. Already launched? → skip
+2. Batch contains `execAsAgent` or `captureScreen`? No → skip
+3. Current `DISPLAY` accessible? Yes → skip (user has working display)
+4. Auto-launch Xvfb, store guard, set `DISPLAY`, emit `DisplayReady` event
+5. On failure → log warning, let `captureScreen` fail naturally
+
+Display allocation prefers `:99` for a predictable VNC port (5999). If `:99` is locked by a live Xvfb from a previous session, it is automatically killed and reclaimed (detected via `/proc/<pid>/cmdline`). If `:99` is held by a non-Xvfb process, allocation falls through to `:100+`.
+
+Per-provider display resolutions:
+- **OpenAI**: 1024×768 (3 tiles of 512×512)
+- **Anthropic**: 819×1456 (9:16 aspect)
+- **Gemini**: 768×1024 (2 tiles of 768×768)
+
+### VNC Remote Observation
+
+An `x11vnc` server is launched alongside Xvfb as a best-effort co-process (port = `5900 + display_id`). If `x11vnc` is not installed, the display works normally. Both Xvfb and x11vnc are killed on drop via `XvfbGuard`.
 
 **On the guest VM** — install `x11vnc`:
 
 ```bash
 sudo apt-get install -y x11vnc
 ```
-
-That's it. When intendant auto-launches a virtual display, it automatically starts an `x11vnc` server alongside it. The default display is `:99` with VNC on port **5999**.
 
 **From your host machine** — connect with any VNC client:
 
@@ -161,3 +181,11 @@ If display `:99` was already taken, intendant falls through to `:100+` and the V
 ```
 22:29:12  VNC server available at vnc://localhost:5999
 ```
+
+## Environment
+
+- **OS:** Linux (Debian 12+)
+- **Runtime:** Tokio async (full features)
+- **Permissions:** Runs as unprivileged user with passwordless sudo
+- **Display:** Auto-managed Xvfb with x11vnc (see above)
+- **X11 auth:** At startup the runtime discovers active X displays and merges their xauth cookies into a session-scoped `session.Xauthority` file, passed as `XAUTHORITY` to all spawned commands

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -6,7 +6,7 @@
 |------|-------------|
 | `--provider <name>` | Force provider (`openai`, `anthropic`, or `gemini`) |
 | `--model <name>` | Override model name |
-| `--verbose` | Show debug-level log entries in TUI |
+| `--verbose` / `-v` | Show debug-level log entries in TUI |
 | `--no-tui` | Disable TUI, use plain text output |
 | `--autonomy <level>` | Set autonomy level (`low`, `medium`, `high`, `full`) |
 | `--log-file <dir>` | Override session log directory |
@@ -16,9 +16,9 @@
 | `--sandbox` | Enable Landlock filesystem sandboxing (Linux kernel 5.13+) |
 | `--direct` | Force single-agent direct mode (skip orchestrator even for complex tasks) |
 | `--no-presence` | Disable the presence layer (direct agent interaction) |
-| `--continue` | Resume most recent session for this project |
-| `--resume <id>` | Resume specific session by ID or prefix |
-| `--web` | Start web gateway for remote TUI + optional voice/text interaction (default port 8765, implies `--mcp`) |
+| `--continue` / `-c` | Resume most recent session for this project |
+| `--resume <id>` / `-r <id>` | Resume specific session by ID or prefix |
+| `--web [PORT]` | Start web gateway for remote TUI + optional voice/text interaction (default port 8765) |
 
 The TUI launches only when both stdin and stdout are terminals. When piping input/output or in sub-agent mode, `intendant` falls back to headless mode.
 
@@ -37,15 +37,25 @@ The TUI launches only when both stdin and stdout are terminals. When piping inpu
 | `STRUCTURED_OUTPUT` | `true` for gpt-5+/o3/o4 | Enable JSON object mode for deterministic parsing |
 | `REASONING_EFFORT` | — | Reasoning effort for GPT-5/o3/o4 models (`low`, `medium`, `high`) |
 | `REASONING_SUMMARY` | — | Reasoning summary mode (`auto`, `concise`, `detailed`) |
-| `INTENDANT_ROLE` | — | Sub-agent role (`orchestrator`, `research`, `implementation`, `testing`) |
-| `INTENDANT_ID` | — | Unique sub-agent identifier |
-| `INTENDANT_RESULT_FILE` | — | Path for sub-agent to write final results |
-| `INTENDANT_PROGRESS_FILE` | — | Path for sub-agent to write periodic progress |
-| `INTENDANT_TASK` | — | Task description for sub-agent mode |
-| `INTENDANT_PARENT_KNOWLEDGE` | — | Path to parent's knowledge store for inheritance |
-| `INTENDANT_LOG_DIR` | auto | Session log directory (set automatically by caller for the runtime) |
 | `PRESENCE_PROVIDER` | — | Override provider for the presence layer (fallback: `PROVIDER`) |
 | `PRESENCE_MODEL` | — | Override model for the presence layer |
+| `INTENDANT_LOG_DIR` | auto | Session log directory (set automatically by caller for the runtime) |
+
+### Sub-Agent Environment Variables
+
+These are set automatically when spawning sub-agents (see [Multi-Agent Orchestration](./multi-agent.md)):
+
+| Variable | Description |
+|----------|-------------|
+| `INTENDANT_ROLE` | Sub-agent role (`orchestrator`, `research`, `implementation`, `testing`) |
+| `INTENDANT_ID` | Unique sub-agent identifier |
+| `INTENDANT_TASK` | Task description for the sub-agent |
+| `INTENDANT_RESULT_FILE` | Path for sub-agent to write final results |
+| `INTENDANT_PROGRESS_FILE` | Path for sub-agent to write periodic progress |
+| `INTENDANT_PARENT_KNOWLEDGE` | Path to parent's knowledge store for inheritance |
+| `INTENDANT_INHERIT_MEMORY` | `1` to inherit project memory |
+| `INTENDANT_SANDBOX_WRITE_PATHS` | Landlock write paths (set by caller when sandboxing) |
+| `INTENDANT_MCP_RELOAD` | `1` when process was exec'd for MCP hot-reload |
 
 The agent runner hard timeout is 120s default, automatically extended to 600s when `askHuman` is present in the command batch.
 
@@ -99,7 +109,7 @@ args = ["-y", "@modelcontextprotocol/server-github"]
 GITHUB_TOKEN = "ghp_..."
 ```
 
-When sandboxing is enabled (via `--sandbox` or `[sandbox].enabled = true`), runtime command execution is restricted to read-only filesystem access plus writes to project root, `/tmp`, session log directory, `~/.intendant`, and `extra_write_paths`.
+When sandboxing is enabled (via `--sandbox` or `[sandbox].enabled = true`), runtime command execution is restricted to read-only filesystem access plus writes to project root, `/tmp`, session log directory, `~/.intendant`, and `extra_write_paths`. On kernels without Landlock support, sandboxing is silently skipped.
 
 ## INTENDANT.md Project Instructions
 
@@ -120,6 +130,6 @@ Prompts are resolved using a 3-layer cascade (highest priority first):
 2. **Global config** — `~/.config/intendant/SysPrompt.md` or `SysPrompt_tools.md` (user-wide customization)
 3. **Compiled-in default** — always available, zero-config
 
-Role-specific prompts (`SysPrompt_orchestrator.md`, `SysPrompt_research.md`, `SysPrompt_implementation.md`) follow the same cascade and are appended to the base prompt.
+Role-specific prompts (`SysPrompt_orchestrator.md`, `SysPrompt_research.md`, `SysPrompt_implementation.md`) follow the same cascade and are appended to the base prompt. The presence layer uses its own standalone prompt (`SysPrompt_presence.md`).
 
 To customize prompts for a specific project, place your modified `.md` files in the project's git root. For user-wide customization, place them in `~/.config/intendant/`.

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -71,17 +71,47 @@ MODEL_NAME=gpt-5.2-codex # optional, provider-specific default used if omitted
 # Verbose output (show debug-level log entries)
 ./target/release/intendant --verbose "echo hello"
 
+# JSONL structured output (implies --no-tui)
+./target/release/intendant --json "echo hello"
+
+# Resume most recent session for this project
+./target/release/intendant --continue "fix that bug"
+
+# Resume specific session by ID or prefix
+./target/release/intendant --resume abc123 "continue"
+
+# Force single-agent mode (skip orchestrator)
+./target/release/intendant --direct "simple task"
+
 # Web TUI (remote terminal + optional voice, default port 8765)
 ./target/release/intendant --web
 
 # Web TUI on custom port
 ./target/release/intendant --web 9000
+
+# Enable filesystem sandboxing (Landlock, Linux 5.13+)
+./target/release/intendant --sandbox "run tests"
+
+# Run as MCP server (stdio transport)
+./target/release/intendant --mcp "Deploy the application"
+
+# Enable Unix control socket
+./target/release/intendant --control-socket "task"
+
+# Disable the presence layer
+./target/release/intendant --no-presence "task"
+
+# Pipe input (auto-detects non-TTY, runs headless)
+echo "task" | ./target/release/intendant
 ```
 
 ## Testing
 
 ```bash
-cargo test
+cargo test --bins         # Unit tests (fast, no API keys needed)
+cargo test -- --list      # List all test names
 ```
 
-The test suite covers both binaries. See [Session Logging](./session-logging.md) for the full test coverage summary.
+The test suite covers both binaries with inline `#[cfg(test)]` modules. See [Session Logging](./session-logging.md) for the full test coverage summary.
+
+Integration tests in `tests/e2e/` spawn a real binary and make real API calls — see [Architecture](./architecture.md) for details.

--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -1,12 +1,14 @@
 # Integrations
 
+This chapter covers the control socket (Unix domain socket) and web gateway (WebSocket) integration points. For the MCP server interface, see [MCP Server](./mcp-server.md). For the presence layer that mediates user interaction, see [Presence Layer](./presence.md).
+
 ## Control Socket
 
-When `--control-socket` is enabled, a Unix domain socket is created at `/tmp/intendant-<pid>.sock`.
+When `--control-socket` is enabled, a Unix domain socket is created at `/tmp/intendant-<pid>.sock`. This enables programmatic control of a running Intendant instance from external scripts and tools.
 
-- Outbound event broadcast is implemented.
-- Inbound command handling is implemented for status, approval, denial, human input, autonomy change, quit, controller-restart workflow commands, and controller-loop intervention commands (in MCP mode).
-- Socket server is opt-in via `--control-socket`.
+- Outbound event broadcast to all connected clients
+- Inbound command handling for status, approval, denial, human input, autonomy change, quit, controller-restart workflow commands, and controller-loop intervention commands (in MCP mode)
+- Socket server is opt-in via `--control-socket`
 
 ### Inbound Commands (JSON-line)
 
@@ -60,6 +62,8 @@ echo '{"action":"status"}' | socat - UNIX:/tmp/intendant-$(pgrep intendant).sock
 ## Web Gateway
 
 The `--web` flag starts a WebSocket server that serves a remote TUI (xterm.js) and optionally enables browser-side live model interaction (voice/text) via the Gemini Live API or OpenAI Realtime API. `--web` implies `--mcp`, so no initial task is required — the agent starts idle and accepts tasks dynamically.
+
+See [TUI & Autonomy — Web TUI](./tui.md#web-tui) for setup instructions and [Presence Layer](./presence.md) for details on the mutual exclusion between server-side and browser-side presence.
 
 ### How It Works
 

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -1,6 +1,6 @@
 # MCP Server
 
-The `--mcp` flag launches Intendant as a [Model Context Protocol](https://modelcontextprotocol.io/) server on stdio. This lets external AI agents (Claude Code, Codex, etc.) observe and control Intendant with full parity to the TUI — every action a human can take in the TUI is available as an MCP tool.
+The `--mcp` flag launches Intendant as a [Model Context Protocol](https://modelcontextprotocol.io/) server on stdio. This lets external AI agents (Claude Code, Codex, etc.) observe and control Intendant with full parity to the TUI — every action a human can take in the TUI is available as an MCP tool. The server also supports connecting to external MCP servers as a client (see [MCP Client](#mcp-client) below).
 
 ## Running
 
@@ -161,3 +161,30 @@ Controller loop monitoring files (for `restart_command` scripts):
 3. When an approval is needed, `get_pending_approval` returns the command preview — call `approve`, `deny`, or `skip`
 4. When `askHuman` triggers, `get_pending_input` returns the question — call `respond` with your answer
 5. Call `quit` when done
+
+## MCP Client
+
+Intendant can also act as an MCP **client**, connecting to external MCP servers configured in `intendant.toml`. This lets agents use tools from external servers (filesystem, GitHub, databases, etc.) alongside Intendant's native tools.
+
+### Configuration
+
+```toml
+[[mcp_servers]]
+name = "filesystem"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+
+[[mcp_servers]]
+name = "github"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+
+[mcp_servers.env]
+GITHUB_TOKEN = "ghp_..."
+```
+
+### How It Works
+
+At startup, `McpClientManager` connects to all configured servers via child process transport, discovers their tools, and registers them with the `mcp__<server>_<tool>` naming convention. For example, a `filesystem` server's `read_file` tool becomes `mcp__filesystem_read_file`.
+
+Tool calls with the `mcp__` prefix are routed through the MCP client manager to the appropriate server. If a server fails to connect at startup, it is skipped with a warning — other servers and native tools continue to work.

--- a/docs/src/multi-agent.md
+++ b/docs/src/multi-agent.md
@@ -1,0 +1,133 @@
+# Multi-Agent Orchestration
+
+Intendant supports multi-agent orchestration where a parent orchestrator decomposes complex tasks into sub-tasks and delegates them to specialized child agents. Each agent runs as a separate `intendant` process with its own context window, system prompt, and session log.
+
+## How It Works
+
+```
+User (TUI / MCP / Web)
+    │
+    ▼
+[User Mode] — pure subprocess monitor, zero API calls
+    │
+    ▼
+[Orchestrator Sub-Agent] — decomposes task, coordinates
+    ├──▶ [Research Agent]       — investigation, file reading, browsing
+    ├──▶ [Implementation Agent] — code writing, builds, tests (git worktree)
+    └──▶ [Testing Agent]        — validation, test execution
+    │
+    ▼
+Results merged, knowledge consolidated
+```
+
+When a complex task is submitted (and `--direct` is not set), intendant enters **User Mode**: it spawns an orchestrator sub-agent and monitors its progress without making any model API calls itself. The orchestrator then spawns specialized sub-agents as needed.
+
+## Agent Roles
+
+Each sub-agent role has a dedicated system prompt that is appended to the base prompt:
+
+| Role | Prompt | Focus |
+|------|--------|-------|
+| `orchestrator` | `SysPrompt_orchestrator.md` | Task decomposition, sub-agent management, coordination, checkpointing |
+| `research` | `SysPrompt_research.md` | Investigation, file reading, browsing, synthesizing findings |
+| `implementation` | `SysPrompt_implementation.md` | Code writing, builds, testing, git worktree isolation |
+| `testing` | `SysPrompt_testing.md` | Validation, test execution, coverage |
+
+## Sub-Agent Spawning
+
+Sub-agents are spawned via `tokio::process::Command` with environment variables that configure their behavior:
+
+| Variable | Purpose |
+|----------|---------|
+| `INTENDANT_ROLE` | Agent role (triggers sub-agent mode) |
+| `INTENDANT_ID` | Unique identifier for this agent |
+| `INTENDANT_TASK` | Task description |
+| `INTENDANT_RESULT_FILE` | Path to write final results |
+| `INTENDANT_PROGRESS_FILE` | Path to write periodic progress |
+| `INTENDANT_PARENT_KNOWLEDGE` | Path to parent's knowledge store |
+| `INTENDANT_INHERIT_MEMORY` | `1` to inherit project memory |
+
+## Progress and Results
+
+### Progress Polling
+
+The parent agent polls each sub-agent's progress file every 500ms. Progress is a JSON file with:
+
+```json
+{
+  "turn": 5,
+  "status": "running",
+  "last_action": "Running cargo test",
+  "question": null
+}
+```
+
+Progress updates are relayed to the TUI or stdout as `OrchestratorProgress` events.
+
+### Result Files
+
+When a sub-agent completes, it writes a result JSON file:
+
+```json
+{
+  "id": "research-1",
+  "status": "Completed",
+  "summary": "Found 3 relevant API endpoints...",
+  "findings": ["endpoint /api/users supports pagination", "..."],
+  "artifacts": ["docs/api-analysis.md"],
+  "usage": { "tokens_used": 15000, "context_window": 128000 }
+}
+```
+
+The orchestrator reads result files to synthesize final outcomes and route knowledge between agents.
+
+## Git Worktree Isolation
+
+Implementation agents can work in isolated git worktrees to avoid conflicts with the main working tree:
+
+- **Create**: `worktree.rs` creates a new worktree branch for the agent
+- **Merge**: On successful completion, the orchestrator merges the worktree branch back
+- **Conflict handling**: If merge conflicts arise, the orchestrator is prompted to resolve them
+- **Cleanup**: Worktrees are removed after merge or on failure
+
+This allows multiple implementation agents to work on different parts of the codebase simultaneously without stepping on each other.
+
+## Knowledge Routing
+
+The knowledge system supports inter-agent communication via pub/sub channels:
+
+- **Publishing**: Agents store findings with tagged channels (e.g., `"findings"`, `"decisions"`, `"project_state"`)
+- **Subscribing**: The orchestrator sets up subscriptions between agents so they receive relevant knowledge
+- **Cursor tracking**: Each subscription tracks which entries have been consumed, ensuring agents only see new knowledge
+- **Inheritance**: Sub-agents can inherit the parent's knowledge store via `INTENDANT_INHERIT_MEMORY`
+
+### Example Flow
+
+1. Research agent discovers database configuration → publishes to `"findings"` channel with tag `"database"`
+2. Orchestrator routes `"findings"` to implementation agent
+3. Implementation agent receives the database config via `recallMemory` with channel filter
+4. Implementation agent writes code using discovered config
+
+## Orchestrator Checkpointing
+
+The orchestrator writes project state checkpoints after each sub-agent completes, using `storeMemory` with a `project_state` channel. Checkpoints capture:
+
+- Completed and active tasks
+- Architectural decisions made so far
+- Constraints and dependencies discovered
+
+This preserves essential context across auto-compaction boundaries — when context is compacted at ~90% usage, the orchestrator can recover state via `recallMemory`.
+
+Checkpoints are also written to disk as both `project_state.json` (machine-readable) and `project_state.md` (human-readable) in the sub-agent directory.
+
+## Configuration
+
+Orchestration behavior can be tuned in `intendant.toml`:
+
+```toml
+[orchestrator]
+max_parallel_agents = 4                    # max concurrent sub-agents
+sub_agent_dir = ".intendant/subagents"     # workspace directory for sub-agents
+```
+
+To force single-agent mode and skip orchestration entirely, use the `--direct` flag.

--- a/docs/src/presence.md
+++ b/docs/src/presence.md
@@ -1,0 +1,145 @@
+# Presence Layer
+
+The presence layer is the conversational interface between the user and the agent system. It mediates all interaction: the user talks to presence, presence delegates work via `submit_task`, and narrates progress as events stream back from the agent loop.
+
+## Architecture
+
+Only one presence model is active at a time — either server-side text presence OR browser-side live presence (Gemini Live / OpenAI Realtime). Never both simultaneously.
+
+```
+User input ──▶ [Presence Layer] ──▶ submit_task ──▶ Agent Loop
+                     │                                  │
+                     │◀── events (phase, approval, etc) ◀┘
+                     │
+                     ▼
+              Narration to user (TUI / Web)
+```
+
+## Server-Side Text Presence
+
+The default mode. `PresenceLayer` wraps a small/fast text model (e.g., `gemini-2.5-flash`) and maintains its own `Conversation` separate from the agent's.
+
+### Behavior
+
+- Processes user input via `process_user_input()` — decides whether to handle directly or delegate to the agent loop
+- Narrates agent events via `handle_event()` — translates phase changes, approvals, completions into conversational updates
+- Handles status queries, memory recall, and autonomy changes directly without involving the agent loop
+- Uses its own system prompt (`SysPrompt_presence.md`) — standalone, not appended to the base agent prompt
+- Follow-up input in the TUI is routed through the presence layer when active
+
+### Configuration
+
+```toml
+[presence]
+enabled = true                # default: true
+provider = "gemini"           # provider for the presence model (optional)
+model = "gemini-2.5-flash"    # model for the presence layer (optional)
+context_window = 32768        # context window for presence conversation (default: 32768)
+```
+
+Or via environment variables:
+- `PRESENCE_PROVIDER` — override provider (fallback: `PROVIDER`)
+- `PRESENCE_MODEL` — override model
+
+Disable with `--no-presence` flag or `[presence] enabled = false` in `intendant.toml`.
+
+## Browser-Side Live Presence
+
+When `--web` is used and a browser connects a live model (Gemini Live / OpenAI Realtime), the browser sends a `live_connected` message over WebSocket. This pauses server-side presence — `PresenceLayer::handle_event()` returns `Ok(None)` while paused. The browser's live model takes over as the conversational front-end, using the same 9 tools via the WebSocket tool request/response protocol.
+
+When the browser's live model disconnects (page close, error), a `live_disconnected` message is sent and server-side presence resumes automatically.
+
+### Configuration
+
+```toml
+[presence]
+audio_model = "gemini-2.5-flash-live"  # model for browser-side live presence (optional)
+```
+
+Voice requires an API key (Gemini or OpenAI), stored in browser localStorage. The key is used browser-side only — it is never sent to the Intendant server.
+
+## Presence Tools
+
+The presence layer has 9 tools, defined in the `presence-core` workspace crate:
+
+### Action Tools
+
+| Tool | Description |
+|------|-------------|
+| `submit_task` | Submit a new task to the agent loop |
+| `approve_action` | Approve a pending action |
+| `deny_action` | Deny a pending action |
+| `skip_action` | Skip a pending action |
+| `respond_to_question` | Answer an `askHuman` question |
+| `set_autonomy` | Change autonomy level |
+
+Action tools dispatch via the EventBus as `ControlMsg` — the same path as TUI key presses and control socket commands.
+
+### Query Tools
+
+| Tool | Description |
+|------|-------------|
+| `check_status` | Read current `AgentStateSnapshot` (phase, turn, budget, pending approval/question) |
+| `query_detail` | Get git diff, file contents, or log details from the project |
+| `recall_memory` | Search the knowledge store by keywords, with optional channel/tag filters; falls back to session log |
+
+Query tools are handled synchronously server-side. They are shared between `PresenceLayer` and the web gateway via standalone functions in `presence.rs`.
+
+## Event Filtering
+
+Not all agent events are worth narrating. The presence layer classifies events as:
+
+**Push-worthy** (trigger narration):
+- `TaskSubmitted`, `TaskComplete`
+- `ApprovalRequired`, `HumanQuestion`
+- `PhaseChanged` (debounced to avoid rapid phase flip noise)
+- `ContextManagement`
+
+**Pull-only** (available on request via `check_status`):
+- Status snapshots, log entries, token usage updates
+
+## Mutual Exclusion
+
+The presence layer enforces mutual exclusion between server-side and browser-side presence:
+
+1. Browser connects live model → sends `{"t":"live_connected"}`
+2. Web gateway emits `AppEvent::LiveConnected` → sets shared `AtomicBool` pause flag
+3. Server-side `PresenceLayer::handle_event()` returns `Ok(None)` while paused
+4. Browser live model handles all presence duties (narration, tool calls, user interaction)
+5. Browser disconnects → sends `{"t":"live_disconnected"}`
+6. Web gateway emits `AppEvent::LiveDisconnected` → clears pause flag
+7. Server-side presence resumes
+
+## presence-core Crate
+
+The `crates/presence-core/` workspace crate contains the WASM-compatible core logic:
+
+- **Types**: `PresenceConfig`, `TaskEnvelope`, `PresenceEvent`, `AgentStateSnapshot`, constants
+- **Dispatch**: `PresenceAction` enum, `dispatch_tool_call()` — pure logic dispatch
+- **Tools**: 9 presence tool definitions (provider-agnostic `ToolDefinition` format)
+- **Format**: `format_event()`, `truncate()` (unicode-safe)
+- **Prompt**: `DEFAULT_PRESENCE_PROMPT` via `include_str!`
+
+Minimal dependencies (serde + serde_json only, no tokio/reqwest). Compiles to both native and `wasm32-unknown-unknown`. The main crate re-exports its types and converts `ToolDefinition` to the provider-specific format.
+
+## Tool Dispatch Flow
+
+Tool dispatch uses `presence_core::dispatch_tool_call()` which returns a `PresenceAction` enum:
+
+```
+Tool call arrives (from text model or browser live model)
+    │
+    ▼
+dispatch_tool_call() → PresenceAction
+    │
+    ├── TextResult(text) → return immediately
+    ├── SubmitTask(envelope) → send to EventBus
+    ├── Approve/Deny/Skip → send ControlMsg to EventBus
+    ├── SetAutonomy(level) → send ControlMsg to EventBus
+    └── NeedsIO(query) → platform layer handles:
+         ├── check_status → read AgentStateSnapshot
+         ├── query_detail → read files, git diff
+         └── recall_memory → search knowledge store + session log
+```
+
+Pure-logic tools return `TextResult`/`SubmitTask`/`Approve`/etc. I/O-dependent tools return `NeedsIO` for the platform layer to handle, keeping `presence-core` free of I/O dependencies.

--- a/docs/src/runtime-protocol.md
+++ b/docs/src/runtime-protocol.md
@@ -1,6 +1,6 @@
 # Runtime Protocol
 
-The agent reads a single JSON object from stdin, executes commands sequentially, and writes result lines to stdout.
+The `intendant-runtime` binary reads a single JSON object from stdin, executes commands sequentially, and writes result lines to stdout.
 
 ## Basic Usage
 
@@ -57,22 +57,63 @@ echo '{"commands":[{"function":"recallMemory","nonce":1,"memory_query":"database
 
 ## Functions
 
+### Runtime Functions
+
 | Function | Description | Key Fields |
 |----------|-------------|------------|
 | `execAsAgent` | Run a bash command (blocks until exit, returns exit code + stdout/stderr tail) | `command`, `display`, `wait_for_port` |
 | `captureScreen` | Screenshot a display via ImageMagick | `display` |
-| `inspectPath` | Inspect filesystem path metadata | `path` |
+| `inspectPath` | Inspect filesystem path metadata (type, size, perms, timestamps) | `path` |
 | `editFile` | Structured file editing without shell commands | `file_path`, `operation`, `content`, `match_content`, `line_number`, `end_line` |
-| `writeFile` | Alias for `editFile` write operation | `file_path`, `content` |
-| `browse` | Fetch URL and convert HTML to text | `url` |
-| `askHuman` | Ask the operator a question and wait for response | `question`, `timeout_ms` |
-| `execPty` | Run command in a persistent PTY session | `command`, `shell_id` |
+| `writeFile` | Alias for `editFile` with `operation: "write"` (backward compatibility) | `file_path`, `content` |
+| `browse` | Fetch URL and convert HTML to plain text (50KB max) | `url` |
+| `askHuman` | Ask the operator a question and wait for response (5-minute timeout) | `question`, `timeout_ms` |
+| `execPty` | Run command in a persistent PTY session (`bash --norc --noprofile`) | `command`, `shell_id` |
 | `storeMemory` | Store a knowledge entry with optional tags/channel | `memory_key`, `memory_summary`, `memory_file`, `memory_tags`, `memory_channel`, `memory_source` |
 | `recallMemory` | Search knowledge by keyword with optional filters | `memory_query`, `memory_file`, `memory_tags`, `memory_channel`, `memory_source`, `memory_since` |
 
+### Caller-Handled Functions
+
+These are intercepted by the caller and never reach the runtime:
+
+| Function | Description |
+|----------|-------------|
+| `manage_context` | Apply context directives (drop/summarize turns) to the conversation |
+| `signal_done` | Signal task completion to the caller loop |
+
+### Native Tool Names
+
+When using native tool calling (the default), tool names use snake_case:
+
+| Native Name | Runtime Function |
+|------------|-----------------|
+| `exec_command` | `execAsAgent` |
+| `capture_screen` | `captureScreen` |
+| `inspect_path` | `inspectPath` |
+| `edit_file` | `editFile` |
+| `browse_url` | `browse` |
+| `ask_human` | `askHuman` |
+| `exec_pty` | `execPty` |
+| `store_memory` | `storeMemory` |
+| `recall_memory` | `recallMemory` |
+| `manage_context` | (caller-handled) |
+| `signal_done` | (caller-handled) |
+
+### editFile Operations
+
+The `editFile` function supports 5 operations:
+
+| Operation | Description | Required Fields |
+|-----------|-------------|-----------------|
+| `write` | Write content to file (creates or overwrites) | `file_path`, `content` |
+| `append` | Append content to end of file | `file_path`, `content` |
+| `replace` | Replace matching text with new content | `file_path`, `match_content`, `content` |
+| `insert_at` | Insert content at a specific line number | `file_path`, `line_number`, `content` |
+| `replace_lines` | Replace a range of lines | `file_path`, `line_number`, `end_line`, `content` |
+
 ## Nonce Variables
 
-Use `$NONCE[id]` in command strings to reference the PID of a previously launched nonce. For example, `kill -9 $NONCE[10]` kills the process started by nonce 10.
+Use `$NONCE[id]` in command strings to reference the PID of a previously launched nonce. For example, `kill -9 $NONCE[10]` kills the process started by nonce 10. Handled by regex-based substitution in `replace_nonce_refs()`.
 
 ## Context Management
 
@@ -97,7 +138,7 @@ The model can include a `context` field alongside `commands` to manage conversat
 Project knowledge persists tagged entries across sessions in `<project>/.intendant/memory.json`. The system supports both the legacy key-value format and the new tagged knowledge format with automatic migration.
 
 - **`storeMemory`**: Creates or updates an entry with key, summary, tags, channel, and source. Backward-compatible with old format.
-- **`recallMemory`**: Searches entries by keyword with optional filters (tags, channel, source, since timestamp).
+- **`recallMemory`**: Searches entries by keyword with optional filters (tags, channel, source, since timestamp). Results are ranked by relevance (key/summary match).
 - Knowledge is loaded and injected into the conversation at session start.
 - Supports pub/sub channels for inter-agent knowledge sharing:
   - Agents publish findings to named channels (e.g., `"findings"`, `"decisions"`)
@@ -109,3 +150,20 @@ Project knowledge persists tagged entries across sessions in `<project>/.intenda
 [memory]
 enabled = false  # default: true
 ```
+
+## JSON Output Mode
+
+`--json` enables JSONL structured output to stdout (implies `--no-tui`). Each line is a JSON object with `type` and `data` fields. Event types include: `turn_started`, `model_response`, `model_response_delta`, `agent_output`, `done`, `error`, `approval_required`, `human_question`, `budget_warning`, `round_complete`, `context_management`.
+
+In JSON mode, stdin accepts both plain text (follow-up messages) and JSON commands using the same `ControlMsg` format as the Unix control socket:
+
+```json
+{"action":"approve","id":123}
+{"action":"deny","id":123}
+{"action":"skip","id":123}
+{"action":"approve_all","id":123}
+{"action":"input","text":"answer to askHuman"}
+{"action":"follow_up","text":"continue with this"}
+```
+
+Lines not starting with `{` or not parseable as `ControlMsg` are treated as follow-up text. This makes `--json` mode fully interactive: approval flows, askHuman, and multi-round conversations all work without a TUI or control socket.

--- a/docs/src/session-logging.md
+++ b/docs/src/session-logging.md
@@ -2,14 +2,18 @@
 
 ## Overview
 
-Each `intendant` invocation creates a structured session log directory at `~/.intendant/logs/<uuid>/`. The log provides full observability for debugging and post-session analysis.
+Each `intendant` invocation creates a structured session log directory at `~/.intendant/logs/<uuid>/`. The log provides full observability for debugging and post-session analysis. No global state files are used — each session is fully isolated.
 
 ## Directory Structure
 
 ```
 ~/.intendant/logs/<uuid>/
+├── session_meta.json               # Session metadata (id, created_at, project_root, task, status, last_turn)
 ├── session.jsonl                    # Structured event log (one JSON per line)
+├── conversation.jsonl               # Serialized conversation for session resume
 ├── summary.json                     # Post-session summary (task, outcome, turns)
+├── human_question                   # askHuman IPC: question file (session-scoped)
+├── human_response                   # askHuman IPC: response file (session-scoped)
 ├── 1_stdout.log                     # Runtime stdout for nonce 1
 ├── 1_stderr.log                     # Runtime stderr for nonce 1
 └── turns/
@@ -20,6 +24,24 @@ Each `intendant` invocation creates a structured session log directory at `~/.in
     ├── turn_001_stdout.txt          # Agent stdout for this turn
     └── turn_001_stderr.txt          # Agent stderr (only if non-empty)
 ```
+
+## Session Metadata
+
+`session_meta.json` contains:
+
+```json
+{
+  "session_id": "a1b2c3d4-...",
+  "created_at": "2025-01-15T10:30:00Z",
+  "project_root": "/home/user/myproject",
+  "task": "Fix the authentication bug",
+  "role": null,
+  "status": "running",
+  "last_turn": 5
+}
+```
+
+This file is used by `--continue` (find most recent session for the project) and `--resume <id>` (find session by ID or prefix).
 
 ## Event Types in session.jsonl
 
@@ -34,6 +56,7 @@ Each `intendant` invocation creates a structured session log directory at `~/.in
 | `agent_input` | Commands sent to runtime |
 | `agent_output` | Runtime stdout/stderr |
 | `approval` | Approval decisions (category, preview, decision) |
+| `context_management` | Auto-compaction or manual context directive |
 | `session_end` | Summary with outcome and turn count |
 
 ## Querying Logs
@@ -50,25 +73,37 @@ cat ~/.intendant/logs/<session>/turns/turn_003_reasoning.txt
 
 # Find all commands executed
 grep '"event":"agent_input"' ~/.intendant/logs/<session>/session.jsonl | jq -r '.message'
+
+# List all sessions
+ls -lt ~/.intendant/logs/
+
+# Find sessions for a specific project
+grep -l '"project_root":"/home/user/myproject"' ~/.intendant/logs/*/session_meta.json
 ```
 
-## Session Management
+## Session Resume
 
-Each invocation creates an isolated session with a UUID-based directory at `~/.intendant/logs/<uuid>/`. No global state files are used.
+Conversation history is saved to `conversation.jsonl` after each turn, enabling session resume:
 
-- **Process state** is in-memory (ephemeral, per-invocation).
-- **Session logs** persist in the session directory.
-- **Conversation history** is saved to `conversation.jsonl` for resume support.
-
-Sessions can be resumed:
 ```bash
-./target/release/intendant --continue "fix that bug"     # Resume most recent session for this project
-./target/release/intendant --resume abc123 "continue"     # Resume specific session by ID or prefix
+# Resume most recent session for this project
+./target/release/intendant --continue "fix that bug"
+
+# Resume specific session by ID or prefix
+./target/release/intendant --resume abc123 "continue"
 ```
+
+When resuming, the conversation is loaded from `conversation.jsonl` and the agent continues from where it left off. Session metadata is updated with the new task.
 
 ## Test Coverage
 
-The test suite covers both binaries:
+The test suite covers both binaries with inline `#[cfg(test)]` modules:
 
 - **Agent binary:** models serialization, error types, process state operations, nonce replacement, path inspection, blocking command execution, file editing, browsing, port waiting, human interaction, PTY sessions, memory storage/recall with tags and filters.
-- **Caller binary:** JSON extraction, done signal handling, conversation management with message layer protection, tool call tracking, and auto-compaction, context directives (drop/summarize), error types, project detection, config parsing with approval rules and MCP server config and sandbox config, provider selection with token usage tracking, Responses API support, rate-limit retry with exponential backoff, API key masking, SSE streaming and event parsing, shared message builders, structured output and reasoning controls, role mapping, native tool definitions (11+ tools including MCP client tools, provider conversion formats), tool call batch assembly and result routing (including MCP tool routing), Gemini provider request/response format, sub-agent spawning and result parsing, git worktree lifecycle, user mode orchestration, knowledge pub/sub system, prompt resolution cascade (project root, global config, compiled-in defaults, tools-mode variant) with INTENDANT.md loading, TUI rendering (status bar, log panel, action panel, approval panel, help overlay, layout calculations, orchestrator progress, streaming buffer), autonomy level resolution and command classification, event bus dispatch, theme color thresholds, control socket serialization, session log file creation, model summary formatting, Xvfb display configuration per provider, dynamic display allocation, MCP client tool name parsing and routing, Landlock sandbox config construction, and JSON structured output mode.
+- **Caller binary:** JSON extraction, done signal handling, conversation management with message layer protection, tool call tracking, and auto-compaction, context directives (drop/summarize), error types, project detection, config parsing with approval rules and MCP server config and sandbox config, provider selection with token usage tracking, Responses API support, rate-limit retry with exponential backoff, API key masking, SSE streaming and event parsing, shared message builders, structured output and reasoning controls, role mapping, native tool definitions (11+ tools including MCP client tools, provider conversion formats), tool call batch assembly and result routing (including MCP tool routing), Gemini provider request/response format, sub-agent spawning and result parsing, git worktree lifecycle, user mode orchestration, knowledge pub/sub system, prompt resolution cascade (project root, global config, compiled-in defaults, tools-mode variant) with INTENDANT.md loading, TUI rendering (status bar, log panel, action panel, approval panel, help overlay, layout calculations, orchestrator progress, streaming buffer), autonomy level resolution and command classification, event bus dispatch, theme color thresholds, control socket serialization, session log file creation, model summary formatting, Xvfb display configuration per provider, dynamic display allocation, MCP client tool name parsing and routing, Landlock sandbox config construction, JSON structured output mode, web gateway (WebSocket lifecycle, tool request/response, broadcast, state bootstrap, live connect/disconnect), and presence event filtering.
+
+Integration tests in `tests/e2e/` spawn a real binary and exercise the full stack (see [Architecture](./architecture.md)):
+
+- **Tier 1 (JSON mode)**: Full-stack exec, approval approve/deny via stdin, multi-round follow-up. No display required.
+- **Tier 2 (Control socket)**: Status/usage queries, autonomy change, approve via Unix control socket. Requires Xvfb.
+- **Tier 3 (Web/Voice)**: WebSocket state_snapshot, tool_request/response, ANSI term frames, /debug endpoint. Voice tests require Firefox, PulseAudio, and espeak-ng.

--- a/docs/src/tui.md
+++ b/docs/src/tui.md
@@ -20,12 +20,23 @@
 └─────────────────────────────────────────────┘
 ```
 
+### Panels
+
+- **Status bar**: Provider, model, turn count, budget percentage, autonomy level
+- **Action panel**: Current phase with spinner — Thinking, RunningAgent, Orchestrating, WaitingApproval, WaitingHuman, WaitingFollowUp, Idle, Done
+- **Log panel**: Scrollable chronological log with color-coded levels (Info, Warning, Error, Debug)
+- **Approval panel**: Shown when an action needs user approval — command preview + category, y/s/a/n keys
+- **Input panel**: Shown when `askHuman` is triggered — `tui-textarea` for response
+- **Follow-up panel**: Shown when agent completes a round and awaits follow-up input
+- **Help overlay**: Key bindings reference (`?` key)
+- **Inspect overlay**: Detailed view of selected log entry
+
 ### Key Bindings
 
 | Key | Action |
 |-----|--------|
 | `q` / `Ctrl-C` | Quit |
-| `v` | Toggle verbose mode |
+| `v` | Toggle verbose mode (cycle through quiet/normal/verbose/debug) |
 | `?` | Help overlay |
 | `+` / `-` | Cycle autonomy level |
 | `Up`/`Down`/`PgUp`/`PgDn` | Scroll log |
@@ -35,6 +46,14 @@
 | `s` | Skip pending action |
 | `a` | Auto-approve all remaining |
 | `n` | Deny and stop |
+
+### Streaming Display
+
+When a model is generating a response, text deltas are forwarded to the TUI in real-time via `AppEvent::ModelResponseDelta` and accumulated in a streaming buffer. The buffer is cleared when the full response arrives. This gives immediate feedback during long model responses.
+
+### Theme
+
+The TUI uses a Catppuccin Mocha-inspired color scheme with budget-aware color thresholds (green → yellow → red as context fills up).
 
 ## Autonomy System
 
@@ -61,7 +80,19 @@ When approval is needed, the agent loop pauses and the TUI shows the command pre
 
 ### Action Classification
 
-Action categories are determined by analyzing command JSON: shell commands are classified by inspecting for destructive patterns (`rm`, `kill`, `dd`, `mkfs`, `sudo`), network operations (`curl`, `wget`, `ssh`), file operations, etc.
+Commands are classified into categories by inspecting the command JSON:
+
+| Category | Examples |
+|----------|----------|
+| FileRead | `inspectPath`, `recallMemory` |
+| FileWrite | `editFile`, `writeFile`, `storeMemory` |
+| FileDelete | Commands with `rm`, `rmdir` |
+| CommandExec | `execAsAgent`, `execPty` |
+| NetworkRequest | Commands with `curl`, `wget`, `ssh`, `git` |
+| Destructive | Commands with `rm -rf`, `kill`, `dd`, `mkfs`, `sudo` |
+| HumanInput | `askHuman` |
+
+Shell commands are further classified by inspecting the command string for destructive patterns, network tools, and file writes (redirects, `tee`, `mv`, `cp`). The `sudo` prefix is detected as Destructive and the actual command after `sudo` is also classified.
 
 ## Web TUI
 
@@ -79,6 +110,8 @@ The `--web` flag serves the TUI remotely via WebSocket using xterm.js. The full 
 
 Open `http://<host>:8765/` in a browser. The terminal renders the same layout as the native TUI — status bar, log panel, action panel, approval/input panels. Key presses and terminal resizes in the browser are sent back to the server.
 
+The `--web` flag implies `--mcp`, so no initial task is required — the agent starts idle and accepts tasks dynamically via the web UI or programmatically.
+
 ### Voice Overlay
 
 The web TUI includes an optional voice overlay for browser-side live model interaction (Gemini Live / OpenAI Realtime). When activated:
@@ -90,4 +123,4 @@ The web TUI includes an optional voice overlay for browser-side live model inter
 
 Voice requires an API key (Gemini or OpenAI), stored in browser localStorage. The remote TUI works without voice enabled.
 
-See [Web Gateway](./integrations.md#web-gateway) for the full WebSocket protocol documentation.
+See [Integrations — Web Gateway](./integrations.md#web-gateway) for the full WebSocket protocol documentation and [Presence Layer](./presence.md) for details on presence mutual exclusion.


### PR DESCRIPTION
## Summary

This PR reorganizes and significantly expands the documentation to provide clearer guidance on Intendant's architecture, the presence layer, and multi-agent orchestration. The changes extract complex topics into dedicated documents and improve clarity throughout the existing docs.

## Key Changes

- **Restructured `architecture.md`**: Added an "Overview" section explaining the two-binary system, reorganized execution modes (Direct → User → Sub-Agent), moved presence layer description to dedicated doc, and added new subsections for Process State, Session Directory, and Execution Model with more detailed explanations.

- **New `presence.md` document**: Comprehensive guide to the presence layer covering server-side text presence, browser-side live presence (Gemini Live / OpenAI Realtime), the 9 presence tools (action and query tools), event filtering, mutual exclusion logic, and the `presence-core` crate architecture.

- **New `multi-agent.md` document**: Detailed guide to multi-agent orchestration including agent roles, sub-agent spawning via environment variables, progress polling and result files, git worktree isolation, knowledge routing with pub/sub channels, orchestrator checkpointing, and configuration options.

- **Enhanced `runtime-protocol.md`**: Clarified that the document describes `intendant-runtime` specifically, added sections for Runtime Functions vs Caller-Handled Functions, documented native tool name mappings (snake_case), detailed the 5 `editFile` operations, and improved descriptions of nonce variables and knowledge persistence.

- **Expanded `session-logging.md`**: Added `session_meta.json` documentation with example structure, clarified session resume workflow with `--continue` and `--resume` flags, improved query examples, and emphasized that no global state files are used.

- **Updated `tui.md`**: Added explicit Panels section documenting all UI components, clarified verbose mode cycles through quiet/normal/verbose/debug, documented streaming display behavior, added theme description, and created an Action Classification table with command categories.

- **Enhanced `configuration.md`**: Added short flags (`-v`, `-c`, `-r`), clarified `--web [PORT]` syntax, and improved environment variable documentation.

- **Expanded `getting-started.md`**: Added examples for `--json`, `--continue`, `--resume`, `--direct`, `--sandbox`, `--mcp`, `--control-socket`, and `--no-presence` flags; clarified test command syntax.

- **Updated `mcp-server.md`**: Added note about MCP client support and began documenting external MCP server configuration.

- **Updated `README.md`**: Refined description to highlight streaming, approval gates, browser-based voice, and session resume; clarified presence layer runs server-side by default.

- **Updated `integrations.md`**: Added introductory note directing readers to MCP Server and Presence Layer docs.

- **Updated `SUMMARY.md`**: Added entries for new `multi-agent.md` and `presence.md` documents.

## Notable Details

- All new documentation maintains consistency with existing style and terminology
- Cross-references between documents guide readers to related topics (e.g., architecture.md → multi-agent.md for sub-agent details)
- Presence layer documentation clarifies the mutual exclusion between server-side and browser-side modes
- Multi-agent documentation explains the full orchestration flow including knowledge routing and checkpointing
- Runtime protocol documentation now clearly separates runtime functions from caller-handled functions

https://claude.ai/code/session_01UDvFW711aHEBkahjwmFbAF