### PR TITLE
User-session display access: enforce the grant at the CU chokepoint

### DIFF
--- a/docs/src/autonomy.md
+++ b/docs/src/autonomy.md
@@ -86,4 +86,9 @@ external-agent approval routing through `external_approval_decision`.
 user-display toggle or `intendant ctl display grant-user` — and the agent keeps
 access to the user's display for the rest of the session (used by both
 [computer use](./computer-use-and-audio.md) and WebRTC streaming). Revoke from
-the same places to drop it.
+the same places to drop it. The grant is enforced fail-closed at the CU
+executor on every platform; only the owner's own surfaces (dashboard, local
+`ctl`, the owner-wired stdio MCP transport) may reach the user display
+without it, because their call is the opt-in. Note the grant is a single
+per-daemon flag: once granted, it holds for every principal the IAM layer
+lets at the display tools until revoked.

--- a/docs/src/computer-use-and-audio.md
+++ b/docs/src/computer-use-and-audio.md
@@ -111,7 +111,15 @@ CU actions operate on a `DisplayTarget` (`#[serde(tag = "kind")]`):
 - **`UserSession`** — the user's real desktop. On Linux X11 it resolves the
   login session's `DISPLAY` (falling back to `:0`); on macOS the primary display
   doesn't use `DISPLAY`. Requires an explicit `DisplayControl` grant via the
-  autonomy system.
+  autonomy system — enforced fail-closed at the `execute_actions` chokepoint
+  on **every** backend (the raw X11/macOS capture/injection paths included,
+  not just by session existence on Wayland/Windows), with one exemption: an
+  **owner surface** (the trusted dashboard, an enrolled root user client,
+  local loopback `ctl`, or the stdio MCP transport the owner wired up —
+  `ToolCallerTrust` in `mcp/mod.rs`, derived from the bound
+  `AccessPrincipal`) may target its own desktop ungranted, because the
+  owner's call *is* the opt-in. Every other caller — supervised external
+  agents, scoped grants, federated peers — needs the standing grant.
 
 When a pixel-CU call (`take_screenshot`, `execute_cu_actions`) omits
 `display_target`, the default is availability-aware
