### PR TITLE
Trust tiers in the product: tier card, hosted-control cap, sealed vault entries

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -724,6 +724,14 @@ sessions can operate but cannot administer. Owners who accept hosted-root
 risk can raise a ceiling or disable them all with an explicit empty map
 (`"role_ceilings": {}`).
 
+The common moves have a one-knob UI: the **hosted-control cap** on
+Access → Overview's Trust tier card writes both hosted bindings at once
+(`role:operator` / `role:observer` / `role:none` — the last refuses
+hosted-origin control entirely; `POST /api/access/hosted-ceiling`).
+Per-binding divergence, raising above operator, and clearing the map
+remain deliberate `iam.json` edits. `role:none` is a zero-permission,
+ceiling-only builtin — it can never be granted to a principal.
+
 The enforced built-in user/client roles are `role:scoped-human`,
 `role:observer`, `role:session-reader`, `role:terminal`, `role:files-read`,
 `role:files-write`, `role:operator`, and `role:root`. `role:peer-profile` is

--- a/docs/src/credential-custody.md
+++ b/docs/src/credential-custody.md
@@ -64,6 +64,17 @@ subscription OAuth credential sets for the external agents (Codex,
 Claude Code). Each entry carries a kind, a label, provider metadata, and
 optional per-daemon scoping rules (below).
 
+Entries may also carry an **unseal policy** (`unseal_policy:
+"trusted"`; absent = anywhere): a trusted-only entry refuses use from
+hosted tabs — no reveal, no lease fueling, no egress relay, no voice
+mirror — while still syncing inside the encrypted body. This is
+client-side self-enforcement (a guard against mistakes and casual
+exfiltration, not against a malicious bundle — see
+[Trust Tiers](./trust-tiers.md)); and since today's vault only opens
+through a Connect service, a trusted-only entry stays stored-but-sealed
+until the direct/app vault path exists. The policy field is invisible
+to the service like every other entry field.
+
 **Keying.** A random 256-bit vault master key `K` encrypts the vault
 body (AES-GCM). `K` itself is never stored — it is wrapped into one
 **envelope per enrolled unlocker**:
@@ -132,7 +143,7 @@ raw frame names are reserved for the `egress_*` relay path):
 | `api_credential_lease_renew` | browser → daemon request with `lease_id` (or legacy `leaseId`) | `lease_id`, new `expires_at_unix_ms` |
 | `api_credential_lease_revoke` | browser → daemon request with optional `lease_id` / `leaseId` / `kind`; omitted revokes every lease on the daemon | `revoked` count |
 | `api_credential_lease_status` | browser → daemon request with no params | active `leases` (`lease_id`, `kind`, `label`, `mode`, grant/renew/expiry timestamps, `ttl_ms`, `offline_ms`, `use_count`), active `egress` relays, and `expired_note` |
-| `api_credential_custody_trail` | browser → daemon request with no params | recent custody events (`at_unix_ms`, `event`, `kind`, `label`, `actor`, `detail`) from the daemon's own record — lease grants/expiries/revocations, relay changes, restart resets; metadata only, never material. Kept at `~/.intendant/custody-audit.jsonl` (0600, bounded), rendered in Access → Advanced → Custody trail |
+| `api_credential_custody_trail` | browser → daemon request with no params | recent custody events (`at_unix_ms`, `event`, `kind`, `label`, `actor`, `origin`, `detail`) from the daemon's own record — lease grants/expiries/revocations, relay changes, restart resets; metadata only, never material. `origin` stamps the session's origin class on ceremonies (`hosted` / `direct` / `local` / `peer`; empty on sessionless events and pre-field records). Kept at `~/.intendant/custody-audit.jsonl` (0600, bounded), rendered in Access → Advanced → Custody trail |
 
 Leases ride the same per-frame IAM checks as every other tunnel
 operation; granting requires a session whose principal holds a new

--- a/docs/src/trust-architecture.md
+++ b/docs/src/trust-architecture.md
@@ -498,8 +498,12 @@ The pieces that implement the model, mapped to the codebase:
   Connect-account principals and client keys enrolled from a hosted origin
   cannot exceed `role:operator` (no `access.manage`, no `settings.manage`,
   no `runtime.control`). Ceilings are enforced as a permission intersection
-  at decision time and surfaced in the Access UI, and are configurable in
-  `iam.json` for owners who explicitly accept hosted-root risk.
+  at decision time and surfaced in the Access UI. Hardening is one knob —
+  the hosted-control cap on the Trust tier card (Access → Overview) moves
+  both hosted bindings to operator / observer / `role:none` (refuse
+  entirely), per [Trust Tiers](./trust-tiers.md); raising a ceiling or
+  clearing them stays an explicit `iam.json` edit for owners who accept
+  hosted-root risk.
 - **Device enrollment**: when a browser's *verified* key is refused, the
   daemon queues a pending enrollment (in-memory, capped, TTL'd — the queue
   grants nothing by itself); the owner approves it with a role, or denies it,

--- a/docs/src/trust-tiers.md
+++ b/docs/src/trust-tiers.md
@@ -131,20 +131,38 @@ which client they open for which box.
 
 ## Product hooks
 
-Three pieces of mechanism would let the product carry this doctrine instead
-of the owner's memory. All three are tracked work:
+Three pieces of mechanism let the product carry this doctrine instead of
+the owner's memory. All three are **shipped**:
 
