### PR TITLE
Session vitals: dynamic git targets for supervised sessions

### DIFF
--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -6,6 +6,15 @@
 use super::*;
 
 impl SessionSupervisor {
+    /// Register a launched session's effective project root as its
+    /// git-vitals probe target (worktree sessions pass their checkout).
+    /// No-op when the daemon runs without the vitals producer.
+    fn register_git_vitals(&self, session_id: &str, root: &std::path::Path) {
+        if let Some(targets) = self.config.git_vitals_targets.as_ref() {
+            targets.register(session_id, root.to_path_buf());
+        }
+    }
+
     pub(crate) async fn start_new_session(
         &self,
         task: String,
@@ -130,6 +139,7 @@ impl SessionSupervisor {
             task_meta,
             session_name.as_deref(),
         );
+        self.register_git_vitals(&session_id, &project.root);
         if let Some(ref meta) = worktree_meta {
             // Persist the linkage after the meta file exists; it survives
             // later meta rewrites (see SessionLog::write_meta_worktree).
@@ -607,6 +617,7 @@ impl SessionSupervisor {
                 });
 
                 write_session_meta(&session_log, &project.root, None, None);
+                self.register_git_vitals(&session_id, &project.root);
                 if let Some(config) = effective_session_agent_config.as_ref() {
                     let _ = crate::session_config::write_log_dir_config(&log_dir, config);
                 }
@@ -729,6 +740,17 @@ impl SessionSupervisor {
         let display_task = crate::thread_actions::side_respawn_display_task(&resume_task)
             .unwrap_or_else(|| resume_task.clone());
         write_session_meta(&session_log, &project.root, Some(&display_task), None);
+        // Forks announce under the child wrapper id (see SessionStarted
+        // below); key the git probe the same way so the row lands on the
+        // child window, not the parent's.
+        self.register_git_vitals(
+            if fork {
+                &intendant_session_id
+            } else {
+                &live_session_id
+            },
+            &project.root,
+        );
         if let Some(config) = effective_session_agent_config.as_ref() {
             let _ = crate::session_config::write_log_dir_config(&log_dir, config);
         }

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -63,6 +63,13 @@ pub struct SessionSupervisorConfig {
     /// otherwise resolve against a real session log and flip the flow
     /// from follow-up routing to a fresh resume dispatch.
     pub logs_home_override: Option<PathBuf>,
+    /// Git-vitals target registry: the supervisor registers each managed
+    /// session's effective project root (the worktree checkout for
+    /// worktree sessions) at launch, which is what puts the dirty /
+    /// merge-parity / unpushed rows on dashboard-spawned sessions.
+    /// `SessionEnded` prunes on the producer side. None when the daemon
+    /// runs without the vitals producer (no web frontends).
+    pub git_vitals_targets: Option<crate::session_vitals::GitVitalsTargets>,
 }
 
 #[derive(Clone)]
@@ -667,6 +674,7 @@ mod tests {
                 std::env::temp_dir()
                     .join(format!("intendant-test-logs-home-{}", std::process::id())),
             ),
+            git_vitals_targets: None,
         })
     }
 

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -322,35 +322,101 @@ fn spawn_cache_vitals_listener(
     })
 }
 
