### PR TITLE
Retire UserAction: MCP tools and ControlMsg arms share named state helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ src/
 │   ├── main.rs                 # entry: CLI flags/help, panic hook, startup prologue + mode dispatch
 │   ├── agent_loop.rs, run_modes.rs, external_mode.rs, external_supervision.rs, display_glue.rs   # carved from main.rs: the native loop + orchestration handlers; native/external mode runners; external supervision helpers; frame/CU/user-display glue
 │   ├── startup/                # web bind/TLS + peer boot; the three mode branches (daemon, mcp_mode, headless)
-│   ├── control_plane.rs, event.rs, frontend.rs   # single-writer state; EventBus; UserAction/ControlMsg
+│   ├── control_plane.rs, event.rs, frontend.rs   # single-writer state; EventBus + ControlMsg; state snapshots
 │   ├── session_supervisor.rs, task_dispatch.rs, file_watcher.rs   # daemon: sessions, dispatch, rewind snapshots
 │   ├── provider.rs, conversation.rs, tools.rs, prompts.rs, skills.rs, autonomy.rs, approval.rs
 │   ├── sub_agent.rs, worktree.rs, worktree_inventory.rs, agent_runner.rs   # native multi-agent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ src/
 │   ├── main.rs                 # entry: CLI flags/help, panic hook, startup prologue + mode dispatch
 │   ├── agent_loop.rs, run_modes.rs, external_mode.rs, external_supervision.rs, display_glue.rs   # carved from main.rs: the native loop + orchestration handlers; native/external mode runners; external supervision helpers; frame/CU/user-display glue
 │   ├── startup/                # web bind/TLS + peer boot; the three mode branches (daemon, mcp_mode, headless)
-│   ├── control_plane.rs, event.rs, frontend.rs   # single-writer state; EventBus; UserAction/ControlMsg
+│   ├── control_plane.rs, event.rs, frontend.rs   # single-writer state; EventBus + ControlMsg; state snapshots
 │   ├── session_supervisor.rs, task_dispatch.rs, file_watcher.rs   # daemon: sessions, dispatch, rewind snapshots
 │   ├── provider.rs, conversation.rs, tools.rs, prompts.rs, skills.rs, autonomy.rs, approval.rs
 │   ├── sub_agent.rs, worktree.rs, worktree_inventory.rs, agent_runner.rs   # native multi-agent

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -239,9 +239,10 @@ delegate it. Verified against `main.rs`:
 `ControlMsg` and `AppEvent` are the shared vocabulary across frontends. The
 web dashboard, MCP server, and control socket render `AppEvent` state and send
 `ControlMsg` intents through the EventBus; the control plane and session
-supervisor are the state writers. The MCP surface additionally maps its
-approval/input tools to `UserAction` and serializes some resource snapshots via
-`StateResult` — `UserAction` is MCP-only vocabulary today.
+supervisor are the state writers. The MCP surface serializes some resource
+snapshots via `StateResult` (`frontend.rs`); its approval/input tools apply
+the same state helpers as the matching `ControlMsg` arms (the former
+`UserAction` middle-man enum is retired).
 
 There is no single compile-time exhaustiveness guarantee across all frontends.
 Rust exhaustive matching protects each local handler, and cross-frontend parity

--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -27,10 +27,10 @@ one in Intendant gives you:
   it and the daemon can run several alongside native agents
   (see [control plane & daemon](./control-plane-and-daemon.md)).
 
-Crucially, external-agent control does **not** flow through the `UserAction` enum
-that unifies the native frontends. It rides `ControlMsg` (inbound) and `AppEvent`
-(outbound) on the EventBus (`event.rs`), because the verbs are backend-shaped
-(steer a turn, fork a thread, roll back) rather than the native action set.
+External-agent control rides the same vocabulary as everything else:
+`ControlMsg` (inbound) and `AppEvent` (outbound) on the EventBus (`event.rs`).
+The verbs are backend-shaped (steer a turn, fork a thread, roll back) rather
+than the native action set.
 
 ## The `ExternalAgent` Trait
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -26,7 +26,7 @@ Intendant is built around a few core ideas:
 
 **A single-writer control plane.** Shared mutable state (autonomy level, the active agent backend, runtime config) has exactly one writer: the control plane. Frontends are *display-only* — they render state and emit intents, but never mutate state directly. See [Control Plane & Daemon](./control-plane-and-daemon.md).
 
-**Shared frontend vocabulary.** Frontends exchange state and intents through `AppEvent` and `ControlMsg`: the web dashboard, MCP server, and control socket render events and submit control messages to the single-writer control plane. The MCP surface also maps approval/input tools to `UserAction`. See [Architecture](./architecture.md) and [Autonomy & Approvals](./autonomy.md).
+**Shared frontend vocabulary.** Frontends exchange state and intents through `AppEvent` and `ControlMsg`: the web dashboard, MCP server, and control socket render events and submit control messages to the single-writer control plane. See [Architecture](./architecture.md) and [Autonomy & Approvals](./autonomy.md).
 
 **Presence as a separate AI.** Rather than a chat wrapper, the presence layer is an independent (usually fast) model with its own conversation, tools, and state awareness. It mediates between the user and the working agent, turning intent into tasks and narrating progress back. See [Presence Layer](./presence.md).
 

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -7,17 +7,14 @@ can take in the dashboard is exposed as an MCP tool, plus display/CU/frame
 tools, live audio, and a controller-orchestration surface.
 
 Architecturally the MCP server is a **frontend peer of the dashboard**: it