-1. **Tier labels + upward-grant guard.** Daemons carry a tier label
-   (integrated/disposable) — in the fleet record, mirrored into local IAM —
-   and the grant flows (human and peer lanes) warn on, or refuse, any grant
-   that would give a lower-tier subject authority on a higher-tier daemon.
-2. **Per-daemon hosted-ceiling knob.** The `role_ceilings` map already
-   supports hardening below `role:operator` by editing `iam.json`; the hook
-   is surfacing it in Access as a first-class per-daemon control with an
-   honest top position — "refuse hosted-origin control entirely" — plus
-   copy that names the tier it implements.
-3. **Per-entry vault unseal policy.** Vault entries gain an origin policy
-   (`any` vs `app/direct-only`); the vault UI enforces it at unseal and the
-   custody trail records the origin class of every ceremony, so an
-   integrated-tier credential physically cannot be unsealed into a hosted
-   tab.
+1. **Tier labels + upward-grant guard.** Each daemon carries its tier in
+   local IAM (`tier` in `iam.json`; `POST /api/access/tier`,
+   audit-logged, manage-gated), chosen on the **Trust tier card** at the
+   top of Access → Overview. The guard is advisory and local-tier-driven:
+   on an integrated machine, the peer pairing-approval card warns that
+   approving grants a peer authority *here* (the upward-grant alarm), and
+   hosted-route device enrollments get an integrated-tier warning chip
+   beside the existing hosted-route one. *Deliberately deferred:*
+   cross-daemon tier visibility (a tier field on fleet records or agent
+   cards, so the granting side can compare both ends' tiers) — that needs
+   a metadata-carrier decision (browser-signed fleet payload v4 vs. the
+   public agent card) and is not required for the local alarm.
+2. **Per-daemon hosted-ceiling knob.** The same card carries "Hosted tabs
+   may: Operate / View only / Nothing" — one control writing both
+   hosted-provenance `role_ceilings` bindings
+   (`POST /api/access/hosted-ceiling`), with `role:none` (a
+   zero-permission, ceiling-only builtin) as the honest refuse-entirely
+   position. Choosing Integrated while hosted tabs can still operate
+   surfaces a one-click "Cap to View only" nudge. Raising ceilings,
+   per-binding divergence, and disabling remain deliberate `iam.json`
+   edits.
+3. **Per-entry vault unseal policy.** Vault entries accept
+   `unseal_policy: "trusted"` (add form + per-entry toggle): trusted-only
+   entries refuse reveal, lease fueling, egress relay, and the voice
+   mirror from hosted tabs, and the custody trail stamps every
+   lease/relay ceremony with the session's origin class
+   (`hosted`/`direct`/`local`/`peer`). Honest limits, stated in the UI
+   too: this is client-side self-enforcement — protection against
+   mistakes and casual exfiltration, not against a malicious bundle —
+   and until the direct/app vault path exists (the local-vault work),
+   a trusted-only entry is stored-but-sealed everywhere the vault
+   currently opens.

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -2001,6 +2001,8 @@ its operation per method/path from `federation_http_operation`.
 | GET | `/api/access/connect/claim-code` | AccessManage | fleet allowlist | none | Reveal the current twelve-word claim phrase (unclaimed daemons only) |
 | POST | `/api/access/connect/config` | AccessManage | fleet allowlist | bounded | Enable/disable the Connect client (persists to intendant.toml, applies live) |
 | POST | `/api/access/connect/unclaim` | AccessManage | fleet allowlist | bounded | Release this daemon's claim binding at the rendezvous (daemon-signed) |
+| POST | `/api/access/tier` | AccessManage | fleet allowlist | bounded | Set this daemon's trust tier label (integrated/disposable; null clears) |
+| POST | `/api/access/hosted-ceiling` | AccessManage | fleet allowlist | bounded | Set the hosted-control ceiling role for hosted-provenance sessions |
 | GET | `/api/dashboard/targets` | AccessInspect | own origin | none | Dashboard target list (this daemon + connected peers) |
 | any | `/api/peers[/…]` | federation (per method/path) | own origin | bounded | Peer registry (list/add/remove), pairing (invite/join/requests/identities), eligibility, and per-peer quick controls + signaling relays |
 | POST | `/api/coordinator/route` | federation (per method/path) | own origin | bounded | Capability-based task routing through the Coordinator |

--- a/src/bin/caller/access/iam.rs
+++ b/src/bin/caller/access/iam.rs
@@ -51,7 +51,20 @@ pub struct LocalIamState {
     /// `max_role` caps what its documents may grant here.
     #[serde(default)]
     pub trusted_orgs: Vec<TrustedOrg>,
+    /// Trust tier of this daemon (docs/src/trust-tiers.md): what a
+    /// compromise of this box would cost its owner. `integrated` = holds
+    /// the owner's personal world; `disposable` = scratch box, nothing
+    /// durable; `None` = the owner has not chosen. The tier is doctrine
+    /// carried to grant flows and the Access UI — it grants and denies
+    /// nothing by itself; ceilings and grants do the enforcing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tier: Option<String>,
 }
+
+/// The daemon tier vocabulary, in UI presentation order. Single source for
+/// the wire values and the dashboard's static mirror (pinned by the
+/// `dashboard_tier_vocabulary_mirrors_daemon_tiers` parity test).
+pub const DAEMON_TIERS: [&str; 2] = ["integrated", "disposable"];
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TrustedOrg {
@@ -91,7 +104,7 @@ fn default_role_ceilings() -> std::collections::BTreeMap<String, String> {
     ceilings
 }
 
-fn default_hosted_origins() -> Vec<String> {
+pub fn default_hosted_origins() -> Vec<String> {
     vec!["https://connect.intendant.dev".to_string()]
 }
 
@@ -613,6 +626,7 @@ impl Default for LocalIamState {
             role_ceilings: default_role_ceilings(),
             hosted_origins: default_hosted_origins(),
             trusted_orgs: Vec::new(),
+            tier: None,
         }
     }
 }
@@ -1088,6 +1102,114 @@ pub fn update_user_client_grant(
     Ok(IamGrantUpdateResult { principal, grant })
 }
 
+/// Set (or clear, with `None`) this daemon's trust tier
+/// (docs/src/trust-tiers.md). Pure state mutation + audit event; the
+/// caller persists. Returns the normalized stored value.
+pub fn set_daemon_tier(
+    state: &mut LocalIamState,
+    tier: Option<&str>,
+    actor: &AccessPrincipal,
+) -> AccessResult<Option<String>> {
+    let normalized = match tier.map(str::trim) {
+        None | Some("") => None,
+        Some(value) => {
+            let value = value.to_ascii_lowercase();
+            if !DAEMON_TIERS.contains(&value.as_str()) {
+                return Err(AccessError(format!(
+                    "unknown tier {value:?} (expected one of: {})",
+                    DAEMON_TIERS.join(", ")
+                )));
+            }
+            Some(value)
+        }
+    };
+    if state.tier == normalized {
+        return Ok(normalized);
+    }
+    let now = now_unix_ms();
+    state.audit_events.push(IamAuditEvent {
+        id: format!("audit:{}:{}", now, state.audit_events.len() + 1),
+        at_unix_ms: Some(now),
+        actor_principal_id: actor.id.clone(),
+        action: "set_daemon_tier".to_string(),
+        target_id: "local".to_string(),
+        summary: format!(
+            "Trust tier {} -> {}",
+            state.tier.as_deref().unwrap_or("unset"),
+            normalized.as_deref().unwrap_or("unset")
+        ),
+    });
+    state.tier = normalized.clone();
+    Ok(normalized)
+}
+
+/// The binding kinds the hosted-control ceiling governs: Connect-account
+/// sessions and browser identity keys enrolled from a hosted origin.
+pub const HOSTED_CEILING_BINDINGS: [&str; 2] = ["connect_account", "client_key"];
+
+/// Set the hosted-control ceiling — the `role_ceilings` entries for both
+/// hosted-provenance binding kinds — to `role_id`, which must name a
+/// defined, enforced role (`role:none` refuses hosted control entirely).
+/// Pure state mutation + audit event; the caller persists. Divergent
+/// per-binding ceilings remain possible by editing `iam.json`; this
+/// function is the one-knob path the dashboard exposes.
+pub fn set_hosted_control_ceiling(
+    state: &mut LocalIamState,
+    role_id: &str,
+    actor: &AccessPrincipal,
+) -> AccessResult<()> {
+    for role in builtin_role_templates() {
+        if !state.roles.iter().any(|existing| existing.id == role.id) {
+            state.roles.push(role);
+        }
+    }
+    let role_id = role_id.trim();
+    let Some(role) = state.roles.iter().find(|role| role.id == role_id) else {
+        return Err(AccessError(format!("unknown IAM role {role_id}")));
+    };
+    if role.status == "planned" {
+        return Err(AccessError(format!(
+            "IAM role {role_id} is planned but not enforced"
+        )));
+    }
+    let role_id = role.id.clone();
+    let previous: Vec<String> = HOSTED_CEILING_BINDINGS
+        .iter()
+        .map(|binding| {
+            state
+                .role_ceilings
+                .get(*binding)
+                .cloned()
+                .unwrap_or_else(|| "uncapped".to_string())
+        })
+        .collect();
+    if previous.iter().all(|existing| *existing == role_id) {
+        return Ok(());
+    }
+    for binding in HOSTED_CEILING_BINDINGS {
+        state
+            .role_ceilings
+            .insert(binding.to_string(), role_id.clone());
+    }
+    let now = now_unix_ms();
+    state.audit_events.push(IamAuditEvent {
+        id: format!("audit:{}:{}", now, state.audit_events.len() + 1),
+        at_unix_ms: Some(now),
+        actor_principal_id: actor.id.clone(),
+        action: "set_hosted_control_ceiling".to_string(),
+        target_id: "role_ceilings".to_string(),
+        summary: format!(
+            "Hosted control ceiling {} -> {role_id}",
+            if previous[0] == previous[1] {
+                previous[0].clone()
+            } else {
+                previous.join(" / ")
+            }
+        ),
+    });
+    Ok(())
+}
+
 fn validate_user_client_role(state: &LocalIamState, role_id: &str) -> AccessResult<()> {
     let Some(role) = state.roles.iter().find(|role| role.id == role_id) else {
         return Err(AccessError(format!("unknown IAM role {role_id}")));
@@ -1095,6 +1217,12 @@ fn validate_user_client_role(state: &LocalIamState, role_id: &str) -> AccessResu
     if role.id == "role:peer-profile" {
         return Err(AccessError(
             "peer-profile is a daemon-to-daemon role and cannot be assigned to a user/client"
+                .to_string(),
+        ));
+    }
+    if role.id == "role:none" {
+        return Err(AccessError(
+            "role:none is a ceiling-only sentinel and cannot be granted to a user/client"
                 .to_string(),
         ));
     }
@@ -1680,6 +1808,7 @@ pub fn overview_metadata(load: &LoadedIamState) -> Value {
         },
         "role_ceilings": load.state.role_ceilings.clone(),
         "hosted_origins": load.state.hosted_origins.clone(),
+        "tier": load.state.tier.clone(),
         "trusted_orgs": load.state.trusted_orgs.clone(),
         "org_issuers": load
             .path
@@ -2011,6 +2140,41 @@ pub fn role_ceiling_for_session(
     Some(ceiling.clone())
 }
 
+/// Origin class of a session for the custody trail
+/// (docs/src/trust-tiers.md): `hosted` (Connect account or a browser key
+/// enrolled from one of `hosted_origins`), `direct` (anchor-grade key,
+/// mTLS certificate, or any other explicit binding), `local` (the
+/// owner's own dashboard / loopback), or `peer` (a federated daemon).
+/// Classification mirrors [`role_ceiling_for_session`]'s hosted test.
+pub fn session_origin_class(hosted_origins: &[String], principal: &AccessPrincipal) -> &'static str {
+    if principal.kind == "peer_daemon" {
+        return "peer";
+    }
+    match principal.authn_kind.as_deref() {
+        Some("connect_account") => "hosted",
+        Some("client_key") => {
+            let origin = principal.authn_origin.as_deref().unwrap_or("");
+            let hosted = !origin.is_empty()
+                && hosted_origins
+                    .iter()
+                    .any(|candidate| candidate.trim_end_matches('/') == origin.trim_end_matches('/'));
+            if hosted {
+                "hosted"
+            } else {
+                "direct"
+            }
+        }
+        Some(_) => "direct",
+        None => {
+            if principal.kind == "root_session" {
+                "local"
+            } else {
+                "direct"
+            }
+        }
+    }
+}
+
 /// True when a permission list grants `permission`. The legacy aggregate id
 /// `terminal.use` implies the three split terminal permissions, so custom
 /// roles and org grant caps written before the split keep their meaning
@@ -2178,6 +2342,17 @@ fn builtin_role_templates() -> Vec<IamRole> {
                 "filesystem.read".to_string(),
                 "filesystem.write".to_string(),
             ],
+            source: "builtin".to_string(),
+        },
+        IamRole {
+            id: "role:none".to_string(),
+            label: "No access".to_string(),
+            status: "enforced".to_string(),
+            summary: "Ceiling-only sentinel with no permissions: used in role_ceilings to \
+                      refuse a binding kind (e.g. hosted-origin control) entirely. Never \
+                      assigned to a principal."
+                .to_string(),
+            permissions: vec![],
             source: "builtin".to_string(),
         },
         IamRole {
@@ -2726,10 +2901,54 @@ mod tests {
         let mut pickable = builtin.clone();
         // The peer-profile role is daemon-peer-only; humans never pick it.
         assert!(pickable.remove("role:peer-profile"));
+        // role:none is the ceiling-only sentinel; it is never granted.
+        assert!(pickable.remove("role:none"));
         assert_eq!(
             quoted_role_ids(picker),
             pickable,
             "ACCESS_ROLE_PICKER_ORDER (static/app.html) drifted from builtin_role_templates"
+        );
+    }
+
+    #[test]
+    fn dashboard_tier_vocabulary_mirrors_daemon_tiers() {
+        let app = app_html();
+        let meta = slice_between(app, "const ACCESS_TIER_META = {", "\n};");
+        let pattern = regex::Regex::new(r"'([a-z]+)':\s*\{").unwrap();
+        let mirrored: Vec<String> = pattern
+            .captures_iter(meta)
+            .map(|caps| caps[1].to_string())
+            .collect();
+        let expected: Vec<String> = DAEMON_TIERS.iter().map(|tier| tier.to_string()).collect();
+        assert_eq!(
+            mirrored, expected,
+            "ACCESS_TIER_META (static/app.html) drifted from DAEMON_TIERS — \
+             ids and presentation order are both pinned"
+        );
+    }
+
+    #[test]
+    fn dashboard_hosted_ceiling_choices_name_builtin_roles() {
+        let app = app_html();
+        let builtin: std::collections::BTreeSet<String> = builtin_role_templates()
+            .into_iter()
+            .map(|role| role.id)
+            .collect();
+        let choices = slice_between(app, "const ACCESS_HOSTED_CEILING_CHOICES = [", "\n];");
+        let mirrored = quoted_role_ids(choices);
+        assert!(
+            !mirrored.is_empty(),
+            "ACCESS_HOSTED_CEILING_CHOICES (static/app.html) lists no role ids"
+        );
+        for role_id in &mirrored {
+            assert!(
+                builtin.contains(role_id),
+                "ACCESS_HOSTED_CEILING_CHOICES entry {role_id} is not a builtin role"
+            );
+        }
+        assert!(
+            mirrored.contains("role:none"),
+            "the hosted-ceiling knob must offer the refuse-entirely position (role:none)"
         );
     }
 
@@ -3779,6 +3998,138 @@ mod tests {
             )
             .allowed
         );
+    }
+
+    #[test]
+    fn set_daemon_tier_validates_normalizes_and_audits() {
+        let mut state = LocalIamState::default();
+        let actor = AccessPrincipal::root_dashboard_session("test", "dashboard-control");
+        assert_eq!(state.tier, None);
+
+        let stored = set_daemon_tier(&mut state, Some("  Integrated "), &actor).unwrap();
+        assert_eq!(stored.as_deref(), Some("integrated"));
+        assert_eq!(state.tier.as_deref(), Some("integrated"));
+        assert_eq!(state.audit_events.len(), 1);
+        assert_eq!(state.audit_events[0].action, "set_daemon_tier");
+
+        // Idempotent set: no state change, no audit noise.
+        set_daemon_tier(&mut state, Some("integrated"), &actor).unwrap();
+        assert_eq!(state.audit_events.len(), 1);
+
+        let err = set_daemon_tier(&mut state, Some("fortress"), &actor).unwrap_err();
+        assert!(err.to_string().contains("unknown tier"));
+        assert_eq!(state.tier.as_deref(), Some("integrated"));
+
+        let cleared = set_daemon_tier(&mut state, None, &actor).unwrap();
+        assert_eq!(cleared, None);
+        assert_eq!(state.tier, None);
+        assert_eq!(state.audit_events.len(), 2);
+    }
+
+    #[test]
+    fn hosted_control_ceiling_role_none_refuses_hosted_sessions_entirely() {
+        let mut state = LocalIamState::default();
+        let actor = AccessPrincipal::root_dashboard_session("test", "dashboard-control");
+        upsert_user_client_grant(
+            &mut state,
+            UserClientGrantUpsertRequest {
+                client_key_fingerprint: Some("hosted-key".to_string()),
+                client_key_origin: Some("https://connect.intendant.dev".to_string()),
+                role_id: Some("role:root".to_string()),
+                ..Default::default()
+            },
+            &actor,
+        )
+        .unwrap();
+        upsert_user_client_grant(
+            &mut state,
+            UserClientGrantUpsertRequest {
+                client_key_fingerprint: Some("anchor-key".to_string()),
+                client_key_origin: Some("https://anchor.local:8765".to_string()),
+                role_id: Some("role:root".to_string()),
+                ..Default::default()
+            },
+            &actor,
+        )
+        .unwrap();
+
+        set_hosted_control_ceiling(&mut state, "role:none", &actor).unwrap();
+        for binding in HOSTED_CEILING_BINDINGS {
+            assert_eq!(
+                state.role_ceilings.get(binding).map(String::as_str),
+                Some("role:none")
+            );
+        }
+        assert!(state
+            .audit_events
+            .iter()
+            .any(|event| event.action == "set_hosted_control_ceiling"));
+
+        // A hosted-origin key with a root grant can no longer do anything —
+        // not even the observer-grade operations operator allowed.
+        let hosted = principal_for_client_key(&state, "hosted-key", "connect").unwrap();
+        for op in [
+            crate::access::access_policy::PeerOperation::ShellSpawn,
+            crate::access::access_policy::PeerOperation::DisplayView,
+            crate::access::access_policy::PeerOperation::SessionInspect,
+        ] {
+            let denied = evaluate_principal_operation_with_state(&state, &hosted, op);
+            assert!(!denied.allowed, "expected {op:?} denied under role:none");
+            assert!(denied.reason.contains("role ceiling"));
+        }
+
+        // Anchor-origin keys are untouched by the hosted ceiling.
+        let anchor = principal_for_client_key(&state, "anchor-key", "connect").unwrap();
+        assert!(
+            evaluate_principal_operation_with_state(
+                &state,
+                &anchor,
+                crate::access::access_policy::PeerOperation::AccessManage,
+            )
+            .allowed
+        );
+
+        // Idempotent set: no extra audit event.
+        let audit_count = state.audit_events.len();
+        set_hosted_control_ceiling(&mut state, "role:none", &actor).unwrap();
+        assert_eq!(state.audit_events.len(), audit_count);
+
+        // And the knob moves back up.
+        set_hosted_control_ceiling(&mut state, "role:operator", &actor).unwrap();
+        assert!(
+            evaluate_principal_operation_with_state(
+                &state,
+                &hosted,
+                crate::access::access_policy::PeerOperation::ShellSpawn,
+            )
+            .allowed
+        );
+    }
+
+    #[test]
+    fn set_hosted_control_ceiling_requires_a_defined_role() {
+        let mut state = LocalIamState::default();
+        let actor = AccessPrincipal::root_dashboard_session("test", "dashboard-control");
+        let err = set_hosted_control_ceiling(&mut state, "role:fortress", &actor).unwrap_err();
+        assert!(err.to_string().contains("unknown IAM role"));
+        assert_eq!(state.role_ceilings, default_role_ceilings());
+    }
+
+    #[test]
+    fn role_none_cannot_be_granted_to_a_user_client() {
+        let mut state = LocalIamState::default();
+        let actor = AccessPrincipal::root_dashboard_session("test", "dashboard-control");
+        let err = upsert_user_client_grant(
+            &mut state,
+            UserClientGrantUpsertRequest {
+                client_key_fingerprint: Some("some-key".to_string()),
+                role_id: Some("role:none".to_string()),
+                ..Default::default()
+            },
+            &actor,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("ceiling-only"));
     }
 
     #[test]

--- a/src/bin/caller/credential_audit.rs
+++ b/src/bin/caller/credential_audit.rs
@@ -40,6 +40,14 @@ pub struct CustodyEvent {
     pub kind: String,
     pub label: String,
     pub actor: String,
+    /// Origin class of the session that performed the ceremony —
+    /// `hosted` (Connect account / hosted-origin browser key), `direct`
+    /// (anchor-grade key or mTLS cert), `local` (the owner's own
+    /// dashboard), or `peer`. Empty for events with no session behind
+    /// them (expiry sweeps, restart resets) and for records written
+    /// before the field existed. See docs/src/trust-tiers.md.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub origin: String,
     pub detail: String,
 }
 
@@ -125,6 +133,7 @@ impl Trail {
             kind: String::new(),
             label: String::new(),
             actor: "daemon".to_string(),
+            origin: String::new(),
             detail: "restart: in-memory leases and relays cleared".to_string(),
         });
     }
