### PR TITLE
Connect: knock-ceremony hardening + first-owner bootstrap

### DIFF
--- a/docs/src/self-hosted-rendezvous.md
+++ b/docs/src/self-hosted-rendezvous.md
@@ -84,7 +84,29 @@ protocol sealed each claim.
 
 Claiming grants **no authority** — sessions still resolve against the
 daemon's local IAM (see the role ceilings and org lanes in the trust
-chapter).
+chapter) — with one deliberate, tightly-scoped exception below.
+
+## First-owner bootstrap (fresh boxes)
+
+A daemon whose local IAM is completely empty (no principals, no grants —
+a fresh VPS) **mints its own claim phrase** instead of accepting a
+service-minted one: it registers only the SHA-256 of the normalized
+phrase, so the rendezvous can route a claim but never sees plaintext.
+The claim page hashes what the user types (plaintext codes stop leaving
+the browser altogether) and, when the service answers
+`needs_bootstrap_arm`, arms the claim: it loads-or-mints this origin's
+browser identity key and posts it with an HMAC tag keyed by the phrase,
+binding that exact key and account. The daemon recomputes the tag — a
+valid tag proves the claimer read the phrase off the box (the same proof
+SSH access would be) and endorses exactly that key, so the daemon
+enrolls it as `role:root` (recorded with the sentinel origin
+`connect-bootstrap`, which no hosted-origin role ceiling caps) and only
+then co-signs the claim. A relay cannot substitute its own key (the tag
+would not verify), a wrong phrase refuses the whole claim with the real
+reason surfaced to the page, and the window closes forever the moment
+any principal or grant exists. This completes the zero-install story:
+`curl … | sh` on a fresh box, read twelve words from its log, and the
+browser that claims it owns it.
 
 Bindings are releasable from both sides, and both paths append
 `daemon_unclaimed` transparency-log entries: the account owner revokes

--- a/docs/src/trust-architecture.md
+++ b/docs/src/trust-architecture.md
@@ -112,7 +112,7 @@ fully rolled out:
 | Your anchor daemon | Full compromise | It already runs your agent; nothing new is delegated to it |
 | Another daemon of yours | That machine's authority | Each daemon is its own authority island |
 | Org portal daemon (guest lane) | The guest's org-scoped session | Blast radius = the org's own resources; self-defeating |
-| Rendezvous / signaling | Denial of service; first-introduction name games | Channels bind to daemon keys; claim phrases bind keys out of band; daemons co-sign claim bindings (v2 proofs) and flag asserted owners they never acknowledged |
+| Rendezvous / signaling | Denial of service; first-introduction name games | Channels bind to daemon keys; claim phrases bind keys out of band; daemons co-sign claim bindings (v2 proofs) and flag asserted owners they never acknowledged; first-owner bootstrap phrases are daemon-minted (the service holds only a hash, so it cannot enroll a key of its own) |
 | TURN relay | Denial of service; traffic analysis | Sees only ciphertext |
 | Fleet metadata store | Denial of service | Records are client-signed (and encrypted where private); clients verify |
 | Name directory | Handle confusion at first introduction | Key-first identity; handles are labels; org keys sign membership; append-only transparency log over all name bindings (STH pinned + consistency-verified by browsers; inclusion proofs on claims), optional DNS/GitHub attestation badges, invite-gated registration + reserved handles + dormant-handle reclamation |

--- a/src/bin/caller/access/client_key.rs
+++ b/src/bin/caller/access/client_key.rs
@@ -28,6 +28,13 @@ use crate::daemon_identity::b64u;
 use base64::Engine as _;
 
 pub const CLIENT_KEY_OFFER_PROTOCOL: &str = "intendant-client-key-offer-v1";
+/// v2 extends the signed payload with the browser's own account claim
+/// (`\n{account_user_id}\n{account_name}`), so the account shown on a
+/// pending enrollment can be **attested by the device key** instead of
+/// taken from whatever the signaling relay asserts. Old browsers keep
+/// signing v1; a v1 offer carrying account fields is rejected outright —
+/// nothing may ride outside the signature.
+pub const CLIENT_KEY_OFFER_PROTOCOL_V2: &str = "intendant-client-key-offer-v2";
 
 /// Accept signatures whose timestamp is at most this far from daemon time in
 /// either direction. Generous enough for clock skew, small enough that a
@@ -45,6 +52,10 @@ pub struct VerifiedClientKey {
     pub fingerprint: String,
     /// base64url of the raw public key point, retained for display/audit.
     pub public_key_b64u: String,
+    /// `(account_user_id, account_name)` covered by a v2 signature — the
+    /// device key itself vouched for this account claim. `None` on v1
+    /// offers (any account hint then rests on the relay's word).
+    pub attested_account: Option<(String, String)>,
 }
 
 /// Stable fingerprint for a raw P-256 public key point.
@@ -63,7 +74,7 @@ pub fn is_client_key_fingerprint(value: &str) -> bool {
             .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
 }
 
-/// The exact byte string a client signs for an offer.
+/// The exact byte string a client signs for a v1 offer.
 pub fn client_key_offer_payload(
     daemon_id: &str,
     client_nonce: &str,
@@ -73,6 +84,23 @@ pub fn client_key_offer_payload(
     let sdp_digest = b64u(ring::digest::digest(&ring::digest::SHA256, sdp.as_bytes()).as_ref());
     format!("{CLIENT_KEY_OFFER_PROTOCOL}\n{daemon_id}\n{client_nonce}\n{sdp_digest}\n{ts_unix_ms}")
         .into_bytes()
+}
+
+/// The exact byte string a client signs for a v2 offer (v1 plus the
+/// browser's own account claim). Mirrored by the dashboard JS signer.
+pub fn client_key_offer_payload_v2(
+    daemon_id: &str,
+    client_nonce: &str,
+    sdp: &str,
+    ts_unix_ms: i64,
+    account_user_id: &str,
+    account_name: &str,
+) -> Vec<u8> {
+    let sdp_digest = b64u(ring::digest::digest(&ring::digest::SHA256, sdp.as_bytes()).as_ref());
+    format!(
+        "{CLIENT_KEY_OFFER_PROTOCOL_V2}\n{daemon_id}\n{client_nonce}\n{sdp_digest}\n{ts_unix_ms}\n{account_user_id}\n{account_name}"
+    )
+    .into_bytes()
 }
 
 /// Verify a signed offer. `daemon_id` must be the daemon's own expectation
@@ -89,6 +117,50 @@ pub fn verify_client_key_offer(
     sdp: &str,
     now_unix_ms: i64,
 ) -> Result<VerifiedClientKey, String> {
+    let payload = client_key_offer_payload(daemon_id, client_nonce, sdp, ts_unix_ms);
+    verify_signed_offer(client_key_b64u, signature_b64u, ts_unix_ms, now_unix_ms, &payload)
+        .map(|(fingerprint, public_key_b64u)| VerifiedClientKey {
+            fingerprint,
+            public_key_b64u,
+            attested_account: None,
+        })
+}
+
+pub fn verify_client_key_offer_v2(
+    client_key_b64u: &str,
+    signature_b64u: &str,
+    ts_unix_ms: i64,
+    daemon_id: &str,
+    client_nonce: &str,
+    sdp: &str,
+    now_unix_ms: i64,
+    account_user_id: &str,
+    account_name: &str,
+) -> Result<VerifiedClientKey, String> {
+    let payload = client_key_offer_payload_v2(
+        daemon_id,
+        client_nonce,
+        sdp,
+        ts_unix_ms,
+        account_user_id,
+        account_name,
+    );
+    verify_signed_offer(client_key_b64u, signature_b64u, ts_unix_ms, now_unix_ms, &payload)
+        .map(|(fingerprint, public_key_b64u)| VerifiedClientKey {
+            fingerprint,
+            public_key_b64u,
+            attested_account: Some((account_user_id.to_string(), account_name.to_string())),
+        })
+}
+
+/// Shared key/signature/timestamp mechanics for every payload version.
+fn verify_signed_offer(
+    client_key_b64u: &str,
+    signature_b64u: &str,
+    ts_unix_ms: i64,
+    now_unix_ms: i64,
+    payload: &[u8],
+) -> Result<(String, String), String> {
     let engine = &base64::engine::general_purpose::URL_SAFE_NO_PAD;
     let key = engine
         .decode(client_key_b64u.trim())
@@ -112,14 +184,10 @@ pub fn verify_client_key_offer(
             "client key signature timestamp is {skew}ms from daemon time (max {CLIENT_KEY_MAX_SKEW_MS}ms)"
         ));
     }
-    let payload = client_key_offer_payload(daemon_id, client_nonce, sdp, ts_unix_ms);
     ring::signature::UnparsedPublicKey::new(&ring::signature::ECDSA_P256_SHA256_FIXED, &key)
-        .verify(&payload, &signature)
+        .verify(payload, &signature)
         .map_err(|_| "client key signature verification failed".to_string())?;
-    Ok(VerifiedClientKey {
-        fingerprint: client_key_fingerprint(&key),
-        public_key_b64u: b64u(&key),
-    })
+    Ok((client_key_fingerprint(&key), b64u(&key)))
 }
 
 /// Optional client-key fields as they appear in offer payloads, shared by the
@@ -132,6 +200,16 @@ pub struct ClientKeyOfferFields {
     pub client_key_sig: Option<String>,
     #[serde(default)]
     pub client_key_ts: Option<i64>,
+    /// Which offer payload the signature covers. Absent/empty = v1
+    /// (browsers that predate the field always signed v1).
+    #[serde(default)]
+    pub client_key_proto: Option<String>,
+    /// Browser-claimed account identity — only meaningful under a v2
+    /// signature, which covers these exact strings.
+    #[serde(default)]
+    pub client_key_account_user_id: Option<String>,
+    #[serde(default)]
+    pub client_key_account_name: Option<String>,
 }
 
 impl ClientKeyOfferFields {
@@ -151,6 +229,10 @@ impl ClientKeyOfferFields {
     /// - `Err(_)` when a key was offered but does not verify — callers must
     ///   fail closed rather than fall back, so a relay cannot strip or corrupt
     ///   the binding to downgrade a key-authenticated session.
+    ///
+    /// Version dispatch is strict: account fields on a v1 offer are an
+    /// error (they would be riding outside the signature), and an unknown
+    /// protocol is an error rather than a fallback.
     pub fn verify(
         &self,
         daemon_id: &str,
@@ -169,7 +251,51 @@ impl ClientKeyOfferFields {
         let ts = self
             .client_key_ts
             .ok_or_else(|| "client key offer is missing its timestamp".to_string())?;
-        verify_client_key_offer(key, sig, ts, daemon_id, client_nonce, sdp, now_unix_ms).map(Some)
+        let account_user_id = self
+            .client_key_account_user_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty());
+        let account_name = self
+            .client_key_account_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty());
+        let proto = self
+            .client_key_proto
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .unwrap_or(CLIENT_KEY_OFFER_PROTOCOL);
+        match proto {
+            CLIENT_KEY_OFFER_PROTOCOL => {
+                if account_user_id.is_some() || account_name.is_some() {
+                    return Err(
+                        "client key account fields require a v2-signed offer".to_string()
+                    );
+                }
+                verify_client_key_offer(key, sig, ts, daemon_id, client_nonce, sdp, now_unix_ms)
+                    .map(Some)
+            }
+            CLIENT_KEY_OFFER_PROTOCOL_V2 => {
+                let account_user_id = account_user_id.ok_or_else(|| {
+                    "v2 client key offer is missing its account user id".to_string()
+                })?;
+                verify_client_key_offer_v2(
+                    key,
+                    sig,
+                    ts,
+                    daemon_id,
+                    client_nonce,
+                    sdp,
+                    now_unix_ms,
+                    account_user_id,
+                    account_name.unwrap_or(""),
+                )
+                .map(Some)
+            }
+            other => Err(format!("unsupported client key offer protocol {other:?}")),
+        }
     }
 }
 
@@ -317,6 +443,7 @@ mod tests {
             client_key: Some("AAAA".to_string()),
             client_key_sig: None,
             client_key_ts: None,
+            ..Default::default()
         };
         assert!(fields.verify("d", "n", "sdp", 0).is_err());
 
