### PR TITLE
Transport S4a: sessions read-core neutral conversion + tunnel delegation

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -47,11 +47,17 @@ filter = 'test(/ctl_peer_mtls_pairing/)'
 slow-timeout = { period = "120s", terminate-after = 3 }
 
 # These handlers walk the real ~/.intendant/logs via dirs::home_dir()
-# (routes_sessions.rs agent-output / managed-context scans); on a box
-# whose log tree has grown to tens of GB their ~12s baseline breaches the
+# (routes_sessions.rs agent-output / managed-context scans; the S4a
+# golden transcripts and tunnel/HTTP parity fixtures pin missing-session
+# 404s and fallback sweeps through the same live store); on a box whose
+# log tree has grown to tens of GB their ~12s baseline breaches the
 # default terminator under suite parallelism while passing in isolation.
 # Headroom until that home scan is cfg(test)-gated like listener.rs's
 # session-index warm scan.
 [[profile.default.overrides]]
-filter = 'test(/^web_gateway::routes_sessions::tests::(agent_output_post_response_reads_json_ids|managed_context_anchors_response_reads_trace_anchors_by_backend_session|managed_context_records_response_)/)'
+filter = 'test(/^web_gateway::routes_sessions::tests::(agent_output_post_response_reads_json_ids|managed_context_anchors_response_reads_trace_anchors_by_backend_session|managed_context_records_response_|golden_session)/)'
+slow-timeout = { period = "60s", terminate-after = 4 }
+
+[[profile.default.overrides]]
+filter = 'test(/^dashboard_control::api_sessions::tests::parity_/)'
 slow-timeout = { period = "60s", terminate-after = 4 }

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1993,7 +1993,9 @@ its operation per method/path from `federation_http_operation`.
 | POST | `/api/session/{id}/agent-output` | SessionInspect | own origin | bounded | Fetch a session's persisted agent output by id (POST-shaped read) |
 | GET | `/api/session/current[/…]` | SessionManage | own origin | none | Current-session detail and artifact sub-routes |
 | POST | `/api/session/current[/…]` | SessionManage | own origin | none | Current-session detail sub-routes (POST fallback callers) |
-| GET | `/api/session[/…]` | SessionInspect | own origin | none | Session detail; context-snapshot, recordings (+segments/playlist), report zip, frames |
+| GET | `/api/session/{id}/context-snapshot` | SessionInspect | own origin | none | Replay one archived context snapshot (file/request_id/request_index/ts selector) |
+| GET | `/api/session/{id}` | SessionInspect | own origin | none | Session detail (paged replay entries; limit/before/source) |
+| GET | `/api/session[/…]` | SessionInspect | own origin | none | Session artifact sub-routes: recordings (+segments/playlist), report zip, frames |
 | POST | `/api/session[/…]` | SessionManage | own origin | none | Session detail sub-routes (POST fallback callers) |
 | GET | `/api/managed-context/anchors` | SessionInspect | own origin | none | Managed-context anchor catalog |
 | GET | `/api/managed-context/records` | SessionInspect | own origin | none | Managed-context record index |

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -538,29 +538,24 @@ pub(crate) async fn api_session_detail_response(
     } else {
         source
     };
+    // Transport-owned decode: the tunnel trims the id (the paged body
+    // helper always did); HTTP passes the raw path segment.
+    let session_id = session_id.trim().to_string();
     let limit = control_session_detail_limit(&params);
     let before = control_session_detail_before(&params);