@@ -124,7 +132,9 @@ same resolution when a session has no CU display configured, except its
 user-session fallback additionally requires the user-display grant — the
 model-driven path never auto-targets the user's desktop ungranted.
 (`read_screen` defaults to the user session unconditionally — element trees
-only exist there.)
+only exist there — and sits behind the same grant/owner gate on all
+platforms: the element tree reveals window titles and field values just as
+pixels do, and it bypasses the session pipeline entirely.)
 
 User-session access uses a **session-grant** model: approve once (the `d` hotkey
 the dashboard control, MCP `grant_user_display`, or
@@ -134,6 +144,14 @@ Computer Use, the operator must enable **Allow Remote Interaction** in the
 physical portal dialog before clicking **Share**; approving screen sharing alone
 can produce screenshots while leaving keyboard/mouse injection unavailable. See
 [Autonomy & Approvals](./autonomy.md) for the approval surface.
+
+Granting is itself owner-surface-only: `grant_user_display` from a scoped
+caller is refused (revoke stays open — de-escalation is fail-safe), and the
+shared-view tools (`show_shared_view`, `focus_shared_view`,
+`request_shared_view_input`, `capture_shared_view_frame`) activate a
+user-session target only for a granted or owner caller instead of flipping
+the grant themselves. Sharing an agent-owned virtual display never touches
+the user-display grant.
 
 ### CU-First Routing
 

--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -72,7 +72,13 @@ evaluated at call time** against that principal's permissions via a per-tool
 operation map (`mcp_tool_operation` in `mcp/tool_gate.rs`; e.g. `execute_cu_actions`
 and `grant_user_display` require `display.input`, `start_task` requires
 `task.run`, unclassified tools require `runtime.control`). `tools/list` is
-filtered to what the principal may actually call. Binding order:
+filtered to what the principal may actually call. The display tools carry a
+second, separate gate: a `user_session` target needs the standing
+user-display grant unless the bound principal is an owner surface (the
+trusted dashboard / enrolled root user client or bare local loopback —
+`AccessPrincipal::is_owner_surface`); the stdio transport, being wired up by
+the owner's own client config, always counts as an owner surface. See
+[Computer Use](./computer-use-and-audio.md#display-targets). Binding order:
 
 1. **Peer daemons** (mTLS peer identity) use their peer-profile principal.
 2. **Supervised backends** present the token in their injected

--- a/docs/src/peer-federation.md
+++ b/docs/src/peer-federation.md
@@ -317,6 +317,14 @@ it). A denial comes back as a structured `isError` tool result
 with the peer's diagnostic text, which every caller surface passes through
 verbatim.
 
+A peer is never an *owner surface* on the target daemon: targeting the
+peer's real desktop (`user_session`) additionally requires the target
+daemon's own standing user-display grant, enforced at the CU executor
+([Computer Use](./computer-use-and-audio.md#display-targets)). The peer
+profile authorizes the operation class; the grant is the target owner's
+opt-in to their desktop specifically — a `peer-operator` profile alone
+reaches agent virtual displays, not an ungranted user session.
+
 Screenshot and CU replies carry real MCP image content blocks; the native
 tool folds them into the conversation as image attachments
 (`add_tool_result_with_images`), and the MCP twins re-emit them as image

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -446,6 +446,17 @@ impl Agent {
         // macOS: use native screencapture (no display number needed)
         #[cfg(target_os = "macos")]
         let output = {
+            // Same gate as the Linux display<=0 branch below: `screencapture`
+            // always reads the user's primary display, which requires the
+            // explicit user-display grant (the env is set at spawn only when
+            // the controller-side guard grant is true).
+            if std::env::var("INTENDANT_USER_DISPLAY_GRANTED").is_err() {
+                return Err(AgentError::Process(
+                    "Access to the user's session display (display :0) requires explicit grant. \
+                     Use a virtual display or request display access first."
+                        .to_string(),
+                ));
+            }
             Command::new("screencapture")
                 .args(["-x", &screenshot_path.to_string_lossy()])
                 .output()

--- a/src/bin/caller/access/iam.rs
+++ b/src/bin/caller/access/iam.rs
@@ -340,6 +340,20 @@ pub struct AccessDecision {
 }
 
 impl AccessPrincipal {
+    /// True for the owner's own control surfaces: the trusted-local
+    /// dashboard and enrolled root user clients (both keep the root
+    /// dashboard grant id, minted nowhere else) plus the documented
+    /// anything-with-a-shell local loopback principal. The derived
+    /// transport defaults — supervised agent sessions and MCP token
+    /// holders — share the `root_session` *kind* but drop the grant id,
+    /// so this predicate must never be widened to the kind alone: those
+    /// callers are root-compatible for IAM yet are exactly who the
+    /// user-display grant exists to hold.
+    pub fn is_owner_surface(&self) -> bool {
+        self.grant_id.as_deref() == Some("grant:root:dashboard")
+            || self.id == "principal:local-process:loopback"
+    }
+
     pub fn root_dashboard_session(source: impl Into<String>, transport: impl Into<String>) -> Self {
         Self {
             id: "principal:root:dashboard".to_string(),
@@ -3515,6 +3529,43 @@ mod tests {
         assert_eq!(local.id, "principal:local-process:loopback");
         assert_eq!(local.source, "mcp-loopback-cleartext");
         assert!(evaluate_principal_operation(&local, PeerOperation::AccessManage).allowed);
+    }
+
+    #[test]
+    fn owner_surface_excludes_the_root_compatible_transport_defaults() {
+        // Owner surfaces: the trusted dashboard / enrolled root user
+        // clients, and the documented local-shell loopback principal.
+        assert!(AccessPrincipal::root_dashboard_session("test", "dashboard").is_owner_surface());
+        assert!(AccessPrincipal::root_user_client(
+            "test",
+            "dashboard",
+            "Alice",
+            None,
+            None,
+            Vec::new()
+        )
+        .is_owner_surface());
+        assert!(AccessPrincipal::root_dashboard_session_with_client_key(
+            "test", "dashboard", "fp", "pk"
+        )
+        .is_owner_surface());
+        assert!(AccessPrincipal::local_loopback_mcp_default("http").is_owner_surface());
+
+        // Root-COMPATIBLE is not owner: supervised external agents and MCP
+        // token holders share kind "root_session" but are exactly who the
+        // user-display grant must hold; peers are gated by their profile.
+        assert!(
+            !AccessPrincipal::supervised_agent_session_default("kid-1", "http", true)
+                .is_owner_surface()
+        );
+        assert!(
+            !AccessPrincipal::supervised_agent_session_default("kid-1", "http", false)
+                .is_owner_surface()
+        );
+        assert!(!AccessPrincipal::mcp_token_holder("http").is_owner_surface());
+        assert!(
+            !AccessPrincipal::peer_daemon("fp", "dell", "peer-root", "mtls").is_owner_surface()
+        );
     }
 
     #[test]

--- a/src/bin/caller/computer_use.rs
+++ b/src/bin/caller/computer_use.rs
@@ -447,9 +447,13 @@ pub fn normalized_to_pixels(
 /// the last non-Screenshot action (all providers expect a screenshot in the
 /// result).
 ///
-/// `user_display_granted` is the autonomy guard's grant state (the single
-/// source of truth for the user-display grant), read by the caller; it is
-/// only used to word the no-session recovery message.
+/// `user_session_allowed` is the single enforcement point for reaching the
+/// user's real desktop: callers pass the autonomy guard's user-display grant,
+/// OR-ed with their surface trust where an owner surface is exempt (the
+/// MCP layer's `ToolCallerTrust`). A `UserSession` target with
+/// `user_session_allowed == false` fails closed here for every action, on
+/// every backend — the Wayland/Windows session-existence requirement is a
+/// second fence, not the gate.
 #[allow(clippy::too_many_arguments)]
 pub async fn execute_actions(
     actions: &[CuAction],
@@ -459,8 +463,21 @@ pub async fn execute_actions(
     action_counter: &mut u64,
     session_registry: &Option<crate::display::SharedSessionRegistry>,
     denorm_ref: Option<(u32, u32)>,
-    user_display_granted: bool,
+    user_session_allowed: bool,
 ) -> Vec<CuActionResult> {
+    if target.is_user_session() && !user_session_allowed {
+        // One result per action, like every other outcome of this function
+        // (a screenshot-only batch still gets its one denial).
+        return actions
+            .iter()
+            .map(|_| CuActionResult {
+                success: false,
+                screenshot: None,
+                error: Some(user_session_denied_message().to_string()),
+            })
+            .collect();
+    }
+
     #[cfg(target_os = "linux")]
     crate::linux_display_env::ensure_gui_session_env("computer use actions");
 
@@ -492,7 +509,7 @@ pub async fn execute_actions(
                 error: Some(no_session_message(
                     effective_backend,
                     &target,
-                    user_display_granted,
+                    user_session_allowed,
                 )),
             }];
         }
@@ -1612,11 +1629,22 @@ fn png_dimensions(data: &[u8]) -> Option<(u32, u32)> {
 // ── Session-only backends: DisplaySession routing ───────────────────────────
 
 /// Build an actionable error for the "no capture session" failure path on the
+/// The fail-closed refusal for a `UserSession` target without the
+/// user-display grant (or an owner surface). One message for every surface
+/// — MCP tools, ctl, peers, the native loop's chokepoint — mirroring the
+/// native shared-view refusal so the opt-in is always worded the same way.
+pub(crate) fn user_session_denied_message() -> &'static str {
+    "Access to the user's real display (user_session) is an explicit opt-in — \
+     the user must grant their display first (dashboard grant, grant_user_display, \
+     or `intendant ctl display grant-user`). Target an agent-owned virtual display \
+     instead, e.g. display_target \":99\"."
+}
+
 /// session-only backends (Wayland, Windows). A bare "no session" message left
 /// callers with no hint about what's wrong or how to recover, which caused
 /// external agents to retry the same call indefinitely.
-/// `user_display_granted` is the autonomy guard's grant state, passed in by
-/// the caller; it only steers the recovery wording.
+/// `user_display_granted` is the caller's `user_session_allowed` (grant or
+/// owner surface); it only steers the recovery wording.
 fn no_session_message(
     backend: DisplayBackend,
     target: &DisplayTarget,
@@ -2822,6 +2850,68 @@ mod tests {
         assert_eq!(ScrollDirection::Down.x11_button(), 5);
         assert_eq!(ScrollDirection::Left.x11_button(), 6);
         assert_eq!(ScrollDirection::Right.x11_button(), 7);
+    }
+
+    #[tokio::test]
+    async fn execute_actions_refuses_user_session_without_allowance() {
+        // The chokepoint: a user_session target with user_session_allowed ==
+        // false fails closed for EVERY action on EVERY backend, before any
+        // capture/injection path runs (headless-safe: nothing touches a
+        // display).
+        let dir = std::env::temp_dir();
+        let mut counter = 0u64;
+        let actions = [CuAction::Screenshot, CuAction::Wait { ms: 1 }];
+        for backend in [
+            DisplayBackend::X11,
+            DisplayBackend::MacOS,
+            DisplayBackend::Wayland,
+            DisplayBackend::Windows,
+        ] {
+            let results = execute_actions(
+                &actions,
+                DisplayTarget::UserSession,
+                backend,
+                &dir,
+                &mut counter,
+                &None,
+                None,
+                false,
+            )
+            .await;
+            assert_eq!(results.len(), actions.len(), "one result per action");
+            for result in results {
+                assert!(!result.success);
+                assert_eq!(
+                    result.error.as_deref(),
+                    Some(user_session_denied_message()),
+                    "backend {backend:?} must fail closed with the opt-in message"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_actions_gate_leaves_virtual_targets_alone() {
+        // A virtual target is agent-owned: the gate must not fire for it even
+        // with user_session_allowed == false (Wayland backend: the virtual
+        // target routes to X11 tooling and then the session lookup, so this
+        // stays headless-safe and returns the no-session recovery text, not
+        // the opt-in refusal).
+        let dir = std::env::temp_dir();
+        let mut counter = 0u64;
+        let results = execute_actions(
+            &[CuAction::Screenshot],
+            DisplayTarget::Virtual { id: 4321 },
+            DisplayBackend::Windows,
+            &dir,
+            &mut counter,
+            &None,
+            None,
+            false,
+        )
+        .await;
+        let error = results[0].error.as_deref().unwrap_or_default();
+        assert_ne!(error, user_session_denied_message());
     }
 
     #[test]

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -869,7 +869,13 @@ pub(crate) async fn api_mcp_tool_call_response(
         .unwrap_or_else(|| serde_json::json!({}));
     let managed_context = optional_managed_context_param(&params);
     match server
-        .call_tool_by_name_for_session(&name, arguments, session_id.as_deref(), managed_context)
+        .call_tool_by_name_as_caller(
+            &name,
+            arguments,
+            session_id.as_deref(),
+            managed_context,
+            crate::mcp::ToolCallerTrust::from_principal(&runtime.grant.access_principal()),
+        )
         .await
     {
         Ok(result) => {

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -227,6 +227,28 @@ impl IntendantServer {
         session_id: Option<&str>,
         managed_context_override: Option<bool>,
     ) -> Result<CallToolResult, String> {
+        // Fail-closed default: a dispatch path that doesn't state its surface
+        // is scoped (internal self-calls, tests). The HTTP gate and the
+        // dashboard tunnel pass their bound principal's surface explicitly
+        // via `call_tool_by_name_as_caller`.
+        self.call_tool_by_name_as_caller(
+            name,
+            args,
+            session_id,
+            managed_context_override,
+            ToolCallerTrust::Scoped,
+        )
+        .await
+    }
+
+    pub async fn call_tool_by_name_as_caller(
+        &self,
+        name: &str,
+        args: serde_json::Value,
+        session_id: Option<&str>,
+        managed_context_override: Option<bool>,
+        caller: ToolCallerTrust,
+    ) -> Result<CallToolResult, String> {
         fn parse_params<T: serde::de::DeserializeOwned>(
             args: serde_json::Value,
         ) -> Result<Parameters<T>, String> {
@@ -417,8 +439,10 @@ impl IntendantServer {
                 Ok(text_tool_result(self.release_display(params).await))
             }
             "grant_user_display" => {
-                let params = parse_params::<GrantUserDisplayParams>(args)?;
-                Ok(text_tool_result(self.grant_user_display(params).await))
+                let Parameters(params) = parse_params::<GrantUserDisplayParams>(args)?;
+                Ok(text_tool_result(
+                    self.grant_user_display_as_caller(params, caller).await,
+                ))
             }
             "revoke_user_display" => {
                 let params = parse_params::<RevokeUserDisplayParams>(args)?;
@@ -427,7 +451,8 @@ impl IntendantServer {
             "show_shared_view" => {
                 let Parameters(params) = parse_params::<ShowSharedViewParams>(args)?;
                 Ok(text_tool_result(
-                    self.show_shared_view_for_session(params, session_id).await,
+                    self.show_shared_view_for_session(params, session_id, caller)
+                        .await,
                 ))
             }
             "hide_shared_view" => {
@@ -439,13 +464,14 @@ impl IntendantServer {
             "focus_shared_view" => {
                 let Parameters(params) = parse_params::<FocusSharedViewParams>(args)?;
                 Ok(text_tool_result(
-                    self.focus_shared_view_for_session(params, session_id).await,
+                    self.focus_shared_view_for_session(params, session_id, caller)
+                        .await,
                 ))
             }
             "request_shared_view_input" => {
                 let Parameters(params) = parse_params::<RequestSharedViewInputParams>(args)?;
                 Ok(text_tool_result(
-                    self.request_shared_view_input_for_session(params, session_id)
+                    self.request_shared_view_input_for_session(params, session_id, caller)
                         .await,
                 ))
             }
@@ -455,25 +481,36 @@ impl IntendantServer {
                     params,
                     session_id,
                     managed_context_override == Some(true),
+                    caller,
                 )
                 .await
                 .map_err(|e| e.to_string())
             }
             "take_screenshot" => {
                 let params = parse_params::<TakeScreenshotParams>(args)?;
-                self.take_screenshot_with_output(params, managed_context_override == Some(true))
-                    .await
-                    .map_err(|e| e.to_string())
+                self.take_screenshot_with_output(
+                    params,
+                    managed_context_override == Some(true),
+                    caller,
+                )
+                .await
+                .map_err(|e| e.to_string())
             }
             "read_screen" => {
                 let params = parse_params::<ReadScreenParams>(args)?;
-                self.read_screen(params).await.map_err(|e| e.to_string())
+                self.read_screen_as_caller(params, caller)
+                    .await
+                    .map_err(|e| e.to_string())
             }
             "execute_cu_actions" => {
                 let params = parse_params::<ExecuteCuActionsParams>(args)?;
-                self.execute_cu_actions_with_output(params, managed_context_override == Some(true))
-                    .await
-                    .map_err(|e| e.to_string())
+                self.execute_cu_actions_with_output(
+                    params,
+                    managed_context_override == Some(true),
+                    caller,
+                )
+                .await
+                .map_err(|e| e.to_string())
             }
             "list_frames" => {
                 let params = parse_params::<ListFramesParams>(args)?;
@@ -1492,26 +1529,64 @@ const FISSION_WAIT_MAX_TIMEOUT_S: u64 = 300;
 /// group on the operator's behalf.
 const FISSION_CONTROL_DETACH_REASON: &str = "operator detach via fission_control";
 
+/// Which surface a tool call arrived from, for user-session display gating.
+/// Owner surfaces — the trusted dashboard / enrolled root user clients, local
+/// loopback, and the stdio MCP transport the owner wired up — may opt in to
+/// the user's real display without the standing grant; every other caller
+/// (supervised external agents, scoped grants, federated peers) needs
+/// `user_display_granted`. Fail-closed: paths that don't state a surface are
+/// `Scoped`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolCallerTrust {
+    OwnerSurface,
+    Scoped,
+}
+
+impl ToolCallerTrust {
+    pub fn from_principal(principal: &crate::access::iam::AccessPrincipal) -> Self {
+        if principal.is_owner_surface() {
+            ToolCallerTrust::OwnerSurface
+        } else {
+            ToolCallerTrust::Scoped
+        }
+    }
+
+    /// Whether this caller may reach the user's real display given the
+    /// autonomy guard's grant state.
+    pub fn allows_user_session(self, user_display_granted: bool) -> bool {
+        user_display_granted || self == ToolCallerTrust::OwnerSurface
+    }
+}
+
 /// Parse an explicit display-target spec. Callers resolve an *omitted*
 /// spec with [`crate::computer_use::default_display_target`], which is
 /// availability-aware, instead of assuming a virtual display exists.
+/// A parsed id of 0 is the user's session, never `Virtual { id: 0 }` —
+/// ":00" must not dodge the user-session gate that ":0" gets.
 fn resolve_display_target(target: &str) -> crate::computer_use::DisplayTarget {
     use crate::computer_use::DisplayTarget;
+    fn virtual_or_user_session(id: u32) -> crate::computer_use::DisplayTarget {
+        if id == 0 {
+            DisplayTarget::UserSession
+        } else {
+            DisplayTarget::Virtual { id }
+        }
+    }
     match target {
         "user_session" | "user" | "primary" | ":0" | "0" | "display_0" => {
             DisplayTarget::UserSession
         }
         s if s.starts_with(':') => {
             let id: u32 = s[1..].parse().unwrap_or(99);
-            DisplayTarget::Virtual { id }
+            virtual_or_user_session(id)
         }
         s if s.starts_with("display_") => {
             let id: u32 = s["display_".len()..].parse().unwrap_or(99);
-            DisplayTarget::Virtual { id }
+            virtual_or_user_session(id)
         }
         s => {
             let id: u32 = s.parse().unwrap_or(99);
-            DisplayTarget::Virtual { id }
+            virtual_or_user_session(id)
         }
     }
 }

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -178,6 +178,24 @@ impl IntendantServer {
         &self,
         Parameters(params): Parameters<GrantUserDisplayParams>,
     ) -> String {
+        // Stdio MCP transport: owner surface (the owner's own client config).
+        self.grant_user_display_as_caller(params, ToolCallerTrust::OwnerSurface)
+            .await
+    }
+
+    pub(crate) async fn grant_user_display_as_caller(
+        &self,
+        params: GrantUserDisplayParams,
+        caller: ToolCallerTrust,
+    ) -> String {
+        // The grant IS the owner's opt-in: only owner surfaces may perform
+        // it. (Revoke stays open to everyone — de-escalation is fail-safe.)
+        if caller == ToolCallerTrust::Scoped {
+            return "Denied: grant_user_display performs the daemon owner's opt-in and is only \
+                    available on owner surfaces. Ask the owner to grant the display from the \
+                    dashboard or with `intendant ctl display grant-user`."
+                .to_string();
+        }
         let display_id = params.display_id.unwrap_or(0);
         let active_resolution = active_display_session_resolution(&self.state, display_id).await;
         let autonomy = {
@@ -309,54 +327,84 @@ impl IntendantServer {
         UserSessionDisplayActivationRequest::Requested
     }
 
+    /// Activate the display a shared-view show/focus/capture targets.
+    /// Display 0 is the user's real display on every platform (nonzero ids
+    /// are agent-owned virtual displays): reaching it is the owner's
+    /// opt-in, so a scoped caller (supervised agent, scoped grant, peer)
+    /// without the standing grant is refused rather than the opt-in being
+    /// performed on the owner's behalf — the native handler refuses exactly
+    /// this (`display_glue::handle_shared_view_calls`), and this is its MCP
+    /// twin. Only the user display ever touches the autonomy guard: an
+    /// agent-owned display activates via the bus event alone (the previous
+    /// code flipped the global user grant as a side effect of sharing a
+    /// virtual display, which silently opted the user in).
     pub(crate) async fn ensure_shared_view_display_active(
         &self,
         display_target: Option<&str>,
         display_id: Option<u32>,
-    ) {
+        caller: ToolCallerTrust,
+    ) -> Result<(), String> {
         let Some(display_id) = shared_view_user_display_id(display_target, display_id) else {
-            return;
+            return Ok(());
         };
-        if display_id == 0
-            && crate::computer_use::DisplayBackend::detect()
-                == crate::computer_use::DisplayBackend::Wayland
-        {
-            let _ = self
-                .ensure_wayland_user_session_display_activation(
-                    crate::computer_use::DisplayTarget::UserSession,
-                    crate::computer_use::DisplayBackend::Wayland,
-                )
-                .await;
-            return;
-        }
 
         let (autonomy, session_registry) = {
             let state = self.state.read().await;
             (state.autonomy.clone(), state.session_registry.clone())
         };
-        if let Some(registry) = session_registry {
-            if registry.read().await.get(display_id).is_some() {
-                return;
+
+        if display_id == 0 {
+            let granted = autonomy.read().await.user_display_granted;
+            if !caller.allows_user_session(granted) {
+                return Err(format!(
+                    "Cannot activate the user display for a shared view. {}",
+                    crate::computer_use::user_session_denied_message()
+                ));
+            }
+            if crate::computer_use::DisplayBackend::detect()
+                == crate::computer_use::DisplayBackend::Wayland
+            {
+                let _ = self
+                    .ensure_wayland_user_session_display_activation(
+                        crate::computer_use::DisplayTarget::UserSession,
+                        crate::computer_use::DisplayBackend::Wayland,
+                    )
+                    .await;
+                return Ok(());
             }
         }
 
-        {
+        if let Some(registry) = session_registry {
+            if registry.read().await.get(display_id).is_some() {
+                return Ok(());
+            }
+        }
+
+        if display_id == 0 {
+            // An owner surface opted in (or the grant was already held);
+            // record it on the guard like the explicit grant paths do.
             let mut guard = autonomy.write().await;
             guard.user_display_granted = true;
         }
         self.bus.send(AppEvent::UserDisplayGranted { display_id });
+        Ok(())
     }
 
     pub(crate) async fn show_shared_view_for_session(
         &self,
         params: ShowSharedViewParams,
         session_id: Option<&str>,
+        caller: ToolCallerTrust,
     ) -> String {
         let display_target = shared_view_display_target(params.display_target, params.display_id);
         let display_id = shared_view_display_id(display_target.as_deref(), params.display_id);
         let region = params.focus_region.map(normalize_shared_view_region);
-        self.ensure_shared_view_display_active(display_target.as_deref(), display_id)
-            .await;
+        if let Err(denied) = self
+            .ensure_shared_view_display_active(display_target.as_deref(), display_id, caller)
+            .await
+        {
+            return denied;
+        }
         self.emit_shared_view(
             session_id,
             "show",
@@ -376,7 +424,10 @@ impl IntendantServer {
         &self,
         Parameters(params): Parameters<ShowSharedViewParams>,
     ) -> String {
-        self.show_shared_view_for_session(params, None).await
+        // The stdio MCP transport is wired up by the daemon owner's own
+        // client configuration: an owner surface.
+        self.show_shared_view_for_session(params, None, ToolCallerTrust::OwnerSurface)
+            .await
     }
 
     pub(crate) async fn hide_shared_view_for_session(
@@ -400,11 +451,16 @@ impl IntendantServer {
         &self,
         params: FocusSharedViewParams,
         session_id: Option<&str>,
+        caller: ToolCallerTrust,
     ) -> String {
         let display_target = shared_view_display_target(params.display_target, params.display_id);
         let display_id = shared_view_display_id(display_target.as_deref(), params.display_id);
-        self.ensure_shared_view_display_active(display_target.as_deref(), display_id)
-            .await;
+        if let Err(denied) = self
+            .ensure_shared_view_display_active(display_target.as_deref(), display_id, caller)
+            .await
+        {
+            return denied;
+        }
         self.emit_shared_view(
             session_id,
             "focus",
@@ -424,18 +480,25 @@ impl IntendantServer {
         &self,
         Parameters(params): Parameters<FocusSharedViewParams>,
     ) -> String {
-        self.focus_shared_view_for_session(params, None).await
+        // Stdio MCP transport: owner surface (the owner's own client config).
+        self.focus_shared_view_for_session(params, None, ToolCallerTrust::OwnerSurface)
+            .await
     }
 
     pub(crate) async fn request_shared_view_input_for_session(
         &self,
         params: RequestSharedViewInputParams,
         session_id: Option<&str>,
+        caller: ToolCallerTrust,
     ) -> String {
         let display_target = shared_view_display_target(params.display_target, params.display_id);
         let display_id = shared_view_display_id(display_target.as_deref(), params.display_id);
-        self.ensure_shared_view_display_active(display_target.as_deref(), display_id)
-            .await;
+        if let Err(denied) = self
+            .ensure_shared_view_display_active(display_target.as_deref(), display_id, caller)
+            .await
+        {
+            return denied;
+        }
         self.emit_shared_view(
             session_id,
             "input_request",
@@ -455,7 +518,8 @@ impl IntendantServer {
         &self,
         Parameters(params): Parameters<RequestSharedViewInputParams>,
     ) -> String {
-        self.request_shared_view_input_for_session(params, None)
+        // Stdio MCP transport: owner surface (the owner's own client config).
+        self.request_shared_view_input_for_session(params, None, ToolCallerTrust::OwnerSurface)
             .await
     }
 
@@ -464,11 +528,16 @@ impl IntendantServer {
         params: CaptureSharedViewFrameParams,
         session_id: Option<&str>,
         compact_output: bool,
+        caller: ToolCallerTrust,
     ) -> Result<CallToolResult, McpError> {
         let display_target = shared_view_display_target(params.display_target, params.display_id);
         let display_id = shared_view_display_id(display_target.as_deref(), params.display_id);
-        self.ensure_shared_view_display_active(display_target.as_deref(), display_id)
-            .await;
+        if let Err(denied) = self
+            .ensure_shared_view_display_active(display_target.as_deref(), display_id, caller)
+            .await
+        {
+            return Ok(text_tool_error(denied));
+        }
         self.emit_shared_view(
             session_id,
             "capture",
@@ -482,6 +551,7 @@ impl IntendantServer {
         self.take_screenshot_with_output(
             Parameters(TakeScreenshotParams { display_target }),
             compact_output,
+            caller,
         )
         .await
     }
@@ -493,7 +563,8 @@ impl IntendantServer {
         &self,
         Parameters(params): Parameters<CaptureSharedViewFrameParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.capture_shared_view_frame_for_session(params, None, false)
+        // Stdio MCP transport: owner surface (the owner's own client config).
+        self.capture_shared_view_frame_for_session(params, None, false, ToolCallerTrust::OwnerSurface)
             .await
     }
 
@@ -502,7 +573,8 @@ impl IntendantServer {
         &self,
         Parameters(params): Parameters<TakeScreenshotParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.take_screenshot_with_output(Parameters(params), false)
+        // Stdio MCP transport: owner surface (the owner's own client config).
+        self.take_screenshot_with_output(Parameters(params), false, ToolCallerTrust::OwnerSurface)
             .await
     }
 
@@ -510,6 +582,7 @@ impl IntendantServer {
         &self,
         Parameters(params): Parameters<TakeScreenshotParams>,
         compact_output: bool,
+        caller: ToolCallerTrust,
     ) -> Result<CallToolResult, McpError> {
         use crate::computer_use::{execute_actions, CuAction, DisplayBackend};
 
@@ -552,7 +625,7 @@ impl IntendantServer {
             &mut counter,
             &session_registry,
             None,
-            user_display_granted,
+            caller.allows_user_session(user_display_granted),
         )
         .await;
 
@@ -597,6 +670,16 @@ impl IntendantServer {
         &self,
         Parameters(params): Parameters<ReadScreenParams>,
     ) -> Result<CallToolResult, McpError> {
+        // Stdio MCP transport: owner surface (the owner's own client config).
+        self.read_screen_as_caller(Parameters(params), ToolCallerTrust::OwnerSurface)
+            .await
+    }
+
+    pub(crate) async fn read_screen_as_caller(
+        &self,
+        Parameters(params): Parameters<ReadScreenParams>,
+        caller: ToolCallerTrust,
+    ) -> Result<CallToolResult, McpError> {
         // Element trees only exist for the real session; default there
         // unconditionally rather than availability-probing like the pixel
         // tools do.
@@ -604,6 +687,19 @@ impl IntendantServer {
             None => crate::computer_use::DisplayTarget::UserSession,
             Some(spec) => resolve_display_target(spec),
         };
+        // The element tree reveals the real session's content (window
+        // titles, field values) just as pixels do — and unlike the pixel
+        // tools it bypasses the session pipeline on every platform, so this
+        // gate is the only fence.
+        if target.is_user_session() {
+            let autonomy = self.state.read().await.autonomy.clone();
+            let granted = autonomy.read().await.user_display_granted;
+            if !caller.allows_user_session(granted) {
+                return Ok(text_tool_error(
+                    crate::computer_use::user_session_denied_message().to_string(),
+                ));
+            }
+        }
         match crate::computer_use::read_screen_elements(target).await {
             Ok(snapshot) => {
                 let body = if params.format.as_deref() == Some("json") {
@@ -625,14 +721,20 @@ impl IntendantServer {
         &self,
         Parameters(params): Parameters<ExecuteCuActionsParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.execute_cu_actions_with_output(Parameters(params), false)
-            .await
+        // Stdio MCP transport: owner surface (the owner's own client config).
+        self.execute_cu_actions_with_output(
+            Parameters(params),
+            false,
+            ToolCallerTrust::OwnerSurface,
+        )
+        .await
     }
 
     pub(crate) async fn execute_cu_actions_with_output(
         &self,
         Parameters(params): Parameters<ExecuteCuActionsParams>,
         compact_output: bool,
+        caller: ToolCallerTrust,
     ) -> Result<CallToolResult, McpError> {
         use crate::computer_use::{execute_actions, DisplayBackend};
 
@@ -700,7 +802,7 @@ impl IntendantServer {
             &mut counter,
             &session_registry,
             denorm_ref,
-            user_display_granted,
+            caller.allows_user_session(user_display_granted),
         )
         .await;
 
@@ -1004,11 +1106,16 @@ mod tests {
                 }
                 other => panic!("expected SharedView event, got {other:?}"),
             }
+
+            // Sharing an agent-owned virtual display must never touch the
+            // user-display grant: activation rides the bus event alone.
+            let autonomy = { server.state.read().await.autonomy.clone() };
+            assert!(!autonomy.read().await.user_display_granted);
         });
     }
 
     #[test]
-    fn shared_view_user_session_requests_display_activation() {
+    fn shared_view_user_session_scoped_caller_is_refused_not_self_granted() {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -1019,6 +1126,8 @@ mod tests {
             let state = test_state();
             let server = IntendantServer::new(state.clone(), bus.clone());
 
+            // The generic by-name dispatch is the fail-closed Scoped path —
+            // the one supervised external agents and peers arrive on.
             let result = server
                 .call_tool_by_name_for_session(
                     "show_shared_view",
@@ -1028,6 +1137,50 @@ mod tests {
                     }),
                     Some("session-a"),
                     None,
+                )
+                .await
+                .expect("tool should dispatch");
+            let rendered = serde_json::to_string(&result).unwrap_or_default();
+            assert!(
+                rendered.contains("explicit opt-in"),
+                "scoped caller must get the opt-in refusal, got: {rendered}"
+            );
+
+            // No activation event, and the guard must be untouched: the
+            // refusal exists precisely so a scoped caller cannot perform
+            // the owner's opt-in (the old code flipped the grant here).
+            assert!(
+                timeout(Duration::from_millis(200), rx.recv()).await.is_err(),
+                "no event may fire for a refused user-session share"
+            );
+            let autonomy = { state.read().await.autonomy.clone() };
+            assert!(!autonomy.read().await.user_display_granted);
+        });
+    }
+
+    #[test]
+    fn shared_view_user_session_owner_surface_requests_display_activation() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let bus = EventBus::new();
+            let mut rx = bus.subscribe();
+            let state = test_state();
+            let server = IntendantServer::new(state.clone(), bus.clone());
+
+            // The owner's call IS the opt-in.
+            let result = server
+                .call_tool_by_name_as_caller(
+                    "show_shared_view",
+                    serde_json::json!({
+                        "display_target": "user_session",
+                        "reason": "show the user's screen"
+                    }),
+                    Some("session-a"),
+                    None,
+                    ToolCallerTrust::OwnerSurface,
                 )
                 .await
                 .expect("tool should dispatch");
@@ -1060,6 +1213,119 @@ mod tests {
             let autonomy = { state.read().await.autonomy.clone() };
             assert!(autonomy.read().await.user_display_granted);
         });
+    }
+
+    #[test]
+    fn read_screen_user_session_scoped_caller_needs_the_grant() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let bus = EventBus::new();
+            let state = test_state();
+            let server = IntendantServer::new(state.clone(), bus);
+
+            // Ungranted scoped caller: refused before any platform
+            // accessibility API runs (the element tree reveals screen
+            // content like pixels do, and bypasses the session pipeline on
+            // every platform).
+            let result = server
+                .call_tool_by_name_for_session(
+                    "read_screen",
+                    serde_json::json!({}),
+                    Some("session-a"),
+                    None,
+                )
+                .await
+                .expect("tool should dispatch");
+            let rendered = serde_json::to_string(&result).unwrap_or_default();
+            assert!(
+                rendered.contains("explicit opt-in"),
+                "scoped ungranted read_screen must be refused, got: {rendered}"
+            );
+
+            // With the grant held, the same scoped caller proceeds past the
+            // gate (whatever the headless platform stack then returns, it
+            // must not be the opt-in refusal).
+            let autonomy = { state.read().await.autonomy.clone() };
+            autonomy.write().await.user_display_granted = true;
+            let result = server
+                .call_tool_by_name_for_session(
+                    "read_screen",
+                    serde_json::json!({}),
+                    Some("session-a"),
+                    None,
+                )
+                .await
+                .expect("tool should dispatch");
+            let rendered = serde_json::to_string(&result).unwrap_or_default();
+            assert!(
+                !rendered.contains("explicit opt-in"),
+                "granted read_screen must clear the gate, got: {rendered}"
+            );
+        });
+    }
+
+    #[test]
+    fn grant_user_display_scoped_caller_is_refused() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let bus = EventBus::new();
+            let mut rx = bus.subscribe();
+            let state = test_state();
+            let server = IntendantServer::new(state.clone(), bus.clone());
+
+            let result = server
+                .call_tool_by_name_for_session(
+                    "grant_user_display",
+                    serde_json::json!({}),
+                    Some("session-a"),
+                    None,
+                )
+                .await
+                .expect("tool should dispatch");
+            let rendered = serde_json::to_string(&result).unwrap_or_default();
+            assert!(
+                rendered.contains("owner"),
+                "scoped grant_user_display must be refused, got: {rendered}"
+            );
+            assert!(
+                timeout(Duration::from_millis(200), rx.recv()).await.is_err(),
+                "no grant event may fire for a refused grant"
+            );
+            let autonomy = { state.read().await.autonomy.clone() };
+            assert!(!autonomy.read().await.user_display_granted);
+        });
+    }
+
+    #[test]
+    fn resolve_display_target_never_yields_a_virtual_user_display() {
+        use crate::computer_use::DisplayTarget;
+        // ":00" / "display_00" / "00" must not dodge the user-session gate
+        // that ":0" gets — a parsed id of 0 IS the user session.
+        for spec in [":00", "display_00", "00", ":0", "0", "user_session"] {
+            assert_eq!(
+                resolve_display_target(spec),
+                DisplayTarget::UserSession,
+                "spec {spec:?}"
+            );
+        }
+        assert_eq!(
+            resolve_display_target(":99"),
+            DisplayTarget::Virtual { id: 99 }
+        );
+    }
+
+    #[test]
+    fn caller_trust_gates_user_session_on_grant_or_owner() {
+        assert!(ToolCallerTrust::OwnerSurface.allows_user_session(false));
+        assert!(ToolCallerTrust::OwnerSurface.allows_user_session(true));
+        assert!(!ToolCallerTrust::Scoped.allows_user_session(false));
+        assert!(ToolCallerTrust::Scoped.allows_user_session(true));
     }
 
     #[test]
@@ -1134,12 +1400,15 @@ mod tests {
             let mut rx = bus.subscribe();
             let server = IntendantServer::new(state.clone(), bus);
 
+            // The grant is owner-surface-only; the routing under test is the
+            // owner path (scoped refusal is pinned separately).
             let result = server
-                .call_tool_by_name_for_session(
+                .call_tool_by_name_as_caller(
                     "grant_user_display",
                     serde_json::json!({ "display_id": 2 }),
                     Some("managed-session"),
                     Some(true),
+                    ToolCallerTrust::OwnerSurface,
                 )
                 .await
                 .expect("grant_user_display should route");
@@ -1362,12 +1631,16 @@ mod tests {
             let mut rx = bus.subscribe();
             let server = IntendantServer::new(state.clone(), bus);
 
+            // Owner path (the grant is owner-surface-only; scoped refusal is
+            // pinned separately) — under test here is the active-session
+            // DisplayReady behavior.
             let result = server
-                .call_tool_by_name_for_session(
+                .call_tool_by_name_as_caller(
                     "grant_user_display",
                     serde_json::json!({ "display_id": 0 }),
                     Some("managed-session"),
                     Some(true),
+                    ToolCallerTrust::OwnerSurface,
                 )
                 .await
                 .expect("grant_user_display should route");

--- a/src/bin/caller/web_gateway/mcp_gate.rs
+++ b/src/bin/caller/web_gateway/mcp_gate.rs
@@ -325,7 +325,13 @@ pub(crate) async fn handle_mcp_http_request(
                 });
             }
             match server
-                .call_tool_by_name_for_session(name, args, session_id, codex_managed_context)
+                .call_tool_by_name_as_caller(
+                    name,
+                    args,
+                    session_id,
+                    codex_managed_context,
+                    crate::mcp::ToolCallerTrust::from_principal(&access.principal),
+                )
                 .await
             {
                 Ok(result) => Ok(serde_json::to_value(result).unwrap_or_else(|e| {

--- a/tests/skills/peer-cu-smoke/SKILL.md
+++ b/tests/skills/peer-cu-smoke/SKILL.md
@@ -71,6 +71,15 @@ ctl --peer <peer-label> cu actions --target user_session \
 #    (principal principal:peer-daemon:<fingerprint>, ...)"
 # — that denial IS the pass for the deny leg; run whichever
 # matches the standing grant, or both against two peers.
+#
+# THIRD outcome class on user_session legs: peers are never owner
+# surfaces, so if the TARGET daemon's user-display grant is not held
+# (`ctl display grant-user` on the box), screenshots/actions/elements
+# against user_session return the explicit opt-in refusal ("Access to
+# the user's real display (user_session) is an explicit opt-in ...").
+# That is the grant gate passing, not a transport or profile failure —
+# distinct from the IAM "Permission denied" above. The fleet boxes with
+# a persistent grant never show it; report it if one does.
 
 ctl --peer <peer-label> cu elements
 # OPTIONAL leg — the peer's frontmost UI element tree (read_screen:


### PR DESCRIPTION
Implements every proposal from the user-session gating audit: the `user_display_granted` invariant — "reaching the user's real desktop requires an explicit opt-in" — previously held by construction only on Wayland/Windows (session-existence), and by wording alone on the raw X11/macOS paths. Any principal clearing IAM `display.view`/`display.input` (supervised external agents and MCP token holders are root-compatible by default) could capture or drive the real desktop ungranted; `read_screen` exposed the session's element tree ungated on every platform; the shared-view tools flipped the grant themselves; the runtime's macOS `capture_screen` lacked the env gate its Linux branch has.

What changed:

- **Chokepoint enforcement**: `execute_actions` fails closed for a `UserSession` target without `user_session_allowed`, on every backend, one denial per action with a single opt-in message shared with the native handler's refusal. Session existence on Wayland/Windows is now a second fence, not the gate.
- **Owner surfaces** (`ToolCallerTrust` in `mcp/mod.rs`): the trusted dashboard / enrolled root user clients, bare local loopback, and the stdio transport (wired up by the owner's own client config) may opt in to their own desktop ungranted — the owner's call *is* the opt-in. Everyone else — supervised external agents, scoped grants, federated peers — needs the standing grant. The HTTP gate and the dashboard tunnel derive trust from their bound principal; `call_tool_by_name_for_session` defaults to Scoped, fail-closed. Note `AccessPrincipal::is_owner_surface` deliberately keys on the root dashboard grant id (minted in exactly one place) plus the loopback principal id, **not** on `kind == "root_session"` — the supervised-agent and token-holder defaults share that kind and are exactly who this gate exists to hold.
- **`read_screen`** sits behind the same gate on all platforms — the element tree reveals window titles and field values like pixels do, and it bypasses the session pipeline entirely.
- **`grant_user_display` is owner-surface-only** (revoke stays open — de-escalation is fail-safe). Shared-view activation (`show`/`focus`/`request_input`/`capture`) refuses a user-session target for scoped ungranted callers instead of performing the owner's opt-in; sharing an agent-owned virtual display no longer touches the user grant at all (it previously flipped the global grant as a side effect, which would have defeated the chokepoint).
- **Resolver hygiene**: a parsed display id of 0 (`":00"`, `"display_00"`, `"00"`) normalizes to `UserSession`, so no alias dodges the gate `":0"` gets.
- **Runtime macOS gate**: `capture_screen` checks `INTENDANT_USER_DISPLAY_GRANTED` like the Linux `display <= 0` branch (macOS `screencapture` always reads the primary display).
- **Docs**: the CU chapter's enforcement claims now describe what the code does; autonomy notes the grant is per-daemon (not per-principal); mcp-server and peer-federation state the owner-surface rule (a peer is never an owner surface on the target daemon); peer-cu-smoke documents the new third outcome class on `user_session` legs.

Compatibility: local `ctl` and the dashboard keep working ungranted (owner surfaces). Peers keep reaching agent-owned virtual displays through their profile; a `user_session` reach now additionally requires the target owner's standing grant — the fleet flow's persistent grant already satisfies this. Supervised external agents need the grant for user-session CU, which is the audit's sharpest finding working as intended. Deliberately unchanged: pairing's `DEFAULT_PROFILE` stays `peer-operator` (flagged separately as an owner decision).

Battery on this branch: nextest 2666/2666 (8 new tests: chokepoint per-backend denial + virtual passthrough, scoped-refusal/owner-activation shared-view pair, read_screen deny/allow, scoped grant refusal, resolver pin, trust-matrix pin, owner-surface principal pin), clippy steady at the 85-warning pre-existing baseline, e2e 6/6.