### PR TITLE
Connect: advertise ICE-TCP at the observed public address (NAT'd daemons)

### DIFF
--- a/docs/src/self-hosted-rendezvous.md
+++ b/docs/src/self-hosted-rendezvous.md
@@ -116,7 +116,19 @@ recovery verb for a squatted or mis-claimed box (whose claiming account
 would never revoke), also exposed as the Access card's "Release claim".
 A fresh claim phrase mints on the next register poll.
 
-## Revocation bulletin board
+## Reachability for NAT'd daemons
+
+Register responses echo `observed_ip` — the public address the service
+saw the poll arrive from. A cloud box's interfaces carry only private
+addresses (the public IP lives on the provider's 1:1 NAT), and the
+dashboard-control engine gathers no server-reflexive candidates, so
+Connect offers advertise an **ICE-TCP candidate at
+`observed_ip:gateway_port`** — the one address the world can actually
+reach, over the same port that already serves the dashboard. Browsers
+dial it directly; no STUN or TURN is required for the hosted
+dashboard-control path (the box's firewall must allow the gateway port
+inbound). Reachability metadata only: a lying proxy chain could at worst
+advertise an unreachable candidate.
 
 The service stores each org's latest root-signed revocation list, blind:
 `POST /api/orgs/revocations/publish` accepts a list whose embedded

--- a/src/bin/caller/connect_rendezvous.rs
+++ b/src/bin/caller/connect_rendezvous.rs
@@ -83,6 +83,12 @@ struct RegisterResponse {
     claim_code_expires_unix_ms: Option<u64>,
     #[serde(default)]
     claim_url: Option<String>,
+    /// This daemon's public address as the rendezvous observed it —
+    /// what a cloud box behind 1:1 NAT advertises as its ICE-TCP
+    /// candidate on Connect offers (reachability metadata, not
+    /// authority).
+    #[serde(default)]
+    observed_ip: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -499,6 +505,8 @@ pub(crate) struct ConnectStatus {
     /// bootstrap phrase: claiming with it also enrolls the claiming
     /// browser as role:root.
     pub bootstrap: bool,
+    /// Public address the rendezvous observes for this daemon.
+    pub observed_ip: Option<String>,
 }
 
 fn status_registry() -> &'static Mutex<ConnectStatus> {
@@ -532,6 +540,9 @@ fn register_nudge() -> &'static Notify {
 struct ClientState {
     handle: Option<JoinHandle<()>>,
     dashboard_control: Option<Arc<DashboardControlRegistry>>,
+    /// The web gateway's TCP port — combined with the rendezvous-observed
+    /// IP to advertise an ICE-TCP candidate on Connect offers.
+    gateway_tcp_port: Option<u16>,
 }
 
 fn client_state() -> &'static Mutex<ClientState> {
@@ -540,6 +551,7 @@ fn client_state() -> &'static Mutex<ClientState> {
         Mutex::new(ClientState {
             handle: None,
             dashboard_control: None,
+            gateway_tcp_port: None,
         })
     })
 }
@@ -547,12 +559,14 @@ fn client_state() -> &'static Mutex<ClientState> {
 pub fn spawn_connect_rendezvous_client(
     config: ConnectConfig,
     dashboard_control: Arc<DashboardControlRegistry>,
+    gateway_tcp_port: Option<u16>,
 ) {
-    client_state()
-        .lock()
-        .expect("connect client state poisoned")
-        .dashboard_control = Some(dashboard_control.clone());
-    start_client(config, dashboard_control);
+    {
+        let mut state = client_state().lock().expect("connect client state poisoned");
+        state.dashboard_control = Some(dashboard_control.clone());
+        state.gateway_tcp_port = gateway_tcp_port;
+    }
+    start_client(config, dashboard_control, gateway_tcp_port);
 }
 
 /// Stop the running client task, if any. All of the task's awaits are
@@ -591,13 +605,13 @@ pub(crate) fn apply_config(config: ConnectConfig) -> Result<bool, String> {
         });
         return Ok(false);
     }
