### PR TITLE
Sessions tab perf: viewport windowing, append-only renders, memoized haystacks, capped menus

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -7027,6 +7027,29 @@ body.context-focus-active {
   color: var(--overlay0);
   font-size: 12px;
 }
+/* Inline filter box atop the (capped) project menus. */
+.sessions-multi-filter-search {
+  position: sticky;
+  top: 0;
+  padding: 2px 2px 6px;
+  background: var(--mantle);
+}
+.sessions-multi-filter-search.hidden { display: none; }
+.sessions-multi-filter-search input {
+  width: 100%;
+  padding: 5px 7px;
+  border: 1px solid var(--surface1);
+  border-radius: 4px;
+  background: var(--base);
+  color: var(--text);
+  font-size: 12px;
+}
+.sessions-multi-filter-more {
+  padding: 6px 7px;
+  color: var(--overlay0);
+  font-size: 11px;
+  font-style: italic;
+}
 .sessions-toggle {
   display: flex;
   align-items: center;
@@ -7676,6 +7699,12 @@ body.context-focus-active {
   display: flex;
   justify-content: center;
   padding: 10px 0 4px;
+}
+/* Invisible IntersectionObserver target that auto-grows the sessions
+   render window as the user scrolls toward the bottom of the list. */
+.sessions-scroll-sentinel {
+  height: 1px;
+  pointer-events: none;
 }
 /* Long-tail stats inside the session-detail overlay. */
 .sd-meta-strip {
@@ -14570,12 +14599,17 @@ let apiKeyStatusLoaded = false;
 // sessions/worktrees module state they touch must be declared up here,
 // not next to their renderers (TDZ).
 const SESSION_LIST_RECENT_LIMIT = 600;
-const SESSION_CARD_RENDER_LIMIT = 300;
+// Sessions render in viewport-sized pages: the initial window, the
+// IntersectionObserver auto-append step, and the Show-more fallback step
+// are all one page. Small pages keep the tab's DOM budget flat no matter
+// how large the corpus grows.
+const SESSION_CARD_RENDER_PAGE = 60;
 const WORKTREE_CARD_RENDER_LIMIT = 200;
 // Show-more render windows: how many cards the list renderers paint before
-// offering a "Show N more" button. Reset on filter/search/sort changes and
-// on a fresh (uncached) list load.
-let sessionsRenderWindow = SESSION_CARD_RENDER_LIMIT;
+// offering a "Show N more" button (sessions also auto-grow via a scroll
+// sentinel). Reset on filter/search/sort changes and on a fresh (uncached)
+// list load.
+let sessionsRenderWindow = SESSION_CARD_RENDER_PAGE;
 let worktreesRenderWindow = WORKTREE_CARD_RENDER_LIMIT;
 let _sessionsLoadToken = 0;
 let _sessionsStreamAbort = null;
@@ -14609,6 +14643,11 @@ let _sessionsHydrationState = {
 let _sessionsRenderTimer = null;
 let _sessionsRenderLastTs = 0;
 const SESSIONS_RENDER_MIN_INTERVAL_MS = 250;
+// Sessions list render-pass state (see 57-sessions-replay.js): the
+// #sessions deep link runs loadSessions → resetSessionsListRenderState on
+// this same script-evaluation path.
+const _sessionsListRenderState = new Map(); // list element id → pass state
+let _sessionCardBuildSeq = 0; // stamps built cards; QA asserts node identity by it
 let worktreesRequestSerial = 0;
 let worktreesActivityClearTimeout = null;
 let worktreesLoadPromise = null;
@@ -32064,55 +32103,123 @@ function applySessionRelationshipsFromSession(session) {
   }
 }
 
+function _foldSessionWindowMetadataRow(session, changedIds) {
+  const meta = sessionWindowMetaFromSession(session);
+  const ids = Array.from(new Set([
+    session.session_id,
+    session.resume_id,
+    session.backend_session_id,
+    session.intendant_session_id,
+  ].map(id => String(id || '').trim()).filter(Boolean)));
+  for (const id of ids) {
+    sessionRowSeenIds.add(id);
+    sessionRelationshipHydrationUnresolved.delete(id);
+    const { meta: merged, changed } = mergeSessionWindowMetadata(id, meta);
+    if (changed && sessionWindows.has(id)) updateSessionWindow(id, merged);
+    if (changed) changedIds.add(id);
+  }
+  if (session.backend_session_id && session.session_id) {
+    applySessionIdentity({
+      session_id: session.session_id,
+      backend_session_id: session.backend_session_id,
+      source: session.backend_source,
+      backend_source_label: session.backend_source_label,
+    });
+  }
+  if (!sessionMetadataStatusIsTerminal(session)) {
+    const rawSource = String(session.source || '').trim().toLowerCase();
+    const source = rawSource === 'intendant'
+      ? 'intendant'
+      : normalizeAgentId(session.source || session.backend_source || '');
+    const backendSessionId = String(session.backend_session_id || '').trim();
+    const intendantSessionId = String(session.intendant_session_id || '').trim();
+    const sessionId = String(session.session_id || '').trim();
+    if (source && source !== 'intendant' && intendantSessionId) {
+      clearStaleSessionWindowDetached(sessionId, 'session metadata reports an attached wrapper');
+    }
+    if (source === 'intendant' && backendSessionId) {
+      clearStaleSessionWindowDetached(backendSessionId, 'wrapper metadata reports this session is attached');
+    }
+  }
+  scheduleExternalSessionWindowTranscriptSyncFromMetadata(session);
+}
+
+// Full-corpus list applies fold thousands of rows; running that
+// synchronously on every stream flush stalled the main thread. Small
+// batches still fold inline (event-driven single-row refreshes stay
+// immediate); large ones fold in idle-time slices. A batch arriving
+// mid-fold queues behind it — latest wins, so every row is eventually
+// folded with the newest data — and the DOM label refresh plus the
+// persist run once per completed fold, not once per flush.
+const SESSION_WINDOW_META_FOLD_SYNC_MAX = 400;
+const SESSION_WINDOW_META_FOLD_CHUNK = 400;
+let _sessionWindowMetaFold = null; // { rows, index, phase, changedIds, queued }
+
 function cacheSessionWindowMetadata(sessions) {
   if (!Array.isArray(sessions)) return;
-  const changedIds = new Set();
-  for (const session of sessions) {
+  if (sessions.length <= SESSION_WINDOW_META_FOLD_SYNC_MAX && !_sessionWindowMetaFold) {
+    const changedIds = new Set();
+    for (const session of sessions) {
+      if (!session || typeof session !== 'object') continue;
+      _foldSessionWindowMetadataRow(session, changedIds);
+    }
+    for (const session of sessions) {
+      if (!session || typeof session !== 'object') continue;
+      applySessionRelationshipsFromSession(session);
+    }
+    refreshSessionIdentityLabelsBulk(changedIds);
+    persistSessionWindowState();
+    return;
+  }
+  if (_sessionWindowMetaFold) {
+    // Union-merge rather than replace: a small event-driven batch queued
+    // behind an in-flight fold must not drop a queued full-corpus apply
+    // (mergeSessionRows keeps newest-per-row).
+    _sessionWindowMetaFold.queued = _sessionWindowMetaFold.queued
+      ? mergeSessionRows(_sessionWindowMetaFold.queued, sessions)
+      : sessions;
+    return;
+  }
+  _sessionWindowMetaFold = { rows: sessions, index: 0, phase: 'meta', changedIds: new Set(), queued: null };
+  _scheduleSessionWindowMetaFoldSlice();
+}
+
+function _scheduleSessionWindowMetaFoldSlice() {
+  if (typeof requestIdleCallback === 'function') {
+    requestIdleCallback(deadline => _runSessionWindowMetaFoldSlice(deadline), { timeout: 300 });
+  } else {
+    setTimeout(() => _runSessionWindowMetaFoldSlice(null), 16);
+  }
+}
+
+function _runSessionWindowMetaFoldSlice(deadline) {
+  const fold = _sessionWindowMetaFold;
+  if (!fold) return;
+  const hasBudget = () => deadline && typeof deadline.timeRemaining === 'function'
+    ? deadline.timeRemaining() > 2
+    : true;
+  let processed = 0;
+  while (processed < SESSION_WINDOW_META_FOLD_CHUNK && hasBudget()) {
+    if (fold.index >= fold.rows.length) {
+      if (fold.phase === 'meta') {
+        fold.phase = 'relationships';
+        fold.index = 0;
+        continue;
+      }
+      _sessionWindowMetaFold = null;
+      refreshSessionIdentityLabelsBulk(fold.changedIds);
+      persistSessionWindowState();
+      if (fold.queued) cacheSessionWindowMetadata(fold.queued);
+      return;
+    }
+    const session = fold.rows[fold.index];
+    fold.index += 1;
     if (!session || typeof session !== 'object') continue;
-    const meta = sessionWindowMetaFromSession(session);
-    const ids = Array.from(new Set([
-      session.session_id,
-      session.resume_id,
-      session.backend_session_id,
-      session.intendant_session_id,
-    ].map(id => String(id || '').trim()).filter(Boolean)));
-    for (const id of ids) {
-      sessionRowSeenIds.add(id);
-      sessionRelationshipHydrationUnresolved.delete(id);
-      const { meta: merged, changed } = mergeSessionWindowMetadata(id, meta);
-      if (changed && sessionWindows.has(id)) updateSessionWindow(id, merged);
-      if (changed) changedIds.add(id);
-    }
-    if (session.backend_session_id && session.session_id) {
-      applySessionIdentity({
-        session_id: session.session_id,
-        backend_session_id: session.backend_session_id,
-        source: session.backend_source,
-        backend_source_label: session.backend_source_label,
-      });
-    }
-    if (!sessionMetadataStatusIsTerminal(session)) {
-      const rawSource = String(session.source || '').trim().toLowerCase();
-      const source = rawSource === 'intendant'
-        ? 'intendant'
-        : normalizeAgentId(session.source || session.backend_source || '');
-      const backendSessionId = String(session.backend_session_id || '').trim();
-      const intendantSessionId = String(session.intendant_session_id || '').trim();
-      const sessionId = String(session.session_id || '').trim();
-      if (source && source !== 'intendant' && intendantSessionId) {
-        clearStaleSessionWindowDetached(sessionId, 'session metadata reports an attached wrapper');
-      }
-      if (source === 'intendant' && backendSessionId) {
-        clearStaleSessionWindowDetached(backendSessionId, 'wrapper metadata reports this session is attached');
-      }
-    }
-    scheduleExternalSessionWindowTranscriptSyncFromMetadata(session);
+    if (fold.phase === 'meta') _foldSessionWindowMetadataRow(session, fold.changedIds);
+    else applySessionRelationshipsFromSession(session);
+    processed += 1;
   }
-  for (const session of sessions) {
-    applySessionRelationshipsFromSession(session);
-  }
-  refreshSessionIdentityLabelsBulk(changedIds);
-  persistSessionWindowState();
+  _scheduleSessionWindowMetaFoldSlice();
 }
 
 // One DOM pass for a whole metadata batch. The per-id
@@ -68966,7 +69073,7 @@ function setSessionsHost(hostId) {
   const next = !hostId || hostId === selfPeerId ? '' : String(hostId);
   if (next === sessionsActiveHostId) return;
   sessionsActiveHostId = next;
-  sessionsRenderWindow = SESSION_CARD_RENDER_LIMIT;
+  sessionsRenderWindow = SESSION_CARD_RENDER_PAGE;
   renderSessionsHostStrip();
   loadSessions({ force: true });
 }
@@ -69064,8 +69171,10 @@ function loadSessions(options = {}) {
   if (cached) {
     applyLoadedSessions(cached, aggEl, hostId);
   } else if (listEl) {
-    // Fresh (uncached) load replaces the list — reset the Show-more window.
-    sessionsRenderWindow = SESSION_CARD_RENDER_LIMIT;
+    // Fresh (uncached) load replaces the list — reset the Show-more window
+    // and drop the render-pass state (the skeleton wipe orphans its DOM).
+    sessionsRenderWindow = SESSION_CARD_RENDER_PAGE;
+    resetSessionsListRenderState(listEl.id);
     listEl.innerHTML = '<div class="ui-skel sessions-skel-card"></div>'.repeat(6);
   }
 
@@ -69189,6 +69298,7 @@ function loadSessions(options = {}) {
           requestedLimit,
         );
         if (!cached && listEl) {
+          resetSessionsListRenderState(listEl.id);
           listEl.innerHTML = '<div class="empty-state">Failed to load sessions</div>';
         }
       });
@@ -69318,7 +69428,17 @@ function sessionLineageRelationshipLabel(kind) {
   return kind || 'related';
 }
 
+// Single-slot memo: the index costs two sessionConfigMetadata sweeps over
+// the whole corpus, and every render pass (each search keystroke included)
+// wants it. The rowset array is replaced whenever data changes
+// (mergeSessionRows), so array identity is the invalidation key.
+let _sessionLineageIndexFor = null;
+let _sessionLineageIndexMemo = null;
+
 function buildSessionLineageIndex(sessions) {
+  if (sessions && sessions === _sessionLineageIndexFor && _sessionLineageIndexMemo) {
+    return _sessionLineageIndexMemo;
+  }
   const byId = new Map();
   const childrenByParentId = new Map();
   const rows = Array.isArray(sessions) ? sessions : [];
@@ -69337,7 +69457,15 @@ function buildSessionLineageIndex(sessions) {
     if (!childrenByParentId.has(parentId)) childrenByParentId.set(parentId, []);
     childrenByParentId.get(parentId).push(session);
   }
-  return { byId, childrenByParentId };
+  // Deterministic child ordering regardless of the caller's sort: newest
+  // first (the index used to inherit the list's sort order).
+  for (const children of childrenByParentId.values()) {
+    children.sort((a, b) => sessionDateSortValue(b, 'updated_at') - sessionDateSortValue(a, 'updated_at'));
+  }
+  const index = { byId, childrenByParentId };
+  _sessionLineageIndexFor = sessions;
+  _sessionLineageIndexMemo = index;
+  return index;
 }
 
 function sessionLineageParentForSession(index, session, meta = null) {
@@ -69372,7 +69500,9 @@ function sessionLineageOpenSession(sourceSession, targetSession, targetId, ev = 
   }
   const id = compactSessionText(targetId || targetSession?.session_id || targetSession?.resume_id);
   if (!id) return;
-  const target = targetSession || {
+  // Re-resolve at click time: lineage chips can outlive the row snapshot
+  // they were built from (cards are cached across stream refreshes).
+  const target = findCachedSessionByAnyId(id) || targetSession || {
     session_id: id,
     source: sessionLineageSource(sourceSession),
     task: shortSessionId(id),
@@ -69520,7 +69650,7 @@ function _refilterSessions() {
 // Filter/search/sort change: the visible set changes shape, so the
 // Show-more window snaps back to the default page size.
 function _refreshSessionsFilters() {
-  sessionsRenderWindow = SESSION_CARD_RENDER_LIMIT;
+  sessionsRenderWindow = SESSION_CARD_RENDER_PAGE;
   _refilterSessions();
 }
 
@@ -69545,6 +69675,20 @@ function sessionChangedSortValue(session) {
   );
 }
 
+// Throwaway scratch paths (agent test homes, e2e rigs, OS temp) can easily
+// outnumber real projects in the corpus. They collapse into one synthetic
+// menu entry instead of ballooning the picker; selecting it matches every
+// temp-shaped path.
+const SESSION_TEMP_PROJECTS_FILTER_VALUE = '::temp-projects::';
+
+function sessionPathLooksTemporary(path) {
+  if (!path) return false;
+  if (/^\/(private\/)?var\/folders\//.test(path)) return true;
+  return String(path)
+    .split(/[\\/]+/)
+    .some(seg => seg === 'tmp' || seg === 'temp' || seg === 'Temp' || seg === 'TEMP');
+}
+
 function sessionProjectFilterOptions(sessions) {
   const buckets = new Map();
   for (const session of Array.isArray(sessions) ? sessions : []) {
@@ -69560,7 +69704,27 @@ function sessionProjectFilterOptions(sessions) {
     existing.latestChanged = Math.max(existing.latestChanged, sessionChangedSortValue(session));
     buckets.set(path, existing);
   }
-  return Array.from(buckets.values()).sort((a, b) => {
+  const options = [];
+  let temp = null;
+  for (const item of buckets.values()) {
+    if (!sessionPathLooksTemporary(item.path)) {
+      options.push(item);
+      continue;
+    }
+    temp = temp || {
+      path: SESSION_TEMP_PROJECTS_FILTER_VALUE,
+      label: 'Temporary directories',
+      title: 'Sessions whose project directory is a throwaway temp path (/tmp, /var/folders, %TEMP%)',
+      count: 0,
+      paths: 0,
+      latestChanged: 0,
+    };
+    temp.count += item.count;
+    temp.paths += 1;
+    temp.latestChanged = Math.max(temp.latestChanged, item.latestChanged);
+  }
+  if (temp) options.push(temp);
+  return options.sort((a, b) => {
     const byChanged = b.latestChanged - a.latestChanged;
     if (byChanged) return byChanged;
     const byLabel = a.label.localeCompare(b.label, undefined, { sensitivity: 'base' });
@@ -69571,10 +69735,49 @@ function sessionProjectFilterOptions(sessions) {
 function sessionProjectMultiFilterOptions(sessions) {
   return sessionProjectFilterOptions(sessions).map(item => ({
     value: item.path,
-    label: `${item.label} (${item.count.toLocaleString()})`,
-    title: item.path,
+    label: item.paths
+      ? `${item.label} (${item.paths.toLocaleString()} paths, ${item.count.toLocaleString()})`
+      : `${item.label} (${item.count.toLocaleString()})`,
+    title: item.title || item.path,
     plural: 'projects',
   }));
+}
+
+// The project menus render a bounded page of the full option set: every
+// selected value (unchecking must always be possible), then the most
+// recently active projects up to the cap, with an inline filter box that
+// narrows against the whole set. An uncapped render once ballooned the
+// hidden DOM with hundreds of scratch-path checkboxes per menu.
+const SESSION_PROJECT_MENU_CAP = 40;
+const _sessionProjectMenuFilterText = new Map(); // menuId → live filter text
+
+function sessionProjectMenuScaffold(menu, kind, cfg) {
+  let optionsWrap = menu.querySelector(':scope > .sessions-multi-filter-options');
+  if (optionsWrap) {
+    return { search: menu.querySelector(':scope > .sessions-multi-filter-search'), optionsWrap };
+  }
+  menu.textContent = '';
+  const search = document.createElement('div');
+  search.className = 'sessions-multi-filter-search';
+  const input = document.createElement('input');
+  input.type = 'search';
+  input.addEventListener('input', () => {
+    _sessionProjectMenuFilterText.set(cfg.menuId, input.value.trim());
+    renderSessionProjectFilterMenu(kind);
+  });
+  input.addEventListener('keydown', (ev) => {
+    if (ev.key !== 'Escape' || !input.value) return;
+    input.value = '';
+    _sessionProjectMenuFilterText.set(cfg.menuId, '');
+    renderSessionProjectFilterMenu(kind);
+    ev.stopPropagation();
+  });
+  search.appendChild(input);
+  optionsWrap = document.createElement('div');
+  optionsWrap.className = 'sessions-multi-filter-options';
+  menu.appendChild(search);
+  menu.appendChild(optionsWrap);
+  return { search, optionsWrap };
 }
 
 function renderSessionProjectFilterMenu(kind) {
@@ -69582,16 +69785,43 @@ function renderSessionProjectFilterMenu(kind) {
   const menu = document.getElementById(cfg.menuId);
   if (!menu) return;
   const selected = new Set(parseStoredSessionMultiFilter(kind));
-  menu.innerHTML = '';
+  const { search, optionsWrap } = sessionProjectMenuScaffold(menu, kind, cfg);
+  const filterText = (_sessionProjectMenuFilterText.get(cfg.menuId) || '').toLowerCase();
+  const searchInput = search.querySelector('input');
+  searchInput.placeholder = `Filter ${cfg.options.length.toLocaleString()} projects...`;
+  search.classList.toggle('hidden', cfg.options.length <= SESSION_PROJECT_MENU_CAP && !filterText);
+  optionsWrap.textContent = '';
 
-  if (cfg.options.length === 0) {
-    const empty = document.createElement('div');
-    empty.className = 'sessions-multi-filter-empty';
-    empty.textContent = 'No project directories';
-    menu.appendChild(empty);
+  const matchesFilter = opt => !filterText
+    || opt.label.toLowerCase().includes(filterText)
+    || String(opt.value).toLowerCase().includes(filterText)
+    || String(opt.title || '').toLowerCase().includes(filterText);
+  const visible = [];
+  for (const opt of cfg.options) {
+    if (selected.has(opt.value)) visible.push(opt);
+  }
+  let overflow = 0;
+  let shown = 0;
+  for (const opt of cfg.options) {
+    if (selected.has(opt.value) || !matchesFilter(opt)) continue;
+    if (shown >= SESSION_PROJECT_MENU_CAP) {
+      overflow += 1;
+      continue;
+    }
+    visible.push(opt);
+    shown += 1;
   }
 
-  for (const opt of cfg.options) {
+  if (visible.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'sessions-multi-filter-empty';
+    empty.textContent = filterText
+      ? `No projects match "${filterText}"`
+      : 'No project directories';
+    optionsWrap.appendChild(empty);
+  }
+
+  for (const opt of visible) {
     const label = document.createElement('label');
     if (opt.title) label.title = opt.title;
     const input = document.createElement('input');
@@ -69603,7 +69833,14 @@ function renderSessionProjectFilterMenu(kind) {
     text.textContent = opt.label;
     label.appendChild(input);
     label.appendChild(text);
-    menu.appendChild(label);
+    optionsWrap.appendChild(label);
+  }
+
+  if (overflow > 0) {
+    const more = document.createElement('div');
+    more.className = 'sessions-multi-filter-more';
+    more.textContent = `+${overflow.toLocaleString()} more — type to narrow`;
+    optionsWrap.appendChild(more);
   }
 
   const validSelected = Array.from(selected).filter(value =>
@@ -69617,10 +69854,29 @@ function renderSessionProjectFilterMenu(kind) {
   setSessionMultiFilterValues(kind, validSelected);
 }
 
+let _sessionProjectOptionsSerialized = null;
+
 function updateSessionProjectFilterOptions(sessions = _cachedSessions) {
   sessionProjectFilterOptionsCache = sessionProjectMultiFilterOptions(sessions);
-  renderSessionProjectFilterMenu('project');
-  renderSessionProjectFilterMenu('deep-project');
+  // Streamed refreshes call this on every flush; skip the DOM work when the
+  // option set didn't change, and never rebuild a menu the user has open —
+  // it re-renders on its next open instead.
+  const serialized = JSON.stringify(sessionProjectFilterOptionsCache.map(o => [o.value, o.label]));
+  const changed = serialized !== _sessionProjectOptionsSerialized;
+  _sessionProjectOptionsSerialized = serialized;
+  for (const kind of ['project', 'deep-project']) {
+    const menu = document.getElementById(sessionMultiFilterConfig(kind).menuId);
+    if (!menu) continue;
+    const rendered = menu.dataset.optionsRendered === '1';
+    if (rendered && !changed) continue;
+    if (rendered && !menu.classList.contains('hidden')) {
+      menu.dataset.staleOptions = '1';
+      continue;
+    }
+    renderSessionProjectFilterMenu(kind);
+    menu.dataset.optionsRendered = '1';
+    delete menu.dataset.staleOptions;
+  }
 }
 
 function sessionMultiFilterConfig(kind) {
@@ -69762,11 +70018,20 @@ function setupSessionMultiFilter(kind, onChange) {
     ev.stopPropagation();
     const willOpen = menu.classList.contains('hidden');
     closeSessionMultiFilterMenus(willOpen ? kind : '');
+    if (willOpen && menu.dataset.staleOptions === '1') {
+      // Option refreshes are deferred while the menu is open (see
+      // updateSessionProjectFilterOptions) — catch up before showing it.
+      renderSessionProjectFilterMenu(kind);
+      delete menu.dataset.staleOptions;
+    }
     menu.classList.toggle('hidden', !willOpen);
     button.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
   });
   menu.addEventListener('click', ev => ev.stopPropagation());
-  menu.addEventListener('change', () => {
+  menu.addEventListener('change', (ev) => {
+    // The project menus embed a text filter input; only checkbox toggles
+    // are selection changes.
+    if (ev.target && ev.target.type !== 'checkbox') return;
     const values = sessionMultiFilterValues(kind);
     localStorage.setItem(cfg.key, JSON.stringify(values));
     updateSessionMultiFilterSummary(kind);
@@ -69965,7 +70230,9 @@ function sessionDeepProjectFilterValue() {
 function sessionMatchesProjectFilter(session, filter) {
   const filters = Array.isArray(filter) ? filter : (filter && filter !== 'all' ? [filter] : []);
   if (filters.length === 0) return true;
-  return filters.includes(sessionProjectDirectory(session));
+  const dir = sessionProjectDirectory(session);
+  if (filters.includes(SESSION_TEMP_PROJECTS_FILTER_VALUE) && sessionPathLooksTemporary(dir)) return true;
+  return filters.includes(dir);
 }
 
 function sessionMatchesSourceFilter(source, filter) {
@@ -70271,7 +70538,19 @@ function updateSessionsSearchStatus() {
   }
 }
 
+// Per-row haystack memo: without it every quick-search keystroke rebuilds
+// a ~30-field string for every row in the corpus. Keyed by row object
+// identity — mergeSessionRows keeps identity for untouched rows and swaps
+// it when a row changes, so entries invalidate themselves; the two inputs
+// that can drift independently of the row (current-session status override)
+// revalidate explicitly. source/shortId derive from the row and need no key.
+const _sessionSearchTextCache = new WeakMap();
+
 function sessionSearchText(session, displayStatus, source, shortId, isCurrent) {
+  const cached = _sessionSearchTextCache.get(session);
+  if (cached && cached.status === displayStatus && cached.current === isCurrent) {
+    return cached.text;
+  }
   const totalBytes = session.total_bytes || 0;
   const fields = [
     session.session_id,
@@ -70309,10 +70588,12 @@ function sessionSearchText(session, displayStatus, source, shortId, isCurrent) {
     session.total_tokens != null ? `${session.total_tokens} tokens` : '',
     session.estimated_cost != null ? `$${Number(session.estimated_cost).toFixed(4)}` : '',
   ];
-  return fields
+  const text = fields
     .filter(v => v !== null && v !== undefined && v !== '')
     .join(' ')
     .toLowerCase();
+  _sessionSearchTextCache.set(session, { status: displayStatus, current: isCurrent, text });
+  return text;
 }
 
 function sessionMatchesSearch(session, query, displayStatus, source, shortId, isCurrent) {
@@ -70378,101 +70659,101 @@ function renderAggregateStatTiles(el, cards) {
 }
 
 /* ── static/app/57-sessions-replay.js ── */
-function renderSessionsList(sessions, el, options = {}) {
-  if (!el) return;
-  el.innerHTML = '';
-  updateSessionsSearchStatus();
+// ── Sessions list rendering: windowed, signature-guarded, node-stable ──
+// The corpus (_cachedSessions) can be thousands of rows; the DOM holds only
+// `sessionsRenderWindow` cards (one SESSION_CARD_RENDER_PAGE initially,
+// auto-grown page-at-a-time by a scroll sentinel, with the Show-more button
+// as the explicit fallback). Each render pass is decided by a cheap
+// signature: an identical pass is skipped outright, a grown window appends
+// only the new cards, and only a changed rowset/filter/sort runs a full
+// pass — and even a full pass reuses the DOM node of every card whose
+// content signature is unchanged, so a stream refresh keeps node identity
+// (and event listeners) for untouched rows instead of wiping the subtree.
+// (Pass state lives in the early client-state block — deep-link TDZ.)
 
-  const deepSearchOnly = !!options.deepSearchOnly;
-  if (deepSearchOnly && !_sessionDeepSearch.active) {
-    const message = _sessionDeepSearch.loading
-      ? 'Deep search is running...'
-      : 'Run a deep search to show log matches';
-    el.innerHTML = `<div class="empty-state">${message}</div>`;
-    return;
+function sessionsListRenderStateFor(elId) {
+  let st = _sessionsListRenderState.get(elId);
+  if (!st) {
+    st = {
+      dataRef: null,
+      optionsKey: '',
+      window: 0,
+      matched: null, // match entries from the last full pass (sorted, filtered)
+      matchedCount: 0,
+      hiddenSubagentCount: 0,
+      renderedCount: 0,
+      cards: new Map(), // row key → { sig, card } — bounded by the render window
+      trailer: [],
+      io: null,
+      growPending: false,
+      lastMode: 'none',
+      lastMs: 0,
+      passSeq: 0, // counts non-skip passes; QA sequencing hook
+    };
+    _sessionsListRenderState.set(elId, st);
   }
+  return st;
+}
 
-  if (sessions.length === 0) {
-    el.innerHTML = '<div class="empty-state">No sessions found</div>';
-    return;
-  }
+// Wipe sites (loading skeletons, empty states, error placeholders) replace
+// the list DOM out from under the pass state — they must drop it so the
+// next render runs a full pass instead of appending into a foreign subtree.
+function resetSessionsListRenderState(elId) {
+  const st = elId ? _sessionsListRenderState.get(elId) : null;
+  if (!st) return;
+  if (st.io) st.io.disconnect();
+  _sessionsListRenderState.delete(elId);
+}
 
-  // Sort sessions based on dropdown
+// Everything besides the rowset that changes what the list shows. A pass
+// with the same data array identity and the same key as the previous one
+// is a no-op (mergeSessionRows returns a new array whenever data changed).
+function sessionsListOptionsKey(options, currentSessionId) {
+  return JSON.stringify([
+    options.mode || '',
+    options.query || '',
+    options.sortValue || 'updated-desc',
+    options.projectFilter || '',
+    options.sourceFilter || [],
+    options.statusFilter || [],
+    !!options.deepSearchOnly,
+    options.deepSearchOnly ? _sessionDeepSearchToken : 0,
+    options.deepSearchOnly ? !!_sessionDeepSearch.active : false,
+    !!options.hideSubagents,
+    currentSessionId,
+    sessionsViewingPeer() ? currentSessionsHostId() : '',
+  ]);
+}
+
+function collectSessionsListMatches(sessions, options, ctx) {
   const sortVal = options.sortValue || 'updated-desc';
-  const sorted = [...sessions];
   const [field, dir] = sortVal.split('-');
   const asc = dir === 'asc';
-  sorted.sort((a, b) => {
-    let va, vb;
+  const sortKey = (s) => {
     switch (field) {
-      case 'created':
-        va = sessionDateSortValue(a, 'created_at');
-        vb = sessionDateSortValue(b, 'created_at');
-        break;
-      case 'updated':
-        va = sessionDateSortValue(a, 'updated_at');
-        vb = sessionDateSortValue(b, 'updated_at');
-        break;
-      case 'cost':
-        va = a.estimated_cost || 0;
-        vb = b.estimated_cost || 0;
-        break;
-      case 'size':
-        va = a.total_bytes || 0;
-        vb = b.total_bytes || 0;
-        break;
-      case 'turns':
-        va = a.turns || 0;
-        vb = b.turns || 0;
-        break;
+      case 'created': return sessionDateSortValue(s, 'created_at');
+      case 'updated': return sessionDateSortValue(s, 'updated_at');
+      case 'cost': return s.estimated_cost || 0;
+      case 'size': return s.total_bytes || 0;
+      case 'turns': return s.turns || 0;
       default: return 0;
     }
-    return asc ? va - vb : vb - va;
-  });
-
-  const currentSessionId = daemonSessionFullId || '';
+  };
+  // Decorate-sort-undecorate: sessionDateSortValue parses timestamps, so
+  // key once per row instead of once per comparison.
+  const decorated = sessions.map(s => [sortKey(s), s]);
+  decorated.sort((a, b) => asc ? a[0] - b[0] : b[0] - a[0]);
 
   const query = options.query || '';
   const projectFilter = options.projectFilter || '';
   const sourceFilter = options.sourceFilter || [];
   const statusFilter = options.statusFilter || [];
-  const hasProjectFilter = Array.isArray(projectFilter) ? projectFilter.length > 0 : !!projectFilter;
-  const deepSearchActive = deepSearchOnly && _sessionDeepSearch.active;
-  const hideSubagents = !!options.hideSubagents;
+  const matched = [];
   let hiddenSubagentCount = 0;
-  let matchedCount = 0;
-  let renderedCount = 0;
-  const fragment = document.createDocumentFragment();
-  const lineageIndex = buildSessionLineageIndex(sorted);
-
-  for (const s of sorted) {
-    const configMeta = sessionConfigMetadata(s);
-    const configSource = sessionConfigSource(configMeta);
-    const relationshipKind = sessionRelationshipKindForRow(s, configMeta);
-    const rawSource = normalizeAgentId(s.source || '') || 'intendant';
-    const backendSource = normalizeAgentId(
-      s.backend_source ||
-      s.backendSource ||
-      s.configured_source ||
-      s.configuredSource ||
-      configMeta.backend_source ||
-      configMeta.backendSource ||
-      configMeta.configured_source ||
-      configMeta.configuredSource ||
-      ''
-    );
-    const hasExternalBackend = !!(
-      backendSource && backendSource !== 'intendant' ||
-      configSource && configSource !== 'intendant' ||
-      s.backend_session_id ||
-      s.backendSessionId ||
-      configMeta.backendSessionId ||
-      configMeta.backend_session_id
-    );
-    const source = rawSource;
+  for (const [, s] of decorated) {
+    const source = normalizeAgentId(s.source || '') || 'intendant';
     const shortId = (s.session_id || '').substring(0, 8);
-    const isExternal = source !== 'intendant';
-    const isCurrent = currentSessionId && s.session_id && s.session_id.startsWith(currentSessionId);
+    const isCurrent = !!(ctx.currentSessionId && s.session_id && s.session_id.startsWith(ctx.currentSessionId));
 
     // Override status for current session — never show as abandoned/idle
     let displayStatus = s.status || 'in_progress';
@@ -70480,382 +70761,228 @@ function renderSessionsList(sessions, el, options = {}) {
       displayStatus = 'in_progress';
     }
 
-    // Apply filters
+    // Cheap filters first; sessionConfigMetadata (object merges per row)
+    // only runs for rows that survive them.
     if (!sessionMatchesProjectFilter(s, projectFilter)) continue;
     if (!sessionMatchesSourceFilter(source, sourceFilter)) continue;
     if (!sessionMatchesStatusFilter(displayStatus, statusFilter)) continue;
-    const summaryMatch = sessionMatchesSearch(s, query, displayStatus, source, shortId, isCurrent);
-    if (!summaryMatch) continue;
-    const logHit = deepSearchOnly ? sessionDeepSearchHit(s, source) : null;
-    if (deepSearchActive && !logHit) continue;
-    if (hideSubagents && relationshipKind === 'subagent') {
+    if (!sessionMatchesSearch(s, query, displayStatus, source, shortId, isCurrent)) continue;
+    const logHit = ctx.deepSearchOnly ? sessionDeepSearchHit(s, source) : null;
+    if (ctx.deepSearchActive && !logHit) continue;
+    if (ctx.hideSubagents && sessionRelationshipKindForRow(s) === 'subagent') {
       hiddenSubagentCount += 1;
       continue;
     }
+    matched.push({ s, source, shortId, isCurrent, displayStatus, logHit });
+  }
+  return { matched, hiddenSubagentCount };
+}
 
-    matchedCount += 1;
-    if (renderedCount >= sessionsRenderWindow) continue;
-    renderedCount += 1;
+// Card inputs computed from OUTSIDE the row object itself (lineage across
+// other rows, live config metadata, deep-search hits, peer browsing).
+// The row's own fields are covered by JSON.stringify(row) in the card
+// signature; this covers the rest, so signature equality ⇒ identical card.
+function sessionCardDerived(m, ctx) {
+  const { s } = m;
+  const configMeta = sessionConfigMetadata(s);
+  const configSource = sessionConfigSource(configMeta);
+  const relationshipKind = sessionRelationshipKindForRow(s, configMeta);
+  const backendSource = normalizeAgentId(
+    s.backend_source ||
+    s.backendSource ||
+    s.configured_source ||
+    s.configuredSource ||
+    configMeta.backend_source ||
+    configMeta.backendSource ||
+    configMeta.configured_source ||
+    configMeta.configuredSource ||
+    ''
+  );
+  const hasExternalBackend = !!(
+    backendSource && backendSource !== 'intendant' ||
+    configSource && configSource !== 'intendant' ||
+    s.backend_session_id ||
+    s.backendSessionId ||
+    configMeta.backendSessionId ||
+    configMeta.backend_session_id
+  );
+  let nickname = '';
+  let parentId = '';
+  let parent = null;
+  let parentLabel = '';
+  if (relationshipKind) {
+    nickname = compactSessionText(configMeta.agentNickname || s.agent_nickname || s.agentNickname);
+    const lineage = sessionLineageParentForSession(ctx.lineageIndex, s, configMeta);
+    parentId = lineage.parentId;
+    parent = lineage.parent;
+    parentLabel = sessionLineageDisplayLabel(parent, parentId);
+  }
+  const lineageChildren = sessionLineageChildrenForSession(ctx.lineageIndex, s, configMeta)
+    .filter(child => !ctx.hideSubagents || sessionRelationshipKindForRow(child) !== 'subagent');
+  return {
+    configMeta, configSource, relationshipKind, backendSource, hasExternalBackend,
+    nickname, parentId, parent, parentLabel, lineageChildren,
+  };
+}
 
-    const rowIsPartial = s.partial === true;
-    const card = document.createElement('div');
-    card.className = 'session-card';
-    if (isCurrent) card.classList.add('current');
-    if (displayStatus === 'abandoned') card.classList.add('dimmed');
-    if (rowIsPartial) card.classList.add('partial');
+function sessionCardSig(m, derived, ctx) {
+  const childSig = derived.lineageChildren.map(child => {
+    const childId = sessionLineageIds(child)[0] || child.session_id || '';
+    return `${sessionRelationshipKindForRow(child)}\u001e${childId}\u001e${sessionLineageDisplayLabel(child, childId)}`;
+  }).join('\u001d');
+  const hitSig = m.logHit
+    ? `${m.logHit.matches || 0}\u001e${(((m.logHit.snippets || [])[0]) || {}).content || ''}`
+    : '';
+  return JSON.stringify(m.s) + '\u001f' + JSON.stringify([
+    m.displayStatus, m.isCurrent, m.source, ctx.viewingPeer,
+    derived.relationshipKind, derived.configSource, derived.backendSource,
+    derived.hasExternalBackend, derived.nickname, derived.parentId,
+    derived.parentLabel, childSig, hitSig,
+  ]);
+}
 
-    const sessionName = compactSessionText(s.name);
-    const taskText = compactSessionText(s.task);
-    const sessionId = s.session_id || '';
-    const primaryText = sessionName || taskText || 'Untitled session';
-    const titleKindText = sessionName ? 'name' : taskText ? 'initial' : 'untitled';
+// Reused cards keep their DOM nodes, so their relative "Nm ago" label is
+// refreshed in place instead of by rebuild (the absolute timestamp lives
+// in the tooltip and never drifts).
+function refreshSessionCardRelativeLabel(card) {
+  const changedAt = card.dataset.changedAt || '';
+  if (!changedAt) return;
+  const span = card.querySelector('.sc-meta .value[data-rel="changed"]');
+  if (!span) return;
+  const label = sessionRelativeLabel(changedAt) || changedAt;
+  if (span.textContent !== label) span.textContent = label;
+}
 
-    // Top row: name/task + status badges
-    const top = document.createElement('div');
-    top.className = 'sc-top';
+function sessionCardFor(m, ctx, st, nextCards) {
+  const key = sessionListRowKey(m.s);
+  const derived = sessionCardDerived(m, ctx);
+  const sig = sessionCardSig(m, derived, ctx);
+  const cached = key ? st.cards.get(key) : null;
+  let card;
+  if (cached && cached.sig === sig) {
+    card = cached.card;
+    refreshSessionCardRelativeLabel(card);
+  } else {
+    card = buildSessionCard(m, derived, ctx);
+    if (key) card.dataset.sessionKey = key;
+    card.dataset.qaBuildSeq = String(++_sessionCardBuildSeq);
+  }
+  if (key) (nextCards || st.cards).set(key, { sig, card });
+  return card;
+}
 
-    const titleBlock = document.createElement('div');
-    titleBlock.className = 'sc-title-block';
-    const titleRow = document.createElement('div');
-    titleRow.className = 'sc-title-row';
-    const titleKind = document.createElement('span');
-    titleKind.className = 'sc-title-kind';
-    titleKind.classList.add(titleKindText);
-    titleKind.textContent = titleKindText;
-    titleKind.title = sessionName
-      ? 'User-assigned session name'
-      : taskText
-        ? 'Initial message fallback'
-        : 'No initial message found';
-    titleRow.appendChild(titleKind);
-    const nameEl = document.createElement('div');
-    nameEl.className = 'sc-name';
-    nameEl.textContent = primaryText;
-    nameEl.title = primaryText;
-    titleRow.appendChild(nameEl);
-    titleBlock.appendChild(titleRow);
-    top.appendChild(titleBlock);
+function growSessionsRenderWindow() {
+  sessionsRenderWindow += SESSION_CARD_RENDER_PAGE;
+  renderSessionsViews();
+}
 
-    const statusEl = document.createElement('span');
-    statusEl.className = `ui-chip ${sessionStatusChipTone(displayStatus)} sc-status ${displayStatus}`;
-    statusEl.textContent = displayStatus.replace('_', ' ');
-    top.appendChild(statusEl);
+function removeSessionsListTrailer(st) {
+  for (const node of st.trailer) node.remove();
+  st.trailer = [];
+}
 
-    const sourceEl = document.createElement('span');
-    sourceEl.className = 'ui-badge sc-source' + (isExternal ? '' : ' local');
-    sourceEl.textContent = isExternal
-      ? (
-        s.source_label ||
-        s.sourceLabel ||
-        s.backend_source_label ||
-        s.backendSourceLabel ||
-        prettyAgentName(source) ||
-        source
-      )
-      : (s.source_label || s.sourceLabel || 'Intendant');
-    if (!isExternal && hasExternalBackend && backendSource && backendSource !== 'intendant') {
-      sourceEl.title = `${prettyAgentName(backendSource) || backendSource} backend`;
-    }
-    top.appendChild(sourceEl);
-
-    if (rowIsPartial) {
-      const loadingEl = document.createElement('span');
-      loadingEl.className = 'ui-chip info sc-role sc-loading-chip';
-      loadingEl.textContent = 'loading details';
-      loadingEl.title = 'Tokens, costs, lineage, and disk sizes are still hydrating';
-      top.appendChild(loadingEl);
-    }
-
-    if (s.role) {
-      const roleEl = document.createElement('span');
-      roleEl.className = 'ui-chip muted sc-role';
-      roleEl.textContent = s.role;
-      top.appendChild(roleEl);
-    }
-
-    if (relationshipKind) {
-      const nickname = compactSessionText(configMeta.agentNickname || s.agent_nickname || s.agentNickname);
-      const { parentId, parent } = sessionLineageParentForSession(lineageIndex, s, configMeta);
-      const parentLabel = sessionLineageDisplayLabel(parent, parentId);
-      const kindLabel = sessionLineageRelationshipLabel(relationshipKind);
-      const chipText = relationshipKind === 'subagent' && nickname
-        ? `${kindLabel} ${nickname}`
-        : parentId
-          ? `${kindLabel} of ${parentLabel}`
-          : kindLabel;
-      const titleParts = [
-        relationshipKind === 'subagent' && nickname ? `Subagent: ${nickname}` : `Relationship: ${kindLabel}`,
-        parentId ? `Parent: ${parentLabel} (${parentId})` : '',
-      ].filter(Boolean);
-      const relationEl = createSessionLineageListChip(s, parent, parentId, chipText, titleParts.join('\n') || `${kindLabel} session`);
-      top.appendChild(relationEl);
-    }
-
-    const lineageChildren = sessionLineageChildrenForSession(lineageIndex, s, configMeta)
-      .filter(child => !hideSubagents || sessionRelationshipKindForRow(child) !== 'subagent');
-    if (lineageChildren.length > 0) {
-      const childrenEl = document.createElement('span');
-      childrenEl.className = 'ui-chip muted sc-role sc-lineage-chip sc-lineage-children';
-      childrenEl.textContent = lineageChildren.length === 1 ? '1 child' : `${lineageChildren.length} children`;
-      childrenEl.title = lineageChildren
-        .slice(0, 8)
-        .map(child => {
-          const childKind = sessionLineageRelationshipLabel(sessionRelationshipKindForRow(child));
-          const childId = sessionLineageIds(child)[0] || child.session_id || '';
-          return `${childKind}: ${sessionLineageDisplayLabel(child, childId)}${childId ? ` (${childId})` : ''}`;
-        })
-        .join('\n') + (lineageChildren.length > 8 ? `\n+${lineageChildren.length - 8} more` : '');
-      top.appendChild(childrenEl);
-    }
-
-    if (isCurrent) {
-      const badge = document.createElement('span');
-      badge.className = 'ui-chip info sc-current-badge';
-      badge.textContent = 'current';
-      top.appendChild(badge);
-    }
-
-    card.appendChild(top);
-
-    // Task
-    if (taskText && sessionName) {
-      const taskEl = document.createElement('div');
-      taskEl.className = 'sc-task';
-      taskEl.textContent = taskText;
-      taskEl.title = taskText;
-      card.appendChild(taskEl);
-    }
-
-    if (logHit) {
-      const hitEl = document.createElement('div');
-      hitEl.className = 'sc-search-hit';
-      const hitCount = document.createElement('span');
-      hitCount.className = 'sc-search-hit-count';
-      const matches = Number(logHit.matches || 0);
-      hitCount.textContent = `${matches} log ${matches === 1 ? 'match' : 'matches'}`;
-      hitEl.appendChild(hitCount);
-      const firstSnippet = (logHit.snippets || [])[0] || {};
-      const hitText = document.createElement('span');
-      hitText.className = 'sc-search-hit-text';
-      hitText.textContent = firstSnippet.content || '';
-      hitText.title = firstSnippet.content || '';
-      hitEl.appendChild(hitText);
-      card.appendChild(hitEl);
-    }
-
-    // Meta row — the full session id (click to copy) plus compact
-    // essentials; the long tail (absolute dates, provider, token breakdown,
-    // disk) moves to the row tooltip and stays visible in the
-    // session-detail overlay.
-    const meta = document.createElement('div');
-    meta.className = 'sc-meta';
-    const addMetaField = (label, value, valueClass, valueTitle) => {
-      if (value === null || value === undefined || value === '') return null;
-      const span = document.createElement('span');
-      const l = document.createElement('span');
-      l.className = 'label';
-      l.textContent = label;
-      const v = document.createElement('span');
-      v.className = 'value' + (valueClass ? ` ${valueClass}` : '');
-      v.textContent = value;
-      if (valueTitle) v.title = valueTitle;
-      span.appendChild(l);
-      span.appendChild(v);
-      meta.appendChild(span);
-      return v;
-    };
-
-    const idVal = addMetaField('id', sessionId || shortId, 'sc-id', 'Click to copy the session ID');
-    if (idVal) {
-      idVal.addEventListener('click', (e) => {
-        e.stopPropagation();
-        const fullId = sessionId || shortId;
-        copyTextToClipboard(fullId)
-          .then(() => showControlToast('success', `Copied session ID ${shortSessionId(fullId)}`))
-          .catch(err => showControlToast('error', `Copy session ID failed: ${err?.message || err}`));
+// Scroll sentinel + Show-more fallback below the rendered cards. The
+// IntersectionObserver grows the window a page at a time as the user nears
+// the bottom; the button stays for environments without IO and as the
+// explicit bulk control.
+function appendSessionsListTrailer(el, st) {
+  removeSessionsListTrailer(st);
+  const remaining = st.matchedCount - st.renderedCount;
+  if (remaining <= 0) {
+    if (st.io) st.io.disconnect();
+    return;
+  }
+  const sentinel = document.createElement('div');
+  sentinel.className = 'sessions-scroll-sentinel';
+  sentinel.setAttribute('aria-hidden', 'true');
+  const moreRow = document.createElement('div');
+  moreRow.className = 'sessions-show-more';
+  const moreBtn = document.createElement('button');
+  moreBtn.type = 'button';
+  moreBtn.className = 'ui-btn sessions-show-more-btn';
+  moreBtn.textContent = `Show ${Math.min(SESSION_CARD_RENDER_PAGE, remaining).toLocaleString()} more (${remaining.toLocaleString()} remaining)`;
+  moreBtn.onclick = () => growSessionsRenderWindow();
+  moreRow.appendChild(moreBtn);
+  el.appendChild(sentinel);
+  el.appendChild(moreRow);
+  st.trailer = [sentinel, moreRow];
+  if (!st.io && typeof IntersectionObserver === 'function') {
+    st.io = new IntersectionObserver((entries) => {
+      if (!entries.some(e => e.isIntersecting)) return;
+      if (st.growPending) return;
+      st.growPending = true;
+      requestAnimationFrame(() => {
+        st.growPending = false;
+        if (st.matchedCount > st.renderedCount) growSessionsRenderWindow();
       });
-    }
-    const changedAt = s.updated_at || s.changed_at;
-    if (changedAt) addMetaField('changed', sessionRelativeLabel(changedAt) || changedAt, null, changedAt);
-    const projectPath = sessionProjectDirectory(s);
-    if (projectPath) addMetaField('project', compactPathLabel(projectPath), null, projectPath);
-    if (s.model) addMetaField('model', s.model, 'model-val');
-    if (s.turns > 0) addMetaField('turns', s.turns);
-    if (rowIsPartial) {
-      const loading = document.createElement('span');
-      loading.className = 'sc-loading-meta';
-      const loadingLabel = document.createElement('span');
-      loadingLabel.className = 'label';
-      loadingLabel.textContent = 'details';
-      const loadingVal = document.createElement('span');
-      loadingVal.className = 'value';
-      loadingVal.textContent = 'tokens, cost, lineage, size';
-      loading.appendChild(loadingLabel);
-      loading.appendChild(loadingVal);
-      meta.appendChild(loading);
-    } else {
-      if (s.total_tokens > 0) addMetaField('tokens', s.total_tokens.toLocaleString());
-      if (s.estimated_cost > 0) addMetaField('cost', formatUsd(s.estimated_cost, 2));
-    }
+    }, { rootMargin: '600px 0px' });
+  }
+  if (st.io) {
+    st.io.disconnect();
+    st.io.observe(sentinel);
+  }
+}
 
-    const tipParts = [];
-    if (s.created_at) tipParts.push(`created: ${s.created_at}`);
-    if (changedAt) tipParts.push(`changed: ${changedAt}`);
-    if (s.provider) tipParts.push(`provider: ${s.provider}`);
-    if (!rowIsPartial && s.total_tokens > 0) {
-      tipParts.push(`tokens: ${(s.prompt_tokens || 0).toLocaleString()} in${s.cached_tokens > 0 ? ` (${s.cached_tokens.toLocaleString()} cached)` : ''} / ${(s.completion_tokens || 0).toLocaleString()} out`);
-    }
-    if (!rowIsPartial && s.total_bytes > 0) tipParts.push(`disk: ${_fmtBytes(s.total_bytes)}`);
-    if (projectPath) tipParts.push(`project: ${projectPath}`);
-    if (tipParts.length) meta.title = tipParts.join('\n');
-    card.appendChild(meta);
+function renderSessionsList(sessions, el, options = {}) {
+  if (!el) return;
+  updateSessionsSearchStatus();
+  const elId = el.id || '';
+  const t0 = performance.now();
 
-    // Media stats row (recordings, annotations, clips) + total session size
-    const hasMedia = (s.recordings > 0 || s.annotations > 0 || s.clips > 0);
-    if (!rowIsPartial && hasMedia) {
-      const mediaMeta = document.createElement('div');
-      mediaMeta.className = 'sc-meta sc-media';
-      const addMediaField = (label, value, valueClass) => {
-        const span = document.createElement('span');
-        const l = document.createElement('span');
-        l.className = 'label';
-        l.textContent = label;
-        const v = document.createElement('span');
-        v.className = 'value' + (valueClass ? ` ${valueClass}` : '');
-        v.textContent = value;
-        span.appendChild(l);
-        span.appendChild(v);
-        mediaMeta.appendChild(span);
-      };
-      if (s.recordings > 0) addMediaField('recordings', s.recordings, 'v-blue');
-      if (s.annotations > 0) addMediaField('annotations', s.annotations, 'v-peach');
-      if (s.clips > 0) addMediaField('clips', s.clips, 'v-peach');
-      if (s.total_bytes > 0) addMediaField('size', _fmtBytes(s.total_bytes), 'v-dim');
-      card.appendChild(mediaMeta);
-    }
-
-    // Actions row. While browsing a peer host the cards are read-only —
-    // resume/delete/config act on THIS daemon's stores and would target
-    // the wrong machine; interaction happens on the peer's own dashboard
-    // (whole-card click below).
-    if (!sessionsViewingPeer()
-        && (sessionId || s.can_resume || s.can_delete || ((s.total_bytes > 0 || !isCurrent) && !isExternal))) {
-      const actions = document.createElement('div');
-      actions.className = 'sc-actions';
-
-      if (s.can_resume !== false) {
-        const resumeBtn = document.createElement('button');
-        resumeBtn.className = 'ui-btn sc-resume-btn';
-        resumeBtn.textContent = 'Resume session';
-        resumeBtn.title = 'Resume this session in Activity';
-        resumeBtn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          resumeSession(s);
-        });
-        actions.appendChild(resumeBtn);
-      }
-
-      if (sessionId) {
-        const renameBtn = document.createElement('button');
-        renameBtn.className = 'ui-btn sc-rename-btn';
-        renameBtn.textContent = 'Rename';
-        renameBtn.title = 'Rename this session';
-        renameBtn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          requestSessionRename(s);
-        });
-        actions.appendChild(renameBtn);
-      }
-
-      if (sessionId && configSource && configSource !== 'intendant') {
-        const configBtn = document.createElement('button');
-        configBtn.className = 'ui-btn sc-rename-btn';
-        configBtn.textContent = 'Configure';
-        configBtn.title = 'Configure binary and managed context for this session';
-        configBtn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          openSessionConfigModal(s);
-        });
-        actions.appendChild(configBtn);
-      }
-
-      const canDeleteLocalSessionData = rawSource === 'intendant'
-        ? s.can_delete !== false
-        : !!(s.can_delete_intendant_log && s.intendant_session_id);
-      if (canDeleteLocalSessionData) {
-        const sessionDeleteLabel = rawSource === 'intendant'
-          ? 'Delete session'
-          : 'Delete Intendant log';
-        const sessionDeleteBytes = rawSource === 'intendant'
-          ? s.total_bytes
-          : (s.intendant_total_bytes || 0);
-        const btn = document.createElement('button');
-        btn.className = 'ui-btn danger sc-delete-btn';
-        btn.textContent = 'Delete...';
-        btn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          // Close any existing menu
-          document.querySelectorAll('.sc-delete-menu').forEach(m => m.remove());
-          const menu = document.createElement('div');
-          menu.className = 'sc-delete-menu';
-          menu.setAttribute('role', 'menu');
-
-          const addItem = (label, target, bytes, danger) => {
-            const item = document.createElement('button');
-            item.type = 'button';
-            item.className = 'sc-delete-menu-item' + (danger ? ' danger' : '');
-            item.setAttribute('role', 'menuitem');
-            const txt = document.createElement('span');
-            txt.textContent = label;
-            item.appendChild(txt);
-            if (bytes > 0) {
-              const hint = document.createElement('span');
-              hint.className = 'size-hint';
-              hint.textContent = _fmtBytes(bytes);
-              item.appendChild(hint);
-            }
-            item.addEventListener('click', (ev) => {
-              ev.stopPropagation();
-              menu.remove();
-              deleteSessionData(s.session_id, target, label);
-            });
-            menu.appendChild(item);
-          };
-
-          if ((s.recordings || 0) > 0) addItem('Delete recordings', 'recordings', s.recording_bytes || 0);
-          if ((s.frames_bytes || 0) > 0 || (s.annotations || 0) > 0 || (s.clips || 0) > 0) addItem('Delete frames', 'frames', s.frames_bytes || 0);
-          const hasMedia = (s.recordings || 0) > 0 || (s.frames_bytes || 0) > 0;
-          if (hasMedia) addItem('Delete all media', 'media', (s.recording_bytes || 0) + (s.frames_bytes || 0));
-          if ((s.turns_bytes || 0) > 0) addItem('Delete turn data', 'turns', s.turns_bytes);
-          if (!isCurrent) addItem(sessionDeleteLabel, 'session', sessionDeleteBytes, true);
-
-          if (menu.children.length > 0) {
-            actions.appendChild(menu);
-            const close = (ev) => { if (!menu.contains(ev.target)) { menu.remove(); document.removeEventListener('click', close); } };
-            setTimeout(() => document.addEventListener('click', close), 0);
-          }
-        });
-        actions.appendChild(btn);
-      }
-      card.appendChild(actions);
-    }
-
-    if (sessionsViewingPeer()) {
-      card.classList.add('sc-peer');
-      card.title = 'Open this session on the peer’s dashboard';
-      card.addEventListener('click', () => openPeerSessionExternally(s));
-    } else {
-      card.addEventListener('click', () => openSessionDetail(s));
-    }
-    fragment.appendChild(card);
+  const deepSearchOnly = !!options.deepSearchOnly;
+  if (deepSearchOnly && !_sessionDeepSearch.active) {
+    const message = _sessionDeepSearch.loading
+      ? 'Deep search is running...'
+      : 'Run a deep search to show log matches';
+    resetSessionsListRenderState(elId);
+    el.innerHTML = `<div class="empty-state">${message}</div>`;
+    return;
   }
 
+  if (sessions.length === 0) {
+    resetSessionsListRenderState(elId);
+    el.innerHTML = '<div class="empty-state">No sessions found</div>';
+    return;
+  }
+
+  const currentSessionId = daemonSessionFullId || '';
+  const st = sessionsListRenderStateFor(elId);
+  const optionsKey = sessionsListOptionsKey(options, currentSessionId);
+  const windowSize = sessionsRenderWindow;
+  const samePass = st.dataRef === sessions && st.optionsKey === optionsKey && st.matched !== null;
+  if (samePass && st.window === windowSize) {
+    st.lastMode = 'skip'; // identical pass — the DOM is already right
+    return;
+  }
+
+  const ctx = {
+    deepSearchOnly,
+    deepSearchActive: deepSearchOnly && _sessionDeepSearch.active,
+    hideSubagents: !!options.hideSubagents,
+    viewingPeer: sessionsViewingPeer(),
+    currentSessionId,
+    lineageIndex: buildSessionLineageIndex(sessions),
+  };
+
+  const appendOnly = samePass && windowSize > st.window && st.renderedCount > 0;
+  let matched = st.matched;
+  let hiddenSubagentCount = st.hiddenSubagentCount;
+  if (!appendOnly) {
+    const collected = collectSessionsListMatches(sessions, options, ctx);
+    matched = collected.matched;
+    hiddenSubagentCount = collected.hiddenSubagentCount;
+  }
+  const matchedCount = matched.length;
+
   if (matchedCount === 0) {
+    const query = options.query || '';
+    const projectFilter = options.projectFilter || '';
+    const hasProjectFilter = Array.isArray(projectFilter) ? projectFilter.length > 0 : !!projectFilter;
     const empty = document.createElement('div');
     empty.className = 'empty-state';
-    empty.textContent = deepSearchActive && sessionDeepSearchHasMissingMetadata()
+    empty.textContent = ctx.deepSearchActive && sessionDeepSearchHasMissingMetadata()
       ? 'Loading session metadata for matching log results...'
-      : deepSearchActive
+      : ctx.deepSearchActive
       ? 'No sessions match the deep search results'
       : query
       ? 'No sessions match your search'
@@ -70863,29 +70990,451 @@ function renderSessionsList(sessions, el, options = {}) {
       ? 'No sessions match the selected projects'
       : hiddenSubagentCount > 0
       ? 'No main sessions found. Subagent sessions are hidden from Recent.'
-      : sessionsViewingPeer()
+      : ctx.viewingPeer
       ? 'No sessions visible on this peer — it may not have granted session access.'
       : 'No sessions match the active filters';
+    resetSessionsListRenderState(elId);
+    el.innerHTML = '';
     el.appendChild(empty);
-  } else {
-    el.appendChild(fragment);
-    if (matchedCount > renderedCount) {
-      const remaining = matchedCount - renderedCount;
-      const moreRow = document.createElement('div');
-      moreRow.className = 'sessions-show-more';
-      const moreBtn = document.createElement('button');
-      moreBtn.type = 'button';
-      moreBtn.className = 'ui-btn sessions-show-more-btn';
-      moreBtn.textContent = `Show ${Math.min(SESSION_CARD_RENDER_LIMIT, remaining).toLocaleString()} more (${remaining.toLocaleString()} remaining)`;
-      moreBtn.onclick = () => {
-        sessionsRenderWindow += SESSION_CARD_RENDER_LIMIT;
-        renderSessionsViews();
-      };
-      moreRow.appendChild(moreBtn);
-      el.appendChild(moreRow);
-    }
+    return;
   }
 
+  const renderedTarget = Math.min(windowSize, matchedCount);
+  const nextCards = appendOnly ? null : new Map();
+  const built = [];
+  for (let i = appendOnly ? st.renderedCount : 0; i < renderedTarget; i++) {
+    built.push(sessionCardFor(matched[i], ctx, st, nextCards));
+  }
+
+  if (appendOnly) {
+    removeSessionsListTrailer(st);
+    for (const card of built) el.appendChild(card);
+  } else {
+    st.cards = nextCards;
+    st.trailer = [];
+    el.replaceChildren(...built);
+  }
+  st.dataRef = sessions;
+  st.optionsKey = optionsKey;
+  st.window = windowSize;
+  st.matched = matched;
+  st.matchedCount = matchedCount;
+  st.hiddenSubagentCount = hiddenSubagentCount;
+  st.renderedCount = renderedTarget;
+  appendSessionsListTrailer(el, st);
+  st.lastMode = appendOnly ? 'append' : 'full';
+  st.lastMs = performance.now() - t0;
+  st.passSeq += 1;
+}
+
+// QA readback (window.qa convention): DOM-budget and node-identity facts
+// the validate-dashboard harness asserts on — module scope hides them.
+// Probe functions stay cheap and side-effect-free.
+window.qa = Object.assign(window.qa || {}, {
+  sessionsDom: (listId = 'sessions-list') => {
+    const el = document.getElementById(listId);
+    const st = _sessionsListRenderState.get(listId) || null;
+    const cards = el ? Array.from(el.querySelectorAll('.session-card')) : [];
+    return {
+      nodes: el ? el.getElementsByTagName('*').length : 0,
+      cards: cards.length,
+      matched: st ? st.matchedCount : null,
+      hiddenSubagents: st ? st.hiddenSubagentCount : null,
+      corpus: Array.isArray(_cachedSessions) ? _cachedSessions.length : null,
+      window: sessionsRenderWindow,
+      page: SESSION_CARD_RENDER_PAGE,
+      lastMode: st ? st.lastMode : 'none',
+      lastMs: st ? st.lastMs : null,
+      passSeq: st ? st.passSeq : 0,
+      loadToken: _sessionsLoadToken,
+      trailer: st ? st.trailer.length : 0,
+      hydration: {
+        active: _sessionsHydrationState.active,
+        done: _sessionsHydrationState.done,
+        phase: _sessionsHydrationState.phase,
+        received: _sessionsHydrationState.received,
+      },
+      cardSeqs: cards.slice(0, 24).map(c => ({
+        key: c.dataset.sessionKey || '',
+        seq: Number(c.dataset.qaBuildSeq || 0),
+      })),
+    };
+  },
+  // QA ACTIONS (not probes — they mutate): the module scope hides the
+  // sessions functions from harness-evaluated JS, so scripted scenarios
+  // need explicit bridges (same reason as the window.* onclick bridges;
+  // precedent: station.activate).
+  sessionsActions: {
+    reload: () => loadSessions({ force: true }),
+    grow: () => growSessionsRenderWindow(),
+    // Pull the complete corpus over the plain-JSON path — deterministic
+    // fallback while the RPC stream leg can wedge before its replace.
+    pullAll: () => fetchSessionsForHost(undefined, { force: true, limit: 'all' })
+      .then(rows => applyLoadedSessions(rows, document.getElementById('sessions-aggregate'))),
+  },
+});
+
+function buildSessionCard(m, derived, ctx) {
+  const { s, source, shortId, isCurrent, displayStatus, logHit } = m;
+  const { configMeta, configSource, relationshipKind, backendSource, hasExternalBackend } = derived;
+  const isExternal = source !== 'intendant';
+
+  const rowIsPartial = s.partial === true;
+  const card = document.createElement('div');
+  card.className = 'session-card';
+  if (isCurrent) card.classList.add('current');
+  if (displayStatus === 'abandoned') card.classList.add('dimmed');
+  if (rowIsPartial) card.classList.add('partial');
+
+  const sessionName = compactSessionText(s.name);
+  const taskText = compactSessionText(s.task);
+  const sessionId = s.session_id || '';
+  const primaryText = sessionName || taskText || 'Untitled session';
+  const titleKindText = sessionName ? 'name' : taskText ? 'initial' : 'untitled';
+
+  // Top row: name/task + status badges
+  const top = document.createElement('div');
+  top.className = 'sc-top';
+
+  const titleBlock = document.createElement('div');
+  titleBlock.className = 'sc-title-block';
+  const titleRow = document.createElement('div');
+  titleRow.className = 'sc-title-row';
+  const titleKind = document.createElement('span');
+  titleKind.className = 'sc-title-kind';
+  titleKind.classList.add(titleKindText);
+  titleKind.textContent = titleKindText;
+  titleKind.title = sessionName
+    ? 'User-assigned session name'
+    : taskText
+      ? 'Initial message fallback'
+      : 'No initial message found';
+  titleRow.appendChild(titleKind);
+  const nameEl = document.createElement('div');
+  nameEl.className = 'sc-name';
+  nameEl.textContent = primaryText;
+  nameEl.title = primaryText;
+  titleRow.appendChild(nameEl);
+  titleBlock.appendChild(titleRow);
+  top.appendChild(titleBlock);
+
+  const statusEl = document.createElement('span');
+  statusEl.className = `ui-chip ${sessionStatusChipTone(displayStatus)} sc-status ${displayStatus}`;
+  statusEl.textContent = displayStatus.replace('_', ' ');
+  top.appendChild(statusEl);
+
+  const sourceEl = document.createElement('span');
+  sourceEl.className = 'ui-badge sc-source' + (isExternal ? '' : ' local');
+  sourceEl.textContent = isExternal
+    ? (
+      s.source_label ||
+      s.sourceLabel ||
+      s.backend_source_label ||
+      s.backendSourceLabel ||
+      prettyAgentName(source) ||
+      source
+    )
+    : (s.source_label || s.sourceLabel || 'Intendant');
+  if (!isExternal && hasExternalBackend && backendSource && backendSource !== 'intendant') {
+    sourceEl.title = `${prettyAgentName(backendSource) || backendSource} backend`;
+  }
+  top.appendChild(sourceEl);
+
+  if (rowIsPartial) {
+    const loadingEl = document.createElement('span');
+    loadingEl.className = 'ui-chip info sc-role sc-loading-chip';
+    loadingEl.textContent = 'loading details';
+    loadingEl.title = 'Tokens, costs, lineage, and disk sizes are still hydrating';
+    top.appendChild(loadingEl);
+  }
+
+  if (s.role) {
+    const roleEl = document.createElement('span');
+    roleEl.className = 'ui-chip muted sc-role';
+    roleEl.textContent = s.role;
+    top.appendChild(roleEl);
+  }
+
+  if (relationshipKind) {
+    const { nickname, parentId, parent, parentLabel } = derived;
+    const kindLabel = sessionLineageRelationshipLabel(relationshipKind);
+    const chipText = relationshipKind === 'subagent' && nickname
+      ? `${kindLabel} ${nickname}`
+      : parentId
+        ? `${kindLabel} of ${parentLabel}`
+        : kindLabel;
+    const titleParts = [
+      relationshipKind === 'subagent' && nickname ? `Subagent: ${nickname}` : `Relationship: ${kindLabel}`,
+      parentId ? `Parent: ${parentLabel} (${parentId})` : '',
+    ].filter(Boolean);
+    const relationEl = createSessionLineageListChip(s, parent, parentId, chipText, titleParts.join('\n') || `${kindLabel} session`);
+    top.appendChild(relationEl);
+  }
+
+  const lineageChildren = derived.lineageChildren;
+  if (lineageChildren.length > 0) {
+    const childrenEl = document.createElement('span');
+    childrenEl.className = 'ui-chip muted sc-role sc-lineage-chip sc-lineage-children';
+    childrenEl.textContent = lineageChildren.length === 1 ? '1 child' : `${lineageChildren.length} children`;
+    childrenEl.title = lineageChildren
+      .slice(0, 8)
+      .map(child => {
+        const childKind = sessionLineageRelationshipLabel(sessionRelationshipKindForRow(child));
+        const childId = sessionLineageIds(child)[0] || child.session_id || '';
+        return `${childKind}: ${sessionLineageDisplayLabel(child, childId)}${childId ? ` (${childId})` : ''}`;
+      })
+      .join('\n') + (lineageChildren.length > 8 ? `\n+${lineageChildren.length - 8} more` : '');
+    top.appendChild(childrenEl);
+  }
+
+  if (isCurrent) {
+    const badge = document.createElement('span');
+    badge.className = 'ui-chip info sc-current-badge';
+    badge.textContent = 'current';
+    top.appendChild(badge);
+  }
+
+  card.appendChild(top);
+
+  // Task
+  if (taskText && sessionName) {
+    const taskEl = document.createElement('div');
+    taskEl.className = 'sc-task';
+    taskEl.textContent = taskText;
+    taskEl.title = taskText;
+    card.appendChild(taskEl);
+  }
+
+  if (logHit) {
+    const hitEl = document.createElement('div');
+    hitEl.className = 'sc-search-hit';
+    const hitCount = document.createElement('span');
+    hitCount.className = 'sc-search-hit-count';
+    const matches = Number(logHit.matches || 0);
+    hitCount.textContent = `${matches} log ${matches === 1 ? 'match' : 'matches'}`;
+    hitEl.appendChild(hitCount);
+    const firstSnippet = (logHit.snippets || [])[0] || {};
+    const hitText = document.createElement('span');
+    hitText.className = 'sc-search-hit-text';
+    hitText.textContent = firstSnippet.content || '';
+    hitText.title = firstSnippet.content || '';
+    hitEl.appendChild(hitText);
+    card.appendChild(hitEl);
+  }
+
+  // Meta row — the full session id (click to copy) plus compact
+  // essentials; the long tail (absolute dates, provider, token breakdown,
+  // disk) moves to the row tooltip and stays visible in the
+  // session-detail overlay.
+  const meta = document.createElement('div');
+  meta.className = 'sc-meta';
+  const addMetaField = (label, value, valueClass, valueTitle) => {
+    if (value === null || value === undefined || value === '') return null;
+    const span = document.createElement('span');
+    const l = document.createElement('span');
+    l.className = 'label';
+    l.textContent = label;
+    const v = document.createElement('span');
+    v.className = 'value' + (valueClass ? ` ${valueClass}` : '');
+    v.textContent = value;
+    if (valueTitle) v.title = valueTitle;
+    span.appendChild(l);
+    span.appendChild(v);
+    meta.appendChild(span);
+    return v;
+  };
+
+  const idVal = addMetaField('id', sessionId || shortId, 'sc-id', 'Click to copy the session ID');
+  if (idVal) {
+    idVal.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const fullId = sessionId || shortId;
+      copyTextToClipboard(fullId)
+        .then(() => showControlToast('success', `Copied session ID ${shortSessionId(fullId)}`))
+        .catch(err => showControlToast('error', `Copy session ID failed: ${err?.message || err}`));
+    });
+  }
+  const changedAt = s.updated_at || s.changed_at;
+  if (changedAt) {
+    const changedVal = addMetaField('changed', sessionRelativeLabel(changedAt) || changedAt, null, changedAt);
+    if (changedVal) {
+      // refreshSessionCardRelativeLabel re-derives this label in place when
+      // the card is reused across render passes.
+      changedVal.dataset.rel = 'changed';
+      card.dataset.changedAt = changedAt;
+    }
+  }
+  const projectPath = sessionProjectDirectory(s);
+  if (projectPath) addMetaField('project', compactPathLabel(projectPath), null, projectPath);
+  if (s.model) addMetaField('model', s.model, 'model-val');
+  if (s.turns > 0) addMetaField('turns', s.turns);
+  if (rowIsPartial) {
+    const loading = document.createElement('span');
+    loading.className = 'sc-loading-meta';
+    const loadingLabel = document.createElement('span');
+    loadingLabel.className = 'label';
+    loadingLabel.textContent = 'details';
+    const loadingVal = document.createElement('span');
+    loadingVal.className = 'value';
+    loadingVal.textContent = 'tokens, cost, lineage, size';
+    loading.appendChild(loadingLabel);
+    loading.appendChild(loadingVal);
+    meta.appendChild(loading);
+  } else {
+    if (s.total_tokens > 0) addMetaField('tokens', s.total_tokens.toLocaleString());
+    if (s.estimated_cost > 0) addMetaField('cost', formatUsd(s.estimated_cost, 2));
+  }
+
+  const tipParts = [];
+  if (s.created_at) tipParts.push(`created: ${s.created_at}`);
+  if (changedAt) tipParts.push(`changed: ${changedAt}`);
+  if (s.provider) tipParts.push(`provider: ${s.provider}`);
+  if (!rowIsPartial && s.total_tokens > 0) {
+    tipParts.push(`tokens: ${(s.prompt_tokens || 0).toLocaleString()} in${s.cached_tokens > 0 ? ` (${s.cached_tokens.toLocaleString()} cached)` : ''} / ${(s.completion_tokens || 0).toLocaleString()} out`);
+  }
+  if (!rowIsPartial && s.total_bytes > 0) tipParts.push(`disk: ${_fmtBytes(s.total_bytes)}`);
+  if (projectPath) tipParts.push(`project: ${projectPath}`);
+  if (tipParts.length) meta.title = tipParts.join('\n');
+  card.appendChild(meta);
+
+  // Media stats row (recordings, annotations, clips) + total session size
+  const hasMedia = (s.recordings > 0 || s.annotations > 0 || s.clips > 0);
+  if (!rowIsPartial && hasMedia) {
+    const mediaMeta = document.createElement('div');
+    mediaMeta.className = 'sc-meta sc-media';
+    const addMediaField = (label, value, valueClass) => {
+      const span = document.createElement('span');
+      const l = document.createElement('span');
+      l.className = 'label';
+      l.textContent = label;
+      const v = document.createElement('span');
+      v.className = 'value' + (valueClass ? ` ${valueClass}` : '');
+      v.textContent = value;
+      span.appendChild(l);
+      span.appendChild(v);
+      mediaMeta.appendChild(span);
+    };
+    if (s.recordings > 0) addMediaField('recordings', s.recordings, 'v-blue');
+    if (s.annotations > 0) addMediaField('annotations', s.annotations, 'v-peach');
+    if (s.clips > 0) addMediaField('clips', s.clips, 'v-peach');
+    if (s.total_bytes > 0) addMediaField('size', _fmtBytes(s.total_bytes), 'v-dim');
+    card.appendChild(mediaMeta);
+  }
+
+  // Actions row. While browsing a peer host the cards are read-only —
+  // resume/delete/config act on THIS daemon's stores and would target
+  // the wrong machine; interaction happens on the peer's own dashboard
+  // (whole-card click below).
+  if (!ctx.viewingPeer
+      && (sessionId || s.can_resume || s.can_delete || ((s.total_bytes > 0 || !isCurrent) && !isExternal))) {
+    const actions = document.createElement('div');
+    actions.className = 'sc-actions';
+
+    if (s.can_resume !== false) {
+      const resumeBtn = document.createElement('button');
+      resumeBtn.className = 'ui-btn sc-resume-btn';
+      resumeBtn.textContent = 'Resume session';
+      resumeBtn.title = 'Resume this session in Activity';
+      resumeBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        resumeSession(s);
+      });
+      actions.appendChild(resumeBtn);
+    }
+
+    if (sessionId) {
+      const renameBtn = document.createElement('button');
+      renameBtn.className = 'ui-btn sc-rename-btn';
+      renameBtn.textContent = 'Rename';
+      renameBtn.title = 'Rename this session';
+      renameBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        requestSessionRename(s);
+      });
+      actions.appendChild(renameBtn);
+    }
+
+    if (sessionId && configSource && configSource !== 'intendant') {
+      const configBtn = document.createElement('button');
+      configBtn.className = 'ui-btn sc-rename-btn';
+      configBtn.textContent = 'Configure';
+      configBtn.title = 'Configure binary and managed context for this session';
+      configBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        openSessionConfigModal(s);
+      });
+      actions.appendChild(configBtn);
+    }
+
+    const canDeleteLocalSessionData = source === 'intendant'
+      ? s.can_delete !== false
+      : !!(s.can_delete_intendant_log && s.intendant_session_id);
+    if (canDeleteLocalSessionData) {
+      const sessionDeleteLabel = source === 'intendant'
+        ? 'Delete session'
+        : 'Delete Intendant log';
+      const sessionDeleteBytes = source === 'intendant'
+        ? s.total_bytes
+        : (s.intendant_total_bytes || 0);
+      const btn = document.createElement('button');
+      btn.className = 'ui-btn danger sc-delete-btn';
+      btn.textContent = 'Delete...';
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        // Close any existing menu
+        document.querySelectorAll('.sc-delete-menu').forEach(m => m.remove());
+        const menu = document.createElement('div');
+        menu.className = 'sc-delete-menu';
+        menu.setAttribute('role', 'menu');
+
+        const addItem = (label, target, bytes, danger) => {
+          const item = document.createElement('button');
+          item.type = 'button';
+          item.className = 'sc-delete-menu-item' + (danger ? ' danger' : '');
+          item.setAttribute('role', 'menuitem');
+          const txt = document.createElement('span');
+          txt.textContent = label;
+          item.appendChild(txt);
+          if (bytes > 0) {
+            const hint = document.createElement('span');
+            hint.className = 'size-hint';
+            hint.textContent = _fmtBytes(bytes);
+            item.appendChild(hint);
+          }
+          item.addEventListener('click', (ev) => {
+            ev.stopPropagation();
+            menu.remove();
+            deleteSessionData(s.session_id, target, label);
+          });
+          menu.appendChild(item);
+        };
+
+        if ((s.recordings || 0) > 0) addItem('Delete recordings', 'recordings', s.recording_bytes || 0);
+        if ((s.frames_bytes || 0) > 0 || (s.annotations || 0) > 0 || (s.clips || 0) > 0) addItem('Delete frames', 'frames', s.frames_bytes || 0);
+        const hasMedia = (s.recordings || 0) > 0 || (s.frames_bytes || 0) > 0;
+        if (hasMedia) addItem('Delete all media', 'media', (s.recording_bytes || 0) + (s.frames_bytes || 0));
+        if ((s.turns_bytes || 0) > 0) addItem('Delete turn data', 'turns', s.turns_bytes);
+        if (!isCurrent) addItem(sessionDeleteLabel, 'session', sessionDeleteBytes, true);
+
+        if (menu.children.length > 0) {
+          actions.appendChild(menu);
+          const close = (ev) => { if (!menu.contains(ev.target)) { menu.remove(); document.removeEventListener('click', close); } };
+          setTimeout(() => document.addEventListener('click', close), 0);
+        }
+      });
+      actions.appendChild(btn);
+    }
+    card.appendChild(actions);
+  }
+
+  if (ctx.viewingPeer) {
+    card.classList.add('sc-peer');
+    card.title = 'Open this session on the peer’s dashboard';
+    card.addEventListener('click', () => openPeerSessionExternally(s));
+  } else {
+    card.addEventListener('click', () => openSessionDetail(s));
+  }
+  return card;
 }
 
 function _refilterWorktrees() {

--- a/static/app/13-styles-sessions-terminal.css
+++ b/static/app/13-styles-sessions-terminal.css
@@ -186,6 +186,29 @@
   color: var(--overlay0);
   font-size: 12px;
 }
+/* Inline filter box atop the (capped) project menus. */
+.sessions-multi-filter-search {
+  position: sticky;
+  top: 0;
+  padding: 2px 2px 6px;
+  background: var(--mantle);
+}
+.sessions-multi-filter-search.hidden { display: none; }
+.sessions-multi-filter-search input {
+  width: 100%;
+  padding: 5px 7px;
+  border: 1px solid var(--surface1);
+  border-radius: 4px;
+  background: var(--base);
+  color: var(--text);
+  font-size: 12px;
+}
+.sessions-multi-filter-more {
+  padding: 6px 7px;
+  color: var(--overlay0);
+  font-size: 11px;
+  font-style: italic;
+}
 .sessions-toggle {
   display: flex;
   align-items: center;
@@ -835,6 +858,12 @@
   display: flex;
   justify-content: center;
   padding: 10px 0 4px;
+}
+/* Invisible IntersectionObserver target that auto-grows the sessions
+   render window as the user scrolls toward the bottom of the list. */
+.sessions-scroll-sentinel {
+  height: 1px;
+  pointer-events: none;
 }
 /* Long-tail stats inside the session-detail overlay. */
 .sd-meta-strip {

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -109,12 +109,17 @@ let apiKeyStatusLoaded = false;
 // sessions/worktrees module state they touch must be declared up here,
 // not next to their renderers (TDZ).
 const SESSION_LIST_RECENT_LIMIT = 600;
-const SESSION_CARD_RENDER_LIMIT = 300;
+// Sessions render in viewport-sized pages: the initial window, the
+// IntersectionObserver auto-append step, and the Show-more fallback step
+// are all one page. Small pages keep the tab's DOM budget flat no matter
+// how large the corpus grows.
+const SESSION_CARD_RENDER_PAGE = 60;
 const WORKTREE_CARD_RENDER_LIMIT = 200;
 // Show-more render windows: how many cards the list renderers paint before
-// offering a "Show N more" button. Reset on filter/search/sort changes and
-// on a fresh (uncached) list load.
-let sessionsRenderWindow = SESSION_CARD_RENDER_LIMIT;
+// offering a "Show N more" button (sessions also auto-grow via a scroll
+// sentinel). Reset on filter/search/sort changes and on a fresh (uncached)
+// list load.
+let sessionsRenderWindow = SESSION_CARD_RENDER_PAGE;
 let worktreesRenderWindow = WORKTREE_CARD_RENDER_LIMIT;
 let _sessionsLoadToken = 0;
 let _sessionsStreamAbort = null;
@@ -148,6 +153,11 @@ let _sessionsHydrationState = {
 let _sessionsRenderTimer = null;
 let _sessionsRenderLastTs = 0;
 const SESSIONS_RENDER_MIN_INTERVAL_MS = 250;
+// Sessions list render-pass state (see 57-sessions-replay.js): the
+// #sessions deep link runs loadSessions → resetSessionsListRenderState on
+// this same script-evaluation path.
+const _sessionsListRenderState = new Map(); // list element id → pass state
+let _sessionCardBuildSeq = 0; // stamps built cards; QA asserts node identity by it
 let worktreesRequestSerial = 0;
 let worktreesActivityClearTimeout = null;
 let worktreesLoadPromise = null;

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -941,55 +941,123 @@ function applySessionRelationshipsFromSession(session) {
   }
 }
 
+function _foldSessionWindowMetadataRow(session, changedIds) {
+  const meta = sessionWindowMetaFromSession(session);
+  const ids = Array.from(new Set([
+    session.session_id,
+    session.resume_id,
+    session.backend_session_id,
+    session.intendant_session_id,
+  ].map(id => String(id || '').trim()).filter(Boolean)));
+  for (const id of ids) {
+    sessionRowSeenIds.add(id);
+    sessionRelationshipHydrationUnresolved.delete(id);
+    const { meta: merged, changed } = mergeSessionWindowMetadata(id, meta);
+    if (changed && sessionWindows.has(id)) updateSessionWindow(id, merged);
+    if (changed) changedIds.add(id);
+  }
+  if (session.backend_session_id && session.session_id) {
+    applySessionIdentity({
+      session_id: session.session_id,
+      backend_session_id: session.backend_session_id,
+      source: session.backend_source,
+      backend_source_label: session.backend_source_label,
+    });
+  }
+  if (!sessionMetadataStatusIsTerminal(session)) {
+    const rawSource = String(session.source || '').trim().toLowerCase();
+    const source = rawSource === 'intendant'
+      ? 'intendant'
+      : normalizeAgentId(session.source || session.backend_source || '');
+    const backendSessionId = String(session.backend_session_id || '').trim();
+    const intendantSessionId = String(session.intendant_session_id || '').trim();
+    const sessionId = String(session.session_id || '').trim();
+    if (source && source !== 'intendant' && intendantSessionId) {
+      clearStaleSessionWindowDetached(sessionId, 'session metadata reports an attached wrapper');
+    }
+    if (source === 'intendant' && backendSessionId) {
+      clearStaleSessionWindowDetached(backendSessionId, 'wrapper metadata reports this session is attached');
+    }
+  }
+  scheduleExternalSessionWindowTranscriptSyncFromMetadata(session);
+}
+
+// Full-corpus list applies fold thousands of rows; running that
+// synchronously on every stream flush stalled the main thread. Small
+// batches still fold inline (event-driven single-row refreshes stay
+// immediate); large ones fold in idle-time slices. A batch arriving
+// mid-fold queues behind it — latest wins, so every row is eventually
+// folded with the newest data — and the DOM label refresh plus the
+// persist run once per completed fold, not once per flush.
+const SESSION_WINDOW_META_FOLD_SYNC_MAX = 400;
+const SESSION_WINDOW_META_FOLD_CHUNK = 400;
+let _sessionWindowMetaFold = null; // { rows, index, phase, changedIds, queued }
+
 function cacheSessionWindowMetadata(sessions) {
   if (!Array.isArray(sessions)) return;
-  const changedIds = new Set();
-  for (const session of sessions) {
+  if (sessions.length <= SESSION_WINDOW_META_FOLD_SYNC_MAX && !_sessionWindowMetaFold) {
+    const changedIds = new Set();
+    for (const session of sessions) {
+      if (!session || typeof session !== 'object') continue;
+      _foldSessionWindowMetadataRow(session, changedIds);
+    }
+    for (const session of sessions) {
+      if (!session || typeof session !== 'object') continue;
+      applySessionRelationshipsFromSession(session);
+    }
+    refreshSessionIdentityLabelsBulk(changedIds);
+    persistSessionWindowState();
+    return;
+  }
+  if (_sessionWindowMetaFold) {
+    // Union-merge rather than replace: a small event-driven batch queued
+    // behind an in-flight fold must not drop a queued full-corpus apply
+    // (mergeSessionRows keeps newest-per-row).
+    _sessionWindowMetaFold.queued = _sessionWindowMetaFold.queued
+      ? mergeSessionRows(_sessionWindowMetaFold.queued, sessions)
+      : sessions;
+    return;
+  }
+  _sessionWindowMetaFold = { rows: sessions, index: 0, phase: 'meta', changedIds: new Set(), queued: null };
+  _scheduleSessionWindowMetaFoldSlice();
+}
+
+function _scheduleSessionWindowMetaFoldSlice() {
+  if (typeof requestIdleCallback === 'function') {
+    requestIdleCallback(deadline => _runSessionWindowMetaFoldSlice(deadline), { timeout: 300 });
+  } else {
+    setTimeout(() => _runSessionWindowMetaFoldSlice(null), 16);
+  }
+}
+
+function _runSessionWindowMetaFoldSlice(deadline) {
+  const fold = _sessionWindowMetaFold;
+  if (!fold) return;
+  const hasBudget = () => deadline && typeof deadline.timeRemaining === 'function'
+    ? deadline.timeRemaining() > 2
+    : true;
+  let processed = 0;
+  while (processed < SESSION_WINDOW_META_FOLD_CHUNK && hasBudget()) {
+    if (fold.index >= fold.rows.length) {
+      if (fold.phase === 'meta') {
+        fold.phase = 'relationships';
+        fold.index = 0;
+        continue;
+      }
+      _sessionWindowMetaFold = null;
+      refreshSessionIdentityLabelsBulk(fold.changedIds);
+      persistSessionWindowState();
+      if (fold.queued) cacheSessionWindowMetadata(fold.queued);
+      return;
+    }
+    const session = fold.rows[fold.index];
+    fold.index += 1;
     if (!session || typeof session !== 'object') continue;
-    const meta = sessionWindowMetaFromSession(session);
-    const ids = Array.from(new Set([
-      session.session_id,
-      session.resume_id,
-      session.backend_session_id,
-      session.intendant_session_id,
-    ].map(id => String(id || '').trim()).filter(Boolean)));
-    for (const id of ids) {
-      sessionRowSeenIds.add(id);
-      sessionRelationshipHydrationUnresolved.delete(id);
-      const { meta: merged, changed } = mergeSessionWindowMetadata(id, meta);
-      if (changed && sessionWindows.has(id)) updateSessionWindow(id, merged);
-      if (changed) changedIds.add(id);
-    }
-    if (session.backend_session_id && session.session_id) {
-      applySessionIdentity({
-        session_id: session.session_id,
-        backend_session_id: session.backend_session_id,
-        source: session.backend_source,
-        backend_source_label: session.backend_source_label,
-      });
-    }
-    if (!sessionMetadataStatusIsTerminal(session)) {
-      const rawSource = String(session.source || '').trim().toLowerCase();
-      const source = rawSource === 'intendant'
-        ? 'intendant'
-        : normalizeAgentId(session.source || session.backend_source || '');
-      const backendSessionId = String(session.backend_session_id || '').trim();
-      const intendantSessionId = String(session.intendant_session_id || '').trim();
-      const sessionId = String(session.session_id || '').trim();
-      if (source && source !== 'intendant' && intendantSessionId) {
-        clearStaleSessionWindowDetached(sessionId, 'session metadata reports an attached wrapper');
-      }
-      if (source === 'intendant' && backendSessionId) {
-        clearStaleSessionWindowDetached(backendSessionId, 'wrapper metadata reports this session is attached');
-      }
-    }
-    scheduleExternalSessionWindowTranscriptSyncFromMetadata(session);
+    if (fold.phase === 'meta') _foldSessionWindowMetadataRow(session, fold.changedIds);
+    else applySessionRelationshipsFromSession(session);
+    processed += 1;
   }
-  for (const session of sessions) {
-    applySessionRelationshipsFromSession(session);
-  }
-  refreshSessionIdentityLabelsBulk(changedIds);
-  persistSessionWindowState();
+  _scheduleSessionWindowMetaFoldSlice();
 }
 
 // One DOM pass for a whole metadata batch. The per-id

--- a/static/app/56-debug-sessions.js
+++ b/static/app/56-debug-sessions.js
@@ -307,7 +307,7 @@ function setSessionsHost(hostId) {
   const next = !hostId || hostId === selfPeerId ? '' : String(hostId);
   if (next === sessionsActiveHostId) return;
   sessionsActiveHostId = next;
-  sessionsRenderWindow = SESSION_CARD_RENDER_LIMIT;
+  sessionsRenderWindow = SESSION_CARD_RENDER_PAGE;
   renderSessionsHostStrip();
   loadSessions({ force: true });
 }
@@ -405,8 +405,10 @@ function loadSessions(options = {}) {
   if (cached) {
     applyLoadedSessions(cached, aggEl, hostId);
   } else if (listEl) {
-    // Fresh (uncached) load replaces the list — reset the Show-more window.
-    sessionsRenderWindow = SESSION_CARD_RENDER_LIMIT;
+    // Fresh (uncached) load replaces the list — reset the Show-more window
+    // and drop the render-pass state (the skeleton wipe orphans its DOM).
+    sessionsRenderWindow = SESSION_CARD_RENDER_PAGE;
+    resetSessionsListRenderState(listEl.id);
     listEl.innerHTML = '<div class="ui-skel sessions-skel-card"></div>'.repeat(6);
   }
 
@@ -530,6 +532,7 @@ function loadSessions(options = {}) {
           requestedLimit,
         );
         if (!cached && listEl) {
+          resetSessionsListRenderState(listEl.id);
           listEl.innerHTML = '<div class="empty-state">Failed to load sessions</div>';
         }
       });
@@ -659,7 +662,17 @@ function sessionLineageRelationshipLabel(kind) {
   return kind || 'related';
 }
 
+// Single-slot memo: the index costs two sessionConfigMetadata sweeps over
+// the whole corpus, and every render pass (each search keystroke included)
+// wants it. The rowset array is replaced whenever data changes
+// (mergeSessionRows), so array identity is the invalidation key.
+let _sessionLineageIndexFor = null;
+let _sessionLineageIndexMemo = null;
+
 function buildSessionLineageIndex(sessions) {
+  if (sessions && sessions === _sessionLineageIndexFor && _sessionLineageIndexMemo) {
+    return _sessionLineageIndexMemo;
+  }
   const byId = new Map();
   const childrenByParentId = new Map();
   const rows = Array.isArray(sessions) ? sessions : [];
@@ -678,7 +691,15 @@ function buildSessionLineageIndex(sessions) {
     if (!childrenByParentId.has(parentId)) childrenByParentId.set(parentId, []);
     childrenByParentId.get(parentId).push(session);
   }
-  return { byId, childrenByParentId };
+  // Deterministic child ordering regardless of the caller's sort: newest
+  // first (the index used to inherit the list's sort order).
+  for (const children of childrenByParentId.values()) {
+    children.sort((a, b) => sessionDateSortValue(b, 'updated_at') - sessionDateSortValue(a, 'updated_at'));
+  }
+  const index = { byId, childrenByParentId };
+  _sessionLineageIndexFor = sessions;
+  _sessionLineageIndexMemo = index;
+  return index;
 }
 
 function sessionLineageParentForSession(index, session, meta = null) {
@@ -713,7 +734,9 @@ function sessionLineageOpenSession(sourceSession, targetSession, targetId, ev = 
   }
   const id = compactSessionText(targetId || targetSession?.session_id || targetSession?.resume_id);
   if (!id) return;
-  const target = targetSession || {
+  // Re-resolve at click time: lineage chips can outlive the row snapshot
+  // they were built from (cards are cached across stream refreshes).
+  const target = findCachedSessionByAnyId(id) || targetSession || {
     session_id: id,
     source: sessionLineageSource(sourceSession),
     task: shortSessionId(id),
@@ -861,7 +884,7 @@ function _refilterSessions() {
 // Filter/search/sort change: the visible set changes shape, so the
 // Show-more window snaps back to the default page size.
 function _refreshSessionsFilters() {
-  sessionsRenderWindow = SESSION_CARD_RENDER_LIMIT;
+  sessionsRenderWindow = SESSION_CARD_RENDER_PAGE;
   _refilterSessions();
 }
 
@@ -886,6 +909,20 @@ function sessionChangedSortValue(session) {
   );
 }
 
+// Throwaway scratch paths (agent test homes, e2e rigs, OS temp) can easily
+// outnumber real projects in the corpus. They collapse into one synthetic
+// menu entry instead of ballooning the picker; selecting it matches every
+// temp-shaped path.
+const SESSION_TEMP_PROJECTS_FILTER_VALUE = '::temp-projects::';
+
+function sessionPathLooksTemporary(path) {
+  if (!path) return false;
+  if (/^\/(private\/)?var\/folders\//.test(path)) return true;
+  return String(path)
+    .split(/[\\/]+/)
+    .some(seg => seg === 'tmp' || seg === 'temp' || seg === 'Temp' || seg === 'TEMP');
+}
+
 function sessionProjectFilterOptions(sessions) {
   const buckets = new Map();
   for (const session of Array.isArray(sessions) ? sessions : []) {
@@ -901,7 +938,27 @@ function sessionProjectFilterOptions(sessions) {
     existing.latestChanged = Math.max(existing.latestChanged, sessionChangedSortValue(session));
     buckets.set(path, existing);
   }
-  return Array.from(buckets.values()).sort((a, b) => {
+  const options = [];
+  let temp = null;
+  for (const item of buckets.values()) {
+    if (!sessionPathLooksTemporary(item.path)) {
+      options.push(item);
+      continue;
+    }
+    temp = temp || {
+      path: SESSION_TEMP_PROJECTS_FILTER_VALUE,
+      label: 'Temporary directories',
+      title: 'Sessions whose project directory is a throwaway temp path (/tmp, /var/folders, %TEMP%)',
+      count: 0,
+      paths: 0,
+      latestChanged: 0,
+    };
+    temp.count += item.count;
+    temp.paths += 1;
+    temp.latestChanged = Math.max(temp.latestChanged, item.latestChanged);
+  }
+  if (temp) options.push(temp);
+  return options.sort((a, b) => {
     const byChanged = b.latestChanged - a.latestChanged;
     if (byChanged) return byChanged;
     const byLabel = a.label.localeCompare(b.label, undefined, { sensitivity: 'base' });
@@ -912,10 +969,49 @@ function sessionProjectFilterOptions(sessions) {
 function sessionProjectMultiFilterOptions(sessions) {
   return sessionProjectFilterOptions(sessions).map(item => ({
     value: item.path,
-    label: `${item.label} (${item.count.toLocaleString()})`,
-    title: item.path,
+    label: item.paths
+      ? `${item.label} (${item.paths.toLocaleString()} paths, ${item.count.toLocaleString()})`
+      : `${item.label} (${item.count.toLocaleString()})`,
+    title: item.title || item.path,
     plural: 'projects',
   }));
+}
+
+// The project menus render a bounded page of the full option set: every
+// selected value (unchecking must always be possible), then the most
+// recently active projects up to the cap, with an inline filter box that
+// narrows against the whole set. An uncapped render once ballooned the
+// hidden DOM with hundreds of scratch-path checkboxes per menu.
+const SESSION_PROJECT_MENU_CAP = 40;
+const _sessionProjectMenuFilterText = new Map(); // menuId → live filter text
+
+function sessionProjectMenuScaffold(menu, kind, cfg) {
+  let optionsWrap = menu.querySelector(':scope > .sessions-multi-filter-options');
+  if (optionsWrap) {
+    return { search: menu.querySelector(':scope > .sessions-multi-filter-search'), optionsWrap };
+  }
+  menu.textContent = '';
+  const search = document.createElement('div');
+  search.className = 'sessions-multi-filter-search';
+  const input = document.createElement('input');
+  input.type = 'search';
+  input.addEventListener('input', () => {
+    _sessionProjectMenuFilterText.set(cfg.menuId, input.value.trim());
+    renderSessionProjectFilterMenu(kind);
+  });
+  input.addEventListener('keydown', (ev) => {
+    if (ev.key !== 'Escape' || !input.value) return;
+    input.value = '';
+    _sessionProjectMenuFilterText.set(cfg.menuId, '');
+    renderSessionProjectFilterMenu(kind);
+    ev.stopPropagation();
+  });
+  search.appendChild(input);
+  optionsWrap = document.createElement('div');
+  optionsWrap.className = 'sessions-multi-filter-options';
+  menu.appendChild(search);
+  menu.appendChild(optionsWrap);
+  return { search, optionsWrap };
 }
 
 function renderSessionProjectFilterMenu(kind) {
@@ -923,16 +1019,43 @@ function renderSessionProjectFilterMenu(kind) {
   const menu = document.getElementById(cfg.menuId);
   if (!menu) return;
   const selected = new Set(parseStoredSessionMultiFilter(kind));
-  menu.innerHTML = '';
+  const { search, optionsWrap } = sessionProjectMenuScaffold(menu, kind, cfg);
+  const filterText = (_sessionProjectMenuFilterText.get(cfg.menuId) || '').toLowerCase();
+  const searchInput = search.querySelector('input');
+  searchInput.placeholder = `Filter ${cfg.options.length.toLocaleString()} projects...`;
+  search.classList.toggle('hidden', cfg.options.length <= SESSION_PROJECT_MENU_CAP && !filterText);
+  optionsWrap.textContent = '';
 
-  if (cfg.options.length === 0) {
-    const empty = document.createElement('div');
-    empty.className = 'sessions-multi-filter-empty';
-    empty.textContent = 'No project directories';
-    menu.appendChild(empty);
+  const matchesFilter = opt => !filterText
+    || opt.label.toLowerCase().includes(filterText)
+    || String(opt.value).toLowerCase().includes(filterText)
+    || String(opt.title || '').toLowerCase().includes(filterText);
+  const visible = [];
+  for (const opt of cfg.options) {
+    if (selected.has(opt.value)) visible.push(opt);
+  }
+  let overflow = 0;
+  let shown = 0;
+  for (const opt of cfg.options) {
+    if (selected.has(opt.value) || !matchesFilter(opt)) continue;
+    if (shown >= SESSION_PROJECT_MENU_CAP) {
+      overflow += 1;
+      continue;
+    }
+    visible.push(opt);
+    shown += 1;
   }
 
-  for (const opt of cfg.options) {
+  if (visible.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'sessions-multi-filter-empty';
+    empty.textContent = filterText
+      ? `No projects match "${filterText}"`
+      : 'No project directories';
+    optionsWrap.appendChild(empty);
+  }
+
+  for (const opt of visible) {
     const label = document.createElement('label');
     if (opt.title) label.title = opt.title;
     const input = document.createElement('input');
@@ -944,7 +1067,14 @@ function renderSessionProjectFilterMenu(kind) {
     text.textContent = opt.label;
     label.appendChild(input);
     label.appendChild(text);
-    menu.appendChild(label);
+    optionsWrap.appendChild(label);
+  }
+
+  if (overflow > 0) {
+    const more = document.createElement('div');
+    more.className = 'sessions-multi-filter-more';
+    more.textContent = `+${overflow.toLocaleString()} more — type to narrow`;
+    optionsWrap.appendChild(more);
   }
 
   const validSelected = Array.from(selected).filter(value =>
@@ -958,10 +1088,29 @@ function renderSessionProjectFilterMenu(kind) {
   setSessionMultiFilterValues(kind, validSelected);
 }
 
+let _sessionProjectOptionsSerialized = null;
+
 function updateSessionProjectFilterOptions(sessions = _cachedSessions) {
   sessionProjectFilterOptionsCache = sessionProjectMultiFilterOptions(sessions);
-  renderSessionProjectFilterMenu('project');
-  renderSessionProjectFilterMenu('deep-project');
+  // Streamed refreshes call this on every flush; skip the DOM work when the
+  // option set didn't change, and never rebuild a menu the user has open —
+  // it re-renders on its next open instead.
+  const serialized = JSON.stringify(sessionProjectFilterOptionsCache.map(o => [o.value, o.label]));
+  const changed = serialized !== _sessionProjectOptionsSerialized;
+  _sessionProjectOptionsSerialized = serialized;
+  for (const kind of ['project', 'deep-project']) {
+    const menu = document.getElementById(sessionMultiFilterConfig(kind).menuId);
+    if (!menu) continue;
+    const rendered = menu.dataset.optionsRendered === '1';
+    if (rendered && !changed) continue;
+    if (rendered && !menu.classList.contains('hidden')) {
+      menu.dataset.staleOptions = '1';
+      continue;
+    }
+    renderSessionProjectFilterMenu(kind);
+    menu.dataset.optionsRendered = '1';
+    delete menu.dataset.staleOptions;
+  }
 }
 
 function sessionMultiFilterConfig(kind) {
@@ -1103,11 +1252,20 @@ function setupSessionMultiFilter(kind, onChange) {
     ev.stopPropagation();
     const willOpen = menu.classList.contains('hidden');
     closeSessionMultiFilterMenus(willOpen ? kind : '');
+    if (willOpen && menu.dataset.staleOptions === '1') {
+      // Option refreshes are deferred while the menu is open (see
+      // updateSessionProjectFilterOptions) — catch up before showing it.
+      renderSessionProjectFilterMenu(kind);
+      delete menu.dataset.staleOptions;
+    }
     menu.classList.toggle('hidden', !willOpen);
     button.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
   });
   menu.addEventListener('click', ev => ev.stopPropagation());
-  menu.addEventListener('change', () => {
+  menu.addEventListener('change', (ev) => {
+    // The project menus embed a text filter input; only checkbox toggles
+    // are selection changes.
+    if (ev.target && ev.target.type !== 'checkbox') return;
     const values = sessionMultiFilterValues(kind);
     localStorage.setItem(cfg.key, JSON.stringify(values));
     updateSessionMultiFilterSummary(kind);
@@ -1306,7 +1464,9 @@ function sessionDeepProjectFilterValue() {
 function sessionMatchesProjectFilter(session, filter) {
   const filters = Array.isArray(filter) ? filter : (filter && filter !== 'all' ? [filter] : []);
   if (filters.length === 0) return true;
-  return filters.includes(sessionProjectDirectory(session));
+  const dir = sessionProjectDirectory(session);
+  if (filters.includes(SESSION_TEMP_PROJECTS_FILTER_VALUE) && sessionPathLooksTemporary(dir)) return true;
+  return filters.includes(dir);
 }
 
 function sessionMatchesSourceFilter(source, filter) {
@@ -1612,7 +1772,19 @@ function updateSessionsSearchStatus() {
   }
 }
 
+// Per-row haystack memo: without it every quick-search keystroke rebuilds
+// a ~30-field string for every row in the corpus. Keyed by row object
+// identity — mergeSessionRows keeps identity for untouched rows and swaps
+// it when a row changes, so entries invalidate themselves; the two inputs
+// that can drift independently of the row (current-session status override)
+// revalidate explicitly. source/shortId derive from the row and need no key.
+const _sessionSearchTextCache = new WeakMap();
+
 function sessionSearchText(session, displayStatus, source, shortId, isCurrent) {
+  const cached = _sessionSearchTextCache.get(session);
+  if (cached && cached.status === displayStatus && cached.current === isCurrent) {
+    return cached.text;
+  }
   const totalBytes = session.total_bytes || 0;
   const fields = [
     session.session_id,
@@ -1650,10 +1822,12 @@ function sessionSearchText(session, displayStatus, source, shortId, isCurrent) {
     session.total_tokens != null ? `${session.total_tokens} tokens` : '',
     session.estimated_cost != null ? `$${Number(session.estimated_cost).toFixed(4)}` : '',
   ];
-  return fields
+  const text = fields
     .filter(v => v !== null && v !== undefined && v !== '')
     .join(' ')
     .toLowerCase();
+  _sessionSearchTextCache.set(session, { status: displayStatus, current: isCurrent, text });
+  return text;
 }
 
 function sessionMatchesSearch(session, query, displayStatus, source, shortId, isCurrent) {

--- a/static/app/57-sessions-replay.js
+++ b/static/app/57-sessions-replay.js
@@ -1,98 +1,98 @@
-function renderSessionsList(sessions, el, options = {}) {
-  if (!el) return;
-  el.innerHTML = '';
-  updateSessionsSearchStatus();
+// ── Sessions list rendering: windowed, signature-guarded, node-stable ──
+// The corpus (_cachedSessions) can be thousands of rows; the DOM holds only
+// `sessionsRenderWindow` cards (one SESSION_CARD_RENDER_PAGE initially,
+// auto-grown page-at-a-time by a scroll sentinel, with the Show-more button
+// as the explicit fallback). Each render pass is decided by a cheap
+// signature: an identical pass is skipped outright, a grown window appends
+// only the new cards, and only a changed rowset/filter/sort runs a full
+// pass — and even a full pass reuses the DOM node of every card whose
+// content signature is unchanged, so a stream refresh keeps node identity
+// (and event listeners) for untouched rows instead of wiping the subtree.
+// (Pass state lives in the early client-state block — deep-link TDZ.)
 
-  const deepSearchOnly = !!options.deepSearchOnly;
-  if (deepSearchOnly && !_sessionDeepSearch.active) {
-    const message = _sessionDeepSearch.loading
-      ? 'Deep search is running...'
-      : 'Run a deep search to show log matches';
-    el.innerHTML = `<div class="empty-state">${message}</div>`;
-    return;
+function sessionsListRenderStateFor(elId) {
+  let st = _sessionsListRenderState.get(elId);
+  if (!st) {
+    st = {
+      dataRef: null,
+      optionsKey: '',
+      window: 0,
+      matched: null, // match entries from the last full pass (sorted, filtered)
+      matchedCount: 0,
+      hiddenSubagentCount: 0,
+      renderedCount: 0,
+      cards: new Map(), // row key → { sig, card } — bounded by the render window
+      trailer: [],
+      io: null,
+      growPending: false,
+      lastMode: 'none',
+      lastMs: 0,
+      passSeq: 0, // counts non-skip passes; QA sequencing hook
+    };
+    _sessionsListRenderState.set(elId, st);
   }
+  return st;
+}
 
-  if (sessions.length === 0) {
-    el.innerHTML = '<div class="empty-state">No sessions found</div>';
-    return;
-  }
+// Wipe sites (loading skeletons, empty states, error placeholders) replace
+// the list DOM out from under the pass state — they must drop it so the
+// next render runs a full pass instead of appending into a foreign subtree.
+function resetSessionsListRenderState(elId) {
+  const st = elId ? _sessionsListRenderState.get(elId) : null;
+  if (!st) return;
+  if (st.io) st.io.disconnect();
+  _sessionsListRenderState.delete(elId);
+}
 
-  // Sort sessions based on dropdown
+// Everything besides the rowset that changes what the list shows. A pass
+// with the same data array identity and the same key as the previous one
+// is a no-op (mergeSessionRows returns a new array whenever data changed).
+function sessionsListOptionsKey(options, currentSessionId) {
+  return JSON.stringify([
+    options.mode || '',
+    options.query || '',
+    options.sortValue || 'updated-desc',
+    options.projectFilter || '',
+    options.sourceFilter || [],
+    options.statusFilter || [],
+    !!options.deepSearchOnly,
+    options.deepSearchOnly ? _sessionDeepSearchToken : 0,
+    options.deepSearchOnly ? !!_sessionDeepSearch.active : false,
+    !!options.hideSubagents,
+    currentSessionId,
+    sessionsViewingPeer() ? currentSessionsHostId() : '',
+  ]);
+}
+
+function collectSessionsListMatches(sessions, options, ctx) {
   const sortVal = options.sortValue || 'updated-desc';
-  const sorted = [...sessions];
   const [field, dir] = sortVal.split('-');
   const asc = dir === 'asc';
-  sorted.sort((a, b) => {
-    let va, vb;
+  const sortKey = (s) => {
     switch (field) {
-      case 'created':
-        va = sessionDateSortValue(a, 'created_at');
-        vb = sessionDateSortValue(b, 'created_at');
-        break;
-      case 'updated':
-        va = sessionDateSortValue(a, 'updated_at');
-        vb = sessionDateSortValue(b, 'updated_at');
-        break;
-      case 'cost':
-        va = a.estimated_cost || 0;
-        vb = b.estimated_cost || 0;
-        break;
-      case 'size':
-        va = a.total_bytes || 0;
-        vb = b.total_bytes || 0;
-        break;
-      case 'turns':
-        va = a.turns || 0;
-        vb = b.turns || 0;
-        break;
+      case 'created': return sessionDateSortValue(s, 'created_at');
+      case 'updated': return sessionDateSortValue(s, 'updated_at');
+      case 'cost': return s.estimated_cost || 0;
+      case 'size': return s.total_bytes || 0;
+      case 'turns': return s.turns || 0;
       default: return 0;
     }
-    return asc ? va - vb : vb - va;
-  });
-
-  const currentSessionId = daemonSessionFullId || '';
+  };
+  // Decorate-sort-undecorate: sessionDateSortValue parses timestamps, so
+  // key once per row instead of once per comparison.
+  const decorated = sessions.map(s => [sortKey(s), s]);
+  decorated.sort((a, b) => asc ? a[0] - b[0] : b[0] - a[0]);
 
   const query = options.query || '';
   const projectFilter = options.projectFilter || '';
   const sourceFilter = options.sourceFilter || [];
   const statusFilter = options.statusFilter || [];
-  const hasProjectFilter = Array.isArray(projectFilter) ? projectFilter.length > 0 : !!projectFilter;
-  const deepSearchActive = deepSearchOnly && _sessionDeepSearch.active;
-  const hideSubagents = !!options.hideSubagents;
+  const matched = [];
   let hiddenSubagentCount = 0;
-  let matchedCount = 0;
-  let renderedCount = 0;
-  const fragment = document.createDocumentFragment();
-  const lineageIndex = buildSessionLineageIndex(sorted);
-
-  for (const s of sorted) {
-    const configMeta = sessionConfigMetadata(s);
-    const configSource = sessionConfigSource(configMeta);
-    const relationshipKind = sessionRelationshipKindForRow(s, configMeta);
-    const rawSource = normalizeAgentId(s.source || '') || 'intendant';
-    const backendSource = normalizeAgentId(
-      s.backend_source ||
-      s.backendSource ||
-      s.configured_source ||
-      s.configuredSource ||
-      configMeta.backend_source ||
-      configMeta.backendSource ||
-      configMeta.configured_source ||
-      configMeta.configuredSource ||
-      ''
-    );
-    const hasExternalBackend = !!(
-      backendSource && backendSource !== 'intendant' ||
-      configSource && configSource !== 'intendant' ||
-      s.backend_session_id ||
-      s.backendSessionId ||
-      configMeta.backendSessionId ||
-      configMeta.backend_session_id
-    );
-    const source = rawSource;
+  for (const [, s] of decorated) {
+    const source = normalizeAgentId(s.source || '') || 'intendant';
     const shortId = (s.session_id || '').substring(0, 8);
-    const isExternal = source !== 'intendant';
-    const isCurrent = currentSessionId && s.session_id && s.session_id.startsWith(currentSessionId);
+    const isCurrent = !!(ctx.currentSessionId && s.session_id && s.session_id.startsWith(ctx.currentSessionId));
 
     // Override status for current session — never show as abandoned/idle
     let displayStatus = s.status || 'in_progress';
@@ -100,382 +100,228 @@ function renderSessionsList(sessions, el, options = {}) {
       displayStatus = 'in_progress';
     }
 
-    // Apply filters
+    // Cheap filters first; sessionConfigMetadata (object merges per row)
+    // only runs for rows that survive them.
     if (!sessionMatchesProjectFilter(s, projectFilter)) continue;
     if (!sessionMatchesSourceFilter(source, sourceFilter)) continue;
     if (!sessionMatchesStatusFilter(displayStatus, statusFilter)) continue;
-    const summaryMatch = sessionMatchesSearch(s, query, displayStatus, source, shortId, isCurrent);
-    if (!summaryMatch) continue;
-    const logHit = deepSearchOnly ? sessionDeepSearchHit(s, source) : null;
-    if (deepSearchActive && !logHit) continue;
-    if (hideSubagents && relationshipKind === 'subagent') {
+    if (!sessionMatchesSearch(s, query, displayStatus, source, shortId, isCurrent)) continue;
+    const logHit = ctx.deepSearchOnly ? sessionDeepSearchHit(s, source) : null;
+    if (ctx.deepSearchActive && !logHit) continue;
+    if (ctx.hideSubagents && sessionRelationshipKindForRow(s) === 'subagent') {
       hiddenSubagentCount += 1;
       continue;
     }
+    matched.push({ s, source, shortId, isCurrent, displayStatus, logHit });
+  }
+  return { matched, hiddenSubagentCount };
+}
 
-    matchedCount += 1;
-    if (renderedCount >= sessionsRenderWindow) continue;
-    renderedCount += 1;
+// Card inputs computed from OUTSIDE the row object itself (lineage across
+// other rows, live config metadata, deep-search hits, peer browsing).
+// The row's own fields are covered by JSON.stringify(row) in the card
+// signature; this covers the rest, so signature equality ⇒ identical card.
+function sessionCardDerived(m, ctx) {
+  const { s } = m;
+  const configMeta = sessionConfigMetadata(s);
+  const configSource = sessionConfigSource(configMeta);
+  const relationshipKind = sessionRelationshipKindForRow(s, configMeta);
+  const backendSource = normalizeAgentId(
+    s.backend_source ||
+    s.backendSource ||
+    s.configured_source ||
+    s.configuredSource ||
+    configMeta.backend_source ||
+    configMeta.backendSource ||
+    configMeta.configured_source ||
+    configMeta.configuredSource ||
+    ''
+  );
+  const hasExternalBackend = !!(
+    backendSource && backendSource !== 'intendant' ||
+    configSource && configSource !== 'intendant' ||
+    s.backend_session_id ||
+    s.backendSessionId ||
+    configMeta.backendSessionId ||
+    configMeta.backend_session_id
+  );
+  let nickname = '';
+  let parentId = '';
+  let parent = null;
+  let parentLabel = '';
+  if (relationshipKind) {
+    nickname = compactSessionText(configMeta.agentNickname || s.agent_nickname || s.agentNickname);
+    const lineage = sessionLineageParentForSession(ctx.lineageIndex, s, configMeta);
+    parentId = lineage.parentId;
+    parent = lineage.parent;
+    parentLabel = sessionLineageDisplayLabel(parent, parentId);
+  }
+  const lineageChildren = sessionLineageChildrenForSession(ctx.lineageIndex, s, configMeta)
+    .filter(child => !ctx.hideSubagents || sessionRelationshipKindForRow(child) !== 'subagent');
+  return {
+    configMeta, configSource, relationshipKind, backendSource, hasExternalBackend,
+    nickname, parentId, parent, parentLabel, lineageChildren,
+  };
+}
 
-    const rowIsPartial = s.partial === true;
-    const card = document.createElement('div');
-    card.className = 'session-card';
-    if (isCurrent) card.classList.add('current');
-    if (displayStatus === 'abandoned') card.classList.add('dimmed');
-    if (rowIsPartial) card.classList.add('partial');
+function sessionCardSig(m, derived, ctx) {
+  const childSig = derived.lineageChildren.map(child => {
+    const childId = sessionLineageIds(child)[0] || child.session_id || '';
+    return `${sessionRelationshipKindForRow(child)}\u001e${childId}\u001e${sessionLineageDisplayLabel(child, childId)}`;
+  }).join('\u001d');
+  const hitSig = m.logHit
+    ? `${m.logHit.matches || 0}\u001e${(((m.logHit.snippets || [])[0]) || {}).content || ''}`
+    : '';
+  return JSON.stringify(m.s) + '\u001f' + JSON.stringify([
+    m.displayStatus, m.isCurrent, m.source, ctx.viewingPeer,
+    derived.relationshipKind, derived.configSource, derived.backendSource,
+    derived.hasExternalBackend, derived.nickname, derived.parentId,
+    derived.parentLabel, childSig, hitSig,
+  ]);
+}
 
-    const sessionName = compactSessionText(s.name);
-    const taskText = compactSessionText(s.task);
-    const sessionId = s.session_id || '';
-    const primaryText = sessionName || taskText || 'Untitled session';
-    const titleKindText = sessionName ? 'name' : taskText ? 'initial' : 'untitled';
+// Reused cards keep their DOM nodes, so their relative "Nm ago" label is
+// refreshed in place instead of by rebuild (the absolute timestamp lives
+// in the tooltip and never drifts).
+function refreshSessionCardRelativeLabel(card) {
+  const changedAt = card.dataset.changedAt || '';
+  if (!changedAt) return;
+  const span = card.querySelector('.sc-meta .value[data-rel="changed"]');
+  if (!span) return;
+  const label = sessionRelativeLabel(changedAt) || changedAt;
+  if (span.textContent !== label) span.textContent = label;
+}
 
-    // Top row: name/task + status badges
-    const top = document.createElement('div');
-    top.className = 'sc-top';
+function sessionCardFor(m, ctx, st, nextCards) {
+  const key = sessionListRowKey(m.s);
+  const derived = sessionCardDerived(m, ctx);
+  const sig = sessionCardSig(m, derived, ctx);
+  const cached = key ? st.cards.get(key) : null;
+  let card;
+  if (cached && cached.sig === sig) {
+    card = cached.card;
+    refreshSessionCardRelativeLabel(card);
+  } else {
+    card = buildSessionCard(m, derived, ctx);
+    if (key) card.dataset.sessionKey = key;
+    card.dataset.qaBuildSeq = String(++_sessionCardBuildSeq);
+  }
+  if (key) (nextCards || st.cards).set(key, { sig, card });
+  return card;
+}
 
-    const titleBlock = document.createElement('div');
-    titleBlock.className = 'sc-title-block';
-    const titleRow = document.createElement('div');
-    titleRow.className = 'sc-title-row';
-    const titleKind = document.createElement('span');
-    titleKind.className = 'sc-title-kind';
-    titleKind.classList.add(titleKindText);
-    titleKind.textContent = titleKindText;
-    titleKind.title = sessionName
-      ? 'User-assigned session name'
-      : taskText
-        ? 'Initial message fallback'
-        : 'No initial message found';
-    titleRow.appendChild(titleKind);
-    const nameEl = document.createElement('div');
-    nameEl.className = 'sc-name';
-    nameEl.textContent = primaryText;
-    nameEl.title = primaryText;
-    titleRow.appendChild(nameEl);
-    titleBlock.appendChild(titleRow);
-    top.appendChild(titleBlock);
+function growSessionsRenderWindow() {
+  sessionsRenderWindow += SESSION_CARD_RENDER_PAGE;
+  renderSessionsViews();
+}
 
-    const statusEl = document.createElement('span');
-    statusEl.className = `ui-chip ${sessionStatusChipTone(displayStatus)} sc-status ${displayStatus}`;
-    statusEl.textContent = displayStatus.replace('_', ' ');
-    top.appendChild(statusEl);
+function removeSessionsListTrailer(st) {
+  for (const node of st.trailer) node.remove();
+  st.trailer = [];
+}
 
-    const sourceEl = document.createElement('span');
-    sourceEl.className = 'ui-badge sc-source' + (isExternal ? '' : ' local');
-    sourceEl.textContent = isExternal
-      ? (
-        s.source_label ||
-        s.sourceLabel ||
-        s.backend_source_label ||
-        s.backendSourceLabel ||
-        prettyAgentName(source) ||
-        source
-      )
-      : (s.source_label || s.sourceLabel || 'Intendant');
-    if (!isExternal && hasExternalBackend && backendSource && backendSource !== 'intendant') {
-      sourceEl.title = `${prettyAgentName(backendSource) || backendSource} backend`;
-    }
-    top.appendChild(sourceEl);
-
-    if (rowIsPartial) {
-      const loadingEl = document.createElement('span');
-      loadingEl.className = 'ui-chip info sc-role sc-loading-chip';
-      loadingEl.textContent = 'loading details';
-      loadingEl.title = 'Tokens, costs, lineage, and disk sizes are still hydrating';
-      top.appendChild(loadingEl);
-    }
-
-    if (s.role) {
-      const roleEl = document.createElement('span');
-      roleEl.className = 'ui-chip muted sc-role';
-      roleEl.textContent = s.role;
-      top.appendChild(roleEl);
-    }
-
-    if (relationshipKind) {
-      const nickname = compactSessionText(configMeta.agentNickname || s.agent_nickname || s.agentNickname);
-      const { parentId, parent } = sessionLineageParentForSession(lineageIndex, s, configMeta);
-      const parentLabel = sessionLineageDisplayLabel(parent, parentId);
-      const kindLabel = sessionLineageRelationshipLabel(relationshipKind);
-      const chipText = relationshipKind === 'subagent' && nickname
-        ? `${kindLabel} ${nickname}`
-        : parentId
-          ? `${kindLabel} of ${parentLabel}`
-          : kindLabel;
-      const titleParts = [
-        relationshipKind === 'subagent' && nickname ? `Subagent: ${nickname}` : `Relationship: ${kindLabel}`,
-        parentId ? `Parent: ${parentLabel} (${parentId})` : '',
-      ].filter(Boolean);
-      const relationEl = createSessionLineageListChip(s, parent, parentId, chipText, titleParts.join('\n') || `${kindLabel} session`);
-      top.appendChild(relationEl);
-    }
-
-    const lineageChildren = sessionLineageChildrenForSession(lineageIndex, s, configMeta)
-      .filter(child => !hideSubagents || sessionRelationshipKindForRow(child) !== 'subagent');
-    if (lineageChildren.length > 0) {
-      const childrenEl = document.createElement('span');
-      childrenEl.className = 'ui-chip muted sc-role sc-lineage-chip sc-lineage-children';
-      childrenEl.textContent = lineageChildren.length === 1 ? '1 child' : `${lineageChildren.length} children`;
-      childrenEl.title = lineageChildren
-        .slice(0, 8)
-        .map(child => {
-          const childKind = sessionLineageRelationshipLabel(sessionRelationshipKindForRow(child));
-          const childId = sessionLineageIds(child)[0] || child.session_id || '';
-          return `${childKind}: ${sessionLineageDisplayLabel(child, childId)}${childId ? ` (${childId})` : ''}`;
-        })
-        .join('\n') + (lineageChildren.length > 8 ? `\n+${lineageChildren.length - 8} more` : '');
-      top.appendChild(childrenEl);
-    }
-
-    if (isCurrent) {
-      const badge = document.createElement('span');
-      badge.className = 'ui-chip info sc-current-badge';
-      badge.textContent = 'current';
-      top.appendChild(badge);
-    }
-
-    card.appendChild(top);
-
-    // Task
-    if (taskText && sessionName) {
-      const taskEl = document.createElement('div');
-      taskEl.className = 'sc-task';
-      taskEl.textContent = taskText;
-      taskEl.title = taskText;
-      card.appendChild(taskEl);
-    }
-
-    if (logHit) {
-      const hitEl = document.createElement('div');
-      hitEl.className = 'sc-search-hit';
-      const hitCount = document.createElement('span');
-      hitCount.className = 'sc-search-hit-count';
-      const matches = Number(logHit.matches || 0);
-      hitCount.textContent = `${matches} log ${matches === 1 ? 'match' : 'matches'}`;
-      hitEl.appendChild(hitCount);
-      const firstSnippet = (logHit.snippets || [])[0] || {};
-      const hitText = document.createElement('span');
-      hitText.className = 'sc-search-hit-text';
-      hitText.textContent = firstSnippet.content || '';
-      hitText.title = firstSnippet.content || '';
-      hitEl.appendChild(hitText);
-      card.appendChild(hitEl);
-    }
-
-    // Meta row — the full session id (click to copy) plus compact
-    // essentials; the long tail (absolute dates, provider, token breakdown,
-    // disk) moves to the row tooltip and stays visible in the
-    // session-detail overlay.
-    const meta = document.createElement('div');
-    meta.className = 'sc-meta';
-    const addMetaField = (label, value, valueClass, valueTitle) => {
-      if (value === null || value === undefined || value === '') return null;
-      const span = document.createElement('span');
-      const l = document.createElement('span');
-      l.className = 'label';
-      l.textContent = label;
-      const v = document.createElement('span');
-      v.className = 'value' + (valueClass ? ` ${valueClass}` : '');
-      v.textContent = value;
-      if (valueTitle) v.title = valueTitle;
-      span.appendChild(l);
-      span.appendChild(v);
-      meta.appendChild(span);
-      return v;
-    };
-
-    const idVal = addMetaField('id', sessionId || shortId, 'sc-id', 'Click to copy the session ID');
-    if (idVal) {
-      idVal.addEventListener('click', (e) => {
-        e.stopPropagation();
-        const fullId = sessionId || shortId;
-        copyTextToClipboard(fullId)
-          .then(() => showControlToast('success', `Copied session ID ${shortSessionId(fullId)}`))
-          .catch(err => showControlToast('error', `Copy session ID failed: ${err?.message || err}`));
+// Scroll sentinel + Show-more fallback below the rendered cards. The
+// IntersectionObserver grows the window a page at a time as the user nears
+// the bottom; the button stays for environments without IO and as the
+// explicit bulk control.
+function appendSessionsListTrailer(el, st) {
+  removeSessionsListTrailer(st);
+  const remaining = st.matchedCount - st.renderedCount;
+  if (remaining <= 0) {
+    if (st.io) st.io.disconnect();
+    return;
+  }
+  const sentinel = document.createElement('div');
+  sentinel.className = 'sessions-scroll-sentinel';
+  sentinel.setAttribute('aria-hidden', 'true');
+  const moreRow = document.createElement('div');
+  moreRow.className = 'sessions-show-more';
+  const moreBtn = document.createElement('button');
+  moreBtn.type = 'button';
+  moreBtn.className = 'ui-btn sessions-show-more-btn';
+  moreBtn.textContent = `Show ${Math.min(SESSION_CARD_RENDER_PAGE, remaining).toLocaleString()} more (${remaining.toLocaleString()} remaining)`;
+  moreBtn.onclick = () => growSessionsRenderWindow();
+  moreRow.appendChild(moreBtn);
+  el.appendChild(sentinel);
+  el.appendChild(moreRow);
+  st.trailer = [sentinel, moreRow];
+  if (!st.io && typeof IntersectionObserver === 'function') {
+    st.io = new IntersectionObserver((entries) => {
+      if (!entries.some(e => e.isIntersecting)) return;
+      if (st.growPending) return;
+      st.growPending = true;
+      requestAnimationFrame(() => {
+        st.growPending = false;
+        if (st.matchedCount > st.renderedCount) growSessionsRenderWindow();
       });
-    }
-    const changedAt = s.updated_at || s.changed_at;
-    if (changedAt) addMetaField('changed', sessionRelativeLabel(changedAt) || changedAt, null, changedAt);
-    const projectPath = sessionProjectDirectory(s);
-    if (projectPath) addMetaField('project', compactPathLabel(projectPath), null, projectPath);
-    if (s.model) addMetaField('model', s.model, 'model-val');
-    if (s.turns > 0) addMetaField('turns', s.turns);
-    if (rowIsPartial) {
-      const loading = document.createElement('span');
-      loading.className = 'sc-loading-meta';
-      const loadingLabel = document.createElement('span');
-      loadingLabel.className = 'label';
-      loadingLabel.textContent = 'details';
-      const loadingVal = document.createElement('span');
-      loadingVal.className = 'value';
-      loadingVal.textContent = 'tokens, cost, lineage, size';
-      loading.appendChild(loadingLabel);
-      loading.appendChild(loadingVal);
-      meta.appendChild(loading);
-    } else {
-      if (s.total_tokens > 0) addMetaField('tokens', s.total_tokens.toLocaleString());
-      if (s.estimated_cost > 0) addMetaField('cost', formatUsd(s.estimated_cost, 2));
-    }
+    }, { rootMargin: '600px 0px' });
+  }
+  if (st.io) {
+    st.io.disconnect();
+    st.io.observe(sentinel);
+  }
+}
 
-    const tipParts = [];
-    if (s.created_at) tipParts.push(`created: ${s.created_at}`);
-    if (changedAt) tipParts.push(`changed: ${changedAt}`);
-    if (s.provider) tipParts.push(`provider: ${s.provider}`);
-    if (!rowIsPartial && s.total_tokens > 0) {
-      tipParts.push(`tokens: ${(s.prompt_tokens || 0).toLocaleString()} in${s.cached_tokens > 0 ? ` (${s.cached_tokens.toLocaleString()} cached)` : ''} / ${(s.completion_tokens || 0).toLocaleString()} out`);
-    }
-    if (!rowIsPartial && s.total_bytes > 0) tipParts.push(`disk: ${_fmtBytes(s.total_bytes)}`);
-    if (projectPath) tipParts.push(`project: ${projectPath}`);
-    if (tipParts.length) meta.title = tipParts.join('\n');
-    card.appendChild(meta);
+function renderSessionsList(sessions, el, options = {}) {
+  if (!el) return;
+  updateSessionsSearchStatus();
+  const elId = el.id || '';
+  const t0 = performance.now();
 
-    // Media stats row (recordings, annotations, clips) + total session size
-    const hasMedia = (s.recordings > 0 || s.annotations > 0 || s.clips > 0);
-    if (!rowIsPartial && hasMedia) {
-      const mediaMeta = document.createElement('div');
-      mediaMeta.className = 'sc-meta sc-media';
-      const addMediaField = (label, value, valueClass) => {
-        const span = document.createElement('span');
-        const l = document.createElement('span');
-        l.className = 'label';
-        l.textContent = label;
-        const v = document.createElement('span');
-        v.className = 'value' + (valueClass ? ` ${valueClass}` : '');
-        v.textContent = value;
-        span.appendChild(l);
-        span.appendChild(v);
-        mediaMeta.appendChild(span);
-      };
-      if (s.recordings > 0) addMediaField('recordings', s.recordings, 'v-blue');
-      if (s.annotations > 0) addMediaField('annotations', s.annotations, 'v-peach');
-      if (s.clips > 0) addMediaField('clips', s.clips, 'v-peach');
-      if (s.total_bytes > 0) addMediaField('size', _fmtBytes(s.total_bytes), 'v-dim');
-      card.appendChild(mediaMeta);
-    }
-
-    // Actions row. While browsing a peer host the cards are read-only —
-    // resume/delete/config act on THIS daemon's stores and would target
-    // the wrong machine; interaction happens on the peer's own dashboard
-    // (whole-card click below).
-    if (!sessionsViewingPeer()
-        && (sessionId || s.can_resume || s.can_delete || ((s.total_bytes > 0 || !isCurrent) && !isExternal))) {
-      const actions = document.createElement('div');
-      actions.className = 'sc-actions';
-
-      if (s.can_resume !== false) {
-        const resumeBtn = document.createElement('button');
-        resumeBtn.className = 'ui-btn sc-resume-btn';
-        resumeBtn.textContent = 'Resume session';
-        resumeBtn.title = 'Resume this session in Activity';
-        resumeBtn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          resumeSession(s);
-        });
-        actions.appendChild(resumeBtn);
-      }
-
-      if (sessionId) {
-        const renameBtn = document.createElement('button');
-        renameBtn.className = 'ui-btn sc-rename-btn';
-        renameBtn.textContent = 'Rename';
-        renameBtn.title = 'Rename this session';
-        renameBtn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          requestSessionRename(s);
-        });
-        actions.appendChild(renameBtn);
-      }
-
-      if (sessionId && configSource && configSource !== 'intendant') {
-        const configBtn = document.createElement('button');
-        configBtn.className = 'ui-btn sc-rename-btn';
-        configBtn.textContent = 'Configure';
-        configBtn.title = 'Configure binary and managed context for this session';
-        configBtn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          openSessionConfigModal(s);
-        });
-        actions.appendChild(configBtn);
-      }
-
-      const canDeleteLocalSessionData = rawSource === 'intendant'
-        ? s.can_delete !== false
-        : !!(s.can_delete_intendant_log && s.intendant_session_id);
-      if (canDeleteLocalSessionData) {
-        const sessionDeleteLabel = rawSource === 'intendant'
-          ? 'Delete session'
-          : 'Delete Intendant log';
-        const sessionDeleteBytes = rawSource === 'intendant'
-          ? s.total_bytes
-          : (s.intendant_total_bytes || 0);
-        const btn = document.createElement('button');
-        btn.className = 'ui-btn danger sc-delete-btn';
-        btn.textContent = 'Delete...';
-        btn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          // Close any existing menu
-          document.querySelectorAll('.sc-delete-menu').forEach(m => m.remove());
-          const menu = document.createElement('div');
-          menu.className = 'sc-delete-menu';
-          menu.setAttribute('role', 'menu');
-
-          const addItem = (label, target, bytes, danger) => {
-            const item = document.createElement('button');
-            item.type = 'button';
-            item.className = 'sc-delete-menu-item' + (danger ? ' danger' : '');
-            item.setAttribute('role', 'menuitem');
-            const txt = document.createElement('span');
-            txt.textContent = label;
-            item.appendChild(txt);
-            if (bytes > 0) {
-              const hint = document.createElement('span');
-              hint.className = 'size-hint';
-              hint.textContent = _fmtBytes(bytes);
-              item.appendChild(hint);
-            }
-            item.addEventListener('click', (ev) => {
-              ev.stopPropagation();
-              menu.remove();
-              deleteSessionData(s.session_id, target, label);
-            });
-            menu.appendChild(item);
-          };
-
-          if ((s.recordings || 0) > 0) addItem('Delete recordings', 'recordings', s.recording_bytes || 0);
-          if ((s.frames_bytes || 0) > 0 || (s.annotations || 0) > 0 || (s.clips || 0) > 0) addItem('Delete frames', 'frames', s.frames_bytes || 0);
-          const hasMedia = (s.recordings || 0) > 0 || (s.frames_bytes || 0) > 0;
-          if (hasMedia) addItem('Delete all media', 'media', (s.recording_bytes || 0) + (s.frames_bytes || 0));
-          if ((s.turns_bytes || 0) > 0) addItem('Delete turn data', 'turns', s.turns_bytes);
-          if (!isCurrent) addItem(sessionDeleteLabel, 'session', sessionDeleteBytes, true);
-
-          if (menu.children.length > 0) {
-            actions.appendChild(menu);
-            const close = (ev) => { if (!menu.contains(ev.target)) { menu.remove(); document.removeEventListener('click', close); } };
-            setTimeout(() => document.addEventListener('click', close), 0);
-          }
-        });
-        actions.appendChild(btn);
-      }
-      card.appendChild(actions);
-    }
-
-    if (sessionsViewingPeer()) {
-      card.classList.add('sc-peer');
-      card.title = 'Open this session on the peer’s dashboard';
-      card.addEventListener('click', () => openPeerSessionExternally(s));
-    } else {
-      card.addEventListener('click', () => openSessionDetail(s));
-    }
-    fragment.appendChild(card);
+  const deepSearchOnly = !!options.deepSearchOnly;
+  if (deepSearchOnly && !_sessionDeepSearch.active) {
+    const message = _sessionDeepSearch.loading
+      ? 'Deep search is running...'
+      : 'Run a deep search to show log matches';
+    resetSessionsListRenderState(elId);
+    el.innerHTML = `<div class="empty-state">${message}</div>`;
+    return;
   }
 
+  if (sessions.length === 0) {
+    resetSessionsListRenderState(elId);
+    el.innerHTML = '<div class="empty-state">No sessions found</div>';
+    return;
+  }
+
+  const currentSessionId = daemonSessionFullId || '';
+  const st = sessionsListRenderStateFor(elId);
+  const optionsKey = sessionsListOptionsKey(options, currentSessionId);
+  const windowSize = sessionsRenderWindow;
+  const samePass = st.dataRef === sessions && st.optionsKey === optionsKey && st.matched !== null;
+  if (samePass && st.window === windowSize) {
+    st.lastMode = 'skip'; // identical pass — the DOM is already right
+    return;
+  }
+
+  const ctx = {
+    deepSearchOnly,
+    deepSearchActive: deepSearchOnly && _sessionDeepSearch.active,
+    hideSubagents: !!options.hideSubagents,
+    viewingPeer: sessionsViewingPeer(),
+    currentSessionId,
+    lineageIndex: buildSessionLineageIndex(sessions),
+  };
+
+  const appendOnly = samePass && windowSize > st.window && st.renderedCount > 0;
+  let matched = st.matched;
+  let hiddenSubagentCount = st.hiddenSubagentCount;
+  if (!appendOnly) {
+    const collected = collectSessionsListMatches(sessions, options, ctx);
+    matched = collected.matched;
+    hiddenSubagentCount = collected.hiddenSubagentCount;
+  }
+  const matchedCount = matched.length;
+
   if (matchedCount === 0) {
+    const query = options.query || '';
+    const projectFilter = options.projectFilter || '';
+    const hasProjectFilter = Array.isArray(projectFilter) ? projectFilter.length > 0 : !!projectFilter;
     const empty = document.createElement('div');
     empty.className = 'empty-state';
-    empty.textContent = deepSearchActive && sessionDeepSearchHasMissingMetadata()
+    empty.textContent = ctx.deepSearchActive && sessionDeepSearchHasMissingMetadata()
       ? 'Loading session metadata for matching log results...'
-      : deepSearchActive
+      : ctx.deepSearchActive
       ? 'No sessions match the deep search results'
       : query
       ? 'No sessions match your search'
@@ -483,29 +329,451 @@ function renderSessionsList(sessions, el, options = {}) {
       ? 'No sessions match the selected projects'
       : hiddenSubagentCount > 0
       ? 'No main sessions found. Subagent sessions are hidden from Recent.'
-      : sessionsViewingPeer()
+      : ctx.viewingPeer
       ? 'No sessions visible on this peer — it may not have granted session access.'
       : 'No sessions match the active filters';
+    resetSessionsListRenderState(elId);
+    el.innerHTML = '';
     el.appendChild(empty);
-  } else {
-    el.appendChild(fragment);
-    if (matchedCount > renderedCount) {
-      const remaining = matchedCount - renderedCount;
-      const moreRow = document.createElement('div');
-      moreRow.className = 'sessions-show-more';
-      const moreBtn = document.createElement('button');
-      moreBtn.type = 'button';
-      moreBtn.className = 'ui-btn sessions-show-more-btn';
-      moreBtn.textContent = `Show ${Math.min(SESSION_CARD_RENDER_LIMIT, remaining).toLocaleString()} more (${remaining.toLocaleString()} remaining)`;
-      moreBtn.onclick = () => {
-        sessionsRenderWindow += SESSION_CARD_RENDER_LIMIT;
-        renderSessionsViews();
-      };
-      moreRow.appendChild(moreBtn);
-      el.appendChild(moreRow);
-    }
+    return;
   }
 
+  const renderedTarget = Math.min(windowSize, matchedCount);
+  const nextCards = appendOnly ? null : new Map();
+  const built = [];
+  for (let i = appendOnly ? st.renderedCount : 0; i < renderedTarget; i++) {
+    built.push(sessionCardFor(matched[i], ctx, st, nextCards));
+  }
+
+  if (appendOnly) {
+    removeSessionsListTrailer(st);
+    for (const card of built) el.appendChild(card);
+  } else {
+    st.cards = nextCards;
+    st.trailer = [];
+    el.replaceChildren(...built);
+  }
+  st.dataRef = sessions;
+  st.optionsKey = optionsKey;
+  st.window = windowSize;
+  st.matched = matched;
+  st.matchedCount = matchedCount;
+  st.hiddenSubagentCount = hiddenSubagentCount;
+  st.renderedCount = renderedTarget;
+  appendSessionsListTrailer(el, st);
+  st.lastMode = appendOnly ? 'append' : 'full';
+  st.lastMs = performance.now() - t0;
+  st.passSeq += 1;
+}
+
+// QA readback (window.qa convention): DOM-budget and node-identity facts
+// the validate-dashboard harness asserts on — module scope hides them.
+// Probe functions stay cheap and side-effect-free.
+window.qa = Object.assign(window.qa || {}, {
+  sessionsDom: (listId = 'sessions-list') => {
+    const el = document.getElementById(listId);
+    const st = _sessionsListRenderState.get(listId) || null;
+    const cards = el ? Array.from(el.querySelectorAll('.session-card')) : [];
+    return {
+      nodes: el ? el.getElementsByTagName('*').length : 0,
+      cards: cards.length,
+      matched: st ? st.matchedCount : null,
+      hiddenSubagents: st ? st.hiddenSubagentCount : null,
+      corpus: Array.isArray(_cachedSessions) ? _cachedSessions.length : null,
+      window: sessionsRenderWindow,
+      page: SESSION_CARD_RENDER_PAGE,
+      lastMode: st ? st.lastMode : 'none',
+      lastMs: st ? st.lastMs : null,
+      passSeq: st ? st.passSeq : 0,
+      loadToken: _sessionsLoadToken,
+      trailer: st ? st.trailer.length : 0,
+      hydration: {
+        active: _sessionsHydrationState.active,
+        done: _sessionsHydrationState.done,
+        phase: _sessionsHydrationState.phase,
+        received: _sessionsHydrationState.received,
+      },
+      cardSeqs: cards.slice(0, 24).map(c => ({
+        key: c.dataset.sessionKey || '',
+        seq: Number(c.dataset.qaBuildSeq || 0),
+      })),
+    };
+  },
+  // QA ACTIONS (not probes — they mutate): the module scope hides the
+  // sessions functions from harness-evaluated JS, so scripted scenarios
+  // need explicit bridges (same reason as the window.* onclick bridges;
+  // precedent: station.activate).
+  sessionsActions: {
+    reload: () => loadSessions({ force: true }),
+    grow: () => growSessionsRenderWindow(),
+    // Pull the complete corpus over the plain-JSON path — deterministic
+    // fallback while the RPC stream leg can wedge before its replace.
+    pullAll: () => fetchSessionsForHost(undefined, { force: true, limit: 'all' })
+      .then(rows => applyLoadedSessions(rows, document.getElementById('sessions-aggregate'))),
+  },
+});
+
+function buildSessionCard(m, derived, ctx) {
+  const { s, source, shortId, isCurrent, displayStatus, logHit } = m;
+  const { configMeta, configSource, relationshipKind, backendSource, hasExternalBackend } = derived;
+  const isExternal = source !== 'intendant';
+
+  const rowIsPartial = s.partial === true;
+  const card = document.createElement('div');
+  card.className = 'session-card';
+  if (isCurrent) card.classList.add('current');
+  if (displayStatus === 'abandoned') card.classList.add('dimmed');
+  if (rowIsPartial) card.classList.add('partial');
+
+  const sessionName = compactSessionText(s.name);
+  const taskText = compactSessionText(s.task);
+  const sessionId = s.session_id || '';
+  const primaryText = sessionName || taskText || 'Untitled session';
+  const titleKindText = sessionName ? 'name' : taskText ? 'initial' : 'untitled';
+
+  // Top row: name/task + status badges
+  const top = document.createElement('div');
+  top.className = 'sc-top';
+
+  const titleBlock = document.createElement('div');
+  titleBlock.className = 'sc-title-block';
+  const titleRow = document.createElement('div');
+  titleRow.className = 'sc-title-row';
+  const titleKind = document.createElement('span');
+  titleKind.className = 'sc-title-kind';
+  titleKind.classList.add(titleKindText);
+  titleKind.textContent = titleKindText;
+  titleKind.title = sessionName
+    ? 'User-assigned session name'
+    : taskText
+      ? 'Initial message fallback'
+      : 'No initial message found';
+  titleRow.appendChild(titleKind);
+  const nameEl = document.createElement('div');
+  nameEl.className = 'sc-name';
+  nameEl.textContent = primaryText;
+  nameEl.title = primaryText;
+  titleRow.appendChild(nameEl);
+  titleBlock.appendChild(titleRow);
+  top.appendChild(titleBlock);
+
+  const statusEl = document.createElement('span');
+  statusEl.className = `ui-chip ${sessionStatusChipTone(displayStatus)} sc-status ${displayStatus}`;
+  statusEl.textContent = displayStatus.replace('_', ' ');
+  top.appendChild(statusEl);
+
+  const sourceEl = document.createElement('span');
+  sourceEl.className = 'ui-badge sc-source' + (isExternal ? '' : ' local');
+  sourceEl.textContent = isExternal
+    ? (
+      s.source_label ||
+      s.sourceLabel ||
+      s.backend_source_label ||
+      s.backendSourceLabel ||
+      prettyAgentName(source) ||
+      source
+    )
+    : (s.source_label || s.sourceLabel || 'Intendant');
+  if (!isExternal && hasExternalBackend && backendSource && backendSource !== 'intendant') {
+    sourceEl.title = `${prettyAgentName(backendSource) || backendSource} backend`;
+  }
+  top.appendChild(sourceEl);
+
+  if (rowIsPartial) {
+    const loadingEl = document.createElement('span');
+    loadingEl.className = 'ui-chip info sc-role sc-loading-chip';
+    loadingEl.textContent = 'loading details';
+    loadingEl.title = 'Tokens, costs, lineage, and disk sizes are still hydrating';
+    top.appendChild(loadingEl);
+  }
+
+  if (s.role) {
+    const roleEl = document.createElement('span');
+    roleEl.className = 'ui-chip muted sc-role';
+    roleEl.textContent = s.role;
+    top.appendChild(roleEl);
+  }
+
+  if (relationshipKind) {
+    const { nickname, parentId, parent, parentLabel } = derived;
+    const kindLabel = sessionLineageRelationshipLabel(relationshipKind);
+    const chipText = relationshipKind === 'subagent' && nickname
+      ? `${kindLabel} ${nickname}`
+      : parentId
+        ? `${kindLabel} of ${parentLabel}`
+        : kindLabel;
+    const titleParts = [
+      relationshipKind === 'subagent' && nickname ? `Subagent: ${nickname}` : `Relationship: ${kindLabel}`,
+      parentId ? `Parent: ${parentLabel} (${parentId})` : '',
+    ].filter(Boolean);
+    const relationEl = createSessionLineageListChip(s, parent, parentId, chipText, titleParts.join('\n') || `${kindLabel} session`);
+    top.appendChild(relationEl);
+  }
+
+  const lineageChildren = derived.lineageChildren;
+  if (lineageChildren.length > 0) {
+    const childrenEl = document.createElement('span');
+    childrenEl.className = 'ui-chip muted sc-role sc-lineage-chip sc-lineage-children';
+    childrenEl.textContent = lineageChildren.length === 1 ? '1 child' : `${lineageChildren.length} children`;
+    childrenEl.title = lineageChildren
+      .slice(0, 8)
+      .map(child => {
+        const childKind = sessionLineageRelationshipLabel(sessionRelationshipKindForRow(child));
+        const childId = sessionLineageIds(child)[0] || child.session_id || '';
+        return `${childKind}: ${sessionLineageDisplayLabel(child, childId)}${childId ? ` (${childId})` : ''}`;
+      })
+      .join('\n') + (lineageChildren.length > 8 ? `\n+${lineageChildren.length - 8} more` : '');
+    top.appendChild(childrenEl);
+  }
+
+  if (isCurrent) {
+    const badge = document.createElement('span');
+    badge.className = 'ui-chip info sc-current-badge';
+    badge.textContent = 'current';
+    top.appendChild(badge);
+  }
+
+  card.appendChild(top);
+
+  // Task
+  if (taskText && sessionName) {
+    const taskEl = document.createElement('div');
+    taskEl.className = 'sc-task';
+    taskEl.textContent = taskText;
+    taskEl.title = taskText;
+    card.appendChild(taskEl);
+  }
+
+  if (logHit) {
+    const hitEl = document.createElement('div');
+    hitEl.className = 'sc-search-hit';
+    const hitCount = document.createElement('span');
+    hitCount.className = 'sc-search-hit-count';
+    const matches = Number(logHit.matches || 0);
+    hitCount.textContent = `${matches} log ${matches === 1 ? 'match' : 'matches'}`;
+    hitEl.appendChild(hitCount);
+    const firstSnippet = (logHit.snippets || [])[0] || {};
+    const hitText = document.createElement('span');
+    hitText.className = 'sc-search-hit-text';
+    hitText.textContent = firstSnippet.content || '';
+    hitText.title = firstSnippet.content || '';
+    hitEl.appendChild(hitText);
+    card.appendChild(hitEl);
+  }
+
+  // Meta row — the full session id (click to copy) plus compact
+  // essentials; the long tail (absolute dates, provider, token breakdown,
+  // disk) moves to the row tooltip and stays visible in the
+  // session-detail overlay.
+  const meta = document.createElement('div');
+  meta.className = 'sc-meta';
+  const addMetaField = (label, value, valueClass, valueTitle) => {
+    if (value === null || value === undefined || value === '') return null;
+    const span = document.createElement('span');
+    const l = document.createElement('span');
+    l.className = 'label';
+    l.textContent = label;
+    const v = document.createElement('span');
+    v.className = 'value' + (valueClass ? ` ${valueClass}` : '');
+    v.textContent = value;
+    if (valueTitle) v.title = valueTitle;
+    span.appendChild(l);
+    span.appendChild(v);
+    meta.appendChild(span);
+    return v;
+  };
+
+  const idVal = addMetaField('id', sessionId || shortId, 'sc-id', 'Click to copy the session ID');
+  if (idVal) {
+    idVal.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const fullId = sessionId || shortId;
+      copyTextToClipboard(fullId)
+        .then(() => showControlToast('success', `Copied session ID ${shortSessionId(fullId)}`))
+        .catch(err => showControlToast('error', `Copy session ID failed: ${err?.message || err}`));
+    });
+  }
+  const changedAt = s.updated_at || s.changed_at;
+  if (changedAt) {
+    const changedVal = addMetaField('changed', sessionRelativeLabel(changedAt) || changedAt, null, changedAt);
+    if (changedVal) {
+      // refreshSessionCardRelativeLabel re-derives this label in place when
+      // the card is reused across render passes.
+      changedVal.dataset.rel = 'changed';
+      card.dataset.changedAt = changedAt;
+    }
+  }
+  const projectPath = sessionProjectDirectory(s);
+  if (projectPath) addMetaField('project', compactPathLabel(projectPath), null, projectPath);
+  if (s.model) addMetaField('model', s.model, 'model-val');
+  if (s.turns > 0) addMetaField('turns', s.turns);
+  if (rowIsPartial) {
+    const loading = document.createElement('span');
+    loading.className = 'sc-loading-meta';
+    const loadingLabel = document.createElement('span');
+    loadingLabel.className = 'label';
+    loadingLabel.textContent = 'details';
+    const loadingVal = document.createElement('span');
+    loadingVal.className = 'value';
+    loadingVal.textContent = 'tokens, cost, lineage, size';
+    loading.appendChild(loadingLabel);
+    loading.appendChild(loadingVal);
+    meta.appendChild(loading);
+  } else {
+    if (s.total_tokens > 0) addMetaField('tokens', s.total_tokens.toLocaleString());
+    if (s.estimated_cost > 0) addMetaField('cost', formatUsd(s.estimated_cost, 2));
+  }
+
+  const tipParts = [];
+  if (s.created_at) tipParts.push(`created: ${s.created_at}`);
+  if (changedAt) tipParts.push(`changed: ${changedAt}`);
+  if (s.provider) tipParts.push(`provider: ${s.provider}`);
+  if (!rowIsPartial && s.total_tokens > 0) {
+    tipParts.push(`tokens: ${(s.prompt_tokens || 0).toLocaleString()} in${s.cached_tokens > 0 ? ` (${s.cached_tokens.toLocaleString()} cached)` : ''} / ${(s.completion_tokens || 0).toLocaleString()} out`);
+  }
+  if (!rowIsPartial && s.total_bytes > 0) tipParts.push(`disk: ${_fmtBytes(s.total_bytes)}`);
+  if (projectPath) tipParts.push(`project: ${projectPath}`);
+  if (tipParts.length) meta.title = tipParts.join('\n');
+  card.appendChild(meta);
+
+  // Media stats row (recordings, annotations, clips) + total session size
+  const hasMedia = (s.recordings > 0 || s.annotations > 0 || s.clips > 0);
+  if (!rowIsPartial && hasMedia) {
+    const mediaMeta = document.createElement('div');
+    mediaMeta.className = 'sc-meta sc-media';
+    const addMediaField = (label, value, valueClass) => {
+      const span = document.createElement('span');
+      const l = document.createElement('span');
+      l.className = 'label';
+      l.textContent = label;
+      const v = document.createElement('span');
+      v.className = 'value' + (valueClass ? ` ${valueClass}` : '');
+      v.textContent = value;
+      span.appendChild(l);
+      span.appendChild(v);
+      mediaMeta.appendChild(span);
+    };
+    if (s.recordings > 0) addMediaField('recordings', s.recordings, 'v-blue');
+    if (s.annotations > 0) addMediaField('annotations', s.annotations, 'v-peach');
+    if (s.clips > 0) addMediaField('clips', s.clips, 'v-peach');
+    if (s.total_bytes > 0) addMediaField('size', _fmtBytes(s.total_bytes), 'v-dim');
+    card.appendChild(mediaMeta);
+  }
+
+  // Actions row. While browsing a peer host the cards are read-only —
+  // resume/delete/config act on THIS daemon's stores and would target
+  // the wrong machine; interaction happens on the peer's own dashboard
+  // (whole-card click below).
+  if (!ctx.viewingPeer
+      && (sessionId || s.can_resume || s.can_delete || ((s.total_bytes > 0 || !isCurrent) && !isExternal))) {
+    const actions = document.createElement('div');
+    actions.className = 'sc-actions';
+
+    if (s.can_resume !== false) {
+      const resumeBtn = document.createElement('button');
+      resumeBtn.className = 'ui-btn sc-resume-btn';
+      resumeBtn.textContent = 'Resume session';
+      resumeBtn.title = 'Resume this session in Activity';
+      resumeBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        resumeSession(s);
+      });
+      actions.appendChild(resumeBtn);
+    }
+
+    if (sessionId) {
+      const renameBtn = document.createElement('button');
+      renameBtn.className = 'ui-btn sc-rename-btn';
+      renameBtn.textContent = 'Rename';
+      renameBtn.title = 'Rename this session';
+      renameBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        requestSessionRename(s);
+      });
+      actions.appendChild(renameBtn);
+    }
+
+    if (sessionId && configSource && configSource !== 'intendant') {
+      const configBtn = document.createElement('button');
+      configBtn.className = 'ui-btn sc-rename-btn';
+      configBtn.textContent = 'Configure';
+      configBtn.title = 'Configure binary and managed context for this session';
+      configBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        openSessionConfigModal(s);
+      });
+      actions.appendChild(configBtn);
+    }
+
+    const canDeleteLocalSessionData = source === 'intendant'
+      ? s.can_delete !== false
+      : !!(s.can_delete_intendant_log && s.intendant_session_id);
+    if (canDeleteLocalSessionData) {
+      const sessionDeleteLabel = source === 'intendant'
+        ? 'Delete session'
+        : 'Delete Intendant log';
+      const sessionDeleteBytes = source === 'intendant'
+        ? s.total_bytes
+        : (s.intendant_total_bytes || 0);
+      const btn = document.createElement('button');
+      btn.className = 'ui-btn danger sc-delete-btn';
+      btn.textContent = 'Delete...';
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        // Close any existing menu
+        document.querySelectorAll('.sc-delete-menu').forEach(m => m.remove());
+        const menu = document.createElement('div');
+        menu.className = 'sc-delete-menu';
+        menu.setAttribute('role', 'menu');
+
+        const addItem = (label, target, bytes, danger) => {
+          const item = document.createElement('button');
+          item.type = 'button';
+          item.className = 'sc-delete-menu-item' + (danger ? ' danger' : '');
+          item.setAttribute('role', 'menuitem');
+          const txt = document.createElement('span');
+          txt.textContent = label;
+          item.appendChild(txt);
+          if (bytes > 0) {
+            const hint = document.createElement('span');
+            hint.className = 'size-hint';
+            hint.textContent = _fmtBytes(bytes);
+            item.appendChild(hint);
+          }
+          item.addEventListener('click', (ev) => {
+            ev.stopPropagation();
+            menu.remove();
+            deleteSessionData(s.session_id, target, label);
+          });
+          menu.appendChild(item);
+        };
+
+        if ((s.recordings || 0) > 0) addItem('Delete recordings', 'recordings', s.recording_bytes || 0);
+        if ((s.frames_bytes || 0) > 0 || (s.annotations || 0) > 0 || (s.clips || 0) > 0) addItem('Delete frames', 'frames', s.frames_bytes || 0);
+        const hasMedia = (s.recordings || 0) > 0 || (s.frames_bytes || 0) > 0;
+        if (hasMedia) addItem('Delete all media', 'media', (s.recording_bytes || 0) + (s.frames_bytes || 0));
+        if ((s.turns_bytes || 0) > 0) addItem('Delete turn data', 'turns', s.turns_bytes);
+        if (!isCurrent) addItem(sessionDeleteLabel, 'session', sessionDeleteBytes, true);
+
+        if (menu.children.length > 0) {
+          actions.appendChild(menu);
+          const close = (ev) => { if (!menu.contains(ev.target)) { menu.remove(); document.removeEventListener('click', close); } };
+          setTimeout(() => document.addEventListener('click', close), 0);
+        }
+      });
+      actions.appendChild(btn);
+    }
+    card.appendChild(actions);
+  }
+
+  if (ctx.viewingPeer) {
+    card.classList.add('sc-peer');
+    card.title = 'Open this session on the peer’s dashboard';
+    card.addEventListener('click', () => openPeerSessionExternally(s));
+  } else {
+    card.addEventListener('click', () => openSessionDetail(s));
+  }
+  return card;
 }
 
 function _refilterWorktrees() {


### PR DESCRIPTION
Perf batch for the Sessions tab (first of two PRs; conversation-preview quick search follows separately).

## What changed

- **Viewport-real rendering**: cards render in 60-card pages, auto-grown by an IntersectionObserver scroll sentinel as the user nears the bottom (Show-more button stays as the explicit fallback).
- **Signature-guarded passes**: identical render passes skip outright; a grown window appends only the new cards; only a changed rowset/filter/sort runs a full pass — and even a full pass reuses the DOM node of every card whose content signature is unchanged, so stream refreshes keep node identity (and event listeners) for untouched rows. Relative-time labels refresh in place on reused cards.
- **Memoized search haystacks** (per row, keyed by object identity — mergeSessionRows preserves identity for untouched rows) and a memoized lineage index (keyed by rowset array identity). First search keystroke builds, the rest hit.
- **Capped project menus**: every selected value + the ~40 most recent projects, an inline filter over the full set, temp-shaped paths (/tmp, /var/folders, %TEMP%) collapsed into one synthetic entry; menu rebuilds skip when unchanged and defer while open.
- **Idle-chunked metadata fold**: full-corpus window-metadata folds run in requestIdleCallback slices; mid-fold batches union-merge into one queued follow-up; label refresh + persist once per fold.
- **QA**: `window.qa.sessionsDom` probe + `window.qa.sessionsActions` bridges for validate-dashboard scenarios.

## Verified (validate-dashboard scenario against a scratch daemon, 3,409-row corpus)

| Metric | Before | After |
|---|---|---|
| DOM nodes / cards (initial) | ~25k / 300 | **1,661 / 60** |
| After one append page | — | 3,386 / 120 (`lastMode: append`, via real Show-more click) |
| Full render pass at 3.4k rows | rebuilt every 250ms tick | 28–35ms, skipped when nothing changed |
| Search keystroke | full haystack + 300-card rebuild | 23ms cold / **2.1ms** memoized |
| Corpus completeness | — | matched 2,996 + 413 hidden subagents = 3,409 ✓ |
| Node identity across stream refresh | n/a (full wipe) | unchanged rows keep their nodes; quick-phase `partial` flips correctly rebuild |

Separate pre-existing finding filed during verification (task #19): the dashboard RPC stream leg can wedge before delivering the ~7MB `replace` on large corpora — reproduces with the stock SPA, independent of this change.