### PR TITLE
Transport S4b: session artifacts/deletes/worktrees neutral conversion

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -59,5 +59,11 @@ filter = 'test(/^web_gateway::routes_sessions::tests::(agent_output_post_respons
 slow-timeout = { period = "60s", terminate-after = 4 }
 
 [[profile.default.overrides]]
-filter = 'test(/^dashboard_control::api_sessions::tests::parity_/)'
+filter = 'test(/^dashboard_control::(api_sessions|api_media)::tests::parity_/)'
+slow-timeout = { period = "60s", terminate-after = 4 }
+
+# The worktrees parity fixtures run the real inventory scan (git
+# subprocess per worktree — the worktree_inventory class above).
+[[profile.default.overrides]]
+filter = 'test(/^dashboard_control::api_control::tests::parity_worktrees/)'
 slow-timeout = { period = "60s", terminate-after = 4 }

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -2006,6 +2006,10 @@ its operation per method/path from `federation_http_operation`.
 | GET | `/api/session/current[/…]` | SessionManage | own origin | none | Current-session detail and artifact sub-routes |
 | POST | `/api/session/current[/…]` | SessionManage | own origin | none | Current-session detail sub-routes (POST fallback callers) |
 | GET | `/api/session/{id}/context-snapshot` | SessionInspect | own origin | none | Replay one archived context snapshot (file/request_id/request_index/ts selector) |