-    let dashboard_control = client_state()
-        .lock()
-        .expect("connect client state poisoned")
-        .dashboard_control
-        .clone()
+    let (dashboard_control, gateway_tcp_port) = {
+        let state = client_state().lock().expect("connect client state poisoned");
+        (state.dashboard_control.clone(), state.gateway_tcp_port)
+    };
+    let dashboard_control = dashboard_control
         .ok_or_else(|| "connect client cannot start before the web gateway".to_string())?;
-    start_client(config, dashboard_control);
+    start_client(config, dashboard_control, gateway_tcp_port);
     Ok(client_state()
         .lock()
         .expect("connect client state poisoned")
@@ -607,7 +621,11 @@ pub(crate) fn apply_config(config: ConnectConfig) -> Result<bool, String> {
 
 /// Shared by boot (`spawn_connect_rendezvous_client`) and the runtime
 /// toggle (`apply_config`).
-fn start_client(config: ConnectConfig, dashboard_control: Arc<DashboardControlRegistry>) {
+fn start_client(
+    config: ConnectConfig,
+    dashboard_control: Arc<DashboardControlRegistry>,
+    gateway_tcp_port: Option<u16>,
+) {
     with_status(|status| {
         status.configured = config.enabled;
         status.env_forced = ConnectConfig::env_forced();
@@ -656,7 +674,7 @@ fn start_client(config: ConnectConfig, dashboard_control: Arc<DashboardControlRe
         }
     };
     let handle = tokio::spawn(async move {
-        run_connect_rendezvous_client(config, base_url, dashboard_control).await;
+        run_connect_rendezvous_client(config, base_url, dashboard_control, gateway_tcp_port).await;
         // Natural exit (identity or HTTP-client construction failure) —
         // an abort via `stop_client` never reaches this line, but that
         // path flips the flag itself.
@@ -674,6 +692,7 @@ async fn run_connect_rendezvous_client(
     config: ConnectConfig,
     base_url: Url,
     dashboard_control: Arc<DashboardControlRegistry>,
+    gateway_tcp_port: Option<u16>,
 ) {
     let identity = match DaemonIdentity::load_or_create_default() {
         Ok(identity) => identity,
@@ -754,6 +773,7 @@ async fn run_connect_rendezvous_client(
                                 &daemon_id,
                                 &identity,
                                 &dashboard_control,
+                                gateway_tcp_port,
                                 event,
                             )
                             .await;
@@ -834,6 +854,7 @@ fn note_register_response(response: &RegisterResponse, base_url: &Url) {
         status.registered = true;
         status.last_register_unix_ms = Some(now);
         status.last_error = None;
+        status.observed_ip = response.observed_ip.clone();
         status.claimed = Some(response.claimed);
         if response.claimed {
             status.claimed_by_user_id = response.claimed_by_user_id.clone();
@@ -1022,6 +1043,7 @@ async fn handle_event(
     daemon_id: &str,
     identity: &DaemonIdentity,
     dashboard_control: &Arc<DashboardControlRegistry>,
+    gateway_tcp_port: Option<u16>,
     event: RendezvousEvent,
 ) {
     match event.kind.as_str() {
@@ -1196,8 +1218,26 @@ async fn handle_event(
                     return;
                 }
             };
+            // A cloud box's interface addresses are private (the public IP
+            // lives on the provider's 1:1 NAT), and this engine gathers no
+            // server-reflexive candidates — so hosted offers advertise an
+            // ICE-TCP candidate at the rendezvous-observed public address
+            // on the gateway port, the one address the world can reach.
+            let tcp_advertised_addr = status_snapshot()
+                .observed_ip
+                .as_deref()
+                .and_then(|ip| ip.parse::<std::net::IpAddr>().ok())
+                .zip(gateway_tcp_port)
+                .map(|(ip, port)| std::net::SocketAddr::new(ip, port));
             match dashboard_control
-                .answer_offer_with_grant(sdp.to_string(), session_grant, client_nonce, grant)
+                .answer_offer_with_session_id_grant_and_tcp(
+                    uuid::Uuid::new_v4().to_string(),
+                    sdp.to_string(),
+                    session_grant,
+                    client_nonce,
+                    grant,
+                    tcp_advertised_addr,
+                )
                 .await
             {
                 Ok(answer) => {
@@ -2277,6 +2317,7 @@ mod tests {
                 claim_code_daemon_minted: false,
                 claim_code_expires_unix_ms: None,
                 claim_url: None,
+                observed_ip: None,
             },
             &base_url,
         );
@@ -2294,6 +2335,7 @@ mod tests {
                 claim_code_daemon_minted: false,
                 claim_code_expires_unix_ms: None,
                 claim_url: None,
+                observed_ip: None,
             },
             &base_url,
         );
@@ -2314,6 +2356,7 @@ mod tests {
                 claim_url: Some(
                     "https://connect.example/connect?claim_code=word-word-word".to_string(),
                 ),
+                observed_ip: None,
             },
             &base_url,
         );

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -551,6 +551,7 @@ pub fn spawn_web_gateway(
     crate::connect_rendezvous::spawn_connect_rendezvous_client(
         config.connect.clone(),
         dashboard_control.clone(),
+        tcp_advertised_port,
     );
 
     // F-1.3b3 federated authority subscribers. Federated counterpart

--- a/src/bin/connect/main.rs
+++ b/src/bin/connect/main.rs
@@ -2726,6 +2726,22 @@ fn client_rate_key(headers: &HeaderMap, scope: &str) -> String {
     format!("{scope}:{peer}")
 }
 
+/// The caller's public IP as this service observed it (first
+/// X-Forwarded-For hop behind the TLS proxy, else X-Real-IP), validated
+/// as a literal address. Echoed to registering daemons so a box behind
+/// 1:1 NAT (every cloud VM) learns the address the world reaches it by —
+/// the daemon advertises it as an ICE-TCP candidate on Connect offers.
+/// Advisory reachability metadata, not authority: a lying proxy could
+/// only make the daemon advertise an unreachable candidate.
+fn client_observed_ip(headers: &HeaderMap) -> Option<String> {
+    header_string(headers, "x-forwarded-for")
+        .and_then(|v| v.split(',').next().map(str::trim).map(str::to_string))
+        .filter(|v| !v.is_empty())
+        .or_else(|| header_string(headers, "x-real-ip"))
+        .and_then(|v| v.parse::<std::net::IpAddr>().ok())
+        .map(|ip| ip.to_string())
+}
+
 async fn check_rate_limit(
     state: &AppState,
     headers: &HeaderMap,
@@ -4063,6 +4079,7 @@ async fn daemon_register(
     Json(body): Json<DaemonRegisterRequest>,
 ) -> ApiResult<Json<serde_json::Value>> {
     require_daemon_auth(&state, &headers)?;
+    let observed_ip = client_observed_ip(&headers);
     check_rate_limit(&state, &headers, "daemon_register", 120, 60_000).await?;
     if body.protocol != PROTOCOL {
         return Err(ApiError::bad_request("unsupported protocol"));
@@ -4214,6 +4231,7 @@ async fn daemon_register(
         "claim_code_expires_unix_ms": claim_code_expires_unix_ms,
         "claim_url": claim_url,
         "daemon_public_key": daemon_public_key,
+        "observed_ip": observed_ip,
     })))
 }
 


### PR DESCRIPTION
Third finding from the live fresh-VPS bootstrap E2E: hosted dashboard control can never establish to a cloud daemon. The box's interfaces carry only private addresses (the public IP is the provider's 1:1 NAT), the control-channel engine gathers no server-reflexive candidates, and the Connect offer path advertised no TCP candidate — the browser sees only `172.31.x`, the daemon sees only the browser's mDNS candidate, and ICE goes Checking → Failed forever.

Fix uses the pieces that already exist: register responses echo `observed_ip` (first X-Forwarded-For hop, validated as a literal IP), and the daemon's Connect offer path advertises an **ICE-TCP candidate at `observed_ip:gateway_port`** via the existing ufrag-muxed `TcpPeerRegistry` — the same port that already serves the dashboard. Browsers dial the public TCP candidate directly; no STUN/TURN required for the hosted control path. Reachability metadata, not authority: a lying proxy chain could at worst advertise an unreachable candidate.

Verified live against the E2E box (see follow-up comment after landing): `cargo test` connect suites green on both binaries; docs updated (self-hosted-rendezvous reachability section).