### PR TITLE
Vault: write-only CLI deposits (plaintext never rides a web UI)

### DIFF
--- a/docs/src/credential-custody.md
+++ b/docs/src/credential-custody.md
@@ -148,10 +148,33 @@ credential lease is already scoped, time-boxed, and revocable (below).
 Users who refuse hosted-origin unsealing browse from an anchor origin —
 both escape hatches stay first-class.
 
-**Reserved, not v1:** an asymmetric sealing half (X25519 keypair derived
-from the same PRF secret, public key published) that would let *daemons*
-seal secrets into the vault one-way — the org-root-key-backup tenant.
-The format reserves an `envelopes[].kind = "sealed"` variant for it.
+**The write-only deposit lane** (`intendant vault deposit <label>`) is
+the asymmetric sealing half, shipped: a P-256 deposit keypair lives
+*inside* the sealed body (`settings.deposit_lane`, so it reaches every
+unlocking device but exists only as ciphertext at rest), and an unlocked
+dashboard publishes its public half to the daemon
+(`~/.intendant/vault-deposit-key.pub.json`). The CLI reads a secret from
+**stdin** — piped, so the plaintext never rides a web UI, a terminal
+echo, or this daemon's disk — seals it ECIES-style to that public key
+(ephemeral P-256 → HKDF-SHA256 → AES-256-GCM, the label bound into both
+the KDF info and the AEAD AAD), and queues one ciphertext record per
+deposit under `~/.intendant/vault-deposits.d/`. The next unlocked
+dashboard on this daemon folds queued deposits into the vault as
+ordinary entries and deletes them **only after** the re-wrapped blob has
+published; a deposit sealed to a superseded key stays queued and visible
+(`intendant vault status`) rather than being consumed blind. Honest
+limits: the depositing CLI trusts the machine it runs on — a malicious
+daemon could swap the deposit key and capture *future* deposits (it
+still can never read the vault), and deposits are write-only by
+construction: nothing on the CLI side can read an entry back out. The
+implementation pair is `vault_deposits.rs` (seal) and
+`32-vault-custody.js` (open); `scripts/vault-deposit-parity.cjs`
+cross-checks the two against real WebCrypto.
+
+**Still reserved, not v1:** deriving the deposit keypair from the PRF
+secret itself (today it is generated randomly and rides the blob), and
+the org-root-key-backup tenant with its `envelopes[].kind = "sealed"`
+variant.
 
 ## Authority transport: credential leases
 

--- a/scripts/vault-deposit-parity.cjs
+++ b/scripts/vault-deposit-parity.cjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/* Cross-implementation parity check for the write-only vault deposit lane:
+   the Rust CLI seals (src/bin/caller/vault_deposits.rs), real WebCrypto
+   opens (the same calls 32-vault-custody.js makes). Run it locally after
+   touching either side — it is deliberately not in CI (needs a built
+   binary):
+
+     cargo build --bin intendant
+     node scripts/vault-deposit-parity.cjs ./target/debug/intendant
+
+   Exit 0 = the two implementations agree byte for byte. */
+'use strict';
+const { webcrypto } = require('node:crypto');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const subtle = webcrypto.subtle;
+const INFO = 'intendant-vault-deposit-v1';
+
+function b64u(bytes) {
+  return Buffer.from(bytes).toString('base64url');
+}
+function fromB64u(text) {
+  return new Uint8Array(Buffer.from(String(text), 'base64url'));
+}
+function concatBytes(...parts) {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let offset = 0;
+  for (const p of parts) { out.set(p, offset); offset += p.length; }
+  return out;
+}
+
+async function main() {
+  const binary = process.argv[2] || './target/debug/intendant';
+  if (!fs.existsSync(binary)) {
+    console.error(`binary not found: ${binary} (build it first)`);
+    process.exit(2);
+  }
+
+  // The "vault": a real WebCrypto P-256 keypair, exactly as the dashboard
+  // generates it.
+  const pair = await subtle.generateKey({ name: 'ECDH', namedCurve: 'P-256' }, true, ['deriveBits']);
+  const pubRaw = new Uint8Array(await subtle.exportKey('raw', pair.publicKey));
+
+  // A scratch daemon state root holding only the published deposit key.
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'vault-parity-'));
+  try {
+    fs.writeFileSync(path.join(home, 'vault-deposit-key.pub.json'), JSON.stringify({
+      alg: 'ECDH-P256',
+      pub_raw_b64u: b64u(pubRaw),
+      published_unix_ms: Date.now(),
+    }));
+
+    const label = 'parity gh-token';
+    const secret = 'correct horse battery staple — π🔑';
+    execFileSync(binary, ['vault', 'deposit', label], {
+      input: secret + '\n',
+      env: { ...process.env, INTENDANT_HOME: home },
+      stdio: ['pipe', 'inherit', 'inherit'],
+    });
+
+    const dir = path.join(home, 'vault-deposits.d');
+    const files = fs.readdirSync(dir).filter(f => f.endsWith('.json'));
+    if (files.length !== 1) throw new Error(`expected 1 deposit record, found ${files.length}`);
+    const record = JSON.parse(fs.readFileSync(path.join(dir, files[0]), 'utf8'));
+    if (record.alg !== 'ECIES-P256-HKDF-SHA256-A256GCM') {
+      throw new Error(`unexpected alg ${record.alg}`);
+    }
+    if (record.label !== label) throw new Error(`label mismatch: ${record.label}`);
+
+    // Open with the dashboard's exact algorithm (vaultOpenDeposit).
+    const encoder = new TextEncoder();
+    const ephRaw = fromB64u(record.eph_pub_raw_b64u);
+    const ephKey = await subtle.importKey('raw', ephRaw, { name: 'ECDH', namedCurve: 'P-256' }, false, []);
+    const shared = new Uint8Array(await subtle.deriveBits({ name: 'ECDH', public: ephKey }, pair.privateKey, 256));
+    const info = concatBytes(encoder.encode(INFO), ephRaw, pubRaw, encoder.encode(record.label));
+    const hkdfKey = await subtle.importKey('raw', shared, 'HKDF', false, ['deriveKey']);
+    const aesKey = await subtle.deriveKey(
+      { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info },
+      hkdfKey, { name: 'AES-GCM', length: 256 }, false, ['decrypt']);
+    const plain = await subtle.decrypt(
+      {
+        name: 'AES-GCM',
+        iv: fromB64u(record.nonce_b64u),
+        additionalData: encoder.encode(`${INFO}:${record.label}`),
+      },
+      aesKey, fromB64u(record.ct_b64u));
+    const text = new TextDecoder().decode(plain);
+    if (text !== secret) throw new Error(`plaintext mismatch: ${JSON.stringify(text)}`);
+
+    // Tamper check: a different label must fail AAD/KDF binding.
+    let tamperFailed = false;
+    try {
+      const badInfo = concatBytes(encoder.encode(INFO), ephRaw, pubRaw, encoder.encode('other'));
+      const badKey = await subtle.deriveKey(
+        { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info: badInfo },
+        hkdfKey, { name: 'AES-GCM', length: 256 }, false, ['decrypt']);
+      await subtle.decrypt(
+        { name: 'AES-GCM', iv: fromB64u(record.nonce_b64u), additionalData: encoder.encode(`${INFO}:other`) },
+        badKey, fromB64u(record.ct_b64u));
+    } catch {
+      tamperFailed = true;
+    }
+    if (!tamperFailed) throw new Error('tampered label decrypted — binding broken');
+
+    console.log('PARITY OK: rust seal ↔ webcrypto open agree (round-trip + label binding)');
+  } finally {
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+main().catch(err => {
+  console.error('PARITY FAILED:', err.message || err);
+  process.exit(1);
+});

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -365,6 +365,101 @@ pub(crate) fn control_frame_response(
                         Err(error) => dashboard_control_error_response(id, error.message()),
                     })
                 }
