### PR TITLE
First-contact provenance: route rungs, CT tripwire, origin chips

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -718,11 +718,17 @@ permissions in that session, no matter what its grant says — the grant record
 itself is untouched. `connect_account` sessions are always subject to their
 ceiling; `client_key` sessions only when the key's recorded enrollment origin
 is listed in `hosted_origins` (default `["https://connect.intendant.dev"]`) —
-keys enrolled from a daemon-served origin are anchor-grade and uncapped. This
-is the honest degraded-trust tier from the trust architecture: hosted-route
-sessions can operate but cannot administer. Owners who accept hosted-root
-risk can raise a ceiling or disable them all with an explicit empty map
-(`"role_ceilings": {}`).
+keys enrolled from any other origin are uncapped by default. Uncapped is a
+routing statement, not a blessing: a typed direct address is trustless first
+contact, while a fleet-certificate name is daemon-served *code* on a
+rendezvous-named *route* ([first-contact rung
+two](./trust-tiers.md#first-contact-three-rungs)); owners who want
+fleet-name sessions capped like hosted ones add the daemon's own fleet
+origin to `hosted_origins` (exact-origin match — the daemon's fleet URL,
+not the bare zone). This is the honest degraded-trust tier from the trust
+architecture: hosted-route sessions can operate but cannot administer.
+Owners who accept hosted-root risk can raise a ceiling or disable them all
+with an explicit empty map (`"role_ceilings": {}`).
 
 The common moves have a one-knob UI: the **hosted-control cap** on
 Access → Overview's Trust tier card writes both hosted bindings at once

--- a/docs/src/trust-architecture.md
+++ b/docs/src/trust-architecture.md
@@ -118,6 +118,7 @@ fully rolled out:
 | TURN relay | Denial of service; traffic analysis | Sees only ciphertext |
 | Fleet metadata store | Denial of service | Records are client-signed (and encrypted where private); clients verify |
 | Name directory | Handle confusion at first introduction | Key-first identity; handles are labels; org keys sign membership; append-only transparency log over all name bindings (STH pinned + consistency-verified by browsers; inclusion proofs on claims), optional DNS/GitHub attestation badges, invite-gated registration + reserved handles + dormant-handle reclamation |
+| Fleet DNS zone + WebPKI (fleet-name route) | Targeted endpoint swap: your daemon's fleet name answered with another box, a fresh certificate minted for it, attacker code served at the enrolled origin | Betrayal must be active (a live wrong answer at connect time; nothing leaks passively or retroactively) and mints public evidence — certificates land in CT logs, the daemon's CT tripwire alarms on serials it never requested — and owners can cap fleet-name sessions under the hosted ceiling; first-load code is *not* bounded, which is why this is [first-contact rung two](./trust-tiers.md#first-contact-three-rungs), not an anchor |
 | Hosted dashboard origin (degraded lane) | The session's granted authority | Sessions are principal-marked and role-capped below root by daemon policy |
 
 Trust scales with the blast radius of the relationship: a global service that

--- a/docs/src/trust-tiers.md
+++ b/docs/src/trust-tiers.md
@@ -5,7 +5,7 @@
 > chapter is the operating model an owner applies across a fleet whose
 > machines carry different stakes. Almost nothing here is new mechanism — it
 > composes ceilings, grants, custody, and client choice that already exist.
-> The three product hooks at the end are the tracked exceptions.
+> The product hooks at the end are the tracked exceptions.
 
 ## Two axes, not one
 
@@ -53,6 +53,11 @@ sensitive thing that ever touches it**, not by the label its owner had in
 mind. Pasting a production credential into a session on a disposable box
 silently promotes the box. Tier discipline is as much about what you feed a
 daemon as about how you reach it.
+
+There is a third axis, easy to conflate with client provenance and
+untangled [below](#first-contact-three-rungs): **first contact** — who
+named the route you followed to reach a daemon at all, and what evidence
+their betrayal would leave.
 
 ## One fleet, zones — not two networks
 
@@ -143,10 +148,94 @@ The owner claims all three into one account, sees them in one dashboard,
 and the tier boundary is carried entirely by ceilings, grant direction, and
 which client they open for which box.
 
+## First contact: three rungs
+
+The two axes above describe steady state: a client you already hold,
+driving a daemon you already reach. A third question is orthogonal to both
+and only looks answered until you ask it precisely: **who did you have to
+trust to reach the daemon at all — and what evidence would their betrayal
+leave?** Client provenance says who serves the code that runs; first
+contact says who *named the route* you followed to it. The answers can
+differ for the same URL, and conflating them is how "it's daemon-served"
+quietly overstates a link's safety.
+
+Three rungs, ordered by what betrayal costs the attacker:
+
+1. **Trustless — nothing between you and the box.** A typed direct address
+   plus the enrollment ceremony (the fingerprint verified out of band pins
+   the daemon's certificate), preinstalled mTLS material, or a client you
+   built or installed yourself. No third party participates in naming or
+   serving, so there is nothing whose betrayal you would need evidence of.
+   This is the only rung that deserves the word *anchor*, and it is bought
+   with the one deliberately inconvenient ceremony.
+2. **Trust with mandatory evidence — the fleet name.**
+   `https://d-<hash>.fleet.intendant.dev:8765` is daemon-served code on a
+   rendezvous-named route: the zone operator — or anything else that can
+   answer DNS for the name and convince a CA — could point your daemon's
+   name at a box of its choosing. What this rung guarantees is not that
+   the swap cannot happen but that it **cannot happen quietly**: serving
+   code at the `https` origin requires a certificate for the name, the
+   attack must be live at the moment you connect (nothing is exposed
+   passively or retroactively), and every issued certificate lands in
+   public Certificate Transparency logs — where the daemon's own CT
+   tripwire watches for serials it never requested and raises **CT
+   ALERT** on the Connect card. Betrayal is possible, targeted, and loud.
+3. **Trusted but bounded — the hosted tab.** The rendezvous origin serves
+   the code itself, so betrayal is a silently different bundle to one
+   visitor, once, with no artifact anywhere. No evidence machinery can
+   apply; what bounds the damage is authority, not detection — role
+   ceilings cap hosted-provenance sessions, trusted-only vault entries
+   refuse hosted unseal, and custody keeps durable secrets off the tier
+   that would leak them.
+
+The product states the rung wherever an owner makes a trust decision:
+device-enrollment approvals carry a daemon-computed route chip (*via
+direct origin* / *via fleet name* / *via hosted route*), and owners who
+want rung-two sessions capped like rung-three ones add the daemon's fleet
+origin to `hosted_origins` (the ceiling test matches exact origins, so it
+is the daemon's own fleet URL that goes in the list, not the bare zone).
+
+One consequence is easy to miss: for any *browser* client, first contact
+re-asks itself on every page load — the tab re-fetches its code each
+visit, so a rung's guarantee is only as durable as its serving origin.
+Enrolled identity keys do not change this: browser storage is
+origin-scoped, so a key enrolled at a fleet name is wieldable by whatever
+code that name serves. Rungs one and two therefore fully converge only
+when the client stops being re-served — the signed native app and code
+transparency over serving origins (both tracked) are the ladder's missing
+top, not polish.
+
+### Still blurry, on purpose
+
+Named honestly rather than smoothed over — each is either tracked or a
+stated non-goal:
+
+- **The time axis (TOFU).** Everything above grades *first* contact;
+  later visits inherit pinned material (enrolled keys, remembered
+  certificates) but re-inherit the code channel every load. The signed
+  app collapses code trust to install-and-update moments; until it
+  ships, rung two re-runs per visit.
+- **The update channel.** A signed app trusts its updater. Code
+  transparency — served-artifact hashes in a public log, monitors,
+  verifiers — is the evidence leg for that too. (Tracked.)
+- **Lookalike names.** `d-<hash>` labels are deliberately opaque, which
+  also means humans cannot eyeball them; a phished lookalike with its own
+  valid certificate raises no CT alarm on *your* name, because it is not
+  your name. The mitigation is navigational: reach fleet names from the
+  fleet strip, bookmarks, or the app — never by retyping.
+- **The browser itself.** Every rung assumes the browser and OS are
+  honest; an extension with page access reads all tiers alike. Outside
+  Intendant's reach — stated so the ladder is not mistaken for covering
+  it.
+- **Hosted-passkey coupling.** Unsealing the vault with a passkey inside
+  a hosted tab is rung-three code wielding rung-one credentials. The
+  write-only CLI vault lane and the pinned crypto kernel (both tracked)
+  are the untangle.
+
 ## Product hooks
 
-Three pieces of mechanism let the product carry this doctrine instead of
-the owner's memory. All three are **shipped**:
+Four pieces of mechanism let the product carry this doctrine instead of
+the owner's memory. All four are **shipped**:
 
 1. **Tier labels + upward-grant guard.** Each daemon carries its tier in
    local IAM (`tier` in `iam.json`; `POST /api/access/tier`,
@@ -181,3 +270,16 @@ the owner's memory. All three are **shipped**:
    [Credential Custody](./credential-custody.md#the-vault)), trusted-only
    entries do real work: sealed against hosted tabs, fully usable from a
    direct dashboard backed by the daemon's own store.
+4. **First-contact route, surfaced and watched.** Enrollment approvals
+   carry a route chip computed daemon-side (`iam::origin_route_class`:
+   hosted / fleet / direct / unknown — route provenance for approval
+   decisions, distinct from `session_origin_class`, the custody-trail
+   code-provenance class), with honest per-rung copy and an
+   integrated-tier warning on any network route. The **CT tripwire**
+   backs rung two's evidence claim: `fleet_cert` records the serial of
+   every certificate it obtains (before install, so a crash cannot make
+   an own certificate look foreign), polls crt.sh for the daemon's fleet
+   name on each renewal tick, and flips the Connect card to **CT ALERT**
+   on any serial the daemon never requested. Advisory and fail-open by
+   design: a crt.sh outage stamps `ct_last_error` rather than blocking
+   renewal.

--- a/src/bin/caller/access/iam.rs
+++ b/src/bin/caller/access/iam.rs
@@ -4016,7 +4016,7 @@ mod tests {
         )
         .unwrap();
 
-        // Anchor-origin keys are anchor-grade: no ceiling.
+        // Keys born on daemon-served origins are uncapped: no ceiling.
         let anchor = principal_for_client_key(&state, "anchor-key", "connect").unwrap();
         assert_eq!(
             anchor.authn_origin.as_deref(),

--- a/src/bin/caller/access/iam.rs
+++ b/src/bin/caller/access/iam.rs
@@ -2118,8 +2118,11 @@ pub fn evaluate_principal_operation_with_state(
 /// The ceiling role applying to this session, if any. `connect_account`
 /// bindings are always subject to their configured ceiling; `client_key`
 /// bindings only when the key's recorded enrollment origin is one of the
-/// configured hosted origins (keys born on daemon-served origins are
-/// anchor-grade and uncapped).
+/// configured hosted origins. Keys born on daemon-served origins are
+/// uncapped — including fleet-name origins, whose code is daemon-served
+/// but whose ROUTE the rendezvous names (first-contact rung two,
+/// docs/src/trust-tiers.md); owners who want fleet-name sessions capped
+/// add the fleet zone's origins to `hosted_origins`.
 pub fn role_ceiling_for_session(
     state: &LocalIamState,
     principal: &AccessPrincipal,
@@ -2142,9 +2145,11 @@ pub fn role_ceiling_for_session(
 
 /// Origin class of a session for the custody trail
 /// (docs/src/trust-tiers.md): `hosted` (Connect account or a browser key
-/// enrolled from one of `hosted_origins`), `direct` (anchor-grade key,
-/// mTLS certificate, or any other explicit binding), `local` (the
-/// owner's own dashboard / loopback), or `peer` (a federated daemon).
+/// enrolled from one of `hosted_origins`), `direct` (a key or mTLS
+/// certificate on a daemon-served origin — fleet-name origins included:
+/// daemon-served for code, rendezvous-named for routing; the finer
+/// routing distinction is [`origin_route_class`]), `local` (the owner's
+/// own dashboard / loopback), or `peer` (a federated daemon).
 /// Classification mirrors [`role_ceiling_for_session`]'s hosted test.
 pub fn session_origin_class(hosted_origins: &[String], principal: &AccessPrincipal) -> &'static str {
     if principal.kind == "peer_daemon" {
@@ -2173,6 +2178,49 @@ pub fn session_origin_class(hosted_origins: &[String], principal: &AccessPrincip
             }
         }
     }
+}
+
+/// Routing provenance of an enrollment origin — the first-contact rung it
+/// arrived on (docs/src/trust-tiers.md, "First contact"):
+///
+/// - `hosted`: one of `hosted_origins` — the rendezvous serves the code.
+/// - `fleet`: a name under the rendezvous's delegated fleet zone — the
+///   daemon serves the code, but the rendezvous names the route (it could
+///   hijack DNS and mint a certificate; active-only, CT-logged).
+/// - `direct`: any other explicit origin (typed IP, mDNS, own domain).
+/// - `unknown`: no origin recorded (pre-origin enrollments).
+///
+/// Distinct from [`session_origin_class`]: that classifies for custody
+/// (code provenance), this classifies for approval decisions (route
+/// provenance). A fleet origin is `direct`-grade there and `fleet` here.
+pub fn origin_route_class(
+    origin: &str,
+    hosted_origins: &[String],
+    fleet_zone: Option<&str>,
+) -> &'static str {
+    let origin = origin.trim();
+    if origin.is_empty() {
+        return "unknown";
+    }
+    if hosted_origins
+        .iter()
+        .any(|candidate| candidate.trim_end_matches('/') == origin.trim_end_matches('/'))
+    {
+        return "hosted";
+    }
+    if let Some(zone) = fleet_zone.map(str::trim).filter(|zone| !zone.is_empty()) {
+        let zone = zone.trim_end_matches('.').to_ascii_lowercase();
+        let host = url::Url::parse(origin)
+            .ok()
+            .and_then(|url| url.host_str().map(str::to_ascii_lowercase));
+        if let Some(host) = host {
+            let host = host.trim_end_matches('.');
+            if host == zone || host.ends_with(&format!(".{zone}")) {
+                return "fleet";
+            }
+        }
+    }
+    "direct"
 }
 
 /// True when a permission list grants `permission`. The legacy aggregate id
@@ -4001,6 +4049,44 @@ mod tests {
             )
             .allowed
         );
+    }
+
+    #[test]
+    fn origin_route_class_distinguishes_the_first_contact_rungs() {
+        let hosted = default_hosted_origins();
+        let zone = Some("fleet.intendant.dev");
+        assert_eq!(
+            origin_route_class("https://connect.intendant.dev", &hosted, zone),
+            "hosted"
+        );
+        assert_eq!(
+            origin_route_class("https://connect.intendant.dev/", &hosted, zone),
+            "hosted"
+        );
+        assert_eq!(
+            origin_route_class("https://d-30a08371a38c1b.fleet.intendant.dev:8765", &hosted, zone),
+            "fleet"
+        );
+        // The zone apex itself is fleet-classed; a lookalike suffix is not.
+        assert_eq!(
+            origin_route_class("https://fleet.intendant.dev", &hosted, zone),
+            "fleet"
+        );
+        assert_eq!(
+            origin_route_class("https://evil-fleet.intendant.dev", &hosted, zone),
+            "direct"
+        );
+        assert_eq!(
+            origin_route_class("https://192.168.1.50:8765", &hosted, zone),
+            "direct"
+        );
+        // No fleet zone configured: fleet-looking names are just direct.
+        assert_eq!(
+            origin_route_class("https://d-x.fleet.intendant.dev", &hosted, None),
+            "direct"
+        );
+        assert_eq!(origin_route_class("", &hosted, zone), "unknown");
+        assert_eq!(origin_route_class("   ", &hosted, zone), "unknown");
     }
 
     #[test]

--- a/src/bin/caller/credential_audit.rs
+++ b/src/bin/caller/credential_audit.rs
@@ -42,8 +42,8 @@ pub struct CustodyEvent {
     pub actor: String,
     /// Origin class of the session that performed the ceremony —
     /// `hosted` (Connect account / hosted-origin browser key), `direct`
-    /// (anchor-grade key or mTLS cert), `local` (the owner's own
-    /// dashboard), or `peer`. Empty for events with no session behind
+    /// (a key or mTLS cert born on a daemon-served origin), `local` (the
+    /// owner's own dashboard), or `peer`. Empty for events with no session behind
     /// them (expiry sweeps, restart resets) and for records written
     /// before the field existed. See docs/src/trust-tiers.md.
     #[serde(default, skip_serializing_if = "String::is_empty")]

--- a/src/bin/caller/fleet_cert.rs
+++ b/src/bin/caller/fleet_cert.rs
@@ -56,6 +56,19 @@ pub struct FleetCertStatus {
     pub last_error: Option<String>,
     /// Addresses last published for the name (what the A/AAAA records say).
     pub addresses: Vec<String>,
+    /// Certificate Transparency tripwire (docs/src/trust-tiers.md, first
+    /// contact rung two): `unchecked` | `ok` | `alert`. An `alert` means
+    /// the public CT logs hold a certificate for this daemon's name that
+    /// this daemon never requested — the fleet-zone operator (or a CA)
+    /// minted one, which is exactly the betrayal the rung's security
+    /// argument says must leave evidence. Reflects the last successful
+    /// check; fetch failures land in `ct_last_error` instead.
+    pub ct_state: String,
+    /// The foreign certificates behind an `alert`: "serial · issuer ·
+    /// not_before" summaries.
+    pub ct_unknown: Vec<String>,
+    pub ct_checked_unix_ms: Option<u64>,
+    pub ct_last_error: Option<String>,
 }
 
 fn registry() -> &'static Mutex<FleetCertStatus> {
@@ -63,6 +76,7 @@ fn registry() -> &'static Mutex<FleetCertStatus> {
     STATUS.get_or_init(|| {
         Mutex::new(FleetCertStatus {
             state: "none".to_string(),
+            ct_state: "unchecked".to_string(),
             ..Default::default()
         })
     })
@@ -313,6 +327,9 @@ async fn request_certificate_inner(addresses: Vec<String>) -> Result<(), String>
         .poll_certificate(&instant_acme::RetryPolicy::default())
         .await
         .map_err(|e| format!("acme certificate: {e}"))?;
+    // The CT tripwire's own-serial ledger — recorded before install so a
+    // crash here can't make this certificate look foreign later.
+    record_own_certificate(&cert_chain_pem, &name, &acme_directory());
     // Best-effort challenge cleanup; the TXT self-expires regardless.
     let _ = crate::connect_rendezvous::dns_acme_clear().await;
 
@@ -328,12 +345,213 @@ async fn request_certificate_inner(addresses: Vec<String>) -> Result<(), String>
     Ok(())
 }
 
-/// Renewal loop: daily check, renew inside the last 30 days of validity
-/// (Let's Encrypt certificates run 90). Spawned once at gateway startup.
+/* ── Certificate Transparency tripwire ──
+The fleet rung's security argument is "the zone operator can only betray
+loudly": a hijack needs a mis-issued certificate, and browsers only
+accept CT-logged certificates. This monitor turns that in-principle
+evidence into an actual alarm — the daemon records the serials of every
+certificate IT obtained and periodically asks the public CT indexes
+whether its name carries any it didn't. Advisory by nature (crt.sh is a
+best-effort public service); failures are reported, never alarmed. */
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct OwnCertRecord {
+    serial_hex: String,
+    name: String,
+    directory: String,
+    issued_unix_ms: u64,
+}
+
+fn serials_path() -> PathBuf {
+    cert_dir().join("fleet-cert-serials.json")
+}
+
+/// Lowercase hex with leading zeros trimmed — both our parsed serials
+/// and crt.sh's strings normalize to this before comparison.
+fn normalize_serial_hex(serial: &str) -> String {
+    let lower = serial.trim().to_ascii_lowercase();
+    let trimmed = lower.trim_start_matches('0');
+    if trimmed.is_empty() {
+        "0".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// The leaf certificate's serial from a PEM chain.
+fn cert_serial_hex(cert_pem: &str) -> Option<String> {
+    let leaf = pem_certificates(cert_pem).into_iter().next()?;
+    let (_, parsed) = x509_parser::parse_x509_certificate(&leaf).ok()?;
+    let hex: String = parsed
+        .raw_serial()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    Some(normalize_serial_hex(&hex))
+}
+
+fn own_serial_records() -> Vec<OwnCertRecord> {
+    std::fs::read_to_string(serials_path())
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+        .unwrap_or_default()
+}
+
+/// Record a certificate this daemon obtained — BEFORE install, so a
+/// crash between issuance and install can't leave an own-cert looking
+/// foreign at the next check.
+fn record_own_certificate(cert_pem: &str, name: &str, directory: &str) {
+    let Some(serial) = cert_serial_hex(cert_pem) else {
+        return;
+    };
+    let mut records = own_serial_records();
+    if records.iter().any(|record| record.serial_hex == serial) {
+        return;
+    }
+    records.push(OwnCertRecord {
+        serial_hex: serial,
+        name: name.to_string(),
+        directory: directory.to_string(),
+        issued_unix_ms: now_unix_ms(),
+    });
+    if let Ok(serialized) = serde_json::to_string_pretty(&records) {
+        let _ = write_private(&serials_path(), serialized.as_bytes());
+    }
+}
+
+#[derive(Debug, PartialEq)]
+struct CtEntry {
+    serial_hex: String,
+    issuer: String,
+    not_before: String,
+}
+
+/// Parse a crt.sh `output=json` response, deduplicating the
+/// precertificate/leaf pairs that share a serial.
+fn parse_crt_sh_entries(json_text: &str) -> Result<Vec<CtEntry>, String> {
+    let rows: Vec<serde_json::Value> =
+        serde_json::from_str(json_text).map_err(|e| format!("crt.sh response: {e}"))?;
+    let mut seen = std::collections::HashSet::new();
+    let mut entries = Vec::new();
+    for row in rows {
+        let serial = row
+            .get("serial_number")
+            .and_then(|v| v.as_str())
+            .map(normalize_serial_hex)
+            .unwrap_or_default();
+        if serial.is_empty() || !seen.insert(serial.clone()) {
+            continue;
+        }
+        entries.push(CtEntry {
+            serial_hex: serial,
+            issuer: row
+                .get("issuer_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown issuer")
+                .to_string(),
+            not_before: row
+                .get("not_before")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        });
+    }
+    Ok(entries)
+}
+
+/// The foreign entries: publicly logged certificates for our name whose
+/// serials this daemon never recorded.
+fn foreign_entries(logged: Vec<CtEntry>, own_serials: &[String]) -> Vec<CtEntry> {
+    logged
+        .into_iter()
+        .filter(|entry| !own_serials.iter().any(|own| *own == entry.serial_hex))
+        .collect()
+}
+
+/// One CT check against the public index. Advisory: fetch/parse failures
+/// set `ct_last_error` and leave the last successful verdict standing.
+pub async fn ct_check_once() {
+    let Some(name) = status_snapshot().name else {
+        return;
+    };
+    let own: Vec<String> = own_serial_records()
+        .into_iter()
+        .map(|record| record.serial_hex)
+        .collect();
+    let result = async {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .user_agent("intendant-fleet-cert-monitor")
+            .build()
+            .map_err(|e| e.to_string())?;
+        let response = client
+            .get(format!("https://crt.sh/?q={name}&output=json"))
+            .send()
+            .await
+            .map_err(|e| e.to_string())?;
+        if !response.status().is_success() {
+            return Err(format!("crt.sh HTTP {}", response.status()));
+        }
+        let text = response.text().await.map_err(|e| e.to_string())?;
+        parse_crt_sh_entries(&text)
+    }
+    .await;
+    let now = now_unix_ms();
+    match result {
+        Ok(logged) => {
+            let foreign = foreign_entries(logged, &own);
+            with_status(|status| {
+                status.ct_checked_unix_ms = Some(now);
+                status.ct_last_error = None;
+                if foreign.is_empty() {
+                    status.ct_state = "ok".to_string();
+                    status.ct_unknown = Vec::new();
+                } else {
+                    status.ct_state = "alert".to_string();
+                    status.ct_unknown = foreign
+                        .iter()
+                        .map(|entry| {
+                            format!(
+                                "{} · {} · {}",
+                                entry.serial_hex, entry.issuer, entry.not_before
+                            )
+                        })
+                        .collect();
+                }
+            });
+            let status = status_snapshot();
+            if status.ct_state == "alert" {
+                eprintln!(
+                    "[fleet-cert] CT ALERT: {} certificate(s) for {name} in the public CT logs \
+                     that this daemon never requested: {:?} — if you did not mint these through \
+                     another channel, treat the fleet route as compromised and reach this \
+                     daemon directly",
+                    status.ct_unknown.len(),
+                    status.ct_unknown,
+                );
+            }
+        }
+        Err(error) => {
+            with_status(|status| {
+                status.ct_last_error = Some(error);
+            });
+        }
+    }
+}
+
+/// Renewal + CT loop: first tick shortly after startup (registration
+/// needs a moment to learn the fleet name), then twice daily. Renewal
+/// fires inside the last 30 days of validity (Let's Encrypt certificates
+/// run 90); the CT tripwire runs every tick. Spawned once at gateway
+/// startup.
 pub fn spawn_renewal_loop() {
     tokio::spawn(async move {
+        let mut first = true;
         loop {
-            tokio::time::sleep(std::time::Duration::from_secs(12 * 60 * 60)).await;
+            let delay = if first { 10 * 60 } else { 12 * 60 * 60 };
+            first = false;
+            tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+            ct_check_once().await;
             let status = status_snapshot();
             let Some(not_after) = status.not_after_unix_ms else {
                 continue;
@@ -429,5 +647,41 @@ mod tests {
             .unwrap();
         let not_after = cert_not_after_unix_ms(&cert.pem()).unwrap();
         assert!(not_after > now_unix_ms());
+    }
+
+    #[test]
+    fn serial_extraction_and_normalization_agree_with_crt_sh_format() {
+        // A fixed serial with a leading zero byte (DER's positive-sign
+        // padding) must normalize to what crt.sh prints for it.
+        let mut params =
+            rcgen::CertificateParams::new(vec!["d-test.fleet.example.test".to_string()]).unwrap();
+        params.serial_number = Some(rcgen::SerialNumber::from(vec![0x00, 0x8a, 0xbc, 0x01]));
+        let key = rcgen::KeyPair::generate().unwrap();
+        let cert = params.self_signed(&key).unwrap();
+        assert_eq!(cert_serial_hex(&cert.pem()).as_deref(), Some("8abc01"));
+
+        assert_eq!(normalize_serial_hex("038ABc"), "38abc");
+        assert_eq!(normalize_serial_hex("0000"), "0");
+        assert_eq!(normalize_serial_hex(" 03f2 "), "3f2");
+    }
+
+    #[test]
+    fn crt_sh_parsing_dedupes_precert_pairs_and_flags_foreign_serials() {
+        let fixture = r#"[
+            {"issuer_name":"C=US, O=Let's Encrypt, CN=R11","serial_number":"03AB01","not_before":"2026-07-09T00:00:00"},
+            {"issuer_name":"C=US, O=Let's Encrypt, CN=R11","serial_number":"03ab01","not_before":"2026-07-09T00:00:00"},
+            {"issuer_name":"C=US, O=Evil CA","serial_number":"04ff02","not_before":"2026-07-10T00:00:00"}
+        ]"#;
+        let entries = parse_crt_sh_entries(fixture).unwrap();
+        assert_eq!(entries.len(), 2, "precert/leaf pair must dedupe");
+
+        let own = vec!["3ab01".to_string()];
+        let foreign = foreign_entries(entries, &own);
+        assert_eq!(foreign.len(), 1);
+        assert_eq!(foreign[0].serial_hex, "4ff02");
+        assert!(foreign[0].issuer.contains("Evil CA"));
+
+        assert!(parse_crt_sh_entries("<html>rate limited</html>").is_err());
+        assert_eq!(parse_crt_sh_entries("[]").unwrap().len(), 0);
     }
 }

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -1051,6 +1051,23 @@ mod tests {
     use tokio::time::{timeout, Duration};
     use crate::mcp::tests::{test_session_registry_with_display, test_state};
 
+    /// A fragment unique to the user-session opt-in refusal
+    /// (`computer_use::user_session_denied_message`, which both gated MCP
+    /// paths return verbatim). Deliberately NOT "explicit opt-in": that
+    /// phrase also lives in tool descriptions and the supervision prompt,
+    /// which external-agent transcripts render in the dashboard — i.e. it
+    /// can be literally visible on screen, and a granted read_screen
+    /// faithfully returns screen text, so asserting its absence flaked on
+    /// a desktop with a live dashboard frontmost (2026-07-09).
+    fn opt_in_refusal_marker() -> &'static str {
+        let marker = "the user must grant their display first";
+        assert!(
+            crate::computer_use::user_session_denied_message().contains(marker),
+            "marker drifted from user_session_denied_message()"
+        );
+        marker
+    }
+
     #[test]
     fn shared_view_tool_activates_target_and_emits_dashboard_event() {
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -1142,7 +1159,7 @@ mod tests {
                 .expect("tool should dispatch");
             let rendered = serde_json::to_string(&result).unwrap_or_default();
             assert!(
-                rendered.contains("explicit opt-in"),
+                rendered.contains(opt_in_refusal_marker()),
                 "scoped caller must get the opt-in refusal, got: {rendered}"
             );
 
@@ -1241,7 +1258,7 @@ mod tests {
                 .expect("tool should dispatch");
             let rendered = serde_json::to_string(&result).unwrap_or_default();
             assert!(
-                rendered.contains("explicit opt-in"),
+                rendered.contains(opt_in_refusal_marker()),
                 "scoped ungranted read_screen must be refused, got: {rendered}"
             );
 
@@ -1261,7 +1278,7 @@ mod tests {
                 .expect("tool should dispatch");
             let rendered = serde_json::to_string(&result).unwrap_or_default();
             assert!(
-                !rendered.contains("explicit opt-in"),
+                !rendered.contains(opt_in_refusal_marker()),
                 "granted read_screen must clear the gate, got: {rendered}"
             );
         });

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -437,6 +437,10 @@ pub(crate) fn access_connect_status_response_value() -> serde_json::Value {
         "not_after_unix_ms": fleet_cert.not_after_unix_ms,
         "last_error": fleet_cert.last_error,
         "addresses": fleet_cert.addresses,
+        "ct_state": fleet_cert.ct_state,
+        "ct_unknown": fleet_cert.ct_unknown,
+        "ct_checked_unix_ms": fleet_cert.ct_checked_unix_ms,
+        "ct_last_error": fleet_cert.ct_last_error,
     });
     serde_json::json!({
         "schema_version": 1,
@@ -1882,11 +1886,37 @@ pub(crate) fn access_org_renew_response_value(
 }
 
 pub(crate) fn access_enrollment_requests_response_value() -> serde_json::Value {
+    // Route provenance is classified daemon-side (derive, don't mirror):
+    // the browser gets a ready `origin_class` per request instead of
+    // re-deriving hosted/fleet membership from its own copies.
+    let cert_dir = crate::access::backend::select_backend().cert_dir();
+    let hosted_origins = crate::access::iam::load_state(&cert_dir)
+        .map(|state| state.hosted_origins)
+        .unwrap_or_else(|_| crate::access::iam::default_hosted_origins());
+    let fleet_zone = crate::fleet_cert::status_snapshot().zone;
+    let requests: Vec<serde_json::Value> = crate::access::enrollment::pending_enrollments(
+        crate::access::client_key::now_unix_ms(),
+    )
+    .into_iter()
+    .map(|pending| {
+        let origin_class = crate::access::iam::origin_route_class(
+            &pending.origin,
+            &hosted_origins,
+            fleet_zone.as_deref(),
+        );
+        let mut value = serde_json::to_value(&pending).unwrap_or_else(|_| serde_json::json!({}));
+        if let Some(map) = value.as_object_mut() {
+            map.insert(
+                "origin_class".to_string(),
+                serde_json::Value::String(origin_class.to_string()),
+            );
+        }
+        value
+    })
+    .collect();
     serde_json::json!({
         "schema_version": 1,
-        "requests": crate::access::enrollment::pending_enrollments(
-            crate::access::client_key::now_unix_ms(),
-        ),
+        "requests": requests,
     })
 }
 

--- a/static/app.html
+++ b/static/app.html
@@ -25850,12 +25850,16 @@ const DASHBOARD_ACTION_MSG_RPC_ACTIONS = new Set([
 /* ── Browser client identity key ──
    The durable identity of this browser *on this origin*: a WebCrypto P-256
    keypair whose non-extractable private key lives in IndexedDB. Because
-   browser storage is origin-scoped, a key created under an anchor daemon's
-   origin can never be wielded by code served from any other origin — that
-   property is what lets daemons treat key-bound sessions as anchor-grade
-   (see docs/src/trust-architecture.md). Offers carry the public key plus a
-   signature over (daemon id, client nonce, sdp digest, timestamp); daemons
-   resolve the key fingerprint against their local IAM. */
+   browser storage is origin-scoped, a key created under one origin can
+   never be wielded by code served from any OTHER origin — which is what
+   lets daemons weight key-bound sessions by their enrollment origin's
+   provenance (see docs/src/trust-architecture.md). Honest limit: origin
+   scoping is only as strong as the origin's own naming — whoever can
+   present a valid certificate for the origin's name IS the origin to this
+   browser (the first-contact rungs in docs/src/trust-tiers.md). Offers
+   carry the public key plus a signature over (daemon id, client nonce,
+   sdp digest, timestamp); daemons resolve the key fingerprint against
+   their local IAM. */
 
 const CLIENT_IDENTITY_DB = 'intendant-client-identity';
 const CLIENT_IDENTITY_STORE = 'keys';
@@ -53909,7 +53913,7 @@ function renderAccessTierCard() {
   const capLabel = document.createElement('span');
   capLabel.className = 'acc-principal-kind';
   capLabel.textContent = 'Hosted tabs may:';
-  capLabel.title = 'Applies to sessions arriving with hosted provenance — Connect accounts and browser keys enrolled from a hosted origin. Direct, app, and anchor-served sessions are never capped by this.';
+  capLabel.title = 'Applies to sessions arriving with hosted provenance — Connect accounts and browser keys enrolled from a hosted origin. Direct and app sessions are never capped by this. Fleet-name sessions (d-….fleet…) are uncapped by default because this daemon serves their code; to cap them too, add the fleet zone\'s origins to hosted_origins in iam.json (docs: trust-tiers, first contact).';
   capRow.appendChild(capLabel);
   const select = document.createElement('select');
   select.className = 'acc-btn';
@@ -54096,10 +54100,20 @@ function renderAccessConnectCard() {
       : 'No addresses published yet — requesting a certificate publishes this daemon’s routable addresses first.';
     row.appendChild(label);
     const chip = document.createElement('span');
+    if (fleetCert.ct_state === 'alert') {
+      const ct = document.createElement('span');
+      ct.className = 'acc-chip route-danger';
+      ct.textContent = 'CT ALERT';
+      ct.title = `The public Certificate Transparency logs hold ${fleetCert.ct_unknown?.length || 'unknown'} certificate(s) for this daemon's fleet name that this daemon never requested: ${(fleetCert.ct_unknown || []).join(' | ')}. If you did not mint these yourself through another channel, someone who controls the fleet zone (or a CA) issued a certificate for this name — treat the fleet route as compromised and reach this daemon directly or through the app.`;
+      row.appendChild(ct);
+    }
     if (fleetCert.state === 'valid') {
       chip.className = 'acc-chip route-webrtc';
       chip.textContent = validUntil ? `certificate ✓ until ${validUntil}` : 'certificate ✓';
-      chip.title = 'A browser-trusted Let’s Encrypt certificate is serving for this name — open the direct dashboard at https://' + fleetCert.name + (window.location.port ? ':' + window.location.port : '') + ' without warnings. Renewals are automatic.';
+      chip.title = 'A browser-trusted Let’s Encrypt certificate is serving for this name — open the direct dashboard at https://' + fleetCert.name + (window.location.port ? ':' + window.location.port : '') + ' without warnings. Renewals are automatic.'
+        + (fleetCert.ct_state === 'ok' && fleetCert.ct_checked_unix_ms
+          ? ` CT tripwire: all publicly logged certificates for this name are this daemon's own (checked ${new Date(Number(fleetCert.ct_checked_unix_ms)).toLocaleString()}).`
+          : '');
     } else if (fleetCert.state === 'requesting') {
       chip.className = 'acc-chip route-remembered';
       chip.textContent = 'requesting…';
@@ -54286,12 +54300,19 @@ function renderAccessEnrollmentRequests() {
     kind.textContent = `${attempts === 1 ? '1 attempt' : `${attempts} attempts`} · last ${new Date(Number(request.last_seen_unix_ms || 0)).toLocaleString()}`;
     nameWrap.append(name, kind);
     headRow.append(glyphEl, nameWrap);
-    if (request.origin) {
-      headRow.appendChild(accessRouteChip('connect', 'via hosted route', `The offer arrived through ${request.origin}; the key will be recorded with that origin, so the role ceiling applies until it is re-enrolled from an anchor origin.`));
-      if (accessModelLabel(accessIamModel(accessOverviewModel()).tier) === 'integrated') {
-        headRow.appendChild(accessRouteChip('danger', 'integrated tier',
-          'This is an integrated-tier machine and the key arrived through a hosted route. Approving is an upward grant (docs: trust-tiers) — the hosted-control cap still bounds the session, but prefer enrolling this device from a direct or app origin.'));
-      }
+    // Route provenance chip: which first-contact rung the key arrived on
+    // (classified daemon-side — origin_class; docs/src/trust-tiers.md).
+    const originClass = request.origin_class || (request.origin ? 'hosted' : 'unknown');
+    if (originClass === 'hosted') {
+      headRow.appendChild(accessRouteChip('connect', 'via hosted route', `The offer arrived through ${request.origin}; the rendezvous serves that page's code, so the hosted role ceiling applies until the key is re-enrolled from a daemon-served origin.`));
+    } else if (originClass === 'fleet') {
+      headRow.appendChild(accessRouteChip('remembered', 'via fleet name', `The offer arrived through ${request.origin} — this daemon serves that page's code, but the rendezvous names the route (it could hijack DNS and mint a certificate; such an attack is active-only and lands in public CT logs, which this daemon monitors). Rung two of first contact: stronger than hosted, weaker than a typed address. No ceiling applies by default; add this exact origin to hosted_origins in iam.json to cap it.`));
+    } else if (request.origin) {
+      headRow.appendChild(accessRouteChip('local', 'via direct origin', `The offer arrived through ${request.origin} — a daemon-served origin the rendezvous neither serves nor names.`));
+    }
+    if (request.origin && accessModelLabel(accessIamModel(accessOverviewModel()).tier) === 'integrated') {
+      headRow.appendChild(accessRouteChip('danger', 'integrated tier',
+        'This is an integrated-tier machine and the key arrived over the network. Approving grants remote authority here — verify the fingerprint below against the requesting device before approving anything above observer (docs: trust-tiers).'));
     }
     if (request.account_hint) {
       headRow.appendChild(request.account_attested

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -801,12 +801,16 @@ const DASHBOARD_ACTION_MSG_RPC_ACTIONS = new Set([
 /* ── Browser client identity key ──
    The durable identity of this browser *on this origin*: a WebCrypto P-256
    keypair whose non-extractable private key lives in IndexedDB. Because
-   browser storage is origin-scoped, a key created under an anchor daemon's
-   origin can never be wielded by code served from any other origin — that
-   property is what lets daemons treat key-bound sessions as anchor-grade
-   (see docs/src/trust-architecture.md). Offers carry the public key plus a
-   signature over (daemon id, client nonce, sdp digest, timestamp); daemons
-   resolve the key fingerprint against their local IAM. */
+   browser storage is origin-scoped, a key created under one origin can
+   never be wielded by code served from any OTHER origin — which is what
+   lets daemons weight key-bound sessions by their enrollment origin's
+   provenance (see docs/src/trust-architecture.md). Honest limit: origin
+   scoping is only as strong as the origin's own naming — whoever can
+   present a valid certificate for the origin's name IS the origin to this
+   browser (the first-contact rungs in docs/src/trust-tiers.md). Offers
+   carry the public key plus a signature over (daemon id, client nonce,
+   sdp digest, timestamp); daemons resolve the key fingerprint against
+   their local IAM. */
 
 const CLIENT_IDENTITY_DB = 'intendant-client-identity';
 const CLIENT_IDENTITY_STORE = 'keys';

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -858,7 +858,7 @@ function renderAccessTierCard() {
   const capLabel = document.createElement('span');
   capLabel.className = 'acc-principal-kind';
   capLabel.textContent = 'Hosted tabs may:';
-  capLabel.title = 'Applies to sessions arriving with hosted provenance — Connect accounts and browser keys enrolled from a hosted origin. Direct, app, and anchor-served sessions are never capped by this.';
+  capLabel.title = 'Applies to sessions arriving with hosted provenance — Connect accounts and browser keys enrolled from a hosted origin. Direct and app sessions are never capped by this. Fleet-name sessions (d-….fleet…) are uncapped by default because this daemon serves their code; to cap them too, add the fleet zone\'s origins to hosted_origins in iam.json (docs: trust-tiers, first contact).';
   capRow.appendChild(capLabel);
   const select = document.createElement('select');
   select.className = 'acc-btn';
@@ -1045,10 +1045,20 @@ function renderAccessConnectCard() {
       : 'No addresses published yet — requesting a certificate publishes this daemon’s routable addresses first.';
     row.appendChild(label);
     const chip = document.createElement('span');
+    if (fleetCert.ct_state === 'alert') {
+      const ct = document.createElement('span');
+      ct.className = 'acc-chip route-danger';
+      ct.textContent = 'CT ALERT';
+      ct.title = `The public Certificate Transparency logs hold ${fleetCert.ct_unknown?.length || 'unknown'} certificate(s) for this daemon's fleet name that this daemon never requested: ${(fleetCert.ct_unknown || []).join(' | ')}. If you did not mint these yourself through another channel, someone who controls the fleet zone (or a CA) issued a certificate for this name — treat the fleet route as compromised and reach this daemon directly or through the app.`;
+      row.appendChild(ct);
+    }
     if (fleetCert.state === 'valid') {
       chip.className = 'acc-chip route-webrtc';
       chip.textContent = validUntil ? `certificate ✓ until ${validUntil}` : 'certificate ✓';
-      chip.title = 'A browser-trusted Let’s Encrypt certificate is serving for this name — open the direct dashboard at https://' + fleetCert.name + (window.location.port ? ':' + window.location.port : '') + ' without warnings. Renewals are automatic.';
+      chip.title = 'A browser-trusted Let’s Encrypt certificate is serving for this name — open the direct dashboard at https://' + fleetCert.name + (window.location.port ? ':' + window.location.port : '') + ' without warnings. Renewals are automatic.'
+        + (fleetCert.ct_state === 'ok' && fleetCert.ct_checked_unix_ms
+          ? ` CT tripwire: all publicly logged certificates for this name are this daemon's own (checked ${new Date(Number(fleetCert.ct_checked_unix_ms)).toLocaleString()}).`
+          : '');
     } else if (fleetCert.state === 'requesting') {
       chip.className = 'acc-chip route-remembered';
       chip.textContent = 'requesting…';
@@ -1235,12 +1245,19 @@ function renderAccessEnrollmentRequests() {
     kind.textContent = `${attempts === 1 ? '1 attempt' : `${attempts} attempts`} · last ${new Date(Number(request.last_seen_unix_ms || 0)).toLocaleString()}`;
     nameWrap.append(name, kind);
     headRow.append(glyphEl, nameWrap);
-    if (request.origin) {
-      headRow.appendChild(accessRouteChip('connect', 'via hosted route', `The offer arrived through ${request.origin}; the key will be recorded with that origin, so the role ceiling applies until it is re-enrolled from an anchor origin.`));
-      if (accessModelLabel(accessIamModel(accessOverviewModel()).tier) === 'integrated') {
-        headRow.appendChild(accessRouteChip('danger', 'integrated tier',
-          'This is an integrated-tier machine and the key arrived through a hosted route. Approving is an upward grant (docs: trust-tiers) — the hosted-control cap still bounds the session, but prefer enrolling this device from a direct or app origin.'));
-      }
+    // Route provenance chip: which first-contact rung the key arrived on
+    // (classified daemon-side — origin_class; docs/src/trust-tiers.md).
+    const originClass = request.origin_class || (request.origin ? 'hosted' : 'unknown');
+    if (originClass === 'hosted') {
+      headRow.appendChild(accessRouteChip('connect', 'via hosted route', `The offer arrived through ${request.origin}; the rendezvous serves that page's code, so the hosted role ceiling applies until the key is re-enrolled from a daemon-served origin.`));
+    } else if (originClass === 'fleet') {
+      headRow.appendChild(accessRouteChip('remembered', 'via fleet name', `The offer arrived through ${request.origin} — this daemon serves that page's code, but the rendezvous names the route (it could hijack DNS and mint a certificate; such an attack is active-only and lands in public CT logs, which this daemon monitors). Rung two of first contact: stronger than hosted, weaker than a typed address. No ceiling applies by default; add the fleet zone to hosted_origins in iam.json to cap it.`));
+    } else if (request.origin) {
+      headRow.appendChild(accessRouteChip('local', 'via direct origin', `The offer arrived through ${request.origin} — a daemon-served origin the rendezvous neither serves nor names.`));
+    }
+    if (request.origin && accessModelLabel(accessIamModel(accessOverviewModel()).tier) === 'integrated') {
+      headRow.appendChild(accessRouteChip('danger', 'integrated tier',
+        'This is an integrated-tier machine and the key arrived over the network. Approving grants remote authority here — verify the fingerprint below against the requesting device before approving anything above observer (docs: trust-tiers).'));
     }
     if (request.account_hint) {
       headRow.appendChild(request.account_attested

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -1251,7 +1251,7 @@ function renderAccessEnrollmentRequests() {
     if (originClass === 'hosted') {
       headRow.appendChild(accessRouteChip('connect', 'via hosted route', `The offer arrived through ${request.origin}; the rendezvous serves that page's code, so the hosted role ceiling applies until the key is re-enrolled from a daemon-served origin.`));
     } else if (originClass === 'fleet') {
-      headRow.appendChild(accessRouteChip('remembered', 'via fleet name', `The offer arrived through ${request.origin} — this daemon serves that page's code, but the rendezvous names the route (it could hijack DNS and mint a certificate; such an attack is active-only and lands in public CT logs, which this daemon monitors). Rung two of first contact: stronger than hosted, weaker than a typed address. No ceiling applies by default; add the fleet zone to hosted_origins in iam.json to cap it.`));
+      headRow.appendChild(accessRouteChip('remembered', 'via fleet name', `The offer arrived through ${request.origin} — this daemon serves that page's code, but the rendezvous names the route (it could hijack DNS and mint a certificate; such an attack is active-only and lands in public CT logs, which this daemon monitors). Rung two of first contact: stronger than hosted, weaker than a typed address. No ceiling applies by default; add this exact origin to hosted_origins in iam.json to cap it.`));
     } else if (request.origin) {
       headRow.appendChild(accessRouteChip('local', 'via direct origin', `The offer arrived through ${request.origin} — a daemon-served origin the rendezvous neither serves nor names.`));
     }


### PR DESCRIPTION
First contact is the third trust axis, and "anchor-grade" was papering over it. A fleet-name URL (`https://d-<hash>.fleet.intendant.dev:8765`) serves daemon-owned code, but the *route* to it is rendezvous-named — DNS plus WebPKI — and whoever answers for the name can, in principle, swap the endpoint and mint a certificate. That is not an anchor; it is a distinct rung whose security argument is *evidence*, not absence of trust. This PR names the axis, builds the evidence leg, and surfaces the rung wherever an owner makes a trust decision.

## Doctrine (docs)

- **trust-tiers.md — "First contact: three rungs"**: trustless (typed direct address + enrollment ceremony / preinstalled material), trust-with-mandatory-evidence (fleet name: betrayal must be active and lands in public CT logs), trusted-but-bounded (hosted tab: betrayal is silent; ceilings + custody bound it). Plus the every-page-load consequence (a browser rung is only as durable as its serving origin — identity keys are wieldable by whatever code the origin serves), a "Still blurry, on purpose" inventory (TOFU/time axis, update channel, lookalike names, the browser base, hosted-passkey coupling — each tracked or a stated non-goal), and product hook 4.
- **trust-architecture.md**: a fleet-DNS-zone + WebPKI row in the trust ledger — worst case (targeted endpoint swap serving attacker code at the enrolled origin), why it is bounded (active-only, CT-evidenced, tripwire-watched, cappable), and what is **not** bounded (first-load code).
- **configuration.md**: the "keys enrolled from a daemon-served origin are anchor-grade and uncapped" claim becomes the routing-statement framing, with the exact-origin `hosted_origins` recipe for capping fleet-name sessions.

## Mechanism

- **`iam::origin_route_class`** — route provenance of an enrollment origin (`hosted` / `fleet` / `direct` / `unknown`), distinct from `session_origin_class` (custody-trail code provenance): a fleet origin is `direct`-grade for custody and `fleet` for approval UX. Lookalike suffixes (`evil-fleet.<zone>`) classify as `direct`, not `fleet`.
- **CT tripwire in `fleet_cert`** — the daemon records the serial of every certificate it obtains (persisted *before* install, so a crash cannot make an own certificate look foreign), polls crt.sh for its fleet name on each renewal tick (first tick 10 min, then 12 h), dedupes precert/leaf pairs, and flags serials it never requested: `ct_state: unchecked|ok|alert` + `ct_unknown` serials on the fleet-cert status payload. Advisory and fail-open: a crt.sh outage stamps `ct_last_error` and never blocks renewal.
- **Enrollment approvals** now carry a daemon-computed `origin_class` per request.

## Product

- Enrollment cards show a route chip per rung — *via hosted route*, *via fleet name* (with honest copy: active-only, CT-logged, how to cap), *via direct origin* — and the integrated-tier warning now fires for any network origin.
- The Connect card raises a **CT ALERT** chip on foreign serials; the valid-cert chip notes the last clean CT check.
- The hosted-ceiling knob and the fleet chip state the capping recipe precisely: the ceiling test is an exact-origin match, so it is the daemon's own fleet origin that goes into `hosted_origins`, not the bare zone.

Also rides along: a de-flake of the user-session gate tests. Their assertions matched the phrase "explicit opt-in", which also appears in the supervision prompt that external-agent transcripts render in the dashboard — i.e. it can be literally visible on screen, and a granted `read_screen` faithfully returns screen text, so the negative assertion failed on any desktop with a live dashboard frontmost (the merge-queue macOS leg runs on a desktop). The assertions now use a fragment unique to `user_session_denied_message()`, pinned to the source so drift fails loudly.

Tests: `origin_route_class` rung classification (incl. lookalike rejection), CT serial normalization against crt.sh's format, precert-pair dedupe + foreign-serial flagging. Battery: `cargo nextest run --bins` 2703/2703 green (no fail-fast), clippy clean, app.html regenerated, mdBook builds with the new anchor.
