### PR TITLE
ci: probe skipped required checks against the merge queue (task #45)

### DIFF
--- a/.github/PROBE.md
+++ b/.github/PROBE.md
@@ -1,0 +1,17 @@
+# CI skipped-check probe (task #45)
+
+Scratch marker for a one-shot experiment: the PR carrying this file
+guards the required `test (…)` jobs with
+`if: github.head_ref != 'ci-skip-probe'`, so its own pull_request runs
+mint **created-then-skipped** required check runs while its merge-group
+gate still executes normally on the fleet.
+
+Question under test: does the merge queue treat a skipped required
+check as satisfied for queue entry (GitHub's documented behavior), or
+does it block like the never-created / "Expected" wedge?
+
+- If this PR merges: answer is yes — the follow-up PR removes this file
+  and the guard, and the two-job hosted-relevance pattern (doc-only PRs
+  off the fleet) becomes viable.
+- If it wedges: answer is no — close the PR, delete the branch, keep
+  the in-job fast-path relevance checks.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -63,6 +63,14 @@ concurrency:
 jobs:
   test:
     name: test (${{ matrix.os }})
+    # CI probe (task #45; the follow-up PR removes this guard): skip this
+    # required job on the probe branch's own pull_request runs, to verify
+    # the merge queue accepts a created-then-skipped required check
+    # (distinct from a never-created one, which wedges at "Expected").
+    # `head_ref` is only set on pull_request events, so every other run —
+    # pushes, other PRs, and this PR's own merge-group gate — executes
+    # normally.
+    if: github.head_ref != 'ci-skip-probe'
     # Trust-based routing: our own refs (pushes, merge-queue refs, same-repo
     # PRs — every agent landing) run on the self-hosted fleet for speed;
     # fork PRs run on GitHub-hosted runners so external code never executes


### PR DESCRIPTION
One-shot experiment per task #45: the required `test (…)` jobs are guarded with `if: github.head_ref != 'ci-skip-probe'`, so this PR's own pull_request runs mint **created-then-skipped** required check runs while the merge-group gate still executes normally on the fleet.

- Merges cleanly → the queue accepts skipped required checks; a follow-up removes the guard + `.github/PROBE.md`, and the two-job hosted-relevance pattern (doc-only PRs off the fleet) is viable.
- Wedges at Expected/pending → the queue rejects them; this PR gets closed and the branch deleted.