### PR TITLE
Pairing default profile: read-only-display, not peer-operator

### DIFF
--- a/docs/src/peer-federation.md
+++ b/docs/src/peer-federation.md
@@ -691,6 +691,13 @@ headless and should be approved from its own CLI/logs.
    intendant peer deny ABCD-1234
    ```
 
+   When neither the request nor the approval states a profile, the grant
+   defaults to **`read-only-display`** (`DEFAULT_PROFILE` in
+   `access_policy.rs`): the peer can view displays but holds no input.
+   Upgrading is an explicit owner act — `peer approve --profile
+   peer-operator` at approval time, or `peer set-profile` later. The
+   identity a `peer invite` pre-approves carries the same default.
+
 5. Approval signs the requester's public key with the target's access CA and
    exposes only the signed client certificate to the requester. The requester's
    private key never leaves the requester.

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -21,7 +21,14 @@ pub(crate) fn unix_timestamp() -> i64 {
         .unwrap_or_default()
 }
 
-pub const DEFAULT_PROFILE: &str = "peer-operator";
+/// The profile a pairing yields when nobody states one — on `peer approve`
+/// without `--profile` (and no requested profile on the doorbell), and on
+/// the identity a `peer invite` pre-approves. Least-privilege by decision
+/// (2026-07-08): displays are viewable, input is not — an owner upgrades a
+/// specific peer explicitly (`peer approve --profile …` or
+/// `peer set-profile <fingerprint> --profile …`), rather than every unlabeled
+/// pairing arriving input-capable.
+pub const DEFAULT_PROFILE: &str = "read-only-display";
 const POLICY_DIR: &str = "peer-access-identities";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -858,6 +865,24 @@ pub fn normalize_fingerprint(raw: &str) -> Result<String, CallerError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pins the least-privilege pairing default (owner decision,
+    /// 2026-07-08): an unlabeled pairing views displays and never holds
+    /// input. Widening this default back to an input-capable profile is a
+    /// security-posture change that must be made here, deliberately, not
+    /// inherited from a refactor.
+    #[test]
+    fn default_profile_is_least_privilege_display_view() {
+        assert_eq!(DEFAULT_PROFILE, "read-only-display");
+        assert!(profile_allows_operation(
+            DEFAULT_PROFILE,
+            PeerOperation::DisplayView
+        ));
+        assert!(!profile_allows_operation(
+            DEFAULT_PROFILE,
+            PeerOperation::DisplayInput
+        ));
+    }
 
     /// The dashboard's profile picker (`PEER_PROFILE_OPTIONS`) and alias
     /// map (`peerProfileMeta`) are static mirrors of [`PROFILES`] /

--- a/src/bin/caller/peer/pairing.rs
+++ b/src/bin/caller/peer/pairing.rs
@@ -326,7 +326,7 @@ fn print_help() {
     println!("    --port <N>           Port for the default Agent Card URL (default 8765)");
     println!("    --label <NAME>       Display label for this peer in the joining daemon");
     println!("    --client-name <NAME> Common name hint for the issued client certificate");
-    println!("    --profile <NAME>     Peer profile to request, approve, or set (default peer-operator; use peer-root for full peer access)");
+    println!("    --profile <NAME>     Peer profile to request, approve, or set (default read-only-display; peer-operator adds display input + tasks, peer-root is full peer access)");
     println!("    --requester-card-url <URL>  Optional Agent Card URL for the requesting daemon");
     println!();
     println!("NOTES:");

--- a/static/app.html
+++ b/static/app.html
@@ -21177,10 +21177,10 @@ html.ui-v2 #tab-settings .settings-save-row {
                   </div>
                   <div class="daemon-pairing-row">
                     <select id="daemon-request-profile">
+                      <option value="read-only-display" title="Presence, stats, and display viewing. No input control. The default when no profile is stated.">Read-only display</option>
                       <option value="peer-operator" title="Daemon-to-daemon display input, messages, tasks, and approvals. No settings or runtime control.">Peer operator</option>
                       <option value="terminal-operator" title="Session reading plus interactive shell access.">Terminal operator</option>
                       <option value="session-reader" title="Presence, stats, and session history. No shell, task, settings, or display input.">Session reader</option>
-                      <option value="read-only-display" title="Presence, stats, and display viewing. No input control.">Read-only display</option>
                       <option value="shared-session-spectator" title="Presence, stats, and display viewing. No input control.">Spectator</option>
                       <option value="task-runner" title="Presence, stats, messages, and task delegation.">Task runner</option>
                       <option value="stats" title="Presence and usage statistics only.">Stats</option>
@@ -69300,14 +69300,14 @@ function setDaemonPairingStatus(id, msg, kind) {
 
 const PEER_PROFILE_OPTIONS = [
   {
+    profile: 'read-only-display',
+    label: 'Read-only display',
+    summary: 'Presence, stats, and display viewing. No input control. The default when no profile is stated.',
+  },
+  {
     profile: 'peer-operator',
     label: 'Peer operator',
     summary: 'Daemon-to-daemon display input, messages, tasks, and approvals. No settings or runtime control.',
-  },
-  {
-    profile: 'read-only-display',
-    label: 'Read-only display',
-    summary: 'Presence, stats, and display viewing. No input control.',
   },
   {
     profile: 'shared-session-spectator',
@@ -69387,7 +69387,9 @@ function peerProfileMeta(profile) {
 }
 
 function renderPeerProfileOptions(selected) {
-  const value = String(selected || 'peer-operator').toLowerCase();
+  // Mirrors the daemon's DEFAULT_PROFILE (access_policy.rs): an approval
+  // with no stated profile yields read-only-display.
+  const value = String(selected || 'read-only-display').toLowerCase();
   const selectedMeta = peerProfileMeta(value);
   return PEER_PROFILE_OPTIONS.map(({ profile, label, summary }) => (
     `<option value="${escapeHtml(profile)}" ${profile === selectedMeta.profile ? 'selected' : ''} title="${escapeHtml(summary)}">${escapeHtml(label)}</option>`
@@ -69647,12 +69649,14 @@ function renderPeerAccessRequests(requests) {
     const label = escapeHtml(req.requester_label || 'Unnamed daemon');
     const code = escapeHtml(req.code || '');
     const status = String(req.status || 'unknown').toLowerCase();
-    const role = peerProfileMeta(req.approved_profile || req.requested_profile || 'peer-operator');
+    // The || fallback mirrors the daemon's DEFAULT_PROFILE: a request with
+    // no stated profile is what an unadorned approval will grant.
+    const role = peerProfileMeta(req.approved_profile || req.requested_profile || 'read-only-display');
     const source = req.source_hint ? `Source ${escapeHtml(req.source_hint)}` : '';
     const expires = req.expires_at_unix ? `Expires ${escapeHtml(accessRequestTimeLabel(req.expires_at_unix))}` : '';
     const timing = [source, expires].filter(Boolean).join(' - ');
     const pending = status === 'pending';
-    const requestedProfile = req.approved_profile || req.requested_profile || 'peer-operator';
+    const requestedProfile = req.approved_profile || req.requested_profile || 'read-only-display';
     const roleLabel = req.approved_profile ? 'Approved peer profile' : 'Requested peer profile';
     return `
       <div class="daemon-access-request-card">

