### PR TITLE
Hoist TokenUsage + session-vitals into core; dev-profile dep optimization

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,9 +12,19 @@ final-status-level = "slow"
 # Per-test timings for slow-test audits (target/nextest/default/junit.xml).
 path = "junit.xml"
 
-# Heavy-crypto tests: subprocess `security` CLI (serialized behind
-# securityd) + real keygen; give them headroom instead of false timeouts
-# on a loaded box.
+# macOS keychain reality: the access backend is the real keychain, so any
+# test that adds a peer or touches an identity shells out to `security`
+# (serialized behind securityd) and pays 30-60s — rustc optimization
+# cannot help a subprocess, and the affected tests span peer::, access::,
+# startup::peer_boot, and the web_gateway peer-API routes. Until the
+# access backend is test-injectable (planned), macOS gets a realistic
+# global ceiling; Linux/Windows keep the tight default above.
+[[profile.default.overrides]]
+platform = 'cfg(target_os = "macos")'
+slow-timeout = { period = "30s", terminate-after = 8 }
+
+# Heavy-crypto tests (subprocess `security` import, real keygen) need
+# headroom on loaded Linux boxes too.
 [[profile.default.overrides]]
 filter = 'test(/p12_|_recert|keychain/)'
 slow-timeout = { period = "60s", terminate-after = 4 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -264,10 +264,17 @@ tokio = { version = "1.0", features = ["test-util"] }
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 security-framework = "3"
 
-# The access layer generates RSA daemon certs (RustCrypto `rsa`); keygen is
-# pure-Rust bignum math that runs ~25s per key unoptimized, and every
-# cert-touching test pays it. Optimizing just the arithmetic crates keeps
-# dev builds debuggable while making keygen near-release speed.
+# Optimize external dependencies even in dev builds. The pure-Rust crypto
+# stack (RustCrypto rsa/num-bigint-dig keygen, the p12 3DES/SHA-1 bundle
+# path) runs 10-50x slower unoptimized and every cert-touching test pays
+# it — RSA keygen alone was ~25s/key, and macOS peer-identity tests still
+# took 60s+ with only the rsa crates optimized. `"*"` matches
+# non-workspace crates only: our own code stays opt-level 0 and fully
+# debuggable, and deps rarely rebuild so the one-time cost is amortized
+# immediately.
+[profile.dev.package."*"]
+opt-level = 2
+# The bignum arithmetic under RSA keygen wants full optimization.
 [profile.dev.package.rsa]
 opt-level = 3
 [profile.dev.package.num-bigint-dig]

--- a/crates/intendant-core/src/lib.rs
+++ b/crates/intendant-core/src/lib.rs
@@ -9,3 +9,5 @@ pub mod autonomy;
 pub mod error;
 pub mod frames;
 pub mod net;
+pub mod usage;
+pub mod vitals;

--- a/crates/intendant-core/src/usage.rs
+++ b/crates/intendant-core/src/usage.rs
@@ -1,0 +1,34 @@
+//! Normalized per-request token accounting, shared by every provider
+//! parser, the conversation/session layers, and the event vocabulary.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TokenUsage {
+    /// Full prompt-side context of the request, including cache reads and
+    /// cache writes. Every provider parser normalizes to this convention —
+    /// `cached_tokens` and `cache_creation_tokens` are subsets.
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+    pub total_tokens: u64,
+    /// Tokens served from cache (subset of prompt_tokens, cheaper pricing).
+    #[serde(default)]
+    pub cached_tokens: u64,
+    /// Tokens written to cache this request (subset of prompt_tokens;
+    /// Anthropic bills these at a premium — providers without a write
+    /// concept leave 0).
+    #[serde(default)]
+    pub cache_creation_tokens: u64,
+    /// Prompt-cache TTL implied by this response's cache writes (Anthropic
+    /// 300s default, 3600s with the extended-TTL beta). `None` when the
+    /// response makes no flavor statement — consumers keep the last known
+    /// value or fall back to a provider default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_ttl_seconds: Option<u32>,
+    /// Provider rate-limit windows read from this response's headers
+    /// (Anthropic `anthropic-ratelimit-*`; empty for providers or
+    /// transports that expose none — the credential-egress relay strips
+    /// headers).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rate_limit_windows: Vec<crate::vitals::SessionLimitWindow>,
+}

