### PR TITLE
Session notes: display-only transcript notes with image attachments

### DIFF
--- a/docs/src/mcp-server.md
+++ b/docs/src/mcp-server.md
@@ -184,6 +184,7 @@ Full MCP tool groups:
 | `skip`          | Skip, continue with the next command. | `id` |
 | `approve_all`   | Approve and set autonomy to Full. | `id` |
 | `respond`       | Answer an `askHuman` question. | `text` |
+| `post_session_note` | Post a **display-only note** into the session transcript — rendered live in the dashboard and persisted for replay, never added to any model's context. Optional base64 images are committed to the session upload store and rendered as clickable thumbnails. Caps: 16 KB text, 6 images, 4 MB per image, 8 MB total; raster types only (`image/png`, `image/jpeg`, `image/gif`, `image/webp`, `image/bmp`). Session-scoped callers post into their own session by default. | `text`, `images?` (`[{media_type, data, name?}]`), `session_id?`, `source?` |
 | `set_autonomy`  | Set autonomy. | `level`: `low`/`medium`/`high`/`full` |
 | `set_verbosity` | Set log verbosity. | `level`: `quiet`/`normal`/`verbose`/`debug` |
 | `start_task`    | Start a new agent task (also used as follow-up when waiting). | `task` |

--- a/skills/intendant-cli/SKILL.md
+++ b/skills/intendant-cli/SKILL.md
@@ -22,6 +22,8 @@ Quick recipes — the highest-traffic one-liners; everything else is one `--help
 ```bash
 "${INTENDANT:-intendant}" ctl display screenshot --output shot.png    # see a local display
 "${INTENDANT:-intendant}" ctl cu actions --actions '[{"type":"click","x":100,"y":200}]' --output after.png
+"${INTENDANT:-intendant}" ctl session note "Milestone: tests green"   # display-only note in your transcript
+"${INTENDANT:-intendant}" ctl session note "Before/after" --image before.png --image after.png
 "${INTENDANT:-intendant}" ctl peer list                               # federated peers + their displays
 "${INTENDANT:-intendant}" ctl peer task <peer-id> "instructions"      # the peer's own agent executes
 "${INTENDANT:-intendant}" ctl --peer <id> display screenshot --output peer.png   # drive another machine
@@ -34,6 +36,7 @@ Useful groups:
 - `"${INTENDANT:-intendant}" ctl browser --help` for browser workspaces, including local CDP-backed browsers and lease management.
   CDP workspaces prefer managed Chromium/Chrome-for-Testing; run `"${INTENDANT:-intendant}" setup browsers` to install/repair the managed browser cache, and use `--provider system_cdp` or `INTENDANT_BROWSER_WORKSPACE_ALLOW_SYSTEM_BROWSER=1` to opt into system Chrome/Chromium on macOS.
 - `"${INTENDANT:-intendant}" ctl cu --help` for computer-use actions; `ctl cu actions --help` prints the per-action JSON shapes with an example. `ctl cu elements` reads the frontmost app's UI element tree (cheap textual grounding — click the center of a reported frame; user-session only via macOS AX, Linux AT-SPI, or Windows UIA).
