### PR TITLE
CI fleet: external per-listener cargo target caches; macOS drops debuginfo

### DIFF
--- a/.github/workflows/smokes.yml
+++ b/.github/workflows/smokes.yml
@@ -113,6 +113,21 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      # Fleet build state lives outside the workspace (checkout's
+      # `git clean -ffdx` wipes an in-tree target/ every job) — same
+      # per-listener, toolchain-keyed scheme as windows.yml; later steps
+      # fall back to the workspace target/ when unset (hosted runners).
+      - name: External cargo target dir
+        if: runner.environment != 'github-hosted'
+        shell: bash
+        run: |
+          key=$(rustc -V | tr ' ()' '_')
+          dir="$HOME/.cache/intendant-ci/target/${RUNNER_NAME:-listener}-${key}"
+          mkdir -p "$dir"
+          touch "$dir/.last-used"
+          echo "CARGO_TARGET_DIR=$dir" >> "$GITHUB_ENV"
+          echo "cargo target dir: $dir"
+
       - name: Install Rust target
         run: rustup target add ${{ matrix.target }}
 
@@ -166,7 +181,8 @@ jobs:
           "$RUNNER_TEMP/pyws/bin/pip" install --quiet websockets
           echo "$RUNNER_TEMP/pyws/bin" >> "$GITHUB_PATH"
 
-      # Hosted-only: self-hosted runners keep a persistent target/.
+      # Hosted-only: self-hosted runners keep their build state in the
+      # external cargo target dir above.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         if: runner.environment == 'github-hosted'
         with:
@@ -183,17 +199,17 @@ jobs:
 
       - name: session-vitals smoke
         if: steps.relevance.outputs.relevant != 'false'
-        run: node tests/skills/session-vitals-smoke/driver.cjs "$GITHUB_WORKSPACE/target/debug/intendant"
+        run: node tests/skills/session-vitals-smoke/driver.cjs "${CARGO_TARGET_DIR:-$GITHUB_WORKSPACE/target}/debug/intendant"
 
       - name: native-goal smoke
         if: steps.relevance.outputs.relevant != 'false'
-        run: node tests/skills/native-goal-smoke/driver.cjs "$GITHUB_WORKSPACE/target/debug/intendant"
+        run: node tests/skills/native-goal-smoke/driver.cjs "${CARGO_TARGET_DIR:-$GITHUB_WORKSPACE/target}/debug/intendant"
 
       - name: peer-sessions smoke
         if: steps.relevance.outputs.relevant != 'false'
-        env:
-          INTENDANT_BIN: ${{ github.workspace }}/target/debug/intendant
-        run: python3 tests/skills/peer-sessions-smoke/peer-rig.py
+        run: |
+          export INTENDANT_BIN="${CARGO_TARGET_DIR:-$GITHUB_WORKSPACE/target}/debug/intendant"
+          python3 tests/skills/peer-sessions-smoke/peer-rig.py
 
   # Dashboard boot smoke — ADVISORY. On 2026-07-09 a cross-fragment TDZ
   # error killed the whole dashboard SPA silently (every JS fragment is one
@@ -250,6 +266,18 @@ jobs:
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      # Same external per-listener build cache as the smokes job above.
+      - name: External cargo target dir
+        if: runner.environment != 'github-hosted'
+        shell: bash
+        run: |
+          key=$(rustc -V | tr ' ()' '_')
+          dir="$HOME/.cache/intendant-ci/target/${RUNNER_NAME:-listener}-${key}"
+          mkdir -p "$dir"
+          touch "$dir/.last-used"
+          echo "CARGO_TARGET_DIR=$dir" >> "$GITHUB_ENV"
+          echo "cargo target dir: $dir"
+
       - name: Install Rust target
         run: rustup target add ${{ matrix.target }}
 
@@ -289,7 +317,8 @@ jobs:
             pkg-config libclang-dev libvpx-dev libpipewire-0.3-dev \
             libxcb1-dev libxcb-shm0-dev libxcb-randr0-dev
 
-      # Hosted-only: self-hosted runners keep a persistent target/.
+      # Hosted-only: self-hosted runners keep their build state in the
+      # external cargo target dir above.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         if: runner.environment == 'github-hosted'
         with:
@@ -318,7 +347,7 @@ jobs:
           cd "$rig/proj"
           env -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u GEMINI_API_KEY -u MODEL_NAME \
             HOME="$rig/home" PROVIDER=mock INTENDANT_MOCK_SCRIPT="$rig/home/mock_script.json" \
