### PR TITLE
comments: point at the carved files' new homes

### DIFF
--- a/crates/intendant-display/src/encode/h264_linux.rs
+++ b/crates/intendant-display/src/encode/h264_linux.rs
@@ -13,7 +13,7 @@
 //! IDR within ~1-2 s rather than waiting indefinitely. The complementary
 //! half of the strategy lives elsewhere: the federated H.264 layer is
 //! encoded at quarter resolution + a capped bitrate (see
-//! `LayerSpec::single` / `single_federated` in `encode/pool.rs`), so even
+//! `LayerSpec::single` / `single_federated` in `encode/pool/types.rs`), so even
 //! the periodic IDR is only a handful of RTP packets and survives the
 //! lossy `browser → TURN → remote peer` relay; and `slice-max-size=1200`
 //! (libx264) keeps each NAL inside a single ~MTU RTP payload so a lost
@@ -596,7 +596,7 @@ impl Drop for FfmpegH264Encoder {
 /// keyframe every ~2 s — short enough that a fresh peer or a
 /// post-loss-burst decoder recovers promptly, long enough that periodic
 /// IDRs don't dominate the bitrate. Combined with the quarter-resolution
-/// + capped-bitrate federated layer (`encode/pool.rs`), each such IDR is
+/// + capped-bitrate federated layer (`encode/pool/types.rs`), each such IDR is
 /// only a handful of RTP packets, so it survives the lossy relay it has
 /// to cross. Replaces the earlier intra-refresh experiment, which left a
 /// desynced decoder with no clean recovery point (Linux ffmpeg ignores
@@ -706,7 +706,7 @@ fn x264_ffmpeg_args(width: u32, height: u32, bitrate_kbps: u32) -> Vec<String> {
 /// **Loss-resilience:** `-g GOP_PERIOD_FRAMES` gives a finite, bounded GOP
 /// so NVENC emits a periodic IDR every ~2 s — a real recovery point for a
 /// desynced decoder. Loss-survivability comes from the upstream
-/// quarter-resolution + capped-bitrate federated layer (`encode/pool.rs`),
+/// quarter-resolution + capped-bitrate federated layer (`encode/pool/types.rs`),
 /// which keeps that IDR small enough to reassemble on the lossy relay. An
 /// earlier iteration pinned an effectively-infinite GOP + `-intra-refresh
 /// 1` (plus `-no-scenecut 1` / `-forced-idr 0`) to suppress all post-seed

--- a/crates/intendant-display/src/encode/pool/lease.rs
+++ b/crates/intendant-display/src/encode/pool/lease.rs
@@ -121,7 +121,7 @@ impl PoolLease {
     /// release ([`Self::release`] or `Drop`).
     ///
     /// Used by the per-peer pool intake at
-    /// `webrtc.rs::pool_frame_intake` after
+    /// `webrtc/pool_glue.rs::pool_frame_intake` after
     /// `active_codec_from_subscriptions` picks the active codec out
     /// of a multi-codec subscription set: the inactive codecs'
     /// subscriptions are partitioned off and their on-demand claims

--- a/crates/intendant-display/src/encode/pool/types.rs
+++ b/crates/intendant-display/src/encode/pool/types.rs
@@ -387,7 +387,7 @@ impl LayerSpec {
     /// layer via [`normalize_layer_dims`]) and a bitrate capped at
     /// [`FEDERATED_H264_BITRATE_KBPS`]. Combined with the finite-GOP
     /// periodic IDR (`encode/h264_linux.rs`) and same-SSRC NACK
-    /// retransmission (`display/webrtc.rs`), the small IDR both survives
+    /// retransmission (`display/webrtc/driver.rs`), the small IDR both survives
     /// the relay and is recoverable.
     ///
     /// **Distinct RID.** The layer carries [`SimulcastRid::federated`], not

--- a/crates/intendant-display/src/forward.rs
+++ b/crates/intendant-display/src/forward.rs
@@ -132,7 +132,7 @@ impl Default for LayerSelector {
 // `run()` method that would loop over encoder subscriptions and write
 // to the peer's RTP track from a dedicated task. That design can't
 // work: the `RTCPeerConnection` instance is owned by the `WebRtcPeer`
-// driver task (`display/webrtc.rs`), and a separate forwarder task
+// driver task (`display/webrtc/driver.rs`), and a separate forwarder task
 // has no path to call into it. Moving the forwarder responsibilities
 // into the driver avoids the cross-task-Rtc-access problem entirely:
 // each peer's driver select!-loops over its pool subscriptions
@@ -370,7 +370,7 @@ mod tests {
 
     // PerPeerForwarder tests were deleted with the type — the
     // keyframe-gate regression guard moves to the driver's write path
-    // (`display/webrtc.rs::write_video_frame`), where `state.keyframe_seen`
+    // (`display/webrtc/driver.rs::write_video_frame`), where `state.keyframe_seen`
     // now lives. Driver-side coverage is via e2e webrtc tests rather
     // than in-unit tests because the relevant path requires a live
     // `Rtc` instance.

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -382,7 +382,7 @@ pub struct DisplayMetricsCounters {
     /// Total per-peer try_send failures in the fan-out task.
     ///
     /// `Arc<AtomicU64>` (not bare `AtomicU64`) so the per-peer
-    /// `pool_frame_intake` task at `webrtc.rs` can share the same
+    /// `pool_frame_intake` task at `webrtc/pool_glue.rs` can share the same
     /// counter via `Arc::clone(&self.counters.peer_drops)`.
     pub peer_drops: Arc<AtomicU64>,
     /// Current number of connected WebRTC peers.

--- a/crates/intendant-display/src/webrtc/pool_glue.rs
+++ b/crates/intendant-display/src/webrtc/pool_glue.rs
@@ -759,7 +759,7 @@ mod tests {
     /// The end-to-end chain is pinned by composition with the
     /// existing `release_on_demand_subset_decrements_only_specified_ids`
     /// + `release_on_demand_subset_silently_skips_unknown_ids` tests
-    /// in `display/encode/pool.rs` — they pin the lease side, this
+    /// in `display/encode/pool/lease.rs` — they pin the lease side, this
     /// pins the partition side, and `pool_frame_intake` passes the
     /// returned `inactive_ids` verbatim to `release_on_demand_subset`.
     #[test]

--- a/src/bin/caller/computer_use.rs
+++ b/src/bin/caller/computer_use.rs
@@ -2,7 +2,7 @@
 //!
 //! Defines common CU action types and an executor that dispatches them via
 //! platform-specific backends (X11, Wayland, macOS). Provider-specific parsing
-//! and result formatting live in `provider.rs`.
+//! and result formatting live in the per-provider modules under `provider/`.
 
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};

--- a/src/bin/caller/web_gateway/access_gates.rs
+++ b/src/bin/caller/web_gateway/access_gates.rs
@@ -206,7 +206,7 @@ pub(crate) fn peer_identity_allows_ws_control(
 
 /// Map a typed `/ws` frame to the `PeerOperation` it exercises — the
 /// direct-WebSocket mirror of `dashboard_control_frame_operation` and
-/// the `CONTROL_METHODS` table (dashboard_control.rs), so the same
+/// the `CONTROL_METHODS` table (dashboard_control/mod.rs), so the same
 /// IAM grant answers the same way whichever transport a client speaks.
 /// `None` means the frame carries no authority of its own: replies, pings,
 /// and the `dashboard_control_*` signaling frames (the tunnel they establish

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -1754,8 +1754,8 @@ pub(crate) async fn handle_federated_webrtc_signal(
             });
             // Loopback TCP candidates (127.0.0.1 / ::1) are silently
             // dropped by browsers as anti-rebinding mitigation (same
-            // filter documented for the local path at
-            // display/webrtc.rs:38-43; the federated path hits the
+            // filter documented for the local path in the
+            // display/webrtc/mod.rs module docs; the federated path hits the
             // same trap when an operator configures a `localhost:NNNN`
             // tunnel on the primary side but the browser doesn't have
             // a matching loopback tunnel). No observable signaling


### PR DESCRIPTION
Comment-only sweep closing the path drift the pure-move carves deliberately left behind (moves relocate comments verbatim; these twelve referenced the pre-carve monoliths). No code changes: `encode/pool.rs` -> `pool/{types,lease}.rs`, `webrtc.rs` -> `webrtc/{driver,pool_glue,mod}.rs` (one line-number reference rewritten as a module-docs pointer since line numbers rot), `provider.rs` -> `provider/`, `dashboard_control.rs` -> `dashboard_control/mod.rs`. Gate: cargo check --tests green (comments only).