### PR TITLE
Discovery: CLI skill indexes its operator nouns; CLAUDE.md points operators at ctl

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,11 @@ Common invocations (full flag reference in `docs/src/getting-started.md`):
 
 Requires an API key in `.env` (searched: cwd + parents → project root → `~/.config/intendant/.env`). `.env` and `intendant.toml` are git-ignored.
 
+**Operating vs. developing:** to drive a *running* daemon — sessions, approvals,
+displays, screenshots, computer use, federated peers — use `intendant ctl`
+(self-describing: `ctl --help`; agent guide in `skills/intendant-cli/SKILL.md`).
+Read the source to change Intendant, not to operate it.
+
 **Tests:** unit tests are inline `#[cfg(test)]` modules. `tests/e2e/` is the headless end-to-end suite (in CI on all three platforms): it spawns the real binaries against the scripted mock provider (`PROVIDER=mock` + `INTENDANT_MOCK_SCRIPT`, `src/bin/caller/provider_mock.rs`) — keyless, no network, no display; run it with `cargo test --test e2e`. Real-LLM scenarios live as SKILL.md files under `tests/skills/` and are **not** in CI (real API calls / need a display). `scripts/validate-dashboard.cjs` is the dashboard/Station QA harness (drives a real browser over CDP; also not in CI). Run `cargo test --bins` and `cargo clippy` locally before committing.
 
 ## Repository Layout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,11 @@ Common invocations (full flag reference in `docs/src/getting-started.md`):
 
 Requires an API key in `.env` (searched: cwd + parents → project root → `~/.config/intendant/.env`). `.env` and `intendant.toml` are git-ignored.
 
+**Operating vs. developing:** to drive a *running* daemon — sessions, approvals,
+displays, screenshots, computer use, federated peers — use `intendant ctl`
+(self-describing: `ctl --help`; agent guide in `skills/intendant-cli/SKILL.md`).
+Read the source to change Intendant, not to operate it.
+
 **Tests:** unit tests are inline `#[cfg(test)]` modules. `tests/e2e/` is the headless end-to-end suite (in CI on all three platforms): it spawns the real binaries against the scripted mock provider (`PROVIDER=mock` + `INTENDANT_MOCK_SCRIPT`, `src/bin/caller/provider_mock.rs`) — keyless, no network, no display; run it with `cargo test --test e2e`. Real-LLM scenarios live as SKILL.md files under `tests/skills/` and are **not** in CI (real API calls / need a display). `scripts/validate-dashboard.cjs` is the dashboard/Station QA harness (drives a real browser over CDP; also not in CI). Run `cargo test --bins` and `cargo clippy` locally before committing.
 
 ## Repository Layout

--- a/skills/intendant-cli/SKILL.md
+++ b/skills/intendant-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: intendant-cli
-description: Use when an agent needs Intendant control beyond the small MCP bootstrap set. Prefer `intendant ctl` over broad MCP tools to keep model context small.
+description: Use to operate a running Intendant daemon from the CLI — sessions, approvals, displays and screenshots, computer-use input, browser workspaces, audio, and federated peers (message or delegate to another machine's agent, or drive its screen directly with --peer). Prefer `intendant ctl` over broad MCP tools to keep model context small.
 ---
 
 # Intendant CLI
@@ -15,6 +15,17 @@ Start with:
 "${INTENDANT:-intendant}" ctl --help
 "${INTENDANT:-intendant}" ctl status --json
 "${INTENDANT:-intendant}" ctl tools list
+```
+
+Quick recipes — the highest-traffic one-liners; everything else is one `--help` away:
+
+```bash
+"${INTENDANT:-intendant}" ctl display screenshot --output shot.png    # see a local display
+"${INTENDANT:-intendant}" ctl cu actions --actions '[{"type":"click","x":100,"y":200}]' --output after.png
+"${INTENDANT:-intendant}" ctl peer list                               # federated peers + their displays
+"${INTENDANT:-intendant}" ctl peer task <peer-id> "instructions"      # the peer's own agent executes
+"${INTENDANT:-intendant}" ctl --peer <id> display screenshot --output peer.png   # drive another machine
+"${INTENDANT:-intendant}" ctl --peer <id> cu actions --actions '[{"type":"click","x":100,"y":200}]'
 ```
 
 Useful groups:


### PR DESCRIPTION
An agent asked to "open a display on the other machine and click around" never matched the `intendant-cli` skill: its frontmatter description said only "Intendant control beyond the small MCP bootstrap set" — none of the nouns an operator task is phrased in. Observed consequence (live): sessions detoured through codebase archaeology before stumbling into `ctl --help`, which then self-served fine. The entry point was the waste, not the depth.

Three fixes, no behavior changes:

- **Skill frontmatter** now names what it teaches — sessions, approvals, displays and screenshots, computer-use input, browser workspaces, audio, and federated peers including `--peer` — so skill matching fires on natural operator phrasing. (The description is the only thing an agent sees when deciding whether to load a skill.)
- **Quick-recipes block** at the top of the skill body: the highest-traffic one-liners (local screenshot / cu; `peer list` / `peer task`; `--peer` screenshot / cu) so a loaded skill gives the direct path without walking help trees.
- **CLAUDE.md** gains an operating-vs-developing pointer beside the common invocations: drive a *running* daemon through `ctl`; read the source to change Intendant, not to operate it. This kills the repo-priming detour for any future operator-shaped task. AGENTS.md updated as the enforced byte-for-byte copy.