### PR TITLE
Projectless daemons: daemon-global fallback store for staged uploads and durable transfers (Wave 1F)

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -50,7 +50,7 @@ for the headless `tests/e2e/` suite and demos) and requires
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `INTENDANT_HOME` | `~/.intendant` | Overrides the daemon state root — the one directory holding session logs, the session-index cache, recordings, quarantine, leased credentials, access certs, the service pidfile, and the rest of the machine-local daemon state. The value is used verbatim as the root (no `.intendant` component is appended); a relative path resolves against the startup directory. Read once at first use and fixed for the process lifetime. Useful for scratch daemons and hermetic harnesses. Locations that are deliberately *not* under the state root are unaffected: project-local `.intendant/` directories, external-agent homes (`~/.codex`, `~/.claude`), and the platform-data-dir daemon identity key. |
+| `INTENDANT_HOME` | `~/.intendant` | Overrides the daemon state root — the one directory holding session logs, the session-index cache, recordings, quarantine, leased credentials, access certs, the service pidfile, the projectless upload/transfer global store (`global-store/`, pruned after 14 idle days at daemon startup), and the rest of the machine-local daemon state. The value is used verbatim as the root (no `.intendant` component is appended); a relative path resolves against the startup directory. Read once at first use and fixed for the process lifetime. Useful for scratch daemons and hermetic harnesses. Locations that are deliberately *not* under the state root are unaffected: project-local `.intendant/` directories, external-agent homes (`~/.codex`, `~/.claude`), and the platform-data-dir daemon identity key. |
 
 ### Model and behavior tuning
 

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -488,6 +488,17 @@ summary uses the same access abstraction as Terminal: local/mTLS, hosted
 transports, and peer dashboard-control routes are shown as targets with their
 available capabilities rather than as transport internals.
 
+The daemon-side durable state behind this surface — staged uploads
+(`uploads/<session-id>/` blob + sidecar) and transfer job metadata
+(`transfers/jobs`, plus daemon-materialized `transfers/artifacts`) — lives
+under `<project>/.intendant/` on project-rooted daemons. A **projectless
+daemon** (the macOS app daemon, or any `intendant` launched from a directory
+with no project marker) serves the same endpoints from a daemon-global
+fallback store at `~/.intendant/global-store/` with an identical layout; a
+project root, when present, always wins. The global store is pruned on
+daemon startup: upload session dirs, job files, and materialized artifacts
+idle for more than 14 days are removed (project stores are never pruned).
+
 The **Editor** sub-tab is a full-bleed workbench: a slim toolbar (target
 picker + one-line route summary + new file/folder), a lazy directory tree
 rail on the left (rooted at the project root locally, `~` on peers;

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -702,19 +702,7 @@ pub(crate) async fn api_session_current_upload_raw_task_response(
             };
         }
     };
