### PR TITLE
Fix cargo audit advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,7 @@
+[advisories]
+ignore = [
+    # RUSTSEC-2023-0071 has no patched stable rsa release. Intendant uses
+    # rsa only for local keypair generation when minting access certificates,
+    # not as a network-observable RSA decrypt/sign oracle.
+    "RUSTSEC-2023-0071",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -3929,9 +3929,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -4389,9 +4389,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.16.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
 dependencies = [
  "async-trait",
  "base64",
@@ -4413,9 +4413,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.16.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
+checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ dirs = "6"
 # Windows, which `CreateProcess` (and thus `Command::new`) does not do. Pure
 # Rust, so no setup-script changes are needed.
 which = "8"
-rmcp = { version = "0.16", features = ["server", "transport-io", "client", "transport-child-process"] }
+rmcp = { version = ">=1.4.0, <1.5.0", features = ["server", "transport-io", "client", "transport-child-process"] }
 schemars = "1"
 base64 = "0.22"
 bip39 = { version = "2", default-features = false, features = ["std"] }

--- a/src/bin/caller/mcp.rs
+++ b/src/bin/caller/mcp.rs
@@ -10884,39 +10884,32 @@ fn resource_definitions() -> Vec<Resource> {
 #[tool_handler]
 impl ServerHandler for IntendantServer {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            instructions: Some(
-                "Intendant AI agent runtime. This MCP server exposes the same controls \
-                 and observations as the TUI. Use tools to control the agent (approve, \
-                 deny, respond, set_autonomy, quit), manage controller restarts \
-                 (schedule_controller_restart, controller_turn_complete, \
-                 get_restart_status, cancel_controller_restart), manage loop \
-                 intervention (request_controller_loop_halt, clear_controller_loop_halt, \
-                 intervene_controller_loop, get_controller_loop_status), and observe state \
-                 (get_status, get_logs, get_pending_approval, get_pending_input). \
-                 Resources provide push-based state updates via subscriptions."
-                    .into(),
-            ),
-            capabilities: ServerCapabilities::builder()
+        let mut implementation = Implementation::new("intendant", env!("CARGO_PKG_VERSION"));
+        implementation.title = Some("Intendant AI Agent Runtime".to_string());
+        implementation.description =
+            Some("MCP interface for controlling and observing the Intendant AI agent".to_string());
+
+        ServerInfo::new(
+            ServerCapabilities::builder()
                 .enable_tools()
                 .enable_tool_list_changed()
                 .enable_resources()
                 .enable_resources_subscribe()
                 .enable_resources_list_changed()
                 .build(),
-            server_info: Implementation {
-                name: "intendant".to_string(),
-                title: Some("Intendant AI Agent Runtime".to_string()),
-                version: env!("CARGO_PKG_VERSION").to_string(),
-                description: Some(
-                    "MCP interface for controlling and observing the Intendant AI agent"
-                        .to_string(),
-                ),
-                icons: None,
-                website_url: None,
-            },
-            ..Default::default()
-        }
+        )
+        .with_instructions(
+            "Intendant AI agent runtime. This MCP server exposes the same controls \
+             and observations as the TUI. Use tools to control the agent (approve, \
+             deny, respond, set_autonomy, quit), manage controller restarts \
+             (schedule_controller_restart, controller_turn_complete, \
+             get_restart_status, cancel_controller_restart), manage loop \
+             intervention (request_controller_loop_halt, clear_controller_loop_halt, \
+             intervene_controller_loop, get_controller_loop_status), and observe state \
+             (get_status, get_logs, get_pending_approval, get_pending_input). \
+             Resources provide push-based state updates via subscriptions.",
+        )
+        .with_server_info(implementation)
     }
 
     async fn list_resources(
@@ -10939,9 +10932,10 @@ impl ServerHandler for IntendantServer {
         if request.uri == RESOURCE_LOOP_URI {
             let value = collect_controller_loop_status(&controller_loop_dir());
             let json = serde_json::to_string_pretty(&value).unwrap_or_else(|_| "null".to_string());
-            return Ok(ReadResourceResult {
-                contents: vec![ResourceContents::text(json, request.uri)],
-            });
+            return Ok(ReadResourceResult::new(vec![ResourceContents::text(
+                json,
+                request.uri,
+            )]));
         }
 
         let s = self.state.read().await;
@@ -10993,9 +10987,10 @@ impl ServerHandler for IntendantServer {
             }
         };
 
-        Ok(ReadResourceResult {
-            contents: vec![ResourceContents::text(json, request.uri)],
-        })
+        Ok(ReadResourceResult::new(vec![ResourceContents::text(
+            json,
+            request.uri,
+        )]))
     }
 
     async fn subscribe(

--- a/src/bin/caller/mcp_client.rs
+++ b/src/bin/caller/mcp_client.rs
@@ -20,17 +20,10 @@ struct McpClientHandler;
 
 impl ClientHandler for McpClientHandler {
     fn get_info(&self) -> ClientInfo {
-        ClientInfo {
-            client_info: Implementation {
-                name: "intendant".into(),
-                version: env!("CARGO_PKG_VERSION").into(),
-                title: None,
-                description: None,
-                icons: None,
-                website_url: None,
-            },
-            ..Default::default()
-        }
+        ClientInfo::new(
+            Default::default(),
+            Implementation::new("intendant", env!("CARGO_PKG_VERSION")),
+        )
     }
 }
 
@@ -145,14 +138,14 @@ impl McpClientManager {
                 None
             };
 
+        let mut request = CallToolRequestParams::new(actual_tool.to_string());
+        if let Some(args_map) = args_map {
+            request = request.with_arguments(args_map);
+        }
+
         let result = server
             .peer
-            .call_tool(CallToolRequestParams {
-                name: actual_tool.to_string().into(),
-                arguments: args_map,
-                meta: None,
-                task: None,
-            })
+            .call_tool(request)
             .await
             .map_err(|e| CallerError::Provider(format!("MCP tool call failed: {}", e)))?;
 

--- a/src/bin/caller/web_gateway.rs
+++ b/src/bin/caller/web_gateway.rs
@@ -7907,12 +7907,18 @@ fn codex_session_list_summary_from_file(path: &Path) -> Option<CodexSessionListS
     Some(summary)
 }
 
-/// Resolve Codex's home directory: `$CODEX_HOME` if set (non-empty), else
-/// `<home>/.codex`. Codex writes its session rollouts under `CODEX_HOME` when
-/// that env var is set (common on managed/headless installs), so the dashboard
-/// session scan must honor it rather than assuming `~/.codex` — otherwise
-/// codex sessions never appear in the listing.
+/// Resolve Codex's home directory for a home-scoped session scan.
+///
+/// Codex writes session rollouts under `$CODEX_HOME` when that env var is set
+/// (common on managed/headless installs), so the dashboard scan for the active
+/// user must honor it rather than assuming `~/.codex`. For explicit alternate
+/// homes, keep the scan scoped to that home; otherwise tests and targeted
+/// home scans can accidentally read the live user's Codex sessions.
 fn codex_dir(home: &Path) -> PathBuf {
+    if home != crate::platform::home_dir() {
+        return home.join(".codex");
+    }
+
     std::env::var_os("CODEX_HOME")
         .map(PathBuf::from)
         .filter(|p| !p.as_os_str().is_empty())


### PR DESCRIPTION
## Summary
- update patched audit dependencies: rmcp 1.4.0, quinn-proto 0.11.15, anyhow 1.0.103
- add a documented cargo-audit ignore for RUSTSEC-2023-0071 because rsa has no patched stable release and Intendant only uses it for local access certificate keypair generation
- adjust rmcp 1.4 API usage and fix Codex session scans so explicit alternate homes do not read the live CODEX_HOME sessions

Fixes #19
Fixes #20

## Validation
- cargo audit --json --file ./Cargo.lock
- cargo test --bins
- cargo clippy
- git diff --check