### PR TITLE
macOS app: extract backend supervision into BackendSupervisor; rotate the backend log

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -160,7 +160,7 @@ cargo build --release -p intendant   # re-embed
 ### macOS app bundle
 
 `scripts/bundle-macos.sh` compiles a small Swift wrapper
-(`macos-app/main.swift`) with `swiftc`, bundles it with the release `intendant`
+(`macos-app/*.swift`) with `swiftc`, bundles it with the release `intendant`
 binary, codesigns it (a persistent self-signed identity, ad-hoc fallback), and
 installs to `/Applications/Intendant.app`.
 

--- a/macos-app/BackendSupervisor.swift
+++ b/macos-app/BackendSupervisor.swift
@@ -1,0 +1,388 @@
+import Foundation
+
+// MARK: - Backend Supervision
+
+/// Supervision states surfaced to the app layer, each driving a screen
+/// (boot page, placeholder/dashboard, failure page, restart countdown).
+/// The `detail` string on the delegate callback carries the human-readable
+/// line that varies per transition (countdown seconds, log-file pointer).
+enum BackendState {
+    /// A spawn was requested and the readiness poll is in flight.
+    case starting
+    /// The readiness poll reached the backend (HTTP 200); the recurring
+    /// health check is now running.
+    case ready
+    /// The readiness poll exhausted its attempts without an answer.
+    case unreachable
+    /// The backend exited cleanly — a deliberate stop; only the manual
+    /// Restart button revives it.
+    case stoppedCleanly
+    /// The backend exited abnormally; the auto-restart countdown is armed.
+    case crashed
+}
+
+/// Callbacks are always delivered on the main queue.
+protocol BackendSupervisorDelegate: AnyObject {
+    /// Drive the boot / placeholder / crash / countdown screens.
+    func backendSupervisor(_ supervisor: BackendSupervisor,
+                           didChangeState state: BackendState,
+                           detail: String)
+    /// Recurring 5s housekeeping hook, fired while the backend process is
+    /// alive and health checks run (the app layer uses it for dashboard
+    /// idle-unload).
+    func backendSupervisorHealthTick(_ supervisor: BackendSupervisor)
+}
+
+/// Supervises the bundled Rust daemon: spawn, readiness polling, health
+/// checks, exit policy (auto-restart with capped exponential backoff), quit
+/// teardown, and the `~/.intendant/app-backend.log` sink the daemon's
+/// stdout/stderr append to (rotation + launch/exit markers).
+///
+/// The daemon MUST remain a **direct child of the app process**: macOS TCC
+/// grants (Screen Recording, Accessibility, Microphone, Camera) flow to the
+/// daemon and its subprocesses through the app's process tree. Moving
+/// supervision to launchd/SMAppService would put the daemon outside that
+/// tree and silently strip every capture capability the wrapper exists to
+/// provide.
+final class BackendSupervisor {
+    weak var delegate: BackendSupervisorDelegate?
+
+    private let binaryPath: String
+    private let arguments: [String]
+    private let port: Int
+    private let scheme: String
+    /// Trust-configured session shared with the app layer (pins the
+    /// installed access server cert / presents the mTLS client identity).
+    private let session: URLSession
+
+    private var backendProcess: Process?
+    private var healthTimer: Timer?
+    private var healthProbeFailures = 0
+    // Backend auto-restart: exponential backoff on abnormal exits, reset
+    // once a backend has stayed up long enough to count as stable.
+    private var backendRestartAttempts = 0
+    private var backendLastStart = Date.distantPast
+    private var backendAutoRestartTimer: Timer?
+    private var isTerminating = false
+    // Readiness-poll chains carry a generation stamp; bumping it orphans
+    // any chain already in flight (a crash mid-boot must not let a stale
+    // chain paint its dead-end failure page over the restart countdown).
+    private var pollGeneration = 0
+
+    /// Rotate `app-backend.log` at launch once it exceeds this many bytes.
+    private static let maxLogBytes: UInt64 = 10 * 1024 * 1024
+
+    init(binaryPath: String, arguments: [String], port: Int, scheme: String, session: URLSession) {
+        self.binaryPath = binaryPath
+        self.arguments = arguments
+        self.port = port
+        self.scheme = scheme
+        self.session = session
+    }
+
+    // MARK: - Process lifecycle
+
+    /// Spawn the daemon as a direct child (see the class doc for why not
+    /// launchd), wiring stdout/stderr into the append-mode backend log.
+    @discardableResult
+    func startBackend() -> Bool {
+        guard FileManager.default.fileExists(atPath: binaryPath) else {
+            NSLog("intendant-bin not found at \(binaryPath)")
+            return false
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binaryPath)
+        process.arguments = arguments
+
+        // Inherit environment + ensure Homebrew PATH
+        var env = ProcessInfo.processInfo.environment
+        let extraPaths = ["/opt/homebrew/bin", "/usr/local/bin"]
+        let currentPath = env["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
+        let missing = extraPaths.filter { !currentPath.contains($0) && FileManager.default.fileExists(atPath: $0) }
+        if !missing.isEmpty {
+            env["PATH"] = missing.joined(separator: ":") + ":" + currentPath
+        }
+        process.environment = env
+
+        // Working directory: plainly the user's home. Nothing derives from
+        // the launch cwd anymore — a daemon started outside a project (no
+        // .git / intendant.toml at cwd) runs projectless on the Rust side:
+        // no cwd file watching, no cwd-derived sandbox scope, no default
+        // session project. Each session picks its project directory in the
+        // dashboard's New Session pane. (Home may itself contain a project
+        // marker; if so the daemon simply roots there, which is the normal
+        // rooted behavior, not a scan hazard — projectless/marker gating
+        // lives in the Rust daemon.)
+        let dir = FileManager.default.homeDirectoryForCurrentUser
+        process.currentDirectoryURL = dir
+        NSLog("Working directory: \(dir.path)")
+
+        // Log backend output for debugging (append mode — preserves crash info
+        // from previous sessions; the Rust panic hook writes per-session panic.log
+        // files for structured auditing, this is the fallback for pre-session
+        // crashes). Rotated at launch so it can't grow without bound.
+        let logFile = backendLogFile()
+        try? FileManager.default.createDirectory(
+            at: logFile.deletingLastPathComponent(), withIntermediateDirectories: true)
+        rotateBackendLogIfNeeded(logFile)
+        if !FileManager.default.fileExists(atPath: logFile.path) {
+            FileManager.default.createFile(atPath: logFile.path, contents: nil)
+        }
+        let logHandle = FileHandle(forWritingAtPath: logFile.path)
+        logHandle?.seekToEndOfFile()
+        // Write launch separator
+        let sep = "\n--- Launch \(ISO8601DateFormatter().string(from: Date())) ---\n"
+        logHandle?.write(sep.data(using: .utf8) ?? Data())
+        process.standardOutput = logHandle ?? FileHandle.nullDevice
+        process.standardError = logHandle ?? FileHandle.nullDevice
+
+        do {
+            try process.run()
+            backendProcess = process
+            backendLastStart = Date()
+            // React to backend death immediately (the 5s health tick stays
+            // as the belt for a missed handler). Remote dashboards have no
+            // crash screen — without a restart this machine just goes dark.
+            process.terminationHandler = { [weak self] proc in
+                DispatchQueue.main.async {
+                    self?.backendDidExit(proc)
+                }
+            }
+            NSLog("Started intendant-bin (PID \(process.processIdentifier)) on port \(port)")
+            return true
+        } catch {
+            NSLog("Failed to start intendant-bin: \(error)")
+            return false
+        }
+    }
+
+    /// Manual (crash-screen Restart button) or auto-restart-timer restart:
+    /// relaunch the backend and re-enter the readiness poll (whose `.ready`
+    /// lands on the placeholder / auto-activation).
+    @discardableResult
+    func restartBackend() -> Bool {
+        NSLog("Backend restart requested")
+        backendAutoRestartTimer?.invalidate()
+        healthTimer?.invalidate()
+        healthProbeFailures = 0
+        if let proc = backendProcess, proc.isRunning {
+            proc.terminationHandler = nil
+            proc.terminate()
+        }
+        let started = startBackend()
+        if started {
+            pollUntilReady()
+        }
+        return started
+    }
+
+    /// Quit teardown: kill the child on purpose without letting the exit
+    /// handler paint a crash screen or schedule a restart mid-teardown.
+    func shutdown() {
+        isTerminating = true
+        backendAutoRestartTimer?.invalidate()
+        healthTimer?.invalidate()
+        guard let proc = backendProcess, proc.isRunning else { return }
+        proc.terminationHandler = nil
+        proc.terminate()
+        // Wait up to 3 seconds, then force-kill to avoid hanging on quit
+        let deadline = Date().addingTimeInterval(3.0)
+        while proc.isRunning && Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.1)
+        }
+        if proc.isRunning {
+            kill(proc.processIdentifier, SIGKILL)
+        }
+    }
+
+    // MARK: - Exit policy
+
+    /// Backend exit policy: abnormal exits (signal / non-zero status)
+    /// auto-restart with capped exponential backoff; a clean exit means
+    /// someone stopped the daemon deliberately, so only the manual Restart
+    /// button revives it.
+    private func backendDidExit(_ proc: Process) {
+        guard !isTerminating, proc === backendProcess, !proc.isRunning else { return }
+        // Consume the reference first: the health tick and the
+        // terminationHandler can both observe the same exit, and a second
+        // pass would double-count the attempt and reschedule the timer.
+        backendProcess = nil
+        healthTimer?.invalidate()
+        let signalled = proc.terminationReason == .uncaughtSignal
+        let status = proc.terminationStatus
+        let abnormal = signalled || status != 0
+        NSLog("Backend exited (\(signalled ? "signal" : "status") \(status), \(abnormal ? "abnormal" : "clean"))")
+        writeExitMarker(status: status, signalled: signalled)
+        guard abnormal else {
+            pollGeneration += 1
+            notifyState(.stoppedCleanly, "The daemon exited cleanly. Restart it to keep using this app.")
+            return
+        }
+        if Date().timeIntervalSince(backendLastStart) > 600 {
+            backendRestartAttempts = 0
+        }
+        scheduleBackendAutoRestart()
+    }
+
+    /// Arm (or re-arm) the auto-restart countdown with capped exponential
+    /// backoff (2s..60s), orphaning any readiness-poll chain so nothing
+    /// paints over the countdown screen. Re-entered by the timer itself
+    /// when a spawn attempt fails, so the chain never dead-ends.
+    private func scheduleBackendAutoRestart() {
+        guard !isTerminating else { return }
+        pollGeneration += 1
+        let delay = min(60.0, pow(2.0, Double(backendRestartAttempts + 1)))
+        backendRestartAttempts += 1
+        NSLog("Auto-restarting backend in \(Int(delay))s (attempt \(backendRestartAttempts))")
+        notifyState(
+            .crashed,
+            "Restarting in \(Int(delay))s (attempt \(backendRestartAttempts)) — see ~/.intendant/app-backend.log"
+        )
+        backendAutoRestartTimer?.invalidate()
+        backendAutoRestartTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+            guard let self = self, !self.isTerminating else { return }
+            if !self.restartBackend() {
+                self.scheduleBackendAutoRestart()
+            }
+        }
+    }
+
+    // MARK: - Readiness polling
+
+    /// Begin (or restart) the generation-stamped readiness poll; announces
+    /// `.starting` so the app layer paints the boot screen.
+    func pollUntilReady() {
+        pollGeneration += 1
+        notifyState(.starting, "Waiting for backend on port \(port)")
+        poll(attempts: 0, generation: pollGeneration)
+    }
+
+    private func poll(attempts: Int, generation: Int) {
+        // A crash or scheduled restart bumps pollGeneration; a stale chain
+        // must go silent rather than paint over the countdown screen.
+        guard generation == pollGeneration else { return }
+        if attempts > 30 {
+            // The window may have been closed while the backend booted;
+            // the poll ran to its end regardless — whether the failure
+            // page can actually paint is the delegate's problem.
+            notifyState(.unreachable, "Check ~/.intendant/app-backend.log for details")
+            return
+        }
+
+        // Poll the backend directly; under bundled auto-TLS/mTLS this is
+        // HTTPS and uses the same local trust delegate as the intendant:// proxy.
+        let healthURL = backendURL("/")
+        var request = URLRequest(url: healthURL, timeoutInterval: 1)
+        request.httpMethod = "HEAD"
+        session.dataTask(with: request) { _, response, error in
+            if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                DispatchQueue.main.async {
+                    guard generation == self.pollGeneration else { return }
+                    self.notifyState(.ready, "Backend ready on port \(self.port)")
+                    self.startHealthCheck()
+                }
+            } else {
+                // Silent-by-default; the last attempts say why the failure
+                // page is about to render (slow cold start vs TLS refusal).
+                if attempts >= 28 {
+                    let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+                    NSLog("Backend readiness poll failing (attempt \(attempts + 1)/30): status=\(status) error=\(error?.localizedDescription ?? "none")")
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    self.poll(attempts: attempts + 1, generation: generation)
+                }
+            }
+        }.resume()
+    }
+
+    // MARK: - Health check
+
+    private func startHealthCheck() {
+        healthTimer?.invalidate()
+        healthTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            // Check if the backend process is still alive
+            if let proc = self.backendProcess, !proc.isRunning {
+                self.healthTimer?.invalidate()
+                self.backendDidExit(proc)
+                return
+            }
+            // Housekeeping hook (dashboard idle-unload lives in the app layer).
+            self.delegate?.backendSupervisorHealthTick(self)
+            // Also ping the HTTP endpoint. Probe failures are logged, never
+            // fatal: the process-liveness check above is the only thing
+            // allowed to declare a crash — a slow daemon or a stalled TLS
+            // probe must not replace a working dashboard with a false
+            // "Backend process exited" screen.
+            let url = self.backendURL("/")
+            var req = URLRequest(url: url, timeoutInterval: 2)
+            req.httpMethod = "HEAD"
+            self.session.dataTask(with: req) { _, response, error in
+                let ok = (response as? HTTPURLResponse)?.statusCode == 200
+                DispatchQueue.main.async {
+                    if ok {
+                        if self.healthProbeFailures >= 3 {
+                            NSLog("Backend health probe recovered after \(self.healthProbeFailures) failures")
+                        }
+                        self.healthProbeFailures = 0
+                        return
+                    }
+                    self.healthProbeFailures += 1
+                    if self.healthProbeFailures == 3 || self.healthProbeFailures % 24 == 0 {
+                        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+                        NSLog("Backend health probe failing (\(self.healthProbeFailures) consecutive; status=\(status) error=\(error?.localizedDescription ?? "none")) — process is still running")
+                    }
+                }
+            }.resume()
+        }
+    }
+
+    // MARK: - Backend log
+
+    /// `~/.intendant/app-backend.log` — the daemon's stdout/stderr sink.
+    private func backendLogFile() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".intendant")
+            .appendingPathComponent("app-backend.log")
+    }
+
+    /// The append-mode log otherwise grows forever. On each backend launch,
+    /// once it exceeds 10 MB shift it aside to `app-backend.log.1`,
+    /// replacing any previous `.1` — exactly one predecessor is kept.
+    private func rotateBackendLogIfNeeded(_ logFile: URL) {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: logFile.path),
+              let size = (attrs[.size] as? NSNumber)?.uint64Value,
+              size > Self.maxLogBytes else { return }
+        let rotated = logFile.appendingPathExtension("1")
+        do {
+            try? FileManager.default.removeItem(at: rotated)
+            try FileManager.default.moveItem(at: logFile, to: rotated)
+            NSLog("Rotated \(logFile.lastPathComponent) (\(size) bytes) to \(rotated.lastPathComponent)")
+        } catch {
+            NSLog("Failed to rotate \(logFile.lastPathComponent): \(error) — continuing with the oversized log")
+        }
+    }
+
+    /// Matching bookend for the launch separator, written where the
+    /// supervisor observes a backend exit — crash forensics need only this
+    /// one file. (Deliberate teardowns — quit, manual restart — clear the
+    /// termination handler first and intentionally write no marker.)
+    private func writeExitMarker(status: Int32, signalled: Bool) {
+        guard let handle = FileHandle(forWritingAtPath: backendLogFile().path) else { return }
+        handle.seekToEndOfFile()
+        let marker = "\n--- Exit \(ISO8601DateFormatter().string(from: Date())) status=\(status) signal=\(signalled) ---\n"
+        handle.write(marker.data(using: .utf8) ?? Data())
+        try? handle.close()
+    }
+
+    // MARK: - Helpers
+
+    private func backendURL(_ path: String) -> URL {
+        URL(string: "\(scheme)://127.0.0.1:\(port)\(path)")!
+    }
+
+    private func notifyState(_ state: BackendState, _ detail: String) {
+        delegate?.backendSupervisor(self, didChangeState: state, detail: detail)
+    }
+}