-            "$GITHUB_WORKSPACE/target/debug/intendant" --web 0 --bind 127.0.0.1 --no-tls \
+            "${CARGO_TARGET_DIR:-$GITHUB_WORKSPACE/target}/debug/intendant" --web 0 --bind 127.0.0.1 --no-tls \
             > "$rig/daemon.log" 2>&1 &
           pid=$!
           echo "pid=$pid" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -75,13 +75,10 @@ jobs:
     env:
       # CI needs pass/fail and panic messages, not debugger-grade binaries.
       # Debug info is the dominant compile+link cost across these large
-      # test binaries, so the Windows AND Linux legs build without it
-      # (Linux joined 2026-07-07: its 12.5-minute leg measured ~95%
-      # compile+link vs ~12s of test execution, and it runs the full suite
-      # on the most triggers — the biggest single lever on the dell
-      # bottleneck). macOS keeps the default: it only builds the full
-      # suite in the merge group, and rich backtraces stay useful when a
-      # failure does need reading in place. Repro locally with default
+      # test binaries, so every leg builds without it (Linux measured ~95%
+      # compile+link vs ~12s of test execution when it joined 2026-07-07;
+      # macOS joined 2026-07-10 — its merge-group full suite was the last
+      # debuginfo=2 build in the gate). Repro locally with default
       # debuginfo when a CI backtrace is too thin.
       CARGO_PROFILE_DEV_DEBUG: ${{ matrix.cargo_debug }}
     # Full test builds are much heavier than the old `cargo check`; a cold
@@ -96,8 +93,10 @@ jobs:
         # required context in the main ruleset — renaming it means a
         # coordinated ruleset edit) AND the hosted-runner label fork PRs
         # route to; `runner` is the self-hosted fleet placement for trusted
-        # refs (dell-206, macbook-vm, samsung-win — persistent target/ dirs
-        # make warm runs minutes instead of half-hours). Provisioning steps
+        # refs (dell-206, macbook-vm, samsung-win — build state persists in
+        # the external per-listener target cache set up below; the
+        # in-workspace target/ is wiped by checkout's `git clean -ffdx`
+        # every job, so warmth never lives there). Provisioning steps
         # (dep installs, cache actions) gate on `runner.environment ==
         # 'github-hosted'`: the fleet boxes are pre-provisioned and keep
         # their build state.
@@ -109,7 +108,7 @@ jobs:
           - os: macos-latest
             runner: [self-hosted, intendant-macos]
             target: aarch64-apple-darwin
-            cargo_debug: "2"
+            cargo_debug: "0"
           - os: ubuntu-latest
             runner: [self-hosted, intendant-linux]
             target: x86_64-unknown-linux-gnu
@@ -152,6 +151,39 @@ jobs:
           }
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # Fleet build state lives OUTSIDE the workspace: checkout
+      # (clean: true) runs `git clean -ffdx` at the start of every job, so
+      # an in-tree target/ restarts cold each run — the "persistent
+      # target/" this file used to describe never actually survived a
+      # checkout. The external cache is per-listener (concurrent listeners
+      # on one host must not share — same-name artifacts clobber each
+      # other) and keyed by `rustc -V` (a toolchain bump starts a fresh
+      # key instead of thrashing the old one). `.last-used` is the recency
+      # marker the fleet watchdog prunes stale keys by (scripts/ci).
+      # Hosted runners skip this and keep the rust-cache action below.
+      - name: External cargo target dir (unix)
+        if: runner.environment != 'github-hosted' && runner.os != 'Windows'
+        shell: bash
+        run: |
+          key=$(rustc -V | tr ' ()' '_')
+          dir="$HOME/.cache/intendant-ci/target/${RUNNER_NAME:-listener}-${key}"
+          mkdir -p "$dir"
+          touch "$dir/.last-used"
+          echo "CARGO_TARGET_DIR=$dir" >> "$GITHUB_ENV"
+          echo "cargo target dir: $dir"
+
+      - name: External cargo target dir (windows)
+        if: runner.environment != 'github-hosted' && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $key = (rustc -V) -replace '[ ()]', '_'
+          $name = if ($env:RUNNER_NAME) { $env:RUNNER_NAME } else { 'listener' }
+          $dir = Join-Path $env:LOCALAPPDATA "intendant-ci\target\$name-$key"
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          New-Item -ItemType File -Force -Path (Join-Path $dir '.last-used') | Out-Null
+          "CARGO_TARGET_DIR=$dir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "cargo target dir: $dir"
 
       # rustup ships preinstalled on the GitHub-hosted runners; just pin the
       # target this job type-checks against.