-    let Some(root) = runtime.project_root.clone() else {
-        return ControlTaskResponse {
-            id: id.clone(),
-            frame: http_body_response(
-                id,
-                404,
-                serde_json::json!({ "ok": false, "error": "no project root" }).to_string(),
-                "upload raw",
-            ),
-            byte_stream: None,
-            done: true,
-        };
-    };
+    let scope = crate::global_store::StoreScope::resolve(runtime.project_root.as_deref());
     let session_log = {
         let session = runtime.shared_session.read().await;
         session.session_log.clone()
@@ -724,7 +712,7 @@ pub(crate) async fn api_session_current_upload_raw_task_response(
             .lock()
             .map(|log| log.dir().to_path_buf())
             .map_err(|_| "session log lock poisoned".to_string()),
-        None => Ok(crate::web_gateway::pending_upload_session_dir(&root)),
+        None => Ok(crate::web_gateway::pending_upload_session_dir(&scope)),
     };
     let session_dir = match session_dir_result {
         Ok(session_dir) => session_dir,
@@ -744,7 +732,7 @@ pub(crate) async fn api_session_current_upload_raw_task_response(
     };
     let upload_id_for_stream = upload_id.clone();
     let read_result = tokio::task::spawn_blocking(move || {
-        let Some(descriptor) = crate::upload_store::find_upload(&upload_id, &session_dir, &root)
+        let Some(descriptor) = crate::upload_store::find_upload(&upload_id, &session_dir, &scope)
         else {
             return Err((
                 404,
@@ -887,18 +875,11 @@ pub(crate) async fn api_session_current_uploads_response(
             );
         }
     };
-    let Some(root) = project_root else {
-        return http_body_response(
-            id,
-            404,
-            serde_json::json!({ "error": "no project root" }).to_string(),
-            "current uploads",
-        );
-    };
+    let scope = crate::global_store::StoreScope::resolve(project_root.as_deref());
     let session_dir =
-        session_dir.unwrap_or_else(|| crate::web_gateway::pending_upload_session_dir(&root));
+        session_dir.unwrap_or_else(|| crate::web_gateway::pending_upload_session_dir(&scope));
     let result = tokio::task::spawn_blocking(move || {
-        serde_json::to_string(&crate::upload_store::list_uploads(&session_dir, &root))
+        serde_json::to_string(&crate::upload_store::list_uploads(&session_dir, &scope))
             .unwrap_or_else(|_| "[]".to_string())
     })
     .await;
@@ -1253,7 +1234,7 @@ pub(crate) async fn api_sessions_search_response(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dashboard_control::tests::{runtime};
+    use crate::dashboard_control::tests::runtime;
 
     #[tokio::test]
     async fn session_report_rpc_returns_zip_for_active_log() {
@@ -1370,6 +1351,8 @@ mod tests {
 
     #[tokio::test]
     async fn current_upload_delete_preserves_http_status() {
+        // Projectless daemons resolve the daemon-global store instead of
+        // refusing; deleting an id that is not there stays idempotent-ok.
         let rt_no_root = runtime();
         let no_root = api_session_current_upload_delete_response(
             "upl1".to_string(),
@@ -1379,9 +1362,8 @@ mod tests {
         .await;
         assert_eq!(no_root["t"], "response");
         assert_eq!(no_root["ok"], true);
-        assert_eq!(no_root["result"]["error"], "no project root");
-        assert_eq!(no_root["result"]["_httpStatus"], 404);
-        assert_eq!(no_root["result"]["_httpOk"], false);
+        assert_eq!(no_root["result"]["_httpStatus"], 200);
+        assert_eq!(no_root["result"]["_httpOk"], true);
 
         let dir = tempfile::tempdir().unwrap();
         let rt = runtime();
@@ -1514,6 +1496,69 @@ mod tests {
             invalid.frame["result"]["error"],
             "range start beyond upload size"
         );
+    }
+
+    /// Route-level proof for projectless daemons (task "Wave 1F"): with no
+    /// project root anywhere, a staged upload POST commits into the
+    /// daemon-global store and the raw read streams the same bytes back.
+    /// Fixture writes go through the process state root (the live
+    /// `~/.intendant` in bin unit tests — same convention as the
+    /// session-frame transfer test), so the session id is unique per run
+    /// and the store dir is removed afterwards.
+    #[tokio::test]
+    async fn projectless_staged_upload_posts_and_reads_raw_from_global_store() {
+        let mut rt = runtime();
+        assert!(rt.project_root.is_none());
+        rt.session_id = format!(
+            "projectless-upload-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let session_store_dir = crate::global_store::global_store_root()
+            .join("uploads")
+            .join(&rt.session_id);
+
+        let bytes = b"projectless staged upload bytes";
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), bytes).unwrap();
+
+        // POST: commit with no project root resolves the global store.
+        let (status, body) = crate::web_gateway::current_upload_commit_response_body(
+            None,
+            None,
+            Some(rt.session_id.as_str()),
+            "projectless.txt",
+            "text/plain",
+            crate::upload_store::UploadDestination::Task,
+            tmp,
+            bytes.len(),
+            &rt.bus,
+        );
+        assert_eq!(status, "200 OK");
+        let descriptor: crate::upload_store::UploadDescriptor =
+            serde_json::from_str(&body).unwrap();
+        assert!(
+            descriptor.path.starts_with(&session_store_dir),
+            "projectless upload must land in the global store, got {}",
+            descriptor.path.display()
+        );
+
+        // Raw GET: the projectless runtime resolves the same store.
+        let response = api_session_current_upload_raw_task_response(
+            "projectless-raw".to_string(),
+            Some(&serde_json::json!({ "id": descriptor.id })),
+            &rt,
+        )
+        .await;
+        let cleanup = std::fs::remove_dir_all(&session_store_dir);
+        assert!(response.done);
+        let stream = response.byte_stream.expect("raw read must stream bytes");
+        assert_eq!(stream.bytes, bytes);
+        assert_eq!(stream.result["ok"], true);
+        assert_eq!(stream.result["id"], descriptor.id);
+        cleanup.expect("global-store session dir cleanup");
     }
 
     #[tokio::test]

--- a/src/bin/caller/dashboard_control/api_transfers_fs.rs
+++ b/src/bin/caller/dashboard_control/api_transfers_fs.rs
@@ -5,13 +5,12 @@
 
 use super::*;
 
-pub(crate) fn transfer_project_root(runtime: &ControlRuntime) -> Result<PathBuf, serde_json::Value> {
-    runtime.project_root.clone().ok_or_else(|| {
-        serde_json::json!({
-            "ok": false,
-            "error": "project root unavailable",
-        })
-    })
+/// Resolve where transfer jobs persist for this daemon: the project store
+/// when a project root exists, the daemon-global fallback store otherwise
+/// (see `global_store.rs`). Infallible — projectless daemons are served,
+/// not refused.
+pub(crate) fn transfer_store_scope(runtime: &ControlRuntime) -> crate::global_store::StoreScope {
+    crate::global_store::StoreScope::resolve(runtime.project_root.as_deref())
 }
 
 pub(crate) fn transfer_http_error_response(
@@ -73,7 +72,7 @@ pub(crate) fn transfer_artifact_type(artifact: &serde_json::Value) -> String {
 }
 
 pub(crate) async fn transfer_create_download_job_from_params(
-    project_root: PathBuf,
+    scope: crate::global_store::StoreScope,
     params: serde_json::Value,
     runtime: &ControlRuntime,
 ) -> Result<crate::transfer_store::TransferJob, crate::transfer_store::TransferStoreError> {
@@ -82,7 +81,7 @@ pub(crate) async fn transfer_create_download_job_from_params(
         .filter(|value| value.is_object())
         .cloned()
     {
-        return transfer_create_artifact_download_job(project_root, artifact, runtime).await;
+        return transfer_create_artifact_download_job(scope, artifact, runtime).await;
     }
     let path = string_param(&params, &["path", "source_path", "sourcePath", "source"]);
     if path.is_empty() {
@@ -91,15 +90,13 @@ pub(crate) async fn transfer_create_download_job_from_params(
             "missing path",
         ));
     }
-    tokio::task::spawn_blocking(move || {
-        crate::transfer_store::create_download_job(&project_root, &path)
-    })
-    .await
-    .map_err(|e| transfer_store_task_error(e, "transfer create"))?
+    tokio::task::spawn_blocking(move || crate::transfer_store::create_download_job(&scope, &path))
+        .await
+        .map_err(|e| transfer_store_task_error(e, "transfer create"))?
 }
 
 pub(crate) async fn transfer_create_upload_job_from_params(
-    project_root: PathBuf,
+    scope: crate::global_store::StoreScope,
     params: serde_json::Value,
 ) -> Result<crate::transfer_store::TransferJob, crate::transfer_store::TransferStoreError> {
     let destination = string_param(
@@ -158,7 +155,7 @@ pub(crate) async fn transfer_create_upload_job_from_params(
             })?;
     tokio::task::spawn_blocking(move || {
         crate::transfer_store::create_upload_job(
-            &project_root,
+            &scope,
             &destination,
             &original_name,
             &mime,
@@ -171,27 +168,25 @@ pub(crate) async fn transfer_create_upload_job_from_params(
 }
 
 pub(crate) async fn transfer_create_artifact_download_job(
-    project_root: PathBuf,
+    scope: crate::global_store::StoreScope,
     artifact: serde_json::Value,
     runtime: &ControlRuntime,
 ) -> Result<crate::transfer_store::TransferJob, crate::transfer_store::TransferStoreError> {
     match transfer_artifact_type(&artifact).as_str() {
         "session_report" | "session-report" => {
-            transfer_create_session_report_download_job(project_root, artifact, runtime).await
+            transfer_create_session_report_download_job(scope, artifact, runtime).await
         }
         "staged_upload" | "staged-upload" | "upload" => {
-            transfer_create_staged_upload_download_job(project_root, artifact, runtime).await
+            transfer_create_staged_upload_download_job(scope, artifact, runtime).await
         }
         "recording_asset" | "recording-asset" => {
-            transfer_create_recording_asset_download_job(project_root, artifact, runtime, false)
-                .await
+            transfer_create_recording_asset_download_job(scope, artifact, runtime, false).await
         }
         "session_recording_asset" | "session-recording-asset" => {
-            transfer_create_recording_asset_download_job(project_root, artifact, runtime, true)
-                .await
+            transfer_create_recording_asset_download_job(scope, artifact, runtime, true).await
         }
         "session_frame_asset" | "session-frame-asset" | "frame_asset" | "frame-asset" => {
-            transfer_create_session_frame_download_job(project_root, artifact).await
+            transfer_create_session_frame_download_job(scope, artifact).await
         }
         "" => Err(crate::transfer_store::TransferStoreError::new(
             400,
@@ -205,7 +200,7 @@ pub(crate) async fn transfer_create_artifact_download_job(
 }
 
 pub(crate) async fn transfer_create_session_report_download_job(
-    project_root: PathBuf,
+    scope: crate::global_store::StoreScope,
     artifact: serde_json::Value,
     runtime: &ControlRuntime,
 ) -> Result<crate::transfer_store::TransferJob, crate::transfer_store::TransferStoreError> {
@@ -243,7 +238,7 @@ pub(crate) async fn transfer_create_session_report_download_job(
     })?;
     tokio::task::spawn_blocking(move || {
         crate::transfer_store::create_download_job_from_bytes(
-            &project_root,
+            &scope,
             report.bytes,
             &report.filename,
             "application/zip",
@@ -257,7 +252,7 @@ pub(crate) async fn transfer_create_session_report_download_job(
 }
 
 pub(crate) async fn transfer_create_staged_upload_download_job(
-    project_root: PathBuf,
+    scope: crate::global_store::StoreScope,
     artifact: serde_json::Value,
     runtime: &ControlRuntime,
 ) -> Result<crate::transfer_store::TransferJob, crate::transfer_store::TransferStoreError> {
@@ -271,16 +266,22 @@ pub(crate) async fn transfer_create_staged_upload_download_job(
     let (upload_root, session_dir) = active_upload_handles(runtime)
         .await
         .map_err(|error| crate::transfer_store::TransferStoreError::new(500, error))?;
-    let upload_root = upload_root.unwrap_or_else(|| project_root.clone());
-    let session_dir =
-        session_dir.unwrap_or_else(|| crate::web_gateway::pending_upload_session_dir(&upload_root));
+    // The staged upload may live under the active session's project store
+    // (when one is set) rather than the daemon's own; without either, both
+    // resolve to the daemon-global store.
+    let upload_scope = match upload_root {
+        Some(root) => crate::global_store::StoreScope::Project(root),
+        None => scope.clone(),
+    };
+    let session_dir = session_dir
+        .unwrap_or_else(|| crate::web_gateway::pending_upload_session_dir(&upload_scope));
     tokio::task::spawn_blocking(move || {
-        let descriptor = crate::upload_store::find_upload(&upload_id, &session_dir, &upload_root)
+        let descriptor = crate::upload_store::find_upload(&upload_id, &session_dir, &upload_scope)
             .ok_or_else(|| {
-            crate::transfer_store::TransferStoreError::new(404, "upload not found")
-        })?;
+                crate::transfer_store::TransferStoreError::new(404, "upload not found")
+            })?;
         crate::transfer_store::create_download_job_from_path(
-            &project_root,
+            &scope,
             descriptor.path.clone(),
             Some(descriptor.name.clone()),
             Some(descriptor.mime.clone()),
@@ -294,7 +295,7 @@ pub(crate) async fn transfer_create_staged_upload_download_job(
 }
 
 pub(crate) async fn transfer_create_recording_asset_download_job(
-    project_root: PathBuf,
+    scope: crate::global_store::StoreScope,
     artifact: serde_json::Value,
     runtime: &ControlRuntime,
     session_scoped: bool,
@@ -341,11 +342,11 @@ pub(crate) async fn transfer_create_recording_asset_download_job(
     .map_err(|(status, body)| {
         crate::transfer_store::TransferStoreError::new(status, transfer_json_error_message(&body))
     })?;
-    transfer_create_recording_asset_job(project_root, artifact, stream_name, asset, resolved).await
+    transfer_create_recording_asset_job(scope, artifact, stream_name, asset, resolved).await
 }
 
 pub(crate) async fn transfer_create_recording_asset_job(
-    project_root: PathBuf,
+    scope: crate::global_store::StoreScope,
     artifact: serde_json::Value,
     stream_name: String,
     asset: String,
@@ -358,7 +359,7 @@ pub(crate) async fn transfer_create_recording_asset_job(
             filename,
         } => tokio::task::spawn_blocking(move || {
             crate::transfer_store::create_download_job_from_bytes(
-                &project_root,
+                &scope,
                 bytes,
                 &filename,
                 content_type,
@@ -375,7 +376,7 @@ pub(crate) async fn transfer_create_recording_asset_job(
             filename,
         } => tokio::task::spawn_blocking(move || {
             crate::transfer_store::create_download_job_from_path(
-                &project_root,
+                &scope,
                 path,
                 Some(filename),
                 Some(content_type.to_string()),
@@ -390,7 +391,7 @@ pub(crate) async fn transfer_create_recording_asset_job(
 }
 
 pub(crate) async fn transfer_create_session_frame_download_job(
-    project_root: PathBuf,
+    scope: crate::global_store::StoreScope,
     artifact: serde_json::Value,
 ) -> Result<crate::transfer_store::TransferJob, crate::transfer_store::TransferStoreError> {
     let session_id = string_param(&artifact, &["session_id", "sessionId", "id"]);
@@ -426,7 +427,7 @@ pub(crate) async fn transfer_create_session_frame_download_job(
     };
     tokio::task::spawn_blocking(move || {
         crate::transfer_store::create_download_job_from_path(
-            &project_root,
+            &scope,
             path,
             Some(filename.clone()),
             Some(content_type.to_string()),
@@ -439,13 +440,13 @@ pub(crate) async fn transfer_create_session_frame_download_job(
     .map_err(|e| transfer_store_task_error(e, "session frame transfer"))?
 }
 
-pub(crate) async fn api_transfer_jobs_response(id: String, runtime: &ControlRuntime) -> serde_json::Value {
-    let project_root = match transfer_project_root(runtime) {
-        Ok(project_root) => project_root,
-        Err(body) => return http_body_response(id, 404, body.to_string(), "transfer jobs"),
-    };
+pub(crate) async fn api_transfer_jobs_response(
+    id: String,
+    runtime: &ControlRuntime,
+) -> serde_json::Value {
+    let scope = transfer_store_scope(runtime);
     let result =
-        tokio::task::spawn_blocking(move || crate::transfer_store::list_jobs(&project_root)).await;
+        tokio::task::spawn_blocking(move || crate::transfer_store::list_jobs(&scope)).await;
     let jobs = match result {
         Ok(jobs) => jobs,
         Err(e) => {
@@ -474,10 +475,7 @@ pub(crate) async fn api_transfer_job_create_response(
     params: Option<&serde_json::Value>,
     runtime: &ControlRuntime,
 ) -> serde_json::Value {
-    let project_root = match transfer_project_root(runtime) {
-        Ok(project_root) => project_root,
-        Err(body) => return http_body_response(id, 404, body.to_string(), "transfer create"),
-    };
+    let scope = transfer_store_scope(runtime);
     let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
     let kind = string_param(&params, &["kind", "type"]);
     let kind = match crate::transfer_store::TransferKind::from_str(&kind.to_ascii_lowercase()) {
@@ -493,10 +491,10 @@ pub(crate) async fn api_transfer_job_create_response(
     };
     let result = match kind {
         crate::transfer_store::TransferKind::Download => {
-            transfer_create_download_job_from_params(project_root, params, runtime).await
+            transfer_create_download_job_from_params(scope, params, runtime).await
         }
         crate::transfer_store::TransferKind::Upload => {
-            transfer_create_upload_job_from_params(project_root, params).await
+            transfer_create_upload_job_from_params(scope, params).await
         }
     };
     match result {
@@ -519,19 +517,15 @@ pub(crate) async fn api_transfer_job_delete_response(
     params: Option<&serde_json::Value>,
     runtime: &ControlRuntime,
 ) -> serde_json::Value {
-    let project_root = match transfer_project_root(runtime) {
-        Ok(project_root) => project_root,
-        Err(body) => return http_body_response(id, 404, body.to_string(), "transfer delete"),
-    };
+    let scope = transfer_store_scope(runtime);
     let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
     let job_id = transfer_id_param(&params);
     if job_id.is_empty() {
         return transfer_http_error_response(id, 400, "missing id", "transfer delete");
     }
-    let result = tokio::task::spawn_blocking(move || {
-        crate::transfer_store::delete_job(&project_root, &job_id)
-    })
-    .await;
+    let result =
+        tokio::task::spawn_blocking(move || crate::transfer_store::delete_job(&scope, &job_id))
+            .await;
     match result {
         Ok(Ok(deleted)) => http_body_response(
             id,
@@ -558,19 +552,14 @@ pub(crate) async fn api_transfer_upload_commit_response(
     params: Option<&serde_json::Value>,
     runtime: &ControlRuntime,
 ) -> serde_json::Value {
-    let project_root = match transfer_project_root(runtime) {
-        Ok(project_root) => project_root,
-        Err(body) => {
-            return http_body_response(id, 404, body.to_string(), "transfer upload commit")
-        }
-    };
+    let scope = transfer_store_scope(runtime);
     let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
     let job_id = transfer_id_param(&params);
     if job_id.is_empty() {
         return transfer_http_error_response(id, 400, "missing id", "transfer upload commit");
     }
     let result = tokio::task::spawn_blocking(move || {
-        crate::transfer_store::commit_upload_job(&project_root, &job_id)
+        crate::transfer_store::commit_upload_job(&scope, &job_id)
     })
     .await;
     match result {
@@ -599,17 +588,7 @@ pub(crate) async fn api_transfer_upload_chunk_task_response(
     upload: InboundUploadState,
     runtime: ControlRuntime,
 ) -> ControlTaskResponse {
-    let project_root = match transfer_project_root(&runtime) {
-        Ok(project_root) => project_root,
-        Err(body) => {
-            return ControlTaskResponse {
-                id: id.clone(),
-                frame: http_body_response(id, 404, body.to_string(), "transfer upload chunk"),
-                byte_stream: None,
-                done: true,
-            };
-        }
-    };
+    let scope = transfer_store_scope(&runtime);
     let job_id = transfer_id_param(&upload.params);
     if job_id.is_empty() {
         return ControlTaskResponse {
@@ -633,11 +612,7 @@ pub(crate) async fn api_transfer_upload_chunk_task_response(
     let chunk_len = upload.received_bytes as u64;
     let result = tokio::task::spawn_blocking(move || {
         crate::transfer_store::append_upload_tempfile(
-            &project_root,
-            &job_id,
-            offset,
-            upload.tmp,
-            chunk_len,
+            &scope, &job_id, offset, upload.tmp, chunk_len,
         )
     })
     .await;
@@ -673,17 +648,7 @@ pub(crate) async fn api_transfer_download_read_task_response(
     params: Option<&serde_json::Value>,
     runtime: &ControlRuntime,
 ) -> ControlTaskResponse {
-    let project_root = match transfer_project_root(runtime) {
-        Ok(project_root) => project_root,
-        Err(body) => {
-            return ControlTaskResponse {
-                id: id.clone(),
-                frame: http_body_response(id, 404, body.to_string(), "transfer download"),
-                byte_stream: None,
-                done: true,
-            };
-        }
-    };
+    let scope = transfer_store_scope(runtime);
     let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
     let job_id = transfer_id_param(&params);
     if job_id.is_empty() {
@@ -699,7 +664,7 @@ pub(crate) async fn api_transfer_download_read_task_response(
     };
     let result = tokio::task::spawn_blocking(move || {
         crate::transfer_store::read_download_range(
-            &project_root,
+            &scope,
             &job_id,
             offset,
             length,

--- a/src/bin/caller/display_glue.rs
+++ b/src/bin/caller/display_glue.rs
@@ -152,20 +152,22 @@ pub(crate) async fn resolve_attachments(
     session_dir: &std::path::Path,
     project_root: &std::path::Path,
 ) -> Vec<external_agent::AgentAttachment> {
-    resolve_attachments_with_project_roots(
+    resolve_attachments_with_scopes(
         ids,
         registry,
         session_dir,
-        &[project_root.to_path_buf()],
+        &[crate::global_store::StoreScope::Project(
+            project_root.to_path_buf(),
+        )],
     )
     .await
 }
 
-pub(crate) async fn resolve_attachments_with_project_roots(
+pub(crate) async fn resolve_attachments_with_scopes(
     ids: &[String],
     registry: &Arc<tokio::sync::RwLock<frames::FrameRegistry>>,
     session_dir: &std::path::Path,
-    project_roots: &[PathBuf],
+    scopes: &[crate::global_store::StoreScope],
 ) -> Vec<external_agent::AgentAttachment> {
     if ids.is_empty() {
         return Vec::new();
@@ -173,9 +175,9 @@ pub(crate) async fn resolve_attachments_with_project_roots(
     let mut out: Vec<external_agent::AgentAttachment> = Vec::with_capacity(ids.len());
     for raw in ids {
         if let Some(upload_id) = raw.strip_prefix("upload:") {
-            let Some(d) = project_roots
+            let Some(d) = scopes
                 .iter()
-                .find_map(|root| upload_store::find_upload(upload_id, session_dir, root))
+                .find_map(|scope| upload_store::find_upload(upload_id, session_dir, scope))
             else {
                 continue;
             };
@@ -1604,7 +1606,6 @@ pub(crate) async fn execute_cu_calls(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::*;
 
     #[tokio::test]
     async fn resolve_attachments_includes_uploaded_files_and_images() {
@@ -1631,7 +1632,7 @@ mod tests {
             upload_store::UploadDestination::Workspace,
             &session_dir,
             "sess-1",
-            &project_root,
+            &crate::global_store::StoreScope::Project(project_root.clone()),
         )
         .unwrap();
         let image_upload = upload_store::commit_upload(
@@ -1642,7 +1643,7 @@ mod tests {
             upload_store::UploadDestination::Task,
             &session_dir,
             "sess-1",
-            &project_root,
+            &crate::global_store::StoreScope::Project(project_root.clone()),
         )
         .unwrap();
 
@@ -1704,7 +1705,7 @@ mod tests {
             upload_store::UploadDestination::Task,
             &session_dir,
             "daemon-session",
-            &daemon_project_root,
+            &crate::global_store::StoreScope::Project(daemon_project_root.clone()),
         )
         .unwrap();
 
@@ -1719,9 +1720,12 @@ mod tests {
             "single-root lookup should not find uploads committed under another project"
         );
 
-        let roots = vec![launch_project_root, daemon_project_root];
+        let scopes = vec![
+            crate::global_store::StoreScope::Project(launch_project_root),
+            crate::global_store::StoreScope::Project(daemon_project_root),
+        ];
         let attachments =
-            resolve_attachments_with_project_roots(&ids, &registry, &session_dir, &roots).await;
+            resolve_attachments_with_scopes(&ids, &registry, &session_dir, &scopes).await;
 
         assert_eq!(attachments.len(), 1);
         match &attachments[0] {

--- a/src/bin/caller/global_store.rs
+++ b/src/bin/caller/global_store.rs
@@ -1,0 +1,277 @@
+//! Daemon-global fallback store for staged uploads and durable transfers,
+//! and the [`StoreScope`] resolution both stores share.
+//!
+//! Project-rooted daemons keep the dashboard's durable file state
+//! project-local: staged uploads under `<project>/.intendant/uploads/` and
+//! transfer jobs under `<project>/.intendant/transfers/`. A projectless
+//! daemon (the macOS app daemon, any `intendant` launched from a directory
+//! with no project marker) has no `<project>/.intendant/` to root those
+//! stores in. Instead of refusing ("no project root"), it falls back to a
+//! daemon-global store under the state dir:
+//!
+//! ```text
+//! ~/.intendant/global-store/
+//! ├── uploads/<session-id>/        # staged uploads: blob + .json sidecar,
+//! │                                # same layout as <project>/.intendant/uploads/
+//! ├── pending_uploads/             # session-dir stand-in when no session log
+//! │                                # is active (mirrors .intendant/pending_uploads)
+//! └── transfers/
+//!     ├── jobs/<id>.json           # transfer job metadata
+//!     └── artifacts/<id>-<name>    # daemon-materialized download sources
+//! ```
+//!
+//! The layouts and file formats are identical to the project store, so all
+//! store code works unchanged against either root. **A project root, when
+//! present, always wins** — the global store is only used when the daemon
+//! has no project root. Writing under `~/.intendant` is normal daemon
+//! behavior (session logs, certs, caches already live there), and the state
+//! root honors the usual `$INTENDANT_HOME` override.
+//!
+//! ## Retention
+//!
+//! Unlike a project store (whose lifetime a user can reason about and
+//! delete with the project), the global store would otherwise grow
+//! unbounded across daemon restarts. On daemon startup,
+//! [`prune_at_daemon_startup`] removes global-store upload session dirs,
+//! transfer job files, and materialized artifacts whose mtime is older than
+//! [`GLOBAL_STORE_RETENTION_DAYS`] (14 days), logging what was pruned.
+//! Project stores are never pruned.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+/// How long global-store entries survive without modification before the
+/// startup prune removes them. See the module docs for the policy.
+pub(crate) const GLOBAL_STORE_RETENTION_DAYS: u64 = 14;
+
+/// Root of the daemon-global fallback store: `<state root>/global-store`
+/// (`~/.intendant/global-store` unless `$INTENDANT_HOME` overrides).
+pub(crate) fn global_store_root() -> PathBuf {
+    global_store_root_in(&crate::platform::intendant_home())
+}
+
+/// Explicit-state-root variant of [`global_store_root`] (the testable seam;
+/// `cfg(test)` scratch homes don't cross crates, so tests thread paths).
+pub(crate) fn global_store_root_in(state_root: &Path) -> PathBuf {
+    state_root.join("global-store")
+}
+
+/// Where the durable dashboard stores (staged uploads, transfer jobs) live
+/// for one daemon: under the project when there is one, under the
+/// daemon-global fallback otherwise. Resolve it once per operation with
+/// [`StoreScope::resolve`] — this is the single project-vs-fallback
+/// decision every store caller shares.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StoreScope {
+    /// Project-rooted daemon: stores live under `<project>/.intendant/`,
+    /// kept out of version control via the project's ignore metadata.
+    Project(PathBuf),
+    /// Projectless daemon: stores live under the daemon-global fallback
+    /// root (the contained path, normally `~/.intendant/global-store`).
+    Global(PathBuf),
+}
+
+impl StoreScope {
+    /// Resolve the store scope for a daemon's (optional) project root. A
+    /// present project root always wins; without one the daemon-global
+    /// store under the state dir is used, logging the fallback once per
+    /// process.
+    pub fn resolve(project_root: Option<&Path>) -> Self {
+        let scope = Self::resolve_in(project_root, &crate::platform::intendant_home());
+        if let StoreScope::Global(base) = &scope {
+            static FALLBACK_LOGGED: std::sync::Once = std::sync::Once::new();
+            FALLBACK_LOGGED.call_once(|| {
+                eprintln!(
+                    "[uploads] projectless daemon — using global store at {}",
+                    base.display()
+                );
+            });
+        }
+        scope
+    }
+
+    /// Pure resolution against an explicit state root (no logging) — the
+    /// unit-test seam for [`StoreScope::resolve`].
+    pub(crate) fn resolve_in(project_root: Option<&Path>, state_root: &Path) -> Self {
+        match project_root {
+            Some(root) => StoreScope::Project(root.to_path_buf()),
+            None => StoreScope::Global(global_store_root_in(state_root)),
+        }
+    }
+
+    /// The directory the store layouts hang off: `<project>/.intendant`
+    /// for project scopes, the global-store root for global scopes. Both
+    /// contain the same `uploads/`, `pending_uploads/`, and `transfers/`
+    /// children.
+    pub fn store_base(&self) -> PathBuf {
+        match self {
+            StoreScope::Project(root) => root.join(".intendant"),
+            StoreScope::Global(base) => base.clone(),
+        }
+    }
+
+    /// The project root, when this scope has one. Project-only concerns
+    /// (git ignore rules, legacy `workspace_files/` lookups) key off this.
+    pub fn project_root(&self) -> Option<&Path> {
+        match self {
+            StoreScope::Project(root) => Some(root),
+            StoreScope::Global(_) => None,
+        }
+    }
+}
+
+/// Startup retention pass: prune expired global-store entries and log what
+/// was removed. Runs once per daemon startup (see `startup::daemon`).
+pub(crate) fn prune_at_daemon_startup() {
+    let root = global_store_root();
+    let retention = Duration::from_secs(GLOBAL_STORE_RETENTION_DAYS * 24 * 60 * 60);
+    let pruned = prune_expired(&root, retention, SystemTime::now());
+    for path in &pruned {
+        eprintln!(
+            "[global-store] pruned {} (unused for over {GLOBAL_STORE_RETENTION_DAYS} days)",
+            path.display()
+        );
+    }
+}
+
+/// Remove global-store entries whose mtime is older than `retention`
+/// relative to `now`: upload session dirs (`uploads/<session-id>`),
+/// transfer job files (`transfers/jobs/<id>.json`), and materialized
+/// artifacts (`transfers/artifacts/*`). Returns the removed paths.
+///
+/// A simple per-entry mtime check is deliberate: upload session dirs get a
+/// fresh mtime whenever a file is added or removed, and job files are
+/// rewritten on every state change, so "mtime older than the retention
+/// window" means the entry has been idle that long.
+pub(crate) fn prune_expired(
+    global_root: &Path,
+    retention: Duration,
+    now: SystemTime,
+) -> Vec<PathBuf> {
+    let Some(cutoff) = now.checked_sub(retention) else {
+        return Vec::new();
+    };
+    let mut pruned = Vec::new();
+    let scan_dirs = [
+        global_root.join("uploads"),
+        global_root.join("pending_uploads"),
+        global_root.join("transfers").join("jobs"),
+        global_root.join("transfers").join("artifacts"),
+    ];
+    for dir in scan_dirs {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            let Ok(modified) = metadata.modified() else {
+                continue;
+            };
+            if modified >= cutoff {
+                continue;
+            }
+            let removed = if metadata.is_dir() {
+                fs::remove_dir_all(&path)
+            } else {
+                fs::remove_file(&path)
+            };
+            match removed {
+                Ok(()) => pruned.push(path),
+                Err(err) => eprintln!("[global-store] failed to prune {}: {err}", path.display()),
+            }
+        }
+    }
+    pruned
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_root_always_wins_resolution() {
+        let state_root = Path::new("/state/.intendant");
+        let project = Path::new("/work/project");
+        assert_eq!(
+            StoreScope::resolve_in(Some(project), state_root),
+            StoreScope::Project(project.to_path_buf())
+        );
+        assert_eq!(
+            StoreScope::resolve_in(None, state_root),
+            StoreScope::Global(state_root.join("global-store"))
+        );
+    }
+
+    #[test]
+    fn store_base_mirrors_project_layout() {
+        let project = StoreScope::Project(PathBuf::from("/work/project"));
+        assert_eq!(
+            project.store_base(),
+            PathBuf::from("/work/project/.intendant")
+        );
+        assert_eq!(project.project_root(), Some(Path::new("/work/project")));
+
+        let global = StoreScope::Global(PathBuf::from("/state/.intendant/global-store"));
+        assert_eq!(
+            global.store_base(),
+            PathBuf::from("/state/.intendant/global-store")
+        );
+        assert_eq!(global.project_root(), None);
+    }
+
+    /// Rather than forging mtimes, age the *cutoff*: pruning with a `now`
+    /// far in the future must remove fresh entries, and pruning with the
+    /// real `now` must keep them.
+    #[test]
+    fn prune_removes_only_entries_older_than_retention() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = global_store_root_in(tmp.path());
+        let session_dir = root.join("uploads").join("sess-old");
+        fs::create_dir_all(&session_dir).unwrap();
+        fs::write(session_dir.join("blob.txt"), b"bytes").unwrap();
+        let jobs = root.join("transfers").join("jobs");
+        fs::create_dir_all(&jobs).unwrap();
+        fs::write(jobs.join("job.json"), b"{}").unwrap();
+        let artifacts = root.join("transfers").join("artifacts");
+        fs::create_dir_all(&artifacts).unwrap();
+        fs::write(artifacts.join("id-report.zip"), b"zip").unwrap();
+
+        let retention = Duration::from_secs(GLOBAL_STORE_RETENTION_DAYS * 24 * 60 * 60);
+
+        // Everything is fresh: nothing prunes at the real "now".
+        assert!(prune_expired(&root, retention, SystemTime::now()).is_empty());
+        assert!(session_dir.exists());
+
+        // From 15 days in the future the fresh entries are expired.
+        let future = SystemTime::now() + Duration::from_secs(15 * 24 * 60 * 60);
+        let mut pruned = prune_expired(&root, retention, future);
+        pruned.sort();
+        assert_eq!(
+            pruned,
+            vec![
+                artifacts.join("id-report.zip"),
+                jobs.join("job.json"),
+                session_dir.clone(),
+            ]
+        );
+        assert!(!session_dir.exists());
+        assert!(!jobs.join("job.json").exists());
+        assert!(!artifacts.join("id-report.zip").exists());
+    }
+
+    #[test]
+    fn prune_of_missing_store_is_a_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = global_store_root_in(tmp.path());
+        assert!(prune_expired(
+            &root,
+            Duration::from_secs(1),
+            SystemTime::now() + Duration::from_secs(60)
+        )
+        .is_empty());
+    }
+}

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -35,6 +35,7 @@ mod fission_lifecycle;
 pub(crate) use intendant_core::frames;
 mod frontend;
 mod gateway_routes;
+mod global_store;
 pub(crate) use intendant_core::knowledge;
 mod lineage_ledger;
 mod linux_display_env;

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -2087,7 +2087,7 @@ mod tests {
             crate::upload_store::UploadDestination::Task,
             &session_dir,
             "parent-thread",
-            &project_root,
+            &crate::global_store::StoreScope::Project(project_root.clone()),
         )
         .unwrap();
 

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -518,14 +518,23 @@ impl SessionSupervisor {
         let _ = handle.await;
     }
 
-    fn attachment_project_roots(&self, primary: &Path) -> Vec<PathBuf> {
-        let mut roots = vec![primary.to_path_buf()];
-        if let Some(default_root) = self.config.project_root.as_deref() {
-            if default_root != primary {
-                roots.push(default_root.to_path_buf());
+    fn attachment_store_scopes(&self, primary: &Path) -> Vec<crate::global_store::StoreScope> {
+        let mut scopes = vec![crate::global_store::StoreScope::Project(
+            primary.to_path_buf(),
+        )];
+        match self.config.project_root.as_deref() {
+            Some(default_root) => {
+                if default_root != primary {
+                    scopes.push(crate::global_store::StoreScope::Project(
+                        default_root.to_path_buf(),
+                    ));
+                }
             }
+            // Projectless daemon: dashboard-staged uploads live in the
+            // daemon-global store, not under any project root.
+            None => scopes.push(crate::global_store::StoreScope::resolve(None)),
         }
-        roots
+        scopes
     }
 
     async fn resolve_session_attachments(
@@ -537,16 +546,15 @@ impl SessionSupervisor {
         if attachments.is_empty() {
             return Vec::new();
         }
-        let roots = self.attachment_project_roots(primary_project_root);
-        resolve_attachments_with_project_roots(
+        let scopes = self.attachment_store_scopes(primary_project_root);
+        resolve_attachments_with_scopes(
             attachments,
             &self.config.frame_registry,
             session_dir,
-            &roots,
+            &scopes,
         )
         .await
     }
-
 }
 
 fn normalize_supervisor_phase(phase: &str) -> String {

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -86,6 +86,10 @@ pub(crate) async fn run_daemon(
     daemon_startup_resume_dir: Option<PathBuf>,
     provider_identity: crate::usage_rail::ProviderIdentity,
 ) -> Result<(), CallerError> {
+    // Retention guard for the daemon-global fallback store (projectless
+    // staged uploads / transfer jobs): prune entries idle past the
+    // retention window so the store cannot grow unbounded across restarts.
+    tokio::task::spawn_blocking(global_store::prune_at_daemon_startup);
     let bus = EventBus::new();
     let _tick_handle = event::spawn_tick_timer(bus.clone(), 1000);
     let _session_listeners = startup::wiring::spawn_session_listeners(

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -216,9 +216,10 @@ pub(crate) fn spawn_mode_web_gateway(
     project: &Project,
     // The mode's project root as served to gateway routes (project-root
     // endpoint, Changes tab, worktree scan, settings persistence). `None`
-    // = projectless daemon; the gateway routes already answer honestly
-    // ("no project root") in that case. Non-daemon modes pass
-    // `Some(project.root)`.
+    // = projectless daemon: routes that need a durable store (staged
+    // uploads, transfer jobs) fall back to the daemon-global store
+    // (`global_store::StoreScope`); the rest answer honestly ("no
+    // project root"). Non-daemon modes pass `Some(project.root)`.
     project_root: Option<PathBuf>,
     autonomy: &SharedAutonomy,
     log_dir: &Path,

--- a/src/bin/caller/transfer_store.rs
+++ b/src/bin/caller/transfer_store.rs
@@ -2,10 +2,20 @@
 //!
 //! The Files tab needs state that survives page reloads and daemon restarts:
 //! download resume tokens, upload destinations, and partially received upload
-//! bytes. Job metadata is stored under `<project>/.intendant/transfers/jobs`.
+//! bytes. Job metadata is stored under `<project>/.intendant/transfers/jobs`
+//! (daemon-materialized download sources under `.../transfers/artifacts`).
 //! Upload partial files are created in the destination directory so the final
 //! commit can be a same-directory rename.
+//!
+//! Every store function takes a [`StoreScope`]: project-rooted daemons use
+//! the project-local store above; projectless daemons fall back to the
+//! daemon-global store (`~/.intendant/global-store/transfers/...`, identical
+//! layout and job format). The fallback store is pruned on daemon startup
+//! after [`crate::global_store::GLOBAL_STORE_RETENTION_DAYS`] days of
+//! inactivity — see `global_store.rs` for the resolution rule and retention
+//! policy.
 
+use crate::global_store::StoreScope;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{Read as _, Seek as _, Write as _};
@@ -126,16 +136,19 @@ impl std::fmt::Display for TransferStoreError {
 
 impl std::error::Error for TransferStoreError {}
 
-pub fn transfer_root(project_root: &Path) -> PathBuf {
-    project_root.join(".intendant").join("transfers")
+/// Root of the transfer store for a scope: `<project>/.intendant/transfers`
+/// or the daemon-global fallback `<global-store>/transfers`. Same layout
+/// either way.
+pub fn transfer_root(scope: &StoreScope) -> PathBuf {
+    scope.store_base().join("transfers")
 }
 
-fn jobs_dir(project_root: &Path) -> PathBuf {
-    transfer_root(project_root).join("jobs")
+fn jobs_dir(scope: &StoreScope) -> PathBuf {
+    transfer_root(scope).join("jobs")
 }
 
-fn artifacts_dir(project_root: &Path) -> PathBuf {
-    transfer_root(project_root).join("artifacts")
+fn artifacts_dir(scope: &StoreScope) -> PathBuf {
+    transfer_root(scope).join("artifacts")
 }
 
 fn is_generated_transfer_key(value: &str) -> bool {
@@ -147,19 +160,19 @@ fn is_generated_transfer_key(value: &str) -> bool {
         })
 }
 
-fn job_path(project_root: &Path, id: &str) -> Result<PathBuf, TransferStoreError> {
+fn job_path(scope: &StoreScope, id: &str) -> Result<PathBuf, TransferStoreError> {
     if !is_generated_transfer_key(id) {
         return Err(TransferStoreError::new(
             500,
             "transfer job id is not a generated UUID",
         ));
     }
-    Ok(jobs_dir(project_root).join(format!("{id}.json")))
+    Ok(jobs_dir(scope).join(format!("{id}.json")))
 }
 
-fn lookup_job_path(project_root: &Path, id_or_token: &str) -> Option<PathBuf> {
+fn lookup_job_path(scope: &StoreScope, id_or_token: &str) -> Option<PathBuf> {
     is_generated_transfer_key(id_or_token)
-        .then(|| jobs_dir(project_root).join(format!("{id_or_token}.json")))
+        .then(|| jobs_dir(scope).join(format!("{id_or_token}.json")))
 }
 
 fn now_unix() -> u64 {
@@ -210,20 +223,24 @@ fn cleanup_created_file_after_save_failure(path: &Path, label: &str) {
     }
 }
 
-fn save_job(project_root: &Path, job: &TransferJob) -> Result<(), TransferStoreError> {
-    crate::upload_store::ensure_project_uploads_ignored(project_root).map_err(|e| {
-        TransferStoreError::new(500, format!("ensure transfer metadata ignored: {e}"))
-    })?;
+fn save_job(scope: &StoreScope, job: &TransferJob) -> Result<(), TransferStoreError> {
+    // Only project stores live inside a checkout; the global store needs
+    // no ignore rule (it is daemon state, not project content).
+    if let Some(project_root) = scope.project_root() {
+        crate::upload_store::ensure_project_uploads_ignored(project_root).map_err(|e| {
+            TransferStoreError::new(500, format!("ensure transfer metadata ignored: {e}"))
+        })?;
+    }
     let bytes = serde_json::to_vec_pretty(job)
         .map_err(|e| TransferStoreError::new(500, format!("serialize transfer job: {e}")))?;
-    let path = job_path(project_root, &job.id)?;
+    let path = job_path(scope, &job.id)?;
     crate::file_watcher::atomic_write(&path, &bytes)
         .map_err(|e| TransferStoreError::new(500, format!("write transfer job: {e}")))
 }
 
-pub fn list_jobs(project_root: &Path) -> Vec<TransferJob> {
+pub fn list_jobs(scope: &StoreScope) -> Vec<TransferJob> {
     let mut jobs = Vec::new();
-    let Ok(entries) = fs::read_dir(jobs_dir(project_root)) else {
+    let Ok(entries) = fs::read_dir(jobs_dir(scope)) else {
         return jobs;
     };
     for entry in entries.flatten() {
@@ -246,7 +263,7 @@ pub fn list_jobs(project_root: &Path) -> Vec<TransferJob> {
     jobs
 }
 
-pub fn find_job(project_root: &Path, id_or_token: &str) -> Option<TransferJob> {
+pub fn find_job(scope: &StoreScope, id_or_token: &str) -> Option<TransferJob> {
     let needle = id_or_token.trim();
     if needle.is_empty() {
         return None;
@@ -254,31 +271,31 @@ pub fn find_job(project_root: &Path, id_or_token: &str) -> Option<TransferJob> {
     if !is_generated_transfer_key(needle) {
         return None;
     }
-    if let Some(direct) = lookup_job_path(project_root, needle).filter(|path| path.is_file()) {
+    if let Some(direct) = lookup_job_path(scope, needle).filter(|path| path.is_file()) {
         if let Ok(content) = fs::read_to_string(direct) {
             if let Ok(job) = serde_json::from_str::<TransferJob>(&content) {
                 return Some(job);
             }
         }
     }
-    list_jobs(project_root)
+    list_jobs(scope)
         .into_iter()
         .find(|job| job.id == needle || job.resume_token == needle)
 }
 
-fn required_job(project_root: &Path, id_or_token: &str) -> Result<TransferJob, TransferStoreError> {
-    find_job(project_root, id_or_token)
+fn required_job(scope: &StoreScope, id_or_token: &str) -> Result<TransferJob, TransferStoreError> {
+    find_job(scope, id_or_token)
         .ok_or_else(|| TransferStoreError::new(404, "transfer job not found"))
 }
 
 pub fn create_download_job(
-    project_root: &Path,
+    scope: &StoreScope,
     raw_path: &str,
 ) -> Result<TransferJob, TransferStoreError> {
     let path = crate::web_gateway::expand_dashboard_fs_path(raw_path)
         .map_err(|e| TransferStoreError::new(400, e))?;
     create_download_job_from_path(
-        project_root,
+        scope,
         path,
         None,
         None,
@@ -289,7 +306,7 @@ pub fn create_download_job(
 }
 
 pub fn create_download_job_from_path(
-    project_root: &Path,
+    scope: &StoreScope,
     path: PathBuf,
     filename: Option<String>,
     mime: Option<String>,
@@ -336,7 +353,7 @@ pub fn create_download_job_from_path(
         error: None,
         conflict_policy: TransferConflictPolicy::Fail,
     };
-    if let Err(err) = save_job(project_root, &job) {
+    if let Err(err) = save_job(scope, &job) {
         if let Some(temp_path) = &job.temp_path {
             if let Err(cleanup_err) = fs::remove_file(temp_path) {
                 eprintln!(
@@ -352,7 +369,7 @@ pub fn create_download_job_from_path(
 }
 
 pub fn create_download_job_from_bytes(
-    project_root: &Path,
+    scope: &StoreScope,
     bytes: Vec<u8>,
     filename: &str,
     mime: &str,
@@ -360,12 +377,14 @@ pub fn create_download_job_from_bytes(
     source_label: Option<String>,
     artifact: Option<serde_json::Value>,
 ) -> Result<TransferJob, TransferStoreError> {
-    crate::upload_store::ensure_project_uploads_ignored(project_root).map_err(|e| {
-        TransferStoreError::new(500, format!("ensure transfer metadata ignored: {e}"))
-    })?;
+    if let Some(project_root) = scope.project_root() {
+        crate::upload_store::ensure_project_uploads_ignored(project_root).map_err(|e| {
+            TransferStoreError::new(500, format!("ensure transfer metadata ignored: {e}"))
+        })?;
+    }
     let id = uuid::Uuid::new_v4().to_string();
     let safe_name = crate::upload_store::sanitize_name(filename);
-    let artifact_path = artifacts_dir(project_root).join(format!("{id}-{safe_name}"));
+    let artifact_path = artifacts_dir(scope).join(format!("{id}-{safe_name}"));
     crate::file_watcher::atomic_write(&artifact_path, &bytes)
         .map_err(|e| TransferStoreError::new(500, format!("write transfer artifact: {e}")))?;
     let now = now_unix();
@@ -397,7 +416,7 @@ pub fn create_download_job_from_bytes(
         error: None,
         conflict_policy: TransferConflictPolicy::Fail,
     };
-    if let Err(err) = save_job(project_root, &job) {
+    if let Err(err) = save_job(scope, &job) {
         cleanup_created_file_after_save_failure(&artifact_path, "transfer artifact");
         return Err(err);
     }
@@ -494,7 +513,7 @@ fn resolve_upload_destination(
 }
 
 pub fn create_upload_job(
-    project_root: &Path,
+    scope: &StoreScope,
     raw_destination: &str,
     original_name: &str,
     mime: &str,
@@ -543,7 +562,7 @@ pub fn create_upload_job(
         error: None,
         conflict_policy,
     };
-    if let Err(err) = save_job(project_root, &job) {
+    if let Err(err) = save_job(scope, &job) {
         cleanup_created_file_after_save_failure(&temp_path, "upload partial");
         return Err(err);
     }
@@ -551,13 +570,13 @@ pub fn create_upload_job(
 }
 
 pub fn append_upload_tempfile(
-    project_root: &Path,
+    scope: &StoreScope,
     id_or_token: &str,
     offset: u64,
     mut chunk: tempfile::NamedTempFile,
     chunk_len: u64,
 ) -> Result<TransferJob, TransferStoreError> {
-    let mut job = required_job(project_root, id_or_token)?;
+    let mut job = required_job(scope, id_or_token)?;
     if job.kind != TransferKind::Upload {
         return Err(TransferStoreError::new(
             400,
@@ -632,15 +651,15 @@ pub fn append_upload_tempfile(
         Some(total) if job.completed_bytes >= total => TransferStatus::Ready,
         _ => TransferStatus::Running,
     };
-    save_job(project_root, &job)?;
+    save_job(scope, &job)?;
     Ok(job)
 }
 
 pub fn commit_upload_job(
-    project_root: &Path,
+    scope: &StoreScope,
     id_or_token: &str,
 ) -> Result<TransferJob, TransferStoreError> {
-    let mut job = required_job(project_root, id_or_token)?;
+    let mut job = required_job(scope, id_or_token)?;
     if job.kind != TransferKind::Upload {
         return Err(TransferStoreError::new(
             400,
@@ -700,18 +719,18 @@ pub fn commit_upload_job(
     job.status = TransferStatus::Completed;
     job.updated_at = now_unix();
     job.error = None;
-    save_job(project_root, &job)?;
+    save_job(scope, &job)?;
     Ok(job)
 }
 
 pub fn read_download_range(
-    project_root: &Path,
+    scope: &StoreScope,
     id_or_token: &str,
     offset: u64,
     length: Option<u64>,
     max_bytes: u64,
 ) -> Result<(TransferJob, Vec<u8>, u64), TransferStoreError> {
-    let mut job = required_job(project_root, id_or_token)?;
+    let mut job = required_job(scope, id_or_token)?;
     if job.kind != TransferKind::Download {
         return Err(TransferStoreError::new(
             400,
@@ -757,12 +776,12 @@ pub fn read_download_range(
         TransferStatus::Running
     };
     job.updated_at = now_unix();
-    save_job(project_root, &job)?;
+    save_job(scope, &job)?;
     Ok((job, bytes, end))
 }
 
-pub fn delete_job(project_root: &Path, id_or_token: &str) -> Result<bool, TransferStoreError> {
-    let Some(mut job) = find_job(project_root, id_or_token) else {
+pub fn delete_job(scope: &StoreScope, id_or_token: &str) -> Result<bool, TransferStoreError> {
+    let Some(mut job) = find_job(scope, id_or_token) else {
         return Ok(false);
     };
     if let Some(temp_path) = job.temp_path.take() {
@@ -775,8 +794,8 @@ pub fn delete_job(project_root: &Path, id_or_token: &str) -> Result<bool, Transf
     }
     job.status = TransferStatus::Cancelled;
     job.updated_at = now_unix();
-    let _ = save_job(project_root, &job);
-    let path = job_path(project_root, &job.id)?;
+    let _ = save_job(scope, &job);
+    let path = job_path(scope, &job.id)?;
     match fs::remove_file(path) {
         Ok(()) => Ok(true),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
@@ -798,8 +817,12 @@ mod tests {
         tmp
     }
 
+    fn scope(project: &Path) -> StoreScope {
+        StoreScope::Project(project.to_path_buf())
+    }
+
     fn block_jobs_dir(project: &Path) {
-        let transfers = transfer_root(project);
+        let transfers = transfer_root(&scope(project));
         fs::create_dir_all(&transfers).unwrap();
         fs::write(transfers.join("jobs"), b"not a directory").unwrap();
     }
@@ -812,21 +835,67 @@ mod tests {
         let source = tmp.path().join("fixture.txt");
         fs::write(&source, b"hello transfer").unwrap();
 
-        let job = create_download_job(&project, source.to_str().unwrap()).unwrap();
+        let job = create_download_job(&scope(&project), source.to_str().unwrap()).unwrap();
         assert_eq!(job.kind, TransferKind::Download);
         assert_eq!(job.total_size, Some(14));
         assert!(!job.resume_token.is_empty());
 
-        let listed = list_jobs(&project);
+        let listed = list_jobs(&scope(&project));
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].id, job.id);
 
         let (updated, bytes, end) =
-            read_download_range(&project, &job.resume_token, 6, Some(8), 100).unwrap();
+            read_download_range(&scope(&project), &job.resume_token, 6, Some(8), 100).unwrap();
         assert_eq!(&bytes, b"transfer");
         assert_eq!(end, 14);
         assert_eq!(updated.status, TransferStatus::Completed);
         assert_eq!(updated.completed_bytes, 14);
+    }
+
+    /// A projectless daemon's scope stores job metadata and materialized
+    /// artifacts under `<global-store>/transfers/` with the same layout,
+    /// writes no git ignore metadata, and the full job lifecycle
+    /// (create/list/read/delete) works unchanged.
+    #[test]
+    fn global_scope_stores_jobs_under_global_store_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let global_base = crate::global_store::global_store_root_in(tmp.path());
+        let global = StoreScope::Global(global_base.clone());
+        let source = tmp.path().join("fixture.txt");
+        fs::write(&source, b"projectless transfer").unwrap();
+
+        let job = create_download_job(&global, source.to_str().unwrap()).unwrap();
+        assert!(global_base
+            .join("transfers")
+            .join("jobs")
+            .join(format!("{}.json", job.id))
+            .is_file());
+        assert!(!global_base.join(".gitignore").exists());
+        assert!(!tmp.path().join(".gitignore").exists());
+
+        let materialized = create_download_job_from_bytes(
+            &global,
+            b"generated bytes".to_vec(),
+            "report.zip",
+            "application/zip",
+            "session_report",
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(materialized
+            .source_path
+            .as_ref()
+            .unwrap()
+            .starts_with(global_base.join("transfers").join("artifacts")));
+
+        assert_eq!(list_jobs(&global).len(), 2);
+        let (_, bytes, _) = read_download_range(&global, &job.resume_token, 0, None, 100).unwrap();
+        assert_eq!(&bytes, b"projectless transfer");
+
+        assert!(delete_job(&global, &job.id).unwrap());
+        assert!(delete_job(&global, &materialized.id).unwrap());
+        assert_eq!(list_jobs(&global).len(), 0);
     }
 
     #[test]
@@ -837,12 +906,12 @@ mod tests {
         let source = tmp.path().join("fixture.txt");
         fs::write(&source, b"hello transfer").unwrap();
 
-        let job = create_download_job(&project, source.to_str().unwrap()).unwrap();
-        assert!(find_job(&project, &job.id).is_some());
-        assert!(find_job(&project, &job.resume_token).is_some());
-        assert!(find_job(&project, &format!("../{}", job.id)).is_none());
-        assert!(find_job(&project, &format!("{}!!", job.id)).is_none());
-        assert!(find_job(&project, &job.id.to_uppercase()).is_none());
+        let job = create_download_job(&scope(&project), source.to_str().unwrap()).unwrap();
+        assert!(find_job(&scope(&project), &job.id).is_some());
+        assert!(find_job(&scope(&project), &job.resume_token).is_some());
+        assert!(find_job(&scope(&project), &format!("../{}", job.id)).is_none());
+        assert!(find_job(&scope(&project), &format!("{}!!", job.id)).is_none());
+        assert!(find_job(&scope(&project), &job.id.to_uppercase()).is_none());
     }
 
     #[test]
@@ -852,7 +921,7 @@ mod tests {
         fs::create_dir_all(&project).unwrap();
 
         let job = create_download_job_from_bytes(
-            &project,
+            &scope(&project),
             b"generated report bytes".to_vec(),
             "report.zip",
             "application/zip",
@@ -873,11 +942,12 @@ mod tests {
         let source_path = job.source_path.clone().unwrap();
         assert!(source_path.exists());
 
-        let (_, bytes, end) = read_download_range(&project, &job.id, 10, Some(6), 100).unwrap();
+        let (_, bytes, end) =
+            read_download_range(&scope(&project), &job.id, 10, Some(6), 100).unwrap();
         assert_eq!(&bytes, b"report");
         assert_eq!(end, 16);
 
-        assert!(delete_job(&project, &job.id).unwrap());
+        assert!(delete_job(&scope(&project), &job.id).unwrap());
         assert!(!source_path.exists());
     }
 
@@ -889,7 +959,7 @@ mod tests {
         block_jobs_dir(&project);
 
         let err = create_download_job_from_bytes(
-            &project,
+            &scope(&project),
             b"generated report bytes".to_vec(),
             "report.zip",
             "application/zip",
@@ -900,7 +970,7 @@ mod tests {
         .unwrap_err();
         assert_eq!(err.status, 500);
 
-        let artifacts = artifacts_dir(&project);
+        let artifacts = artifacts_dir(&scope(&project));
         assert!(artifacts.exists());
         assert!(fs::read_dir(artifacts).unwrap().next().is_none());
     }
@@ -915,7 +985,7 @@ mod tests {
         let dest = dest_dir.join("out.txt");
 
         let job = create_upload_job(
-            &project,
+            &scope(&project),
             dest.to_str().unwrap(),
             "out.txt",
             "text/plain",
@@ -926,15 +996,22 @@ mod tests {
         let temp_path = job.temp_path.clone().unwrap();
         assert!(temp_path.starts_with(fs::canonicalize(&dest_dir).unwrap()));
 
-        let job = append_upload_tempfile(&project, &job.id, 0, write_chunk(b"hello "), 6).unwrap();
+        let job = append_upload_tempfile(&scope(&project), &job.id, 0, write_chunk(b"hello "), 6)
+            .unwrap();
         assert_eq!(job.completed_bytes, 6);
         assert_eq!(job.status, TransferStatus::Running);
 
-        let job = append_upload_tempfile(&project, &job.resume_token, 6, write_chunk(b"world"), 5)
-            .unwrap();
+        let job = append_upload_tempfile(
+            &scope(&project),
+            &job.resume_token,
+            6,
+            write_chunk(b"world"),
+            5,
+        )
+        .unwrap();
         assert_eq!(job.status, TransferStatus::Ready);
 
-        let committed = commit_upload_job(&project, &job.id).unwrap();
+        let committed = commit_upload_job(&scope(&project), &job.id).unwrap();
         assert_eq!(committed.status, TransferStatus::Completed);
         let expected_final_path = fs::canonicalize(&dest_dir).unwrap().join("out.txt");
         assert_eq!(
@@ -956,7 +1033,7 @@ mod tests {
         fs::write(&dest, b"existing").unwrap();
 
         let err = create_upload_job(
-            &project,
+            &scope(&project),
             dest.to_str().unwrap(),
             "out.txt",
             "text/plain",
@@ -967,7 +1044,7 @@ mod tests {
         assert_eq!(err.status, 409);
 
         let job = create_upload_job(
-            &project,
+            &scope(&project),
             dest.to_str().unwrap(),
             "out.txt",
             "text/plain",
@@ -976,8 +1053,9 @@ mod tests {
         )
         .unwrap();
         assert_ne!(job.destination_path.as_deref(), Some(dest.as_path()));
-        let job = append_upload_tempfile(&project, &job.id, 0, write_chunk(b"new"), 3).unwrap();
-        let committed = commit_upload_job(&project, &job.id).unwrap();
+        let job =
+            append_upload_tempfile(&scope(&project), &job.id, 0, write_chunk(b"new"), 3).unwrap();
+        let committed = commit_upload_job(&scope(&project), &job.id).unwrap();
         assert_eq!(fs::read(&dest).unwrap(), b"existing");
         assert_eq!(fs::read(committed.final_path.unwrap()).unwrap(), b"new");
     }
@@ -992,7 +1070,7 @@ mod tests {
         block_jobs_dir(&project);
 
         let err = create_upload_job(
-            &project,
+            &scope(&project),
             dest_dir.join("out.txt").to_str().unwrap(),
             "out.txt",
             "text/plain",
@@ -1023,7 +1101,7 @@ mod tests {
         fs::create_dir_all(&dest_dir).unwrap();
 
         let job = create_upload_job(
-            &project,
+            &scope(&project),
             dest_dir.join("out.txt").to_str().unwrap(),
             "out.txt",
             "text/plain",
@@ -1031,8 +1109,10 @@ mod tests {
             TransferConflictPolicy::Fail,
         )
         .unwrap();
-        let job = append_upload_tempfile(&project, &job.id, 0, write_chunk(b"hello "), 6).unwrap();
-        let same = append_upload_tempfile(&project, &job.id, 0, write_chunk(b"hello "), 6).unwrap();
+        let job = append_upload_tempfile(&scope(&project), &job.id, 0, write_chunk(b"hello "), 6)
+            .unwrap();
+        let same = append_upload_tempfile(&scope(&project), &job.id, 0, write_chunk(b"hello "), 6)
+            .unwrap();
         assert_eq!(same.completed_bytes, 6);
         assert_eq!(same.status, TransferStatus::Ready);
     }
@@ -1049,7 +1129,7 @@ mod tests {
         fs::write(&dest, b"existing").unwrap();
 
         let job = create_upload_job(
-            &project,
+            &scope(&project),
             dest.to_str().unwrap(),
             "out.txt",
             "text/plain",
@@ -1057,8 +1137,9 @@ mod tests {
             TransferConflictPolicy::Overwrite,
         )
         .unwrap();
-        let job = append_upload_tempfile(&project, &job.id, 0, write_chunk(b"new"), 3).unwrap();
-        let committed = commit_upload_job(&project, &job.id).unwrap();
+        let job =
+            append_upload_tempfile(&scope(&project), &job.id, 0, write_chunk(b"new"), 3).unwrap();
+        let committed = commit_upload_job(&scope(&project), &job.id).unwrap();
 
         let expected_final_path = fs::canonicalize(&dest_dir).unwrap().join("out.txt");
         assert_eq!(
@@ -1080,7 +1161,7 @@ mod tests {
         fs::write(&dest, b"existing").unwrap();
 
         let err = create_upload_job(
-            &project,
+            &scope(&project),
             dest.to_str().unwrap(),
             "out.txt",
             "text/plain",

--- a/src/bin/caller/upload_store.rs
+++ b/src/bin/caller/upload_store.rs
@@ -10,12 +10,21 @@
 //!   dashboards. It now uses the same ignored `.intendant/uploads` store
 //!   instead of the old `<project_root>/workspace_files/` directory.
 //!
+//! Every store function takes a [`StoreScope`]: project-rooted daemons use
+//! the project-local store above; projectless daemons fall back to the
+//! daemon-global store (`~/.intendant/global-store/uploads/<session-id>/`,
+//! identical layout and sidecar format). The fallback store is pruned on
+//! daemon startup after [`crate::global_store::GLOBAL_STORE_RETENTION_DAYS`]
+//! days of inactivity — see `global_store.rs` for the resolution rule and
+//! retention policy.
+//!
 //! The browser-facing POST endpoint picks the destination based on a
 //! query param; both variants produce an [`UploadDescriptor`] that the
 //! dashboard can attach to a task via `attachments: ["upload:<id>", ...]`
 //! on [`crate::event::ControlMsg::StartTask`] / `FollowUp`.
 
 use crate::error::CallerError;
+use crate::global_store::StoreScope;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::fs::OpenOptions;
@@ -137,25 +146,17 @@ fn legacy_workspace_uploads_dir(project_root: &Path) -> PathBuf {
     project_root.join("workspace_files")
 }
 
-/// Root of the project-local ignored upload store.
-fn project_uploads_root(project_root: &Path) -> PathBuf {
-    project_root.join(".intendant").join("uploads")
+/// Root of the upload store for a scope: the project-local ignored store
+/// (`<project>/.intendant/uploads`) or the daemon-global fallback
+/// (`<global-store>/uploads`). Same layout either way.
+fn uploads_root(scope: &StoreScope) -> PathBuf {
+    scope.store_base().join("uploads")
 }
 
 /// Directory for uploads associated with one Intendant wrapper/worker session.
-fn project_session_uploads_dir(project_root: &Path, session_id: &str) -> PathBuf {
+fn session_uploads_dir(scope: &StoreScope, session_id: &str) -> PathBuf {
     let safe_session = sanitize_name(session_id);
-    project_uploads_root(project_root).join(safe_session)
-}
-
-/// Pick the target directory for a given destination.
-fn target_dir(
-    _destination: UploadDestination,
-    _session_dir: &Path,
-    session_id: &str,
-    project_root: &Path,
-) -> PathBuf {
-    project_session_uploads_dir(project_root, session_id)
+    uploads_root(scope).join(safe_session)
 }
 
 fn ignore_rule_matches_intendant_uploads(line: &str) -> bool {
@@ -252,15 +253,19 @@ pub fn commit_upload(
     mime: &str,
     size: u64,
     destination: UploadDestination,
-    session_dir: &Path,
+    _session_dir: &Path,
     session_id: &str,
-    project_root: &Path,
+    scope: &StoreScope,
 ) -> Result<UploadDescriptor, CallerError> {
     let id = uuid::Uuid::new_v4().to_string();
     let safe_name = sanitize_name(original_name);
     let original_display_name = display_name(original_name, &safe_name);
-    ensure_project_uploads_ignored(project_root)?;
-    let dir = target_dir(destination, session_dir, session_id, project_root);
+    // Only project stores live inside a checkout; the global store needs
+    // no ignore rule (it is daemon state, not project content).
+    if let Some(project_root) = scope.project_root() {
+        ensure_project_uploads_ignored(project_root)?;
+    }
+    let dir = session_uploads_dir(scope, session_id);
     fs::create_dir_all(&dir)?;
 
     // Filename layout:
@@ -324,16 +329,17 @@ fn descriptor_extension(path: &Path) -> String {
     }
 }
 
-/// Read all descriptors currently stored for a project/session, including
+/// Read all descriptors currently stored for a scope/session, including
 /// legacy pre-.intendant upload locations. Order: newest first (by
 /// `created_at`).
-pub fn list_uploads(session_dir: &Path, project_root: &Path) -> Vec<UploadDescriptor> {
+pub fn list_uploads(session_dir: &Path, scope: &StoreScope) -> Vec<UploadDescriptor> {
     let mut out: Vec<UploadDescriptor> = Vec::new();
-    let mut dirs = vec![
-        legacy_task_uploads_dir(session_dir),
-        legacy_workspace_uploads_dir(project_root),
-    ];
-    let root = project_uploads_root(project_root);
+    let mut dirs = vec![legacy_task_uploads_dir(session_dir)];
+    if let Some(project_root) = scope.project_root() {
+        // The legacy workspace store only ever existed inside projects.
+        dirs.push(legacy_workspace_uploads_dir(project_root));
+    }
+    let root = uploads_root(scope);
     if let Ok(entries) = fs::read_dir(&root) {
         for entry in entries.flatten() {
             let path = entry.path();
@@ -366,8 +372,8 @@ pub fn list_uploads(session_dir: &Path, project_root: &Path) -> Vec<UploadDescri
 }
 
 /// Look up a single upload by id. `None` if no descriptor matches.
-pub fn find_upload(id: &str, session_dir: &Path, project_root: &Path) -> Option<UploadDescriptor> {
-    list_uploads(session_dir, project_root)
+pub fn find_upload(id: &str, session_dir: &Path, scope: &StoreScope) -> Option<UploadDescriptor> {
+    list_uploads(session_dir, scope)
         .into_iter()
         .find(|u| u.id == id)
         .or_else(|| find_task_upload_in_sibling_sessions(id, session_dir))
@@ -408,8 +414,8 @@ fn find_task_upload_in_sibling_sessions(id: &str, session_dir: &Path) -> Option<
 /// Remove an upload and its sidecar. Returns `Ok(false)` if no descriptor
 /// matched (idempotent — the caller can treat "already gone" the same as
 /// "just deleted").
-pub fn delete_upload(id: &str, session_dir: &Path, project_root: &Path) -> io::Result<bool> {
-    let Some(descriptor) = find_upload(id, session_dir, project_root) else {
+pub fn delete_upload(id: &str, session_dir: &Path, scope: &StoreScope) -> io::Result<bool> {
+    let Some(descriptor) = find_upload(id, session_dir, scope) else {
         return Ok(false);
     };
     let sidecar = descriptor
@@ -433,6 +439,10 @@ mod tests {
         f.write_all(bytes).unwrap();
         f.flush().unwrap();
         f
+    }
+
+    fn project_scope(project_root: &Path) -> StoreScope {
+        StoreScope::Project(project_root.to_path_buf())
     }
 
     #[test]
@@ -460,7 +470,7 @@ mod tests {
             UploadDestination::Task,
             &session_dir,
             "sess-1",
-            &project_root,
+            &project_scope(&project_root),
         )
         .unwrap();
 
@@ -488,7 +498,7 @@ mod tests {
             UploadDestination::Task,
             &session_dir,
             "sess-1",
-            &project_root,
+            &project_scope(&project_root),
         )
         .unwrap();
 
@@ -508,11 +518,61 @@ mod tests {
             &project_root.join(".gitignore")
         ));
 
-        let listed = list_uploads(&session_dir, &project_root);
+        let listed = list_uploads(&session_dir, &project_scope(&project_root));
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].id, descriptor.id);
         assert_eq!(listed[0].name, "notes.txt");
         assert_eq!(listed[0].destination, UploadDestination::Task);
+    }
+
+    /// A projectless daemon's scope stores the same blob + sidecar layout
+    /// under `<global-store>/uploads/<session-id>/`, with no git ignore
+    /// metadata written anywhere, and the full commit/list/find/delete
+    /// cycle works unchanged.
+    #[test]
+    fn global_scope_stores_under_global_store_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = tmp.path().join("session");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        let global_base = crate::global_store::global_store_root_in(tmp.path());
+        let scope = StoreScope::Global(global_base.clone());
+
+        let descriptor = commit_upload(
+            mk_tempfile(b"projectless bytes"),
+            "notes.txt",
+            "text/plain",
+            17,
+            UploadDestination::Task,
+            &session_dir,
+            "sess-global",
+            &scope,
+        )
+        .unwrap();
+
+        assert!(
+            descriptor
+                .path
+                .starts_with(global_base.join("uploads").join("sess-global")),
+            "global-scope upload must live under <global-store>/uploads/<session>, got {}",
+            descriptor.path.display()
+        );
+        assert_eq!(
+            std::fs::read(&descriptor.path).unwrap(),
+            b"projectless bytes"
+        );
+        // No project: no ignore metadata may be created.
+        assert!(!tmp.path().join(".gitignore").exists());
+        assert!(!global_base.join(".gitignore").exists());
+
+        let listed = list_uploads(&session_dir, &scope);
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, descriptor.id);
+
+        let found = find_upload(&descriptor.id, &session_dir, &scope).unwrap();
+        assert_eq!(found.path, descriptor.path);
+
+        assert!(delete_upload(&descriptor.id, &session_dir, &scope).unwrap());
+        assert!(!descriptor.path.exists());
     }
 
     #[test]
@@ -534,11 +594,16 @@ mod tests {
             UploadDestination::Task,
             &first_session_dir,
             "session-1",
-            &project_root,
+            &project_scope(&project_root),
         )
         .unwrap();
 
-        let found = find_upload(&descriptor.id, &second_session_dir, &project_root).unwrap();
+        let found = find_upload(
+            &descriptor.id,
+            &second_session_dir,
+            &project_scope(&project_root),
+        )
+        .unwrap();
         assert_eq!(found.id, descriptor.id);
         assert_eq!(found.path, descriptor.path);
         assert_eq!(found.destination, UploadDestination::Task);
@@ -561,7 +626,7 @@ mod tests {
             UploadDestination::Workspace,
             &session_dir,
             "sess-1",
-            &project_root,
+            &project_scope(&project_root),
         )
         .unwrap();
 
@@ -597,7 +662,7 @@ mod tests {
             UploadDestination::Task,
             &session_dir,
             "sess-1",
-            &project_root,
+            &project_scope(&project_root),
         )
         .unwrap();
 
@@ -625,14 +690,18 @@ mod tests {
             UploadDestination::Task,
             &session_dir,
             "sess-1",
-            &project_root,
+            &project_scope(&project_root),
         )
         .unwrap();
 
-        assert!(delete_upload(&descriptor.id, &session_dir, &project_root).unwrap());
+        assert!(
+            delete_upload(&descriptor.id, &session_dir, &project_scope(&project_root)).unwrap()
+        );
         assert!(!descriptor.path.exists());
         // Second delete: also Ok, returns false.
-        assert!(!delete_upload(&descriptor.id, &session_dir, &project_root).unwrap());
+        assert!(
+            !delete_upload(&descriptor.id, &session_dir, &project_scope(&project_root)).unwrap()
+        );
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/routes_files.rs
+++ b/src/bin/caller/web_gateway/routes_files.rs
@@ -98,8 +98,13 @@ pub(crate) struct FsDeleteRequest {
 /// configurable later via `[upload] max_size_mb` in intendant.toml.
 pub(crate) const UPLOAD_MAX_BYTES: usize = 100 * 1024 * 1024;
 
-pub(crate) fn pending_upload_session_dir(project_root: &std::path::Path) -> std::path::PathBuf {
-    project_root.join(".intendant").join("pending_uploads")
+/// Session-dir stand-in used when no session log is active:
+/// `<project>/.intendant/pending_uploads`, or the equivalent directory in
+/// the daemon-global store on projectless daemons.
+pub(crate) fn pending_upload_session_dir(
+    scope: &crate::global_store::StoreScope,
+) -> std::path::PathBuf {
+    scope.store_base().join("pending_uploads")
 }
 
 pub(crate) fn current_upload_commit_response_body(
@@ -113,12 +118,7 @@ pub(crate) fn current_upload_commit_response_body(
     size: usize,
     bus: &crate::event::EventBus,
 ) -> (&'static str, String) {
-    let Some(root) = project_root else {
-        return (
-            "400 Bad Request",
-            serde_json::json!({ "error": "no project root" }).to_string(),
-        );
-    };
+    let scope = crate::global_store::StoreScope::resolve(project_root);
 
     let (session_dir, session_id) = if let Some(slog) = session_log {
         match slog.lock() {
@@ -132,7 +132,7 @@ pub(crate) fn current_upload_commit_response_body(
         }
     } else {
         (
-            pending_upload_session_dir(root),
+            pending_upload_session_dir(&scope),
             daemon_session_id.unwrap_or("pending").to_string(),
         )
     };
@@ -145,7 +145,7 @@ pub(crate) fn current_upload_commit_response_body(
         destination,
         &session_dir,
         &session_id,
-        root,
+        &scope,
     ) {
         Ok(descriptor) => {
             bus.send(crate::event::AppEvent::UploadReady {
@@ -168,13 +168,7 @@ pub(crate) fn current_upload_delete_response_body(
     session_dir: Option<&std::path::Path>,
     id: &str,
 ) -> (&'static str, String, Option<String>) {
-    let Some(root) = project_root else {
-        return (
-            "404 Not Found",
-            serde_json::json!({ "error": "no project root" }).to_string(),
-            None,
-        );
-    };
+    let scope = crate::global_store::StoreScope::resolve(project_root);
     let id = id.trim();
     if id.is_empty() {
         return (
@@ -187,11 +181,11 @@ pub(crate) fn current_upload_delete_response_body(
     let session_dir = match session_dir {
         Some(dir) => dir,
         None => {
-            pending_dir = pending_upload_session_dir(root);
+            pending_dir = pending_upload_session_dir(&scope);
             pending_dir.as_path()
         }
     };
-    match crate::upload_store::delete_upload(id, session_dir, root) {
+    match crate::upload_store::delete_upload(id, session_dir, &scope) {
         Ok(_) => (
             "200 OK",
             serde_json::json!({ "ok": true }).to_string(),
@@ -2239,10 +2233,11 @@ pub(crate) async fn handle_current_uploads_post(
     //   <raw bytes>
     //
     // Streams the body into a tempfile, commits it into
-    // the project-local ignored upload store
-    // (`.intendant/uploads/<session-id>/`), and
-    // broadcasts UploadReady so all connected browsers
-    // see it.
+    // the upload store for this daemon's scope (the
+    // project-local ignored `.intendant/uploads/<session-id>/`,
+    // or the daemon-global store on projectless daemons),
+    // and broadcasts UploadReady so all connected
+    // browsers see it.
     //
     // Route sits in the `/api/session/current/*` family
     // alongside `changes`, `history`, `rollback`, etc.
@@ -2252,9 +2247,7 @@ pub(crate) async fn handle_current_uploads_post(
     // protect uploads, gate the whole family at once.
     use tokio::io::AsyncWriteExt;
     let response = 'upload: {
-        let Some(ref root) = project_root_for_changes else {
-            break 'upload upload_error_response("400 Bad Request", "no project root");
-        };
+        let scope = crate::global_store::StoreScope::resolve(project_root_for_changes.as_deref());
 
         let name = query_param(request_line, "name").unwrap_or_else(|| "upload.bin".to_string());
         let requested_destination = query_param(request_line, "destination")
@@ -2292,7 +2285,7 @@ pub(crate) async fn handle_current_uploads_post(
                         }
                     } else {
                         (
-                            pending_upload_session_dir(root),
+                            pending_upload_session_dir(&scope),
                             daemon_session_id
                                 .clone()
                                 .unwrap_or_else(|| "pending".to_string()),
@@ -2309,7 +2302,7 @@ pub(crate) async fn handle_current_uploads_post(
                     destination,
                     &session_dir,
                     &session_id,
-                    root,
+                    &scope,
                 ) {
                     Ok(descriptor) => {
                         bus.send(crate::event::AppEvent::UploadReady {
@@ -2345,9 +2338,7 @@ pub(crate) async fn handle_current_uploads_get(
     // GET /api/session/current/uploads/<id>/raw  — stream bytes of one upload
     use tokio::io::AsyncWriteExt;
     let response = 'get_upload: {
-        let Some(ref root) = project_root_for_changes else {
-            break 'get_upload upload_error_response("404 Not Found", "no project root");
-        };
+        let scope = crate::global_store::StoreScope::resolve(project_root_for_changes.as_deref());
         let session_dir = if let Some(ref slog) = session_log {
             match slog.lock() {
                 Ok(l) => l.dir().to_path_buf(),
@@ -2359,7 +2350,7 @@ pub(crate) async fn handle_current_uploads_get(
                 }
             }
         } else {
-            pending_upload_session_dir(root)
+            pending_upload_session_dir(&scope)
         };
         // Path after /api/session/current/uploads
         let path_and_q = request_line.split_whitespace().nth(1).unwrap_or("");
@@ -2368,7 +2359,7 @@ pub(crate) async fn handle_current_uploads_get(
             .trim_start_matches("/api/session/current/uploads")
             .trim_matches('/');
         if suffix.is_empty() {
-            let uploads = crate::upload_store::list_uploads(&session_dir, root);
+            let uploads = crate::upload_store::list_uploads(&session_dir, &scope);
             let body = serde_json::to_string(&uploads).unwrap_or_else(|_| "[]".to_string());
             HttpResponse::with_content("200 OK", "application/json", body)
                 .header("Cache-Control", "no-cache")
@@ -2377,7 +2368,7 @@ pub(crate) async fn handle_current_uploads_get(
                 .into_string()
         } else if let Some(id) = suffix.strip_suffix("/raw") {
             // GET raw bytes for one upload.
-            match crate::upload_store::find_upload(id, &session_dir, root) {
+            match crate::upload_store::find_upload(id, &session_dir, &scope) {
                 None => upload_error_response("404 Not Found", "upload not found"),
                 Some(d) => {
                     match std::fs::read(&d.path) {
@@ -2543,11 +2534,16 @@ mod tests {
     }
 
     #[test]
-    fn pending_upload_session_dir_is_project_scoped() {
+    fn pending_upload_session_dir_follows_store_scope() {
         let root = std::path::PathBuf::from("/tmp/project");
         assert_eq!(
-            pending_upload_session_dir(&root),
+            pending_upload_session_dir(&crate::global_store::StoreScope::Project(root.clone())),
             root.join(".intendant").join("pending_uploads")
+        );
+        let global = std::path::PathBuf::from("/tmp/state/global-store");
+        assert_eq!(
+            pending_upload_session_dir(&crate::global_store::StoreScope::Global(global.clone())),
+            global.join("pending_uploads")
         );
     }
 

--- a/static/app.html
+++ b/static/app.html
@@ -77868,12 +77868,14 @@ function settleCompletedFilesDownload(transfer, { resumable }) {
 }
 
 // Server errors like "no project root" are accurate but unactionable in the
-// transfers pane; translate the known ones before surfacing.
+// transfers pane; translate the known ones before surfacing. Current daemons
+// serve projectless staged uploads/transfers from a daemon-global store, so
+// these strings only reach us from older daemons that still refuse.
 function filesTransferFriendlyServerError(error, fallback) {
   const message = String(error || '').trim();
   if (!message) return fallback;
-  if (message === 'no project root') {
-    return 'This daemon has no project open — staged uploads and resumable transfers need an active session with a project root';
+  if (message === 'no project root' || message === 'project root unavailable') {
+    return 'This daemon predates projectless staged uploads and transfers — it needs a project open (or a daemon upgrade)';
   }
   return message;
 }

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -2247,12 +2247,14 @@ function settleCompletedFilesDownload(transfer, { resumable }) {
 }
 
 // Server errors like "no project root" are accurate but unactionable in the
-// transfers pane; translate the known ones before surfacing.
+// transfers pane; translate the known ones before surfacing. Current daemons
+// serve projectless staged uploads/transfers from a daemon-global store, so
+// these strings only reach us from older daemons that still refuse.
 function filesTransferFriendlyServerError(error, fallback) {
   const message = String(error || '').trim();
   if (!message) return fallback;
-  if (message === 'no project root') {
-    return 'This daemon has no project open — staged uploads and resumable transfers need an active session with a project root';
+  if (message === 'no project root' || message === 'project root unavailable') {
+    return 'This daemon predates projectless staged uploads and transfers — it needs a project open (or a daemon upgrade)';
   }
   return message;
 }


### PR DESCRIPTION
Resolves #7 (repo tasks Wave 1F). Projectless daemons (the macOS app daemon, any `intendant` launched outside a project) previously hard-failed staged uploads and durable transfer jobs with `no project root` / `project root unavailable`. Per the operator decision, this implements a daemon-global fallback store rather than a UI-disable.

## Store resolution
One shared rule, `global_store::StoreScope` (`src/bin/caller/global_store.rs`), resolves where both stores live:

- **Project root present (unchanged):** `<project>/.intendant/uploads/<session-id>/` and `<project>/.intendant/transfers/{jobs,artifacts}` — absolute precedence, no behavior change for rooted daemons.
- **Projectless:** `~/.intendant/global-store/uploads/<session-id>/` and `~/.intendant/global-store/transfers/{jobs,artifacts}` — identical layout, sidecars, and job format, so all existing store code runs unchanged against either root. Honors `$INTENDANT_HOME`. Writing under `~/.intendant` matches existing daemon behavior (logs, certs, caches), and the runtime sandbox already lists `~/.intendant` as a default writable path.

`upload_store` / `transfer_store` functions take `&StoreScope`; git-ignore maintenance and legacy `workspace_files/` lookups stay project-only.

## Gates removed
- `web_gateway/routes_files.rs`: `handle_current_uploads_post`, `handle_current_uploads_get`, `current_upload_commit_response_body`, `current_upload_delete_response_body`
- `dashboard_control/api_sessions.rs`: upload raw read, uploads list (delete already flowed through the shared response body)
- `dashboard_control/api_transfers_fs.rs`: all six transfer methods (jobs list, create, delete, upload chunk, upload commit, download read); `transfer_project_root` is now the infallible `transfer_store_scope`
- attachment delivery (`session_supervisor::attachment_store_scopes`, `display_glue::resolve_attachments_with_scopes`) searches the global store on projectless daemons so staged uploads actually reach agents

First fallback use logs once: `[uploads] projectless daemon — using global store at ...`.

## Retention guard
On daemon startup (`run_daemon`), `global_store::prune_at_daemon_startup` removes global-store upload session dirs, transfer job files, and materialized artifacts whose mtime is older than 14 days, logging each removal. Project stores are never pruned. Policy documented in the module docs of `global_store.rs`, `upload_store.rs`, and `transfer_store.rs`.

## Tests
- `global_store`: resolution precedence (project vs fallback), store-base layout, prune keeps-fresh/removes-expired, missing-store no-op
- hermetic global-scope store tests: upload commit/list/find/delete cycle; transfer job create/list/read/delete incl. materialized artifacts (no git metadata written)
- route-level projectless proof: staged upload POST commits into the global store and raw GET streams the bytes back (`projectless_staged_upload_posts_and_reads_raw_from_global_store`)
- `cargo test --bins`: 2706 passed; clippy: warning count identical to the HEAD baseline (66 = 66, none in the new/changed store code)

## E2E evidence (manual)
Debug daemon launched from a non-project cwd (`PROVIDER=mock intendant --no-tls --web 0 --bind 127.0.0.1`):
- `POST /api/session/current/uploads?name=proof.txt` → 200, descriptor path `~/.intendant/global-store/uploads/<session-id>/…__proof.txt`
- `GET /api/session/current/uploads/<id>/raw` → bytes identical to the payload; list shows the upload; `DELETE` → `{"ok":true}` and blob+sidecar removed
- daemon stderr: `[uploads] projectless daemon — using global store at /Users/…/.intendant/global-store`

## Docs / frontend
- `docs/src/web-dashboard.md` (Files section): store roots, projectless fallback, retention
- `docs/src/configuration.md`: `INTENDANT_HOME` row lists `global-store/`
- `static/app/54-session-lifecycle.js` (`filesTransferFriendlyServerError`): the old errors are now mapped as an older-daemon message; `static/app.html` regenerated via the assembler