### PR TITLE
IAM alignment: tunnel and HTTP lanes agree on the two divergent session-read methods

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1900,10 +1900,10 @@ family (sub-routes elided where the family is uniform):
 | `WS /` or `WS /ws` | Main WebSocket: events, fallback Shell terminal I/O, presence protocol, WebRTC signaling |
 | `GET /api/sessions` | List past sessions (`/stream` NDJSON variant, `/search` full-text) |
 | `GET /api/session/{id}/*` | Per-session detail, report, log replay, context snapshots, recordings, frame assets |
-| `POST /api/session/{id}/agent-output` | Append agent output for a historical/session-scoped backend transcript |
+| `POST /api/session/{id}/agent-output` | Fetch persisted agent output by id for a historical/session-scoped transcript (POST-shaped read: the ids ride the body) |
 | `DELETE /api/session/{id}[/{target}]`, `POST /api/session/{id}/delete[/{target}]` | Delete archived session data (native DELETE plus WKWebView fallback) |
 | `GET /api/session/current/history`, `GET /api/session/current/changes[/*]` | Current-session reads: serialized history and file-change list/detail |
-| `POST /api/session/current/{rollback,redo,prune,agent-output}` | Current-session mutations: history rollback/redo/prune and active-session agent-output append |
+| `POST /api/session/current/{rollback,redo,prune,agent-output}` | Current-session actions: history rollback/redo/prune mutations, plus the POST-shaped agent-output fetch |
 | `GET /api/session/current/uploads[/*]`, `POST /api/session/current/uploads`, `DELETE /api/session/current/uploads/{id}` | Task attachment store: list, upload, raw fetch, delete |
 | `GET /api/managed-context/{records,anchors,fission}` | Managed-context state: rewind records, anchors, fission groups |
 | `GET /recordings/*`, `GET /frames/*` | Current-session recording segments and captured frame assets |
@@ -1947,7 +1947,7 @@ its operation per method/path from `federation_http_operation`.
 | POST | `/api/session/current/rollback` | SessionManage | own origin | bounded | Roll the current session back to a round (optionally reverting files) |
 | POST | `/api/session/current/redo` | SessionManage | own origin | bounded | Redo the last rolled-back round |
 | POST | `/api/session/current/prune` | SessionManage | own origin | bounded | Prune rollback state for the current session |
-| POST | `/api/session/current/agent-output` | SessionManage | own origin | bounded | Append agent output to the current session's log |
+| POST | `/api/session/current/agent-output` | SessionManage | own origin | bounded | Fetch the current session's persisted agent output by id (POST-shaped read) |
 | POST | `/api/session/current/uploads` | SessionManage | own origin | streaming | Upload a file attachment (raw streamed body; name/destination in query) |
 | GET | `/api/session/current/uploads[/…]` | SessionManage | own origin | none | List uploads, or fetch one (subpath {id}/raw) |
 | DELETE | `/api/session/current/uploads/{upload_id}` | SessionManage | own origin | none | Delete one upload (file + sidecar) |
@@ -1956,7 +1956,7 @@ its operation per method/path from `federation_http_operation`.
 | DELETE | `/api/session/{id}/{target}/delete` | SessionManage | own origin | none | Delete one data kind for a session (suffix form) |
 | POST | `/api/session/{id}/delete` | SessionManage | own origin | none | Delete a session's data (POST fallback for WKWebView) |
 | POST | `/api/session/{id}/{target}/delete` | SessionManage | own origin | none | Delete one data kind for a session (POST fallback) |
-| POST | `/api/session/{id}/agent-output` | SessionManage | own origin | bounded | Append agent output to a session's log by id |
+| POST | `/api/session/{id}/agent-output` | SessionInspect | own origin | bounded | Fetch a session's persisted agent output by id (POST-shaped read) |
 | GET | `/api/session/current[/…]` | SessionManage | own origin | none | Current-session detail and artifact sub-routes |
 | POST | `/api/session/current[/…]` | SessionManage | own origin | none | Current-session detail sub-routes (POST fallback callers) |
 | GET | `/api/session[/…]` | SessionInspect | own origin | none | Session detail; context-snapshot, recordings (+segments/playlist), report zip, frames |

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -243,7 +243,21 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
     method("api_sessions_stream", PeerOperation::SessionInspect),
     method("api_session_detail", PeerOperation::SessionInspect),
     method("api_session_report", PeerOperation::SessionInspect),
+    // Fetches persisted stdout/stderr chunks by output id — a pure
+    // session-log read, inspect-grade like the neighboring by-id reads.
+    // Keep equal to the HTTP twin row (POST /api/session/{id}/agent-output;
+    // POST-shaped only because the ids ride the body) until transport
+    // unification derives tunnel ops from the route rows — pinned by
+    // `formerly_divergent_twins_gate_identically_on_both_lanes`.
     method("api_session_agent_output", PeerOperation::SessionInspect),