+- `"${INTENDANT:-intendant}" ctl session note --help` to post a **display-only note** into your session transcript — show the user progress, findings, or before/after screenshots without touching any model's context. The note appears live in the dashboard transcript and persists for replay; each `--image` file (png/jpg/gif/webp/bmp, ≤4 MB each, ≤6 per note) renders as a clickable thumbnail. Use `--source LABEL` to label the entry.
 - `"${INTENDANT:-intendant}" ctl shared --help` for shared display collaboration.
 - `"${INTENDANT:-intendant}" ctl peer --help` for federated peers — list peers, message a peer's agent, delegate tasks (`ctl peer list|message|task`; the peer executes under its own autonomy/IAM).
 - Global `--peer ID` routes **any** ctl subcommand to a federated peer's `/mcp` over mTLS — no local daemon needed. It resolves the `[[peer]]` entry in `intendant.toml` by label, card_url host, or `intendant:<label>` id (falling back to the user-level `~/.intendant/peers.toml` when the project has no match, so paired peers work from any directory), then e.g. `ctl --peer dell display screenshot --output peer.png` or `ctl --peer dell cu actions --actions '[...]'` drive the peer's screen directly. `ctl --peer dell cu elements` reads the **peer's** frontmost UI element tree — the cheap first look before screenshots (needs the peer's platform accessibility stack). The peer's IAM profile for this daemon decides: screenshots and `cu elements` need display view (read-only-display or better), `cu actions` needs display input (peer-operator/peer-root). A denial is the peer's owner not having granted it — report, don't retry.

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -61,6 +61,7 @@ pub async fn run(raw_args: Vec<String>) -> Result<(), String> {
         "approval" | "approvals" => run_approval(&client, &config, &command[1..]).await?,
         "input" => run_input(&client, &config, &command[1..]).await?,
         "settings" | "set" => run_settings(&client, &config, &command[1..]).await?,
+        "session" | "sessions" => run_session(&client, &config, &command[1..]).await?,
         "task" => run_task(&client, &config, &command[1..]).await?,
         "controller" => run_controller(&client, &config, &command[1..]).await?,
         "context" => run_context(&client, &config, &command[1..]).await?,
@@ -1101,6 +1102,132 @@ async fn run_settings(
     Ok(())
 }
 
+async fn run_session(
+    client: &reqwest::Client,
+    config: &Config,
+    raw: &[String],
+) -> Result<(), String> {
+    if raw.is_empty() || is_help(raw) {
+        help_session();
+        return Ok(());
+    }
+    match raw[0].as_str() {
+        "note" => {
+            if is_help(&raw[1..]) {
+                help_session_note();
+                return Ok(());
+            }
+            let response = call_tool(
+                client,
+                config,
+                "post_session_note",
+                session_note_args(&raw[1..])?,
+            )
+            .await?;
+            print_tool_response(response, config, None)?;
+        }
+        other => return Err(format!("unknown session command '{other}'")),
+    }
+    Ok(())
+}
+
+/// Build `post_session_note` arguments from `session note` flags. Reads
+/// each `--image` file locally (so the caller's own sandbox governs what
+/// is readable) and base64-encodes it into the tool arguments; the daemon
+/// deliberately accepts no file paths from MCP callers.
+fn session_note_args(raw: &[String]) -> Result<Value, String> {
+    let args = parse_command_args(raw, &["--image", "--source", "--session"], &[])?;
+    let text = if args.positional.is_empty() {
+        return Err("session note requires note text".to_string());
+    } else {
+        args.positional.join(" ")
+    };
+    if text.len() > crate::mcp::SESSION_NOTE_MAX_TEXT_BYTES {
+        return Err(format!(
+            "note text is {} bytes; max {} KB",
+            text.len(),
+            crate::mcp::SESSION_NOTE_MAX_TEXT_BYTES / 1024
+        ));
+    }
+    let mut map = Map::new();
+    map.insert("text".to_string(), Value::String(text));
+    insert_string(&mut map, "source", args.one("--source"));
+    insert_string(&mut map, "session_id", args.one("--session"));
+    let image_paths: Vec<&str> = args.all("--image").collect();
+    if image_paths.len() > crate::mcp::SESSION_NOTE_MAX_IMAGES {
+        return Err(format!(
+            "too many images: {} (max {} per note)",
+            image_paths.len(),
+            crate::mcp::SESSION_NOTE_MAX_IMAGES
+        ));
+    }
+    let mut images = Vec::new();
+    let mut total_bytes = 0usize;
+    for path in image_paths {
+        let (media_type, name, data, size) = read_session_note_image(Path::new(path))?;
+        total_bytes = total_bytes.saturating_add(size);
+        if total_bytes > crate::mcp::SESSION_NOTE_MAX_TOTAL_IMAGE_BYTES {
+            return Err(format!(
+                "total image size exceeds the {} MB per-note cap",
+                crate::mcp::SESSION_NOTE_MAX_TOTAL_IMAGE_BYTES / (1024 * 1024)
+            ));
+        }
+        images.push(json_object([
+            ("media_type", Value::String(media_type.to_string())),
+            ("data", Value::String(data)),
+            ("name", Value::String(name)),
+        ]));
+    }
+    if !images.is_empty() {
+        map.insert("images".to_string(), Value::Array(images));
+    }
+    Ok(Value::Object(map))
+}
+
+/// Read one `--image` file: infer the MIME type from the extension,
+/// enforce the per-image cap, and return (mime, basename, base64, size).
+fn read_session_note_image(path: &Path) -> Result<(&'static str, String, String, usize), String> {
+    let media_type = match path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("png") => "image/png",
+        Some("jpg") | Some("jpeg") => "image/jpeg",
+        Some("gif") => "image/gif",
+        Some("webp") => "image/webp",
+        Some("bmp") => "image/bmp",
+        other => {
+            return Err(format!(
+                "unsupported image extension {:?} for {}; supported: png, jpg, jpeg, gif, webp, bmp",
+                other.unwrap_or(""),
+                path.display()
+            ));
+        }
+    };
+    let bytes =
+        std::fs::read(path).map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    if bytes.is_empty() {
+        return Err(format!("{} is empty", path.display()));
+    }
+    if bytes.len() > crate::mcp::SESSION_NOTE_MAX_IMAGE_BYTES {
+        return Err(format!(
+            "{} is {} bytes; max {} MB per image",
+            path.display(),
+            bytes.len(),
+            crate::mcp::SESSION_NOTE_MAX_IMAGE_BYTES / (1024 * 1024)
+        ));
+    }
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "image".to_string());
+    let size = bytes.len();
+    let data = base64::engine::general_purpose::STANDARD.encode(bytes);
+    Ok((media_type, name, data, size))
+}
+
 async fn run_task(client: &reqwest::Client, config: &Config, raw: &[String]) -> Result<(), String> {
     if raw.is_empty() || is_help(raw) {
         help_task();
@@ -1976,6 +2103,7 @@ Commands:\n\
   approval                  Pending approvals and approval responses\n\
   input                     Pending human question and response\n\
   settings                  Autonomy and verbosity\n\
+  session                   Session transcript notes (display-only, optional images)\n\
   task                      Start tasks\n\
   controller                Controller loop and restart controls\n\
   context                   Managed-context rewind/backout controls\n\
@@ -2154,6 +2282,34 @@ fn help_settings() {
     );
 }
 
+fn help_session() {
+    println!(
+        "Usage:\n\
+  intendant ctl session note TEXT [--image PATH ...] [--source LABEL] [--session ID]\n\
+\n\
+Run `intendant ctl session note --help` for details."
+    );
+}
+
+fn help_session_note() {
+    println!(
+        "Usage: intendant ctl session note TEXT [--image PATH ...] [--source LABEL] [--session ID]\n\
+\n\
+Post a display-only note into the session transcript. The note shows up\n\
+live in the dashboard and persists for replay; it never enters any model's\n\
+context. Each --image file (png, jpg, jpeg, gif, webp, bmp) is read locally,\n\
+stored in the session upload store, and rendered as a clickable thumbnail.\n\
+Caps: 16 KB text, 6 images, 4 MB per image, 8 MB total.\n\
+\n\
+--session defaults to the calling session (INTENDANT_SESSION_ID or the\n\
+session bound into your injected MCP URL).\n\
+\n\
+Examples:\n\
+  intendant ctl session note \"Milestone: encoder pool rewired\"\n\
+  intendant ctl session note \"Before/after comparison\" --image before.png --image after.png"
+    );
+}
+
 fn help_task() {
     println!(
         "Usage: intendant ctl task start [--task TEXT] [--session ID] [--orchestrate|--direct] [--display-target TARGET] [--frame ID]\n\
@@ -2230,6 +2386,58 @@ mod tests {
         let parsed = parse_command_args(&args(&["-vyeJaE3hyqm4"]), &[], &[])
             .expect("single-dash token is a positional, not a flag");
         assert_eq!(parsed.positional, vec!["-vyeJaE3hyqm4".to_string()]);
+    }
+
+    #[test]
+    fn session_note_args_builds_tool_arguments_with_images() {
+        let dir = tempfile::tempdir().unwrap();
+        let image_path = dir.path().join("shot.png");
+        std::fs::write(&image_path, [0x89u8, b'P', b'N', b'G']).unwrap();
+
+        let value = session_note_args(&args(&[
+            "Milestone",
+            "reached",
+            "--image",
+            image_path.to_str().unwrap(),
+            "--source",
+            "codex",
+            "--session",
+            "sess-1",
+        ]))
+        .unwrap();
+        assert_eq!(value["text"], "Milestone reached");
+        assert_eq!(value["source"], "codex");
+        assert_eq!(value["session_id"], "sess-1");
+        assert_eq!(value["images"][0]["media_type"], "image/png");
+        assert_eq!(value["images"][0]["name"], "shot.png");
+        use base64::Engine as _;
+        assert_eq!(
+            value["images"][0]["data"],
+            base64::engine::general_purpose::STANDARD.encode([0x89u8, b'P', b'N', b'G'])
+        );
+
+        // Text-only notes omit the images key entirely.
+        let value = session_note_args(&args(&["just", "text"])).unwrap();
+        assert_eq!(value["text"], "just text");
+        assert!(value.get("images").is_none());
+    }
+
+    #[test]
+    fn session_note_args_rejects_missing_text_bad_extension_and_missing_file() {
+        let err = session_note_args(&args(&[])).unwrap_err();
+        assert!(err.contains("requires note text"), "{err}");
+
+        let dir = tempfile::tempdir().unwrap();
+        let svg = dir.path().join("vector.svg");
+        std::fs::write(&svg, b"<svg/>").unwrap();
+        let err =
+            session_note_args(&args(&["text", "--image", svg.to_str().unwrap()])).unwrap_err();
+        assert!(err.contains("unsupported image extension"), "{err}");
+
+        let missing = dir.path().join("nope.png");
+        let err =
+            session_note_args(&args(&["text", "--image", missing.to_str().unwrap()])).unwrap_err();
+        assert!(err.contains("failed to read"), "{err}");
     }
 
     #[test]

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -773,6 +773,21 @@ pub enum AppEvent {
         content: String,
         turn: Option<usize>,
     },
+    /// Display-only session note posted by an agent (`post_session_note`
+    /// MCP tool / `intendant ctl session note`). Presentation rail only:
+    /// broadcast to frontends and persisted to the session log, never
+    /// injected into any model conversation (that path is
+    /// [`ContextInjection`]). Attachments reference blobs already
+    /// committed to the session upload store.
+    SessionNote {
+        session_id: Option<String>,
+        note_id: String,
+        text: String,
+        attachments: Vec<crate::types::SessionNoteAttachment>,
+        source: Option<String>,
+        /// Unix epoch milliseconds when the note was posted.
+        ts: u64,
+    },
     /// Active user-message edit rewound already-rendered session context.
     UserMessageRewind {
         session_id: Option<String>,
@@ -2440,6 +2455,21 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
             user_turn_revision: None,
             replacement_for_user_turn_index: None,
         }),
+        AppEvent::SessionNote {
+            session_id,
+            note_id,
+            text,
+            attachments,
+            source,
+            ts,
+        } => Some(OutboundEvent::SessionNote {
+            session_id: session_id.clone(),
+            note_id: note_id.clone(),
+            text: text.clone(),
+            attachments: attachments.clone(),
+            source: source.clone(),
+            ts: *ts,
+        }),
         AppEvent::UserMessageRewind {
             session_id,
             user_turn_index,
@@ -2692,6 +2722,7 @@ fn app_event_writes_to_session_log(event: &AppEvent) -> bool {
             | AppEvent::ApprovalResolved { .. }
             | AppEvent::HumanQuestionDetected { .. }
             | AppEvent::HumanResponseSent
+            | AppEvent::SessionNote { .. }
             | AppEvent::DisplayReady { .. }
             | AppEvent::DisplayResize { .. }
             | AppEvent::DisplayTaken { .. }
@@ -2852,6 +2883,23 @@ fn write_event_to_session_log(session_log: &crate::SharedSessionLog, event: &App
         }
         AppEvent::SubAgentResult { formatted } => {
             log.sub_agent_result(formatted);
+        }
+        AppEvent::SessionNote {
+            session_id,
+            note_id,
+            text,
+            attachments,
+            source,
+            ts,
+        } => {
+            log.session_note(
+                session_id.as_deref(),
+                note_id,
+                text,
+                attachments,
+                source.as_deref(),
+                *ts,
+            );
         }
         AppEvent::RoundComplete {
             round,

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -150,6 +150,7 @@ pub fn spawn_event_listener(
                 match event {
                     AppEvent::Resize(_, _) => {}
                     AppEvent::LogEntry { .. }
+                    | AppEvent::SessionNote { .. }
                     | AppEvent::UserMessageRewind { .. }
                     | AppEvent::UserMessageEditStatus { .. }
                     | AppEvent::UserMessageLog { .. }

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -53,9 +53,16 @@ pub(crate) use tool_gate::*;
 mod tool_params;
 pub(crate) use tool_params::*;
 // tools_managed / tools_display / tools_peer contribute impl-block
-// methods only — nothing importable, so no re-export.
+// methods only — nothing importable, so no re-export. tools_notes also
+// exports the session-note caps, which `intendant ctl session note`
+// enforces client-side (derive, don't mirror).
 mod tools_display;
 mod tools_managed;
+mod tools_notes;
+pub(crate) use tools_notes::{
+    SESSION_NOTE_MAX_IMAGES, SESSION_NOTE_MAX_IMAGE_BYTES, SESSION_NOTE_MAX_TEXT_BYTES,
+    SESSION_NOTE_MAX_TOTAL_IMAGE_BYTES,
+};
 mod tools_peer;
 
 const CONTEXT_PRESSURE_REWIND_THRESHOLD_PCT: f64 = 85.0;
@@ -308,6 +315,17 @@ impl IntendantServer {
             "respond" => {
                 let params = parse_params::<RespondParams>(args)?;
                 Ok(text_tool_result(self.respond(params).await))
+            }
+            "post_session_note" => {
+                let Parameters(params) = parse_params::<PostSessionNoteParams>(
+                    with_default_mcp_session_id(args, session_id),
+                )?;
+                Ok(match self.post_session_note_inner(params).await {
+                    Ok(value) => text_tool_result(value.to_string()),
+                    Err(message) => {
+                        text_tool_error(format!("post_session_note failed: {message}"))
+                    }
+                })
             }
             "set_autonomy" => {
                 let params = parse_params::<SetAutonomyParams>(args)?;

--- a/src/bin/caller/mcp/state.rs
+++ b/src/bin/caller/mcp/state.rs
@@ -46,6 +46,12 @@ pub struct McpAppState {
     pub should_quit: bool,
     /// Session log directory for askHuman files.
     pub log_dir: std::path::PathBuf,
+    /// The daemon's project root, when it serves one. Must match the web
+    /// gateway's `project_root_for_changes` so upload-store writes made by
+    /// MCP tools (`post_session_note` image commits) resolve to the same
+    /// [`crate::global_store::StoreScope`] the gateway's
+    /// `/api/session/current/uploads/<id>/raw` route reads from.
+    pub project_root: Option<std::path::PathBuf>,
     pub(crate) controller_loop_dir_override: Option<std::path::PathBuf>,
     pub(crate) controller_loop_status_override: Option<serde_json::Value>,
     /// Test override for the home that anchors persisted-session lookup
@@ -187,6 +193,7 @@ impl McpAppState {
             human_question: None,
             should_quit: false,
             log_dir,
+            project_root: None,
             controller_loop_dir_override: None,
             controller_loop_status_override: None,
             session_logs_home_override: None,

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -100,6 +100,11 @@ pub(crate) fn tool_allowed_for_profile(name: &str, managed_context: bool, profil
             matches!(
                 name,
                 "get_status"
+                    // Display-only transcript notes are a collaboration
+                    // primitive for supervised backends (the note's images
+                    // travel as base64 tool arguments), so they ride in
+                    // the small profile next to the shared-view set.
+                    | "post_session_note"
                     | "show_shared_view"
                     | "focus_shared_view"
                     | "request_shared_view_input"
@@ -189,8 +194,12 @@ pub(crate) fn mcp_tool_operation(name: &str) -> crate::peer::access_policy::Peer
         | "inspect_rewind_anchor" => PeerOperation::SessionInspect,
         // Resolving supervised approvals.
         "approve" | "deny" | "skip" | "approve_all" => PeerOperation::Approval,
-        // Injecting user-style messages into the session.
-        "respond" => PeerOperation::Message,
+        // Injecting user-style messages into the session — and the agent's
+        // own display-only transcript notes, which are the same
+        // session-surface write from the other direction (low-risk session
+        // output; deliberately reachable by session-scoped supervised
+        // agents, the tool's primary callers).
+        "respond" | "post_session_note" => PeerOperation::Message,
         // Starting or delegating agent work.
         "start_task" => PeerOperation::Task,
         // Mutating the supervised session's context/lineage.
@@ -334,6 +343,14 @@ pub(crate) fn append_manual_http_tool_definitions(
             "claim_fission_canonical",
             "Claim a fission group's canonical branch. Omit expected_canonical_session_id for first-writer-wins; provide it to deliberately compare-and-swap from the current canonical branch.",
             ClaimFissionCanonicalParams
+        ),
+    );
+    push(
+        "post_session_note",
+        manual_http_tool_definition!(
+            "post_session_note",
+            "Post a display-only note into the session transcript, with optional base64 images. The note renders live in the dashboard transcript and persists for replay; it never enters any model's context. Images are committed to the session upload store and rendered as clickable thumbnails. Caps: 16 KB text, 6 images, 4 MB per image, 8 MB total.",
+            PostSessionNoteParams
         ),
     );
     push(
@@ -553,6 +570,46 @@ mod tests {
     }
 
     #[test]
+    fn manual_http_session_note_description_matches_tool_attribute() {
+        // Same drift guard as the rewind/peer tools: post_session_note
+        // lives in a non-router impl block, so the HTTP transport serves
+        // the manual definition while the #[tool] attribute documents the
+        // method; the two copies must not drift.
+        let mut manual = Vec::new();
+        append_manual_http_tool_definitions(&mut manual, true, None);
+        let manual_description = manual
+            .iter()
+            .find(|tool| tool["name"] == "post_session_note")
+            .and_then(|tool| tool["description"].as_str())
+            .expect("missing manual HTTP definition for post_session_note");
+        let attr = IntendantServer::post_session_note_tool_attr();
+        assert_eq!(
+            manual_description,
+            attr.description.as_deref().unwrap_or_default(),
+            "post_session_note manual HTTP description drifted from its #[tool] attribute"
+        );
+    }
+
+    #[test]
+    fn session_note_tool_is_advertised_to_supervised_profiles() {
+        // The tool exists to be called by supervised session-scoped
+        // agents: it must be advertised in the small `core` profile and
+        // in the permissive default/full lists.
+        for profile in [None, Some("full"), Some("core"), Some("codex-core"), Some("cli"), Some("minimal")] {
+            assert!(
+                tool_allowed_for_profile("post_session_note", false, profile),
+                "post_session_note must be listed for profile {profile:?}"
+            );
+        }
+        let mut manual = Vec::new();
+        append_manual_http_tool_definitions(&mut manual, false, Some("core"));
+        assert!(
+            manual.iter().any(|tool| tool["name"] == "post_session_note"),
+            "core-profile manual definitions must include post_session_note"
+        );
+    }
+
+    #[test]
     fn fission_tool_profile_gating_matrix() {
         for name in [
             "fission_spawn",
@@ -607,6 +664,13 @@ mod tests {
         );
         assert_eq!(mcp_tool_operation("approve"), PeerOperation::Approval);
         assert_eq!(mcp_tool_operation("respond"), PeerOperation::Message);
+        // Display-only transcript notes classify with `respond`: a session
+        // message-surface write, deliberately below RuntimeControl so
+        // session-scoped supervised agents (the primary callers) pass.
+        assert_eq!(
+            mcp_tool_operation("post_session_note"),
+            PeerOperation::Message
+        );
         assert_eq!(mcp_tool_operation("start_task"), PeerOperation::Task);
         assert_eq!(
             mcp_tool_operation("rewind_context"),

--- a/src/bin/caller/mcp/tool_params.rs
+++ b/src/bin/caller/mcp/tool_params.rs
@@ -72,6 +72,32 @@ pub struct StartTaskParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct SessionNoteImageParams {
+    /// Image MIME type: image/png, image/jpeg, image/gif, image/webp, or image/bmp.
+    pub media_type: String,
+    /// Base64-encoded image bytes (standard alphabet; an optional data-URL prefix is tolerated).
+    pub data: String,
+    /// Optional display filename for the attachment.
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct PostSessionNoteParams {
+    /// Note text shown in the session transcript. Plain text (rendered escaped).
+    pub text: String,
+    /// Optional target session id. Omit to post into the calling session.
+    #[serde(default, alias = "sessionId")]
+    pub session_id: Option<String>,
+    /// Optional short source label shown on the entry (e.g. "codex"). Defaults to "note".
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Optional images to attach. Each is committed to the session upload store and rendered as a clickable thumbnail.
+    #[serde(default)]
+    pub images: Vec<SessionNoteImageParams>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct RewindContextAnchorParams {
     /// Exact Codex thread item/tool-call id to roll back to. Once a rewind is needed, use list_rewind_anchors first when the id is not already known.
     pub item_id: String,

--- a/src/bin/caller/mcp/tools_notes.rs
+++ b/src/bin/caller/mcp/tools_notes.rs
@@ -1,0 +1,574 @@
+//! The `post_session_note` tool: a display-only note (text + optional
+//! images) an agent posts into its own session transcript.
+//!
+//! Presentation rail only — the note is broadcast as
+//! [`AppEvent::SessionNote`], rendered live by the dashboard, and persisted
+//! to the session log for replay; it is **never** injected into any model
+//! conversation (that path is [`crate::event::ContextInjection`]).
+//!
+//! Images arrive as base64 in the tool arguments (a sandboxed supervised
+//! agent must not be able to make the unsandboxed daemon read arbitrary
+//! file paths, so there deliberately is no path form), are committed into
+//! the calling session's upload store, and travel onward as *references*
+//! (`/api/session/current/uploads/<id>/raw`) — never inline bytes on the
+//! WebSocket or in the session log.
+
+use super::*;
+
+/// Maximum note text size. Notes are transcript annotations, not documents.
+pub(crate) const SESSION_NOTE_MAX_TEXT_BYTES: usize = 16 * 1024;
+/// Maximum number of images per note.
+pub(crate) const SESSION_NOTE_MAX_IMAGES: usize = 6;
+/// Maximum decoded size of a single image.
+pub(crate) const SESSION_NOTE_MAX_IMAGE_BYTES: usize = 4 * 1024 * 1024;
+/// Maximum total decoded image bytes per call. Sized so the base64
+/// encoding (4/3 overhead) plus text and JSON-RPC framing always fits
+/// under the `POST /mcp` body cap — pinned by a test below.
+pub(crate) const SESSION_NOTE_MAX_TOTAL_IMAGE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Raster image MIME types a note may attach. SVG is deliberately
+/// excluded: the `/raw` route serves blobs inline with their stored MIME,
+/// and an inline SVG document executes scripts on the daemon origin when
+/// opened via the thumbnail's click-through link. Raster types cannot.
+const SESSION_NOTE_ALLOWED_MIME: [&str; 5] = [
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "image/bmp",
+];
+
+#[derive(Debug)]
+pub(crate) struct DecodedSessionNoteImage {
+    pub(crate) name: String,
+    pub(crate) mime: String,
+    pub(crate) bytes: Vec<u8>,
+}
+
+fn canonical_note_image_mime(media_type: &str) -> Result<&'static str, String> {
+    let normalized = media_type.trim().to_ascii_lowercase();
+    let normalized = match normalized.as_str() {
+        "image/jpg" => "image/jpeg",
+        other => other,
+    };
+    SESSION_NOTE_ALLOWED_MIME
+        .iter()
+        .find(|mime| **mime == normalized)
+        .copied()
+        .ok_or_else(|| {
+            format!(
+                "unsupported media_type '{media_type}'; supported: {}",
+                SESSION_NOTE_ALLOWED_MIME.join(", ")
+            )
+        })
+}
+
+fn note_image_extension(mime: &str) -> &'static str {
+    match mime {
+        "image/png" => "png",
+        "image/jpeg" => "jpg",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        "image/bmp" => "bmp",
+        _ => "bin",
+    }
+}
+
+/// Decode and validate the base64 images of a `post_session_note` call.
+/// Enforces the count / per-image / total caps and the raster-MIME
+/// allowlist with actionable error messages.
+pub(crate) fn decode_session_note_images(
+    images: &[SessionNoteImageParams],
+) -> Result<Vec<DecodedSessionNoteImage>, String> {
+    use base64::Engine as _;
+
+    if images.len() > SESSION_NOTE_MAX_IMAGES {
+        return Err(format!(
+            "too many images: {} (max {SESSION_NOTE_MAX_IMAGES} per note)",
+            images.len()
+        ));
+    }
+    let mut decoded = Vec::with_capacity(images.len());
+    let mut total_bytes = 0usize;
+    for (index, image) in images.iter().enumerate() {
+        let mime = canonical_note_image_mime(&image.media_type)
+            .map_err(|e| format!("images[{index}]: {e}"))?;
+        // Tolerate a data-URL prefix and embedded whitespace — both are
+        // common in agent-produced base64 — then require valid standard
+        // base64 for the remainder.
+        let raw = image.data.trim();
+        let raw = match raw.split_once("base64,") {
+            Some((prefix, rest)) if prefix.starts_with("data:") => rest,
+            _ => raw,
+        };
+        let compact: String = raw.chars().filter(|c| !c.is_ascii_whitespace()).collect();
+        if compact.is_empty() {
+            return Err(format!("images[{index}]: empty base64 data"));
+        }
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(compact.as_bytes())
+            .map_err(|e| format!("images[{index}]: invalid base64: {e}"))?;
+        if bytes.is_empty() {
+            return Err(format!("images[{index}]: decoded image is empty"));
+        }
+        if bytes.len() > SESSION_NOTE_MAX_IMAGE_BYTES {
+            return Err(format!(
+                "images[{index}]: {} bytes exceeds the {} MB per-image cap",
+                bytes.len(),
+                SESSION_NOTE_MAX_IMAGE_BYTES / (1024 * 1024)
+            ));
+        }
+        total_bytes = total_bytes.saturating_add(bytes.len());
+        if total_bytes > SESSION_NOTE_MAX_TOTAL_IMAGE_BYTES {
+            return Err(format!(
+                "total decoded image size exceeds the {} MB per-note cap",
+                SESSION_NOTE_MAX_TOTAL_IMAGE_BYTES / (1024 * 1024)
+            ));
+        }
+        let name = image
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(crate::upload_store::sanitize_name)
+            .unwrap_or_else(|| format!("note-image-{}.{}", index + 1, note_image_extension(mime)));
+        decoded.push(DecodedSessionNoteImage {
+            name,
+            mime: mime.to_string(),
+            bytes,
+        });
+    }
+    Ok(decoded)
+}
+
+/// Current unix time in milliseconds (0 on a pre-epoch clock).
+fn now_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+impl IntendantServer {
+    #[tool(
+        description = "Post a display-only note into the session transcript, with optional base64 images. The note renders live in the dashboard transcript and persists for replay; it never enters any model's context. Images are committed to the session upload store and rendered as clickable thumbnails. Caps: 16 KB text, 6 images, 4 MB per image, 8 MB total."
+    )]
+    pub(crate) async fn post_session_note(
+        &self,
+        Parameters(params): Parameters<PostSessionNoteParams>,
+    ) -> String {
+        match self.post_session_note_inner(params).await {
+            Ok(value) => value.to_string(),
+            Err(message) => format!("post_session_note failed: {message}"),
+        }
+    }
+
+    /// Core of `post_session_note`, shared by the stdio `#[tool]` method
+    /// and the HTTP dispatch arm (which maps `Err` to an `isError` tool
+    /// result so supervised callers see the refusal reason).
+    pub(crate) async fn post_session_note_inner(
+        &self,
+        params: PostSessionNoteParams,
+    ) -> Result<serde_json::Value, String> {
+        let text = params.text.trim();
+        if text.is_empty() {
+            return Err("note text must not be empty".to_string());
+        }
+        if text.len() > SESSION_NOTE_MAX_TEXT_BYTES {
+            return Err(format!(
+                "note text is {} bytes; max {} KB",
+                text.len(),
+                SESSION_NOTE_MAX_TEXT_BYTES / 1024
+            ));
+        }
+        let source = params
+            .source
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|s| crate::types::truncate_str(s, 48).to_string());
+
+        // The HTTP dispatch injects the URL-bound session id into
+        // `params.session_id` (`with_default_mcp_session_id`), so an
+        // explicit argument wins, then the caller's own session, then the
+        // single-session state fallback.
+        let (session_id, project_root, log_dir) = {
+            let state = self.state.read().await;
+            let session_id = params
+                .session_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .or_else(|| {
+                    let fallback = state.session_id.trim();
+                    if fallback.is_empty() {
+                        None
+                    } else {
+                        Some(fallback.to_string())
+                    }
+                });
+            (session_id, state.project_root.clone(), state.log_dir.clone())
+        };
+        let Some(session_id) = session_id else {
+            return Err(
+                "no session to attach the note to; pass session_id (or call through the \
+                 session-scoped MCP URL Intendant injected)"
+                    .to_string(),
+            );
+        };
+
+        let decoded = decode_session_note_images(&params.images)?;
+
+        // Commit every image into the session's upload-store scope — the
+        // same scope the gateway's `/raw` route resolves, so the URLs in
+        // the note render in every browser now and after replay.
+        let scope = crate::global_store::StoreScope::resolve(project_root.as_deref());
+        let mut attachments: Vec<crate::types::SessionNoteAttachment> = Vec::new();
+        for image in &decoded {
+            let committed = write_note_image_tempfile(&image.bytes).and_then(|tmp| {
+                crate::upload_store::commit_upload(
+                    tmp,
+                    &image.name,
+                    &image.mime,
+                    image.bytes.len() as u64,
+                    crate::upload_store::UploadDestination::Task,
+                    &log_dir,
+                    &session_id,
+                    &scope,
+                )
+                .map_err(|e| format!("failed to store image '{}': {e}", image.name))
+            });
+            match committed {
+                Ok(descriptor) => attachments.push(crate::types::SessionNoteAttachment {
+                    url: format!("/api/session/current/uploads/{}/raw", descriptor.id),
+                    upload_id: descriptor.id,
+                    name: descriptor.name,
+                    mime: descriptor.mime,
+                }),
+                Err(message) => {
+                    // Roll back blobs committed earlier in this call so a
+                    // failed note doesn't strand half its attachments.
+                    for attachment in &attachments {
+                        let _ = crate::upload_store::delete_upload(
+                            &attachment.upload_id,
+                            &log_dir,
+                            &scope,
+                        );
+                    }
+                    return Err(message);
+                }
+            }
+        }
+
+        let note_id = format!("note-{}", Uuid::new_v4().simple());
+        let ts = now_unix_ms();
+        self.bus.send(AppEvent::SessionNote {
+            session_id: Some(session_id.clone()),
+            note_id: note_id.clone(),
+            text: text.to_string(),
+            attachments: attachments.clone(),
+            source,
+            ts,
+        });
+
+        Ok(serde_json::json!({
+            "status": "posted",
+            "note_id": note_id,
+            "session_id": session_id,
+            "attachments": attachments,
+        }))
+    }
+}
+
+fn write_note_image_tempfile(bytes: &[u8]) -> Result<tempfile::NamedTempFile, String> {
+    use std::io::Write as _;
+    let mut tmp =
+        tempfile::NamedTempFile::new().map_err(|e| format!("failed to create tempfile: {e}"))?;
+    tmp.write_all(bytes)
+        .and_then(|_| tmp.flush())
+        .map_err(|e| format!("failed to write image tempfile: {e}"))?;
+    Ok(tmp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine as _;
+
+    fn b64(bytes: &[u8]) -> String {
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    }
+
+    fn image(media_type: &str, data: String, name: Option<&str>) -> SessionNoteImageParams {
+        SessionNoteImageParams {
+            media_type: media_type.to_string(),
+            data,
+            name: name.map(str::to_string),
+        }
+    }
+
+    /// The documented caps must always fit inside the `/mcp` body cap:
+    /// base64 inflates 3 bytes to 4 characters, and the JSON-RPC envelope
+    /// plus maximal text rides along. If someone raises the image caps or
+    /// lowers the body cap, this fails instead of shipping a tool whose
+    /// documented maximum request cannot be transported.
+    #[test]
+    fn documented_caps_fit_inside_mcp_body_cap() {
+        let base64_overhead = SESSION_NOTE_MAX_TOTAL_IMAGE_BYTES.div_ceil(3) * 4;
+        let envelope_headroom = 64 * 1024;
+        assert!(
+            base64_overhead + SESSION_NOTE_MAX_TEXT_BYTES + envelope_headroom
+                < crate::gateway_routes::MCP_BODY_CAP_BYTES,
+            "session-note caps ({} base64 + {} text) exceed the /mcp body cap {}",
+            base64_overhead,
+            SESSION_NOTE_MAX_TEXT_BYTES,
+            crate::gateway_routes::MCP_BODY_CAP_BYTES,
+        );
+    }
+
+    #[test]
+    fn decode_accepts_valid_images_and_data_urls() {
+        let png = vec![0x89u8, b'P', b'N', b'G', 1, 2, 3];
+        let decoded = decode_session_note_images(&[
+            image("image/png", b64(&png), Some("shot one.png")),
+            image("image/jpg", format!("data:image/jpeg;base64,{}", b64(&png)), None),
+            // Whitespace-wrapped base64 (agents often hard-wrap).
+            image("image/webp", format!("{}\n", b64(&png)), None),
+        ])
+        .unwrap();
+        assert_eq!(decoded.len(), 3);
+        assert_eq!(decoded[0].bytes, png);
+        assert_eq!(decoded[0].name, "shot_one.png");
+        assert_eq!(decoded[0].mime, "image/png");
+        // image/jpg normalizes to image/jpeg; unnamed images get a
+        // deterministic extension-correct fallback name.
+        assert_eq!(decoded[1].mime, "image/jpeg");
+        assert_eq!(decoded[1].name, "note-image-2.jpg");
+        assert_eq!(decoded[2].mime, "image/webp");
+    }
+
+    #[test]
+    fn decode_rejects_bad_mime_bad_base64_and_empty_data() {
+        let err = decode_session_note_images(&[image("text/html", b64(b"x"), None)]).unwrap_err();
+        assert!(err.contains("unsupported media_type"), "{err}");
+        // SVG is deliberately not an accepted note attachment type.
+        let err =
+            decode_session_note_images(&[image("image/svg+xml", b64(b"<svg/>"), None)])
+                .unwrap_err();
+        assert!(err.contains("unsupported media_type"), "{err}");
+        let err = decode_session_note_images(&[image("image/png", "!!".to_string(), None)])
+            .unwrap_err();
+        assert!(err.contains("invalid base64"), "{err}");
+        let err =
+            decode_session_note_images(&[image("image/png", "  ".to_string(), None)]).unwrap_err();
+        assert!(err.contains("empty base64"), "{err}");
+    }
+
+    #[test]
+    fn decode_enforces_count_and_size_caps() {
+        let tiny = b64(b"x");
+        let too_many: Vec<SessionNoteImageParams> = (0..SESSION_NOTE_MAX_IMAGES + 1)
+            .map(|_| image("image/png", tiny.clone(), None))
+            .collect();
+        let err = decode_session_note_images(&too_many).unwrap_err();
+        assert!(err.contains("too many images"), "{err}");
+
+        let oversized = vec![0u8; SESSION_NOTE_MAX_IMAGE_BYTES + 1];
+        let err =
+            decode_session_note_images(&[image("image/png", b64(&oversized), None)]).unwrap_err();
+        assert!(err.contains("per-image cap"), "{err}");
+
+        // Three images individually under the per-image cap but over the
+        // total cap together.
+        let chunk = vec![0u8; SESSION_NOTE_MAX_TOTAL_IMAGE_BYTES / 2];
+        let err = decode_session_note_images(&[
+            image("image/png", b64(&chunk), None),
+            image("image/png", b64(&chunk), None),
+            image("image/png", b64(&chunk), None),
+        ])
+        .unwrap_err();
+        assert!(err.contains("per-note cap"), "{err}");
+    }
+
+    fn test_server_with_project(
+        project_root: &std::path::Path,
+        log_dir: &std::path::Path,
+        session_id: &str,
+    ) -> (IntendantServer, EventBus) {
+        let bus = EventBus::new();
+        let mut state = McpAppState::new(
+            "test".into(),
+            "test".into(),
+            crate::autonomy::shared_autonomy(crate::autonomy::AutonomyState::default()),
+            log_dir.to_path_buf(),
+        );
+        state.project_root = Some(project_root.to_path_buf());
+        state.session_id = session_id.to_string();
+        let server = IntendantServer::new(
+            Arc::new(tokio::sync::RwLock::new(state)),
+            bus.clone(),
+        );
+        (server, bus)
+    }
+
+    #[tokio::test]
+    async fn post_session_note_commits_images_and_emits_event() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_root = tmp.path().join("project");
+        let log_dir = tmp.path().join("logs");
+        std::fs::create_dir_all(&project_root).unwrap();
+        std::fs::create_dir_all(&log_dir).unwrap();
+        let (server, bus) = test_server_with_project(&project_root, &log_dir, "");
+        let mut rx = bus.subscribe();
+
+        let png = vec![0x89u8, b'P', b'N', b'G'];
+        let result = server
+            .post_session_note_inner(PostSessionNoteParams {
+                text: "Milestone: encoder pool rewired".to_string(),
+                session_id: Some("sess-7".to_string()),
+                source: Some("codex".to_string()),
+                images: vec![SessionNoteImageParams {
+                    media_type: "image/png".to_string(),
+                    data: b64(&png),
+                    name: Some("pool.png".to_string()),
+                }],
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result["status"], "posted");
+        assert_eq!(result["session_id"], "sess-7");
+        let note_id = result["note_id"].as_str().unwrap();
+        assert!(note_id.starts_with("note-"), "{note_id}");
+        let upload_id = result["attachments"][0]["upload_id"].as_str().unwrap();
+        assert_eq!(
+            result["attachments"][0]["url"],
+            format!("/api/session/current/uploads/{upload_id}/raw")
+        );
+
+        // The blob must land in the same scope the gateway's /raw route
+        // resolves for this project root, under the note's session id,
+        // with the bytes intact.
+        let scope = crate::global_store::StoreScope::resolve(Some(&project_root));
+        let descriptor =
+            crate::upload_store::find_upload(upload_id, &log_dir, &scope).expect("blob committed");
+        assert_eq!(descriptor.session_id, "sess-7");
+        assert_eq!(descriptor.mime, "image/png");
+        assert_eq!(std::fs::read(&descriptor.path).unwrap(), png);
+
+        match rx.try_recv().expect("SessionNote broadcast") {
+            AppEvent::SessionNote {
+                session_id,
+                note_id: event_note_id,
+                text,
+                attachments,
+                source,
+                ts,
+            } => {
+                assert_eq!(session_id.as_deref(), Some("sess-7"));
+                assert_eq!(event_note_id, note_id);
+                assert_eq!(text, "Milestone: encoder pool rewired");
+                assert_eq!(attachments.len(), 1);
+                assert_eq!(attachments[0].upload_id, upload_id);
+                assert_eq!(attachments[0].name, "pool.png");
+                assert!(ts > 0);
+                assert_eq!(source.as_deref(), Some("codex"));
+            }
+            other => panic!("expected SessionNote, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn post_session_note_requires_text_and_some_session() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (server, _bus) = test_server_with_project(tmp.path(), tmp.path(), "");
+
+        let err = server
+            .post_session_note_inner(PostSessionNoteParams {
+                text: "   ".to_string(),
+                session_id: Some("sess".to_string()),
+                source: None,
+                images: vec![],
+            })
+            .await
+            .unwrap_err();
+        assert!(err.contains("must not be empty"), "{err}");
+
+        let err = server
+            .post_session_note_inner(PostSessionNoteParams {
+                text: "hello".to_string(),
+                session_id: None,
+                source: None,
+                images: vec![],
+            })
+            .await
+            .unwrap_err();
+        assert!(err.contains("no session"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn post_session_note_falls_back_to_state_session() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (server, bus) = test_server_with_project(tmp.path(), tmp.path(), "state-sess");
+        let mut rx = bus.subscribe();
+        let result = server
+            .post_session_note_inner(PostSessionNoteParams {
+                text: "text-only note".to_string(),
+                session_id: None,
+                source: None,
+                images: vec![],
+            })
+            .await
+            .unwrap();
+        assert_eq!(result["session_id"], "state-sess");
+        assert_eq!(result["attachments"].as_array().unwrap().len(), 0);
+        match rx.try_recv().unwrap() {
+            AppEvent::SessionNote {
+                session_id, source, ..
+            } => {
+                assert_eq!(session_id.as_deref(), Some("state-sess"));
+                assert_eq!(source, None);
+            }
+            other => panic!("expected SessionNote, got {other:?}"),
+        }
+    }
+
+    /// The tool must be callable through the generic HTTP dispatch path
+    /// (the `/mcp` transport ctl and supervised agents use), with the
+    /// URL-bound session id injected when the args omit one, and must
+    /// surface validation failures as `isError` tool results.
+    #[tokio::test]
+    async fn post_session_note_dispatches_by_name_with_url_session() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (server, bus) = test_server_with_project(tmp.path(), tmp.path(), "");
+        let mut rx = bus.subscribe();
+        let result = server
+            .call_tool_by_name_for_session(
+                "post_session_note",
+                serde_json::json!({ "text": "from dispatch" }),
+                Some("url-sess"),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_ne!(result.is_error, Some(true));
+        match rx.try_recv().unwrap() {
+            AppEvent::SessionNote { session_id, .. } => {
+                assert_eq!(session_id.as_deref(), Some("url-sess"));
+            }
+            other => panic!("expected SessionNote, got {other:?}"),
+        }
+
+        let result = server
+            .call_tool_by_name_for_session(
+                "post_session_note",
+                serde_json::json!({ "text": "" }),
+                Some("url-sess"),
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.is_error, Some(true));
+    }
+}

--- a/src/bin/caller/peer/upcast.rs
+++ b/src/bin/caller/peer/upcast.rs
@@ -80,6 +80,17 @@ pub(crate) fn log_event(level: LogLevel, source: &str, message: String) -> PeerE
     }
 }
 
+/// Peer-facing text for a display-only session note: the note body plus a
+/// count marker for attachments, whose `/api/session/current/uploads/*`
+/// URLs only resolve against the origin daemon.
+pub(crate) fn session_note_peer_log_text(text: &str, attachment_count: usize) -> String {
+    match attachment_count {
+        0 => text.to_string(),
+        1 => format!("{text} [1 image attachment]"),
+        n => format!("{text} [{n} image attachments]"),
+    }
+}
+
 /// Map Intendant's internal multi-source `LogLevel` to the peer
 /// module's 5-level vocabulary. Source-specific variants
 /// (Model/Agent/SubAgent) collapse to `Info` because the peer Log
@@ -1508,6 +1519,20 @@ impl AppEventUpcaster {
                 };
                 vec![log_event(log_level, source, content.clone())]
             }
+            // Display-only session note: forward the text as peer log
+            // activity. Attachment URLs are daemon-local (`/api/session/
+            // current/uploads/.../raw` on the origin daemon), so peers get
+            // a count marker instead of unreachable references.
+            AppEvent::SessionNote {
+                text,
+                attachments,
+                source,
+                ..
+            } => vec![log_event(
+                LogLevel::Info,
+                source.as_deref().unwrap_or("note"),
+                session_note_peer_log_text(text, attachments.len()),
+            )],
             AppEvent::UserMessageRewind {
                 user_turn_index,
                 turns_removed,
@@ -2791,6 +2816,19 @@ impl WireEventUpcaster {
             } => {
                 vec![log_event(wire_log_level(level), source, content.clone())]
             }
+            // Same treatment as the AppEvent-side arm: note text as peer
+            // log activity, attachments as a count (their URLs only
+            // resolve on the origin daemon).
+            OutboundEvent::SessionNote {
+                text,
+                attachments,
+                source,
+                ..
+            } => vec![log_event(
+                LogLevel::Info,
+                source.as_deref().unwrap_or("note"),
+                session_note_peer_log_text(text, attachments.len()),
+            )],
             OutboundEvent::UserMessageRewind {
                 user_turn_index,
                 turns_removed,

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -1047,6 +1047,7 @@ pub fn filter_event(event: &AppEvent, last_phase: &mut String) -> Option<Presenc
         | AppEvent::LiveUsageUpdate { .. }
         | AppEvent::StatusUpdate { .. }
         | AppEvent::LogEntry { .. }
+        | AppEvent::SessionNote { .. }
         | AppEvent::UserMessageRewind { .. }
         | AppEvent::UserMessageEditStatus { .. }
         | AppEvent::UserMessageLog { .. }

--- a/src/bin/caller/session_log/bus_events.rs
+++ b/src/bin/caller/session_log/bus_events.rs
@@ -206,6 +206,66 @@ impl SessionLog {
         );
     }
 
+    /// Persist a display-only session note (`AppEvent::SessionNote`).
+    ///
+    /// The full note text and the attachment *references* live in `data`;
+    /// `message` carries a short preview for plain-log readers. Replay
+    /// reconstructs the event via `session_log_entry_to_app_event` so a
+    /// rehydrated session renders the note exactly like the live path.
+    /// Attachment blobs themselves persist in the session upload store.
+    pub fn session_note(
+        &mut self,
+        session_id: Option<&str>,
+        note_id: &str,
+        text: &str,
+        attachments: &[crate::types::SessionNoteAttachment],
+        source: Option<&str>,
+        ts_ms: u64,
+    ) {
+        let mut data = serde_json::Map::new();
+        if let Some(session_id) = session_id.map(str::trim).filter(|s| !s.is_empty()) {
+            data.insert(
+                "session_id".to_string(),
+                serde_json::Value::String(session_id.to_string()),
+            );
+        }
+        data.insert(
+            "note_id".to_string(),
+            serde_json::Value::String(note_id.to_string()),
+        );
+        data.insert(
+            "text".to_string(),
+            serde_json::Value::String(text.to_string()),
+        );
+        if let Some(source) = source.map(str::trim).filter(|s| !s.is_empty()) {
+            data.insert(
+                "source".to_string(),
+                serde_json::Value::String(source.to_string()),
+            );
+        }
+        data.insert("ts_ms".to_string(), serde_json::Value::from(ts_ms));
+        if !attachments.is_empty() {
+            data.insert(
+                "attachments".to_string(),
+                serde_json::to_value(attachments).unwrap_or(serde_json::Value::Null),
+            );
+        }
+        self.emit(LogEvent {
+            ts: Self::ts(),
+            turn: if self.current_turn > 0 {
+                Some(self.current_turn)
+            } else {
+                None
+            },
+            event: "session_note".to_string(),
+            level: Some("info".to_string()),
+            message: Some(format!("Note: {}", log_preview(text, 160))),
+            data: Some(serde_json::Value::Object(data)),
+            file: None,
+            file2: None,
+        });
+    }
+
     /// Log a new session starting (MCP multi-task).
     pub fn session_started(&mut self, session_id: &str, task: Option<&str>) {
         self.emit(LogEvent {

--- a/src/bin/caller/session_log/replay.rs
+++ b/src/bin/caller/session_log/replay.rs
@@ -599,6 +599,43 @@ pub fn session_log_entry_to_app_event(
                 .map(String::from);
             Some(AppEvent::SessionStarted { session_id, task })
         }
+        "session_note" => {
+            let session_id = data
+                .and_then(|d| d.get("session_id"))
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let note_id = data
+                .and_then(|d| d.get("note_id"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let text = data
+                .and_then(|d| d.get("text"))
+                .and_then(|v| v.as_str())
+                .unwrap_or(message.strip_prefix("Note: ").unwrap_or(message))
+                .to_string();
+            let attachments = data
+                .and_then(|d| d.get("attachments"))
+                .cloned()
+                .and_then(|value| serde_json::from_value(value).ok())
+                .unwrap_or_default();
+            let source = data
+                .and_then(|d| d.get("source"))
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let ts = data
+                .and_then(|d| d.get("ts_ms"))
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            Some(AppEvent::SessionNote {
+                session_id,
+                note_id,
+                text,
+                attachments,
+                source,
+                ts,
+            })
+        }
         "session_identity" => {
             let session_id = data
                 .and_then(|d| d.get("session_id"))
@@ -1200,6 +1237,64 @@ mod tests {
             }
             other => panic!("expected SteerRequested, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn rt_session_note_preserves_text_and_attachment_refs() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let mut log = SessionLog::open(log_dir.clone()).unwrap();
+        let attachments = vec![crate::types::SessionNoteAttachment {
+            upload_id: "u-1".to_string(),
+            name: "diagram.png".to_string(),
+            mime: "image/png".to_string(),
+            url: "/api/session/current/uploads/u-1/raw".to_string(),
+        }];
+        let text = "Milestone reached.\nSee the attached diagram for the new topology.";
+        log.session_note(
+            Some("thread-9"),
+            "note-1",
+            text,
+            &attachments,
+            Some("codex"),
+            1_752_000_000_123,
+        );
+        drop(log);
+
+        let entry = read_last_event(&log_dir, "session_note");
+        match session_log_entry_to_app_event(&entry, &log_dir).unwrap() {
+            AppEvent::SessionNote {
+                session_id,
+                note_id,
+                text: replayed,
+                attachments: replayed_attachments,
+                source,
+                ts,
+            } => {
+                assert_eq!(session_id.as_deref(), Some("thread-9"));
+                assert_eq!(note_id, "note-1");
+                assert_eq!(replayed, text);
+                assert_eq!(replayed_attachments, attachments);
+                assert_eq!(source.as_deref(), Some("codex"));
+                assert_eq!(ts, 1_752_000_000_123);
+            }
+            other => panic!("expected SessionNote, got {:?}", other),
+        }
+
+        // The replay entry must survive the full browser-entry pipeline
+        // (AppEvent -> OutboundEvent -> tagged JSON) with the wire shape
+        // the dashboard consumes.
+        let app_event = session_log_entry_to_app_event(&entry, &log_dir).unwrap();
+        let outbound = crate::event::app_event_to_outbound(&app_event).unwrap();
+        let value = serde_json::to_value(&outbound).unwrap();
+        assert_eq!(value["event"], "session_note");
+        assert_eq!(value["note_id"], "note-1");
+        assert_eq!(value["text"], text);
+        assert_eq!(value["attachments"][0]["upload_id"], "u-1");
+        assert_eq!(
+            value["attachments"][0]["url"],
+            "/api/session/current/uploads/u-1/raw"
+        );
     }
 
     #[test]

--- a/src/bin/caller/startup/mcp_mode.rs
+++ b/src/bin/caller/startup/mcp_mode.rs
@@ -140,6 +140,8 @@ pub(crate) async fn run_mcp_mode(
     mcp_app_state.codex_managed_context =
         project::codex_managed_context_enabled(&project.config.agent.codex.managed_context);
     mcp_app_state.configured_codex_managed_context = mcp_app_state.codex_managed_context;
+    // Matches the project root the gateway above serves uploads from.
+    mcp_app_state.project_root = Some(project.root.clone());
     mcp_app_state.context_window = provider.as_ref().map(|p| p.context_window()).unwrap_or(0);
     mcp_app_state.hard_context_window = provider.as_ref().map(|p| p.context_window());
     mcp_app_state.session_id = session_log

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -280,6 +280,9 @@ pub(crate) fn spawn_mode_web_gateway(
     mcp_http_state.codex_managed_context =
         project::codex_managed_context_enabled(&project.config.agent.codex.managed_context);
     mcp_http_state.configured_codex_managed_context = mcp_http_state.codex_managed_context;
+    // Same value as ActiveSessionState.project_root_for_changes above, so
+    // MCP upload-store writes resolve to the scope the gateway serves.
+    mcp_http_state.project_root = project_root.clone();
     mcp_http_state.frame_registry = Some(frame_registry.clone());
     mcp_http_state.session_registry = Some(session_registry.clone());
     mcp_http_state.peer_registry = Some(peer_registry.clone());

--- a/src/bin/caller/types.rs
+++ b/src/bin/caller/types.rs
@@ -183,6 +183,24 @@ fn default_true() -> bool {
     true
 }
 
+/// One image attached to a display-only session note. A *reference* to a
+/// blob committed into the session's upload store — never inline bytes:
+/// the WebSocket broadcast and the session log both stay small, and the
+/// browser fetches the pixels lazily from `url` (the upload store's
+/// existing `/raw` route, which serves the stored MIME inline).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionNoteAttachment {
+    /// Upload-store descriptor id the blob was committed under.
+    pub upload_id: String,
+    /// Display filename (sanitized).
+    pub name: String,
+    /// Image MIME type (`image/png`, ...).
+    pub mime: String,
+    /// Same-origin URL that serves the blob
+    /// (`/api/session/current/uploads/<id>/raw`).
+    pub url: String,
+}
+
 /// Events sent to connected control socket clients, web gateway, and MCP.
 ///
 /// Also deserialized by `crate::peer::upcast::OutboundEventUpcaster`
@@ -663,6 +681,27 @@ pub enum OutboundEvent {
         user_turn_revision: Option<u32>,
         #[serde(skip_serializing_if = "Option::is_none")]
         replacement_for_user_turn_index: Option<u32>,
+    },
+    /// Display-only note an agent posted into its session transcript
+    /// (`post_session_note` MCP tool / `intendant ctl session note`).
+    /// Never enters any model's context — this is a presentation rail:
+    /// the dashboard renders it as a distinct transcript entry and the
+    /// session log persists it for replay. Attachments are references
+    /// to session upload-store blobs, never inline bytes.
+    SessionNote {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session_id: Option<String>,
+        note_id: String,
+        text: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        attachments: Vec<SessionNoteAttachment>,
+        /// Short label shown on the entry (e.g. "codex"); defaults to
+        /// "note" in the dashboard when absent.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+        /// Unix epoch milliseconds when the note was posted.
+        #[serde(default)]
+        ts: u64,
     },
     /// Live user-message edit rewound an active external-agent session.
     UserMessageRewind {

--- a/static/app.html
+++ b/static/app.html
@@ -50129,6 +50129,17 @@ function handleSessionNoteEvent(d) {
   stationScheduleUpdate();
 }
 
+// QA readback (window.qa convention): the dashboard validator exercises
+// the note rail's module-scoped pieces directly — the attachment strip
+// (including its deleted-blob chip degradation) and the wire-event
+// normalizer. Side-effect-free beyond the DOM node the caller passes in.
+window.qa = Object.assign(window.qa || {}, {
+  sessionNotes: {
+    renderStrip: (target, c) => appendLogAttachmentStrip(target, c),
+    logCommand: (d) => sessionNoteLogCommand(d),
+  },
+});
+
 // Bootstrap-replay adapter: the WASM activity-feed pipeline only carries
 // log_entry-shaped replay rows (AddLogEntry has no attachment fields), so
 // session_note entries replay as note-styled text entries; the session

--- a/static/app.html
+++ b/static/app.html
@@ -10979,6 +10979,29 @@ body.display-fullscreen-open {
   color: var(--subtext1);
   font-size: 11px;
 }
+.log-attachment-link {
+  display: inline-flex;
+  line-height: 0;
+  border-radius: 4px;
+}
+.log-attachment-link:hover .log-attachment-thumb {
+  border-color: var(--blue);
+}
+.log-attachment-missing {
+  border-style: dashed;
+  color: var(--overlay0);
+  font-style: italic;
+}
+/* Display-only session notes (post_session_note / ctl session note):
+   subtle accent so agent annotations read apart from run output. */
+.log-entry[data-kind="session_note"] {
+  border-left: 2px solid var(--mauve);
+  background: color-mix(in srgb, var(--mauve) 6%, transparent);
+  border-radius: 0 4px 4px 0;
+}
+.log-entry[data-kind="session_note"] > .log-level {
+  color: var(--mauve);
+}
 .pending-attachment-chip .chip-remove {
   width: 14px;
   height: 14px;
@@ -25780,6 +25803,8 @@ const DASHBOARD_DEDUPABLE_EVENT_NAMES = new Set([
   'user_display_granted',
   'user_display_revoked',
   'shared_view',
+  // Unique note_id per note makes the JSON.stringify dedupe key exact.
+  'session_note',
   'recording_started',
   'recording_stopped',
   'recording_deleted',
@@ -37301,6 +37326,12 @@ async function main() {
         handleSharedViewEvent(d);
         return;
       }
+      if (d.event === 'session_note') {
+        // Display-only transcript note: rendered end to end in JS (the
+        // WASM presence layer does not know this event).
+        handleSessionNoteEvent(d);
+        return;
+      }
       if (d.t === 'browser_workspace_snapshot' || d.event === 'browser_workspace_changed') {
         handleBrowserWorkspaceMessage(d);
         return;
@@ -37322,7 +37353,13 @@ async function main() {
         const wasProcessingLogReplay = processingLogReplay;
         processingLogReplay = true;
         try {
-          const cmds = app.handle_server_message(filtered);
+          // session_note entries ride the WASM pipeline as note-styled
+          // log_entry rows (see sessionNoteReplayEntryToLogEntry) so the
+          // replayed transcript keeps chronological order.
+          const cmds = app.handle_server_message({
+            ...filtered,
+            entries: filtered.entries.map(sessionNoteReplayEntryToLogEntry),
+          });
           if (cmds) processCommands(cmds);
         } finally {
           processingLogReplay = wasProcessingLogReplay;
@@ -44021,6 +44058,18 @@ function sessionWindowRecordFromReplayEntry(entry = {}, fallbackSessionId = '') 
     if (!content) return null;
     return { ...base, level: level || 'info', source: source || 'system', content, kind, output_id: entry.output_id || entry.outputId || '' };
   }
+  if (event === 'session_note') {
+    const noteText = String(entry.text || content || '').trim();
+    if (!noteText) return null;
+    return {
+      ...base,
+      level: 'info',
+      source: source || 'note',
+      content: noteText,
+      kind: 'session_note',
+      attachment_previews: sessionNoteAttachmentPreviews(entry),
+    };
+  }
   if (event === 'model_response') {
     if (!content) {
       const reasoning = String(entry.reasoning_summary || entry.reasoningSummary || '').trim();
@@ -46478,6 +46527,7 @@ function buildSessionWindowLogEntry(c) {
   cnt.className = 'log-content';
   renderLogContentElement(cnt, c);
   appendLogStateBadges(cnt, c);
+  appendLogAttachmentStrip(cnt, c);
   entry.appendChild(cnt);
   appendCopyLogEntryButton(entry, c.content ?? '');
   appendEditUserMessageButton(entry, c);
@@ -48692,6 +48742,7 @@ function sessionWindowRecordFromLogCommand(c) {
     superseded: !!c?.superseded,
     superseded_reason: c?.superseded_reason || c?.supersededReason || '',
     collapsible: !!c?.collapsible,
+    attachment_previews: Array.isArray(c?.attachment_previews) ? c.attachment_previews : [],
   };
 }
 
@@ -49977,6 +50028,130 @@ function appendEditUserMessageButton(entry, c) {
   entry.appendChild(btn);
 }
 
+// Render a log entry's attachment previews as a thumbnail strip.
+// Each preview is { dataUrl?, url?, name?, note?, frameId?, mime? }:
+// `dataUrl` (a data: URL or a same-origin /raw URL) renders as an <img>;
+// `url` additionally wraps the thumb in a click-through link that opens
+// the blob in a new tab. A preview without pixels — or one whose blob was
+// deleted from the upload store (the <img> error path) — degrades to a
+// named chip instead of a broken image.
+function appendLogAttachmentStrip(cnt, c) {
+  const attachmentPreviews = Array.isArray(c?.attachment_previews) ? c.attachment_previews : [];
+  if (attachmentPreviews.length === 0) return;
+  const strip = document.createElement('div');
+  strip.className = 'log-attachment-strip';
+  const missingChip = (att) => {
+    const chip = document.createElement('span');
+    chip.className = 'log-attachment-file';
+    chip.textContent = (att && (att.name || att.frameId)) || 'attachment';
+    return chip;
+  };
+  for (const att of attachmentPreviews) {
+    if (att && att.dataUrl) {
+      const img = document.createElement('img');
+      img.className = 'log-attachment-thumb';
+      img.loading = 'lazy';
+      img.src = att.dataUrl;
+      img.alt = '';
+      img.title = att.note || att.name || att.frameId || 'attachment';
+      let holder = img;
+      if (att.url) {
+        const link = document.createElement('a');
+        link.className = 'log-attachment-link';
+        link.href = att.url;
+        link.target = '_blank';
+        link.rel = 'noopener';
+        link.title = img.title;
+        link.appendChild(img);
+        holder = link;
+      }
+      img.addEventListener('error', () => {
+        const chip = missingChip(att);
+        chip.classList.add('log-attachment-missing');
+        chip.title = 'attachment unavailable (blob deleted from the upload store)';
+        holder.replaceWith(chip);
+      }, { once: true });
+      strip.appendChild(holder);
+    } else {
+      strip.appendChild(missingChip(att));
+    }
+  }
+  cnt.appendChild(strip);
+}
+
+// ── Session notes (display-only transcript notes) ──
+// Wire shape: { event: 'session_note', session_id, note_id, text,
+// attachments: [{upload_id, name, mime, url}], source?, ts }.
+// Rendered as an ordinary log entry with kind 'session_note' (distinct
+// styling via .log-entry[data-kind=session_note]) and the attachment
+// strip fed by the upload-store /raw URLs.
+
+function sessionNoteAttachmentPreviews(d) {
+  const attachments = Array.isArray(d?.attachments) ? d.attachments : [];
+  return attachments.map(att => ({
+    dataUrl: att?.url || '',
+    url: att?.url || '',
+    name: att?.name || 'image',
+    mime: att?.mime || '',
+  }));
+}
+
+// Normalize a session_note wire event (live WS or a raw replay/session-
+// detail entry) into the log-command shape renderLogEntry consumes.
+function sessionNoteLogCommand(d) {
+  const text = String(d?.text ?? d?.content ?? '').trim();
+  if (!text) return null;
+  const tsMs = Number(d?.ts_ms ?? d?.tsMs ?? d?.ts);
+  return {
+    session_id: String(d?.session_id || d?.sessionId || '').trim(),
+    level: 'info',
+    source: String(d?.source || '').trim() || 'note',
+    kind: 'session_note',
+    content: text,
+    note_id: d?.note_id || d?.noteId || '',
+    event_id: d?.event_id || d?.eventId || (d?.note_id ? `session-note:${d.note_id}` : ''),
+    delivery: d?.delivery || d?.delivery_class || d?.deliveryClass || '',
+    // Raw wire events carry unix-ms in `ts`; replay entries carry the
+    // session log's HH:MM:SS string there instead, so only accept numbers.
+    ts_ms: Number.isFinite(tsMs) && tsMs > 0 ? tsMs : undefined,
+    ts: typeof d?.ts === 'string' ? d.ts : '',
+    attachment_previews: sessionNoteAttachmentPreviews(d),
+  };
+}
+
+// Live-path handler for the session_note WS event (the WASM presence
+// layer does not know this event; the JS owns its rendering end to end).
+function handleSessionNoteEvent(d) {
+  const c = sessionNoteLogCommand(d);
+  if (!c) return;
+  stationPushLogEvent(c);
+  renderLogEntry(c);
+  stationScheduleUpdate();
+}
+
+// Bootstrap-replay adapter: the WASM activity-feed pipeline only carries
+// log_entry-shaped replay rows (AddLogEntry has no attachment fields), so
+// session_note entries replay as note-styled text entries; the session
+// windows and the Sessions detail view re-attach the thumbnails from the
+// raw entries. The content deliberately stays byte-identical to the raw
+// note text so the transcript-signature dedupe collapses this row with
+// the attachment-bearing record the external window sync later inserts.
+// Everything else passes through untouched.
+function sessionNoteReplayEntryToLogEntry(entry) {
+  if (!entry || entry.event !== 'session_note') return entry;
+  return {
+    event: 'log_entry',
+    level: 'info',
+    source: String(entry.source || '').trim() || 'note',
+    kind: 'session_note',
+    content: String(entry.text || '').trim(),
+    session_id: entry.session_id || '',
+    ts: entry.ts,
+    event_id: entry.event_id || '',
+    delivery: entry.delivery || '',
+  };
+}
+
 function renderLogEntry(c) {
   if (isCommandOutputLog(c)) {
     inferSessionPhaseFromLog(c);
@@ -50000,34 +50175,13 @@ function renderLogEntry(c) {
   appendLogStateBadges(cnt, c);
 
   const hasImages = c.images && c.images.length > 0;
-  const attachmentPreviews = Array.isArray(c.attachment_previews) ? c.attachment_previews : [];
   if (hasImages) {
     const badge = document.createElement('span');
     badge.className = 'log-image-badge';
     badge.textContent = c.images.length === 1 ? '[screenshot]' : '[' + c.images.length + ' screenshots]';
     cnt.appendChild(badge);
   }
-  if (attachmentPreviews.length > 0) {
-    const strip = document.createElement('div');
-    strip.className = 'log-attachment-strip';
-    for (const att of attachmentPreviews) {
-      if (att && att.dataUrl) {
-        const img = document.createElement('img');
-        img.className = 'log-attachment-thumb';
-        img.loading = 'lazy';
-        img.src = att.dataUrl;
-        img.alt = '';
-        img.title = att.note || att.name || att.frameId || 'attachment';
-        strip.appendChild(img);
-      } else {
-        const chip = document.createElement('span');
-        chip.className = 'log-attachment-file';
-        chip.textContent = (att && (att.name || att.frameId)) || 'attachment';
-        strip.appendChild(chip);
-      }
-    }
-    cnt.appendChild(strip);
-  }
+  appendLogAttachmentStrip(cnt, c);
 
   entry.appendChild(cnt);
   appendCopyLogEntryButton(entry, c.content ?? '');
@@ -87514,7 +87668,15 @@ function buildSessionDetailRows(entries) {
   let lastTurn = null;
   const visibleLevels = sessionDetailVisibleLevels();
 
-  for (const e of entries || []) {
+  for (let e of entries || []) {
+    // Display-only session notes carry their body in `text` and their
+    // image references in `attachments`; normalize them into the generic
+    // record shape (content + attachment_previews) the renderer expects.
+    if (e && e.event === 'session_note') {
+      const note = sessionNoteLogCommand(e);
+      if (!note) continue;
+      e = { ...e, ...note };
+    }
     const level = e.level || 'info';
     if (!visibleLevels.includes(level)) continue;
     if (!sessionDetailEntryMatchesLogFilter(e)) continue;
@@ -87729,6 +87891,7 @@ function materializeSessionDetailRow(view, row, index) {
   const entry = document.createElement('div');
   entry.className = 'log-entry level-' + e.level;
   entry.dataset.detailRowIndex = String(index);
+  if (e.kind) entry.dataset.kind = e.kind;
   const sourceClass = String(e.source).toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
   if (sourceClass) entry.classList.add('source-' + sourceClass);
   if (e.session_id) entry.dataset.sessionId = e.session_id;
@@ -87794,6 +87957,7 @@ function materializeSessionDetailRow(view, row, index) {
     content: e.content
   });
   appendLogStateBadges(cnt, e);
+  appendLogAttachmentStrip(cnt, e);
   if (sessionDetailLevelColors[e.level]) cnt.style.color = sessionDetailLevelColors[e.level];
 
   entry.appendChild(ts);

--- a/static/app/14-styles-displays-voice.css
+++ b/static/app/14-styles-displays-voice.css
@@ -847,6 +847,29 @@ body.display-fullscreen-open {
   color: var(--subtext1);
   font-size: 11px;
 }
+.log-attachment-link {
+  display: inline-flex;
+  line-height: 0;
+  border-radius: 4px;
+}
+.log-attachment-link:hover .log-attachment-thumb {
+  border-color: var(--blue);
+}
+.log-attachment-missing {
+  border-style: dashed;
+  color: var(--overlay0);
+  font-style: italic;
+}
+/* Display-only session notes (post_session_note / ctl session note):
+   subtle accent so agent annotations read apart from run output. */
+.log-entry[data-kind="session_note"] {
+  border-left: 2px solid var(--mauve);
+  background: color-mix(in srgb, var(--mauve) 6%, transparent);
+  border-radius: 0 4px 4px 0;
+}
+.log-entry[data-kind="session_note"] > .log-level {
+  color: var(--mauve);
+}
 .pending-attachment-chip .chip-remove {
   width: 14px;
   height: 14px;

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -707,6 +707,8 @@ const DASHBOARD_DEDUPABLE_EVENT_NAMES = new Set([
   'user_display_granted',
   'user_display_revoked',
   'shared_view',
+  // Unique note_id per note makes the JSON.stringify dedupe key exact.
+  'session_note',
   'recording_started',
   'recording_stopped',
   'recording_deleted',

--- a/static/app/36-voice-wasm-init.js
+++ b/static/app/36-voice-wasm-init.js
@@ -388,6 +388,12 @@ async function main() {
         handleSharedViewEvent(d);
         return;
       }
+      if (d.event === 'session_note') {
+        // Display-only transcript note: rendered end to end in JS (the
+        // WASM presence layer does not know this event).
+        handleSessionNoteEvent(d);
+        return;
+      }
       if (d.t === 'browser_workspace_snapshot' || d.event === 'browser_workspace_changed') {
         handleBrowserWorkspaceMessage(d);
         return;
@@ -409,7 +415,13 @@ async function main() {
         const wasProcessingLogReplay = processingLogReplay;
         processingLogReplay = true;
         try {
-          const cmds = app.handle_server_message(filtered);
+          // session_note entries ride the WASM pipeline as note-styled
+          // log_entry rows (see sessionNoteReplayEntryToLogEntry) so the
+          // replayed transcript keeps chronological order.
+          const cmds = app.handle_server_message({
+            ...filtered,
+            entries: filtered.entries.map(sessionNoteReplayEntryToLogEntry),
+          });
           if (cmds) processCommands(cmds);
         } finally {
           processingLogReplay = wasProcessingLogReplay;

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -1303,6 +1303,18 @@ function sessionWindowRecordFromReplayEntry(entry = {}, fallbackSessionId = '') 
     if (!content) return null;
     return { ...base, level: level || 'info', source: source || 'system', content, kind, output_id: entry.output_id || entry.outputId || '' };
   }
+  if (event === 'session_note') {
+    const noteText = String(entry.text || content || '').trim();
+    if (!noteText) return null;
+    return {
+      ...base,
+      level: 'info',
+      source: source || 'note',
+      content: noteText,
+      kind: 'session_note',
+      attachment_previews: sessionNoteAttachmentPreviews(entry),
+    };
+  }
   if (event === 'model_response') {
     if (!content) {
       const reasoning = String(entry.reasoning_summary || entry.reasoningSummary || '').trim();

--- a/static/app/40-session-launch.js
+++ b/static/app/40-session-launch.js
@@ -1025,6 +1025,7 @@ function buildSessionWindowLogEntry(c) {
   cnt.className = 'log-content';
   renderLogContentElement(cnt, c);
   appendLogStateBadges(cnt, c);
+  appendLogAttachmentStrip(cnt, c);
   entry.appendChild(cnt);
   appendCopyLogEntryButton(entry, c.content ?? '');
   appendEditUserMessageButton(entry, c);

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -710,6 +710,7 @@ function sessionWindowRecordFromLogCommand(c) {
     superseded: !!c?.superseded,
     superseded_reason: c?.superseded_reason || c?.supersededReason || '',
     collapsible: !!c?.collapsible,
+    attachment_previews: Array.isArray(c?.attachment_previews) ? c.attachment_previews : [],
   };
 }
 
@@ -1995,6 +1996,130 @@ function appendEditUserMessageButton(entry, c) {
   entry.appendChild(btn);
 }
 
+// Render a log entry's attachment previews as a thumbnail strip.
+// Each preview is { dataUrl?, url?, name?, note?, frameId?, mime? }:
+// `dataUrl` (a data: URL or a same-origin /raw URL) renders as an <img>;
+// `url` additionally wraps the thumb in a click-through link that opens
+// the blob in a new tab. A preview without pixels — or one whose blob was
+// deleted from the upload store (the <img> error path) — degrades to a
+// named chip instead of a broken image.
+function appendLogAttachmentStrip(cnt, c) {
+  const attachmentPreviews = Array.isArray(c?.attachment_previews) ? c.attachment_previews : [];
+  if (attachmentPreviews.length === 0) return;
+  const strip = document.createElement('div');
+  strip.className = 'log-attachment-strip';
+  const missingChip = (att) => {
+    const chip = document.createElement('span');
+    chip.className = 'log-attachment-file';
+    chip.textContent = (att && (att.name || att.frameId)) || 'attachment';
+    return chip;
+  };
+  for (const att of attachmentPreviews) {
+    if (att && att.dataUrl) {
+      const img = document.createElement('img');
+      img.className = 'log-attachment-thumb';
+      img.loading = 'lazy';
+      img.src = att.dataUrl;
+      img.alt = '';
+      img.title = att.note || att.name || att.frameId || 'attachment';
+      let holder = img;
+      if (att.url) {
+        const link = document.createElement('a');
+        link.className = 'log-attachment-link';
+        link.href = att.url;
+        link.target = '_blank';
+        link.rel = 'noopener';
+        link.title = img.title;
+        link.appendChild(img);
+        holder = link;
+      }
+      img.addEventListener('error', () => {
+        const chip = missingChip(att);
+        chip.classList.add('log-attachment-missing');
+        chip.title = 'attachment unavailable (blob deleted from the upload store)';
+        holder.replaceWith(chip);
+      }, { once: true });
+      strip.appendChild(holder);
+    } else {
+      strip.appendChild(missingChip(att));
+    }
+  }
+  cnt.appendChild(strip);
+}
+
+// ── Session notes (display-only transcript notes) ──
+// Wire shape: { event: 'session_note', session_id, note_id, text,
+// attachments: [{upload_id, name, mime, url}], source?, ts }.
+// Rendered as an ordinary log entry with kind 'session_note' (distinct
+// styling via .log-entry[data-kind=session_note]) and the attachment
+// strip fed by the upload-store /raw URLs.
+
+function sessionNoteAttachmentPreviews(d) {
+  const attachments = Array.isArray(d?.attachments) ? d.attachments : [];
+  return attachments.map(att => ({
+    dataUrl: att?.url || '',
+    url: att?.url || '',
+    name: att?.name || 'image',
+    mime: att?.mime || '',
+  }));
+}
+
+// Normalize a session_note wire event (live WS or a raw replay/session-
+// detail entry) into the log-command shape renderLogEntry consumes.
+function sessionNoteLogCommand(d) {
+  const text = String(d?.text ?? d?.content ?? '').trim();
+  if (!text) return null;
+  const tsMs = Number(d?.ts_ms ?? d?.tsMs ?? d?.ts);
+  return {
+    session_id: String(d?.session_id || d?.sessionId || '').trim(),
+    level: 'info',
+    source: String(d?.source || '').trim() || 'note',
+    kind: 'session_note',
+    content: text,
+    note_id: d?.note_id || d?.noteId || '',
+    event_id: d?.event_id || d?.eventId || (d?.note_id ? `session-note:${d.note_id}` : ''),
+    delivery: d?.delivery || d?.delivery_class || d?.deliveryClass || '',
+    // Raw wire events carry unix-ms in `ts`; replay entries carry the
+    // session log's HH:MM:SS string there instead, so only accept numbers.
+    ts_ms: Number.isFinite(tsMs) && tsMs > 0 ? tsMs : undefined,
+    ts: typeof d?.ts === 'string' ? d.ts : '',
+    attachment_previews: sessionNoteAttachmentPreviews(d),
+  };
+}
+
+// Live-path handler for the session_note WS event (the WASM presence
+// layer does not know this event; the JS owns its rendering end to end).
+function handleSessionNoteEvent(d) {
+  const c = sessionNoteLogCommand(d);
+  if (!c) return;
+  stationPushLogEvent(c);
+  renderLogEntry(c);
+  stationScheduleUpdate();
+}
+
+// Bootstrap-replay adapter: the WASM activity-feed pipeline only carries
+// log_entry-shaped replay rows (AddLogEntry has no attachment fields), so
+// session_note entries replay as note-styled text entries; the session
+// windows and the Sessions detail view re-attach the thumbnails from the
+// raw entries. The content deliberately stays byte-identical to the raw
+// note text so the transcript-signature dedupe collapses this row with
+// the attachment-bearing record the external window sync later inserts.
+// Everything else passes through untouched.
+function sessionNoteReplayEntryToLogEntry(entry) {
+  if (!entry || entry.event !== 'session_note') return entry;
+  return {
+    event: 'log_entry',
+    level: 'info',
+    source: String(entry.source || '').trim() || 'note',
+    kind: 'session_note',
+    content: String(entry.text || '').trim(),
+    session_id: entry.session_id || '',
+    ts: entry.ts,
+    event_id: entry.event_id || '',
+    delivery: entry.delivery || '',
+  };
+}
+
 function renderLogEntry(c) {
   if (isCommandOutputLog(c)) {
     inferSessionPhaseFromLog(c);
@@ -2018,34 +2143,13 @@ function renderLogEntry(c) {
   appendLogStateBadges(cnt, c);
 
   const hasImages = c.images && c.images.length > 0;
-  const attachmentPreviews = Array.isArray(c.attachment_previews) ? c.attachment_previews : [];
   if (hasImages) {
     const badge = document.createElement('span');
     badge.className = 'log-image-badge';
     badge.textContent = c.images.length === 1 ? '[screenshot]' : '[' + c.images.length + ' screenshots]';
     cnt.appendChild(badge);
   }
-  if (attachmentPreviews.length > 0) {
-    const strip = document.createElement('div');
-    strip.className = 'log-attachment-strip';
-    for (const att of attachmentPreviews) {
-      if (att && att.dataUrl) {
-        const img = document.createElement('img');
-        img.className = 'log-attachment-thumb';
-        img.loading = 'lazy';
-        img.src = att.dataUrl;
-        img.alt = '';
-        img.title = att.note || att.name || att.frameId || 'attachment';
-        strip.appendChild(img);
-      } else {
-        const chip = document.createElement('span');
-        chip.className = 'log-attachment-file';
-        chip.textContent = (att && (att.name || att.frameId)) || 'attachment';
-        strip.appendChild(chip);
-      }
-    }
-    cnt.appendChild(strip);
-  }
+  appendLogAttachmentStrip(cnt, c);
 
   entry.appendChild(cnt);
   appendCopyLogEntryButton(entry, c.content ?? '');

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -2097,6 +2097,17 @@ function handleSessionNoteEvent(d) {
   stationScheduleUpdate();
 }
 
+// QA readback (window.qa convention): the dashboard validator exercises
+// the note rail's module-scoped pieces directly — the attachment strip
+// (including its deleted-blob chip degradation) and the wire-event
+// normalizer. Side-effect-free beyond the DOM node the caller passes in.
+window.qa = Object.assign(window.qa || {}, {
+  sessionNotes: {
+    renderStrip: (target, c) => appendLogAttachmentStrip(target, c),
+    logCommand: (d) => sessionNoteLogCommand(d),
+  },
+});
+
 // Bootstrap-replay adapter: the WASM activity-feed pipeline only carries
 // log_entry-shaped replay rows (AddLogEntry has no attachment fields), so
 // session_note entries replay as note-styled text entries; the session

--- a/static/app/57-sessions-replay.js
+++ b/static/app/57-sessions-replay.js
@@ -2625,7 +2625,15 @@ function buildSessionDetailRows(entries) {
   let lastTurn = null;
   const visibleLevels = sessionDetailVisibleLevels();
 
-  for (const e of entries || []) {
+  for (let e of entries || []) {
+    // Display-only session notes carry their body in `text` and their
+    // image references in `attachments`; normalize them into the generic
+    // record shape (content + attachment_previews) the renderer expects.
+    if (e && e.event === 'session_note') {
+      const note = sessionNoteLogCommand(e);
+      if (!note) continue;
+      e = { ...e, ...note };
+    }
     const level = e.level || 'info';
     if (!visibleLevels.includes(level)) continue;
     if (!sessionDetailEntryMatchesLogFilter(e)) continue;
@@ -2840,6 +2848,7 @@ function materializeSessionDetailRow(view, row, index) {
   const entry = document.createElement('div');
   entry.className = 'log-entry level-' + e.level;
   entry.dataset.detailRowIndex = String(index);
+  if (e.kind) entry.dataset.kind = e.kind;
   const sourceClass = String(e.source).toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
   if (sourceClass) entry.classList.add('source-' + sourceClass);
   if (e.session_id) entry.dataset.sessionId = e.session_id;
@@ -2905,6 +2914,7 @@ function materializeSessionDetailRow(view, row, index) {
     content: e.content
   });
   appendLogStateBadges(cnt, e);
+  appendLogAttachmentStrip(cnt, e);
   if (sessionDetailLevelColors[e.level]) cnt.style.color = sessionDetailLevelColors[e.level];
 
   entry.appendChild(ts);

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -842,6 +842,136 @@ async fn mock_provider_without_a_script_fails_closed() {
     );
 }
 
+/// `intendant ctl session note` against a live daemon, end to end:
+/// (1) the note broadcasts as an `OutboundEvent::SessionNote` on `/ws`
+/// with the text, source, and attachment *references* (never bytes);
+/// (2) the referenced blob really serves from the upload store's `/raw`
+/// route with the stored MIME and exact bytes; (3) the note persists as a
+/// `session_note` row in the session log — the replay source of truth.
+#[tokio::test]
+async fn ctl_session_note_posts_a_display_only_note_with_image() {
+    const NOTE_TEXT: &str = "E2E_SESSION_NOTE milestone reached";
+    // Not a decodable PNG — the note rail stores and serves bytes verbatim,
+    // so any payload proves the round trip.
+    const IMAGE_BYTES: &[u8] = &[0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4];
+
+    let idle_script = serde_json::json!({
+        "profiles": [{
+            "steps": [
+                { "content": "fallback profile (unexpected session)",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "unexpected session" } }] }
+            ]
+        }]
+    });
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("http client");
+    let port = free_loopback_port();
+    let daemon = spawn_daemon(&client, &idle_script, port).await;
+
+    let image_path = daemon.rig.project.path().join("note-image.png");
+    std::fs::write(&image_path, IMAGE_BYTES).expect("write note image");
+
+    // Subscribe before posting so the broadcast cannot race the assert.
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/ws"))
+        .await
+        .expect("connect /ws");
+
+    let output = ctl(
+        &daemon,
+        &[
+            "--json",
+            "session",
+            "note",
+            NOTE_TEXT,
+            "--image",
+            image_path.to_str().expect("utf8 image path"),
+            "--session",
+            "note-e2e-session",
+            "--source",
+            "e2e",
+        ],
+    )
+    .await;
+    assert!(output.status.success(), "{}", text_of(&output));
+    let posted = stdout_json(&output);
+    assert_eq!(posted["status"], "posted", "{posted}");
+    assert_eq!(posted["session_id"], "note-e2e-session", "{posted}");
+    let note_id = posted["note_id"].as_str().expect("note_id").to_string();
+    let attachment_url = posted["attachments"][0]["url"]
+        .as_str()
+        .expect("attachment url")
+        .to_string();
+
+    // (1) The /ws broadcast carries the note as references, not bytes.
+    let event = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("session_note")
+    })
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "session_note never broadcast on /ws:\n{}",
+            daemon.log_tail()
+        )
+    });
+    assert_eq!(event["note_id"], note_id.as_str(), "{event}");
+    assert_eq!(event["text"], NOTE_TEXT, "{event}");
+    assert_eq!(event["source"], "e2e", "{event}");
+    assert_eq!(event["session_id"], "note-e2e-session", "{event}");
+    assert_eq!(event["attachments"][0]["url"], attachment_url.as_str(), "{event}");
+    assert_eq!(event["attachments"][0]["mime"], "image/png", "{event}");
+    assert!(
+        event["attachments"][0].get("data").is_none(),
+        "attachments must be references, never inline bytes: {event}"
+    );
+
+    // (2) The referenced blob serves with the stored MIME and exact bytes.
+    let response = client
+        .get(format!("http://127.0.0.1:{port}{attachment_url}"))
+        .send()
+        .await
+        .expect("GET note attachment");
+    assert!(
+        response.status().is_success(),
+        "attachment fetch failed: HTTP {}\n{}",
+        response.status(),
+        daemon.log_tail()
+    );
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok()),
+        Some("image/png")
+    );
+    let bytes = response.bytes().await.expect("attachment bytes");
+    assert_eq!(&bytes[..], IMAGE_BYTES, "blob bytes must round-trip");
+
+    // (3) The note persisted to the session log for replay.
+    poll_until(
+        "the session_note row in the session log",
+        RUN_TIMEOUT,
+        || {
+            let logs = daemon.rig.session_logs();
+            let note_id = note_id.clone();
+            async move {
+                (logs.contains("\"event\":\"session_note\"") && logs.contains(&note_id))
+                    .then_some(())
+            }
+        },
+        || {
+            format!(
+                "--- session logs ---\n{}\n--- daemon log tail ---\n{}",
+                tail(&daemon.rig.session_logs(), 2000),
+                daemon.log_tail()
+            )
+        },
+    )
+    .await;
+}
+
 /// `intendant ctl peer …` against a live federated pair: daemon A federates
 /// to daemon B over `POST /api/peers` (the peer-sessions smoke's pattern),
 /// then the ctl surface — which reaches A's `/mcp` over tokenless loopback —


### PR DESCRIPTION
Gives agents a first-class way to post a **display-only note** — text plus optional images — into their own session transcript: visible live in the web dashboard, persisted for replay, and **never part of any model's context** (the model-context path remains `ContextInjection`; this is purely a presentation rail).

## Surfaces

- **MCP tool `post_session_note`** — params: `text` (required), `images: [{media_type, data(base64), name?}]`, `session_id?` (defaults to the calling session), `source?` (entry label). Images are committed into the session upload store and travel as **references** (`/api/session/current/uploads/<id>/raw`) — never base64 on the WS broadcast or in the session log. Session-scoped supervised agents (Codex / Claude Code with injected MCP URLs) are the primary callers and post into their own session by default; the tool is advertised in the `core` tool profile.
- **`intendant ctl session note "text" [--image PATH ...] [--source LABEL] [--session ID]`** — ctl reads the files itself (inside the caller's own sandbox) and base64s them into the tool call; caps are derived from the mcp module constants, not mirrored.
- **Wire**: new `AppEvent::SessionNote` / `OutboundEvent::SessionNote { session_id, note_id, text, attachments: [{upload_id, name, mime, url}], source, ts }`.

## Security posture

- **No daemon-side file paths from MCP callers** — base64-only by design: a sandboxed supervised agent must not be able to make the unsandboxed daemon read arbitrary files. No path form was added at all (the simplest of the allowed options); ctl's `--image` reads happen under the caller's own sandbox.
- **Raster MIME allowlist** (`image/png`, `image/jpeg`, `image/gif`, `image/webp`, `image/bmp`). SVG is rejected: the `/raw` route serves blobs inline with their stored MIME, and a clicked-through SVG document would execute scripts on the daemon origin. Raster types cannot.
- **Caps**: 16 KB text, 6 images, 4 MB per image, 8 MB total decoded — pinned by a unit test to always fit (with base64 inflation + envelope headroom) inside the 16 MB `POST /mcp` body cap.
- **IAM**: `post_session_note` classifies as `Message` alongside `respond` — a session message-surface write, deliberately below `RuntimeControl` so session-scoped principals (the tool's audience) pass; pinned in the `mcp_tool_operation` test. Manual HTTP definition has a drift test against the `#[tool]` attribute.
- Note text renders **escaped** (`textContent`); no new markdown engine.

## Rendering and replay

- **Live**: `/ws` `session_note` events render as note-styled entries (`data-kind=session_note`, accent border + source label) in the activity feed and session windows; thumbnails load lazily from `/raw`, click through to the blob in a new tab, and degrade to a named chip when the blob has been deleted (img `error` → chip; no JS errors).
- **Replay**: `session.jsonl` persists a `session_note` row (full text + attachment refs); `session_log_entry_to_app_event` reconstructs it through the shared single-rendering-path pipeline, so the Sessions detail view, external window sync, and window restore all render notes with attachments. Bootstrap `log_replay` rides the WASM activity-feed pipeline as note-styled `log_entry` rows (chronological order preserved; content kept byte-identical to the raw text so the transcript-signature dedupe collapses it with the attachment-bearing record the window sync inserts).
- The attachment strip was factored into `appendLogAttachmentStrip` and reused across the activity feed, session windows, and the Sessions detail view; `window.qa.sessionNotes` exposes it to the dashboard validator.

## Tests

- **Unit** (all in `cargo test --bins`): base64/MIME/cap validation, commit + bus event emission, URL-session dispatch + `isError` mapping, caps-fit-under-body-cap pin, IAM mapping pin, manual-vs-`#[tool]` description drift guard, profile advertisement, session-log replay round trip (writer → parser → outbound JSON), ctl args builder + error paths.
- **e2e** (`cargo test --test e2e`): `ctl session note` against a live daemon — the `/ws` broadcast carries references (never bytes), `/raw` serves the exact blob with its stored MIME, and the `session_note` row persists in the session log.
- **Browser** (validate-dashboard.cjs, post-landing battery — not CI): live path verified against a real daemon (note entry renders with loaded thumbnail + click-through link, `functions=1 PASS`). Deleted-blob chip probe recipe for operator hardware: post a note via page-context `/mcp` fetch, wait for `img.complete && naturalWidth > 0`, `DELETE` the upload, cache-bust the img src, assert `.log-attachment-missing` replaces the thumb.

## Deliberate deferrals (follow-ups)

- **CU screenshot trail in the transcript**: CU frames already persist on disk in the `FrameRegistry`; this note rail could carry them later behind a toggle (e.g. one note per CU batch referencing the frame blobs) — deferred from this PR.
- **presence-web `AddLogEntry` attachments**: the WASM UiCommand cannot carry attachment previews yet, so bootstrap-replayed activity-feed rows show note text without thumbs (session windows and the Sessions detail view render full fidelity). Threading attachments through `AddLogEntry` removes that gap and the replay adapter.
- **Station parity**: notes reach Station as ordinary log activity (`stationPushLogEvent`); a dedicated note treatment in the Station transcript pane is follow-up.
- **Peer dashboards** receive note text as peer log activity with an image-count marker; attachment URLs are origin-daemon-local by design.
