### PR TITLE
CI: Windows leg joins the self-hosted fleet (samsung-win)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -80,18 +80,17 @@ jobs:
         # `os` is the check-name key ("test (ubuntu-latest)" is pinned as a
         # required context in the main ruleset — renaming it means a
         # coordinated ruleset edit); `runner` is where the job actually
-        # runs. The Linux and macOS legs live on the self-hosted fleet
-        # (dell-206, macbook-vm): persistent target/ dirs make warm runs
-        # minutes instead of half-hours. Windows stays hosted until the
-        # third box is up. `hosted` gates the runner-provisioning steps —
-        # the self-hosted boxes are pre-provisioned (deps, toolchains) and
-        # keep their build state, so cache actions and dep installs are
-        # hosted-only.
+        # runs. All three legs live on the self-hosted fleet (dell-206,
+        # macbook-vm, samsung-win): persistent target/ dirs make warm runs
+        # minutes instead of half-hours. `hosted` gates the
+        # runner-provisioning steps — the self-hosted boxes are
+        # pre-provisioned (deps, toolchains) and keep their build state, so
+        # cache actions and dep installs are hosted-only.
         include:
           - os: windows-latest
-            runner: windows-latest
+            runner: [self-hosted, intendant-windows]
             target: x86_64-pc-windows-msvc
-            hosted: true
+            hosted: false
           - os: macos-latest
             runner: [self-hosted, intendant-macos]
             target: aarch64-apple-darwin
@@ -110,12 +109,12 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       # `ring` (our TLS provider — aws-lc-rs is deliberately disabled) builds
-      # its x86_64 perlasm assembly with NASM on the MSVC target. The GitHub
-      # windows-latest image ships NASM, but install it explicitly so the
-      # workflow doesn't silently break if that ever changes; choco is a no-op
-      # when it's already present.
+      # its x86_64 perlasm assembly with NASM on the MSVC target. Hosted-only,
+      # like the other provisioning steps: the self-hosted Windows box has
+      # NASM preinstalled on the machine PATH, and its runner user neither
+      # has nor needs choco.
       - name: Install NASM (Windows, for ring)
