### PR TITLE
cleanup: zero the intendant-core and intendant-display lib warnings

### DIFF
--- a/crates/intendant-core/src/autonomy.rs
+++ b/crates/intendant-core/src/autonomy.rs
@@ -79,23 +79,40 @@ impl ActionCategory {
             Self::DisplayControl => 8,
         }
     }
+}
 
-    /// Inverse of `Display`: parse the lowercase snake-case category name
-    /// back into a variant.  Used by session-log replay to reconstruct
-    /// `ApprovalRequired` events from persisted approval rows.
-    pub fn from_str(s: &str) -> Option<Self> {
+/// Parse error for an unrecognized [`ActionCategory`] name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnknownActionCategory;
+
+impl fmt::Display for UnknownActionCategory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("unknown action category")
+    }
+}
+
+impl std::error::Error for UnknownActionCategory {}
+
+/// Inverse of `Display`: parse the lowercase snake-case category name
+/// back into a variant (`s.parse().ok()` for Option ergonomics). Used
+/// by session-log replay to reconstruct `ApprovalRequired` events from
+/// persisted approval rows.
+impl std::str::FromStr for ActionCategory {
+    type Err = UnknownActionCategory;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "file_read" => Some(Self::FileRead),
-            "file_write" => Some(Self::FileWrite),
-            "file_delete" => Some(Self::FileDelete),
-            "command_exec" => Some(Self::CommandExec),
-            "network" => Some(Self::NetworkRequest),
-            "destructive" => Some(Self::Destructive),
-            "human_input" => Some(Self::HumanInput),
-            "live_audio_spawn" => Some(Self::LiveAudioSpawn),
-            "display_control" => Some(Self::DisplayControl),
-            "tool_call" => Some(Self::ToolCall),
-            _ => None,
+            "file_read" => Ok(Self::FileRead),
+            "file_write" => Ok(Self::FileWrite),
+            "file_delete" => Ok(Self::FileDelete),
+            "command_exec" => Ok(Self::CommandExec),
+            "network" => Ok(Self::NetworkRequest),
+            "destructive" => Ok(Self::Destructive),
+            "human_input" => Ok(Self::HumanInput),
+            "live_audio_spawn" => Ok(Self::LiveAudioSpawn),
+            "display_control" => Ok(Self::DisplayControl),
+            "tool_call" => Ok(Self::ToolCall),
+            _ => Err(UnknownActionCategory),
         }
     }
 }

