### PR TITLE
CU: availability-aware default display target

### DIFF
--- a/crates/intendant-platform/src/vision.rs
+++ b/crates/intendant-platform/src/vision.rs
@@ -191,6 +191,22 @@ fn find_free_display() -> u32 {
     0
 }
 
+/// The conventional agent virtual display (`:99`) when an X server is
+/// listening for it, judged by its socket in `/tmp/.X11-unix`. Callers
+/// use this to resolve the *default* computer-use display target on
+/// hosts with no registered capture session; explicit targets never
+/// consult it. Always `None` off Linux — virtual displays are Xvfb.
+pub fn conventional_virtual_display() -> Option<u32> {
+    #[cfg(target_os = "linux")]
+    {
+        let socket = format!("/tmp/.X11-unix/X{}", PREFERRED_DISPLAY);
+        if std::path::Path::new(&socket).exists() {
+            return Some(PREFERRED_DISPLAY);
+        }
+    }
+    None
+}
+
 // ── Xvfb guard ──────────────────────────────────────────────────────────────
 
 /// Guard that kills the Xvfb process when dropped.

--- a/docs/src/computer-use-and-audio.md
+++ b/docs/src/computer-use-and-audio.md
@@ -112,6 +112,19 @@ CU actions operate on a `DisplayTarget` (`#[serde(tag = "kind")]`):
   doesn't use `DISPLAY`. Requires an explicit `DisplayControl` grant via the
   autonomy system.
 
+When a pixel-CU call (`take_screenshot`, `execute_cu_actions`) omits
+`display_target`, the default is availability-aware
+(`computer_use::default_display_target`): the lowest-id live virtual capture
+session wins, then the conventional agent Xvfb display (`:99`) when its X
+socket is up (Linux only), then the user session. Explicit targets are never
+second-guessed, and every downstream gate applies to the fallback exactly as
+it would to an explicit `user_session` request. The native agent loop uses the
+same resolution when a session has no CU display configured, except its
+user-session fallback additionally requires the user-display grant — the
+model-driven path never auto-targets the user's desktop ungranted.
+(`read_screen` defaults to the user session unconditionally — element trees
+only exist there.)
+
 User-session access uses a **session-grant** model: approve once (the `d` hotkey
 the dashboard control, MCP `grant_user_display`, or
 `intendant ctl display grant-user`), and the grant holds for the rest of the

--- a/src/bin/caller/computer_use.rs
+++ b/src/bin/caller/computer_use.rs
@@ -1707,6 +1707,47 @@ async fn lookup_display_session(
     registry.read().await.get(display_id)
 }
 
+/// Pick the display target for CU calls that omit `display_target`.
+///
+/// Preference order: the lowest-id live virtual-display capture session,
+/// then the conventional agent Xvfb display when its X socket is up
+/// (Linux only), then the user's session display. The old default was a
+/// blind `Virtual { id: 99 }`, which turned "omit the target" into a
+/// hard error on hosts that never started a virtual display — a machine
+/// whose only session is `:0`, or Windows, where virtual displays don't
+/// exist at all. The user-session fallback grants nothing new: the same
+/// caller could always pass `display_target="user_session"` explicitly,
+/// and every downstream gate (per-tool IAM, the user-display grant on
+/// the session-only backends) applies to the fallback identically.
+pub async fn default_display_target(
+    session_registry: &Option<crate::display::SharedSessionRegistry>,
+) -> DisplayTarget {
+    let session_display_ids = match session_registry.as_ref() {
+        Some(registry) => registry.read().await.display_ids(),
+        None => Vec::new(),
+    };
+    choose_default_display_target(
+        session_display_ids,
+        intendant_platform::vision::conventional_virtual_display(),
+    )
+}
+
+/// Registry/probe-injectable core of [`default_display_target`].
+fn choose_default_display_target(
+    session_display_ids: Vec<u32>,
+    conventional_virtual: Option<u32>,
+) -> DisplayTarget {
+    // Display id 0 is the user-session capture session, not a virtual
+    // display — never let it masquerade as `Virtual { id: 0 }`.
+    if let Some(id) = session_display_ids.into_iter().filter(|id| *id != 0).min() {
+        return DisplayTarget::Virtual { id };
+    }
+    if let Some(id) = conventional_virtual {
+        return DisplayTarget::Virtual { id };
+    }
+    DisplayTarget::UserSession
+}
+
 /// Execute CU actions by routing through a `DisplaySession` (WebRTC pipeline).
 ///
 /// Converts CU pixel coordinates to normalised 0.0..1.0 coordinates expected by