@@ -191,12 +200,27 @@ fn global() -> &'static Mutex<Trail> {
 /// Record one custody event. `detail` is free-form human text; material
 /// must never be passed here.
 pub fn record(event: &str, kind: &str, label: &str, actor: &str, detail: String) {
+    record_with_origin(event, kind, label, actor, "", detail);
+}
+
+/// Like [`record`], stamping the origin class of the session behind the
+/// ceremony (`hosted` / `direct` / `local` / `peer`; empty = unknown or
+/// no session).
+pub fn record_with_origin(
+    event: &str,
+    kind: &str,
+    label: &str,
+    actor: &str,
+    origin: &str,
+    detail: String,
+) {
     let entry = CustodyEvent {
         at_unix_ms: now_unix_ms(),
         event: event.to_string(),
         kind: kind.to_string(),
         label: label.to_string(),
         actor: actor.to_string(),
+        origin: origin.to_string(),
         detail,
     };
     global()
@@ -237,6 +261,7 @@ mod tests {
 
     fn event(n: u64, event: &str) -> CustodyEvent {
         CustodyEvent {
+            origin: String::new(),
             at_unix_ms: n,
             event: event.to_string(),
             kind: "api_key:anthropic".to_string(),

--- a/src/bin/caller/credential_egress.rs
+++ b/src/bin/caller/credential_egress.rs
@@ -86,6 +86,7 @@ fn b64(data: &[u8]) -> String {
 pub fn register(
     session_id: &str,
     label: &str,
+    via: &str,
     kinds: &[String],
     frames_tx: mpsc::UnboundedSender<serde_json::Value>,
 ) -> Result<Vec<String>, String> {
@@ -118,11 +119,12 @@ pub fn register(
         }
     }
     for kind in &accepted {
-        crate::credential_audit::record(
+        crate::credential_audit::record_with_origin(
             crate::credential_audit::EVENT_EGRESS_REGISTERED,
             kind,
             label.trim(),
             label.trim(),
+            via,
             format!("provider calls relay through browser session {session_id}"),
         );
     }
@@ -523,6 +525,7 @@ mod tests {
         let accepted = register(
             "s1",
             "Tab A",
+            "local",
             &kinds(&[KIND_ANTHROPIC, "oauth:codex", "junk"]),
             tx,
         )
@@ -530,7 +533,7 @@ mod tests {
         assert_eq!(accepted, vec![KIND_ANTHROPIC.to_string()]);
         assert!(available(KIND_ANTHROPIC));
         assert!(!available(KIND_GEMINI));
-        assert!(register("s1", "Tab A", &kinds(&["junk"]), {
+        assert!(register("s1", "Tab A", "local", &kinds(&["junk"]), {
             let (tx, _rx) = mpsc::unbounded_channel();
             tx
         })
@@ -538,7 +541,7 @@ mod tests {
 
         // A later session takes the kind over.
         let (tx2, _rx2) = mpsc::unbounded_channel();
-        register("s2", "Tab B", &kinds(&[KIND_ANTHROPIC]), tx2).unwrap();
+        register("s2", "Tab B", "local", &kinds(&[KIND_ANTHROPIC]), tx2).unwrap();
         let status = relay_status();
         assert_eq!(status.len(), 1);
         assert_eq!(status[0].session_id, "s2");
@@ -553,7 +556,7 @@ mod tests {
         let _guard = lock();
         reset();
         let (tx, mut relay_rx) = mpsc::unbounded_channel();
-        register("s1", "Tab A", &kinds(&[KIND_GEMINI]), tx).unwrap();
+        register("s1", "Tab A", "local", &kinds(&[KIND_GEMINI]), tx).unwrap();
 
         let fetch_task = tokio::spawn(fetch(
             KIND_GEMINI,
@@ -616,7 +619,7 @@ mod tests {
         let _guard = lock();
         reset();
         let (tx, mut relay_rx) = mpsc::unbounded_channel();
-        register("s1", "Tab A", &kinds(&[KIND_ANTHROPIC]), tx).unwrap();
+        register("s1", "Tab A", "local", &kinds(&[KIND_ANTHROPIC]), tx).unwrap();
 
         let fetch_task = tokio::spawn(fetch(
             KIND_ANTHROPIC,
@@ -662,7 +665,7 @@ mod tests {
         let _guard = lock();
         reset();
         let (tx, mut relay_rx) = mpsc::unbounded_channel();
-        register("s1", "Tab A", &kinds(&[KIND_ANTHROPIC]), tx).unwrap();
+        register("s1", "Tab A", "local", &kinds(&[KIND_ANTHROPIC]), tx).unwrap();
         let fetch_task = tokio::spawn(fetch(
             KIND_ANTHROPIC,
             "POST",

--- a/src/bin/caller/credential_leases.rs
+++ b/src/bin/caller/credential_leases.rs
@@ -516,6 +516,7 @@ pub fn grant(
     material: &str,
     mode: Option<&str>,
     granted_by: &str,
+    granted_via: &str,
     ttl_ms: Option<u64>,
     offline_ms: Option<u64>,
 ) -> Result<GrantOutcome, String> {
@@ -567,11 +568,12 @@ pub fn grant(
         .write()
         .expect("lease tombstones poisoned")
         .remove(kind);
-    crate::credential_audit::record(
+    crate::credential_audit::record_with_origin(
         crate::credential_audit::EVENT_LEASE_GRANTED,
         kind,
         label.trim(),
         granted_by.trim(),
+        granted_via,
         format!(
             "ttl {}m · offline {}h · mode {}{}",
             ttl_ms / 60_000,
@@ -620,7 +622,7 @@ impl LeaseShutdownGuard {
 
 impl Drop for LeaseShutdownGuard {
     fn drop(&mut self) {
-        let dropped = revoke(None, "process exit");
+        let dropped = revoke(None, "process exit", "local");
         if dropped > 0 {
             eprintln!("Revoked {dropped} credential lease(s) at process exit");
         }
@@ -632,7 +634,7 @@ impl Drop for LeaseShutdownGuard {
 /// deliberate forgetting — it leaves no "expired" tombstone. `actor` is
 /// who asked (a principal label, or "daemon shutdown"), recorded in the
 /// custody trail.
-pub fn revoke(selector: Option<&str>, actor: &str) -> usize {
+pub fn revoke(selector: Option<&str>, actor: &str, via: &str) -> usize {
     let mut leases = store().write().expect("lease store poisoned");
     let before = leases.len();
     let mut dropped: Vec<(String, String)> = Vec::new();
@@ -660,11 +662,12 @@ pub fn revoke(selector: Option<&str>, actor: &str) -> usize {
             eprintln!("[credential-leases] revoked lease cleanup for {kind} failed: {err}");
             queue_materialization_cleanup(&kind);
         }
-        crate::credential_audit::record(
+        crate::credential_audit::record_with_origin(
             crate::credential_audit::EVENT_LEASE_REVOKED,
             &kind,
             &label,
             actor,
+            via,
             "material dropped and zeroized".to_string(),
         );
     }
@@ -785,6 +788,7 @@ mod tests {
             "sk-ant-lease-material",
             None,
             "connect:alice",
+            "hosted",
             None,
             None,
         )
@@ -805,7 +809,7 @@ mod tests {
         let renewed_expiry = renew(&outcome.lease_id).unwrap();
         assert!(renewed_expiry >= outcome.expires_at_unix_ms);
 
-        assert_eq!(revoke(Some(&outcome.lease_id), "test"), 1);
+        assert_eq!(revoke(Some(&outcome.lease_id), "test", "local"), 1);
         assert!(leased_secret("api_key:anthropic").is_none());
         // Revocation is deliberate — it must not read as "went dry".
         assert!(expired_lease_note().is_none());
@@ -816,13 +820,13 @@ mod tests {
     fn regrant_replaces_and_unknown_kinds_are_refused() {
         let _guard = lock();
         reset();
-        grant("api_key:openai", "a", "first", None, "root", None, None).unwrap();
-        let outcome = grant("api_key:openai", "b", "second", None, "root", None, None).unwrap();
+        grant("api_key:openai", "a", "first", None, "root", "local", None, None).unwrap();
+        let outcome = grant("api_key:openai", "b", "second", None, "root", "local", None, None).unwrap();
         assert!(outcome.replaced);
         assert_eq!(leased_secret("api_key:openai").as_deref(), Some("second"));
 
-        assert!(grant("api_key:mystery", "x", "y", None, "root", None, None).is_err());
-        assert!(grant("api_key:gemini", "x", "", None, "root", None, None).is_err());
+        assert!(grant("api_key:mystery", "x", "y", None, "root", "local", None, None).is_err());
+        assert!(grant("api_key:gemini", "x", "", None, "root", "local", None, None).is_err());
         reset();
     }
 
@@ -836,6 +840,7 @@ mod tests {
             "gm-key",
             None,
             "root",
+            "local",
             Some(0), // clamps to MIN_TTL_MS
             Some(0), // offline 0: dies one TTL after the last renewal
         )
@@ -858,6 +863,7 @@ mod tests {
             "gm-key-2",
             None,
             "root",
+            "local",
             None,
             None,
         )
@@ -919,6 +925,7 @@ mod tests {
             r#"{"tokens":{"access_token":"at","refresh_token":"rt"}}"#,
             Some("access_token"),
             "root",
+            "local",
             None,
             None,
         )
@@ -930,6 +937,7 @@ mod tests {
             r#"{"claudeAiOauth":{"accessToken":"at","refreshToken":"rt"}}"#,
             Some("access_token"),
             "root",
+            "local",
             None,
             None,
         )
@@ -942,6 +950,7 @@ mod tests {
             r#"{"OPENAI_API_KEY":"sk-live","tokens":{"access_token":"at"}}"#,
             Some("access_token"),
             "root",
+            "local",
             None,
             None,
         )
@@ -954,6 +963,7 @@ mod tests {
             "not json",
             Some("access_token"),
             "root",
+            "local",
             None,
             None
         )
@@ -964,6 +974,7 @@ mod tests {
             r#"{"tokens":{}}"#,
             Some("sideways"),
             "root",
+            "local",
             None,
             None
         )
@@ -1007,6 +1018,7 @@ mod tests {
             "gm",
             Some("access_token"),
             "root",
+            "local",
             None,
             None,
         )
@@ -1020,7 +1032,7 @@ mod tests {
                 .as_str(),
             "api_key"
         );
-        revoke(None, "test");
+        revoke(None, "test", "local");
         reset();
     }
 
@@ -1034,6 +1046,7 @@ mod tests {
             "sk-ant-from-lease",
             None,
             "root",
+            "local",
             None,
             None,
         )

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -125,6 +125,7 @@ pub(crate) fn control_frame_response(
                             &material,
                             mode.as_deref(),
                             runtime.grant.label(),
+                            runtime.grant.custody_origin_class(),
                             ttl_ms,
                             offline_ms,
                         ) {
@@ -176,6 +177,7 @@ pub(crate) fn control_frame_response(
                     let revoked = crate::credential_leases::revoke(
                         selector.as_deref(),
                         runtime.grant.label(),
+                        runtime.grant.custody_origin_class(),
                     );
                     Some(serde_json::json!({
                         "t": "response",
@@ -270,6 +272,7 @@ pub(crate) fn control_frame_response(
                         Some(frames_tx) => match crate::credential_egress::register(
                             &runtime.session_id,
                             runtime.grant.label(),
+                            runtime.grant.custody_origin_class(),
                             &kinds,
                             frames_tx,
                         ) {
@@ -398,6 +401,29 @@ pub(crate) fn control_frame_response(
                         params,
                         runtime.project_root.as_deref(),
                     ) {
+                        Ok(result) => Some(serde_json::json!({
+                            "t": "response",
+                            "id": id,
+                            "ok": true,
+                            "result": result,
+                        })),
+                        Err(error) => Some(serde_json::json!({
+                            "t": "response",
+                            "id": id,
+                            "ok": false,
+                            "error": error,
+                        })),
+                    }
+                }
+                "api_access_set_tier" | "api_access_set_hosted_ceiling" => {
+                    let params = params.unwrap_or_else(|| serde_json::json!({}));
+                    let actor = runtime.grant.access_principal();
+                    let result = if method == "api_access_set_hosted_ceiling" {
+                        crate::web_gateway::access_set_hosted_ceiling_response_value(params, &actor)
+                    } else {
+                        crate::web_gateway::access_set_tier_response_value(params, &actor)
+                    };
+                    match result {
                         Ok(result) => Some(serde_json::json!({
                             "t": "response",
                             "id": id,

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -148,6 +148,10 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
     method("api_access_connect_claim_code", PeerOperation::AccessManage),
     method("api_access_connect_config", PeerOperation::AccessManage),
     method("api_access_connect_unclaim", PeerOperation::AccessManage),
+    // Trust-tier settings (docs/src/trust-tiers.md): the tier label and
+    // the hosted-control ceiling knob (mirrors the HTTP route rows).
+    method("api_access_set_tier", PeerOperation::AccessManage),
+    method("api_access_set_hosted_ceiling", PeerOperation::AccessManage),
     // Credential custody (vault leases + client egress): granting, renewing,
     // revoking, and even reading lease status all sit behind the dedicated
     // gate — a scoped guest session can neither fuel nor drain a daemon, nor
@@ -484,6 +488,26 @@ impl DashboardControlGrant {
                 profile.clone(),
                 "peer-dashboard-control",
             ),
+        }
+    }
+
+    /// Origin class of this session for the custody trail —
+    /// `hosted` / `direct` / `local` / `peer`
+    /// (`access::iam::session_origin_class`). `UserClient` grants carry
+    /// their IAM snapshot's `hosted_origins`; the root-equivalent
+    /// variants classify against the compiled default list.
+    pub(crate) fn custody_origin_class(&self) -> &'static str {
+        match self {
+            Self::TrustedLocal => "local",
+            Self::UserClientRoot { principal } => crate::access::iam::session_origin_class(
+                &crate::access::iam::default_hosted_origins(),
+                principal,
+            ),
+            Self::UserClient {
+                principal,
+                iam_state,
+            } => crate::access::iam::session_origin_class(&iam_state.hosted_origins, principal),
+            Self::Peer { .. } => "peer",
         }
     }
 

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -255,6 +255,10 @@ pub(crate) enum RouteHandlerId {
     AccessConnectClaimCode,
     AccessConnectConfig,
     AccessConnectUnclaim,
+    /// Trust-tier settings pair (docs/src/trust-tiers.md): the daemon
+    /// tier label and the hosted-control ceiling knob. One handler, two
+    /// paths, switched on `req_path`.
+    AccessTierSettings,
     DashboardTargets,
     /// The whole /api/peers registry + pairing sub-router, moved
     /// verbatim (its internal shapes stay as they were; leaf-shape
@@ -962,6 +966,22 @@ pub(crate) static ROUTES: &[Route] = &[
         RouteHandlerId::AccessConnectUnclaim,
         "Release this daemon's claim binding at the rendezvous (daemon-signed)",
     ),
+    fleet_route(
+        RouteMethod::Post,
+        PathPattern::Exact("/api/access/tier"),
+        PeerOperation::AccessManage,
+        BodyPolicy::Default,
+        RouteHandlerId::AccessTierSettings,
+        "Set this daemon's trust tier label (integrated/disposable; null clears)",
+    ),
+    fleet_route(
+        RouteMethod::Post,
+        PathPattern::Exact("/api/access/hosted-ceiling"),
+        PeerOperation::AccessManage,
+        BodyPolicy::Default,
+        RouteHandlerId::AccessTierSettings,
+        "Set the hosted-control ceiling role for hosted-provenance sessions",
+    ),
     op_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/dashboard/targets"),
@@ -1417,6 +1437,7 @@ mod tests {
             RouteHandlerId::AccessIamGrants,
             RouteHandlerId::AccessOrgApplyRenew,
             RouteHandlerId::AccessOrgManage,
+            RouteHandlerId::AccessTierSettings,
             RouteHandlerId::McpStream,
         ];
         let mut seen: HashSet<RouteHandlerId> = HashSet::new();

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -3437,7 +3437,7 @@ async fn main() -> Result<(), CallerError> {
                 }
                 // Drop every credential lease (zeroizes memory, deletes
                 // materialized oauth auth files) before the process dies.
-                let _ = credential_leases::revoke(None, "daemon shutdown");
+                let _ = credential_leases::revoke(None, "daemon shutdown", "local");
                 // Clean up control socket
                 control::cleanup();
                 std::process::exit(130);

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -696,6 +696,17 @@ pub(crate) async fn serve_http_request(
                 )
                 .await;
             }
+            RouteHandlerId::AccessTierSettings => {
+                return handle_access_tier_settings(
+                    stream,
+                    route_body,
+                    req_method,
+                    req_path,
+                    http_access_context,
+                    fleet_cors_origin,
+                )
+                .await;
+            }
             RouteHandlerId::AccessOverview => {
                 return handle_access_overview(
                     stream,

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -1189,6 +1189,131 @@ pub(crate) fn access_iam_upsert_user_client_grant_response_value_with_cert_dir(
     }))
 }
 
+/// Set (or clear) this daemon's trust tier (docs/src/trust-tiers.md):
+/// `{"tier": "integrated" | "disposable" | null}`. Shared by the HTTP
+/// route and the dashboard-control method.
+pub(crate) fn access_set_tier_response_value(
+    params: serde_json::Value,
+    actor: &crate::access::iam::AccessPrincipal,
+) -> Result<serde_json::Value, String> {
+    let tier = match params.get("tier") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::String(value)) => Some(value.as_str()),
+        Some(_) => return Err("tier must be a string or null".to_string()),
+    };
+    let cert_dir = crate::access::backend::select_backend().cert_dir();
+    let mut state = crate::access::iam::load_state(&cert_dir)
+        .map_err(|e| format!("load local IAM state: {e}"))?;
+    let stored =
+        crate::access::iam::set_daemon_tier(&mut state, tier, actor).map_err(|e| e.to_string())?;
+    crate::access::iam::save_state(&cert_dir, &state)
+        .map_err(|e| format!("save local IAM state: {e}"))?;
+    let loaded = crate::access::iam::load_state_for_overview(&cert_dir);
+    Ok(serde_json::json!({
+        "schema_version": 1,
+        "tier": stored,
+        "iam": crate::access::iam::overview_metadata(&loaded),
+    }))
+}
+
+/// Set the hosted-control ceiling (docs/src/trust-tiers.md):
+/// `{"role_id": "role:operator" | "role:observer" | "role:none" | …}` —
+/// any defined, enforced role. Writes both hosted-provenance binding
+/// ceilings; per-binding divergence stays an `iam.json` edit.
+pub(crate) fn access_set_hosted_ceiling_response_value(
+    params: serde_json::Value,
+    actor: &crate::access::iam::AccessPrincipal,
+) -> Result<serde_json::Value, String> {
+    let role_id = params
+        .get("role_id")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "role_id is required".to_string())?;
+    let cert_dir = crate::access::backend::select_backend().cert_dir();
+    let mut state = crate::access::iam::load_state(&cert_dir)
+        .map_err(|e| format!("load local IAM state: {e}"))?;
+    crate::access::iam::set_hosted_control_ceiling(&mut state, role_id, actor)
+        .map_err(|e| e.to_string())?;
+    crate::access::iam::save_state(&cert_dir, &state)
+        .map_err(|e| format!("save local IAM state: {e}"))?;
+    let loaded = crate::access::iam::load_state_for_overview(&cert_dir);
+    Ok(serde_json::json!({
+        "schema_version": 1,
+        "role_ceilings": loaded.state.role_ceilings,
+        "iam": crate::access::iam::overview_metadata(&loaded),
+    }))
+}
+
+/// One handler for the trust-tier settings pair; `req_path` picks the
+/// mutation. Both are manage-gated POSTs mirroring the IAM grant writes.
+pub(crate) async fn handle_access_tier_settings(
+    mut stream: DemuxStream,
+    body_text: String,
+    req_method: &str,
+    req_path: &str,
+    http_access_context: HttpAccessContext,
+    fleet_cors_origin: Option<String>,
+) {
+    use tokio::io::AsyncWriteExt;
+    if req_method != "POST" {
+        let response = json_response(
+            "405 Method Not Allowed",
+            serde_json::json!({"error": "method not allowed"}).to_string(),
+        );
+        let _ = stream.write_all(response.as_bytes()).await;
+    } else {
+        let decision =
+            http_access_context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
+        if !decision.allowed {
+            let response = json_response(
+                "403 Forbidden",
+                serde_json::json!({
+                    "error": "principal does not allow this operation",
+                    "principal": http_access_context.principal.as_value(),
+                    "permission": decision.permission,
+                    "reason": decision.reason,
+                })
+                .to_string(),
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+        } else {
+            let params: serde_json::Value = if body_text.trim().is_empty() {
+                serde_json::json!({})
+            } else {
+                match serde_json::from_str(&body_text) {
+                    Ok(value) => value,
+                    Err(e) => {
+                        let response = json_response(
+                            "400 Bad Request",
+                            serde_json::json!({"error": format!("invalid request body: {e}")})
+                                .to_string(),
+                        );
+                        let _ = stream.write_all(response.as_bytes()).await;
+                        finalize_http_stream(&mut stream).await;
+                        return;
+                    }
+                }
+            };
+            let result = if req_path == "/api/access/hosted-ceiling" {
+                access_set_hosted_ceiling_response_value(params, &http_access_context.principal)
+            } else {
+                access_set_tier_response_value(params, &http_access_context.principal)
+            };
+            let (status, body) = match result {
+                Ok(value) => (200, value.to_string()),
+                Err(error) => (400, serde_json::json!({"error": error}).to_string()),
+            };
+            let response = with_fleet_cors(
+                json_response(status_reason(status), body),
+                fleet_cors_origin.as_deref(),
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+        }
+    }
+    finalize_http_stream(&mut stream).await;
+}
+
 /// The Access API paths that participate in fleet cross-origin access: the
 /// anchor-served Access page manages sibling daemons by calling these
 /// directly, so they get an origin allowlist instead of the wildcard CORS
@@ -1210,6 +1335,8 @@ pub(crate) fn is_fleet_cors_access_path(req_path: &str) -> bool {
             | "/api/access/connect/claim-code"
             | "/api/access/connect/config"
             | "/api/access/connect/unclaim"
+            | "/api/access/tier"
+            | "/api/access/hosted-ceiling"
     )
 }
 

--- a/static/app.html
+++ b/static/app.html
@@ -3616,6 +3616,22 @@ body.access-page #tab-access {
 .daemon-role-summary {
   color: var(--subtext1);
 }
+.daemon-access-request-warn {
+  color: var(--peach);
+  font-weight: 600;
+}
+/* Trust tier card (Access → Overview) */
+.acc-tier-options .acc-btn {
+  flex: 1 1 0;
+  text-align: left;
+}
+.acc-tier-cap-row {
+  align-items: center;
+  gap: 10px;
+}
+.acc-tier-cap-row select.acc-btn {
+  min-width: 180px;
+}
 .daemon-access-request-actions {
   display: flex;
   gap: 6px;
@@ -21825,6 +21841,7 @@ html.ui-v2 .ui2-appearance-note {
           <div class="access-pane-body">
             <div id="access-attention" class="acc-attention"></div>
             <div id="access-identity-hero" class="acc-hero-grid"></div>
+            <div id="access-tier-card"></div>
             <div id="access-connect-card"></div>
             <div class="acc-section-head">
               <div class="acc-section-title">Fleet</div>
@@ -25927,6 +25944,22 @@ function vaultQueuePersist() {
   return result;
 }
 
+/* Per-entry unseal policy (docs/src/trust-tiers.md, hook 3). 'any' (or
+   absent — every pre-policy entry) uses the entry everywhere the vault
+   opens; 'trusted' refuses use from hosted tabs. Client-side self-
+   enforcement: it defends against mistakes and casual exfiltration, not
+   against a malicious page — and since today the vault only opens
+   through a Connect service, a trusted-only entry stays sealed until
+   the direct/app vault path lands. It still syncs, and the policy
+   rides inside the encrypted body like every other entry field. */
+function vaultEntryUnsealPolicy(entry) {
+  return entry?.unseal_policy === 'trusted' ? 'trusted' : 'any';
+}
+
+function vaultEntryUsableHere(entry) {
+  return vaultEntryUnsealPolicy(entry) !== 'trusted' || !DASHBOARD_CONNECT_MODE;
+}
+
 function vaultUpsertEntry(entry) {
   const now = Date.now();
   const existing = entry.id ? vaultState.entries.find(e => e.id === entry.id) : null;
@@ -25998,10 +26031,11 @@ let vaultVoiceMirror = {};
 function vaultSyncVoiceMirror() {
   const mirror = {};
   if (vaultState.status === 'unlocked' || vaultState.kBytes) {
+    const usable = vaultState.entries.filter(vaultEntryUsableHere);
     for (const [storageKey, provider] of Object.entries(VAULT_VOICE_STORAGE_PROVIDERS)) {
       const entry =
-        vaultState.entries.find(e => e.kind === 'api_key' && e.provider === provider && e.voice && e.secret) ||
-        vaultState.entries.find(e => e.kind === 'api_key' && e.provider === provider && e.secret);
+        usable.find(e => e.kind === 'api_key' && e.provider === provider && e.voice && e.secret) ||
+        usable.find(e => e.kind === 'api_key' && e.provider === provider && e.secret);
       if (entry) mirror[storageKey] = String(entry.secret);
     }
   }
@@ -26291,9 +26325,12 @@ function vaultLeaseRpc(method, params = {}) {
   return window.intendantDashboardControl.request(method, params, { timeoutMs: 15000 });
 }
 
-/* The lease kind a vault entry fuels, or null when it cannot fuel. */
+/* The lease kind a vault entry fuels, or null when it cannot fuel.
+   A trusted-only entry cannot fuel from this context at all — this is
+   the single choke point for fueling, re-fueling, and renew re-grants. */
 function vaultEntryLeaseKind(entry) {
   if (!entry || !entry.secret) return null;
+  if (!vaultEntryUsableHere(entry)) return null;
   if (entry.kind === 'api_key' && ['anthropic', 'openai', 'gemini'].includes(entry.provider)) {
     return `api_key:${entry.provider}`;
   }
@@ -26395,7 +26432,11 @@ function renderAccessCustodySection() {
     main.textContent = [event.label, event.kind].filter(Boolean).join(' · ');
     const meta = document.createElement('span');
     meta.className = 'custody-meta';
-    meta.textContent = [event.actor ? `by ${event.actor}` : '', event.detail]
+    meta.textContent = [
+      event.actor ? `by ${event.actor}` : '',
+      event.origin ? `via ${event.origin}` : '',
+      event.detail,
+    ]
       .filter(Boolean)
       .join(' — ');
     row.append(ts, chip, main, meta);
@@ -26557,9 +26598,10 @@ function vaultEgressEntryFor(kind) {
   if (vaultState.status !== 'unlocked') return null;
   const provider = String(kind || '').startsWith('api_key:') ? String(kind).slice(8) : '';
   if (!provider) return null;
+  const usable = vaultState.entries.filter(vaultEntryUsableHere);
   return (
-    vaultState.entries.find(e => e.kind === 'api_key' && e.provider === provider && e.secret && !e.voice) ||
-    vaultState.entries.find(e => e.kind === 'api_key' && e.provider === provider && e.secret) ||
+    usable.find(e => e.kind === 'api_key' && e.provider === provider && e.secret && !e.voice) ||
+    usable.find(e => e.kind === 'api_key' && e.provider === provider && e.secret) ||
     null
   );
 }
@@ -26896,10 +26938,21 @@ function vaultRenderEntries(card) {
     const kindChip = document.createElement('span');
     kindChip.className = 'vault-chip';
     kindChip.textContent = entry.kind === 'oauth' ? 'OAuth' : 'API key';
+    const trustedOnly = vaultEntryUnsealPolicy(entry) === 'trusted';
+    const usableHere = vaultEntryUsableHere(entry);
+    let policyChip = null;
+    if (trustedOnly) {
+      policyChip = document.createElement('span');
+      policyChip.className = usableHere ? 'vault-chip' : 'vault-chip warn';
+      policyChip.textContent = usableHere ? 'trusted origins' : 'sealed here';
+      policyChip.title = usableHere
+        ? 'This credential only works from trusted origins (direct or app) — hosted tabs cannot reveal, fuel, or relay it.'
+        : 'This credential is marked trusted-origins-only and this dashboard arrived through a hosted tab: it stays sealed here — no reveal, fueling, or relay. It still syncs with the vault.';
+    }
     const secret = document.createElement('span');
     secret.className = 'secret';
     const secretValue = String(entry.secret || '');
-    secret.textContent = vaultRevealedEntries.has(entry.id)
+    secret.textContent = usableHere && vaultRevealedEntries.has(entry.id)
       ? secretValue || '(token set)'
       : secretValue
         ? `••••${secretValue.slice(-4)}`
@@ -26907,26 +26960,37 @@ function vaultRenderEntries(card) {
     const actions = document.createElement('span');
     actions.className = 'vault-entry-actions';
     if (secretValue) {
-      actions.appendChild(
-        vaultButton(vaultRevealedEntries.has(entry.id) ? 'Hide' : 'Reveal', () => {
-          if (vaultRevealedEntries.has(entry.id)) vaultRevealedEntries.delete(entry.id);
-          else vaultRevealedEntries.add(entry.id);
-          renderAccessVaultSection();
-        })
-      );
-      actions.appendChild(
-        vaultButton('Copy', () => {
-          navigator.clipboard?.writeText(secretValue).catch(() => {});
-        })
-      );
+      const reveal = vaultButton(usableHere && vaultRevealedEntries.has(entry.id) ? 'Hide' : 'Reveal', () => {
+        if (vaultRevealedEntries.has(entry.id)) vaultRevealedEntries.delete(entry.id);
+        else vaultRevealedEntries.add(entry.id);
+        renderAccessVaultSection();
+      });
+      const copy = vaultButton('Copy', () => {
+        navigator.clipboard?.writeText(secretValue).catch(() => {});
+      });
+      if (!usableHere) {
+        reveal.disabled = true;
+        copy.disabled = true;
+        reveal.title = copy.title = 'Sealed in hosted tabs — this entry is marked trusted-origins-only.';
+      }
+      actions.append(reveal, copy);
     }
+    const policyBtn = vaultButton(trustedOnly ? 'Allow anywhere' : 'Trusted only', () => {
+      vaultUpsertEntry({ id: entry.id, unseal_policy: trustedOnly ? 'any' : 'trusted' });
+      renderAccessVaultSection();
+    });
+    policyBtn.title = trustedOnly
+      ? 'Let every dashboard this vault opens in use this credential again.'
+      : 'Seal this credential against hosted tabs: only direct or app origins may reveal, fuel, or relay it. (Client-side policy — it guards against mistakes, not a malicious page.)';
+    actions.appendChild(policyBtn);
     actions.appendChild(
       vaultButton('Remove', () => {
         vaultRemoveEntry(entry.id);
         renderAccessVaultSection();
       }, { danger: true })
     );
-    row.append(lbl, chip, kindChip, secret, actions);
+    if (policyChip) row.append(lbl, chip, kindChip, policyChip, secret, actions);
+    else row.append(lbl, chip, kindChip, secret, actions);
     list.appendChild(row);
   }
   card.appendChild(list);
@@ -26991,7 +27055,20 @@ function vaultRenderAddForm(card) {
     secretInput.style.display = oauth ? 'none' : '';
     secretArea.style.display = oauth ? '' : 'none';
   });
-  grid.append(kindLabel, kindSelect, providerLabel, providerSelect, labelLabel, labelInput, secretLabel, secretInput);
+  const policyLabel = document.createElement('label');
+  policyLabel.textContent = 'Unseal where?';
+  const policySelect = document.createElement('select');
+  for (const [value, label, title] of [
+    ['any', 'Anywhere this vault opens', 'The default: usable from every dashboard that can open your vault.'],
+    ['trusted', 'Trusted origins only (direct / app)', 'Sealed against hosted tabs: no reveal, fueling, or relay from them. Client-side policy — a guard against mistakes, not a malicious page. Today the vault itself opens through Connect, so a trusted-only entry stays stored-but-sealed until the direct/app vault path lands.'],
+  ]) {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = label;
+    option.title = title;
+    policySelect.appendChild(option);
+  }
+  grid.append(kindLabel, kindSelect, providerLabel, providerSelect, labelLabel, labelInput, policyLabel, policySelect, secretLabel, secretInput);
   body.appendChild(grid);
   body.appendChild(secretArea);
 
@@ -27018,6 +27095,7 @@ function vaultRenderAddForm(card) {
         label: labelInput.value.trim() ||
           (oauth ? vaultProviderLabel(providerSelect.value) : `${vaultProviderLabel(providerSelect.value)} key`),
         secret: secretValue,
+        ...(policySelect.value === 'trusted' ? { unseal_policy: 'trusted' } : {}),
       });
       secretInput.value = '';
       secretArea.value = '';
@@ -27139,6 +27217,15 @@ function vaultRenderFueling(card) {
   const fuelable = vaultState.entries
     .map(entry => ({ entry, kind: vaultEntryLeaseKind(entry) }))
     .filter(item => item.kind);
+  // No silent caps: say when entries exist but are sealed against this
+  // context, instead of quietly rendering fewer fuel buttons.
+  const sealed = vaultState.entries.filter(e => e.secret && !vaultEntryUsableHere(e)).length;
+  if (sealed > 0) {
+    const note = document.createElement('div');
+    note.className = 'vault-note';
+    note.textContent = `${sealed === 1 ? '1 credential is' : `${sealed} credentials are`} marked trusted-origins-only and stay${sealed === 1 ? 's' : ''} sealed in hosted tabs — no fueling from here.`;
+    card.appendChild(note);
+  }
   const fuelRow = document.createElement('div');
   fuelRow.className = 'vault-actions';
   for (const { entry, kind } of fuelable) {
@@ -49385,6 +49472,46 @@ async function accessConnectSetEnabled(enabled, rendezvousUrl) {
   renderAccessAdminSummaries();
 }
 
+async function accessSetTier(tier) {
+  const payload = { tier: tier || null };
+  try {
+    const resp = await dashboardJsonFetch('api_access_set_tier', payload, () => authedFetch('/api/access/tier', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }), 'api_access_set_tier', { fallbackAfterRpcFailure: false });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
+    showControlToast?.('success', tier
+      ? `Trust tier set: ${tier}`
+      : 'Trust tier cleared');
+  } catch (err) {
+    showControlToast?.('error', err?.message || 'Trust tier change failed');
+  }
+  await refreshAccessOverviewFromApi().catch(() => null);
+  renderAccessAdminSummaries();
+}
+
+async function accessSetHostedCeiling(roleId) {
+  const payload = { role_id: roleId };
+  try {
+    const resp = await dashboardJsonFetch('api_access_set_hosted_ceiling', payload, () => authedFetch('/api/access/hosted-ceiling', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }), 'api_access_set_hosted_ceiling', { fallbackAfterRpcFailure: false });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
+    showControlToast?.('success', roleId === 'role:none'
+      ? 'Hosted-origin control refused. Reach this daemon directly, through the app, or from an enrolled peer — a hosted tab can no longer change this back.'
+      : `Hosted control ceiling set to ${roleId.replace(/^role:/, '')}`);
+  } catch (err) {
+    showControlToast?.('error', err?.message || 'Hosted ceiling change failed');
+  }
+  await refreshAccessOverviewFromApi().catch(() => null);
+  renderAccessAdminSummaries();
+}
+
 async function accessConnectUnclaim() {
   try {
     const resp = await dashboardJsonFetch('api_access_connect_unclaim', {}, () => authedFetch('/api/access/connect/unclaim', {
@@ -50123,6 +50250,13 @@ function accessFallbackIamRoles() {
     status: 'enforced',
     summary: 'Daemon-to-daemon grants enforced by the approved peer identity profile.',
     permissions: ['presence.read', 'stats.read', 'display.view', 'display.input', 'message.send', 'task.run', 'approval.resolve', 'access.inspect', 'peer.inspect', 'peer.manage', 'session.inspect', 'session.manage', 'terminal.view', 'terminal.write', 'shell.spawn', 'settings.manage', 'runtime.control', 'filesystem.read', 'filesystem.write'],
+    source: 'builtin',
+  }, {
+    id: 'role:none',
+    label: 'No access',
+    status: 'enforced',
+    summary: 'Ceiling-only sentinel with no permissions: used in role_ceilings to refuse a binding kind (e.g. hosted-origin control) entirely. Never assigned to a principal.',
+    permissions: [],
     source: 'builtin',
   }, {
     id: 'role:scoped-human',
@@ -50955,7 +51089,7 @@ function accessSyncUserClientGrantFields(form) {
       && selectedRoleObj.permissions.some(perm => !ceilingRole.permissions.includes(perm)));
     note.style.display = exceeds ? '' : 'none';
     if (exceeds) {
-      note.textContent = `Hosted-route sessions for this account are capped at ${ceiling.replace(/^role:/, '')} by this daemon's role ceiling — the grant saves as ${selectedRole.replace(/^role:/, '')}, but Connect sessions won't exceed the ceiling. Raise or clear role_ceilings in iam.json to change this.`;
+      note.textContent = `Hosted-route sessions for this account are capped at ${ceiling.replace(/^role:/, '')} by this daemon's role ceiling — the grant saves as ${selectedRole.replace(/^role:/, '')}, but Connect sessions won't exceed the ceiling. The "Hosted tabs may" control on the Overview tab moves it.`;
     }
   }
 }
@@ -50968,6 +51102,8 @@ function accessAssignableIamRoles(overview = accessOverviewModel()) {
     const status = accessModelLabel(role?.status, 'enforced');
     if (!id || status === 'planned') return false;
     if (id === 'role:peer-profile') return false;
+    // role:none is the ceiling-only sentinel; it is never granted.
+    if (id === 'role:none') return false;
     return true;
   });
   if (filtered.length) return filtered;
@@ -51758,7 +51894,33 @@ const ACCESS_ROLE_META = {
   'role:observer': { cls: 'role-observer', short: 'Watch read-only, including live displays.' },
   'role:scoped-human': { cls: 'role-scoped', short: 'Inspect the access model only. A safe first grant.' },
   'role:peer-profile': { cls: 'role-peer', short: 'Daemon-to-daemon authority bounded by the peer profile.' },
+  'role:none': { cls: 'role-scoped', short: 'No permissions at all. Ceiling-only: used to refuse hosted-origin control entirely, never granted to anyone.' },
 };
+
+/* Trust tiers (docs/src/trust-tiers.md). The id vocabulary mirrors the
+   daemon's DAEMON_TIERS constant and is pinned by the
+   dashboard_tier_vocabulary_mirrors_daemon_tiers parity test — change
+   both together. */
+const ACCESS_TIER_META = {
+  'integrated': {
+    label: 'Integrated',
+    glyph: '⌂',
+    short: 'Holds your personal world — accounts, files, mail. Protect it: control it directly or through the app, and grant conservatively.',
+  },
+  'disposable': {
+    label: 'Disposable',
+    glyph: '♻',
+    short: 'Scratch box holding nothing durable. Worst case: rotate a key and destroy it. Hosted tabs are fine here.',
+  },
+};
+
+/* The curated hosted-ceiling positions, strongest last. Every id must
+   name a builtin role (pinned by the role-catalog parity test). */
+const ACCESS_HOSTED_CEILING_CHOICES = [
+  { id: 'role:operator', label: 'Operate (default)', short: 'Hosted tabs can drive sessions, terminal, files, and fuel credentials — the right setting for disposable boxes.' },
+  { id: 'role:observer', label: 'View only', short: 'Hosted tabs can watch displays and sessions but change nothing. Vault fueling from hosted tabs stops working on this daemon.' },
+  { id: 'role:none', label: 'Nothing', short: 'This daemon refuses hosted-origin control entirely — reach it directly, through the app, or from an enrolled peer.' },
+];
 
 function accessRoleMeta(roleId) {
   const id = accessModelLabel(roleId);
@@ -52475,6 +52637,151 @@ function renderAccessPeopleCurrent() {
   }));
 }
 
+/* Overview: Trust tier — what this machine holds, and how tightly hosted
+   tabs are capped on it (docs/src/trust-tiers.md). The tier is a doctrine
+   label (it grants and denies nothing); the ceiling row below it is the
+   enforcement, kept visually coupled so choosing "Integrated" naturally
+   leads to hardening hosted control. */
+function accessHostedCeilingCurrent(iam) {
+  const ceilings = iam.role_ceilings && typeof iam.role_ceilings === 'object' ? iam.role_ceilings : {};
+  const account = accessModelLabel(ceilings['connect_account']);
+  const key = accessModelLabel(ceilings['client_key']);
+  if (!account && !key) return { value: '', state: 'uncapped' };
+  if (account !== key) return { value: '', state: 'mixed' };
+  return { value: account, state: ACCESS_HOSTED_CEILING_CHOICES.some(c => c.id === account) ? 'choice' : 'custom' };
+}
+
+function renderAccessTierCard() {
+  const mount = document.getElementById('access-tier-card');
+  if (!mount) return;
+  const iam = accessIamModel(accessOverviewModel());
+  const tier = accessModelLabel(iam.tier);
+  const canSetTier = dashboardControlTransport?.lastStatus?.api_access_set_tier_available !== false;
+  const canSetCeiling = dashboardControlTransport?.lastStatus?.api_access_set_hosted_ceiling_available !== false;
+
+  mount.textContent = '';
+  const head = document.createElement('div');
+  head.className = 'acc-section-head';
+  const title = document.createElement('div');
+  title.className = 'acc-section-title';
+  title.textContent = 'Trust tier';
+  const sub = document.createElement('div');
+  sub.className = 'acc-section-sub';
+  sub.textContent = 'What would a compromise of this machine cost you? The tier is a label that guides grants and clients — the enforcement lives in the hosted-control cap below it.';
+  head.append(title, sub);
+  mount.appendChild(head);
+
+  const card = document.createElement('div');
+  card.className = 'acc-principal-card';
+
+  const headRow = document.createElement('div');
+  headRow.className = 'acc-principal-head';
+  const glyphEl = document.createElement('div');
+  glyphEl.className = 'acc-principal-glyph kind-local';
+  glyphEl.textContent = tier ? (ACCESS_TIER_META[tier]?.glyph || 'T') : '?';
+  const nameWrap = document.createElement('div');
+  const name = document.createElement('div');
+  name.className = 'acc-principal-name';
+  name.textContent = tier
+    ? `${ACCESS_TIER_META[tier]?.label || tier} machine`
+    : 'What does this machine hold?';
+  const kindLine = document.createElement('div');
+  kindLine.className = 'acc-principal-kind';
+  kindLine.textContent = tier
+    ? (ACCESS_TIER_META[tier]?.short || '')
+    : 'Pick a tier so grant flows and clients can hold you to it.';
+  nameWrap.append(name, kindLine);
+  headRow.append(glyphEl, nameWrap);
+  if (!tier) {
+    headRow.appendChild(accessRouteChip('remembered', 'not set',
+      'No tier chosen yet. The tier changes no permissions by itself — it drives warnings, recommendations, and (via the cap below) hosted-control policy.'));
+  }
+  card.appendChild(headRow);
+
+  // The two tier options, side by side, current one highlighted.
+  const options = document.createElement('div');
+  options.className = 'acc-grant-flow-actions acc-tier-options';
+  for (const [id, meta] of Object.entries(ACCESS_TIER_META)) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'acc-btn' + (tier === id ? ' primary' : '');
+    btn.textContent = `${meta.glyph} ${meta.label}`;
+    btn.title = meta.short + (tier === id ? ' (current — click again to clear)' : '');
+    btn.disabled = !canSetTier;
+    btn.addEventListener('click', () => accessSetTier(tier === id ? null : id));
+    options.appendChild(btn);
+  }
+  card.appendChild(options);
+
+  // Hosted-control cap: the enforcement row.
+  const ceiling = accessHostedCeilingCurrent(iam);
+  const capRow = document.createElement('div');
+  capRow.className = 'acc-grant-flow-actions acc-tier-cap-row';
+  const capLabel = document.createElement('span');
+  capLabel.className = 'acc-principal-kind';
+  capLabel.textContent = 'Hosted tabs may:';
+  capLabel.title = 'Applies to sessions arriving with hosted provenance — Connect accounts and browser keys enrolled from a hosted origin. Direct, app, and anchor-served sessions are never capped by this.';
+  capRow.appendChild(capLabel);
+  const select = document.createElement('select');
+  select.className = 'acc-btn';
+  select.disabled = !canSetCeiling;
+  for (const choice of ACCESS_HOSTED_CEILING_CHOICES) {
+    const opt = document.createElement('option');
+    opt.value = choice.id;
+    opt.textContent = choice.label;
+    opt.title = choice.short;
+    select.appendChild(opt);
+  }
+  if (ceiling.state === 'choice') {
+    select.value = ceiling.value;
+  } else {
+    const opt = document.createElement('option');
+    opt.value = '';
+    opt.disabled = true;
+    opt.selected = true;
+    opt.textContent = ceiling.state === 'mixed'
+      ? 'custom (per-binding, via iam.json)'
+      : ceiling.state === 'custom'
+        ? `custom (${ceiling.value.replace(/^role:/, '')})`
+        : 'uncapped (via iam.json)';
+    select.appendChild(opt);
+  }
+  select.addEventListener('change', () => {
+    if (select.value) accessSetHostedCeiling(select.value);
+  });
+  capRow.appendChild(select);
+  card.appendChild(capRow);
+
+  const hint = document.createElement('div');
+  hint.className = 'acc-principal-kind';
+  const currentChoice = ACCESS_HOSTED_CEILING_CHOICES.find(c => c.id === ceiling.value);
+  hint.textContent = ceiling.state === 'choice'
+    ? (currentChoice?.short || '')
+    : ceiling.state === 'uncapped'
+      ? 'Ceilings are disabled in iam.json — hosted sessions can hold whatever their grant says, including root. Choose a cap here to restore them.'
+      : 'This daemon carries a hand-tuned ceiling in iam.json; picking an option here overwrites it for both hosted bindings.';
+  card.appendChild(hint);
+
+  // The doctrine nudge: an integrated machine still operable from any
+  // hosted tab is the mismatch the tiers chapter warns about.
+  if (tier === 'integrated' && ceiling.value === 'role:operator') {
+    const nudge = document.createElement('div');
+    nudge.className = 'acc-connect-warn';
+    const text = document.createElement('span');
+    text.textContent = 'Integrated machine, yet hosted tabs can still operate it. Recommended: cap them to View only (or Nothing) and drive this daemon directly or through the app. ';
+    const harden = document.createElement('button');
+    harden.type = 'button';
+    harden.className = 'acc-btn';
+    harden.textContent = 'Cap to View only';
+    harden.disabled = !canSetCeiling;
+    harden.addEventListener('click', () => accessSetHostedCeiling('role:observer'));
+    nudge.append(text, harden);
+    card.appendChild(nudge);
+  }
+
+  mount.appendChild(card);
+}
+
 /* Overview: Intendant Connect — this daemon's hosted reachability and
    claim binding. States: off → one-click enable; registering; unclaimed
    → reveal the twelve words (manage-gated, fetched only on click);
@@ -52738,6 +53045,10 @@ function renderAccessEnrollmentRequests() {
     headRow.append(glyphEl, nameWrap);
     if (request.origin) {
       headRow.appendChild(accessRouteChip('connect', 'via hosted route', `The offer arrived through ${request.origin}; the key will be recorded with that origin, so the role ceiling applies until it is re-enrolled from an anchor origin.`));
+      if (accessModelLabel(accessIamModel(accessOverviewModel()).tier) === 'integrated') {
+        headRow.appendChild(accessRouteChip('danger', 'integrated tier',
+          'This is an integrated-tier machine and the key arrived through a hosted route. Approving is an upward grant (docs: trust-tiers) — the hosted-control cap still bounds the session, but prefer enrolling this device from a direct or app origin.'));
+      }
     }
     if (request.account_hint) {
       headRow.appendChild(request.account_attested
@@ -53794,6 +54105,7 @@ function renderAccessAdminSummaries() {
   }
   renderAccessAttention();
   renderAccessIdentityHero();
+  renderAccessTierCard();
   renderAccessConnectCard();
   renderAccessFleetStrip();
   renderAccessExplainer();
@@ -70867,6 +71179,12 @@ function renderPeerAccessRequests(requests) {
     return;
   }
 
+  // Upward-grant guard (docs/src/trust-tiers.md): approving a peer here
+  // grants that daemon authority ON this machine. On an integrated-tier
+  // machine that is the alarm condition — advisory, never a refusal.
+  const integratedTier = (typeof accessIamModel === 'function' && typeof accessOverviewModel === 'function')
+    && String(accessIamModel(accessOverviewModel())?.tier || '') === 'integrated';
+
   list.innerHTML = requests.map(req => {
     const requestId = String(req.request_id || '');
     const label = escapeHtml(req.requester_label || 'Unnamed daemon');
@@ -70889,6 +71207,7 @@ function renderPeerAccessRequests(requests) {
         </div>
         <div class="daemon-access-request-meta">Status ${escapeHtml(status)} - ${roleLabel} ${escapeHtml(role.label)}</div>
         <div class="daemon-access-request-meta daemon-role-summary">${escapeHtml(role.summary)}</div>
+        ${pending && integratedTier ? '<div class="daemon-access-request-meta daemon-access-request-warn" title="Grants flow toward disposable machines, never up. If that daemon is lower-trust than this one, approving bridges your tiers — see the Trust tier card in Access.">⚠ Integrated-tier machine: approving grants a peer daemon authority here. Make sure trust flows downward.</div>' : ''}
         ${timing ? `<div class="daemon-access-request-meta">${timing}</div>` : ''}
         ${pending ? `<div class="daemon-pairing-row"><select data-access-request-profile="${escapeHtml(requestId)}">${renderPeerProfileOptions(requestedProfile)}</select></div>` : ''}
         <div class="daemon-access-request-actions">

--- a/static/app/11-styles-access-files.css
+++ b/static/app/11-styles-access-files.css
@@ -2436,6 +2436,22 @@
 .daemon-role-summary {
   color: var(--subtext1);
 }
+.daemon-access-request-warn {
+  color: var(--peach);
+  font-weight: 600;
+}
+/* Trust tier card (Access → Overview) */
+.acc-tier-options .acc-btn {
+  flex: 1 1 0;
+  text-align: left;
+}
+.acc-tier-cap-row {
+  align-items: center;
+  gap: 10px;
+}
+.acc-tier-cap-row select.acc-btn {
+  min-width: 180px;
+}
 .daemon-access-request-actions {
   display: flex;
   gap: 6px;

--- a/static/app/21-access-dialogs.html
+++ b/static/app/21-access-dialogs.html
@@ -3,6 +3,7 @@
           <div class="access-pane-body">
             <div id="access-attention" class="acc-attention"></div>
             <div id="access-identity-hero" class="acc-hero-grid"></div>
+            <div id="access-tier-card"></div>
             <div id="access-connect-card"></div>
             <div class="acc-section-head">
               <div class="acc-section-title">Fleet</div>

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -789,6 +789,22 @@ function vaultQueuePersist() {
   return result;
 }
 
+/* Per-entry unseal policy (docs/src/trust-tiers.md, hook 3). 'any' (or
+   absent — every pre-policy entry) uses the entry everywhere the vault
+   opens; 'trusted' refuses use from hosted tabs. Client-side self-
+   enforcement: it defends against mistakes and casual exfiltration, not
+   against a malicious page — and since today the vault only opens
+   through a Connect service, a trusted-only entry stays sealed until
+   the direct/app vault path lands. It still syncs, and the policy
+   rides inside the encrypted body like every other entry field. */
+function vaultEntryUnsealPolicy(entry) {
+  return entry?.unseal_policy === 'trusted' ? 'trusted' : 'any';
+}
+
+function vaultEntryUsableHere(entry) {
+  return vaultEntryUnsealPolicy(entry) !== 'trusted' || !DASHBOARD_CONNECT_MODE;
+}
+
 function vaultUpsertEntry(entry) {
   const now = Date.now();
   const existing = entry.id ? vaultState.entries.find(e => e.id === entry.id) : null;
@@ -860,10 +876,11 @@ let vaultVoiceMirror = {};
 function vaultSyncVoiceMirror() {
   const mirror = {};
   if (vaultState.status === 'unlocked' || vaultState.kBytes) {
+    const usable = vaultState.entries.filter(vaultEntryUsableHere);
     for (const [storageKey, provider] of Object.entries(VAULT_VOICE_STORAGE_PROVIDERS)) {
       const entry =
-        vaultState.entries.find(e => e.kind === 'api_key' && e.provider === provider && e.voice && e.secret) ||
-        vaultState.entries.find(e => e.kind === 'api_key' && e.provider === provider && e.secret);
+        usable.find(e => e.kind === 'api_key' && e.provider === provider && e.voice && e.secret) ||
+        usable.find(e => e.kind === 'api_key' && e.provider === provider && e.secret);
       if (entry) mirror[storageKey] = String(entry.secret);
     }
   }
@@ -1153,9 +1170,12 @@ function vaultLeaseRpc(method, params = {}) {
   return window.intendantDashboardControl.request(method, params, { timeoutMs: 15000 });
 }
 
-/* The lease kind a vault entry fuels, or null when it cannot fuel. */
+/* The lease kind a vault entry fuels, or null when it cannot fuel.
+   A trusted-only entry cannot fuel from this context at all — this is
+   the single choke point for fueling, re-fueling, and renew re-grants. */
 function vaultEntryLeaseKind(entry) {
   if (!entry || !entry.secret) return null;
+  if (!vaultEntryUsableHere(entry)) return null;
   if (entry.kind === 'api_key' && ['anthropic', 'openai', 'gemini'].includes(entry.provider)) {
     return `api_key:${entry.provider}`;
   }
@@ -1257,7 +1277,11 @@ function renderAccessCustodySection() {
     main.textContent = [event.label, event.kind].filter(Boolean).join(' · ');
     const meta = document.createElement('span');
     meta.className = 'custody-meta';
-    meta.textContent = [event.actor ? `by ${event.actor}` : '', event.detail]
+    meta.textContent = [
+      event.actor ? `by ${event.actor}` : '',
+      event.origin ? `via ${event.origin}` : '',
+      event.detail,
+    ]
       .filter(Boolean)
       .join(' — ');
     row.append(ts, chip, main, meta);
@@ -1419,9 +1443,10 @@ function vaultEgressEntryFor(kind) {
   if (vaultState.status !== 'unlocked') return null;
   const provider = String(kind || '').startsWith('api_key:') ? String(kind).slice(8) : '';
   if (!provider) return null;
+  const usable = vaultState.entries.filter(vaultEntryUsableHere);
   return (
-    vaultState.entries.find(e => e.kind === 'api_key' && e.provider === provider && e.secret && !e.voice) ||
-    vaultState.entries.find(e => e.kind === 'api_key' && e.provider === provider && e.secret) ||
+    usable.find(e => e.kind === 'api_key' && e.provider === provider && e.secret && !e.voice) ||
+    usable.find(e => e.kind === 'api_key' && e.provider === provider && e.secret) ||
     null
   );
 }
@@ -1758,10 +1783,21 @@ function vaultRenderEntries(card) {
     const kindChip = document.createElement('span');
     kindChip.className = 'vault-chip';
     kindChip.textContent = entry.kind === 'oauth' ? 'OAuth' : 'API key';
+    const trustedOnly = vaultEntryUnsealPolicy(entry) === 'trusted';
+    const usableHere = vaultEntryUsableHere(entry);
+    let policyChip = null;
+    if (trustedOnly) {
+      policyChip = document.createElement('span');
+      policyChip.className = usableHere ? 'vault-chip' : 'vault-chip warn';
+      policyChip.textContent = usableHere ? 'trusted origins' : 'sealed here';
+      policyChip.title = usableHere
+        ? 'This credential only works from trusted origins (direct or app) — hosted tabs cannot reveal, fuel, or relay it.'
+        : 'This credential is marked trusted-origins-only and this dashboard arrived through a hosted tab: it stays sealed here — no reveal, fueling, or relay. It still syncs with the vault.';
+    }
     const secret = document.createElement('span');
     secret.className = 'secret';
     const secretValue = String(entry.secret || '');
-    secret.textContent = vaultRevealedEntries.has(entry.id)
+    secret.textContent = usableHere && vaultRevealedEntries.has(entry.id)
       ? secretValue || '(token set)'
       : secretValue
         ? `••••${secretValue.slice(-4)}`
@@ -1769,26 +1805,37 @@ function vaultRenderEntries(card) {
     const actions = document.createElement('span');
     actions.className = 'vault-entry-actions';
     if (secretValue) {
-      actions.appendChild(
-        vaultButton(vaultRevealedEntries.has(entry.id) ? 'Hide' : 'Reveal', () => {
-          if (vaultRevealedEntries.has(entry.id)) vaultRevealedEntries.delete(entry.id);
-          else vaultRevealedEntries.add(entry.id);
-          renderAccessVaultSection();
-        })
-      );
-      actions.appendChild(
-        vaultButton('Copy', () => {
-          navigator.clipboard?.writeText(secretValue).catch(() => {});
-        })
-      );
+      const reveal = vaultButton(usableHere && vaultRevealedEntries.has(entry.id) ? 'Hide' : 'Reveal', () => {
+        if (vaultRevealedEntries.has(entry.id)) vaultRevealedEntries.delete(entry.id);
+        else vaultRevealedEntries.add(entry.id);
+        renderAccessVaultSection();
+      });
+      const copy = vaultButton('Copy', () => {
+        navigator.clipboard?.writeText(secretValue).catch(() => {});
+      });
+      if (!usableHere) {
+        reveal.disabled = true;
+        copy.disabled = true;
+        reveal.title = copy.title = 'Sealed in hosted tabs — this entry is marked trusted-origins-only.';
+      }
+      actions.append(reveal, copy);
     }
+    const policyBtn = vaultButton(trustedOnly ? 'Allow anywhere' : 'Trusted only', () => {
+      vaultUpsertEntry({ id: entry.id, unseal_policy: trustedOnly ? 'any' : 'trusted' });
+      renderAccessVaultSection();
+    });
+    policyBtn.title = trustedOnly
+      ? 'Let every dashboard this vault opens in use this credential again.'
+      : 'Seal this credential against hosted tabs: only direct or app origins may reveal, fuel, or relay it. (Client-side policy — it guards against mistakes, not a malicious page.)';
+    actions.appendChild(policyBtn);
     actions.appendChild(
       vaultButton('Remove', () => {
         vaultRemoveEntry(entry.id);
         renderAccessVaultSection();
       }, { danger: true })
     );
-    row.append(lbl, chip, kindChip, secret, actions);
+    if (policyChip) row.append(lbl, chip, kindChip, policyChip, secret, actions);
+    else row.append(lbl, chip, kindChip, secret, actions);
     list.appendChild(row);
   }
   card.appendChild(list);
@@ -1853,7 +1900,20 @@ function vaultRenderAddForm(card) {
     secretInput.style.display = oauth ? 'none' : '';
     secretArea.style.display = oauth ? '' : 'none';
   });
-  grid.append(kindLabel, kindSelect, providerLabel, providerSelect, labelLabel, labelInput, secretLabel, secretInput);
+  const policyLabel = document.createElement('label');
+  policyLabel.textContent = 'Unseal where?';
+  const policySelect = document.createElement('select');
+  for (const [value, label, title] of [
+    ['any', 'Anywhere this vault opens', 'The default: usable from every dashboard that can open your vault.'],
+    ['trusted', 'Trusted origins only (direct / app)', 'Sealed against hosted tabs: no reveal, fueling, or relay from them. Client-side policy — a guard against mistakes, not a malicious page. Today the vault itself opens through Connect, so a trusted-only entry stays stored-but-sealed until the direct/app vault path lands.'],
+  ]) {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = label;
+    option.title = title;
+    policySelect.appendChild(option);
+  }
+  grid.append(kindLabel, kindSelect, providerLabel, providerSelect, labelLabel, labelInput, policyLabel, policySelect, secretLabel, secretInput);
   body.appendChild(grid);
   body.appendChild(secretArea);
 
@@ -1880,6 +1940,7 @@ function vaultRenderAddForm(card) {
         label: labelInput.value.trim() ||
           (oauth ? vaultProviderLabel(providerSelect.value) : `${vaultProviderLabel(providerSelect.value)} key`),
         secret: secretValue,
+        ...(policySelect.value === 'trusted' ? { unseal_policy: 'trusted' } : {}),
       });
       secretInput.value = '';
       secretArea.value = '';
@@ -2001,6 +2062,15 @@ function vaultRenderFueling(card) {
   const fuelable = vaultState.entries
     .map(entry => ({ entry, kind: vaultEntryLeaseKind(entry) }))
     .filter(item => item.kind);
+  // No silent caps: say when entries exist but are sealed against this
+  // context, instead of quietly rendering fewer fuel buttons.
+  const sealed = vaultState.entries.filter(e => e.secret && !vaultEntryUsableHere(e)).length;
+  if (sealed > 0) {
+    const note = document.createElement('div');
+    note.className = 'vault-note';
+    note.textContent = `${sealed === 1 ? '1 credential is' : `${sealed} credentials are`} marked trusted-origins-only and stay${sealed === 1 ? 's' : ''} sealed in hosted tabs — no fueling from here.`;
+    card.appendChild(note);
+  }
   const fuelRow = document.createElement('div');
   fuelRow.className = 'vault-actions';
   for (const { entry, kind } of fuelable) {

--- a/static/app/42-usage-terminal.js
+++ b/static/app/42-usage-terminal.js
@@ -763,6 +763,46 @@ async function accessConnectSetEnabled(enabled, rendezvousUrl) {
   renderAccessAdminSummaries();
 }
 
+async function accessSetTier(tier) {
+  const payload = { tier: tier || null };
+  try {
+    const resp = await dashboardJsonFetch('api_access_set_tier', payload, () => authedFetch('/api/access/tier', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }), 'api_access_set_tier', { fallbackAfterRpcFailure: false });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
+    showControlToast?.('success', tier
+      ? `Trust tier set: ${tier}`
+      : 'Trust tier cleared');
+  } catch (err) {
+    showControlToast?.('error', err?.message || 'Trust tier change failed');
+  }
+  await refreshAccessOverviewFromApi().catch(() => null);
+  renderAccessAdminSummaries();
+}
+
+async function accessSetHostedCeiling(roleId) {
+  const payload = { role_id: roleId };
+  try {
+    const resp = await dashboardJsonFetch('api_access_set_hosted_ceiling', payload, () => authedFetch('/api/access/hosted-ceiling', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }), 'api_access_set_hosted_ceiling', { fallbackAfterRpcFailure: false });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
+    showControlToast?.('success', roleId === 'role:none'
+      ? 'Hosted-origin control refused. Reach this daemon directly, through the app, or from an enrolled peer — a hosted tab can no longer change this back.'
+      : `Hosted control ceiling set to ${roleId.replace(/^role:/, '')}`);
+  } catch (err) {
+    showControlToast?.('error', err?.message || 'Hosted ceiling change failed');
+  }
+  await refreshAccessOverviewFromApi().catch(() => null);
+  renderAccessAdminSummaries();
+}
+
 async function accessConnectUnclaim() {
   try {
     const resp = await dashboardJsonFetch('api_access_connect_unclaim', {}, () => authedFetch('/api/access/connect/unclaim', {
@@ -1501,6 +1541,13 @@ function accessFallbackIamRoles() {
     status: 'enforced',
     summary: 'Daemon-to-daemon grants enforced by the approved peer identity profile.',
     permissions: ['presence.read', 'stats.read', 'display.view', 'display.input', 'message.send', 'task.run', 'approval.resolve', 'access.inspect', 'peer.inspect', 'peer.manage', 'session.inspect', 'session.manage', 'terminal.view', 'terminal.write', 'shell.spawn', 'settings.manage', 'runtime.control', 'filesystem.read', 'filesystem.write'],
+    source: 'builtin',
+  }, {
+    id: 'role:none',
+    label: 'No access',
+    status: 'enforced',
+    summary: 'Ceiling-only sentinel with no permissions: used in role_ceilings to refuse a binding kind (e.g. hosted-origin control) entirely. Never assigned to a principal.',
+    permissions: [],
     source: 'builtin',
   }, {
     id: 'role:scoped-human',
@@ -2333,7 +2380,7 @@ function accessSyncUserClientGrantFields(form) {
       && selectedRoleObj.permissions.some(perm => !ceilingRole.permissions.includes(perm)));
     note.style.display = exceeds ? '' : 'none';
     if (exceeds) {
-      note.textContent = `Hosted-route sessions for this account are capped at ${ceiling.replace(/^role:/, '')} by this daemon's role ceiling — the grant saves as ${selectedRole.replace(/^role:/, '')}, but Connect sessions won't exceed the ceiling. Raise or clear role_ceilings in iam.json to change this.`;
+      note.textContent = `Hosted-route sessions for this account are capped at ${ceiling.replace(/^role:/, '')} by this daemon's role ceiling — the grant saves as ${selectedRole.replace(/^role:/, '')}, but Connect sessions won't exceed the ceiling. The "Hosted tabs may" control on the Overview tab moves it.`;
     }
   }
 }
@@ -2346,6 +2393,8 @@ function accessAssignableIamRoles(overview = accessOverviewModel()) {
     const status = accessModelLabel(role?.status, 'enforced');
     if (!id || status === 'planned') return false;
     if (id === 'role:peer-profile') return false;
+    // role:none is the ceiling-only sentinel; it is never granted.
+    if (id === 'role:none') return false;
     return true;
   });
   if (filtered.length) return filtered;

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -14,7 +14,33 @@ const ACCESS_ROLE_META = {
   'role:observer': { cls: 'role-observer', short: 'Watch read-only, including live displays.' },
   'role:scoped-human': { cls: 'role-scoped', short: 'Inspect the access model only. A safe first grant.' },
   'role:peer-profile': { cls: 'role-peer', short: 'Daemon-to-daemon authority bounded by the peer profile.' },
+  'role:none': { cls: 'role-scoped', short: 'No permissions at all. Ceiling-only: used to refuse hosted-origin control entirely, never granted to anyone.' },
 };
+
+/* Trust tiers (docs/src/trust-tiers.md). The id vocabulary mirrors the
+   daemon's DAEMON_TIERS constant and is pinned by the
+   dashboard_tier_vocabulary_mirrors_daemon_tiers parity test — change
+   both together. */
+const ACCESS_TIER_META = {
+  'integrated': {
+    label: 'Integrated',
+    glyph: '⌂',
+    short: 'Holds your personal world — accounts, files, mail. Protect it: control it directly or through the app, and grant conservatively.',
+  },
+  'disposable': {
+    label: 'Disposable',
+    glyph: '♻',
+    short: 'Scratch box holding nothing durable. Worst case: rotate a key and destroy it. Hosted tabs are fine here.',
+  },
+};
+
+/* The curated hosted-ceiling positions, strongest last. Every id must
+   name a builtin role (pinned by the role-catalog parity test). */
+const ACCESS_HOSTED_CEILING_CHOICES = [
+  { id: 'role:operator', label: 'Operate (default)', short: 'Hosted tabs can drive sessions, terminal, files, and fuel credentials — the right setting for disposable boxes.' },
+  { id: 'role:observer', label: 'View only', short: 'Hosted tabs can watch displays and sessions but change nothing. Vault fueling from hosted tabs stops working on this daemon.' },
+  { id: 'role:none', label: 'Nothing', short: 'This daemon refuses hosted-origin control entirely — reach it directly, through the app, or from an enrolled peer.' },
+];
 
 function accessRoleMeta(roleId) {
   const id = accessModelLabel(roleId);
@@ -731,6 +757,151 @@ function renderAccessPeopleCurrent() {
   }));
 }
 
+/* Overview: Trust tier — what this machine holds, and how tightly hosted
+   tabs are capped on it (docs/src/trust-tiers.md). The tier is a doctrine
+   label (it grants and denies nothing); the ceiling row below it is the
+   enforcement, kept visually coupled so choosing "Integrated" naturally
+   leads to hardening hosted control. */
+function accessHostedCeilingCurrent(iam) {
+  const ceilings = iam.role_ceilings && typeof iam.role_ceilings === 'object' ? iam.role_ceilings : {};
+  const account = accessModelLabel(ceilings['connect_account']);
+  const key = accessModelLabel(ceilings['client_key']);
+  if (!account && !key) return { value: '', state: 'uncapped' };
+  if (account !== key) return { value: '', state: 'mixed' };
+  return { value: account, state: ACCESS_HOSTED_CEILING_CHOICES.some(c => c.id === account) ? 'choice' : 'custom' };
+}
+
+function renderAccessTierCard() {
+  const mount = document.getElementById('access-tier-card');
+  if (!mount) return;
+  const iam = accessIamModel(accessOverviewModel());
+  const tier = accessModelLabel(iam.tier);
+  const canSetTier = dashboardControlTransport?.lastStatus?.api_access_set_tier_available !== false;
+  const canSetCeiling = dashboardControlTransport?.lastStatus?.api_access_set_hosted_ceiling_available !== false;
+
+  mount.textContent = '';
+  const head = document.createElement('div');
+  head.className = 'acc-section-head';
+  const title = document.createElement('div');
+  title.className = 'acc-section-title';
+  title.textContent = 'Trust tier';
+  const sub = document.createElement('div');
+  sub.className = 'acc-section-sub';
+  sub.textContent = 'What would a compromise of this machine cost you? The tier is a label that guides grants and clients — the enforcement lives in the hosted-control cap below it.';
+  head.append(title, sub);
+  mount.appendChild(head);
+
+  const card = document.createElement('div');
+  card.className = 'acc-principal-card';
+
+  const headRow = document.createElement('div');
+  headRow.className = 'acc-principal-head';
+  const glyphEl = document.createElement('div');
+  glyphEl.className = 'acc-principal-glyph kind-local';
+  glyphEl.textContent = tier ? (ACCESS_TIER_META[tier]?.glyph || 'T') : '?';
+  const nameWrap = document.createElement('div');
+  const name = document.createElement('div');
+  name.className = 'acc-principal-name';
+  name.textContent = tier
+    ? `${ACCESS_TIER_META[tier]?.label || tier} machine`
+    : 'What does this machine hold?';
+  const kindLine = document.createElement('div');
+  kindLine.className = 'acc-principal-kind';
+  kindLine.textContent = tier
+    ? (ACCESS_TIER_META[tier]?.short || '')
+    : 'Pick a tier so grant flows and clients can hold you to it.';
+  nameWrap.append(name, kindLine);
+  headRow.append(glyphEl, nameWrap);
+  if (!tier) {
+    headRow.appendChild(accessRouteChip('remembered', 'not set',
+      'No tier chosen yet. The tier changes no permissions by itself — it drives warnings, recommendations, and (via the cap below) hosted-control policy.'));
+  }
+  card.appendChild(headRow);
+
+  // The two tier options, side by side, current one highlighted.
+  const options = document.createElement('div');
+  options.className = 'acc-grant-flow-actions acc-tier-options';
+  for (const [id, meta] of Object.entries(ACCESS_TIER_META)) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'acc-btn' + (tier === id ? ' primary' : '');
+    btn.textContent = `${meta.glyph} ${meta.label}`;
+    btn.title = meta.short + (tier === id ? ' (current — click again to clear)' : '');
+    btn.disabled = !canSetTier;
+    btn.addEventListener('click', () => accessSetTier(tier === id ? null : id));
+    options.appendChild(btn);
+  }
+  card.appendChild(options);
+
+  // Hosted-control cap: the enforcement row.
+  const ceiling = accessHostedCeilingCurrent(iam);
+  const capRow = document.createElement('div');
+  capRow.className = 'acc-grant-flow-actions acc-tier-cap-row';
+  const capLabel = document.createElement('span');
+  capLabel.className = 'acc-principal-kind';
+  capLabel.textContent = 'Hosted tabs may:';
+  capLabel.title = 'Applies to sessions arriving with hosted provenance — Connect accounts and browser keys enrolled from a hosted origin. Direct, app, and anchor-served sessions are never capped by this.';
+  capRow.appendChild(capLabel);
+  const select = document.createElement('select');
+  select.className = 'acc-btn';
+  select.disabled = !canSetCeiling;
+  for (const choice of ACCESS_HOSTED_CEILING_CHOICES) {
+    const opt = document.createElement('option');
+    opt.value = choice.id;
+    opt.textContent = choice.label;
+    opt.title = choice.short;
+    select.appendChild(opt);
+  }
+  if (ceiling.state === 'choice') {
+    select.value = ceiling.value;
+  } else {
+    const opt = document.createElement('option');
+    opt.value = '';
+    opt.disabled = true;
+    opt.selected = true;
+    opt.textContent = ceiling.state === 'mixed'
+      ? 'custom (per-binding, via iam.json)'
+      : ceiling.state === 'custom'
+        ? `custom (${ceiling.value.replace(/^role:/, '')})`
+        : 'uncapped (via iam.json)';
+    select.appendChild(opt);
+  }
+  select.addEventListener('change', () => {
+    if (select.value) accessSetHostedCeiling(select.value);
+  });
+  capRow.appendChild(select);
+  card.appendChild(capRow);
+
+  const hint = document.createElement('div');
+  hint.className = 'acc-principal-kind';
+  const currentChoice = ACCESS_HOSTED_CEILING_CHOICES.find(c => c.id === ceiling.value);
+  hint.textContent = ceiling.state === 'choice'
+    ? (currentChoice?.short || '')
+    : ceiling.state === 'uncapped'
+      ? 'Ceilings are disabled in iam.json — hosted sessions can hold whatever their grant says, including root. Choose a cap here to restore them.'
+      : 'This daemon carries a hand-tuned ceiling in iam.json; picking an option here overwrites it for both hosted bindings.';
+  card.appendChild(hint);
+
+  // The doctrine nudge: an integrated machine still operable from any
+  // hosted tab is the mismatch the tiers chapter warns about.
+  if (tier === 'integrated' && ceiling.value === 'role:operator') {
+    const nudge = document.createElement('div');
+    nudge.className = 'acc-connect-warn';
+    const text = document.createElement('span');
+    text.textContent = 'Integrated machine, yet hosted tabs can still operate it. Recommended: cap them to View only (or Nothing) and drive this daemon directly or through the app. ';
+    const harden = document.createElement('button');
+    harden.type = 'button';
+    harden.className = 'acc-btn';
+    harden.textContent = 'Cap to View only';
+    harden.disabled = !canSetCeiling;
+    harden.addEventListener('click', () => accessSetHostedCeiling('role:observer'));
+    nudge.append(text, harden);
+    card.appendChild(nudge);
+  }
+
+  mount.appendChild(card);
+}
+
 /* Overview: Intendant Connect — this daemon's hosted reachability and
    claim binding. States: off → one-click enable; registering; unclaimed
    → reveal the twelve words (manage-gated, fetched only on click);
@@ -994,6 +1165,10 @@ function renderAccessEnrollmentRequests() {
     headRow.append(glyphEl, nameWrap);
     if (request.origin) {
       headRow.appendChild(accessRouteChip('connect', 'via hosted route', `The offer arrived through ${request.origin}; the key will be recorded with that origin, so the role ceiling applies until it is re-enrolled from an anchor origin.`));
+      if (accessModelLabel(accessIamModel(accessOverviewModel()).tier) === 'integrated') {
+        headRow.appendChild(accessRouteChip('danger', 'integrated tier',
+          'This is an integrated-tier machine and the key arrived through a hosted route. Approving is an upward grant (docs: trust-tiers) — the hosted-control cap still bounds the session, but prefer enrolling this device from a direct or app origin.'));
+      }
     }
     if (request.account_hint) {
       headRow.appendChild(request.account_attested
@@ -2050,6 +2225,7 @@ function renderAccessAdminSummaries() {
   }
   renderAccessAttention();
   renderAccessIdentityHero();
+  renderAccessTierCard();
   renderAccessConnectCard();
   renderAccessFleetStrip();
   renderAccessExplainer();

--- a/static/app/52-peer-display.js
+++ b/static/app/52-peer-display.js
@@ -2008,6 +2008,12 @@ function renderPeerAccessRequests(requests) {
     return;
   }
 
+  // Upward-grant guard (docs/src/trust-tiers.md): approving a peer here
+  // grants that daemon authority ON this machine. On an integrated-tier
+  // machine that is the alarm condition — advisory, never a refusal.
+  const integratedTier = (typeof accessIamModel === 'function' && typeof accessOverviewModel === 'function')
+    && String(accessIamModel(accessOverviewModel())?.tier || '') === 'integrated';
+
   list.innerHTML = requests.map(req => {
     const requestId = String(req.request_id || '');
     const label = escapeHtml(req.requester_label || 'Unnamed daemon');
@@ -2030,6 +2036,7 @@ function renderPeerAccessRequests(requests) {
         </div>
         <div class="daemon-access-request-meta">Status ${escapeHtml(status)} - ${roleLabel} ${escapeHtml(role.label)}</div>
         <div class="daemon-access-request-meta daemon-role-summary">${escapeHtml(role.summary)}</div>
+        ${pending && integratedTier ? '<div class="daemon-access-request-meta daemon-access-request-warn" title="Grants flow toward disposable machines, never up. If that daemon is lower-trust than this one, approving bridges your tiers — see the Trust tier card in Access.">⚠ Integrated-tier machine: approving grants a peer daemon authority here. Make sure trust flows downward.</div>' : ''}
         ${timing ? `<div class="daemon-access-request-meta">${timing}</div>` : ''}
         ${pending ? `<div class="daemon-pairing-row"><select data-access-request-profile="${escapeHtml(requestId)}">${renderPeerProfileOptions(requestedProfile)}</select></div>` : ''}
         <div class="daemon-access-request-actions">


### PR DESCRIPTION
Implements all three product hooks from the trust-tiers doctrine chapter (`docs/src/trust-tiers.md`, PR #109), so the product carries the doctrine instead of the owner's memory.

## Hook 1 — tier labels + upward-grant guard
- `iam.json` gains a validated, audit-logged `tier` (`integrated`/`disposable`), settable from the new **Trust tier card** at the top of Access → Overview (`POST /api/access/tier` + `api_access_set_tier`, manage-gated, fleet-CORS).
- Advisory guard where upward grants actually happen: the peer pairing-approval card warns on integrated-tier machines (approving grants a peer authority *here*), and hosted-route device enrollments get an integrated-tier chip beside the existing hosted-route chip.
- Deliberately deferred: cross-daemon tier visibility (fleet-record v4 vs agent-card carrier decision) — not needed for the local alarm.

## Hook 2 — per-daemon hosted-ceiling knob
- "Hosted tabs may: **Operate / View only / Nothing**" on the same card writes both hosted-provenance `role_ceilings` bindings at once (`POST /api/access/hosted-ceiling` + `api_access_set_hosted_ceiling`).
- New zero-permission, ceiling-only builtin `role:none` (refuse-entirely position; never grantable — guarded like `role:peer-profile`).
- Integrated tier + hosted-operable surfaces a one-click "Cap to View only" nudge; custom/mixed/uncapped iam.json states render honestly instead of being clobbered silently.

## Hook 3 — per-entry vault unseal policy + custody origin
- Vault entries accept `unseal_policy: "trusted"` (add-form choice + per-entry toggle): trusted-only entries refuse reveal/copy, lease fueling, egress relay, and the voice mirror from hosted tabs — single choke point in `vaultEntryLeaseKind`, with no-silent-caps notes where entries hide. Copy states the honest limits (client-side self-enforcement; stored-but-sealed until the direct/app vault path lands).
- The custody trail stamps every lease/relay ceremony with the session's origin class: `CustodyEvent.origin` (`hosted`/`direct`/`local`/`peer`), classified by `session_origin_class()` mirroring the ceiling's hosted test, threaded through grant/revoke/egress-register and rendered in the trail.

## Derive-don't-mirror
New parity gates pin `ACCESS_TIER_META` to `DAEMON_TIERS` (ids **and** order) and the ceiling knob's choices to builtin roles; the role-catalog mirrors gained `role:none` (picker-excluded). Route-table rows drive dispatch/IAM/docs as usual; the web-dashboard endpoint table and the trust-tiers/trust-architecture/credential-custody/configuration chapters are updated in step.

Battery: 2682 unit tests green (both bins), clippy clean, app.html regenerated from fragments.