+/// Live registry of (session id → working dir) git-probe targets. The
+/// daemon seeds the primary session at startup; the session supervisor
+/// registers every managed session at launch — which is what puts the
+/// dirty-count / merge-parity / unpushed rows on dashboard-spawned
+/// sessions and on projectless daemons (whose primary has no repo).
+/// `SessionEnded` prunes entries, so a handle owner only has to register.
+#[derive(Clone, Default)]
+pub(crate) struct GitVitalsTargets {
+    targets: Arc<Mutex<HashMap<String, PathBuf>>>,
+}
+
+impl GitVitalsTargets {
+    /// Register (or retarget) a session's git probe root. No-ops on empty
+    /// ids so callers can pass through unresolved values unchecked.
+    pub(crate) fn register(&self, session_id: &str, cwd: PathBuf) {
+        let session_id = session_id.trim();
+        if session_id.is_empty() {
+            return;
+        }
+        self.targets
+            .lock()
+            .expect("git vitals targets lock")
+            .insert(session_id.to_string(), cwd);
+    }
+
+    pub(crate) fn remove(&self, session_id: &str) {
+        self.targets
+            .lock()
+            .expect("git vitals targets lock")
+            .remove(session_id.trim());
+    }
+
+    fn snapshot(&self) -> Vec<(String, PathBuf)> {
+        self.targets
+            .lock()
+            .expect("git vitals targets lock")
+            .iter()
+            .map(|(id, cwd)| (id.clone(), cwd.clone()))
+            .collect()
+    }
+}
+
 /// Vitals producer: spawns the cache listener and runs the periodic git
-/// prober for a fixed set of (session id, working dir) targets — today the
-/// primary session. All emission flows through the change-detecting hub;
-/// the session log persists each emission so reconnecting frontends replay
-/// the latest.
+/// prober over the live target registry (seeded with the primary session,
+/// fed by the session supervisor as sessions launch). All emission flows
+/// through the change-detecting hub; the session log persists each
+/// emission so reconnecting frontends replay the latest.
 ///
