### PR TITLE
Display backends: explicit teardown contract + stress tests (Wave 1C)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,7 +2649,6 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "schemars",
- "screencapturekit",
  "security-framework",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,8 @@ x11rb = { version = "0.13", features = ["shm", "damage", "xfixes", "xtest"] }
 atspi = { version = "0.30", features = ["tokio"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-screencapturekit = "8.0"
+# (screencapturekit moved to crates/intendant-display with the display
+# pipeline — macos.rs there is its only user in the workspace.)
 core-graphics = { version = "0.25", features = ["highsierra"] }
 core-foundation = "0.10"
 shiguredo_video_toolbox = "2026.1"

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -581,13 +581,82 @@ impl DisplayMetricsSnapshot {
 // ---------------------------------------------------------------------------
 
 /// Platform-specific display capture and input injection.
+///
+/// # Capture lifecycle contract
+///
+/// [`Self::start_capture`] / [`Self::stop_capture`] form a session lifecycle
+/// that every backend must implement with the same observable semantics, so
+/// the capture bridge ([`DisplaySession::start`]) can reason about teardown
+/// identically on every platform:
+///
+/// - **Serialized calls.** Callers serialize `start_capture` / `stop_capture`
+///   per backend instance (`DisplaySession` owns its backend and does so).
+///   Backends are not required to make *concurrent* start/stop calls
+///   linearizable, but every serialized call must leave the backend in a
+///   state where the next call upholds this contract.
+/// - **`start_capture` yields a fresh session.** Each successful call
+///   returns a new bounded frame channel (capacity 4; producers `try_send`
+///   and drop frames when the buffer is full). Starting while a previous
+///   session is still running first tears that session down (its channel
+///   closes) and then starts clean — an implicit `stop_capture`. A *failed*
+///   `start_capture` leaves no capture state behind: no threads, no OS
+///   streams, and `stop_capture` remains a no-op.
+/// - **The channel may close early.** When the OS source ends on its own
+///   (portal revoked, display disconnected, capture thread died), the
+///   producer side drops and the receiver sees `None`. Consumers must treat
+///   channel-close as capture-lost — the capture bridge emits
+///   [`DisplayEvent::CaptureLost`].
+///
+/// # Teardown contract (`stop_capture`)
+///
+/// After `stop_capture().await` returns:
+///
+/// 1. **The frame channel closes within bounded time.** The receiver from
+///    the most recent `start_capture` drains at most the few buffered frames
+///    and then sees `None`. Thread-backed backends (x11, wayland, windows)
+///    join the producer thread before returning, so the close is immediate;
+///    the macOS callback backend empties its shared sender slot before
+///    returning. ("Bounded" presumes the one in-flight OS capture call
+///    itself returns — a hung X server or SCK daemon can extend it.)
+/// 2. **No captured-frame side effect may touch freed state.** The backend
+///    owns whatever quiesce its OS needs: joining capture threads where
+///    possible, or — where the OS delivery queue cannot be joined (macOS
+///    ScreenCaptureKit) — keeping handler state alive until the OS truly
+///    stops calling it *and* gating the handler body on a per-session
+///    shutdown flag so post-stop callbacks are no-ops. This clause is paid
+///    for: on 2026-07-08 SCK delivered a frame ~53 s after `stop_capture()`
+///    and the then-current screencapturekit crate had freed the handler
+///    state on `Drop` — the late callback segfaulted the daemon.
+/// 3. **Double-stop and stop-without-start are no-ops** — cheap and
+///    side-effect-free beyond taking the state mutex.
+/// 4. **Start after stop yields a fresh, clean session** — a new channel and
+///    new per-session teardown state. Nothing from a previous session (late
+///    frames, a stale shutdown flag, an unjoined producer) may leak into or
+///    tear down the new one.
+///
+/// The `capture_teardown_contract` tests in this crate hammer these
+/// guarantees on synthetic backends in both conformance styles (join-on-stop
+/// and detached-callbacks); each real OS backend additionally has an
+/// `#[ignore]`d start/stop stress test for operator hardware (Wayland
+/// excepted: every portal session re-prompts for user approval, so it cannot
+/// run unattended).
 #[async_trait]
 pub trait DisplayBackend: Send + Sync + 'static {
     /// Begin capturing frames at the target framerate.
-    /// Returns a receiver for raw frames (bounded channel, backend drops on full).
+    /// Returns the receiver of a bounded frame channel (capacity 4, backend
+    /// `try_send`s and drops on full).
+    ///
+    /// Implements the fresh-session semantics of the [capture lifecycle
+    /// contract](DisplayBackend): implicit teardown of any session still
+    /// running, and no residual capture state when it returns `Err`.
     async fn start_capture(&self, fps: u32) -> Result<mpsc::Receiver<Frame>, CallerError>;
 
-    /// Stop capturing. Blocks until the capture thread/task has exited.
+    /// Stop capturing and quiesce the platform source.
+    ///
+    /// Upholds the [teardown contract](DisplayBackend): on return the frame
+    /// channel closes within bounded time, no late captured-frame side effect
+    /// can touch freed state, double-stop / stop-without-start are no-ops,
+    /// and a subsequent `start_capture` gets a clean slate.
     async fn stop_capture(&self);
 
     /// Inject a browser input event into the display.
@@ -3059,6 +3128,118 @@ pub(crate) fn gated_input_handler(
 }
 
 // ---------------------------------------------------------------------------
+// Capture teardown-contract stress driver (test-only, shared with the
+// per-OS backend modules)
+// ---------------------------------------------------------------------------
+
+/// Shared driver for the per-backend `#[ignore]`d real-OS capture stress
+/// tests (`macos.rs` / `x11.rs` / `windows.rs`). Hammers start/stop cycles
+/// against the [`DisplayBackend`] teardown contract on real capture
+/// hardware, then lingers so a late OS callback into freed state (the
+/// 2026-07-08 ScreenCaptureKit incident class: a frame delivered ~53 s
+/// after stop) crashes the test process instead of a production daemon.
+///
+/// Run on operator hardware (needs a display; macOS additionally needs the
+/// Screen Recording TCC grant):
+///
+/// ```text
+/// cargo test -p intendant-display --lib -- --ignored real_capture_stress
+/// ```
+///
+/// Tunables: `INTENDANT_DISPLAY_STRESS_CYCLES` (default 10) and
+/// `INTENDANT_DISPLAY_STRESS_LINGER_SECS` (default 60 — sized to cover the
+/// observed ~53 s late-callback window).
+#[cfg(test)]
+pub(crate) mod capture_stress {
+    use super::DisplayBackend;
+    use std::time::Duration;
+
+    fn env_u64(name: &str, default: u64) -> u64 {
+        std::env::var(name)
+            .ok()
+            .and_then(|v| v.trim().parse().ok())
+            .unwrap_or(default)
+    }
+
+    /// Drive `cycles` fast start/stop cycles, asserting per cycle that a
+    /// frame flows and that the frame channel closes within bounded time of
+    /// `stop_capture` returning, then linger to catch late OS callbacks.
+    ///
+    /// If the very first `start_capture` fails, the environment simply
+    /// cannot run this backend (headless box, missing TCC grant, Session 0
+    /// desktop) — the test logs and returns instead of failing, so the
+    /// `--ignored` battery stays runnable on any operator machine. A
+    /// failure on a *later* cycle is a real contract violation
+    /// (start-after-stop must yield a fresh session) and panics.
+    pub(crate) async fn run_real_backend_stress(backend: &dyn DisplayBackend) {
+        let cycles = env_u64("INTENDANT_DISPLAY_STRESS_CYCLES", 10);
+        let linger = Duration::from_secs(env_u64("INTENDANT_DISPLAY_STRESS_LINGER_SECS", 60));
+
+        for cycle in 0..cycles {
+            let mut rx = match backend.start_capture(30).await {
+                Ok(rx) => rx,
+                Err(e) if cycle == 0 => {
+                    eprintln!(
+                        "[capture-stress] skipping: {} capture unavailable in this \
+                         environment: {e}",
+                        backend.kind(),
+                    );
+                    return;
+                }
+                Err(e) => panic!(
+                    "cycle {cycle}: start_capture after stop_capture must yield a \
+                     fresh session: {e}"
+                ),
+            };
+
+            match tokio::time::timeout(Duration::from_secs(15), rx.recv()).await {
+                Ok(Some(_frame)) => {}
+                Ok(None) => panic!("cycle {cycle}: capture channel closed before the first frame"),
+                Err(_) => panic!("cycle {cycle}: no frame within 15s of start_capture"),
+            }
+
+            backend.stop_capture().await;
+
+            // Contract clause 1: bounded channel-close. Drain whatever was
+            // buffered; `None` must arrive promptly.
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+            loop {
+                match tokio::time::timeout_at(deadline, rx.recv()).await {
+                    Ok(Some(_buffered)) => continue,
+                    Ok(None) => break,
+                    Err(_) => panic!(
+                        "cycle {cycle}: frame channel still open 5s after \
+                         stop_capture returned"
+                    ),
+                }
+            }
+
+            // Small pause so any immediately-late OS callback overlaps the
+            // *next* session's startup — the exact per-session-state race
+            // the contract's clause 4 exists for.
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+
+        eprintln!(
+            "[capture-stress] {} cycles complete on {}; lingering {:?} to catch \
+             late OS callbacks into freed state",
+            cycles,
+            backend.kind(),
+            linger,
+        );
+        tokio::time::sleep(linger).await;
+
+        // The backend must still be fully usable after the linger.
+        let mut rx = backend
+            .start_capture(30)
+            .await
+            .expect("start_capture after linger must yield a fresh session");
+        let _ = tokio::time::timeout(Duration::from_secs(15), rx.recv()).await;
+        backend.stop_capture().await;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -4915,5 +5096,340 @@ mod tests {
             2,
             "gate must check authorization on every event, not at construction time"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Capture teardown-contract stress (Wave 1C)
+    //
+    // Hammers the `DisplayBackend` start/stop lifecycle contract on a
+    // synthetic backend with a real producer thread, in the two conformance
+    // styles the real backends use:
+    //
+    //  - `TeardownStyle::JoinOnStop` — the x11/wayland/windows shape:
+    //    `stop_capture` joins the producer thread, so channel-close is
+    //    implied by the join.
+    //  - `TeardownStyle::DetachedCallbacks` — the macOS ScreenCaptureKit
+    //    shape: the producer cannot be joined (it models an OS callback
+    //    queue), so `stop_capture` gates a per-session shutdown flag and
+    //    empties a shared sender slot, and the producer deliberately lingers
+    //    afterward firing "late callbacks" — proving they are harmless
+    //    no-ops and that the channel still closed within bounded time.
+    //
+    // The real-OS counterparts live as `#[ignore]`d tests in the per-backend
+    // modules, driven by `crate::capture_stress::run_real_backend_stress`.
+    // -----------------------------------------------------------------------
+
+    mod capture_teardown_contract {
+        use super::*;
+        use std::sync::atomic::AtomicUsize;
+        use std::sync::Mutex as StdMutex;
+
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        enum TeardownStyle {
+            JoinOnStop,
+            DetachedCallbacks,
+        }
+
+        /// How long a detached producer keeps firing late callbacks after it
+        /// observes shutdown (models SCK's post-stop delivery window,
+        /// compressed to test scale).
+        const DETACHED_LINGER: Duration = Duration::from_millis(120);
+        /// Contract bound the tests hold `stop_capture` to: the receiver
+        /// must see `None` within this window after stop returns. Generous
+        /// versus the ~2ms producer interval to stay robust on loaded CI.
+        const CLOSE_BOUND: Duration = Duration::from_secs(2);
+
+        struct SyntheticCaptureState {
+            shutdown: Arc<AtomicBool>,
+            frame_tx: Arc<StdMutex<Option<mpsc::Sender<Frame>>>>,
+            thread: Option<std::thread::JoinHandle<()>>,
+        }
+
+        /// Test-only `DisplayBackend` whose producer is a real OS thread, so
+        /// the stress exercises genuine cross-thread teardown rather than a
+        /// pre-closed stub channel (`StubBackend`).
+        struct SyntheticCaptureBackend {
+            style: TeardownStyle,
+            capture: Mutex<Option<SyntheticCaptureState>>,
+            /// Producer threads currently alive. Join-style stops must leave
+            /// this at 0 synchronously; detached-style producers may outlive
+            /// stop by `DETACHED_LINGER`.
+            live_producers: Arc<AtomicUsize>,
+            starts: AtomicUsize,
+        }
+
+        impl SyntheticCaptureBackend {
+            fn new(style: TeardownStyle) -> Self {
+                Self {
+                    style,
+                    capture: Mutex::new(None),
+                    live_producers: Arc::new(AtomicUsize::new(0)),
+                    starts: AtomicUsize::new(0),
+                }
+            }
+
+            fn test_frame() -> Frame {
+                Frame {
+                    data: vec![0u8; 16 * 16 * 4],
+                    format: FrameFormat::Bgra,
+                    width: 16,
+                    height: 16,
+                    stride: 16 * 4,
+                    timestamp: Instant::now(),
+                    dirty_rects: None,
+                }
+            }
+        }
+
+        #[async_trait]
+        impl DisplayBackend for SyntheticCaptureBackend {
+            async fn start_capture(
+                &self,
+                _fps: u32,
+            ) -> Result<mpsc::Receiver<Frame>, CallerError> {
+                // Contract: implicit teardown of any session still running.
+                self.stop_capture().await;
+
+                self.starts.fetch_add(1, Ordering::SeqCst);
+                let (tx, rx) = mpsc::channel::<Frame>(4);
+                let frame_tx = Arc::new(StdMutex::new(Some(tx)));
+                let shutdown = Arc::new(AtomicBool::new(false));
+
+                let producer_slot = Arc::clone(&frame_tx);
+                let producer_shutdown = Arc::clone(&shutdown);
+                let live = Arc::clone(&self.live_producers);
+                let style = self.style;
+                live.fetch_add(1, Ordering::SeqCst);
+                let thread = std::thread::spawn(move || {
+                    loop {
+                        if producer_shutdown.load(Ordering::SeqCst) {
+                            break;
+                        }
+                        if let Some(tx) = producer_slot
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .as_ref()
+                        {
+                            let _ = tx.try_send(Self::test_frame());
+                        }
+                        std::thread::sleep(Duration::from_millis(2));
+                    }
+                    if style == TeardownStyle::DetachedCallbacks {
+                        // Late-callback phase: nobody joins us; keep firing
+                        // against the (already emptied) slot and the flag,
+                        // like SCK delivering frames after stop. Every
+                        // attempt must be a harmless no-op.
+                        let deadline = Instant::now() + DETACHED_LINGER;
+                        while Instant::now() < deadline {
+                            if let Some(tx) = producer_slot
+                                .lock()
+                                .unwrap_or_else(|e| e.into_inner())
+                                .as_ref()
+                            {
+                                let _ = tx.try_send(Self::test_frame());
+                            }
+                            std::thread::sleep(Duration::from_millis(2));
+                        }
+                    }
+                    live.fetch_sub(1, Ordering::SeqCst);
+                });
+
+                *self.capture.lock().await = Some(SyntheticCaptureState {
+                    shutdown,
+                    frame_tx,
+                    thread: Some(thread),
+                });
+                Ok(rx)
+            }
+
+            async fn stop_capture(&self) {
+                let Some(mut state) = self.capture.lock().await.take() else {
+                    return;
+                };
+                state.shutdown.store(true, Ordering::SeqCst);
+                match self.style {
+                    TeardownStyle::JoinOnStop => {
+                        // x11/wayland/windows shape: join implies close.
+                        if let Some(thread) = state.thread.take() {
+                            let _ = tokio::task::spawn_blocking(move || {
+                                let _ = thread.join();
+                            })
+                            .await;
+                        }
+                    }
+                    TeardownStyle::DetachedCallbacks => {
+                        // macOS shape: no join possible; close the channel by
+                        // emptying the slot, leave the producer to its late
+                        // callbacks.
+                        state
+                            .frame_tx
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .take();
+                        drop(state.thread.take());
+                    }
+                }
+            }
+
+            async fn inject_input(&self, _event: InputEvent) -> Result<(), CallerError> {
+                Ok(())
+            }
+            fn resolution(&self) -> (u32, u32) {
+                (16, 16)
+            }
+            fn kind(&self) -> &'static str {
+                "synthetic-stress"
+            }
+        }
+
+        /// Receive until the first frame arrives, failing on close/timeout.
+        async fn expect_frame(rx: &mut mpsc::Receiver<Frame>, ctx: &str) {
+            match tokio::time::timeout(CLOSE_BOUND, rx.recv()).await {
+                Ok(Some(_)) => {}
+                Ok(None) => panic!("{ctx}: channel closed before delivering a frame"),
+                Err(_) => panic!("{ctx}: no frame within {CLOSE_BOUND:?}"),
+            }
+        }
+
+        /// Drain buffered frames until the channel closes, bounded.
+        async fn expect_close(rx: &mut mpsc::Receiver<Frame>, ctx: &str) {
+            let deadline = tokio::time::Instant::now() + CLOSE_BOUND;
+            loop {
+                match tokio::time::timeout_at(deadline, rx.recv()).await {
+                    Ok(Some(_buffered)) => continue,
+                    Ok(None) => return,
+                    Err(_) => panic!(
+                        "{ctx}: channel still open {CLOSE_BOUND:?} after stop_capture returned"
+                    ),
+                }
+            }
+        }
+
+        /// Wait (bounded) for every producer thread to wind down.
+        async fn expect_no_live_producers(backend: &SyntheticCaptureBackend, ctx: &str) {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while backend.live_producers.load(Ordering::SeqCst) != 0 {
+                assert!(
+                    Instant::now() < deadline,
+                    "{ctx}: producer threads still alive 5s after teardown"
+                );
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn join_style_start_stop_cycles_close_channel_and_leak_no_threads() {
+            let backend = SyntheticCaptureBackend::new(TeardownStyle::JoinOnStop);
+            for cycle in 0..50 {
+                let mut rx = backend.start_capture(60).await.expect("start");
+                expect_frame(&mut rx, &format!("join cycle {cycle}")).await;
+                backend.stop_capture().await;
+                // Join-on-stop makes both guarantees synchronous.
+                assert_eq!(
+                    backend.live_producers.load(Ordering::SeqCst),
+                    0,
+                    "join cycle {cycle}: stop_capture returned with the producer alive"
+                );
+                expect_close(&mut rx, &format!("join cycle {cycle}")).await;
+            }
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn detached_style_channel_closes_promptly_despite_late_callbacks() {
+            let backend = SyntheticCaptureBackend::new(TeardownStyle::DetachedCallbacks);
+            for cycle in 0..25 {
+                let mut rx = backend.start_capture(60).await.expect("start");
+                expect_frame(&mut rx, &format!("detached cycle {cycle}")).await;
+                backend.stop_capture().await;
+                // The channel must close within the bound even though the
+                // producer is still alive firing late callbacks — the whole
+                // point of the sender-slot pattern.
+                expect_close(&mut rx, &format!("detached cycle {cycle}")).await;
+                // Immediately start the next cycle: fresh sessions must be
+                // undisturbed by the previous session's lingering producer.
+            }
+            backend.stop_capture().await;
+            expect_no_live_producers(&backend, "detached stress").await;
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn rapid_unconsumed_cycles_never_wedge() {
+            // Never read a single frame: producers run against a full
+            // channel (try_send drop path) while start/stop churns.
+            for style in [TeardownStyle::JoinOnStop, TeardownStyle::DetachedCallbacks] {
+                let backend = SyntheticCaptureBackend::new(style);
+                let mut receivers = Vec::new();
+                for _ in 0..40 {
+                    receivers.push(backend.start_capture(60).await.expect("start"));
+                }
+                backend.stop_capture().await;
+                // Every superseded session's channel must have closed too
+                // (implicit teardown on start-over-running).
+                for (i, rx) in receivers.iter_mut().enumerate() {
+                    expect_close(rx, &format!("rapid session {i}")).await;
+                }
+                expect_no_live_producers(&backend, "rapid churn").await;
+                assert_eq!(backend.starts.load(Ordering::SeqCst), 40);
+            }
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn double_stop_and_stop_without_start_are_noops() {
+            for style in [TeardownStyle::JoinOnStop, TeardownStyle::DetachedCallbacks] {
+                let backend = SyntheticCaptureBackend::new(style);
+                // Stop-without-start: nothing to do, returns promptly.
+                backend.stop_capture().await;
+                backend.stop_capture().await;
+
+                let mut rx = backend.start_capture(60).await.expect("start");
+                expect_frame(&mut rx, "noop test").await;
+                backend.stop_capture().await;
+                expect_close(&mut rx, "noop test").await;
+                // Double-stop after a real stop: still a no-op.
+                backend.stop_capture().await;
+
+                // Contract clause 4: start after (multiple) stops yields a
+                // fresh working session.
+                let mut rx2 = backend.start_capture(60).await.expect("restart");
+                expect_frame(&mut rx2, "restart after double-stop").await;
+                backend.stop_capture().await;
+                expect_close(&mut rx2, "restart after double-stop").await;
+                expect_no_live_producers(&backend, "noop test").await;
+            }
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn start_over_running_capture_supersedes_previous_session() {
+            for style in [TeardownStyle::JoinOnStop, TeardownStyle::DetachedCallbacks] {
+                let backend = SyntheticCaptureBackend::new(style);
+                let mut rx1 = backend.start_capture(60).await.expect("first start");
+                expect_frame(&mut rx1, "first session").await;
+
+                let mut rx2 = backend.start_capture(60).await.expect("second start");
+                // The superseded session's channel closes...
+                expect_close(&mut rx1, "superseded session").await;
+                // ...while the new session flows frames.
+                expect_frame(&mut rx2, "successor session").await;
+
+                backend.stop_capture().await;
+                expect_close(&mut rx2, "successor session").await;
+                expect_no_live_producers(&backend, "supersede test").await;
+            }
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn stop_returns_even_when_receiver_was_dropped_first() {
+            for style in [TeardownStyle::JoinOnStop, TeardownStyle::DetachedCallbacks] {
+                let backend = SyntheticCaptureBackend::new(style);
+                let rx = backend.start_capture(60).await.expect("start");
+                drop(rx);
+                // Producer now try_sends into a closed channel; stop must
+                // still tear down cleanly within the bound.
+                tokio::time::timeout(CLOSE_BOUND, backend.stop_capture())
+                    .await
+                    .expect("stop_capture wedged after receiver drop");
+                expect_no_live_producers(&backend, "receiver-drop test").await;
+            }
+        }
     }
 }

--- a/crates/intendant-display/src/macos.rs
+++ b/crates/intendant-display/src/macos.rs
@@ -26,7 +26,7 @@ use screencapturekit::cm::{CMTime, SCFrameStatus};
 use screencapturekit::cv::CVPixelBufferLockFlags;
 use screencapturekit::prelude::*;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex as StdMutex, RwLock};
 use tokio::sync::{mpsc, Mutex};
 
 /// Synthetic display IDs at and above this value represent macOS native
@@ -79,9 +79,27 @@ impl InputGeometry {
     }
 }
 
-/// Active capture state: holds the `SCStream` and shutdown flag.
+/// One active ScreenCaptureKit session.
+///
+/// All teardown-relevant state is **per-session** (created fresh by each
+/// `start_capture` and owned here), not per-backend: unlike the thread-backed
+/// backends, ScreenCaptureKit's callback queue cannot be joined, so a late
+/// callback from a *previous* stream can fire long after `stop_capture`
+/// returned (~53 s observed in the 2026-07-08 incident) — possibly while a
+/// *new* session is already running. Per-session flags/slots mean such a
+/// callback can only ever observe its own, already-quiesced session.
 struct CaptureState {
     stream: SCStream,
+    /// Shutdown gate shared with this session's SCK output handler. Set
+    /// first during teardown; late callbacks check it and return before
+    /// touching pixels, geometry, or the channel.
+    shutdown: Arc<AtomicBool>,
+    /// The frame channel's only `Sender`, shared with the output handler.
+    /// `stop_capture` takes it out of the slot, closing the channel
+    /// immediately (the teardown contract's bounded channel-close) instead
+    /// of waiting for the OS to release the handler closure that would
+    /// otherwise keep the sender alive.
+    frame_tx: Arc<StdMutex<Option<mpsc::Sender<Frame>>>>,
 }
 
 /// macOS screen capture and input injection backend.
@@ -92,7 +110,6 @@ pub struct MacOSBackend {
     capture: Mutex<Option<CaptureState>>,
     width: Arc<AtomicU32>,
     height: Arc<AtomicU32>,
-    shutdown: Arc<AtomicBool>,
     input_geometry: Arc<RwLock<InputGeometry>>,
     target: CaptureTarget,
 }
@@ -115,7 +132,6 @@ impl MacOSBackend {
             capture: Mutex::new(None),
             width: Arc::new(AtomicU32::new(0)),
             height: Arc::new(AtomicU32::new(0)),
-            shutdown: Arc::new(AtomicBool::new(false)),
             input_geometry: Arc::new(RwLock::new(InputGeometry::from_frame_size(0, 0))),
             target,
         }
@@ -484,13 +500,11 @@ fn enumerate_window_display_infos(content: &SCShareableContent) -> Vec<super::Di
 #[async_trait]
 impl DisplayBackend for MacOSBackend {
     async fn start_capture(&self, fps: u32) -> Result<mpsc::Receiver<Frame>, CallerError> {
-        // Defensive: matching the x11.rs pattern — teardown any previous
-        // capture before starting a new one, so a double-start doesn't
-        // leak the ScreenCaptureKit stream. `stop_capture` is idempotent
-        // when nothing's running.
+        // Contract: starting over a running capture first tears the old
+        // session down (matching the x11.rs pattern) so a double-start
+        // doesn't leak the ScreenCaptureKit stream. `stop_capture` is
+        // idempotent when nothing's running.
         self.stop_capture().await;
-
-        self.shutdown.store(false, Ordering::SeqCst);
 
         // Get shareable content (triggers TCC permission prompt on first use).
         let content = SCShareableContent::create()
@@ -520,10 +534,21 @@ impl DisplayBackend for MacOSBackend {
             .with_shows_cursor(true)
             .with_minimum_frame_interval(&frame_interval);
 
-        // Bounded channel: backend drops frames if consumer is slow.
+        // Bounded channel: backend drops frames if consumer is slow. The
+        // sender lives in a per-session slot shared with the output handler
+        // so `stop_capture` can close the channel promptly (see
+        // `CaptureState`); it stays the channel's *only* sender — cloning it
+        // out of the slot would let a late callback keep the channel open
+        // past teardown.
         let (tx, rx) = mpsc::channel::<Frame>(4);
+        let frame_slot = Arc::new(StdMutex::new(Some(tx)));
 
-        let shutdown_flag = Arc::clone(&self.shutdown);
+        // Per-session teardown state (see `CaptureState` for why these must
+        // not be backend-shared).
+        let shutdown_flag = Arc::new(AtomicBool::new(false));
+
+        let handler_slot = Arc::clone(&frame_slot);
+        let handler_shutdown = Arc::clone(&shutdown_flag);
         // Share width/height atomics with the output handler so it can
         // update them when ScreenCaptureKit delivers frames at a different
         // resolution (e.g. Retina scale change, resolution switch).
@@ -539,7 +564,12 @@ impl DisplayBackend for MacOSBackend {
                 if of_type != SCStreamOutputType::Screen {
                     return;
                 }
-                if shutdown_flag.load(Ordering::SeqCst) {
+                // Teardown gate: ScreenCaptureKit can deliver callbacks well
+                // after SCStream::stop_capture (observed ~53 s late). The
+                // handler state itself stays ARC-retained by the crate's
+                // Swift bridge until the OS releases it, so this runs against
+                // live memory; the flag makes it a no-op.
+                if handler_shutdown.load(Ordering::SeqCst) {
                     return;
                 }
                 let Some(buffer) = sample.image_buffer() else {
@@ -599,8 +629,18 @@ impl DisplayBackend for MacOSBackend {
                     dirty_rects,
                 };
 
-                // Backpressure: drop frame if channel is full.
-                let _ = tx.try_send(frame);
+                // Send while holding the slot lock: `stop_capture` empties
+                // the slot under the same lock, so once it returns no
+                // callback can slip another frame into the channel.
+                // Backpressure: `try_send` drops the frame if the channel
+                // is full.
+                if let Some(tx) = handler_slot
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .as_ref()
+                {
+                    let _ = tx.try_send(frame);
+                }
             },
             SCStreamOutputType::Screen,
         );
@@ -609,17 +649,47 @@ impl DisplayBackend for MacOSBackend {
             .start_capture()
             .map_err(|e| CallerError::Display(format!("start_capture: {e}")))?;
 
-        *self.capture.lock().await = Some(CaptureState { stream });
+        *self.capture.lock().await = Some(CaptureState {
+            stream,
+            shutdown: shutdown_flag,
+            frame_tx: frame_slot,
+        });
 
         Ok(rx)
     }
 
     async fn stop_capture(&self) {
-        self.shutdown.store(true, Ordering::SeqCst);
+        // Double-stop / stop-without-start: nothing registered, no-op.
+        let Some(state) = self.capture.lock().await.take() else {
+            return;
+        };
 
-        if let Some(state) = self.capture.lock().await.take() {
+        // Quiesce order matters:
+        // 1. Gate first — callbacks that fire from here on return without
+        //    touching pixels, geometry atomics, or the channel.
+        state.shutdown.store(true, Ordering::SeqCst);
+        // 2. Close the frame channel now (contract: bounded channel-close).
+        //    The slot holds the channel's only sender; SCK may keep the
+        //    handler closure — and thus the slot Arc — alive long after
+        //    stop, so waiting for the closure to drop would leave the
+        //    receiver hanging for tens of seconds.
+        state
+            .frame_tx
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take();
+        // 3. Stop and release the stream off the executor thread —
+        //    SCStream::stop_capture blocks on an SCK completion handler
+        //    (same executor-stall class as the x11 thread-join). A late OS
+        //    callback after this is safe: the crate's Swift bridge keeps the
+        //    handler context ARC-retained until the OS stops calling it
+        //    (screencapturekit 8.0 — the 1.5 free-on-Drop was the 2026-07-08
+        //    daemon segfault), and the callback body hits the gate above.
+        let _ = tokio::task::spawn_blocking(move || {
             let _ = state.stream.stop_capture();
-        }
+            drop(state);
+        })
+        .await;
     }
 
     async fn inject_input(&self, event: InputEvent) -> Result<(), CallerError> {
@@ -834,5 +904,28 @@ mod tests {
         for value in ["", "0", "false", "no", "off", "enabled"] {
             assert!(!sck_dirty_rects_enabled_value(value), "{value}");
         }
+    }
+
+    /// Real-ScreenCaptureKit teardown-contract stress: fast start/stop
+    /// cycles, per-cycle bounded channel-close assertions, then a long
+    /// linger so a late SCK callback into freed state (the 2026-07-08
+    /// segfault class: a frame delivered ~53 s after stop) crashes this
+    /// test process instead of a production daemon.
+    ///
+    /// Ignored by default — drives the real OS capture stack, so it needs a
+    /// display and the Screen Recording TCC grant (it skips itself cleanly
+    /// when capture is unavailable). Run on operator hardware:
+    ///
+    /// ```text
+    /// cargo test -p intendant-display --lib -- --ignored real_capture_stress
+    /// ```
+    ///
+    /// Tunables: `INTENDANT_DISPLAY_STRESS_CYCLES` (default 10),
+    /// `INTENDANT_DISPLAY_STRESS_LINGER_SECS` (default 60).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "real ScreenCaptureKit capture: needs a display + Screen Recording TCC; run via -- --ignored real_capture_stress on operator hardware"]
+    async fn macos_real_capture_stress_cycles() {
+        let backend = MacOSBackend::new();
+        crate::capture_stress::run_real_backend_stress(&backend).await;
     }
 }

--- a/crates/intendant-display/src/wayland.rs
+++ b/crates/intendant-display/src/wayland.rs
@@ -263,6 +263,11 @@ impl DisplayBackend for WaylandBackend {
     async fn stop_capture(&self) {
         self.shutdown.store(true, Ordering::SeqCst);
 
+        // Teardown contract: the PipeWire thread owns every sender clone of
+        // the frame channel (the process-callback clone lives in the stream
+        // listener, dropped when the thread's mainloop returns), so the join
+        // below doubles as the bounded channel-close. Taking the state makes
+        // double-stop / stop-without-start no-ops.
         if let Some(mut ps) = self.portal_session.lock().await.take() {
             if let Some(handle) = ps.pw_thread.take() {
                 // Same rationale as x11.rs: don't block the executor on

--- a/crates/intendant-display/src/windows.rs
+++ b/crates/intendant-display/src/windows.rs
@@ -493,6 +493,10 @@ impl DisplayBackend for WindowsBackend {
     async fn stop_capture(&self) {
         self.shutdown.store(true, Ordering::SeqCst);
 
+        // Teardown contract: the capture thread (GDI or DXGI loop) owns the
+        // frame channel's only sender, so the join below doubles as the
+        // bounded channel-close. Taking the state makes double-stop /
+        // stop-without-start no-ops.
         if let Some(state) = self.capture.lock().await.take() {
             // `JoinHandle::join` is blocking; pushing it onto the blocking
             // pool keeps the executor thread free (same rationale as the X11
@@ -2365,5 +2369,26 @@ mod tests {
         let got = map_normalized_to_virtualdesk_abs(0.5, 0.5, rect, (0, 0, 0, 0));
         assert!((0..=65535).contains(&got.0));
         assert!((0..=65535).contains(&got.1));
+    }
+
+    /// Real-desktop teardown-contract stress (GDI default path): fast
+    /// start/stop cycles with per-cycle bounded channel-close assertions,
+    /// plus a post-stop linger (see `crate::capture_stress`). Ignored by
+    /// default — needs an interactive desktop (skips itself cleanly on the
+    /// headless Session 0 desktop, where capture init fails loudly). Run on
+    /// operator hardware:
+    ///
+    /// ```text
+    /// cargo test -p intendant-display --lib -- --ignored real_capture_stress
+    /// ```
+    ///
+    /// Tunables: `INTENDANT_DISPLAY_STRESS_CYCLES` (default 10),
+    /// `INTENDANT_DISPLAY_STRESS_LINGER_SECS` (default 60).
+    /// `INTENDANT_WINDOWS_CAPTURE=dxgi` stresses the DXGI path instead.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "real Windows desktop capture: needs an interactive desktop; run via -- --ignored real_capture_stress on operator hardware"]
+    async fn windows_real_capture_stress_cycles() {
+        let backend = WindowsBackend::new();
+        crate::capture_stress::run_real_backend_stress(&backend).await;
     }
 }

--- a/crates/intendant-display/src/x11.rs
+++ b/crates/intendant-display/src/x11.rs
@@ -254,6 +254,10 @@ impl DisplayBackend for X11Backend {
     async fn stop_capture(&self) {
         self.shutdown.store(true, Ordering::SeqCst);
 
+        // Teardown contract: the capture thread owns the frame channel's only
+        // sender, so the join below doubles as the bounded channel-close —
+        // the receiver is guaranteed to see `None` once this returns. Taking
+        // the state also makes double-stop / stop-without-start no-ops.
         if let Some(state) = self.capture.lock().await.take() {
             // `std::thread::join()` is blocking — parking it on the tokio
             // executor thread stalls every other async task scheduled
@@ -868,5 +872,30 @@ DP-1 disconnected (normal left inverted right x axis y axis)
     fn parse_mode_token_invalid() {
         assert_eq!(parse_mode_token("primary"), (0, 0));
         assert_eq!(parse_mode_token(""), (0, 0));
+    }
+
+    /// Real-X-server teardown-contract stress: fast start/stop cycles with
+    /// per-cycle bounded channel-close assertions, plus a post-stop linger
+    /// (see `crate::capture_stress`). Ignored by default — needs a live X
+    /// display; skips itself cleanly on a Wayland-only or headless box. Run
+    /// on operator hardware:
+    ///
+    /// ```text
+    /// cargo test -p intendant-display --lib -- --ignored real_capture_stress
+    /// ```
+    ///
+    /// Tunables: `INTENDANT_DISPLAY_STRESS_CYCLES` (default 10),
+    /// `INTENDANT_DISPLAY_STRESS_LINGER_SECS` (default 60).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore = "real X11 capture: needs a live DISPLAY; run via -- --ignored real_capture_stress on operator hardware"]
+    async fn x11_real_capture_stress_cycles() {
+        let backend = match X11Backend::new() {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("[capture-stress] skipping: no X11 display available: {e}");
+                return;
+            }
+        };
+        crate::capture_stress::run_real_backend_stress(&backend).await;
     }
 }

--- a/docs/src/display-pipeline.md
+++ b/docs/src/display-pipeline.md
@@ -341,6 +341,20 @@ Windows backends in detail.
 `WAYLAND_DISPLAY` before falling back to `DISPLAY`; macOS and Windows always use
 the native backend.
 
+Every backend implements the same **capture teardown contract** (doc-commented
+on the `DisplayBackend` trait in `crates/intendant-display/src/lib.rs` — that
+doc is canonical): after `stop_capture()` returns, the frame channel closes
+within bounded time; no late captured-frame callback may touch freed state
+(each backend owns whatever quiesce its OS needs — the thread-backed backends
+join their capture thread, while macOS gates ScreenCaptureKit's unjoinable
+callback queue behind a per-session shutdown flag and sender slot, because SCK
+has been observed delivering frames ~53 s after stop); double-stop and
+stop-without-start are no-ops; and start-after-stop yields a fresh, clean
+session. The `capture_teardown_contract` tests stress the contract on
+synthetic backends in CI, and each real OS backend has an `#[ignore]`d
+start/stop stress test for operator hardware
+(`cargo test -p intendant-display --lib -- --ignored real_capture_stress`).
+
 > **Browser input is physical-key-only (Phase 1).** Injected key events use the
 > DOM `code` field (physical key position), not `key`. Non-US keyboard layouts
 > therefore produce incorrect character output until a future phase adds


### PR DESCRIPTION
## Why

On 2026-07-08 the macOS daemon segfaulted: ScreenCaptureKit delivered a frame ~53s after `stop_capture()` into handler state the screencapturekit 1.5 crate had freed on Drop. The 8.0 upgrade (24358c7d) fixed that instance, but the `DisplayBackend` trait never stated what `stop_capture()` guarantees — each platform improvised, so the same bug class could recur on any backend.

## What

**Contract** (doc-commented on the trait in `crates/intendant-display/src/lib.rs` — canonical): after `stop_capture().await` returns —
1. the frame channel closes within bounded time (receiver sees `None`);
2. no captured-frame side effect may touch freed state (backends own whatever quiesce their OS needs);
3. double-stop / stop-without-start are no-ops;
4. start-after-stop yields a fresh, clean session.

Plus: start-over-running implicitly tears down the old session, a failed start leaves no residue, and the channel may close early on source loss (`None` = capture-lost).

**Per-backend conformance audit:**
- **x11 / wayland / windows — already conforming** (pre-existing OK): the capture thread owns the channel senders and stop joins it on the blocking pool before returning, so channel-close is implied by the join. Now documented at each impl.
- **macos — two gaps fixed:**
  - Teardown state was backend-shared: `start_capture` reset the shared shutdown flag to `false`, so a late callback from a *previous* stream could pass the gate while a new session ran. The flag and the channel's only `Sender` now live per-session in `CaptureState`.
  - The `Sender` lived inside the SCK handler closure, which the OS can retain long after stop — the channel would not close for tens of seconds. `stop_capture` now empties a per-session sender slot (channel closes immediately; late callbacks find the slot empty and no-op). `SCStream` stop/drop also moved to the blocking pool (executor-stall class, same rationale as the x11 thread-join).

**Stress tests:**
- `capture_teardown_contract` (runs in CI on all platforms, headless): synthetic backend with a real producer thread, in both conformance styles — join-on-stop (x11/wayland/windows shape) and detached-callbacks (macOS shape, firing deliberate post-stop late callbacks). Covers 50-cycle churn, bounded channel-close, supersede-on-start, 40x unconsumed rapid starts, double-stop / stop-without-start, stop-after-receiver-drop.
- Per-OS `#[ignore]`d real-backend stress (macos/x11/windows): N fast start/stop cycles with per-cycle bounded-close assertions + a late-callback linger (default 60s > the observed ~53s window); skips itself cleanly where capture is unavailable. Run on operator hardware:
  `cargo test -p intendant-display --lib -- --ignored real_capture_stress`
  (Tunables: `INTENDANT_DISPLAY_STRESS_CYCLES`, `INTENDANT_DISPLAY_STRESS_LINGER_SECS`.) Wayland is excluded by design — every portal session re-prompts for approval, so it cannot run unattended.

**Dependency cleanup:** the workspace root `Cargo.toml` still listed `screencapturekit = "8.0"`; nothing under `src/` uses it since the display-pipeline extraction (only `crates/intendant-display`) — removed, workspace builds clean without it.

**Docs:** `docs/src/display-pipeline.md` gains a teardown-contract paragraph pointing at the trait doc.

## Verification

- `cargo test -p intendant-display --lib` — 491 passed (incl. the 6 new contract tests)
- `cargo nextest run --bins` — 2699 passed
- `cargo clippy -p intendant-display --all-targets` — no new warnings (16 pre-existing, none on touched lines)
- `cargo check --bins` — workspace builds without the root dep
- **Real hardware:** `macos_real_capture_stress_cycles` run on the macOS box (5 cycles, 70s linger): 5 real SCK sessions, per-cycle bounded channel-close held, no late-callback crash, fresh session after the linger — passed in 72.75s.
