### PR TITLE
Split user-display sharing: private "View this machine" vs "Share with agent"

### DIFF
--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -710,6 +710,19 @@ pub struct DisplaySession {
     /// lower 32 bits of `(arrived - session_epoch).as_millis()`, so each
     /// frame carries its capture-time timestamp without a side channel.
     diagnostics_visual_marker: Arc<AtomicBool>,
+    /// **Agent visibility.** `true` (the default) means this display may be
+    /// seen and driven by agents: it appears in agent-facing registry
+    /// lookups ([`SessionRegistry::get`], [`SessionRegistry::display_ids`])
+    /// and its 1 Hz FrameRegistry sampler publishes `display_<id>` frames
+    /// for model feeds. `false` marks a **private user view** ("View this
+    /// machine"): the session still streams to the owner's dashboards over
+    /// WebRTC and accepts dashboard input, but every agent-facing lookup
+    /// skips it and the FrameRegistry sampler stays silent, so agent
+    /// screenshot/CU/frame paths cannot reach it (fail closed). Flipped to
+    /// `true` in place when the user later shares the display with the
+    /// agent — no capture restart needed; frames start publishing on the
+    /// next sampler tick. Never downgraded automatically.
+    agent_visible: Arc<AtomicBool>,
     /// Reference instant for the diagnostic marker's 32-bit timestamp.
     /// Set once in [`Self::new`]; the bridge computes
     /// `arrived.duration_since(session_epoch).as_millis() as u32` per
@@ -1144,9 +1157,23 @@ impl DisplaySession {
             tile_epoch: Arc::new(AtomicU32::new(1)),
             tile_snapshot_id: Arc::new(AtomicU32::new(1)),
             diagnostics_visual_marker: Arc::new(AtomicBool::new(false)),
+            agent_visible: Arc::new(AtomicBool::new(true)),
             session_epoch: Instant::now(),
             layer_policy_handle: Mutex::new(None),
         }
+    }
+
+    /// Set whether agents may see this display (see the `agent_visible`
+    /// field docs). Callers only ever *raise* visibility automatically on
+    /// an explicit user grant; creation-time hiding happens before the
+    /// session enters the registry.
+    pub fn set_agent_visible(&self, visible: bool) {
+        self.agent_visible.store(visible, Ordering::Relaxed);
+    }
+
+    /// Whether agents may see this display. `false` = private user view.
+    pub fn agent_visible(&self) -> bool {
+        self.agent_visible.load(Ordering::Relaxed)
     }
 
     /// Toggle the Phase 0 visual-freshness diagnostic marker on or off.
@@ -1453,6 +1480,7 @@ impl DisplaySession {
             let latest = Arc::clone(&self.latest_frame);
             let shutdown_reg = self.shutdown.clone();
             let display_id = self.display_id;
+            let agent_visible = Arc::clone(&self.agent_visible);
             let mut frame_counter = 0u64;
             let reg_handle = tokio::spawn(async move {
                 let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
@@ -1460,6 +1488,13 @@ impl DisplaySession {
                     tokio::select! {
                         _ = shutdown_reg.cancelled() => break,
                         _ = interval.tick() => {
+                            // The FrameRegistry is a model feed (agent
+                            // auto-attach, presence frame tools, MCP
+                            // list_frames/read_frame). A private user view
+                            // must publish nothing to it — checked per tick
+                            // so a later "share with agent" upgrade starts
+                            // publishing without a capture restart.
+                            if !agent_visible.load(Ordering::Relaxed) { continue }
                             let frame = latest.read().await.clone();
                             let Some(frame) = frame else { continue };
                             let w = frame.width;
@@ -2964,7 +2999,27 @@ impl SessionRegistry {
         }
     }
 
+    /// Agent-facing lookup — the **fail-closed default**. Returns the
+    /// session only when it is agent-visible; a private user view
+    /// ("View this machine", [`DisplaySession::agent_visible`] == false)
+    /// reads as absent. Every agent-reachable path (CU action execution,
+    /// screenshot session lookup, default-target selection, display
+    /// enumeration overlays, federated peer streaming) goes through this,
+    /// so new callers are private-view-safe unless they explicitly opt
+    /// into [`Self::get_any`].
     pub fn get(&self, display_id: u32) -> Option<Arc<DisplaySession>> {
+        self.sessions
+            .get(&display_id)
+            .filter(|s| s.agent_visible())
+            .cloned()
+    }
+
+    /// Unfiltered lookup for **user/dashboard surfaces only** (WebRTC
+    /// offers and input from the owner's dashboards, lifecycle teardown,
+    /// activation dedupe, explicit user-initiated recording). Returns
+    /// private user views too — never call this from a path whose output
+    /// reaches an agent.
+    pub fn get_any(&self, display_id: u32) -> Option<Arc<DisplaySession>> {
         self.sessions.get(&display_id).cloned()
     }
 
@@ -2983,8 +3038,20 @@ impl SessionRegistry {
         self.sessions.remove(&display_id)
     }
 
-    /// All active display IDs.
+    /// Agent-visible display IDs — the fail-closed default enumeration
+    /// (see [`Self::get`]). Private user views are excluded.
     pub fn display_ids(&self) -> Vec<u32> {
+        self.sessions
+            .iter()
+            .filter(|(_, s)| s.agent_visible())
+            .map(|(id, _)| *id)
+            .collect()
+    }
+
+    /// All active display IDs including private user views — for
+    /// user/dashboard surfaces only (bootstrap replay, input-authority
+    /// snapshots, virtual-display id allocation).
+    pub fn all_display_ids(&self) -> Vec<u32> {
         self.sessions.keys().copied().collect()
     }
 
@@ -3642,6 +3709,60 @@ mod tests {
             Some(now),
             min
         ));
+    }
+
+    #[test]
+    fn session_registry_agent_hidden_sessions_absent_from_agent_lookups() {
+        let mut reg = SessionRegistry::new();
+        let backend = Arc::new(StubBackend {
+            width: 64,
+            height: 64,
+        });
+        let private_view = Arc::new(DisplaySession::new(0, Arc::clone(&backend) as _));
+        private_view.set_agent_visible(false);
+        let agent_display = Arc::new(DisplaySession::new(99, backend as _));
+        reg.insert(0, Arc::clone(&private_view));
+        reg.insert(99, Arc::clone(&agent_display));
+
+        // Agent-facing default lookups: the private view reads as absent.
+        assert!(
+            reg.get(0).is_none(),
+            "agent-facing get must not return a private user view"
+        );
+        assert!(reg.get(99).is_some(), "agent displays stay visible");
+        assert_eq!(
+            reg.display_ids(),
+            vec![99],
+            "agent-facing enumeration must exclude the private view"
+        );
+
+        // Dashboard surfaces see everything.
+        assert!(reg.get_any(0).is_some(), "dashboard get_any sees the view");
+        let mut all = reg.all_display_ids();
+        all.sort_unstable();
+        assert_eq!(all, vec![0, 99]);
+
+        // A later "share with agent" upgrade makes it visible in place.
+        private_view.set_agent_visible(true);
+        assert!(reg.get(0).is_some(), "upgraded session becomes agent-visible");
+        let mut ids = reg.display_ids();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![0, 99]);
+    }
+
+    #[test]
+    fn display_session_agent_visible_defaults_true() {
+        let backend = Arc::new(StubBackend {
+            width: 64,
+            height: 64,
+        });
+        let session = DisplaySession::new(1, backend);
+        assert!(
+            session.agent_visible(),
+            "sessions default to agent-visible (legacy grant semantics)"
+        );
+        session.set_agent_visible(false);
+        assert!(!session.agent_visible());
     }
 
     #[test]

--- a/docs/src/autonomy.md
+++ b/docs/src/autonomy.md
@@ -83,7 +83,8 @@ external-agent approval routing through `external_approval_decision`.
 ## DisplayControl session grant
 
 `DisplayControl` uses a **session-grant** model: approve once — the dashboard's
-user-display toggle or `intendant ctl display grant-user` — and the agent keeps
+**Share with agent** action (or its v1 user-display toggle) or
+`intendant ctl display grant-user` — and the agent keeps
 access to the user's display for the rest of the session (used by both
 [computer use](./computer-use-and-audio.md) and WebRTC streaming). Revoke from
 the same places to drop it. The grant is enforced fail-closed at the CU
@@ -92,3 +93,12 @@ executor on every platform; only the owner's own surfaces (dashboard, local
 without it, because their call is the opt-in. Note the grant is a single
 per-daemon flag: once granted, it holds for every principal the IAM layer
 lets at the display tools until revoked.
+
+The dashboard's **View this machine** action is *not* a `DisplayControl`
+grant: it opens a **private user view** — a capture session flagged
+`agent_visible = false` that streams to the owner's dashboards only. It
+never touches this grant, and the session itself is skipped by every
+agent-facing display lookup (a second fence, independent of the flag —
+see [Computer Use](./computer-use-and-audio.md)). Revoking *any*
+user-display session — shared or private — clears the per-daemon grant
+flag: over-revocation is the fail-closed direction.

--- a/docs/src/computer-use-and-audio.md
+++ b/docs/src/computer-use-and-audio.md
@@ -145,13 +145,59 @@ platforms: the element tree reveals window titles and field values just as
 pixels do, and it bypasses the session pipeline entirely.)
 
 User-session access uses a **session-grant** model: approve once (the `d` hotkey
-the dashboard control, MCP `grant_user_display`, or
+the dashboard's **Share with agent** action, MCP `grant_user_display`, or
 `intendant ctl display grant-user`), and the grant holds for the rest of the
 session until revoked. On Wayland, granting starts the GNOME portal flow. For
 Computer Use, the operator must enable **Allow Remote Interaction** in the
 physical portal dialog before clicking **Share**; approving screen sharing alone
 can produce screenshots while leaving keyboard/mouse injection unavailable. See
 [Autonomy & Approvals](./autonomy.md) for the approval surface.
