### PR TITLE
Frozen-dashboard incident fixes: transfer pump freeze, direct-mTLS transfer fallbacks, screencapturekit 8.0 (daemon segfault), app watchdog, virtual-display gating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "apple-cf"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7fd680cd0f3f02ee717b2014b26d18985c57b784384ba47213fcf8791e8c250"
+dependencies = [
+ "doom-fish-utils",
+]
+
+[[package]]
+name = "apple-metal"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b1c24b280fad9eadf6f2bf560d826392020ac6258b4c88c6dd356ae7a24f4e3"
+dependencies = [
+ "doom-fish-utils",
+ "libc",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,6 +1153,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1446,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
+]
+
+[[package]]
+name = "doom-fish-utils"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c801f6c2a0db1a1909d89fc395b9dccc594de9ef599659fbde9bb3b55ef67f9f"
+dependencies = [
+ "crossbeam-queue",
+ "futures-util",
 ]
 
 [[package]]
@@ -4986,9 +5024,13 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "screencapturekit"
-version = "1.5.4"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b732b2db50b25cfbcb171e1b7abda06e77873aeef493e635eb209482fdd149"
+checksum = "c549b1b0bc1ae3a536a88e3097d394234657402191e6867a3215bd897d43b9fd"
+dependencies = [
+ "apple-cf",
+ "apple-metal",
+]
 
 [[package]]
 name = "scrypt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ x11rb = { version = "0.13", features = ["shm", "damage", "xfixes", "xtest"] }
 atspi = { version = "0.30", features = ["tokio"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-screencapturekit = "1.5"
+screencapturekit = "8.0"
 core-graphics = { version = "0.25", features = ["highsierra"] }
 core-foundation = "0.10"
 shiguredo_video_toolbox = "2026.1"

--- a/crates/intendant-display/Cargo.toml
+++ b/crates/intendant-display/Cargo.toml
@@ -35,7 +35,7 @@ pipewire = "0.8"
 x11rb = { version = "0.13", features = ["shm", "damage", "xfixes", "xtest"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-screencapturekit = "1.5"
+screencapturekit = "8.0"
 core-graphics = { version = "0.25", features = ["highsierra"] }
 shiguredo_video_toolbox = "2026.1"
 

--- a/crates/intendant-display/src/macos.rs
+++ b/crates/intendant-display/src/macos.rs
@@ -63,7 +63,12 @@ impl InputGeometry {
     }
 
     fn from_sck_rect(rect: ScRect) -> Self {
-        Self::new(rect.x, rect.y, rect.width.max(1.0), rect.height.max(1.0))
+        Self::new(
+            rect.origin.x,
+            rect.origin.y,
+            rect.size.width.max(1.0),
+            rect.size.height.max(1.0),
+        )
     }
 
     fn point(self, x: f64, y: f64) -> CGPoint {
@@ -189,15 +194,15 @@ fn resolve_capture_target(
                 .find(|w| w.window_id() == window_id)
                 .ok_or_else(|| CallerError::Display(format!("window {window_id} not found")))?;
             let frame = window.frame();
-            if frame.width <= 0.0 || frame.height <= 0.0 {
+            if frame.size.width <= 0.0 || frame.size.height <= 0.0 {
                 return Err(CallerError::Display(format!(
                     "window {window_id} has invalid frame {}x{}",
-                    frame.width, frame.height
+                    frame.size.width, frame.size.height
                 )));
             }
             let scale = display_scale_for_sck_rect(frame);
-            let width = even_dimension_from_f64(frame.width * scale);
-            let height = even_dimension_from_f64(frame.height * scale);
+            let width = even_dimension_from_f64(frame.size.width * scale);
+            let height = even_dimension_from_f64(frame.size.height * scale);
             let filter = SCContentFilter::create().with_window(&window).build();
             Ok(ResolvedCaptureTarget {
                 filter,
@@ -251,8 +256,8 @@ fn current_input_geometry(target: &Arc<RwLock<InputGeometry>>) -> InputGeometry 
 
 fn display_scale_for_sck_rect(rect: ScRect) -> f64 {
     let cg_rect = CgRect::new(
-        &CGPoint::new(rect.x, rect.y),
-        &CGSize::new(rect.width.max(1.0), rect.height.max(1.0)),
+        &CGPoint::new(rect.origin.x, rect.origin.y),
+        &CGSize::new(rect.size.width.max(1.0), rect.size.height.max(1.0)),
     );
     if let Ok((display_ids, count)) = CGDisplay::displays_with_rect(cg_rect, 8) {
         if count > 0 {
@@ -312,14 +317,14 @@ fn dirty_rect_scale(sample: &CMSampleBuffer, rects: &[ScRect], frame_w: u32, fra
     let Some(content) = sample.content_rect() else {
         return 1.0;
     };
-    let scaled_w_matches = approx_eq(content.width * scale, frame_w as f64, 3.0);
-    let scaled_h_matches = approx_eq(content.height * scale, frame_h as f64, 3.0);
+    let scaled_w_matches = approx_eq(content.size.width * scale, frame_w as f64, 3.0);
+    let scaled_h_matches = approx_eq(content.size.height * scale, frame_h as f64, 3.0);
     if !scaled_w_matches || !scaled_h_matches {
         return 1.0;
     }
     let max_x = rects.iter().map(|r| r.max_x()).fold(0.0, f64::max);
     let max_y = rects.iter().map(|r| r.max_y()).fold(0.0, f64::max);
-    if max_x > content.width + 1.0 || max_y > content.height + 1.0 {
+    if max_x > content.size.width + 1.0 || max_y > content.size.height + 1.0 {
         1.0
     } else {
         scale
@@ -336,15 +341,15 @@ fn scaled_rect_to_damage_rect(
     frame_w: u32,
     frame_h: u32,
 ) -> Option<Rect> {
-    if frame_w == 0 || frame_h == 0 || rect.width <= 0.0 || rect.height <= 0.0 {
+    if frame_w == 0 || frame_h == 0 || rect.size.width <= 0.0 || rect.size.height <= 0.0 {
         return None;
     }
-    let x0 = (rect.x * scale).floor().clamp(0.0, frame_w as f64);
-    let y0 = (rect.y * scale).floor().clamp(0.0, frame_h as f64);
-    let x1 = ((rect.x + rect.width) * scale)
+    let x0 = (rect.origin.x * scale).floor().clamp(0.0, frame_w as f64);
+    let y0 = (rect.origin.y * scale).floor().clamp(0.0, frame_h as f64);
+    let x1 = ((rect.origin.x + rect.size.width) * scale)
         .ceil()
         .clamp(0.0, frame_w as f64);
-    let y1 = ((rect.y + rect.height) * scale)
+    let y1 = ((rect.origin.y + rect.size.height) * scale)
         .ceil()
         .clamp(0.0, frame_h as f64);
     if x1 <= x0 || y1 <= y0 {
@@ -435,12 +440,12 @@ fn enumerate_window_display_infos(content: &SCShareableContent) -> Vec<super::Di
             continue;
         };
         let frame = window.frame();
-        if frame.width <= 0.0 || frame.height <= 0.0 {
+        if frame.size.width <= 0.0 || frame.size.height <= 0.0 {
             continue;
         }
         let scale = display_scale_for_sck_rect(frame);
-        let width = even_dimension_from_f64(frame.width * scale);
-        let height = even_dimension_from_f64(frame.height * scale);
+        let width = even_dimension_from_f64(frame.size.width * scale);
+        let height = even_dimension_from_f64(frame.size.height * scale);
         if width < super::encode::pool::MIN_LAYER_DIM || height < super::encode::pool::MIN_LAYER_DIM
         {
             continue;
@@ -555,7 +560,7 @@ impl DisplayBackend for MacOSBackend {
 
                 if is_window_capture {
                     if let Some(bounds) = sample.bounding_rect() {
-                        if bounds.width > 0.0 && bounds.height > 0.0 {
+                        if bounds.size.width > 0.0 && bounds.size.height > 0.0 {
                             set_input_geometry(
                                 &input_geometry,
                                 InputGeometry::from_sck_rect(bounds),

--- a/crates/intendant-platform/src/vision.rs
+++ b/crates/intendant-platform/src/vision.rs
@@ -360,6 +360,13 @@ pub async fn launch_display(_config: &DisplayConfig) -> Result<XvfbGuard, Caller
     ))
 }
 
+/// Whether this daemon can launch virtual displays at all (Xvfb-based,
+/// Linux-only). Dashboards derive their "New virtual display" affordance
+/// from this single source instead of mirroring the platform matrix.
+pub fn virtual_displays_supported() -> bool {
+    cfg!(target_os = "linux")
+}
+
 // ── Display accessibility ───────────────────────────────────────────────────
 
 /// On macOS, the native display is always accessible.

--- a/macos-app/main.swift
+++ b/macos-app/main.swift
@@ -291,6 +291,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
     var backendProcess: Process?
     var healthTimer: Timer?
     var healthProbeFailures = 0
+    // Backend auto-restart: exponential backoff on abnormal exits, reset
+    // once a backend has stayed up long enough to count as stable.
+    var backendRestartAttempts = 0
+    var backendLastStart = Date.distantPast
+    var backendAutoRestartTimer: Timer?
+    var isTerminating = false
     var port: Int = 8765
     let portSearchLimit = 20
     var launchPlan: BackendLaunchPlan!
@@ -581,9 +587,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
     /// readiness poll (which lands on the placeholder / auto-activation).
     func restartBackend() {
         NSLog("Backend restart requested")
+        backendAutoRestartTimer?.invalidate()
         healthTimer?.invalidate()
         healthProbeFailures = 0
         if let proc = backendProcess, proc.isRunning {
+            proc.terminationHandler = nil
             proc.terminate()
         }
         startBackend()
@@ -591,8 +599,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        isTerminating = true
+        backendAutoRestartTimer?.invalidate()
         healthTimer?.invalidate()
         guard let proc = backendProcess, proc.isRunning else { return }
+        // Quitting kills the backend on purpose; don't let the exit handler
+        // paint a crash screen or schedule a restart mid-teardown.
+        proc.terminationHandler = nil
         proc.terminate()
         // Wait up to 3 seconds, then force-kill to avoid hanging on quit
         let deadline = Date().addingTimeInterval(3.0)
@@ -746,9 +759,53 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         do {
             try process.run()
             backendProcess = process
+            backendLastStart = Date()
+            // React to backend death immediately (the 5s health tick stays
+            // as the belt for a missed handler). Remote dashboards have no
+            // crash screen — without a restart this machine just goes dark.
+            process.terminationHandler = { [weak self] proc in
+                DispatchQueue.main.async {
+                    self?.backendDidExit(proc)
+                }
+            }
             NSLog("Started intendant-bin (PID \(process.processIdentifier)) on port \(port)")
         } catch {
             NSLog("Failed to start intendant-bin: \(error)")
+        }
+    }
+
+    /// Backend exit policy: abnormal exits (signal / non-zero status)
+    /// auto-restart with capped exponential backoff; a clean exit means
+    /// someone stopped the daemon deliberately, so only the manual Restart
+    /// button revives it.
+    func backendDidExit(_ proc: Process) {
+        guard !isTerminating, proc === backendProcess, !proc.isRunning else { return }
+        healthTimer?.invalidate()
+        let signalled = proc.terminationReason == .uncaughtSignal
+        let status = proc.terminationStatus
+        let abnormal = signalled || status != 0
+        NSLog("Backend exited (\(signalled ? "signal" : "status") \(status), \(abnormal ? "abnormal" : "clean"))")
+        guard abnormal else {
+            showBackendCrash(
+                title: "Backend stopped",
+                detail: "The daemon exited cleanly. Restart it to keep using this app."
+            )
+            return
+        }
+        if Date().timeIntervalSince(backendLastStart) > 600 {
+            backendRestartAttempts = 0
+        }
+        let delay = min(60.0, pow(2.0, Double(backendRestartAttempts + 1)))
+        backendRestartAttempts += 1
+        NSLog("Auto-restarting backend in \(Int(delay))s (attempt \(backendRestartAttempts))")
+        showBackendCrash(
+            title: "Backend process crashed",
+            detail: "Restarting in \(Int(delay))s (attempt \(backendRestartAttempts)) — see ~/.intendant/app-backend.log"
+        )
+        backendAutoRestartTimer?.invalidate()
+        backendAutoRestartTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+            guard let self = self, !self.isTerminating else { return }
+            self.restartBackend()
         }
     }
 
@@ -930,7 +987,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
             // Check if the backend process is still alive
             if let proc = self.backendProcess, !proc.isRunning {
                 self.healthTimer?.invalidate()
-                self.showBackendCrash()
+                self.backendDidExit(proc)
                 return
             }
             // Idle unload: an SPA nobody has seen for hours is pure cost —
@@ -974,22 +1031,30 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         URL(string: "\(launchPlan.scheme)://127.0.0.1:\(port)\(path)")!
     }
 
-    func showBackendCrash() {
-        NSLog("Backend process is no longer running")
+    func showBackendCrash(
+        title: String = "Backend process exited",
+        detail: String = "Check ~/.intendant/app-backend.log for details"
+    ) {
+        NSLog("Backend crash screen: \(title) — \(detail)")
         // A dead daemon is worth a window even if the user had closed it —
         // remotely this machine just went dark.
         if window == nil { createWindow() }
         dashboardActive = false
         guard webView != nil else { return }
+        let esc = { (s: String) -> String in
+            s.replacingOccurrences(of: "&", with: "&amp;")
+                .replacingOccurrences(of: "<", with: "&lt;")
+                .replacingOccurrences(of: ">", with: "&gt;")
+        }
         webView.loadHTMLString("""
             <html>
             <body style="background:#1e1e2e;color:#cdd6f4;font-family:-apple-system;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
             <div style="text-align:center">
-                <div style="font-size:20px;color:#f38ba8;margin-bottom:12px">Backend process exited</div>
-                <div style="font-size:14px;color:#6c7086;margin-bottom:16px">Check ~/.intendant/app-backend.log for details</div>
+                <div style="font-size:20px;color:#f38ba8;margin-bottom:12px">\(esc(title))</div>
+                <div style="font-size:14px;color:#6c7086;margin-bottom:16px">\(esc(detail))</div>
                 <button onclick="window.webkit.messageHandlers.restart && window.webkit.messageHandlers.restart.postMessage(null)"
                         style="padding:8px 24px;border:1px solid #89b4fa;border-radius:6px;background:transparent;color:#89b4fa;font-size:14px;cursor:pointer">
-                    Restart
+                    Restart now
                 </button>
             </div>
             </body>

--- a/macos-app/main.swift
+++ b/macos-app/main.swift
@@ -297,6 +297,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
     var backendLastStart = Date.distantPast
     var backendAutoRestartTimer: Timer?
     var isTerminating = false
+    // Readiness-poll chains carry a generation stamp; bumping it orphans
+    // any chain already in flight (a crash mid-boot must not let a stale
+    // chain paint its dead-end failure page over the restart countdown).
+    var pollGeneration = 0
     var port: Int = 8765
     let portSearchLimit = 20
     var launchPlan: BackendLaunchPlan!
@@ -585,7 +589,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
 
     /// Crash-screen Restart button: relaunch the backend and re-enter the
     /// readiness poll (which lands on the placeholder / auto-activation).
-    func restartBackend() {
+    @discardableResult
+    func restartBackend() -> Bool {
         NSLog("Backend restart requested")
         backendAutoRestartTimer?.invalidate()
         healthTimer?.invalidate()
@@ -594,8 +599,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
             proc.terminationHandler = nil
             proc.terminate()
         }
-        startBackend()
-        pollUntilReady()
+        let started = startBackend()
+        if started {
+            pollUntilReady()
+        }
+        return started
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -695,13 +703,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
 
     // MARK: - Backend
 
-    func startBackend() {
+    @discardableResult
+    func startBackend() -> Bool {
         let bundle = Bundle.main
         let binPath = bundle.bundlePath + "/Contents/MacOS/intendant-bin"
 
         guard FileManager.default.fileExists(atPath: binPath) else {
             NSLog("intendant-bin not found at \(binPath)")
-            return
+            return false
         }
 
         let process = Process()
@@ -769,8 +778,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
                 }
             }
             NSLog("Started intendant-bin (PID \(process.processIdentifier)) on port \(port)")
+            return true
         } catch {
             NSLog("Failed to start intendant-bin: \(error)")
+            return false
         }
     }
 
@@ -780,12 +791,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
     /// button revives it.
     func backendDidExit(_ proc: Process) {
         guard !isTerminating, proc === backendProcess, !proc.isRunning else { return }
+        // Consume the reference first: the health tick and the
+        // terminationHandler can both observe the same exit, and a second
+        // pass would double-count the attempt and reschedule the timer.
+        backendProcess = nil
         healthTimer?.invalidate()
         let signalled = proc.terminationReason == .uncaughtSignal
         let status = proc.terminationStatus
         let abnormal = signalled || status != 0
         NSLog("Backend exited (\(signalled ? "signal" : "status") \(status), \(abnormal ? "abnormal" : "clean"))")
         guard abnormal else {
+            pollGeneration += 1
             showBackendCrash(
                 title: "Backend stopped",
                 detail: "The daemon exited cleanly. Restart it to keep using this app."
@@ -795,6 +811,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         if Date().timeIntervalSince(backendLastStart) > 600 {
             backendRestartAttempts = 0
         }
+        scheduleBackendAutoRestart()
+    }
+
+    /// Arm (or re-arm) the auto-restart countdown with capped exponential
+    /// backoff, orphaning any readiness-poll chain so nothing paints over
+    /// the countdown screen. Re-entered by the timer itself when a spawn
+    /// attempt fails, so the chain never dead-ends.
+    func scheduleBackendAutoRestart() {
+        guard !isTerminating else { return }
+        pollGeneration += 1
         let delay = min(60.0, pow(2.0, Double(backendRestartAttempts + 1)))
         backendRestartAttempts += 1
         NSLog("Auto-restarting backend in \(Int(delay))s (attempt \(backendRestartAttempts))")
@@ -805,7 +831,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         backendAutoRestartTimer?.invalidate()
         backendAutoRestartTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
             guard let self = self, !self.isTerminating else { return }
-            self.restartBackend()
+            if !self.restartBackend() {
+                self.scheduleBackendAutoRestart()
+            }
         }
     }
 
@@ -919,6 +947,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
     // MARK: - Polling
 
     func pollUntilReady() {
+        pollGeneration += 1
         webView?.loadHTMLString("""
             <html>
             <body style="background:#1e1e2e;color:#cdd6f4;font-family:-apple-system;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
@@ -930,17 +959,27 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
             </html>
             """, baseURL: nil)
 
-        poll(attempts: 0)
+        poll(attempts: 0, generation: pollGeneration)
     }
 
-    func poll(attempts: Int) {
+    func poll(attempts: Int, generation: Int) {
+        // A crash or scheduled restart bumps pollGeneration; a stale chain
+        // must go silent rather than paint over the countdown screen.
+        guard generation == pollGeneration else { return }
         if attempts > 30 {
             // The window may have been closed while the backend booted;
             // the poll keeps running regardless, only painting is skipped.
             webView?.loadHTMLString("""
                 <html>
-                <body style="background:#1e1e2e;color:#f38ba8;font-family:-apple-system;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
-                <div>Failed to connect to backend on port \(port)</div>
+                <body style="background:#1e1e2e;color:#cdd6f4;font-family:-apple-system;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
+                <div style="text-align:center">
+                    <div style="font-size:20px;color:#f38ba8;margin-bottom:12px">Failed to connect to backend on port \(port)</div>
+                    <div style="font-size:14px;color:#6c7086;margin-bottom:16px">Check ~/.intendant/app-backend.log for details</div>
+                    <button onclick="window.webkit.messageHandlers.restart && window.webkit.messageHandlers.restart.postMessage(null)"
+                            style="padding:8px 24px;border:1px solid #89b4fa;border-radius:6px;background:transparent;color:#89b4fa;font-size:14px;cursor:pointer">
+                        Restart now
+                    </button>
+                </div>
                 </body>
                 </html>
                 """, baseURL: nil)
@@ -955,6 +994,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         backendSession.dataTask(with: request) { _, response, error in
             if let http = response as? HTTPURLResponse, http.statusCode == 200 {
                 DispatchQueue.main.async {
+                    guard generation == self.pollGeneration else { return }
                     // Backend is up. The SPA is deferred behind the
                     // placeholder unless a harness/user asked for it.
                     if self.autoActivateDashboard {
@@ -972,7 +1012,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
                     NSLog("Backend readiness poll failing (attempt \(attempts + 1)/30): status=\(status) error=\(error?.localizedDescription ?? "none")")
                 }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    self.poll(attempts: attempts + 1)
+                    self.poll(attempts: attempts + 1, generation: generation)
                 }
             }
         }.resume()

--- a/scripts/validate-connect-rendezvous.cjs
+++ b/scripts/validate-connect-rendezvous.cjs
@@ -2387,7 +2387,7 @@ async function main() {
         Object.prototype.hasOwnProperty.call(result.safeReads.projectRoot, 'project_root'),
       'project-root RPC did not return project_root'
     );
-    assert(Array.isArray(result.safeReads?.displays), 'displays RPC did not return an array');
+    assert(Array.isArray(result.safeReads?.displays?.displays), 'displays RPC did not return a displays list');
     assert(Array.isArray(result.safeReads?.managedContextRecords?.records), 'managed context records RPC did not return records');
     assert(Array.isArray(result.safeReads?.managedContextAnchors?.anchors), 'managed context anchors RPC did not return anchors');
     assert(Array.isArray(result.safeReads?.managedContextFission?.groups), 'managed context fission RPC did not return groups');
@@ -2907,7 +2907,7 @@ async function main() {
         dashboardBootstrapFrameCount: result.dashboardBootstrap.frame_count,
         sessionCount: result.sessions.length,
         sessionsSearchResultCount: result.safeReads.sessionsSearch.results.length,
-        displaysCount: result.safeReads.displays.length,
+        displaysCount: result.safeReads.displays.displays.length,
         managedContextRecordCount: result.safeReads.managedContextRecords.records.length,
         managedContextAnchorCount: result.safeReads.managedContextAnchors.anchors.length,
         managedContextFissionGroupCount: result.safeReads.managedContextFission.groups.length,

--- a/scripts/validate-dashboard-control-local-signaling.cjs
+++ b/scripts/validate-dashboard-control-local-signaling.cjs
@@ -786,7 +786,7 @@ async function main() {
         Object.prototype.hasOwnProperty.call(result.safeReads.projectRoot, 'project_root'),
       'project-root RPC did not return project_root'
     );
-    assert(Array.isArray(result.safeReads?.displays), 'displays RPC did not return an array');
+    assert(Array.isArray(result.safeReads?.displays?.displays), 'displays RPC did not return a displays list');
     assert(Array.isArray(result.safeReads?.managedContextRecords?.records), 'managed context records RPC did not return records');
     assert(Array.isArray(result.safeReads?.managedContextAnchors?.anchors), 'managed context anchors RPC did not return anchors');
     assert(Array.isArray(result.safeReads?.managedContextFission?.groups), 'managed context fission RPC did not return groups');
@@ -995,7 +995,7 @@ async function main() {
         dashboardBootstrapFrameCount: result.dashboardBootstrap.frame_count,
         sessionCount: result.sessions.length,
         sessionsSearchResultCount: result.safeReads.sessionsSearch.results.length,
-        displaysCount: result.safeReads.displays.length,
+        displaysCount: result.safeReads.displays.displays.length,
         managedContextRecordCount: result.safeReads.managedContextRecords.records.length,
         managedContextAnchorCount: result.safeReads.managedContextAnchors.anchors.length,
         managedContextFissionGroupCount: result.safeReads.managedContextFission.groups.length,

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -2182,6 +2182,12 @@ pub(crate) fn status_response_frame(id: String, runtime: &ControlRuntime) -> ser
             "api_coordinator_available",
             peer_registry_available && peer_manage,
         ),
+        // Host capability, not a grant: dashboards derive the "New virtual
+        // display" affordance from this (Xvfb-based, Linux-only).
+        (
+            "virtual_displays_available",
+            crate::vision::virtual_displays_supported(),
+        ),
     ];
     for (name, available) in capabilities {
         result.insert(name.to_string(), serde_json::json!(available));

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -46,6 +46,11 @@ const MIN_HEIGHT: u32 = 240;
 const MAX_WIDTH: u32 = 3840;
 const MAX_HEIGHT: u32 = 2160;
 
+/// Failure-report id for platforms where no display number is ever
+/// allocated. Must never match a real capture session: the
+/// DisplayCaptureLost handler tears down whatever session carries the id.
+const VIRTUAL_DISPLAY_UNSUPPORTED_SENTINEL: u32 = u32::MAX;
+
 /// Resolve requested dimensions: defaults for omitted axes, bounds-checked,
 /// rounded down to even (VP8 rejects odd frame dimensions).
 pub(crate) fn virtual_display_dimensions(
@@ -76,18 +81,19 @@ pub(crate) async fn create_virtual_display(
     width: Option<u32>,
     height: Option<u32>,
 ) {
-    // Unsupported platforms bail before any display number is chosen: the
-    // failure fallback below reports through DisplayCaptureLost, and with
-    // no allocation the fallback id can collide with a live capture (a
-    // failed macOS create once tore down the real display-0 session).
+    // Unsupported platforms bail before any display number is chosen. The
+    // error still flows through DisplayCaptureLost (the channel dashboards
+    // and MCP callers toast), but against a sentinel id: with no allocation
+    // the natural fallback id is 0, and the DisplayCaptureLost handler
+    // tears down whatever live session matches — a failed macOS create once
+    // killed the real display-0 capture that way.
     if !vision::virtual_displays_supported() {
-        bus.send(AppEvent::PresenceLog {
-            message: "[virtual_display] not available on this platform: virtual displays are \
-                      Xvfb-based and Linux-only; use \"Your display\" to stream this desktop instead"
-                .to_string(),
-            level: Some(LogLevel::Warn),
-            turn: None,
-        });
+        report_user_display_capture_unavailable(
+            bus,
+            VIRTUAL_DISPLAY_UNSUPPORTED_SENTINEL,
+            "virtual display create failed: virtual displays are Xvfb-based and Linux-only; \
+             use \"Your display\" to stream this machine's desktop instead",
+        );
         return;
     }
 

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -76,6 +76,21 @@ pub(crate) async fn create_virtual_display(
     width: Option<u32>,
     height: Option<u32>,
 ) {
+    // Unsupported platforms bail before any display number is chosen: the
+    // failure fallback below reports through DisplayCaptureLost, and with
+    // no allocation the fallback id can collide with a live capture (a
+    // failed macOS create once tore down the real display-0 session).
+    if !vision::virtual_displays_supported() {
+        bus.send(AppEvent::PresenceLog {
+            message: "[virtual_display] not available on this platform: virtual displays are \
+                      Xvfb-based and Linux-only; use \"Your display\" to stream this desktop instead"
+                .to_string(),
+            level: Some(LogLevel::Warn),
+            turn: None,
+        });
+        return;
+    }
+
     // Displays this daemon holds alive must never be orphan-reclaimed by
     // the allocator: our own guards, plus every registered virtual capture
     // session (an agent-launched Xvfb has a session but no guard here).

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -312,7 +312,15 @@ pub(crate) async fn displays_response_body(
     session_registry: &Option<crate::display::SharedSessionRegistry>,
 ) -> String {
     let displays = crate::display::enumerate_displays_with_sessions(session_registry).await;
-    serde_json::to_string(&displays).unwrap_or_else(|_| "[]".to_string())
+    // Object form (normalizeDisplaysPayload accepts both): the displays
+    // surface also advertises display capabilities, so dashboards derive
+    // affordances like "New virtual display" instead of mirroring the
+    // platform matrix.
+    serde_json::to_string(&serde_json::json!({
+        "displays": displays,
+        "virtual_displays_available": crate::vision::virtual_displays_supported(),
+    }))
+    .unwrap_or_else(|_| "{\"displays\":[]}".to_string())
 }
 
 async fn handle_diagnostics_visual_freshness(

--- a/static/app.html
+++ b/static/app.html
@@ -21998,7 +21998,7 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
           </div>
           <div class="ui-empty-title">No displays active</div>
           <div class="ui-empty-hint">Displays appear when the agent launches a GUI or you share your screen — or create one right here</div>
-          <button class="ui-empty-btn" id="displays-create-virtual" onclick="createVirtualDisplay(event)" title="Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed. Linux hosts only.">New virtual display</button>
+          <button class="ui-empty-btn" id="displays-create-virtual" hidden onclick="createVirtualDisplay(event)" title="Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed.">New virtual display</button>
         </div>
       </div>
       <div class="displays-collapse-bar hidden" id="displays-collapse-bar">
@@ -86951,16 +86951,18 @@ function showDisplayPicker(displays) {
     });
     picker.appendChild(item);
   }
-  const createItem = document.createElement('div');
-  createItem.className = 'display-picker-item dp-action';
-  createItem.textContent = 'New virtual display';
-  createItem.title = 'Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed. Linux hosts only.';
-  createItem.addEventListener('click', (e) => {
-    e.stopPropagation();
-    hideDisplayPicker();
-    createVirtualDisplay();
-  });
-  picker.appendChild(createItem);
+  if (daemonVirtualDisplaysAvailable === true) {
+    const createItem = document.createElement('div');
+    createItem.className = 'display-picker-item dp-action';
+    createItem.textContent = 'New virtual display';
+    createItem.title = 'Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed.';
+    createItem.addEventListener('click', (e) => {
+      e.stopPropagation();
+      hideDisplayPicker();
+      createVirtualDisplay();
+    });
+    picker.appendChild(createItem);
+  }
   // ui-v2 hides #status-bar (the picker's v1 anchor subtree), so an
   // in-place open can never render — portal to <body> and pin the popover
   // to the live rail's "Your screen" card (the control that proxies the
@@ -87351,6 +87353,23 @@ document.getElementById('strip-minimize')?.addEventListener('click', (e) => {
     document.body.style.userSelect = '';
   });
 })();
+
+// ── Virtual display availability ──
+// Virtual displays are a host capability (Xvfb-based, Linux-only): derive
+// the "New virtual display" affordances from the daemon's displays payload
+// instead of offering a button that can only fail on macOS/Windows hosts.
+let daemonVirtualDisplaysAvailable = null;
+async function refreshVirtualDisplayAvailability() {
+  try {
+    const payload = await fetchLocalDisplaysPayload();
+    daemonVirtualDisplaysAvailable = payload?.virtual_displays_available === true;
+  } catch (_) {
+    daemonVirtualDisplaysAvailable = null;
+  }
+  const btn = document.getElementById('displays-create-virtual');
+  if (btn) btn.hidden = daemonVirtualDisplaysAvailable !== true;
+}
+refreshVirtualDisplayAvailability();
 
 // ── Start ──
 main();

--- a/static/app.html
+++ b/static/app.html
@@ -21997,7 +21997,7 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
             </svg>
           </div>
           <div class="ui-empty-title">No displays active</div>
-          <div class="ui-empty-hint">Displays appear when the agent launches a GUI or you share your screen — or create one right here</div>
+          <div class="ui-empty-hint">Displays appear when the agent launches a GUI or you share your screen</div>
           <button class="ui-empty-btn" id="displays-create-virtual" hidden onclick="createVirtualDisplay(event)" title="Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed.">New virtual display</button>
         </div>
       </div>
@@ -63580,6 +63580,7 @@ function dashboardUpdateTransportStatus() {
   renderConnectHealthPanel(status, summary);
   renderDashboardTargetSummaries();
   refreshFilesDownloadAvailability();
+  updateVirtualDisplayAvailabilityUi();
   if (activeTab === 'files') refreshFilesTransferJobs();
   maybeOpenShellAfterTransportReady();
 }
@@ -67481,6 +67482,18 @@ function downloadDashboardBytes(bytes, filename, contentType) {
 function rangedDownloadTimeoutMs(chunkBytes) {
   const size = Number(chunkBytes) || DASHBOARD_RANGED_DOWNLOAD_CHUNK_BYTES;
   return Math.max(30000, Math.ceil(size / (256 * 1024)) * 10000);
+}
+
+// Compose a caller's abort signal with a hard timeout. fetch() has no
+// default timeout, and the transfers pump runs entries strictly
+// sequentially — a single hung request must fail rather than wedge the
+// whole queue behind it.
+function dashboardComposeFetchSignal(signal, timeoutMs) {
+  const ms = Number(timeoutMs) || 0;
+  if (!(ms > 0) || typeof AbortSignal?.timeout !== 'function') return signal || undefined;
+  const timeout = AbortSignal.timeout(ms);
+  if (!signal) return timeout;
+  return typeof AbortSignal.any === 'function' ? AbortSignal.any([signal, timeout]) : signal;
 }
 
 async function dashboardRequestBytesWithRetry(method, params, options = {}) {
@@ -77441,6 +77454,7 @@ function filesUpdateActiveDownloadSummary(transfer = null) {
 }
 
 function queueFilesTransfer(transfer) {
+  transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
   filesTransferCompletion(transfer);
   filesTransfers.unshift(transfer);
   filesTransferPersistState();
@@ -77760,27 +77774,7 @@ async function runFilesDownloadTransfer(transfer) {
       }
       if (transfer.loaded >= transfer.totalSize || range.bytes.byteLength === 0) break;
     }
-    const blob = new Blob(transfer.parts, { type: transfer.contentType || 'application/octet-stream' });
-    const result = {
-      ok: true,
-      blob,
-      parts: transfer.parts.slice(),
-      filename: transfer.filename || 'download.bin',
-      content_type: transfer.contentType,
-      size: blob.size,
-      total_size: transfer.totalSize || blob.size,
-      range_start: 0,
-      range_end: transfer.loaded,
-      range_count: transfer.rangeCount,
-      resumable: true,
-    };
-    transfer.result = result;
-    transfer.status = 'completed';
-    filesTransferPersistState();
-    setFilesDownloadProgress(result.size, result.total_size || result.size);
-    setFilesDownloadStatus('ok', `Downloaded ${result.filename} (${humanBytes(result.size)})`);
-    if (!transfer.skipBrowserSave) downloadDashboardBlob(result.blob, result.filename, result.content_type);
-    transfer.resolve?.(result);
+    settleCompletedFilesDownload(transfer, { resumable: true });
   } catch (err) {
     const message = err?.message || String(err);
     if (transfer.cancelRequested) {
@@ -77812,6 +77806,34 @@ async function runFilesDownloadTransfer(transfer) {
   }
 }
 
+// Shared settle for a fully-downloaded transfer: build the result from the
+// accumulated parts, mark completed, and surface it. Both the ranged runner
+// and the one-shot staged-raw path end here — keep them from diverging.
+function settleCompletedFilesDownload(transfer, { resumable }) {
+  const blob = new Blob(transfer.parts, { type: transfer.contentType || 'application/octet-stream' });
+  const result = {
+    ok: true,
+    blob,
+    parts: transfer.parts.slice(),
+    filename: transfer.filename || 'download.bin',
+    content_type: transfer.contentType,
+    size: blob.size,
+    total_size: transfer.totalSize || blob.size,
+    range_start: 0,
+    range_end: transfer.loaded,
+    range_count: transfer.rangeCount,
+    resumable,
+  };
+  transfer.result = result;
+  transfer.status = 'completed';
+  filesTransferPersistState();
+  setFilesDownloadProgress(result.size, result.total_size || result.size);
+  setFilesDownloadStatus('ok', `Downloaded ${result.filename} (${humanBytes(result.size)})`);
+  if (!transfer.skipBrowserSave) downloadDashboardBlob(result.blob, result.filename, result.content_type);
+  transfer.resolve?.(result);
+  return result;
+}
+
 // Server errors like "no project root" are accurate but unactionable in the
 // transfers pane; translate the known ones before surfacing.
 function filesTransferFriendlyServerError(error, fallback) {
@@ -77821,19 +77843,6 @@ function filesTransferFriendlyServerError(error, fallback) {
     return 'This daemon has no project open — staged uploads and resumable transfers need an active session with a project root';
   }
   return message;
-}
-
-function filesTransferBlobToBase64(blob) {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onerror = () => reject(new Error('Failed to read upload file'));
-    reader.onload = () => {
-      const url = String(reader.result || '');
-      const comma = url.indexOf(',');
-      resolve(comma >= 0 ? url.slice(comma + 1) : '');
-    };
-    reader.readAsDataURL(blob);
-  });
 }
 
 // Staged-upload artifact download over plain HTTP: one-shot fetch of
@@ -77850,7 +77859,7 @@ async function runFilesStagedRawHttpDownload(transfer, controller) {
   const id = String(transfer.artifact?.id || '').trim();
   const resp = await authedFetch(`/api/session/current/uploads/${encodeURIComponent(id)}/raw`, {
     cache: 'no-store',
-    signal: controller.signal,
+    signal: dashboardComposeFetchSignal(controller.signal, transfer.timeoutMs || 300000),
   });
   if (!resp.ok) {
     const body = await resp.json().catch(() => ({}));
@@ -77875,26 +77884,7 @@ async function runFilesStagedRawHttpDownload(transfer, controller) {
   transfer.totalSize = bytes.byteLength;
   transfer.loaded = bytes.byteLength;
   transfer.rangeCount = 1;
-  const result = {
-    ok: true,
-    blob,
-    parts: transfer.parts.slice(),
-    filename: transfer.filename,
-    content_type: transfer.contentType,
-    size: blob.size,
-    total_size: blob.size,
-    range_start: 0,
-    range_end: bytes.byteLength,
-    range_count: 1,
-    resumable: false,
-  };
-  transfer.result = result;
-  transfer.status = 'completed';
-  filesTransferPersistState();
-  setFilesDownloadProgress(result.size, result.total_size || result.size);
-  setFilesDownloadStatus('ok', `Downloaded ${result.filename} (${humanBytes(result.size)})`);
-  if (!transfer.skipBrowserSave) downloadDashboardBlob(result.blob, result.filename, result.content_type);
-  transfer.resolve?.(result);
+  settleCompletedFilesDownload(transfer, { resumable: false });
 }
 
 // Filesystem upload over plain HTTP: the durable transfer-job RPC needs the
@@ -77918,24 +77908,13 @@ async function runFilesFilesystemUploadHttpFallback(transfer, controller) {
   }
   const destination = await filesResolveHttpUploadDestinationPath(transfer, file);
   setFilesUploadStatus('warn', `Uploading ${transfer.name} to ${destination}`);
-  const body = {
-    path: destination,
-    content_b64: await filesTransferBlobToBase64(file),
-  };
-  if (conflict === 'overwrite') {
-    body.force = true;
-  } else {
-    body.create_new = true;
-  }
-  const resp = await authedFetch('/api/fs/write', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-    signal: controller.signal,
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const resp = await filesIdeWriteFile('', destination, bytes, {
+    ...(conflict === 'overwrite' ? { force: true } : { create_new: true }),
+    signal: dashboardComposeFetchSignal(controller.signal, transfer.timeoutMs || rangedDownloadTimeoutMs(file.size)),
   });
-  const payload = await resp.json().catch(() => ({}));
-  if (!resp.ok || payload?.ok === false) {
-    throw new Error(filesTransferFriendlyServerError(payload?.error, `file write returned HTTP ${resp.status}`));
+  if (!resp.ok) {
+    throw new Error(filesTransferFriendlyServerError(resp.body?.error, `file write returned HTTP ${resp.status}`));
   }
   transfer.loaded = transfer.totalSize;
   transfer.status = 'completed';
@@ -77952,11 +77931,14 @@ async function filesResolveHttpUploadDestinationPath(transfer, file) {
   const raw = String(transfer.destination || '').trim();
   if (!raw) throw new Error('missing upload destination');
   const name = String(transfer.name || file.name || 'upload.bin');
-  let status = null;
+  let status;
   try {
     status = await fetchProjectPathStatus(raw);
-  } catch (_) {
-    status = null;
+  } catch (err) {
+    // A failed stat is not "does not exist": guessing here either rejects
+    // a valid directory destination or writes the file over the directory
+    // path itself. Fail retryably instead.
+    throw new Error(`Could not verify upload destination ${raw}: ${err?.message || err}`);
   }
   if (status?.exists && status.is_dir) {
     return `${raw.replace(/\/+$/, '')}/${name}`;
@@ -77969,6 +77951,14 @@ async function filesResolveHttpUploadDestinationPath(transfer, file) {
 
 async function runFilesFilesystemUploadTransfer(transfer, controller) {
   if (!await ensureDashboardTransferUploadAvailable({ signal: controller.signal })) {
+    if (transfer.serverJobId || transfer.resumeToken) {
+      // A durable job already holds this upload's chunks server-side.
+      // Rerouting to the whole-file fallback would orphan that job (no
+      // GC; the Files tab re-merges it as a ghost row forever) and throw
+      // away resumability — fail clearly and keep the resume for when
+      // the control channel is back.
+      throw new Error('Resuming this upload needs the dashboard control channel — retry when it reconnects, or cancel to discard the partial upload');
+    }
     if (!dashboardConnectModeEnabled()) {
       return runFilesFilesystemUploadHttpFallback(transfer, controller);
     }
@@ -78072,6 +78062,7 @@ async function runFilesUploadTransfer(transfer) {
   transfer.error = '';
   transfer.loaded = Number(transfer.loaded || 0);
   transfer.cancelRequested = false;
+  transfer.transport = '';
   const controller = new AbortController();
   transfer.abortController = controller;
   renderFilesTransfers();
@@ -78123,7 +78114,7 @@ async function runFilesUploadTransfer(transfer) {
             method: 'POST',
             headers: { 'Content-Type': transfer.file.type || transfer.mime || 'application/octet-stream' },
             body: transfer.file,
-            signal: controller.signal,
+            signal: dashboardComposeFetchSignal(controller.signal, transfer.timeoutMs || rangedDownloadTimeoutMs(transfer.file.size)),
           }
         );
         const payload = await resp.json().catch(() => null);
@@ -78167,18 +78158,25 @@ async function pumpFilesTransfers() {
     for (;;) {
       const transfer = filesTransfers.slice().reverse().find(item => item.status === 'queued');
       if (!transfer) break;
+      const epoch = transfer.queueEpoch || 0;
       const failure = transfer.kind === 'upload'
         ? await runFilesUploadTransfer(transfer).then(() => null, err => err)
         : await runFilesDownloadTransfer(transfer).then(() => null, err => err);
-      if (['queued', 'running'].includes(transfer.status)) {
+      if (
+        ['queued', 'running'].includes(transfer.status) &&
+        (transfer.queueEpoch || 0) === epoch
+      ) {
         // Forward-progress backstop: a runner that exits without settling
         // its transfer would be re-picked by the find() above forever — a
         // synchronous microtask spin that freezes the page and allocates
         // without bound. Force the entry failed so the pump always drains.
+        // The epoch check exempts entries the user legitimately re-queued
+        // (Resume/Retry bump it) while the runner was tearing down.
         transfer.status = 'failed';
         transfer.error = failure?.message || transfer.error || 'transfer runner exited without settling';
         filesTransferPersistState();
         renderFilesTransfers();
+        transfer.reject?.(failure || new Error(transfer.error));
       }
       // Macrotask yield: even a misbehaving runner that settles instantly
       // can only busy the tab, never wedge the event loop.
@@ -78237,6 +78235,7 @@ function cancelFilesTransfer(id) {
 function resumeFilesTransfer(id) {
   const transfer = filesTransferById(id);
   if (!transfer || !['paused', 'failed'].includes(transfer.status)) return null;
+  transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
   transfer.status = 'queued';
   transfer.error = '';
   transfer.pauseRequested = false;
@@ -78252,6 +78251,7 @@ function retryFilesTransfer(id) {
   const transfer = filesTransferById(id);
   if (!transfer || !['failed', 'cancelled', 'completed'].includes(transfer.status)) return null;
   if (transfer.kind === 'download') resetFilesDownloadTransfer(transfer);
+  transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
   transfer.status = 'queued';
   transfer.error = '';
   transfer.cancelRequested = false;
@@ -78406,49 +78406,23 @@ async function downloadFilesStagedUpload(id) {
   const upload = filesStagedUploads.get(String(id || ''));
   if (!upload) return null;
   try {
-    if (dashboardTransferDownloadAvailable()) {
-      const name = filesStagedDescriptorName(upload);
-      const transfer = queueDashboardArtifactDownload({
-        type: 'staged_upload',
-        id: String(id || ''),
-      }, {
-        sourceLabel: `Staged upload: ${name}`,
-        filename: name,
-        contentType: upload.mime || upload.content_type || 'application/octet-stream',
-        directMethod: 'api_session_current_upload_raw',
-        directParams: { id: String(id || '') },
-      });
-      if (!transfer) throw new Error('Staged upload download was not queued');
-      const result = await transfer.completion;
-      setFilesUploadStatus('ok', `Downloaded ${result.filename || name}`);
-      return result;
-    }
-    if (dashboardConnectModeEnabled()) {
-      throw new Error('Staged upload download is unavailable until file access is ready');
-    }
+    // One implementation for every transport: queue a transfer and let
+    // runFilesDownloadTransfer pick durable RPC, byte-stream, or the
+    // staged-raw HTTP fallback — the inline fetch this replaces had
+    // drifted (no size cap, no cancel, raw server errors).
     const name = filesStagedDescriptorName(upload);
-    const resp = await authedFetch(`/api/session/current/uploads/${encodeURIComponent(id)}/raw`, {
-      cache: 'no-store',
-    });
-    if (!resp.ok) {
-      const body = await resp.json().catch(() => ({}));
-      throw new Error(body.error || `staged upload download returned ${resp.status}`);
-    }
-    const blob = await resp.blob();
-    const result = {
-      ok: true,
-      blob,
+    const transfer = queueDashboardArtifactDownload({
+      type: 'staged_upload',
+      id: String(id || ''),
+    }, {
+      sourceLabel: `Staged upload: ${name}`,
       filename: name,
-      content_type: resp.headers.get('content-type') || upload.mime || 'application/octet-stream',
-      size: blob.size,
-      total_size: blob.size,
-      range_count: 1,
-    };
-    downloadDashboardBlob(
-      result.blob,
-      result.filename || name,
-      result.content_type || upload.mime || 'application/octet-stream'
-    );
+      contentType: upload.mime || upload.content_type || 'application/octet-stream',
+      directMethod: 'api_session_current_upload_raw',
+      directParams: { id: String(id || '') },
+    });
+    if (!transfer) throw new Error('Staged upload download was not queued');
+    const result = await transfer.completion;
     setFilesUploadStatus('ok', `Downloaded ${result.filename || name}`);
     return result;
   } catch (err) {
@@ -78788,6 +78762,7 @@ async function filesIdeWriteFile(hostId, path, bytes, opts = {}) {
   if (opts.expected_sha256) params.expected_sha256 = opts.expected_sha256;
   if (opts.create_new) params.create_new = true;
   if (opts.force) params.force = true;
+  const requestOpts = { signal: opts.signal, timeoutMs: opts.timeoutMs };
   if (hostId) {
     const conn = await filesIdePeerConnection(hostId);
     if (conn.lastStatus && conn.lastStatus.api_fs_write_available === false) {
@@ -78797,20 +78772,21 @@ async function filesIdeWriteFile(hostId, path, bytes, opts = {}) {
         body: { error: `${filesIdeHostLabel(hostId)} grants read-only file access to this daemon` },
       };
     }
-    const payload = await conn.uploadBytes('api_fs_write', params, bytes);
+    const payload = await conn.uploadBytes('api_fs_write', params, bytes, requestOpts);
     return filesIdeNormalizePayload(payload);
   }
   if (dashboardConnectModeEnabled()) {
     if (!(dashboardTransport?.canUseRpc?.() && dashboardControlTransport?.lastStatus?.api_fs_write_available !== false)) {
       return { ok: false, status: 503, body: { error: 'File writes are unavailable until this dashboard reconnects' } };
     }
-    const payload = await dashboardControlTransport.uploadBytes('api_fs_write', params, bytes);
+    const payload = await dashboardControlTransport.uploadBytes('api_fs_write', params, bytes, requestOpts);
     return filesIdeNormalizePayload(payload);
   }
   const resp = await authedFetch('/api/fs/write', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ ...params, content_b64: dashboardControlBytesToBase64(bytes) }),
+    signal: opts.signal,
   });
   const body = await resp.json().catch(() => ({}));
   return { ok: resp.ok, status: resp.status, body: body || {} };
@@ -86951,7 +86927,7 @@ function showDisplayPicker(displays) {
     });
     picker.appendChild(item);
   }
-  if (daemonVirtualDisplaysAvailable === true) {
+  if (virtualDisplaysAvailableNow()) {
     const createItem = document.createElement('div');
     createItem.className = 'display-picker-item dp-action';
     createItem.textContent = 'New virtual display';
@@ -87356,18 +87332,32 @@ document.getElementById('strip-minimize')?.addEventListener('click', (e) => {
 
 // ── Virtual display availability ──
 // Virtual displays are a host capability (Xvfb-based, Linux-only): derive
-// the "New virtual display" affordances from the daemon's displays payload
-// instead of offering a button that can only fail on macOS/Windows hosts.
+// the "New virtual display" affordances from the daemon instead of offering
+// a button that can only fail on macOS/Windows hosts. Two sources, because
+// each covers a transport the other can't: the displays payload reaches
+// direct dashboards over HTTP, and the dashboard-control status capability
+// reaches Connect dashboards once the channel is up (the HTTP probe is
+// impossible there, so dashboardUpdateTransportStatus re-applies the gate
+// whenever transport state changes).
 let daemonVirtualDisplaysAvailable = null;
-async function refreshVirtualDisplayAvailability() {
-  try {
-    const payload = await fetchLocalDisplaysPayload();
-    daemonVirtualDisplaysAvailable = payload?.virtual_displays_available === true;
-  } catch (_) {
-    daemonVirtualDisplaysAvailable = null;
-  }
+function virtualDisplaysAvailableNow() {
+  return daemonVirtualDisplaysAvailable === true ||
+    dashboardControlTransport?.lastStatus?.virtual_displays_available === true;
+}
+function updateVirtualDisplayAvailabilityUi() {
   const btn = document.getElementById('displays-create-virtual');
-  if (btn) btn.hidden = daemonVirtualDisplaysAvailable !== true;
+  if (btn) btn.hidden = !virtualDisplaysAvailableNow();
+}
+async function refreshVirtualDisplayAvailability() {
+  if (!dashboardConnectModeEnabled()) {
+    try {
+      const payload = await fetchLocalDisplaysPayload();
+      daemonVirtualDisplaysAvailable = payload?.virtual_displays_available === true;
+    } catch (_) {
+      daemonVirtualDisplaysAvailable = null;
+    }
+  }
+  updateVirtualDisplayAvailabilityUi();
 }
 refreshVirtualDisplayAvailability();
 

--- a/static/app.html
+++ b/static/app.html
@@ -77576,26 +77576,10 @@ function filesTransferApplyServerJob(transfer, job) {
 }
 
 async function runFilesDownloadTransfer(transfer) {
-  const peerId = String(transfer.peerId || '').trim();
-  let usePeerDashboardControl = Boolean(peerId) && peerDashboardControlSignalAvailable(peerId);
-  let usePeerFileTransfer = Boolean(peerId) && !usePeerDashboardControl;
-  const useDurableTransfer = !peerId && dashboardTransferDownloadAvailable();
-  const hasArtifact = Boolean(transfer.artifact && typeof transfer.artifact === 'object');
-  const fallbackMethod = String(transfer.directMethod || (!hasArtifact ? 'api_fs_read' : '')).trim();
-  const canUseFallbackMethod = !peerId && Boolean(fallbackMethod && dashboardByteStreamMethodAvailable(fallbackMethod));
-  const useHttpFilesystemFallback = !useDurableTransfer &&
-    !canUseFallbackMethod &&
-    !peerId &&
-    !hasArtifact &&
-    !dashboardConnectModeEnabled();
-  if (peerId && !usePeerDashboardControl && !peerFileTransferSignalAvailable(peerId)) {
-    throw new Error(filesDownloadUnavailableMessage(peerId));
-  }
-  if (!peerId && !useDurableTransfer && !canUseFallbackMethod && !useHttpFilesystemFallback) {
-    throw new Error(hasArtifact
-      ? 'Artifact download is unavailable until resumable file access is ready'
-      : filesDownloadUnavailableMessage());
-  }
+  // Mark the transfer running before any transport checks: an early throw
+  // that left the status at 'queued' would make pumpFilesTransfers re-pick
+  // the same entry forever, so every failure must flow through the catch
+  // below. The transport guards therefore live inside the try.
   transfer.status = 'running';
   transfer.error = '';
   transfer.pauseRequested = false;
@@ -77609,6 +77593,39 @@ async function runFilesDownloadTransfer(transfer) {
   let peerConnection = null;
   let peerDashboardConnection = null;
   try {
+    const peerId = String(transfer.peerId || '').trim();
+    let usePeerDashboardControl = Boolean(peerId) && peerDashboardControlSignalAvailable(peerId);
+    let usePeerFileTransfer = Boolean(peerId) && !usePeerDashboardControl;
+    const useDurableTransfer = !peerId && dashboardTransferDownloadAvailable();
+    const hasArtifact = Boolean(transfer.artifact && typeof transfer.artifact === 'object');
+    const fallbackMethod = String(transfer.directMethod || (!hasArtifact ? 'api_fs_read' : '')).trim();
+    const canUseFallbackMethod = !peerId && Boolean(fallbackMethod && dashboardByteStreamMethodAvailable(fallbackMethod));
+    const useHttpFilesystemFallback = !useDurableTransfer &&
+      !canUseFallbackMethod &&
+      !peerId &&
+      !hasArtifact &&
+      !dashboardConnectModeEnabled();
+    // Staged uploads are also served over plain HTTP, so a direct-connected
+    // dashboard without the control channel can still download them.
+    const useHttpStagedRawFallback = !useDurableTransfer &&
+      !canUseFallbackMethod &&
+      !peerId &&
+      hasArtifact &&
+      transfer.artifact.type === 'staged_upload' &&
+      String(transfer.artifact.id || '').trim() !== '' &&
+      !dashboardConnectModeEnabled();
+    if (peerId && !usePeerDashboardControl && !peerFileTransferSignalAvailable(peerId)) {
+      throw new Error(filesDownloadUnavailableMessage(peerId));
+    }
+    if (!peerId && !useDurableTransfer && !canUseFallbackMethod && !useHttpFilesystemFallback && !useHttpStagedRawFallback) {
+      throw new Error(hasArtifact
+        ? 'Artifact download is unavailable until resumable file access is ready'
+        : filesDownloadUnavailableMessage());
+    }
+    if (useHttpStagedRawFallback) {
+      await runFilesStagedRawHttpDownload(transfer, controller);
+      return;
+    }
     if (transfer.loaded > 0 && (!Array.isArray(transfer.parts) || transfer.parts.length === 0)) {
       const hydrated = await filesTransferLoadDownloadParts(transfer);
       if (!hydrated) resetFilesDownloadTransfer(transfer);
@@ -77795,8 +77812,166 @@ async function runFilesDownloadTransfer(transfer) {
   }
 }
 
+// Server errors like "no project root" are accurate but unactionable in the
+// transfers pane; translate the known ones before surfacing.
+function filesTransferFriendlyServerError(error, fallback) {
+  const message = String(error || '').trim();
+  if (!message) return fallback;
+  if (message === 'no project root') {
+    return 'This daemon has no project open — staged uploads and resumable transfers need an active session with a project root';
+  }
+  return message;
+}
+
+function filesTransferBlobToBase64(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error('Failed to read upload file'));
+    reader.onload = () => {
+      const url = String(reader.result || '');
+      const comma = url.indexOf(',');
+      resolve(comma >= 0 ? url.slice(comma + 1) : '');
+    };
+    reader.readAsDataURL(blob);
+  });
+}
+
+// Staged-upload artifact download over plain HTTP: one-shot fetch of
+// /api/session/current/uploads/{id}/raw (the route streams the whole file;
+// staged uploads are bounded by the upload cap, so no ranged loop needed).
+async function runFilesStagedRawHttpDownload(transfer, controller) {
+  transfer.transport = 'http-staged-raw';
+  if (transfer.loaded > 0 || (Array.isArray(transfer.parts) && transfer.parts.length > 0)) {
+    resetFilesDownloadTransfer(transfer);
+    // reset clears the abort handle; re-arm it so Cancel keeps working
+    // while the one-shot fetch below is in flight.
+    transfer.abortController = controller;
+  }
+  const id = String(transfer.artifact?.id || '').trim();
+  const resp = await authedFetch(`/api/session/current/uploads/${encodeURIComponent(id)}/raw`, {
+    cache: 'no-store',
+    signal: controller.signal,
+  });
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({}));
+    throw new Error(filesTransferFriendlyServerError(body.error, `staged upload download returned ${resp.status}`));
+  }
+  const declared = Number(resp.headers.get('content-length') || 0);
+  if (declared > transfer.maxBytes) {
+    throw new Error(`Download too large (${humanBytes(declared)}; cap is ${humanBytes(transfer.maxBytes)})`);
+  }
+  const blob = await resp.blob();
+  if (blob.size > transfer.maxBytes) {
+    throw new Error(`Download too large (${humanBytes(blob.size)}; cap is ${humanBytes(transfer.maxBytes)})`);
+  }
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  transfer.contentType = resp.headers.get('content-type') || transfer.contentType || 'application/octet-stream';
+  if (!transfer.filename) {
+    transfer.filename = dashboardFilenameFromContentDisposition(resp.headers.get('content-disposition')) ||
+      transfer.name || 'download.bin';
+  }
+  await filesTransferPutDownloadPart(transfer, 0, bytes);
+  transfer.parts = [bytes];
+  transfer.totalSize = bytes.byteLength;
+  transfer.loaded = bytes.byteLength;
+  transfer.rangeCount = 1;
+  const result = {
+    ok: true,
+    blob,
+    parts: transfer.parts.slice(),
+    filename: transfer.filename,
+    content_type: transfer.contentType,
+    size: blob.size,
+    total_size: blob.size,
+    range_start: 0,
+    range_end: bytes.byteLength,
+    range_count: 1,
+    resumable: false,
+  };
+  transfer.result = result;
+  transfer.status = 'completed';
+  filesTransferPersistState();
+  setFilesDownloadProgress(result.size, result.total_size || result.size);
+  setFilesDownloadStatus('ok', `Downloaded ${result.filename} (${humanBytes(result.size)})`);
+  if (!transfer.skipBrowserSave) downloadDashboardBlob(result.blob, result.filename, result.content_type);
+  transfer.resolve?.(result);
+}
+
+// Filesystem upload over plain HTTP: the durable transfer-job RPC needs the
+// dashboard-control channel, but /api/fs/write covers the same size range
+// (its body cap is sized for UPLOAD_MAX_BYTES of base64 plus envelope), so
+// a single guarded write keeps direct-connected uploads working.
+async function runFilesFilesystemUploadHttpFallback(transfer, controller) {
+  transfer.transport = 'http-fs-write';
+  const file = await filesTransferGetUploadBlob(transfer);
+  if (!(file instanceof Blob)) {
+    throw new Error('Upload file is unavailable after reload');
+  }
+  if (file.size > UPLOAD_MAX_BYTES) {
+    throw new Error(`File too large (${humanBytes(file.size)}; cap is ${humanBytes(UPLOAD_MAX_BYTES)})`);
+  }
+  transfer.totalSize = Number(file.size || 0);
+  transfer.name = transfer.name || file.name || 'upload.bin';
+  const conflict = transfer.conflictPolicy || 'fail';
+  if (conflict === 'rename') {
+    throw new Error('Rename-on-conflict needs the dashboard control channel — choose "Fail on conflict" or "Overwrite" for direct connections');
+  }
+  const destination = await filesResolveHttpUploadDestinationPath(transfer, file);
+  setFilesUploadStatus('warn', `Uploading ${transfer.name} to ${destination}`);
+  const body = {
+    path: destination,
+    content_b64: await filesTransferBlobToBase64(file),
+  };
+  if (conflict === 'overwrite') {
+    body.force = true;
+  } else {
+    body.create_new = true;
+  }
+  const resp = await authedFetch('/api/fs/write', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal: controller.signal,
+  });
+  const payload = await resp.json().catch(() => ({}));
+  if (!resp.ok || payload?.ok === false) {
+    throw new Error(filesTransferFriendlyServerError(payload?.error, `file write returned HTTP ${resp.status}`));
+  }
+  transfer.loaded = transfer.totalSize;
+  transfer.status = 'completed';
+  filesTransferPersistState();
+  await filesTransferDeleteUploadBlob(transfer.id);
+  setFilesUploadStatus('ok', `Uploaded ${transfer.name} to ${destination}`);
+  transfer.resolve?.({ ok: true, path: destination, transport: 'http-fs-write' });
+}
+
+// Mirror the durable-job destination semantics client-side: an existing
+// directory receives the file under its own name; anything else is treated
+// as the target file path.
+async function filesResolveHttpUploadDestinationPath(transfer, file) {
+  const raw = String(transfer.destination || '').trim();
+  if (!raw) throw new Error('missing upload destination');
+  const name = String(transfer.name || file.name || 'upload.bin');
+  let status = null;
+  try {
+    status = await fetchProjectPathStatus(raw);
+  } catch (_) {
+    status = null;
+  }
+  if (status?.exists && status.is_dir) {
+    return `${raw.replace(/\/+$/, '')}/${name}`;
+  }
+  if (!status?.exists && raw.endsWith('/')) {
+    throw new Error(`Destination folder does not exist: ${raw}`);
+  }
+  return raw;
+}
+
 async function runFilesFilesystemUploadTransfer(transfer, controller) {
   if (!await ensureDashboardTransferUploadAvailable({ signal: controller.signal })) {
+    if (!dashboardConnectModeEnabled()) {
+      return runFilesFilesystemUploadHttpFallback(transfer, controller);
+    }
     throw new Error('Filesystem upload is unavailable until file-write access is ready');
   }
   const file = await filesTransferGetUploadBlob(transfer);
@@ -77891,48 +78066,73 @@ function filesDeleteServerTransfer(transfer) {
 }
 
 async function runFilesUploadTransfer(transfer) {
-  const filesystemUpload = Boolean(transfer.destination && transfer.destination !== 'task');
-  if (filesystemUpload && transfer.uploadBlobPersistPromise) {
-    setFilesUploadStatus('warn', `Preparing ${transfer.name || 'upload.bin'}`);
-    const persisted = await transfer.uploadBlobPersistPromise;
-    transfer.uploadBlobPersistPromise = null;
-    if (!persisted) {
-      throw new Error('Browser storage is unavailable for resumable uploads');
-    }
-  }
-  if (!transfer.file && !(filesystemUpload && transfer.uploadBlobStored)) {
-    throw new Error('missing upload file');
-  }
-  const initialSize = Number(transfer.file?.size || transfer.totalSize || 0);
-  if (initialSize > UPLOAD_MAX_BYTES) {
-    throw new Error(`File too large (${humanBytes(initialSize)}; cap is ${humanBytes(UPLOAD_MAX_BYTES)})`);
-  }
+  // Same rule as downloads: settle the status before any guard can throw,
+  // so pumpFilesTransfers never re-picks a permanently 'queued' entry.
   transfer.status = 'running';
   transfer.error = '';
   transfer.loaded = Number(transfer.loaded || 0);
-  transfer.totalSize = initialSize;
   transfer.cancelRequested = false;
   const controller = new AbortController();
   transfer.abortController = controller;
   renderFilesTransfers();
   try {
+    const filesystemUpload = Boolean(transfer.destination && transfer.destination !== 'task');
+    if (filesystemUpload && transfer.uploadBlobPersistPromise) {
+      setFilesUploadStatus('warn', `Preparing ${transfer.name || 'upload.bin'}`);
+      const persisted = await transfer.uploadBlobPersistPromise;
+      transfer.uploadBlobPersistPromise = null;
+      if (!persisted) {
+        throw new Error('Browser storage is unavailable for resumable uploads');
+      }
+    }
+    if (!transfer.file && !(filesystemUpload && transfer.uploadBlobStored)) {
+      throw new Error('missing upload file');
+    }
+    const initialSize = Number(transfer.file?.size || transfer.totalSize || 0);
+    if (initialSize > UPLOAD_MAX_BYTES) {
+      throw new Error(`File too large (${humanBytes(initialSize)}; cap is ${humanBytes(UPLOAD_MAX_BYTES)})`);
+    }
+    transfer.totalSize = initialSize;
     if (filesystemUpload) {
       await runFilesFilesystemUploadTransfer(transfer, controller);
     } else {
       if (!transfer.file) throw new Error('missing upload file');
-      if (!dashboardUploadRpcAvailable()) {
+      let descriptor;
+      if (dashboardUploadRpcAvailable()) {
+        descriptor = await dashboardTransport.uploadBytes('api_session_current_upload', {
+          destination: 'task',
+          name: transfer.file.name || transfer.name || 'upload.bin',
+          mime: transfer.file.type || transfer.mime || 'application/octet-stream',
+        }, transfer.file, {
+          timeoutMs: transfer.timeoutMs || 120000,
+          signal: controller.signal,
+        });
+        if (descriptor?._httpOk === false) {
+          throw new Error(descriptor.error || `upload returned ${descriptor._httpStatus || 'error'}`);
+        }
+      } else if (!dashboardConnectModeEnabled()) {
+        // Direct connection without the dashboard-control channel: POST to
+        // the staged-upload HTTP route instead — it streams the body into a
+        // tempfile and commits into the same store as the RPC path.
+        transfer.transport = 'http-staged-upload';
+        const name = transfer.file.name || transfer.name || 'upload.bin';
+        setFilesUploadStatus('warn', `Uploading ${name}`);
+        const resp = await authedFetch(
+          `/api/session/current/uploads?name=${encodeURIComponent(name)}&destination=task`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': transfer.file.type || transfer.mime || 'application/octet-stream' },
+            body: transfer.file,
+            signal: controller.signal,
+          }
+        );
+        const payload = await resp.json().catch(() => null);
+        if (!resp.ok || !payload || typeof payload !== 'object') {
+          throw new Error(filesTransferFriendlyServerError(payload?.error, `upload returned HTTP ${resp.status}`));
+        }
+        descriptor = payload;
+      } else {
         throw new Error('Upload is unavailable until dashboard access reconnects');
-      }
-      const descriptor = await dashboardTransport.uploadBytes('api_session_current_upload', {
-        destination: 'task',
-        name: transfer.file.name || transfer.name || 'upload.bin',
-        mime: transfer.file.type || transfer.mime || 'application/octet-stream',
-      }, transfer.file, {
-        timeoutMs: transfer.timeoutMs || 120000,
-        signal: controller.signal,
-      });
-      if (descriptor?._httpOk === false) {
-        throw new Error(descriptor.error || `upload returned ${descriptor._httpStatus || 'error'}`);
       }
       transfer.loaded = transfer.file.size;
       transfer.descriptor = descriptor;
@@ -77967,11 +78167,22 @@ async function pumpFilesTransfers() {
     for (;;) {
       const transfer = filesTransfers.slice().reverse().find(item => item.status === 'queued');
       if (!transfer) break;
-      if (transfer.kind === 'upload') {
-        await runFilesUploadTransfer(transfer).catch(() => {});
-      } else {
-        await runFilesDownloadTransfer(transfer).catch(() => {});
+      const failure = transfer.kind === 'upload'
+        ? await runFilesUploadTransfer(transfer).then(() => null, err => err)
+        : await runFilesDownloadTransfer(transfer).then(() => null, err => err);
+      if (['queued', 'running'].includes(transfer.status)) {
+        // Forward-progress backstop: a runner that exits without settling
+        // its transfer would be re-picked by the find() above forever — a
+        // synchronous microtask spin that freezes the page and allocates
+        // without bound. Force the entry failed so the pump always drains.
+        transfer.status = 'failed';
+        transfer.error = failure?.message || transfer.error || 'transfer runner exited without settling';
+        filesTransferPersistState();
+        renderFilesTransfers();
       }
+      // Macrotask yield: even a misbehaving runner that settles instantly
+      // can only busy the tab, never wedge the event loop.
+      await new Promise(resolve => setTimeout(resolve, 0));
     }
   } finally {
     filesTransferRunnerActive = false;

--- a/static/app.html
+++ b/static/app.html
@@ -63551,6 +63551,38 @@ function dashboardSetControlLastError(message = '', kind = '') {
   dashboardControlLastErrorKind = dashboardControlLastError ? String(kind || '').trim() : '';
 }
 
+// ── Virtual display availability ──
+// Virtual displays are a host capability (Xvfb-based, Linux-only): derive
+// the "New virtual display" affordances from the daemon instead of offering
+// a button that can only fail on macOS/Windows hosts. Two sources, because
+// each covers a transport the other can't: the displays payload reaches
+// direct dashboards over HTTP, and the dashboard-control status capability
+// reaches Connect dashboards once the channel is up (the HTTP probe is
+// impossible there, so dashboardUpdateTransportStatus re-applies the gate
+// whenever transport state changes). Declared HERE, before that function's
+// first eval-time call — a later-fragment `let` would be a TDZ trap that
+// kills the whole module.
+let daemonVirtualDisplaysAvailable = null;
+function virtualDisplaysAvailableNow() {
+  return daemonVirtualDisplaysAvailable === true ||
+    dashboardControlTransport?.lastStatus?.virtual_displays_available === true;
+}
+function updateVirtualDisplayAvailabilityUi() {
+  const btn = document.getElementById('displays-create-virtual');
+  if (btn) btn.hidden = !virtualDisplaysAvailableNow();
+}
+async function refreshVirtualDisplayAvailability() {
+  if (!dashboardConnectModeEnabled()) {
+    try {
+      const payload = await fetchLocalDisplaysPayload();
+      daemonVirtualDisplaysAvailable = payload?.virtual_displays_available === true;
+    } catch (_) {
+      daemonVirtualDisplaysAvailable = null;
+    }
+  }
+  updateVirtualDisplayAvailabilityUi();
+}
+
 function dashboardUpdateTransportStatus() {
   const group = document.getElementById('sb-dashboard-transport');
   const dot = document.getElementById('sb-dashboard-transport-dot');
@@ -64282,6 +64314,7 @@ class DashboardTransport {
 
 dashboardTransport = new DashboardTransport();
 dashboardUpdateTransportStatus();
+refreshVirtualDisplayAvailability();
 
 function maybeStartDashboardControlTransport() {
   return dashboardTransport.startControl();
@@ -87329,37 +87362,6 @@ document.getElementById('strip-minimize')?.addEventListener('click', (e) => {
     document.body.style.userSelect = '';
   });
 })();
-
-// ── Virtual display availability ──
-// Virtual displays are a host capability (Xvfb-based, Linux-only): derive
-// the "New virtual display" affordances from the daemon instead of offering
-// a button that can only fail on macOS/Windows hosts. Two sources, because
-// each covers a transport the other can't: the displays payload reaches
-// direct dashboards over HTTP, and the dashboard-control status capability
-// reaches Connect dashboards once the channel is up (the HTTP probe is
-// impossible there, so dashboardUpdateTransportStatus re-applies the gate
-// whenever transport state changes).
-let daemonVirtualDisplaysAvailable = null;
-function virtualDisplaysAvailableNow() {
-  return daemonVirtualDisplaysAvailable === true ||
-    dashboardControlTransport?.lastStatus?.virtual_displays_available === true;
-}
-function updateVirtualDisplayAvailabilityUi() {
-  const btn = document.getElementById('displays-create-virtual');
-  if (btn) btn.hidden = !virtualDisplaysAvailableNow();
-}
-async function refreshVirtualDisplayAvailability() {
-  if (!dashboardConnectModeEnabled()) {
-    try {
-      const payload = await fetchLocalDisplaysPayload();
-      daemonVirtualDisplaysAvailable = payload?.virtual_displays_available === true;
-    } catch (_) {
-      daemonVirtualDisplaysAvailable = null;
-    }
-  }
-  updateVirtualDisplayAvailabilityUi();
-}
-refreshVirtualDisplayAvailability();
 
 // ── Start ──
 main();

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -983,7 +983,7 @@
           </div>
           <div class="ui-empty-title">No displays active</div>
           <div class="ui-empty-hint">Displays appear when the agent launches a GUI or you share your screen — or create one right here</div>
-          <button class="ui-empty-btn" id="displays-create-virtual" onclick="createVirtualDisplay(event)" title="Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed. Linux hosts only.">New virtual display</button>
+          <button class="ui-empty-btn" id="displays-create-virtual" hidden onclick="createVirtualDisplay(event)" title="Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed.">New virtual display</button>
         </div>
       </div>
       <div class="displays-collapse-bar hidden" id="displays-collapse-bar">

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -982,7 +982,7 @@
             </svg>
           </div>
           <div class="ui-empty-title">No displays active</div>
-          <div class="ui-empty-hint">Displays appear when the agent launches a GUI or you share your screen — or create one right here</div>
+          <div class="ui-empty-hint">Displays appear when the agent launches a GUI or you share your screen</div>
           <button class="ui-empty-btn" id="displays-create-virtual" hidden onclick="createVirtualDisplay(event)" title="Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed.">New virtual display</button>
         </div>
       </div>

--- a/static/app/49-daemons-multihost.js
+++ b/static/app/49-daemons-multihost.js
@@ -199,6 +199,38 @@ function dashboardSetControlLastError(message = '', kind = '') {
   dashboardControlLastErrorKind = dashboardControlLastError ? String(kind || '').trim() : '';
 }
 
+// ── Virtual display availability ──
+// Virtual displays are a host capability (Xvfb-based, Linux-only): derive
+// the "New virtual display" affordances from the daemon instead of offering
+// a button that can only fail on macOS/Windows hosts. Two sources, because
+// each covers a transport the other can't: the displays payload reaches
+// direct dashboards over HTTP, and the dashboard-control status capability
+// reaches Connect dashboards once the channel is up (the HTTP probe is
+// impossible there, so dashboardUpdateTransportStatus re-applies the gate
+// whenever transport state changes). Declared HERE, before that function's
+// first eval-time call — a later-fragment `let` would be a TDZ trap that
+// kills the whole module.
+let daemonVirtualDisplaysAvailable = null;
+function virtualDisplaysAvailableNow() {
+  return daemonVirtualDisplaysAvailable === true ||
+    dashboardControlTransport?.lastStatus?.virtual_displays_available === true;
+}
+function updateVirtualDisplayAvailabilityUi() {
+  const btn = document.getElementById('displays-create-virtual');
+  if (btn) btn.hidden = !virtualDisplaysAvailableNow();
+}
+async function refreshVirtualDisplayAvailability() {
+  if (!dashboardConnectModeEnabled()) {
+    try {
+      const payload = await fetchLocalDisplaysPayload();
+      daemonVirtualDisplaysAvailable = payload?.virtual_displays_available === true;
+    } catch (_) {
+      daemonVirtualDisplaysAvailable = null;
+    }
+  }
+  updateVirtualDisplayAvailabilityUi();
+}
+
 function dashboardUpdateTransportStatus() {
   const group = document.getElementById('sb-dashboard-transport');
   const dot = document.getElementById('sb-dashboard-transport-dot');
@@ -930,6 +962,7 @@ class DashboardTransport {
 
 dashboardTransport = new DashboardTransport();
 dashboardUpdateTransportStatus();
+refreshVirtualDisplayAvailability();
 
 function maybeStartDashboardControlTransport() {
   return dashboardTransport.startControl();

--- a/static/app/49-daemons-multihost.js
+++ b/static/app/49-daemons-multihost.js
@@ -228,6 +228,7 @@ function dashboardUpdateTransportStatus() {
   renderConnectHealthPanel(status, summary);
   renderDashboardTargetSummaries();
   refreshFilesDownloadAvailability();
+  updateVirtualDisplayAvailabilityUi();
   if (activeTab === 'files') refreshFilesTransferJobs();
   maybeOpenShellAfterTransportReady();
 }

--- a/static/app/50-control-transport.js
+++ b/static/app/50-control-transport.js
@@ -1900,6 +1900,18 @@ function rangedDownloadTimeoutMs(chunkBytes) {
   return Math.max(30000, Math.ceil(size / (256 * 1024)) * 10000);
 }
 
+// Compose a caller's abort signal with a hard timeout. fetch() has no
+// default timeout, and the transfers pump runs entries strictly
+// sequentially — a single hung request must fail rather than wedge the
+// whole queue behind it.
+function dashboardComposeFetchSignal(signal, timeoutMs) {
+  const ms = Number(timeoutMs) || 0;
+  if (!(ms > 0) || typeof AbortSignal?.timeout !== 'function') return signal || undefined;
+  const timeout = AbortSignal.timeout(ms);
+  if (!signal) return timeout;
+  return typeof AbortSignal.any === 'function' ? AbortSignal.any([signal, timeout]) : signal;
+}
+
 async function dashboardRequestBytesWithRetry(method, params, options = {}) {
   const retries = Number.isFinite(Number(options.retries)) ? Math.max(0, Number(options.retries)) : 2;
   let attempt = 0;

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -1866,6 +1866,7 @@ function filesUpdateActiveDownloadSummary(transfer = null) {
 }
 
 function queueFilesTransfer(transfer) {
+  transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
   filesTransferCompletion(transfer);
   filesTransfers.unshift(transfer);
   filesTransferPersistState();
@@ -2185,27 +2186,7 @@ async function runFilesDownloadTransfer(transfer) {
       }
       if (transfer.loaded >= transfer.totalSize || range.bytes.byteLength === 0) break;
     }
-    const blob = new Blob(transfer.parts, { type: transfer.contentType || 'application/octet-stream' });
-    const result = {
-      ok: true,
-      blob,
-      parts: transfer.parts.slice(),
-      filename: transfer.filename || 'download.bin',
-      content_type: transfer.contentType,
-      size: blob.size,
-      total_size: transfer.totalSize || blob.size,
-      range_start: 0,
-      range_end: transfer.loaded,
-      range_count: transfer.rangeCount,
-      resumable: true,
-    };
-    transfer.result = result;
-    transfer.status = 'completed';
-    filesTransferPersistState();
-    setFilesDownloadProgress(result.size, result.total_size || result.size);
-    setFilesDownloadStatus('ok', `Downloaded ${result.filename} (${humanBytes(result.size)})`);
-    if (!transfer.skipBrowserSave) downloadDashboardBlob(result.blob, result.filename, result.content_type);
-    transfer.resolve?.(result);
+    settleCompletedFilesDownload(transfer, { resumable: true });
   } catch (err) {
     const message = err?.message || String(err);
     if (transfer.cancelRequested) {
@@ -2237,6 +2218,34 @@ async function runFilesDownloadTransfer(transfer) {
   }
 }
 
+// Shared settle for a fully-downloaded transfer: build the result from the
+// accumulated parts, mark completed, and surface it. Both the ranged runner
+// and the one-shot staged-raw path end here — keep them from diverging.
+function settleCompletedFilesDownload(transfer, { resumable }) {
+  const blob = new Blob(transfer.parts, { type: transfer.contentType || 'application/octet-stream' });
+  const result = {
+    ok: true,
+    blob,
+    parts: transfer.parts.slice(),
+    filename: transfer.filename || 'download.bin',
+    content_type: transfer.contentType,
+    size: blob.size,
+    total_size: transfer.totalSize || blob.size,
+    range_start: 0,
+    range_end: transfer.loaded,
+    range_count: transfer.rangeCount,
+    resumable,
+  };
+  transfer.result = result;
+  transfer.status = 'completed';
+  filesTransferPersistState();
+  setFilesDownloadProgress(result.size, result.total_size || result.size);
+  setFilesDownloadStatus('ok', `Downloaded ${result.filename} (${humanBytes(result.size)})`);
+  if (!transfer.skipBrowserSave) downloadDashboardBlob(result.blob, result.filename, result.content_type);
+  transfer.resolve?.(result);
+  return result;
+}
+
 // Server errors like "no project root" are accurate but unactionable in the
 // transfers pane; translate the known ones before surfacing.
 function filesTransferFriendlyServerError(error, fallback) {
@@ -2246,19 +2255,6 @@ function filesTransferFriendlyServerError(error, fallback) {
     return 'This daemon has no project open — staged uploads and resumable transfers need an active session with a project root';
   }
   return message;
-}
-
-function filesTransferBlobToBase64(blob) {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onerror = () => reject(new Error('Failed to read upload file'));
-    reader.onload = () => {
-      const url = String(reader.result || '');
-      const comma = url.indexOf(',');
-      resolve(comma >= 0 ? url.slice(comma + 1) : '');
-    };
-    reader.readAsDataURL(blob);
-  });
 }
 
 // Staged-upload artifact download over plain HTTP: one-shot fetch of
@@ -2275,7 +2271,7 @@ async function runFilesStagedRawHttpDownload(transfer, controller) {
   const id = String(transfer.artifact?.id || '').trim();
   const resp = await authedFetch(`/api/session/current/uploads/${encodeURIComponent(id)}/raw`, {
     cache: 'no-store',
-    signal: controller.signal,
+    signal: dashboardComposeFetchSignal(controller.signal, transfer.timeoutMs || 300000),
   });
   if (!resp.ok) {
     const body = await resp.json().catch(() => ({}));
@@ -2300,26 +2296,7 @@ async function runFilesStagedRawHttpDownload(transfer, controller) {
   transfer.totalSize = bytes.byteLength;
   transfer.loaded = bytes.byteLength;
   transfer.rangeCount = 1;
-  const result = {
-    ok: true,
-    blob,
-    parts: transfer.parts.slice(),
-    filename: transfer.filename,
-    content_type: transfer.contentType,
-    size: blob.size,
-    total_size: blob.size,
-    range_start: 0,
-    range_end: bytes.byteLength,
-    range_count: 1,
-    resumable: false,
-  };
-  transfer.result = result;
-  transfer.status = 'completed';
-  filesTransferPersistState();
-  setFilesDownloadProgress(result.size, result.total_size || result.size);
-  setFilesDownloadStatus('ok', `Downloaded ${result.filename} (${humanBytes(result.size)})`);
-  if (!transfer.skipBrowserSave) downloadDashboardBlob(result.blob, result.filename, result.content_type);
-  transfer.resolve?.(result);
+  settleCompletedFilesDownload(transfer, { resumable: false });
 }
 
 // Filesystem upload over plain HTTP: the durable transfer-job RPC needs the
@@ -2343,24 +2320,13 @@ async function runFilesFilesystemUploadHttpFallback(transfer, controller) {
   }
   const destination = await filesResolveHttpUploadDestinationPath(transfer, file);
   setFilesUploadStatus('warn', `Uploading ${transfer.name} to ${destination}`);
-  const body = {
-    path: destination,
-    content_b64: await filesTransferBlobToBase64(file),
-  };
-  if (conflict === 'overwrite') {
-    body.force = true;
-  } else {
-    body.create_new = true;
-  }
-  const resp = await authedFetch('/api/fs/write', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-    signal: controller.signal,
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const resp = await filesIdeWriteFile('', destination, bytes, {
+    ...(conflict === 'overwrite' ? { force: true } : { create_new: true }),
+    signal: dashboardComposeFetchSignal(controller.signal, transfer.timeoutMs || rangedDownloadTimeoutMs(file.size)),
   });
-  const payload = await resp.json().catch(() => ({}));
-  if (!resp.ok || payload?.ok === false) {
-    throw new Error(filesTransferFriendlyServerError(payload?.error, `file write returned HTTP ${resp.status}`));
+  if (!resp.ok) {
+    throw new Error(filesTransferFriendlyServerError(resp.body?.error, `file write returned HTTP ${resp.status}`));
   }
   transfer.loaded = transfer.totalSize;
   transfer.status = 'completed';
@@ -2377,11 +2343,14 @@ async function filesResolveHttpUploadDestinationPath(transfer, file) {
   const raw = String(transfer.destination || '').trim();
   if (!raw) throw new Error('missing upload destination');
   const name = String(transfer.name || file.name || 'upload.bin');
-  let status = null;
+  let status;
   try {
     status = await fetchProjectPathStatus(raw);
-  } catch (_) {
-    status = null;
+  } catch (err) {
+    // A failed stat is not "does not exist": guessing here either rejects
+    // a valid directory destination or writes the file over the directory
+    // path itself. Fail retryably instead.
+    throw new Error(`Could not verify upload destination ${raw}: ${err?.message || err}`);
   }
   if (status?.exists && status.is_dir) {
     return `${raw.replace(/\/+$/, '')}/${name}`;
@@ -2394,6 +2363,14 @@ async function filesResolveHttpUploadDestinationPath(transfer, file) {
 
 async function runFilesFilesystemUploadTransfer(transfer, controller) {
   if (!await ensureDashboardTransferUploadAvailable({ signal: controller.signal })) {
+    if (transfer.serverJobId || transfer.resumeToken) {
+      // A durable job already holds this upload's chunks server-side.
+      // Rerouting to the whole-file fallback would orphan that job (no
+      // GC; the Files tab re-merges it as a ghost row forever) and throw
+      // away resumability — fail clearly and keep the resume for when
+      // the control channel is back.
+      throw new Error('Resuming this upload needs the dashboard control channel — retry when it reconnects, or cancel to discard the partial upload');
+    }
     if (!dashboardConnectModeEnabled()) {
       return runFilesFilesystemUploadHttpFallback(transfer, controller);
     }
@@ -2497,6 +2474,7 @@ async function runFilesUploadTransfer(transfer) {
   transfer.error = '';
   transfer.loaded = Number(transfer.loaded || 0);
   transfer.cancelRequested = false;
+  transfer.transport = '';
   const controller = new AbortController();
   transfer.abortController = controller;
   renderFilesTransfers();
@@ -2548,7 +2526,7 @@ async function runFilesUploadTransfer(transfer) {
             method: 'POST',
             headers: { 'Content-Type': transfer.file.type || transfer.mime || 'application/octet-stream' },
             body: transfer.file,
-            signal: controller.signal,
+            signal: dashboardComposeFetchSignal(controller.signal, transfer.timeoutMs || rangedDownloadTimeoutMs(transfer.file.size)),
           }
         );
         const payload = await resp.json().catch(() => null);
@@ -2592,18 +2570,25 @@ async function pumpFilesTransfers() {
     for (;;) {
       const transfer = filesTransfers.slice().reverse().find(item => item.status === 'queued');
       if (!transfer) break;
+      const epoch = transfer.queueEpoch || 0;
       const failure = transfer.kind === 'upload'
         ? await runFilesUploadTransfer(transfer).then(() => null, err => err)
         : await runFilesDownloadTransfer(transfer).then(() => null, err => err);
-      if (['queued', 'running'].includes(transfer.status)) {
+      if (
+        ['queued', 'running'].includes(transfer.status) &&
+        (transfer.queueEpoch || 0) === epoch
+      ) {
         // Forward-progress backstop: a runner that exits without settling
         // its transfer would be re-picked by the find() above forever — a
         // synchronous microtask spin that freezes the page and allocates
         // without bound. Force the entry failed so the pump always drains.
+        // The epoch check exempts entries the user legitimately re-queued
+        // (Resume/Retry bump it) while the runner was tearing down.
         transfer.status = 'failed';
         transfer.error = failure?.message || transfer.error || 'transfer runner exited without settling';
         filesTransferPersistState();
         renderFilesTransfers();
+        transfer.reject?.(failure || new Error(transfer.error));
       }
       // Macrotask yield: even a misbehaving runner that settles instantly
       // can only busy the tab, never wedge the event loop.
@@ -2662,6 +2647,7 @@ function cancelFilesTransfer(id) {
 function resumeFilesTransfer(id) {
   const transfer = filesTransferById(id);
   if (!transfer || !['paused', 'failed'].includes(transfer.status)) return null;
+  transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
   transfer.status = 'queued';
   transfer.error = '';
   transfer.pauseRequested = false;
@@ -2677,6 +2663,7 @@ function retryFilesTransfer(id) {
   const transfer = filesTransferById(id);
   if (!transfer || !['failed', 'cancelled', 'completed'].includes(transfer.status)) return null;
   if (transfer.kind === 'download') resetFilesDownloadTransfer(transfer);
+  transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
   transfer.status = 'queued';
   transfer.error = '';
   transfer.cancelRequested = false;
@@ -2831,49 +2818,23 @@ async function downloadFilesStagedUpload(id) {
   const upload = filesStagedUploads.get(String(id || ''));
   if (!upload) return null;
   try {
-    if (dashboardTransferDownloadAvailable()) {
-      const name = filesStagedDescriptorName(upload);
-      const transfer = queueDashboardArtifactDownload({
-        type: 'staged_upload',
-        id: String(id || ''),
-      }, {
-        sourceLabel: `Staged upload: ${name}`,
-        filename: name,
-        contentType: upload.mime || upload.content_type || 'application/octet-stream',
-        directMethod: 'api_session_current_upload_raw',
-        directParams: { id: String(id || '') },
-      });
-      if (!transfer) throw new Error('Staged upload download was not queued');
-      const result = await transfer.completion;
-      setFilesUploadStatus('ok', `Downloaded ${result.filename || name}`);
-      return result;
-    }
-    if (dashboardConnectModeEnabled()) {
-      throw new Error('Staged upload download is unavailable until file access is ready');
-    }
+    // One implementation for every transport: queue a transfer and let
+    // runFilesDownloadTransfer pick durable RPC, byte-stream, or the
+    // staged-raw HTTP fallback — the inline fetch this replaces had
+    // drifted (no size cap, no cancel, raw server errors).
     const name = filesStagedDescriptorName(upload);
-    const resp = await authedFetch(`/api/session/current/uploads/${encodeURIComponent(id)}/raw`, {
-      cache: 'no-store',
-    });
-    if (!resp.ok) {
-      const body = await resp.json().catch(() => ({}));
-      throw new Error(body.error || `staged upload download returned ${resp.status}`);
-    }
-    const blob = await resp.blob();
-    const result = {
-      ok: true,
-      blob,
+    const transfer = queueDashboardArtifactDownload({
+      type: 'staged_upload',
+      id: String(id || ''),
+    }, {
+      sourceLabel: `Staged upload: ${name}`,
       filename: name,
-      content_type: resp.headers.get('content-type') || upload.mime || 'application/octet-stream',
-      size: blob.size,
-      total_size: blob.size,
-      range_count: 1,
-    };
-    downloadDashboardBlob(
-      result.blob,
-      result.filename || name,
-      result.content_type || upload.mime || 'application/octet-stream'
-    );
+      contentType: upload.mime || upload.content_type || 'application/octet-stream',
+      directMethod: 'api_session_current_upload_raw',
+      directParams: { id: String(id || '') },
+    });
+    if (!transfer) throw new Error('Staged upload download was not queued');
+    const result = await transfer.completion;
     setFilesUploadStatus('ok', `Downloaded ${result.filename || name}`);
     return result;
   } catch (err) {

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -2001,26 +2001,10 @@ function filesTransferApplyServerJob(transfer, job) {
 }
 
 async function runFilesDownloadTransfer(transfer) {
-  const peerId = String(transfer.peerId || '').trim();
-  let usePeerDashboardControl = Boolean(peerId) && peerDashboardControlSignalAvailable(peerId);
-  let usePeerFileTransfer = Boolean(peerId) && !usePeerDashboardControl;
-  const useDurableTransfer = !peerId && dashboardTransferDownloadAvailable();
-  const hasArtifact = Boolean(transfer.artifact && typeof transfer.artifact === 'object');
-  const fallbackMethod = String(transfer.directMethod || (!hasArtifact ? 'api_fs_read' : '')).trim();
-  const canUseFallbackMethod = !peerId && Boolean(fallbackMethod && dashboardByteStreamMethodAvailable(fallbackMethod));
-  const useHttpFilesystemFallback = !useDurableTransfer &&
-    !canUseFallbackMethod &&
-    !peerId &&
-    !hasArtifact &&
-    !dashboardConnectModeEnabled();
-  if (peerId && !usePeerDashboardControl && !peerFileTransferSignalAvailable(peerId)) {
-    throw new Error(filesDownloadUnavailableMessage(peerId));
-  }
-  if (!peerId && !useDurableTransfer && !canUseFallbackMethod && !useHttpFilesystemFallback) {
-    throw new Error(hasArtifact
-      ? 'Artifact download is unavailable until resumable file access is ready'
-      : filesDownloadUnavailableMessage());
-  }
+  // Mark the transfer running before any transport checks: an early throw
+  // that left the status at 'queued' would make pumpFilesTransfers re-pick
+  // the same entry forever, so every failure must flow through the catch
+  // below. The transport guards therefore live inside the try.
   transfer.status = 'running';
   transfer.error = '';
   transfer.pauseRequested = false;
@@ -2034,6 +2018,39 @@ async function runFilesDownloadTransfer(transfer) {
   let peerConnection = null;
   let peerDashboardConnection = null;
   try {
+    const peerId = String(transfer.peerId || '').trim();
+    let usePeerDashboardControl = Boolean(peerId) && peerDashboardControlSignalAvailable(peerId);
+    let usePeerFileTransfer = Boolean(peerId) && !usePeerDashboardControl;
+    const useDurableTransfer = !peerId && dashboardTransferDownloadAvailable();
+    const hasArtifact = Boolean(transfer.artifact && typeof transfer.artifact === 'object');
+    const fallbackMethod = String(transfer.directMethod || (!hasArtifact ? 'api_fs_read' : '')).trim();
+    const canUseFallbackMethod = !peerId && Boolean(fallbackMethod && dashboardByteStreamMethodAvailable(fallbackMethod));
+    const useHttpFilesystemFallback = !useDurableTransfer &&
+      !canUseFallbackMethod &&
+      !peerId &&
+      !hasArtifact &&
+      !dashboardConnectModeEnabled();
+    // Staged uploads are also served over plain HTTP, so a direct-connected
+    // dashboard without the control channel can still download them.
+    const useHttpStagedRawFallback = !useDurableTransfer &&
+      !canUseFallbackMethod &&
+      !peerId &&
+      hasArtifact &&
+      transfer.artifact.type === 'staged_upload' &&
+      String(transfer.artifact.id || '').trim() !== '' &&
+      !dashboardConnectModeEnabled();
+    if (peerId && !usePeerDashboardControl && !peerFileTransferSignalAvailable(peerId)) {
+      throw new Error(filesDownloadUnavailableMessage(peerId));
+    }
+    if (!peerId && !useDurableTransfer && !canUseFallbackMethod && !useHttpFilesystemFallback && !useHttpStagedRawFallback) {
+      throw new Error(hasArtifact
+        ? 'Artifact download is unavailable until resumable file access is ready'
+        : filesDownloadUnavailableMessage());
+    }
+    if (useHttpStagedRawFallback) {
+      await runFilesStagedRawHttpDownload(transfer, controller);
+      return;
+    }
     if (transfer.loaded > 0 && (!Array.isArray(transfer.parts) || transfer.parts.length === 0)) {
       const hydrated = await filesTransferLoadDownloadParts(transfer);
       if (!hydrated) resetFilesDownloadTransfer(transfer);
@@ -2220,8 +2237,166 @@ async function runFilesDownloadTransfer(transfer) {
   }
 }
 
+// Server errors like "no project root" are accurate but unactionable in the
+// transfers pane; translate the known ones before surfacing.
+function filesTransferFriendlyServerError(error, fallback) {
+  const message = String(error || '').trim();
+  if (!message) return fallback;
+  if (message === 'no project root') {
+    return 'This daemon has no project open — staged uploads and resumable transfers need an active session with a project root';
+  }
+  return message;
+}
+
+function filesTransferBlobToBase64(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error('Failed to read upload file'));
+    reader.onload = () => {
+      const url = String(reader.result || '');
+      const comma = url.indexOf(',');
+      resolve(comma >= 0 ? url.slice(comma + 1) : '');
+    };
+    reader.readAsDataURL(blob);
+  });
+}
+
+// Staged-upload artifact download over plain HTTP: one-shot fetch of
+// /api/session/current/uploads/{id}/raw (the route streams the whole file;
+// staged uploads are bounded by the upload cap, so no ranged loop needed).
+async function runFilesStagedRawHttpDownload(transfer, controller) {
+  transfer.transport = 'http-staged-raw';
+  if (transfer.loaded > 0 || (Array.isArray(transfer.parts) && transfer.parts.length > 0)) {
+    resetFilesDownloadTransfer(transfer);
+    // reset clears the abort handle; re-arm it so Cancel keeps working
+    // while the one-shot fetch below is in flight.
+    transfer.abortController = controller;
+  }
+  const id = String(transfer.artifact?.id || '').trim();
+  const resp = await authedFetch(`/api/session/current/uploads/${encodeURIComponent(id)}/raw`, {
+    cache: 'no-store',
+    signal: controller.signal,
+  });
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => ({}));
+    throw new Error(filesTransferFriendlyServerError(body.error, `staged upload download returned ${resp.status}`));
+  }
+  const declared = Number(resp.headers.get('content-length') || 0);
+  if (declared > transfer.maxBytes) {
+    throw new Error(`Download too large (${humanBytes(declared)}; cap is ${humanBytes(transfer.maxBytes)})`);
+  }
+  const blob = await resp.blob();
+  if (blob.size > transfer.maxBytes) {
+    throw new Error(`Download too large (${humanBytes(blob.size)}; cap is ${humanBytes(transfer.maxBytes)})`);
+  }
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  transfer.contentType = resp.headers.get('content-type') || transfer.contentType || 'application/octet-stream';
+  if (!transfer.filename) {
+    transfer.filename = dashboardFilenameFromContentDisposition(resp.headers.get('content-disposition')) ||
+      transfer.name || 'download.bin';
+  }
+  await filesTransferPutDownloadPart(transfer, 0, bytes);
+  transfer.parts = [bytes];
+  transfer.totalSize = bytes.byteLength;
+  transfer.loaded = bytes.byteLength;
+  transfer.rangeCount = 1;
+  const result = {
+    ok: true,
+    blob,
+    parts: transfer.parts.slice(),
+    filename: transfer.filename,
+    content_type: transfer.contentType,
+    size: blob.size,
+    total_size: blob.size,
+    range_start: 0,
+    range_end: bytes.byteLength,
+    range_count: 1,
+    resumable: false,
+  };
+  transfer.result = result;
+  transfer.status = 'completed';
+  filesTransferPersistState();
+  setFilesDownloadProgress(result.size, result.total_size || result.size);
+  setFilesDownloadStatus('ok', `Downloaded ${result.filename} (${humanBytes(result.size)})`);
+  if (!transfer.skipBrowserSave) downloadDashboardBlob(result.blob, result.filename, result.content_type);
+  transfer.resolve?.(result);
+}
+
+// Filesystem upload over plain HTTP: the durable transfer-job RPC needs the
+// dashboard-control channel, but /api/fs/write covers the same size range
+// (its body cap is sized for UPLOAD_MAX_BYTES of base64 plus envelope), so
+// a single guarded write keeps direct-connected uploads working.
+async function runFilesFilesystemUploadHttpFallback(transfer, controller) {
+  transfer.transport = 'http-fs-write';
+  const file = await filesTransferGetUploadBlob(transfer);
+  if (!(file instanceof Blob)) {
+    throw new Error('Upload file is unavailable after reload');
+  }
+  if (file.size > UPLOAD_MAX_BYTES) {
+    throw new Error(`File too large (${humanBytes(file.size)}; cap is ${humanBytes(UPLOAD_MAX_BYTES)})`);
+  }
+  transfer.totalSize = Number(file.size || 0);
+  transfer.name = transfer.name || file.name || 'upload.bin';
+  const conflict = transfer.conflictPolicy || 'fail';
+  if (conflict === 'rename') {
+    throw new Error('Rename-on-conflict needs the dashboard control channel — choose "Fail on conflict" or "Overwrite" for direct connections');
+  }
+  const destination = await filesResolveHttpUploadDestinationPath(transfer, file);
+  setFilesUploadStatus('warn', `Uploading ${transfer.name} to ${destination}`);
+  const body = {
+    path: destination,
+    content_b64: await filesTransferBlobToBase64(file),
+  };
+  if (conflict === 'overwrite') {
+    body.force = true;
+  } else {
+    body.create_new = true;
+  }
+  const resp = await authedFetch('/api/fs/write', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal: controller.signal,
+  });
+  const payload = await resp.json().catch(() => ({}));
+  if (!resp.ok || payload?.ok === false) {
+    throw new Error(filesTransferFriendlyServerError(payload?.error, `file write returned HTTP ${resp.status}`));
+  }
+  transfer.loaded = transfer.totalSize;
+  transfer.status = 'completed';
+  filesTransferPersistState();
+  await filesTransferDeleteUploadBlob(transfer.id);
+  setFilesUploadStatus('ok', `Uploaded ${transfer.name} to ${destination}`);
+  transfer.resolve?.({ ok: true, path: destination, transport: 'http-fs-write' });
+}
+
+// Mirror the durable-job destination semantics client-side: an existing
+// directory receives the file under its own name; anything else is treated
+// as the target file path.
+async function filesResolveHttpUploadDestinationPath(transfer, file) {
+  const raw = String(transfer.destination || '').trim();
+  if (!raw) throw new Error('missing upload destination');
+  const name = String(transfer.name || file.name || 'upload.bin');
+  let status = null;
+  try {
+    status = await fetchProjectPathStatus(raw);
+  } catch (_) {
+    status = null;
+  }
+  if (status?.exists && status.is_dir) {
+    return `${raw.replace(/\/+$/, '')}/${name}`;
+  }
+  if (!status?.exists && raw.endsWith('/')) {
+    throw new Error(`Destination folder does not exist: ${raw}`);
+  }
+  return raw;
+}
+
 async function runFilesFilesystemUploadTransfer(transfer, controller) {
   if (!await ensureDashboardTransferUploadAvailable({ signal: controller.signal })) {
+    if (!dashboardConnectModeEnabled()) {
+      return runFilesFilesystemUploadHttpFallback(transfer, controller);
+    }
     throw new Error('Filesystem upload is unavailable until file-write access is ready');
   }
   const file = await filesTransferGetUploadBlob(transfer);
@@ -2316,48 +2491,73 @@ function filesDeleteServerTransfer(transfer) {
 }
 
 async function runFilesUploadTransfer(transfer) {
-  const filesystemUpload = Boolean(transfer.destination && transfer.destination !== 'task');
-  if (filesystemUpload && transfer.uploadBlobPersistPromise) {
-    setFilesUploadStatus('warn', `Preparing ${transfer.name || 'upload.bin'}`);
-    const persisted = await transfer.uploadBlobPersistPromise;
-    transfer.uploadBlobPersistPromise = null;
-    if (!persisted) {
-      throw new Error('Browser storage is unavailable for resumable uploads');
-    }
-  }
-  if (!transfer.file && !(filesystemUpload && transfer.uploadBlobStored)) {
-    throw new Error('missing upload file');
-  }
-  const initialSize = Number(transfer.file?.size || transfer.totalSize || 0);
-  if (initialSize > UPLOAD_MAX_BYTES) {
-    throw new Error(`File too large (${humanBytes(initialSize)}; cap is ${humanBytes(UPLOAD_MAX_BYTES)})`);
-  }
+  // Same rule as downloads: settle the status before any guard can throw,
+  // so pumpFilesTransfers never re-picks a permanently 'queued' entry.
   transfer.status = 'running';
   transfer.error = '';
   transfer.loaded = Number(transfer.loaded || 0);
-  transfer.totalSize = initialSize;
   transfer.cancelRequested = false;
   const controller = new AbortController();
   transfer.abortController = controller;
   renderFilesTransfers();
   try {
+    const filesystemUpload = Boolean(transfer.destination && transfer.destination !== 'task');
+    if (filesystemUpload && transfer.uploadBlobPersistPromise) {
+      setFilesUploadStatus('warn', `Preparing ${transfer.name || 'upload.bin'}`);
+      const persisted = await transfer.uploadBlobPersistPromise;
+      transfer.uploadBlobPersistPromise = null;
+      if (!persisted) {
+        throw new Error('Browser storage is unavailable for resumable uploads');
+      }
+    }
+    if (!transfer.file && !(filesystemUpload && transfer.uploadBlobStored)) {
+      throw new Error('missing upload file');
+    }
+    const initialSize = Number(transfer.file?.size || transfer.totalSize || 0);
+    if (initialSize > UPLOAD_MAX_BYTES) {
+      throw new Error(`File too large (${humanBytes(initialSize)}; cap is ${humanBytes(UPLOAD_MAX_BYTES)})`);
+    }
+    transfer.totalSize = initialSize;
     if (filesystemUpload) {
       await runFilesFilesystemUploadTransfer(transfer, controller);
     } else {
       if (!transfer.file) throw new Error('missing upload file');
-      if (!dashboardUploadRpcAvailable()) {
+      let descriptor;
+      if (dashboardUploadRpcAvailable()) {
+        descriptor = await dashboardTransport.uploadBytes('api_session_current_upload', {
+          destination: 'task',
+          name: transfer.file.name || transfer.name || 'upload.bin',
+          mime: transfer.file.type || transfer.mime || 'application/octet-stream',
+        }, transfer.file, {
+          timeoutMs: transfer.timeoutMs || 120000,
+          signal: controller.signal,
+        });
+        if (descriptor?._httpOk === false) {
+          throw new Error(descriptor.error || `upload returned ${descriptor._httpStatus || 'error'}`);
+        }
+      } else if (!dashboardConnectModeEnabled()) {
+        // Direct connection without the dashboard-control channel: POST to
+        // the staged-upload HTTP route instead — it streams the body into a
+        // tempfile and commits into the same store as the RPC path.
+        transfer.transport = 'http-staged-upload';
+        const name = transfer.file.name || transfer.name || 'upload.bin';
+        setFilesUploadStatus('warn', `Uploading ${name}`);
+        const resp = await authedFetch(
+          `/api/session/current/uploads?name=${encodeURIComponent(name)}&destination=task`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': transfer.file.type || transfer.mime || 'application/octet-stream' },
+            body: transfer.file,
+            signal: controller.signal,
+          }
+        );
+        const payload = await resp.json().catch(() => null);
+        if (!resp.ok || !payload || typeof payload !== 'object') {
+          throw new Error(filesTransferFriendlyServerError(payload?.error, `upload returned HTTP ${resp.status}`));
+        }
+        descriptor = payload;
+      } else {
         throw new Error('Upload is unavailable until dashboard access reconnects');
-      }
-      const descriptor = await dashboardTransport.uploadBytes('api_session_current_upload', {
-        destination: 'task',
-        name: transfer.file.name || transfer.name || 'upload.bin',
-        mime: transfer.file.type || transfer.mime || 'application/octet-stream',
-      }, transfer.file, {
-        timeoutMs: transfer.timeoutMs || 120000,
-        signal: controller.signal,
-      });
-      if (descriptor?._httpOk === false) {
-        throw new Error(descriptor.error || `upload returned ${descriptor._httpStatus || 'error'}`);
       }
       transfer.loaded = transfer.file.size;
       transfer.descriptor = descriptor;
@@ -2392,11 +2592,22 @@ async function pumpFilesTransfers() {
     for (;;) {
       const transfer = filesTransfers.slice().reverse().find(item => item.status === 'queued');
       if (!transfer) break;
-      if (transfer.kind === 'upload') {
-        await runFilesUploadTransfer(transfer).catch(() => {});
-      } else {
-        await runFilesDownloadTransfer(transfer).catch(() => {});
+      const failure = transfer.kind === 'upload'
+        ? await runFilesUploadTransfer(transfer).then(() => null, err => err)
+        : await runFilesDownloadTransfer(transfer).then(() => null, err => err);
+      if (['queued', 'running'].includes(transfer.status)) {
+        // Forward-progress backstop: a runner that exits without settling
+        // its transfer would be re-picked by the find() above forever — a
+        // synchronous microtask spin that freezes the page and allocates
+        // without bound. Force the entry failed so the pump always drains.
+        transfer.status = 'failed';
+        transfer.error = failure?.message || transfer.error || 'transfer runner exited without settling';
+        filesTransferPersistState();
+        renderFilesTransfers();
       }
+      // Macrotask yield: even a misbehaving runner that settles instantly
+      // can only busy the tab, never wedge the event loop.
+      await new Promise(resolve => setTimeout(resolve, 0));
     }
   } finally {
     filesTransferRunnerActive = false;

--- a/static/app/55-files-ide.js
+++ b/static/app/55-files-ide.js
@@ -225,6 +225,7 @@ async function filesIdeWriteFile(hostId, path, bytes, opts = {}) {
   if (opts.expected_sha256) params.expected_sha256 = opts.expected_sha256;
   if (opts.create_new) params.create_new = true;
   if (opts.force) params.force = true;
+  const requestOpts = { signal: opts.signal, timeoutMs: opts.timeoutMs };
   if (hostId) {
     const conn = await filesIdePeerConnection(hostId);
     if (conn.lastStatus && conn.lastStatus.api_fs_write_available === false) {
@@ -234,20 +235,21 @@ async function filesIdeWriteFile(hostId, path, bytes, opts = {}) {
         body: { error: `${filesIdeHostLabel(hostId)} grants read-only file access to this daemon` },
       };
     }
-    const payload = await conn.uploadBytes('api_fs_write', params, bytes);
+    const payload = await conn.uploadBytes('api_fs_write', params, bytes, requestOpts);
     return filesIdeNormalizePayload(payload);
   }
   if (dashboardConnectModeEnabled()) {
     if (!(dashboardTransport?.canUseRpc?.() && dashboardControlTransport?.lastStatus?.api_fs_write_available !== false)) {
       return { ok: false, status: 503, body: { error: 'File writes are unavailable until this dashboard reconnects' } };
     }
-    const payload = await dashboardControlTransport.uploadBytes('api_fs_write', params, bytes);
+    const payload = await dashboardControlTransport.uploadBytes('api_fs_write', params, bytes, requestOpts);
     return filesIdeNormalizePayload(payload);
   }
   const resp = await authedFetch('/api/fs/write', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ ...params, content_b64: dashboardControlBytesToBase64(bytes) }),
+    signal: opts.signal,
   });
   const body = await resp.json().catch(() => ({}));
   return { ok: resp.ok, status: resp.status, body: body || {} };

--- a/static/app/58-shortcuts-boot.js
+++ b/static/app/58-shortcuts-boot.js
@@ -231,7 +231,7 @@ function showDisplayPicker(displays) {
     });
     picker.appendChild(item);
   }
-  if (daemonVirtualDisplaysAvailable === true) {
+  if (virtualDisplaysAvailableNow()) {
     const createItem = document.createElement('div');
     createItem.className = 'display-picker-item dp-action';
     createItem.textContent = 'New virtual display';
@@ -636,18 +636,32 @@ document.getElementById('strip-minimize')?.addEventListener('click', (e) => {
 
 // ── Virtual display availability ──
 // Virtual displays are a host capability (Xvfb-based, Linux-only): derive
-// the "New virtual display" affordances from the daemon's displays payload
-// instead of offering a button that can only fail on macOS/Windows hosts.
+// the "New virtual display" affordances from the daemon instead of offering
+// a button that can only fail on macOS/Windows hosts. Two sources, because
+// each covers a transport the other can't: the displays payload reaches
+// direct dashboards over HTTP, and the dashboard-control status capability
+// reaches Connect dashboards once the channel is up (the HTTP probe is
+// impossible there, so dashboardUpdateTransportStatus re-applies the gate
+// whenever transport state changes).
 let daemonVirtualDisplaysAvailable = null;
-async function refreshVirtualDisplayAvailability() {
-  try {
-    const payload = await fetchLocalDisplaysPayload();
-    daemonVirtualDisplaysAvailable = payload?.virtual_displays_available === true;
-  } catch (_) {
-    daemonVirtualDisplaysAvailable = null;
-  }
+function virtualDisplaysAvailableNow() {
+  return daemonVirtualDisplaysAvailable === true ||
+    dashboardControlTransport?.lastStatus?.virtual_displays_available === true;
+}
+function updateVirtualDisplayAvailabilityUi() {
   const btn = document.getElementById('displays-create-virtual');
-  if (btn) btn.hidden = daemonVirtualDisplaysAvailable !== true;
+  if (btn) btn.hidden = !virtualDisplaysAvailableNow();
+}
+async function refreshVirtualDisplayAvailability() {
+  if (!dashboardConnectModeEnabled()) {
+    try {
+      const payload = await fetchLocalDisplaysPayload();
+      daemonVirtualDisplaysAvailable = payload?.virtual_displays_available === true;
+    } catch (_) {
+      daemonVirtualDisplaysAvailable = null;
+    }
+  }
+  updateVirtualDisplayAvailabilityUi();
 }
 refreshVirtualDisplayAvailability();
 

--- a/static/app/58-shortcuts-boot.js
+++ b/static/app/58-shortcuts-boot.js
@@ -634,36 +634,5 @@ document.getElementById('strip-minimize')?.addEventListener('click', (e) => {
   });
 })();
 
-// ── Virtual display availability ──
-// Virtual displays are a host capability (Xvfb-based, Linux-only): derive
-// the "New virtual display" affordances from the daemon instead of offering
-// a button that can only fail on macOS/Windows hosts. Two sources, because
-// each covers a transport the other can't: the displays payload reaches
-// direct dashboards over HTTP, and the dashboard-control status capability
-// reaches Connect dashboards once the channel is up (the HTTP probe is
-// impossible there, so dashboardUpdateTransportStatus re-applies the gate
-// whenever transport state changes).
-let daemonVirtualDisplaysAvailable = null;
-function virtualDisplaysAvailableNow() {
-  return daemonVirtualDisplaysAvailable === true ||
-    dashboardControlTransport?.lastStatus?.virtual_displays_available === true;
-}
-function updateVirtualDisplayAvailabilityUi() {
-  const btn = document.getElementById('displays-create-virtual');
-  if (btn) btn.hidden = !virtualDisplaysAvailableNow();
-}
-async function refreshVirtualDisplayAvailability() {
-  if (!dashboardConnectModeEnabled()) {
-    try {
-      const payload = await fetchLocalDisplaysPayload();
-      daemonVirtualDisplaysAvailable = payload?.virtual_displays_available === true;
-    } catch (_) {
-      daemonVirtualDisplaysAvailable = null;
-    }
-  }
-  updateVirtualDisplayAvailabilityUi();
-}
-refreshVirtualDisplayAvailability();
-
 // ── Start ──
 main();

--- a/static/app/58-shortcuts-boot.js
+++ b/static/app/58-shortcuts-boot.js
@@ -231,16 +231,18 @@ function showDisplayPicker(displays) {
     });
     picker.appendChild(item);
   }
-  const createItem = document.createElement('div');
-  createItem.className = 'display-picker-item dp-action';
-  createItem.textContent = 'New virtual display';
-  createItem.title = 'Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed. Linux hosts only.';
-  createItem.addEventListener('click', (e) => {
-    e.stopPropagation();
-    hideDisplayPicker();
-    createVirtualDisplay();
-  });
-  picker.appendChild(createItem);
+  if (daemonVirtualDisplaysAvailable === true) {
+    const createItem = document.createElement('div');
+    createItem.className = 'display-picker-item dp-action';
+    createItem.textContent = 'New virtual display';
+    createItem.title = 'Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed.';
+    createItem.addEventListener('click', (e) => {
+      e.stopPropagation();
+      hideDisplayPicker();
+      createVirtualDisplay();
+    });
+    picker.appendChild(createItem);
+  }
   // ui-v2 hides #status-bar (the picker's v1 anchor subtree), so an
   // in-place open can never render — portal to <body> and pin the popover
   // to the live rail's "Your screen" card (the control that proxies the
@@ -631,6 +633,23 @@ document.getElementById('strip-minimize')?.addEventListener('click', (e) => {
     document.body.style.userSelect = '';
   });
 })();
+
+// ── Virtual display availability ──
+// Virtual displays are a host capability (Xvfb-based, Linux-only): derive
+// the "New virtual display" affordances from the daemon's displays payload
+// instead of offering a button that can only fail on macOS/Windows hosts.
+let daemonVirtualDisplaysAvailable = null;
+async function refreshVirtualDisplayAvailability() {
+  try {
+    const payload = await fetchLocalDisplaysPayload();
+    daemonVirtualDisplaysAvailable = payload?.virtual_displays_available === true;
+  } catch (_) {
+    daemonVirtualDisplaysAvailable = null;
+  }
+  const btn = document.getElementById('displays-create-virtual');
+  if (btn) btn.hidden = daemonVirtualDisplaysAvailable !== true;
+}
+refreshVirtualDisplayAvailability();
 
 // ── Start ──
 main();


### PR DESCRIPTION
## What

Everything found root-causing the 2026-07-08 frozen-dashboard incident (daemon segfault at 22:25:42 + a Safari tab at 50 GB footprint + transfers broken over direct mTLS).

**1. Transfer pump freeze + memory bomb (frontend).** `pumpFilesTransfers`'s `for(;;)` re-picked the same `queued` transfer forever when a runner threw before setting `status='running'` — a pure microtask spin: the page froze at the moment of the Retry click (mouseup handler never exited its microtask checkpoint; `sample(1)` showed `constructErrorConstructor`+`getStackTrace` at 100% CPU) and allocated Errors without bound (50 GB WebKit-malloc footprint on a 24 GB machine). Both runners now settle status before any guard can throw; the pump force-fails unsettled entries and yields a macrotask per iteration.

**2. Direct-HTTP transfer fallbacks (frontend).** All byte-stream/transfer features were gated on the WebRTC dashboard-control channel, which is opt-in/absent on plain mTLS dashboards — staged uploads, filesystem uploads, and staged downloads all failed (reproduced end-to-end from Safari over mTLS). When the channel is absent and not in Connect mode: staged uploads POST `/api/session/current/uploads`, staged-upload downloads GET `.../uploads/{id}/raw`, filesystem uploads write via `/api/fs/write` (single shot — its body cap was already sized for `UPLOAD_MAX_BYTES` of base64). `no project root` errors now surface actionably.

**3. screencapturekit 1.5 → 8.0 (daemon segfault).** A display-session stop dropped the SCStream and 1.5.4 freed its `StreamContext` while ScreenCaptureKit's remote receive queue could still deliver — the next screen change after an idle gap (observed 53s) called into the freed handler closure: SIGSEGV `KERN_INVALID_ADDRESS at 0x10` on `com.screencapturekit.output.0`, killing the daemon. 8.0 redesigned exactly this teardown (Swift-side holders take their own +1 on the context; callbacks run on ARC-retained objects — verified in source). Migration surface was CGRect `origin`/`size` nesting only; 485 display-crate tests pass.

**4. macOS app watchdog.** The wrapper only noticed backend death via a 5s poll and painted a manual-restart crash screen — remote dashboards just went dark (30+ min during the incident). Now: `terminationHandler` reacts immediately; abnormal exits auto-restart with capped exponential backoff (2s..60s, reset after 10 min stable); clean exits stay manual; quit/manual-restart detach the handler.

**5. Virtual displays are now a derived capability.** `vision::virtual_displays_supported()` (Xvfb, Linux-only) drives the displays payload (now object form `{displays, virtual_displays_available}` — `normalizeDisplaysPayload` always accepted it; QA harness asserts updated) and the status capabilities; the dashboard renders the "New virtual display" affordances only when advertised. Also fixed: a failed create on unsupported platforms reported `DisplayCaptureLost` against fallback id 0, which could tear down a live display-0 capture session.

## Testing
- `cargo nextest run --bins`: 2699 passed. `cargo test -p intendant-display --lib`: 485 passed. clippy + headless e2e in flight.
- Reproduced each transfer failure from Safari over mTLS before the fix; post-deploy E2E verification (rebuilt app bundle, all transfer legs + watchdog kill test + display start/stop) to follow on the incident machine.