--- a/crates/intendant-core/src/conversation.rs
+++ b/crates/intendant-core/src/conversation.rs
@@ -639,8 +639,7 @@ impl Conversation {
         let file = std::fs::File::create(path)?;
         let mut writer = std::io::BufWriter::new(file);
         for msg in &self.messages {
-            let json = serde_json::to_string(msg)
-                .map_err(std::io::Error::other)?;
+            let json = serde_json::to_string(msg).map_err(std::io::Error::other)?;
             writeln!(writer, "{}", json)?;
         }
         writer.flush()?;

--- a/crates/intendant-core/src/net.rs
+++ b/crates/intendant-core/src/net.rs
@@ -165,9 +165,7 @@ pub fn should_continue_after_accept_error(error: &std::io::Error) -> bool {
 /// `bind_dual_stack_or_v4`: dual-stack for the IPv6 wildcard,
 /// `SO_REUSEADDR` so lingering TIME_WAIT sockets don't block the port.
 /// Shared by the dashboard gateway and the enrollment cert server.
-pub fn rebind_dead_tcp_listener(
-    addr: std::net::SocketAddr,
-) -> std::io::Result<TcpListener> {
+pub fn rebind_dead_tcp_listener(addr: std::net::SocketAddr) -> std::io::Result<TcpListener> {
     use socket2::{Domain, Protocol, Socket, Type};
     let domain = if addr.is_ipv6() {
         Domain::IPV6
@@ -212,9 +210,7 @@ mod tests {
     /// SO_REUSEADDR, so the only systematic `AddrInUse` source is a socket
     /// that is genuinely still bound — which keeps failing past the
     /// deadline and still fails the test.
-    async fn rebind_with_patience(
-        addr: std::net::SocketAddr,
-    ) -> std::io::Result<TcpListener> {
+    async fn rebind_with_patience(addr: std::net::SocketAddr) -> std::io::Result<TcpListener> {
         let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
         loop {
             match rebind_dead_tcp_listener(addr) {
@@ -243,10 +239,9 @@ mod tests {
             .expect("rebind on the freed address");
         assert_eq!(rebound.local_addr().unwrap(), addr);
 
-        let (client, (server, _peer)) = tokio::join!(
-            tokio::net::TcpStream::connect(addr),
-            async { rebound.accept().await.unwrap() },
-        );
+        let (client, (server, _peer)) = tokio::join!(tokio::net::TcpStream::connect(addr), async {
+            rebound.accept().await.unwrap()
+        },);
         client.expect("client connects to rebound listener");
         drop(server);
     }

--- a/crates/intendant-core/src/peer_id.rs
+++ b/crates/intendant-core/src/peer_id.rs
@@ -38,7 +38,7 @@ impl PeerId {
     #[allow(dead_code)]
     pub fn kind(&self) -> Option<PeerKind> {
         let prefix = self.0.split(':').next()?;
-        PeerKind::from_str(prefix)
+        prefix.parse().ok()
     }
 
     /// Return the label portion (everything after the first `:`).
@@ -100,27 +100,43 @@ impl PeerKind {
         }
     }
 
-    /// Strict parse — returns `Some` only for known kinds. Use when
-    /// you want to distinguish "unrecognized" from "explicit Other"
-    /// (which [`from_wire`](Self::from_wire) collapses).
-    pub fn from_str(s: &str) -> Option<Self> {
-        match s {
-            "intendant" => Some(Self::Intendant),
-            "openclaw" => Some(Self::OpenClaw),
-            "hermes" => Some(Self::Hermes),
-            "letta" => Some(Self::Letta),
-            "a2a" => Some(Self::A2A),
-            "mcp" => Some(Self::Mcp),
-            "other" => Some(Self::Other),
-            _ => None,
-        }
-    }
-
     /// Parse with forward-compat fallback: unrecognized wire strings
     /// collapse to [`PeerKind::Other`] rather than returning `None`.
     /// This is what the custom `Deserialize` impl calls.
     pub fn from_wire(s: &str) -> Self {
-        Self::from_str(s).unwrap_or(Self::Other)
+        s.parse().unwrap_or(Self::Other)
+    }
+}
+
+/// Parse error for an unrecognized [`PeerKind`] name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnknownPeerKind;
+
+impl std::fmt::Display for UnknownPeerKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("unknown peer kind")
+    }
+}
+
+impl std::error::Error for UnknownPeerKind {}
+
+/// Strict parse — `Ok` only for known kinds (`s.parse().ok()` for
+/// Option ergonomics). Use when you want to distinguish "unrecognized"
+/// from "explicit Other" (which [`PeerKind::from_wire`] collapses).
+impl std::str::FromStr for PeerKind {
+    type Err = UnknownPeerKind;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "intendant" => Ok(Self::Intendant),
+            "openclaw" => Ok(Self::OpenClaw),
+            "hermes" => Ok(Self::Hermes),
+            "letta" => Ok(Self::Letta),
+            "a2a" => Ok(Self::A2A),
+            "mcp" => Ok(Self::Mcp),
+            "other" => Ok(Self::Other),
+            _ => Err(UnknownPeerKind),
+        }
     }
 }
 

--- a/crates/intendant-display/src/aggregator.rs
+++ b/crates/intendant-display/src/aggregator.rs
@@ -824,6 +824,11 @@ pub fn compose_effective_wanted(
     effective
 }
 
+/// Probe for a simulcast layer's paused state (`None` = the pool does
+/// not know the layer). Shared by the coordinator signature and its
+/// callers, which would otherwise each spell the boxed-closure type.
+pub type LayerPauseProbe = Box<dyn Fn(&SimulcastRid) -> Option<bool> + Send + Sync>;
+
 /// Spawn the single layer-policy coordinator for one display.
 ///
 /// One task, three policies, one writer. Subscribes to each peer's
@@ -863,7 +868,7 @@ pub fn compose_effective_wanted(
 pub fn spawn_layer_policy_coordinator(
     peers: Arc<RwLock<HashMap<PeerId, Arc<WebRtcPeer>>>>,
     get_current_rids: Box<dyn Fn() -> Vec<SimulcastRid> + Send + Sync>,
-    is_layer_paused: Box<dyn Fn(&SimulcastRid) -> Option<bool> + Send + Sync>,
+    is_layer_paused: LayerPauseProbe,
     on_action: Box<dyn Fn(CapacityAction) + Send + Sync>,
     config: CapacityPolicyConfig,
     shutdown: CancellationToken,
@@ -2608,8 +2613,7 @@ mod tests {
         // Pool reports every layer ACTIVE — the diff after the
         // presence policy fires Idle must produce a PauseLayer
         // for each.
-        let is_layer_paused: Box<dyn Fn(&SimulcastRid) -> Option<bool> + Send + Sync> =
-            Box::new(|_| Some(false));
+        let is_layer_paused: LayerPauseProbe = Box::new(|_| Some(false));
 
         let shutdown = CancellationToken::new();
         let handle = spawn_layer_policy_coordinator(

--- a/crates/intendant-display/src/clipboard.rs
+++ b/crates/intendant-display/src/clipboard.rs
@@ -32,6 +32,12 @@ pub struct ClipboardMonitor {
     shutdown: Arc<AtomicBool>,
 }
 
+impl Default for ClipboardMonitor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ClipboardMonitor {
     pub fn new() -> Self {
         Self {

--- a/crates/intendant-display/src/encode/pool/mod.rs
+++ b/crates/intendant-display/src/encode/pool/mod.rs
@@ -401,8 +401,7 @@ impl EncoderPool {
         // reflects the pool's total throughput. Tests that don't
         // care about metrics pass `None`; production passes
         // `Some(Arc::clone(&self.counters))` from DisplaySession::start.
-        let counters =
-            counters.unwrap_or_else(|| Arc::new(crate::DisplayMetricsCounters::new()));
+        let counters = counters.unwrap_or_else(|| Arc::new(crate::DisplayMetricsCounters::new()));
         let duration_ms = if framerate > 0 {
             1000 / framerate as u64
         } else {

--- a/crates/intendant-display/src/encode/pool/worker.rs
+++ b/crates/intendant-display/src/encode/pool/worker.rs
@@ -63,7 +63,8 @@ pub(crate) fn try_spawn_encoder_thread(
     // (Windows COM/MF) is initialized on the thread that will use it.
     let mime = id.codec.mime();
     let (cw, ch, cbr) = (layer.width, layer.height, layer.target_bitrate_kbps);
-    let construct = move || crate::encode::select_codec_for_mime(mime, cw, ch, cbr).map(|(enc, _)| enc);
+    let construct =
+        move || crate::encode::select_codec_for_mime(mime, cw, ch, cbr).map(|(enc, _)| enc);
     spawn_encoder_thread_with(
         id,
         layer,
@@ -214,6 +215,7 @@ pub(crate) fn try_h264_fallback_for_layer(
 /// is built. Constructing on the thread that will use and drop the
 /// encoder is what makes the Windows MF backend's per-thread COM
 /// init/teardown correct; see [`try_spawn_encoder_thread`].
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn spawn_encoder_thread_with(
     id: EncoderId,
     layer: LayerSpec,

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -415,6 +415,12 @@ pub struct DisplayMetricsCounters {
     pub epoch_us: AtomicU64,
 }
 
+impl Default for DisplayMetricsCounters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DisplayMetricsCounters {
     pub fn new() -> Self {
         let now_us = Instant::now().elapsed().as_micros() as u64;
@@ -1035,6 +1041,7 @@ async fn send_tile_control_to_peers(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn send_latest_tile_snapshot_to_peer_id(
     peers: Arc<RwLock<HashMap<PeerId, Arc<webrtc::WebRtcPeer>>>>,
     latest_frame: Arc<RwLock<Option<Arc<Frame>>>>,
@@ -1179,7 +1186,9 @@ impl DisplaySession {
     pub async fn start(
         &self,
         fps: u32,
-        frame_registry: Option<std::sync::Arc<tokio::sync::RwLock<intendant_core::frames::FrameRegistry>>>,
+        frame_registry: Option<
+            std::sync::Arc<tokio::sync::RwLock<intendant_core::frames::FrameRegistry>>,
+        >,
         events: Option<DisplayEventSender>,
     ) -> Result<(), CallerError> {
         let mut capture_rx = self.backend.start_capture(fps).await?;
@@ -1400,9 +1409,7 @@ impl DisplaySession {
                     .collect()
             });
         let pool_for_query = Arc::clone(&pool_arc);
-        let is_layer_paused: Box<
-            dyn Fn(&encode::pool::SimulcastRid) -> Option<bool> + Send + Sync,
-        > = Box::new(move |rid| {
+        let is_layer_paused: aggregator::LayerPauseProbe = Box::new(move |rid| {
             pool_for_query.is_layer_paused(encode::pool::CodecKind::Vp8, rid.clone())
         });
         let pool_for_action = Arc::clone(&pool_arc);
@@ -1957,6 +1964,7 @@ impl DisplaySession {
     ///     task drops the lease via `drop(current_lease.take())`
     ///     (RAII releases on-demand refcounts under the existing
     ///     generation gate).
+    #[allow(clippy::too_many_arguments)]
     async fn handle_offer_pool_mode(
         &self,
         peer_id: PeerId,
@@ -2941,6 +2949,12 @@ pub struct SessionRegistry {
 }
 
 pub type SharedSessionRegistry = Arc<RwLock<SessionRegistry>>;
+
+impl Default for SessionRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl SessionRegistry {
     pub fn new() -> Self {

--- a/crates/intendant-display/src/macos.rs
+++ b/crates/intendant-display/src/macos.rs
@@ -13,7 +13,6 @@
 use super::{
     capture::damage::Rect, DisplayBackend, DisplayInfoKind, Frame, FrameFormat, InputEvent,
 };
-use intendant_core::error::CallerError;
 use async_trait::async_trait;
 use core_graphics::display::CGDisplay;
 use core_graphics::event::{
@@ -21,6 +20,7 @@ use core_graphics::event::{
 };
 use core_graphics::event_source::{CGEventSource, CGEventSourceStateID};
 use core_graphics::geometry::{CGPoint, CGRect as CgRect, CGSize};
+use intendant_core::error::CallerError;
 use screencapturekit::cg::CGRect as ScRect;
 use screencapturekit::cm::{CMTime, SCFrameStatus};
 use screencapturekit::cv::CVPixelBufferLockFlags;
@@ -90,6 +90,12 @@ pub struct MacOSBackend {
     shutdown: Arc<AtomicBool>,
     input_geometry: Arc<RwLock<InputGeometry>>,
     target: CaptureTarget,
+}
+
+impl Default for MacOSBackend {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MacOSBackend {

--- a/crates/intendant-display/src/tile/recovery.rs
+++ b/crates/intendant-display/src/tile/recovery.rs
@@ -61,6 +61,11 @@ impl TileUpdateReplayBuffer {
     }
 
     #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    #[allow(dead_code)]
     pub fn total_bytes(&self) -> usize {
         self.total_bytes
     }

--- a/crates/intendant-display/src/wayland.rs
+++ b/crates/intendant-display/src/wayland.rs
@@ -6,13 +6,13 @@
 //! frames and an `AtomicBool` for shutdown signaling.
 
 use super::{DisplayBackend, Frame, FrameFormat, InputEvent};
-use intendant_core::error::CallerError;
 use ashpd::desktop::clipboard::Clipboard;
 use ashpd::desktop::remote_desktop::{Axis, DeviceType, KeyState, RemoteDesktop};
 use ashpd::desktop::screencast::{CursorMode, Screencast, SourceType};
 use ashpd::desktop::{PersistMode, Session};
 use async_trait::async_trait;
 use futures_util::StreamExt;
+use intendant_core::error::CallerError;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use tokio::io::AsyncWriteExt;

--- a/crates/intendant-display/src/webrtc/driver.rs
+++ b/crates/intendant-display/src/webrtc/driver.rs
@@ -1786,7 +1786,10 @@ pub(crate) const TILE_DELTAS_CHANNEL_LABEL: &str = "tile-deltas";
 /// `display_input_authority` data channel. Wire format matches the
 /// local 5c WS message exactly (same `t` discriminator, same `state`
 /// vocabulary) so browser handlers can stay symmetric.
-pub(crate) fn serialize_authority_state(display_id: u32, state: DisplayInputAuthorityState) -> String {
+pub(crate) fn serialize_authority_state(
+    display_id: u32,
+    state: DisplayInputAuthorityState,
+) -> String {
     serde_json::json!({
         "t": "display_input_authority_state",
         "display_id": display_id,

--- a/crates/intendant-display/src/webrtc/ice.rs
+++ b/crates/intendant-display/src/webrtc/ice.rs
@@ -4,7 +4,10 @@
 
 use super::*;
 
-pub(crate) fn host_candidate_init(addr: SocketAddr, protocol: RTCIceProtocol) -> RTCIceCandidateInit {
+pub(crate) fn host_candidate_init(
+    addr: SocketAddr,
+    protocol: RTCIceProtocol,
+) -> RTCIceCandidateInit {
     let (foundation, proto, priority, tcp_suffix) = match protocol {
         RTCIceProtocol::Udp => ("1", "udp", 2_130_706_431u32, ""),
         RTCIceProtocol::Tcp => ("9001", "tcp", 1_677_721_855u32, " tcptype passive"),
@@ -74,7 +77,8 @@ pub(crate) const STUN_BINDING_TIMEOUT: Duration = Duration::from_millis(1500);
 /// meta-crate — no new dep): `Message::build` writes the 20-byte header
 /// with the magic cookie and a random transaction ID, sets the message
 /// type to `BINDING_REQUEST`, and `marshal_binary` yields the wire bytes.
-pub(crate) fn build_stun_binding_request() -> Result<(Vec<u8>, rtc::stun::message::TransactionId), String> {
+pub(crate) fn build_stun_binding_request(
+) -> Result<(Vec<u8>, rtc::stun::message::TransactionId), String> {
     use rtc::stun::message::{Message, BINDING_REQUEST};
 
     let mut request = Message::new();

--- a/crates/intendant-display/src/webrtc/mod.rs
+++ b/crates/intendant-display/src/webrtc/mod.rs
@@ -49,8 +49,8 @@ use super::encode::pool::{
 use super::tile::backpressure::{TileDeltaBackpressure, TileDeltaSendDecision};
 use super::tile::transport as tile_transport;
 use super::{EncodedFrame, IceConfig, InputEvent, PeerId};
-use intendant_core::error::CallerError;
 use bytes::{Bytes, BytesMut};
+use intendant_core::error::CallerError;
 use rtc::data_channel::{RTCDataChannelId, RTCDataChannelMessage};
 use rtc::media_stream::MediaStreamTrack;
 use rtc::peer_connection::configuration::media_engine::{
@@ -396,9 +396,7 @@ impl WebRtcPeer {
     /// Receivers are independent — multiple subscribers (capacity
     /// aggregator + a metrics dashboard, say) can each
     /// `subscribe_twcc_health` and read independently.
-    pub fn subscribe_twcc_health(
-        &self,
-    ) -> watch::Receiver<Option<crate::twcc_tap::TwccHealth>> {
+    pub fn subscribe_twcc_health(&self) -> watch::Receiver<Option<crate::twcc_tap::TwccHealth>> {
         self.twcc_health_rx.clone()
     }
 

--- a/crates/intendant-display/src/webrtc/offer.rs
+++ b/crates/intendant-display/src/webrtc/offer.rs
@@ -499,6 +499,7 @@ impl WebRtcPeer {
     /// encoded frame channel — the caller (`Self::new`) hands it
     /// directly to `pool_frame_intake` rather than parking it on
     /// the struct.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn build_with_codec_set(
         peer_id: PeerId,
         offer_sdp: &str,
@@ -697,9 +698,8 @@ impl WebRtcPeer {
                 .with_size(2048)
                 .build(),
         );
-        let registry = registry.with(|inner| {
-            crate::twcc_tap::TwccTapInterceptor::new(inner, twcc_tap_tx.clone())
-        });
+        let registry = registry
+            .with(|inner| crate::twcc_tap::TwccTapInterceptor::new(inner, twcc_tap_tx.clone()));
 
         let mut rtc = RTCPeerConnectionBuilder::new()
             .with_configuration(RTCConfigurationBuilder::new().build())

--- a/crates/intendant-display/src/webrtc/pool_glue.rs
+++ b/crates/intendant-display/src/webrtc/pool_glue.rs
@@ -17,7 +17,9 @@ use super::*;
 /// dedup avoids counting the same codec twice in a multi-layer
 /// simulcast set.
 #[cfg(test)]
-pub(crate) fn codec_set_from_subscriptions(subscriptions: &[EncoderSubscription]) -> Vec<CodecKind> {
+pub(crate) fn codec_set_from_subscriptions(
+    subscriptions: &[EncoderSubscription],
+) -> Vec<CodecKind> {
     let mut seen: std::collections::HashSet<CodecKind> = std::collections::HashSet::new();
     let mut codecs: Vec<CodecKind> = Vec::new();
     for sub in subscriptions {

--- a/crates/intendant-display/src/windows.rs
+++ b/crates/intendant-display/src/windows.rs
@@ -78,8 +78,8 @@
 //! 0" desktop) -- see the crate-level Windows-port notes.
 
 use super::{DisplayBackend, Frame, FrameFormat, InputEvent};
-use intendant_core::error::CallerError;
 use async_trait::async_trait;
+use intendant_core::error::CallerError;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};

--- a/crates/intendant-display/src/x11.rs
+++ b/crates/intendant-display/src/x11.rs
@@ -10,8 +10,8 @@
 //! (slower but always works).
 
 use super::{DisplayBackend, Frame, FrameFormat, InputEvent};
-use intendant_core::error::CallerError;
 use async_trait::async_trait;
+use intendant_core::error::CallerError;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};

--- a/src/bin/caller/session_log/replay.rs
+++ b/src/bin/caller/session_log/replay.rs
@@ -748,7 +748,8 @@ pub fn session_log_entry_to_app_event(
             let id = turn.unwrap_or(0) as u64;
             match decision {
                 "waiting" => {
-                    let category = crate::autonomy::ActionCategory::from_str(category_str)
+                    let category = category_str
+                        .parse()
                         .unwrap_or(crate::autonomy::ActionCategory::CommandExec);
                     Some(AppEvent::ApprovalRequired {
                         session_id: None,


### PR DESCRIPTION
The 13 lib-crate warnings → 0.

**intendant-core (2)**: the Option-returning inherent `from_str` parsers on `ActionCategory` and `PeerKind` shadowed `FromStr::from_str` — both now implement the real trait with small typed errors; callers use `.parse()` with `.ok()`/`.unwrap_or`.

**intendant-display (11)**: `Default` impls for the four `new()`-only types; `is_empty()` beside `TileUpdateReplayBuffer::len`; a `LayerPauseProbe` type alias replaces the boxed-closure type spelled at three sites; the four god-signature fns take `#[allow(clippy::too_many_arguments)]` per the station-web precedent — params-struct refactors of live WebRTC plumbing belong to a deliberate pass, not a lint batch.

Also carries `cargo fmt` canonicalization of pre-existing drift in ten display files (whitespace-only hunks).

Battery: both lib crates clippy-clean, 676 lib tests + 2676 bin tests green.