### PR TITLE
dashboard-boot smoke: profile-dir teardown must not outvote the verdict

### DIFF
--- a/scripts/smoke-dashboard-boot.cjs
+++ b/scripts/smoke-dashboard-boot.cjs
@@ -729,7 +729,13 @@ async function main() {
       await Promise.race([new Promise((resolve) => child.once('exit', resolve)), delay(2000)]);
       if (child.exitCode === null) child.kill('SIGKILL');
     }
-    fs.rmSync(userDataDir, { recursive: true, force: true });
+    try {
+      fs.rmSync(userDataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+    } catch (cleanupError) {
+      // Chromium helper processes can still be flushing the profile dir
+      // after the kill above; teardown must never outvote the verdict.
+      console.error(`profile-dir cleanup failed (ignored): ${cleanupError.message}`);
+    }
   }
   process.exit(verdict);
 }


### PR DESCRIPTION
The boot smoke passed its assertions, then `fs.rmSync(userDataDir)` hit `ENOTEMPTY` (Chromium helpers still flushing the profile dir after the kill) and the throw rode `main().catch` into exit 1 — a green boot reported as a check failure (run 29107981252 on PR #159, dashboard-boot ubuntu leg).

One-hunk fix: `maxRetries: 5, retryDelay: 200` on the removal, and a caught+logged failure instead of a thrown one — teardown residue in a per-run temp dir must never override the smoke's verdict.