+
+### Three separate concepts: private view, agent share, presence streaming
+
+Putting the user's screen on the wire means one of three deliberately
+distinct things, and the surfaces never conflate them:
+
+1. **Private view** (dashboard **View this machine**) — remote
+   view/control of this machine's display from the owner's dashboards.
+   The capture session is created with **`agent_visible = false`**
+   (`ControlMsg::GrantUserDisplay { agent_visible: false }`): it streams
+   over WebRTC to connected dashboards and accepts dashboard input like
+   any display, but it is invisible to agents, **fail closed**, at two
+   independent layers:
+   - the `DisplayControl` autonomy grant is never set (so the CU
+     `execute_actions` chokepoint, `INTENDANT_USER_DISPLAY_GRANTED` on
+     runtime children, `shared_view`, and `read_screen` all refuse the
+     user session exactly as if nothing was granted), and
+   - the session itself is skipped by every agent-facing registry
+     lookup — `SessionRegistry::get` / `display_ids()` are filtered by
+     the session's `agent_visible` flag, so CU session routing, the
+     screenshot session lookup, `default_display_target`,
+     `list_displays` resolution overlays, federated peer streaming and
+     peer display announcements, presence's available-display list, and
+     the 1 Hz FrameRegistry sampler (`display_<id>` model-feed frames,
+     hence `list_frames`/`read_frame` and conversation auto-attach) all
+     read it as absent. Dashboard surfaces use the unfiltered
+     `get_any` / `all_display_ids` accessors.
+   Auto-recording also skips private views (an explicit user-initiated
+   `StartRecording` still works — that is the user's own decision).
+2. **Agent share** (dashboard **Share with agent**, MCP
+   `grant_user_display`, ctl `display grant-user`) — the classic grant:
+   `agent_visible = true`, the autonomy grant is set, and the display is
+   enumerable/screenshotable/drivable by agents until revoked. A share
+   over an existing private view **upgrades it in place** (frames start
+   feeding the registry on the next sampler tick; no capture restart,
+   no second portal dialog). The reverse never happens implicitly: a
+   view request over a shared display does not downgrade it — taking
+   the agent's access away is an explicit revoke.
+3. **Presence streaming** (the tile's **Stream** button) — continuous
+   frames to the live presence (voice) model only. Independent of both
+   modes above and unchanged by them; main agents are not affected.
+
+Revoking a user display (either mode) tears the session down and clears
+the per-daemon grant flag. On the wire, `GrantUserDisplay` without
+`agent_visible` keeps its historical meaning (`true` — the agent share),
+so pre-split frontends and scripts are unaffected.
 
 Granting is itself owner-surface-only: `grant_user_display` from a scoped
 caller is refused (revoke stays open — de-escalation is fail-safe), and the

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -334,6 +334,29 @@ control (see [Display Pipeline](./display-pipeline.md)):
 - **Recording replay** — browse and play back recorded sessions with timeline
   seeking and speed control (1x / 2x / 4x)
 
+The live rail's **Your screen** card keeps the three screen-on-the-wire
+concepts separate (see
+[Computer Use](./computer-use-and-audio.md#three-separate-concepts-private-view-agent-share-presence-streaming)):
+
+- **View this machine** — a private remote view: watch and control this
+  machine's display from the dashboard. The agent cannot see it — the
+  session is `agent_visible = false` and every agent-facing display
+  lookup skips it. The tile wears a **Private view** chip and the live
+  rail row a `PRIVATE` tag.
+- **Share with agent** — the classic `DisplayControl` grant: the screen
+  becomes visible to the agent for computer-use tasks until revoked. The
+  tile wears an **Agent can see this** chip. Sharing while a private
+  view is active upgrades it in place; the reverse never happens
+  implicitly.
+- The tile's **Stream** button is the third, unrelated control: frames
+  to the live presence (voice) model only.
+
+Both modes revoke from the same card (**Stop viewing** / **Revoke
+access**), the v1 status-bar chip (`off`/`view`/`on`) stays a pure
+toggle with its historical agent-share semantics, and
+`GET /api/displays` annotates entries with `capture_active` +
+`agent_visible` so pickers and chips can render live state.
+
 Displays appear automatically when the agent's first command triggers Xvfb
 auto-launch, or when access to the user's real session display is granted.
 WebRTC negotiation (SDP offer/answer + ICE candidates) is multiplexed over the

--- a/src/bin/caller/computer_use.rs
+++ b/src/bin/caller/computer_use.rs
@@ -2891,6 +2891,115 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn agent_paths_cannot_reach_private_view_sessions() {
+        // A "View this machine" session (agent_visible == false) must be
+        // invisible to every agent-facing CU path even when the caller
+        // would otherwise be ALLOWED to reach the user session (owner
+        // surface / standing grant): the filtered registry lookup is a
+        // second, independent fence.
+        let dir = std::env::temp_dir();
+        let mut counter = 0u64;
+
+        // Private view of the primary display (0) and of a secondary
+        // monitor (3); one agent-owned virtual display (99).
+        let registry = crate::mcp::tests::test_session_registry_with_display(0, 1920, 1080);
+        {
+            let reg = registry.read().await;
+            reg.get_any(0).unwrap().set_agent_visible(false);
+        }
+        {
+            use std::sync::Arc;
+            let backend3 = Arc::new(crate::display::DisplaySession::new(
+                3,
+                Arc::new(crate::mcp::tests::TestDisplayBackend {
+                    width: 800,
+                    height: 600,
+                }),
+            ));
+            backend3.set_agent_visible(false);
+            let backend99 = Arc::new(crate::display::DisplaySession::new(
+                99,
+                Arc::new(crate::mcp::tests::TestDisplayBackend {
+                    width: 1024,
+                    height: 768,
+                }),
+            ));
+            let mut reg = registry.write().await;
+            reg.insert(3, backend3);
+            reg.insert(99, backend99);
+        }
+        let registry = Some(registry);
+
+        // Default target selection must not pick the private monitor (3):
+        // the lowest agent-VISIBLE non-zero session wins.
+        assert_eq!(
+            default_display_target(&registry).await,
+            DisplayTarget::Virtual { id: 99 },
+            "default target must skip private views"
+        );
+
+        // Session-only backend (Wayland), user_session target, caller
+        // allowed: the private session at 0 must read as absent — the
+        // call fails with the no-session guidance, it does NOT capture.
+        let results = execute_actions(
+            &[CuAction::Screenshot],
+            DisplayTarget::UserSession,
+            DisplayBackend::Wayland,
+            &dir,
+            &mut counter,
+            &registry,
+            None,
+            true,
+        )
+        .await;
+        assert!(!results[0].success);
+        assert_eq!(
+            results[0].error.as_deref(),
+            Some(no_session_message(DisplayBackend::Wayland, &DisplayTarget::UserSession, true))
+                .as_deref(),
+            "private view at 0 must be unreachable even for an allowed caller"
+        );
+
+        // Explicitly targeting the private secondary monitor by id fails
+        // the same way (Wayland virtual targets route via the session).
+        let results = execute_actions(
+            &[CuAction::Screenshot],
+            DisplayTarget::Virtual { id: 3 },
+            DisplayBackend::Windows,
+            &dir,
+            &mut counter,
+            &registry,
+            None,
+            true,
+        )
+        .await;
+        assert!(!results[0].success);
+        assert!(
+            results[0]
+                .error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("No virtual display 3"),
+            "private monitor must read as absent: {:?}",
+            results[0].error
+        );
+
+        // The agent-owned display is unaffected by the filtering.
+        assert!(
+            lookup_display_session(&registry, &DisplayTarget::Virtual { id: 99 })
+                .await
+                .is_some(),
+            "agent-visible sessions stay reachable"
+        );
+        assert!(
+            lookup_display_session(&registry, &DisplayTarget::UserSession)
+                .await
+                .is_none(),
+            "private view must be absent from the CU session lookup"
+        );
+    }
+
+    #[tokio::test]
     async fn execute_actions_gate_leaves_virtual_targets_alone() {
         // A virtual target is agent-owned: the gate must not fire for it even
         // with user_session_allowed == false (Wayland backend: the virtual

--- a/src/bin/caller/control_plane.rs
+++ b/src/bin/caller/control_plane.rs
@@ -650,7 +650,10 @@ async fn handle_control_msg(msg: &ControlMsg, state: &ControlPlaneState) {
                 }),
             }
         }
-        ControlMsg::GrantUserDisplay { display_id } => {
+        ControlMsg::GrantUserDisplay {
+            display_id,
+            agent_visible,
+        } => {
             // Owned here (not by any frontend) so the display-control path
             // never depends on a rendering loop to process revokes/grants.
             // Historically this lived in the TUI's control handler, where a
@@ -662,20 +665,31 @@ async fn handle_control_msg(msg: &ControlMsg, state: &ControlPlaneState) {
             // before any web terminal connects; subsequent grants after
             // churn would have shown the same lag.
             let did = display_id.unwrap_or(0);
-            {
+            // Wire absence means the pre-split message: share with the
+            // agent. `Some(false)` is the dashboard's "View this machine"
+            // — a private view that must never mint agent authority.
+            let agent_visible = agent_visible.unwrap_or(true);
+            if agent_visible {
                 // The autonomy guard is the single holder of the grant;
                 // runtime children observe it via the env derivation at the
-                // spawn boundary (agent_runner).
+                // spawn boundary (agent_runner). A private view leaves the
+                // guard untouched: viewing your own machine grants the
+                // agent nothing.
                 let mut guard = state.autonomy.write().await;
                 guard.user_display_granted = true;
             }
-            state
-                .bus
-                .send(AppEvent::UserDisplayGranted { display_id: did });
+            state.bus.send(AppEvent::UserDisplayGranted {
+                display_id: did,
+                agent_visible,
+            });
         }
         ControlMsg::RevokeUserDisplay { display_id, note } => {
             let did = display_id.unwrap_or(0);
             {
+                // Cleared unconditionally: the grant is a single per-daemon
+                // flag, and dropping agent authority on any user-display
+                // revoke (even of a private view that never set it) is the
+                // fail-closed direction.
                 let mut guard = state.autonomy.write().await;
                 guard.user_display_granted = false;
             }
@@ -876,6 +890,83 @@ mod tests {
             permission_mode: "default".to_string(),
             allowed_tools: Vec::new(),
         }))
+    }
+
+    #[tokio::test]
+    async fn grant_user_display_agent_visibility_controls_autonomy_grant() {
+        let bus = EventBus::new();
+        let mut events = bus.subscribe();
+        let autonomy = crate::autonomy::shared_autonomy(AutonomyState::default());
+        let state = ControlPlaneState {
+            autonomy: autonomy.clone(),
+            external_agent: Arc::new(RwLock::new(None)),
+            codex_config: test_codex_config(),
+            claude_config: test_claude_config(),
+            bus: bus.clone(),
+            project_root: None,
+        };
+
+        // "View this machine": a private view must never mint agent
+        // display authority.
+        handle_control_msg(
+            &ControlMsg::GrantUserDisplay {
+                display_id: Some(3),
+                agent_visible: Some(false),
+            },
+            &state,
+        )
+        .await;
+        assert!(
+            !autonomy.read().await.user_display_granted,
+            "a private view must not set the autonomy user-display grant"
+        );
+        match events.try_recv() {
+            Ok(AppEvent::UserDisplayGranted {
+                display_id,
+                agent_visible,
+            }) => {
+                assert_eq!(display_id, 3);
+                assert!(!agent_visible, "the event must carry the private mode");
+            }
+            other => panic!("expected UserDisplayGranted, got {other:?}"),
+        }
+
+        // The legacy wire shape (agent_visible absent) keeps its historical
+        // meaning: share with the agent.
+        handle_control_msg(
+            &ControlMsg::GrantUserDisplay {
+                display_id: None,
+                agent_visible: None,
+            },
+            &state,
+        )
+        .await;
+        assert!(
+            autonomy.read().await.user_display_granted,
+            "a legacy grant still sets the autonomy user-display grant"
+        );
+        match events.try_recv() {
+            Ok(AppEvent::UserDisplayGranted {
+                display_id,
+                agent_visible,
+            }) => {
+                assert_eq!(display_id, 0);
+                assert!(agent_visible);
+            }
+            other => panic!("expected UserDisplayGranted, got {other:?}"),
+        }
+
+        // Revoke clears the grant (of any user-display session — the flag
+        // is per-daemon; over-revocation is the fail-closed direction).
+        handle_control_msg(
+            &ControlMsg::RevokeUserDisplay {
+                display_id: None,
+                note: None,
+            },
+            &state,
+        )
+        .await;
+        assert!(!autonomy.read().await.user_display_granted);
     }
 
     #[tokio::test]

--- a/src/bin/caller/display_glue.rs
+++ b/src/bin/caller/display_glue.rs
@@ -477,15 +477,38 @@ pub(crate) fn report_user_display_capture_unavailable(
 /// `target_display_id` is the intendant-stable display ID (0 = primary).
 /// This wires the user's display into the same lifecycle as virtual displays —
 /// the recording listener starts ffmpeg and the web dashboard shows a display slot.
+///
+/// `agent_visible` selects the session mode: `true` is the classic grant
+/// (agents may enumerate/screenshot/drive it), `false` a private user view
+/// streamed to the owner's dashboards only. When a session already exists,
+/// a `true` grant **upgrades** a private view in place (the emitters of
+/// agent-visible grant events are all explicit owner opt-ins — the
+/// dashboard/ctl ControlMsg and the owner-surface-only MCP grant tool;
+/// every implicit re-activation path first checks for an existing session
+/// via `get_any` and never emits over one). A `false` request never
+/// downgrades an existing shared session: taking the agent's access away
+/// is an explicit revoke, not a side effect of opening a view.
 pub(crate) async fn activate_user_display(
     bus: &EventBus,
     session_registry: &display::SharedSessionRegistry,
     frame_registry: Option<std::sync::Arc<tokio::sync::RwLock<frames::FrameRegistry>>>,
     target_display_id: u32,
+    agent_visible: bool,
 ) {
     let display_id: u32 = target_display_id;
 
-    if let Some(session) = session_registry.read().await.get(display_id) {
+    // Dedupe against ANY live session — a private view is still a live
+    // capture. The filtered `get` would miss it and stack a second
+    // capture session onto the same display, with the visible insert
+    // clobbering the private one (an accidental upgrade).
+    if let Some(session) = session_registry.read().await.get_any(display_id) {
+        if agent_visible && !session.agent_visible() {
+            eprintln!(
+                "[user_display] Display :{} upgraded from private view to agent-shared",
+                display_id
+            );
+            session.set_agent_visible(true);
+        }
         let (width, height) = session.resolution();
         eprintln!(
             "[user_display] Display :{} capture already active ({}x{}); skipping activation",
@@ -495,6 +518,7 @@ pub(crate) async fn activate_user_display(
             display_id,
             width,
             height,
+            agent_visible: session.agent_visible(),
         });
         return;
     }
@@ -524,6 +548,7 @@ pub(crate) async fn activate_user_display(
             }
         };
         let session = display::DisplaySession::new(display_id, Arc::new(backend));
+        session.set_agent_visible(agent_visible);
         if let Err(e) = session
             .start(
                 30,
@@ -547,6 +572,7 @@ pub(crate) async fn activate_user_display(
             display_id,
             width,
             height,
+            agent_visible,
         });
         return;
     }
@@ -582,6 +608,7 @@ pub(crate) async fn activate_user_display(
         );
         let backend = display::wayland::WaylandBackend::new();
         let session = display::DisplaySession::new(display_id, Arc::new(backend));
+        session.set_agent_visible(agent_visible);
         // The portal dialog requires user interaction on the physical display.
         // If the user is accessing intendant remotely (web dashboard, SSH) they
         // may never see the dialog, so emit a status event for the dashboard to
@@ -612,6 +639,7 @@ pub(crate) async fn activate_user_display(
                     display_id,
                     width,
                     height,
+                    agent_visible,
                 });
                 return;
             }
@@ -684,6 +712,7 @@ pub(crate) async fn activate_user_display(
             };
             if let Ok(backend) = backend {
                 let session = display::DisplaySession::new(display_id, Arc::new(backend));
+                session.set_agent_visible(agent_visible);
                 if let Err(e) = session
                     .start(
                         30,
@@ -716,6 +745,7 @@ pub(crate) async fn activate_user_display(
                         display_id,
                         width,
                         height,
+                        agent_visible,
                     });
                     return;
                 }
@@ -755,6 +785,7 @@ pub(crate) async fn activate_user_display(
             display::macos::MacOSBackend::new()
         };
         let session = display::DisplaySession::new(display_id, Arc::new(backend));
+        session.set_agent_visible(agent_visible);
         if let Err(e) = session
             .start(30, frame_registry, Some(display_event_forwarder(bus.clone())))
             .await {
@@ -773,6 +804,7 @@ pub(crate) async fn activate_user_display(
                 display_id,
                 width,
                 height,
+                agent_visible,
             });
             return;
         }
@@ -799,6 +831,7 @@ pub(crate) async fn activate_user_display(
             display::windows::WindowsBackend::new()
         };
         let session = display::DisplaySession::new(display_id, Arc::new(backend));
+        session.set_agent_visible(agent_visible);
         if let Err(e) = session
             .start(30, frame_registry, Some(display_event_forwarder(bus.clone())))
             .await {
@@ -817,6 +850,7 @@ pub(crate) async fn activate_user_display(
                 display_id,
                 width,
                 height,
+                agent_visible,
             });
             return;
         }
@@ -910,7 +944,7 @@ pub(crate) async fn auto_activate_windows_user_display(
         let mut guard = autonomy.write().await;
         guard.user_display_granted = true;
     }
-    activate_user_display(bus, session_registry, frame_registry, 0).await;
+    activate_user_display(bus, session_registry, frame_registry, 0, true).await;
 }
 
 /// Detect a Wayland compositor socket even when WAYLAND_DISPLAY is not set.
@@ -1392,14 +1426,20 @@ pub(crate) async fn handle_shared_view_calls(
         let output = match action {
             "show" => {
                 // (Re)activate a granted user display whose session is gone;
-                // the grant listener owns the platform work.
+                // the grant listener owns the platform work. `get_any`: a
+                // private user view is still a live session — re-emitting a
+                // grant over it would upgrade it to agent-visible from an
+                // agent tool call, which only explicit owner grants may do.
                 if display_id == Some(0) {
                     let session_missing = match session_registry {
-                        Some(registry) => registry.read().await.get(0).is_none(),
+                        Some(registry) => registry.read().await.get_any(0).is_none(),
                         None => false,
                     };
                     if session_missing {
-                        bus.send(AppEvent::UserDisplayGranted { display_id: 0 });
+                        bus.send(AppEvent::UserDisplayGranted {
+                            display_id: 0,
+                            agent_visible: true,
+                        });
                     }
                 }
                 bus.send(emit("show", None));
@@ -1818,16 +1858,18 @@ mod tests {
             registry.insert(0, session);
             let registry = std::sync::Arc::new(tokio::sync::RwLock::new(registry));
 
-            activate_user_display(&bus, &registry, None, 0).await;
+            activate_user_display(&bus, &registry, None, 0, true).await;
 
             match tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await {
                 Ok(Ok(AppEvent::DisplayReady {
                     display_id,
                     width,
                     height,
+                    agent_visible,
                 })) => {
                     assert_eq!(display_id, 0);
                     assert_eq!((width, height), (1920, 1080));
+                    assert!(agent_visible);
                 }
                 other => panic!("expected DisplayReady for active capture, got {other:?}"),
             }
@@ -1837,6 +1879,68 @@ mod tests {
                     .is_err(),
                 "already-active capture should not emit a portal-pending event"
             );
+        });
+    }
+
+    #[test]
+    fn activate_user_display_upgrades_private_view_on_agent_grant_only() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let bus = EventBus::new();
+            let mut rx = bus.subscribe();
+            let backend = std::sync::Arc::new(ActiveDisplayBackend {
+                width: 1920,
+                height: 1080,
+            });
+            let session = std::sync::Arc::new(display::DisplaySession::new(0, backend));
+            session.set_agent_visible(false);
+            let mut registry = display::SessionRegistry::new();
+            registry.insert(0, std::sync::Arc::clone(&session));
+            let registry = std::sync::Arc::new(tokio::sync::RwLock::new(registry));
+
+            // A view request over an existing private view: stays private.
+            activate_user_display(&bus, &registry, None, 0, false).await;
+            match tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await {
+                Ok(Ok(AppEvent::DisplayReady { agent_visible, .. })) => {
+                    assert!(!agent_visible, "view request must not change the mode");
+                }
+                other => panic!("expected DisplayReady, got {other:?}"),
+            }
+            assert!(!session.agent_visible());
+            assert!(
+                registry.read().await.get(0).is_none(),
+                "agent lookups still can't see the private view"
+            );
+
+            // An explicit agent grant upgrades the private view in place.
+            activate_user_display(&bus, &registry, None, 0, true).await;
+            match tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await {
+                Ok(Ok(AppEvent::DisplayReady { agent_visible, .. })) => {
+                    assert!(agent_visible, "grant must report the upgraded mode");
+                }
+                other => panic!("expected DisplayReady, got {other:?}"),
+            }
+            assert!(session.agent_visible(), "session upgraded in place");
+            assert!(
+                registry.read().await.get(0).is_some(),
+                "agent lookups see the display after the upgrade"
+            );
+
+            // And a later view request never downgrades the shared session.
+            activate_user_display(&bus, &registry, None, 0, false).await;
+            match tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await {
+                Ok(Ok(AppEvent::DisplayReady { agent_visible, .. })) => {
+                    assert!(
+                        agent_visible,
+                        "revoking agent access is an explicit revoke, not a view side effect"
+                    );
+                }
+                other => panic!("expected DisplayReady, got {other:?}"),
+            }
+            assert!(session.agent_visible());
         });
     }
 

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -395,6 +395,13 @@ pub enum AppEvent {
         display_id: u32,
         width: u32,
         height: u32,
+        /// Whether agents may see this display (mirrors
+        /// [`crate::display::DisplaySession::agent_visible`]). `false`
+        /// marks a private user view: consumers that surface displays to
+        /// agents or peers (presence display list, peer upcasters,
+        /// recording auto-start) must skip it; dashboards use it to
+        /// render the "private view" chip on the tile.
+        agent_visible: bool,
     },
 
     /// Resolution changed on a live display (e.g. monitor mode switch, scale
