### PR TITLE
Supervised-session approvals + the ui-v2 default flip

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -45,3 +45,13 @@ slow-timeout = { period = "60s", terminate-after = 4 }
 [[profile.default.overrides]]
 filter = 'test(/ctl_peer_mtls_pairing/)'
 slow-timeout = { period = "120s", terminate-after = 3 }
+
+# These handlers walk the real ~/.intendant/logs via dirs::home_dir()
+# (routes_sessions.rs agent-output / managed-context scans); on a box
+# whose log tree has grown to tens of GB their ~12s baseline breaches the
+# default terminator under suite parallelism while passing in isolation.
+# Headroom until that home scan is cfg(test)-gated like listener.rs's
+# session-index warm scan.
+[[profile.default.overrides]]
+filter = 'test(/^web_gateway::routes_sessions::tests::(agent_output_post_response_reads_json_ids|managed_context_anchors_response_reads_trace_anchors_by_backend_session|managed_context_records_response_)/)'
+slow-timeout = { period = "60s", terminate-after = 4 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,10 @@ SysPrompt*.md   # per-role system prompts (base, tools, user, orchestrator, rese
   `crates/app-html-assembler`; CI enforces the match). Edit the fragments,
   never the artifact. Merge conflicts: resolve them in the fragments, run
   `cargo run -p app-html-assembler`, then `git add static/app.html` — never
-  hand-reconcile the generated file.
+  hand-reconcile the generated file. The dashboard ships the **ui-v2 chrome
+  by default** (design overhaul: `ui2-*` fragments + the `16-styles-v2-tokens`
+  palette, all scoped under `html.ui-v2`); `?ui=v1` is the soak-period escape
+  hatch until the v1 chrome/Catppuccin generation is deleted.
 - Pure-safe Rust by default. The Unix (macOS / Linux) code paths keep `unsafe`
   confined to documented islands: small platform probes/signals and display or
   identity queries in `platform.rs` (now `crates/intendant-platform`); macOS Accessibility bindings in `ax.rs`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,10 @@ SysPrompt*.md   # per-role system prompts (base, tools, user, orchestrator, rese
   `crates/app-html-assembler`; CI enforces the match). Edit the fragments,
   never the artifact. Merge conflicts: resolve them in the fragments, run
   `cargo run -p app-html-assembler`, then `git add static/app.html` — never
-  hand-reconcile the generated file.
+  hand-reconcile the generated file. The dashboard ships the **ui-v2 chrome
+  by default** (design overhaul: `ui2-*` fragments + the `16-styles-v2-tokens`
+  palette, all scoped under `html.ui-v2`); `?ui=v1` is the soak-period escape
+  hatch until the v1 chrome/Catppuccin generation is deleted.
 - Pure-safe Rust by default. The Unix (macOS / Linux) code paths keep `unsafe`
   confined to documented islands: small platform probes/signals and display or
   identity queries in `platform.rs` (now `crates/intendant-platform`); macOS Accessibility bindings in `ax.rs`

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -3,7 +3,11 @@
 The web dashboard is Intendant's **default frontend**. It is a single-page app
 served by the controller's built-in HTTP/WebSocket gateway, running entirely in
 the browser with WASM-powered state management (the `presence-web` crate,
-Catppuccin Mocha theme, mobile-responsive). The SPA is served as one
+mobile-responsive). Since the design-overhaul flip the default look is the
+**v2 chrome** (dark, Iris accent: left navigation rail, oversight bar, ⌘K
+command palette, bottom composer); the previous Catppuccin Mocha generation
+remains reachable at `?ui=v1` as an escape hatch during the soak period, after
+which it will be deleted. The SPA is served as one
 self-contained file, `static/app.html` — a **generated artifact**: `build.rs`
 assembles it from the ordered fragments in `static/app/` (`manifest.txt` fixes
 the order) via `crates/app-html-assembler`, and CI rejects any drift between
@@ -81,10 +85,20 @@ the idle daemon loop.
 
 ## Tabs
 
-The top tab bar has ten tabs: **Activity**, **Stats**, **Terminal**,
-**Video**, **Station**, **Sessions**, **Files**, **Access**, **Debug**, and
-**Settings**. New events arriving while you are on another tab raise a
-notification badge.
+The v2 chrome groups eleven destinations in the left navigation rail —
+**Activity** and **Sessions** (Work), **Live display** and **Station** (Watch),
+**Terminal** and **Files** (Machine), **Usage** (Insight), **Access** and
+**Vault** (Trust), **Settings** and **Debug** (System). The oversight bar on
+top carries the phase pill, stop control, context meter, transport state, the
+Activity Focus/Grid layout toggle, and the ⌘K command palette; the composer —
+the global task input — docks at the bottom and reaches the daemon from any
+destination. New events arriving while you are elsewhere raise a badge on the
+rail item. (Under `?ui=v1` the same panes hang off the classic top tab bar;
+Vault lives inside Access there.)
+
+The section headings below keep the internal pane names (`Video` is the Live
+display destination, `Stats` is Usage) — ids, routes, and deep links are
+unchanged by the redesign.
 
 ### One design language, bounded DOM
 
