### PR TITLE
Fleet CI host kit: runner watchdog gates disk before job assignment

### DIFF
--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -1,0 +1,71 @@
+# Fleet CI host kit
+
+Versioned host-side configuration for the self-hosted runner fleet.
+Everything a runner box needs beyond the GitHub Actions listener itself
+lives here, so host state is auditable and reinstallable instead of
+snowflake config. **The repo is public: host-specific values (account
+names, LAN addresses, listener labels) belong in `/etc/intendant-ci/`
+on the host, never in these files.**
+
+## fleet-watchdog
+
+The in-job disk preflight (windows.yml / smokes.yml) fails a job
+*after* the queue assigned it — a full disk burns whole speculative
+merge-queue entries (seven macOS validations died at 18G free on
+2026-07-10). The watchdog acts *before* assignment, as root, every
+5 minutes:
+
+- **Pause/resume with hysteresis.** Below `STOP_GB` (default 50) it
+  stops the runner listeners — deferring while a job is mid-flight
+  unless free space falls below `HARD_STOP_GB` (25). It resumes them
+  only at `RESUME_GB` (75), so it never flaps at a threshold.
+- **Honest measurement on macOS.** Local APFS snapshots make `df`
+  swing tens of GB with zero real deletions; the watchdog thins them
+  (`tmutil thinlocalsnapshots`) before trusting a low reading. This is
+  also what keeps the in-job preflight (which stays, as the last-resort
+  backstop) from tripping on purgeable-space noise.
+- **Owns the external cargo target caches.** The workflows' "External
+  cargo target dir" steps build under
+  `~/.cache/intendant-ci/target/<listener>-<toolchain>` with a
+  `.last-used` marker. The watchdog prunes keys unused for
+  `PRUNE_DAYS` (7) and evicts oldest-first over `CAP_GB` per root —
+  and, under disk pressure, until free space clears the resume
+  ceiling. It deletes **only** inside the configured cache roots.
+
+### Install
+
+```bash
+# macOS (LaunchDaemon, tick 300s):
+sudo scripts/ci/install-watchdog-macos.sh <runner-account>
+
+# Linux (systemd timer, tick 5min):
+sudo scripts/ci/install-watchdog-linux.sh <runner-account>
+```
+
+The installer seeds `/etc/intendant-ci/watchdog.conf` from
+`watchdog.conf.example`, auto-detecting the account's listener
+LaunchAgents / systemd units — review the seeded file. Re-running an
+installer upgrades the script and daemon but never overwrites an
+existing conf.
+
+Verify: `tail -f /var/log/intendant-ci-watchdog.log` (one line per
+action; silent ticks log nothing).
+
+Rollback: each installer prints its one-line rollback command.
+
+### Windows
+
+Deferred: the Windows runner host needs the equivalent (scheduled task,
+`LOCALAPPDATA\intendant-ci\target` cache root, 60G budget) once the box
+is reachable for verification — tracked in the CI hardening program.
+
+## Interlocks
+
+- The workflow cache steps and this watchdog share the cache layout
+  contract: per-listener key dirs with a `.last-used` marker. Change
+  one, change both (windows.yml / smokes.yml "External cargo target
+  dir" steps ↔ `fleet-watchdog.sh` prune/evict).
+- The in-job preflight floor (20G) is deliberately BELOW `STOP_GB`:
+  the watchdog should pause listeners long before any job can see a
+  sub-floor disk, leaving the preflight as the backstop for the
+  watchdog being dead or misconfigured.

--- a/scripts/ci/fleet-watchdog.sh
+++ b/scripts/ci/fleet-watchdog.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+# Fleet runner watchdog — one tick per invocation (drive it from a
+# LaunchDaemon StartInterval / systemd timer, as root).
+#
+# Why this exists: the in-job disk preflight fails AFTER a job is
+# assigned, so a full disk burns whole speculative merge-queue entries
+# (seven macOS validations died at 18G free on 2026-07-10). This
+# watchdog acts BEFORE assignment: it pauses the runner listeners when
+# free disk drops below the stop floor, reclaims what it owns (stale
+# external cargo target caches — see the "External cargo target dir"
+# workflow steps), and resumes the listeners only once free space
+# clears the resume ceiling (hysteresis, so it never flaps). On macOS
+# it thins local APFS snapshots first: purgeable space makes `df`
+# swing tens of GB with zero real deletions, and thinning makes the
+# number honest before any decision is taken.
+#
+# It only ever deletes inside the configured cache roots. It never
+# touches checkouts, project worktrees, or anything it did not create.
+#
+# Config: /etc/intendant-ci/watchdog.conf (see watchdog.conf.example).
+set -u
+
+CONF="${INTENDANT_CI_WATCHDOG_CONF:-/etc/intendant-ci/watchdog.conf}"
+# shellcheck disable=SC1090
+[ -r "$CONF" ] && . "$CONF"
+
+STOP_GB="${STOP_GB:-50}"            # pause listeners below this (idle listeners)
+HARD_STOP_GB="${HARD_STOP_GB:-25}"  # pause even mid-job below this
+RESUME_GB="${RESUME_GB:-75}"        # resume listeners at/above this
+PRUNE_DAYS="${PRUNE_DAYS:-7}"       # drop cache keys unused this long
+CAP_GB="${CAP_GB:-50}"              # total cap per cache root
+CACHE_ROOTS="${CACHE_ROOTS:-}"      # space-separated cache roots
+VOLUME="${VOLUME:-/}"               # volume free space is measured on
+STATE_DIR="${STATE_DIR:-/var/db/intendant-ci}"
+LOG="${LOG:-/var/log/intendant-ci-watchdog.log}"
+RUNNER_USER="${RUNNER_USER:-}"      # account the listeners run as
+RUNNER_UID="${RUNNER_UID:-}"        # its uid (macOS launchctl domain)
+RUNNER_LABELS="${RUNNER_LABELS:-}"  # macOS: LaunchAgent labels
+RUNNER_PLIST_DIR="${RUNNER_PLIST_DIR:-}"  # macOS: dir holding those plists
+RUNNER_UNITS="${RUNNER_UNITS:-}"    # Linux: systemd units
+
+PAUSED_MARKER="$STATE_DIR/listeners.paused"
+mkdir -p "$STATE_DIR"
+
+log() {
+    printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" >> "$LOG"
+}
+
+# Rotate a runaway log (keep it a bounded artifact, not a disk risk).
+if [ -f "$LOG" ] && [ "$(wc -c < "$LOG")" -gt 1048576 ]; then
+    tail -c 262144 "$LOG" > "$LOG.tmp" && mv "$LOG.tmp" "$LOG"
+fi
+
+free_gb() {
+    df -Pk "$VOLUME" | awk 'NR==2 {print int($4 / 1024 / 1024)}'
+}
+
+is_macos() { [ "$(uname -s)" = "Darwin" ]; }
+
+job_running() {
+    # Runner.Worker only exists while a job executes on a listener.
+    if [ -n "$RUNNER_USER" ]; then
+        pgrep -u "$RUNNER_USER" -f 'Runner\.Worker' >/dev/null 2>&1
+    else
+        pgrep -f 'Runner\.Worker' >/dev/null 2>&1
+    fi
+}
+
+stop_listeners() {
+    if is_macos; then
+        for label in $RUNNER_LABELS; do
+            launchctl bootout "gui/$RUNNER_UID/$label" 2>/dev/null \
+                && log "stopped listener $label" \
+                || log "listener $label was not running"
+        done
+    else
+        for unit in $RUNNER_UNITS; do
+            systemctl stop "$unit" 2>/dev/null \
+                && log "stopped listener $unit" \
+                || log "listener $unit was not running"
+        done
+    fi
+    touch "$PAUSED_MARKER"
+}
+
+start_listeners() {
+    if is_macos; then
+        for label in $RUNNER_LABELS; do
+            launchctl bootstrap "gui/$RUNNER_UID" "$RUNNER_PLIST_DIR/$label.plist" 2>/dev/null \
+                && log "resumed listener $label" \
+                || log "listener $label already running (or bootstrap failed — check manually)"
+        done
+    else
+        for unit in $RUNNER_UNITS; do
+            systemctl start "$unit" 2>/dev/null \
+                && log "resumed listener $unit" \
+                || log "listener $unit failed to start — check manually"
+        done
+    fi
+    rm -f "$PAUSED_MARKER"
+}
+
+# Cache keys are the per-listener, per-toolchain dirs the workflows
+# create; each carries a .last-used recency marker.
+prune_stale_keys() {
+    for root in $CACHE_ROOTS; do
+        [ -d "$root" ] || continue
+        for key in "$root"/*/; do
+            [ -d "$key" ] || continue
+            marker="$key.last-used"
+            if [ ! -f "$marker" ] || [ -n "$(find "$marker" -mtime +"$PRUNE_DAYS" 2>/dev/null)" ]; then
+                log "pruning stale cache key $key"
+                rm -rf "$key"
+            fi
+        done
+    done
+}
+
+# Oldest-first eviction until the root fits its cap (or, under disk
+# pressure, until the volume clears the resume ceiling).
+evict_until() {
+    target_free="$1"  # 0 = only enforce CAP_GB
+    for root in $CACHE_ROOTS; do
+        [ -d "$root" ] || continue
+        while :; do
+            used_kb=$(du -sk "$root" 2>/dev/null | awk '{print $1}')
+            used_gb=$((used_kb / 1024 / 1024))
+            over_cap=$([ "$used_gb" -gt "$CAP_GB" ] && echo 1 || echo 0)
+            need_free=$([ "$target_free" -gt 0 ] && [ "$(free_gb)" -lt "$target_free" ] && echo 1 || echo 0)
+            [ "$over_cap" = 0 ] && [ "$need_free" = 0 ] && break
+            oldest=$(ls -1td "$root"/*/ 2>/dev/null | tail -1)
+            [ -z "$oldest" ] && break
+            log "evicting cache key $oldest (root ${used_gb}G, cap ${CAP_GB}G, free $(free_gb)G)"
+            rm -rf "$oldest"
+        done
+    done
+}
+
+main() {
+    free=$(free_gb)
+
+    # macOS: purgeable space (local Time Machine snapshots) makes the
+    # free number swing tens of GB on its own. Thin snapshots before
+    # trusting a low reading, then re-measure.
+    if is_macos && [ "$free" -lt "$RESUME_GB" ]; then
+        tmutil thinlocalsnapshots "$VOLUME" 999999999999 4 >/dev/null 2>&1
+        free=$(free_gb)
+    fi
+
+    prune_stale_keys
+    evict_until 0  # steady-state cap enforcement
+
+    free=$(free_gb)
+    if [ "$free" -lt "$STOP_GB" ]; then
+        if [ "$free" -lt "$HARD_STOP_GB" ]; then
+            log "free ${free}G below hard floor ${HARD_STOP_GB}G — pausing listeners (even mid-job)"
+            stop_listeners
+        elif job_running; then
+            log "free ${free}G below ${STOP_GB}G but a job is running — deferring pause to next tick"
+        else
+            log "free ${free}G below ${STOP_GB}G — pausing listeners"
+            stop_listeners
+        fi
+        evict_until "$RESUME_GB"
+        free=$(free_gb)
+    fi
+
+    if [ -f "$PAUSED_MARKER" ] && [ "$free" -ge "$RESUME_GB" ]; then
+        log "free ${free}G cleared resume ceiling ${RESUME_GB}G — resuming listeners"
+        start_listeners
+    fi
+}
+
+main

