### PR TITLE
Local vault: daemon-stored blob backs direct dashboards

### DIFF
--- a/docs/src/credential-custody.md
+++ b/docs/src/credential-custody.md
@@ -70,10 +70,39 @@ hosted tabs — no reveal, no lease fueling, no egress relay, no voice
 mirror — while still syncing inside the encrypted body. This is
 client-side self-enforcement (a guard against mistakes and casual
 exfiltration, not against a malicious bundle — see
-[Trust Tiers](./trust-tiers.md)); and since today's vault only opens
-through a Connect service, a trusted-only entry stays stored-but-sealed
-until the direct/app vault path exists. The policy field is invisible
-to the service like every other entry field.
+[Trust Tiers](./trust-tiers.md)). On a **direct** dashboard backed by
+the daemon store (below), trusted-only entries work normally — that is
+the tier the policy reserves them for. The policy field is invisible
+to every store like any other entry field.
+
+**Storage backends.** The sealed blob has two possible homes, both
+blind to its contents, and the dashboard says which one backs it (the
+store chip on the vault card):
+
+- **Account store** (hosted tabs): the Connect service keeps one blob
+  per account — the vault follows the person across daemons. This is
+  the original path and remains the default wherever the dashboard
+  arrived through Connect.
+- **Daemon store** (direct dashboards): the daemon itself keeps the
+  blob at `~/.intendant/vault-blob.json` (0600), served over the
+  verified control channel (`api_daemon_vault_fetch` /
+  `api_daemon_vault_publish`, `credentials.manage`-gated). No Connect
+  service is in the loop: a direct dashboard creates, unseals, and
+  fuels from a vault that never leaves machines the owner controls.
+  The daemon-side rules replicate the hosted store's exactly
+  (`vault_store.rs` twin-tested against `bin/connect/fleet.rs`): shape
+  validation, the monotonic-revision rollback ratchet, same-revision
+  divergence conflicts, and the MAC-presence ratchet.
+
+The two stores are **independent** — each keeps its own revision
+ratchet, and nothing syncs implicitly between them. Moving a vault is
+an explicit action: a hosted tab with an unlocked vault offers **"Keep
+a sealed copy on this daemon"**, which publishes the encrypted blob to
+the tunneled daemon's store; the direct dashboard there then unseals it
+with the same recovery phrase, or with a passkey enrolled from that
+origin (passkeys are origin-scoped, so the first unseal on a new origin
+is phrase-first, then enroll the local passkey — the blob holds one
+envelope per unlocker).
 
 **Keying.** A random 256-bit vault master key `K` encrypts the vault
 body (AES-GCM). `K` itself is never stored — it is wrapped into one
@@ -144,6 +173,8 @@ raw frame names are reserved for the `egress_*` relay path):
 | `api_credential_lease_revoke` | browser → daemon request with optional `lease_id` / `leaseId` / `kind`; omitted revokes every lease on the daemon | `revoked` count |
 | `api_credential_lease_status` | browser → daemon request with no params | active `leases` (`lease_id`, `kind`, `label`, `mode`, grant/renew/expiry timestamps, `ttl_ms`, `offline_ms`, `use_count`), active `egress` relays, and `expired_note` |
 | `api_credential_custody_trail` | browser → daemon request with no params | recent custody events (`at_unix_ms`, `event`, `kind`, `label`, `actor`, `origin`, `detail`) from the daemon's own record — lease grants/expiries/revocations, relay changes, restart resets; metadata only, never material. `origin` stamps the session's origin class on ceremonies (`hosted` / `direct` / `local` / `peer`; empty on sessionless events and pre-field records). Kept at `~/.intendant/custody-audit.jsonl` (0600, bounded), rendered in Access → Advanced → Custody trail |
+| `api_daemon_vault_fetch` | browser → daemon request with no params | the daemon-stored sealed blob, if any: `revision`, `vault` (E2E ciphertext the daemon cannot read), `updated_unix_ms`; `revision: 0, vault: null` when empty |
+| `api_daemon_vault_publish` | browser → daemon request with `revision` and the full `vault` blob | `stored` (`false` = idempotent same-revision republish); rollback, same-revision divergence, and MAC-stripping are refused with a `vault revision conflict:`-prefixed error the dashboard treats like the hosted store's HTTP 409 |
 
 Leases ride the same per-frame IAM checks as every other tunnel
 operation; granting requires a session whose principal holds a new

--- a/docs/src/trust-tiers.md
+++ b/docs/src/trust-tiers.md
@@ -118,6 +118,17 @@ was built *for* boxes you do not trust. Apply it there and only there:
   non-technical user's consolation prize; it is *everyone's* correct client
   for the machines that matter.
 
+Getting a pleasant direct origin today: the fleet strip offers **↗
+direct** wherever a daemon's own URL is known, and the daemon-store vault
+([Credential Custody](./credential-custody.md#the-vault)) makes that tab
+self-sufficient. For a warning-free padlock, give the daemon a real
+certificate — a hostname you own with a DNS-01 Let's Encrypt cert, or
+`tailscale cert` on a tailnet — otherwise accept the browser's one-time
+exception for the self-signed cert and let the enrollment ceremony carry
+identity from there. A fleet-DNS service that mints per-daemon names and
+certificates automatically (the Tailscale pattern, operated by the
+rendezvous as pure plumbing) is the designed follow-on.
+
 A worked example, one fleet:
 
 | Daemon | Tier | Control origins | Custody | Peer grants |
@@ -162,7 +173,8 @@ the owner's memory. All three are **shipped**:
    lease/relay ceremony with the session's origin class
    (`hosted`/`direct`/`local`/`peer`). Honest limits, stated in the UI
    too: this is client-side self-enforcement — protection against
-   mistakes and casual exfiltration, not against a malicious bundle —
-   and until the direct/app vault path exists (the local-vault work),
-   a trusted-only entry is stored-but-sealed everywhere the vault
-   currently opens.
+   mistakes and casual exfiltration, not against a malicious bundle.
+   With the **local vault** shipped (the daemon-store backend in
+   [Credential Custody](./credential-custody.md#the-vault)), trusted-only
+   entries do real work: sealed against hosted tabs, fully usable from a
+   direct dashboard backed by the daemon's own store.

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -241,6 +241,7 @@ pub(crate) fn control_frame_response(
                                 "kind": event.kind,
                                 "label": event.label,
                                 "actor": event.actor,
+                                "origin": event.origin,
                                 "detail": event.detail,
                             })
                         })
@@ -251,6 +252,48 @@ pub(crate) fn control_frame_response(
                         "ok": true,
                         "result": { "events": events },
                     }))