@@ -259,9 +291,9 @@ jobs:
       # saving them buys nothing — and the Windows tar/zstd save step is flaky
       # enough to fail an otherwise-green job. `save-if` keeps the speed-up on
       # restore while removing the unreliable post-run save from PR checks.
-      # Hosted-only: the self-hosted runners keep a persistent target/ between
-      # runs — that persistence IS the cache, and shipping it to GitHub's
-      # cache store would only add minutes.
+      # Hosted-only: the self-hosted runners keep their build state in the
+      # external per-listener cargo target dir set up above — shipping it
+      # to GitHub's cache store would only add minutes.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         if: runner.environment == 'github-hosted'
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,8 +351,12 @@ triggers keep paths filters — push runs are check-only warm passes, not gates
 
 Trusted refs (pushes, merge-queue refs, same-repo PRs) run on the
 **self-hosted fleet** (`dell-206` = `intendant-linux`, `macbook-vm` =
-`intendant-macos`, `samsung-win` = `intendant-windows`) with persistent
-incremental `target/` dirs — warm gate runs are minutes, not half-hours.
+`intendant-macos`, `samsung-win` = `intendant-windows`) with build state
+in **external per-listener cargo target caches** (`CARGO_TARGET_DIR`
+under the runner account's `~/.cache/intendant-ci/`, keyed by `rustc -V`
+— checkout's `git clean -ffdx` wipes an in-workspace `target/` every
+job, so warmth can only live outside it) — warm gate runs are minutes,
+not half-hours.
 **Fork PRs route to GitHub-hosted runners instead** (dynamic `runs-on`;
 `matrix.os` doubles as the hosted label): external code never executes on
 our hardware, yet its required checks really run. Fork-PR workflows also

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,8 +351,12 @@ triggers keep paths filters — push runs are check-only warm passes, not gates
 
 Trusted refs (pushes, merge-queue refs, same-repo PRs) run on the
 **self-hosted fleet** (`dell-206` = `intendant-linux`, `macbook-vm` =
-`intendant-macos`, `samsung-win` = `intendant-windows`) with persistent
-incremental `target/` dirs — warm gate runs are minutes, not half-hours.
+`intendant-macos`, `samsung-win` = `intendant-windows`) with build state
+in **external per-listener cargo target caches** (`CARGO_TARGET_DIR`
+under the runner account's `~/.cache/intendant-ci/`, keyed by `rustc -V`
+— checkout's `git clean -ffdx` wipes an in-workspace `target/` every
+job, so warmth can only live outside it) — warm gate runs are minutes,
+not half-hours.
 **Fork PRs route to GitHub-hosted runners instead** (dynamic `runs-on`;
 `matrix.os` doubles as the hosted label): external code never executes on
 our hardware, yet its required checks really run. Fork-PR workflows also


### PR DESCRIPTION
First slice of the CI hardening program (wave 1 of the reviewed plan).

**Finding, verified in checkout step logs:** `actions/checkout` runs `clean: true` → `git clean -ffdx` at the start of every self-hosted job, wiping the in-workspace `target/`. The "persistent incremental target dirs" the workflows and CLAUDE.md describe never existed — every gate build cold-compiles with only `~/.cargo` registry warmth.

- Self-hosted jobs export `CARGO_TARGET_DIR` to `~/.cache/intendant-ci/target/<runner>-<rustc -V>` (per-listener: two listeners per host would clobber same-name artifacts; toolchain-keyed: a rustc bump starts fresh). `.last-used` marker feeds the fleet watchdog's prune (host kit is a separate PR under `scripts/ci`).
- Hosted/fork-PR path unchanged (rust-cache action stays); smoke binary refs fall back to workspace `target/` when unset.
- macOS test leg joins Linux/Windows at `CARGO_PROFILE_DEV_DEBUG=0` — it was the gate's last debuginfo=2 build.
- Fiction corrected at every place it was written down (workflow comments, CLAUDE.md CI chapter, AGENTS.md synced).

Expected effect: first run per listener+toolchain is cold (unchanged from today's every-run reality); every run after is incremental. Merge-group p50 should drop substantially; will re-baseline after a week before touching queue settings (wave 4).