### PR TITLE
Worktree sessions: launch top-level sessions in a git worktree + finish card

### DIFF
--- a/docs/src/multi-agent.md
+++ b/docs/src/multi-agent.md
@@ -206,6 +206,50 @@ implementation-2 ─► branch subagent-e5f6a7b8 ─┼─► parent merges each
 > import / canonical claim) rather than an orchestrator merge. See
 > [External-Agent Orchestration](./external-agent-orchestration.md).
 
+### Top-Level Worktree Sessions
+
+Worktree isolation is also available to **top-level sessions**, not just
+sub-agents: `CreateSession { worktree: true, worktree_branch? }` (the New
+Session pane's "Run in a git worktree" toggle) branches a fresh worktree off
+the resolved project root's `HEAD` and makes the checkout the session's
+effective project root. The project root must be a git repository with at
+least one commit — anything else fails the launch with an actionable error
+instead of a half-created session.
+
+The branch name is either user-supplied (validated against a conservative,
+path-safe subset of git ref syntax — traversal shapes, `@{`, `.lock`
+segments, leading `-`/`.` are all rejected) or derived: a slug of the
+session name, else `session-<short-id>`, with a numeric suffix on collision.
+The linkage — branch, checkout path, base root, base branch, base commit —
+is recorded in the session's `session_meta.json` (`SessionMeta.worktree`),
+survives meta rewrites (resume, rename), and is served on session-catalog
+rows; the dashboard renders it as a branch badge in the session window
+header, and the Worktrees tab links sessions to checkouts by cwd exactly as
+it does for sub-agent worktrees.
+
+The worktree persists after the session ends — same doctrine as above; the
+branch is the work product and nothing is removed automatically. When a
+worktree-backed session ends, its window shows a dismissible **finish card**
+with the three explicit outcomes:
+
+- **Merge into `<base branch>` & remove worktree** — `POST
+  /api/worktrees/merge` (dashboard-control twin `api_worktrees_merge`) takes
+  only a session id and resolves everything else from the recorded linkage,
+  so it can only ever merge a session-linked worktree branch. It runs
+  `git merge <branch> --no-edit` in the base checkout — refusing fail-closed
+  if the checkout is no longer registered, the branch was renamed, or the
+  base checkout has moved to a different branch or a detached HEAD — aborts
+  cleanly on conflict, then removes the checkout through the same
+  safety-checked path as `/api/worktrees/remove`. A refused removal (say the
+  checkout picked up new dirt) is reported in the response, not fatal: the
+  merge already landed, and the branch ref is always kept.
+- **Remove worktree** — the inventory-safe removal; refuses dirty or
+  unmerged checkouts and surfaces the safety reason.
+- **Keep** — dismiss; the checkout stays available in the Worktrees tab.
+
+An explicitly stopped worktree session keeps its dashboard window until the
+card is dismissed — the merge/remove/keep decision outlives the stop.
+
 ## Knowledge Routing Between Agents
 
 Agents share findings through the **knowledge store** — a tagged,

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1710,9 +1710,10 @@ include `offset`/`length`; the response carries `range_start`, `range_end`,
 tab uses repeated ranged reads to download staged uploads back to the browser.
 This is a bounded current-session attachment primitive, not yet a general
 daemon-filesystem upload/download adapter.
-Worktree cached inventory reads, explicit scans, and guarded removals use
-`api_worktrees`, `api_worktrees_scan`, and `api_worktrees_remove`; removal uses
-the same no-replay fallback rule as other writes.
+Worktree cached inventory reads, explicit scans, guarded removals, and the
+session finish card's merge use `api_worktrees`, `api_worktrees_scan`,
+`api_worktrees_remove`, and `api_worktrees_merge`; the writes use the same
+no-replay fallback rule as other writes.
 The filesystem picker's path checks, directory listings, and mkdir operation use
 `api_fs_stat`, `api_fs_list`, and `api_fs_mkdir`; mkdir uses the same no-replay
 fallback rule as other writes.
@@ -1949,7 +1950,7 @@ family (sub-routes elided where the family is uniform):
 | `POST /api/access/...` | Trust mutations: enrollment decide, IAM grant upsert/update, org trust/revoke, org-grant issue/renew/revoke-member, issuer init/delegate/install, revocation-list apply |
 | `GET /api/peers[/*]`, `POST /api/peers[/*]`, `DELETE /api/peers` | Peer federation: registry reads (GET), pairing + management/signaling (POST), registry removal (DELETE) |
 | `POST /api/coordinator/route` | Multi-agent coordinator task routing (peer lane) |
-| `GET /api/worktrees`, `POST /api/worktrees/{inspect,scan,remove}` | Agent worktree inventory and lifecycle |
+| `GET /api/worktrees`, `POST /api/worktrees/{inspect,scan,remove,merge}` | Agent worktree inventory and lifecycle (merge = session-linked worktree finish card) |
 | `GET /connect/{bootstrap,status}`, `POST /connect/dashboard/{offer,ice,close}` | Intendant Connect tunnel: bootstrap metadata and dashboard-control WebRTC signaling |
 
 ### Declared API routes
@@ -2000,6 +2001,7 @@ its operation per method/path from `federation_http_operation`.
 | GET | `/api/managed-context/fission` | SessionInspect | own origin | none | Managed-context fission state |
 | POST | `/api/worktrees/inspect` | SessionInspect | own origin | bounded | Inspect one worktree (branch, ahead/behind, dirty state) |
 | POST | `/api/worktrees/remove` | SessionManage | own origin | bounded | Remove a worktree from the inventory |
+| POST | `/api/worktrees/merge` | SessionManage | own origin | bounded | Merge a session's linked worktree branch into its base checkout, then remove the checkout |
 | POST | `/api/worktrees/scan` | SessionManage | own origin | none | Rescan the worktree inventory (refreshes the cache) |
 | GET | `/api/worktrees` | SessionInspect | own origin | none | Cached worktree inventory |
 | GET | `/api/sessions/stream` | SessionInspect | own origin | none | NDJSON stream of the session list |

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -741,6 +741,41 @@ pub(crate) async fn api_worktrees_remove_response(
     }
 }
 
