### PR TITLE
Transport S2b: tunnel fs write-quartet delegation (parity-pinned)

### DIFF
--- a/src/bin/caller/dashboard_control/api_transfers_fs.rs
+++ b/src/bin/caller/dashboard_control/api_transfers_fs.rs
@@ -797,49 +797,59 @@ pub(crate) async fn api_fs_mkdir_response(
     params: Option<&serde_json::Value>,
 ) -> serde_json::Value {
     let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
+    // Transport-owned param decode (HTTP's twin decodes a typed serde
+    // request); the historical string_param read carries over verbatim.
     let path = string_param(&params, &["path"]);
-    let (status_line, body) = crate::web_gateway::dashboard_fs_mkdir_response_body(&path);
-    http_body_response(id, status_line_code(&status_line), body, "filesystem mkdir")
+    frame_api_response(
+        id,
+        crate::web_gateway::fs_mkdir_api_response(&path),
+        "filesystem mkdir",
+    )
 }
 
 pub(crate) async fn api_fs_rename_response(
     id: String,
     params: Option<&serde_json::Value>,
 ) -> serde_json::Value {
-    let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
-    let result = tokio::task::spawn_blocking(move || {
-        crate::web_gateway::dashboard_fs_rename_response_parts(&params)
-    })
-    .await;
-    match result {
-        Ok((code, body)) => http_body_response(id, code, body, "filesystem rename"),
-        Err(e) => serde_json::json!({
-            "t": "response",
-            "id": id,
-            "ok": false,
-            "error": format!("filesystem rename task failed: {e}"),
-        }),
-    }
+    // Transport-owned param decode: the historical lenient reads,
+    // verbatim (the neutral fn owns the blocking apply leg).
+    let from = params
+        .and_then(|p| p.get("from"))
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let to = params
+        .and_then(|p| p.get("to"))
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    frame_api_response(
+        id,
+        crate::web_gateway::fs_rename_api_response(from, to).await,
+        "filesystem rename",
+    )
 }
 
 pub(crate) async fn api_fs_delete_response(
     id: String,
     params: Option<&serde_json::Value>,
 ) -> serde_json::Value {
-    let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
-    let result = tokio::task::spawn_blocking(move || {
-        crate::web_gateway::dashboard_fs_delete_response_parts(&params)
-    })
-    .await;
-    match result {
-        Ok((code, body)) => http_body_response(id, code, body, "filesystem delete"),
-        Err(e) => serde_json::json!({
-            "t": "response",
-            "id": id,
-            "ok": false,
-            "error": format!("filesystem delete task failed: {e}"),
-        }),
-    }
+    // Transport-owned param decode: the historical lenient reads,
+    // verbatim (the neutral fn owns the blocking apply leg).
+    let path = params
+        .and_then(|p| p.get("path"))
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let recursive = params
+        .and_then(|p| p.get("recursive"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    frame_api_response(
+        id,
+        crate::web_gateway::fs_delete_api_response(path, recursive).await,
+        "filesystem delete",
+    )
 }
 
 /// Terminal leg of an `api_fs_write` upload: the file contents arrived via
@@ -867,16 +877,23 @@ pub(crate) async fn api_fs_write_upload_task_response(
             done: true,
         };
     }
-    let result = tokio::task::spawn_blocking(move || {
-        let bytes = std::fs::read(upload.tmp.path())?;
-        Ok::<_, std::io::Error>(crate::web_gateway::dashboard_fs_write_response_parts(
-            &upload.params,
-            &bytes,
-        ))
+    // Drain the upload spool off the async runtime — the content
+    // carriage is transport-owned (the tunnel's upload lane vs HTTP's
+    // JSON content fields); the apply leg is the shared neutral seam.
+    let read_result = tokio::task::spawn_blocking(move || {
+        std::fs::read(upload.tmp.path()).map(|bytes| (upload.params, bytes))
     })
     .await;
-    let frame = match result {
-        Ok(Ok((code, body))) => http_body_response(id.clone(), code, body, "filesystem write"),
+    let frame = match read_result {
+        Ok(Ok((params, bytes))) => frame_api_response(
+            id.clone(),
+            crate::web_gateway::fs_write_bytes_api_response(
+                crate::web_gateway::fs_write_args_from_params(&params),
+                bytes,
+            )
+            .await,
+            "filesystem write",
+        ),
         Ok(Err(e)) => http_body_response(
             id.clone(),
             500,
@@ -1198,6 +1215,233 @@ mod tests {
         assert_eq!(tunnel_body["error"], http_body["error"]);
         assert_eq!(tunnel_body["ok"], false);
         assert!(http_body.get("ok").is_none());
+    }
+
+    // ── Quartet parity (S2b): mkdir/rename/delete/write ──
+    //
+    // Same discipline as the stat/list/read set above; all four are
+    // JSON-lane, so envelope differences #1 (tunnel result wrapper +
+    // injected status metadata) and #2 (HTTP header decoration) apply
+    // verbatim. The quartet-specific differences, pinned here:
+    //
+    //  8. Write content carriage (design §2.7's preserved asymmetry):
+    //     HTTP carries JSON `content`/`content_b64` (exactly one,
+    //     under the row's body cap) decoded by the serde
+    //     FsWriteRequest; the tunnel spools raw bytes via
+    //     upload_start/chunk/end frames and folds its params
+    //     leniently (fs_write_args_from_params).
+    //  9. Param decode is transport-owned: HTTP's typed serde decode
+    //     rejects missing/mistyped fields as 400 "invalid JSON"
+    //     before the neutral fn runs; the tunnel's historical lenient
+    //     reads (string_param trim/coercion on mkdir; as_str/as_bool
+    //     defaults on rename/delete/write) reach the neutral fn with
+    //     defaults instead.
+    // 10. The formerly tunnel-side spawn-join arms (unreachable in
+    //     practice) now converge on the neutral fns' enveloped 500s;
+    //     only the tunnel's upload-spool read keeps its historical
+    //     bare-frame join arm and tempfile-read 500.
+    //
+    // Mutations are compared under identical pre-state: fixtures
+    // reset the filesystem between the HTTP-render leg and the tunnel
+    // leg, so "same params ⇒ same body" holds exactly (the write
+    // success leg normalizes the time-varying `modified_ms` only).
+
+    #[tokio::test]
+    async fn parity_fs_mkdir_serves_the_same_body_on_both_transports() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("made-here");
+        let target_params = serde_json::json!({ "path": target.to_string_lossy() });
+
+        // Create leg (reset between transports).
+        let (status, _headers, body) = http_parts(crate::web_gateway::fs_mkdir_api_response(
+            &target.to_string_lossy(),
+        ));
+        assert_eq!(status, 200);
+        let http_body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(http_body["created"], true);
+        std::fs::remove_dir(&target).unwrap();
+        let frame = api_fs_mkdir_response("parity-mkdir".to_string(), Some(&target_params)).await;
+        assert_eq!(tunnel_result_body(&frame, status), http_body);
+
+        // Already-exists and relative-path legs are idempotent.
+        for (params, path) in [
+            (
+                serde_json::json!({ "path": dir.path().to_string_lossy() }),
+                dir.path().to_string_lossy().into_owned(),
+            ),
+            (
+                serde_json::json!({ "path": "relative/path" }),
+                "relative/path".to_string(),
+            ),
+        ] {
+            let (status, _headers, body) =
+                http_parts(crate::web_gateway::fs_mkdir_api_response(&path));
+            let http_body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            let frame = api_fs_mkdir_response("parity-mkdir".to_string(), Some(&params)).await;
+            assert_eq!(tunnel_result_body(&frame, status), http_body, "{params}");
+        }
+    }
+
+    #[tokio::test]
+    async fn parity_fs_rename_serves_the_same_body_on_both_transports() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("from.txt");
+        let dest = dir.path().join("to.txt");
+        let params = serde_json::json!({
+            "from": source.to_string_lossy(),
+            "to": dest.to_string_lossy(),
+        });
+
+        // Success leg (reset between transports).
+        std::fs::write(&source, b"payload").unwrap();
+        let (status, _headers, body) = http_parts(
+            crate::web_gateway::fs_rename_api_response(
+                source.to_string_lossy().into_owned(),
+                dest.to_string_lossy().into_owned(),
+            )
+            .await,
+        );
+        assert_eq!(status, 200);
+        let http_body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(http_body["renamed"], true);
+        std::fs::rename(&dest, &source).unwrap();
+        let frame = api_fs_rename_response("parity-rename".to_string(), Some(&params)).await;
+        assert_eq!(tunnel_result_body(&frame, status), http_body);
+        std::fs::rename(&dest, &source).unwrap();
+
+        // Destination-exists 409 (idempotent: state untouched).
+        std::fs::write(&dest, b"occupied").unwrap();
+        let (status, _headers, body) = http_parts(
+            crate::web_gateway::fs_rename_api_response(
+                source.to_string_lossy().into_owned(),
+                dest.to_string_lossy().into_owned(),
+            )
+            .await,
+        );
+        assert_eq!(status, 409);
+        let http_body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(http_body["code"], "exists");
+        let frame = api_fs_rename_response("parity-rename".to_string(), Some(&params)).await;
+        assert_eq!(tunnel_result_body(&frame, status), http_body);
+
+        // Missing-source 404 (idempotent).
+        std::fs::remove_file(&source).unwrap();
+        std::fs::remove_file(&dest).unwrap();
+        let (status, _headers, body) = http_parts(
+            crate::web_gateway::fs_rename_api_response(
+                source.to_string_lossy().into_owned(),
+                dest.to_string_lossy().into_owned(),
+            )
+            .await,
+        );
+        assert_eq!(status, 404);
+        let http_body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let frame = api_fs_rename_response("parity-rename".to_string(), Some(&params)).await;
+        assert_eq!(tunnel_result_body(&frame, status), http_body);
+    }
+
+    #[tokio::test]
+    async fn parity_fs_delete_serves_the_same_body_on_both_transports() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // File-delete success leg (reset between transports).
+        let file = dir.path().join("victim.txt");
+        std::fs::write(&file, b"bytes").unwrap();
+        let params = serde_json::json!({ "path": file.to_string_lossy() });
+        let (status, _headers, body) = http_parts(
+            crate::web_gateway::fs_delete_api_response(
+                file.to_string_lossy().into_owned(),
+                false,
+            )
+            .await,
+        );
+        assert_eq!(status, 200);
+        let http_body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(http_body["deleted"], true);
+        std::fs::write(&file, b"bytes").unwrap();
+        let frame = api_fs_delete_response("parity-delete".to_string(), Some(&params)).await;
+        assert_eq!(tunnel_result_body(&frame, status), http_body);
+
+        // Non-empty directory 409 without recursive (idempotent).
+        let full = dir.path().join("occupied");
+        std::fs::create_dir(&full).unwrap();
+        std::fs::write(full.join("keep.txt"), b"keep").unwrap();
+        let params = serde_json::json!({ "path": full.to_string_lossy() });
+        let (status, _headers, body) = http_parts(
+            crate::web_gateway::fs_delete_api_response(
+                full.to_string_lossy().into_owned(),
+                false,
+            )
+            .await,
+        );
+        assert_eq!(status, 409);
+        let http_body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(http_body["code"], "not_empty");
+        let frame = api_fs_delete_response("parity-delete".to_string(), Some(&params)).await;
+        assert_eq!(tunnel_result_body(&frame, status), http_body);
+    }
+
+    #[tokio::test]
+    async fn parity_fs_write_serves_the_same_body_under_both_carriages() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("edited.toml");
+        let content = b"[section]\nkey = \"value\"\n";
+        std::fs::write(&file, content).unwrap();
+
+        // Force-overwrite with the byte-identical payload: pre-state is
+        // identical before each leg; only `modified_ms` varies (pinned
+        // present, then normalized out).
+        let http_request: crate::web_gateway::FsWriteRequest =
+            serde_json::from_value(serde_json::json!({
+                "path": file.to_string_lossy(),
+                "content": String::from_utf8_lossy(content),
+                "force": true,
+            }))
+            .unwrap();
+        let (status, _headers, body) =
+            http_parts(crate::web_gateway::fs_write_api_response(http_request).await);
+        assert_eq!(status, 200);
+        let mut http_body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let tunnel_params = serde_json::json!({
+            "path": file.to_string_lossy(),
+            "force": true,
+        });
+        let response = api_fs_write_upload_task_response(
+            "parity-write".to_string(),
+            test_upload_state("api_fs_write", tunnel_params, content),
+            runtime(),
+        )
+        .await;
+        let mut tunnel_body = tunnel_result_body(&response.frame, status);
+        for body in [&mut http_body, &mut tunnel_body] {
+            let map = body.as_object_mut().expect("write body object");
+            assert!(
+                map.remove("modified_ms").is_some(),
+                "modified_ms present: {map:?}"
+            );
+        }
+        assert_eq!(tunnel_body, http_body);
+
+        // Precondition-required 400 (idempotent, fully deterministic).
+        let http_request: crate::web_gateway::FsWriteRequest =
+            serde_json::from_value(serde_json::json!({
+                "path": file.to_string_lossy(),
+                "content": String::from_utf8_lossy(content),
+            }))
+            .unwrap();
+        let (status, _headers, body) =
+            http_parts(crate::web_gateway::fs_write_api_response(http_request).await);
+        assert_eq!(status, 400);
+        let http_body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(http_body["code"], "precondition_required");
+        let tunnel_params = serde_json::json!({ "path": file.to_string_lossy() });
+        let response = api_fs_write_upload_task_response(
+            "parity-write-precondition".to_string(),
+            test_upload_state("api_fs_write", tunnel_params, content),
+            runtime(),
+        )
+        .await;
+        assert_eq!(tunnel_result_body(&response.frame, status), http_body);
     }
 
     #[tokio::test]

--- a/src/bin/caller/web_gateway/routes_files.rs
+++ b/src/bin/caller/web_gateway/routes_files.rs
@@ -1366,13 +1366,6 @@ pub(crate) fn mkdir_dashboard_fs_path(raw: &str) -> Result<serde_json::Value, (S
     }))
 }
 
