### PR TITLE
Transport S6a: access inspect/connect/tier family onto the neutral api core

### DIFF
--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -2279,6 +2279,231 @@ mod tests {
         assert_eq!(frame["error"], "missing body");
     }
 
+    // ── S6 tunnel/HTTP parity: access inspect/connect/tier family ──
+    //
+    // Extends the S4/S5 enumerations. The S6-specific envelope
+    // differences, deliberate and pinned across this set (the org and
+    // grant-mutation slices extend it):
+    //
+    //  10. The ok/error envelope: this family predates `_httpStatus` —
+    //      2xx bodies ride the body-only `{t,id,ok:true,result}` frame,
+    //      and error statuses surface the shared cores' `{"error": …}`
+    //      body as the frame-level `{ok:false, error}` shape
+    //      (frame_api_ok_error_response). No status metadata on either
+    //      shape.
+    //  11. Fleet-CORS decoration is HTTP-lane-only: the fleet-allowlist
+    //      origin echo + `Vary: Origin` — and the historical
+    //      undecorated shapes underneath it (the belt-and-suspenders
+    //      manage-recheck 403, the tier pair's parse-error 400) — never
+    //      appear on the tunnel (the golden transcripts in
+    //      routes_access.rs pin the HTTP side).
+    //  12. The manage re-check is an HTTP-edge belt: the tunnel's
+    //      equivalent gate is the pre-dispatch method authorizer (the
+    //      row-derived operation), whose denial is the authorizer's own
+    //      `{ok:false, error:"…is not allowed…"}` frame, not a 403
+    //      body.
+    //  13. Transport-owned request carriage: the tunnel's params object
+    //      is the canonical shape (§2.1) and absent params read as
+    //      `{}`; HTTP parses its body text at the edge with the
+    //      historical wordings ("invalid request body: …"), so
+    //      parse-failure shapes are HTTP-only.
+    //  14. Store resolution at the edges: both lanes resolve the
+    //      ambient cert dir / project root at their dispatch arms and
+    //      hand paths to the shared cores (hermeticity convention) —
+    //      these fixtures inject tempdirs and never touch the live
+    //      account's stores.
+
+    #[tokio::test]
+    async fn parity_dashboard_targets_rides_the_ok_error_envelope() {
+        // Both lanes render the ONE neutral fn over the same inputs (an
+        // empty agent card, no registry — the deterministic local-only
+        // list).
+        let card = serde_json::json!({});
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::dashboard_targets_api_response(&card, None),
+        );
+        assert_eq!(status, 200);
+        let frame = frame_api_ok_error_response(
+            "parity-targets".to_string(),
+            crate::web_gateway::dashboard_targets_api_response(&card, None),
+            "dashboard targets",
+        );
+        assert_eq!(frame["ok"], true);
+        assert!(frame["result"]
+            .as_object()
+            .is_some_and(|map| !map.contains_key("_httpStatus")));
+        assert_eq!(frame["result"], http_body);
+    }
+
+    #[tokio::test]
+    async fn parity_access_inspect_reads_share_bodies_over_an_injected_cert_dir() {
+        // iam/state and enrollment-requests: deterministic empty-store
+        // bodies from the one core each, body-only envelope on the
+        // tunnel.
+        let tmp = tempfile::tempdir().expect("temp cert dir");
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_iam_state_api_response(tmp.path()),
+        );
+        assert_eq!(status, 200);
+        let frame = frame_api_ok_error_response(
+            "parity-iam-state".to_string(),
+            crate::web_gateway::access_iam_state_api_response(tmp.path()),
+            "access iam state",
+        );
+        assert_eq!(frame["ok"], true);
+        assert_eq!(frame["result"], http_body);
+        assert_eq!(frame["result"]["schema_version"], 1);
+
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_enrollment_requests_api_response(tmp.path()),
+        );
+        assert_eq!(status, 200);
+        let frame = frame_api_ok_error_response(
+            "parity-enrollment".to_string(),
+            crate::web_gateway::access_enrollment_requests_api_response(tmp.path()),
+            "access enrollment requests",
+        );
+        assert_eq!(frame["ok"], true);
+        assert_eq!(frame["result"], http_body);
+
+        // Overview: same principal, same card, same store on both lanes.
+        let card = serde_json::json!({});
+        let principal =
+            crate::access::iam::AccessPrincipal::root_dashboard_session("parity", "https");
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_overview_api_response(tmp.path(), &card, None, &principal),
+        );
+        assert_eq!(status, 200);
+        let frame = frame_api_ok_error_response(
+            "parity-overview".to_string(),
+            crate::web_gateway::access_overview_api_response(tmp.path(), &card, None, &principal),
+            "access overview",
+        );
+        assert_eq!(frame["ok"], true);
+        assert_eq!(frame["result"], http_body);
+    }
+
+    #[tokio::test]
+    async fn parity_access_tier_settings_shares_the_core_across_lanes() {
+        let tmp = tempfile::tempdir().expect("temp cert dir");
+        let actor =
+            crate::access::iam::AccessPrincipal::root_dashboard_session("parity", "https");
+
+        // Validation error: the shared core's wording surfaces as the
+        // HTTP `{"error"}` body and the tunnel's frame-level error
+        // (difference #10) — no store touched.
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_tier_settings_api_response(
+                tmp.path(),
+                false,
+                serde_json::json!({"tier": 123}),
+                &actor,
+            ),
+        );
+        assert_eq!(status, 400);
+        assert_eq!(
+            http_body,
+            serde_json::json!({"error": "tier must be a string or null"})
+        );
+        let frame = frame_api_ok_error_response(
+            "parity-tier-bad".to_string(),
+            crate::web_gateway::access_tier_settings_api_response(
+                tmp.path(),
+                false,
+                serde_json::json!({"tier": 123}),
+                &actor,
+            ),
+            "trust tier settings",
+        );
+        assert_eq!(frame["ok"], false);
+        assert_eq!(frame["error"], "tier must be a string or null");
+
+        // Success over the injected store: both lanes set the tier
+        // through the one core (the `iam` overview metadata carries
+        // store fingerprints, so equality is asserted on the mutation's
+        // own fields).
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_tier_settings_api_response(
+                tmp.path(),
+                false,
+                serde_json::json!({"tier": "disposable"}),
+                &actor,
+            ),
+        );
+        assert_eq!(status, 200);
+        assert_eq!(http_body["tier"], "disposable");
+        let frame = frame_api_ok_error_response(
+            "parity-tier".to_string(),
+            crate::web_gateway::access_tier_settings_api_response(
+                tmp.path(),
+                false,
+                serde_json::json!({"tier": "disposable"}),
+                &actor,
+            ),
+            "trust tier settings",
+        );
+        assert_eq!(frame["ok"], true);
+        assert_eq!(frame["result"]["tier"], "disposable");
+        assert_eq!(frame["result"]["schema_version"], http_body["schema_version"]);
+
+        // Hosted ceiling validation on both lanes.
+        let frame = frame_api_ok_error_response(
+            "parity-ceiling-bad".to_string(),
+            crate::web_gateway::access_tier_settings_api_response(
+                tmp.path(),
+                true,
+                serde_json::json!({}),
+                &actor,
+            ),
+            "trust tier settings",
+        );
+        assert_eq!(frame["ok"], false);
+        assert_eq!(frame["error"], "role_id is required");
+    }
+
+    #[tokio::test]
+    async fn parity_connect_config_and_unclaim_deterministic_errors() {
+        // Connect config, missing `enabled`: the shared validation
+        // error before any store access, on both lanes.
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_connect_config_api_response(serde_json::json!({}), None),
+        );
+        assert_eq!(status, 400);
+        assert_eq!(
+            http_body,
+            serde_json::json!({"error": "enabled must be true or false"})
+        );
+        let frame = frame_api_ok_error_response(
+            "parity-connect-config".to_string(),
+            crate::web_gateway::access_connect_config_api_response(serde_json::json!({}), None),
+            "connect config",
+        );
+        assert_eq!(frame["ok"], false);
+        assert_eq!(frame["error"], "enabled must be true or false");
+
+        // Unclaim over a tempdir project root: the deterministic
+        // no-rendezvous error through the tunnel twin fn (the live
+        // release path stays smoke-covered). The tempdir root keeps the
+        // store off the daemon-scoped connect.toml.
+        let dir = tempfile::tempdir().expect("temp project root");
+        let mut rt = runtime();
+        rt.project_root = Some(dir.path().to_path_buf());
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_connect_unclaim_api_response(
+                Some(dir.path().to_path_buf()),
+            )
+            .await,
+        );
+        assert_eq!(status, 400);
+        assert_eq!(
+            http_body,
+            serde_json::json!({"error": "no rendezvous_url configured"})
+        );
+        let frame = api_access_connect_unclaim_response("parity-unclaim".to_string(), &rt).await;
+        assert_eq!(frame["ok"], false);
+        assert_eq!(frame["error"], "no rendezvous_url configured");
+    }
+
     use crate::*;
     use crate::dashboard_control::tests::{runtime};
 

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -146,6 +146,21 @@ pub(crate) async fn api_credential_egress_probe_response(
     }
 }
 
