### PR TITLE
Fleet DNS + one-click real certificates for daemons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -978,6 +984,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1126,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-utils"
@@ -1655,6 +1677,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,6 +1996,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,6 +2090,73 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "rand 0.10.1",
+ "ring",
+ "serde",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-server"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "130236ba6abba90da6a7acf7a87b27d862b592c3145dc74bc47bf86d8ff198ec"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipnet",
+ "prefix-trie",
+ "serde",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "hkdf"
@@ -2148,6 +2262,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2170,7 +2285,9 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2417,6 +2534,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant-acme"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f05ad37c421b962354c358d347d4a6130151df9407978372d3ad7f0c8f71a64"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "httpdate",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "rcgen",
+ "ring",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "intendant"
 version = "0.1.0"
 dependencies = [
@@ -2440,9 +2583,11 @@ dependencies = [
  "env_logger",
  "flate2",
  "futures-util",
+ "hickory-server",
  "html2text",
  "if-addrs",
  "image",
+ "instant-acme",
  "intendant-core",
  "intendant-display",
  "intendant-platform",
@@ -2559,6 +2704,9 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -2621,6 +2769,52 @@ checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
  "syn",
 ]
 
@@ -3272,6 +3466,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3721,6 +3919,17 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
 
 [[package]]
 name = "presence-core"
@@ -4661,6 +4870,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5005,6 +5241,16 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -5977,6 +6223,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6381,6 +6636,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6413,6 +6677,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6459,6 +6738,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6471,6 +6756,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6480,6 +6771,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6507,6 +6804,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6516,6 +6819,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6531,6 +6840,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6540,6 +6855,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,15 @@ toml = "0.8"
 uuid = { version = "1", features = ["v4", "serde"] }
 url = "2"
 axum = "0.8"
+# Embedded authoritative DNS for the delegated fleet subzone
+# (bin/connect dns.rs): plain UDP/TCP serving only — no dnssec/tls
+# features, and nothing here may re-enable rustls/aws_lc_rs (the
+# workspace is pinned to the ring provider).
+hickory-server = { version = "0.26", default-features = false }
+# Daemon-side ACME (Let's Encrypt DNS-01) for fleet certificates
+# (bin/caller fleet_cert.rs). ring feature, matching the workspace
+# crypto stack; default aws-lc-rs feature explicitly avoided.
+instant-acme = { version = "0.8", default-features = false, features = ["ring", "hyper-rustls"] }
 passkey-auth = "0.1.3"
 # Used by upload_store for atomic-rename of streamed uploads into the final
 # store location, and by tests elsewhere as a dev-dep.

--- a/docs/src/self-hosted-rendezvous.md
+++ b/docs/src/self-hosted-rendezvous.md
@@ -34,6 +34,9 @@ cargo build --release --bin intendant-connect
 | `--data-file` | `INTENDANT_CONNECT_DATA_FILE` | JSON state (accounts, claims, fleet records) |
 | `--daemon-token` | `INTENDANT_CONNECT_TOKEN` | Bearer token daemons present on the polling endpoints; also the admin-API credential |
 | `--open-registration` | `INTENDANT_CONNECT_OPEN_REGISTRATION` | Let daemons register/poll without the token (rate-limited; unclaimed records expire after a day; the gate moves to claim time). The token keeps guarding the admin API. This is what makes the landing one-liner claimable by people who never saw the token |
+| `--dns-zone` | `INTENDANT_CONNECT_DNS_ZONE` | Fleet DNS: the delegated subzone this service answers for authoritatively (see below). All three `--dns-*` values or none |
+| `--dns-ns-name` | `INTENDANT_CONNECT_DNS_NS_NAME` | The NS host the parent zone delegates to (served in the apex SOA/NS) |
+| `--dns-listen` | `INTENDANT_CONNECT_DNS_LISTEN` | UDP+TCP bind for the DNS server, e.g. `0.0.0.0:53` |
 
 The service speaks plain HTTP; terminate TLS in front of it (nginx,
 Caddy, a cloud load balancer). WebAuthn requires the public origin to be
@@ -59,6 +62,47 @@ connect.example.com {
 	}
 }
 ```
+
+## Fleet DNS: real certificates for daemons
+
+The convenient-direct-path option ([Trust Tiers](./trust-tiers.md)):
+delegate one subzone to the service and every registered daemon gets a
+real name — `d-<hash>.<zone>`, an opaque sha256-derived label (these
+names land in public CT logs) — plus a one-click Let's Encrypt
+certificate from its Access card. The daemon publishes its own
+addresses (LAN addresses are the point: public name + real certificate
++ private address gives a warning-free padlock on your own network with
+no port forwarding), answers the ACME DNS-01 challenge through the
+service with daemon-signed requests, and keeps its private keys local.
+The service's DNS authority covers exactly the subzone and nothing else
+— the zero-authority doctrine applied to DNS.
+
+Setup, one time:
+
+1. In the parent zone (wherever `example.com` is hosted), add two
+   records: `A ns-fleet.example.com → <this box's public IP>` and
+   `NS fleet.example.com → ns-fleet.example.com`. Pin that IP (an
+   elastic/static address) — replacing the box means keeping it.
+2. Open 53/udp and 53/tcp to the box. Binding :53 as a non-root service
+   needs `AmbientCapabilities=CAP_NET_BIND_SERVICE` in the systemd unit.
+3. Run with `--dns-zone fleet.example.com --dns-ns-name
+   ns-fleet.example.com --dns-listen 0.0.0.0:53`.
+
+The register response then carries each daemon's `fleet_dns` name; the
+daemon's Connect card shows it with a **Get a real certificate** button.
+Address records persist in the state file and follow the daemon-record
+lifecycle (they survive claim/release; the stale-unclaimed sweep drops
+them). ACME TXT challenges are in-memory and self-expire. Posture:
+authoritative-only, `Refused` outside the zone, no AXFR, RFC 8482
+minimal `ANY`, 60 s TTLs. Daemons validating against Let's Encrypt
+*staging* set `INTENDANT_ACME_DIRECTORY` to the staging directory URL.
+Honest caveats: a single NS is a SPOF for fleet *names* (enrolled
+browsers keep working via remembered routes; renewals retry), Let's
+Encrypt rate-limits new certificates per registered domain (~50/week —
+request a limit raise before any large fleet), and a hostile zone
+operator could mint certificates for fleet names — key verification
+protects enrolled browsers, and CT logs make mis-issuance public
+evidence.
 
 ## Pointing daemons at it
 

--- a/docs/src/trust-tiers.md
+++ b/docs/src/trust-tiers.md
@@ -121,13 +121,16 @@ was built *for* boxes you do not trust. Apply it there and only there:
 Getting a pleasant direct origin today: the fleet strip offers **↗
 direct** wherever a daemon's own URL is known, and the daemon-store vault
 ([Credential Custody](./credential-custody.md#the-vault)) makes that tab
-self-sufficient. For a warning-free padlock, give the daemon a real
-certificate — a hostname you own with a DNS-01 Let's Encrypt cert, or
-`tailscale cert` on a tailnet — otherwise accept the browser's one-time
-exception for the self-signed cert and let the enrollment ceremony carry
-identity from there. A fleet-DNS service that mints per-daemon names and
-certificates automatically (the Tailscale pattern, operated by the
-rendezvous as pure plumbing) is the designed follow-on.
+self-sufficient. For the warning-free padlock, **fleet certificates** do
+it in one click: a rendezvous serving a delegated DNS subzone
+([Self-Hosted Rendezvous → Fleet DNS](./self-hosted-rendezvous.md#fleet-dns-real-certificates-for-daemons))
+gives each daemon a real name, and the Connect card's *Get a real
+certificate* button publishes the daemon's addresses (LAN included — no
+port forwarding needed) and mints a Let's Encrypt certificate via DNS-01,
+renewed automatically, private keys never leaving the machine. Without
+fleet DNS, the manual routes remain: a hostname you own with a DNS-01
+cert, `tailscale cert` on a tailnet, or the browser's one-time exception
+plus the enrollment ceremony.
 
 A worked example, one fleet:
 

--- a/src/bin/caller/connect_rendezvous.rs
+++ b/src/bin/caller/connect_rendezvous.rs
@@ -89,6 +89,19 @@ struct RegisterResponse {
     /// authority).
     #[serde(default)]
     observed_ip: Option<String>,
+    /// Fleet DNS hint: this daemon's derived name under the rendezvous's
+    /// delegated zone, when it serves one (fleet certificates —
+    /// `fleet_cert.rs`).
+    #[serde(default)]
+    fleet_dns: Option<FleetDnsHint>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FleetDnsHint {
+    #[serde(default)]
+    zone: String,
+    #[serde(default)]
+    name: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -850,6 +863,20 @@ fn note_register_response(response: &RegisterResponse, base_url: &Url) {
     };
     let now = crate::access::client_key::now_unix_ms();
     let mut print_claim: Option<String> = None;
+    // Fleet DNS: hand the name to the certificate machinery (it installs
+    // any stored certificate the first time the name is learned).
+    crate::fleet_cert::note_fleet_dns(
+        response
+            .fleet_dns
+            .as_ref()
+            .map(|hint| hint.zone.clone())
+            .filter(|zone| !zone.is_empty()),
+        response
+            .fleet_dns
+            .as_ref()
+            .map(|hint| hint.name.clone())
+            .filter(|name| !name.is_empty()),
+    );
     with_status(|status| {
         status.registered = true;
         status.last_register_unix_ms = Some(now);
@@ -1752,6 +1779,150 @@ pub(crate) async fn request_unclaim(config: &ConnectConfig) -> Result<bool, Stri
     Ok(changed)
 }
 
+/* ── Fleet DNS: daemon-signed record publishes (fleet_cert.rs) ──
+Payloads REPLICATE bin/connect/rendezvous.rs (twin golden test below);
+same resolution + signing discipline as request_unclaim. */
+
+const DNS_PUBLISH_PROTOCOL: &str = "intendant-connect-dns-publish-v1";
+const DNS_ACME_PROTOCOL: &str = "intendant-connect-dns-acme-v1";
+
+fn dns_publish_signing_payload(
+    daemon_id: &str,
+    daemon_public_key: &str,
+    issued_at_unix_ms: u64,
+    addresses_csv: &str,
+) -> String {
+    format!(
+        "{DNS_PUBLISH_PROTOCOL}\n{daemon_id}\n{daemon_public_key}\n{issued_at_unix_ms}\n{addresses_csv}\n"
+    )
+}
+
+fn dns_acme_signing_payload(
+    daemon_id: &str,
+    daemon_public_key: &str,
+    issued_at_unix_ms: u64,
+    txt_value: &str,
+) -> String {
+    format!(
+        "{DNS_ACME_PROTOCOL}\n{daemon_id}\n{daemon_public_key}\n{issued_at_unix_ms}\n{txt_value}\n"
+    )
+}
+
+/// The signing context every fleet-DNS call needs: effective config,
+/// rendezvous URL, identity, and the effective daemon id.
+fn dns_signing_context() -> Result<(ConnectConfig, Url, DaemonIdentity, String), String> {
+    let mut config = crate::project::ConnectConfig::default().effective_with_env();
+    if config.rendezvous_url.is_none() {
+        config.rendezvous_url = status_snapshot().rendezvous_url;
+    }
+    if config.daemon_id.is_none() {
+        config.daemon_id = status_snapshot().daemon_id;
+    }
+    let base_url = config
+        .rendezvous_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .ok_or_else(|| "no rendezvous configured".to_string())?;
+    let base_url = Url::parse(base_url).map_err(|e| format!("invalid rendezvous_url: {e}"))?;
+    let identity = DaemonIdentity::load_or_create_default()?;
+    let daemon_id = config
+        .daemon_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| identity.public_key_b64u());
+    Ok((config, base_url, identity, daemon_id))
+}
+
+async fn dns_signed_post(
+    path: &str,
+    protocol: &str,
+    payload_tail: &str,
+    extra: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let (config, base_url, identity, daemon_id) = dns_signing_context()?;
+    let daemon_public_key = identity.public_key_b64u();
+    let issued_at_unix_ms = crate::access::client_key::now_unix_ms().max(0) as u64;
+    let payload = format!(
+        "{protocol}\n{daemon_id}\n{daemon_public_key}\n{issued_at_unix_ms}\n{payload_tail}\n"
+    );
+    let mut body = serde_json::json!({
+        "protocol": protocol,
+        "daemon_id": daemon_id,
+        "daemon_public_key": daemon_public_key,
+        "issued_at_unix_ms": issued_at_unix_ms,
+        "signature": identity.sign_b64u(payload.as_bytes()),
+    });
+    if let (Some(map), Some(extra_map)) = (body.as_object_mut(), extra.as_object()) {
+        for (key, value) in extra_map {
+            map.insert(key.clone(), value.clone());
+        }
+    }
+    let client = Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|e| e.to_string())?;
+    let response = authenticated(&config, client.post(join_url(&base_url, path)?))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!("dns publish rejected: HTTP {status} {text}"));
+    }
+    response.json().await.map_err(|e| e.to_string())
+}
+
+/// Publish this daemon's A/AAAA addresses for its fleet name. Returns
+/// the address list the service accepted.
+pub(crate) async fn dns_publish_addresses(addresses: &[String]) -> Result<Vec<String>, String> {
+    let addresses_csv = addresses.join(",");
+    let body = dns_signed_post(
+        "api/dns/publish",
+        DNS_PUBLISH_PROTOCOL,
+        &addresses_csv,
+        serde_json::json!({ "addresses": addresses }),
+    )
+    .await?;
+    Ok(body
+        .get("addresses")
+        .and_then(|value| value.as_array())
+        .map(|list| {
+            list.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default())
+}
+
+/// Publish an ACME DNS-01 TXT value for this daemon's name.
+pub(crate) async fn dns_acme_set(txt_value: &str) -> Result<(), String> {
+    dns_signed_post(
+        "api/dns/acme-challenge",
+        DNS_ACME_PROTOCOL,
+        txt_value,
+        serde_json::json!({ "txt_value": txt_value }),
+    )
+    .await
+    .map(|_| ())
+}
+
+/// Clear this daemon's ACME TXT records (order finished either way).
+pub(crate) async fn dns_acme_clear() -> Result<(), String> {
+    dns_signed_post(
+        "api/dns/acme-challenge",
+        DNS_ACME_PROTOCOL,
+        "",
+        serde_json::json!({ "clear": true }),
+    )
+    .await
+    .map(|_| ())
+}
+
 async fn post_error(
     client: &Client,
     base_url: &Url,
@@ -2131,6 +2302,19 @@ mod tests {
             unclaim_signing_payload("daemon-1", "PubKey", 1_700_000_000_000),
             "intendant-connect-unclaim-v1\ndaemon-1\nPubKey\n1700000000000\n"
         );
+        assert_eq!(
+            dns_publish_signing_payload(
+                "daemon-1",
+                "PubKey",
+                1_700_000_000_000,
+                "192.168.1.50,2001:db8::7"
+            ),
+            "intendant-connect-dns-publish-v1\ndaemon-1\nPubKey\n1700000000000\n192.168.1.50,2001:db8::7\n"
+        );
+        assert_eq!(
+            dns_acme_signing_payload("daemon-1", "PubKey", 1_700_000_000_000, "tok-value"),
+            "intendant-connect-dns-acme-v1\ndaemon-1\nPubKey\n1700000000000\ntok-value\n"
+        );
     }
 
     /// Twin of the service's normalize/hash tests — one shared literal
@@ -2318,6 +2502,7 @@ mod tests {
                 claim_code_expires_unix_ms: None,
                 claim_url: None,
                 observed_ip: None,
+                fleet_dns: None,
             },
             &base_url,
         );
@@ -2336,6 +2521,7 @@ mod tests {
                 claim_code_expires_unix_ms: None,
                 claim_url: None,
                 observed_ip: None,
+                fleet_dns: None,
             },
             &base_url,
         );
@@ -2357,6 +2543,7 @@ mod tests {
                     "https://connect.example/connect?claim_code=word-word-word".to_string(),
                 ),
                 observed_ip: None,
+                fleet_dns: None,
             },
             &base_url,
         );

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -481,6 +481,42 @@ pub(crate) fn control_frame_response(
                         })),
                     }
                 }
