### PR TITLE
macOS app: Developer ID signing seam, notarized releases, version + update check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,258 @@
+name: macOS app release
+
+# Builds, signs, notarizes, and publishes the native macOS app
+# (the macos-app/ WKWebView wrapper bundling the release `intendant` +
+# `intendant-runtime` binaries) via scripts/bundle-macos.sh.
+#
+# Triggers are version tags (v*) and manual dispatch ONLY — deliberately
+# never pull_request or merge_group, so this workflow can never gate the
+# merge queue. A red release run blocks a release, not landings.
+#
+# Signing/notarization secrets (repo Settings → Secrets and variables →
+# Actions → Repository secrets). When absent the job still runs end to end
+# and produces an UNSIGNED artifact named "-unsigned-dev" — useful for
+# dry-running the pipeline. Secret names, exactly:
+#
+#   MACOS_SIGN_P12_B64       base64 of a "Developer ID Application" identity
+#                            exported as .p12 — export WITH the certificate
+#                            chain included, or identity validation fails
+#   MACOS_SIGN_P12_PASSWORD  password protecting that .p12
+#   NOTARY_KEY_B64           base64 of an App Store Connect API private key (.p8)
+#   NOTARY_KEY_ID            Key ID of that API key
+#   NOTARY_ISSUER_ID         Issuer ID of the API-keys page
+#
+# Each group is all-or-nothing; a partially configured group fails the run
+# rather than silently shipping a less-signed artifact. Provisioning ceremony
+# (exporting the p12, minting the notary key): docs/src/getting-started.md,
+# "Signed releases".
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write # gh release create / upload
+
+# One release build at a time per ref; never cancel a half-published release.
+concurrency:
+  group: macos-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  macos-app:
+    name: macos-app
+    # Tags and manual dispatch only exist on trusted refs, so this always
+    # runs on the fleet Mac (same label windows.yml places its macOS leg on);
+    # there is no fork-PR path to route to hosted runners.
+    runs-on: [self-hosted, intendant-macos]
+    timeout-minutes: 120
+    steps:
+      # Same fleet preflight as windows.yml: a nearly-full disk produces
+      # resource-kill compile failures with useless diagnostics.
+      - name: Fleet preflight
+        shell: bash
+        run: |
+          avail_kb=$(df -Pk . | awk 'NR==2 {print $4}')
+          avail_gb=$((avail_kb / 1024 / 1024))
+          echo "disk available: ${avail_gb}G"
+          if [ "$avail_gb" -lt 20 ]; then
+            echo "::error::fleet preflight: only ${avail_gb}G free on this runner — below the 20G floor. Reclaim disk (merged worktrees' target/ dirs are the usual culprits) and rerun."
+            exit 1
+          fi
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Full history so dev builds (workflow_dispatch off a branch) can
+          # stamp a `git describe --tags` version.
+          fetch-depth: 0
+
+      - name: Gate on signing secrets
+        id: gate
+        shell: bash
+        env:
+          P12_B64: ${{ secrets.MACOS_SIGN_P12_B64 }}
+          P12_PASSWORD: ${{ secrets.MACOS_SIGN_P12_PASSWORD }}
+          NOTARY_KEY_B64: ${{ secrets.NOTARY_KEY_B64 }}
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.NOTARY_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          sign_set=0
+          [ -n "$P12_B64" ] && sign_set=$((sign_set + 1))
+          [ -n "$P12_PASSWORD" ] && sign_set=$((sign_set + 1))
+          notary_set=0
+          [ -n "$NOTARY_KEY_B64" ] && notary_set=$((notary_set + 1))
+          [ -n "$NOTARY_KEY_ID" ] && notary_set=$((notary_set + 1))
+          [ -n "$NOTARY_ISSUER_ID" ] && notary_set=$((notary_set + 1))
+          if [ "$sign_set" = "1" ]; then
+            echo "::error::Partial signing config: set both MACOS_SIGN_P12_B64 and MACOS_SIGN_P12_PASSWORD, or neither."
+            exit 1
+          fi
+          if [ "$notary_set" != "0" ] && [ "$notary_set" != "3" ]; then
+            echo "::error::Partial notarization config: set all of NOTARY_KEY_B64, NOTARY_KEY_ID, NOTARY_ISSUER_ID, or none."
+            exit 1
+          fi
+          if [ "$notary_set" = "3" ] && [ "$sign_set" = "0" ]; then
+            echo "::error::Notarization secrets are set but the signing identity is not; Apple only notarizes Developer ID-signed bundles."
+            exit 1
+          fi
+          sign=false notarize=false
+          [ "$sign_set" = "2" ] && sign=true
+          [ "$notary_set" = "3" ] && notarize=true
+          echo "sign=$sign" >> "$GITHUB_OUTPUT"
+          echo "notarize=$notarize" >> "$GITHUB_OUTPUT"
+          echo "Signing: $sign — notarization: $notarize"
+          if [ "$sign" = "false" ]; then
+            echo "::warning::No signing secrets configured — this run produces an unsigned-dev artifact."
+          fi
+
+      # Throwaway keychain: created fresh, added to the FRONT of the user
+      # search list (codesign cannot find identities in a keychain outside
+      # the search list — verified empirically; --keychain alone is not
+      # enough), deleted and the original list restored in the always()
+      # cleanup step below.
+      - name: Import signing identity (throwaway keychain)
+        if: steps.gate.outputs.sign == 'true'
+        shell: bash
+        env:
+          P12_B64: ${{ secrets.MACOS_SIGN_P12_B64 }}
+          P12_PASSWORD: ${{ secrets.MACOS_SIGN_P12_PASSWORD }}
+        run: |
+          set -euo pipefail
+          umask 077
+          KEYCHAIN="$RUNNER_TEMP/intendant-release.keychain-db"
+          KEYCHAIN_PASS="$(uuidgen)"
+          # A hard-cancelled previous run may have left one behind.
+          security delete-keychain "$KEYCHAIN" 2>/dev/null || true
+          # Save the original search list (one absolute path per line) BEFORE
+          # touching it; `security list-keychains -s` replaces the whole list.
+          security list-keychains -d user | sed 's/^ *"//; s/"$//' > "$RUNNER_TEMP/keychain-list.orig"
+          security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+          security set-keychain-settings -lut 7200 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+          printf '%s' "$P12_B64" | base64 -d > "$RUNNER_TEMP/sign.p12"
+          security import "$RUNNER_TEMP/sign.p12" -k "$KEYCHAIN" -f pkcs12 -P "$P12_PASSWORD" -T /usr/bin/codesign
+          rm -f "$RUNNER_TEMP/sign.p12"
+          # Let codesign use the imported key without a GUI prompt.
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASS" "$KEYCHAIN" > /dev/null
+          { echo "$KEYCHAIN"; cat "$RUNNER_TEMP/keychain-list.orig"; } | tr '\n' '\0' \
+            | xargs -0 security list-keychains -d user -s
+          IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" \
+            | sed -n 's/.*"\(Developer ID Application: [^"]*\)".*/\1/p' | head -n 1)"
+          if [ -z "$IDENTITY" ]; then
+            echo "::error::No valid 'Developer ID Application' identity in the imported .p12. Re-export it from Keychain Access WITH the certificate chain included."
+            security find-identity -p codesigning "$KEYCHAIN" || true
+            exit 1
+          fi
+          echo "Imported identity: $IDENTITY"
+          {
+            echo "INTENDANT_SIGN_IDENTITY=$IDENTITY"
+            echo "INTENDANT_SIGN_KEYCHAIN=$KEYCHAIN"
+          } >> "$GITHUB_ENV"
+
+      - name: Materialize notary API key
+        if: steps.gate.outputs.notarize == 'true'
+        shell: bash
+        env:
+          NOTARY_KEY_B64: ${{ secrets.NOTARY_KEY_B64 }}
+        run: |
+          set -euo pipefail
+          umask 077
+          printf '%s' "$NOTARY_KEY_B64" | base64 -d > "$RUNNER_TEMP/notary-key.p8"
+          echo "INTENDANT_NOTARY_KEY_FILE=$RUNNER_TEMP/notary-key.p8" >> "$GITHUB_ENV"
+
+      # Lockfile gate first (the bundle script's own cargo build is not
+      # --locked); its build then reuses this compilation unchanged.
+      - name: Build release binaries
+        shell: bash
+        run: cargo build --release --locked --bin intendant --bin intendant-runtime
+
+      - name: Bundle, sign, notarize
+        shell: bash
+        env:
+          INSTALL_APP: "0"
+          INTENDANT_ARTIFACT_DIR: ${{ github.workspace }}/dist
+          # Tag builds stamp the tag; dispatch builds fall back to the
+          # script's `git describe` dev version.
+          INTENDANT_APP_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+          # The gate step guarantees these are either all present or all
+          # empty; bundle-macos.sh treats empty as unset.
+          INTENDANT_NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          INTENDANT_NOTARY_ISSUER: ${{ secrets.NOTARY_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          rm -rf dist
+          ./scripts/bundle-macos.sh
+          ls -l dist
+
+      # Always remove the key material and restore the runner's keychain
+      # state, even when a build/notarization step failed.
+      - name: Clean up signing material
+        if: always()
+        shell: bash
+        run: |
+          rm -f "$RUNNER_TEMP/sign.p12" "$RUNNER_TEMP/notary-key.p8"
+          if [ -f "$RUNNER_TEMP/keychain-list.orig" ]; then
+            tr '\n' '\0' < "$RUNNER_TEMP/keychain-list.orig" | xargs -0 security list-keychains -d user -s
+            rm -f "$RUNNER_TEMP/keychain-list.orig"
+          fi
+          if [ -f "$RUNNER_TEMP/intendant-release.keychain-db" ]; then
+            security delete-keychain "$RUNNER_TEMP/intendant-release.keychain-db" || true
+          fi
+
+      - name: Publish GitHub release
+        if: github.ref_type == 'tag'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # Self-hosted runner PATH may not include Homebrew.
+          export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+          command -v gh > /dev/null || { echo "::error::gh CLI not found on the runner"; exit 1; }
+          tag="$GITHUB_REF_NAME"
+          zip_file="$(ls dist/Intendant-*.zip)"
+          case "$zip_file" in
+            *-unsigned-dev.zip)
+              signing_note="**Unsigned build** — signing secrets were not configured for this run. macOS Gatekeeper will warn on first launch." ;;
+            *-signed-unnotarized.zip)
+              signing_note="Signed with a Developer ID certificate but **not notarized** (notary secrets were not configured for this run)." ;;
+            *)
+              signing_note="Signed with a Developer ID certificate, notarized by Apple, and stapled — Gatekeeper opens it without warnings." ;;
+          esac
+          {
+            echo "Native macOS app: the \`macos-app/\` WKWebView wrapper bundling the release \`intendant\` and \`intendant-runtime\` binaries (Apple Silicon)."
+            echo
+            echo "$signing_note"
+            echo
+            echo "**Install:** unzip, drag \`Intendant.app\` to /Applications, launch. The app spawns its own daemon and serves the dashboard; grant Screen Recording / Accessibility / Microphone when prompted."
+            echo
+            echo "**Verify the download:**"
+            echo '```'
+            echo "shasum -a 256 -c $(basename "$zip_file").sha256"
+            echo '```'
+            echo
+            echo '```'
+            cat dist/*.sha256
+            echo '```'
+          } > "$RUNNER_TEMP/release-notes.md"
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            gh release upload "$tag" dist/* --clobber --repo "$GITHUB_REPOSITORY"
+          else
+            gh release create "$tag" dist/* \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --title "Intendant $tag" \
+              --notes-file "$RUNNER_TEMP/release-notes.md"
+          fi
+
+      # Manual dispatch has no tag to hang a release on; keep the artifact
+      # on the workflow run instead.
+      - name: Upload workflow artifact (no tag)
+        if: github.ref_type != 'tag'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: intendant-macos-app
+          path: dist/*
+          if-no-files-found: error

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -162,7 +162,10 @@ cargo build --release -p intendant   # re-embed
 `scripts/bundle-macos.sh` compiles a small Swift wrapper
 (`macos-app/*.swift`) with `swiftc`, bundles it with the release `intendant`
 binary, codesigns it (a persistent self-signed identity, ad-hoc fallback), and
-installs to `/Applications/Intendant.app`.
+installs to `/Applications/Intendant.app`. The same script carries the
+[release signing seam](#macos-releases-signing-and-notarization): with
+`INTENDANT_SIGN_IDENTITY` (and optionally the notary variables) set, it
+produces the Developer ID-signed, notarized bundle that tagged releases ship.
 
 The wrapper hosts a `WKWebView` that loads the dashboard over a custom
 `intendant://` URL scheme. This is deliberate: `WKWebView` does not treat
@@ -205,6 +208,74 @@ back to the placeholder automatically. Two environment variables tune this:
 ./scripts/bundle-macos.sh debug     # debug build + install
 INSTALL_APP=0 ./scripts/bundle-macos.sh   # build the bundle without installing
 ```
+
+### macOS releases: signing and notarization
+
+Tagged releases ship a prebuilt, signed macOS app. Pushing a `v*` tag runs
+`.github/workflows/release.yml` on the self-hosted macOS runner: it
+release-builds the binaries, runs `scripts/bundle-macos.sh` with the signing
+seam active, and publishes a GitHub Release carrying
+`Intendant-<version>-macos-<arch>.zip` plus a `.sha256` checksum file.
+
+**Installing a release:** download the zip and checksum from
+[GitHub releases](https://github.com/intendant-dev/Intendant/releases),
+verify with `shasum -a 256 -c <zip>.sha256`, unzip, and drag `Intendant.app`
+to `/Applications`. On first launch macOS asks for the TCC permissions
+(Screen Recording, Accessibility, Microphone) exactly as with a local build.
+The app checks GitHub for a newer release at launch (silently, release builds
+only) and via **Intendant → Check for Updates…**; updating is always manual —
+the prompt only opens the release page in your browser.
+
+**What the signature means.** Release bundles are signed with a
+`Developer ID Application` certificate under the hardened runtime with a
+secure timestamp, notarized by Apple, and stapled — Gatekeeper opens them
+without warnings, and a tampered bundle fails validation. Signing is
+inside-out: bundled non-system dylibs (`Contents/Frameworks`, e.g. libvpx),
+then the embedded `intendant-bin` / `intendant-runtime`, then the bundle.
+All executables carry the minimal entitlements in
+`macos-app/entitlements.plist` — microphone (`device.audio-input`, live
+voice), camera (`device.camera`, presence video input), and Apple Events
+(`automation.apple-events`, the daemon's osascript paths); the rationale for
+what is present *and absent* is commented in that file. The app bundle stamps
+its version (`CFBundleShortVersionString`) from the tag; dev builds get a
+`git describe` stamp and an artifact suffixed `-unsigned-dev` so the two can
+never be confused. Versions are visible in **Intendant → About Intendant**.
+
+**Provisioning the release secrets** (repo → Settings → Secrets and
+variables → Actions). Without them the workflow still runs and publishes an
+unsigned dev artifact; each group is all-or-nothing and a partial group fails
+the run.
+
+Signing identity — `MACOS_SIGN_P12_B64`, `MACOS_SIGN_P12_PASSWORD`:
+
+1. In your Apple Developer account (Certificates → `+`), create a
+   **Developer ID Application** certificate, or use Xcode → Settings →
+   Accounts → Manage Certificates to create it in your login keychain.
+2. In **Keychain Access**, expand the certificate, select the certificate
+   *and* its private key, File → Export Items… → `.p12`, and set a strong
+   password. Export **with the certificate chain included** (select the
+   Developer ID intermediate alongside if offered) — the release job
+   validates the identity and rejects chain-less exports.
+3. `base64 -i cert.p12 | pbcopy`, paste into the `MACOS_SIGN_P12_B64`
+   secret; put the export password in `MACOS_SIGN_P12_PASSWORD`.
+
+Notarization — `NOTARY_KEY_B64`, `NOTARY_KEY_ID`, `NOTARY_ISSUER_ID`:
+
+1. In [App Store Connect](https://appstoreconnect.apple.com) → Users and
+   Access → Integrations → **App Store Connect API** → Team Keys, generate a
+   key with the **Developer** role. Download the `.p8` (one-time download).
+2. `base64 -i AuthKey_XXXX.p8 | pbcopy` → `NOTARY_KEY_B64`; the key's
+   **Key ID** → `NOTARY_KEY_ID`; the page's **Issuer ID** → `NOTARY_ISSUER_ID`.
+
+The workflow imports the identity into a throwaway keychain (created, used,
+and deleted with the original keychain search list restored even on failure)
+and materializes the `.p8` only for the run. To sign a build by hand instead,
+`scripts/bundle-macos.sh` takes the same seam as environment variables:
+`INTENDANT_SIGN_IDENTITY` (activates hardened-runtime distribution signing),
+`INTENDANT_SIGN_KEYCHAIN`, `INTENDANT_NOTARY_KEY_FILE` /
+`INTENDANT_NOTARY_KEY_ID` / `INTENDANT_NOTARY_ISSUER` (notarize + staple),
+`INTENDANT_ARTIFACT_DIR` (versioned zip + checksum), and
+`INTENDANT_APP_VERSION` (version override; defaults to `git describe`).
 
 ## API keys (.env)
 

--- a/macos-app/UpdateChecker.swift
+++ b/macos-app/UpdateChecker.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Manual-update checker against the GitHub releases of this repo.
+///
+/// Deliberately minimal and honest: it compares the bundled
+/// `CFBundleShortVersionString` with the latest published release tag, and
+/// the strongest action it ever takes is opening the release page in the
+/// default browser. No auto-download, no auto-install, no background timers —
+/// one silent check at launch (release builds only) plus the explicit
+/// "Check for Updates…" menu item.
+enum UpdateChecker {
+    static let repoSlug = "intendant-dev/Intendant"
+
+    static var releasesPageURL: URL {
+        URL(string: "https://github.com/\(repoSlug)/releases/latest")!
+    }
+
+    private static var latestReleaseAPI: URL {
+        URL(string: "https://api.github.com/repos/\(repoSlug)/releases/latest")!
+    }
+
+    struct Release {
+        let tag: String
+        let pageURL: URL
+    }
+
+    /// Version stamped into Info.plist by scripts/bundle-macos.sh (the tag on
+    /// release builds, a `git describe` derivative on dev builds).
+    static func bundledVersion() -> String {
+        (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String)
+            ?? "0.0.0-dev"
+    }
+
+    /// Release builds are stamped with plain dotted numerics from the tag;
+    /// dev builds carry a suffix ("0.0.0-1a2b3c4d", "1.2.0-4-g1a2b3c4d-dirty").
+    /// Dev builds skip the launch-time check — a local bundle nagging about
+    /// the latest release is noise, not signal.
+    static func isDevBuild(_ version: String) -> Bool {
+        version.isEmpty || version.contains("-")
+    }
+
+    /// Compares dotted numeric prefixes ("v1.2.3-whatever" → [1,2,3]);
+    /// suffixes are ignored, and unparseable versions are never "newer"
+    /// (an update prompt must not fire on garbage input).
+    static func isNewer(remote: String, than local: String) -> Bool {
+        func numericPrefix(_ version: String) -> [Int]? {
+            var core = version
+            if core.hasPrefix("v") || core.hasPrefix("V") {
+                core.removeFirst()
+            }
+            core = core.split(separator: "-").first.map(String.init) ?? core
+            let rawParts = core.split(separator: ".").map { Int($0) }
+            guard !rawParts.isEmpty, !rawParts.contains(nil) else { return nil }
+            return rawParts.compactMap { $0 }
+        }
+        guard let remoteParts = numericPrefix(remote),
+              let localParts = numericPrefix(local) else { return false }
+        for i in 0..<max(remoteParts.count, localParts.count) {
+            let r = i < remoteParts.count ? remoteParts[i] : 0
+            let l = i < localParts.count ? localParts[i] : 0
+            if r != l { return r > l }
+        }
+        return false
+    }
+
+    /// Fetch the latest published release. Completion runs on the main queue;
+    /// `nil` means "couldn't determine" (offline, rate-limited, no releases
+    /// published yet, unexpected payload) — callers decide whether that is
+    /// silence (launch check) or an alert (explicit menu action).
+    static func fetchLatestRelease(completion: @escaping (Release?) -> Void) {
+        var request = URLRequest(
+            url: latestReleaseAPI,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 15
+        )
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        URLSession.shared.dataTask(with: request) { data, response, _ in
+            var release: Release?
+            if let http = response as? HTTPURLResponse, http.statusCode == 200,
+               let data = data,
+               let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+               let tag = object["tag_name"] as? String, !tag.isEmpty {
+                let page = (object["html_url"] as? String).flatMap { URL(string: $0) }
+                    ?? releasesPageURL
+                release = Release(tag: tag, pageURL: page)
+            }
+            DispatchQueue.main.async { completion(release) }
+        }.resume()
+    }
+}

--- a/macos-app/entitlements.plist
+++ b/macos-app/entitlements.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Hardened-runtime entitlements for release-signed Intendant.app builds
+  (scripts/bundle-macos.sh applies this file to the wrapper bundle AND the
+  embedded intendant-bin / intendant-runtime executables when
+  INTENDANT_SIGN_IDENTITY is set; local-dev builds don't use it).
+
+  This is the minimal set for a hardened-runtime app; keep each key paired
+  with the code that needs it, and delete the key if that code goes away.
+
+  Deliberately absent:
+  - com.apple.security.cs.allow-jit / allow-unsigned-executable-memory:
+    WKWebView on macOS runs JavaScript in Apple's out-of-process WebContent
+    XPC services, which have their own JIT entitlements — the host app needs
+    none, and the Rust daemon does no JIT.
+  - com.apple.security.cs.disable-library-validation: unnecessary because
+    bundle-macos.sh copies every non-system dylib (today: libvpx) into
+    Contents/Frameworks and re-signs it with the same identity.
+  - com.apple.security.network.client / .server: those are App Sandbox keys;
+    this app does not adopt the App Sandbox (it exists to run a daemon that
+    spawns arbitrary tools), and the hardened runtime does not gate network.
+  - Screen Recording / Accessibility: TCC permissions granted by the user at
+    runtime, not entitlements.
+-->
+<plist version="1.0">
+<dict>
+    <!-- Microphone. Live voice: getUserMedia({audio}) in the dashboard
+         WKWebView (static/app/36-voice-wasm-init.js), plus the daemon's own
+         audio capture paths (transcription, live audio). The hardened
+         runtime denies audio input outright — no TCC prompt — without this.
+         Pairs with NSMicrophoneUsageDescription in Info.plist. -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <!-- Camera. Dashboard video input to the presence layer
+         (startVideo() in static/app/36-voice-wasm-init.js). Pairs with
+         NSCameraUsageDescription. -->
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    <!-- Apple Events. The daemon shells out to osascript (image clipboard in
+         crates/intendant-display/src/clipboard.rs, system-control paths); a
+         hardened-runtime process tree cannot send Apple Events without this.
+         Pairs with NSAppleEventsUsageDescription. -->
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+</dict>
+</plist>

--- a/macos-app/main.swift
+++ b/macos-app/main.swift
@@ -350,6 +350,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         backendSupervisor.startBackend()
         createWindow()
         backendSupervisor.pollUntilReady()
+        checkForUpdatesQuietly()
     }
 
     /// The app historically had no menu bar because closing the window
@@ -362,6 +363,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         mainMenu.addItem(appItem)
         let appMenu = NSMenu()
         appItem.submenu = appMenu
+        // Standard about panel — shows the CFBundleShortVersionString stamped
+        // by scripts/bundle-macos.sh (the release tag, or a git-describe dev
+        // version), which is how a user answers "what version am I running?".
+        appMenu.addItem(
+            withTitle: "About Intendant",
+            action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)),
+            keyEquivalent: ""
+        )
+        let updateItem = appMenu.addItem(
+            withTitle: "Check for Updates…",
+            action: #selector(checkForUpdates(_:)),
+            keyEquivalent: ""
+        )
+        updateItem.target = self
+        appMenu.addItem(NSMenuItem.separator())
         appMenu.addItem(
             withTitle: "Quit Intendant (stops the daemon)",
             action: #selector(NSApplication.terminate(_:)),
@@ -593,6 +609,81 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         backendSupervisor?.shutdown()
     }
 
+    // MARK: - Update check
+
+    /// Launch-time check: strictly non-intrusive. Dev builds skip it, every
+    /// failure mode (offline, rate limit, no releases yet) is silent, and a
+    /// newer release surfaces as a window sheet — never an app-modal alert.
+    func checkForUpdatesQuietly() {
+        let local = UpdateChecker.bundledVersion()
+        guard !UpdateChecker.isDevBuild(local) else { return }
+        UpdateChecker.fetchLatestRelease { [weak self] release in
+            guard let self = self,
+                  let release = release,
+                  UpdateChecker.isNewer(remote: release.tag, than: local) else { return }
+            self.presentUpdatePrompt(release: release, interactive: false)
+        }
+    }
+
+    /// "Check for Updates…" menu item. An explicit request deserves explicit
+    /// answers, so unlike the launch check this also reports "no update" and
+    /// "couldn't check".
+    @objc func checkForUpdates(_ sender: Any?) {
+        UpdateChecker.fetchLatestRelease { [weak self] release in
+            guard let self = self else { return }
+            guard let release = release else {
+                let alert = NSAlert()
+                alert.messageText = "Couldn't check for updates"
+                alert.informativeText =
+                    "GitHub releases could not be reached (offline, rate-limited, or nothing published yet)."
+                alert.addButton(withTitle: "OK")
+                alert.addButton(withTitle: "Open Releases Page")
+                if alert.runModal() == .alertSecondButtonReturn {
+                    NSWorkspace.shared.open(UpdateChecker.releasesPageURL)
+                }
+                return
+            }
+            let local = UpdateChecker.bundledVersion()
+            if UpdateChecker.isNewer(remote: release.tag, than: local) {
+                self.presentUpdatePrompt(release: release, interactive: true)
+            } else {
+                let alert = NSAlert()
+                alert.messageText = "No update available"
+                alert.informativeText =
+                    "This app is version \(local). The latest published release is \(release.tag)."
+                alert.addButton(withTitle: "OK")
+                alert.runModal()
+            }
+        }
+    }
+
+    /// The prompt never downloads anything: "View Release" opens the GitHub
+    /// release page in the default browser and the user takes it from there.
+    func presentUpdatePrompt(release: UpdateChecker.Release, interactive: Bool) {
+        let alert = NSAlert()
+        alert.messageText = "Intendant \(release.tag) is available"
+        alert.informativeText =
+            "This app is version \(UpdateChecker.bundledVersion()). "
+            + "Updating is manual: View Release opens the GitHub release page in your browser — "
+            + "nothing is downloaded or installed automatically."
+        alert.addButton(withTitle: "View Release")
+        alert.addButton(withTitle: "Not Now")
+        let handle: (NSApplication.ModalResponse) -> Void = { response in
+            if response == .alertFirstButtonReturn {
+                NSWorkspace.shared.open(release.pageURL)
+            }
+        }
+        if !interactive, let window = window {
+            // Sheet on the (placeholder) window: visible next time the user
+            // looks, steals no focus from other apps.
+            alert.beginSheetModal(for: window, completionHandler: handle)
+        } else if interactive {
+            handle(alert.runModal())
+        }
+        // Launch check with no window (closed before the response arrived):
+        // stay silent; the menu item remains available.
+    }
+
     // MARK: - WKUIDelegate (JS alert/confirm/prompt)
 
     func webView(_ webView: WKWebView,
@@ -798,7 +889,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
         webView = WKWebView(frame: .zero, configuration: config)
         webView.uiDelegate = self
         webView.navigationDelegate = self
-        webView.customUserAgent = "Intendant/1.0"
+        webView.customUserAgent = "Intendant/\(UpdateChecker.bundledVersion())"
 
         // Starting in macOS 13.3, the legacy `developerExtrasEnabled` KVC
         // trick above is a no-op for release-signed builds; Safari's Web

--- a/scripts/bundle-macos.sh
+++ b/scripts/bundle-macos.sh
@@ -38,6 +38,41 @@
 #   ./scripts/bundle-macos.sh debug    # Debug build + install
 #   INSTALL_APP=0 ./scripts/bundle-macos.sh   # Build only
 #
+# Release signing seam (all optional; when none of these are set the script
+# produces the local-dev bundle exactly as before):
+#
+#   INTENDANT_SIGN_IDENTITY    Codesign identity name, e.g.
+#                              "Developer ID Application: Jane Doe (TEAMID)".
+#                              Setting it activates the distribution path:
+#                              non-system dylibs are bundled into
+#                              Contents/Frameworks and everything is signed
+#                              inside-out with the hardened runtime, a secure
+#                              timestamp, and macos-app/entitlements.plist.
+#   INTENDANT_SIGN_KEYCHAIN    Optional keychain holding that identity (a CI
+#                              throwaway keychain). It must already be
+#                              unlocked and in the keychain search list —
+#                              codesign does not find identities in
+#                              out-of-search-list keychains (verified
+#                              empirically; --keychain alone is not enough).
+#   INTENDANT_NOTARY_KEY_FILE  App Store Connect API private key (.p8) for
+#                              `notarytool`.
+#   INTENDANT_NOTARY_KEY_ID    Key ID of that API key.
+#   INTENDANT_NOTARY_ISSUER    Issuer ID of that API key. The three notary
+#                              variables are all-or-nothing, and require
+#                              INTENDANT_SIGN_IDENTITY: partial configuration
+#                              is a hard error (a release must never silently
+#                              ship less signed than the operator intended).
+#   INTENDANT_ARTIFACT_DIR     When set, stage a versioned
+#                              Intendant-<version>-macos-<arch>.zip plus a
+#                              .sha256 checksum file there. Builds without
+#                              INTENDANT_SIGN_IDENTITY are suffixed
+#                              "-unsigned-dev" so nobody mistakes a local
+#                              bundle for a release.
+#   INTENDANT_APP_VERSION      Version stamp override (the release workflow
+#                              passes the git tag). Default: `git describe
+#                              --tags --match "v*"`, so dev builds get
+#                              "0.0.0-<sha>"-style versions.
+#
 # Output:
 #   target/Intendant.app           (always — staged build)
 #   /Applications/Intendant.app    (when INSTALL_APP=1, the default)
@@ -49,6 +84,69 @@ set -euo pipefail
 BUNDLE_ID="com.intendant.app"
 
 PROFILE="${1:-release}"
+
+die() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+# --- Release-signing configuration (validated before the long build) -------
+
+SIGN_RELEASE_IDENTITY="${INTENDANT_SIGN_IDENTITY:-}"
+SIGN_RELEASE_KEYCHAIN="${INTENDANT_SIGN_KEYCHAIN:-}"
+NOTARY_KEY_FILE="${INTENDANT_NOTARY_KEY_FILE:-}"
+NOTARY_KEY_ID="${INTENDANT_NOTARY_KEY_ID:-}"
+NOTARY_ISSUER="${INTENDANT_NOTARY_ISSUER:-}"
+
+# Notary env is all-or-nothing: a partially configured release run must fail
+# loudly, not quietly ship an un-notarized artifact.
+notary_env_state() {
+    local n=0
+    [ -n "$NOTARY_KEY_FILE" ] && n=$((n + 1))
+    [ -n "$NOTARY_KEY_ID" ] && n=$((n + 1))
+    [ -n "$NOTARY_ISSUER" ] && n=$((n + 1))
+    case "$n" in
+        0) echo "none" ;;
+        3) echo "all" ;;
+        *) echo "partial" ;;
+    esac
+}
+
+NOTARY_STATE="$(notary_env_state)"
+case "$NOTARY_STATE" in
+    partial)
+        die "partial notarization config: INTENDANT_NOTARY_KEY_FILE, INTENDANT_NOTARY_KEY_ID, and INTENDANT_NOTARY_ISSUER must all be set together (or none)"
+        ;;
+    all)
+        [ -n "$SIGN_RELEASE_IDENTITY" ] \
+            || die "notarization requires INTENDANT_SIGN_IDENTITY (Apple only notarizes Developer ID-signed bundles)"
+        [ -f "$NOTARY_KEY_FILE" ] \
+            || die "INTENDANT_NOTARY_KEY_FILE does not exist: $NOTARY_KEY_FILE"
+        ;;
+esac
+
+# --- Version stamp ----------------------------------------------------------
+# Release builds get the tag (workflow passes INTENDANT_APP_VERSION=v1.2.3);
+# dev builds derive from `git describe` against v* tags only — this repo also
+# carries non-version tags (bench-pilot-*) that must not leak into versions.
+# With no v* tag in history the describe output is a bare commit hash, which
+# gets a "0.0.0-" prefix so CFBundleShortVersionString stays ordered and
+# recognizably a dev stamp.
+APP_VERSION="${INTENDANT_APP_VERSION:-}"
+if [ -z "$APP_VERSION" ]; then
+    APP_VERSION="$(git describe --tags --match 'v*' --always --dirty 2>/dev/null || true)"
+fi
+[ -n "$APP_VERSION" ] || APP_VERSION="0.0.0-dev"
+APP_VERSION="${APP_VERSION#v}"
+case "$APP_VERSION" in
+    # Tag-derived versions always contain a dot; a no-v-tag `git describe
+    # --always` yields a bare (dotless) commit hash, optionally "-dirty".
+    *.*) : ;;
+    *) APP_VERSION="0.0.0-${APP_VERSION}" ;;
+esac
+echo "App version: $APP_VERSION"
+
+# --- Build ------------------------------------------------------------------
 
 if [ "$PROFILE" = "debug" ]; then
     BINARY="target/debug/intendant"
@@ -64,6 +162,7 @@ APP="target/Intendant.app"
 CONTENTS="$APP/Contents"
 MACOS="$CONTENTS/MacOS"
 RESOURCES="$CONTENTS/Resources"
+FRAMEWORKS="$CONTENTS/Frameworks"
 
 # Where the freshly-built bundle gets installed at the end of this
 # script. `/Applications` is the only install location a few tools
@@ -74,23 +173,29 @@ RESOURCES="$CONTENTS/Resources"
 INSTALLED_APP="/Applications/Intendant.app"
 INSTALL_APP="${INSTALL_APP:-1}"
 
-# Unregister any stale Intendant.app bundles from other worktrees or Trash.
-# Multiple bundles with the same CFBundleIdentifier cause macOS LaunchServices
-# to launch the wrong one (possibly an old worktree build from days ago).
 LS=/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
-while IFS= read -r stale_path; do
-    # Skip the current target (this build's output) AND the canonical
-    # install destination — both are expected to hold an Intendant.app
-    # at the end of this script, and the install step below overwrites
-    # `/Applications` in place rather than deleting it first.
-    if [ "$stale_path" != "$PROJECT_ROOT/$APP" ] && [ "$stale_path" != "$INSTALLED_APP" ]; then
-        $LS -u "$stale_path" 2>/dev/null || true
-        rm -rf "$stale_path" 2>/dev/null || true
-    fi
-done < <($LS -dump 2>/dev/null | grep -o '/[^ ]*Intendant\.app' | sort -u)
+
+# Unregister any stale Intendant.app bundles from other worktrees or Trash.
+# Multiple bundles with the same CFBundleIdentifier cause macOS LaunchServices
+# to launch the wrong one (possibly an old worktree build from days ago).
+# Only when installing: this cleanup exists to disambiguate *launching*, and a
+# build-only run (INSTALL_APP=0 — CI, release packaging) must not delete other
+# worktrees' staged bundles on a shared machine.
+if [ "$INSTALL_APP" = "1" ]; then
+    while IFS= read -r stale_path; do
+        # Skip the current target (this build's output) AND the canonical
+        # install destination — both are expected to hold an Intendant.app
+        # at the end of this script, and the install step below overwrites
+        # `/Applications` in place rather than deleting it first.
+        if [ "$stale_path" != "$PROJECT_ROOT/$APP" ] && [ "$stale_path" != "$INSTALLED_APP" ]; then
+            "$LS" -u "$stale_path" 2>/dev/null || true
+            rm -rf "$stale_path" 2>/dev/null || true
+        fi
+    done < <("$LS" -dump 2>/dev/null | grep -o '/[^ ]*Intendant\.app' | sort -u)
+fi
 
 rm -rf "$APP"
 mkdir -p "$MACOS" "$RESOURCES"
@@ -99,69 +204,23 @@ mkdir -p "$MACOS" "$RESOURCES"
 # files, swiftc only allows top-level code in a file named main.swift)
 echo "Compiling macOS app wrapper..."
 swiftc -O -o "$MACOS/Intendant" macos-app/main.swift macos-app/BackendSupervisor.swift \
+    macos-app/UpdateChecker.swift \
     -framework Cocoa -framework WebKit
 
 # Copy Rust binaries
 cp "$BINARY" "$MACOS/intendant-bin"
 cp "$RUNTIME" "$MACOS/intendant-runtime"
 
-# Code-sign with a stable local identity so TCC permissions survive recompiles.
-# Uses a dedicated keychain at ~/.intendant/signing.keychain-db (works over SSH,
-# no Apple Developer account needed, no GUI Keychain prompts).
-SIGN_IDENTITY="Intendant Dev"
-SIGN_KEYCHAIN="$HOME/.intendant/signing.keychain-db"
-SIGN_KEYCHAIN_PASS="intendant-dev"
-
-if ! security find-identity -p codesigning "$SIGN_KEYCHAIN" 2>/dev/null | grep -q "$SIGN_IDENTITY"; then
-    echo "Creating local code signing certificate '$SIGN_IDENTITY'..."
-    CERT_DIR=$(mktemp -d)
-    cat > "$CERT_DIR/cert.conf" << 'CERTCONF'
-[req]
-distinguished_name = req_dn
-x509_extensions = codesign
-prompt = no
-[req_dn]
-CN = Intendant Dev
-[codesign]
-keyUsage = digitalSignature
-extendedKeyUsage = codeSigning
-CERTCONF
-    openssl req -x509 -newkey rsa:2048 -nodes \
-        -keyout "$CERT_DIR/key.pem" -out "$CERT_DIR/cert.pem" \
-        -days 3650 -config "$CERT_DIR/cert.conf" 2>/dev/null
-    openssl pkcs12 -export -out "$CERT_DIR/cert.p12" \
-        -inkey "$CERT_DIR/key.pem" -in "$CERT_DIR/cert.pem" \
-        -passout pass:intendant 2>/dev/null
-    mkdir -p "$(dirname "$SIGN_KEYCHAIN")"
-    security create-keychain -p "$SIGN_KEYCHAIN_PASS" "$SIGN_KEYCHAIN" 2>/dev/null || true
-    security unlock-keychain -p "$SIGN_KEYCHAIN_PASS" "$SIGN_KEYCHAIN"
-    security set-keychain-settings "$SIGN_KEYCHAIN"
-    security import "$CERT_DIR/cert.p12" -k "$SIGN_KEYCHAIN" -P "intendant" -T /usr/bin/codesign -A
-    security set-key-partition-list -S apple-tool:,apple: -s -k "$SIGN_KEYCHAIN_PASS" "$SIGN_KEYCHAIN" >/dev/null 2>&1
-    # Add to search list so codesign can find it
-    security list-keychains -d user -s "$SIGN_KEYCHAIN" $(security list-keychains -d user | tr -d '"')
-    rm -rf "$CERT_DIR"
-    echo "Certificate created in $SIGN_KEYCHAIN"
-fi
-
-echo "Signing app bundle..."
-security unlock-keychain -p "$SIGN_KEYCHAIN_PASS" "$SIGN_KEYCHAIN" 2>/dev/null
-if security find-identity -p codesigning "$SIGN_KEYCHAIN" 2>/dev/null | grep -q "$SIGN_IDENTITY"; then
-    codesign --force --deep --keychain "$SIGN_KEYCHAIN" --sign "$SIGN_IDENTITY" "$APP"
-    echo "Signed with '$SIGN_IDENTITY' (TCC grants will persist across recompiles)"
-else
-    echo "Warning: '$SIGN_IDENTITY' certificate not found, falling back to ad-hoc signing"
-    echo "TCC permissions may be invalidated on each recompile"
-    codesign --force --deep --sign - "$APP" 2>/dev/null || true
-fi
-
 # Copy app icon
 if [ -f "macos-app/AppIcon.icns" ]; then
     cp "macos-app/AppIcon.icns" "$RESOURCES/AppIcon.icns"
 fi
 
-# Info.plist
-cat > "$CONTENTS/Info.plist" << 'PLIST'
+# Info.plist — written before signing, so the signature seals it (the
+# pre-release-seam script signed first and wrote the plist after, which left
+# the seal broken and the code-signing identifier inferred from the executable
+# name instead of the bundle identifier).
+cat > "$CONTENTS/Info.plist" << PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -169,15 +228,15 @@ cat > "$CONTENTS/Info.plist" << 'PLIST'
     <key>CFBundleExecutable</key>
     <string>Intendant</string>
     <key>CFBundleIdentifier</key>
-    <string>com.intendant.app</string>
+    <string>${BUNDLE_ID}</string>
     <key>CFBundleName</key>
     <string>Intendant</string>
     <key>CFBundleDisplayName</key>
     <string>Intendant</string>
     <key>CFBundleVersion</key>
-    <string>1.0</string>
+    <string>${APP_VERSION}</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0</string>
+    <string>${APP_VERSION}</string>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>CFBundlePackageType</key>
@@ -197,6 +256,199 @@ cat > "$CONTENTS/Info.plist" << 'PLIST'
 </dict>
 </plist>
 PLIST
+
+# --- Signing ----------------------------------------------------------------
+
+# codesign wrapper: appends --keychain when INTENDANT_SIGN_KEYCHAIN is set.
+# (A function instead of an array: macOS bash 3.2 + `set -u` rejects empty
+# array expansion.)
+release_codesign() {
+    if [ -n "$SIGN_RELEASE_KEYCHAIN" ]; then
+        codesign --keychain "$SIGN_RELEASE_KEYCHAIN" "$@"
+    else
+        codesign "$@"
+    fi
+}
+
+# Bundle every non-system dylib the executables reference (today: Homebrew
+# libvpx) into Contents/Frameworks and rewrite the load commands to
+# @executable_path/../Frameworks/. A distributable app cannot reference
+# /opt/homebrew paths — the dylib won't exist on the user's machine, and
+# hardened-runtime library validation rejects a dylib signed by another team.
+# Bundled copies get re-signed with our identity in the inside-out pass below.
+bundle_nonsystem_dylibs() {
+    local pass=0 changed=1 bin dep name
+    while [ "$changed" = "1" ] && [ "$pass" -lt 5 ]; do
+        changed=0
+        pass=$((pass + 1))
+        for bin in "$MACOS/Intendant" "$MACOS/intendant-bin" "$MACOS/intendant-runtime" "$FRAMEWORKS"/*.dylib; do
+            [ -f "$bin" ] || continue
+            # otool -L lists "<path> (compatibility ...)" lines after a header.
+            for dep in $(otool -L "$bin" | awk 'NR>1 {print $1}'); do
+                case "$dep" in
+                    /usr/lib/* | /System/* | @rpath/* | @executable_path/* | @loader_path/*) continue ;;
+                esac
+                name="$(basename "$dep")"
+                if [ ! -f "$FRAMEWORKS/$name" ]; then
+                    echo "Bundling non-system dylib: $dep"
+                    mkdir -p "$FRAMEWORKS"
+                    cp "$dep" "$FRAMEWORKS/$name"
+                    chmod u+w "$FRAMEWORKS/$name"
+                    install_name_tool -id "@executable_path/../Frameworks/$name" "$FRAMEWORKS/$name"
+                    changed=1
+                fi
+                install_name_tool -change "$dep" "@executable_path/../Frameworks/$name" "$bin"
+            done
+        done
+    done
+    if [ "$changed" = "1" ]; then
+        die "dylib bundling did not converge after $pass passes — circular or deeply nested non-system dylib graph?"
+    fi
+}
+
+if [ -n "$SIGN_RELEASE_IDENTITY" ]; then
+    # Distribution path: hardened runtime + secure timestamp + entitlements,
+    # signed inside-out (nested code first, then the bundle — Apple deprecated
+    # --deep for a reason: it applies the *bundle's* flags to nested code and
+    # misses entitlements). Notarization requires all of this on every Mach-O
+    # in the bundle.
+    ENTITLEMENTS="macos-app/entitlements.plist"
+    [ -f "$ENTITLEMENTS" ] || die "missing $ENTITLEMENTS"
+    plutil -lint "$ENTITLEMENTS" > /dev/null
+
+    bundle_nonsystem_dylibs
+
+    echo "Signing app bundle with '$SIGN_RELEASE_IDENTITY' (hardened runtime + timestamp)..."
+    if [ -d "$FRAMEWORKS" ]; then
+        for dylib in "$FRAMEWORKS"/*.dylib; do
+            [ -f "$dylib" ] || continue
+            release_codesign --force --options runtime --timestamp \
+                --sign "$SIGN_RELEASE_IDENTITY" "$dylib"
+        done
+    fi
+    for exe in "$MACOS/intendant-runtime" "$MACOS/intendant-bin"; do
+        release_codesign --force --options runtime --timestamp \
+            --entitlements "$ENTITLEMENTS" \
+            --sign "$SIGN_RELEASE_IDENTITY" "$exe"
+    done
+    # Signing the bundle signs Contents/MacOS/Intendant (the CFBundleExecutable)
+    # and seals Info.plist + Resources + the already-signed nested code.
+    release_codesign --force --options runtime --timestamp \
+        --entitlements "$ENTITLEMENTS" \
+        --sign "$SIGN_RELEASE_IDENTITY" "$APP"
+
+    codesign --verify --deep --strict --verbose=2 "$APP"
+    echo "Signed and verified with '$SIGN_RELEASE_IDENTITY'"
+else
+    # Local-dev path (unchanged behavior): sign with a stable self-signed
+    # identity so TCC permissions survive recompiles. Uses a dedicated
+    # keychain at ~/.intendant/signing.keychain-db (works over SSH, no Apple
+    # Developer account needed, no GUI Keychain prompts).
+    SIGN_IDENTITY="Intendant Dev"
+    SIGN_KEYCHAIN="$HOME/.intendant/signing.keychain-db"
+    SIGN_KEYCHAIN_PASS="intendant-dev"
+
+    if ! security find-identity -p codesigning "$SIGN_KEYCHAIN" 2>/dev/null | grep -q "$SIGN_IDENTITY"; then
+        echo "Creating local code signing certificate '$SIGN_IDENTITY'..."
+        CERT_DIR=$(mktemp -d)
+        cat > "$CERT_DIR/cert.conf" << 'CERTCONF'
+[req]
+distinguished_name = req_dn
+x509_extensions = codesign
+prompt = no
+[req_dn]
+CN = Intendant Dev
+[codesign]
+keyUsage = digitalSignature
+extendedKeyUsage = codeSigning
+CERTCONF
+        openssl req -x509 -newkey rsa:2048 -nodes \
+            -keyout "$CERT_DIR/key.pem" -out "$CERT_DIR/cert.pem" \
+            -days 3650 -config "$CERT_DIR/cert.conf" 2>/dev/null
+        openssl pkcs12 -export -out "$CERT_DIR/cert.p12" \
+            -inkey "$CERT_DIR/key.pem" -in "$CERT_DIR/cert.pem" \
+            -passout pass:intendant 2>/dev/null
+        mkdir -p "$(dirname "$SIGN_KEYCHAIN")"
+        security create-keychain -p "$SIGN_KEYCHAIN_PASS" "$SIGN_KEYCHAIN" 2>/dev/null || true
+        security unlock-keychain -p "$SIGN_KEYCHAIN_PASS" "$SIGN_KEYCHAIN"
+        security set-keychain-settings "$SIGN_KEYCHAIN"
+        security import "$CERT_DIR/cert.p12" -k "$SIGN_KEYCHAIN" -P "intendant" -T /usr/bin/codesign -A
+        security set-key-partition-list -S apple-tool:,apple: -s -k "$SIGN_KEYCHAIN_PASS" "$SIGN_KEYCHAIN" >/dev/null 2>&1
+        # Add to search list so codesign can find it (list-keychains -s
+        # replaces the whole list, so re-list the existing entries too;
+        # word-splitting the quoted paths is intended).
+        # shellcheck disable=SC2046
+        security list-keychains -d user -s "$SIGN_KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+        rm -rf "$CERT_DIR"
+        echo "Certificate created in $SIGN_KEYCHAIN"
+    fi
+
+    echo "Signing app bundle..."
+    security unlock-keychain -p "$SIGN_KEYCHAIN_PASS" "$SIGN_KEYCHAIN" 2>/dev/null
+    if security find-identity -p codesigning "$SIGN_KEYCHAIN" 2>/dev/null | grep -q "$SIGN_IDENTITY"; then
+        codesign --force --deep --keychain "$SIGN_KEYCHAIN" --sign "$SIGN_IDENTITY" "$APP"
+        echo "Signed with '$SIGN_IDENTITY' (TCC grants will persist across recompiles)"
+    else
+        echo "Warning: '$SIGN_IDENTITY' certificate not found, falling back to ad-hoc signing"
+        echo "TCC permissions may be invalidated on each recompile"
+        codesign --force --deep --sign - "$APP" 2>/dev/null || true
+    fi
+fi
+
+# --- Notarization (optional; requires the release identity) ------------------
+
+NOTARIZED=0
+if [ "$NOTARY_STATE" = "all" ]; then
+    echo "Submitting to the Apple notary service (typically 1-5 minutes)..."
+    NOTARIZE_ZIP="$(mktemp -d)/Intendant-notarize.zip"
+    ditto -c -k --keepParent "$APP" "$NOTARIZE_ZIP"
+    SUBMIT_JSON="$(xcrun notarytool submit "$NOTARIZE_ZIP" \
+        --key "$NOTARY_KEY_FILE" \
+        --key-id "$NOTARY_KEY_ID" \
+        --issuer "$NOTARY_ISSUER" \
+        --wait --timeout 30m \
+        --output-format json)" || die "notarytool submit failed"
+    echo "$SUBMIT_JSON"
+    SUBMIT_STATUS="$(printf '%s' "$SUBMIT_JSON" \
+        | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin).get("status",""))')"
+    SUBMIT_ID="$(printf '%s' "$SUBMIT_JSON" \
+        | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin).get("id",""))')"
+    rm -f "$NOTARIZE_ZIP"
+    if [ "$SUBMIT_STATUS" != "Accepted" ]; then
+        echo "Notarization was not accepted (status: ${SUBMIT_STATUS:-unknown}); fetching the notary log:" >&2
+        [ -n "$SUBMIT_ID" ] && xcrun notarytool log "$SUBMIT_ID" \
+            --key "$NOTARY_KEY_FILE" --key-id "$NOTARY_KEY_ID" --issuer "$NOTARY_ISSUER" >&2 || true
+        die "notarization failed"
+    fi
+    # Staple the ticket so Gatekeeper accepts the app offline.
+    xcrun stapler staple "$APP"
+    xcrun stapler validate "$APP"
+    NOTARIZED=1
+    # Informational only: spctl consults the local policy database, which can
+    # reject for machine-local reasons even on a correctly notarized bundle.
+    spctl --assess --type exec -vv "$APP" || echo "Note: spctl assessment failed (see above); stapler validate passed"
+    echo "Notarized and stapled."
+fi
+
+# --- Versioned artifact (optional) -------------------------------------------
+
+if [ -n "${INTENDANT_ARTIFACT_DIR:-}" ]; then
+    mkdir -p "$INTENDANT_ARTIFACT_DIR"
+    ARCH="$(uname -m)"
+    SUFFIX=""
+    if [ -z "$SIGN_RELEASE_IDENTITY" ]; then
+        SUFFIX="-unsigned-dev"
+    elif [ "$NOTARIZED" != "1" ]; then
+        SUFFIX="-signed-unnotarized"
+    fi
+    ZIP_NAME="Intendant-${APP_VERSION}-macos-${ARCH}${SUFFIX}.zip"
+    ditto -c -k --keepParent "$APP" "$INTENDANT_ARTIFACT_DIR/$ZIP_NAME"
+    (cd "$INTENDANT_ARTIFACT_DIR" && shasum -a 256 "$ZIP_NAME" > "$ZIP_NAME.sha256")
+    echo "Artifact: $INTENDANT_ARTIFACT_DIR/$ZIP_NAME"
+    echo "Checksum: $INTENDANT_ARTIFACT_DIR/$ZIP_NAME.sha256"
+fi
+
+# --- Install ------------------------------------------------------------------
 
 if [ "$INSTALL_APP" = "1" ]; then
     # Install the freshly-signed bundle to /Applications so everything
@@ -221,7 +473,7 @@ if [ "$INSTALL_APP" = "1" ]; then
     # Refresh LaunchServices so the new build is recognised
     # immediately (without the refresh, the Dock / Spotlight /
     # computer-use MCP can take a minute or two to notice).
-    $LS -f "$INSTALLED_APP"
+    "$LS" -f "$INSTALLED_APP"
 
     # Unregister the `target/` build path. Both paths holding the
     # same CFBundleIdentifier re-introduces the ambiguity the
@@ -230,14 +482,14 @@ if [ "$INSTALL_APP" = "1" ]; then
     # nondeterministically. Leave the files (some devs may `open
     # target/Intendant.app` directly for debugging); just drop the
     # LaunchServices record.
-    $LS -u "$PROJECT_ROOT/$APP" 2>/dev/null || true
+    "$LS" -u "$PROJECT_ROOT/$APP" 2>/dev/null || true
 
-    echo "✅ Built + installed: $INSTALLED_APP"
+    echo "✅ Built + installed: $INSTALLED_APP (version $APP_VERSION)"
     echo ""
     echo "Launch:"
     echo "  open -b com.intendant.app"
 else
-    echo "✅ Built: $APP (skipping install; set INSTALL_APP=1 to install)"
+    echo "✅ Built: $APP (version $APP_VERSION; skipping install; set INSTALL_APP=1 to install)"
     echo ""
     echo "Launch:"
     echo "  open target/Intendant.app"


### PR DESCRIPTION
Task #23: the signed, released native macOS app — the integrated-tier client from the trust-tiers client ladder.

## What this adds

**Signing seam in `scripts/bundle-macos.sh`** (env-gated; without the env vars the script behaves as before and dev artifacts are explicitly named `-unsigned-dev`):
- `INTENDANT_SIGN_IDENTITY` activates the distribution path: hardened runtime, secure timestamp, minimal entitlements (`macos-app/entitlements.plist`: `device.audio-input` for live voice, `device.camera` for presence video input, `automation.apple-events` for the daemon's osascript paths — each justified inline, with the deliberately-absent keys documented too).
- Non-system dylibs (today: Homebrew libvpx, which `intendant` links dynamically) are bundled into `Contents/Frameworks` with rewritten load commands and re-signed — a released app can't reference `/opt/homebrew`, and library validation wants our team's signature.
- Signing is inside-out (dylibs → embedded `intendant-runtime`/`intendant-bin` → bundle), not `--deep`.
- `INTENDANT_NOTARY_KEY_FILE` / `INTENDANT_NOTARY_KEY_ID` / `INTENDANT_NOTARY_ISSUER` (all-or-nothing; partial config is a hard, early error) drive `notarytool submit --wait` + `stapler staple` + `stapler validate`.
- `INTENDANT_ARTIFACT_DIR` stages `Intendant-<version>-macos-<arch>[-unsigned-dev|-signed-unnotarized].zip` + `.sha256`.

Two latent bundle bugs fixed en route:
- Info.plist/icon were written **after** codesigning, so every dev bundle shipped a broken seal and a signing identifier inferred from the executable name ("Intendant") instead of the bundle id. They now precede signing; `codesign --verify --deep --strict` passes on dev bundles for the first time. (One-time local effect: the identifier change may require re-toggling existing TCC grants after the next rebuild — the app's existing permissions alert already guides that.)
- The LaunchServices stale-bundle sweep (which deletes other paths' `Intendant.app`s) is now gated on `INSTALL_APP=1`: it exists to disambiguate launching, and a build-only run on a shared machine must not delete other worktrees' staged bundles.

**`.github/workflows/release.yml`** — triggers on `v*` tag pushes and `workflow_dispatch` only (never `pull_request`/`merge_group`; it cannot gate the queue). Runs on the self-hosted macOS runner (same fleet label as windows.yml's macOS leg). If signing secrets exist it imports the p12 into a throwaway keychain — created in `$RUNNER_TEMP`, added to the front of the keychain search list (codesign cannot see identities in out-of-search-list keychains; `--keychain` alone is not sufficient — verified empirically), and removed with the original search list restored in an `always()` cleanup step. Notary `.p8` materialized only for the run and shredded in the same cleanup. Publishes a GitHub Release (artifact + checksum, honest signing-status note) via `gh` for tag refs; off-tag dispatch runs upload a workflow artifact instead. Secrets (documented in the workflow header and docs): `MACOS_SIGN_P12_B64`, `MACOS_SIGN_P12_PASSWORD`, `NOTARY_KEY_B64`, `NOTARY_KEY_ID`, `NOTARY_ISSUER_ID`.

**Version plumbing** — `CFBundleShortVersionString`/`CFBundleVersion` stamp from the tag (`INTENDANT_APP_VERSION`) or `git describe --tags --match 'v*'` (dev builds become `0.0.0-<sha>[-dirty]`; the `--match` matters — this repo has non-version tags). Visible in the new **About Intendant** menu item; the WKWebView user agent now carries the real version.

**Update check** (`macos-app/UpdateChecker.swift` + menu wiring) — one silent launch-time check (release builds only; dev builds never nag) against the GitHub releases-latest API, plus an explicit **Check for Updates…** menu item that also reports "no update"/"couldn't check". A newer release shows a window sheet whose only action opens the release page in the default browser. No auto-download, no auto-install.

**Docs** — `getting-started.md` gains the install/verify story, what the signature and notarization mean, and the operator ceremony for both secret groups (Developer ID p12 export with chain, App Store Connect API key minting).

## Verification

- Unsigned dev path end-to-end: bundle built, `codesign --verify --deep --strict` passes, `plutil -lint` OK on Info.plist, zip + checksum verified with `shasum -c`.
- Release path exercised with a local codesigning identity: dylib bundling (`libvpx.12.dylib` → Frameworks, load command rewritten), hardened-runtime flag + secure timestamp + entitlements confirmed on all four code objects, strict deep verify green, `-signed-unnotarized` artifact naming confirmed.
- Notarization gating: all three partial/invalid-config permutations fail early (exit 1) with precise messages, before the cargo build.
- `shellcheck scripts/bundle-macos.sh` clean; `actionlint` clean except the expected custom self-hosted label warning (same labels windows.yml uses).
- `cargo nextest run --bins` + `cargo clippy` green (no Rust touched).