--- a/static/app/21-access-dialogs.html
+++ b/static/app/21-access-dialogs.html
@@ -120,10 +120,10 @@
                   </div>
                   <div class="daemon-pairing-row">
                     <select id="daemon-request-profile">
+                      <option value="read-only-display" title="Presence, stats, and display viewing. No input control. The default when no profile is stated.">Read-only display</option>
                       <option value="peer-operator" title="Daemon-to-daemon display input, messages, tasks, and approvals. No settings or runtime control.">Peer operator</option>
                       <option value="terminal-operator" title="Session reading plus interactive shell access.">Terminal operator</option>
                       <option value="session-reader" title="Presence, stats, and session history. No shell, task, settings, or display input.">Session reader</option>
-                      <option value="read-only-display" title="Presence, stats, and display viewing. No input control.">Read-only display</option>
                       <option value="shared-session-spectator" title="Presence, stats, and display viewing. No input control.">Spectator</option>
                       <option value="task-runner" title="Presence, stats, messages, and task delegation.">Task runner</option>
                       <option value="stats" title="Presence and usage statistics only.">Stats</option>

--- a/static/app/52-peer-display.js
+++ b/static/app/52-peer-display.js
@@ -1664,14 +1664,14 @@ function setDaemonPairingStatus(id, msg, kind) {
 
 const PEER_PROFILE_OPTIONS = [
   {
+    profile: 'read-only-display',
+    label: 'Read-only display',
+    summary: 'Presence, stats, and display viewing. No input control. The default when no profile is stated.',
+  },
+  {
     profile: 'peer-operator',
     label: 'Peer operator',
     summary: 'Daemon-to-daemon display input, messages, tasks, and approvals. No settings or runtime control.',
-  },
-  {
-    profile: 'read-only-display',
-    label: 'Read-only display',
-    summary: 'Presence, stats, and display viewing. No input control.',
   },
   {
     profile: 'shared-session-spectator',
@@ -1751,7 +1751,9 @@ function peerProfileMeta(profile) {
 }
 
 function renderPeerProfileOptions(selected) {
-  const value = String(selected || 'peer-operator').toLowerCase();
+  // Mirrors the daemon's DEFAULT_PROFILE (access_policy.rs): an approval
+  // with no stated profile yields read-only-display.
+  const value = String(selected || 'read-only-display').toLowerCase();
   const selectedMeta = peerProfileMeta(value);
   return PEER_PROFILE_OPTIONS.map(({ profile, label, summary }) => (
     `<option value="${escapeHtml(profile)}" ${profile === selectedMeta.profile ? 'selected' : ''} title="${escapeHtml(summary)}">${escapeHtml(label)}</option>`
@@ -2011,12 +2013,14 @@ function renderPeerAccessRequests(requests) {
     const label = escapeHtml(req.requester_label || 'Unnamed daemon');
     const code = escapeHtml(req.code || '');
     const status = String(req.status || 'unknown').toLowerCase();
-    const role = peerProfileMeta(req.approved_profile || req.requested_profile || 'peer-operator');
+    // The || fallback mirrors the daemon's DEFAULT_PROFILE: a request with
+    // no stated profile is what an unadorned approval will grant.
+    const role = peerProfileMeta(req.approved_profile || req.requested_profile || 'read-only-display');
     const source = req.source_hint ? `Source ${escapeHtml(req.source_hint)}` : '';
     const expires = req.expires_at_unix ? `Expires ${escapeHtml(accessRequestTimeLabel(req.expires_at_unix))}` : '';
     const timing = [source, expires].filter(Boolean).join(' - ');
     const pending = status === 'pending';
-    const requestedProfile = req.approved_profile || req.requested_profile || 'peer-operator';
+    const requestedProfile = req.approved_profile || req.requested_profile || 'read-only-display';
     const roleLabel = req.approved_profile ? 'Approved peer profile' : 'Requested peer profile';
     return `
       <div class="daemon-access-request-card">

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1162,8 +1162,10 @@ async fn ctl_peer_mtls_pairing_binds_scoped_profile_and_gates_display_input() {
     // Approve headlessly on B: a direct state-file write against B's
     // cert store (the running daemon rereads the file per status poll).
     // The profile is stated explicitly again — approval, not the
-    // request, is what grants — and canonically: unknown profile
-    // strings silently degrade to presence-only rather than erroring.
+    // request, is what grants — and canonically: the CLI validates
+    // profile names loudly, while unknown strings arriving on the wire
+    // are stored as-is and stay fail-closed (presence-only) at
+    // authorization time.
     let approve = {
         let mut cmd = daemon_b.rig.command();
         cmd.args([


### PR DESCRIPTION
The flagged least-privilege follow-up: an unlabeled pairing — `peer approve` without `--profile` on a request that stated none, or the identity a `peer invite` pre-approves — used to arrive **input-capable** (`DEFAULT_PROFILE = peer-operator`), meaning the default outcome of the ceremony included `execute_cu_actions` on the granting box. The default is now `read-only-display`: displays viewable, input never, upgrades explicit.

- The const carries the decision rationale and a pin test (exact value + allows `DisplayView` + denies `DisplayInput`), so widening it back is a deliberate edit at the definition, not a refactor side effect.
- Dashboard mirrors follow: both profile pickers list read-only-display first, and the request-card/approve-dialog fallback literals that render an unstated profile now show what an unadorned approval actually grants. The picker parity tests pin ID sets, which are unchanged.
- `peer --help` and the peer-federation pairing walkthrough state the default and the upgrade path (`peer approve --profile …` at approval time, `peer set-profile` later — no re-pairing).
- A stale e2e comment corrected in passing: CLI profile values validate loudly since the set-profile change; only wire-arrived strings stay lenient and fail-closed.

Existing peers are untouched — stored identity records keep whatever profile was granted. The e2e ceremonies state profiles explicitly on both sides and are unaffected.

Battery: nextest 2659/2659, e2e 6/6, clippy steady at the pre-existing baseline. `static/app.html` regenerated from the fragments.