--- a/crates/intendant-core/src/vitals.rs
+++ b/crates/intendant-core/src/vitals.rs
@@ -1,0 +1,74 @@
+//! Session vitals: the git / prompt-cache / rate-limit chips shown by
+//! the dashboard and Station (the operator-statusline port). Plain
+//! data, shared by providers, the session supervisor, and frontends.
+
+use serde::{Deserialize, Serialize};
+
+/// Per-session working-tree/branch state for the vitals chips (the
+/// statusline-port git segment). All probes are fetch-free reads of local
+/// refs; `merge_parity` is `"clean"` / `"conflict"` from an in-memory
+/// `git merge-tree`, or empty when not applicable (identical refs, old
+/// git). `unpushed` is `None` when no upstream is configured — a visible
+/// zero means "checked and synced", absence means "nothing to check".
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionGitVitals {
+    pub branch: String,
+    pub dirty_files: u32,
+    pub ahead: u32,
+    pub behind: u32,
+    /// The comparison ref for ahead/behind (e.g. `origin/main`).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub primary_ref: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub merge_parity: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unpushed: Option<u32>,
+    /// Primary branch's unpushed count, shown when the session is not on
+    /// the primary branch itself.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_unpushed: Option<u32>,
+}
+
+/// Prompt-cache lifecycle for the vitals chips: `hit_pct` is the share of
+/// the latest request's prompt read from cache; the TTL countdown derives
+/// client-side from `last_activity_epoch + ttl_seconds` so no per-second
+/// events are needed.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionCacheVitals {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hit_pct: Option<u8>,
+    /// Unix seconds of the last usage-bearing provider activity.
+    pub last_activity_epoch: u64,
+    /// Provider prompt-cache TTL in seconds; `None` when the provider's TTL
+    /// is unknown (the countdown is hidden, the hit receipt still shows).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl_seconds: Option<u32>,
+}
+
+/// One provider rate-limit window (subscription 5h/7d, per-minute API
+/// windows, …) for the vitals gauges.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionLimitWindow {
+    pub label: String,
+    pub used_pct: u8,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resets_at_epoch: Option<u64>,
+}
+
+/// Per-session vitals (git / prompt-cache / rate limits) shown by the
+/// dashboard and Station — the port of the operator statusline. Sections
+/// are independent: producers fill what they know, frontends hide what is
+/// absent.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionVitals {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git: Option<SessionGitVitals>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache: Option<SessionCacheVitals>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub limits: Vec<SessionLimitWindow>,
+}