-pub(crate) fn dashboard_fs_mkdir_response_body(raw: &str) -> (String, String) {
-    match mkdir_dashboard_fs_path(raw) {
-        Ok(body) => ("200 OK".to_string(), body.to_string()),
-        Err((status, message)) => (status, serde_json::json!({ "error": message }).to_string()),
-    }
-}
-
 pub(crate) fn system_time_unix_ms(time: std::time::SystemTime) -> Option<u64> {
     time.duration_since(std::time::UNIX_EPOCH)
         .ok()
@@ -1627,36 +1620,6 @@ pub(crate) fn apply_dashboard_fs_write(
     )
 }
 
-/// Tunnel-facing wrapper: apply a write whose payload arrived out-of-band
-/// (dashboard-control upload frames) with the request fields as JSON params.
-/// Returns `(http-ish status code, body)` for `http_body_response`.
-pub(crate) fn dashboard_fs_write_response_parts(
-    params: &serde_json::Value,
-    bytes: &[u8],
-) -> (u16, String) {
-    let args = FsWriteArgs {
-        path: params
-            .get("path")
-            .and_then(|v| v.as_str())
-            .unwrap_or_default()
-            .to_string(),
-        expected_sha256: params
-            .get("expected_sha256")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string()),
-        create_new: params
-            .get("create_new")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        force: params
-            .get("force")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-    };
-    let (status_line, body) = apply_dashboard_fs_write(&args, bytes);
-    (status_line_u16(&status_line), body.to_string())
-}
-
 /// Rename/move half of the dashboard editor. Same contract as
 /// [`apply_dashboard_fs_write`]: the caller has already routed **both** paths
 /// through the write-scope gate — this function performs no IAM checks of its