+/// The tunnel's `api_access_connect_unclaim` twin: the S6 neutral core
+/// under the family's historical ok/error envelope (the transport edge
+/// hands over this daemon's project root).
+pub(crate) async fn api_access_connect_unclaim_response(
+    id: String,
+    runtime: &ControlRuntime,
+) -> serde_json::Value {
+    frame_api_ok_error_response(
+        id,
+        crate::web_gateway::access_connect_unclaim_api_response(runtime.project_root.clone())
+            .await,
+        "connect unclaim",
+    )
+}
+
 pub(crate) async fn control_request_response(
     id: String,
     method: String,
@@ -161,24 +176,7 @@ pub(crate) async fn control_request_response(
             api_credential_egress_probe_response(id, params.as_ref()).await
         }
         "api_access_connect_unclaim" => {
-            match crate::web_gateway::access_connect_unclaim_response_value(
-                runtime.project_root.clone(),
-            )
-            .await
-            {
-                Ok(result) => serde_json::json!({
-                    "t": "response",
-                    "id": id,
-                    "ok": true,
-                    "result": result,
-                }),
-                Err(error) => serde_json::json!({
-                    "t": "response",
-                    "id": id,
-                    "ok": false,
-                    "error": error,
-                }),
-            }
+            api_access_connect_unclaim_response(id, &runtime).await
         }
         "api_sessions" => api_sessions_response(id, params.as_ref()).await,
         "api_session_detail" => api_session_detail_response(id, params.as_ref()).await,

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -573,11 +573,16 @@ pub(crate) fn control_frame_response(
                 })),
                 "api_access_overview" => {
                     let current_principal = runtime.grant.access_principal();
+                    // The transport edge resolves the ambient cert dir;
+                    // the shared cores are path-parameterized
+                    // (hermeticity convention).
+                    let cert_dir = crate::access::backend::select_backend().cert_dir();
                     Some(serde_json::json!({
                         "t": "response",
                         "id": id,
                         "ok": true,
                         "result": crate::web_gateway::access_overview_response_value_for_principal(
+                            &cert_dir,
                             &runtime.agent_card,
                             runtime.peer_registry.as_ref(),
                             Some(&current_principal),
@@ -588,13 +593,17 @@ pub(crate) fn control_frame_response(
                     "t": "response",
                     "id": id,
                     "ok": true,
-                    "result": crate::web_gateway::access_iam_state_response_value(),
+                    "result": crate::web_gateway::access_iam_state_response_value(
+                        &crate::access::backend::select_backend().cert_dir(),
+                    ),
                 })),
                 "api_access_enrollment_requests" => Some(serde_json::json!({
                     "t": "response",
                     "id": id,
                     "ok": true,
-                    "result": crate::web_gateway::access_enrollment_requests_response_value(),
+                    "result": crate::web_gateway::access_enrollment_requests_response_value(
+                        &crate::access::backend::select_backend().cert_dir(),
+                    ),
                 })),
                 "api_access_enrollment_decide" => {
                     let params = params.unwrap_or_else(|| serde_json::json!({}));
@@ -651,10 +660,15 @@ pub(crate) fn control_frame_response(
                 "api_access_set_tier" | "api_access_set_hosted_ceiling" => {
                     let params = params.unwrap_or_else(|| serde_json::json!({}));
                     let actor = runtime.grant.access_principal();
+                    // Transport edge resolves the ambient cert dir
+                    // (hermeticity convention).
+                    let cert_dir = crate::access::backend::select_backend().cert_dir();
                     let result = if method == "api_access_set_hosted_ceiling" {
-                        crate::web_gateway::access_set_hosted_ceiling_response_value(params, &actor)
+                        crate::web_gateway::access_set_hosted_ceiling_response_value(
+                            &cert_dir, params, &actor,
+                        )
                     } else {
-                        crate::web_gateway::access_set_tier_response_value(params, &actor)
+                        crate::web_gateway::access_set_tier_response_value(&cert_dir, params, &actor)
                     };
                     match result {
                         Ok(result) => Some(serde_json::json!({

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -54,6 +54,53 @@ pub(crate) fn frame_api_json_body_response(
     }
 }
 
+/// Tunnel adapter for the access family's historical ok/error envelope:
+/// a 2xx JSON body renders as `{t:"response", id, ok:true,
+/// result:<body>}` — the body-only shape, no `_httpStatus` metadata
+/// (this family predates the injected-status envelope) — while an error
+/// status surfaces the body's `error` string as the frame-level
+/// `{ok:false, error}` shape the family has always answered with. A
+/// byte response on these JSON-only methods is a wiring bug and fails
+/// closed.
+pub(crate) fn frame_api_ok_error_response(
+    id: String,
+    response: crate::web_gateway::ApiResponse,
+    label: &str,
+) -> serde_json::Value {
+    match response {
+        crate::web_gateway::ApiResponse::Json { status, body, .. } => {
+            let body = body.into_string();
+            if (200..300).contains(&status) {
+                return json_body_response(id, body, label);
+            }
+            // The family's error bodies are the shared cores'
+            // `{"error": <string>}` shape; the frame carries the string
+            // itself (with the whole body as a defensive fallback).
+            let error = serde_json::from_str::<serde_json::Value>(&body)
+                .ok()
+                .and_then(|value| {
+                    value
+                        .get("error")
+                        .and_then(|error| error.as_str())
+                        .map(str::to_string)
+                })
+                .unwrap_or(body);
+            serde_json::json!({
+                "t": "response",
+                "id": id,
+                "ok": false,
+                "error": error,
+            })
+        }
+        crate::web_gateway::ApiResponse::Bytes { .. } => serde_json::json!({
+            "t": "response",
+            "id": id,
+            "ok": false,
+            "error": format!("{label} returned an unexpected byte response"),
+        }),
+    }
+}
+
 /// Tunnel adapter for byte-capable methods: `Bytes` becomes a
 /// `byte_stream_start/chunk/end` sequence — chunking, credits, and
 /// backpressure stay wire.rs-owned — with the neutral fn's `meta`
@@ -562,49 +609,46 @@ pub(crate) fn control_frame_response(
                         "error": "peer registry unavailable",
                     })),
                 },
-                "api_dashboard_targets" => Some(serde_json::json!({
-                    "t": "response",
-                    "id": id,
-                    "ok": true,
-                    "result": crate::web_gateway::dashboard_targets_response_value(
+                // The access inspect/connect/tier twins delegate to the
+                // S6 neutral cores under the family's historical
+                // ok/error envelope; the transport edge resolves the
+                // ambient cert dir (hermeticity convention).
+                "api_dashboard_targets" => Some(frame_api_ok_error_response(
+                    id,
+                    crate::web_gateway::dashboard_targets_api_response(
                         &runtime.agent_card,
                         runtime.peer_registry.as_ref(),
                     ),
-                })),
+                    "dashboard targets",
+                )),
                 "api_access_overview" => {
                     let current_principal = runtime.grant.access_principal();
-                    // The transport edge resolves the ambient cert dir;
-                    // the shared cores are path-parameterized
-                    // (hermeticity convention).
                     let cert_dir = crate::access::backend::select_backend().cert_dir();
-                    Some(serde_json::json!({
-                        "t": "response",
-                        "id": id,
-                        "ok": true,
-                        "result": crate::web_gateway::access_overview_response_value_for_principal(
+                    Some(frame_api_ok_error_response(
+                        id,
+                        crate::web_gateway::access_overview_api_response(
                             &cert_dir,
                             &runtime.agent_card,
                             runtime.peer_registry.as_ref(),
-                            Some(&current_principal),
+                            &current_principal,
                         ),
-                    }))
+                        "access overview",
+                    ))
                 }
-                "api_access_iam_state" => Some(serde_json::json!({
-                    "t": "response",
-                    "id": id,
-                    "ok": true,
-                    "result": crate::web_gateway::access_iam_state_response_value(
+                "api_access_iam_state" => Some(frame_api_ok_error_response(
+                    id,
+                    crate::web_gateway::access_iam_state_api_response(
                         &crate::access::backend::select_backend().cert_dir(),
                     ),
-                })),
-                "api_access_enrollment_requests" => Some(serde_json::json!({
-                    "t": "response",
-                    "id": id,
-                    "ok": true,
-                    "result": crate::web_gateway::access_enrollment_requests_response_value(
+                    "access iam state",
+                )),
+                "api_access_enrollment_requests" => Some(frame_api_ok_error_response(
+                    id,
+                    crate::web_gateway::access_enrollment_requests_api_response(
                         &crate::access::backend::select_backend().cert_dir(),
                     ),
-                })),
+                    "access enrollment requests",
+                )),
                 "api_access_enrollment_decide" => {
                     let params = params.unwrap_or_else(|| serde_json::json!({}));
                     match crate::web_gateway::access_enrollment_decide_response_value(
@@ -625,37 +669,26 @@ pub(crate) fn control_frame_response(
                         })),
                     }
                 }
-                "api_access_connect_status" => Some(serde_json::json!({
-                    "t": "response",
-                    "id": id,
-                    "ok": true,
-                    "result": crate::web_gateway::access_connect_status_response_value(),
-                })),
-                "api_access_connect_claim_code" => Some(serde_json::json!({
-                    "t": "response",
-                    "id": id,
-                    "ok": true,
-                    "result": crate::web_gateway::access_connect_claim_code_response_value(),
-                })),
+                "api_access_connect_status" => Some(frame_api_ok_error_response(
+                    id,
+                    crate::web_gateway::access_connect_status_api_response(),
+                    "connect status",
+                )),
+                "api_access_connect_claim_code" => Some(frame_api_ok_error_response(
+                    id,
+                    crate::web_gateway::access_connect_claim_code_api_response(),
+                    "connect claim code",
+                )),
                 "api_access_connect_config" => {
                     let params = params.unwrap_or_else(|| serde_json::json!({}));
-                    match crate::web_gateway::access_connect_config_response_value(
-                        params,
-                        runtime.project_root.as_deref(),
-                    ) {
-                        Ok(result) => Some(serde_json::json!({
-                            "t": "response",
-                            "id": id,
-                            "ok": true,
-                            "result": result,
-                        })),
-                        Err(error) => Some(serde_json::json!({
-                            "t": "response",
-                            "id": id,
-                            "ok": false,
-                            "error": error,
-                        })),
-                    }
+                    Some(frame_api_ok_error_response(
+                        id,
+                        crate::web_gateway::access_connect_config_api_response(
+                            params,
+                            runtime.project_root.as_deref(),
+                        ),
+                        "connect config",
+                    ))
                 }
                 "api_access_set_tier" | "api_access_set_hosted_ceiling" => {
                     let params = params.unwrap_or_else(|| serde_json::json!({}));
@@ -663,27 +696,16 @@ pub(crate) fn control_frame_response(
                     // Transport edge resolves the ambient cert dir
                     // (hermeticity convention).
                     let cert_dir = crate::access::backend::select_backend().cert_dir();
-                    let result = if method == "api_access_set_hosted_ceiling" {
-                        crate::web_gateway::access_set_hosted_ceiling_response_value(
-                            &cert_dir, params, &actor,
-                        )
-                    } else {
-                        crate::web_gateway::access_set_tier_response_value(&cert_dir, params, &actor)
-                    };
-                    match result {
-                        Ok(result) => Some(serde_json::json!({
-                            "t": "response",
-                            "id": id,
-                            "ok": true,
-                            "result": result,
-                        })),
-                        Err(error) => Some(serde_json::json!({
-                            "t": "response",
-                            "id": id,
-                            "ok": false,
-                            "error": error,
-                        })),
-                    }
+                    Some(frame_api_ok_error_response(
+                        id,
+                        crate::web_gateway::access_tier_settings_api_response(
+                            &cert_dir,
+                            method == "api_access_set_hosted_ceiling",
+                            params,
+                            &actor,
+                        ),
+                        "trust tier settings",
+                    ))
                 }
                 "api_fleet_cert_request" => {
                     // Optional explicit addresses; default = every

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -143,21 +143,12 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
     method("api_cached_bootstrap_events", PeerOperation::SessionInspect),
     internal("subscribe_events", PeerOperation::SessionInspect),
     internal("unsubscribe_events", PeerOperation::SessionInspect),
-    method("api_access_overview", PeerOperation::AccessInspect),
-    method("api_access_iam_state", PeerOperation::AccessInspect),
-    method("api_access_enrollment_requests", PeerOperation::AccessInspect),
-    method("api_dashboard_targets", PeerOperation::AccessInspect),
-    // Connect rendezvous administration. Status is inspect-grade and
-    // never carries the claim phrase; the phrase reveal, config toggle,
-    // and unclaim are manage-gated (mirrors the HTTP route rows).
-    method("api_access_connect_status", PeerOperation::AccessInspect),
-    method("api_access_connect_claim_code", PeerOperation::AccessManage),
-    method("api_access_connect_config", PeerOperation::AccessManage),
-    method("api_access_connect_unclaim", PeerOperation::AccessManage),
-    // Trust-tier settings (docs/src/trust-tiers.md): the tier label and
-    // the hosted-control ceiling knob (mirrors the HTTP route rows).
-    method("api_access_set_tier", PeerOperation::AccessManage),
-    method("api_access_set_hosted_ceiling", PeerOperation::AccessManage),
+    // The access inspect reads (api_access_overview, api_access_iam_state,
+    // api_access_enrollment_requests, api_dashboard_targets), the connect
+    // admin quartet (status, claim-code, config, unclaim), and the
+    // trust-tier pair (set_tier, set_hosted_ceiling) live as tunnel
+    // columns on their route rows — their IAM operations derive from the
+    // rows (S6).
     // Fleet certificate: publish this daemon's addresses for its fleet
     // name and run the ACME DNS-01 order (fleet_cert.rs). Slow flow,
     // started async; progress rides the connect status payload.
@@ -2990,34 +2981,34 @@ mod tests {
             ),
             ("subscribe_events", Residue, Some(Op::SessionInspect)),
             ("unsubscribe_events", Residue, Some(Op::SessionInspect)),
-            ("api_access_overview", Residue, Some(Op::AccessInspect)),
-            ("api_access_iam_state", Residue, Some(Op::AccessInspect)),
+            ("api_access_overview", Row, Some(Op::AccessInspect)),
+            ("api_access_iam_state", Row, Some(Op::AccessInspect)),
             (
                 "api_access_enrollment_requests",
-                Residue,
+                Row,
                 Some(Op::AccessInspect),
             ),
-            ("api_dashboard_targets", Residue, Some(Op::AccessInspect)),
+            ("api_dashboard_targets", Row, Some(Op::AccessInspect)),
             (
                 "api_access_connect_status",
-                Residue,
+                Row,
                 Some(Op::AccessInspect),
             ),
             (
                 "api_access_connect_claim_code",
-                Residue,
+                Row,
                 Some(Op::AccessManage),
             ),
-            ("api_access_connect_config", Residue, Some(Op::AccessManage)),
+            ("api_access_connect_config", Row, Some(Op::AccessManage)),
             (
                 "api_access_connect_unclaim",
-                Residue,
+                Row,
                 Some(Op::AccessManage),
             ),
-            ("api_access_set_tier", Residue, Some(Op::AccessManage)),
+            ("api_access_set_tier", Row, Some(Op::AccessManage)),
             (
                 "api_access_set_hosted_ceiling",
-                Residue,
+                Row,
                 Some(Op::AccessManage),
             ),
             ("api_fleet_cert_request", Residue, Some(Op::AccessManage)),

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -1208,7 +1208,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::AccessEnrollmentRequests,
         "Pending enrollment requests",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_enrollment_requests")),
     fleet_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/access/iam/state"),
@@ -1216,7 +1217,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::AccessIamState,
         "Local IAM state (roles, grants, bindings)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_iam_state")),
     fleet_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/access/overview"),
@@ -1224,7 +1226,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::AccessOverview,
         "Access overview for the calling principal",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_overview")),
     // ── Connect rendezvous administration. Status is inspect-grade but
     //    never carries the claim phrase; the phrase reveal is its own
     //    manage-gated route so the one secret-bearing response has the
@@ -1236,7 +1239,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::AccessConnectStatus,
         "Connect rendezvous status (claim state, binding provenance; no claim phrase)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_connect_status")),
     fleet_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/access/connect/claim-code"),
@@ -1244,7 +1248,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::AccessConnectClaimCode,
         "Reveal the current twelve-word claim phrase (unclaimed daemons only)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_connect_claim_code")),
     fleet_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/access/connect/config"),
@@ -1252,7 +1257,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::AccessConnectConfig,
         "Enable/disable the Connect client (persists to intendant.toml, applies live)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_connect_config")),
     fleet_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/access/connect/unclaim"),
@@ -1260,7 +1266,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::AccessConnectUnclaim,
         "Release this daemon's claim binding at the rendezvous (daemon-signed)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_connect_unclaim")),
     fleet_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/access/tier"),