--- a/src/bin/caller/provider.rs
+++ b/src/bin/caller/provider.rs
@@ -70,35 +70,9 @@ fn parse_sse_line(line: &str) -> Option<(&str, &str)> {
 /// Streaming timeout for SSE connections (10 minutes).
 const STREAM_TIMEOUT: Duration = Duration::from_secs(600);
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct TokenUsage {
-    /// Full prompt-side context of the request, including cache reads and
-    /// cache writes. Every provider parser normalizes to this convention —
-    /// `cached_tokens` and `cache_creation_tokens` are subsets.
-    pub prompt_tokens: u64,
-    pub completion_tokens: u64,
-    pub total_tokens: u64,
-    /// Tokens served from cache (subset of prompt_tokens, cheaper pricing).
-    #[serde(default)]
-    pub cached_tokens: u64,
-    /// Tokens written to cache this request (subset of prompt_tokens;
-    /// Anthropic bills these at a premium — providers without a write
-    /// concept leave 0).
-    #[serde(default)]
-    pub cache_creation_tokens: u64,
-    /// Prompt-cache TTL implied by this response's cache writes (Anthropic
-    /// 300s default, 3600s with the extended-TTL beta). `None` when the
-    /// response makes no flavor statement — consumers keep the last known
-    /// value or fall back to a provider default.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cache_ttl_seconds: Option<u32>,
-    /// Provider rate-limit windows read from this response's headers
-    /// (Anthropic `anthropic-ratelimit-*`; empty for providers or
-    /// transports that expose none — the credential-egress relay strips
-    /// headers).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub rate_limit_windows: Vec<crate::types::SessionLimitWindow>,
-}
+// TokenUsage is hoisted to intendant-core (its consumers span the event
+// vocabulary and session layers); re-exported at the old mount point.
+pub use intendant_core::usage::TokenUsage;
 
 /// Parse Anthropic's per-minute rate-limit headers into vitals windows.
 /// `-reset` is RFC 3339; a missing or unparsable header degrades to a

--- a/src/bin/caller/types.rs
+++ b/src/bin/caller/types.rs
@@ -131,74 +131,11 @@ pub struct SessionGoal {
     pub token_budget: Option<u64>,
 }
 
-/// Per-session working-tree/branch state for the vitals chips (the
-/// statusline-port git segment). All probes are fetch-free reads of local
-/// refs; `merge_parity` is `"clean"` / `"conflict"` from an in-memory
-/// `git merge-tree`, or empty when not applicable (identical refs, old
-/// git). `unpushed` is `None` when no upstream is configured — a visible
-/// zero means "checked and synced", absence means "nothing to check".
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SessionGitVitals {
-    pub branch: String,
-    pub dirty_files: u32,
-    pub ahead: u32,
-    pub behind: u32,
-    /// The comparison ref for ahead/behind (e.g. `origin/main`).
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub primary_ref: String,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub merge_parity: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub unpushed: Option<u32>,
-    /// Primary branch's unpushed count, shown when the session is not on
-    /// the primary branch itself.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub primary_unpushed: Option<u32>,
-}
-
-/// Prompt-cache lifecycle for the vitals chips: `hit_pct` is the share of
-/// the latest request's prompt read from cache; the TTL countdown derives
-/// client-side from `last_activity_epoch + ttl_seconds` so no per-second
-/// events are needed.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SessionCacheVitals {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub hit_pct: Option<u8>,
-    /// Unix seconds of the last usage-bearing provider activity.
-    pub last_activity_epoch: u64,
-    /// Provider prompt-cache TTL in seconds; `None` when the provider's TTL
-    /// is unknown (the countdown is hidden, the hit receipt still shows).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ttl_seconds: Option<u32>,
-}
-
-/// One provider rate-limit window (subscription 5h/7d, per-minute API
-/// windows, …) for the vitals gauges.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SessionLimitWindow {
-    pub label: String,
-    pub used_pct: u8,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub resets_at_epoch: Option<u64>,
-}
-
-/// Per-session vitals (git / prompt-cache / rate limits) shown by the
-/// dashboard and Station — the port of the operator statusline. Sections
-/// are independent: producers fill what they know, frontends hide what is
-/// absent.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SessionVitals {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub git: Option<SessionGitVitals>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cache: Option<SessionCacheVitals>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub limits: Vec<SessionLimitWindow>,
-}
+// Session-vitals family: hoisted to intendant-core; re-exported here so
+// existing `crate::types::Session*Vitals` paths keep working.
+pub use intendant_core::vitals::{
+    SessionCacheVitals, SessionGitVitals, SessionLimitWindow, SessionVitals,
+};
 
 /// Normalized region in a shared display view.
 ///


### PR DESCRIPTION
Two commits continuing the workspace-extraction program and the test-speed work:

**1. Core hoists (the types+event unlock).** `TokenUsage` (provider.rs) and the session-vitals family (`SessionVitals` / `SessionGitVitals` / `SessionCacheVitals` / `SessionLimitWindow`, types.rs) are plain shared data whose consumers span the event vocabulary, session layers, and frontends. They move to `intendant-core` (`usage.rs`, `vitals.rs`) with re-exports at the old mount points, so every existing `crate::provider::TokenUsage` / `crate::types::Session*` path keeps compiling. This removes the type-level `event → provider` edge that blocked the planned types+event descent into core.

**2. Dev-profile follow-up with macOS measurements.** Optimizing only the rsa crates (#34) left macOS peer-identity tests at 60s+: the access backend there is the real keychain, and subprocess `security` calls serialized behind `securityd` are beyond any rustc flag.
- `[profile.dev.package."*"] opt-level = 2` (workspace crates stay 0 and debuggable): covers the whole pure-Rust crypto stack (p12 3DES/SHA-1, x509) — worst keychain test 61.8s → 37.7s, and the Linux full suite drops to 15.9s. Deps rebuild once.
- nextest gets a macOS-wide slow-timeout (30s × 8) while Linux/Windows keep 15s × 2 — the keychain-bound tests span `peer::`, `access::`, `startup::peer_boot`, and the web_gateway peer-API routes, so per-family filters were whack-a-mole.
- The real fix is queued as the next program item: a test-injectable access backend, so unit tests stop talking to the developer's actual keychain entirely.

Verification: full bins suite green on macOS under the new ceilings and on Linux (2,662/2,662 in 15.9s); lib crates green on both (597/597 Linux); clippy at the main baseline; e2e/smokes validated by the queue's clean runners as usual.