### PR TITLE
Transport S3a: tunnel column on the route table + classification differential pin

### DIFF
--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -2189,11 +2189,12 @@ pub(crate) fn status_response_frame(id: String, runtime: &ControlRuntime) -> ser
         runtime_allows_operation(runtime, crate::peer::access_policy::PeerOperation::Message);
 
     // Every gated api_* method derives its `<method>_available` boolean from
-    // `CONTROL_METHODS`: operation granted && backing subsystem wired
+    // the effective method table (route-row tunnel specs ∪ the
+    // CONTROL_METHODS residue): operation granted && backing subsystem wired
     // (`control_method_runtime_ready`). One boolean per advertised RPC lets
     // the SPA distinguish "denied for this session" from "unsupported
     // daemon" (feature list) without probing calls.
-    for spec in CONTROL_METHODS {
+    for spec in all_control_methods() {
         if !spec.name.starts_with("api_") {
             continue;
         }
@@ -2208,7 +2209,7 @@ pub(crate) fn status_response_frame(id: String, runtime: &ControlRuntime) -> ser
 
     // Operation aggregates, composite rollups, and frame-transport
     // availability the SPA reads — none has a single backing method in
-    // `CONTROL_METHODS`, so they stay hand-written.
+    // the method table, so they stay hand-written.
     let capabilities = [
         ("access_inspect_available", access_inspect),
         ("access_manage_available", access_manage),
@@ -2345,7 +2346,7 @@ mod tests {
     fn status_advertises_an_availability_boolean_for_every_gated_api_method() {
         let rt = runtime();
         let status = status_response_frame("s1".to_string(), &rt);
-        for spec in CONTROL_METHODS {
+        for spec in all_control_methods() {
             if !spec.name.starts_with("api_") || spec.op.is_none() {
                 continue;
             }

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -64,14 +64,22 @@ const CONTROL_RESPONSE_MAX_CREDIT_GRANT: usize = 64;
 const CONTROL_BINDING_TTL_MS: i64 = 5 * 60 * 1000;
 const DASHBOARD_MEDIA_CLIP_MAX_FRAMES: usize = 1000;
 static NEXT_DASHBOARD_DISPLAY_PEER_ID: AtomicU64 = AtomicU64::new(1);
-/// One dashboard-control method's declared surface. `CONTROL_METHODS` is the
-/// single source the method authorizer (`authorize_dashboard_control_method`),
-/// the advertised feature list (`control_features`), the per-method
-/// `<method>_available` status booleans, and the upload-frame allowlist
-/// (`authorize_dashboard_control_upload`) all derive from — a method added or
-/// re-gated in one place cannot drift out of sync in the others. Composite
-/// rollup booleans the SPA also reads (peer mutations, managed context, …)
-/// stay hand-written next to the derived block in `status_response_frame`.
+/// One dashboard-control method's declared surface. The effective method
+/// table (`all_control_methods`) is the single source the method authorizer
+/// (`authorize_dashboard_control_method`), the advertised feature list
+/// (`control_features`), the per-method `<method>_available` status booleans,
+/// and the upload-frame allowlist (`authorize_dashboard_control_upload`) all
+/// derive from — a method added or re-gated in one place cannot drift out of
+/// sync in the others. It is the union of two declaration sources, resolved
+/// rows-first: tunnel columns on `gateway_routes::ROUTES` rows (twinned
+/// methods, whose IAM operation derives from the route row — transport-
+/// unification design §2.2) and the residue `CONTROL_METHODS` below (methods
+/// whose family has not yet ported, plus tunnel-only methods with no HTTP
+/// twin). The `tunnel_method_partition_is_pinned` differential test freezes
+/// which methods live on which side. Composite rollup booleans the SPA also
+/// reads (peer mutations, managed context, …) stay hand-written next to the
+/// derived block in `status_response_frame`.
+#[derive(Clone, Copy)]
 struct ControlMethodSpec {
     name: &'static str,
     /// Operation gating the method; `None` = any bound session (ping).
@@ -124,6 +132,14 @@ const fn upload_only(name: &'static str, op: PeerOperation) -> ControlMethodSpec
     }
 }
 
+/// The residue half of the tunnel method table: methods not (yet) declared
+/// as a `tunnel:` column on a `gateway_routes::ROUTES` row. Do NOT add a
+/// method here if its HTTP twin has a route row — declare it on the row
+/// (`Route::with_tunnel`) so its IAM operation derives from the shared
+/// declaration; this list is for tunnel-only methods and families the
+/// migration has not reached. Never read directly outside this module's
+/// union plumbing and pins — consume `all_control_methods()` /
+/// `control_method_spec()`.
 const CONTROL_METHODS: &[ControlMethodSpec] = &[
     ControlMethodSpec {
         name: "ping",
@@ -286,9 +302,10 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
     upload_only("api_session_current_upload", PeerOperation::SessionManage),
     method("api_transfer_jobs", PeerOperation::FilesystemRead),
     method("api_transfer_download_read", PeerOperation::FilesystemRead),
-    method("api_fs_stat", PeerOperation::FilesystemRead),
-    method("api_fs_list", PeerOperation::FilesystemRead),
-    method("api_fs_read", PeerOperation::FilesystemRead),
+    // The api_fs_* methods live as tunnel columns on their route rows
+    // (gateway_routes::ROUTES, /api/fs/*) — the first family whose tunnel
+    // ops derive from the rows instead of entries here. The api_transfer_*
+    // methods join them when their HTTP rows land (design §4, task #6).
     method("api_transfer_job_create", PeerOperation::FilesystemWrite),
     method("api_transfer_job_delete", PeerOperation::FilesystemWrite),
     // Transfer chunks arrive only as upload frames; their destination was
@@ -296,10 +313,6 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
     // only needs the write operation (`authorize_dashboard_control_upload`).
     uploadable("api_transfer_upload_chunk", PeerOperation::FilesystemWrite),
     method("api_transfer_upload_commit", PeerOperation::FilesystemWrite),
-    method("api_fs_mkdir", PeerOperation::FilesystemWrite),
-    uploadable("api_fs_write", PeerOperation::FilesystemWrite),
-    method("api_fs_rename", PeerOperation::FilesystemWrite),
-    method("api_fs_delete", PeerOperation::FilesystemWrite),
     method("api_display_bootstrap", PeerOperation::DisplayView),
     method("api_display_webrtc_signal", PeerOperation::DisplayView),
     method("api_displays", PeerOperation::DisplayView),
@@ -351,8 +364,39 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
     method("api_external_agents", PeerOperation::SessionInspect),
 ];
 
+/// The effective method table: route-row tunnel specs first (in ROUTES
+/// declaration order, with the IAM operation derived from each row —
+/// `Route::tunnel_operation`), then the residue `CONTROL_METHODS`.
+/// Materialized once; every consumer sees the same union. Resolution is
+/// deterministic — rows win — so even the (unlandable, pin-tested) state
+/// of a method declared on both sides cannot flap between operations. A
+/// tunnel row without a fail-closed operation derivation (non-Operation
+/// authz and no override; equally unlandable per the gateway invariant
+/// test) is skipped entirely, leaving the authorizer's unknown-method
+/// deny as the runtime backstop.
+fn all_control_methods() -> &'static [ControlMethodSpec] {
+    static METHODS: std::sync::OnceLock<Vec<ControlMethodSpec>> = std::sync::OnceLock::new();
+    METHODS.get_or_init(|| {
+        let mut methods: Vec<ControlMethodSpec> = crate::gateway_routes::tunnel_specs()
+            .filter_map(|(route, spec)| {
+                let op = route.tunnel_operation()?;
+                Some(ControlMethodSpec {
+                    name: spec.name,
+                    op: Some(op),
+                    advertised: spec.advertised,
+                    upload: spec.upload,
+                })
+            })
+            .collect();
+        methods.extend_from_slice(CONTROL_METHODS);
+        methods
+    })
+}
+
 fn control_method_spec(method: &str) -> Option<&'static ControlMethodSpec> {
-    CONTROL_METHODS.iter().find(|spec| spec.name == method)
+    all_control_methods()
+        .iter()
+        .find(|spec| spec.name == method)
 }
 
 /// Transport/frame-family features that aren't request methods (chunking,
@@ -371,15 +415,16 @@ const CONTROL_WIRE_FEATURES: &[&str] = &[
     "presence_tool_request",
 ];
 
-/// The advertised `features` list: every advertised method in
-/// `CONTROL_METHODS` plus the wire features. Consumers membership-test —
-/// order carries no meaning.
+/// The advertised `features` list: every advertised method in the
+/// effective table (route-row tunnel specs ∪ the `CONTROL_METHODS`
+/// residue) plus the wire features. Consumers membership-test — order
+/// carries no meaning.
 fn control_features() -> &'static [&'static str] {
     static FEATURES: std::sync::OnceLock<Vec<&'static str>> = std::sync::OnceLock::new();
     FEATURES.get_or_init(|| {
         let mut features: Vec<&'static str> = CONTROL_WIRE_FEATURES.to_vec();
         features.extend(
-            CONTROL_METHODS
+            all_control_methods()
                 .iter()
                 .filter(|spec| spec.advertised)
                 .map(|spec| spec.name),
@@ -1567,9 +1612,10 @@ fn authorize_dashboard_control_method(
     method: &str,
     params: Option<&serde_json::Value>,
 ) -> Result<(), String> {
-    // Fail closed: a method must be declared in `CONTROL_METHODS` to be
-    // callable at all — a dispatch arm added without a table row is denied
-    // here instead of shipping ungated.
+    // Fail closed: a method must be declared — as a route row's tunnel
+    // column or a residue `CONTROL_METHODS` entry — to be callable at
+    // all; a dispatch arm added without a declaration is denied here
+    // instead of shipping ungated.
     let Some(spec) = control_method_spec(method) else {
         return Err(format!("unknown dashboard-control method: {method}"));
     };
@@ -1661,7 +1707,8 @@ fn authorize_dashboard_control_upload(
     method: &str,
 ) -> Result<(), String> {
     // Fail closed twice over: the method must be declared upload-deliverable
-    // in `CONTROL_METHODS`, and upload methods are always operation-gated.
+    // (route-row tunnel column or residue `CONTROL_METHODS` entry), and
+    // upload methods are always operation-gated.
     let Some(op) = control_method_spec(method)
         .filter(|spec| spec.upload)
         .and_then(|spec| spec.op)
@@ -2887,7 +2934,8 @@ mod tests {
         assert!(pending.get("q1").is_none());
     }
 
-    /// The operation a method's `CONTROL_METHODS` row declares.
+    /// The operation a method's declaration carries (route-row tunnel
+    /// column or residue `CONTROL_METHODS` entry — the effective table).
     fn method_operation(method: &str) -> Option<crate::peer::access_policy::PeerOperation> {
         control_method_spec(method).and_then(|spec| spec.op)
     }
@@ -2928,8 +2976,11 @@ mod tests {
 
     #[test]
     fn control_method_table_is_coherent() {
+        // Coherence holds over the effective union (route-row tunnel
+        // specs ∪ the CONTROL_METHODS residue): a name declared on both
+        // sides is a duplicate here just like two residue rows were.
         let mut seen = HashSet::new();
-        for spec in CONTROL_METHODS {
+        for spec in all_control_methods() {
             assert!(
                 seen.insert(spec.name),
                 "duplicate method row: {}",
@@ -2948,6 +2999,461 @@ mod tests {
             features.len(),
             "wire features must not collide with method names"
         );
+    }
+
+    /// Transport-unification S3 differential pin (design §8, risks
+    /// R2/R4): the complete tunnel-method partition — every wire method
+    /// name, the declaration source that carries it (`Row` = a `tunnel:`
+    /// column on a `gateway_routes::ROUTES` row, `Residue` = a
+    /// `CONTROL_METHODS` entry), and the IAM operation gating it —
+    /// frozen as a literal table. Re-gating a method (operation change
+    /// on either side), losing one (gone from both sources), duplicating
+    /// one (declared on both), or moving one between sources fails here
+    /// until this table is updated in the same change, deliberately.
+    /// Permanent program infrastructure: the migration stages move
+    /// families from `Residue` to `Row` by flipping tags here alongside
+    /// their declarations, and the removal stage shrinks the residue to
+    /// the tunnel-only set — the union below never changes by accident.
+    #[test]
+    fn tunnel_method_partition_is_pinned() {
+        use crate::peer::access_policy::PeerOperation as Op;
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        enum Source {
+            Row,
+            Residue,
+        }
+        use Source::{Residue, Row};
+        let frozen: &[(&str, Source, Option<Op>)] = &[
+            ("ping", Residue, None),
+            ("config", Residue, Some(Op::RuntimeControl)),
+            ("status", Residue, Some(Op::PresenceRead)),
+            ("api_agent_card", Residue, Some(Op::PresenceRead)),
+            (
+                "api_cached_bootstrap_events",
+                Residue,
+                Some(Op::SessionInspect),
+            ),
+            ("subscribe_events", Residue, Some(Op::SessionInspect)),
+            ("unsubscribe_events", Residue, Some(Op::SessionInspect)),
+            ("api_access_overview", Residue, Some(Op::AccessInspect)),
+            ("api_access_iam_state", Residue, Some(Op::AccessInspect)),
+            (
+                "api_access_enrollment_requests",
+                Residue,
+                Some(Op::AccessInspect),
+            ),
+            ("api_dashboard_targets", Residue, Some(Op::AccessInspect)),
+            (
+                "api_access_connect_status",
+                Residue,
+                Some(Op::AccessInspect),
+            ),
+            (
+                "api_access_connect_claim_code",
+                Residue,
+                Some(Op::AccessManage),
+            ),
+            ("api_access_connect_config", Residue, Some(Op::AccessManage)),
+            (
+                "api_access_connect_unclaim",
+                Residue,
+                Some(Op::AccessManage),
+            ),
+            ("api_access_set_tier", Residue, Some(Op::AccessManage)),
+            (
+                "api_access_set_hosted_ceiling",
+                Residue,
+                Some(Op::AccessManage),
+            ),
+            ("api_fleet_cert_request", Residue, Some(Op::AccessManage)),
+            (
+                "api_credential_lease_grant",
+                Residue,
+                Some(Op::CredentialsManage),
+            ),
+            (
+                "api_credential_lease_renew",
+                Residue,
+                Some(Op::CredentialsManage),
+            ),
+            (
+                "api_credential_lease_revoke",
+                Residue,
+                Some(Op::CredentialsManage),
+            ),
+            (
+                "api_credential_lease_status",
+                Residue,
+                Some(Op::CredentialsManage),
+            ),
+            (
+                "api_credential_custody_trail",
+                Residue,
+                Some(Op::CredentialsManage),
+            ),
+            (
+                "api_daemon_vault_fetch",
+                Residue,
+                Some(Op::CredentialsManage),
+            ),
+            (
+                "api_daemon_vault_publish",
+                Residue,
+                Some(Op::CredentialsManage),
+            ),
+            (
+                "api_credential_egress_register",
+                Residue,
+                Some(Op::CredentialsManage),
+            ),
+            (
+                "api_credential_egress_unregister",
+                Residue,
+                Some(Op::CredentialsManage),
+            ),
+            (
+                "api_credential_egress_probe",
+                Residue,
+                Some(Op::CredentialsManage),
+            ),
+            (
+                "api_access_iam_upsert_user_client_grant",
+                Residue,
+                Some(Op::AccessManage),
+            ),
+            (
+                "api_access_iam_update_grant",
+                Residue,
+                Some(Op::AccessManage),
+            ),
+            (
+                "api_access_enrollment_decide",
+                Residue,
+                Some(Op::AccessManage),
+            ),
+            ("api_access_org_trust", Residue, Some(Op::AccessManage)),
+            ("api_access_org_revoke", Residue, Some(Op::AccessManage)),
+            ("api_access_org_issue", Residue, Some(Op::AccessManage)),
+            (
+                "api_access_org_revoke_member",
+                Residue,
+                Some(Op::AccessManage),
+            ),
+            (
+                "api_access_org_issuer_init",
+                Residue,
+                Some(Op::AccessManage),
+            ),
+            (
+                "api_access_org_issuer_delegate",
+                Residue,
+                Some(Op::AccessManage),
+            ),
+            (
+                "api_access_org_issuer_install",
+                Residue,
+                Some(Op::AccessManage),
+            ),
+            ("api_access_org_present", Residue, Some(Op::AccessInspect)),
+            ("api_access_org_orl", Residue, Some(Op::AccessInspect)),
+            ("api_access_org_renew", Residue, Some(Op::AccessInspect)),
+            ("api_access_org_orl_apply", Residue, Some(Op::PresenceRead)),
+            (
+                "api_peer_pairing_requests",
+                Residue,
+                Some(Op::AccessInspect),
+            ),
+            (
+                "api_peer_pairing_identities",
+                Residue,
+                Some(Op::AccessInspect),
+            ),
+            (
+                "api_peer_pairing_request_decision",
+                Residue,
+                Some(Op::AccessManage),
+            ),
+            (
+                "api_peer_pairing_identity_revoke",
+                Residue,
+                Some(Op::AccessManage),
+            ),
+            ("api_peer_pairing_invite", Residue, Some(Op::AccessManage)),
+            ("api_peers", Residue, Some(Op::PeerInspect)),
+            ("api_peer_eligible", Residue, Some(Op::PeerInspect)),
+            ("api_peer_webrtc_signal", Residue, Some(Op::PeerUse)),
+            ("api_peer_file_transfer_signal", Residue, Some(Op::PeerUse)),
+            (
+                "api_peer_dashboard_control_signal",
+                Residue,
+                Some(Op::PeerUse),
+            ),
+            ("api_peer_message", Residue, Some(Op::PeerUse)),
+            ("api_peer_task", Residue, Some(Op::PeerUse)),
+            ("api_peer_approval", Residue, Some(Op::PeerUse)),
+            ("api_peer_add", Residue, Some(Op::PeerManage)),
+            ("api_peer_remove", Residue, Some(Op::PeerManage)),
+            ("api_peer_pairing_join", Residue, Some(Op::PeerManage)),
+            (
+                "api_peer_pairing_request_access",
+                Residue,
+                Some(Op::PeerManage),
+            ),
+            (
+                "api_peer_pairing_request_access_poll",
+                Residue,
+                Some(Op::PeerManage),
+            ),
+            ("api_coordinator_route", Residue, Some(Op::PeerManage)),
+            ("api_sessions", Residue, Some(Op::SessionInspect)),
+            ("api_sessions_stream", Residue, Some(Op::SessionInspect)),
+            ("api_session_detail", Residue, Some(Op::SessionInspect)),
+            ("api_session_report", Residue, Some(Op::SessionInspect)),
+            (
+                "api_session_agent_output",
+                Residue,
+                Some(Op::SessionInspect),
+            ),
+            (
+                "api_session_context_snapshot",
+                Residue,
+                Some(Op::SessionInspect),
+            ),
+            ("api_sessions_search", Residue, Some(Op::SessionInspect)),
+            ("api_session_recordings", Residue, Some(Op::SessionInspect)),
+            (
+                "api_session_recording_asset",
+                Residue,
+                Some(Op::SessionInspect),
+            ),
+            ("api_session_frame_asset", Residue, Some(Op::SessionInspect)),
+            ("api_worktrees", Residue, Some(Op::SessionInspect)),
+            ("api_worktrees_inspect", Residue, Some(Op::SessionInspect)),
+            ("api_session_delete", Residue, Some(Op::SessionManage)),
+            (
+                "api_session_current_history",
+                Residue,
+                Some(Op::SessionManage),
+            ),
+            (
+                "api_session_current_rollback",
+                Residue,
+                Some(Op::SessionManage),
+            ),
+            ("api_session_current_redo", Residue, Some(Op::SessionManage)),
+            (
+                "api_session_current_prune",
+                Residue,
+                Some(Op::SessionManage),
+            ),
+            (
+                "api_session_current_changes",
+                Residue,
+                Some(Op::SessionManage),
+            ),
+            (
+                "api_session_current_uploads",
+                Residue,
+                Some(Op::SessionManage),
+            ),
+            (
+                "api_session_current_upload_raw",
+                Residue,
+                Some(Op::SessionManage),
+            ),
+            (
+                "api_session_current_upload_delete",
+                Residue,
+                Some(Op::SessionManage),
+            ),
+            (
+                "api_session_current_agent_output",
+                Residue,
+                Some(Op::SessionManage),
+            ),
+            ("api_session_control_msg", Residue, Some(Op::SessionManage)),
+            ("api_worktrees_scan", Residue, Some(Op::SessionManage)),
+            ("api_worktrees_remove", Residue, Some(Op::SessionManage)),
+            (
+                "api_session_current_upload",
+                Residue,
+                Some(Op::SessionManage),
+            ),
+            ("api_transfer_jobs", Residue, Some(Op::FilesystemRead)),
+            (
+                "api_transfer_download_read",
+                Residue,
+                Some(Op::FilesystemRead),
+            ),
+            ("api_fs_stat", Row, Some(Op::FilesystemRead)),
+            ("api_fs_list", Row, Some(Op::FilesystemRead)),
+            ("api_fs_read", Row, Some(Op::FilesystemRead)),
+            (
+                "api_transfer_job_create",
+                Residue,
+                Some(Op::FilesystemWrite),
+            ),
+            (
+                "api_transfer_job_delete",
+                Residue,
+                Some(Op::FilesystemWrite),
+            ),
+            (
+                "api_transfer_upload_chunk",
+                Residue,
+                Some(Op::FilesystemWrite),
+            ),
+            (
+                "api_transfer_upload_commit",
+                Residue,
+                Some(Op::FilesystemWrite),
+            ),
+            ("api_fs_mkdir", Row, Some(Op::FilesystemWrite)),
+            ("api_fs_write", Row, Some(Op::FilesystemWrite)),
+            ("api_fs_rename", Row, Some(Op::FilesystemWrite)),
+            ("api_fs_delete", Row, Some(Op::FilesystemWrite)),
+            ("api_display_bootstrap", Residue, Some(Op::DisplayView)),
+            ("api_display_webrtc_signal", Residue, Some(Op::DisplayView)),
+            ("api_displays", Residue, Some(Op::DisplayView)),
+            (
+                "api_display_input_authority_snapshot",
+                Residue,
+                Some(Op::DisplayInput),
+            ),
+            (
+                "api_display_input_authority_request",
+                Residue,
+                Some(Op::DisplayInput),
+            ),
+            (
+                "api_display_input_authority_release",
+                Residue,
+                Some(Op::DisplayInput),
+            ),
+            (
+                "api_diagnostics_visual_freshness",
+                Residue,
+                Some(Op::DisplayInput),
+            ),
+            ("api_control_msg", Residue, Some(Op::Message)),
+            ("api_dashboard_action_msg", Residue, Some(Op::Message)),
+            ("api_mcp_tool_call", Residue, Some(Op::Message)),
+            ("api_settings", Residue, Some(Op::Settings)),
+            ("api_settings_save", Residue, Some(Op::Settings)),
+            ("api_key_status", Residue, Some(Op::Settings)),
+            ("api_api_keys_save", Residue, Some(Op::Settings)),
+            ("api_project_root", Residue, Some(Op::Settings)),
+            ("api_voice_session", Residue, Some(Op::RuntimeControl)),
+            (
+                "api_presence_video_frame",
+                Residue,
+                Some(Op::RuntimeControl),
+            ),
+            (
+                "api_media_annotation_attach",
+                Residue,
+                Some(Op::RuntimeControl),
+            ),
+            (
+                "api_media_annotation_submit",
+                Residue,
+                Some(Op::RuntimeControl),
+            ),
+            ("api_media_clip_start", Residue, Some(Op::RuntimeControl)),
+            ("api_media_clip_frame", Residue, Some(Op::RuntimeControl)),
+            ("api_media_clip_end", Residue, Some(Op::RuntimeControl)),
+            ("api_media_clip_cancel", Residue, Some(Op::RuntimeControl)),
+            ("api_recordings", Residue, Some(Op::RuntimeControl)),
+            ("api_recording_asset", Residue, Some(Op::RuntimeControl)),
+            (
+                "api_browser_workspace_snapshot",
+                Residue,
+                Some(Op::SessionInspect),
+            ),
+            ("api_state_snapshot", Residue, Some(Op::SessionInspect)),
+            ("api_session_log_replay", Residue, Some(Op::SessionInspect)),
+            (
+                "api_external_session_activity_replay",
+                Residue,
+                Some(Op::SessionInspect),
+            ),
+            ("api_dashboard_bootstrap", Residue, Some(Op::SessionInspect)),
+            (
+                "api_managed_context_records",
+                Residue,
+                Some(Op::SessionInspect),
+            ),
+            (
+                "api_managed_context_anchors",
+                Residue,
+                Some(Op::SessionInspect),
+            ),
+            (
+                "api_managed_context_fission",
+                Residue,
+                Some(Op::SessionInspect),
+            ),
+            ("api_external_agents", Residue, Some(Op::SessionInspect)),
+        ];
+
+        // Live partition: rows first (the resolution order), then the
+        // residue; a name on both sides is declared twice — an error.
+        let mut live: BTreeMap<&str, (Source, Option<Op>)> = BTreeMap::new();
+        for (route, spec) in crate::gateway_routes::tunnel_specs() {
+            let op = route.tunnel_operation();
+            assert!(
+                op.is_some(),
+                "{}: tunnel row must derive an IAM operation",
+                spec.name
+            );
+            assert!(
+                live.insert(spec.name, (Row, op)).is_none(),
+                "{} is declared on more than one route row",
+                spec.name
+            );
+        }
+        for spec in CONTROL_METHODS {
+            assert!(
+                live.insert(spec.name, (Residue, spec.op)).is_none(),
+                "{} is declared BOTH as a route-row tunnel column and in \
+                 CONTROL_METHODS — remove the residue entry",
+                spec.name
+            );
+        }
+
+        let mut pinned: BTreeMap<&str, (Source, Option<Op>)> = BTreeMap::new();
+        for (name, source, op) in frozen.iter().copied() {
+            assert!(
+                pinned.insert(name, (source, op)).is_none(),
+                "frozen partition lists {name} twice"
+            );
+        }
+        for (name, (source, op)) in &pinned {
+            let Some((live_source, live_op)) = live.get(name) else {
+                panic!(
+                    "{name} vanished from the live declarations (frozen as \
+                     {source:?} {op:?}); if the removal is deliberate, drop \
+                     it from the frozen partition in the same change"
+                );
+            };
+            assert_eq!(
+                live_source, source,
+                "{name} moved declaration source; update the frozen \
+                 partition deliberately"
+            );
+            assert_eq!(
+                live_op, op,
+                "{name} was re-gated; an IAM operation change must update \
+                 the frozen partition deliberately"
+            );
+        }
+        for name in live.keys() {
+            assert!(
+                pinned.contains_key(name),
+                "{name} is a new tunnel method not in the frozen partition; \
+                 add it (source + operation) deliberately"
+            );
+        }
     }
 
     /// The SPA's `daemonApi` facade mirrors the HTTP twins of its tunnel

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -18,6 +18,13 @@
 //! 4. **Docs** — [`render_endpoint_docs`] renders the endpoint table in
 //!    `docs/src/web-dashboard.md`; the `endpoint_docs_match_chapter`
 //!    drift test pins the chapter to it.
+//! 5. **Tunnel exposure** — a row's optional [`TunnelSpec`] declares its
+//!    dashboard-control datachannel twin. The tunnel's method table
+//!    (`dashboard_control::control_method_spec`) resolves these rows
+//!    first, then its residue `CONTROL_METHODS`, so a twinned method's
+//!    IAM operation derives from the same declaration HTTP gates on
+//!    (transport-unification design §2.2) instead of a second table that
+//!    can drift.
 //!
 //! **Never add an API route by editing the dispatch chain**: declare it
 //! here and give it a handler arm in `web_gateway.rs`'s table-dispatch
@@ -271,6 +278,58 @@ pub(crate) enum RouteHandlerId {
     McpStream,
 }
 
+/// Datachannel (dashboard-control tunnel) twin of a route row — the
+/// `tunnel:` column of the transport-unification design (§2.2). The wire
+/// method name is unchanged from its legacy `CONTROL_METHODS` entry: the
+/// datachannel wire never changes; the name becomes an alias of this
+/// row. The IAM operation gating the tunnel method is **derived from the
+/// row** ([`Route::tunnel_operation`]) — declaring it once is the point
+/// of the column: the two transports cannot drift apart again. (§2.2's
+/// `lanes`/`http_params` fields arrive with the migration stages that
+/// consume them; adding them before a consumer exists would be dead
+/// weight.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TunnelSpec {
+    /// Wire method name (e.g. `"api_fs_write"`), exactly as datachannel
+    /// clients send it in `t:"request"` frames.
+    pub(crate) name: &'static str,
+    /// Documented divergent-by-design IAM override. `None` — the default
+    /// and the point — derives the operation from the row's
+    /// [`RouteAuthz::Operation`]. `Some((op, reason))` gates the tunnel
+    /// method on `op` instead; the reason string is mandatory, and the
+    /// `tunnel_op_overrides_are_a_closed_documented_enumeration` test
+    /// pins the override list closed (design §2.7: the signed-org
+    /// doorbell rows — Public on HTTP, session-gated on the tunnel — are
+    /// the intended occupants when their family ports).
+    pub(crate) op_override: Option<(PeerOperation, &'static str)>,
+    /// Advertised in the tunnel `features` handshake (the legacy
+    /// `advertised` flag).
+    pub(crate) advertised: bool,
+    /// May also (or only) be delivered as an upload frame (the legacy
+    /// `upload` flag; feeds `authorize_dashboard_control_upload`).
+    pub(crate) upload: bool,
+}
+
+/// Advertised, non-upload tunnel twin (the common shape).
+const fn tunnel_method(name: &'static str) -> TunnelSpec {
+    TunnelSpec {
+        name,
+        op_override: None,
+        advertised: true,
+        upload: false,
+    }
+}
+
+/// Advertised tunnel twin that may also arrive as an upload frame.
+const fn tunnel_uploadable(name: &'static str) -> TunnelSpec {
+    TunnelSpec {
+        name,
+        op_override: None,
+        advertised: true,
+        upload: true,
+    }
+}
+
 pub(crate) struct Route {
     pub(crate) method: RouteMethod,
     pub(crate) pattern: PathPattern,
@@ -281,6 +340,42 @@ pub(crate) struct Route {
     /// One line, becomes the docs endpoint-table row. Required — an
     /// empty doc string fails the invariant test.
     pub(crate) doc: &'static str,
+    /// Datachannel exposure of this row. `None` = HTTP-only, or the
+    /// tunnel twin has not yet ported out of `CONTROL_METHODS` (the
+    /// transitional state the migration drains family by family; the
+    /// differential pin test in `dashboard_control` freezes which
+    /// methods live where).
+    pub(crate) tunnel: Option<TunnelSpec>,
+}
+
+impl Route {
+    /// Attach the row's datachannel twin (builder-style; rows are const).
+    const fn with_tunnel(mut self, spec: TunnelSpec) -> Route {
+        self.tunnel = Some(spec);
+        self
+    }
+
+    /// The IAM operation this row's tunnel twin gates on: the documented
+    /// override when declared, otherwise the row's own
+    /// [`RouteAuthz::Operation`]. `None` means no fail-closed derivation
+    /// exists (a non-`Operation` row without an override): the tunnel
+    /// method table skips such a row entirely, so the authorizer's
+    /// unknown-method deny is the runtime backstop, and the
+    /// `tunnel_specs_are_unique_and_derive_operations_fail_closed`
+    /// invariant test keeps the state unlandable. `PeerFederation` rows
+    /// will derive from `federation_http_operation` on the row's
+    /// canonical leaf when the peers family ports (design §2.2 / S7);
+    /// until then they too must declare an override to carry a tunnel.
+    pub(crate) fn tunnel_operation(&self) -> Option<PeerOperation> {
+        let spec = self.tunnel.as_ref()?;
+        if let Some((op, _reason)) = spec.op_override {
+            return Some(op);
+        }
+        match self.authz {
+            RouteAuthz::Operation(op) => Some(op),
+            RouteAuthz::Public | RouteAuthz::McpToken | RouteAuthz::PeerFederation => None,
+        }
+    }
 }
 
 /// Compact constructor for the common row shape: IAM-gated via a
@@ -301,6 +396,7 @@ const fn op_route(
         body,
         handler,
         doc,
+        tunnel: None,
     }
 }
 
@@ -321,6 +417,7 @@ const fn fleet_route(
         body,
         handler,
         doc,
+        tunnel: None,
     }
 }
 
@@ -340,6 +437,7 @@ const fn public_route(
         body,
         handler,
         doc,
+        tunnel: None,
     }
 }
 
@@ -360,6 +458,7 @@ const fn federation_route(
         body,
         handler,
         doc,
+        tunnel: None,
     }
 }
 
@@ -370,6 +469,9 @@ const fn federation_route(
 pub(crate) static ROUTES: &[Route] = &[
     // ── Filesystem (scoped by authorize_http_filesystem_access; the GET
     //    trio is additionally pre-gated by peer_filesystem_query_request).
+    //    First family carrying the tunnel column: the datachannel twins'
+    //    IAM operations derive from these rows (their legacy
+    //    CONTROL_METHODS entries are gone).
     op_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/fs/stat"),
@@ -377,7 +479,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::FsStat,
         "Stat a filesystem path (scope-checked)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_fs_stat")),
     op_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/fs/list"),
@@ -385,7 +488,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::FsList,
         "List a directory (scope-checked)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_fs_list")),
     op_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/fs/read"),
@@ -393,7 +497,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::FsRead,
         "Read file bytes (scope-checked; supports byte ranges)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_fs_read")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/fs/mkdir"),
@@ -401,7 +506,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::FsMkdir,
         "Create a directory (scope-checked)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_fs_mkdir")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/fs/write"),
@@ -413,7 +519,10 @@ pub(crate) static ROUTES: &[Route] = &[
         ),
         RouteHandlerId::FsWrite,
         "Write file bytes (scope-checked; sha256-guarded overwrite)",
-    ),
+    )
+    // Tunnel-side the content may also ride upload frames (the JSON
+    // `content_b64` / upload-frame asymmetry is preserved by design).
+    .with_tunnel(tunnel_uploadable("api_fs_write")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/fs/rename"),
@@ -421,7 +530,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::FsRename,
         "Move/rename a file or directory (scope-checked)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_fs_rename")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/fs/delete"),
@@ -429,7 +539,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::FsDelete,
         "Delete a file or directory (scope-checked)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_fs_delete")),
     // ── Current-session routes (exact/subtree rows precede the generic
     //    session sub-router rows below).
     op_route(
@@ -1034,6 +1145,7 @@ pub(crate) static ROUTES: &[Route] = &[
         body: BodyPolicy::Capped(MCP_BODY_CAP_BYTES),
         handler: RouteHandlerId::McpPost,
         doc: "MCP Streamable HTTP endpoint (JSON-RPC requests + notifications)",
+        tunnel: None,
     },
     Route {
         method: RouteMethod::Get,
@@ -1043,6 +1155,7 @@ pub(crate) static ROUTES: &[Route] = &[
         body: BodyPolicy::None,
         handler: RouteHandlerId::McpStream,
         doc: "MCP SSE stream (405: stateless server)",
+        tunnel: None,
     },
     Route {
         method: RouteMethod::Delete,
@@ -1052,6 +1165,7 @@ pub(crate) static ROUTES: &[Route] = &[
         body: BodyPolicy::None,
         handler: RouteHandlerId::McpStream,
         doc: "MCP session delete (405: stateless server)",
+        tunnel: None,
     },
 ];
 
@@ -1145,6 +1259,17 @@ pub(crate) fn classify(req_method: &str, req_path: &str) -> TableClassification 
         }),
         None => TableClassification::NoMatch,
     }
+}
+
+/// Every (route, tunnel spec) pair, in declaration order — the ROW half
+/// of the tunnel method partition. `dashboard_control` unions this with
+/// its residue `CONTROL_METHODS` (rows first) to build the effective
+/// method table; its differential pin test freezes exactly which methods
+/// live on which side.
+pub(crate) fn tunnel_specs() -> impl Iterator<Item = (&'static Route, &'static TunnelSpec)> {
+    ROUTES
+        .iter()
+        .filter_map(|route| route.tunnel.as_ref().map(|spec| (route, spec)))
 }
 
 /// CORS/preflight posture for a path: the first row matching it on any
@@ -1733,6 +1858,66 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn tunnel_specs_are_unique_and_derive_operations_fail_closed() {
+        let mut seen: HashSet<&str> = HashSet::new();
+        for (route, spec) in tunnel_specs() {
+            assert!(
+                seen.insert(spec.name),
+                "tunnel method {} is declared on more than one row",
+                spec.name,
+            );
+            // The status `<method>_available` derivation keys on the
+            // api_ prefix; a differently-named tunnel method would
+            // silently lose its availability boolean.
+            assert!(
+                spec.name.starts_with("api_"),
+                "tunnel method {} must be api_-prefixed",
+                spec.name,
+            );
+            // Fail-closed derivation must exist: a Public / McpToken /
+            // PeerFederation row may only carry a tunnel twin with an
+            // explicit documented op override — otherwise the method
+            // would resolve to nothing and (correctly, but uselessly) be
+            // denied as unknown.
+            assert!(
+                route.tunnel_operation().is_some(),
+                "tunnel method {} has no derivable IAM operation: \
+                 non-Operation rows must declare an op_override",
+                spec.name,
+            );
+        }
+    }
+
+    /// The op-override slot is a closed, documented enumeration (design
+    /// §2.7 / risk R2): every override names its reason, and this test
+    /// pins the exact set so a tunnel/HTTP divergence can only ever be
+    /// added deliberately. Empty today — S0 (PR #128) settled the two
+    /// formerly-divergent twins identically on both lanes, so the first
+    /// legitimate entries arrive with the signed-org doorbell rows
+    /// (Public on HTTP, session-gated on the tunnel) when their family
+    /// ports.
+    #[test]
+    fn tunnel_op_overrides_are_a_closed_documented_enumeration() {
+        let documented: &[&str] = &[];
+        let mut actual: Vec<&str> = Vec::new();
+        for (_, spec) in tunnel_specs() {
+            if let Some((_, reason)) = spec.op_override {
+                assert!(
+                    !reason.trim().is_empty(),
+                    "tunnel op override on {} must state a non-empty reason",
+                    spec.name,
+                );
+                actual.push(spec.name);
+            }
+        }
+        actual.sort_unstable();
+        assert_eq!(
+            actual, documented,
+            "tunnel op overrides drifted from the documented divergence set",
+        );
     }
 
     /// The docs chapter's generated endpoint table must equal the one


### PR DESCRIPTION
Transport-unification **S3, PR 1 of 2** (design §2.2, §6 "S3", §7 R2/R4, §8): the route table grows a `tunnel:` column and the dashboard-control method table starts deriving from it, with a permanent differential pin freezing the whole method partition.

## What changed

**`gateway_routes.rs` — the `tunnel:` column (§2.2)**
- `Route` gains `tunnel: Option<TunnelSpec>`; `TunnelSpec` carries the wire method name (unchanged on the wire — the name becomes an alias of the row), the `advertised`/`upload` flags, and an `op_override: Option<(PeerOperation, &'static str)>` slot whose reason string is mandatory by construction. §2.2's `lanes`/`http_params` fields arrive with the stages that consume them.
- The IAM operation for a twinned method is **derived from the row** (`Route::tunnel_operation`): the override when declared, otherwise the row's `RouteAuthz::Operation`. Non-`Operation` rows (Public/McpToken/PeerFederation) have no fail-closed derivation and may not carry a tunnel spec without an override — invariant-tested, and skipped (⇒ unknown-method deny) if ever reached at runtime.
- The seven fs rows are populated (`api_fs_stat/list/read` + the write quartet `mkdir/write/rename/delete`; `api_fs_write` keeps its upload-frame delivery). Flags match their removed `CONTROL_METHODS` entries exactly.

**`dashboard_control` — rows-first resolution**
- New `all_control_methods()`: the effective method table, materialized once — route-row tunnel specs first (ROUTES declaration order), then the residue `CONTROL_METHODS`. `control_method_spec` resolves over it, so rows win deterministically even in the (unlandable, pin-tested) duplicated state.
- Every consumer sees the same union: the fail-closed authorizer, the upload-frame allowlist, `control_features()`, and the `<method>_available` status loop — same booleans, same feature names, zero wire-visible change.
- The seven `api_fs_*` entries are **removed from `CONTROL_METHODS`** (now the residue table; header comment says so and points additions at the row column).

**Fail-closed default preserved**: unknown method ⇒ deny is untouched (`authorize_dashboard_control_method`) and stays covered by the existing `unknown_dashboard_control_methods_are_denied_fail_closed` test, which also proves `api_fs_write` upload-frame delivery survived the move to rows.

## New pins (permanent program infrastructure)

- **`tunnel_method_partition_is_pinned`** (dashboard_control): the complete 134-name × {source: ROW|RESIDUE} × operation partition frozen as a literal table. Any accidental re-gating, loss, duplication (declared on both sides), or silent source move fails the suite; S4–S10 flip tags here deliberately alongside their declarations.
- **`tunnel_op_overrides_are_a_closed_documented_enumeration`** (gateway_routes): the override set is pinned to the documented divergence list — **empty today** (S0/PR #128 settled both formerly-divergent twins as SessionInspect on both lanes; the first legitimate entries are the §2.7 signed-org doorbell rows when their family ports). Also asserts any future override's reason is non-empty.
- **`tunnel_specs_are_unique_and_derive_operations_fail_closed`** (gateway_routes): tunnel names unique across rows, `api_`-prefixed (the availability-boolean derivation keys on it), and always operation-derivable.

## Existing tests touched (the CONTROL_METHODS-enumeration set, updated minimally)

1. `dashboard_control::tests::control_method_table_is_coherent` — iterates `all_control_methods()` (the union) instead of `CONTROL_METHODS`; strictly stronger (cross-source duplicates now count as duplicates).
2. `dashboard_control::dispatch::tests::status_advertises_an_availability_boolean_for_every_gated_api_method` — same one-line union switch, so the seven fs `<method>_available` booleans stay covered.
3. (comment-only) the `method_operation` test helper's doc line now names the effective table.

Everything else is green unchanged — including `daemon_api_http_map_mirrors_gateway_routes` (fs methods now resolve via rows, and its tunnel-op/route-op agreement check is trivially satisfied by derivation) and `formerly_divergent_twins_gate_identically_on_both_lanes`.

## Gates

- `cargo nextest run --bins`
- `cargo clippy` (no new warnings)
- `cargo test --test e2e` (8/8)

PR 2 of S3 (assessed separately): CLAUDE.md "add tunnel methods as row columns" note + AGENTS.md copy; optional endpoint-docs tunnel column.
