### PR TITLE
Peer-CU fleet smoke skill + e2e input-allowed leg

### DIFF
--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1044,16 +1044,16 @@ fn line_suffix(text: &str, prefix: &str) -> String {
         .to_string()
 }
 
-/// Run `intendant ctl --peer peer-e2e-b <args…>` from side A's project —
+/// Run `intendant ctl --peer <peer> <args…>` from side A's project —
 /// deliberately no `--port` and no daemon on side A: peer routing reads
 /// `[[peer]]` from the project config and dials the peer directly.
-async fn ctl_peer(rig: &TestRig, args: &[&str]) -> std::process::Output {
+async fn ctl_peer(rig: &TestRig, peer: &str, args: &[&str]) -> std::process::Output {
     let mut cmd = rig.command();
     cmd.env_remove("INTENDANT_MCP_URL")
         .env_remove("INTENDANT_PORT")
         .env_remove("INTENDANT_SESSION_ID")
         .env_remove("INTENDANT_MANAGED_CONTEXT");
-    cmd.arg("ctl").args(["--peer", "peer-e2e-b"]).args(args);
+    cmd.arg("ctl").args(["--peer", peer]).args(args);
     rig.run(cmd).await
 }
 
@@ -1071,7 +1071,11 @@ async fn ctl_peer(rig: &TestRig, args: &[&str]) -> std::process::Output {
 /// hard 403, so success cannot be an anonymous fallback. The denied call
 /// proves the same principal is refused display input, and the diagnostic
 /// must name the peer-daemon principal — a transport failure or a
-/// non-peer denial would not.
+/// non-peer denial would not. A second ceremony under `peer-operator`
+/// then completes the matrix: the swapped-in cert clears the
+/// display-input gate for the very tool the read-only principal was
+/// refused (pinned via the handler's pre-display "No actions provided"
+/// reply, so the leg holds on headless rigs).
 ///
 /// Not on Windows: the `intendant access` provisioning CLI is
 /// `#[cfg(not(target_os = "windows"))]` and `WindowsBackend::cert_dir()`
@@ -1218,7 +1222,7 @@ async fn ctl_peer_mtls_pairing_binds_scoped_profile_and_gates_display_input() {
     );
 
     // Allowed: display list is display-view, within read-only-display.
-    let allowed = ctl_peer(&rig_a, &["display", "list"]).await;
+    let allowed = ctl_peer(&rig_a, "peer-e2e-b", &["display", "list"]).await;
     let allowed_text = text_of(&allowed);
     assert!(
         allowed.status.success(),
@@ -1233,6 +1237,7 @@ async fn ctl_peer_mtls_pairing_binds_scoped_profile_and_gates_display_input() {
     // Denied: cu actions is display-input, above the profile ceiling.
     let denied = ctl_peer(
         &rig_a,
+        "peer-e2e-b",
         &["cu", "actions", "--actions", r#"[{"type":"screenshot"}]"#],
     )
     .await;
@@ -1245,6 +1250,114 @@ async fn ctl_peer_mtls_pairing_binds_scoped_profile_and_gates_display_input() {
     assert!(
         denied_text.contains("principal:peer-daemon:"),
         "denial should carry the peer-daemon principal:\n{denied_text}"
+    );
+
+    // Upgrade: a second ceremony under `peer-operator` completes the
+    // gate matrix. `peer complete` upserts keyed by card_url, so side
+    // A's single [[peer]] entry swaps in place to the operator label
+    // and cert pair — B then resolves the newly presented cert to the
+    // higher profile (both identities stay approved on B; the
+    // presented cert decides).
+    let request_op = {
+        let mut cmd = rig_a.command();
+        cmd.args([
+            "peer",
+            "request",
+            &format!("https://127.0.0.1:{port_b}"),
+            "--label",
+            "peer-e2e-a-op",
+            "--profile",
+            "peer-operator",
+        ]);
+        rig_a.run(cmd).await
+    };
+    assert!(
+        request_op.status.success(),
+        "operator peer request failed:\n{}\ndaemon B log:\n{}",
+        text_of(&request_op),
+        daemon_b.log_tail()
+    );
+    let request_op_stdout = String::from_utf8_lossy(&request_op.stdout).into_owned();
+    let request_op_id = line_suffix(&request_op_stdout, ":: request id: ");
+    let approval_op_code = line_suffix(&request_op_stdout, ":: approval code: ");
+
+    let approve_op = {
+        let mut cmd = daemon_b.rig.command();
+        cmd.args(["peer", "approve", &approval_op_code, "--profile", "peer-operator"]);
+        daemon_b.rig.run(cmd).await
+    };
+    assert!(
+        approve_op.status.success(),
+        "operator peer approve failed:\n{}",
+        text_of(&approve_op)
+    );
+
+    let complete_op = {
+        let mut cmd = rig_a.command();
+        cmd.args(["peer", "complete", &request_op_id, "--label", "peer-e2e-b-op"]);
+        rig_a.run(cmd).await
+    };
+    let complete_op_text = text_of(&complete_op);
+    assert!(
+        complete_op.status.success(),
+        "operator peer complete failed:\n{complete_op_text}"
+    );
+    assert!(
+        complete_op_text.contains(":: client cert:"),
+        "operator peer complete did not install an identity (still pending?):\n{complete_op_text}"
+    );
+    let peer_config = std::fs::read_to_string(rig_a.project.path().join("intendant.toml"))
+        .expect("read side A's intendant.toml after upgrade");
+    assert!(
+        peer_config.contains("peer-e2e-b-op"),
+        "upgrade did not relabel the [[peer]] entry:\n{peer_config}"
+    );
+    assert_eq!(
+        peer_config.matches("[[peer]]").count(),
+        1,
+        "same-card_url completion must update in place, not duplicate:\n{peer_config}"
+    );
+
+    let identities = {
+        let mut cmd = daemon_b.rig.command();
+        cmd.args(["peer", "identities"]);
+        daemon_b.rig.run(cmd).await
+    };
+    let identities_text = text_of(&identities);
+    assert!(
+        identities_text.contains("profile=peer-operator"),
+        "operator identity not recorded on B:\n{identities_text}"
+    );
+
+    // Allowed input: the same tool the read-only principal was refused
+    // now reaches its handler. `--args {"actions":[]}` deliberately
+    // bypasses ctl's client-side validation (`cu actions` rejects empty
+    // arrays locally), so the affirmative signal is the handler's own
+    // "No actions provided" — emitted before any display-target
+    // resolution, which is what makes the leg meaningful on a headless
+    // rig: the gate opened, and only the (absent) display stops it.
+    let allowed_input = ctl_peer(
+        &rig_a,
+        "peer-e2e-b-op",
+        &[
+            "tools",
+            "call",
+            "execute_cu_actions",
+            "--args",
+            r#"{"actions":[]}"#,
+        ],
+    )
+    .await;
+    let allowed_input_text = text_of(&allowed_input);
+    assert!(
+        !allowed_input_text.contains("Permission denied"),
+        "display input should be allowed under peer-operator:\n{allowed_input_text}\ndaemon B log:\n{}",
+        daemon_b.log_tail()
+    );
+    assert!(
+        allowed_input_text.contains("No actions provided"),
+        "the empty-actions probe should reach the tool handler:\n{allowed_input_text}\ndaemon B log:\n{}",
+        daemon_b.log_tail()
     );
 
     let _ = daemon_b.child.kill().await;

--- a/tests/skills/peer-cu-smoke/SKILL.md
+++ b/tests/skills/peer-cu-smoke/SKILL.md
@@ -1,0 +1,101 @@
+# Peer direct-CU fleet smoke
+
+Live proof of the direct-computer-use-on-peers path: `intendant ctl
+--peer` drives a **real federated peer box** — display inventory,
+screenshot, input injection — over the peer's `/mcp` with mTLS, with
+**no daemon running on either the operator side or locally at all**
+(the target's daemon is the peer; nothing runs here but `ctl`).
+
+The headless twin lives in CI
+(`ctl_peer_mtls_pairing_binds_scoped_profile_and_gates_display_input`
+in `tests/e2e/`): it pins the pairing ceremony and the profile gates on
+loopback rigs. This smoke covers what that can't: a real box across the
+network, a real user graphical session, standing grants that survived
+daemon restarts, and screenshots a human actually looks at.
+
+Not in CI because it needs a paired fleet peer with a live graphical
+session and persistent grants.
+
+## Prerequisites
+
+- A release controller built from **your own worktree** (never the
+  repo root): `cargo build --release`.
+- A `[[peer]]` entry for the target box, produced by the pairing
+  ceremony (`intendant peer request/approve/complete` — see
+  `docs/src/peer-federation.md`): `card_url`, `client_cert` /
+  `client_key` (absolute paths), ideally `pinned_fingerprints`.
+- On the peer, a profile grant for this daemon's identity:
+  `read-only-display` or better for the view legs,
+  `peer-operator` / `peer-root` for the input leg.
+
+## Setup — scratch-dir technique
+
+`ctl --peer` resolves the `[[peer]]` entry from the working
+directory's `intendant.toml`. Run from a scratch dir so the smoke
+never touches a live project's config and never runs from the repo
+root:
+
+```bash
+mkdir -p /tmp/peer-cu-smoke && cd /tmp/peer-cu-smoke
+# Copy the target box's [[peer]] block out of the live project's
+# intendant.toml — cert/key paths are absolute, so it ports verbatim.
+cat > intendant.toml <<'EOF'
+[[peer]]
+card_url = "https://<peer-host>:<port>/.well-known/agent-card.json"
+label = "<peer-label>"
+client_cert = "/abs/path/to/peers/<slug>/client.crt"
+client_key = "/abs/path/to/peers/<slug>/client.key"
+pinned_fingerprints = ["<sha256-hex>"]
+EOF
+# Scrub supervised-session env so ctl can't route to a local daemon:
+ctl() { env -u INTENDANT_MCP_URL -u INTENDANT_PORT \
+            -u INTENDANT_SESSION_ID -u INTENDANT_MANAGED_CONTEXT \
+        <your-worktree>/target/release/intendant ctl "$@"; }
+```
+
+## The legs
+
+```bash
+ctl --peer <peer-label> display list
+# → the peer's real monitors with geometry (e.g. "eDP-1 1920x1080")
+
+ctl --peer <peer-label> display screenshot --target user_session --output peer.png
+# → PNG of the box's live desktop. Open it and look — the pass
+#   criterion is visual, not exit-code-only.
+
+ctl --peer <peer-label> cu actions --target user_session \
+    --actions '[{"type":"move_mouse","x":400,"y":300}]'
+# Grant holds display input (peer-operator/peer-root) → ok.
+# Grant is read-only-display → non-zero exit with
+#   "Permission denied for tool 'execute_cu_actions' ...
+#    (principal principal:peer-daemon:<fingerprint>, ...)"
+# — that denial IS the pass for the deny leg; run whichever
+# matches the standing grant, or both against two peers.
+```
+
+## What it proves
+
+- The `[[peer]]` mTLS identity + pinned fingerprints carry a one-shot
+  JSON-RPC `tools/call` to the peer's `/mcp` — no local daemon, no
+  WebRTC, no card-advertised auth fallback.
+- `display list` reflects the peer's real hardware.
+- `user_session` screenshots show the live desktop, and the image
+  content survives the whole MCP → ctl → PNG path.
+- Input is gated by the **peer-granted profile**, and the denial
+  diagnostic names the peer-daemon principal.
+- Peer-side diagnostics travel verbatim; `ctl` exits non-zero when the
+  tool reply is an error.
+
+## Traps
+
+- **Always pass `--target user_session`.** Omitting the target
+  auto-detects the `:99` virtual-display convention; a box whose only
+  session is `:0` fails with "cannot connect to X display :99".
+- A denial means the peer's owner has not granted the capability —
+  report it, don't retry or work around it.
+- `--peer` resolves by label (case-insensitive), `card_url` host,
+  exact `card_url`, or `intendant:<label>`.
+- `client_cert` / `client_key` must come together — a half-set pair
+  errors loudly rather than silently falling back.
+- Failures arrive as the peer's own diagnostic text; if it's opaque,
+  the next stop is the peer box's daemon log, not this side.


### PR DESCRIPTION
Two follow-ups closing out the agentic-peer-control gate matrix:

- **tests/skills/peer-cu-smoke/SKILL.md** — live fleet validation guide for direct CU on a federated peer over /mcp mTLS from a daemon-less `ctl --peer`: scratch-dir `[[peer]]` setup, supervised-env scrub, the `:99` auto-detect trap (`--target user_session`), and deny-as-pass semantics for the input leg. Complements the headless pairing e2e in CI.
- **e2e input-allowed leg** — the mTLS pairing test now runs a second ceremony under `peer-operator`: `peer complete` upserts the `[[peer]]` entry keyed by card_url (in-place relabel + cert swap, no duplicate — pinned), and the upgraded principal clears the display-input gate for the very tool the read-only principal was refused. The probe sends an empty actions array via `ctl tools call`, so the handler's pre-display "No actions provided" reply is a headless-safe affirmative signal on all CI platforms.

Battery: full e2e suite 6/6 (extended test 12.1s, inside its 120s nextest override); zero clippy findings in changed files.