@@ -2959,6 +3000,44 @@ mod tests {
     fn display_target_display_fmt() {
         assert_eq!(format!("{}", DisplayTarget::Virtual { id: 99 }), ":99");
         assert_eq!(format!("{}", DisplayTarget::UserSession), "user_session");
+    }
+
+    #[test]
+    fn default_target_prefers_lowest_live_virtual_session() {
+        assert_eq!(
+            choose_default_display_target(vec![0, 120, 100], None),
+            DisplayTarget::Virtual { id: 100 }
+        );
+        // A live session beats the conventional-socket probe.
+        assert_eq!(
+            choose_default_display_target(vec![101], Some(99)),
+            DisplayTarget::Virtual { id: 101 }
+        );
+    }
+
+    #[test]
+    fn default_target_uses_conventional_socket_without_sessions() {
+        assert_eq!(
+            choose_default_display_target(vec![], Some(99)),
+            DisplayTarget::Virtual { id: 99 }
+        );
+        // The user-session capture session (id 0) is not a virtual display.
+        assert_eq!(
+            choose_default_display_target(vec![0], Some(99)),
+            DisplayTarget::Virtual { id: 99 }
+        );
+    }
+
+    #[test]
+    fn default_target_falls_back_to_user_session() {
+        assert_eq!(
+            choose_default_display_target(vec![], None),
+            DisplayTarget::UserSession
+        );
+        assert_eq!(
+            choose_default_display_target(vec![0], None),
+            DisplayTarget::UserSession
+        );
     }
 
     #[test]

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -1940,7 +1940,8 @@ fn help_display() {
 fn help_display_screenshot() {
     println!(
         "Usage: intendant ctl display screenshot [--target TARGET] [--output out.png]\n\
-Targets include user_session, display_99, 99, and legacy :99."
+Targets include user_session, display_99, 99, and legacy :99.\n\
+Omit --target to auto-detect: a live agent virtual display when one exists, else the user session."
     );
 }
 
@@ -1995,7 +1996,8 @@ fn help_cu() {
 Run `intendant ctl cu actions --help` for the action JSON shapes.\n\
 `cu elements` reads the frontmost app's UI element tree (roles, labels, values, frames) — \n\
 cheap textual grounding: click the center of a reported frame. macOS user-session only for now.\n\
-Targets: user_session (needs display grant), 99/display_99 (virtual). Omit to auto-detect."
+Targets: user_session (needs display grant), 99/display_99 (virtual).\n\
+Omit to auto-detect: a live agent virtual display when one exists, else the user session."
     );
 }
 

--- a/src/bin/caller/display_glue.rs
+++ b/src/bin/caller/display_glue.rs
@@ -1450,8 +1450,17 @@ pub(crate) async fn execute_cu_calls(
     let display_target = if cu_display.is_some() {
         resolve_cu_display_target(user_display_granted)
     } else {
-        // No CU display configured — default to virtual :99
-        computer_use::DisplayTarget::Virtual { id: 99 }
+        // No CU display configured — resolve availability-aware, but
+        // never auto-target the user's desktop from the model-driven
+        // loop without the user-display grant (the same gating as
+        // resolve_cu_display_target above): ungranted, keep the
+        // conventional virtual display, whose failure is actionable.
+        match computer_use::default_display_target(&session_registry).await {
+            computer_use::DisplayTarget::UserSession if !user_display_granted => {
+                computer_use::DisplayTarget::Virtual { id: 99 }
+            }
+            target => target,
+        }
     };
 
     for cu_call in cu_calls {

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -1492,26 +1492,26 @@ const FISSION_WAIT_MAX_TIMEOUT_S: u64 = 300;
 /// group on the operator's behalf.
 const FISSION_CONTROL_DETACH_REASON: &str = "operator detach via fission_control";
 
-fn resolve_display_target(target: Option<&str>) -> crate::computer_use::DisplayTarget {
+/// Parse an explicit display-target spec. Callers resolve an *omitted*
+/// spec with [`crate::computer_use::default_display_target`], which is
+/// availability-aware, instead of assuming a virtual display exists.
+fn resolve_display_target(target: &str) -> crate::computer_use::DisplayTarget {
     use crate::computer_use::DisplayTarget;
     match target {
-        Some("user_session") | Some("user") | Some("primary") | Some(":0") | Some("0")
-        | Some("display_0") => DisplayTarget::UserSession,
-        Some(s) if s.starts_with(':') => {
+        "user_session" | "user" | "primary" | ":0" | "0" | "display_0" => {
+            DisplayTarget::UserSession
+        }
+        s if s.starts_with(':') => {
             let id: u32 = s[1..].parse().unwrap_or(99);
             DisplayTarget::Virtual { id }
         }
-        Some(s) if s.starts_with("display_") => {
+        s if s.starts_with("display_") => {
             let id: u32 = s["display_".len()..].parse().unwrap_or(99);
             DisplayTarget::Virtual { id }
         }
-        Some(s) => {
+        s => {
             let id: u32 = s.parse().unwrap_or(99);
             DisplayTarget::Virtual { id }
-        }
-        None => {
-            // Default: first virtual display
-            DisplayTarget::Virtual { id: 99 }
         }
     }
 }

--- a/src/bin/caller/mcp/tool_params.rs
+++ b/src/bin/caller/mcp/tool_params.rs
@@ -372,7 +372,9 @@ pub(crate) fn default_timeout() -> u64 {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct TakeScreenshotParams {
-    /// Display target: "user_session", "display_99", etc. Auto-detects if omitted.
+    /// Display target: "user_session", "display_99", etc. Auto-detects if
+    /// omitted: a live agent virtual display when one exists, else the
+    /// user session.
     #[serde(default)]
     pub display_target: Option<String>,
 }
@@ -444,7 +446,8 @@ pub struct ExecuteCuActionsParams {
     /// with "type" (click, double_click, type, key, scroll, move_mouse, drag,
     /// screenshot, wait) and type-specific fields.
     pub actions: Vec<crate::computer_use::CuAction>,
-    /// Display target. Auto-detects if omitted.
+    /// Display target. Auto-detects if omitted: a live agent virtual
+    /// display when one exists, else the user session.
     #[serde(default)]
     pub display_target: Option<String>,
     /// Coordinate space for click/scroll/move coordinates. Default: "pixel"

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -516,12 +516,6 @@ impl IntendantServer {
         #[cfg(target_os = "linux")]
         crate::linux_display_env::ensure_gui_session_env("mcp take_screenshot");
 
-        let target = resolve_display_target(params.display_target.as_deref());
-        let backend = DisplayBackend::detect();
-        let activation_request = self
-            .ensure_wayland_user_session_display_activation(target, backend)
-            .await;
-
         let state = self.state.read().await;
         let screenshot_dir = state
             .screenshot_dir
@@ -530,6 +524,15 @@ impl IntendantServer {
         let session_registry = state.session_registry.clone();
         let autonomy = state.autonomy.clone();
         drop(state);
+
+        let target = match params.display_target.as_deref() {
+            Some(spec) => resolve_display_target(spec),
+            None => crate::computer_use::default_display_target(&session_registry).await,
+        };
+        let backend = DisplayBackend::detect();
+        let activation_request = self
+            .ensure_wayland_user_session_display_activation(target, backend)
+            .await;
         // Read after the Wayland activation above, which may have flipped
         // the grant on the guard.
         let user_display_granted = autonomy.read().await.user_display_granted;
@@ -594,11 +597,12 @@ impl IntendantServer {
         &self,
         Parameters(params): Parameters<ReadScreenParams>,
     ) -> Result<CallToolResult, McpError> {
-        // Element trees only exist for the real session; default there rather
-        // than to a virtual display like the pixel tools do.
+        // Element trees only exist for the real session; default there
+        // unconditionally rather than availability-probing like the pixel
+        // tools do.
         let target = match params.display_target.as_deref() {
             None => crate::computer_use::DisplayTarget::UserSession,
-            some => resolve_display_target(some),
+            Some(spec) => resolve_display_target(spec),
         };
         match crate::computer_use::read_screen_elements(target).await {
             Ok(snapshot) => {
@@ -641,12 +645,6 @@ impl IntendantServer {
             return Ok(text_tool_error("No actions provided"));
         }
 
-        let target = resolve_display_target(params.display_target.as_deref());
-        let backend = DisplayBackend::detect();
-        let activation_request = self
-            .ensure_wayland_user_session_display_activation(target, backend)
-            .await;
-
         let state = self.state.read().await;
         let screenshot_dir = state
             .screenshot_dir
@@ -655,6 +653,15 @@ impl IntendantServer {
         let session_registry = state.session_registry.clone();
         let autonomy = state.autonomy.clone();
         drop(state);
+
+        let target = match params.display_target.as_deref() {
+            Some(spec) => resolve_display_target(spec),
+            None => crate::computer_use::default_display_target(&session_registry).await,
+        };
+        let backend = DisplayBackend::detect();
+        let activation_request = self
+            .ensure_wayland_user_session_display_activation(target, backend)
+            .await;
         // Read after the Wayland activation above, which may have flipped
         // the grant on the guard.
         let user_display_granted = autonomy.read().await.user_display_granted;

--- a/src/bin/caller/peer/access_request.rs
+++ b/src/bin/caller/peer/access_request.rs
@@ -618,7 +618,12 @@ fn request_id_for(request: &AccessRequestCreate, server_cert_fingerprint: &str) 
     hasher.update(b"\0");
     hasher.update(server_cert_fingerprint.as_bytes());
     let digest = hasher.finalize();
-    URL_SAFE_NO_PAD.encode(&digest[..18])
+    // The 'r' prefix keeps the id from ever starting with base64url's
+    // '-', which argv parsers (this CLI's `peer complete <id>` included)
+    // read as a flag. Ids are opaque: minted here once, carried on the
+    // wire and in store paths, never decoded — old unprefixed ids stay
+    // valid, and the CLI additionally tolerates their leading dash.
+    format!("r{}", URL_SAFE_NO_PAD.encode(&digest[..18]))
 }
 
 fn verification_code_for(
@@ -945,6 +950,37 @@ mod tests {
         };
 
         assert_eq!(effective_body_limit_bytes(&config), 1);
+    }
+
+    #[test]
+    fn minted_request_ids_are_flag_safe() {
+        let certs = tempfile::TempDir::new().unwrap();
+        setup_certs(certs.path());
+        let key = access::certs::generate_client_key_material().unwrap();
+        let request = AccessRequestCreate {
+            version: 1,
+            requester_label: "primary".into(),
+            public_key_pem: key.public_key_pem,
+            nonce: "0123456789abcdef".into(),
+            requested_profile: None,
+            requester_card_url: None,
+        };
+        let created = create_pending_request(
+            certs.path(),
+            request,
+            "https://target/.well-known/agent-card.json".into(),
+            Some("127.0.0.1".into()),
+            &PeerAccessRequestConfig::default(),
+        )
+        .unwrap();
+        // The id rides argv in `peer complete <id>`: a leading '-' reads
+        // as a flag. The 'r' prefix pins the invariant structurally.
+        assert!(
+            created.request_id.starts_with('r'),
+            "id not flag-safe: {}",
+            created.request_id
+        );
+        assert!(validate_request_id(&created.request_id).is_ok());
     }
 
     #[test]

--- a/src/bin/caller/peer/pairing.rs
+++ b/src/bin/caller/peer/pairing.rs
@@ -194,60 +194,90 @@ fn parse_args(argv: &[String]) -> Result<PeerArgs, CallerError> {
                 args.action = PeerAction::Help;
                 return Ok(args);
             }
-            other if other.starts_with('-') => {
+            "--" => {
+                // Standard end-of-flags separator: everything after is
+                // positional, however it starts.
+                for rest in iter.by_ref() {
+                    take_positional(&mut args, rest)?;
+                }
+            }
+            other if other.starts_with("--") => {
                 return Err(CallerError::Config(format!("unknown peer flag '{other}'")));
             }
-            other => match args.action {
-                PeerAction::Join if args.invite.is_none() => {
-                    args.invite = Some(other.to_string());
+            other if other.starts_with('-') => {
+                // Request ids are opaque tokens; historically base64url,
+                // where 1 in 64 starts with '-'. When the action still
+                // expects its positional code/id, a single-dash token is
+                // that value, not a flag typo.
+                if expects_code_or_id(&args) {
+                    take_positional(&mut args, other)?;
+                } else {
+                    return Err(CallerError::Config(format!("unknown peer flag '{other}'")));
                 }
-                PeerAction::Request if args.target_url.is_none() => {
-                    args.target_url = Some(other.to_string());
-                }
-                PeerAction::Approve
-                | PeerAction::Deny
-                | PeerAction::Complete
-                | PeerAction::Revoke
-                    if args.code_or_id.is_none() =>
-                {
-                    args.code_or_id = Some(other.to_string());
-                }
-                PeerAction::Invite => {
-                    return Err(CallerError::Config(format!(
-                        "unexpected argument '{other}' for `intendant peer invite`"
-                    )));
-                }
-                PeerAction::Join => {
-                    return Err(CallerError::Config(format!(
-                        "unexpected extra invite argument '{other}'"
-                    )));
-                }
-                PeerAction::Request => {
-                    return Err(CallerError::Config(format!(
-                        "unexpected extra target argument '{other}'"
-                    )));
-                }
-                PeerAction::Approve | PeerAction::Deny | PeerAction::Complete => {
-                    return Err(CallerError::Config(format!(
-                        "unexpected extra request argument '{other}'"
-                    )));
-                }
-                PeerAction::Revoke => {
-                    return Err(CallerError::Config(format!(
-                        "unexpected extra identity argument '{other}'"
-                    )));
-                }
-                PeerAction::Requests | PeerAction::Identities => {
-                    return Err(CallerError::Config(format!(
-                        "unexpected argument '{other}' for this peer subcommand"
-                    )));
-                }
-                PeerAction::Help => {}
-            },
+            }
+            other => take_positional(&mut args, other)?,
         }
     }
 
     Ok(args)
+}
+
+/// Whether the parsed action takes a positional code/id that is still
+/// unfilled.
+fn expects_code_or_id(args: &PeerArgs) -> bool {
+    matches!(
+        args.action,
+        PeerAction::Approve | PeerAction::Deny | PeerAction::Complete | PeerAction::Revoke
+    ) && args.code_or_id.is_none()
+}
+
+/// Assign a positional argument according to the action's grammar.
+fn take_positional(args: &mut PeerArgs, other: &str) -> Result<(), CallerError> {
+    match args.action {
+        PeerAction::Join if args.invite.is_none() => {
+            args.invite = Some(other.to_string());
+        }
+        PeerAction::Request if args.target_url.is_none() => {
+            args.target_url = Some(other.to_string());
+        }
+        PeerAction::Approve | PeerAction::Deny | PeerAction::Complete | PeerAction::Revoke
+            if args.code_or_id.is_none() =>
+        {
+            args.code_or_id = Some(other.to_string());
+        }
+        PeerAction::Invite => {
+            return Err(CallerError::Config(format!(
+                "unexpected argument '{other}' for `intendant peer invite`"
+            )));
+        }
+        PeerAction::Join => {
+            return Err(CallerError::Config(format!(
+                "unexpected extra invite argument '{other}'"
+            )));
+        }
+        PeerAction::Request => {
+            return Err(CallerError::Config(format!(
+                "unexpected extra target argument '{other}'"
+            )));
+        }
+        PeerAction::Approve | PeerAction::Deny | PeerAction::Complete => {
+            return Err(CallerError::Config(format!(
+                "unexpected extra request argument '{other}'"
+            )));
+        }
+        PeerAction::Revoke => {
+            return Err(CallerError::Config(format!(
+                "unexpected extra identity argument '{other}'"
+            )));
+        }
+        PeerAction::Requests | PeerAction::Identities => {
+            return Err(CallerError::Config(format!(
+                "unexpected argument '{other}' for this peer subcommand"
+            )));
+        }
+        PeerAction::Help => {}
+    }
+    Ok(())
 }
 
 fn print_help() {
@@ -828,6 +858,47 @@ mod tests {
         let encoded = encode_invite(&original).unwrap();
         assert!(encoded.starts_with(INVITE_PREFIX));
         assert_eq!(decode_invite(&encoded).unwrap(), original);
+    }
+
+    fn argv(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn complete_accepts_dash_leading_request_id() {
+        // Historical request ids are raw base64url: 1 in 64 starts with
+        // '-' and used to die here as "unknown peer flag" (the 2026-07-08
+        // merge-queue ejection).
+        let args = parse_args(&argv(&[
+            "complete",
+            "-vyeJaE3hyqm4J45K5j_sVTX",
+            "--label",
+            "peer-b",
+        ]))
+        .expect("dash-leading id is the positional, not a flag");
+        assert!(matches!(args.action, PeerAction::Complete));
+        assert_eq!(args.code_or_id.as_deref(), Some("-vyeJaE3hyqm4J45K5j_sVTX"));
+        assert_eq!(args.label.as_deref(), Some("peer-b"));
+    }
+
+    #[test]
+    fn double_dash_separator_forces_positionals() {
+        let args = parse_args(&argv(&["revoke", "--", "--looks-like-a-flag"]))
+            .expect("everything after -- is positional");
+        assert!(matches!(args.action, PeerAction::Revoke));
+        assert_eq!(args.code_or_id.as_deref(), Some("--looks-like-a-flag"));
+    }
+
+    #[test]
+    fn unknown_double_dash_flag_still_errors() {
+        let err = parse_args(&argv(&["complete", "--profle", "x"])).unwrap_err();
+        assert!(err.to_string().contains("unknown peer flag '--profle'"));
+    }
+
+    #[test]
+    fn dash_token_after_filled_positional_still_errors() {
+        let err = parse_args(&argv(&["complete", "req-1", "-extra"])).unwrap_err();
+        assert!(err.to_string().contains("unknown peer flag '-extra'"));
     }
 
     #[test]

--- a/tests/skills/peer-cu-smoke/SKILL.md
+++ b/tests/skills/peer-cu-smoke/SKILL.md
@@ -88,9 +88,14 @@ ctl --peer <peer-label> cu actions --target user_session \
 
 ## Traps
 
-- **Always pass `--target user_session`.** Omitting the target
-  auto-detects the `:99` virtual-display convention; a box whose only
-  session is `:0` fails with "cannot connect to X display :99".
+- **Pass `--target user_session` explicitly.** Current daemons
+  auto-detect an omitted target availability-aware (a live virtual
+  display when one exists, else the user session), but the explicit
+  flag is deterministic: on a peer running an older daemon, an omitted
+  target blindly assumes `:99` and a box whose only session is `:0`
+  fails with "cannot connect to X display :99" — and on a box that
+  *does* have an agent virtual display, the omitted form captures that
+  display, not the desktop this smoke wants to look at.
 - A denial means the peer's owner has not granted the capability —
   report it, don't retry or work around it.
 - `--peer` resolves by label (case-insensitive), `card_url` host,


### PR DESCRIPTION
Omitting `display_target` used to blind-default to `Virtual{99}`, which turned the omitted form into a hard error on hosts that never started a virtual display (a box whose only session is `:0`, or Windows, where virtual displays don't exist) and into a mislabeled main-display capture on macOS.

The default now resolves availability-aware (`computer_use::default_display_target`): the lowest-id live virtual capture session, else the conventional agent Xvfb display when its X socket is up (`vision::conventional_virtual_display`, derived from `PREFERRED_DISPLAY`, Linux only), else the user session.

- **No new authority**: the fallback reaches only what an explicit `display_target=user_session` could always reach, through the same IAM/grant gates.
- **Native loop**: the no-CU-display branch uses the same resolution but keeps its user-session fallback behind the user-display grant — the model-driven path never auto-targets the user's desktop ungranted.
- `read_screen` keeps its unconditional user-session default; `resolve_display_target` now parses explicit specs only.
- Docs updated: CU chapter, tool param schemas, ctl help, peer-cu-smoke skill (explicit `--target` stays the recommendation there — deterministic across fleet daemon versions).

Battery: 4 new unit tests on the pure chooser; `cargo test --bins`; all 6 e2e; clippy clean in changed files.