### PR TITLE
Docs: integrations CI chapter follows the merge-queue reality

### DIFF
--- a/.github/workflows/agents-md-sync.yml
+++ b/.github/workflows/agents-md-sync.yml
@@ -10,12 +10,10 @@ on:
       - "CLAUDE.md"
       - "AGENTS.md"
       - ".github/workflows/agents-md-sync.yml"
+  # Required-check triggers — unfiltered on purpose: a paths-skipped
+  # required check blocks queue entry (PRs) or wedges the group
+  # (merge_group); see windows.yml. `cmp` runs in seconds.
   pull_request:
-    paths:
-      - "CLAUDE.md"
-      - "AGENTS.md"
-  # Merge-queue gate — unconditional (see windows.yml: a paths-skipped
-  # required check wedges the queue). `cmp` runs in seconds.
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/app-html.yml
+++ b/.github/workflows/app-html.yml
@@ -19,16 +19,11 @@ on:
       - "crates/app-html-assembler/**"
       - "build.rs"
       - ".github/workflows/app-html.yml"
+  # Required-check triggers — unfiltered on purpose: a paths-skipped
+  # required check blocks queue entry (PRs) or wedges the group
+  # (merge_group); see windows.yml. The assembler runs in seconds.
   pull_request:
     branches: [main]
-    paths:
-      - "static/app/**"
-      - "static/app.html"
-      - "crates/app-html-assembler/**"
-      - "build.rs"
-      - ".github/workflows/app-html.yml"
-  # Merge-queue gate — unconditional (see windows.yml: a paths-skipped
-  # required check wedges the queue). The assembler runs in seconds.
   merge_group:
 
 permissions:

--- a/.github/workflows/smokes.yml
+++ b/.github/workflows/smokes.yml
@@ -37,19 +37,12 @@ on:
       - "tests/skills/native-goal-smoke/**"
       - "tests/skills/peer-sessions-smoke/**"
       - ".github/workflows/smokes.yml"
+  # Required-check triggers — unfiltered on purpose: a paths-skipped
+  # required check blocks queue entry (PRs) or wedges the group
+  # (merge_group). See windows.yml for the full rationale; the push
+  # trigger keeps its paths for cache warming only.
   pull_request:
     branches: [main]
-    paths:
-      - "**/*.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "crates/**/Cargo.toml"
-      - "tests/skills/session-vitals-smoke/**"
-      - "tests/skills/native-goal-smoke/**"
-      - "tests/skills/peer-sessions-smoke/**"
-      - ".github/workflows/smokes.yml"
-  # Merge-queue gate — unconditional (see windows.yml: a paths-skipped
-  # required check wedges the queue).
   merge_group:
 
 permissions:

