### PR TITLE
Transport S2: tunnel fs methods delegate to the neutral api core (parity-pinned)

### DIFF
--- a/src/bin/caller/dashboard_control/api_transfers_fs.rs
+++ b/src/bin/caller/dashboard_control/api_transfers_fs.rs
@@ -747,21 +747,26 @@ pub(crate) fn transfer_download_error_task_response(
     }
 }
 
+/// Build the neutral [`crate::web_gateway::ApiRequest`] for a tunnel
+/// method: the frame's `params` object rides verbatim (transport-
+/// unification design §2.1 — the tunnel's shape is the canonical one).
+fn control_api_request(
+    params: Option<&serde_json::Value>,
+    range: Option<crate::web_gateway::ByteRange>,
+) -> crate::web_gateway::ApiRequest {
+    crate::web_gateway::ApiRequest {
+        params: params.cloned().unwrap_or_else(|| serde_json::json!({})),
+        range,
+    }
+}
+
 pub(crate) async fn api_fs_stat_response(id: String, params: Option<&serde_json::Value>) -> serde_json::Value {
-    let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
-    let path = string_param(&params, &["path"]);
-    let result = tokio::task::spawn_blocking(move || {
-        crate::web_gateway::dashboard_fs_stat_response_body(&path)
-    })
-    .await;
+    let request = control_api_request(params, None);
+    let result =
+        tokio::task::spawn_blocking(move || crate::web_gateway::fs_stat_api_response(&request))
+            .await;
     match result {
-        Ok(Ok(body)) => http_body_response(id, 200, body, "filesystem stat"),
-        Ok(Err(error)) => http_body_response(
-            id,
-            400,
-            serde_json::json!({ "error": error }).to_string(),
-            "filesystem stat",
-        ),
+        Ok(response) => frame_api_response(id, response, "filesystem stat"),
         Err(e) => serde_json::json!({
             "t": "response",
             "id": id,
@@ -772,20 +777,12 @@ pub(crate) async fn api_fs_stat_response(id: String, params: Option<&serde_json:
 }
 
 pub(crate) async fn api_fs_list_response(id: String, params: Option<&serde_json::Value>) -> serde_json::Value {
-    let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
-    let path = string_param(&params, &["path"]);
-    let result = tokio::task::spawn_blocking(move || {
-        crate::web_gateway::dashboard_fs_list_response_body(&path)
-    })
-    .await;
+    let request = control_api_request(params, None);
+    let result =
+        tokio::task::spawn_blocking(move || crate::web_gateway::fs_list_api_response(&request))
+            .await;
     match result {
-        Ok(Ok(body)) => http_body_response(id, 200, body, "filesystem list"),
-        Ok(Err(error)) => http_body_response(
-            id,
-            400,
-            serde_json::json!({ "error": error }).to_string(),
-            "filesystem list",
-        ),
+        Ok(response) => frame_api_response(id, response, "filesystem list"),
         Err(e) => serde_json::json!({
             "t": "response",
             "id": id,
@@ -908,9 +905,14 @@ pub(crate) async fn api_fs_read_task_response(
     id: String,
     params: Option<&serde_json::Value>,
 ) -> ControlTaskResponse {
-    let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
-    let path_param = string_param(&params, &["path"]);
-    let offset = match optional_u64_param(&params, &["offset", "start"]) {
+    // Transport-owned range normalization: the tunnel's offset/length
+    // param aliases become the neutral request's ByteRange, exactly as
+    // the HTTP shim lifts its `Range` header (design §2.1 — ranges
+    // arrive pre-normalized, per transport).
+    let offset = match params
+        .map(|p| optional_u64_param(p, &["offset", "start"]))
+        .unwrap_or(Ok(None))
+    {
         Ok(value) => value.unwrap_or(0),
         Err(error) => {
             return filesystem_read_error_task_response(
@@ -920,7 +922,10 @@ pub(crate) async fn api_fs_read_task_response(
             );
         }
     };
-    let length = match optional_u64_param(&params, &["length", "limit"]) {
+    let length = match params
+        .map(|p| optional_u64_param(p, &["length", "limit"]))
+        .unwrap_or(Ok(None))
+    {
         Ok(value) => value,
         Err(error) => {
             return filesystem_read_error_task_response(
@@ -930,183 +935,27 @@ pub(crate) async fn api_fs_read_task_response(
             );
         }
     };
-    let path = match crate::web_gateway::expand_dashboard_fs_path(&path_param) {
-        Ok(path) => path,
-        Err(error) => {
-            return filesystem_read_error_task_response(
-                id,
-                400,
-                serde_json::json!({ "ok": false, "error": error }),
-            );
-        }
-    };
-    let filename = path
-        .file_name()
-        .map(|name| name.to_string_lossy().to_string())
-        .filter(|name| !name.is_empty());
-    let content_type = dashboard_fs_content_type(&path);
-    let read_result = tokio::task::spawn_blocking({
-        let path = path.clone();
-        move || read_dashboard_fs_file_range(&path, offset, length)
-    })
-    .await;
-    let (bytes, total_size, end, display_path) = match read_result {
-        Ok(Ok(value)) => value,
-        Ok(Err((status, body))) => return filesystem_read_error_task_response(id, status, body),
-        Err(e) => {
-            return ControlTaskResponse {
-                id: id.clone(),
-                frame: serde_json::json!({
-                    "t": "response",
-                    "id": id,
-                    "ok": false,
-                    "error": format!("filesystem read task failed: {e}"),
-                }),
-                byte_stream: None,
-                done: true,
-            };
-        }
-    };
-    let size = bytes.len();
-    // Full reads carry the content hash so the editor has a conflict
-    // baseline for its later write-back (mirrors the HTTP route's
-    // X-Content-Sha256 header).
-    let sha256 = (offset == 0 && bytes.len() as u64 == total_size)
-        .then(|| crate::web_gateway::fs_sha256_hex(&bytes));
-    let stream_name = display_path.to_string_lossy().to_string();
-    ControlTaskResponse {
-        id: id.clone(),
-        frame: serde_json::Value::Null,
-        byte_stream: Some(ControlByteStream {
+    let request = control_api_request(
+        params,
+        Some(crate::web_gateway::ByteRange::OffsetLength { offset, length }),
+    );
+    let result =
+        tokio::task::spawn_blocking(move || crate::web_gateway::fs_read_api_response(&request))
+            .await;
+    match result {
+        Ok(response) => frame_api_task_response(id, response, "fs-read", "filesystem read"),
+        Err(e) => ControlTaskResponse {
             id: id.clone(),
-            stream_id: format!("{id}:fs-read"),
-            content_type: content_type.clone(),
-            filename: filename.clone(),
-            bytes,
-            result: serde_json::json!({
-                "ok": true,
-                "path": stream_name,
-                "filename": filename,
-                "content_type": content_type,
-                "size": size,
-                "total_size": total_size,
-                "offset": offset,
-                "range_start": offset,
-                "range_end": end,
-                "resumable": true,
-                "sha256": sha256,
-            }),
-        }),
-        done: true,
-    }
-}
-
-pub(crate) fn dashboard_fs_content_type(path: &std::path::Path) -> String {
-    match path
-        .extension()
-        .and_then(|extension| extension.to_str())
-        .map(|extension| extension.to_ascii_lowercase())
-        .as_deref()
-    {
-        Some("css") => "text/css; charset=utf-8",
-        Some("csv") => "text/csv; charset=utf-8",
-        Some("html") | Some("htm") => "text/html; charset=utf-8",
-        Some("json") => "application/json",
-        Some("js") | Some("mjs") => "text/javascript; charset=utf-8",
-        Some("md") | Some("markdown") | Some("txt") | Some("toml") | Some("yaml") | Some("yml") => {
-            "text/plain; charset=utf-8"
-        }
-        Some("png") => "image/png",
-        Some("jpg") | Some("jpeg") => "image/jpeg",
-        Some("gif") => "image/gif",
-        Some("svg") => "image/svg+xml",
-        Some("webp") => "image/webp",
-        Some("wasm") => "application/wasm",
-        Some("zip") => "application/zip",
-        _ => "application/octet-stream",
-    }
-    .to_string()
-}
-
-pub(crate) fn read_dashboard_fs_file_range(
-    path: &std::path::Path,
-    offset: u64,
-    length: Option<u64>,
-) -> Result<(Vec<u8>, u64, u64, PathBuf), (u16, serde_json::Value)> {
-    let metadata = std::fs::metadata(path).map_err(|e| {
-        (
-            404,
-            serde_json::json!({ "ok": false, "error": format!("file not accessible: {e}") }),
-        )
-    })?;
-    if !metadata.is_file() {
-        return Err((
-            400,
-            serde_json::json!({ "ok": false, "error": "path is not a regular file" }),
-        ));
-    }
-    let total_size = metadata.len();
-    let (start, transfer_len, end) = filesystem_read_range(total_size, offset, length)?;
-    let mut file = std::fs::File::open(path).map_err(|e| {
-        (
-            500,
-            serde_json::json!({ "ok": false, "error": format!("open file: {e}") }),
-        )
-    })?;
-    file.seek(std::io::SeekFrom::Start(start)).map_err(|e| {
-        (
-            500,
-            serde_json::json!({ "ok": false, "error": format!("seek file: {e}") }),
-        )
-    })?;
-    let mut bytes = vec![0u8; transfer_len];
-    file.read_exact(&mut bytes).map_err(|e| {
-        (
-            500,
-            serde_json::json!({ "ok": false, "error": format!("read file: {e}") }),
-        )
-    })?;
-    let display = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-    Ok((bytes, total_size, end, display))
-}
-
-pub(crate) fn filesystem_read_range(
-    total_size: u64,
-    offset: u64,
-    length: Option<u64>,
-) -> Result<(u64, usize, u64), (u16, serde_json::Value)> {
-    if offset > total_size {
-        return Err((
-            416,
-            serde_json::json!({
+            frame: serde_json::json!({
+                "t": "response",
+                "id": id,
                 "ok": false,
-                "error": "range start beyond file size",
-                "total_size": total_size,
+                "error": format!("filesystem read task failed: {e}"),
             }),
-        ));
+            byte_stream: None,
+            done: true,
+        },
     }
-    let available = total_size.saturating_sub(offset);
-    let requested = length.unwrap_or(available).min(available);
-    if requested > crate::web_gateway::UPLOAD_MAX_BYTES as u64 {
-        return Err((
-            413,
-            serde_json::json!({
-                "ok": false,
-                "error": format!(
-                    "range too large: {} bytes (cap is {})",
-                    requested,
-                    crate::web_gateway::UPLOAD_MAX_BYTES
-                ),
-            }),
-        ));
-    }
-    let transfer_len = usize::try_from(requested).map_err(|_| {
-        (
-            413,
-            serde_json::json!({ "ok": false, "error": "range too large for this platform" }),
-        )
-    })?;
-    Ok((offset, transfer_len, offset.saturating_add(requested)))
 }
 
 pub(crate) fn filesystem_read_error_task_response(
@@ -1126,6 +975,230 @@ pub(crate) fn filesystem_read_error_task_response(
 mod tests {
     use super::*;
     use crate::dashboard_control::tests::{runtime, test_upload_state};
+
+    // ── Tunnel/HTTP parity fixtures (transport-unification design §8) ──
+    //
+    // The S2 convergence claim: the same params through the ONE neutral
+    // fn (`crate::web_gateway::fs_{stat,list,read}_api_response`),
+    // rendered by the HTTP adapter (`api_response_http_bytes`) and by
+    // the tunnel framer (`api_fs_*_response` → `frame_api_*response`),
+    // yield IDENTICAL JSON result bodies. The envelope differences —
+    // deliberate, historical, and pinned by these fixtures — are:
+    //
+    //  1. Frame envelope: the tunnel wraps the body as `{t:"response",
+    //     id, ok:true, result:<body>}` and injects `_httpStatus` /
+    //     `_httpOk` into the result object (`http_body_response`);
+    //     HTTP sends the raw body with the status on the status line.
+    //  2. Headers: HTTP decorates with `Content-Type`/`Content-Length`,
+    //     the `Cache-Control`/`Connection` tail, and CORS per the
+    //     route's posture; the tunnel has no header lane.
+    //  3. fs_read success: both lanes carry the same payload bytes.
+    //     HTTP renders the meta as headers (`X-Content-Sha256` on full
+    //     reads, `Content-Range` + 206 on partials,
+    //     `Content-Disposition`); the tunnel emits
+    //     `byte_stream_start/chunk/end` with the meta object emitted
+    //     verbatim as `byte_stream_end.result`.
+    //  4. Range addressing: HTTP `Range: bytes=a-b` is end-inclusive;
+    //     the tunnel's offset/length form reports an end-EXCLUSIVE
+    //     `range_end` (`bytes=7-16` ≙ offset=7,length=10 → 17).
+    //  5. fs_read errors: the header form answers `{"error": …}`; the
+    //     offset/length form keeps its historical `{"ok":false,
+    //     "error": …}` body (`total_size` inline on 416 instead of a
+    //     `Content-Range: bytes */N` header), and each form keeps its
+    //     historical wordings (e.g. "<path> is not a file" vs "path is
+    //     not a regular file").
+    //  6. fs_read filename: HTTP sanitizes the canonicalized name
+    //     (fallback "download.bin"); the offset/length form reports
+    //     the expanded path's file name verbatim (nullable).
+    //  7. fs_read sha256: HTTP hashes form-full reads (no `Range`
+    //     header sent); the offset/length form hashes extent-full
+    //     reads (offset 0 covering the whole file).
+
+    /// Render a neutral response through the HTTP adapter and split it
+    /// into (status, headers, body).
+    fn http_parts(
+        response: crate::web_gateway::ApiResponse,
+    ) -> (u16, Vec<(String, String)>, Vec<u8>) {
+        let bytes = crate::web_gateway::api_response_http_bytes(
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        );
+        let split = bytes
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .expect("header/body split");
+        let head = String::from_utf8(bytes[..split].to_vec()).expect("ascii head");
+        let body = bytes[split + 4..].to_vec();
+        let mut lines = head.lines();
+        let status = lines
+            .next()
+            .and_then(|line| line.strip_prefix("HTTP/1.1 "))
+            .and_then(|line| line.split_whitespace().next())
+            .and_then(|code| code.parse::<u16>().ok())
+            .expect("status line");
+        let headers = lines
+            .map(|line| {
+                let (name, value) = line.split_once(": ").expect("header line");
+                (name.to_string(), value.to_string())
+            })
+            .collect();
+        (status, headers, body)
+    }
+
+    fn header_value<'a>(headers: &'a [(String, String)], name: &str) -> Option<&'a str> {
+        headers
+            .iter()
+            .find(|(header, _)| header == name)
+            .map(|(_, value)| value.as_str())
+    }
+
+    /// Strip the tunnel envelope (difference #1): assert the
+    /// `http_body_response` shape, check the injected status metadata
+    /// against the HTTP adapter's status, and return the result object
+    /// minus the injected keys.
+    fn tunnel_result_body(frame: &serde_json::Value, expect_status: u16) -> serde_json::Value {
+        assert_eq!(frame["t"], "response");
+        assert_eq!(frame["ok"], true, "{frame}");
+        let mut result = frame["result"].clone();
+        let map = result.as_object_mut().expect("result object");
+        assert_eq!(
+            map.remove("_httpStatus"),
+            Some(serde_json::json!(expect_status)),
+            "{frame}"
+        );
+        assert_eq!(
+            map.remove("_httpOk"),
+            Some(serde_json::json!((200..300).contains(&expect_status)))
+        );
+        result
+    }
+
+    #[tokio::test]
+    async fn parity_fs_stat_serves_the_same_body_on_both_transports() {
+        let dir = tempfile::tempdir().unwrap();
+        for params in [
+            serde_json::json!({ "path": dir.path().to_string_lossy() }),
+            serde_json::json!({ "path": "relative/path" }),
+        ] {
+            let request = crate::web_gateway::ApiRequest {
+                params: params.clone(),
+                range: None,
+            };
+            let (status, _headers, body) =
+                http_parts(crate::web_gateway::fs_stat_api_response(&request));
+            let http_body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+            let frame = api_fs_stat_response("parity-stat".to_string(), Some(&params)).await;
+            assert_eq!(tunnel_result_body(&frame, status), http_body, "{params}");
+        }
+    }
+
+    #[tokio::test]
+    async fn parity_fs_list_serves_the_same_body_on_both_transports() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("beta")).unwrap();
+        std::fs::write(dir.path().join("alpha.txt"), b"a").unwrap();
+        let not_a_dir = dir.path().join("alpha.txt");
+        for params in [
+            serde_json::json!({ "path": dir.path().to_string_lossy() }),
+            serde_json::json!({ "path": not_a_dir.to_string_lossy() }),
+        ] {
+            let request = crate::web_gateway::ApiRequest {
+                params: params.clone(),
+                range: None,
+            };
+            let (status, _headers, body) =
+                http_parts(crate::web_gateway::fs_list_api_response(&request));
+            let http_body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+            let frame = api_fs_list_response("parity-list".to_string(), Some(&params)).await;
+            assert_eq!(tunnel_result_body(&frame, status), http_body, "{params}");
+        }
+    }
+
+    #[tokio::test]
+    async fn parity_fs_read_serves_the_same_bytes_and_meta_on_both_transports() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("parity.txt");
+        std::fs::write(&file, b"parity read fixture payload").unwrap();
+        let path = file.to_string_lossy().into_owned();
+
+        // Full read: no range on either transport — same bytes, and the
+        // tunnel meta matches the HTTP headers (differences #3/#7).
+        let request = crate::web_gateway::ApiRequest {
+            params: serde_json::json!({ "path": path }),
+            range: None,
+        };
+        let (status, headers, body) =
+            http_parts(crate::web_gateway::fs_read_api_response(&request));
+        assert_eq!(status, 200);
+        let full = api_fs_read_task_response(
+            "parity-read".to_string(),
+            Some(&serde_json::json!({ "path": path })),
+        )
+        .await;
+        let stream = full.byte_stream.expect("tunnel byte stream");
+        assert_eq!(stream.bytes, body);
+        assert_eq!(
+            stream.result["sha256"].as_str(),
+            header_value(&headers, "X-Content-Sha256")
+        );
+        assert_eq!(
+            Some(stream.content_type.as_str()),
+            header_value(&headers, "Content-Type")
+        );
+        assert_eq!(stream.result["total_size"].as_u64(), Some(body.len() as u64));
+
+        // Ranged read: offset=7,length=10 ≙ `Range: bytes=7-16` — same
+        // bytes; inclusive header vs exclusive range_end (difference #4).
+        let request = crate::web_gateway::ApiRequest {
+            params: serde_json::json!({ "path": path }),
+            range: Some(crate::web_gateway::ByteRange::HttpHeader(
+                "bytes=7-16".to_string(),
+            )),
+        };
+        let (status, headers, body) =
+            http_parts(crate::web_gateway::fs_read_api_response(&request));
+        assert_eq!(status, 206);
+        assert_eq!(
+            header_value(&headers, "Content-Range"),
+            Some("bytes 7-16/27")
+        );
+        let ranged = api_fs_read_task_response(
+            "parity-read-range".to_string(),
+            Some(&serde_json::json!({ "path": path, "offset": 7, "length": 10 })),
+        )
+        .await;
+        let stream = ranged.byte_stream.expect("tunnel byte stream");
+        assert_eq!(stream.bytes, body);
+        assert_eq!(stream.result["range_start"].as_u64(), Some(7));
+        assert_eq!(stream.result["range_end"].as_u64(), Some(17));
+        assert!(stream.result["sha256"].is_null());
+    }
+
+    #[tokio::test]
+    async fn parity_fs_read_errors_share_messages_under_their_own_envelopes() {
+        // Difference #5 pinned from both sides: the same expand failure
+        // surfaces the same message under each form's historical body.
+        let params = serde_json::json!({ "path": "relative/path" });
+        let request = crate::web_gateway::ApiRequest {
+            params: params.clone(),
+            range: None,
+        };
+        let (status, _headers, body) =
+            http_parts(crate::web_gateway::fs_read_api_response(&request));
+        assert_eq!(status, 400);
+        let http_body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        let response =
+            api_fs_read_task_response("parity-read-error".to_string(), Some(&params)).await;
+        assert!(response.byte_stream.is_none());
+        let tunnel_body = tunnel_result_body(&response.frame, 400);
+        assert_eq!(tunnel_body["error"], http_body["error"]);
+        assert_eq!(tunnel_body["ok"], false);
+        assert!(http_body.get("ok").is_none());
+    }
 
     #[tokio::test]
     async fn fs_read_returns_bounded_byte_stream() {

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -5,6 +5,76 @@
 
 use super::*;
 
+/// Tunnel adapter for the transport-neutral api core (transport-
+/// unification design §2.1): render a JSON [`crate::web_gateway::ApiResponse`]
+/// into the tunnel's historical envelope — `http_body_response`, which
+/// wraps the body as `{t:"response", id, ok:true, result:<body>}` and
+/// injects `_httpStatus`/`_httpOk` into the result object. A byte
+/// response on a JSON-only method is a wiring bug and fails closed.
+pub(crate) fn frame_api_response(
+    id: String,
+    response: crate::web_gateway::ApiResponse,
+    label: &str,
+) -> serde_json::Value {
+    match response {
+        crate::web_gateway::ApiResponse::Json { status, body, .. } => {
+            http_body_response(id, status, body.into_string(), label)
+        }
+        crate::web_gateway::ApiResponse::Bytes { .. } => serde_json::json!({
+            "t": "response",
+            "id": id,
+            "ok": false,
+            "error": format!("{label} returned an unexpected byte response"),
+        }),
+    }
+}
+
+/// Tunnel adapter for byte-capable methods: `Bytes` becomes a
+/// `byte_stream_start/chunk/end` sequence — chunking, credits, and
+/// backpressure stay wire.rs-owned — with the neutral fn's `meta`
+/// object emitted verbatim as `byte_stream_end.result` (and the
+/// stream's filename lifted from it); JSON responses (the error
+/// shapes) ride the plain response envelope.
+pub(crate) fn frame_api_task_response(
+    id: String,
+    response: crate::web_gateway::ApiResponse,
+    stream_suffix: &str,
+    label: &str,
+) -> ControlTaskResponse {
+    match response {
+        crate::web_gateway::ApiResponse::Bytes {
+            content_type,
+            bytes: crate::web_gateway::BytesPayload::InMemory(bytes),
+            meta,
+            ..
+        } => {
+            let filename = meta
+                .get("filename")
+                .and_then(|value| value.as_str())
+                .map(str::to_string);
+            ControlTaskResponse {
+                id: id.clone(),
+                frame: serde_json::Value::Null,
+                byte_stream: Some(ControlByteStream {
+                    id: id.clone(),
+                    stream_id: format!("{id}:{stream_suffix}"),
+                    content_type,
+                    filename,
+                    bytes,
+                    result: meta,
+                }),
+                done: true,
+            }
+        }
+        json @ crate::web_gateway::ApiResponse::Json { .. } => ControlTaskResponse {
+            id: id.clone(),
+            frame: frame_api_response(id, json, label),
+            byte_stream: None,
+            done: true,
+        },
+    }
+}
+
 pub(crate) fn control_frame_response(
     text: &str,
     runtime: &mut ControlRuntime,
@@ -2205,6 +2275,24 @@ pub(crate) fn status_response_frame(id: String, runtime: &ControlRuntime) -> ser
 mod tests {
     use super::*;
     use crate::dashboard_control::tests::{runtime, scoped_user_client_grant};
+
+    #[test]
+    fn frame_api_response_fails_closed_on_byte_payloads() {
+        let response = crate::web_gateway::ApiResponse::Bytes {
+            status: 200,
+            content_type: "application/octet-stream".to_string(),
+            headers: Vec::new(),
+            bytes: crate::web_gateway::BytesPayload::InMemory(b"x".to_vec()),
+            meta: serde_json::Value::Null,
+        };
+        let frame = frame_api_response("bad-lane".to_string(), response, "unit probe");
+        assert_eq!(frame["t"], "response");
+        assert_eq!(frame["ok"], false);
+        assert!(frame["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("unexpected byte response"));
+    }
 
     #[test]
     fn dashboard_preview_text_truncates_on_char_boundary() {

--- a/src/bin/caller/web_gateway/api_core.rs
+++ b/src/bin/caller/web_gateway/api_core.rs
@@ -36,12 +36,17 @@ impl ApiRequest {
 
 /// A byte-range request as it arrived on its transport. Satisfiability
 /// (and the exact 416 wording) is resolved against the target's size
-/// inside the handler, exactly where today's code resolves it; the
-/// tunnel's offset/length form joins as a second variant when the fs
-/// family's tunnel lane delegates (S2).
+/// inside the handler, exactly where today's code resolves it. The two
+/// forms keep their historical semantics: the HTTP header is
+/// end-inclusive; the tunnel's offset/length form is start+count with
+/// an end-exclusive `range_end` in the response meta.
 pub(crate) enum ByteRange {
     /// Verbatim HTTP `Range` header value (e.g. `bytes=100-199`).
     HttpHeader(String),
+    /// The datachannel tunnel's resumable form (`offset`/`length`
+    /// params, pre-normalized by the tunnel adapter). `length: None`
+    /// reads to end of file.
+    OffsetLength { offset: u64, length: Option<u64> },
 }
 
 /// JSON response body in whichever form the handler already has (risk
@@ -89,6 +94,14 @@ pub(crate) enum ApiResponse {
         /// Same contract as `Json::headers`.
         headers: Vec<(&'static str, String)>,
         bytes: BytesPayload,
+        /// Sidecar result for the byte lane: the tunnel adapter emits it
+        /// verbatim as `byte_stream_end.result` (the historical
+        /// `{ok, path, filename, …, range_start, range_end, resumable,
+        /// sha256}` object). The HTTP adapter ignores it today — the
+        /// header-form responses already carry their meta as headers;
+        /// the transfer rows (S9) define meta's HTTP rendering. `Null`
+        /// when the response has no sidecar.
+        meta: serde_json::Value,
     },
 }
 

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1314,6 +1314,10 @@ pub(crate) fn api_response_http_bytes(
             content_type,
             headers,
             bytes,
+            // The byte lane's sidecar is a tunnel-frame concern; on HTTP
+            // the header tail already carries the response's meta (the
+            // S9 transfer rows define an HTTP rendering for it).
+            meta: _,
         } => {
             let BytesPayload::InMemory(payload) = bytes;
             let mut http =

--- a/src/bin/caller/web_gateway/routes_files.rs
+++ b/src/bin/caller/web_gateway/routes_files.rs
@@ -1067,11 +1067,6 @@ pub(crate) fn inspect_dashboard_fs_path(raw: &str) -> Result<FsPathStatus, Strin
     })
 }
 
-pub(crate) fn dashboard_fs_stat_response_body(raw: &str) -> Result<String, String> {
-    inspect_dashboard_fs_path(raw)
-        .and_then(|status| serde_json::to_string(&status).map_err(|e| e.to_string()))
-}
-
 pub(crate) fn list_dashboard_fs_dir(raw: &str) -> Result<serde_json::Value, String> {
     let path = expand_dashboard_fs_path(raw)?;
     let canonical = std::fs::canonicalize(&path)
@@ -1112,10 +1107,6 @@ pub(crate) fn list_dashboard_fs_dir(raw: &str) -> Result<serde_json::Value, Stri
         "entries": entries,
         "truncated": truncated,
     }))
-}
-
-pub(crate) fn dashboard_fs_list_response_body(raw: &str) -> Result<String, String> {
-    list_dashboard_fs_dir(raw).map(|body| body.to_string())
 }
 
 #[derive(Debug)]
@@ -2053,11 +2044,16 @@ pub(crate) async fn handle_fs_list(
 /// Transport-neutral core of `GET /api/fs/read` (tunnel twin
 /// `api_fs_read`): bytes lane on success (200 full / 206 partial), JSON
 /// error shapes otherwise (the 416 keeps its range-probing header tail).
+/// Each [`ByteRange`] form keeps its transport's historical semantics —
+/// the divergences are enumerated on the tunnel-side parity fixtures.
 pub(crate) fn fs_read_api_response(request: &ApiRequest) -> ApiResponse {
-    let range_header = request.range.as_ref().map(|range| {
-        let ByteRange::HttpHeader(value) = range;
-        value.as_str()
-    });
+    let range_header = match &request.range {
+        Some(ByteRange::OffsetLength { offset, length }) => {
+            return fs_read_offset_length_api_response(request.str_param("path"), *offset, *length);
+        }
+        Some(ByteRange::HttpHeader(value)) => Some(value.as_str()),
+        None => None,
+    };
     match dashboard_fs_read_file(request.str_param("path"), range_header) {
         Ok(file) => {
             let mut headers: Vec<(&'static str, String)> =
@@ -2097,6 +2093,7 @@ pub(crate) fn fs_read_api_response(request: &ApiRequest) -> ApiResponse {
                 content_type: file.content_type,
                 headers,
                 bytes: BytesPayload::InMemory(file.bytes),
+                meta: serde_json::Value::Null,
             }
         }
         Err(error) => {
@@ -2118,6 +2115,153 @@ pub(crate) fn fs_read_api_response(request: &ApiRequest) -> ApiResponse {
             }
         }
     }
+}
+
+/// The offset/length read form — the datachannel tunnel's historical
+/// `api_fs_read` semantics, preserved byte-for-byte through the S2
+/// delegation: errors keep their `{"ok": false, …}` bodies and their
+/// wordings; success carries the payload plus the tunnel's result
+/// object as [`ApiResponse::Bytes`] `meta` (filename and content type
+/// derive from the expanded — not canonicalized — path, exactly as
+/// before). Status and headers on the success arm are HTTP-lane
+/// decoration only until the transfer rows (S9) define this form's
+/// HTTP rendering; the tunnel framer consumes `content_type`, `bytes`,
+/// and `meta`.
+fn fs_read_offset_length_api_response(
+    raw_path: &str,
+    offset: u64,
+    length: Option<u64>,
+) -> ApiResponse {
+    let path = match expand_dashboard_fs_path(raw_path) {
+        Ok(path) => path,
+        Err(error) => {
+            return ApiResponse::json(
+                400,
+                JsonBody::Value(serde_json::json!({ "ok": false, "error": error })),
+            );
+        }
+    };
+    let filename = path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .filter(|name| !name.is_empty());
+    let content_type = dashboard_fs_content_type(&path);
+    let (bytes, total_size, end, display_path) =
+        match read_dashboard_fs_file_range(&path, offset, length) {
+            Ok(value) => value,
+            Err((status, body)) => return ApiResponse::json(status, JsonBody::Value(body)),
+        };
+    // Full-extent reads carry the content hash so the editor has a
+    // conflict baseline for its later write-back (mirrors the HTTP
+    // route's X-Content-Sha256 header; this form is extent-based where
+    // the header form keys off the request shape).
+    let full = offset == 0 && bytes.len() as u64 == total_size;
+    let sha256 = full.then(|| fs_sha256_hex(&bytes));
+    let meta = serde_json::json!({
+        "ok": true,
+        "path": display_path.to_string_lossy().to_string(),
+        "filename": filename,
+        "content_type": content_type.clone(),
+        "size": bytes.len(),
+        "total_size": total_size,
+        "offset": offset,
+        "range_start": offset,
+        "range_end": end,
+        "resumable": true,
+        "sha256": sha256,
+    });
+    ApiResponse::Bytes {
+        status: if full { 200 } else { 206 },
+        content_type,
+        headers: vec![
+            ("Cache-Control", "no-cache".to_string()),
+            ("Connection", "close".to_string()),
+        ],
+        bytes: BytesPayload::InMemory(bytes),
+        meta,
+    }
+}
+
+pub(crate) fn read_dashboard_fs_file_range(
+    path: &Path,
+    offset: u64,
+    length: Option<u64>,
+) -> Result<(Vec<u8>, u64, u64, PathBuf), (u16, serde_json::Value)> {
+    use std::io::{Read as _, Seek as _};
+    let metadata = std::fs::metadata(path).map_err(|e| {
+        (
+            404,
+            serde_json::json!({ "ok": false, "error": format!("file not accessible: {e}") }),
+        )
+    })?;
+    if !metadata.is_file() {
+        return Err((
+            400,
+            serde_json::json!({ "ok": false, "error": "path is not a regular file" }),
+        ));
+    }
+    let total_size = metadata.len();
+    let (start, transfer_len, end) = filesystem_read_range(total_size, offset, length)?;
+    let mut file = std::fs::File::open(path).map_err(|e| {
+        (
+            500,
+            serde_json::json!({ "ok": false, "error": format!("open file: {e}") }),
+        )
+    })?;
+    file.seek(std::io::SeekFrom::Start(start)).map_err(|e| {
+        (
+            500,
+            serde_json::json!({ "ok": false, "error": format!("seek file: {e}") }),
+        )
+    })?;
+    let mut bytes = vec![0u8; transfer_len];
+    file.read_exact(&mut bytes).map_err(|e| {
+        (
+            500,
+            serde_json::json!({ "ok": false, "error": format!("read file: {e}") }),
+        )
+    })?;
+    let display = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    Ok((bytes, total_size, end, display))
+}
+
+pub(crate) fn filesystem_read_range(
+    total_size: u64,
+    offset: u64,
+    length: Option<u64>,
+) -> Result<(u64, usize, u64), (u16, serde_json::Value)> {
+    if offset > total_size {
+        return Err((
+            416,
+            serde_json::json!({
+                "ok": false,
+                "error": "range start beyond file size",
+                "total_size": total_size,
+            }),
+        ));
+    }
+    let available = total_size.saturating_sub(offset);
+    let requested = length.unwrap_or(available).min(available);
+    if requested > crate::web_gateway::UPLOAD_MAX_BYTES as u64 {
+        return Err((
+            413,
+            serde_json::json!({
+                "ok": false,
+                "error": format!(
+                    "range too large: {} bytes (cap is {})",
+                    requested,
+                    crate::web_gateway::UPLOAD_MAX_BYTES
+                ),
+            }),
+        ));
+    }
+    let transfer_len = usize::try_from(requested).map_err(|_| {
+        (
+            413,
+            serde_json::json!({ "ok": false, "error": "range too large for this platform" }),
+        )
+    })?;
+    Ok((offset, transfer_len, offset.saturating_add(requested)))
 }
 
 pub(crate) async fn handle_fs_read(


### PR DESCRIPTION
Stage S2 of the transport-unification program (design doc §6 "Server track", §2.1, §8): the datachannel tunnel's fs methods now delegate to the same transport-neutral fns the HTTP lane runs, with the convergence claim pinned by parity fixtures.

## What delegates

`api_fs_stat`, `api_fs_list`, `api_fs_read` (tunnel) now build an `ApiRequest` from the frame's `params` (verbatim, per §2.1) and call `fs_{stat,list,read}_api_response` — the S1a neutral fns — under `spawn_blocking`, rendered back into the tunnel's exact historical frames by two new adapters in `dashboard_control/dispatch.rs`:

- `frame_api_response`: `Json` → the historical `http_body_response` envelope (`_httpStatus`/`_httpOk` injected into the result object, preserved exactly); byte payloads on a JSON-only method fail closed.
- `frame_api_task_response`: `Bytes` → `byte_stream_start/chunk/end` with the neutral fn's `meta` object emitted verbatim as `byte_stream_end.result` (filename lifted from it); chunking, credits, and backpressure stay `wire.rs`-owned and untouched.

Core vocabulary grew the two pieces §2.1 planned for S2: `ByteRange::OffsetLength` (the tunnel's resumable range form) and `ApiResponse::Bytes.meta` (the byte-lane sidecar; the HTTP adapter ignores it until the S9 transfer rows define its rendering).

## What got deleted (the dedup)

- The tunnel-side stat/list bodies and the whole read middle (`api_transfers_fs.rs`).
- The tunnel's duplicate `dashboard_fs_content_type` table.
- The now-dead `dashboard_fs_{stat,list}_response_body` bridges in `routes_files.rs`.
- The range readers (`read_dashboard_fs_file_range`, `filesystem_read_range`) moved verbatim into `routes_files.rs` next to the neutral core (only adaptation: the `&Path` shorthand + the inline io-trait `use` the new location needs).

Production-code delta is near-neutral; the +322 net is the parity fixtures and adapter/vocabulary docs.

## Parity fixtures (§8, "the convergence claim itself")

`api_transfers_fs.rs` tests: same params through the neutral fn's HTTP rendering (`api_response_http_bytes`) and through the tunnel framing ⇒ identical JSON result bodies (stat/list), identical payload bytes + corresponding meta (read full + ranged), and converged error messages under each form's envelope. The **seven envelope differences are enumerated in the fixture comment** and asserted rather than hidden:

1. tunnel `{t:"response", id, ok:true, result}` wrapper + `_httpStatus`/`_httpOk` injection vs raw HTTP body + status line;
2. HTTP header decoration (Content-Type/Length, cache/connection tail, CORS posture) vs no header lane on the tunnel;
3. read success meta as HTTP headers (X-Content-Sha256 / Content-Range / Content-Disposition) vs `byte_stream_end.result`;
4. HTTP `Range: bytes=a-b` end-inclusive vs tunnel offset/length with end-exclusive `range_end`;
5. read errors `{"error"}` (header form) vs historical `{"ok":false,"error"}` (offset/length form; `total_size` inline on 416), each form keeping its historical wordings;
6. read filename: sanitized canonical name (fallback `download.bin`) vs expanded path's name verbatim (nullable);
7. read sha256: form-full (no Range header) vs extent-full (offset 0 covering the file).

## Deferred to S2b

`api_fs_mkdir` / `api_fs_write` / `api_fs_rename` / `api_fs_delete` keep their existing paths: their neutral fns are S1b (#133), still in flight — not duplicated here, per stage scoping. S2b delegates them once #133 lands.

**Coordination note:** #133 also touches `routes_files.rs` (adds the write-family neutral fns near the same seam where this PR adds the read offset-arm + moved range readers). Whichever lands second likely takes a trivial textual reconcile; semantics don't overlap (this PR owns the tunnel side + stat/list/read only).

## Behavior notes (deliberate, unpinned-corner convergences)

- Non-string `path` params on the tunnel (e.g. `{"path": 42}`) previously stringified via `string_param`; they now collapse to `""` via the neutral `str_param` (home-dir expansion), converging tunnel and HTTP on one reader. No client sends non-strings; fs-scope authorization runs pre-dispatch and is unaffected.
- The unreachable stat-serialization-failure arm converges from tunnel-400 to the neutral 200-`{}` shape.

## Gates

- `cargo nextest run --bins`: 2731/2732 passed — the one failure is the known environmental exception on this shared Mac (`mcp::tools_display::tests::read_screen_user_session_scoped_caller_needs_the_grant`), untouched by this diff.
- All pre-existing dashboard_control tests green **unchanged** (the stage's definition), incl. `fs_stat_and_list_preserve_http_status`, the fs-read byte-stream/sha/reject pins, and the fs scope suites; all S1a golden HTTP transcripts still pass byte-exact.
- `cargo clippy`: no new warnings (the `type_complexity` warning on `read_dashboard_fs_file_range` pre-exists and moved files with the fn).
- `cargo test --test e2e`: 8/8 (one load-flake on `mock_provider_without_a_script_fails_closed` in a first run passed in isolation and in the full rerun).
- `git diff --color-moved=dimmed-zebra` self-review + mechanical old-vs-new diff of the moved fns.
