### PR TITLE
Display viewers deregister on teardown; pre-slot capture failures surface in the UI

### DIFF
--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -1083,6 +1083,35 @@ async fn tile_subscriber_peer_handles(
         .collect()
 }
 
+/// Core of the per-peer reaper (see [`DisplaySession::spawn_peer_reaper`]):
+/// remove `peer_id`'s registration — but only while the map still holds
+/// **this** peer (`Arc::ptr_eq`), so a reaper firing late for a replaced
+/// peer leaves its successor untouched, and a peer already removed by
+/// `remove_peer` is not double-decremented. Returns whether it removed.
+async fn reap_peer_registration(
+    peers: &Arc<RwLock<HashMap<PeerId, Arc<webrtc::WebRtcPeer>>>>,
+    tile_subscribers: &Arc<RwLock<HashSet<PeerId>>>,
+    counters: &Arc<DisplayMetricsCounters>,
+    peer_id: PeerId,
+    peer: &Arc<webrtc::WebRtcPeer>,
+) -> bool {
+    let removed = {
+        let mut guard = peers.write().await;
+        match guard.get(&peer_id) {
+            Some(current) if Arc::ptr_eq(current, peer) => {
+                guard.remove(&peer_id);
+                true
+            }
+            _ => false,
+        }
+    };
+    if removed {
+        tile_subscribers.write().await.remove(&peer_id);
+        counters.peer_count.fetch_sub(1, Ordering::Relaxed);
+    }
+    removed
+}
+
 impl DisplaySession {
     /// Create a new display session.  Does NOT start capture -- call `start()`.
     pub fn new(display_id: u32, backend: Arc<dyn DisplayBackend>) -> Self {
@@ -2051,6 +2080,7 @@ impl DisplaySession {
                 self.counters.peer_count.fetch_add(1, Ordering::Relaxed);
             }
         }
+        self.spawn_peer_reaper(peer_id, &peer);
 
         self.ensure_clipboard_forwarding().await;
 
@@ -2839,6 +2869,28 @@ impl DisplaySession {
         }
     }
 
+    /// Deregister the peer from the session maps when its driver tears
+    /// down. `remove_peer` only covers gateway-WS-signaled viewers (the
+    /// WS teardown path is its sole caller) — peers signaled over the
+    /// dashboard-control channel (hosted Connect) or torn down by ICE
+    /// failure had no deregistration path at all, leaving `peer_count`
+    /// and the presence policy's peer map stale, so the layer-pause idle
+    /// policy never engaged (observed live: `peers=1` forever on a cloud
+    /// box after its only viewer left). Identity-guarded (`Arc::ptr_eq`)
+    /// so a replaced peer's reaper cannot remove its successor under the
+    /// same id, and idempotent alongside `remove_peer`.
+    fn spawn_peer_reaper(&self, peer_id: PeerId, peer: &Arc<self::webrtc::WebRtcPeer>) {
+        let peers = Arc::clone(&self.peers);
+        let tile_subscribers = Arc::clone(&self.tile_subscribers);
+        let counters = Arc::clone(&self.counters);
+        let peer = Arc::clone(peer);
+        let closed = peer.closed();
+        tokio::spawn(async move {
+            closed.await;
+            reap_peer_registration(&peers, &tile_subscribers, &counters, peer_id, &peer).await;
+        });
+    }
+
     /// F-1.3b3: fetch a clone of the per-peer
     /// [`self::webrtc::WebRtcPeer`] handle for gateway-side wiring
     /// after [`Self::handle_offer`]. Returns `None` if the peer has