+                "api_fleet_cert_request" => {
+                    // Optional explicit addresses; default = every
+                    // routable local address (the LAN is the point).
+                    let addresses: Vec<String> = params
+                        .as_ref()
+                        .and_then(|p| p.get("addresses"))
+                        .and_then(|v| v.as_array())
+                        .map(|list| {
+                            list.iter()
+                                .filter_map(|v| v.as_str().map(str::to_string))
+                                .collect()
+                        })
+                        .filter(|list: &Vec<String>| !list.is_empty())
+                        .unwrap_or_else(crate::fleet_cert::default_publish_addresses);
+                    if crate::fleet_cert::status_snapshot().name.is_none() {
+                        return Some(dashboard_control_error_response(
+                            id,
+                            "this daemon has no fleet name — enable Connect against a \
+                             rendezvous with fleet DNS and let it register first",
+                        ));
+                    }
+                    let spawned_addresses = addresses.clone();
+                    tokio::spawn(async move {
+                        if let Err(error) =
+                            crate::fleet_cert::request_certificate(spawned_addresses).await
+                        {
+                            eprintln!("[fleet-cert] request failed: {error}");
+                        }
+                    });
+                    Some(serde_json::json!({
+                        "t": "response",
+                        "id": id,
+                        "ok": true,
+                        "result": { "started": true, "addresses": addresses },
+                    }))
+                }
                 "api_access_org_trust"
                 | "api_access_org_revoke"
                 | "api_access_org_issue"

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -152,6 +152,10 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
     // the hosted-control ceiling knob (mirrors the HTTP route rows).
     method("api_access_set_tier", PeerOperation::AccessManage),
     method("api_access_set_hosted_ceiling", PeerOperation::AccessManage),
+    // Fleet certificate: publish this daemon's addresses for its fleet
+    // name and run the ACME DNS-01 order (fleet_cert.rs). Slow flow,
+    // started async; progress rides the connect status payload.
+    method("api_fleet_cert_request", PeerOperation::AccessManage),
     // Credential custody (vault leases + client egress): granting, renewing,
     // revoking, and even reading lease status all sit behind the dedicated
     // gate — a scoped guest session can neither fuel nor drain a daemon, nor