@@ -329,6 +456,7 @@ mod tests {
             client_key: Some(key.raw_point_b64u.clone()),
             client_key_sig: Some(sign(&key, "d", "n", "sdp", ts)),
             client_key_ts: Some(ts),
+            ..Default::default()
         };
         let verified = fields.verify("d", "n", "sdp", ts).unwrap().unwrap();
         assert_eq!(
@@ -339,5 +467,70 @@ mod tests {
                     .unwrap()
             )
         );
+        assert_eq!(verified.attested_account, None);
+    }
+
+    fn sign_v2(
+        key: &TestKey,
+        daemon_id: &str,
+        nonce: &str,
+        sdp: &str,
+        ts: i64,
+        user: &str,
+        name: &str,
+    ) -> String {
+        let rng = ring::rand::SystemRandom::new();
+        let payload = client_key_offer_payload_v2(daemon_id, nonce, sdp, ts, user, name);
+        b64u(key.pair.sign(&rng, &payload).unwrap().as_ref())
+    }
+
+    #[test]
+    fn v2_offer_attests_the_account_and_binds_it() {
+        let key = generate_key();
+        let ts = 1_700_000_000_000;
+        let fields = ClientKeyOfferFields {
+            client_key: Some(key.raw_point_b64u.clone()),
+            client_key_sig: Some(sign_v2(
+                &key, "daemon-a", "nonce-1", "v=0 sdp", ts, "user-1", "alice",
+            )),
+            client_key_ts: Some(ts),
+            client_key_proto: Some(CLIENT_KEY_OFFER_PROTOCOL_V2.to_string()),
+            client_key_account_user_id: Some("user-1".to_string()),
+            client_key_account_name: Some("alice".to_string()),
+        };
+        let verified = fields
+            .verify("daemon-a", "nonce-1", "v=0 sdp", ts)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            verified.attested_account,
+            Some(("user-1".to_string(), "alice".to_string()))
+        );
+
+        // A relay swapping the claimed account fails the signature.
+        let swapped = ClientKeyOfferFields {
+            client_key_account_user_id: Some("mallory-user".to_string()),
+            ..fields.clone()
+        };
+        assert!(swapped.verify("daemon-a", "nonce-1", "v=0 sdp", ts).is_err());
+
+        // Account fields glued onto a v1-signed offer are rejected: nothing
+        // may ride outside the signature.
+        let glued = ClientKeyOfferFields {
+            client_key: Some(key.raw_point_b64u.clone()),
+            client_key_sig: Some(sign(&key, "daemon-a", "nonce-1", "v=0 sdp", ts)),
+            client_key_ts: Some(ts),
+            client_key_proto: None,
+            client_key_account_user_id: Some("mallory-user".to_string()),
+            client_key_account_name: None,
+        };
+        assert!(glued.verify("daemon-a", "nonce-1", "v=0 sdp", ts).is_err());
+
+        // Unknown protocol versions fail closed instead of falling back.
+        let unknown = ClientKeyOfferFields {
+            client_key_proto: Some("intendant-client-key-offer-v9".to_string()),
+            ..fields
+        };
+        assert!(unknown.verify("daemon-a", "nonce-1", "v=0 sdp", ts).is_err());
     }
 }