@@ -1268,7 +1275,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::AccessTierSettings,
         "Set this daemon's trust tier label (integrated/disposable; null clears)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_set_tier")),
     fleet_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/access/hosted-ceiling"),
@@ -1276,7 +1284,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::AccessTierSettings,
         "Set the hosted-control ceiling role for hosted-provenance sessions",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_set_hosted_ceiling")),
     op_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/dashboard/targets"),
@@ -1284,7 +1293,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::DashboardTargets,
         "Dashboard target list (this daemon + connected peers)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_dashboard_targets")),
     // ── Federation surface: registry, pairing, quick controls,
     //    capability routing. The peers sub-router keeps its method-`Any`
     //    catch-all row on purpose: IAM already classifies per leaf through

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -857,20 +857,37 @@ pub(crate) async fn serve_http_request(
                 .await;
             }
             RouteHandlerId::AccessEnrollmentRequests => {
-                return handle_access_enrollment_requests(stream, cert_dir, fleet_cors_origin)
-                    .await;
+                return handle_access_enrollment_requests(
+                    stream,
+                    cert_dir,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::AccessIamState => {
-                return handle_access_iam_state(stream, cert_dir, fleet_cors_origin).await;
+                return handle_access_iam_state(
+                    stream,
+                    cert_dir,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::AccessConnectStatus => {
-                return handle_access_connect_status(stream, fleet_cors_origin).await;
+                return handle_access_connect_status(
+                    stream,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::AccessConnectClaimCode => {
                 return handle_access_connect_claim_code(
                     stream,
                     http_access_context,
-                    fleet_cors_origin,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
                 )
                 .await;
             }
@@ -878,20 +895,20 @@ pub(crate) async fn serve_http_request(
                 return handle_access_connect_config(
                     stream,
                     route_body,
-                    req_method,
                     http_access_context,
                     project_root,
-                    fleet_cors_origin,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
                 )
                 .await;
             }
             RouteHandlerId::AccessConnectUnclaim => {
                 return handle_access_connect_unclaim(
                     stream,
-                    req_method,
                     http_access_context,
                     project_root,
-                    fleet_cors_origin,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
                 )
                 .await;
             }
@@ -899,11 +916,11 @@ pub(crate) async fn serve_http_request(
                 return handle_access_tier_settings(
                     stream,
                     route_body,
-                    req_method,
                     req_path,
                     cert_dir,
                     http_access_context,
-                    fleet_cors_origin,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
                 )
                 .await;
             }
@@ -912,9 +929,10 @@ pub(crate) async fn serve_http_request(
                     stream,
                     cert_dir,
                     http_access_context,
-                    fleet_cors_origin,
                     peer_registry,
                     agent_card_value_for_targets,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
                 )
                 .await;
             }
@@ -923,6 +941,8 @@ pub(crate) async fn serve_http_request(
                     stream,
                     peer_registry,
                     agent_card_value_for_targets,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
                 )
                 .await;
             }

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -857,10 +857,11 @@ pub(crate) async fn serve_http_request(
                 .await;
             }
             RouteHandlerId::AccessEnrollmentRequests => {
-                return handle_access_enrollment_requests(stream, fleet_cors_origin).await;
+                return handle_access_enrollment_requests(stream, cert_dir, fleet_cors_origin)
+                    .await;
             }
             RouteHandlerId::AccessIamState => {
-                return handle_access_iam_state(stream, fleet_cors_origin).await;
+                return handle_access_iam_state(stream, cert_dir, fleet_cors_origin).await;
             }
             RouteHandlerId::AccessConnectStatus => {
                 return handle_access_connect_status(stream, fleet_cors_origin).await;
@@ -900,6 +901,7 @@ pub(crate) async fn serve_http_request(
                     route_body,
                     req_method,
                     req_path,
+                    cert_dir,
                     http_access_context,
                     fleet_cors_origin,
                 )
@@ -908,6 +910,7 @@ pub(crate) async fn serve_http_request(
             RouteHandlerId::AccessOverview => {
                 return handle_access_overview(
                     stream,
+                    cert_dir,
                     http_access_context,
                     fleet_cors_origin,
                     peer_registry,

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -162,16 +162,15 @@ pub(crate) fn access_overview_inbound_peer_identities(
 }
 
 pub(crate) async fn handle_dashboard_targets(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     peer_registry: Option<crate::peer::PeerRegistry>,
     agent_card_value_for_targets: serde_json::Value,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
-    let body =
-        dashboard_targets_response_body(&agent_card_value_for_targets, peer_registry.as_ref());
-    let response = json_response("200 OK", body);
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    let response =
+        dashboard_targets_api_response(&agent_card_value_for_targets, peer_registry.as_ref());
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_access_org_grant_present(
@@ -406,27 +405,23 @@ pub(crate) async fn handle_access_enrollment_decide(
 }
 
 pub(crate) async fn handle_access_enrollment_requests(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     cert_dir: std::path::PathBuf,
-    fleet_cors_origin: Option<String>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
-    let body = access_enrollment_requests_response_body(&cert_dir);
-    let response = with_fleet_cors(json_response("200 OK", body), fleet_cors_origin.as_deref());
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    let response = access_enrollment_requests_api_response(&cert_dir);
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_access_iam_state(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     cert_dir: std::path::PathBuf,
-    fleet_cors_origin: Option<String>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
-    let body = access_iam_state_response_body(&cert_dir);
-    let response = with_fleet_cors(json_response("200 OK", body), fleet_cors_origin.as_deref());
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    let response = access_iam_state_api_response(&cert_dir);
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 /// Connect status for the Access card — inspect-grade. Everything EXCEPT
@@ -479,14 +474,11 @@ pub(crate) fn access_connect_status_response_value() -> serde_json::Value {
 }
 
 pub(crate) async fn handle_access_connect_status(
-    mut stream: DemuxStream,
-    fleet_cors_origin: Option<String>,
+    stream: DemuxStream,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
-    let body = access_connect_status_response_value().to_string();
-    let response = with_fleet_cors(json_response("200 OK", body), fleet_cors_origin.as_deref());
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    write_api_response(stream, access_connect_status_api_response(), cors, fleet_origin).await;
 }
 
 pub(crate) fn access_connect_claim_code_response_value() -> serde_json::Value {
@@ -501,36 +493,36 @@ pub(crate) fn access_connect_claim_code_response_value() -> serde_json::Value {
 }
 
 pub(crate) async fn handle_access_connect_claim_code(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     http_access_context: HttpAccessContext,
-    fleet_cors_origin: Option<String>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
     // Belt and suspenders on the one secret-bearing response: the
     // pre-dispatch gate already enforced AccessManage from the route
     // row; re-verify so a dispatch refactor can't quietly downgrade the
-    // claim phrase to inspect-grade.
+    // claim phrase to inspect-grade. The denial keeps its historical
+    // PLAIN tail (own-origin render, no fleet echo).
     let decision =
         http_access_context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
     if !decision.allowed {
-        let response = json_response(
-            "403 Forbidden",
-            serde_json::json!({
-                "error": "principal does not allow this operation",
-                "principal": http_access_context.principal.as_value(),
-                "permission": decision.permission,
-                "reason": decision.reason,
-            })
-            .to_string(),
-        );
-        let _ = stream.write_all(response.as_bytes()).await;
-    } else {
-        let body = access_connect_claim_code_response_value().to_string();
-        let response =
-            with_fleet_cors(json_response("200 OK", body), fleet_cors_origin.as_deref());
-        let _ = stream.write_all(response.as_bytes()).await;
+        let response = access_manage_denied_api_response(&http_access_context, decision);
+        write_api_response(
+            stream,
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        )
+        .await;
+        return;
     }
-    finalize_http_stream(&mut stream).await;
+    write_api_response(
+        stream,
+        access_connect_claim_code_api_response(),
+        cors,
+        fleet_origin,
+    )
+    .await;
 }
 
 /// Enable/disable the Connect client: persist `[connect]` to the
@@ -583,96 +575,59 @@ fn access_connect_config_response_value_in(
 }
 
 pub(crate) async fn handle_access_connect_config(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     body_text: String,
-    req_method: &str,
     http_access_context: HttpAccessContext,
     project_root: Option<std::path::PathBuf>,
-    fleet_cors_origin: Option<String>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
-    if req_method != "POST" {
-        let response = json_response(
-            "405 Method Not Allowed",
-            serde_json::json!({"error": "method not allowed"}).to_string(),
-        );
-        let _ = stream.write_all(response.as_bytes()).await;
-    } else {
-        let decision =
-            http_access_context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
-        if !decision.allowed {
-            let response = json_response(
-                "403 Forbidden",
-                serde_json::json!({
-                    "error": "principal does not allow this operation",
-                    "principal": http_access_context.principal.as_value(),
-                    "permission": decision.permission,
-                    "reason": decision.reason,
-                })
-                .to_string(),
-            );
-            let _ = stream.write_all(response.as_bytes()).await;
-        } else {
-            let (status, body) = match serde_json::from_str::<serde_json::Value>(&body_text)
-                .map_err(|e| format!("invalid request body: {e}"))
-                .and_then(|params| {
-                    access_connect_config_response_value(params, project_root.as_deref())
-                }) {
-                Ok(value) => (200, value.to_string()),
-                Err(error) => (400, serde_json::json!({"error": error}).to_string()),
-            };
-            let response = with_fleet_cors(
-                json_response(status_reason(status), body),
-                fleet_cors_origin.as_deref(),
-            );
-            let _ = stream.write_all(response.as_bytes()).await;
-        }
+    // Belt-and-suspenders manage re-check (see the claim-code shim).
+    let decision =
+        http_access_context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
+    if !decision.allowed {
+        let response = access_manage_denied_api_response(&http_access_context, decision);
+        write_api_response(
+            stream,
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        )
+        .await;
+        return;
     }
-    finalize_http_stream(&mut stream).await;
+    // Transport-owned body decode; this endpoint's parse-error 400
+    // historically rides the fleet tail like its value errors.
+    let response = match serde_json::from_str::<serde_json::Value>(&body_text) {
+        Ok(params) => access_connect_config_api_response(params, project_root.as_deref()),
+        Err(e) => ApiResponse::json_error(400, format!("invalid request body: {e}")),
+    };
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_access_connect_unclaim(
-    mut stream: DemuxStream,
-    req_method: &str,
+    stream: DemuxStream,
     http_access_context: HttpAccessContext,
     project_root: Option<std::path::PathBuf>,
-    fleet_cors_origin: Option<String>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
-    if req_method != "POST" {
-        let response = json_response(
-            "405 Method Not Allowed",
-            serde_json::json!({"error": "method not allowed"}).to_string(),
-        );
-        let _ = stream.write_all(response.as_bytes()).await;
-    } else {
-        let decision =
-            http_access_context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
-        if !decision.allowed {
-            let response = json_response(
-                "403 Forbidden",
-                serde_json::json!({
-                    "error": "principal does not allow this operation",
-                    "principal": http_access_context.principal.as_value(),
-                    "permission": decision.permission,
-                    "reason": decision.reason,
-                })
-                .to_string(),
-            );
-            let _ = stream.write_all(response.as_bytes()).await;
-        } else {
-            let (status, body) = match access_connect_unclaim_response_value(project_root).await {
-                Ok(value) => (200, value.to_string()),
-                Err(error) => (400, serde_json::json!({"error": error}).to_string()),
-            };
-            let response = with_fleet_cors(
-                json_response(status_reason(status), body),
-                fleet_cors_origin.as_deref(),
-            );
-            let _ = stream.write_all(response.as_bytes()).await;
-        }
+    // Belt-and-suspenders manage re-check (see the claim-code shim).
+    let decision =
+        http_access_context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
+    if !decision.allowed {
+        let response = access_manage_denied_api_response(&http_access_context, decision);
+        write_api_response(
+            stream,
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        )
+        .await;
+        return;
     }
-    finalize_http_stream(&mut stream).await;
+    let response = access_connect_unclaim_api_response(project_root).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 /// Shared by the HTTP route and the dashboard-control method: resolve the
@@ -696,24 +651,162 @@ pub(crate) async fn access_connect_unclaim_response_value(
     }))
 }
 
+// ── Transport-neutral cores (transport-unification design §2.1, S6):
+//    the access inspect/connect/tier family. Each fn is the single
+//    response builder both lanes render — the HTTP shims hand them to
+//    `write_api_response` under the row's CORS posture; the tunnel twins
+//    frame them through the ok/error dispatch adapter. Store paths
+//    arrive from the transport edges (hermeticity convention).
+
+/// The family's shared `Result` framing: `Ok` bodies answer 200, `Err`
+/// strings answer `error_status` as the historical `{"error": …}` body.
+fn access_result_api_response(
+    result: Result<serde_json::Value, String>,
+    error_status: u16,
+) -> ApiResponse {
+    match result {
+        Ok(value) => ApiResponse::json(200, JsonBody::PreSerialized(value.to_string())),
+        Err(error) => ApiResponse::json_error(error_status, error),
+    }
+}
+
+/// The in-handler manage re-check's 403 (belt and suspenders under the
+/// pre-dispatch row gate; kept so a dispatch refactor cannot quietly
+/// downgrade these writes). Historically written under the PLAIN
+/// canonical tail — no fleet decoration even for an allowlisted origin —
+/// so the shims render it with an own-origin posture on purpose.
+pub(crate) fn access_manage_denied_api_response(
+    context: &HttpAccessContext,
+    decision: crate::access::iam::AccessDecision,
+) -> ApiResponse {
+    ApiResponse::json(
+        403,
+        JsonBody::Value(serde_json::json!({
+            "error": "principal does not allow this operation",
+            "principal": context.principal.as_value(),
+            "permission": decision.permission,
+            "reason": decision.reason,
+        })),
+    )
+}
+
+/// GET /api/dashboard/targets + the tunnel's `api_dashboard_targets`.
+pub(crate) fn dashboard_targets_api_response(
+    agent_card: &serde_json::Value,
+    registry: Option<&crate::peer::PeerRegistry>,
+) -> ApiResponse {
+    ApiResponse::json(
+        200,
+        JsonBody::PreSerialized(dashboard_targets_response_body(agent_card, registry)),
+    )
+}
+
+/// GET /api/access/overview + the tunnel's `api_access_overview`.
+pub(crate) fn access_overview_api_response(
+    cert_dir: &std::path::Path,
+    agent_card: &serde_json::Value,
+    registry: Option<&crate::peer::PeerRegistry>,
+    current_principal: &crate::access::iam::AccessPrincipal,
+) -> ApiResponse {
+    ApiResponse::json(
+        200,
+        JsonBody::PreSerialized(access_overview_response_body_for_principal(
+            cert_dir,
+            agent_card,
+            registry,
+            current_principal,
+        )),
+    )
+}
+
+/// GET /api/access/iam/state + the tunnel's `api_access_iam_state`.
+pub(crate) fn access_iam_state_api_response(cert_dir: &std::path::Path) -> ApiResponse {
+    ApiResponse::json(
+        200,
+        JsonBody::PreSerialized(access_iam_state_response_body(cert_dir)),
+    )
+}
+
+/// GET /api/access/enrollment-requests + the tunnel's
+/// `api_access_enrollment_requests`.
+pub(crate) fn access_enrollment_requests_api_response(
+    cert_dir: &std::path::Path,
+) -> ApiResponse {
+    ApiResponse::json(
+        200,
+        JsonBody::PreSerialized(access_enrollment_requests_response_body(cert_dir)),
+    )
+}
+
+/// GET /api/access/connect/status + the tunnel's
+/// `api_access_connect_status`.
+pub(crate) fn access_connect_status_api_response() -> ApiResponse {
+    ApiResponse::json(
+        200,
+        JsonBody::PreSerialized(access_connect_status_response_value().to_string()),
+    )
+}
+
+/// GET /api/access/connect/claim-code + the tunnel's
+/// `api_access_connect_claim_code` (the manage gate stays at each
+/// transport's edge: the row/method op plus the HTTP shim's re-check).
+pub(crate) fn access_connect_claim_code_api_response() -> ApiResponse {
+    ApiResponse::json(
+        200,
+        JsonBody::PreSerialized(access_connect_claim_code_response_value().to_string()),
+    )
+}
+
+/// POST /api/access/connect/config + the tunnel's
+/// `api_access_connect_config`. `params` is the canonical structured
+/// shape (design §2.1) — the HTTP shim owns the body parse.
+pub(crate) fn access_connect_config_api_response(
+    params: serde_json::Value,
+    project_root: Option<&std::path::Path>,
+) -> ApiResponse {
+    access_result_api_response(access_connect_config_response_value(params, project_root), 400)
+}
+
+/// POST /api/access/connect/unclaim + the tunnel's
+/// `api_access_connect_unclaim`.
+pub(crate) async fn access_connect_unclaim_api_response(
+    project_root: Option<std::path::PathBuf>,
+) -> ApiResponse {
+    access_result_api_response(access_connect_unclaim_response_value(project_root).await, 400)
+}
+
+/// POST /api/access/tier | /api/access/hosted-ceiling + the tunnel's
+/// `api_access_set_tier` / `api_access_set_hosted_ceiling`.
+pub(crate) fn access_tier_settings_api_response(
+    cert_dir: &std::path::Path,
+    hosted_ceiling: bool,
+    params: serde_json::Value,
+    actor: &crate::access::iam::AccessPrincipal,
+) -> ApiResponse {
+    let result = if hosted_ceiling {
+        access_set_hosted_ceiling_response_value(cert_dir, params, actor)
+    } else {
+        access_set_tier_response_value(cert_dir, params, actor)
+    };
+    access_result_api_response(result, 400)
+}
+
 pub(crate) async fn handle_access_overview(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     cert_dir: std::path::PathBuf,
     http_access_context: HttpAccessContext,
-    fleet_cors_origin: Option<String>,
     peer_registry: Option<crate::peer::PeerRegistry>,
     agent_card_value_for_targets: serde_json::Value,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
-    let body = access_overview_response_body_for_principal(
+    let response = access_overview_api_response(
         &cert_dir,
         &agent_card_value_for_targets,
         peer_registry.as_ref(),
         &http_access_context.principal,
     );
-    let response = with_fleet_cors(json_response("200 OK", body), fleet_cors_origin.as_deref());
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 #[cfg(test)]
@@ -1292,75 +1385,56 @@ pub(crate) fn access_set_hosted_ceiling_response_value(
 /// One handler for the trust-tier settings pair; `req_path` picks the
 /// mutation. Both are manage-gated POSTs mirroring the IAM grant writes.
 pub(crate) async fn handle_access_tier_settings(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     body_text: String,
-    req_method: &str,
     req_path: &str,
     cert_dir: std::path::PathBuf,
     http_access_context: HttpAccessContext,
-    fleet_cors_origin: Option<String>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
-    if req_method != "POST" {
-        let response = json_response(
-            "405 Method Not Allowed",
-            serde_json::json!({"error": "method not allowed"}).to_string(),
-        );
-        let _ = stream.write_all(response.as_bytes()).await;
-    } else {
-        let decision =
-            http_access_context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
-        if !decision.allowed {
-            let response = json_response(
-                "403 Forbidden",
-                serde_json::json!({
-                    "error": "principal does not allow this operation",
-                    "principal": http_access_context.principal.as_value(),
-                    "permission": decision.permission,
-                    "reason": decision.reason,
-                })
-                .to_string(),
-            );
-            let _ = stream.write_all(response.as_bytes()).await;
-        } else {
-            let params: serde_json::Value = if body_text.trim().is_empty() {
-                serde_json::json!({})
-            } else {
-                match serde_json::from_str(&body_text) {
-                    Ok(value) => value,
-                    Err(e) => {
-                        let response = json_response(
-                            "400 Bad Request",
-                            serde_json::json!({"error": format!("invalid request body: {e}")})
-                                .to_string(),
-                        );
-                        let _ = stream.write_all(response.as_bytes()).await;
-                        finalize_http_stream(&mut stream).await;
-                        return;
-                    }
-                }
-            };
-            let result = if req_path == "/api/access/hosted-ceiling" {
-                access_set_hosted_ceiling_response_value(
-                    &cert_dir,
-                    params,
-                    &http_access_context.principal,
-                )
-            } else {
-                access_set_tier_response_value(&cert_dir, params, &http_access_context.principal)
-            };
-            let (status, body) = match result {
-                Ok(value) => (200, value.to_string()),
-                Err(error) => (400, serde_json::json!({"error": error}).to_string()),
-            };
-            let response = with_fleet_cors(
-                json_response(status_reason(status), body),
-                fleet_cors_origin.as_deref(),
-            );
-            let _ = stream.write_all(response.as_bytes()).await;
-        }
+    // Belt-and-suspenders manage re-check (see the claim-code shim).
+    let decision =
+        http_access_context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
+    if !decision.allowed {
+        let response = access_manage_denied_api_response(&http_access_context, decision);
+        write_api_response(
+            stream,
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        )
+        .await;
+        return;
     }
-    finalize_http_stream(&mut stream).await;
+    // Transport-owned body decode: an empty body reads as `{}`, and the
+    // parse-error 400 keeps its historical PLAIN tail (own-origin
+    // render, no fleet echo) unlike this pair's fleet-decorated value
+    // errors.
+    let params: serde_json::Value = if body_text.trim().is_empty() {
+        serde_json::json!({})
+    } else {
+        match serde_json::from_str(&body_text) {
+            Ok(value) => value,
+            Err(e) => {
+                write_api_response(
+                    stream,
+                    ApiResponse::json_error(400, format!("invalid request body: {e}")),
+                    crate::gateway_routes::CorsPosture::OwnOrigin,
+                    None,
+                )
+                .await;
+                return;
+            }
+        }
+    };
+    let response = access_tier_settings_api_response(
+        &cert_dir,
+        req_path == "/api/access/hosted-ceiling",
+        params,
+        &http_access_context.principal,
+    );
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 /// The Access API paths that participate in fleet cross-origin access: the
@@ -3308,22 +3382,20 @@ mod tests {
         )
     }
 
-    /// Pin a route's declared CORS posture alongside its byte pins so a
-    /// row-posture change fails these tests instead of silently changing
-    /// the wire.
-    fn assert_access_route_posture(
+    /// The CORS posture dispatch hands the shim — read from the route
+    /// table AND asserted, so a row-posture change fails these byte pins
+    /// instead of silently changing the wire.
+    fn access_route_cors(
         method: &str,
         path: &str,
-        posture: crate::gateway_routes::CorsPosture,
-    ) {
-        assert_eq!(
-            crate::gateway_routes::match_route(method, path)
-                .expect("access route declared")
-                .0
-                .cors,
-            posture,
-            "{method} {path}"
-        );
+        expected: crate::gateway_routes::CorsPosture,
+    ) -> crate::gateway_routes::CorsPosture {
+        let cors = crate::gateway_routes::match_route(method, path)
+            .expect("access route declared")
+            .0
+            .cors;
+        assert_eq!(cors, expected, "{method} {path}");
+        cors
     }
 
     const GOLDEN_FLEET_ORIGIN: &str = "https://fleet-anchor.example:8765";
@@ -3335,7 +3407,7 @@ mod tests {
 
     #[tokio::test]
     async fn golden_dashboard_targets_transcript() {
-        assert_access_route_posture(
+        let cors = access_route_cors(
             "GET",
             "/api/dashboard/targets",
             crate::gateway_routes::CorsPosture::OwnOrigin,
@@ -3345,7 +3417,7 @@ mod tests {
         let card = serde_json::json!({});
         let body = dashboard_targets_response_body(&card, None);
         let response = collect_access_handler_response(|stream| {
-            handle_dashboard_targets(stream, None, card.clone())
+            handle_dashboard_targets(stream, None, card.clone(), cors, None)
         })
         .await;
         assert_eq!(
@@ -3363,7 +3435,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let cert_dir = tmp.path().to_path_buf();
 
-        assert_access_route_posture(
+        let cors = access_route_cors(
             "GET",
             "/api/access/iam/state",
             crate::gateway_routes::CorsPosture::FleetAllowlist,
@@ -3372,7 +3444,7 @@ mod tests {
         for origin in [None, Some(GOLDEN_FLEET_ORIGIN)] {
             let dir = cert_dir.clone();
             let response = collect_access_handler_response(|stream| {
-                handle_access_iam_state(stream, dir, origin.map(str::to_string))
+                handle_access_iam_state(stream, dir, cors, origin)
             })
             .await;
             assert_eq!(
@@ -3381,7 +3453,7 @@ mod tests {
             );
         }
 
-        assert_access_route_posture(
+        let cors = access_route_cors(
             "GET",
             "/api/access/enrollment-requests",
             crate::gateway_routes::CorsPosture::FleetAllowlist,
@@ -3390,7 +3462,7 @@ mod tests {
         for origin in [None, Some(GOLDEN_FLEET_ORIGIN)] {
             let dir = cert_dir.clone();
             let response = collect_access_handler_response(|stream| {
-                handle_access_enrollment_requests(stream, dir, origin.map(str::to_string))
+                handle_access_enrollment_requests(stream, dir, cors, origin)
             })
             .await;
             assert_eq!(
@@ -3399,7 +3471,7 @@ mod tests {
             );
         }
 
-        assert_access_route_posture(
+        let cors = access_route_cors(
             "GET",
             "/api/access/overview",
             crate::gateway_routes::CorsPosture::FleetAllowlist,
@@ -3419,14 +3491,7 @@ mod tests {
                 iam_state: None,
             };
             let response = collect_access_handler_response(|stream| {
-                handle_access_overview(
-                    stream,
-                    dir,
-                    context,
-                    origin.map(str::to_string),
-                    None,
-                    card,
-                )
+                handle_access_overview(stream, dir, context, None, card, cors, origin)
             })
             .await;
             assert_eq!(
@@ -3442,14 +3507,14 @@ mod tests {
         // fleet cert, hosted-bundle tripwire), so the FRAMING is the pin:
         // head hand-written around the served body's length, body sanity-
         // checked through the schema marker.
-        assert_access_route_posture(
+        let cors = access_route_cors(
             "GET",
             "/api/access/connect/status",
             crate::gateway_routes::CorsPosture::FleetAllowlist,
         );
         for origin in [None, Some(GOLDEN_FLEET_ORIGIN)] {
             let response = collect_access_handler_response(|stream| {
-                handle_access_connect_status(stream, origin.map(str::to_string))
+                handle_access_connect_status(stream, cors, origin)
             })
             .await;
             let text = golden_access_transcript(&response);
@@ -3505,7 +3570,7 @@ mod tests {
 
     #[tokio::test]
     async fn golden_access_connect_claim_code_transcripts() {
-        assert_access_route_posture(
+        let cors = access_route_cors(
             "GET",
             "/api/access/connect/claim-code",
             crate::gateway_routes::CorsPosture::FleetAllowlist,
@@ -3520,7 +3585,7 @@ mod tests {
                 iam_state: None,
             };
             let response = collect_access_handler_response(|stream| {
-                handle_access_connect_claim_code(stream, context, origin.map(str::to_string))
+                handle_access_connect_claim_code(stream, context, cors, origin)
             })
             .await;
             let text = golden_access_transcript(&response);
@@ -3540,11 +3605,7 @@ mod tests {
         let context = golden_denied_manage_context(tmp.path());
         let body = golden_denied_manage_body(&context);
         let response = collect_access_handler_response(|stream| {
-            handle_access_connect_claim_code(
-                stream,
-                context,
-                Some(GOLDEN_FLEET_ORIGIN.to_string()),
-            )
+            handle_access_connect_claim_code(stream, context, cors, Some(GOLDEN_FLEET_ORIGIN))
         })
         .await;
         assert_eq!(
@@ -3555,7 +3616,7 @@ mod tests {
 
     #[tokio::test]
     async fn golden_access_connect_config_transcripts() {
-        assert_access_route_posture(
+        let cors = access_route_cors(
             "POST",
             "/api/access/connect/config",
             crate::gateway_routes::CorsPosture::FleetAllowlist,
@@ -3578,10 +3639,10 @@ mod tests {
             handle_access_connect_config(
                 stream,
                 invalid.to_string(),
-                "POST",
                 root_context(),
                 None,
-                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+                cors,
+                Some(GOLDEN_FLEET_ORIGIN),
             )
         })
         .await;
@@ -3599,9 +3660,9 @@ mod tests {
             handle_access_connect_config(
                 stream,
                 "{}".to_string(),
-                "POST",
                 root_context(),
                 None,
+                cors,
                 None,
             )
         })
@@ -3624,10 +3685,10 @@ mod tests {
             handle_access_connect_config(
                 stream,
                 r#"{"enabled":false}"#.to_string(),
-                "POST",
                 root_context(),
                 Some(root.clone()),
-                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+                cors,
+                Some(GOLDEN_FLEET_ORIGIN),
             )
         })
         .await;
@@ -3644,7 +3705,7 @@ mod tests {
 
     #[tokio::test]
     async fn golden_access_connect_unclaim_transcript() {
-        assert_access_route_posture(
+        let cors = access_route_cors(
             "POST",
             "/api/access/connect/unclaim",
             crate::gateway_routes::CorsPosture::FleetAllowlist,
@@ -3663,13 +3724,7 @@ mod tests {
             };
             let root = dir.path().to_path_buf();
             let response = collect_access_handler_response(|stream| {
-                handle_access_connect_unclaim(
-                    stream,
-                    "POST",
-                    context,
-                    Some(root),
-                    origin.map(str::to_string),
-                )
+                handle_access_connect_unclaim(stream, context, Some(root), cors, origin)
             })
             .await;
             assert_eq!(
@@ -3685,12 +3740,12 @@ mod tests {
 
     #[tokio::test]
     async fn golden_access_tier_transcripts() {
-        assert_access_route_posture(
+        let cors = access_route_cors(
             "POST",
             "/api/access/tier",
             crate::gateway_routes::CorsPosture::FleetAllowlist,
         );
-        assert_access_route_posture(
+        let ceiling_cors = access_route_cors(
             "POST",
             "/api/access/hosted-ceiling",
             crate::gateway_routes::CorsPosture::FleetAllowlist,
@@ -3709,11 +3764,11 @@ mod tests {
             handle_access_tier_settings(
                 stream,
                 r#"{"tier":123}"#.to_string(),
-                "POST",
                 "/api/access/tier",
                 cert_dir.clone(),
                 root_context(),
-                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+                cors,
+                Some(GOLDEN_FLEET_ORIGIN),
             )
         })
         .await;
@@ -3738,11 +3793,11 @@ mod tests {
             handle_access_tier_settings(
                 stream,
                 invalid.to_string(),
-                "POST",
                 "/api/access/tier",
                 cert_dir.clone(),
                 root_context(),
-                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+                cors,
+                Some(GOLDEN_FLEET_ORIGIN),
             )
         })
         .await;
@@ -3758,11 +3813,11 @@ mod tests {
             handle_access_tier_settings(
                 stream,
                 String::new(),
-                "POST",
                 "/api/access/tier",
                 cert_dir.clone(),
                 root_context(),
-                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+                cors,
+                Some(GOLDEN_FLEET_ORIGIN),
             )
         })
         .await;
@@ -3781,10 +3836,10 @@ mod tests {
             handle_access_tier_settings(
                 stream,
                 "{}".to_string(),
-                "POST",
                 "/api/access/hosted-ceiling",
                 cert_dir.clone(),
                 root_context(),
+                ceiling_cors,
                 None,
             )
         })

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -128,14 +128,18 @@ pub(crate) fn dashboard_targets_response_body(
 /// gives every dashboard route the same vocabulary - principals, targets,
 /// grants, policies, and transports - while the existing mTLS, Connect, and
 /// peer-profile paths continue to enforce their current rules.
+/// `cert_dir` arrives from the transport edges (the identity and IAM
+/// stores are read under it), so tests inject a tempdir instead of
+/// reading the live account's stores (the CLAUDE.md tests-are-hermetic
+/// convention).
 pub(crate) fn access_overview_response_value_for_principal(
+    cert_dir: &std::path::Path,
     agent_card: &serde_json::Value,
     registry: Option<&crate::peer::PeerRegistry>,
     current_principal: Option<&crate::access::iam::AccessPrincipal>,
 ) -> serde_json::Value {
-    let inbound_peer_identities = access_overview_inbound_peer_identities();
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    let iam_state = crate::access::iam::load_state_for_overview(&cert_dir);
+    let inbound_peer_identities = access_overview_inbound_peer_identities(cert_dir);
+    let iam_state = crate::access::iam::load_state_for_overview(cert_dir);
     access_overview_response_value_with_identities_and_iam(
         agent_card,
         registry,
@@ -146,9 +150,9 @@ pub(crate) fn access_overview_response_value_for_principal(
 }
 
 pub(crate) fn access_overview_inbound_peer_identities(
+    cert_dir: &std::path::Path,
 ) -> Vec<crate::peer::access_policy::PeerIdentityRecord> {
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    match crate::peer::access_policy::list_identities(&cert_dir) {
+    match crate::peer::access_policy::list_identities(cert_dir) {
         Ok(records) => records,
         Err(e) => {
             eprintln!("intendant: failed to list inbound peer identities for access overview: {e}");
@@ -403,10 +407,11 @@ pub(crate) async fn handle_access_enrollment_decide(
 
 pub(crate) async fn handle_access_enrollment_requests(
     mut stream: DemuxStream,
+    cert_dir: std::path::PathBuf,
     fleet_cors_origin: Option<String>,
 ) {
     use tokio::io::AsyncWriteExt;
-    let body = access_enrollment_requests_response_body();
+    let body = access_enrollment_requests_response_body(&cert_dir);
     let response = with_fleet_cors(json_response("200 OK", body), fleet_cors_origin.as_deref());
     let _ = stream.write_all(response.as_bytes()).await;
     finalize_http_stream(&mut stream).await;
@@ -414,10 +419,11 @@ pub(crate) async fn handle_access_enrollment_requests(
 
 pub(crate) async fn handle_access_iam_state(
     mut stream: DemuxStream,
+    cert_dir: std::path::PathBuf,
     fleet_cors_origin: Option<String>,
 ) {
     use tokio::io::AsyncWriteExt;
-    let body = access_iam_state_response_body();
+    let body = access_iam_state_response_body(&cert_dir);
     let response = with_fleet_cors(json_response("200 OK", body), fleet_cors_origin.as_deref());
     let _ = stream.write_all(response.as_bytes()).await;
     finalize_http_stream(&mut stream).await;
@@ -692,6 +698,7 @@ pub(crate) async fn access_connect_unclaim_response_value(
 
 pub(crate) async fn handle_access_overview(
     mut stream: DemuxStream,
+    cert_dir: std::path::PathBuf,
     http_access_context: HttpAccessContext,
     fleet_cors_origin: Option<String>,
     peer_registry: Option<crate::peer::PeerRegistry>,
@@ -699,6 +706,7 @@ pub(crate) async fn handle_access_overview(
 ) {
     use tokio::io::AsyncWriteExt;
     let body = access_overview_response_body_for_principal(
+        &cert_dir,
         &agent_card_value_for_targets,
         peer_registry.as_ref(),
         &http_access_context.principal,
@@ -1161,17 +1169,23 @@ pub(crate) fn current_access_overview_transport(
 }
 
 pub(crate) fn access_overview_response_body_for_principal(
+    cert_dir: &std::path::Path,
     agent_card: &serde_json::Value,
     registry: Option<&crate::peer::PeerRegistry>,
     current_principal: &crate::access::iam::AccessPrincipal,
 ) -> String {
-    access_overview_response_value_for_principal(agent_card, registry, Some(current_principal))
-        .to_string()
+    access_overview_response_value_for_principal(
+        cert_dir,
+        agent_card,
+        registry,
+        Some(current_principal),
+    )
+    .to_string()
 }
 
-pub(crate) fn access_iam_state_response_value() -> serde_json::Value {
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    let iam_state = crate::access::iam::load_state_for_overview(&cert_dir);
+/// `cert_dir` arrives from the transport edges (hermeticity convention).
+pub(crate) fn access_iam_state_response_value(cert_dir: &std::path::Path) -> serde_json::Value {
+    let iam_state = crate::access::iam::load_state_for_overview(cert_dir);
     serde_json::json!({
         "schema_version": 1,
         "iam": crate::access::iam::overview_metadata(&iam_state),
@@ -1179,8 +1193,8 @@ pub(crate) fn access_iam_state_response_value() -> serde_json::Value {
     })
 }
 
-pub(crate) fn access_iam_state_response_body() -> String {
-    access_iam_state_response_value().to_string()
+pub(crate) fn access_iam_state_response_body(cert_dir: &std::path::Path) -> String {
+    access_iam_state_response_value(cert_dir).to_string()
 }
 
 pub(crate) fn access_iam_upsert_user_client_grant_response_value(
@@ -1218,8 +1232,11 @@ pub(crate) fn access_iam_upsert_user_client_grant_response_value_with_cert_dir(
 
 /// Set (or clear) this daemon's trust tier (docs/src/trust-tiers.md):
 /// `{"tier": "integrated" | "disposable" | null}`. Shared by the HTTP
-/// route and the dashboard-control method.
+/// route and the dashboard-control method. `cert_dir` arrives from the
+/// transport edges (the IAM state under it is read AND written), so
+/// tests inject a tempdir (hermeticity convention).
 pub(crate) fn access_set_tier_response_value(
+    cert_dir: &std::path::Path,
     params: serde_json::Value,
     actor: &crate::access::iam::AccessPrincipal,
 ) -> Result<serde_json::Value, String> {
@@ -1228,14 +1245,13 @@ pub(crate) fn access_set_tier_response_value(
         Some(serde_json::Value::String(value)) => Some(value.as_str()),
         Some(_) => return Err("tier must be a string or null".to_string()),
     };
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    let mut state = crate::access::iam::load_state(&cert_dir)
+    let mut state = crate::access::iam::load_state(cert_dir)
         .map_err(|e| format!("load local IAM state: {e}"))?;
     let stored =
         crate::access::iam::set_daemon_tier(&mut state, tier, actor).map_err(|e| e.to_string())?;
-    crate::access::iam::save_state(&cert_dir, &state)
+    crate::access::iam::save_state(cert_dir, &state)
         .map_err(|e| format!("save local IAM state: {e}"))?;
-    let loaded = crate::access::iam::load_state_for_overview(&cert_dir);
+    let loaded = crate::access::iam::load_state_for_overview(cert_dir);
     Ok(serde_json::json!({
         "schema_version": 1,
         "tier": stored,
@@ -1246,8 +1262,10 @@ pub(crate) fn access_set_tier_response_value(
 /// Set the hosted-control ceiling (docs/src/trust-tiers.md):
 /// `{"role_id": "role:operator" | "role:observer" | "role:none" | …}` —
 /// any defined, enforced role. Writes both hosted-provenance binding
-/// ceilings; per-binding divergence stays an `iam.json` edit.
+/// ceilings; per-binding divergence stays an `iam.json` edit. `cert_dir`
+/// arrives from the transport edges (hermeticity convention).
 pub(crate) fn access_set_hosted_ceiling_response_value(
+    cert_dir: &std::path::Path,
     params: serde_json::Value,
     actor: &crate::access::iam::AccessPrincipal,
 ) -> Result<serde_json::Value, String> {
@@ -1257,14 +1275,13 @@ pub(crate) fn access_set_hosted_ceiling_response_value(
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .ok_or_else(|| "role_id is required".to_string())?;
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    let mut state = crate::access::iam::load_state(&cert_dir)
+    let mut state = crate::access::iam::load_state(cert_dir)
         .map_err(|e| format!("load local IAM state: {e}"))?;
     crate::access::iam::set_hosted_control_ceiling(&mut state, role_id, actor)
         .map_err(|e| e.to_string())?;
-    crate::access::iam::save_state(&cert_dir, &state)
+    crate::access::iam::save_state(cert_dir, &state)
         .map_err(|e| format!("save local IAM state: {e}"))?;
-    let loaded = crate::access::iam::load_state_for_overview(&cert_dir);
+    let loaded = crate::access::iam::load_state_for_overview(cert_dir);
     Ok(serde_json::json!({
         "schema_version": 1,
         "role_ceilings": loaded.state.role_ceilings,
@@ -1279,6 +1296,7 @@ pub(crate) async fn handle_access_tier_settings(
     body_text: String,
     req_method: &str,
     req_path: &str,
+    cert_dir: std::path::PathBuf,
     http_access_context: HttpAccessContext,
     fleet_cors_origin: Option<String>,
 ) {
@@ -1323,9 +1341,13 @@ pub(crate) async fn handle_access_tier_settings(
                 }
             };
             let result = if req_path == "/api/access/hosted-ceiling" {
-                access_set_hosted_ceiling_response_value(params, &http_access_context.principal)
+                access_set_hosted_ceiling_response_value(
+                    &cert_dir,
+                    params,
+                    &http_access_context.principal,
+                )
             } else {
-                access_set_tier_response_value(params, &http_access_context.principal)
+                access_set_tier_response_value(&cert_dir, params, &http_access_context.principal)
             };
             let (status, body) = match result {
                 Ok(value) => (200, value.to_string()),
@@ -1898,12 +1920,14 @@ pub(crate) fn access_org_renew_response_value(
     }))
 }
 
-pub(crate) fn access_enrollment_requests_response_value() -> serde_json::Value {
+/// `cert_dir` arrives from the transport edges (hermeticity convention).
+pub(crate) fn access_enrollment_requests_response_value(
+    cert_dir: &std::path::Path,
+) -> serde_json::Value {
     // Route provenance is classified daemon-side (derive, don't mirror):
     // the browser gets a ready `origin_class` per request instead of
     // re-deriving hosted/fleet membership from its own copies.
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    let hosted_origins = crate::access::iam::load_state(&cert_dir)
+    let hosted_origins = crate::access::iam::load_state(cert_dir)
         .map(|state| state.hosted_origins)
         .unwrap_or_else(|_| crate::access::iam::default_hosted_origins());
     let fleet_zone = crate::fleet_cert::status_snapshot().zone;
@@ -1933,8 +1957,8 @@ pub(crate) fn access_enrollment_requests_response_value() -> serde_json::Value {
     })
 }
 
-pub(crate) fn access_enrollment_requests_response_body() -> String {
-    access_enrollment_requests_response_value().to_string()
+pub(crate) fn access_enrollment_requests_response_body(cert_dir: &std::path::Path) -> String {
+    access_enrollment_requests_response_value(cert_dir).to_string()
 }
 
 /// Approve or deny a pending browser-key enrollment. Approval reuses the
@@ -3213,5 +3237,565 @@ mod tests {
             &steer,
             &bus
         ));
+    }
+
+    // ── S6 golden transcripts: access inspect/connect/tier family ──
+    //
+    // Byte-exact pins of the access overview / IAM state / enrollment
+    // list / dashboard targets / connect admin / trust-tier HTTP
+    // responses, captured before the transport-neutral conversion
+    // (transport-unification design §6 S6, risk R1) and kept as the
+    // conversion's proof. This family's hazard is the FLEET-CORS
+    // decoration (docs/src/trust-architecture.md): the anchor-served
+    // Access page reads sibling daemons cross-origin, so every fleet pin
+    // here covers both the no-Origin shape (bare `Vary: Origin`) and the
+    // allowlisted fleet-origin shape (echoed
+    // `Access-Control-Allow-Origin` + `Vary: Origin`). The expected
+    // framing is hand-written below — never built through the response
+    // helpers under conversion. Store-backed bodies compute through the
+    // untouched builders over injected tempdir cert stores (never the
+    // live account's stores); process-global bodies (connect status /
+    // claim code) are framing-only pins, spliced around whatever the
+    // snapshot says at run time. Historical quirks pinned deliberately:
+    // the in-handler manage re-check 403 and the tier parse-error 400
+    // answer WITHOUT the fleet decoration (no echo, no Vary), and
+    // dashboard-targets answers under the bare canonical tail.
+
+    /// Run one stream-consuming handler and collect every byte it wrote.
+    async fn collect_access_handler_response<Fut>(run: impl FnOnce(DemuxStream) -> Fut) -> Vec<u8>
+    where
+        Fut: std::future::Future<Output = ()>,
+    {
+        use tokio::io::AsyncReadExt;
+        let (mut client, server) = tokio::io::duplex(1 << 20);
+        run(Box::pin(server)).await;
+        let mut response = Vec::new();
+        client
+            .read_to_end(&mut response)
+            .await
+            .expect("collect handler response");
+        response
+    }
+
+    fn golden_access_transcript(bytes: &[u8]) -> String {
+        String::from_utf8_lossy(bytes).into_owned()
+    }
+
+    /// The canonical JSON framing (`Cache-Control` + `Connection` tail),
+    /// spelled out literally.
+    fn golden_access_canonical_json_transcript(status_line: &str, body: &str) -> String {
+        format!(
+            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+    }
+
+    /// The fleet-allowlist JSON framing: the canonical tail, then the
+    /// origin echo (only when the origin passed the allowlist), then
+    /// `Vary: Origin` — spelled out literally.
+    fn golden_access_fleet_json_transcript(
+        status_line: &str,
+        body: &str,
+        echoed_origin: Option<&str>,
+    ) -> String {
+        let echo = match echoed_origin {
+            Some(origin) => format!("Access-Control-Allow-Origin: {origin}\r\n"),
+            None => String::new(),
+        };
+        format!(
+            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n{echo}Vary: Origin\r\n\r\n{body}",
+            body.len()
+        )
+    }
+
+    /// Pin a route's declared CORS posture alongside its byte pins so a
+    /// row-posture change fails these tests instead of silently changing
+    /// the wire.
+    fn assert_access_route_posture(
+        method: &str,
+        path: &str,
+        posture: crate::gateway_routes::CorsPosture,
+    ) {
+        assert_eq!(
+            crate::gateway_routes::match_route(method, path)
+                .expect("access route declared")
+                .0
+                .cors,
+            posture,
+            "{method} {path}"
+        );
+    }
+
+    const GOLDEN_FLEET_ORIGIN: &str = "https://fleet-anchor.example:8765";
+
+    /// Head/body split of a raw HTTP transcript.
+    fn split_transcript(text: &str) -> (&str, &str) {
+        text.split_once("\r\n\r\n").expect("header/body split")
+    }
+
+    #[tokio::test]
+    async fn golden_dashboard_targets_transcript() {
+        assert_access_route_posture(
+            "GET",
+            "/api/dashboard/targets",
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+        );
+        // An empty agent card and no registry produce the deterministic
+        // local-only target list through the untouched builder.
+        let card = serde_json::json!({});
+        let body = dashboard_targets_response_body(&card, None);
+        let response = collect_access_handler_response(|stream| {
+            handle_dashboard_targets(stream, None, card.clone())
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_canonical_json_transcript("200 OK", &body)
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_access_fleet_get_transcripts() {
+        // The fleet inspect reads: iam/state, enrollment-requests, and
+        // overview over an injected tempdir cert store (deterministic
+        // empty-store bodies), each pinned with and without the
+        // allowlisted fleet origin.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cert_dir = tmp.path().to_path_buf();
+
+        assert_access_route_posture(
+            "GET",
+            "/api/access/iam/state",
+            crate::gateway_routes::CorsPosture::FleetAllowlist,
+        );
+        let body = access_iam_state_response_body(&cert_dir);
+        for origin in [None, Some(GOLDEN_FLEET_ORIGIN)] {
+            let dir = cert_dir.clone();
+            let response = collect_access_handler_response(|stream| {
+                handle_access_iam_state(stream, dir, origin.map(str::to_string))
+            })
+            .await;
+            assert_eq!(
+                golden_access_transcript(&response),
+                golden_access_fleet_json_transcript("200 OK", &body, origin)
+            );
+        }
+
+        assert_access_route_posture(
+            "GET",
+            "/api/access/enrollment-requests",
+            crate::gateway_routes::CorsPosture::FleetAllowlist,
+        );
+        let body = access_enrollment_requests_response_body(&cert_dir);
+        for origin in [None, Some(GOLDEN_FLEET_ORIGIN)] {
+            let dir = cert_dir.clone();
+            let response = collect_access_handler_response(|stream| {
+                handle_access_enrollment_requests(stream, dir, origin.map(str::to_string))
+            })
+            .await;
+            assert_eq!(
+                golden_access_transcript(&response),
+                golden_access_fleet_json_transcript("200 OK", &body, origin)
+            );
+        }
+
+        assert_access_route_posture(
+            "GET",
+            "/api/access/overview",
+            crate::gateway_routes::CorsPosture::FleetAllowlist,
+        );
+        let card = serde_json::json!({});
+        let principal =
+            crate::access::iam::AccessPrincipal::root_dashboard_session("golden", "https");
+        let body =
+            access_overview_response_body_for_principal(&cert_dir, &card, None, &principal);
+        for origin in [None, Some(GOLDEN_FLEET_ORIGIN)] {
+            let dir = cert_dir.clone();
+            let card = card.clone();
+            let context = HttpAccessContext {
+                principal: crate::access::iam::AccessPrincipal::root_dashboard_session(
+                    "golden", "https",
+                ),
+                iam_state: None,
+            };
+            let response = collect_access_handler_response(|stream| {
+                handle_access_overview(
+                    stream,
+                    dir,
+                    context,
+                    origin.map(str::to_string),
+                    None,
+                    card,
+                )
+            })
+            .await;
+            assert_eq!(
+                golden_access_transcript(&response),
+                golden_access_fleet_json_transcript("200 OK", &body, origin)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn golden_access_connect_status_framing() {
+        // The status body reads process-global snapshots (connect client,
+        // fleet cert, hosted-bundle tripwire), so the FRAMING is the pin:
+        // head hand-written around the served body's length, body sanity-
+        // checked through the schema marker.
+        assert_access_route_posture(
+            "GET",
+            "/api/access/connect/status",
+            crate::gateway_routes::CorsPosture::FleetAllowlist,
+        );
+        for origin in [None, Some(GOLDEN_FLEET_ORIGIN)] {
+            let response = collect_access_handler_response(|stream| {
+                handle_access_connect_status(stream, origin.map(str::to_string))
+            })
+            .await;
+            let text = golden_access_transcript(&response);
+            let (_, body) = split_transcript(&text);
+            assert_eq!(
+                text,
+                golden_access_fleet_json_transcript("200 OK", body, origin)
+            );
+            let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
+            assert_eq!(parsed["schema_version"], 1, "{body}");
+        }
+    }
+
+    /// A hermetically-built DENIED manage context: a scoped browser-cert
+    /// grant in a tempdir cert store (the
+    /// `scoped_browser_cert_denies_http_access_management` recipe).
+    fn golden_denied_manage_context(tmp: &std::path::Path) -> HttpAccessContext {
+        let actor =
+            crate::access::iam::AccessPrincipal::root_dashboard_session("golden", "https");
+        access_iam_upsert_user_client_grant_response_value_with_cert_dir(
+            tmp,
+            serde_json::json!({
+                "kind": "browser_certificate",
+                "label": "Golden scoped browser",
+                "fingerprint": "60:1D",
+                "role_id": "role:scoped-human"
+            }),
+            &actor,
+        )
+        .unwrap();
+        let context = http_access_context(tmp, None, Some("601d"), true, true).unwrap();
+        assert!(
+            !context
+                .decision(crate::peer::access_policy::PeerOperation::AccessManage)
+                .allowed
+        );
+        context
+    }
+
+    /// The in-handler manage re-check's 403 body for a context/decision
+    /// pair, exactly as every access handler builds it.
+    fn golden_denied_manage_body(context: &HttpAccessContext) -> String {
+        let decision =
+            context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
+        serde_json::json!({
+            "error": "principal does not allow this operation",
+            "principal": context.principal.as_value(),
+            "permission": decision.permission,
+            "reason": decision.reason,
+        })
+        .to_string()
+    }
+
+    #[tokio::test]
+    async fn golden_access_connect_claim_code_transcripts() {
+        assert_access_route_posture(
+            "GET",
+            "/api/access/connect/claim-code",
+            crate::gateway_routes::CorsPosture::FleetAllowlist,
+        );
+        // Allowed: the claim-code body reads the process-global connect
+        // snapshot — framing-only pin, both origin shapes.
+        for origin in [None, Some(GOLDEN_FLEET_ORIGIN)] {
+            let context = HttpAccessContext {
+                principal: crate::access::iam::AccessPrincipal::root_dashboard_session(
+                    "golden", "https",
+                ),
+                iam_state: None,
+            };
+            let response = collect_access_handler_response(|stream| {
+                handle_access_connect_claim_code(stream, context, origin.map(str::to_string))
+            })
+            .await;
+            let text = golden_access_transcript(&response);
+            let (_, body) = split_transcript(&text);
+            assert_eq!(
+                text,
+                golden_access_fleet_json_transcript("200 OK", body, origin)
+            );
+            let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
+            assert_eq!(parsed["schema_version"], 1, "{body}");
+        }
+
+        // Denied: the belt-and-suspenders re-check answers 403 under the
+        // PLAIN canonical tail — historically no fleet decoration even
+        // when an allowlisted origin is present. Pinned deliberately.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let context = golden_denied_manage_context(tmp.path());
+        let body = golden_denied_manage_body(&context);
+        let response = collect_access_handler_response(|stream| {
+            handle_access_connect_claim_code(
+                stream,
+                context,
+                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_canonical_json_transcript("403 Forbidden", &body)
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_access_connect_config_transcripts() {
+        assert_access_route_posture(
+            "POST",
+            "/api/access/connect/config",
+            crate::gateway_routes::CorsPosture::FleetAllowlist,
+        );
+        let root_context = || HttpAccessContext {
+            principal: crate::access::iam::AccessPrincipal::root_dashboard_session(
+                "golden", "https",
+            ),
+            iam_state: None,
+        };
+
+        // Invalid JSON: serde's wording for this exact input, derived
+        // through the same parse — 400 under the fleet tail (echo case).
+        let invalid = "not json";
+        let serde_error = serde_json::from_str::<serde_json::Value>(invalid).unwrap_err();
+        let expected_body =
+            serde_json::json!({"error": format!("invalid request body: {serde_error}")})
+                .to_string();
+        let response = collect_access_handler_response(|stream| {
+            handle_access_connect_config(
+                stream,
+                invalid.to_string(),
+                "POST",
+                root_context(),
+                None,
+                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_fleet_json_transcript(
+                "400 Bad Request",
+                &expected_body,
+                Some(GOLDEN_FLEET_ORIGIN)
+            )
+        );
+
+        // Missing `enabled`: the validation error, before any store access.
+        let response = collect_access_handler_response(|stream| {
+            handle_access_connect_config(
+                stream,
+                "{}".to_string(),
+                "POST",
+                root_context(),
+                None,
+                None,
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_fleet_json_transcript(
+                "400 Bad Request",
+                r#"{"error":"enabled must be true or false"}"#,
+                None
+            )
+        );
+
+        // Success on a tempdir project root (enabled=false keeps
+        // apply_config on its stop path): framing pinned, body computed
+        // through the untouched core over the same store.
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path().to_path_buf();
+        let response = collect_access_handler_response(|stream| {
+            handle_access_connect_config(
+                stream,
+                r#"{"enabled":false}"#.to_string(),
+                "POST",
+                root_context(),
+                Some(root.clone()),
+                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+            )
+        })
+        .await;
+        let text = golden_access_transcript(&response);
+        let (_, body) = split_transcript(&text);
+        assert_eq!(
+            text,
+            golden_access_fleet_json_transcript("200 OK", body, Some(GOLDEN_FLEET_ORIGIN))
+        );
+        let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed["written_enabled"], serde_json::json!(false));
+        assert!(root.join("intendant.toml").exists());
+    }
+
+    #[tokio::test]
+    async fn golden_access_connect_unclaim_transcript() {
+        assert_access_route_posture(
+            "POST",
+            "/api/access/connect/unclaim",
+            crate::gateway_routes::CorsPosture::FleetAllowlist,
+        );
+        // A tempdir project root has no rendezvous configured — the
+        // deterministic no-rendezvous error, 400 under the fleet tail.
+        // The live release path needs a claimed rendezvous and stays
+        // smoke-covered (validate-connect-* / fresh-VPS e2e).
+        let dir = tempfile::TempDir::new().unwrap();
+        for origin in [None, Some(GOLDEN_FLEET_ORIGIN)] {
+            let context = HttpAccessContext {
+                principal: crate::access::iam::AccessPrincipal::root_dashboard_session(
+                    "golden", "https",
+                ),
+                iam_state: None,
+            };
+            let root = dir.path().to_path_buf();
+            let response = collect_access_handler_response(|stream| {
+                handle_access_connect_unclaim(
+                    stream,
+                    "POST",
+                    context,
+                    Some(root),
+                    origin.map(str::to_string),
+                )
+            })
+            .await;
+            assert_eq!(
+                golden_access_transcript(&response),
+                golden_access_fleet_json_transcript(
+                    "400 Bad Request",
+                    r#"{"error":"no rendezvous_url configured"}"#,
+                    origin
+                )
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn golden_access_tier_transcripts() {
+        assert_access_route_posture(
+            "POST",
+            "/api/access/tier",
+            crate::gateway_routes::CorsPosture::FleetAllowlist,
+        );
+        assert_access_route_posture(
+            "POST",
+            "/api/access/hosted-ceiling",
+            crate::gateway_routes::CorsPosture::FleetAllowlist,
+        );
+        let root_context = || HttpAccessContext {
+            principal: crate::access::iam::AccessPrincipal::root_dashboard_session(
+                "golden", "https",
+            ),
+            iam_state: None,
+        };
+
+        // Non-string tier: the validation 400 under the fleet tail.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cert_dir = tmp.path().to_path_buf();
+        let response = collect_access_handler_response(|stream| {
+            handle_access_tier_settings(
+                stream,
+                r#"{"tier":123}"#.to_string(),
+                "POST",
+                "/api/access/tier",
+                cert_dir.clone(),
+                root_context(),
+                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_fleet_json_transcript(
+                "400 Bad Request",
+                r#"{"error":"tier must be a string or null"}"#,
+                Some(GOLDEN_FLEET_ORIGIN)
+            )
+        );
+
+        // Unparseable body: the early-return 400 answers under the PLAIN
+        // canonical tail — historically no fleet decoration. Pinned
+        // deliberately (serde wording derived through the same parse).
+        let invalid = "not json";
+        let serde_error = serde_json::from_str::<serde_json::Value>(invalid).unwrap_err();
+        let expected_body =
+            serde_json::json!({"error": format!("invalid request body: {serde_error}")})
+                .to_string();
+        let response = collect_access_handler_response(|stream| {
+            handle_access_tier_settings(
+                stream,
+                invalid.to_string(),
+                "POST",
+                "/api/access/tier",
+                cert_dir.clone(),
+                root_context(),
+                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_canonical_json_transcript("400 Bad Request", &expected_body)
+        );
+
+        // Success over the injected tempdir store: an empty body reads as
+        // `{}` (tier cleared) — framing pinned, body asserted through the
+        // parse (the `iam` metadata carries store timestamps).
+        let response = collect_access_handler_response(|stream| {
+            handle_access_tier_settings(
+                stream,
+                String::new(),
+                "POST",
+                "/api/access/tier",
+                cert_dir.clone(),
+                root_context(),
+                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+            )
+        })
+        .await;
+        let text = golden_access_transcript(&response);
+        let (_, body) = split_transcript(&text);
+        assert_eq!(
+            text,
+            golden_access_fleet_json_transcript("200 OK", body, Some(GOLDEN_FLEET_ORIGIN))
+        );
+        let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed["schema_version"], 1);
+        assert_eq!(parsed["tier"], serde_json::Value::Null, "{body}");
+
+        // Hosted ceiling, missing role_id: the validation 400.
+        let response = collect_access_handler_response(|stream| {
+            handle_access_tier_settings(
+                stream,
+                "{}".to_string(),
+                "POST",
+                "/api/access/hosted-ceiling",
+                cert_dir.clone(),
+                root_context(),
+                None,
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_fleet_json_transcript(
+                "400 Bad Request",
+                r#"{"error":"role_id is required"}"#,
+                None
+            )
+        );
     }
 }


### PR DESCRIPTION
First S6 PR unit (transport-unification design §6 S6): the access inspect reads (overview, iam/state, enrollment-requests, dashboard-targets), the connect admin quartet (status, claim-code, config, unclaim), and the trust-tier pair (tier, hosted-ceiling).

Follows the S4/S5 template, commits in the established order:
1. hermetic seams + golden transcripts — cert-dir stores resolve at the transport edges; the goldens pin the current HTTP wire bytes over injected tempdirs, and (this family's hazard) cover the fleet-origin CORS echo on every fleet row: bare `Vary: Origin` vs echoed `Access-Control-Allow-Origin` + `Vary: Origin`
2. HTTP side: transport-neutral `*_api_response` fns; handlers become shims
3. tunnel side: the ten tunnel twins delegate to the same neutral fns under their historical ok/error envelope; tunnel/HTTP parity fixtures extend the enumeration
4. route rows gain `tunnel:` columns; CONTROL_METHODS sheds the ten entries; partition pin flips

No wire change on either lane; goldens + parity fixtures are the proof. Gates: gateway invariants, dashboard_control units, e2e; operator battery adds validate-fleet-cors + validate-org-grants before the family lands.