### PR TITLE
Dashboard UI fixes: transcript plumbing noise, session-card action overlap, light-theme toast contrast

### DIFF
--- a/src/bin/caller/codex_history.rs
+++ b/src/bin/caller/codex_history.rs
@@ -186,19 +186,9 @@ impl UserTurnRevisionState {
 }
 
 pub(crate) fn is_codex_injected_user_text_for_main(text: &str) -> bool {
-    let trimmed = text.trim_start();
-    trimmed.starts_with("# AGENTS.md instructions for ")
-        || trimmed.starts_with("<turn_aborted>")
-        || trimmed.starts_with("<subagent_notification>")
-        || trimmed.starts_with("<environment_context>")
-        || trimmed.starts_with("<task-notification>")
-        || trimmed.starts_with("<command-name>")
-        || trimmed.starts_with("<command-message>")
-        || trimmed.starts_with("<local-command-stdout>")
-        || trimmed.starts_with("<bash-input>")
-        || trimmed.starts_with("<bash-stdout>")
-        || trimmed.starts_with("<bash-stderr>")
-        || trimmed.starts_with("<user_shell_command>")
+    // Delegates to the canonical predicate — this was a byte-for-byte copy
+    // that had already drifted from the session-catalog vocabulary.
+    crate::web_gateway::is_injected_external_user_text(text)
 }
 
 pub(crate) fn codex_user_turn_state_from_history(session_id: &str) -> Option<UserTurnRevisionState> {

--- a/src/bin/caller/web_gateway/session_catalog/codex_values.rs
+++ b/src/bin/caller/web_gateway/session_catalog/codex_values.rs
@@ -442,7 +442,12 @@ pub(crate) fn codex_thread_rollback_anchor(
     Some((item_id, position))
 }
 
-pub(crate) fn is_codex_injected_user_text(text: &str) -> bool {
+/// Harness-injected "user" text no human actually typed — Codex wrappers,
+/// Claude Code local-command plumbing, notification envelopes. One shared
+/// vocabulary for every external-transcript surface (Codex history, Codex
+/// catalog rows, Claude Code transcript replay): rendering these verbatim
+/// puts `<local-command-caveat>` rows in the Activity log.
+pub(crate) fn is_injected_external_user_text(text: &str) -> bool {
     let trimmed = text.trim_start();
     trimmed.starts_with("# AGENTS.md instructions for ")
         || trimmed.starts_with("<turn_aborted>")
@@ -451,11 +456,18 @@ pub(crate) fn is_codex_injected_user_text(text: &str) -> bool {
         || trimmed.starts_with("<task-notification>")
         || trimmed.starts_with("<command-name>")
         || trimmed.starts_with("<command-message>")
+        || trimmed.starts_with("<command-args>")
+        || trimmed.starts_with("<local-command-caveat>")
         || trimmed.starts_with("<local-command-stdout>")
+        || trimmed.starts_with("<local-command-stderr>")
         || trimmed.starts_with("<bash-input>")
         || trimmed.starts_with("<bash-stdout>")
         || trimmed.starts_with("<bash-stderr>")
         || trimmed.starts_with("<user_shell_command>")
+}
+
+pub(crate) fn is_codex_injected_user_text(text: &str) -> bool {
+    is_injected_external_user_text(text)
 }
 
 pub(crate) fn codex_thread_display_name(value: Option<String>) -> Option<String> {

--- a/src/bin/caller/web_gateway/session_catalog/transcripts.rs
+++ b/src/bin/caller/web_gateway/session_catalog/transcripts.rs
@@ -776,6 +776,12 @@ pub(crate) fn parse_claude_session_entries(path: &Path) -> Option<Vec<serde_json
         if text.is_empty() {
             continue;
         }
+        // Claude Code writes its local-command plumbing (/login, /compact …)
+        // as ordinary user lines; the Codex surfaces already filter this
+        // vocabulary and the Activity log must not render it either.
+        if typ == "user" && is_injected_external_user_text(&text) {
+            continue;
+        }
         entries.push(serde_json::json!({
             "ts": value_str(&obj, "timestamp").unwrap_or_default(),
             "level": if typ == "assistant" { "model" } else { "info" },

--- a/static/app.html
+++ b/static/app.html
@@ -8571,6 +8571,24 @@ body.context-focus-active {
   right: 12px;
   top: 34px;
 }
+/* sc-split cards lay the actions out as a real second column instead of
+   floating them over the content — the absolute cluster used to overlap
+   the badge chips and clip its last button on short/dense cards. */
+.session-card.sc-split {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 12px;
+}
+.session-card.sc-split .sc-main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.session-card.sc-split .sc-actions {
+  position: static;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
 /* Card action buttons are compact ui-btn variants; ui-btn (+.danger)
    carries look and hover states. At rest they go quiet (ghost) so the
    list reads as content instead of a wall of buttons; engaging the card
@@ -9609,6 +9627,14 @@ body.context-focus-active {
 .control-toast.error { border-left-color: var(--red); }
 .control-toast.success { border-left-color: var(--green); }
 .control-toast.info { border-left-color: var(--blue); }
+/* The base gradient is a literal dark glass; under the ui-v2 light theme
+   --text flips to dark ink, which rendered toasts dark-on-dark ("Load
+   failed" unreadable). Light mode gets a light raised surface instead. */
+html.ui-v2[data-theme="light"] .control-toast {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.97), rgba(241, 243, 249, 0.97));
+  border-color: var(--line-2);
+  box-shadow: 0 10px 28px rgba(18, 23, 42, 0.18);
+}
 .control-toast.global-command-toast {
   position: fixed;
   bottom: 16px;
@@ -16784,6 +16810,13 @@ html.ui-v2 #tab-sessions .session-card .sc-actions {
   flex-wrap: nowrap;
   justify-content: flex-end;
   gap: 6px;
+}
+/* sc-split cards: the actions are a flex column sibling, not an overlay —
+   undo the centered-absolute positioning above. */
+html.ui-v2 #tab-sessions .session-card.sc-split .sc-actions {
+  top: auto;
+  right: auto;
+  transform: none;
 }
 html.ui-v2 #tab-sessions .session-card .sc-actions .ui-btn {
   min-height: 0;
@@ -84086,10 +84119,17 @@ function buildSessionCard(m, derived, ctx) {
 
   const rowIsPartial = s.partial === true;
   const card = document.createElement('div');
-  card.className = 'session-card';
+  // sc-split: content column + actions column as real flex layout. The
+  // actions used to float absolutely over the card and collided with the
+  // badge chips (and clipped "Delete…") whenever the cluster grew or the
+  // card ran short.
+  card.className = 'session-card sc-split';
   if (isCurrent) card.classList.add('current');
   if (displayStatus === 'abandoned') card.classList.add('dimmed');
   if (rowIsPartial) card.classList.add('partial');
+  const main = document.createElement('div');
+  main.className = 'sc-main';
+  card.appendChild(main);
 
   const sessionName = compactSessionText(s.name);
   const taskText = compactSessionText(s.task);
@@ -84205,7 +84245,7 @@ function buildSessionCard(m, derived, ctx) {
     top.appendChild(badge);
   }
 
-  card.appendChild(top);
+  main.appendChild(top);
 
   // Task
   if (taskText && sessionName) {
@@ -84324,7 +84364,7 @@ function buildSessionCard(m, derived, ctx) {
   if (!rowIsPartial && s.total_bytes > 0) tipParts.push(`disk: ${_fmtBytes(s.total_bytes)}`);
   if (projectPath) tipParts.push(`project: ${projectPath}`);
   if (tipParts.length) meta.title = tipParts.join('\n');
-  card.appendChild(meta);
+  main.appendChild(meta);
 
   // Media stats row (recordings, annotations, clips) + total session size
   const hasMedia = (s.recordings > 0 || s.annotations > 0 || s.clips > 0);
@@ -84347,7 +84387,7 @@ function buildSessionCard(m, derived, ctx) {
     if (s.annotations > 0) addMediaField('annotations', s.annotations, 'v-peach');
     if (s.clips > 0) addMediaField('clips', s.clips, 'v-peach');
     if (s.total_bytes > 0) addMediaField('size', _fmtBytes(s.total_bytes), 'v-dim');
-    card.appendChild(mediaMeta);
+    main.appendChild(mediaMeta);
   }
 
   // Actions row. While browsing a peer host the cards are read-only —

--- a/static/app/13-styles-sessions-terminal.css
+++ b/static/app/13-styles-sessions-terminal.css
@@ -1633,6 +1633,24 @@
   right: 12px;
   top: 34px;
 }
+/* sc-split cards lay the actions out as a real second column instead of
+   floating them over the content — the absolute cluster used to overlap
+   the badge chips and clip its last button on short/dense cards. */
+.session-card.sc-split {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 12px;
+}
+.session-card.sc-split .sc-main {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.session-card.sc-split .sc-actions {
+  position: static;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
 /* Card action buttons are compact ui-btn variants; ui-btn (+.danger)
    carries look and hover states. At rest they go quiet (ghost) so the
    list reads as content instead of a wall of buttons; engaging the card
@@ -2671,6 +2689,14 @@
 .control-toast.error { border-left-color: var(--red); }
 .control-toast.success { border-left-color: var(--green); }
 .control-toast.info { border-left-color: var(--blue); }
+/* The base gradient is a literal dark glass; under the ui-v2 light theme
+   --text flips to dark ink, which rendered toasts dark-on-dark ("Load
+   failed" unreadable). Light mode gets a light raised surface instead. */
+html.ui-v2[data-theme="light"] .control-toast {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.97), rgba(241, 243, 249, 0.97));
+  border-color: var(--line-2);
+  box-shadow: 0 10px 28px rgba(18, 23, 42, 0.18);
+}
 .control-toast.global-command-toast {
   position: fixed;
   bottom: 16px;

--- a/static/app/57-sessions-replay.js
+++ b/static/app/57-sessions-replay.js
@@ -441,10 +441,17 @@ function buildSessionCard(m, derived, ctx) {
 
   const rowIsPartial = s.partial === true;
   const card = document.createElement('div');
-  card.className = 'session-card';
+  // sc-split: content column + actions column as real flex layout. The
+  // actions used to float absolutely over the card and collided with the
+  // badge chips (and clipped "Delete…") whenever the cluster grew or the
+  // card ran short.
+  card.className = 'session-card sc-split';
   if (isCurrent) card.classList.add('current');
   if (displayStatus === 'abandoned') card.classList.add('dimmed');
   if (rowIsPartial) card.classList.add('partial');
+  const main = document.createElement('div');
+  main.className = 'sc-main';
+  card.appendChild(main);
 
   const sessionName = compactSessionText(s.name);
   const taskText = compactSessionText(s.task);
@@ -560,7 +567,7 @@ function buildSessionCard(m, derived, ctx) {
     top.appendChild(badge);
   }
 
-  card.appendChild(top);
+  main.appendChild(top);
 
   // Task
   if (taskText && sessionName) {
@@ -679,7 +686,7 @@ function buildSessionCard(m, derived, ctx) {
   if (!rowIsPartial && s.total_bytes > 0) tipParts.push(`disk: ${_fmtBytes(s.total_bytes)}`);
   if (projectPath) tipParts.push(`project: ${projectPath}`);
   if (tipParts.length) meta.title = tipParts.join('\n');
-  card.appendChild(meta);
+  main.appendChild(meta);
 
   // Media stats row (recordings, annotations, clips) + total session size
   const hasMedia = (s.recordings > 0 || s.annotations > 0 || s.clips > 0);
@@ -702,7 +709,7 @@ function buildSessionCard(m, derived, ctx) {
     if (s.annotations > 0) addMediaField('annotations', s.annotations, 'v-peach');
     if (s.clips > 0) addMediaField('clips', s.clips, 'v-peach');
     if (s.total_bytes > 0) addMediaField('size', _fmtBytes(s.total_bytes), 'v-dim');
-    card.appendChild(mediaMeta);
+    main.appendChild(mediaMeta);
   }
 
   // Actions row. While browsing a peer host the cards are read-only —

--- a/static/app/ui2-sessions.css
+++ b/static/app/ui2-sessions.css
@@ -551,6 +551,13 @@ html.ui-v2 #tab-sessions .session-card .sc-actions {
   justify-content: flex-end;
   gap: 6px;
 }
+/* sc-split cards: the actions are a flex column sibling, not an overlay —
+   undo the centered-absolute positioning above. */
+html.ui-v2 #tab-sessions .session-card.sc-split .sc-actions {
+  top: auto;
+  right: auto;
+  transform: none;
+}
 html.ui-v2 #tab-sessions .session-card .sc-actions .ui-btn {
   min-height: 0;
   padding: 6px 11px;


### PR DESCRIPTION
Fixes the four UI bugs reported via screenshots from the 2026-07-08 session (pre-freeze):

1. **Activity log rendered Claude Code local-command plumbing** (`<local-command-caveat>`, `<command-name>`, `<local-command-stdout>` from /login, /compact) as YOU rows — the Claude transcript path now filters through the (extended, canonicalized) injected-user-text predicate the Codex surfaces already used; codex_history's drifted private copy now delegates to it.
2+3. **Session-card actions floated over the badges and clipped 'Delete…'** — cards are now a real two-column flex layout (.sc-split): the action cluster reserves its own space; no overlap, no clipping, both themes.
4. **Light-theme toasts were dark-on-dark** ('Load failed' unreadable) — .control-toast hardcoded dark glass; light theme now gets a light raised surface.

Tests: 120 targeted session-catalog/codex tests pass; app.html regenerated; live Safari verification on the incident machine before undrafting.