-subscribes to the same `EventBus` and translates its tools through the
-`UserAction` enum (`frontend.rs`), processed by the shared `process_action`
-handler.
-
-> **Parity scope:** `UserAction` is MCP-only vocabulary today (the retired
-> terminal TUI was its other consumer). The web dashboard and the Unix control
-> socket dispatch [`ControlMsg`](./integrations.md) values that the centralized
-> `control_plane.rs` applies (see [Autonomy & Approvals](./autonomy.md) for why
-> frontends are display-only). So there are two dispatch contracts today:
-> `UserAction` (MCP) and `ControlMsg` (web/control-socket) — a unification
-> candidate. `--mcp` is its own run mode and is **not** implied by `--web`.
+subscribes to the same `EventBus`, and user intents are
+[`ControlMsg`](./integrations.md) values everywhere — the web dashboard and the
+Unix control socket dispatch them to the centralized `control_plane.rs` (see
+[Autonomy & Approvals](./autonomy.md) for why frontends are display-only), and
+the MCP server's approval/input tools apply the same state helpers as its own
+`ControlMsg` arms (`resolve_pending_approval` & co. in `mcp.rs`; the former
+MCP-only `UserAction` enum is retired). `--mcp` is its own run mode and is
+**not** implied by `--web`.
 
 ## Running
 
@@ -172,7 +169,7 @@ Full MCP tool groups:
 | `get_pending_approval` | The current pending approval request (or null). | — |
 | `get_pending_input`    | The current pending `askHuman` question (or null). | — |
 
-### Interactive actions (→ `UserAction`)
+### Interactive actions
 
 | Tool            | Description | Params |
 |-----------------|-------------|--------|

--- a/src/bin/caller/frontend.rs
+++ b/src/bin/caller/frontend.rs
@@ -1,49 +1,16 @@
-//! MCP action and snapshot helpers.
+//! Serializable state snapshots shared by the frontends.
 //!
 //! The cross-frontend vocabulary is [`ControlMsg`](crate::event::ControlMsg) and
-//! [`AppEvent`](crate::event::AppEvent). The TUI, web dashboard, MCP server, and
-//! control socket all meet on that EventBus surface.
-//!
-//! `UserAction` and `StateResult` are MCP-oriented helpers used for
-//! approval/input tools and resource serialization. They do not provide a
-//! compile-time exhaustiveness contract across all frontends.
+//! [`AppEvent`](crate::event::AppEvent). The web dashboard, MCP server, and
+//! control socket all meet on that EventBus surface; the snapshot types here
+//! (status, usage, logs, pending approval/input, and the `StateResult`
+//! envelope) are how that state serializes onto those surfaces.
 
-use crate::autonomy::AutonomyLevel;
-use crate::types::{LogLevel, Verbosity};
+use crate::types::LogLevel;
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
-// MCP approval/input actions
-// ---------------------------------------------------------------------------
-
-/// Approval/input actions exposed by the MCP surface.
-///
-/// Adding a variant here requires updating MCP action mapping and handling.
-#[derive(Debug, Clone, PartialEq)]
-pub enum UserAction {
-    /// Approve a pending command (`approve` tool).
-    Approve { id: u64 },
-    /// Deny a pending command (`deny` tool).
-    Deny { id: u64 },
-    /// Skip a pending command (`skip` tool).
-    Skip { id: u64 },
-    /// Approve all future commands (`approve_all` tool).
-    ApproveAll { id: u64 },
-    /// Respond to an askHuman question (`respond` tool).
-    RespondHuman { text: String },
-    /// Change the autonomy level (`set_autonomy` tool).
-    SetAutonomy { level: AutonomyLevel },
-    /// Set verbosity (`set_verbosity` tool).
-    SetVerbosity { level: Verbosity },
-    /// Submit a follow-up message after a round completes.
-    #[allow(dead_code)]
-    SubmitFollowUp { text: String },
-    /// Shut down the agent (`quit` tool).
-    Quit,
-}
-
-// ---------------------------------------------------------------------------
-// MCP snapshots
+// Snapshots
 // ---------------------------------------------------------------------------
 
 /// A snapshot of the current status bar.
@@ -138,26 +105,6 @@ pub struct HumanQuestionSnapshot {
     pub question: String,
 }
 
-/// Snapshot queries used by MCP-style resource handling.
-#[allow(dead_code)]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum StateQuery {
-    /// Current status bar information.
-    Status,
-    /// Token usage for all models.
-    Usage,
-    /// Log entries, optionally filtered.
-    Logs {
-        since_id: Option<u64>,
-        level_filter: Option<String>,
-        limit: Option<usize>,
-    },
-    /// The current pending approval (if any).
-    PendingApproval,
-    /// The current pending human question (if any).
-    PendingInput,
-}
-
 /// Result of a state query.
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -175,73 +122,9 @@ pub enum StateResult {
     },
 }
 
