### PR TITLE
Projectless daemon: optional project root, no cwd fallback, structured no_project error

### DIFF
--- a/docs/src/control-plane-and-daemon.md
+++ b/docs/src/control-plane-and-daemon.md
@@ -127,7 +127,11 @@ When `start_new_session` runs, it:
 1. resolves a fresh session log directory (`SessionLog::resolve_path(None)` →
    `~/.intendant/logs/<uuid>/`) and opens the `SessionLog`;
 2. resolves the project root (per-session override or the daemon's default) and
-   loads the `Project`;
+   loads the `Project`. On a **projectless daemon** (see below) there is no
+   default: a `CreateSession` without an explicit `project_root` fails with
+   `SessionEnded { error_kind: "no_project" }` — a structured class the
+   dashboard turns into the project picker — instead of silently rooting the
+   session at the daemon's launch directory;
 3. writes `session_meta.json` and activates the shared active-session handle;
 4. resolves the backend (one-shot `agent` override → configured default →
    internal) and applies the runtime external-agent config;
@@ -179,7 +183,8 @@ by it, so the supervisor picks it up.
 
 ## File Watcher, Snapshots, and Rewind
 
-`file_watcher.rs` is a live filesystem watcher rooted at the project directory.
+`file_watcher.rs` is a live filesystem watcher rooted at the project directory
+(a projectless daemon starts no watcher — there is nothing to watch).
 It works for **all** agent types — internal, Codex, Claude Code —
 because it watches the filesystem directly rather than diffing git, so an
 external CLI's edits show up the same as Intendant's own. It does two jobs:
@@ -256,6 +261,23 @@ many sessions over its lifetime, driven entirely from frontends. Passing a task
 on the command line instead runs it as the foreground session under the same
 gateway (the headless arm), which falls through to this daemon loop when the
 session ends.
+
+**Projectless daemons.** The daemon path's `project_root` is an
+`Option<PathBuf>`. When the daemon starts in a directory with no project
+marker — no `.git` (directory or worktree file) and no `intendant.toml`; the
+single definition lives in `project::root_has_project_marker`, which the
+boot-scan gate (`file_watcher::root_is_snapshot_worthy`) also uses — it runs
+*projectless* instead of adopting cwd as an implicit project. Concretely: no
+file-watcher baseline (nothing is watched at all), no cwd-derived sandbox
+write scope (scratch + log dir + `~/.intendant` + explicit absolute grants
+only), no project-root `.env` layer at startup, `GET /api/project-root`
+returns `project_root: null` (the dashboard's New Session pane requires a
+project before submitting), and there is **no default session project** —
+each `CreateSession`/resume carries its own `project_root`, and a create
+without one gets the structured `no_project` failure. This is the normal
+shape for installed-app and service deployments, whose launch cwd (`$HOME`,
+`/Applications`, …) is an accident; CLI invocations keep cwd-as-project,
+which is correct for `intendant "task"` inside a repo.
 
 Ctrl+C in this mode is handled by the global signal handler installed in `main`
 (it marks the session interrupted and exits 130); the daemon loop deliberately

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -245,19 +245,22 @@ unset) prefers **OpenAI** when an OpenAI key is present, then Anthropic, then
 Gemini. See [Configuration](./configuration.md) for the full environment
 reference and per-provider default models.
 
-> **Daemon installs: "project root" means the daemon's launch directory.**
-> The search above runs **once, at process startup**, relative to wherever the
-> daemon was launched — for the installed macOS app that is a synthetic
-> workspace dir (`~/projects/intendant-workspace`), for a service install
-> usually `$HOME`. The project you pick when creating a session in the
-> dashboard does **not** feed this search. What a session's project `.env`
-> *does* contribute: the three provider key variables (and only those — never
-> `PROVIDER`, model, or endpoint settings) join that session's key resolution
-> as the last layer, after credential leases and the daemon's own environment.
-> For a daemon, the reliable places for keys are **Dashboard → Settings → API
-> Keys** (persists to `~/.config/intendant/.env` and applies immediately, no
-> restart), that global file itself (restart required if edited by hand), or
-> vault leases per [Credential Custody](./credential-custody.md).
+> **Daemon installs run projectless.** The search above runs **once, at
+> process startup**, relative to wherever the daemon was launched — for the
+> installed macOS app and service installs that is usually `$HOME`. A launch
+> directory without a project marker (`.git` / `intendant.toml`) is **not**
+> treated as a project: the daemon runs projectless (its `.env` layer for that
+> directory comes only from the ordinary cwd walk-up, and each dashboard
+> session picks its own project directory). The project you pick when creating
+> a session does **not** feed this startup search. What a session's project
+> `.env` *does* contribute: the three provider key variables (and only those —
+> never `PROVIDER`, model, or endpoint settings) join that session's key
+> resolution as the last layer, after credential leases and the daemon's own
+> environment. For a daemon, the reliable places for keys are **Dashboard →
+> Settings → API Keys** (persists to `~/.config/intendant/.env` and applies
+> immediately, no restart), that global file itself (restart required if
+> edited by hand), or vault leases per
+> [Credential Custody](./credential-custody.md).
 
 ## Your first run
 

--- a/macos-app/main.swift
+++ b/macos-app/main.swift
@@ -713,52 +713,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         }
         process.environment = env
 
