### PR TITLE
Supervised Claude: ghost-window/vitals/meter fixes, /btw side conversations, 2.1.206 delta

### DIFF
--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -1403,8 +1403,8 @@ pub enum ControlMsg {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         claude_permission_mode: Option<String>,
         /// Optional one-shot Claude Code reasoning-effort level
-        /// (low/medium/high/xhigh/max) for this session. Only applies when
-        /// the resolved agent is Claude Code.
+        /// (low/medium/high/xhigh/max/ultracode) for this session. Only
+        /// applies when the resolved agent is Claude Code.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         claude_effort: Option<String>,
         /// Optional one-shot Codex model override for this session (e.g.

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -848,6 +848,14 @@ impl CcReader {
             .filter(|s| !s.is_empty())?
             .to_string();
         if !self.task_children.contains_key(&ptid) {
+            // The lazy path exists for resume replays whose Agent tool_use
+            // was never observed. An id currently open as an ordinary tool
+            // is that command's own tool_use, never a spawn scope — route
+            // such envelopes to the main thread instead of materializing a
+            // ghost child (the task_started guard's belt, mirrored here).
+            if self.open_tools.contains_key(&ptid) {
+                return None;
+            }
             let spawn = CcTaskSpawn {
                 description: msg
                     .get("task_description")
@@ -1150,17 +1158,20 @@ impl CcReader {
             self.task_ids
                 .insert(task_id.to_string(), tool_use_id.to_string());
         }
-        let is_agent_task = match msg.get("task_type").and_then(|v| v.as_str()) {
-            Some(task_type) => task_type == "agent" || task_type.ends_with("_agent"),
-            // Pre-task_type CLIs (< 2.1.206) emitted task_started only for
-            // Agent spawns, and those payloads carried `subagent_type` +
-            // `prompt` (live-probed); Bash payloads carry neither, so this
-            // affirmative check stays fail-closed for unknown task kinds.
-            None => {
-                msg.get("subagent_type").and_then(|v| v.as_str()).is_some()
-                    || msg.get("prompt").and_then(|v| v.as_str()).is_some()
-            }
-        };
+        // `subagent_type` only ever rides agent spawns (live-probed: Bash
+        // payloads carry neither it nor `prompt`), so its presence is
+        // affirmative regardless of task_type — a future CLI renaming the
+        // agent task kind (e.g. "subagent") must not drop registration
+        // while the field still identifies the spawn.
+        let is_agent_task = msg.get("subagent_type").and_then(|v| v.as_str()).is_some()
+            || match msg.get("task_type").and_then(|v| v.as_str()) {
+                Some(task_type) => task_type == "agent" || task_type.ends_with("_agent"),
+                // Pre-task_type CLIs (< 2.1.206) emitted task_started only
+                // for Agent spawns, and those payloads carried `prompt`
+                // (live-probed) — the affirmative check stays fail-closed
+                // for unknown task kinds.
+                None => msg.get("prompt").and_then(|v| v.as_str()).is_some(),
+            };
         if !is_agent_task || self.open_tools.contains_key(tool_use_id) {
             return;
         }
@@ -3430,6 +3441,42 @@ mod tests {
             r#"{"type":"system","subtype":"task_notification","task_id":"b7mlg8ym4","tool_use_id":"toolu_01SLOWBASH00000000","status":"completed","output_file":"","summary":"Slow foreground probe loop","session_id":"s1"}"#,
         );
         assert!(out.events.is_empty());
+    }
+
+    #[test]
+    fn subagent_typed_task_started_registers_despite_unknown_task_type() {
+        // subagent_type identifies a spawn even if a future CLI renames the
+        // agent task_type to something outside the *_agent vocabulary.
+        let mut reader = test_reader();
+        let out = reader.process_line(
+            r#"{"type":"system","subtype":"task_started","task_id":"zz9","tool_use_id":"toolu_01RENAMEDAGENT0000","description":"probe","subagent_type":"general-purpose","task_type":"subagent","prompt":"go","session_id":"s1"}"#,
+        );
+        assert!(out.events.iter().any(|e| matches!(
+            e,
+            AgentEvent::SubAgentToolCall { status, .. } if status == "inProgress"
+        )));
+    }
+
+    #[test]
+    fn lazy_scope_for_an_open_tool_never_materializes_a_child() {
+        // An envelope parented to an id that is currently open as an
+        // ordinary tool must not ghost a child through the lazy
+        // resume-replay path; it routes to the main thread instead.
+        let mut reader = test_reader();
+        reader.process_line(
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_01OPENLAZY00000000","name":"Bash","input":{"command":"sleep 5","description":"slow"}}]},"parent_tool_use_id":null,"session_id":"s1"}"#,
+        );
+        let out = reader.process_line(
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"partial output"}]},"parent_tool_use_id":"toolu_01OPENLAZY00000000","session_id":"s1"}"#,
+        );
+        assert!(!reader.task_children.contains_key("toolu_01OPENLAZY00000000"));
+        assert!(
+            !out.events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::SubAgentToolCall { .. })),
+            "lazy path spawned: {:?}",
+            out.events
+        );
     }
 
     #[test]

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -482,10 +482,15 @@ impl SessionSupervisor {
             // requested kind — `side` for /btw conversations).
             if let Some(config) = session_agent_config.as_mut() {
                 config.forked_from = Some(resume_token.clone());
+                // Only vetted lineage kinds may ride the wire into persisted
+                // lineage: the kind drives frontend gating (side-window
+                // affordances), so an arbitrary string from any ResumeSession
+                // sender must not masquerade as e.g. "subagent". Unknown
+                // kinds degrade to the plain "fork" emit (None).
                 config.fork_relationship = relationship_kind
                     .as_deref()
                     .map(str::trim)
-                    .filter(|kind| !kind.is_empty() && *kind != "fork")
+                    .filter(|kind| *kind == "side")
                     .map(str::to_string);
             }
         }