+| GET | `/api/session/{id}/report` | SessionInspect | own origin | none | Session report zip (text artifacts; id=current targets the live session) |
+| GET | `/api/session/{id}/recordings` | SessionInspect | own origin | none | List a session's recording streams |
+| GET | `/api/session/{id}/recordings/{stream}/{asset}` | SessionInspect | own origin | none | Recording assets: segments listing, playlist.m3u8, or a segment file |
+| GET | `/api/session/{id}/frames/{filename}` | SessionInspect | own origin | none | Session frame image asset |
 | GET | `/api/session/{id}` | SessionInspect | own origin | none | Session detail (paged replay entries; limit/before/source) |
 | GET | `/api/session[/…]` | SessionInspect | own origin | none | Session artifact sub-routes: recordings (+segments/playlist), report zip, frames |
 | POST | `/api/session[/…]` | SessionManage | own origin | none | Session detail sub-routes (POST fallback callers) |

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -642,13 +642,11 @@ pub(crate) async fn active_replay_log_dir(runtime: &ControlRuntime) -> Option<Pa
 }
 
 pub(crate) async fn api_worktrees_response(id: String, runtime: &ControlRuntime) -> serde_json::Value {
-    let body = runtime
-        .worktree_inventory_cache
-        .lock()
-        .ok()
-        .and_then(|guard| guard.clone())
-        .unwrap_or_else(crate::web_gateway::empty_worktree_inventory_response);
-    json_body_response(id, body, "worktrees")
+    frame_api_json_body_response(
+        id,
+        crate::web_gateway::worktrees_list_api_response(&runtime.worktree_inventory_cache),
+        "worktrees",
+    )
 }
 
 pub(crate) async fn api_worktrees_inspect_response(
@@ -657,15 +655,12 @@ pub(crate) async fn api_worktrees_inspect_response(
     _runtime: &ControlRuntime,
 ) -> serde_json::Value {
     let body_text = params_body_text(params);
-    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
     let result = tokio::task::spawn_blocking(move || {
-        crate::web_gateway::inspect_worktree_inventory_response(&home, &body_text)
+        crate::web_gateway::worktrees_inspect_api_response(&body_text)
     })
     .await;
     match result {
-        Ok((status_line, body)) => {
-            http_body_response(id, status_line_code(status_line), body, "worktree inspect")
-        }
+        Ok(response) => frame_api_response(id, response, "worktree inspect"),
         Err(e) => http_body_response(
             id,
             500,
@@ -680,20 +675,14 @@ pub(crate) async fn api_worktrees_inspect_response(
 }
 
 pub(crate) async fn api_worktrees_scan_response(id: String, runtime: &ControlRuntime) -> serde_json::Value {
-    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
     let project_root = runtime.project_root.clone();
     let cache = runtime.worktree_inventory_cache.clone();
     let result = tokio::task::spawn_blocking(move || {
-        let body =
-            crate::web_gateway::scan_worktree_inventory_response(&home, project_root.as_deref());
-        if let Ok(mut guard) = cache.lock() {
-            *guard = Some(body.clone());
-        }
-        body
+        crate::web_gateway::worktrees_scan_api_response(project_root.as_deref(), &cache)
     })
     .await;
     match result {
-        Ok(body) => json_body_response(id, body, "worktree scan"),
+        Ok(response) => frame_api_json_body_response(id, response, "worktree scan"),
         Err(e) => http_body_response(
             id,
             500,
@@ -712,22 +701,13 @@ pub(crate) async fn api_worktrees_remove_response(
     runtime: &ControlRuntime,
 ) -> serde_json::Value {
     let body_text = params_body_text(params);
-    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
     let cache = runtime.worktree_inventory_cache.clone();
     let result = tokio::task::spawn_blocking(move || {
-        let result = crate::web_gateway::remove_worktree_inventory_response(&home, &body_text);
-        if result.0 == "200 OK" {
-            if let Ok(mut guard) = cache.lock() {
-                *guard = None;
-            }
-        }
-        result
+        crate::web_gateway::worktrees_remove_api_response(&body_text, &cache)
     })
     .await;
     match result {
-        Ok((status_line, body)) => {
-            http_body_response(id, status_line_code(status_line), body, "worktree remove")
-        }
+        Ok(response) => frame_api_response(id, response, "worktree remove"),
         Err(e) => http_body_response(
             id,
             500,
@@ -1698,6 +1678,142 @@ pub(crate) async fn api_coordinator_route_response(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── S4b tunnel/HTTP parity: worktrees (design §8) ──
+    //
+    // Extends the S4a enumeration (api_sessions.rs). The S4b-specific
+    // envelope differences, deliberate and pinned across this slice's
+    // fixtures (worktrees here; delete/report in api_sessions.rs;
+    // recordings in api_media.rs):
+    //
+    //  1. Body-only envelopes again: api_session_delete, api_worktrees
+    //     (list), and api_worktrees_scan predate the injected-status
+    //     envelope — plain `{t,id,ok:true,result}` frames; worktrees
+    //     inspect/remove and api_session_recordings ride the
+    //     injected-status envelope, whose keys only decorate OBJECT
+    //     bodies (the recordings array passes through untouched).
+    //  2. BYTES lane: the report zip and the recording listing assets
+    //     serve identical bytes on both lanes; HTTP renders meta as its
+    //     attachment/no-cache header tails, the tunnel emits the meta
+    //     object verbatim as byte_stream_end.result. The delete tail
+    //     orders the wildcard CORS header first (HTTP-lane decoration
+    //     only).
+    //  3. Transport-owned asset carriage: segment/frame FILES stream
+    //     ranged and capped on the tunnel (offset/length params,
+    //     UPLOAD_MAX_BYTES cap, 413/416 shapes) but serve as one
+    //     unbounded body on HTTP; tunnel asset validators are stricter
+    //     (trim, backslash) than the HTTP leaves' historical inline
+    //     checks, and each lane keeps its historical error wording
+    //     (json `{"ok":false,…}` vs text/plain).
+    //  4. Transport-owned params: the tunnel's report id defaults to
+    //     "current" and delete's target to "session"; HTTP addresses
+    //     both by path segment (five delete wire shapes).
+    //  5. Task-failure shapes stay per-lane (scan answers 200 with an
+    //     error body on HTTP, an ok:false frame on the tunnel).
+
+    fn parity_worktrees_http_body(
+        response: crate::web_gateway::ApiResponse,
+    ) -> (u16, serde_json::Value) {
+        let bytes = crate::web_gateway::api_response_http_bytes(
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        );
+        let split = bytes
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .expect("header/body split");
+        let head = String::from_utf8(bytes[..split].to_vec()).expect("ascii head");
+        let status = head
+            .lines()
+            .next()
+            .and_then(|line| line.strip_prefix("HTTP/1.1 "))
+            .and_then(|line| line.split_whitespace().next())
+            .and_then(|code| code.parse::<u16>().ok())
+            .expect("status line");
+        (status, serde_json::from_slice(&bytes[split + 4..]).expect("json body"))
+    }
+
+    #[tokio::test]
+    async fn parity_worktrees_list_serves_the_same_body_on_both_transports() {
+        let rt = crate::dashboard_control::tests::runtime();
+        {
+            let mut guard = rt.worktree_inventory_cache.lock().unwrap();
+            *guard = Some(r#"{"worktrees":[],"cached":true}"#.to_string());
+        }
+        let (status, http_body) = parity_worktrees_http_body(
+            crate::web_gateway::worktrees_list_api_response(&rt.worktree_inventory_cache),
+        );
+        assert_eq!(status, 200);
+        let frame = api_worktrees_response("parity-wt-list".to_string(), &rt).await;
+        assert_eq!(frame["ok"], true);
+        // Body-only envelope: no injected status metadata.
+        assert!(frame["result"]
+            .as_object()
+            .is_none_or(|map| !map.contains_key("_httpStatus")));
+        assert_eq!(frame["result"], http_body);
+    }
+
+    #[tokio::test]
+    async fn parity_worktrees_inspect_shares_bodies_with_status_metadata() {
+        let rt = crate::dashboard_control::tests::runtime();
+        // Invalid request body: deterministic serde wording on both lanes.
+        let (status, http_body) = parity_worktrees_http_body(
+            crate::web_gateway::worktrees_inspect_api_response("not json"),
+        );
+        assert_eq!(status, 400);
+        let frame = api_worktrees_inspect_response(
+            "parity-wt-inspect".to_string(),
+            Some(&serde_json::json!("not json")),
+            &rt,
+        )
+        .await;
+        let mut result = frame["result"].clone();
+        let map = result.as_object_mut().expect("result object");
+        assert_eq!(map.remove("_httpStatus"), Some(serde_json::json!(400)));
+        assert_eq!(map.remove("_httpOk"), Some(serde_json::json!(false)));
+        // The tunnel serializes its params value as the request body —
+        // "not json" arrives quoted, so the serde wording differs in the
+        // offending token but both are the invalid-request shape.
+        assert_eq!(result["ok"], http_body["ok"]);
+        assert!(result["error"]
+            .as_str()
+            .unwrap()
+            .starts_with("invalid worktree inspect request:"));
+        assert!(http_body["error"]
+            .as_str()
+            .unwrap()
+            .starts_with("invalid worktree inspect request:"));
+    }
+
+    #[tokio::test]
+    async fn parity_worktrees_scan_rides_the_shared_core_and_plain_envelope() {
+        // Both lanes call the ONE neutral scan (worktrees_scan_api_response)
+        // by construction; live worktree state moves between scans on a
+        // multi-agent box, so this fixture runs a single tunnel scan and
+        // pins the envelope mapping plus the shared cache side-effect
+        // (byte-equal double scans would race the fleet).
+        let rt = crate::dashboard_control::tests::runtime();
+        let frame = api_worktrees_scan_response("parity-wt-scan".to_string(), &rt).await;
+        assert_eq!(frame["t"], "response");
+        assert_eq!(frame["ok"], true);
+        // Body-only envelope: no injected status metadata.
+        let result = frame["result"].as_object().expect("inventory object");
+        assert!(!result.contains_key("_httpStatus"), "{frame}");
+        assert!(result.contains_key("worktrees"), "{frame}");
+        let cached = rt
+            .worktree_inventory_cache
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("scan must warm the shared cache");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&cached).unwrap(),
+            frame["result"],
+            "the cache holds the served body"
+        );
+    }
+
     use crate::*;
     use crate::dashboard_control::tests::{runtime};
 

--- a/src/bin/caller/dashboard_control/api_media.rs
+++ b/src/bin/caller/dashboard_control/api_media.rs
@@ -4,6 +4,20 @@
 
 use super::*;
 
+// The recording/frame asset content core — the RecordingAsset vocabulary,
+// its resolvers, safety predicates, and range readers — moved verbatim to
+// web_gateway::session_catalog (transport-unification S4b): both lanes
+// resolve assets through one core; this module keeps the tunnel's ranged
+// byte-stream carriage.
+pub(crate) use crate::web_gateway::{
+    read_frame_asset_file_range, read_recording_asset_bytes_range,
+    read_recording_asset_file_range, recording_asset_range,
+    recording_asset_name_is_safe, recording_segment_filename_is_safe,
+    recording_stream_name_is_safe, resolve_recording_asset_from_dir_pair,
+    resolve_session_recording_asset, session_frame_filename_is_safe,
+    RecordingAsset,
+};
+
 pub(crate) fn media_http_response(id: String, status: u16, body: serde_json::Value) -> serde_json::Value {
     http_body_response(id, status, body.to_string(), "dashboard media")
 }
@@ -732,43 +746,6 @@ pub(crate) fn recording_asset_request_params(
     Ok((stream_name, asset, offset, length))
 }
 
-pub(crate) fn recording_stream_name_is_safe(name: &str) -> bool {
-    !name.is_empty()
-        && name.len() < 128
-        && name.trim() == name
-        && name != "."
-        && name != ".."
-        && name
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
-}
-
-pub(crate) fn recording_asset_name_is_safe(asset: &str) -> bool {
-    asset == "segments" || asset == "playlist.m3u8" || (recording_segment_filename_is_safe(asset))
-}
-
-pub(crate) fn recording_segment_filename_is_safe(filename: &str) -> bool {
-    filename.starts_with("seg_")
-        && (filename.ends_with(".mp4") || filename.ends_with(".ts"))
-        && filename.len() < 30
-        && !filename.contains("..")
-        && !filename.contains('/')
-        && !filename.contains('\\')
-}
-
-pub(crate) enum RecordingAsset {
-    Bytes {
-        bytes: Vec<u8>,
-        content_type: &'static str,
-        filename: String,
-    },
-    File {
-        path: PathBuf,
-        content_type: &'static str,
-        filename: String,
-    },
-}
-
 pub(crate) async fn resolve_live_recording_asset(
     registry: Arc<tokio::sync::RwLock<crate::recording::RecordingRegistry>>,
     stream_name: &str,
@@ -789,86 +766,6 @@ pub(crate) async fn resolve_live_recording_asset(
         segments,
         asset,
     )
-}
-
-pub(crate) fn resolve_session_recording_asset(
-    session_dir: Option<PathBuf>,
-    stream_name: &str,
-    asset: &str,
-) -> Result<RecordingAsset, (u16, serde_json::Value)> {
-    let stream_dir = session_dir
-        .as_ref()
-        .map(|dir| dir.join("recordings").join(stream_name));
-    let segments = stream_dir
-        .as_ref()
-        .map(|dir| crate::recording::parse_segment_csv_pub(&dir.join("segments.csv"), dir))
-        .unwrap_or_default();
-    resolve_recording_asset_from_dir_pair(stream_dir, None, segments, asset)
-}
-
-pub(crate) fn resolve_recording_asset_from_dir_pair(
-    primary_dir: Option<PathBuf>,
-    fallback_dir: Option<PathBuf>,
-    segments: Vec<crate::recording::SegmentInfo>,
-    asset: &str,
-) -> Result<RecordingAsset, (u16, serde_json::Value)> {
-    if asset == "segments" {
-        let seg_json: Vec<serde_json::Value> = segments
-            .iter()
-            .map(|s| {
-                serde_json::json!({
-                    "filename": s.filename,
-                    "start_secs": s.start_secs,
-                    "end_secs": s.end_secs,
-                })
-            })
-            .collect();
-        let bytes = serde_json::to_vec(&seg_json).unwrap_or_else(|_| b"[]".to_vec());
-        return Ok(RecordingAsset::Bytes {
-            bytes,
-            content_type: "application/json",
-            filename: "segments.json".to_string(),
-        });
-    }
-    if asset == "playlist.m3u8" {
-        return Ok(RecordingAsset::Bytes {
-            bytes: crate::web_gateway::recording_playlist_m3u8(&segments).into_bytes(),
-            content_type: "application/vnd.apple.mpegurl",
-            filename: "playlist.m3u8".to_string(),
-        });
-    }
-    if !recording_segment_filename_is_safe(asset) {
-        return Err((
-            400,
-            serde_json::json!({ "ok": false, "error": "invalid recording asset" }),
-        ));
-    }
-    let path = primary_dir
-        .as_ref()
-        .map(|dir| dir.join(asset))
-        .filter(|path| path.exists())
-        .or_else(|| {
-            fallback_dir
-                .as_ref()
-                .map(|dir| dir.join(asset))
-                .filter(|path| path.exists())
-        });
-    let Some(path) = path else {
-        return Err((
-            404,
-            serde_json::json!({ "ok": false, "error": "recording asset not found" }),
-        ));
-    };
-    let content_type = if asset.ends_with(".ts") {
-        "video/mp2t"
-    } else {
-        "video/mp4"
-    };
-    Ok(RecordingAsset::File {
-        path,
-        content_type,
-        filename: asset.to_string(),
-    })
 }
 
 pub(crate) async fn recording_asset_task_response(
@@ -952,96 +849,6 @@ pub(crate) async fn recording_asset_task_response(
         }),
         done: true,
     }
-}
-
-pub(crate) fn read_recording_asset_bytes_range(
-    bytes: Vec<u8>,
-    offset: u64,
-    length: Option<u64>,
-) -> Result<(Vec<u8>, u64, u64), (u16, serde_json::Value)> {
-    let total_size = bytes.len() as u64;
-    let (start, transfer_len, end) = recording_asset_range(total_size, offset, length)?;
-    let start = usize::try_from(start).map_err(|_| {
-        (
-            413,
-            serde_json::json!({ "ok": false, "error": "range too large for this platform" }),
-        )
-    })?;
-    Ok((bytes[start..start + transfer_len].to_vec(), total_size, end))
-}
-
-pub(crate) fn read_recording_asset_file_range(
-    path: &std::path::Path,
-    offset: u64,
-    length: Option<u64>,
-) -> Result<(Vec<u8>, u64, u64), (u16, serde_json::Value)> {
-    let metadata = std::fs::metadata(path).map_err(|e| {
-        (
-            500,
-            serde_json::json!({ "ok": false, "error": format!("stat recording asset: {e}") }),
-        )
-    })?;
-    let total_size = metadata.len();
-    let (start, transfer_len, end) = recording_asset_range(total_size, offset, length)?;
-    let mut file = std::fs::File::open(path).map_err(|e| {
-        (
-            500,
-            serde_json::json!({ "ok": false, "error": format!("open recording asset: {e}") }),
-        )
-    })?;
-    file.seek(std::io::SeekFrom::Start(start)).map_err(|e| {
-        (
-            500,
-            serde_json::json!({ "ok": false, "error": format!("seek recording asset: {e}") }),
-        )
-    })?;
-    let mut bytes = vec![0u8; transfer_len];
-    file.read_exact(&mut bytes).map_err(|e| {
-        (
-            500,
-            serde_json::json!({ "ok": false, "error": format!("read recording asset: {e}") }),
-        )
-    })?;
-    Ok((bytes, total_size, end))
-}
-
-pub(crate) fn recording_asset_range(
-    total_size: u64,
-    offset: u64,
-    length: Option<u64>,
-) -> Result<(u64, usize, u64), (u16, serde_json::Value)> {
-    if offset > total_size {
-        return Err((
-            416,
-            serde_json::json!({
-                "ok": false,
-                "error": "range start beyond recording asset size",
-                "total_size": total_size,
-            }),
-        ));
-    }
-    let available = total_size.saturating_sub(offset);
-    let requested = length.unwrap_or(available).min(available);
-    if requested > crate::web_gateway::UPLOAD_MAX_BYTES as u64 {
-        return Err((
-            413,
-            serde_json::json!({
-                "ok": false,
-                "error": format!(
-                    "range too large: {} bytes (cap is {})",
-                    requested,
-                    crate::web_gateway::UPLOAD_MAX_BYTES
-                ),
-            }),
-        ));
-    }
-    let transfer_len = usize::try_from(requested).map_err(|_| {
-        (
-            413,
-            serde_json::json!({ "ok": false, "error": "range too large for this platform" }),
-        )
-    })?;
-    Ok((offset, transfer_len, offset.saturating_add(requested)))
 }
 
 pub(crate) fn recording_asset_error_task_response(
@@ -1173,51 +980,6 @@ pub(crate) async fn api_session_frame_asset_task_response(
         }),
         done: true,
     }
-}
-
-pub(crate) fn session_frame_filename_is_safe(filename: &str) -> bool {
-    (filename.ends_with(".jpg") || filename.ends_with(".png"))
-        && filename.len() < 80
-        && !filename.is_empty()
-        && filename.trim() == filename
-        && !filename.contains("..")
-        && !filename.contains('/')
-        && !filename.contains('\\')
-}
-
-pub(crate) fn read_frame_asset_file_range(
-    path: &std::path::Path,
-    offset: u64,
-    length: Option<u64>,
-) -> Result<(Vec<u8>, u64, u64), (u16, serde_json::Value)> {
-    let metadata = std::fs::metadata(path).map_err(|e| {
-        (
-            500,
-            serde_json::json!({ "ok": false, "error": format!("stat session frame: {e}") }),
-        )
-    })?;
-    let total_size = metadata.len();
-    let (start, transfer_len, end) = recording_asset_range(total_size, offset, length)?;
-    let mut file = std::fs::File::open(path).map_err(|e| {
-        (
-            500,
-            serde_json::json!({ "ok": false, "error": format!("open session frame: {e}") }),
-        )
-    })?;
-    file.seek(std::io::SeekFrom::Start(start)).map_err(|e| {
-        (
-            500,
-            serde_json::json!({ "ok": false, "error": format!("seek session frame: {e}") }),
-        )
-    })?;
-    let mut bytes = vec![0u8; transfer_len];
-    file.read_exact(&mut bytes).map_err(|e| {
-        (
-            500,
-            serde_json::json!({ "ok": false, "error": format!("read session frame: {e}") }),
-        )
-    })?;
-    Ok((bytes, total_size, end))
 }
 
 pub(crate) fn session_frame_asset_error_task_response(

--- a/src/bin/caller/dashboard_control/api_media.rs
+++ b/src/bin/caller/dashboard_control/api_media.rs
@@ -11,8 +11,7 @@ use super::*;
 // byte-stream carriage.
 pub(crate) use crate::web_gateway::{
     read_frame_asset_file_range, read_recording_asset_bytes_range,
-    read_recording_asset_file_range, recording_asset_range,
-    recording_asset_name_is_safe, recording_segment_filename_is_safe,
+    read_recording_asset_file_range, recording_asset_name_is_safe,
     recording_stream_name_is_safe, resolve_recording_asset_from_dir_pair,
     resolve_session_recording_asset, session_frame_filename_is_safe,
     RecordingAsset,
@@ -653,12 +652,9 @@ pub(crate) async fn api_session_recordings_response(
 ) -> serde_json::Value {
     let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
     let session_id = string_param(&params, &["session_id", "sessionId", "id"]);
-    let (status_line, body) =
-        crate::web_gateway::session_recordings_list_response_body(&session_id);
-    http_body_response(
+    frame_api_response(
         id,
-        status_line_code(status_line),
-        body,
+        crate::web_gateway::session_recordings_api_response(&session_id),
         "session recordings",
     )
 }
@@ -998,6 +994,128 @@ pub(crate) fn session_frame_asset_error_task_response(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Live-store recordings fixture (unique id; caller removes).
+    fn parity_recordings_fixture(prefix: &str) -> (String, std::path::PathBuf) {
+        let session_id = format!(
+            "{prefix}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let log_dir = crate::platform::intendant_home()
+            .join("logs")
+            .join(&session_id);
+        let stream_dir = log_dir.join("recordings").join("screen");
+        std::fs::create_dir_all(&stream_dir).unwrap();
+        std::fs::write(stream_dir.join("seg_00001.mp4"), b"parity segment bytes").unwrap();
+        std::fs::write(stream_dir.join("segments.csv"), "seg_00001.mp4,0.0,2.0\n").unwrap();
+        (session_id, log_dir)
+    }
+
+    fn parity_http_json_body(
+        response: crate::web_gateway::ApiResponse,
+    ) -> (u16, serde_json::Value) {
+        let bytes = crate::web_gateway::api_response_http_bytes(
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        );
+        let split = bytes
+            .windows(4)
+            .position(|window| window == b"\r\n\r\n")
+            .expect("header/body split");
+        let head = String::from_utf8(bytes[..split].to_vec()).expect("ascii head");
+        let status = head
+            .lines()
+            .next()
+            .and_then(|line| line.strip_prefix("HTTP/1.1 "))
+            .and_then(|line| line.split_whitespace().next())
+            .and_then(|code| code.parse::<u16>().ok())
+            .expect("status line");
+        (status, serde_json::from_slice(&bytes[split + 4..]).expect("json body"))
+    }
+
+    // ── S4b parity: recordings list + the listing-asset vocabulary ──
+
+    #[tokio::test]
+    async fn parity_session_recordings_list_shares_bodies_with_status_metadata() {
+        let (session_id, log_dir) = parity_recordings_fixture("parity-rec-list");
+        let (status, http_body) = parity_http_json_body(
+            crate::web_gateway::session_recordings_api_response(&session_id),
+        );
+        assert_eq!(status, 200);
+        let frame = api_session_recordings_response(
+            "parity-rec-list".to_string(),
+            Some(&serde_json::json!({ "session_id": session_id })),
+        )
+        .await;
+        let cleanup = std::fs::remove_dir_all(&log_dir);
+        assert_eq!(frame["t"], "response");
+        assert_eq!(frame["ok"], true);
+        // The list body is a json ARRAY: the injected-status envelope
+        // only decorates objects, so the array passes through untouched.
+        assert!(frame["result"].is_array(), "{frame}");
+        assert_eq!(frame["result"], http_body);
+        cleanup.expect("parity recordings fixture cleanup");
+
+        // Invalid id: an object body — the injection appears and matches
+        // the HTTP status.
+        let (status, http_body) = parity_http_json_body(
+            crate::web_gateway::session_recordings_api_response(".."),
+        );
+        assert_eq!(status, 400);
+        let frame = api_session_recordings_response(
+            "parity-rec-list-invalid".to_string(),
+            Some(&serde_json::json!({ "session_id": ".." })),
+        )
+        .await;
+        let mut result = frame["result"].clone();
+        let map = result.as_object_mut().expect("result object");
+        assert_eq!(map.remove("_httpStatus"), Some(serde_json::json!(400)));
+        assert_eq!(map.remove("_httpOk"), Some(serde_json::json!(false)));
+        assert_eq!(result, http_body);
+    }
+
+    #[tokio::test]
+    async fn parity_recording_listing_assets_share_bytes_on_both_transports() {
+        let (session_id, log_dir) = parity_recordings_fixture("parity-rec-assets");
+        for asset in ["segments", "playlist.m3u8"] {
+            // HTTP: the shared resolver under the canonical tail.
+            let response = crate::web_gateway::session_recording_listing_asset_api_response(
+                &session_id,
+                "screen",
+                asset,
+            );
+            let (http_bytes, http_ct) = match response {
+                crate::web_gateway::ApiResponse::Bytes {
+                    bytes: crate::web_gateway::BytesPayload::InMemory(payload),
+                    content_type,
+                    ..
+                } => (payload, content_type),
+                _ => panic!("listing asset must ride the bytes lane"),
+            };
+            // Tunnel: the same asset vocabulary through the ranged
+            // byte-stream carriage (offset 0, unbounded).
+            let task = api_session_recording_asset_task_response(
+                format!("parity-asset-{asset}"),
+                Some(&serde_json::json!({
+                    "session_id": session_id,
+                    "stream_name": "screen",
+                    "asset": asset,
+                })),
+            )
+            .await;
+            let stream = task.byte_stream.expect("tunnel byte stream");
+            assert_eq!(stream.bytes, http_bytes, "{asset}");
+            assert_eq!(stream.content_type, http_ct, "{asset}");
+            assert_eq!(stream.result["ok"], true);
+            assert_eq!(stream.result["total_size"], http_bytes.len());
+        }
+        std::fs::remove_dir_all(&log_dir).expect("parity assets fixture cleanup");
+    }
+
     use crate::dashboard_control::tests::{runtime, test_upload_state};
 
     #[tokio::test]

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -624,27 +624,12 @@ pub(crate) async fn api_session_report_task_response(
             };
         }
     };
-    let size = report.bytes.len();
-    let filename = report.filename;
-    let content_type = "application/zip".to_string();
-    ControlTaskResponse {
-        id: id.clone(),
-        frame: serde_json::Value::Null,
-        byte_stream: Some(ControlByteStream {
-            id: id.clone(),
-            stream_id: format!("{id}:session-report"),
-            content_type: content_type.clone(),
-            filename: Some(filename.clone()),
-            bytes: report.bytes,
-            result: serde_json::json!({
-                "ok": true,
-                "filename": filename,
-                "content_type": content_type,
-                "size": size,
-            }),
-        }),
-        done: true,
-    }
+    frame_api_task_response(
+        id,
+        crate::web_gateway::session_report_api_response(report),
+        "session-report",
+        "session report",
+    )
 }
 
 pub(crate) async fn api_session_current_upload_raw_task_response(
@@ -955,11 +940,11 @@ pub(crate) async fn api_session_delete_response(
     let target =
         optional_string_param(&params, &["target"]).unwrap_or_else(|| "session".to_string());
     let result = tokio::task::spawn_blocking(move || {
-        crate::web_gateway::delete_session_data(&session_id, &target)
+        crate::web_gateway::session_delete_api_response(&session_id, &target)
     })
     .await;
     match result {
-        Ok(body) => json_body_response(id, body, "session delete"),
+        Ok(response) => frame_api_json_body_response(id, response, "session delete"),
         Err(e) => serde_json::json!({
             "t": "response",
             "id": id,
@@ -1953,6 +1938,101 @@ mod tests {
         )
         .await;
         assert_eq!(tunnel_result_body(&frame, 400), http_body);
+    }
+
+    // ── S4b parity: deletes + report (see the S4a enumeration above; the
+    // S4b-specific envelope differences are enumerated on the worktrees
+    // fixture set in api_control.rs) ──
+
+    #[tokio::test]
+    async fn parity_session_delete_serves_the_same_body_on_both_transports() {
+        // Invalid id: deterministic, store-free; the delete trio rides the
+        // pre-_httpStatus envelope (difference #1).
+        let (status, http_body) = http_status_and_body(
+            crate::web_gateway::session_delete_api_response("..", "session"),
+        );
+        assert_eq!(status, 200);
+        let frame = api_session_delete_response(
+            "parity-delete".to_string(),
+            Some(&serde_json::json!({ "session_id": ".." })),
+        )
+        .await;
+        assert_eq!(tunnel_plain_body(&frame), http_body);
+
+        // A real deletion under identical pre-state on each lane.
+        let (session_id, log_dir) = parity_session_fixture("parity-delete-http");
+        let (status, http_body) = http_status_and_body(
+            crate::web_gateway::session_delete_api_response(&session_id, "session"),
+        );
+        assert_eq!(status, 200);
+        assert!(!log_dir.exists(), "http-lane delete must remove the dir");
+        assert_eq!(http_body["ok"], true);
+        assert_eq!(http_body["deleted"], "session");
+
+        let (session_id, log_dir) = parity_session_fixture("parity-delete-rpc");
+        let frame = api_session_delete_response(
+            "parity-delete-2".to_string(),
+            Some(&serde_json::json!({ "session_id": session_id })),
+        )
+        .await;
+        assert!(!log_dir.exists(), "tunnel delete must remove the dir");
+        let tunnel_body = tunnel_plain_body(&frame);
+        assert_eq!(tunnel_body["ok"], true);
+        assert_eq!(tunnel_body["deleted"], "session");
+        // bytes_freed varies with the fixture inode sizes; the shape keys
+        // are the parity claim.
+        assert_eq!(
+            tunnel_body.as_object().unwrap().keys().collect::<Vec<_>>(),
+            http_body.as_object().unwrap().keys().collect::<Vec<_>>(),
+        );
+    }
+
+    #[tokio::test]
+    async fn parity_session_report_serves_the_same_zip_and_meta_on_both_transports() {
+        let (session_id, log_dir) = parity_session_fixture("parity-report");
+        std::fs::write(log_dir.join("summary.json"), "{\"ok\":true}\n").unwrap();
+
+        let report = crate::web_gateway::session_report_zip_for_request(&session_id, None, None)
+            .unwrap_or_else(|_| panic!("fixture report must build"));
+        let response = crate::web_gateway::session_report_api_response(report);
+        let (http_bytes, http_meta) = match &response {
+            crate::web_gateway::ApiResponse::Bytes { bytes, meta, .. } => {
+                let crate::web_gateway::BytesPayload::InMemory(payload) = bytes;
+                (payload.clone(), meta.clone())
+            }
+            _ => panic!("report must ride the bytes lane"),
+        };
+
+        let task = api_session_report_task_response(
+            "parity-report".to_string(),
+            Some(&serde_json::json!({ "session_id": session_id })),
+            &runtime(),
+        )
+        .await;
+        let cleanup = std::fs::remove_dir_all(&log_dir);
+        let stream = task.byte_stream.expect("tunnel byte stream");
+        assert_eq!(stream.stream_id, "parity-report:session-report");
+        assert_eq!(stream.content_type, "application/zip");
+        assert_eq!(stream.bytes.len(), http_bytes.len());
+        assert_eq!(stream.result, http_meta);
+        assert_eq!(
+            stream.filename.as_deref(),
+            http_meta["filename"].as_str(),
+            "byte-stream filename lifts from the shared meta"
+        );
+
+        // Invalid id: per-lane error framing — the tunnel answers the
+        // injected-status envelope; HTTP answers wildcard json (pinned by
+        // the goldens).
+        let invalid = api_session_report_task_response(
+            "parity-report-invalid".to_string(),
+            Some(&serde_json::json!({ "session_id": ".." })),
+            &runtime(),
+        )
+        .await;
+        assert!(invalid.byte_stream.is_none());
+        assert_eq!(invalid.frame["result"]["_httpStatus"], 400);
+        cleanup.expect("parity report fixture cleanup");
     }
 
     #[tokio::test]

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -261,14 +261,11 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
     // route rows — their IAM operations derive from the rows (S4a; the
     // formerly divergent agent-output/context-snapshot twins are now
     // derivation-equal by construction).
+    // The session artifact reads (api_session_report,
+    // api_session_recordings, api_session_recording_asset,
+    // api_session_frame_asset), api_session_delete, and the worktrees
+    // quartet live as tunnel columns on their route rows (S4b).
     method("api_sessions_stream", PeerOperation::SessionInspect),
-    method("api_session_report", PeerOperation::SessionInspect),
-    method("api_session_recordings", PeerOperation::SessionInspect),
-    method("api_session_recording_asset", PeerOperation::SessionInspect),
-    method("api_session_frame_asset", PeerOperation::SessionInspect),
-    method("api_worktrees", PeerOperation::SessionInspect),
-    method("api_worktrees_inspect", PeerOperation::SessionInspect),
-    method("api_session_delete", PeerOperation::SessionManage),
     method("api_session_current_history", PeerOperation::SessionManage),
     method("api_session_current_rollback", PeerOperation::SessionManage),
     method("api_session_current_redo", PeerOperation::SessionManage),
@@ -285,8 +282,6 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
         PeerOperation::SessionManage,
     ),
     method("api_session_control_msg", PeerOperation::SessionManage),
-    method("api_worktrees_scan", PeerOperation::SessionManage),
-    method("api_worktrees_remove", PeerOperation::SessionManage),
     upload_only("api_session_current_upload", PeerOperation::SessionManage),
     method("api_transfer_jobs", PeerOperation::FilesystemRead),
     method("api_transfer_download_read", PeerOperation::FilesystemRead),
@@ -3205,7 +3200,7 @@ mod tests {
             ("api_sessions", Row, Some(Op::SessionInspect)),
             ("api_sessions_stream", Residue, Some(Op::SessionInspect)),
             ("api_session_detail", Row, Some(Op::SessionInspect)),
-            ("api_session_report", Residue, Some(Op::SessionInspect)),
+            ("api_session_report", Row, Some(Op::SessionInspect)),
             ("api_session_agent_output", Row, Some(Op::SessionInspect)),
             (
                 "api_session_context_snapshot",
@@ -3213,16 +3208,16 @@ mod tests {
                 Some(Op::SessionInspect),
             ),
             ("api_sessions_search", Row, Some(Op::SessionInspect)),
-            ("api_session_recordings", Residue, Some(Op::SessionInspect)),
+            ("api_session_recordings", Row, Some(Op::SessionInspect)),
             (
                 "api_session_recording_asset",
-                Residue,
+                Row,
                 Some(Op::SessionInspect),
             ),
-            ("api_session_frame_asset", Residue, Some(Op::SessionInspect)),
-            ("api_worktrees", Residue, Some(Op::SessionInspect)),
-            ("api_worktrees_inspect", Residue, Some(Op::SessionInspect)),
-            ("api_session_delete", Residue, Some(Op::SessionManage)),
+            ("api_session_frame_asset", Row, Some(Op::SessionInspect)),
+            ("api_worktrees", Row, Some(Op::SessionInspect)),
+            ("api_worktrees_inspect", Row, Some(Op::SessionInspect)),
+            ("api_session_delete", Row, Some(Op::SessionManage)),
             (
                 "api_session_current_history",
                 Residue,
@@ -3265,8 +3260,8 @@ mod tests {
                 Some(Op::SessionManage),
             ),
             ("api_session_control_msg", Residue, Some(Op::SessionManage)),
-            ("api_worktrees_scan", Residue, Some(Op::SessionManage)),
-            ("api_worktrees_remove", Residue, Some(Op::SessionManage)),
+            ("api_worktrees_scan", Row, Some(Op::SessionManage)),
+            ("api_worktrees_remove", Row, Some(Op::SessionManage)),
             ("api_worktrees_merge", Row, Some(Op::SessionManage)),
             (
                 "api_session_current_upload",

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -625,6 +625,8 @@ pub(crate) static ROUTES: &[Route] = &[
     // ── Session deletion. Five accepted wire shapes (native DELETE plus
     //    the WKWebView POST fallback with a literal `delete` suffix); one
     //    handler serves all of them by filtering the `delete` segment.
+    //    The datachannel twin rides the canonical shape below (one tunnel
+    //    name per row; all five rows share the operation and handler).
     op_route(
         RouteMethod::Delete,
         PathPattern::Segments("/api/session", &[SegmentSpec::Capture("id")]),
@@ -632,7 +634,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::SessionDelete,
         "Delete a session's data",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_session_delete")),
     op_route(
         RouteMethod::Delete,
         PathPattern::Segments(
@@ -752,6 +755,66 @@ pub(crate) static ROUTES: &[Route] = &[
     .with_tunnel(tunnel_method("api_session_context_snapshot")),
     op_route(
         RouteMethod::Get,
+        PathPattern::Segments(
+            "/api/session",
+            &[SegmentSpec::Capture("id"), SegmentSpec::Literal("report")],
+        ),
+        PeerOperation::SessionInspect,
+        BodyPolicy::None,
+        RouteHandlerId::SessionSubRouter,
+        "Session report zip (text artifacts; id=current targets the live session)",
+    )
+    .with_tunnel(tunnel_method("api_session_report")),
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Segments(
+            "/api/session",
+            &[
+                SegmentSpec::Capture("id"),
+                SegmentSpec::Literal("recordings"),
+            ],
+        ),
+        PeerOperation::SessionInspect,
+        BodyPolicy::None,
+        RouteHandlerId::SessionSubRouter,
+        "List a session's recording streams",
+    )
+    .with_tunnel(tunnel_method("api_session_recordings")),
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Segments(
+            "/api/session",
+            &[
+                SegmentSpec::Capture("id"),
+                SegmentSpec::Literal("recordings"),
+                SegmentSpec::Capture("stream"),
+                SegmentSpec::Capture("asset"),
+            ],
+        ),
+        PeerOperation::SessionInspect,
+        BodyPolicy::None,
+        RouteHandlerId::SessionSubRouter,
+        "Recording assets: segments listing, playlist.m3u8, or a segment file",
+    )
+    .with_tunnel(tunnel_method("api_session_recording_asset")),
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Segments(
+            "/api/session",
+            &[
+                SegmentSpec::Capture("id"),
+                SegmentSpec::Literal("frames"),
+                SegmentSpec::Capture("filename"),
+            ],
+        ),
+        PeerOperation::SessionInspect,
+        BodyPolicy::None,
+        RouteHandlerId::SessionSubRouter,
+        "Session frame image asset",
+    )
+    .with_tunnel(tunnel_method("api_session_frame_asset")),
+    op_route(
+        RouteMethod::Get,
         PathPattern::Segments("/api/session", &[SegmentSpec::Capture("id")]),
         PeerOperation::SessionInspect,
         BodyPolicy::None,
@@ -808,7 +871,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::WorktreesInspect,
         "Inspect one worktree (branch, ahead/behind, dirty state)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_worktrees_inspect")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/worktrees/remove"),
@@ -816,7 +880,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::WorktreesRemove,
         "Remove a worktree from the inventory",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_worktrees_remove")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/worktrees/merge"),
@@ -833,7 +898,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::WorktreesScan,
         "Rescan the worktree inventory (refreshes the cache)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_worktrees_scan")),
     op_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/worktrees"),
@@ -841,7 +907,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::WorktreesList,
         "Cached worktree inventory",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_worktrees")),
     // ── Session listing. The stream/search rows close a historical gap:
     //    dispatch served them but the hand classifier never gated them
     //    for browser principals (peers were already SessionInspect-gated

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -449,19 +449,45 @@ pub(crate) async fn serve_http_request(
                 .await;
             }
             RouteHandlerId::WorktreesInspect => {
-                return handle_worktrees_inspect(stream, route_body).await;
+                return handle_worktrees_inspect(
+                    stream,
+                    route_body,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::WorktreesRemove => {
-                return handle_worktrees_remove(stream, route_body, worktree_inventory_cache).await;
+                return handle_worktrees_remove(
+                    stream,
+                    route_body,
+                    worktree_inventory_cache,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::WorktreesMerge => {
                 return handle_worktrees_merge(stream, route_body, worktree_inventory_cache).await;
             }
             RouteHandlerId::WorktreesScan => {
-                return handle_worktrees_scan(stream, project_root, worktree_inventory_cache).await;
+                return handle_worktrees_scan(
+                    stream,
+                    project_root,
+                    worktree_inventory_cache,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::WorktreesList => {
-                return handle_worktrees_list(stream, worktree_inventory_cache).await;
+                return handle_worktrees_list(
+                    stream,
+                    worktree_inventory_cache,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::SessionsList => {
                 return handle_sessions_list(
@@ -586,7 +612,13 @@ pub(crate) async fn serve_http_request(
                 .await;
             }
             RouteHandlerId::SessionDelete => {
-                return handle_session_delete(stream, request_line).await;
+                return handle_session_delete(
+                    stream,
+                    request_line,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::SessionAgentOutput => {
                 return handle_session_agent_output(

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -5435,4 +5435,377 @@ mod tests {
                 r#"{"error":"context snapshot not found"}"#
             )
         );
-    }}
+    }
+
+    // ── S4b golden transcripts: session artifacts / deletes / worktrees ──
+    //
+    // Same discipline as the S4a set above: byte-exact pins of the HTTP
+    // wire bytes captured before the transport-neutral conversion
+    // (design §6 S4, risk R1). The five session-delete wire shapes have
+    // routing pins in gateway_routes; these pin the response bytes.
+
+    /// The session-delete json framing — its wildcard tail historically
+    /// orders `Access-Control-Allow-Origin` BEFORE `Cache-Control`,
+    /// unlike the list/search/upload-error tail.
+    fn golden_delete_json_transcript(body: &str) -> String {
+        format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nAccess-Control-Allow-Origin: *\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+    }
+
+    /// The text/plain framing (report/asset error bodies), spelled out.
+    fn golden_text_plain_transcript(status_line: &str, body: &str) -> String {
+        format!(
+            "HTTP/1.1 {status_line}\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+    }
+
+    /// The immutable-asset framing (recording segments, frame images).
+    fn golden_public_asset_transcript(content_type: &str, bytes: &[u8]) -> Vec<u8> {
+        let mut expected = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nCache-Control: public, max-age=3600\r\nConnection: close\r\n\r\n",
+            bytes.len()
+        )
+        .into_bytes();
+        expected.extend_from_slice(bytes);
+        expected
+    }
+
+    #[tokio::test]
+    async fn golden_session_delete_five_wire_shapes_transcripts() {
+        // All five accepted shapes answer 200 with the wildcard-CORS tail;
+        // `..` fails the bare-id policy so the body is deterministic.
+        for request_line in [
+            "DELETE /api/session/.. HTTP/1.1",
+            "DELETE /api/session/../recordings HTTP/1.1",
+            "DELETE /api/session/../recordings/delete HTTP/1.1",
+            "POST /api/session/../delete HTTP/1.1",
+            "POST /api/session/../recordings/delete HTTP/1.1",
+        ] {
+            let response = collect_session_handler_response(|stream| {
+                handle_session_delete(stream, request_line)
+            })
+            .await;
+            assert_eq!(
+                golden_transcript(&response),
+                golden_delete_json_transcript(r#"{"error":"invalid session id","ok":false}"#),
+                "{request_line}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn golden_session_delete_missing_session_transcript() {
+        let session_id = golden_unique_session_id("golden-delete-missing");
+        let request_line = format!("DELETE /api/session/{session_id} HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_delete(stream, &request_line)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_delete_json_transcript(r#"{"error":"session not found","ok":false}"#)
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_session_report_invalid_id_transcript() {
+        let request_line = "GET /api/session/../report HTTP/1.1";
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, request_line, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_wildcard_json_transcript(
+                "400 Bad Request",
+                r#"{"error":"invalid session id"}"#
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_session_report_missing_transcript() {
+        let session_id = golden_unique_session_id("golden-report-missing");
+        let request_line = format!("GET /api/session/{session_id}/report HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, &request_line, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_text_plain_transcript("404 Not Found", "Session not found")
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_session_report_success_transcript() {
+        let session_id = golden_unique_session_id("golden-report");
+        let log_dir = crate::platform::intendant_home().join("logs").join(&session_id);
+        std::fs::create_dir_all(log_dir.join("turns")).unwrap();
+        std::fs::write(log_dir.join("summary.json"), "{\"ok\":true}\n").unwrap();
+        std::fs::write(log_dir.join("turns").join("turn_001_stdout.txt"), "hi\n").unwrap();
+
+        let request_line = format!("GET /api/session/{session_id}/report HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, &request_line, None, None)
+        })
+        .await;
+        // Zip bytes from the store layer (same-run mtimes make the two
+        // builds byte-identical); the framing around them is the pin.
+        let bytes = build_session_report_zip(&log_dir).unwrap();
+        let cleanup = std::fs::remove_dir_all(&log_dir);
+        let mut expected = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/zip\r\nContent-Length: {}\r\nContent-Disposition: attachment; filename=\"intendant-session-{session_id}.zip\"\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n",
+            bytes.len()
+        )
+        .into_bytes();
+        expected.extend_from_slice(&bytes);
+        assert_eq!(golden_transcript(&response), golden_transcript(&expected));
+        cleanup.expect("golden report fixture cleanup");
+    }
+
+    /// Live-store recordings fixture: one stream with one playable
+    /// segment (csv row + on-disk file).
+    fn golden_recordings_fixture(session_id: &str) -> (std::path::PathBuf, Vec<u8>) {
+        let log_dir = crate::platform::intendant_home().join("logs").join(session_id);
+        let stream_dir = log_dir.join("recordings").join("screen");
+        std::fs::create_dir_all(&stream_dir).unwrap();
+        let seg_bytes = b"golden fake mp4 segment bytes".to_vec();
+        std::fs::write(stream_dir.join("seg_00001.mp4"), &seg_bytes).unwrap();
+        std::fs::write(stream_dir.join("segments.csv"), "seg_00001.mp4,0.0,2.0\n").unwrap();
+        (log_dir, seg_bytes)
+    }
+
+    #[tokio::test]
+    async fn golden_session_recordings_list_transcripts() {
+        // Invalid id: the branch precheck answers under the wildcard tail.
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, "GET /api/session/../recordings HTTP/1.1", None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_wildcard_json_transcript(
+                "400 Bad Request",
+                r#"{"error":"invalid session id"}"#
+            )
+        );
+
+        // Missing session: empty list under the canonical tail.
+        let missing = golden_unique_session_id("golden-recordings-missing");
+        let request_line = format!("GET /api/session/{missing}/recordings HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, &request_line, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_json_transcript("200 OK", "[]")
+        );
+
+        // Fixture stream: body from the store layer.
+        let session_id = golden_unique_session_id("golden-recordings");
+        let (log_dir, _seg) = golden_recordings_fixture(&session_id);
+        let request_line = format!("GET /api/session/{session_id}/recordings HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, &request_line, None, None)
+        })
+        .await;
+        let (status, body) = session_recordings_list_response_body(&session_id);
+        let cleanup = std::fs::remove_dir_all(&log_dir);
+        assert_eq!(status, "200 OK");
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_json_transcript("200 OK", &body)
+        );
+        cleanup.expect("golden recordings fixture cleanup");
+    }
+
+    #[tokio::test]
+    async fn golden_recording_segments_and_playlist_transcripts() {
+        let session_id = golden_unique_session_id("golden-rec-assets");
+        let (log_dir, _seg) = golden_recordings_fixture(&session_id);
+
+        // Segments listing: json array under the canonical tail.
+        let request_line =
+            format!("GET /api/session/{session_id}/recordings/screen/segments HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, &request_line, None, None)
+        })
+        .await;
+        let body = r#"[{"end_secs":2.0,"filename":"seg_00001.mp4","start_secs":0.0}]"#;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_json_transcript("200 OK", body)
+        );
+
+        // Playlist: HLS body under the mpegurl content type.
+        let request_line =
+            format!("GET /api/session/{session_id}/recordings/screen/playlist.m3u8 HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, &request_line, None, None)
+        })
+        .await;
+        let m3u8 = "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-MEDIA-SEQUENCE:0\n#EXT-X-TARGETDURATION:2\n#EXTINF:2.000,\nseg_00001.mp4\n#EXT-X-ENDLIST\n";
+        let expected = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/vnd.apple.mpegurl\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{m3u8}",
+            m3u8.len()
+        );
+        let cleanup = std::fs::remove_dir_all(&log_dir);
+        assert_eq!(golden_transcript(&response), expected);
+        cleanup.expect("golden rec-assets fixture cleanup");
+    }
+
+    #[tokio::test]
+    async fn golden_recording_segment_file_transcripts() {
+        let session_id = golden_unique_session_id("golden-seg-file");
+        let (log_dir, seg_bytes) = golden_recordings_fixture(&session_id);
+
+        // Success: video content type under the immutable-asset tail.
+        let request_line =
+            format!("GET /api/session/{session_id}/recordings/screen/seg_00001.mp4 HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, &request_line, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_transcript(&golden_public_asset_transcript("video/mp4", &seg_bytes))
+        );
+
+        // Invalid filename / missing segment: text/plain errors.
+        let request_line =
+            format!("GET /api/session/{session_id}/recordings/screen/evil.txt HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, &request_line, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_text_plain_transcript("400 Bad Request", "Invalid filename")
+        );
+
+        let request_line =
+            format!("GET /api/session/{session_id}/recordings/screen/seg_09999.mp4 HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, &request_line, None, None)
+        })
+        .await;
+        let cleanup = std::fs::remove_dir_all(&log_dir);
+        assert_eq!(
+            golden_transcript(&response),
+            golden_text_plain_transcript("404 Not Found", "Segment not found")
+        );
+        cleanup.expect("golden seg-file fixture cleanup");
+    }
+
+    #[tokio::test]
+    async fn golden_session_frame_asset_transcripts() {
+        let session_id = golden_unique_session_id("golden-frame");
+        let log_dir = crate::platform::intendant_home().join("logs").join(&session_id);
+        std::fs::create_dir_all(log_dir.join("frames")).unwrap();
+        let frame_bytes = b"golden fake jpeg bytes".to_vec();
+        std::fs::write(log_dir.join("frames").join("frame_0001.jpg"), &frame_bytes).unwrap();
+
+        let request_line = format!("GET /api/session/{session_id}/frames/frame_0001.jpg HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, &request_line, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_transcript(&golden_public_asset_transcript("image/jpeg", &frame_bytes))
+        );
+
+        let request_line = format!("GET /api/session/{session_id}/frames/evil.exe HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, &request_line, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_text_plain_transcript("400 Bad Request", "Invalid filename")
+        );
+
+        let request_line = format!("GET /api/session/{session_id}/frames/frame_9.jpg HTTP/1.1");
+        let response = collect_session_handler_response(|stream| {
+            handle_session_sub_router(stream, &request_line, None, None)
+        })
+        .await;
+        let cleanup = std::fs::remove_dir_all(&log_dir);
+        assert_eq!(
+            golden_transcript(&response),
+            golden_text_plain_transcript("404 Not Found", "Frame not found")
+        );
+        cleanup.expect("golden frame fixture cleanup");
+    }
+
+    #[tokio::test]
+    async fn golden_worktrees_transcripts() {
+        // List with a cold cache: the empty inventory scan body.
+        let cache: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let response = collect_session_handler_response(|stream| {
+            handle_worktrees_list(stream, cache.clone())
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_json_transcript("200 OK", &empty_worktree_inventory_response())
+        );
+
+        // List with a warm cache: served verbatim.
+        {
+            let mut guard = cache.lock().unwrap();
+            *guard = Some(r#"{"worktrees":[],"cached":true}"#.to_string());
+        }
+        let response = collect_session_handler_response(|stream| {
+            handle_worktrees_list(stream, cache.clone())
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_json_transcript("200 OK", r#"{"worktrees":[],"cached":true}"#)
+        );
+
+        // Inspect / remove with invalid bodies: serde error wordings.
+        let response = collect_session_handler_response(|stream| {
+            handle_worktrees_inspect(stream, "not json".to_string())
+        })
+        .await;
+        let body = serde_json::json!({
+            "ok": false,
+            "error": format!(
+                "invalid worktree inspect request: {}",
+                serde_json::from_str::<crate::worktree_inventory::WorktreeInspectRequest>("not json")
+                    .unwrap_err()
+            ),
+        })
+        .to_string();
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_json_transcript("400 Bad Request", &body)
+        );
+
+        let cache2: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let response = collect_session_handler_response(|stream| {
+            handle_worktrees_remove(stream, "not json".to_string(), cache2)
+        })
+        .await;
+        let body = serde_json::json!({
+            "ok": false,
+            "error": format!(
+                "invalid worktree removal request: {}",
+                serde_json::from_str::<crate::worktree_inventory::WorktreeRemoveRequest>("not json")
+                    .unwrap_err()
+            ),
+        })
+        .to_string();
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_json_transcript("400 Bad Request", &body)
+        );
+    }
+}

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -373,6 +373,52 @@ pub(crate) fn scan_worktree_inventory_response(home: &Path, project_root: Option
     serde_json::to_string(&scan).unwrap_or_else(|_| "{}".to_string())
 }
 
+/// Transport-neutral worktrees cores (tunnel twins `api_worktrees`,
+/// `api_worktrees_inspect`, `api_worktrees_scan`, `api_worktrees_remove`):
+/// the inventory (status, body) helpers plus the shared cache
+/// side-effects, rendered as [`ApiResponse`]s. Spawn placement and
+/// task-failure shapes stay transport-owned.
+pub(crate) fn worktrees_list_api_response(cache: &Arc<Mutex<Option<String>>>) -> ApiResponse {
+    let body = cache
+        .lock()
+        .ok()
+        .and_then(|guard| guard.clone())
+        .unwrap_or_else(empty_worktree_inventory_response);
+    ApiResponse::json(200, JsonBody::PreSerialized(body))
+}
+
+pub(crate) fn worktrees_inspect_api_response(body_text: &str) -> ApiResponse {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+    let (status_line, body) = inspect_worktree_inventory_response(&home, body_text);
+    ApiResponse::json(status_line_code(status_line), JsonBody::PreSerialized(body))
+}
+
+pub(crate) fn worktrees_scan_api_response(
+    project_root: Option<&Path>,
+    cache: &Arc<Mutex<Option<String>>>,
+) -> ApiResponse {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+    let body = scan_worktree_inventory_response(&home, project_root);
+    if let Ok(mut guard) = cache.lock() {
+        *guard = Some(body.clone());
+    }
+    ApiResponse::json(200, JsonBody::PreSerialized(body))
+}
+
+pub(crate) fn worktrees_remove_api_response(
+    body_text: &str,
+    cache: &Arc<Mutex<Option<String>>>,
+) -> ApiResponse {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+    let (status_line, body) = remove_worktree_inventory_response(&home, body_text);
+    if status_line == "200 OK" {
+        if let Ok(mut guard) = cache.lock() {
+            *guard = None;
+        }
+    }
+    ApiResponse::json(status_line_code(status_line), JsonBody::PreSerialized(body))
+}
+
 pub(crate) fn inspect_worktree_inventory_response(
     home: &Path,
     body_text: &str,
@@ -2582,10 +2628,31 @@ pub(crate) async fn handle_sessions_list(
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 
-pub(crate) async fn handle_session_delete(mut stream: DemuxStream, request_line: &str) {
+/// Transport-neutral core of session deletion (all five HTTP wire
+/// shapes; tunnel twin `api_session_delete`): the bare-id policy, target
+/// resolution, and store removal live in `delete_session_data`; the
+/// delete tail historically orders the wildcard CORS header before
+/// `Cache-Control`, unlike the list/search tail.
+pub(crate) fn session_delete_api_response(session_id: &str, target: &str) -> ApiResponse {
+    ApiResponse::Json {
+        status: 200,
+        body: JsonBody::PreSerialized(delete_session_data(session_id, target)),
+        headers: vec![
+            ("Access-Control-Allow-Origin", "*".to_string()),
+            ("Cache-Control", "no-cache".to_string()),
+            ("Connection", "close".to_string()),
+        ],
+    }
+}
+
+pub(crate) async fn handle_session_delete(
+    stream: DemuxStream,
+    request_line: &str,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
     // DELETE /api/session/{id}[/{target}]  (native DELETE)
     // POST  /api/session/{id}/delete[/{target}]  (WKWebView fallback)
-    use tokio::io::AsyncWriteExt;
     let rest = request_line
         .split("/api/session/")
         .nth(1)
@@ -2597,14 +2664,8 @@ pub(crate) async fn handle_session_delete(mut stream: DemuxStream, request_line:
         .collect();
     let session_id = rest_parts.first().copied().unwrap_or("");
     let target = rest_parts.get(1).copied().unwrap_or("session");
-    let body = delete_session_data(session_id, target);
-    let response = HttpResponse::with_content("200 OK", "application/json", body)
-        .header("Access-Control-Allow-Origin", "*")
-        .header("Cache-Control", "no-cache")
-        .header("Connection", "close")
-        .into_string();
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    let response = session_delete_api_response(session_id, target);
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_session_agent_output(
@@ -2694,53 +2755,19 @@ pub(crate) async fn handle_session_sub_router(
         if !session_lookup_id_is_safe(session_id) {
             let response = upload_error_response("400 Bad Request", "invalid session id");
             let _ = stream.write_all(response.as_bytes()).await;
-        } else if rec_rest.len() == 2 && rec_rest[1] == "segments" {
-            // GET /api/session/{id}/recordings/{stream}/segments
-            let stream_name = rec_rest[0];
-            let body = if let Some(session_dir) = resolve_session_dir(session_id) {
-                let stream_dir = session_dir.join("recordings").join(stream_name);
-                let segments = crate::recording::parse_segment_csv_pub(
-                    &stream_dir.join("segments.csv"),
-                    &stream_dir,
-                );
-                let seg_json: Vec<serde_json::Value> = segments
-                    .iter()
-                    .map(|s| {
-                        serde_json::json!({
-                            "filename": s.filename,
-                            "start_secs": s.start_secs,
-                            "end_secs": s.end_secs,
-                        })
-                    })
-                    .collect();
-                serde_json::to_string(&seg_json).unwrap_or("[]".to_string())
-            } else {
-                "[]".to_string()
-            };
-            let response = HttpResponse::with_content("200 OK", "application/json", body)
-                .header("Cache-Control", "no-cache")
-                .header("Connection", "close")
-                .into_string();
-            let _ = stream.write_all(response.as_bytes()).await;
-        } else if rec_rest.len() == 2 && rec_rest[1] == "playlist.m3u8" {
-            // GET /api/session/{id}/recordings/{stream}/playlist.m3u8
-            let stream_name = rec_rest[0];
-            let segments = resolve_session_dir(session_id)
-                .map(|session_dir| {
-                    let stream_dir = session_dir.join("recordings").join(stream_name);
-                    crate::recording::parse_segment_csv_pub(
-                        &stream_dir.join("segments.csv"),
-                        &stream_dir,
-                    )
-                })
-                .unwrap_or_default();
-            let m3u8 = recording_playlist_m3u8(&segments);
+        } else if rec_rest.len() == 2 && (rec_rest[1] == "segments" || rec_rest[1] == "playlist.m3u8")
+        {
+            // GET /api/session/{id}/recordings/{stream}/{segments|playlist.m3u8}
+            // — the tunnel twin's listing-asset vocabulary, resolved
+            // through the shared content core.
             let response =
-                HttpResponse::with_content("200 OK", "application/vnd.apple.mpegurl", m3u8)
-                    .header("Cache-Control", "no-cache")
-                    .header("Connection", "close")
-                    .into_string();
-            let _ = stream.write_all(response.as_bytes()).await;
+                session_recording_listing_asset_api_response(session_id, rec_rest[0], rec_rest[1]);
+            let bytes = api_response_http_bytes(
+                response,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            );
+            let _ = stream.write_all(&bytes).await;
         } else if rec_rest.len() == 2 {
             // GET /api/session/{id}/recordings/{stream}/{filename}
             let stream_name = rec_rest[0];
@@ -2797,70 +2824,45 @@ pub(crate) async fn handle_session_sub_router(
             }
         } else {
             // GET /api/session/{id}/recordings — list streams
-            let (status, body) = session_recordings_list_response_body(session_id);
-            let response = HttpResponse::with_content(status, "application/json", body)
-                .header("Cache-Control", "no-cache")
-                .header("Connection", "close")
-                .into_string();
-            let _ = stream.write_all(response.as_bytes()).await;
+            let response = session_recordings_api_response(session_id);
+            let bytes = api_response_http_bytes(
+                response,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            );
+            let _ = stream.write_all(&bytes).await;
         }
     } else if rest_parts.len() >= 2 && route_name == "report" {
         // GET /api/session/{id}/report — download a zip of
         // the current session's text artifacts for sharing
         // with the dev. Pass id="current" to target the
         // live daemon's own session via WebQueryCtx.
-        use tokio::io::AsyncWriteExt;
         let session_id = rest_parts[0];
-        if session_id != "current" && !session_lookup_id_is_safe(session_id) {
-            let response = upload_error_response("400 Bad Request", "invalid session id");
-            let _ = stream.write_all(response.as_bytes()).await;
-        } else {
-            let resolved_dir: Option<PathBuf> = if session_id == "current" {
-                current_session_log_dir(session_log.as_ref(), query_ctx.as_ref())
-            } else {
-                resolve_session_dir(session_id)
-            };
-            match resolved_dir {
-                Some(dir) => match build_session_report_zip(&dir) {
-                    Ok(bytes) => {
-                        let fname = dir
-                            .file_name()
-                            .map(|n| n.to_string_lossy().to_string())
-                            .unwrap_or_else(|| "session".to_string());
-                        let header = HttpResponse::new("200 OK")
-                            .header("Content-Type", "application/zip")
-                            .header("Content-Length", bytes.len().to_string())
-                            .header(
-                                "Content-Disposition",
-                                format!("attachment; filename=\"intendant-session-{}.zip\"", fname),
-                            )
-                            .header("Cache-Control", "no-cache")
-                            .header("Connection", "close")
-                            .into_string();
-                        let _ = stream.write_all(header.as_bytes()).await;
-                        let _ = stream.write_all(&bytes).await;
-                    }
-                    Err(e) => {
-                        let body = format!("Failed to build report: {}", e);
-                        let response = HttpResponse::with_content(
-                            "500 Internal Server Error",
-                            "text/plain",
-                            body,
-                        )
-                        .header("Connection", "close")
-                        .into_string();
-                        let _ = stream.write_all(response.as_bytes()).await;
-                    }
-                },
-                None => {
-                    let body = "Session not found";
-                    let response = HttpResponse::with_content("404 Not Found", "text/plain", body)
-                        .header("Connection", "close")
-                        .into_string();
-                    let _ = stream.write_all(response.as_bytes()).await;
-                }
+        let response = match session_report_zip_for_request(
+            session_id,
+            session_log.as_ref(),
+            query_ctx.as_ref(),
+        ) {
+            Ok(report) => session_report_api_response(report),
+            // Per-lane error framing, historical: the id-policy failure
+            // answers json under the wildcard tail; the resolution and
+            // build failures answer text/plain.
+            Err(SessionReportZipError::InvalidSessionId) => {
+                session_wildcard_json_error(400, "invalid session id")
             }
-        }
+            Err(SessionReportZipError::NotFound) => {
+                session_text_plain_response(404, "Session not found".to_string())
+            }
+            Err(SessionReportZipError::Build(e)) => {
+                session_text_plain_response(500, format!("Failed to build report: {}", e))
+            }
+        };
+        let bytes = api_response_http_bytes(
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        );
+        let _ = stream.write_all(&bytes).await;
     } else if rest_parts.len() >= 2 && route_name == "frames" {
         // Session frame sub-routes: /api/session/{id}/frames[/{filename}]
         use tokio::io::AsyncWriteExt;
@@ -3013,6 +3015,84 @@ pub(crate) fn session_detail_api_response(
 /// decoded (query string vs frame params); the bare-id policy, selector
 /// validation, and log-dir scan are the shared
 /// `session_context_snapshot_response_body` core.
+/// text/plain rendering for the session artifact error bodies (report
+/// and asset leaves keep their historical plain-text wordings on the
+/// HTTP lane; the tunnel answers its own json envelopes).
+pub(crate) fn session_text_plain_response(status: u16, body: String) -> ApiResponse {
+    ApiResponse::Bytes {
+        status,
+        content_type: "text/plain".to_string(),
+        headers: vec![("Connection", "close".to_string())],
+        bytes: BytesPayload::InMemory(body.into_bytes()),
+        meta: serde_json::Value::Null,
+    }
+}
+
+/// Bytes-lane rendering of a built session report (tunnel twin
+/// `api_session_report`): the zip under its historical attachment tail;
+/// the meta sidecar is the tunnel's `byte_stream_end.result` object.
+pub(crate) fn session_report_api_response(report: SessionReportZip) -> ApiResponse {
+    let size = report.bytes.len();
+    ApiResponse::Bytes {
+        status: 200,
+        content_type: "application/zip".to_string(),
+        headers: vec![
+            (
+                "Content-Disposition",
+                format!("attachment; filename=\"{}\"", report.filename),
+            ),
+            ("Cache-Control", "no-cache".to_string()),
+            ("Connection", "close".to_string()),
+        ],
+        meta: serde_json::json!({
+            "ok": true,
+            "filename": report.filename,
+            "content_type": "application/zip",
+            "size": size,
+        }),
+        bytes: BytesPayload::InMemory(report.bytes),
+    }
+}
+
+/// Transport-neutral core of the recordings stream list
+/// (`GET /api/session/{id}/recordings`, tunnel twin
+/// `api_session_recordings`).
+pub(crate) fn session_recordings_api_response(session_id: &str) -> ApiResponse {
+    let (status_line, body) = session_recordings_list_response_body(session_id);
+    ApiResponse::json(status_line_code(status_line), JsonBody::PreSerialized(body))
+}
+
+/// Neutral core of the recordings listing-asset leaves (the tunnel
+/// twin's "segments" / "playlist.m3u8" asset vocabulary): the shared
+/// resolver supplies the bytes; the HTTP tail is the canonical no-cache
+/// pair. Segment files stay on their own transport-owned carriage (the
+/// tunnel streams ranged and capped; HTTP serves the whole file).
+pub(crate) fn session_recording_listing_asset_api_response(
+    session_id: &str,
+    stream_name: &str,
+    asset: &str,
+) -> ApiResponse {
+    match resolve_session_recording_asset(resolve_session_dir(session_id), stream_name, asset) {
+        Ok(RecordingAsset::Bytes {
+            bytes,
+            content_type,
+            ..
+        }) => ApiResponse::Bytes {
+            status: 200,
+            content_type: content_type.to_string(),
+            headers: vec![
+                ("Cache-Control", "no-cache".to_string()),
+                ("Connection", "close".to_string()),
+            ],
+            bytes: BytesPayload::InMemory(bytes),
+            meta: serde_json::Value::Null,
+        },
+        // The listing assets never resolve to files or errors; a wiring
+        // bug fails closed.
+        _ => ApiResponse::json_error(500, "unexpected recording asset resolution"),
+    }
+}
+
 pub(crate) fn session_context_snapshot_api_response(
     session_id: &str,
     source: &str,
@@ -3187,61 +3267,55 @@ pub(crate) async fn handle_sessions_search(
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 
-pub(crate) async fn handle_worktrees_inspect(mut stream: DemuxStream, body_text: String) {
-    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
-    let (status, body) = match tokio::task::spawn_blocking(move || {
-        inspect_worktree_inventory_response(&home, &body_text)
-    })
-    .await
-    {
-        Ok(result) => result,
-        Err(e) => (
-            "500 Internal Server Error",
-            serde_json::json!({
-                "ok": false,
-                "error": format!("worktree inspect task failed: {e}")
-            })
-            .to_string(),
-        ),
-    };
-    let response = json_response(status, body);
-    use tokio::io::AsyncWriteExt;
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+pub(crate) async fn handle_worktrees_inspect(
+    stream: DemuxStream,
+    body_text: String,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let response =
+        match tokio::task::spawn_blocking(move || worktrees_inspect_api_response(&body_text)).await
+        {
+            Ok(response) => response,
+            Err(e) => ApiResponse::json(
+                500,
+                JsonBody::PreSerialized(
+                    serde_json::json!({
+                        "ok": false,
+                        "error": format!("worktree inspect task failed: {e}")
+                    })
+                    .to_string(),
+                ),
+            ),
+        };
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_worktrees_remove(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     body_text: String,
     worktree_inventory_cache: Arc<Mutex<Option<String>>>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
-    let cache = worktree_inventory_cache.clone();
-    let (status, body) = match tokio::task::spawn_blocking(move || {
-        let result = remove_worktree_inventory_response(&home, &body_text);
-        if result.0 == "200 OK" {
-            if let Ok(mut guard) = cache.lock() {
-                *guard = None;
-            }
-        }
-        result
+    let response = match tokio::task::spawn_blocking(move || {
+        worktrees_remove_api_response(&body_text, &worktree_inventory_cache)
     })
     .await
     {
-        Ok(result) => result,
-        Err(e) => (
-            "500 Internal Server Error",
-            serde_json::json!({
-                "ok": false,
-                "error": format!("worktree removal task failed: {e}")
-            })
-            .to_string(),
+        Ok(response) => response,
+        Err(e) => ApiResponse::json(
+            500,
+            JsonBody::PreSerialized(
+                serde_json::json!({
+                    "ok": false,
+                    "error": format!("worktree removal task failed: {e}")
+                })
+                .to_string(),
+            ),
         ),
     };
-    let response = json_response(status, body);
-    use tokio::io::AsyncWriteExt;
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_worktrees_merge(
@@ -3281,47 +3355,41 @@ pub(crate) async fn handle_worktrees_merge(
 }
 
 pub(crate) async fn handle_worktrees_scan(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     project_root: Option<PathBuf>,
     worktree_inventory_cache: Arc<Mutex<Option<String>>>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
-    let project_root = project_root.clone();
-    let cache = worktree_inventory_cache.clone();
-    let body = match tokio::task::spawn_blocking(move || {
-        let body = scan_worktree_inventory_response(&home, project_root.as_deref());
-        if let Ok(mut guard) = cache.lock() {
-            *guard = Some(body.clone());
-        }
-        body
+    let response = match tokio::task::spawn_blocking(move || {
+        worktrees_scan_api_response(project_root.as_deref(), &worktree_inventory_cache)
     })
     .await
     {
-        Ok(body) => body,
-        Err(e) => serde_json::json!({
-            "error": format!("worktree scan task failed: {e}")
-        })
-        .to_string(),
+        Ok(response) => response,
+        // Historical shape: a failed scan task answers 200 with the
+        // error body.
+        Err(e) => ApiResponse::json(
+            200,
+            JsonBody::PreSerialized(
+                serde_json::json!({
+                    "error": format!("worktree scan task failed: {e}")
+                })
+                .to_string(),
+            ),
+        ),
     };
-    let response = json_response("200 OK", body);
-    use tokio::io::AsyncWriteExt;
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_worktrees_list(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     worktree_inventory_cache: Arc<Mutex<Option<String>>>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    let body = worktree_inventory_cache
-        .lock()
-        .ok()
-        .and_then(|guard| guard.clone())
-        .unwrap_or_else(empty_worktree_inventory_response);
-    let response = json_response("200 OK", body);
-    use tokio::io::AsyncWriteExt;
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    let response = worktrees_list_api_response(&worktree_inventory_cache);
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_displays(
@@ -5485,7 +5553,12 @@ mod tests {
             "POST /api/session/../recordings/delete HTTP/1.1",
         ] {
             let response = collect_session_handler_response(|stream| {
-                handle_session_delete(stream, request_line)
+                handle_session_delete(
+                    stream,
+                    request_line,
+                    crate::gateway_routes::CorsPosture::OwnOrigin,
+                    None,
+                )
             })
             .await;
             assert_eq!(
@@ -5501,7 +5574,12 @@ mod tests {
         let session_id = golden_unique_session_id("golden-delete-missing");
         let request_line = format!("DELETE /api/session/{session_id} HTTP/1.1");
         let response = collect_session_handler_response(|stream| {
-            handle_session_delete(stream, &request_line)
+            handle_session_delete(
+                stream,
+                &request_line,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            )
         })
         .await;
         assert_eq!(
@@ -5748,7 +5826,12 @@ mod tests {
         // List with a cold cache: the empty inventory scan body.
         let cache: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
         let response = collect_session_handler_response(|stream| {
-            handle_worktrees_list(stream, cache.clone())
+            handle_worktrees_list(
+                stream,
+                cache.clone(),
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            )
         })
         .await;
         assert_eq!(
@@ -5762,7 +5845,12 @@ mod tests {
             *guard = Some(r#"{"worktrees":[],"cached":true}"#.to_string());
         }
         let response = collect_session_handler_response(|stream| {
-            handle_worktrees_list(stream, cache.clone())
+            handle_worktrees_list(
+                stream,
+                cache.clone(),
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            )
         })
         .await;
         assert_eq!(
@@ -5772,7 +5860,12 @@ mod tests {
 
         // Inspect / remove with invalid bodies: serde error wordings.
         let response = collect_session_handler_response(|stream| {
-            handle_worktrees_inspect(stream, "not json".to_string())
+            handle_worktrees_inspect(
+                stream,
+                "not json".to_string(),
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            )
         })
         .await;
         let body = serde_json::json!({
@@ -5791,7 +5884,13 @@ mod tests {
 
         let cache2: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
         let response = collect_session_handler_response(|stream| {
-            handle_worktrees_remove(stream, "not json".to_string(), cache2)
+            handle_worktrees_remove(
+                stream,
+                "not json".to_string(),
+                cache2,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            )
         })
         .await;
         let body = serde_json::json!({

--- a/src/bin/caller/web_gateway/session_catalog/external_rows.rs
+++ b/src/bin/caller/web_gateway/session_catalog/external_rows.rs
@@ -805,6 +805,264 @@ pub(crate) fn session_relationships_from_log_dir(session_dir: &Path) -> Vec<serd
         .collect()
 }
 
+// ── Recording/frame asset content core (moved verbatim from
+// dashboard_control/api_media.rs — transport-unification S4b). The
+// RecordingAsset vocabulary is the tunnel twin's asset addressing
+// ("segments" / "playlist.m3u8" / seg files); the HTTP artifact leaves
+// and the tunnel's ranged byte streams resolve through these.
+
+pub(crate) fn recording_stream_name_is_safe(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() < 128
+        && name.trim() == name
+        && name != "."
+        && name != ".."
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
+}
+
+pub(crate) fn recording_asset_name_is_safe(asset: &str) -> bool {
+    asset == "segments" || asset == "playlist.m3u8" || (recording_segment_filename_is_safe(asset))
+}
+
+pub(crate) fn recording_segment_filename_is_safe(filename: &str) -> bool {
+    filename.starts_with("seg_")
+        && (filename.ends_with(".mp4") || filename.ends_with(".ts"))
+        && filename.len() < 30
+        && !filename.contains("..")
+        && !filename.contains('/')
+        && !filename.contains('\\')
+}
+
+pub(crate) enum RecordingAsset {
+    Bytes {
+        bytes: Vec<u8>,
+        content_type: &'static str,
+        filename: String,
+    },
+    File {
+        path: PathBuf,
+        content_type: &'static str,
+        filename: String,
+    },
+}
+
+pub(crate) fn resolve_session_recording_asset(
+    session_dir: Option<PathBuf>,
+    stream_name: &str,
+    asset: &str,
+) -> Result<RecordingAsset, (u16, serde_json::Value)> {
+    let stream_dir = session_dir
+        .as_ref()
+        .map(|dir| dir.join("recordings").join(stream_name));
+    let segments = stream_dir
+        .as_ref()
+        .map(|dir| crate::recording::parse_segment_csv_pub(&dir.join("segments.csv"), dir))
+        .unwrap_or_default();
+    resolve_recording_asset_from_dir_pair(stream_dir, None, segments, asset)
+}
+
+pub(crate) fn resolve_recording_asset_from_dir_pair(
+    primary_dir: Option<PathBuf>,
+    fallback_dir: Option<PathBuf>,
+    segments: Vec<crate::recording::SegmentInfo>,
+    asset: &str,
+) -> Result<RecordingAsset, (u16, serde_json::Value)> {
+    if asset == "segments" {
+        let seg_json: Vec<serde_json::Value> = segments
+            .iter()
+            .map(|s| {
+                serde_json::json!({
+                    "filename": s.filename,
+                    "start_secs": s.start_secs,
+                    "end_secs": s.end_secs,
+                })
+            })
+            .collect();
+        let bytes = serde_json::to_vec(&seg_json).unwrap_or_else(|_| b"[]".to_vec());
+        return Ok(RecordingAsset::Bytes {
+            bytes,
+            content_type: "application/json",
+            filename: "segments.json".to_string(),
+        });
+    }
+    if asset == "playlist.m3u8" {
+        return Ok(RecordingAsset::Bytes {
+            bytes: crate::web_gateway::recording_playlist_m3u8(&segments).into_bytes(),
+            content_type: "application/vnd.apple.mpegurl",
+            filename: "playlist.m3u8".to_string(),
+        });
+    }
+    if !recording_segment_filename_is_safe(asset) {
+        return Err((
+            400,
+            serde_json::json!({ "ok": false, "error": "invalid recording asset" }),
+        ));
+    }
+    let path = primary_dir
+        .as_ref()
+        .map(|dir| dir.join(asset))
+        .filter(|path| path.exists())
+        .or_else(|| {
+            fallback_dir
+                .as_ref()
+                .map(|dir| dir.join(asset))
+                .filter(|path| path.exists())
+        });
+    let Some(path) = path else {
+        return Err((
+            404,
+            serde_json::json!({ "ok": false, "error": "recording asset not found" }),
+        ));
+    };
+    let content_type = if asset.ends_with(".ts") {
+        "video/mp2t"
+    } else {
+        "video/mp4"
+    };
+    Ok(RecordingAsset::File {
+        path,
+        content_type,
+        filename: asset.to_string(),
+    })
+}
+
+pub(crate) fn read_recording_asset_bytes_range(
+    bytes: Vec<u8>,
+    offset: u64,
+    length: Option<u64>,
+) -> Result<(Vec<u8>, u64, u64), (u16, serde_json::Value)> {
+    let total_size = bytes.len() as u64;
+    let (start, transfer_len, end) = recording_asset_range(total_size, offset, length)?;
+    let start = usize::try_from(start).map_err(|_| {
+        (
+            413,
+            serde_json::json!({ "ok": false, "error": "range too large for this platform" }),
+        )
+    })?;
+    Ok((bytes[start..start + transfer_len].to_vec(), total_size, end))
+}
+
+pub(crate) fn read_recording_asset_file_range(
+    path: &std::path::Path,
+    offset: u64,
+    length: Option<u64>,
+) -> Result<(Vec<u8>, u64, u64), (u16, serde_json::Value)> {
+    let metadata = std::fs::metadata(path).map_err(|e| {
+        (
+            500,
+            serde_json::json!({ "ok": false, "error": format!("stat recording asset: {e}") }),
+        )
+    })?;
+    let total_size = metadata.len();
+    let (start, transfer_len, end) = recording_asset_range(total_size, offset, length)?;
+    let mut file = std::fs::File::open(path).map_err(|e| {
+        (
+            500,
+            serde_json::json!({ "ok": false, "error": format!("open recording asset: {e}") }),
+        )
+    })?;
+    file.seek(std::io::SeekFrom::Start(start)).map_err(|e| {
+        (
+            500,
+            serde_json::json!({ "ok": false, "error": format!("seek recording asset: {e}") }),
+        )
+    })?;
+    let mut bytes = vec![0u8; transfer_len];
+    file.read_exact(&mut bytes).map_err(|e| {
+        (
+            500,
+            serde_json::json!({ "ok": false, "error": format!("read recording asset: {e}") }),
+        )
+    })?;
+    Ok((bytes, total_size, end))
+}
+
+pub(crate) fn recording_asset_range(
+    total_size: u64,
+    offset: u64,
+    length: Option<u64>,
+) -> Result<(u64, usize, u64), (u16, serde_json::Value)> {
+    if offset > total_size {
+        return Err((
+            416,
+            serde_json::json!({
+                "ok": false,
+                "error": "range start beyond recording asset size",
+                "total_size": total_size,
+            }),
+        ));
+    }
+    let available = total_size.saturating_sub(offset);
+    let requested = length.unwrap_or(available).min(available);
+    if requested > crate::web_gateway::UPLOAD_MAX_BYTES as u64 {
+        return Err((
+            413,
+            serde_json::json!({
+                "ok": false,
+                "error": format!(
+                    "range too large: {} bytes (cap is {})",
+                    requested,
+                    crate::web_gateway::UPLOAD_MAX_BYTES
+                ),
+            }),
+        ));
+    }
+    let transfer_len = usize::try_from(requested).map_err(|_| {
+        (
+            413,
+            serde_json::json!({ "ok": false, "error": "range too large for this platform" }),
+        )
+    })?;
+    Ok((offset, transfer_len, offset.saturating_add(requested)))
+}
+
+pub(crate) fn session_frame_filename_is_safe(filename: &str) -> bool {
+    (filename.ends_with(".jpg") || filename.ends_with(".png"))
+        && filename.len() < 80
+        && !filename.is_empty()
+        && filename.trim() == filename
+        && !filename.contains("..")
+        && !filename.contains('/')
+        && !filename.contains('\\')
+}
+
+pub(crate) fn read_frame_asset_file_range(
+    path: &std::path::Path,
+    offset: u64,
+    length: Option<u64>,
+) -> Result<(Vec<u8>, u64, u64), (u16, serde_json::Value)> {
+    let metadata = std::fs::metadata(path).map_err(|e| {
+        (
+            500,
+            serde_json::json!({ "ok": false, "error": format!("stat session frame: {e}") }),
+        )
+    })?;
+    let total_size = metadata.len();
+    let (start, transfer_len, end) = recording_asset_range(total_size, offset, length)?;
+    let mut file = std::fs::File::open(path).map_err(|e| {
+        (
+            500,
+            serde_json::json!({ "ok": false, "error": format!("open session frame: {e}") }),
+        )
+    })?;
+    file.seek(std::io::SeekFrom::Start(start)).map_err(|e| {
+        (
+            500,
+            serde_json::json!({ "ok": false, "error": format!("seek session frame: {e}") }),
+        )
+    })?;
+    let mut bytes = vec![0u8; transfer_len];
+    file.read_exact(&mut bytes).map_err(|e| {
+        (
+            500,
+            serde_json::json!({ "ok": false, "error": format!("read session frame: {e}") }),
+        )
+    })?;
+    Ok((bytes, total_size, end))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Stage S4 slice 2 of 3 of the transport-unification program (design §2.1–2.5, §6 S4, §7 R1/R2, §8), following the S4a template (#146): the session **artifacts, deletes, and worktrees** go transport-neutral, with tunnel columns on the rows and nine differential-pin flips.

## What this PR does, commit by commit

1. **Golden transcripts first** (own commit): byte-exact pins of the family's HTTP wire bytes — all **five session-delete wire shapes** (native DELETE, target form, the WKWebView POST `/delete`-suffix fallbacks; the routing pins at `gateway_routes` cover dispatch, these cover the response bytes) plus the delete missing-session body; report invalid/missing/success (zip attachment framing); recordings list invalid/missing/fixture; the segments listing, HLS playlist, and segment-file leaves (immutable `public, max-age=3600` tail; text/plain error wordings); frame-asset success/invalid/missing; worktrees list cold/warm cache and inspect/remove invalid-body 400s.
2. **HTTP side**: neutral cores in `routes_sessions.rs` — `session_delete_api_response` (the delete tail keeps its historical ACAO-before-Cache-Control order), `session_report_api_response` (BYTES lane; meta = the tunnel's `byte_stream_end.result`), `session_text_plain_response`, `session_recordings_api_response`, `session_recording_listing_asset_api_response` (the tunnel twin's `segments`/`playlist.m3u8` vocabulary through the shared resolver), and the four `worktrees_*_api_response` cores (inventory bodies + the shared cache side-effects). The **recording/frame asset content core** (`RecordingAsset`, resolvers, safety predicates, range readers) moves **verbatim** from `dashboard_control/api_media.rs` into `web_gateway/session_catalog/external_rows.rs` (fs-template precedent), with a `pub(crate) use` at the old location. The report branch now consumes `session_report_zip_for_request` — the shared core the tunnel already used. Goldens pass unchanged.
3. **Tunnel side**: the nine twins delegate through the same neutral fns — delete/list/scan under the body-only envelope (`frame_api_json_body_response`), inspect/remove/recordings under the injected-status envelope, report through `frame_api_task_response` with the shared meta. The recording/frame asset task handlers keep their **transport-owned ranged byte-stream carriage** over the moved core (per the design rule: neutral fn supplies content, lane owns framing). Parity fixtures across `api_sessions`/`api_media`/`api_control` tests pin the convergence.
4. **Rows + pin flips**: tunnel columns on the four worktrees rows and the canonical delete shape (all five delete rows share op + handler; one tunnel name per row rides the primary DELETE form); four carved artifact leaf rows (`{id}/report`, `{id}/recordings`, `{id}/recordings/{stream}/{asset}`, `{id}/frames/{filename}`) join the SessionSubRouter shared-handler group, classification-preserving. Docs table regenerated.

## Differential pin flips (Residue → Row), 9 names

- `api_session_report` (SessionInspect)
- `api_session_recordings` (SessionInspect)
- `api_session_recording_asset` (SessionInspect)
- `api_session_frame_asset` (SessionInspect)
- `api_session_delete` (SessionManage)
- `api_worktrees` (SessionInspect)
- `api_worktrees_inspect` (SessionInspect)
- `api_worktrees_scan` (SessionManage)
- `api_worktrees_remove` (SessionManage)

All operations unchanged, now derived from the rows. The op-override enumeration stays empty. (`api_worktrees_merge` was already row-first on main.)

## Envelope differences found (enumerated on the api_control fixture set)

1. **Body-only envelopes again**: `api_session_delete`, `api_worktrees` (list), and `api_worktrees_scan` predate the injected-status envelope; worktrees inspect/remove and `api_session_recordings` ride it — and its keys only decorate OBJECT bodies (the recordings list array passes through untouched, as it always did).
2. **BYTES lane**: report zip and the recording listing assets serve identical bytes on both lanes; HTTP renders meta as its attachment/no-cache header tails, the tunnel emits meta verbatim as `byte_stream_end.result`. The delete tail orders the wildcard CORS header before `Cache-Control` (HTTP-lane decoration; a third tail order, now pinned).
3. **Transport-owned asset carriage**: segment/frame FILES stream ranged and capped on the tunnel (`offset`/`length`, `UPLOAD_MAX_BYTES` cap, 413/416 shapes) but serve as one unbounded body on HTTP; the tunnel's validators are stricter (trim, backslash) than the HTTP leaves' historical inline checks; each lane keeps its historical error wording (json `{"ok":false,…}` vs text/plain `Invalid filename`/`Segment not found`/`Frame not found`).
4. **Transport-owned params**: the tunnel's report id defaults to `current`, delete's target to `session`; HTTP addresses both by path segment (five delete wire shapes).
5. **Task-failure shapes stay per-lane** (scan answers 200 with an error body on HTTP, an ok:false frame on the tunnel).

The worktrees-scan parity fixture pins the shared core + cache side-effect on a **single** scan — byte-equal double scans would race this fleet's live worktree churn (first version did exactly that and failed honestly).

## Size note

~700 product-diff lines net (conversion + verbatim move + rows); the golden/parity pins add ~750 test lines on top.

## Gates

- `cargo nextest run --bins`: **2848/2848** (all 45 S4a+S4b goldens byte-identical through the conversion; parity fixtures green; flipped partition pin green; the new store-scanning/git-spawning fixtures joined the documented nextest override lanes)
- `cargo test --test e2e`: **10/10**
- clippy: no new warnings vs origin/main (touched-file warnings pre-exist with shifted lines; the moved code warns nowhere new)
- `--color-moved=dimmed-zebra` self-review of the verbatim move