@@ -1882,36 +1845,6 @@ pub(crate) fn apply_dashboard_fs_delete(
     }
 }
 
-/// Tunnel-facing wrapper for [`apply_dashboard_fs_rename`]: request fields
-/// as JSON params, `(http-ish status code, body)` out for
-/// `http_body_response`.
-pub(crate) fn dashboard_fs_rename_response_parts(params: &serde_json::Value) -> (u16, String) {
-    let from = params
-        .get("from")
-        .and_then(|v| v.as_str())
-        .unwrap_or_default();
-    let to = params
-        .get("to")
-        .and_then(|v| v.as_str())
-        .unwrap_or_default();
-    let (status_line, body) = apply_dashboard_fs_rename(from, to);
-    (status_line_u16(&status_line), body.to_string())
-}
-
-/// Tunnel-facing wrapper for [`apply_dashboard_fs_delete`].
-pub(crate) fn dashboard_fs_delete_response_parts(params: &serde_json::Value) -> (u16, String) {
-    let path = params
-        .get("path")
-        .and_then(|v| v.as_str())
-        .unwrap_or_default();
-    let recursive = params
-        .get("recursive")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    let (status_line, body) = apply_dashboard_fs_delete(path, recursive);
-    (status_line_u16(&status_line), body.to_string())
-}
-
 pub(crate) fn status_line_u16(status_line: &str) -> u16 {
     status_line
         .split_whitespace()
@@ -1943,25 +1876,61 @@ pub(crate) async fn fs_write_api_response(req: FsWriteRequest) -> ApiResponse {
                 create_new: req.create_new,
                 force: req.force,
             };
-            let (status, body) =
-                tokio::task::spawn_blocking(move || apply_dashboard_fs_write(&args, &bytes))
-                    .await
-                    .unwrap_or_else(|e| {
-                        (
-                            "500 Internal Server Error".to_string(),
-                            serde_json::json!({
-                                "error": format!(
-                                    "filesystem write task failed: {e}"
-                                )
-                            }),
-                        )
-                    });
-            ApiResponse::json(
-                status_line_u16(&status),
-                JsonBody::PreSerialized(body.to_string()),
-            )
+            fs_write_bytes_api_response(args, bytes).await
         }
         Err(message) => ApiResponse::json_error(400, message),
