### PR TITLE
Windows hardening: fix MetadataExt regression + cross-platform CI + docs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,114 @@
+name: Cross-platform check
+
+# Type-checks the controller (`intendant`) on every supported platform so
+# cross-platform regressions surface in CI rather than only when someone
+# builds on a non-Linux box.
+#
+# Windows is the point: the codebase is mostly developed on macOS/Linux, and
+# Unix-only APIs (`std::os::unix::fs::MetadataExt`, libc, /proc, …) slip in
+# unnoticed because they compile fine on the author's machine. This workflow
+# runs `cargo check -p intendant` for the `x86_64-pc-windows-msvc` target and
+# catches that whole class — e.g. an unconditional
+# `use std::os::unix::fs::MetadataExt;` plus `.blocks()`/`.dev()`/`.ino()`
+# calls that broke the MSVC build.
+#
+# `cargo check` (not full build/test) is deliberate: it does the type/cfg
+# resolution that catches platform breakage at a fraction of the cost, and
+# the Windows display/audio runtime can't be exercised on a headless runner
+# anyway. macOS and Linux jobs ride along as a bonus tripwire.
+
+on:
+  push:
+    branches: [main]
+    # Only platform-relevant sources can introduce a compile regression, so
+    # skip pure-docs / static-asset pushes. Mirrors audit.yml's scoping.
+    paths:
+      - "**/*.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**/Cargo.toml"
+      - ".github/workflows/windows.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**/Cargo.toml"
+      - ".github/workflows/windows.yml"
+
+permissions:
+  contents: read
+
+# Don't pile up redundant runs on a fast-moving branch: a newer push to the
+# same ref cancels the in-flight check.
+concurrency:
+  group: cross-platform-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # One platform failing shouldn't mask the others — we want to see every
+      # target's result on a regression.
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # rustup ships preinstalled on the GitHub-hosted runners; just pin the
+      # target this job type-checks against.
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.target }}
+
+      # `ring` (our TLS provider — aws-lc-rs is deliberately disabled) builds
+      # its x86_64 perlasm assembly with NASM on the MSVC target. The GitHub
+      # windows-latest image ships NASM, but install it explicitly so the
+      # workflow doesn't silently break if that ever changes; choco is a no-op
+      # when it's already present.
+      - name: Install NASM (Windows, for ring)
+        if: runner.os == 'Windows'
+        run: |
+          if (-not (Get-Command nasm -ErrorAction SilentlyContinue)) {
+            choco install nasm --no-progress -y
+            "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          }
+        shell: pwsh
+
+      # Linux build deps for the `-sys` crates that have a native backend
+      # there (the subset of scripts/setup-linux.sh's APT_PACKAGES that are
+      # build-time, not runtime): libclang for the bindgen used by
+      # env-libvpx-sys + pipewire-sys, libvpx + libpipewire + libxcb headers
+      # for those crates' link/pkg-config steps. macOS and Windows pull their
+      # platform deps as prebuilt FFI crates, so no system package step is
+      # needed there. (No libssl-dev / libpng-dev: the tree is on pure-Rust
+      # ring + the `png` crate, not openssl-sys / libpng.)
+      - name: Install Linux build deps
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config libclang-dev libvpx-dev libpipewire-0.3-dev \
+            libxcb1-dev libxcb-shm0-dev libxcb-randr0-dev
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      # Type-check the whole `intendant` package — both binaries (the
+      # `intendant` controller and the `intendant-runtime` executor) and their
+      # shared modules — for this target. `-p intendant` deliberately excludes
+      # the `presence-web` workspace member, which is a wasm32 crate with its
+      # own wasm-pack build and doesn't type-check against a native target.
+      - name: cargo check
+        run: cargo check -p intendant --target ${{ matrix.target }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -89,10 +89,9 @@ jobs:
       # there (the subset of scripts/setup-linux.sh's APT_PACKAGES that are
       # build-time, not runtime): libclang for the bindgen used by
       # env-libvpx-sys + pipewire-sys, libvpx + libpipewire + libxcb headers
-      # for those crates' link/pkg-config steps. macOS and Windows pull their
-      # platform deps as prebuilt FFI crates, so no system package step is
-      # needed there. (No libssl-dev / libpng-dev: the tree is on pure-Rust
-      # ring + the `png` crate, not openssl-sys / libpng.)
+      # for those crates' link/pkg-config steps. (No libssl-dev / libpng-dev:
+      # the tree is on pure-Rust ring + the `png` crate, not openssl-sys /
+      # libpng.)
       - name: Install Linux build deps
         if: runner.os == 'Linux'
         run: |
@@ -101,9 +100,27 @@ jobs:
             pkg-config libclang-dev libvpx-dev libpipewire-0.3-dev \
             libxcb1-dev libxcb-shm0-dev libxcb-randr0-dev
 
+      # macOS build deps. `env-libvpx-sys` (the VP8 encoder backend) is gated to
+      # non-Windows, so the aarch64-apple-darwin target *does* build it and its
+      # build.rs runs `pkg-config --libs --cflags vpx`. The GitHub macos-latest
+      # image ships neither pkg-config nor a `vpx.pc`; on a dev box setup-macos.sh
+      # pulls both in transitively via `brew install ffmpeg`. Install them
+      # directly here (leaner than all of ffmpeg). The other macOS FFI deps
+      # (ScreenCaptureKit, VideoToolbox, CoreFoundation) bind system frameworks
+      # at link time only, which `cargo check` never reaches.
+      - name: Install macOS build deps
+        if: runner.os == 'macOS'
+        run: brew install pkg-config libvpx
+
+      # Restore the cargo cache on every run, but only *save* it on pushes to
+      # main. PR caches live in an isolated scope GitHub discards on merge, so
+      # saving them buys nothing — and the Windows tar/zstd save step is flaky
+      # enough to fail an otherwise-green job. `save-if` keeps the speed-up on
+      # restore while removing the unreliable post-run save from PR checks.
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Type-check the whole `intendant` package — both binaries (the
       # `intendant` controller and the `intendant-runtime` executor) and their

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Two binaries form a security boundary:
 - **intendant-runtime** — Sandboxed command executor. Reads JSON commands from stdin, executes them sequentially, writes results to stdout. Runs under Landlock filesystem restrictions. Never holds API keys.
 - **intendant** — Controller/caller. Manages the LLM conversation loop, calls model APIs, dispatches tool calls to the runtime subprocess, and runs all user-facing interfaces (CLI, TUI, Web, MCP).
 
-The system is **provider-agnostic** (OpenAI, Anthropic, Gemini), **cross-platform** (macOS, Linux/Debian), and designed around the principle that every capability should be accessible through any interface — TUI, web dashboard, MCP, voice, or programmatic control.
+The system is **provider-agnostic** (OpenAI, Anthropic, Gemini), **cross-platform** (macOS, Linux/Debian, Windows), and designed around the principle that every capability should be accessible through any interface — TUI, web dashboard, MCP, voice, or programmatic control.
 
 ## Vision and Direction
 
@@ -225,7 +225,17 @@ cargo test --test e2e test_voice -- --nocapture           # Tier 3: needs Xvfb +
 
 ### Platform Support
 
-Target platforms: macOS, Linux (Debian, X11 and Wayland).
+Target platforms: **macOS, Linux** (Debian, X11 and Wayland), **and Windows**
+(`x86_64-pc-windows-msvc`). Windows is a first-class target — capture, input
+injection, H.264 encode, and the gateway all have Windows backends, built and
+run via `scripts/setup-windows.ps1` (see `docs/src/windows-support.md`).
+
+**OS-specific `std` APIs must be `#[cfg]`-guarded.** Don't
+`use std::os::unix::fs::MetadataExt;` (→ `.ctime()/.dev()/.ino()/.nlink()/.blocks()`),
+or any `std::os::unix::*` / `std::os::windows::*` item, unconditionally — it
+breaks the other platform's build. Wrap the platform call in a
+`#[cfg(unix)]`/`#[cfg(windows)]`-paired helper in `platform.rs` (the existing
+convention) with a portable fallback, and route callers through it.
 
 Prefer platform-agnostic code by default. When platform-specific behavior is
 unavoidable, use `cfg!(target_os = ...)` runtime checks for small branches or
@@ -239,7 +249,7 @@ supported platforms — never panic or silently do nothing.
 
 ## Environment Requirements
 
-- **OS**: macOS or Linux (Debian), unprivileged user with passwordless sudo (Linux)
+- **OS**: macOS, Linux (Debian), or Windows (Server 2022 / 11); unprivileged user with passwordless sudo on Linux
 - **API keys**: `.env` with `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `GEMINI_API_KEY`
 - **Display capture**: libxcb + libxcb-shm (Linux X11), PipeWire (Linux Wayland), ScreenCaptureKit (macOS)
 - **Input injection**: xdotool (Linux X11), ydotool (Linux Wayland), cliclick (macOS)

--- a/src/bin/caller/platform.rs
+++ b/src/bin/caller/platform.rs
@@ -473,6 +473,103 @@ pub async fn spawn_detached_restart(cmd: &str) -> Result<u32, String> {
         .ok_or_else(|| "Detached restart child has no PID".to_string())
 }
 
+// ── Cross-platform std::fs::Metadata extras ────────────────────────────────
+//
+// `std::os::unix::fs::MetadataExt` exposes inode-level fields (ctime, dev,
+// ino, nlink, blocks) that have no portable equivalent. The session-list
+// cache fingerprints and the worktree disk-usage walk used them directly,
+// which broke the Windows build. These helpers wrap each access behind a
+// `#[cfg(unix)]`/`#[cfg(windows)]` pair so callers stay platform-agnostic.
+
+/// Change-time of a file as whole + sub-second nanoseconds since the Unix
+/// epoch, used purely as a cache-invalidation fingerprint.
+///
+/// - **Unix**: `ctime`/`ctime_nsec` (inode change time — flips on metadata
+///   edits that leave mtime untouched, so it's a stricter cache key).
+/// - **Windows**: there is no ctime; fall back to the creation time when
+///   available, else 0. The fingerprint already folds in `len` + mtime, so
+///   a coarser ctime only widens cache hits slightly, never causing a stale
+///   read.
+pub fn metadata_ctime_nanos(metadata: &std::fs::Metadata) -> i128 {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        metadata.ctime() as i128 * 1_000_000_000 + metadata.ctime_nsec() as i128
+    }
+    #[cfg(not(unix))]
+    {
+        metadata
+            .created()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_nanos() as i128)
+            .unwrap_or(0)
+    }
+}
+
+/// `(device, inode)` identity pair for a file, used to fingerprint cache
+/// keys and to de-duplicate hardlinked files in disk-usage walks.
+///
+/// - **Unix**: the real `(dev, ino)`.
+/// - **Windows**: NTFS has an analogous `(volume-serial, file-index)` but it
+///   is not surfaced by `std::fs::Metadata`. Returning `(0, 0)` is correct
+///   for both callers: cache keys still vary on `len`+mtime+ctime, and the
+///   disk-usage de-dup is paired with [`metadata_is_multiply_linked`] which
+///   reports `false` on Windows, so the de-dup set is never consulted.
+pub fn metadata_dev_ino(metadata: &std::fs::Metadata) -> (u64, u64) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        (metadata.dev(), metadata.ino())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = metadata;
+        (0, 0)
+    }
+}
+
+/// Whether a file has more than one hardlink (so a disk-usage walk should
+/// de-duplicate it by `(dev, ino)`).
+///
+/// - **Unix**: `nlink() > 1`.
+/// - **Windows**: hardlinks exist but `nlink` is not exposed by
+///   `std::fs::Metadata`; report `false` so each path is counted once. The
+///   apparent-size fallback in [`metadata_on_disk_bytes`] already avoids the
+///   inode model entirely, so no double-counting results.
+pub fn metadata_is_multiply_linked(metadata: &std::fs::Metadata) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        metadata.nlink() > 1
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = metadata;
+        false
+    }
+}
+
+/// On-disk byte allocation for a file (what `du` reports), not apparent size.
+///
+/// - **Unix**: `blocks() * 512` — the actual allocated 512-byte blocks, which
+///   correctly discounts sparse files and (combined with the `(dev, ino)`
+///   de-dup) hardlink-dense trees like Cargo `target/`.
+/// - **Windows**: `std::fs::Metadata` exposes no block count; fall back to
+///   apparent `len()`. This over-counts sparse files, but the figure is only
+///   an informational disk-usage estimate, never a correctness input.
+pub fn metadata_on_disk_bytes(metadata: &std::fs::Metadata) -> u64 {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        metadata.blocks().saturating_mul(512)
+    }
+    #[cfg(not(unix))]
+    {
+        metadata.len()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/bin/caller/web_gateway.rs
+++ b/src/bin/caller/web_gateway.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, Read, Seek, SeekFrom};
-use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -3049,7 +3048,7 @@ fn metadata_mtime_nanos(metadata: &std::fs::Metadata) -> u128 {
 }
 
 fn metadata_ctime_nanos(metadata: &std::fs::Metadata) -> i128 {
-    metadata.ctime() as i128 * 1_000_000_000 + metadata.ctime_nsec() as i128
+    crate::platform::metadata_ctime_nanos(metadata)
 }
 
 fn session_list_path_key(path: &Path) -> String {
@@ -3060,14 +3059,17 @@ fn session_list_path_key(path: &Path) -> String {
 fn file_dependency_fingerprint(path: &Path) -> String {
     let path_key = session_list_path_key(path);
     match std::fs::metadata(path) {
-        Ok(metadata) => format!(
-            "{path_key}\0{}\0{}\0{}\0{}\0{}",
-            metadata.len(),
-            metadata_mtime_nanos(&metadata),
-            metadata_ctime_nanos(&metadata),
-            metadata.dev(),
-            metadata.ino()
-        ),
+        Ok(metadata) => {
+            let (dev, ino) = crate::platform::metadata_dev_ino(&metadata);
+            format!(
+                "{path_key}\0{}\0{}\0{}\0{}\0{}",
+                metadata.len(),
+                metadata_mtime_nanos(&metadata),
+                metadata_ctime_nanos(&metadata),
+                dev,
+                ino
+            )
+        }
         Err(_) => format!("{path_key}\0missing"),
     }
 }
@@ -3081,14 +3083,15 @@ fn session_list_cache_key(
     if !metadata.is_file() {
         return None;
     }
+    let (dev, ino) = crate::platform::metadata_dev_ino(&metadata);
     Some(SessionListCacheKey {
         namespace,
         path: session_list_path_key(path),
         len: metadata.len(),
         mtime_nanos: metadata_mtime_nanos(&metadata),
         ctime_nanos: metadata_ctime_nanos(&metadata),
-        dev: metadata.dev(),
-        ino: metadata.ino(),
+        dev,
+        ino,
         extra: extra.into(),
     })
 }
@@ -4883,13 +4886,14 @@ fn push_session_file_fingerprint(
         .unwrap_or(path)
         .to_string_lossy()
         .to_string();
+    let (dev, ino) = crate::platform::metadata_dev_ino(&metadata);
     entries.push(SessionFileFingerprint {
         rel,
         len: metadata.len(),
         mtime_nanos: metadata_mtime_nanos(&metadata),
         ctime_nanos: metadata_ctime_nanos(&metadata),
-        dev: metadata.dev(),
-        ino: metadata.ino(),
+        dev,
+        ino,
         is_dir,
     });
 }
@@ -6553,10 +6557,13 @@ fn delete_session_data(session_id: &str, target: &str) -> String {
                         if p.is_dir() {
                             walk(&p, total, seen);
                         } else if let Ok(m) = p.metadata() {
-                            if m.nlink() > 1 && !seen.insert((m.dev(), m.ino())) {
+                            if crate::platform::metadata_is_multiply_linked(&m)
+                                && !seen.insert(crate::platform::metadata_dev_ino(&m))
+                            {
                                 continue;
                             }
-                            *total = total.saturating_add(m.blocks().saturating_mul(512));
+                            *total = total
+                                .saturating_add(crate::platform::metadata_on_disk_bytes(&m));
                         }
                     }
                 }

--- a/src/bin/caller/worktree_inventory.rs
+++ b/src/bin/caller/worktree_inventory.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::SystemTime;
@@ -954,12 +953,14 @@ fn measure_tree(root: &Path) -> TreeMeasure {
             // reclaimed by deleting the worktree. `meta.len()` (apparent size)
             // over-counts both sparse files and hardlink-dense trees like Cargo
             // `target/` dirs (e.g. a 5.6 GiB worktree reported as 9+ GiB).
-            if meta.nlink() > 1 && !seen_inodes.insert((meta.dev(), meta.ino())) {
+            if crate::platform::metadata_is_multiply_linked(&meta)
+                && !seen_inodes.insert(crate::platform::metadata_dev_ino(&meta))
+            {
                 continue;
             }
             measure.bytes = measure
                 .bytes
-                .saturating_add(meta.blocks().saturating_mul(512));
+                .saturating_add(crate::platform::metadata_on_disk_bytes(&meta));
         }
     }
     measure
@@ -1317,8 +1318,14 @@ mod tests {
         assert!(wt.exists());
     }
 
+    // du-style block accounting + hardlink de-dup is Unix-only semantics
+    // (`MetadataExt::blocks`/`nlink`). On Windows the disk-usage walk falls
+    // back to apparent `len()` with no inode de-dup, so this assertion does
+    // not apply — see `crate::platform::metadata_on_disk_bytes`.
+    #[cfg(unix)]
     #[test]
     fn measure_tree_counts_hardlinks_once() {
+        use std::os::unix::fs::MetadataExt;
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join("tree");
         std::fs::create_dir(&dir).unwrap();


### PR DESCRIPTION
Fixes the Windows build break (unconditional `use std::os::unix::fs::MetadataExt` in web_gateway.rs + worktree_inventory.rs, from 088ba9f / f23ddde) via #[cfg]-paired helpers in platform.rs (Unix = on-disk bytes + hardlink dedup; Windows = apparent size, no dedup).

Adds .github/workflows/windows.yml (cargo check on windows-latest / macOS / linux) to catch cross-platform regressions going forward.

Windows cargo check verified green in isolation. CLAUDE.md updated to make Windows first-class + require cfg-guarding OS-specific std APIs.