--- a/src/bin/caller/access/enrollment.rs
+++ b/src/bin/caller/access/enrollment.rs
@@ -33,6 +33,11 @@ pub struct PendingClientKeyEnrollment {
     /// Human hint from the offer's account identity, e.g. "@alice". Display
     /// only — never an authorization input.
     pub account_hint: String,
+    /// Whether the account hint was covered by the device key's own v2
+    /// offer signature (attested) or merely asserted by the signaling
+    /// relay. Display provenance for the approval card, nothing more.
+    #[serde(default)]
+    pub account_attested: bool,
     pub first_seen_unix_ms: i64,
     pub last_seen_unix_ms: i64,
     pub attempts: u32,
@@ -55,6 +60,7 @@ pub fn record_refused_client_key(
     origin: &str,
     transport: &str,
     account_hint: &str,
+    account_attested: bool,
     now_unix_ms: i64,
 ) {
     let fingerprint = fingerprint.trim();
@@ -71,6 +77,7 @@ pub fn record_refused_client_key(
         entry.attempts = entry.attempts.saturating_add(1);
         if !account_hint.trim().is_empty() {
             entry.account_hint = account_hint.trim().to_string();
+            entry.account_attested = account_attested;
         }
         if !origin.trim().is_empty() {
             entry.origin = origin.trim().to_string();
@@ -94,6 +101,7 @@ pub fn record_refused_client_key(
         origin: origin.trim().to_string(),
         transport: transport.trim().to_string(),
         account_hint: account_hint.trim().to_string(),
+        account_attested,
         first_seen_unix_ms: now_unix_ms,
         last_seen_unix_ms: now_unix_ms,
         attempts: 1,
@@ -143,6 +151,7 @@ mod tests {
             "https://connect.intendant.dev",
             "connect-dashboard-control",
             "@alice",
+            false,
             now,
         );
         record_refused_client_key(
@@ -151,18 +160,35 @@ mod tests {
             "",
             "connect-dashboard-control",
             "",
+            false,
             now + 10,
         );
         let pending = pending_enrollments(now + 20);
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].attempts, 2);
         assert_eq!(pending[0].account_hint, "@alice");
+        assert!(!pending[0].account_attested);
         assert_eq!(pending[0].origin, "https://connect.intendant.dev");
         assert_eq!(pending[0].first_seen_unix_ms, now);
         assert_eq!(pending[0].last_seen_unix_ms, now + 10);
 
-        // TTL prunes stale entries.
-        assert!(pending_enrollments(now + PENDING_TTL_MS + 11).is_empty());
+        // A later attested retry upgrades the hint's provenance (and a
+        // still-later unattested hint downgrades it — latest wins, the
+        // flag always describes the CURRENT hint).
+        record_refused_client_key(
+            "fp-a",
+            "pk-a",
+            "",
+            "connect-dashboard-control",
+            "@alice",
+            true,
+            now + 15,
+        );
+        assert!(pending_enrollments(now + 20)[0].account_attested);
+
+        // TTL prunes stale entries (last activity was the attested retry
+        // at now + 15).
+        assert!(pending_enrollments(now + PENDING_TTL_MS + 16).is_empty());
 
         // Cap evicts the stalest entry, and take() removes on decide.
         clear_for_tests();
@@ -173,6 +199,7 @@ mod tests {
                 "",
                 "connect-dashboard-control",
                 "",
+                false,
                 now + i as i64,
             );
         }

--- a/src/bin/caller/connect_rendezvous.rs
+++ b/src/bin/caller/connect_rendezvous.rs
@@ -92,6 +92,14 @@ struct RendezvousEvent {
     client_key_sig: Option<String>,
     #[serde(default)]
     client_key_ts: Option<i64>,
+    /// v2 offer-signature fields (see `access::client_key`): the payload
+    /// version plus the browser's own account claim, relayed verbatim.
+    #[serde(default)]
+    client_key_proto: Option<String>,
+    #[serde(default)]
+    client_key_account_user_id: Option<String>,
+    #[serde(default)]
+    client_key_account_name: Option<String>,
     #[serde(default)]
     org_grant: Option<serde_json::Value>,
     #[serde(default)]
@@ -761,6 +769,9 @@ async fn handle_event(
                 client_key: event.client_key.clone(),
                 client_key_sig: event.client_key_sig.clone(),
                 client_key_ts: event.client_key_ts,
+                client_key_proto: event.client_key_proto.clone(),
+                client_key_account_user_id: event.client_key_account_user_id.clone(),
+                client_key_account_name: event.client_key_account_name.clone(),
             };
             let verified_client_key = match client_key_fields.verify(
                 daemon_id,
@@ -782,6 +793,37 @@ async fn handle_event(
                     return;
                 }
             };
+            // When the device key attests an account (v2 signature) AND the
+            // service stamped one from its session, the two must agree — a
+            // disagreement means the relay and the device are telling
+            // different stories about who is knocking, and nothing
+            // downstream should silently pick one.
+            if let (Some((attested_user, _)), Some(stamped_user)) = (
+                verified_client_key
+                    .as_ref()
+                    .and_then(|key| key.attested_account.as_ref()),
+                event
+                    .user_id
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty()),
+            ) {
+                if attested_user != stamped_user {
+                    let _ = post_error(
+                        client,
+                        base_url,
+                        config,
+                        daemon_id,
+                        &event.id,
+                        &format!(
+                            "client key attests account {attested_user:?} but the rendezvous \
+                             asserts {stamped_user:?} — refusing the mismatched offer"
+                        ),
+                    )
+                    .await;
+                    return;
+                }
+            }
             // Org-grant ride-along (phase 6 step 4): a member's offer may
             // carry its signed org grant document so first contact with a
             // daemon that trusts the org is one round trip. Materialize it
@@ -823,21 +865,34 @@ async fn handle_event(
                     // fingerprint out of this error by hand.
                     if let Some(key) = verified_client_key.as_ref() {
                         let origin = base_origin(base_url);
-                        let account_hint = match (
-                            event
-                                .account_name
-                                .as_deref()
-                                .map(str::trim)
-                                .filter(|v| !v.is_empty()),
-                            event
-                                .user_id
-                                .as_deref()
-                                .map(str::trim)
-                                .filter(|v| !v.is_empty()),
-                        ) {
-                            (Some(name), _) => format!("@{name}"),
-                            (None, Some(id)) => id.chars().take(12).collect(),
-                            (None, None) => String::new(),
+                        // Prefer the account the device key itself attested
+                        // (v2 signature); the relay-asserted identity is
+                        // only the fallback hint.
+                        let (account_hint, account_attested) = match key.attested_account.as_ref()
+                        {
+                            Some((_, name)) if !name.is_empty() => (format!("@{name}"), true),
+                            Some((user_id, _)) => {
+                                (user_id.chars().take(12).collect::<String>(), true)
+                            }
+                            None => (
+                                match (
+                                    event
+                                        .account_name
+                                        .as_deref()
+                                        .map(str::trim)
+                                        .filter(|v| !v.is_empty()),
+                                    event
+                                        .user_id
+                                        .as_deref()
+                                        .map(str::trim)
+                                        .filter(|v| !v.is_empty()),
+                                ) {
+                                    (Some(name), _) => format!("@{name}"),
+                                    (None, Some(id)) => id.chars().take(12).collect(),
+                                    (None, None) => String::new(),
+                                },
+                                false,
+                            ),
                         };
                         crate::access::enrollment::record_refused_client_key(
                             &key.fingerprint,
@@ -845,6 +900,7 @@ async fn handle_event(
                             &origin,
                             "connect-dashboard-control",
                             &account_hint,
+                            account_attested,
                             crate::access::client_key::now_unix_ms(),
                         );
                     }
@@ -1538,6 +1594,7 @@ mod tests {
         let key = crate::access::client_key::VerifiedClientKey {
             fingerprint: "fp-abc".to_string(),
             public_key_b64u: "unused".to_string(),
+            attested_account: None,
         };
         // Account metadata matches nothing, but the verified key must bind.
         let grant = connect_dashboard_grant_from_state(
@@ -1579,6 +1636,7 @@ mod tests {
         let key = crate::access::client_key::VerifiedClientKey {
             fingerprint: "fp-unenrolled".to_string(),
             public_key_b64u: "unused".to_string(),
+            attested_account: None,
         };
         let error = connect_dashboard_grant_from_state(state, None, None, Some(&key)).unwrap_err();
         assert!(error.contains("fp-unenrolled"));

--- a/src/bin/caller/connect_rendezvous.rs
+++ b/src/bin/caller/connect_rendezvous.rs
@@ -10,6 +10,7 @@
 use crate::daemon_identity::DaemonIdentity;
 use crate::dashboard_control::DashboardControlRegistry;
 use crate::project::ConnectConfig;
+use base64::Engine as _;
 use reqwest::{Client, RequestBuilder, Url};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -30,6 +31,12 @@ const CLAIM_PROTOCOL_V1: &str = "intendant-connect-claim-v1";
 const CLAIM_PROTOCOL_V2: &str = "intendant-connect-claim-v2";
 /// Daemon-signed release of a claim binding, mirrored by the service.
 const UNCLAIM_PROTOCOL: &str = "intendant-connect-unclaim-v1";
+/// First-owner bootstrap tag (mirrored by the /connect claim page): an
+/// HMAC-SHA256 keyed by the daemon-minted phrase, binding the claiming
+/// browser's identity key and account. Possession of the phrase is
+/// box-grade proof (it exists only in this daemon's log/Access card), so
+/// a valid tag is what authorizes minting the FIRST owner grant.
+const BOOTSTRAP_TAG_PROTOCOL: &str = "intendant-connect-bootstrap-v1";
 
 /// Register failures split by what retrying can fix. `Rejected` is a 4xx
 /// verdict from the service — a missing/invalid daemon token or a gated
@@ -48,6 +55,12 @@ struct RegisterRequest {
     protocol: &'static str,
     daemon_id: String,
     daemon_public_key: String,
+    /// First-owner bootstrap: SHA-256 (base64url) of this daemon's own
+    /// normalized claim phrase, sent only while the box is fresh (empty
+    /// IAM). The rendezvous stores the hash for claim routing and never
+    /// sees the plaintext.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    bootstrap_code_hash: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -62,6 +75,10 @@ struct RegisterResponse {
     claimed_by_handle: Option<String>,
     #[serde(default)]
     claim_code: Option<String>,
+    /// The service accepted this daemon's bootstrap hash — the phrase to
+    /// show is the local one, not a service-minted code.
+    #[serde(default)]
+    claim_code_daemon_minted: bool,
     #[serde(default)]
     claim_code_expires_unix_ms: Option<u64>,
     #[serde(default)]
@@ -106,6 +123,12 @@ struct RendezvousEvent {
     claim_id: Option<String>,
     #[serde(default)]
     challenge: Option<String>,
+    /// First-owner bootstrap arm fields, relayed blind by the service —
+    /// this daemon recomputes the phrase-derived tag itself.
+    #[serde(default)]
+    bootstrap_client_key: Option<String>,
+    #[serde(default)]
+    bootstrap_client_key_tag: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -122,6 +145,11 @@ struct AnswerRequest {
 struct ErrorRequest {
     daemon_id: String,
     request_id: String,
+    /// When the error concerns a claim, its id — the service then rejects
+    /// the pending claim so the claiming page shows the real reason
+    /// instead of timing out. Older services ignore the field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    claim_id: Option<String>,
     error: String,
 }
 
@@ -200,6 +228,234 @@ fn clear_signed_claim_record() {
     }
 }
 
+/// A box is first-owner-bootstrap eligible while its local IAM holds
+/// nothing at all: no principals, no grants. The auto-minted mTLS client
+/// bundle does NOT count as ownership — it exists on every daemon from
+/// first boot, and holding its P12 is box-grade access, exactly what the
+/// bootstrap phrase proves too. The window closes the moment any
+/// principal or grant is written, and unreadable IAM state fails closed.
+fn first_owner_bootstrap_eligible() -> bool {
+    let cert_dir = crate::access::backend::select_backend().cert_dir();
+    match crate::access::iam::load_state(&cert_dir) {
+        Ok(state) => state.principals.is_empty() && state.grants.is_empty(),
+        Err(_) => false,
+    }
+}
+
+fn bootstrap_phrase_registry() -> &'static Mutex<Option<String>> {
+    static REGISTRY: OnceLock<Mutex<Option<String>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(None))
+}
+
+/// The daemon-minted first-owner phrase for this process: minted on first
+/// use while the box is eligible, dropped forever once an owner exists.
+/// Regenerated per boot — the phrase is a bootstrap secret, not durable
+/// state.
+fn current_bootstrap_phrase() -> Option<String> {
+    let mut slot = bootstrap_phrase_registry()
+        .lock()
+        .expect("bootstrap phrase poisoned");
+    if !first_owner_bootstrap_eligible() {
+        if slot.take().is_some() {
+            eprintln!("[connect] first-owner bootstrap closed (this daemon now has an owner)");
+        }
+        return None;
+    }
+    if slot.is_none() {
+        let mut entropy = [0u8; 16];
+        if let Err(e) =
+            ring::rand::SecureRandom::fill(&ring::rand::SystemRandom::new(), &mut entropy)
+        {
+            eprintln!("[connect] bootstrap phrase entropy unavailable: {e:?}");
+            return None;
+        }
+        match bip39::Mnemonic::from_entropy(&entropy) {
+            Ok(mnemonic) => *slot = Some(mnemonic.to_string().replace(' ', "-")),
+            Err(e) => {
+                eprintln!("[connect] bootstrap phrase generation failed: {e}");
+                return None;
+            }
+        }
+    }
+    slot.clone()
+}
+
+fn clear_bootstrap_phrase() {
+    bootstrap_phrase_registry()
+        .lock()
+        .expect("bootstrap phrase poisoned")
+        .take();
+}
+
+/// Mirrors `normalize_claim_code` in `intendant-connect`: lowercase
+/// alphanumeric runs joined by `-`.
+fn normalize_claim_code(input: &str) -> String {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    for ch in input.chars() {
+        if ch.is_ascii_alphanumeric() {
+            current.push(ch.to_ascii_lowercase());
+        } else if !current.is_empty() {
+            parts.push(std::mem::take(&mut current));
+        }
+    }
+    if !current.is_empty() {
+        parts.push(current);
+    }
+    parts.join("-")
+}
+
+/// Mirrors `claim_code_hash` in `intendant-connect` (and the /connect
+/// page JS): SHA-256 of the normalized phrase, base64url unpadded.
+fn claim_code_hash(code: &str) -> String {
+    crate::daemon_identity::b64u(
+        ring::digest::digest(
+            &ring::digest::SHA256,
+            normalize_claim_code(code).as_bytes(),
+        )
+        .as_ref(),
+    )
+}
+
+/// The exact string the /connect page HMACs with the phrase-derived key.
+/// Binds the claiming browser's identity key and account, so the relay
+/// (which never sees the phrase) cannot substitute a key of its own.
+fn bootstrap_tag_payload(
+    daemon_id: &str,
+    daemon_public_key: &str,
+    client_key_b64u: &str,
+    account_user_id: &str,
+    account_name: &str,
+) -> String {
+    format!(
+        "{BOOTSTRAP_TAG_PROTOCOL}\n{daemon_id}\n{daemon_public_key}\n{client_key_b64u}\n{account_user_id}\n{account_name}\n"
+    )
+}
+
+/// Verify a bootstrap arm and enroll the claiming browser as this
+/// daemon's FIRST owner (`role:root`). Authority basis: the tag proves
+/// possession of the daemon-minted phrase, which only box-grade access
+/// (this daemon's log, or its Access card behind AccessManage) reveals —
+/// the same proof SSH access would be. Recorded with the sentinel origin
+/// `connect-bootstrap`, which is not a hosted origin, so no role ceiling
+/// demotes the owner it mints. Fails closed on any mismatch and on any
+/// non-empty IAM.
+fn bootstrap_enroll_first_owner(
+    client_key_b64u: &str,
+    tag_b64u: &str,
+    account_user_id: &str,
+    account_name: &str,
+    daemon_id: &str,
+    daemon_public_key: &str,
+) -> Result<String, String> {
+    let Some(phrase) = current_bootstrap_phrase() else {
+        return Err(
+            "this daemon is not offering first-owner bootstrap (it already has an owner)"
+                .to_string(),
+        );
+    };
+    let cert_dir = crate::access::backend::select_backend().cert_dir();
+    let fingerprint = bootstrap_enroll_first_owner_at(
+        &cert_dir,
+        &phrase,
+        client_key_b64u,
+        tag_b64u,
+        account_user_id,
+        account_name,
+        daemon_id,
+        daemon_public_key,
+    )?;
+    clear_bootstrap_phrase();
+    eprintln!(
+        "[connect] first-owner bootstrap: enrolled client key {fingerprint} as role:root{}",
+        if account_name.is_empty() {
+            String::new()
+        } else {
+            format!(" (@{account_name})")
+        }
+    );
+    Ok(fingerprint)
+}
+
+/// Testable core: explicit state directory and phrase.
+#[allow(clippy::too_many_arguments)]
+fn bootstrap_enroll_first_owner_at(
+    cert_dir: &std::path::Path,
+    phrase: &str,
+    client_key_b64u: &str,
+    tag_b64u: &str,
+    account_user_id: &str,
+    account_name: &str,
+    daemon_id: &str,
+    daemon_public_key: &str,
+) -> Result<String, String> {
+    let engine = &base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let raw_key = engine
+        .decode(client_key_b64u)
+        .map_err(|_| "bootstrap client key is not valid base64url".to_string())?;
+    if raw_key.len() != 65 || raw_key[0] != 0x04 {
+        return Err("bootstrap client key must be a 65-byte uncompressed P-256 point".to_string());
+    }
+    let tag = engine
+        .decode(tag_b64u)
+        .map_err(|_| "bootstrap tag is not valid base64url".to_string())?;
+    let hmac_key = ring::hmac::Key::new(
+        ring::hmac::HMAC_SHA256,
+        ring::digest::digest(
+            &ring::digest::SHA256,
+            normalize_claim_code(phrase).as_bytes(),
+        )
+        .as_ref(),
+    );
+    let payload = bootstrap_tag_payload(
+        daemon_id,
+        daemon_public_key,
+        client_key_b64u,
+        account_user_id,
+        account_name,
+    );
+    ring::hmac::verify(&hmac_key, payload.as_bytes(), &tag).map_err(|_| {
+        "bootstrap tag verification failed — the phrase entered does not match this daemon's"
+            .to_string()
+    })?;
+
+    let mut state = crate::access::iam::load_state(cert_dir)
+        .map_err(|e| format!("load local IAM state: {e}"))?;
+    // Re-check under the state we are about to write: eligibility may
+    // have closed between the phrase snapshot and now.
+    if !(state.principals.is_empty() && state.grants.is_empty()) {
+        return Err("this daemon already has an owner; bootstrap enrollment is closed".to_string());
+    }
+    let fingerprint = crate::access::client_key::client_key_fingerprint(&raw_key);
+    let request = crate::access::iam::UserClientGrantUpsertRequest {
+        kind: "client_key".to_string(),
+        label: Some(if account_name.is_empty() {
+            "First owner (bootstrap)".to_string()
+        } else {
+            format!("@{account_name} (first owner)")
+        }),
+        client_key_fingerprint: Some(fingerprint.clone()),
+        client_key: Some(client_key_b64u.to_string()),
+        client_key_origin: Some("connect-bootstrap".to_string()),
+        role_id: Some("role:root".to_string()),
+        user_id: (!account_user_id.is_empty()).then(|| account_user_id.to_string()),
+        account_name: (!account_name.is_empty()).then(|| account_name.to_string()),
+        reason: Some(
+            "first-owner bootstrap: phrase-holder enrolled at claim time".to_string(),
+        ),
+        ..Default::default()
+    };
+    let actor = crate::access::iam::AccessPrincipal::root_dashboard_session(
+        "connect-bootstrap",
+        "connect-rendezvous",
+    );
+    crate::access::iam::upsert_user_client_grant(&mut state, request, &actor)
+        .map_err(|e| e.to_string())?;
+    crate::access::iam::save_state(cert_dir, &state)
+        .map_err(|e| format!("save local IAM state: {e}"))?;
+    Ok(fingerprint)
+}
+
 /// How the daemon's local signed claim record relates to the owner the
 /// service currently asserts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -239,6 +495,10 @@ pub(crate) struct ConnectStatus {
     pub claim_code: Option<String>,
     pub claim_url: Option<String>,
     pub claim_code_expires_unix_ms: Option<u64>,
+    /// The current claim phrase is this daemon's own first-owner
+    /// bootstrap phrase: claiming with it also enrolls the claiming
+    /// browser as role:root.
+    pub bootstrap: bool,
 }
 
 fn status_registry() -> &'static Mutex<ConnectStatus> {
@@ -457,7 +717,7 @@ async fn run_connect_rendezvous_client(
 
     loop {
         match register(&client, &base_url, &config, &daemon_id, &daemon_public_key).await {
-            Ok(response) => note_register_response(&response),
+            Ok(response) => note_register_response(&response, &base_url),
             Err(RegisterError::Rejected(e)) => {
                 eprintln!(
                     "[connect] register rejected: {e} — the rendezvous refused this daemon \
@@ -518,7 +778,7 @@ async fn run_connect_rendezvous_client(
             if force_register || last_register.elapsed() >= REGISTER_REFRESH_INTERVAL {
                 match register(&client, &base_url, &config, &daemon_id, &daemon_public_key).await {
                     Ok(response) => {
-                        note_register_response(&response);
+                        note_register_response(&response, &base_url);
                         last_register = Instant::now();
                     }
                     Err(RegisterError::Rejected(e)) => {
@@ -555,7 +815,19 @@ fn note_register_error(error: &str) {
 /// and print the claim line when the code actually changed (the old
 /// every-60s repeat was log noise; the current code is always visible in
 /// the Access card).
-fn note_register_response(response: &RegisterResponse) {
+fn note_register_response(response: &RegisterResponse, base_url: &Url) {
+    // Daemon-minted bootstrap: the service echoes no code (it only holds
+    // the hash) — the phrase to show, in the log and the Access card, is
+    // the local one. Build the claim URL against the rendezvous origin
+    // exactly like service-minted claim URLs.
+    let bootstrap = if !response.claimed && response.claim_code_daemon_minted {
+        current_bootstrap_phrase().map(|phrase| {
+            let url = format!("{}/connect?claim_code={phrase}", base_origin(base_url));
+            (phrase, url)
+        })
+    } else {
+        None
+    };
     let now = crate::access::client_key::now_unix_ms();
     let mut print_claim: Option<String> = None;
     with_status(|status| {
@@ -569,6 +841,7 @@ fn note_register_response(response: &RegisterResponse) {
             status.claim_code = None;
             status.claim_url = None;
             status.claim_code_expires_unix_ms = None;
+            status.bootstrap = false;
             status.claim_binding =
                 Some(match (&status.signed_claim, &response.claimed_by_user_id) {
                     (Some(record), Some(asserted)) if record.account_user_id == *asserted => {
@@ -599,21 +872,29 @@ fn note_register_response(response: &RegisterResponse) {
             status.claimed_by_user_id = None;
             status.claimed_by_handle = None;
             status.claim_binding = None;
-            if status.claim_code != response.claim_code {
-                print_claim = Some(match (&response.claim_url, &response.claim_code) {
-                    (Some(url), _) if !url.is_empty() => {
-                        format!("claim this daemon at {url}")
+            let (effective_code, effective_url) = match &bootstrap {
+                Some((phrase, url)) => (Some(phrase.clone()), Some(url.clone())),
+                None => (response.claim_code.clone(), response.claim_url.clone()),
+            };
+            if status.claim_code != effective_code {
+                print_claim = match (&bootstrap, &effective_url, &effective_code) {
+                    (Some(_), Some(url), _) => Some(format!(
+                        "first-owner bootstrap: claim this daemon at {url} — entering the \
+                         phrase also enrolls the claiming browser as this daemon's first owner"
+                    )),
+                    (None, Some(url), _) if !url.is_empty() => {
+                        Some(format!("claim this daemon at {url}"))
                     }
-                    (_, Some(code)) if !code.is_empty() => {
-                        format!("claim this daemon with code {code}")
+                    (None, _, Some(code)) if !code.is_empty() => {
+                        Some(format!("claim this daemon with code {code}"))
                     }
-                    _ => String::new(),
-                })
-                .filter(|line| !line.is_empty());
+                    _ => None,
+                };
             }
-            status.claim_code = response.claim_code.clone();
-            status.claim_url = response.claim_url.clone();
+            status.claim_code = effective_code;
+            status.claim_url = effective_url;
             status.claim_code_expires_unix_ms = response.claim_code_expires_unix_ms;
+            status.bootstrap = bootstrap.is_some();
         }
     });
     if let Some(line) = print_claim {
@@ -674,6 +955,13 @@ async fn register(
         protocol: "intendant-connect-rendezvous-v1",
         daemon_id: daemon_id.to_string(),
         daemon_public_key: daemon_public_key.to_string(),
+        // Fresh boxes offer first-owner bootstrap: mint (or keep) the
+        // local phrase and register only its hash. `None` the moment an
+        // owner exists — the service then reverts to minting its own
+        // display-only codes.
+        bootstrap_code_hash: current_bootstrap_phrase()
+            .as_deref()
+            .map(claim_code_hash),
     };
     authenticated(
         config,
@@ -1009,6 +1297,45 @@ async fn handle_event(
                 .unwrap_or("")
                 .to_string();
             let daemon_public_key = identity.public_key_b64u();
+            // First-owner bootstrap: an armed claim carries the browser's
+            // identity key plus a tag derived from the daemon-minted
+            // phrase. Verify and enroll BEFORE acknowledging the claim —
+            // a claim that promised ownership must never half-complete as
+            // a metadata-only binding.
+            if let (Some(bootstrap_key), Some(bootstrap_tag)) = (
+                event
+                    .bootstrap_client_key
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty()),
+                event
+                    .bootstrap_client_key_tag
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty()),
+            ) {
+                if let Err(e) = bootstrap_enroll_first_owner(
+                    bootstrap_key,
+                    bootstrap_tag,
+                    account_user_id.as_deref().unwrap_or(""),
+                    &account_name,
+                    daemon_id,
+                    &daemon_public_key,
+                ) {
+                    eprintln!("[connect] first-owner bootstrap refused: {e}");
+                    let _ = post_claim_error(
+                        client,
+                        base_url,
+                        config,
+                        daemon_id,
+                        &event.id,
+                        claim_id,
+                        &format!("first-owner bootstrap refused: {e}"),
+                    )
+                    .await;
+                    return;
+                }
+            }
             let (protocol, payload) = match account_user_id.as_deref() {
                 Some(user_id) => (
                     CLAIM_PROTOCOL_V2,
@@ -1393,9 +1720,45 @@ async fn post_error(
     request_id: &str,
     error: &str,
 ) -> Result<(), String> {
+    post_error_inner(client, base_url, config, daemon_id, request_id, None, error).await
+}
+
+/// Claim-scoped error: also names the claim so the service rejects it and
+/// the claiming page surfaces the reason instead of timing out.
+async fn post_claim_error(
+    client: &Client,
+    base_url: &Url,
+    config: &ConnectConfig,
+    daemon_id: &str,
+    request_id: &str,
+    claim_id: &str,
+    error: &str,
+) -> Result<(), String> {
+    post_error_inner(
+        client,
+        base_url,
+        config,
+        daemon_id,
+        request_id,
+        Some(claim_id),
+        error,
+    )
+    .await
+}
+
+async fn post_error_inner(
+    client: &Client,
+    base_url: &Url,
+    config: &ConnectConfig,
+    daemon_id: &str,
+    request_id: &str,
+    claim_id: Option<&str>,
+    error: &str,
+) -> Result<(), String> {
     let body = ErrorRequest {
         daemon_id: daemon_id.to_string(),
         request_id: request_id.to_string(),
+        claim_id: claim_id.map(str::to_string),
         error: error.to_string(),
     };
     authenticated(config, client.post(join_url(base_url, "api/daemon/error")?))
@@ -1730,6 +2093,133 @@ mod tests {
         );
     }
 
+    /// Twin of the service's normalize/hash tests — one shared literal
+    /// pins the cross-binary (and /connect-page JS) hash construction.
+    #[test]
+    fn claim_code_hash_matches_the_service_construction() {
+        assert_eq!(
+            normalize_claim_code("  Abandon ABILITY__able "),
+            "abandon-ability-able"
+        );
+        assert_eq!(
+            claim_code_hash("  Abandon ABILITY__able "),
+            "Q4-Jf1pewq3jBEyujMeltvQLFADs3UikZAMej9Iu4j0"
+        );
+    }
+
+    #[test]
+    fn bootstrap_enrolls_first_owner_only_with_a_valid_tag_on_a_fresh_box() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_dir = dir.path();
+        let phrase =
+            "legal-winner-thank-year-wave-sausage-worth-useful-legal-winner-thank-yellow";
+        let mut raw = vec![0x04u8];
+        raw.extend_from_slice(&[7u8; 64]);
+        let client_key_b64u = crate::daemon_identity::b64u(&raw);
+        let tag = {
+            let hmac_key = ring::hmac::Key::new(
+                ring::hmac::HMAC_SHA256,
+                ring::digest::digest(
+                    &ring::digest::SHA256,
+                    normalize_claim_code(phrase).as_bytes(),
+                )
+                .as_ref(),
+            );
+            let payload = bootstrap_tag_payload(
+                "daemon-1",
+                "DaemonPub",
+                &client_key_b64u,
+                "user-1",
+                "alice",
+            );
+            crate::daemon_identity::b64u(ring::hmac::sign(&hmac_key, payload.as_bytes()).as_ref())
+        };
+
+        // Wrong phrase → refused, nothing written.
+        let err = bootstrap_enroll_first_owner_at(
+            cert_dir,
+            "wrong-phrase",
+            &client_key_b64u,
+            &tag,
+            "user-1",
+            "alice",
+            "daemon-1",
+            "DaemonPub",
+        )
+        .unwrap_err();
+        assert!(err.contains("tag verification failed"), "{err}");
+        assert!(crate::access::iam::load_state(cert_dir)
+            .unwrap()
+            .principals
+            .is_empty());
+
+        // Tag bound to a different key → refused (the relay cannot swap
+        // the enrolled key).
+        let mut other_raw = vec![0x04u8];
+        other_raw.extend_from_slice(&[9u8; 64]);
+        let other_key_b64u = crate::daemon_identity::b64u(&other_raw);
+        let err = bootstrap_enroll_first_owner_at(
+            cert_dir,
+            phrase,
+            &other_key_b64u,
+            &tag,
+            "user-1",
+            "alice",
+            "daemon-1",
+            "DaemonPub",
+        )
+        .unwrap_err();
+        assert!(err.contains("tag verification failed"), "{err}");
+
+        // Right phrase, right key → enrolls role:root with the bootstrap
+        // sentinel origin (not a hosted origin, so no ceiling demotes it).
+        let fingerprint = bootstrap_enroll_first_owner_at(
+            cert_dir,
+            phrase,
+            &client_key_b64u,
+            &tag,
+            "user-1",
+            "alice",
+            "daemon-1",
+            "DaemonPub",
+        )
+        .unwrap();
+        let state = crate::access::iam::load_state(cert_dir).unwrap();
+        assert_eq!(state.grants.len(), 1);
+        assert_eq!(state.grants[0].role_id, "role:root");
+        assert_eq!(state.principals.len(), 1);
+        let authn = &state.principals[0].authn;
+        assert!(authn.iter().any(|entry| {
+            entry.get("fingerprint").and_then(|v| v.as_str()) == Some(fingerprint.as_str())
+                && entry.get("origin").and_then(|v| v.as_str()) == Some("connect-bootstrap")
+        }));
+        let principal = crate::access::iam::principal_for_client_key(
+            &state,
+            &fingerprint,
+            "connect-dashboard-control",
+        )
+        .expect("bootstrap principal resolves");
+        assert_eq!(
+            crate::access::iam::role_ceiling_for_session(&state, &principal),
+            None,
+            "the bootstrap sentinel origin must not be ceiling-capped"
+        );
+
+        // A second bootstrap of any kind is refused: the box has an owner.
+        let err = bootstrap_enroll_first_owner_at(
+            cert_dir,
+            phrase,
+            &client_key_b64u,
+            &tag,
+            "user-1",
+            "alice",
+            "daemon-1",
+            "DaemonPub",
+        )
+        .unwrap_err();
+        assert!(err.contains("already has an owner"), "{err}");
+    }
+
     #[test]
     fn register_response_reads_claimed_by_and_expiry_fields() {
         let response: RegisterResponse = serde_json::from_str(
@@ -1777,43 +2267,56 @@ mod tests {
             status.signed_claim = Some(record);
         });
 
-        note_register_response(&RegisterResponse {
-            claimed: true,
-            claimed_by_user_id: Some("alice-user-id".to_string()),
-            claimed_by_handle: Some("alice".to_string()),
-            claim_code: None,
-            claim_code_expires_unix_ms: None,
-            claim_url: None,
-        });
+        let base_url = Url::parse("https://connect.example").unwrap();
+        note_register_response(
+            &RegisterResponse {
+                claimed: true,
+                claimed_by_user_id: Some("alice-user-id".to_string()),
+                claimed_by_handle: Some("alice".to_string()),
+                claim_code: None,
+                claim_code_daemon_minted: false,
+                claim_code_expires_unix_ms: None,
+                claim_url: None,
+            },
+            &base_url,
+        );
         assert_eq!(
             status_snapshot().claim_binding,
             Some(ClaimBinding::DaemonSigned)
         );
 
-        note_register_response(&RegisterResponse {
-            claimed: true,
-            claimed_by_user_id: Some("mallory-user-id".to_string()),
-            claimed_by_handle: Some("mallory".to_string()),
-            claim_code: None,
-            claim_code_expires_unix_ms: None,
-            claim_url: None,
-        });
+        note_register_response(
+            &RegisterResponse {
+                claimed: true,
+                claimed_by_user_id: Some("mallory-user-id".to_string()),
+                claimed_by_handle: Some("mallory".to_string()),
+                claim_code: None,
+                claim_code_daemon_minted: false,
+                claim_code_expires_unix_ms: None,
+                claim_url: None,
+            },
+            &base_url,
+        );
         assert_eq!(
             status_snapshot().claim_binding,
             Some(ClaimBinding::Mismatch)
         );
 
         // Unclaimed responses clear the claim view and surface the code.
-        note_register_response(&RegisterResponse {
-            claimed: false,
-            claimed_by_user_id: None,
-            claimed_by_handle: None,
-            claim_code: Some("word-word-word".to_string()),
-            claim_code_expires_unix_ms: Some(1_700_000_600_000),
-            claim_url: Some(
-                "https://connect.example/connect?claim_code=word-word-word".to_string(),
-            ),
-        });
+        note_register_response(
+            &RegisterResponse {
+                claimed: false,
+                claimed_by_user_id: None,
+                claimed_by_handle: None,
+                claim_code: Some("word-word-word".to_string()),
+                claim_code_daemon_minted: false,
+                claim_code_expires_unix_ms: Some(1_700_000_600_000),
+                claim_url: Some(
+                    "https://connect.example/connect?claim_code=word-word-word".to_string(),
+                ),
+            },
+            &base_url,
+        );
         let status = status_snapshot();
         assert_eq!(status.claimed, Some(false));
         assert_eq!(status.claim_binding, None);

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -446,6 +446,7 @@ pub(crate) fn access_connect_status_response_value() -> serde_json::Value {
         "signed_claim": status.signed_claim,
         "claim_code_available": status.claim_code.is_some(),
         "claim_code_expires_unix_ms": status.claim_code_expires_unix_ms,
+        "bootstrap": status.bootstrap,
         "default_rendezvous_url": crate::project::DEFAULT_CONNECT_RENDEZVOUS_URL,
     })
 }

--- a/src/bin/connect/main.rs
+++ b/src/bin/connect/main.rs
@@ -131,6 +131,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/api/vault", get(api_vault_fetch).post(api_vault_publish))
         .route("/api/claims/claim", post(api_claim_start))
         .route("/api/claims/{claim_id}", get(api_claim_status))
+        .route("/api/claims/{claim_id}/arm", post(api_claim_arm))
         .route("/api/audit", get(api_audit))
         .route("/api/status", get(api_status))
         .route("/api/attest/dns", post(attest_dns))
@@ -592,6 +593,13 @@ struct DaemonRecord {
     daemon_public_key: String,
     owner_user_id: Option<Uuid>,
     claim_code_hash: Option<String>,
+    /// True when `claim_code_hash` was minted by the daemon itself
+    /// (first-owner bootstrap): this service holds only the hash, the
+    /// freshness is presence-bound (refreshed on every register poll
+    /// instead of the 10-minute TTL), and a claim against it requires the
+    /// arm step before the challenge fires.
+    #[serde(default)]
+    claim_code_daemon_minted: bool,
     claim_code_created_unix_ms: Option<u64>,
     registered_unix_ms: u64,
     last_seen_unix_ms: u64,
@@ -749,6 +757,11 @@ struct PendingClaim {
     daemon_id: String,
     challenge: String,
     created_unix_ms: u64,
+    /// First-owner bootstrap (daemon-minted phrase): the challenge does
+    /// not fire until the browser arms the claim with its identity key
+    /// and phrase-derived tag.
+    bootstrap_required: bool,
+    armed: bool,
     status: ClaimStatus,
 }
 
@@ -3722,7 +3735,12 @@ async fn api_daemon_label(
 
 #[derive(Debug, Deserialize)]
 struct ClaimStartRequest {
+    #[serde(default)]
     claim_code: String,
+    /// Preferred: SHA-256 (base64url) of the normalized phrase, computed
+    /// client-side — this service never needs to see plaintext codes.
+    #[serde(default)]
+    claim_code_hash: Option<String>,
 }
 
 async fn api_claim_start(
@@ -3733,11 +3751,27 @@ async fn api_claim_start(
     let user = require_user(&state, &headers).await?;
     require_csrf(&state, &headers).await?;
     check_rate_limit(&state, &headers, "claim_start", 10, 60_000).await?;
-    let code = normalize_claim_code(&body.claim_code);
-    if code.is_empty() {
-        return Err(ApiError::bad_request("claim_code is required"));
-    }
-    let code_hashes = claim_code_hash_candidates(&body.claim_code);
+    let code_hashes = match body
+        .claim_code_hash
+        .as_deref()
+        .map(str::trim)
+        .filter(|hash| !hash.is_empty())
+    {
+        Some(hash) => {
+            if !is_sha256_b64u(hash) {
+                return Err(ApiError::bad_request(
+                    "claim_code_hash must be an unpadded base64url SHA-256 digest",
+                ));
+            }
+            vec![hash.to_string()]
+        }
+        None => {
+            if normalize_claim_code(&body.claim_code).is_empty() {
+                return Err(ApiError::bad_request("claim_code is required"));
+            }
+            claim_code_hash_candidates(&body.claim_code)
+        }
+    };
     let now = now_unix_ms();
     let daemon = {
         let store = state.store.lock().await;
@@ -3749,12 +3783,17 @@ async fn api_claim_start(
                     && d.claim_code_hash
                         .as_deref()
                         .is_some_and(|hash| code_hashes.iter().any(|candidate| candidate == hash))
-                    && d.claim_code_created_unix_ms
-                        .is_some_and(|created| now.saturating_sub(created) <= CLAIM_CODE_TTL_MS)
+                    && d.claim_code_created_unix_ms.is_some_and(|created| {
+                        // Daemon-minted hashes are presence-fresh (renewed
+                        // on every register poll), so the same TTL check
+                        // naturally covers both kinds.
+                        now.saturating_sub(created) <= CLAIM_CODE_TTL_MS
+                    })
             })
             .cloned()
             .ok_or_else(|| ApiError::not_found("claim code not found"))?
     };
+    let needs_bootstrap_arm = daemon.claim_code_daemon_minted;
     let claim_id = Uuid::new_v4().to_string();
     let challenge = random_b64u(32);
     state.pending_claims.lock().await.insert(
@@ -3765,22 +3804,123 @@ async fn api_claim_start(
             daemon_id: daemon.daemon_id.clone(),
             challenge: challenge.clone(),
             created_unix_ms: now_unix_ms(),
+            bootstrap_required: needs_bootstrap_arm,
+            armed: false,
             status: ClaimStatus::Pending,
         },
     );
     // The challenge names the claiming account so the daemon can co-sign
     // *who* it is being claimed by (v2 proofs) and show "claimed by
     // @handle" from its own signed record rather than this service's word.
+    // Bootstrap claims hold the challenge until the browser arms them
+    // with its identity key + phrase-derived tag (api_claim_arm).
+    if !needs_bootstrap_arm {
+        enqueue_event(
+            &state,
+            &daemon.daemon_id,
+            RendezvousEvent {
+                id: Uuid::new_v4().to_string(),
+                kind: "claim_challenge".to_string(),
+                claim_id: Some(claim_id.clone()),
+                challenge: Some(challenge),
+                user_id: Some(user.id.to_string()),
+                account_name: Some(user.account_name.clone()),
+                ..RendezvousEvent::default()
+            },
+        )
+        .await;
+    }
+    {
+        let mut store = state.store.lock().await;
+        audit(
+            &mut store,
+            "daemon_claim_started",
+            Some(user.id),
+            Some(daemon.daemon_id.clone()),
+            json!({ "claim_id": claim_id, "bootstrap": needs_bootstrap_arm }),
+        );
+        persist_locked(&state, &store)?;
+    }
+    Ok(Json(json!({
+        "ok": true,
+        "claim_id": claim_id,
+        "daemon_id": daemon.daemon_id,
+        "daemon_public_key": daemon.daemon_public_key,
+        "needs_bootstrap_arm": needs_bootstrap_arm,
+    })))
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaimArmRequest {
+    client_key: String,
+    client_key_tag: String,
+}
+
+/// Arm a first-owner bootstrap claim: the browser presents its identity
+/// key plus an HMAC tag derived from the daemon-minted phrase, and only
+/// then does the claim challenge fire. This service relays both blind —
+/// it holds the phrase's hash, not the phrase, so it can neither compute
+/// a tag for a key of its own nor alter the browser's (the daemon
+/// recomputes the tag over the exact key it enrolls).
+async fn api_claim_arm(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    AxumPath(claim_id): AxumPath<String>,
+    Json(body): Json<ClaimArmRequest>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let user = require_user(&state, &headers).await?;
+    require_csrf(&state, &headers).await?;
+    check_rate_limit(&state, &headers, "claim_arm", 10, 60_000).await?;
+    let client_key = body.client_key.trim().to_string();
+    let client_key_tag = body.client_key_tag.trim().to_string();
+    if client_key.is_empty() || client_key_tag.is_empty() {
+        return Err(ApiError::bad_request(
+            "client_key and client_key_tag are required",
+        ));
+    }
+    let (daemon_id, challenge, user_id_string, account_name) = {
+        let mut claims = state.pending_claims.lock().await;
+        let claim = claims
+            .get_mut(claim_id.trim())
+            .ok_or_else(|| ApiError::not_found("claim not found"))?;
+        if claim.user_id != user.id {
+            return Err(ApiError::forbidden("claim belongs to a different account"));
+        }
+        if !matches!(claim.status, ClaimStatus::Pending) {
+            return Err(ApiError::bad_request("claim is already resolved"));
+        }
+        if now_unix_ms().saturating_sub(claim.created_unix_ms) > CLAIM_TIMEOUT_MS {
+            claim.status = ClaimStatus::Rejected {
+                error: "claim timed out".to_string(),
+            };
+            return Err(ApiError::bad_request("claim timed out"));
+        }
+        if !claim.bootstrap_required {
+            return Err(ApiError::bad_request("claim does not need arming"));
+        }
+        if claim.armed {
+            return Err(ApiError::bad_request("claim is already armed"));
+        }
+        claim.armed = true;
+        (
+            claim.daemon_id.clone(),
+            claim.challenge.clone(),
+            claim.user_id.to_string(),
+            claim.account_name.clone(),
+        )
+    };
     enqueue_event(
         &state,
-        &daemon.daemon_id,
+        &daemon_id,
         RendezvousEvent {
             id: Uuid::new_v4().to_string(),
             kind: "claim_challenge".to_string(),
-            claim_id: Some(claim_id.clone()),
+            claim_id: Some(claim_id.trim().to_string()),
             challenge: Some(challenge),
-            user_id: Some(user.id.to_string()),
-            account_name: Some(user.account_name.clone()),
+            user_id: Some(user_id_string),
+            account_name: Some(account_name),
+            bootstrap_client_key: Some(client_key),
+            bootstrap_client_key_tag: Some(client_key_tag),
             ..RendezvousEvent::default()
         },
     )
@@ -3789,18 +3929,14 @@ async fn api_claim_start(
         let mut store = state.store.lock().await;
         audit(
             &mut store,
-            "daemon_claim_started",
+            "daemon_claim_armed",
             Some(user.id),
-            Some(daemon.daemon_id.clone()),
-            json!({ "claim_id": claim_id }),
+            Some(daemon_id),
+            json!({ "claim_id": claim_id.trim() }),
         );
         persist_locked(&state, &store)?;
     }
-    Ok(Json(json!({
-        "ok": true,
-        "claim_id": claim_id,
-        "daemon_id": daemon.daemon_id,
-    })))
+    Ok(Json(json!({ "ok": true })))
 }
 
 async fn api_claim_status(
@@ -3912,6 +4048,13 @@ struct DaemonRegisterRequest {
     protocol: String,
     daemon_id: String,
     daemon_public_key: String,
+    /// First-owner bootstrap (fresh boxes): the daemon minted its own
+    /// claim phrase locally and registers only the SHA-256 (base64url) of
+    /// its normalized form. This service never sees the plaintext, so it
+    /// can route a claim to the daemon but cannot claim (or enroll
+    /// against) the daemon itself.
+    #[serde(default)]
+    bootstrap_code_hash: Option<String>,
 }
 
 async fn daemon_register(
@@ -3931,7 +4074,20 @@ async fn daemon_register(
             "daemon_id and daemon_public_key are required",
         ));
     }
+    let bootstrap_code_hash = body
+        .bootstrap_code_hash
+        .as_deref()
+        .map(str::trim)
+        .filter(|hash| !hash.is_empty());
+    if let Some(hash) = bootstrap_code_hash {
+        if !is_sha256_b64u(hash) {
+            return Err(ApiError::bad_request(
+                "bootstrap_code_hash must be an unpadded base64url SHA-256 digest",
+            ));
+        }
+    }
     let mut claim_code = None;
+    let mut daemon_minted = false;
     let (claimed, claimed_by, claim_code_expires_unix_ms) = {
         let mut claim_codes = state.claim_codes.lock().await;
         let mut store = state.store.lock().await;
@@ -3940,6 +4096,41 @@ async fn daemon_register(
             claim_codes.remove(&stale_id);
         }
         let active_claim_hashes = active_claim_code_hashes(&store, &daemon_id, now);
+        // Applies the unclaimed-record claim-code policy: a daemon-minted
+        // bootstrap hash wins (presence-fresh, plaintext never seen here);
+        // otherwise the service mints and remints on the usual TTL.
+        let apply_claim_code = |record: &mut DaemonRecord,
+                                claim_codes: &mut HashMap<String, String>,
+                                claim_code: &mut Option<String>|
+         -> ApiResult<()> {
+            match bootstrap_code_hash {
+                Some(hash) => {
+                    if active_claim_hashes.contains(hash) {
+                        return Err(ApiError::conflict(
+                            "bootstrap claim hash collides with another active claim code",
+                        ));
+                    }
+                    claim_codes.remove(&record.daemon_id);
+                    record.claim_code_hash = Some(hash.to_string());
+                    record.claim_code_daemon_minted = true;
+                    // Presence-bound freshness: valid while the daemon
+                    // polls, instead of the 10-minute TTL.
+                    record.claim_code_created_unix_ms = Some(now);
+                }
+                None => {
+                    if record.claim_code_daemon_minted {
+                        // The daemon stopped offering bootstrap (an owner
+                        // appeared locally) — revert to service-minted.
+                        record.claim_code_hash = None;
+                        record.claim_code_daemon_minted = false;
+                        record.claim_code_created_unix_ms = None;
+                    }
+                    *claim_code =
+                        Some(ensure_claim_code(claim_codes, record, &active_claim_hashes)?);
+                }
+            }
+            Ok(())
+        };
         let (owner_user_id, code_created_unix_ms) = if let Some(existing) =
             store.daemons.iter_mut().find(|d| d.daemon_id == daemon_id)
         {
@@ -3953,11 +4144,8 @@ async fn daemon_register(
             record_presence_hour(&mut existing.presence_hours, now);
             existing.updated_unix_ms = now;
             if existing.owner_user_id.is_none() {
-                claim_code = Some(ensure_claim_code(
-                    &mut claim_codes,
-                    existing,
-                    &active_claim_hashes,
-                )?);
+                apply_claim_code(existing, &mut claim_codes, &mut claim_code)?;
+                daemon_minted = existing.claim_code_daemon_minted;
             }
             (existing.owner_user_id, existing.claim_code_created_unix_ms)
         } else {
@@ -3967,17 +4155,15 @@ async fn daemon_register(
                 daemon_public_key: daemon_public_key.clone(),
                 owner_user_id: None,
                 claim_code_hash: None,
+                claim_code_daemon_minted: false,
                 claim_code_created_unix_ms: None,
                 registered_unix_ms: now,
                 last_seen_unix_ms: now,
                 updated_unix_ms: now,
                 presence_hours: Vec::new(),
             };
-            claim_code = Some(ensure_claim_code(
-                &mut claim_codes,
-                &mut record,
-                &active_claim_hashes,
-            )?);
+            apply_claim_code(&mut record, &mut claim_codes, &mut claim_code)?;
+            daemon_minted = record.claim_code_daemon_minted;
             let created = record.claim_code_created_unix_ms;
             store.daemons.push(record);
             (None, created)
@@ -3997,9 +4183,11 @@ async fn daemon_register(
                     .unwrap_or_default(),
             )
         });
-        let expires = if owner_user_id.is_none() {
+        let expires = if owner_user_id.is_none() && !daemon_minted {
             code_created_unix_ms.map(|created| created.saturating_add(CLAIM_CODE_TTL_MS))
         } else {
+            // Claimed, or daemon-minted (presence-bound: fresh while the
+            // daemon keeps polling).
             None
         };
         (owner_user_id.is_some(), claimed_by, expires)
@@ -4022,10 +4210,20 @@ async fn daemon_register(
             .map(|(_, handle)| handle.clone())
             .filter(|handle| !handle.is_empty()),
         "claim_code": claim_code,
+        "claim_code_daemon_minted": daemon_minted,
         "claim_code_expires_unix_ms": claim_code_expires_unix_ms,
         "claim_url": claim_url,
         "daemon_public_key": daemon_public_key,
     })))
+}
+
+/// Shape check for a daemon-minted bootstrap hash: unpadded base64url of
+/// a SHA-256 digest — exactly 43 characters of the base64url alphabet.
+fn is_sha256_b64u(value: &str) -> bool {
+    value.len() == 43
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
 }
 
 fn ensure_claim_code(
@@ -4236,6 +4434,13 @@ struct RendezvousEvent {
     claim_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     challenge: Option<String>,
+    // First-owner bootstrap arm fields, relayed blind: the daemon
+    // recomputes the phrase-derived tag itself, so this service cannot
+    // substitute a key of its own.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    bootstrap_client_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    bootstrap_client_key_tag: Option<String>,
 }
 
 async fn enqueue_event(state: &AppState, daemon_id: &str, event: RendezvousEvent) {
@@ -4427,6 +4632,10 @@ fn validate_dashboard_binding(
 struct DaemonErrorRequest {
     daemon_id: String,
     request_id: String,
+    /// Claim-scoped errors name their claim so the claiming page shows
+    /// the daemon's reason instead of timing out.
+    #[serde(default)]
+    claim_id: Option<String>,
     error: String,
 }
 
@@ -4443,7 +4652,21 @@ async fn daemon_error(
         .remove(body.request_id.trim())
     {
         if pending.daemon_id == body.daemon_id {
-            let _ = pending.response_tx.send(Err(body.error));
+            let _ = pending.response_tx.send(Err(body.error.clone()));
+        }
+    }
+    if let Some(claim_id) = body
+        .claim_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        let mut claims = state.pending_claims.lock().await;
+        if let Some(claim) = claims.get_mut(claim_id) {
+            // Only the daemon the claim targets may reject it.
+            if claim.daemon_id == body.daemon_id && matches!(claim.status, ClaimStatus::Pending) {
+                claim.status = ClaimStatus::Rejected { error: body.error };
+            }
         }
     }
     Ok(Json(json!({ "ok": true })))
@@ -6683,22 +6906,132 @@ async function login() {{
   }}
 }}
 
+/* Mirrors the daemon/service normalize_claim_code: lowercase alphanumeric
+   runs joined by '-'. */
+function normalizeClaimPhrase(input) {{
+  return String(input || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+    .join('-');
+}}
+
+async function sha256B64uOfText(text) {{
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(text));
+  return bufToB64u(digest);
+}}
+
+/* Load or CREATE this origin's browser identity key — the exact record
+   the dashboard app uses (IndexedDB intendant-client-identity/keys/v1,
+   non-extractable P-256, {{privateKey, publicRaw, createdAtMs}}).
+   Creating here is what makes bootstrap one ceremony: the key that
+   claims is the key the daemon enrolls, and the dashboard then signs in
+   with it. */
+async function ensureOwnIdentity() {{
+  if (!window.indexedDB || !crypto?.subtle) throw new Error('WebCrypto unavailable');
+  const db = await new Promise((resolve, reject) => {{
+    const req = indexedDB.open('intendant-client-identity', 1);
+    req.onupgradeneeded = () => {{
+      if (!req.result.objectStoreNames.contains('keys')) req.result.createObjectStore('keys');
+    }};
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  }});
+  try {{
+    let record = await new Promise((resolve, reject) => {{
+      const tx = db.transaction('keys', 'readonly');
+      const req = tx.objectStore('keys').get('v1');
+      req.onsuccess = () => resolve(req.result || null);
+      req.onerror = () => reject(req.error);
+    }});
+    if (!record?.privateKey || !record?.publicRaw) {{
+      const pair = await crypto.subtle.generateKey(
+        {{ name: 'ECDSA', namedCurve: 'P-256' }},
+        false,
+        ['sign']
+      );
+      const publicRaw = await crypto.subtle.exportKey('raw', pair.publicKey);
+      record = {{ privateKey: pair.privateKey, publicRaw, createdAtMs: Date.now() }};
+      await new Promise((resolve, reject) => {{
+        const tx = db.transaction('keys', 'readwrite');
+        tx.objectStore('keys').put(record, 'v1');
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+      }});
+    }}
+    return {{ publicRawB64u: bufToB64u(record.publicRaw) }};
+  }} finally {{
+    db.close();
+  }}
+}}
+
+/* First-owner bootstrap tag (mirrors connect_rendezvous.rs): HMAC-SHA256
+   keyed by SHA-256(normalized phrase) over a payload binding this
+   browser's key and account. The service relays it blind — it holds the
+   phrase's hash, never the phrase, so only a phrase-holder can endorse a
+   key for enrollment. */
+async function bootstrapTag(normalizedPhrase, daemonId, daemonPublicKey, clientKeyB64u, userId, accountName) {{
+  const phraseDigest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(normalizedPhrase)
+  );
+  const hmacKey = await crypto.subtle.importKey(
+    'raw',
+    phraseDigest,
+    {{ name: 'HMAC', hash: 'SHA-256' }},
+    false,
+    ['sign']
+  );
+  const payload = `intendant-connect-bootstrap-v1\n${{daemonId}}\n${{daemonPublicKey}}\n${{clientKeyB64u}}\n${{userId}}\n${{accountName}}\n`;
+  const tag = await crypto.subtle.sign('HMAC', hmacKey, new TextEncoder().encode(payload));
+  return bufToB64u(tag);
+}}
+
 async function claimDaemon() {{
   const claimCode = $('claim-code').value.trim();
   if (!claimCode) throw new Error('Claim phrase is required');
   setBusy('claim', true);
   setStatus('claim-status', 'Waiting for daemon proof', '');
   try {{
+    const normalized = normalizeClaimPhrase(claimCode);
+    if (!normalized) throw new Error('Claim phrase is required');
+    // Hash-only claim: the service routes by digest and never sees the
+    // plaintext phrase (a daemon-minted phrase must stay between the
+    // daemon and this browser).
     const start = await api('/api/claims/claim', {{
       method: 'POST',
-      body: JSON.stringify({{ claim_code: claimCode }}),
+      body: JSON.stringify({{ claim_code_hash: await sha256B64uOfText(normalized) }}),
     }});
+    let bootstrap = false;
+    if (start.needs_bootstrap_arm) {{
+      bootstrap = true;
+      setStatus('claim-status', 'Fresh daemon — enrolling this browser as its first owner', '');
+      const identity = await ensureOwnIdentity();
+      const tag = await bootstrapTag(
+        normalized,
+        String(start.daemon_id || ''),
+        String(start.daemon_public_key || ''),
+        identity.publicRawB64u,
+        String(state.user?.id || ''),
+        String(state.user?.account_name || '')
+      );
+      await api(`/api/claims/${{encodeURIComponent(start.claim_id)}}/arm`, {{
+        method: 'POST',
+        body: JSON.stringify({{ client_key: identity.publicRawB64u, client_key_tag: tag }}),
+      }});
+    }}
     const deadline = Date.now() + 65000;
     while (Date.now() < deadline) {{
       await new Promise(resolve => setTimeout(resolve, 750));
       const status = await api(`/api/claims/${{encodeURIComponent(start.claim_id)}}`);
       if (status.result?.status === 'approved') {{
-        setStatus('claim-status', `Rendezvous route claimed for ${{status.result.daemon_id}}. Next: open that daemon directly (its https://host:8765 address) as root, go to Access → People & Devices, and grant this account a role — until then the daemon will refuse hosted dashboard control.`, 'ok');
+        setStatus(
+          'claim-status',
+          bootstrap
+            ? `Claimed ${{status.result.daemon_id}} — and this browser is enrolled as its first owner (role: root, co-signed by the daemon). Open it from your computers list; the dashboard signs in with this browser's key.`
+            : `Rendezvous route claimed for ${{status.result.daemon_id}}. Next: open that daemon directly (its https://host:8765 address) as root, go to Access → People & Devices, and grant this account a role — until then the daemon will refuse hosted dashboard control.`,
+          'ok'
+        );
         $('claim-code').value = '';
         await refreshAll();
         return;
@@ -7409,6 +7742,7 @@ mod tests {
             daemon_public_key: format!("{daemon_id}-key"),
             owner_user_id,
             claim_code_hash: claim_code.map(claim_code_hash),
+            claim_code_daemon_minted: false,
             claim_code_created_unix_ms,
             registered_unix_ms: 1,
             last_seen_unix_ms: 1,
@@ -7726,6 +8060,25 @@ mod tests {
         ));
     }
 
+    /// Twin of the daemon's `claim_code_hash_matches_the_service_construction`
+    /// (and the /connect page JS): one shared literal pins the hash across
+    /// all three implementations.
+    #[test]
+    fn claim_code_hash_pins_the_cross_binary_literal() {
+        assert_eq!(
+            claim_code_hash("  Abandon ABILITY__able "),
+            "Q4-Jf1pewq3jBEyujMeltvQLFADs3UikZAMej9Iu4j0"
+        );
+        assert!(is_sha256_b64u(
+            "Q4-Jf1pewq3jBEyujMeltvQLFADs3UikZAMej9Iu4j0"
+        ));
+        assert!(!is_sha256_b64u("too-short"));
+        assert!(!is_sha256_b64u(&format!(
+            "{}=",
+            "Q4-Jf1pewq3jBEyujMeltvQLFADs3UikZAMej9Iu4j0"
+        )));
+    }
+
     #[test]
     fn claim_code_normalization_accepts_case_and_separator_variants() {
         let code = "abandon-ability-able-about-above-absent-absorb";
@@ -7939,6 +8292,7 @@ mod tests {
                 daemon_public_key: "daemon-key".to_string(),
                 owner_user_id: Some(user_id),
                 claim_code_hash: None,
+                claim_code_daemon_minted: false,
                 claim_code_created_unix_ms: None,
                 registered_unix_ms: 10,
                 last_seen_unix_ms: now_unix_ms(),

--- a/src/bin/connect/main.rs
+++ b/src/bin/connect/main.rs
@@ -4221,6 +4221,12 @@ struct RendezvousEvent {
     client_key_sig: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     client_key_ts: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    client_key_proto: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    client_key_account_user_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    client_key_account_name: Option<String>,
     // Signed org-grant document, also relayed verbatim: the daemon verifies
     // it against the org keys it locally trusts, so this service can
     // neither mint nor amplify one.
@@ -4855,6 +4861,12 @@ struct BrowserOfferRequest {
     #[serde(default)]
     client_key_ts: Option<i64>,
     #[serde(default)]
+    client_key_proto: Option<String>,
+    #[serde(default)]
+    client_key_account_user_id: Option<String>,
+    #[serde(default)]
+    client_key_account_name: Option<String>,
+    #[serde(default)]
     org_grant: Option<serde_json::Value>,
 }
 
@@ -5284,6 +5296,27 @@ async fn browser_offer(
                 .filter(|v| !v.is_empty())
                 .map(str::to_string),
             client_key_ts: body.client_key_ts,
+            // v2 offer-signature fields, relayed verbatim like the key
+            // itself: the daemon verifies the signature covers them, so
+            // this service can neither mint nor alter an account claim.
+            client_key_proto: body
+                .client_key_proto
+                .as_deref()
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
+                .map(str::to_string),
+            client_key_account_user_id: body
+                .client_key_account_user_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
+                .map(str::to_string),
+            client_key_account_name: body
+                .client_key_account_name
+                .as_deref()
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
+                .map(str::to_string),
             // Opaque passthrough, size-capped so the relay cannot be used
             // to firehose daemons; the daemon re-verifies and rate-limits.
             org_grant: body.org_grant.filter(|doc| {

--- a/static/app.html
+++ b/static/app.html
@@ -42754,7 +42754,9 @@ function renderAccessConnectCard() {
     const expiresText = expires
       ? ` · expires ${new Date(expires).toLocaleTimeString()} (a fresh phrase mints automatically)`
       : '';
-    hint.textContent = `Sign in and enter this phrase to claim this daemon into your fleet${expiresText}`;
+    hint.textContent = status.bootstrap
+      ? `First-owner bootstrap: this daemon minted the phrase itself (the rendezvous holds only its hash). Entering it claims the daemon AND enrolls the claiming browser as owner${expiresText || ' · valid while this daemon runs'}`
+      : `Sign in and enter this phrase to claim this daemon into your fleet${expiresText}`;
     card.appendChild(hint);
     if (accessConnectRevealed.claim_url) {
       const linkRow = document.createElement('div');

--- a/static/app.html
+++ b/static/app.html
@@ -17895,8 +17895,14 @@ window.intendantVault = {
 /* Sign an offer. Absence is legacy-compatible (the daemon falls back to
    account/trusted-transport identity); a present-but-invalid signature is
    rejected by the daemon, so a signaling relay can neither forge nor splice
-   a key binding. */
-async function clientIdentityOfferFields(daemonId, clientNonce, sdp) {
+   a key binding.
+
+   With `account` ({userId, name}) the signature covers the v2 payload,
+   which additionally binds this browser's OWN account claim — the pending
+   enrollment then shows "@name" attested by the device key instead of
+   whatever the relay asserts. Mirrors access/client_key.rs payloads
+   byte-for-byte. */
+async function clientIdentityOfferFields(daemonId, clientNonce, sdp, account) {
   try {
     const identity = await clientIdentityGet();
     if (!identity) return {};
@@ -17904,8 +17910,13 @@ async function clientIdentityOfferFields(daemonId, clientNonce, sdp) {
     const sdpDigest = dashboardBytesToBase64Url(
       new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(sdp)))
     );
+    const accountUserId = account?.userId ? String(account.userId).trim() : '';
+    const accountName = account?.name ? String(account.name).trim() : '';
+    const v2 = Boolean(accountUserId);
     const payload = new TextEncoder().encode(
-      `intendant-client-key-offer-v1\n${daemonId || ''}\n${clientNonce || ''}\n${sdpDigest}\n${ts}`
+      v2
+        ? `intendant-client-key-offer-v2\n${daemonId || ''}\n${clientNonce || ''}\n${sdpDigest}\n${ts}\n${accountUserId}\n${accountName}`
+        : `intendant-client-key-offer-v1\n${daemonId || ''}\n${clientNonce || ''}\n${sdpDigest}\n${ts}`
     );
     const signature = await crypto.subtle.sign(
       { name: 'ECDSA', hash: 'SHA-256' },
@@ -17916,6 +17927,13 @@ async function clientIdentityOfferFields(daemonId, clientNonce, sdp) {
       client_key: identity.publicRawB64u,
       client_key_sig: dashboardBytesToBase64Url(new Uint8Array(signature)),
       client_key_ts: ts,
+      ...(v2
+        ? {
+            client_key_proto: 'intendant-client-key-offer-v2',
+            client_key_account_user_id: accountUserId,
+            ...(accountName ? { client_key_account_name: accountName } : {}),
+          }
+        : {}),
     };
   } catch (err) {
     console.warn('[client-identity] offer signing failed:', err?.message || err);
@@ -42228,11 +42246,33 @@ function accessPeerGrantCounts(overview = accessOverviewModel()) {
   };
 }
 
+/* This device's own identity-key fingerprint, cached for synchronous
+   renderers. The SAS property of the knock ceremony: the approving human
+   compares the fingerprint the REQUESTING device displays locally against
+   the pending entry on the trusted session — approval by comparison, not
+   by timing coincidence. */
+let accessOwnDeviceFingerprint = '';
+let accessOwnDeviceFingerprintRequested = false;
+function accessEnsureOwnFingerprint() {
+  if (accessOwnDeviceFingerprintRequested) return;
+  accessOwnDeviceFingerprintRequested = true;
+  (async () => {
+    try {
+      const identity = await clientIdentityGet();
+      if (identity?.fingerprint) {
+        accessOwnDeviceFingerprint = String(identity.fingerprint);
+        renderAccessAdminSummaries();
+      }
+    } catch { /* no identity available — the hint below stays generic */ }
+  })();
+}
+
 /* Overview: actionable warnings first — an empty div when all is well. */
 function renderAccessAttention() {
   const mount = document.getElementById('access-attention');
   if (!mount) return;
   mount.innerHTML = '';
+  accessEnsureOwnFingerprint();
   const items = [];
   const status = dashboardTransport?.status
     ? dashboardTransport.status()
@@ -42249,6 +42289,9 @@ function renderAccessAttention() {
         steps: [
           'Open the daemon directly (its https://host:8765 address) with root access.',
           'Go to Access → People & Devices and grant your Connect account a role.',
+          accessOwnDeviceFingerprint
+            ? `Verify it is really this device: this browser's key fingerprint is ${accessOwnDeviceFingerprint} — approve the pending request only if it matches.`
+            : 'Compare the pending request’s key fingerprint against this device before approving.',
           'Reload this page — Connect is only the route; the daemon decides.',
         ],
         action: { label: 'Diagnostics', onClick: () => routeTo('access', 'diagnostics') },
@@ -42850,6 +42893,11 @@ function renderAccessEnrollmentRequests() {
     headRow.append(glyphEl, nameWrap);
     if (request.origin) {
       headRow.appendChild(accessRouteChip('connect', 'via hosted route', `The offer arrived through ${request.origin}; the key will be recorded with that origin, so the role ceiling applies until it is re-enrolled from an anchor origin.`));
+    }
+    if (request.account_hint) {
+      headRow.appendChild(request.account_attested
+        ? accessRouteChip('webrtc', 'account attested ✓', 'The device key itself signed this account claim (v2 offer) — the name is as trustworthy as the key fingerprint below.')
+        : accessRouteChip('remembered', 'account via route', 'The account name is asserted by the signaling relay, not signed by the device key. Verify the key fingerprint against the requesting device before trusting the name.'));
     }
     card.appendChild(headRow);
 
@@ -54731,11 +54779,20 @@ class DashboardControlTransport {
     return body;
   }
 
+  /* One cached /api/me fetch serves both the CSRF header and the signed
+     account claim on v2 offers. */
+  async connectMe() {
+    if (!this.connectMeInfo) {
+      const resp = await fetch('/api/me');
+      this.connectMeInfo = await resp.json().catch(() => ({}));
+    }
+    return this.connectMeInfo || {};
+  }
+
   async connectSignalHeaders() {
     if (!this.connectCsrfToken) {
-      const resp = await fetch('/api/me');
-      const body = await resp.json().catch(() => ({}));
-      this.connectCsrfToken = String(body.csrf_token || '');
+      const me = await this.connectMe();
+      this.connectCsrfToken = String(me.csrf_token || '');
     }
     const headers = { 'content-type': 'application/json' };
     if (this.connectCsrfToken) headers['x-intendant-csrf'] = this.connectCsrfToken;
@@ -54755,10 +54812,18 @@ class DashboardControlTransport {
       if (!DASHBOARD_CONNECT_DAEMON_ID) {
         throw new Error('Connect dashboard missing daemon_id');
       }
+      // Sign the browser's own account claim into the offer (v2) so the
+      // daemon's pending-enrollment card can show an account attested by
+      // this device key rather than asserted by the relay.
+      const me = await this.connectMe().catch(() => ({}));
+      const account = me?.authenticated && me?.user?.id
+        ? { userId: String(me.user.id), name: String(me.user.account_name || '') }
+        : null;
       const identity = await clientIdentityOfferFields(
         DASHBOARD_CONNECT_DAEMON_ID,
         this.clientNonce,
-        sdp
+        sdp,
+        account
       );
       // A stored org grant rides along so a daemon that trusts the org
       // materializes it before resolving this very offer (one-round-trip

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -2326,8 +2326,14 @@ window.intendantVault = {
 /* Sign an offer. Absence is legacy-compatible (the daemon falls back to
    account/trusted-transport identity); a present-but-invalid signature is
    rejected by the daemon, so a signaling relay can neither forge nor splice
-   a key binding. */
-async function clientIdentityOfferFields(daemonId, clientNonce, sdp) {
+   a key binding.
+
+   With `account` ({userId, name}) the signature covers the v2 payload,
+   which additionally binds this browser's OWN account claim — the pending
+   enrollment then shows "@name" attested by the device key instead of
+   whatever the relay asserts. Mirrors access/client_key.rs payloads
+   byte-for-byte. */
+async function clientIdentityOfferFields(daemonId, clientNonce, sdp, account) {
   try {
     const identity = await clientIdentityGet();
     if (!identity) return {};
@@ -2335,8 +2341,13 @@ async function clientIdentityOfferFields(daemonId, clientNonce, sdp) {
     const sdpDigest = dashboardBytesToBase64Url(
       new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(sdp)))
     );
+    const accountUserId = account?.userId ? String(account.userId).trim() : '';
+    const accountName = account?.name ? String(account.name).trim() : '';
+    const v2 = Boolean(accountUserId);
     const payload = new TextEncoder().encode(
-      `intendant-client-key-offer-v1\n${daemonId || ''}\n${clientNonce || ''}\n${sdpDigest}\n${ts}`
+      v2
+        ? `intendant-client-key-offer-v2\n${daemonId || ''}\n${clientNonce || ''}\n${sdpDigest}\n${ts}\n${accountUserId}\n${accountName}`
+        : `intendant-client-key-offer-v1\n${daemonId || ''}\n${clientNonce || ''}\n${sdpDigest}\n${ts}`
     );
     const signature = await crypto.subtle.sign(
       { name: 'ECDSA', hash: 'SHA-256' },
@@ -2347,6 +2358,13 @@ async function clientIdentityOfferFields(daemonId, clientNonce, sdp) {
       client_key: identity.publicRawB64u,
       client_key_sig: dashboardBytesToBase64Url(new Uint8Array(signature)),
       client_key_ts: ts,
+      ...(v2
+        ? {
+            client_key_proto: 'intendant-client-key-offer-v2',
+            client_key_account_user_id: accountUserId,
+            ...(accountName ? { client_key_account_name: accountName } : {}),
+          }
+        : {}),
     };
   } catch (err) {
     console.warn('[client-identity] offer signing failed:', err?.message || err);

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -803,7 +803,9 @@ function renderAccessConnectCard() {
     const expiresText = expires
       ? ` · expires ${new Date(expires).toLocaleTimeString()} (a fresh phrase mints automatically)`
       : '';
-    hint.textContent = `Sign in and enter this phrase to claim this daemon into your fleet${expiresText}`;
+    hint.textContent = status.bootstrap
+      ? `First-owner bootstrap: this daemon minted the phrase itself (the rendezvous holds only its hash). Entering it claims the daemon AND enrolls the claiming browser as owner${expiresText || ' · valid while this daemon runs'}`
+      : `Sign in and enter this phrase to claim this daemon into your fleet${expiresText}`;
     card.appendChild(hint);
     if (accessConnectRevealed.claim_url) {
       const linkRow = document.createElement('div');

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -295,11 +295,33 @@ function accessPeerGrantCounts(overview = accessOverviewModel()) {
   };
 }
 
+/* This device's own identity-key fingerprint, cached for synchronous
+   renderers. The SAS property of the knock ceremony: the approving human
+   compares the fingerprint the REQUESTING device displays locally against
+   the pending entry on the trusted session — approval by comparison, not
+   by timing coincidence. */
+let accessOwnDeviceFingerprint = '';
+let accessOwnDeviceFingerprintRequested = false;
+function accessEnsureOwnFingerprint() {
+  if (accessOwnDeviceFingerprintRequested) return;
+  accessOwnDeviceFingerprintRequested = true;
+  (async () => {
+    try {
+      const identity = await clientIdentityGet();
+      if (identity?.fingerprint) {
+        accessOwnDeviceFingerprint = String(identity.fingerprint);
+        renderAccessAdminSummaries();
+      }
+    } catch { /* no identity available — the hint below stays generic */ }
+  })();
+}
+
 /* Overview: actionable warnings first — an empty div when all is well. */
 function renderAccessAttention() {
   const mount = document.getElementById('access-attention');
   if (!mount) return;
   mount.innerHTML = '';
+  accessEnsureOwnFingerprint();
   const items = [];
   const status = dashboardTransport?.status
     ? dashboardTransport.status()
@@ -316,6 +338,9 @@ function renderAccessAttention() {
         steps: [
           'Open the daemon directly (its https://host:8765 address) with root access.',
           'Go to Access → People & Devices and grant your Connect account a role.',
+          accessOwnDeviceFingerprint
+            ? `Verify it is really this device: this browser's key fingerprint is ${accessOwnDeviceFingerprint} — approve the pending request only if it matches.`
+            : 'Compare the pending request’s key fingerprint against this device before approving.',
           'Reload this page — Connect is only the route; the daemon decides.',
         ],
         action: { label: 'Diagnostics', onClick: () => routeTo('access', 'diagnostics') },
@@ -917,6 +942,11 @@ function renderAccessEnrollmentRequests() {
     headRow.append(glyphEl, nameWrap);
     if (request.origin) {
       headRow.appendChild(accessRouteChip('connect', 'via hosted route', `The offer arrived through ${request.origin}; the key will be recorded with that origin, so the role ceiling applies until it is re-enrolled from an anchor origin.`));
+    }
+    if (request.account_hint) {
+      headRow.appendChild(request.account_attested
+        ? accessRouteChip('webrtc', 'account attested ✓', 'The device key itself signed this account claim (v2 offer) — the name is as trustworthy as the key fingerprint below.')
+        : accessRouteChip('remembered', 'account via route', 'The account name is asserted by the signaling relay, not signed by the device key. Verify the key fingerprint against the requesting device before trusting the name.'));
     }
     card.appendChild(headRow);
 

--- a/static/app/50-control-transport.js
+++ b/static/app/50-control-transport.js
@@ -878,11 +878,20 @@ class DashboardControlTransport {
     return body;
   }
 
+  /* One cached /api/me fetch serves both the CSRF header and the signed
+     account claim on v2 offers. */
+  async connectMe() {
+    if (!this.connectMeInfo) {
+      const resp = await fetch('/api/me');
+      this.connectMeInfo = await resp.json().catch(() => ({}));
+    }
+    return this.connectMeInfo || {};
+  }
+
   async connectSignalHeaders() {
     if (!this.connectCsrfToken) {
-      const resp = await fetch('/api/me');
-      const body = await resp.json().catch(() => ({}));
-      this.connectCsrfToken = String(body.csrf_token || '');
+      const me = await this.connectMe();
+      this.connectCsrfToken = String(me.csrf_token || '');
     }
     const headers = { 'content-type': 'application/json' };
     if (this.connectCsrfToken) headers['x-intendant-csrf'] = this.connectCsrfToken;
@@ -902,10 +911,18 @@ class DashboardControlTransport {
       if (!DASHBOARD_CONNECT_DAEMON_ID) {
         throw new Error('Connect dashboard missing daemon_id');
       }
+      // Sign the browser's own account claim into the offer (v2) so the
+      // daemon's pending-enrollment card can show an account attested by
+      // this device key rather than asserted by the relay.
+      const me = await this.connectMe().catch(() => ({}));
+      const account = me?.authenticated && me?.user?.id
+        ? { userId: String(me.user.id), name: String(me.user.account_name || '') }
+        : null;
       const identity = await clientIdentityOfferFields(
         DASHBOARD_CONNECT_DAEMON_ID,
         this.clientNonce,
-        sdp
+        sdp,
+        account
       );
       // A stored org grant rides along so a daemon that trusts the org
       // materializes it before resolving this very offer (one-round-trip


### PR DESCRIPTION
Two hardenings from the Connect security review, closing the parked items.

## Knock-ceremony hardening (792d9e64)

- **v2 offer signatures** (`intendant-client-key-offer-v2`) bind the browser's own account claim into the payload the device key signs. The service relays the fields verbatim; strict version dispatch fails closed on account fields without a v2 signature, unknown protocols, or a v2-attested account that disagrees with the service-stamped session account.
- Pending enrollments record whether the account hint was **attested by the device key** or asserted by the relay; the Access request card shows which chip.
- The refused-knock attention pane displays that browser's own key fingerprint, so approval is a fingerprint comparison across two screens (SAS), not a timing coincidence.
- The dashboard reuses its existing `/api/me` fetch to learn the account and signs v2 automatically in Connect mode; local offers stay v1.

## First-owner bootstrap (61786b44)

Completes the zero-install story: a fresh box (empty IAM) **mints its own twelve-word phrase** and registers only its SHA-256 — the rendezvous can route a claim but cannot claim or enroll against the daemon itself.

- The claim page hashes what the user types (plaintext codes stop leaving the browser for all claims). On `needs_bootstrap_arm` it loads-or-mints this origin's identity key (the same IndexedDB record the dashboard uses) and arms the claim with an HMAC tag keyed by the phrase, binding that exact key and account.
- The daemon recomputes the tag — phrase possession is box-grade proof — enrolls the key as `role:root` under the sentinel origin `connect-bootstrap` (uncapped by hosted-origin ceilings), and only then co-signs the claim. Wrong phrase or swapped key refuses the whole claim, with the reason carried back via a new claim-scoped error channel instead of a silent timeout.
- The window closes forever once any principal or grant exists; daemon-minted hashes are presence-fresh instead of TTL'd. The Access card labels the phrase's bootstrap nature.

## Verification

`cargo test --bins` 2575+38+81 / 0 failed · clippy 0 errors · headless e2e 4/4. Golden literals pin the normalize/hash construction across daemon, service, and page JS; twin tests on both binaries. Version skew safe in all directions (old daemons/pages keep v1 + plaintext codes; old services see no bootstrap fields).