### PR TITLE
Sessions preview quick search: conversation snippets in row search

### DIFF
--- a/src/bin/caller/web_gateway/session_catalog/backend_lists.rs
+++ b/src/bin/caller/web_gateway/session_catalog/backend_lists.rs
@@ -577,7 +577,7 @@ pub(crate) fn list_codex_sessions_with_limit(
 }
 
 pub(crate) fn claude_session_list_row_from_file(path: &Path) -> Option<serde_json::Value> {
-    let key = session_list_cache_key("claude-code", path, "")?;
+    let key = session_list_cache_key("claude-code", path, SESSION_ROW_PREVIEW_FORMAT)?;
     if let Some(row) = cached_session_list_row(&key) {
         return Some(row);
     }
@@ -602,6 +602,7 @@ pub(crate) fn claude_session_list_row_from_file(path: &Path) -> Option<serde_jso
     let mut daily_usage: BTreeMap<String, SessionUsage> = BTreeMap::new();
     let mut seen_usage = HashSet::new();
     let mut turns = 0u64;
+    let mut preview = SessionPreviewBuilder::default();
     for (line_idx, line_result) in reader.lines().enumerate() {
         let Ok(line) = line_result else {
             continue;
@@ -617,7 +618,9 @@ pub(crate) fn claude_session_list_row_from_file(path: &Path) -> Option<serde_jso
             }
             cwd = Some(value);
         }
-        if obj.get("type").and_then(|v| v.as_str()) == Some("user") {
+        let record_type = obj.get("type").and_then(|v| v.as_str());
+        let record_is_meta = obj.get("isMeta").and_then(|v| v.as_bool()).unwrap_or(false);
+        if record_type == Some("user") {
             turns += 1;
             if task.is_none() {
                 if let Some(msg) = obj.get("message") {
@@ -635,6 +638,33 @@ pub(crate) fn claude_session_list_row_from_file(path: &Path) -> Option<serde_jso
                         task = Some(compact_text(user_text, 180));
                     }
                 }
+            }
+            // Preview wants real prompts only: prose text blocks (a
+            // tool_result record is also type=user), never meta records.
+            if !record_is_meta {
+                if let Some(content) = obj
+                    .get("message")
+                    .and_then(|m| m.get("content"))
+                    .and_then(message_prose_text)
+                {
+                    let user_text = content
+                        .split(
+                            crate::external_agent::claude_code::CLAUDE_CODE_BOOTSTRAP_ADDENDUM_MARKER,
+                        )
+                        .next()
+                        .unwrap_or(&content)
+                        .trim_end();
+                    preview.push_user(user_text);
+                }
+            }
+        }
+        if record_type == Some("assistant") && !record_is_meta {
+            if let Some(content) = obj
+                .get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(message_prose_text)
+            {
+                preview.push_assistant(&content);
             }
         }
         if let Some(msg) = obj.get("message") {
@@ -683,6 +713,9 @@ pub(crate) fn claude_session_list_row_from_file(path: &Path) -> Option<serde_jso
     );
     apply_session_usage(&mut session, usage, model.as_deref());
     apply_session_daily_usage(&mut session, &daily_usage, model.as_deref());
+    if let Some(preview) = preview.into_value() {
+        session["preview"] = preview;
+    }
     store_session_list_row(key, &session);
     Some(session)
 }
