### PR TITLE
Late-join dashboards rebuild live-session windows; session-list caches invalidate on lifecycle events

### DIFF
--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -25,13 +25,15 @@
 
 use crate::*;
 
-/// Handles for the two session listeners every mode spawns first:
-/// the recording listener and the user-display grant/revoke listener.
+/// Handles for the session listeners every mode spawns first:
+/// the recording listener, the user-display grant/revoke listener, and
+/// the session-list cache invalidator.
 /// tokio tasks detach on drop; the struct mirrors the original
 /// keep-until-scope-end bindings.
 pub(crate) struct SessionListeners {
     pub(crate) _recording_listener: tokio::task::JoinHandle<()>,
     pub(crate) _user_display_listener: tokio::task::JoinHandle<()>,
+    pub(crate) _session_list_cache_invalidator: tokio::task::JoinHandle<()>,
 }
 
 pub(crate) fn spawn_session_listeners(
@@ -51,10 +53,43 @@ pub(crate) fn spawn_session_listeners(
         session_registry.clone(),
         Some(frame_registry.clone()),
     );
+    let _session_list_cache_invalidator = spawn_session_list_cache_invalidator(bus.subscribe());
     SessionListeners {
         _recording_listener,
         _user_display_listener,
+        _session_list_cache_invalidator,
     }
+}
+
+/// Session-list response caches go stale the moment session membership
+/// changes; the daemon emits those changes on the bus, so listen and drop
+/// the cached bodies instead of serving ghosts for up to the SWR window
+/// (bit the dashboard's own post-create refresh and every parameterless
+/// /api/sessions caller).
+fn spawn_session_list_cache_invalidator(
+    mut event_rx: tokio::sync::broadcast::Receiver<AppEvent>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match event_rx.recv().await {
+                Ok(
+                    AppEvent::SessionStarted { .. }
+                    | AppEvent::SessionEnded { .. }
+                    | AppEvent::SessionAttached { .. }
+                    | AppEvent::SessionIdentity { .. }
+                    | AppEvent::SessionRelationship { .. },
+                ) => {
+                    crate::web_gateway::invalidate_session_list_response_caches();
+                }
+                Ok(_) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                    // Missed events ⇒ the list may have changed unseen.
+                    crate::web_gateway::invalidate_session_list_response_caches();
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    })
 }
 
 /// The debug-screen handler, spawned only when the web gateway is up

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -655,11 +655,19 @@ pub fn spawn_web_gateway(
                         }
                         if line.contains("\"event\":\"session_vitals\"")
                             || line.contains("\"event\":\"session_goal\"")