-/// Outcome of processing a [`UserAction`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ActionOutcome {
-    /// Action was accepted and applied.
-    Ok,
-    /// Action was not applicable (e.g. no pending approval when approving).
-    NoOp { reason: String },
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn user_action_variants_are_distinct() {
-        let a = UserAction::Approve { id: 1 };
-        let b = UserAction::Deny { id: 1 };
-        assert_ne!(a, b);
-    }
-
-    #[test]
-    fn user_action_approve_eq() {
-        let a = UserAction::Approve { id: 42 };
-        let b = UserAction::Approve { id: 42 };
-        assert_eq!(a, b);
-    }
-
-    #[test]
-    fn user_action_set_autonomy() {
-        let a = UserAction::SetAutonomy {
-            level: AutonomyLevel::High,
-        };
-        let b = UserAction::SetAutonomy {
-            level: AutonomyLevel::Low,
-        };
-        assert_ne!(a, b);
-    }
-
-    #[test]
-    fn user_action_respond_human() {
-        let a = UserAction::RespondHuman {
-            text: "PostgreSQL".to_string(),
-        };
-        assert_eq!(
-            a,
-            UserAction::RespondHuman {
-                text: "PostgreSQL".to_string()
-            }
-        );
-    }
-
-    #[test]
-    fn state_query_variants_are_distinct() {
-        let a = StateQuery::Status;
-        let b = StateQuery::PendingApproval;
-        assert_ne!(a, b);
-    }
-
-    #[test]
-    fn state_query_logs_with_filter() {
-        let q = StateQuery::Logs {
-            since_id: Some(5),
-            level_filter: Some("error".to_string()),
-            limit: Some(100),
-        };
-        assert_ne!(q, StateQuery::Status);
-    }
 
     #[test]
     fn status_snapshot_serializes() {
@@ -374,59 +257,6 @@ mod tests {
     }
 
     #[test]
-    fn action_outcome_ok() {
-        assert_eq!(ActionOutcome::Ok, ActionOutcome::Ok);
-    }
-
-    #[test]
-    fn action_outcome_noop() {
-        let outcome = ActionOutcome::NoOp {
-            reason: "no pending approval".to_string(),
-        };
-        assert_ne!(outcome, ActionOutcome::Ok);
-    }
-
-    #[test]
-    fn all_user_actions_constructible() {
-        // Ensures every variant can be constructed — catches accidental removal.
-        let actions: Vec<UserAction> = vec![
-            UserAction::Approve { id: 1 },
-            UserAction::Deny { id: 1 },
-            UserAction::Skip { id: 1 },
-            UserAction::ApproveAll { id: 1 },
-            UserAction::RespondHuman {
-                text: "test".to_string(),
-            },
-            UserAction::SetAutonomy {
-                level: AutonomyLevel::Medium,
-            },
-            UserAction::SetVerbosity {
-                level: Verbosity::Normal,
-            },
-            UserAction::SubmitFollowUp {
-                text: "continue".to_string(),
-            },
-            UserAction::Quit,
-        ];
-        assert_eq!(actions.len(), 9);
-    }
-
-    #[test]
-    fn all_state_queries_constructible() {
-        let queries: Vec<StateQuery> = vec![
-            StateQuery::Status,
-            StateQuery::Logs {
-                since_id: None,
-                level_filter: None,
-                limit: None,
-            },
-            StateQuery::PendingApproval,
-            StateQuery::PendingInput,
-        ];
-        assert_eq!(queries.len(), 4);
-    }
-
-    #[test]
     fn log_level_round_trips_through_snapshot() {
         // Verify that LogLevel variants can be stringified for snapshots.
         let levels = vec![
@@ -459,18 +289,3 @@ pub fn log_level_to_str(level: &LogLevel) -> &'static str {
     }
 }
 
-/// Parse a log level filter string back to a LogLevel.
-#[allow(dead_code)]
-pub fn parse_log_level(s: &str) -> Option<LogLevel> {
-    match s.to_lowercase().as_str() {
-        "info" => Some(LogLevel::Info),
-        "model" => Some(LogLevel::Model),
-        "agent" => Some(LogLevel::Agent),
-        "error" => Some(LogLevel::Error),
-        "warn" => Some(LogLevel::Warn),
-        "subagent" => Some(LogLevel::SubAgent),
-        "detail" => Some(LogLevel::Detail),
-        "debug" => Some(LogLevel::Debug),
-        _ => None,
-    }
-}

--- a/src/bin/caller/mcp.rs
+++ b/src/bin/caller/mcp.rs
@@ -1,15 +1,12 @@
 //! MCP (Model Context Protocol) server for Intendant.
 //!
 //! This module implements an MCP server that exposes Intendant's full state and
-//! controls via the standard protocol. It is architecturally a **peer** of the
-//! TUI — both consume the same [`EventBus`] events and translate user/agent
-//! actions through the shared [`UserAction`](crate::frontend::UserAction) enum.
-//!
-//! ## Parity Contract
-//!
-//! The [`IntendantServer`] uses the same [`UserAction`] enum and [`StateQuery`]
-//! types as the TUI. Adding a new `UserAction` variant forces both this module
-//! and the TUI key handler to handle it (Rust exhaustive match, no wildcards).
+//! controls via the standard protocol. It is architecturally a frontend peer of
+//! the web dashboard and the control socket: all of them consume the same
+//! [`EventBus`] events, and control intents arrive as
+//! [`ControlMsg`](crate::event::ControlMsg). The approval/input tools and the
+//! matching `ControlMsg` arms feed the same state helpers
+//! ([`resolve_pending_approval`] & co.), so both entry points stay in lockstep.
 
 use std::collections::HashSet;
 use std::future::Future;
@@ -37,8 +34,7 @@ use crate::autonomy::{AutonomyLevel, SharedAutonomy};
 use crate::control;
 use crate::event::{AppEvent, ApprovalRegistry, ApprovalResponse, ControlMsg, EventBus};
 use crate::frontend::{
-    self, ActionOutcome, ApprovalSnapshot, HumanQuestionSnapshot, LogEntrySnapshot, StateResult,
-    StatusSnapshot, UserAction,
+    self, ApprovalSnapshot, HumanQuestionSnapshot, LogEntrySnapshot, StateResult, StatusSnapshot,
 };
 use crate::types::OutboundEvent;
 use crate::types::{truncate_str, LogLevel, Phase, Verbosity};
@@ -3986,7 +3982,7 @@ async fn handle_control_command_mcp(
         }
         ControlMsg::Approve { id, .. } => {
             let mut s = state.write().await;
-            let outcome = process_action_sync(&mut s, UserAction::Approve { id });
+            let outcome = resolve_pending_approval(&mut s, ApprovalResponse::Approve);
             if matches!(outcome, ActionOutcome::Ok) {
                 bus.send(AppEvent::ApprovalResolved {
                     session_id: None,
@@ -4005,7 +4001,7 @@ async fn handle_control_command_mcp(
         }
         ControlMsg::Deny { id, .. } => {
             let mut s = state.write().await;
-            let outcome = process_action_sync(&mut s, UserAction::Deny { id });
+            let outcome = resolve_pending_approval(&mut s, ApprovalResponse::Deny);
             if matches!(outcome, ActionOutcome::Ok) {
                 bus.send(AppEvent::ApprovalResolved {
                     session_id: None,
@@ -4050,7 +4046,7 @@ async fn handle_control_command_mcp(
         }
         ControlMsg::Input { text } => {
             let mut s = state.write().await;
-            let outcome = process_action_sync(&mut s, UserAction::RespondHuman { text });
+            let outcome = respond_to_human_question(&mut s, &text);
             emit_control_result(
                 control_tx,
                 "input",
@@ -4062,7 +4058,7 @@ async fn handle_control_command_mcp(
         }
         ControlMsg::Skip { id, .. } => {
             let mut s = state.write().await;
-            let outcome = process_action_sync(&mut s, UserAction::Skip { id });
+            let outcome = resolve_pending_approval(&mut s, ApprovalResponse::Skip);
             if matches!(outcome, ActionOutcome::Ok) {
                 bus.send(AppEvent::ApprovalResolved {
                     session_id: None,
@@ -4081,7 +4077,7 @@ async fn handle_control_command_mcp(
         }
         ControlMsg::ApproveAll { id, .. } => {
             let mut s = state.write().await;
-            let outcome = process_action_sync(&mut s, UserAction::ApproveAll { id });
+            let outcome = resolve_pending_approval(&mut s, ApprovalResponse::ApproveAll);
             if matches!(outcome, ActionOutcome::Ok) {
                 bus.send(AppEvent::ApprovalResolved {
                     session_id: None,
@@ -5134,9 +5130,8 @@ async fn handle_control_command_mcp(
             None
         }
         ControlMsg::Quit => {
-            let action = UserAction::Quit;
             let mut s = state.write().await;
-            let outcome = process_action_sync(&mut s, action);
+            let outcome = request_quit(&mut s);
             emit_control_result(
                 control_tx,
                 "quit",
@@ -7972,12 +7967,16 @@ impl IntendantServer {
     }
 }
 
-/// Process a [`UserAction`] against the shared state. This is the **single**
-/// handler that both TUI and MCP feed into.
-///
-/// Note: for actions that need async access (like writing autonomy), the caller
-/// must handle the async parts. This function handles the state-mutation and
-/// oneshot-sending synchronously.
+/// Outcome of an MCP-surface state action.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ActionOutcome {
+    /// Action was accepted and applied.
+    Ok,
+    /// Action was not applicable (e.g. no pending approval when approving).
+    NoOp { reason: String },
+}
+
+/// Send `response` to the registry waiter registered under `id`.
 fn resolve_approval(registry: &ApprovalRegistry, id: u64, response: ApprovalResponse) {
     if let Ok(mut reg) = registry.lock() {
         if let Some(responder) = reg.remove(&id) {
@@ -7986,112 +7985,65 @@ fn resolve_approval(registry: &ApprovalRegistry, id: u64, response: ApprovalResp
     }
 }
 
-fn process_action_sync(state: &mut McpAppState, action: UserAction) -> ActionOutcome {
-    // Exhaustive match — no wildcard. Compile-time parity enforcement.
-    match action {
-        UserAction::Approve { id: _ } => {
-            if let Some(pending) = state.pending_approval.take() {
-                resolve_approval(
-                    &state.approval_registry,
-                    pending.id,
-                    ApprovalResponse::Approve,
-                );
-                state.set_phase(Phase::RunningAgent);
-                state.push_log(LogLevel::Info, "Approved by MCP agent".to_string());
-                ActionOutcome::Ok
-            } else {
-                ActionOutcome::NoOp {
-                    reason: "No pending approval".to_string(),
-                }
-            }
-        }
-        UserAction::Deny { id: _ } => {
-            if let Some(pending) = state.pending_approval.take() {
-                resolve_approval(&state.approval_registry, pending.id, ApprovalResponse::Deny);
-                state.set_phase(Phase::Done);
-                state.push_log(LogLevel::Info, "Denied by MCP agent".to_string());
-                ActionOutcome::Ok
-            } else {
-                ActionOutcome::NoOp {
-                    reason: "No pending approval".to_string(),
-                }
-            }
-        }
-        UserAction::Skip { id: _ } => {
-            if let Some(pending) = state.pending_approval.take() {
-                resolve_approval(&state.approval_registry, pending.id, ApprovalResponse::Skip);
-                state.set_phase(Phase::RunningAgent);
-                state.push_log(LogLevel::Info, "Skipped by MCP agent".to_string());
-                ActionOutcome::Ok
-            } else {
-                ActionOutcome::NoOp {
-                    reason: "No pending approval".to_string(),
-                }
-            }
-        }
-        UserAction::ApproveAll { id: _ } => {
-            if let Some(pending) = state.pending_approval.take() {
-                resolve_approval(
-                    &state.approval_registry,
-                    pending.id,
-                    ApprovalResponse::ApproveAll,
-                );
-                state.set_phase(Phase::RunningAgent);
-                state.push_log(
-                    LogLevel::Info,
-                    "Approved all (autonomy → Full) by MCP agent".to_string(),
-                );
-                ActionOutcome::Ok
-            } else {
-                ActionOutcome::NoOp {
-                    reason: "No pending approval".to_string(),
-                }
-            }
-        }
-        UserAction::RespondHuman { text } => {
-            if state.human_question.is_some() {
-                // Write response to session-scoped file (same mechanism as TUI)
-                let response_path = state.log_dir.join("human_response");
-                if std::fs::write(&response_path, &text).is_ok() {
-                    state.human_question = None;
-                    state.set_phase(Phase::RunningAgent);
-                    state.push_log(LogLevel::Info, format!("Human response (MCP): {}", text));
-                    ActionOutcome::Ok
-                } else {
-                    ActionOutcome::NoOp {
-                        reason: "Failed to write response file".to_string(),
-                    }
-                }
-            } else {
-                ActionOutcome::NoOp {
-                    reason: "No pending human question".to_string(),
-                }
-            }
-        }
-        UserAction::SetAutonomy { level: _ } => {
-            // Autonomy is set asynchronously by the caller after this returns.
-            ActionOutcome::Ok
-        }
-        UserAction::SetVerbosity { level } => {
-            state.verbosity = level;
-            state.push_log(
-                LogLevel::Info,
-                format!("Verbosity set to {} by MCP agent", verbosity_to_str(level)),
-            );
-            ActionOutcome::Ok
-        }
-        UserAction::SubmitFollowUp { .. } => {
-            // Follow-up is handled asynchronously via the channel, not here.
-            ActionOutcome::NoOp {
-                reason: "SubmitFollowUp must be sent via follow-up channel".to_string(),
-            }
-        }
-        UserAction::Quit => {
-            state.should_quit = true;
-            state.push_log(LogLevel::Info, "Quit requested by MCP agent".to_string());
-            ActionOutcome::Ok
+/// Resolve the pending approval prompt with `response` — the single handler
+/// behind the approve/deny/skip/approve_all tools and their `ControlMsg`
+/// twins. Phase transition and log line derive from the response kind.
+fn resolve_pending_approval(state: &mut McpAppState, response: ApprovalResponse) -> ActionOutcome {
+    let Some(pending) = state.pending_approval.take() else {
+        return ActionOutcome::NoOp {
+            reason: "No pending approval".to_string(),
+        };
+    };
+    let (phase, log) = match &response {
+        ApprovalResponse::Approve => (Phase::RunningAgent, "Approved by MCP agent"),
+        ApprovalResponse::Skip => (Phase::RunningAgent, "Skipped by MCP agent"),
+        ApprovalResponse::Deny => (Phase::Done, "Denied by MCP agent"),
+        ApprovalResponse::ApproveAll => (
+            Phase::RunningAgent,
+            "Approved all (autonomy → Full) by MCP agent",
+        ),
+        ApprovalResponse::Answer { .. } => (Phase::RunningAgent, "Question answered by MCP agent"),
+    };
+    resolve_approval(&state.approval_registry, pending.id, response);
+    state.set_phase(phase);
+    state.push_log(LogLevel::Info, log.to_string());
+    ActionOutcome::Ok
+}
+
+/// Deliver an askHuman reply by writing the session-scoped response file the
+/// agent loop polls.
+fn respond_to_human_question(state: &mut McpAppState, text: &str) -> ActionOutcome {
+    if state.human_question.is_none() {
+        return ActionOutcome::NoOp {
+            reason: "No pending human question".to_string(),
+        };
+    }
+    let response_path = state.log_dir.join("human_response");
+    if std::fs::write(&response_path, text).is_ok() {
+        state.human_question = None;
+        state.set_phase(Phase::RunningAgent);
+        state.push_log(LogLevel::Info, format!("Human response (MCP): {}", text));
+        ActionOutcome::Ok
+    } else {
+        ActionOutcome::NoOp {
+            reason: "Failed to write response file".to_string(),
         }
     }
+}
+
+fn apply_verbosity(state: &mut McpAppState, level: Verbosity) -> ActionOutcome {
+    state.verbosity = level;
+    state.push_log(
+        LogLevel::Info,
+        format!("Verbosity set to {} by MCP agent", verbosity_to_str(level)),
+    );
+    ActionOutcome::Ok
+}
+
+fn request_quit(state: &mut McpAppState) -> ActionOutcome {
+    state.should_quit = true;
+    state.push_log(LogLevel::Info, "Quit requested by MCP agent".to_string());
+    ActionOutcome::Ok
 }
 
 // ---------------------------------------------------------------------------
@@ -8565,13 +8517,10 @@ impl IntendantServer {
         }
     }
 
-    #[tool(
-        description = "Approve a pending command execution. Equivalent to pressing 'y' in the TUI."
-    )]
+    #[tool(description = "Approve a pending command execution.")]
     async fn approve(&self, Parameters(params): Parameters<ApproveParams>) -> String {
-        let action = UserAction::Approve { id: params.id };
         let mut s = self.state.write().await;
-        let outcome = process_action_sync(&mut s, action);
+        let outcome = resolve_pending_approval(&mut s, ApprovalResponse::Approve);
         if outcome == ActionOutcome::Ok {
             self.bus.send(AppEvent::ApprovalResolved {
                 session_id: None,
@@ -8582,13 +8531,10 @@ impl IntendantServer {
         format_outcome(outcome)
     }
 
-    #[tool(
-        description = "Deny a pending command execution. Stops the agent loop. Equivalent to pressing 'n' in the TUI."
-    )]
+    #[tool(description = "Deny a pending command execution. Stops the agent loop.")]
     async fn deny(&self, Parameters(params): Parameters<DenyParams>) -> String {
-        let action = UserAction::Deny { id: params.id };
         let mut s = self.state.write().await;
-        let outcome = process_action_sync(&mut s, action);
+        let outcome = resolve_pending_approval(&mut s, ApprovalResponse::Deny);
         if outcome == ActionOutcome::Ok {
             self.bus.send(AppEvent::ApprovalResolved {
                 session_id: None,
@@ -8600,12 +8546,11 @@ impl IntendantServer {
     }
 
     #[tool(
-        description = "Skip a pending command execution. The agent continues with the next command. Equivalent to pressing 's' in the TUI."
+        description = "Skip a pending command execution. The agent continues with the next command."
     )]
     async fn skip(&self, Parameters(params): Parameters<SkipParams>) -> String {
-        let action = UserAction::Skip { id: params.id };
         let mut s = self.state.write().await;
-        let outcome = process_action_sync(&mut s, action);
+        let outcome = resolve_pending_approval(&mut s, ApprovalResponse::Skip);
         if outcome == ActionOutcome::Ok {
             self.bus.send(AppEvent::ApprovalResolved {
                 session_id: None,
@@ -8616,13 +8561,10 @@ impl IntendantServer {
         format_outcome(outcome)
     }
 
-    #[tool(
-        description = "Approve this and all future commands (sets autonomy to Full). Equivalent to pressing 'a' in the TUI."
-    )]
+    #[tool(description = "Approve this and all future commands (sets autonomy to Full).")]
     async fn approve_all(&self, Parameters(params): Parameters<ApproveAllParams>) -> String {
-        let action = UserAction::ApproveAll { id: params.id };
         let mut s = self.state.write().await;
-        let outcome = process_action_sync(&mut s, action);
+        let outcome = resolve_pending_approval(&mut s, ApprovalResponse::ApproveAll);
         if outcome == ActionOutcome::Ok {
             self.bus.send(AppEvent::ApprovalResolved {
                 session_id: None,
@@ -8637,19 +8579,14 @@ impl IntendantServer {
         format_outcome(outcome)
     }
 
-    #[tool(
-        description = "Respond to an askHuman question. Equivalent to typing a response and pressing Enter in the TUI."
-    )]
+    #[tool(description = "Respond to an askHuman question.")]
     async fn respond(&self, Parameters(params): Parameters<RespondParams>) -> String {
-        let action = UserAction::RespondHuman { text: params.text };
         let mut s = self.state.write().await;
-        let outcome = process_action_sync(&mut s, action);
+        let outcome = respond_to_human_question(&mut s, &params.text);
         format_outcome(outcome)
     }
 
-    #[tool(
-        description = "Set the autonomy level. Controls how much approval is required. Equivalent to +/- keys in the TUI."
-    )]
+    #[tool(description = "Set the autonomy level. Controls how much approval is required.")]
     async fn set_autonomy(&self, Parameters(params): Parameters<SetAutonomyParams>) -> String {
         let level = AutonomyLevel::from_str_loose(&params.level);
         let s = self.state.read().await;
@@ -8660,7 +8597,6 @@ impl IntendantServer {
             a.level = level;
         }
         let mut s = self.state.write().await;
-        let _ = process_action_sync(&mut s, UserAction::SetAutonomy { level });
         s.push_log(
             LogLevel::Info,
             format!("Autonomy set to {} by MCP agent", level),
@@ -8668,15 +8604,12 @@ impl IntendantServer {
         format!("Autonomy set to {}", level)
     }
 
-    #[tool(
-        description = "Set log verbosity level. Controls which log entries are shown. Equivalent to pressing 'v' in the TUI."
-    )]
+    #[tool(description = "Set log verbosity level. Controls which log entries are shown.")]
     async fn set_verbosity(&self, Parameters(params): Parameters<SetVerbosityParams>) -> String {
         match parse_verbosity(&params.level) {
             Some(level) => {
-                let action = UserAction::SetVerbosity { level };
                 let mut s = self.state.write().await;
-                let outcome = process_action_sync(&mut s, action);
+                let outcome = apply_verbosity(&mut s, level);
                 format_outcome(outcome)
             }
             None => format!(
@@ -8686,13 +8619,10 @@ impl IntendantServer {
         }
     }
 
-    #[tool(
-        description = "Shut down the Intendant agent. Equivalent to pressing 'q' or Ctrl-C in the TUI."
-    )]
+    #[tool(description = "Shut down the Intendant agent.")]
     async fn quit(&self) -> String {
-        let action = UserAction::Quit;
         let mut s = self.state.write().await;
-        let outcome = process_action_sync(&mut s, action);
+        let outcome = request_quit(&mut s);
         format_outcome(outcome)
     }
 
@@ -17740,7 +17670,7 @@ mod tests {
     }
 
     #[test]
-    fn process_action_approve_with_pending() {
+    fn resolve_pending_approval_approve() {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -17756,7 +17686,7 @@ mod tests {
                 category: "destructive".to_string(),
             });
 
-            let outcome = process_action_sync(&mut s, UserAction::Approve { id: 1 });
+            let outcome = resolve_pending_approval(&mut s, ApprovalResponse::Approve);
             assert_eq!(outcome, ActionOutcome::Ok);
             assert!(s.pending_approval.is_none());
             assert_eq!(s.phase, Phase::RunningAgent);
@@ -17768,7 +17698,7 @@ mod tests {
     }
 
     #[test]
-    fn process_action_approve_without_pending() {
+    fn resolve_pending_approval_without_pending() {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -17776,7 +17706,7 @@ mod tests {
         rt.block_on(async {
             let state = test_state();
             let mut s = state.write().await;
-            let outcome = process_action_sync(&mut s, UserAction::Approve { id: 1 });
+            let outcome = resolve_pending_approval(&mut s, ApprovalResponse::Approve);
             match outcome {
                 ActionOutcome::NoOp { reason } => {
                     assert!(reason.contains("No pending approval"));
@@ -17787,7 +17717,7 @@ mod tests {
     }
 
     #[test]
-    fn process_action_deny() {
+    fn resolve_pending_approval_deny() {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -17803,7 +17733,7 @@ mod tests {
                 category: "network".to_string(),
             });
 
-            let outcome = process_action_sync(&mut s, UserAction::Deny { id: 2 });
+            let outcome = resolve_pending_approval(&mut s, ApprovalResponse::Deny);
             assert_eq!(outcome, ActionOutcome::Ok);
             assert_eq!(s.phase, Phase::Done);
 
@@ -17813,7 +17743,7 @@ mod tests {
     }
 
     #[test]
-    fn process_action_skip() {
+    fn resolve_pending_approval_skip() {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -17829,7 +17759,7 @@ mod tests {
                 category: "exec".to_string(),
             });
 
-            let outcome = process_action_sync(&mut s, UserAction::Skip { id: 3 });
+            let outcome = resolve_pending_approval(&mut s, ApprovalResponse::Skip);
             assert_eq!(outcome, ActionOutcome::Ok);
             assert_eq!(s.phase, Phase::RunningAgent);
 
@@ -17839,7 +17769,7 @@ mod tests {
     }
 
     #[test]
-    fn process_action_approve_all() {
+    fn resolve_pending_approval_approve_all() {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -17855,7 +17785,7 @@ mod tests {
                 category: "exec".to_string(),
             });
 
-            let outcome = process_action_sync(&mut s, UserAction::ApproveAll { id: 4 });
+            let outcome = resolve_pending_approval(&mut s, ApprovalResponse::ApproveAll);
             assert_eq!(outcome, ActionOutcome::Ok);
 
             let response = rx.await.unwrap();
@@ -17864,7 +17794,7 @@ mod tests {
     }
 
     #[test]
-    fn process_action_set_verbosity() {
+    fn apply_verbosity_sets_level() {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -17872,19 +17802,14 @@ mod tests {
         rt.block_on(async {
             let state = test_state();
             let mut s = state.write().await;
-            let outcome = process_action_sync(
-                &mut s,
-                UserAction::SetVerbosity {
-                    level: Verbosity::Debug,
-                },
-            );
+            let outcome = apply_verbosity(&mut s, Verbosity::Debug);
             assert_eq!(outcome, ActionOutcome::Ok);
             assert_eq!(s.verbosity, Verbosity::Debug);
         });
     }
 
     #[test]
-    fn process_action_quit() {
+    fn request_quit_sets_flag() {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -17892,14 +17817,14 @@ mod tests {
         rt.block_on(async {
             let state = test_state();
             let mut s = state.write().await;
-            let outcome = process_action_sync(&mut s, UserAction::Quit);
+            let outcome = request_quit(&mut s);
             assert_eq!(outcome, ActionOutcome::Ok);
             assert!(s.should_quit);
         });
     }
 
     #[test]
-    fn process_action_respond_human_without_question() {
+    fn respond_to_human_question_without_question() {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -17907,12 +17832,7 @@ mod tests {
         rt.block_on(async {
             let state = test_state();
             let mut s = state.write().await;
-            let outcome = process_action_sync(
-                &mut s,
-                UserAction::RespondHuman {
-                    text: "hello".to_string(),
-                },
-            );
+            let outcome = respond_to_human_question(&mut s, "hello");
             match outcome {
                 ActionOutcome::NoOp { reason } => {
                     assert!(reason.contains("No pending human question"));
@@ -19294,6 +19214,14 @@ mod tests {
     }
 
     #[test]
+    fn action_outcome_noop_differs_from_ok() {
+        let outcome = ActionOutcome::NoOp {
+            reason: "no pending approval".to_string(),
+        };
+        assert_ne!(outcome, ActionOutcome::Ok);
+    }
+
+    #[test]
     fn server_info_has_correct_name() {
         let state = test_state();
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -19306,41 +19234,6 @@ mod tests {
             let info = server.get_info();
             assert_eq!(info.server_info.name, "intendant");
             assert!(info.instructions.is_some());
-        });
-    }
-
-    #[test]
-    fn all_user_actions_handled_by_process_action() {
-        // This test ensures process_action_sync handles every UserAction variant.
-        // If a new variant is added, the exhaustive match in process_action_sync
-        // will cause a compile error, AND this test will need updating.
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        rt.block_on(async {
-            let state = test_state();
-            let actions: Vec<UserAction> = vec![
-                UserAction::Approve { id: 1 },
-                UserAction::Deny { id: 1 },
-                UserAction::Skip { id: 1 },
-                UserAction::ApproveAll { id: 1 },
-                UserAction::RespondHuman {
-                    text: "test".to_string(),
-                },
-                UserAction::SetAutonomy {
-                    level: AutonomyLevel::High,
-                },
-                UserAction::SetVerbosity {
-                    level: Verbosity::Normal,
-                },
-                UserAction::Quit,
-            ];
-            for action in actions {
-                let mut s = state.write().await;
-                // Should not panic for any variant
-                let _ = process_action_sync(&mut s, action);
-            }
         });
     }
 

--- a/src/bin/caller/startup/mcp_mode.rs
+++ b/src/bin/caller/startup/mcp_mode.rs
@@ -1,6 +1,6 @@
 //! The MCP execution shape: run_mcp_mode is main()'s `if flags.mcp`
-//! arm — Model Context Protocol on stdio, architecturally a peer of
-//! the TUI (same EventBus, same UserAction contract).
+//! arm — Model Context Protocol on stdio, architecturally a frontend
+//! peer of the dashboard (same EventBus, same ControlMsg vocabulary).
 
 // Same entangled class as the drain (external_events.rs): keeps the
 // crate-root view it was written against. Narrowing to named imports
@@ -32,7 +32,7 @@ pub(crate) async fn run_mcp_mode(
 ) -> Result<(), CallerError> {
     // MCP mode — speaks Model Context Protocol on stdio.
     // Architecturally a frontend peer of the dashboard: same EventBus,
-    // translating through the UserAction contract.
+    // same ControlMsg vocabulary.
     let bus = EventBus::new();
     let event_rx = bus.subscribe();
     let human_question_path = event::shared_question_path(log_dir.join("human_question"));


### PR DESCRIPTION
The UserAction enum (frontend.rs) survived the TUI gut as a 9-variant
middle-man: handle_control_command_mcp already received ControlMsg and
translated per-arm into UserAction just to call process_action_sync.
Dissolve that dispatch into named helpers in mcp.rs —
resolve_pending_approval / respond_to_human_question / apply_verbosity /
request_quit — called directly by both the MCP tools and the ControlMsg
arms. ControlMsg is now the single user-intent vocabulary across
frontends.

- frontend.rs shrinks to the serializable snapshot module: UserAction,
  StateQuery (dead) and parse_log_level (dead) deleted; ActionOutcome
  moves into mcp.rs next to its only consumers.
- The SetAutonomy no-op arm and the dead SubmitFollowUp variant dissolve.
- MCP tool descriptions stop citing TUI keybindings that no longer
  exist; docs (architecture, mcp-server, introduction,
  external-agent-orchestration) and CLAUDE.md/AGENTS.md follow.

Behavior-preserving: same registry resolution, phases, and log lines.
Suite 2562+35+81 green (net -10 = the retired enum's tests), clippy adds
no warnings in touched files, e2e 3/3.
