### PR TITLE
Bundled-app + enrollment papercuts: projectless Connect, temp prefills, phone enrollment

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -50,7 +50,7 @@ for the headless `tests/e2e/` suite and demos) and requires
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `INTENDANT_HOME` | `~/.intendant` | Overrides the daemon state root — the one directory holding session logs, the session-index cache, recordings, quarantine, leased credentials, access certs, the service pidfile, the projectless upload/transfer global store (`global-store/`, pruned after 14 idle days at daemon startup), and the rest of the machine-local daemon state. The value is used verbatim as the root (no `.intendant` component is appended); a relative path resolves against the startup directory. Read once at first use and fixed for the process lifetime. Useful for scratch daemons and hermetic harnesses. Locations that are deliberately *not* under the state root are unaffected: project-local `.intendant/` directories, external-agent homes (`~/.codex`, `~/.claude`), and the platform-data-dir daemon identity key. |
+| `INTENDANT_HOME` | `~/.intendant` | Overrides the daemon state root — the one directory holding session logs, the session-index cache, recordings, quarantine, leased credentials, access certs, the service pidfile, the projectless daemon's Connect config (`connect.toml`), the projectless upload/transfer global store (`global-store/`, pruned after 14 idle days at daemon startup), and the rest of the machine-local daemon state. The value is used verbatim as the root (no `.intendant` component is appended); a relative path resolves against the startup directory. Read once at first use and fixed for the process lifetime. Useful for scratch daemons and hermetic harnesses. Locations that are deliberately *not* under the state root are unaffected: project-local `.intendant/` directories, external-agent homes (`~/.codex`, `~/.claude`), and the platform-data-dir daemon identity key. |
 
 ### Model and behavior tuning
 
@@ -357,6 +357,12 @@ here), shows registration/claim state, reveals the twelve-word claim
 phrase to manage-grade sessions, and can release the claim binding. The
 `INTENDANT_CONNECT_RENDEZVOUS_URL` environment variable still force-enables
 the client and overrides the file (the card reports when it does).
+
+**Projectless daemons** (the bundled macOS app's normal shape — no
+`.git`/`intendant.toml` at the launch directory) have no project file to
+persist into; for them the same `[connect]` table lives in the
+daemon-scoped `connect.toml` under the state root (`~/.intendant/`), and
+the toggle and daemon boot both use it. Rooted daemons are unaffected.
 
 Hosted Connect uses the same daemon-side settings:
 