+    }
+}
+
+/// Bytes-taking transport-neutral core of the fs write apply leg. The
+/// content-carriage asymmetry is preserved by design (§2.7): HTTP
+/// decodes JSON `content`/`content_b64` into these bytes
+/// ([`fs_write_api_response`] above); the tunnel spools them from
+/// `upload_start/chunk/end` frames. Path authorization is the caller's
+/// lane gate.
+pub(crate) async fn fs_write_bytes_api_response(args: FsWriteArgs, bytes: Vec<u8>) -> ApiResponse {
+    let (status, body) =
+        tokio::task::spawn_blocking(move || apply_dashboard_fs_write(&args, &bytes))
+            .await
+            .unwrap_or_else(|e| {
+                (
+                    "500 Internal Server Error".to_string(),
+                    serde_json::json!({
+                        "error": format!(
+                            "filesystem write task failed: {e}"
+                        )
+                    }),
+                )
+            });
+    ApiResponse::json(
+        status_line_u16(&status),
+        JsonBody::PreSerialized(body.to_string()),
+    )
+}
+
+/// The tunnel's write params→args fold (lifted from the retired
+/// `dashboard_fs_write_response_parts` bridge; HTTP's twin decode is
+/// the serde [`FsWriteRequest`]). Param decode stays transport-owned:
+/// these are the historical lenient reads, verbatim.
+pub(crate) fn fs_write_args_from_params(params: &serde_json::Value) -> FsWriteArgs {
+    FsWriteArgs {
+        path: params
+            .get("path")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        expected_sha256: params
+            .get("expected_sha256")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        create_new: params
+            .get("create_new")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        force: params
+            .get("force")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
     }
 }
 