-/// `targets` may be empty: the cache/limits sections are usage-driven and
+/// The seed may be empty: the cache/limits sections are usage-driven and
 /// backend-agnostic, so the listener runs wherever a bus exists — a
 /// projectless daemon still reports cache and rate-limit vitals for every
 /// session; only the git segment needs a repo target.
 pub(crate) fn spawn_session_vitals_producer(
     bus: EventBus,
-    targets: Vec<(String, PathBuf)>,
-) -> tokio::task::JoinHandle<()> {
+    seed_targets: Vec<(String, PathBuf)>,
+) -> (GitVitalsTargets, tokio::task::JoinHandle<()>) {
+    let registry = GitVitalsTargets::default();
+    for (session_id, cwd) in seed_targets {
+        registry.register(&session_id, cwd);
+    }
     let hub = SessionVitalsHub::new(bus.clone());
-    let _cache_listener = spawn_cache_vitals_listener(bus, hub.clone());
-    tokio::spawn(async move {
-        if targets.is_empty() {
-            // Nothing to probe — the cache/limits listener above is
-            // detached and outlives this task.
-            return;
-        }
-        let mut prober = GitVitalsProber::default();
-        loop {
-            for (session_id, cwd) in &targets {
-                let probed = prober.probe(cwd).await;
-                hub.apply(session_id, |vitals| vitals.git = probed);
+    let _cache_listener = spawn_cache_vitals_listener(bus.clone(), hub.clone());
+    let _target_pruner = spawn_git_target_pruner(bus, registry.clone());
+    let handle = tokio::spawn({
+        let registry = registry.clone();
+        async move {
+            let mut prober = GitVitalsProber::default();
+            loop {
+                for (session_id, cwd) in registry.snapshot() {
+                    let probed = prober.probe(&cwd).await;
+                    hub.apply(&session_id, |vitals| vitals.git = probed);
+                }
+                tokio::time::sleep(PROBE_INTERVAL).await;
             }
-            tokio::time::sleep(PROBE_INTERVAL).await;
+        }
+    });
+    (registry, handle)
+}
+
+/// Prune git targets when their session ends — mirrors the cache
+/// listener's `SessionEnded` hygiene so registered sessions never leak
+/// probe work past their lifetime.
+fn spawn_git_target_pruner(
+    bus: EventBus,
+    registry: GitVitalsTargets,
+) -> tokio::task::JoinHandle<()> {
+    let mut rx = bus.subscribe();
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(AppEvent::SessionEnded { session_id, .. }) => registry.remove(&session_id),
+                Ok(_) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
         }
     })
 }
@@ -513,6 +579,54 @@ mod tests {
             emissions[2].1.cache.is_none(),
             "removed session re-registers from scratch"
         );
+    }
+
+    #[tokio::test]
+    async fn registered_target_probes_and_session_end_prunes() {
+        // Supervisor-registered sessions get git rows without a restart;
+        // SessionEnded prunes the target (registry drops the entry).
+        let temp = tempfile::tempdir().expect("tempdir");
+        let root = temp.path();
+        git_cmd(root, &["init", "-q", "-b", "main"]);
+        std::fs::write(root.join("a.txt"), "one\n").unwrap();
+        git_cmd(root, &["add", "."]);
+        git_cmd(root, &["commit", "-qm", "init"]);
+        std::fs::write(root.join("b.txt"), "dirty\n").unwrap();
+
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        let (targets, _producer) = spawn_session_vitals_producer(bus.clone(), Vec::new());
+        targets.register("supervised-1", root.to_path_buf());
+
+        let deadline = std::time::Duration::from_secs(20);
+        loop {
+            let event = tokio::time::timeout(deadline, rx.recv())
+                .await
+                .expect("git vitals emission before timeout")
+                .expect("bus open");
+            if let AppEvent::SessionVitals { session_id, vitals } = event {
+                assert_eq!(session_id, "supervised-1");
+                let git = vitals.git.expect("git section probed");
+                assert_eq!(git.branch, "main");
+                assert_eq!(git.dirty_files, 1);
+                break;
+            }
+        }
+
+        bus.send(AppEvent::SessionEnded {
+            session_id: "supervised-1".into(),
+            reason: "done".into(),
+            error_kind: None,
+        });
+        // The pruner runs on the bus; poll until the entry is gone.
+        let start = std::time::Instant::now();
+        while !targets.snapshot().is_empty() {
+            assert!(
+                start.elapsed() < std::time::Duration::from_secs(5),
+                "SessionEnded did not prune the git target"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
     }
 
     #[tokio::test]

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -26,6 +26,9 @@ pub(crate) struct DaemonConfig {
     pub(crate) flags_direct: bool,
     /// Optional shared session state for headless mode (cleared between tasks).
     pub(crate) shared_session: Option<web_gateway::SharedActiveSession>,
+    /// Git-vitals target registry handed to the supervisor (see
+    /// `SessionSupervisorConfig::git_vitals_targets`).
+    pub(crate) git_vitals_targets: Option<session_vitals::GitVitalsTargets>,
 }
 
 /// Daemon loop the headless web-gateway path falls through to after its task ends.
@@ -53,6 +56,7 @@ pub(crate) async fn run_daemon_loop(config: DaemonConfig) {
         shared_session: config.shared_session,
         provider_factory: None,
         logs_home_override: None,
+        git_vitals_targets: config.git_vitals_targets,
     })
     .run()
     .await;
@@ -170,14 +174,16 @@ pub(crate) async fn run_daemon(
 
     // Session vitals: cache/limits are usage-driven and cover every
     // session on any backend, so the producer always runs. The git segment
-    // additionally needs a repo target — the daemon's primary session when
-    // a project root exists (a projectless daemon just has no git row).
-    let vitals_git_targets = match (session_log_id(&session_log), project_root.clone()) {
+    // probes the live target registry: seeded with the daemon's primary
+    // session when a project root exists, and fed per-session by the
+    // supervisor at launch — dashboard-spawned sessions get their dirty /
+    // merge-parity / unpushed rows even on a projectless daemon.
+    let vitals_git_seed = match (session_log_id(&session_log), project_root.clone()) {
         (Some(session_id), Some(root)) => vec![(session_id, root)],
         _ => Vec::new(),
     };
-    let _vitals_producer =
-        session_vitals::spawn_session_vitals_producer(bus.clone(), vitals_git_targets);
+    let (vitals_git_targets, _vitals_producer) =
+        session_vitals::spawn_session_vitals_producer(bus.clone(), vitals_git_seed);
     // Native usage rail: derive per-session UsageSnapshots from
     // ModelResponse events (dashboard meter + cache/limits vitals).
     // Covers supervisor-spawned native children too.
@@ -201,6 +207,7 @@ pub(crate) async fn run_daemon(
             shared_session: Some(shared_session),
             provider_factory: None,
             logs_home_override: None,
+            git_vitals_targets: Some(vitals_git_targets.clone()),
         })
         .spawn();
     // --continue/--resume under the daemon: the supervisor (subscribed

--- a/src/bin/caller/startup/headless.rs
+++ b/src/bin/caller/startup/headless.rs
@@ -466,6 +466,22 @@ pub(crate) async fn run_headless_mode(
         },
     );
 
+    // Session vitals: cache/limits are usage-driven and always produced;
+    // the git segment probes the live target registry (primary session
+    // seed + supervisor-registered sessions).
+    let vitals = if use_web {
+        let seed = session_log_id(&session_log)
+            .map(|session_id| vec![(session_id, project.root.clone())])
+            .unwrap_or_default();
+        Some(session_vitals::spawn_session_vitals_producer(
+            bus.clone(),
+            seed,
+        ))
+    } else {
+        None
+    };
+    let vitals_git_targets = vitals.as_ref().map(|(targets, _)| targets.clone());
+
     // Dashboard-driven CreateSession / ResumeSession while the foreground
     // session runs: parallel sessions are owned by the session supervisor
     // (the dispatcher deliberately ignores them).
@@ -487,6 +503,7 @@ pub(crate) async fn run_headless_mode(
                     shared_session: headless_shared_session.clone(),
                     provider_factory: None,
                     logs_home_override: None,
+                    git_vitals_targets: vitals_git_targets.clone(),
                 },
             )
             .spawn_resume_listener(),