@@ -451,6 +458,13 @@ pub enum AppEvent {
     UserDisplayGranted {
         /// The display ID that was granted.  0 = primary (default).
         display_id: u32,
+        /// `true` = the classic grant: the display is shared with agents
+        /// for computer use (and the autonomy user-display grant is set
+        /// by the emitter). `false` = a private user view ("View this
+        /// machine"): the capture session streams to the owner's
+        /// dashboards only and stays out of every agent-facing lookup.
+        /// A `true` grant upgrades an existing private view in place.
+        agent_visible: bool,
     },
     UserDisplayRevoked {
         /// The display ID being revoked.  0 = primary (default).
@@ -1567,6 +1581,16 @@ pub enum ControlMsg {
         /// display (id 0) -- backwards-compatible with single-monitor setups.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         display_id: Option<u32>,
+        /// Whether the created display session is visible to agents.
+        /// `None` (absent on the wire) means `true` — the pre-split
+        /// message always meant "share with the agent for computer
+        /// use", and old frontends keep that meaning. `Some(false)` is
+        /// the dashboard's "View this machine": a private remote view
+        /// streamed to the user's dashboards only, invisible to agent
+        /// display enumeration/screenshot/CU paths and never touching
+        /// the autonomy user-display grant.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        agent_visible: Option<bool>,
     },
     RevokeUserDisplay {
         /// Optional display ID to revoke.  When `None`, revokes the primary
@@ -2122,10 +2146,12 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
             display_id,
             width,
             height,
+            agent_visible,
         } => Some(OutboundEvent::DisplayReady {
             display_id: *display_id,
             width: *width,
             height: *height,
+            agent_visible: *agent_visible,
         }),
         AppEvent::DisplayResize {
             display_id,
@@ -2143,7 +2169,13 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
             display_id: *display_id,
             note: note.clone(),
         }),
-        AppEvent::UserDisplayGranted { .. } => Some(OutboundEvent::UserDisplayGranted),
+        AppEvent::UserDisplayGranted {
+            display_id,
+            agent_visible,
+        } => Some(OutboundEvent::UserDisplayGranted {
+            display_id: *display_id,
+            agent_visible: *agent_visible,
+        }),
         AppEvent::UserDisplayRevoked { display_id, note } => {
             Some(OutboundEvent::UserDisplayRevoked {
                 display_id: *display_id,
@@ -2848,8 +2880,9 @@ fn write_event_to_session_log(session_log: &crate::SharedSessionLog, event: &App
             display_id,
             width,
             height,
+            agent_visible,
         } => {
-            log.display_ready(*display_id, *width, *height);
+            log.display_ready(*display_id, *width, *height, *agent_visible);
         }
         AppEvent::DisplayResize {
             display_id,
@@ -2896,9 +2929,17 @@ fn write_event_to_session_log(session_log: &crate::SharedSessionLog, event: &App
                 .unwrap_or_default();
             log.info(&format!("Shared view {} on {}{}", action, target, detail));
         }
-        AppEvent::UserDisplayGranted { display_id } => {
+        AppEvent::UserDisplayGranted {
+            display_id,
+            agent_visible,
+        } => {
             log.info(&format!(
-                "User display access grant recorded (display_id: {})",
+                "User display {} recorded (display_id: {})",
+                if *agent_visible {
+                    "access grant"
+                } else {
+                    "private view"
+                },
                 display_id
             ));
         }
@@ -3583,7 +3624,10 @@ mod tests {
                 display_id: 99,
                 note: Some("done testing".to_string()),
             },
-            ControlMsg::GrantUserDisplay { display_id: None },
+            ControlMsg::GrantUserDisplay {
+                display_id: None,
+                agent_visible: None,
+            },
             ControlMsg::RevokeUserDisplay {
                 display_id: None,
                 note: Some("done with user display".to_string()),
@@ -4314,11 +4358,17 @@ mod tests {
 
     #[test]
     fn control_msg_grant_user_display_deserialize() {
+        // The legacy wire shape (no agent_visible) must keep parsing —
+        // and keep meaning "share with the agent" (None → true at the
+        // control plane).
         let json = r#"{"action":"grant_user_display"}"#;
         let msg: ControlMsg = serde_json::from_str(json).unwrap();
         assert!(matches!(
             msg,
-            ControlMsg::GrantUserDisplay { display_id: None }
+            ControlMsg::GrantUserDisplay {
+                display_id: None,
+                agent_visible: None,
+            }
         ));
 
         // With explicit display_id
@@ -4327,7 +4377,19 @@ mod tests {
         assert!(matches!(
             msg,
             ControlMsg::GrantUserDisplay {
-                display_id: Some(2)
+                display_id: Some(2),
+                agent_visible: None,
+            }
+        ));
+
+        // The dashboard's "View this machine" — a private view.
+        let json = r#"{"action":"grant_user_display","display_id":2,"agent_visible":false}"#;
+        let msg: ControlMsg = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            msg,
+            ControlMsg::GrantUserDisplay {
+                display_id: Some(2),
+                agent_visible: Some(false),
             }
         ));
     }

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -1312,7 +1312,11 @@ async fn apply_user_approval(
     }
     if cat == autonomy::ActionCategory::DisplayControl && !state.user_display_granted {
         state.user_display_granted = true;
-        bus.send(AppEvent::UserDisplayGranted { display_id: 0 });
+        // Approving an agent display-control action IS the agent opt-in.
+        bus.send(AppEvent::UserDisplayGranted {
+            display_id: 0,
+            agent_visible: true,
+        });
     }
 }
 
@@ -2764,12 +2768,16 @@ pub fn spawn_user_display_listener(
         let mut virtual_display_guards = virtual_display::VirtualDisplayGuards::new();
         loop {
             match rx.recv().await {
-                Ok(AppEvent::UserDisplayGranted { display_id }) => {
+                Ok(AppEvent::UserDisplayGranted {
+                    display_id,
+                    agent_visible,
+                }) => {
                     activate_user_display(
                         &bus,
                         &session_registry,
                         frame_registry.clone(),
                         display_id,
+                        agent_visible,
                     )
                     .await;
                 }

--- a/src/bin/caller/mcp/commands.rs
+++ b/src/bin/caller/mcp/commands.rs
@@ -1199,23 +1199,39 @@ pub(crate) async fn handle_control_command_mcp(
             );
             Some(RESOURCE_LOGS_URI)
         }
-        ControlMsg::GrantUserDisplay { display_id } => {
+        ControlMsg::GrantUserDisplay {
+            display_id,
+            agent_visible,
+        } => {
             let did = display_id.unwrap_or(0);
+            // Absent on the wire = the pre-split meaning: share with the
+            // agent. `Some(false)` = private user view — never touches
+            // the autonomy grant.
+            let agent_visible = agent_visible.unwrap_or(true);
+            // Filtered lookup on purpose: an active private view reads as
+            // absent, so an agent-visible grant falls through to the
+            // event and the activation listener upgrades it in place.
             let active_resolution = active_display_session_resolution(state, did).await;
             let autonomy = {
                 let mut s = state.write().await;
                 s.user_display_activation_pending.remove(&did);
                 s.autonomy.clone()
             };
-            autonomy.write().await.user_display_granted = true;
+            if agent_visible {
+                autonomy.write().await.user_display_granted = true;
+            }
             if let Some((width, height)) = active_resolution {
                 bus.send(AppEvent::DisplayReady {
                     display_id: did,
                     width,
                     height,
+                    agent_visible: true,
                 });
             } else {
-                bus.send(AppEvent::UserDisplayGranted { display_id: did });
+                bus.send(AppEvent::UserDisplayGranted {
+                    display_id: did,
+                    agent_visible,
+                });
             }
             emit_control_result(
                 control_tx,

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -603,12 +603,20 @@ pub fn spawn_event_listener(
                         resource_changed = Some("intendant://logs");
                     }
 
-                    AppEvent::UserDisplayGranted { display_id } => {
+                    AppEvent::UserDisplayGranted {
+                        display_id,
+                        agent_visible,
+                    } => {
                         let active_resolution = s.display_session_resolution_now(display_id);
-                        s.push_log(
-                            LogLevel::Warn,
-                            user_display_grant_result_message(display_id, active_resolution),
-                        );
+                        let msg = if agent_visible {
+                            user_display_grant_result_message(display_id, active_resolution)
+                        } else {
+                            format!(
+                                "User display {display_id} opened as a private view \
+                                 (dashboard-only; not agent-visible)"
+                            )
+                        };
+                        s.push_log(LogLevel::Warn, msg);
                         resource_changed = Some("intendant://logs");
                     }
 

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -2120,7 +2120,7 @@ fn resolve_refs(value: &mut serde_json::Value, defs: &serde_json::Map<String, se
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::autonomy::{self, AutonomyState};
     use tempfile::tempdir;
@@ -2161,9 +2161,9 @@ mod tests {
         )))
     }
 
-    struct TestDisplayBackend {
-        width: u32,
-        height: u32,
+    pub(crate) struct TestDisplayBackend {
+        pub(crate) width: u32,
+        pub(crate) height: u32,
     }
 
     #[async_trait::async_trait]

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -197,6 +197,11 @@ impl IntendantServer {
                 .to_string();
         }
         let display_id = params.display_id.unwrap_or(0);
+        // Filtered lookup on purpose: an active *private view* session
+        // reads as absent here, so the grant falls through to the
+        // UserDisplayGranted event and the activation listener upgrades
+        // the view to agent-shared in place (this tool is owner-surface
+        // only — the call is the opt-in).
         let active_resolution = active_display_session_resolution(&self.state, display_id).await;
         let autonomy = {
             let mut state = self.state.write().await;
@@ -209,9 +214,13 @@ impl IntendantServer {
                 display_id,
                 width,
                 height,
+                agent_visible: true,
             });
         } else {
-            self.bus.send(AppEvent::UserDisplayGranted { display_id });
+            self.bus.send(AppEvent::UserDisplayGranted {
+                display_id,
+                agent_visible: true,
+            });
         }
         user_display_grant_result_message(display_id, active_resolution)
     }
@@ -286,8 +295,14 @@ impl IntendantServer {
                 state.user_display_activation_pending.get(&0).copied(),
             )
         };
+        // `get_any`: a private user view is still a live portal session —
+        // re-emitting a grant here would upgrade it to agent-visible from
+        // an implicit reacquire path. With the view treated as "already
+        // active", the screenshot's own (filtered) session lookup then
+        // fails with the no-session guidance and the caller must use the
+        // explicit owner-only grant to share it.
         if let Some(registry) = &session_registry {
-            if registry.read().await.get(0).is_some() {
+            if registry.read().await.get_any(0).is_some() {
                 self.state.write().await.note_display_capture_ready(0);
                 return UserSessionDisplayActivationRequest::AlreadyActive;
             }
@@ -322,8 +337,10 @@ impl IntendantServer {
             let mut guard = autonomy.write().await;
             guard.user_display_granted = true;
         }
-        self.bus
-            .send(AppEvent::UserDisplayGranted { display_id: 0 });
+        self.bus.send(AppEvent::UserDisplayGranted {
+            display_id: 0,
+            agent_visible: true,
+        });
         UserSessionDisplayActivationRequest::Requested
     }
 
@@ -374,8 +391,12 @@ impl IntendantServer {
             }
         }
 
+        // `get_any`: an existing private view counts as "already active"
+        // — sharing a view is an explicit grant, not a side effect of a
+        // shared-view call (the capture verb's own filtered lookup still
+        // refuses to read the private session).
         if let Some(registry) = session_registry {
-            if registry.read().await.get(display_id).is_some() {
+            if registry.read().await.get_any(display_id).is_some() {
                 return Ok(());
             }
         }
@@ -386,7 +407,10 @@ impl IntendantServer {
             let mut guard = autonomy.write().await;
             guard.user_display_granted = true;
         }
-        self.bus.send(AppEvent::UserDisplayGranted { display_id });
+        self.bus.send(AppEvent::UserDisplayGranted {
+            display_id,
+            agent_visible: true,
+        });
         Ok(())
     }
 
@@ -1078,7 +1102,8 @@ mod tests {
             assert!(!result.is_error.unwrap_or(false));
 
             match timeout(Duration::from_secs(1), rx.recv()).await {
-                Ok(Ok(AppEvent::UserDisplayGranted { display_id })) => {
+                Ok(Ok(AppEvent::UserDisplayGranted { display_id, agent_visible })) => {
+                    assert!(agent_visible, "MCP grant paths always share with the agent");
                     assert_eq!(display_id, 99);
                 }
                 other => panic!("expected UserDisplayGranted event, got {other:?}"),
@@ -1187,7 +1212,8 @@ mod tests {
             assert!(!result.is_error.unwrap_or(false));
 
             match timeout(Duration::from_secs(1), rx.recv()).await {
-                Ok(Ok(AppEvent::UserDisplayGranted { display_id })) => {
+                Ok(Ok(AppEvent::UserDisplayGranted { display_id, agent_visible })) => {
+                    assert!(agent_visible, "MCP grant paths always share with the agent");
                     assert_eq!(display_id, 0);
                 }
                 other => panic!("expected UserDisplayGranted event, got {other:?}"),
@@ -1415,7 +1441,8 @@ mod tests {
             assert!(!result.is_error.unwrap_or(false));
 
             match timeout(Duration::from_secs(1), rx.recv()).await {
-                Ok(Ok(AppEvent::UserDisplayGranted { display_id })) => {
+                Ok(Ok(AppEvent::UserDisplayGranted { display_id, agent_visible })) => {
+                    assert!(agent_visible, "MCP grant paths always share with the agent");
                     assert_eq!(display_id, 2);
                 }
                 other => panic!("expected UserDisplayGranted event, got {other:?}"),
@@ -1498,7 +1525,8 @@ mod tests {
             );
 
             match timeout(Duration::from_secs(1), rx.recv()).await {
-                Ok(Ok(AppEvent::UserDisplayGranted { display_id })) => {
+                Ok(Ok(AppEvent::UserDisplayGranted { display_id, agent_visible })) => {
+                    assert!(agent_visible, "MCP grant paths always share with the agent");
                     assert_eq!(display_id, 0);
                 }
                 other => panic!("expected UserDisplayGranted event, got {other:?}"),
@@ -1605,7 +1633,8 @@ mod tests {
                 "refreshed pending timestamp should be current"
             );
             match timeout(Duration::from_secs(1), rx.recv()).await {
-                Ok(Ok(AppEvent::UserDisplayGranted { display_id })) => {
+                Ok(Ok(AppEvent::UserDisplayGranted { display_id, agent_visible })) => {
+                    assert!(agent_visible, "MCP grant paths always share with the agent");
                     assert_eq!(display_id, 0);
                 }
                 other => panic!("expected refreshed UserDisplayGranted event, got {other:?}"),
@@ -1656,9 +1685,11 @@ mod tests {
                     display_id,
                     width,
                     height,
+                    agent_visible,
                 })) => {
                     assert_eq!(display_id, 0);
                     assert_eq!((width, height), (1920, 1080));
+                    assert!(agent_visible, "the MCP grant shares with the agent");
                 }
                 other => panic!("expected DisplayReady event, got {other:?}"),
             }

--- a/src/bin/caller/peer/handle.rs
+++ b/src/bin/caller/peer/handle.rs
@@ -1007,6 +1007,7 @@ mod tests {
                     display_id: 99,
                     width: 1920,
                     height: 1080,
+                    agent_visible: true,
                 })
                 .unwrap(),
             )

--- a/src/bin/caller/peer/upcast.rs
+++ b/src/bin/caller/peer/upcast.rs
@@ -350,9 +350,21 @@ pub(crate) struct PeerDisplayFold {
 }
 
 impl PeerDisplayFold {
-    /// Upsert from a `display_ready` / `display_resize`; emits only
-    /// when the display is new or its geometry actually changed.
-    fn ready(&mut self, display_id: u32, width: u32, height: u32) -> Vec<PeerEvent> {
+    /// Upsert from a `display_ready`; emits only when the display is new
+    /// or its geometry actually changed. `agent_visible == false` marks a
+    /// private user view — those are never announced to peers (a peer's
+    /// agents and dashboards are not the granting user), and one that was
+    /// previously tracked as shared retires with a `DisplayLost`.
+    fn ready(
+        &mut self,
+        display_id: u32,
+        width: u32,
+        height: u32,
+        agent_visible: bool,
+    ) -> Vec<PeerEvent> {
+        if !agent_visible {
+            return self.lost(display_id, Some("private user view".to_string()));
+        }
         let info = PeerDisplayInfo {
             display_id,
             width,
@@ -370,6 +382,17 @@ impl PeerDisplayFold {
         } else {
             vec![]
         }
+    }
+
+    /// Geometry update from a `display_resize`. Only updates displays
+    /// already tracked: resize events carry no visibility, so letting
+    /// them upsert would resurrect a private view (or a lost display)
+    /// from its resize traffic.
+    fn resize(&mut self, display_id: u32, width: u32, height: u32) -> Vec<PeerEvent> {
+        if !self.displays.contains_key(&display_id) {
+            return vec![];
+        }
+        self.ready(display_id, width, height, true)
     }
 
     /// Retire a display; emits only if it was actually tracked (a
@@ -967,7 +990,10 @@ impl AppEventUpcaster {
                 display_id,
                 width,
                 height,
-            } => self.displays.ready(*display_id, *width, *height),
+                agent_visible,
+            } => self
+                .displays
+                .ready(*display_id, *width, *height, *agent_visible),
 
             AppEvent::DisplayResize {
                 display_id,
@@ -979,7 +1005,7 @@ impl AppEventUpcaster {
                     "display",
                     format!("display {display_id} resized to {width}x{height}"),
                 )];
-                events.extend(self.displays.ready(*display_id, *width, *height));
+                events.extend(self.displays.resize(*display_id, *width, *height));
                 events
             }
 
@@ -1009,11 +1035,24 @@ impl AppEventUpcaster {
                 format!("display approval pending on {backend}"),
             )],
 
-            AppEvent::UserDisplayGranted { display_id } => vec![log_event(
-                LogLevel::Info,
-                "display",
-                format!("user granted display {display_id}"),
-            )],
+            // Private views ride the same event with agent_visible=false;
+            // peers are not told about them at all (not even a log line —
+            // "the owner is privately viewing their screen" is nobody
+            // else's telemetry).
+            AppEvent::UserDisplayGranted {
+                display_id,
+                agent_visible,
+            } => {
+                if *agent_visible {
+                    vec![log_event(
+                        LogLevel::Info,
+                        "display",
+                        format!("user granted display {display_id}"),
+                    )]
+                } else {
+                    vec![]
+                }
+            }
 
             AppEvent::UserDisplayRevoked { display_id, note } => {
                 let note_str = note.as_deref().unwrap_or("");
@@ -2305,7 +2344,10 @@ impl WireEventUpcaster {
                 display_id,
                 width,
                 height,
-            } => self.displays.ready(*display_id, *width, *height),
+                agent_visible,
+            } => self
+                .displays
+                .ready(*display_id, *width, *height, *agent_visible),
 
             OutboundEvent::DisplayResize {
                 display_id,
@@ -2317,7 +2359,7 @@ impl WireEventUpcaster {
                     "display",
                     format!("display {display_id} resized to {width}x{height}"),
                 )];
-                events.extend(self.displays.ready(*display_id, *width, *height));
+                events.extend(self.displays.resize(*display_id, *width, *height));
                 events
             }
 
@@ -2349,14 +2391,24 @@ impl WireEventUpcaster {
                 format!("display approval pending on {backend}"),
             )],
 
-            // OutboundEvent::UserDisplayGranted has NO fields on the
-            // wire — AppEvent has `display_id: u32` but that's dropped
-            // in app_event_to_outbound. Parity test documents this.
-            OutboundEvent::UserDisplayGranted => vec![log_event(
-                LogLevel::Info,
-                "display",
-                "user granted display".to_string(),
-            )],
+            // Private views (agent_visible=false) are not surfaced to
+            // peers at all — see the AppEvent twin. Old wires omit both
+            // fields; serde defaults them to display 0 / agent-visible,
+            // the pre-split meaning.
+            OutboundEvent::UserDisplayGranted {
+                display_id,
+                agent_visible,
+            } => {
+                if *agent_visible {
+                    vec![log_event(
+                        LogLevel::Info,
+                        "display",
+                        format!("user granted display {display_id}"),
+                    )]
+                } else {
+                    vec![]
+                }
+            }
 
             OutboundEvent::UserDisplayRevoked { display_id, note } => {
                 let note_str = note.as_deref().unwrap_or("");
@@ -3033,6 +3085,7 @@ mod tests {
             display_id: 1,
             width: 1920,
             height: 1080,
+            agent_visible: true,
         });
         assert_eq!(ready.len(), 1);
         match &ready[0] {
@@ -3831,6 +3884,7 @@ mod tests {
             display_id: 1,
             width: 1920,
             height: 1080,
+            agent_visible: true,
         });
     }
 
@@ -3857,6 +3911,7 @@ mod tests {
             display_id,
             width,
             height,
+            agent_visible: true,
         }
     }
 
@@ -4202,11 +4257,17 @@ mod tests {
         );
     }
 
-    /// `UserDisplayGranted` loses its `display_id` field on the wire
-    /// — `OutboundEvent::UserDisplayGranted` has no fields at all.
+    /// `UserDisplayGranted` carries `display_id` + `agent_visible` on
+    /// the wire since the private-view split (it was fieldless before);
+    /// both upcast paths preserve the id, and private views
+    /// (`agent_visible: false`) are silent on BOTH paths — peers are
+    /// never told about the owner's private screen view.
     #[test]
-    fn drift_user_display_granted_loses_display_id_on_wire() {
-        let app_event = AppEvent::UserDisplayGranted { display_id: 99 };
+    fn user_display_granted_paths_agree_and_hide_private_views() {
+        let app_event = AppEvent::UserDisplayGranted {
+            display_id: 99,
+            agent_visible: true,
+        };
         let mut app_upcaster = AppEventUpcaster::new();
         let path_a = app_upcaster.upcast(&app_event);
         let msg_a = match &path_a[0] {
@@ -4227,9 +4288,32 @@ mod tests {
             _ => panic!("expected Log"),
         };
         assert!(
-            !msg_b.contains("99"),
-            "wire path cannot include display_id because wire variant has no fields: {msg_b}"
+            msg_b.contains("99"),
+            "wire path preserves display_id since the private-view split: {msg_b}"
         );
+
+        // Private view: silence on both paths.
+        let private = AppEvent::UserDisplayGranted {
+            display_id: 3,
+            agent_visible: false,
+        };
+        assert!(
+            app_upcaster.upcast(&private).is_empty(),
+            "app path must not announce a private view to peers"
+        );
+        let outbound_private =
+            crate::event::app_event_to_outbound(&private).expect("UserDisplayGranted maps");
+        assert!(
+            wire_upcaster.upcast(&outbound_private).is_empty(),
+            "wire path must not announce a private view to peers"
+        );
+
+        // Legacy fieldless wire line: defaults keep the old meaning
+        // (display 0, agent-visible) and still announce.
+        let legacy: OutboundEvent =
+            serde_json::from_str(r#"{"event":"user_display_granted"}"#).unwrap();
+        let legacy_events = wire_upcaster.upcast(&legacy);
+        assert_eq!(legacy_events.len(), 1, "legacy grant lines still log");
     }
 
     // ===================================================================

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -1289,8 +1289,14 @@ pub fn update_agent_state(event: &AppEvent, state: &Arc<Mutex<AgentStateSnapshot
             display_id,
             width,
             height,
-            ..
+            agent_visible,
         } => {
+            // A private user view is not an available display for the
+            // presence model's routing decisions — it belongs to the
+            // user's dashboards only.
+            if !agent_visible {
+                return;
+            }
             let prefix = if *display_id == 0 {
                 "user_session".to_string()
             } else {

--- a/src/bin/caller/recording.rs
+++ b/src/bin/caller/recording.rs
@@ -892,8 +892,13 @@ async fn start_display_auto(
         return Err("ffmpeg not installed".to_string());
     }
 
+    // `get_any`: reaching this function is already an authorized recording
+    // decision (the auto path skips private views before calling; the
+    // manual path is an explicit user command), and the frame-fed branch
+    // must find a private view's session or it would fall through to the
+    // legacy x11grab path and record the same pixels anyway.
     let display_session = match session_registry {
-        Some(sr) => sr.read().await.get(display_id),
+        Some(sr) => sr.read().await.get_any(display_id),
         None => None,
     };
 
@@ -936,10 +941,22 @@ pub fn spawn_recording_listener(
                     display_id,
                     width,
                     height,
-                    ..
+                    agent_visible,
                 }) => {
                     // Auto-recording is opt-in; if disabled in config, skip.
                     if !registry.read().await.is_enabled() {
+                        continue;
+                    }
+                    // Never auto-record a private user view: its frames
+                    // would land on disk in the session log dir, which
+                    // agents routinely read. An explicit user-initiated
+                    // StartRecording (the arm below) still works — that is
+                    // the user's own recording decision.
+                    if !agent_visible {
+                        eprintln!(
+                            "[recording] display {display_id} is a private user view; \
+                             skipping auto-record"
+                        );
                         continue;
                     }
                     match start_display_auto(

--- a/src/bin/caller/session_log/bus_events.rs
+++ b/src/bin/caller/session_log/bus_events.rs
@@ -607,21 +607,26 @@ impl SessionLog {
         });
     }
 
-    /// Log display ready.
-    pub fn display_ready(&mut self, display_id: u32, width: u32, height: u32) {
+    /// Log display ready. `agent_visible == false` marks a private user
+    /// view (streams to the owner's dashboards only; agents can't see it).
+    pub fn display_ready(&mut self, display_id: u32, width: u32, height: u32, agent_visible: bool) {
         self.emit(LogEvent {
             ts: Self::ts(),
             turn: None,
             event: "display_ready".to_string(),
             level: Some("info".to_string()),
             message: Some(format!(
-                "Display :{} ready ({}x{})",
-                display_id, width, height
+                "Display :{} ready ({}x{}){}",
+                display_id,
+                width,
+                height,
+                if agent_visible { "" } else { " [private user view]" }
             )),
             data: Some(serde_json::json!({
                 "display_id": display_id,
                 "width": width,
                 "height": height,
+                "agent_visible": agent_visible,
             })),
             file: None,
             file2: None,

--- a/src/bin/caller/session_log/replay.rs
+++ b/src/bin/caller/session_log/replay.rs
@@ -828,6 +828,12 @@ pub fn session_log_entry_to_app_event(
             display_id: u32_from_data(data, "display_id")?,
             width: u32_from_data(data, "width").unwrap_or(0),
             height: u32_from_data(data, "height").unwrap_or(0),
+            // Logs that predate the private-view split never hid displays
+            // from agents, so absent means agent-visible.
+            agent_visible: data
+                .and_then(|d| d.get("agent_visible"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true),
         }),
         "display_resize" => Some(AppEvent::DisplayResize {
             display_id: u32_from_data(data, "display_id")?,
@@ -1872,7 +1878,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let log_dir = dir.path().join("session");
         let mut log = SessionLog::open(log_dir.clone()).unwrap();
-        log.display_ready(99, 1920, 1080);
+        log.display_ready(99, 1920, 1080, true);
         log.display_taken(99);
         log.display_released(99, Some("session ended"));
         drop(log);
@@ -1883,10 +1889,24 @@ mod tests {
                 display_id,
                 width,
                 height,
+                agent_visible,
             } => {
                 assert_eq!(display_id, 99);
                 assert_eq!(width, 1920);
                 assert_eq!(height, 1080);
+                assert!(agent_visible);
+            }
+            other => panic!("expected DisplayReady, got {:?}", other),
+        }
+
+        // Pre-split log lines have no agent_visible — absent means true.
+        let mut legacy = ready.clone();
+        if let Some(data) = legacy.get_mut("data").and_then(|d| d.as_object_mut()) {
+            data.remove("agent_visible");
+        }
+        match session_log_entry_to_app_event(&legacy, &log_dir).unwrap() {
+            AppEvent::DisplayReady { agent_visible, .. } => {
+                assert!(agent_visible, "legacy display_ready lines default visible");
             }
             other => panic!("expected DisplayReady, got {:?}", other),
         }

--- a/src/bin/caller/types.rs
+++ b/src/bin/caller/types.rs
@@ -177,6 +177,12 @@ pub struct UserQuestion {
     pub multi_select: bool,
 }
 
+/// Serde default for fields whose wire absence means `true` (lines
+/// written before the field existed keep their historical meaning).
+fn default_true() -> bool {
+    true
+}
+
 /// Events sent to connected control socket clients, web gateway, and MCP.
 ///
 /// Also deserialized by `crate::peer::upcast::OutboundEventUpcaster`
@@ -290,6 +296,12 @@ pub enum OutboundEvent {
         display_id: u32,
         width: u32,
         height: u32,
+        /// `false` marks a private user view ("View this machine"):
+        /// dashboards render the tile with a "private view" chip; peer
+        /// upcasters skip it. Absent on wires older than the split —
+        /// those daemons never hid displays, so default `true`.
+        #[serde(default = "default_true")]
+        agent_visible: bool,
     },
     DisplayResize {
         display_id: u32,
@@ -304,7 +316,18 @@ pub enum OutboundEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         note: Option<String>,
     },
-    UserDisplayGranted,
+    UserDisplayGranted {
+        /// Which display the grant/view targets. Absent on wires older
+        /// than the private-view split (the variant used to be fieldless);
+        /// 0 = primary, matching the historical single-display meaning.
+        #[serde(default)]
+        display_id: u32,
+        /// `false` = private user view (dashboard-only); `true` = shared
+        /// with the agent for computer use. Absent-means-true keeps old
+        /// wire lines meaning what they always meant.
+        #[serde(default = "default_true")]
+        agent_visible: bool,
+    },
     UserDisplayRevoked {
         display_id: u32,
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/bin/caller/virtual_display.rs
+++ b/src/bin/caller/virtual_display.rs
@@ -100,8 +100,10 @@ pub(crate) async fn create_virtual_display(
     // Displays this daemon holds alive must never be orphan-reclaimed by
     // the allocator: our own guards, plus every registered virtual capture
     // session (an agent-launched Xvfb has a session but no guard here).
+    // `all_display_ids`: allocation must also avoid ids held by private
+    // user views, which the agent-facing enumeration hides.
     let mut exclude: Vec<u32> = guards.keys().copied().collect();
-    for id in session_registry.read().await.display_ids() {
+    for id in session_registry.read().await.all_display_ids() {
         if id != 0 && !exclude.contains(&id) {
             exclude.push(id);
         }
@@ -132,10 +134,14 @@ pub(crate) async fn create_virtual_display(
                 level: Some(LogLevel::Info),
                 turn: None,
             });
-            activate_user_display(bus, session_registry, frame_registry, display_id).await;
+            // Dashboard-created virtual displays are agent workspaces:
+            // always agent-visible.
+            activate_user_display(bus, session_registry, frame_registry, display_id, true).await;
             // Activation failure already reported its reason; don't leave a
             // guarded Xvfb running with no tile and no way to destroy it.
-            if session_registry.read().await.get(display_id).is_none()
+            // (`get_any` for symmetry — this is lifecycle bookkeeping, not
+            // an agent lookup, though virtual displays are never hidden.)
+            if session_registry.read().await.get_any(display_id).is_none()
                 && guards.remove(&display_id).is_some()
             {
                 eprintln!("[virtual_display] :{display_id} activation failed — Xvfb reaped");

--- a/src/bin/caller/web_gateway/input_authority.rs
+++ b/src/bin/caller/web_gateway/input_authority.rs
@@ -990,7 +990,9 @@ pub(crate) async fn close_federated_peers_for_sessions(
     {
         let reg = sr.read().await;
         for (sid, did) in released {
-            if let Some(session) = reg.get(*did) {
+            // `get_any`: teardown must reach every session that could
+            // have accepted this connection's peers.
+            if let Some(session) = reg.get_any(*did) {
                 targets.push((session, peer_id_for_federated_session(sid)));
             }
         }

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -1504,16 +1504,20 @@ pub fn spawn_web_gateway(
                     let bootstrap_authority_snapshots: Vec<(u32, &'static str)> =
                         if let Some(ref sr) = session_registry {
                             let reg = sr.read().await;
-                            let active_ids: Vec<u32> = reg.display_ids();
+                            // Dashboards are the user surface: replay
+                            // private user views too (they exist FOR this
+                            // surface), tagged so the tile renders its
+                            // "private view" chip.
+                            let active_ids: Vec<u32> = reg.all_display_ids();
                             // Snapshot resolutions + auth states under the
                             // std lock, then drop the guard before any
                             // direct_tx.send calls.
-                            let resolutions: Vec<(u32, u32, u32)> = active_ids
+                            let resolutions: Vec<(u32, u32, u32, bool)> = active_ids
                                 .iter()
                                 .filter_map(|&did| {
-                                    reg.get(did).map(|session| {
+                                    reg.get_any(did).map(|session| {
                                         let (w, h) = session.resolution();
-                                        (did, w, h)
+                                        (did, w, h, session.agent_visible())
                                     })
                                 })
                                 .collect();
@@ -1522,19 +1526,20 @@ pub fn spawn_web_gateway(
                                     .read()
                                     .unwrap_or_else(|e| e.into_inner());
                                 compute_bootstrap_authority_snapshots(
-                                    resolutions.iter().map(|(did, _, _)| *did),
+                                    resolutions.iter().map(|(did, _, _, _)| *did),
                                     &auth,
                                     &connection_id,
                                 )
                             };
                             // Send the display_ready frames now; defer the
                             // authority frames until after log_replay.
-                            for (did, w, h) in resolutions {
+                            for (did, w, h, agent_visible) in resolutions {
                                 let ready = serde_json::json!({
                                     "event": "display_ready",
                                     "display_id": did,
                                     "width": w,
                                     "height": h,
+                                    "agent_visible": agent_visible,
                                 });
                                 let _ = direct_tx.send(ready.to_string());
                             }

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -312,6 +312,28 @@ pub(crate) async fn displays_response_body(
     session_registry: &Option<crate::display::SharedSessionRegistry>,
 ) -> String {
     let displays = crate::display::enumerate_displays_with_sessions(session_registry).await;
+    // This route serves the owner's dashboards (the display picker), so
+    // each entry is annotated with its live capture state via the
+    // unfiltered registry view: `capture_active` plus `agent_visible`
+    // (false = private user view). Agent-facing display enumeration
+    // (MCP `list_displays`, ctl) uses the filtered lookups and never
+    // sees a private view's session.
+    let mut displays: Vec<serde_json::Value> = displays
+        .iter()
+        .map(|d| serde_json::to_value(d).unwrap_or_else(|_| serde_json::json!({})))
+        .collect();
+    if let Some(sr) = session_registry.as_ref() {
+        let reg = sr.read().await;
+        for entry in displays.iter_mut() {
+            let Some(id) = entry.get("id").and_then(|v| v.as_u64()) else {
+                continue;
+            };
+            if let Some(session) = reg.get_any(id as u32) {
+                entry["capture_active"] = serde_json::json!(true);
+                entry["agent_visible"] = serde_json::json!(session.agent_visible());
+            }
+        }
+    }
     // Object form (normalizeDisplaysPayload accepts both): the displays
     // surface also advertises display capabilities, so dashboards derive
     // affordances like "New virtual display" instead of mirroring the

--- a/src/bin/caller/web_gateway/ws_session.rs
+++ b/src/bin/caller/web_gateway/ws_session.rs
@@ -85,8 +85,11 @@ pub(crate) async fn ws_outbound_task(
                         // tokio lock for the active-display list — order
                         // matters: take the std lock LAST and drop it before
                         // awaiting the send to avoid awaiting under a sync guard.
-                                        let display_ids: Vec<u32> = match session_registry.as_ref() {
-                            Some(sr) => sr.read().await.display_ids(),
+                                        // `all_display_ids`: authority chips are a
+                        // dashboard surface — private user views hold
+                        // input authority like any other display.
+                        let display_ids: Vec<u32> = match session_registry.as_ref() {
+                            Some(sr) => sr.read().await.all_display_ids(),
                             None => Vec::new(),
                         };
                         let snapshots: Vec<(u32, &'static str)> = {
@@ -1255,10 +1258,12 @@ pub(crate) async fn ws_inbound_task(
                         // (notably deactivate_user_display's
                         // registry.write()) for as long as this block
                         // runs. The Arc keeps the session alive
-                        // independently of the lock.
+                        // independently of the lock. `get_any`: local
+                        // dashboard viewers are the user surface —
+                        // private user views stream here (and only here).
                         let session: Option<Arc<crate::display::DisplaySession>> =
                             match session_registry_inbound.as_ref() {
-                                Some(sr) => sr.read().await.get(display_id),
+                                Some(sr) => sr.read().await.get_any(display_id),
                                 None => None,
                             };
                         if let Some(session) = session {
@@ -1388,9 +1393,12 @@ pub(crate) async fn ws_inbound_task(
                             // first lets deactivate proceed
                             // immediately; the session Arc keeps the
                             // target alive while mDNS resolves.
+                            // `get_any`: same local-dashboard leg as the
+                            // display_offer handler — private user views
+                            // stream to the owner's dashboards.
                             let session: Option<Arc<crate::display::DisplaySession>> =
                                 match sr_clone.as_ref() {
-                                    Some(sr) => sr.read().await.get(display_id),
+                                    Some(sr) => sr.read().await.get_any(display_id),
                                     None => None,
                                 };
                             if let Some(session) = session {
@@ -1696,9 +1704,12 @@ pub(crate) async fn ws_inbound_task(
                             if let Ok(input_event) =
                                 serde_json::from_value::<crate::display::InputEvent>(evt.clone())
                             {
+                                // `get_any`: dashboard input drives private
+                                // user views too (that's the remote-control
+                                // point of "View this machine").
                                 let session: Option<Arc<crate::display::DisplaySession>> =
                                     match session_registry_inbound.as_ref() {
-                                        Some(sr) => sr.read().await.get(display_id),
+                                        Some(sr) => sr.read().await.get_any(display_id),
                                         None => None,
                                     };
                                 if let Some(session) = session {
@@ -2058,12 +2069,13 @@ pub(crate) async fn ws_inbound_task(
     if is_presence_connected && is_active {
         bus_inbound.send(AppEvent::PresenceDisconnected);
     }
-    // Remove this peer from display sessions it connected to
+    // Remove this peer from display sessions it connected to. `get_any`:
+    // teardown must find private user views too, or their RTC peers leak.
     if !peer_display_ids.is_empty() {
         if let Some(ref sr) = session_registry_inbound {
             let reg = sr.read().await;
             for did in &peer_display_ids {
-                if let Some(session) = reg.get(*did) {
+                if let Some(session) = reg.get_any(*did) {
                     session.remove_peer(peer_id).await;
                 }
             }

--- a/static/app.html
+++ b/static/app.html
@@ -297,6 +297,9 @@ html {
   color: var(--red);
 }
 .status-bar #sb-display-access.granted { color: var(--green); }
+/* Private view active: the chip reads 'view' in a neutral accent — the
+   agent does NOT have the display, so the granted green stays off. */
+.status-bar #sb-display-access.view-only { color: var(--blue); }
 .display-toggle-wrap { position: relative; display: inline-flex; align-items: center; gap: 4px; }
 .display-picker {
   display: none;
@@ -10250,6 +10253,27 @@ body.display-fullscreen-open {
   color: var(--blue);
   font-family: monospace;
   white-space: nowrap;
+}
+/* Agent-visibility chip on the display tile: "Private view" (the agent
+   cannot see this display) vs "Agent can see this" (a user display
+   shared for computer use). Hidden for agent-owned virtual displays. */
+.display-visibility {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: 999px;
+  border: 1px solid var(--surface1);
+  white-space: nowrap;
+}
+.display-visibility.private {
+  color: var(--green);
+  border-color: color-mix(in srgb, var(--green) 40%, transparent);
+  background: color-mix(in srgb, var(--green) 12%, transparent);
+}
+.display-visibility.agent {
+  color: var(--peach);
+  border-color: color-mix(in srgb, var(--peach) 40%, transparent);
+  background: color-mix(in srgb, var(--peach) 12%, transparent);
 }
 .display-status {
   font-size: 12px;
@@ -29013,6 +29037,38 @@ const SHELL_KEY_SEQS = {
 // Displays
 const displaySlots = new Map();
 const peerDisplayConnections = new Map(); // sessionKey -> PeerDisplayConnection
+// Per-display agent visibility, fed by `display_ready` / `user_display_granted`
+// events (both carry `agent_visible` since the private-view split). false =
+// a private user view ("View this machine"): streams to this dashboard only,
+// invisible to agent screenshot/CU/enumeration paths on the daemon.
+const displayAgentVisibility = new Map();
+// Display ids that are user-display sessions (granted or private-viewed) --
+// distinguishes "agent can see this" chips on user screens from ordinary
+// agent-owned virtual displays, which get no chip.
+const userDisplayIds = new Set();
+// User-display grant state (single active slot, matching the daemon's
+// per-daemon grant flag). Declared here -- before the display fragments
+// that render against it at load time -- because module-scope `let` from
+// a later fragment is in TDZ during earlier fragments' initial render.
+let userDisplayGranted = false;
+let grantedDisplayId = 0;
+// Mode of the active user-display session: true = shared with the agent
+// (computer use), false = a private view. Meaningful only while
+// userDisplayGranted is true.
+let userDisplayAgentVisible = true;
+function setDisplayAgentVisibility(displayId, visible) {
+  displayId = Number(displayId);
+  displayAgentVisibility.set(displayId, !!visible);
+  const slot = displaySlots.get(displayId);
+  if (slot && typeof slot.setAgentVisibility === 'function') {
+    slot.setAgentVisibility(!!visible);
+  }
+}
+function clearDisplayAgentVisibility(displayId) {
+  displayId = Number(displayId);
+  displayAgentVisibility.delete(displayId);
+  userDisplayIds.delete(displayId);
+}
 // Session/phase state is read by Station during direct #station boot before
 // the lower dashboard sections finish registering their helpers.
 const sessionsListCache = new Map();
@@ -36691,13 +36747,19 @@ async function main() {
           }
         }
       }
-      // Track user display grant/revoke events
+      // Track user display grant/revoke events. `agent_visible` is
+      // absent on wires older than the private-view split; absent
+      // means the classic agent share.
       if (d.event === 'user_display_granted') {
         grantedDisplayId = Number(d.display_id || 0);
-        setUserDisplayState(true);
+        const agentVisible = d.agent_visible !== false;
+        userDisplayIds.add(grantedDisplayId);
+        setDisplayAgentVisibility(grantedDisplayId, agentVisible);
+        setUserDisplayState(true, agentVisible);
       } else if (d.event === 'user_display_revoked') {
         const revokedId = Number(d.display_id || 0);
         if (Number(grantedDisplayId) === revokedId) setUserDisplayState(false);
+        clearDisplayAgentVisibility(revokedId);
         removeDisplaySlot(revokedId);
         const banner = document.getElementById('display-approval-banner');
         if (banner) banner.classList.add('hidden');
@@ -36738,6 +36800,11 @@ async function main() {
       if (d.event === 'display_ready') {
         const banner = document.getElementById('display-approval-banner');
         if (banner) banner.classList.add('hidden');
+        // Record the display's agent-visibility mode for the tile chip
+        // (live events and the gateway's bootstrap replay both carry it).
+        if (d.agent_visible !== undefined) {
+          setDisplayAgentVisibility(Number(d.display_id || 0), d.agent_visible !== false);
+        }
       }
       // Track recording state on display slots
       if (d.event === 'recording_started' && d.stream_name) {
@@ -56340,6 +56407,7 @@ class DisplaySlot {
     this.el.innerHTML = `
       <div class="display-toolbar">
         <span class="display-label">${label}</span>
+        <span class="display-visibility" id="ds-visibility-${displayId}" style="display:none"></span>
         <span class="display-status" id="ds-status-${displayId}">Connecting...</span>
         <span class="display-input-authority" id="ds-authority-${displayId}" style="display:none" title="Input authority for this display: who can drive keyboard/mouse. Phase 5c."></span>
         <input class="release-note" id="ds-note-${displayId}" placeholder="Note (optional)" style="display:none">
@@ -56356,6 +56424,7 @@ class DisplaySlot {
       </div>
       <div class="display-canvas" id="display-canvas-${displayId}"></div>`;
     this.statusEl = this.el.querySelector(`#ds-status-${displayId}`);
+    this.visibilityEl = this.el.querySelector(`#ds-visibility-${displayId}`);
     this.authorityEl = this.el.querySelector(`#ds-authority-${displayId}`);
     this.noteInput = this.el.querySelector(`#ds-note-${displayId}`);
     this.takeBtn = this.el.querySelector(`#ds-take-${displayId}`);
@@ -56432,6 +56501,7 @@ class DisplaySlot {
     const displayId = Number(this.displayId);
     dispatchDashboardActionMsg({ action: 'revoke_user_display', display_id: displayId });
     removeDisplaySlot(displayId);
+    clearDisplayAgentVisibility(displayId);
     if (Number(grantedDisplayId) === displayId) {
       setUserDisplayState(false);
     }
@@ -57110,6 +57180,36 @@ class DisplaySlot {
   // the source of truth for input enforcement; this UI logic exists
   // strictly to keep the chip + buttons + interactive mode consistent
   // with what the gate is doing.
+  // Render the agent-visibility chip: "Private view" (the agent cannot
+  // see this display) vs "Agent can see this" (a user display shared for
+  // computer use). Agent-owned virtual displays get no chip -- they are
+  // the agent's own workspaces, so annotating them is noise.
+  setAgentVisibility(visible) {
+    if (!this.visibilityEl) return;
+    const id = Number(this.displayId);
+    if (visible === false) {
+      this.visibilityEl.textContent = 'Private view';
+      this.visibilityEl.title =
+        'Only your dashboard can see this display. It is hidden from the ' +
+        "agent's screenshot, computer-use, and display-listing paths.";
+      this.visibilityEl.classList.add('private');
+      this.visibilityEl.classList.remove('agent');
+      this.visibilityEl.style.display = '';
+    } else if (visible === true && userDisplayIds.has(id)) {
+      this.visibilityEl.textContent = 'Agent can see this';
+      this.visibilityEl.title =
+        'This screen is shared with the agent for computer-use tasks ' +
+        'until you revoke access.';
+      this.visibilityEl.classList.add('agent');
+      this.visibilityEl.classList.remove('private');
+      this.visibilityEl.style.display = '';
+    } else {
+      this.visibilityEl.style.display = 'none';
+    }
+    // The ui2 live rail re-renders via its MutationObserver on
+    // #displays-container (class/style/text changes on this chip).
+  }
+
   setAuthority(state) {
     if (state !== 'you' && state !== 'other' && state !== 'unclaimed') {
       // Forward-compat: future state strings (we don't expect any) leave
@@ -57602,6 +57702,11 @@ function addDisplaySlot(displayId, width, height) {
   }
   const slot = new DisplaySlot(displayId, width, height);
   displaySlots.set(displayId, slot);
+  // Apply the recorded agent-visibility mode (from display_ready /
+  // user_display_granted events, which may precede slot creation).
+  if (displayAgentVisibility.has(displayId)) {
+    slot.setAgentVisibility(displayAgentVisibility.get(displayId));
+  }
   // Phase 5c: drain any authority state that arrived before this slot
   // existed.  See pendingAuthorityStates docs for the race rationale.
   const pendingState = pendingAuthorityStates.get(displayId);
@@ -57865,6 +57970,13 @@ if (typeof ui2Enabled === 'function' && ui2Enabled()) (() => {
       main.appendChild(meta);
       row.appendChild(dot);
       row.appendChild(main);
+      if (displayAgentVisibility.get(Number(slot.displayId)) === false) {
+        const tag = document.createElement('span');
+        tag.className = 'ui2-live-row-tag';
+        tag.textContent = 'PRIVATE';
+        tag.title = 'Private view — the agent cannot see this display';
+        row.appendChild(tag);
+      }
       if (slot.connected) {
         const tag = document.createElement('span');
         tag.className = 'ui2-live-row-tag';
@@ -57990,7 +58102,6 @@ if (typeof ui2Enabled === 'function' && ui2Enabled()) (() => {
 
   function renderYourScreen() {
     yourScreen.textContent = '';
-    const chip = document.getElementById('sb-display-access');
     const card = document.createElement('div');
     card.className = 'ui2-live-card';
     const head = document.createElement('div');
@@ -58001,32 +58112,64 @@ if (typeof ui2Enabled === 'function' && ui2Enabled()) (() => {
     title.className = 'ui2-live-card-title';
     title.style.flex = '1';
     title.textContent = 'Your screen';
-    const granted = !!(chip && chip.classList.contains('granted'));
+    // Two distinct things can be active here, and the card never
+    // conflates them:
+    //  - a PRIVATE VIEW ("View this machine"): remote view/control of
+    //    this machine from the dashboard; the agent cannot see it;
+    //  - an AGENT SHARE ("Share with agent"): the screen is visible to
+    //    the agent for computer-use tasks.
+    // (Streaming frames to the live presence/voice model is a third,
+    // separate control -- the Stream button on the display tile.)
+    const granted = userDisplayGranted;
+    const shared = granted && userDisplayAgentVisible;
     const pill = document.createElement('span');
-    pill.className = 'ui2-live-state-pill' + (granted ? ' you' : '');
-    pill.textContent = granted ? 'shared' : 'off';
+    pill.className = 'ui2-live-state-pill'
+      + (shared ? ' other' : granted ? ' you' : '');
+    pill.textContent = shared ? 'agent can see this' : granted ? 'private view' : 'off';
     head.appendChild(title);
     head.appendChild(pill);
     const sub = document.createElement('div');
     sub.className = 'ui2-live-card-sub';
-    sub.textContent = granted
+    sub.textContent = shared
       ? 'The agent can see and drive this screen for computer-use tasks until you revoke access.'
-      : 'Share your own screen with the agent for computer-use tasks. You choose the display and can revoke at any time.';
+      : granted
+        ? 'Streaming to your dashboard only. The agent cannot see this display.'
+        : 'View and control this machine’s display from here, or share it with the agent for computer-use tasks. You choose the display and can stop at any time.';
     card.appendChild(head);
     card.appendChild(sub);
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'ui2-live-card-btn ' + (granted ? 'danger' : 'secondary');
-    btn.textContent = granted ? 'Revoke access' : 'Share your screen…';
-    btn.title = chip ? chip.title : '';
-    btn.disabled = !chip;
-    btn.addEventListener('click', (e) => {
-      // Same flow as the status-bar chip (single display → instant
-      // grant; multiple → picker popover anchored at the chip).
-      e.stopPropagation();
-      if (chip) chip.click();
-    });
-    card.appendChild(btn);
+    const addBtn = (label, cls, title, onClick) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'ui2-live-card-btn ' + cls;
+      btn.textContent = label;
+      btn.title = title;
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        onClick();
+      });
+      card.appendChild(btn);
+      return btn;
+    };
+    if (!granted) {
+      // Primary: private remote view. Secondary: the agent share.
+      addBtn('View this machine', 'secondary',
+        'Watch and control this machine’s display from the dashboard. Private: the agent cannot see it.',
+        () => { if (typeof startUserDisplayGrantFlow === 'function') startUserDisplayGrantFlow('view'); });
+      addBtn('Share with agent…', 'secondary',
+        'Make this screen visible to the agent for computer-use tasks. Revocable at any time.',
+        () => { if (typeof startUserDisplayGrantFlow === 'function') startUserDisplayGrantFlow('share'); });
+    } else if (!shared) {
+      addBtn('Stop viewing', 'danger',
+        'Close the private view of this machine.',
+        () => { if (typeof revokeUserDisplayNow === 'function') revokeUserDisplayNow(); });
+      addBtn('Share with agent', 'secondary',
+        'Upgrade this private view: make the display visible to the agent for computer-use tasks.',
+        () => { if (typeof shareUserDisplayWithAgent === 'function') shareUserDisplayWithAgent(); });
+    } else {
+      addBtn('Revoke access', 'danger',
+        'Take the display away from the agent and stop streaming it.',
+        () => { if (typeof revokeUserDisplayNow === 'function') revokeUserDisplayNow(); });
+    }
     yourScreen.appendChild(card);
   }
 
@@ -86920,9 +87063,13 @@ function updateDisplayMetrics(d) {
 }
 
 // ── User display access toggle ──
-let userDisplayGranted = false;
-let grantedDisplayId = 0;
+// (userDisplayGranted / grantedDisplayId / userDisplayAgentVisible are
+// declared in fragment 32 next to the display maps: earlier fragments
+// render against them at load time.)
 let displayPickerVisible = false;
+// Which action the open picker performs: 'share' (agent access) or
+// 'view' (private remote view; the agent cannot see the display).
+let displayPickerMode = 'share';
 var cachedDisplays = null;
 
 function hideDisplayPicker() {
@@ -86931,7 +87078,8 @@ function hideDisplayPicker() {
   displayPickerVisible = false;
 }
 
-function showDisplayPicker(displays) {
+function showDisplayPicker(displays, mode) {
+  displayPickerMode = mode === 'view' ? 'view' : 'share';
   const picker = document.getElementById('display-picker');
   picker.innerHTML = '';
   for (const d of displays) {
@@ -86954,13 +87102,13 @@ function showDisplayPicker(displays) {
       e.stopPropagation();
       hideDisplayPicker();
       if (!app) return;
-      dispatchDashboardActionMsg({ action: 'grant_user_display', display_id: d.id });
-      grantedDisplayId = d.id;
-      setUserDisplayState(true);
+      grantUserDisplayTarget(d, displayPickerMode !== 'view');
     });
     picker.appendChild(item);
   }
-  if (virtualDisplaysAvailableNow()) {
+  if (displayPickerMode !== 'view' && virtualDisplaysAvailableNow()) {
+    // Virtual displays are agent workspaces — offering one from the
+    // private "View this machine" flow would conflate the two concepts.
     const createItem = document.createElement('div');
     createItem.className = 'display-picker-item dp-action';
     createItem.textContent = 'New virtual display';
@@ -87020,14 +87168,81 @@ window.createVirtualDisplay = function(event) {
   }
 };
 
-function grantUserDisplayTarget(display) {
+function grantUserDisplayTarget(display, agentVisible = true) {
   const displayId = Number(display?.id);
   const msg = { action: 'grant_user_display' };
   if (Number.isFinite(displayId) && displayId !== 0) msg.display_id = displayId;
+  // The bare message is the legacy wire shape and means "share with the
+  // agent"; only the private view sends the new field.
+  if (!agentVisible) msg.agent_visible = false;
   dispatchDashboardActionMsg(msg);
   grantedDisplayId = Number.isFinite(displayId) ? displayId : 0;
-  setUserDisplayState(true);
+  userDisplayIds.add(grantedDisplayId);
+  setDisplayAgentVisibility(grantedDisplayId, agentVisible);
+  setUserDisplayState(true, agentVisible);
 }
+
+// Start a user-display flow in the given mode: 'share' makes the chosen
+// display visible to the agent for computer use (the classic grant);
+// 'view' opens a private remote view of this machine that the agent
+// cannot see. Single physical display grants instantly; multiple open
+// the picker in that mode.
+function startUserDisplayGrantFlow(mode) {
+  if (!app) return;
+  const agentVisible = mode !== 'view';
+  const applyDisplayList = (displays) => {
+    cachedDisplays = displays;
+    const rows = Array.isArray(displays) ? displays : [];
+    const physicalDisplays = rows.filter((display) => display?.kind !== 'window');
+    if (rows.length <= 1 || physicalDisplays.length === 1) {
+      grantUserDisplayTarget(physicalDisplays[0] || rows[0], agentVisible);
+    } else {
+      showDisplayPicker(rows, mode);
+    }
+  };
+  if (cachedDisplays && cachedDisplays.length > 0) {
+    applyDisplayList(cachedDisplays);
+    return;
+  }
+  fetchLocalDisplaysPayload()
+    .then(normalizeDisplaysPayload)
+    .then(applyDisplayList)
+    .catch(() => {
+      // Fetch failed: fall back to the default display.
+      grantUserDisplayTarget(null, agentVisible);
+    });
+}
+
+// Revoke the active user-display session (share or private view).
+function revokeUserDisplayNow() {
+  if (!app || !userDisplayGranted) return;
+  // Tear the display slot down locally before the round-trip -- see
+  // toggleUserDisplay for why (decode-saturated main thread delays the
+  // server's revoke broadcast by seconds).
+  removeDisplaySlot(Number(grantedDisplayId));
+  dispatchDashboardActionMsg({ action: 'revoke_user_display', display_id: Number(grantedDisplayId) || 0 });
+  clearDisplayAgentVisibility(Number(grantedDisplayId));
+  setUserDisplayState(false);
+}
+window.revokeUserDisplayNow = revokeUserDisplayNow;
+
+// Upgrade the active private view to an agent share (or start a share
+// flow when nothing is active). Never downgrades an existing share.
+function shareUserDisplayWithAgent() {
+  if (!app) return;
+  if (userDisplayGranted && !userDisplayAgentVisible) {
+    const msg = { action: 'grant_user_display' };
+    if (Number(grantedDisplayId) !== 0) msg.display_id = Number(grantedDisplayId);
+    dispatchDashboardActionMsg(msg);
+    userDisplayIds.add(Number(grantedDisplayId));
+    setDisplayAgentVisibility(Number(grantedDisplayId), true);
+    setUserDisplayState(true, true);
+    return;
+  }
+  if (!userDisplayGranted) startUserDisplayGrantFlow('share');
+}
+window.shareUserDisplayWithAgent = shareUserDisplayWithAgent;
+window.startUserDisplayGrantFlow = startUserDisplayGrantFlow;
 
 window.cycleAutonomy = function() {
   const levels = ['Low', 'Medium', 'High', 'Full'];
@@ -87039,6 +87254,11 @@ window.cycleAutonomy = function() {
   dispatchControlMsg({ action: 'set_autonomy', level: next.toLowerCase() });
 };
 
+// The v1 status-bar chip stays a pure on/off toggle with its historical
+// agent-share semantics: off -> start a SHARE flow; anything active
+// (share or private view) -> revoke. Upgrading a private view to an
+// agent share is only ever an explicit button on the ui2 "Your screen"
+// card -- never a side effect of clicking a toggle.
 window.toggleUserDisplay = function(event) {
   if (!app) return;
   if (event?.stopPropagation) event.stopPropagation();
@@ -87055,50 +87275,28 @@ window.toggleUserDisplay = function(event) {
     // confirmation of something we've already done rather than a gate
     // on the UI response. removeDisplaySlot is idempotent — if the
     // broadcast does arrive later, re-running it is a no-op.
-    removeDisplaySlot(Number(grantedDisplayId));
-    dispatchDashboardActionMsg({ action: 'revoke_user_display', display_id: Number(grantedDisplayId) || 0 });
-    setUserDisplayState(false);
+    revokeUserDisplayNow();
     return;
   }
-  // If we've already enumerated displays this session, use the cached
-  // result and short-circuit the fetch. /api/displays runs xrandr
-  // against the X server, which blocks behind in-flight XShmGetImage
-  // calls from any concurrent capture — so right after a revoke
-  // (while the backgrounded capture thread is still joining), the
-  // call can take 1-1.5s and stalls the indicator flip by the same
-  // margin. Displays rarely change mid-session, so honoring the
-  // cache between toggles makes ON#2 as fast as ON#1 without trading
-  // correctness for speed: we still fetch on first toggle to
-  // populate the cache, and a hotplug that invalidates the cache
-  // would surface either as a stale picker entry (benign) or a
-  // failed grant that user can retry (also benign).
-  const applyDisplayList = (displays) => {
-    cachedDisplays = displays;
-    const rows = Array.isArray(displays) ? displays : [];
-    const physicalDisplays = rows.filter((display) => display?.kind !== 'window');
-    if (rows.length <= 1 || physicalDisplays.length === 1) {
-      grantUserDisplayTarget(physicalDisplays[0] || rows[0]);
-    } else {
-      showDisplayPicker(rows);
-    }
-  };
-  if (cachedDisplays && cachedDisplays.length > 0) {
-    applyDisplayList(cachedDisplays);
-    return;
-  }
-  fetchLocalDisplaysPayload()
-    .then(normalizeDisplaysPayload)
-    .then(applyDisplayList)
-    .catch(() => {
-      // Fetch failed: fall back to granting default display
-      grantUserDisplayTarget(null);
-    });
+  // startUserDisplayGrantFlow reuses the cached /api/displays result
+  // between toggles: the route runs xrandr against the X server, which
+  // blocks behind in-flight XShmGetImage calls from any concurrent
+  // capture — so right after a revoke (while the backgrounded capture
+  // thread is still joining), the call can take 1-1.5s and stalls the
+  // indicator flip by the same margin. Displays rarely change
+  // mid-session; a hotplug surfaces as a stale picker entry (benign)
+  // or a failed grant the user can retry (also benign).
+  startUserDisplayGrantFlow('share');
 };
-function setUserDisplayState(granted) {
+function setUserDisplayState(granted, agentVisible = true) {
   userDisplayGranted = granted;
+  userDisplayAgentVisible = granted ? agentVisible : true;
   const el = document.getElementById('sb-display-access');
-  el.textContent = granted ? 'on' : 'off';
-  el.classList.toggle('granted', granted);
+  // 'on' keeps its historical meaning: the AGENT has the display. A
+  // private view shows 'view' and never lights the granted style.
+  el.textContent = granted ? (agentVisible ? 'on' : 'view') : 'off';
+  el.classList.toggle('granted', granted && agentVisible);
+  el.classList.toggle('view-only', granted && !agentVisible);
 }
 
 // Dismiss display picker on click outside or Escape

--- a/static/app/10-styles-shell.css
+++ b/static/app/10-styles-shell.css
@@ -211,6 +211,9 @@ html {
   color: var(--red);
 }
 .status-bar #sb-display-access.granted { color: var(--green); }
+/* Private view active: the chip reads 'view' in a neutral accent — the
+   agent does NOT have the display, so the granted green stays off. */
+.status-bar #sb-display-access.view-only { color: var(--blue); }
 .display-toggle-wrap { position: relative; display: inline-flex; align-items: center; gap: 4px; }
 .display-picker {
   display: none;

--- a/static/app/14-styles-displays-voice.css
+++ b/static/app/14-styles-displays-voice.css
@@ -148,6 +148,27 @@ body.display-fullscreen-open {
   font-family: monospace;
   white-space: nowrap;
 }
+/* Agent-visibility chip on the display tile: "Private view" (the agent
+   cannot see this display) vs "Agent can see this" (a user display
+   shared for computer use). Hidden for agent-owned virtual displays. */
+.display-visibility {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 7px;
+  border-radius: 999px;
+  border: 1px solid var(--surface1);
+  white-space: nowrap;
+}
+.display-visibility.private {
+  color: var(--green);
+  border-color: color-mix(in srgb, var(--green) 40%, transparent);
+  background: color-mix(in srgb, var(--green) 12%, transparent);
+}
+.display-visibility.agent {
+  color: var(--peach);
+  border-color: color-mix(in srgb, var(--peach) 40%, transparent);
+  background: color-mix(in srgb, var(--peach) 12%, transparent);
+}
 .display-status {
   font-size: 12px;
   color: var(--overlay0);

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -2947,6 +2947,38 @@ const SHELL_KEY_SEQS = {
 // Displays
 const displaySlots = new Map();
 const peerDisplayConnections = new Map(); // sessionKey -> PeerDisplayConnection
+// Per-display agent visibility, fed by `display_ready` / `user_display_granted`
+// events (both carry `agent_visible` since the private-view split). false =
+// a private user view ("View this machine"): streams to this dashboard only,
+// invisible to agent screenshot/CU/enumeration paths on the daemon.
+const displayAgentVisibility = new Map();
+// Display ids that are user-display sessions (granted or private-viewed) --
+// distinguishes "agent can see this" chips on user screens from ordinary
+// agent-owned virtual displays, which get no chip.
+const userDisplayIds = new Set();
+// User-display grant state (single active slot, matching the daemon's
+// per-daemon grant flag). Declared here -- before the display fragments
+// that render against it at load time -- because module-scope `let` from
+// a later fragment is in TDZ during earlier fragments' initial render.
+let userDisplayGranted = false;
+let grantedDisplayId = 0;
+// Mode of the active user-display session: true = shared with the agent
+// (computer use), false = a private view. Meaningful only while
+// userDisplayGranted is true.
+let userDisplayAgentVisible = true;
+function setDisplayAgentVisibility(displayId, visible) {
+  displayId = Number(displayId);
+  displayAgentVisibility.set(displayId, !!visible);
+  const slot = displaySlots.get(displayId);
+  if (slot && typeof slot.setAgentVisibility === 'function') {
+    slot.setAgentVisibility(!!visible);
+  }
+}
+function clearDisplayAgentVisibility(displayId) {
+  displayId = Number(displayId);
+  displayAgentVisibility.delete(displayId);
+  userDisplayIds.delete(displayId);
+}
 // Session/phase state is read by Station during direct #station boot before
 // the lower dashboard sections finish registering their helpers.
 const sessionsListCache = new Map();

--- a/static/app/36-voice-wasm-init.js
+++ b/static/app/36-voice-wasm-init.js
@@ -597,13 +597,19 @@ async function main() {
           }
         }
       }
-      // Track user display grant/revoke events
+      // Track user display grant/revoke events. `agent_visible` is
+      // absent on wires older than the private-view split; absent
+      // means the classic agent share.
       if (d.event === 'user_display_granted') {
         grantedDisplayId = Number(d.display_id || 0);
-        setUserDisplayState(true);
+        const agentVisible = d.agent_visible !== false;
+        userDisplayIds.add(grantedDisplayId);
+        setDisplayAgentVisibility(grantedDisplayId, agentVisible);
+        setUserDisplayState(true, agentVisible);
       } else if (d.event === 'user_display_revoked') {
         const revokedId = Number(d.display_id || 0);
         if (Number(grantedDisplayId) === revokedId) setUserDisplayState(false);
+        clearDisplayAgentVisibility(revokedId);
         removeDisplaySlot(revokedId);
         const banner = document.getElementById('display-approval-banner');
         if (banner) banner.classList.add('hidden');
@@ -644,6 +650,11 @@ async function main() {
       if (d.event === 'display_ready') {
         const banner = document.getElementById('display-approval-banner');
         if (banner) banner.classList.add('hidden');
+        // Record the display's agent-visibility mode for the tile chip
+        // (live events and the gateway's bootstrap replay both carry it).
+        if (d.agent_visible !== undefined) {
+          setDisplayAgentVisibility(Number(d.display_id || 0), d.agent_visible !== false);
+        }
       }
       // Track recording state on display slots
       if (d.event === 'recording_started' && d.stream_name) {

--- a/static/app/45-displays-webrtc.js
+++ b/static/app/45-displays-webrtc.js
@@ -131,6 +131,7 @@ class DisplaySlot {
     this.el.innerHTML = `
       <div class="display-toolbar">
         <span class="display-label">${label}</span>
+        <span class="display-visibility" id="ds-visibility-${displayId}" style="display:none"></span>
         <span class="display-status" id="ds-status-${displayId}">Connecting...</span>
         <span class="display-input-authority" id="ds-authority-${displayId}" style="display:none" title="Input authority for this display: who can drive keyboard/mouse. Phase 5c."></span>
         <input class="release-note" id="ds-note-${displayId}" placeholder="Note (optional)" style="display:none">
@@ -147,6 +148,7 @@ class DisplaySlot {
       </div>
       <div class="display-canvas" id="display-canvas-${displayId}"></div>`;
     this.statusEl = this.el.querySelector(`#ds-status-${displayId}`);
+    this.visibilityEl = this.el.querySelector(`#ds-visibility-${displayId}`);
     this.authorityEl = this.el.querySelector(`#ds-authority-${displayId}`);
     this.noteInput = this.el.querySelector(`#ds-note-${displayId}`);
     this.takeBtn = this.el.querySelector(`#ds-take-${displayId}`);
@@ -223,6 +225,7 @@ class DisplaySlot {
     const displayId = Number(this.displayId);
     dispatchDashboardActionMsg({ action: 'revoke_user_display', display_id: displayId });
     removeDisplaySlot(displayId);
+    clearDisplayAgentVisibility(displayId);
     if (Number(grantedDisplayId) === displayId) {
       setUserDisplayState(false);
     }
@@ -901,6 +904,36 @@ class DisplaySlot {
   // the source of truth for input enforcement; this UI logic exists
   // strictly to keep the chip + buttons + interactive mode consistent
   // with what the gate is doing.
+  // Render the agent-visibility chip: "Private view" (the agent cannot
+  // see this display) vs "Agent can see this" (a user display shared for
+  // computer use). Agent-owned virtual displays get no chip -- they are
+  // the agent's own workspaces, so annotating them is noise.
+  setAgentVisibility(visible) {
+    if (!this.visibilityEl) return;
+    const id = Number(this.displayId);
+    if (visible === false) {
+      this.visibilityEl.textContent = 'Private view';
+      this.visibilityEl.title =
+        'Only your dashboard can see this display. It is hidden from the ' +
+        "agent's screenshot, computer-use, and display-listing paths.";
+      this.visibilityEl.classList.add('private');
+      this.visibilityEl.classList.remove('agent');
+      this.visibilityEl.style.display = '';
+    } else if (visible === true && userDisplayIds.has(id)) {
+      this.visibilityEl.textContent = 'Agent can see this';
+      this.visibilityEl.title =
+        'This screen is shared with the agent for computer-use tasks ' +
+        'until you revoke access.';
+      this.visibilityEl.classList.add('agent');
+      this.visibilityEl.classList.remove('private');
+      this.visibilityEl.style.display = '';
+    } else {
+      this.visibilityEl.style.display = 'none';
+    }
+    // The ui2 live rail re-renders via its MutationObserver on
+    // #displays-container (class/style/text changes on this chip).
+  }
+
   setAuthority(state) {
     if (state !== 'you' && state !== 'other' && state !== 'unclaimed') {
       // Forward-compat: future state strings (we don't expect any) leave
@@ -1393,6 +1426,11 @@ function addDisplaySlot(displayId, width, height) {
   }
   const slot = new DisplaySlot(displayId, width, height);
   displaySlots.set(displayId, slot);
+  // Apply the recorded agent-visibility mode (from display_ready /
+  // user_display_granted events, which may precede slot creation).
+  if (displayAgentVisibility.has(displayId)) {
+    slot.setAgentVisibility(displayAgentVisibility.get(displayId));
+  }
   // Phase 5c: drain any authority state that arrived before this slot
   // existed.  See pendingAuthorityStates docs for the race rationale.
   const pendingState = pendingAuthorityStates.get(displayId);
@@ -1656,6 +1694,13 @@ if (typeof ui2Enabled === 'function' && ui2Enabled()) (() => {
       main.appendChild(meta);
       row.appendChild(dot);
       row.appendChild(main);
+      if (displayAgentVisibility.get(Number(slot.displayId)) === false) {
+        const tag = document.createElement('span');
+        tag.className = 'ui2-live-row-tag';
+        tag.textContent = 'PRIVATE';
+        tag.title = 'Private view — the agent cannot see this display';
+        row.appendChild(tag);
+      }
       if (slot.connected) {
         const tag = document.createElement('span');
         tag.className = 'ui2-live-row-tag';
@@ -1781,7 +1826,6 @@ if (typeof ui2Enabled === 'function' && ui2Enabled()) (() => {
 
   function renderYourScreen() {
     yourScreen.textContent = '';
-    const chip = document.getElementById('sb-display-access');
     const card = document.createElement('div');
     card.className = 'ui2-live-card';
     const head = document.createElement('div');
@@ -1792,32 +1836,64 @@ if (typeof ui2Enabled === 'function' && ui2Enabled()) (() => {
     title.className = 'ui2-live-card-title';
     title.style.flex = '1';
     title.textContent = 'Your screen';
-    const granted = !!(chip && chip.classList.contains('granted'));
+    // Two distinct things can be active here, and the card never
+    // conflates them:
+    //  - a PRIVATE VIEW ("View this machine"): remote view/control of
+    //    this machine from the dashboard; the agent cannot see it;
+    //  - an AGENT SHARE ("Share with agent"): the screen is visible to
+    //    the agent for computer-use tasks.
+    // (Streaming frames to the live presence/voice model is a third,
+    // separate control -- the Stream button on the display tile.)
+    const granted = userDisplayGranted;
+    const shared = granted && userDisplayAgentVisible;
     const pill = document.createElement('span');
-    pill.className = 'ui2-live-state-pill' + (granted ? ' you' : '');
-    pill.textContent = granted ? 'shared' : 'off';
+    pill.className = 'ui2-live-state-pill'
+      + (shared ? ' other' : granted ? ' you' : '');
+    pill.textContent = shared ? 'agent can see this' : granted ? 'private view' : 'off';
     head.appendChild(title);
     head.appendChild(pill);
     const sub = document.createElement('div');
     sub.className = 'ui2-live-card-sub';
-    sub.textContent = granted
+    sub.textContent = shared
       ? 'The agent can see and drive this screen for computer-use tasks until you revoke access.'
-      : 'Share your own screen with the agent for computer-use tasks. You choose the display and can revoke at any time.';
+      : granted
+        ? 'Streaming to your dashboard only. The agent cannot see this display.'
+        : 'View and control this machine’s display from here, or share it with the agent for computer-use tasks. You choose the display and can stop at any time.';
     card.appendChild(head);
     card.appendChild(sub);
-    const btn = document.createElement('button');
-    btn.type = 'button';
-    btn.className = 'ui2-live-card-btn ' + (granted ? 'danger' : 'secondary');
-    btn.textContent = granted ? 'Revoke access' : 'Share your screen…';
-    btn.title = chip ? chip.title : '';
-    btn.disabled = !chip;
-    btn.addEventListener('click', (e) => {
-      // Same flow as the status-bar chip (single display → instant
-      // grant; multiple → picker popover anchored at the chip).
-      e.stopPropagation();
-      if (chip) chip.click();
-    });
-    card.appendChild(btn);
+    const addBtn = (label, cls, title, onClick) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'ui2-live-card-btn ' + cls;
+      btn.textContent = label;
+      btn.title = title;
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        onClick();
+      });
+      card.appendChild(btn);
+      return btn;
+    };
+    if (!granted) {
+      // Primary: private remote view. Secondary: the agent share.
+      addBtn('View this machine', 'secondary',
+        'Watch and control this machine’s display from the dashboard. Private: the agent cannot see it.',
+        () => { if (typeof startUserDisplayGrantFlow === 'function') startUserDisplayGrantFlow('view'); });
+      addBtn('Share with agent…', 'secondary',
+        'Make this screen visible to the agent for computer-use tasks. Revocable at any time.',
+        () => { if (typeof startUserDisplayGrantFlow === 'function') startUserDisplayGrantFlow('share'); });
+    } else if (!shared) {
+      addBtn('Stop viewing', 'danger',
+        'Close the private view of this machine.',
+        () => { if (typeof revokeUserDisplayNow === 'function') revokeUserDisplayNow(); });
+      addBtn('Share with agent', 'secondary',
+        'Upgrade this private view: make the display visible to the agent for computer-use tasks.',
+        () => { if (typeof shareUserDisplayWithAgent === 'function') shareUserDisplayWithAgent(); });
+    } else {
+      addBtn('Revoke access', 'danger',
+        'Take the display away from the agent and stop streaming it.',
+        () => { if (typeof revokeUserDisplayNow === 'function') revokeUserDisplayNow(); });
+    }
     yourScreen.appendChild(card);
   }
 

--- a/static/app/58-shortcuts-boot.js
+++ b/static/app/58-shortcuts-boot.js
@@ -191,9 +191,13 @@ function updateDisplayMetrics(d) {
 }
 
 // ── User display access toggle ──
-let userDisplayGranted = false;
-let grantedDisplayId = 0;
+// (userDisplayGranted / grantedDisplayId / userDisplayAgentVisible are
+// declared in fragment 32 next to the display maps: earlier fragments
+// render against them at load time.)
 let displayPickerVisible = false;
+// Which action the open picker performs: 'share' (agent access) or
+// 'view' (private remote view; the agent cannot see the display).
+let displayPickerMode = 'share';
 var cachedDisplays = null;
 
 function hideDisplayPicker() {
@@ -202,7 +206,8 @@ function hideDisplayPicker() {
   displayPickerVisible = false;
 }
 
-function showDisplayPicker(displays) {
+function showDisplayPicker(displays, mode) {
+  displayPickerMode = mode === 'view' ? 'view' : 'share';
   const picker = document.getElementById('display-picker');
   picker.innerHTML = '';
   for (const d of displays) {
@@ -225,13 +230,13 @@ function showDisplayPicker(displays) {
       e.stopPropagation();
       hideDisplayPicker();
       if (!app) return;
-      dispatchDashboardActionMsg({ action: 'grant_user_display', display_id: d.id });
-      grantedDisplayId = d.id;
-      setUserDisplayState(true);
+      grantUserDisplayTarget(d, displayPickerMode !== 'view');
     });
     picker.appendChild(item);
   }
-  if (virtualDisplaysAvailableNow()) {
+  if (displayPickerMode !== 'view' && virtualDisplaysAvailableNow()) {
+    // Virtual displays are agent workspaces — offering one from the
+    // private "View this machine" flow would conflate the two concepts.
     const createItem = document.createElement('div');
     createItem.className = 'display-picker-item dp-action';
     createItem.textContent = 'New virtual display';
@@ -291,14 +296,81 @@ window.createVirtualDisplay = function(event) {
   }
 };
 
-function grantUserDisplayTarget(display) {
+function grantUserDisplayTarget(display, agentVisible = true) {
   const displayId = Number(display?.id);
   const msg = { action: 'grant_user_display' };
   if (Number.isFinite(displayId) && displayId !== 0) msg.display_id = displayId;
+  // The bare message is the legacy wire shape and means "share with the
+  // agent"; only the private view sends the new field.
+  if (!agentVisible) msg.agent_visible = false;
   dispatchDashboardActionMsg(msg);
   grantedDisplayId = Number.isFinite(displayId) ? displayId : 0;
-  setUserDisplayState(true);
+  userDisplayIds.add(grantedDisplayId);
+  setDisplayAgentVisibility(grantedDisplayId, agentVisible);
+  setUserDisplayState(true, agentVisible);
 }
+
+// Start a user-display flow in the given mode: 'share' makes the chosen
+// display visible to the agent for computer use (the classic grant);
+// 'view' opens a private remote view of this machine that the agent
+// cannot see. Single physical display grants instantly; multiple open
+// the picker in that mode.
+function startUserDisplayGrantFlow(mode) {
+  if (!app) return;
+  const agentVisible = mode !== 'view';
+  const applyDisplayList = (displays) => {
+    cachedDisplays = displays;
+    const rows = Array.isArray(displays) ? displays : [];
+    const physicalDisplays = rows.filter((display) => display?.kind !== 'window');
+    if (rows.length <= 1 || physicalDisplays.length === 1) {
+      grantUserDisplayTarget(physicalDisplays[0] || rows[0], agentVisible);
+    } else {
+      showDisplayPicker(rows, mode);
+    }
+  };
+  if (cachedDisplays && cachedDisplays.length > 0) {
+    applyDisplayList(cachedDisplays);
+    return;
+  }
+  fetchLocalDisplaysPayload()
+    .then(normalizeDisplaysPayload)
+    .then(applyDisplayList)
+    .catch(() => {
+      // Fetch failed: fall back to the default display.
+      grantUserDisplayTarget(null, agentVisible);
+    });
+}
+
+// Revoke the active user-display session (share or private view).
+function revokeUserDisplayNow() {
+  if (!app || !userDisplayGranted) return;
+  // Tear the display slot down locally before the round-trip -- see
+  // toggleUserDisplay for why (decode-saturated main thread delays the
+  // server's revoke broadcast by seconds).
+  removeDisplaySlot(Number(grantedDisplayId));
+  dispatchDashboardActionMsg({ action: 'revoke_user_display', display_id: Number(grantedDisplayId) || 0 });
+  clearDisplayAgentVisibility(Number(grantedDisplayId));
+  setUserDisplayState(false);
+}
+window.revokeUserDisplayNow = revokeUserDisplayNow;
+
+// Upgrade the active private view to an agent share (or start a share
+// flow when nothing is active). Never downgrades an existing share.
+function shareUserDisplayWithAgent() {
+  if (!app) return;
+  if (userDisplayGranted && !userDisplayAgentVisible) {
+    const msg = { action: 'grant_user_display' };
+    if (Number(grantedDisplayId) !== 0) msg.display_id = Number(grantedDisplayId);
+    dispatchDashboardActionMsg(msg);
+    userDisplayIds.add(Number(grantedDisplayId));
+    setDisplayAgentVisibility(Number(grantedDisplayId), true);
+    setUserDisplayState(true, true);
+    return;
+  }
+  if (!userDisplayGranted) startUserDisplayGrantFlow('share');
+}
+window.shareUserDisplayWithAgent = shareUserDisplayWithAgent;
+window.startUserDisplayGrantFlow = startUserDisplayGrantFlow;
 
 window.cycleAutonomy = function() {
   const levels = ['Low', 'Medium', 'High', 'Full'];
@@ -310,6 +382,11 @@ window.cycleAutonomy = function() {
   dispatchControlMsg({ action: 'set_autonomy', level: next.toLowerCase() });
 };
 
+// The v1 status-bar chip stays a pure on/off toggle with its historical
+// agent-share semantics: off -> start a SHARE flow; anything active
+// (share or private view) -> revoke. Upgrading a private view to an
+// agent share is only ever an explicit button on the ui2 "Your screen"
+// card -- never a side effect of clicking a toggle.
 window.toggleUserDisplay = function(event) {
   if (!app) return;
   if (event?.stopPropagation) event.stopPropagation();
@@ -326,50 +403,28 @@ window.toggleUserDisplay = function(event) {
     // confirmation of something we've already done rather than a gate
     // on the UI response. removeDisplaySlot is idempotent — if the
     // broadcast does arrive later, re-running it is a no-op.
-    removeDisplaySlot(Number(grantedDisplayId));
-    dispatchDashboardActionMsg({ action: 'revoke_user_display', display_id: Number(grantedDisplayId) || 0 });
-    setUserDisplayState(false);
+    revokeUserDisplayNow();
     return;
   }
-  // If we've already enumerated displays this session, use the cached
-  // result and short-circuit the fetch. /api/displays runs xrandr
-  // against the X server, which blocks behind in-flight XShmGetImage
-  // calls from any concurrent capture — so right after a revoke
-  // (while the backgrounded capture thread is still joining), the
-  // call can take 1-1.5s and stalls the indicator flip by the same
-  // margin. Displays rarely change mid-session, so honoring the
-  // cache between toggles makes ON#2 as fast as ON#1 without trading
-  // correctness for speed: we still fetch on first toggle to
-  // populate the cache, and a hotplug that invalidates the cache
-  // would surface either as a stale picker entry (benign) or a
-  // failed grant that user can retry (also benign).
-  const applyDisplayList = (displays) => {
-    cachedDisplays = displays;
-    const rows = Array.isArray(displays) ? displays : [];
-    const physicalDisplays = rows.filter((display) => display?.kind !== 'window');
-    if (rows.length <= 1 || physicalDisplays.length === 1) {
-      grantUserDisplayTarget(physicalDisplays[0] || rows[0]);
-    } else {
-      showDisplayPicker(rows);
-    }
-  };
-  if (cachedDisplays && cachedDisplays.length > 0) {
-    applyDisplayList(cachedDisplays);
-    return;
-  }
-  fetchLocalDisplaysPayload()
-    .then(normalizeDisplaysPayload)
-    .then(applyDisplayList)
-    .catch(() => {
-      // Fetch failed: fall back to granting default display
-      grantUserDisplayTarget(null);
-    });
+  // startUserDisplayGrantFlow reuses the cached /api/displays result
+  // between toggles: the route runs xrandr against the X server, which
+  // blocks behind in-flight XShmGetImage calls from any concurrent
+  // capture — so right after a revoke (while the backgrounded capture
+  // thread is still joining), the call can take 1-1.5s and stalls the
+  // indicator flip by the same margin. Displays rarely change
+  // mid-session; a hotplug surfaces as a stale picker entry (benign)
+  // or a failed grant the user can retry (also benign).
+  startUserDisplayGrantFlow('share');
 };
-function setUserDisplayState(granted) {
+function setUserDisplayState(granted, agentVisible = true) {
   userDisplayGranted = granted;
+  userDisplayAgentVisible = granted ? agentVisible : true;
   const el = document.getElementById('sb-display-access');
-  el.textContent = granted ? 'on' : 'off';
-  el.classList.toggle('granted', granted);
+  // 'on' keeps its historical meaning: the AGENT has the display. A
+  // private view shows 'view' and never lights the granted style.
+  el.textContent = granted ? (agentVisible ? 'on' : 'view') : 'off';
+  el.classList.toggle('granted', granted && agentVisible);
+  el.classList.toggle('view-only', granted && !agentVisible);
 }
 
 // Dismiss display picker on click outside or Escape


### PR DESCRIPTION
Repo task #15: the dashboard's "Share your screen…" flow conflated remote view/control of your own machine with making the screen visible to the agent. This splits them into two explicit modes on the user-display session, with presence streaming untouched as the third, separate concept.

## Design

A user-display capture session now carries **`agent_visible: bool`**, stored on the `DisplaySession` itself (single source of truth). The registry's **agent-facing accessors filter on it by default** (`SessionRegistry::get` / `display_ids()`), and dashboard surfaces explicitly opt into the unfiltered view (`get_any` / `all_display_ids`) — so future agent-side callers are private-view-safe unless they deliberately opt out (fail closed).

- **View this machine** (new, ui2 "Your screen" card): `grant_user_display { agent_visible: false }` → private view. Streams to the owner's dashboards (WebRTC view + input authority as usual); never sets the autonomy user-display grant; absent from every agent-facing lookup.
- **Share with agent** (existing semantics, unchanged): bare `grant_user_display` → `agent_visible: true`, sets the `DisplayControl` grant. A share over an existing private view **upgrades it in place** (frame publication resumes on the next sampler tick — no capture restart, no second Wayland portal dialog). A view request **never downgrades** a share; taking agent access away is an explicit revoke.
- **Presence streaming** (tile **Stream** button): untouched; copy already says frames go to the presence model only.

## Semantics: old vs new

| Surface | Old (single "Share your screen…") | New: Share with agent | New: View this machine |
|---|---|---|---|
| Wire | `{"action":"grant_user_display"}` | same bare message (`agent_visible` absent = `true`) | `{"action":"grant_user_display","agent_visible":false}` |
| Autonomy `user_display_granted` | set | set | **never set** |
| Runtime children (`INTENDANT_USER_DISPLAY_GRANTED`) | set at spawn | set at spawn | not set |
| CU `execute_actions` user_session gate | passes | passes | refuses (flag unset) |
| Registry lookups (CU session routing, screenshot, `default_display_target`) | visible | visible | **absent** (filtered `get`/`display_ids`) |
| FrameRegistry `display_<id>` stream (auto-attach, `list_frames`/`read_frame`, presence frames) | published | published | **not published** (per-tick sampler gate) |
| Presence available-display list | listed | listed | skipped |
| Peers (DisplayReady/UserDisplayGranted upcasts, federated WebRTC) | announced/streamable | announced/streamable | **silent + unstreamable** |
| Recording | auto-record (if enabled) | auto-record (if enabled) | auto-record skipped; explicit user `StartRecording` still works |
| Dashboard WebRTC view/input, input authority, bootstrap replay | works | works | works (via `get_any`/`all_display_ids`) |
| Revoke | clears grant + tears down | same | same (tears down; grant flag cleared unconditionally — fail-closed over-revocation, pre-existing single-flag coarseness) |

## Agent-facing paths filtered, and how fail-closed is proven

1. **`SessionRegistry::get` / `display_ids()`** filter on `DisplaySession::agent_visible` — covers `computer_use::lookup_display_session` (all CU actions + screenshots), `default_display_target`, `capture_display_screenshot` (CU-first), `enumerate_displays_with_sessions` (MCP `list_displays`, ctl `ListDisplays`), `active_display_session_resolution`, and `handle_federated_webrtc_signal` (peers). Test: `session_registry_agent_hidden_sessions_absent_from_agent_lookups` (display crate) pins get/get_any/display_ids/all_display_ids.
2. **CU executor**: `agent_paths_cannot_reach_private_view_sessions` (computer_use) proves a private session at 0 and at a secondary id is unreachable **even with `user_session_allowed == true`** (the registry filter is a second fence independent of the grant flag), and that `default_display_target` skips private ids.
3. **FrameRegistry model feed**: the 1 Hz sampler in `DisplaySession::start` checks `agent_visible` per tick — private sessions publish no `display_<id>` frames, so `list_frames`/`read_frame`/auto-attach/presence can't see them at the source.
4. **Autonomy grant**: `grant_user_display_agent_visibility_controls_autonomy_grant` (control_plane) pins that `agent_visible: false` never sets the flag and the legacy bare message still does.
5. **Upgrade/no-downgrade**: `activate_user_display_upgrades_private_view_on_agent_grant_only` (display_glue). All implicit re-activation paths (`shared_view` show, Wayland reacquire, MCP `ensure_shared_view_display_active`) now check for an existing session via `get_any` and never emit a grant over one, so only the explicit owner grant verbs can upgrade.
6. **Peers**: `user_display_granted_paths_agree_and_hide_private_views` + updated display-fold tests pin that private views are never announced (both AppEvent and wire upcasters), and that `display_resize` can no longer resurrect an untracked/private display.

## Wire compatibility

- `ControlMsg::GrantUserDisplay` gains optional `agent_visible` (absent = `true`, the pre-split meaning) — old frontends/scripts unchanged; deserialize tests pin all three shapes.
- `AppEvent`/`OutboundEvent::DisplayReady` gain `agent_visible` (serde default `true` on parse); `OutboundEvent::UserDisplayGranted` gains `display_id` + `agent_visible` (was fieldless; defaults keep legacy lines meaning display 0 / shared). Old session logs replay as agent-visible.
- MCP `grant_user_display` / ctl `display grant-user` keep pure agent-share semantics (the view affordance is dashboard-only by design).

## UI

- ui2 "Your screen" card: two actions when off (**View this machine** / **Share with agent…**), mode pill (`private view` / `agent can see this`), per-mode copy, **Stop viewing** / **Revoke access**, plus an explicit upgrade button while a private view is active.
- Display tiles wear a **Private view** / **Agent can see this** chip; live-rail rows a `PRIVATE` tag; the v1 status-bar chip stays a pure toggle (`off`/`view`/`on`) with its historical agent-share click semantics (no accidental escalation — upgrade is only the explicit card button).
- The multi-display picker is mode-aware; "New virtual display" is hidden from the view picker (virtual displays are agent workspaces).
- `/api/displays` entries now carry `capture_active` + `agent_visible` for the owner's dashboards.

## Verification

- `cargo test --bins` — 2702 pass; `cargo nextest -p intendant-display` — 487 pass; `cargo test --test e2e` — 8 pass.
- `cargo clippy` — zero new warnings (diffed against the pristine tree; only pre-existing ones, line-shifted).
- `node --check` on all touched fragments plus the fully assembled `app.html` module script; `app.html` regenerated via `cargo run -p app-html-assembler`.
- Live smoke: headless daemon (`--web 0 --no-tls`, mock provider) serves the enriched `/api/displays` and the new card/chip code; no real capture exercised on this machine (unit tests cover activation/upgrade).

## Open questions

- Revoking a *private view* clears the per-daemon `user_display_granted` flag even though the view never set it (pre-existing single-flag coarseness; over-revocation chosen as the fail-closed direction). Per-display grant tracking would fix the rare share(0)+view(3) interaction.
- ctl/MCP intentionally have no view-only verb; add `--view-only` to `ctl display grant-user` if operators want private views from the CLI.
- On multi-display late joins, the "Agent can see this" chip is best-effort for the *second* shared display after a refresh (the "Private view" chip — the privacy-critical one — is always exact, carried on `display_ready`).