-    let body = tokio::task::spawn_blocking(move || {
-        crate::web_gateway::session_detail_response_body_with_page(
-            &session_id,
-            &source,
-            limit,
-            before,
-        )
+    let result = tokio::task::spawn_blocking(move || {
+        crate::web_gateway::session_detail_api_response(&session_id, &source, limit, before)
     })
     .await;
-    let body = match body {
-        Ok(body) => body,
-        Err(e) => {
-            return serde_json::json!({
-                "t": "response",
-                "id": id,
-                "ok": false,
-                "error": format!("session detail task failed: {e}"),
-            });
-        }
-    };
-    json_body_response(id, body, "session detail")
+    match result {
+        Ok(response) => frame_api_json_body_response(id, response, "session detail"),
+        Err(e) => serde_json::json!({
+            "t": "response",
+            "id": id,
+            "ok": false,
+            "error": format!("session detail task failed: {e}"),
+        }),
+    }
 }
 
 pub(crate) async fn api_session_report_task_response(
@@ -1021,12 +1016,12 @@ pub(crate) async fn api_session_agent_output_response(
         source
     };
     let body_text = params_body_text(Some(&params));
-    let response = tokio::task::spawn_blocking(move || {
-        crate::web_gateway::session_agent_output_post_response(&body_text, &session_id, &source)
+    let result = tokio::task::spawn_blocking(move || {
+        crate::web_gateway::session_agent_output_api_response(&body_text, &session_id, &source)
     })
     .await;
-    match response {
-        Ok(response) => http_wire_response(id, response, "session agent output"),
+    match result {
+        Ok(response) => frame_api_response(id, response, "session agent output"),
         Err(e) => http_body_response(
             id,
             500,
@@ -1135,10 +1130,8 @@ pub(crate) async fn api_session_context_snapshot_response(
         }
     };
     let ts = optional_string_param(&params, &["ts"]);
-    let home = crate::platform::home_dir();
     let result = tokio::task::spawn_blocking(move || {
-        crate::web_gateway::session_context_snapshot_response_body(
-            &home,
+        crate::web_gateway::session_context_snapshot_api_response(
             &session_id,
             &source,
             file,
@@ -1149,9 +1142,7 @@ pub(crate) async fn api_session_context_snapshot_response(
     })
     .await;
     match result {
-        Ok((status_line, body)) => {
-            http_body_response(id, status_line_code(status_line), body, "context snapshot")
-        }
+        Ok(response) => frame_api_response(id, response, "context snapshot"),
         Err(e) => serde_json::json!({
             "t": "response",
             "id": id,
@@ -1220,7 +1211,7 @@ pub(crate) async fn api_sessions_search_response(
     };
     let mode = string_param(&params, &["mode"]);
     let project_filter = control_project_filter(&params);
-    let body = crate::web_gateway::sessions_search_response_body_with_cancel(
+    let response = crate::web_gateway::sessions_search_api_response(
         query,
         source_filter,
         mode,
@@ -1228,7 +1219,7 @@ pub(crate) async fn api_sessions_search_response(
         cancel,
     )
     .await;
-    json_body_response(id, body, "session search")
+    frame_api_json_body_response(id, response, "session search")
 }
 
 #[cfg(test)]
@@ -1681,5 +1672,303 @@ mod tests {
             ),
             "capability=display&capability=custom:gpu"
         );
+    }
+
+    // ── Sessions-family tunnel/HTTP parity fixtures (S4a, design §8) ──
+    //
+    // Same discipline as the fs set (api_transfers_fs.rs): the same
+    // params through the ONE neutral fn — `sessions_list_api_response`,
+    // `sessions_search_api_response`, `session_detail_api_response`,
+    // `session_agent_output_api_response`,
+    // `session_context_snapshot_api_response` — rendered by the HTTP
+    // adapter and by the tunnel framers, yield IDENTICAL JSON bodies.
+    // The sessions-family envelope differences, deliberate and pinned
+    // here, extend the fs enumeration:
+    //
+    //  1. Pre-_httpStatus envelopes: api_sessions / api_session_detail /
+    //     api_sessions_search predate the injected-status envelope —
+    //     their frames are `{t,id,ok:true,result:<body>}` with NO
+    //     `_httpStatus`/`_httpOk` (`frame_api_json_body_response`), so
+    //     HTTP-side statuses (detail 400/404) do not surface on the
+    //     tunnel; error bodies carry `{"error":…}` inline under ok:true.
+    //  2. api_sessions result-shape guard: the tunnel rejects a
+    //     non-array list body with ok:false "session list returned
+    //     invalid JSON"; HTTP passes any body through under 200.
+    //  3. api_session_agent_output / api_session_context_snapshot ride
+    //     the injected-status envelope (`frame_api_response` →
+    //     `http_body_response`): result objects gain
+    //     `_httpStatus`/`_httpOk` matching the HTTP status exactly.
+    //  4. Transport-owned param decode: HTTP's `ids=` comma filter
+    //     distinguishes present-but-empty (→ `[]`) from absent; the
+    //     tunnel's ids vocabulary cannot express the empty filter, and
+    //     its ids path never applies the limit truncation (historical
+    //     for_ids semantics — the tunnel maps ids requests to
+    //     `limit=None`). HTTP reads limit/max/count aliases capped at
+    //     SESSION_LIST_LIMIT; the tunnel reads `limit` with the
+    //     CONTROL_DEFAULT_SESSION_LIMIT default and the "all"/"full"
+    //     escape. The tunnel trims session_id and accepts
+    //     sessionId/id aliases; HTTP takes the raw path segment.
+    //  5. Header tails are HTTP-lane decoration only: list/search and
+    //     the intendant-source agent-output shapes carry the
+    //     wildcard-CORS tail; detail/context-snapshot the canonical
+    //     tail; the external-source agent-output success rides the
+    //     canonical tail (historical asymmetry). The tunnel has no
+    //     header lane.
+    //  6. Task-failure shapes stay transport-owned: HTTP answers 200
+    //     with an `{"error":…}` body (list/detail); the tunnel emits
+    //     ok:false frames.
+
+    /// Render a neutral response through the HTTP adapter and split it
+    /// into (status, body).
+    fn http_status_and_body(response: crate::web_gateway::ApiResponse) -> (u16, serde_json::Value) {
+        let bytes = crate::web_gateway::api_response_http_bytes(
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        );
+        let split = bytes
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .expect("header/body split");
+        let head = String::from_utf8(bytes[..split].to_vec()).expect("ascii head");
+        let status = head
+            .lines()
+            .next()
+            .and_then(|line| line.strip_prefix("HTTP/1.1 "))
+            .and_then(|line| line.split_whitespace().next())
+            .and_then(|code| code.parse::<u16>().ok())
+            .expect("status line");
+        let body = serde_json::from_slice(&bytes[split + 4..]).expect("json body");
+        (status, body)
+    }
+
+    /// Strip the injected-status tunnel envelope (difference #3): assert
+    /// the `http_body_response` shape against the HTTP adapter's status
+    /// and return the result minus the injected keys.
+    fn tunnel_result_body(frame: &serde_json::Value, expect_status: u16) -> serde_json::Value {
+        assert_eq!(frame["t"], "response");
+        assert_eq!(frame["ok"], true, "{frame}");
+        let mut result = frame["result"].clone();
+        let map = result.as_object_mut().expect("result object");
+        assert_eq!(
+            map.remove("_httpStatus"),
+            Some(serde_json::json!(expect_status)),
+            "{frame}"
+        );
+        assert_eq!(
+            map.remove("_httpOk"),
+            Some(serde_json::json!((200..300).contains(&expect_status)))
+        );
+        result
+    }
+
+    /// The pre-_httpStatus envelope (difference #1): ok:true with the
+    /// body as the verbatim result — no injected status metadata.
+    fn tunnel_plain_body(frame: &serde_json::Value) -> serde_json::Value {
+        assert_eq!(frame["t"], "response");
+        assert_eq!(frame["ok"], true, "{frame}");
+        if let Some(result) = frame["result"].as_object() {
+            assert!(
+                !result.contains_key("_httpStatus") && !result.contains_key("_httpOk"),
+                "pre-_httpStatus envelope must not carry injected status metadata: {frame}"
+            );
+        }
+        frame["result"].clone()
+    }
+
+    /// Unique-per-run fixture session in the live logs store (the
+    /// bin-test convention; removed by the caller).
+    fn parity_session_fixture(prefix: &str) -> (String, std::path::PathBuf) {
+        let session_id = format!(
+            "{prefix}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let log_dir = crate::platform::intendant_home()
+            .join("logs")
+            .join(&session_id);
+        let mut log = crate::session_log::SessionLog::open(log_dir.clone()).unwrap();
+        log.agent_output_with_id("parity stdout", "", Some("Codex"), Some("parity-out-1"));
+        drop(log);
+        (session_id, log_dir)
+    }
+
+    #[tokio::test]
+    async fn parity_sessions_list_serves_the_same_rows_on_both_transports() {
+        let (session_id, log_dir) = parity_session_fixture("parity-list");
+
+        // ids filter, plain view.
+        let (status, http_body) = http_status_and_body(
+            crate::web_gateway::sessions_list_api_response(
+                Some(vec![session_id.clone()]),
+                None,
+                false,
+            ),
+        );
+        assert_eq!(status, 200);
+        let frame = api_sessions_response(
+            "parity-list".to_string(),
+            Some(&serde_json::json!({ "ids": [session_id] })),
+        )
+        .await;
+        let cleanup = std::fs::remove_dir_all(&log_dir);
+        let tunnel_body = tunnel_plain_body(&frame);
+        assert!(tunnel_body.is_array(), "{frame}");
+        assert_eq!(tunnel_body, http_body);
+        assert!(
+            tunnel_body
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|row| row["session_id"] == session_id),
+            "fixture session must be listed: {tunnel_body}"
+        );
+        cleanup.expect("parity list fixture cleanup");
+    }
+
+    #[tokio::test]
+    async fn parity_sessions_list_usage_view_serves_the_same_projection() {
+        let (session_id, log_dir) = parity_session_fixture("parity-usage");
+        let (status, http_body) = http_status_and_body(
+            crate::web_gateway::sessions_list_api_response(
+                Some(vec![session_id.clone()]),
+                None,
+                true,
+            ),
+        );
+        let frame = api_sessions_response(
+            "parity-usage".to_string(),
+            Some(&serde_json::json!({ "ids": [session_id], "view": "usage" })),
+        )
+        .await;
+        let cleanup = std::fs::remove_dir_all(&log_dir);
+        assert_eq!(status, 200);
+        let tunnel_body = tunnel_plain_body(&frame);
+        assert_eq!(tunnel_body, http_body);
+        let row = &tunnel_body.as_array().unwrap()[0];
+        assert!(row.get("session_id").is_some());
+        assert!(
+            row.get("entries").is_none() && row.get("goal").is_none(),
+            "usage view must project rows down: {row}"
+        );
+        cleanup.expect("parity usage fixture cleanup");
+    }
+
+    #[tokio::test]
+    async fn parity_sessions_search_serves_the_same_body_on_both_transports() {
+        let _guard = crate::web_gateway::SESSIONS_SEARCH_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // The no-input short-circuit: deterministic, store-free.
+        let (status, http_body) = http_status_and_body(
+            crate::web_gateway::sessions_search_api_response(
+                String::new(),
+                "all".to_string(),
+                String::new(),
+                Vec::new(),
+                CancellationToken::new(),
+            )
+            .await,
+        );
+        assert_eq!(status, 200);
+        let frame = api_sessions_search_response(
+            "parity-search".to_string(),
+            Some(&serde_json::json!({ "q": "" })),
+            CancellationToken::new(),
+        )
+        .await;
+        assert_eq!(tunnel_plain_body(&frame), http_body);
+    }
+
+    #[tokio::test]
+    async fn parity_session_detail_serves_the_same_body_on_both_transports() {
+        let (session_id, log_dir) = parity_session_fixture("parity-detail");
+        let (status, http_body) = http_status_and_body(
+            crate::web_gateway::session_detail_api_response(&session_id, "intendant", Some(5), None),
+        );
+        let frame = api_session_detail_response(
+            "parity-detail".to_string(),
+            Some(&serde_json::json!({ "session_id": session_id, "limit": 5 })),
+        )
+        .await;
+        let cleanup = std::fs::remove_dir_all(&log_dir);
+        assert_eq!(status, 200);
+        assert_eq!(tunnel_plain_body(&frame), http_body);
+        cleanup.expect("parity detail fixture cleanup");
+    }
+
+    #[tokio::test]
+    async fn parity_session_detail_errors_share_bodies_under_the_plain_envelope() {
+        // Difference #1 pinned from both sides: the HTTP 400 does not
+        // surface on the tunnel — only the identical error body does.
+        let (status, http_body) = http_status_and_body(
+            crate::web_gateway::session_detail_api_response("..", "intendant", None, None),
+        );
+        assert_eq!(status, 400);
+        let frame = api_session_detail_response(
+            "parity-detail-invalid".to_string(),
+            Some(&serde_json::json!({ "session_id": ".." })),
+        )
+        .await;
+        assert_eq!(tunnel_plain_body(&frame), http_body);
+    }
+
+    #[tokio::test]
+    async fn parity_session_agent_output_serves_the_same_body_with_status_metadata() {
+        let (session_id, log_dir) = parity_session_fixture("parity-output");
+        let ids_body = r#"{"ids":["parity-out-1","parity-missing"]}"#;
+        let (status, http_body) = http_status_and_body(
+            crate::web_gateway::session_agent_output_api_response(
+                ids_body,
+                &session_id,
+                "intendant",
+            ),
+        );
+        // The tunnel serializes its whole params object as the body; the
+        // chunk fetch only reads `ids`.
+        let frame = api_session_agent_output_response(
+            "parity-output".to_string(),
+            Some(&serde_json::json!({
+                "session_id": session_id,
+                "ids": ["parity-out-1", "parity-missing"],
+            })),
+        )
+        .await;
+        let cleanup = std::fs::remove_dir_all(&log_dir);
+        assert_eq!(status, 200);
+        assert_eq!(tunnel_result_body(&frame, 200), http_body);
+        cleanup.expect("parity output fixture cleanup");
+
+        // Missing-ids: same 400 body under each envelope.
+        let (status, http_body) = http_status_and_body(
+            crate::web_gateway::session_agent_output_api_response("{}", "abc123", "intendant"),
+        );
+        assert_eq!(status, 400);
+        let frame = api_session_agent_output_response(
+            "parity-output-missing-ids".to_string(),
+            Some(&serde_json::json!({ "session_id": "abc123" })),
+        )
+        .await;
+        assert_eq!(tunnel_result_body(&frame, 400), http_body);
+    }
+
+    #[tokio::test]
+    async fn parity_session_context_snapshot_shares_bodies_with_status_metadata() {
+        // Missing selector: 400 on both lanes.
+        let (status, http_body) = http_status_and_body(
+            crate::web_gateway::session_context_snapshot_api_response(
+                "abc123", "intendant", None, None, None, None,
+            ),
+        );
+        assert_eq!(status, 400);
+        let frame = api_session_context_snapshot_response(
+            "parity-snapshot".to_string(),
+            Some(&serde_json::json!({ "session_id": "abc123" })),
+        )
+        .await;
+        assert_eq!(tunnel_result_body(&frame, 400), http_body);
+        assert_eq!(http_body["error"], "missing snapshot selector");
     }
 }

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -29,6 +29,31 @@ pub(crate) fn frame_api_response(
     }
 }
 
+/// Tunnel adapter for the pre-`_httpStatus` methods (the sessions
+/// list/detail/search trio predates the injected-status envelope):
+/// render only the neutral response's JSON body through the historical
+/// `json_body_response` wrapper — `{t:"response", id, ok:true,
+/// result:<body>}` with NO status metadata injected — so the wire stays
+/// byte-identical through the delegation. A byte response on these
+/// methods is a wiring bug and fails closed.
+pub(crate) fn frame_api_json_body_response(
+    id: String,
+    response: crate::web_gateway::ApiResponse,
+    label: &str,
+) -> serde_json::Value {
+    match response {
+        crate::web_gateway::ApiResponse::Json { body, .. } => {
+            json_body_response(id, body.into_string(), label)
+        }
+        crate::web_gateway::ApiResponse::Bytes { .. } => serde_json::json!({
+            "t": "response",
+            "id": id,
+            "ok": false,
+            "error": format!("{label} returned an unexpected byte response"),
+        }),
+    }
+}
+
 /// Tunnel adapter for byte-capable methods: `Bytes` becomes a
 /// `byte_stream_start/chunk/end` sequence — chunking, credits, and
 /// backpressure stay wire.rs-owned — with the neutral fn's `meta`

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -1792,13 +1792,9 @@ fn split_http_response(response: &str) -> (u16, &str) {
     (status, body)
 }
 
-fn status_line_code(status_line: &str) -> u16 {
-    status_line
-        .split_whitespace()
-        .next()
-        .and_then(|value| value.parse::<u16>().ok())
-        .unwrap_or(500)
-}
+// One status-line parser across both lanes (the api core's (status,
+// body) helper vocabulary).
+pub(crate) use crate::web_gateway::status_line_code;
 
 fn params_body_text(params: Option<&serde_json::Value>) -> String {
     serde_json::to_string(&params.cloned().unwrap_or_else(|| serde_json::json!({})))
@@ -1831,17 +1827,21 @@ async fn api_sessions_response(
     let limit = control_session_limit(&params);
     let ids = control_session_ids(&params);
     let usage_view = params.get("view").and_then(|v| v.as_str()) == Some("usage");
-    let body = tokio::task::spawn_blocking(move || {
-        let body = crate::web_gateway::sessions_list_response_body(limit, &ids);
-        if usage_view {
-            crate::web_gateway::session_list_body_usage_view(&body)
-        } else {
-            body
-        }
+    // Transport-owned param mapping onto the neutral core: the tunnel's
+    // ids path historically never applied the limit truncation (and its
+    // ids vocabulary cannot express HTTP's present-but-empty filter), so
+    // an ids request passes no limit.
+    let (ids_filter, limit) = if ids.is_empty() {
+        (None, limit)
+    } else {
+        (Some(ids), None)
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        crate::web_gateway::sessions_list_api_response(ids_filter, limit, usage_view)
     })
     .await;
-    let body = match body {
-        Ok(body) => body,
+    let response = match result {
+        Ok(response) => response,
         Err(e) => {
             return serde_json::json!({
                 "t": "response",
@@ -1851,7 +1851,16 @@ async fn api_sessions_response(
             });
         }
     };
-    match serde_json::from_str::<serde_json::Value>(&body) {
+    let crate::web_gateway::ApiResponse::Json { body, .. } = response else {
+        return serde_json::json!({
+            "t": "response",
+            "id": id,
+            "ok": false,
+            "error": "session list returned an unexpected byte response",
+        });
+    };
+    // Historical result-shape guard: the list must be a JSON array.
+    match serde_json::from_str::<serde_json::Value>(&body.into_string()) {
         Ok(result) if result.is_array() => serde_json::json!({
             "t": "response",
             "id": id,

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -255,26 +255,14 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
         PeerOperation::PeerManage,
     ),
     method("api_coordinator_route", PeerOperation::PeerManage),
-    method("api_sessions", PeerOperation::SessionInspect),
+    // The sessions read-core methods (api_sessions, api_sessions_search,
+    // api_session_detail, api_session_agent_output,
+    // api_session_context_snapshot) live as tunnel columns on their
+    // route rows — their IAM operations derive from the rows (S4a; the
+    // formerly divergent agent-output/context-snapshot twins are now
+    // derivation-equal by construction).
     method("api_sessions_stream", PeerOperation::SessionInspect),
-    method("api_session_detail", PeerOperation::SessionInspect),
     method("api_session_report", PeerOperation::SessionInspect),
-    // Fetches persisted stdout/stderr chunks by output id — a pure
-    // session-log read, inspect-grade like the neighboring by-id reads.
-    // Keep equal to the HTTP twin row (POST /api/session/{id}/agent-output;
-    // POST-shaped only because the ids ride the body) until transport
-    // unification derives tunnel ops from the route rows — pinned by
-    // `formerly_divergent_twins_gate_identically_on_both_lanes`.
-    method("api_session_agent_output", PeerOperation::SessionInspect),
-    // Replays one archived context snapshot out of the session log — a
-    // pure read; inspect-grade to match the HTTP twin (the GET
-    // /api/session sub-router row serving {id}/context-snapshot). It was
-    // originally mis-grouped with the manage-gated mutations below. Keep
-    // equal to the route row until transport unification derives tunnel
-    // ops from the rows — pinned by
-    // `formerly_divergent_twins_gate_identically_on_both_lanes`.
-    method("api_session_context_snapshot", PeerOperation::SessionInspect),
-    method("api_sessions_search", PeerOperation::SessionInspect),
     method("api_session_recordings", PeerOperation::SessionInspect),
     method("api_session_recording_asset", PeerOperation::SessionInspect),
     method("api_session_frame_asset", PeerOperation::SessionInspect),
@@ -3214,21 +3202,17 @@ mod tests {
                 Some(Op::PeerManage),
             ),
             ("api_coordinator_route", Residue, Some(Op::PeerManage)),
-            ("api_sessions", Residue, Some(Op::SessionInspect)),
+            ("api_sessions", Row, Some(Op::SessionInspect)),
             ("api_sessions_stream", Residue, Some(Op::SessionInspect)),
-            ("api_session_detail", Residue, Some(Op::SessionInspect)),
+            ("api_session_detail", Row, Some(Op::SessionInspect)),
             ("api_session_report", Residue, Some(Op::SessionInspect)),
-            (
-                "api_session_agent_output",
-                Residue,
-                Some(Op::SessionInspect),
-            ),
+            ("api_session_agent_output", Row, Some(Op::SessionInspect)),
             (
                 "api_session_context_snapshot",
-                Residue,
+                Row,
                 Some(Op::SessionInspect),
             ),
-            ("api_sessions_search", Residue, Some(Op::SessionInspect)),
+            ("api_sessions_search", Row, Some(Op::SessionInspect)),
             ("api_session_recordings", Residue, Some(Op::SessionInspect)),
             (
                 "api_session_recording_asset",
@@ -3677,13 +3661,13 @@ mod tests {
 
     /// The two methods whose tunnel rows historically diverged from their
     /// HTTP route rows are pinned equal across BOTH lanes. Their handlers
-    /// are pure session-log reads (`session_agent_output_post_response`
+    /// are pure session-log reads (`session_agent_output_api_response`
     /// fetches persisted output chunks by id;
-    /// `session_context_snapshot_response_body` replays one archived
-    /// snapshot), so both lanes gate them inspect-grade. Transport
-    /// unification will derive the tunnel op from the route row and make
-    /// this drift class unrepresentable; until then this test is the pin
-    /// — if either declaration moves, move its twin in the same commit.
+    /// `session_context_snapshot_api_response` replays one archived
+    /// snapshot), so both lanes gate them inspect-grade. Since S4a their
+    /// tunnel ops DERIVE from the route rows (`tunnel:` columns), making
+    /// the drift class unrepresentable — this test stays as the
+    /// end-to-end assertion that classification and method table agree.
     #[test]
     fn formerly_divergent_twins_gate_identically_on_both_lanes() {
         use crate::gateway_routes::{classify, TableClassification};

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -685,15 +685,14 @@ pub(crate) static ROUTES: &[Route] = &[
         "Delete one data kind for a session (POST fallback)",
     ),
     // POST-shaped read: the body carries output ids and the handler
-    // (`session_agent_output_post_response`) only fetches persisted
+    // (`session_agent_output_api_response`) only fetches persisted
     // stdout/stderr chunks back out of the session's log — nothing is
     // appended, so it is inspect-grade like every other by-id session
     // read. The legacy verb-shaped classifier (POST under /api/session ⇒
-    // manage) mis-tagged it and diverged from the tunnel twin
-    // `api_session_agent_output`. Keep the two lanes' operations equal
-    // (pinned by dashboard_control's
-    // `formerly_divergent_twins_gate_identically_on_both_lanes`) until
-    // transport unification derives the tunnel op from this row.
+    // manage) mis-tagged it and diverged from the tunnel twin — now the
+    // twin is this row's tunnel column and its operation derives from
+    // here (`formerly_divergent_twins_gate_identically_on_both_lanes`
+    // stays as the end-to-end assertion).
     op_route(
         RouteMethod::Post,
         PathPattern::Segments(
@@ -707,7 +706,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::SessionAgentOutput,
         "Fetch a session's persisted agent output by id (POST-shaped read)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_session_agent_output")),
     // ── Session detail + artifacts sub-router. Method-explicit ports of
     //    the method-blind legacy catch-all: the classifier's historical
     //    split (current/* manage-gated on every method; {id} inspect on
@@ -728,13 +728,43 @@ pub(crate) static ROUTES: &[Route] = &[
         RouteHandlerId::SessionSubRouter,
         "Current-session detail sub-routes (POST fallback callers)",
     ),
+    // Converted read leaves of the method-blind catch-all, carved as
+    // method-explicit rows so each can carry its datachannel twin
+    // (transport-unification S4a; one tunnel name per row). Same
+    // operation and shared handler as the Under rows they were served by
+    // — classification-preserving; the generic rows below keep the
+    // unconverted artifact leaves and the POST-fallback callers.
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Segments(
+            "/api/session",
+            &[
+                SegmentSpec::Capture("id"),
+                SegmentSpec::Literal("context-snapshot"),
+            ],
+        ),
+        PeerOperation::SessionInspect,
+        BodyPolicy::None,
+        RouteHandlerId::SessionSubRouter,
+        "Replay one archived context snapshot (file/request_id/request_index/ts selector)",
+    )
+    .with_tunnel(tunnel_method("api_session_context_snapshot")),
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Segments("/api/session", &[SegmentSpec::Capture("id")]),
+        PeerOperation::SessionInspect,
+        BodyPolicy::None,
+        RouteHandlerId::SessionSubRouter,
+        "Session detail (paged replay entries; limit/before/source)",
+    )
+    .with_tunnel(tunnel_method("api_session_detail")),
     op_route(
         RouteMethod::Get,
         PathPattern::Under("/api/session"),
         PeerOperation::SessionInspect,
         BodyPolicy::None,
         RouteHandlerId::SessionSubRouter,
-        "Session detail; context-snapshot, recordings (+segments/playlist), report zip, frames",
+        "Session artifact sub-routes: recordings (+segments/playlist), report zip, frames",
     ),
     op_route(
         RouteMethod::Post,
@@ -822,7 +852,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::SessionsSearch,
         "Search sessions (q, source, mode, project filters)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_sessions_search")),
     op_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/sessions"),
@@ -830,7 +861,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::SessionsList,
         "List sessions (id filter, limit, usage view; response CORS * for the fleet Stats tab)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_sessions")),
     // ── Settings / info endpoints. Ported method-blind from the legacy
     //    chain as `Any` rows, then tightened to their real methods: an
     //    undeclared method on a declared path now gets the dispatch-level

--- a/src/bin/caller/web_gateway/http.rs
+++ b/src/bin/caller/web_gateway/http.rs
@@ -736,6 +736,17 @@ pub(crate) async fn read_request_body_capped<S: AsyncRead + Unpin>(
     Ok(full)
 }
 
+/// Numeric code of a status line (`"404 Not Found"` → 404); unparseable
+/// input collapses to 500. Inverse of [`status_reason`] for the (status,
+/// body) helper cores predating [`crate::web_gateway::ApiResponse`].
+pub(crate) fn status_line_code(status_line: &str) -> u16 {
+    status_line
+        .split_whitespace()
+        .next()
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(500)
+}
+
 pub(crate) fn status_reason(status: u16) -> &'static str {
     match status {
         200 => "200 OK",

--- a/src/bin/caller/web_gateway/http.rs
+++ b/src/bin/caller/web_gateway/http.rs
@@ -48,10 +48,6 @@ pub(crate) async fn finalize_http_stream(stream: &mut DemuxStream) {
     let _ = stream.shutdown().await;
 }
 
-pub(crate) fn json_response_body(body: String) -> String {
-    HttpResponse::json("200 OK", body).into_string()
-}
-
 /// Gzip-compress `data` (pure-Rust miniz_oxide backend via flate2).
 pub(crate) fn gzip_compress(data: &[u8]) -> Vec<u8> {
     use flate2::{write::GzEncoder, Compression};

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -461,7 +461,13 @@ pub(crate) async fn serve_http_request(
                 return handle_worktrees_list(stream, worktree_inventory_cache).await;
             }
             RouteHandlerId::SessionsList => {
-                return handle_sessions_list(stream, request_line).await;
+                return handle_sessions_list(
+                    stream,
+                    request_line,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::FsStat => {
                 return handle_fs_stat(
@@ -580,7 +586,14 @@ pub(crate) async fn serve_http_request(
                 return handle_session_delete(stream, request_line).await;
             }
             RouteHandlerId::SessionAgentOutput => {
-                return handle_session_agent_output(stream, route_body, request_line).await;
+                return handle_session_agent_output(
+                    stream,
+                    route_body,
+                    request_line,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::SessionSubRouter => {
                 return handle_session_sub_router(stream, request_line, session_log, query_ctx)
@@ -599,7 +612,13 @@ pub(crate) async fn serve_http_request(
                 return handle_sessions_stream(stream, request_line).await;
             }
             RouteHandlerId::SessionsSearch => {
-                return handle_sessions_search(stream, request_line).await;
+                return handle_sessions_search(
+                    stream,
+                    request_line,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::ProjectRoot => {
                 return handle_project_root(stream, project_root).await;

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -287,7 +287,7 @@ impl Default for WebGatewayConfig {
 // ---------------------------------------------------------------------------
 
 
-// Same-origin by default; see `json_response_body` for the CORS rationale.
+// Same-origin by default (the canonical json tail carries no CORS header).
 
 
 /// Check whether it is safe to mutate the project tree (rollback/redo) right

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -2494,16 +2494,25 @@ pub(crate) async fn handle_session_sub_router(
         let raw_id = rest_parts[0];
         let session_id = raw_id.split('?').next().unwrap_or(raw_id);
         let source = query_param(request_line, "source").unwrap_or_else(|| "intendant".to_string());
-        let response = match context_snapshot_selector_parts_from_request(request_line) {
-            Ok((file, request_id, request_index, ts)) => session_context_snapshot_api_response(
-                session_id,
-                &source,
-                file,
-                request_id,
-                request_index,
-                ts,
-            ),
-            Err(error) => ApiResponse::json_error(400, error),
+        // Historical HTTP precedence: the bare-id check answers before
+        // the selector decode (the tunnel's transport-owned decode keeps
+        // its own historical index-error-first order).
+        let response = if !session_lookup_id_is_safe(session_id) {
+            ApiResponse::json_error(400, "invalid session id")
+        } else {
+            match context_snapshot_selector_parts_from_request(request_line) {
+                Ok((file, request_id, request_index, ts)) => {
+                    session_context_snapshot_api_response(
+                        session_id,
+                        &source,
+                        file,
+                        request_id,
+                        request_index,
+                        ts,
+                    )
+                }
+                Err(error) => ApiResponse::json_error(400, error),
+            }
         };
         let bytes = api_response_http_bytes(
             response,
@@ -5035,6 +5044,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn golden_session_context_snapshot_double_error_precedence_transcript() {
+        // Invalid id AND invalid request_index: the bare-id check answers
+        // first on the HTTP lane (historical precedence, kept through the
+        // S4a conversion; the tunnel's decode keeps index-error-first).
+        let request_line = "GET /api/session/../context-snapshot?request_index=abc HTTP/1.1";
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, request_line, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_json_transcript("400 Bad Request", r#"{"error":"invalid session id"}"#)
+        );
+    }
+
+    #[tokio::test]
     async fn golden_session_context_snapshot_not_found_transcript() {
         let session_id = golden_unique_session_id("golden-snapshot-missing");
         let request_line =
@@ -5050,5 +5075,4 @@ mod tests {
                 r#"{"error":"context snapshot not found"}"#
             )
         );
-    }
-}
+    }}

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -67,9 +67,45 @@ pub(crate) fn is_valid_agent_output_id(id: &str) -> bool {
             .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | ':' | '.'))
 }
 
-pub(crate) fn current_agent_output_response_for_ids(ids: Vec<String>, log_dir: &Path) -> String {
+/// The wildcard-CORS json envelope several session surfaces answer with
+/// (`Cache-Control` + `Access-Control-Allow-Origin: *` + `Connection`
+/// tail — the historical `upload_error_response`/hand-rolled shape).
+pub(crate) fn session_wildcard_json_response(status: u16, body: String) -> ApiResponse {
+    ApiResponse::Json {
+        status,
+        body: JsonBody::PreSerialized(body),
+        headers: vec![
+            ("Cache-Control", "no-cache".to_string()),
+            ("Access-Control-Allow-Origin", "*".to_string()),
+            ("Connection", "close".to_string()),
+        ],
+    }
+}
+
+/// `{"error": message}` under the wildcard-CORS tail.
+pub(crate) fn session_wildcard_json_error(status: u16, message: &str) -> ApiResponse {
+    session_wildcard_json_response(status, serde_json::json!({ "error": message }).to_string())
+}
+
+/// Transitional raw-HTTP rendering for the current-session callers that
+/// have not yet converted to [`ApiResponse`] (S4 slices 2–3); byte-
+/// identical to the historical hand-rolled strings (the HTTP adapter's
+/// parity tests pin the framing).
+fn api_response_to_http_string(response: ApiResponse) -> String {
+    String::from_utf8_lossy(&api_response_http_bytes(
+        response,
+        crate::gateway_routes::CorsPosture::OwnOrigin,
+        None,
+    ))
+    .into_owned()
+}
+
+pub(crate) fn current_agent_output_response_for_ids(
+    ids: Vec<String>,
+    log_dir: &Path,
+) -> ApiResponse {
     if ids.is_empty() {
-        return upload_error_response("400 Bad Request", "missing output ids");
+        return session_wildcard_json_error(400, "missing output ids");
     }
 
     let fallback_logs_dir = Some(crate::platform::intendant_home().join("logs"));
@@ -88,11 +124,7 @@ pub(crate) fn current_agent_output_response_for_ids(ids: Vec<String>, log_dir: &
         "missing": missing,
     })
     .to_string();
-    HttpResponse::with_content("200 OK", "application/json", body)
-        .header("Cache-Control", "no-cache")
-        .header("Access-Control-Allow-Origin", "*")
-        .header("Connection", "close")
-        .into_string()
+    session_wildcard_json_response(200, body)
 }
 
 pub(crate) fn agent_output_ids_from_json_body(body: &str) -> Result<Vec<String>, String> {
@@ -115,10 +147,11 @@ pub(crate) fn agent_output_ids_from_json_body(body: &str) -> Result<Vec<String>,
 }
 
 pub(crate) fn current_agent_output_post_response(body: &str, log_dir: &Path) -> String {
-    match agent_output_ids_from_json_body(body) {
+    let response = match agent_output_ids_from_json_body(body) {
         Ok(ids) => current_agent_output_response_for_ids(ids, log_dir),
-        Err(e) => upload_error_response("400 Bad Request", &e),
-    }
+        Err(e) => session_wildcard_json_error(400, &e),
+    };
+    api_response_to_http_string(response)
 }
 
 pub(crate) fn external_agent_output_response_for_ids(
@@ -126,9 +159,9 @@ pub(crate) fn external_agent_output_response_for_ids(
     source: &str,
     session_id: &str,
     ids: Vec<String>,
-) -> String {
+) -> ApiResponse {
     let Some(entries) = external_session_entries_from_home(home, source, session_id) else {
-        return upload_error_response("404 Not Found", "session not found");
+        return session_wildcard_json_error(404, "session not found");
     };
     let wanted: HashSet<&str> = ids.iter().map(String::as_str).collect();
     let mut found: HashMap<String, serde_json::Value> = HashMap::new();
@@ -167,12 +200,18 @@ pub(crate) fn external_agent_output_response_for_ids(
         .map(String::as_str)
         .filter(|id| !output_ids.contains(id))
         .collect();
-    json_response_body(
-        serde_json::json!({
-            "outputs": outputs,
-            "missing": missing,
-        })
-        .to_string(),
+    // Historical asymmetry, preserved: the external-source success rides
+    // the canonical json tail (no wildcard CORS header), unlike the
+    // intendant-source success above.
+    ApiResponse::json(
+        200,
+        JsonBody::PreSerialized(
+            serde_json::json!({
+                "outputs": outputs,
+                "missing": missing,
+            })
+            .to_string(),
+        ),
     )
 }
 
@@ -181,25 +220,29 @@ pub(crate) fn session_agent_output_response_for_ids(
     session_id: &str,
     source: &str,
     ids: Vec<String>,
-) -> String {
+) -> ApiResponse {
     let source = crate::session_names::normalize_source(source);
     if source == "intendant" {
         let Some(session_dir) = resolve_bare_session_dir_from_home(home, session_id) else {
-            return upload_error_response("404 Not Found", "session not found");
+            return session_wildcard_json_error(404, "session not found");
         };
         return current_agent_output_response_for_ids(ids, &session_dir);
     }
     external_agent_output_response_for_ids(home, &source, session_id, ids)
 }
 
-pub(crate) fn session_agent_output_post_response(
+/// Transport-neutral core of the by-id agent-output read
+/// (`POST /api/session/{id}/agent-output`, a POST-shaped read; tunnel twin
+/// `api_session_agent_output`): bare-id policy, output-id decode from the
+/// JSON body, then the persisted-chunk fetch.
+pub(crate) fn session_agent_output_api_response(
     body: &str,
     session_id: &str,
     source: &str,
-) -> String {
+) -> ApiResponse {
     let session_id = session_id.trim();
     if !session_lookup_id_is_safe(session_id) {
-        return upload_error_response("400 Bad Request", "invalid session id");
+        return session_wildcard_json_error(400, "invalid session id");
     }
     match agent_output_ids_from_json_body(body) {
         Ok(ids) => session_agent_output_response_for_ids(
@@ -208,8 +251,18 @@ pub(crate) fn session_agent_output_post_response(
             source,
             ids,
         ),
-        Err(e) => upload_error_response("400 Bad Request", &e),
+        Err(e) => session_wildcard_json_error(400, &e),
     }
+}
+
+/// Raw-string bridge for the tunnel twin until it delegates through the
+/// neutral fn (removed with that conversion).
+pub(crate) fn session_agent_output_post_response(
+    body: &str,
+    session_id: &str,
+    source: &str,
+) -> String {
+    api_response_to_http_string(session_agent_output_api_response(body, session_id, source))
 }
 
 /// Build a zip containing the current session's text artifacts for the
@@ -2319,45 +2372,58 @@ pub(crate) async fn handle_current_agent_output(
     finalize_http_stream(&mut stream).await;
 }
 
-pub(crate) async fn handle_sessions_list(mut stream: DemuxStream, request_line: &str) {
-    // Session listing endpoint. CORS `*` so the
-    // multi-host Stats tab can fetch sibling
-    // daemons' session lists to populate its "All
-    // Sessions" and "Disk Usage" cards per host.
+/// Transport-neutral core of `GET /api/sessions` (tunnel twin
+/// `api_sessions`; the hot list path — `PreSerialized` keeps it
+/// allocation-identical, risk R8). Params arrive transport-decoded; the
+/// composition below is the row's semantics: the ids filter wins, then
+/// the limit truncation, then the usage projection. Answers 200 with the
+/// wildcard-CORS tail so the multi-host Stats tab can fetch sibling
+/// daemons' session lists for its "All Sessions" / "Disk Usage" cards.
+pub(crate) fn sessions_list_api_response(
+    ids_filter: Option<Vec<String>>,
+    limit: Option<usize>,
+    usage_view: bool,
+) -> ApiResponse {
+    let body = match ids_filter {
+        Some(ids) => cached_list_sessions_for_ids(&ids),
+        None => match limit {
+            Some(limit) => cached_list_sessions_with_limit(limit),
+            None => cached_list_sessions(),
+        },
+    };
+    let body = limit_session_list_body(&body, limit);
+    let body = if usage_view {
+        session_list_body_usage_view(&body)
+    } else {
+        body
+    };
+    session_wildcard_json_response(200, body)
+}
+
+pub(crate) async fn handle_sessions_list(
+    stream: DemuxStream,
+    request_line: &str,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
     let ids_filter = session_ids_filter_from_request(request_line);
     let limit = session_list_limit_from_request(request_line);
     let usage_view = session_list_usage_view_from_request(request_line);
-    let body = match tokio::task::spawn_blocking(move || {
-        let body = match ids_filter {
-            Some(ids) => cached_list_sessions_for_ids(&ids),
-            None => match limit {
-                Some(limit) => cached_list_sessions_with_limit(limit),
-                None => cached_list_sessions(),
-            },
-        };
-        let body = limit_session_list_body(&body, limit);
-        if usage_view {
-            session_list_body_usage_view(&body)
-        } else {
-            body
-        }
+    let response = match tokio::task::spawn_blocking(move || {
+        sessions_list_api_response(ids_filter, limit, usage_view)
     })
     .await
     {
-        Ok(body) => body,
-        Err(e) => serde_json::json!({
-            "error": format!("session list task failed: {e}")
-        })
-        .to_string(),
+        Ok(response) => response,
+        Err(e) => session_wildcard_json_response(
+            200,
+            serde_json::json!({
+                "error": format!("session list task failed: {e}")
+            })
+            .to_string(),
+        ),
     };
-    let response = HttpResponse::with_content("200 OK", "application/json", body)
-        .header("Cache-Control", "no-cache")
-        .header("Access-Control-Allow-Origin", "*")
-        .header("Connection", "close")
-        .into_string();
-    use tokio::io::AsyncWriteExt;
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_session_delete(mut stream: DemuxStream, request_line: &str) {
@@ -2386,11 +2452,12 @@ pub(crate) async fn handle_session_delete(mut stream: DemuxStream, request_line:
 }
 
 pub(crate) async fn handle_session_agent_output(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     body_text: String,
     request_line: &str,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
     let rest = request_line
         .split("/api/session/")
         .nth(1)
@@ -2402,12 +2469,11 @@ pub(crate) async fn handle_session_agent_output(
     let is_agent_output_route = rest_parts.get(1).copied() == Some("agent-output");
     let source = query_param(request_line, "source").unwrap_or_else(|| "intendant".to_string());
     let response = if is_agent_output_route {
-        session_agent_output_post_response(&body_text, session_id, &source)
+        session_agent_output_api_response(&body_text, session_id, &source)
     } else {
-        upload_error_response("404 Not Found", "unknown session output route")
+        session_wildcard_json_error(404, "unknown session output route")
     };
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_session_sub_router(
@@ -2438,17 +2504,23 @@ pub(crate) async fn handle_session_sub_router(
         let raw_id = rest_parts[0];
         let session_id = raw_id.split('?').next().unwrap_or(raw_id);
         let source = query_param(request_line, "source").unwrap_or_else(|| "intendant".to_string());
-        let (status, body) = get_session_context_snapshot_from_home(
-            &crate::platform::home_dir(),
-            session_id,
-            &source,
-            request_line,
+        let response = match context_snapshot_selector_parts_from_request(request_line) {
+            Ok((file, request_id, request_index, ts)) => session_context_snapshot_api_response(
+                session_id,
+                &source,
+                file,
+                request_id,
+                request_index,
+                ts,
+            ),
+            Err(error) => ApiResponse::json_error(400, error),
+        };
+        let bytes = api_response_http_bytes(
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
         );
-        let response = HttpResponse::with_content(status, "application/json", body)
-            .header("Cache-Control", "no-cache")
-            .header("Connection", "close")
-            .into_string();
-        let _ = stream.write_all(response.as_bytes()).await;
+        let _ = stream.write_all(&bytes).await;
     } else if rest_parts.len() >= 2 && route_name == "recordings" {
         // Session recording sub-routes: /api/session/{id}/recordings[/...]
         let session_id = rest_parts[0];
@@ -2719,56 +2791,84 @@ pub(crate) async fn handle_session_sub_router(
         let entry_limit = session_detail_entry_limit_from_request(request_line);
         let entry_before = session_detail_before_from_request(request_line);
         let session_id_owned = session_id.to_string();
-        let source_owned = source.clone();
-        let body = if !session_lookup_id_is_safe(session_id) {
-            serde_json::json!({"error": "invalid session id"}).to_string()
-        } else {
-            match tokio::task::spawn_blocking(move || {
-                let home = crate::platform::home_dir();
-                if source_owned == "intendant" {
-                    get_session_detail_from_home_with_page(
-                        &home,
-                        &session_id_owned,
-                        entry_limit,
-                        entry_before,
-                    )
-                } else {
-                    external_session_detail_from_home_with_page(
-                        &home,
-                        &source_owned,
-                        &session_id_owned,
-                        entry_limit,
-                        entry_before,
-                    )
-                    .unwrap_or_else(|| {
-                        serde_json::json!({
-                            "error": "session not found"
-                        })
-                        .to_string()
+        let response = match tokio::task::spawn_blocking(move || {
+            session_detail_api_response(&session_id_owned, &source, entry_limit, entry_before)
+        })
+        .await
+        {
+            Ok(response) => response,
+            // Historical shape: a failed detail task answers 200 with the
+            // error body (the status mapping only knows "not found").
+            Err(e) => ApiResponse::json(
+                200,
+                JsonBody::PreSerialized(
+                    serde_json::json!({
+                        "error": format!("session detail task failed: {e}")
                     })
-                }
-            })
-            .await
-            {
-                Ok(body) => body,
-                Err(e) => serde_json::json!({
-                    "error": format!("session detail task failed: {e}")
-                })
-                .to_string(),
-            }
+                    .to_string(),
+                ),
+            ),
         };
-        let status = if !session_lookup_id_is_safe(session_id) {
-            "400 Bad Request"
-        } else {
-            session_detail_http_status(&body)
-        };
-        let response = HttpResponse::with_content(status, "application/json", body)
-            .header("Cache-Control", "no-cache")
-            .header("Connection", "close")
-            .into_string();
-        let _ = stream.write_all(response.as_bytes()).await;
+        let bytes = api_response_http_bytes(
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        );
+        let _ = stream.write_all(&bytes).await;
     }
     finalize_http_stream(&mut stream).await;
+}
+
+/// Transport-neutral core of session detail (`GET /api/session/{id}`,
+/// tunnel twin `api_session_detail`): the bare-id policy check (the raw,
+/// untrimmed id — the HTTP lane's historical strictness; the tunnel
+/// trims before delegating), then the paged replay body with its
+/// historical status mapping (404 only for "session not found").
+pub(crate) fn session_detail_api_response(
+    session_id: &str,
+    source: &str,
+    limit: Option<usize>,
+    before: Option<usize>,
+) -> ApiResponse {
+    if !session_lookup_id_is_safe(session_id) {
+        return ApiResponse::json_error(400, "invalid session id");
+    }
+    let body = session_detail_response_body_with_page(session_id, source, limit, before);
+    let status = if session_detail_http_status(&body) == "404 Not Found" {
+        404
+    } else {
+        200
+    };
+    ApiResponse::json(status, JsonBody::PreSerialized(body))
+}
+
+/// Transport-neutral core of the context-snapshot replay
+/// (`GET /api/session/{id}/context-snapshot`, tunnel twin
+/// `api_session_context_snapshot`): selector parts arrive transport-
+/// decoded (query string vs frame params); the bare-id policy, selector
+/// validation, and log-dir scan are the shared
+/// `session_context_snapshot_response_body` core.
+pub(crate) fn session_context_snapshot_api_response(
+    session_id: &str,
+    source: &str,
+    file: Option<String>,
+    request_id: Option<String>,
+    request_index: Option<u64>,
+    ts: Option<String>,
+) -> ApiResponse {
+    let (status_line, body) = session_context_snapshot_response_body(
+        &crate::platform::home_dir(),
+        session_id,
+        source,
+        file,
+        request_id,
+        request_index,
+        ts,
+    );
+    ApiResponse::json(
+        status_line_code(status_line),
+        JsonBody::PreSerialized(body),
+    )
 }
 
 pub(crate) async fn handle_mc_anchors(
@@ -2879,20 +2979,47 @@ pub(crate) async fn handle_sessions_stream(mut stream: DemuxStream, request_line
     finalize_http_stream(&mut stream).await;
 }
 
-pub(crate) async fn handle_sessions_search(mut stream: DemuxStream, request_line: &str) {
+/// Transport-neutral core of `GET /api/sessions/search` (tunnel twin
+/// `api_sessions_search`): one search composition — the single-flight
+/// guard plus the blocking store scan — under the caller's cancellation
+/// token, answered 200 under the wildcard-CORS tail.
+pub(crate) async fn sessions_search_api_response(
+    query: String,
+    source_filter: String,
+    mode: String,
+    project_filter: Vec<String>,
+    cancel: tokio_util::sync::CancellationToken,
+) -> ApiResponse {
+    let body = sessions_search_response_body_with_cancel(
+        query,
+        source_filter,
+        mode,
+        project_filter,
+        cancel,
+    )
+    .await;
+    session_wildcard_json_response(200, body)
+}
+
+pub(crate) async fn handle_sessions_search(
+    stream: DemuxStream,
+    request_line: &str,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
     let query = query_param(request_line, "q").unwrap_or_default();
     let source_filter = query_param(request_line, "source").unwrap_or_else(|| "all".to_string());
     let mode = query_param(request_line, "mode").unwrap_or_default();
     let project_filter = session_project_filter_from_request(request_line);
-    let body = sessions_search_response_body(query, source_filter, mode, project_filter).await;
-    let response = HttpResponse::with_content("200 OK", "application/json", body)
-        .header("Cache-Control", "no-cache")
-        .header("Access-Control-Allow-Origin", "*")
-        .header("Connection", "close")
-        .into_string();
-    use tokio::io::AsyncWriteExt;
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    let response = sessions_search_api_response(
+        query,
+        source_filter,
+        mode,
+        project_filter,
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await;
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_worktrees_inspect(mut stream: DemuxStream, body_text: String) {
@@ -4631,7 +4758,14 @@ mod tests {
         // touching the session stores — fully deterministic.
         let request_line = "GET /api/sessions?ids= HTTP/1.1";
         let response =
-            collect_session_handler_response(|stream| handle_sessions_list(stream, request_line))
+            collect_session_handler_response(|stream| {
+            handle_sessions_list(
+                stream,
+                request_line,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            )
+        })
                 .await;
         assert_eq!(
             golden_transcript(&response),
@@ -4645,7 +4779,14 @@ mod tests {
         // pins the query-parameter plumbing end to end.
         let request_line = "GET /api/sessions?ids=&limit=3&view=usage HTTP/1.1";
         let response =
-            collect_session_handler_response(|stream| handle_sessions_list(stream, request_line))
+            collect_session_handler_response(|stream| {
+            handle_sessions_list(
+                stream,
+                request_line,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            )
+        })
                 .await;
         assert_eq!(
             golden_transcript(&response),
@@ -4661,7 +4802,14 @@ mod tests {
         // An empty query short-circuits before any store scan.
         let request_line = "GET /api/sessions/search?q= HTTP/1.1";
         let response =
-            collect_session_handler_response(|stream| handle_sessions_search(stream, request_line))
+            collect_session_handler_response(|stream| {
+            handle_sessions_search(
+                stream,
+                request_line,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            )
+        })
                 .await;
         let body = serde_json::json!({
             "query": "",
@@ -4689,7 +4837,14 @@ mod tests {
         assert!(!SESSION_SEARCH_IN_FLIGHT.swap(true, Ordering::SeqCst));
         let request_line = "GET /api/sessions/search?q=anything HTTP/1.1";
         let response =
-            collect_session_handler_response(|stream| handle_sessions_search(stream, request_line))
+            collect_session_handler_response(|stream| {
+            handle_sessions_search(
+                stream,
+                request_line,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            )
+        })
                 .await;
         SESSION_SEARCH_IN_FLIGHT.store(false, Ordering::SeqCst);
         let body = serde_json::json!({
@@ -4764,7 +4919,13 @@ mod tests {
     async fn golden_session_agent_output_missing_ids_transcript() {
         let request_line = "POST /api/session/abc123/agent-output HTTP/1.1";
         let response = collect_session_handler_response(|stream| {
-            handle_session_agent_output(stream, "{}".to_string(), request_line)
+            handle_session_agent_output(
+                stream,
+                "{}".to_string(),
+                request_line,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            )
         })
         .await;
         assert_eq!(
@@ -4785,6 +4946,8 @@ mod tests {
                 stream,
                 r#"{"ids":["out-1"]}"#.to_string(),
                 &request_line,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
             )
         })
         .await;
@@ -4811,6 +4974,8 @@ mod tests {
                 stream,
                 r#"{"ids":["go-out-1","go-missing"]}"#.to_string(),
                 &request_line,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
             )
         })
         .await;

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -255,16 +255,6 @@ pub(crate) fn session_agent_output_api_response(
     }
 }
 
-/// Raw-string bridge for the tunnel twin until it delegates through the
-/// neutral fn (removed with that conversion).
-pub(crate) fn session_agent_output_post_response(
-    body: &str,
-    session_id: &str,
-    source: &str,
-) -> String {
-    api_response_to_http_string(session_agent_output_api_response(body, session_id, source))
-}
-
 /// Build a zip containing the current session's text artifacts for the
 /// Settings → "Download session report" feature. Includes session.jsonl,
 /// session_meta.json, transcript.jsonl, summary.json, daemon.log,

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -6,6 +6,13 @@
 
 use super::*;
 
+/// Serializes tests that drive the session search's single-flight guard
+/// (`SESSION_SEARCH_IN_FLIGHT` is process-global): the golden transcripts
+/// here and the tunnel/HTTP parity fixtures in `dashboard_control` lock it
+/// so a concurrent test never observes a spurious busy response.
+#[cfg(test)]
+pub(crate) static SESSIONS_SEARCH_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 pub(crate) fn agent_output_chunks_with_fallback(
     primary_log_dir: &Path,
     ids: &[String],
@@ -4551,5 +4558,342 @@ mod tests {
         assert_eq!(parsed.len(), 700);
         assert_eq!(parsed[0], "ao-19e4f985a17-0");
         assert_eq!(parsed[699], "ao-19e4f985a17-2bb");
+    }
+
+    // ── Golden HTTP transcripts: the sessions read-core wire contract ──
+    //
+    // Byte-exact pins of the session list / search / detail /
+    // agent-output / context-snapshot HTTP responses, captured before the
+    // transport-neutral conversion (transport-unification design §6 S4,
+    // risk R1) and kept as the conversion's proof. The expected framing
+    // is hand-written below — never built through the response helpers
+    // under conversion. Store-dependent bodies (detail success,
+    // agent-output success) come from the store-layer fns the conversion
+    // does not touch, over fixtures written into the live `~/.intendant`
+    // logs store (the bin-test convention — unique id per run, dir
+    // removed afterwards).
+
+    /// Run one stream-consuming handler and collect every byte it wrote.
+    async fn collect_session_handler_response<Fut>(
+        run: impl FnOnce(DemuxStream) -> Fut,
+    ) -> Vec<u8>
+    where
+        Fut: std::future::Future<Output = ()>,
+    {
+        use tokio::io::AsyncReadExt;
+        let (mut client, server) = tokio::io::duplex(1 << 20);
+        run(Box::pin(server)).await;
+        let mut response = Vec::new();
+        client
+            .read_to_end(&mut response)
+            .await
+            .expect("collect handler response");
+        response
+    }
+
+    /// The canonical JSON framing (`Cache-Control` + `Connection` tail):
+    /// detail and context-snapshot responses, spelled out literally.
+    fn golden_session_json_transcript(status_line: &str, body: &str) -> String {
+        format!(
+            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+    }
+
+    /// The wildcard-CORS JSON framing (`Cache-Control` +
+    /// `Access-Control-Allow-Origin: *` + `Connection` tail): the session
+    /// list, search, and agent-output shapes, spelled out literally.
+    fn golden_session_wildcard_json_transcript(status_line: &str, body: &str) -> String {
+        format!(
+            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+    }
+
+    fn golden_transcript(bytes: &[u8]) -> String {
+        String::from_utf8_lossy(bytes).into_owned()
+    }
+
+    /// Unique-per-run id for fixtures written into the live logs store.
+    fn golden_unique_session_id(prefix: &str) -> String {
+        format!(
+            "{prefix}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        )
+    }
+
+    #[tokio::test]
+    async fn golden_sessions_list_empty_ids_filter_transcript() {
+        // A present-but-empty ids filter answers the empty list without
+        // touching the session stores — fully deterministic.
+        let request_line = "GET /api/sessions?ids= HTTP/1.1";
+        let response =
+            collect_session_handler_response(|stream| handle_sessions_list(stream, request_line))
+                .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_wildcard_json_transcript("200 OK", "[]")
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_sessions_list_usage_view_and_limit_transcript() {
+        // The limit and view=usage knobs ride the same empty-filter body:
+        // pins the query-parameter plumbing end to end.
+        let request_line = "GET /api/sessions?ids=&limit=3&view=usage HTTP/1.1";
+        let response =
+            collect_session_handler_response(|stream| handle_sessions_list(stream, request_line))
+                .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_wildcard_json_transcript("200 OK", "[]")
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_sessions_search_no_input_transcript() {
+        let _guard = SESSIONS_SEARCH_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // An empty query short-circuits before any store scan.
+        let request_line = "GET /api/sessions/search?q= HTTP/1.1";
+        let response =
+            collect_session_handler_response(|stream| handle_sessions_search(stream, request_line))
+                .await;
+        let body = serde_json::json!({
+            "query": "",
+            "mode": "all_keywords",
+            "source_filter": "all",
+            "searched": 0,
+            "truncated": false,
+            "exhaustive": true,
+            "truncated_files": 0,
+            "results": [],
+        })
+        .to_string();
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_wildcard_json_transcript("200 OK", &body)
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_sessions_search_busy_transcript() {
+        let _guard = SESSIONS_SEARCH_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // The single-flight guard answers 200 with the busy body.
+        assert!(!SESSION_SEARCH_IN_FLIGHT.swap(true, Ordering::SeqCst));
+        let request_line = "GET /api/sessions/search?q=anything HTTP/1.1";
+        let response =
+            collect_session_handler_response(|stream| handle_sessions_search(stream, request_line))
+                .await;
+        SESSION_SEARCH_IN_FLIGHT.store(false, Ordering::SeqCst);
+        let body = serde_json::json!({
+            "error": "Another deep session search is already running. Wait for it to finish before starting a new one.",
+            "busy": true,
+        })
+        .to_string();
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_wildcard_json_transcript("200 OK", &body)
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_session_detail_invalid_id_transcript() {
+        // `..` fails the bare-id policy (session_lookup_id_is_safe).
+        let request_line = "GET /api/session/.. HTTP/1.1";
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, request_line, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_json_transcript("400 Bad Request", r#"{"error":"invalid session id"}"#)
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_session_detail_missing_transcript() {
+        let session_id = golden_unique_session_id("golden-detail-missing");
+        let request_line = format!("GET /api/session/{session_id} HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, &request_line, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_json_transcript("404 Not Found", r#"{"error":"session not found"}"#)
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_session_detail_success_transcript() {
+        let session_id = golden_unique_session_id("golden-detail");
+        let log_dir = crate::platform::intendant_home().join("logs").join(&session_id);
+        let mut log = crate::session_log::SessionLog::open(log_dir.clone()).unwrap();
+        log.agent_output_with_id("golden detail stdout", "", Some("Codex"), Some("gd-out-1"));
+        drop(log);
+
+        let request_line = format!("GET /api/session/{session_id}?limit=5 HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, &request_line, None, None)
+        })
+        .await;
+        // Body from the store layer (untouched by the conversion); the
+        // framing around it is the golden contract.
+        let body = get_session_detail_from_home_with_page(
+            &crate::platform::home_dir(),
+            &session_id,
+            Some(5),
+            None,
+        );
+        let cleanup = std::fs::remove_dir_all(&log_dir);
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_json_transcript("200 OK", &body)
+        );
+        cleanup.expect("golden detail fixture cleanup");
+    }
+
+    #[tokio::test]
+    async fn golden_session_agent_output_missing_ids_transcript() {
+        let request_line = "POST /api/session/abc123/agent-output HTTP/1.1";
+        let response = collect_session_handler_response(|stream| {
+            handle_session_agent_output(stream, "{}".to_string(), request_line)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_wildcard_json_transcript(
+                "400 Bad Request",
+                r#"{"error":"missing output ids"}"#
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_session_agent_output_missing_session_transcript() {
+        let session_id = golden_unique_session_id("golden-output-missing");
+        let request_line = format!("POST /api/session/{session_id}/agent-output HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_agent_output(
+                stream,
+                r#"{"ids":["out-1"]}"#.to_string(),
+                &request_line,
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_wildcard_json_transcript(
+                "404 Not Found",
+                r#"{"error":"session not found"}"#
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_session_agent_output_success_transcript() {
+        let session_id = golden_unique_session_id("golden-output");
+        let log_dir = crate::platform::intendant_home().join("logs").join(&session_id);
+        let mut log = crate::session_log::SessionLog::open(log_dir.clone()).unwrap();
+        log.agent_output_with_id("golden stdout", "", Some("Codex"), Some("go-out-1"));
+        drop(log);
+
+        let request_line = format!("POST /api/session/{session_id}/agent-output HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_agent_output(
+                stream,
+                r#"{"ids":["go-out-1","go-missing"]}"#.to_string(),
+                &request_line,
+            )
+        })
+        .await;
+        // Body from the chunk store layer (untouched by the conversion).
+        let chunks = agent_output_chunks_with_fallback(
+            &log_dir,
+            &["go-out-1".to_string(), "go-missing".to_string()],
+            None,
+        );
+        let body = serde_json::json!({
+            "outputs": chunks,
+            "missing": ["go-missing"],
+        })
+        .to_string();
+        let cleanup = std::fs::remove_dir_all(&log_dir);
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_wildcard_json_transcript("200 OK", &body)
+        );
+        cleanup.expect("golden agent-output fixture cleanup");
+    }
+
+    #[tokio::test]
+    async fn golden_session_context_snapshot_missing_selector_transcript() {
+        let request_line = "GET /api/session/abc123/context-snapshot HTTP/1.1";
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, request_line, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_json_transcript(
+                "400 Bad Request",
+                r#"{"error":"missing snapshot selector"}"#
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_session_context_snapshot_invalid_index_transcript() {
+        let request_line = "GET /api/session/abc123/context-snapshot?request_index=abc HTTP/1.1";
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, request_line, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_json_transcript(
+                "400 Bad Request",
+                r#"{"error":"invalid request_index"}"#
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_session_context_snapshot_invalid_id_transcript() {
+        // `..` fails the bare-id policy (session_lookup_id_is_safe).
+        let request_line = "GET /api/session/../context-snapshot?file=snapshot.json HTTP/1.1";
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, request_line, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_json_transcript("400 Bad Request", r#"{"error":"invalid session id"}"#)
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_session_context_snapshot_not_found_transcript() {
+        let session_id = golden_unique_session_id("golden-snapshot-missing");
+        let request_line =
+            format!("GET /api/session/{session_id}/context-snapshot?file=snapshot.json HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, &request_line, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_json_transcript(
+                "404 Not Found",
+                r#"{"error":"context snapshot not found"}"#
+            )
+        );
     }
 }

--- a/src/bin/caller/web_gateway/session_catalog/detail_search.rs
+++ b/src/bin/caller/web_gateway/session_catalog/detail_search.rs
@@ -126,10 +126,17 @@ pub(crate) fn context_snapshot_file_selector_is_safe(file: &str) -> bool {
             .all(|component| matches!(component, std::path::Component::Normal(_)))
 }
 
-pub(crate) fn context_snapshot_selector_from_request(
+/// Query-string decode of the snapshot selector parts — the HTTP lane's
+/// transport-owned decode (the tunnel decodes the same parts from frame
+/// params). Selector validation lives with the shared
+/// [`session_context_snapshot_response_body`] core; only the u64 parse
+/// can fail here, keeping its historical wording.
+pub(crate) type ContextSnapshotSelectorParts =
+    (Option<String>, Option<String>, Option<u64>, Option<String>);
+
+pub(crate) fn context_snapshot_selector_parts_from_request(
     request_line: &str,
-) -> Result<ContextSnapshotSelector, String> {
-    let file = query_param(request_line, "file").filter(|value| !value.trim().is_empty());
+) -> Result<ContextSnapshotSelectorParts, String> {
     let request_index =
         match query_param(request_line, "request_index").filter(|value| !value.trim().is_empty()) {
             Some(value) => Some(
@@ -139,12 +146,12 @@ pub(crate) fn context_snapshot_selector_from_request(
             ),
             None => None,
         };
-    context_snapshot_selector_from_parts(
-        file,
+    Ok((
+        query_param(request_line, "file").filter(|value| !value.trim().is_empty()),
         query_param(request_line, "request_id").filter(|value| !value.trim().is_empty()),
         request_index,
         query_param(request_line, "ts").filter(|value| !value.trim().is_empty()),
-    )
+    ))
 }
 
 pub(crate) fn context_snapshot_selector_from_parts(
@@ -326,30 +333,6 @@ pub(crate) fn session_context_snapshot_response_body(
     session_context_snapshot_response_for_selector(home, session_id, source, selector)
 }
 
-pub(crate) fn get_session_context_snapshot_from_home(
-    home: &Path,
-    session_id: &str,
-    source: &str,
-    request_line: &str,
-) -> (&'static str, String) {
-    if !session_lookup_id_is_safe(session_id) {
-        return (
-            "400 Bad Request",
-            serde_json::json!({"error": "invalid session id"}).to_string(),
-        );
-    }
-    let selector = match context_snapshot_selector_from_request(request_line) {
-        Ok(selector) => selector,
-        Err(error) => {
-            return (
-                "400 Bad Request",
-                serde_json::json!({"error": error}).to_string(),
-            );
-        }
-    };
-    session_context_snapshot_response_for_selector(home, session_id, source, selector)
-}
-
 pub(crate) fn session_context_snapshot_response_for_selector(
     home: &Path,
     session_id: &str,
@@ -387,22 +370,6 @@ pub(crate) fn session_context_snapshot_response_for_selector(
         "404 Not Found",
         serde_json::json!({"error": "context snapshot not found"}).to_string(),
     )
-}
-
-pub(crate) async fn sessions_search_response_body(
-    query: String,
-    source_filter: String,
-    mode: String,
-    project_filter: Vec<String>,
-) -> String {
-    sessions_search_response_body_with_cancel(
-        query,
-        source_filter,
-        mode,
-        project_filter,
-        tokio_util::sync::CancellationToken::new(),
-    )
-    .await
 }
 
 pub(crate) async fn sessions_search_response_body_with_cancel(
@@ -1803,11 +1770,19 @@ mod tests {
         let request = format!(
             "GET /api/session/lazy-session/context-snapshot?source=intendant&file={encoded_file} HTTP/1.1"
         );
-        let (status, body) = get_session_context_snapshot_from_home(
+        // The HTTP lane's decode (url-decoding the file selector) feeding
+        // the shared (status, body) core, over this test's own home.
+        let (file, request_id, request_index, ts) =
+            context_snapshot_selector_parts_from_request(&request).unwrap();
+        assert_eq!(file.as_deref(), Some(snapshot_file));
+        let (status, body) = session_context_snapshot_response_body(
             dir.path(),
             "lazy-session",
             "intendant",
-            &request,
+            file,
+            request_id,
+            request_index,
+            ts,
         );
         assert_eq!(status, "200 OK");
         let loaded: serde_json::Value = serde_json::from_str(&body).unwrap();

--- a/src/bin/caller/web_gateway/session_catalog/mod.rs
+++ b/src/bin/caller/web_gateway/session_catalog/mod.rs
@@ -3019,9 +3019,11 @@ mod tests {
             "codex",
             vec!["call_large".to_string()],
         );
-        assert!(response.starts_with("HTTP/1.1 200 OK"));
-        let body = response.split("\r\n\r\n").nth(1).unwrap();
-        let json: serde_json::Value = serde_json::from_str(body).unwrap();
+        let crate::web_gateway::ApiResponse::Json { status, body, .. } = response else {
+            panic!("agent output must answer on the json lane");
+        };
+        assert_eq!(status, 200);
+        let json: serde_json::Value = serde_json::from_str(&body.into_string()).unwrap();
         assert_eq!(json["missing"].as_array().unwrap().len(), 0);
         let stdout = json["outputs"][0]["stdout"].as_str().unwrap();
         assert_eq!(

--- a/src/bin/caller/web_gateway/session_catalog/mod.rs
+++ b/src/bin/caller/web_gateway/session_catalog/mod.rs
@@ -683,16 +683,6 @@ pub(crate) fn cached_list_sessions_for_ids(ids: &[String]) -> String {
     cached_list_sessions_for_ids_from_home(&crate::platform::home_dir(), ids)
 }
 
-pub(crate) fn sessions_list_response_body(limit: Option<usize>, ids: &[String]) -> String {
-    if !ids.is_empty() {
-        cached_list_sessions_for_ids(ids)
-    } else if let Some(limit) = limit {
-        cached_list_sessions_with_limit(limit)
-    } else {
-        cached_list_sessions()
-    }
-}
-
 /// Strip session rows down to what the Stats tab folds: usage, costs,
 /// per-day buckets, disk sizes, and the model name (the ui-v2 Usage
 /// screen aggregates cost by model client-side). Full rows carry tasks,


### PR DESCRIPTION
Stage S4 slice 1 of 3 of the transport-unification program (design §2.1–2.5, §6 S4, §7 R1/R2/R8, §8): the sessions **read-heavy core** goes transport-neutral — one handler per method, each lane an adapter — with the tunnel columns moved onto the route rows and the differential pin flipped for the converted names.

## Proposed S4 slice split

- **S4a (this PR) — read core**: `api_sessions` (list; the R8 hot path), `api_sessions_search`, `api_session_detail`, `api_session_agent_output` (POST-shaped read), `api_session_context_snapshot` + their HTTP twins; the sub-router's two converted GET leaves carved as method-explicit rows carrying the tunnel columns.
- **S4b — artifacts, deletes, worktrees**: `api_session_report` (BYTES lane), `api_session_recordings`, `api_session_recording_asset` (BYTES), `api_session_frame_asset` (BYTES), `api_session_delete` (the five wire shapes), `api_worktrees`, `api_worktrees_inspect`, `api_worktrees_scan`, `api_worktrees_remove` — carving further sub-router leaves as their twins move (9 pin flips).
- **S4c — current-session + managed-context**: `api_session_current_{history,rollback,redo,prune,changes,agent_output,uploads,upload_raw,upload_delete,upload}` (UPLOAD/BYTES lanes), `api_managed_context_{records,anchors,fission}` — retiring the remaining `http_wire_response`/`api_response_to_http_string` bridges (13 pin flips).

(`api_sessions_stream` stays put for S10; `api_external_agents` belongs to the S5 settings/info family.)

## What this PR does

Template = the fs family (#132/#133/#134/#137), commit by commit:

1. **Golden transcripts first** (own commit): 14 byte-exact pins of the five surfaces' HTTP wire bytes — list empty-ids/limit/usage plumbing, search no-input + single-flight busy bodies, detail invalid/missing/success, agent-output missing-ids/missing-session/success (outputs/missing body + wildcard-CORS tail), context-snapshot 400s/404 (a 15th pin — the double-error precedence corner — joins in the rows commit with the precedence restoration) — framing hand-written, store-dependent bodies from store-layer fns the conversion does not touch, live-store fixtures per the bin-test convention.
2. **HTTP side**: neutral cores in `routes_sessions.rs` — `sessions_list_api_response` (PreSerialized end to end, risk R8), `sessions_search_api_response` (single-flight + blocking scan under the caller's cancel token), `session_detail_api_response`, `session_agent_output_api_response`, `session_context_snapshot_api_response`. Handlers become two-line shims taking the row's CORS posture from dispatch; the sub-router's two converted branches collapse onto the cores. Goldens pass unchanged.
3. **Tunnel side**: the five tunnel handlers delegate through the same neutral fns. `frame_api_response` carries the `_httpStatus`-injecting pair (agent-output, context-snapshot); a new `frame_api_json_body_response` adapter carries the pre-`_httpStatus` trio (list/detail/search) so their historical body-only envelope stays byte-identical. Parity fixtures pin same-params ⇒ same-body across lanes, with the family's envelope differences enumerated (below). Dedup deletions: `sessions_list_response_body`, `session_agent_output_post_response`, `get_session_context_snapshot_from_home` + `context_snapshot_selector_from_request` (collapsed into a parts decode + the shared core), the non-cancel `sessions_search_response_body` wrapper, and dashboard-control's private `status_line_code` (now the `http.rs` helper). `http_wire_response` loses its `api_session_agent_output` caller (two callers remain for S4c).
4. **Rows + pin flip**: `tunnel:` columns on `GET /api/sessions`, `GET /api/sessions/search`, `POST /api/session/{id}/agent-output`, and two carved method-explicit leaf rows `GET /api/session/{id}` and `GET /api/session/{id}/context-snapshot` (joining the SessionSubRouter shared-handler group; classification-preserving — both were SessionInspect GETs via the Under row). Their five `CONTROL_METHODS` entries are gone; the docs endpoint table regenerates.

## Differential pin flips (Residue → Row)

- `api_sessions`
- `api_sessions_search`
- `api_session_detail`
- `api_session_agent_output`
- `api_session_context_snapshot`

All five keep `SessionInspect`, now derived from their rows (`Route::tunnel_operation`) instead of declared twice. The op-override enumeration stays empty.

## Envelope differences found (enumerated on the parity fixtures)

1. **Pre-`_httpStatus` envelopes**: `api_sessions` / `api_session_detail` / `api_sessions_search` predate the injected-status envelope — frames stay `{t,id,ok:true,result:<body>}` with **no** `_httpStatus`/`_httpOk`, so HTTP-side statuses (detail 400/404) don't surface on the tunnel; error bodies ride `{"error":…}` inline under ok:true. Preserved verbatim via `frame_api_json_body_response` (wire freeze, design §5).
2. **List result-shape guard**: the tunnel rejects a non-array list body (`ok:false "session list returned invalid JSON"`); HTTP passes any body through under 200.
3. **Injected-status pair**: agent-output + context-snapshot keep `http_body_response` semantics — `_httpStatus`/`_httpOk` match the HTTP status exactly.
4. **Transport-owned param decode**: HTTP's `ids=` distinguishes present-but-empty (→ `[]`) from absent; the tunnel's ids vocabulary can't express the empty filter and its ids path never applies the limit truncation (the tunnel maps ids requests to `limit=None` — historical `for_ids` semantics). HTTP limit aliases (`limit`/`max`/`count`, `SESSION_LIST_LIMIT` cap) vs tunnel `limit` with the `CONTROL_DEFAULT_SESSION_LIMIT` default and `"all"`/`"full"` escape. The tunnel trims `session_id` and takes `sessionId`/`id` aliases; HTTP takes the raw path segment.
5. **Header tails are HTTP-lane decoration**: list/search + intendant-source agent-output carry the wildcard-CORS tail; detail/context-snapshot the canonical tail; the external-source agent-output success rides the canonical tail (historical asymmetry, kept).
6. **Task-failure shapes stay per-lane**: HTTP answers 200 with an `{"error":…}` body (list/detail); the tunnel emits ok:false frames.
7. **Double-error precedence (context-snapshot) stays per-lane**: HTTP answers invalid-id before an unparseable `request_index` (historical order, restored after review and pinned by a golden); the tunnel's transport-owned decode keeps its historical index-error-first order. Both are 400s either way.

## R8 timing note (api_sessions)

Interleaved before/after probe on this box's live store (~7.1 MiB list response, warm list cache so serialization dominates; n=10 per path; "old" replicates the pre-conversion handler body verbatim, minus its sub-microsecond query parse):

| path | median | p90 |
|---|---|---|
| old (inline `HttpResponse::into_string`) | 3.27 ms | 3.31 ms |
| new (`sessions_list_api_response` → `write_api_response`) | **1.08 ms** | **1.15 ms** |

The conversion is not merely allocation-identical — it *removed* a full-body copy: the old handler rendered through `into_string()` (`String::from_utf8_lossy(...).into_owned()` — a 7 MB UTF-8 validation plus second copy) before `as_bytes()`; the neutral path renders `ApiResponse` straight to bytes. Cold-scan cost (store walk) is untouched on both paths. Probe kept out of the tree (a scratch `#[ignore]` test; the duplex harness drains concurrently, as real sockets do).

## Size note

~1.3k diff lines total, of which ~700 are the golden transcripts + parity fixtures (line-heavy pins, not review complexity); product-code delta is ~600 lines net across the five conversions, the two carved rows, and the dedup deletions (incl. the now-dead `json_response_body`).

## Gates

- `cargo nextest run --bins` green (new goldens + parity + the flipped partition pin; the live-store scans joined the documented nextest slow-timeout override lane)
- `cargo test --test e2e` 8/8
- clippy: no new warnings vs the origin/main baseline
- `--color-moved=dimmed-zebra` self-review