@@ -739,7 +772,11 @@ pub(crate) fn gemini_session_list_row_from_file(
     {
         return None;
     }
-    let key = session_list_cache_key("gemini", path, roots_fingerprint)?;
+    let key = session_list_cache_key(
+        "gemini",
+        path,
+        format!("{SESSION_ROW_PREVIEW_FORMAT}:{roots_fingerprint}"),
+    )?;
     if let Some(row) = cached_session_list_row(&key) {
         return Some(row);
     }
@@ -758,6 +795,7 @@ pub(crate) fn gemini_session_list_row_from_file(
     let mut model = value_str(&obj, "model");
     let mut usage = SessionUsage::default();
     let mut daily_usage: BTreeMap<String, SessionUsage> = BTreeMap::new();
+    let mut preview = SessionPreviewBuilder::default();
     let session_started_at = value_str(&obj, "startTime");
     if let Some(messages) = obj.get("messages").and_then(|v| v.as_array()) {
         for msg in messages {
@@ -779,15 +817,25 @@ pub(crate) fn gemini_session_list_row_from_file(
                 .unwrap_or("");
             if role == "user" {
                 turns += 1;
-                if task.is_none() {
-                    let text = msg
-                        .get("text")
-                        .or_else(|| msg.get("message"))
-                        .or_else(|| msg.get("content"))
-                        .and_then(message_content_text);
-                    if let Some(text) = text {
+                let text = msg
+                    .get("text")
+                    .or_else(|| msg.get("message"))
+                    .or_else(|| msg.get("content"))
+                    .and_then(message_content_text);
+                if let Some(text) = text {
+                    if task.is_none() {
                         task = Some(compact_text(&text, 180));
                     }
+                    preview.push_user(&text);
+                }
+            } else if role == "assistant" || role == "model" {
+                if let Some(text) = msg
+                    .get("text")
+                    .or_else(|| msg.get("message"))
+                    .or_else(|| msg.get("content"))
+                    .and_then(message_prose_text)
+                {
+                    preview.push_assistant(&text);
                 }
             }
         }
@@ -813,6 +861,9 @@ pub(crate) fn gemini_session_list_row_from_file(
     );
     apply_session_usage(&mut session, usage, model.as_deref());
     apply_session_daily_usage(&mut session, &daily_usage, model.as_deref());
+    if let Some(preview) = preview.into_value() {
+        session["preview"] = preview;
+    }
     store_session_list_row(key, &session);
     Some(session)
 }
@@ -2173,6 +2224,86 @@ mod tests {
         assert_eq!(session["turns"].as_u64(), Some(1));
         let cost = session["estimated_cost"].as_f64().unwrap();
         assert!((cost - 0.000714).abs() < 1e-12, "unexpected cost {cost}");
+    }
+
+    #[test]
+    fn claude_row_preview_takes_prose_and_skips_tool_and_meta_records() {
+        let home = tempfile::tempdir().unwrap();
+        let project_dir = home.path().join(".claude").join("projects").join("-tmp-p");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let lines = [
+            serde_json::json!({
+                "timestamp": "2026-07-07T10:00:00Z",
+                "type": "user",
+                "cwd": "/tmp/p",
+                "message": {"content": "Refactor the parser"}
+            }),
+            // Meta records are typed user but are not conversation.
+            serde_json::json!({
+                "timestamp": "2026-07-07T10:00:01Z",
+                "type": "user",
+                "isMeta": true,
+                "message": {"content": "Caveat: system housekeeping text"}
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-07T10:00:02Z",
+                "type": "assistant",
+                "message": {"content": [
+                    {"type": "text", "text": "Starting with the tokenizer."},
+                    {"type": "tool_use", "name": "Bash", "input": {"command": "cargo test"}}
+                ]}
+            }),
+            // Tool results come back as type=user; content is tool output.
+            serde_json::json!({
+                "timestamp": "2026-07-07T10:00:03Z",
+                "type": "user",
+                "message": {"content": [
+                    {"type": "tool_result", "content": "test result: ok. 100 passed"}
+                ]}
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-07T10:00:04Z",
+                "type": "user",
+                "message": {"content": "Now handle unicode too"}
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-07T10:00:05Z",
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "Unicode handled."}]}
+            }),
+        ];
+        let contents = lines
+            .iter()
+            .map(serde_json::Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(project_dir.join("preview-abc.jsonl"), contents).unwrap();
+
+        let sessions = list_claude_sessions(home.path());
+        let session = sessions
+            .iter()
+            .find(|s| s.get("session_id").and_then(|v| v.as_str()) == Some("preview-abc"))
+            .expect("claude session should be listed");
+        let preview = session.get("preview").and_then(|v| v.as_array()).unwrap();
+        let flat: Vec<(&str, &str)> = preview
+            .iter()
+            .map(|e| {
+                (
+                    e.get("role").and_then(|v| v.as_str()).unwrap(),
+                    e.get("text").and_then(|v| v.as_str()).unwrap(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            flat,
+            vec![
+                ("user", "Refactor the parser"),
+                ("assistant", "Starting with the tokenizer."),
+                ("user", "Now handle unicode too"),
+                ("assistant", "Unicode handled."),
+            ]
+        );
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/session_catalog/codex_values.rs
+++ b/src/bin/caller/web_gateway/session_catalog/codex_values.rs
@@ -74,6 +74,113 @@ pub(crate) fn message_content_text(content: &serde_json::Value) -> Option<String
     }
 }
 
+/// Prose-only variant of [`message_content_text`] for row previews: string
+/// content passes through, but array content contributes only explicit
+/// `type == "text"` blocks — tool_use/tool_result blocks (whose `content`
+/// can be a plain string) must never leak into a conversation preview.
+pub(crate) fn message_prose_text(content: &serde_json::Value) -> Option<String> {
+    match content {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Array(items) => {
+            let parts: Vec<&str> = items
+                .iter()
+                .filter(|item| item.get("type").and_then(|v| v.as_str()) == Some("text"))
+                .filter_map(|item| item.get("text").and_then(|v| v.as_str()))
+                .collect();
+            if parts.is_empty() {
+                None
+            } else {
+                Some(parts.join("\n"))
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Compact conversation preview carried on session list rows: the first
+/// couple of user and assistant MESSAGES, prose only — callers feed only
+/// message-text events/records, so tool calls, tool results, and command
+/// output are excluded structurally rather than by content sniffing. It
+/// powers the Sessions-tab quick search without shipping transcripts;
+/// Deep Search keeps full-history duty.
+pub(crate) const SESSION_PREVIEW_ROLE_SLOTS: usize = 2;
+pub(crate) const SESSION_PREVIEW_TEXT_CHARS: usize = 160;
+/// Cap on the total preview TEXT bytes per row (JSON scaffolding rides on
+/// top). Keeps the unlimited list's growth bounded (~+2 MB at 4k rows).
+pub(crate) const SESSION_PREVIEW_MAX_BYTES: usize = 500;
+/// Version token folded into external row cache keys; bump it whenever the
+/// preview shape changes so persisted rows rebuild with the new field.
+/// (Intendant rows version through the fingerprint digest byte instead.)
+pub(crate) const SESSION_ROW_PREVIEW_FORMAT: &str = "p1";
+
+#[derive(Default)]
+pub(crate) struct SessionPreviewBuilder {
+    entries: Vec<(&'static str, String)>, // chronological (role, text)
+    user: usize,
+    assistant: usize,
+}
+
+impl SessionPreviewBuilder {
+    pub(crate) fn push_user(&mut self, text: &str) {
+        Self::push(&mut self.user, "user", text, &mut self.entries);
+    }
+
+    pub(crate) fn push_assistant(&mut self, text: &str) {
+        Self::push(&mut self.assistant, "assistant", text, &mut self.entries);
+    }
+
+    fn push(
+        slot: &mut usize,
+        role: &'static str,
+        text: &str,
+        entries: &mut Vec<(&'static str, String)>,
+    ) {
+        if *slot >= SESSION_PREVIEW_ROLE_SLOTS {
+            return;
+        }
+        let text = compact_text(text, SESSION_PREVIEW_TEXT_CHARS);
+        if text.is_empty() {
+            return;
+        }
+        *slot += 1;
+        entries.push((role, text));
+    }
+
+    /// Serializes to the row's `preview` value, enforcing the byte cap on
+    /// a char boundary; `None` when nothing prose-shaped was collected.
+    pub(crate) fn into_value(self) -> Option<serde_json::Value> {
+        if self.entries.is_empty() {
+            return None;
+        }
+        let mut used = 0usize;
+        let mut out = Vec::new();
+        for (role, text) in self.entries {
+            if used >= SESSION_PREVIEW_MAX_BYTES {
+                break;
+            }
+            let budget = SESSION_PREVIEW_MAX_BYTES - used;
+            let mut text = text;
+            if text.len() > budget {
+                let mut cut = budget;
+                while cut > 0 && !text.is_char_boundary(cut) {
+                    cut -= 1;
+                }
+                text.truncate(cut);
+            }
+            if text.is_empty() {
+                break;
+            }
+            used += text.len();
+            out.push(serde_json::json!({ "role": role, "text": text }));
+        }
+        if out.is_empty() {
+            None
+        } else {
+            Some(serde_json::Value::Array(out))
+        }
+    }
+}
+
 #[derive(Deserialize)]
 pub(crate) struct ExternalJsonLineKind<'a> {
     #[serde(rename = "type", borrow)]

--- a/src/bin/caller/web_gateway/session_catalog/mod.rs
+++ b/src/bin/caller/web_gateway/session_catalog/mod.rs
@@ -1465,11 +1465,11 @@ pub(crate) fn intendant_session_dir_fingerprint(dir: &Path) -> Option<SessionDir
 /// next list pass.
 pub(crate) fn session_file_fingerprints_digest(entries: &[SessionFileFingerprint]) -> String {
     let mut ctx = ring::digest::Context::new(&ring::digest::SHA256);
-    // Format v2: `updated_at` derives from transcript activity, not dir
-    // mtime. Bumping the layout invalidates every persisted row once, so
-    // cached rows with the old bookkeeping-bumped timestamps rebuild on
-    // the next list pass instead of lingering until their dir changes.
-    ctx.update(&[2u8]);
+    // Format v3: rows carry the conversation `preview`. Bumping the layout
+    // invalidates every persisted row once, so cached rows without the new
+    // field rebuild on the next list pass instead of lingering until their
+    // dir changes. (v2 moved `updated_at` to transcript activity.)
+    ctx.update(&[3u8]);
     for entry in entries {
         ctx.update(entry.rel.as_bytes());
         ctx.update(&[0]);
@@ -1555,6 +1555,13 @@ pub(crate) fn intendant_session_list_row_from_dir(
         }
     }
 
+    // Conversation preview: the meta task is the first user message; the
+    // event loop below adds steer follow-ups and assistant text.
+    let mut preview = SessionPreviewBuilder::default();
+    if let Some(task_text) = task.as_deref() {
+        preview.push_user(task_text);
+    }
+
     let jsonl_path = dir.join("session.jsonl");
     if let Ok(contents) = std::fs::read_to_string(&jsonl_path) {
         for line in contents.lines() {
@@ -1618,7 +1625,9 @@ pub(crate) fn intendant_session_list_row_from_dir(
                         } else if message.starts_with("Model: ") && model.is_none() {
                             model = Some(message.trim_start_matches("Model: ").to_string());
                         } else if message.starts_with("Task: ") && task.is_none() {
-                            task = Some(message.trim_start_matches("Task: ").to_string());
+                            let task_text = message.trim_start_matches("Task: ");
+                            preview.push_user(task_text);
+                            task = Some(task_text.to_string());
                         } else if message.starts_with("Interrupted: ")
                             || message.starts_with("External agent interrupted: ")
                         {
@@ -1640,7 +1649,21 @@ pub(crate) fn intendant_session_list_row_from_dir(
                         }
                     }
                 }
+                "steer_requested" => {
+                    if let Some(text) = obj
+                        .get("data")
+                        .and_then(|d| d.get("text"))
+                        .and_then(|v| v.as_str())
+                    {
+                        preview.push_user(text);
+                    }
+                }
                 "model_response" => {
+                    // The event's message is the model TEXT preview (first
+                    // 200 chars); tool calls live in other event kinds.
+                    if !message.is_empty() {
+                        preview.push_assistant(message);
+                    }
                     if let Some(tok) = obj.get("data").and_then(|d| d.get("tokens")) {
                         let mut event_usage = SessionUsage::default();
                         if let Some(t) = tok.get("total").and_then(|v| v.as_u64()) {
@@ -1885,6 +1908,9 @@ pub(crate) fn intendant_session_list_row_from_dir(
         "can_resume": true,
         "relationships": relationships,
     });
+    if let Some(preview) = preview.into_value() {
+        wrapper_session["preview"] = preview;
+    }
     if let Some(config) = session_agent_config.as_ref() {
         crate::session_config::apply_config_to_session_json(&mut wrapper_session, config);
     }
@@ -2672,6 +2698,101 @@ mod tests {
         let body = list_sessions_from_home_with_limit(home.path(), Some(2));
         let sessions: Vec<serde_json::Value> = serde_json::from_str(&body).unwrap();
         assert_eq!(sessions.len(), 2);
+    }
+
+    #[test]
+    fn intendant_row_preview_collects_prose_and_respects_slots() {
+        let home = tempfile::tempdir().unwrap();
+        let log_dir = home.path().join(".intendant").join("logs").join("preview-1");
+        std::fs::create_dir_all(&log_dir).unwrap();
+        std::fs::write(
+            log_dir.join("session_meta.json"),
+            serde_json::json!({
+                "created_at": "2026-07-07T10:00:00Z",
+                "task": "Fix the login bug",
+                "status": "idle"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let events = [
+            serde_json::json!({"ts": "2026-07-07T10:00:00Z", "event": "session_start", "message": "Session started"}),
+            // Non-conversation events must never enter the preview.
+            serde_json::json!({"ts": "2026-07-07T10:00:01Z", "event": "messages_input", "turn": 1, "message": "Messages logged (9000 bytes)"}),
+            serde_json::json!({"ts": "2026-07-07T10:00:02Z", "event": "info", "level": "info", "message": "[runtime] Task dispatched: something"}),
+            serde_json::json!({"ts": "2026-07-07T10:00:03Z", "event": "model_response", "turn": 1, "message": "I will start by reading the auth module."}),
+            serde_json::json!({"ts": "2026-07-07T10:00:04Z", "event": "steer_requested", "message": "Steer requested: Also update the tests", "data": {"id": "s1", "status": "requested", "text": "Also update the tests"}}),
+            serde_json::json!({"ts": "2026-07-07T10:00:05Z", "event": "model_response", "turn": 2, "message": "Tests updated; the fix is in."}),
+            // Third assistant message: both assistant slots are taken.
+            serde_json::json!({"ts": "2026-07-07T10:00:06Z", "event": "model_response", "turn": 3, "message": "Extra reply that must not appear."}),
+        ];
+        let jsonl: String = events.iter().map(|e| format!("{e}\n")).collect();
+        std::fs::write(log_dir.join("session.jsonl"), jsonl).unwrap();
+
+        let row = intendant_session_list_row_from_dir(&log_dir, "preview-1").unwrap();
+        let preview = row.get("preview").and_then(|v| v.as_array()).unwrap();
+        let flat: Vec<(String, String)> = preview
+            .iter()
+            .map(|e| {
+                (
+                    e.get("role").and_then(|v| v.as_str()).unwrap().to_string(),
+                    e.get("text").and_then(|v| v.as_str()).unwrap().to_string(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            flat,
+            vec![
+                ("user".to_string(), "Fix the login bug".to_string()),
+                (
+                    "assistant".to_string(),
+                    "I will start by reading the auth module.".to_string()
+                ),
+                ("user".to_string(), "Also update the tests".to_string()),
+                (
+                    "assistant".to_string(),
+                    "Tests updated; the fix is in.".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn preview_builder_enforces_byte_cap_on_char_boundary() {
+        let mut builder = SessionPreviewBuilder::default();
+        let long = "é".repeat(200); // 2 bytes per char; compacted to 160 chars
+        builder.push_user(&long);
+        builder.push_assistant(&long);
+        builder.push_user(&long);
+        builder.push_assistant(&long);
+        let value = builder.into_value().unwrap();
+        let entries = value.as_array().unwrap();
+        let total: usize = entries
+            .iter()
+            .map(|e| e.get("text").and_then(|v| v.as_str()).unwrap().len())
+            .sum();
+        assert!(total <= SESSION_PREVIEW_MAX_BYTES, "total {total}");
+        // Every surviving text is valid UTF-8 by construction (as_str) —
+        // the cap must land on a char boundary rather than panic.
+        assert!(entries.len() >= 2);
+    }
+
+    #[test]
+    fn preview_prose_text_excludes_tool_blocks() {
+        let content = serde_json::json!([
+            {"type": "text", "text": "real prose"},
+            {"type": "tool_use", "name": "Bash", "input": {"command": "rm -rf /tmp/x"}},
+            {"type": "tool_result", "content": "raw tool output that must not leak"},
+        ]);
+        assert_eq!(message_prose_text(&content).as_deref(), Some("real prose"));
+        let tool_only = serde_json::json!([
+            {"type": "tool_result", "content": "raw tool output"},
+        ]);
+        assert_eq!(message_prose_text(&tool_only), None);
+        assert_eq!(
+            message_prose_text(&serde_json::json!("plain string prompt")).as_deref(),
+            Some("plain string prompt")
+        );
     }
 
     #[test]

--- a/static/app.html
+++ b/static/app.html
@@ -8455,6 +8455,33 @@ body.context-focus-active {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* Quick-search match inside the row's conversation preview. */
+.session-card .sc-preview-hit {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  margin: 3px 0 5px;
+  padding: 4px 7px;
+  border-left: 2px solid var(--mauve);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--mauve) 8%, transparent);
+  font-size: 12px;
+  color: var(--subtext0);
+}
+.session-card .sc-preview-hit-role {
+  flex: 0 0 auto;
+  color: var(--mauve);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.session-card .sc-preview-hit-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .session-card .sc-meta {
   display: flex;
   gap: 11px;
@@ -71616,6 +71643,11 @@ function sessionSearchText(session, displayStatus, source, shortId, isCurrent) {
     return cached.text;
   }
   const totalBytes = session.total_bytes || 0;
+  // Server-side conversation preview (first user/assistant messages) —
+  // quick search reaches into conversation text without a Deep Search.
+  const previewText = Array.isArray(session.preview)
+    ? session.preview.map(p => (p && p.text) || '').filter(Boolean).join(' ')
+    : '';
   const fields = [
     session.session_id,
     shortId,
@@ -71651,6 +71683,7 @@ function sessionSearchText(session, displayStatus, source, shortId, isCurrent) {
     totalBytes > 0 ? `${_fmtBytes(totalBytes)} size` : '',
     session.total_tokens != null ? `${session.total_tokens} tokens` : '',
     session.estimated_cost != null ? `$${Number(session.estimated_cost).toFixed(4)}` : '',
+    previewText,
   ];
   const text = fields
     .filter(v => v !== null && v !== undefined && v !== '')
@@ -71883,9 +71916,26 @@ function sessionCardDerived(m, ctx) {
   }
   const lineageChildren = sessionLineageChildrenForSession(ctx.lineageIndex, s, configMeta)
     .filter(child => !ctx.hideSubagents || sessionRelationshipKindForRow(child) !== 'subagent');
+  // Quick-search hit inside the conversation preview: surface the message
+  // matching the most query terms as a snippet line on the card (any-term
+  // picking made a stray "to" beat the entry holding the actual phrase).
+  let previewHit = null;
+  if (ctx.query && Array.isArray(s.preview)) {
+    const terms = ctx.query.split(/\s+/).filter(Boolean);
+    let bestScore = 0;
+    for (const p of s.preview) {
+      const text = String((p && p.text) || '').toLowerCase();
+      if (!text) continue;
+      const score = terms.reduce((n, term) => n + (text.includes(term) ? 1 : 0), 0);
+      if (score > bestScore) {
+        bestScore = score;
+        previewHit = p;
+      }
+    }
+  }
   return {
     configMeta, configSource, relationshipKind, backendSource, hasExternalBackend,
-    nickname, parentId, parent, parentLabel, lineageChildren,
+    nickname, parentId, parent, parentLabel, lineageChildren, previewHit,
   };
 }
 
@@ -71897,11 +71947,14 @@ function sessionCardSig(m, derived, ctx) {
   const hitSig = m.logHit
     ? `${m.logHit.matches || 0}\u001e${(((m.logHit.snippets || [])[0]) || {}).content || ''}`
     : '';
+  const previewHitSig = derived.previewHit
+    ? `${derived.previewHit.role || ''}\u001e${derived.previewHit.text || ''}`
+    : '';
   return JSON.stringify(m.s) + '\u001f' + JSON.stringify([
     m.displayStatus, m.isCurrent, m.source, ctx.viewingPeer,
     derived.relationshipKind, derived.configSource, derived.backendSource,
     derived.hasExternalBackend, derived.nickname, derived.parentId,
-    derived.parentLabel, childSig, hitSig,
+    derived.parentLabel, childSig, hitSig, previewHitSig,
   ]);
 }
 
@@ -72025,6 +72078,7 @@ function renderSessionsList(sessions, el, options = {}) {
     hideSubagents: !!options.hideSubagents,
     viewingPeer: sessionsViewingPeer(),
     currentSessionId,
+    query: options.query || '',
     lineageIndex: buildSessionLineageIndex(sessions),
   };
 
@@ -72284,6 +72338,24 @@ function buildSessionCard(m, derived, ctx) {
     hitText.title = firstSnippet.content || '';
     hitEl.appendChild(hitText);
     card.appendChild(hitEl);
+  }
+
+  // Quick-search hit inside the conversation preview: one quiet snippet
+  // line showing where the match lives. Deep Search keeps the log-hit row
+  // above for full-history matches.
+  if (derived.previewHit) {
+    const prevEl = document.createElement('div');
+    prevEl.className = 'sc-preview-hit';
+    const roleEl = document.createElement('span');
+    roleEl.className = 'sc-preview-hit-role';
+    roleEl.textContent = derived.previewHit.role === 'assistant' ? 'assistant' : 'user';
+    prevEl.appendChild(roleEl);
+    const textEl = document.createElement('span');
+    textEl.className = 'sc-preview-hit-text';
+    textEl.textContent = derived.previewHit.text || '';
+    textEl.title = derived.previewHit.text || '';
+    prevEl.appendChild(textEl);
+    card.appendChild(prevEl);
   }
 
   // Meta row — the full session id (click to copy) plus compact

--- a/static/app/13-styles-sessions-terminal.css
+++ b/static/app/13-styles-sessions-terminal.css
@@ -1556,6 +1556,33 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* Quick-search match inside the row's conversation preview. */
+.session-card .sc-preview-hit {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  margin: 3px 0 5px;
+  padding: 4px 7px;
+  border-left: 2px solid var(--mauve);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--mauve) 8%, transparent);
+  font-size: 12px;
+  color: var(--subtext0);
+}
+.session-card .sc-preview-hit-role {
+  flex: 0 0 auto;
+  color: var(--mauve);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.session-card .sc-preview-hit-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .session-card .sc-meta {
   display: flex;
   gap: 11px;

--- a/static/app/56-debug-sessions.js
+++ b/static/app/56-debug-sessions.js
@@ -1786,6 +1786,11 @@ function sessionSearchText(session, displayStatus, source, shortId, isCurrent) {
     return cached.text;
   }
   const totalBytes = session.total_bytes || 0;
+  // Server-side conversation preview (first user/assistant messages) —
+  // quick search reaches into conversation text without a Deep Search.
+  const previewText = Array.isArray(session.preview)
+    ? session.preview.map(p => (p && p.text) || '').filter(Boolean).join(' ')
+    : '';
   const fields = [
     session.session_id,
     shortId,
@@ -1821,6 +1826,7 @@ function sessionSearchText(session, displayStatus, source, shortId, isCurrent) {
     totalBytes > 0 ? `${_fmtBytes(totalBytes)} size` : '',
     session.total_tokens != null ? `${session.total_tokens} tokens` : '',
     session.estimated_cost != null ? `$${Number(session.estimated_cost).toFixed(4)}` : '',
+    previewText,
   ];
   const text = fields
     .filter(v => v !== null && v !== undefined && v !== '')

--- a/static/app/57-sessions-replay.js
+++ b/static/app/57-sessions-replay.js
@@ -158,9 +158,26 @@ function sessionCardDerived(m, ctx) {
   }
   const lineageChildren = sessionLineageChildrenForSession(ctx.lineageIndex, s, configMeta)
     .filter(child => !ctx.hideSubagents || sessionRelationshipKindForRow(child) !== 'subagent');
+  // Quick-search hit inside the conversation preview: surface the message
+  // matching the most query terms as a snippet line on the card (any-term
+  // picking made a stray "to" beat the entry holding the actual phrase).
+  let previewHit = null;
+  if (ctx.query && Array.isArray(s.preview)) {
+    const terms = ctx.query.split(/\s+/).filter(Boolean);
+    let bestScore = 0;
+    for (const p of s.preview) {
+      const text = String((p && p.text) || '').toLowerCase();
+      if (!text) continue;
+      const score = terms.reduce((n, term) => n + (text.includes(term) ? 1 : 0), 0);
+      if (score > bestScore) {
+        bestScore = score;
+        previewHit = p;
+      }
+    }
+  }
   return {
     configMeta, configSource, relationshipKind, backendSource, hasExternalBackend,
-    nickname, parentId, parent, parentLabel, lineageChildren,
+    nickname, parentId, parent, parentLabel, lineageChildren, previewHit,
   };
 }
 
@@ -172,11 +189,14 @@ function sessionCardSig(m, derived, ctx) {
   const hitSig = m.logHit
     ? `${m.logHit.matches || 0}\u001e${(((m.logHit.snippets || [])[0]) || {}).content || ''}`
     : '';
+  const previewHitSig = derived.previewHit
+    ? `${derived.previewHit.role || ''}\u001e${derived.previewHit.text || ''}`
+    : '';
   return JSON.stringify(m.s) + '\u001f' + JSON.stringify([
     m.displayStatus, m.isCurrent, m.source, ctx.viewingPeer,
     derived.relationshipKind, derived.configSource, derived.backendSource,
     derived.hasExternalBackend, derived.nickname, derived.parentId,
-    derived.parentLabel, childSig, hitSig,
+    derived.parentLabel, childSig, hitSig, previewHitSig,
   ]);
 }
 
@@ -300,6 +320,7 @@ function renderSessionsList(sessions, el, options = {}) {
     hideSubagents: !!options.hideSubagents,
     viewingPeer: sessionsViewingPeer(),
     currentSessionId,
+    query: options.query || '',
     lineageIndex: buildSessionLineageIndex(sessions),
   };
 
@@ -559,6 +580,24 @@ function buildSessionCard(m, derived, ctx) {
     hitText.title = firstSnippet.content || '';
     hitEl.appendChild(hitText);
     card.appendChild(hitEl);
+  }
+
+  // Quick-search hit inside the conversation preview: one quiet snippet
+  // line showing where the match lives. Deep Search keeps the log-hit row
+  // above for full-history matches.
+  if (derived.previewHit) {
+    const prevEl = document.createElement('div');
+    prevEl.className = 'sc-preview-hit';
+    const roleEl = document.createElement('span');
+    roleEl.className = 'sc-preview-hit-role';
+    roleEl.textContent = derived.previewHit.role === 'assistant' ? 'assistant' : 'user';
+    prevEl.appendChild(roleEl);
+    const textEl = document.createElement('span');
+    textEl.className = 'sc-preview-hit-text';
+    textEl.textContent = derived.previewHit.text || '';
+    textEl.title = derived.previewHit.text || '';
+    prevEl.appendChild(textEl);
+    card.appendChild(prevEl);
   }
 
   // Meta row — the full session id (click to copy) plus compact


### PR DESCRIPTION
Second PR of the Sessions-tab program (perf batch was #59).

## What changed

- **Server**: session list rows carry a compact `preview` — the first ~2 user + ~2 assistant conversation messages, prose only, 160 chars/entry, 500-byte text cap per row. Tool calls, tool results, and command output are excluded **structurally** (builders feed only message-text events/records; a new prose-only content extractor ignores non-text blocks so a tool_result's string content can never leak). Sources: intendant session logs (task + steers + model responses), claude-code transcripts, gemini chats. Codex rollout rows are a noted follow-up (their bounded excerpt parser doesn't walk messages).
- **Fingerprint v3**: persisted intendant rows rebuild once with the new field; external row caches version via a preview-format token in their keys.
- **Client**: preview joins the memoized quick-search haystack; when the query matches conversation text, cards show a role-labelled snippet line (the entry matching the most query terms). Deep Search keeps full-history duty.

## Verified (scratch daemon, 3,488-row corpus)

- 1,096 rows carry previews (794 claude-code / 285 intendant / 17 gemini); zero cap violations; median 331 text bytes/row; unlimited list grew **+0.5 MB** (5.08 → 5.58 MB)
- Searching `unnecessary attempt to access` — a phrase existing only in one session's assistant prose — surfaces exactly the right rows, with the phrase-bearing assistant snippet on the card
- Full unit battery green (adds three preview tests: intendant event-loop collection + slot limits, byte-cap char-boundary enforcement, prose extractor tool-block exclusion; plus a claude-code fixture test covering isMeta/tool_result records)

Note: #70 also touches `56-debug-sessions.js` (different region — browser-workspace code vs search); whichever lands second regenerates `app.html` per the documented fragment-conflict recipe.