--- a/macos-app/main.swift
+++ b/macos-app/main.swift
@@ -282,25 +282,17 @@ final class AppMessageBridge: NSObject, WKScriptMessageHandler {
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelegate,
-    WKNavigationDelegate
+    WKNavigationDelegate, BackendSupervisorDelegate
 {
     let consoleBridge = ConsoleBridge()
     let messageBridge = AppMessageBridge()
     var window: NSWindow!
     var webView: WKWebView!
-    var backendProcess: Process?
-    var healthTimer: Timer?
-    var healthProbeFailures = 0
-    // Backend auto-restart: exponential backoff on abnormal exits, reset
-    // once a backend has stayed up long enough to count as stable.
-    var backendRestartAttempts = 0
-    var backendLastStart = Date.distantPast
-    var backendAutoRestartTimer: Timer?
-    var isTerminating = false
-    // Readiness-poll chains carry a generation stamp; bumping it orphans
-    // any chain already in flight (a crash mid-boot must not let a stale
-    // chain paint its dead-end failure page over the restart countdown).
-    var pollGeneration = 0
+    /// Owns the daemon child process, restart/backoff policy, readiness
+    /// polling, health checks, and the backend log (see
+    /// macos-app/BackendSupervisor.swift). State changes come back through
+    /// BackendSupervisorDelegate and drive the screens below.
+    var backendSupervisor: BackendSupervisor!
     var port: Int = 8765
     let portSearchLimit = 20
     var launchPlan: BackendLaunchPlan!
@@ -354,9 +346,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         configureBackendSession()
         checkPermissions()
         installMainMenu()
-        startBackend()
+        backendSupervisor = makeBackendSupervisor()
+        backendSupervisor.startBackend()
         createWindow()
-        pollUntilReady()
+        backendSupervisor.pollUntilReady()
     }
 
     /// The app historically had no menu bar because closing the window
@@ -591,38 +584,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
     /// readiness poll (which lands on the placeholder / auto-activation).
     @discardableResult
     func restartBackend() -> Bool {
-        NSLog("Backend restart requested")
-        backendAutoRestartTimer?.invalidate()
-        healthTimer?.invalidate()
-        healthProbeFailures = 0
-        if let proc = backendProcess, proc.isRunning {
-            proc.terminationHandler = nil
-            proc.terminate()
-        }
-        let started = startBackend()
-        if started {
-            pollUntilReady()
-        }
-        return started
+        backendSupervisor.restartBackend()
     }
 
     func applicationWillTerminate(_ notification: Notification) {
-        isTerminating = true
-        backendAutoRestartTimer?.invalidate()
-        healthTimer?.invalidate()
-        guard let proc = backendProcess, proc.isRunning else { return }
-        // Quitting kills the backend on purpose; don't let the exit handler
-        // paint a crash screen or schedule a restart mid-teardown.
-        proc.terminationHandler = nil
-        proc.terminate()
-        // Wait up to 3 seconds, then force-kill to avoid hanging on quit
-        let deadline = Date().addingTimeInterval(3.0)
-        while proc.isRunning && Date() < deadline {
-            Thread.sleep(forTimeInterval: 0.1)
-        }
-        if proc.isRunning {
-            kill(proc.processIdentifier, SIGKILL)
-        }
+        // Quitting kills the backend on purpose; the supervisor suppresses
+        // its exit handling and takes the child down with a bounded wait.
+        backendSupervisor?.shutdown()
     }
 
     // MARK: - WKUIDelegate (JS alert/confirm/prompt)
@@ -701,20 +669,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         NSLog("Dashboard failed to load: \(error.localizedDescription)")
     }
 