-        if: runner.os == 'Windows'
+        if: matrix.hosted && runner.os == 'Windows'
         run: |
           if (-not (Get-Command nasm -ErrorAction SilentlyContinue)) {
             choco install nasm --no-progress -y

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -281,14 +281,14 @@ required checks pass, so a paths-skipped required check blocks queue entry
 (and on the group side wedges the entry at "Expected"). Only the push-to-main
 triggers keep paths filters — they exist for cache warming, not gating.
 
-The Linux and macOS legs run on the **self-hosted fleet** (`dell-206` =
-`intendant-linux`, `macbook-vm` = `intendant-macos`) with persistent
-incremental `target/` dirs — warm gate runs are minutes, not half-hours;
-Windows stays on hosted runners until its box joins. Self-hosted jobs carry a
-same-repo guard (fork-PR code never executes on our hardware), the Dell
-runner runs as a sudo-less dedicated `ci` user, and the check *names* stay
-pinned to the `test (ubuntu-latest)`-style contexts the ruleset requires
-(matrix `os` is the name key, `runner` is the placement):
+All three legs run on the **self-hosted fleet** (`dell-206` =
+`intendant-linux`, `macbook-vm` = `intendant-macos`, `samsung-win` =
+`intendant-windows`) with persistent incremental `target/` dirs — warm gate
+runs are minutes, not half-hours. Self-hosted jobs carry a same-repo guard
+(fork-PR code never executes on our hardware), the Dell and Windows runners
+run as dedicated non-admin `ci` users, and the check *names* stay pinned to
+the `test (ubuntu-latest)`-style contexts the ruleset requires (matrix `os`
+is the name key, `runner` is the placement):
 - **`windows.yml`** — cross-platform `cargo test -p intendant --bins -p intendant-core -p intendant-display` + the headless mock-provider e2e on Windows + macOS + Linux (catches platform-specific build breaks *and* Unix-only test/path assumptions; excludes the WASM crates). Headless-safe: needs no display or API keys. **Required check.**
 - **`smokes.yml`** — the keyless smokes (session-vitals, native-goal, peer-sessions) against real release binaries on Linux + macOS. **Required check.**
 - **`app-html.yml`** — the `static/app/` fragments ↔ generated `static/app.html` regen gate. **Required check.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,14 +281,14 @@ required checks pass, so a paths-skipped required check blocks queue entry
 (and on the group side wedges the entry at "Expected"). Only the push-to-main
 triggers keep paths filters — they exist for cache warming, not gating.
 
-The Linux and macOS legs run on the **self-hosted fleet** (`dell-206` =
-`intendant-linux`, `macbook-vm` = `intendant-macos`) with persistent
-incremental `target/` dirs — warm gate runs are minutes, not half-hours;
-Windows stays on hosted runners until its box joins. Self-hosted jobs carry a
-same-repo guard (fork-PR code never executes on our hardware), the Dell
-runner runs as a sudo-less dedicated `ci` user, and the check *names* stay
-pinned to the `test (ubuntu-latest)`-style contexts the ruleset requires
-(matrix `os` is the name key, `runner` is the placement):
+All three legs run on the **self-hosted fleet** (`dell-206` =
+`intendant-linux`, `macbook-vm` = `intendant-macos`, `samsung-win` =
+`intendant-windows`) with persistent incremental `target/` dirs — warm gate
+runs are minutes, not half-hours. Self-hosted jobs carry a same-repo guard
+(fork-PR code never executes on our hardware), the Dell and Windows runners
+run as dedicated non-admin `ci` users, and the check *names* stay pinned to
+the `test (ubuntu-latest)`-style contexts the ruleset requires (matrix `os`
+is the name key, `runner` is the placement):
 - **`windows.yml`** — cross-platform `cargo test -p intendant --bins -p intendant-core -p intendant-display` + the headless mock-provider e2e on Windows + macOS + Linux (catches platform-specific build breaks *and* Unix-only test/path assumptions; excludes the WASM crates). Headless-safe: needs no display or API keys. **Required check.**
 - **`smokes.yml`** — the keyless smokes (session-vitals, native-goal, peer-sessions) against real release binaries on Linux + macOS. **Required check.**
 - **`app-html.yml`** — the `static/app/` fragments ↔ generated `static/app.html` regen gate. **Required check.**

--- a/docs/src/integrations.md
+++ b/docs/src/integrations.md
@@ -185,15 +185,15 @@ adds a PR to the queue once the PR's own required checks pass, so a
 wedges the entry at "Expected"). Their push-to-main triggers keep paths
 filters — those runs warm the main-branch caches, they don't gate.
 
-The Linux and macOS legs run on a **self-hosted fleet** (`dell-206` /
-`intendant-linux`, `macbook-vm` / `intendant-macos`) whose persistent
-incremental `target/` dirs make warm gate runs a few minutes; the Windows leg
-stays on GitHub-hosted runners until a Windows box joins the fleet.
-Self-hosted hardening: jobs carry a same-repo guard so fork-PR code never
-executes on the fleet (fork PRs are handled manually behind the Actions
-fork-approval gate — only maintainers can enqueue anyway), the Dell runner
-runs as a dedicated sudo-less `ci` user, runners are registered per-repo,
-and the default `GITHUB_TOKEN` is read-only.
+All three legs run on a **self-hosted fleet** (`dell-206` /
+`intendant-linux`, `macbook-vm` / `intendant-macos`, `samsung-win` /
+`intendant-windows`) whose persistent incremental `target/` dirs make warm
+gate runs a few minutes. Self-hosted hardening: jobs carry a same-repo guard
+so fork-PR code never executes on the fleet (fork PRs are handled manually
+behind the Actions fork-approval gate — only maintainers can enqueue anyway),
+the Dell and Windows runners run as dedicated non-admin `ci` users (sudo-less
+on Linux; a plain `Users`-group service account on Windows), runners are
+registered per-repo, and the default `GITHUB_TOKEN` is read-only.
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|


### PR DESCRIPTION
Flip windows.yml's Windows matrix entry from GitHub-hosted to the
self-hosted box: runner [self-hosted, intendant-windows], hosted false.
The check name stays test (windows-latest) — matrix os is the pinned
ruleset context, runner is only placement, same as the Linux/macOS legs.

The NASM install step becomes hosted-only like the other provisioning
steps: the box has NASM preinstalled on the machine PATH and its
non-admin runner user neither has nor needs choco. rust-cache was
already hosted-gated; the persistent target/ dir IS the cache.

CLAUDE.md/AGENTS.md + docs/src/integrations.md: the fleet paragraph now
lists all three legs and the Windows runner's non-admin service user.
