### PR TITLE
Keyless virtual displays: the dashboard's New virtual display path

### DIFF
--- a/crates/intendant-display/src/x11.rs
+++ b/crates/intendant-display/src/x11.rs
@@ -64,8 +64,8 @@ impl X11Backend {
     }
 
     /// Create a backend targeting a specific X11 display string (e.g. ":0", ":99").
-    /// Currently unused but available for virtual display sessions and multi-server setups.
-    #[allow(dead_code)]
+    /// Virtual display sessions use this to connect to their own Xvfb server
+    /// regardless of where the process-wide `DISPLAY` points.
     pub fn with_display(display_str: &str) -> Result<Self, CallerError> {
         let (conn, screen_num) = x11rb::connect(Some(display_str))
             .map_err(|e| CallerError::Display(format!("X11 connect to {display_str}: {e}")))?;

--- a/crates/intendant-platform/src/vision.rs
+++ b/crates/intendant-platform/src/vision.rs
@@ -146,6 +146,12 @@ pub fn display_config_for_provider(provider_name: &str) -> DisplayConfig {
 #[cfg(target_os = "linux")]
 const PREFERRED_DISPLAY: u32 = 99;
 
+/// One past the last display number [`find_free_display`] will allocate.
+/// `:99..:199` is the agent virtual-display range; sockets outside it are
+/// treated as user/session X servers, never as reclaimable Xvfb instances.
+#[cfg(target_os = "linux")]
+const VIRTUAL_DISPLAY_END: u32 = 200;
+
 /// Find a free X display number, preferring :99.
 ///
 /// Strategy for each candidate display:
@@ -156,16 +162,25 @@ const PREFERRED_DISPLAY: u32 = 99;
 /// 4. Lock file with some other live process → skip to next display
 #[cfg(target_os = "linux")]
 fn find_free_display() -> u32 {
-    find_free_display_in(std::path::Path::new("/tmp"))
+    find_free_display_in(std::path::Path::new("/tmp"), &[])
 }
 
 /// Lock-dir-injectable core of [`find_free_display`]. Tests pin a temp dir
 /// so the scan never probes the real X11 locks — a live :99 on a shared box
 /// (or a CI runner that also hosts a daemon) must never be examined, let
 /// alone reclaimed, by a unit test.
+///
+/// `exclude` lists display numbers this process knows are live and its own
+/// (held `XvfbGuard`s, registered capture sessions). Step 3's orphan
+/// reclaim would otherwise kill them: a guard-held `:99` looks exactly like
+/// an orphaned Xvfb to the lock-file scan, so allocating a *second* display
+/// must skip it rather than reclaim it.
 #[cfg(target_os = "linux")]
-fn find_free_display_in(lock_dir: &std::path::Path) -> u32 {
-    for id in PREFERRED_DISPLAY..200 {
+fn find_free_display_in(lock_dir: &std::path::Path, exclude: &[u32]) -> u32 {
+    for id in PREFERRED_DISPLAY..VIRTUAL_DISPLAY_END {
+        if exclude.contains(&id) {
+            continue;
+        }
         let lock = lock_dir.join(format!(".X{}-lock", id));
         if !lock.exists() {
             return id;
@@ -189,6 +204,57 @@ fn find_free_display_in(lock_dir: &std::path::Path) -> u32 {
 #[cfg(not(target_os = "linux"))]
 fn find_free_display() -> u32 {
     0
+}
+
+/// Allocate a virtual-display config at an explicit resolution, for callers
+/// that create displays for people rather than for a model's screenshot
+/// pipeline (the dashboard's keyless "new virtual display" path). Same
+/// allocator as [`display_config_for_provider`], provider-independent size.
+///
+/// `exclude` must list virtual-display numbers the caller already holds
+/// alive (guards, registered capture sessions) so the allocator never
+/// reclaims them as orphans — see [`find_free_display_in`].
+pub fn virtual_display_config(width: u32, height: u32, exclude: &[u32]) -> DisplayConfig {
+    #[cfg(target_os = "linux")]
+    let id = find_free_display_in(std::path::Path::new("/tmp"), exclude);
+    #[cfg(not(target_os = "linux"))]
+    let id = {
+        let _ = exclude;
+        find_free_display()
+    };
+    DisplayConfig {
+        target: DisplayTarget::Virtual { id },
+        width,
+        height,
+    }
+}
+
+/// Whether a live X server socket exists for virtual display `:id`.
+///
+/// True only inside the agent virtual-display number range (`:99..:199`) —
+/// callers use it to decide "this display target is an Xvfb we can connect
+/// to directly", and low-numbered sockets (`:0`, `:1`) are user session
+/// servers that must keep flowing through the user-display backends.
+/// Always false off Linux — virtual displays are Xvfb.
+pub fn virtual_display_socket_exists(id: u32) -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        virtual_display_socket_exists_in(std::path::Path::new("/tmp/.X11-unix"), id)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = id;
+        false
+    }
+}
+
+/// Socket-dir-injectable core of [`virtual_display_socket_exists`].
+#[cfg(target_os = "linux")]
+fn virtual_display_socket_exists_in(socket_dir: &std::path::Path, id: u32) -> bool {
+    if !(PREFERRED_DISPLAY..VIRTUAL_DISPLAY_END).contains(&id) {
+        return false;
+    }
+    socket_dir.join(format!("X{}", id)).exists()
 }
 
 /// The conventional agent virtual display (`:99`) when an X server is
@@ -422,7 +488,56 @@ mod tests {
             format!("{}\n", std::process::id()),
         )
         .unwrap();
-        assert_eq!(find_free_display_in(tmp.path()), 100);
+        assert_eq!(find_free_display_in(tmp.path(), &[]), 100);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn find_free_display_skips_excluded_ids_without_reclaiming() {
+        let tmp = tempfile::tempdir().unwrap();
+        // :99 has a stale lock (dead pid). Without the exclusion the scan
+        // would clean it up and hand out 99; a caller that still holds :99
+        // alive (guard, capture session) must get the next number and the
+        // lock file must survive untouched.
+        let lock = tmp.path().join(".X99-lock");
+        std::fs::write(&lock, " 1999999999\n").unwrap();
+        assert_eq!(find_free_display_in(tmp.path(), &[99]), 100);
+        assert!(lock.exists(), "excluded display's lock must not be touched");
+        assert_eq!(find_free_display_in(tmp.path(), &[99, 100, 101]), 102);
+    }
+
+    #[test]
+    fn virtual_display_config_carries_requested_resolution() {
+        let config = virtual_display_config(1920, 1080, &[]);
+        assert_eq!((config.width, config.height), (1920, 1080));
+        let DisplayTarget::Virtual { id } = config.target else {
+            panic!("virtual_display_config must target a virtual display");
+        };
+        #[cfg(target_os = "linux")]
+        assert!((99..200).contains(&id));
+        #[cfg(not(target_os = "linux"))]
+        assert_eq!(id, 0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn virtual_display_socket_probe_is_range_scoped() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("X0"), b"").unwrap();
+        std::fs::write(tmp.path().join("X99"), b"").unwrap();
+        std::fs::write(tmp.path().join("X250"), b"").unwrap();
+        // User-session servers (:0) and out-of-range numbers never count.
+        assert!(!virtual_display_socket_exists_in(tmp.path(), 0));
+        assert!(virtual_display_socket_exists_in(tmp.path(), 99));
+        assert!(!virtual_display_socket_exists_in(tmp.path(), 250));
+        // In-range but no socket.
+        assert!(!virtual_display_socket_exists_in(tmp.path(), 150));
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn virtual_display_socket_probe_is_linux_only() {
+        assert!(!virtual_display_socket_exists(99));
     }
 
     #[cfg(target_os = "linux")]

--- a/docs/src/computer-use-and-audio.md
+++ b/docs/src/computer-use-and-audio.md
@@ -113,8 +113,9 @@ CU actions operate on a `DisplayTarget` (`#[serde(tag = "kind")]`):
   (`create_virtual_display`) — the path that gives a claimed headless box a
   display with no API key configured. Dashboard-created displays register a
   capture session immediately (streaming tile, CU-routable), are daemon-owned,
-  and are destroyed when their tile is closed or the daemon exits. Xvfb is
-  Linux-only; other platforms answer the action with a clear error.
+  and are destroyed when their tile is closed (a hard daemon kill leaves the
+  usual orphan for the next allocation to reclaim). Xvfb is Linux-only; other
+  platforms answer the action with a clear error.
 - **`UserSession`** — the user's real desktop. On Linux X11 it resolves the
   login session's `DISPLAY` (falling back to `:0`); on macOS the primary display
   doesn't use `DISPLAY`. Requires an explicit `DisplayControl` grant via the

--- a/docs/src/computer-use-and-audio.md
+++ b/docs/src/computer-use-and-audio.md
@@ -107,7 +107,14 @@ All paths execute under the same server-side autonomy/approval model
 CU actions operate on a `DisplayTarget` (`#[serde(tag = "kind")]`):
 
 - **`Virtual { id }`** — an Xvfb-managed virtual display (`:99`, `:100`, …).
-  `display_env_string()` → `":<id>"`.
+  `display_env_string()` → `":<id>"`. Virtual displays come into being three
+  ways: the agent loop's Xvfb auto-launch, the agent starting one itself
+  (`Xvfb :99 … &`), or the dashboard's keyless **New virtual display** action
+  (`create_virtual_display`) — the path that gives a claimed headless box a
+  display with no API key configured. Dashboard-created displays register a
+  capture session immediately (streaming tile, CU-routable), are daemon-owned,
+  and are destroyed when their tile is closed or the daemon exits. Xvfb is
+  Linux-only; other platforms answer the action with a clear error.
 - **`UserSession`** — the user's real desktop. On Linux X11 it resolves the
   login session's `DISPLAY` (falling back to `:0`); on macOS the primary display
   doesn't use `DISPLAY`. Requires an explicit `DisplayControl` grant via the

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -315,6 +315,18 @@ connected, local display input authority requests and keyboard/mouse input can
 use that daemon-scoped control tunnel; video media still flows through the
 per-display WebRTC session.
 
+- **New virtual display** (empty state + display picker) — create a virtual
+  display keylessly: the daemon launches an Xvfb through the same machinery
+  agent sessions use, registers a capture session, and every connected
+  dashboard gets a streaming tile (`create_virtual_display`, gated as
+  `display.input`, on both the `/ws` and dashboard-control transports). This
+  is how a freshly claimed headless box — no display server, no API key —
+  gets a working display; agents can then target it for computer use. The
+  created display is daemon-owned: it never touches the "Your display"
+  opt-in, and it is destroyed (Xvfb killed) when any dashboard closes its
+  tile or the daemon exits. Xvfb is Linux-only; on macOS/Windows the button
+  reports a clear error and "Your display" streams the real desktop instead.
+
 ### Station
 
 An immersive WASM-rendered control center for the same operational surfaces as

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -324,8 +324,10 @@ per-display WebRTC session.
   gets a working display; agents can then target it for computer use. The
   created display is daemon-owned: it never touches the "Your display"
   opt-in, and it is destroyed (Xvfb killed) when any dashboard closes its
-  tile or the daemon exits. Xvfb is Linux-only; on macOS/Windows the button
-  reports a clear error and "Your display" streams the real desktop instead.
+  tile; after a hard daemon kill it is reclaimed like any orphaned agent
+  Xvfb on the next allocation. Xvfb is Linux-only; on macOS/Windows the
+  button reports a clear error and "Your display" streams the real desktop
+  instead.
 
 ### Station
 

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -352,6 +352,7 @@ pub fn control_msg_operation(ctrl: &ControlMsg) -> PeerOperation {
         | ControlMsg::ReleaseDisplay { .. }
         | ControlMsg::GrantUserDisplay { .. }
         | ControlMsg::RevokeUserDisplay { .. }
+        | ControlMsg::CreateVirtualDisplay { .. }
         | ControlMsg::SetDiagnosticsVisualMarker { .. } => PeerOperation::DisplayInput,
         ControlMsg::Input { .. }
         | ControlMsg::FollowUp { .. }

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -1258,27 +1258,36 @@ pub(crate) fn dashboard_session_control_msg_allowed(ctrl: &ControlMsg) -> bool {
     )
 }
 
+/// The "dashboard action" RPC lane's allowlist, by wire action name. Single
+/// declaration: `dashboard_action_msg_allowed` gates against it, and the
+/// parity test below pins the SPA's `DASHBOARD_ACTION_MSG_RPC_ACTIONS`
+/// mirror (static/app/31-init-identity-fleet.js) to this exact set — adding
+/// an action here without the frontend mirror (or vice versa) fails the
+/// suite instead of shipping as drift. Fail-closed: a new `ControlMsg`
+/// variant is not dispatchable over this lane until named here.
+pub(crate) const DASHBOARD_ACTION_MSG_ACTIONS: &[&str] = &[
+    "codex_thread_action",
+    "take_display",
+    "release_display",
+    "grant_user_display",
+    "revoke_user_display",
+    "create_virtual_display",
+    "create_browser_workspace",
+    "close_browser_workspace",
+    "acquire_browser_workspace",
+    "release_browser_workspace",
+    "setup_debug_screen",
+    "teardown_debug_screen",
+    "start_debug_recording",
+    "stop_debug_recording",
+    "start_recording",
+    "stop_recording",
+    "delete_recording",
+    "set_diagnostics_visual_marker",
+];
+
 pub(crate) fn dashboard_action_msg_allowed(ctrl: &ControlMsg) -> bool {
-    matches!(
-        ctrl,
-        ControlMsg::CodexThreadAction { .. }
-            | ControlMsg::TakeDisplay { .. }
-            | ControlMsg::ReleaseDisplay { .. }
-            | ControlMsg::GrantUserDisplay { .. }
-            | ControlMsg::RevokeUserDisplay { .. }
-            | ControlMsg::CreateBrowserWorkspace { .. }
-            | ControlMsg::CloseBrowserWorkspace { .. }
-            | ControlMsg::AcquireBrowserWorkspace { .. }
-            | ControlMsg::ReleaseBrowserWorkspace { .. }
-            | ControlMsg::SetupDebugScreen
-            | ControlMsg::TeardownDebugScreen
-            | ControlMsg::StartDebugRecording
-            | ControlMsg::StopDebugRecording
-            | ControlMsg::StartRecording { .. }
-            | ControlMsg::StopRecording { .. }
-            | ControlMsg::DeleteRecording { .. }
-            | ControlMsg::SetDiagnosticsVisualMarker { .. }
-    )
+    DASHBOARD_ACTION_MSG_ACTIONS.contains(&dashboard_control_msg_action(ctrl))
 }
 
 pub(crate) fn dashboard_control_msg_action(ctrl: &ControlMsg) -> &'static str {
@@ -1336,6 +1345,7 @@ pub(crate) fn dashboard_control_msg_action(ctrl: &ControlMsg) -> &'static str {
         ControlMsg::ReleaseDisplay { .. } => "release_display",
         ControlMsg::GrantUserDisplay { .. } => "grant_user_display",
         ControlMsg::RevokeUserDisplay { .. } => "revoke_user_display",
+        ControlMsg::CreateVirtualDisplay { .. } => "create_virtual_display",
         ControlMsg::CreateBrowserWorkspace { .. } => "create_browser_workspace",
         ControlMsg::CloseBrowserWorkspace { .. } => "close_browser_workspace",
         ControlMsg::AcquireBrowserWorkspace { .. } => "acquire_browser_workspace",

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -1677,11 +1677,8 @@ mod tests {
         let to = rest
             .find("]);")
             .expect("DASHBOARD_ACTION_MSG_RPC_ACTIONS set is unterminated");
-        let js_set: std::collections::BTreeSet<&str> = rest[..to]
-            .split('\'')
-            .skip(1)
-            .step_by(2)
-            .collect();
+        let js_set: std::collections::BTreeSet<&str> =
+            rest[..to].split('\'').skip(1).step_by(2).collect();
         let rust_set: std::collections::BTreeSet<&str> =
             DASHBOARD_ACTION_MSG_ACTIONS.iter().copied().collect();
         assert_eq!(
@@ -1718,39 +1715,50 @@ mod tests {
 
     /// Samples for allowlisted actions whose variants have required fields.
     const SAMPLE_ACTION_MSGS: &[(&str, fn() -> serde_json::Value)] = &[
-        ("codex_thread_action", || {
-            serde_json::json!({"action": "codex_thread_action", "session_id": "s", "op": "new", "params": {}})
-        }),
-        ("take_display", || {
-            serde_json::json!({"action": "take_display", "display_id": 1})
-        }),
-        ("release_display", || {
-            serde_json::json!({"action": "release_display", "display_id": 1})
-        }),
-        ("create_virtual_display", || {
-            serde_json::json!({"action": "create_virtual_display", "width": 1280, "height": 800})
-        }),
-        ("close_browser_workspace", || {
-            serde_json::json!({"action": "close_browser_workspace", "workspace_id": "w"})
-        }),
-        ("acquire_browser_workspace", || {
-            serde_json::json!({"action": "acquire_browser_workspace", "workspace_id": "w", "holder_id": "h"})
-        }),
-        ("release_browser_workspace", || {
-            serde_json::json!({"action": "release_browser_workspace", "workspace_id": "w", "holder_id": "h"})
-        }),
-        ("start_recording", || {
-            serde_json::json!({"action": "start_recording", "stream_name": "s"})
-        }),
-        ("stop_recording", || {
-            serde_json::json!({"action": "stop_recording", "stream_name": "s"})
-        }),
-        ("delete_recording", || {
-            serde_json::json!({"action": "delete_recording", "stream_name": "s"})
-        }),
-        ("set_diagnostics_visual_marker", || {
-            serde_json::json!({"action": "set_diagnostics_visual_marker", "enabled": true})
-        }),
+        (
+            "codex_thread_action",
+            || serde_json::json!({"action": "codex_thread_action", "session_id": "s", "op": "new", "params": {}}),
+        ),
+        (
+            "take_display",
+            || serde_json::json!({"action": "take_display", "display_id": 1}),
+        ),
+        (
+            "release_display",
+            || serde_json::json!({"action": "release_display", "display_id": 1}),
+        ),
+        (
+            "create_virtual_display",
+            || serde_json::json!({"action": "create_virtual_display", "width": 1280, "height": 800}),
+        ),
+        (
+            "close_browser_workspace",
+            || serde_json::json!({"action": "close_browser_workspace", "workspace_id": "w"}),
+        ),
+        (
+            "acquire_browser_workspace",
+            || serde_json::json!({"action": "acquire_browser_workspace", "workspace_id": "w", "holder_id": "h"}),
+        ),
+        (
+            "release_browser_workspace",
+            || serde_json::json!({"action": "release_browser_workspace", "workspace_id": "w", "holder_id": "h"}),
+        ),
+        (
+            "start_recording",
+            || serde_json::json!({"action": "start_recording", "stream_name": "s"}),
+        ),
+        (
+            "stop_recording",
+            || serde_json::json!({"action": "stop_recording", "stream_name": "s"}),
+        ),
+        (
+            "delete_recording",
+            || serde_json::json!({"action": "delete_recording", "stream_name": "s"}),
+        ),
+        (
+            "set_diagnostics_visual_marker",
+            || serde_json::json!({"action": "set_diagnostics_visual_marker", "enabled": true}),
+        ),
     ];
 
     struct DashboardControlStubDisplayBackend;

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -1660,6 +1660,99 @@ mod tests {
     use crate::*;
     use crate::dashboard_control::tests::{runtime};
 
+    /// The SPA mirrors the action-message allowlist as
+    /// `DASHBOARD_ACTION_MSG_RPC_ACTIONS` (static/app/31-init-identity-fleet.js)
+    /// to pick the RPC lane before dispatching. That copy can't derive from
+    /// this file, so pin its set to `DASHBOARD_ACTION_MSG_ACTIONS` — same
+    /// pattern as the IAM catalog parity tests in `access::iam`.
+    #[test]
+    fn spa_action_msg_rpc_set_mirrors_dashboard_action_allowlist() {
+        let app = include_str!("../../../../static/app.html");
+        let start = "const DASHBOARD_ACTION_MSG_RPC_ACTIONS = new Set([";
+        let from = app
+            .find(start)
+            .expect("DASHBOARD_ACTION_MSG_RPC_ACTIONS set not found in app.html")
+            + start.len();
+        let rest = &app[from..];
+        let to = rest
+            .find("]);")
+            .expect("DASHBOARD_ACTION_MSG_RPC_ACTIONS set is unterminated");
+        let js_set: std::collections::BTreeSet<&str> = rest[..to]
+            .split('\'')
+            .skip(1)
+            .step_by(2)
+            .collect();
+        let rust_set: std::collections::BTreeSet<&str> =
+            DASHBOARD_ACTION_MSG_ACTIONS.iter().copied().collect();
+        assert_eq!(
+            js_set, rust_set,
+            "DASHBOARD_ACTION_MSG_RPC_ACTIONS (static/app/31-init-identity-fleet.js) \
+             drifted from DASHBOARD_ACTION_MSG_ACTIONS"
+        );
+    }
+
+    /// Every allowlisted action name must be a real `ControlMsg` wire name —
+    /// a typo in the const would silently close the lane for that action.
+    #[test]
+    fn dashboard_action_allowlist_names_are_reachable() {
+        for name in DASHBOARD_ACTION_MSG_ACTIONS {
+            let probe = serde_json::json!({ "action": name });
+            let parses = serde_json::from_value::<ControlMsg>(probe).is_ok();
+            // Actions with required fields don't parse from the bare probe;
+            // check those against the canonical name map via a sample.
+            let known = parses
+                || SAMPLE_ACTION_MSGS
+                    .iter()
+                    .any(|(sample_name, _)| sample_name == name);
+            assert!(known, "allowlisted action {name:?} matches no ControlMsg");
+        }
+        for (name, sample) in SAMPLE_ACTION_MSGS {
+            let msg: ControlMsg = serde_json::from_value(sample()).unwrap();
+            assert_eq!(dashboard_control_msg_action(&msg), *name);
+            assert!(
+                dashboard_action_msg_allowed(&msg),
+                "sample for {name:?} not admitted by the allowlist"
+            );
+        }
+    }
+
+    /// Samples for allowlisted actions whose variants have required fields.
+    const SAMPLE_ACTION_MSGS: &[(&str, fn() -> serde_json::Value)] = &[
+        ("codex_thread_action", || {
+            serde_json::json!({"action": "codex_thread_action", "session_id": "s", "op": "new", "params": {}})
+        }),
+        ("take_display", || {
+            serde_json::json!({"action": "take_display", "display_id": 1})
+        }),
+        ("release_display", || {
+            serde_json::json!({"action": "release_display", "display_id": 1})
+        }),
+        ("create_virtual_display", || {
+            serde_json::json!({"action": "create_virtual_display", "width": 1280, "height": 800})
+        }),
+        ("close_browser_workspace", || {
+            serde_json::json!({"action": "close_browser_workspace", "workspace_id": "w"})
+        }),
+        ("acquire_browser_workspace", || {
+            serde_json::json!({"action": "acquire_browser_workspace", "workspace_id": "w", "holder_id": "h"})
+        }),
+        ("release_browser_workspace", || {
+            serde_json::json!({"action": "release_browser_workspace", "workspace_id": "w", "holder_id": "h"})
+        }),
+        ("start_recording", || {
+            serde_json::json!({"action": "start_recording", "stream_name": "s"})
+        }),
+        ("stop_recording", || {
+            serde_json::json!({"action": "stop_recording", "stream_name": "s"})
+        }),
+        ("delete_recording", || {
+            serde_json::json!({"action": "delete_recording", "stream_name": "s"})
+        }),
+        ("set_diagnostics_visual_marker", || {
+            serde_json::json!({"action": "set_diagnostics_visual_marker", "enabled": true})
+        }),
+    ];
+
     struct DashboardControlStubDisplayBackend;
 
     #[async_trait::async_trait]

--- a/src/bin/caller/display_glue.rs
+++ b/src/bin/caller/display_glue.rs
@@ -502,6 +502,55 @@ pub(crate) async fn activate_user_display(
     #[cfg(target_os = "linux")]
     crate::linux_display_env::ensure_gui_session_env("user display activation");
 
+    // Virtual (Xvfb) display targets connect directly to their own X server.
+    // A display id in the agent virtual range with a live socket is an Xvfb
+    // — agent-launched or dashboard-created — and must never fall through to
+    // the user-session backends: the Wayland arm would raise a portal dialog
+    // for the wrong display, and the X11 arm's xrandr lookup only knows
+    // monitor ids of $DISPLAY, so it previously captured the right Xvfb only
+    // when the process-wide DISPLAY happened to point at it.
+    #[cfg(target_os = "linux")]
+    if target_display_id != 0 && vision::virtual_display_socket_exists(target_display_id) {
+        let display_str = format!(":{target_display_id}");
+        let backend = match display::x11::X11Backend::with_display(&display_str) {
+            Ok(backend) => backend,
+            Err(e) => {
+                report_user_display_capture_unavailable(
+                    bus,
+                    display_id,
+                    format!("virtual display {display_str} connect failed: {e}"),
+                );
+                return;
+            }
+        };
+        let session = display::DisplaySession::new(display_id, Arc::new(backend));
+        if let Err(e) = session
+            .start(
+                30,
+                frame_registry.clone(),
+                Some(display_event_forwarder(bus.clone())),
+            )
+            .await
+        {
+            report_user_display_capture_unavailable(
+                bus,
+                display_id,
+                format!("virtual display {display_str} session failed: {e}"),
+            );
+            return;
+        }
+        let (width, height) = session.resolution();
+        let session = Arc::new(session);
+        session.spawn_metrics_logger(Some(display_event_forwarder(bus.clone())));
+        session_registry.write().await.insert(display_id, session);
+        bus.send(AppEvent::DisplayReady {
+            display_id,
+            width,
+            height,
+        });
+        return;
+    }
+
     // On Wayland: create a DisplaySession with WaylandBackend.
     // Detect Wayland even when WAYLAND_DISPLAY isn't in our env (e.g. started
     // from a tty/ssh session while a graphical session is active).

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -1575,9 +1575,12 @@ pub enum ControlMsg {
     /// Xvfb through the same machinery agent sessions use, registers a
     /// capture session, and announces it with `DisplayReady`; failures
     /// surface as `DisplayCaptureLost` with an actionable reason. The
-    /// created display is daemon-owned: it dies with the daemon, or when
-    /// any dashboard closes its tile (`RevokeUserDisplay` on its id).
-    /// Linux-only mechanism — other platforms report a clear error.
+    /// created display is daemon-owned: closing its tile
+    /// (`RevokeUserDisplay` on its id) destroys it, a graceful daemon exit
+    /// drops its guard, and a hard kill leaves it to the standard Xvfb
+    /// orphan-reclaim on the next allocation (signal shutdown is
+    /// `process::exit` — no `Drop`). Linux-only mechanism — other
+    /// platforms report a clear error.
     CreateVirtualDisplay {
         /// Optional resolution; defaults to 1920x1080. Values are clamped
         /// to sane bounds and rounded down to even (VP8 requirement).

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -1569,6 +1569,23 @@ pub enum ControlMsg {
         #[serde(default)]
         note: Option<String>,
     },
+    /// Create a virtual (Xvfb) display from a frontend — the keyless path
+    /// that gives a claimed headless box a working display without any
+    /// agent tool call. The daemon allocates the display number, launches
+    /// Xvfb through the same machinery agent sessions use, registers a
+    /// capture session, and announces it with `DisplayReady`; failures
+    /// surface as `DisplayCaptureLost` with an actionable reason. The
+    /// created display is daemon-owned: it dies with the daemon, or when
+    /// any dashboard closes its tile (`RevokeUserDisplay` on its id).
+    /// Linux-only mechanism — other platforms report a clear error.
+    CreateVirtualDisplay {
+        /// Optional resolution; defaults to 1920x1080. Values are clamped
+        /// to sane bounds and rounded down to even (VP8 requirement).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        width: Option<u32>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        height: Option<u32>,
+    },
     /// **Phase 0 visual-freshness diagnostic** (task #83). Toggle the
     /// per-display marker overlay that the pool-feed bridge stamps into
     /// the I420 Y plane. Off by default; operator flips it on for a
@@ -4313,6 +4330,29 @@ mod tests {
             }
             _ => panic!("expected RevokeUserDisplay"),
         }
+    }
+
+    #[test]
+    fn control_msg_create_virtual_display_deserialize() {
+        let json = r#"{"action":"create_virtual_display"}"#;
+        let msg: ControlMsg = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            msg,
+            ControlMsg::CreateVirtualDisplay {
+                width: None,
+                height: None
+            }
+        ));
+
+        let json = r#"{"action":"create_virtual_display","width":1280,"height":800}"#;
+        let msg: ControlMsg = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            msg,
+            ControlMsg::CreateVirtualDisplay {
+                width: Some(1280),
+                height: Some(800)
+            }
+        ));
     }
 
     #[test]

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -74,6 +74,7 @@ mod transcription;
 mod transfer_store;
 mod types;
 mod upload_store;
+mod virtual_display;
 pub(crate) use intendant_platform::vision;
 mod web_gateway;
 mod web_tls;
@@ -117,7 +118,7 @@ pub(crate) use display_glue::*;
 use autonomy::{AutonomyLevel, AutonomyState, SharedAutonomy};
 use conversation::Conversation;
 use error::CallerError;
-use event::{AppEvent, EventBus};
+use event::{AppEvent, ControlMsg, EventBus};
 use project::Project;
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -2637,6 +2638,12 @@ fn setup_fresh_conversation_with_attachments(
 /// Spawn a listener that reacts to display grant/revoke events.
 /// On grant: create a DisplaySession (Wayland) and emit DisplayReady.
 /// On revoke: stop the session and remove it from the registry.
+///
+/// Also the owner of dashboard-created virtual displays: it consumes
+/// `ControlMsg::CreateVirtualDisplay` off the bus (this task is the one
+/// place with the session/frame registries the create needs), and holds
+/// their `XvfbGuard`s as task-local state — created displays die with the
+/// daemon, on tile close (revoke of their id), or on capture loss.
 pub fn spawn_user_display_listener(
     bus: EventBus,
     session_registry: display::SharedSessionRegistry,
@@ -2644,6 +2651,7 @@ pub fn spawn_user_display_listener(
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut rx = bus.subscribe();
+        let mut virtual_display_guards = virtual_display::VirtualDisplayGuards::new();
         loop {
             match rx.recv().await {
                 Ok(AppEvent::UserDisplayGranted { display_id }) => {
@@ -2655,8 +2663,30 @@ pub fn spawn_user_display_listener(
                     )
                     .await;
                 }
+                Ok(AppEvent::ControlCommand(ControlMsg::CreateVirtualDisplay {
+                    width,
+                    height,
+                })) => {
+                    virtual_display::create_virtual_display(
+                        &bus,
+                        &session_registry,
+                        frame_registry.clone(),
+                        &mut virtual_display_guards,
+                        width,
+                        height,
+                    )
+                    .await;
+                }
                 Ok(AppEvent::UserDisplayRevoked { display_id, .. }) => {
                     deactivate_user_display(&session_registry, display_id).await;
+                    // Closing the tile of a dashboard-created display IS its
+                    // destroy: nothing else owns it, and leaving the Xvfb
+                    // running would leak displays with no way to kill them.
+                    virtual_display::reap_virtual_display(
+                        &mut virtual_display_guards,
+                        display_id,
+                        "tile closed",
+                    );
                 }
                 Ok(AppEvent::DisplayCaptureLost {
                     display_id,
@@ -2672,6 +2702,11 @@ pub fn spawn_user_display_listener(
                     if let Some(session) = session_registry.write().await.remove(display_id) {
                         session.stop().await;
                     }
+                    virtual_display::reap_virtual_display(
+                        &mut virtual_display_guards,
+                        display_id,
+                        "capture lost",
+                    );
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                 _ => {}

--- a/src/bin/caller/mcp/commands.rs
+++ b/src/bin/caller/mcp/commands.rs
@@ -1226,6 +1226,22 @@ pub(crate) async fn handle_control_command_mcp(
             );
             Some(RESOURCE_LOGS_URI)
         }
+        ControlMsg::CreateVirtualDisplay { .. } => {
+            // The user-display listener (spawned in every mode) owns the
+            // actual work — Xvfb launch, capture session, DisplayReady /
+            // DisplayCaptureLost — by consuming this same bus event. This
+            // arm only acknowledges receipt on the MCP control surface.
+            emit_control_result(
+                control_tx,
+                "create_virtual_display",
+                true,
+                "virtual display creation requested — outcome arrives as \
+                 display_ready or display_capture_lost"
+                    .to_string(),
+                None,
+            );
+            Some(RESOURCE_LOGS_URI)
+        }
         ControlMsg::ListDisplays => {
             let session_registry = state.read().await.session_registry.clone();
             let displays =

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -114,12 +114,10 @@ pub(crate) async fn create_virtual_display(
             activate_user_display(bus, session_registry, frame_registry, display_id).await;
             // Activation failure already reported its reason; don't leave a
             // guarded Xvfb running with no tile and no way to destroy it.
-            if session_registry.read().await.get(display_id).is_none() {
-                if guards.remove(&display_id).is_some() {
-                    eprintln!(
-                        "[virtual_display] :{display_id} activation failed — Xvfb reaped"
-                    );
-                }
+            if session_registry.read().await.get(display_id).is_none()
+                && guards.remove(&display_id).is_some()
+            {
+                eprintln!("[virtual_display] :{display_id} activation failed — Xvfb reaped");
             }
         }
         Err(e) => {

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -1,0 +1,214 @@
+//! Keyless virtual displays: the dashboard's "New virtual display" path.
+//!
+//! A claimed headless box has no display server and no API key, so no agent
+//! tool call can ever launch one — yet the flagship story is "watch every
+//! fleet display live from the browser". This module lets a frontend create
+//! (and destroy) an Xvfb display through the exact machinery agent sessions
+//! use: `vision::launch_display` for the process, `activate_user_display`
+//! for the capture session, `DisplayReady`/`DisplayCaptureLost` for the
+//! outcome.
+//!
+//! Ownership model: a created display is **daemon-owned** — like an
+//! agent-owned display it carries no user privacy, so it is default-visible
+//! to every connected dashboard, and input authority stays with the
+//! existing per-display holder model. It never touches the
+//! `user_display_granted` opt-in (that flag is about the *user's* screen).
+//! Lifecycle: the `XvfbGuard` map lives in the user-display listener task
+//! (`spawn_user_display_listener`), so a created display dies with the
+//! daemon; closing its tile (`RevokeUserDisplay` on its id) or a capture
+//! loss reaps it explicitly.
+
+use crate::display;
+use crate::display_glue::{activate_user_display, report_user_display_capture_unavailable};
+use crate::event::{AppEvent, EventBus};
+use crate::frames;
+use crate::types::LogLevel;
+use crate::vision;
+use intendant_platform::DisplayTarget;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Xvfb guards for dashboard-created virtual displays, keyed by display
+/// number. Owned as plain task-local state by the user-display listener —
+/// single consumer, no locking. Dropping a guard kills the Xvfb and cleans
+/// its X lock/socket.
+pub(crate) type VirtualDisplayGuards = HashMap<u32, vision::XvfbGuard>;
+
+/// Default resolution for a dashboard-created display. Human-facing desktop
+/// default — the token-optimized provider resolutions in
+/// `vision::display_config_for_provider` are for model screenshot
+/// pipelines, not people watching a tile.
+const DEFAULT_WIDTH: u32 = 1920;
+const DEFAULT_HEIGHT: u32 = 1080;
+
+const MIN_WIDTH: u32 = 320;
+const MIN_HEIGHT: u32 = 240;
+const MAX_WIDTH: u32 = 3840;
+const MAX_HEIGHT: u32 = 2160;
+
+/// Resolve requested dimensions: defaults for omitted axes, bounds-checked,
+/// rounded down to even (VP8 rejects odd frame dimensions).
+pub(crate) fn virtual_display_dimensions(
+    width: Option<u32>,
+    height: Option<u32>,
+) -> Result<(u32, u32), String> {
+    let width = width.unwrap_or(DEFAULT_WIDTH);
+    let height = height.unwrap_or(DEFAULT_HEIGHT);
+    if !(MIN_WIDTH..=MAX_WIDTH).contains(&width) || !(MIN_HEIGHT..=MAX_HEIGHT).contains(&height) {
+        return Err(format!(
+            "virtual display resolution {width}x{height} out of range \
+             ({MIN_WIDTH}x{MIN_HEIGHT} to {MAX_WIDTH}x{MAX_HEIGHT})"
+        ));
+    }
+    Ok((width & !1, height & !1))
+}
+
+/// Handle `ControlMsg::CreateVirtualDisplay`: launch an Xvfb at a free
+/// display number and register its capture session so every dashboard gets
+/// a streaming tile. All failure paths report through
+/// `DisplayCaptureLost` — the dashboard surfaces that as an error toast —
+/// and never leave an unguarded Xvfb behind.
+pub(crate) async fn create_virtual_display(
+    bus: &EventBus,
+    session_registry: &display::SharedSessionRegistry,
+    frame_registry: Option<Arc<tokio::sync::RwLock<frames::FrameRegistry>>>,
+    guards: &mut VirtualDisplayGuards,
+    width: Option<u32>,
+    height: Option<u32>,
+) {
+    // Displays this daemon holds alive must never be orphan-reclaimed by
+    // the allocator: our own guards, plus every registered virtual capture
+    // session (an agent-launched Xvfb has a session but no guard here).
+    let mut exclude: Vec<u32> = guards.keys().copied().collect();
+    for id in session_registry.read().await.display_ids() {
+        if id != 0 && !exclude.contains(&id) {
+            exclude.push(id);
+        }
+    }
+
+    let (width, height) = match virtual_display_dimensions(width, height) {
+        Ok(dims) => dims,
+        Err(reason) => {
+            // No display number was consumed; report against the display
+            // the allocator would pick so the toast is still actionable.
+            let config = vision::virtual_display_config(DEFAULT_WIDTH, DEFAULT_HEIGHT, &exclude);
+            let id = virtual_target_id(&config);
+            report_user_display_capture_unavailable(bus, id, reason);
+            return;
+        }
+    };
+
+    let config = vision::virtual_display_config(width, height, &exclude);
+    let display_id = virtual_target_id(&config);
+
+    match vision::launch_display(&config).await {
+        Ok(guard) => {
+            guards.insert(display_id, guard);
+            bus.send(AppEvent::PresenceLog {
+                message: format!(
+                    "[virtual_display] created :{display_id} ({width}x{height}) from the dashboard"
+                ),
+                level: Some(LogLevel::Info),
+                turn: None,
+            });
+            activate_user_display(bus, session_registry, frame_registry, display_id).await;
+            // Activation failure already reported its reason; don't leave a
+            // guarded Xvfb running with no tile and no way to destroy it.
+            if session_registry.read().await.get(display_id).is_none() {
+                if guards.remove(&display_id).is_some() {
+                    eprintln!(
+                        "[virtual_display] :{display_id} activation failed — Xvfb reaped"
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            report_user_display_capture_unavailable(bus, display_id, create_failure_reason(&e));
+        }
+    }
+}
+
+/// Drop the guard for a dashboard-created display, killing its Xvfb and
+/// cleaning the X lock/socket. Returns whether this display was ours.
+/// Reaped on tile close (`UserDisplayRevoked`) and on capture loss (the
+/// Xvfb died, or activation never produced a session).
+pub(crate) fn reap_virtual_display(
+    guards: &mut VirtualDisplayGuards,
+    display_id: u32,
+    context: &str,
+) -> bool {
+    if guards.remove(&display_id).is_some() {
+        eprintln!("[virtual_display] destroyed :{display_id} ({context})");
+        true
+    } else {
+        false
+    }
+}
+
+fn virtual_target_id(config: &vision::DisplayConfig) -> u32 {
+    match config.target {
+        DisplayTarget::Virtual { id } => id,
+        // virtual_display_config always returns a Virtual target; keep a
+        // sane value if that invariant ever changes rather than panicking
+        // in the listener task.
+        DisplayTarget::UserSession => 0,
+    }
+}
+
+/// Platform-honest failure text. `vision::launch_display` already explains
+/// the Linux mechanics (missing Xvfb binary, unresponsive display); off
+/// Linux we add what to do instead, since the affordance is visible on
+/// every platform.
+fn create_failure_reason(e: &crate::error::CallerError) -> String {
+    if cfg!(target_os = "linux") {
+        format!("virtual display create failed: {e}")
+    } else {
+        format!(
+            "virtual display create failed: {e}. Virtual displays are Xvfb-based and \
+             Linux-only; use \"Your display\" to stream this machine's desktop instead."
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dimensions_default_to_full_hd() {
+        assert_eq!(virtual_display_dimensions(None, None), Ok((1920, 1080)));
+    }
+
+    #[test]
+    fn dimensions_default_each_axis_independently() {
+        assert_eq!(
+            virtual_display_dimensions(Some(1280), None),
+            Ok((1280, 1080))
+        );
+        assert_eq!(virtual_display_dimensions(None, Some(800)), Ok((1920, 800)));
+    }
+
+    #[test]
+    fn dimensions_round_down_to_even_for_vp8() {
+        assert_eq!(
+            virtual_display_dimensions(Some(1281), Some(801)),
+            Ok((1280, 800))
+        );
+    }
+
+    #[test]
+    fn dimensions_reject_out_of_range() {
+        assert!(virtual_display_dimensions(Some(100), None).is_err());
+        assert!(virtual_display_dimensions(None, Some(10_000)).is_err());
+        let err = virtual_display_dimensions(Some(8000), Some(600)).unwrap_err();
+        assert!(err.contains("out of range"), "{err}");
+    }
+
+    #[test]
+    fn reap_is_scoped_to_created_displays() {
+        let mut guards = VirtualDisplayGuards::new();
+        // Nothing created from the dashboard: reap must refuse — agent
+        // Xvfbs and user displays are not ours to kill.
+        assert!(!reap_virtual_display(&mut guards, 99, "test"));
+    }
+}

--- a/static/app.html
+++ b/static/app.html
@@ -309,6 +309,8 @@ html {
 }
 .display-picker-item:hover { background: var(--surface1); }
 .display-picker-item .dp-primary { color: var(--green); font-size: 10px; margin-left: 4px; }
+/* Action rows (e.g. "New virtual display") sit under the capture targets. */
+.display-picker-item.dp-action { border-top: 1px solid var(--surface1); margin-top: 4px; padding-top: 8px; color: var(--blue); }
 .budget-bar {
   display: inline-flex;
   align-items: center;
@@ -19719,7 +19721,8 @@ html.ui-v2 #tab-stats .ui2-fold-body .usage-cards { margin-top: 12px; }
             </svg>
           </div>
           <div class="ui-empty-title">No displays active</div>
-          <div class="ui-empty-hint">Displays will appear when the agent launches a GUI</div>
+          <div class="ui-empty-hint">Displays appear when the agent launches a GUI or you share your screen — or create one right here</div>
+          <button class="ui-empty-btn" id="displays-create-virtual" onclick="createVirtualDisplay(event)" title="Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed. Linux hosts only.">New virtual display</button>
         </div>
       </div>
       <div class="displays-collapse-bar hidden" id="displays-collapse-bar">
@@ -22850,6 +22853,7 @@ const DASHBOARD_ACTION_MSG_RPC_ACTIONS = new Set([
   'release_display',
   'grant_user_display',
   'revoke_user_display',
+  'create_virtual_display',
   'create_browser_workspace',
   'close_browser_workspace',
   'acquire_browser_workspace',
@@ -82604,9 +82608,38 @@ function showDisplayPicker(displays) {
     });
     picker.appendChild(item);
   }
+  const createItem = document.createElement('div');
+  createItem.className = 'display-picker-item dp-action';
+  createItem.textContent = 'New virtual display';
+  createItem.title = 'Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed. Linux hosts only.';
+  createItem.addEventListener('click', (e) => {
+    e.stopPropagation();
+    hideDisplayPicker();
+    createVirtualDisplay();
+  });
+  picker.appendChild(createItem);
   picker.classList.add('visible');
   displayPickerVisible = true;
 }
+
+// Keyless "new virtual display": the daemon launches an Xvfb and registers
+// a capture session — the tile arrives via the normal display_ready
+// broadcast, and failures come back as display_capture_lost (toasted by
+// the slot-less branch of that handler). Works with zero API keys, which
+// is what makes a freshly claimed headless box show a display at all.
+window.createVirtualDisplay = function(event) {
+  if (event?.stopPropagation) event.stopPropagation();
+  const sent = dispatchDashboardActionMsg({ action: 'create_virtual_display' }, {
+    onError: (err) => {
+      if (typeof showControlToast === 'function') {
+        showControlToast('error', err?.message || 'Virtual display create failed');
+      }
+    },
+  });
+  if (sent && typeof showControlToast === 'function') {
+    showControlToast('info', 'Creating virtual display… the tile appears when its stream is ready');
+  }
+};
 
 function grantUserDisplayTarget(display) {
   const displayId = Number(display?.id);

--- a/static/app/10-styles-shell.css
+++ b/static/app/10-styles-shell.css
@@ -238,6 +238,8 @@ html {
 }
 .display-picker-item:hover { background: var(--surface1); }
 .display-picker-item .dp-primary { color: var(--green); font-size: 10px; margin-left: 4px; }
+/* Action rows (e.g. "New virtual display") sit under the capture targets. */
+.display-picker-item.dp-action { border-top: 1px solid var(--surface1); margin-top: 4px; padding-top: 8px; color: var(--blue); }
 .budget-bar {
   display: inline-flex;
   align-items: center;

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -978,7 +978,8 @@
             </svg>
           </div>
           <div class="ui-empty-title">No displays active</div>
-          <div class="ui-empty-hint">Displays will appear when the agent launches a GUI</div>
+          <div class="ui-empty-hint">Displays appear when the agent launches a GUI or you share your screen — or create one right here</div>
+          <button class="ui-empty-btn" id="displays-create-virtual" onclick="createVirtualDisplay(event)" title="Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed. Linux hosts only.">New virtual display</button>
         </div>
       </div>
       <div class="displays-collapse-bar hidden" id="displays-collapse-bar">

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -781,6 +781,7 @@ const DASHBOARD_ACTION_MSG_RPC_ACTIONS = new Set([
   'release_display',
   'grant_user_display',
   'revoke_user_display',
+  'create_virtual_display',
   'create_browser_workspace',
   'close_browser_workspace',
   'acquire_browser_workspace',

--- a/static/app/58-shortcuts-boot.js
+++ b/static/app/58-shortcuts-boot.js
@@ -231,9 +231,38 @@ function showDisplayPicker(displays) {
     });
     picker.appendChild(item);
   }
+  const createItem = document.createElement('div');
+  createItem.className = 'display-picker-item dp-action';
+  createItem.textContent = 'New virtual display';
+  createItem.title = 'Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed. Linux hosts only.';
+  createItem.addEventListener('click', (e) => {
+    e.stopPropagation();
+    hideDisplayPicker();
+    createVirtualDisplay();
+  });
+  picker.appendChild(createItem);
   picker.classList.add('visible');
   displayPickerVisible = true;
 }
+
+// Keyless "new virtual display": the daemon launches an Xvfb and registers
+// a capture session — the tile arrives via the normal display_ready
+// broadcast, and failures come back as display_capture_lost (toasted by
+// the slot-less branch of that handler). Works with zero API keys, which
+// is what makes a freshly claimed headless box show a display at all.
+window.createVirtualDisplay = function(event) {
+  if (event?.stopPropagation) event.stopPropagation();
+  const sent = dispatchDashboardActionMsg({ action: 'create_virtual_display' }, {
+    onError: (err) => {
+      if (typeof showControlToast === 'function') {
+        showControlToast('error', err?.message || 'Virtual display create failed');
+      }
+    },
+  });
+  if (sent && typeof showControlToast === 'function') {
+    showControlToast('info', 'Creating virtual display… the tile appears when its stream is ready');
+  }
+};
 
 function grantUserDisplayTarget(display) {
   const displayId = Number(display?.id);


### PR DESCRIPTION
A claimed headless box has no display server and no API key, so nothing could ever give it a display — the flagship zero-install story ended at a blank Video tab. This adds the keyless path: a "New virtual display" affordance (display picker + Video-tab empty state) that has the daemon launch an Xvfb through the same machinery agent sessions use and register its capture session, so every connected dashboard gets a streaming tile.

Design points:
- **Daemon-owned display class**: default-visible like agent displays (a fresh Xvfb carries no user privacy), never touches the `user_display_granted` opt-in (that flag is about the user's screen), input authority stays with the existing per-display holder model, IAM grade `display.input` — identical to `grant_user_display`.
- **No parallel implementation**: creation is `vision::launch_display`, registration is `activate_user_display`, announcement is `DisplayReady`/`DisplayCaptureLost` (failures surface as the error toast from the slot-less capture-lost branch).
- **Lifecycle**: guards live task-locally in the user-display listener; closing the tile is the destroy, capture loss reaps, graceful daemon exit kills the Xvfb. The allocator gained an exclude list so creating a second display can never orphan-reclaim a live guard-held one, and the socket probe is range-scoped (`:99..:199`) so user session servers are never treated as reclaimable.
- **Action-lane hygiene**: the dashboard action allowlist is now a single named declaration with parity tests (fail-closed for new ControlMsg variants), mirrored in the RPC lane.
- **Platforms**: Linux is the mechanism (missing Xvfb → actionable toast); macOS/Windows report a clear pointer to "Your display" instead. Fixes two latent agent-path bugs on the way: Wayland desktops raised a portal dialog for Xvfb targets, and X11 captured whatever `$DISPLAY` pointed at instead of the target's own server.

Verified: 2635 unit tests + headless e2e 6/6 (macOS), `intendant-platform` suite incl. new allocator/probe tests on Linux, and a live keyless end-to-end on a Linux box over the real `/ws` lane: create (with dims validation), coexisting second display, tile-close destroy scoped to the right Xvfb, capture-loss reap, and the platform-honest error on macOS.