### PR TITLE
Transport F2b: sessions list and NDJSON stream over the daemonApi facade

### DIFF
--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -3490,10 +3490,12 @@ mod tests {
             );
         }
 
-        // Coverage pin: exactly the F1 family's twinned methods (fs +
-        // staged uploads). The `api_transfer_*` methods join when their
-        // HTTP rows land (task #6, /api/transfers); adding or dropping an
-        // entry updates this list in the same change, deliberately.
+        // Coverage pin: the F1 family's twinned methods (fs + staged
+        // uploads) plus the F2 sessions-family reads converted so far
+        // (managed-context + worktrees). The `api_transfer_*` methods join
+        // when their HTTP rows land (task #6, /api/transfers); adding or
+        // dropping an entry updates this list in the same change,
+        // deliberately.
         let expected: std::collections::BTreeSet<&str> = [
             "api_fs_stat",
             "api_fs_list",
@@ -3506,6 +3508,14 @@ mod tests {
             "api_session_current_upload",
             "api_session_current_upload_raw",
             "api_session_current_upload_delete",
+            "api_managed_context_records",
+            "api_managed_context_anchors",
+            "api_managed_context_fission",
+            "api_worktrees",
+            "api_worktrees_inspect",
+            "api_worktrees_scan",
+            "api_worktrees_remove",
+            "api_worktrees_merge",
         ]
         .into_iter()
         .collect();

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -3492,7 +3492,8 @@ mod tests {
 
         // Coverage pin: the F1 family's twinned methods (fs + staged
         // uploads) plus the F2 sessions-family reads converted so far
-        // (managed-context + worktrees). The `api_transfer_*` methods join
+        // (managed-context + worktrees + the session list and its NDJSON
+        // stream). The `api_transfer_*` methods join
         // when their HTTP rows land (task #6, /api/transfers); adding or
         // dropping an entry updates this list in the same change,
         // deliberately.
@@ -3508,6 +3509,8 @@ mod tests {
             "api_session_current_upload",
             "api_session_current_upload_raw",
             "api_session_current_upload_delete",
+            "api_sessions",
+            "api_sessions_stream",
             "api_managed_context_records",
             "api_managed_context_anchors",
             "api_managed_context_fission",

--- a/static/app.html
+++ b/static/app.html
@@ -26119,13 +26119,16 @@ async function accessFleetRefreshProvenance() {
 // mirror"). KEEP ONE ENTRY PER LINE: the test parses this literal.
 //
 // Coverage: the F1 family (filesystem + staged uploads) and the F2
-// sessions-family reads (managed-context + worktrees so far). The
-// `api_transfer_*` methods are deliberately absent: they have no HTTP rows
+// sessions-family reads (managed-context + worktrees + the session list
+// and its NDJSON stream so far). The `api_transfer_*` methods are
+// deliberately absent: they have no HTTP rows
 // until the server-track stage that adds /api/transfers (task #6); F1 adds
 // their entries when those rows land.
 // Entry shape: verb + path template (`{name}` segments are lifted from
-// params), `query` = param keys lifted into the query string, `lane` =
-// non-JSON response/request lane ('bytes' | 'upload'), `encode` = upload
+// params), `query` = param keys lifted into the query string (arrays
+// comma-join; empty arrays stay absent), `lane` =
+// non-JSON response/request lane ('bytes' | 'upload' | 'stream'),
+// `encode` = upload
 // body encoding ('raw' streamed body | 'json-b64' JSON envelope with
 // content_b64), `rawQuery` = the named param is a pre-encoded query STRING
 // the HTTP twin takes verbatim (the managed-context tunnel contract).
@@ -26143,6 +26146,8 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_session_current_upload: { verb: 'POST', path: '/api/session/current/uploads', query: ['name', 'destination'], lane: 'upload', encode: 'raw' },
   api_session_current_upload_raw: { verb: 'GET', path: '/api/session/current/uploads/{id}/raw', lane: 'bytes' },
   api_session_current_upload_delete: { verb: 'DELETE', path: '/api/session/current/uploads/{upload_id}' },
+  api_sessions: { verb: 'GET', path: '/api/sessions', query: ['ids', 'limit', 'view'] },
+  api_sessions_stream: { verb: 'GET', path: '/api/sessions/stream', query: ['limit'], lane: 'stream' },
   api_managed_context_records: { verb: 'GET', path: '/api/managed-context/records', rawQuery: 'query' },
   api_managed_context_anchors: { verb: 'GET', path: '/api/managed-context/anchors', rawQuery: 'query' },
   api_managed_context_fission: { verb: 'GET', path: '/api/managed-context/fission', rawQuery: 'query' },
@@ -26348,6 +26353,15 @@ function daemonApiHttpTarget(spec, method, params) {
     const value = source[key];
     if (value === undefined || value === null) continue;
     used.add(key);
+    // Array params comma-join (api_sessions ids); an empty list stays
+    // absent — the tunnel vocabulary cannot express HTTP's
+    // present-but-empty filter, and no legacy call site sent one.
+    if (Array.isArray(value)) {
+      if (value.length) {
+        query.push(`${encodeURIComponent(key)}=${encodeURIComponent(value.join(','))}`);
+      }
+      continue;
+    }
     query.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
   }
   // rawQuery twins: the tunnel method takes one pre-encoded query-string
@@ -26466,6 +26480,68 @@ async function daemonApiHttpUpload(method, params, source, opts) {
   }
   const body = await resp.json().catch(() => ({}));
   return { ok: resp.ok, status: resp.status, body: body ?? {} };
+}
+
+// Read a newline-delimited JSON body, invoking onLine per non-empty line.
+// Shared with call sites that keep an explicit remote NDJSON lane (the
+// cross-origin peer session stream) so the reader exists exactly once.
+async function daemonApiReadNdjsonBody(response, onLine) {
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  const handleLine = line => {
+    const trimmed = line.trim();
+    if (trimmed) onLine(trimmed);
+  };
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() || '';
+    for (const line of lines) handleLine(line);
+  }
+  buffer += decoder.decode();
+  if (buffer.trim()) handleLine(buffer);
+}
+
+// Stream-lane twins over direct HTTP: the daemon's NDJSON endpoints emit
+// the same event objects the tunnel's stream_event frames carry (the
+// sessions stream predates the tunnel lane), so the adapter reads lines
+// and feeds the same callbacks. There is no stream_end result on HTTP —
+// resolve with null, exactly what consumers that track state from events
+// expect. `end` fires like the tunnel's; `start` has no HTTP equivalent
+// frame and is never synthesized.
+async function daemonApiHttpStream(method, params, opts, onEvent) {
+  const spec = DAEMON_API_HTTP_MAP[method];
+  const { url } = daemonApiHttpTarget(spec, method, params);
+  let resp;
+  try {
+    resp = await authedFetch(url, { method: spec.verb, signal: daemonApiHttpSignal(method, opts) });
+  } catch (err) {
+    throw daemonApiHttpError(err, method);
+  }
+  if (!resp.ok || !resp.body) {
+    throw new DaemonApiError('http', method, null, `${method} returned HTTP ${resp.status}`, resp.status);
+  }
+  const emit = event => {
+    // Same callback-shape tolerance as the tunnel's callStreamCallback.
+    try {
+      if (typeof onEvent === 'function') onEvent(event);
+      else if (onEvent && typeof onEvent.event === 'function') onEvent.event(event);
+    } catch (err) {
+      console.warn('[daemon-api] stream callback failed', err);
+    }
+  };
+  try {
+    await daemonApiReadNdjsonBody(resp, line => emit(JSON.parse(line)));
+  } catch (err) {
+    throw daemonApiHttpError(err, method);
+  }
+  if (onEvent && typeof onEvent.end === 'function') {
+    try { onEvent.end(null); } catch (err) { console.warn('[daemon-api] stream end callback failed', err); }
+  }
+  return null;
 }
 
 // ── Tunnel adapters ───────────────────────────────────────────────────────
@@ -26600,20 +26676,21 @@ async function daemonApiStream(method, params = {}, opts = {}, onEvent = {}) {
     }
   }
   const transport = dashboardControlTransport;
-  if (!transport || !transport.canUseRpc()) {
-    // No stream twin exists in the F0 descriptor family; the NDJSON HTTP
-    // lane arrives with the sessions family (F2) once the server stream
-    // stage lands. Until then streams are tunnel-only.
-    throw new DaemonApiError(
-      'unavailable', method, null,
-      `dashboard tunnel is not connected for ${method} (streams have no HTTP lane yet)`
-    );
+  let tunnelError = null;
+  if (transport && transport.canUseRpc()) {
+    try {
+      return await transport.stream(method, params, daemonApiTunnelOptions(method, opts), onEvent);
+    } catch (err) {
+      tunnelError = daemonApiTunnelError(err, method, null);
+      if (tunnelError.kind === 'abort') throw tunnelError;
+    }
   }
-  try {
-    return await transport.stream(method, params, daemonApiTunnelOptions(method, opts), onEvent);
-  } catch (err) {
-    throw daemonApiTunnelError(err, method, null);
-  }
+  // Streams are GET twins: a failed tunnel stream may replay over the
+  // NDJSON HTTP lane (consumers merge idempotent event objects; a
+  // mid-stream restart re-delivers rows, exactly like the legacy
+  // per-call-site fallbacks did). Connect mode never uses HTTP.
+  daemonApiEnsureHttpFallback(method, opts, tunnelError);
+  return daemonApiHttpStream(method, params, opts, onEvent);
 }
 
 // ── Availability (§3.4): one function, derived ────────────────────────────
@@ -26630,9 +26707,15 @@ function daemonApiTunnelMethodAvailability(transport, method) {
   const status = transport.lastStatus || null;
   const features = Array.isArray(transport.controlFeatures) ? transport.controlFeatures : [];
   const lane = (spec && spec.lane) || 'json';
-  const laneFeature = lane === 'bytes' ? 'byte_streams' : (lane === 'upload' ? 'upload_frames' : '');
+  const laneFeature = lane === 'bytes' ? 'byte_streams'
+    : (lane === 'upload' ? 'upload_frames'
+      : (lane === 'stream' ? 'stream_frames' : ''));
   if (laneFeature) {
-    const laneOk = status ? status[`${laneFeature}_available`] === true : features.includes(laneFeature);
+    // Not every lane feature has a status boolean (stream_frames is
+    // wire-level only), and pre-status daemons carry none — fall back to
+    // the hello features list rather than reading absence as denial.
+    const laneFlag = status ? status[`${laneFeature}_available`] : undefined;
+    const laneOk = typeof laneFlag === 'boolean' ? laneFlag : features.includes(laneFeature);
     if (!laneOk) return { ok: false, reason: 'unsupported' };
   }
   const flag = status ? status[`${method}_available`] : undefined;
@@ -26733,6 +26816,8 @@ window.qa = Object.assign(window.qa || {}, {
         api_fs_stat: daemonApiAvailability('api_fs_stat'),
         api_fs_write: daemonApiAvailability('api_fs_write'),
         api_session_current_upload: daemonApiAvailability('api_session_current_upload'),
+        api_sessions: daemonApiAvailability('api_sessions'),
+        api_sessions_stream: daemonApiAvailability('api_sessions_stream'),
       },
       descriptor: {
         methods: Object.keys(DAEMON_API_HTTP_MAP).length,
@@ -74641,37 +74726,41 @@ function fetchSessionsForHost(hostId, options = {}) {
       if (!r.ok) throw new Error(`/api/sessions returned ${r.status}`);
       return r.json();
     }
-    if (hostId === selfPeerId && dashboardTransport?.canUseRpc()) {
-      try {
-        return await dashboardTransport.request('api_sessions', rpcParams);
-      } catch (err) {
-        if (dashboardConnectModeEnabled()) throw err;
-        console.warn('[dashboard-control] api_sessions RPC failed, falling back to HTTP', err);
+    if (hostId === selfPeerId) {
+      // daemonApi (transport F2): tunnel first, direct HTTP per the
+      // GET-twin fallback policy; Connect mode never falls back. The
+      // availability pre-check keeps the exact reconnect copy this pane
+      // always showed for the tunnel-down Connect case.
+      if (dashboardConnectModeEnabled() && !daemonApi.availability('api_sessions').ok) {
+        throw new Error('Session list is unavailable until dashboard access reconnects');
       }
+      const resp = await daemonApi.request('api_sessions', rpcParams, { signal: options.signal });
+      if (!resp.ok) throw new Error(resp.body?.error || `/api/sessions returned ${resp.status}`);
+      return resp.body;
     }
-    if (hostId === selfPeerId && dashboardConnectModeEnabled()) {
-      throw new Error('Session list is unavailable until dashboard access reconnects');
-    }
-    if (hostId !== selfPeerId && peerDashboardControlSignalAvailable(hostId)) {
+    if (peerDashboardControlSignalAvailable(hostId)) {
       try {
-        const conn = await peerDashboardControlConnectionForHost(hostId, {
-          signal: options.signal,
-          timeoutMs: 30000,
-        });
-        return await conn.request('api_sessions', rpcParams, {
+        const resp = await daemonApi.request('api_sessions', rpcParams, {
+          target: hostId,
           signal: options.signal,
           timeoutMs: 60000,
         });
+        return resp.body;
       } catch (err) {
-        if (err?.name === 'AbortError') throw err;
+        // Facade aborts are DaemonApiError kind:'abort' (name differs
+        // from the DOM AbortError the old path threw).
+        if (err?.name === 'AbortError' || err?.kind === 'abort') throw err;
         if (dashboardConnectModeEnabled()) throw err;
         console.warn('[peer-dashboard-control] api_sessions RPC failed, falling back to direct peer HTTP', err);
       }
     }
-    if (hostId !== selfPeerId && dashboardConnectModeEnabled()) {
+    if (dashboardConnectModeEnabled()) {
       throw new Error('Peer sessions are unavailable for this target');
     }
-    const r = await (hostId === selfPeerId ? authedFetch(url) : fetch(url));
+    // Cross-origin peer HTTP is an explicit remote lane (the fleet Stats
+    // CORS design), never a facade fallback — the browser holds no
+    // authenticated HTTP lane to a peer.
+    const r = await fetch(url);
     if (!r.ok) throw new Error(`/api/sessions returned ${r.status}`);
     return r.json();
   };
@@ -74739,80 +74828,58 @@ async function streamSessionsForHost(hostId, options = {}, onEvent = {}) {
     baseUrl = d.url.replace(/\/$/, '');
   }
   const limit = sessionListRequestLimit(options);
-  if (hostId === selfPeerId && dashboardTransport?.canUseRpc()) {
-    const state = { finalSessions: null };
-    try {
-      await dashboardTransport.stream('api_sessions_stream', { limit }, {
-        signal: options.signal,
-        timeoutMs: 120000,
-      }, {
-        event(event) {
-          handleSessionStreamEvent(event, onEvent, state);
-        },
-      });
-      return state.finalSessions;
-    } catch (err) {
-      if (err?.name === 'AbortError') throw err;
-      if (dashboardConnectModeEnabled()) throw err;
-      console.warn('[dashboard-control] api_sessions_stream RPC failed, falling back to HTTP stream', err);
+  const state = { finalSessions: null };
+  const streamCallbacks = {
+    event(event) {
+      handleSessionStreamEvent(event, onEvent, state);
+    },
+  };
+  if (hostId === selfPeerId) {
+    // daemonApi (transport F2): tunnel stream first; on a failed lane the
+    // facade replays the GET twin as a chunked NDJSON read — the HTTP
+    // endpoint emits the same event objects, and consumers merge rows
+    // idempotently (exactly what the hand-rolled fallback here did).
+    // Connect mode never uses HTTP; keep the exact reconnect copy for the
+    // tunnel-down Connect case.
+    if (dashboardConnectModeEnabled() && !daemonApi.availability('api_sessions_stream').ok) {
+      throw new Error('Session stream is unavailable until dashboard access reconnects');
     }
+    await daemonApi.stream('api_sessions_stream', { limit }, {
+      signal: options.signal,
+      timeoutMs: 120000,
+    }, streamCallbacks);
+    return state.finalSessions;
   }
-  if (hostId === selfPeerId && dashboardConnectModeEnabled()) {
-    throw new Error('Session stream is unavailable until dashboard access reconnects');
-  }
-  if (hostId !== selfPeerId && peerDashboardControlSignalAvailable(hostId)) {
-    const state = { finalSessions: null };
+  if (peerDashboardControlSignalAvailable(hostId)) {
     try {
-      const conn = await peerDashboardControlConnectionForHost(hostId, {
-        signal: options.signal,
-        timeoutMs: 30000,
-      });
-      await conn.stream('api_sessions_stream', { limit }, {
+      await daemonApi.stream('api_sessions_stream', { limit }, {
+        target: hostId,
         signal: options.signal,
         timeoutMs: 120000,
-      }, {
-        event(event) {
-          handleSessionStreamEvent(event, onEvent, state);
-        },
-      });
+      }, streamCallbacks);
       return state.finalSessions;
     } catch (err) {
-      if (err?.name === 'AbortError') throw err;
+      // Facade aborts are DaemonApiError kind:'abort' (name differs from
+      // the DOM AbortError the old path threw).
+      if (err?.name === 'AbortError' || err?.kind === 'abort') throw err;
       if (dashboardConnectModeEnabled()) throw err;
       console.warn('[peer-dashboard-control] api_sessions_stream RPC failed, falling back to direct peer HTTP stream', err);
     }
   }
-  if (hostId !== selfPeerId && dashboardConnectModeEnabled()) {
+  if (dashboardConnectModeEnabled()) {
     throw new Error('Peer session updates are unavailable for this target');
   }
+  // Cross-origin peer HTTP stream: an explicit remote lane, never a facade
+  // fallback (the browser holds no authenticated HTTP lane to a peer). The
+  // NDJSON reader is the facade's — declared once.
   const url = sessionListStreamUrl(baseUrl, limit);
-  const request = hostId === selfPeerId
-    ? authedFetch(url, { signal: options.signal })
-    : fetch(url, { signal: options.signal });
-  const response = await request;
+  const response = await fetch(url, { signal: options.signal });
   if (!response.ok || !response.body) {
     throw new Error(`/api/sessions/stream returned ${response.status}`);
   }
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-  const state = { finalSessions: null };
-  const handleLine = line => {
-    const trimmed = line.trim();
-    if (!trimmed) return;
-    const event = JSON.parse(trimmed);
-    handleSessionStreamEvent(event, onEvent, state);
-  };
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split('\n');
-    buffer = lines.pop() || '';
-    for (const line of lines) handleLine(line);
-  }
-  buffer += decoder.decode();
-  if (buffer.trim()) handleLine(buffer);
+  await daemonApiReadNdjsonBody(response, line => {
+    handleSessionStreamEvent(JSON.parse(line), onEvent, state);
+  });
   return state.finalSessions;
 }
 
@@ -77260,19 +77327,14 @@ async function hydrateSessionWorktreeFinishInfo(sid) {
   const existing = sessionWorktreeFinishInfo(sid);
   if (existing) return existing;
   let sessions = null;
-  if (typeof dashboardTransport !== 'undefined' && dashboardTransport?.canUseRpc()) {
-    try {
-      sessions = await dashboardTransport.request('api_sessions', { ids: [sid] });
-    } catch (_) {}
-  }
-  if (!sessions) {
-    try {
-      const r = await authedFetch(`/api/sessions?ids=${encodeURIComponent(sid)}`);
-      if (!r.ok) return null;
-      sessions = await r.json();
-    } catch (_) {
-      return null;
-    }
+  try {
+    // daemonApi (transport F2): tunnel first, direct HTTP per the GET-twin
+    // fallback policy — this helper always tolerated a missing list.
+    const resp = await daemonApi.request('api_sessions', { ids: [sid] });
+    if (!resp.ok) return null;
+    sessions = resp.body;
+  } catch (_) {
+    return null;
   }
   if (Array.isArray(sessions)) cacheSessionWindowMetadata(sessions);
   return sessionWorktreeFinishInfo(sid);
@@ -84047,7 +84109,9 @@ function loadSessions(options = {}) {
     })
     .catch(err => {
       if (_sessionsStreamAbort === controller) _sessionsStreamAbort = null;
-      if (err?.name === 'AbortError') {
+      // Facade aborts are DaemonApiError kind:'abort' (name differs from
+      // the DOM AbortError the pre-facade stream threw).
+      if (err?.name === 'AbortError' || err?.kind === 'abort') {
         if (token === _sessionsLoadToken) {
           setSessionsHydrationState({ active: false, done: false, error: '', phase: 'idle' });
         }

--- a/static/app.html
+++ b/static/app.html
@@ -26090,11 +26090,11 @@ async function accessFleetRefreshProvenance() {
 //     not an adapter: it forces `fallback:'never'` (hosted validators probe
 //     exactly this no-legacy-fallback behavior).
 //
-// STATUS (F0): wired to NOTHING. No existing call site consumes this yet —
-// the F1+ family migrations (transfers/fs first, per the design's frontend
-// track) move `rpcOrHttp`/`jsonFetch`/`filesIdeRpc`/pump call sites onto
-// these verbs family by family; the boot smoke's window.qa.daemonApi()
-// probe is the only reader today.
+// STATUS: consumed by the F1 family (files IDE fs calls, transfers pump,
+// staged uploads) and the F2 sessions-family reads as they migrate; the
+// remaining `rpcOrHttp`/`jsonFetch` call sites move onto these verbs family
+// by family per the design's frontend track. The boot smoke's
+// window.qa.daemonApi() probe asserts the facade evaluates.
 //
 // Fragment placement: this file must evaluate BEFORE every consumer
 // fragment's eval-time code (manifest order is program order — the
@@ -26118,15 +26118,18 @@ async function accessFleetRefreshProvenance() {
 // the sanctioned mirror-with-parity-test pattern (CLAUDE.md "Derive, don't
 // mirror"). KEEP ONE ENTRY PER LINE: the test parses this literal.
 //
-// Coverage (F0): the F1 family's twinned methods only — filesystem and
-// staged uploads. The `api_transfer_*` methods are deliberately absent:
-// they have no HTTP rows until the server-track stage that adds
-// /api/transfers (task #6); F1 adds their entries when those rows land.
+// Coverage: the F1 family (filesystem + staged uploads) and the F2
+// sessions-family reads (managed-context + worktrees so far). The
+// `api_transfer_*` methods are deliberately absent: they have no HTTP rows
+// until the server-track stage that adds /api/transfers (task #6); F1 adds
+// their entries when those rows land.
 // Entry shape: verb + path template (`{name}` segments are lifted from
 // params), `query` = param keys lifted into the query string, `lane` =
 // non-JSON response/request lane ('bytes' | 'upload'), `encode` = upload
 // body encoding ('raw' streamed body | 'json-b64' JSON envelope with
-// content_b64). `mutation` is DERIVED from the verb (POST/DELETE), never
+// content_b64), `rawQuery` = the named param is a pre-encoded query STRING
+// the HTTP twin takes verbatim (the managed-context tunnel contract).
+// `mutation` is DERIVED from the verb (POST/DELETE), never
 // stored — that derivation is the fallback policy (§3.7).
 const DAEMON_API_HTTP_MAP = Object.freeze({
   api_fs_stat: { verb: 'GET', path: '/api/fs/stat', query: ['path'] },
@@ -26140,6 +26143,14 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_session_current_upload: { verb: 'POST', path: '/api/session/current/uploads', query: ['name', 'destination'], lane: 'upload', encode: 'raw' },
   api_session_current_upload_raw: { verb: 'GET', path: '/api/session/current/uploads/{id}/raw', lane: 'bytes' },
   api_session_current_upload_delete: { verb: 'DELETE', path: '/api/session/current/uploads/{upload_id}' },
+  api_managed_context_records: { verb: 'GET', path: '/api/managed-context/records', rawQuery: 'query' },
+  api_managed_context_anchors: { verb: 'GET', path: '/api/managed-context/anchors', rawQuery: 'query' },
+  api_managed_context_fission: { verb: 'GET', path: '/api/managed-context/fission', rawQuery: 'query' },
+  api_worktrees: { verb: 'GET', path: '/api/worktrees' },
+  api_worktrees_inspect: { verb: 'POST', path: '/api/worktrees/inspect' },
+  api_worktrees_scan: { verb: 'POST', path: '/api/worktrees/scan' },
+  api_worktrees_remove: { verb: 'POST', path: '/api/worktrees/remove' },
+  api_worktrees_merge: { verb: 'POST', path: '/api/worktrees/merge' },
 });
 
 // ── Uniform error shape (§3.5) ────────────────────────────────────────────
@@ -26339,6 +26350,16 @@ function daemonApiHttpTarget(spec, method, params) {
     used.add(key);
     query.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
   }
+  // rawQuery twins: the tunnel method takes one pre-encoded query-string
+  // param (the managed-context handlers rebuild a request line from it);
+  // the HTTP twin takes that same string as the URL query verbatim.
+  if (spec.rawQuery) {
+    const raw = source[spec.rawQuery];
+    used.add(spec.rawQuery);
+    if (raw !== undefined && raw !== null && String(raw) !== '') {
+      query.push(String(raw));
+    }
+  }
   const rest = {};
   for (const [key, value] of Object.entries(source)) {
     if (!used.has(key)) rest[key] = value;
@@ -26350,7 +26371,10 @@ async function daemonApiHttpRequest(method, params, opts) {
   const spec = DAEMON_API_HTTP_MAP[method];
   const { url, rest } = daemonApiHttpTarget(spec, method, params);
   const init = { method: spec.verb, signal: daemonApiHttpSignal(method, opts) };
-  if (spec.verb === 'POST') {
+  // Body-less POST twins stay body-less (api_worktrees_scan rides a
+  // BodyPolicy::None row, and every legacy empty-payload POST call site
+  // sent no body/Content-Type either).
+  if (spec.verb === 'POST' && Object.keys(rest).length > 0) {
     init.headers = { 'Content-Type': 'application/json' };
     init.body = JSON.stringify(rest);
   }
@@ -40948,13 +40972,14 @@ async function fetchManagedContextFission() {
 }
 
 async function fetchManagedContextHistoryJson(kind, query) {
+  // daemonApi (transport F2): tunnel first, direct HTTP per the GET-twin
+  // fallback policy. The tunnel contract is one pre-encoded query string
+  // (`{ query }`); the descriptor's rawQuery column turns it back into the
+  // HTTP twin's URL query.
   const method = `api_managed_context_${kind}`;
-  const resp = await dashboardTransport.jsonFetch(method, { query }, () => (
-    authedFetch(`/api/managed-context/${kind}?${query}`)
-  ), method);
-  const payload = await resp.json().catch(() => ({}));
-  if (!resp.ok) throw new Error(payload.error || `${kind} HTTP ${resp.status}`);
-  return payload;
+  const resp = await daemonApi.request(method, { query });
+  if (!resp.ok) throw new Error(resp.body?.error || `${kind} HTTP ${resp.status}`);
+  return resp.body;
 }
 
 function settleManagedContextPromise(promise) {
@@ -77345,17 +77370,12 @@ function renderWorktreeFinishCard(win, sid, info, options = {}) {
     dismissBtn.addEventListener('click', () => dismissWorktreeFinishCard(sid, options));
     actions.appendChild(dismissBtn);
   };
+  // daemonApi (transport F2): POST twins — the facade's no-replay policy
+  // covers the fallbackAfterRpcFailure:false these calls passed by hand.
+  // `url` survives only as the error label the card always showed.
   const callWorktreeAction = async (method, url, payload) => {
-    const r = await dashboardTransport.jsonFetch(method, payload, () => (
-      authedFetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      })
-    ), method, { fallbackAfterRpcFailure: false });
-    const textBody = await r.text();
-    let result = {};
-    try { result = textBody ? JSON.parse(textBody) : {}; } catch (_) {}
+    const r = await daemonApi.request(method, payload);
+    const result = (r.body && typeof r.body === 'object') ? r.body : {};
     if (!r.ok || result.ok === false) {
       throw new Error(result.error || `${url} returned ${r.status}`);
     }
@@ -86357,10 +86377,11 @@ function loadWorktrees(options = {}) {
   }
   const url = forceScan ? '/api/worktrees/scan' : '/api/worktrees';
   const rpcMethod = forceScan ? 'api_worktrees_scan' : 'api_worktrees';
-  const promise = dashboardJsonFetch(rpcMethod, {}, () => (
-    authedFetch(url, { method: forceScan ? 'POST' : 'GET' })
-  ), rpcMethod)
-    .then(r => r.ok ? r.json() : Promise.reject(new Error(`${url} returned ${r.status}`)))
+  // daemonApi (transport F2): the cached read is a GET twin (tunnel first,
+  // HTTP fallback allowed); the forced scan is a POST twin, so the facade
+  // never replays it over HTTP after an attempted tunnel send.
+  const promise = daemonApi.request(rpcMethod, {})
+    .then(resp => resp.ok ? resp.body : Promise.reject(new Error(`${url} returned ${resp.status}`)))
     .then(scan => {
       if (requestSerial !== worktreesRequestSerial) return;
       worktreesLoaded = true;
@@ -86527,16 +86548,11 @@ async function openWorktreeInspect(wt) {
   renderWorktreeInspectLoading(wt);
   try {
     const payload = worktreeInspectPayload(wt);
-    const resp = await dashboardTransport.jsonFetch('api_worktrees_inspect', payload, () => (
-      authedFetch('/api/worktrees/inspect', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      })
-    ), 'api_worktrees_inspect', { fallbackAfterRpcFailure: false });
-    const text = await resp.text();
-    let inspect = {};
-    try { inspect = text ? JSON.parse(text) : {}; } catch (_) {}
+    // daemonApi (transport F2): a POST twin — the facade's no-replay
+    // policy covers the fallbackAfterRpcFailure:false this call passed by
+    // hand.
+    const resp = await daemonApi.request('api_worktrees_inspect', payload);
+    const inspect = (resp.body && typeof resp.body === 'object') ? resp.body : {};
     if (!resp.ok || inspect.ok === false) {
       throw new Error(inspect.error || `worktree inspect returned ${resp.status}`);
     }
@@ -86880,16 +86896,11 @@ async function drainWorktreeRemovalQueue() {
         path: wt.path,
         expected_head: wt.head || null,
       };
-      const r = await dashboardTransport.jsonFetch('api_worktrees_remove', payload, () => (
-        authedFetch('/api/worktrees/remove', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
-        })
-      ), 'api_worktrees_remove', { fallbackAfterRpcFailure: false });
-      const text = await r.text();
-      let result = {};
-      try { result = text ? JSON.parse(text) : {}; } catch (_) {}
+      // daemonApi (transport F2): a POST twin — the facade's no-replay
+      // policy covers the fallbackAfterRpcFailure:false this call passed
+      // by hand.
+      const r = await daemonApi.request('api_worktrees_remove', payload);
+      const result = (r.body && typeof r.body === 'object') ? r.body : {};
       if (!r.ok || result.ok === false) {
         throw new Error(result.error || `worktree removal returned ${r.status}`);
       }

--- a/static/app/32-daemon-api.js
+++ b/static/app/32-daemon-api.js
@@ -49,13 +49,16 @@
 // mirror"). KEEP ONE ENTRY PER LINE: the test parses this literal.
 //
 // Coverage: the F1 family (filesystem + staged uploads) and the F2
-// sessions-family reads (managed-context + worktrees so far). The
-// `api_transfer_*` methods are deliberately absent: they have no HTTP rows
+// sessions-family reads (managed-context + worktrees + the session list
+// and its NDJSON stream so far). The `api_transfer_*` methods are
+// deliberately absent: they have no HTTP rows
 // until the server-track stage that adds /api/transfers (task #6); F1 adds
 // their entries when those rows land.
 // Entry shape: verb + path template (`{name}` segments are lifted from
-// params), `query` = param keys lifted into the query string, `lane` =
-// non-JSON response/request lane ('bytes' | 'upload'), `encode` = upload
+// params), `query` = param keys lifted into the query string (arrays
+// comma-join; empty arrays stay absent), `lane` =
+// non-JSON response/request lane ('bytes' | 'upload' | 'stream'),
+// `encode` = upload
 // body encoding ('raw' streamed body | 'json-b64' JSON envelope with
 // content_b64), `rawQuery` = the named param is a pre-encoded query STRING
 // the HTTP twin takes verbatim (the managed-context tunnel contract).
@@ -73,6 +76,8 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_session_current_upload: { verb: 'POST', path: '/api/session/current/uploads', query: ['name', 'destination'], lane: 'upload', encode: 'raw' },
   api_session_current_upload_raw: { verb: 'GET', path: '/api/session/current/uploads/{id}/raw', lane: 'bytes' },
   api_session_current_upload_delete: { verb: 'DELETE', path: '/api/session/current/uploads/{upload_id}' },
+  api_sessions: { verb: 'GET', path: '/api/sessions', query: ['ids', 'limit', 'view'] },
+  api_sessions_stream: { verb: 'GET', path: '/api/sessions/stream', query: ['limit'], lane: 'stream' },
   api_managed_context_records: { verb: 'GET', path: '/api/managed-context/records', rawQuery: 'query' },
   api_managed_context_anchors: { verb: 'GET', path: '/api/managed-context/anchors', rawQuery: 'query' },
   api_managed_context_fission: { verb: 'GET', path: '/api/managed-context/fission', rawQuery: 'query' },
@@ -278,6 +283,15 @@ function daemonApiHttpTarget(spec, method, params) {
     const value = source[key];
     if (value === undefined || value === null) continue;
     used.add(key);
+    // Array params comma-join (api_sessions ids); an empty list stays
+    // absent — the tunnel vocabulary cannot express HTTP's
+    // present-but-empty filter, and no legacy call site sent one.
+    if (Array.isArray(value)) {
+      if (value.length) {
+        query.push(`${encodeURIComponent(key)}=${encodeURIComponent(value.join(','))}`);
+      }
+      continue;
+    }
     query.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
   }
   // rawQuery twins: the tunnel method takes one pre-encoded query-string
@@ -396,6 +410,68 @@ async function daemonApiHttpUpload(method, params, source, opts) {
   }
   const body = await resp.json().catch(() => ({}));
   return { ok: resp.ok, status: resp.status, body: body ?? {} };
+}
+
+// Read a newline-delimited JSON body, invoking onLine per non-empty line.
+// Shared with call sites that keep an explicit remote NDJSON lane (the
+// cross-origin peer session stream) so the reader exists exactly once.
+async function daemonApiReadNdjsonBody(response, onLine) {
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  const handleLine = line => {
+    const trimmed = line.trim();
+    if (trimmed) onLine(trimmed);
+  };
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() || '';
+    for (const line of lines) handleLine(line);
+  }
+  buffer += decoder.decode();
+  if (buffer.trim()) handleLine(buffer);
+}
+
+// Stream-lane twins over direct HTTP: the daemon's NDJSON endpoints emit
+// the same event objects the tunnel's stream_event frames carry (the
+// sessions stream predates the tunnel lane), so the adapter reads lines
+// and feeds the same callbacks. There is no stream_end result on HTTP —
+// resolve with null, exactly what consumers that track state from events
+// expect. `end` fires like the tunnel's; `start` has no HTTP equivalent
+// frame and is never synthesized.
+async function daemonApiHttpStream(method, params, opts, onEvent) {
+  const spec = DAEMON_API_HTTP_MAP[method];
+  const { url } = daemonApiHttpTarget(spec, method, params);
+  let resp;
+  try {
+    resp = await authedFetch(url, { method: spec.verb, signal: daemonApiHttpSignal(method, opts) });
+  } catch (err) {
+    throw daemonApiHttpError(err, method);
+  }
+  if (!resp.ok || !resp.body) {
+    throw new DaemonApiError('http', method, null, `${method} returned HTTP ${resp.status}`, resp.status);
+  }
+  const emit = event => {
+    // Same callback-shape tolerance as the tunnel's callStreamCallback.
+    try {
+      if (typeof onEvent === 'function') onEvent(event);
+      else if (onEvent && typeof onEvent.event === 'function') onEvent.event(event);
+    } catch (err) {
+      console.warn('[daemon-api] stream callback failed', err);
+    }
+  };
+  try {
+    await daemonApiReadNdjsonBody(resp, line => emit(JSON.parse(line)));
+  } catch (err) {
+    throw daemonApiHttpError(err, method);
+  }
+  if (onEvent && typeof onEvent.end === 'function') {
+    try { onEvent.end(null); } catch (err) { console.warn('[daemon-api] stream end callback failed', err); }
+  }
+  return null;
 }
 
 // ── Tunnel adapters ───────────────────────────────────────────────────────
@@ -530,20 +606,21 @@ async function daemonApiStream(method, params = {}, opts = {}, onEvent = {}) {
     }
   }
   const transport = dashboardControlTransport;
-  if (!transport || !transport.canUseRpc()) {
-    // No stream twin exists in the F0 descriptor family; the NDJSON HTTP
-    // lane arrives with the sessions family (F2) once the server stream
-    // stage lands. Until then streams are tunnel-only.
-    throw new DaemonApiError(
-      'unavailable', method, null,
-      `dashboard tunnel is not connected for ${method} (streams have no HTTP lane yet)`
-    );
+  let tunnelError = null;
+  if (transport && transport.canUseRpc()) {
+    try {
+      return await transport.stream(method, params, daemonApiTunnelOptions(method, opts), onEvent);
+    } catch (err) {
+      tunnelError = daemonApiTunnelError(err, method, null);
+      if (tunnelError.kind === 'abort') throw tunnelError;
+    }
   }
-  try {
-    return await transport.stream(method, params, daemonApiTunnelOptions(method, opts), onEvent);
-  } catch (err) {
-    throw daemonApiTunnelError(err, method, null);
-  }
+  // Streams are GET twins: a failed tunnel stream may replay over the
+  // NDJSON HTTP lane (consumers merge idempotent event objects; a
+  // mid-stream restart re-delivers rows, exactly like the legacy
+  // per-call-site fallbacks did). Connect mode never uses HTTP.
+  daemonApiEnsureHttpFallback(method, opts, tunnelError);
+  return daemonApiHttpStream(method, params, opts, onEvent);
 }
 
 // ── Availability (§3.4): one function, derived ────────────────────────────
@@ -560,9 +637,15 @@ function daemonApiTunnelMethodAvailability(transport, method) {
   const status = transport.lastStatus || null;
   const features = Array.isArray(transport.controlFeatures) ? transport.controlFeatures : [];
   const lane = (spec && spec.lane) || 'json';
-  const laneFeature = lane === 'bytes' ? 'byte_streams' : (lane === 'upload' ? 'upload_frames' : '');
+  const laneFeature = lane === 'bytes' ? 'byte_streams'
+    : (lane === 'upload' ? 'upload_frames'
+      : (lane === 'stream' ? 'stream_frames' : ''));
   if (laneFeature) {
-    const laneOk = status ? status[`${laneFeature}_available`] === true : features.includes(laneFeature);
+    // Not every lane feature has a status boolean (stream_frames is
+    // wire-level only), and pre-status daemons carry none — fall back to
+    // the hello features list rather than reading absence as denial.
+    const laneFlag = status ? status[`${laneFeature}_available`] : undefined;
+    const laneOk = typeof laneFlag === 'boolean' ? laneFlag : features.includes(laneFeature);
     if (!laneOk) return { ok: false, reason: 'unsupported' };
   }
   const flag = status ? status[`${method}_available`] : undefined;
@@ -663,6 +746,8 @@ window.qa = Object.assign(window.qa || {}, {
         api_fs_stat: daemonApiAvailability('api_fs_stat'),
         api_fs_write: daemonApiAvailability('api_fs_write'),
         api_session_current_upload: daemonApiAvailability('api_session_current_upload'),
+        api_sessions: daemonApiAvailability('api_sessions'),
+        api_sessions_stream: daemonApiAvailability('api_sessions_stream'),
       },
       descriptor: {
         methods: Object.keys(DAEMON_API_HTTP_MAP).length,

--- a/static/app/32-daemon-api.js
+++ b/static/app/32-daemon-api.js
@@ -20,11 +20,11 @@
 //     not an adapter: it forces `fallback:'never'` (hosted validators probe
 //     exactly this no-legacy-fallback behavior).
 //
-// STATUS (F0): wired to NOTHING. No existing call site consumes this yet —
-// the F1+ family migrations (transfers/fs first, per the design's frontend
-// track) move `rpcOrHttp`/`jsonFetch`/`filesIdeRpc`/pump call sites onto
-// these verbs family by family; the boot smoke's window.qa.daemonApi()
-// probe is the only reader today.
+// STATUS: consumed by the F1 family (files IDE fs calls, transfers pump,
+// staged uploads) and the F2 sessions-family reads as they migrate; the
+// remaining `rpcOrHttp`/`jsonFetch` call sites move onto these verbs family
+// by family per the design's frontend track. The boot smoke's
+// window.qa.daemonApi() probe asserts the facade evaluates.
 //
 // Fragment placement: this file must evaluate BEFORE every consumer
 // fragment's eval-time code (manifest order is program order — the
@@ -48,15 +48,18 @@
 // the sanctioned mirror-with-parity-test pattern (CLAUDE.md "Derive, don't
 // mirror"). KEEP ONE ENTRY PER LINE: the test parses this literal.
 //
-// Coverage (F0): the F1 family's twinned methods only — filesystem and
-// staged uploads. The `api_transfer_*` methods are deliberately absent:
-// they have no HTTP rows until the server-track stage that adds
-// /api/transfers (task #6); F1 adds their entries when those rows land.
+// Coverage: the F1 family (filesystem + staged uploads) and the F2
+// sessions-family reads (managed-context + worktrees so far). The
+// `api_transfer_*` methods are deliberately absent: they have no HTTP rows
+// until the server-track stage that adds /api/transfers (task #6); F1 adds
+// their entries when those rows land.
 // Entry shape: verb + path template (`{name}` segments are lifted from
 // params), `query` = param keys lifted into the query string, `lane` =
 // non-JSON response/request lane ('bytes' | 'upload'), `encode` = upload
 // body encoding ('raw' streamed body | 'json-b64' JSON envelope with
-// content_b64). `mutation` is DERIVED from the verb (POST/DELETE), never
+// content_b64), `rawQuery` = the named param is a pre-encoded query STRING
+// the HTTP twin takes verbatim (the managed-context tunnel contract).
+// `mutation` is DERIVED from the verb (POST/DELETE), never
 // stored — that derivation is the fallback policy (§3.7).
 const DAEMON_API_HTTP_MAP = Object.freeze({
   api_fs_stat: { verb: 'GET', path: '/api/fs/stat', query: ['path'] },
@@ -70,6 +73,14 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_session_current_upload: { verb: 'POST', path: '/api/session/current/uploads', query: ['name', 'destination'], lane: 'upload', encode: 'raw' },
   api_session_current_upload_raw: { verb: 'GET', path: '/api/session/current/uploads/{id}/raw', lane: 'bytes' },
   api_session_current_upload_delete: { verb: 'DELETE', path: '/api/session/current/uploads/{upload_id}' },
+  api_managed_context_records: { verb: 'GET', path: '/api/managed-context/records', rawQuery: 'query' },
+  api_managed_context_anchors: { verb: 'GET', path: '/api/managed-context/anchors', rawQuery: 'query' },
+  api_managed_context_fission: { verb: 'GET', path: '/api/managed-context/fission', rawQuery: 'query' },
+  api_worktrees: { verb: 'GET', path: '/api/worktrees' },
+  api_worktrees_inspect: { verb: 'POST', path: '/api/worktrees/inspect' },
+  api_worktrees_scan: { verb: 'POST', path: '/api/worktrees/scan' },
+  api_worktrees_remove: { verb: 'POST', path: '/api/worktrees/remove' },
+  api_worktrees_merge: { verb: 'POST', path: '/api/worktrees/merge' },
 });
 
 // ── Uniform error shape (§3.5) ────────────────────────────────────────────
@@ -269,6 +280,16 @@ function daemonApiHttpTarget(spec, method, params) {
     used.add(key);
     query.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
   }
+  // rawQuery twins: the tunnel method takes one pre-encoded query-string
+  // param (the managed-context handlers rebuild a request line from it);
+  // the HTTP twin takes that same string as the URL query verbatim.
+  if (spec.rawQuery) {
+    const raw = source[spec.rawQuery];
+    used.add(spec.rawQuery);
+    if (raw !== undefined && raw !== null && String(raw) !== '') {
+      query.push(String(raw));
+    }
+  }
   const rest = {};
   for (const [key, value] of Object.entries(source)) {
     if (!used.has(key)) rest[key] = value;
@@ -280,7 +301,10 @@ async function daemonApiHttpRequest(method, params, opts) {
   const spec = DAEMON_API_HTTP_MAP[method];
   const { url, rest } = daemonApiHttpTarget(spec, method, params);
   const init = { method: spec.verb, signal: daemonApiHttpSignal(method, opts) };
-  if (spec.verb === 'POST') {
+  // Body-less POST twins stay body-less (api_worktrees_scan rides a
+  // BodyPolicy::None row, and every legacy empty-payload POST call site
+  // sent no body/Content-Type either).
+  if (spec.verb === 'POST' && Object.keys(rest).length > 0) {
     init.headers = { 'Content-Type': 'application/json' };
     init.body = JSON.stringify(rest);
   }

--- a/static/app/38-managed-context.js
+++ b/static/app/38-managed-context.js
@@ -605,13 +605,14 @@ async function fetchManagedContextFission() {
 }
 
 async function fetchManagedContextHistoryJson(kind, query) {
+  // daemonApi (transport F2): tunnel first, direct HTTP per the GET-twin
+  // fallback policy. The tunnel contract is one pre-encoded query string
+  // (`{ query }`); the descriptor's rawQuery column turns it back into the
+  // HTTP twin's URL query.
   const method = `api_managed_context_${kind}`;
-  const resp = await dashboardTransport.jsonFetch(method, { query }, () => (
-    authedFetch(`/api/managed-context/${kind}?${query}`)
-  ), method);
-  const payload = await resp.json().catch(() => ({}));
-  if (!resp.ok) throw new Error(payload.error || `${kind} HTTP ${resp.status}`);
-  return payload;
+  const resp = await daemonApi.request(method, { query });
+  if (!resp.ok) throw new Error(resp.body?.error || `${kind} HTTP ${resp.status}`);
+  return resp.body;
 }
 
 function settleManagedContextPromise(promise) {

--- a/static/app/53-stats-settings.js
+++ b/static/app/53-stats-settings.js
@@ -479,37 +479,41 @@ function fetchSessionsForHost(hostId, options = {}) {
       if (!r.ok) throw new Error(`/api/sessions returned ${r.status}`);
       return r.json();
     }
-    if (hostId === selfPeerId && dashboardTransport?.canUseRpc()) {
-      try {
-        return await dashboardTransport.request('api_sessions', rpcParams);
-      } catch (err) {
-        if (dashboardConnectModeEnabled()) throw err;
-        console.warn('[dashboard-control] api_sessions RPC failed, falling back to HTTP', err);
+    if (hostId === selfPeerId) {
+      // daemonApi (transport F2): tunnel first, direct HTTP per the
+      // GET-twin fallback policy; Connect mode never falls back. The
+      // availability pre-check keeps the exact reconnect copy this pane
+      // always showed for the tunnel-down Connect case.
+      if (dashboardConnectModeEnabled() && !daemonApi.availability('api_sessions').ok) {
+        throw new Error('Session list is unavailable until dashboard access reconnects');
       }
+      const resp = await daemonApi.request('api_sessions', rpcParams, { signal: options.signal });
+      if (!resp.ok) throw new Error(resp.body?.error || `/api/sessions returned ${resp.status}`);
+      return resp.body;
     }
-    if (hostId === selfPeerId && dashboardConnectModeEnabled()) {
-      throw new Error('Session list is unavailable until dashboard access reconnects');
-    }
-    if (hostId !== selfPeerId && peerDashboardControlSignalAvailable(hostId)) {
+    if (peerDashboardControlSignalAvailable(hostId)) {
       try {
-        const conn = await peerDashboardControlConnectionForHost(hostId, {
-          signal: options.signal,
-          timeoutMs: 30000,
-        });
-        return await conn.request('api_sessions', rpcParams, {
+        const resp = await daemonApi.request('api_sessions', rpcParams, {
+          target: hostId,
           signal: options.signal,
           timeoutMs: 60000,
         });
+        return resp.body;
       } catch (err) {
-        if (err?.name === 'AbortError') throw err;
+        // Facade aborts are DaemonApiError kind:'abort' (name differs
+        // from the DOM AbortError the old path threw).
+        if (err?.name === 'AbortError' || err?.kind === 'abort') throw err;
         if (dashboardConnectModeEnabled()) throw err;
         console.warn('[peer-dashboard-control] api_sessions RPC failed, falling back to direct peer HTTP', err);
       }
     }
-    if (hostId !== selfPeerId && dashboardConnectModeEnabled()) {
+    if (dashboardConnectModeEnabled()) {
       throw new Error('Peer sessions are unavailable for this target');
     }
-    const r = await (hostId === selfPeerId ? authedFetch(url) : fetch(url));
+    // Cross-origin peer HTTP is an explicit remote lane (the fleet Stats
+    // CORS design), never a facade fallback — the browser holds no
+    // authenticated HTTP lane to a peer.
+    const r = await fetch(url);
     if (!r.ok) throw new Error(`/api/sessions returned ${r.status}`);
     return r.json();
   };
@@ -577,80 +581,58 @@ async function streamSessionsForHost(hostId, options = {}, onEvent = {}) {
     baseUrl = d.url.replace(/\/$/, '');
   }
   const limit = sessionListRequestLimit(options);
-  if (hostId === selfPeerId && dashboardTransport?.canUseRpc()) {
-    const state = { finalSessions: null };
-    try {
-      await dashboardTransport.stream('api_sessions_stream', { limit }, {
-        signal: options.signal,
-        timeoutMs: 120000,
-      }, {
-        event(event) {
-          handleSessionStreamEvent(event, onEvent, state);
-        },
-      });
-      return state.finalSessions;
-    } catch (err) {
-      if (err?.name === 'AbortError') throw err;
-      if (dashboardConnectModeEnabled()) throw err;
-      console.warn('[dashboard-control] api_sessions_stream RPC failed, falling back to HTTP stream', err);
+  const state = { finalSessions: null };
+  const streamCallbacks = {
+    event(event) {
+      handleSessionStreamEvent(event, onEvent, state);
+    },
+  };
+  if (hostId === selfPeerId) {
+    // daemonApi (transport F2): tunnel stream first; on a failed lane the
+    // facade replays the GET twin as a chunked NDJSON read — the HTTP
+    // endpoint emits the same event objects, and consumers merge rows
+    // idempotently (exactly what the hand-rolled fallback here did).
+    // Connect mode never uses HTTP; keep the exact reconnect copy for the
+    // tunnel-down Connect case.
+    if (dashboardConnectModeEnabled() && !daemonApi.availability('api_sessions_stream').ok) {
+      throw new Error('Session stream is unavailable until dashboard access reconnects');
     }
+    await daemonApi.stream('api_sessions_stream', { limit }, {
+      signal: options.signal,
+      timeoutMs: 120000,
+    }, streamCallbacks);
+    return state.finalSessions;
   }
-  if (hostId === selfPeerId && dashboardConnectModeEnabled()) {
-    throw new Error('Session stream is unavailable until dashboard access reconnects');
-  }
-  if (hostId !== selfPeerId && peerDashboardControlSignalAvailable(hostId)) {
-    const state = { finalSessions: null };
+  if (peerDashboardControlSignalAvailable(hostId)) {
     try {
-      const conn = await peerDashboardControlConnectionForHost(hostId, {
-        signal: options.signal,
-        timeoutMs: 30000,
-      });
-      await conn.stream('api_sessions_stream', { limit }, {
+      await daemonApi.stream('api_sessions_stream', { limit }, {
+        target: hostId,
         signal: options.signal,
         timeoutMs: 120000,
-      }, {
-        event(event) {
-          handleSessionStreamEvent(event, onEvent, state);
-        },
-      });
+      }, streamCallbacks);
       return state.finalSessions;
     } catch (err) {
-      if (err?.name === 'AbortError') throw err;
+      // Facade aborts are DaemonApiError kind:'abort' (name differs from
+      // the DOM AbortError the old path threw).
+      if (err?.name === 'AbortError' || err?.kind === 'abort') throw err;
       if (dashboardConnectModeEnabled()) throw err;
       console.warn('[peer-dashboard-control] api_sessions_stream RPC failed, falling back to direct peer HTTP stream', err);
     }
   }
-  if (hostId !== selfPeerId && dashboardConnectModeEnabled()) {
+  if (dashboardConnectModeEnabled()) {
     throw new Error('Peer session updates are unavailable for this target');
   }
+  // Cross-origin peer HTTP stream: an explicit remote lane, never a facade
+  // fallback (the browser holds no authenticated HTTP lane to a peer). The
+  // NDJSON reader is the facade's — declared once.
   const url = sessionListStreamUrl(baseUrl, limit);
-  const request = hostId === selfPeerId
-    ? authedFetch(url, { signal: options.signal })
-    : fetch(url, { signal: options.signal });
-  const response = await request;
+  const response = await fetch(url, { signal: options.signal });
   if (!response.ok || !response.body) {
     throw new Error(`/api/sessions/stream returned ${response.status}`);
   }
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = '';
-  const state = { finalSessions: null };
-  const handleLine = line => {
-    const trimmed = line.trim();
-    if (!trimmed) return;
-    const event = JSON.parse(trimmed);
-    handleSessionStreamEvent(event, onEvent, state);
-  };
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split('\n');
-    buffer = lines.pop() || '';
-    for (const line of lines) handleLine(line);
-  }
-  buffer += decoder.decode();
-  if (buffer.trim()) handleLine(buffer);
+  await daemonApiReadNdjsonBody(response, line => {
+    handleSessionStreamEvent(JSON.parse(line), onEvent, state);
+  });
   return state.finalSessions;
 }
 

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -185,19 +185,14 @@ async function hydrateSessionWorktreeFinishInfo(sid) {
   const existing = sessionWorktreeFinishInfo(sid);
   if (existing) return existing;
   let sessions = null;
-  if (typeof dashboardTransport !== 'undefined' && dashboardTransport?.canUseRpc()) {
-    try {
-      sessions = await dashboardTransport.request('api_sessions', { ids: [sid] });
-    } catch (_) {}
-  }
-  if (!sessions) {
-    try {
-      const r = await authedFetch(`/api/sessions?ids=${encodeURIComponent(sid)}`);
-      if (!r.ok) return null;
-      sessions = await r.json();
-    } catch (_) {
-      return null;
-    }
+  try {
+    // daemonApi (transport F2): tunnel first, direct HTTP per the GET-twin
+    // fallback policy — this helper always tolerated a missing list.
+    const resp = await daemonApi.request('api_sessions', { ids: [sid] });
+    if (!resp.ok) return null;
+    sessions = resp.body;
+  } catch (_) {
+    return null;
   }
   if (Array.isArray(sessions)) cacheSessionWindowMetadata(sessions);
   return sessionWorktreeFinishInfo(sid);

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -295,17 +295,12 @@ function renderWorktreeFinishCard(win, sid, info, options = {}) {
     dismissBtn.addEventListener('click', () => dismissWorktreeFinishCard(sid, options));
     actions.appendChild(dismissBtn);
   };
+  // daemonApi (transport F2): POST twins — the facade's no-replay policy
+  // covers the fallbackAfterRpcFailure:false these calls passed by hand.
+  // `url` survives only as the error label the card always showed.
   const callWorktreeAction = async (method, url, payload) => {
-    const r = await dashboardTransport.jsonFetch(method, payload, () => (
-      authedFetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      })
-    ), method, { fallbackAfterRpcFailure: false });
-    const textBody = await r.text();
-    let result = {};
-    try { result = textBody ? JSON.parse(textBody) : {}; } catch (_) {}
+    const r = await daemonApi.request(method, payload);
+    const result = (r.body && typeof r.body === 'object') ? r.body : {};
     if (!r.ok || result.ok === false) {
       throw new Error(result.error || `${url} returned ${r.status}`);
     }

--- a/static/app/56-debug-sessions.js
+++ b/static/app/56-debug-sessions.js
@@ -667,7 +667,9 @@ function loadSessions(options = {}) {
     })
     .catch(err => {
       if (_sessionsStreamAbort === controller) _sessionsStreamAbort = null;
-      if (err?.name === 'AbortError') {
+      // Facade aborts are DaemonApiError kind:'abort' (name differs from
+      // the DOM AbortError the pre-facade stream threw).
+      if (err?.name === 'AbortError' || err?.kind === 'abort') {
         if (token === _sessionsLoadToken) {
           setSessionsHydrationState({ active: false, done: false, error: '', phase: 'idle' });
         }

--- a/static/app/57-sessions-replay.js
+++ b/static/app/57-sessions-replay.js
@@ -920,10 +920,11 @@ function loadWorktrees(options = {}) {
   }
   const url = forceScan ? '/api/worktrees/scan' : '/api/worktrees';
   const rpcMethod = forceScan ? 'api_worktrees_scan' : 'api_worktrees';
-  const promise = dashboardJsonFetch(rpcMethod, {}, () => (
-    authedFetch(url, { method: forceScan ? 'POST' : 'GET' })
-  ), rpcMethod)
-    .then(r => r.ok ? r.json() : Promise.reject(new Error(`${url} returned ${r.status}`)))
+  // daemonApi (transport F2): the cached read is a GET twin (tunnel first,
+  // HTTP fallback allowed); the forced scan is a POST twin, so the facade
+  // never replays it over HTTP after an attempted tunnel send.
+  const promise = daemonApi.request(rpcMethod, {})
+    .then(resp => resp.ok ? resp.body : Promise.reject(new Error(`${url} returned ${resp.status}`)))
     .then(scan => {
       if (requestSerial !== worktreesRequestSerial) return;
       worktreesLoaded = true;
@@ -1090,16 +1091,11 @@ async function openWorktreeInspect(wt) {
   renderWorktreeInspectLoading(wt);
   try {
     const payload = worktreeInspectPayload(wt);
-    const resp = await dashboardTransport.jsonFetch('api_worktrees_inspect', payload, () => (
-      authedFetch('/api/worktrees/inspect', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      })
-    ), 'api_worktrees_inspect', { fallbackAfterRpcFailure: false });
-    const text = await resp.text();
-    let inspect = {};
-    try { inspect = text ? JSON.parse(text) : {}; } catch (_) {}
+    // daemonApi (transport F2): a POST twin — the facade's no-replay
+    // policy covers the fallbackAfterRpcFailure:false this call passed by
+    // hand.
+    const resp = await daemonApi.request('api_worktrees_inspect', payload);
+    const inspect = (resp.body && typeof resp.body === 'object') ? resp.body : {};
     if (!resp.ok || inspect.ok === false) {
       throw new Error(inspect.error || `worktree inspect returned ${resp.status}`);
     }
@@ -1443,16 +1439,11 @@ async function drainWorktreeRemovalQueue() {
         path: wt.path,
         expected_head: wt.head || null,
       };
-      const r = await dashboardTransport.jsonFetch('api_worktrees_remove', payload, () => (
-        authedFetch('/api/worktrees/remove', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
-        })
-      ), 'api_worktrees_remove', { fallbackAfterRpcFailure: false });
-      const text = await r.text();
-      let result = {};
-      try { result = text ? JSON.parse(text) : {}; } catch (_) {}
+      // daemonApi (transport F2): a POST twin — the facade's no-replay
+      // policy covers the fallbackAfterRpcFailure:false this call passed
+      // by hand.
+      const r = await daemonApi.request('api_worktrees_remove', payload);
+      const result = (r.body && typeof r.body === 'object') ? r.body : {};
       if (!r.ok || result.ok === false) {
         throw new Error(result.error || `worktree removal returned ${r.status}`);
       }


### PR DESCRIPTION
Second of the three F2 (sessions-family) PR units from the transport-unification frontend track. Stacked on #166 (F2a) — the diff collapses to the F2b delta once that lands.

## What moves
- `53-stats-settings.js`: `fetchSessionsForHost` (the session-list read every pane shares) and `streamSessionsForHost` (the hydration stream) ride `daemonApi.request` / `daemonApi.stream`. The hand-rolled tunnel-then-HTTP ladders collapse into the facade; the deliberate exceptions stay explicit and documented:
  - the whole-corpus usage view keeps its local-HTTP fast path (`preferHttp`) — a perf carve-out, not a transport decision;
  - cross-origin peer HTTP (the fleet Stats CORS lane) stays an explicit remote lane at the call site — peers have no authenticated HTTP lane, so it must never look like a facade fallback.
- `54-session-lifecycle.js`: `hydrateSessionWorktreeFinishInfo` one-shot list read.
- `56-debug-sessions.js`: `loadSessions`' abort check accepts facade aborts (`kind:'abort'`) alongside DOM `AbortError`.

## The stream-verb decision
S10 (server stream unification) has NOT landed — and is not needed for this lane: `GET /api/sessions/stream` already emits NDJSON lines carrying the same event objects the tunnel's `stream_event` frames deliver (the client fed both through one handler before this change). So the facade's `stream` verb gains its HTTP adapter now: tunnel stream first, and a failed lane replays the GET twin as a chunked NDJSON read (row merges are idempotent, exactly like the legacy per-call-site fallback). Connect mode never uses HTTP. S10 stays a server-internal dedup with no frontend dependency.

## Descriptor + pin
`DAEMON_API_HTTP_MAP` += `api_sessions` (query lifts `ids`/`limit`/`view`; arrays comma-join, empty arrays stay absent) and `api_sessions_stream` (lane `stream`); parity-pin coverage extended in the same change.

## Facade extensions (data-shaped)
- Array query params comma-join; empty arrays stay absent (the tunnel vocabulary cannot express HTTP's present-but-empty filter).
- `lane: 'stream'` maps to the `stream_frames` wire feature for availability; lane features without a status boolean fall back to the hello features list instead of reading absence as denial.
- One NDJSON reader (`daemonApiReadNdjsonBody`), shared by the facade's HTTP stream adapter and the explicit peer remote lane.

Remaining F2 unit: F2c detail/search/report/context-snapshot (50/48/39/40).