@@ -172,9 +186,20 @@ Five subtabs:
   - **live** — voice transcripts, presence lifecycle, tool requests
   - **server** — presence model internals (thinking, tool calls)
 
-  The Log pane also carries the approval controls (Approve / Skip / Approve All
-  / Deny) and a follow-up text input for sending a message after a round
-  completes.
+  Under v2 the Log pane has two layouts, toggled from the oversight bar and
+  persisted per browser: **Focus** (the default) shows the combined stream as
+  one centered timeline with role eyebrows, and on wide viewports a vitals
+  rail for the foreground session (working tree, context budget, prompt
+  cache, rate limits, changes); **Grid** shows the classic per-session
+  window grid with relationship wires and the concurrent stream below.
+
+  The Log pane also carries the approval card. **Approve** clears the
+  pending command once; **Approve all like this** sets that approval
+  category's rule to `auto` (the shipped per-category machinery, scoped and
+  revocable in Settings) and then approves; **Switch to Full autonomy** is
+  the old approve-all — it lifts every gate, and is labeled for what it is.
+  Skip and Deny complete the set (`y` / `a` / `s` / `n`). A follow-up text
+  input sends a message after a round completes.
 - **Context** — the agent's current working context (what it is operating on).
 - **Managed** — operator console for managed-Codex context maintenance (see
   below).

--- a/macos-app/main.swift
+++ b/macos-app/main.swift
@@ -852,9 +852,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         window.delegate = self
         window.makeKeyAndOrderFront(nil)
 
-        // Dark title bar to match Catppuccin Mocha theme
+        // Dark title bar matching the ui-v2 background (--bg #0B0C10);
+        // the dashboard defaults to v2 since the P3 flip.
         window.titlebarAppearsTransparent = true
-        window.backgroundColor = NSColor(red: 30/255, green: 30/255, blue: 46/255, alpha: 1.0)
+        window.backgroundColor = NSColor(red: 11/255, green: 12/255, blue: 16/255, alpha: 1.0)
         window.appearance = NSAppearance(named: .darkAqua)
     }
 

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -911,7 +911,14 @@ impl SessionSupervisor {
                     context_injection,
                     supervisor.config.session_registry.clone(),
                     supervisor.config.peer_registry.clone(),
-                    true,
+                    // Headless (auto-deny gated commands) only when there is
+                    // no dashboard to ask: with the gateway up, supervised
+                    // sessions surface approvals per session — the dispatch
+                    // table routes Approve/Deny/Skip into this session's
+                    // registry, and spawn_sub_agent documents children as
+                    // having "their own approvals". Mirrors the foreground's
+                    // `!use_web`.
+                    web_port.is_none(),
                     attachments,
                     native,
                 )

--- a/static/app.html
+++ b/static/app.html
@@ -8,25 +8,31 @@
 <link rel="icon" type="image/png" sizes="128x128" href="/icon-128.png" id="favicon">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.webmanifest">
-<meta name="theme-color" content="#11111b">
+<meta name="theme-color" content="#0B0C10">
 <script>
   // ui-v2 flag (design-overhaul program): decide before first paint so
   // neither UI generation flashes. `?ui=v2` / `?ui=v1` overrides and
-  // persists; otherwise localStorage wins; default stays v1 until the
-  // program flips it. The class lives on <html> — all v2 styles are
-  // scoped under `html.ui-v2` and are inert without it.
+  // persists; otherwise localStorage wins. v2 is the DEFAULT since the
+  // P3 flip — `?ui=v1` (or a stored '0') is the soak-period escape
+  // hatch until the v1 chrome is deleted. The class lives on <html> —
+  // all v2 styles are scoped under `html.ui-v2` and inert without it.
   (function () {
-    var on = false;
+    var on = true;
     try {
       var q = new URLSearchParams(location.search).get('ui');
       if (q === 'v2' || q === 'v1') {
         on = q === 'v2';
         localStorage.setItem('intendant.ui2', on ? '1' : '0');
       } else {
-        on = localStorage.getItem('intendant.ui2') === '1';
+        on = localStorage.getItem('intendant.ui2') !== '0';
       }
-    } catch (e) { /* storage unavailable: stay v1 */ }
+    } catch (e) { /* storage unavailable: v2 default */ }
     if (on) document.documentElement.classList.add('ui-v2');
+    else {
+      // v1 keeps its Catppuccin crust tab tint during the soak.
+      var meta = document.querySelector('meta[name="theme-color"]');
+      if (meta) meta.setAttribute('content', '#11111b');
+    }
   })();
 </script>
 <style>
