### PR TITLE
Dashboard QA: window.qa probe convention + validate-dashboard --probe-json readback

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -118,6 +118,42 @@ can probe pane/render state and drive the real log append pipeline via
 `window.__intendantPaneDiag` (the app script is module-scoped, so probes
 cannot reach bindings by name).
 
+### QA probes (`window.qa`)
+
+The SPA is one `<script type="module">`, so harnesses evaluating in the
+page's main world cannot reach module bindings by name. Fragments that have
+QA-relevant state export it on the shared readback namespace, declared next
+to the state it reads:
+
+```js
+window.qa = Object.assign(window.qa || {}, {
+  sessionsHydration: () => ({ seen, unresolved, inFlight }),
+});
+```
+
+Each entry is a cheap, side-effect-free function returning a
+JSON-serializable snapshot. Current probes: `qa.sessionsHydration()`
+(sessions-tab relationship-hydration termination, `40-session-launch.js`),
+`qa.sessionsFuel()` (new-session credential preflight, `55-files-ide.js`),
+and `qa.station()` — a pointer to `window.stationProbe`, which predates the
+namespace and keeps its legacy name (the validator's `--station-*` probes
+and smoke skills depend on it). `window.__intendantPaneDiag` above is the
+other legacy surface.
+
+`scripts/validate-dashboard.cjs` reads probes back without a bespoke sink
+via the repeatable `--probe-json EXPR` flag (optional `label=EXPR` form):
+after the checks pass — and on failure, before exit, so you see the state
+that failed — it evaluates each expression in the page and prints one
+`probe <label> = <compact JSON>` line to stdout (thrown errors print as
+`{"error":...}`; ~4KB cap per probe):
+
+```bash
+node scripts/validate-dashboard.cjs --url "http://127.0.0.1:<port>/#sessions" \
+  --wait-for-function "(() => typeof window.qa === 'object')()" \
+  --probe-json "fuel=window.qa.sessionsFuel()" \
+  --probe-json "window.qa.sessionsHydration()"
+```
+
 ### Activity
 
 The default tab, and the classic DOM control surface. It remains fully

--- a/scripts/validate-dashboard.cjs
+++ b/scripts/validate-dashboard.cjs
@@ -25,6 +25,7 @@ const FAILURE_SCREENSHOT_SETTLE_MS = 300;
 const DEFAULT_LOG_LINES = 8;
 const LOG_BUFFER_LIMIT = 80;
 const LOG_TEXT_LIMIT = 260;
+const PROBE_JSON_LIMIT = 4096;
 const RESULT_REASON_LIMIT = 520;
 const RESULT_LOG_LIMIT = 320;
 const DIAGNOSTIC_TEXT_LIMIT = 260;
@@ -144,6 +145,15 @@ Options:
   --sandbox                  Omit default --no-sandbox
   --log-lines N              Bounded browser/page log lines on failure (default: ${DEFAULT_LOG_LINES})
   --diagnostics              On failure, include compact generic DOM/page state
+  --probe-json EXPR          Evaluate EXPR in the page after checks pass — and on failure,
+                             before exit — and print one "probe <label> = <JSON>" readback
+                             line per flag to stdout (JSON.stringify'd inside the page;
+                             thrown errors print as {"error":...}; ~${Math.round(PROBE_JSON_LIMIT / 1024)}KB cap per probe).
+                             Optional label=EXPR form; repeatable. Pairs with the SPA's
+                             window.qa probe namespace, e.g.
+                             --probe-json "fuel=window.qa.sessionsFuel()".
+                             With --json the readbacks ride in the result as "probes"
+                             instead of separate lines
   --screenshot PATH          Capture a PNG screenshot after validation/probes
   --station-interaction-probe
                              Click/activate rendered Station hotspots and report latency
