### PR TITLE
Transport S4c: current-session + managed-context neutral conversion; http_wire_response retired

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -63,7 +63,9 @@ filter = 'test(/^dashboard_control::(api_sessions|api_media)::tests::parity_/)'
 slow-timeout = { period = "60s", terminate-after = 4 }
 
 # The worktrees parity fixtures run the real inventory scan (git
-# subprocess per worktree — the worktree_inventory class above).
+# subprocess per worktree — the worktree_inventory class above); the
+# managed-context parity fixture walks the real ~/.intendant/logs
+# candidate scan (the routes_sessions home-scan class above).
 [[profile.default.overrides]]
-filter = 'test(/^dashboard_control::api_control::tests::parity_worktrees/)'
+filter = 'test(/^dashboard_control::api_control::tests::parity_/)'
 slow-timeout = { period = "60s", terminate-after = 4 }

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1995,7 +1995,9 @@ its operation per method/path from `federation_http_operation`.
 | POST | `/api/session/current/prune` | SessionManage | own origin | bounded | Prune rollback state for the current session |
 | POST | `/api/session/current/agent-output` | SessionManage | own origin | bounded | Fetch the current session's persisted agent output by id (POST-shaped read) |
 | POST | `/api/session/current/uploads` | SessionManage | own origin | streaming | Upload a file attachment (raw streamed body; name/destination in query) |
-| GET | `/api/session/current/uploads[/…]` | SessionManage | own origin | none | List uploads, or fetch one (subpath {id}/raw) |
+| GET | `/api/session/current/uploads` | SessionManage | own origin | none | List uploads for the current session |
+| GET | `/api/session/current/uploads/{id}/raw` | SessionManage | own origin | none | Fetch one upload's raw bytes (inline Content-Disposition) |
+| GET | `/api/session/current/uploads[/…]` | SessionManage | own origin | none | Unknown upload subpaths (handler-owned JSON 404) |
 | DELETE | `/api/session/current/uploads/{upload_id}` | SessionManage | own origin | none | Delete one upload (file + sidecar) |
 | DELETE | `/api/session/{id}` | SessionManage | own origin | none | Delete a session's data |
 | DELETE | `/api/session/{id}/{target}` | SessionManage | own origin | none | Delete one data kind for a session (recordings, frames, …) |

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -778,27 +778,31 @@ pub(crate) async fn api_managed_context_response(
         }
     };
     let home = crate::platform::home_dir();
