### PR TITLE
Formalize the dashboard files-transfer state machine

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -75618,6 +75618,240 @@ function ui2SettingsBuild() {
 if (typeof ui2Enabled === 'function' && ui2Enabled()) {
   ui2SettingsBuild();
 }
+/* ── static/app/53-transfer-fsm.js ── */
+// ── Files-transfer state machine ─────────────────────────────────────────
+// Every `status` write on a filesTransfers entry flows through this module:
+// filesTransferFsmInit() when an entry is created (queue* entry points,
+// localStorage restore, server-job merge) and filesTransferTransition() for
+// every mutation afterwards. The table below is the contract that used to be
+// implicit across ~20 ad-hoc mutation sites in 54-session-lifecycle.js; the
+// runner/pump invariants it encodes are load-bearing:
+//
+//  - Runners settle `status` away from 'queued' before any guard can throw
+//    (runFiles*Transfer marks 'running' as its first statement):
+//    pumpFilesTransfers re-picks 'queued' entries, so an entry left 'queued'
+//    after its runner returned would be re-picked forever — a microtask spin
+//    that freezes the tab and allocates without bound.
+//  - The pump backstop force-fails an entry whose runner exited without
+//    settling it, and that transition MUST reject the completion promise —
+//    unless the entry's queueEpoch moved, which marks a legitimate re-queue
+//    (Resume/Retry) racing the runner's teardown.
+//  - Terminal statuses settle `completion`: entering 'completed' resolves
+//    it, entering 'failed'/'cancelled' rejects it. The transition performs
+//    the settle, so a terminal entry can never strand an awaiting caller.
+//    (Settling an already-settled promise is a no-op, so late duplicates —
+//    retry-after-completed, server re-merges — are harmless.)
+//  - Entering 'queued' re-arms the attempt: queueEpoch bumps, the teardown
+//    flags clear, and a fresh completion promise is minted for the new run.
+//
+// Statuses: queued | running | paused | failed | cancelled | completed,
+// plus 'ready' on server-side transfer jobs merged from api_transfer_jobs.
+// Actors: 'user' (transfer-pane buttons + the queue* entry points),
+// 'runner' (runFilesDownloadTransfer / runFilesUploadTransfer and their
+// settle paths), 'pump' (pumpFilesTransfers' forward-progress backstop),
+// 'restore' (restoreFilesTransferState), 'server' (filesTransferMergeServerJob).
+
+const FILES_TRANSFER_STATUSES = new Set([
+  'queued', 'running', 'paused', 'failed', 'cancelled', 'completed', 'ready',
+]);
+
+// Settled history: pruning, Clear-history, and the persistence filter treat
+// these as finished; the FSM settles the completion promise on entry.
+const FILES_TRANSFER_TERMINAL_STATUSES = new Set(['completed', 'cancelled', 'failed']);
+
+// from-status → to-status → actors allowed to perform it. The 'server'
+// actor is not listed here: filesTransferMergeServerJob may overwrite any
+// row whose local status is not actively owned by this tab (see
+// filesTransferTransitionAllowed below).
+const FILES_TRANSFER_TRANSITIONS = {
+  queued: {
+    running: ['runner'],   // pump picked the entry; runner marks it before any guard can throw
+    paused: ['user'],      // Pause on a not-yet-started entry parks it in place
+    cancelled: ['user'],   // Cancel before the pump picks the entry up
+    failed: ['pump'],      // backstop: runner exited with the entry unsettled (epoch unchanged)
+  },
+  running: {
+    completed: ['runner'],
+    paused: ['runner'],    // pauseRequested teardown / AbortError
+    cancelled: ['runner'], // cancelRequested teardown
+    failed: ['runner', 'pump'],
+  },
+  paused: {
+    queued: ['user'],      // Resume
+    cancelled: ['user'],
+  },
+  failed: {
+    queued: ['user'],      // Resume (downloads with partial progress) or Retry
+  },
+  cancelled: {
+    queued: ['user'],      // Retry
+  },
+  completed: {
+    // Documented exceptions — deliberate quirks, not bugs:
+    queued: ['user'],      // Retry re-runs a finished transfer from scratch
+    failed: ['user'],      // Save after reload with the cached download chunks evicted
+  },
+  ready: {},               // server-owned; only the server merge moves it
+};
+
+// Statuses an entry may be created in, per creating actor. The queue*
+// entry points always mint 'queued'; restoreFilesTransferState only sees
+// what filesTransferPersistable writes (running/queued normalize to
+// 'paused'; cancelled rows and completed uploads are dropped — a restored
+// 'completed' is always a download); server merges mirror the job's own
+// status (filesTransferStatusFromJob normalizes unknowns to 'queued').
+const FILES_TRANSFER_INITIAL_STATUSES = {
+  user: ['queued'],
+  restore: ['paused', 'failed', 'completed', 'ready'],
+  server: ['queued', 'running', 'paused', 'failed', 'cancelled', 'completed', 'ready'],
+};
+
+const FILES_TRANSFER_FSM_TAG = '[transfer-fsm]';
+let filesTransferFsmIllegalCount = 0;
+const filesTransferFsmRecentReports = [];
+
+// Diagnostics only — the offending transition is still applied afterwards
+// (the UI must keep working; the table polices intent, it never gates
+// behavior). NEVER throw from here.
+function filesTransferFsmReport(message, transfer, detail = {}) {
+  filesTransferFsmIllegalCount += 1;
+  const report = {
+    message,
+    id: transfer?.id || '',
+    kind: transfer?.kind || '',
+    ...detail,
+  };
+  filesTransferFsmRecentReports.push(report);
+  if (filesTransferFsmRecentReports.length > 20) filesTransferFsmRecentReports.shift();
+  console.error(FILES_TRANSFER_FSM_TAG, message, report);
+}
+
+function filesTransferTransitionAllowed(from, to, actor) {
+  if (actor === 'server') {
+    // Mirror of the filesTransferMergeServerJob guard: a row whose local
+    // status is actively owned by this tab (queued/running/paused/failed)
+    // is never overwritten by a merged job; for anything else the server
+    // job's status is authoritative, whatever it says.
+    return !['queued', 'running', 'paused', 'failed'].includes(from);
+  }
+  const actors = FILES_TRANSFER_TRANSITIONS[from]?.[to];
+  return Array.isArray(actors) && actors.includes(actor);
+}
+
+// Settle the completion promise for a transfer entering `status`:
+// completed → resolve(result); failed/cancelled → reject(failure, or an
+// Error built from transfer.error). Other statuses settle only when the
+// caller hands in the teardown failure — pausing a *running* transfer
+// rejects the in-flight attempt (AbortError) while pausing a *queued* one
+// leaves the promise pending; Resume mints a fresh promise either way.
+function filesTransferFsmSettle(transfer, status, { result, failure } = {}) {
+  if (status === 'completed') {
+    transfer.resolve?.(result);
+  } else if (status === 'failed' || status === 'cancelled') {
+    transfer.reject?.(failure !== undefined ? failure : new Error(transfer.error || `transfer ${status}`));
+  } else if (failure !== undefined) {
+    transfer.reject?.(failure);
+  }
+}
+
+// Register a newly created entry with the machine: validate its initial
+// status for the creating actor, arm the completion promise, and settle it
+// immediately when the entry is born terminal (a restored 'completed'
+// download, a merged job that already finished) so "terminal ⇒ settled"
+// holds from birth. User creations bump queueEpoch — together with the
+// Resume/Retry re-arm these are the "queue/resume/retry" bumps the pump
+// backstop keys on.
+function filesTransferFsmInit(transfer, { actor = 'unknown' } = {}) {
+  if (!transfer) return null;
+  const status = transfer.status;
+  const allowed = FILES_TRANSFER_INITIAL_STATUSES[actor];
+  if (!allowed || !allowed.includes(status)) {
+    filesTransferFsmReport(
+      `illegal initial status '${status}' for actor '${actor}'`,
+      transfer,
+      { actor, to: status }
+    );
+  }
+  if (actor === 'user') transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
+  filesTransferCompletion(transfer);
+  filesTransferFsmSettle(transfer, status, {});
+  return transfer;
+}
+
+// The single mutation point for transfer.status. Options:
+//   actor   — 'user' | 'runner' | 'pump' | 'server'; checked against the
+//             table, illegal moves are reported (console.error, counted in
+//             window.qa.transfers()) and then applied anyway.
+//   error   — string (including '') assigns transfer.error; undefined
+//             applies the default (entering queued/running clears it, as
+//             every queue/resume/retry/runner-start site does; other
+//             targets leave it untouched); null forces leave-untouched
+//             even for queued/running (the server merge owns error itself).
+//   result  — resolve value for the completion promise when to='completed'.
+//   failure — reject error for the completion promise (defaults to an
+//             Error from transfer.error for failed/cancelled; also rejects
+//             the in-flight attempt on a runner's pause teardown).
+//   reason  — free-text context for the illegal-transition report.
+//   persist/render — default true; the server-merge loop batches both.
+function filesTransferTransition(transfer, to, options = {}) {
+  const {
+    actor = 'unknown',
+    error,
+    reason = '',
+    result,
+    failure,
+    persist = true,
+    render = true,
+  } = options;
+  if (!transfer) {
+    filesTransferFsmReport(`transition to '${to}' on a missing transfer`, null, { actor, to, reason });
+    return null;
+  }
+  const from = transfer.status;
+  if (!FILES_TRANSFER_STATUSES.has(to)) {
+    filesTransferFsmReport(`unknown target status '${to}'`, transfer, { actor, from, to, reason });
+  } else if (!filesTransferTransitionAllowed(from, to, actor)) {
+    filesTransferFsmReport(`illegal transition ${from} → ${to} (actor '${actor}')`, transfer, { actor, from, to, reason });
+  }
+  transfer.status = to;
+  if (to === 'queued') {
+    // Re-arm: entering the queue is a fresh attempt. Bump queueEpoch (the
+    // pump backstop exempts entries whose epoch moved — re-queues racing a
+    // runner teardown are legitimate), clear the teardown flags, and mint a
+    // fresh completion promise for the new attempt.
+    transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
+    transfer.pauseRequested = false;
+    transfer.cancelRequested = false;
+    if (error === undefined) transfer.error = '';
+    filesTransferCompletion(transfer);
+  } else if (to === 'running') {
+    transfer.pauseRequested = false;
+    transfer.cancelRequested = false;
+    if (error === undefined) transfer.error = '';
+  }
+  if (error !== undefined && error !== null) transfer.error = error;
+  if (persist) filesTransferPersistState();
+  if (render) renderFilesTransfers();
+  filesTransferFsmSettle(transfer, to, { result, failure });
+  return transfer;
+}
+
+// QA readback (window.qa convention): the transfer table harnesses assert
+// on — entry states plus the FSM's illegal-transition counter (0 in a
+// healthy session). Probe stays cheap and side-effect-free.
+window.qa = Object.assign(window.qa || {}, {
+  transfers: () => ({
+    entries: filesTransfers.map(transfer => ({
+      id: transfer.id,
+      kind: transfer.kind,
+      status: transfer.status,
+      error: transfer.error || '',
+      epoch: Number(transfer.queueEpoch || 0),
+    })),
+    illegalTransitions: filesTransferFsmIllegalCount,
+    recentReports: filesTransferFsmRecentReports.slice(),
+  }),
+});
 /* ── static/app/54-session-lifecycle.js ── */
 // ── Session Lifecycle ──
 function onSessionStarted(sessionId, task, opts = {}) {
@@ -76951,7 +77185,7 @@ function restoreFilesTransferState() {
       cancelRequested: false,
       abortController: null,
     };
-    filesTransferCompletion(transfer);
+    filesTransferFsmInit(transfer, { actor: 'restore' });
     filesTransfers.push(transfer);
   }
 }