@@ -3000,6 +3052,55 @@ pub(crate) fn gated_input_handler(
 mod tests {
     use super::*;
     use std::sync::atomic::AtomicBool;
+
+    fn reaper_fixture(
+        peer_id: PeerId,
+    ) -> (
+        Arc<RwLock<HashMap<PeerId, Arc<webrtc::WebRtcPeer>>>>,
+        Arc<RwLock<HashSet<PeerId>>>,
+        Arc<DisplayMetricsCounters>,
+        Arc<webrtc::WebRtcPeer>,
+    ) {
+        let peer = Arc::new(webrtc::WebRtcPeer::new_for_test(peer_id, Vec::new()));
+        let peers = Arc::new(RwLock::new(HashMap::from([(peer_id, Arc::clone(&peer))])));
+        let tile_subscribers = Arc::new(RwLock::new(HashSet::from([peer_id])));
+        let counters = Arc::new(DisplayMetricsCounters::new());
+        counters.peer_count.store(1, Ordering::Relaxed);
+        (peers, tile_subscribers, counters, peer)
+    }
+
+    #[tokio::test]
+    async fn reap_removes_the_registered_peer_and_decrements_the_gauge() {
+        let (peers, subs, counters, peer) = reaper_fixture(7);
+        assert!(reap_peer_registration(&peers, &subs, &counters, 7, &peer).await);
+        assert!(peers.read().await.is_empty());
+        assert!(subs.read().await.is_empty());
+        assert_eq!(counters.peer_count.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn reap_leaves_a_replacement_peer_registered_under_the_same_id() {
+        let (peers, subs, counters, old_peer) = reaper_fixture(7);
+        let replacement = Arc::new(webrtc::WebRtcPeer::new_for_test(7, Vec::new()));
+        peers.write().await.insert(7, Arc::clone(&replacement));
+        assert!(!reap_peer_registration(&peers, &subs, &counters, 7, &old_peer).await);
+        assert!(Arc::ptr_eq(
+            peers.read().await.get(&7).expect("replacement stays"),
+            &replacement
+        ));
+        assert!(subs.read().await.contains(&7));
+        assert_eq!(counters.peer_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn reap_is_a_no_op_after_remove_peer_already_deregistered() {
+        let (peers, subs, counters, peer) = reaper_fixture(7);
+        peers.write().await.remove(&7);
+        subs.write().await.remove(&7);
+        counters.peer_count.store(0, Ordering::Relaxed);
+        assert!(!reap_peer_registration(&peers, &subs, &counters, 7, &peer).await);
+        assert_eq!(counters.peer_count.load(Ordering::Relaxed), 0);
+    }
 
     #[test]
     fn tile_damage_uses_xdamage_only_for_x11_backend() {

--- a/crates/intendant-display/src/webrtc.rs
+++ b/crates/intendant-display/src/webrtc.rs
@@ -3276,6 +3276,15 @@ impl WebRtcPeer {
         self.shutdown.cancel();
         // Driver exits on the next select! iteration; channels close on drop.
     }
+
+    /// Resolves once this peer has begun teardown — the driver cancels the
+    /// token on exit (ICE failure, drain error), `close()` cancels it for
+    /// external teardown, and the pool intake task cancels it when the peer
+    /// can no longer be served. The session's per-peer reaper keys on this
+    /// to deregister the peer from the session maps.
+    pub(crate) fn closed(&self) -> tokio_util::sync::WaitForCancellationFutureOwned {
+        self.shutdown.clone().cancelled_owned()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/static/app.html
+++ b/static/app.html
@@ -27377,11 +27377,24 @@ async function main() {
       // Handle display capture lost — disconnect but keep slot for possible re-grant
       if (d.event === 'display_capture_lost') {
         const id = Number(d.display_id || 0);
+        const reason = d.reason || 'capture ended';
         const slot = displaySlots.get(id);
         if (slot) {
           slot.disconnect();
-          slot.statusEl.textContent = 'Display lost: ' + (d.reason || 'capture ended');
+          slot.statusEl.textContent = 'Display lost: ' + reason;
           slot.statusEl.className = 'display-status error';
+        } else {
+          // Capture died before any slot existed — a grant that failed
+          // immediately, e.g. "Your display" on a headless box with no
+          // display server. Without this branch the failure is invisible:
+          // the toggle stays on and no tile ever appears (the daemon-side
+          // reason lands only in its journal).
+          if (Number(grantedDisplayId) === id && typeof setUserDisplayState === 'function') {
+            setUserDisplayState(false);
+          }
+          if (typeof showControlToast === 'function') {
+            showControlToast('error', 'Display unavailable: ' + reason);
+          }
         }
         // Hide the approval banner — capture lost supersedes any pending grant.
         const banner = document.getElementById('display-approval-banner');

--- a/static/app/36-voice-wasm-init.js
+++ b/static/app/36-voice-wasm-init.js
@@ -611,11 +611,24 @@ async function main() {
       // Handle display capture lost — disconnect but keep slot for possible re-grant
       if (d.event === 'display_capture_lost') {
         const id = Number(d.display_id || 0);
+        const reason = d.reason || 'capture ended';
         const slot = displaySlots.get(id);
         if (slot) {
           slot.disconnect();
-          slot.statusEl.textContent = 'Display lost: ' + (d.reason || 'capture ended');
+          slot.statusEl.textContent = 'Display lost: ' + reason;
           slot.statusEl.className = 'display-status error';
+        } else {
+          // Capture died before any slot existed — a grant that failed
+          // immediately, e.g. "Your display" on a headless box with no
+          // display server. Without this branch the failure is invisible:
+          // the toggle stays on and no tile ever appears (the daemon-side
+          // reason lands only in its journal).
+          if (Number(grantedDisplayId) === id && typeof setUserDisplayState === 'function') {
+            setUserDisplayState(false);
+          }
+          if (typeof showControlToast === 'function') {
+            showControlToast('error', 'Display unavailable: ' + reason);
+          }
         }
         // Hide the approval banner — capture lost supersedes any pending grant.
         const banner = document.getElementById('display-approval-banner');


### PR DESCRIPTION
Two follow-ups from the hosted-Connect live E2E (tasks #15/#16), both observed on a real cloud box.

**Stale peer registrations (the peers=1-forever bug).** `remove_peer`'s only caller is the gateway-WS teardown path — viewers signaled over the dashboard-control channel (hosted Connect has no per-display WebSocket) or torn down by ICE failure were never deregistered, so the peers map and `peer_count` gauge stayed stale and the presence policy's zero-peers layer-pausing never engaged. Every registration now spawns a per-peer reaper keyed on the peer's own teardown token, with an identity-guarded (`Arc::ptr_eq`) idempotent removal core so a replaced peer's late reaper can't remove its successor and a WS-teardown removal isn't double-decremented. Three unit tests pin those semantics. Capture and the always-on baseline encoder deliberately keep running with zero viewers (computer-use screenshots, recording, and snapshot serving read the same frames).

**Silent blank tile on headless boxes.** The `display_capture_lost` event pipeline existed end to end, but the frontend handler only annotated an existing display slot — a grant that fails immediately (enabling "Your display" on a box with no display server) dies before any slot exists, so the toggle stayed on and nothing was shown while the reason landed only in the daemon journal. The no-slot branch now resets the toggle and raises an error toast carrying the daemon's reason.

Verified: 2618 unit tests + 3 new reaper tests, clippy clean on touched code, app.html regenerated from fragments.