### PR TITLE
Hosted Connect: make the WebRTC transport actually work end to end

### DIFF
--- a/crates/intendant-display/src/webrtc.rs
+++ b/crates/intendant-display/src/webrtc.rs
@@ -4184,61 +4184,65 @@ async fn drain_outputs<I: rtc::interceptor::Interceptor>(
             }
             continue;
         }
-        // Routability filtering only applies to UDP: for UDP we need the
-        // kernel's `sendto` to succeed from our bound socket, and a
-        // loopback-source-to-routable-destination pair would be rejected with
-        // EINVAL. For TCP the connection is already established and we own the
-        // stream directly.
-        if t.transport.transport_protocol == TransportProtocol::UDP {
-            if t.transport.local_addr.is_ipv4() != t.transport.peer_addr.is_ipv4() {
-                continue;
+        // Route by connection before trusting the engine's protocol stamp:
+        // rtc 0.9 marks DTLS and SCTP transmits `TransportProtocol::UDP`
+        // even when the selected pair is TCP ("TransportProtocol doesn't
+        // matter" — rtc/src/peer_connection/transport/dtls/mod.rs), so a
+        // peer that reached us over ICE-TCP must be matched by its tuple,
+        // not by the stamp, or every post-ICE packet misses the stream and
+        // DTLS times out. (The relay check above stays first: relay
+        // transmits key on our relayed *local* address, which is never a
+        // TCP peer tuple.)
+        if let Some(sender) = tcp_senders.get(&t.transport.peer_addr) {
+            let contents: Vec<u8> = t.message.to_vec();
+            // Enqueue onto the connection's ordered writer channel.
+            // `try_send` (never `send().await`) keeps the rtc poll loop
+            // non-blocking: a full queue means the writer task can't
+            // keep up with the encoder, so we drop *this* frame as
+            // backpressure rather than stalling the driver or
+            // overflowing the kernel send buffer. The writer task,
+            // not the scheduler, controls wire order.
+            match sender.try_send(contents) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    // Slow/saturated TCP path — drop and let RTP
+                    // recovery (PLI/FIR + keyframes) catch the peer up.
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    // Writer task exited (connection torn down). Forget
+                    // the dead sender so we stop trying to route to it.
+                    tcp_senders.remove(&t.transport.peer_addr);
+                }
             }
-            if t.transport.local_addr.ip().is_loopback() != t.transport.peer_addr.ip().is_loopback()
-            {
-                continue;
-            }
+            continue;
         }
-        match t.transport.transport_protocol {
-            TransportProtocol::UDP => {
-                let Some(sock) = sockets_by_addr.get(&t.transport.local_addr) else {
-                    eprintln!(
-                        "[display/webrtc] UDP transmit from unknown source {}, dropping",
-                        t.transport.local_addr
-                    );
-                    continue;
-                };
-                if let Err(e) = sock.send_to(&t.message, t.transport.peer_addr).await {
-                    eprintln!(
-                        "[display/webrtc] udp send {} -> {} failed: {e}",
-                        t.transport.local_addr, t.transport.peer_addr
-                    );
-                }
-            }
-            TransportProtocol::TCP => {
-                let Some(sender) = tcp_senders.get(&t.transport.peer_addr) else {
-                    continue;
-                };
-                let contents: Vec<u8> = t.message.to_vec();
-                // Enqueue onto the connection's ordered writer channel.
-                // `try_send` (never `send().await`) keeps the rtc poll loop
-                // non-blocking: a full queue means the writer task can't
-                // keep up with the encoder, so we drop *this* frame as
-                // backpressure rather than stalling the driver or
-                // overflowing the kernel send buffer. The writer task,
-                // not the scheduler, controls wire order.
-                match sender.try_send(contents) {
-                    Ok(()) => {}
-                    Err(mpsc::error::TrySendError::Full(_)) => {
-                        // Slow/saturated TCP path — drop and let RTP
-                        // recovery (PLI/FIR + keyframes) catch the peer up.
-                    }
-                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                        // Writer task exited (connection torn down). Forget
-                        // the dead sender so we stop trying to route to it.
-                        tcp_senders.remove(&t.transport.peer_addr);
-                    }
-                }
-            }
+        if t.transport.transport_protocol == TransportProtocol::TCP {
+            // TCP-stamped transmit with no live stream for the tuple: the
+            // connection is gone and there is nothing to write to.
+            continue;
+        }
+        // Routability filtering only applies to UDP: we need the kernel's
+        // `sendto` to succeed from our bound socket, and a
+        // loopback-source-to-routable-destination pair would be rejected
+        // with EINVAL.
+        if t.transport.local_addr.is_ipv4() != t.transport.peer_addr.is_ipv4() {
+            continue;
+        }
+        if t.transport.local_addr.ip().is_loopback() != t.transport.peer_addr.ip().is_loopback() {
+            continue;
+        }
+        let Some(sock) = sockets_by_addr.get(&t.transport.local_addr) else {
+            eprintln!(
+                "[display/webrtc] UDP transmit from unknown source {}, dropping",
+                t.transport.local_addr
+            );
+            continue;
+        };
+        if let Err(e) = sock.send_to(&t.message, t.transport.peer_addr).await {
+            eprintln!(
+                "[display/webrtc] udp send {} -> {} failed: {e}",
+                t.transport.local_addr, t.transport.peer_addr
+            );
         }
     }
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -507,8 +507,8 @@ INTENDANT_CONNECT_TOKEN=shared-dev-token \
   ./target/release/intendant --web 8876
 ```
 
-There are two committed validators. The hosted production-alpha validator starts
-`intendant-connect`, a daemon, and a browser virtual authenticator:
+There are three committed validators. The hosted production-alpha validator
+starts `intendant-connect`, a daemon, and a browser virtual authenticator:
 
 ```bash
 node scripts/validate-connect-hosted-mvp.cjs
@@ -528,6 +528,16 @@ Connect account, then proves the browser-public-origin -> rendezvous ->
 daemon-outbound-signaling -> direct WebRTC DataChannel path while keeping the
 normal dashboard mTLS default in place. The hosted MVP validator covers the real
 account/passkey flow, claim proof, local grant binding, revoke, and audit.
+
+The transport validator drives the fresh-box ceremony end to end — passkey
+signup, daemon-minted first-owner bootstrap phrase, hosted `/app` dashboard —
+and asserts the control DataChannel actually opens, including over the
+ICE-TCP path a NAT'd cloud daemon depends on (see
+[Self-Hosted Rendezvous → End-to-end transport validation](./self-hosted-rendezvous.md#end-to-end-transport-validation)):
+
+```bash
+node scripts/connect-transport-e2e.cjs
+```
 
 ### `[server]` (daemon and federation)
 

--- a/docs/src/self-hosted-rendezvous.md
+++ b/docs/src/self-hosted-rendezvous.md
@@ -155,6 +155,48 @@ block, `header_up -X-Forwarded-For` deletions are applied **after**
 idiom deletes the value it just set. Use the set alone — a set already
 replaces anything the client supplied.
 
+## End-to-end transport validation
+
+`scripts/connect-transport-e2e.cjs` asserts the outcome this whole
+chapter exists for — a browser that registered at the rendezvous,
+claimed a **fresh** daemon with its first-owner bootstrap phrase, and
+opened the hosted dashboard gets an **OPEN dashboard-control
+DataChannel** — entirely locally: no cloud resources, no real accounts.
+It spawns `intendant-connect` (`--open-registration`, `localhost`
+WebAuthn origin), a ~30-line `X-Forwarded-For`-injecting forward proxy
+standing in for the production reverse proxy, and a scratch-`HOME`
+daemon (keyless, `PROVIDER=mock`) whose empty IAM mints the bootstrap
+phrase; headless Chromium then mints the passkey account with a CDP
+virtual authenticator and walks the real `/connect` signup → phrase →
+bootstrap-arm page flow.
+
+Two hosted `/app` dashboard connections are asserted. The baseline pass
+requires channel open + verified daemon binding + an answered status RPC
+(a granted session, not a refusal — the claiming browser key was
+bootstrap-enrolled `role:root`). The TCP-forced pass then makes UDP
+unroutable from inside the page (answer-SDP candidate strip plus
+suppression of the browser's own UDP trickle, so no peer-reflexive UDP
+pair can sneak back) — the topology of a cloud box whose UDP is filtered
+— and requires the *selected* ICE pair to be `tcp` at
+`observed_ip:gateway_port`, the daemon to log `ICE-TCP enabled on …`,
+and a second `[dashboard/control] data channel open`. Each regression
+the first cloud deployment hit fails a distinct printed stage: a proxy
+dropping `X-Forwarded-For` fails the register-echo stage, a daemon not
+advertising ICE-TCP fails the candidate stage, and DTLS/SCTP transmits
+misrouted off the nominated TCP pair reproduce their 30-second DTLS
+stall in the final stage.
+
+```bash
+cargo build --bin intendant --bin intendant-runtime --bin intendant-connect
+node scripts/connect-transport-e2e.cjs      # target/debug; --release for release bins
+```
+
+Operator battery, not CI: it needs a Chromium (Playwright's browser or
+`CHROME_PATH`/`CHROME_BIN`; see `scripts/lib/browser-automation.cjs`)
+and one routable non-loopback IPv4 interface (auto-detected; `--lan-ip`
+overrides). Prints staged progress, exits 0/1, cleans up its scratch
+state (kept on failure for inspection).
+
 The service stores each org's latest root-signed revocation list, blind:
 `POST /api/orgs/revocations/publish` accepts a list whose embedded
 signature verifies and whose `seq` is not lower than the stored one;

--- a/docs/src/self-hosted-rendezvous.md
+++ b/docs/src/self-hosted-rendezvous.md
@@ -127,8 +127,29 @@ Connect offers advertise an **ICE-TCP candidate at
 reach, over the same port that already serves the dashboard. Browsers
 dial it directly; no STUN or TURN is required for the hosted
 dashboard-control path (the box's firewall must allow the gateway port
-inbound). Reachability metadata only: a lying proxy chain could at worst
-advertise an unreachable candidate.
+inbound). Display sessions opened through a hosted dashboard advertise
+the same tuple. Reachability metadata only: a lying proxy chain could at
+worst advertise an unreachable candidate.
+
+Because the service reads the caller's address from `X-Forwarded-For`
+(falling back to `X-Real-IP`), the reverse proxy in front of a
+self-hosted instance **must set one of those headers** — with a plain
+proxy_pass and no forwarding headers, `observed_ip` stays empty and
+hosted dashboards cannot reach any NAT'd daemon, a failure that only
+shows up later as an ICE timeout. Verify the full chain after deploying:
+
+```bash
+curl -s -X POST https://connect.example.com/api/daemon/register \
+  -H 'content-type: application/json' \
+  -d '{"protocol":"intendant-connect-rendezvous-v1","daemon_id":"probe","daemon_public_key":"probe"}' \
+  | grep observed_ip   # must echo YOUR public IP, not null
+```
+
+Caddy gotcha (this bit the default instance): within a `reverse_proxy`
+block, `header_up -X-Forwarded-For` deletions are applied **after**
+`header_up X-Forwarded-For {remote_host}` sets, so the strip-then-set
+idiom deletes the value it just set. Use the set alone — a set already
+replaces anything the client supplied.
 
 The service stores each org's latest root-signed revocation list, blind:
 `POST /api/orgs/revocations/publish` accepts a list whose embedded

--- a/docs/src/self-hosted-rendezvous.md
+++ b/docs/src/self-hosted-rendezvous.md
@@ -128,8 +128,12 @@ reach, over the same port that already serves the dashboard. Browsers
 dial it directly; no STUN or TURN is required for the hosted
 dashboard-control path (the box's firewall must allow the gateway port
 inbound). Display sessions opened through a hosted dashboard advertise