+                            || line.contains("\"event\":\"session_started\"")
                         {
                             if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&line) {
                                 let kind = match parsed["event"].as_str() {
                                     Some("session_vitals") => Some("session_vitals"),
                                     Some("session_goal") => Some("session_goal"),
+                                    // A live session's birth announcement:
+                                    // replayed to late joiners so their
+                                    // Activity grid rebuilds windows for
+                                    // work that predates the connection
+                                    // (session_started routinely falls off
+                                    // the tail-limited log replay).
+                                    Some("session_started") => Some("session_started"),
                                     _ => None,
                                 };
                                 if let (Some(kind), Some(sid)) =
@@ -1346,17 +1354,38 @@ pub fn spawn_web_gateway(
                     }
 
                     // Re-send the latest change-detected per-session state
-                    // (session_vitals / session_goal). These fire on change
-                    // only, so without this a late joiner — a refreshed
-                    // browser on an idle daemon, or a peer transport
-                    // attaching — would never see state that last changed
-                    // before this connection existed.
+                    // (session_started / session_vitals / session_goal).
+                    // These fire on change only, so without this a late
+                    // joiner — a refreshed browser on an idle daemon, or a
+                    // peer transport attaching — would never see state that
+                    // last changed before this connection existed. Each
+                    // session's `session_started` goes FIRST (windows must
+                    // exist before state lands on them) and is stamped
+                    // `replayed: true` so the frontend rebuilds the window
+                    // without live-start side effects (thinking phase,
+                    // focus steal, current-task clobber).
                     let session_state_replay: Vec<String> = session_state_lines
                         .lock()
                         .map(|guard| {
                             guard
                                 .values()
-                                .flat_map(|kinds| kinds.values().cloned())
+                                .flat_map(|kinds| {
+                                    let started = kinds.get("session_started").map(|line| {
+                                        match serde_json::from_str::<serde_json::Value>(line) {
+                                            Ok(mut parsed) => {
+                                                parsed["replayed"] = serde_json::json!(true);
+                                                parsed.to_string()
+                                            }
+                                            Err(_) => line.clone(),
+                                        }
+                                    });
+                                    started.into_iter().chain(
+                                        kinds
+                                            .iter()
+                                            .filter(|(kind, _)| **kind != "session_started")
+                                            .map(|(_, line)| line.clone()),
+                                    )
+                                })
                                 .collect()
                         })
                         .unwrap_or_default();

--- a/src/bin/caller/web_gateway/session_catalog/mod.rs
+++ b/src/bin/caller/web_gateway/session_catalog/mod.rs
@@ -376,6 +376,23 @@ pub(crate) fn serve_session_list_cache_entry(
     None
 }
 
+/// Drop every cached session-list response. Called on session lifecycle
+/// events (create/end/attach/identity/relationship): the daemon KNOWS the
+/// list just changed, and serving out the 30s hard-TTL / 15-minute SWR
+/// window after a membership change hands ghosts to the dashboard's own
+/// post-create refresh and to every parameterless caller (MCP, ctl,
+/// peers). Status-only drift still rides the TTLs — that freshness
+/// trade-off is the cache's reason to exist on 50GB log trees.
+pub(crate) fn invalidate_session_list_response_caches() {
+    if let Some(cache) = SESSION_LIST_RESPONSE_CACHE.get() {
+        *cache.lock().unwrap_or_else(|e| e.into_inner()) = None;
+    }
+    cached_limited_session_list_cache()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
+}
+
 pub(crate) fn cached_list_sessions() -> String {
     let cache = SESSION_LIST_RESPONSE_CACHE.get_or_init(|| Mutex::new(None));
     {
@@ -2391,6 +2408,30 @@ pub(crate) fn stream_sessions_from_request(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn invalidate_session_list_response_caches_clears_both_tiers() {
+        {
+            let cache = SESSION_LIST_RESPONSE_CACHE.get_or_init(|| Mutex::new(None));
+            *cache.lock().unwrap_or_else(|e| e.into_inner()) =
+                Some(SessionListResponseCacheEntry {
+                    generated_at: std::time::Instant::now(),
+                    body: "[{\"session_id\":\"stale\"}]".to_string(),
+                });
+        }
+        store_session_list_response(5, "[]".to_string());
+        invalidate_session_list_response_caches();
+        assert!(SESSION_LIST_RESPONSE_CACHE
+            .get()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .is_none());
+        assert!(cached_limited_session_list_cache()
+            .lock()
+            .unwrap()
+            .is_empty());
+    }
 
     #[test]
     fn summary_json_status_maps_outcomes_honestly() {

--- a/static/app.html
+++ b/static/app.html
@@ -37292,8 +37292,8 @@ function processCommands(cmds) {
       case 'delete_recording': deleteRecordingStream(c.stream_name); break;
       case 'recording_error': /* logged via add_log_entry */ break;
       case 'session_started':
-        managedContextSessionManuallySelected = false;
-        onSessionStarted(c.session_id, c.task);
+        if (!c.replayed) managedContextSessionManuallySelected = false;
+        onSessionStarted(c.session_id, c.task, { replayed: !!c.replayed });
         scheduleManagedContextRefresh(400);
         stationScheduleUpdate();
         break;
@@ -75500,34 +75500,45 @@ if (typeof ui2Enabled === 'function' && ui2Enabled()) {
 }
 /* ── static/app/54-session-lifecycle.js ── */
 // ── Session Lifecycle ──
-function onSessionStarted(sessionId, task) {
+function onSessionStarted(sessionId, task, opts = {}) {
   const sid = String(sessionId || '').trim();
   const hasTask = hasSessionLifecycleTask(task);
-  if (hasTask) {
+  // A replayed announcement (connect-time bootstrap for a session that
+  // started before this page existed) rebuilds the window but must not
+  // act like a live birth: no focus steal, no current-task clobber, no
+  // thinking phase, no changes-pane reset.
+  const replayed = !!opts.replayed;
+  if (hasTask && !replayed) {
     stationCurrentTask = compactSessionText(task);
     stationCurrentApproval = null;
   }
   stationScheduleUpdate();
-  const shouldFocusActivity = newSessionSpawnPending;
+  const shouldFocusActivity = !replayed && newSessionSpawnPending;
   const currentTarget = resolvePromptTargetSessionId();
-  finishNewSessionSpawnNotice(sid, task);
+  if (!replayed) finishNewSessionSpawnNotice(sid, task);
   const alias = externalBackendAliasForSession(sid);
   const visibleSessionId = alias?.backendSessionId || sid;
   if (visibleSessionId) {
     setSessionWindowDetached(visibleSessionId, false);
     const meta = {
-      phase: processingLogReplay || !hasTask ? 'idle' : 'thinking',
+      phase: replayed || processingLogReplay || !hasTask ? 'idle' : 'thinking',
       ended: false,
       ...(alias?.source ? { source: alias.source, backendSource: alias.source } : {}),
     };
     if (hasTask) meta.task = task;
     ensureSessionWindow(visibleSessionId, meta);
-    focusSessionWindowFromLifecycle(visibleSessionId, {
-      force: shouldFocusActivity,
-      currentTarget,
-    });
+    if (!replayed) {
+      focusSessionWindowFromLifecycle(visibleSessionId, {
+        force: shouldFocusActivity,
+        currentTarget,
+      });
+    }
   } else {
     updateTaskTargetChip();
+  }
+  if (replayed) {
+    refreshSessionWindowMetadata(250);
+    return;
   }
   resetChangesPane();
   focusActivityForSessionEvent({ force: shouldFocusActivity });

--- a/static/app/37-uicommand-changes-control.js
+++ b/static/app/37-uicommand-changes-control.js
@@ -93,8 +93,8 @@ function processCommands(cmds) {
       case 'delete_recording': deleteRecordingStream(c.stream_name); break;
       case 'recording_error': /* logged via add_log_entry */ break;
       case 'session_started':
-        managedContextSessionManuallySelected = false;
-        onSessionStarted(c.session_id, c.task);
+        if (!c.replayed) managedContextSessionManuallySelected = false;
+        onSessionStarted(c.session_id, c.task, { replayed: !!c.replayed });
         scheduleManagedContextRefresh(400);
         stationScheduleUpdate();
         break;

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -1,32 +1,43 @@
 // ── Session Lifecycle ──
-function onSessionStarted(sessionId, task) {
+function onSessionStarted(sessionId, task, opts = {}) {
   const sid = String(sessionId || '').trim();
   const hasTask = hasSessionLifecycleTask(task);
-  if (hasTask) {
+  // A replayed announcement (connect-time bootstrap for a session that
+  // started before this page existed) rebuilds the window but must not
+  // act like a live birth: no focus steal, no current-task clobber, no
+  // thinking phase, no changes-pane reset.
+  const replayed = !!opts.replayed;
+  if (hasTask && !replayed) {
     stationCurrentTask = compactSessionText(task);
     stationCurrentApproval = null;
   }
   stationScheduleUpdate();
-  const shouldFocusActivity = newSessionSpawnPending;
+  const shouldFocusActivity = !replayed && newSessionSpawnPending;
   const currentTarget = resolvePromptTargetSessionId();
-  finishNewSessionSpawnNotice(sid, task);
+  if (!replayed) finishNewSessionSpawnNotice(sid, task);
   const alias = externalBackendAliasForSession(sid);
   const visibleSessionId = alias?.backendSessionId || sid;
   if (visibleSessionId) {
     setSessionWindowDetached(visibleSessionId, false);
     const meta = {
-      phase: processingLogReplay || !hasTask ? 'idle' : 'thinking',
+      phase: replayed || processingLogReplay || !hasTask ? 'idle' : 'thinking',
       ended: false,
       ...(alias?.source ? { source: alias.source, backendSource: alias.source } : {}),
     };
     if (hasTask) meta.task = task;
     ensureSessionWindow(visibleSessionId, meta);
-    focusSessionWindowFromLifecycle(visibleSessionId, {
-      force: shouldFocusActivity,
-      currentTarget,
-    });
+    if (!replayed) {
+      focusSessionWindowFromLifecycle(visibleSessionId, {
+        force: shouldFocusActivity,
+        currentTarget,
+      });
+    }
   } else {
     updateTaskTargetChip();
+  }
+  if (replayed) {
+    refreshSessionWindowMetadata(250);
+    return;
   }
   resetChangesPane();
   focusActivityForSessionEvent({ force: shouldFocusActivity });


### PR DESCRIPTION
Closes the last confirmed QA-fleet product gap (late-join pages replay the timeline but build **zero grid windows** for live quiet sessions). The investigation found two independent causes, both fixed and empirically proven on a mock rig:

1. **Event-blind list caches**: `/api/sessions` response caches (30s hard-TTL + 15-min stale-while-revalidate) were never invalidated by the daemon's own lifecycle events — fresh sessions invisible to bare-endpoint callers (MCP/ctl/peers) *and* to the dashboard's own post-create refresh (`limit=all` hits the same full-list cache). A wiring-level bus listener now drops both tiers on session membership changes. Proof: the poisoned-cache repro (bare fetch pre-seed → fetch post-seed) went 1 stale row → all rows fresh.

2. **Birth announcements age out of the bootstrap tail**: the WS connect replay is tail-limited, so `session_started` entries for anything but the newest activity never reach a late joiner — and window creation is event-driven. `session_started` now rides the existing `session_state_lines` bootstrap cache (pruned on end), replayed first per session with `replayed: true`; the frontend rebuilds windows without live-birth side effects. Proof: CDP late-join capture went **0 windows → 2 windows** with correct ids and metadata hydration.

Battery: nextest 2692/2692 (new invalidation test), e2e 8/8, clippy baseline.