+    // Replays one archived context snapshot out of the session log — a
+    // pure read; inspect-grade to match the HTTP twin (the GET
+    // /api/session sub-router row serving {id}/context-snapshot). It was
+    // originally mis-grouped with the manage-gated mutations below. Keep
+    // equal to the route row until transport unification derives tunnel
+    // ops from the rows — pinned by
+    // `formerly_divergent_twins_gate_identically_on_both_lanes`.
+    method("api_session_context_snapshot", PeerOperation::SessionInspect),
     method("api_sessions_search", PeerOperation::SessionInspect),
     method("api_session_recordings", PeerOperation::SessionInspect),
     method("api_session_recording_asset", PeerOperation::SessionInspect),
@@ -266,7 +280,6 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
         "api_session_current_agent_output",
         PeerOperation::SessionManage,
     ),
-    method("api_session_context_snapshot", PeerOperation::SessionManage),
     method("api_session_control_msg", PeerOperation::SessionManage),
     method("api_worktrees_scan", PeerOperation::SessionManage),
     method("api_worktrees_remove", PeerOperation::SessionManage),
@@ -2978,6 +2991,47 @@ mod tests {
             method_operation("api_transfer_upload_chunk"),
             Some(PeerOperation::FilesystemWrite)
         );
+    }
+
+    /// The two methods whose tunnel rows historically diverged from their
+    /// HTTP route rows are pinned equal across BOTH lanes. Their handlers
+    /// are pure session-log reads (`session_agent_output_post_response`
+    /// fetches persisted output chunks by id;
+    /// `session_context_snapshot_response_body` replays one archived
+    /// snapshot), so both lanes gate them inspect-grade. Transport
+    /// unification will derive the tunnel op from the route row and make
+    /// this drift class unrepresentable; until then this test is the pin
+    /// — if either declaration moves, move its twin in the same commit.
+    #[test]
+    fn formerly_divergent_twins_gate_identically_on_both_lanes() {
+        use crate::gateway_routes::{classify, TableClassification};
+        use crate::peer::access_policy::PeerOperation;
+        for (method, http_method, http_path) in [
+            (
+                "api_session_agent_output",
+                "POST",
+                "/api/session/abc123/agent-output",
+            ),
+            (
+                "api_session_context_snapshot",
+                "GET",
+                "/api/session/abc123/context-snapshot",
+            ),
+        ] {
+            let tunnel_op = method_operation(method);
+            assert_eq!(
+                tunnel_op,
+                Some(PeerOperation::SessionInspect),
+                "{method}: session-log reads are inspect-grade"
+            );
+            let TableClassification::Matched(route_op) = classify(http_method, http_path) else {
+                panic!("{http_method} {http_path} must classify via the route table");
+            };
+            assert_eq!(
+                tunnel_op, route_op,
+                "{method} must gate identically on the tunnel and on {http_method} {http_path}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -472,13 +472,16 @@ pub(crate) static ROUTES: &[Route] = &[
         RouteHandlerId::CurrentPrune,
         "Prune rollback state for the current session",
     ),
+    // POST-shaped read (the body carries output ids; nothing is written).
+    // Manage-gated only because the whole current/* family deliberately
+    // is (see the sub-router comment below), not because it mutates.
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/session/current/agent-output"),
         PeerOperation::SessionManage,
         BodyPolicy::Default,
         RouteHandlerId::CurrentAgentOutput,
-        "Append agent output to the current session's log",
+        "Fetch the current session's persisted agent output by id (POST-shaped read)",
     ),
     op_route(
         RouteMethod::Post,
@@ -570,6 +573,16 @@ pub(crate) static ROUTES: &[Route] = &[
         RouteHandlerId::SessionDelete,
         "Delete one data kind for a session (POST fallback)",
     ),
+    // POST-shaped read: the body carries output ids and the handler
+    // (`session_agent_output_post_response`) only fetches persisted
+    // stdout/stderr chunks back out of the session's log — nothing is
+    // appended, so it is inspect-grade like every other by-id session
+    // read. The legacy verb-shaped classifier (POST under /api/session ⇒
+    // manage) mis-tagged it and diverged from the tunnel twin
+    // `api_session_agent_output`. Keep the two lanes' operations equal
+    // (pinned by dashboard_control's
+    // `formerly_divergent_twins_gate_identically_on_both_lanes`) until
+    // transport unification derives the tunnel op from this row.
     op_route(
         RouteMethod::Post,
         PathPattern::Segments(
@@ -579,10 +592,10 @@ pub(crate) static ROUTES: &[Route] = &[
                 SegmentSpec::Literal("agent-output"),
             ],
         ),
-        PeerOperation::SessionManage,
+        PeerOperation::SessionInspect,
         BodyPolicy::Default,
         RouteHandlerId::SessionAgentOutput,
-        "Append agent output to a session's log by id",
+        "Fetch a session's persisted agent output by id (POST-shaped read)",
     ),
     // ── Session detail + artifacts sub-router. Method-explicit ports of
     //    the method-blind legacy catch-all: the classifier's historical
@@ -1699,6 +1712,27 @@ mod tests {
             classify("GET", "/api/definitely-not-a-route"),
             TableClassification::NoMatch
         ));
+        // The formerly-divergent dashboard twins classify inspect-grade:
+        // both are pure session-log reads (agent-output is POST-shaped
+        // only because the output ids ride the body). The tunnel lane is
+        // pinned equal by dashboard_control's
+        // `formerly_divergent_twins_gate_identically_on_both_lanes`;
+        // transport unification will replace both pins with derivation.
+        for (method, path) in [
+            ("POST", "/api/session/abc123/agent-output"),
+            ("GET", "/api/session/abc123/context-snapshot"),
+        ] {
+            match classify(method, path) {
+                TableClassification::Matched(op) => assert_eq!(
+                    op,
+                    Some(PeerOperation::SessionInspect),
+                    "{method} {path} is a read and must classify inspect-grade"
+                ),
+                TableClassification::NoMatch => {
+                    panic!("{method} {path} must classify via table")
+                }
+            }
+        }
     }
 
     /// The docs chapter's generated endpoint table must equal the one