@@ -23310,6 +23316,12 @@ function ui2ApproveCategoryRule() {
   const category = ui2ApprovalCategory();
   if (category && typeof dispatchControlMsg === 'function') {
     dispatchControlMsg({ action: 'set_approval_rule', category, rule: 'auto' });
+    // Re-pull the shared control state so an already-open Control pane /
+    // Settings autonomy section shows the new rule (they otherwise
+    // refresh only on open — pull-based by design).
+    setTimeout(() => {
+      if (typeof refreshControlPane === 'function') refreshControlPane();
+    }, 400);
   }
   sendApproval('approve');
 }

--- a/static/app/00-head.html
+++ b/static/app/00-head.html
@@ -7,24 +7,30 @@
 <link rel="icon" type="image/png" sizes="128x128" href="/icon-128.png" id="favicon">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <link rel="manifest" href="/manifest.webmanifest">
-<meta name="theme-color" content="#11111b">
+<meta name="theme-color" content="#0B0C10">
 <script>
   // ui-v2 flag (design-overhaul program): decide before first paint so
   // neither UI generation flashes. `?ui=v2` / `?ui=v1` overrides and
-  // persists; otherwise localStorage wins; default stays v1 until the
-  // program flips it. The class lives on <html> — all v2 styles are
-  // scoped under `html.ui-v2` and are inert without it.
+  // persists; otherwise localStorage wins. v2 is the DEFAULT since the
+  // P3 flip — `?ui=v1` (or a stored '0') is the soak-period escape
+  // hatch until the v1 chrome is deleted. The class lives on <html> —
+  // all v2 styles are scoped under `html.ui-v2` and inert without it.
   (function () {
-    var on = false;
+    var on = true;
     try {
       var q = new URLSearchParams(location.search).get('ui');
       if (q === 'v2' || q === 'v1') {
         on = q === 'v2';
         localStorage.setItem('intendant.ui2', on ? '1' : '0');
       } else {
-        on = localStorage.getItem('intendant.ui2') === '1';
+        on = localStorage.getItem('intendant.ui2') !== '0';
       }
-    } catch (e) { /* storage unavailable: stay v1 */ }
+    } catch (e) { /* storage unavailable: v2 default */ }
     if (on) document.documentElement.classList.add('ui-v2');
+    else {
+      // v1 keeps its Catppuccin crust tab tint during the soak.
+      var meta = document.querySelector('meta[name="theme-color"]');
+      if (meta) meta.setAttribute('content', '#11111b');
+    }
   })();
 </script>

--- a/static/app/ui2-activity.js
+++ b/static/app/ui2-activity.js
@@ -24,6 +24,12 @@ function ui2ApproveCategoryRule() {
   const category = ui2ApprovalCategory();
   if (category && typeof dispatchControlMsg === 'function') {
     dispatchControlMsg({ action: 'set_approval_rule', category, rule: 'auto' });
+    // Re-pull the shared control state so an already-open Control pane /
+    // Settings autonomy section shows the new rule (they otherwise
+    // refresh only on open — pull-based by design).
+    setTimeout(() => {
+      if (typeof refreshControlPane === 'function') refreshControlPane();
+    }, 400);
   }
   sendApproval('approve');
 }

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1364,3 +1364,135 @@ async fn ctl_peer_mtls_pairing_binds_scoped_profile_and_gates_display_input() {
 
     let _ = daemon_b.child.kill().await;
 }