@@ -190,6 +200,7 @@ function parseArgs(argv, env = process.env) {
     path: '/',
     selectors: [],
     functions: [],
+    probeJson: [],
     stationProbes: [],
     stationMinFps: DEFAULT_STATION_MIN_FPS,
     stationMaxFrameGapMs: DEFAULT_STATION_MAX_FRAME_GAP_MS,
@@ -277,6 +288,10 @@ function parseArgs(argv, env = process.env) {
       opts.functions.push(readValue());
     } else if (arg.startsWith('--wait-for-function=')) {
       opts.functions.push(arg.slice('--wait-for-function='.length));
+    } else if (arg === '--probe-json') {
+      opts.probeJson.push(parseProbeJsonArgument(readValue()));
+    } else if (arg.startsWith('--probe-json=')) {
+      opts.probeJson.push(parseProbeJsonArgument(arg.slice('--probe-json='.length)));
     } else if (arg === '--station-min-fps') {
       opts.stationMinFps = parsePositiveInt(readValue(), '--station-min-fps');
     } else if (arg.startsWith('--station-min-fps=')) {
@@ -436,6 +451,20 @@ function parseStationProbeArgument(raw) {
     throw new Error('--station-probe requires at least one probe name');
   }
   return names;
+}
+
+function parseProbeJsonArgument(raw) {
+  const value = String(raw || '').trim();
+  if (!value) {
+    throw new Error('--probe-json requires a JS expression');
+  }
+  // Optional label=EXPR form: a bare identifier label followed by '='.
+  // '==' and '=>' keep the whole argument as a plain expression.
+  const labeled = value.match(/^([A-Za-z_$][\w$-]*)=(?![=>])\s*(\S[\s\S]*)$/);
+  if (labeled) {
+    return { label: labeled[1], expression: labeled[2] };
+  }
+  return { label: value, expression: value };
 }
 
 function normalizeStationActivateTarget(raw) {
@@ -639,6 +668,9 @@ async function main() {
     if (opts.keepArtifacts || opts.keepBrowser) {
       artifacts.browserUserDataDir = harness.userDataDir;
     }
+    const probes = opts.probeJson.length
+      ? await harness.collectProbeJson(opts.probeJson)
+      : undefined;
     const result = {
       status: 'pass',
       url: opts.url,
@@ -648,6 +680,7 @@ async function main() {
       artifacts,
       selectors: opts.selectors.length,
       functions: opts.functions.length,
+      probes,
       stationProbes: opts.stationProbes.length,
       stationProbeReports: validation.stationProbeReports,
       stationInteraction: validation.stationInteraction,
@@ -680,11 +713,23 @@ async function main() {
           error: diagError.message || String(diagError),
         }))
       : undefined;
+    // Probe readback runs on failure too — the state at failure is the point.
+    let probes;
+    if (opts.probeJson.length) {
+      probes = harness
+        ? await harness.collectProbeJson(opts.probeJson).catch(() => undefined)
+        : undefined;
+      probes = probes || opts.probeJson.map((probe) => ({
+        label: probe.label,
+        error: 'browser harness unavailable',
+      }));
+    }
     const result = {
       status: 'fail',
       url: opts.url,
       ms: Date.now() - started,
       reason: error.message || String(error),
+      probes,
       failureKind: validationFailureKind(error.message || String(error)),
       browser: harness && harness.browserExecutable,
       websocket: harness && harness.websocketKind,
@@ -712,6 +757,7 @@ function staticScriptsOnly(opts) {
       && !opts.holdDashboard
       && opts.selectors.length === 0
       && opts.functions.length === 0
+      && opts.probeJson.length === 0
       && opts.stationProbes.length === 0
       && !opts.stationInteractionProbe
       && opts.stationActivateTargets.length === 0
@@ -866,11 +912,19 @@ function printResult(opts, result) {
     if (displayResult.staticScripts) {
       console.log(formatStaticScriptPass(displayResult.staticScripts));
     }
+    for (const line of formatProbeJsonLines(displayResult.probes)) {
+      console.log(line);
+    }
     return;
   }
   console.error(
     `FAIL dashboard-validation url=${quote(displayResult.url)} kind=${quote(displayResult.failureKind || 'unknown')} reason=${quote(displayResult.reason)} ms=${displayResult.ms}`,
   );
+  // Probe readback stays on stdout even on failure: it is data for the
+  // caller, not diagnostics noise, and failure state is what probes are for.
+  for (const line of formatProbeJsonLines(displayResult.probes)) {
+    console.log(line);
+  }
   if (displayResult.stationPerfEval) {
     console.error(formatStationPerfEvalLine(displayResult.stationPerfEval));
   }
@@ -912,6 +966,19 @@ function printDashboardHoldResult(opts, result) {
     `PASS dashboard-hold url=${quote(result.url)} readyUrl=${quote(result.readyUrl)} pid=${result.pid || 'unknown'} ms=${result.ms}`,
   );
   console.log('Hold this command open while running CU/browser E2E; interrupt it to stop the temporary dashboard.');
+}
+
+function formatProbeJsonLines(probes) {
+  if (!Array.isArray(probes) || !probes.length) {
+    return [];
+  }
+  return probes.map((probe) => {
+    const payload = probe.error !== undefined
+      ? JSON.stringify({ error: String(probe.error) })
+      : String(probe.json);
+    const suffix = probe.truncated ? ` [truncated, ${probe.truncated} chars total]` : '';
+    return `probe ${probe.label} = ${payload}${suffix}`;
+  });
 }
 
 function formatArtifactLines(artifacts) {
@@ -2065,6 +2132,34 @@ class BrowserHarness {
         return `wait-for-function did not become truthy${suffix}`;
       },
     );
+  }
+
+  // --probe-json readback: best-effort and per-probe fault-isolated, because
+  // it also runs on the failure path where the page may be wedged or gone.
+  async collectProbeJson(probes, timeoutMs = DEFAULT_CDP_COMMAND_TIMEOUT_MS) {
+    const results = [];
+    for (const probe of probes) {
+      let outcome;
+      try {
+        outcome = await this.evaluate(probeJsonExpression(probe.expression), timeoutMs);
+      } catch (error) {
+        outcome = { ok: false, error: error.message || String(error) };
+      }
+      const entry = { label: probe.label };
+      if (outcome && outcome.ok) {
+        entry.json = String(outcome.json);
+        if (outcome.truncated) {
+          entry.truncated = Number(outcome.truncated);
+        }
+      } else {
+        entry.error = truncate(
+          String((outcome && outcome.error) || 'probe evaluation returned no result'),
+          PROBE_JSON_LIMIT,
+        );
+      }
+      results.push(entry);
+    }
+    return results;
   }
 
   async runStationProbe(probe, opts) {
@@ -3358,6 +3453,22 @@ function waitFunctionExpression(source) {
     const candidate = (${trimmed});
     return typeof candidate === 'function' ? candidate() : candidate;
   })())`;
+}
+
+// --probe-json: serialize inside the page so the readback needs no bespoke
+// sink; report thrown errors instead of failing, and cap the transfer.
+function probeJsonExpression(source) {
+  const trimmed = String(source).trim();
+  return `Promise.resolve()
+    .then(() => (${trimmed}))
+    .then((value) => {
+      const json = JSON.stringify(value);
+      const text = json === undefined ? String(value) : json;
+      return text.length > ${PROBE_JSON_LIMIT}
+        ? { ok: true, json: text.slice(0, ${PROBE_JSON_LIMIT}), truncated: text.length }
+        : { ok: true, json: text };
+    })
+    .catch((error) => ({ ok: false, error: String((error && error.message) || error) }))`;
 }
 
 function stationProbeExpression(probe, options = {}) {
@@ -5665,6 +5776,53 @@ async function runSelfTest() {
   // The page-side workflow op source must stay valid JS.
   assert.strictEqual(typeof stationWorkflowOpSource(), 'string');
   new Function(`return (${stationWorkflowOpSource()});`)();
+
+  // --probe-json readback: parsing, page-side expression, line formatting.
+  const probeParsed = parseArgs(
+    [
+      '--port',
+      '1234',
+      '--probe-json',
+      'window.qa.sessionsHydration()',
+      '--probe-json=fuel=window.qa.sessionsFuel()',
+    ],
+    {},
+  );
+  assert.deepStrictEqual(probeParsed.probeJson, [
+    { label: 'window.qa.sessionsHydration()', expression: 'window.qa.sessionsHydration()' },
+    { label: 'fuel', expression: 'window.qa.sessionsFuel()' },
+  ]);
+  // '==' and '=>' after an identifier are expressions, not labels.
+  assert.deepStrictEqual(parseProbeJsonArgument('a==b'), { label: 'a==b', expression: 'a==b' });
+  assert.deepStrictEqual(parseProbeJsonArgument('x=>x'), { label: 'x=>x', expression: 'x=>x' });
+  assert.throws(() => parseProbeJsonArgument('   '), /requires a JS expression/);
+  const probeValue = await new Function(`return (${probeJsonExpression('({ n: 1, s: "two" })')});`)();
+  assert.deepStrictEqual(probeValue, { ok: true, json: '{"n":1,"s":"two"}' });
+  const probeThrown = await new Function(`return (${probeJsonExpression('window.qa.missing()')});`)();
+  assert.strictEqual(probeThrown.ok, false);
+  assert.ok(String(probeThrown.error).includes('window is not defined'));
+  const probeBig = await new Function(`return (${probeJsonExpression(`'y'.repeat(${PROBE_JSON_LIMIT + 100})`)});`)();
+  assert.strictEqual(probeBig.ok, true);
+  assert.strictEqual(probeBig.json.length, PROBE_JSON_LIMIT);
+  assert.strictEqual(probeBig.truncated, PROBE_JSON_LIMIT + 102);
+  assert.deepStrictEqual(
+    formatProbeJsonLines([
+      { label: 'fuel', json: '{"ok":true}' },
+      { label: 'broken', error: 'boom' },
+      { label: 'big', json: '"y"', truncated: 9000 },
+    ]),
+    [
+      'probe fuel = {"ok":true}',
+      'probe broken = {"error":"boom"}',
+      'probe big = "y" [truncated, 9000 chars total]',
+    ],
+  );
+  assert.deepStrictEqual(formatProbeJsonLines(undefined), []);
+  // --probe-json needs a live page: it must not degrade to static-scripts-only.
+  assert.strictEqual(
+    staticScriptsOnly(parseArgs(['--check-static-scripts', '--probe-json', 'window.qa'], {})),
+    false,
+  );
 
   assert.ok(browserArgs('/tmp/profile', parseArgs([], {})).includes('--disable-gpu'));
   const gpuBrowserArgs = browserArgs('/tmp/profile', parsed);

--- a/static/app.html
+++ b/static/app.html
@@ -18824,6 +18824,13 @@ window.stationProbe = Object.assign(window.stationProbe || {}, {
   },
 });
 
+// QA readback (window.qa convention): Station predates the namespace and
+// keeps its legacy window.stationProbe name (the validator's --station-*
+// probes and smoke skills depend on it); window.qa.station points at it.
+window.qa = Object.assign(window.qa || {}, {
+  station: () => window.stationProbe,
+});
+
 function stationLogEventId(c, fallbackIndex = '') {
   const hostId = String(c?.host_id || c?.hostId || selfPeerId || 'local');
   const sessionId = String(c?.session_id || c?.sessionId || '');
@@ -35582,12 +35589,15 @@ function hydrateSessionRelationshipRows(rel) {
     });
 }
 
-// QA hook (stationProbe convention): the hydration-termination state the
+// QA readback (window.qa convention): the hydration-termination state the
 // validate-dashboard harness asserts on — module scope hides it otherwise.
-window.sessionsHydrationProbe = () => ({
-  seen: sessionRowSeenIds.size,
-  unresolved: sessionRelationshipHydrationUnresolved.size,
-  inFlight: sessionRelationshipHydrationInFlight.size,
+// Probe functions stay cheap and side-effect-free.
+window.qa = Object.assign(window.qa || {}, {
+  sessionsHydration: () => ({
+    seen: sessionRowSeenIds.size,
+    unresolved: sessionRelationshipHydrationUnresolved.size,
+    inFlight: sessionRelationshipHydrationInFlight.size,
+  }),
 });
 
 function applySessionRelationship(evt = {}) {
@@ -67721,16 +67731,19 @@ const NEW_SESSION_UNFUELED_MESSAGE =
   'This daemon has no model credentials, so the internal agent can’t start. ' +
   'External agents (Codex, Claude Code) sign in with their own accounts and still work.';
 
-// QA hook (stationProbe convention): the preflight inputs the
+// QA readback (window.qa convention): the preflight inputs the
 // validate-dashboard harness asserts on — module scope hides them.
-window.sessionsFuelProbe = () => ({
-  fueled: dashboardControlTransport?.lastStatus?.fueled ?? null,
-  haveStatus: !!dashboardControlTransport?.lastStatus,
-  unfueledCached: daemonUnfueledCached,
-  effectiveAgent: effectiveNewSessionAgentId(),
-  configuredAgent: newSessionConfiguredAgent || '',
-  bannerHidden: !!document.getElementById('new-session-unfueled-banner')?.classList.contains('hidden'),
-  startDisabled: !!document.getElementById('new-session-start-btn')?.disabled,
+// Probe functions stay cheap and side-effect-free.
+window.qa = Object.assign(window.qa || {}, {
+  sessionsFuel: () => ({
+    fueled: dashboardControlTransport?.lastStatus?.fueled ?? null,
+    haveStatus: !!dashboardControlTransport?.lastStatus,
+    unfueledCached: daemonUnfueledCached,
+    effectiveAgent: effectiveNewSessionAgentId(),
+    configuredAgent: newSessionConfiguredAgent || '',
+    bannerHidden: !!document.getElementById('new-session-unfueled-banner')?.classList.contains('hidden'),
+    startDisabled: !!document.getElementById('new-session-start-btn')?.disabled,
+  }),
 });
 
 function updateNewSessionFuelBanner() {

--- a/static/app/33-station-core.js
+++ b/static/app/33-station-core.js
@@ -432,6 +432,13 @@ window.stationProbe = Object.assign(window.stationProbe || {}, {
   },
 });
 
+// QA readback (window.qa convention): Station predates the namespace and
+// keeps its legacy window.stationProbe name (the validator's --station-*
+// probes and smoke skills depend on it); window.qa.station points at it.
+window.qa = Object.assign(window.qa || {}, {
+  station: () => window.stationProbe,
+});
+
 function stationLogEventId(c, fallbackIndex = '') {
   const hostId = String(c?.host_id || c?.hostId || selfPeerId || 'local');
   const sessionId = String(c?.session_id || c?.sessionId || '');

--- a/static/app/40-session-launch.js
+++ b/static/app/40-session-launch.js
@@ -1925,12 +1925,15 @@ function hydrateSessionRelationshipRows(rel) {
     });
 }
 
-// QA hook (stationProbe convention): the hydration-termination state the
+// QA readback (window.qa convention): the hydration-termination state the
 // validate-dashboard harness asserts on — module scope hides it otherwise.
-window.sessionsHydrationProbe = () => ({
-  seen: sessionRowSeenIds.size,
-  unresolved: sessionRelationshipHydrationUnresolved.size,
-  inFlight: sessionRelationshipHydrationInFlight.size,
+// Probe functions stay cheap and side-effect-free.
+window.qa = Object.assign(window.qa || {}, {
+  sessionsHydration: () => ({
+    seen: sessionRowSeenIds.size,
+    unresolved: sessionRelationshipHydrationUnresolved.size,
+    inFlight: sessionRelationshipHydrationInFlight.size,
+  }),
 });
 
 function applySessionRelationship(evt = {}) {

--- a/static/app/55-files-ide.js
+++ b/static/app/55-files-ide.js
@@ -2448,16 +2448,19 @@ const NEW_SESSION_UNFUELED_MESSAGE =
   'This daemon has no model credentials, so the internal agent can’t start. ' +
   'External agents (Codex, Claude Code) sign in with their own accounts and still work.';
 
-// QA hook (stationProbe convention): the preflight inputs the
+// QA readback (window.qa convention): the preflight inputs the
 // validate-dashboard harness asserts on — module scope hides them.
-window.sessionsFuelProbe = () => ({
-  fueled: dashboardControlTransport?.lastStatus?.fueled ?? null,
-  haveStatus: !!dashboardControlTransport?.lastStatus,
-  unfueledCached: daemonUnfueledCached,
-  effectiveAgent: effectiveNewSessionAgentId(),
-  configuredAgent: newSessionConfiguredAgent || '',
-  bannerHidden: !!document.getElementById('new-session-unfueled-banner')?.classList.contains('hidden'),
-  startDisabled: !!document.getElementById('new-session-start-btn')?.disabled,
+// Probe functions stay cheap and side-effect-free.
+window.qa = Object.assign(window.qa || {}, {
+  sessionsFuel: () => ({
+    fueled: dashboardControlTransport?.lastStatus?.fueled ?? null,
+    haveStatus: !!dashboardControlTransport?.lastStatus,
+    unfueledCached: daemonUnfueledCached,
+    effectiveAgent: effectiveNewSessionAgentId(),
+    configuredAgent: newSessionConfiguredAgent || '',
+    bannerHidden: !!document.getElementById('new-session-unfueled-banner')?.classList.contains('hidden'),
+    startDisabled: !!document.getElementById('new-session-start-btn')?.disabled,
+  }),
 });
 
 function updateNewSessionFuelBanner() {


### PR DESCRIPTION
Formalizes the dashboard QA-probe convention and gives the CDP harness a first-class readback channel, so verification runs stop bouncing page state off ad-hoc HTTP sinks.

## window.qa probe namespace

The SPA is one assembled `<script type="module">`, so harnesses evaluating in the page main world cannot reach module bindings. The convention: each fragment exposes its QA state as

```js
window.qa = Object.assign(window.qa || {}, { <area>: () => ({...}) });
```

declared next to the state it reads; probe functions are cheap and side-effect-free.

- `window.sessionsHydrationProbe` -> `window.qa.sessionsHydration` (`static/app/40-session-launch.js`)
- `window.sessionsFuelProbe` -> `window.qa.sessionsFuel` (`static/app/55-files-ide.js`) — both names were one day old with no other users; deleted, not aliased.
- `window.qa.station = () => window.stationProbe` pointer added in `static/app/33-station-core.js`; `window.stationProbe` itself keeps its legacy name (validator `--station-*` probes and smoke skills depend on it).
- `static/app.html` regenerated from the fragments (committed together).

## validate-dashboard --probe-json

Repeatable `--probe-json EXPR` flag (optional `label=EXPR` form) in `scripts/validate-dashboard.cjs`: after all waits/checks pass — and also on failure, before exit, since state at failure is the whole point — each expression is evaluated in the page (JSON.stringify'd in-page, thrown errors reported as `{"error":...}`, ~4KB cap per probe) and printed to stdout as:

```
probe <label> = <compact JSON>
```

Probe collection is per-probe fault-isolated so a wedged page can't take out the readback; with `--json` the readbacks ride in the single JSON result as `probes` instead of separate lines. Self-tests cover parsing (`==`/`=>` disambiguation), the page-side expression, truncation, and line formatting.

Docs: new "QA probes (`window.qa`)" subsection in `docs/src/web-dashboard.md` next to the existing pane-diag QA material.

## Live evidence

Debug daemon on `127.0.0.1:18940` (empty scratch cwd, `--no-tls`), success path:

```
$ node scripts/validate-dashboard.cjs --url "http://127.0.0.1:18940/#sessions" \
    --probe-json "window.qa.sessionsHydration()" --probe-json "fuel=window.qa.sessionsFuel()" \
    --wait-for-function "(() => typeof window.qa === 'object')()"
PASS dashboard-validation url="http://127.0.0.1:18940/#sessions" selectors=0 functions=1 stationProbes=0 stationInteractions=0 stationActivations=0 ms=18419 websocket=global
probe window.qa.sessionsHydration() = {"seen":0,"unresolved":0,"inFlight":0}
probe fuel = {"fueled":null,"haveStatus":false,"unfueledCached":null,"effectiveAgent":"","configuredAgent":"","bannerHidden":true,"startDisabled":false}
```

On-failure readback (deliberately impossible wait, `--timeout 4000`; probes still print to stdout before exit 1, and captured that hydration/fuel state had since resolved — plus a thrown-error probe):

```
$ node scripts/validate-dashboard.cjs --url "http://127.0.0.1:18940/#sessions" \
    --probe-json "window.qa.sessionsHydration()" --probe-json "fuel=window.qa.sessionsFuel()" \
    --probe-json "window.qa.noSuchProbe()" --wait-for-function "(() => false)()" --timeout 4000
FAIL dashboard-validation url="http://127.0.0.1:18940/#sessions" kind="assertion" reason="wait-for-function did not become truthy (last value: false)" ms=7692
probe window.qa.sessionsHydration() = {"seen":618,"unresolved":0,"inFlight":0}
probe fuel = {"fueled":null,"haveStatus":false,"unfueledCached":true,"effectiveAgent":"","configuredAgent":"","bannerHidden":false,"startDisabled":true}
probe window.qa.noSuchProbe() = {"error":"window.qa.noSuchProbe is not a function"}
```

Verification: `node --check` on each edited fragment (as `.mjs`), `node scripts/validate-dashboard.cjs --self-test` PASS, `--check-static-scripts` PASS on the regenerated `static/app.html`, `cargo run -p app-html-assembler` regen committed with the fragments, `cargo check --bins` clean.
