### PR TITLE
peer: stage-0 agent-facing federation control (ctl + MCP + native tool)

### DIFF
--- a/SysPrompt_tools.md
+++ b/SysPrompt_tools.md
@@ -25,6 +25,10 @@ For non-display tasks (shell commands, file editing, code), continue using `exec
 
 Use the `shared_view` tool to give the user live dashboard visibility into an agent-owned display — your virtual display, a sandbox, or a VM. Open it proactively when the human should visually stay in the loop: demoing a finished result (`show` with a short `reason`), longer GUI/browser sessions the user may want to watch, or auth/judgment handoffs (`input` — the user grants input authority from the dashboard; the tool only asks). Use `focus` when referencing a specific screen region, and `hide` when the moment is over. Sharing the user's own screen (`user_session`) is an explicit opt-in that requires their display grant — default to your own displays.
 
+## Federated Peers
+
+Use the `peer` tool to work with federated peer daemons — sibling Intendants on other machines, not subordinates. `list` shows each peer's id, connection state, capabilities, and visible sessions; `message` sends text to a peer's agent; `task` delegates work that the peer's own agent executes on its machine under its own autonomy and approval policy (you get a task id back, and the peer's progress streams to the dashboard's peers rail — you do not supervise it). The receiving daemon authorizes every action against its own grants for this daemon, so a denied action means the peer's owner has not granted it — report that rather than retrying. If federation is not configured the tool says so; that is not an error to work around.
+
 ## Best Practices
 
 1. **Sequential Execution:** Each tool call blocks until completion and returns results directly.

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -229,6 +229,23 @@ active holder.
 |--------------------|-------------|--------|
 | `spawn_live_audio` | Spawn an untrusted [live-audio](./computer-use-and-audio.md#live-audio) voice session. | `id`, `provider`, `playbook`, `response_schema`, … |
 
+### Peer federation
+
+The stage-0 agent-facing surface for [peer federation](./peer-federation.md):
+inspect the peer roster and delegate work to sibling daemons. `list_peers` is
+gated as `peer.inspect` (same classification as `GET /api/peers`);
+`peer_send_message` and `peer_delegate_task` are gated as `peer.use` — acting
+through a peer delegates this daemon's peer identity, and the receiving peer
+authorizes the request against its own grants for this daemon. A delegated
+task runs on the peer's machine under the peer's own autonomy/approval policy;
+no display/computer-use invocation on peers rides this surface yet.
+
+| Tool                 | Description | Params |
+|----------------------|-------------|--------|
+| `list_peers`         | Peer snapshot list — id, label, connection state, capabilities, sessions (same payload as `GET /api/peers`). | — |
+| `peer_send_message`  | Send a message to a peer's agent. | `peer_id`, `message`, `session?` |
+| `peer_delegate_task` | Delegate a task executed by the peer's own agent; returns `task_id`. | `peer_id`, `instructions`, `context?` |
+
 ### Controller Orchestration
 
 | Tool                            | Description | Params |

--- a/docs/src/peer-federation.md
+++ b/docs/src/peer-federation.md
@@ -8,8 +8,9 @@ displays across machines.
 
 This chapter covers what federation is and how it differs from external agents,
 the Agent Card and discovery model, the peer actor/registry/coordinator layer,
-the transport stack (native WebSocket, multi-URL probing, cert pinning), the
-cross-machine display path, and dashboard TLS/mTLS setup. For the local display pipeline
+the agent-facing control surface (`ctl peer` + MCP tools), the transport stack
+(native WebSocket, multi-URL probing, cert pinning), the cross-machine display
+path, and dashboard TLS/mTLS setup. For the local display pipeline
 those federated displays plug into, see [Display Pipeline](./display-pipeline.md).
 
 Peer federation is **not** the same security domain as a browser dashboard login.
@@ -210,6 +211,54 @@ exhaustive list). Action pills stay off peer session nodes in v1: the
 session-action handlers assume local session ids. None of this changes what a
 peer exposes — the sessions rail is derived entirely from the event stream the
 peer already sends under its access profile.
+
+## Agent-Facing Peer Control (ctl + MCP)
+
+Federation is not a dashboard-only surface. A stage-0 control surface exposes
+the delegation verbs to agents in three shapes with identical semantics:
+
+- **MCP tools** on the daemon's `/mcp` surface — `list_peers`,
+  `peer_send_message`, `peer_delegate_task`.
+- **CLI** — the `intendant ctl peer` verb group (distinct from the top-level
+  `intendant peer …` pairing commands below, which provision relationships
+  rather than acting through them):
+
+  ```bash
+  intendant ctl peer list
+  intendant ctl peer message <peer-id> "text" [--session ID]
+  intendant ctl peer task <peer-id> "instructions" [--context JSON]
+  ```
+
+- **Native agent tool** — a `peer` tool with actions `list` | `message` |
+  `task`, so supervised and native agent sessions reach federation without
+  the dashboard.
+
+`list_peers` returns the same peer snapshot list as `GET /api/peers` — id,
+label, connection state, capabilities, and the folded per-peer `sessions`
+rail above. `peer_send_message` (`peer_id`, `message`, optional `session`)
+sends a message to the peer's agent. `peer_delegate_task` (`peer_id`,
+`instructions`, optional `context`) delegates a task and returns a `task_id`.
+
+Delegation keeps the sibling-not-subordinate contract: a delegated task
+executes on the peer's machine, by the peer's own agent, under the peer's own
+autonomy/approval policy. The caller gets a `task_id` to follow up on, not a
+supervised child process.
+
+All three are IAM-gated at call time (`mcp_tool_operation`), mirroring the
+classification of the HTTP routes they parallel: `list_peers` requires
+`peer.inspect` (same as `GET /api/peers`); `peer_send_message` and
+`peer_delegate_task` require `peer.use` (same as
+`POST /api/peers/{id}/message` and `…/task`). `peer.use` is the gate because
+acting through a peer delegates **this daemon's peer identity** — the caller
+acts with the daemon's peer credentials, and what is actually permitted is
+decided by the *receiving* peer's grants for this daemon, not by anything the
+caller holds locally (the same split the signaling relays above ride).
+
+Stage 0 is deliberately the delegation surface only: no display or
+computer-use invocation on peers rides these tools. Cross-machine display
+viewing remains the browser WebRTC path below, and peer session activity
+already streams to the dashboard peers rail and the Station scene without any
+of this surface.
 
 ## Transports
 

--- a/skills/intendant-cli/SKILL.md
+++ b/skills/intendant-cli/SKILL.md
@@ -24,6 +24,7 @@ Useful groups:
   CDP workspaces prefer managed Chromium/Chrome-for-Testing; run `"${INTENDANT:-intendant}" setup browsers` to install/repair the managed browser cache, and use `--provider system_cdp` or `INTENDANT_BROWSER_WORKSPACE_ALLOW_SYSTEM_BROWSER=1` to opt into system Chrome/Chromium on macOS.
 - `"${INTENDANT:-intendant}" ctl cu --help` for computer-use actions; `ctl cu actions --help` prints the per-action JSON shapes with an example. `ctl cu elements` reads the frontmost app's UI element tree (cheap textual grounding — click the center of a reported frame; user-session only via macOS AX, Linux AT-SPI, or Windows UIA).
 - `"${INTENDANT:-intendant}" ctl shared --help` for shared display collaboration.
+- `"${INTENDANT:-intendant}" ctl peer --help` for federated peers — list peers, message a peer's agent, delegate tasks (`ctl peer list|message|task`; the peer executes under its own autonomy/IAM).
 - `"${INTENDANT:-intendant}" ctl approval --help` and `"${INTENDANT:-intendant}" ctl input --help` for pending approval/input flows.
 - `"${INTENDANT:-intendant}" ctl context --help` for managed-context rewind/backout.
 - `"${INTENDANT:-intendant}" ctl controller --help` for controller-loop and restart controls.

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -625,6 +625,88 @@ pub(crate) async fn handle_wait_sub_agents_call(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Handle a native `peer` tool call: validate the action and its
+/// arguments, then route to the shared `crate::peer::ops`
+/// implementations (the same bodies behind the MCP peer tools and
+/// `intendant ctl peer`, so the surfaces cannot drift).
+pub(crate) async fn handle_peer_tool_call(
+    args: &serde_json::Value,
+    peer_registry: Option<&crate::peer::PeerRegistry>,
+) -> String {
+    fn required_str<'a>(
+        args: &'a serde_json::Value,
+        key: &str,
+        action: &str,
+    ) -> Result<&'a str, String> {
+        args.get(key)
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                serde_json::json!({
+                    "ok": false,
+                    "error": format!("the {action} action requires a non-empty '{key}'"),
+                })
+                .to_string()
+            })
+    }
+
+    let action = args
+        .get("action")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    match action {
+        "list" => crate::peer::ops::list_peers_json(peer_registry),
+        "message" => {
+            let peer_id = match required_str(args, "peer_id", "message") {
+                Ok(value) => value,
+                Err(error) => return error,
+            };
+            let message = match required_str(args, "message", "message") {
+                Ok(value) => value,
+                Err(error) => return error,
+            };
+            let session = args
+                .get("session")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string);
+            crate::peer::ops::send_message_json(
+                peer_registry,
+                peer_id,
+                message.to_string(),
+                session,
+            )
+            .await
+        }
+        "task" => {
+            let peer_id = match required_str(args, "peer_id", "task") {
+                Ok(value) => value,
+                Err(error) => return error,
+            };
+            let instructions = match required_str(args, "instructions", "task") {
+                Ok(value) => value,
+                Err(error) => return error,
+            };
+            let context = args
+                .get("context")
+                .filter(|value| !value.is_null())
+                .cloned();
+            crate::peer::ops::delegate_task_json(
+                peer_registry,
+                peer_id,
+                instructions.to_string(),
+                context,
+            )
+            .await
+        }
+        other => serde_json::json!({
+            "ok": false,
+            "error": format!("unknown peer action '{other}' (expected list, message, or task)"),
+        })
+        .to_string(),
+    }
+}
+
 pub(crate) async fn run_agent_loop(
     provider: &dyn provider::ChatProvider,
     conversation: &mut Conversation,
@@ -643,6 +725,10 @@ pub(crate) async fn run_agent_loop(
     context_injection: &event::ContextInjectionQueue,
     xvfb_guard: &mut Option<vision::XvfbGuard>,
     session_registry: Option<&display::SharedSessionRegistry>,
+    // Federated peer registry: backs the `peer` tool (list / message /
+    // task). None outside the web-gateway daemon shapes, where the tool
+    // answers with a clear federation-inactive note.
+    peer_registry: Option<&crate::peer::PeerRegistry>,
     // When true, askHuman is unavailable and approvals without a json_approval
     // slot are auto-denied (headless non-JSON mode).
     headless: bool,
@@ -1269,6 +1355,15 @@ pub(crate) async fn run_agent_loop(
                         );
                     }
                 }
+            }
+
+            // Peer-federation tool calls (list / message / task), routed
+            // through the shared `crate::peer::ops` bodies — the same
+            // implementations behind the MCP tools and `intendant ctl peer`.
+            for (call_id, args) in &batch.peer_calls {
+                handled_call_ids.insert(call_id.clone());
+                let response = handle_peer_tool_call(args, peer_registry).await;
+                conversation.add_tool_result(call_id, "peer", &response);
             }
 
             // Spawn supervised sub-agent sessions (spawn_sub_agent).
@@ -2229,6 +2324,7 @@ pub(crate) async fn run_round_loop(
     approval_registry: &event::ApprovalRegistry,
     context_injection: &event::ContextInjectionQueue,
     session_registry: Option<&display::SharedSessionRegistry>,
+    peer_registry: Option<&crate::peer::PeerRegistry>,
     headless: bool,
     orchestration: Option<&session_supervisor::SessionOrchestration>,
 ) -> Result<LoopStats, CallerError> {
@@ -2255,6 +2351,7 @@ pub(crate) async fn run_round_loop(
             context_injection,
             &mut xvfb_guard,
             session_registry,
+            peer_registry,
             headless,
             orchestration,
         )

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -55,6 +55,7 @@ pub async fn run(raw_args: Vec<String>) -> Result<(), String> {
         "controller" => run_controller(&client, &config, &command[1..]).await?,
         "context" => run_context(&client, &config, &command[1..]).await?,
         "audio" => run_audio(&client, &config, &command[1..]).await?,
+        "peer" | "peers" => run_peer(&client, &config, &command[1..]).await?,
         other => {
             return Err(format!(
                 "unknown command '{other}'. Run `intendant ctl --help`."
@@ -1161,6 +1162,86 @@ async fn run_audio(
     Ok(())
 }
 
+async fn run_peer(client: &reqwest::Client, config: &Config, raw: &[String]) -> Result<(), String> {
+    if raw.is_empty() || is_help(raw) {
+        help_peer();
+        return Ok(());
+    }
+    match raw[0].as_str() {
+        "list" => {
+            let response =
+                call_tool(client, config, "list_peers", Value::Object(Map::new())).await?;
+            print_tool_response(response, config, None)?;
+        }
+        "message" => {
+            let response = call_tool(
+                client,
+                config,
+                "peer_send_message",
+                peer_message_args(&raw[1..])?,
+            )
+            .await?;
+            print_tool_response(response, config, None)?;
+        }
+        "task" => {
+            let response = call_tool(
+                client,
+                config,
+                "peer_delegate_task",
+                peer_task_args(&raw[1..])?,
+            )
+            .await?;
+            print_tool_response(response, config, None)?;
+        }
+        other => return Err(format!("unknown peer command '{other}'")),
+    }
+    Ok(())
+}
+
+fn peer_message_args(raw: &[String]) -> Result<Value, String> {
+    let args = parse_command_args(raw, &["--session"], &[])?;
+    let peer_id = args
+        .positional
+        .first()
+        .ok_or_else(|| "peer message requires a peer id".to_string())?;
+    let message = args
+        .positional
+        .get(1..)
+        .filter(|rest| !rest.is_empty())
+        .map(|rest| rest.join(" "))
+        .ok_or_else(|| "peer message requires message text".to_string())?;
+    let mut map = Map::new();
+    map.insert("peer_id".to_string(), Value::String(peer_id.clone()));
+    map.insert("message".to_string(), Value::String(message));
+    insert_string(&mut map, "session", args.one("--session"));
+    Ok(Value::Object(map))
+}
+
+fn peer_task_args(raw: &[String]) -> Result<Value, String> {
+    let args = parse_command_args(raw, &["--context"], &[])?;
+    let peer_id = args
+        .positional
+        .first()
+        .ok_or_else(|| "peer task requires a peer id".to_string())?;
+    let instructions = args
+        .positional
+        .get(1..)
+        .filter(|rest| !rest.is_empty())
+        .map(|rest| rest.join(" "))
+        .ok_or_else(|| "peer task requires instructions".to_string())?;
+    let mut map = Map::new();
+    map.insert("peer_id".to_string(), Value::String(peer_id.clone()));
+    map.insert("instructions".to_string(), Value::String(instructions));
+    if let Some(context) = args.one("--context") {
+        // Free-form context is legal: forward valid JSON parsed, anything else
+        // as a plain string value.
+        let value = serde_json::from_str::<Value>(context)
+            .unwrap_or_else(|_| Value::String(context.to_string()));
+        map.insert("context".to_string(), value);
+    }
+    Ok(Value::Object(map))
+}
+
 async fn call_tool(
     client: &reqwest::Client,
     config: &Config,
@@ -1604,6 +1685,7 @@ Commands:\n\
   controller                Controller loop and restart controls\n\
   context                   Managed-context rewind/backout controls\n\
   audio                     Live-audio controls\n\
+  peer                      Federated peers, messaging, task delegation\n\
 \n\
 Run `intendant ctl <command> --help` for focused help."
     );
@@ -1813,6 +1895,20 @@ The JSON object is the spawn_live_audio parameter object."
     );
 }
 
+fn help_peer() {
+    println!(
+        "Usage:\n\
+  intendant ctl peer list\n\
+  intendant ctl peer message PEER_ID TEXT... [--session ID]\n\
+  intendant ctl peer task PEER_ID INSTRUCTIONS... [--context JSON|TEXT]\n\
+\n\
+`list` shows the federated peers and their capabilities.\n\
+`message` sends text to the peer's agent.\n\
+`task` delegates work the peer's own agent executes under its own autonomy and approvals.\n\
+--context accepts a JSON value; non-JSON text is passed through as a string."
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1923,6 +2019,86 @@ mod tests {
             value.pointer("/orchestrate").and_then(Value::as_bool),
             Some(false)
         );
+    }
+
+    #[test]
+    fn peer_message_args_joins_text_and_omits_absent_session() {
+        let value = peer_message_args(&args(&["peer-1", "hello", "over", "there"]))
+            .expect("message args should parse");
+
+        assert_eq!(
+            value.pointer("/peer_id").and_then(Value::as_str),
+            Some("peer-1")
+        );
+        assert_eq!(
+            value.pointer("/message").and_then(Value::as_str),
+            Some("hello over there")
+        );
+        assert!(value.get("session").is_none());
+    }
+
+    #[test]
+    fn peer_message_args_accepts_session_flag() {
+        let value = peer_message_args(&args(&["--session", "sess-1", "peer-1", "ping", "pong"]))
+            .expect("message args should parse");
+
+        assert_eq!(
+            value.pointer("/session").and_then(Value::as_str),
+            Some("sess-1")
+        );
+        assert_eq!(
+            value.pointer("/message").and_then(Value::as_str),
+            Some("ping pong")
+        );
+    }
+
+    #[test]
+    fn peer_message_args_requires_peer_id_and_message_text() {
+        assert!(peer_message_args(&args(&[])).is_err());
+        assert!(peer_message_args(&args(&["peer-1"])).is_err());
+    }
+
+    #[test]
+    fn peer_task_args_joins_instructions_and_parses_json_context() {
+        let value = peer_task_args(&args(&[
+            "peer-1",
+            "audit",
+            "the",
+            "logs",
+            "--context",
+            r#"{"repo":"intendant"}"#,
+        ]))
+        .expect("task args should parse");
+
+        assert_eq!(
+            value.pointer("/peer_id").and_then(Value::as_str),
+            Some("peer-1")
+        );
+        assert_eq!(
+            value.pointer("/instructions").and_then(Value::as_str),
+            Some("audit the logs")
+        );
+        assert_eq!(
+            value.pointer("/context/repo").and_then(Value::as_str),
+            Some("intendant")
+        );
+    }
+
+    #[test]
+    fn peer_task_args_passes_free_form_context_as_string() {
+        let value = peer_task_args(&args(&["peer-1", "task", "--context", "just some notes"]))
+            .expect("task args should parse");
+
+        assert_eq!(
+            value.pointer("/context").and_then(Value::as_str),
+            Some("just some notes")
+        );
+    }
+
+    #[test]
+    fn peer_task_args_omits_absent_context() {
+        let value = peer_task_args(&args(&["peer-1", "go"])).expect("task args should parse");
+        assert!(value.get("context").is_none());
     }
 
     #[test]

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -52,10 +52,11 @@ mod tool_gate;
 pub(crate) use tool_gate::*;
 mod tool_params;
 pub(crate) use tool_params::*;
-// tools_managed / tools_display contribute impl-block methods only —
-// nothing importable, so no re-export.
+// tools_managed / tools_display / tools_peer contribute impl-block
+// methods only — nothing importable, so no re-export.
 mod tools_display;
 mod tools_managed;
+mod tools_peer;
 
 const CONTEXT_PRESSURE_REWIND_THRESHOLD_PCT: f64 = 85.0;
 const DENSITY_MAINTENANCE_ANCHOR_LIST_LIMIT: usize = 1;
@@ -485,6 +486,15 @@ impl IntendantServer {
             "spawn_live_audio" => {
                 let params = parse_params::<SpawnLiveAudioParams>(args)?;
                 Ok(text_tool_result(self.spawn_live_audio(params).await))
+            }
+            "list_peers" => Ok(text_tool_result(self.list_peers().await)),
+            "peer_send_message" => {
+                let params = parse_params::<PeerSendMessageParams>(args)?;
+                Ok(text_tool_result(self.peer_send_message(params).await))
+            }
+            "peer_delegate_task" => {
+                let params = parse_params::<PeerDelegateTaskParams>(args)?;
+                Ok(text_tool_result(self.peer_delegate_task(params).await))
             }
             _ => Err(format!("Unknown tool: {}", name)),
         }

--- a/src/bin/caller/mcp/state.rs
+++ b/src/bin/caller/mcp/state.rs
@@ -74,6 +74,10 @@ pub struct McpAppState {
     pub frame_registry: Option<Arc<tokio::sync::RwLock<crate::frames::FrameRegistry>>>,
     /// Display session registry for CU action dispatch.
     pub session_registry: Option<crate::display::SharedSessionRegistry>,
+    /// Federated peer registry for the peer tools (`list_peers`,
+    /// `peer_send_message`, `peer_delegate_task`). `None` when this
+    /// process runs without federation (standalone `--mcp`, tests).
+    pub peer_registry: Option<crate::peer::PeerRegistry>,
     /// User-session display IDs with an activation/portal request already in
     /// flight, keyed by when MCP/ctl last requested activation. This keeps
     /// screenshot loops from queueing duplicate Wayland portal sessions while
@@ -199,6 +203,7 @@ impl McpAppState {
             presence_usage_pct: 0.0,
             frame_registry: None,
             session_registry: None,
+            peer_registry: None,
             user_display_activation_pending: std::collections::HashMap::new(),
             display_capture_ready: HashSet::new(),
             screenshot_dir: None,

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -199,6 +199,14 @@ pub(crate) fn mcp_tool_operation(name: &str) -> crate::peer::access_policy::Peer
         | "claim_fission_canonical"
         | "fission_spawn"
         | "fission_control" => PeerOperation::SessionManage,
+        // Peer federation. Listing is peer-topology inspection; messaging
+        // and delegation act *through* a connected peer and are peer use —
+        // the same classification the `/api/peers` HTTP routes and the
+        // dashboard-control RPCs carry: using a peer delegates this
+        // daemon's peer identity, and the receiving peer authorizes the
+        // action against its own grants for this daemon.
+        "list_peers" => PeerOperation::PeerInspect,
+        "peer_send_message" | "peer_delegate_task" => PeerOperation::PeerUse,
         // Viewing displays, frames, and shared-view surfaces.
         "list_displays"
         | "take_screenshot"
@@ -408,6 +416,30 @@ pub(crate) fn append_manual_http_tool_definitions(
             ExecuteCuActionsParams
         ),
     );
+    push(
+        "list_peers",
+        manual_http_tool_definition!(
+            "list_peers",
+            "List federated peer daemons: id, label, connection state, advertised capabilities, and currently visible sessions.",
+            EmptyToolParams
+        ),
+    );
+    push(
+        "peer_send_message",
+        manual_http_tool_definition!(
+            "peer_send_message",
+            "Send a text message to a federated peer daemon's agent. Addresses the peer's current/default session unless 'session' targets one. The receiving peer authorizes against its own grants for this daemon.",
+            PeerSendMessageParams
+        ),
+    );
+    push(
+        "peer_delegate_task",
+        manual_http_tool_definition!(
+            "peer_delegate_task",
+            "Delegate a task to a federated peer daemon: the peer's own agent executes the natural-language instructions on its machine under its own autonomy and approval policy. Returns a task id; progress streams to the dashboard's peers rail.",
+            PeerDelegateTaskParams
+        ),
+    );
 }
 
 #[cfg(test)]
@@ -529,6 +561,17 @@ mod tests {
         assert_eq!(
             mcp_tool_operation("request_shared_view_input"),
             PeerOperation::DisplayInput
+        );
+        // Peer federation: listing inspects topology; message/task act
+        // through the peer and ride peer.use like their /api/peers twins.
+        assert_eq!(mcp_tool_operation("list_peers"), PeerOperation::PeerInspect);
+        assert_eq!(
+            mcp_tool_operation("peer_send_message"),
+            PeerOperation::PeerUse
+        );
+        assert_eq!(
+            mcp_tool_operation("peer_delegate_task"),
+            PeerOperation::PeerUse
         );
         assert_eq!(mcp_tool_operation("quit"), PeerOperation::RuntimeControl);
         assert_eq!(

--- a/src/bin/caller/mcp/tool_params.rs
+++ b/src/bin/caller/mcp/tool_params.rs
@@ -550,6 +550,30 @@ pub struct CaptureSharedViewFrameParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct PeerSendMessageParams {
+    /// Peer daemon id, as returned by list_peers.
+    pub peer_id: String,
+    /// Message text delivered to the peer's agent.
+    pub message: String,
+    /// Optional peer-side session id to scope the message to. Omit to
+    /// address the peer's current/default session.
+    #[serde(default)]
+    pub session: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct PeerDelegateTaskParams {
+    /// Peer daemon id, as returned by list_peers.
+    pub peer_id: String,
+    /// Free-form natural-language instructions for the peer's agent.
+    pub instructions: String,
+    /// Optional structured context passed through to the peer (file
+    /// paths, prior state, anything not expressible in the instructions).
+    #[serde(default)]
+    pub context: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ScheduleControllerRestartParams {
     /// Identifier for the controlling agent/client (e.g. "codex", "claude_code").
     pub controller_id: String,

--- a/src/bin/caller/mcp/tools_peer.rs
+++ b/src/bin/caller/mcp/tools_peer.rs
@@ -1,0 +1,147 @@
+//! The peer-federation tool implementations: listing federated peers,
+//! messaging a peer's agent, and delegating tasks the peer's own agent
+//! executes under its own autonomy and approval policy. Stage 0 of the
+//! agent-facing peer control surface — deliberately the delegation verbs
+//! only; capability invocation on peers (display, computer use) is
+//! future work. The operation bodies live in `crate::peer::ops`, shared
+//! with the native `peer` tool so the surfaces cannot drift.
+
+use super::*;
+
+impl IntendantServer {
+    async fn peer_registry(&self) -> Option<crate::peer::PeerRegistry> {
+        self.state.read().await.peer_registry.clone()
+    }
+
+    #[tool(
+        description = "List federated peer daemons: id, label, connection state, advertised capabilities, and currently visible sessions."
+    )]
+    pub(crate) async fn list_peers(&self) -> String {
+        crate::peer::ops::list_peers_json(self.peer_registry().await.as_ref())
+    }
+
+    #[tool(
+        description = "Send a text message to a federated peer daemon's agent. Addresses the peer's current/default session unless 'session' targets one. The receiving peer authorizes against its own grants for this daemon."
+    )]
+    pub(crate) async fn peer_send_message(
+        &self,
+        Parameters(params): Parameters<PeerSendMessageParams>,
+    ) -> String {
+        crate::peer::ops::send_message_json(
+            self.peer_registry().await.as_ref(),
+            &params.peer_id,
+            params.message,
+            params.session,
+        )
+        .await
+    }
+
+    #[tool(
+        description = "Delegate a task to a federated peer daemon: the peer's own agent executes the natural-language instructions on its machine under its own autonomy and approval policy. Returns a task id; progress streams to the dashboard's peers rail."
+    )]
+    pub(crate) async fn peer_delegate_task(
+        &self,
+        Parameters(params): Parameters<PeerDelegateTaskParams>,
+    ) -> String {
+        crate::peer::ops::delegate_task_json(
+            self.peer_registry().await.as_ref(),
+            &params.peer_id,
+            params.instructions,
+            params.context,
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::tests::test_state;
+    use crate::peer::ops::FEDERATION_INACTIVE_NOTE;
+
+    fn empty_registry() -> crate::peer::PeerRegistry {
+        let (log_sink, _rx) = tokio::sync::mpsc::channel(crate::peer::LOG_CHANNEL_CAPACITY);
+        crate::peer::PeerRegistry::new(log_sink)
+    }
+
+    #[test]
+    fn peer_tools_degrade_gracefully_without_a_registry() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let server = IntendantServer::new(test_state(), EventBus::new());
+
+            let listed: serde_json::Value =
+                serde_json::from_str(&server.list_peers().await).unwrap();
+            assert_eq!(listed["peers"], serde_json::json!([]));
+            assert_eq!(listed["note"], FEDERATION_INACTIVE_NOTE);
+
+            let sent = server
+                .peer_send_message(Parameters(PeerSendMessageParams {
+                    peer_id: "intendant:nowhere".to_string(),
+                    message: "hello".to_string(),
+                    session: None,
+                }))
+                .await;
+            let sent: serde_json::Value = serde_json::from_str(&sent).unwrap();
+            assert_eq!(sent["ok"], serde_json::json!(false));
+            assert_eq!(sent["error"], FEDERATION_INACTIVE_NOTE);
+        });
+    }
+
+    #[test]
+    fn peer_tools_report_unknown_peers_against_an_empty_registry() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let state = test_state();
+            state.write().await.peer_registry = Some(empty_registry());
+            let server = IntendantServer::new(state, EventBus::new());
+
+            let listed: serde_json::Value =
+                serde_json::from_str(&server.list_peers().await).unwrap();
+            assert_eq!(listed["peers"], serde_json::json!([]));
+            assert!(listed.get("note").is_none());
+
+            let delegated = server
+                .peer_delegate_task(Parameters(PeerDelegateTaskParams {
+                    peer_id: "intendant:nowhere".to_string(),
+                    instructions: "bring up a display".to_string(),
+                    context: None,
+                }))
+                .await;
+            let delegated: serde_json::Value = serde_json::from_str(&delegated).unwrap();
+            assert_eq!(delegated["ok"], serde_json::json!(false));
+            assert!(delegated["error"]
+                .as_str()
+                .unwrap()
+                .contains("peer not found: intendant:nowhere"));
+        });
+    }
+
+    #[test]
+    fn peer_tools_dispatch_through_the_http_tool_router() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let server = IntendantServer::new(test_state(), EventBus::new());
+            let result = server
+                .call_tool_by_name_for_session("list_peers", serde_json::json!({}), None, None)
+                .await
+                .unwrap();
+            assert!(!result.is_error.unwrap_or(false));
+            let result_json = serde_json::to_value(&result).unwrap();
+            let text = result_json
+                .pointer("/content/0/text")
+                .and_then(serde_json::Value::as_str)
+                .unwrap();
+            assert!(text.contains(FEDERATION_INACTIVE_NOTE));
+        });
+    }
+}

--- a/src/bin/caller/peer/mod.rs
+++ b/src/bin/caller/peer/mod.rs
@@ -98,6 +98,7 @@ pub mod event;
 pub mod handle;
 pub mod id;
 pub mod log_writer;
+pub mod ops;
 pub mod pairing;
 pub mod registry;
 pub mod traits;

--- a/src/bin/caller/peer/ops.rs
+++ b/src/bin/caller/peer/ops.rs
@@ -1,0 +1,101 @@
+//! Shared implementations of the agent-facing peer operations, behind
+//! every control surface: the MCP tools (`mcp/tools_peer.rs`), the
+//! native `peer` tool (`agent_loop.rs`), and — through the MCP tools —
+//! `intendant ctl peer`. One implementation so argument handling and
+//! result shapes cannot drift between surfaces. Mirrors the
+//! `/api/peers` HTTP handlers in `web_gateway/routes_peers.rs`.
+//!
+//! Results are JSON strings: `{"peers": [...]}` for listing, and
+//! `{"ok": true, ...}` / `{"ok": false, "error": ...}` for actions —
+//! the same envelope the display/browser MCP tools use.
+
+use super::{
+    MessageContent, MessageRole, PeerHandle, PeerId, PeerMessage, PeerRegistry, PeerSnapshot,
+    PeerTask,
+};
+
+/// Note returned when this process runs without a peer registry
+/// (standalone `--mcp`, `--no-web` shapes, tests).
+pub const FEDERATION_INACTIVE_NOTE: &str = "peer federation is not active on this daemon";
+
+fn error_json(error: impl Into<String>) -> String {
+    serde_json::json!({ "ok": false, "error": error.into() }).to_string()
+}
+
+/// Look up a connected peer by id, mirroring `peer_handle_or_404` on
+/// the HTTP surface. The error is a ready-to-return result JSON.
+fn peer_handle(registry: Option<&PeerRegistry>, peer_id: &str) -> Result<PeerHandle, String> {
+    let Some(registry) = registry else {
+        return Err(error_json(FEDERATION_INACTIVE_NOTE));
+    };
+    let id = PeerId(peer_id.to_string());
+    registry
+        .get(&id)
+        .ok_or_else(|| error_json(format!("peer not found: {peer_id} (see list_peers)")))
+}
+
+/// List federated peers as `{"peers": [PeerSnapshot...]}` — the same
+/// snapshot payload `GET /api/peers` serves. Without a registry the
+/// list is empty and carries an explanatory note.
+pub fn list_peers_json(registry: Option<&PeerRegistry>) -> String {
+    let Some(registry) = registry else {
+        return serde_json::json!({ "peers": [], "note": FEDERATION_INACTIVE_NOTE }).to_string();
+    };
+    let peers: Vec<PeerSnapshot> = registry.list().iter().map(|h| h.snapshot()).collect();
+    serde_json::to_string_pretty(&serde_json::json!({ "peers": peers }))
+        .unwrap_or_else(|_| "{\"peers\":[]}".to_string())
+}
+
+/// Send a user-role text message to a peer's agent, optionally scoped
+/// to a peer-side session.
+pub async fn send_message_json(
+    registry: Option<&PeerRegistry>,
+    peer_id: &str,
+    message: String,
+    session: Option<String>,
+) -> String {
+    let handle = match peer_handle(registry, peer_id) {
+        Ok(handle) => handle,
+        Err(error) => return error,
+    };
+    let message = PeerMessage {
+        session,
+        role: MessageRole::User,
+        content: MessageContent::Text { text: message },
+    };
+    match handle.send_message(message).await {
+        Ok(message_id) => {
+            serde_json::json!({ "ok": true, "message_id": message_id.0 }).to_string()
+        }
+        Err(err) => error_json(err.to_string()),
+    }
+}
+
+/// Delegate a task to a peer. The peer's own agent executes the
+/// instructions on its machine under its own autonomy and approval
+/// policy; the returned task id correlates its progress events.
+pub async fn delegate_task_json(
+    registry: Option<&PeerRegistry>,
+    peer_id: &str,
+    instructions: String,
+    context: Option<serde_json::Value>,
+) -> String {
+    let handle = match peer_handle(registry, peer_id) {
+        Ok(handle) => handle,
+        Err(error) => return error,
+    };
+    let task = PeerTask {
+        instructions,
+        context: context.unwrap_or(serde_json::Value::Null),
+        client_correlation_id: None,
+    };
+    match handle.delegate_task(task).await {
+        Ok(task_id) => serde_json::json!({
+            "ok": true,
+            "task_id": task_id.0,
+            "note": "the peer's agent executes this under its own autonomy and approval policy",
+        })
+        .to_string(),
+        Err(err) => error_json(err.to_string()),
+    }
+}

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -99,6 +99,7 @@ pub(crate) async fn run_with_presence(
     frame_registry: Arc<tokio::sync::RwLock<frames::FrameRegistry>>,
     context_injection: event::ContextInjectionQueue,
     session_registry: display::SharedSessionRegistry,
+    peer_registry: Option<peer::PeerRegistry>,
     agent_backend_override: Option<external_agent::AgentBackend>,
     shared_external_agent: Arc<tokio::sync::RwLock<Option<external_agent::AgentBackend>>>,
     shared_codex_config: control_plane::SharedCodexConfig,
@@ -2834,6 +2835,7 @@ pub(crate) async fn run_with_presence(
                 &approval_registry,
                 &context_injection, // shared with presence
                 Some(&session_registry),
+                peer_registry.as_ref(),
                 false, // not headless
                 None,  // presence mode has no session supervisor
             )
@@ -2932,6 +2934,7 @@ pub(crate) async fn run_direct_mode(
     approval_registry: event::ApprovalRegistry,
     context_injection: event::ContextInjectionQueue,
     session_registry: Option<display::SharedSessionRegistry>,
+    peer_registry: Option<peer::PeerRegistry>,
     headless: bool,
     attachments: UserAttachments,
     native: NativeSessionConfig,
@@ -3090,6 +3093,7 @@ pub(crate) async fn run_direct_mode(
         &approval_registry,
         &context_injection,
         session_registry.as_ref(),
+        peer_registry.as_ref(),
         headless,
         native.orchestration.as_ref(),
     )

--- a/src/bin/caller/session_supervisor.rs
+++ b/src/bin/caller/session_supervisor.rs
@@ -26,6 +26,10 @@ pub struct SessionSupervisorConfig {
     /// Live display sessions, when the daemon runs a display pipeline. CU
     /// screenshots prefer their in-memory frames over subprocess capture.
     pub session_registry: Option<display::SharedSessionRegistry>,
+    /// Federated peer registry, when the daemon runs the web gateway.
+    /// Backs the native `peer` tool in supervised sessions; None makes
+    /// the tool answer with a federation-inactive note.
+    pub peer_registry: Option<peer::PeerRegistry>,
     pub web_port: Option<u16>,
     pub flags_direct: bool,
     pub shared_session: Option<web_gateway::SharedActiveSession>,
@@ -2276,6 +2280,7 @@ impl SessionSupervisor {
                     approval_registry,
                     context_injection,
                     supervisor.config.session_registry.clone(),
+                    supervisor.config.peer_registry.clone(),
                     true,
                     attachments,
                     native,
@@ -5416,6 +5421,7 @@ mod tests {
             project_root,
             autonomy: crate::autonomy::shared_autonomy(crate::autonomy::AutonomyState::default()),
             session_registry: None,
+            peer_registry: None,
             shared_external_agent: Arc::new(tokio::sync::RwLock::new(None)),
             shared_codex_config: Arc::new(tokio::sync::RwLock::new(
                 control_plane::CodexRuntimeConfig {

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -19,6 +19,7 @@ pub(crate) struct DaemonConfig {
     pub(crate) shared_claude_config: control_plane::SharedClaudeConfig,
     pub(crate) frame_registry: Arc<tokio::sync::RwLock<frames::FrameRegistry>>,
     pub(crate) session_registry: Option<display::SharedSessionRegistry>,
+    pub(crate) peer_registry: Option<peer::PeerRegistry>,
     pub(crate) web_port: Option<u16>,
     pub(crate) flags_direct: bool,
     /// Optional shared session state for headless mode (cleared between tasks).
@@ -44,6 +45,7 @@ pub(crate) async fn run_daemon_loop(config: DaemonConfig) {
         shared_claude_config: config.shared_claude_config,
         frame_registry: config.frame_registry,
         session_registry: config.session_registry,
+        peer_registry: config.peer_registry,
         web_port: config.web_port,
         flags_direct: config.flags_direct,
         shared_session: config.shared_session,
@@ -180,6 +182,7 @@ pub(crate) async fn run_daemon(
             shared_claude_config,
             frame_registry,
             session_registry: Some(session_registry.clone()),
+            peer_registry: Some(gateway.peer_registry.clone()),
             web_port: web_port_for_agent,
             flags_direct: flags.direct,
             shared_session: Some(shared_session),

--- a/src/bin/caller/startup/headless.rs
+++ b/src/bin/caller/startup/headless.rs
@@ -381,6 +381,7 @@ pub(crate) async fn run_headless_mode(
     // injections reach the agent loop in --no-presence mode too. When
     // presence is disabled, agent_state is a fresh empty snapshot (no
     // live updates), but context_injection is still wired through.
+    let mut headless_peer_registry: Option<peer::PeerRegistry> = None;
     let headless_shared_session: Option<web_gateway::SharedActiveSession> = if use_web {
         let (transcriber, transcriber_err) =
             startup::wiring::build_transcriber(&project.config.transcription);
@@ -420,6 +421,7 @@ pub(crate) async fn run_headless_mode(
             Some(session_log.clone()),
         )?;
         eprintln!("{}", gateway.log_line);
+        headless_peer_registry = Some(gateway.peer_registry.clone());
         Some(gateway.shared_session)
     } else {
         None
@@ -478,6 +480,7 @@ pub(crate) async fn run_headless_mode(
                     shared_claude_config: shared_claude_config.clone(),
                     frame_registry: frame_registry.clone(),
                     session_registry: Some(session_registry.clone()),
+                    peer_registry: headless_peer_registry.clone(),
                     web_port: web_port_for_agent,
                     flags_direct: flags.direct,
                     shared_session: headless_shared_session.clone(),
@@ -580,6 +583,7 @@ pub(crate) async fn run_headless_mode(
             frame_registry.clone(),
             context_injection.clone(),
             session_registry.clone(),
+            headless_peer_registry.clone(),
             agent_backend,
             shared_external_agent.clone(),
             shared_codex_config.clone(),
@@ -637,6 +641,7 @@ pub(crate) async fn run_headless_mode(
             approval_registry.clone(),
             context_injection.clone(),
             Some(session_registry.clone()),
+            headless_peer_registry.clone(),
             !use_web, // under the gateway, approvals surface in the dashboard
             UserAttachments::default(),
             NativeSessionConfig::direct(),
@@ -695,6 +700,7 @@ pub(crate) async fn run_headless_mode(
             shared_claude_config: shared_claude_config.clone(),
             frame_registry: frame_registry.clone(),
             session_registry: Some(session_registry.clone()),
+            peer_registry: headless_peer_registry.clone(),
             web_port: web_port_for_agent,
             flags_direct: flags.direct,
             shared_session: headless_shared_session.clone(),

--- a/src/bin/caller/startup/mcp_mode.rs
+++ b/src/bin/caller/startup/mcp_mode.rs
@@ -148,6 +148,10 @@ pub(crate) async fn run_mcp_mode(
     mcp_app_state.task_description = task.clone().unwrap_or_default();
     mcp_app_state.frame_registry = Some(frame_registry.clone());
     mcp_app_state.session_registry = Some(session_registry.clone());
+    let mcp_peer_registry = _web_handle
+        .as_ref()
+        .map(|gateway| gateway.peer_registry.clone());
+    mcp_app_state.peer_registry = mcp_peer_registry.clone();
     mcp_app_state.screenshot_dir = Some(log_dir.join("screenshots"));
     let mcp_state = std::sync::Arc::new(tokio::sync::RwLock::new(mcp_app_state));
 
@@ -160,6 +164,7 @@ pub(crate) async fn run_mcp_mode(
     let log_dir_for_launcher = log_dir.clone();
     let mcp_state_for_launcher = mcp_state.clone();
     let session_registry_for_launcher = session_registry.clone();
+    let peer_registry_for_launcher = mcp_peer_registry.clone();
     #[allow(clippy::async_yields_async)]
     let launcher: mcp::TaskLauncher = Box::new(move |task_str: String, bus: EventBus| {
         let project_root = project_root.clone();
@@ -168,6 +173,7 @@ pub(crate) async fn run_mcp_mode(
         let _parent_log_dir = log_dir_for_launcher.clone();
         let mcp_state = mcp_state_for_launcher.clone();
         let session_registry = session_registry_for_launcher.clone();
+        let peer_registry = peer_registry_for_launcher.clone();
         Box::pin(async move {
             // Each MCP task gets a fresh session directory so conversations
             // don't bleed between tasks (reasoning items, tool calls, etc.).
@@ -291,6 +297,7 @@ pub(crate) async fn run_mcp_mode(
                         approval_registry,
                         event::ContextInjectionQueue::default(),
                         Some(session_registry),
+                        peer_registry,
                         false, // not headless — MCP has interactive approval
                         UserAttachments::default(),
                         NativeSessionConfig::direct(),

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -159,6 +159,10 @@ pub(crate) struct GatewaySpawn {
     pub(crate) _handle: tokio::task::JoinHandle<()>,
     pub(crate) shared_session: web_gateway::SharedActiveSession,
     pub(crate) log_line: String,
+    /// The federated peer registry the gateway serves. Mode runners
+    /// thread it into session launches so the native `peer` tool and
+    /// the MCP peer tools act on the same registry.
+    pub(crate) peer_registry: crate::peer::PeerRegistry,
 }
 
 /// Build and spawn the web gateway the way every mode does: gateway
@@ -217,6 +221,7 @@ pub(crate) fn spawn_mode_web_gateway(
         },
         file_watcher: shared_file_watcher.clone(),
     }));
+    let peer_registry = build_and_hydrate_peer_registry(log_dir, &project.config.peers);
     let mut mcp_http_state = mcp::McpAppState::new(
         "none".into(),
         "none".into(),
@@ -228,12 +233,12 @@ pub(crate) fn spawn_mode_web_gateway(
     mcp_http_state.configured_codex_managed_context = mcp_http_state.codex_managed_context;
     mcp_http_state.frame_registry = Some(frame_registry.clone());
     mcp_http_state.session_registry = Some(session_registry.clone());
+    mcp_http_state.peer_registry = Some(peer_registry.clone());
     mcp_http_state.screenshot_dir = Some(log_dir.join("screenshots"));
     let mcp_http_server = Some(Arc::new(mcp::IntendantServer::new_http(
         Arc::new(tokio::sync::RwLock::new(mcp_http_state)),
         bus.clone(),
     )));
-    let peer_registry = build_and_hydrate_peer_registry(log_dir, &project.config.peers);
     let advertise_urls = resolve_advertise_urls_from_flags_and_config(flags, project);
     let handle = web_gateway::spawn_web_gateway(
         web_listener
@@ -247,7 +252,7 @@ pub(crate) fn spawn_mode_web_gateway(
         None, // task_tx: browser SubmitTask routes via the EventBus → dispatcher path
         Some(project.root.clone()),
         mcp_http_server,
-        Some(peer_registry),
+        Some(peer_registry.clone()),
         advertise_urls,
         project.config.server.auth.bearer_token.clone(),
         build_local_advertised_auth(
@@ -261,5 +266,6 @@ pub(crate) fn spawn_mode_web_gateway(
         _handle: handle,
         shared_session,
         log_line: dashboard_log_line(web_tls_acceptor, web_port, web_bind_ip),
+        peer_registry,
     })
 }

--- a/src/bin/caller/tool_batch.rs
+++ b/src/bin/caller/tool_batch.rs
@@ -25,6 +25,9 @@ pub struct ToolBatchResult {
     /// Shared-view calls extracted from shared_view tool calls.
     /// Vec of (call_id, raw_args_json).
     pub shared_view_calls: Vec<(String, serde_json::Value)>,
+    /// Peer-federation calls extracted from peer tool calls.
+    /// Vec of (call_id, raw_args_json).
+    pub peer_calls: Vec<(String, serde_json::Value)>,
     /// Live audio spawn requests extracted from spawn_live_audio tool calls.
     /// Vec of (call_id, session_id, full_args_json).
     pub live_audio_spawns: Vec<(String, String, serde_json::Value)>,
@@ -52,6 +55,7 @@ pub fn assemble_batch_from_tool_calls(tool_calls: &[provider::ToolCall]) -> Tool
     let mut precomputed_results = Vec::new();
     let mut skill_invocations = Vec::new();
     let mut shared_view_calls = Vec::new();
+    let mut peer_calls = Vec::new();
     let mut live_audio_spawns = Vec::new();
     let mut sub_agent_spawns = Vec::new();
     let mut sub_agent_waits = Vec::new();
@@ -85,6 +89,11 @@ pub fn assemble_batch_from_tool_calls(tool_calls: &[provider::ToolCall]) -> Tool
                 if let Ok(args) = serde_json::from_str::<serde_json::Value>(&tc.arguments) {
                     shared_view_calls.push((tc.call_id.clone(), args));
                 }
+            }
+            "peer" => {
+                let args =
+                    serde_json::from_str::<serde_json::Value>(&tc.arguments).unwrap_or_default();
+                peer_calls.push((tc.call_id.clone(), args));
             }
             "spawn_live_audio" => {
                 if let Ok(args) = serde_json::from_str::<serde_json::Value>(&tc.arguments) {
@@ -174,6 +183,7 @@ pub fn assemble_batch_from_tool_calls(tool_calls: &[provider::ToolCall]) -> Tool
         precomputed_results,
         skill_invocations,
         shared_view_calls,
+        peer_calls,
         live_audio_spawns,
         sub_agent_spawns,
         sub_agent_waits,
@@ -250,6 +260,7 @@ pub fn map_results_to_tool_responses(
             || tool_name == "signal_done"
             || tool_name == "invoke_skill"
             || tool_name == "shared_view"
+            || tool_name == "peer"
             || tool_name == "spawn_live_audio"
             || tool_name == "spawn_sub_agent"
             || tool_name == "wait_sub_agents"

--- a/src/bin/caller/tools.rs
+++ b/src/bin/caller/tools.rs
@@ -4,7 +4,7 @@ use std::sync::Mutex;
 
 /// Extra tool definitions registered at runtime (e.g. from MCP servers).
 static EXTRA_TOOLS: Mutex<Vec<ToolDefinition>> = Mutex::new(Vec::new());
-const BUILT_IN_TOOL_COUNT: usize = 17;
+const BUILT_IN_TOOL_COUNT: usize = 18;
 
 /// Provider-agnostic tool definition.
 #[derive(Debug, Clone, Serialize)]
@@ -560,6 +560,43 @@ pub fn all_tools() -> Vec<ToolDefinition> {
         }),
     });
 
+    // 18. peer (caller-handled, federated peer daemons)
+    tools.push(ToolDefinition {
+        name: "peer".to_string(),
+        description: "Interact with federated peer daemons. Actions: list enumerates peers with their connection state, capabilities, and visible sessions; message sends text to a peer's agent; task delegates work that the peer's own agent executes on its machine under its own autonomy and approval policy (returns a task id; progress streams to the dashboard's peers rail). Peers are siblings, not subordinates: the receiving daemon authorizes every action against its own grants for this daemon. Requires peer federation to be configured.".to_string(),
+        parameters: json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "message", "task"],
+                    "description": "Peer verb to perform."
+                },
+                "peer_id": {
+                    "type": "string",
+                    "description": "Peer daemon id from the list action. Required for message and task."
+                },
+                "message": {
+                    "type": "string",
+                    "description": "Message text delivered to the peer's agent (message action)."
+                },
+                "instructions": {
+                    "type": "string",
+                    "description": "Free-form natural-language instructions for the peer's agent (task action)."
+                },
+                "context": {
+                    "description": "Optional structured context passed through with a task (file paths, prior state)."
+                },
+                "session": {
+                    "type": "string",
+                    "description": "Optional peer-side session id to scope a message to."
+                }
+            },
+            "required": ["action"],
+            "additionalProperties": false
+        }),
+    });
+
     // Append any extra tools registered at runtime (MCP servers, etc.)
     if let Ok(extra) = EXTRA_TOOLS.lock() {
         tools.extend(extra.iter().cloned());
@@ -627,6 +664,7 @@ mod tests {
         "spawn_sub_agent",
         "wait_sub_agents",
         "submit_result",
+        "peer",
     ];
 
     #[test]

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1,7 +1,7 @@
 //! Headless end-to-end tests: spawn the real `intendant` binary and drive
 //! the production stack — CLI parsing, provider selection, the agent loop,
 //! tool dispatch, the sandboxed `intendant-runtime` subprocess, and session
-//! logging — with no API keys, no network, and no display.
+//! logging — with no API keys, no network beyond loopback, and no display.
 //!
 //! The model is the scripted mock provider (`PROVIDER=mock` +
 //! `INTENDANT_MOCK_SCRIPT`, see `src/bin/caller/provider_mock.rs`): each
@@ -10,6 +10,10 @@
 //! log, and on-disk effects. Scripts fail loudly (unmet expectation or
 //! exhausted steps error out), so a hung or drifted loop fails the test
 //! instead of green-looping.
+//!
+//! Besides one-shot runs, the suite can host persistent `--web` daemons on
+//! ephemeral loopback ports (see [`DaemonRig`]) and federate them over
+//! `POST /api/peers` — still keyless and with no network beyond loopback.
 //!
 //! Run: cargo test --test e2e -- --nocapture
 
@@ -20,6 +24,10 @@ use std::time::Duration;
 /// Generous ceiling for one binary run: a debug build on a cold CI runner
 /// spawns the runtime several times but each chat turn is local.
 const RUN_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Ceiling for a `--web` daemon to bind its port and serve the agent card
+/// on a cold CI runner.
+const DAEMON_START_TIMEOUT: Duration = Duration::from_secs(60);
 
 fn intendant_bin() -> &'static str {
     // Referencing the runtime binary's env var makes Cargo build it too —
@@ -131,6 +139,175 @@ fn text_of(output: &std::process::Output) -> String {
 
 fn marker_file(project: &Path, name: &str) -> PathBuf {
     project.join(name)
+}
+
+/// Two distinct free loopback ports, grabbed while both listeners are
+/// alive so the kernel cannot hand out the same port twice. The listeners
+/// are dropped on return and the daemons re-bind moments later; if a port
+/// is stolen in that window the daemon walks to the next free port and the
+/// test fails loudly on its readiness poll — a flake, never a false pass.
+fn two_free_loopback_ports() -> (u16, u16) {
+    let first = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind ephemeral port");
+    let second = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind ephemeral port");
+    (
+        first.local_addr().expect("ephemeral port addr").port(),
+        second.local_addr().expect("ephemeral port addr").port(),
+    )
+}
+
+/// A persistent-daemon variant of [`TestRig`]: the same isolated binary
+/// invocation, but running as an idle `--web` daemon on a loopback port
+/// instead of a one-shot task.
+struct DaemonRig {
+    /// Declared first so drop kills the daemon (kill_on_drop) before the
+    /// rig's temp dirs are removed — fields drop in declaration order, and
+    /// a still-running process holds open log handles on Windows.
+    child: tokio::process::Child,
+    rig: TestRig,
+    port: u16,
+}
+
+impl DaemonRig {
+    /// Tail of the daemon's combined stdout/stderr log, for failure context.
+    fn log_tail(&self) -> String {
+        let path = self.rig.home.path().join("daemon.log");
+        let contents = std::fs::read_to_string(&path).unwrap_or_default();
+        let mut start = contents.len().saturating_sub(4000);
+        while !contents.is_char_boundary(start) {
+            start += 1;
+        }
+        contents[start..].to_string()
+    }
+}
+
+/// Spawn an idle daemon (no task) with the given mock script and wait until
+/// its gateway serves the agent card — the same flags and readiness probe as
+/// the peer-sessions smoke rig (`tests/skills/peer-sessions-smoke`).
+async fn spawn_daemon(
+    client: &reqwest::Client,
+    script: &serde_json::Value,
+    port: u16,
+) -> DaemonRig {
+    let rig = TestRig::new();
+    let script_path = rig.write_script(script);
+    let log = std::fs::File::create(rig.home.path().join("daemon.log")).expect("daemon log");
+    let mut cmd = rig.command();
+    cmd.env("INTENDANT_MOCK_SCRIPT", &script_path)
+        // A daemon outlives the test body's reads; piped-but-unread stdio
+        // would deadlock once the pipe buffer fills, so tee both streams
+        // to a file instead.
+        .stdout(log.try_clone().expect("clone daemon log"))
+        .stderr(log);
+    cmd.arg("--web")
+        .arg(port.to_string())
+        .args([
+            "--bind",
+            "127.0.0.1",
+            "--no-tls",
+            "--no-tui",
+            "--autonomy",
+            "full",
+        ])
+        .arg("--advertise-url")
+        .arg(format!("ws://127.0.0.1:{port}/ws"));
+    let child = cmd.spawn().expect("spawn intendant daemon");
+    let mut daemon = DaemonRig { child, rig, port };
+
+    let card_url = format!("http://127.0.0.1:{port}/.well-known/agent-card.json");
+    let deadline = tokio::time::Instant::now() + DAEMON_START_TIMEOUT;
+    loop {
+        if http_get_json(client, &card_url).await.is_some() {
+            return daemon;
+        }
+        if let Ok(Some(status)) = daemon.child.try_wait() {
+            panic!(
+                "daemon on port {port} exited during startup ({status}):\n{}",
+                daemon.log_tail()
+            );
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "daemon on port {port} did not serve its agent card within \
+             {DAEMON_START_TIMEOUT:?}:\n{}",
+            daemon.log_tail()
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+/// Run `intendant ctl --port <daemon port> <args…>` against a daemon,
+/// isolated the same way as the daemon itself. `intendant ctl` honors
+/// INTENDANT_MCP_URL / INTENDANT_PORT / INTENDANT_SESSION_ID /
+/// INTENDANT_MANAGED_CONTEXT from the environment — a test run from inside a
+/// supervised session inherits them and would target the wrong daemon — so
+/// scrub them and let `--port` select exactly this daemon (tokenless
+/// loopback /mcp binds the root-capable `local_process` default on a fresh,
+/// grant-less HOME).
+async fn ctl(daemon: &DaemonRig, args: &[&str]) -> std::process::Output {
+    let mut cmd = daemon.rig.command();
+    cmd.env_remove("INTENDANT_MCP_URL")
+        .env_remove("INTENDANT_PORT")
+        .env_remove("INTENDANT_SESSION_ID")
+        .env_remove("INTENDANT_MANAGED_CONTEXT");
+    cmd.arg("ctl")
+        .arg("--port")
+        .arg(daemon.port.to_string())
+        .args(args);
+    daemon.rig.run(cmd).await
+}
+
+/// Parse a ctl run's stdout as the single JSON document the command prints.
+fn stdout_json(output: &std::process::Output) -> serde_json::Value {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "ctl did not print one JSON document ({e}):\n{}",
+            text_of(output)
+        )
+    })
+}
+
+async fn http_get_json(client: &reqwest::Client, url: &str) -> Option<serde_json::Value> {
+    let response = client.get(url).send().await.ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    response.json().await.ok()
+}
+
+/// The first peer in `GET /api/peers` whose connection is up, if any.
+async fn connected_peer(client: &reqwest::Client, port: u16) -> Option<serde_json::Value> {
+    let peers = http_get_json(client, &format!("http://127.0.0.1:{port}/api/peers")).await?;
+    peers
+        .get("peers")?
+        .as_array()?
+        .iter()
+        .find(|peer| {
+            peer.pointer("/connection_state/state")
+                .and_then(|v| v.as_str())
+                == Some("connected")
+        })
+        .cloned()
+}
+
+/// Poll `probe` every 250 ms until it yields `Some`, panicking after
+/// `timeout` — the suite's polling convention for daemon-shaped tests
+/// (one-shot runs use [`TestRig::run`]'s hard timeout instead).
+async fn poll_until<T, Fut>(what: &str, timeout: Duration, mut probe: impl FnMut() -> Fut) -> T
+where
+    Fut: std::future::Future<Output = Option<T>>,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Some(found) = probe().await {
+            return found;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out after {timeout:?} waiting for {what}"
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
 }
 
 #[tokio::test]
@@ -251,4 +428,182 @@ async fn mock_provider_without_a_script_fails_closed() {
         evidence.contains("INTENDANT_MOCK_SCRIPT"),
         "expected the mock-script configuration error, got:\n{evidence}"
     );
+}
+
+/// `intendant ctl peer …` against a live federated pair: daemon A federates
+/// to daemon B over `POST /api/peers` (the peer-sessions smoke's pattern),
+/// then the ctl surface — which reaches A's `/mcp` over tokenless loopback —
+/// must (1) print `{"peers":[]}` before any peer exists, (2) list B with its
+/// snapshot id/label and a connected connection_state, and (3) delegate a
+/// task to B via `peer task`, printing a task_id while B's supervisor starts
+/// a child session that really executes the instructions. B-side execution
+/// is proven the same way the smoke rig proves it: the instructions carry a
+/// marker that selects B's scripted mock profile, and that profile's done
+/// signal — gated on the runtime echo reaching the transcript — lands in
+/// B's session log (any other session would consume the fallback profile
+/// and log "unexpected session" instead).
+#[tokio::test]
+async fn ctl_peer_list_and_task_drive_a_federated_peer_daemon() {
+    const TASK_MARK: &str = "PEER_E2E_DELEGATED_TASK";
+    const DONE_MESSAGE: &str = "peer delegated task complete";
+
+    // Daemon A idles; ctl drives it. The fallback profile only exists so an
+    // unexpected session fails the test legibly instead of hanging the mock.
+    let idle_script = serde_json::json!({
+        "profiles": [{
+            "steps": [
+                { "content": "fallback profile (unexpected session)",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "unexpected session" } }] }
+            ]
+        }]
+    });
+    let peer_script = serde_json::json!({
+        "profiles": [
+            { "match": TASK_MARK, "steps": [
+                { "content": "Running the delegated command.",
+                  "tool_calls": [{ "name": "exec_command",
+                                   "arguments": { "nonce": 1, "command": "echo PEER_E2E_ROUNDTRIP" } }] },
+                { "expect_transcript_contains": "PEER_E2E_ROUNDTRIP",
+                  "content": "Delegated work finished.",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": DONE_MESSAGE } }] }
+            ]},
+            { "steps": [
+                { "content": "fallback profile (unexpected session)",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "unexpected session" } }] }
+            ]}
+        ]
+    });
+
+    // Everything here is loopback; ignore any ambient HTTP(S)_PROXY.
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("http client");
+    let (port_a, port_b) = two_free_loopback_ports();
+    let mut a = spawn_daemon(&client, &idle_script, port_a).await;
+    let mut b = spawn_daemon(&client, &peer_script, port_b).await;
+
+    // Zero peers: a fresh daemon lists an empty registry.
+    let empty = ctl(&a, &["peer", "list"]).await;
+    assert!(empty.status.success(), "{}", text_of(&empty));
+    let parsed = stdout_json(&empty);
+    assert_eq!(
+        parsed.get("peers").and_then(|v| v.as_array()).map(Vec::len),
+        Some(0),
+        "expected an empty peers list:\n{}",
+        text_of(&empty)
+    );
+
+    // Federate A -> B by B's card URL and wait for the connection to form.
+    let response = client
+        .post(format!("http://127.0.0.1:{port_a}/api/peers"))
+        .json(&serde_json::json!({
+            "card_url": format!("http://127.0.0.1:{port_b}/.well-known/agent-card.json"),
+            "label": "e2e-peer-b",
+        }))
+        .send()
+        .await
+        .expect("POST /api/peers");
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    assert!(
+        status.is_success(),
+        "federating A->B failed (HTTP {status}): {body}\n--- daemon A ---\n{}",
+        a.log_tail()
+    );
+    let peer = poll_until(
+        "daemon A reporting peer B connected",
+        Duration::from_secs(45),
+        || {
+            let client = client.clone();
+            async move { connected_peer(&client, port_a).await }
+        },
+    )
+    .await;
+    let peer_id = peer
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("peer snapshot missing id: {peer}"))
+        .to_string();
+    let peer_label = peer
+        .get("label")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+
+    // `ctl peer list` prints the same snapshot GET /api/peers serves.
+    let list = ctl(&a, &["peer", "list"]).await;
+    assert!(list.status.success(), "{}", text_of(&list));
+    let listed = stdout_json(&list);
+    let entry = listed
+        .get("peers")
+        .and_then(|v| v.as_array())
+        .and_then(|peers| {
+            peers
+                .iter()
+                .find(|p| p.get("id").and_then(|v| v.as_str()) == Some(peer_id.as_str()))
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "ctl peer list is missing peer {peer_id}:\n{}",
+                text_of(&list)
+            )
+        })
+        .clone();
+    assert_eq!(
+        entry
+            .pointer("/connection_state/state")
+            .and_then(|v| v.as_str()),
+        Some("connected"),
+        "ctl peer list did not report B connected:\n{}",
+        text_of(&list)
+    );
+    assert_eq!(
+        entry.get("label").and_then(|v| v.as_str()),
+        Some(peer_label.as_str()),
+        "ctl peer list label diverges from the /api/peers snapshot:\n{}",
+        text_of(&list)
+    );
+
+    // Delegate a task to B through A; the command must print a task id.
+    let instructions = format!("{TASK_MARK} - run the scripted delegated steps");
+    let task = ctl(&a, &["peer", "task", &peer_id, &instructions]).await;
+    assert!(task.status.success(), "{}", text_of(&task));
+    let task_json = stdout_json(&task);
+    let task_id = task_json
+        .get("task_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        !task_id.is_empty(),
+        "ctl peer task did not print a task_id:\n{}",
+        text_of(&task)
+    );
+
+    // B really ran it: only the TASK_MARK-matched profile emits the done
+    // message, and the mock releases it only after the runtime's echo
+    // reached the transcript — instructions crossed, session ran, exec
+    // round-tripped.
+    poll_until(
+        "the delegated task completing on peer daemon B",
+        Duration::from_secs(90),
+        || {
+            let logs = b.rig.session_logs();
+            async move { logs.contains(DONE_MESSAGE).then_some(()) }
+        },
+    )
+    .await;
+    let artifacts = b.rig.turn_artifacts();
+    assert!(
+        artifacts.contains("PEER_E2E_ROUNDTRIP"),
+        "peer B turn artifacts missing the delegated runtime stdout:\n{artifacts}"
+    );
+
+    // Explicit shutdown (kill_on_drop remains the panic-path backstop) so
+    // both daemons are dead before their temp homes are removed.
+    let _ = a.child.kill().await;
+    let _ = b.child.kill().await;
 }


### PR DESCRIPTION
Expose the delegation verbs to agents on every control surface, all
routed through shared bodies in peer/ops.rs so the surfaces cannot
drift, and all IAM-gated at call time mirroring the /api/peers
classification: list_peers -> peer.inspect; peer_send_message and
peer_delegate_task -> peer.use (acting through a peer delegates this
daemon's peer identity; the receiving peer authorizes against its own
grants for this daemon).

- MCP tools list_peers / peer_send_message / peer_delegate_task
  (mcp/tools_peer.rs); McpAppState carries the PeerRegistry, wired in
  the gateway and --mcp shapes; None degrades to a clear
  federation-inactive note
- intendant ctl peer list|message|task
- native peer tool (actions list|message|task), threaded through the
  session launch paths (supervisor children, headless foreground,
  presence dispatch, MCP launcher) via GatewaySpawn.peer_registry
- docs: peer-federation.md agent-facing section, mcp-server.md tool
  table, intendant-cli SKILL.md line, SysPrompt_tools.md guidance
- tests: tool-gate operation pins, tools_peer unit tests, ctl arg
  tests, and a two-daemon federation e2e (ctl peer list/task against
  a live peer; execution proven by a runtime echo marker roundtrip)

Stage 0 is deliberately delegation-only: no display/CU invocation on
peers; cross-machine display viewing stays on the browser WebRTC path.