+pub(crate) async fn api_worktrees_merge_response(
+    id: String,
+    params: Option<&serde_json::Value>,
+    runtime: &ControlRuntime,
+) -> serde_json::Value {
+    let body_text = params_body_text(params);
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+    let cache = runtime.worktree_inventory_cache.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        let result = crate::web_gateway::merge_session_worktree_response(&home, &body_text);
+        if result.0 == "200 OK" {
+            if let Ok(mut guard) = cache.lock() {
+                *guard = None;
+            }
+        }
+        result
+    })
+    .await;
+    match result {
+        Ok((status_line, body)) => {
+            http_body_response(id, status_line_code(status_line), body, "worktree merge")
+        }
+        Err(e) => http_body_response(
+            id,
+            500,
+            serde_json::json!({
+                "ok": false,
+                "error": format!("worktree merge task failed: {e}")
+            })
+            .to_string(),
+            "worktree merge",
+        ),
+    }
+}
+
 pub(crate) async fn api_managed_context_response(
     id: String,
     kind: &'static str,

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -286,6 +286,7 @@ pub(crate) async fn control_request_response(
         "api_worktrees_remove" => {
             api_worktrees_remove_response(id, params.as_ref(), &runtime).await
         }
+        "api_worktrees_merge" => api_worktrees_merge_response(id, params.as_ref(), &runtime).await,
         "api_managed_context_records" => {
             api_managed_context_response(id, "records", params.as_ref(), &runtime).await
         }

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -799,6 +799,7 @@ pub(crate) fn control_frame_response(
                 | "api_worktrees_inspect"
                 | "api_worktrees_scan"
                 | "api_worktrees_remove"
+                | "api_worktrees_merge"
                 | "api_managed_context_records"
                 | "api_managed_context_anchors"
                 | "api_managed_context_fission"

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -3274,6 +3274,7 @@ mod tests {
             ("api_session_control_msg", Residue, Some(Op::SessionManage)),
             ("api_worktrees_scan", Residue, Some(Op::SessionManage)),
             ("api_worktrees_remove", Residue, Some(Op::SessionManage)),
+            ("api_worktrees_merge", Row, Some(Op::SessionManage)),
             (
                 "api_session_current_upload",
                 Residue,

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -1389,6 +1389,17 @@ pub enum ControlMsg {
         /// Frame/upload IDs attached via the dashboard.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         attachments: Vec<String>,
+        /// Launch the session in a fresh git worktree branched off the
+        /// resolved project root's HEAD; the worktree checkout becomes the
+        /// session's effective project root. Requires the project root to
+        /// be a git repository with at least one commit.
+        #[serde(default)]
+        worktree: Option<bool>,
+        /// Branch name for the worktree (validated against a conservative
+        /// git-ref subset). Omitted: derived from the session name, else
+        /// `session-<short-id>`; collisions get a numeric suffix.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        worktree_branch: Option<String>,
     },
     /// Delegate a task to a new supervised sub-agent under an existing
     /// internal session (the dashboard "delegate" action). The child is
@@ -3593,6 +3604,8 @@ mod tests {
                 reference_frame_ids: vec!["display_99-f00001".to_string()],
                 display_target: Some("user_session".to_string()),
                 attachments: vec!["upload:u1".to_string()],
+                worktree: Some(true),
+                worktree_branch: Some("feature-branch".to_string()),
             },
             ControlMsg::StartTask {
                 session_id: None,
@@ -3866,6 +3879,8 @@ mod tests {
                 reference_frame_ids,
                 display_target,
                 attachments,
+                worktree,
+                worktree_branch,
             } => {
                 assert_eq!(task, "fix bug");
                 assert!(claude_model.is_none());
@@ -3886,6 +3901,26 @@ mod tests {
                 assert!(reference_frame_ids.is_empty());
                 assert!(display_target.is_none());
                 assert_eq!(attachments, vec!["upload:u1"]);
+                // Legacy payloads without the worktree fields parse as "off".
+                assert!(worktree.is_none());
+                assert!(worktree_branch.is_none());
+            }
+            _ => panic!("expected CreateSession"),
+        }
+    }
+
+    #[test]
+    fn control_msg_create_session_worktree_deserialize() {
+        let json = r#"{"action":"create_session","task":"fix bug","worktree":true,"worktree_branch":"fix/login"}"#;
+        let msg: ControlMsg = serde_json::from_str(json).unwrap();
+        match msg {
+            ControlMsg::CreateSession {
+                worktree,
+                worktree_branch,
+                ..
+            } => {
+                assert_eq!(worktree, Some(true));
+                assert_eq!(worktree_branch.as_deref(), Some("fix/login"));
             }
             _ => panic!("expected CreateSession"),
         }

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -228,6 +228,7 @@ pub(crate) enum RouteHandlerId {
     McFission,
     WorktreesInspect,
     WorktreesRemove,
+    WorktreesMerge,
     WorktreesScan,
     WorktreesList,
     SessionsStream,
@@ -786,6 +787,15 @@ pub(crate) static ROUTES: &[Route] = &[
         RouteHandlerId::WorktreesRemove,
         "Remove a worktree from the inventory",
     ),
+    op_route(
+        RouteMethod::Post,
+        PathPattern::Exact("/api/worktrees/merge"),
+        PeerOperation::SessionManage,
+        BodyPolicy::Default,
+        RouteHandlerId::WorktreesMerge,
+        "Merge a session's linked worktree branch into its base checkout, then remove the checkout",
+    )
+    .with_tunnel(tunnel_method("api_worktrees_merge")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/worktrees/scan"),

--- a/src/bin/caller/session_log/mod.rs
+++ b/src/bin/caller/session_log/mod.rs
@@ -72,6 +72,30 @@ pub struct SessionMeta {
     pub role: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rounds: Option<usize>,
+    /// Git-worktree linkage for sessions launched into a fresh worktree
+    /// (`CreateSession { worktree: true }`): the branch, its checkout path
+    /// (the session's effective project root), and where it branched from.
+    /// The single source of truth the dashboard's worktree badge, the
+    /// session-end finish card, and the merge endpoint all derive from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<SessionWorktreeMeta>,
+}
+
+/// Worktree linkage recorded on a session (see [`SessionMeta::worktree`]).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct SessionWorktreeMeta {
+    /// Branch checked out in the worktree.
+    pub branch: String,
+    /// Absolute worktree checkout path (the session's project root).
+    pub path: String,
+    /// Project root the worktree was created from (where merges run).
+    pub base_root: String,
+    /// Branch the base checkout was on at creation, if not detached.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_branch: Option<String>,
+    /// Commit `HEAD` resolved to when the worktree branched off.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_sha: Option<String>,
 }
 
 static OPEN_SESSION_LOG_DIRS: OnceLock<StdMutex<HashSet<PathBuf>>> = OnceLock::new();
@@ -347,10 +371,12 @@ impl SessionLog {
         name: Option<&str>,
         role: Option<&str>,
     ) {
-        let existing_name = fs::read_to_string(self.dir.join("session_meta.json"))
+        let existing = fs::read_to_string(self.dir.join("session_meta.json"))
             .ok()
-            .and_then(|raw| serde_json::from_str::<SessionMeta>(&raw).ok())
-            .and_then(|meta| meta.name);
+            .and_then(|raw| serde_json::from_str::<SessionMeta>(&raw).ok());
+        let (existing_name, existing_worktree) = existing
+            .map(|meta| (meta.name, meta.worktree))
+            .unwrap_or((None, None));
         let meta = SessionMeta {
             session_id: self.session_id.clone(),
             created_at: Local::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
@@ -361,9 +387,34 @@ impl SessionLog {
             last_turn: None,
             role: role.map(|r| r.to_string()),
             rounds: None,
+            // Worktree linkage is written once at launch and survives every
+            // later meta rewrite (resume, rename), like the session name.
+            worktree: existing_worktree,
         };
         if let Ok(json) = serde_json::to_string_pretty(&meta) {
             if let Err(e) = fs::write(self.dir.join("session_meta.json"), json) {
+                eprintln!("session_log: failed to write session_meta.json: {}", e);
+            }
+        }
+    }
+
+    /// Record (or update) the session's git-worktree linkage in
+    /// `session_meta.json`. Call after `write_meta*` has created the file;
+    /// the linkage then survives later meta rewrites.
+    pub fn write_meta_worktree(&self, worktree: &SessionWorktreeMeta) {
+        let meta_path = self.dir.join("session_meta.json");
+        let Some(mut meta) = fs::read_to_string(&meta_path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<SessionMeta>(&raw).ok())
+        else {
+            eprintln!(
+                "session_log: cannot record worktree linkage before session_meta.json exists"
+            );
+            return;
+        };
+        meta.worktree = Some(worktree.clone());
+        if let Ok(json) = serde_json::to_string_pretty(&meta) {
+            if let Err(e) = fs::write(&meta_path, json) {
                 eprintln!("session_log: failed to write session_meta.json: {}", e);
             }
         }
@@ -1262,6 +1313,7 @@ mod tests {
             last_turn: None,
             role: None,
             rounds: None,
+            worktree: None,
         };
         fs::write(
             log_dir.join("session_meta.json"),
@@ -1310,6 +1362,31 @@ mod tests {
     }
 
     #[test]
+    fn write_meta_worktree_records_and_survives_meta_rewrites() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("session");
+        let log = SessionLog::open(log_dir.clone()).unwrap();
+        log.write_meta(Some(Path::new("/tmp/wt/checkout")), Some("task"));
+
+        let linkage = SessionWorktreeMeta {
+            branch: "session-branch".to_string(),
+            path: "/tmp/wt/checkout".to_string(),
+            base_root: "/tmp/wt".to_string(),
+            base_branch: Some("main".to_string()),
+            base_sha: Some("abc123".to_string()),
+        };
+        log.write_meta_worktree(&linkage);
+        // A later meta rewrite (resume / rename) must not drop the linkage.
+        log.write_meta(Some(Path::new("/tmp/wt/checkout")), Some("resumed task"));
+
+        let meta: SessionMeta =
+            serde_json::from_str(&fs::read_to_string(log_dir.join("session_meta.json")).unwrap())
+                .unwrap();
+        assert_eq!(meta.task.as_deref(), Some("resumed task"));
+        assert_eq!(meta.worktree, Some(linkage));
+    }
+
+    #[test]
     fn resolve_path_with_override() {
         let dir = tempfile::tempdir().unwrap();
         let custom = dir.path().join("custom_logs");
@@ -1344,6 +1421,7 @@ mod tests {
             last_turn: Some(5),
             role: None,
             rounds: None,
+            worktree: None,
         };
         fs::write(
             s1_dir.join("session_meta.json"),
@@ -1363,6 +1441,7 @@ mod tests {
             last_turn: Some(3),
             role: None,
             rounds: None,
+            worktree: None,
         };
         fs::write(
             s2_dir.join("session_meta.json"),
@@ -1420,6 +1499,7 @@ mod tests {
             last_turn: None,
             role: None,
             rounds: None,
+            worktree: None,
         };
         fs::write(
             log_dir.join("session_meta.json"),

--- a/src/bin/caller/session_supervisor/dispatch.rs
+++ b/src/bin/caller/session_supervisor/dispatch.rs
@@ -27,7 +27,14 @@ impl SessionSupervisor {
                 reference_frame_ids,
                 display_target,
                 attachments,
+                worktree,
+                worktree_branch,
             } => {
+                let worktree_request = worktree
+                    .unwrap_or(false)
+                    .then(|| SessionWorktreeRequest {
+                        branch: worktree_branch,
+                    });
                 if let Some(parsed) = parse_codex_slash_command(&task) {
                     match parsed {
                         Ok(command) if command.op == "fast" => {
@@ -69,6 +76,7 @@ impl SessionSupervisor {
                                     crate::external_agent::codex::CODEX_FAST_SERVICE_TIER
                                         .to_string(),
                                 ),
+                                worktree_request,
                             )
                             .await;
                             return;
@@ -89,6 +97,7 @@ impl SessionSupervisor {
                         || codex_context_archive.is_some()
                         || codex_service_tier.is_some()
                         || name.is_some()
+                        || worktree_request.is_some()
                     {
                         self.warn(
                             "Slash command dropped new-session metadata; routing to active Codex session",
@@ -118,6 +127,7 @@ impl SessionSupervisor {
                     display_target,
                     attachments,
                     codex_service_tier,
+                    worktree_request,
                 )
                 .await;
             }
@@ -184,6 +194,7 @@ impl SessionSupervisor {
                                     crate::external_agent::codex::CODEX_FAST_SERVICE_TIER
                                         .to_string(),
                                 ),
+                                None,
                             )
                             .await;
                             return;
@@ -218,6 +229,7 @@ impl SessionSupervisor {
                     reference_frame_ids,
                     display_target,
                     attachments,
+                    None,
                     None,
                 )
                 .await;

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -27,6 +27,7 @@ impl SessionSupervisor {
         display_target: Option<String>,
         attachments: Vec<String>,
         codex_service_tier: Option<String>,
+        worktree: Option<SessionWorktreeRequest>,
     ) {
         let session_name = match normalize_session_name_option(name.as_deref()) {
             Ok(name) => name,
@@ -76,6 +77,40 @@ impl SessionSupervisor {
                 return;
             }
         };
+        // Worktree launch: branch off the resolved project root's HEAD and
+        // make the fresh checkout the session's effective project root. A
+        // failure (not a git repo, no commits, bad branch name) closes the
+        // just-opened session honestly, exactly like the no-project arm.
+        let worktree_meta = match worktree.as_ref() {
+            Some(request) => {
+                match prepare_session_worktree(
+                    &project_root,
+                    request,
+                    session_name.as_deref(),
+                    &session_id,
+                ) {
+                    Ok(meta) => Some(meta),
+                    Err(e) => {
+                        let reason = format!("worktree launch failed: {e}");
+                        slog(&session_log, |l| {
+                            l.write_summary(&task, &format!("error: {reason}"), 0)
+                        });
+                        self.loop_error(format!("Session create failed: {reason}"));
+                        self.config.bus.send(AppEvent::SessionEnded {
+                            session_id,
+                            reason: format!("error: {reason}"),
+                            error_kind: None,
+                        });
+                        return;
+                    }
+                }
+            }
+            None => None,
+        };
+        let project_root = worktree_meta
+            .as_ref()
+            .map(|meta| PathBuf::from(&meta.path))
+            .unwrap_or(project_root);
         let project = match Project::from_root(project_root) {
             Ok(project) => project,
             Err(e) => {
@@ -95,6 +130,17 @@ impl SessionSupervisor {
             task_meta,
             session_name.as_deref(),
         );
+        if let Some(ref meta) = worktree_meta {
+            // Persist the linkage after the meta file exists; it survives
+            // later meta rewrites (see SessionLog::write_meta_worktree).
+            slog(&session_log, |l| l.write_meta_worktree(meta));
+            self.info(&format!(
+                "Session {} runs in git worktree {} (branch {})",
+                short_session(&session_id),
+                meta.path,
+                meta.branch
+            ));
+        }
         self.activate_shared_session(session_log.clone()).await;
 
         if !reference_frame_ids.is_empty()
@@ -1183,6 +1229,52 @@ impl std::fmt::Display for ProjectRootResolveError {
     }
 }
 
+/// Worktree launch request carried by `CreateSession { worktree: true }`.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SessionWorktreeRequest {
+    /// User-supplied branch name; derived from the session name / id when
+    /// absent.
+    pub(crate) branch: Option<String>,
+}
+
+/// Create the git worktree for a new session: validate the requested
+/// branch (or derive one from the session name / id, suffixing on
+/// collision), branch off the resolved project root's HEAD, and return
+/// the linkage recorded in `session_meta.json`. The returned meta's
+/// `path` becomes the session's effective project root.
+pub(crate) fn prepare_session_worktree(
+    project_root: &Path,
+    request: &SessionWorktreeRequest,
+    session_name: Option<&str>,
+    session_id: &str,
+) -> Result<session_log::SessionWorktreeMeta, String> {
+    // Doubles as the git preflight: a non-repo project root and a repo
+    // with no commits both fail here with an actionable message.
+    let base_sha = worktree::head_commit(project_root)?;
+    let branch = match request
+        .branch
+        .as_deref()
+        .map(str::trim)
+        .filter(|branch| !branch.is_empty())
+    {
+        Some(requested) => worktree::validate_branch_name(requested)
+            .map_err(|e| format!("invalid worktree branch name {requested:?}: {e}"))?,
+        None => {
+            let derived = worktree::derive_branch_name(session_name, session_id);
+            worktree::unique_branch_name(project_root, &derived)
+        }
+    };
+    let base_branch = worktree::current_branch(project_root);
+    let wt = worktree::create(project_root, &branch, "HEAD").map_err(|e| e.to_string())?;
+    Ok(session_log::SessionWorktreeMeta {
+        branch: wt.branch_name,
+        path: wt.path.to_string_lossy().to_string(),
+        base_root: project_root.to_string_lossy().to_string(),
+        base_branch,
+        base_sha: Some(base_sha),
+    })
+}
+
 pub(crate) fn resolve_project_root_override(
     project_root: Option<String>,
     default_root: Option<&Path>,
@@ -1617,6 +1709,113 @@ mod tests {
             resolve_external_resume_project_root(None, None, None).unwrap_err(),
             ProjectRootResolveError::NoProject
         );
+    }
+
+    fn init_worktree_test_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let run = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(dir.path())
+                .output()
+                .unwrap();
+            assert!(out.status.success(), "git {args:?} failed");
+        };
+        run(&["init", "-b", "main"]);
+        run(&["config", "user.email", "test@test.com"]);
+        run(&["config", "user.name", "Test"]);
+        std::fs::write(dir.path().join("README.md"), "# test\n").unwrap();
+        run(&["add", "README.md"]);
+        run(&["commit", "-m", "initial"]);
+        dir
+    }
+
+    #[test]
+    fn prepare_session_worktree_requires_a_git_repository() {
+        let plain = tempfile::tempdir().unwrap();
+        let err = prepare_session_worktree(
+            plain.path(),
+            &SessionWorktreeRequest::default(),
+            None,
+            "abcd1234",
+        )
+        .unwrap_err();
+        assert!(err.contains("not a git repository"), "{err}");
+        // The failure is clean: nothing was created under the project.
+        assert!(!plain.path().join(".intendant").exists());
+    }
+
+    #[test]
+    fn prepare_session_worktree_records_full_linkage() {
+        let repo = init_worktree_test_repo();
+        let meta = prepare_session_worktree(
+            repo.path(),
+            &SessionWorktreeRequest::default(),
+            Some("Fix the Login Bug"),
+            "abcd1234-uuid",
+        )
+        .unwrap();
+        assert_eq!(meta.branch, "fix-the-login-bug");
+        let path = PathBuf::from(&meta.path);
+        assert!(path.is_dir(), "worktree checkout exists");
+        assert_eq!(
+            path,
+            repo.path()
+                .join(".intendant")
+                .join("worktrees")
+                .join("fix-the-login-bug")
+        );
+        assert_eq!(meta.base_root, repo.path().to_string_lossy());
+        assert_eq!(meta.base_branch.as_deref(), Some("main"));
+        let sha = meta.base_sha.expect("base sha recorded");
+        assert_eq!(sha.len(), 40, "{sha}");
+        // Derived names dodge collisions with a numeric suffix.
+        let second = prepare_session_worktree(
+            repo.path(),
+            &SessionWorktreeRequest::default(),
+            Some("Fix the Login Bug"),
+            "efgh5678-uuid",
+        )
+        .unwrap();
+        assert_eq!(second.branch, "fix-the-login-bug-2");
+    }
+
+    #[test]
+    fn prepare_session_worktree_validates_requested_branch() {
+        let repo = init_worktree_test_repo();
+        let err = prepare_session_worktree(
+            repo.path(),
+            &SessionWorktreeRequest {
+                branch: Some("../escape".to_string()),
+            },
+            None,
+            "abcd1234",
+        )
+        .unwrap_err();
+        assert!(err.contains("invalid worktree branch name"), "{err}");
+
+        let meta = prepare_session_worktree(
+            repo.path(),
+            &SessionWorktreeRequest {
+                branch: Some("feat/requested".to_string()),
+            },
+            None,
+            "abcd1234",
+        )
+        .unwrap();
+        assert_eq!(meta.branch, "feat/requested");
+        // A user-supplied duplicate is an error (git refuses), not a
+        // silent suffix.
+        let err = prepare_session_worktree(
+            repo.path(),
+            &SessionWorktreeRequest {
+                branch: Some("feat/requested".to_string()),
+            },
+            None,
+            "efgh5678",
+        )
+        .unwrap_err();
+        assert!(err.contains("feat/requested"), "{err}");
     }
 
     /// End-to-end substrate test, keyless: a mock provider drives an

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -454,6 +454,9 @@ pub(crate) async fn serve_http_request(
             RouteHandlerId::WorktreesRemove => {
                 return handle_worktrees_remove(stream, route_body, worktree_inventory_cache).await;
             }
+            RouteHandlerId::WorktreesMerge => {
+                return handle_worktrees_merge(stream, route_body, worktree_inventory_cache).await;
+            }
             RouteHandlerId::WorktreesScan => {
                 return handle_worktrees_scan(stream, project_root, worktree_inventory_cache).await;
             }

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -394,6 +394,172 @@ pub(crate) fn remove_worktree_inventory_response(
     }
 }
 
+/// Session-end finish-card action: merge a session's linked worktree
+/// branch into its base checkout, then remove the checkout via the same
+/// safety-checked path `/api/worktrees/remove` uses.
+///
+/// The request carries only a session id; the branch, checkout path, and
+/// base root all come from the session's own recorded linkage in
+/// `session_meta.json` — so the endpoint can only ever merge a
+/// session-linked worktree branch, never an arbitrary ref.
+pub(crate) fn merge_session_worktree_response(
+    home: &Path,
+    body_text: &str,
+) -> (&'static str, String) {
+    let session_id = serde_json::from_str::<serde_json::Value>(body_text)
+        .ok()
+        .and_then(|body| {
+            body.get("session_id")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        });
+    let Some(session_id) = session_id.filter(|id| session_lookup_id_is_safe(id)) else {
+        return (
+            "400 Bad Request",
+            serde_json::json!({
+                "ok": false,
+                "error": "worktree merge request needs a session_id"
+            })
+            .to_string(),
+        );
+    };
+    let Some(session_dir) = resolve_bare_session_dir_from_home(home, &session_id) else {
+        return (
+            "404 Not Found",
+            serde_json::json!({
+                "ok": false,
+                "error": format!("session '{session_id}' was not found")
+            })
+            .to_string(),
+        );
+    };
+    let hints = worktree_session_hints_from_home(home);
+    match merge_linked_session_worktree(&session_dir, &hints) {
+        Ok(body) => ("200 OK", body.to_string()),
+        Err(message) => (
+            "409 Conflict",
+            serde_json::json!({
+                "ok": false,
+                "error": message
+            })
+            .to_string(),
+        ),
+    }
+}
+
+/// The merge itself, keyed entirely off the session's recorded linkage.
+/// Fails closed on every drifted precondition (unregistered checkout,
+/// renamed branch, base checkout moved to another branch or detached);
+/// a conflicted merge is aborted by `worktree::merge` and reported. A
+/// post-merge removal refusal is reported in the response, not an error —
+/// the merge itself already landed.
+pub(crate) fn merge_linked_session_worktree(
+    session_dir: &Path,
+    hints: &[crate::worktree_inventory::WorktreeSessionHint],
+) -> Result<serde_json::Value, String> {
+    let meta = std::fs::read_to_string(session_dir.join("session_meta.json"))
+        .ok()
+        .and_then(|raw| serde_json::from_str::<crate::session_log::SessionMeta>(&raw).ok())
+        .ok_or_else(|| "session metadata was not readable".to_string())?;
+    let linkage = meta
+        .worktree
+        .ok_or_else(|| "this session has no linked git worktree".to_string())?;
+    let base_root = PathBuf::from(&linkage.base_root);
+    if !base_root.is_dir() {
+        return Err(format!(
+            "base checkout {} no longer exists",
+            base_root.display()
+        ));
+    }
+    let worktree_path = PathBuf::from(&linkage.path);
+    // The linked checkout must still be a registered worktree of the base
+    // repo, still on the branch the session recorded.
+    let registered = crate::worktree::list(&base_root)
+        .map_err(|e| format!("could not list worktrees: {e}"))?
+        .into_iter()
+        .find(|wt| worktree_merge_paths_match(&wt.path, &worktree_path));
+    let Some(registered) = registered else {
+        return Err(format!(
+            "{} is no longer a registered worktree of {}",
+            worktree_path.display(),
+            base_root.display()
+        ));
+    };
+    if registered.branch_name != linkage.branch {
+        return Err(format!(
+            "worktree {} is now on branch {:?}, not the session's recorded {:?} — merge manually",
+            worktree_path.display(),
+            registered.branch_name,
+            linkage.branch
+        ));
+    }
+    // Merge into the branch the base checkout is on — and require it to
+    // still be the branch the worktree branched from, so "Merge into
+    // <base>" can never silently land on a different branch.
+    let current = crate::worktree::current_branch(&base_root);
+    let merge_target = match (&linkage.base_branch, current) {
+        (Some(recorded), Some(current)) if *recorded == current => current,
+        (Some(recorded), Some(current)) => {
+            return Err(format!(
+                "base checkout is now on {current:?} (it was on {recorded:?} when the \
+                 worktree was created) — check out {recorded:?} first or merge manually"
+            ));
+        }
+        (Some(recorded), None) => {
+            return Err(format!(
+                "base checkout is on a detached HEAD — check out {recorded:?} first"
+            ));
+        }
+        (None, _) => {
+            return Err(
+                "the worktree was created from a detached HEAD; merge manually".to_string(),
+            );
+        }
+    };
+    let wt = crate::worktree::Worktree {
+        branch_name: linkage.branch.clone(),
+        path: worktree_path.clone(),
+        base_branch: merge_target.clone(),
+    };
+    match crate::worktree::merge(&base_root, &wt, &merge_target).map_err(|e| e.to_string())? {
+        crate::worktree::MergeResult::Conflict(message) => Err(message),
+        crate::worktree::MergeResult::Clean => {
+            let repo_root = crate::worktree_inventory::git_repo_root(&base_root)
+                .unwrap_or_else(|| base_root.clone());
+            let removal = crate::worktree_inventory::remove_worktree_if_safe(
+                crate::worktree_inventory::WorktreeRemoveRequest {
+                    repo_root,
+                    path: worktree_path.clone(),
+                    expected_head: None,
+                },
+                hints,
+            );
+            let (removed, removal_error) = match removal {
+                Ok(_) => (true, None),
+                Err(e) => (false, Some(e)),
+            };
+            Ok(serde_json::json!({
+                "ok": true,
+                "merged": true,
+                "branch": linkage.branch,
+                "merged_into": merge_target,
+                "base_root": linkage.base_root,
+                "worktree_path": linkage.path,
+                "removed": removed,
+                "removal_error": removal_error,
+            }))
+        }
+    }
+}
+
+/// Compare a `git worktree list` path against the session's recorded
+/// checkout path, tolerating symlinked tempdirs (macOS `/tmp` vs
+/// `/private/tmp`) by canonicalizing when possible.
+fn worktree_merge_paths_match(a: &Path, b: &Path) -> bool {
+    let canon = |p: &Path| p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
+    a == b || canon(a) == canon(b)
+}
+
 /// Handle `/api/session/current/changes[/{path}]` requests.
 ///
 /// - No path suffix: list all changed files (baseline vs current).
@@ -2945,6 +3111,42 @@ pub(crate) async fn handle_worktrees_remove(
     finalize_http_stream(&mut stream).await;
 }
 
+pub(crate) async fn handle_worktrees_merge(
+    mut stream: DemuxStream,
+    body_text: String,
+    worktree_inventory_cache: Arc<Mutex<Option<String>>>,
+) {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+    let cache = worktree_inventory_cache.clone();
+    let (status, body) = match tokio::task::spawn_blocking(move || {
+        let result = merge_session_worktree_response(&home, &body_text);
+        if result.0 == "200 OK" {
+            // The merge (and usually the removal) changed the inventory;
+            // drop the cached scan like the remove handler does.
+            if let Ok(mut guard) = cache.lock() {
+                *guard = None;
+            }
+        }
+        result
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(e) => (
+            "500 Internal Server Error",
+            serde_json::json!({
+                "ok": false,
+                "error": format!("worktree merge task failed: {e}")
+            })
+            .to_string(),
+        ),
+    };
+    let response = json_response(status, body);
+    use tokio::io::AsyncWriteExt;
+    let _ = stream.write_all(response.as_bytes()).await;
+    finalize_http_stream(&mut stream).await;
+}
+
 pub(crate) async fn handle_worktrees_scan(
     mut stream: DemuxStream,
     project_root: Option<PathBuf>,
@@ -3438,6 +3640,164 @@ mod tests {
             .map(|(_, body)| body)
             .expect("response body");
         serde_json::from_str(body).expect("json response")
+    }
+
+    mod worktree_merge {
+        use super::*;
+        use std::process::Command;
+
+        fn git(repo: &Path, args: &[&str]) {
+            let out = Command::new("git")
+                .args(args)
+                .current_dir(repo)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+
+        fn init_repo(dir: &Path) {
+            git(dir, &["init", "-b", "main"]);
+            git(dir, &["config", "user.email", "test@test.com"]);
+            git(dir, &["config", "user.name", "Test"]);
+            std::fs::write(dir.join("README.md"), "# base\n").unwrap();
+            git(dir, &["add", "README.md"]);
+            git(dir, &["commit", "-m", "initial"]);
+        }
+
+        /// A repo + linked worktree with one committed change, and the
+        /// session dir whose meta records the linkage — the state a
+        /// worktree session leaves behind when it ends.
+        fn linked_session(
+            repo: &Path,
+            session_dir: &Path,
+            branch: &str,
+        ) -> crate::session_log::SessionWorktreeMeta {
+            init_repo(repo);
+            let wt = crate::worktree::create(repo, branch, "HEAD").unwrap();
+            std::fs::write(wt.path.join("feature.txt"), "from the worktree\n").unwrap();
+            git(&wt.path, &["add", "feature.txt"]);
+            git(&wt.path, &["commit", "-m", "worktree change"]);
+
+            let linkage = crate::session_log::SessionWorktreeMeta {
+                branch: branch.to_string(),
+                path: wt.path.to_string_lossy().to_string(),
+                base_root: repo.to_string_lossy().to_string(),
+                base_branch: Some("main".to_string()),
+                base_sha: crate::worktree::head_commit(repo).ok(),
+            };
+            std::fs::create_dir_all(session_dir).unwrap();
+            let meta = serde_json::json!({
+                "session_id": "wt-session",
+                "created_at": "2026-07-09T00:00:00",
+                "project_root": linkage.path,
+                "worktree": linkage,
+            });
+            std::fs::write(
+                session_dir.join("session_meta.json"),
+                serde_json::to_string_pretty(&meta).unwrap(),
+            )
+            .unwrap();
+            linkage
+        }
+
+        #[test]
+        fn clean_merge_lands_and_removes_the_worktree() {
+            let repo_dir = tempfile::tempdir().unwrap();
+            let session_dir = tempfile::tempdir().unwrap();
+            let linkage = linked_session(repo_dir.path(), session_dir.path(), "wt-clean");
+
+            let body = merge_linked_session_worktree(session_dir.path(), &[]).unwrap();
+            assert_eq!(body["ok"], true);
+            assert_eq!(body["merged"], true);
+            assert_eq!(body["merged_into"], "main");
+            assert_eq!(body["branch"], "wt-clean");
+            assert_eq!(body["removed"], true, "{body}");
+            // The change landed in the base checkout; the checkout is gone
+            // but the branch ref survives (the work product).
+            assert!(repo_dir.path().join("feature.txt").exists());
+            assert!(!PathBuf::from(&linkage.path).exists());
+            assert!(crate::worktree::branch_exists(repo_dir.path(), "wt-clean"));
+        }
+
+        #[test]
+        fn conflicted_merge_aborts_and_keeps_everything() {
+            let repo_dir = tempfile::tempdir().unwrap();
+            let session_dir = tempfile::tempdir().unwrap();
+            let linkage = linked_session(repo_dir.path(), session_dir.path(), "wt-conflict");
+            // Divergent edit to the same file in the base checkout.
+            std::fs::write(repo_dir.path().join("feature.txt"), "from main\n").unwrap();
+            git(repo_dir.path(), &["add", "feature.txt"]);
+            git(repo_dir.path(), &["commit", "-m", "conflicting main change"]);
+
+            let err = merge_linked_session_worktree(session_dir.path(), &[]).unwrap_err();
+            assert!(err.contains("wt-conflict"), "{err}");
+            // The merge was aborted: no merge in progress, worktree intact.
+            assert!(!repo_dir.path().join(".git").join("MERGE_HEAD").exists());
+            assert!(PathBuf::from(&linkage.path).exists());
+        }
+
+        #[test]
+        fn merge_refuses_when_base_checkout_moved_branches() {
+            let repo_dir = tempfile::tempdir().unwrap();
+            let session_dir = tempfile::tempdir().unwrap();
+            linked_session(repo_dir.path(), session_dir.path(), "wt-moved");
+            git(repo_dir.path(), &["checkout", "-b", "elsewhere"]);
+
+            let err = merge_linked_session_worktree(session_dir.path(), &[]).unwrap_err();
+            assert!(err.contains("elsewhere"), "{err}");
+            assert!(err.contains("main"), "{err}");
+        }
+
+        #[test]
+        fn merge_requires_a_recorded_linkage() {
+            let session_dir = tempfile::tempdir().unwrap();
+            std::fs::write(
+                session_dir.path().join("session_meta.json"),
+                serde_json::json!({
+                    "session_id": "plain",
+                    "created_at": "2026-07-09T00:00:00",
+                })
+                .to_string(),
+            )
+            .unwrap();
+            let err = merge_linked_session_worktree(session_dir.path(), &[]).unwrap_err();
+            assert!(err.contains("no linked git worktree"), "{err}");
+        }
+
+        #[test]
+        fn merge_response_rejects_bad_and_unknown_session_ids() {
+            let home = tempfile::tempdir().unwrap();
+            let (status, body) = merge_session_worktree_response(home.path(), "{}");
+            assert_eq!(status, "400 Bad Request", "{body}");
+            let (status, body) = merge_session_worktree_response(
+                home.path(),
+                &serde_json::json!({"session_id": "../escape"}).to_string(),
+            );
+            assert_eq!(status, "400 Bad Request", "{body}");
+            let (status, body) = merge_session_worktree_response(
+                home.path(),
+                &serde_json::json!({"session_id": "does-not-exist"}).to_string(),
+            );
+            assert_eq!(status, "404 Not Found", "{body}");
+        }
+
+        #[test]
+        fn merge_refuses_a_session_linked_to_a_missing_worktree() {
+            let repo_dir = tempfile::tempdir().unwrap();
+            let session_dir = tempfile::tempdir().unwrap();
+            let linkage = linked_session(repo_dir.path(), session_dir.path(), "wt-gone");
+            // Simulate the checkout being removed out from under the card.
+            git(
+                repo_dir.path(),
+                &["worktree", "remove", "--force", &linkage.path],
+            );
+            let err = merge_linked_session_worktree(session_dir.path(), &[]).unwrap_err();
+            assert!(err.contains("no longer a registered worktree"), "{err}");
+        }
     }
 
     fn managed_context_test_record(

--- a/src/bin/caller/web_gateway/session_catalog/mod.rs
+++ b/src/bin/caller/web_gateway/session_catalog/mod.rs
@@ -1563,6 +1563,7 @@ pub(crate) fn intendant_session_list_row_from_dir(
     let mut external_source: Option<String> = None;
     let mut canonical_session_id: Option<String> = None;
     let mut capabilities: Option<serde_json::Value> = None;
+    let mut worktree = serde_json::Value::Null;
     let mut session_agent_config = crate::session_config::read_log_dir_config(dir);
     let mut updated_at_secs = session_activity_mtime_secs(dir);
 
@@ -1598,6 +1599,9 @@ pub(crate) fn intendant_session_list_row_from_dir(
                 .get("session_id")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
+            if let Some(value) = meta.get("worktree").filter(|v| v.is_object()) {
+                worktree = value.clone();
+            }
         }
     }
 
@@ -1956,6 +1960,7 @@ pub(crate) fn intendant_session_list_row_from_dir(
         "total_bytes": total_bytes,
         "cwd": cwd.clone().or_else(|| project_root.clone()),
         "project_root": project_root.clone(),
+        "worktree": worktree,
         "path": dir.to_string_lossy().to_string(),
         "can_delete": true,
         "can_resume": true,
@@ -2067,6 +2072,7 @@ pub(crate) fn intendant_session_skeleton_from_dir(
     let mut project_root: Option<String> = None;
     let mut status = "in_progress".to_string();
     let mut role: Option<String> = None;
+    let mut worktree = serde_json::Value::Null;
     if let Ok(meta_str) = std::fs::read_to_string(&meta_path) {
         if let Ok(meta) = serde_json::from_str::<serde_json::Value>(&meta_str) {
             task = value_str(&meta, "task");
@@ -2077,6 +2083,9 @@ pub(crate) fn intendant_session_skeleton_from_dir(
                 status = value;
             }
             role = value_str(&meta, "role");
+            if let Some(value) = meta.get("worktree").filter(|v| v.is_object()) {
+                worktree = value.clone();
+            }
         }
     }
     if status != "completed" {
@@ -2121,6 +2130,7 @@ pub(crate) fn intendant_session_skeleton_from_dir(
         "total_bytes": 0,
         "cwd": project_root.clone(),
         "project_root": project_root,
+        "worktree": worktree,
         "path": dir.to_string_lossy().to_string(),
         "can_delete": true,
         "can_resume": true,

--- a/src/bin/caller/worktree.rs
+++ b/src/bin/caller/worktree.rs
@@ -12,11 +12,191 @@ pub struct Worktree {
     pub base_branch: String,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum MergeResult {
     Clean,
     Conflict(String),
+}
+
+/// Ceiling for user-supplied worktree branch names. Git itself allows far
+/// longer refs, but the branch doubles as the worktree directory name under
+/// `.intendant/worktrees/`, so keep it filesystem-friendly.
+const MAX_BRANCH_NAME_LEN: usize = 120;
+
+/// Validate a user-supplied branch name for a session worktree.
+///
+/// A deliberately conservative subset of `git check-ref-format` that is
+/// also path-safe: the branch becomes a directory under
+/// `.intendant/worktrees/`, so `..`, absolute separators, and other
+/// traversal shapes are rejected outright rather than left for git to
+/// maybe-accept.
+pub fn validate_branch_name(raw: &str) -> Result<String, String> {
+    let name = raw.trim();
+    if name.is_empty() {
+        return Err("branch name is empty".to_string());
+    }
+    if name.len() > MAX_BRANCH_NAME_LEN {
+        return Err(format!(
+            "branch name is longer than {MAX_BRANCH_NAME_LEN} characters"
+        ));
+    }
+    if name.starts_with('-') {
+        return Err("branch name must not start with '-'".to_string());
+    }
+    if name.starts_with('/') || name.ends_with('/') {
+        return Err("branch name must not start or end with '/'".to_string());
+    }
+    if name.ends_with('.') {
+        return Err("branch name must not end with '.'".to_string());
+    }
+    if name.contains("@{") {
+        return Err("branch name must not contain '@{'".to_string());
+    }
+    if let Some(bad) = name
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '/')))
+    {
+        return Err(format!(
+            "branch name may only contain letters, digits, '.', '_', '-' and '/' (got {bad:?})"
+        ));
+    }
+    for component in name.split('/') {
+        if component.is_empty() {
+            return Err("branch name must not contain empty path segments ('//')".to_string());
+        }
+        if component.starts_with('.') {
+            return Err(format!(
+                "branch name segment {component:?} must not start with '.'"
+            ));
+        }
+        if component.ends_with(".lock") {
+            return Err("branch name segments must not end with '.lock'".to_string());
+        }
+    }
+    Ok(name.to_string())
+}
+
+/// Derive a worktree branch name when the user did not supply one: a slug
+/// of the session name when present, otherwise `session-<short-id>`.
+pub fn derive_branch_name(session_name: Option<&str>, session_id: &str) -> String {
+    if let Some(name) = session_name.map(str::trim).filter(|name| !name.is_empty()) {
+        let mut slug = String::new();
+        let mut last_dash = true; // suppress a leading dash
+        for c in name.chars() {
+            let c = c.to_ascii_lowercase();
+            if c.is_ascii_alphanumeric() {
+                slug.push(c);
+                last_dash = false;
+            } else if !last_dash {
+                slug.push('-');
+                last_dash = true;
+            }
+            if slug.len() >= 40 {
+                break;
+            }
+        }
+        let slug = slug.trim_matches('-').to_string();
+        if !slug.is_empty() {
+            return slug;
+        }
+    }
+    let short_id: String = session_id.chars().take(8).collect();
+    format!("session-{short_id}")
+}
+
+/// First branch name in `base`, `base-2`, `base-3`, … that neither exists
+/// as a local branch nor collides with an existing worktree directory.
+/// After a bounded scan it falls back to a nanos suffix so the launch can
+/// never loop forever on a pathological repo.
+pub fn unique_branch_name(project_root: &Path, base: &str) -> String {
+    let taken = |candidate: &str| {
+        branch_exists(project_root, candidate)
+            || project_root
+                .join(".intendant")
+                .join("worktrees")
+                .join(candidate)
+                .exists()
+    };
+    if !taken(base) {
+        return base.to_string();
+    }
+    for n in 2..=50 {
+        let candidate = format!("{base}-{n}");
+        if !taken(&candidate) {
+            return candidate;
+        }
+    }
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    format!("{base}-{nanos}")
+}
+
+pub fn branch_exists(project_root: &Path, branch: &str) -> bool {
+    Command::new("git")
+        .args([
+            "show-ref",
+            "--verify",
+            "--quiet",
+            &format!("refs/heads/{branch}"),
+        ])
+        .current_dir(project_root)
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+/// The commit `HEAD` resolves to in `project_root`.
+///
+/// Doubles as the "can this directory host a session worktree?" preflight:
+/// a non-repo directory and a repo with no commits both fail here with an
+/// actionable message, before `git worktree add` gets a chance to emit a
+/// more cryptic one.
+pub fn head_commit(project_root: &Path) -> Result<String, String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(project_root)
+        .output()
+        .map_err(|e| format!("failed to run git: {e}"))?;
+    if !output.status.success() {
+        let inside_repo = Command::new("git")
+            .args(["rev-parse", "--is-inside-work-tree"])
+            .current_dir(project_root)
+            .output()
+            .map(|out| {
+                out.status.success() && String::from_utf8_lossy(&out.stdout).trim() == "true"
+            })
+            .unwrap_or(false);
+        if !inside_repo {
+            return Err(format!(
+                "{} is not a git repository — worktree sessions need a git project \
+                 (run `git init` there or launch without the worktree option)",
+                project_root.display()
+            ));
+        }
+        return Err(format!(
+            "{} has no commits yet — a worktree branches from HEAD, so make an \
+             initial commit first",
+            project_root.display()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// The branch currently checked out at `path`, `None` when detached (or
+/// not a repo).
+pub fn current_branch(path: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["symbolic-ref", "--short", "-q", "HEAD"])
+        .current_dir(path)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!branch.is_empty()).then_some(branch)
 }
 
 pub fn create(project_root: &Path, branch: &str, base: &str) -> Result<Worktree, CallerError> {
@@ -107,7 +287,6 @@ pub fn remove_worktree_and_branch(project_root: &Path, wt: &Worktree) -> Result<
     Ok(())
 }
 
-#[allow(dead_code)]
 /// Merge the worktree branch into the current checkout at `project_root`.
 ///
 /// `current_checkout_label` is used only for diagnostics; this helper does
@@ -146,7 +325,6 @@ pub fn merge(
     }
 }
 
-#[allow(dead_code)]
 pub fn list(project_root: &Path) -> Result<Vec<Worktree>, CallerError> {
     let output = Command::new("git")
         .args(["worktree", "list", "--porcelain"])
@@ -364,6 +542,115 @@ mod tests {
             }
             MergeResult::Clean => panic!("Expected conflict"),
         }
+    }
+
+    #[test]
+    fn validate_branch_name_accepts_sane_names() {
+        for name in [
+            "feature-1",
+            "feat/worktree-sessions",
+            "user.branch_2",
+            "  padded  ",
+        ] {
+            let validated = validate_branch_name(name).unwrap();
+            assert_eq!(validated, name.trim());
+        }
+    }
+
+    #[test]
+    fn validate_branch_name_rejects_traversal_and_weird_refs() {
+        for bad in [
+            "",
+            "   ",
+            "../escape",
+            "a/../b",
+            "a/..",
+            "..",
+            ".hidden",
+            "a/.hidden",
+            "-flag",
+            "/rooted",
+            "trailing/",
+            "double//slash",
+            "dot.",
+            "ref@{1}",
+            "has space",
+            "semi;colon",
+            "back\\slash",
+            "tilde~1",
+            "caret^2",
+            "colon:ref",
+            "quest?ion",
+            "star*",
+            "brack[et",
+            "locky.lock",
+            "deep/locky.lock",
+        ] {
+            assert!(
+                validate_branch_name(bad).is_err(),
+                "{bad:?} should be rejected"
+            );
+        }
+        let too_long = "a".repeat(200);
+        assert!(validate_branch_name(&too_long).is_err());
+    }
+
+    #[test]
+    fn derive_branch_name_slugs_session_name_or_falls_back_to_id() {
+        assert_eq!(
+            derive_branch_name(Some("Fix the Login Bug!"), "abcd1234-rest"),
+            "fix-the-login-bug"
+        );
+        assert_eq!(
+            derive_branch_name(Some("  --- "), "abcd1234-rest"),
+            "session-abcd1234"
+        );
+        assert_eq!(derive_branch_name(None, "abcd1234-rest"), "session-abcd1234");
+        // Long names are capped and never end on a dash.
+        let long = derive_branch_name(Some(&"word ".repeat(30)), "abcd1234");
+        assert!(long.len() <= 40, "{long}");
+        assert!(!long.ends_with('-'), "{long}");
+    }
+
+    #[test]
+    fn unique_branch_name_suffixes_on_collision() {
+        let dir = init_test_repo();
+        let repo = dir.path();
+        assert_eq!(unique_branch_name(repo, "fresh"), "fresh");
+
+        create(repo, "taken", "HEAD").unwrap();
+        assert_eq!(unique_branch_name(repo, "taken"), "taken-2");
+        create(repo, "taken-2", "HEAD").unwrap();
+        assert_eq!(unique_branch_name(repo, "taken"), "taken-3");
+    }
+
+    #[test]
+    fn head_commit_reports_non_repo_and_empty_repo_clearly() {
+        let plain = tempfile::tempdir().unwrap();
+        let err = head_commit(plain.path()).unwrap_err();
+        assert!(err.contains("not a git repository"), "{err}");
+
+        let empty = tempfile::tempdir().unwrap();
+        Command::new("git")
+            .args(["init"])
+            .current_dir(empty.path())
+            .output()
+            .unwrap();
+        let err = head_commit(empty.path()).unwrap_err();
+        assert!(err.contains("no commits yet"), "{err}");
+
+        let dir = init_test_repo();
+        let sha = head_commit(dir.path()).unwrap();
+        assert_eq!(sha.len(), 40, "{sha}");
+    }
+
+    #[test]
+    fn current_branch_reads_checkout_branch() {
+        let dir = init_test_repo();
+        let branch = current_branch(dir.path()).expect("fresh repo is on a branch");
+        assert!(!branch.is_empty());
+        let wt = create(dir.path(), "branch-probe", "HEAD").unwrap();
+        assert_eq!(current_branch(&wt.path).as_deref(), Some("branch-probe"));
     }
 
     #[test]

--- a/src/bin/caller/worktree_inventory.rs
+++ b/src/bin/caller/worktree_inventory.rs
@@ -1182,7 +1182,7 @@ fn default_branch_for_repo(repo: &Path) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-fn git_repo_root(path: &Path) -> Option<PathBuf> {
+pub(crate) fn git_repo_root(path: &Path) -> Option<PathBuf> {
     git_string(path, &["rev-parse", "--show-toplevel"])
         .ok()
         .map(|s| PathBuf::from(s.trim()))

--- a/static/app.html
+++ b/static/app.html
@@ -5198,6 +5198,82 @@ body.context-focus-active {
 .session-window-task::before { content: "msg"; }
 .session-window-project::before { content: "proj"; }
 .session-window-cwd::before { content: "cwd"; }
+.session-window-worktree {
+  flex-shrink: 1;
+  min-width: 0;
+  max-width: 220px;
+  padding: 1px 7px;
+  border: 1px solid color-mix(in srgb, var(--mauve) 30%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--mauve) 10%, transparent);
+  color: var(--mauve);
+  font-size: 10px;
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.session-worktree-card {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 6px 8px 0;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--mauve) 35%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--mauve) 8%, transparent);
+  font-size: 12px;
+}
+.session-worktree-card.busy {
+  opacity: 0.75;
+}
+.session-worktree-card-text {
+  flex: 1 1 240px;
+  min-width: 0;
+}
+.session-worktree-card-title {
+  font-weight: 700;
+}
+.session-worktree-card-detail {
+  color: var(--overlay1);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.session-worktree-card-status {
+  flex: 1 1 100%;
+  font-size: 11px;
+}
+.session-worktree-card-status.hidden {
+  display: none;
+}
+.session-worktree-card-status.pending {
+  color: var(--yellow);
+}
+.session-worktree-card-status.ok {
+  color: var(--green);
+}
+.session-worktree-card-status.error {
+  color: var(--red);
+}
+.session-worktree-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+.session-worktree-card-btn {
+  height: 24px;
+  padding: 0 10px;
+  font-size: 11px;
+}
+.session-worktree-card-btn.primary {
+  border-color: color-mix(in srgb, var(--mauve) 45%, transparent);
+  background: color-mix(in srgb, var(--mauve) 18%, transparent);
+  color: var(--text);
+}
 .session-window-status {
   flex-shrink: 0;
   padding: 1px 6px;
@@ -7526,6 +7602,22 @@ body.context-focus-active {
 .sessions-project-status.ok { color: var(--green); }
 .sessions-project-status.warn { color: var(--yellow); }
 .sessions-project-status.error { color: var(--red); }
+.sessions-worktree-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+.sessions-worktree-toggle {
+  flex-shrink: 0;
+  text-transform: none;
+}
+.sessions-worktree-branch {
+  flex: 1 1 200px;
+  min-width: 160px;
+}
+.sessions-worktree-branch.hidden { display: none; }
 .sessions-start-btn {
   align-self: flex-start;
   padding: 4px 12px;
@@ -22432,6 +22524,17 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
                   </div>
                   <div id="new-session-project-status" class="sessions-project-status"></div>
                   <datalist id="new-session-project-options"></datalist>
+                  <div class="sessions-worktree-row">
+                    <label class="sessions-toggle sessions-worktree-toggle" id="new-session-worktree-wrap"
+                           title="Create a fresh git worktree branched off the project's HEAD and run the session inside it. Needs a git repository with at least one commit.">
+                      <input id="new-session-worktree" type="checkbox" onchange="onNewSessionWorktreeToggle()">
+                      Run in a git worktree
+                    </label>
+                    <label class="sessions-new-session-field sessions-worktree-branch hidden" for="new-session-worktree-branch" id="new-session-worktree-branch-row">
+                      Branch name
+                      <input id="new-session-worktree-branch" class="sessions-project-input" type="text" maxlength="120" autocomplete="off" spellcheck="false" placeholder="Optional — derived from the session name">
+                    </label>
+                  </div>
                 </div>
                 <div class="sessions-new-agent-row sessions-new-agent-picker">
                   <label class="sessions-new-session-field" for="new-session-agent">
@@ -43156,7 +43259,13 @@ function normalizeSessionWindowMeta(meta = {}) {
     out.projectRoot = project;
     out.projectLabel = compactPathLabel(project, true);
   }
-  const cwd = compactSessionText(meta.cwd || meta.workdir || meta.workDir || meta.worktree || project);
+  // Worktree linkage (an OBJECT — branch/path/base) is distinct from the
+  // legacy string `worktree` cwd alias some callers pass; only the string
+  // form may feed the cwd fallback below.
+  const worktreeInfo = normalizeSessionWorktreeInfo(meta.worktree);
+  if (worktreeInfo) out.worktree = worktreeInfo;
+  const worktreeCwdAlias = typeof meta.worktree === 'string' ? meta.worktree : '';
+  const cwd = compactSessionText(meta.cwd || meta.workdir || meta.workDir || worktreeCwdAlias || project);
   if (cwd) {
     out.cwd = cwd;
     out.cwdLabel = compactPathLabel(cwd, true);
@@ -43207,6 +43316,24 @@ function normalizeSessionWindowMeta(meta = {}) {
   return out;
 }
 
+// Session worktree linkage from the catalog row / session_meta.json —
+// `{branch, path, base_root, base_branch?, base_sha?}` — normalized to a
+// compact object, or null when absent/malformed.
+function normalizeSessionWorktreeInfo(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const branch = compactSessionText(raw.branch);
+  const path = compactSessionText(raw.path);
+  if (!branch || !path) return null;
+  const info = { branch, path };
+  const baseRoot = compactSessionText(raw.base_root || raw.baseRoot);
+  if (baseRoot) info.baseRoot = baseRoot;
+  const baseBranch = compactSessionText(raw.base_branch || raw.baseBranch);
+  if (baseBranch) info.baseBranch = baseBranch;
+  const baseSha = compactSessionText(raw.base_sha || raw.baseSha);
+  if (baseSha) info.baseSha = baseSha;
+  return info;
+}
+
 function sessionWindowMetadataSignature(meta = {}) {
   return [
     meta.name || '',
@@ -43215,6 +43342,7 @@ function sessionWindowMetadataSignature(meta = {}) {
     meta.projectLabel || '',
     meta.cwd || '',
     meta.cwdLabel || '',
+    meta.worktree ? `${meta.worktree.branch}${meta.worktree.path}${meta.worktree.baseBranch || ''}` : '',
     meta.source || '',
     meta.sourceLabel || '',
     meta.backendSource || '',
@@ -43623,6 +43751,7 @@ function sessionWindowMetaFromSession(session) {
     task: session.task,
     cwd: session.cwd || session.workdir || session.workDir,
     project_root: session.project_root,
+    worktree: session.worktree,
     source: session.source,
     source_label: session.backend_source_label || session.source_label || prettyAgentName(session.backend_source || session.source || '') || session.backend_source || session.source,
     backend_source: session.backend_source,
@@ -43896,6 +44025,7 @@ function persistedSessionWindowRecord(sessionId, win = null) {
   if (meta.codexContextArchive) record.codex_context_archive = meta.codexContextArchive;
   if (meta.projectRoot) record.project_root = meta.projectRoot;
   if (meta.cwd) record.cwd = meta.cwd;
+  if (meta.worktree) record.worktree = meta.worktree;
   if (meta.parentId && meta.relationshipKind) {
     record.parent_session_id = meta.parentId;
     record.relationship = meta.relationshipKind;
@@ -48132,11 +48262,14 @@ function ensureSessionWindow(sessionId, meta = {}) {
     'unknown',
     'Working directory not known yet'
   );
+  const worktreeBadge = document.createElement('span');
+  worktreeBadge.className = 'session-window-worktree hidden';
   const metaRow = document.createElement('div');
   metaRow.className = 'session-window-meta';
   metaRow.appendChild(id);
   metaRow.appendChild(relationStrip);
   metaRow.appendChild(project);
+  metaRow.appendChild(worktreeBadge);
   const task = document.createElement('div');
   task.className = 'session-window-task';
   task.textContent = meta.task || 'initial message pending';
@@ -48305,6 +48438,7 @@ function ensureSessionWindow(sessionId, meta = {}) {
     relationStrip,
     project,
     cwd,
+    worktreeBadge,
     task,
     status,
     goal,
@@ -48389,6 +48523,7 @@ function updateSessionWindow(sessionId, meta = {}) {
     );
   }
   refreshSessionWindowPathLabels(win);
+  renderSessionWindowWorktreeBadge(win, meta.worktree || null);
   if (meta.task) {
     win.task.textContent = meta.task;
     win.task.title = meta.task;
@@ -48424,6 +48559,27 @@ function updateSessionWindow(sessionId, meta = {}) {
   if (meta.parentId) updateSessionRelationshipBadges(meta.parentId);
   scheduleSessionRelationshipRender();
   persistSessionWindowState();
+}
+
+// Worktree badge next to the project path: branch name up front, the full
+// linkage (checkout path, base branch/commit) in the tooltip.
+function renderSessionWindowWorktreeBadge(win, worktree) {
+  if (!win?.worktreeBadge) return;
+  if (!worktree?.branch) {
+    win.worktreeBadge.className = 'session-window-worktree hidden';
+    win.worktreeBadge.textContent = '';
+    win.worktreeBadge.title = '';
+    return;
+  }
+  win.worktreeBadge.className = 'session-window-worktree';
+  win.worktreeBadge.textContent = `⎇ ${worktree.branch}`;
+  const lines = [`Session runs in a git worktree on branch ${worktree.branch}`];
+  if (worktree.path) lines.push(`Checkout: ${worktree.path}`);
+  if (worktree.baseRoot) lines.push(`Base project: ${worktree.baseRoot}`);
+  if (worktree.baseBranch) {
+    lines.push(`Branched from ${worktree.baseBranch}${worktree.baseSha ? ` @ ${worktree.baseSha.slice(0, 12)}` : ''}`);
+  }
+  win.worktreeBadge.title = lines.join('\n');
 }
 
 function updateSessionWindowMinimizeState(sessionId) {
@@ -76894,7 +77050,15 @@ function onSessionEnded(sessionId, reason, errorKind) {
   } else if (explicitStop) {
     clearPendingFollowUpsForSession(sid, reason || 'session stopped');
     removeSessionRelationshipsForSession(sid);
-    removeSessionWindow(sid);
+    // A worktree-backed session leaves a decision behind (merge / remove /
+    // keep the worktree), so its window survives an explicit stop to host
+    // the finish card; dismissing the card completes the removal.
+    if (sessionWorktreeFinishInfo(sid)) {
+      updateSessionWindow(sid, { phase: 'done', ended: true });
+      maybeShowWorktreeFinishCard(sid, { removeWindowOnDismiss: true });
+    } else {
+      removeSessionWindow(sid);
+    }
   } else if (restarting) {
     clearPendingFollowUpsForSession(sid, reason || 'restarting session');
     updateSessionWindow(sid, { phase: 'idle', ended: false });
@@ -76904,6 +77068,7 @@ function onSessionEnded(sessionId, reason, errorKind) {
     setSessionWindowDetached(sid, true, reason || 'session ended');
   } else if (sid) {
     updateSessionWindow(sid, { phase: 'done', ended: true });
+    maybeShowWorktreeFinishCard(sid);
   }
   if (!keepExternalDetached && (!sessionId || sessionId === currentSessionFullId)) {
     currentSessionFullId = '';
@@ -76931,6 +77096,197 @@ function onSessionEnded(sessionId, reason, errorKind) {
   scheduleSessionRelationshipRender();
   // Refresh sessions list if already loaded
   if (sessionsLoaded) loadSessions();
+}
+
+// ── Worktree finish card ───────────────────────────────────────────────────
+// When a session that ran in a git worktree ends, its window offers the
+// three explicit outcomes for the branch it leaves behind: merge it back
+// into the base checkout (and remove the checkout), remove the checkout
+// via the same safety-checked path as the Worktrees tab, or keep it.
+// Nothing is ever automatic — the worktree persists until a click.
+
+const worktreeFinishCardDismissed = new Set();
+
+function sessionWorktreeFinishInfo(sid) {
+  const meta = sid ? (sessionMetadataById.get(sid) || {}) : {};
+  return meta.worktree && meta.worktree.branch && meta.worktree.path ? meta.worktree : null;
+}
+
+// The linkage rides the session catalog row (from session_meta.json); it is
+// normally hydrated well before the session ends, but fetch once on demand
+// for windows that never saw a metadata refresh.
+async function hydrateSessionWorktreeFinishInfo(sid) {
+  const existing = sessionWorktreeFinishInfo(sid);
+  if (existing) return existing;
+  let sessions = null;
+  if (typeof dashboardTransport !== 'undefined' && dashboardTransport?.canUseRpc()) {
+    try {
+      sessions = await dashboardTransport.request('api_sessions', { ids: [sid] });
+    } catch (_) {}
+  }
+  if (!sessions) {
+    try {
+      const r = await authedFetch(`/api/sessions?ids=${encodeURIComponent(sid)}`);
+      if (!r.ok) return null;
+      sessions = await r.json();
+    } catch (_) {
+      return null;
+    }
+  }
+  if (Array.isArray(sessions)) cacheSessionWindowMetadata(sessions);
+  return sessionWorktreeFinishInfo(sid);
+}
+
+function maybeShowWorktreeFinishCard(sid, options = {}) {
+  if (!sid || worktreeFinishCardDismissed.has(sid)) return;
+  const attach = info => {
+    if (!info || worktreeFinishCardDismissed.has(sid)) return;
+    const win = sessionWindows.get(sid);
+    if (!win || win.worktreeCard) return;
+    renderWorktreeFinishCard(win, sid, info, options);
+  };
+  const existing = sessionWorktreeFinishInfo(sid);
+  if (existing) {
+    attach(existing);
+    return;
+  }
+  hydrateSessionWorktreeFinishInfo(sid).then(attach).catch(() => {});
+}
+
+function dismissWorktreeFinishCard(sid, options = {}) {
+  worktreeFinishCardDismissed.add(sid);
+  const win = sessionWindows.get(sid);
+  if (win?.worktreeCard) {
+    win.worktreeCard.remove();
+    win.worktreeCard = null;
+  }
+  // An explicitly stopped session only kept its window to host this card;
+  // finishing the decision completes the original removal.
+  if (options.removeWindowOnDismiss) removeSessionWindow(sid);
+}
+
+function renderWorktreeFinishCard(win, sid, info, options = {}) {
+  const card = document.createElement('div');
+  card.className = 'session-worktree-card';
+  card.setAttribute('role', 'status');
+
+  const text = document.createElement('div');
+  text.className = 'session-worktree-card-text';
+  const title = document.createElement('div');
+  title.className = 'session-worktree-card-title';
+  title.textContent = `Session ended — worktree branch ${info.branch} is still checked out.`;
+  const detail = document.createElement('div');
+  detail.className = 'session-worktree-card-detail';
+  detail.textContent = info.path;
+  detail.title = info.path;
+  text.appendChild(title);
+  text.appendChild(detail);
+
+  const statusLine = document.createElement('div');
+  statusLine.className = 'session-worktree-card-status hidden';
+
+  const actions = document.createElement('div');
+  actions.className = 'session-worktree-card-actions';
+  const mergeBtn = document.createElement('button');
+  mergeBtn.type = 'button';
+  mergeBtn.className = 'ui-btn session-worktree-card-btn primary';
+  mergeBtn.textContent = info.baseBranch
+    ? `Merge into ${info.baseBranch} & remove worktree`
+    : 'Merge & remove worktree';
+  mergeBtn.title = info.baseBranch
+    ? `git merge ${info.branch} in ${info.baseRoot || 'the base checkout'} (on ${info.baseBranch}), then remove the worktree checkout. Aborts cleanly on conflict.`
+    : 'Merge the worktree branch into the base checkout, then remove the checkout.';
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.className = 'ui-btn session-worktree-card-btn';
+  removeBtn.textContent = 'Remove worktree';
+  removeBtn.title = 'Remove the checkout without merging (refused if it has uncommitted or unmerged work). The branch ref is kept.';
+  const keepBtn = document.createElement('button');
+  keepBtn.type = 'button';
+  keepBtn.className = 'ui-btn session-worktree-card-btn';
+  keepBtn.textContent = 'Keep';
+  keepBtn.title = 'Keep the worktree and dismiss. It stays available in Sessions -> Worktrees.';
+  actions.appendChild(mergeBtn);
+  actions.appendChild(removeBtn);
+  actions.appendChild(keepBtn);
+
+  const setBusy = busy => {
+    for (const btn of [mergeBtn, removeBtn, keepBtn]) btn.disabled = busy;
+    card.classList.toggle('busy', busy);
+  };
+  const showStatus = (kind, message) => {
+    statusLine.className = `session-worktree-card-status ${kind}`;
+    statusLine.textContent = message;
+  };
+  const finishResolved = message => {
+    card.classList.remove('busy');
+    showStatus('ok', message);
+    actions.replaceChildren();
+    const dismissBtn = document.createElement('button');
+    dismissBtn.type = 'button';
+    dismissBtn.className = 'ui-btn session-worktree-card-btn';
+    dismissBtn.textContent = 'Dismiss';
+    dismissBtn.addEventListener('click', () => dismissWorktreeFinishCard(sid, options));
+    actions.appendChild(dismissBtn);
+  };
+  const callWorktreeAction = async (method, url, payload) => {
+    const r = await dashboardTransport.jsonFetch(method, payload, () => (
+      authedFetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+    ), method, { fallbackAfterRpcFailure: false });
+    const textBody = await r.text();
+    let result = {};
+    try { result = textBody ? JSON.parse(textBody) : {}; } catch (_) {}
+    if (!r.ok || result.ok === false) {
+      throw new Error(result.error || `${url} returned ${r.status}`);
+    }
+    return result;
+  };
+
+  mergeBtn.addEventListener('click', async () => {
+    setBusy(true);
+    showStatus('pending', `Merging ${info.branch}...`);
+    try {
+      const result = await callWorktreeAction(
+        'api_worktrees_merge',
+        '/api/worktrees/merge',
+        { session_id: sid },
+      );
+      showControlToast('success', `Merged ${info.branch} into ${result.merged_into || info.baseBranch || 'the base branch'}.`);
+      finishResolved(result.removed
+        ? `Merged into ${result.merged_into || 'the base branch'} and removed the worktree.`
+        : `Merged into ${result.merged_into || 'the base branch'}. Worktree kept: ${result.removal_error || 'removal was refused'}.`);
+    } catch (err) {
+      setBusy(false);
+      showStatus('error', err?.message || 'Worktree merge failed.');
+    }
+  });
+  removeBtn.addEventListener('click', async () => {
+    setBusy(true);
+    showStatus('pending', 'Removing the worktree...');
+    try {
+      await callWorktreeAction(
+        'api_worktrees_remove',
+        '/api/worktrees/remove',
+        { repo_root: info.baseRoot || '', path: info.path },
+      );
+      showControlToast('success', 'Worktree removed.');
+      finishResolved(`Removed the worktree. Branch ${info.branch} is kept.`);
+    } catch (err) {
+      setBusy(false);
+      showStatus('error', err?.message || 'Worktree removal was refused.');
+    }
+  });
+  keepBtn.addEventListener('click', () => dismissWorktreeFinishCard(sid, options));
+
+  card.appendChild(text);
+  card.appendChild(statusLine);
+  card.appendChild(actions);
+  win.el.insertBefore(card, win.log);
+  win.worktreeCard = card;
 }
 
 const TASK_TEXTAREA_MIN_HEIGHT_PX = 28;
@@ -82791,6 +83147,13 @@ async function startNewSession() {
   } else if (execution === 'direct' || direct) {
     msg.direct = true;
   }
+  // Worktree launch: the daemon validates/derives the branch, creates the
+  // worktree off the project's HEAD, and roots the session inside it.
+  if (document.getElementById('new-session-worktree')?.checked) {
+    msg.worktree = true;
+    const worktreeBranch = document.getElementById('new-session-worktree-branch')?.value.trim() || '';
+    if (worktreeBranch) msg.worktree_branch = worktreeBranch;
+  }
   if (attachments.length > 0) msg.attachments = attachments;
 
   try {
@@ -82813,6 +83176,14 @@ async function startNewSession() {
   }
 }
 window.startNewSession = startNewSession;
+
+// Reveal the optional branch-name input only while the worktree launch is
+// requested; an untouched form stays exactly as before.
+function onNewSessionWorktreeToggle() {
+  const checked = !!document.getElementById('new-session-worktree')?.checked;
+  document.getElementById('new-session-worktree-branch-row')?.classList.toggle('hidden', !checked);
+}
+window.onNewSessionWorktreeToggle = onNewSessionWorktreeToggle;
 
 /* ── static/app/56-debug-sessions.js ── */
 // ── Debug Screen ──

--- a/static/app/12-styles-tasks-log.css
+++ b/static/app/12-styles-tasks-log.css
@@ -1236,6 +1236,82 @@ body.context-focus-active {
 .session-window-task::before { content: "msg"; }
 .session-window-project::before { content: "proj"; }
 .session-window-cwd::before { content: "cwd"; }
+.session-window-worktree {
+  flex-shrink: 1;
+  min-width: 0;
+  max-width: 220px;
+  padding: 1px 7px;
+  border: 1px solid color-mix(in srgb, var(--mauve) 30%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--mauve) 10%, transparent);
+  color: var(--mauve);
+  font-size: 10px;
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.session-worktree-card {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 6px 8px 0;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--mauve) 35%, transparent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--mauve) 8%, transparent);
+  font-size: 12px;
+}
+.session-worktree-card.busy {
+  opacity: 0.75;
+}
+.session-worktree-card-text {
+  flex: 1 1 240px;
+  min-width: 0;
+}
+.session-worktree-card-title {
+  font-weight: 700;
+}
+.session-worktree-card-detail {
+  color: var(--overlay1);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.session-worktree-card-status {
+  flex: 1 1 100%;
+  font-size: 11px;
+}
+.session-worktree-card-status.hidden {
+  display: none;
+}
+.session-worktree-card-status.pending {
+  color: var(--yellow);
+}
+.session-worktree-card-status.ok {
+  color: var(--green);
+}
+.session-worktree-card-status.error {
+  color: var(--red);
+}
+.session-worktree-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+.session-worktree-card-btn {
+  height: 24px;
+  padding: 0 10px;
+  font-size: 11px;
+}
+.session-worktree-card-btn.primary {
+  border-color: color-mix(in srgb, var(--mauve) 45%, transparent);
+  background: color-mix(in srgb, var(--mauve) 18%, transparent);
+  color: var(--text);
+}
 .session-window-status {
   flex-shrink: 0;
   padding: 1px 6px;

--- a/static/app/13-styles-sessions-terminal.css
+++ b/static/app/13-styles-sessions-terminal.css
@@ -585,6 +585,22 @@
 .sessions-project-status.ok { color: var(--green); }
 .sessions-project-status.warn { color: var(--yellow); }
 .sessions-project-status.error { color: var(--red); }
+.sessions-worktree-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+.sessions-worktree-toggle {
+  flex-shrink: 0;
+  text-transform: none;
+}
+.sessions-worktree-branch {
+  flex: 1 1 200px;
+  min-width: 160px;
+}
+.sessions-worktree-branch.hidden { display: none; }
 .sessions-start-btn {
   align-self: flex-start;
   padding: 4px 12px;

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -1360,6 +1360,17 @@
                   </div>
                   <div id="new-session-project-status" class="sessions-project-status"></div>
                   <datalist id="new-session-project-options"></datalist>
+                  <div class="sessions-worktree-row">
+                    <label class="sessions-toggle sessions-worktree-toggle" id="new-session-worktree-wrap"
+                           title="Create a fresh git worktree branched off the project's HEAD and run the session inside it. Needs a git repository with at least one commit.">
+                      <input id="new-session-worktree" type="checkbox" onchange="onNewSessionWorktreeToggle()">
+                      Run in a git worktree
+                    </label>
+                    <label class="sessions-new-session-field sessions-worktree-branch hidden" for="new-session-worktree-branch" id="new-session-worktree-branch-row">
+                      Branch name
+                      <input id="new-session-worktree-branch" class="sessions-project-input" type="text" maxlength="120" autocomplete="off" spellcheck="false" placeholder="Optional — derived from the session name">
+                    </label>
+                  </div>
                 </div>
                 <div class="sessions-new-agent-row sessions-new-agent-picker">
                   <label class="sessions-new-session-field" for="new-session-agent">

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -438,7 +438,13 @@ function normalizeSessionWindowMeta(meta = {}) {
     out.projectRoot = project;
     out.projectLabel = compactPathLabel(project, true);
   }
-  const cwd = compactSessionText(meta.cwd || meta.workdir || meta.workDir || meta.worktree || project);
+  // Worktree linkage (an OBJECT — branch/path/base) is distinct from the
+  // legacy string `worktree` cwd alias some callers pass; only the string
+  // form may feed the cwd fallback below.
+  const worktreeInfo = normalizeSessionWorktreeInfo(meta.worktree);
+  if (worktreeInfo) out.worktree = worktreeInfo;
+  const worktreeCwdAlias = typeof meta.worktree === 'string' ? meta.worktree : '';
+  const cwd = compactSessionText(meta.cwd || meta.workdir || meta.workDir || worktreeCwdAlias || project);
   if (cwd) {
     out.cwd = cwd;
     out.cwdLabel = compactPathLabel(cwd, true);
@@ -489,6 +495,24 @@ function normalizeSessionWindowMeta(meta = {}) {
   return out;
 }
 
+// Session worktree linkage from the catalog row / session_meta.json —
+// `{branch, path, base_root, base_branch?, base_sha?}` — normalized to a
+// compact object, or null when absent/malformed.
+function normalizeSessionWorktreeInfo(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const branch = compactSessionText(raw.branch);
+  const path = compactSessionText(raw.path);
+  if (!branch || !path) return null;
+  const info = { branch, path };
+  const baseRoot = compactSessionText(raw.base_root || raw.baseRoot);
+  if (baseRoot) info.baseRoot = baseRoot;
+  const baseBranch = compactSessionText(raw.base_branch || raw.baseBranch);
+  if (baseBranch) info.baseBranch = baseBranch;
+  const baseSha = compactSessionText(raw.base_sha || raw.baseSha);
+  if (baseSha) info.baseSha = baseSha;
+  return info;
+}
+
 function sessionWindowMetadataSignature(meta = {}) {
   return [
     meta.name || '',
@@ -497,6 +521,7 @@ function sessionWindowMetadataSignature(meta = {}) {
     meta.projectLabel || '',
     meta.cwd || '',
     meta.cwdLabel || '',
+    meta.worktree ? `${meta.worktree.branch}${meta.worktree.path}${meta.worktree.baseBranch || ''}` : '',
     meta.source || '',
     meta.sourceLabel || '',
     meta.backendSource || '',
@@ -905,6 +930,7 @@ function sessionWindowMetaFromSession(session) {
     task: session.task,
     cwd: session.cwd || session.workdir || session.workDir,
     project_root: session.project_root,
+    worktree: session.worktree,
     source: session.source,
     source_label: session.backend_source_label || session.source_label || prettyAgentName(session.backend_source || session.source || '') || session.backend_source || session.source,
     backend_source: session.backend_source,
@@ -1178,6 +1204,7 @@ function persistedSessionWindowRecord(sessionId, win = null) {
   if (meta.codexContextArchive) record.codex_context_archive = meta.codexContextArchive;
   if (meta.projectRoot) record.project_root = meta.projectRoot;
   if (meta.cwd) record.cwd = meta.cwd;
+  if (meta.worktree) record.worktree = meta.worktree;
   if (meta.parentId && meta.relationshipKind) {
     record.parent_session_id = meta.parentId;
     record.relationship = meta.relationshipKind;

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -150,11 +150,14 @@ function ensureSessionWindow(sessionId, meta = {}) {
     'unknown',
     'Working directory not known yet'
   );
+  const worktreeBadge = document.createElement('span');
+  worktreeBadge.className = 'session-window-worktree hidden';
   const metaRow = document.createElement('div');
   metaRow.className = 'session-window-meta';
   metaRow.appendChild(id);
   metaRow.appendChild(relationStrip);
   metaRow.appendChild(project);
+  metaRow.appendChild(worktreeBadge);
   const task = document.createElement('div');
   task.className = 'session-window-task';
   task.textContent = meta.task || 'initial message pending';
@@ -323,6 +326,7 @@ function ensureSessionWindow(sessionId, meta = {}) {
     relationStrip,
     project,
     cwd,
+    worktreeBadge,
     task,
     status,
     goal,
@@ -407,6 +411,7 @@ function updateSessionWindow(sessionId, meta = {}) {
     );
   }
   refreshSessionWindowPathLabels(win);
+  renderSessionWindowWorktreeBadge(win, meta.worktree || null);
   if (meta.task) {
     win.task.textContent = meta.task;
     win.task.title = meta.task;
@@ -442,6 +447,27 @@ function updateSessionWindow(sessionId, meta = {}) {
   if (meta.parentId) updateSessionRelationshipBadges(meta.parentId);
   scheduleSessionRelationshipRender();
   persistSessionWindowState();
+}
+
+// Worktree badge next to the project path: branch name up front, the full
+// linkage (checkout path, base branch/commit) in the tooltip.
+function renderSessionWindowWorktreeBadge(win, worktree) {
+  if (!win?.worktreeBadge) return;
+  if (!worktree?.branch) {
+    win.worktreeBadge.className = 'session-window-worktree hidden';
+    win.worktreeBadge.textContent = '';
+    win.worktreeBadge.title = '';
+    return;
+  }
+  win.worktreeBadge.className = 'session-window-worktree';
+  win.worktreeBadge.textContent = `⎇ ${worktree.branch}`;
+  const lines = [`Session runs in a git worktree on branch ${worktree.branch}`];
+  if (worktree.path) lines.push(`Checkout: ${worktree.path}`);
+  if (worktree.baseRoot) lines.push(`Base project: ${worktree.baseRoot}`);
+  if (worktree.baseBranch) {
+    lines.push(`Branched from ${worktree.baseBranch}${worktree.baseSha ? ` @ ${worktree.baseSha.slice(0, 12)}` : ''}`);
+  }
+  win.worktreeBadge.title = lines.join('\n');
 }
 
 function updateSessionWindowMinimizeState(sessionId) {

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -116,7 +116,15 @@ function onSessionEnded(sessionId, reason, errorKind) {
   } else if (explicitStop) {
     clearPendingFollowUpsForSession(sid, reason || 'session stopped');
     removeSessionRelationshipsForSession(sid);
-    removeSessionWindow(sid);
+    // A worktree-backed session leaves a decision behind (merge / remove /
+    // keep the worktree), so its window survives an explicit stop to host
+    // the finish card; dismissing the card completes the removal.
+    if (sessionWorktreeFinishInfo(sid)) {
+      updateSessionWindow(sid, { phase: 'done', ended: true });
+      maybeShowWorktreeFinishCard(sid, { removeWindowOnDismiss: true });
+    } else {
+      removeSessionWindow(sid);
+    }
   } else if (restarting) {
     clearPendingFollowUpsForSession(sid, reason || 'restarting session');
     updateSessionWindow(sid, { phase: 'idle', ended: false });
@@ -126,6 +134,7 @@ function onSessionEnded(sessionId, reason, errorKind) {
     setSessionWindowDetached(sid, true, reason || 'session ended');
   } else if (sid) {
     updateSessionWindow(sid, { phase: 'done', ended: true });
+    maybeShowWorktreeFinishCard(sid);
   }
   if (!keepExternalDetached && (!sessionId || sessionId === currentSessionFullId)) {
     currentSessionFullId = '';
@@ -153,6 +162,197 @@ function onSessionEnded(sessionId, reason, errorKind) {
   scheduleSessionRelationshipRender();
   // Refresh sessions list if already loaded
   if (sessionsLoaded) loadSessions();
+}
+
+// ── Worktree finish card ───────────────────────────────────────────────────
+// When a session that ran in a git worktree ends, its window offers the
+// three explicit outcomes for the branch it leaves behind: merge it back
+// into the base checkout (and remove the checkout), remove the checkout
+// via the same safety-checked path as the Worktrees tab, or keep it.
+// Nothing is ever automatic — the worktree persists until a click.
+
+const worktreeFinishCardDismissed = new Set();
+
+function sessionWorktreeFinishInfo(sid) {
+  const meta = sid ? (sessionMetadataById.get(sid) || {}) : {};
+  return meta.worktree && meta.worktree.branch && meta.worktree.path ? meta.worktree : null;
+}
+
+// The linkage rides the session catalog row (from session_meta.json); it is
+// normally hydrated well before the session ends, but fetch once on demand
+// for windows that never saw a metadata refresh.
+async function hydrateSessionWorktreeFinishInfo(sid) {
+  const existing = sessionWorktreeFinishInfo(sid);
+  if (existing) return existing;
+  let sessions = null;
+  if (typeof dashboardTransport !== 'undefined' && dashboardTransport?.canUseRpc()) {
+    try {
+      sessions = await dashboardTransport.request('api_sessions', { ids: [sid] });
+    } catch (_) {}
+  }
+  if (!sessions) {
+    try {
+      const r = await authedFetch(`/api/sessions?ids=${encodeURIComponent(sid)}`);
+      if (!r.ok) return null;
+      sessions = await r.json();
+    } catch (_) {
+      return null;
+    }
+  }
+  if (Array.isArray(sessions)) cacheSessionWindowMetadata(sessions);
+  return sessionWorktreeFinishInfo(sid);
+}
+
+function maybeShowWorktreeFinishCard(sid, options = {}) {
+  if (!sid || worktreeFinishCardDismissed.has(sid)) return;
+  const attach = info => {
+    if (!info || worktreeFinishCardDismissed.has(sid)) return;
+    const win = sessionWindows.get(sid);
+    if (!win || win.worktreeCard) return;
+    renderWorktreeFinishCard(win, sid, info, options);
+  };
+  const existing = sessionWorktreeFinishInfo(sid);
+  if (existing) {
+    attach(existing);
+    return;
+  }
+  hydrateSessionWorktreeFinishInfo(sid).then(attach).catch(() => {});
+}
+
+function dismissWorktreeFinishCard(sid, options = {}) {
+  worktreeFinishCardDismissed.add(sid);
+  const win = sessionWindows.get(sid);
+  if (win?.worktreeCard) {
+    win.worktreeCard.remove();
+    win.worktreeCard = null;
+  }
+  // An explicitly stopped session only kept its window to host this card;
+  // finishing the decision completes the original removal.
+  if (options.removeWindowOnDismiss) removeSessionWindow(sid);
+}
+
+function renderWorktreeFinishCard(win, sid, info, options = {}) {
+  const card = document.createElement('div');
+  card.className = 'session-worktree-card';
+  card.setAttribute('role', 'status');
+
+  const text = document.createElement('div');
+  text.className = 'session-worktree-card-text';
+  const title = document.createElement('div');
+  title.className = 'session-worktree-card-title';
+  title.textContent = `Session ended — worktree branch ${info.branch} is still checked out.`;
+  const detail = document.createElement('div');
+  detail.className = 'session-worktree-card-detail';
+  detail.textContent = info.path;
+  detail.title = info.path;
+  text.appendChild(title);
+  text.appendChild(detail);
+
+  const statusLine = document.createElement('div');
+  statusLine.className = 'session-worktree-card-status hidden';
+
+  const actions = document.createElement('div');
+  actions.className = 'session-worktree-card-actions';
+  const mergeBtn = document.createElement('button');
+  mergeBtn.type = 'button';
+  mergeBtn.className = 'ui-btn session-worktree-card-btn primary';
+  mergeBtn.textContent = info.baseBranch
+    ? `Merge into ${info.baseBranch} & remove worktree`
+    : 'Merge & remove worktree';
+  mergeBtn.title = info.baseBranch
+    ? `git merge ${info.branch} in ${info.baseRoot || 'the base checkout'} (on ${info.baseBranch}), then remove the worktree checkout. Aborts cleanly on conflict.`
+    : 'Merge the worktree branch into the base checkout, then remove the checkout.';
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.className = 'ui-btn session-worktree-card-btn';
+  removeBtn.textContent = 'Remove worktree';
+  removeBtn.title = 'Remove the checkout without merging (refused if it has uncommitted or unmerged work). The branch ref is kept.';
+  const keepBtn = document.createElement('button');
+  keepBtn.type = 'button';
+  keepBtn.className = 'ui-btn session-worktree-card-btn';
+  keepBtn.textContent = 'Keep';
+  keepBtn.title = 'Keep the worktree and dismiss. It stays available in Sessions -> Worktrees.';
+  actions.appendChild(mergeBtn);
+  actions.appendChild(removeBtn);
+  actions.appendChild(keepBtn);
+
+  const setBusy = busy => {
+    for (const btn of [mergeBtn, removeBtn, keepBtn]) btn.disabled = busy;
+    card.classList.toggle('busy', busy);
+  };
+  const showStatus = (kind, message) => {
+    statusLine.className = `session-worktree-card-status ${kind}`;
+    statusLine.textContent = message;
+  };
+  const finishResolved = message => {
+    card.classList.remove('busy');
+    showStatus('ok', message);
+    actions.replaceChildren();
+    const dismissBtn = document.createElement('button');
+    dismissBtn.type = 'button';
+    dismissBtn.className = 'ui-btn session-worktree-card-btn';
+    dismissBtn.textContent = 'Dismiss';
+    dismissBtn.addEventListener('click', () => dismissWorktreeFinishCard(sid, options));
+    actions.appendChild(dismissBtn);
+  };
+  const callWorktreeAction = async (method, url, payload) => {
+    const r = await dashboardTransport.jsonFetch(method, payload, () => (
+      authedFetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+    ), method, { fallbackAfterRpcFailure: false });
+    const textBody = await r.text();
+    let result = {};
+    try { result = textBody ? JSON.parse(textBody) : {}; } catch (_) {}
+    if (!r.ok || result.ok === false) {
+      throw new Error(result.error || `${url} returned ${r.status}`);
+    }
+    return result;
+  };
+
+  mergeBtn.addEventListener('click', async () => {
+    setBusy(true);
+    showStatus('pending', `Merging ${info.branch}...`);
+    try {
+      const result = await callWorktreeAction(
+        'api_worktrees_merge',
+        '/api/worktrees/merge',
+        { session_id: sid },
+      );
+      showControlToast('success', `Merged ${info.branch} into ${result.merged_into || info.baseBranch || 'the base branch'}.`);
+      finishResolved(result.removed
+        ? `Merged into ${result.merged_into || 'the base branch'} and removed the worktree.`
+        : `Merged into ${result.merged_into || 'the base branch'}. Worktree kept: ${result.removal_error || 'removal was refused'}.`);
+    } catch (err) {
+      setBusy(false);
+      showStatus('error', err?.message || 'Worktree merge failed.');
+    }
+  });
+  removeBtn.addEventListener('click', async () => {
+    setBusy(true);
+    showStatus('pending', 'Removing the worktree...');
+    try {
+      await callWorktreeAction(
+        'api_worktrees_remove',
+        '/api/worktrees/remove',
+        { repo_root: info.baseRoot || '', path: info.path },
+      );
+      showControlToast('success', 'Worktree removed.');
+      finishResolved(`Removed the worktree. Branch ${info.branch} is kept.`);
+    } catch (err) {
+      setBusy(false);
+      showStatus('error', err?.message || 'Worktree removal was refused.');
+    }
+  });
+  keepBtn.addEventListener('click', () => dismissWorktreeFinishCard(sid, options));
+
+  card.appendChild(text);
+  card.appendChild(statusLine);
+  card.appendChild(actions);
+  win.el.insertBefore(card, win.log);
+  win.worktreeCard = card;
 }
 
 const TASK_TEXTAREA_MIN_HEIGHT_PX = 28;

--- a/static/app/55-files-ide.js
+++ b/static/app/55-files-ide.js
@@ -3070,6 +3070,13 @@ async function startNewSession() {
   } else if (execution === 'direct' || direct) {
     msg.direct = true;
   }
+  // Worktree launch: the daemon validates/derives the branch, creates the
+  // worktree off the project's HEAD, and roots the session inside it.
+  if (document.getElementById('new-session-worktree')?.checked) {
+    msg.worktree = true;
+    const worktreeBranch = document.getElementById('new-session-worktree-branch')?.value.trim() || '';
+    if (worktreeBranch) msg.worktree_branch = worktreeBranch;
+  }
   if (attachments.length > 0) msg.attachments = attachments;
 
   try {
@@ -3092,4 +3099,12 @@ async function startNewSession() {
   }
 }
 window.startNewSession = startNewSession;
+
+// Reveal the optional branch-name input only while the worktree launch is
+// requested; an untouched form stays exactly as before.
+function onNewSessionWorktreeToggle() {
+  const checked = !!document.getElementById('new-session-worktree')?.checked;
+  document.getElementById('new-session-worktree-branch-row')?.classList.toggle('hidden', !checked);
+}
+window.onNewSessionWorktreeToggle = onNewSessionWorktreeToggle;
 

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -816,6 +816,201 @@ async fn projectless_daemon_serves_and_requires_an_explicit_session_project() {
     child.kill().await.expect("stop the daemon");
 }
 
+/// Worktree sessions, the daemon lane: `CreateSession { worktree: true }`
+/// must branch a fresh worktree off the project's HEAD and run the session
+/// INSIDE it. The scripted loop proves the cwd through the real runtime by
+/// writing a relative-path probe file — it must land in the worktree
+/// checkout, not the base project — and the session's recorded meta pins
+/// the linkage (branch, checkout path, base branch/sha) plus the effective
+/// project root.
+#[tokio::test]
+async fn create_session_with_worktree_runs_inside_the_worktree() {
+    use futures_util::SinkExt;
+
+    let rig = TestRig::new();
+    // The daemon's default project is a real git repo with one commit
+    // (worktree launches branch from HEAD, so an empty repo is an error by
+    // design). intendant.toml doubles as the rooted-daemon marker
+    // spawn_daemon_on_rig would write; committing it keeps the base clean.
+    let project = rig.project.path().to_path_buf();
+    let git = |args: &[&str]| {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(&project)
+            .output()
+            .expect("run git");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+    git(&["init", "-b", "main"]);
+    git(&["config", "user.email", "e2e@test.com"]);
+    git(&["config", "user.name", "E2E"]);
+    std::fs::write(project.join("intendant.toml"), "").expect("project marker");
+    std::fs::write(project.join("README.md"), "# worktree e2e\n").expect("seed file");
+    git(&["add", "."]);
+    git(&["commit", "-m", "initial"]);
+    let base_head = {
+        let out = std::process::Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&project)
+            .output()
+            .expect("read base HEAD");
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    };
+
+    // `echo MARKER && echo done > wt_probe.txt` works under both sh and
+    // cmd; the relative redirect target is the cwd proof.
+    let script = serde_json::json!({
+        "profiles": [{
+            "steps": [
+                { "content": "Writing the cwd probe.",
+                  "tool_calls": [{ "name": "exec_command",
+                                   "arguments": { "nonce": 1,
+                                                  "command": "echo WORKTREE_E2E_ROUNDTRIP && echo done > wt_probe.txt" } }] },
+                { "expect_transcript_contains": "WORKTREE_E2E_ROUNDTRIP",
+                  "content": "Probe written.",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "worktree session complete" } }] }
+            ]
+        }]
+    });
+
+    let client = reqwest::Client::new();
+    let mut daemon = spawn_daemon_on_rig(&client, rig, &script, free_loopback_port(), false).await;
+    let (mut ws, _) =
+        tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{}/ws", daemon.port))
+            .await
+            .expect("connect /ws");
+
+    // The very first control message can race daemon startup on a
+    // saturated box (the gateway accepts /ws a beat before the
+    // supervisor's bus subscription), so retry until session_started.
+    let mut started = None;
+    for _ in 0..6 {
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::json!({
+                "action": "create_session",
+                "task": "write the probe file in the isolated checkout",
+                "direct": true,
+                "worktree": true,
+                "worktree_branch": "wt-e2e",
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send worktree create_session");
+        started = next_matching_ws_event(&mut ws, Duration::from_secs(30), |json| {
+            json.get("event").and_then(|v| v.as_str()) == Some("session_started")
+                && json
+                    .get("task")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|task| task.contains("isolated checkout"))
+        })
+        .await;
+        if started.is_some() {
+            break;
+        }
+    }
+    let started = started.unwrap_or_else(|| {
+        panic!(
+            "worktree create_session never started; daemon log:\n{}",
+            daemon.log_tail()
+        )
+    });
+    let session_id = started
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .expect("session_started carries a session id")
+        .to_string();
+
+    complete_and_stop_session(&mut ws, &session_id, || daemon.log_tail()).await;
+
+    // The worktree exists where the launch contract says (a `.git` file,
+    // not a directory, marks a linked worktree checkout).
+    let worktree_path = project.join(".intendant").join("worktrees").join("wt-e2e");
+    assert!(
+        worktree_path.join(".git").is_file(),
+        "expected a linked worktree checkout at {}",
+        worktree_path.display()
+    );
+
+    // cwd proof: the relative-path probe landed inside the worktree, and
+    // did NOT land in the base project.
+    assert!(
+        worktree_path.join("wt_probe.txt").is_file(),
+        "probe file missing from the worktree — the session did not run inside it; daemon log:\n{}",
+        daemon.log_tail()
+    );
+    assert!(
+        !project.join("wt_probe.txt").exists(),
+        "probe file leaked into the base project — the session ran in the wrong cwd"
+    );
+
+    // Recorded linkage: effective project root is the worktree, and the
+    // worktree meta names the branch and where it branched from.
+    let meta_raw = std::fs::read_to_string(
+        daemon
+            .rig
+            .home
+            .path()
+            .join(".intendant")
+            .join("logs")
+            .join(&session_id)
+            .join("session_meta.json"),
+    )
+    .expect("session_meta.json for the worktree session");
+    let meta: serde_json::Value = serde_json::from_str(&meta_raw).expect("meta parses");
+    let recorded_root = meta
+        .get("project_root")
+        .and_then(|v| v.as_str())
+        .expect("meta records a project root");
+    assert!(
+        std::fs::canonicalize(recorded_root).expect("recorded root exists")
+            == std::fs::canonicalize(&worktree_path).expect("worktree exists"),
+        "meta project_root {recorded_root} is not the worktree {}",
+        worktree_path.display()
+    );
+    let linkage = meta.get("worktree").expect("meta records worktree linkage");
+    assert_eq!(linkage["branch"], "wt-e2e", "{linkage}");
+    assert_eq!(linkage["base_branch"], "main", "{linkage}");
+    assert_eq!(linkage["base_sha"], serde_json::json!(base_head), "{linkage}");
+    assert!(
+        linkage
+            .get("base_root")
+            .and_then(|v| v.as_str())
+            .is_some_and(
+                |root| std::fs::canonicalize(root).ok() == std::fs::canonicalize(&project).ok()
+            ),
+        "{linkage}"
+    );
+
+    // The done signal only fired after the runtime round-trip, and the
+    // base checkout never left its branch.
+    assert!(
+        daemon
+            .rig
+            .session_logs()
+            .contains("worktree session complete"),
+        "session log missing the done signal"
+    );
+    let base_branch_now = std::process::Command::new("git")
+        .args(["symbolic-ref", "--short", "-q", "HEAD"])
+        .current_dir(&project)
+        .output()
+        .expect("read base branch");
+    assert_eq!(
+        String::from_utf8_lossy(&base_branch_now.stdout).trim(),
+        "main",
+        "worktree launch must not move the base checkout"
+    );
+
+    daemon.child.kill().await.expect("stop the daemon");
+}
+
 #[tokio::test]
 async fn mock_provider_without_a_script_fails_closed() {
     let rig = TestRig::new();


### PR DESCRIPTION
Adds "launch in a git worktree" to top-level session creation, end to end, plus a session-end worktree finish card.

## Wire + launch
- `ControlMsg::CreateSession` gains `worktree: Option<bool>` and `worktree_branch: Option<String>` (serde-defaulted; legacy payloads unchanged).
- `start_new_session` resolves the project root as before, then (when requested) requires a git repository with at least one commit (clear, actionable errors; the failure closes the just-opened session honestly, mirroring the no-project arm), validates the requested branch name against a conservative git-ref subset (path traversal, `@{`, `.lock`, leading `-`/`.` all rejected) or derives one (session-name slug, else `session-<short-id>`, numeric suffix on collision), creates the worktree off HEAD via `worktree::create`, and uses the checkout as the session's effective project root.
- Linkage (branch, checkout path, base root, base branch, base sha) is recorded in `session_meta.json` (`SessionMeta.worktree`), survives later meta rewrites, and is served on session-catalog rows; the Worktrees tab keeps inferring session-linkage by cwd/project-root as before (no duplication).

## Dashboard
- New Session form: "Run in a git worktree" checkbox grouped with the Project field; optional branch-name input revealed when checked.
- Session window header shows a worktree badge (branch; tooltip carries checkout path + base branch/sha).
- Finish card when a worktree-backed session ends: "Merge into `<base branch>` & remove worktree" / "Remove worktree" / "Keep" — every action an explicit click, nothing automatic. Merge conflicts abort cleanly and surface the message; removal refusals (dirty/unmerged) surface the safety reason. An explicitly stopped worktree session keeps its window until the card is dismissed (the decision outlives the stop); dismissal completes the removal.

## Server: `/api/worktrees/merge`
- Declared as a `ROUTES` row (SessionManage, bounded body) with an `api_worktrees_merge` tunnel twin on the row (`TunnelSpec`; IAM derives from the row) — no `CONTROL_METHODS` entry. Partition pin + docs table updated.
- The request carries only a `session_id`; branch/path/base all come from the session's recorded linkage, so the endpoint can only merge session-linked worktree branches, never arbitrary refs. It refuses drifted preconditions fail-closed (unregistered checkout, renamed branch, base checkout moved to another branch or detached), runs `worktree::merge` (now un-dead-coded) in the base checkout, aborts on conflict, then removes the checkout via `worktree_inventory::remove_worktree_if_safe` (a refusal is reported in the response, not fatal — the merge already landed; the branch ref is always kept).

## Tests
- Unit: branch validation/derivation/uniqueness, git preflight errors (non-repo, no commits), linkage recording + meta-rewrite survival, merge endpoint (clean merge+remove, conflict abort, moved-base refusal, no-linkage, bad/unknown session ids, missing worktree), CreateSession wire round-trip.
- E2E (mock provider, keyless): create-with-worktree over `/ws` → the scripted loop proves cwd by reading the checked-out branch inside the session; asserts the worktree checkout, recorded linkage, and effective project root.

## Docs
- `docs/src/multi-agent.md`: top-level worktree sessions section.
- `docs/src/web-dashboard.md`: endpoint table row (pinned by `endpoint_docs_match_chapter`) + RPC method notes.

## Follow-ups (not in this PR)
- `intendant ctl task start` reaches the daemon via the MCP `start_task` tool (`ControlMsg::StartTask`), which never goes through `CreateSession` — adding `--worktree/--worktree-branch` there means threading the fields through `StartTask` or teaching `ctl` to emit `create_session`; left as a follow-up rather than widening the legacy wire shape in this PR.
- Station parity for the worktree badge/finish card (`crates/station-web` deliberately untouched — committed WASM artifacts).
- Post-merge removal uses the inventory safety check, which requires the worktree head to be reachable from the default branch or upstream; merging into a non-default base branch reports "kept: not reachable" instead of removing — by design (fail-closed), noted here for operators.