--- a/src/bin/caller/fleet_cert.rs
+++ b/src/bin/caller/fleet_cert.rs
@@ -1,0 +1,385 @@
+//! Fleet certificates: a real, browser-trusted certificate for this
+//! daemon's fleet name (docs/src/trust-tiers.md; the convenient direct
+//! path). The rendezvous serves a delegated DNS subzone and this daemon
+//! owns exactly one name under it — `d-<hash>.<zone>`, derived from its
+//! Connect daemon id. Flow, all daemon-side:
+//!
+//! 1. the register response carries the `fleet_dns` hint (zone + name);
+//! 2. on request, the daemon publishes its routable addresses for the
+//!    name (LAN addresses are the point: public name + real certificate
+//!    + private address needs no port forwarding);
+//! 3. ACME (Let's Encrypt, DNS-01 via `instant-acme`): the TXT
+//!    challenge is published through the rendezvous with a
+//!    daemon-signed request — the ACME account key and the certificate
+//!    private key never leave this machine;
+//! 4. the minted certificate is installed live into the web gateway's
+//!    SNI resolver (`web_tls::install_fleet_certificate`) and persisted
+//!    beside the access certs; a background loop renews it.
+//!
+//! Honest limits: certificate names appear in public CT logs (the label
+//! is an opaque hash for exactly that reason), and a hostile zone
+//! operator could mint certificates for fleet names — enrolled browsers
+//! stay safe via key verification, and CT makes mis-issuance public
+//! evidence.
+
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+/// The daemon's fleet label: `d-<hex(sha256(daemon_id))[..20]>` —
+/// REPLICATES `bin/connect/dns.rs::daemon_label` (the two binaries never
+/// link each other); the golden test below twins the service's.
+pub fn daemon_fleet_label(daemon_id: &str) -> Option<String> {
+    use sha2::{Digest, Sha256};
+    let id = daemon_id.trim();
+    if id.is_empty() {
+        return None;
+    }
+    let digest = Sha256::digest(id.as_bytes());
+    let hex: String = digest
+        .iter()
+        .take(10)
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    Some(format!("d-{hex}"))
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct FleetCertStatus {
+    /// The delegated zone the rendezvous serves, from the register
+    /// response (`None` = rendezvous has no fleet DNS).
+    pub zone: Option<String>,
+    /// This daemon's fully qualified fleet name.
+    pub name: Option<String>,
+    /// none | requesting | valid | error
+    pub state: String,
+    pub not_after_unix_ms: Option<u64>,
+    pub last_error: Option<String>,
+    /// Addresses last published for the name (what the A/AAAA records say).
+    pub addresses: Vec<String>,
+}
+
+fn registry() -> &'static Mutex<FleetCertStatus> {
+    static STATUS: OnceLock<Mutex<FleetCertStatus>> = OnceLock::new();
+    STATUS.get_or_init(|| {
+        Mutex::new(FleetCertStatus {
+            state: "none".to_string(),
+            ..Default::default()
+        })
+    })
+}
+
+pub fn status_snapshot() -> FleetCertStatus {
+    registry().lock().expect("fleet cert status poisoned").clone()
+}
+
+fn with_status(update: impl FnOnce(&mut FleetCertStatus)) {
+    let mut status = registry().lock().expect("fleet cert status poisoned");
+    update(&mut status);
+}
+
+/// Called from the Connect client when a register response carries the
+/// fleet_dns hint. Also loads any existing on-disk certificate state the
+/// first time the name is learned.
+pub fn note_fleet_dns(zone: Option<String>, name: Option<String>) {
+    let newly_named = {
+        let mut status = registry().lock().expect("fleet cert status poisoned");
+        let newly_named = name.is_some() && status.name != name;
+        status.zone = zone;
+        status.name = name;
+        newly_named
+    };
+    if newly_named {
+        refresh_installed_state();
+    }
+}
+
+fn cert_dir() -> PathBuf {
+    crate::access::backend::select_backend().cert_dir()
+}
+
+fn cert_path() -> PathBuf {
+    cert_dir().join("fleet-cert.pem")
+}
+
+fn key_path() -> PathBuf {
+    cert_dir().join("fleet-key.pem")
+}
+
+fn acme_account_path() -> PathBuf {
+    cert_dir().join("acme-account.json")
+}
+
+/// Certificate expiry (`not_after`, unix ms) from a PEM chain's leaf.
+fn cert_not_after_unix_ms(cert_pem: &str) -> Option<u64> {
+    let leaf = pem_certificates(cert_pem).into_iter().next()?;
+    let (_, parsed) = x509_parser::parse_x509_certificate(&leaf).ok()?;
+    let seconds = parsed.validity().not_after.timestamp();
+    (seconds > 0).then(|| seconds as u64 * 1000)
+}
+
+fn pem_certificates(pem: &str) -> Vec<Vec<u8>> {
+    use rustls::pki_types::pem::PemObject;
+    rustls::pki_types::CertificateDer::pem_slice_iter(pem.as_bytes())
+        .filter_map(|item| item.ok())
+        .map(|der| der.as_ref().to_vec())
+        .collect()
+}
+
+/// Load on-disk certificate state into the registry and the live TLS
+/// resolver (startup + after learning the name). Quietly does nothing
+/// when no certificate exists yet.
+pub fn refresh_installed_state() {
+    let (Ok(cert_pem), Ok(key_pem)) = (
+        std::fs::read_to_string(cert_path()),
+        std::fs::read_to_string(key_path()),
+    ) else {
+        return;
+    };
+    let Some(name) = status_snapshot().name else {
+        // Cert on disk but no name learned yet: install once the
+        // register response names us (note_fleet_dns re-runs this).
+        return;
+    };
+    let not_after = cert_not_after_unix_ms(&cert_pem);
+    match crate::web_tls::install_fleet_certificate(&name, &cert_pem, &key_pem) {
+        Ok(()) => with_status(|status| {
+            status.state = "valid".to_string();
+            status.not_after_unix_ms = not_after;
+            status.last_error = None;
+        }),
+        Err(error) => with_status(|status| {
+            status.state = "error".to_string();
+            status.last_error = Some(format!("install stored certificate: {error}"));
+        }),
+    }
+}
+
+fn now_unix_ms() -> u64 {
+    crate::access::client_key::now_unix_ms().max(0) as u64
+}
+
+/// The ACME directory: Let's Encrypt production unless overridden (the
+/// staging directory for rig runs: `INTENDANT_ACME_DIRECTORY`).
+fn acme_directory() -> String {
+    std::env::var("INTENDANT_ACME_DIRECTORY")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| instant_acme::LetsEncrypt::Production.url().to_string())
+}
+
+async fn acme_account() -> Result<instant_acme::Account, String> {
+    let path = acme_account_path();
+    if let Ok(stored) = std::fs::read_to_string(&path) {
+        if let Ok(credentials) = serde_json::from_str::<instant_acme::AccountCredentials>(&stored)
+        {
+            return instant_acme::Account::builder()
+                .map_err(|e| format!("acme http client: {e}"))?
+                .from_credentials(credentials)
+                .await
+                .map_err(|e| format!("restore acme account: {e}"));
+        }
+    }
+    let (account, credentials) = instant_acme::Account::builder()
+        .map_err(|e| format!("acme http client: {e}"))?
+        .create(
+            &instant_acme::NewAccount {
+                contact: &[],
+                terms_of_service_agreed: true,
+                only_return_existing: false,
+            },
+            acme_directory(),
+            None,
+        )
+        .await
+        .map_err(|e| format!("create acme account: {e}"))?;
+    let serialized = serde_json::to_string(&credentials)
+        .map_err(|e| format!("serialize acme credentials: {e}"))?;
+    write_private(&path, serialized.as_bytes())?;
+    Ok(account)
+}
+
+fn write_private(path: &std::path::Path, bytes: &[u8]) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    std::fs::write(path, bytes).map_err(|e| format!("write {}: {e}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(metadata) = std::fs::metadata(path) {
+            let mut perms = metadata.permissions();
+            perms.set_mode(0o600);
+            let _ = std::fs::set_permissions(path, perms);
+        }
+    }
+    Ok(())
+}
+
+/// The default addresses to publish: every routable local address (LAN
+/// included — that is the point), loopback excluded, capped at 8.
+pub fn default_publish_addresses() -> Vec<String> {
+    let mut addresses: Vec<String> = intendant_core::net::routable_local_addrs(false)
+        .into_iter()
+        .map(|ip| ip.to_string())
+        .collect();
+    addresses.dedup();
+    addresses.truncate(8);
+    addresses
+}
+
+/// One guarded flow at a time — a second request while one runs is a
+/// no-op with an honest error.
+fn request_in_flight() -> &'static std::sync::atomic::AtomicBool {
+    static FLAG: OnceLock<std::sync::atomic::AtomicBool> = OnceLock::new();
+    FLAG.get_or_init(|| std::sync::atomic::AtomicBool::new(false))
+}
+
+/// Publish addresses + run the ACME DNS-01 order + install the result.
+/// Slow (Let's Encrypt polling); callers spawn it and watch the status
+/// registry.
+pub async fn request_certificate(addresses: Vec<String>) -> Result<(), String> {
+    use std::sync::atomic::Ordering;
+    if request_in_flight().swap(true, Ordering::SeqCst) {
+        return Err("a certificate request is already running".to_string());
+    }
+    let result = request_certificate_inner(addresses).await;
+    request_in_flight().store(false, Ordering::SeqCst);
+    if let Err(error) = &result {
+        with_status(|status| {
+            status.state = "error".to_string();
+            status.last_error = Some(error.clone());
+        });
+    }
+    result
+}
+
+async fn request_certificate_inner(addresses: Vec<String>) -> Result<(), String> {
+    let snapshot = status_snapshot();
+    let name = snapshot.name.clone().ok_or_else(|| {
+        "this daemon has no fleet name — enable Connect against a rendezvous with fleet DNS"
+            .to_string()
+    })?;
+    with_status(|status| {
+        status.state = "requesting".to_string();
+        status.last_error = None;
+    });
+
+    // 1. Make the name resolve: publish the addresses (daemon-signed).
+    let published = crate::connect_rendezvous::dns_publish_addresses(&addresses).await?;
+    with_status(|status| status.addresses = published.clone());
+
+    // 2. The ACME order.
+    let account = acme_account().await?;
+    let identifiers = [instant_acme::Identifier::Dns(name.clone())];
+    let mut order = account
+        .new_order(&instant_acme::NewOrder::new(&identifiers))
+        .await
+        .map_err(|e| format!("acme new order: {e}"))?;
+
+    let mut authorizations = order.authorizations();
+    while let Some(result) = authorizations.next().await {
+        let mut authz = result.map_err(|e| format!("acme authorization: {e}"))?;
+        match authz.status {
+            instant_acme::AuthorizationStatus::Pending => {}
+            instant_acme::AuthorizationStatus::Valid => continue,
+            other => return Err(format!("acme authorization in unexpected state {other:?}")),
+        }
+        let mut challenge = authz
+            .challenge(instant_acme::ChallengeType::Dns01)
+            .ok_or_else(|| "acme order offers no dns-01 challenge".to_string())?;
+        let txt_value = challenge.key_authorization().dns_value();
+        crate::connect_rendezvous::dns_acme_set(&txt_value).await?;
+        challenge
+            .set_ready()
+            .await
+            .map_err(|e| format!("acme challenge ready: {e}"))?;
+    }
+    drop(authorizations);
+
+    let status = order
+        .poll_ready(&instant_acme::RetryPolicy::default())
+        .await
+        .map_err(|e| format!("acme validation: {e}"))?;
+    if status != instant_acme::OrderStatus::Ready {
+        let _ = crate::connect_rendezvous::dns_acme_clear().await;
+        return Err(format!("acme order did not become ready: {status:?}"));
+    }
+    let private_key_pem = order
+        .finalize()
+        .await
+        .map_err(|e| format!("acme finalize: {e}"))?;
+    let cert_chain_pem = order
+        .poll_certificate(&instant_acme::RetryPolicy::default())
+        .await
+        .map_err(|e| format!("acme certificate: {e}"))?;
+    // Best-effort challenge cleanup; the TXT self-expires regardless.
+    let _ = crate::connect_rendezvous::dns_acme_clear().await;
+
+    // 3. Persist + install live.
+    write_private(&key_path(), private_key_pem.as_bytes())?;
+    write_private(&cert_path(), cert_chain_pem.as_bytes())?;
+    crate::web_tls::install_fleet_certificate(&name, &cert_chain_pem, &private_key_pem)?;
+    with_status(|status| {
+        status.state = "valid".to_string();
+        status.not_after_unix_ms = cert_not_after_unix_ms(&cert_chain_pem);
+        status.last_error = None;
+    });
+    Ok(())
+}
+
+/// Renewal loop: daily check, renew inside the last 30 days of validity
+/// (Let's Encrypt certificates run 90). Spawned once at gateway startup.
+pub fn spawn_renewal_loop() {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(12 * 60 * 60)).await;
+            let status = status_snapshot();
+            let Some(not_after) = status.not_after_unix_ms else {
+                continue;
+            };
+            if status.state != "valid" || status.name.is_none() {
+                continue;
+            }
+            let remaining_ms = not_after.saturating_sub(now_unix_ms());
+            if remaining_ms > 30 * 24 * 60 * 60 * 1000 {
+                continue;
+            }
+            let addresses = if status.addresses.is_empty() {
+                default_publish_addresses()
+            } else {
+                status.addresses.clone()
+            };
+            if let Err(error) = request_certificate(addresses).await {
+                eprintln!("[fleet-cert] renewal failed: {error}");
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fleet_label_twins_the_service_derivation() {
+        // Golden value pinned in bin/connect/dns.rs — change together.
+        assert_eq!(
+            daemon_fleet_label("example-daemon-id").as_deref(),
+            Some("d-30a08371a38c1b447038")
+        );
+        assert!(daemon_fleet_label(" ").is_none());
+    }
+
+    #[test]
+    fn not_after_parses_a_real_certificate() {
+        // A throwaway self-signed cert exercises the PEM + x509 path.
+        let key = rcgen::KeyPair::generate().unwrap();
+        let cert = rcgen::CertificateParams::new(vec!["d-test.fleet.example.test".to_string()])
+            .unwrap()
+            .self_signed(&key)
+            .unwrap();
+        let not_after = cert_not_after_unix_ms(&cert.pem()).unwrap();
+        assert!(not_after > now_unix_ms());
+    }
+}

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -29,6 +29,7 @@ mod event;
 mod external_agent;
 mod external_wrapper_index;
 mod file_watcher;
+mod fleet_cert;
 mod fission_ledger;
 mod fission_lifecycle;
 pub(crate) use intendant_core::frames;

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -487,6 +487,10 @@ pub fn spawn_web_gateway(
         dashboard_control.clone(),
         tcp_advertised_port,
     );