### PR DESCRIPTION
Follow-up to #134 (S2) completing the fs family's tunnel delegation now that S1b (#133) is on main: the write quartet — `api_fs_mkdir` / `api_fs_rename` / `api_fs_delete` / `api_fs_write` — runs the same neutral fns the HTTP lane runs, framed by S2's tunnel adapters. Scope exactly as coordinated; +335/−122.

## What delegates

- **mkdir/rename/delete**: the tunnel fns decode their params (transport-owned, historical reads verbatim — `string_param` trim/coercion on mkdir, `.as_str()`/`.as_bool()` defaults on rename/delete) and call S1b's `fs_{mkdir,rename,delete}_api_response` through `frame_api_response` — the `_httpStatus`/`_httpOk` envelope is byte-identical to the retired bridge path (`status_line_code` ≡ `status_line_u16`, same bodies).
- **write (upload leg)**: `api_fs_write_upload_task_response` keeps its authorize gate and drains the upload spool (transport-owned content carriage, tempfile-read 500 arm verbatim), then applies through a new bytes-taking neutral seam:

## The seam (coordination point 1)

`fs_write_bytes_api_response(FsWriteArgs, Vec<u8>) -> ApiResponse` — the apply leg factored out of S1b's `fs_write_api_response`, which keeps its JSON-decoding surface undisturbed and now delegates to the same seam. The tunnel's params→args fold is lifted to `fs_write_args_from_params` next to `FsWriteArgs` (the retired bridge's reads, verbatim). One `apply_dashboard_fs_write` path; the content-carriage asymmetry (HTTP JSON `content`/`content_b64` vs tunnel `upload_*` spool) stays preserved per design §2.7.

## Deleted

All four tunnel-facing bridges: `dashboard_fs_mkdir_response_body`, `dashboard_fs_write_response_parts`, `dashboard_fs_rename_response_parts`, `dashboard_fs_delete_response_parts`. Each had exactly one caller (the tunnel fn it fed). The fs family now has one apply path per operation, both transports.

## Parity fixtures (quartet)

Four new fixtures extend #134's set (same `http_parts`/`tunnel_result_body` discipline): same params ⇒ identical JSON bodies on both transports, for mkdir (create / already-exists / relative-400), rename (success / dest-exists-409 / missing-source-404), delete (file success / not-empty-409), and write (force-overwrite success / precondition-400). Mutations are compared under **identical pre-state** — the fixtures reset the filesystem between the HTTP-render leg and the tunnel leg — so equality is exact; the write success leg normalizes only the time-varying `modified_ms` (pinned present on both sides first). Quartet-specific envelope differences are enumerated in the fixture comment, continuing #134's numbering:

8. write content carriage: HTTP JSON `content`/`content_b64` (exactly-one, row body cap) vs tunnel upload spool + lenient param fold;
9. param decode is transport-owned: HTTP's typed serde decode 400s on missing/mistyped fields before the neutral fn runs; the tunnel's historical lenient reads reach it with defaults;
10. the formerly tunnel-side spawn-join arms (unreachable in practice) converge on the neutral fns' enveloped 500s — same message text, now `_httpStatus`-enveloped like HTTP — while the upload-spool read keeps its historical bare-frame join arm and tempfile-read 500.

## Gates

- `cargo nextest run --bins --no-fail-fast`: **2751/2751 passed** (the environmental AX test passed this run too).
- All pre-existing tests green **unchanged** — incl. `fs_stat_and_list_preserve_http_status` (mkdir legs), `fs_rename_and_delete_enforce_scope_on_both_legs`, the `fs_write_upload_*` scope/precondition/audit pins, and every S1a+S1b golden HTTP transcript (byte-exact).
- `cargo test --test e2e`: 8/8.
- `cargo clippy`: warning set **identical to origin/main** (verified by diffing full location-normalized warning lists against a fresh origin/main clippy run — 64 = 64, zero new).
- `git diff --color-moved=dimmed-zebra` self-review.
