### PR TITLE
Native askHuman joins the dashboard question rail

### DIFF
--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -1626,6 +1626,65 @@ pub(crate) async fn run_agent_loop(
                     bus.send(AppEvent::HumanQuestionDetected { question });
                 }
             }
+            // askHuman with a dashboard attached: a question is a request for
+            // *input*, not permission — route it through the same question
+            // rail external backends use (UserQuestionRequired → answered via
+            // AnswerQuestion into this session's approval registry) instead
+            // of dispatching to the runtime, which would park on the
+            // human_question file no frontend watches under the daemon.
+            // Scope: batches that are entirely askHuman (the shape models
+            // emit — a blocking question stands alone); a mixed batch keeps
+            // the legacy path and logs why.
+            if !headless && json_approval.is_none() && has_ask_human_command(&json_str) {
+                if batch_is_all_ask_human(&json_str) {
+                    let question = extract_ask_human_question(&json_str)
+                        .unwrap_or_else(|| "The agent asked for your input.".to_string());
+                    slog(&session_log, |l| l.human_question(&question));
+                    let question_id = turn as u64;
+                    let (tx, rx) = tokio::sync::oneshot::channel();
+                    approval_registry.lock().unwrap().insert(question_id, tx);
+                    bus.send(AppEvent::UserQuestionRequired {
+                        session_id: local_session_id.clone(),
+                        id: question_id,
+                        questions: vec![crate::types::UserQuestion {
+                            question: question.clone(),
+                            header: String::new(),
+                            options: Vec::new(),
+                            multi_select: false,
+                        }],
+                    });
+                    let answer = match rx.await {
+                        Ok(event::ApprovalResponse::Answer { answers }) => answers
+                            .get(&question)
+                            .cloned()
+                            .or_else(|| answers.values().next().cloned())
+                            .unwrap_or_default(),
+                        Ok(_) | Err(_) => String::new(),
+                    };
+                    let reply = if answer.trim().is_empty() {
+                        "The user dismissed the question without answering. Proceed with \
+                         your best judgment; you can re-ask later if it is still relevant."
+                            .to_string()
+                    } else {
+                        slog(&session_log, |l| l.human_response_sent());
+                        answer
+                    };
+                    for (call_id, tool_name) in &batch.call_id_names {
+                        if handled_call_ids.contains(call_id) {
+                            continue;
+                        }
+                        conversation.add_tool_result(call_id, tool_name, &reply);
+                    }
+                    continue;
+                }
+                slog(&session_log, |l| {
+                    l.warn(
+                        "askHuman arrived mixed into a command batch; the runtime file \
+                         prompt handles it, which no dashboard surfaces — answer via MCP \
+                         or expect the model to re-ask",
+                    )
+                });
+            }
 
             // Autonomy / approval check (same as text path)
             let needs_approval = {
@@ -2080,6 +2139,47 @@ Proceed with explicit assumptions and continue without additional questions."
                 if let Some(question) = extract_ask_human_question(&json_str) {
                     bus.send(AppEvent::HumanQuestionDetected { question });
                 }
+            }
+            // askHuman with a dashboard attached → the question rail (see the
+            // JSON-batch twin above). The text loop mirrors its headless
+            // precedent: the batch is consumed by the question — the model
+            // re-issues any other commands after reading the answer.
+            if !headless && json_approval.is_none() && has_ask_human_command(&json_str) {
+                let question = extract_ask_human_question(&json_str)
+                    .unwrap_or_else(|| "The agent asked for your input.".to_string());
+                slog(&session_log, |l| l.human_question(&question));
+                let question_id = turn as u64;
+                let (tx, rx) = tokio::sync::oneshot::channel();
+                approval_registry.lock().unwrap().insert(question_id, tx);
+                bus.send(AppEvent::UserQuestionRequired {
+                    session_id: local_session_id.clone(),
+                    id: question_id,
+                    questions: vec![crate::types::UserQuestion {
+                        question: question.clone(),
+                        header: String::new(),
+                        options: Vec::new(),
+                        multi_select: false,
+                    }],
+                });
+                let answer = match rx.await {
+                    Ok(event::ApprovalResponse::Answer { answers }) => answers
+                        .get(&question)
+                        .cloned()
+                        .or_else(|| answers.values().next().cloned())
+                        .unwrap_or_default(),
+                    Ok(_) | Err(_) => String::new(),
+                };
+                if answer.trim().is_empty() {
+                    conversation.add_user(
+                        "The user dismissed the question without answering. Proceed with \
+                         your best judgment; you can re-ask later if it is still relevant."
+                            .to_string(),
+                    );
+                } else {
+                    slog(&session_log, |l| l.human_response_sent());
+                    conversation.add_user(format!("The user's answer to your question: {answer}"));
+                }
+                continue;
             }
 
             // Check autonomy / approval for commands

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -954,6 +954,27 @@ fn has_ask_human_command(json_str: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// True when the batch consists ENTIRELY of askHuman commands — the shape
+/// models actually emit for a blocking question. The question-rail
+/// interception only fires for this shape; a mixed batch would need the
+/// controller to reorder execution around the runtime.
+fn batch_is_all_ask_human(json_str: &str) -> bool {
+    let parsed: serde_json::Value = match serde_json::from_str(json_str) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    parsed
+        .get("commands")
+        .and_then(|v| v.as_array())
+        .map(|commands| {
+            !commands.is_empty()
+                && commands.iter().all(|cmd| {
+                    cmd.get("function").and_then(|v| v.as_str()) == Some("askHuman")
+                })
+        })
+        .unwrap_or(false)
+}
+
 /// Extract the question text from an askHuman command in a batch JSON string.
 fn extract_ask_human_question(json_str: &str) -> Option<String> {
     let parsed: serde_json::Value = serde_json::from_str(json_str).ok()?;
@@ -2239,6 +2260,20 @@ Also: {"source": "bare"}"#;
     #[test]
     fn has_ask_human_command_invalid_json() {
         assert!(!has_ask_human_command("not json"));
+    }
+
+    #[test]
+    fn batch_is_all_ask_human_pure_batch() {
+        let json = r#"{"commands":[{"function":"askHuman","question":"a?","nonce":1},{"function":"askHuman","question":"b?","nonce":2}]}"#;
+        assert!(batch_is_all_ask_human(json));
+    }
+
+    #[test]
+    fn batch_is_all_ask_human_rejects_mixed_empty_and_invalid() {
+        let mixed = r#"{"commands":[{"function":"execAsAgent","nonce":1},{"function":"askHuman","nonce":2}]}"#;
+        assert!(!batch_is_all_ask_human(mixed));
+        assert!(!batch_is_all_ask_human(r#"{"commands":[]}"#));
+        assert!(!batch_is_all_ask_human("not json"));
     }
 
     #[test]

--- a/static/app.html
+++ b/static/app.html
@@ -49553,9 +49553,9 @@ function showUserQuestion(id, questions, sessionId) {
     const free = document.createElement('input');
     free.className = 'question-free-text';
     free.type = 'text';
-    free.placeholder = q.multi_select
+    free.placeholder = (q.options || []).length
       ? 'Or type your own answer…'
-      : 'Or type your own answer…';
+      : 'Type your answer…';
     free.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') { e.preventDefault(); sendQuestionAnswer(); }
     });

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -2525,9 +2525,9 @@ function showUserQuestion(id, questions, sessionId) {
     const free = document.createElement('input');
     free.className = 'question-free-text';
     free.type = 'text';
-    free.placeholder = q.multi_select
+    free.placeholder = (q.options || []).length
       ? 'Or type your own answer…'
-      : 'Or type your own answer…';
+      : 'Type your answer…';
     free.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') { e.preventDefault(); sendQuestionAnswer(); }
     });

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1503,3 +1503,120 @@ async fn supervised_session_surfaces_approvals_on_the_dashboard() {
 
     let _ = child.kill().await;
 }
+
+/// The native askHuman command reaches the dashboard question rail: a
+/// supervised session's question arrives as a `user_question` event tagged
+/// with the session id, the dashboard's `answer_question` resolves it, and
+/// the answer text reaches the model as the tool result (pinned by the mock
+/// script's transcript expectation on the next step).
+#[tokio::test]
+async fn supervised_session_ask_human_reaches_the_question_rail() {
+    use futures_util::SinkExt;
+
+    let rig = TestRig::new();
+    let script = rig.write_script(&serde_json::json!({
+        "profiles": [{
+            "steps": [
+                { "content": "I need to know the color before painting.",
+                  "tool_calls": [{ "name": "ask_human",
+                                   "arguments": { "nonce": 1, "question": "Which color should the widget be?" } }] },
+                // The transcript gate proves the rail answer became the
+                // askHuman tool result the model actually read.
+                { "content": "Painting it cerulean.",
+                  "expect_transcript_contains": "cerulean",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "question answered" } }] }
+            ]
+        }]
+    }));
+    let session_project = tempfile::tempdir().expect("session project dir");
+
+    let mut cmd = rig.command();
+    cmd.env("INTENDANT_MOCK_SCRIPT", &script)
+        .args(["--no-tls", "--web", "18942"]);
+    let mut child = cmd.spawn().expect("spawn intendant daemon");
+    let stderr_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let stdout_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let _stderr_drain = drain_pipe_into(child.stderr.take().expect("stderr"), stderr_buf.clone());
+    let _stdout_drain = drain_pipe_into(child.stdout.take().expect("stdout"), stdout_buf.clone());
+
+    let stderr_so_far = wait_for_output(&stderr_buf, "Dashboard: http://", RUN_TIMEOUT).await;
+    let port: u16 = stderr_so_far
+        .lines()
+        .find_map(|line| {
+            let url = line.strip_prefix("Dashboard: http://")?;
+            url.rsplit(':').next()?.trim().parse().ok()
+        })
+        .expect("parse the dashboard port from the startup line");
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/ws"))
+        .await
+        .expect("connect /ws");
+
+    // Same startup race + retry shape as the approvals e2e above.
+    let mut question = None;
+    for _ in 0..6 {
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::json!({
+                "action": "create_session",
+                "task": "paint the widget the right color",
+                "project_root": session_project.path().to_string_lossy(),
+                "direct": true,
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send create_session");
+        question = next_matching_ws_event(&mut ws, Duration::from_secs(30), |json| {
+            json.get("event").and_then(|v| v.as_str()) == Some("user_question")
+        })
+        .await;
+        if question.is_some() {
+            break;
+        }
+    }
+    let question = question.unwrap_or_else(|| {
+        panic!(
+            "no user_question from the supervised session's askHuman (file-park regression?); daemon stderr:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
+        )
+    });
+    let session_id = question
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("user_question must carry its session id, got {question}"))
+        .to_string();
+    let question_id = question
+        .get("id")
+        .and_then(|v| v.as_u64())
+        .unwrap_or_else(|| panic!("user_question must carry an id, got {question}"));
+    let question_text = question
+        .pointer("/questions/0/question")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("user_question must carry the question text, got {question}"));
+    assert_eq!(question_text, "Which color should the widget be?");
+
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "answer_question",
+            "session_id": session_id,
+            "id": question_id,
+            "answers": { question_text: "cerulean" },
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send answer_question");
+
+    // signal_done only fires after the transcript gate saw "cerulean" —
+    // reaching a completed round IS the proof the answer landed.
+    let stderr_ctx = stderr_buf.clone();
+    complete_and_stop_session(&mut ws, &session_id, move || {
+        stderr_ctx.lock().map(|b| b.clone()).unwrap_or_default()
+    })
+    .await;
+
+    let _ = child.kill().await;
+}


### PR DESCRIPTION
Closes the QA-fleet finding: supervised sessions' runtime `askHuman` parked on the `human_question` file, which nothing watches under the daemon — the question was invisible and unanswerable from the dashboard (same class as the #104 supervised-approvals emission gap).

With a dashboard attached, the agent loop now intercepts askHuman batches and routes them through the **same question rail external backends use**: `UserQuestionRequired` (free-text question) → `answer_question` resolves the session's approval registry → the answer becomes the askHuman tool result (JSON loop) or a user message (text loop). Dismissals nudge the model to proceed on its best judgment. The file protocol remains for headless-JSON and MCP shapes. Scope: all-askHuman batches (the shape models emit); mixed batches keep the legacy path and log why. The rail already renders optionless questions as free text — placeholder polish only.

Pinned by e2e `supervised_session_ask_human_reaches_the_question_rail`: CreateSession over /ws → `user_question` tagged with session id + question text → `answer_question` → the mock transcript gate sees the answer as the tool result → round completes.

Not included (tracked follow-up, shared with approvals which also don't rehydrate): pending-question rehydration on reload.

Battery: nextest 2687/2687, clippy baseline, e2e 8/8.