+
+/// A supervised session under the web gateway surfaces Ask-category
+/// approvals on the dashboard instead of failing closed. The launch used
+/// to hard-code `headless: true`, so a CreateSession'd session auto-denied
+/// gated commands with "Approval required in headless mode" even though
+/// the dispatch table routes Approve/Deny/Skip into the session's own
+/// approval registry — and the spawn_sub_agent contract documents children
+/// as having "their own approvals". Pin the whole loop: the approval event
+/// arrives tagged with the session id, an `approve` over /ws releases it,
+/// and the gated command really runs (the seeded marker file disappears).
+#[tokio::test]
+async fn supervised_session_surfaces_approvals_on_the_dashboard() {
+    use futures_util::SinkExt;
+
+    let rig = TestRig::new();
+    let script = rig.write_script(&serde_json::json!({
+        "profiles": [{
+            "steps": [
+                { "content": "Deleting the marker.",
+                  "tool_calls": [{ "name": "exec_command",
+                                   "arguments": { "nonce": 1, "command": "rm approval-pin-marker.txt" } }] },
+                // No transcript expectation: a successful rm prints
+                // nothing — the test's proof is the marker file itself
+                // disappearing from the session project.
+                { "content": "Marker removed.",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "approval pin complete" } }] }
+            ]
+        }]
+    }));
+    // The session's project: seeded with the marker the gated `rm` deletes.
+    let session_project = tempfile::tempdir().expect("session project dir");
+    let marker = session_project.path().join("approval-pin-marker.txt");
+    std::fs::write(&marker, "pin").expect("seed marker");
+
+    // Default autonomy (Medium): `rm` classifies destructive → Ask.
+    let mut cmd = rig.command();
+    cmd.env("INTENDANT_MOCK_SCRIPT", &script)
+        .args(["--no-tls", "--web", "18941"]);
+    let mut child = cmd.spawn().expect("spawn intendant daemon");
+    let stderr_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let stdout_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let _stderr_drain = drain_pipe_into(child.stderr.take().expect("stderr"), stderr_buf.clone());
+    let _stdout_drain = drain_pipe_into(child.stdout.take().expect("stdout"), stdout_buf.clone());
+
+    let stderr_so_far = wait_for_output(&stderr_buf, "Dashboard: http://", RUN_TIMEOUT).await;
+    let port: u16 = stderr_so_far
+        .lines()
+        .find_map(|line| {
+            let url = line.strip_prefix("Dashboard: http://")?;
+            url.rsplit(':').next()?.trim().parse().ok()
+        })
+        .expect("parse the dashboard port from the startup line");
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/ws"))
+        .await
+        .expect("connect /ws");
+
+    // The very first control message can race daemon startup (the gateway
+    // accepts /ws a beat before the supervisor subscribes) — retry the
+    // send until the approval surfaces. A duplicate create is harmless
+    // here: we approve the first approval's session and stop it; the rig
+    // kills the daemon on drop.
+    let mut approval = None;
+    for _ in 0..6 {
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::json!({
+                "action": "create_session",
+                "task": "delete the pinned marker file",
+                "project_root": session_project.path(),
+                "direct": true,
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send create_session");
+        approval = next_matching_ws_event(&mut ws, Duration::from_secs(30), |json| {
+            json.get("event").and_then(|v| v.as_str()) == Some("approval_required")
+        })
+        .await;
+        if approval.is_some() {
+            break;
+        }
+    }
+    let approval = approval.unwrap_or_else(|| {
+        panic!(
+            "no approval_required from the supervised session (fail-closed regression?); daemon stderr:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
+        )
+    });
+    let session_id = approval
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("approval event must carry its session id, got {approval}"))
+        .to_string();
+    let approval_id = approval
+        .get("id")
+        .and_then(|v| v.as_u64())
+        .unwrap_or_else(|| panic!("approval event must carry an id, got {approval}"));
+
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "approve",
+            "session_id": session_id,
+            "id": approval_id,
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send approve");
+
+    // The released command really runs: the seeded marker disappears.
+    let deadline = tokio::time::Instant::now() + RUN_TIMEOUT;
+    while marker.exists() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "approved rm never ran; daemon stderr:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    let stderr_ctx = stderr_buf.clone();
+    complete_and_stop_session(&mut ws, &session_id, move || {
+        stderr_ctx.lock().map(|b| b.clone()).unwrap_or_default()
+    })
+    .await;
+
+    let _ = child.kill().await;
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1382,11 +1382,17 @@ async fn supervised_session_surfaces_approvals_on_the_dashboard() {
     let script = rig.write_script(&serde_json::json!({
         "profiles": [{
             "steps": [
+                // `rmdir`, not `rm`: it is in the classifier's destructive
+                // list AND exists on every platform this e2e runs on — a
+                // POSIX utility and a cmd.exe built-in (`rm` is neither on
+                // Windows, where the approved command then fails and the
+                // marker survives; that exact miss ejected this test's PR
+                // from the merge queue on the windows leg).
                 { "content": "Deleting the marker.",
                   "tool_calls": [{ "name": "exec_command",
-                                   "arguments": { "nonce": 1, "command": "rm approval-pin-marker.txt" } }] },
-                // No transcript expectation: a successful rm prints
-                // nothing — the test's proof is the marker file itself
+                                   "arguments": { "nonce": 1, "command": "rmdir approval-pin-marker" } }] },
+                // No transcript expectation: a successful rmdir prints
+                // nothing — the test's proof is the marker directory itself
                 // disappearing from the session project.
                 { "content": "Marker removed.",
                   "tool_calls": [{ "name": "signal_done",
@@ -1394,12 +1400,13 @@ async fn supervised_session_surfaces_approvals_on_the_dashboard() {
             ]
         }]
     }));
-    // The session's project: seeded with the marker the gated `rm` deletes.
+    // The session's project: seeded with the empty marker directory the
+    // gated `rmdir` deletes.
     let session_project = tempfile::tempdir().expect("session project dir");
-    let marker = session_project.path().join("approval-pin-marker.txt");
-    std::fs::write(&marker, "pin").expect("seed marker");
+    let marker = session_project.path().join("approval-pin-marker");
+    std::fs::create_dir(&marker).expect("seed marker dir");
 
-    // Default autonomy (Medium): `rm` classifies destructive → Ask.
+    // Default autonomy (Medium): `rmdir` classifies destructive → Ask.
     let mut cmd = rig.command();
     cmd.env("INTENDANT_MOCK_SCRIPT", &script)
         .args(["--no-tls", "--web", "18941"]);
@@ -1432,8 +1439,8 @@ async fn supervised_session_surfaces_approvals_on_the_dashboard() {
         ws.send(tokio_tungstenite::tungstenite::Message::Text(
             serde_json::json!({
                 "action": "create_session",
-                "task": "delete the pinned marker file",
-                "project_root": session_project.path(),
+                "task": "delete the pinned marker directory",
+                "project_root": session_project.path().to_string_lossy(),
                 "direct": true,
             })
             .to_string()
@@ -1482,7 +1489,7 @@ async fn supervised_session_surfaces_approvals_on_the_dashboard() {
     while marker.exists() {
         assert!(
             tokio::time::Instant::now() < deadline,
-            "approved rm never ran; daemon stderr:\n{}",
+            "approved rmdir never ran; daemon stderr:\n{}",
             stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
         );
         tokio::time::sleep(Duration::from_millis(200)).await;


### PR DESCRIPTION
Two commits, one story: fix the last behavioral finding from the design-overhaul verification, then flip the default. Bisectable per commit.

## 1. Supervised sessions surface approvals under the gateway

`launch.rs` hard-coded `headless: true` for every supervised native session, so a dashboard-created session (or a `spawn_sub_agent` child) auto-denied Ask-category commands with "Approval required in headless mode" — even though the supervisor's dispatch table already routes Approve/Deny/Skip/ApproveAll into each session's approval registry, the frontend routes approval panels per session, and the `spawn_sub_agent` tool description documents children as having "their own approvals". Now headless only when there is no gateway (`web_port.is_none()`), mirroring the foreground's `!use_web` — no dashboard still means fail-closed.

Pinned by a new headless e2e (`supervised_session_surfaces_approvals_on_the_dashboard`): CreateSession over `/ws` under default Medium autonomy → `approval_required` arrives tagged with the session id → `approve` over `/ws` → the gated `rm` really runs (a seeded marker file disappears) → round completes and the session stops cleanly. Runs in ~3s.

Riders: the ui-v2 category-approve re-pulls the shared control state so an open Control pane / Settings autonomy section reflects a freshly set rule (they are pull-on-open by design); nextest gains a documented loaded-box timeout override for the five `routes_sessions` tests that walk the real `~/.intendant/logs`.

## 2. The P3 flip: ui-v2 is the default

A bare URL now boots the v2 chrome; `?ui=v1` (or the preference it persists) is the soak-period escape hatch until the v1 chrome and Catppuccin palette are deleted in a follow-up landing. The pre-paint script keeps `theme-color` honest per generation, and the macOS wrapper window background matches the v2 `--bg`. Docs: web-dashboard.md leads with the v2 chrome, documents Focus/Grid and the category-scoped approval actions, and keeps the pinned endpoint table untouched; CLAUDE.md records the default next to the fragment conventions (AGENTS.md synced byte-for-byte).

Verified live against a mock daemon: bare URL → v2 + v2 theme-color; `?ui=v1` flips, persists, and restores the crust tint; the stored preference survives a bare reload; `?ui=v2` returns.

## Battery

- `cargo nextest run --bins`: 2676/2676
- `cargo test --test e2e`: 7/7 (including the new approval pin)
- clippy: no new warnings in touched files
- Flip semantics: 4/4 live CDP checks