### PR TITLE
Test-speed lap: optimize dev-profile RSA keygen, adopt nextest locally

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,20 @@
+# Workspace nextest configuration. `cargo nextest run --bins` is the fast
+# local equivalent of `cargo test --bins`: one process per test (no shared
+# process globals), better scheduling, per-test timings.
+
+[profile.default]
+# Surface anything slower than 15s in the run summary; two periods then
+# terminate — no unit test should legitimately run 30s.
+slow-timeout = { period = "15s", terminate-after = 2 }
+final-status-level = "slow"
+
+[profile.default.junit]
+# Per-test timings for slow-test audits (target/nextest/default/junit.xml).
+path = "junit.xml"
+
+# Heavy-crypto tests: subprocess `security` CLI (serialized behind
+# securityd) + real keygen; give them headroom instead of false timeouts
+# on a loaded box.
+[[profile.default.overrides]]
+filter = 'test(/p12_|_recert|keychain/)'
+slow-timeout = { period = "60s", terminate-after = 4 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,9 @@ Read the relevant chapter before changing a subsystem:
 cargo build --release     # → target/release/{intendant-runtime, intendant}
 cargo build               # debug
 cargo check               # type-check only
-cargo test --bins         # unit tests (fast, no API keys)
+cargo test --bins         # unit tests (no API keys; what CI runs)
+cargo nextest run --bins  # same tests, much faster: one process per test
+                          # (needs cargo-nextest; config in .config/nextest.toml)
 cargo clippy              # lint
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,9 @@ Read the relevant chapter before changing a subsystem:
 cargo build --release     # → target/release/{intendant-runtime, intendant}
 cargo build               # debug
 cargo check               # type-check only
-cargo test --bins         # unit tests (fast, no API keys)
+cargo test --bins         # unit tests (no API keys; what CI runs)
+cargo nextest run --bins  # same tests, much faster: one process per test
+                          # (needs cargo-nextest; config in .config/nextest.toml)
 cargo clippy              # lint
 ```
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,6 +245,11 @@ app-html-assembler = { path = "crates/app-html-assembler" }
 
 [profile.dev]
 split-debuginfo = "unpacked"
+# Line tables keep panic backtraces readable while dropping the bulk of
+# debuginfo the edit->check->test loop never uses; full `debug = 2` is a
+# `cargo build --profile dev-debug`-style opt-in away if a debugger
+# session ever needs it (or temporarily flip this line).
+debug = "line-tables-only"
 
 # The edit→rebuild loop ships from target/release (the multi-agent
 # convention), and the caller is one huge compilation unit — without
@@ -270,3 +275,12 @@ tokio = { version = "1.0", features = ["test-util"] }
 # rustls-native-certs), so pinning it here adds no new crate to the lock.
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 security-framework = "3"
+
+# The access layer generates RSA daemon certs (RustCrypto `rsa`); keygen is
+# pure-Rust bignum math that runs ~25s per key unoptimized, and every
+# cert-touching test pays it. Optimizing just the arithmetic crates keeps
+# dev builds debuggable while making keygen near-release speed.
+[profile.dev.package.rsa]
+opt-level = 3
+[profile.dev.package.num-bigint-dig]
+opt-level = 3


### PR DESCRIPTION
The local test loop was dominated by test execution, not compilation: `cargo test --bins` ran ~303s, and per-test timings (via cargo-nextest) traced most of it to one hot spot — the access layer's RSA daemon-cert generation. RustCrypto `rsa` keygen is pure-Rust bignum math that runs ~15–30s per key in an unoptimized build, and every cert-touching test pays it (123 tests hit a 30s per-test ceiling when run isolated).

Changes:
- `[profile.dev.package.rsa]` / `[profile.dev.package.num-bigint-dig]` `opt-level = 3` — a representative cert test drops 14.9s → 0.9s (Linux box); dev builds stay debuggable everywhere else.
- `[profile.dev] debug = "line-tables-only"` — backtraces survive, the debuginfo bulk leaves the edit→check→test loop.
- `.config/nextest.toml` + a CLAUDE.md pointer: `cargo nextest run --bins` as the fast local runner — one process per test (no shared process globals), slow tests surfaced at 15s, JUnit timings for future audits, and explicit headroom for the genuinely heavy keychain/keygen tests.

Result: the full unit suite via nextest runs **2,689/2,689 green in 18.6s** on the Linux box, versus ~303s for `cargo test --bins` before the change.

CI is deliberately unchanged — required checks still run `cargo test` (adopting nextest in CI is a separate decision) and get the keygen speedup for free. The profile fingerprint change means each runner's warm dev cache repopulates once on its first build of this PR; subsequent runs return to normal incremental times.

Verification: full nextest suite green on Linux (post-fix); the before/after keygen measurement above; queue validation covers macOS and Windows `cargo test`.