@@ -77325,8 +77559,15 @@ function filesTransferMergeServerJob(job) {
     abortController: null,
   };
   transfer.kind = kind;
-  if (!existing || !['queued', 'running', 'paused', 'failed'].includes(existing.status || '')) {
-    transfer.status = filesTransferStatusFromJob(job);
+  if (existing && !['queued', 'running', 'paused', 'failed'].includes(existing.status || '')) {
+    // A row this tab does not actively own mirrors the server job's status.
+    // (A brand-new row was already minted with it, so no self-transition.)
+    filesTransferTransition(transfer, filesTransferStatusFromJob(job), {
+      actor: 'server',
+      error: null,     // job.error merges below, after the status move
+      persist: false,  // refreshFilesTransferJobs persists + renders once per batch
+      render: false,
+    });
   }
   transfer.path = transfer.path || source;
   transfer.destination = transfer.destination || destination;
@@ -77339,7 +77580,7 @@ function filesTransferMergeServerJob(job) {
   transfer.error = job.error || transfer.error || '';
   filesTransferApplyServerJob(transfer, job);
   if (!existing) {
-    filesTransferCompletion(transfer);
+    filesTransferFsmInit(transfer, { actor: 'server' });
     filesTransfers.unshift(transfer);
   }
   return transfer;
@@ -77368,7 +77609,7 @@ async function refreshFilesTransferJobs() {
 
 // Finished transfers accumulate for the lifetime of the page; keep the
 // list bounded (active/queued/paused transfers are never pruned).
-const FILES_TRANSFER_TERMINAL_STATUSES = new Set(['completed', 'cancelled', 'failed']);
+// FILES_TRANSFER_TERMINAL_STATUSES lives in 53-transfer-fsm.js.
 const FILES_TRANSFER_HISTORY_LIMIT = 100;
 function pruneFinishedFilesTransfers() {
   let terminal = 0;
@@ -77487,8 +77728,7 @@ function filesUpdateActiveDownloadSummary(transfer = null) {
 }
 
 function queueFilesTransfer(transfer) {
-  transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
-  filesTransferCompletion(transfer);
+  filesTransferFsmInit(transfer, { actor: 'user' });
   filesTransfers.unshift(transfer);
   filesTransferPersistState();
   renderFilesTransfers();
@@ -77627,15 +77867,11 @@ async function runFilesDownloadTransfer(transfer) {
   // that left the status at 'queued' would make pumpFilesTransfers re-pick
   // the same entry forever, so every failure must flow through the catch
   // below. The transport guards therefore live inside the try.
-  transfer.status = 'running';
-  transfer.error = '';
-  transfer.pauseRequested = false;
-  transfer.cancelRequested = false;
+  filesTransferTransition(transfer, 'running', { actor: 'runner' });
   const controller = new AbortController();
   transfer.abortController = controller;
   transfer.transport = '';
   filesDownloadAbort = controller;
-  renderFilesTransfers();
   filesUpdateActiveDownloadSummary(transfer);
   let peerConnection = null;
   let peerDashboardConnection = null;
@@ -77811,22 +78047,15 @@ async function runFilesDownloadTransfer(transfer) {
   } catch (err) {
     const message = err?.message || String(err);
     if (transfer.cancelRequested) {
-      transfer.status = 'cancelled';
-      transfer.error = '';
-      filesTransferPersistState();
-      transfer.reject?.(err);
+      filesTransferTransition(transfer, 'cancelled', { actor: 'runner', error: '', failure: err });
       setFilesDownloadStatus('warn', 'Download cancelled');
     } else if (transfer.pauseRequested || err?.name === 'AbortError') {
-      transfer.status = 'paused';
-      transfer.error = '';
-      filesTransferPersistState();
-      transfer.reject?.(err);
+      // Non-terminal teardown: the in-flight attempt's promise still
+      // rejects (failure) — Resume mints a fresh one.
+      filesTransferTransition(transfer, 'paused', { actor: 'runner', error: '', failure: err });
       setFilesDownloadStatus('warn', `Paused at ${filesTransferProgressText(transfer)}`);
     } else {
-      transfer.status = 'failed';
-      transfer.error = message;
-      filesTransferPersistState();
-      transfer.reject?.(err);
+      filesTransferTransition(transfer, 'failed', { actor: 'runner', error: message, failure: err });
       setFilesDownloadStatus('error', message);
       if (typeof showControlToast === 'function') showControlToast('error', message);
     }
@@ -77858,12 +78087,10 @@ function settleCompletedFilesDownload(transfer, { resumable }) {
     resumable,
   };
   transfer.result = result;
-  transfer.status = 'completed';
-  filesTransferPersistState();
+  filesTransferTransition(transfer, 'completed', { actor: 'runner', result });
   setFilesDownloadProgress(result.size, result.total_size || result.size);
   setFilesDownloadStatus('ok', `Downloaded ${result.filename} (${humanBytes(result.size)})`);
   if (!transfer.skipBrowserSave) downloadDashboardBlob(result.blob, result.filename, result.content_type);
-  transfer.resolve?.(result);
   return result;
 }
 
@@ -77950,11 +78177,12 @@ async function runFilesFilesystemUploadHttpFallback(transfer, controller) {
     throw new Error(filesTransferFriendlyServerError(resp.body?.error, `file write returned HTTP ${resp.status}`));
   }
   transfer.loaded = transfer.totalSize;
-  transfer.status = 'completed';
-  filesTransferPersistState();
+  filesTransferTransition(transfer, 'completed', {
+    actor: 'runner',
+    result: { ok: true, path: destination, transport: 'http-fs-write' },
+  });
   await filesTransferDeleteUploadBlob(transfer.id);
   setFilesUploadStatus('ok', `Uploaded ${transfer.name} to ${destination}`);
-  transfer.resolve?.({ ok: true, path: destination, transport: 'http-fs-write' });
 }
 
 // Mirror the durable-job destination semantics client-side: an existing
@@ -78072,11 +78300,9 @@ async function runFilesFilesystemUploadTransfer(transfer, controller) {
   filesTransferApplyServerJob(transfer, committed.job);
   transfer.loaded = transfer.totalSize;
   transfer.descriptor = committed.job;
-  transfer.status = 'completed';
-  filesTransferPersistState();
+  filesTransferTransition(transfer, 'completed', { actor: 'runner', result: committed.job });
   await filesTransferDeleteUploadBlob(transfer.id);
   setFilesUploadStatus('ok', `Uploaded ${transfer.name || 'upload.bin'}`);
-  transfer.resolve?.(committed.job);
 }
 
 function filesDeleteServerTransfer(transfer) {
@@ -78091,14 +78317,11 @@ function filesDeleteServerTransfer(transfer) {
 async function runFilesUploadTransfer(transfer) {
   // Same rule as downloads: settle the status before any guard can throw,
   // so pumpFilesTransfers never re-picks a permanently 'queued' entry.
-  transfer.status = 'running';
-  transfer.error = '';
+  filesTransferTransition(transfer, 'running', { actor: 'runner' });
   transfer.loaded = Number(transfer.loaded || 0);
-  transfer.cancelRequested = false;
   transfer.transport = '';
   const controller = new AbortController();
   transfer.abortController = controller;
-  renderFilesTransfers();
   try {
     const filesystemUpload = Boolean(transfer.destination && transfer.destination !== 'task');
     if (filesystemUpload && transfer.uploadBlobPersistPromise) {
@@ -78160,23 +78383,18 @@ async function runFilesUploadTransfer(transfer) {
       }
       transfer.loaded = transfer.file.size;
       transfer.descriptor = descriptor;
-      transfer.status = 'completed';
+      filesTransferTransition(transfer, 'completed', { actor: 'runner', result: descriptor });
       filesStagedUploads.set(String(descriptor.id || transfer.id), descriptor);
       setFilesUploadStatus('ok', `Uploaded ${descriptor.name || transfer.file.name || 'upload.bin'}`);
       renderFilesStagedUploads();
-      transfer.resolve?.(descriptor);
     }
   } catch (err) {
     if (transfer.cancelRequested || err?.name === 'AbortError') {
-      transfer.status = 'cancelled';
-      transfer.error = '';
+      filesTransferTransition(transfer, 'cancelled', { actor: 'runner', error: '', failure: err });
     } else {
-      transfer.status = 'failed';
-      transfer.error = err?.message || String(err);
+      filesTransferTransition(transfer, 'failed', { actor: 'runner', error: err?.message || String(err), failure: err });
       setFilesUploadStatus('error', transfer.error);
     }
-    filesTransferPersistState();
-    transfer.reject?.(err);
   } finally {
     transfer.abortController = null;
     filesTransferPersistState();
@@ -78202,14 +78420,16 @@ async function pumpFilesTransfers() {
         // Forward-progress backstop: a runner that exits without settling
         // its transfer would be re-picked by the find() above forever — a
         // synchronous microtask spin that freezes the page and allocates
-        // without bound. Force the entry failed so the pump always drains.
-        // The epoch check exempts entries the user legitimately re-queued
-        // (Resume/Retry bump it) while the runner was tearing down.
-        transfer.status = 'failed';
-        transfer.error = failure?.message || transfer.error || 'transfer runner exited without settling';
-        filesTransferPersistState();
-        renderFilesTransfers();
-        transfer.reject?.(failure || new Error(transfer.error));
+        // without bound. Force the entry failed so the pump always drains
+        // (the transition also rejects the completion promise). The epoch
+        // check exempts entries legitimately re-queued (Resume/Retry bump
+        // it) while the runner was tearing down.
+        filesTransferTransition(transfer, 'failed', {
+          actor: 'pump',
+          error: failure?.message || transfer.error || 'transfer runner exited without settling',
+          failure: failure || undefined,
+          reason: 'runner exited without settling its transfer',
+        });
       }
       // Macrotask yield: even a misbehaving runner that settles instantly
       // can only busy the tab, never wedge the event loop.
@@ -78237,9 +78457,9 @@ function pauseFilesTransfer(id) {
   const transfer = filesTransferById(id);
   if (!transfer) return;
   if (transfer.status === 'queued') {
-    transfer.status = 'paused';
-    filesTransferPersistState();
-    renderFilesTransfers();
+    // Not started yet: park it in place. The completion promise stays
+    // pending until Resume re-arms it — only a runner teardown rejects.
+    filesTransferTransition(transfer, 'paused', { actor: 'user' });
     return;
   }
   if (transfer.status !== 'running') return;
@@ -78257,10 +78477,10 @@ function cancelFilesTransfer(id) {
   if (transfer.status === 'running') {
     transfer.abortController?.abort();
   } else if (['queued', 'paused'].includes(transfer.status)) {
-    transfer.status = 'cancelled';
-    transfer.reject?.(new Error('transfer cancelled'));
-    filesTransferPersistState();
-    renderFilesTransfers();
+    filesTransferTransition(transfer, 'cancelled', {
+      actor: 'user',
+      failure: new Error('transfer cancelled'),
+    });
     pumpFilesTransfers();
   }
 }
@@ -78268,14 +78488,8 @@ function cancelFilesTransfer(id) {
 function resumeFilesTransfer(id) {
   const transfer = filesTransferById(id);
   if (!transfer || !['paused', 'failed'].includes(transfer.status)) return null;
-  transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
-  transfer.status = 'queued';
-  transfer.error = '';
-  transfer.pauseRequested = false;
-  transfer.cancelRequested = false;
-  filesTransferCompletion(transfer);
-  filesTransferPersistState();
-  renderFilesTransfers();
+  // Entering 'queued' re-arms the attempt (epoch bump, flags, completion).
+  filesTransferTransition(transfer, 'queued', { actor: 'user' });
   pumpFilesTransfers();
   return transfer.completion;
 }
@@ -78284,21 +78498,15 @@ function retryFilesTransfer(id) {
   const transfer = filesTransferById(id);
   if (!transfer || !['failed', 'cancelled', 'completed'].includes(transfer.status)) return null;
   if (transfer.kind === 'download') resetFilesDownloadTransfer(transfer);
-  transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
-  transfer.status = 'queued';
-  transfer.error = '';
-  transfer.cancelRequested = false;
-  transfer.pauseRequested = false;
-  filesTransferCompletion(transfer);
-  filesTransferPersistState();
-  renderFilesTransfers();
+  // Entering 'queued' re-arms the attempt (epoch bump, flags, completion).
+  filesTransferTransition(transfer, 'queued', { actor: 'user' });
   pumpFilesTransfers();
   return transfer.completion;
 }
 
 function clearFilesTransferHistory() {
   for (let i = filesTransfers.length - 1; i >= 0; i -= 1) {
-    if (['completed', 'failed', 'cancelled'].includes(filesTransfers[i].status)) {
+    if (FILES_TRANSFER_TERMINAL_STATUSES.has(filesTransfers[i].status)) {
       filesTransferDeleteDownloadParts(filesTransfers[i].id, Number(filesTransfers[i].rangeCount || 512));
       filesTransferDeleteUploadBlob(filesTransfers[i].id);
       filesTransfers.splice(i, 1);
@@ -78314,10 +78522,13 @@ async function saveCompletedFilesDownload(id) {
   if (!transfer.result?.blob) {
     const hydrated = await filesTransferLoadDownloadParts(transfer);
     if (!hydrated) {
-      transfer.status = 'failed';
-      transfer.error = 'download chunks are no longer available';
-      filesTransferPersistState();
-      renderFilesTransfers();
+      // Documented completed → failed exception: Save clicked after the
+      // cached download chunks were evicted (typically post-reload).
+      filesTransferTransition(transfer, 'failed', {
+        actor: 'user',
+        error: 'download chunks are no longer available',
+        reason: 'saved download chunks were evicted',
+      });
       return null;
     }
     const blob = new Blob(transfer.parts || [], { type: transfer.contentType || 'application/octet-stream' });

--- a/static/app/53-transfer-fsm.js
+++ b/static/app/53-transfer-fsm.js
@@ -1,0 +1,233 @@
+// ── Files-transfer state machine ─────────────────────────────────────────
+// Every `status` write on a filesTransfers entry flows through this module:
+// filesTransferFsmInit() when an entry is created (queue* entry points,
+// localStorage restore, server-job merge) and filesTransferTransition() for
+// every mutation afterwards. The table below is the contract that used to be
+// implicit across ~20 ad-hoc mutation sites in 54-session-lifecycle.js; the
+// runner/pump invariants it encodes are load-bearing:
+//
+//  - Runners settle `status` away from 'queued' before any guard can throw
+//    (runFiles*Transfer marks 'running' as its first statement):
+//    pumpFilesTransfers re-picks 'queued' entries, so an entry left 'queued'
+//    after its runner returned would be re-picked forever — a microtask spin
+//    that freezes the tab and allocates without bound.
+//  - The pump backstop force-fails an entry whose runner exited without
+//    settling it, and that transition MUST reject the completion promise —
+//    unless the entry's queueEpoch moved, which marks a legitimate re-queue
+//    (Resume/Retry) racing the runner's teardown.
+//  - Terminal statuses settle `completion`: entering 'completed' resolves
+//    it, entering 'failed'/'cancelled' rejects it. The transition performs
+//    the settle, so a terminal entry can never strand an awaiting caller.
+//    (Settling an already-settled promise is a no-op, so late duplicates —
+//    retry-after-completed, server re-merges — are harmless.)
+//  - Entering 'queued' re-arms the attempt: queueEpoch bumps, the teardown
+//    flags clear, and a fresh completion promise is minted for the new run.
+//
+// Statuses: queued | running | paused | failed | cancelled | completed,
+// plus 'ready' on server-side transfer jobs merged from api_transfer_jobs.
+// Actors: 'user' (transfer-pane buttons + the queue* entry points),
+// 'runner' (runFilesDownloadTransfer / runFilesUploadTransfer and their
+// settle paths), 'pump' (pumpFilesTransfers' forward-progress backstop),
+// 'restore' (restoreFilesTransferState), 'server' (filesTransferMergeServerJob).
+
+const FILES_TRANSFER_STATUSES = new Set([
+  'queued', 'running', 'paused', 'failed', 'cancelled', 'completed', 'ready',
+]);
+
+// Settled history: pruning, Clear-history, and the persistence filter treat
+// these as finished; the FSM settles the completion promise on entry.
+const FILES_TRANSFER_TERMINAL_STATUSES = new Set(['completed', 'cancelled', 'failed']);
+
+// from-status → to-status → actors allowed to perform it. The 'server'
+// actor is not listed here: filesTransferMergeServerJob may overwrite any
+// row whose local status is not actively owned by this tab (see
+// filesTransferTransitionAllowed below).
+const FILES_TRANSFER_TRANSITIONS = {
+  queued: {
+    running: ['runner'],   // pump picked the entry; runner marks it before any guard can throw
+    paused: ['user'],      // Pause on a not-yet-started entry parks it in place
+    cancelled: ['user'],   // Cancel before the pump picks the entry up
+    failed: ['pump'],      // backstop: runner exited with the entry unsettled (epoch unchanged)
+  },
+  running: {
+    completed: ['runner'],
+    paused: ['runner'],    // pauseRequested teardown / AbortError
+    cancelled: ['runner'], // cancelRequested teardown
+    failed: ['runner', 'pump'],
+  },
+  paused: {
+    queued: ['user'],      // Resume
+    cancelled: ['user'],
+  },
+  failed: {
+    queued: ['user'],      // Resume (downloads with partial progress) or Retry
+  },
+  cancelled: {
+    queued: ['user'],      // Retry
+  },
+  completed: {
+    // Documented exceptions — deliberate quirks, not bugs:
+    queued: ['user'],      // Retry re-runs a finished transfer from scratch
+    failed: ['user'],      // Save after reload with the cached download chunks evicted
+  },
+  ready: {},               // server-owned; only the server merge moves it
+};
+
+// Statuses an entry may be created in, per creating actor. The queue*
+// entry points always mint 'queued'; restoreFilesTransferState only sees
+// what filesTransferPersistable writes (running/queued normalize to
+// 'paused'; cancelled rows and completed uploads are dropped — a restored
+// 'completed' is always a download); server merges mirror the job's own
+// status (filesTransferStatusFromJob normalizes unknowns to 'queued').
+const FILES_TRANSFER_INITIAL_STATUSES = {
+  user: ['queued'],
+  restore: ['paused', 'failed', 'completed', 'ready'],
+  server: ['queued', 'running', 'paused', 'failed', 'cancelled', 'completed', 'ready'],
+};
+
+const FILES_TRANSFER_FSM_TAG = '[transfer-fsm]';
+let filesTransferFsmIllegalCount = 0;
+const filesTransferFsmRecentReports = [];
+
+// Diagnostics only — the offending transition is still applied afterwards
+// (the UI must keep working; the table polices intent, it never gates
+// behavior). NEVER throw from here.
+function filesTransferFsmReport(message, transfer, detail = {}) {
+  filesTransferFsmIllegalCount += 1;
+  const report = {
+    message,
+    id: transfer?.id || '',
+    kind: transfer?.kind || '',
+    ...detail,
+  };
+  filesTransferFsmRecentReports.push(report);
+  if (filesTransferFsmRecentReports.length > 20) filesTransferFsmRecentReports.shift();
+  console.error(FILES_TRANSFER_FSM_TAG, message, report);
+}
+
+function filesTransferTransitionAllowed(from, to, actor) {
+  if (actor === 'server') {
+    // Mirror of the filesTransferMergeServerJob guard: a row whose local
+    // status is actively owned by this tab (queued/running/paused/failed)
+    // is never overwritten by a merged job; for anything else the server
+    // job's status is authoritative, whatever it says.
+    return !['queued', 'running', 'paused', 'failed'].includes(from);
+  }
+  const actors = FILES_TRANSFER_TRANSITIONS[from]?.[to];
+  return Array.isArray(actors) && actors.includes(actor);
+}
+
+// Settle the completion promise for a transfer entering `status`:
+// completed → resolve(result); failed/cancelled → reject(failure, or an
+// Error built from transfer.error). Other statuses settle only when the
+// caller hands in the teardown failure — pausing a *running* transfer
+// rejects the in-flight attempt (AbortError) while pausing a *queued* one
+// leaves the promise pending; Resume mints a fresh promise either way.
+function filesTransferFsmSettle(transfer, status, { result, failure } = {}) {
+  if (status === 'completed') {
+    transfer.resolve?.(result);
+  } else if (status === 'failed' || status === 'cancelled') {
+    transfer.reject?.(failure !== undefined ? failure : new Error(transfer.error || `transfer ${status}`));
+  } else if (failure !== undefined) {
+    transfer.reject?.(failure);
+  }
+}
+
+// Register a newly created entry with the machine: validate its initial
+// status for the creating actor, arm the completion promise, and settle it
+// immediately when the entry is born terminal (a restored 'completed'
+// download, a merged job that already finished) so "terminal ⇒ settled"
+// holds from birth. User creations bump queueEpoch — together with the
+// Resume/Retry re-arm these are the "queue/resume/retry" bumps the pump
+// backstop keys on.
+function filesTransferFsmInit(transfer, { actor = 'unknown' } = {}) {
+  if (!transfer) return null;
+  const status = transfer.status;
+  const allowed = FILES_TRANSFER_INITIAL_STATUSES[actor];
+  if (!allowed || !allowed.includes(status)) {
+    filesTransferFsmReport(
+      `illegal initial status '${status}' for actor '${actor}'`,
+      transfer,
+      { actor, to: status }
+    );
+  }
+  if (actor === 'user') transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
+  filesTransferCompletion(transfer);
+  filesTransferFsmSettle(transfer, status, {});
+  return transfer;
+}
+
+// The single mutation point for transfer.status. Options:
+//   actor   — 'user' | 'runner' | 'pump' | 'server'; checked against the
+//             table, illegal moves are reported (console.error, counted in
+//             window.qa.transfers()) and then applied anyway.
+//   error   — string (including '') assigns transfer.error; undefined
+//             applies the default (entering queued/running clears it, as
+//             every queue/resume/retry/runner-start site does; other
+//             targets leave it untouched); null forces leave-untouched
+//             even for queued/running (the server merge owns error itself).
+//   result  — resolve value for the completion promise when to='completed'.
+//   failure — reject error for the completion promise (defaults to an
+//             Error from transfer.error for failed/cancelled; also rejects
+//             the in-flight attempt on a runner's pause teardown).
+//   reason  — free-text context for the illegal-transition report.
+//   persist/render — default true; the server-merge loop batches both.
+function filesTransferTransition(transfer, to, options = {}) {
+  const {
+    actor = 'unknown',
+    error,
+    reason = '',
+    result,
+    failure,
+    persist = true,
+    render = true,
+  } = options;
+  if (!transfer) {
+    filesTransferFsmReport(`transition to '${to}' on a missing transfer`, null, { actor, to, reason });
+    return null;
+  }
+  const from = transfer.status;
+  if (!FILES_TRANSFER_STATUSES.has(to)) {
+    filesTransferFsmReport(`unknown target status '${to}'`, transfer, { actor, from, to, reason });
+  } else if (!filesTransferTransitionAllowed(from, to, actor)) {
+    filesTransferFsmReport(`illegal transition ${from} → ${to} (actor '${actor}')`, transfer, { actor, from, to, reason });
+  }
+  transfer.status = to;
+  if (to === 'queued') {
+    // Re-arm: entering the queue is a fresh attempt. Bump queueEpoch (the
+    // pump backstop exempts entries whose epoch moved — re-queues racing a
+    // runner teardown are legitimate), clear the teardown flags, and mint a
+    // fresh completion promise for the new attempt.
+    transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
+    transfer.pauseRequested = false;
+    transfer.cancelRequested = false;
+    if (error === undefined) transfer.error = '';
+    filesTransferCompletion(transfer);
+  } else if (to === 'running') {
+    transfer.pauseRequested = false;
+    transfer.cancelRequested = false;
+    if (error === undefined) transfer.error = '';
+  }
+  if (error !== undefined && error !== null) transfer.error = error;
+  if (persist) filesTransferPersistState();
+  if (render) renderFilesTransfers();
+  filesTransferFsmSettle(transfer, to, { result, failure });
+  return transfer;
+}
+
+// QA readback (window.qa convention): the transfer table harnesses assert
+// on — entry states plus the FSM's illegal-transition counter (0 in a
+// healthy session). Probe stays cheap and side-effect-free.
+window.qa = Object.assign(window.qa || {}, {
+  transfers: () => ({
+    entries: filesTransfers.map(transfer => ({
+      id: transfer.id,
+      kind: transfer.kind,
+      status: transfer.status,
+      error: transfer.error || '',
+      epoch: Number(transfer.queueEpoch || 0),
+    })),
+    illegalTransitions: filesTransferFsmIllegalCount,
+    recentReports: filesTransferFsmRecentReports.slice(),
+  }),
+});

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -1330,7 +1330,7 @@ function restoreFilesTransferState() {
       cancelRequested: false,
       abortController: null,
     };
-    filesTransferCompletion(transfer);
+    filesTransferFsmInit(transfer, { actor: 'restore' });
     filesTransfers.push(transfer);
   }
 }
@@ -1704,8 +1704,15 @@ function filesTransferMergeServerJob(job) {
     abortController: null,
   };
   transfer.kind = kind;
-  if (!existing || !['queued', 'running', 'paused', 'failed'].includes(existing.status || '')) {
-    transfer.status = filesTransferStatusFromJob(job);
+  if (existing && !['queued', 'running', 'paused', 'failed'].includes(existing.status || '')) {
+    // A row this tab does not actively own mirrors the server job's status.
+    // (A brand-new row was already minted with it, so no self-transition.)
+    filesTransferTransition(transfer, filesTransferStatusFromJob(job), {
+      actor: 'server',
+      error: null,     // job.error merges below, after the status move
+      persist: false,  // refreshFilesTransferJobs persists + renders once per batch
+      render: false,
+    });
   }
   transfer.path = transfer.path || source;
   transfer.destination = transfer.destination || destination;
@@ -1718,7 +1725,7 @@ function filesTransferMergeServerJob(job) {
   transfer.error = job.error || transfer.error || '';
   filesTransferApplyServerJob(transfer, job);
   if (!existing) {
-    filesTransferCompletion(transfer);
+    filesTransferFsmInit(transfer, { actor: 'server' });
     filesTransfers.unshift(transfer);
   }
   return transfer;
@@ -1747,7 +1754,7 @@ async function refreshFilesTransferJobs() {
 
 // Finished transfers accumulate for the lifetime of the page; keep the
 // list bounded (active/queued/paused transfers are never pruned).
-const FILES_TRANSFER_TERMINAL_STATUSES = new Set(['completed', 'cancelled', 'failed']);
+// FILES_TRANSFER_TERMINAL_STATUSES lives in 53-transfer-fsm.js.
 const FILES_TRANSFER_HISTORY_LIMIT = 100;
 function pruneFinishedFilesTransfers() {
   let terminal = 0;
@@ -1866,8 +1873,7 @@ function filesUpdateActiveDownloadSummary(transfer = null) {
 }
 
 function queueFilesTransfer(transfer) {
-  transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
-  filesTransferCompletion(transfer);
+  filesTransferFsmInit(transfer, { actor: 'user' });
   filesTransfers.unshift(transfer);
   filesTransferPersistState();
   renderFilesTransfers();
@@ -2006,15 +2012,11 @@ async function runFilesDownloadTransfer(transfer) {
   // that left the status at 'queued' would make pumpFilesTransfers re-pick
   // the same entry forever, so every failure must flow through the catch
   // below. The transport guards therefore live inside the try.
-  transfer.status = 'running';
-  transfer.error = '';
-  transfer.pauseRequested = false;
-  transfer.cancelRequested = false;
+  filesTransferTransition(transfer, 'running', { actor: 'runner' });
   const controller = new AbortController();
   transfer.abortController = controller;
   transfer.transport = '';
   filesDownloadAbort = controller;
-  renderFilesTransfers();
   filesUpdateActiveDownloadSummary(transfer);
   let peerConnection = null;
   let peerDashboardConnection = null;
@@ -2190,22 +2192,15 @@ async function runFilesDownloadTransfer(transfer) {
   } catch (err) {
     const message = err?.message || String(err);
     if (transfer.cancelRequested) {
-      transfer.status = 'cancelled';
-      transfer.error = '';
-      filesTransferPersistState();
-      transfer.reject?.(err);
+      filesTransferTransition(transfer, 'cancelled', { actor: 'runner', error: '', failure: err });
       setFilesDownloadStatus('warn', 'Download cancelled');
     } else if (transfer.pauseRequested || err?.name === 'AbortError') {
-      transfer.status = 'paused';
-      transfer.error = '';
-      filesTransferPersistState();
-      transfer.reject?.(err);
+      // Non-terminal teardown: the in-flight attempt's promise still
+      // rejects (failure) — Resume mints a fresh one.
+      filesTransferTransition(transfer, 'paused', { actor: 'runner', error: '', failure: err });
       setFilesDownloadStatus('warn', `Paused at ${filesTransferProgressText(transfer)}`);
     } else {
-      transfer.status = 'failed';
-      transfer.error = message;
-      filesTransferPersistState();
-      transfer.reject?.(err);
+      filesTransferTransition(transfer, 'failed', { actor: 'runner', error: message, failure: err });
       setFilesDownloadStatus('error', message);
       if (typeof showControlToast === 'function') showControlToast('error', message);
     }
@@ -2237,12 +2232,10 @@ function settleCompletedFilesDownload(transfer, { resumable }) {
     resumable,
   };
   transfer.result = result;
-  transfer.status = 'completed';
-  filesTransferPersistState();
+  filesTransferTransition(transfer, 'completed', { actor: 'runner', result });
   setFilesDownloadProgress(result.size, result.total_size || result.size);
   setFilesDownloadStatus('ok', `Downloaded ${result.filename} (${humanBytes(result.size)})`);
   if (!transfer.skipBrowserSave) downloadDashboardBlob(result.blob, result.filename, result.content_type);
-  transfer.resolve?.(result);
   return result;
 }
 
@@ -2329,11 +2322,12 @@ async function runFilesFilesystemUploadHttpFallback(transfer, controller) {
     throw new Error(filesTransferFriendlyServerError(resp.body?.error, `file write returned HTTP ${resp.status}`));
   }
   transfer.loaded = transfer.totalSize;
-  transfer.status = 'completed';
-  filesTransferPersistState();
+  filesTransferTransition(transfer, 'completed', {
+    actor: 'runner',
+    result: { ok: true, path: destination, transport: 'http-fs-write' },
+  });
   await filesTransferDeleteUploadBlob(transfer.id);
   setFilesUploadStatus('ok', `Uploaded ${transfer.name} to ${destination}`);
-  transfer.resolve?.({ ok: true, path: destination, transport: 'http-fs-write' });
 }
 
 // Mirror the durable-job destination semantics client-side: an existing
@@ -2451,11 +2445,9 @@ async function runFilesFilesystemUploadTransfer(transfer, controller) {
   filesTransferApplyServerJob(transfer, committed.job);
   transfer.loaded = transfer.totalSize;
   transfer.descriptor = committed.job;
-  transfer.status = 'completed';
-  filesTransferPersistState();
+  filesTransferTransition(transfer, 'completed', { actor: 'runner', result: committed.job });
   await filesTransferDeleteUploadBlob(transfer.id);
   setFilesUploadStatus('ok', `Uploaded ${transfer.name || 'upload.bin'}`);
-  transfer.resolve?.(committed.job);
 }
 
 function filesDeleteServerTransfer(transfer) {
@@ -2470,14 +2462,11 @@ function filesDeleteServerTransfer(transfer) {
 async function runFilesUploadTransfer(transfer) {
   // Same rule as downloads: settle the status before any guard can throw,
   // so pumpFilesTransfers never re-picks a permanently 'queued' entry.
-  transfer.status = 'running';
-  transfer.error = '';
+  filesTransferTransition(transfer, 'running', { actor: 'runner' });
   transfer.loaded = Number(transfer.loaded || 0);
-  transfer.cancelRequested = false;
   transfer.transport = '';
   const controller = new AbortController();
   transfer.abortController = controller;
-  renderFilesTransfers();
   try {
     const filesystemUpload = Boolean(transfer.destination && transfer.destination !== 'task');
     if (filesystemUpload && transfer.uploadBlobPersistPromise) {
@@ -2539,23 +2528,18 @@ async function runFilesUploadTransfer(transfer) {
       }
       transfer.loaded = transfer.file.size;
       transfer.descriptor = descriptor;
-      transfer.status = 'completed';
+      filesTransferTransition(transfer, 'completed', { actor: 'runner', result: descriptor });
       filesStagedUploads.set(String(descriptor.id || transfer.id), descriptor);
       setFilesUploadStatus('ok', `Uploaded ${descriptor.name || transfer.file.name || 'upload.bin'}`);
       renderFilesStagedUploads();
-      transfer.resolve?.(descriptor);
     }
   } catch (err) {
     if (transfer.cancelRequested || err?.name === 'AbortError') {
-      transfer.status = 'cancelled';
-      transfer.error = '';
+      filesTransferTransition(transfer, 'cancelled', { actor: 'runner', error: '', failure: err });
     } else {
-      transfer.status = 'failed';
-      transfer.error = err?.message || String(err);
+      filesTransferTransition(transfer, 'failed', { actor: 'runner', error: err?.message || String(err), failure: err });
       setFilesUploadStatus('error', transfer.error);
     }
-    filesTransferPersistState();
-    transfer.reject?.(err);
   } finally {
     transfer.abortController = null;
     filesTransferPersistState();
@@ -2581,14 +2565,16 @@ async function pumpFilesTransfers() {
         // Forward-progress backstop: a runner that exits without settling
         // its transfer would be re-picked by the find() above forever — a
         // synchronous microtask spin that freezes the page and allocates
-        // without bound. Force the entry failed so the pump always drains.
-        // The epoch check exempts entries the user legitimately re-queued
-        // (Resume/Retry bump it) while the runner was tearing down.
-        transfer.status = 'failed';
-        transfer.error = failure?.message || transfer.error || 'transfer runner exited without settling';
-        filesTransferPersistState();
-        renderFilesTransfers();
-        transfer.reject?.(failure || new Error(transfer.error));
+        // without bound. Force the entry failed so the pump always drains
+        // (the transition also rejects the completion promise). The epoch
+        // check exempts entries legitimately re-queued (Resume/Retry bump
+        // it) while the runner was tearing down.
+        filesTransferTransition(transfer, 'failed', {
+          actor: 'pump',
+          error: failure?.message || transfer.error || 'transfer runner exited without settling',
+          failure: failure || undefined,
+          reason: 'runner exited without settling its transfer',
+        });
       }
       // Macrotask yield: even a misbehaving runner that settles instantly
       // can only busy the tab, never wedge the event loop.
@@ -2616,9 +2602,9 @@ function pauseFilesTransfer(id) {
   const transfer = filesTransferById(id);
   if (!transfer) return;
   if (transfer.status === 'queued') {
-    transfer.status = 'paused';
-    filesTransferPersistState();
-    renderFilesTransfers();
+    // Not started yet: park it in place. The completion promise stays
+    // pending until Resume re-arms it — only a runner teardown rejects.
+    filesTransferTransition(transfer, 'paused', { actor: 'user' });
     return;
   }
   if (transfer.status !== 'running') return;
@@ -2636,10 +2622,10 @@ function cancelFilesTransfer(id) {
   if (transfer.status === 'running') {
     transfer.abortController?.abort();
   } else if (['queued', 'paused'].includes(transfer.status)) {
-    transfer.status = 'cancelled';
-    transfer.reject?.(new Error('transfer cancelled'));
-    filesTransferPersistState();
-    renderFilesTransfers();
+    filesTransferTransition(transfer, 'cancelled', {
+      actor: 'user',
+      failure: new Error('transfer cancelled'),
+    });
     pumpFilesTransfers();
   }
 }
@@ -2647,14 +2633,8 @@ function cancelFilesTransfer(id) {
 function resumeFilesTransfer(id) {
   const transfer = filesTransferById(id);
   if (!transfer || !['paused', 'failed'].includes(transfer.status)) return null;
-  transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
-  transfer.status = 'queued';
-  transfer.error = '';
-  transfer.pauseRequested = false;
-  transfer.cancelRequested = false;
-  filesTransferCompletion(transfer);
-  filesTransferPersistState();
-  renderFilesTransfers();
+  // Entering 'queued' re-arms the attempt (epoch bump, flags, completion).
+  filesTransferTransition(transfer, 'queued', { actor: 'user' });
   pumpFilesTransfers();
   return transfer.completion;
 }
@@ -2663,21 +2643,15 @@ function retryFilesTransfer(id) {
   const transfer = filesTransferById(id);
   if (!transfer || !['failed', 'cancelled', 'completed'].includes(transfer.status)) return null;
   if (transfer.kind === 'download') resetFilesDownloadTransfer(transfer);
-  transfer.queueEpoch = (transfer.queueEpoch || 0) + 1;
-  transfer.status = 'queued';
-  transfer.error = '';
-  transfer.cancelRequested = false;
-  transfer.pauseRequested = false;
-  filesTransferCompletion(transfer);
-  filesTransferPersistState();
-  renderFilesTransfers();
+  // Entering 'queued' re-arms the attempt (epoch bump, flags, completion).
+  filesTransferTransition(transfer, 'queued', { actor: 'user' });
   pumpFilesTransfers();
   return transfer.completion;
 }
 
 function clearFilesTransferHistory() {
   for (let i = filesTransfers.length - 1; i >= 0; i -= 1) {
-    if (['completed', 'failed', 'cancelled'].includes(filesTransfers[i].status)) {
+    if (FILES_TRANSFER_TERMINAL_STATUSES.has(filesTransfers[i].status)) {
       filesTransferDeleteDownloadParts(filesTransfers[i].id, Number(filesTransfers[i].rangeCount || 512));
       filesTransferDeleteUploadBlob(filesTransfers[i].id);
       filesTransfers.splice(i, 1);
@@ -2693,10 +2667,13 @@ async function saveCompletedFilesDownload(id) {
   if (!transfer.result?.blob) {
     const hydrated = await filesTransferLoadDownloadParts(transfer);
     if (!hydrated) {
-      transfer.status = 'failed';
-      transfer.error = 'download chunks are no longer available';
-      filesTransferPersistState();
-      renderFilesTransfers();
+      // Documented completed → failed exception: Save clicked after the
+      // cached download chunks were evicted (typically post-reload).
+      filesTransferTransition(transfer, 'failed', {
+        actor: 'user',
+        error: 'download chunks are no longer available',
+        reason: 'saved download chunks were evicted',
+      });
       return null;
     }
     const blob = new Blob(transfer.parts || [], { type: transfer.contentType || 'application/octet-stream' });

--- a/static/app/manifest.txt
+++ b/static/app/manifest.txt
@@ -67,6 +67,7 @@ ui2-activity.js
 52-peer-display.js
 53-stats-settings.js
 ui2-settings.js
+53-transfer-fsm.js
 54-session-lifecycle.js
 55-files-ide.js
 56-debug-sessions.js


### PR DESCRIPTION
Formalizes the dashboard files-transfer lifecycle (repo task "Wave 1E"). `filesTransfers` status was mutated ad-hoc from ~20 sites with the runner/pump/promise invariants implicit; a recent review found six bugs here. New fragment `static/app/53-transfer-fsm.js` (evals before 54/55 — `restoreFilesTransferState()` runs at fragment-55 eval time, so the table consts must initialize earlier) declares the machine; every status write in `54-session-lifecycle.js` now flows through `filesTransferTransition(transfer, to, {actor, error, reason, result, failure, persist, render})`, or `filesTransferFsmInit(transfer, {actor})` at entry creation. Persisted format (`intendant.files.transfers.v2`), wire calls, and observable behavior are unchanged.

## Transition table

| from \ to | queued | running | paused | failed | cancelled | completed |
|---|---|---|---|---|---|---|
| **queued** | — | runner (pump picked it; marked before any guard can throw) | user (Pause before start; promise stays pending) | pump (backstop, epoch unchanged) | user (Cancel) | — |
| **running** | — | — | runner (pauseRequested/AbortError teardown; rejects the in-flight attempt) | runner, pump | runner (cancelRequested teardown) | runner |
| **paused** | user (Resume) | — | — | — | user (Cancel) | — |
| **failed** | user (Resume/Retry) | — | — | — | — | — |
| **cancelled** | user (Retry) | — | — | — | — | — |
| **completed** | user (Retry — documented exception) | — | — | user (Save with evicted chunks — documented exception) | — | — |
| **ready** | server-owned: no local actor moves it | | | | | |

Plus the **server** actor (`filesTransferMergeServerJob`): may overwrite any row whose local status is *not* tab-owned (`queued/running/paused/failed`) with the job's status verbatim — the pre-existing merge guard, now expressed as a rule in `filesTransferTransitionAllowed`.

Initial statuses per creating actor: user → `queued`; restore → `paused|failed|completed|ready` (all `filesTransferPersistable` can write — running/queued normalize to paused, cancelled rows and completed uploads are dropped); server → any (jobs normalize unknowns to `queued`).

Invariants the transition owns (previously scattered):
- entering **queued** re-arms the attempt: `queueEpoch` bump (the PR #120 backstop exemption for re-queues racing a runner teardown), teardown flags cleared, error cleared, fresh completion promise;
- entering **running** clears flags/error — runners do this as their *first* statement so `pumpFilesTransfers` can never re-pick an unsettled `queued` entry (the 50GB microtask-spin class);
- entering a **terminal** status settles the completion promise (`completed` resolves `result`; `failed`/`cancelled` reject `failure` or an Error from `transfer.error`) — a terminal entry can never strand an awaiting caller; double-settles are no-ops;
- a runner's **pause teardown** still rejects the in-flight attempt (explicit `failure`), while Pause on a queued entry still leaves the promise pending (as before);
- illegal transitions: `console.error('[transfer-fsm] …')` + counter, then **applied anyway** — diagnostics never gate the UI, no throws.

QA bridge: `window.qa.transfers()` → `{ entries: [{id, kind, status, error, epoch}], illegalTransitions, recentReports }`.

## Mutation sites converted (21)

18 transitions: download runner start / catch-cancelled / catch-paused / catch-failed; `settleCompletedFilesDownload`; http-fs-write upload complete; filesystem-upload commit; upload runner start; task-upload complete; upload catch-cancelled / catch-failed; pump backstop; `pauseFilesTransfer` (queued); `cancelFilesTransfer` (queued/paused); `resumeFilesTransfer`; `retryFilesTransfer`; `saveCompletedFilesDownload` (evicted chunks); `filesTransferMergeServerJob` (existing-row overwrite).
3 inits: `queueFilesTransfer` (covers all three queue* creators), `restoreFilesTransferState`, `filesTransferMergeServerJob` (new row). `filesTransferApplyServerJob` writes `serverStatus`, never `status` — untouched. `FILES_TRANSFER_TERMINAL_STATUSES` moved into the FSM fragment as the single terminal-set definition (pruning, Clear history, persistence filter, settle).

## Documented exceptions (kept, marked in the table)

- `completed → queued` (user): Retry re-runs a finished transfer from scratch.
- `completed → failed` (user): Save after reload when the cached download chunks were evicted.

## Reasoning pass: unobservable deltas from unifying side effects

The existing behavior was the spec; these are the only deltas, each argued no-op in practice:
- **Runner-start persist**: transitions persist by default; the old runner starts didn't. `filesTransferPersistable` maps both `queued` and `running` to `paused` and error was already `''`, so the write is byte-identical (same-value `setItem` doesn't even fire storage events).
- **Settle-at-birth / settle-on-merge**: restored `completed`/`failed` rows and server-merged terminal rows used to keep a forever-pending completion promise; they now settle at init/merge. Nothing holds those promises (only queue*/resume/retry hand them out, and each mints a fresh one), and every completion pre-attaches `.catch(() => {})`, so no unhandled rejections.
- **Server re-queue re-arm**: a merge moving a non-tab-owned row to `queued` now bumps `queueEpoch` like any other re-queue. Previously unbumped — which would have let the pump backstop force-fail a row the *server* legitimately re-queued during a runner teardown; the bump extends PR #120's exemption to that case. Epoch is compared only for sameness and is not persisted.
- **Upload runner start clears `pauseRequested`** (downloads always did): no reachable path enters a runner with it set — `pauseFilesTransfer` only sets the flag on `running` rows and Resume clears it.
- **Coalesced double renders**: some paths render both in the transition and in their `finally`; `renderFilesTransfers` is rAF-coalesced, so one rebuild as before.
- Merge-loop transitions pass `persist:false, render:false` (`refreshFilesTransferJobs` batches once per refresh) and `error:null` (the job's error merges separately, after the status move — order preserved).

## Verification

- `node --check` on 53/54/55; `cargo run -p app-html-assembler` (64 fragments; artifact committed); `cargo check --bins`.
- Functional smoke driving the real fragment with 54's deps stubbed: 28/28 checks (settle semantics incl. resolve values and reject identity, re-arm epoch/flags/completion, pause-queued pending vs runner-pause reject, server-overwrite legality both ways, `error:null`, born-terminal settles, illegal-transition count/apply/tag, qa shape).
- `cargo nextest run --bins`: 2699 passed; `cargo test -p app-html-assembler`: 6 passed.

Draft on purpose: lands serially after the other frontend PRs (app.html regen conflicts expected); auto-merge intentionally not armed.