### PR DESCRIPTION
Supervised-Claude bug batch + /btw side conversations + CC 2.1.206 delta.

## Reported bugs fixed
- **Ghost sub-agent windows** (session 0b119ef7: 5 windows for 3 spawns): CC 2.1.206 announces background/auto-backgrounded Bash commands through the same `system:task_started` channel as Agent spawns (`task_type:"local_bash"`, probed live); the adapter's registration fallback materialized a dead child window per slow command. Registration now requires an affirmatively agent-typed task, never fires for an id already open as an ordinary tool, and the lazy resume-replay path carries the same belt.
- **Empty PROMPT CACHE vitals**: the usage-driven cache/limits listener died with the git prober's project-root gating — a projectless daemon (launched from `$HOME`) lost cache and rate-limit vitals for every session on every backend. The producer now always runs; empty git target set just means no git rows.
- **Stuck context meter on grid switching**: any session's status tick wrote `budget_pct` straight onto the header meter, so a busy background session perpetually overwrote the focused session's number. Status-borne budget writes are now foreground-scoped (identity-group aware); the review batch extended focus gating to the provider/model/turn chips and the foreground usage lookup.

## /btw for supervised Claude sessions
CC's native `/btw` is interactive-only — over stream-json the CLI answers with a synthetic "isn't available in this environment" result (probed on 2.1.206). Supervised sessions reproduce the semantics on the universal side rails: `/side` (`/btw` alias, composer + kebab + ctl) respawns a `--fork-session` child whose first prompt carries the shared side-conversation contract + the question; lineage persists as `fork_relationship:"side"` and the identity upgrade emits an ephemeral `side` relationship (Codex parity). Both dispatch sites (drain + presence-loop mirror) share one `respawn_resume_thread_action` helper. Live-verified end to end (side action result, `side` edge, child answered from forked context).

## CC 2.1.206 delta
- Permission modes: `dontAsk` + the CLI's classifier `auto` join the vocabulary; legacy `"auto"` configs get a load-time escalation warning (pre-2.1.206 Intendant coerced auto→default); canonical `CLAUDE_PERMISSION_MODES` const + parity test pin all four frontend mirrors + station-web pills.
- `ultracode` effort (2.1.203+) end to end.
- `[agent.claude_code] max_budget_usd` arms the CLI's `--max-budget-usd` backstop, fail-closed on non-positive/non-finite values (the CLI crashes on 0), with an `error_max_budget_usd` recovery hint noting resumes/forks share the parent's counted spend (probed).
- `background_tasks_changed` joins the deliberately-ignored system subtypes.

## Review hardening (max-effort review, 34 confirmed findings → 15 distinct, all closed)
Budget fail-closed + spawn refusal, side-child display polish (bare question in meta/SessionStarted, child-id announcement instead of the parent's), Stop on side windows, `relationship_kind` whitelisted before persisting as lineage, `subagent_type` recognized regardless of future `task_type` renames, stale wire docs.

Verified: full unit suite green (2754), focused suites re-run green post-batch (149), live rig (ghosts/vitals//btw/side lineage), zero-cost stream-json probes for every new protocol fact.