+                "api_daemon_vault_deposit_key_fetch" => {
+                    let result = match crate::vault_deposits::load_deposit_key_in(
+                        &crate::vault_deposits::deposit_key_path(),
+                    ) {
+                        Ok(Some(key)) => serde_json::json!({
+                            "present": true,
+                            "alg": key.alg,
+                            "pub_raw_b64u": key.pub_raw_b64u,
+                            "published_unix_ms": key.published_unix_ms,
+                        }),
+                        Ok(None) => serde_json::json!({ "present": false }),
+                        Err(error) => {
+                            return Some(dashboard_control_error_response(id, error))
+                        }
+                    };
+                    Some(serde_json::json!({
+                        "t": "response",
+                        "id": id,
+                        "ok": true,
+                        "result": result,
+                    }))
+                }
+                "api_daemon_vault_deposit_key_publish" => {
+                    let params_ref = params.as_ref();
+                    let pub_raw_b64u = params_ref
+                        .and_then(|p| p.get("pub_raw_b64u"))
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string)
+                        .unwrap_or_default();
+                    let alg = params_ref
+                        .and_then(|p| p.get("alg"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("ECDH-P256")
+                        .to_string();
+                    let key = crate::vault_deposits::DepositKey {
+                        alg,
+                        pub_raw_b64u,
+                        published_unix_ms: chrono::Utc::now().timestamp_millis().max(0) as u64,
+                    };
+                    Some(
+                        match crate::vault_deposits::save_deposit_key_in(
+                            &crate::vault_deposits::deposit_key_path(),
+                            &key,
+                        ) {
+                            Ok(()) => serde_json::json!({
+                                "t": "response",
+                                "id": id,
+                                "ok": true,
+                                "result": { "stored": true },
+                            }),
+                            Err(error) => dashboard_control_error_response(id, error),
+                        },
+                    )
+                }
+                "api_daemon_vault_deposits_fetch" => {
+                    Some(
+                        match crate::vault_deposits::list_deposits_in(
+                            &crate::vault_deposits::deposits_dir(),
+                        ) {
+                            Ok(deposits) => serde_json::json!({
+                                "t": "response",
+                                "id": id,
+                                "ok": true,
+                                "result": {
+                                    "deposits": serde_json::to_value(&deposits)
+                                        .unwrap_or(serde_json::Value::Null),
+                                },
+                            }),
+                            Err(error) => dashboard_control_error_response(id, error),
+                        },
+                    )
+                }
+                "api_daemon_vault_deposits_consume" => {
+                    let ids: Vec<String> = params
+                        .as_ref()
+                        .and_then(|p| p.get("ids"))
+                        .and_then(|v| v.as_array())
+                        .map(|list| {
+                            list.iter()
+                                .filter_map(|v| v.as_str())
+                                .map(str::to_string)
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let removed = crate::vault_deposits::consume_deposits_in(
+                        &crate::vault_deposits::deposits_dir(),
+                        &ids,
+                    );
+                    Some(serde_json::json!({
+                        "t": "response",
+                        "id": id,
+                        "ok": true,
+                        "result": { "removed": removed },
+                    }))
+                }
                 "api_credential_egress_register" => {
                     let kinds: Vec<String> = params
                         .as_ref()

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -189,6 +189,14 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
     // and revision history are custody-sensitive.
     method("api_daemon_vault_fetch", PeerOperation::CredentialsManage),
     method("api_daemon_vault_publish", PeerOperation::CredentialsManage),
+    // Write-only vault deposits (vault_deposits.rs): the dashboard
+    // publishes the vault's deposit public key here and folds queued
+    // deposits into the blob on unlock. All ciphertext/public material —
+    // the daemon can neither read deposits nor mint vault entries.
+    method("api_daemon_vault_deposit_key_fetch", PeerOperation::CredentialsManage),
+    method("api_daemon_vault_deposit_key_publish", PeerOperation::CredentialsManage),
+    method("api_daemon_vault_deposits_fetch", PeerOperation::CredentialsManage),
+    method("api_daemon_vault_deposits_consume", PeerOperation::CredentialsManage),
     method(
         "api_credential_egress_register",
         PeerOperation::CredentialsManage,
@@ -3098,6 +3106,26 @@ mod tests {
             ),
             (
                 "api_daemon_vault_publish",
+                Residue,
+                Some(Op::CredentialsManage),
+            ),
+            (
+                "api_daemon_vault_deposit_key_fetch",
+                Residue,
+                Some(Op::CredentialsManage),
+            ),
+            (
+                "api_daemon_vault_deposit_key_publish",
+                Residue,
+                Some(Op::CredentialsManage),
+            ),
+            (
+                "api_daemon_vault_deposits_fetch",
+                Residue,
+                Some(Op::CredentialsManage),
+            ),
+            (
+                "api_daemon_vault_deposits_consume",
                 Residue,
                 Some(Op::CredentialsManage),
             ),

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -76,6 +76,7 @@ mod transcription;
 mod transfer_store;
 mod types;
 mod upload_store;
+mod vault_deposits;
 mod vault_store;
 mod virtual_display;
 pub(crate) use intendant_platform::vision;
@@ -3169,6 +3170,10 @@ async fn main() -> Result<(), CallerError> {
     // Intercept `intendant access <action>` before the main runtime setup.
     // This is a local certificate/enrollment path with no project, no .env,
     // and no provider selection.
+    if env::args().nth(1).as_deref() == Some("vault") {
+        let argv: Vec<String> = env::args().skip(2).collect();
+        std::process::exit(vault_deposits::run_vault_cli(argv).await);
+    }
     if env::args().nth(1).as_deref() == Some("access") {
         #[cfg(not(target_os = "windows"))]
         {

--- a/src/bin/caller/vault_deposits.rs
+++ b/src/bin/caller/vault_deposits.rs
@@ -1,0 +1,524 @@
+//! Write-only vault deposits: the CLI lane that gets a secret INTO the
+//! vault without the plaintext ever riding a web UI — and without this
+//! daemon being able to read it afterwards.
+//!
+//! The vault blob is a single sealed body (`32-vault-custody.js`): nothing
+//! outside a browser holding the master key can append inside it. So a
+//! deposit is a sidecar: an ECIES envelope to the vault's deposit public
+//! key, queued as one file per record on this daemon's disk, folded into
+//! the blob by the next unlocked dashboard, then consumed (deleted) once
+//! the re-wrapped blob has been published.
+//!
+//! Wire/crypto format (v1) — the browser mirror lives in
+//! `32-vault-custody.js` (`vaultConsumeDeposits`), and
+//! `scripts/vault-deposit-parity.cjs` cross-checks the two
+//! implementations against each other with real WebCrypto:
+//!
+//! - recipient key: P-256, raw uncompressed point (65 bytes, base64url),
+//!   published by an unlocked dashboard into `vault-deposit-key.pub.json`
+//!   under the daemon state root. Public material — world-readable is fine.
+//! - seal: ephemeral P-256 → ECDH → HKDF-SHA256 with empty salt and
+//!   `info = "intendant-vault-deposit-v1" || eph_pub_raw ||
+//!   recipient_pub_raw || label_utf8` → AES-256-GCM key; random 96-bit
+//!   nonce; `AAD = "intendant-vault-deposit-v1:" || label_utf8` (binds the
+//!   label the depositor typed to the ciphertext).
+//! - record: one JSON file per deposit under `vault-deposits.d/` —
+//!   atomic create, so a depositing CLI and a consuming dashboard never
+//!   race on a shared file.
+//!
+//! Trust notes: the deposit CLI trusts the local pubkey file exactly as
+//! far as it trusts the machine it runs on (same boundary as the daemon
+//! state root itself). A malicious daemon could swap the deposit key and
+//! capture FUTURE deposits — it cannot read existing vault entries, and
+//! the dashboard's fold step surfaces every consumed deposit visibly.
+
+use ring::aead;
+use ring::agreement;
+use ring::rand::{SecureRandom, SystemRandom};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+const DEPOSIT_VERSION_INFO: &[u8] = b"intendant-vault-deposit-v1";
+const DEPOSIT_AAD_PREFIX: &[u8] = b"intendant-vault-deposit-v1:";
+const DEPOSIT_KEY_ALG: &str = "ECDH-P256";
+const DEPOSIT_SEAL_ALG: &str = "ECIES-P256-HKDF-SHA256-A256GCM";
+/// Uncompressed SEC1 P-256 point: 0x04 || X (32) || Y (32).
+const P256_POINT_LEN: usize = 65;
+
+/// The vault's deposit public key, as published by an unlocked dashboard.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DepositKey {
+    pub alg: String,
+    pub pub_raw_b64u: String,
+    #[serde(default)]
+    pub published_unix_ms: u64,
+}
+
+/// One sealed deposit, queued for the next unlocked dashboard.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DepositRecord {
+    pub id: String,
+    pub label: String,
+    pub created_unix_ms: u64,
+    pub alg: String,
+    pub eph_pub_raw_b64u: String,
+    pub nonce_b64u: String,
+    pub ct_b64u: String,
+}
+
+pub fn deposit_key_path() -> PathBuf {
+    crate::platform::intendant_home().join("vault-deposit-key.pub.json")
+}
+
+pub fn deposits_dir() -> PathBuf {
+    crate::platform::intendant_home().join("vault-deposits.d")
+}
+
+fn b64u(bytes: &[u8]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn from_b64u(text: &str) -> Result<Vec<u8>, String> {
+    use base64::Engine as _;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(text.trim())
+        .map_err(|e| format!("invalid base64url: {e}"))
+}
+
+fn now_unix_ms() -> u64 {
+    crate::access::client_key::now_unix_ms().max(0) as u64
+}
+
+fn format_unix_ms(ms: u64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms as i64)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M UTC").to_string())
+        .unwrap_or_else(|| ms.to_string())
+}
+
+// ── deposit key file ──
+
+pub fn save_deposit_key_in(path: &Path, key: &DepositKey) -> Result<(), String> {
+    let point = from_b64u(&key.pub_raw_b64u)?;
+    if key.alg != DEPOSIT_KEY_ALG {
+        return Err(format!("unsupported deposit key alg {}", key.alg));
+    }
+    if point.len() != P256_POINT_LEN || point[0] != 0x04 {
+        return Err("deposit key must be an uncompressed P-256 point".to_string());
+    }
+    let text = serde_json::to_string_pretty(key).map_err(|e| e.to_string())?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create {}: {e}", parent.display()))?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, text).map_err(|e| format!("write {}: {e}", tmp.display()))?;
+    std::fs::rename(&tmp, path).map_err(|e| format!("finalize {}: {e}", path.display()))
+}
+
+pub fn load_deposit_key_in(path: &Path) -> Result<Option<DepositKey>, String> {
+    let text = match std::fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(format!("read {}: {e}", path.display())),
+    };
+    serde_json::from_str(&text)
+        .map(Some)
+        .map_err(|e| format!("parse {}: {e}", path.display()))
+}
+
+// ── sealing (the CLI side; the browser opens) ──
+
+fn hkdf_aes256_key(shared_secret: &[u8], info_parts: &[&[u8]]) -> Result<[u8; 32], String> {
+    struct Len32;
+    impl ring::hkdf::KeyType for Len32 {
+        fn len(&self) -> usize {
+            32
+        }
+    }
+    let salt = ring::hkdf::Salt::new(ring::hkdf::HKDF_SHA256, &[]);
+    let prk = salt.extract(shared_secret);
+    let okm = prk
+        .expand(info_parts, Len32)
+        .map_err(|_| "HKDF expand failed".to_string())?;
+    let mut key = [0u8; 32];
+    okm.fill(&mut key)
+        .map_err(|_| "HKDF fill failed".to_string())?;
+    Ok(key)
+}
+
+fn aead_key(key_bytes: &[u8; 32]) -> Result<aead::LessSafeKey, String> {
+    let unbound = aead::UnboundKey::new(&aead::AES_256_GCM, key_bytes)
+        .map_err(|_| "AEAD key init failed".to_string())?;
+    Ok(aead::LessSafeKey::new(unbound))
+}
+
+fn deposit_aad(label: &str) -> Vec<u8> {
+    let mut aad = DEPOSIT_AAD_PREFIX.to_vec();
+    aad.extend_from_slice(label.as_bytes());
+    aad
+}
+
+/// Seal `secret` to the vault's deposit public key. The ephemeral private
+/// key never leaves this function; the daemon (and any later reader of
+/// the record) holds only ciphertext.
+pub fn seal_deposit(
+    recipient_pub_raw: &[u8],
+    label: &str,
+    secret: &[u8],
+) -> Result<DepositRecord, String> {
+    if recipient_pub_raw.len() != P256_POINT_LEN || recipient_pub_raw[0] != 0x04 {
+        return Err("recipient key must be an uncompressed P-256 point".to_string());
+    }
+    let rng = SystemRandom::new();
+    let eph = agreement::EphemeralPrivateKey::generate(&agreement::ECDH_P256, &rng)
+        .map_err(|_| "ephemeral key generation failed".to_string())?;
+    let eph_pub = eph
+        .compute_public_key()
+        .map_err(|_| "ephemeral public key failed".to_string())?;
+    let eph_pub_raw = eph_pub.as_ref().to_vec();
+    let recipient = agreement::UnparsedPublicKey::new(&agreement::ECDH_P256, recipient_pub_raw);
+
+    let key_bytes = agreement::agree_ephemeral(eph, &recipient, |shared| {
+        hkdf_aes256_key(
+            shared,
+            &[
+                DEPOSIT_VERSION_INFO,
+                &eph_pub_raw,
+                recipient_pub_raw,
+                label.as_bytes(),
+            ],
+        )
+    })
+    .map_err(|_| "ECDH agreement failed (malformed recipient key?)".to_string())??;
+
+    let key = aead_key(&key_bytes)?;
+    let mut nonce_bytes = [0u8; 12];
+    rng.fill(&mut nonce_bytes)
+        .map_err(|_| "nonce generation failed".to_string())?;
+    let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes);
+    let mut in_out = secret.to_vec();
+    key.seal_in_place_append_tag(nonce, aead::Aad::from(deposit_aad(label)), &mut in_out)
+        .map_err(|_| "seal failed".to_string())?;
+
+    let mut id_bytes = [0u8; 12];
+    rng.fill(&mut id_bytes)
+        .map_err(|_| "id generation failed".to_string())?;
+    Ok(DepositRecord {
+        id: format!("dep-{}", b64u(&id_bytes)),
+        label: label.to_string(),
+        created_unix_ms: now_unix_ms(),
+        alg: DEPOSIT_SEAL_ALG.to_string(),
+        eph_pub_raw_b64u: b64u(&eph_pub_raw),
+        nonce_b64u: b64u(&nonce_bytes),
+        ct_b64u: b64u(&in_out),
+    })
+}
+
+// ── the per-record queue ──
+
+pub fn store_deposit_in(dir: &Path, record: &DepositRecord) -> Result<PathBuf, String> {
+    std::fs::create_dir_all(dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+    let path = dir.join(format!("{}.json", record.id));
+    let tmp = dir.join(format!("{}.json.tmp", record.id));
+    let text = serde_json::to_string_pretty(record).map_err(|e| e.to_string())?;
+    std::fs::write(&tmp, text).map_err(|e| format!("write {}: {e}", tmp.display()))?;
+    restrict_file(&tmp);
+    std::fs::rename(&tmp, &path).map_err(|e| format!("finalize {}: {e}", path.display()))?;
+    Ok(path)
+}
+
+pub fn list_deposits_in(dir: &Path) -> Result<Vec<DepositRecord>, String> {
+    let mut records = Vec::new();
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(records),
+        Err(e) => return Err(format!("read {}: {e}", dir.display())),
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        match std::fs::read_to_string(&path)
+            .map_err(|e| e.to_string())
+            .and_then(|text| serde_json::from_str::<DepositRecord>(&text).map_err(|e| e.to_string()))
+        {
+            Ok(record) => records.push(record),
+            Err(e) => eprintln!("[vault-deposits] skipping {}: {e}", path.display()),
+        }
+    }
+    records.sort_by_key(|r| (r.created_unix_ms, r.id.clone()));
+    Ok(records)
+}
+
+/// Delete consumed records. Only called after the dashboard reports the
+/// re-wrapped blob was published; missing files are fine (another
+/// dashboard may have consumed concurrently).
+pub fn consume_deposits_in(dir: &Path, ids: &[String]) -> usize {
+    let mut removed = 0;
+    for id in ids {
+        // Ids are self-minted (`dep-<b64url>`); refuse anything that
+        // could traverse.
+        if id.is_empty() || id.contains(['/', '\\', '.']) {
+            continue;
+        }
+        let path = dir.join(format!("{id}.json"));
+        if std::fs::remove_file(&path).is_ok() {
+            removed += 1;
+        }
+    }
+    removed
+}
+
+fn restrict_file(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(metadata) = std::fs::metadata(path) {
+            let mut perms = metadata.permissions();
+            perms.set_mode(0o600);
+            let _ = std::fs::set_permissions(path, perms);
+        }
+    }
+}
+
+// ── CLI: `intendant vault deposit <label>` ──
+
+pub async fn run_vault_cli(args: Vec<String>) -> i32 {
+    match args.first().map(String::as_str) {
+        Some("deposit") => cli_deposit(&args[1..]),
+        Some("status") => cli_status(),
+        _ => {
+            print_vault_usage();
+            2
+        }
+    }
+}
+
+fn print_vault_usage() {
+    println!("Usage:");
+    println!("    intendant vault deposit <label>   # seal a secret INTO the vault (write-only)");
+    println!("    intendant vault status            # deposit key + pending deposit count");
+    println!();
+    println!("  `deposit` reads the secret from stdin. Pipe it to keep it out of the");
+    println!("  terminal: `pbpaste | intendant vault deposit gh-token`. The secret is");
+    println!("  sealed to the vault's deposit key on this machine; only an unlocked");
+    println!("  dashboard can read it, and this CLI cannot read anything back out.");
+}
+
+fn cli_status() -> i32 {
+    match load_deposit_key_in(&deposit_key_path()) {
+        Ok(Some(key)) => {
+            println!(
+                "deposit key: present ({}, published {})",
+                key.alg,
+                format_unix_ms(key.published_unix_ms)
+            );
+        }
+        Ok(None) => {
+            println!("deposit key: none — unlock the vault in a dashboard on this daemon once");
+        }
+        Err(e) => {
+            eprintln!("deposit key: unreadable: {e}");
+            return 1;
+        }
+    }
+    match list_deposits_in(&deposits_dir()) {
+        Ok(records) => {
+            println!("pending deposits: {}", records.len());
+            for record in records {
+                println!(
+                    "  {}  {}  ({})",
+                    record.id,
+                    record.label,
+                    format_unix_ms(record.created_unix_ms)
+                );
+            }
+            0
+        }
+        Err(e) => {
+            eprintln!("pending deposits: unreadable: {e}");
+            1
+        }
+    }
+}
+
+fn cli_deposit(args: &[String]) -> i32 {
+    let Some(label) = args.first().map(|s| s.trim()).filter(|s| !s.is_empty()) else {
+        eprintln!("usage: intendant vault deposit <label>   (secret on stdin)");
+        return 2;
+    };
+    let key = match load_deposit_key_in(&deposit_key_path()) {
+        Ok(Some(key)) => key,
+        Ok(None) => {
+            eprintln!("No vault deposit key on this daemon yet.");
+            eprintln!("Unlock the vault once in a dashboard connected to this daemon —");
+            eprintln!("it publishes the deposit public key here, after which deposits work");
+            eprintln!("even while the vault stays locked.");
+            return 1;
+        }
+        Err(e) => {
+            eprintln!("deposit key unreadable: {e}");
+            return 1;
+        }
+    };
+    let recipient = match from_b64u(&key.pub_raw_b64u) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            eprintln!("deposit key corrupt: {e}");
+            return 1;
+        }
+    };
+
+    use std::io::IsTerminal;
+    use std::io::Read;
+    if std::io::stdin().is_terminal() {
+        eprintln!("Reading the secret from stdin. NOTE: typed input echoes in this");
+        eprintln!("terminal — prefer piping (`pbpaste | intendant vault deposit {label}`).");
+        eprintln!("End with Ctrl-D on an empty line.");
+    }
+    let mut secret = String::new();
+    if let Err(e) = std::io::stdin().read_to_string(&mut secret) {
+        eprintln!("failed to read secret from stdin: {e}");
+        return 1;
+    }
+    let trimmed = secret.trim_end_matches(['\r', '\n']);
+    if trimmed.is_empty() {
+        eprintln!("empty secret; nothing deposited");
+        return 1;
+    }
+
+    match seal_deposit(&recipient, label, trimmed.as_bytes())
+        .and_then(|record| store_deposit_in(&deposits_dir(), &record).map(|path| (record, path)))
+    {
+        Ok((record, _path)) => {
+            println!("Sealed deposit {} ({label}).", record.id);
+            println!("It will appear in the vault the next time an owner unlocks it in a");
+            println!("dashboard connected to this daemon. This machine holds only ciphertext.");
+            0
+        }
+        Err(e) => {
+            eprintln!("deposit failed: {e}");
+            1
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Recipient side, test-only: ring's agreement API is ephemeral-only
+    /// by design, so the "vault" here is a second ephemeral keypair —
+    /// which is exactly the browser's math (ECDH is symmetric in the two
+    /// key roles).
+    fn open_deposit(
+        recipient_priv: agreement::EphemeralPrivateKey,
+        recipient_pub_raw: &[u8],
+        record: &DepositRecord,
+    ) -> Result<Vec<u8>, String> {
+        let eph_pub_raw = from_b64u(&record.eph_pub_raw_b64u)?;
+        let eph_pub = agreement::UnparsedPublicKey::new(&agreement::ECDH_P256, &eph_pub_raw);
+        let key_bytes = agreement::agree_ephemeral(recipient_priv, &eph_pub, |shared| {
+            hkdf_aes256_key(
+                shared,
+                &[
+                    DEPOSIT_VERSION_INFO,
+                    &eph_pub_raw,
+                    recipient_pub_raw,
+                    record.label.as_bytes(),
+                ],
+            )
+        })
+        .map_err(|_| "agree failed".to_string())??;
+        let key = aead_key(&key_bytes)?;
+        let nonce_bytes: [u8; 12] = from_b64u(&record.nonce_b64u)?
+            .try_into()
+            .map_err(|_| "bad nonce".to_string())?;
+        let mut ct = from_b64u(&record.ct_b64u)?;
+        let plain = key
+            .open_in_place(
+                aead::Nonce::assume_unique_for_key(nonce_bytes),
+                aead::Aad::from(deposit_aad(&record.label)),
+                &mut ct,
+            )
+            .map_err(|_| "open failed".to_string())?;
+        Ok(plain.to_vec())
+    }
+
+    fn test_recipient() -> (agreement::EphemeralPrivateKey, Vec<u8>) {
+        let rng = SystemRandom::new();
+        let priv_key =
+            agreement::EphemeralPrivateKey::generate(&agreement::ECDH_P256, &rng).unwrap();
+        let pub_raw = priv_key.compute_public_key().unwrap().as_ref().to_vec();
+        (priv_key, pub_raw)
+    }
+
+    #[test]
+    fn seal_round_trips_against_an_independent_recipient_implementation() {
+        let (recipient_priv, recipient_pub) = test_recipient();
+        let record = seal_deposit(&recipient_pub, "gh-token", b"hunter2-but-long").unwrap();
+        assert_eq!(record.alg, DEPOSIT_SEAL_ALG);
+        let plain = open_deposit(recipient_priv, &recipient_pub, &record).unwrap();
+        assert_eq!(plain, b"hunter2-but-long");
+    }
+
+    #[test]
+    fn tampered_label_fails_the_aad_binding() {
+        let (recipient_priv, recipient_pub) = test_recipient();
+        let mut record = seal_deposit(&recipient_pub, "gh-token", b"secret").unwrap();
+        record.label = "prod-db-password".to_string();
+        assert!(open_deposit(recipient_priv, &recipient_pub, &record).is_err());
+    }
+
+    #[test]
+    fn queue_stores_lists_and_consumes_per_record_files() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path().join("vault-deposits.d");
+        assert!(list_deposits_in(&dir).unwrap().is_empty());
+
+        let (_priv1, pub1) = test_recipient();
+        let a = seal_deposit(&pub1, "a", b"1").unwrap();
+        let b = seal_deposit(&pub1, "b", b"2").unwrap();
+        store_deposit_in(&dir, &a).unwrap();
+        store_deposit_in(&dir, &b).unwrap();
+        let listed = list_deposits_in(&dir).unwrap();
+        assert_eq!(listed.len(), 2);
+
+        assert_eq!(consume_deposits_in(&dir, &[a.id.clone()]), 1);
+        // Missing + traversal-shaped ids are ignored, not errors.
+        assert_eq!(
+            consume_deposits_in(&dir, &[a.id.clone(), "../etc/passwd".to_string()]),
+            0
+        );
+        let listed = list_deposits_in(&dir).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, b.id);
+    }
+
+    #[test]
+    fn deposit_key_file_round_trips_and_validates_the_point() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("vault-deposit-key.pub.json");
+        assert!(load_deposit_key_in(&path).unwrap().is_none());
+
+        let (_priv1, pub1) = test_recipient();
+        let key = DepositKey {
+            alg: DEPOSIT_KEY_ALG.to_string(),
+            pub_raw_b64u: b64u(&pub1),
+            published_unix_ms: 1,
+        };
+        save_deposit_key_in(&path, &key).unwrap();
+        let loaded = load_deposit_key_in(&path).unwrap().unwrap();
+        assert_eq!(loaded.pub_raw_b64u, key.pub_raw_b64u);
+
+        // A compressed/garbage point is refused at save time.
+        let bad = DepositKey {
+            alg: DEPOSIT_KEY_ALG.to_string(),
+            pub_raw_b64u: b64u(&[0x02; 33]),
+            published_unix_ms: 1,
+        };
+        assert!(save_deposit_key_in(&path, &bad).is_err());
+    }
+}