-the same tuple. Reachability metadata only: a lying proxy chain could at
-worst advertise an unreachable candidate.
+the same tuple. The echoed address family follows how the daemon reached
+the service — a daemon polling over IPv6 advertises a v6 candidate that
+v4-only visitors cannot dial, so pin the daemon's egress (or the service
+hostname it resolves) to v4 if your visitors are. Reachability metadata
+only: a lying proxy chain could at worst advertise an unreachable
+candidate.
 
 Because the service reads the caller's address from `X-Forwarded-For`
 (falling back to `X-Real-IP`), the reverse proxy in front of a

--- a/scripts/connect-transport-e2e.cjs
+++ b/scripts/connect-transport-e2e.cjs
@@ -1,0 +1,838 @@
+#!/usr/bin/env node
+'use strict';
+
+// Hosted-Connect transport E2E: asserts the OUTCOME the claim ceremony
+// exists for — a browser that signed up at the rendezvous, claimed a fresh
+// daemon with its twelve-word bootstrap phrase, and opened the hosted
+// dashboard actually gets an OPEN dashboard-control DataChannel to the
+// daemon. The fresh-VPS ceremony validation stopped at enrollment, and
+// three real transport bugs survived it undetected:
+//
+//   1. the reverse proxy dropped X-Forwarded-For, so the register echo's
+//      observed_ip was null and the daemon never learned its public address;
+//   2. the daemon then advertised no ICE-TCP candidate at all;
+//   3. the WebRTC engine stamped DTLS/SCTP transmits as UDP, the IO glue
+//      misrouted them off the nominated TCP pair, and DTLS timed out at 30s.
+//
+// This rig reproduces the topology locally with no cloud resources and no
+// real accounts:
+//
+//   browser (headless Chromium) ── http ──> intendant-connect (127.0.0.1)
+//   daemon ── http ──> XFF-injecting forward proxy ──> intendant-connect
+//   browser ── WebRTC (ICE-TCP + DTLS + SCTP) ──> daemon gateway port
+//
+// The proxy plays the production reverse proxy: it stamps every daemon->
+// service request with `X-Forwarded-For: <this machine's LAN IP>`, so the
+// register echo carries a non-loopback observed_ip and the daemon
+// advertises `<LAN-IP>:<gateway-port>` as its ICE-TCP candidate — locally
+// reachable, so the browser can really dial it. (A daemon polling the
+// service directly on 127.0.0.1 gets observed_ip=null and never advertises
+// the candidate: exactly the bug class under test, and untestable without
+// the proxy.)
+//
+// Stages (each printed, each asserted):
+//   1. service + proxy + fresh-HOME daemon come up; register echo carries
+//      observed_ip == LAN IP (bug class 1);
+//   2. headless Chromium creates a passkey account (CDP virtual
+//      authenticator), enters the daemon-minted phrase, and the first-owner
+//      bootstrap enrolls the browser key as role:root;
+//   3. hosted /app dashboard connects: control DataChannel OPEN, binding
+//      verified, status RPC answered (grant, not refusal);
+//   4. TCP-forced pass: a fresh /app load with every UDP candidate stripped
+//      from the daemon's answer (what a cloud box's filtered network does),
+//      so ICE must nominate the advertised ICE-TCP candidate and DTLS+SCTP
+//      must flow over it (bug classes 2 and 3). Asserts the selected ICE
+//      pair is protocol=tcp at <LAN-IP>:<gateway-port> and the daemon logs
+//      a second "data channel open".
+//
+// Prerequisites (this script builds nothing):
+//   cargo build --bin intendant --bin intendant-runtime --bin intendant-connect
+//   plus a Chromium (Playwright's, or CHROME_PATH/CHROME_BIN, or a system
+//   install — see scripts/lib/browser-automation.cjs).
+//
+// Not in CI: needs a Chromium and a routable (non-loopback) local IP. Part
+// of the operator battery next to validate-connect-rendezvous.cjs.
+
+const assert = require('assert');
+const fs = require('fs');
+const http = require('http');
+const net = require('net');
+const os = require('os');
+const path = require('path');
+const { spawn, spawnSync } = require('child_process');
+const { launchBrowser } = require('./lib/browser-automation.cjs');
+
+const DEFAULT_SERVICE_PORT = 9891;
+const DEFAULT_PROXY_PORT = 9892;
+const DEFAULT_DAEMON_PORT = 8891;
+const DEFAULT_DAEMON_ID = 'connect-transport-e2e';
+const START_TIMEOUT_MS = 60000;
+const CLAIM_TIMEOUT_MS = 75000;
+const TRANSPORT_TIMEOUT_MS = 45000;
+
+function usage() {
+  console.log(`Usage:
+  node scripts/connect-transport-e2e.cjs [options]
+
+Options:
+  --connect-binary <path>   intendant-connect binary. Default target/debug/intendant-connect.
+  --daemon-binary <path>    intendant daemon binary. Default target/debug/intendant.
+  --release                 Use target/release binaries instead of target/debug.
+  --service-port <port>     intendant-connect listen port. Default ${DEFAULT_SERVICE_PORT}.
+  --proxy-port <port>       XFF forward-proxy port (daemon's rendezvous). Default ${DEFAULT_PROXY_PORT}.
+  --daemon-port <port>      Daemon web/gateway port (also the ICE-TCP port). Default ${DEFAULT_DAEMON_PORT}.
+  --daemon-id <id>          Connect daemon id. Default ${DEFAULT_DAEMON_ID}.
+  --lan-ip <ip>             Address to inject as X-Forwarded-For (must be a
+                            reachable local interface address). Default: auto-detect.
+  --keep                    Keep the scratch dir on success too.
+  --help                    This message.
+
+Binaries are NOT built by this script:
+  cargo build --bin intendant --bin intendant-runtime --bin intendant-connect
+`);
+}
+
+function parseArgs(argv) {
+  const repoRoot = path.resolve(__dirname, '..');
+  const out = {
+    repoRoot,
+    profile: 'debug',
+    connectBinary: null,
+    daemonBinary: null,
+    servicePort: DEFAULT_SERVICE_PORT,
+    proxyPort: DEFAULT_PROXY_PORT,
+    daemonPort: DEFAULT_DAEMON_PORT,
+    daemonId: DEFAULT_DAEMON_ID,
+    lanIp: null,
+    keep: false,
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--connect-binary') out.connectBinary = path.resolve(argv[++i]);
+    else if (arg === '--daemon-binary') out.daemonBinary = path.resolve(argv[++i]);
+    else if (arg === '--release') out.profile = 'release';
+    else if (arg === '--service-port') out.servicePort = Number(argv[++i]);
+    else if (arg === '--proxy-port') out.proxyPort = Number(argv[++i]);
+    else if (arg === '--daemon-port') out.daemonPort = Number(argv[++i]);
+    else if (arg === '--daemon-id') out.daemonId = String(argv[++i] || '').trim();
+    else if (arg === '--lan-ip') out.lanIp = String(argv[++i] || '').trim();
+    else if (arg === '--keep') out.keep = true;
+    else if (arg === '--help' || arg === '-h') {
+      usage();
+      process.exit(0);
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  if (!out.connectBinary) {
+    out.connectBinary = path.join(repoRoot, 'target', out.profile, 'intendant-connect');
+  }
+  if (!out.daemonBinary) {
+    out.daemonBinary = path.join(repoRoot, 'target', out.profile, 'intendant');
+  }
+  for (const port of [out.servicePort, out.proxyPort, out.daemonPort]) {
+    assert(Number.isInteger(port) && port > 0 && port < 65536, `invalid port ${port}`);
+  }
+  assert(out.daemonId, 'daemon id is required');
+  return out;
+}
+
+function stage(name, detail) {
+  console.log(`[stage] ${name}${detail ? `: ${detail}` : ''}`);
+}
+
+/// First non-internal, non-link-local IPv4 on this machine — the address
+/// the proxy injects as X-Forwarded-For, and therefore the address the
+/// daemon advertises as its ICE-TCP candidate. Must be locally dialable.
+function detectLanIp() {
+  const candidates = [];
+  for (const [name, addrs] of Object.entries(os.networkInterfaces())) {
+    for (const addr of addrs || []) {
+      if (addr.internal) continue;
+      if (addr.family !== 'IPv4' && addr.family !== 4) continue;
+      if (addr.address.startsWith('169.254.')) continue;
+      candidates.push({ name, address: addr.address });
+    }
+  }
+  // Prefer conventional primary interfaces over tunnels/bridges.
+  const score = ({ name }) => {
+    if (/^(en0|eth0|wlan0)$/.test(name)) return 0;
+    if (/^(en|eth|wlan|wl)/.test(name)) return 1;
+    if (/^(utun|tun|tap|bridge|vnic|docker|veth|awdl|llw)/.test(name)) return 3;
+    return 2;
+  };
+  candidates.sort((a, b) => score(a) - score(b));
+  return candidates.length ? candidates[0].address : null;
+}
+
+async function waitFor(fn, timeoutMs, label) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+  while (Date.now() < deadline) {
+    try {
+      const value = await fn();
+      if (value) return value;
+    } catch (err) {
+      if (err && err.fatal) throw err;
+      lastError = err;
+    }
+    await new Promise(resolve => setTimeout(resolve, 200));
+  }
+  throw new Error(`timed out waiting for ${label}${lastError ? `: ${lastError.message}` : ''}`);
+}
+
+async function fetchJson(url, options = {}) {
+  const resp = await fetch(url, options);
+  const body = await resp.json().catch(() => ({}));
+  if (!resp.ok || body.ok === false) {
+    throw new Error(`${url} returned ${resp.status}: ${body.error || JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+async function httpStatus(url) {
+  const resp = await fetch(url).catch(() => null);
+  return resp ? resp.status : 0;
+}
+
+function portIsFree(port) {
+  return new Promise(resolve => {
+    const probe = net
+      .createServer()
+      .once('error', () => resolve(false))
+      .once('listening', () => probe.close(() => resolve(true)));
+    probe.listen(port, '0.0.0.0');
+  });
+}
+
+function tcpDialOk(host, port, timeoutMs = 3000) {
+  return new Promise(resolve => {
+    const sock = net.connect({ host, port });
+    const done = ok => {
+      sock.destroy();
+      resolve(ok);
+    };
+    sock.setTimeout(timeoutMs, () => done(false));
+    sock.once('connect', () => done(true));
+    sock.once('error', () => done(false));
+  });
+}
+
+/// The ~30-line reverse-proxy stand-in: forward every request to the
+/// service, stamping X-Forwarded-For with the LAN IP, and capture the
+/// /api/daemon/register response body so the driver can assert the
+/// observed_ip echo (bug class 1) without touching product code.
+function startXffProxy(servicePort, lanIp, registerEchoes) {
+  const server = http.createServer((req, res) => {
+    const headers = { ...req.headers };
+    delete headers['accept-encoding']; // keep register responses parseable
+    headers.host = `127.0.0.1:${servicePort}`;
+    headers['x-forwarded-for'] = lanIp;
+    const upstream = http.request(
+      { host: '127.0.0.1', port: servicePort, path: req.url, method: req.method, headers },
+      upstreamRes => {
+        const captured = [];
+        const capture = String(req.url || '').startsWith('/api/daemon/register');
+        res.writeHead(upstreamRes.statusCode || 502, upstreamRes.headers);
+        upstreamRes.on('data', chunk => {
+          if (capture) captured.push(chunk);
+          res.write(chunk);
+        });
+        upstreamRes.on('end', () => {
+          res.end();
+          if (capture) {
+            try {
+              registerEchoes.push(JSON.parse(Buffer.concat(captured).toString('utf8')));
+            } catch (_) {
+              registerEchoes.push({ unparseable: true });
+            }
+          }
+        });
+      }
+    );
+    upstream.on('error', err => {
+      res.writeHead(502, { 'content-type': 'text/plain' });
+      res.end(`xff proxy upstream error: ${err.message}`);
+    });
+    req.pipe(upstream);
+  });
+  // The daemon long-polls /api/daemon/next; do not reap those sockets.
+  server.requestTimeout = 0;
+  server.headersTimeout = 60000;
+  return server;
+}
+
+function prepareDaemonAccessCerts(binary, homeDir, repoRoot, label) {
+  const result = spawnSync(
+    binary,
+    ['access', 'setup', '--no-serve-certs', '--force', '--name', label, '--ip', '127.0.0.1', '--host', 'localhost'],
+    {
+      cwd: repoRoot,
+      env: { ...process.env, HOME: homeDir, USERPROFILE: homeDir },
+      encoding: 'utf8',
+    }
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`access setup failed: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+  }
+}
+
+async function addVirtualAuthenticator(browser, page) {
+  const options = {
+    protocol: 'ctap2',
+    transport: 'internal',
+    hasResidentKey: true,
+    hasUserVerification: true,
+    isUserVerified: true,
+    automaticPresenceSimulation: true,
+  };
+  if (browser.kind === 'playwright' && page.context) {
+    const client = await page.context().newCDPSession(page);
+    await client.send('WebAuthn.enable');
+    await client.send('WebAuthn.addVirtualAuthenticator', { options });
+    return;
+  }
+  if (page.connection && page.sessionId) {
+    await page.connection.send('WebAuthn.enable', {}, page.sessionId);
+    await page.connection.send('WebAuthn.addVirtualAuthenticator', { options }, page.sessionId);
+    return;
+  }
+  throw new Error('browser driver does not expose CDP WebAuthn controls');
+}
+
+/// Fault injection for the TCP-forced pass, installed before the page
+/// loads: make UDP unroutable between browser and daemon, the exact
+/// topology of a cloud daemon whose UDP is filtered, so ICE can only
+/// nominate the daemon's advertised ICE-TCP candidate. Three legs, all
+/// needed:
+///   - strip UDP candidates from the daemon's answer SDP (and any remote
+///     trickle) so the browser never dials daemon UDP;
+///   - swallow the browser's own UDP trickle candidates before the page
+///     signals them, or the daemon would send UDP checks back and the
+///     browser would mint a working peer-reflexive UDP pair (observed:
+///     same-host prflx quietly un-forced an earlier version of this rig);
+///   - register every RTCPeerConnection so the driver can read getStats()
+///     and assert which pair actually got nominated.
+const TCP_ONLY_INIT_SCRIPT = `(() => {
+  if (window.__rigTcpOnlyInstalled) return;
+  window.__rigTcpOnlyInstalled = true;
+  window.__rigStrippedUdpLines = 0;
+  window.__rigDroppedRemoteUdpTrickle = 0;
+  window.__rigDroppedLocalUdpTrickle = 0;
+  window.__rigPCs = [];
+  const udpCandidateLine = line => /^(a=)?candidate:\\S+ \\d+ udp /i.test(String(line).trim());
+  const stripSdp = sdp => String(sdp)
+    .split(/\\r\\n|\\n/)
+    .filter(line => {
+      if (udpCandidateLine(line)) {
+        window.__rigStrippedUdpLines += 1;
+        return false;
+      }
+      return true;
+    })
+    .join('\\r\\n');
+  const NativePC = window.RTCPeerConnection;
+  const origSetRemote = NativePC.prototype.setRemoteDescription;
+  NativePC.prototype.setRemoteDescription = function (desc, ...rest) {
+    let next = desc;
+    try {
+      if (desc && typeof desc.sdp === 'string') next = { type: desc.type, sdp: stripSdp(desc.sdp) };
+    } catch (_) {
+      next = desc;
+    }
+    return origSetRemote.call(this, next, ...rest);
+  };
+  const origAddIce = NativePC.prototype.addIceCandidate;
+  NativePC.prototype.addIceCandidate = function (candidate, ...rest) {
+    try {
+      const line = candidate && typeof candidate.candidate === 'string' ? candidate.candidate : '';
+      if (udpCandidateLine(line)) {
+        window.__rigDroppedRemoteUdpTrickle += 1;
+        return Promise.resolve();
+      }
+    } catch (_) {}
+    return origAddIce.call(this, candidate, ...rest);
+  };
+  const accessor = Object.getOwnPropertyDescriptor(NativePC.prototype, 'onicecandidate');
+  if (accessor && accessor.set) {
+    Object.defineProperty(NativePC.prototype, 'onicecandidate', {
+      configurable: true,
+      enumerable: accessor.enumerable,
+      get() {
+        return accessor.get.call(this);
+      },
+      set(handler) {
+        const wrapped = typeof handler === 'function'
+          ? function (ev) {
+              const line = ev && ev.candidate && typeof ev.candidate.candidate === 'string'
+                ? ev.candidate.candidate
+                : '';
+              if (line && udpCandidateLine(line)) {
+                window.__rigDroppedLocalUdpTrickle += 1;
+                return undefined;
+              }
+              return handler.call(this, ev);
+            }
+          : handler;
+        return accessor.set.call(this, wrapped);
+      },
+    });
+  }
+  window.RTCPeerConnection = new Proxy(NativePC, {
+    construct(target, args) {
+      const pc = new target(...args);
+      window.__rigPCs.push(pc);
+      return pc;
+    },
+  });
+})();`;
+
+async function addInitScript(browser, page, source) {
+  if (browser.kind === 'playwright' && typeof page.addInitScript === 'function') {
+    await page.addInitScript(source);
+    return;
+  }
+  if (page.connection && page.sessionId) {
+    await page.connection.send('Page.addScriptToEvaluateOnNewDocument', { source }, page.sessionId);
+    return;
+  }
+  throw new Error('browser driver does not expose init-script injection');
+}
+
+async function click(page, selector) {
+  if (typeof page.locator === 'function') {
+    await page.locator(selector).click();
+    return;
+  }
+  const point = await page.evaluate(`(() => {
+    const el = document.querySelector(${JSON.stringify(selector)});
+    if (!el) throw new Error('missing selector ${selector}');
+    el.scrollIntoView({ block: 'center' });
+    const r = el.getBoundingClientRect();
+    return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+  })()`);
+  for (const type of ['mousePressed', 'mouseReleased']) {
+    await page.connection.send(
+      'Input.dispatchMouseEvent',
+      { type, x: point.x, y: point.y, button: 'left', clickCount: 1 },
+      page.sessionId
+    );
+  }
+}
+
+async function goto(page, url, opts = {}) {
+  const response = await page.goto(url, opts);
+  if (response && response.status && response.status() >= 400) {
+    throw new Error(`${url} returned ${response.status()}`);
+  }
+  return response;
+}
+
+/// Wait for the hosted dashboard control transport to be fully live:
+/// channel OPEN, daemon binding verified, hosted signaling, and a status
+/// RPC answered over the channel (grantKind is only ever set from the
+/// daemon's status response — a refused session never reaches it).
+async function waitForHostedTransport(page, label) {
+  let last = null;
+  try {
+    return await waitFor(async () => {
+      last = await page.evaluate(() => window.intendantDashboardControl?.status?.() || null);
+      if (
+        last &&
+        last.connected === true &&
+        last.channelState === 'open' &&
+        last.signalingMode === 'connect-rendezvous' &&
+        last.verifiedBinding &&
+        last.verifiedBinding.ok === true &&
+        last.grantKind
+      ) {
+        return last;
+      }
+      return null;
+    }, TRANSPORT_TIMEOUT_MS, label);
+  } catch (err) {
+    throw new Error(`${err.message}; last dashboard status: ${JSON.stringify(last)}`);
+  }
+}
+
+async function selectedIcePair(page) {
+  return page.evaluate(async () => {
+    const out = {
+      found: false,
+      pcCount: (window.__rigPCs || []).length,
+      strippedUdpLines: window.__rigStrippedUdpLines || 0,
+      droppedRemoteUdpTrickle: window.__rigDroppedRemoteUdpTrickle || 0,
+      droppedLocalUdpTrickle: window.__rigDroppedLocalUdpTrickle || 0,
+    };
+    for (const pc of window.__rigPCs || []) {
+      if (pc.connectionState !== 'connected') continue;
+      const stats = await pc.getStats();
+      let pair = null;
+      stats.forEach(report => {
+        if (report.type === 'transport' && report.selectedCandidatePairId) {
+          pair = stats.get(report.selectedCandidatePairId) || pair;
+        }
+      });
+      if (!pair) {
+        stats.forEach(report => {
+          if (
+            report.type === 'candidate-pair' &&
+            (report.selected || report.nominated) &&
+            (!report.state || report.state === 'succeeded')
+          ) {
+            pair = report;
+          }
+        });
+      }
+      if (!pair) continue;
+      const local = stats.get(pair.localCandidateId) || {};
+      const remote = stats.get(pair.remoteCandidateId) || {};
+      const view = c => ({
+        protocol: c.protocol || '',
+        address: c.address || c.ip || '',
+        port: c.port ?? null,
+        candidateType: c.candidateType || '',
+        tcpType: c.tcpType || '',
+      });
+      return { ...out, found: true, local: view(local), remote: view(remote) };
+    }
+    return out;
+  });
+}
+
+async function main() {
+  const options = parseArgs(process.argv);
+  for (const binary of [options.connectBinary, options.daemonBinary]) {
+    if (!fs.existsSync(binary)) {
+      throw new Error(
+        `missing binary ${binary}; run: cargo build --bin intendant --bin intendant-runtime --bin intendant-connect`
+      );
+    }
+  }
+  const lanIp = options.lanIp || detectLanIp();
+  if (!lanIp) {
+    throw new Error(
+      'no routable non-loopback IPv4 interface found (offline box?); pass --lan-ip <address> of a reachable local interface'
+    );
+  }
+  for (const [label, port] of [
+    ['service', options.servicePort],
+    ['proxy', options.proxyPort],
+    ['daemon', options.daemonPort],
+  ]) {
+    if (!(await portIsFree(port))) {
+      throw new Error(`${label} port ${port} is already in use; pass --${label}-port`);
+    }
+  }
+  stage('preflight', `lan_ip=${lanIp} service=${options.servicePort} proxy=${options.proxyPort} daemon=${options.daemonPort}`);
+
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'intendant-connect-transport-e2e-'));
+  const serviceOrigin = `http://localhost:${options.servicePort}`;
+  const serviceApi = `http://127.0.0.1:${options.servicePort}`;
+  const serviceLogs = [];
+  const daemonLogs = [];
+  const registerEchoes = [];
+  const children = [];
+  let proxy = null;
+  let browser = null;
+  let failed = false;
+
+  const daemonLog = () => daemonLogs.join('');
+  const countMatches = (text, needle) => text.split(needle).length - 1;
+
+  function spawnLogged(command, args, spawnOptions, logs) {
+    const child = spawn(command, args, spawnOptions);
+    children.push(child);
+    child.stdout?.on('data', chunk => logs.push(String(chunk)));
+    child.stderr?.on('data', chunk => logs.push(String(chunk)));
+    child.once('error', err => logs.push(String((err && err.message) || err)));
+    return child;
+  }
+
+  try {
+    // ── Rendezvous service ──────────────────────────────────────────────
+    spawnLogged(
+      options.connectBinary,
+      [
+        '--listen', `127.0.0.1:${options.servicePort}`,
+        '--origin', serviceOrigin,
+        '--rp-id', 'localhost',
+        '--static-root', path.join(options.repoRoot, 'static'),
+        '--data-file', path.join(tmp, 'connect-state.json'),
+        '--open-registration',
+      ],
+      { cwd: options.repoRoot, stdio: ['ignore', 'pipe', 'pipe'] },
+      serviceLogs
+    );
+    await waitFor(async () => (await httpStatus(`${serviceApi}/healthz`)) === 200, START_TIMEOUT_MS, 'intendant-connect health');
+    stage('service up', serviceOrigin);
+
+    // ── XFF forward proxy (the daemon's rendezvous URL) ────────────────
+    proxy = startXffProxy(options.servicePort, lanIp, registerEchoes);
+    await new Promise((resolve, reject) => {
+      proxy.once('error', reject);
+      proxy.listen(options.proxyPort, '127.0.0.1', resolve);
+    });
+    stage('xff proxy up', `127.0.0.1:${options.proxyPort} injecting X-Forwarded-For: ${lanIp}`);
+
+    // ── Fresh daemon: scratch HOME, empty IAM, Connect via the proxy ───
+    const daemonHome = path.join(tmp, 'daemon-home');
+    const daemonProject = path.join(tmp, 'daemon-project');
+    fs.mkdirSync(daemonHome, { recursive: true });
+    fs.mkdirSync(daemonProject, { recursive: true });
+    // Minimal project marker so the daemon roots itself in the scratch dir.
+    fs.writeFileSync(path.join(daemonProject, 'intendant.toml'), '');
+    // Keyless: the scripted mock provider, with a trivial script (no
+    // session ever starts here; the daemon just needs a valid provider).
+    const mockScript = path.join(tmp, 'mock-script.json');
+    fs.writeFileSync(
+      mockScript,
+      JSON.stringify({ model: 'mock-1', profiles: [{ match: '', steps: [] }] })
+    );
+    prepareDaemonAccessCerts(options.daemonBinary, daemonHome, options.repoRoot, options.daemonId);
+
+    const daemonEnv = { ...process.env };
+    for (const name of [
+      'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'GEMINI_API_KEY', 'MODEL_NAME',
+      'PRESENCE_PROVIDER', 'PRESENCE_MODEL', 'CU_PROVIDER', 'CU_MODEL',
+      'INTENDANT_HOME', 'INTENDANT_MCP_URL', 'INTENDANT_PORT', 'INTENDANT_SESSION_ID',
+      'INTENDANT_MANAGED_CONTEXT', 'INTENDANT_APP_HTML_PATH',
+      'HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy', 'ALL_PROXY', 'all_proxy', 'NO_PROXY', 'no_proxy',
+    ]) {
+      delete daemonEnv[name];
+    }
+    Object.assign(daemonEnv, {
+      HOME: daemonHome,
+      USERPROFILE: daemonHome,
+      PROVIDER: 'mock',
+      INTENDANT_MOCK_SCRIPT: mockScript,
+      INTENDANT_CONNECT_RENDEZVOUS_URL: `http://127.0.0.1:${options.proxyPort}`,
+      INTENDANT_CONNECT_DAEMON_ID: options.daemonId,
+      DISPLAY: ':99',
+    });
+    // Default bind (0.0.0.0) on purpose: the ICE-TCP candidate advertises
+    // <LAN-IP>:<gateway-port>, which a loopback-only bind could not serve.
+    spawnLogged(
+      options.daemonBinary,
+      ['--web', String(options.daemonPort), '--no-tui'],
+      { cwd: daemonProject, env: daemonEnv, stdio: ['ignore', 'pipe', 'pipe'] },
+      daemonLogs
+    );
+
+    await waitFor(
+      () => daemonLog().includes(`[web_gateway] ICE-TCP candidates advertise port ${options.daemonPort}`),
+      START_TIMEOUT_MS,
+      'daemon gateway startup (ICE-TCP advertise line)'
+    );
+    stage('daemon gateway up', `port ${options.daemonPort}`);
+
+    const registered = await waitFor(async () => {
+      const status = await fetchJson(`${serviceApi}/api/status?daemon_id=${encodeURIComponent(options.daemonId)}`);
+      return status.registered && status.daemon_public_key ? status : null;
+    }, START_TIMEOUT_MS, 'daemon registration at the rendezvous');
+    assert.strictEqual(registered.claimed, false, 'fresh daemon must start unclaimed');
+
+    // Bug class 1: the register echo must carry the proxy-observed IP.
+    const echo = await waitFor(
+      () => registerEchoes.find(body => body && typeof body.observed_ip === 'string' && body.observed_ip) || null,
+      START_TIMEOUT_MS,
+      'register response echoing observed_ip'
+    );
+    assert.strictEqual(
+      echo.observed_ip,
+      lanIp,
+      `register echoed observed_ip=${JSON.stringify(echo.observed_ip)}, expected the injected X-Forwarded-For ${lanIp}`
+    );
+    assert.strictEqual(echo.claim_code_daemon_minted, true, `fresh daemon did not mint its own claim phrase: ${JSON.stringify(echo)}`);
+    stage('register echo ok', `observed_ip=${echo.observed_ip} (from X-Forwarded-For), daemon-minted claim phrase`);
+
+    const claimPhrase = await waitFor(() => {
+      const match = daemonLog().match(/first-owner bootstrap: claim this daemon at [^\s]*claim_code=([^\s"'<>]+)/);
+      return match ? decodeURIComponent(match[1]) : null;
+    }, START_TIMEOUT_MS, 'daemon-minted bootstrap claim phrase in the daemon log');
+    stage('bootstrap phrase minted', `${claimPhrase.split('-').length} words`);
+
+    // Sanity: the ICE-TCP candidate the daemon will advertise must be
+    // dialable from this machine, or a failure below would be ambiguous.
+    assert(
+      await tcpDialOk(lanIp, options.daemonPort),
+      `cannot dial ${lanIp}:${options.daemonPort} (local firewall?) — the advertised ICE-TCP candidate would be unreachable`
+    );
+    stage('gateway reachable at advertised address', `${lanIp}:${options.daemonPort}`);
+
+    // ── Browser: account, claim, first-owner bootstrap ──────────────────
+    browser = await launchBrowser({ headless: true, ignoreHTTPSErrors: true });
+    const page = await browser.newPage();
+    page.on('console', msg => {
+      const text = msg.text();
+      if (/error|warn|\[dashboard-control\]/i.test(text)) console.log(`[browser:${msg.type()}] ${text}`);
+    });
+    await addVirtualAuthenticator(browser, page);
+    await goto(page, `${serviceOrigin}/connect`, { timeout: START_TIMEOUT_MS });
+
+    const accountName = `transport-e2e-${Date.now().toString(36)}`;
+    await page.evaluate(`document.getElementById('account').value = ${JSON.stringify(accountName)}`);
+    await click(page, '#register');
+    await waitFor(
+      () => page.evaluate("!document.getElementById('manage').classList.contains('hidden')"),
+      START_TIMEOUT_MS,
+      'account registration (signed-in manage view)'
+    );
+    stage('account created', `@${accountName} (passkey via CDP virtual authenticator)`);
+
+    await page.evaluate(`document.getElementById('claim-code').value = ${JSON.stringify(claimPhrase)}`);
+    await click(page, '#claim');
+    await waitFor(async () => {
+      const text = await page.evaluate("document.getElementById('claim-status').textContent || ''");
+      if (/rejected|timed out|error/i.test(text)) {
+        const err = new Error(`claim failed on the page: ${text}`);
+        err.fatal = true;
+        throw err;
+      }
+      return text.includes('Claimed') && text.includes('first owner') ? text : null;
+    }, CLAIM_TIMEOUT_MS, 'first-owner bootstrap claim on the /connect page');
+    stage('claim ok', 'page reports first-owner bootstrap claim');
+
+    await waitFor(
+      () => daemonLog().includes('first-owner bootstrap: enrolled client key'),
+      START_TIMEOUT_MS,
+      'daemon-side bootstrap enrollment log'
+    );
+    await waitFor(
+      () => daemonLog().includes('claim acknowledged — this daemon co-signed'),
+      START_TIMEOUT_MS,
+      'daemon-side co-signed claim log'
+    );
+    const enrolled = daemonLog().match(/first-owner bootstrap: enrolled client key (\S+) as role:root[^\n]*/);
+    stage('bootstrap enrolled', enrolled ? enrolled[0].replace(/^.*enrolled/, 'enrolled') : 'role:root');
+
+    const daemons = await page.evaluate(() => fetch('/api/daemons').then(r => r.json()));
+    assert.strictEqual(daemons.daemons?.length, 1, `expected one claimed daemon: ${JSON.stringify(daemons)}`);
+    assert.strictEqual(daemons.daemons[0].daemon_id, options.daemonId);
+
+    // ── Pass A: hosted dashboard, unmodified network ────────────────────
+    const appUrl = `${serviceOrigin}/app?connect=1&daemon_id=${encodeURIComponent(options.daemonId)}`;
+    await goto(page, appUrl, { timeout: START_TIMEOUT_MS });
+    const baseline = await waitForHostedTransport(page, 'hosted dashboard control transport (baseline)');
+    assert.strictEqual(baseline.claimedDaemonPublicKey, registered.daemon_public_key, 'baseline binding key mismatch');
+    assert(baseline.sessionGrantSha256, 'baseline session did not bind a Connect session grant');
+    await waitFor(
+      () => countMatches(daemonLog(), '[dashboard/control] data channel open:') >= 1,
+      START_TIMEOUT_MS,
+      'daemon "data channel open" log (baseline)'
+    );
+    stage(
+      'transport ready (baseline)',
+      `channel open, binding verified, grant=${baseline.grantKind}, ice=${baseline.iceCandidatePair || baseline.iceRoute || 'n/a'}`
+    );
+
+    // ── Pass B: TCP-forced — the cloud-daemon topology ──────────────────
+    const page2 = await browser.newPage();
+    page2.on('console', msg => {
+      const text = msg.text();
+      if (/error|warn|\[dashboard-control\]/i.test(text)) console.log(`[browser2:${msg.type()}] ${text}`);
+    });
+    await addInitScript(browser, page2, TCP_ONLY_INIT_SCRIPT);
+    await goto(page2, appUrl, { timeout: START_TIMEOUT_MS });
+    const forced = await waitForHostedTransport(page2, 'hosted dashboard control transport (TCP-forced)');
+    assert.strictEqual(forced.claimedDaemonPublicKey, registered.daemon_public_key, 'TCP-forced binding key mismatch');
+
+    // Bug class 2: the daemon must have advertised the observed address as
+    // an ICE-TCP candidate on the gateway port.
+    const iceTcpEnabled = `[dashboard/control] ICE-TCP enabled on ${lanIp}:${options.daemonPort}`;
+    assert(
+      daemonLog().includes(iceTcpEnabled),
+      `daemon log never announced "${iceTcpEnabled}" — no ICE-TCP candidate was advertised`
+    );
+
+    const pair = await selectedIcePair(page2);
+    assert(pair.strippedUdpLines > 0, `TCP-forcing never engaged (no UDP candidates stripped): ${JSON.stringify(pair)}`);
+    assert(
+      pair.droppedLocalUdpTrickle > 0,
+      `TCP-forcing did not suppress the browser's UDP trickle (prflx would un-force the pair): ${JSON.stringify(pair)}`
+    );
+    assert(pair.found, `no selected ICE candidate pair on the TCP-forced connection: ${JSON.stringify(pair)}`);
+    // Bug class 3: DTLS+SCTP actually flowed over the nominated TCP pair.
+    assert.strictEqual(
+      pair.remote.protocol,
+      'tcp',
+      `TCP-forced session selected a non-TCP pair: ${JSON.stringify(pair)}`
+    );
+    if (pair.remote.port !== null) {
+      assert.strictEqual(Number(pair.remote.port), options.daemonPort, `remote ICE-TCP port mismatch: ${JSON.stringify(pair)}`);
+    }
+    if (pair.remote.address) {
+      assert.strictEqual(pair.remote.address, lanIp, `remote ICE-TCP address mismatch: ${JSON.stringify(pair)}`);
+    }
+    await waitFor(
+      () => countMatches(daemonLog(), '[dashboard/control] data channel open:') >= 2,
+      START_TIMEOUT_MS,
+      'daemon "data channel open" log (TCP-forced)'
+    );
+    stage(
+      'channel open over ICE-TCP',
+      `selected pair ${pair.local.protocol}/${pair.local.candidateType} -> ${pair.remote.protocol}/${pair.remote.candidateType} @ ${pair.remote.address || '<hidden>'}:${pair.remote.port ?? '?'}, grant=${forced.grantKind}`
+    );
+
+    console.log(JSON.stringify({
+      ok: true,
+      lan_ip: lanIp,
+      daemon_id: options.daemonId,
+      daemon_public_key: registered.daemon_public_key,
+      observed_ip_echo: echo.observed_ip,
+      account: accountName,
+      baseline: {
+        session_id: baseline.sessionId,
+        grant_kind: baseline.grantKind,
+        ice_candidate_pair: baseline.iceCandidatePair || null,
+      },
+      tcp_forced: {
+        session_id: forced.sessionId,
+        grant_kind: forced.grantKind,
+        stripped_udp_candidate_lines: pair.strippedUdpLines,
+        dropped_local_udp_trickle: pair.droppedLocalUdpTrickle,
+        selected_pair: pair,
+      },
+      data_channel_open_logs: countMatches(daemonLog(), '[dashboard/control] data channel open:'),
+    }, null, 2));
+  } catch (err) {
+    failed = true;
+    console.error(`\nFAILED: ${(err && err.stack) || err}`);
+    const tailOf = logs => logs.join('').split(/\r?\n/).filter(Boolean).slice(-40).join('\n');
+    console.error(`\n--- intendant-connect log tail ---\n${tailOf(serviceLogs)}`);
+    console.error(`\n--- daemon log tail ---\n${tailOf(daemonLogs)}`);
+    console.error(`\nscratch dir kept for inspection: ${tmp}`);
+    process.exitCode = 1;
+  } finally {
+    // A page mid-WebRTC-reconnect can wedge a graceful browser close;
+    // bound it and fall through to child cleanup regardless.
+    if (browser) {
+      await Promise.race([
+        browser.close().catch(() => {}),
+        new Promise(resolve => setTimeout(resolve, 8000)),
+      ]);
+    }
+    if (proxy) await new Promise(resolve => proxy.close(resolve)).catch(() => {});
+    for (const child of children.reverse()) {
+      if (child.exitCode === null && !child.killed) child.kill('SIGTERM');
+    }
+    await new Promise(resolve => setTimeout(resolve, 500));
+    for (const child of children) {
+      if (child.exitCode === null && !child.killed) child.kill('SIGKILL');
+    }
+    if (!failed && !options.keep) {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    } else if (!failed) {
+      console.log(`scratch dir kept: ${tmp}`);
+    }
+  }
+}
+
+main().then(() => {
+  if (!process.exitCode) process.exit(0);
+  process.exit(process.exitCode);
+}).catch(err => {
+  console.error((err && err.stack) || err);
+  process.exit(1);
+});

--- a/scripts/connect-transport-e2e.cjs
+++ b/scripts/connect-transport-e2e.cjs
@@ -813,13 +813,18 @@ async function main() {
         new Promise(resolve => setTimeout(resolve, 8000)),
       ]);
     }
-    if (proxy) await new Promise(resolve => proxy.close(resolve)).catch(() => {});
+    // Children first: the daemon holds a long-poll open through the proxy,
+    // so a graceful proxy close would wait on it forever.
     for (const child of children.reverse()) {
       if (child.exitCode === null && !child.killed) child.kill('SIGTERM');
     }
     await new Promise(resolve => setTimeout(resolve, 500));
     for (const child of children) {
       if (child.exitCode === null && !child.killed) child.kill('SIGKILL');
+    }
+    if (proxy) {
+      proxy.close(() => {});
+      if (typeof proxy.closeAllConnections === 'function') proxy.closeAllConnections();
     }
     if (!failed && !options.keep) {
       fs.rmSync(tmp, { recursive: true, force: true });

--- a/scripts/validate-connect-hosted-mvp.cjs
+++ b/scripts/validate-connect-hosted-mvp.cjs
@@ -370,7 +370,7 @@ async function main() {
     }, daemonLogs);
 
     await waitFor(
-      () => daemonLogs.join('').includes(`Web TUI: https://0.0.0.0:${options.daemonPort}`),
+      () => daemonLogs.join('').includes(`Dashboard: https://0.0.0.0:${options.daemonPort}`),
       START_TIMEOUT_MS,
       'daemon web startup'
     );

--- a/scripts/validate-connect-rendezvous.cjs
+++ b/scripts/validate-connect-rendezvous.cjs
@@ -1443,7 +1443,7 @@ async function main() {
 
   let browser;
   try {
-    await waitFor(() => daemonLogs.join('').includes(`Web TUI: https://0.0.0.0:${options.daemonPort}`), START_TIMEOUT_MS, 'daemon web startup');
+    await waitFor(() => daemonLogs.join('').includes(`Dashboard: https://0.0.0.0:${options.daemonPort}`), START_TIMEOUT_MS, 'daemon web startup');
     const daemonNoAuthStatus = await httpStatus(`http://127.0.0.1:${options.rendezvousPort}/api/daemon/next?daemon_id=${encodeURIComponent(options.daemonId)}&timeout_ms=1`);
     assert.strictEqual(daemonNoAuthStatus, 401, `/api/daemon/next without bearer returned ${daemonNoAuthStatus}`);
     const registeredStatus = await waitFor(async () => {

--- a/src/bin/caller/dashboard_control.rs
+++ b/src/bin/caller/dashboard_control.rs
@@ -1686,44 +1686,47 @@ async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
     terminal_forwarders: &mut HashMap<(String, String), tokio::task::JoinHandle<()>>,
 ) -> Result<Instant, ()> {
     while let Some(t) = rtc.poll_write() {
-        if t.transport.transport_protocol == TransportProtocol::UDP {
-            if t.transport.local_addr.is_ipv4() != t.transport.peer_addr.is_ipv4() {
-                continue;
+        // Route by connection before trusting the engine's protocol stamp:
+        // rtc 0.9 marks DTLS and SCTP transmits `TransportProtocol::UDP`
+        // even when the selected pair is TCP ("TransportProtocol doesn't
+        // matter" — rtc/src/peer_connection/transport/dtls/mod.rs), so a
+        // peer that reached us over ICE-TCP must be matched by its tuple,
+        // not by the stamp, or every post-ICE packet misses the stream and
+        // DTLS times out.
+        if let Some(sender) = tcp_senders.get(&t.transport.peer_addr) {
+            let contents = t.message.to_vec();
+            match sender.try_send(contents) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {}
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    tcp_senders.remove(&t.transport.peer_addr);
+                }
             }
-            if t.transport.local_addr.ip().is_loopback() != t.transport.peer_addr.ip().is_loopback()
-            {
-                continue;
-            }
+            continue;
         }
-        match t.transport.transport_protocol {
-            TransportProtocol::UDP => {
-                let Some(sock) = sockets_by_addr.get(&t.transport.local_addr) else {
-                    eprintln!(
-                        "[dashboard/control] UDP transmit from unknown source {}, dropping",
-                        t.transport.local_addr
-                    );
-                    continue;
-                };
-                if let Err(e) = sock.send_to(&t.message, t.transport.peer_addr).await {
-                    eprintln!(
-                        "[dashboard/control] udp send {} -> {} failed: {e}",
-                        t.transport.local_addr, t.transport.peer_addr
-                    );
-                }
-            }
-            TransportProtocol::TCP => {
-                let Some(sender) = tcp_senders.get(&t.transport.peer_addr) else {
-                    continue;
-                };
-                let contents = t.message.to_vec();
-                match sender.try_send(contents) {
-                    Ok(()) => {}
-                    Err(mpsc::error::TrySendError::Full(_)) => {}
-                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                        tcp_senders.remove(&t.transport.peer_addr);
-                    }
-                }
-            }
+        if t.transport.transport_protocol == TransportProtocol::TCP {
+            // TCP-stamped transmit with no live stream for the tuple: the
+            // connection is gone and there is nothing to write to.
+            continue;
+        }
+        if t.transport.local_addr.is_ipv4() != t.transport.peer_addr.is_ipv4() {
+            continue;
+        }
+        if t.transport.local_addr.ip().is_loopback() != t.transport.peer_addr.ip().is_loopback() {
+            continue;
+        }
+        let Some(sock) = sockets_by_addr.get(&t.transport.local_addr) else {
+            eprintln!(
+                "[dashboard/control] UDP transmit from unknown source {}, dropping",
+                t.transport.local_addr
+            );
+            continue;
+        };
+        if let Err(e) = sock.send_to(&t.message, t.transport.peer_addr).await {
+            eprintln!(
+                "[dashboard/control] udp send {} -> {} failed: {e}",
+                t.transport.local_addr, t.transport.peer_addr
+            );
         }
     }
 

--- a/src/bin/caller/dashboard_control.rs
+++ b/src/bin/caller/dashboard_control.rs
@@ -1074,6 +1074,7 @@ impl DashboardControlPeer {
             presence,
             ice_config,
             tcp_peer_registry,
+            tcp_advertised,
             media_clip_ops: Arc::new(Mutex::new(HashMap::new())),
             control_frames_tx: None,
             display_peer_id: NEXT_DASHBOARD_DISPLAY_PEER_ID.fetch_add(1, Ordering::Relaxed),
@@ -1152,6 +1153,13 @@ struct ControlRuntime {
     presence: Option<DashboardPresenceBridge>,
     ice_config: crate::display::IceConfig,
     tcp_peer_registry: Arc<crate::display::webrtc::TcpPeerRegistry>,
+    /// The ICE-TCP tuple this control session itself advertised (the
+    /// rendezvous-observed public address on the gateway port for hosted
+    /// Connect sessions; `None` for locally-signaled sessions, whose
+    /// browsers signal displays over the gateway WS instead). Display
+    /// offers arriving on the control channel advertise the same tuple —
+    /// the browser reached us through it, so display traffic can too.
+    tcp_advertised: Option<SocketAddr>,
     media_clip_ops: Arc<Mutex<HashMap<String, DashboardMediaClipOperation>>>,
     control_frames_tx: Option<mpsc::UnboundedSender<serde_json::Value>>,
     display_peer_id: crate::display::PeerId,
@@ -8434,7 +8442,7 @@ async fn api_display_webrtc_offer_response(
             &sdp,
             &runtime.ice_config,
             Some(Arc::clone(&runtime.tcp_peer_registry)),
-            None,
+            runtime.tcp_advertised,
             ice_tx,
             input_authorized,
             authority_handler,
@@ -10371,6 +10379,7 @@ mod tests {
             presence: None,
             ice_config: crate::display::IceConfig::default(),
             tcp_peer_registry: crate::display::webrtc::TcpPeerRegistry::new(),
+            tcp_advertised: None,
             media_clip_ops: Arc::new(Mutex::new(HashMap::new())),
             control_frames_tx: None,
             display_peer_id: 1,

--- a/src/bin/caller/dashboard_control.rs
+++ b/src/bin/caller/dashboard_control.rs
@@ -1191,6 +1191,29 @@ struct InboundPacket {
     received_at: Instant,
 }
 
+/// Outbound transmits the drain dropped, by reason. Individual drops stay
+/// silent (cross-family pairs are routine noise while ICE probes candidate
+/// combinations), but a connection that dies with a nonzero tally logs the
+/// summary — a misrouted-transmit bug then names itself instead of
+/// presenting as a bare DTLS timeout (which once cost a full debugging
+/// round on the hosted-Connect path).
+#[derive(Debug, Default)]
+struct TransmitDropStats {
+    cross_family: u64,
+    loopback_mismatch: u64,
+    unknown_udp_source: u64,
+    tcp_without_stream: u64,
+}
+
+impl TransmitDropStats {
+    fn any(&self) -> bool {
+        self.cross_family != 0
+            || self.loopback_mismatch != 0
+            || self.unknown_udp_source != 0
+            || self.tcp_without_stream != 0
+    }
+}
+
 struct ControlTaskResponse {
     id: String,
     frame: serde_json::Value,
@@ -1390,12 +1413,14 @@ async fn control_driver<I: rtc::interceptor::Interceptor + Send + Sync + 'static
         .display_authority
         .as_ref()
         .map(DashboardDisplayAuthorityBridge::subscribe);
+    let mut drop_stats = TransmitDropStats::default();
 
     loop {
         let timeout_at = match drain_control_outputs(
             &mut rtc,
             &sockets_by_addr,
             &mut tcp_senders,
+            &mut drop_stats,
             &mut channels,
             &mut runtime,
             &task_tx,
@@ -1684,6 +1709,7 @@ async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
     rtc: &mut RTCPeerConnection<I>,
     sockets_by_addr: &HashMap<SocketAddr, Arc<UdpSocket>>,
     tcp_senders: &mut HashMap<SocketAddr, TcpFrameSender>,
+    drop_stats: &mut TransmitDropStats,
     channels: &mut HashMap<String, rtc::data_channel::RTCDataChannelId>,
     runtime: &mut ControlRuntime,
     task_tx: &mpsc::Sender<ControlTaskResponse>,
@@ -1715,15 +1741,19 @@ async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
         if t.transport.transport_protocol == TransportProtocol::TCP {
             // TCP-stamped transmit with no live stream for the tuple: the
             // connection is gone and there is nothing to write to.
+            drop_stats.tcp_without_stream += 1;
             continue;
         }
         if t.transport.local_addr.is_ipv4() != t.transport.peer_addr.is_ipv4() {
+            drop_stats.cross_family += 1;
             continue;
         }
         if t.transport.local_addr.ip().is_loopback() != t.transport.peer_addr.ip().is_loopback() {
+            drop_stats.loopback_mismatch += 1;
             continue;
         }
         let Some(sock) = sockets_by_addr.get(&t.transport.local_addr) else {
+            drop_stats.unknown_udp_source += 1;
             eprintln!(
                 "[dashboard/control] UDP transmit from unknown source {}, dropping",
                 t.transport.local_addr
@@ -1791,6 +1821,15 @@ async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
                     rtc::peer_connection::state::RTCPeerConnectionState::Failed
                         | rtc::peer_connection::state::RTCPeerConnectionState::Closed
                 ) {
+                    if drop_stats.any() {
+                        eprintln!(
+                            "[dashboard/control] transmit drops this session: {} cross-family, {} loopback-mismatch, {} unknown-udp-source, {} tcp-without-stream",
+                            drop_stats.cross_family,
+                            drop_stats.loopback_mismatch,
+                            drop_stats.unknown_udp_source,
+                            drop_stats.tcp_without_stream
+                        );
+                    }
                     return Err(());
                 }
             }

--- a/src/bin/caller/peer_file_transfer.rs
+++ b/src/bin/caller/peer_file_transfer.rs
@@ -603,39 +603,42 @@ async fn drain_transfer_outputs<I: rtc::interceptor::Interceptor>(
     channels: &mut HashMap<String, rtc::data_channel::RTCDataChannelId>,
 ) -> Result<Instant, ()> {
     while let Some(t) = rtc.poll_write() {
-        if t.transport.transport_protocol == TransportProtocol::UDP {
-            if t.transport.local_addr.is_ipv4() != t.transport.peer_addr.is_ipv4() {
-                continue;
+        // Route by connection before trusting the engine's protocol stamp:
+        // rtc 0.9 marks DTLS and SCTP transmits `TransportProtocol::UDP`
+        // even when the selected pair is TCP ("TransportProtocol doesn't
+        // matter" — rtc/src/peer_connection/transport/dtls/mod.rs), so a
+        // peer that reached us over ICE-TCP must be matched by its tuple,
+        // not by the stamp, or every post-ICE packet misses the stream and
+        // DTLS times out.
+        if let Some(sender) = tcp_senders.get(&t.transport.peer_addr) {
+            match sender.try_send(t.message.to_vec()) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {}
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    tcp_senders.remove(&t.transport.peer_addr);
+                }
             }
-            if t.transport.local_addr.ip().is_loopback() != t.transport.peer_addr.ip().is_loopback()
-            {
-                continue;
-            }
+            continue;
         }
-        match t.transport.transport_protocol {
-            TransportProtocol::UDP => {
-                let Some(sock) = sockets_by_addr.get(&t.transport.local_addr) else {
-                    continue;
-                };
-                if let Err(e) = sock.send_to(&t.message, t.transport.peer_addr).await {
-                    eprintln!(
-                        "[peer-file-transfer] udp send {} -> {} failed: {e}",
-                        t.transport.local_addr, t.transport.peer_addr
-                    );
-                }
-            }
-            TransportProtocol::TCP => {
-                let Some(sender) = tcp_senders.get(&t.transport.peer_addr) else {
-                    continue;
-                };
-                match sender.try_send(t.message.to_vec()) {
-                    Ok(()) => {}
-                    Err(mpsc::error::TrySendError::Full(_)) => {}
-                    Err(mpsc::error::TrySendError::Closed(_)) => {
-                        tcp_senders.remove(&t.transport.peer_addr);
-                    }
-                }
-            }
+        if t.transport.transport_protocol == TransportProtocol::TCP {
+            // TCP-stamped transmit with no live stream for the tuple: the
+            // connection is gone and there is nothing to write to.
+            continue;
+        }
+        if t.transport.local_addr.is_ipv4() != t.transport.peer_addr.is_ipv4() {
+            continue;
+        }
+        if t.transport.local_addr.ip().is_loopback() != t.transport.peer_addr.ip().is_loopback() {
+            continue;
+        }
+        let Some(sock) = sockets_by_addr.get(&t.transport.local_addr) else {
+            continue;
+        };
+        if let Err(e) = sock.send_to(&t.message, t.transport.peer_addr).await {
+            eprintln!(
+                "[peer-file-transfer] udp send {} -> {} failed: {e}",
+                t.transport.local_addr, t.transport.peer_addr
+            );
         }
     }
 

--- a/static/app.html
+++ b/static/app.html
@@ -15085,6 +15085,11 @@ let dashboardServerMessageDispatcher = null;
 const wsDeniedToastShown = new Set();
 let dashboardControlEventsActive = false;
 let dashboardControlLastError = '';
+// Coarse failure class for dashboardControlLastError so panes can give
+// honest guidance: 'refused' (the daemon itself rejected the offer),
+// 'transport' (answer received but ICE/DTLS/DataChannel never became
+// ready), 'signaling' (no answer at all), or '' (unclassified).
+let dashboardControlLastErrorKind = '';
 let dashboardConnectReconnectTimer = null;
 let dashboardConnectReconnectAttempt = 0;
 let dashboardConnectReconnectInFlight = false;
@@ -26260,7 +26265,7 @@ async function main() {
       setConnectEventStatus('ok', 'Dashboard events are live through verified Hosted Connect');
     } catch (err) {
       console.warn('[dashboard-control] Connect dashboard bootstrap failed', err);
-      dashboardSetControlLastError(err?.message || String(err));
+      dashboardSetControlLastError(err?.message || String(err), err?.controlErrorKind || '');
       dashboardUpdateTransportStatus();
       setConnectEventStatus('err', 'Hosted Connect dashboard events failed');
       scheduleDashboardConnectReconnect(err?.message || String(err), { delayMs: 1000 });
@@ -42353,21 +42358,63 @@ function renderAccessAttention() {
   const lastError = String(status.lastError || dashboardControlLastError || '').trim();
   if (summary.kind === 'err') {
     if (dashboardConnectModeEnabled()) {
-      items.push({
-        kind: 'err',
-        icon: '!',
-        message: 'Hosted Connect reached this daemon, but the daemon refused dashboard control.',
-        detail: lastError,
-        steps: [
-          'Open the daemon directly (its https://host:8765 address) with root access.',
-          'Go to Access → People & Devices and grant your Connect account a role.',
-          accessOwnDeviceFingerprint
-            ? `Verify it is really this device: this browser's key fingerprint is ${accessOwnDeviceFingerprint} — approve the pending request only if it matches.`
-            : 'Compare the pending request’s key fingerprint against this device before approving.',
-          'Reload this page — Connect is only the route; the daemon decides.',
-        ],
-        action: { label: 'Diagnostics', onClick: () => routeTo('access', 'diagnostics') },
-      });
+      // Three distinct failures share this err state; the transport records
+      // which one happened ('refused' | 'transport' | 'signaling') so the
+      // guidance matches reality. IAM advice is reserved for a genuine
+      // daemon refusal — sending someone to grant roles over a firewall
+      // problem wastes their debugging on the wrong layer.
+      const failureKind = String(status.lastErrorKind || dashboardControlLastErrorKind || '').trim();
+      if (failureKind === 'refused') {
+        items.push({
+          kind: 'err',
+          icon: '!',
+          message: 'Hosted Connect reached this daemon, but the daemon refused dashboard control.',
+          detail: lastError,
+          steps: [
+            'Open the daemon directly (its https://host:8765 address) with root access.',
+            'Go to Access → People & Devices and grant your Connect account a role.',
+            accessOwnDeviceFingerprint
+              ? `Verify it is really this device: this browser's key fingerprint is ${accessOwnDeviceFingerprint} — approve the pending request only if it matches.`
+              : 'Compare the pending request’s key fingerprint against this device before approving.',
+            'Reload this page — Connect is only the route; the daemon decides.',
+          ],
+          action: { label: 'Diagnostics', onClick: () => routeTo('access', 'diagnostics') },
+        });
+      } else if (failureKind === 'transport') {
+        items.push({
+          kind: 'err',
+          icon: '!',
+          message: 'This daemon answered through Hosted Connect, but the connection could not be established.',
+          detail: lastError,
+          steps: [
+            'Check that the daemon’s gateway port (its https://host:8765 listener) accepts inbound connections from the internet — a cloud box needs an inbound firewall rule.',
+            'The daemon advertises the public address the rendezvous observed for it; an extra NAT or proxy layer can make that address unreachable.',
+            'Hard-reload this page to retry with a fresh connection.',
+          ],
+          action: { label: 'Diagnostics', onClick: () => routeTo('access', 'diagnostics') },
+        });
+      } else if (failureKind === 'signaling') {
+        items.push({
+          kind: 'err',
+          icon: '!',
+          message: 'This daemon did not answer the Hosted Connect offer.',
+          detail: lastError,
+          steps: [
+            'Check that the daemon is running and has internet access — offers only reach it while it polls the rendezvous.',
+            'Confirm Connect is still enabled on the daemon and that it is claimed by this account.',
+            'Wait a moment and reload this page — a daemon that just started can take a few seconds to begin polling.',
+          ],
+          action: { label: 'Diagnostics', onClick: () => routeTo('access', 'diagnostics') },
+        });
+      } else {
+        items.push({
+          kind: 'err',
+          icon: '!',
+          message: 'The Hosted Connect control channel failed.',
+          detail: lastError,
+          action: { label: 'Diagnostics', onClick: () => routeTo('access', 'diagnostics') },
+        });
+      }
     } else {
       items.push({
         kind: 'err',
@@ -51947,8 +51994,9 @@ function dashboardConnectSignalUrl(path) {
   return `${DASHBOARD_CONNECT_SIGNALING_BASE}${normalized.startsWith('/') ? '' : '/'}${normalized}`;
 }
 
-function dashboardSetControlLastError(message = '') {
+function dashboardSetControlLastError(message = '', kind = '') {
   dashboardControlLastError = String(message || '').trim();
+  dashboardControlLastErrorKind = dashboardControlLastError ? String(kind || '').trim() : '';
 }
 
 function dashboardUpdateTransportStatus() {
@@ -52405,9 +52453,10 @@ class DashboardTransport {
     dashboardUpdateTransportStatus();
     this.controlStartPromise = dashboardControlTransport.connect().then(() => true).catch(err => {
       console.warn('[dashboard-control] connect failed', err);
-      dashboardSetControlLastError(err?.message || String(err));
+      dashboardSetControlLastError(err?.message || String(err), err?.controlErrorKind || '');
       if (dashboardControlTransport) {
         dashboardControlTransport.lastError = dashboardControlLastError;
+        dashboardControlTransport.lastErrorKind = dashboardControlLastErrorKind;
       }
       dashboardUpdateTransportStatus();
       dashboardControlTransport = null;
@@ -52442,6 +52491,7 @@ class DashboardTransport {
       enabled: this.enabled(),
       connected: false,
       lastError: dashboardControlLastError,
+      lastErrorKind: dashboardControlLastErrorKind,
       ...reconnect,
     };
   }
@@ -52690,12 +52740,18 @@ async function waitForDashboardControlReady(timeoutMs = 30000) {
     if (dashboardTransport?.canUseRpc?.()) return true;
     await new Promise(resolve => setTimeout(resolve, 100));
   }
-  throw new Error('dashboard Connect transport did not become ready');
+  // Signaling already succeeded by this point (the offer resolved to a
+  // verified answer) — what never happened is the WebRTC transport itself.
+  const err = new Error('dashboard Connect transport did not become ready');
+  err.controlErrorKind = 'transport';
+  throw err;
 }
 
 async function hydrateDashboardFromControl() {
   if (!dashboardTransport?.canUseRpc?.()) {
-    throw new Error('dashboard Connect transport is not connected');
+    const err = new Error('dashboard Connect transport is not connected');
+    err.controlErrorKind = 'transport';
+    throw err;
   }
   const [status, config, card, accessOverview, targets] = await Promise.all([
     dashboardTransport.request('status', {}, { timeoutMs: 15000 }).catch(() => null),
@@ -52784,7 +52840,7 @@ async function runDashboardConnectReconnect(reason = 'dashboard transport discon
   } catch (err) {
     retryReason = err?.message || String(err);
     console.warn('[dashboard-control] Hosted Connect reconnect failed', err);
-    dashboardSetControlLastError(retryReason);
+    dashboardSetControlLastError(retryReason, err?.controlErrorKind || '');
     setConnectEventStatus('err', 'Hosted Connect dashboard reconnect failed');
   } finally {
     dashboardConnectReconnectInFlight = false;
@@ -53987,6 +54043,7 @@ class DashboardControlTransport {
     this.localOfferSdp = '';
     this.lastStatus = null;
     this.lastError = '';
+    this.lastErrorKind = '';
     this.iceRoute = '';
     this.iceCandidatePair = '';
     this.pendingIce = [];
@@ -54004,6 +54061,7 @@ class DashboardControlTransport {
 
   async connect() {
     this.lastError = '';
+    this.lastErrorKind = '';
     dashboardSetControlLastError('');
     dashboardUpdateTransportStatus();
     const iceServers = buildIceServersFromGatewayConfig(gatewayConfig);
@@ -54018,7 +54076,8 @@ class DashboardControlTransport {
     };
     this.channel.onerror = () => {
       this.lastError = 'DataChannel error';
-      dashboardSetControlLastError(this.lastError);
+      this.lastErrorKind = 'transport';
+      dashboardSetControlLastError(this.lastError, this.lastErrorKind);
       dashboardUpdateTransportStatus();
       this.scheduleReconnect(this.lastError, { delayMs: 1000 });
     };
@@ -54034,6 +54093,11 @@ class DashboardControlTransport {
     this.pc.onconnectionstatechange = () => {
       const state = this.pc?.connectionState || 'closed';
       console.info('[dashboard-control] pc state', state);
+      // A peer connection that reaches `failed` did get signaling through
+      // (there was something to fail); the loss is ICE/DTLS-level. Record
+      // that durably on this transport so status renders long after the
+      // event still classify the failure honestly.
+      if (state === 'failed' && !this.lastErrorKind) this.lastErrorKind = 'transport';
       this.refreshIceRoute().catch(err => console.debug('[dashboard-control] route stats failed', err));
       dashboardUpdateTransportStatus();
       if (state === 'failed' || state === 'closed') {
@@ -54120,7 +54184,8 @@ class DashboardControlTransport {
   handleError(error) {
     console.warn('[dashboard-control] signaling error', error);
     this.lastError = String(error || 'signaling error');
-    dashboardSetControlLastError(this.lastError);
+    this.lastErrorKind = 'signaling';
+    dashboardSetControlLastError(this.lastError, this.lastErrorKind);
     dashboardUpdateTransportStatus();
     this.close();
     this.scheduleReconnect(this.lastError, { delayMs: 1000 });
@@ -54133,6 +54198,7 @@ class DashboardControlTransport {
 
   handleOpen() {
     this.lastError = '';
+    this.lastErrorKind = '';
     dashboardSetControlLastError('');
     this.refreshIceRoute().catch(() => {});
     dashboardUpdateTransportStatus();
@@ -54848,7 +54914,11 @@ class DashboardControlTransport {
     });
     const body = await resp.json().catch(() => ({}));
     if (!resp.ok || body.ok === false) {
-      throw new Error(body.error || `${path} returned ${resp.status}`);
+      const err = new Error(body.error || `${path} returned ${resp.status}`);
+      // The rendezvous encodes who failed in the status: callers use it to
+      // tell a daemon-authored refusal from "no answer ever came back".
+      err.connectHttpStatus = resp.status;
+      throw err;
     }
     return body;
   }
@@ -54903,13 +54973,26 @@ class DashboardControlTransport {
       // materializes it before resolving this very offer (one-round-trip
       // first contact). The daemon re-verifies everything.
       const orgGrant = await orgGrantForOffer(DASHBOARD_CONNECT_DAEMON_ID);
-      const answer = await this.postConnectSignal('/api/browser/offer', {
-        daemon_id: DASHBOARD_CONNECT_DAEMON_ID,
-        sdp,
-        client_nonce: this.clientNonce,
-        ...identity,
-        ...(orgGrant ? { org_grant: orgGrant } : {}),
-      });
+      let answer;
+      try {
+        answer = await this.postConnectSignal('/api/browser/offer', {
+          daemon_id: DASHBOARD_CONNECT_DAEMON_ID,
+          sdp,
+          client_nonce: this.clientNonce,
+          ...identity,
+          ...(orgGrant ? { org_grant: orgGrant } : {}),
+        });
+      } catch (err) {
+        // 502 relays the daemon's own words: it received the offer and
+        // posted an explicit refusal back through the rendezvous (the one
+        // exception is the service-internal "daemon answer channel
+        // closed"). Everything else — 504 offer timeout, 404 unknown
+        // daemon, a fetch failure — means no answer ever arrived.
+        const daemonSpoke = err?.connectHttpStatus === 502 &&
+          !/daemon answer channel closed/i.test(String(err?.message || ''));
+        err.controlErrorKind = daemonSpoke ? 'refused' : 'signaling';
+        throw err;
+      }
       this.signalingMode = 'connect-rendezvous';
       dashboardUpdateTransportStatus();
       return answer;
@@ -55061,6 +55144,7 @@ class DashboardControlTransport {
       iceRoute: this.iceRoute,
       iceCandidatePair: this.iceCandidatePair,
       lastError: this.lastError,
+      lastErrorKind: this.lastErrorKind,
       eventsActive: dashboardControlEventsActive,
       grantKind: this.lastStatus?.grant_kind ?? null,
       grantLabel: this.lastStatus?.grant_label ?? null,

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -624,6 +624,11 @@ let dashboardServerMessageDispatcher = null;
 const wsDeniedToastShown = new Set();
 let dashboardControlEventsActive = false;
 let dashboardControlLastError = '';
+// Coarse failure class for dashboardControlLastError so panes can give
+// honest guidance: 'refused' (the daemon itself rejected the offer),
+// 'transport' (answer received but ICE/DTLS/DataChannel never became
+// ready), 'signaling' (no answer at all), or '' (unclassified).
+let dashboardControlLastErrorKind = '';
 let dashboardConnectReconnectTimer = null;
 let dashboardConnectReconnectAttempt = 0;
 let dashboardConnectReconnectInFlight = false;

--- a/static/app/36-voice-wasm-init.js
+++ b/static/app/36-voice-wasm-init.js
@@ -913,7 +913,7 @@ async function main() {
       setConnectEventStatus('ok', 'Dashboard events are live through verified Hosted Connect');
     } catch (err) {
       console.warn('[dashboard-control] Connect dashboard bootstrap failed', err);
-      dashboardSetControlLastError(err?.message || String(err));
+      dashboardSetControlLastError(err?.message || String(err), err?.controlErrorKind || '');
       dashboardUpdateTransportStatus();
       setConnectEventStatus('err', 'Hosted Connect dashboard events failed');
       scheduleDashboardConnectReconnect(err?.message || String(err), { delayMs: 1000 });

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -330,21 +330,63 @@ function renderAccessAttention() {
   const lastError = String(status.lastError || dashboardControlLastError || '').trim();
   if (summary.kind === 'err') {
     if (dashboardConnectModeEnabled()) {
-      items.push({
-        kind: 'err',
-        icon: '!',
-        message: 'Hosted Connect reached this daemon, but the daemon refused dashboard control.',
-        detail: lastError,
-        steps: [
-          'Open the daemon directly (its https://host:8765 address) with root access.',
-          'Go to Access → People & Devices and grant your Connect account a role.',
-          accessOwnDeviceFingerprint
-            ? `Verify it is really this device: this browser's key fingerprint is ${accessOwnDeviceFingerprint} — approve the pending request only if it matches.`
-            : 'Compare the pending request’s key fingerprint against this device before approving.',
-          'Reload this page — Connect is only the route; the daemon decides.',
-        ],
-        action: { label: 'Diagnostics', onClick: () => routeTo('access', 'diagnostics') },
-      });
+      // Three distinct failures share this err state; the transport records
+      // which one happened ('refused' | 'transport' | 'signaling') so the
+      // guidance matches reality. IAM advice is reserved for a genuine
+      // daemon refusal — sending someone to grant roles over a firewall
+      // problem wastes their debugging on the wrong layer.
+      const failureKind = String(status.lastErrorKind || dashboardControlLastErrorKind || '').trim();
+      if (failureKind === 'refused') {
+        items.push({
+          kind: 'err',
+          icon: '!',
+          message: 'Hosted Connect reached this daemon, but the daemon refused dashboard control.',
+          detail: lastError,
+          steps: [
+            'Open the daemon directly (its https://host:8765 address) with root access.',
+            'Go to Access → People & Devices and grant your Connect account a role.',
+            accessOwnDeviceFingerprint
+              ? `Verify it is really this device: this browser's key fingerprint is ${accessOwnDeviceFingerprint} — approve the pending request only if it matches.`
+              : 'Compare the pending request’s key fingerprint against this device before approving.',
+            'Reload this page — Connect is only the route; the daemon decides.',
+          ],
+          action: { label: 'Diagnostics', onClick: () => routeTo('access', 'diagnostics') },
+        });
+      } else if (failureKind === 'transport') {
+        items.push({
+          kind: 'err',
+          icon: '!',
+          message: 'This daemon answered through Hosted Connect, but the connection could not be established.',
+          detail: lastError,
+          steps: [
+            'Check that the daemon’s gateway port (its https://host:8765 listener) accepts inbound connections from the internet — a cloud box needs an inbound firewall rule.',
+            'The daemon advertises the public address the rendezvous observed for it; an extra NAT or proxy layer can make that address unreachable.',
+            'Hard-reload this page to retry with a fresh connection.',
+          ],
+          action: { label: 'Diagnostics', onClick: () => routeTo('access', 'diagnostics') },
+        });
+      } else if (failureKind === 'signaling') {
+        items.push({
+          kind: 'err',
+          icon: '!',
+          message: 'This daemon did not answer the Hosted Connect offer.',
+          detail: lastError,
+          steps: [
+            'Check that the daemon is running and has internet access — offers only reach it while it polls the rendezvous.',
+            'Confirm Connect is still enabled on the daemon and that it is claimed by this account.',
+            'Wait a moment and reload this page — a daemon that just started can take a few seconds to begin polling.',
+          ],
+          action: { label: 'Diagnostics', onClick: () => routeTo('access', 'diagnostics') },
+        });
+      } else {
+        items.push({
+          kind: 'err',
+          icon: '!',
+          message: 'The Hosted Connect control channel failed.',
+          detail: lastError,
+          action: { label: 'Diagnostics', onClick: () => routeTo('access', 'diagnostics') },
+        });
+      }
     } else {
       items.push({
         kind: 'err',

--- a/static/app/49-daemons-multihost.js
+++ b/static/app/49-daemons-multihost.js
@@ -194,8 +194,9 @@ function dashboardConnectSignalUrl(path) {
   return `${DASHBOARD_CONNECT_SIGNALING_BASE}${normalized.startsWith('/') ? '' : '/'}${normalized}`;
 }
 
-function dashboardSetControlLastError(message = '') {
+function dashboardSetControlLastError(message = '', kind = '') {
   dashboardControlLastError = String(message || '').trim();
+  dashboardControlLastErrorKind = dashboardControlLastError ? String(kind || '').trim() : '';
 }
 
 function dashboardUpdateTransportStatus() {
@@ -652,9 +653,10 @@ class DashboardTransport {
     dashboardUpdateTransportStatus();
     this.controlStartPromise = dashboardControlTransport.connect().then(() => true).catch(err => {
       console.warn('[dashboard-control] connect failed', err);
-      dashboardSetControlLastError(err?.message || String(err));
+      dashboardSetControlLastError(err?.message || String(err), err?.controlErrorKind || '');
       if (dashboardControlTransport) {
         dashboardControlTransport.lastError = dashboardControlLastError;
+        dashboardControlTransport.lastErrorKind = dashboardControlLastErrorKind;
       }
       dashboardUpdateTransportStatus();
       dashboardControlTransport = null;
@@ -689,6 +691,7 @@ class DashboardTransport {
       enabled: this.enabled(),
       connected: false,
       lastError: dashboardControlLastError,
+      lastErrorKind: dashboardControlLastErrorKind,
       ...reconnect,
     };
   }
@@ -937,12 +940,18 @@ async function waitForDashboardControlReady(timeoutMs = 30000) {
     if (dashboardTransport?.canUseRpc?.()) return true;
     await new Promise(resolve => setTimeout(resolve, 100));
   }
-  throw new Error('dashboard Connect transport did not become ready');
+  // Signaling already succeeded by this point (the offer resolved to a
+  // verified answer) — what never happened is the WebRTC transport itself.
+  const err = new Error('dashboard Connect transport did not become ready');
+  err.controlErrorKind = 'transport';
+  throw err;
 }
 
 async function hydrateDashboardFromControl() {
   if (!dashboardTransport?.canUseRpc?.()) {
-    throw new Error('dashboard Connect transport is not connected');
+    const err = new Error('dashboard Connect transport is not connected');
+    err.controlErrorKind = 'transport';
+    throw err;
   }
   const [status, config, card, accessOverview, targets] = await Promise.all([
     dashboardTransport.request('status', {}, { timeoutMs: 15000 }).catch(() => null),
@@ -1031,7 +1040,7 @@ async function runDashboardConnectReconnect(reason = 'dashboard transport discon
   } catch (err) {
     retryReason = err?.message || String(err);
     console.warn('[dashboard-control] Hosted Connect reconnect failed', err);
-    dashboardSetControlLastError(retryReason);
+    dashboardSetControlLastError(retryReason, err?.controlErrorKind || '');
     setConnectEventStatus('err', 'Hosted Connect dashboard reconnect failed');
   } finally {
     dashboardConnectReconnectInFlight = false;

--- a/static/app/50-control-transport.js
+++ b/static/app/50-control-transport.js
@@ -12,6 +12,7 @@ class DashboardControlTransport {
     this.localOfferSdp = '';
     this.lastStatus = null;
     this.lastError = '';
+    this.lastErrorKind = '';
     this.iceRoute = '';
     this.iceCandidatePair = '';
     this.pendingIce = [];
@@ -29,6 +30,7 @@ class DashboardControlTransport {
 
   async connect() {
     this.lastError = '';
+    this.lastErrorKind = '';
     dashboardSetControlLastError('');
     dashboardUpdateTransportStatus();
     const iceServers = buildIceServersFromGatewayConfig(gatewayConfig);
@@ -43,7 +45,8 @@ class DashboardControlTransport {
     };
     this.channel.onerror = () => {
       this.lastError = 'DataChannel error';
-      dashboardSetControlLastError(this.lastError);
+      this.lastErrorKind = 'transport';
+      dashboardSetControlLastError(this.lastError, this.lastErrorKind);
       dashboardUpdateTransportStatus();
       this.scheduleReconnect(this.lastError, { delayMs: 1000 });
     };
@@ -59,6 +62,11 @@ class DashboardControlTransport {
     this.pc.onconnectionstatechange = () => {
       const state = this.pc?.connectionState || 'closed';
       console.info('[dashboard-control] pc state', state);
+      // A peer connection that reaches `failed` did get signaling through
+      // (there was something to fail); the loss is ICE/DTLS-level. Record
+      // that durably on this transport so status renders long after the
+      // event still classify the failure honestly.
+      if (state === 'failed' && !this.lastErrorKind) this.lastErrorKind = 'transport';
       this.refreshIceRoute().catch(err => console.debug('[dashboard-control] route stats failed', err));
       dashboardUpdateTransportStatus();
       if (state === 'failed' || state === 'closed') {
@@ -145,7 +153,8 @@ class DashboardControlTransport {
   handleError(error) {
     console.warn('[dashboard-control] signaling error', error);
     this.lastError = String(error || 'signaling error');
-    dashboardSetControlLastError(this.lastError);
+    this.lastErrorKind = 'signaling';
+    dashboardSetControlLastError(this.lastError, this.lastErrorKind);
     dashboardUpdateTransportStatus();
     this.close();
     this.scheduleReconnect(this.lastError, { delayMs: 1000 });
@@ -158,6 +167,7 @@ class DashboardControlTransport {
 
   handleOpen() {
     this.lastError = '';
+    this.lastErrorKind = '';
     dashboardSetControlLastError('');
     this.refreshIceRoute().catch(() => {});
     dashboardUpdateTransportStatus();
@@ -873,7 +883,11 @@ class DashboardControlTransport {
     });
     const body = await resp.json().catch(() => ({}));
     if (!resp.ok || body.ok === false) {
-      throw new Error(body.error || `${path} returned ${resp.status}`);
+      const err = new Error(body.error || `${path} returned ${resp.status}`);
+      // The rendezvous encodes who failed in the status: callers use it to
+      // tell a daemon-authored refusal from "no answer ever came back".
+      err.connectHttpStatus = resp.status;
+      throw err;
     }
     return body;
   }
@@ -928,13 +942,26 @@ class DashboardControlTransport {
       // materializes it before resolving this very offer (one-round-trip
       // first contact). The daemon re-verifies everything.
       const orgGrant = await orgGrantForOffer(DASHBOARD_CONNECT_DAEMON_ID);
-      const answer = await this.postConnectSignal('/api/browser/offer', {
-        daemon_id: DASHBOARD_CONNECT_DAEMON_ID,
-        sdp,
-        client_nonce: this.clientNonce,
-        ...identity,
-        ...(orgGrant ? { org_grant: orgGrant } : {}),
-      });
+      let answer;
+      try {
+        answer = await this.postConnectSignal('/api/browser/offer', {
+          daemon_id: DASHBOARD_CONNECT_DAEMON_ID,
+          sdp,
+          client_nonce: this.clientNonce,
+          ...identity,
+          ...(orgGrant ? { org_grant: orgGrant } : {}),
+        });
+      } catch (err) {
+        // 502 relays the daemon's own words: it received the offer and
+        // posted an explicit refusal back through the rendezvous (the one
+        // exception is the service-internal "daemon answer channel
+        // closed"). Everything else — 504 offer timeout, 404 unknown
+        // daemon, a fetch failure — means no answer ever arrived.
+        const daemonSpoke = err?.connectHttpStatus === 502 &&
+          !/daemon answer channel closed/i.test(String(err?.message || ''));
+        err.controlErrorKind = daemonSpoke ? 'refused' : 'signaling';
+        throw err;
+      }
       this.signalingMode = 'connect-rendezvous';
       dashboardUpdateTransportStatus();
       return answer;
@@ -1086,6 +1113,7 @@ class DashboardControlTransport {
       iceRoute: this.iceRoute,
       iceCandidatePair: this.iceCandidatePair,
       lastError: this.lastError,
+      lastErrorKind: this.lastErrorKind,
       eventsActive: dashboardControlEventsActive,
       grantKind: this.lastStatus?.grant_kind ?? null,
       grantLabel: this.lastStatus?.grant_label ?? null,


### PR DESCRIPTION
Hosted dashboard-control to a NAT'd cloud daemon connected at the ICE layer and then died in a silent 30s loop: rtc 0.9 stamps DTLS/SCTP transmits \`TransportProtocol::UDP\` even when the selected pair is TCP, and all three sans-IO drains routed by that stamp, so every post-ICE packet missed the TCP stream (dashboard control, display, peer file transfer). Live-diagnosed and verified on a fresh cloud box today.

- Route outbound transmits by live TCP connection first, stamp second (all three drains).
- Display offers arriving on the control channel now advertise the control session's ICE-TCP tuple — hosted display streaming on cloud daemons was impossible before this (it passed \`None\`).
- Count silently-dropped transmits and summarize on connection failure, so the next misroute names itself instead of presenting as a bare DTLS timeout.
- Dashboard error pane now distinguishes daemon refusal / transport failure / no-answer — the old copy sent operators to IAM debugging for firewall problems.
- New \`scripts/connect-transport-e2e.cjs\`: keyless local rig (rendezvous + XFF proxy + fresh daemon + headless Chromium with a virtual passkey) asserting the outcome our E2E never asserted — the control data channel actually opens over ICE-TCP. Red against main without this PR's fix, with exactly the live failure signature; green with it.
- Docs: the reverse proxy in front of a self-hosted rendezvous must set X-Forwarded-For (plus the Caddy delete-after-set trap that bit the default instance, a deploy-time probe, the IPv6 family caveat, and the rig).
- Connect validators wait for the current startup banner ('Dashboard:', not the removed 'Web TUI:').

Verified: 2×2625 unit tests, headless e2e 5/5, the transport rig green from this branch, and live on a fresh cloud box — claim, bootstrap, control channel, and display streaming all working through the hosted path.