-        // Set working directory to the directory containing the .app bundle.
-        // For ~/projects/intendant/target/Intendant.app this gives ~/projects/intendant/target/
-        // Then walk up to find the project root (directory with .env or Cargo.toml).
-        //
-        // When the .app is installed (the common case — /Applications/Intendant.app),
-        // the walk-up from /Applications never finds a Cargo.toml / .env marker and
-        // terminates at `/`. If we then set cwd=/, the Rust daemon's FileWatcher::new
-        // recursively indexes the entire root filesystem (every /System, /Library,
-        // /Volumes mount) and blocks main forever — web_gateway never spawns, the
-        // app's WKWebView sits on "Waiting for backend…" until it gives up.
-        //
-        // Fallback: when no project marker is found after the walk, use ~/.intendant
-        // as the cwd. That directory is small, bounded, and already the home of the
-        // daemon's logs + config — so FileWatcher completes in milliseconds rather
-        // than hanging on /System.
-        var dir = URL(fileURLWithPath: bundle.bundlePath).deletingLastPathComponent()
-        var foundProjectMarker = false
-        for _ in 0..<5 {
-            if FileManager.default.fileExists(atPath: dir.appendingPathComponent("Cargo.toml").path) ||
-               FileManager.default.fileExists(atPath: dir.appendingPathComponent(".env").path) {
-                foundProjectMarker = true
-                break
-            }
-            let parent = dir.deletingLastPathComponent()
-            if parent.path == dir.path { break }
-            dir = parent
-        }
-        if !foundProjectMarker {
-            // Bandaid until we land a proper "no project open" story
-            // (tracked separately): give the daemon a fresh, empty
-            // workspace under ~/projects/ as its cwd. NOT ~/.intendant
-            // — that's where the daemon writes its own logs + snapshots,
-            // so setting cwd there makes FileWatcher + file_snapshots
-            // watch the daemon's own output and loop forever.
-            //
-            // ~/projects/intendant-workspace is empty on first launch,
-            // persists across launches (so the agent's edits stay
-            // visible), and is out of the daemon's state dir. The
-            // sustainable fix makes project_root optional on the Rust
-            // side so there's no cwd-is-project-root fallback at all.
-            let workspace = FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent("projects/intendant-workspace")
-            try? FileManager.default.createDirectory(
-                at: workspace, withIntermediateDirectories: true)
-            dir = workspace
-        }
+        // Working directory: plainly the user's home. Nothing derives from
+        // the launch cwd anymore — a daemon started outside a project (no
+        // .git / intendant.toml at cwd) runs projectless on the Rust side:
+        // no cwd file watching, no cwd-derived sandbox scope, no default
+        // session project. Each session picks its project directory in the
+        // dashboard's New Session pane. (Home may itself contain a project
+        // marker; if so the daemon simply roots there, which is the normal
+        // rooted behavior, not a scan hazard — projectless/marker gating
+        // lives in the Rust daemon.)
+        let dir = FileManager.default.homeDirectoryForCurrentUser
         process.currentDirectoryURL = dir
         NSLog("Working directory: \(dir.path)")
 

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -340,8 +340,9 @@ pub enum AppEvent {
         session_id: String,
         reason: String,
         /// Structured failure class the UI can act on without parsing
-        /// prose (e.g. "unfueled" → an Add-API-keys action). None for
-        /// normal ends and unclassified errors.
+        /// prose (e.g. "unfueled" → an Add-API-keys action; "no_project"
+        /// → the project picker). None for normal ends and unclassified
+        /// errors.
         error_kind: Option<String>,
     },
     DebugScreenReady {

--- a/src/bin/caller/file_watcher.rs
+++ b/src/bin/caller/file_watcher.rs
@@ -204,9 +204,9 @@ const IGNORED_EXTENSIONS: &[&str] = &[
 /// minutes reading `~/.rustup` before the dashboard and rendezvous
 /// client could spawn.)
 pub fn root_is_snapshot_worthy(root: &Path) -> bool {
-    // A git worktree's `.git` is a file, not a directory — exists()
-    // covers both shapes.
-    root.join(".git").exists() || root.join("intendant.toml").exists()
+    // Same marker notion as "does the daemon have a project at all" —
+    // one definition, owned by project.rs.
+    crate::project::root_has_project_marker(root)
 }
 
 /// Tree-wide budget for the initial baseline scan. A root that blows

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -2716,19 +2716,39 @@ fn is_simple_task(task: &str) -> bool {
     task.len() < 100
 }
 
-fn configure_sandbox_env(flags: &CliFlags, project: &Project, log_dir: &std::path::Path) {
+fn configure_sandbox_env(
+    flags: &CliFlags,
+    project: &Project,
+    log_dir: &std::path::Path,
+    // `None` = projectless daemon: the write scope is scratch + logs +
+    // ~/.intendant + explicit absolute grants only — the launch cwd never
+    // becomes writable by accident. Every other path passes the project root.
+    project_write_scope: Option<&std::path::Path>,
+) {
     let enabled = flags.sandbox || project.config.sandbox.enabled;
     if !enabled {
         env::remove_var("INTENDANT_SANDBOX_WRITE_PATHS");
         return;
     }
 
-    let mut sandbox_cfg = sandbox::SandboxConfig::default_for_project(&project.root, log_dir);
+    let mut sandbox_cfg = match project_write_scope {
+        Some(root) => sandbox::SandboxConfig::default_for_project(root, log_dir),
+        None => sandbox::SandboxConfig::projectless(log_dir),
+    };
     for p in &project.config.sandbox.extra_write_paths {
         let extra = if std::path::Path::new(p).is_absolute() {
             PathBuf::from(p)
+        } else if let Some(root) = project_write_scope {
+            root.join(p)
         } else {
-            project.root.join(p)
+            // No project to anchor a relative grant to; resolving against
+            // the launch cwd would silently widen the projectless scope.
+            // (Unreachable in practice — projectless implies no
+            // intendant.toml, so this list is empty — kept fail-closed.)
+            eprintln!(
+                "[sandbox] relative extra write path {p} ignored: the daemon has no project root to resolve it against"
+            );
+            continue;
         };
         sandbox_cfg.write_paths.push(extra);
     }
@@ -3065,8 +3085,16 @@ async fn main() -> Result<(), CallerError> {
     // session was created with; see provider::EnvSearchReport).
     let cwd_env = dotenvy::dotenv().ok();
     let mut project = Project::detect()?;
-    let project_env_path = project.root.join(".env");
-    let project_env_loaded = dotenvy::from_path(&project_env_path).is_ok();
+    // A root without a project marker (.git / intendant.toml) is just the
+    // launch cwd — its .env, if any, was already covered by the cwd walk
+    // above. Don't load (or report) it a second time as a "project root"
+    // layer: under a daemon that label misled credential errors.
+    let project_has_marker = project::root_has_project_marker(&project.root);
+    let project_env = project_has_marker.then(|| {
+        let path = project.root.join(".env");
+        let loaded = dotenvy::from_path(&path).is_ok();
+        (path, loaded)
+    });
     let global_env = dirs::config_dir().map(|config_dir| {
         let path = config_dir.join("intendant").join(".env");
         let loaded = dotenvy::from_path(&path).is_ok();
@@ -3074,7 +3102,7 @@ async fn main() -> Result<(), CallerError> {
     });
     provider::record_env_search(provider::EnvSearchReport {
         cwd_env,
-        project_env: Some((project_env_path, project_env_loaded)),
+        project_env,
         global_env,
     });
 
@@ -3097,17 +3125,39 @@ async fn main() -> Result<(), CallerError> {
             env::set_var("MAX_OUTPUT_TOKENS", max_out.to_string());
         }
     }
+    // Idle web/dashboard startup defaults to the daemon path (the session
+    // supervisor owns all launches). Computed here — from flags only, which
+    // are not mutated below — because the daemon shape decides resume
+    // ownership, the sandbox write scope, and whether a markerless cwd
+    // becomes a project at all.
+    let web_daemon_requested =
+        should_start_idle_web_daemon(!flags.no_web && !flags.mcp && !flags.json_output, &flags);
+    // Projectless: a daemon launched from a directory with no project marker
+    // (.git / intendant.toml — `project::root_has_project_marker`) runs
+    // without a project instead of adopting cwd; an installed app or service
+    // otherwise inherits an accident of launch directory as its sandbox
+    // scope, watcher root, and default session project. CLI (headless/MCP)
+    // invocations keep cwd-as-project — correct for `intendant "task"`
+    // inside a repo.
+    let projectless_daemon = web_daemon_requested && !project_has_marker;
+    let daemon_project_root: Option<PathBuf> =
+        (!projectless_daemon).then(|| project.root.clone());
+    if projectless_daemon {
+        eprintln!(
+            "Projectless daemon: {} has no project marker (.git or intendant.toml) — \
+             running without a default project; sessions choose their own project directory",
+            project.root.display()
+        );
+    }
     // Create or resume session log.
     //
     // Under the default-web daemon, --continue/--resume are owned by the
     // SUPERVISOR: the daemon starts on a fresh base log and resumes the
     // target session through ResumeSession at startup. (These flags used to
     // be silently swallowed — the daemon adopted the old session's log dir
-    // and then idled.) The predicate mirrors use_web/web_daemon_requested
-    // computed below; the flags it reads are not mutated in between.
+    // and then idled.)
     let daemon_owns_resume =
-        should_start_idle_web_daemon(!flags.no_web && !flags.mcp && !flags.json_output, &flags)
-            && (flags.continue_last || flags.resume_id.is_some());
+        web_daemon_requested && (flags.continue_last || flags.resume_id.is_some());
     let mut daemon_startup_resume_dir: Option<PathBuf> = None;
     let log_dir = if let Some(ref session_id) = flags.resume_id {
         // --resume <id>: find a specific session by ID or path
@@ -3204,7 +3254,7 @@ async fn main() -> Result<(), CallerError> {
     let session_registry: display::SharedSessionRegistry =
         Arc::new(tokio::sync::RwLock::new(display::SessionRegistry::new()));
 
-    configure_sandbox_env(&flags, &project, &log_dir);
+    configure_sandbox_env(&flags, &project, &log_dir, daemon_project_root.as_deref());
 
     // --owner bootstrap: pin root authority to the given browser key
     // before any surface comes up. Failing this with the flag present is
@@ -3290,9 +3340,11 @@ async fn main() -> Result<(), CallerError> {
         });
     }
 
-    // Write session metadata (project root, task will be filled in later if available).
+    // Write session metadata (project root, task will be filled in later if
+    // available). A projectless daemon's base session honestly records no
+    // project instead of attributing itself to the launch cwd.
     slog(&session_log, |l| {
-        l.write_meta(Some(&project.root), None);
+        l.write_meta(daemon_project_root.as_deref(), None);
     });
 
     // Web gateway is on by default unless explicitly disabled, or when running
@@ -3410,14 +3462,20 @@ async fn main() -> Result<(), CallerError> {
         Err(e) => return Err(e),
     };
     slog(&session_log, |l| {
-        l.debug(&format!("Project root: {}", project.root.display()));
+        match daemon_project_root.as_deref() {
+            Some(root) => l.debug(&format!("Project root: {}", root.display())),
+            None => l.debug(&format!(
+                "Project root: none (projectless daemon; launched from {})",
+                project.root.display()
+            )),
+        }
         l.debug(&format!("Autonomy: {}", flags.autonomy));
     });
 
-    // Idle web/dashboard startup defaults to the daemon path: the session
+    // web_daemon_requested (computed above, before the session log): idle
+    // web/dashboard startup defaults to the daemon path — the session
     // supervisor owns all launches. A task on the command line runs it as
     // the foreground (headless) session under the same gateway.
-    let web_daemon_requested = should_start_idle_web_daemon(use_web, &flags);
 
     // Task resolution: the daemon starts idle; MCP mode allows starting
     // without a task (it honors an explicit --task-file but must not
@@ -3439,6 +3497,7 @@ async fn main() -> Result<(), CallerError> {
         return startup::daemon::run_daemon(
             &flags,
             &project,
+            daemon_project_root,
             autonomy,
             session_log,
             log_dir,

--- a/src/bin/caller/project.rs
+++ b/src/bin/caller/project.rs
@@ -1,7 +1,7 @@
 use crate::autonomy::ApprovalConfig;
 use crate::error::CallerError;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1252,6 +1252,21 @@ fn detect_project_root() -> Result<PathBuf, CallerError> {
 
     std::env::current_dir()
         .map_err(|e| CallerError::Config(format!("Failed to get current directory: {}", e)))
+}
+
+/// Whether `root` is a *real* project root — it carries a project marker:
+/// a `.git` (directory, or file for git worktrees) or an `intendant.toml`.
+///
+/// This is the single definition of "has a project" (the boot-scan gate in
+/// `file_watcher::root_is_snapshot_worthy` delegates here). When
+/// `detect_project_root()` fell back to cwd and that cwd has no marker, a
+/// daemon must run projectless rather than adopt the launch directory as an
+/// implicit project (sandbox write scope, watcher root, default session
+/// project). CLI (non-daemon) invocations keep cwd-as-project.
+pub fn root_has_project_marker(root: &Path) -> bool {
+    // A git worktree's `.git` is a file, not a directory — exists()
+    // covers both shapes.
+    root.join(".git").exists() || root.join("intendant.toml").exists()
 }
 
 #[cfg(test)]

--- a/src/bin/caller/sandbox.rs
+++ b/src/bin/caller/sandbox.rs
@@ -85,6 +85,17 @@ impl SandboxConfig {
     /// - Read: `/` (everything)
     /// - Write: project root, the OS scratch dir, log directory, home `.intendant`
     pub fn default_for_project(project_root: &Path, log_dir: &Path) -> Self {
+        let mut config = Self::projectless(log_dir);
+        config.write_paths.insert(0, project_root.to_path_buf());
+        config
+    }
+
+    /// Default config for a daemon with **no project** (projectless): the
+    /// same base scope as `default_for_project` minus the project root —
+    /// scratch dir, log dir, and `~/.intendant` only. Absence of a project
+    /// must shrink the write scope, never widen it: in particular the
+    /// daemon's launch cwd is *not* writable.
+    pub fn projectless(log_dir: &Path) -> Self {
         // The scratch dir stays the literal `/tmp` on Unix (macOS `TMPDIR`
         // aliases are composed into the Seatbelt profile separately); on
         // Windows the equivalent is the profile-local `%TEMP%`, which has
@@ -94,7 +105,7 @@ impl SandboxConfig {
         } else {
             PathBuf::from("/tmp")
         };
-        let mut write_paths = vec![project_root.to_path_buf(), scratch, log_dir.to_path_buf()];
+        let mut write_paths = vec![scratch, log_dir.to_path_buf()];
 
         // Allow writes to ~/.intendant
         if let Some(home) = dirs::home_dir() {
@@ -383,6 +394,23 @@ mod tests {
         assert!(config.write_paths.contains(&scratch));
         assert!(config.write_paths.contains(&PathBuf::from("/tmp/logs")));
         assert!(config.read_paths.contains(&PathBuf::from("/")));
+    }
+
+    #[test]
+    fn projectless_config_is_the_project_config_minus_the_project_root() {
+        let log_dir = Path::new("/tmp/logs");
+        let projectless = SandboxConfig::projectless(log_dir);
+        let mut with_project =
+            SandboxConfig::default_for_project(Path::new("/home/user/project"), log_dir);
+        // Exactly one path apart: the project root. No cwd, no widening.
+        assert!(!projectless
+            .write_paths
+            .contains(&PathBuf::from("/home/user/project")));
+        with_project
+            .write_paths
+            .retain(|p| p != Path::new("/home/user/project"));
+        assert_eq!(projectless.write_paths, with_project.write_paths);
+        assert!(projectless.enabled);
     }
 
     #[test]

--- a/src/bin/caller/session_supervisor.rs
+++ b/src/bin/caller/session_supervisor.rs
@@ -17,7 +17,13 @@ use super::*;
 #[derive(Clone)]
 pub struct SessionSupervisorConfig {
     pub bus: EventBus,
-    pub project_root: PathBuf,
+    /// The daemon's default project for sessions that don't carry their
+    /// own. `None` = projectless daemon (launch dir had no project
+    /// marker): creating or resuming a session then *requires* an
+    /// explicit project root, and a CreateSession without one fails
+    /// with the structured `no_project` error kind instead of silently
+    /// adopting the launch cwd.
+    pub project_root: Option<PathBuf>,
     pub autonomy: SharedAutonomy,
     pub shared_external_agent: Arc<tokio::sync::RwLock<Option<external_agent::AgentBackend>>>,
     pub shared_codex_config: control_plane::SharedCodexConfig,
@@ -500,8 +506,10 @@ impl SessionSupervisor {
 
     fn attachment_project_roots(&self, primary: &Path) -> Vec<PathBuf> {
         let mut roots = vec![primary.to_path_buf()];
-        if self.config.project_root != primary {
-            roots.push(self.config.project_root.clone());
+        if let Some(default_root) = self.config.project_root.as_deref() {
+            if default_root != primary {
+                roots.push(default_root.to_path_buf());
+            }
         }
         roots
     }
@@ -1108,14 +1116,34 @@ impl SessionSupervisor {
             .lock()
             .map(|log| log.session_id().to_string())
             .unwrap_or_else(|_| path_file_name(&log_dir));
-        let project_root =
-            match resolve_project_root_override(project_root, &self.config.project_root) {
-                Ok(root) => root,
-                Err(e) => {
-                    self.loop_error(format!("Project load failed: {}", e));
-                    return;
-                }
-            };
+        let project_root = match resolve_project_root_override(
+            project_root,
+            self.config.project_root.as_deref(),
+        ) {
+            Ok(root) => root,
+            Err(ProjectRootResolveError::NoProject) => {
+                let reason = no_project_reason();
+                // Close out the just-opened session log honestly, keep the
+                // log-shaped failure the dashboard's pending-spawn notice
+                // already keys on ("Session create failed:"), and emit the
+                // structured end event so any client can act on the class
+                // without parsing prose (the unfueled precedent).
+                slog(&session_log, |l| {
+                    l.write_summary(&task, &format!("error: {reason}"), 0)
+                });
+                self.loop_error(format!("Session create failed: {reason}"));
+                self.config.bus.send(AppEvent::SessionEnded {
+                    session_id,
+                    reason: format!("error: {reason}"),
+                    error_kind: Some(NO_PROJECT_ERROR_KIND.to_string()),
+                });
+                return;
+            }
+            Err(e) => {
+                self.loop_error(format!("Project load failed: {}", e));
+                return;
+            }
+        };
         let project = match Project::from_root(project_root) {
             Ok(project) => project,
             Err(e) => {
@@ -1466,7 +1494,7 @@ impl SessionSupervisor {
             match resolve_external_resume_project_root(
                 project_root,
                 session_agent_config.as_ref(),
-                &self.config.project_root,
+                self.config.project_root.as_deref(),
             ) {
                 Ok(root) => root,
                 Err(e) => {
@@ -1475,9 +1503,20 @@ impl SessionSupervisor {
                 }
             }
         } else {
-            project_root
+            // Native resume: explicit request → daemon default → the root
+            // recorded in the session's own meta (reached only on a
+            // projectless daemon; rooted daemons behave exactly as before).
+            let resolved = project_root
                 .map(PathBuf::from)
-                .unwrap_or_else(|| self.config.project_root.clone())
+                .or_else(|| self.config.project_root.clone())
+                .or_else(|| native_session_meta_project_root(&session_id));
+            match resolved {
+                Some(root) => root,
+                None => {
+                    self.loop_error(format!("Project load failed: {}", no_project_reason()));
+                    return;
+                }
+            }
         };
 
         if resume_task.is_none() {
@@ -4470,36 +4509,75 @@ fn path_file_name(path: &std::path::Path) -> String {
         .to_string()
 }
 
+/// Structured `SessionEnded.error_kind` for "no project selected on a
+/// projectless daemon" — lets UIs point at the project picker instead of
+/// parsing prose (the `unfueled` precedent).
+pub(crate) const NO_PROJECT_ERROR_KIND: &str = "no_project";
+
+fn no_project_reason() -> String {
+    "no project selected — this daemon runs without a default project; \
+     pick a project directory in the New Session pane"
+        .to_string()
+}
+
+/// How a session's project root failed to resolve.
+#[derive(Debug, PartialEq, Eq)]
+enum ProjectRootResolveError {
+    /// No usable override and the daemon has no default project
+    /// (projectless). Surfaces as the structured `no_project` error kind.
+    NoProject,
+    /// An override was given but is unusable (relative, missing, not a
+    /// directory).
+    Invalid(String),
+}
+
+impl std::fmt::Display for ProjectRootResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoProject => f.write_str(&no_project_reason()),
+            Self::Invalid(msg) => f.write_str(msg),
+        }
+    }
+}
+
 fn resolve_project_root_override(
     project_root: Option<String>,
-    default_root: &Path,
-) -> Result<PathBuf, String> {
+    default_root: Option<&Path>,
+) -> Result<PathBuf, ProjectRootResolveError> {
+    let fall_back_to_default = || match default_root {
+        Some(root) => Ok(root.to_path_buf()),
+        None => Err(ProjectRootResolveError::NoProject),
+    };
     let Some(raw) = project_root else {
-        return Ok(default_root.to_path_buf());
+        return fall_back_to_default();
     };
     let trimmed = raw.trim();
     if trimmed.is_empty() {
-        return Ok(default_root.to_path_buf());
+        return fall_back_to_default();
     }
+    let invalid = ProjectRootResolveError::Invalid;
     let path = if trimmed == "~" {
-        dirs::home_dir().ok_or_else(|| "could not resolve home directory".to_string())?
+        dirs::home_dir().ok_or_else(|| invalid("could not resolve home directory".to_string()))?
     } else if let Some(rest) = trimmed.strip_prefix("~/") {
         dirs::home_dir()
-            .ok_or_else(|| "could not resolve home directory".to_string())?
+            .ok_or_else(|| invalid("could not resolve home directory".to_string()))?
             .join(rest)
     } else {
         PathBuf::from(trimmed)
     };
     if !path.is_absolute() {
-        return Err(format!(
+        return Err(invalid(format!(
             "project directory must be absolute or start with ~/ (got {})",
             trimmed
-        ));
+        )));
     }
     let canonical = std::fs::canonicalize(&path)
-        .map_err(|e| format!("{} is not accessible: {}", path.display(), e))?;
+        .map_err(|e| invalid(format!("{} is not accessible: {}", path.display(), e)))?;
     if !canonical.is_dir() {
-        return Err(format!("{} is not a directory", canonical.display()));
+        return Err(invalid(format!(
+            "{} is not a directory",
+            canonical.display()
+        )));
     }
     Ok(canonical)
 }
@@ -4507,8 +4585,8 @@ fn resolve_project_root_override(
 fn resolve_external_resume_project_root(
     project_root: Option<String>,
     config: Option<&crate::session_config::SessionAgentConfig>,
-    default_root: &Path,
-) -> Result<PathBuf, String> {
+    default_root: Option<&Path>,
+) -> Result<PathBuf, ProjectRootResolveError> {
     if let Some(root) = project_root
         .as_deref()
         .and_then(|root| crate::session_config::normalize_project_root(Some(root)))
@@ -4521,7 +4599,21 @@ fn resolve_external_resume_project_root(
     {
         return resolve_project_root_override(Some(root), default_root);
     }
-    Ok(default_root.to_path_buf())
+    match default_root {
+        Some(root) => Ok(root.to_path_buf()),
+        None => Err(ProjectRootResolveError::NoProject),
+    }
+}
+
+/// Last-resort project root for resuming a *native* session on a
+/// projectless daemon: the root the session was created with, recorded in
+/// its `session_meta.json`. Rooted daemons never reach this (the daemon
+/// default wins first, exactly as before).
+fn native_session_meta_project_root(session_id: &str) -> Option<PathBuf> {
+    let dir = crate::session_log::SessionLog::find_session_by_id(session_id)?;
+    let raw = std::fs::read_to_string(dir.join("session_meta.json")).ok()?;
+    let meta: crate::session_log::SessionMeta = serde_json::from_str(&raw).ok()?;
+    meta.project_root.map(PathBuf::from)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -5413,7 +5505,7 @@ mod tests {
     fn test_supervisor(project_root: PathBuf, bus: EventBus) -> SessionSupervisor {
         SessionSupervisor::new(SessionSupervisorConfig {
             bus,
-            project_root,
+            project_root: Some(project_root),
             autonomy: crate::autonomy::shared_autonomy(crate::autonomy::AutonomyState::default()),
             session_registry: None,
             shared_external_agent: Arc::new(tokio::sync::RwLock::new(None)),
@@ -6060,7 +6152,8 @@ mod tests {
         config.project_root = Some(station_root.to_string_lossy().to_string());
 
         let resolved =
-            resolve_external_resume_project_root(None, Some(&config), &helper_root).unwrap();
+            resolve_external_resume_project_root(None, Some(&config), Some(helper_root.as_path()))
+                .unwrap();
         assert_eq!(resolved, station_root.canonicalize().unwrap());
     }
 
@@ -6087,10 +6180,49 @@ mod tests {
         let resolved = resolve_external_resume_project_root(
             Some(requested_root.to_string_lossy().to_string()),
             Some(&config),
-            &helper_root,
+            Some(helper_root.as_path()),
         )
         .unwrap();
         assert_eq!(resolved, requested_root);
+    }
+
+    #[test]
+    fn project_root_override_without_default_is_the_structured_no_project_error() {
+        // A projectless daemon (no default root) must fail closed with the
+        // structured class — never adopt cwd or improvise a root.
+        assert_eq!(
+            resolve_project_root_override(None, None).unwrap_err(),
+            ProjectRootResolveError::NoProject
+        );
+        assert_eq!(
+            resolve_project_root_override(Some("   ".to_string()), None).unwrap_err(),
+            ProjectRootResolveError::NoProject
+        );
+        // An unusable override is a different class: the caller keeps its
+        // prose error instead of sending the user to the project picker.
+        assert!(matches!(
+            resolve_project_root_override(Some("relative/path".to_string()), None).unwrap_err(),
+            ProjectRootResolveError::Invalid(_)
+        ));
+    }
+
+    #[test]
+    fn project_root_override_with_explicit_root_works_without_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let resolved = resolve_project_root_override(
+            Some(dir.path().to_string_lossy().to_string()),
+            None,
+        )
+        .unwrap();
+        assert_eq!(resolved, dir.path().canonicalize().unwrap());
+    }
+
+    #[test]
+    fn external_resume_project_root_without_any_source_is_no_project() {
+        assert_eq!(
+            resolve_external_resume_project_root(None, None, None).unwrap_err(),
+            ProjectRootResolveError::NoProject
+        );
     }
 
     #[tokio::test]

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -11,7 +11,9 @@ use crate::*;
 /// Configuration for `run_daemon_loop`.
 pub(crate) struct DaemonConfig {
     pub(crate) bus: EventBus,
-    pub(crate) project_root: PathBuf,
+    /// `None` = projectless daemon: no default session project; every
+    /// CreateSession must carry an explicit `project_root` override.
+    pub(crate) project_root: Option<PathBuf>,
     pub(crate) autonomy: SharedAutonomy,
     pub(crate) shared_external_agent:
         Arc<tokio::sync::RwLock<Option<external_agent::AgentBackend>>>,
@@ -58,6 +60,12 @@ pub(crate) async fn run_daemon_loop(config: DaemonConfig) {
 pub(crate) async fn run_daemon(
     flags: &CliFlags,
     project: &Project,
+    // The daemon's default project root, `None` when the launch directory
+    // has no project marker (projectless — see main's
+    // `daemon_project_root`). `project` still supplies config defaults;
+    // its `root` field is only the launch cwd and must not be treated as
+    // a project here.
+    project_root: Option<PathBuf>,
     autonomy: SharedAutonomy,
     session_log: SharedSessionLog,
     log_dir: PathBuf,
@@ -105,7 +113,7 @@ pub(crate) async fn run_daemon(
     let _log_sinks = startup::wiring::spawn_log_sinks(&bus, &session_log);
 
     let (shared_file_watcher, _watcher_handle, _round_snapshot_handle) =
-        startup::wiring::start_project_file_watcher(&project.root, &log_dir, &bus);
+        startup::wiring::start_project_file_watcher(project_root.as_deref(), &log_dir, &bus);
 
     let (transcriber, transcriber_err) =
         startup::wiring::build_transcriber(&project.config.transcription);
@@ -115,6 +123,7 @@ pub(crate) async fn run_daemon(
     let gateway = startup::wiring::spawn_mode_web_gateway(
         flags,
         project,
+        project_root.clone(),
         &autonomy,
         &log_dir,
         &session_log,
@@ -149,19 +158,19 @@ pub(crate) async fn run_daemon(
             codex_config: shared_codex_config.clone(),
             claude_config: shared_claude_config.clone(),
             bus: bus.clone(),
-            project_root: Some(project.root.clone()),
+            project_root: project_root.clone(),
         },
     );
 
     // Vitals chips for the daemon's primary session: git state of the
-    // project root (statusline port).
-    let _vitals_producer = if let Some(session_id) = session_log_id(&session_log) {
-        Some(session_vitals::spawn_session_vitals_producer(
+    // project root (statusline port). A projectless daemon has no repo to
+    // report on — no producer.
+    let _vitals_producer = match (session_log_id(&session_log), project_root.clone()) {
+        (Some(session_id), Some(root)) => Some(session_vitals::spawn_session_vitals_producer(
             bus.clone(),
-            vec![(session_id, project.root.clone())],
-        ))
-    } else {
-        None
+            vec![(session_id, root)],
+        )),
+        _ => None,
     };
     // Native usage rail: derive per-session UsageSnapshots from
     // ModelResponse events (dashboard meter + cache/limits vitals).
@@ -173,7 +182,7 @@ pub(crate) async fn run_daemon(
     let supervisor_handle =
         session_supervisor::SessionSupervisor::new(session_supervisor::SessionSupervisorConfig {
             bus,
-            project_root: project.root.clone(),
+            project_root,
             autonomy,
             shared_external_agent,
             shared_codex_config,

--- a/src/bin/caller/startup/headless.rs
+++ b/src/bin/caller/startup/headless.rs
@@ -74,7 +74,7 @@ pub(crate) async fn run_headless_mode(
     let _log_sinks = startup::wiring::spawn_log_sinks(&bus, &session_log);
 
     let (shared_file_watcher, _watcher_handle, _round_snapshot_handle) =
-        startup::wiring::start_project_file_watcher(&project.root, &log_dir, &bus);
+        startup::wiring::start_project_file_watcher(Some(&project.root), &log_dir, &bus);
 
     // JSON stdout subscriber: prints OutboundEvents as JSONL to stdout
     if flags.json_output {
@@ -398,6 +398,7 @@ pub(crate) async fn run_headless_mode(
         let gateway = startup::wiring::spawn_mode_web_gateway(
             flags,
             &project,
+            Some(project.root.clone()),
             &autonomy,
             &log_dir,
             &session_log,
@@ -471,7 +472,7 @@ pub(crate) async fn run_headless_mode(
             session_supervisor::SessionSupervisor::new(
                 session_supervisor::SessionSupervisorConfig {
                     bus: bus.clone(),
-                    project_root: project.root.clone(),
+                    project_root: Some(project.root.clone()),
                     autonomy: autonomy.clone(),
                     shared_external_agent: shared_external_agent.clone(),
                     shared_codex_config: shared_codex_config.clone(),
@@ -688,7 +689,7 @@ pub(crate) async fn run_headless_mode(
 
         run_daemon_loop(DaemonConfig {
             bus: bus.clone(),
-            project_root: project_root.clone(),
+            project_root: Some(project_root.clone()),
             autonomy: autonomy_for_daemon.clone(),
             shared_external_agent: shared_external_agent.clone(),
             shared_codex_config: shared_codex_config.clone(),

--- a/src/bin/caller/startup/mcp_mode.rs
+++ b/src/bin/caller/startup/mcp_mode.rs
@@ -83,7 +83,7 @@ pub(crate) async fn run_mcp_mode(
     let _log_sinks = startup::wiring::spawn_log_sinks(&bus, &session_log);
 
     let (shared_file_watcher, _watcher_handle, _round_snapshot_handle) =
-        startup::wiring::start_project_file_watcher(&project.root, &log_dir, &bus);
+        startup::wiring::start_project_file_watcher(Some(&project.root), &log_dir, &bus);
 
     // Web gateway (WebSocket)
     let _web_handle = if use_web {
@@ -95,6 +95,7 @@ pub(crate) async fn run_mcp_mode(
         let gateway = startup::wiring::spawn_mode_web_gateway(
             flags,
             project,
+            Some(project.root.clone()),
             &autonomy,
             &log_dir,
             &session_log,

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -115,12 +115,13 @@ pub(crate) fn build_transcriber(
     }
 }
 
-/// Project file watcher for rewind snapshots. Fallback roots (no .git
-/// / intendant.toml — e.g. a service's $HOME WorkingDirectory) must
+/// Project file watcher for rewind snapshots. A projectless daemon
+/// (`None`) watches nothing at all, and fallback roots (no .git /
+/// intendant.toml — e.g. a service's $HOME WorkingDirectory) must
 /// never be baseline-scanned: it blocks boot for minutes and
 /// shadow-copies the whole tree.
 pub(crate) fn start_project_file_watcher(
-    project_root: &Path,
+    project_root: Option<&Path>,
     log_dir: &Path,
     bus: &EventBus,
 ) -> (
@@ -128,6 +129,12 @@ pub(crate) fn start_project_file_watcher(
     Option<tokio::task::JoinHandle<()>>,
     Option<tokio::task::JoinHandle<()>>,
 ) {
+    let Some(project_root) = project_root else {
+        eprintln!(
+            "[file_watcher] rewind snapshots off: the daemon has no project — nothing to watch"
+        );
+        return (None, None, None);
+    };
     if !file_watcher::root_is_snapshot_worthy(project_root) {
         eprintln!(
             "[file_watcher] rewind snapshots off: {} is not a project root (no .git or \
@@ -168,6 +175,12 @@ pub(crate) struct GatewaySpawn {
 pub(crate) fn spawn_mode_web_gateway(
     flags: &CliFlags,
     project: &Project,
+    // The mode's project root as served to gateway routes (project-root
+    // endpoint, Changes tab, worktree scan, settings persistence). `None`
+    // = projectless daemon; the gateway routes already answer honestly
+    // ("no project root") in that case. Non-daemon modes pass
+    // `Some(project.root)`.
+    project_root: Option<PathBuf>,
     autonomy: &SharedAutonomy,
     log_dir: &Path,
     session_log: &SharedSessionLog,
@@ -210,7 +223,7 @@ pub(crate) fn spawn_mode_web_gateway(
         recording_registry: Some(recording_registry.clone()),
         session_registry: Some(session_registry.clone()),
         snapshot_dir: Some(log_dir.join("file_snapshots")),
-        project_root_for_changes: Some(project.root.clone()),
+        project_root_for_changes: project_root.clone(),
         runtime_settings: web_gateway::RuntimeSettingsState {
             external_agent: Some(shared_external_agent.clone()),
             presence_enabled: Some(runtime_presence_enabled),
@@ -245,7 +258,7 @@ pub(crate) fn spawn_mode_web_gateway(
         shared_session.clone(),
         transcriber,
         None, // task_tx: browser SubmitTask routes via the EventBus → dispatcher path
-        Some(project.root.clone()),
+        project_root,
         mcp_http_server,
         Some(peer_registry),
         advertise_urls,

--- a/src/bin/caller/types.rs
+++ b/src/bin/caller/types.rs
@@ -332,7 +332,8 @@ pub enum OutboundEvent {
         session_id: String,
         reason: String,
         /// Structured failure class for actionable errors ("unfueled" →
-        /// the dashboard offers Add API Keys). Absent for normal ends.
+        /// the dashboard offers Add API Keys; "no_project" → it points
+        /// at the project picker). Absent for normal ends.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         error_kind: Option<String>,
     },

--- a/static/app.html
+++ b/static/app.html
@@ -67779,6 +67779,7 @@ window.sessionsFuelProbe = () => ({
   fueled: dashboardControlTransport?.lastStatus?.fueled ?? null,
   haveStatus: !!dashboardControlTransport?.lastStatus,
   unfueledCached: daemonUnfueledCached,
+  projectless: daemonProjectless,
   effectiveAgent: effectiveNewSessionAgentId(),
   configuredAgent: newSessionConfiguredAgent || '',
   bannerHidden: !!document.getElementById('new-session-unfueled-banner')?.classList.contains('hidden'),

--- a/static/app.html
+++ b/static/app.html
@@ -21240,6 +21240,11 @@ async function stationStartSession() {
   }
   const name = String(stationLaunchDraft.name || '').trim();
   const requestedProjectRoot = String(stationLaunchDraft.project || '').trim();
+  if (newSessionProjectlessBlocked(requestedProjectRoot)) {
+    showControlToast?.('error', NEW_SESSION_NO_PROJECT_MESSAGE);
+    stationOpenPanel?.('system:controls', 'Pick a project directory for the session');
+    return;
+  }
   beginNewSessionSpawnNotice(
     task,
     requestedProjectRoot ? 'Checking project directory...' : 'Spawning new session...',
@@ -62594,6 +62599,7 @@ function onSessionEnded(sessionId, reason, errorKind) {
   stationCurrentTask = '';
   stationCurrentApproval = null;
   stationScheduleUpdate();
+  maybeFailPendingNewSessionSpawnNoProject(errorKind);
   maybeFailRecentNewSessionSpawn(sid, reason, errorKind);
   const meta = sid ? (sessionMetadataById.get(sid) || {}) : {};
   const win = sid ? sessionWindows.get(sid) : null;
@@ -67721,6 +67727,52 @@ const NEW_SESSION_UNFUELED_MESSAGE =
   'This daemon has no model credentials, so the internal agent can’t start. ' +
   'External agents (Codex, Claude Code) sign in with their own accounts and still work.';
 
+// ── Projectless preflight ──
+// A daemon launched outside any project reports project_root: null and has
+// no default project — a session cannot start without one. Mirrors the
+// unfueled preflight: known-projectless blocks submit with a pointer at the
+// Project field; unknown (fetch failed, older daemon) never blocks — the
+// daemon's structured no_project failure is the backstop.
+let daemonProjectless = null; // null = unknown
+
+const NEW_SESSION_NO_PROJECT_MESSAGE =
+  'This daemon has no project open. Pick a project directory in the Project field to start a session.';
+
+function newSessionPickProjectAction() {
+  return {
+    label: 'Pick project',
+    onClick: () => {
+      const input = document.getElementById('new-session-project-root');
+      input?.focus();
+      input?.scrollIntoView?.({ block: 'center' });
+    },
+  };
+}
+
+// Shared submit guard (Sessions pane + Station launch): true = blocked.
+function newSessionProjectlessBlocked(requestedProjectRoot) {
+  if (requestedProjectRoot || daemonProjectless !== true) return false;
+  setNewSessionSpawnNotice('error', NEW_SESSION_NO_PROJECT_MESSAGE, newSessionPickProjectAction());
+  return true;
+}
+
+// A no_project SessionEnded can only come from a failed create (no session
+// ever starts under it), so one arriving while a spawn is pending is ours:
+// fail the pending notice with the structured class instead of leaving it
+// to the timeout or prose-matched log entries.
+function maybeFailPendingNewSessionSpawnNoProject(errorKind) {
+  if (errorKind !== 'no_project' || !newSessionSpawnPending) return false;
+  clearNewSessionSpawnTimers();
+  clearNewSessionSpawnRecent();
+  newSessionSpawnPending = false;
+  newSessionSpawnTask = '';
+  newSessionSpawnName = '';
+  setNewSessionStartButtonPending(false);
+  setNewSessionSpawnNotice('error', NEW_SESSION_NO_PROJECT_MESSAGE, newSessionPickProjectAction());
+  showControlToast('error', NEW_SESSION_NO_PROJECT_MESSAGE);
+  return true;
+}
+
 // QA hook (stationProbe convention): the preflight inputs the
 // validate-dashboard harness asserts on — module scope hides them.
 window.sessionsFuelProbe = () => ({
@@ -67831,7 +67883,11 @@ function maybeFailRecentNewSessionSpawn(sessionId, reason, errorKind) {
   newSessionSpawnName = '';
   setNewSessionStartButtonPending(false);
   // Structured failure classes carry an action instead of prose-parsing.
-  const action = errorKind === 'unfueled' ? newSessionAddKeysAction() : null;
+  const action = errorKind === 'unfueled'
+    ? newSessionAddKeysAction()
+    : errorKind === 'no_project'
+      ? newSessionPickProjectAction()
+      : null;
   setNewSessionSpawnNotice('error', message, action);
   showControlToast('error', message);
   return true;
@@ -67919,6 +67975,10 @@ function maybeFailNewSessionSpawnFromLog(c) {
 async function loadNewSessionProjectRoot() {
   try {
     const d = await fetchProjectRoot();
+    // project_root: null = projectless daemon (a rooted daemon always
+    // reports a non-empty string). On fetch failure the flag stays
+    // unknown and never blocks.
+    daemonProjectless = !d.project_root;
     setNewSessionProjectRoot(d.project_root || '');
   } catch (e) {
     console.warn('Failed to load project root:', e);
@@ -67953,6 +68013,7 @@ async function startNewSession() {
   const attachments = pendingAttachments.map(a => a.frameId);
   const attachmentReceipt = pendingAttachments.slice();
   const requestedProjectRoot = document.getElementById('new-session-project-root')?.value.trim() || '';
+  if (newSessionProjectlessBlocked(requestedProjectRoot)) return;
   beginNewSessionSpawnNotice(
     task,
     requestedProjectRoot ? 'Checking project directory...' : 'Spawning new session...',

--- a/static/app/34-station-panes.js
+++ b/static/app/34-station-panes.js
@@ -317,6 +317,11 @@ async function stationStartSession() {
   }
   const name = String(stationLaunchDraft.name || '').trim();
   const requestedProjectRoot = String(stationLaunchDraft.project || '').trim();
+  if (newSessionProjectlessBlocked(requestedProjectRoot)) {
+    showControlToast?.('error', NEW_SESSION_NO_PROJECT_MESSAGE);
+    stationOpenPanel?.('system:controls', 'Pick a project directory for the session');
+    return;
+  }
   beginNewSessionSpawnNotice(
     task,
     requestedProjectRoot ? 'Checking project directory...' : 'Spawning new session...',

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -86,6 +86,7 @@ function onSessionEnded(sessionId, reason, errorKind) {
   stationCurrentTask = '';
   stationCurrentApproval = null;
   stationScheduleUpdate();
+  maybeFailPendingNewSessionSpawnNoProject(errorKind);
   maybeFailRecentNewSessionSpawn(sid, reason, errorKind);
   const meta = sid ? (sessionMetadataById.get(sid) || {}) : {};
   const win = sid ? sessionWindows.get(sid) : null;

--- a/static/app/55-files-ide.js
+++ b/static/app/55-files-ide.js
@@ -2448,12 +2448,59 @@ const NEW_SESSION_UNFUELED_MESSAGE =
   'This daemon has no model credentials, so the internal agent can’t start. ' +
   'External agents (Codex, Claude Code) sign in with their own accounts and still work.';
 
+// ── Projectless preflight ──
+// A daemon launched outside any project reports project_root: null and has
+// no default project — a session cannot start without one. Mirrors the
+// unfueled preflight: known-projectless blocks submit with a pointer at the
+// Project field; unknown (fetch failed, older daemon) never blocks — the
+// daemon's structured no_project failure is the backstop.
+let daemonProjectless = null; // null = unknown
+
+const NEW_SESSION_NO_PROJECT_MESSAGE =
+  'This daemon has no project open. Pick a project directory in the Project field to start a session.';
+
+function newSessionPickProjectAction() {
+  return {
+    label: 'Pick project',
+    onClick: () => {
+      const input = document.getElementById('new-session-project-root');
+      input?.focus();
+      input?.scrollIntoView?.({ block: 'center' });
+    },
+  };
+}
+
+// Shared submit guard (Sessions pane + Station launch): true = blocked.
+function newSessionProjectlessBlocked(requestedProjectRoot) {
+  if (requestedProjectRoot || daemonProjectless !== true) return false;
+  setNewSessionSpawnNotice('error', NEW_SESSION_NO_PROJECT_MESSAGE, newSessionPickProjectAction());
+  return true;
+}
+
+// A no_project SessionEnded can only come from a failed create (no session
+// ever starts under it), so one arriving while a spawn is pending is ours:
+// fail the pending notice with the structured class instead of leaving it
+// to the timeout or prose-matched log entries.
+function maybeFailPendingNewSessionSpawnNoProject(errorKind) {
+  if (errorKind !== 'no_project' || !newSessionSpawnPending) return false;
+  clearNewSessionSpawnTimers();
+  clearNewSessionSpawnRecent();
+  newSessionSpawnPending = false;
+  newSessionSpawnTask = '';
+  newSessionSpawnName = '';
+  setNewSessionStartButtonPending(false);
+  setNewSessionSpawnNotice('error', NEW_SESSION_NO_PROJECT_MESSAGE, newSessionPickProjectAction());
+  showControlToast('error', NEW_SESSION_NO_PROJECT_MESSAGE);
+  return true;
+}
+
 // QA hook (stationProbe convention): the preflight inputs the
 // validate-dashboard harness asserts on — module scope hides them.
 window.sessionsFuelProbe = () => ({
   fueled: dashboardControlTransport?.lastStatus?.fueled ?? null,
   haveStatus: !!dashboardControlTransport?.lastStatus,
   unfueledCached: daemonUnfueledCached,
+  projectless: daemonProjectless,
   effectiveAgent: effectiveNewSessionAgentId(),
   configuredAgent: newSessionConfiguredAgent || '',
   bannerHidden: !!document.getElementById('new-session-unfueled-banner')?.classList.contains('hidden'),
@@ -2558,7 +2605,11 @@ function maybeFailRecentNewSessionSpawn(sessionId, reason, errorKind) {
   newSessionSpawnName = '';
   setNewSessionStartButtonPending(false);
   // Structured failure classes carry an action instead of prose-parsing.
-  const action = errorKind === 'unfueled' ? newSessionAddKeysAction() : null;
+  const action = errorKind === 'unfueled'
+    ? newSessionAddKeysAction()
+    : errorKind === 'no_project'
+      ? newSessionPickProjectAction()
+      : null;
   setNewSessionSpawnNotice('error', message, action);
   showControlToast('error', message);
   return true;
@@ -2646,6 +2697,10 @@ function maybeFailNewSessionSpawnFromLog(c) {
 async function loadNewSessionProjectRoot() {
   try {
     const d = await fetchProjectRoot();
+    // project_root: null = projectless daemon (a rooted daemon always
+    // reports a non-empty string). On fetch failure the flag stays
+    // unknown and never blocks.
+    daemonProjectless = !d.project_root;
     setNewSessionProjectRoot(d.project_root || '');
   } catch (e) {
     console.warn('Failed to load project root:', e);
@@ -2680,6 +2735,7 @@ async function startNewSession() {
   const attachments = pendingAttachments.map(a => a.frameId);
   const attachmentReceipt = pendingAttachments.slice();
   const requestedProjectRoot = document.getElementById('new-session-project-root')?.value.trim() || '';
+  if (newSessionProjectlessBlocked(requestedProjectRoot)) return;
   beginNewSessionSpawnNotice(
     task,
     requestedProjectRoot ? 'Checking project directory...' : 'Spawning new session...',

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -66,6 +66,9 @@ impl TestRig {
             .env_remove("PRESENCE_MODEL")
             .env_remove("CU_PROVIDER")
             .env_remove("CU_MODEL")
+            // A host shell exporting the Connect rendezvous URL would make
+            // the daemon-lane tests dial out; the suite is no-network.
+            .env_remove("INTENDANT_CONNECT_RENDEZVOUS_URL")
             .env("PROVIDER", "mock");
         cmd
     }
@@ -225,6 +228,240 @@ async fn direct_mode_writes_files_through_the_runtime() {
     let written = std::fs::read_to_string(&target)
         .unwrap_or_else(|e| panic!("artifact not written ({e}):\n{}", text_of(&output)));
     assert_eq!(written, "written by the mock e2e\n");
+}
+
+/// Append a child pipe's lines into a shared buffer as they arrive.
+fn drain_pipe_into(
+    pipe: impl tokio::io::AsyncRead + Unpin + Send + 'static,
+    buf: std::sync::Arc<std::sync::Mutex<String>>,
+) -> tokio::task::JoinHandle<()> {
+    use tokio::io::AsyncBufReadExt;
+    tokio::spawn(async move {
+        let mut lines = tokio::io::BufReader::new(pipe).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if let Ok(mut guard) = buf.lock() {
+                guard.push_str(&line);
+                guard.push('\n');
+            }
+        }
+    })
+}
+
+/// Poll a shared output buffer until `needle` appears (returning the full
+/// buffer) or the timeout elapses (panicking with the buffer for context).
+async fn wait_for_output(
+    buf: &std::sync::Arc<std::sync::Mutex<String>>,
+    needle: &str,
+    timeout: Duration,
+) -> String {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let snapshot = buf.lock().map(|guard| guard.clone()).unwrap_or_default();
+        if snapshot.contains(needle) {
+            return snapshot;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("timed out waiting for {needle:?} in daemon output:\n{snapshot}");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Read WebSocket text frames until one satisfies `pred`, with a timeout.
+async fn wait_for_ws_event<S>(
+    ws: &mut S,
+    timeout: Duration,
+    mut pred: impl FnMut(&serde_json::Value) -> bool,
+) -> serde_json::Value
+where
+    S: futures_util::Stream<
+            Item = Result<
+                tokio_tungstenite::tungstenite::Message,
+                tokio_tungstenite::tungstenite::Error,
+            >,
+        > + Unpin,
+{
+    use futures_util::StreamExt;
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let remaining = deadline
+            .checked_duration_since(tokio::time::Instant::now())
+            .unwrap_or_else(|| panic!("timed out waiting for a matching /ws event"));
+        let msg = tokio::time::timeout(remaining, ws.next())
+            .await
+            .expect("timed out waiting for a /ws event")
+            .expect("/ws stream ended unexpectedly")
+            .expect("/ws read failed");
+        if let tokio_tungstenite::tungstenite::Message::Text(text) = msg {
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
+                if pred(&json) {
+                    return json;
+                }
+            }
+        }
+    }
+}
+
+/// The daemon lane, projectless: booted from an empty (markerless) temp
+/// cwd it must come up serving — no cwd baseline scan, `project_root:
+/// null` on the gateway — run a CreateSession that carries an explicit
+/// `project_root` to completion, and fail one without it with the
+/// structured `no_project` error kind instead of adopting cwd.
+#[tokio::test]
+async fn projectless_daemon_serves_and_requires_an_explicit_session_project() {
+    use futures_util::SinkExt;
+
+    let rig = TestRig::new();
+    let script = rig.write_script(&serde_json::json!({
+        "profiles": [{
+            "steps": [
+                { "content": "Working in the explicit project.",
+                  "tool_calls": [{ "name": "exec_command",
+                                   "arguments": { "nonce": 1, "command": "echo PROJECTLESS_E2E_ROUNDTRIP" } }] },
+                { "expect_transcript_contains": "PROJECTLESS_E2E_ROUNDTRIP",
+                  "content": "All work finished.",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "projectless mock run complete" } }] }
+            ]
+        }]
+    }));
+    // The session's project: a real directory, distinct from the daemon's
+    // (empty, markerless) launch cwd, passed explicitly per session.
+    let session_project = tempfile::tempdir().expect("session project dir");
+
+    let mut cmd = rig.command();
+    cmd.env("INTENDANT_MOCK_SCRIPT", &script).args([
+        "--no-tls",
+        "--autonomy",
+        "full",
+        "--web",
+        "18921", // base only: the daemon scans forward if taken; the real
+                 // port is parsed from the "Dashboard:" startup line.
+    ]);
+    let mut child = cmd.spawn().expect("spawn intendant daemon");
+    let stderr_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let stdout_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let _stderr_drain = drain_pipe_into(child.stderr.take().expect("stderr"), stderr_buf.clone());
+    let _stdout_drain = drain_pipe_into(child.stdout.take().expect("stdout"), stdout_buf.clone());
+
+    // (a) It comes up projectless and serves.
+    let stderr_so_far = wait_for_output(&stderr_buf, "Dashboard: http://", RUN_TIMEOUT).await;
+    assert!(
+        stderr_so_far.contains("Projectless daemon:"),
+        "missing the projectless startup line:\n{stderr_so_far}"
+    );
+    assert!(
+        stderr_so_far.contains("rewind snapshots off: the daemon has no project"),
+        "the projectless daemon still tried to watch a project root:\n{stderr_so_far}"
+    );
+    let port: u16 = stderr_so_far
+        .lines()
+        .find_map(|line| {
+            let url = line.strip_prefix("Dashboard: http://")?;
+            url.rsplit(':').next()?.trim().parse().ok()
+        })
+        .expect("parse the dashboard port from the startup line");
+
+    let http = reqwest::Client::new();
+    let base = format!("http://127.0.0.1:{port}");
+    let deadline = tokio::time::Instant::now() + RUN_TIMEOUT;
+    let project_root_body: serde_json::Value = loop {
+        match http.get(format!("{base}/api/project-root")).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                break resp.json().await.expect("project-root JSON")
+            }
+            _ if tokio::time::Instant::now() >= deadline => {
+                panic!("gateway never served /api/project-root");
+            }
+            _ => tokio::time::sleep(Duration::from_millis(200)).await,
+        }
+    };
+    assert!(
+        project_root_body.get("project_root").is_some_and(|v| v.is_null()),
+        "projectless daemon must report project_root: null, got {project_root_body}"
+    );
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/ws"))
+        .await
+        .expect("connect /ws");
+
+    // (c) CreateSession WITHOUT a project root: the structured failure,
+    // not a dead session and not a cwd-rooted one.
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "create_session",
+            "task": "must not start without a project",
+            "direct": true,
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send projectless create_session");
+    let ended = wait_for_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("session_ended")
+    })
+    .await;
+    assert_eq!(
+        ended.get("error_kind").and_then(|v| v.as_str()),
+        Some("no_project"),
+        "expected the structured no_project failure, got {ended}"
+    );
+    assert!(
+        ended
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .is_some_and(|reason| reason.contains("no project selected")),
+        "no_project reason should tell the user to pick a project, got {ended}"
+    );
+
+    // (b) CreateSession WITH an explicit project root runs the scripted
+    // task through the real stack to completion.
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "create_session",
+            "task": "run the scripted command in the explicit project",
+            "project_root": session_project.path().to_string_lossy(),
+            "direct": true,
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send rooted create_session");
+    let started = wait_for_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("session_started")
+            && json
+                .get("task")
+                .and_then(|v| v.as_str())
+                .is_some_and(|task| task.contains("explicit project"))
+    })
+    .await;
+    let started_id = started
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .expect("session_started carries a session id")
+        .to_string();
+    let ended = wait_for_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("session_ended")
+            && json.get("session_id").and_then(|v| v.as_str()) == Some(started_id.as_str())
+    })
+    .await;
+    assert!(
+        ended.get("error_kind").is_none_or(|v| v.is_null()),
+        "explicit-project session must end cleanly, got {ended}"
+    );
+    let logs = rig.session_logs();
+    assert!(
+        logs.contains("projectless mock run complete"),
+        "session log missing the done signal:\n{logs}"
+    );
+    assert!(
+        logs.contains("PROJECTLESS_E2E_ROUNDTRIP") || rig.turn_artifacts().contains("PROJECTLESS_E2E_ROUNDTRIP"),
+        "missing the runtime round-trip evidence"
+    );
+
+    child.kill().await.expect("stop the daemon");
 }
 
 #[tokio::test]

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -69,6 +69,14 @@ impl TestRig {
             // A host shell exporting the Connect rendezvous URL would make
             // the daemon-lane tests dial out; the suite is no-network.
             .env_remove("INTENDANT_CONNECT_RENDEZVOUS_URL")
+            // The suite is display-free by contract, but a host with a live
+            // X session at :0 (a self-hosted runner doubling as a desktop)
+            // breaks that hermeticity: the caller's vision probe finds the
+            // socket, exports DISPLAY=:0, and the runtime's fail-closed
+            // user-display gate then refuses every exec_command without a
+            // grant. Pin the virtual-display convention instead — nothing
+            // here opens an X connection, and display ids > 0 need no grant.
+            .env("DISPLAY", ":99")
             .env("PROVIDER", "mock");
         cmd
     }
@@ -267,12 +275,13 @@ async fn wait_for_output(
     }
 }
 
-/// Read WebSocket text frames until one satisfies `pred`, with a timeout.
-async fn wait_for_ws_event<S>(
+/// Read WebSocket text frames until one satisfies `pred`; `None` on
+/// timeout (callers decide whether that is fatal and what context to dump).
+async fn next_matching_ws_event<S>(
     ws: &mut S,
     timeout: Duration,
     mut pred: impl FnMut(&serde_json::Value) -> bool,
-) -> serde_json::Value
+) -> Option<serde_json::Value>
 where
     S: futures_util::Stream<
             Item = Result<
@@ -284,18 +293,16 @@ where
     use futures_util::StreamExt;
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
-        let remaining = deadline
-            .checked_duration_since(tokio::time::Instant::now())
-            .unwrap_or_else(|| panic!("timed out waiting for a matching /ws event"));
+        let remaining = deadline.checked_duration_since(tokio::time::Instant::now())?;
         let msg = tokio::time::timeout(remaining, ws.next())
             .await
-            .expect("timed out waiting for a /ws event")
+            .ok()?
             .expect("/ws stream ended unexpectedly")
             .expect("/ws read failed");
         if let tokio_tungstenite::tungstenite::Message::Text(text) = msg {
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
                 if pred(&json) {
-                    return json;
+                    return Some(json);
                 }
             }
         }
@@ -386,22 +393,37 @@ async fn projectless_daemon_serves_and_requires_an_explicit_session_project() {
         .expect("connect /ws");
 
     // (c) CreateSession WITHOUT a project root: the structured failure,
-    // not a dead session and not a cwd-rooted one.
-    ws.send(tokio_tungstenite::tungstenite::Message::Text(
-        serde_json::json!({
-            "action": "create_session",
-            "task": "must not start without a project",
-            "direct": true,
+    // not a dead session and not a cwd-rooted one. The very first control
+    // message can race daemon startup on a saturated box — the gateway
+    // task accepts /ws a beat before the supervisor's bus subscription —
+    // so retry the send until the structured failure arrives.
+    let mut ended = None;
+    for _ in 0..6 {
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::json!({
+                "action": "create_session",
+                "task": "must not start without a project",
+                "direct": true,
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send projectless create_session");
+        ended = next_matching_ws_event(&mut ws, Duration::from_secs(30), |json| {
+            json.get("event").and_then(|v| v.as_str()) == Some("session_ended")
         })
-        .to_string()
-        .into(),
-    ))
-    .await
-    .expect("send projectless create_session");
-    let ended = wait_for_ws_event(&mut ws, RUN_TIMEOUT, |json| {
-        json.get("event").and_then(|v| v.as_str()) == Some("session_ended")
-    })
-    .await;
+        .await;
+        if ended.is_some() {
+            break;
+        }
+    }
+    let ended = ended.unwrap_or_else(|| {
+        panic!(
+            "no session_ended for the projectless create; daemon stderr:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
+        )
+    });
     assert_eq!(
         ended.get("error_kind").and_then(|v| v.as_str()),
         Some("no_project"),
@@ -429,24 +451,36 @@ async fn projectless_daemon_serves_and_requires_an_explicit_session_project() {
     ))
     .await
     .expect("send rooted create_session");
-    let started = wait_for_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+    let started = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
         json.get("event").and_then(|v| v.as_str()) == Some("session_started")
             && json
                 .get("task")
                 .and_then(|v| v.as_str())
                 .is_some_and(|task| task.contains("explicit project"))
     })
-    .await;
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "rooted create never started; daemon stderr:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
+        )
+    });
     let started_id = started
         .get("session_id")
         .and_then(|v| v.as_str())
         .expect("session_started carries a session id")
         .to_string();
-    let ended = wait_for_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+    let ended = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
         json.get("event").and_then(|v| v.as_str()) == Some("session_ended")
             && json.get("session_id").and_then(|v| v.as_str()) == Some(started_id.as_str())
     })
-    .await;
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "rooted session never ended; daemon stderr:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
+        )
+    });
     assert!(
         ended.get("error_kind").is_none_or(|v| v.is_null()),
         "explicit-project session must end cleanly, got {ended}"

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -314,6 +314,11 @@ where
 /// null` on the gateway — run a CreateSession that carries an explicit
 /// `project_root` to completion, and fail one without it with the
 /// structured `no_project` error kind instead of adopting cwd.
+///
+/// "Completion" for a supervised session is `round_complete` plus the done
+/// signal in its log: by design the session then parks awaiting follow-ups
+/// (no SessionEnded on task completion); `session_ended` is asserted via an
+/// explicit stop_session afterwards.
 #[tokio::test]
 async fn projectless_daemon_serves_and_requires_an_explicit_session_project() {
     use futures_util::SinkExt;
@@ -470,21 +475,20 @@ async fn projectless_daemon_serves_and_requires_an_explicit_session_project() {
         .and_then(|v| v.as_str())
         .expect("session_started carries a session id")
         .to_string();
-    let ended = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
-        json.get("event").and_then(|v| v.as_str()) == Some("session_ended")
+    // Task completion: the loop finishes its round (done signal) and the
+    // session parks for follow-ups — by design there is no SessionEnded
+    // here, so round_complete is the completion signal.
+    next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("round_complete")
             && json.get("session_id").and_then(|v| v.as_str()) == Some(started_id.as_str())
     })
     .await
     .unwrap_or_else(|| {
         panic!(
-            "rooted session never ended; daemon stderr:\n{}",
+            "rooted session never completed its round; daemon stderr:\n{}",
             stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
         )
     });
-    assert!(
-        ended.get("error_kind").is_none_or(|v| v.is_null()),
-        "explicit-project session must end cleanly, got {ended}"
-    );
     let logs = rig.session_logs();
     assert!(
         logs.contains("projectless mock run complete"),
@@ -493,6 +497,34 @@ async fn projectless_daemon_serves_and_requires_an_explicit_session_project() {
     assert!(
         logs.contains("PROJECTLESS_E2E_ROUNDTRIP") || rig.turn_artifacts().contains("PROJECTLESS_E2E_ROUNDTRIP"),
         "missing the runtime round-trip evidence"
+    );
+
+    // The idle session ends when explicitly stopped — the one place a
+    // supervised session emits session_ended on the happy path.
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "stop_session",
+            "session_id": started_id,
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send stop_session");
+    let ended = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("session_ended")
+            && json.get("session_id").and_then(|v| v.as_str()) == Some(started_id.as_str())
+    })
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "stopped session never ended; daemon stderr:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
+        )
+    });
+    assert!(
+        ended.get("error_kind").is_none_or(|v| v.is_null()),
+        "user-stopped session must end without an error class, got {ended}"
     );
 
     child.kill().await.expect("stop the daemon");


### PR DESCRIPTION
Phase 1 of the "no project open" story: a daemon launched from a directory with no project marker runs **projectless** instead of adopting cwd as an implicit project. Removes the macos-app `~/projects/intendant-workspace` bandaid at its source.

## Design

- **Detection rule (one definition):** a root is a real project iff it carries a marker — `.git` (directory, or file for git worktrees) or `intendant.toml`. Now owned by `project::root_has_project_marker()`; the 872a64ab boot-scan gate (`file_watcher::root_is_snapshot_worthy`) delegates to it. The *daemon* shape with a markerless launch cwd runs projectless; CLI (headless/MCP) invocations keep cwd-as-project — correct for `intendant "task"` inside a repo.
- **`Option<PathBuf>` through the daemon path:** `main` computes `daemon_project_root` once (from flags + the marker) and threads it through `run_daemon`, `DaemonConfig`, `SessionSupervisorConfig.project_root`, `spawn_mode_web_gateway`, and `start_project_file_watcher`. The gateway routes were already `Option`-ready (`project_root: null`, settings POST 400s "No project root", worktree scan tolerates None) — the daemon just never passed `None` before.
- **Fail-closed consequences of projectless** (absence of a project shrinks scope, never widens it):
  - no file watcher at all (one clear log line), on top of the existing non-project-root scan gate;
  - sandbox write scope = scratch + log dir + `~/.intendant` + explicit **absolute** grants only (`SandboxConfig::projectless`); a relative grant with no project to anchor to is dropped loudly;
  - no project-root `.env` layer at startup (the marker gate also stops the redundant cwd-fallback double-report on CLI runs; the ordinary cwd walk-up still applies);
  - the daemon's base session meta records no project; the git-vitals producer is skipped.
- **Sessions:** every create/resume funnels through one choke point. Explicit `project_root` works exactly as before. A `CreateSession` without one on a projectless daemon fails with structured `SessionEnded { error_kind: "no_project" }` (the unfueled precedent) plus the log-shaped "Session create failed:" line the dashboard already keys on, and an honest failed-session summary. Native resume gains a last-resort fallback to the session's own `session_meta.json` root (reachable only when projectless — rooted daemons behave byte-for-byte as before); external resume: explicit → persisted config → daemon default → structured failure.
- **Dashboard (minimal):** the New Session submit path blocks when the daemon reports `project_root: null` and no project is entered (existing spawn-notice mechanism, "Pick project" action focusing the Project field); the Station launch pane uses the same guard; a `no_project` SessionEnded fails a pending spawn notice with the same action. No wasm changes — presence-web already passes `error_kind` through generically, so `static/wasm-web` is untouched.
- **macos-app:** the synthetic-workspace fabrication and marker walk-up are deleted; cwd is plainly `$HOME`. The workspace dir remains supported as user data — it just stops being auto-created/assumed.

## Evidence

- `cargo check --bins` and `cargo check --test e2e` clean; new unit tests added (projectless sandbox scope parity, marker-gated resolve errors, no-project resolve classes).
- New headless e2e scenario `projectless_daemon_serves_and_requires_an_explicit_session_project` (mock provider, no keys/network/display): boots the daemon from an empty temp cwd, asserts the projectless startup lines + `project_root: null` over HTTP, drives `/ws` for (a) a rooted CreateSession completing a scripted exec round-trip through the real runtime and (b) the structured `no_project` failure for a rootless one — the required cross-platform check runs it on all three platforms.
- Local full battery (`cargo test --bins`, `cargo test --test e2e`, clippy, manual projectless boot check) is running on a heavily loaded box; results will be posted as a PR comment before review sign-off.

## Phase 2 (tracked in the design handoff)

- Dashboard "no project open" empty state (project picker front-and-center) + the Activity-composer path (`StartTask` with no session currently gets only the structured failure, no composer UX).
- Per-session sandbox write scope (`INTENDANT_SANDBOX_WRITE_PATHS` is daemon-global; with `--sandbox` a projectless daemon's sessions can't write their own project root — pre-existing, now more visible).
- An explicitly configured default project for daemons; `--continue` on a projectless daemon; settings persistence without a project root (global config home); terminals defaulting to a session's project; fresh-VPS/service re-verification under projectless.



---
Supersedes #35: GitHub stopped creating check suites for that PR's heads (zero suites for two consecutive pushes; reopen and synchronize both undelivered), so it was recreated to re-mint Actions dispatch. Diagnosis history and the e2e root-cause comments live on #35.