--- a/static/app.html
+++ b/static/app.html
@@ -27418,6 +27418,7 @@ async function vaultFinishUnlock(kBytes, envelopeId) {
       });
   }
   renderAccessVaultSection();
+  vaultDepositLaneSync().catch(() => {});
   return true;
 }
 
@@ -27734,6 +27735,140 @@ function vaultRemoveEntry(id) {
   vaultRevealedEntries.delete(id);
   vaultSyncVoiceMirror();
   return vaultQueuePersist();
+}
+
+/* ── Write-only deposits (the CLI lane) ──
+   `intendant vault deposit <label>` seals a secret to the vault's deposit
+   public key and queues it on the DAEMON (vault_deposits.rs) — the daemon
+   holds ciphertext only, and the plaintext never rides a web UI. After
+   every unlock we (1) ensure the deposit keypair exists inside the sealed
+   body's settings and publish its public half to this daemon, then
+   (2) fold queued deposits into the vault as ordinary entries, consuming
+   them only AFTER the re-wrapped blob has published. The crypto mirrors
+   vault_deposits.rs (v1) exactly: P-256 ECDH → HKDF-SHA256 (empty salt,
+   info = "intendant-vault-deposit-v1" || eph_pub || recipient_pub ||
+   label) → AES-256-GCM with AAD "intendant-vault-deposit-v1:" + label.
+   ring concatenates its HKDF info parts, so `info` here is the same
+   byte string. Cross-implementation parity harness:
+   scripts/vault-deposit-parity.cjs. */
+const VAULT_DEPOSIT_INFO = 'intendant-vault-deposit-v1';
+
+function vaultDepositConcatBytes(...parts) {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+async function vaultDepositLaneSync() {
+  if (vaultState.status !== 'unlocked' || !vaultState.kBytes) return;
+  try {
+    // 1. Keypair lives inside the sealed body (extractable so it rides
+    //    the blob to every unlocking device; it exists only as ciphertext
+    //    at rest).
+    let lane = vaultState.settings.deposit_lane;
+    if (!lane || !lane.priv_jwk || !lane.pub_raw_b64u) {
+      const pair = await crypto.subtle.generateKey(
+        { name: 'ECDH', namedCurve: 'P-256' }, true, ['deriveBits']);
+      const privJwk = await crypto.subtle.exportKey('jwk', pair.privateKey);
+      const pubRaw = new Uint8Array(await crypto.subtle.exportKey('raw', pair.publicKey));
+      lane = {
+        alg: 'ECDH-P256',
+        priv_jwk: privJwk,
+        pub_raw_b64u: dashboardBytesToBase64Url(pubRaw),
+        created_unix_ms: Date.now(),
+      };
+      vaultState.settings.deposit_lane = lane;
+      await vaultQueuePersist();
+    }
+
+    // 2. Publish the public half to this daemon (idempotent; a daemon can
+    //    hold at most one deposit key — last unlocked vault wins, and the
+    //    mismatch check keeps this a no-op in the steady state).
+    const current = await vaultLeaseRpc('api_daemon_vault_deposit_key_fetch').catch(() => null);
+    if (!current?.present || current.pub_raw_b64u !== lane.pub_raw_b64u) {
+      await vaultLeaseRpc('api_daemon_vault_deposit_key_publish', {
+        alg: 'ECDH-P256',
+        pub_raw_b64u: lane.pub_raw_b64u,
+      });
+    }
+
+    // 3. Fold queued deposits, then consume. Consume strictly after the
+    //    folded blob PUBLISHED — a failed publish leaves them queued.
+    const fetched = await vaultLeaseRpc('api_daemon_vault_deposits_fetch').catch(() => null);
+    const deposits = Array.isArray(fetched?.deposits) ? fetched.deposits : [];
+    if (!deposits.length) return;
+    const privKey = await crypto.subtle.importKey(
+      'jwk', lane.priv_jwk, { name: 'ECDH', namedCurve: 'P-256' }, false, ['deriveBits']);
+    const consumed = [];
+    for (const dep of deposits) {
+      try {
+        const secret = await vaultOpenDeposit(privKey, lane.pub_raw_b64u, dep);
+        vaultState.entries.push({
+          id: vaultRandomId('cred'),
+          kind: 'api_key',
+          provider: '',
+          label: String(dep.label || 'CLI deposit'),
+          secret,
+          origin: 'cli-deposit',
+          created_unix_ms: Number(dep.created_unix_ms) || Date.now(),
+          updated_unix_ms: Date.now(),
+        });
+        consumed.push(String(dep.id));
+      } catch (err) {
+        // Sealed to a superseded deposit key, or corrupt: leave it queued
+        // (visible via `intendant vault status`); never consume blind.
+        console.warn('[vault] deposit', dep?.id, 'did not open — leaving it queued:', err?.message || err);
+      }
+    }
+    if (!consumed.length) return;
+    await vaultQueuePersist();
+    await vaultLeaseRpc('api_daemon_vault_deposits_consume', { ids: consumed });
+    vaultSyncVoiceMirror();
+    renderAccessVaultSection();
+    console.info(`[vault] folded ${consumed.length} CLI deposit(s) into the vault`);
+  } catch (err) {
+    // Advisory lane: never let it break an unlock.
+    console.warn('[vault] deposit-lane sync failed:', err?.message || err);
+  }
+}
+
+async function vaultOpenDeposit(privKey, recipientPubB64u, dep) {
+  if (dep?.alg !== 'ECIES-P256-HKDF-SHA256-A256GCM') {
+    throw new Error(`unknown deposit alg ${dep?.alg}`);
+  }
+  const encoder = new TextEncoder();
+  const ephRaw = dashboardBase64UrlToBytes(String(dep.eph_pub_raw_b64u || ''));
+  const ephKey = await crypto.subtle.importKey(
+    'raw', ephRaw, { name: 'ECDH', namedCurve: 'P-256' }, false, []);
+  const shared = new Uint8Array(
+    await crypto.subtle.deriveBits({ name: 'ECDH', public: ephKey }, privKey, 256));
+  const label = String(dep.label || '');
+  const info = vaultDepositConcatBytes(
+    encoder.encode(VAULT_DEPOSIT_INFO),
+    ephRaw,
+    dashboardBase64UrlToBytes(recipientPubB64u),
+    encoder.encode(label));
+  const hkdfKey = await crypto.subtle.importKey('raw', shared, 'HKDF', false, ['deriveKey']);
+  const aesKey = await crypto.subtle.deriveKey(
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info },
+    hkdfKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['decrypt']);
+  const plain = await crypto.subtle.decrypt(
+    {
+      name: 'AES-GCM',
+      iv: dashboardBase64UrlToBytes(String(dep.nonce_b64u || '')),
+      additionalData: encoder.encode(VAULT_DEPOSIT_INFO + ':' + label),
+    },
+    aesKey,
+    dashboardBase64UrlToBytes(String(dep.ct_b64u || '')));
+  return new TextDecoder().decode(plain);
 }
 
 async function vaultEnrollThisPasskey() {

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -565,6 +565,7 @@ async function vaultFinishUnlock(kBytes, envelopeId) {
       });
   }
   renderAccessVaultSection();