-    // MARK: - Backend
+    // MARK: - Backend supervision
 
-    @discardableResult
-    func startBackend() -> Bool {
-        let bundle = Bundle.main
-        let binPath = bundle.bundlePath + "/Contents/MacOS/intendant-bin"
-
-        guard FileManager.default.fileExists(atPath: binPath) else {
-            NSLog("intendant-bin not found at \(binPath)")
-            return false
-        }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: binPath)
+    /// Assemble the supervisor for the bundled daemon. Argument policy
+    /// (TLS mode, forwarded CLI args) derives from the launch plan here;
+    /// process lifecycle, restart backoff, readiness polling, health
+    /// checks, and the backend log live in BackendSupervisor.
+    func makeBackendSupervisor() -> BackendSupervisor {
         // Forward any extra CLI arguments (e.g. --agent codex) to the backend
         var args = ["--web", String(port)]
         if launchPlan.autoMtls {
@@ -723,117 +684,52 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
             args.append("--no-tls")
         }
         args.append(contentsOf: launchPlan.extraArgs)
-        process.arguments = args
-
-        // Inherit environment + ensure Homebrew PATH
-        var env = ProcessInfo.processInfo.environment
-        let extraPaths = ["/opt/homebrew/bin", "/usr/local/bin"]
-        let currentPath = env["PATH"] ?? "/usr/bin:/bin:/usr/sbin:/sbin"
-        let missing = extraPaths.filter { !currentPath.contains($0) && FileManager.default.fileExists(atPath: $0) }
-        if !missing.isEmpty {
-            env["PATH"] = missing.joined(separator: ":") + ":" + currentPath
-        }
-        process.environment = env
-
-        // Working directory: plainly the user's home. Nothing derives from
-        // the launch cwd anymore — a daemon started outside a project (no
-        // .git / intendant.toml at cwd) runs projectless on the Rust side:
-        // no cwd file watching, no cwd-derived sandbox scope, no default
-        // session project. Each session picks its project directory in the
-        // dashboard's New Session pane. (Home may itself contain a project
-        // marker; if so the daemon simply roots there, which is the normal
-        // rooted behavior, not a scan hazard — projectless/marker gating
-        // lives in the Rust daemon.)
-        let dir = FileManager.default.homeDirectoryForCurrentUser
-        process.currentDirectoryURL = dir
-        NSLog("Working directory: \(dir.path)")
-
-        // Log backend output for debugging (append mode — preserves crash info
-        // from previous sessions; the Rust panic hook writes per-session panic.log
-        // files for structured auditing, this is the fallback for pre-session crashes)
-        let logDir = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".intendant")
-        try? FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
-        let logFile = logDir.appendingPathComponent("app-backend.log")
-        if !FileManager.default.fileExists(atPath: logFile.path) {
-            FileManager.default.createFile(atPath: logFile.path, contents: nil)
-        }
-        let logHandle = FileHandle(forWritingAtPath: logFile.path)
-        logHandle?.seekToEndOfFile()
-        // Write launch separator
-        let sep = "\n--- Launch \(ISO8601DateFormatter().string(from: Date())) ---\n"
-        logHandle?.write(sep.data(using: .utf8) ?? Data())
-        process.standardOutput = logHandle ?? FileHandle.nullDevice
-        process.standardError = logHandle ?? FileHandle.nullDevice
-
-        do {
-            try process.run()
-            backendProcess = process
-            backendLastStart = Date()
-            // React to backend death immediately (the 5s health tick stays
-            // as the belt for a missed handler). Remote dashboards have no
-            // crash screen — without a restart this machine just goes dark.
-            process.terminationHandler = { [weak self] proc in
-                DispatchQueue.main.async {
-                    self?.backendDidExit(proc)
-                }
-            }
-            NSLog("Started intendant-bin (PID \(process.processIdentifier)) on port \(port)")
-            return true
-        } catch {
-            NSLog("Failed to start intendant-bin: \(error)")
-            return false
-        }
-    }
-
-    /// Backend exit policy: abnormal exits (signal / non-zero status)
-    /// auto-restart with capped exponential backoff; a clean exit means
-    /// someone stopped the daemon deliberately, so only the manual Restart
-    /// button revives it.
-    func backendDidExit(_ proc: Process) {
-        guard !isTerminating, proc === backendProcess, !proc.isRunning else { return }
-        // Consume the reference first: the health tick and the
-        // terminationHandler can both observe the same exit, and a second
-        // pass would double-count the attempt and reschedule the timer.
-        backendProcess = nil
-        healthTimer?.invalidate()
-        let signalled = proc.terminationReason == .uncaughtSignal
-        let status = proc.terminationStatus
-        let abnormal = signalled || status != 0
-        NSLog("Backend exited (\(signalled ? "signal" : "status") \(status), \(abnormal ? "abnormal" : "clean"))")
-        guard abnormal else {
-            pollGeneration += 1
-            showBackendCrash(
-                title: "Backend stopped",
-                detail: "The daemon exited cleanly. Restart it to keep using this app."
-            )
-            return
-        }
-        if Date().timeIntervalSince(backendLastStart) > 600 {
-            backendRestartAttempts = 0
-        }
-        scheduleBackendAutoRestart()
-    }
-
-    /// Arm (or re-arm) the auto-restart countdown with capped exponential
-    /// backoff, orphaning any readiness-poll chain so nothing paints over
-    /// the countdown screen. Re-entered by the timer itself when a spawn
-    /// attempt fails, so the chain never dead-ends.
-    func scheduleBackendAutoRestart() {
-        guard !isTerminating else { return }
-        pollGeneration += 1
-        let delay = min(60.0, pow(2.0, Double(backendRestartAttempts + 1)))
-        backendRestartAttempts += 1
-        NSLog("Auto-restarting backend in \(Int(delay))s (attempt \(backendRestartAttempts))")
-        showBackendCrash(
-            title: "Backend process crashed",
-            detail: "Restarting in \(Int(delay))s (attempt \(backendRestartAttempts)) — see ~/.intendant/app-backend.log"
+        let supervisor = BackendSupervisor(
+            binaryPath: Bundle.main.bundlePath + "/Contents/MacOS/intendant-bin",
+            arguments: args,
+            port: port,
+            scheme: launchPlan.scheme,
+            session: backendSession
         )
-        backendAutoRestartTimer?.invalidate()
-        backendAutoRestartTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
-            guard let self = self, !self.isTerminating else { return }
-            if !self.restartBackend() {
-                self.scheduleBackendAutoRestart()
+        supervisor.delegate = self
+        return supervisor
+    }
+
+    /// Map supervision states to the screens the user sees. The supervisor
+    /// owns the process and the policy; this layer only paints.
+    func backendSupervisor(_ supervisor: BackendSupervisor,
+                           didChangeState state: BackendState,
+                           detail: String) {
+        switch state {
+        case .starting:
+            showBackendStarting(detail: detail)
+        case .ready:
+            // Backend is up. The SPA is deferred behind the
+            // placeholder unless a harness/user asked for it.
+            if autoActivateDashboard {
+                activateDashboard()
+            } else {
+                showPlaceholder(paused: false)
             }
+        case .unreachable:
+            showBackendUnreachable(detail: detail)
+        case .stoppedCleanly:
+            showBackendCrash(title: "Backend stopped", detail: detail)
+        case .crashed:
+            showBackendCrash(title: "Backend process crashed", detail: detail)
+        }
+    }
+
+    /// 5s housekeeping tick from the supervisor's health timer.
+    func backendSupervisorHealthTick(_ supervisor: BackendSupervisor) {
+        // Idle unload: an SPA nobody has seen for hours is pure cost —
+        // its web-content process grows with every streamed session.
+        if dashboardActive,
+           idleUnloadSeconds > 0,
+           let win = window,
+           !win.occlusionState.contains(.visible),
+           Date().timeIntervalSince(lastWindowVisibleAt) > idleUnloadSeconds {
+            showPlaceholder(paused: true)
         }
     }
 
@@ -944,131 +840,31 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         window.appearance = NSAppearance(named: .darkAqua)
     }
 
-    // MARK: - Polling
+    // MARK: - Backend screens
 
-    func pollUntilReady() {
-        pollGeneration += 1
+    /// Boot screen while the readiness poll runs. The window may be
+    /// closed; the poll keeps running regardless, only painting is
+    /// skipped.
+    func showBackendStarting(detail: String) {
         webView?.loadHTMLString("""
             <html>
             <body style="background:#1e1e2e;color:#cdd6f4;font-family:-apple-system;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
             <div style="text-align:center">
                 <div style="font-size:24px;margin-bottom:8px">Starting Intendant...</div>
-                <div style="font-size:14px;color:#6c7086">Waiting for backend on port \(port)</div>
+                <div style="font-size:14px;color:#6c7086">\(detail)</div>
             </div>
             </body>
             </html>
             """, baseURL: nil)
-
-        poll(attempts: 0, generation: pollGeneration)
     }
 
-    func poll(attempts: Int, generation: Int) {
-        // A crash or scheduled restart bumps pollGeneration; a stale chain
-        // must go silent rather than paint over the countdown screen.
-        guard generation == pollGeneration else { return }
-        if attempts > 30 {
-            // The window may have been closed while the backend booted;
-            // the poll keeps running regardless, only painting is skipped.
-            webView?.loadHTMLString("""
-                <html>
-                <body style="background:#1e1e2e;color:#cdd6f4;font-family:-apple-system;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">
-                <div style="text-align:center">
-                    <div style="font-size:20px;color:#f38ba8;margin-bottom:12px">Failed to connect to backend on port \(port)</div>
-                    <div style="font-size:14px;color:#6c7086;margin-bottom:16px">Check ~/.intendant/app-backend.log for details</div>
-                    <button onclick="window.webkit.messageHandlers.restart && window.webkit.messageHandlers.restart.postMessage(null)"
-                            style="padding:8px 24px;border:1px solid #89b4fa;border-radius:6px;background:transparent;color:#89b4fa;font-size:14px;cursor:pointer">
-                        Restart now
-                    </button>
-                </div>
-                </body>
-                </html>
-                """, baseURL: nil)
-            return
-        }
-
-        // Poll the backend directly; under bundled auto-TLS/mTLS this is
-        // HTTPS and uses the same local trust delegate as the intendant:// proxy.
-        let healthURL = backendURL("/")
-        var request = URLRequest(url: healthURL, timeoutInterval: 1)
-        request.httpMethod = "HEAD"
-        backendSession.dataTask(with: request) { _, response, error in
-            if let http = response as? HTTPURLResponse, http.statusCode == 200 {
-                DispatchQueue.main.async {
-                    guard generation == self.pollGeneration else { return }
-                    // Backend is up. The SPA is deferred behind the
-                    // placeholder unless a harness/user asked for it.
-                    if self.autoActivateDashboard {
-                        self.activateDashboard()
-                    } else {
-                        self.showPlaceholder(paused: false)
-                    }
-                    self.startHealthCheck()
-                }
-            } else {
-                // Silent-by-default; the last attempts say why the failure
-                // page is about to render (slow cold start vs TLS refusal).
-                if attempts >= 28 {
-                    let status = (response as? HTTPURLResponse)?.statusCode ?? 0
-                    NSLog("Backend readiness poll failing (attempt \(attempts + 1)/30): status=\(status) error=\(error?.localizedDescription ?? "none")")
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    self.poll(attempts: attempts + 1, generation: generation)
-                }
-            }
-        }.resume()
-    }
-
-    // MARK: - Health Check
-
-    func startHealthCheck() {
-        healthTimer?.invalidate()
-        healthTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
-            guard let self = self else { return }
-            // Check if the backend process is still alive
-            if let proc = self.backendProcess, !proc.isRunning {
-                self.healthTimer?.invalidate()
-                self.backendDidExit(proc)
-                return
-            }
-            // Idle unload: an SPA nobody has seen for hours is pure cost —
-            // its web-content process grows with every streamed session.
-            if self.dashboardActive,
-               self.idleUnloadSeconds > 0,
-               let win = self.window,
-               !win.occlusionState.contains(.visible),
-               Date().timeIntervalSince(self.lastWindowVisibleAt) > self.idleUnloadSeconds {
-                self.showPlaceholder(paused: true)
-            }
-            // Also ping the HTTP endpoint. Probe failures are logged, never
-            // fatal: the process-liveness check above is the only thing
-            // allowed to declare a crash — a slow daemon or a stalled TLS
-            // probe must not replace a working dashboard with a false
-            // "Backend process exited" screen.
-            let url = self.backendURL("/")
-            var req = URLRequest(url: url, timeoutInterval: 2)
-            req.httpMethod = "HEAD"
-            self.backendSession.dataTask(with: req) { _, response, error in
-                let ok = (response as? HTTPURLResponse)?.statusCode == 200
-                DispatchQueue.main.async {
-                    if ok {
-                        if self.healthProbeFailures >= 3 {
-                            NSLog("Backend health probe recovered after \(self.healthProbeFailures) failures")
-                        }
-                        self.healthProbeFailures = 0
-                        return
-                    }
-                    self.healthProbeFailures += 1
-                    if self.healthProbeFailures == 3 || self.healthProbeFailures % 24 == 0 {
-                        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
-                        NSLog("Backend health probe failing (\(self.healthProbeFailures) consecutive; status=\(status) error=\(error?.localizedDescription ?? "none")) — process is still running")
-                    }
-                }
-            }.resume()
-        }
-    }
-
-    func backendURL(_ path: String) -> URL {
-        URL(string: "\(launchPlan.scheme)://127.0.0.1:\(port)\(path)")!
+    /// Readiness poll exhausted. Unlike a crash this never conjures a
+    /// window — if it was closed mid-boot, only the painting is skipped.
+    func showBackendUnreachable(detail: String) {
+        paintBackendFailurePage(
+            title: "Failed to connect to backend on port \(port)",
+            detail: detail
+        )
     }
 
     func showBackendCrash(
@@ -1080,6 +876,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         // remotely this machine just went dark.
         if window == nil { createWindow() }
         dashboardActive = false
+        paintBackendFailurePage(title: title, detail: detail)
+    }
+
+    /// Shared failure page (red title, detail line, Restart button);
+    /// paints only when a webview exists.
+    func paintBackendFailurePage(title: String, detail: String) {
         guard webView != nil else { return }
         let esc = { (s: String) -> String in
             s.replacingOccurrences(of: "&", with: "&amp;")

--- a/scripts/bundle-macos.sh
+++ b/scripts/bundle-macos.sh
@@ -12,7 +12,7 @@
 # runtime. This script solves that by:
 #
 #   1. Compiling the Rust binaries (intendant + intendant-runtime).
-#   2. Compiling a small Swift wrapper (macos-app/main.swift) that
+#   2. Compiling a small Swift wrapper (macos-app/*.swift) that
 #      hosts a WKWebView loading the dashboard and spawns the Rust
 #      daemon as a child — so TCC grants to the .app flow through
 #      to the daemon (in-process CGEvent/AX computer use) and its
@@ -95,9 +95,10 @@ done < <($LS -dump 2>/dev/null | grep -o '/[^ ]*Intendant\.app' | sort -u)
 rm -rf "$APP"
 mkdir -p "$MACOS" "$RESOURCES"
 
-# Compile Swift wrapper
+# Compile Swift wrapper (main.swift must stay first: with multiple input
+# files, swiftc only allows top-level code in a file named main.swift)
 echo "Compiling macOS app wrapper..."
-swiftc -O -o "$MACOS/Intendant" macos-app/main.swift \
+swiftc -O -o "$MACOS/Intendant" macos-app/main.swift macos-app/BackendSupervisor.swift \
     -framework Cocoa -framework WebKit
 
 # Copy Rust binaries


### PR DESCRIPTION
Wave 1D: extract the macOS app wrapper's backend supervision into a coherent component, and add log rotation.

## What changed

**Extraction — `macos-app/BackendSupervisor.swift` (new).** All daemon-child supervision moves out of `AppDelegate` into a `BackendSupervisor` class: process spawn, manual/auto restart with capped exponential backoff (2s..60s, attempts reset after 10 min stable), clean-exit ⇒ manual-restart-only policy, spawn-failure re-arm, idempotent exit handling, generation-stamped readiness polls, the 5s health timer, and quit teardown (SIGTERM, 3s wait, SIGKILL). The `AppDelegate` consumes a two-method delegate surface:

- `backendSupervisor(_:didChangeState:detail:)` — `starting` / `ready` / `unreachable` / `stoppedCleanly` / `crashed`, driving the boot/placeholder/crash/countdown screens (screen HTML and copy unchanged);
- `backendSupervisorHealthTick(_:)` — the 5s housekeeping hook the dashboard idle-unload rides on (same position in the tick as before: after process-liveness, before the HTTP probe).

The daemon **remains a direct child of the app process** — TCC capture/mic grants flow through the app's process tree; the supervisor's class doc pins that constraint so nobody "improves" it into launchd.

**Log rotation.** On each backend launch, if `~/.intendant/app-backend.log` exceeds 10 MB it is moved to `app-backend.log.1`, replacing any existing `.1` (exactly one predecessor kept). Append-mode + launch separator behavior unchanged.

**Exit markers.** The supervisor now writes `--- Exit <iso8601> status=<n> signal=<bool> ---` to the same log when it observes a backend exit (both clean and abnormal), bookending the existing `--- Launch ... ---` separator so crash forensics need one file. Deliberate teardowns (quit, manual restart) clear the termination handler first and intentionally write no marker, as before.

**Build script.** `scripts/bundle-macos.sh` swiftc invocation now compiles `macos-app/main.swift macos-app/BackendSupervisor.swift` (main.swift must stay first: with multiple inputs, swiftc only allows top-level code in a file named main.swift).

## Behavior preservation

All policy constants, NSLog lines, screen HTML, and state strings are moved verbatim (audited old vs. new: backoff formula, 600s stability reset, `attempts > 30` poll bound, probe-failure logging cadence, teardown deadline each appear exactly once on both sides). New behavior is limited to the rotation and the exit marker.

## Verification

- `xcrun swiftc -typecheck macos-app/main.swift macos-app/BackendSupervisor.swift` — clean.
- `INSTALL_APP=0 ./scripts/bundle-macos.sh` — full bundle builds (not installed).
- Standalone harness exercised the rotation + marker code paths: >10 MB rotates, exactly-10 MB kept, existing `.1` replaced, missing log no-op, markers append after daemon output with the exact format.

**Needs operator bundle+restart verification before landing** (install the bundle, crash/stop the backend, watch the countdown/crash screens and the log markers). Not armed for auto-merge.
