### PR TITLE
Drain comments point at the upstream rtc report

### DIFF
--- a/crates/intendant-display/src/webrtc/driver.rs
+++ b/crates/intendant-display/src/webrtc/driver.rs
@@ -917,7 +917,9 @@ pub(crate) async fn drain_outputs<I: rtc::interceptor::Interceptor>(
         // matter" — rtc/src/peer_connection/transport/dtls/mod.rs), so a
         // peer that reached us over ICE-TCP must be matched by its tuple,
         // not by the stamp, or every post-ICE packet misses the stream and
-        // DTLS times out. (The relay check above stays first: relay
+        // DTLS times out. Reported upstream as
+        // webrtc-rs/rtc#109 (fix PR #110); revisit this routing only
+        // after a release past 0.9.0 lands the fix and we upgrade. (The relay check above stays first: relay
         // transmits key on our relayed *local* address, which is never a
         // TCP peer tuple.)
         if let Some(sender) = tcp_senders.get(&t.transport.peer_addr) {

--- a/src/bin/caller/dashboard_control/wire.rs
+++ b/src/bin/caller/dashboard_control/wire.rs
@@ -381,7 +381,9 @@ pub(crate) async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
         // matter" — rtc/src/peer_connection/transport/dtls/mod.rs), so a
         // peer that reached us over ICE-TCP must be matched by its tuple,
         // not by the stamp, or every post-ICE packet misses the stream and
-        // DTLS times out.
+        // DTLS times out. Reported upstream as
+        // webrtc-rs/rtc#109 (fix PR #110); revisit this routing only
+        // after a release past 0.9.0 lands the fix and we upgrade.
         if let Some(sender) = tcp_senders.get(&t.transport.peer_addr) {
             let contents = t.message.to_vec();
             match sender.try_send(contents) {

--- a/src/bin/caller/peer_file_transfer.rs
+++ b/src/bin/caller/peer_file_transfer.rs
@@ -609,7 +609,9 @@ async fn drain_transfer_outputs<I: rtc::interceptor::Interceptor>(
         // matter" — rtc/src/peer_connection/transport/dtls/mod.rs), so a
         // peer that reached us over ICE-TCP must be matched by its tuple,
         // not by the stamp, or every post-ICE packet misses the stream and
-        // DTLS times out.
+        // DTLS times out. Reported upstream as
+        // webrtc-rs/rtc#109 (fix PR #110); revisit this routing only
+        // after a release past 0.9.0 lands the fix and we upgrade.
         if let Some(sender) = tcp_senders.get(&t.transport.peer_addr) {
             match sender.try_send(t.message.to_vec()) {
                 Ok(()) => {}


### PR DESCRIPTION
The engine's UDP-stamped DTLS/SCTP transmits are now reported as
webrtc-rs/rtc#109 with fix PR #110; note when the tuple-first routing
can be revisited.
