### PR TITLE
docs: trust-tiers doctrine chapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Read the relevant chapter before changing a subsystem:
 | WebRTC display (shared encoder pool, tile streaming) | `docs/src/display-pipeline.md` |
 | Peer federation, cross-machine display, LAN/mTLS | `docs/src/peer-federation.md` |
 | Trust model: anchor daemons, client identity keys, role ceilings, IAM | `docs/src/trust-architecture.md` |
+| Trust tiers: which client for which daemon, fleet zones, custody per tier | `docs/src/trust-tiers.md` |
 | Credential custody: leases, vault, egress relay, OAuth modes | `docs/src/credential-custody.md` |
 | Hosted rendezvous (intendant-connect), claims, self-hosting | `docs/src/self-hosted-rendezvous.md` |
 | Computer use, live audio, phone/voice-call skills | `docs/src/computer-use-and-audio.md` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Read the relevant chapter before changing a subsystem:
 | WebRTC display (shared encoder pool, tile streaming) | `docs/src/display-pipeline.md` |
 | Peer federation, cross-machine display, LAN/mTLS | `docs/src/peer-federation.md` |
 | Trust model: anchor daemons, client identity keys, role ceilings, IAM | `docs/src/trust-architecture.md` |
+| Trust tiers: which client for which daemon, fleet zones, custody per tier | `docs/src/trust-tiers.md` |
 | Credential custody: leases, vault, egress relay, OAuth modes | `docs/src/credential-custody.md` |
 | Hosted rendezvous (intendant-connect), claims, self-hosting | `docs/src/self-hosted-rendezvous.md` |
 | Computer use, live audio, phone/voice-call skills | `docs/src/computer-use-and-audio.md` |

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -13,6 +13,7 @@
 - [Self-Hosted Rendezvous](./self-hosted-rendezvous.md)
 - [Credential Custody: the Vault and Leases](./credential-custody.md)
 - [Trust Architecture](./trust-architecture.md)
+- [Trust Tiers](./trust-tiers.md)
 - [Computer Use & Live Audio](./computer-use-and-audio.md)
 - [Presence Layer](./presence.md)
 - [Autonomy & Approvals](./autonomy.md)

