### PR TITLE
Findings batch: resident relabel, honest ended statuses, fs_scope, debug re-announce, codex model override

### DIFF
--- a/src/bin/caller/access/iam.rs
+++ b/src/bin/caller/access/iam.rs
@@ -2295,6 +2295,9 @@ pub fn grant_overview_values(state: &LocalIamState, default_target_id: &str) -> 
                 "source": if grant.source.is_empty() { "local_iam_state" } else { grant.source.as_str() },
                 "status": status,
                 "enforced": grant.is_active_at(now),
+                // The dashboard's grant-row fs chip reads this; a grant
+                // without a scope serializes null so the chip stays off.
+                "fs_scope": grant.fs_scope.as_ref().filter(|scope| !scope.is_empty()),
                 "reason": grant.reason.clone(),
                 "created_at_unix_ms": grant.created_at_unix_ms,
                 "revoked_at_unix_ms": grant.revoked_at_unix_ms,

--- a/src/bin/caller/debug.rs
+++ b/src/bin/caller/debug.rs
@@ -175,8 +175,16 @@ pub fn spawn_debug_screen_handler(
         loop {
             match event_rx.recv().await {
                 Ok(AppEvent::ControlCommand(ControlMsg::SetupDebugScreen)) => {
-                    if screen.is_some() {
-                        eprintln!("[debug] Screen already active");
+                    if let Some(ref s) = screen {
+                        // A reloaded dashboard has no memory of the active
+                        // screen — re-announce it instead of going silent.
+                        eprintln!(
+                            "[debug] Screen already active on :{} — re-announcing",
+                            s.display_id
+                        );
+                        bus.send(AppEvent::DebugScreenReady {
+                            display_id: s.display_id,
+                        });
                         continue;
                     }
                     match setup_debug_screen(web_port).await {

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -1330,6 +1330,13 @@ pub enum ControlMsg {
         /// the resolved agent is Claude Code.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         claude_effort: Option<String>,
+        /// Optional one-shot Codex model override for this session (e.g.
+        /// "gpt-5.3-codex"). Launch-time only — Codex sessions cannot switch
+        /// models mid-session, so unlike `claude_model` there is no matching
+        /// per-session update path. Only applies when the resolved agent is
+        /// Codex.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        codex_model: Option<String>,
         /// Optional one-shot Codex sandbox mode for this session. Only applies
         /// when the resolved agent is Codex.
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -3534,6 +3541,7 @@ mod tests {
                 claude_model: None,
                 claude_effort: None,
                 claude_permission_mode: None,
+                codex_model: Some("gpt-5.3-codex".to_string()),
                 codex_sandbox: Some("danger-full-access".to_string()),
                 codex_approval_policy: Some("never".to_string()),
                 codex_managed_context: Some("managed".to_string()),
@@ -3791,7 +3799,7 @@ mod tests {
 
     #[test]
     fn control_msg_create_session_deserialize() {
-        let json = r#"{"action":"create_session","task":"fix bug","name":"Bugfix work","project_root":"/repo","agent":"codex","agent_command":"/opt/codex/bin/codex","codex_sandbox":"danger-full-access","codex_approval_policy":"never","codex_managed_context":"managed","codex_context_archive":"exact","codex_service_tier":"priority","direct":true,"attachments":["upload:u1"]}"#;
+        let json = r#"{"action":"create_session","task":"fix bug","name":"Bugfix work","project_root":"/repo","agent":"codex","agent_command":"/opt/codex/bin/codex","codex_model":"gpt-5.3-codex","codex_sandbox":"danger-full-access","codex_approval_policy":"never","codex_managed_context":"managed","codex_context_archive":"exact","codex_service_tier":"priority","direct":true,"attachments":["upload:u1"]}"#;
         let msg: ControlMsg = serde_json::from_str(json).unwrap();
         match msg {
             ControlMsg::CreateSession {
@@ -3803,6 +3811,7 @@ mod tests {
                 claude_model,
                 claude_permission_mode,
                 claude_effort,
+                codex_model,
                 codex_sandbox,
                 codex_approval_policy,
                 codex_managed_context,
@@ -3822,6 +3831,7 @@ mod tests {
                 assert_eq!(project_root.as_deref(), Some("/repo"));
                 assert_eq!(agent.as_deref(), Some("codex"));
                 assert_eq!(agent_command.as_deref(), Some("/opt/codex/bin/codex"));
+                assert_eq!(codex_model.as_deref(), Some("gpt-5.3-codex"));
                 assert_eq!(codex_sandbox.as_deref(), Some("danger-full-access"));
                 assert_eq!(codex_approval_policy.as_deref(), Some("never"));
                 assert_eq!(codex_managed_context.as_deref(), Some("managed"));

--- a/src/bin/caller/external_agent/codex/mod.rs
+++ b/src/bin/caller/external_agent/codex/mod.rs
@@ -438,6 +438,20 @@ impl CodexAgent {
         }
     }
 
+    /// Escalate a backend-internal warning to the session (dashboard
+    /// activity log via `AgentEvent::Log`, same as the resume-cwd mismatch)
+    /// in addition to the daemon's stderr — stderr-only warnings are
+    /// invisible to the operator watching the dashboard.
+    fn emit_backend_warning(&self, message: String) {
+        eprintln!("[codex] Warning: {message}");
+        if let Some(event_tx) = self.event_tx.as_ref() {
+            let _ = event_tx.send(AgentEvent::Log {
+                level: "warn".to_string(),
+                message,
+            });
+        }
+    }
+
     fn cleanup_temporary_request_trace_root(&mut self) {
         if !self.request_trace_temporary {
             return;
@@ -1313,19 +1327,19 @@ impl ExternalAgent for CodexAgent {
                 .mark_existing_context_requests_seen(Some(&thread_id))
                 .await
             {
-                eprintln!(
-                    "[codex] Warning: failed to seed context request trace baseline for resumed thread {thread_id}: {e}"
-                );
+                self.emit_backend_warning(format!(
+                    "failed to seed context request trace baseline for resumed thread {thread_id}: {e}"
+                ));
             }
             let rollout_path = match extract_thread_path(&result) {
                 Some(path) => Some(path),
                 None => match self.read_thread_snapshot(&thread_id).await {
                     Ok(snapshot) => snapshot.rollout_path,
                     Err(e) => {
-                        eprintln!(
-                            "[codex] Warning: failed to read resumed thread metadata for token usage seed: {}",
-                            e
-                        );
+                        self.emit_backend_warning(format!(
+                            "failed to read resumed thread metadata for token usage seed: {e}; \
+                             the context meter starts unseeded until the next turn reports usage"
+                        ));
                         None
                     }
                 },
@@ -1343,11 +1357,11 @@ impl ExternalAgent for CodexAgent {
                     }
                     Ok(None) => {}
                     Err(e) => {
-                        eprintln!(
-                            "[codex] Warning: failed to seed token usage from rollout {}: {}",
+                        self.emit_backend_warning(format!(
+                            "failed to seed token usage from rollout {}: {}",
                             rollout_path.display(),
                             e
-                        );
+                        ));
                     }
                 }
             }

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -3447,9 +3447,16 @@ async fn main() -> Result<(), CallerError> {
 
     // Write session metadata (project root, task will be filled in later if
     // available). A projectless daemon's base session honestly records no
-    // project instead of attributing itself to the launch cwd.
+    // project instead of attributing itself to the launch cwd. The daemon's
+    // own base session is marked `resident` so the catalog labels it as the
+    // daemon's resident session instead of an abandoned user task; the
+    // marker is dropped by the next write_meta if a task ever lands on it.
     slog(&session_log, |l| {
-        l.write_meta(daemon_project_root.as_deref(), None);
+        if web_daemon_requested {
+            l.write_meta_with_role(daemon_project_root.as_deref(), None, Some("resident"));
+        } else {
+            l.write_meta(daemon_project_root.as_deref(), None);
+        }
     });
 
     // Web gateway is on by default unless explicitly disabled, or when running

--- a/src/bin/caller/session_config.rs
+++ b/src/bin/caller/session_config.rs
@@ -19,6 +19,8 @@ pub struct SessionAgentConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_command: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codex_sandbox: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codex_approval_policy: Option<String>,
@@ -61,6 +63,7 @@ impl SessionAgentConfig {
         self.source.is_none()
             && self.project_root.is_none()
             && self.agent_command.is_none()
+            && self.codex_model.is_none()
             && self.codex_sandbox.is_none()
             && self.codex_approval_policy.is_none()
             && self.codex_managed_context.is_none()
@@ -83,6 +86,9 @@ impl SessionAgentConfig {
         }
         if self.agent_command.is_none() {
             self.agent_command = fallback.agent_command;
+        }
+        if self.codex_model.is_none() {
+            self.codex_model = fallback.codex_model;
         }
         if self.codex_sandbox.is_none() {
             self.codex_sandbox = fallback.codex_sandbox;
@@ -135,6 +141,13 @@ pub fn normalize_project_root(root: Option<&str>) -> Option<String> {
 
 pub fn normalize_codex_service_tier(tier: Option<&str>) -> Option<String> {
     crate::project::normalize_codex_service_tier(tier)
+}
+
+pub fn normalize_codex_model(model: Option<&str>) -> Option<String> {
+    model
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
 }
 
 pub fn normalize_codex_home(home: Option<&str>) -> Option<String> {
@@ -254,6 +267,7 @@ pub fn effective_codex_home() -> Option<String> {
 pub struct WireSessionAgentFields<'a> {
     pub source: Option<&'a str>,
     pub agent_command: Option<&'a str>,
+    pub codex_model: Option<&'a str>,
     pub codex_sandbox: Option<&'a str>,
     pub codex_approval_policy: Option<&'a str>,
     pub codex_managed_context: Option<&'a str>,
@@ -297,6 +311,9 @@ pub fn from_wire_fields(fields: WireSessionAgentFields) -> SessionAgentConfig {
         source,
         project_root: None,
         agent_command: normalize_agent_command(fields.agent_command),
+        codex_model: is_codex
+            .then(|| normalize_codex_model(fields.codex_model))
+            .flatten(),
         codex_sandbox: is_codex
             .then(|| normalize_codex_sandbox(fields.codex_sandbox))
             .flatten(),
@@ -335,6 +352,7 @@ pub fn from_project(backend: &AgentBackend, project: &Project) -> SessionAgentCo
             source: Some("codex".to_string()),
             project_root: normalize_project_root(Some(&project.root.to_string_lossy())),
             agent_command: Some(project.config.agent.codex.command.clone()),
+            codex_model: normalize_codex_model(project.config.agent.codex.model.as_deref()),
             codex_sandbox: Some(crate::project::normalize_sandbox_mode(
                 &project.config.agent.codex.sandbox,
             )),
@@ -363,6 +381,7 @@ pub fn from_project(backend: &AgentBackend, project: &Project) -> SessionAgentCo
                 source: Some("claude-code".to_string()),
                 project_root: normalize_project_root(Some(&project.root.to_string_lossy())),
                 agent_command: Some(claude.command.clone()),
+                codex_model: None,
                 codex_sandbox: None,
                 codex_approval_policy: None,
                 codex_managed_context: None,
@@ -393,6 +412,9 @@ pub fn apply_to_project(
         AgentBackend::Codex => {
             if let Some(command) = config.agent_command.clone() {
                 project.config.agent.codex.command = command;
+            }
+            if let Some(model) = config.codex_model.clone() {
+                project.config.agent.codex.model = Some(model);
             }
             if let Some(mode) = config.codex_sandbox.clone() {
                 project.config.agent.codex.sandbox = crate::project::normalize_sandbox_mode(&mode);
@@ -475,6 +497,9 @@ fn normalize_session_agent_config(
     }
     if let Some(command) = config.agent_command.take() {
         config.agent_command = normalize_agent_command(Some(&command));
+    }
+    if let Some(model) = config.codex_model.take() {
+        config.codex_model = normalize_codex_model(Some(&model));
     }
     if let Some(mode) = config.codex_sandbox.take() {
         config.codex_sandbox = normalize_codex_sandbox(Some(&mode));
@@ -765,6 +790,9 @@ pub fn apply_config_to_session_json(session: &mut Value, config: &SessionAgentCo
     }
     if let Some(home) = config.codex_home.as_deref() {
         obj.insert("codex_home".to_string(), Value::String(home.to_string()));
+    }
+    if let Some(model) = config.codex_model.as_deref() {
+        obj.insert("codex_model".to_string(), Value::String(model.to_string()));
     }
     if let Some(model) = config.claude_model.as_deref() {
         obj.insert("claude_model".to_string(), Value::String(model.to_string()));

--- a/src/bin/caller/session_log/mod.rs
+++ b/src/bin/caller/session_log/mod.rs
@@ -326,6 +326,20 @@ impl SessionLog {
         self.write_meta_with_name_and_role(project_root, task, name, None);
     }
 
+    /// Write session metadata with an explicit role marker (e.g. `resident`
+    /// for the daemon's own base session). The role survives in
+    /// `session_meta.json` so the session catalog can tell the daemon's
+    /// resident session apart from an abandoned user task after this
+    /// process exits.
+    pub fn write_meta_with_role(
+        &self,
+        project_root: Option<&Path>,
+        task: Option<&str>,
+        role: Option<&str>,
+    ) {
+        self.write_meta_with_name_and_role(project_root, task, None, role);
+    }
+
     fn write_meta_with_name_and_role(
         &self,
         project_root: Option<&Path>,

--- a/src/bin/caller/session_supervisor/agent_config.rs
+++ b/src/bin/caller/session_supervisor/agent_config.rs
@@ -520,6 +520,10 @@ impl LaunchOverrides {
         crate::session_config::WireSessionAgentFields {
             source: Some(source),
             agent_command: self.agent_command.as_deref(),
+            // Launch-time only (CreateSession): a codex session cannot
+            // switch models mid-session, so configure/restart never carries
+            // one and the persisted pin must survive untouched.
+            codex_model: None,
             codex_sandbox: self.codex_sandbox.as_deref(),
             codex_approval_policy: self.codex_approval_policy.as_deref(),
             codex_managed_context: self.codex_managed_context.as_deref(),
@@ -643,6 +647,20 @@ pub(crate) fn apply_session_claude_effort(
             Ok(())
         }
         _ => Err("claude_effort requires Claude Code".to_string()),
+    }
+}
+
+pub(crate) fn apply_session_codex_model(
+    project: &mut Project,
+    backend: &external_agent::AgentBackend,
+    model: String,
+) -> Result<(), String> {
+    match backend {
+        external_agent::AgentBackend::Codex => {
+            project.config.agent.codex.model = Some(model);
+            Ok(())
+        }
+        _ => Err("codex_model requires Codex".to_string()),
     }
 }
 

--- a/src/bin/caller/session_supervisor/dispatch.rs
+++ b/src/bin/caller/session_supervisor/dispatch.rs
@@ -16,6 +16,7 @@ impl SessionSupervisor {
                 claude_model,
                 claude_permission_mode,
                 claude_effort,
+                codex_model,
                 codex_sandbox,
                 codex_approval_policy,
                 codex_managed_context,
@@ -54,6 +55,7 @@ impl SessionSupervisor {
                                 None,
                                 None,
                                 None,
+                                codex_model,
                                 codex_sandbox,
                                 codex_approval_policy,
                                 codex_managed_context,
@@ -80,6 +82,7 @@ impl SessionSupervisor {
                         || claude_model.is_some()
                         || claude_permission_mode.is_some()
                         || claude_effort.is_some()
+                        || codex_model.is_some()
                         || codex_sandbox.is_some()
                         || codex_approval_policy.is_some()
                         || codex_managed_context.is_some()
@@ -104,6 +107,7 @@ impl SessionSupervisor {
                     claude_model,
                     claude_permission_mode,
                     claude_effort,
+                    codex_model,
                     codex_sandbox,
                     codex_approval_policy,
                     codex_managed_context,
@@ -170,6 +174,7 @@ impl SessionSupervisor {
                                 None,
                                 None,
                                 None,
+                                None,
                                 orchestrate,
                                 direct,
                                 Vec::new(),
@@ -196,6 +201,7 @@ impl SessionSupervisor {
                 }
                 self.start_new_session(
                     task,
+                    None,
                     None,
                     None,
                     None,

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -16,6 +16,7 @@ impl SessionSupervisor {
         claude_model: Option<String>,
         claude_permission_mode: Option<String>,
         claude_effort: Option<String>,
+        codex_model: Option<String>,
         codex_sandbox: Option<String>,
         codex_approval_policy: Option<String>,
         codex_managed_context: Option<String>,
@@ -201,6 +202,20 @@ impl SessionSupervisor {
                 return;
             };
             if let Err(e) = apply_session_claude_effort(&mut project, backend, effort.to_string()) {
+                self.loop_error(format!("Session create failed: {}", e));
+                return;
+            }
+        }
+        if let Some(model) = codex_model
+            .as_deref()
+            .map(str::trim)
+            .filter(|m| !m.is_empty())
+        {
+            let Some(ref backend) = backend else {
+                self.loop_error("Session create failed: codex_model requires Codex".to_string());
+                return;
+            };
+            if let Err(e) = apply_session_codex_model(&mut project, backend, model.to_string()) {
                 self.loop_error(format!("Session create failed: {}", e));
                 return;
             }

--- a/src/bin/caller/web_gateway/session_catalog/mod.rs
+++ b/src/bin/caller/web_gateway/session_catalog/mod.rs
@@ -1494,6 +1494,29 @@ pub(crate) fn session_file_fingerprints_digest(entries: &[SessionFileFingerprint
     out
 }
 
+/// Status for a session whose `summary.json` exists: the session ended,
+/// but not necessarily well. A backend that died ("external agent event
+/// channel closed", spawn failures, `error: …`) must not present as
+/// `completed` — that flattening hid real backend deaths from operators.
+fn summary_json_status(dir: &Path) -> Option<&'static str> {
+    let raw = std::fs::read_to_string(dir.join("summary.json")).ok()?;
+    let summary: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let outcome = summary
+        .get("outcome")
+        .and_then(|v| v.as_str())
+        .unwrap_or("completed");
+    let normalized = outcome.trim().to_ascii_lowercase();
+    Some(
+        if normalized.is_empty() || normalized == "completed" || normalized == "done" {
+            "completed"
+        } else if normalized.contains("stopped by user") || normalized.contains("interrupt") {
+            "interrupted"
+        } else {
+            "failed"
+        },
+    )
+}
+
 pub(crate) fn intendant_session_list_row_from_dir(
     dir: &Path,
     session_id: &str,
@@ -1751,8 +1774,10 @@ pub(crate) fn intendant_session_list_row_from_dir(
         }
     }
 
-    if status != "completed" && dir.join("summary.json").exists() {
-        status = "completed".to_string();
+    if status != "completed" {
+        if let Some(ended) = summary_json_status(dir) {
+            status = ended.to_string();
+        }
     }
 
     let mut recording_count: u64 = 0;
@@ -1843,11 +1868,16 @@ pub(crate) fn intendant_session_list_row_from_dir(
 
     let total_bytes = recording_bytes + frames_bytes + turns_bytes + logs_bytes;
 
-    if status != "completed" {
+    let session_ended = matches!(status.as_str(), "completed" | "failed" | "interrupted");
+    if !session_ended {
         let has_model_work = turns > 0 || total_tokens > 0;
         if !has_model_work {
             let has_media = recording_count > 0 || annotation_count > 0 || clip_count > 0;
-            if task.is_some() || has_media {
+            if role.as_deref() == Some("resident") {
+                // The daemon's own base session (marked at boot): a bare
+                // one is the daemon idling, not an abandoned user task.
+                status = "resident".to_string();
+            } else if task.is_some() || has_media {
                 status = "idle".to_string();
             } else {
                 status = "abandoned".to_string();
@@ -2032,8 +2062,10 @@ pub(crate) fn intendant_session_skeleton_from_dir(
             role = value_str(&meta, "role");
         }
     }
-    if status != "completed" && dir.join("summary.json").exists() {
-        status = "completed".to_string();
+    if status != "completed" {
+        if let Some(ended) = summary_json_status(dir) {
+            status = ended.to_string();
+        }
     }
     if created_at.is_none() {
         created_at = mtime_secs_to_string(file_mtime_secs(dir));
@@ -2359,6 +2391,70 @@ pub(crate) fn stream_sessions_from_request(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn summary_json_status_maps_outcomes_honestly() {
+        let dir = tempfile::tempdir().unwrap();
+        let write = |outcome: &str| {
+            std::fs::write(
+                dir.path().join("summary.json"),
+                serde_json::json!({ "task": "t", "outcome": outcome }).to_string(),
+            )
+            .unwrap();
+        };
+        write("completed");
+        assert_eq!(summary_json_status(dir.path()), Some("completed"));
+        write("stopped by user");
+        assert_eq!(summary_json_status(dir.path()), Some("interrupted"));
+        write("Interrupted");
+        assert_eq!(summary_json_status(dir.path()), Some("interrupted"));
+        write("external agent event channel closed");
+        assert_eq!(summary_json_status(dir.path()), Some("failed"));
+        write("error: spawn failed");
+        assert_eq!(summary_json_status(dir.path()), Some("failed"));
+        // Legacy summaries without an outcome field still read completed.
+        std::fs::write(dir.path().join("summary.json"), "{\"task\":\"t\"}").unwrap();
+        assert_eq!(summary_json_status(dir.path()), Some("completed"));
+        // No summary at all → the session has not ended.
+        std::fs::remove_file(dir.path().join("summary.json")).unwrap();
+        assert_eq!(summary_json_status(dir.path()), None);
+    }
+
+    #[test]
+    fn resident_role_dir_classifies_as_resident_not_abandoned() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("session_meta.json"),
+            serde_json::json!({
+                "session_id": "resident-1",
+                "created_at": "2026-07-08T00:00:00",
+                "status": "running",
+                "role": "resident",
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let row = intendant_session_list_row_from_dir(dir.path(), "resident-1").unwrap();
+        assert_eq!(row["status"], "resident");
+        assert_eq!(row["role"], "resident");
+    }
+
+    #[test]
+    fn bare_taskless_dir_without_role_still_classifies_abandoned() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("session_meta.json"),
+            serde_json::json!({
+                "session_id": "ghost-1",
+                "created_at": "2026-07-08T00:00:00",
+                "status": "running",
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let row = intendant_session_list_row_from_dir(dir.path(), "ghost-1").unwrap();
+        assert_eq!(row["status"], "abandoned");
+    }
 
     #[test]
     fn session_row_answers_to_id_checks_all_identity_fields() {

--- a/static/app.html
+++ b/static/app.html
@@ -25506,7 +25506,9 @@ const SESSION_SOURCE_FILTER_OPTIONS = [
 const SESSION_STATUS_FILTER_OPTIONS = [
   { value: 'active', label: 'Active', plural: 'statuses' },
   { value: 'idle', label: 'Idle', plural: 'statuses' },
+  { value: 'resident', label: 'Resident', plural: 'statuses' },
   { value: 'completed', label: 'Completed', plural: 'statuses' },
+  { value: 'failed', label: 'Failed', plural: 'statuses' },
   { value: 'abandoned', label: 'Abandoned', plural: 'statuses' },
   { value: 'interrupted', label: 'Interrupted', plural: 'statuses' },
 ];
@@ -31796,7 +31798,8 @@ function stationSessionRow(session, indexedIds = new Set()) {
   return {
     id: rowId,
     action: indexedIds.has(String(id)) ? 'detail' : '',
-    label: stationSessionTask(session) || 'Untitled session',
+    label: stationSessionTask(session)
+      || (session?.role === 'resident' || session?.status === 'resident' ? 'Daemon session' : 'Untitled session'),
     value: [status, source].filter(Boolean).join(' · '),
     detail: [
       String(id).slice(0, 8),
@@ -34453,7 +34456,10 @@ function stationBuildSessionsSummary() {
     external: externalIds.size,
     totalTokens,
     diskBytes,
-    latestTask: latest ? (stationSessionTask(latest) || 'Untitled session') : '',
+    latestTask: latest
+      ? (stationSessionTask(latest)
+        || (latest?.role === 'resident' || latest?.status === 'resident' ? 'Daemon session' : 'Untitled session'))
+      : '',
     latestSource: latest
       ? (sessionConfigSource(sessionConfigMetadata(latest)) || stationSessionSource(latest) || latest?.source || 'session')
       : '',
@@ -49411,7 +49417,10 @@ function showApproval(id, command, category, sessionId) {
     focusSessionWindow(pendingApprovalSessionId);
   }
   document.getElementById('approval-command').textContent = command;
-  document.getElementById('approval-category').textContent = category || '';
+  const approvalCategoryEl = document.getElementById('approval-category');
+  approvalCategoryEl.textContent = category || '';
+  // No category (older sessions, rehydrated approvals) → no empty pill.
+  approvalCategoryEl.style.display = category ? '' : 'none';
   stationCurrentApproval = {
     id: String(id),
     command: command || '',
@@ -83638,8 +83647,9 @@ function buildSessionCard(m, derived, ctx) {
   const sessionName = compactSessionText(s.name);
   const taskText = compactSessionText(s.task);
   const sessionId = s.session_id || '';
-  const primaryText = sessionName || taskText || 'Untitled session';
-  const titleKindText = sessionName ? 'name' : taskText ? 'initial' : 'untitled';
+  const isResident = s.role === 'resident' || displayStatus === 'resident';
+  const primaryText = sessionName || taskText || (isResident ? 'Daemon session' : 'Untitled session');
+  const titleKindText = sessionName ? 'name' : taskText ? 'initial' : isResident ? 'resident' : 'untitled';
 
   // Top row: name/task + status badges
   const top = document.createElement('div');
@@ -83657,7 +83667,9 @@ function buildSessionCard(m, derived, ctx) {
     ? 'User-assigned session name'
     : taskText
       ? 'Initial message fallback'
-      : 'No initial message found';
+      : isResident
+        ? "The daemon's own resident session — becomes a task session when you message it"
+        : 'No initial message found';
   titleRow.appendChild(titleKind);
   const nameEl = document.createElement('div');
   nameEl.className = 'sc-name';
@@ -85035,14 +85047,17 @@ function renderSessionDetailTitle(session) {
   const source = session.source || 'intendant';
   const sessionName = compactSessionText(session.name);
   const task = compactSessionText(session.task);
-  const primaryText = sessionName || task || 'Untitled session';
+  const isResident = session.role === 'resident' || session.status === 'resident';
+  const primaryText = sessionName || task || (isResident ? 'Daemon session' : 'Untitled session');
   const sourceLabel = session.source_label || (source === 'intendant' ? 'Intendant' : prettyAgentName(source) || source);
-  const titleKindLabel = sessionName ? 'name' : task ? 'initial' : 'untitled';
+  const titleKindLabel = sessionName ? 'name' : task ? 'initial' : isResident ? 'resident' : 'untitled';
   const titleKindHelp = sessionName
     ? 'User-assigned session name'
     : task
       ? 'Initial message fallback'
-      : 'No initial message found';
+      : isResident
+        ? "The daemon's own resident session — becomes a task session when you message it"
+        : 'No initial message found';
 
   titleEl.innerHTML = '';
   const titleLine = document.createElement('div');

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -572,7 +572,9 @@ const SESSION_SOURCE_FILTER_OPTIONS = [
 const SESSION_STATUS_FILTER_OPTIONS = [
   { value: 'active', label: 'Active', plural: 'statuses' },
   { value: 'idle', label: 'Idle', plural: 'statuses' },
+  { value: 'resident', label: 'Resident', plural: 'statuses' },
   { value: 'completed', label: 'Completed', plural: 'statuses' },
+  { value: 'failed', label: 'Failed', plural: 'statuses' },
   { value: 'abandoned', label: 'Abandoned', plural: 'statuses' },
   { value: 'interrupted', label: 'Interrupted', plural: 'statuses' },
 ];

--- a/static/app/34-station-panes.js
+++ b/static/app/34-station-panes.js
@@ -143,7 +143,8 @@ function stationSessionRow(session, indexedIds = new Set()) {
   return {
     id: rowId,
     action: indexedIds.has(String(id)) ? 'detail' : '',
-    label: stationSessionTask(session) || 'Untitled session',
+    label: stationSessionTask(session)
+      || (session?.role === 'resident' || session?.status === 'resident' ? 'Daemon session' : 'Untitled session'),
     value: [status, source].filter(Boolean).join(' · '),
     detail: [
       String(id).slice(0, 8),

--- a/static/app/35-station-diff-viewer.js
+++ b/static/app/35-station-diff-viewer.js
@@ -869,7 +869,10 @@ function stationBuildSessionsSummary() {
     external: externalIds.size,
     totalTokens,
     diskBytes,
-    latestTask: latest ? (stationSessionTask(latest) || 'Untitled session') : '',
+    latestTask: latest
+      ? (stationSessionTask(latest)
+        || (latest?.role === 'resident' || latest?.status === 'resident' ? 'Daemon session' : 'Untitled session'))
+      : '',
     latestSource: latest
       ? (sessionConfigSource(sessionConfigMetadata(latest)) || stationSessionSource(latest) || latest?.source || 'session')
       : '',

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -2389,7 +2389,10 @@ function showApproval(id, command, category, sessionId) {
     focusSessionWindow(pendingApprovalSessionId);
   }
   document.getElementById('approval-command').textContent = command;
-  document.getElementById('approval-category').textContent = category || '';
+  const approvalCategoryEl = document.getElementById('approval-category');
+  approvalCategoryEl.textContent = category || '';
+  // No category (older sessions, rehydrated approvals) → no empty pill.
+  approvalCategoryEl.style.display = category ? '' : 'none';
   stationCurrentApproval = {
     id: String(id),
     command: command || '',

--- a/static/app/57-sessions-replay.js
+++ b/static/app/57-sessions-replay.js
@@ -449,8 +449,9 @@ function buildSessionCard(m, derived, ctx) {
   const sessionName = compactSessionText(s.name);
   const taskText = compactSessionText(s.task);
   const sessionId = s.session_id || '';
-  const primaryText = sessionName || taskText || 'Untitled session';
-  const titleKindText = sessionName ? 'name' : taskText ? 'initial' : 'untitled';
+  const isResident = s.role === 'resident' || displayStatus === 'resident';
+  const primaryText = sessionName || taskText || (isResident ? 'Daemon session' : 'Untitled session');
+  const titleKindText = sessionName ? 'name' : taskText ? 'initial' : isResident ? 'resident' : 'untitled';
 
   // Top row: name/task + status badges
   const top = document.createElement('div');
@@ -468,7 +469,9 @@ function buildSessionCard(m, derived, ctx) {
     ? 'User-assigned session name'
     : taskText
       ? 'Initial message fallback'
-      : 'No initial message found';
+      : isResident
+        ? "The daemon's own resident session — becomes a task session when you message it"
+        : 'No initial message found';
   titleRow.appendChild(titleKind);
   const nameEl = document.createElement('div');
   nameEl.className = 'sc-name';
@@ -1846,14 +1849,17 @@ function renderSessionDetailTitle(session) {
   const source = session.source || 'intendant';
   const sessionName = compactSessionText(session.name);
   const task = compactSessionText(session.task);
-  const primaryText = sessionName || task || 'Untitled session';
+  const isResident = session.role === 'resident' || session.status === 'resident';
+  const primaryText = sessionName || task || (isResident ? 'Daemon session' : 'Untitled session');
   const sourceLabel = session.source_label || (source === 'intendant' ? 'Intendant' : prettyAgentName(source) || source);
-  const titleKindLabel = sessionName ? 'name' : task ? 'initial' : 'untitled';
+  const titleKindLabel = sessionName ? 'name' : task ? 'initial' : isResident ? 'resident' : 'untitled';
   const titleKindHelp = sessionName
     ? 'User-assigned session name'
     : task
       ? 'Initial message fallback'
-      : 'No initial message found';
+      : isResident
+        ? "The daemon's own resident session — becomes a task session when you message it"
+        : 'No initial message found';
 
   titleEl.innerHTML = '';
   const titleLine = document.createElement('div');


### PR DESCRIPTION
QA-fleet + E2E-ledger findings batch (the Rust quick wins):

- **Resident ghost row** (user call: *relabel, don't hide*): the daemon marks its base session `role=resident` at boot; the catalog classifies a bare resident dir as status `resident` instead of `abandoned`; the dashboard shows a **Daemon session** title, a resident eyebrow, and a Resident status filter (sessions list, detail, Station panes).
- **Honest ended statuses**: `summary.json` outcomes now map to `completed` / `interrupted` (user stops) / `failed` (backend deaths: channel closed, `error: …`, spawn failures) instead of everything flattening to `completed`. A codex process that spawned-then-died is now visibly a failed session. New Failed filter option.
- **`fs_scope` on `/api/access/overview`**: IAM grants carry their filesystem scope so the grant-row fs chip renders (access FR-1).
- **Debug screen re-announce**: `SetupDebugScreen` on an already-active screen re-emits `DebugScreenReady` instead of going silent — reloads can rehydrate (debug R2).
- **`codex_model` on CreateSession**: one-shot launch-time Codex model override, persisted into session-config for resume durability. Launch-time only by design (codex threads can't switch models mid-session).
- **Approval category pill** hides when a request carries no category.
- **Codex resume seed warnings** (context-trace baseline, thread metadata, rollout usage) escalate to the session activity log via `AgentEvent::Log`, matching the resume-cwd-mismatch pattern.

Verified already-landed (no change needed, ledger updated): app.html ETag/no-cache headers; external fatal-error/channel-closed round completion.

Battery: nextest 2685/2685 (3 new tests: outcome mapping, resident classification, abandoned guard), clippy baseline, e2e 7/7.