### PR TITLE
Tests: deterministic gates for four fleet-flaky tests

### DIFF
--- a/src/bin/caller/dashboard_control.rs
+++ b/src/bin/caller/dashboard_control.rs
@@ -12432,12 +12432,61 @@ mod tests {
         )
         .is_none());
 
-        let opened = tokio::time::timeout(Duration::from_secs(3), terminal_rx.recv())
+        // Generous budget: the PTY spawn behind terminal_open (PowerShell
+        // under ConPTY on a loaded Windows runner, especially) can take
+        // tens of seconds before the shell paints; a passing run returns
+        // the moment each frame arrives and never waits the budget out.
+        let budget = Duration::from_secs(60);
+        let opened = tokio::time::timeout(budget, terminal_rx.recv())
             .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(opened["t"], "terminal_opened");
+            .expect("no terminal frame within budget after terminal_open")
+            .expect("terminal frame channel closed before terminal_opened");
+        assert_eq!(opened["t"], "terminal_opened", "got frame: {opened}");
         assert_eq!(opened["terminal_id"], terminal_id);
+
+        // Drain frames until the accumulated decoded output satisfies
+        // `until`, panicking loudly — with everything received — on the
+        // deadline. Matching runs on the accumulated transcript, not per
+        // frame, so output split across chunks still matches.
+        async fn drain_output_until(
+            terminal_rx: &mut mpsc::UnboundedReceiver<serde_json::Value>,
+            budget: Duration,
+            phase: &str,
+            until: impl Fn(&str) -> bool,
+        ) -> String {
+            let deadline = tokio::time::Instant::now() + budget;
+            let mut transcript = String::new();
+            let mut other_frames: Vec<String> = Vec::new();
+            loop {
+                match tokio::time::timeout_at(deadline, terminal_rx.recv()).await {
+                    Ok(Some(frame)) if frame["t"] == "terminal_output" => {
+                        let data = frame["data"].as_str().unwrap_or("");
+                        let bytes = base64::engine::general_purpose::STANDARD
+                            .decode(data)
+                            .unwrap_or_default();
+                        transcript.push_str(&String::from_utf8_lossy(&bytes));
+                        if until(&transcript) {
+                            return transcript;
+                        }
+                    }
+                    Ok(Some(frame)) => other_frames.push(frame.to_string()),
+                    Ok(None) => panic!(
+                        "{phase}: terminal frame channel closed; output so far: \
+                         {transcript:?}; other frames: {other_frames:?}"
+                    ),
+                    Err(_) => panic!(
+                        "{phase}: no matching terminal output within {budget:?}; \
+                         output so far: {transcript:?}; other frames: {other_frames:?}"
+                    ),
+                }
+            }
+        }
+
+        // Don't type until the shell has painted something — bytes written
+        // during shell startup can be silently discarded (see terminal.rs
+        // tests); a dashboard user typing at a rendered prompt never races
+        // this.
+        drain_output_until(&mut terminal_rx, budget, "shell startup", |t| !t.is_empty()).await;
 
         let token = "dashboard_terminal_frame_ok";
         let input = serde_json::json!({
@@ -12459,29 +12508,10 @@ mod tests {
         )
         .is_none());
 
-        let deadline = Instant::now() + Duration::from_secs(5);
-        let mut saw_token = false;
-        while Instant::now() < deadline {
-            match tokio::time::timeout(Duration::from_millis(200), terminal_rx.recv()).await {
-                Ok(Some(frame)) if frame["t"] == "terminal_output" => {
-                    let data = frame["data"].as_str().unwrap_or("");
-                    let bytes = base64::engine::general_purpose::STANDARD
-                        .decode(data)
-                        .unwrap_or_default();
-                    if String::from_utf8_lossy(&bytes).contains(token) {
-                        saw_token = true;
-                        break;
-                    }
-                }
-                Ok(Some(_)) => {}
-                Ok(None) => break,
-                Err(_) => {}
-            }
-        }
-        assert!(
-            saw_token,
-            "did not receive terminal output over control frames"
-        );
+        drain_output_until(&mut terminal_rx, budget, "token echo", |t| {
+            t.contains(token)
+        })
+        .await;
 
         let close = serde_json::json!({
             "t": "terminal_close",

--- a/src/bin/caller/session_supervisor.rs
+++ b/src/bin/caller/session_supervisor.rs
@@ -5471,6 +5471,65 @@ mod tests {
         SessionSupervisor::new(config)
     }
 
+    /// The scripted mock provider behind a test-held gate: every chat call
+    /// waits for the test to release the gate first. This pins a spawned
+    /// child session provably alive — its loop cannot get a model response,
+    /// so it cannot complete and retire the state under assertion — turning
+    /// "assert before the child happens to finish" races into deterministic
+    /// sequencing. A dropped sender (test panicked) errors the call instead
+    /// of hanging the child loop forever.
+    struct GatedMockProvider {
+        inner: provider::mock::MockOrchestrationProvider,
+        release: tokio::sync::watch::Receiver<bool>,
+    }
+
+    #[async_trait::async_trait]
+    impl provider::ChatProvider for GatedMockProvider {
+        async fn chat(
+            &self,
+            messages: &[crate::conversation::Message],
+        ) -> Result<provider::ChatResponse, crate::error::CallerError> {
+            let mut release = self.release.clone();
+            release
+                .wait_for(|released| *released)
+                .await
+                .map_err(|_| crate::error::CallerError::Config("provider gate dropped".into()))?;
+            self.inner.chat(messages).await
+        }
+        fn name(&self) -> &str {
+            self.inner.name()
+        }
+        fn model(&self) -> &str {
+            self.inner.model()
+        }
+        fn context_window(&self) -> u64 {
+            self.inner.context_window()
+        }
+        fn max_output_tokens(&self) -> u64 {
+            self.inner.max_output_tokens()
+        }
+        fn use_tools(&self) -> bool {
+            self.inner.use_tools()
+        }
+    }
+
+    /// [`test_supervisor_with_mock_provider`], but every spawned loop's
+    /// provider blocks until the returned sender publishes `true`.
+    fn test_supervisor_with_gated_mock_provider(
+        project_root: PathBuf,
+        bus: EventBus,
+    ) -> (SessionSupervisor, tokio::sync::watch::Sender<bool>) {
+        let (release_tx, release_rx) = tokio::sync::watch::channel(false);
+        let mut config = (*test_supervisor(project_root, bus).config).clone();
+        config.provider_factory = Some(Arc::new(move || {
+            Box::new(GatedMockProvider {
+                inner: provider::mock::MockOrchestrationProvider::new(),
+                release: release_rx.clone(),
+            }) as Box<dyn provider::ChatProvider>
+        }));
+        (SessionSupervisor::new(config), release_tx)
+    }
+
     fn slash(text: &str) -> CodexSlashCommand {
         parse_codex_slash_command(text)
             .expect("recognized slash command")
@@ -6414,6 +6473,13 @@ mod tests {
     /// wait_sub_agents reads, the relationship is recorded, the parent is
     /// woken with a notification follow-up, and the completion resolves
     /// through the registry like a model-spawned child's would.
+    ///
+    /// The child's provider is gated: it cannot get its first model
+    /// response — so it provably cannot complete and retire its state —
+    /// until every spawn-time assertion has run. Without the gate the mock
+    /// child completes near-instantly and `finish_session` →
+    /// `remove_session` purges `related_sessions`, so state reads raced
+    /// child completion and flaked under CI load.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn dashboard_delegate_tracks_child_in_parent_registry_and_wakes_parent() {
         let bus = EventBus::new();
@@ -6422,8 +6488,8 @@ mod tests {
         // subscribe.
         let mut bus_rx = bus.subscribe();
         let project_dir = tempfile::tempdir().unwrap();
-        let supervisor =
-            test_supervisor_with_mock_provider(project_dir.path().to_path_buf(), bus.clone());
+        let (supervisor, release_gate) =
+            test_supervisor_with_gated_mock_provider(project_dir.path().to_path_buf(), bus.clone());
         let (follow_up_tx, mut follow_up_rx) = mpsc::channel(4);
         let children: SubAgentChildrenMap = Arc::new(std::sync::Mutex::new(HashMap::new()));
         {
@@ -6469,11 +6535,18 @@ mod tests {
                 child.rx.take().expect("completion receiver present"),
             )
         };
-        // Assert the relationship via its bus event, not by peeking
-        // supervisor state: the state entry is transient — the mock child
-        // completes near-instantly and its retirement purges
-        // `related_sessions`, so a state read here races the child and
-        // flakes under CI load. The event is the durable signal frontends
+        // The relationship is recorded in supervisor state (the gate keeps
+        // the child alive, so the entry cannot have been retired) …
+        {
+            let state = supervisor.state.lock().await;
+            let relation = state
+                .related_sessions
+                .get(&child_id)
+                .expect("relationship recorded");
+            assert_eq!(relation.parent_session_id, "parent");
+            assert_eq!(relation.relationship, "subagent");
+        }
+        // … and announced on the bus — the durable signal frontends
         // consume, emitted synchronously during the spawn.
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
         loop {
@@ -6511,6 +6584,9 @@ mod tests {
             "notice should point the model at wait_sub_agents: {}",
             notice.text
         );
+
+        // Spawn-time state is verified — release the child and let it run.
+        release_gate.send(true).expect("child loop holds a receiver");
 
         // The completion resolves through the registry exactly like a
         // model-spawned child's (mock research child ends text-only; the

--- a/src/bin/caller/terminal.rs
+++ b/src/bin/caller/terminal.rs
@@ -970,6 +970,51 @@ mod tests {
         }
     }
 
+    /// Total wait budget for PTY output in these tests. A cold shell spawn
+    /// on a loaded CI runner (PowerShell under ConPTY on the Windows box,
+    /// especially) can take tens of seconds before the first byte shows;
+    /// a passing run returns the moment the bytes arrive and never waits
+    /// the budget out, so generous costs nothing when green.
+    const OUTPUT_BUDGET: std::time::Duration = std::time::Duration::from_secs(60);
+
+    /// Drain `rx` until the accumulated output contains `needle`
+    /// (`None` = return on the first output event, i.e. the shell painted
+    /// something). Matching runs on the accumulated transcript, not per
+    /// chunk, so a token split across PTY read chunks still matches.
+    /// Panics loudly — including everything that WAS received — on
+    /// deadline, shell exit, or channel close.
+    async fn expect_output(
+        rx: &mut mpsc::UnboundedReceiver<TerminalEvent>,
+        needle: Option<&str>,
+        phase: &str,
+    ) -> String {
+        let deadline = tokio::time::Instant::now() + OUTPUT_BUDGET;
+        let mut transcript = String::new();
+        loop {
+            match tokio::time::timeout_at(deadline, rx.recv()).await {
+                Ok(Some(TerminalEvent::Output(bytes))) => {
+                    transcript.push_str(&String::from_utf8_lossy(&bytes));
+                    match needle {
+                        Some(token) if !transcript.contains(token) => {}
+                        _ => return transcript,
+                    }
+                }
+                Ok(Some(TerminalEvent::Exited { status })) => panic!(
+                    "{phase}: shell exited (status {status}) before output \
+                     contained {needle:?}; received: {transcript:?}"
+                ),
+                Ok(None) => panic!(
+                    "{phase}: event channel closed before output contained \
+                     {needle:?}; received: {transcript:?}"
+                ),
+                Err(_) => panic!(
+                    "{phase}: no output containing {needle:?} within \
+                     {OUTPUT_BUDGET:?}; received: {transcript:?}"
+                ),
+            }
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn open_attach_write_and_receive_output() {
         let registry = TerminalRegistry::new(std::env::temp_dir());
@@ -983,27 +1028,17 @@ mod tests {
         let (tx, mut rx) = mpsc::unbounded_channel();
         session.attach(tx);
 
+        // Don't type until the shell has painted something: zsh's tty
+        // setup flushes pending input, so bytes written during startup can
+        // be silently discarded (see scoped_shell_is_sandboxed_on_macos —
+        // a human typing into the dashboard never races this).
+        expect_output(&mut rx, None, "shell startup").await;
+
         // A terminal client sends CR (the Enter key), not LF — required for
         // ConPTY to submit the line on Windows; harmless on Unix.
         session.write_input(b"echo hello_from_pty\r");
 
-        // Drain events until we see the expected echo, with a bounded wait.
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
-        let mut saw_echo = false;
-        while tokio::time::Instant::now() < deadline {
-            match tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await {
-                Ok(Some(TerminalEvent::Output(bytes))) => {
-                    if String::from_utf8_lossy(&bytes).contains("hello_from_pty") {
-                        saw_echo = true;
-                        break;
-                    }
-                }
-                Ok(Some(TerminalEvent::Exited { .. })) => break,
-                Ok(None) => break,
-                Err(_) => {}
-            }
-        }
-        assert!(saw_echo, "did not see echoed output from PTY");
+        expect_output(&mut rx, Some("hello_from_pty"), "echo output").await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1015,38 +1050,26 @@ mod tests {
             .await
             .unwrap();
 
-        // Drive a command through the first listener, then detach.
+        // Drive a command through the first listener, then detach. Wait
+        // for the shell to paint before typing (startup can flush pending
+        // input — see open_attach_write_and_receive_output), and confirm
+        // the token echoed before detaching: the reader thread pushes to
+        // scrollback before broadcasting, so once a listener saw the
+        // token the scrollback provably contains it.
         let (tx1, mut rx1) = mpsc::unbounded_channel();
         session.attach(tx1);
+        expect_output(&mut rx1, None, "shell startup").await;
         // CR (Enter), not LF — see open_attach_write_and_receive_output.
         session.write_input(b"echo scroll_token_abc\r");
-
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
-        while tokio::time::Instant::now() < deadline {
-            match tokio::time::timeout(std::time::Duration::from_millis(100), rx1.recv()).await {
-                Ok(Some(TerminalEvent::Output(bytes))) => {
-                    if String::from_utf8_lossy(&bytes).contains("scroll_token_abc") {
-                        break;
-                    }
-                }
-                _ => {}
-            }
-        }
+        expect_output(&mut rx1, Some("scroll_token_abc"), "first listener").await;
         drop(rx1);
 
         // Reattach with a fresh listener and expect the scrollback replay
-        // to contain the token — no additional commands driven.
+        // to contain the token — no additional commands driven, so the
+        // token can only come from the replay.
         let (tx2, mut rx2) = mpsc::unbounded_channel();
         session.attach(tx2);
-        match tokio::time::timeout(std::time::Duration::from_millis(500), rx2.recv()).await {
-            Ok(Some(TerminalEvent::Output(bytes))) => {
-                assert!(
-                    String::from_utf8_lossy(&bytes).contains("scroll_token_abc"),
-                    "replayed scrollback missing token"
-                );
-            }
-            other => panic!("expected replay event, got {other:?}"),
-        }
+        expect_output(&mut rx2, Some("scroll_token_abc"), "scrollback replay").await;
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Yesterday's merge-queue landing rolled four different flaky tests across four gate attempts on the self-hosted fleet. This makes each deterministic. Test-code-only: no production behavior changes.

## 1. `session_supervisor::tests::dashboard_delegate_tracks_child_in_parent_registry_and_wakes_parent`

**Mechanism.** After `handle_control_msg(SpawnSubAgent)` the mock child session runs concurrently and completes near-instantly; `finish_session` -> `remove_session` purges `related_sessions`, so spawn-time state reads raced child completion. The earlier bus-event workaround (47609c9f) dodged the race by dropping the supervisor-state assertion rather than de-racing the test.

**Fix.** Gate the child's completion through `SessionSupervisorConfig.provider_factory` (the designed injection point): a `GatedMockProvider` blocks every chat call on a test-held `watch` channel, so the child provably cannot complete - or retire its state - until the registry, `related_sessions`, bus-relationship, and parent-wake assertions have all run; then the gate opens and the completion path is verified end-to-end as before. Restores the stronger `related_sessions` assertion the flake had forced out. A dropped gate errors the child's chat call instead of hanging the loop. Sibling delegate tests audited: the refusal test spawns nothing; the orchestration test is already event-driven.

## 2. `terminal::tests::attach_replays_scrollback`

**Mechanism.** Windows-flaky ("replayed scrollback missing token"): 3s deadline on the first echo that a cold PowerShell spawn under ConPTY on a loaded runner blows through - and that phase-1 timeout was swallowed silently, so the test failed one phase later with a misleading message. Token matching also ran per chunk, so a token split across PTY reads could never match.

**Fix.** New `expect_output` helper: drain-until-deadline with a 60s budget (a passing run returns the moment the bytes arrive), match on the accumulated transcript, panic with the full transcript on deadline/exit/close. Type only after the shell's first paint (startup can flush pending input - zsh's tty init; see the macOS scoped-shell test). Same treatment for the same-shaped sibling `open_attach_write_and_receive_output`.

## 3. `mcp::tools_display::tests::shared_view_user_session_requests_display_activation`

**Mechanism.** Asserted `std::env::var("INTENDANT_USER_DISPLAY_GRANTED")` while parallel tests in the same process mutate that process-global env var.

**Fix - no new code; landed on main this morning as 47609c9f** (crate-wide `test_support::TEST_ENV_LOCK`, every touching test takes it). This PR's contribution is the coverage audit + determinism evidence. Audit: every mutation site of the var is either production code unreachable from unit tests (`control_plane` grant/revoke handler - no test dispatches those msgs; `display_glue` Windows startup; `main.rs` startup; `mcp/commands.rs` slash arm - no test sends grant/revoke) or test code that holds the lock (all 8 `tools_display` tests, the `computer_use` portal test). Lock chosen over an injectable seam deliberately: the env write *is* the production side effect under test - it is the cross-process propagation channel the runtime binary (`src/agent.rs`) reads and `agent_runner` forwards to children - so a seam that fakes the env would un-test the very behavior the assertion exists for, while threading an env abstraction through 5 production files for a test concern is disproportionate.

## 4. `dashboard_control::tests::terminal_frames_open_input_and_forward_output`

**Mechanism.** Windows-flaky ("did not receive terminal output over control frames"): 3s deadline on `terminal_opened` (which sits behind the PTY spawn itself) and 5s on token output, per-frame token matching, failure printed nothing about what was received.

**Fix.** Same treatment as (2): 60s budgets, `drain_output_until` accumulates decoded output across frames and panics with the transcript plus any non-output frames; input sent only after the shell's first painted frame.

## Verification

- `cargo check --bins` clean; `cargo clippy --tests` - no warnings in the touched code (all pre-existing tree warnings are in untouched lines).
- The four tests together: 20/20 loop runs green.
- Full touched-module suites (`session_supervisor::` 64, `terminal::` 9, `dashboard_control::` 75, `mcp::tools_display::` 10): green.
- Under load (release build + full-tests check + a concurrent CI job + a second agent's build; load average 93-134): each fixed test green individually; `session_supervisor::` suite looped **588x** consecutively at load ~114 - zero failures; 20 additional runs as two concurrent instances - zero failures.
- One data point disclosed honestly: a single `session_supervisor::` suite run during the very first load spike (~134) reported 63 passed / 1 failed, and the failing test's name was lost to a `grep "test result"` pipeline. It did not reproduce in 686 subsequent suite runs under equal or higher load. The four tests fixed here were green in every attributable run.
- Windows fleet box: see the follow-up comment for the 10x runs of (2) and (4).

Do not auto-merge - orchestrator reviews and arms the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