-    let response = tokio::task::spawn_blocking(move || match kind {
-        "records" => crate::web_gateway::managed_context_records_response_from_home(
-            &request_line,
-            active_log_dir.as_deref(),
-            &home,
-        ),
-        "anchors" => crate::web_gateway::managed_context_anchors_response_from_home(
-            &request_line,
-            active_log_dir.as_deref(),
-            &home,
-        ),
-        "fission" => crate::web_gateway::managed_context_fission_response_from_home(
-            &request_line,
-            active_log_dir.as_deref(),
-            &home,
-        ),
-        _ => crate::web_gateway::managed_context_records_response_from_home(
-            &request_line,
-            active_log_dir.as_deref(),
-            &home,
-        ),
+    // Transitional raw-string render around the (now neutral) builders;
+    // the S4c tunnel commit replaces it with frame_api_response.
+    let response = tokio::task::spawn_blocking(move || {
+        crate::web_gateway::api_response_to_http_string(match kind {
+            "records" => crate::web_gateway::managed_context_records_response_from_home(
+                &request_line,
+                active_log_dir.as_deref(),
+                &home,
+            ),
+            "anchors" => crate::web_gateway::managed_context_anchors_response_from_home(
+                &request_line,
+                active_log_dir.as_deref(),
+                &home,
+            ),
+            "fission" => crate::web_gateway::managed_context_fission_response_from_home(
+                &request_line,
+                active_log_dir.as_deref(),
+                &home,
+            ),
+            _ => crate::web_gateway::managed_context_records_response_from_home(
+                &request_line,
+                active_log_dir.as_deref(),
+                &home,
+            ),
+        })
     })
     .await;
     let response = match response {

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -778,31 +778,27 @@ pub(crate) async fn api_managed_context_response(
         }
     };
     let home = crate::platform::home_dir();
-    // Transitional raw-string render around the (now neutral) builders;
-    // the S4c tunnel commit replaces it with frame_api_response.
-    let response = tokio::task::spawn_blocking(move || {
-        crate::web_gateway::api_response_to_http_string(match kind {
-            "records" => crate::web_gateway::managed_context_records_response_from_home(
-                &request_line,
-                active_log_dir.as_deref(),
-                &home,
-            ),
-            "anchors" => crate::web_gateway::managed_context_anchors_response_from_home(
-                &request_line,
-                active_log_dir.as_deref(),
-                &home,
-            ),
-            "fission" => crate::web_gateway::managed_context_fission_response_from_home(
-                &request_line,
-                active_log_dir.as_deref(),
-                &home,
-            ),
-            _ => crate::web_gateway::managed_context_records_response_from_home(
-                &request_line,
-                active_log_dir.as_deref(),
-                &home,
-            ),
-        })
+    let response = tokio::task::spawn_blocking(move || match kind {
+        "records" => crate::web_gateway::managed_context_records_response_from_home(
+            &request_line,
+            active_log_dir.as_deref(),
+            &home,
+        ),
+        "anchors" => crate::web_gateway::managed_context_anchors_response_from_home(
+            &request_line,
+            active_log_dir.as_deref(),
+            &home,
+        ),
+        "fission" => crate::web_gateway::managed_context_fission_response_from_home(
+            &request_line,
+            active_log_dir.as_deref(),
+            &home,
+        ),
+        _ => crate::web_gateway::managed_context_records_response_from_home(
+            &request_line,
+            active_log_dir.as_deref(),
+            &home,
+        ),
     })
     .await;
     let response = match response {
@@ -816,7 +812,7 @@ pub(crate) async fn api_managed_context_response(
             });
         }
     };
-    http_wire_response(id, response, "managed context")
+    frame_api_response(id, response, "managed context")
 }
 
 pub(crate) async fn api_mcp_tool_call_response(
@@ -1816,6 +1812,85 @@ mod tests {
             frame["result"],
             "the cache holds the served body"
         );
+    }
+
+    // ── S4c parity: managed context (the S4c envelope differences are
+    // enumerated on the current-session fixture set in api_sessions.rs;
+    // the tunnel's query synthesis is difference #5, the injected-status
+    // envelope difference #1) ──
+
+    #[tokio::test]
+    async fn parity_managed_context_shares_bodies_with_status_metadata() {
+        // A unique session id keeps the home-scoped candidate scan empty
+        // and deterministic on a live box; both lanes then serve the
+        // scoped empty bodies from the ONE neutral fn per kind.
+        let rt = runtime();
+        let session_id = format!(
+            "parity-mc-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let home = crate::platform::home_dir();
+        for (kind, empty_key) in [
+            ("anchors", "anchors"),
+            ("records", "records"),
+            ("fission", "groups"),
+        ] {
+            let request_line =
+                format!("GET /api/managed-context/{kind}?session_id={session_id} HTTP/1.1");
+            let response = match kind {
+                "anchors" => crate::web_gateway::managed_context_anchors_response_from_home(
+                    &request_line,
+                    None,
+                    &home,
+                ),
+                "records" => crate::web_gateway::managed_context_records_response_from_home(
+                    &request_line,
+                    None,
+                    &home,
+                ),
+                _ => crate::web_gateway::managed_context_fission_response_from_home(
+                    &request_line,
+                    None,
+                    &home,
+                ),
+            };
+            let (status, http_body) = parity_worktrees_http_body(response);
+            assert_eq!(status, 200, "{kind}");
+            assert_eq!(http_body[empty_key], serde_json::json!([]), "{kind}");
+
+            let frame = api_managed_context_response(
+                format!("parity-mc-{kind}"),
+                kind,
+                Some(&serde_json::json!({ "session_id": session_id })),
+                &rt,
+            )
+            .await;
+            let mut result = frame["result"].clone();
+            let map = result.as_object_mut().expect("result object");
+            assert_eq!(
+                map.remove("_httpStatus"),
+                Some(serde_json::json!(200)),
+                "{kind}: {frame}"
+            );
+            assert_eq!(
+                map.remove("_httpOk"),
+                Some(serde_json::json!(true)),
+                "{kind}"
+            );
+            assert_eq!(result, http_body, "{kind}");
+        }
+
+        // The tunnel-only missing-selector shape (difference #5): no
+        // session selector at all cannot be synthesized into a request
+        // line, so the tunnel answers its own decode error.
+        let frame =
+            api_managed_context_response("parity-mc-missing".to_string(), "records", None, &rt)
+                .await;
+        assert_eq!(frame["ok"], false);
+        assert_eq!(frame["error"], "missing query", "{frame}");
     }
 
     use crate::*;

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -713,101 +713,25 @@ pub(crate) async fn api_session_current_upload_raw_task_response(
     };
     let upload_id_for_stream = upload_id.clone();
     let read_result = tokio::task::spawn_blocking(move || {
-        let Some(descriptor) = crate::upload_store::find_upload(&upload_id, &session_dir, &scope)
-        else {
-            return Err((
-                404,
-                serde_json::json!({ "ok": false, "error": "upload not found" }),
-            ));
-        };
-        let metadata = std::fs::metadata(&descriptor.path).map_err(|e| {
-            (
-                500,
-                serde_json::json!({ "ok": false, "error": format!("stat upload: {e}") }),
-            )
-        })?;
-        let total_size = metadata.len();
-        if offset > total_size {
-            return Err((
-                416,
-                serde_json::json!({
-                    "ok": false,
-                    "error": "range start beyond upload size",
-                    "total_size": total_size,
-                }),
-            ));
-        }
-        let available = total_size.saturating_sub(offset);
-        let requested = length.unwrap_or(available).min(available);
-        if requested > crate::web_gateway::UPLOAD_MAX_BYTES as u64 {
-            return Err((
-                413,
-                serde_json::json!({
-                    "ok": false,
-                    "error": format!(
-                        "range too large: {} bytes (cap is {})",
-                        requested,
-                        crate::web_gateway::UPLOAD_MAX_BYTES
-                    ),
-                }),
-            ));
-        }
-        let transfer_len = usize::try_from(requested).map_err(|_| {
-            (
-                413,
-                serde_json::json!({ "ok": false, "error": "range too large for this platform" }),
-            )
-        })?;
-        let mut file = std::fs::File::open(&descriptor.path).map_err(|e| {
-            (
-                500,
-                serde_json::json!({ "ok": false, "error": format!("open upload: {e}") }),
-            )
-        })?;
-        file.seek(std::io::SeekFrom::Start(offset)).map_err(|e| {
-            (
-                500,
-                serde_json::json!({ "ok": false, "error": format!("seek upload: {e}") }),
-            )
-        })?;
-        let mut bytes = vec![0u8; transfer_len];
-        file.read_exact(&mut bytes).map_err(|e| {
-            (
-                500,
-                serde_json::json!({ "ok": false, "error": format!("read upload: {e}") }),
-            )
-        })?;
-        let end = offset.saturating_add(requested);
-        let descriptor_id = descriptor.id.clone();
-        let descriptor_name = descriptor.name.clone();
-        let descriptor_mime = descriptor.mime.clone();
-        Ok((
-            descriptor_name.clone(),
-            descriptor_mime.clone(),
-            bytes,
-            serde_json::json!({
-                "ok": true,
-                "id": descriptor_id,
-                "name": descriptor_name,
-                "filename": descriptor_name,
-                "mime": descriptor_mime,
-                "content_type": descriptor_mime,
-                "size": requested,
-                "total_size": total_size,
-                "offset": offset,
-                "range_start": offset,
-                "range_end": end,
-                "resumable": true,
-            }),
-        ))
+        crate::web_gateway::current_upload_raw_api_response(
+            &upload_id,
+            Some((offset, length)),
+            &session_dir,
+            &scope,
+        )
     })
     .await;
-    let (filename, content_type, bytes, result) = match read_result {
-        Ok(Ok(value)) => value,
-        Ok(Err((status, body))) => {
+    let response = match read_result {
+        Ok(Ok(response)) => response,
+        Ok(Err(err)) => {
             return ControlTaskResponse {
                 id: id.clone(),
-                frame: http_body_response(id, status, body.to_string(), "upload raw"),
+                frame: http_body_response(
+                    id,
+                    err.status(),
+                    upload_raw_tunnel_error_body(&err).to_string(),
+                    "upload raw",
+                ),
                 byte_stream: None,
                 done: true,
             };
@@ -826,19 +750,27 @@ pub(crate) async fn api_session_current_upload_raw_task_response(
             };
         }
     };
-    ControlTaskResponse {
-        id: id.clone(),
-        frame: serde_json::Value::Null,
-        byte_stream: Some(ControlByteStream {
-            id: id.clone(),
-            stream_id: format!("{id}:upload:{upload_id_for_stream}"),
-            content_type,
-            filename: Some(filename),
-            bytes,
-            result,
-        }),
-        done: true,
+    frame_api_task_response(
+        id,
+        response,
+        &format!("upload:{upload_id_for_stream}"),
+        "upload raw",
+    )
+}
+
+/// The tunnel's historical error bodies for the upload-raw content core:
+/// `{"ok":false,"error":…}` objects, the 416 additionally carrying
+/// `total_size` — versus HTTP's wildcard `{"error":…}` framing of the
+/// same [`crate::web_gateway::CurrentUploadRawError`] (the enumerated
+/// per-lane difference).
+fn upload_raw_tunnel_error_body(
+    err: &crate::web_gateway::CurrentUploadRawError,
+) -> serde_json::Value {
+    let mut body = serde_json::json!({ "ok": false, "error": err.message() });
+    if let crate::web_gateway::CurrentUploadRawError::RangeBeyondSize { total_size } = err {
+        body["total_size"] = serde_json::json!(total_size);
     }
+    body
 }
 
 pub(crate) async fn api_session_current_uploads_response(
@@ -860,12 +792,14 @@ pub(crate) async fn api_session_current_uploads_response(
     let session_dir =
         session_dir.unwrap_or_else(|| crate::web_gateway::pending_upload_session_dir(&scope));
     let result = tokio::task::spawn_blocking(move || {
-        serde_json::to_string(&crate::upload_store::list_uploads(&session_dir, &scope))
-            .unwrap_or_else(|_| "[]".to_string())
+        crate::web_gateway::current_uploads_list_api_response(&session_dir, &scope)
     })
     .await;
     match result {
-        Ok(body) => json_body_response(id, body, "current uploads"),
+        // The injected-status envelope only decorates OBJECT bodies —
+        // the uploads list array passes through untouched, as it always
+        // did under its historical body-only framing.
+        Ok(response) => frame_api_response(id, response, "current uploads"),
         Err(e) => serde_json::json!({
             "t": "response",
             "id": id,
@@ -899,7 +833,7 @@ pub(crate) async fn api_session_current_upload_task_response(
     let project_root = runtime.project_root.clone();
     let bus = runtime.bus.clone();
     let result = tokio::task::spawn_blocking(move || {
-        crate::web_gateway::current_upload_commit_response_body(
+        crate::web_gateway::current_upload_commit_api_response(
             project_root.as_deref(),
             session_log.as_ref(),
             daemon_session_id.as_deref(),
@@ -913,9 +847,7 @@ pub(crate) async fn api_session_current_upload_task_response(
     })
     .await;
     let frame = match result {
-        Ok((status, body)) => {
-            http_body_response(id.clone(), status_line_code(status), body, "current upload")
-        }
+        Ok(response) => frame_api_response(id.clone(), response, "current upload"),
         Err(e) => serde_json::json!({
             "t": "response",
             "id": id.clone(),
@@ -961,9 +893,9 @@ pub(crate) async fn api_session_current_agent_output_response(
 ) -> serde_json::Value {
     let body_text = params_body_text(params);
     match active_session_log_dir(runtime).await {
-        Ok(Some(log_dir)) => http_wire_response(
+        Ok(Some(log_dir)) => frame_api_response(
             id,
-            crate::web_gateway::current_agent_output_post_response(&body_text, &log_dir),
+            crate::web_gateway::current_agent_output_api_response(&body_text, &log_dir),
             "agent output",
         ),
         Ok(None) => http_body_response(
@@ -1022,8 +954,11 @@ pub(crate) async fn api_session_current_history_response(
     runtime: &ControlRuntime,
 ) -> serde_json::Value {
     let (file_watcher, _) = active_history_handles(runtime).await;
-    let (status_line, body) = crate::web_gateway::handle_history_get(file_watcher.as_ref()).await;
-    http_body_response(id, status_line_code(status_line), body, "session history")
+    frame_api_response(
+        id,
+        crate::web_gateway::current_history_api_response(file_watcher.as_ref()).await,
+        "session history",
+    )
 }
 
 pub(crate) async fn api_session_current_rollback_response(
@@ -1033,14 +968,17 @@ pub(crate) async fn api_session_current_rollback_response(
 ) -> serde_json::Value {
     let body_text = params_body_text(params);
     let (file_watcher, agent_state) = active_history_handles(runtime).await;
-    let (status_line, body) = crate::web_gateway::handle_history_rollback(
-        &body_text,
-        file_watcher.as_ref(),
-        agent_state.as_ref(),
-        &runtime.bus,
+    frame_api_response(
+        id,
+        crate::web_gateway::current_rollback_api_response(
+            &body_text,
+            file_watcher.as_ref(),
+            agent_state.as_ref(),
+            &runtime.bus,
+        )
+        .await,
+        "session rollback",
     )
-    .await;
-    http_body_response(id, status_line_code(status_line), body, "session rollback")
 }
 
 pub(crate) async fn api_session_current_redo_response(
@@ -1048,9 +986,12 @@ pub(crate) async fn api_session_current_redo_response(
     runtime: &ControlRuntime,
 ) -> serde_json::Value {
     let (file_watcher, agent_state) = active_history_handles(runtime).await;
-    let (status_line, body) =
-        crate::web_gateway::handle_history_redo(file_watcher.as_ref(), agent_state.as_ref()).await;
-    http_body_response(id, status_line_code(status_line), body, "session redo")
+    frame_api_response(
+        id,
+        crate::web_gateway::current_redo_api_response(file_watcher.as_ref(), agent_state.as_ref())
+            .await,
+        "session redo",
+    )
 }
 
 pub(crate) async fn api_session_current_prune_response(
@@ -1058,8 +999,11 @@ pub(crate) async fn api_session_current_prune_response(
     runtime: &ControlRuntime,
 ) -> serde_json::Value {
     let (file_watcher, _) = active_history_handles(runtime).await;
-    let (status_line, body) = crate::web_gateway::handle_history_prune(file_watcher.as_ref()).await;
-    http_body_response(id, status_line_code(status_line), body, "session prune")
+    frame_api_response(
+        id,
+        crate::web_gateway::current_prune_api_response(file_watcher.as_ref()).await,
+        "session prune",
+    )
 }
 
 pub(crate) async fn api_session_current_changes_response(
@@ -1071,7 +1015,7 @@ pub(crate) async fn api_session_current_changes_response(
     let (snapshot_dir, project_root) = active_changes_handles(runtime).await;
     let home = crate::platform::home_dir();
     let result = tokio::task::spawn_blocking(move || {
-        crate::web_gateway::handle_changes_request_for_home(
+        crate::web_gateway::session_current_changes_api_response(
             &request_line,
             snapshot_dir.as_deref(),
             project_root.as_deref(),
@@ -1080,9 +1024,7 @@ pub(crate) async fn api_session_current_changes_response(
     })
     .await;
     match result {
-        Ok((status_line, body)) => {
-            http_body_response(id, status_line_code(status_line), body, "session changes")
-        }
+        Ok(response) => frame_api_response(id, response, "session changes"),
         Err(e) => serde_json::json!({
             "t": "response",
             "id": id,
@@ -1156,23 +1098,18 @@ pub(crate) async fn api_session_current_upload_delete_response(
             );
         }
     };
+    let bus = runtime.bus.clone();
     let result = tokio::task::spawn_blocking(move || {
-        crate::web_gateway::current_upload_delete_response_body(
+        crate::web_gateway::current_upload_delete_api_response(
             project_root.as_deref(),
             session_dir.as_deref(),
             &upload_id,
+            &bus,
         )
     })
     .await;
     match result {
-        Ok((status_line, body, deleted_id)) => {
-            if let Some(id) = deleted_id {
-                runtime
-                    .bus
-                    .send(crate::event::AppEvent::UploadDeleted { id });
-            }
-            http_body_response(id, status_line_code(status_line), body, "upload delete")
-        }
+        Ok(response) => frame_api_response(id, response, "upload delete"),
         Err(e) => serde_json::json!({
             "t": "response",
             "id": id,
@@ -2051,5 +1988,318 @@ mod tests {
         .await;
         assert_eq!(tunnel_result_body(&frame, 400), http_body);
         assert_eq!(http_body["error"], "missing snapshot selector");
+    }
+
+    // ── S4c parity: current-session + managed-context (design §8) ──
+    //
+    // Extends the S4a (above) and S4b (api_control.rs) enumerations.
+    // The S4c-specific envelope differences, deliberate and pinned
+    // across this slice's fixtures (current-session family here;
+    // managed-context in api_control.rs):
+    //
+    //  1. All thirteen twins ride the injected-status envelope
+    //     (frame_api_response → http_body_response): result OBJECTS
+    //     gain _httpStatus/_httpOk matching the HTTP status; the
+    //     uploads list (array body) passes through undecorated —
+    //     byte-identical to its historical json_body_response framing.
+    //  2. Header tails stay HTTP-lane decoration: the current/* family
+    //     and upload POST/list/raw ride the wildcard-CORS tail,
+    //     managed-context and the upload delete the canonical tail,
+    //     raw fetches the inline Content-Disposition; the tunnel
+    //     renders none of them.
+    //  3. Transport-owned upload carriage: HTTP streams the raw POST
+    //     body (100-continue, spool, its own 413/400 wordings); the
+    //     tunnel spools upload_start/chunk/end frames with its own
+    //     wire-integrity errors (sequence/size mismatch, base64). The
+    //     commit leg is the one shared neutral fn. The raw read is one
+    //     unbounded full body on HTTP but ranged +
+    //     UPLOAD_MAX_BYTES-capped on the tunnel (the 416/413 shapes are
+    //     tunnel-only), over the same content core.
+    //  4. Content-core error framing stays per-lane on the raw read:
+    //     wildcard `{"error":…}` (HTTP) vs `{"ok":false,"error":…}`
+    //     with the 416 total_size sidecar (tunnel), both built from the
+    //     one CurrentUploadRawError.
+    //  5. Transport-owned param decode: tunnel id/offset/length aliases
+    //     and defaults, changes path/query synthesis
+    //     (changes_request_line), managed-context query synthesis
+    //     (managed_context_request_line, whose missing-query shape is
+    //     tunnel-only); HTTP takes raw path segments and query strings.
+    //  6. Task-failure and resolution shapes stay per-lane: ok:false
+    //     frames vs in-band HTTP errors; both lanes build their
+    //     lock-poisoned 500s and the agent-output no-active-log 404
+    //     with the same wording but their own framing.
+
+    #[tokio::test]
+    async fn parity_current_history_family_shares_bodies_with_status_metadata() {
+        // No file watcher: the 503 shape on both lanes, store-free.
+        let rt = runtime();
+        let (status, http_body) =
+            http_status_and_body(crate::web_gateway::current_history_api_response(None).await);
+        assert_eq!(status, 503);
+        let frame = api_session_current_history_response("parity-hist".to_string(), &rt).await;
+        assert_eq!(tunnel_result_body(&frame, 503), http_body);
+        assert_eq!(http_body["error"], "file watcher not active");
+
+        let frame = api_session_current_rollback_response(
+            "parity-rollback".to_string(),
+            Some(&serde_json::json!({ "round_id": 1 })),
+            &rt,
+        )
+        .await;
+        let (status, http_body) = http_status_and_body(
+            crate::web_gateway::current_rollback_api_response(
+                r#"{"round_id":1}"#,
+                None,
+                None,
+                &rt.bus,
+            )
+            .await,
+        );
+        assert_eq!(status, 503);
+        assert_eq!(tunnel_result_body(&frame, 503), http_body);
+
+        let frame = api_session_current_redo_response("parity-redo".to_string(), &rt).await;
+        let (status, http_body) = http_status_and_body(
+            crate::web_gateway::current_redo_api_response(None, None).await,
+        );
+        assert_eq!(status, 503);
+        assert_eq!(tunnel_result_body(&frame, 503), http_body);
+
+        let frame = api_session_current_prune_response("parity-prune".to_string(), &rt).await;
+        let (status, http_body) =
+            http_status_and_body(crate::web_gateway::current_prune_api_response(None).await);
+        assert_eq!(status, 503);
+        assert_eq!(tunnel_result_body(&frame, 503), http_body);
+    }
+
+    #[tokio::test]
+    async fn parity_current_changes_shares_bodies_with_status_metadata() {
+        // No snapshot dir / project root: the 503 watcher-absent shape.
+        // The tunnel synthesizes the request line from params
+        // (difference #5); both lanes then run the one neutral fn.
+        let rt = runtime();
+        let home = tempfile::tempdir().unwrap();
+        let (status, http_body) = http_status_and_body(
+            crate::web_gateway::session_current_changes_api_response(
+                "GET /api/session/current/changes HTTP/1.1",
+                None,
+                None,
+                home.path(),
+            ),
+        );
+        assert_eq!(status, 503);
+        let frame =
+            api_session_current_changes_response("parity-changes".to_string(), None, &rt).await;
+        assert_eq!(tunnel_result_body(&frame, 503), http_body);
+        assert_eq!(http_body["error"], "file watcher not active");
+    }
+
+    #[tokio::test]
+    async fn parity_current_agent_output_shares_bodies_with_status_metadata() {
+        let (session_id, log_dir) = parity_session_fixture("parity-current-output");
+        {
+            let rt = runtime();
+            let log = crate::session_log::SessionLog::open(log_dir.clone()).unwrap();
+            {
+                let mut session = rt.shared_session.write().await;
+                session.session_log = Some(Arc::new(std::sync::Mutex::new(log)));
+            }
+
+            // Success: one persisted id — found in the primary dir, so
+            // neither lane runs the fallback sweep.
+            let (status, http_body) = http_status_and_body(
+                crate::web_gateway::current_agent_output_api_response(
+                    r#"{"ids":["parity-out-1"]}"#,
+                    &log_dir,
+                ),
+            );
+            assert_eq!(status, 200);
+            assert_eq!(http_body["outputs"][0]["output_id"], "parity-out-1");
+            let frame = api_session_current_agent_output_response(
+                "parity-current-output".to_string(),
+                Some(&serde_json::json!({ "ids": ["parity-out-1"] })),
+                &rt,
+            )
+            .await;
+            assert_eq!(tunnel_result_body(&frame, 200), http_body);
+
+            // Decode error: 400 missing-ids on both lanes.
+            let (status, http_body) = http_status_and_body(
+                crate::web_gateway::current_agent_output_api_response("{}", &log_dir),
+            );
+            assert_eq!(status, 400);
+            let frame = api_session_current_agent_output_response(
+                "parity-current-output-400".to_string(),
+                Some(&serde_json::json!({})),
+                &rt,
+            )
+            .await;
+            assert_eq!(tunnel_result_body(&frame, 400), http_body);
+            assert_eq!(http_body["error"], "missing output ids");
+        }
+        std::fs::remove_dir_all(&log_dir)
+            .unwrap_or_else(|e| panic!("cleanup {session_id}: {e}"));
+    }
+
+    #[tokio::test]
+    async fn parity_current_uploads_list_and_delete_share_bodies() {
+        let project = tempfile::tempdir().unwrap();
+        let mut rt = runtime();
+        rt.project_root = Some(project.path().to_path_buf());
+        {
+            let mut session = rt.shared_session.write().await;
+            session.project_root_for_changes = Some(project.path().to_path_buf());
+        }
+        let scope = crate::global_store::StoreScope::resolve(Some(project.path()));
+        let pending = crate::web_gateway::pending_upload_session_dir(&scope);
+
+        // Empty list: the array body passes both envelopes undecorated
+        // (difference #1).
+        let (status, http_body) = http_status_and_body(
+            crate::web_gateway::current_uploads_list_api_response(&pending, &scope),
+        );
+        assert_eq!(status, 200);
+        assert_eq!(http_body, serde_json::json!([]));
+        let frame =
+            api_session_current_uploads_response("parity-uploads-list".to_string(), &rt).await;
+        assert_eq!(tunnel_plain_body(&frame), http_body);
+
+        // Idempotent delete of a missing id: 200 {"ok":true} on both
+        // lanes (canonical tail on HTTP — difference #2).
+        let (status, http_body) = http_status_and_body(
+            crate::web_gateway::current_upload_delete_api_response(
+                Some(project.path()),
+                None,
+                "parity-nope",
+                &rt.bus,
+            ),
+        );
+        assert_eq!(status, 200);
+        let frame = api_session_current_upload_delete_response(
+            "parity-upload-delete".to_string(),
+            Some(&serde_json::json!({ "upload_id": "parity-nope" })),
+            &rt,
+        )
+        .await;
+        assert_eq!(tunnel_result_body(&frame, 200), http_body);
+        assert_eq!(http_body, serde_json::json!({ "ok": true }));
+    }
+
+    #[tokio::test]
+    async fn parity_current_upload_commit_and_raw_share_content() {
+        use std::io::Write as _;
+        let project = tempfile::tempdir().unwrap();
+        let mut rt = runtime();
+        rt.project_root = Some(project.path().to_path_buf());
+        {
+            let mut session = rt.shared_session.write().await;
+            session.project_root_for_changes = Some(project.path().to_path_buf());
+        }
+        let payload = b"parity staged upload bytes".to_vec();
+
+        // Tunnel commit: the upload lane's spooled frames end in the
+        // same shared neutral fn the HTTP POST runs (difference #3 —
+        // only the carriage differs).
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(&payload).unwrap();
+        let upload = InboundUploadState {
+            method: "api_session_current_upload".to_string(),
+            params: serde_json::json!({ "name": "parity.txt", "mime": "text/plain" }),
+            tmp,
+            total_bytes: payload.len(),
+            expected_chunks: 1,
+            next_seq: 1,
+            received_bytes: payload.len(),
+        };
+        let commit = api_session_current_upload_task_response(
+            "parity-upload-commit".to_string(),
+            upload,
+            rt.clone(),
+        )
+        .await;
+        let tunnel_descriptor = tunnel_result_body(&commit.frame, 200);
+        assert_eq!(tunnel_descriptor["name"], "parity.txt");
+        let upload_id = tunnel_descriptor["id"].as_str().expect("id").to_string();
+
+        // HTTP commit through the same neutral fn: same descriptor
+        // shape (ids/paths are store-generated per commit).
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(&payload).unwrap();
+        let (status, http_descriptor) = http_status_and_body(
+            crate::web_gateway::current_upload_commit_api_response(
+                Some(project.path()),
+                None,
+                Some("parity-session"),
+                "parity.txt",
+                "text/plain",
+                crate::upload_store::UploadDestination::Task,
+                tmp,
+                payload.len(),
+                &rt.bus,
+            ),
+        );
+        assert_eq!(status, 200);
+        assert_eq!(
+            tunnel_descriptor.as_object().unwrap().keys().collect::<Vec<_>>(),
+            http_descriptor.as_object().unwrap().keys().collect::<Vec<_>>(),
+        );
+
+        // Raw read of the tunnel-committed upload: identical bytes on
+        // both lanes over the one content core; the tunnel's
+        // byte_stream_end.result meta and HTTP's header tail are the
+        // per-lane decorations (differences #2/#3).
+        let scope = crate::global_store::StoreScope::resolve(Some(project.path()));
+        let pending = crate::web_gateway::pending_upload_session_dir(&scope);
+        let http_raw = crate::web_gateway::current_upload_raw_api_response(
+            &upload_id,
+            None,
+            &pending,
+            &scope,
+        )
+        .unwrap_or_else(|_| panic!("http raw read"));
+        let (http_bytes, http_meta) = match &http_raw {
+            crate::web_gateway::ApiResponse::Bytes { bytes, meta, .. } => {
+                let crate::web_gateway::BytesPayload::InMemory(payload) = bytes;
+                (payload.clone(), meta.clone())
+            }
+            crate::web_gateway::ApiResponse::Json { .. } => panic!("raw read must be bytes"),
+        };
+        assert_eq!(http_bytes, payload);
+        let raw = api_session_current_upload_raw_task_response(
+            "parity-upload-raw".to_string(),
+            Some(&serde_json::json!({ "id": upload_id })),
+            &rt,
+        )
+        .await;
+        let stream = raw.byte_stream.expect("tunnel raw byte stream");
+        assert_eq!(stream.bytes, payload);
+        assert_eq!(stream.result, http_meta);
+        assert_eq!(stream.result["range_end"], payload.len());
+        assert_eq!(stream.result["resumable"], true);
+
+        // Missing id: the shared content core's NotFound framed
+        // per-lane (difference #4).
+        let missing = crate::web_gateway::current_upload_raw_api_response(
+            "parity-missing",
+            None,
+            &pending,
+            &scope,
+        );
+        let err = match missing {
+            Err(err) => err,
+            Ok(_) => panic!("missing upload must err"),
+        };
+        assert_eq!(err.status(), 404);
+        assert_eq!(err.message(), "upload not found");
+        let raw = api_session_current_upload_raw_task_response(
+            "parity-upload-raw-404".to_string(),
+            Some(&serde_json::json!({ "id": "parity-missing" })),
+            &rt,
+        )
+        .await;
+        assert!(raw.byte_stream.is_none());
+        assert_eq!(raw.frame["result"]["_httpStatus"], 404);
+        assert_eq!(raw.frame["result"]["ok"], false);
+        assert_eq!(raw.frame["result"]["error"], "upload not found");
     }
 }

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -122,16 +122,6 @@ const fn uploadable(name: &'static str, op: PeerOperation) -> ControlMethodSpec 
     }
 }
 
-/// Upload-frame-only method (no request-lane dispatch, no feature entry).
-const fn upload_only(name: &'static str, op: PeerOperation) -> ControlMethodSpec {
-    ControlMethodSpec {
-        name,
-        op: Some(op),
-        advertised: false,
-        upload: true,
-    }
-}
-
 /// The residue half of the tunnel method table: methods not (yet) declared
 /// as a `tunnel:` column on a `gateway_routes::ROUTES` row. Do NOT add a
 /// method here if its HTTP twin has a route row — declare it on the row

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -264,25 +264,12 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
     // The session artifact reads (api_session_report,
     // api_session_recordings, api_session_recording_asset,
     // api_session_frame_asset), api_session_delete, and the worktrees
-    // quartet live as tunnel columns on their route rows (S4b).
+    // quartet live as tunnel columns on their route rows (S4b), and so
+    // does the whole current-session family — history/rollback/redo/
+    // prune, changes, agent-output, uploads list/raw/delete, and the
+    // upload-frame-only api_session_current_upload (S4c).
     method("api_sessions_stream", PeerOperation::SessionInspect),
-    method("api_session_current_history", PeerOperation::SessionManage),
-    method("api_session_current_rollback", PeerOperation::SessionManage),
-    method("api_session_current_redo", PeerOperation::SessionManage),
-    method("api_session_current_prune", PeerOperation::SessionManage),
-    method("api_session_current_changes", PeerOperation::SessionManage),
-    method("api_session_current_uploads", PeerOperation::SessionManage),
-    method("api_session_current_upload_raw", PeerOperation::SessionManage),
-    method(
-        "api_session_current_upload_delete",
-        PeerOperation::SessionManage,
-    ),
-    method(
-        "api_session_current_agent_output",
-        PeerOperation::SessionManage,
-    ),
     method("api_session_control_msg", PeerOperation::SessionManage),
-    upload_only("api_session_current_upload", PeerOperation::SessionManage),
     method("api_transfer_jobs", PeerOperation::FilesystemRead),
     method("api_transfer_download_read", PeerOperation::FilesystemRead),
     // The api_fs_* methods live as tunnel columns on their route rows
@@ -341,9 +328,8 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
         PeerOperation::SessionInspect,
     ),
     method("api_dashboard_bootstrap", PeerOperation::SessionInspect),
-    method("api_managed_context_records", PeerOperation::SessionInspect),
-    method("api_managed_context_anchors", PeerOperation::SessionInspect),
-    method("api_managed_context_fission", PeerOperation::SessionInspect),
+    // The api_managed_context_* trio lives as tunnel columns on the
+    // /api/managed-context/* route rows (S4c).
     method("api_external_agents", PeerOperation::SessionInspect),
 ];
 
@@ -3203,43 +3189,43 @@ mod tests {
             ("api_session_delete", Row, Some(Op::SessionManage)),
             (
                 "api_session_current_history",
-                Residue,
+                Row,
                 Some(Op::SessionManage),
             ),
             (
                 "api_session_current_rollback",
-                Residue,
+                Row,
                 Some(Op::SessionManage),
             ),
-            ("api_session_current_redo", Residue, Some(Op::SessionManage)),
+            ("api_session_current_redo", Row, Some(Op::SessionManage)),
             (
                 "api_session_current_prune",
-                Residue,
+                Row,
                 Some(Op::SessionManage),
             ),
             (
                 "api_session_current_changes",
-                Residue,
+                Row,
                 Some(Op::SessionManage),
             ),
             (
                 "api_session_current_uploads",
-                Residue,
+                Row,
                 Some(Op::SessionManage),
             ),
             (
                 "api_session_current_upload_raw",
-                Residue,
+                Row,
                 Some(Op::SessionManage),
             ),
             (
                 "api_session_current_upload_delete",
-                Residue,
+                Row,
                 Some(Op::SessionManage),
             ),
             (
                 "api_session_current_agent_output",
-                Residue,
+                Row,
                 Some(Op::SessionManage),
             ),
             ("api_session_control_msg", Residue, Some(Op::SessionManage)),
@@ -3248,7 +3234,7 @@ mod tests {
             ("api_worktrees_merge", Row, Some(Op::SessionManage)),
             (
                 "api_session_current_upload",
-                Residue,
+                Row,
                 Some(Op::SessionManage),
             ),
             ("api_transfer_jobs", Residue, Some(Op::FilesystemRead)),
@@ -3352,17 +3338,17 @@ mod tests {
             ("api_dashboard_bootstrap", Residue, Some(Op::SessionInspect)),
             (
                 "api_managed_context_records",
-                Residue,
+                Row,
                 Some(Op::SessionInspect),
             ),
             (
                 "api_managed_context_anchors",
-                Residue,
+                Row,
                 Some(Op::SessionInspect),
             ),
             (
                 "api_managed_context_fission",
-                Residue,
+                Row,
                 Some(Op::SessionInspect),
             ),
             ("api_external_agents", Residue, Some(Op::SessionInspect)),

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -1758,23 +1758,6 @@ fn http_body_response(id: String, status: u16, body: String, label: &str) -> ser
     }
 }
 
-fn http_wire_response(id: String, response: String, label: &str) -> serde_json::Value {
-    let (status, body) = split_http_response(&response);
-    http_body_response(id, status, body.to_string(), label)
-}
-
-fn split_http_response(response: &str) -> (u16, &str) {
-    let (head, body) = response.split_once("\r\n\r\n").unwrap_or(("", response));
-    let status = head
-        .lines()
-        .next()
-        .and_then(|line| line.strip_prefix("HTTP/1.1 "))
-        .and_then(|line| line.split_whitespace().next())
-        .and_then(|code| code.parse::<u16>().ok())
-        .unwrap_or(200);
-    (status, body)
-}
-
 // One status-line parser across both lanes (the api core's (status,
 // body) helper vocabulary).
 pub(crate) use crate::web_gateway::status_line_code;
@@ -4374,17 +4357,6 @@ mod tests {
             "GET /api/managed-context/anchors?session_id=wrapper+id&backend_session_id=thread%2F1&intendant_session_id=daemon%2Bsession HTTP/1.1"
         );
         assert!(managed_context_request_line("fission", &serde_json::json!({})).is_none());
-    }
-
-    #[test]
-    fn http_wire_response_preserves_http_status_metadata() {
-        let response = "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\n\r\n{\"error\":\"missing\"}";
-        let frame = http_wire_response("m1".into(), response.into(), "managed context");
-        assert_eq!(frame["t"], "response");
-        assert_eq!(frame["ok"], true);
-        assert_eq!(frame["result"]["error"], "missing");
-        assert_eq!(frame["result"]["_httpStatus"], 404);
-        assert_eq!(frame["result"]["_httpOk"], false);
     }
 
 }

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -331,6 +331,18 @@ const fn tunnel_uploadable(name: &'static str) -> TunnelSpec {
     }
 }
 
+/// Upload-frame-only tunnel twin: never dispatched on the request lane,
+/// advertised through the "upload_frames" transport feature rather than
+/// by name (the legacy `upload_only` shape).
+const fn tunnel_upload_only(name: &'static str) -> TunnelSpec {
+    TunnelSpec {
+        name,
+        op_override: None,
+        advertised: false,
+        upload: true,
+    }
+}
+
 pub(crate) struct Route {
     pub(crate) method: RouteMethod,
     pub(crate) pattern: PathPattern,
@@ -551,7 +563,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::SessionCurrentChanges,
         "List the session's changed files, or the unified diff for one file (subpath)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_session_current_changes")),
     op_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/session/current/history"),
@@ -559,7 +572,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::CurrentHistory,
         "Serialized rollback History for the current session",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_session_current_history")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/session/current/rollback"),
@@ -567,7 +581,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::CurrentRollback,
         "Roll the current session back to a round (optionally reverting files)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_session_current_rollback")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/session/current/redo"),
@@ -575,7 +590,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::CurrentRedo,
         "Redo the last rolled-back round",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_session_current_redo")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/session/current/prune"),
@@ -583,7 +599,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::CurrentPrune,
         "Prune rollback state for the current session",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_session_current_prune")),
     // POST-shaped read (the body carries output ids; nothing is written).
     // Manage-gated only because the whole current/* family deliberately
     // is (see the sub-router comment below), not because it mutates.
@@ -594,7 +611,10 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::CurrentAgentOutput,
         "Fetch the current session's persisted agent output by id (POST-shaped read)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_session_current_agent_output")),
+    // The staged-upload POST's datachannel twin arrives only as upload
+    // frames (upload_start/chunk/end), never on the request lane.
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/session/current/uploads"),
@@ -602,14 +622,44 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Streaming,
         RouteHandlerId::CurrentUploadsPost,
         "Upload a file attachment (raw streamed body; name/destination in query)",
-    ),
+    )
+    .with_tunnel(tunnel_upload_only("api_session_current_upload")),
+    // The uploads GET family: list (exact) and raw-fetch (segments) rows
+    // carved ahead of the Under catch-all so each carries its
+    // datachannel twin; all three share the handler, which routes by
+    // path (the catch-all keeps the handler-owned JSON 404 for unknown
+    // upload subpaths).
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Exact("/api/session/current/uploads"),
+        PeerOperation::SessionManage,
+        BodyPolicy::None,
+        RouteHandlerId::CurrentUploadsGet,
+        "List uploads for the current session",
+    )
+    .with_tunnel(tunnel_method("api_session_current_uploads")),
+    // Capture named `id`: the facade's HTTP adapter lifts template
+    // segments by name and the raw fetch's callers pass `{ id }` (the
+    // tunnel's primary alias) — pinned by the descriptor parity test.
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Segments(
+            "/api/session/current/uploads",
+            &[SegmentSpec::Capture("id"), SegmentSpec::Literal("raw")],
+        ),
+        PeerOperation::SessionManage,
+        BodyPolicy::None,
+        RouteHandlerId::CurrentUploadsGet,
+        "Fetch one upload's raw bytes (inline Content-Disposition)",
+    )
+    .with_tunnel(tunnel_method("api_session_current_upload_raw")),
     op_route(
         RouteMethod::Get,
         PathPattern::Under("/api/session/current/uploads"),
         PeerOperation::SessionManage,
         BodyPolicy::None,
         RouteHandlerId::CurrentUploadsGet,
-        "List uploads, or fetch one (subpath {id}/raw)",
+        "Unknown upload subpaths (handler-owned JSON 404)",
     ),
     op_route(
         RouteMethod::Delete,
@@ -621,7 +671,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::CurrentUploadDelete,
         "Delete one upload (file + sidecar)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_session_current_upload_delete")),
     // ── Session deletion. Five accepted wire shapes (native DELETE plus
     //    the WKWebView POST fallback with a literal `delete` suffix); one
     //    handler serves all of them by filtering the `delete` segment.
@@ -846,7 +897,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::McAnchors,
         "Managed-context anchor catalog",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_managed_context_anchors")),
     op_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/managed-context/records"),
@@ -854,7 +906,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::McRecords,
         "Managed-context record index",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_managed_context_records")),
     op_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/managed-context/fission"),
@@ -862,7 +915,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::McFission,
         "Managed-context fission state",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_managed_context_fission")),
     // ── Worktrees.
     op_route(
         RouteMethod::Post,
@@ -1679,6 +1733,7 @@ mod tests {
         // Handlers deliberately serving several wire shapes; their rows
         // must be contiguous so the sharing is visible in the table.
         let shared: &[RouteHandlerId] = &[
+            RouteHandlerId::CurrentUploadsGet,
             RouteHandlerId::SessionDelete,
             RouteHandlerId::SessionSubRouter,
             RouteHandlerId::AccessIamGrants,
@@ -1882,6 +1937,24 @@ mod tests {
         let (route, captures) = match_route("DELETE", "/api/session/current/uploads/u1").unwrap();
         assert_eq!(route.handler, RouteHandlerId::CurrentUploadDelete);
         assert_eq!(captures, vec!["u1"]);
+        // The uploads GET family: list on the exact row, raw fetch on the
+        // segments row, anything else on the Under catch-all — all three
+        // share the handler (declared shared group), so the carve is
+        // routing-neutral; it exists to give list and raw their own
+        // datachannel twins.
+        let (route, captures) = match_route("GET", "/api/session/current/uploads").unwrap();
+        assert_eq!(route.pattern, PathPattern::Exact("/api/session/current/uploads"));
+        assert_eq!(route.handler, RouteHandlerId::CurrentUploadsGet);
+        assert_eq!(route.tunnel.as_ref().map(|spec| spec.name), Some("api_session_current_uploads"));
+        assert!(captures.is_empty());
+        let (route, captures) = match_route("GET", "/api/session/current/uploads/u1/raw").unwrap();
+        assert_eq!(route.handler, RouteHandlerId::CurrentUploadsGet);
+        assert_eq!(route.tunnel.as_ref().map(|spec| spec.name), Some("api_session_current_upload_raw"));
+        assert_eq!(captures, vec!["u1"]);
+        let (route, _) = match_route("GET", "/api/session/current/uploads/u1/other").unwrap();
+        assert_eq!(route.handler, RouteHandlerId::CurrentUploadsGet);
+        assert_eq!(route.pattern, PathPattern::Under("/api/session/current/uploads"));
+        assert!(route.tunnel.is_none());
         // Agent-output: current-exact row first, then the by-id row.
         let (route, _) = match_route("POST", "/api/session/current/agent-output").unwrap();
         assert_eq!(route.handler, RouteHandlerId::CurrentAgentOutput);

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -445,6 +445,8 @@ pub(crate) async fn serve_http_request(
                     request_line,
                     project_root_for_changes,
                     snapshot_dir,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
                 )
                 .await;
             }
@@ -563,21 +565,55 @@ pub(crate) async fn serve_http_request(
                 .await;
             }
             RouteHandlerId::CurrentHistory => {
-                return handle_current_history(stream, file_watcher).await;
+                return handle_current_history(
+                    stream,
+                    file_watcher,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::CurrentRollback => {
-                return handle_current_rollback(stream, route_body, bus, query_ctx, file_watcher)
-                    .await;
+                return handle_current_rollback(
+                    stream,
+                    route_body,
+                    bus,
+                    query_ctx,
+                    file_watcher,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::CurrentRedo => {
-                return handle_current_redo(stream, query_ctx, file_watcher).await;
+                return handle_current_redo(
+                    stream,
+                    query_ctx,
+                    file_watcher,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::CurrentPrune => {
-                return handle_current_prune(stream, file_watcher).await;
+                return handle_current_prune(
+                    stream,
+                    file_watcher,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::CurrentAgentOutput => {
-                return handle_current_agent_output(stream, route_body, query_ctx, session_log)
-                    .await;
+                return handle_current_agent_output(
+                    stream,
+                    route_body,
+                    query_ctx,
+                    session_log,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::CurrentUploadsPost => {
                 return handle_current_uploads_post(
@@ -589,6 +625,8 @@ pub(crate) async fn serve_http_request(
                     project_root_for_changes,
                     session_log,
                     daemon_session_id,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
                 )
                 .await;
             }
@@ -598,6 +636,8 @@ pub(crate) async fn serve_http_request(
                     request_line,
                     project_root_for_changes,
                     session_log,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
                 )
                 .await;
             }
@@ -608,6 +648,8 @@ pub(crate) async fn serve_http_request(
                     bus,
                     project_root_for_changes,
                     session_log,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
                 )
                 .await;
             }
@@ -635,13 +677,34 @@ pub(crate) async fn serve_http_request(
                     .await;
             }
             RouteHandlerId::McAnchors => {
-                return handle_mc_anchors(stream, request_line, session_log).await;
+                return handle_mc_anchors(
+                    stream,
+                    request_line,
+                    session_log,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::McRecords => {
-                return handle_mc_records(stream, request_line, session_log).await;
+                return handle_mc_records(
+                    stream,
+                    request_line,
+                    session_log,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::McFission => {
-                return handle_mc_fission(stream, request_line, session_log).await;
+                return handle_mc_fission(
+                    stream,
+                    request_line,
+                    session_log,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::SessionsStream => {
                 return handle_sessions_stream(stream, request_line).await;

--- a/src/bin/caller/web_gateway/routes_files.rs
+++ b/src/bin/caller/web_gateway/routes_files.rs
@@ -3788,4 +3788,170 @@ mod tests {
         );
         assert!(target.join("kept.txt").exists());
     }
+    // ── S4c golden transcripts: the staged-upload family (design §6 S4,
+    // risk R1). The POST body rides the `discard` prefix (dispatch's
+    // already-read bytes), so the duplex harness needs no writer side.
+
+    async fn collect_upload_handler_response<Fut>(run: impl FnOnce(DemuxStream) -> Fut) -> Vec<u8>
+    where
+        Fut: std::future::Future<Output = ()>,
+    {
+        use tokio::io::AsyncReadExt;
+        let (mut client, server) = tokio::io::duplex(1 << 20);
+        run(Box::pin(server)).await;
+        let mut response = Vec::new();
+        client.read_to_end(&mut response).await.unwrap();
+        response
+    }
+
+    fn upload_golden_tail() -> &'static str {
+        "Cache-Control: no-cache\r\nAccess-Control-Allow-Origin: *\r\nConnection: close\r\n\r\n"
+    }
+
+    /// POST success over a project-rooted store: framing pinned exactly
+    /// around the store-generated descriptor body.
+    #[tokio::test]
+    async fn golden_current_uploads_post_project_rooted_transcript() {
+        let project = tempfile::tempdir().unwrap();
+        let body = b"golden staged upload bytes".to_vec();
+        let header_text = format!(
+            "POST /api/session/current/uploads?name=golden.txt HTTP/1.1\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n",
+            body.len()
+        );
+        let bus = crate::event::EventBus::new();
+        let root = project.path().to_path_buf();
+        let response = collect_upload_handler_response(|stream| {
+            handle_current_uploads_post(
+                stream,
+                &header_text,
+                "POST /api/session/current/uploads?name=golden.txt HTTP/1.1",
+                [header_text.as_bytes(), body.as_slice()].concat(),
+                bus,
+                Some(root),
+                None,
+                Some("golden-session".to_string()),
+            )
+        })
+        .await;
+        let text = String::from_utf8_lossy(&response);
+        let (head, resp_body) = text.split_once("\r\n\r\n").expect("split");
+        assert!(head.starts_with("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "), "{text}");
+        assert!(text.contains(upload_golden_tail()), "{head}");
+        let descriptor: serde_json::Value = serde_json::from_str(resp_body).unwrap();
+        assert_eq!(descriptor["name"], "golden.txt");
+        assert_eq!(descriptor["size"], body.len());
+        assert!(descriptor["path"]
+            .as_str()
+            .unwrap()
+            .starts_with(&project.path().to_string_lossy().to_string()));
+    }
+
+    /// POST success on a projectless daemon: the commit resolves the
+    /// daemon-global store (PR #129 semantics), same wire framing.
+    #[tokio::test]
+    async fn golden_current_uploads_post_projectless_transcript() {
+        let body = b"golden projectless upload bytes".to_vec();
+        let session_id = format!(
+            "golden-projectless-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let header_text = format!(
+            "POST /api/session/current/uploads?name=global.txt HTTP/1.1\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n",
+            body.len()
+        );
+        let bus = crate::event::EventBus::new();
+        let response = collect_upload_handler_response(|stream| {
+            handle_current_uploads_post(
+                stream,
+                &header_text,
+                "POST /api/session/current/uploads?name=global.txt HTTP/1.1",
+                [header_text.as_bytes(), body.as_slice()].concat(),
+                bus,
+                None,
+                None,
+                Some(session_id.clone()),
+            )
+        })
+        .await;
+        let text = String::from_utf8_lossy(&response);
+        let (head, resp_body) = text.split_once("\r\n\r\n").expect("split");
+        assert!(head.starts_with("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "), "{text}");
+        assert!(text.contains(upload_golden_tail()), "{head}");
+        let descriptor: serde_json::Value = serde_json::from_str(resp_body).unwrap();
+        let store_root = crate::global_store::global_store_root();
+        let path = descriptor["path"].as_str().unwrap().to_string();
+        assert!(
+            path.starts_with(&store_root.to_string_lossy().to_string()),
+            "projectless upload must land in the global store: {path}"
+        );
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(format!("{path}.json"));
+    }
+
+    #[tokio::test]
+    async fn golden_current_uploads_get_and_delete_transcripts() {
+        let project = tempfile::tempdir().unwrap();
+        // Empty list.
+        let root = project.path().to_path_buf();
+        let response = collect_upload_handler_response(|stream| {
+            handle_current_uploads_get(
+                stream,
+                "GET /api/session/current/uploads HTTP/1.1",
+                Some(root),
+                None,
+            )
+        })
+        .await;
+        let expected = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\n{}[]",
+            upload_golden_tail()
+        );
+        assert_eq!(String::from_utf8_lossy(&response), expected);
+
+        // Raw fetch of a missing upload.
+        let root = project.path().to_path_buf();
+        let response = collect_upload_handler_response(|stream| {
+            handle_current_uploads_get(
+                stream,
+                "GET /api/session/current/uploads/nope/raw HTTP/1.1",
+                Some(root),
+                None,
+            )
+        })
+        .await;
+        let body = r#"{"error":"upload not found"}"#;
+        let expected = format!(
+            "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{}{}",
+            body.len(),
+            upload_golden_tail(),
+            body
+        );
+        assert_eq!(String::from_utf8_lossy(&response), expected);
+
+        // Delete of an id that is not there stays idempotent-ok, under
+        // the canonical json tail (json_response framing).
+        let root = project.path().to_path_buf();
+        let bus = crate::event::EventBus::new();
+        let response = collect_upload_handler_response(|stream| {
+            handle_current_upload_delete(
+                stream,
+                "DELETE /api/session/current/uploads/nope HTTP/1.1",
+                bus,
+                Some(root),
+                None,
+            )
+        })
+        .await;
+        let body = r#"{"ok":true}"#;
+        let expected = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        assert_eq!(String::from_utf8_lossy(&response), expected);
+    }
+
 }

--- a/src/bin/caller/web_gateway/routes_files.rs
+++ b/src/bin/caller/web_gateway/routes_files.rs
@@ -199,6 +199,205 @@ pub(crate) fn current_upload_delete_response_body(
     }
 }
 
+/// Transport-neutral core of the staged-upload commit (`POST
+/// /api/session/current/uploads` once its transport has spooled the raw
+/// body; tunnel twin `api_session_current_upload`'s upload_end leg): the
+/// shared (status, body) commit core — session-dir resolution, store
+/// commit, `UploadReady` broadcast — under the wildcard-CORS tail.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn current_upload_commit_api_response(
+    project_root: Option<&std::path::Path>,
+    session_log: Option<&Arc<Mutex<crate::session_log::SessionLog>>>,
+    daemon_session_id: Option<&str>,
+    name: &str,
+    mime: &str,
+    requested_destination: crate::upload_store::UploadDestination,
+    tmp: tempfile::NamedTempFile,
+    size: usize,
+    bus: &crate::event::EventBus,
+) -> ApiResponse {
+    let (status, body) = current_upload_commit_response_body(
+        project_root,
+        session_log,
+        daemon_session_id,
+        name,
+        mime,
+        requested_destination,
+        tmp,
+        size,
+        bus,
+    );
+    session_wildcard_json_response(status_line_code(status), body)
+}
+
+/// Transport-neutral core of the staged-uploads list (`GET
+/// /api/session/current/uploads`; tunnel twin
+/// `api_session_current_uploads`): the store listing under the
+/// wildcard-CORS tail. The session dir arrives lane-resolved.
+pub(crate) fn current_uploads_list_api_response(
+    session_dir: &std::path::Path,
+    scope: &crate::global_store::StoreScope,
+) -> ApiResponse {
+    let uploads = crate::upload_store::list_uploads(session_dir, scope);
+    let body = serde_json::to_string(&uploads).unwrap_or_else(|_| "[]".to_string());
+    session_wildcard_json_response(200, body)
+}
+
+/// Content-core error of the staged-upload raw read. Each lane frames it
+/// in its historical shape — HTTP as wildcard `{"error":…}` bodies, the
+/// tunnel as `{"ok":false,"error":…}` objects under the injected-status
+/// envelope (with `total_size` riding the 416 as a body sidecar) — so
+/// the framing difference stays deliberate and enumerated instead of
+/// converging by accident.
+pub(crate) enum CurrentUploadRawError {
+    NotFound,
+    RangeBeyondSize { total_size: u64 },
+    RangeTooLarge { requested: u64 },
+    RangeUnrepresentable,
+    Io { message: String },
+}
+
+impl CurrentUploadRawError {
+    pub(crate) fn status(&self) -> u16 {
+        match self {
+            CurrentUploadRawError::NotFound => 404,
+            CurrentUploadRawError::RangeBeyondSize { .. } => 416,
+            CurrentUploadRawError::RangeTooLarge { .. }
+            | CurrentUploadRawError::RangeUnrepresentable => 413,
+            CurrentUploadRawError::Io { .. } => 500,
+        }
+    }
+
+    /// The human wording both lanes share.
+    pub(crate) fn message(&self) -> String {
+        match self {
+            CurrentUploadRawError::NotFound => "upload not found".to_string(),
+            CurrentUploadRawError::RangeBeyondSize { .. } => {
+                "range start beyond upload size".to_string()
+            }
+            CurrentUploadRawError::RangeTooLarge { requested } => format!(
+                "range too large: {requested} bytes (cap is {UPLOAD_MAX_BYTES})"
+            ),
+            CurrentUploadRawError::RangeUnrepresentable => {
+                "range too large for this platform".to_string()
+            }
+            CurrentUploadRawError::Io { message } => message.clone(),
+        }
+    }
+}
+
+/// Transport-neutral content core of the staged-upload raw read (`GET
+/// /api/session/current/uploads/{id}/raw`; tunnel twin
+/// `api_session_current_upload_raw`, BYTES lane). `range: None` is the
+/// HTTP form — one unbounded full-body read; `Some((offset, length))` is
+/// the tunnel's resumable form — seek plus a read capped at
+/// [`UPLOAD_MAX_BYTES`] per request (`length: None` reads to end of
+/// file). The success carries both lanes' decoration: the inline
+/// `Content-Disposition` header tail for HTTP, the range/descriptor meta
+/// object for the tunnel's `byte_stream_end.result`.
+pub(crate) fn current_upload_raw_api_response(
+    upload_id: &str,
+    range: Option<(u64, Option<u64>)>,
+    session_dir: &std::path::Path,
+    scope: &crate::global_store::StoreScope,
+) -> Result<ApiResponse, CurrentUploadRawError> {
+    use std::io::{Read, Seek};
+    let Some(descriptor) = crate::upload_store::find_upload(upload_id, session_dir, scope) else {
+        return Err(CurrentUploadRawError::NotFound);
+    };
+    let (bytes, offset, requested, total_size) = match range {
+        None => {
+            let bytes =
+                std::fs::read(&descriptor.path).map_err(|e| CurrentUploadRawError::Io {
+                    message: format!("read upload: {e}"),
+                })?;
+            let total_size = bytes.len() as u64;
+            (bytes, 0u64, total_size, total_size)
+        }
+        Some((offset, length)) => {
+            let metadata =
+                std::fs::metadata(&descriptor.path).map_err(|e| CurrentUploadRawError::Io {
+                    message: format!("stat upload: {e}"),
+                })?;
+            let total_size = metadata.len();
+            if offset > total_size {
+                return Err(CurrentUploadRawError::RangeBeyondSize { total_size });
+            }
+            let available = total_size.saturating_sub(offset);
+            let requested = length.unwrap_or(available).min(available);
+            if requested > UPLOAD_MAX_BYTES as u64 {
+                return Err(CurrentUploadRawError::RangeTooLarge { requested });
+            }
+            let transfer_len = usize::try_from(requested)
+                .map_err(|_| CurrentUploadRawError::RangeUnrepresentable)?;
+            let mut file =
+                std::fs::File::open(&descriptor.path).map_err(|e| CurrentUploadRawError::Io {
+                    message: format!("open upload: {e}"),
+                })?;
+            file.seek(std::io::SeekFrom::Start(offset))
+                .map_err(|e| CurrentUploadRawError::Io {
+                    message: format!("seek upload: {e}"),
+                })?;
+            let mut bytes = vec![0u8; transfer_len];
+            file.read_exact(&mut bytes)
+                .map_err(|e| CurrentUploadRawError::Io {
+                    message: format!("read upload: {e}"),
+                })?;
+            (bytes, offset, requested, total_size)
+        }
+    };
+    let end = offset.saturating_add(requested);
+    let meta = serde_json::json!({
+        "ok": true,
+        "id": descriptor.id,
+        "name": descriptor.name,
+        "filename": descriptor.name,
+        "mime": descriptor.mime,
+        "content_type": descriptor.mime,
+        "size": requested,
+        "total_size": total_size,
+        "offset": offset,
+        "range_start": offset,
+        "range_end": end,
+        "resumable": true,
+    });
+    Ok(ApiResponse::Bytes {
+        status: 200,
+        content_type: descriptor.mime.clone(),
+        headers: vec![
+            (
+                "Content-Disposition",
+                format!("inline; filename=\"{}\"", descriptor.name.replace('"', "")),
+            ),
+            ("Cache-Control", "no-cache".to_string()),
+            ("Access-Control-Allow-Origin", "*".to_string()),
+            ("Connection", "close".to_string()),
+        ],
+        bytes: BytesPayload::InMemory(bytes),
+        meta,
+    })
+}
+
+/// Transport-neutral core of the staged-upload delete (`DELETE
+/// /api/session/current/uploads/{id}`; tunnel twin
+/// `api_session_current_upload_delete`): the shared delete core plus its
+/// `UploadDeleted` broadcast, under the canonical json tail — the delete
+/// answers same-origin, unlike the rest of its family (pinned by the
+/// golden transcripts).
+pub(crate) fn current_upload_delete_api_response(
+    project_root: Option<&std::path::Path>,
+    session_dir: Option<&std::path::Path>,
+    upload_id: &str,
+    bus: &crate::event::EventBus,
+) -> ApiResponse {
+    let (status, body, deleted_id) =
+        current_upload_delete_response_body(project_root, session_dir, upload_id);
+    if let Some(id) = deleted_id {
+        bus.send(crate::event::AppEvent::UploadDeleted { id });
+    }
+    ApiResponse::json(status_line_code(status), JsonBody::PreSerialized(body))
+}
+
 pub(crate) fn dashboard_source_request_from_line(
     request_line: &str,
 ) -> Option<DashboardSourceRequest> {
@@ -2413,17 +2612,19 @@ pub(crate) async fn handle_current_uploads_post(
     project_root_for_changes: Option<PathBuf>,
     session_log: Option<Arc<Mutex<crate::session_log::SessionLog>>>,
     daemon_session_id: Option<String>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
     // POST /api/session/current/uploads?name=<fn>&destination=task|workspace
     //   Content-Type: <mime>
     //   <raw bytes>
     //
-    // Streams the body into a tempfile, commits it into
-    // the upload store for this daemon's scope (the
-    // project-local ignored `.intendant/uploads/<session-id>/`,
-    // or the daemon-global store on projectless daemons),
-    // and broadcasts UploadReady so all connected
-    // browsers see it.
+    // Streams the body into a tempfile (transport-owned carriage), then
+    // commits it through the shared neutral fn — the upload store for
+    // this daemon's scope (the project-local ignored
+    // `.intendant/uploads/<session-id>/`, or the daemon-global store on
+    // projectless daemons) — which broadcasts UploadReady so all
+    // connected browsers see it.
     //
     // Route sits in the `/api/session/current/*` family
     // alongside `changes`, `history`, `rollback`, etc.
@@ -2432,209 +2633,119 @@ pub(crate) async fn handle_current_uploads_post(
     // doesn't apply. If a WAN-exposed deploy wants to
     // protect uploads, gate the whole family at once.
     use tokio::io::AsyncWriteExt;
-    let response = 'upload: {
-        let scope = crate::global_store::StoreScope::resolve(project_root_for_changes.as_deref());
+    let name = query_param(request_line, "name").unwrap_or_else(|| "upload.bin".to_string());
+    let requested_destination = query_param(request_line, "destination")
+        .as_deref()
+        .and_then(crate::upload_store::UploadDestination::from_str)
+        .unwrap_or(crate::upload_store::UploadDestination::Task);
+    let mime = content_type_header(header_text);
+    if header_text
+        .lines()
+        .any(|l| l.trim().eq_ignore_ascii_case("expect: 100-continue"))
+    {
+        let _ = stream.write_all(b"HTTP/1.1 100 Continue\r\n\r\n").await;
+    }
 
-        let name = query_param(request_line, "name").unwrap_or_else(|| "upload.bin".to_string());
-        let requested_destination = query_param(request_line, "destination")
-            .as_deref()
-            .and_then(crate::upload_store::UploadDestination::from_str)
-            .unwrap_or(crate::upload_store::UploadDestination::Task);
-        let mime = content_type_header(header_text);
-        if header_text
-            .lines()
-            .any(|l| l.trim().eq_ignore_ascii_case("expect: 100-continue"))
-        {
-            let _ = stream.write_all(b"HTTP/1.1 100 Continue\r\n\r\n").await;
-        }
-
+    let response =
         match stream_body_to_tempfile(header_text, &discard, &mut stream, UPLOAD_MAX_BYTES).await {
             Err(e) => {
-                let status = if e.contains("too large") {
-                    "413 Payload Too Large"
-                } else {
-                    "400 Bad Request"
-                };
-                break 'upload upload_error_response(status, &e);
+                let status = if e.contains("too large") { 413 } else { 400 };
+                session_wildcard_json_error(status, &e)
             }
-            Ok((tmp, size)) => {
-                let (session_dir, session_id) = {
-                    if let Some(ref slog) = session_log {
-                        match slog.lock() {
-                            Ok(l) => (l.dir().to_path_buf(), l.session_id().to_string()),
-                            Err(_) => {
-                                break 'upload upload_error_response(
-                                    "500 Internal Server Error",
-                                    "session log lock poisoned",
-                                );
-                            }
-                        }
-                    } else {
-                        (
-                            pending_upload_session_dir(&scope),
-                            daemon_session_id
-                                .clone()
-                                .unwrap_or_else(|| "pending".to_string()),
-                        )
-                    }
-                };
-                let destination =
-                    effective_upload_destination(requested_destination, session_log.is_some());
-                match crate::upload_store::commit_upload(
-                    tmp,
-                    &name,
-                    &mime,
-                    size as u64,
-                    destination,
-                    &session_dir,
-                    &session_id,
-                    &scope,
-                ) {
-                    Ok(descriptor) => {
-                        bus.send(crate::event::AppEvent::UploadReady {
-                            descriptor: descriptor.clone(),
-                        });
-                        let body =
-                            serde_json::to_string(&descriptor).unwrap_or_else(|_| "{}".to_string());
-                        HttpResponse::with_content("200 OK", "application/json", body)
-                            .header("Cache-Control", "no-cache")
-                            .header("Access-Control-Allow-Origin", "*")
-                            .header("Connection", "close")
-                            .into_string()
-                    }
-                    Err(e) => upload_error_response(
-                        "500 Internal Server Error",
-                        &format!("commit upload: {e}"),
-                    ),
-                }
-            }
-        }
-    };
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+            Ok((tmp, size)) => current_upload_commit_api_response(
+                project_root_for_changes.as_deref(),
+                session_log.as_ref(),
+                daemon_session_id.as_deref(),
+                &name,
+                &mime,
+                requested_destination,
+                tmp,
+                size,
+                &bus,
+            ),
+        };
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_current_uploads_get(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     request_line: &str,
     project_root_for_changes: Option<PathBuf>,
     session_log: Option<Arc<Mutex<crate::session_log::SessionLog>>>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
     // GET /api/session/current/uploads           — list uploads for the current session
     // GET /api/session/current/uploads/<id>/raw  — stream bytes of one upload
-    use tokio::io::AsyncWriteExt;
-    let response = 'get_upload: {
-        let scope = crate::global_store::StoreScope::resolve(project_root_for_changes.as_deref());
-        let session_dir = if let Some(ref slog) = session_log {
-            match slog.lock() {
-                Ok(l) => l.dir().to_path_buf(),
-                Err(_) => {
-                    break 'get_upload upload_error_response(
-                        "500 Internal Server Error",
-                        "session log lock poisoned",
-                    );
-                }
-            }
-        } else {
-            pending_upload_session_dir(&scope)
-        };
-        // Path after /api/session/current/uploads
-        let path_and_q = request_line.split_whitespace().nth(1).unwrap_or("");
-        let path = path_and_q.split('?').next().unwrap_or("");
-        let suffix = path
-            .trim_start_matches("/api/session/current/uploads")
-            .trim_matches('/');
-        if suffix.is_empty() {
-            let uploads = crate::upload_store::list_uploads(&session_dir, &scope);
-            let body = serde_json::to_string(&uploads).unwrap_or_else(|_| "[]".to_string());
-            HttpResponse::with_content("200 OK", "application/json", body)
-                .header("Cache-Control", "no-cache")
-                .header("Access-Control-Allow-Origin", "*")
-                .header("Connection", "close")
-                .into_string()
-        } else if let Some(id) = suffix.strip_suffix("/raw") {
-            // GET raw bytes for one upload.
-            match crate::upload_store::find_upload(id, &session_dir, &scope) {
-                None => upload_error_response("404 Not Found", "upload not found"),
-                Some(d) => {
-                    match std::fs::read(&d.path) {
-                        Ok(bytes) => {
-                            let header = HttpResponse::new("200 OK")
-                                .header("Content-Type", d.mime)
-                                .header("Content-Length", bytes.len().to_string())
-                                .header(
-                                    "Content-Disposition",
-                                    format!("inline; filename=\"{}\"", d.name.replace('"', ""),),
-                                )
-                                .header("Cache-Control", "no-cache")
-                                .header("Access-Control-Allow-Origin", "*")
-                                .header("Connection", "close")
-                                .into_string();
-                            let _ = stream.write_all(header.as_bytes()).await;
-                            let _ = stream.write_all(&bytes).await;
-                            // Skip the trailing write_all below.
-                            break 'get_upload String::new();
-                        }
-                        Err(e) => upload_error_response(
-                            "500 Internal Server Error",
-                            &format!("read upload: {e}"),
-                        ),
-                    }
-                }
-            }
-        } else {
-            upload_error_response("404 Not Found", "unknown upload route")
+    let scope = crate::global_store::StoreScope::resolve(project_root_for_changes.as_deref());
+    let session_dir = match session_log.as_ref() {
+        Some(slog) => match slog.lock() {
+            Ok(l) => Ok(l.dir().to_path_buf()),
+            Err(_) => Err("session log lock poisoned"),
+        },
+        None => Ok(pending_upload_session_dir(&scope)),
+    };
+    let session_dir = match session_dir {
+        Ok(dir) => dir,
+        Err(error) => {
+            let response = session_wildcard_json_error(500, error);
+            return write_api_response(stream, response, cors, fleet_origin).await;
         }
     };
-    if !response.is_empty() {
-        let _ = stream.write_all(response.as_bytes()).await;
-    }
-    finalize_http_stream(&mut stream).await;
+    // Path after /api/session/current/uploads
+    let path_and_q = request_line.split_whitespace().nth(1).unwrap_or("");
+    let path = path_and_q.split('?').next().unwrap_or("");
+    let suffix = path
+        .trim_start_matches("/api/session/current/uploads")
+        .trim_matches('/');
+    let response = if suffix.is_empty() {
+        current_uploads_list_api_response(&session_dir, &scope)
+    } else if let Some(id) = suffix.strip_suffix("/raw") {
+        // GET raw bytes for one upload (the HTTP form: one full read).
+        match current_upload_raw_api_response(id, None, &session_dir, &scope) {
+            Ok(response) => response,
+            Err(err) => session_wildcard_json_error(err.status(), &err.message()),
+        }
+    } else {
+        session_wildcard_json_error(404, "unknown upload route")
+    };
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_current_upload_delete(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     request_line: &str,
     bus: EventBus,
     project_root_for_changes: Option<PathBuf>,
     session_log: Option<Arc<Mutex<crate::session_log::SessionLog>>>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
     // DELETE /api/session/current/uploads/<id> — remove the file + sidecar.
-    use tokio::io::AsyncWriteExt;
-    let response = {
-        let session_dir = if let Some(ref slog) = session_log {
-            match slog.lock() {
-                Ok(l) => Ok(Some(l.dir().to_path_buf())),
-                Err(_) => Err("session log lock poisoned"),
-            }
-        } else {
-            Ok(None)
-        };
-        match session_dir {
-            Err(error) => json_response(
-                "500 Internal Server Error",
-                serde_json::json!({ "error": error }).to_string(),
-            ),
-            Ok(session_dir) => {
-                let path_and_q = request_line.split_whitespace().nth(1).unwrap_or("");
-                let path = path_and_q.split('?').next().unwrap_or("");
-                let id = path
-                    .trim_start_matches("/api/session/current/uploads/")
-                    .trim_matches('/');
-                let (status, body, deleted_id) = current_upload_delete_response_body(
-                    project_root_for_changes.as_deref(),
-                    session_dir.as_deref(),
-                    id,
-                );
-                if let Some(id) = deleted_id {
-                    bus.send(crate::event::AppEvent::UploadDeleted { id });
-                }
-                json_response(status, body)
-            }
+    let session_dir = match session_log.as_ref() {
+        Some(slog) => match slog.lock() {
+            Ok(l) => Ok(Some(l.dir().to_path_buf())),
+            Err(_) => Err("session log lock poisoned"),
+        },
+        None => Ok(None),
+    };
+    let response = match session_dir {
+        Err(error) => ApiResponse::json_error(500, error),
+        Ok(session_dir) => {
+            let path_and_q = request_line.split_whitespace().nth(1).unwrap_or("");
+            let path = path_and_q.split('?').next().unwrap_or("");
+            let id = path
+                .trim_start_matches("/api/session/current/uploads/")
+                .trim_matches('/');
+            current_upload_delete_api_response(
+                project_root_for_changes.as_deref(),
+                session_dir.as_deref(),
+                id,
+                &bus,
+            )
         }
     };
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 #[cfg(test)]
@@ -3830,6 +3941,8 @@ mod tests {
                 Some(root),
                 None,
                 Some("golden-session".to_string()),
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
             )
         })
         .await;
@@ -3873,6 +3986,8 @@ mod tests {
                 None,
                 None,
                 Some(session_id.clone()),
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
             )
         })
         .await;
@@ -3902,6 +4017,8 @@ mod tests {
                 "GET /api/session/current/uploads HTTP/1.1",
                 Some(root),
                 None,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
             )
         })
         .await;
@@ -3918,6 +4035,8 @@ mod tests {
                 stream,
                 "GET /api/session/current/uploads/nope/raw HTTP/1.1",
                 Some(root),
+                None,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
                 None,
             )
         })
@@ -3941,6 +4060,8 @@ mod tests {
                 "DELETE /api/session/current/uploads/nope HTTP/1.1",
                 bus,
                 Some(root),
+                None,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
                 None,
             )
         })

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -5907,4 +5907,132 @@ mod tests {
             golden_session_json_transcript("400 Bad Request", &body)
         );
     }
+    // ── S4c golden transcripts: current-session + managed-context ──
+    // Same discipline as the S4a/S4b sets: byte-exact pins captured
+    // before the transport-neutral conversion (design §6 S4, risk R1).
+
+    #[tokio::test]
+    async fn golden_current_history_and_mutations_without_watcher_transcripts() {
+        for (make, expect_status) in [
+            ("GET", "503 Service Unavailable"),
+        ] {
+            let _ = make;
+            let response = collect_session_handler_response(|stream| {
+                handle_current_history(stream, None)
+            })
+            .await;
+            assert_eq!(
+                golden_transcript(&response),
+                golden_session_wildcard_json_transcript(
+                    expect_status,
+                    r#"{"error":"file watcher not active"}"#
+                )
+            );
+        }
+        let response = collect_session_handler_response(|stream| {
+            handle_current_redo(stream, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_wildcard_json_transcript(
+                "503 Service Unavailable",
+                r#"{"error":"file watcher not active"}"#
+            )
+        );
+        let response = collect_session_handler_response(|stream| {
+            handle_current_prune(stream, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_wildcard_json_transcript(
+                "503 Service Unavailable",
+                r#"{"error":"file watcher not active"}"#
+            )
+        );
+        let bus = crate::event::EventBus::new();
+        let response = collect_session_handler_response(|stream| {
+            handle_current_rollback(stream, "{}".to_string(), bus, None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_wildcard_json_transcript(
+                "503 Service Unavailable",
+                r#"{"error":"file watcher not active"}"#
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_current_changes_without_context_transcript() {
+        let response = collect_session_handler_response(|stream| {
+            handle_session_current_changes(
+                stream,
+                "GET /api/session/current/changes HTTP/1.1",
+                None,
+                None,
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_wildcard_json_transcript(
+                "503 Service Unavailable",
+                r#"{"error":"file watcher not active"}"#
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_current_agent_output_without_log_transcript() {
+        let response = collect_session_handler_response(|stream| {
+            handle_current_agent_output(stream, r#"{"ids":["x"]}"#.to_string(), None, None)
+        })
+        .await;
+        assert_eq!(
+            golden_transcript(&response),
+            golden_session_wildcard_json_transcript(
+                "404 Not Found",
+                r#"{"error":"no active session log"}"#
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_managed_context_empty_home_transcripts() {
+        // A tempdir home: the candidate scan finds nothing — the empty
+        // bodies and framing are the pin (query names one session id so
+        // the scan stays home-scoped).
+        let home = tempfile::tempdir().unwrap();
+        let anchors = managed_context_anchors_response_from_home(
+            "GET /api/managed-context/anchors?session_id=abc123 HTTP/1.1",
+            None,
+            home.path(),
+        );
+        assert_eq!(
+            anchors,
+            golden_session_json_transcript("200 OK", r#"{"anchors":[]}"#)
+        );
+        let records = managed_context_records_response_from_home(
+            "GET /api/managed-context/records?session_id=abc123 HTTP/1.1",
+            None,
+            home.path(),
+        );
+        assert_eq!(
+            records,
+            golden_session_json_transcript("200 OK", r#"{"records":[]}"#)
+        );
+        let fission = managed_context_fission_response_from_home(
+            "GET /api/managed-context/fission?session_id=abc123 HTTP/1.1",
+            None,
+            home.path(),
+        );
+        assert_eq!(
+            fission,
+            golden_session_json_transcript("200 OK", r#"{"groups":[]}"#)
+        );
+    }
+
 }

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -87,11 +87,12 @@ pub(crate) fn session_wildcard_json_error(status: u16, message: &str) -> ApiResp
     session_wildcard_json_response(status, serde_json::json!({ "error": message }).to_string())
 }
 
-/// Transitional raw-HTTP rendering for the current-session callers that
-/// have not yet converted to [`ApiResponse`] (S4 slices 2–3); byte-
-/// identical to the historical hand-rolled strings (the HTTP adapter's
-/// parity tests pin the framing).
-fn api_response_to_http_string(response: ApiResponse) -> String {
+/// Transitional raw-HTTP rendering for the tunnel callers that have not
+/// yet converted to [`ApiResponse`] (the S4c tunnel commit retires it
+/// with the last `http_wire_response` caller); byte-identical to the
+/// historical hand-rolled strings (the HTTP adapter's parity tests pin
+/// the framing).
+pub(crate) fn api_response_to_http_string(response: ApiResponse) -> String {
     String::from_utf8_lossy(&api_response_http_bytes(
         response,
         crate::gateway_routes::CorsPosture::OwnOrigin,
@@ -146,12 +147,22 @@ pub(crate) fn agent_output_ids_from_json_body(body: &str) -> Result<Vec<String>,
     Ok(ids)
 }
 
-pub(crate) fn current_agent_output_post_response(body: &str, log_dir: &Path) -> String {
-    let response = match agent_output_ids_from_json_body(body) {
+/// Transport-neutral core of `POST /api/session/current/agent-output`
+/// (tunnel twin `api_session_current_agent_output`): output-id decode
+/// from the JSON body, then the persisted-chunk fetch against the active
+/// session log dir. The no-active-log 404 stays with each lane's log
+/// resolution step.
+pub(crate) fn current_agent_output_api_response(body: &str, log_dir: &Path) -> ApiResponse {
+    match agent_output_ids_from_json_body(body) {
         Ok(ids) => current_agent_output_response_for_ids(ids, log_dir),
         Err(e) => session_wildcard_json_error(400, &e),
-    };
-    api_response_to_http_string(response)
+    }
+}
+
+/// Transitional raw-string form for the unconverted tunnel twin (the
+/// S4c tunnel commit retires it together with `http_wire_response`).
+pub(crate) fn current_agent_output_post_response(body: &str, log_dir: &Path) -> String {
+    api_response_to_http_string(current_agent_output_api_response(body, log_dir))
 }
 
 pub(crate) fn external_agent_output_response_for_ids(
@@ -1997,11 +2008,15 @@ pub(crate) fn managed_context_anchor_matches_session(
         || anchor.intendant_session_id.as_deref() == Some(session_id)
 }
 
+/// Transport-neutral core of `GET /api/managed-context/anchors` (tunnel
+/// twin `api_managed_context_anchors`): the deduped, capped anchor
+/// catalog from the home-scoped candidate scan, under the canonical
+/// json tail.
 pub(crate) fn managed_context_anchors_response_from_home(
     request_line: &str,
     active_log_dir: Option<&Path>,
     home: &Path,
-) -> String {
+) -> ApiResponse {
     let session_id = managed_context_query_session_id(request_line);
     let wrapper_session_id = managed_context_query_wrapper_session_id(request_line);
     let filter_session_id = session_id.as_deref().or(wrapper_session_id.as_deref());
@@ -2022,24 +2037,27 @@ pub(crate) fn managed_context_anchors_response_from_home(
                 &log_dir,
                 filter_session_id,
             ) {
-                return json_error(
-                    "500 Internal Server Error",
+                return ApiResponse::json_error(
+                    500,
                     format!("failed to read managed-context anchors: {err}"),
                 );
             }
         }
     } else if active_log_dir.is_some() {
         // Active log was present but unreadable or raced with session teardown.
-        return json_ok(serde_json::json!({ "anchors": [] }));
+        return ApiResponse::json(200, JsonBody::Value(serde_json::json!({ "anchors": [] })));
     } else if session_id.is_none() && wrapper_session_id.is_none() {
-        return json_error(
-            "404 Not Found",
+        return ApiResponse::json_error(
+            404,
             "managed-context anchors need an active session log",
         );
     } else {
         let Some(log_dir) = active_log_dir else {
             anchors.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-            return json_ok(serde_json::json!({ "anchors": anchors }));
+            return ApiResponse::json(
+                200,
+                JsonBody::Value(serde_json::json!({ "anchors": anchors })),
+            );
         };
         if let Err(err) = append_managed_context_anchors_from_dir(
             &mut anchors,
@@ -2047,8 +2065,8 @@ pub(crate) fn managed_context_anchors_response_from_home(
             log_dir,
             filter_session_id,
         ) {
-            return json_error(
-                "500 Internal Server Error",
+            return ApiResponse::json_error(
+                500,
                 format!("failed to read managed-context anchors: {err}"),
             );
         }
@@ -2058,7 +2076,7 @@ pub(crate) fn managed_context_anchors_response_from_home(
     let mut seen_items = HashSet::new();
     anchors.retain(|anchor| seen_items.insert(anchor.item_id.clone()));
     anchors.truncate(MANAGED_CONTEXT_ANCHOR_LIMIT);
-    json_ok(serde_json::json!({ "anchors": anchors }))
+    ApiResponse::json(200, JsonBody::Value(serde_json::json!({ "anchors": anchors })))
 }
 
 pub(crate) fn append_managed_context_records_from_dir(
@@ -2452,126 +2470,161 @@ pub(crate) async fn handle_history_prune(
     }
 }
 
+/// Transport-neutral core of `GET /api/session/current/changes[/…]`
+/// (tunnel twin `api_session_current_changes`): the change list / one
+/// file's unified diff under the wildcard-CORS tail. The request line
+/// arrives transport-decoded — HTTP passes it verbatim, the tunnel
+/// synthesizes it from its path/query params.
+pub(crate) fn session_current_changes_api_response(
+    request_line: &str,
+    snapshot_dir: Option<&Path>,
+    project_root: Option<&Path>,
+    home: &Path,
+) -> ApiResponse {
+    let (status, body) =
+        handle_changes_request_for_home(request_line, snapshot_dir, project_root, home);
+    session_wildcard_json_response(status_line_code(status), body)
+}
+
 pub(crate) async fn handle_session_current_changes(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     request_line: &str,
     project_root_for_changes: Option<PathBuf>,
     snapshot_dir: Option<PathBuf>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
     // File change tracking endpoints:
     //   GET /api/session/current/changes        — list all changed files
     //   GET /api/session/current/changes/{path} — unified diff for one file
-    use tokio::io::AsyncWriteExt;
-    let (status, body) = handle_changes_request_for_home(
+    let response = session_current_changes_api_response(
         request_line,
         snapshot_dir.as_deref(),
         project_root_for_changes.as_deref(),
         &crate::platform::home_dir(),
     );
-    let response = HttpResponse::with_content(status, "application/json", body)
-        .header("Cache-Control", "no-cache")
-        .header("Access-Control-Allow-Origin", "*")
-        .header("Connection", "close")
-        .into_string();
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+/// Transport-neutral core of `GET /api/session/current/history` (tunnel
+/// twin `api_session_current_history`): the serialized rewind History —
+/// or the 503 watcher-absent shape — under the wildcard-CORS tail.
+pub(crate) async fn current_history_api_response(
+    file_watcher: Option<&crate::file_watcher::SharedFileWatcher>,
+) -> ApiResponse {
+    let (status, body) = handle_history_get(file_watcher).await;
+    session_wildcard_json_response(status_line_code(status), body)
 }
 
 pub(crate) async fn handle_current_history(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     file_watcher: Option<crate::file_watcher::SharedFileWatcher>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
     // GET /api/session/current/history — serialized History.
-    use tokio::io::AsyncWriteExt;
-    let (status, body) = handle_history_get(file_watcher.as_ref()).await;
-    let response = HttpResponse::with_content(status, "application/json", body)
-        .header("Cache-Control", "no-cache")
-        .header("Access-Control-Allow-Origin", "*")
-        .header("Connection", "close")
-        .into_string();
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    let response = current_history_api_response(file_watcher.as_ref()).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+/// Transport-neutral core of `POST /api/session/current/rollback`
+/// (tunnel twin `api_session_current_rollback`): the shared rollback
+/// core — validation, file revert, conversation-rollback event — under
+/// the wildcard-CORS tail.
+pub(crate) async fn current_rollback_api_response(
+    body_text: &str,
+    file_watcher: Option<&crate::file_watcher::SharedFileWatcher>,
+    agent_state: Option<&Arc<Mutex<AgentStateSnapshot>>>,
+    bus: &EventBus,
+) -> ApiResponse {
+    let (status, body) =
+        handle_history_rollback(body_text, file_watcher, agent_state, bus).await;
+    session_wildcard_json_response(status_line_code(status), body)
 }
 
 pub(crate) async fn handle_current_rollback(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     body_text: String,
     bus: EventBus,
     query_ctx: Option<WebQueryCtx>,
     file_watcher: Option<crate::file_watcher::SharedFileWatcher>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
     // POST /api/session/current/rollback body:
     //   {"round_id": N,
     //    "revert_files": bool (default true),
     //    "revert_conversation": bool (default false)}
-    use tokio::io::AsyncWriteExt;
     let agent_state = query_ctx.as_ref().map(|ctx| ctx.agent_state.clone());
-    let (status, body) = handle_history_rollback(
+    let response = current_rollback_api_response(
         &body_text,
         file_watcher.as_ref(),
         agent_state.as_ref(),
         &bus,
     )
     .await;
-    let response = HttpResponse::with_content(status, "application/json", body)
-        .header("Cache-Control", "no-cache")
-        .header("Access-Control-Allow-Origin", "*")
-        .header("Connection", "close")
-        .into_string();
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+/// Transport-neutral core of `POST /api/session/current/redo` (tunnel
+/// twin `api_session_current_redo`), under the wildcard-CORS tail.
+pub(crate) async fn current_redo_api_response(
+    file_watcher: Option<&crate::file_watcher::SharedFileWatcher>,
+    agent_state: Option<&Arc<Mutex<AgentStateSnapshot>>>,
+) -> ApiResponse {
+    let (status, body) = handle_history_redo(file_watcher, agent_state).await;
+    session_wildcard_json_response(status_line_code(status), body)
 }
 
 pub(crate) async fn handle_current_redo(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     query_ctx: Option<WebQueryCtx>,
     file_watcher: Option<crate::file_watcher::SharedFileWatcher>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
     // POST /api/session/current/redo — no body required (dispatch
     // drains any body sent anyway).
-    use tokio::io::AsyncWriteExt;
     let agent_state = query_ctx.as_ref().map(|ctx| ctx.agent_state.clone());
-    let (status, body) = handle_history_redo(file_watcher.as_ref(), agent_state.as_ref()).await;
-    let response = HttpResponse::with_content(status, "application/json", body)
-        .header("Cache-Control", "no-cache")
-        .header("Access-Control-Allow-Origin", "*")
-        .header("Connection", "close")
-        .into_string();
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    let response = current_redo_api_response(file_watcher.as_ref(), agent_state.as_ref()).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+/// Transport-neutral core of `POST /api/session/current/prune` (tunnel
+/// twin `api_session_current_prune`), under the wildcard-CORS tail.
+pub(crate) async fn current_prune_api_response(
+    file_watcher: Option<&crate::file_watcher::SharedFileWatcher>,
+) -> ApiResponse {
+    let (status, body) = handle_history_prune(file_watcher).await;
+    session_wildcard_json_response(status_line_code(status), body)
 }
 
 pub(crate) async fn handle_current_prune(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     file_watcher: Option<crate::file_watcher::SharedFileWatcher>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
     // POST /api/session/current/prune — no body required (dispatch
     // drains any body sent anyway).
-    use tokio::io::AsyncWriteExt;
-    let (status, body) = handle_history_prune(file_watcher.as_ref()).await;
-    let response = HttpResponse::with_content(status, "application/json", body)
-        .header("Cache-Control", "no-cache")
-        .header("Access-Control-Allow-Origin", "*")
-        .header("Connection", "close")
-        .into_string();
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    let response = current_prune_api_response(file_watcher.as_ref()).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_current_agent_output(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     body_text: String,
     query_ctx: Option<WebQueryCtx>,
     session_log: Option<Arc<Mutex<crate::session_log::SessionLog>>>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
     let log_dir = current_session_log_dir(session_log.as_ref(), query_ctx.as_ref());
     let response = match log_dir {
-        Some(dir) => current_agent_output_post_response(&body_text, &dir),
-        None => upload_error_response("404 Not Found", "no active session log"),
+        Some(dir) => current_agent_output_api_response(&body_text, &dir),
+        None => session_wildcard_json_error(404, "no active session log"),
     };
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 /// Transport-neutral core of `GET /api/sessions` (tunnel twin
@@ -3117,11 +3170,12 @@ pub(crate) fn session_context_snapshot_api_response(
 }
 
 pub(crate) async fn handle_mc_anchors(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     request_line: &str,
     session_log: Option<Arc<Mutex<crate::session_log::SessionLog>>>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
     let response = match session_log.as_ref() {
         Some(log) => match log.lock() {
             Ok(log) => {
@@ -3132,7 +3186,7 @@ pub(crate) async fn handle_mc_anchors(
                     &crate::platform::home_dir(),
                 )
             }
-            Err(_) => json_error("500 Internal Server Error", "session log lock poisoned"),
+            Err(_) => ApiResponse::json_error(500, "session log lock poisoned"),
         },
         None => managed_context_anchors_response_from_home(
             request_line,
@@ -3140,16 +3194,16 @@ pub(crate) async fn handle_mc_anchors(
             &crate::platform::home_dir(),
         ),
     };
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_mc_records(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     request_line: &str,
     session_log: Option<Arc<Mutex<crate::session_log::SessionLog>>>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
     let response = match session_log.as_ref() {
         Some(log) => match log.lock() {
             Ok(log) => {
@@ -3160,7 +3214,7 @@ pub(crate) async fn handle_mc_records(
                     &crate::platform::home_dir(),
                 )
             }
-            Err(_) => json_error("500 Internal Server Error", "session log lock poisoned"),
+            Err(_) => ApiResponse::json_error(500, "session log lock poisoned"),
         },
         None => managed_context_records_response_from_home(
             request_line,
@@ -3168,16 +3222,16 @@ pub(crate) async fn handle_mc_records(
             &crate::platform::home_dir(),
         ),
     };
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_mc_fission(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     request_line: &str,
     session_log: Option<Arc<Mutex<crate::session_log::SessionLog>>>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
     let response = match session_log.as_ref() {
         Some(log) => match log.lock() {
             Ok(log) => {
@@ -3188,7 +3242,7 @@ pub(crate) async fn handle_mc_fission(
                     &crate::platform::home_dir(),
                 )
             }
-            Err(_) => json_error("500 Internal Server Error", "session log lock poisoned"),
+            Err(_) => ApiResponse::json_error(500, "session log lock poisoned"),
         },
         None => managed_context_fission_response_from_home(
             request_line,
@@ -3196,8 +3250,7 @@ pub(crate) async fn handle_mc_fission(
             &crate::platform::home_dir(),
         ),
     };
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_sessions_stream(mut stream: DemuxStream, request_line: &str) {
@@ -3410,18 +3463,21 @@ pub(crate) async fn handle_displays(
 
 #[cfg(test)]
 pub(crate) fn managed_context_anchors_response(request_line: &str, log_dir: &Path) -> String {
-    managed_context_anchors_response_from_home(
+    test_render_api_response(managed_context_anchors_response_from_home(
         request_line,
         Some(log_dir),
         &crate::platform::home_dir(),
-    )
+    ))
 }
 
+/// Transport-neutral core of `GET /api/managed-context/records` (tunnel
+/// twin `api_managed_context_records`): the rewind-record index from the
+/// home-scoped candidate scan, under the canonical json tail.
 pub(crate) fn managed_context_records_response_from_home(
     request_line: &str,
     active_log_dir: Option<&Path>,
     home: &Path,
-) -> String {
+) -> ApiResponse {
     let session_id = managed_context_query_session_id(request_line);
     let wrapper_session_id = managed_context_query_wrapper_session_id(request_line);
     let mut filter_session_ids = Vec::new();
@@ -3475,23 +3531,26 @@ pub(crate) fn managed_context_records_response_from_home(
                 &log_dir,
                 &filter_session_ids,
             ) {
-                return json_error(
-                    "500 Internal Server Error",
+                return ApiResponse::json_error(
+                    500,
                     format!("failed to read managed-context records: {err}"),
                 );
             }
         }
     } else if active_log_dir.is_some() {
-        return json_ok(serde_json::json!({ "records": [] }));
+        return ApiResponse::json(200, JsonBody::Value(serde_json::json!({ "records": [] })));
     } else if session_id.is_none() && wrapper_session_id.is_none() {
-        return json_error(
-            "404 Not Found",
+        return ApiResponse::json_error(
+            404,
             "managed-context records need an active session log",
         );
     } else {
         let Some(log_dir) = active_log_dir else {
             records.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-            return json_ok(serde_json::json!({ "records": records }));
+            return ApiResponse::json(
+                200,
+                JsonBody::Value(serde_json::json!({ "records": records })),
+            );
         };
         if let Err(err) = append_managed_context_records_from_dir(
             &mut records,
@@ -3499,24 +3558,36 @@ pub(crate) fn managed_context_records_response_from_home(
             log_dir,
             &filter_session_ids,
         ) {
-            return json_error(
-                "500 Internal Server Error",
+            return ApiResponse::json_error(
+                500,
                 format!("failed to read managed-context records: {err}"),
             );
         }
     }
 
     records.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-    json_ok(serde_json::json!({ "records": records }))
+    ApiResponse::json(200, JsonBody::Value(serde_json::json!({ "records": records })))
 }
 
 #[cfg(test)]
 pub(crate) fn managed_context_records_response(request_line: &str, log_dir: &Path) -> String {
-    managed_context_records_response_from_home(
+    test_render_api_response(managed_context_records_response_from_home(
         request_line,
         Some(log_dir),
         &crate::platform::home_dir(),
-    )
+    ))
+}
+
+/// Test-only wire render of a neutral response through the real HTTP
+/// adapter under the managed-context rows' own-origin posture.
+#[cfg(test)]
+pub(crate) fn test_render_api_response(response: ApiResponse) -> String {
+    String::from_utf8_lossy(&api_response_http_bytes(
+        response,
+        crate::gateway_routes::CorsPosture::OwnOrigin,
+        None,
+    ))
+    .into_owned()
 }
 
 /// Merged dashboard view of one fission group: the wire ledger fields from
@@ -3604,11 +3675,15 @@ pub(crate) fn managed_context_fission_group_view(
     }
 }
 
+/// Transport-neutral core of `GET /api/managed-context/fission` (tunnel
+/// twin `api_managed_context_fission`): the deduped, capped fission
+/// groups from the home-scoped candidate scan, under the canonical json
+/// tail.
 pub(crate) fn managed_context_fission_response_from_home(
     request_line: &str,
     active_log_dir: Option<&Path>,
     home: &Path,
-) -> String {
+) -> ApiResponse {
     let session_id = managed_context_query_session_id(request_line);
     let wrapper_session_id = managed_context_query_wrapper_session_id(request_line);
     let mut filter_session_ids = Vec::new();
@@ -3662,22 +3737,25 @@ pub(crate) fn managed_context_fission_response_from_home(
                 &log_dir,
                 &filter_session_ids,
             ) {
-                return json_error(
-                    "500 Internal Server Error",
+                return ApiResponse::json_error(
+                    500,
                     format!("failed to read managed-context fission groups: {err}"),
                 );
             }
         }
     } else if active_log_dir.is_some() {
-        return json_ok(serde_json::json!({ "groups": [] }));
+        return ApiResponse::json(200, JsonBody::Value(serde_json::json!({ "groups": [] })));
     } else if session_id.is_none() && wrapper_session_id.is_none() {
-        return json_error(
-            "404 Not Found",
+        return ApiResponse::json_error(
+            404,
             "managed-context fission groups need an active session log",
         );
     } else {
         let Some(log_dir) = active_log_dir else {
-            return json_ok(serde_json::json!({ "groups": groups }));
+            return ApiResponse::json(
+                200,
+                JsonBody::Value(serde_json::json!({ "groups": groups })),
+            );
         };
         if let Err(err) = append_managed_context_fission_groups_from_dir(
             &mut groups,
@@ -3685,8 +3763,8 @@ pub(crate) fn managed_context_fission_response_from_home(
             log_dir,
             &filter_session_ids,
         ) {
-            return json_error(
-                "500 Internal Server Error",
+            return ApiResponse::json_error(
+                500,
                 format!("failed to read managed-context fission groups: {err}"),
             );
         }
@@ -3696,7 +3774,7 @@ pub(crate) fn managed_context_fission_response_from_home(
     let mut seen_groups = HashSet::new();
     groups.retain(|group| seen_groups.insert(group.group_id.clone()));
     groups.truncate(MANAGED_CONTEXT_FISSION_GROUP_LIMIT);
-    json_ok(serde_json::json!({ "groups": groups }))
+    ApiResponse::json(200, JsonBody::Value(serde_json::json!({ "groups": groups })))
 }
 
 /// Delete session data: entire session, media, recordings, frames, or turns.
@@ -4165,11 +4243,11 @@ mod tests {
         )
         .unwrap();
 
-        let response = managed_context_records_response_from_home(
+        let response = test_render_api_response(managed_context_records_response_from_home(
             "GET /api/managed-context/records?session_id=codex-thread-a HTTP/1.1",
             Some(active.path()),
             home.path(),
-        );
+        ));
         let body = response_json_body(&response);
         let ids: Vec<_> = body["records"]
             .as_array()
@@ -4218,11 +4296,11 @@ mod tests {
         )
         .unwrap();
 
-        let response = managed_context_records_response_from_home(
+        let response = test_render_api_response(managed_context_records_response_from_home(
             "GET /api/managed-context/records?session_id=wrapper-session HTTP/1.1",
             Some(active.path()),
             home.path(),
-        );
+        ));
         let body = response_json_body(&response);
         let ids: Vec<_> = body["records"]
             .as_array()
@@ -4293,11 +4371,11 @@ mod tests {
         crate::fission_ledger::detach_group(dir.path(), &detached.group_id, "anchor rewound away")
             .unwrap();
 
-        let response = managed_context_fission_response_from_home(
+        let response = test_render_api_response(managed_context_fission_response_from_home(
             "GET /api/managed-context/fission?session_id=fission-web-parent HTTP/1.1",
             Some(dir.path()),
             home.path(),
-        );
+        ));
         let body = response_json_body(&response);
         let groups = body["groups"].as_array().unwrap();
         assert_eq!(groups.len(), 2);
@@ -4341,11 +4419,11 @@ mod tests {
         );
 
         // A session id outside the connected component sees no groups.
-        let unrelated = managed_context_fission_response_from_home(
+        let unrelated = test_render_api_response(managed_context_fission_response_from_home(
             "GET /api/managed-context/fission?session_id=unrelated-session HTTP/1.1",
             Some(dir.path()),
             home.path(),
-        );
+        ));
         let unrelated_body = response_json_body(&unrelated);
         assert_eq!(unrelated_body["groups"].as_array().unwrap().len(), 0);
     }
@@ -4446,11 +4524,11 @@ mod tests {
         )
         .unwrap();
 
-        let response = managed_context_anchors_response_from_home(
+        let response = test_render_api_response(managed_context_anchors_response_from_home(
             "GET /api/managed-context/anchors?session_id=wrapper-a HTTP/1.1",
             Some(active.path()),
             home.path(),
-        );
+        ));
         let body = response_json_body(&response);
         let anchors = body["anchors"].as_array().unwrap();
         assert_eq!(anchors.len(), 1);
@@ -4486,11 +4564,11 @@ mod tests {
         )
         .unwrap();
 
-        let response = managed_context_anchors_response_from_home(
+        let response = test_render_api_response(managed_context_anchors_response_from_home(
             "GET /api/managed-context/anchors?session_id=codex-thread-a&backend_session_id=codex-thread-a&intendant_session_id=wrapper-stale HTTP/1.1",
             Some(active.path()),
             home.path(),
-        );
+        ));
         let body = response_json_body(&response);
         let anchors = body["anchors"].as_array().unwrap();
         assert_eq!(anchors.len(), 1);
@@ -5918,7 +5996,12 @@ mod tests {
         ] {
             let _ = make;
             let response = collect_session_handler_response(|stream| {
-                handle_current_history(stream, None)
+                handle_current_history(
+                    stream,
+                    None,
+                    crate::gateway_routes::CorsPosture::OwnOrigin,
+                    None,
+                )
             })
             .await;
             assert_eq!(
@@ -5930,7 +6013,13 @@ mod tests {
             );
         }
         let response = collect_session_handler_response(|stream| {
-            handle_current_redo(stream, None, None)
+            handle_current_redo(
+                stream,
+                None,
+                None,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            )
         })
         .await;
         assert_eq!(
@@ -5941,7 +6030,12 @@ mod tests {
             )
         );
         let response = collect_session_handler_response(|stream| {
-            handle_current_prune(stream, None)
+            handle_current_prune(
+                stream,
+                None,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            )
         })
         .await;
         assert_eq!(
@@ -5953,7 +6047,15 @@ mod tests {
         );
         let bus = crate::event::EventBus::new();
         let response = collect_session_handler_response(|stream| {
-            handle_current_rollback(stream, "{}".to_string(), bus, None, None)
+            handle_current_rollback(
+                stream,
+                "{}".to_string(),
+                bus,
+                None,
+                None,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            )
         })
         .await;
         assert_eq!(
@@ -5973,6 +6075,8 @@ mod tests {
                 "GET /api/session/current/changes HTTP/1.1",
                 None,
                 None,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
             )
         })
         .await;
@@ -5988,7 +6092,14 @@ mod tests {
     #[tokio::test]
     async fn golden_current_agent_output_without_log_transcript() {
         let response = collect_session_handler_response(|stream| {
-            handle_current_agent_output(stream, r#"{"ids":["x"]}"#.to_string(), None, None)
+            handle_current_agent_output(
+                stream,
+                r#"{"ids":["x"]}"#.to_string(),
+                None,
+                None,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            )
         })
         .await;
         assert_eq!(
@@ -6006,29 +6117,29 @@ mod tests {
         // bodies and framing are the pin (query names one session id so
         // the scan stays home-scoped).
         let home = tempfile::tempdir().unwrap();
-        let anchors = managed_context_anchors_response_from_home(
+        let anchors = test_render_api_response(managed_context_anchors_response_from_home(
             "GET /api/managed-context/anchors?session_id=abc123 HTTP/1.1",
             None,
             home.path(),
-        );
+        ));
         assert_eq!(
             anchors,
             golden_session_json_transcript("200 OK", r#"{"anchors":[]}"#)
         );
-        let records = managed_context_records_response_from_home(
+        let records = test_render_api_response(managed_context_records_response_from_home(
             "GET /api/managed-context/records?session_id=abc123 HTTP/1.1",
             None,
             home.path(),
-        );
+        ));
         assert_eq!(
             records,
             golden_session_json_transcript("200 OK", r#"{"records":[]}"#)
         );
-        let fission = managed_context_fission_response_from_home(
+        let fission = test_render_api_response(managed_context_fission_response_from_home(
             "GET /api/managed-context/fission?session_id=abc123 HTTP/1.1",
             None,
             home.path(),
-        );
+        ));
         assert_eq!(
             fission,
             golden_session_json_transcript("200 OK", r#"{"groups":[]}"#)

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -87,20 +87,6 @@ pub(crate) fn session_wildcard_json_error(status: u16, message: &str) -> ApiResp
     session_wildcard_json_response(status, serde_json::json!({ "error": message }).to_string())
 }
 
-/// Transitional raw-HTTP rendering for the tunnel callers that have not
-/// yet converted to [`ApiResponse`] (the S4c tunnel commit retires it
-/// with the last `http_wire_response` caller); byte-identical to the
-/// historical hand-rolled strings (the HTTP adapter's parity tests pin
-/// the framing).
-pub(crate) fn api_response_to_http_string(response: ApiResponse) -> String {
-    String::from_utf8_lossy(&api_response_http_bytes(
-        response,
-        crate::gateway_routes::CorsPosture::OwnOrigin,
-        None,
-    ))
-    .into_owned()
-}
-
 pub(crate) fn current_agent_output_response_for_ids(
     ids: Vec<String>,
     log_dir: &Path,
@@ -157,12 +143,6 @@ pub(crate) fn current_agent_output_api_response(body: &str, log_dir: &Path) -> A
         Ok(ids) => current_agent_output_response_for_ids(ids, log_dir),
         Err(e) => session_wildcard_json_error(400, &e),
     }
-}
-
-/// Transitional raw-string form for the unconverted tunnel twin (the
-/// S4c tunnel commit retires it together with `http_wire_response`).
-pub(crate) fn current_agent_output_post_response(body: &str, log_dir: &Path) -> String {
-    api_response_to_http_string(current_agent_output_api_response(body, log_dir))
 }
 
 pub(crate) fn external_agent_output_response_for_ids(
@@ -5161,8 +5141,10 @@ mod tests {
         log.agent_output_with_id("first output", "", Some("Codex"), Some("out-1"));
         drop(log);
 
-        let response =
-            current_agent_output_post_response(r#"{"ids":["out-1","missing-out"]}"#, &log_dir);
+        let response = test_render_api_response(current_agent_output_api_response(
+            r#"{"ids":["out-1","missing-out"]}"#,
+            &log_dir,
+        ));
         assert!(response.starts_with("HTTP/1.1 200 OK"));
 
         let body = response.split("\r\n\r\n").nth(1).unwrap();
@@ -5175,7 +5157,8 @@ mod tests {
     #[test]
     fn agent_output_post_response_rejects_empty_json_ids() {
         let dir = tempfile::tempdir().unwrap();
-        let response = current_agent_output_post_response(r#"{"ids":[""]}"#, dir.path());
+        let response =
+            test_render_api_response(current_agent_output_api_response(r#"{"ids":[""]}"#, dir.path()));
         assert!(response.starts_with("HTTP/1.1 400 Bad Request"));
         assert!(response.contains("missing output ids"));
     }


### PR DESCRIPTION
Stage S4 slice 3 of 3 of the transport-unification program (design §2.1–2.5, §6 S4, §8), following the S4a/S4b template (#146/#153). **Status: conversion COMPLETE — all four stages landed on this branch (goldens → HTTP side → tunnel side → rows/pins/docs, plus the orphaned `upload_only` constructor cleanup); gates green (full nextest 2881/2881, e2e 12/12, clippy warning-inventory identical to fork-point main, goldens byte-identical). Awaiting operator review before ready/queue.**

## Scope (13 pin flips planned, Residue → Row)

`api_session_current_history`, `api_session_current_rollback`, `api_session_current_redo`, `api_session_current_prune`, `api_session_current_changes`, `api_session_current_agent_output` (all SessionManage), `api_session_current_uploads`, `api_session_current_upload_raw` (BYTES lane), `api_session_current_upload_delete`, `api_session_current_upload` (UPLOAD lane, upload-frame-only — needs a non-advertised TunnelSpec shape), `api_managed_context_records`, `api_managed_context_anchors`, `api_managed_context_fission` (SessionInspect).

This slice retires the last `http_wire_response`/`split_http_response` callers (`api_session_current_agent_output_response`, `api_managed_context_response`) and the transitional `api_response_to_http_string` bridge — the raw-HTTP-string re-parse smell dies with it.

## Landed: golden transcripts (own commit, per template)

- current history/rollback/redo/prune 503 watcher-absent shapes; changes 503; current agent-output 404 — all under the **wildcard-CORS tail**
- staged-upload POST success on **both the project-rooted and projectless global-store paths** (PR #129 first-class), empty list, missing-raw 404, idempotent-ok delete (**canonical tail** — delete differs from its family)
- managed-context anchors/records/fission empty-home bodies — **canonical tail**

Surface facts the conversion must preserve (discovered + pinned): the `current/*` family rides the wildcard tail while managed-context and upload-delete ride the canonical tail; upload POST body arrives through dispatch's initial-request-bytes prefix (`initial_body_bytes` splits on the blank line — carriage is transport-owned, the commit leg is the already-shared `current_upload_commit_response_body`); the managed-context `*_response_from_home` builders return raw HTTP strings today and convert to `ApiResponse` returns; `api_session_current_uploads` (list) and `api_session_current_upload_raw` share the `Under(/api/session/current/uploads)` row today, so the list gets an `Exact` row and raw a `Segments(...,{id},raw)` row (capture named `id`, not `upload_id`: the facade's HTTP adapter lifts template segments by name and the shipped `DAEMON_API_HTTP_MAP` raw entry + its callers pass `{ id }` — the descriptor parity pin enforces it) carved ahead of it (`CurrentUploadsGet` joins the shared-handler allowlist).

## Stages (all landed, in order, per template)

1. HTTP-side neutral fns + shims (goldens must pass unchanged).
2. Tunnel delegation + parity fixtures with enumerated envelope differences (all thirteen ride the injected-status envelope today — no body-only exceptions in this family).
3. Rows (two carved upload rows + eleven `with_tunnel` columns; `api_session_current_upload` needs `advertised:false, upload:true`), 13 pin flips, docs regen.
4. Gates: full nextest, e2e, clippy-vs-baseline, `--color-moved`.