+                }
+                "api_daemon_vault_fetch" => {
+                    // Blind storage: the blob is E2E ciphertext this daemon
+                    // can neither read nor forge (vault_store.rs).
+                    let result = match crate::vault_store::fetch() {
+                        Some((revision, vault, updated_unix_ms)) => serde_json::json!({
+                            "revision": revision,
+                            "vault": vault,
+                            "updated_unix_ms": updated_unix_ms,
+                        }),
+                        None => serde_json::json!({ "revision": 0, "vault": null }),
+                    };
+                    Some(serde_json::json!({
+                        "t": "response",
+                        "id": id,
+                        "ok": true,
+                        "result": result,
+                    }))
+                }
+                "api_daemon_vault_publish" => {
+                    let params_ref = params.as_ref();
+                    let revision = match params_ref
+                        .map(|p| optional_u64_param(p, &["revision"]))
+                        .unwrap_or(Ok(None))
+                    {
+                        Ok(value) => value.unwrap_or(0),
+                        Err(error) => return Some(dashboard_control_error_response(id, error)),
+                    };
+                    let vault = params_ref
+                        .and_then(|p| p.get("vault"))
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null);
+                    let now = chrono::Utc::now().timestamp_millis().max(0) as u64;
+                    Some(match crate::vault_store::publish(revision, vault, now) {
+                        Ok(stored) => serde_json::json!({
+                            "t": "response",
+                            "id": id,
+                            "ok": true,
+                            "result": { "stored": stored, "revision": revision },
+                        }),
+                        Err(error) => dashboard_control_error_response(id, error.message()),
+                    })
                 }
                 "api_credential_egress_register" => {
                     let kinds: Vec<String> = params

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -162,6 +162,13 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
     method("api_credential_lease_revoke", PeerOperation::CredentialsManage),
     method("api_credential_lease_status", PeerOperation::CredentialsManage),
     method("api_credential_custody_trail", PeerOperation::CredentialsManage),
+    // Daemon-local vault blob storage (the local-vault half of custody):
+    // blind E2E ciphertext the daemon can neither read nor forge, so a
+    // direct dashboard has a vault home without any Connect service in
+    // the loop. Same gate as leases — fetch included: envelope metadata
+    // and revision history are custody-sensitive.
+    method("api_daemon_vault_fetch", PeerOperation::CredentialsManage),
+    method("api_daemon_vault_publish", PeerOperation::CredentialsManage),
     method(
         "api_credential_egress_register",
         PeerOperation::CredentialsManage,

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -74,6 +74,7 @@ mod transcription;
 mod transfer_store;
 mod types;
 mod upload_store;
+mod vault_store;
 mod virtual_display;
 pub(crate) use intendant_platform::vision;
 mod web_gateway;

--- a/src/bin/caller/vault_store.rs
+++ b/src/bin/caller/vault_store.rs
@@ -1,0 +1,354 @@
+//! Daemon-local vault blob storage — the local-vault half of credential
+//! custody (docs/src/credential-custody.md; docs/src/trust-tiers.md).
+//!
+//! The browser's credential vault is one end-to-end encrypted blob. The
+//! hosted Connect service stores it per account; this module gives a
+//! daemon the same blind storage so a **direct** dashboard (no Connect
+//! service in the loop) has a vault home: the blob lives at
+//! `~/.intendant/vault-blob.json` (0600), the daemon can neither read
+//! nor forge it, and the browser seals/unseals exactly as it does
+//! against the hosted store.
+//!
+//! The validation and ratchet semantics deliberately REPLICATE
+//! `bin/connect/fleet.rs` (`validate_vault_blob` / `apply_vault_publish`)
+//! — the two binaries never link each other, so the rules are duplicated
+//! and pinned by mirrored unit tests in both files, the same pattern as
+//! the claim-proof golden payloads. Change them together:
+//! - shape: ≤128 KiB, `v == 1`, `kind == "intendant-vault"`, positive
+//!   revision matching the blob, non-empty `envelopes`, object `body`,
+//!   plausible `mac` when present;
+//! - rollback ratchet: an older revision — or the same revision with
+//!   different content — is a conflict, never a silent overwrite;
+//! - MAC-presence ratchet: once the stored blob carries a client-side
+//!   integrity MAC, a MAC-less replacement is refused.
+
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+pub const MAX_VAULT_BLOB_BYTES: usize = 128 * 1024;
+
+/// Publish errors the dashboard distinguishes: a `Conflict` tells the
+/// losing client to refetch, merge, and bump; everything else is a plain
+/// failure. Over the control channel the conflict travels as an error
+/// string prefixed `vault revision conflict:` (pinned by test — the
+/// dashboard matches on it the way it matches HTTP 409 from the hosted
+/// store).
+#[derive(Debug, PartialEq)]
+pub enum VaultPublishError {
+    Conflict(String),
+    Invalid(String),
+    Io(String),
+}
+
+impl VaultPublishError {
+    pub fn message(&self) -> String {
+        match self {
+            Self::Conflict(msg) => format!("vault revision conflict: {msg}"),
+            Self::Invalid(msg) | Self::Io(msg) => msg.clone(),
+        }
+    }
+}
+
+fn blob_path() -> PathBuf {
+    // NOTE: `intendant_home()`'s cfg(test) scratch default does NOT apply
+    // in this bin's test build (cfg(test) does not cross crates — see
+    // state_paths.rs). Tests therefore go through the `_in` variants with
+    // explicit scratch paths and must never call the bare entry points.
+    crate::platform::intendant_home().join("vault-blob.json")
+}
+
+/// One store-wide lock: publishes are read-check-write and rare.
+fn store_lock() -> &'static Mutex<()> {
+    static LOCK: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct StoredVault {
+    revision: u64,
+    vault: serde_json::Value,
+    updated_unix_ms: u64,
+}
+
+fn read_stored(path: &std::path::Path) -> Option<StoredVault> {
+    let text = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+fn write_stored(path: &std::path::Path, record: &StoredVault) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    {
+        let mut file = std::fs::File::create(&tmp).map_err(|e| format!("write vault blob: {e}"))?;
+        file.write_all(
+            serde_json::to_string(record)
+                .map_err(|e| format!("serialize vault blob: {e}"))?
+                .as_bytes(),
+        )
+        .map_err(|e| format!("write vault blob: {e}"))?;
+    }
+    restrict_file(&tmp);
+    std::fs::rename(&tmp, &path).map_err(|e| format!("finalize vault blob: {e}"))
+}
+
+/// Same private-permissions convention as the custody trail (0600 on
+/// Unix; Windows relies on the profile ACL).
+fn restrict_file(path: &std::path::Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(metadata) = std::fs::metadata(path) {
+            let mut perms = metadata.permissions();
+            perms.set_mode(0o600);
+            let _ = std::fs::set_permissions(path, perms);
+        }
+    }
+}
+
+/// Shape checks replicated from the hosted store. The daemon is blind to
+/// everything inside `body` and cannot verify `mac` — by design.
+pub fn validate_vault_blob(revision: u64, vault: &serde_json::Value) -> Result<(), String> {
+    if serde_json::to_string(vault)
+        .map(|s| s.len())
+        .unwrap_or(usize::MAX)
+        > MAX_VAULT_BLOB_BYTES
+    {
+        return Err("vault blob is too large".to_string());
+    }
+    if vault.get("v").and_then(|v| v.as_u64()) != Some(1)
+        || vault.get("kind").and_then(|v| v.as_str()) != Some("intendant-vault")
+    {
+        return Err("not an intendant vault blob".to_string());
+    }
+    if revision == 0 {
+        return Err("vault revision must be positive".to_string());
+    }
+    if vault.get("revision").and_then(|v| v.as_u64()) != Some(revision) {
+        return Err("vault revision does not match blob".to_string());
+    }
+    let has_envelopes = vault
+        .get("envelopes")
+        .and_then(|v| v.as_array())
+        .map(|a| !a.is_empty())
+        .unwrap_or(false);
+    if !has_envelopes {
+        return Err("vault blob has no key envelopes".to_string());
+    }
+    if !vault.get("body").map(|b| b.is_object()).unwrap_or(false) {
+        return Err("vault blob has no body".to_string());
+    }
+    if let Some(mac) = vault.get("mac") {
+        let plausible = mac
+            .as_str()
+            .map(|s| !s.is_empty() && s.len() <= 88)
+            .unwrap_or(false);
+        if !plausible {
+            return Err("vault mac is malformed".to_string());
+        }
+    }
+    Ok(())
+}
+
+/// The stored blob, if any: `(revision, vault, updated_unix_ms)`.
+pub fn fetch() -> Option<(u64, serde_json::Value, u64)> {
+    fetch_in(&blob_path())
+}
+
+fn fetch_in(path: &std::path::Path) -> Option<(u64, serde_json::Value, u64)> {
+    let _guard = store_lock().lock().expect("vault store lock poisoned");
+    read_stored(path).map(|record| (record.revision, record.vault, record.updated_unix_ms))
+}
+
+/// Store the blob if it is newer than what this daemon holds. Returns
+/// `true` when stored, `false` for an idempotent same-revision republish
+/// of identical content. Rollback — and a same-revision write with
+/// different content — is a conflict so the losing client refetches,
+/// merges, and bumps.
+pub fn publish(
+    revision: u64,
+    vault: serde_json::Value,
+    now_unix_ms: u64,
+) -> Result<bool, VaultPublishError> {
+    publish_in(&blob_path(), revision, vault, now_unix_ms)
+}
+
+fn publish_in(
+    path: &std::path::Path,
+    revision: u64,
+    vault: serde_json::Value,
+    now_unix_ms: u64,
+) -> Result<bool, VaultPublishError> {
+    validate_vault_blob(revision, &vault).map_err(VaultPublishError::Invalid)?;
+    let _guard = store_lock().lock().expect("vault store lock poisoned");
+    if let Some(existing) = read_stored(path) {
+        if existing.vault.get("mac").is_some() && vault.get("mac").is_none() {
+            return Err(VaultPublishError::Conflict(
+                "unauthenticated vault refused: the stored vault carries an integrity MAC \
+                 (update this dashboard to one that signs vault blobs)"
+                    .to_string(),
+            ));
+        }
+        if revision < existing.revision
+            || (revision == existing.revision && existing.vault != vault)
+        {
+            return Err(VaultPublishError::Conflict(format!(
+                "stale vault: revision {revision} conflicts with stored revision {}",
+                existing.revision
+            )));
+        }
+        if revision == existing.revision {
+            return Ok(false);
+        }
+    }
+    write_stored(
+        path,
+        &StoredVault {
+            revision,
+            vault,
+            updated_unix_ms: now_unix_ms,
+        },
+    )
+    .map_err(VaultPublishError::Io)?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Per-test scratch blob path (unique dir per call, removed on drop) —
+    /// the explicit-path convention from state_paths.rs: this bin's test
+    /// build compiles intendant-core WITHOUT cfg(test), so the bare
+    /// `fetch()`/`publish()` would hit the developer's LIVE
+    /// `~/.intendant/vault-blob.json` (and nextest's process-per-test
+    /// would race it cross-process). Tests never call the bare entry
+    /// points.
+    struct ScratchBlob(PathBuf);
+
+    impl ScratchBlob {
+        fn new(tag: &str) -> Self {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            let dir = std::env::temp_dir().join(format!(
+                "intendant-vault-store-test-{tag}-{}-{nanos}",
+                std::process::id()
+            ));
+            Self(dir.join("vault-blob.json"))
+        }
+
+        fn path(&self) -> &std::path::Path {
+            &self.0
+        }
+    }
+
+    impl Drop for ScratchBlob {
+        fn drop(&mut self) {
+            if let Some(dir) = self.0.parent() {
+                let _ = std::fs::remove_dir_all(dir);
+            }
+        }
+    }
+
+    // Mirrors bin/connect/fleet.rs `vault_blob` — keep the twins in sync.
+    fn vault_blob(revision: u64, marker: &str) -> serde_json::Value {
+        json!({
+            "v": 1,
+            "kind": "intendant-vault",
+            "revision": revision,
+            "envelopes": [
+                { "kind": "prf", "id": "env-1", "iv": "aW4=", "wrapped": marker },
+            ],
+            "body": { "iv": "aW4=", "ct": marker },
+        })
+    }
+
+    fn vault_blob_with_mac(revision: u64, marker: &str, mac: &str) -> serde_json::Value {
+        let mut blob = vault_blob(revision, marker);
+        blob["mac"] = json!(mac);
+        blob
+    }
+
+    #[test]
+    fn publish_stores_bumps_and_is_idempotent() {
+        let blob = ScratchBlob::new("idempotent");
+        let path = blob.path();
+
+        assert!(publish_in(path, 1, vault_blob(1, "a"), 10).unwrap());
+        let (revision, _, updated) = fetch_in(path).unwrap();
+        assert_eq!((revision, updated), (1, 10));
+
+        // Identical same-revision republish is an idempotent no-op.
+        assert!(!publish_in(path, 1, vault_blob(1, "a"), 20).unwrap());
+        assert_eq!(fetch_in(path).unwrap().2, 10);
+
+        // A newer revision replaces the blob.
+        assert!(publish_in(path, 3, vault_blob(3, "b"), 30).unwrap());
+        let (revision, vault, updated) = fetch_in(path).unwrap();
+        assert_eq!((revision, updated), (3, 30));
+        assert_eq!(vault["body"]["ct"], "b");
+    }
+
+    #[test]
+    fn publish_refuses_rollback_and_same_revision_divergence() {
+        let blob = ScratchBlob::new("rollback");
+        let path = blob.path();
+
+        assert!(publish_in(path, 5, vault_blob(5, "a"), 10).unwrap());
+        assert!(matches!(
+            publish_in(path, 4, vault_blob(4, "b"), 20).unwrap_err(),
+            VaultPublishError::Conflict(_)
+        ));
+        // Same revision, different content: two devices bumped
+        // independently — the loser must refetch and merge.
+        let err = publish_in(path, 5, vault_blob(5, "b"), 20).unwrap_err();
+        assert!(matches!(err, VaultPublishError::Conflict(_)));
+        assert!(err.message().starts_with("vault revision conflict:"));
+        assert_eq!(fetch_in(path).unwrap().0, 5);
+    }
+
+    #[test]
+    fn publish_enforces_the_mac_presence_ratchet() {
+        let blob = ScratchBlob::new("mac-ratchet");
+        let path = blob.path();
+
+        // Legacy MAC-less vaults are accepted, and upgrading to an
+        // authenticated blob is a normal publish.
+        assert!(publish_in(path, 1, vault_blob(1, "a"), 10).unwrap());
+        assert!(publish_in(path, 2, vault_blob_with_mac(2, "b", "bWFj"), 20).unwrap());
+
+        // Once authenticated, a MAC-less replacement is refused even at a
+        // newer revision — the store must not strip the guarantee.
+        assert!(matches!(
+            publish_in(path, 3, vault_blob(3, "c"), 30).unwrap_err(),
+            VaultPublishError::Conflict(_)
+        ));
+        assert_eq!(fetch_in(path).unwrap().0, 2);
+
+        // Authenticated publishes keep flowing.
+        assert!(publish_in(path, 3, vault_blob_with_mac(3, "d", "bWFj"), 40).unwrap());
+    }
+
+    #[test]
+    fn validate_rejects_malformed_blobs() {
+        assert!(validate_vault_blob(1, &json!({"v": 2, "kind": "intendant-vault"})).is_err());
+        assert!(validate_vault_blob(1, &json!({"v": 1, "kind": "other"})).is_err());
+        assert!(validate_vault_blob(0, &vault_blob(0, "a")).is_err());
+        assert!(validate_vault_blob(2, &vault_blob(1, "a")).is_err());
+        let mut no_envelopes = vault_blob(1, "a");
+        no_envelopes["envelopes"] = json!([]);
+        assert!(validate_vault_blob(1, &no_envelopes).is_err());
+        let mut no_body = vault_blob(1, "a");
+        no_body["body"] = json!("nope");
+        assert!(validate_vault_blob(1, &no_body).is_err());
+        let mut bad_mac = vault_blob(1, "a");
+        bad_mac["mac"] = json!("");
+        assert!(validate_vault_blob(1, &bad_mac).is_err());
+        assert!(validate_vault_blob(1, &vault_blob_with_mac(1, "a", "bWFj")).is_ok());
+    }
+}

--- a/static/app.html
+++ b/static/app.html
@@ -1467,6 +1467,12 @@ body.access-page #tab-access {
   transition: border-color 0.15s ease, color 0.15s ease;
 }
 .acc-fleet-add:hover { border-color: var(--blue); color: var(--blue); }