### PR DESCRIPTION
Stage S0 of the transport-unification program (task #14): the datachannel tunnel's `CONTROL_METHODS` and the HTTP `gateway_routes::ROUTES` disagreed on the IAM operation class for two twinned methods. Both are now aligned on the class their handlers' actual semantics dictate, and both lanes are pinned equal by tests until the program derives tunnel ops from route rows.

## Before / after

| Method / route | Tunnel before | HTTP before | Both lanes after |
|---|---|---|---|
| `api_session_agent_output` / `POST /api/session/{id}/agent-output` | SessionInspect | SessionManage | **SessionInspect** |
| `api_session_context_snapshot` / `GET /api/session/{id}/context-snapshot` | SessionManage | SessionInspect | **SessionInspect** |

## Why Inspect (including where this diverges from the design doc)

The design note for this stage assumed `api_session_agent_output` **appends** to a session's log and recommended retagging the tunnel to SessionManage. Independent verification refutes the premise: the handler chain (`session_agent_output_post_response` → `session_agent_output_response_for_ids` → `agent_output_chunks_by_id`) only parses output **ids** from the body and reads persisted stdout/stderr chunks back out of `session.jsonl` and its span files. Nothing is written anywhere in the chain. The endpoint exists so the dashboard can lazy-load full command output that the live event stream truncates (introduced by "Load full dashboard tool output lazily"; the SPA caller is `fetchSessionAgentOutputPayload`; the handler's own unit test is named `agent_output_post_response_reads_json_ids`). It is POST-shaped only because the id list rides the request body.

Provenance of the divergence: the HTTP Manage tag was inherited mechanically from the legacy verb-shaped classifier (`POST` under `/api/session` ⇒ manage) and carried into the route table byte-stable by the phase-1 port, which also introduced the false "Append agent output…" row description. The tunnel's Inspect tag was the deliberate semantic choice, grouping it with the other by-id session reads when the method→operation ladder was introduced.

`api_session_context_snapshot` is the mirror case and matches the design note's recommendation: `session_context_snapshot_response_body` replays one archived context snapshot from the session log — a pure read whose HTTP twin already rides the Inspect GET sub-router row. Its tunnel Manage tag came from positional grouping with the `current/*` mutations in that same ladder.

The fail-closed tiebreak ("stricter wins") applies to genuine ambiguity; neither handler is ambiguous — both are verifiably read-only. Tagging a read as Manage is not "safe": the `SessionReader`/`SharedSessionSpectator` role ceilings allow exactly `SessionInspect`, so a Manage tag denies read-scoped grants a read they are meant to have (over plain HTTP today, a session-reader grant 403s on lazy output load that the tunnel serves) — while every sibling by-id session read (detail, report, log replay, recordings, frame assets) is already Inspect on both lanes. Baking Manage into the future row-derived tunnel op would have converted the misclassification into a tunnel regression for those grants.

## What is deliberately not changed

`POST /api/session/current/agent-output` stays SessionManage on both lanes: same read semantics, but the `current/*` family is manage-gated on every method as a documented historical split, and it has no cross-lane divergence. Only its false "Append…" description is corrected (with a row comment noting the gate is the family split, not mutation).

## Drift pins until derivation

- `dashboard_control::tests::formerly_divergent_twins_gate_identically_on_both_lanes` — asserts tunnel op == route-table classification for both methods (and pins Inspect).
- `gateway_routes::tests::classify_maps_authz_to_operations` — pins both HTTP paths to Inspect.
- Table-row comments on all touched declarations point at the twin and at the coming single-source derivation.
- Docs endpoint table regenerated (`endpoint_docs_match_chapter` green); the narrative rows repeating the append myth corrected.

Verification: `cargo nextest run --bins` full suite green (2700 passed), `cargo check --bins`, clippy clean of new warnings.

Draft on purpose: auto-merge NOT armed — the agent-output resolution contradicts the design note's recommendation and awaits owner sign-off.