### PR TITLE
Access: same-host peer-id collision no longer steals the local target's grant labels

### DIFF
--- a/src/bin/caller/access/iam.rs
+++ b/src/bin/caller/access/iam.rs
@@ -2330,10 +2330,20 @@ pub fn grant_overview_values(state: &LocalIamState, default_target_id: &str) -> 
             } else {
                 grant.status.as_str()
             };
+            // Stored grants carry the literal "local" sentinel when the
+            // upsert request named no target (`upsert_user_client_grant`
+            // defaults to it); it means "this daemon", never a peer.
+            // Project it — like the empty default — to the daemon's real
+            // target id so the dashboard resolves the row to this daemon's
+            // label instead of echoing the raw sentinel ("on local").
+            let target_id = match grant.target_id.as_str() {
+                "" | "local" => default_target_id,
+                other => other,
+            };
             json!({
                 "id": grant.id.clone(),
                 "principal_id": grant.principal_id.clone(),
-                "target_id": if grant.target_id.is_empty() { default_target_id } else { grant.target_id.as_str() },
+                "target_id": target_id,
                 "kind": "user_client_local_iam",
                 "kind_label": "Local IAM user/client grant",
                 "policy_id": if grant.policy_id.is_empty() { "policy:scoped-human" } else { grant.policy_id.as_str() },
@@ -3402,6 +3412,32 @@ mod tests {
         assert_eq!(grants[0]["target_id"], "local-daemon");
         assert_eq!(grants[0]["status"], "draft");
         assert_eq!(grants[0]["enforced"], false);
+    }
+
+    /// `upsert_user_client_grant` stores the literal "local" sentinel when
+    /// the request names no target. The overview projection must map that
+    /// sentinel — exactly like the empty default — to the daemon's real
+    /// target id, or the dashboard's grant rows echo the raw string
+    /// ("Scoped human on local") instead of resolving this daemon's label
+    /// (seen in the design-overhaul QA fleet access audit, FR-3 evidence).
+    #[test]
+    fn overview_values_map_local_sentinel_target_to_default_target_id() {
+        let mut state = LocalIamState::default();
+        let actor = AccessPrincipal::root_dashboard_session("test", "dashboard-control");
+        upsert_user_client_grant(
+            &mut state,
+            UserClientGrantUpsertRequest {
+                client_key_fingerprint: Some("alice-key".to_string()),
+                ..Default::default()
+            },
+            &actor,
+        )
+        .unwrap();
+        assert_eq!(state.grants[0].target_id, "local", "stored sentinel");
+
+        let grants = grant_overview_values(&state, "intendant:qa-host");
+
+        assert_eq!(grants[0]["target_id"], "intendant:qa-host");
     }
 
     fn active_browser_cert_state() -> LocalIamState {

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -2612,6 +2612,110 @@ mod tests {
         assert_eq!(payload["iam"]["managed_grants"], 1);
     }
 
+    /// FR-3 (design-overhaul QA fleet, Access tab): a manually added
+    /// same-host peer carries the same id as the local daemon — `PeerId`
+    /// is `intendant:<host label>`, so two daemons sharing a hostname
+    /// collide. The dashboard resolves every grant row's target label over
+    /// `targets[]` id-first with FIRST-writer-wins
+    /// (`accessOverviewTargetLabelMap` in static/app/42-usage-terminal.js),
+    /// so the payload contract pinned here is:
+    ///
+    /// 1. the local daemon is present and FIRST in `targets[]`, keeping its
+    ///    label authoritative for the shared id under first-wins;
+    /// 2. the colliding peer row still appears (a real configured peer is
+    ///    never silently dropped), carrying its own label; and
+    /// 3. the current-subject root grant is stamped with the local target
+    ///    id, so it resolves to the local daemon's label.
+    ///
+    /// Before the first-wins fix the peer row overwrote the shared map key
+    /// and every local-daemon grant rendered under the peer's name — the
+    /// audit screenshot showed "Root on qa-peer-b" for a grant on the
+    /// local daemon.
+    #[tokio::test]
+    async fn access_overview_same_host_peer_id_collision_keeps_local_label_authoritative() {
+        use crate::peer::id::{PeerId, PeerKind};
+
+        // Both daemons resolve the same host label, so both cards carry
+        // the same id — the local one via `build_local_agent_card`, the
+        // peer via its fetched card.
+        let shared_id = PeerId::new(PeerKind::Intendant, "qa-host");
+        let host_form_id = shared_id.as_str();
+        let agent_card = serde_json::json!({
+            "id": host_form_id,
+            "label": "This daemon",
+            "capabilities": [],
+        });
+
+        let (log_tx, _log_rx) =
+            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(16);
+        let registry = crate::peer::PeerRegistry::new(log_tx);
+        registry
+            .add_peer_with_card(crate::peer::AgentCard {
+                id: shared_id.clone(),
+                label: "qa-peer-b".to_string(),
+                version: "0.0.0".to_string(),
+                git_sha: None,
+                transports: vec![crate::peer::TransportSpec::IntendantWs {
+                    url: "ws://127.0.0.1:9/ws".to_string(),
+                }],
+                capabilities: Vec::new(),
+                auth: crate::peer::AuthRequirements::none(),
+            })
+            .await
+            .expect("register colliding same-host peer");
+
+        let iam_state = crate::access::iam::LoadedIamState {
+            path: std::path::PathBuf::from(crate::access::iam::IAM_STATE_FILE),
+            state: crate::access::iam::LocalIamState::default(),
+            status: crate::access::iam::IamStateStatus::Missing,
+        };
+        let payload = access_overview_response_value_with_identities_and_iam(
+            &agent_card,
+            Some(&registry),
+            &[],
+            &iam_state,
+            None,
+        );
+
+        let targets = payload["targets"].as_array().expect("targets");
+        assert_eq!(targets.len(), 2, "local + colliding peer");
+        assert_eq!(targets[0]["local"], true, "local target must stay first");
+        assert_eq!(targets[0]["id"], host_form_id);
+        assert_eq!(targets[0]["label"], "This daemon");
+        assert_eq!(targets[1]["id"], host_form_id, "collision is representable");
+        assert_eq!(targets[1]["label"], "qa-peer-b");
+
+        let grants = payload["grants"].as_array().expect("grants");
+        let root_grant = grants
+            .iter()
+            .find(|grant| grant["role"] == "root")
+            .expect("current-subject root grant");
+        assert_eq!(root_grant["target_id"], host_form_id);
+
+        // Mirror of the dashboard's target-label resolution
+        // (accessOverviewTargetLabelMap + accessCreateGrantRow): id-first
+        // over id/host_id, first writer wins. Under the payload order
+        // pinned above this resolves the root grant to the local label;
+        // the pre-fix last-writer-wins fill resolved it to "qa-peer-b".
+        let mut labels: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+        for target in targets {
+            for key in ["id", "host_id"] {
+                if let Some(id) = target[key].as_str().filter(|v| !v.trim().is_empty()) {
+                    labels
+                        .entry(id)
+                        .or_insert_with(|| target["label"].as_str().unwrap_or(id));
+                }
+            }
+        }
+        assert_eq!(
+            labels
+                .get(root_grant["target_id"].as_str().expect("root target id"))
+                .copied(),
+            Some("This daemon"),
+            "local root grant must resolve to the local daemon's label"
+        );
+    }
+
     #[test]
     fn peer_connection_identity_requires_approved_record_for_peer_mode() {
         let tmp = tempfile::TempDir::new().unwrap();

--- a/static/app.html
+++ b/static/app.html
@@ -52602,9 +52602,16 @@ function accessModelLabel(value, fallback = '') {
 
 function accessOverviewTargetLabelMap(overview) {
   const map = new Map();
+  // First writer wins on BOTH keys. The daemon emits the local target as
+  // the first targets[] row, and a manually added same-host peer can carry
+  // the very same id/host_id (PeerId is `intendant:<host label>`, and host
+  // labels collide when two daemons share a hostname). Letting a later peer
+  // row overwrite the key relabelled every local-daemon grant with the
+  // peer's name — "Root on qa-peer-b" for a grant on this daemon
+  // (design-overhaul QA fleet, access finding FR-3).
   for (const target of Array.isArray(overview.targets) ? overview.targets : []) {
     const id = accessModelLabel(target.id || target.host_id);
-    if (id) map.set(id, accessModelLabel(target.label, id));
+    if (id && !map.has(id)) map.set(id, accessModelLabel(target.label, id));
     const hostId = accessModelLabel(target.host_id);
     if (hostId && !map.has(hostId)) map.set(hostId, accessModelLabel(target.label, hostId));
   }

--- a/static/app/42-usage-terminal.js
+++ b/static/app/42-usage-terminal.js
@@ -2025,9 +2025,16 @@ function accessModelLabel(value, fallback = '') {
 
 function accessOverviewTargetLabelMap(overview) {
   const map = new Map();
+  // First writer wins on BOTH keys. The daemon emits the local target as
+  // the first targets[] row, and a manually added same-host peer can carry
+  // the very same id/host_id (PeerId is `intendant:<host label>`, and host
+  // labels collide when two daemons share a hostname). Letting a later peer
+  // row overwrite the key relabelled every local-daemon grant with the
+  // peer's name — "Root on qa-peer-b" for a grant on this daemon
+  // (design-overhaul QA fleet, access finding FR-3).
   for (const target of Array.isArray(overview.targets) ? overview.targets : []) {
     const id = accessModelLabel(target.id || target.host_id);
-    if (id) map.set(id, accessModelLabel(target.label, id));
+    if (id && !map.has(id)) map.set(id, accessModelLabel(target.label, id));
     const hostId = accessModelLabel(target.host_id);
     if (hostId && !map.has(hostId)) map.set(hostId, accessModelLabel(target.label, hostId));
   }


### PR DESCRIPTION
Closes QA-fleet finding access FR-3 ("Root on qa-peer-b" on a local grant). Root cause, reproduced and pinned: `PeerId` = `intendant:<host_label>`, so a same-host peer carries the local daemon's id; `targets[]` has no dedupe (local first, peers after), and the frontend's target-label map filled keys **last-writer-wins** — the peer row stole the shared key, relabeling every local grant.

- `42-usage-terminal.js`: the label map is now first-writer-wins on both keys (server order makes the local label authoritative; matches the `accessTargetRecords` dedupe precedent).
- `access/iam.rs`: `grant_overview_values` projects the stored `"local"` sentinel to the daemon's real target id (visible as raw "on local" in the same evidence shot) — `"local"` can never name a peer.
- Pins: a Rust test registers a colliding peer through the real `PeerRegistry` and asserts local-first + label resolution; an iam.rs test pins the sentinel projection. Old-vs-new JS run over the pinned payload reproduces the screenshot verbatim pre-fix.

Battery: nextest 2766/2766, clippy clean for changed files, app-html regen gate satisfied.