### PR TITLE
Transport S3b: tunnel-column doctrine in CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,13 +154,14 @@ SysPrompt*.md   # per-role system prompts (base, tools, user, orchestrator, rese
   violation.
 - **Derive, don't mirror.** Daemon truth a frontend needs — permission
   catalogs, feature lists, availability booleans, option vocabularies — is
-  declared once and derived everywhere else (exemplar: `CONTROL_METHODS` in
-  `dashboard_control/mod.rs` drives the authorizer, the `features` list, and the
-  per-method availability booleans). When a static frontend fallback copy is
-  unavoidable (app.html's IAM catalog, the peer-profile picker), a
-  daemon-side parity test pins its ID sets to the source, so a catalog
-  change that forgets the mirror fails the suite instead of shipping as
-  drift.
+  declared once and derived everywhere else (exemplar: the tunnel method
+  table — `gateway_routes::ROUTES` tunnel columns ∪ the `CONTROL_METHODS`
+  residue in `dashboard_control/mod.rs` — drives the authorizer, the
+  `features` list, and the per-method availability booleans). When a static
+  frontend fallback copy is unavoidable (app.html's IAM catalog, the
+  peer-profile picker), a daemon-side parity test pins its ID sets to the
+  source, so a catalog change that forgets the mirror fails the suite
+  instead of shipping as drift.
 - WASM boundary: `serde_wasm_bindgen` with `serialize_maps_as_objects(true)`
 - **Gateway API routes are declared once** in `src/bin/caller/gateway_routes.rs`
   (`ROUTES`): dispatch, the pre-dispatch IAM classification, the OPTIONS
@@ -169,8 +170,13 @@ SysPrompt*.md   # per-role system prompts (base, tools, user, orchestrator, rese
   Never add an HTTP route by editing `web_gateway/http_dispatch.rs`'s dispatch chain —
   add a table row plus a `RouteHandlerId` match arm; the row also declares the
   request-body policy (dispatch reads and caps the body before the handler
-  runs). Unit tests enforce the table invariants, pin the docs chapter, and
-  pin every route-specific body cap.
+  runs). A route's dashboard-control (datachannel) twin is declared on the
+  same row: tunnel-twinned methods get the row's `tunnel:` column
+  (`TunnelSpec`) — never a `CONTROL_METHODS` entry; that table is the residue
+  for tunnel-only methods, and the tunnel derives each twinned method's IAM
+  operation from its row. Unit tests enforce the table invariants, pin the
+  docs chapter, pin every route-specific body cap, and freeze the tunnel
+  method partition (`tunnel_method_partition_is_pinned`).
 - `static/app.html` is **generated** from the `static/app/` fragments (order =
   `static/app/manifest.txt`; assembled by `build.rs` via
   `crates/app-html-assembler`; CI enforces the match). Edit the fragments,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,13 +154,14 @@ SysPrompt*.md   # per-role system prompts (base, tools, user, orchestrator, rese
   violation.
 - **Derive, don't mirror.** Daemon truth a frontend needs — permission
   catalogs, feature lists, availability booleans, option vocabularies — is
-  declared once and derived everywhere else (exemplar: `CONTROL_METHODS` in
-  `dashboard_control/mod.rs` drives the authorizer, the `features` list, and the
-  per-method availability booleans). When a static frontend fallback copy is
-  unavoidable (app.html's IAM catalog, the peer-profile picker), a
-  daemon-side parity test pins its ID sets to the source, so a catalog
-  change that forgets the mirror fails the suite instead of shipping as
-  drift.
+  declared once and derived everywhere else (exemplar: the tunnel method
+  table — `gateway_routes::ROUTES` tunnel columns ∪ the `CONTROL_METHODS`
+  residue in `dashboard_control/mod.rs` — drives the authorizer, the
+  `features` list, and the per-method availability booleans). When a static
+  frontend fallback copy is unavoidable (app.html's IAM catalog, the
+  peer-profile picker), a daemon-side parity test pins its ID sets to the
+  source, so a catalog change that forgets the mirror fails the suite
+  instead of shipping as drift.
 - WASM boundary: `serde_wasm_bindgen` with `serialize_maps_as_objects(true)`
 - **Gateway API routes are declared once** in `src/bin/caller/gateway_routes.rs`
   (`ROUTES`): dispatch, the pre-dispatch IAM classification, the OPTIONS
@@ -169,8 +170,13 @@ SysPrompt*.md   # per-role system prompts (base, tools, user, orchestrator, rese
   Never add an HTTP route by editing `web_gateway/http_dispatch.rs`'s dispatch chain —
   add a table row plus a `RouteHandlerId` match arm; the row also declares the
   request-body policy (dispatch reads and caps the body before the handler
-  runs). Unit tests enforce the table invariants, pin the docs chapter, and
-  pin every route-specific body cap.
+  runs). A route's dashboard-control (datachannel) twin is declared on the
+  same row: tunnel-twinned methods get the row's `tunnel:` column
+  (`TunnelSpec`) — never a `CONTROL_METHODS` entry; that table is the residue
+  for tunnel-only methods, and the tunnel derives each twinned method's IAM
+  operation from its row. Unit tests enforce the table invariants, pin the
+  docs chapter, pin every route-specific body cap, and freeze the tunnel
+  method partition (`tunnel_method_partition_is_pinned`).
 - `static/app.html` is **generated** from the `static/app/` fragments (order =
   `static/app/manifest.txt`; assembled by `build.rs` via
   `crates/app-html-assembler`; CI enforces the match). Edit the fragments,


### PR DESCRIPTION
Transport-unification **S3, PR 2 of 2** (design §7 R4 mitigation: "CLAUDE.md note updated at S3"): codify the tunnel-column doctrine now that S3a (#138) derives the fs family's tunnel methods from route rows.

- **"Gateway API routes are declared once"** bullet: a route's dashboard-control twin is declared on the same row — tunnel-twinned methods get the row's `tunnel:` column (`TunnelSpec`), never a `CONTROL_METHODS` entry; that table is the residue for tunnel-only methods; the twinned method's IAM operation derives from its row; the S3 differential pin (`tunnel_method_partition_is_pinned`) freezes the partition.
- **"Derive, don't mirror"** exemplar: it still named `CONTROL_METHODS` as the single source — now names the two-source union (ROUTES tunnel columns ∪ the residue).
- `AGENTS.md` updated by `cp CLAUDE.md AGENTS.md` in the same commit (agents-md-sync byte-parity verified locally with `diff`).

**Deferred by design**: the docs endpoint-table tunnel column (`render_endpoint_docs`) — nothing in `docs/src/web-dashboard.md` pins the method table today, and a column populated for only 7/95 rows adds churn without signal; revisit when S4+ ports more families.

Doc-only change: no code, no tests touched.