+  vaultDepositLaneSync().catch(() => {});
   return true;
 }
 
@@ -881,6 +882,140 @@ function vaultRemoveEntry(id) {
   vaultRevealedEntries.delete(id);
   vaultSyncVoiceMirror();
   return vaultQueuePersist();
+}
+
+/* ── Write-only deposits (the CLI lane) ──
+   `intendant vault deposit <label>` seals a secret to the vault's deposit
+   public key and queues it on the DAEMON (vault_deposits.rs) — the daemon
+   holds ciphertext only, and the plaintext never rides a web UI. After
+   every unlock we (1) ensure the deposit keypair exists inside the sealed
+   body's settings and publish its public half to this daemon, then
+   (2) fold queued deposits into the vault as ordinary entries, consuming
+   them only AFTER the re-wrapped blob has published. The crypto mirrors
+   vault_deposits.rs (v1) exactly: P-256 ECDH → HKDF-SHA256 (empty salt,
+   info = "intendant-vault-deposit-v1" || eph_pub || recipient_pub ||
+   label) → AES-256-GCM with AAD "intendant-vault-deposit-v1:" + label.
+   ring concatenates its HKDF info parts, so `info` here is the same
+   byte string. Cross-implementation parity harness:
+   scripts/vault-deposit-parity.cjs. */
+const VAULT_DEPOSIT_INFO = 'intendant-vault-deposit-v1';
+
+function vaultDepositConcatBytes(...parts) {
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+async function vaultDepositLaneSync() {
+  if (vaultState.status !== 'unlocked' || !vaultState.kBytes) return;
+  try {
+    // 1. Keypair lives inside the sealed body (extractable so it rides
+    //    the blob to every unlocking device; it exists only as ciphertext
+    //    at rest).
+    let lane = vaultState.settings.deposit_lane;
+    if (!lane || !lane.priv_jwk || !lane.pub_raw_b64u) {
+      const pair = await crypto.subtle.generateKey(
+        { name: 'ECDH', namedCurve: 'P-256' }, true, ['deriveBits']);
+      const privJwk = await crypto.subtle.exportKey('jwk', pair.privateKey);
+      const pubRaw = new Uint8Array(await crypto.subtle.exportKey('raw', pair.publicKey));
+      lane = {
+        alg: 'ECDH-P256',
+        priv_jwk: privJwk,
+        pub_raw_b64u: dashboardBytesToBase64Url(pubRaw),
+        created_unix_ms: Date.now(),
+      };
+      vaultState.settings.deposit_lane = lane;
+      await vaultQueuePersist();
+    }
+
+    // 2. Publish the public half to this daemon (idempotent; a daemon can
+    //    hold at most one deposit key — last unlocked vault wins, and the
+    //    mismatch check keeps this a no-op in the steady state).
+    const current = await vaultLeaseRpc('api_daemon_vault_deposit_key_fetch').catch(() => null);
+    if (!current?.present || current.pub_raw_b64u !== lane.pub_raw_b64u) {
+      await vaultLeaseRpc('api_daemon_vault_deposit_key_publish', {
+        alg: 'ECDH-P256',
+        pub_raw_b64u: lane.pub_raw_b64u,
+      });
+    }
+
+    // 3. Fold queued deposits, then consume. Consume strictly after the
+    //    folded blob PUBLISHED — a failed publish leaves them queued.
+    const fetched = await vaultLeaseRpc('api_daemon_vault_deposits_fetch').catch(() => null);
+    const deposits = Array.isArray(fetched?.deposits) ? fetched.deposits : [];
+    if (!deposits.length) return;
+    const privKey = await crypto.subtle.importKey(
+      'jwk', lane.priv_jwk, { name: 'ECDH', namedCurve: 'P-256' }, false, ['deriveBits']);
+    const consumed = [];
+    for (const dep of deposits) {
+      try {
+        const secret = await vaultOpenDeposit(privKey, lane.pub_raw_b64u, dep);
+        vaultState.entries.push({
+          id: vaultRandomId('cred'),
+          kind: 'api_key',
+          provider: '',
+          label: String(dep.label || 'CLI deposit'),
+          secret,
+          origin: 'cli-deposit',
+          created_unix_ms: Number(dep.created_unix_ms) || Date.now(),
+          updated_unix_ms: Date.now(),
+        });
+        consumed.push(String(dep.id));
+      } catch (err) {
+        // Sealed to a superseded deposit key, or corrupt: leave it queued
+        // (visible via `intendant vault status`); never consume blind.
+        console.warn('[vault] deposit', dep?.id, 'did not open — leaving it queued:', err?.message || err);
+      }
+    }
+    if (!consumed.length) return;
+    await vaultQueuePersist();
+    await vaultLeaseRpc('api_daemon_vault_deposits_consume', { ids: consumed });
+    vaultSyncVoiceMirror();
+    renderAccessVaultSection();
+    console.info(`[vault] folded ${consumed.length} CLI deposit(s) into the vault`);
+  } catch (err) {
+    // Advisory lane: never let it break an unlock.
+    console.warn('[vault] deposit-lane sync failed:', err?.message || err);
+  }
+}
+
+async function vaultOpenDeposit(privKey, recipientPubB64u, dep) {
+  if (dep?.alg !== 'ECIES-P256-HKDF-SHA256-A256GCM') {
+    throw new Error(`unknown deposit alg ${dep?.alg}`);
+  }
+  const encoder = new TextEncoder();
+  const ephRaw = dashboardBase64UrlToBytes(String(dep.eph_pub_raw_b64u || ''));
+  const ephKey = await crypto.subtle.importKey(
+    'raw', ephRaw, { name: 'ECDH', namedCurve: 'P-256' }, false, []);
+  const shared = new Uint8Array(
+    await crypto.subtle.deriveBits({ name: 'ECDH', public: ephKey }, privKey, 256));
+  const label = String(dep.label || '');
+  const info = vaultDepositConcatBytes(
+    encoder.encode(VAULT_DEPOSIT_INFO),
+    ephRaw,
+    dashboardBase64UrlToBytes(recipientPubB64u),
+    encoder.encode(label));
+  const hkdfKey = await crypto.subtle.importKey('raw', shared, 'HKDF', false, ['deriveKey']);
+  const aesKey = await crypto.subtle.deriveKey(
+    { name: 'HKDF', hash: 'SHA-256', salt: new Uint8Array(0), info },
+    hkdfKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['decrypt']);
+  const plain = await crypto.subtle.decrypt(
+    {
+      name: 'AES-GCM',
+      iv: dashboardBase64UrlToBytes(String(dep.nonce_b64u || '')),
+      additionalData: encoder.encode(VAULT_DEPOSIT_INFO + ':' + label),
+    },
+    aesKey,
+    dashboardBase64UrlToBytes(String(dep.ct_b64u || '')));
+  return new TextDecoder().decode(plain);
 }
 
 async function vaultEnrollThisPasskey() {


### PR DESCRIPTION
The write-only vault lane (task: CLI deposits — plaintext never rides a web UI): `intendant vault deposit <label>` seals a secret from stdin into the owner's vault, and nothing on this machine — the daemon included — can read it back.

## The mechanism

The vault blob is a single sealed body, so nothing outside an unlocked browser can append inside it. Deposits are therefore a sidecar with an asymmetric envelope:

- A P-256 deposit keypair lives **inside the sealed body** (`settings.deposit_lane`) — it reaches every unlocking device by riding the blob, and exists only as ciphertext at rest. After every unlock the dashboard ensures it exists and publishes the public half to the daemon (`~/.intendant/vault-deposit-key.pub.json`).
- The CLI reads the secret from **stdin** (piping recommended; a TTY gets an echo warning), seals it ECIES-style to that public key — ephemeral P-256 ECDH → HKDF-SHA256 (empty salt, `info = "intendant-vault-deposit-v1" || eph_pub || recipient_pub || label`) → AES-256-GCM with the label bound into the AAD — and queues one JSON record per deposit under `~/.intendant/vault-deposits.d/` (atomic create; no shared-file races between a depositing CLI and a consuming dashboard).
- The next unlocked dashboard folds queued deposits into the vault as ordinary entries and consumes (deletes) them **only after** the re-wrapped blob has published. A deposit sealed to a superseded key stays queued and visible (`intendant vault status`) instead of being consumed blind.

Four new dashboard-control methods carry the lane (`api_daemon_vault_deposit_key_fetch/publish`, `api_daemon_vault_deposits_fetch/consume`), all `CredentialsManage`-gated, all carrying only ciphertext or public material, with the partition pins updated.

## Honest limits (also in credential-custody.md, which reconciles its "reserved asymmetric sealing half" note — this ships it)

The depositing CLI trusts the machine it runs on: a malicious daemon could swap the deposit key and capture *future* deposits — it can never read the vault or existing deposits. The lane is write-only by construction; there is deliberately no CLI read path.

## Verification

- Rust unit tests: seal/open round-trip (recipient side re-implemented in-test against ring's ephemeral-only agreement API), AAD label-tamper rejection, queue store/list/consume with traversal-shaped ids ignored, deposit-key validation (compressed points refused).
- **Cross-implementation parity harness** (`scripts/vault-deposit-parity.cjs`, local-only — needs a built binary): the real CLI seals into a scratch `INTENDANT_HOME` against a real WebCrypto keypair; node's WebCrypto opens with the dashboard's exact algorithm; a tampered label must fail. Green, including a unicode secret.
- Full battery: 2768/2768 tests, clippy clean, app.html regenerated.