+.acc-fleet-direct {
+  font-size: 10.5px;
+  padding: 2px 7px;
+  min-height: 0;
+  line-height: 1.4;
+}
 
 /* "How access works" explainer. */
 .acc-explainer, .ui-explainer {
@@ -25206,8 +25212,39 @@ let vaultCeremony = null;          // { phrase } while the create ceremony is on
 let vaultPublishChain = Promise.resolve(true);
 const vaultRevealedEntries = new Set();
 
+/* ── Vault storage backends ──
+   The blob has two possible homes, both blind to its contents:
+   - 'account': the Connect service stores one blob per account (hosted
+     tabs — the original path; follows the person across daemons).
+   - 'daemon': this daemon stores the blob itself (~/.intendant/
+     vault-blob.json via api_daemon_vault_fetch/publish) — the local
+     vault for direct dashboards, no Connect service in the loop.
+   The stores are independent (each keeps its own revision ratchet);
+   copying between them is an explicit user action, never implicit. */
+function vaultDaemonStoreReady() {
+  if (DASHBOARD_CONNECT_MODE) return false; // hosted tabs use the account store
+  try {
+    const status = window.intendantDashboardControl?.status?.();
+    if (!status?.connected || !status?.verifiedBinding?.ok) return false;
+    // An empty feature list means the hello_ack hasn't landed yet: fall
+    // through and let the RPCs answer (mirrors vaultLeaseTransportReady).
+    const features = status.controlFeatures;
+    if (Array.isArray(features) && features.length) {
+      return features.includes('api_daemon_vault_fetch');
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function vaultBackendKind() {
+  if (DASHBOARD_CONNECT_MODE) return 'account';
+  return vaultDaemonStoreReady() ? 'daemon' : null;
+}
+
 function vaultAvailable() {
-  return DASHBOARD_CONNECT_MODE && Boolean(crypto?.subtle);
+  return Boolean(crypto?.subtle) && vaultBackendKind() !== null;
 }
 
 /* ── Vault crypto ── */
@@ -25490,6 +25527,14 @@ function vaultWriteLocal() {
 }
 
 async function vaultServerFetch() {
+  if (vaultBackendKind() === 'daemon') {
+    const result = await vaultLeaseRpc('api_daemon_vault_fetch');
+    return {
+      authenticated: true,
+      revision: Number(result?.revision) || 0,
+      vault: result?.vault || null,
+    };
+  }
   const resp = await fetch(accessFleetHostedUrl('/api/vault'));
   if (resp.status === 401) return { authenticated: false };
   const body = await resp.json().catch(() => ({}));
@@ -25498,6 +25543,21 @@ async function vaultServerFetch() {
 }
 
 async function vaultServerPublish(blob) {
+  if (vaultBackendKind() === 'daemon') {
+    try {
+      return await vaultLeaseRpc('api_daemon_vault_publish', {
+        revision: blob.revision,
+        vault: blob,
+      });
+    } catch (err) {
+      // The daemon store's conflict travels as an error string; give it
+      // the same shape the hosted store's HTTP 409 gets.
+      if (/revision conflict|stale vault/i.test(String(err?.message || ''))) {
+        err.vaultConflict = true;
+      }
+      throw err;
+    }
+  }
   const headers = await accessFleetHostedHeaders();
   if (!headers) throw new Error('sign in to the hosted account first');
   const resp = await fetch(accessFleetHostedUrl('/api/vault'), {
@@ -26302,7 +26362,6 @@ async function vaultOauthAccessTokenMaterial(entry, kind) {
 }
 
 function vaultLeaseTransportReady() {
-  if (!DASHBOARD_CONNECT_MODE) return false;
   try {
     const status = window.intendantDashboardControl?.status?.();
     if (!status?.connected || !status?.verifiedBinding?.ok) return false;
@@ -26323,6 +26382,19 @@ function vaultLeaseTransportReady() {
 
 function vaultLeaseRpc(method, params = {}) {
   return window.intendantDashboardControl.request(method, params, { timeoutMs: 15000 });
+}
+
+/* Whether the tunneled daemon advertises local vault storage — strict
+   (feature must be listed) because this only gates an optional action. */
+function vaultTunnelDaemonVaultAvailable() {
+  try {
+    const status = window.intendantDashboardControl?.status?.();
+    if (!status?.connected || !status?.verifiedBinding?.ok) return false;
+    const features = status.controlFeatures;
+    return Array.isArray(features) && features.includes('api_daemon_vault_publish');
+  } catch {
+    return false;
+  }
 }
 
 /* The lease kind a vault entry fuels, or null when it cannot fuel.
@@ -27110,9 +27182,10 @@ function vaultRenderAddForm(card) {
 }
 
 /* Fueling panel: this daemon's active leases + a fuel button per
-   fuelable vault entry. Rendered only in connect mode. */
+   fuelable vault entry. Renders wherever a vault store is reachable —
+   hosted tabs (account vault) and direct dashboards (local vault). */
 function vaultRenderFueling(card) {
-  if (!DASHBOARD_CONNECT_MODE) return;
+  if (!vaultAvailable()) return;
   const head = document.createElement('div');
   head.className = 'vault-status-line';
   const title = document.createElement('span');
@@ -27419,9 +27492,11 @@ function renderAccessVaultSection() {
   switch (vaultState.status) {
     case 'unavailable':
       chip.textContent = 'unavailable';
-      statusText = DASHBOARD_CONNECT_MODE
+      statusText = !crypto?.subtle
         ? 'This browser lacks the WebCrypto features the vault needs.'
-        : 'The vault rides your hosted account — open this dashboard through Hosted Connect to use it.';
+        : DASHBOARD_CONNECT_MODE
+          ? 'The hosted vault store is unreachable right now.'
+          : 'No vault store reachable yet: this daemon predates local vault storage, this session lacks credentials.manage, or the control channel is still connecting (retries automatically). Hosted Connect dashboards use the account vault instead.';
       break;
     case 'signed-out':
       chip.textContent = 'signed out';
@@ -27445,8 +27520,27 @@ function renderAccessVaultSection() {
       chip.textContent = 'checking';
       statusText = 'Looking for your vault…';
   }
+  // Which store backs this vault — the one-glance answer to "where does
+  // this blob live?" (docs/src/credential-custody.md, storage backends).
+  const backend = vaultBackendKind();
+  if (backend && vaultState.status !== 'unavailable') {
+    const store = document.createElement('span');
+    store.className = 'vault-chip';
+    store.textContent = backend === 'daemon' ? 'stored on this daemon' : 'account store';
+    store.title = backend === 'daemon'
+      ? 'The sealed blob lives on this daemon (~/.intendant/vault-blob.json) — no Connect service in the loop. The daemon cannot read or forge it.'
+      : 'The sealed blob lives with your hosted account and follows you across daemons. The service cannot read or forge it.';
+    statusLine.appendChild(store);
+  }
   statusLine.append(chip, document.createTextNode(statusText));
   card.appendChild(statusLine);
+
+  // The backend can appear after boot (control channel connects, feature
+  // list lands): leave 'unavailable' as soon as a store is reachable.
+  if (vaultState.status === 'unavailable' && vaultAvailable()) {
+    vaultInitPromise = null;
+    vaultInit();
+  }
 
   if (vaultState.rollbackWarning) {
     const warning = document.createElement('div');
@@ -27459,6 +27553,36 @@ function renderAccessVaultSection() {
     error.className = 'vault-error';
     error.textContent = vaultState.lastError;
     card.appendChild(error);
+  }
+
+  // Hosted tab + unlocked vault + a daemon that has local vault storage:
+  // offer to keep a sealed copy there, so its direct dashboard has a
+  // vault home without any Connect service in the loop. Explicit and
+  // one-way — the two stores keep independent revision ratchets.
+  if (
+    vaultState.status === 'unlocked' &&
+    backend === 'account' &&
+    vaultState.blob &&
+    vaultTunnelDaemonVaultAvailable()
+  ) {
+    const copyRow = document.createElement('div');
+    copyRow.className = 'vault-actions';
+    const copyBtn = vaultButton('Keep a sealed copy on this daemon', async () => {
+      try {
+        const result = await vaultLeaseRpc('api_daemon_vault_publish', {
+          revision: vaultState.blob.revision,
+          vault: vaultState.blob,
+        });
+        showControlToast?.('success', result?.stored
+          ? `Sealed vault copy (revision ${vaultState.blob.revision}) stored on this daemon — its direct dashboard can now unseal it with your passkey or phrase.`
+          : 'This daemon already holds this exact vault revision.');
+      } catch (err) {
+        showControlToast?.('error', `Vault copy failed: ${err?.message || err}`);
+      }
+    });
+    copyBtn.title = 'Publishes the encrypted blob to this daemon (~/.intendant/vault-blob.json). The daemon cannot read it; a direct dashboard on that machine unseals it with the same passkey or recovery phrase. The copy does not auto-sync afterwards.';
+    copyRow.appendChild(copyBtn);
+    card.appendChild(copyRow);
   }
 
   if (vaultCeremony) {
@@ -52507,6 +52631,24 @@ function renderAccessFleetStrip() {
     }
     const provenanceChip = accessTargetProvenanceChip(target);
     if (provenanceChip) meta.appendChild(provenanceChip);
+    // The door to the direct path (docs/src/trust-tiers.md): when the
+    // record carries the daemon's own URL, offer it — a direct tab talks
+    // straight to that daemon (local vault, no Connect service in the
+    // loop). Self-signed daemons show the browser's certificate warning
+    // on first visit until a real cert or the enrollment ceremony.
+    const directUrl = String(target.url || descriptor.peer?.url || '').trim();
+    if (directUrl && !target.local && !descriptor.local && /^https?:\/\//.test(directUrl)) {
+      const direct = document.createElement('button');
+      direct.type = 'button';
+      direct.className = 'acc-btn acc-fleet-direct';
+      direct.textContent = '↗ direct';
+      direct.title = `Open ${directUrl} — this daemon's own dashboard, no rendezvous in the loop. Works when this browser can reach it (same LAN/VPN); a self-signed daemon shows a one-time certificate warning.`;
+      direct.addEventListener('click', event => {
+        event.stopPropagation();
+        window.open(directUrl, '_blank', 'noopener');
+      });
+      meta.appendChild(direct);
+    }
     card.append(top, meta);
     card.addEventListener('click', () => routeTo('access', 'daemons'));
     mount.appendChild(card);

--- a/static/app/11-styles-access-files.css
+++ b/static/app/11-styles-access-files.css
@@ -287,6 +287,12 @@
   transition: border-color 0.15s ease, color 0.15s ease;
 }
 .acc-fleet-add:hover { border-color: var(--blue); color: var(--blue); }
+.acc-fleet-direct {
+  font-size: 10.5px;
+  padding: 2px 7px;
+  min-height: 0;
+  line-height: 1.4;
+}
 
 /* "How access works" explainer. */
 .acc-explainer, .ui-explainer {

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -51,8 +51,39 @@ let vaultCeremony = null;          // { phrase } while the create ceremony is on
 let vaultPublishChain = Promise.resolve(true);
 const vaultRevealedEntries = new Set();
 
+/* ── Vault storage backends ──
+   The blob has two possible homes, both blind to its contents:
+   - 'account': the Connect service stores one blob per account (hosted
+     tabs — the original path; follows the person across daemons).
+   - 'daemon': this daemon stores the blob itself (~/.intendant/
+     vault-blob.json via api_daemon_vault_fetch/publish) — the local
+     vault for direct dashboards, no Connect service in the loop.
+   The stores are independent (each keeps its own revision ratchet);
+   copying between them is an explicit user action, never implicit. */
+function vaultDaemonStoreReady() {
+  if (DASHBOARD_CONNECT_MODE) return false; // hosted tabs use the account store
+  try {
+    const status = window.intendantDashboardControl?.status?.();
+    if (!status?.connected || !status?.verifiedBinding?.ok) return false;
+    // An empty feature list means the hello_ack hasn't landed yet: fall
+    // through and let the RPCs answer (mirrors vaultLeaseTransportReady).
+    const features = status.controlFeatures;
+    if (Array.isArray(features) && features.length) {
+      return features.includes('api_daemon_vault_fetch');
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function vaultBackendKind() {
+  if (DASHBOARD_CONNECT_MODE) return 'account';
+  return vaultDaemonStoreReady() ? 'daemon' : null;
+}
+
 function vaultAvailable() {
-  return DASHBOARD_CONNECT_MODE && Boolean(crypto?.subtle);
+  return Boolean(crypto?.subtle) && vaultBackendKind() !== null;
 }
 
 /* ── Vault crypto ── */
@@ -335,6 +366,14 @@ function vaultWriteLocal() {
 }
 
 async function vaultServerFetch() {
+  if (vaultBackendKind() === 'daemon') {
+    const result = await vaultLeaseRpc('api_daemon_vault_fetch');
+    return {
+      authenticated: true,
+      revision: Number(result?.revision) || 0,
+      vault: result?.vault || null,
+    };
+  }
   const resp = await fetch(accessFleetHostedUrl('/api/vault'));
   if (resp.status === 401) return { authenticated: false };
   const body = await resp.json().catch(() => ({}));
@@ -343,6 +382,21 @@ async function vaultServerFetch() {
 }
 
 async function vaultServerPublish(blob) {
+  if (vaultBackendKind() === 'daemon') {
+    try {
+      return await vaultLeaseRpc('api_daemon_vault_publish', {
+        revision: blob.revision,
+        vault: blob,
+      });
+    } catch (err) {
+      // The daemon store's conflict travels as an error string; give it
+      // the same shape the hosted store's HTTP 409 gets.
+      if (/revision conflict|stale vault/i.test(String(err?.message || ''))) {
+        err.vaultConflict = true;
+      }
+      throw err;
+    }
+  }
   const headers = await accessFleetHostedHeaders();
   if (!headers) throw new Error('sign in to the hosted account first');
   const resp = await fetch(accessFleetHostedUrl('/api/vault'), {
@@ -1147,7 +1201,6 @@ async function vaultOauthAccessTokenMaterial(entry, kind) {
 }
 
 function vaultLeaseTransportReady() {
-  if (!DASHBOARD_CONNECT_MODE) return false;
   try {
     const status = window.intendantDashboardControl?.status?.();
     if (!status?.connected || !status?.verifiedBinding?.ok) return false;
@@ -1168,6 +1221,19 @@ function vaultLeaseTransportReady() {
 
 function vaultLeaseRpc(method, params = {}) {
   return window.intendantDashboardControl.request(method, params, { timeoutMs: 15000 });
+}
+
+/* Whether the tunneled daemon advertises local vault storage — strict
+   (feature must be listed) because this only gates an optional action. */
+function vaultTunnelDaemonVaultAvailable() {
+  try {
+    const status = window.intendantDashboardControl?.status?.();
+    if (!status?.connected || !status?.verifiedBinding?.ok) return false;
+    const features = status.controlFeatures;
+    return Array.isArray(features) && features.includes('api_daemon_vault_publish');
+  } catch {
+    return false;
+  }
 }
 
 /* The lease kind a vault entry fuels, or null when it cannot fuel.
@@ -1955,9 +2021,10 @@ function vaultRenderAddForm(card) {
 }
 
 /* Fueling panel: this daemon's active leases + a fuel button per
-   fuelable vault entry. Rendered only in connect mode. */
+   fuelable vault entry. Renders wherever a vault store is reachable —
+   hosted tabs (account vault) and direct dashboards (local vault). */
 function vaultRenderFueling(card) {
-  if (!DASHBOARD_CONNECT_MODE) return;
+  if (!vaultAvailable()) return;
   const head = document.createElement('div');
   head.className = 'vault-status-line';
   const title = document.createElement('span');
@@ -2264,9 +2331,11 @@ function renderAccessVaultSection() {
   switch (vaultState.status) {
     case 'unavailable':
       chip.textContent = 'unavailable';
-      statusText = DASHBOARD_CONNECT_MODE
+      statusText = !crypto?.subtle
         ? 'This browser lacks the WebCrypto features the vault needs.'
-        : 'The vault rides your hosted account — open this dashboard through Hosted Connect to use it.';
+        : DASHBOARD_CONNECT_MODE
+          ? 'The hosted vault store is unreachable right now.'
+          : 'No vault store reachable yet: this daemon predates local vault storage, this session lacks credentials.manage, or the control channel is still connecting (retries automatically). Hosted Connect dashboards use the account vault instead.';
       break;
     case 'signed-out':
       chip.textContent = 'signed out';
@@ -2290,8 +2359,27 @@ function renderAccessVaultSection() {
       chip.textContent = 'checking';
       statusText = 'Looking for your vault…';
   }
+  // Which store backs this vault — the one-glance answer to "where does
+  // this blob live?" (docs/src/credential-custody.md, storage backends).
+  const backend = vaultBackendKind();
+  if (backend && vaultState.status !== 'unavailable') {
+    const store = document.createElement('span');
+    store.className = 'vault-chip';
+    store.textContent = backend === 'daemon' ? 'stored on this daemon' : 'account store';
+    store.title = backend === 'daemon'
+      ? 'The sealed blob lives on this daemon (~/.intendant/vault-blob.json) — no Connect service in the loop. The daemon cannot read or forge it.'
+      : 'The sealed blob lives with your hosted account and follows you across daemons. The service cannot read or forge it.';
+    statusLine.appendChild(store);
+  }
   statusLine.append(chip, document.createTextNode(statusText));
   card.appendChild(statusLine);
+
+  // The backend can appear after boot (control channel connects, feature
+  // list lands): leave 'unavailable' as soon as a store is reachable.
+  if (vaultState.status === 'unavailable' && vaultAvailable()) {
+    vaultInitPromise = null;
+    vaultInit();
+  }
 
   if (vaultState.rollbackWarning) {
     const warning = document.createElement('div');
@@ -2304,6 +2392,36 @@ function renderAccessVaultSection() {
     error.className = 'vault-error';
     error.textContent = vaultState.lastError;
     card.appendChild(error);
+  }
+
+  // Hosted tab + unlocked vault + a daemon that has local vault storage:
+  // offer to keep a sealed copy there, so its direct dashboard has a
+  // vault home without any Connect service in the loop. Explicit and
+  // one-way — the two stores keep independent revision ratchets.
+  if (
+    vaultState.status === 'unlocked' &&
+    backend === 'account' &&
+    vaultState.blob &&
+    vaultTunnelDaemonVaultAvailable()
+  ) {
+    const copyRow = document.createElement('div');
+    copyRow.className = 'vault-actions';
+    const copyBtn = vaultButton('Keep a sealed copy on this daemon', async () => {
+      try {
+        const result = await vaultLeaseRpc('api_daemon_vault_publish', {
+          revision: vaultState.blob.revision,
+          vault: vaultState.blob,
+        });
+        showControlToast?.('success', result?.stored
+          ? `Sealed vault copy (revision ${vaultState.blob.revision}) stored on this daemon — its direct dashboard can now unseal it with your passkey or phrase.`
+          : 'This daemon already holds this exact vault revision.');
+      } catch (err) {
+        showControlToast?.('error', `Vault copy failed: ${err?.message || err}`);
+      }
+    });
+    copyBtn.title = 'Publishes the encrypted blob to this daemon (~/.intendant/vault-blob.json). The daemon cannot read it; a direct dashboard on that machine unseals it with the same passkey or recovery phrase. The copy does not auto-sync afterwards.';
+    copyRow.appendChild(copyBtn);
+    card.appendChild(copyRow);
   }
 
   if (vaultCeremony) {

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -627,6 +627,24 @@ function renderAccessFleetStrip() {
     }
     const provenanceChip = accessTargetProvenanceChip(target);
     if (provenanceChip) meta.appendChild(provenanceChip);
+    // The door to the direct path (docs/src/trust-tiers.md): when the
+    // record carries the daemon's own URL, offer it — a direct tab talks
+    // straight to that daemon (local vault, no Connect service in the
+    // loop). Self-signed daemons show the browser's certificate warning
+    // on first visit until a real cert or the enrollment ceremony.
+    const directUrl = String(target.url || descriptor.peer?.url || '').trim();
+    if (directUrl && !target.local && !descriptor.local && /^https?:\/\//.test(directUrl)) {
+      const direct = document.createElement('button');
+      direct.type = 'button';
+      direct.className = 'acc-btn acc-fleet-direct';
+      direct.textContent = '↗ direct';
+      direct.title = `Open ${directUrl} — this daemon's own dashboard, no rendezvous in the loop. Works when this browser can reach it (same LAN/VPN); a self-signed daemon shows a one-time certificate warning.`;
+      direct.addEventListener('click', event => {
+        event.stopPropagation();
+        window.open(directUrl, '_blank', 'noopener');
+      });
+      meta.appendChild(direct);
+    }
     card.append(top, meta);
     card.addEventListener('click', () => routeTo('access', 'daemons'));
     mount.appendChild(card);


### PR DESCRIPTION
The deferred unlock from the trust-tiers arc (#109/#110): a **direct dashboard now has a vault home with no Connect service in the loop** — resolving the original "vault only through hosted Connect" complaint by design rather than by copy.

## Daemon store
- `vault_store.rs`: the E2E-sealed blob at `~/.intendant/vault-blob.json` (0600, atomic tmp+rename), blind to contents. Semantics **replicate the hosted store exactly** — ≤128 KiB shape validation, monotonic-revision rollback ratchet, same-revision-divergence conflict, MAC-presence ratchet — with mirrored unit tests twin-pinning `bin/connect/fleet.rs` (the claim-proof golden-payload pattern).
- New `credentials.manage`-gated control methods `api_daemon_vault_fetch` / `api_daemon_vault_publish`; conflicts travel as `vault revision conflict:`-prefixed errors that the dashboard maps to the same shape as the hosted store's HTTP 409.
- Tests use the explicit-path convention from `state_paths.rs` (cfg(test) doesn't cross crates — the bare entry points would hit the live home under the bin's test build).

## Browser backend switch
- `vaultBackendKind()`: hosted tabs keep the **account store**; direct dashboards use the **daemon store** when the verified control channel advertises it, with automatic retry once the transport connects. A store chip on the vault card answers "where does this blob live?" at a glance.
- Fueling, leases, and custody panels un-gate from connect mode — they render wherever a store is reachable. **Trusted-only entries now do real work**: sealed against hosted tabs, fully usable on a direct dashboard.
- Hosted tabs with an unlocked vault offer **"Keep a sealed copy on this daemon"** — explicit and one-way; the two stores keep independent revision ratchets (stated in the UI and docs). First unseal on a new origin is phrase-first, then enroll the local passkey (passkeys are origin-scoped; the blob holds one envelope per unlocker).

## Also
- Fixes a gap from #110: the custody-trail dispatch arm dropped the new `origin` field on the wire.
- Fleet-strip cards gain **↗ direct** wherever a daemon's own URL is known — the door to the direct path (task #22's in-repo slice).
- Docs: credential-custody "Storage backends" section + wire-table rows; trust-tiers hook-3 status + a direct-origin recipe (real cert via own domain DNS-01 / tailscale cert, else one-time exception + enrollment).

Battery: 2686 unit tests green on both bins, clippy clean, app.html regenerated from fragments.