+    // Fleet certificates: restore any stored certificate into the live
+    // SNI resolver and keep it renewed (fleet_cert.rs).
+    crate::fleet_cert::refresh_installed_state();
+    crate::fleet_cert::spawn_renewal_loop();
 
     // F-1.3b3 federated authority subscribers. Federated counterpart
     // to local 5c's per-WS subscriber loop: federated browsers don't

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -429,6 +429,15 @@ pub(crate) async fn handle_access_iam_state(
 /// a code exists and when it expires.
 pub(crate) fn access_connect_status_response_value() -> serde_json::Value {
     let status = crate::connect_rendezvous::status_snapshot();
+    let fleet_cert = crate::fleet_cert::status_snapshot();
+    let fleet_cert_value = serde_json::json!({
+        "zone": fleet_cert.zone,
+        "name": fleet_cert.name,
+        "state": fleet_cert.state,
+        "not_after_unix_ms": fleet_cert.not_after_unix_ms,
+        "last_error": fleet_cert.last_error,
+        "addresses": fleet_cert.addresses,
+    });
     serde_json::json!({
         "schema_version": 1,
         "configured": status.configured,
@@ -448,6 +457,7 @@ pub(crate) fn access_connect_status_response_value() -> serde_json::Value {
         "claim_code_expires_unix_ms": status.claim_code_expires_unix_ms,
         "bootstrap": status.bootstrap,
         "default_rendezvous_url": crate::project::DEFAULT_CONNECT_RENDEZVOUS_URL,
+        "fleet_cert": fleet_cert_value,
     })
 }
 

--- a/src/bin/caller/web_tls.rs
+++ b/src/bin/caller/web_tls.rs
@@ -225,14 +225,92 @@ fn server_config_from(
             builder.with_client_cert_verifier(verifier)
         }
     };
-    let mut config = builder
-        .with_single_cert(cert_chain, key)
-        .map_err(|e| format!("rustls server config (cert/key) failed: {e}"))?;
+    // A resolver instead of `with_single_cert`: the base cert (installed
+    // access certs or the startup self-signed) answers by default, and a
+    // fleet certificate (fleet_cert.rs) can be installed LIVE for its
+    // SNI name — first issuance and every renewal apply without a daemon
+    // restart.
+    let signing_key = rustls::crypto::ring::sign::any_supported_type(&key)
+        .map_err(|e| format!("rustls server key unusable: {e}"))?;
+    let base = Arc::new(rustls::sign::CertifiedKey::new(cert_chain, signing_key));
+    fleet_sni_resolver().set_base(base);
+    let mut config = builder.with_cert_resolver(fleet_sni_resolver());
     // The dashboard speaks HTTP/1.1 and upgrades to WebSocket; advertise
     // only http/1.1 so a browser never negotiates h2 (which the gateway's
     // hand-rolled HTTP/1 handler doesn't implement).
     config.alpn_protocols = vec![b"http/1.1".to_vec()];
     Ok(config)
+}
+
+/// SNI-aware certificate resolver: the daemon's base certificate by
+/// default; the fleet certificate for requests naming the fleet name.
+/// Process-global so `fleet_cert.rs` can hot-swap certificates into the
+/// running acceptor.
+#[derive(Debug, Default)]
+pub struct FleetSniResolver {
+    base: std::sync::RwLock<Option<Arc<rustls::sign::CertifiedKey>>>,
+    fleet: std::sync::RwLock<Option<(String, Arc<rustls::sign::CertifiedKey>)>>,
+}
+
+impl FleetSniResolver {
+    fn set_base(&self, key: Arc<rustls::sign::CertifiedKey>) {
+        *self.base.write().expect("tls resolver poisoned") = Some(key);
+    }
+
+    fn set_fleet(&self, name: String, key: Arc<rustls::sign::CertifiedKey>) {
+        *self.fleet.write().expect("tls resolver poisoned") = Some((name, key));
+    }
+}
+
+impl rustls::server::ResolvesServerCert for FleetSniResolver {
+    fn resolve(
+        &self,
+        client_hello: rustls::server::ClientHello<'_>,
+    ) -> Option<Arc<rustls::sign::CertifiedKey>> {
+        if let Some(server_name) = client_hello.server_name() {
+            let fleet = self.fleet.read().expect("tls resolver poisoned");
+            if let Some((name, key)) = fleet.as_ref() {
+                if server_name.eq_ignore_ascii_case(name) {
+                    return Some(key.clone());
+                }
+            }
+        }
+        self.base.read().expect("tls resolver poisoned").clone()
+    }
+}
+
+fn fleet_sni_resolver() -> Arc<FleetSniResolver> {
+    static RESOLVER: std::sync::OnceLock<Arc<FleetSniResolver>> = std::sync::OnceLock::new();
+    RESOLVER
+        .get_or_init(|| Arc::new(FleetSniResolver::default()))
+        .clone()
+}
+
+/// Install (or replace) the fleet certificate served for `name` —
+/// called by `fleet_cert.rs` at startup-restore, first issuance, and
+/// every renewal. Applies to live acceptors immediately.
+pub fn install_fleet_certificate(
+    name: &str,
+    cert_chain_pem: &str,
+    key_pem: &str,
+) -> Result<(), String> {
+    use rustls::pki_types::pem::PemObject;
+    let cert_chain: Vec<rustls::pki_types::CertificateDer<'static>> =
+        rustls::pki_types::CertificateDer::pem_slice_iter(cert_chain_pem.as_bytes())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("parse fleet certificate: {e}"))?;
+    if cert_chain.is_empty() {
+        return Err("fleet certificate PEM holds no certificates".to_string());
+    }
+    let key = rustls::pki_types::PrivateKeyDer::from_pem_slice(key_pem.as_bytes())
+        .map_err(|e| format!("parse fleet key: {e}"))?;
+    let signing_key = rustls::crypto::ring::sign::any_supported_type(&key)
+        .map_err(|e| format!("fleet key unusable: {e}"))?;
+    fleet_sni_resolver().set_fleet(
+        name.trim().trim_end_matches('.').to_ascii_lowercase(),
+        Arc::new(rustls::sign::CertifiedKey::new(cert_chain, signing_key)),
+    );
+    Ok(())
 }
 
 pub fn load_ca_roots(ca_path: &std::path::Path) -> Result<RootCertStore, String> {

--- a/src/bin/connect/dns.rs
+++ b/src/bin/connect/dns.rs
@@ -1,0 +1,648 @@
+//! Embedded authoritative DNS for the delegated fleet subzone
+//! (docs/src/self-hosted-rendezvous.md; docs/src/trust-tiers.md).
+//!
+//! The convenient-direct-path design: the parent zone NS-delegates one
+//! subzone (e.g. `fleet.intendant.dev`) to this service, which answers
+//! for exactly that subzone and nothing else — the DNS twin of the
+//! zero-authority doctrine. Records served:
+//!
+//! - apex `SOA` / `NS` (this server, via the parent-zone glue name);
+//! - `d-<daemon-id>.<zone>` `A`/`AAAA` — addresses a registered daemon
+//!   published for itself (LAN addresses are legitimate: public name +
+//!   real certificate + private address is the whole point);
+//! - `_acme-challenge.d-<daemon-id>.<zone>` `TXT` — short-lived ACME
+//!   DNS-01 tokens a daemon published while minting its certificate.
+//!
+//! Posture: authoritative-only (no recursion), `Refused` outside the
+//! zone, AXFR/IXFR refused, `ANY` answered minimally per RFC 8482,
+//! low TTLs (daemon addresses move). Publishing is authenticated at the
+//! HTTP layer (daemon-signed requests against the registered identity
+//! key — the same freshness pattern as unclaim); this module only
+//! serves what the store hands it.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::RwLock;
+
+use hickory_server::net::runtime::Time;
+use hickory_server::proto::op::{Header, HeaderCounts, MessageType, Metadata, OpCode, ResponseCode};
+use hickory_server::proto::rr::rdata::{HINFO, NS, SOA, TXT};
+use hickory_server::proto::rr::{Name, RData, Record, RecordType};
+use hickory_server::server::{Request, RequestHandler, ResponseHandler, ResponseInfo};
+use hickory_server::zone_handler::MessageResponseBuilder;
+
+/// Answer TTL for daemon records — addresses move (laptops roam, boxes
+/// get replaced), so resolvers must not cache long.
+const RECORD_TTL: u32 = 60;
+/// Apex SOA/NS TTL.
+const APEX_TTL: u32 = 300;
+/// How long a published ACME TXT stays served before it self-expires.
+/// Let's Encrypt validates within seconds of being told to; ten minutes
+/// covers retries without leaving stale tokens around.
+pub const ACME_TXT_TTL_MS: u64 = 10 * 60 * 1000;
+
+/// The label under the zone for a daemon id: `d-<hex(sha256(id))[..20]>`.
+///
+/// Derived, not verbatim: daemon ids default to the base64url public key
+/// (43 chars, may contain `_`) or are operator-chosen free text — neither
+/// is a valid DNS label. A truncated hash is DNS-safe, deterministic on
+/// BOTH sides (the daemon derives its own name offline — twin-pinned in
+/// `bin/caller/fleet_cert.rs`), and opaque: these names end up in public
+/// CT logs, so nothing meaningful may ride in them. 80 bits keeps
+/// accidental collisions out of reach at any plausible fleet size.
+pub fn daemon_label(daemon_id: &str) -> Option<String> {
+    use sha2::{Digest, Sha256};
+    let id = daemon_id.trim();
+    if id.is_empty() {
+        return None;
+    }
+    let digest = Sha256::digest(id.as_bytes());
+    let hex: String = digest
+        .iter()
+        .take(10)
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    Some(format!("d-{hex}"))
+}
+
+#[derive(Default)]
+struct ZoneData {
+    /// label (`d-<id>`) → published addresses.
+    v4: HashMap<String, Vec<Ipv4Addr>>,
+    v6: HashMap<String, Vec<Ipv6Addr>>,
+    /// label (`d-<id>`) → active ACME TXT values with their expiry.
+    acme_txt: HashMap<String, Vec<(String, u64)>>,
+}
+
+/// The zone: origin, glue NS name, and the dynamic record table.
+pub struct FleetZone {
+    origin: Name,
+    ns_name: Name,
+    serial: AtomicU32,
+    data: RwLock<ZoneData>,
+}
+
+impl FleetZone {
+    pub fn new(zone: &str, ns_name: &str) -> Result<Self, String> {
+        let mut origin = Name::from_utf8(zone)
+            .map_err(|e| format!("invalid dns zone {zone:?}: {e}"))?
+            .to_lowercase();
+        // Config values arrive without the trailing dot; queries arrive
+        // fully qualified — normalize so apex equality holds.
+        origin.set_fqdn(true);
+        let mut ns_name = Name::from_utf8(ns_name)
+            .map_err(|e| format!("invalid dns ns name {ns_name:?}: {e}"))?
+            .to_lowercase();
+        ns_name.set_fqdn(true);
+        if origin.is_root() || origin.num_labels() < 2 {
+            return Err(format!("dns zone {zone:?} is too broad to serve"));
+        }
+        Ok(Self {
+            origin,
+            ns_name,
+            serial: AtomicU32::new(1),
+            data: RwLock::new(ZoneData::default()),
+        })
+    }
+
+    pub fn origin_utf8(&self) -> String {
+        self.origin.to_utf8().trim_end_matches('.').to_string()
+    }
+
+    /// The fully qualified name a daemon id resolves under, or None for
+    /// an id that cannot be a DNS label.
+    pub fn daemon_fqdn(&self, daemon_id: &str) -> Option<String> {
+        Some(format!("{}.{}", daemon_label(daemon_id)?, self.origin_utf8()))
+    }
+
+    fn bump_serial(&self) {
+        self.serial.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Replace the published addresses for a daemon (empty = remove).
+    pub fn set_daemon_addresses(&self, daemon_id: &str, addresses: &[IpAddr]) -> Result<(), String> {
+        let label = daemon_label(daemon_id).ok_or("daemon id is not a usable DNS label")?;
+        let mut data = self.data.write().expect("fleet zone poisoned");
+        let v4: Vec<Ipv4Addr> = addresses
+            .iter()
+            .filter_map(|ip| match ip {
+                IpAddr::V4(v4) => Some(*v4),
+                IpAddr::V6(_) => None,
+            })
+            .collect();
+        let v6: Vec<Ipv6Addr> = addresses
+            .iter()
+            .filter_map(|ip| match ip {
+                IpAddr::V6(v6) => Some(*v6),
+                IpAddr::V4(_) => None,
+            })
+            .collect();
+        if v4.is_empty() {
+            data.v4.remove(&label);
+        } else {
+            data.v4.insert(label.clone(), v4);
+        }
+        if v6.is_empty() {
+            data.v6.remove(&label);
+        } else {
+            data.v6.insert(label, v6);
+        }
+        drop(data);
+        self.bump_serial();
+        Ok(())
+    }
+
+    /// Drop every record for a daemon (release/sweep lifecycle).
+    pub fn remove_daemon(&self, daemon_id: &str) {
+        let Some(label) = daemon_label(daemon_id) else {
+            return;
+        };
+        let mut data = self.data.write().expect("fleet zone poisoned");
+        let removed = data.v4.remove(&label).is_some()
+            | data.v6.remove(&label).is_some()
+            | data.acme_txt.remove(&label).is_some();
+        drop(data);
+        if removed {
+            self.bump_serial();
+        }
+    }
+
+    /// Publish an ACME DNS-01 TXT value for a daemon (additive within
+    /// the expiry window — Let's Encrypt may probe multiple values
+    /// during retries; expired ones are swept on read and write).
+    pub fn set_acme_txt(&self, daemon_id: &str, value: &str, now_unix_ms: u64) -> Result<(), String> {
+        let label = daemon_label(daemon_id).ok_or("daemon id is not a usable DNS label")?;
+        let value = value.trim();
+        if value.is_empty() || value.len() > 255 {
+            return Err("acme txt value must be 1..=255 bytes".to_string());
+        }
+        let mut data = self.data.write().expect("fleet zone poisoned");
+        let entries = data.acme_txt.entry(label).or_default();
+        entries.retain(|(existing, expires)| *expires > now_unix_ms && existing != value);
+        entries.push((value.to_string(), now_unix_ms + ACME_TXT_TTL_MS));
+        drop(data);
+        self.bump_serial();
+        Ok(())
+    }
+
+    /// Remove a daemon's ACME TXT values (the daemon finished its order).
+    pub fn clear_acme_txt(&self, daemon_id: &str) {
+        let Some(label) = daemon_label(daemon_id) else {
+            return;
+        };
+        let mut data = self.data.write().expect("fleet zone poisoned");
+        let removed = data.acme_txt.remove(&label).is_some();
+        drop(data);
+        if removed {
+            self.bump_serial();
+        }
+    }
+
+    fn soa_record(&self) -> Record {
+        let soa = SOA::new(
+            self.ns_name.clone(),
+            Name::from_utf8(format!("hostmaster.{}", self.origin.to_utf8()))
+                .unwrap_or_else(|_| self.ns_name.clone()),
+            self.serial.load(Ordering::Relaxed),
+            1200,    // refresh
+            300,     // retry
+            604_800, // expire
+            60,      // negative-answer TTL
+        );
+        Record::from_rdata(self.origin.clone(), APEX_TTL, RData::SOA(soa))
+    }
+
+    fn ns_record(&self) -> Record {
+        Record::from_rdata(
+            self.origin.clone(),
+            APEX_TTL,
+            RData::NS(NS(self.ns_name.clone())),
+        )
+    }
+
+    /// Answer a query for `qname`/`qtype`. `None` = the name is outside
+    /// this zone (REFUSED); `Some(answer)` carries the records plus
+    /// whether the name exists at all (NXDOMAIN vs NODATA).
+    fn lookup(&self, qname: &Name, qtype: RecordType, now_unix_ms: u64) -> Option<ZoneAnswer> {
+        let qname = qname.to_lowercase();
+        if !self.origin.zone_of(&qname) {
+            return None;
+        }
+        let mut answer = ZoneAnswer::default();
+
+        if qname == self.origin {
+            answer.name_exists = true;
+            match qtype {
+                RecordType::SOA => answer.records.push(self.soa_record()),
+                RecordType::NS => answer.records.push(self.ns_record()),
+                RecordType::ANY => {
+                    // RFC 8482: a minimal single answer instead of "all".
+                    answer.records.push(Record::from_rdata(
+                        self.origin.clone(),
+                        APEX_TTL,
+                        RData::HINFO(HINFO::new("RFC8482".to_string(), String::new())),
+                    ));
+                }
+                _ => {}
+            }
+            return Some(answer);
+        }
+
+        // Exactly one label under the zone: `d-<id>`, or two labels for
+        // `_acme-challenge.d-<id>`. Anything deeper does not exist.
+        let origin_labels = usize::from(self.origin.num_labels());
+        let relative_labels = usize::from(qname.num_labels()).saturating_sub(origin_labels);
+        let data = self.data.read().expect("fleet zone poisoned");
+        match relative_labels {
+            1 => {
+                let label = label_at(&qname, origin_labels, 0);
+                let v4 = data.v4.get(&label);
+                let v6 = data.v6.get(&label);
+                let has_txt = data
+                    .acme_txt
+                    .get(&label)
+                    .map(|entries| entries.iter().any(|(_, expires)| *expires > now_unix_ms))
+                    .unwrap_or(false);
+                answer.name_exists = v4.is_some() || v6.is_some() || has_txt;
+                match qtype {
+                    RecordType::A => {
+                        for ip in v4.into_iter().flatten() {
+                            answer.records.push(Record::from_rdata(
+                                qname.clone(),
+                                RECORD_TTL,
+                                RData::A((*ip).into()),
+                            ));
+                        }
+                    }
+                    RecordType::AAAA => {
+                        for ip in v6.into_iter().flatten() {
+                            answer.records.push(Record::from_rdata(
+                                qname.clone(),
+                                RECORD_TTL,
+                                RData::AAAA((*ip).into()),
+                            ));
+                        }
+                    }
+                    RecordType::ANY => {
+                        if answer.name_exists {
+                            answer.records.push(Record::from_rdata(
+                                qname.clone(),
+                                RECORD_TTL,
+                                RData::HINFO(HINFO::new("RFC8482".to_string(), String::new())),
+                            ));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            2 => {
+                let challenge = label_at(&qname, origin_labels, 1);
+                let label = label_at(&qname, origin_labels, 0);
+                if challenge == "_acme-challenge" {
+                    if let Some(entries) = data.acme_txt.get(&label) {
+                        let live: Vec<&String> = entries
+                            .iter()
+                            .filter(|(_, expires)| *expires > now_unix_ms)
+                            .map(|(value, _)| value)
+                            .collect();
+                        answer.name_exists = !live.is_empty();
+                        if qtype == RecordType::TXT {
+                            for value in live {
+                                answer.records.push(Record::from_rdata(
+                                    qname.clone(),
+                                    RECORD_TTL,
+                                    RData::TXT(TXT::new(vec![value.clone()])),
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        Some(answer)
+    }
+}
+
+/// Label helper for zone-relative names (labels iterate leftmost-first):
+/// `from_zone` counts up from the zone boundary, so for
+/// `_acme-challenge.d-x.<zone>` with `origin_labels` = the zone's label
+/// count, `from_zone = 0` is `d-x` and `from_zone = 1` is
+/// `_acme-challenge`.
+fn label_at(name: &Name, origin_labels: usize, from_zone: usize) -> String {
+    let labels: Vec<String> = name
+        .iter()
+        .map(|l| String::from_utf8_lossy(l).to_ascii_lowercase())
+        .collect();
+    let relative = labels.len().saturating_sub(origin_labels);
+    match relative.checked_sub(1 + from_zone) {
+        Some(index) => labels.get(index).cloned().unwrap_or_default(),
+        None => String::new(),
+    }
+}
+
+#[derive(Default)]
+struct ZoneAnswer {
+    records: Vec<Record>,
+    name_exists: bool,
+}
+
+/// The hickory request handler: answers for the zone, refuses the rest.
+pub struct FleetZoneHandler {
+    zone: std::sync::Arc<FleetZone>,
+}
+
+impl FleetZoneHandler {
+    pub fn new(zone: std::sync::Arc<FleetZone>) -> Self {
+        Self { zone }
+    }
+}
+
+fn now_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// A `ResponseInfo` for the failed-to-send path (the crate-internal
+/// `ResponseInfo::serve_failed` is not public).
+fn send_failed_info(request_metadata: &Metadata) -> ResponseInfo {
+    let mut metadata = Metadata::response_from_request(request_metadata);
+    metadata.response_code = ResponseCode::ServFail;
+    Header {
+        metadata,
+        counts: HeaderCounts::default(),
+    }
+    .into()
+}
+
+#[async_trait::async_trait]
+impl RequestHandler for FleetZoneHandler {
+    async fn handle_request<R: ResponseHandler, T: Time>(
+        &self,
+        request: &Request,
+        mut response_handle: R,
+    ) -> ResponseInfo {
+        // `Request` derefs to the decoded MessageRequest: `metadata`,
+        // `queries`, and `edns` are direct field reads.
+        let error_code = 'error: {
+            if request.metadata.op_code != OpCode::Query
+                || request.metadata.message_type != MessageType::Query
+            {
+                break 'error Some(ResponseCode::Refused);
+            }
+            let Ok(info) = request.request_info() else {
+                break 'error Some(ResponseCode::FormErr);
+            };
+            if matches!(info.query.query_type(), RecordType::AXFR | RecordType::IXFR) {
+                break 'error Some(ResponseCode::Refused);
+            }
+            None
+        };
+        if let Some(code) = error_code {
+            let response = MessageResponseBuilder::new(&request.queries, None)
+                .error_msg(&request.metadata, code);
+            return match response_handle.send_response(response).await {
+                Ok(info) => info,
+                Err(_) => send_failed_info(&request.metadata),
+            };
+        }
+
+        // Infallible now — checked above.
+        let info = match request.request_info() {
+            Ok(info) => info,
+            Err(_) => return send_failed_info(&request.metadata),
+        };
+        let qtype = info.query.query_type();
+        let qname = Name::from(info.query.name().clone());
+        let Some(answer) = self.zone.lookup(&qname, qtype, now_unix_ms()) else {
+            // Outside the zone: authoritative-only servers refuse.
+            let response = MessageResponseBuilder::new(&request.queries, None)
+                .error_msg(&request.metadata, ResponseCode::Refused);
+            return match response_handle.send_response(response).await {
+                Ok(info) => info,
+                Err(_) => send_failed_info(&request.metadata),
+            };
+        };
+
+        let mut metadata = Metadata::response_from_request(&request.metadata);
+        metadata.authoritative = true;
+        metadata.recursion_available = false;
+        // NODATA (name exists) and NXDOMAIN both carry the SOA in the
+        // authority section for negative caching.
+        let soa_records: Vec<Record> = if answer.records.is_empty() {
+            if !answer.name_exists {
+                metadata.response_code = ResponseCode::NXDomain;
+            }
+            vec![self.zone.soa_record()]
+        } else {
+            Vec::new()
+        };
+        let response = MessageResponseBuilder::new(&request.queries, None).build(
+            metadata,
+            answer.records.iter(),
+            std::iter::empty(),
+            soa_records.iter(),
+            std::iter::empty(),
+        );
+        match response_handle.send_response(response).await {
+            Ok(info) => info,
+            Err(_) => send_failed_info(&request.metadata),
+        }
+    }
+}
+
+/// Bind the zone's UDP + TCP sockets on `listen` and return the serving
+/// future. Binding is eager so a misconfigured listener (privileges,
+/// port in use) fails startup loudly; the returned future is spawned
+/// and runs until process exit like the other connect background tasks.
+pub async fn bind_fleet_dns(
+    zone: std::sync::Arc<FleetZone>,
+    listen: std::net::SocketAddr,
+) -> Result<impl std::future::Future<Output = Result<(), String>>, String> {
+    let udp = tokio::net::UdpSocket::bind(listen)
+        .await
+        .map_err(|e| format!("bind dns udp {listen}: {e}"))?;
+    let tcp = tokio::net::TcpListener::bind(listen)
+        .await
+        .map_err(|e| format!("bind dns tcp {listen}: {e}"))?;
+    let mut server = hickory_server::server::Server::new(FleetZoneHandler::new(zone));
+    server.register_socket(udp);
+    // 5s per-connection timeout; responses are tiny (a handful of
+    // records), so a small per-connection output buffer suffices.
+    server.register_listener(tcp, std::time::Duration::from_secs(5), 4096);
+    Ok(async move {
+        server
+            .block_until_done()
+            .await
+            .map_err(|e| format!("dns server exited: {e}"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn zone() -> FleetZone {
+        FleetZone::new("fleet.example.test", "ns-fleet.example.test").unwrap()
+    }
+
+    fn name(value: &str) -> Name {
+        Name::from_utf8(value).unwrap()
+    }
+
+    #[test]
+    fn daemon_labels_are_derived_dns_safe_and_opaque() {
+        // Golden value — the daemon derives the same label offline
+        // (bin/caller/fleet_cert.rs twin test); change them together.
+        assert_eq!(
+            daemon_label("example-daemon-id").as_deref(),
+            Some("d-30a08371a38c1b447038")
+        );
+        // A default daemon id (43-char base64url public key, `_` and all)
+        // still derives a valid label.
+        let label = daemon_label("j8Xn_qUvT-43charBase64urlPublicKeyExample__").unwrap();
+        assert!(label.starts_with("d-"));
+        assert_eq!(label.len(), 22);
+        assert!(label
+            .chars()
+            .all(|c| c.is_ascii_digit() || c.is_ascii_lowercase() || c == '-'));
+        // Deterministic; whitespace-insensitive; empty refused.
+        assert_eq!(daemon_label(" x "), daemon_label("x"));
+        assert!(daemon_label("").is_none());
+        assert!(daemon_label("   ").is_none());
+        assert_ne!(daemon_label("a"), daemon_label("b"));
+    }
+
+    #[test]
+    fn lookup_serves_apex_daemon_and_acme_records() {
+        let zone = zone();
+        zone.set_daemon_addresses(
+            "abc123",
+            &["192.168.1.50".parse().unwrap(), "2001:db8::7".parse().unwrap()],
+        )
+        .unwrap();
+        zone.set_acme_txt("abc123", "tok-en_VALUE", 1_000).unwrap();
+
+        // Apex SOA + NS.
+        let soa = zone
+            .lookup(&name("fleet.example.test."), RecordType::SOA, 1_000)
+            .unwrap();
+        assert_eq!(soa.records.len(), 1);
+        let ns = zone
+            .lookup(&name("fleet.example.test."), RecordType::NS, 1_000)
+            .unwrap();
+        assert_eq!(ns.records.len(), 1);
+
+        // Daemon A (LAN addresses are legitimate) + AAAA.
+        let a = zone
+            .lookup(&name("d-6ca13d52ca70c883e0f0.fleet.example.test."), RecordType::A, 1_000)
+            .unwrap();
+        assert!(a.name_exists);
+        assert_eq!(a.records.len(), 1);
+        let aaaa = zone
+            .lookup(&name("d-6ca13d52ca70c883e0f0.fleet.example.test."), RecordType::AAAA, 1_000)
+            .unwrap();
+        assert_eq!(aaaa.records.len(), 1);
+
+        // ACME TXT, case-insensitive owner, expiring.
+        let txt = zone
+            .lookup(
+                &name("_ACME-CHALLENGE.D-6CA13D52CA70C883E0F0.fleet.example.test."),
+                RecordType::TXT,
+                1_000,
+            )
+            .unwrap();
+        assert!(txt.name_exists);
+        assert_eq!(txt.records.len(), 1);
+        let expired = zone
+            .lookup(
+                &name("_acme-challenge.d-6ca13d52ca70c883e0f0.fleet.example.test."),
+                RecordType::TXT,
+                1_000 + ACME_TXT_TTL_MS + 1,
+            )
+            .unwrap();
+        assert!(!expired.name_exists);
+        assert!(expired.records.is_empty());
+    }
+
+    #[test]
+    fn lookup_distinguishes_nxdomain_nodata_and_out_of_zone() {
+        let zone = zone();
+        zone.set_daemon_addresses("abc123", &["10.0.0.9".parse().unwrap()])
+            .unwrap();
+
+        // Unknown name: NXDOMAIN.
+        let missing = zone
+            .lookup(&name("d-nope.fleet.example.test."), RecordType::A, 0)
+            .unwrap();
+        assert!(!missing.name_exists);
+        assert!(missing.records.is_empty());
+
+        // Known name, absent type: NODATA.
+        let nodata = zone
+            .lookup(&name("d-6ca13d52ca70c883e0f0.fleet.example.test."), RecordType::AAAA, 0)
+            .unwrap();
+        assert!(nodata.name_exists);
+        assert!(nodata.records.is_empty());
+
+        // Too-deep names do not exist.
+        let deep = zone
+            .lookup(
+                &name("x.y.d-6ca13d52ca70c883e0f0.fleet.example.test."),
+                RecordType::A,
+                0,
+            )
+            .unwrap();
+        assert!(!deep.name_exists);
+
+        // Outside the zone: refused (None).
+        assert!(zone
+            .lookup(&name("example.test."), RecordType::A, 0)
+            .is_none());
+        assert!(zone
+            .lookup(&name("evil.example.com."), RecordType::A, 0)
+            .is_none());
+    }
+
+    #[test]
+    fn lifecycle_updates_replace_and_remove() {
+        let zone = zone();
+        zone.set_daemon_addresses("abc123", &["10.0.0.9".parse().unwrap()])
+            .unwrap();
+        zone.set_daemon_addresses("abc123", &["10.0.0.10".parse().unwrap()])
+            .unwrap();
+        let a = zone
+            .lookup(&name("d-6ca13d52ca70c883e0f0.fleet.example.test."), RecordType::A, 0)
+            .unwrap();
+        assert_eq!(a.records.len(), 1);
+
+        zone.set_acme_txt("abc123", "tok1", 0).unwrap();
+        zone.set_acme_txt("abc123", "tok2", 0).unwrap();
+        let txt = zone
+            .lookup(
+                &name("_acme-challenge.d-6ca13d52ca70c883e0f0.fleet.example.test."),
+                RecordType::TXT,
+                1,
+            )
+            .unwrap();
+        assert_eq!(txt.records.len(), 2);
+        zone.clear_acme_txt("abc123");
+        let cleared = zone
+            .lookup(
+                &name("_acme-challenge.d-6ca13d52ca70c883e0f0.fleet.example.test."),
+                RecordType::TXT,
+                1,
+            )
+            .unwrap();
+        assert!(cleared.records.is_empty());
+
+        zone.remove_daemon("abc123");
+        let gone = zone
+            .lookup(&name("d-6ca13d52ca70c883e0f0.fleet.example.test."), RecordType::A, 0)
+            .unwrap();
+        assert!(!gone.name_exists);
+    }
+}

--- a/src/bin/connect/fleet.rs
+++ b/src/bin/connect/fleet.rs
@@ -883,6 +883,7 @@ mod tests {
     fn fleet_targets_merge_claimed_daemons_over_remembered_records() {
         let user_id = Uuid::new_v4();
         let store = Store {
+            dns_records: Vec::new(),
             users: Vec::new(),
             daemons: vec![DaemonRecord {
                 daemon_id: "daemon-1".to_string(),
@@ -1011,6 +1012,9 @@ mod tests {
             invite_required: false,
             open_daemon_registration: false,
             cookie_secure: true,
+            dns_zone: None,
+            dns_ns_name: None,
+            dns_listen: None,
         };
 
         let targets = fleet_targets_for_user(&config, &store, user_id);

--- a/src/bin/connect/main.rs
+++ b/src/bin/connect/main.rs
@@ -35,6 +35,8 @@ mod fleet;
 pub(crate) use fleet::*;
 mod rendezvous;
 pub(crate) use rendezvous::*;
+mod dns;
+pub(crate) use dns::*;
 
 const PROTOCOL: &str = "intendant-connect-rendezvous-v1";
 const CLAIM_PROTOCOL: &str = "intendant-connect-claim-v1";
@@ -49,8 +51,13 @@ const CLAIM_PROTOCOL_V2: &str = "intendant-connect-claim-v2";
 const UNCLAIM_PROTOCOL: &str = "intendant-connect-unclaim-v1";
 /// Freshness window for daemon-signed unclaim payloads: signatures bind a
 /// timestamp so a captured release cannot be replayed to evict a future
-/// re-claim.
+/// re-claim. Fleet-DNS publishes reuse the same window.
 const UNCLAIM_MAX_SKEW_MS: u64 = 5 * 60 * 1000;
+/// Daemon-signed fleet-DNS publishes: address records for the daemon's
+/// own name, and short-lived ACME DNS-01 TXT tokens. The registered
+/// identity key is the only authority over a name (docs/src/trust-tiers.md).
+const DNS_PUBLISH_PROTOCOL: &str = "intendant-connect-dns-publish-v1";
+const DNS_ACME_PROTOCOL: &str = "intendant-connect-dns-acme-v1";
 const COOKIE_NAME: &str = "ic_session";
 const SESSION_TTL_MS: u64 = 30 * 24 * 60 * 60 * 1000;
 const OFFER_TIMEOUT_MS: u64 = 30_000;
@@ -90,6 +97,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if !had_keys {
         save_store(&config.data_file, &store).map_err(|e| format!("persist service keys: {e}"))?;
     }
+    // Fleet DNS: build the zone, hydrate persisted records, and bind the
+    // sockets BEFORE serving — a misconfigured DNS listener must fail the
+    // whole startup loudly, not limp along HTTP-only.
+    let dns_zone = match (&config.dns_zone, &config.dns_ns_name, &config.dns_listen) {
+        (Some(zone_name), Some(ns_name), Some(_listen)) => {
+            let zone = Arc::new(FleetZone::new(zone_name, ns_name)?);
+            for entry in &store.dns_records {
+                let addresses: Vec<std::net::IpAddr> = entry
+                    .addresses
+                    .iter()
+                    .filter_map(|value| value.parse().ok())
+                    .collect();
+                if let Err(error) = zone.set_daemon_addresses(&entry.daemon_id, &addresses) {
+                    eprintln!(
+                        "[connect] skipping persisted dns record for {}: {error}",
+                        entry.daemon_id
+                    );
+                }
+            }
+            Some(zone)
+        }
+        _ => None,
+    };
     let state = Arc::new(AppState {
         config: config.clone(),
         webauthn,
@@ -109,10 +139,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         claim_codes: Mutex::new(HashMap::new()),
         rate_limits: Mutex::new(HashMap::new()),
         active_sessions: Mutex::new(HashMap::new()),
+        dns_zone,
     });
 
     tokio::spawn(presence_alert_monitor(state.clone()));
     tokio::spawn(handle_reclaim_monitor(state.clone()));
+    if let (Some(zone), Some(listen)) = (state.dns_zone.clone(), state.config.dns_listen) {
+        // Fail startup on an unbindable DNS listener (privileges, port
+        // in use); afterwards the server runs until process exit.
+        let server = bind_fleet_dns(zone, listen).await?;
+        eprintln!(
+            "[connect] fleet dns serving {} on {listen} (udp+tcp)",
+            state.config.dns_zone.as_deref().unwrap_or_default()
+        );
+        tokio::spawn(async move {
+            if let Err(error) = server.await {
+                eprintln!("[connect] fleet dns server exited: {error}");
+            }
+        });
+    }
 
     let app = Router::new()
         .route("/", get(landing_ui))
@@ -185,6 +230,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/api/daemon/error", post(daemon_error))
         .route("/api/daemon/claim-proof", post(daemon_claim_proof))
         .route("/api/daemon/unclaim", post(daemon_unclaim))
+        .route("/api/dns/publish", post(dns_publish))
+        .route("/api/dns/acme-challenge", post(dns_acme_challenge))
         .route("/api/daemon/dry", post(daemon_dry))
         .route("/api/browser/offer", post(browser_offer))
         .route("/api/browser/ice", post(browser_ice))
@@ -223,6 +270,17 @@ struct ServiceConfig {
     /// what makes the landing one-liner's claim story reachable by
     /// someone who has never seen the operator token.
     open_daemon_registration: bool,
+    /// Fleet DNS (docs/src/self-hosted-rendezvous.md): the delegated
+    /// subzone this service answers for authoritatively (e.g.
+    /// `fleet.intendant.dev`). All three `dns_*` values must be set for
+    /// the DNS server and publish endpoints to switch on; default off.
+    dns_zone: Option<String>,
+    /// The zone's NS host as delegated in the parent zone (e.g.
+    /// `ns-fleet.intendant.dev`) — served in the apex SOA/NS records.
+    dns_ns_name: Option<String>,
+    /// UDP+TCP listen address for the DNS server (e.g. `0.0.0.0:53`;
+    /// binding :53 unprivileged needs CAP_NET_BIND_SERVICE).
+    dns_listen: Option<SocketAddr>,
 }
 
 impl ServiceConfig {
@@ -253,6 +311,24 @@ impl ServiceConfig {
         let mut open_daemon_registration = std::env::var("INTENDANT_CONNECT_OPEN_REGISTRATION")
             .map(|v| matches!(v.trim(), "1" | "true" | "yes"))
             .unwrap_or(false);
+        let mut dns_zone = std::env::var("INTENDANT_CONNECT_DNS_ZONE")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
+        let mut dns_ns_name = std::env::var("INTENDANT_CONNECT_DNS_NS_NAME")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
+        let mut dns_listen: Option<SocketAddr> = match std::env::var("INTENDANT_CONNECT_DNS_LISTEN")
+        {
+            Ok(value) if !value.trim().is_empty() => Some(
+                value
+                    .trim()
+                    .parse()
+                    .map_err(|e| format!("invalid INTENDANT_CONNECT_DNS_LISTEN {value:?}: {e}"))?,
+            ),
+            _ => None,
+        };
 
         let mut args = std::env::args().skip(1);
         while let Some(arg) = args.next() {
@@ -285,6 +361,20 @@ impl ServiceConfig {
                 "--open-registration" => {
                     open_daemon_registration = true;
                 }
+                "--dns-zone" => {
+                    dns_zone = Some(args.next().ok_or("--dns-zone requires a zone name")?);
+                }
+                "--dns-ns-name" => {
+                    dns_ns_name = Some(args.next().ok_or("--dns-ns-name requires a host name")?);
+                }
+                "--dns-listen" => {
+                    let value = args.next().ok_or("--dns-listen requires an address")?;
+                    dns_listen = Some(
+                        value
+                            .parse()
+                            .map_err(|e| format!("invalid --dns-listen {value:?}: {e}"))?,
+                    );
+                }
                 "--help" | "-h" => {
                     print_help();
                     std::process::exit(0);
@@ -306,6 +396,19 @@ impl ServiceConfig {
             }
         });
         let cookie_secure = parsed_origin.scheme() == "https";
+        // Fleet DNS is all-or-nothing: a partial config would serve a
+        // zone nobody delegated or delegate a zone nobody serves.
+        let dns_parts = [
+            dns_zone.is_some(),
+            dns_ns_name.is_some(),
+            dns_listen.is_some(),
+        ];
+        if dns_parts.iter().any(|set| *set) && !dns_parts.iter().all(|set| *set) {
+            return Err(
+                "fleet dns needs all of --dns-zone, --dns-ns-name, and --dns-listen (or none)"
+                    .to_string(),
+            );
+        }
         Ok(Self {
             listen,
             public_origin: trim_trailing_slash(&public_origin),
@@ -316,6 +419,9 @@ impl ServiceConfig {
             invite_required,
             open_daemon_registration,
             cookie_secure,
+            dns_zone,
+            dns_ns_name,
+            dns_listen,
         })
     }
 }
@@ -326,7 +432,10 @@ fn print_help() {
          \n\
          Env: INTENDANT_CONNECT_LISTEN, INTENDANT_CONNECT_ORIGIN, INTENDANT_CONNECT_RP_ID,\n\
               INTENDANT_CONNECT_STATIC_ROOT, INTENDANT_CONNECT_DATA_FILE, INTENDANT_CONNECT_TOKEN,\n\
-              INTENDANT_CONNECT_INVITE_REQUIRED, INTENDANT_CONNECT_OPEN_REGISTRATION"
+              INTENDANT_CONNECT_INVITE_REQUIRED, INTENDANT_CONNECT_OPEN_REGISTRATION,\n\
+              INTENDANT_CONNECT_DNS_ZONE, INTENDANT_CONNECT_DNS_NS_NAME, INTENDANT_CONNECT_DNS_LISTEN\n\
+              (--dns-zone fleet.example.com --dns-ns-name ns-fleet.example.com --dns-listen 0.0.0.0:53\n\
+               enable the embedded fleet DNS server; all three or none)"
     );
 }
 
@@ -372,6 +481,22 @@ struct AppState {
     vapid: ring::signature::EcdsaKeyPair,
     log_key: ring::signature::EcdsaKeyPair,
     push_http: reqwest::Client,
+    /// The fleet DNS zone when the `dns_*` config group is set — the
+    /// live record table the embedded server answers from (hydrated
+    /// from `Store::dns_records` at startup).
+    dns_zone: Option<Arc<FleetZone>>,
+}
+
+/// A daemon's published fleet-DNS addresses (`d-<label>.<zone>` A/AAAA).
+/// ACME TXT challenges are deliberately NOT persisted — they live only
+/// in the in-memory zone and self-expire.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DnsRecordEntry {
+    daemon_id: String,
+    #[serde(default)]
+    addresses: Vec<String>,
+    #[serde(default)]
+    updated_unix_ms: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -380,6 +505,8 @@ struct Store {
     users: Vec<UserRecord>,
     #[serde(default)]
     daemons: Vec<DaemonRecord>,
+    #[serde(default)]
+    dns_records: Vec<DnsRecordEntry>,
     #[serde(default)]
     fleet_targets: Vec<FleetTargetRecord>,
     #[serde(default)]

--- a/src/bin/connect/rendezvous.rs
+++ b/src/bin/connect/rendezvous.rs
@@ -366,6 +366,12 @@ pub(crate) async fn daemon_register(
         let now = now_unix_ms();
         for stale_id in sweep_stale_unclaimed_daemons(&mut store, now) {
             claim_codes.remove(&stale_id);
+            // Names follow the daemon record: a hard-deleted record
+            // takes its fleet-DNS records with it.
+            store.dns_records.retain(|r| r.daemon_id != stale_id);
+            if let Some(zone) = state.dns_zone.as_ref() {
+                zone.remove_daemon(&stale_id);
+            }
         }
         let active_claim_hashes = active_claim_code_hashes(&store, &daemon_id, now);
         // Applies the unclaimed-record claim-code policy: a daemon-minted
@@ -487,6 +493,14 @@ pub(crate) async fn daemon_register(
         "claim_url": claim_url,
         "daemon_public_key": daemon_public_key,
         "observed_ip": observed_ip,
+        // Fleet DNS hint: the daemon's derived name under the delegated
+        // zone, when this rendezvous serves one. The daemon uses it to
+        // mint a real certificate (ACME DNS-01 via /api/dns/*).
+        "fleet_dns": state.dns_zone.as_ref().and_then(|zone| {
+            zone.daemon_fqdn(&daemon_id).map(|name| {
+                json!({ "zone": zone.origin_utf8(), "name": name })
+            })
+        }),
     })))
 }
 
@@ -1332,6 +1346,281 @@ pub(crate) async fn daemon_unclaim(
     Ok(Json(json!({ "ok": true, "changed": true })))
 }
 
+/* ── Fleet DNS: daemon-signed record publishes ──
+The embedded authoritative server (dns.rs) answers for the delegated
+subzone; these endpoints are the only way records get into it. Authority
+model: a daemon's REGISTERED identity key is the sole authority over its
+own derived name (`d-<hash>.<zone>`) — same signature + freshness
+discipline as unclaim, same key pinning. Names follow the daemon RECORD
+lifecycle (they survive claim/unclaim — the name serves the daemon's
+certificate, not the fleet binding) and are hard-dropped only when the
+stale-unclaimed sweep deletes the record itself. */
+
+pub(crate) fn dns_publish_signing_payload(
+    daemon_id: &str,
+    daemon_public_key: &str,
+    issued_at_unix_ms: u64,
+    addresses_csv: &str,
+) -> String {
+    format!(
+        "{DNS_PUBLISH_PROTOCOL}\n{daemon_id}\n{daemon_public_key}\n{issued_at_unix_ms}\n{addresses_csv}\n"
+    )
+}
+
+pub(crate) fn dns_acme_signing_payload(
+    daemon_id: &str,
+    daemon_public_key: &str,
+    issued_at_unix_ms: u64,
+    txt_value: &str,
+) -> String {
+    format!(
+        "{DNS_ACME_PROTOCOL}\n{daemon_id}\n{daemon_public_key}\n{issued_at_unix_ms}\n{txt_value}\n"
+    )
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct DnsPublishRequest {
+    protocol: String,
+    daemon_id: String,
+    daemon_public_key: String,
+    issued_at_unix_ms: u64,
+    signature: String,
+    /// Routable unicast addresses for the daemon's name; empty clears.
+    /// Private-range addresses are deliberately legitimate (public name
+    /// + real certificate + LAN address is the point).
+    #[serde(default)]
+    addresses: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct DnsAcmeChallengeRequest {
+    protocol: String,
+    daemon_id: String,
+    daemon_public_key: String,
+    issued_at_unix_ms: u64,
+    signature: String,
+    /// The DNS-01 TXT value to serve; empty together with `clear`.
+    #[serde(default)]
+    txt_value: String,
+    /// Remove this daemon's challenge records instead of adding one.
+    #[serde(default)]
+    clear: bool,
+}
+
+/// The shared front half of both DNS endpoints: bearer gate, rate
+/// limit, protocol + freshness checks, and the registered-key pin.
+/// Returns the daemon record the signature must verify against.
+async fn dns_request_daemon(
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    rate_key: &str,
+    protocol: &str,
+    expected_protocol: &str,
+    daemon_id: &str,
+    daemon_public_key: &str,
+    issued_at_unix_ms: u64,
+) -> ApiResult<DaemonRecord> {
+    if state.dns_zone.is_none() {
+        return Err(ApiError::not_found("fleet dns is not enabled on this rendezvous"));
+    }
+    require_daemon_auth(state, headers)?;
+    check_rate_limit(state, headers, rate_key, 30, 60_000).await?;
+    if protocol != expected_protocol {
+        return Err(ApiError::bad_request("unsupported dns publish protocol"));
+    }
+    let now = now_unix_ms();
+    if now.abs_diff(issued_at_unix_ms) > UNCLAIM_MAX_SKEW_MS {
+        return Err(ApiError::bad_request(
+            "dns publish payload is stale — check the daemon clock and retry",
+        ));
+    }
+    let daemon = {
+        let store = state.store.lock().await;
+        store
+            .daemons
+            .iter()
+            .find(|d| d.daemon_id == daemon_id)
+            .cloned()
+            .ok_or_else(|| ApiError::not_found("daemon not found"))?
+    };
+    if daemon_public_key.trim() != daemon.daemon_public_key {
+        return Err(ApiError::bad_request(
+            "daemon_public_key does not match the registered key",
+        ));
+    }
+    Ok(daemon)
+}
+
+/// A publishable address: routable unicast only. Loopback, unspecified,
+/// multicast, broadcast, and link-local are refused — they are never a
+/// reachable daemon and some make cute mischief primitives.
+fn publishable_address(value: &str) -> Result<std::net::IpAddr, String> {
+    let ip: std::net::IpAddr = value
+        .trim()
+        .parse()
+        .map_err(|_| format!("not an IP address: {value:?}"))?;
+    let refused = match ip {
+        std::net::IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_unspecified()
+                || v4.is_multicast()
+                || v4.is_broadcast()
+                || v4.is_link_local()
+        }
+        std::net::IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || v6.is_multicast()
+                || (v6.segments()[0] & 0xffc0) == 0xfe80
+        }
+    };
+    if refused {
+        return Err(format!("{ip} is not a publishable unicast address"));
+    }
+    Ok(ip)
+}
+
+pub(crate) async fn dns_publish(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<DnsPublishRequest>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let daemon_id = body.daemon_id.trim().to_string();
+    let daemon = dns_request_daemon(
+        &state,
+        &headers,
+        "dns_publish",
+        &body.protocol,
+        DNS_PUBLISH_PROTOCOL,
+        &daemon_id,
+        &body.daemon_public_key,
+        body.issued_at_unix_ms,
+    )
+    .await?;
+    if body.addresses.len() > 8 {
+        return Err(ApiError::bad_request("too many addresses (max 8)"));
+    }
+    let mut addresses = Vec::with_capacity(body.addresses.len());
+    for value in &body.addresses {
+        addresses.push(publishable_address(value).map_err(ApiError::bad_request)?);
+    }
+    // The signature covers the exact address list (trimmed, as parsed).
+    let addresses_csv = addresses
+        .iter()
+        .map(|ip| ip.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let payload = dns_publish_signing_payload(
+        &daemon_id,
+        &daemon.daemon_public_key,
+        body.issued_at_unix_ms,
+        &addresses_csv,
+    );
+    if !verify_ed25519_b64u(
+        &daemon.daemon_public_key,
+        payload.as_bytes(),
+        body.signature.trim(),
+    ) {
+        return Err(ApiError::bad_request("dns publish signature invalid"));
+    }
+    let zone = state
+        .dns_zone
+        .as_ref()
+        .expect("checked in dns_request_daemon")
+        .clone();
+    let name = zone
+        .daemon_fqdn(&daemon_id)
+        .ok_or_else(|| ApiError::bad_request("daemon id does not derive a DNS label"))?;
+    zone.set_daemon_addresses(&daemon_id, &addresses)
+        .map_err(ApiError::bad_request)?;
+    let now = now_unix_ms();
+    {
+        let mut store = state.store.lock().await;
+        store.dns_records.retain(|r| r.daemon_id != daemon_id);
+        if !addresses.is_empty() {
+            store.dns_records.push(DnsRecordEntry {
+                daemon_id: daemon_id.clone(),
+                addresses: addresses.iter().map(|ip| ip.to_string()).collect(),
+                updated_unix_ms: now,
+            });
+        }
+        audit(
+            &mut store,
+            "dns_publish",
+            daemon.owner_user_id,
+            Some(daemon_id.clone()),
+            json!({ "name": name, "addresses": addresses.len() }),
+        );
+        persist_locked(&state, &store)?;
+    }
+    Ok(Json(json!({
+        "ok": true,
+        "zone": zone.origin_utf8(),
+        "name": name,
+        "addresses": addresses.iter().map(|ip| ip.to_string()).collect::<Vec<_>>(),
+    })))
+}
+
+pub(crate) async fn dns_acme_challenge(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<DnsAcmeChallengeRequest>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let daemon_id = body.daemon_id.trim().to_string();
+    let daemon = dns_request_daemon(
+        &state,
+        &headers,
+        "dns_acme",
+        &body.protocol,
+        DNS_ACME_PROTOCOL,
+        &daemon_id,
+        &body.daemon_public_key,
+        body.issued_at_unix_ms,
+    )
+    .await?;
+    let txt_value = body.txt_value.trim().to_string();
+    if body.clear != txt_value.is_empty() {
+        return Err(ApiError::bad_request(
+            "set a txt_value, or clear=true with none — not both",
+        ));
+    }
+    let payload = dns_acme_signing_payload(
+        &daemon_id,
+        &daemon.daemon_public_key,
+        body.issued_at_unix_ms,
+        &txt_value,
+    );
+    if !verify_ed25519_b64u(
+        &daemon.daemon_public_key,
+        payload.as_bytes(),
+        body.signature.trim(),
+    ) {
+        return Err(ApiError::bad_request("dns acme signature invalid"));
+    }
+    let zone = state
+        .dns_zone
+        .as_ref()
+        .expect("checked in dns_request_daemon")
+        .clone();
+    let name = zone
+        .daemon_fqdn(&daemon_id)
+        .ok_or_else(|| ApiError::bad_request("daemon id does not derive a DNS label"))?;
+    if body.clear {
+        zone.clear_acme_txt(&daemon_id);
+    } else {
+        zone.set_acme_txt(&daemon_id, &txt_value, now_unix_ms())
+            .map_err(ApiError::bad_request)?;
+    }
+    // TXT challenges are in-memory + self-expiring: no persist, and no
+    // audit noise — the public CT log is the durable record of issuance.
+    Ok(Json(json!({
+        "ok": true,
+        "zone": zone.origin_utf8(),
+        "name": format!("_acme-challenge.{name}"),
+        "cleared": body.clear,
+    })))
+}
+
 pub(crate) fn verify_ed25519_b64u(public_key_b64u: &str, payload: &[u8], signature_b64u: &str) -> bool {
     let Ok(public_key) = b64u_decode(public_key_b64u) else {
         return false;
@@ -1672,6 +1961,43 @@ mod tests {
             unclaim_signing_payload("daemon-1", "PubKey", 1_700_000_000_000),
             "intendant-connect-unclaim-v1\ndaemon-1\nPubKey\n1700000000000\n"
         );
+        // Twin-pinned in the daemon (bin/caller/fleet_cert.rs) — change
+        // both together.
+        assert_eq!(
+            dns_publish_signing_payload(
+                "daemon-1",
+                "PubKey",
+                1_700_000_000_000,
+                "192.168.1.50,2001:db8::7"
+            ),
+            "intendant-connect-dns-publish-v1\ndaemon-1\nPubKey\n1700000000000\n192.168.1.50,2001:db8::7\n"
+        );
+        assert_eq!(
+            dns_acme_signing_payload("daemon-1", "PubKey", 1_700_000_000_000, "tok-value"),
+            "intendant-connect-dns-acme-v1\ndaemon-1\nPubKey\n1700000000000\ntok-value\n"
+        );
+    }
+
+    #[test]
+    fn publishable_addresses_are_routable_unicast_only() {
+        assert!(publishable_address("192.168.1.50").is_ok());
+        assert!(publishable_address("10.0.0.9").is_ok());
+        assert!(publishable_address("203.0.113.7").is_ok());
+        assert!(publishable_address("2001:db8::7").is_ok());
+        for refused in [
+            "127.0.0.1",
+            "0.0.0.0",
+            "224.0.0.1",
+            "255.255.255.255",
+            "169.254.1.1",
+            "::1",
+            "::",
+            "ff02::1",
+            "fe80::1",
+            "not-an-ip",
+        ] {
+            assert!(publishable_address(refused).is_err(), "{refused} should be refused");
+        }
     }
 
     /// The v2 property the whole exercise exists for: the signature is
@@ -1757,6 +2083,7 @@ mod tests {
         let expired = "achieve-acid-acoustic-acquire-across-act-action";
         let claimed = "actor-actress-actual-adapt-add-addict-address";
         let store = Store {
+            dns_records: Vec::new(),
             users: Vec::new(),
             daemons: vec![
                 daemon_record("fresh", None, Some(fresh), Some(now)),

--- a/static/app.html
+++ b/static/app.html
@@ -50541,6 +50541,26 @@ async function accessSetHostedCeiling(roleId) {
   renderAccessAdminSummaries();
 }
 
+async function accessFleetCertRequest() {
+  try {
+    const resp = await dashboardJsonFetch('api_fleet_cert_request', {}, () => Promise.reject(new Error('fleet certificate requests ride the control channel — connect to the daemon first')), 'api_fleet_cert_request', { fallbackAfterRpcFailure: false });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
+    showControlToast?.('success', 'Certificate request started — publishing DNS records and answering the Let’s Encrypt challenge (usually under a minute).');
+  } catch (err) {
+    showControlToast?.('error', err?.message || 'Certificate request failed');
+  }
+  // Poll the card a few times while the async flow runs.
+  for (const delay of [5000, 15000, 40000]) {
+    setTimeout(() => {
+      refreshAccessConnectStatus({ silent: true }).catch(() => null);
+      renderAccessAdminSummaries();
+    }, delay);
+  }
+  await refreshAccessConnectStatus({ silent: true }).catch(() => null);
+  renderAccessAdminSummaries();
+}
+
 async function accessConnectUnclaim() {
   try {
     const resp = await dashboardJsonFetch('api_access_connect_unclaim', {}, () => authedFetch('/api/access/connect/unclaim', {
@@ -53936,6 +53956,60 @@ function renderAccessConnectCard() {
     err.className = 'acc-connect-warn';
     err.textContent = `Last error: ${status.last_error}`;
     card.appendChild(err);
+  }
+
+  // Fleet certificate (docs/src/trust-tiers.md, the convenient direct
+  // path): when the rendezvous serves a fleet DNS zone, this daemon owns
+  // a real name — one click publishes its addresses and mints a
+  // Let's Encrypt certificate, so the direct dashboard gets a warning-free
+  // padlock (LAN address + public name included).
+  const fleetCert = status.fleet_cert || {};
+  if (fleetCert.name) {
+    const row = document.createElement('div');
+    row.className = 'acc-grant-flow-actions';
+    const label = document.createElement('span');
+    label.className = 'acc-principal-kind';
+    const validUntil = fleetCert.not_after_unix_ms
+      ? new Date(Number(fleetCert.not_after_unix_ms)).toLocaleDateString()
+      : '';
+    label.textContent = `Fleet name: ${fleetCert.name}`;
+    label.title = fleetCert.addresses?.length
+      ? `Resolves to ${fleetCert.addresses.join(', ')} (published by this daemon; LAN addresses are fine — the certificate makes the padlock, not the address).`
+      : 'No addresses published yet — requesting a certificate publishes this daemon’s routable addresses first.';
+    row.appendChild(label);
+    const chip = document.createElement('span');
+    if (fleetCert.state === 'valid') {
+      chip.className = 'acc-chip route-webrtc';
+      chip.textContent = validUntil ? `certificate ✓ until ${validUntil}` : 'certificate ✓';
+      chip.title = 'A browser-trusted Let’s Encrypt certificate is serving for this name — open the direct dashboard at https://' + fleetCert.name + (window.location.port ? ':' + window.location.port : '') + ' without warnings. Renewals are automatic.';
+    } else if (fleetCert.state === 'requesting') {
+      chip.className = 'acc-chip route-remembered';
+      chip.textContent = 'requesting…';
+      chip.title = 'Publishing DNS records and answering the Let’s Encrypt challenge — usually under a minute.';
+    } else if (fleetCert.state === 'error') {
+      chip.className = 'acc-chip route-danger';
+      chip.textContent = 'certificate error';
+      chip.title = fleetCert.last_error || 'The last certificate request failed.';
+    }
+    if (chip.textContent) row.appendChild(chip);
+    const canRequest = dashboardControlTransport?.lastStatus?.api_fleet_cert_request_available !== false;
+    if (fleetCert.state !== 'requesting' && fleetCert.state !== 'valid') {
+      const request = document.createElement('button');
+      request.type = 'button';
+      request.className = 'acc-btn primary';
+      request.textContent = 'Get a real certificate';
+      request.title = 'Publishes this daemon’s routable addresses under its fleet name and mints a Let’s Encrypt certificate (DNS-01 through the rendezvous — the private key never leaves this machine). The name lands in public CT logs; it is an opaque hash for that reason.';
+      request.disabled = !canRequest;
+      request.addEventListener('click', () => accessFleetCertRequest());
+      row.appendChild(request);
+    }
+    if (fleetCert.state === 'error' && fleetCert.last_error) {
+      const err = document.createElement('div');
+      err.className = 'acc-connect-warn';
+      err.textContent = `Certificate: ${fleetCert.last_error}`;
+      card.appendChild(err);
+    }
+    card.appendChild(row);
   }
 
   // The reveal: the twelve words, full-width, with where to type them.

--- a/static/app/42-usage-terminal.js
+++ b/static/app/42-usage-terminal.js
@@ -803,6 +803,26 @@ async function accessSetHostedCeiling(roleId) {
   renderAccessAdminSummaries();
 }
 
+async function accessFleetCertRequest() {
+  try {
+    const resp = await dashboardJsonFetch('api_fleet_cert_request', {}, () => Promise.reject(new Error('fleet certificate requests ride the control channel — connect to the daemon first')), 'api_fleet_cert_request', { fallbackAfterRpcFailure: false });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
+    showControlToast?.('success', 'Certificate request started — publishing DNS records and answering the Let’s Encrypt challenge (usually under a minute).');
+  } catch (err) {
+    showControlToast?.('error', err?.message || 'Certificate request failed');
+  }
+  // Poll the card a few times while the async flow runs.
+  for (const delay of [5000, 15000, 40000]) {
+    setTimeout(() => {
+      refreshAccessConnectStatus({ silent: true }).catch(() => null);
+      renderAccessAdminSummaries();
+    }, delay);
+  }
+  await refreshAccessConnectStatus({ silent: true }).catch(() => null);
+  renderAccessAdminSummaries();
+}
+
 async function accessConnectUnclaim() {
   try {
     const resp = await dashboardJsonFetch('api_access_connect_unclaim', {}, () => authedFetch('/api/access/connect/unclaim', {

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -1025,6 +1025,60 @@ function renderAccessConnectCard() {
     card.appendChild(err);
   }
 
+  // Fleet certificate (docs/src/trust-tiers.md, the convenient direct
+  // path): when the rendezvous serves a fleet DNS zone, this daemon owns
+  // a real name — one click publishes its addresses and mints a
+  // Let's Encrypt certificate, so the direct dashboard gets a warning-free
+  // padlock (LAN address + public name included).
+  const fleetCert = status.fleet_cert || {};
+  if (fleetCert.name) {
+    const row = document.createElement('div');
+    row.className = 'acc-grant-flow-actions';
+    const label = document.createElement('span');
+    label.className = 'acc-principal-kind';
+    const validUntil = fleetCert.not_after_unix_ms
+      ? new Date(Number(fleetCert.not_after_unix_ms)).toLocaleDateString()
+      : '';
+    label.textContent = `Fleet name: ${fleetCert.name}`;
+    label.title = fleetCert.addresses?.length
+      ? `Resolves to ${fleetCert.addresses.join(', ')} (published by this daemon; LAN addresses are fine — the certificate makes the padlock, not the address).`
+      : 'No addresses published yet — requesting a certificate publishes this daemon’s routable addresses first.';
+    row.appendChild(label);
+    const chip = document.createElement('span');
+    if (fleetCert.state === 'valid') {
+      chip.className = 'acc-chip route-webrtc';
+      chip.textContent = validUntil ? `certificate ✓ until ${validUntil}` : 'certificate ✓';
+      chip.title = 'A browser-trusted Let’s Encrypt certificate is serving for this name — open the direct dashboard at https://' + fleetCert.name + (window.location.port ? ':' + window.location.port : '') + ' without warnings. Renewals are automatic.';
+    } else if (fleetCert.state === 'requesting') {
+      chip.className = 'acc-chip route-remembered';
+      chip.textContent = 'requesting…';
+      chip.title = 'Publishing DNS records and answering the Let’s Encrypt challenge — usually under a minute.';
+    } else if (fleetCert.state === 'error') {
+      chip.className = 'acc-chip route-danger';
+      chip.textContent = 'certificate error';
+      chip.title = fleetCert.last_error || 'The last certificate request failed.';
+    }
+    if (chip.textContent) row.appendChild(chip);
+    const canRequest = dashboardControlTransport?.lastStatus?.api_fleet_cert_request_available !== false;
+    if (fleetCert.state !== 'requesting' && fleetCert.state !== 'valid') {
+      const request = document.createElement('button');
+      request.type = 'button';
+      request.className = 'acc-btn primary';
+      request.textContent = 'Get a real certificate';
+      request.title = 'Publishes this daemon’s routable addresses under its fleet name and mints a Let’s Encrypt certificate (DNS-01 through the rendezvous — the private key never leaves this machine). The name lands in public CT logs; it is an opaque hash for that reason.';
+      request.disabled = !canRequest;
+      request.addEventListener('click', () => accessFleetCertRequest());
+      row.appendChild(request);
+    }
+    if (fleetCert.state === 'error' && fleetCert.last_error) {
+      const err = document.createElement('div');
+      err.className = 'acc-connect-warn';
+      err.textContent = `Certificate: ${fleetCert.last_error}`;
+      card.appendChild(err);
+    }
+    card.appendChild(row);
+  }
+
   // The reveal: the twelve words, full-width, with where to type them.
   if (accessConnectRevealed?.claim_code) {
     const phraseWrap = document.createElement('div');


### PR DESCRIPTION
The infrastructure half of the convenient direct path (task #22, per the trust-tiers doctrine): **delegate one subzone to the rendezvous, and every daemon gets a browser-trusted certificate for its own name — one click, keys never leave the machine.** The Tailscale pattern, operated by the rendezvous as pure plumbing.

## Connect service (dark until configured)
- **`dns.rs`** — embedded authoritative DNS (hickory-server 0.26, plain UDP+TCP, ring-only tree preserved) answering for exactly the delegated zone: apex SOA/NS, per-daemon `A`/`AAAA`, `_acme-challenge` TXT. Posture: authoritative-only, `Refused` outside the zone, AXFR refused, RFC 8482 minimal `ANY`, 60s TTLs.
- Names are **derived labels** `d-<hex(sha256(daemon_id))[..20]>` — daemon ids default to base64url keys (not DNS-safe), and the hash keeps CT-logged names opaque. Derivation is twin-pinned in both binaries.
- `--dns-zone / --dns-ns-name / --dns-listen` (env twins; all-or-nothing, default **off**). Sockets bind before serve: misconfiguration fails startup loudly.
- **Daemon-signed publish endpoints** mirroring the unclaim discipline (registered-key pin, ±5 min freshness, bearer gate, rate limits): `POST /api/dns/publish` (routable unicast only — loopback/multicast/link-local refused; persisted) and `POST /api/dns/acme-challenge` (in-memory, self-expiring). Records follow the daemon-record lifecycle.
- Register responses carry the `fleet_dns` hint (zone + name).

## Daemon
- **`fleet_cert.rs`** — ACME via `instant-acme` (ring feature; `cargo tree -i aws-lc-rs` stays empty): account + certificate + key persisted beside the access certs (0600), LE production with `INTENDANT_ACME_DIRECTORY` staging override, renewal loop inside the last 30 days.
- **`web_tls::FleetSniResolver`** replaces `with_single_cert`: base certificate by default, fleet certificate for its SNI name, **hot-swapped at issuance and renewal — no restart**.
- `api_fleet_cert_request` (manage-gated) publishes the daemon's routable addresses (LAN included — public name + real cert + private address = warning-free padlock at home with zero port forwarding) and runs the order async; the Connect card shows the fleet name, a certificate state chip, and **Get a real certificate**.

## Docs
`self-hosted-rendezvous.md` gains the Fleet DNS section — the two-record delegation runbook, `CAP_NET_BIND_SERVICE` note, and the honest caveats (single-NS SPOF, LE per-domain rate limits, hostile-zone mis-issuance vs end-to-end key verification + CT evidence). Trust-tiers client ladder updated.

Battery: 2693 tests green across both bins (incl. zone lookup NXDOMAIN/NODATA/refused semantics, label goldens, payload twins, address-policy table), clippy clean. Deployable dark; the production delegation (two parent-zone records + SG port 53 + systemd capability) is the operator step.