--- a/scripts/ci/install-watchdog-linux.sh
+++ b/scripts/ci/install-watchdog-linux.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Install the fleet watchdog on a Linux runner host (run with sudo from
+# a repo checkout: sudo scripts/ci/install-watchdog-linux.sh <runner-account>).
+#
+# Installs a root systemd service + 5-minute timer around
+# scripts/ci/fleet-watchdog.sh. Idempotent: re-running upgrades the
+# script and units, and leaves an existing watchdog.conf alone.
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "run with sudo" >&2
+    exit 1
+fi
+
+RUNNER_ACCOUNT="${1:-}"
+if [ -z "$RUNNER_ACCOUNT" ]; then
+    echo "usage: sudo $0 <runner-account>" >&2
+    exit 1
+fi
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LIB_DIR="/usr/local/lib/intendant-ci"
+CONF_DIR="/etc/intendant-ci"
+
+install -d -m 0755 "$LIB_DIR" "$CONF_DIR"
+install -m 0755 "$HERE/fleet-watchdog.sh" "$LIB_DIR/fleet-watchdog.sh"
+
+if [ ! -f "$CONF_DIR/watchdog.conf" ]; then
+    home=$(getent passwd "$RUNNER_ACCOUNT" | cut -d: -f6)
+    units=$(systemctl list-unit-files 'actions.runner.*.service' --no-legend 2>/dev/null | awk '{print $1}' | tr '\n' ' ')
+    sed -e "s|^CACHE_ROOTS=.*|CACHE_ROOTS=\"$home/.cache/intendant-ci/target\"|" \
+        -e "s|^RUNNER_USER=.*|RUNNER_USER=\"$RUNNER_ACCOUNT\"|" \
+        -e "s|^RUNNER_UNITS=.*|RUNNER_UNITS=\"${units% }\"|" \
+        -e "s|^STATE_DIR=.*|STATE_DIR=\"/var/lib/intendant-ci\"|" \
+        "$HERE/watchdog.conf.example" > "$CONF_DIR/watchdog.conf"
+    chmod 0644 "$CONF_DIR/watchdog.conf"
+    echo "seeded $CONF_DIR/watchdog.conf (detected units: ${units:-none}) — review it"
+else
+    echo "keeping existing $CONF_DIR/watchdog.conf"
+fi
+
+cat > /etc/systemd/system/intendant-ci-watchdog.service <<'EOF'
+[Unit]
+Description=Intendant fleet runner watchdog (one tick)
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash /usr/local/lib/intendant-ci/fleet-watchdog.sh
+EOF
+
+cat > /etc/systemd/system/intendant-ci-watchdog.timer <<'EOF'
+[Unit]
+Description=Intendant fleet runner watchdog tick
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now intendant-ci-watchdog.timer
+echo "watchdog installed (systemd timer, tick 5min)"
+echo "verify: journalctl -u intendant-ci-watchdog.service -f  (and /var/log/intendant-ci-watchdog.log)"
+echo "rollback: sudo systemctl disable --now intendant-ci-watchdog.timer"

--- a/scripts/ci/install-watchdog-macos.sh
+++ b/scripts/ci/install-watchdog-macos.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Install the fleet watchdog on a macOS runner host (run with sudo from
+# a repo checkout: sudo scripts/ci/install-watchdog-macos.sh <runner-account>).
+#
+# Installs a root LaunchDaemon that ticks scripts/ci/fleet-watchdog.sh
+# every 5 minutes. Idempotent: re-running upgrades the script and
+# daemon, and leaves an existing /etc/intendant-ci/watchdog.conf alone.
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "run with sudo" >&2
+    exit 1
+fi
+
+RUNNER_ACCOUNT="${1:-}"
+if [ -z "$RUNNER_ACCOUNT" ]; then
+    echo "usage: sudo $0 <runner-account>" >&2
+    exit 1
+fi
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+LABEL="dev.intendant.ci-watchdog"
+LIB_DIR="/usr/local/lib/intendant-ci"
+CONF_DIR="/etc/intendant-ci"
+PLIST="/Library/LaunchDaemons/$LABEL.plist"
+
+install -d -m 0755 "$LIB_DIR" "$CONF_DIR"
+install -m 0755 "$HERE/fleet-watchdog.sh" "$LIB_DIR/fleet-watchdog.sh"
+
+if [ ! -f "$CONF_DIR/watchdog.conf" ]; then
+    uid=$(id -u "$RUNNER_ACCOUNT")
+    home=$(dscl . -read "/Users/$RUNNER_ACCOUNT" NFSHomeDirectory | awk '{print $2}')
+    labels=""
+    for plist in "$home"/Library/LaunchAgents/actions.runner.*.plist; do
+        [ -f "$plist" ] || continue
+        base=$(basename "$plist" .plist)
+        labels="$labels $base"
+    done
+    sed -e "s|^CACHE_ROOTS=.*|CACHE_ROOTS=\"$home/.cache/intendant-ci/target\"|" \
+        -e "s|^RUNNER_USER=.*|RUNNER_USER=\"$RUNNER_ACCOUNT\"|" \
+        -e "s|^RUNNER_UID=.*|RUNNER_UID=\"$uid\"|" \
+        -e "s|^RUNNER_LABELS=.*|RUNNER_LABELS=\"${labels# }\"|" \
+        -e "s|^RUNNER_PLIST_DIR=.*|RUNNER_PLIST_DIR=\"$home/Library/LaunchAgents\"|" \
+        "$HERE/watchdog.conf.example" > "$CONF_DIR/watchdog.conf"
+    chmod 0644 "$CONF_DIR/watchdog.conf"
+    echo "seeded $CONF_DIR/watchdog.conf (detected listeners:${labels:- none}) — review it"
+else
+    echo "keeping existing $CONF_DIR/watchdog.conf"
+fi
+
+cat > "$PLIST" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key><string>$LABEL</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>$LIB_DIR/fleet-watchdog.sh</string>
+    </array>
+    <key>RunAtLoad</key><true/>
+    <key>StartInterval</key><integer>300</integer>
+</dict>
+</plist>
+PLIST_EOF
+chmod 0644 "$PLIST"
+
+launchctl bootout system "$PLIST" 2>/dev/null || true
+launchctl bootstrap system "$PLIST"
+echo "watchdog installed and running (label $LABEL, tick 300s)"
+echo "verify: tail -f /var/log/intendant-ci-watchdog.log"
+echo "rollback: sudo launchctl bootout system $PLIST && sudo rm $PLIST"

--- a/scripts/ci/watchdog.conf.example
+++ b/scripts/ci/watchdog.conf.example
@@ -1,0 +1,38 @@
+# /etc/intendant-ci/watchdog.conf — fleet watchdog configuration.
+# Copy to the host and fill in the runner specifics; this file stays ON
+# THE HOST (the repo is public — never commit host identifiers, user
+# names, or LAN details).
+
+# Disk thresholds (GB, measured on VOLUME with `df -Pk`).
+STOP_GB=50        # pause idle listeners below this
+HARD_STOP_GB=25   # pause even mid-job below this
+RESUME_GB=75      # resume listeners at/above this (hysteresis gap is deliberate)
+
+# External cargo target cache roots (the workflows'
+# "External cargo target dir" steps create per-listener keys here).
+# Space-separated if a host serves several accounts.
+#CACHE_ROOTS="/Users/<runner-account>/.cache/intendant-ci/target"
+#CACHE_ROOTS="/home/<runner-account>/.cache/intendant-ci/target"
+CACHE_ROOTS=""
+
+PRUNE_DAYS=7      # drop cache keys with no run this long
+CAP_GB=50         # total per cache root (2 listeners x 25G budget)
+
+VOLUME="/"
+STATE_DIR="/var/db/intendant-ci"        # /var/lib/intendant-ci on Linux
+LOG="/var/log/intendant-ci-watchdog.log"
+
+# Listener control.
+RUNNER_USER=""    # account the listeners run as
+
+# macOS (LaunchAgent listeners):
+#RUNNER_UID=501
+#RUNNER_LABELS="actions.runner.<org>-<repo>.<runner-name> actions.runner.<org>-<repo>.<runner-name>-b"
+#RUNNER_PLIST_DIR="/Users/<runner-account>/Library/LaunchAgents"
+RUNNER_UID=""
+RUNNER_LABELS=""
+RUNNER_PLIST_DIR=""
+
+# Linux (systemd listeners):
+#RUNNER_UNITS="actions.runner.<org>-<repo>.<runner-name>.service"
+RUNNER_UNITS=""


### PR DESCRIPTION
CI hardening wave 1, slice 3 (new files only — parallel to #161/#162).

Companion to #161's external target caches: a root watchdog (5-min tick) that acts **before** job assignment where the in-job preflight can only fail after — pause below 50G (mid-job deferral until a 25G hard floor), resume at 75G, APFS snapshot thinning so macOS `df` readings are honest, 7-day `.last-used` prune + oldest-first cap eviction scoped strictly to the cache roots. Installers (LaunchDaemon / systemd timer) seed `/etc/intendant-ci/watchdog.conf` with auto-detected listener labels; host specifics never enter the public repo.

Tested: prune/evict/pause/resume state machine against a sandbox config; `bash -n` + actionlint clean. Fleet install (this Mac + the Linux box) happens from landed main after merge, per binary-provenance practice. Windows host deferred until reachable — tracked in the program.