--- a/src/bin/caller/access/cert_server.rs
+++ b/src/bin/caller/access/cert_server.rs
@@ -110,6 +110,7 @@ pub async fn serve(
         .map_err(|e| AccessError(format!("bind {bind_addr}: {e}")))?;
 
     let gate = Arc::new(EnrollmentGate::default());
+    warn_if_access_host_missing_from_cert(&cert_path, access_host);
     print_client_setup_banner(access_host, port, https_port);
 
     let prompt_gate = Arc::clone(&gate);
@@ -134,7 +135,7 @@ pub async fn serve(
 
     tokio::select! {
         _ = shutdown => {}
-        _ = accept_loop(listener, acceptor, cert_dir, p12_password, host_label, access_host, https_port, gate) => {}
+        _ = accept_loop(listener, acceptor, cert_dir, p12_password, host_label, access_host, port, https_port, gate) => {}
     }
 
     Ok(())
@@ -193,6 +194,7 @@ async fn prompt_for_pairing(expected_fingerprint: String, gate: Arc<EnrollmentGa
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn accept_loop(
     listener: TcpListener,
     acceptor: TlsAcceptor,
@@ -200,6 +202,7 @@ async fn accept_loop(
     p12_password: String,
     host_label: String,
     access_host: String,
+    cert_port: u16,
     https_port: u16,
     gate: Arc<EnrollmentGate>,
 ) {
@@ -273,6 +276,34 @@ async fn accept_loop(
         let access_host = access_host.clone();
         let gate = Arc::clone(&gate);
         tokio::spawn(async move {
+            // Phones dialing a bare `host:port` try plain http:// first;
+            // feeding that into the TLS accept used to die with
+            // InvalidContentType and leave the browser on a blank page.
+            // Peek the first byte (TLS handshake records start 0x16; HTTP
+            // methods are ASCII letters — same demux the web gateway
+            // uses) and bounce cleartext HTTP to the https URL instead.
+            // Nothing sensitive rides the enrollment URL: auth is the
+            // fingerprint ceremony plus the one-time secret typed on the
+            // page, so the redirect leaks nothing the cleartext request
+            // didn't already.
+            let mut head = [0u8; 1];
+            match stream.peek(&mut head).await {
+                Ok(n) if n > 0 && head[0] != 0x16 => {
+                    if let Err(err) =
+                        redirect_plaintext_to_https(stream, &access_host, cert_port).await
+                    {
+                        eprintln!(
+                            "[access/cert-server] plaintext redirect for {peer} failed: {err}"
+                        );
+                    }
+                    return;
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    eprintln!("[access/cert-server] peek from {peer} failed: {err}");
+                    return;
+                }
+            }
             let stream = match acceptor.accept(stream).await {
                 Ok(stream) => stream,
                 Err(err) => {
@@ -1333,6 +1364,119 @@ fn escape_html(input: &str) -> String {
         .replace('"', "&quot;")
 }
 
+/// Answer a cleartext HTTP request on the TLS-only enrollment port with a
+/// permanent redirect to the same URL over https. Prefers the host the
+/// client actually dialed (this machine may be reachable on several
+/// addresses); falls back to the advertised access host.
+async fn redirect_plaintext_to_https<S>(
+    mut stream: S,
+    access_host: &str,
+    cert_port: u16,
+) -> std::io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let Some(req) = read_request(&mut stream).await? else {
+        return Ok(());
+    };
+    let dialed = req
+        .header("host")
+        .map(host_without_port)
+        .map(str::trim)
+        .filter(|host| !host.is_empty())
+        .unwrap_or(access_host)
+        .to_string();
+    let path = if req.path.starts_with('/') {
+        req.path.clone()
+    } else {
+        "/".to_string()
+    };
+    let location = format!("https://{dialed}:{cert_port}{path}");
+    let response = format!(
+        "HTTP/1.1 301 Moved Permanently\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+    );
+    stream.write_all(response.as_bytes()).await?;
+    stream.shutdown().await
+}
+
+/// `Host` header without its port: `name:8443` → `name`,
+/// `[::1]:8443` → `[::1]` (brackets kept — they go back into a URL).
+fn host_without_port(host: &str) -> &str {
+    let host = host.trim();
+    if host.starts_with('[') {
+        if let Some(end) = host.find(']') {
+            return &host[..=end];
+        }
+        return host;
+    }
+    match host.rsplit_once(':') {
+        Some((name, port))
+            if !name.is_empty() && !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) =>
+        {
+            name
+        }
+        _ => host,
+    }
+}
+
+/// Whether the server certificate's SANs cover the advertised access
+/// host, plus the SAN labels for the operator message. `None` when the
+/// cert cannot be read or parsed (the acceptor build already failed
+/// loudly in that case, so no separate warning is useful).
+fn cert_sans_cover_access_host(cert_path: &Path, access_host: &str) -> Option<(bool, Vec<String>)> {
+    use x509_parser::extensions::GeneralName;
+    use x509_parser::prelude::*;
+
+    let der = super::certs::read_cert_der(cert_path).ok()?;
+    let (_, cert) = X509Certificate::from_der(&der).ok()?;
+    let san = cert.subject_alternative_name().ok().flatten()?;
+    let target_ip: Option<std::net::IpAddr> = access_host.parse().ok();
+    let mut labels = Vec::new();
+    let mut covered = false;
+    for name in &san.value.general_names {
+        match name {
+            GeneralName::DNSName(dns) => {
+                labels.push(dns.to_string());
+                if dns.eq_ignore_ascii_case(access_host) {
+                    covered = true;
+                }
+            }
+            GeneralName::IPAddress(bytes) => {
+                let ip: Option<std::net::IpAddr> = match bytes.len() {
+                    4 => <[u8; 4]>::try_from(*bytes).ok().map(std::net::IpAddr::from),
+                    16 => <[u8; 16]>::try_from(*bytes).ok().map(std::net::IpAddr::from),
+                    _ => None,
+                };
+                if let Some(ip) = ip {
+                    labels.push(ip.to_string());
+                    if target_ip == Some(ip) {
+                        covered = true;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    Some((covered, labels))
+}
+
+/// CertificateUnknown triage, before the ceremony instead of after it
+/// fails: enrolling clients hard-reject TLS when the host they dial is
+/// not in the server certificate's SANs — the common case is a cert
+/// minted before an address existed (new tailnet IP, renamed host).
+/// Warn the operator up front with the fix.
+fn warn_if_access_host_missing_from_cert(cert_path: &Path, access_host: &str) {
+    if let Some((false, sans)) = cert_sans_cover_access_host(cert_path, access_host) {
+        eprintln!();
+        eprintln!("!! The advertised enrollment host {access_host} is NOT covered by the");
+        eprintln!("!! server certificate (SANs: {}).", sans.join(", "));
+        eprintln!("!! Enrolling devices will refuse the connection (CertificateUnknown).");
+        eprintln!("!! Run `intendant access setup --force` to mint certificates covering");
+        eprintln!("!! this machine's current addresses, then rerun `intendant access serve-certs`.");
+        eprintln!();
+    }
+}
+
 fn print_client_setup_banner(access_host: &str, cert_port: u16, https_port: u16) {
     println!();
     println!("============================================================");
@@ -1366,6 +1510,91 @@ fn print_client_setup_banner(access_host: &str, cert_port: u16, https_port: u16)
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn host_without_port_handles_names_ips_and_bracketed_v6() {
+        assert_eq!(host_without_port("daemon.local:8443"), "daemon.local");
+        assert_eq!(host_without_port("192.168.1.50:8443"), "192.168.1.50");
+        assert_eq!(host_without_port("[fd7a::1]:8443"), "[fd7a::1]");
+        assert_eq!(host_without_port("daemon.local"), "daemon.local");
+        assert_eq!(host_without_port("[fd7a::1]"), "[fd7a::1]");
+    }
+
+    #[test]
+    fn plaintext_http_gets_redirected_to_https_on_the_dialed_host() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let (mut client, server) = tokio::io::duplex(4096);
+            client
+                .write_all(
+                    b"GET /?k=v HTTP/1.1\r\nHost: 100.101.102.103:8443\r\nUser-Agent: x\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            redirect_plaintext_to_https(server, "fallback.host", 8443)
+                .await
+                .unwrap();
+            let mut response = String::new();
+            client.read_to_string(&mut response).await.unwrap();
+            assert!(response.starts_with("HTTP/1.1 301"), "{response}");
+            assert!(
+                response.contains("Location: https://100.101.102.103:8443/?k=v"),
+                "redirect must target the dialed host and keep the path/query: {response}"
+            );
+        });
+    }
+
+    #[test]
+    fn plaintext_redirect_falls_back_to_the_access_host_without_a_host_header() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let (mut client, server) = tokio::io::duplex(4096);
+            client
+                .write_all(b"GET / HTTP/1.0\r\n\r\n")
+                .await
+                .unwrap();
+            redirect_plaintext_to_https(server, "10.0.0.42", 9000)
+                .await
+                .unwrap();
+            let mut response = String::new();
+            client.read_to_string(&mut response).await.unwrap();
+            assert!(
+                response.contains("Location: https://10.0.0.42:9000/"),
+                "{response}"
+            );
+        });
+    }
+
+    #[test]
+    fn san_preflight_flags_hosts_the_cert_does_not_cover() {
+        let tmp = TempDir::new().unwrap();
+        let server_names = super::super::certs::ServerNames::new(
+            "10.0.0.42".parse().unwrap(),
+            vec!["192.168.1.42".parse().unwrap()],
+            vec!["station.example.test".to_string()],
+        )
+        .unwrap();
+        super::super::certs::ensure_certs(tmp.path(), &server_names, "label", false).unwrap();
+        let cert_path = tmp.path().join("server.crt");
+
+        let (covered, _) = cert_sans_cover_access_host(&cert_path, "10.0.0.42").unwrap();
+        assert!(covered, "primary IP SAN must count as covered");
+        let (covered, _) =
+            cert_sans_cover_access_host(&cert_path, "station.example.test").unwrap();
+        assert!(covered, "DNS SAN must count as covered (case-insensitive)");
+        let (covered, sans) = cert_sans_cover_access_host(&cert_path, "100.64.0.7").unwrap();
+        assert!(
+            !covered,
+            "an address minted after the cert must be flagged; SANs: {sans:?}"
+        );
+        assert!(!sans.is_empty());
+    }
 
     #[test]
     fn fingerprint_input_accepts_browser_colon_uppercase_format() {

--- a/src/bin/caller/project.rs
+++ b/src/bin/caller/project.rs
@@ -660,6 +660,119 @@ fn default_connect_retry_delay_ms() -> u64 {
     1_000
 }
 
+/// On-disk shape of the daemon-scoped Connect config file: the same
+/// `[connect]` table `intendant.toml` carries, alone in its own file.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct DaemonConnectFile {
+    #[serde(default)]
+    connect: ConnectConfig,
+}
+
+/// Where a projectless daemon persists its Connect client config. Rooted
+/// daemons keep `[connect]` in the project's `intendant.toml`; a daemon
+/// with no project (the bundled app's normal shape) has no intendant.toml
+/// to write, so the config lives with the rest of the machine-local daemon
+/// state under the state root.
+pub fn daemon_connect_config_path() -> PathBuf {
+    crate::platform::intendant_home().join("connect.toml")
+}
+
+/// Load the daemon-scoped Connect config. An absent file is the normal
+/// never-enabled state, not an error.
+pub fn load_daemon_connect_config_in(path: &Path) -> Result<ConnectConfig, String> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(ConnectConfig::default())
+        }
+        Err(e) => return Err(format!("read {}: {e}", path.display())),
+    };
+    let file: DaemonConnectFile =
+        toml::from_str(&text).map_err(|e| format!("parse {}: {e}", path.display()))?;
+    Ok(file.connect)
+}
+
+/// Daemon-scoped Connect config at the live state-root path.
+pub fn load_daemon_connect_config() -> Result<ConnectConfig, String> {
+    load_daemon_connect_config_in(&daemon_connect_config_path())
+}
+
+/// Persist the daemon-scoped Connect config (atomic tmp+rename; the file
+/// may carry `auth_token`, so it gets owner-only permissions like the
+/// vault blob).
+pub fn save_daemon_connect_config_in(path: &Path, config: &ConnectConfig) -> Result<(), String> {
+    let file = DaemonConnectFile {
+        connect: config.clone(),
+    };
+    let text =
+        toml::to_string_pretty(&file).map_err(|e| format!("serialize connect config: {e}"))?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    let tmp = path.with_extension("toml.tmp");
+    std::fs::write(&tmp, text).map_err(|e| format!("write {}: {e}", tmp.display()))?;
+    restrict_connect_file(&tmp);
+    std::fs::rename(&tmp, path).map_err(|e| format!("finalize {}: {e}", path.display()))
+}
+
+fn restrict_connect_file(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(metadata) = std::fs::metadata(path) {
+            let mut perms = metadata.permissions();
+            perms.set_mode(0o600);
+            let _ = std::fs::set_permissions(path, perms);
+        }
+    }
+}
+
+/// Which store a Connect config round-trips through — resolved once from
+/// the daemon's project root so every surface (HTTP route, dashboard
+/// tunnel, boot) agrees on where the config lives.
+pub(crate) enum ConnectConfigStore {
+    /// Rooted daemon: `[connect]` in the project's `intendant.toml`.
+    Project(PathBuf),
+    /// Projectless daemon: the daemon-scoped `connect.toml` (path is
+    /// explicit so tests can point it at a scratch directory — the
+    /// default-path constructor hits the live state root).
+    DaemonFile(PathBuf),
+}
+
+impl ConnectConfigStore {
+    pub(crate) fn for_project_root(project_root: Option<&Path>) -> Self {
+        match project_root {
+            Some(root) => Self::Project(root.to_path_buf()),
+            None => Self::DaemonFile(daemon_connect_config_path()),
+        }
+    }
+
+    pub(crate) fn load(&self) -> Result<ConnectConfig, String> {
+        match self {
+            Self::Project(root) => Ok(Project::from_root(root.clone())
+                .map_err(|e| format!("load project config: {e}"))?
+                .config
+                .connect),
+            Self::DaemonFile(path) => load_daemon_connect_config_in(path),
+        }
+    }
+
+    pub(crate) fn save(&self, config: &ConnectConfig) -> Result<(), String> {
+        match self {
+            Self::Project(root) => {
+                let mut project = Project::from_root(root.clone())
+                    .map_err(|e| format!("load project config: {e}"))?;
+                project.config.connect = config.clone();
+                project
+                    .save_config()
+                    .map_err(|e| format!("write intendant.toml: {e}"))
+            }
+            Self::DaemonFile(path) => save_daemon_connect_config_in(path, config),
+        }
+    }
+}
+
 /// Daemon-level settings for what this Intendant advertises to peers
 /// and what it requires of inbound peer connections.
 /// Lives under `[server]` in intendant.toml.
@@ -1970,5 +2083,59 @@ context_recovery = "managed"
 "#;
         let config: ProjectConfig = toml::from_str(alias_toml).unwrap();
         assert_eq!(config.agent.codex.managed_context, "managed");
+    }
+
+    #[test]
+    fn daemon_connect_config_round_trips_and_defaults_when_absent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("connect.toml");
+
+        // Absent file = never enabled, not an error.
+        let absent = load_daemon_connect_config_in(&path).unwrap();
+        assert!(!absent.enabled);
+        assert!(absent.rendezvous_url.is_none());
+
+        let mut config = ConnectConfig::default();
+        config.enabled = true;
+        config.rendezvous_url = Some("https://rendezvous.example".to_string());
+        save_daemon_connect_config_in(&path, &config).unwrap();
+
+        let loaded = load_daemon_connect_config_in(&path).unwrap();
+        assert!(loaded.enabled);
+        assert_eq!(
+            loaded.rendezvous_url.as_deref(),
+            Some("https://rendezvous.example")
+        );
+
+        // The file is the same [connect] table intendant.toml carries.
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(text.contains("[connect]"), "{text}");
+
+        // Disable round-trips too (the toggle's off path).
+        config.enabled = false;
+        save_daemon_connect_config_in(&path, &config).unwrap();
+        assert!(!load_daemon_connect_config_in(&path).unwrap().enabled);
+    }
+
+    #[test]
+    fn connect_config_store_uses_daemon_file_when_projectless() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("connect.toml");
+        let store = ConnectConfigStore::DaemonFile(path.clone());
+
+        let mut config = store.load().unwrap();
+        assert!(!config.enabled);
+        config.enabled = true;
+        store.save(&config).unwrap();
+        assert!(path.exists());
+        assert!(store.load().unwrap().enabled);
+
+        // Rooted daemons keep resolving to the project store.
+        match ConnectConfigStore::for_project_root(Some(std::path::Path::new("/tmp/p"))) {
+            ConnectConfigStore::Project(root) => {
+                assert_eq!(root, std::path::PathBuf::from("/tmp/p"))
+            }
+            ConnectConfigStore::DaemonFile(_) => panic!("rooted daemon must use the project store"),
+        }
     }
 }

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -250,7 +250,18 @@ pub(crate) fn spawn_mode_web_gateway(
         project.config.webrtc.federation_allow_h264,
     );
     config.peer_access_requests = project.config.server.peer_access_requests.clone();
-    config.connect = project.config.connect.clone().effective_with_env();
+    // Connect config follows the same store the dashboard toggle writes:
+    // the project's intendant.toml when rooted, the daemon-scoped
+    // connect.toml when projectless — otherwise the bundled app's toggle
+    // would not survive a daemon restart.
+    let connect_base = match &project_root {
+        Some(_) => project.config.connect.clone(),
+        None => crate::project::load_daemon_connect_config().unwrap_or_else(|e| {
+            eprintln!("[connect] daemon-scoped connect.toml unreadable: {e}");
+            Default::default()
+        }),
+    };
+    config.connect = connect_base.effective_with_env();
     config.presence_enabled = runtime_presence_enabled;
     config.external_agent = initial_agent_backend
         .as_ref()

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -520,14 +520,26 @@ pub(crate) async fn handle_access_connect_claim_code(
     finalize_http_stream(&mut stream).await;
 }
 
-/// Enable/disable the Connect client: persist `[connect]` to
-/// intendant.toml, then apply the effective config to the running client
+/// Enable/disable the Connect client: persist `[connect]` to the
+/// daemon's Connect store — the project's intendant.toml when rooted,
+/// the daemon-scoped connect.toml when projectless (the bundled app's
+/// normal shape) — then apply the effective config to the running client
 /// (start/stop live). The environment override always wins over the
 /// file, so the response reports both what was written and what is
 /// actually in effect.
 pub(crate) fn access_connect_config_response_value(
     params: serde_json::Value,
     project_root: Option<&std::path::Path>,
+) -> Result<serde_json::Value, String> {
+    access_connect_config_response_value_in(
+        params,
+        &crate::project::ConnectConfigStore::for_project_root(project_root),
+    )
+}
+
+fn access_connect_config_response_value_in(
+    params: serde_json::Value,
+    store: &crate::project::ConnectConfigStore,
 ) -> Result<serde_json::Value, String> {
     let enabled = params
         .get("enabled")
@@ -539,17 +551,13 @@ pub(crate) fn access_connect_config_response_value(
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(str::to_string);
-    let root = project_root.ok_or_else(|| "no project root for this daemon".to_string())?;
-    let mut project = crate::project::Project::from_root(root.to_path_buf())
-        .map_err(|e| format!("load project config: {e}"))?;
-    project.config.connect.enabled = enabled;
+    let mut config = store.load()?;
+    config.enabled = enabled;
     if let Some(url) = rendezvous_url {
-        project.config.connect.rendezvous_url = Some(url);
+        config.rendezvous_url = Some(url);
     }
-    project
-        .save_config()
-        .map_err(|e| format!("write intendant.toml: {e}"))?;
-    let effective = project.config.connect.clone().effective_with_env();
+    store.save(&config)?;
+    let effective = config.effective_with_env();
     let running = crate::connect_rendezvous::apply_config(effective.clone())?;
     Ok(serde_json::json!({
         "schema_version": 1,
@@ -660,10 +668,8 @@ pub(crate) async fn handle_access_connect_unclaim(
 pub(crate) async fn access_connect_unclaim_response_value(
     project_root: Option<std::path::PathBuf>,
 ) -> Result<serde_json::Value, String> {
-    let root = project_root.ok_or_else(|| "no project root for this daemon".to_string())?;
-    let project = crate::project::Project::from_root(root)
-        .map_err(|e| format!("load project config: {e}"))?;
-    let mut config = project.config.connect.clone().effective_with_env();
+    let store = crate::project::ConnectConfigStore::for_project_root(project_root.as_deref());
+    let mut config = store.load()?.effective_with_env();
     if config.rendezvous_url.is_none() {
         // Enabled-by-dashboard-then-restarted edge: fall back to whatever
         // rendezvous the running client used.
@@ -2411,6 +2417,29 @@ pub(crate) fn resolve_peer_connection_identity_from_cert_dir(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn connect_toggle_works_on_a_projectless_daemon_via_the_daemon_store() {
+        // The bundled app's daemon has no project root; the toggle must
+        // round-trip through the daemon-scoped connect.toml instead of
+        // failing with "no project root for this daemon". enabled=false
+        // keeps apply_config on its stop path (no client spawned).
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("connect.toml");
+        let store = crate::project::ConnectConfigStore::DaemonFile(path.clone());
+
+        let value = access_connect_config_response_value_in(
+            serde_json::json!({ "enabled": false }),
+            &store,
+        )
+        .expect("projectless toggle must not require a project root");
+        assert_eq!(value["written_enabled"], serde_json::json!(false));
+        assert_eq!(value["running"], serde_json::json!(false));
+        assert!(path.exists(), "daemon-scoped connect.toml must be written");
+        assert!(!crate::project::load_daemon_connect_config_in(&path)
+            .unwrap()
+            .enabled);
+    }
 
     #[test]
     fn fleet_origin_gate_normalizes_and_allowlists() {

--- a/static/app.html
+++ b/static/app.html
@@ -77494,7 +77494,10 @@ function onSteerStatusUpdate(id, text, status, reason, options = {}) {
 function setNewSessionProjectRoot(root) {
   dashboardProjectRoot = String(root || '').trim();
   const input = document.getElementById('new-session-project-root');
-  if (input && dashboardProjectRoot && !input.value.trim()) input.value = dashboardProjectRoot;
+  if (input && dashboardProjectRoot && !input.value.trim()
+      && newSessionPathPrefillable(dashboardProjectRoot)) {
+    input.value = dashboardProjectRoot;
+  }
   updateNewSessionProjectPrefills();
   if (input) input.title = input.value.trim() || dashboardProjectRoot;
   scheduleNewSessionProjectStatusRefresh({ hideWhileChecking: true });
@@ -77646,9 +77649,21 @@ async function ensureNewSessionProjectDirectory(projectRoot) {
   return createdPath;
 }
 
+// Temp-shaped paths (agent rigs, e2e homes, OS temp) dominate recent
+// sessions on busy machines; never suggest one, and never auto-fill the
+// project input with one. Typing a temp path stays possible — this only
+// stops the dashboard from proposing it. (sessionPathLooksTemporary is
+// declared in a later fragment; calls here run at event time, after all
+// fragments are parsed.)
+function newSessionPathPrefillable(path) {
+  if (!path) return false;
+  return !(typeof sessionPathLooksTemporary === 'function' && sessionPathLooksTemporary(path));
+}
+
 function addNewSessionProjectPrefill(options, seen, value, source, sessionId = '') {
   const path = String(value || '').trim();
   if (!path || seen.has(path)) return;
+  if (!newSessionPathPrefillable(path)) return;
   seen.add(path);
   const sid = shortSessionId(sessionId);
   options.push({

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -716,7 +716,10 @@ function onSteerStatusUpdate(id, text, status, reason, options = {}) {
 function setNewSessionProjectRoot(root) {
   dashboardProjectRoot = String(root || '').trim();
   const input = document.getElementById('new-session-project-root');
-  if (input && dashboardProjectRoot && !input.value.trim()) input.value = dashboardProjectRoot;
+  if (input && dashboardProjectRoot && !input.value.trim()
+      && newSessionPathPrefillable(dashboardProjectRoot)) {
+    input.value = dashboardProjectRoot;
+  }
   updateNewSessionProjectPrefills();
   if (input) input.title = input.value.trim() || dashboardProjectRoot;
   scheduleNewSessionProjectStatusRefresh({ hideWhileChecking: true });
@@ -868,9 +871,21 @@ async function ensureNewSessionProjectDirectory(projectRoot) {
   return createdPath;
 }
 
+// Temp-shaped paths (agent rigs, e2e homes, OS temp) dominate recent
+// sessions on busy machines; never suggest one, and never auto-fill the
+// project input with one. Typing a temp path stays possible — this only
+// stops the dashboard from proposing it. (sessionPathLooksTemporary is
+// declared in a later fragment; calls here run at event time, after all
+// fragments are parsed.)
+function newSessionPathPrefillable(path) {
+  if (!path) return false;
+  return !(typeof sessionPathLooksTemporary === 'function' && sessionPathLooksTemporary(path));
+}
+
 function addNewSessionProjectPrefill(options, seen, value, source, sessionId = '') {
   const path = String(value || '').trim();
   if (!path || seen.has(path)) return;
+  if (!newSessionPathPrefillable(path)) return;
   seen.add(path);
   const sid = shortSessionId(sessionId);
   options.push({


### PR DESCRIPTION
Four small user-reported papercuts on the bundled-app / first-run path, batched to share one CI ride. Common thread: the projectless-daemon design (a6c1144c) and the enrollment ceremony each had leftovers that contradicted their own intent.

## 1. `Turn on Connect` failed with "no project root for this daemon"

The toggle persisted `[connect]` into the project's `intendant.toml` — a projectless daemon (the bundled macOS app's deliberate shape) had nowhere to write and hard-failed. The Connect client is a daemon property, so it now has a daemon-scoped store: `ConnectConfigStore` resolves once from the project root — rooted daemons keep `intendant.toml` exactly as before; projectless daemons read/write `~/.intendant/connect.toml` (the same `[connect]` table, atomic tmp+rename, owner-only permissions since it may carry `auth_token`). The toggle, the unclaim path, and — the part that makes it a fix rather than a bandaid — **daemon boot** all use the same store, so enablement survives a restart. Env overrides keep winning.

## 2. New Session prefilled an ugly temp directory

The project input auto-fills from the most recent session's project/cwd, and on a machine whose shared state root is full of agent rigs and e2e runs, that is nearly always a `/tmp` / `/var/folders` path. The prefill builder now reuses the sessions filter's `sessionPathLooksTemporary`: temp-shaped paths no longer enter the datalist, auto-fill the input, or ride the daemon-root prefill. Typing one stays possible — the dashboard just stops proposing it.

## 3. Enrollment from a phone died on `InvalidContentType`

Safari dials `http://` first when a bare `host:port` is typed; the enrollment server fed that into its TLS accept, which died with `InvalidContentType` while the phone showed a blank page. The accept path now peeks the first byte (the same demux idea the web gateway uses) and answers cleartext HTTP with a **301 to the same URL over https**, preferring the host the client actually dialed. Unlike the main gateway's strict-TLS 426 (where cleartext is anomalous), redirecting is right for enrollment: nothing sensitive rides the URL — auth remains the fingerprint ceremony plus the one-time secret typed on the page — and the cleartext request had already transited before we answer.

## 4. Enrollment died on `CertificateUnknown` with no hint

Devices hard-reject TLS when the host they dialed is not in the server certificate's SANs — typical when the cert predates an address (new tailnet IP, renamed host). `serve-certs` now preflights the advertised host against the cert's SANs and prints the diagnosis plus the fix (`intendant access setup --force`) **before** the ceremony, instead of letting the phone fail after it.

Tests: daemon connect store round-trip + absent-file default + store resolution; projectless toggle end-to-end through the shared handler; `Host`-header port stripping (names, IPs, bracketed IPv6); redirect over an in-memory duplex (dialed-host preference + path/query preservation + no-Host fallback); SAN preflight against a really-minted cert (covered IP, covered DNS, uncovered address flagged). Full battery green locally.