--- a/docs/src/trust-architecture.md
+++ b/docs/src/trust-architecture.md
@@ -4,7 +4,9 @@
 > access system is shaped the way it is, what each piece of infrastructure is
 > allowed to do, and the order in which the remaining pieces land. The
 > operational reference for the UI lives in [Web Dashboard → Access](./web-dashboard.md#access);
-> the daemon-to-daemon layer is in [Peer Federation](./peer-federation.md).
+> the daemon-to-daemon layer is in [Peer Federation](./peer-federation.md);
+> the fleet-level operating model built on these mechanisms — which client
+> for which daemon, custody per tier — is [Trust Tiers](./trust-tiers.md).
 
 Intendant's goal is a **network of agentic networks**: daemons (agents) owned
 by people and organizations, where an owner can grant other people and other

--- a/docs/src/trust-tiers.md
+++ b/docs/src/trust-tiers.md
@@ -1,0 +1,150 @@
+# Trust Tiers
+
+> Status: adopted doctrine (2026-07-08). [Trust Architecture](./trust-architecture.md)
+> bounds what each *component* may do to you if it turns malicious; this
+> chapter is the operating model an owner applies across a fleet whose
+> machines carry different stakes. Almost nothing here is new mechanism — it
+> composes ceilings, grants, custody, and client choice that already exist.
+> The three product hooks at the end are the tracked exceptions.
+
+## Two axes, not one
+
+"How much should I trust Intendant?" is a single axis, and the wrong one.
+Every real deployment decision sits on two independent axes:
+
+- **Payload tier of a daemon** — what a compromise of that box costs its
+  owner. At one end, a **disposable** daemon: a rented VPS holding a
+  time-boxed provider lease and scratch work; worst case is a rotated key
+  and a destroyed box. At the other, an **integrated** daemon: the machine
+  that reads your mail, holds your files, drives your accounts; worst case
+  is your life.
+- **Client provenance** — how sure you are that the code driving a daemon
+  is honest. At one end, the hosted dashboard tab: convenient, zero-install,
+  and explicitly a [degraded-trust tier](./trust-architecture.md#organizations-two-lanes),
+  because the hosted origin can change what it serves at any time. At the
+  other, code whose provenance you control: the signed native app, or a
+  dashboard served by a daemon you own (the
+  [anchor rule](./trust-architecture.md#anchor-daemons)).
+
+The doctrine is one sentence: **match the client's provenance to the payload
+of the daemon it is driving — per daemon, not per person.**
+
+Stated per tier, and resolving what looks like a paradox:
+
+- Driving a *disposable* daemon from a hosted tab is not a compromise you
+  tolerate — it is the design working. The custody machinery (vault,
+  time-boxed leases, zero-authority rendezvous, claims-grant-nothing) exists
+  precisely so that the worst a poisoned hosted page can harvest from this
+  tier is bounded, revocable, and logged. The hosted path is *most*
+  compelling exactly where trust in the infrastructure is lowest, because
+  the payload puts a hard ceiling on the loss.
+- Driving an *integrated* daemon demands provenance: the native app or an
+  owner-served origin. This is where "just open intendant.dev" stops being
+  an acceptable answer, however encrypted the transport and however honest
+  the service intends to be.
+
+Trust machinery scales with payload, not with paranoia. A user who "doesn't
+trust Intendant" and keeps every daemon disposable is served perfectly well
+by the most convenient path; a user who trusts it with everything needs the
+inconvenient-once path for exactly one machine.
+
+One footgun completes the model: **a daemon's tier is set by the most
+sensitive thing that ever touches it**, not by the label its owner had in
+mind. Pasting a production credential into a session on a disposable box
+silently promotes the box. Tier discipline is as much about what you feed a
+daemon as about how you reach it.
+
+## One fleet, zones — not two networks
+
+The instinct, once both tiers exist side by side, is to ask for two fleets
+or two isolated networks. Neither is needed, because a fleet is a phonebook,
+not a trust domain: [claiming grants no authority](./self-hosted-rendezvous.md),
+membership is directory metadata, and every daemon's local IAM remains the
+only mint. Two daemons in one fleet are no more security-coupled than two
+strangers — until an owner writes a grant. The boundary between tiers is
+therefore made of three disciplines, not of infrastructure:
+
+1. **Grants flow down the trust gradient, never up.** An integrated daemon
+   may hold peer grants on disposables (it orchestrates them); no disposable
+   ever holds a grant on an integrated daemon. An upward grant is the only
+   way tiers actually bridge, which makes it the alarm condition — the one
+   thing a fleet owner should never do casually.
+2. **Origin ceilings, hardened per daemon.** The default
+   [role ceilings](./trust-architecture.md#mechanisms) already cap
+   hosted-provenance sessions at `role:operator` everywhere
+   (`role_ceilings` in `iam.json`). That is a floor of protection sized for
+   the disposable tier. Integrated daemons should harden it further —
+   ceiling hosted provenance at an observer role, or refuse hosted-origin
+   control outright — so that "this box cannot be driven from a hosted tab"
+   is enforced where all authority already lives, not remembered by the
+   owner.
+3. **Separate keys, not separate networks.** The one genuinely cross-tier
+   single point is the browser identity key: one browser profile enrolled
+   as root on every daemon means one stolen profile owns both worlds. Keep
+   the enrollment that holds root on integrated daemons in a dedicated
+   browser profile or device (or in the native app's own storage); let the
+   everyday profile carry the disposable tier. This costs one extra
+   enrollment ceremony, once.
+
+Two accounts — two actual fleets — buy exactly one additional property:
+the rendezvous cannot see that both worlds belong to the same person.
+That is metadata unlinkability, a legitimate but niche posture, and it is
+opt-in paranoia rather than the recommended shape.
+
+## Custody inverts across tiers
+
+The [credential custody](./credential-custody.md) discipline — vault blob on
+the account, nothing durable on disk, browsers minting time-boxed leases —
+was built *for* boxes you do not trust. Apply it there and only there:
+
+- **Disposable tier**: leases only. The box's disk holds no durable secret;
+  destroying the box revokes nothing because there was nothing to revoke.
+- **Integrated tier**: the box is already inside your trusted computing
+  base — it runs the agent that reads the mail. It may simply hold its own
+  credentials (OS keystore, local config), because routing them through the
+  account vault adds a hosted dependency without adding safety. Where vault
+  storage is still preferred (cross-device sync, sealed-at-rest), those
+  entries want a stricter unseal policy than the disposable tier's — see
+  hook 3.
+
+## The client ladder
+
+- **Disposable tier**: any hosted tab, anywhere. This is the zero-install
+  promise, delivered honestly.
+- **Integrated tier**: the signed native app, or a direct/owner-served
+  origin. Store-signed releases are the out-of-band code anchor a bare
+  browser tab cannot have — the same reason messengers with real E2E
+  guarantees treat their web clients as the weak tier. The app is not the
+  non-technical user's consolation prize; it is *everyone's* correct client
+  for the machines that matter.
+
+A worked example, one fleet:
+
+| Daemon | Tier | Control origins | Custody | Peer grants |
+|---|---|---|---|---|
+| `home` (desktop) | integrated | native app / direct only (hosted ceiling: none) | local keystore; vault entries app-only | holds grants **on** `vps-1`, `vps-2` |
+| `vps-1`, `vps-2` (rented) | disposable | any hosted tab | vault leases only | none; controlled **by** `home` |
+
+The owner claims all three into one account, sees them in one dashboard,
+and the tier boundary is carried entirely by ceilings, grant direction, and
+which client they open for which box.
+
+## Product hooks
+
+Three pieces of mechanism would let the product carry this doctrine instead
+of the owner's memory. All three are tracked work:
+
+1. **Tier labels + upward-grant guard.** Daemons carry a tier label
+   (integrated/disposable) — in the fleet record, mirrored into local IAM —
+   and the grant flows (human and peer lanes) warn on, or refuse, any grant
+   that would give a lower-tier subject authority on a higher-tier daemon.
+2. **Per-daemon hosted-ceiling knob.** The `role_ceilings` map already
+   supports hardening below `role:operator` by editing `iam.json`; the hook
+   is surfacing it in Access as a first-class per-daemon control with an
+   honest top position — "refuse hosted-origin control entirely" — plus
+   copy that names the tier it implements.
+3. **Per-entry vault unseal policy.** Vault entries gain an origin policy
+   (`any` vs `app/direct-only`); the vault UI enforces it at unseal and the
+   custody trail records the origin class of every ceremony, so an
+   integrated-tier credential physically cannot be unsealed into a hosted
+   tab.


### PR DESCRIPTION
New mdBook chapter `docs/src/trust-tiers.md` — the fleet-level operating model on top of the trust architecture:

- **Two axes, not one**: daemon payload tier (disposable ↔ integrated) × client provenance (hosted tab ↔ app/direct); the doctrine is matching them per daemon. Resolves the apparent paradox that the hosted convenience path is *most* appropriate for the least-trusted daemons.
- **One fleet, zones — not two networks**: the fleet is a phonebook; the tier boundary is three disciplines (grants flow down only, per-daemon origin-ceiling hardening, separate browser identity keys per tier).
- **Custody inverts across tiers**: vault/leases for disposables; local custody is legitimate on integrated anchors.
- **Product hooks** (tracked as work items, not in this PR): tier labels + upward-grant guard, per-daemon hosted-ceiling knob in Access, per-entry vault unseal policy.

Also: SUMMARY.md entry, cross-link from trust-architecture.md, CLAUDE.md chapter-table row (+ AGENTS.md byte-copy).