### PR TITLE
smokes: kernel-assigned ports; land on any Linux instance (task #46)

### DIFF
--- a/.github/workflows/smokes.yml
+++ b/.github/workflows/smokes.yml
@@ -70,15 +70,19 @@ jobs:
       fail-fast: false
       matrix:
         # `os` is the pinned check-name key and the fork-PR hosted label;
-        # `runner` is the self-hosted fleet placement. The smokes pin to the
-        # dedicated intendant-smokes-* labels (one runner instance per box
-        # carries them): the drivers bind fixed ports, so two smokes jobs
-        # must never run concurrently on one machine, while the test jobs
-        # are free to land on any instance. Provisioning steps gate on
-        # runner.environment. See windows.yml for the full rationale.
+        # `runner` is the self-hosted fleet placement. The smokes land on
+        # any Linux instance (same label as the test jobs): the drivers
+        # use kernel-assigned ports (`--web 0`, parsed from the daemon's
+        # output) and pid-keyed control sockets, so concurrent smoke jobs
+        # on one machine can't collide or cross-talk. (They previously
+        # bound fixed ports and pinned to a dedicated one-instance-per-box
+        # intendant-smokes-linux label — that serialization is gone; the
+        # label can be retired from the runner config.) Provisioning steps
+        # gate on runner.environment. See windows.yml for the full
+        # rationale.
         include:
           - os: ubuntu-latest
-            runner: [self-hosted, intendant-smokes-linux]
+            runner: [self-hosted, intendant-linux]
             target: x86_64-unknown-linux-gnu
 
     steps:

--- a/src/bin/caller/startup/web.rs
+++ b/src/bin/caller/startup/web.rs
@@ -37,7 +37,15 @@ pub(crate) async fn find_available_port(
     for offset in 0..20u16 {
         let port = preferred.checked_add(offset).unwrap_or(preferred);
         match bind_web_listener(port, bind_ip).await {
-            Ok(listener) => return Ok((port, listener)),
+            Ok(listener) => {
+                // Report the port actually bound, not the one requested:
+                // `--web 0` asks the kernel for an ephemeral port (the
+                // race-free way to run parallel daemons — smoke rigs and
+                // CI runner instances sharing a box), and `local_addr` is
+                // the only truthful source for what it picked.
+                let bound = listener.local_addr().map(|a| a.port()).unwrap_or(port);
+                return Ok((bound, listener));
+            }
             Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => continue,
             Err(e) => {
                 return Err(CallerError::Config(format!(
@@ -570,6 +578,22 @@ pub(crate) fn should_start_idle_web_daemon(use_web: bool, flags: &CliFlags) -> b
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn find_available_port_reports_the_kernel_assigned_port_for_web_zero() {
+        // `--web 0` = ephemeral bind: the returned port must be what the
+        // kernel actually assigned (smoke rigs parse it from the
+        // Dashboard log line), never the literal 0 that was requested.
+        let loopback = Some("127.0.0.1".parse().unwrap());
+        let (port, listener) = find_available_port(0, loopback).await.unwrap();
+        assert_ne!(port, 0);
+        assert_eq!(port, listener.local_addr().unwrap().port());
+        // A second ephemeral bind coexists — the parallel-daemon case.
+        let (port2, listener2) = find_available_port(0, loopback).await.unwrap();
+        assert_ne!(port2, 0);
+        assert_ne!(port2, port);
+        drop((listener, listener2));
+    }
 
     #[test]
     fn public_ip_classification_excludes_private_and_documentation_ranges() {

--- a/tests/skills/native-goal-smoke/driver.cjs
+++ b/tests/skills/native-goal-smoke/driver.cjs
@@ -13,7 +13,6 @@ const path = require('path');
 const BINARY = process.argv[2] || path.resolve(__dirname, '../../../..', 'target/release/intendant');
 const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'native-goal-home-'));
 const PROJ = fs.mkdtempSync(path.join(os.tmpdir(), 'native-goal-proj-'));
-const PORT = 18994;
 
 const script = {
   profiles: [{
@@ -51,7 +50,11 @@ for (const k of ['OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'GEMINI_API_KEY', 'MODEL
 // which does not spawn the control socket — with a task the run lands in
 // the foreground web branch whose worker loop is run_with_presence (the native
 // goal engine's home).
-const child = spawn(BINARY, ['--no-tui', '--web', String(PORT), '--bind', '127.0.0.1', '--no-tls',
+// `--web 0` = kernel-assigned port: this driver only talks over the
+// pid-keyed control socket, so any free port works, and concurrent
+// smoke runs on one box (two CI runner instances) can't collide or
+// cross-talk.
+const child = spawn(BINARY, ['--no-tui', '--web', '0', '--bind', '127.0.0.1', '--no-tls',
   '--control-socket', '--autonomy', 'full', 'do the initial smoke task'], {
   cwd: PROJ, env, stdio: ['ignore', 'pipe', 'pipe'],
 });

--- a/tests/skills/peer-sessions-smoke/SKILL.md
+++ b/tests/skills/peer-sessions-smoke/SKILL.md
@@ -6,8 +6,12 @@ federate, a task is delegated through the primary, and the primary's
 folded per-session state.
 
 Keyless — both daemons run the scripted mock provider (`PROVIDER=mock`).
-Not in CI because it binds fixed local ports (18777/18778), spawns real
-daemons, and the `--browser` leg drives a real headless Chrome.
+The API leg gates landings in CI (smokes.yml). Daemon ports are
+kernel-assigned (`--web 0`, parsed from each daemon's log), so
+concurrent runs on one box — two CI runner instances, or a rig beside a
+dev daemon — can't collide. The `--browser` leg stays a local/canary
+check: it drives a real headless Chrome (CDP port 9333; override with
+`PEER_RIG_CDP_PORT`).
 
 ## Run
 

--- a/tests/skills/peer-sessions-smoke/peer-rig.py
+++ b/tests/skills/peer-sessions-smoke/peer-rig.py
@@ -18,6 +18,7 @@ Native daemon-lane children emit no per-session usage/limits (the known
 """
 import json
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -33,7 +34,12 @@ WORKTREE = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__
 # battery keeps exercising the release artifact by default.
 BIN = os.environ.get("INTENDANT_BIN") or os.path.join(WORKTREE, "target/release/intendant")
 SCRATCH = os.environ.get("PEER_RIG_SCRATCH") or tempfile.mkdtemp(prefix="peer-rig-")
-A_PORT, B_PORT, CDP_PORT = 18777, 18778, 9333
+# Daemon ports are kernel-assigned (`--web 0`, parsed from the Dashboard
+# log line) so concurrent rig runs on one box — two CI runner instances,
+# or a rig beside a dev daemon — can't collide or cross-talk. The CDP
+# port only exists on the local --browser leg; override it if 9333 is
+# taken.
+CDP_PORT = int(os.environ.get("PEER_RIG_CDP_PORT", "9333"))
 BROWSER = "--browser" in sys.argv
 SLEEP_STEP = 30 if BROWSER else 6
 CHROME = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
@@ -90,7 +96,7 @@ def wait_for(desc, fn, timeout=45, interval=0.25):
     raise SystemExit(f"TIMEOUT waiting for {desc} (last error: {last})")
 
 
-def spawn_daemon(name, home, port, script, cwd):
+def spawn_daemon(name, home, script, cwd):
     os.makedirs(home, exist_ok=True)
     os.makedirs(cwd, exist_ok=True)
     script_path = os.path.join(home, "mock_script.json")
@@ -101,16 +107,31 @@ def spawn_daemon(name, home, port, script, cwd):
                         "MODEL_NAME", "PRESENCE_PROVIDER", "PRESENCE_MODEL",
                         "CU_PROVIDER", "CU_MODEL")}
     env.update(HOME=home, PROVIDER="mock", INTENDANT_MOCK_SCRIPT=script_path)
-    out = open(os.path.join(home, "daemon.log"), "w")
+    log_path = os.path.join(home, "daemon.log")
+    out = open(log_path, "w")
+    # `--web 0` asks the kernel for a free port (race-free — the daemon
+    # binds it directly, no probe-then-reuse window) and the daemon
+    # prints the port it actually bound. A 127.0.0.1 bind self-advertises
+    # ws://127.0.0.1:<actual>/ws on the agent card, so no --advertise-url
+    # is needed.
     p = subprocess.Popen(
-        [BIN, "--web", str(port), "--bind", "127.0.0.1", "--no-tls", "--no-tui",
-         "--autonomy", "full", "--advertise-url", f"ws://127.0.0.1:{port}/ws"],
+        [BIN, "--web", "0", "--bind", "127.0.0.1", "--no-tls", "--no-tui",
+         "--autonomy", "full"],
         cwd=cwd, env=env, stdin=subprocess.DEVNULL, stdout=out, stderr=out)
     procs.append((name, p))
+
+    def parse_port():
+        if p.poll() is not None:
+            raise SystemExit(f"{name} exited early (code {p.poll()}) — see {log_path}")
+        with open(log_path) as f:
+            m = re.search(r"Dashboard: https?://127\.0\.0\.1:(\d+)", f.read())
+        return int(m.group(1)) if m else None
+
+    port = wait_for(f"{name} bound port", parse_port, timeout=30)
     log(f"daemon {name} pid {p.pid} port {port} home {home}")
     wait_for(f"{name} agent card",
              lambda: http("GET", f"http://127.0.0.1:{port}/.well-known/agent-card.json"))
-    return p
+    return p, port
 
 
 PEER_TASK_MARK = "PEER RIG TASK"
@@ -162,17 +183,17 @@ try:
     with open(os.path.join(proj_a, "dirty.txt"), "w") as f:
         f.write("uncommitted\n")
 
-    spawn_daemon("A(peer)", os.path.join(SCRATCH, "home-a"), A_PORT, script_a, proj_a)
-    spawn_daemon("B(primary)", os.path.join(SCRATCH, "home-b"), B_PORT, script_b,
-                 os.path.join(SCRATCH, "proj-b"))
+    _, a_port = spawn_daemon("A(peer)", os.path.join(SCRATCH, "home-a"), script_a, proj_a)
+    _, b_port = spawn_daemon("B(primary)", os.path.join(SCRATCH, "home-b"), script_b,
+                             os.path.join(SCRATCH, "proj-b"))
 
-    add = http("POST", f"http://127.0.0.1:{B_PORT}/api/peers",
-               {"card_url": f"http://127.0.0.1:{A_PORT}/.well-known/agent-card.json",
+    add = http("POST", f"http://127.0.0.1:{b_port}/api/peers",
+               {"card_url": f"http://127.0.0.1:{a_port}/.well-known/agent-card.json",
                 "label": "rig-peer"})
     log(f"peer add -> {add}")
 
     def connected():
-        for p in http("GET", f"http://127.0.0.1:{B_PORT}/api/peers")["peers"]:
+        for p in http("GET", f"http://127.0.0.1:{b_port}/api/peers")["peers"]:
             if p.get("connection_state", {}).get("state") == "connected":
                 return p
         return None
@@ -182,12 +203,12 @@ try:
     log(f"connected: {peer_id}")
 
     def peer_sessions():
-        for p in http("GET", f"http://127.0.0.1:{B_PORT}/api/peers")["peers"]:
+        for p in http("GET", f"http://127.0.0.1:{b_port}/api/peers")["peers"]:
             if p["id"] == peer_id:
                 return p.get("sessions", [])
         return []
 
-    task = http("POST", f"http://127.0.0.1:{B_PORT}/api/peers/{peer_id}/task",
+    task = http("POST", f"http://127.0.0.1:{b_port}/api/peers/{peer_id}/task",
                 {"instructions": f"{PEER_TASK_MARK} - run the scripted steps"})
     log(f"delegated -> {task}")
 
@@ -226,7 +247,7 @@ try:
             return r.stdout.strip()
 
         wait_for("chrome CDP", lambda: cdp("eval", "1+1"))
-        cdp("nav", f"http://127.0.0.1:{B_PORT}/")
+        cdp("nav", f"http://127.0.0.1:{b_port}/")
         wait_for("dashboard booted", lambda: True if cdp(
             "eval", "!!document.querySelector('.tab-btn')") == "true" else None)
         cdp("eval", "(() => { const b = [...document.querySelectorAll('button.tab-btn')]"
@@ -273,7 +294,7 @@ try:
           f"git vitals rode the peer rail (dirtyFiles={git.get('dirtyFiles')})")
 
     log(f"stopping child {child_sid} on A via /ws stop_session")
-    ws_action(A_PORT, {"action": "stop_session", "session_id": child_sid})
+    ws_action(a_port, {"action": "stop_session", "session_id": child_sid})
     wait_for("child retirement after stop",
              lambda: True if child_of(peer_sessions()) is None else None, timeout=30)
     check(True, "SessionEnded retired the folded child")

--- a/tests/skills/session-vitals-smoke/driver.cjs
+++ b/tests/skills/session-vitals-smoke/driver.cjs
@@ -12,7 +12,6 @@ const path = require('path');
 const BINARY = process.argv[2];
 const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'vitals-home-'));
 const PROJ = fs.mkdtempSync(path.join(os.tmpdir(), 'vitals-proj-'));
-const PORT = 18997;
 
 // The project is a real git repo: one commit, a feature branch one ahead
 // of main, plus a dirty file.
@@ -34,7 +33,11 @@ fs.writeFileSync(scriptPath, JSON.stringify(script));
 const env = { ...process.env, HOME, USERPROFILE: HOME, PROVIDER: 'mock', INTENDANT_MOCK_SCRIPT: scriptPath };
 for (const k of ['OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'GEMINI_API_KEY', 'MODEL_NAME']) delete env[k];
 
-const child = spawn(BINARY, ['--no-tui', '--web', String(PORT), '--bind', '127.0.0.1', '--no-tls',
+// `--web 0` = kernel-assigned port: this driver only talks over the
+// pid-keyed control socket, so any free port works, and concurrent
+// smoke runs on one box (two CI runner instances) can't collide or
+// cross-talk.
+const child = spawn(BINARY, ['--no-tui', '--web', '0', '--bind', '127.0.0.1', '--no-tls',
   '--control-socket', '--autonomy', 'full', 'trivial task'], { cwd: PROJ, env, stdio: ['ignore', 'pipe', 'pipe'] });
 let exited = false;
 child.on('exit', () => { exited = true; });


### PR DESCRIPTION
The three keyless smoke drivers bound fixed ports (18997, 18994,
18777/18778), which serialized the smokes job onto a dedicated
one-instance-per-box runner label — and the fixed ports were also a
cross-talk hazard: the daemon's bind walk means a second daemon asked
for a taken port comes up on a neighbor while its driver still polls
the original, i.e. someone else's daemon.

find_available_port now reports the port actually bound (local_addr)
instead of the requested one, which makes '--web 0' work end to end:
the kernel assigns a free port race-free and the real port flows to
the Dashboard log line, the agent card, and everything downstream.
The vitals and goal drivers just pass --web 0 (they only talk over
the pid-keyed control socket); the peer rig parses each daemon's
bound port from its log and drops --advertise-url (a 127.0.0.1 bind
self-advertises the same loopback URL with the actual port). The CDP
port stays fixed but overridable (PEER_RIG_CDP_PORT) — browser leg
only, not in CI.

smokes.yml moves from intendant-smokes-linux to plain intendant-linux:
concurrent smoke jobs on one box can no longer collide, so the smokes
land on any instance like the test jobs, doubling their slots without
touching runner config (the dedicated label can be retired). Proven
locally with two of each driver — eight daemons — running
concurrently, all green.
