### PR TITLE
E2E retro batch: deploy-time proxy probe, honest status-bar provider, encoder cleanup

### DIFF
--- a/crates/intendant-display/src/encode/h264_linux.rs
+++ b/crates/intendant-display/src/encode/h264_linux.rs
@@ -86,8 +86,6 @@ struct Nal {
 /// frame starts whenever `first_mb_in_slice == 0`.
 pub struct FfmpegH264Encoder {
     child: Child,
-    width: u32,
-    height: u32,
     frame_count: u64,
     pts_offset: u64,
     frame_size: usize,
@@ -304,8 +302,6 @@ impl FfmpegH264Encoder {
 
         Ok(Self {
             child,
-            width,
-            height,
             frame_count: 0,
             pts_offset: 0,
             frame_size,

--- a/docs/src/self-hosted-rendezvous.md
+++ b/docs/src/self-hosted-rendezvous.md
@@ -42,6 +42,24 @@ HTTPS. A systemd unit is just the command above with
 default instance uses (`scripts/deploy-connect-prod-alpha.sh`) is a
 worked example.
 
+A worked Caddy site block (the shape the default instance runs — the
+forwarding headers are load-bearing, see
+[Reachability](#reachability-for-natd-daemons)):
+
+```caddy
+connect.example.com {
+	encode gzip zstd
+
+	reverse_proxy 127.0.0.1:9876 {
+		header_up Host {host}
+		header_up -X-Forwarded-Host
+		header_up X-Forwarded-For {remote_host}
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-Proto {scheme}
+	}
+}
+```
+
 ## Pointing daemons at it
 
 In `intendant.toml`:
@@ -148,6 +166,9 @@ curl -s -X POST https://connect.example.com/api/daemon/register \
   -d '{"protocol":"intendant-connect-rendezvous-v1","daemon_id":"probe","daemon_public_key":"probe"}' \
   | grep observed_ip   # must echo YOUR public IP, not null
 ```
+
+(`scripts/deploy-connect-prod-alpha.sh` runs this probe automatically
+after every deploy and fails loudly when the echo is missing.)
 
 Caddy gotcha (this bit the default instance): within a `reverse_proxy`
 block, `header_up -X-Forwarded-For` deletions are applied **after**

--- a/scripts/deploy-connect-prod-alpha.sh
+++ b/scripts/deploy-connect-prod-alpha.sh
@@ -131,4 +131,25 @@ fi
 info "checking public readiness at $CONNECT_PUBLIC_READYZ_URL"
 curl -fsS "$CONNECT_PUBLIC_READYZ_URL" >/dev/null
 
+# Regression probe for the whole reverse-proxy chain: register a throwaway
+# daemon through the public origin and require the response to echo the
+# caller's address. observed_ip is what lets hosted dashboards reach NAT'd
+# daemons (they advertise ICE-TCP at that address) — a proxy that stops
+# forwarding X-Forwarded-For/X-Real-IP breaks every hosted dashboard, and
+# the failure only surfaces later as an ICE timeout on some daemon. The
+# throwaway registration is unclaimed and expires on its own.
+info "checking observed_ip echo at $CONNECT_PUBLIC_ORIGIN"
+PROBE_ARGS=(
+    -fsS -X POST "$CONNECT_PUBLIC_ORIGIN/api/daemon/register"
+    -H 'content-type: application/json'
+    -d '{"protocol":"intendant-connect-rendezvous-v1","daemon_id":"deploy-observed-ip-probe","daemon_public_key":"deploy-observed-ip-probe"}'
+)
+if [[ -n "${INTENDANT_CONNECT_TOKEN:-}" ]]; then
+    PROBE_ARGS+=(-H "Authorization: Bearer $INTENDANT_CONNECT_TOKEN")
+fi
+PROBE_RESPONSE="$(curl "${PROBE_ARGS[@]}")"
+if ! grep -qE '"observed_ip":"[0-9a-fA-F:.]+"' <<<"$PROBE_RESPONSE"; then
+    die "register response did not echo the caller address (observed_ip) — the reverse proxy in front of the service is not forwarding X-Forwarded-For/X-Real-IP, so hosted dashboards cannot reach NAT'd daemons. See the Reachability section of docs/src/self-hosted-rendezvous.md (Caddy applies header_up deletions after sets — do not strip-then-set). Response: $PROBE_RESPONSE"
+fi
+
 info "deploy complete"

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -175,7 +175,14 @@ pub struct VoiceDebugState {
 /// future runtime config additions re-blur the boundary.
 #[derive(Clone, Debug, Serialize)]
 pub struct WebGatewayConfig {
+    /// Browser live-audio **voice** provider (Gemini Live by default) — NOT
+    /// the chat/agent provider. `PROVIDER=mock` and chat provider selection
+    /// deliberately do not affect this pair, and nothing should render it
+    /// as the daemon's chat provider (that once made keyless daemons claim
+    /// to run gemini). Kept as the bare `provider`/`model` wire keys for
+    /// compatibility with hosted pages older or newer than this daemon.
     pub provider: String,
+    /// Browser live-audio **voice** model. See `provider` above.
     pub model: String,
     /// Effective server-side presence state for this running daemon. This is
     /// intentionally runtime-scoped, because `--no-presence` can override the

--- a/static/app.html
+++ b/static/app.html
@@ -42043,8 +42043,13 @@ function applyMainBackendStatus() {
     return;
   }
 
-  providerEl.textContent = (gatewayConfig && gatewayConfig.provider) || '--';
-  modelEl.textContent = (gatewayConfig && gatewayConfig.model) || '--';
+  // No fallback to gatewayConfig here: its provider/model fields are the
+  // browser live-audio VOICE pair (Gemini Live by default), not the chat
+  // provider — using them made an idle or keyless daemon's status bar
+  // claim a chat provider it does not run. Real values arrive with the
+  // first session status event; until then the chips stay honest.
+  providerEl.textContent = '--';
+  modelEl.textContent = '--';
 }
 
 function updateStatusBar(d) {

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -2158,8 +2158,13 @@ function applyMainBackendStatus() {
     return;
   }
 
-  providerEl.textContent = (gatewayConfig && gatewayConfig.provider) || '--';
-  modelEl.textContent = (gatewayConfig && gatewayConfig.model) || '--';
+  // No fallback to gatewayConfig here: its provider/model fields are the
+  // browser live-audio VOICE pair (Gemini Live by default), not the chat
+  // provider — using them made an idle or keyless daemon's status bar
+  // claim a chat provider it does not run. Real values arrive with the
+  // first session status event; until then the chips stay honest.
+  providerEl.textContent = '--';
+  modelEl.textContent = '--';
 }
 
 function updateStatusBar(d) {


### PR DESCRIPTION
Three small items from the hosted-Connect E2E retrospective.

- **Deploy script verifies the observed_ip echo.** The prod Caddy header regression (delete-after-set erasing X-Forwarded-For) was invisible at deploy time and surfaced days later as ICE timeouts. The deploy script now registers a throwaway daemon through the public origin after every deploy and fails loudly unless the response echoes a caller address. The self-hosted chapter gains the worked Caddy site block (forwarding headers are load-bearing) and notes the automation.
- **Status bar stops presenting the voice provider as the chat provider.** WebGatewayConfig's provider/model pair is the browser live-audio voice configuration; the status bar used it as a chat-chip fallback, so keyless/idle daemons claimed to run gemini. Chips stay at '--' until a real session status arrives; the config fields now carry unmissable doc comments.
- **Drop unread FfmpegH264Encoder dimensions** (Linux-only struct; verified with cargo check on a Linux box).

Verified: 2627 unit tests, clippy clean on touched files, app.html regenerated from fragments, probe logic live-tested against the production service (passes post-Caddy-fix; fails by construction on a null echo).