@@ -495,19 +512,6 @@ pub(crate) async fn run_headless_mode(
         None
     };
 
-    // Session vitals: cache/limits are usage-driven and always produced;
-    // the git segment probes the project root for the primary session.
-    let _vitals_producer = if use_web {
-        let targets = session_log_id(&session_log)
-            .map(|session_id| vec![(session_id, project.root.clone())])
-            .unwrap_or_default();
-        Some(session_vitals::spawn_session_vitals_producer(
-            bus.clone(),
-            targets,
-        ))
-    } else {
-        None
-    };
     // Native usage rail: derive per-session UsageSnapshots from
     // ModelResponse events (dashboard meter + cache/limits vitals).
     let _usage_rail = if use_web {
@@ -706,6 +710,7 @@ pub(crate) async fn run_headless_mode(
             web_port: web_port_for_agent,
             flags_direct: flags.direct,
             shared_session: headless_shared_session.clone(),
+            git_vitals_targets: vitals_git_targets.clone(),
         })
         .await;
     } else {


### PR DESCRIPTION
The git prober's target set was frozen at daemon startup as (primary session, project root), so the statusline port's git rows — dirty count ●N, merge-parity preview ✓/⚠, ahead/behind, unpushed ⇡N — never appeared where the operator actually works: dashboard-spawned sessions were never targets, and a projectless daemon (launched from $HOME, the daily shape) had no target at all, hiding the segment daemon-wide.

`spawn_session_vitals_producer` now owns a live `GitVitalsTargets` registry (primary-session seed; `SessionEnded` prunes) and the session supervisor registers every managed session's effective project root at launch. Worktree sessions register their checkout, so a worktree session's row shows its own dirty state and merge parity against the shared primary — the worktrees→main preview the port was built for. Fork/side children register under the announced child wrapper id so the row lands on the child window.

Covers all three supervisor launch paths (create, resume/attach, fork/side respawn) plus both startup shapes (daemon, headless fall-through). Registry + prune covered by a new integration test against a real temp repo; supervisor/startup/vitals suites green.