--- a/.github/workflows/smokes.yml
+++ b/.github/workflows/smokes.yml
@@ -55,16 +55,26 @@ concurrency:
 jobs:
   smokes:
     name: smokes (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
+    # Self-hosted hardening — same rule as windows.yml: fork PR code never
+    # runs on our own hardware.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
+        # `os` is the pinned check-name key; `runner` is the self-hosted
+        # fleet placement; `hosted` gates provisioning steps. See
+        # windows.yml for the full rationale.
         include:
           - os: ubuntu-latest
+            runner: [self-hosted, intendant-linux]
             target: x86_64-unknown-linux-gnu
+            hosted: false
           - os: macos-latest
+            runner: [self-hosted, intendant-macos]
             target: aarch64-apple-darwin
+            hosted: false
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -73,9 +83,11 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       # Same native build deps as windows.yml's test job — the release
-      # build compiles the identical dependency set.
+      # build compiles the identical dependency set. Hosted-only: the
+      # self-hosted boxes are pre-provisioned, and the runner user has
+      # no sudo.
       - name: Install Linux build deps
-        if: runner.os == 'Linux'
+        if: matrix.hosted && runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -83,20 +95,23 @@ jobs:
             libxcb1-dev libxcb-shm0-dev libxcb-randr0-dev
 
       - name: Install macOS build deps
-        if: runner.os == 'macOS'
+        if: matrix.hosted && runner.os == 'macOS'
         run: brew install pkg-config libvpx
 
       # peer-rig.py drives stop_session over a raw WebSocket. A venv
-      # sidesteps PEP 668 (the macos runner's python is
-      # externally-managed and rejects bare pip installs); prepending
-      # its bin to GITHUB_PATH makes it the `python3` later steps get.
+      # sidesteps PEP 668 (externally-managed pythons reject bare pip
+      # installs); prepending its bin to GITHUB_PATH makes it the
+      # `python3` later steps get. Cheap and idempotent, so it runs on
+      # every runner class.
       - name: Install python websockets
         run: |
           python3 -m venv "$RUNNER_TEMP/pyws"
           "$RUNNER_TEMP/pyws/bin/pip" install --quiet websockets
           echo "$RUNNER_TEMP/pyws/bin" >> "$GITHUB_PATH"
 
+      # Hosted-only: self-hosted runners keep a persistent target/.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: matrix.hosted
         with:
           key: smokes-${{ matrix.target }}
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,20 +36,19 @@ on:
       - "Cargo.lock"
       - "crates/**/Cargo.toml"
       - ".github/workflows/windows.yml"
+  # Required-check trigger #1 — deliberately unfiltered. This job is a
+  # required status check, and GitHub only lets a PR *enter* the merge
+  # queue once its own required checks have passed: a paths-skipped
+  # required check leaves the PR BLOCKED at "Expected" forever (verified
+  # live on the first docs-only PR through this repo's queue). Every PR
+  # pays the full matrix; that is the price of a required check. The push
+  # trigger above keeps its paths — its job is warming the main-branch
+  # cache, not gating.
   pull_request:
     branches: [main]
-    paths:
-      - "**/*.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "crates/**/Cargo.toml"
-      - ".github/workflows/windows.yml"
-  # Merge-queue gate. Deliberately unconditional: this job is a required
-  # status check, and a required check that never starts leaves a queue
-  # entry stuck at "Expected" until it times out — merge_group events
-  # don't support paths filtering, and skipped-but-required is the classic
-  # queue wedge. Every queued landing pays the full matrix; the queue's
-  # speculative batching validates entries in parallel, so throughput holds.
+  # Required-check trigger #2 — the merge-queue revalidation against the
+  # speculative merge state (main + everything queued ahead). merge_group
+  # events don't support paths filtering anyway.
   merge_group:
 
 permissions:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -63,7 +63,12 @@ concurrency:
 jobs:
   test:
     name: test (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
+    # Self-hosted hardening: never run pull_request code from a fork on our
+    # own hardware — only same-repo branches (every agent landing) and the
+    # merge queue's own refs. Fork PRs are the rare external-contribution
+    # case and get handled manually behind the Actions fork-approval gate.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     # Full test builds are much heavier than the old `cargo check`; a cold
     # Windows runner can take a while, but a hung run shouldn't burn hours.
     timeout-minutes: 90
@@ -72,13 +77,29 @@ jobs:
       # target's result on a regression.
       fail-fast: false
       matrix:
+        # `os` is the check-name key ("test (ubuntu-latest)" is pinned as a
+        # required context in the main ruleset — renaming it means a
+        # coordinated ruleset edit); `runner` is where the job actually
+        # runs. The Linux and macOS legs live on the self-hosted fleet
+        # (dell-206, macbook-vm): persistent target/ dirs make warm runs
+        # minutes instead of half-hours. Windows stays hosted until the
+        # third box is up. `hosted` gates the runner-provisioning steps —
+        # the self-hosted boxes are pre-provisioned (deps, toolchains) and
+        # keep their build state, so cache actions and dep installs are
+        # hosted-only.
         include:
           - os: windows-latest
+            runner: windows-latest
             target: x86_64-pc-windows-msvc
+            hosted: true
           - os: macos-latest
+            runner: [self-hosted, intendant-macos]
             target: aarch64-apple-darwin
+            hosted: false
           - os: ubuntu-latest
+            runner: [self-hosted, intendant-linux]
             target: x86_64-unknown-linux-gnu
+            hosted: false
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -108,9 +129,10 @@ jobs:
       # env-libvpx-sys + pipewire-sys, libvpx + libpipewire + libxcb headers
       # for those crates' link/pkg-config steps. (No libssl-dev / libpng-dev:
       # the tree is on pure-Rust ring + the `png` crate, not openssl-sys /
-      # libpng.)
+      # libpng.) Hosted-only: the self-hosted boxes are pre-provisioned and
+      # the runner user deliberately has no sudo.
       - name: Install Linux build deps
-        if: runner.os == 'Linux'
+        if: matrix.hosted && runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -124,9 +146,10 @@ jobs:
       # pulls both in transitively via `brew install ffmpeg`. Install them
       # directly here (leaner than all of ffmpeg). The other macOS FFI deps
       # (ScreenCaptureKit, VideoToolbox, CoreFoundation) are system frameworks
-      # already present on the runner image.
+      # already present on the runner image. Hosted-only: the self-hosted Mac
+      # is a provisioned dev box.
       - name: Install macOS build deps
-        if: runner.os == 'macOS'
+        if: matrix.hosted && runner.os == 'macOS'
         run: brew install pkg-config libvpx
 
       # Restore the cargo cache on every run, but only *save* it on pushes to
@@ -134,7 +157,11 @@ jobs:
       # saving them buys nothing — and the Windows tar/zstd save step is flaky
       # enough to fail an otherwise-green job. `save-if` keeps the speed-up on
       # restore while removing the unreliable post-run save from PR checks.
+      # Hosted-only: the self-hosted runners keep a persistent target/ between
+      # runs — that persistence IS the cache, and shipping it to GitHub's
+      # cache store would only add minutes.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: matrix.hosted
         with:
           key: ${{ matrix.target }}
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,8 +275,11 @@ queue itself is wedged, that is an operator (org-owner) decision.
 ## CI/CD
 
 GitHub Actions on push / PR to `main`, and — for the required checks — on every
-`merge_group` (the merge-queue gate; those triggers are deliberately
-unconditional because a paths-skipped required check wedges the queue):
+`merge_group`. The required-check workflows run **unfiltered on `pull_request`
+and `merge_group`**: GitHub only lets a PR enter the merge queue after its own
+required checks pass, so a paths-skipped required check blocks queue entry
+(and on the group side wedges the entry at "Expected"). Only the push-to-main
+triggers keep paths filters — they exist for cache warming, not gating:
 - **`windows.yml`** — cross-platform `cargo test -p intendant --bins -p intendant-core -p intendant-display` + the headless mock-provider e2e on Windows + macOS + Linux (catches platform-specific build breaks *and* Unix-only test/path assumptions; excludes the WASM crates). Headless-safe: needs no display or API keys. **Required check.**
 - **`smokes.yml`** — the keyless smokes (session-vitals, native-goal, peer-sessions) against real release binaries on Linux + macOS. **Required check.**
 - **`app-html.yml`** — the `static/app/` fragments ↔ generated `static/app.html` regen gate. **Required check.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,7 +279,16 @@ GitHub Actions on push / PR to `main`, and — for the required checks — on ev
 and `merge_group`**: GitHub only lets a PR enter the merge queue after its own
 required checks pass, so a paths-skipped required check blocks queue entry
 (and on the group side wedges the entry at "Expected"). Only the push-to-main
-triggers keep paths filters — they exist for cache warming, not gating:
+triggers keep paths filters — they exist for cache warming, not gating.
+
+The Linux and macOS legs run on the **self-hosted fleet** (`dell-206` =
+`intendant-linux`, `macbook-vm` = `intendant-macos`) with persistent
+incremental `target/` dirs — warm gate runs are minutes, not half-hours;
+Windows stays on hosted runners until its box joins. Self-hosted jobs carry a
+same-repo guard (fork-PR code never executes on our hardware), the Dell
+runner runs as a sudo-less dedicated `ci` user, and the check *names* stay
+pinned to the `test (ubuntu-latest)`-style contexts the ruleset requires
+(matrix `os` is the name key, `runner` is the placement):
 - **`windows.yml`** — cross-platform `cargo test -p intendant --bins -p intendant-core -p intendant-display` + the headless mock-provider e2e on Windows + macOS + Linux (catches platform-specific build breaks *and* Unix-only test/path assumptions; excludes the WASM crates). Headless-safe: needs no display or API keys. **Required check.**
 - **`smokes.yml`** — the keyless smokes (session-vitals, native-goal, peer-sessions) against real release binaries on Linux + macOS. **Required check.**
 - **`app-html.yml`** — the `static/app/` fragments ↔ generated `static/app.html` regen gate. **Required check.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,8 +275,11 @@ queue itself is wedged, that is an operator (org-owner) decision.
 ## CI/CD
 
 GitHub Actions on push / PR to `main`, and — for the required checks — on every
-`merge_group` (the merge-queue gate; those triggers are deliberately
-unconditional because a paths-skipped required check wedges the queue):
+`merge_group`. The required-check workflows run **unfiltered on `pull_request`
+and `merge_group`**: GitHub only lets a PR enter the merge queue after its own
+required checks pass, so a paths-skipped required check blocks queue entry
+(and on the group side wedges the entry at "Expected"). Only the push-to-main
+triggers keep paths filters — they exist for cache warming, not gating:
 - **`windows.yml`** — cross-platform `cargo test -p intendant --bins -p intendant-core -p intendant-display` + the headless mock-provider e2e on Windows + macOS + Linux (catches platform-specific build breaks *and* Unix-only test/path assumptions; excludes the WASM crates). Headless-safe: needs no display or API keys. **Required check.**
 - **`smokes.yml`** — the keyless smokes (session-vitals, native-goal, peer-sessions) against real release binaries on Linux + macOS. **Required check.**
 - **`app-html.yml`** — the `static/app/` fragments ↔ generated `static/app.html` regen gate. **Required check.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,7 +279,16 @@ GitHub Actions on push / PR to `main`, and — for the required checks — on ev
 and `merge_group`**: GitHub only lets a PR enter the merge queue after its own
 required checks pass, so a paths-skipped required check blocks queue entry
 (and on the group side wedges the entry at "Expected"). Only the push-to-main
-triggers keep paths filters — they exist for cache warming, not gating:
+triggers keep paths filters — they exist for cache warming, not gating.
+
+The Linux and macOS legs run on the **self-hosted fleet** (`dell-206` =
+`intendant-linux`, `macbook-vm` = `intendant-macos`) with persistent
+incremental `target/` dirs — warm gate runs are minutes, not half-hours;
+Windows stays on hosted runners until its box joins. Self-hosted jobs carry a
+same-repo guard (fork-PR code never executes on our hardware), the Dell
+runner runs as a sudo-less dedicated `ci` user, and the check *names* stay
+pinned to the `test (ubuntu-latest)`-style contexts the ruleset requires
+(matrix `os` is the name key, `runner` is the placement):
 - **`windows.yml`** — cross-platform `cargo test -p intendant --bins -p intendant-core -p intendant-display` + the headless mock-provider e2e on Windows + macOS + Linux (catches platform-specific build breaks *and* Unix-only test/path assumptions; excludes the WASM crates). Headless-safe: needs no display or API keys. **Required check.**
 - **`smokes.yml`** — the keyless smokes (session-vitals, native-goal, peer-sessions) against real release binaries on Linux + macOS. **Required check.**
 - **`app-html.yml`** — the `static/app/` fragments ↔ generated `static/app.html` regen gate. **Required check.**

--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -176,15 +176,26 @@ managed browser cache used by CDP browser workspaces.
 
 ### CI (`.github/workflows/`)
 
+`main` on `github.com/intendant-dev/Intendant` is ruleset-protected: every
+landing is a pull request validated by **GitHub's merge queue**, and the
+checks marked *required* below gate it. Their workflows carry an
+**unconditional `merge_group:` trigger** on purpose — a required check that a
+`paths:` filter skips leaves the queue entry stuck at "Expected" until it
+times out, so queue runs never path-filter.
+
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `windows.yml` | push/PR to `main` (Rust/Cargo paths) | Cross-platform `cargo test -p intendant --bins` on Windows (`x86_64-pc-windows-msvc`), macOS (`aarch64-apple-darwin`), and Linux (`x86_64-unknown-linux-gnu`) to catch platform-specific build breaks and Unix-only test assumptions |
-| `audit.yml` | push/PR (Cargo paths) + weekly cron (Mon 08:00 UTC) | `cargo audit` against the RustSec advisory DB |
-| `docs.yml` | docs changes | Build and deploy this mdBook |
-| `agents-md-sync.yml` | push/PR touching `CLAUDE.md` or `AGENTS.md`, plus manual dispatch | Fails when tracked `AGENTS.md` differs byte-for-byte from `CLAUDE.md` |
+| `windows.yml` | push/PR to `main` (Rust/Cargo paths) + every merge group | **Required.** Cross-platform `cargo test -p intendant --bins -p intendant-core -p intendant-display` plus the headless mock-provider e2e on Windows (`x86_64-pc-windows-msvc`), macOS (`aarch64-apple-darwin`), and Linux (`x86_64-unknown-linux-gnu`) to catch platform-specific build breaks and Unix-only test assumptions |
+| `smokes.yml` | push/PR to `main` (Rust/Cargo/smoke paths) + every merge group | **Required.** The keyless smokes (`session-vitals`, `native-goal`, `peer-sessions`) driving real release binaries with the scripted mock provider on Linux + macOS |
+| `app-html.yml` | push/PR touching `static/app/**` or the assembler + every merge group | **Required.** Reruns the assembler and fails when the committed `static/app.html` doesn't match the fragments |
+| `agents-md-sync.yml` | push/PR touching `CLAUDE.md` or `AGENTS.md`, manual dispatch + every merge group | **Required.** Fails when tracked `AGENTS.md` differs byte-for-byte from `CLAUDE.md` |
+| `audit.yml` | push/PR (Cargo paths) + weekly cron (Mon 08:00 UTC) | Advisory: `cargo audit` against the RustSec advisory DB — new upstream advisories must not block unrelated landings |
+| `docs.yml` | docs changes on `main` | Build and deploy this mdBook to GitHub Pages |
 
-The E2E scenarios under `tests/skills/` make real API calls / need a display and
-are **not** in CI.
+The `tests/skills/` scenarios that make real API calls or need a display (the
+live claude-code-e2e battery, browser/Station probes, the peer smoke's
+`--browser` leg) are **not** in CI — they run on operator hardware as the
+post-landing battery.
 Run `cargo test --bins` and `cargo clippy` locally before committing. The TLS
 stack is pure-Rust `ring` / `rustls` / `rcgen` (no OpenSSL), which is why the
 Windows CI job installs NASM (for `ring`'s assembly) but no `libssl`.

--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -178,17 +178,19 @@ managed browser cache used by CDP browser workspaces.
 
 `main` on `github.com/intendant-dev/Intendant` is ruleset-protected: every
 landing is a pull request validated by **GitHub's merge queue**, and the
-checks marked *required* below gate it. Their workflows carry an
-**unconditional `merge_group:` trigger** on purpose — a required check that a
-`paths:` filter skips leaves the queue entry stuck at "Expected" until it
-times out, so queue runs never path-filter.
+checks marked *required* below gate it. The required-check workflows run
+**unfiltered on `pull_request` and `merge_group`** on purpose: GitHub only
+adds a PR to the queue once the PR's own required checks pass, so a
+`paths:`-skipped required check blocks queue entry (and a skipped group check
+wedges the entry at "Expected"). Their push-to-main triggers keep paths
+filters — those runs warm the main-branch caches, they don't gate.
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `windows.yml` | push/PR to `main` (Rust/Cargo paths) + every merge group | **Required.** Cross-platform `cargo test -p intendant --bins -p intendant-core -p intendant-display` plus the headless mock-provider e2e on Windows (`x86_64-pc-windows-msvc`), macOS (`aarch64-apple-darwin`), and Linux (`x86_64-unknown-linux-gnu`) to catch platform-specific build breaks and Unix-only test assumptions |
-| `smokes.yml` | push/PR to `main` (Rust/Cargo/smoke paths) + every merge group | **Required.** The keyless smokes (`session-vitals`, `native-goal`, `peer-sessions`) driving real release binaries with the scripted mock provider on Linux + macOS |
-| `app-html.yml` | push/PR touching `static/app/**` or the assembler + every merge group | **Required.** Reruns the assembler and fails when the committed `static/app.html` doesn't match the fragments |
-| `agents-md-sync.yml` | push/PR touching `CLAUDE.md` or `AGENTS.md`, manual dispatch + every merge group | **Required.** Fails when tracked `AGENTS.md` differs byte-for-byte from `CLAUDE.md` |
+| `windows.yml` | every PR + merge group; push to `main` (Rust/Cargo paths, cache warming) | **Required.** Cross-platform `cargo test -p intendant --bins -p intendant-core -p intendant-display` plus the headless mock-provider e2e on Windows (`x86_64-pc-windows-msvc`), macOS (`aarch64-apple-darwin`), and Linux (`x86_64-unknown-linux-gnu`) to catch platform-specific build breaks and Unix-only test assumptions |
+| `smokes.yml` | every PR + merge group; push to `main` (Rust/Cargo/smoke paths, cache warming) | **Required.** The keyless smokes (`session-vitals`, `native-goal`, `peer-sessions`) driving real release binaries with the scripted mock provider on Linux + macOS |
+| `app-html.yml` | every PR + merge group; push to `main` (fragment/assembler paths) | **Required.** Reruns the assembler and fails when the committed `static/app.html` doesn't match the fragments |
+| `agents-md-sync.yml` | every PR + merge group; push touching `CLAUDE.md`/`AGENTS.md`; manual dispatch | **Required.** Fails when tracked `AGENTS.md` differs byte-for-byte from `CLAUDE.md` |
 | `audit.yml` | push/PR (Cargo paths) + weekly cron (Mon 08:00 UTC) | Advisory: `cargo audit` against the RustSec advisory DB — new upstream advisories must not block unrelated landings |
 | `docs.yml` | docs changes on `main` | Build and deploy this mdBook to GitHub Pages |
 

--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -185,6 +185,16 @@ adds a PR to the queue once the PR's own required checks pass, so a
 wedges the entry at "Expected"). Their push-to-main triggers keep paths
 filters — those runs warm the main-branch caches, they don't gate.
 
+The Linux and macOS legs run on a **self-hosted fleet** (`dell-206` /
+`intendant-linux`, `macbook-vm` / `intendant-macos`) whose persistent
+incremental `target/` dirs make warm gate runs a few minutes; the Windows leg
+stays on GitHub-hosted runners until a Windows box joins the fleet.
+Self-hosted hardening: jobs carry a same-repo guard so fork-PR code never
+executes on the fleet (fork PRs are handled manually behind the Actions
+fork-approval gate — only maintainers can enqueue anyway), the Dell runner
+runs as a dedicated sudo-less `ci` user, runners are registered per-repo,
+and the default `GITHUB_TOKEN` is read-only.
+
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
 | `windows.yml` | every PR + merge group; push to `main` (Rust/Cargo paths, cache warming) | **Required.** Cross-platform `cargo test -p intendant --bins -p intendant-core -p intendant-display` plus the headless mock-provider e2e on Windows (`x86_64-pc-windows-msvc`), macOS (`aarch64-apple-darwin`), and Linux (`x86_64-unknown-linux-gnu`) to catch platform-specific build breaks and Unix-only test assumptions |


### PR DESCRIPTION
The CI table gains smokes.yml and app-html.yml, marks the four required
checks and audit's advisory status, and documents the unconditional
merge_group triggers (a paths-skipped required check wedges a queue
entry at Expected).

This PR is also the live validation of the queue setup itself: a
docs-only change, so it proves required checks still run on the merge
group instead of wedging behind paths filters.
