### PR TITLE
CI wave 3 kit: macOS _intendant-ci service account + listener migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,7 +371,9 @@ not half-hours.
 our hardware, yet its required checks really run. Fork-PR workflows also
 need maintainer approval before anything runs (all outside collaborators,
 not just first-timers). The Dell and Windows runners run as dedicated
-non-admin `ci` users, and the check *names* stay pinned to the
+non-admin `ci` users — the Mac joins them as the `scripts/ci` service-account
+kit (`_intendant-ci`: hidden role account, LaunchDaemon listeners, job hooks)
+is cut over — and the check *names* stay pinned to the
 `test (ubuntu-latest)`-style contexts the ruleset requires (matrix `os` is
 the name key, `runner` is the fleet placement):
 - **`windows.yml`** — cross-platform `cargo test` (the `intendant` bins + the `intendant-core`/`intendant-display`/`intendant-platform` lib crates) + the headless mock-provider e2e on Windows + macOS + Linux (catches platform-specific build breaks *and* Unix-only test/path assumptions; excludes the WASM crates). Full suites run in exactly two places: the **merge group** (all three platforms — the actual gate) and the **Linux `pull_request` leg** (the pre-queue runtime signal); everything else — non-Linux PR legs, every push-to-main warm run — is `cargo check` only. The Windows and Linux legs build with debuginfo off (`CARGO_PROFILE_DEV_DEBUG=0` — the Linux leg measured ~95% compile+link vs ~12s of test execution; repro locally with default debuginfo when a CI backtrace is too thin). Headless-safe: needs no display or API keys. **Required check.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,7 +371,9 @@ not half-hours.
 our hardware, yet its required checks really run. Fork-PR workflows also
 need maintainer approval before anything runs (all outside collaborators,
 not just first-timers). The Dell and Windows runners run as dedicated
-non-admin `ci` users, and the check *names* stay pinned to the
+non-admin `ci` users — the Mac joins them as the `scripts/ci` service-account
+kit (`_intendant-ci`: hidden role account, LaunchDaemon listeners, job hooks)
+is cut over — and the check *names* stay pinned to the
 `test (ubuntu-latest)`-style contexts the ruleset requires (matrix `os` is
 the name key, `runner` is the fleet placement):
 - **`windows.yml`** — cross-platform `cargo test` (the `intendant` bins + the `intendant-core`/`intendant-display`/`intendant-platform` lib crates) + the headless mock-provider e2e on Windows + macOS + Linux (catches platform-specific build breaks *and* Unix-only test/path assumptions; excludes the WASM crates). Full suites run in exactly two places: the **merge group** (all three platforms — the actual gate) and the **Linux `pull_request` leg** (the pre-queue runtime signal); everything else — non-Linux PR legs, every push-to-main warm run — is `cargo check` only. The Windows and Linux legs build with debuginfo off (`CARGO_PROFILE_DEV_DEBUG=0` — the Linux leg measured ~95% compile+link vs ~12s of test execution; repro locally with default debuginfo when a CI backtrace is too thin). Headless-safe: needs no display or API keys. **Required check.**

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -87,6 +87,158 @@ Future watchdog enhancement (not yet implemented): gate listener
 resume on `memory_pressure` in addition to disk, so a swap storm
 pauses assignment the way a full disk does.
 
+## macOS CI service account (`_intendant-ci`)
+
+**Why:** CI jobs on the Mac listeners historically executed as the
+operator's own account — so any code that lands in a PR (and every
+action it pulls in) could read everything the operator can read
+(`~/.ssh`, `.env` API keys, gh tokens, browser profiles, session
+stores) and inherited the operator's TCC grants (Screen Recording,
+Microphone, Accessibility). The Dell and Windows runners already run
+as dedicated non-admin `ci` users; this kit brings the Mac to parity.
+
+The kit (all root, all idempotent, everything host-specific detected
+at run time — nothing beyond the generic `_intendant-ci` name is
+committed):
+
+- **`setup-ci-account-macos.sh`** — creates the hidden role account
+  (`sysadminctl -roleAccount`: UID auto-picked in 200–400, own primary
+  group — not `staff`, not `admin` — no password login, home `/var/ci`;
+  role accounts conventionally live outside `/Users`, and an empty
+  non-template home keeps the hermeticity signal clean). Provisions the
+  per-user toolchain **as that account**: rustup pinned to the invoking
+  host's current `rustc -V` (printed; the workflows key their cargo
+  target caches by it), `~/.cargo/config.toml` with the jobs cap above
+  (mirrors the operator's value; adds `rustc-wrapper = <sccache>` iff
+  sccache exists at install time), wasm-pack at the repo's
+  `.wasm-pack-version` pin (failure is a loud, canary-visible gap, not
+  a blocker). Installs the job hooks. Verifies and prints: not in
+  admin/staff, no password material, HOME resolves, and that the
+  account **cannot traverse any human `/Users/<home>`** (expects 700;
+  reports, never chmods — that fix is the operator's call).
+- **`migrate-runner-macos.sh <listener-name>`** — one listener per
+  invocation. Stops the operator-account LaunchAgent, waits for the
+  service tree to exit, moves the runner dir into `/var/ci` (the
+  `.runner`/`.credentials` registration travels with it — identity and
+  name preserved, **no re-registration**), remaps `.path` onto the CI
+  home, wires the hooks into `.env`, renders a LaunchDaemon from the
+  runner's own `bin/actions.runner.plist.template` (the exact template
+  `svc.sh` renders LaunchAgents from — same load-bearing keys:
+  `runsvc.sh` ProgramArguments, WorkingDirectory, RunAtLoad, log paths,
+  `ACTIONS_RUNNER_SVC=1`, ProcessType Interactive, SessionCreate) with
+  `UserName` swapped to `_intendant-ci` and `HOME`/`USER` injected into
+  `EnvironmentVariables` (the one deliberate divergence: gui
+  LaunchAgents inherit them from the login session, system
+  LaunchDaemons get neither, and rustup/cargo need `HOME`), bootstraps
+  it in the system domain, waits for the runner to report online
+  (`gh api`, when
+  available), and rewires `watchdog.conf` (label moves to
+  `RUNNER_DAEMON_LABELS`, CI cache root and account are added; the old
+  cache root stays listed so the watchdog prunes its stale keys away).
+  Prints the rollback invocation on completion. Post-migration the
+  runner's `svc.sh` no longer applies (gui-domain only) — control the
+  listener via `launchctl … system …` or the watchdog.
+- **`rollback-runner-macos.sh <listener-name>`** — exact inverse, from
+  the metadata migrate parked under `/etc/intendant-ci/migration/`:
+  bootout the daemon, move the dir back, chown, restore
+  `.path`/`.env`/`.service`, restore + bootstrap the original
+  LaunchAgent, restore the watchdog entries (the CI account and cache
+  root drop out once no daemon listener remains).
+
+### Migration runbook
+
+```bash
+sudo scripts/ci/setup-ci-account-macos.sh        # account + toolchain + hooks
+sudo scripts/ci/migrate-runner-macos.sh <listener-b>   # secondary listener first
+# canary (below), soak ≥ a day
+sudo scripts/ci/migrate-runner-macos.sh <listener-a>   # primary listener
+# final soak; rollback at any point:
+sudo scripts/ci/rollback-runner-macos.sh <name>
+```
+
+Canary: after migrating the first listener, force a full required-check
+run onto it — pause the un-migrated listener for one run
+(`launchctl bootout gui/<uid>/<label>`, resume with the matching
+`bootstrap`) or simply watch until the migrated listener has executed
+each required workflow at least once (`gh run list`, per-job runner
+name in the job log).
+
+### Canary expectations (fresh account: zero TCC grants, no Aqua/WindowServer session)
+
+The LaunchDaemon carries `SessionCreate=true`, so jobs get a security
+session (securityd works) but no window server and no TCC grants.
+Suite grep, 2026-07-10 — the classes that touch macOS machinery, and
+what to expect:
+
+| Test class | Expectation as `_intendant-ci` |
+|---|---|
+| `access/certs.rs::p12_imports_via_real_macos_keychain`, `::p12_imports_via_security_cli_auto_detection` | **PASS — watch these closest.** Real Keychain machinery, but against throwaway *file-backed* keychains in tempdirs (never the login keychain). Needs securityd + a security session, not WindowServer/TCC. A regression here looks like `errSecInteractionNotAllowed` / `security create-keychain` failing. |
+| `sandbox.rs` seatbelt tests (3 spawn real `/usr/bin/sandbox-exec`) | PASS — Seatbelt needs no GUI or TCC. |
+| `access/cert_server.rs::mobileconfig_profile_is_valid_plist_on_macos` | PASS — spawns `plutil`, headless-safe. |
+| `terminal.rs` PTY suite | PASS — `openpty` needs no controlling terminal or GUI. |
+| `platform.rs` (process tree/spawn), `vision.rs` (Linux-display logic), `computer_use.rs` (pure key parsing), `audio_routing.rs` / `transcription.rs` / `recording.rs` (pure command construction), `encode/*` (software VP8 + AVCC byte-munging), `clipboard.rs` (struct-only — tests never start the NSPasteboard poller) | PASS — pure logic; no live OS surface. |
+| `ax.rs::live_read_frontmost` (AX TCC), `intendant-display::macos_real_capture_stress_cycles` (Screen Recording TCC + display), `live_audio.rs` live-API tests | Already `#[ignore]`d — not in CI on any account; they stay operator-hardware smokes. |
+| `tests/e2e` (mock provider, headless) | PASS — hermetic by design; fixtures inject their roots. A test that fails **only** on the CI account because it resolved the real `$HOME` (now an empty `/var/ci`) is an unhermetic-fixture bug to fix (CLAUDE.md, "Tests are hermetic"), not a migration blocker. |
+
+What *would* regress, and deliberately doesn't exist: any non-ignored
+test calling WindowServer (CGDisplay/ScreenCaptureKit/NSPasteboard/
+CGEvent-post) — the grep found none; new tests must keep it that way.
+Runtime capabilities of the box under the CI account are reduced **by
+design**: `screencapture`, ScreenCaptureKit, AX, and live audio would
+each need TCC grants the fresh account doesn't have — CI never uses
+them.
+
+### Job hooks
+
+`hooks/job-started.sh` / `hooks/job-completed.sh` (shared engine
+`hooks/hook-lib.sh`) are wired through each runner root's `.env` —
+`ACTIONS_RUNNER_HOOK_JOB_STARTED=…` / `…_JOB_COMPLETED=…`, the
+documented runner mechanism; the runner reads `.env` at listener
+startup, so re-wiring needs a listener restart. Per invocation,
+bounded by a 60s self-timeout (a watchdog subshell reaps hung work —
+GitHub applies no timeout of its own, and a wedged started-hook would
+wedge the job):
+
+- wipe `$RUNNER_TEMP` contents (per-runner, recreated every job);
+- reap stale (>24h) temp/test-home residue — `$TMPDIR` and
+  `~/.intendant` are per-*account*, shared with the other listener's
+  live jobs, hence the age gate;
+- kill leftover CI-account processes that no live runner tree owns —
+  decided by **ancestry**, not age (both listeners share the account);
+  the runner service stacks and the shared sccache server are
+  protected (killing sccache mid-compile fails the other listener's
+  rustc invocations);
+- log exactly one summary line to `/var/log/intendant-ci-hooks.log`
+  (rotated at 1MB like the watchdog log, truncate-in-place because the
+  account can't create files in `/var/log`);
+- **always exit 0** — a non-zero started-hook fails the job (GitHub
+  semantics), and janitorial trouble must never take down CI.
+
+Never touched: `~/.cache/intendant-ci` (the watchdog owns the warm
+target caches), `~/.cargo`, `~/.rustup`.
+
+### Watchdog interplay
+
+`fleet-watchdog.sh` understands both listener shapes at once —
+`RUNNER_LABELS` (gui-domain LaunchAgents, `RUNNER_UID` +
+`RUNNER_PLIST_DIR`) and `RUNNER_DAEMON_LABELS` (system-domain
+LaunchDaemons, `RUNNER_DAEMON_PLIST_DIR`) — and `RUNNER_USER` may list
+several accounts, so a half-migrated host stays fully supervised. The
+migrate/rollback scripts edit `watchdog.conf` themselves; the
+before-images land in `/etc/intendant-ci/migration/` for audit.
+
+### Deliberately deferred
+
+- **PF / private-LAN egress deny for the CI account** (packet-filter
+  rules keyed to `_intendant-ci`'s uid, so PR code can't probe the
+  LAN): needs operator sign-off at apply time — not part of this kit.
+- **Windows host equivalent** of the hooks + migration ergonomics (the
+  Windows runner already runs as a dedicated non-admin user; see the
+  watchdog "Windows" note above).
+- **sccache cache custody**: the CI account's sccache cache lives in
+  its own `~/Library/Caches` under sccache's default 10G self-cap; the
+  watchdog does not manage it yet.
+
 ## Interlocks
 
 - The workflow cache steps and this watchdog share the cache layout
@@ -97,3 +249,8 @@ pauses assignment the way a full disk does.
   the watchdog should pause listeners long before any job can see a
   sub-floor disk, leaving the preflight as the backstop for the
   watchdog being dead or misconfigured.
+- The migrate/rollback scripts and the watchdog share the
+  `watchdog.conf` vocabulary (`RUNNER_LABELS` ↔
+  `RUNNER_DAEMON_LABELS`, multi-account `RUNNER_USER`). Change the
+  conf schema, change `migrate-runner-macos.sh` /
+  `rollback-runner-macos.sh` in the same commit.

--- a/scripts/ci/fleet-watchdog.sh
+++ b/scripts/ci/fleet-watchdog.sh
@@ -33,10 +33,12 @@ CACHE_ROOTS="${CACHE_ROOTS:-}"      # space-separated cache roots
 VOLUME="${VOLUME:-/}"               # volume free space is measured on
 STATE_DIR="${STATE_DIR:-/var/db/intendant-ci}"
 LOG="${LOG:-/var/log/intendant-ci-watchdog.log}"
-RUNNER_USER="${RUNNER_USER:-}"      # account the listeners run as
-RUNNER_UID="${RUNNER_UID:-}"        # its uid (macOS launchctl domain)
-RUNNER_LABELS="${RUNNER_LABELS:-}"  # macOS: LaunchAgent labels
+RUNNER_USER="${RUNNER_USER:-}"      # account(s) the listeners run as (space-separated)
+RUNNER_UID="${RUNNER_UID:-}"        # LaunchAgent account uid (macOS gui domain)
+RUNNER_LABELS="${RUNNER_LABELS:-}"  # macOS: LaunchAgent labels (gui domain)
 RUNNER_PLIST_DIR="${RUNNER_PLIST_DIR:-}"  # macOS: dir holding those plists
+RUNNER_DAEMON_LABELS="${RUNNER_DAEMON_LABELS:-}"  # macOS: LaunchDaemon labels (system domain)
+RUNNER_DAEMON_PLIST_DIR="${RUNNER_DAEMON_PLIST_DIR:-/Library/LaunchDaemons}"
 RUNNER_UNITS="${RUNNER_UNITS:-}"    # Linux: systemd units
 
 PAUSED_MARKER="$STATE_DIR/listeners.paused"
@@ -59,8 +61,14 @@ is_macos() { [ "$(uname -s)" = "Darwin" ]; }
 
 job_running() {
     # Runner.Worker only exists while a job executes on a listener.
+    # RUNNER_USER may list several accounts (mid-migration a host runs
+    # LaunchAgent listeners as the operator and LaunchDaemon listeners as
+    # the CI service account at the same time).
     if [ -n "$RUNNER_USER" ]; then
-        pgrep -u "$RUNNER_USER" -f 'Runner\.Worker' >/dev/null 2>&1
+        for u in $RUNNER_USER; do
+            pgrep -u "$u" -f 'Runner\.Worker' >/dev/null 2>&1 && return 0
+        done
+        return 1
     else
         pgrep -f 'Runner\.Worker' >/dev/null 2>&1
     fi
@@ -72,6 +80,11 @@ stop_listeners() {
             launchctl bootout "gui/$RUNNER_UID/$label" 2>/dev/null \
                 && log "stopped listener $label" \
                 || log "listener $label was not running"
+        done
+        for label in $RUNNER_DAEMON_LABELS; do
+            launchctl bootout "system/$label" 2>/dev/null \
+                && log "stopped daemon listener $label" \
+                || log "daemon listener $label was not running"
         done
     else
         for unit in $RUNNER_UNITS; do
@@ -89,6 +102,11 @@ start_listeners() {
             launchctl bootstrap "gui/$RUNNER_UID" "$RUNNER_PLIST_DIR/$label.plist" 2>/dev/null \
                 && log "resumed listener $label" \
                 || log "listener $label already running (or bootstrap failed — check manually)"
+        done
+        for label in $RUNNER_DAEMON_LABELS; do
+            launchctl bootstrap system "$RUNNER_DAEMON_PLIST_DIR/$label.plist" 2>/dev/null \
+                && log "resumed daemon listener $label" \
+                || log "daemon listener $label already running (or bootstrap failed — check manually)"
         done
     else
         for unit in $RUNNER_UNITS; do

--- a/scripts/ci/hooks/hook-lib.sh
+++ b/scripts/ci/hooks/hook-lib.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+# Shared engine for the GitHub Actions runner job hooks (job-started.sh /
+# job-completed.sh source this; wiring and doctrine in scripts/ci/README.md,
+# "Job hooks").
+#
+# Runs as the CI service account, inside the job's Runner.Worker, with the
+# job's environment (RUNNER_TEMP, RUNNER_NAME, GITHUB_*). Duties per
+# invocation:
+#
+#   1. wipe the per-runner $RUNNER_TEMP residue,
+#   2. reap stale per-ACCOUNT temp and test-home residue (age-gated:
+#      $TMPDIR and ~/.intendant are shared with the other listener's
+#      live jobs — never yank a fresh entry),
+#   3. kill leftover processes that no live runner tree owns,
+#   4. log exactly one summary line to $LOG (rotated), and
+#   5. always exit 0, within HOOK_TIMEOUT_SECS.
+#
+# Never touched: ~/.cache/intendant-ci (the warm external cargo target
+# caches — the fleet watchdog owns those), ~/.cargo, ~/.rustup.
+#
+# Exit-0 doctrine: a non-zero exit from the job-started hook FAILS the job
+# (GitHub semantics), so janitorial trouble must never take down CI — every
+# failure path logs what it can and exits 0.
+
+LOG="${INTENDANT_CI_HOOK_LOG:-/var/log/intendant-ci-hooks.log}"
+HOOK_TIMEOUT_SECS="${INTENDANT_CI_HOOK_TIMEOUT_SECS:-60}"
+
+log_line() {
+    printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$*" >> "$LOG" 2>/dev/null || true
+}
+
+# Rotation mirrors fleet-watchdog.sh's budget (1MB cap, keep the last 256K)
+# — but the hook runs as the CI account, which can write the pre-created log
+# FILE yet cannot create siblings in /var/log, so it rotates by
+# truncate-in-place instead of tmp+mv. (The two listeners' hooks can race
+# here; the worst case is a lost tail line in a janitor log.)
+rotate_log() {
+    [ -f "$LOG" ] || return 0
+    [ "$(wc -c < "$LOG" 2>/dev/null || echo 0)" -gt 1048576 ] || return 0
+    local tmp
+    tmp=$(mktemp 2>/dev/null) || return 0
+    if tail -c 262144 "$LOG" > "$tmp" 2>/dev/null; then
+        cat "$tmp" > "$LOG" 2>/dev/null
+    fi
+    rm -f "$tmp"
+}
+
+# $RUNNER_TEMP is per-runner (<runner root>/_work/_temp) — never shared with
+# the other listener — and the runner recreates it every job, so a full wipe
+# of its CONTENTS is safe. The case guard keeps a mis-set variable from ever
+# aiming this at / or $HOME.
+wipe_runner_temp() {
+    local n=0 entry
+    case "${RUNNER_TEMP:-}" in
+        */_work/_temp)
+            if [ -d "$RUNNER_TEMP" ]; then
+                for entry in "$RUNNER_TEMP"/* "$RUNNER_TEMP"/.[!.]* "$RUNNER_TEMP"/..?*; do
+                    [ -e "$entry" ] || [ -L "$entry" ] || continue
+                    rm -rf "$entry" 2>/dev/null && n=$((n + 1))
+                done
+            fi
+            ;;
+    esac
+    printf '%s' "$n"
+}
+
+# $TMPDIR (the per-account DARWIN_USER_TEMP_DIR under a gui session; plain
+# /tmp under a LaunchDaemon, which launchd gives no TMPDIR) is shared by
+# BOTH listeners' jobs — a fresh tempdir may belong to the other listener's
+# live job. Only reap well-known test/temp prefixes older than 24h (no job
+# runs remotely that long); under /tmp the sticky bit additionally limits
+# deletion to this account's own entries.
+wipe_stale_tmp() {
+    local base="${TMPDIR:-/tmp}" n=0 entry
+    if [ ! -d "$base" ]; then
+        printf '0'
+        return 0
+    fi
+    while IFS= read -r entry; do
+        [ -n "$entry" ] || continue
+        rm -rf "$entry" 2>/dev/null && n=$((n + 1))
+    done < <(find "$base" -mindepth 1 -maxdepth 1 \
+        \( -name '.tmp*' -o -name 'tmp.*' -o -name 'intendant-*' \
+           -o -name 'rustc*' -o -name 'cargo-install*' \) \
+        -mmin +1440 2>/dev/null)
+    printf '%s' "$n"
+}
+
+# Hermetic tests never write $HOME, but escaped fixtures historically did
+# (CLAUDE.md, "Tests are hermetic"). On the dedicated CI account,
+# ~/.intendant is only ever such residue — reap it age-gated so an
+# unhermetic test still running on the other listener isn't yanked mid-job.
+wipe_stale_test_home() {
+    local n=0 entry
+    if [ ! -d "$HOME/.intendant" ]; then
+        printf '0'
+        return 0
+    fi
+    while IFS= read -r entry; do
+        [ -n "$entry" ] || continue
+        rm -rf "$entry" 2>/dev/null && n=$((n + 1))
+    done < <(find "$HOME/.intendant" -mindepth 1 -maxdepth 1 -mmin +1440 2>/dev/null)
+    printf '%s' "$n"
+}
+
+# Kill leftover processes owned by the CI account that no live runner tree
+# owns (daemons leaked by killed test jobs). Both listeners run as this
+# account, so "leftover" is decided by ANCESTRY, not age: a process whose
+# ancestor chain reaches a runner service process (either listener's
+# runsvc.sh / RunnerService.js / Runner.Listener / Runner.Worker) is a live
+# job's process and is left alone; one that chains straight to launchd
+# without passing a runner process is an orphan. The shared per-account
+# sccache server is explicitly protected — killing it mid-compile would fail
+# the other listener's rustc invocations.
+reap_orphans() {
+    local uid snapshot
+    uid=$(id -u)
+    snapshot=$(ps -axo pid=,ppid=,uid=,command= 2>/dev/null | awk -v u="$uid" '$3 == u')
+    if [ -z "$snapshot" ]; then
+        printf 'killed=0'
+        return 0
+    fi
+
+    local protected=" " pid ppid cmd
+    while read -r pid ppid _ cmd; do
+        [ -n "$pid" ] || continue
+        case "$cmd" in
+            *runsvc.sh* | *RunnerService.js* | *Runner.Listener* | *Runner.Worker* | *sccache*)
+                protected="$protected$pid "
+                ;;
+        esac
+    done <<< "$snapshot"
+
+    # Belt and braces: protect this hook's own ancestor chain (it chains to
+    # Runner.Worker anyway). Bounded walk in case of a ppid anomaly.
+    local hop=0
+    pid=$$
+    while [ "$hop" -lt 64 ] && [ -n "$pid" ] && [ "$pid" -gt 1 ] 2>/dev/null; do
+        protected="$protected$pid "
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+        hop=$((hop + 1))
+    done
+
+    # Fixed point: every descendant of a protected process is protected
+    # (descendants of a live Worker are that job's processes).
+    local changed=1
+    while [ "$changed" = 1 ]; do
+        changed=0
+        while read -r pid ppid _ cmd; do
+            [ -n "$pid" ] || continue
+            case "$protected" in
+                *" $pid "*) continue ;;
+            esac
+            case "$protected" in
+                *" $ppid "*)
+                    protected="$protected$pid "
+                    changed=1
+                    ;;
+            esac
+        done <<< "$snapshot"
+    done
+
+    # Everything else is an orphan: TERM, short grace, then KILL.
+    local victims="" detail="" n=0 comm
+    while read -r pid ppid _ cmd; do
+        [ -n "$pid" ] || continue
+        case "$protected" in
+            *" $pid "*) continue ;;
+        esac
+        victims="$victims $pid"
+        comm=$(basename "${cmd%% *}" 2>/dev/null)
+        detail="$detail,$pid:${comm:-?}"
+        n=$((n + 1))
+    done <<< "$snapshot"
+
+    if [ -n "$victims" ]; then
+        # shellcheck disable=SC2086 # victims is a deliberate pid word-list
+        kill -TERM $victims 2>/dev/null
+        sleep 3
+        for pid in $victims; do
+            kill -0 "$pid" 2>/dev/null && kill -KILL "$pid" 2>/dev/null
+        done
+    fi
+    printf 'killed=%s%s' "$n" "${detail:+ [${detail#,}]}"
+}
+
+# The bounded driver: the real work runs in a child subshell so a hung
+# cleanup can be reaped by the timer — GitHub applies no timeout of its own
+# to these hooks, and a wedged started-hook would wedge the job.
+run_hook() {
+    local phase="$1"
+    rotate_log
+    local t0 result_file work timer outcome detail=""
+    t0=$(date +%s)
+    result_file=$(mktemp 2>/dev/null) || result_file=""
+
+    (
+        rt=$(wipe_runner_temp)
+        st=$(wipe_stale_tmp)
+        sh_=$(wipe_stale_test_home)
+        ko=$(reap_orphans)
+        if [ -n "$result_file" ]; then
+            printf 'runner_temp=%s stale_tmp=%s stale_home=%s %s' \
+                "$rt" "$st" "$sh_" "$ko" > "$result_file"
+        fi
+    ) &
+    work=$!
+    ( sleep "$HOOK_TIMEOUT_SECS"; kill -TERM "$work" 2>/dev/null ) &
+    timer=$!
+
+    outcome=ok
+    wait "$work" 2>/dev/null || outcome=timeout
+    # (The reap-to-kill gap here is a theoretical PID-reuse window only when
+    # the work finishes at exactly the deadline; blast radius is a stray
+    # TERM inside our own account.)
+    kill "$timer" 2>/dev/null
+    wait "$timer" 2>/dev/null
+
+    if [ -n "$result_file" ]; then
+        detail=$(cat "$result_file" 2>/dev/null || true)
+        rm -f "$result_file"
+    fi
+    log_line "$phase runner=${RUNNER_NAME:-?} job=${GITHUB_JOB:-?} run=${GITHUB_RUN_ID:-?} took=$(($(date +%s) - t0))s outcome=$outcome $detail"
+    exit 0
+}

--- a/scripts/ci/hooks/job-completed.sh
+++ b/scripts/ci/hooks/job-completed.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# ACTIONS_RUNNER_HOOK_JOB_COMPLETED — post-job janitor for the CI service
+# account (cleans up after the job that just finished; job-started.sh
+# catches anything this one couldn't see yet). Wired via the `.env` file in
+# each runner root; see scripts/ci/README.md, "Job hooks". All logic lives
+# in hook-lib.sh; this wrapper only names the phase.
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/ci/hooks/hook-lib.sh
+. "$HERE/hook-lib.sh"
+run_hook completed

--- a/scripts/ci/hooks/job-started.sh
+++ b/scripts/ci/hooks/job-started.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# ACTIONS_RUNNER_HOOK_JOB_STARTED — pre-job janitor for the CI service
+# account (safety net for residue a killed previous job left behind).
+# Wired via the `.env` file in each runner root; see scripts/ci/README.md,
+# "Job hooks". All logic lives in hook-lib.sh; this wrapper only names the
+# phase. Always exits 0: a non-zero exit here would fail the job.
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/ci/hooks/hook-lib.sh
+. "$HERE/hook-lib.sh"
+run_hook started

--- a/scripts/ci/migrate-runner-macos.sh
+++ b/scripts/ci/migrate-runner-macos.sh
@@ -1,0 +1,371 @@
+#!/bin/bash
+# Migrate one macOS GitHub Actions listener from the operator's account to
+# the dedicated CI service account (run with sudo from a repo checkout:
+# sudo scripts/ci/migrate-runner-macos.sh <listener-name>).
+#
+# One listener per invocation, so the fleet keeps capacity while each
+# migration soaks. The move preserves the runner's registration
+# (.runner/.credentials travel with the directory) — the runner keeps its
+# identity and name; nothing re-registers.
+#
+# What it does, in order:
+#   1. finds the listener's LaunchAgent under a /Users/<account> home and
+#      derives everything from it (label, runner root, owning account) —
+#      nothing host-specific is hardcoded;
+#   2. stops the LaunchAgent (launchctl bootout gui/<uid>/<label>), waits
+#      for the service tree to exit, and parks the agent plist in
+#      /etc/intendant-ci/migration/ for rollback;
+#   3. rewires /etc/intendant-ci/watchdog.conf (label moves from
+#      RUNNER_LABELS to RUNNER_DAEMON_LABELS, CI cache root + account are
+#      added) so a watchdog tick can neither resurrect the old agent nor
+#      miss the new daemon;
+#   4. moves the runner directory into the CI account's home, chowns it,
+#      remaps .path onto the CI home, and wires the job hooks into .env;
+#   5. writes a LaunchDaemon plist rendered from the runner's own
+#      bin/actions.runner.plist.template (the exact template svc.sh
+#      renders LaunchAgents from, so the load-bearing keys — runsvc.sh
+#      ProgramArguments, WorkingDirectory, RunAtLoad, log paths,
+#      ACTIONS_RUNNER_SVC=1, ProcessType Interactive, SessionCreate — stay
+#      in lockstep with the runner release), with UserName swapped to the
+#      CI account and HOME/USER injected into EnvironmentVariables (the
+#      one deliberate divergence: gui LaunchAgents inherit them from the
+#      login session, system LaunchDaemons get neither, and rustup/cargo
+#      need HOME); bootstraps it in the system domain;
+#   6. waits for the runner to report online (gh api, when available) and
+#      prints the rollback invocation.
+#
+# After migration the runner's own svc.sh no longer applies (it only
+# manages gui-domain LaunchAgents); control the listener with
+# `launchctl bootout|bootstrap system ...` or the fleet watchdog.
+set -euo pipefail
+
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+[ "$(id -u)" -eq 0 ] || die "run with sudo"
+[ "$(uname -s)" = "Darwin" ] || die "macOS only"
+
+LISTENER="${1:-}"
+[ -n "$LISTENER" ] || die "usage: sudo $0 <listener-name>   (the <name> in actions.runner.<org>-<repo>.<name>)"
+case "$LISTENER" in
+    */* | *[[:space:]]*) die "listener name must be a bare runner name" ;;
+esac
+
+CI_ACCOUNT="${INTENDANT_CI_ACCOUNT:-_intendant-ci}"
+WATCHDOG_CONF="/etc/intendant-ci/watchdog.conf"
+BACKUP_DIR="/etc/intendant-ci/migration"
+LIB_DIR="/usr/local/lib/intendant-ci"
+DAEMON_PLIST_DIR="/Library/LaunchDaemons"
+
+# ---- locate the listener ------------------------------------------------
+matches=""
+for plist in /Users/*/Library/LaunchAgents/actions.runner.*."$LISTENER".plist; do
+    if [ -f "$plist" ]; then
+        matches="$matches $plist"
+    fi
+done
+matches="${matches# }"
+[ -n "$matches" ] || die "no LaunchAgent actions.runner.*.$LISTENER.plist under any /Users/<account>/Library/LaunchAgents"
+case "$matches" in
+    *" "*) die "listener name '$LISTENER' matches more than one LaunchAgent: $matches" ;;
+esac
+AGENT_PLIST="$matches"
+
+LABEL="$(basename "$AGENT_PLIST" .plist)"
+OP_ACCOUNT="$(stat -f %Su "$AGENT_PLIST")"
+OP_UID="$(id -u "$OP_ACCOUNT")"
+OP_AGENTS_DIR="$(dirname "$AGENT_PLIST")"
+RUNNER_ROOT="$(/usr/libexec/PlistBuddy -c 'Print :WorkingDirectory' "$AGENT_PLIST")"
+[ -d "$RUNNER_ROOT" ] || die "runner root $RUNNER_ROOT (from the plist WorkingDirectory) does not exist"
+[ -f "$RUNNER_ROOT/.runner" ] || die "$RUNNER_ROOT has no .runner registration file"
+
+dscl . -read "/Users/$CI_ACCOUNT" UniqueID >/dev/null 2>&1 \
+    || die "account $CI_ACCOUNT does not exist — run setup-ci-account-macos.sh first"
+CI_HOME="$(dscl . -read "/Users/$CI_ACCOUNT" NFSHomeDirectory | awk '{print $2}')"
+CI_GROUP="$(id -gn "$CI_ACCOUNT")"
+[ -x "$CI_HOME/.cargo/bin/rustc" ] || die "$CI_ACCOUNT has no toolchain — run setup-ci-account-macos.sh first"
+[ -x "$LIB_DIR/hooks/job-started.sh" ] || die "job hooks not installed — run setup-ci-account-macos.sh first"
+
+DEST="$CI_HOME/$(basename "$RUNNER_ROOT")"
+DAEMON_PLIST="$DAEMON_PLIST_DIR/$LABEL.plist"
+[ ! -e "$DEST" ] || die "$DEST already exists — refusing to overwrite"
+[ ! -e "$DAEMON_PLIST" ] || die "$DAEMON_PLIST already exists — is $LISTENER already migrated?"
+
+# Refuse to move a runner mid-job: Runner.Worker only exists while a job
+# executes, and both the Worker and the Listener are spawned by absolute
+# path, so the root shows up verbatim in their command lines.
+if ps -axo command= | grep -F "$RUNNER_ROOT/bin/Runner.Worker" | grep -qv grep; then
+    die "a job is running on $LISTENER (Runner.Worker alive) — retry when idle"
+fi
+
+echo "migrating listener: $LISTENER"
+echo "  label:        $LABEL"
+echo "  from:         $RUNNER_ROOT ($OP_ACCOUNT, uid $OP_UID)"
+echo "  to:           $DEST ($CI_ACCOUNT)"
+echo "  LaunchDaemon: $DAEMON_PLIST"
+
+install -d -m 0755 "$BACKUP_DIR"
+
+# ---- stop the LaunchAgent ------------------------------------------------
+launchctl bootout "gui/$OP_UID/$LABEL" 2>/dev/null \
+    && echo "stopped LaunchAgent $LABEL" \
+    || echo "LaunchAgent $LABEL was not running"
+
+# Wait for the whole service tree to exit before moving the directory.
+# runsvc.sh / Runner.Listener / Runner.Worker carry the absolute root in
+# their command lines; the node middleman (RunnerService.js) is spawned
+# relative but keeps the root as its cwd — check both.
+tree_alive() {
+    ps -axo command= | grep -F "$RUNNER_ROOT/" | grep -qv grep && return 0
+    lsof -a -u "$OP_ACCOUNT" -d cwd 2>/dev/null \
+        | awk -v r="$RUNNER_ROOT" '$NF == r || index($NF, r "/") == 1 { found = 1 } END { exit !found }'
+}
+waited=0
+while tree_alive; do
+    [ "$waited" -lt 60 ] || die "runner processes still alive under $RUNNER_ROOT after ${waited}s — aborting (nothing moved)"
+    sleep 2
+    waited=$((waited + 2))
+done
+
+mv "$AGENT_PLIST" "$BACKUP_DIR/$LABEL.launchagent.plist"
+echo "parked LaunchAgent plist in $BACKUP_DIR"
+
+# ---- rewire the watchdog BEFORE the move ---------------------------------
+# (so a tick during the move can't bootstrap the parked agent; if the move
+# aborts, rollback-runner-macos.sh restores the entries.)
+conf_get() {
+    # shellcheck disable=SC1090 # host conf, root-owned
+    ( . "$WATCHDOG_CONF" 2>/dev/null; eval "printf '%s' \"\${$1:-}\"" )
+}
+conf_set() {
+    local key="$1" val="$2"
+    if grep -q "^${key}=" "$WATCHDOG_CONF"; then
+        sed -i '' "s|^${key}=.*|${key}=\"${val}\"|" "$WATCHDOG_CONF"
+    else
+        printf '%s="%s"\n' "$key" "$val" >> "$WATCHDOG_CONF"
+    fi
+}
+list_remove() {
+    local out="" w
+    for w in $1; do
+        [ "$w" = "$2" ] || out="$out $w"
+    done
+    printf '%s' "${out# }"
+}
+list_add() {
+    local w
+    for w in $1; do
+        if [ "$w" = "$2" ]; then
+            printf '%s' "$1"
+            return 0
+        fi
+    done
+    if [ -n "$1" ]; then
+        printf '%s %s' "$1" "$2"
+    else
+        printf '%s' "$2"
+    fi
+}
+if [ -f "$WATCHDOG_CONF" ]; then
+    cp -p "$WATCHDOG_CONF" "$BACKUP_DIR/watchdog.conf.before-migrate-$LISTENER"
+    conf_set RUNNER_LABELS "$(list_remove "$(conf_get RUNNER_LABELS)" "$LABEL")"
+    conf_set RUNNER_DAEMON_LABELS "$(list_add "$(conf_get RUNNER_DAEMON_LABELS)" "$LABEL")"
+    conf_set RUNNER_DAEMON_PLIST_DIR "$DAEMON_PLIST_DIR"
+    conf_set CACHE_ROOTS "$(list_add "$(conf_get CACHE_ROOTS)" "$CI_HOME/.cache/intendant-ci/target")"
+    conf_set RUNNER_USER "$(list_add "$(conf_get RUNNER_USER)" "$CI_ACCOUNT")"
+    echo "rewired $WATCHDOG_CONF (LaunchDaemon label, CI cache root, CI account)"
+    echo "  note: the old cache root stays listed — the watchdog prunes its stale keys away on its own"
+else
+    echo "note: $WATCHDOG_CONF not found — skipping watchdog rewiring (install-watchdog-macos.sh not run?)"
+fi
+
+# ---- move the runner directory -------------------------------------------
+mv "$RUNNER_ROOT" "$DEST"
+chown -R "$CI_ACCOUNT:$CI_GROUP" "$DEST"
+echo "moved runner dir (registration files travel with it — identity preserved)"
+
+for f in .path .env .service; do
+    if [ -f "$DEST/$f" ]; then
+        cp -p "$DEST/$f" "$BACKUP_DIR/$LABEL$f"
+    fi
+done
+
+# .path is the PATH runsvc.sh exports to the listener (and thus to every
+# job step). Remap segments under the old home onto the CI home; keep the
+# rest (homebrew, system paths) verbatim.
+OP_HOME="$(dscl . -read "/Users/$OP_ACCOUNT" NFSHomeDirectory | awk '{print $2}')"
+if [ -f "$DEST/.path" ]; then
+    old_path="$(cat "$DEST/.path")"
+else
+    old_path="$OP_HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+fi
+new_path=""
+old_ifs="$IFS"
+IFS=':'
+for seg in $old_path; do
+    case "$seg" in
+        "$OP_HOME"/*) seg="$CI_HOME${seg#"$OP_HOME"}" ;;
+        "$OP_HOME") seg="$CI_HOME" ;;
+    esac
+    new_path="${new_path:+$new_path:}$seg"
+done
+IFS="$old_ifs"
+# (trailing newline for fidelity with env.sh's `echo $PATH>.path`)
+printf '%s\n' "$new_path" > "$DEST/.path"
+chown "$CI_ACCOUNT:$CI_GROUP" "$DEST/.path"
+echo "remapped .path: $new_path"
+
+# Job hooks (GitHub reads .env at listener startup; the daemon bootstrap
+# below is that startup).
+set_env_kv() {
+    local env_file="$1" key="$2" val="$3"
+    touch "$env_file"
+    if grep -q "^${key}=" "$env_file"; then
+        sed -i '' "s|^${key}=.*|${key}=${val}|" "$env_file"
+    else
+        printf '%s=%s\n' "$key" "$val" >> "$env_file"
+    fi
+}
+set_env_kv "$DEST/.env" ACTIONS_RUNNER_HOOK_JOB_STARTED "$LIB_DIR/hooks/job-started.sh"
+set_env_kv "$DEST/.env" ACTIONS_RUNNER_HOOK_JOB_COMPLETED "$LIB_DIR/hooks/job-completed.sh"
+chown "$CI_ACCOUNT:$CI_GROUP" "$DEST/.env"
+echo "wired job hooks into .env"
+
+# ---- write + bootstrap the LaunchDaemon ----------------------------------
+install -d -o "$CI_ACCOUNT" -g "$CI_GROUP" -m 0755 "$CI_HOME/Library/Logs/$LABEL"
+
+TEMPLATE="$DEST/bin/actions.runner.plist.template"
+if [ -f "$TEMPLATE" ]; then
+    # Same substitution svc.sh performs, so the daemon inherits whatever
+    # keys the installed runner release considers load-bearing.
+    sed -e "s|{{User}}|$CI_ACCOUNT|g" \
+        -e "s|{{SvcName}}|$LABEL|g" \
+        -e "s|{{RunnerRoot}}|$DEST|g" \
+        -e "s|{{UserHome}}|$CI_HOME|g" \
+        "$TEMPLATE" > "$DAEMON_PLIST.tmp"
+else
+    # Fallback replica of the runner's template (actions/runner as of
+    # 2026-07: src/Misc/layoutbin/actions.runner.plist.template) in case a
+    # future release drops it. Keep in lockstep if the template changes.
+    echo "note: $TEMPLATE missing — writing the vendored replica"
+    cat > "$DAEMON_PLIST.tmp" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>$LABEL</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>$DEST/runsvc.sh</string>
+    </array>
+    <key>UserName</key>
+    <string>$CI_ACCOUNT</string>
+    <key>WorkingDirectory</key>
+    <string>$DEST</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>$CI_HOME/Library/Logs/$LABEL/stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>$CI_HOME/Library/Logs/$LABEL/stderr.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>ACTIONS_RUNNER_SVC</key>
+      <string>1</string>
+    </dict>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>SessionCreate</key>
+    <true/>
+  </dict>
+</plist>
+PLIST_EOF
+fi
+
+# The one deliberate divergence from the template: gui-domain LaunchAgents
+# inherit HOME/USER from the login session, but system-domain LaunchDaemons
+# get neither — and without HOME the rustup shims, cargo, and the job hooks
+# have no anchor. Inject them explicitly.
+add_env() {
+    /usr/libexec/PlistBuddy -c "Add :EnvironmentVariables:$1 string $2" "$DAEMON_PLIST.tmp" 2>/dev/null \
+        || /usr/libexec/PlistBuddy -c "Set :EnvironmentVariables:$1 $2" "$DAEMON_PLIST.tmp"
+}
+/usr/libexec/PlistBuddy -c "Add :EnvironmentVariables dict" "$DAEMON_PLIST.tmp" 2>/dev/null || true
+add_env HOME "$CI_HOME"
+add_env USER "$CI_ACCOUNT"
+
+plutil -lint "$DAEMON_PLIST.tmp" >/dev/null || die "generated plist failed plutil -lint: $DAEMON_PLIST.tmp"
+mv "$DAEMON_PLIST.tmp" "$DAEMON_PLIST"
+chown root:wheel "$DAEMON_PLIST"
+chmod 0644 "$DAEMON_PLIST"
+
+# .service is svc.sh's pointer; svc.sh can no longer manage this listener,
+# but the file should point at the truth for whoever reads it.
+printf '%s\n' "$DAEMON_PLIST" > "$DEST/.service"
+chown "$CI_ACCOUNT:$CI_GROUP" "$DEST/.service"
+
+launchctl bootout "system/$LABEL" 2>/dev/null || true
+launchctl bootstrap system "$DAEMON_PLIST"
+echo "bootstrapped $LABEL in the system domain"
+
+# ---- wait for the listener to report online ------------------------------
+ORG_REPO="$(sed -n 's|.*"gitHubUrl": *"https://github.com/\([^"]*\)".*|\1|p' "$DEST/.runner" | head -1)"
+ORG_REPO="${ORG_REPO%/}"
+VERIFY_CMD="gh api repos/$ORG_REPO/actions/runners --paginate --jq '.runners[] | select(.name==\"$LISTENER\") | .status'"
+# gh auth lives with the invoking operator; sudo's secure_path usually
+# lacks the homebrew prefix, so resolve the binary explicitly.
+GH_BIN=""
+for cand in /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh; do
+    if [ -x "$cand" ]; then
+        GH_BIN="$cand"
+        break
+    fi
+done
+status=""
+if [ -n "${SUDO_USER:-}" ] && [ -n "$GH_BIN" ] && [ -n "$ORG_REPO" ]; then
+    echo "waiting for $LISTENER to report online..."
+    for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24; do
+        status="$(sudo -u "$SUDO_USER" -H "$GH_BIN" api "repos/$ORG_REPO/actions/runners" --paginate \
+            --jq ".runners[] | select(.name==\"$LISTENER\") | .status" 2>/dev/null | head -1 || true)"
+        if [ "$status" = "online" ]; then
+            break
+        fi
+        sleep 5
+    done
+    if [ "$status" = "online" ]; then
+        echo "listener $LISTENER is ONLINE as $CI_ACCOUNT"
+    else
+        echo "listener not online yet (last status: '${status:-unknown}') — check:"
+        echo "  $VERIFY_CMD"
+        echo "  tail -f $CI_HOME/Library/Logs/$LABEL/stderr.log"
+    fi
+else
+    echo "gh not available for ${SUDO_USER:-<no SUDO_USER>} — verify manually:"
+    echo "  $VERIFY_CMD"
+    echo "  tail -f $CI_HOME/Library/Logs/$LABEL/stderr.log"
+fi
+
+# ---- record rollback metadata --------------------------------------------
+cat > "$BACKUP_DIR/$LABEL.meta" <<META_EOF
+# written by migrate-runner-macos.sh — consumed by rollback-runner-macos.sh
+LABEL="$LABEL"
+LISTENER="$LISTENER"
+OP_ACCOUNT="$OP_ACCOUNT"
+OP_UID="$OP_UID"
+OP_HOME="$OP_HOME"
+OP_AGENTS_DIR="$OP_AGENTS_DIR"
+ORIG_ROOT="$RUNNER_ROOT"
+DEST="$DEST"
+CI_ACCOUNT="$CI_ACCOUNT"
+CI_HOME="$CI_HOME"
+MIGRATED_AT="$(date '+%Y-%m-%dT%H:%M:%S%z')"
+META_EOF
+chmod 0644 "$BACKUP_DIR/$LABEL.meta"
+
+echo
+echo "migration of $LISTENER complete."
+echo "watch a canary job before migrating the next listener."
+echo "rollback: sudo scripts/ci/rollback-runner-macos.sh $LISTENER"

--- a/scripts/ci/rollback-runner-macos.sh
+++ b/scripts/ci/rollback-runner-macos.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# Roll one migrated macOS listener back to the operator account (run with
+# sudo from a repo checkout: sudo scripts/ci/rollback-runner-macos.sh
+# <listener-name>). Exact inverse of migrate-runner-macos.sh, driven by the
+# metadata that script parked in /etc/intendant-ci/migration/:
+#
+#   1. bootout the LaunchDaemon and wait for the service tree to exit;
+#   2. move the runner directory back to its original path and chown it to
+#      the operator account (registration files travel back — identity
+#      preserved);
+#   3. restore the saved .path/.env/.service;
+#   4. restore the original LaunchAgent plist and bootstrap it in the
+#      operator's gui domain (deferred to next login when no gui session);
+#   5. restore the watchdog.conf entries (label back to RUNNER_LABELS; the
+#      CI account and its cache root drop out once no daemon listener
+#      remains).
+set -euo pipefail
+
+die() {
+    echo "error: $*" >&2
+    exit 1
+}
+
+[ "$(id -u)" -eq 0 ] || die "run with sudo"
+[ "$(uname -s)" = "Darwin" ] || die "macOS only"
+
+LISTENER="${1:-}"
+[ -n "$LISTENER" ] || die "usage: sudo $0 <listener-name>"
+case "$LISTENER" in
+    */* | *[[:space:]]*) die "listener name must be a bare runner name" ;;
+esac
+
+WATCHDOG_CONF="/etc/intendant-ci/watchdog.conf"
+BACKUP_DIR="/etc/intendant-ci/migration"
+
+# ---- locate the migration record -----------------------------------------
+metas=""
+for meta in "$BACKUP_DIR"/actions.runner.*."$LISTENER".meta; do
+    if [ -f "$meta" ]; then
+        metas="$metas $meta"
+    fi
+done
+metas="${metas# }"
+[ -n "$metas" ] || die "no migration record for '$LISTENER' in $BACKUP_DIR — was it migrated by migrate-runner-macos.sh?"
+case "$metas" in
+    *" "*) die "'$LISTENER' matches more than one migration record: $metas" ;;
+esac
+META="$metas"
+
+# Root-owned metadata written by migrate-runner-macos.sh.
+LABEL="" OP_ACCOUNT="" OP_UID="" OP_AGENTS_DIR="" ORIG_ROOT="" DEST="" CI_ACCOUNT="" CI_HOME=""
+# shellcheck disable=SC1090
+. "$META"
+for var in LABEL OP_ACCOUNT OP_UID OP_AGENTS_DIR ORIG_ROOT DEST CI_ACCOUNT CI_HOME; do
+    eval "val=\"\${$var:-}\""
+    [ -n "$val" ] || die "migration record $META is missing $var"
+done
+
+DAEMON_PLIST="/Library/LaunchDaemons/$LABEL.plist"
+AGENT_BACKUP="$BACKUP_DIR/$LABEL.launchagent.plist"
+[ -d "$DEST" ] || die "migrated runner dir $DEST does not exist"
+[ ! -e "$ORIG_ROOT" ] || die "original path $ORIG_ROOT is occupied — refusing to overwrite"
+[ -f "$AGENT_BACKUP" ] || die "parked LaunchAgent plist $AGENT_BACKUP is missing"
+
+if ps -axo command= | grep -F "$DEST/bin/Runner.Worker" | grep -qv grep; then
+    die "a job is running on $LISTENER (Runner.Worker alive) — retry when idle"
+fi
+
+echo "rolling back listener: $LISTENER"
+echo "  label: $LABEL"
+echo "  from:  $DEST ($CI_ACCOUNT)"
+echo "  to:    $ORIG_ROOT ($OP_ACCOUNT, uid $OP_UID)"
+
+# ---- stop the LaunchDaemon ------------------------------------------------
+launchctl bootout "system/$LABEL" 2>/dev/null \
+    && echo "stopped LaunchDaemon $LABEL" \
+    || echo "LaunchDaemon $LABEL was not running"
+
+tree_alive() {
+    ps -axo command= | grep -F "$DEST/" | grep -qv grep && return 0
+    lsof -a -u "$CI_ACCOUNT" -d cwd 2>/dev/null \
+        | awk -v r="$DEST" '$NF == r || index($NF, r "/") == 1 { found = 1 } END { exit !found }'
+}
+waited=0
+while tree_alive; do
+    [ "$waited" -lt 60 ] || die "runner processes still alive under $DEST after ${waited}s — aborting (nothing moved)"
+    sleep 2
+    waited=$((waited + 2))
+done
+
+rm -f "$DAEMON_PLIST"
+
+# ---- move the runner directory back ---------------------------------------
+mv "$DEST" "$ORIG_ROOT"
+OP_GROUP="$(id -gn "$OP_ACCOUNT")"
+chown -R "$OP_ACCOUNT:$OP_GROUP" "$ORIG_ROOT"
+echo "moved runner dir back (registration preserved)"
+
+# True inverse: restore each dotfile from its backup, or remove it when the
+# original runner had none (migrate writes .path/.env/.service either way).
+for f in .path .env .service; do
+    if [ -f "$BACKUP_DIR/$LABEL$f" ]; then
+        cp -p "$BACKUP_DIR/$LABEL$f" "$ORIG_ROOT/$f"
+        chown "$OP_ACCOUNT:$OP_GROUP" "$ORIG_ROOT/$f"
+    else
+        rm -f "$ORIG_ROOT/$f"
+    fi
+done
+echo "restored .path/.env/.service"
+
+# ---- restore the LaunchAgent ----------------------------------------------
+install -d -o "$OP_ACCOUNT" -g "$OP_GROUP" "$OP_AGENTS_DIR"
+AGENT_PLIST="$OP_AGENTS_DIR/$LABEL.plist"
+cp -p "$AGENT_BACKUP" "$AGENT_PLIST"
+chown "$OP_ACCOUNT:$OP_GROUP" "$AGENT_PLIST"
+chmod 0644 "$AGENT_PLIST"
+
+# ---- restore the watchdog entries -----------------------------------------
+conf_get() {
+    # shellcheck disable=SC1090 # host conf, root-owned
+    ( . "$WATCHDOG_CONF" 2>/dev/null; eval "printf '%s' \"\${$1:-}\"" )
+}
+conf_set() {
+    local key="$1" val="$2"
+    if grep -q "^${key}=" "$WATCHDOG_CONF"; then
+        sed -i '' "s|^${key}=.*|${key}=\"${val}\"|" "$WATCHDOG_CONF"
+    else
+        printf '%s="%s"\n' "$key" "$val" >> "$WATCHDOG_CONF"
+    fi
+}
+list_remove() {
+    local out="" w
+    for w in $1; do
+        [ "$w" = "$2" ] || out="$out $w"
+    done
+    printf '%s' "${out# }"
+}
+list_add() {
+    local w
+    for w in $1; do
+        if [ "$w" = "$2" ]; then
+            printf '%s' "$1"
+            return 0
+        fi
+    done
+    if [ -n "$1" ]; then
+        printf '%s %s' "$1" "$2"
+    else
+        printf '%s' "$2"
+    fi
+}
+if [ -f "$WATCHDOG_CONF" ]; then
+    cp -p "$WATCHDOG_CONF" "$BACKUP_DIR/watchdog.conf.before-rollback-$LISTENER"
+    conf_set RUNNER_DAEMON_LABELS "$(list_remove "$(conf_get RUNNER_DAEMON_LABELS)" "$LABEL")"
+    conf_set RUNNER_LABELS "$(list_add "$(conf_get RUNNER_LABELS)" "$LABEL")"
+    conf_set RUNNER_UID "$OP_UID"
+    conf_set RUNNER_PLIST_DIR "$OP_AGENTS_DIR"
+    conf_set RUNNER_USER "$(list_add "$(conf_get RUNNER_USER)" "$OP_ACCOUNT")"
+    if [ -z "$(conf_get RUNNER_DAEMON_LABELS)" ]; then
+        # Last daemon listener gone: the CI account and its cache root drop
+        # out of the watchdog's purview.
+        conf_set RUNNER_USER "$(list_remove "$(conf_get RUNNER_USER)" "$CI_ACCOUNT")"
+        conf_set CACHE_ROOTS "$(list_remove "$(conf_get CACHE_ROOTS)" "$CI_HOME/.cache/intendant-ci/target")"
+    fi
+    echo "restored watchdog.conf entries"
+else
+    echo "note: $WATCHDOG_CONF not found — skipping watchdog rewiring"
+fi
+
+# ---- start the LaunchAgent -------------------------------------------------
+if launchctl bootstrap "gui/$OP_UID" "$AGENT_PLIST" 2>/dev/null; then
+    echo "bootstrapped LaunchAgent $LABEL in gui/$OP_UID"
+else
+    echo "could not bootstrap gui/$OP_UID (no gui session for $OP_ACCOUNT?) —"
+    echo "the LaunchAgent will start at $OP_ACCOUNT's next login, or run:"
+    echo "  launchctl bootstrap gui/$OP_UID $AGENT_PLIST"
+fi
+
+# Consume the migration record (the backups it points to were restored).
+rm -f "$META" "$AGENT_BACKUP" "$BACKUP_DIR/$LABEL.path" "$BACKUP_DIR/$LABEL.env" "$BACKUP_DIR/$LABEL.service"
+
+ORG_REPO="$(sed -n 's|.*"gitHubUrl": *"https://github.com/\([^"]*\)".*|\1|p' "$ORIG_ROOT/.runner" | head -1 || true)"
+ORG_REPO="${ORG_REPO%/}"
+echo
+echo "rollback of $LISTENER complete."
+if [ -n "$ORG_REPO" ]; then
+    echo "verify: gh api repos/$ORG_REPO/actions/runners --paginate --jq '.runners[] | select(.name==\"$LISTENER\") | .status'"
+fi

--- a/scripts/ci/setup-ci-account-macos.sh
+++ b/scripts/ci/setup-ci-account-macos.sh
@@ -1,0 +1,320 @@
+#!/bin/bash
+# Create the dedicated macOS CI service account and provision its per-user
+# toolchain (run with sudo from a repo checkout:
+# sudo scripts/ci/setup-ci-account-macos.sh).
+#
+# Why: CI jobs executing as the operator's own account can read everything
+# the operator can (~/.ssh, .env API keys, gh tokens, session stores) and
+# inherit the operator's TCC grants. The Dell and Windows runners already
+# run as dedicated non-admin ci users; this brings the Mac to parity.
+# Migration of the listeners themselves is a separate, per-listener step
+# (migrate-runner-macos.sh) — this script only prepares the account.
+#
+# Idempotent: re-running upgrades the job hooks and converges the toolchain
+# pin; it never recreates an existing account and never overwrites an
+# existing ~/.cargo/config.toml.
+#
+# The repo is public: this script auto-detects every host specific at run
+# time and hardcodes none (the one committed name is the generic account
+# `_intendant-ci` itself).
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "run with sudo" >&2
+    exit 1
+fi
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo "macOS only (Linux hosts already run a dedicated ci user)" >&2
+    exit 1
+fi
+
+CI_ACCOUNT="${INTENDANT_CI_ACCOUNT:-_intendant-ci}"
+# Home placement: role accounts conventionally live OUTSIDE /Users (cf.
+# Apple's own daemon accounts under /var/*). A /Users home implies a human
+# loginwindow account — Spotlight indexing, user-template contents, showing
+# up in sharing/backup surfaces — none of which a headless CI principal
+# should have. /var/ci is on the Data volume (same free-space pool the
+# watchdog measures), short (kind to unix-socket path limits in tests), and
+# clearly machine-scoped.
+CI_HOME="${INTENDANT_CI_HOME:-/var/ci}"
+LIB_DIR="/usr/local/lib/intendant-ci"
+HOOKS_LOG="/var/log/intendant-ci-hooks.log"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+
+# Run a command as the CI account with its own HOME and a deterministic
+# PATH (the account has no login shell profile to lean on).
+ci_run() {
+    sudo -u "$CI_ACCOUNT" -H env HOME="$CI_HOME" \
+        PATH="$CI_HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        "$@"
+}
+
+echo "== account"
+if dscl . -read "/Users/$CI_ACCOUNT" UniqueID >/dev/null 2>&1; then
+    echo "account $CI_ACCOUNT already exists — leaving it as is"
+else
+    # Free UID in Apple's role-account range (sysadminctl -roleAccount
+    # requires the underscore prefix and a 200-400 UID). One dscl snapshot,
+    # then a pure-shell scan.
+    used_uids="$(dscl . -list /Users UniqueID | awk '{print $2}')"
+    uid=""
+    for candidate in $(seq 200 400); do
+        if ! printf '%s\n' "$used_uids" | grep -qx "$candidate"; then
+            uid="$candidate"
+            break
+        fi
+    done
+    if [ -z "$uid" ]; then
+        echo "no free role-account UID in 200-400" >&2
+        exit 1
+    fi
+    # Dedicated primary group (NOT staff, NOT admin); prefer gid == uid.
+    used_gids="$(dscl . -list /Groups PrimaryGroupID | awk '{print $2}')"
+    gid=""
+    for candidate in "$uid" $(seq 200 400); do
+        if ! printf '%s\n' "$used_gids" | grep -qx "$candidate"; then
+            gid="$candidate"
+            break
+        fi
+    done
+    if [ -z "$gid" ]; then
+        echo "no free role-account GID in 200-400" >&2
+        exit 1
+    fi
+    if ! dseditgroup -o read "$CI_ACCOUNT" >/dev/null 2>&1; then
+        dseditgroup -o create -i "$gid" -r "Intendant CI" "$CI_ACCOUNT"
+    fi
+    echo "creating role account $CI_ACCOUNT (uid $uid, gid $gid, home $CI_HOME)"
+    # -roleAccount: hidden service account semantics. No -password: the
+    # account gets no password material, so password login is impossible.
+    sysadminctl -addUser "$CI_ACCOUNT" -roleAccount -UID "$uid" -GID "$gid" \
+        -fullName "Intendant CI" -home "$CI_HOME" -shell /bin/bash
+    # Belt and braces (role accounts are already hidden by UID range):
+    dscl . -create "/Users/$CI_ACCOUNT" IsHidden 1
+fi
+
+CI_GROUP="$(id -gn "$CI_ACCOUNT")"
+
+echo "== home"
+# Deliberately NOT createhomedir: a headless account needs none of the user
+# template, and an otherwise-empty home keeps the hermeticity canary signal
+# clean (anything that appears in it was put there by a job).
+for dir in "$CI_HOME" \
+    "$CI_HOME/.cache" \
+    "$CI_HOME/.cache/intendant-ci" \
+    "$CI_HOME/.cache/intendant-ci/target" \
+    "$CI_HOME/Library" \
+    "$CI_HOME/Library/Logs"; do
+    install -d -o "$CI_ACCOUNT" -g "$CI_GROUP" -m 0750 "$dir"
+done
+
+echo "== rust toolchain"
+# Pin = whatever the invoking host currently builds with. The workflows key
+# the external cargo target caches by `rustc -V`, so pinning the same
+# toolchain keeps one warm cache lineage per listener across the migration.
+PIN="${INTENDANT_CI_RUST_VERSION:-}"
+HOST_RUSTC_LINE=""
+if [ -z "$PIN" ]; then
+    inv="${SUDO_USER:-}"
+    if [ -n "$inv" ]; then
+        inv_home="$(dscl . -read "/Users/$inv" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
+        for cand in "${inv_home:-/nonexistent}/.cargo/bin/rustc" /opt/homebrew/bin/rustc /usr/local/bin/rustc; do
+            if [ -x "$cand" ]; then
+                # rustup shims resolve their toolchain from $HOME — run as
+                # the invoking user so the shim sees theirs.
+                HOST_RUSTC_LINE="$(sudo -u "$inv" -H "$cand" -V 2>/dev/null || true)"
+                if [ -n "$HOST_RUSTC_LINE" ]; then
+                    break
+                fi
+            fi
+        done
+        if [ -z "$HOST_RUSTC_LINE" ]; then
+            HOST_RUSTC_LINE="$(sudo -u "$inv" -H bash -lc 'rustc -V' 2>/dev/null || true)"
+        fi
+    fi
+    if [ -z "$HOST_RUSTC_LINE" ]; then
+        echo "could not detect the host toolchain (no rustc for ${inv:-<no SUDO_USER>});" >&2
+        echo "re-run with INTENDANT_CI_RUST_VERSION=<x.y.z> sudo -E $0" >&2
+        exit 1
+    fi
+    PIN="$(echo "$HOST_RUSTC_LINE" | awk '{print $2}')"
+    case "$PIN" in
+        *nightly* | *beta* | *dev*)
+            echo "host toolchain '$HOST_RUSTC_LINE' is not a plain stable version;" >&2
+            echo "re-run with an explicit INTENDANT_CI_RUST_VERSION=<toolchain>" >&2
+            exit 1
+            ;;
+    esac
+fi
+echo "host toolchain: ${HOST_RUSTC_LINE:-<explicit override>} -> pinning $PIN for $CI_ACCOUNT"
+
+if [ -x "$CI_HOME/.cargo/bin/rustup" ]; then
+    echo "rustup already installed for $CI_ACCOUNT"
+else
+    installer="$CI_HOME/.rustup-init.sh"
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o "$installer"
+    chmod 0644 "$installer"
+    ci_run sh "$installer" -y --no-modify-path --profile default --default-toolchain "$PIN"
+    rm -f "$installer"
+fi
+# Converge on re-runs (the host toolchain may have moved since first setup).
+ci_run "$CI_HOME/.cargo/bin/rustup" toolchain install "$PIN" --profile default
+ci_run "$CI_HOME/.cargo/bin/rustup" default "$PIN"
+
+echo "== cargo config"
+CARGO_CONFIG="$CI_HOME/.cargo/config.toml"
+if [ -f "$CARGO_CONFIG" ]; then
+    echo "keeping existing $CARGO_CONFIG"
+else
+    # Account-level jobs cap (scripts/ci/README.md, "Cargo parallelism
+    # cap"): mirror the operator account's cap when one is set so the two
+    # accounts obey the same doctrine, else the documented default.
+    jobs=""
+    if [ -n "${SUDO_USER:-}" ]; then
+        inv_home="$(dscl . -read "/Users/${SUDO_USER}" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
+        if [ -n "$inv_home" ] && [ -f "$inv_home/.cargo/config.toml" ]; then
+            jobs="$(awk -F= '/^[[:space:]]*jobs[[:space:]]*=/ {gsub(/[^0-9]/, "", $2); print $2; exit}' \
+                "$inv_home/.cargo/config.toml" 2>/dev/null || true)"
+        fi
+    fi
+    jobs="${jobs:-6}"
+    sccache_bin=""
+    for cand in /opt/homebrew/bin/sccache /usr/local/bin/sccache; do
+        if [ -x "$cand" ]; then
+            sccache_bin="$cand"
+            break
+        fi
+    done
+    {
+        echo "# Account-level cargo cap — scripts/ci/README.md, \"Cargo parallelism cap\"."
+        echo "[build]"
+        echo "jobs = $jobs"
+        if [ -n "$sccache_bin" ]; then
+            echo "rustc-wrapper = \"$sccache_bin\""
+        fi
+    } > "$CARGO_CONFIG"
+    chown "$CI_ACCOUNT:$CI_GROUP" "$CARGO_CONFIG"
+    chmod 0644 "$CARGO_CONFIG"
+    if [ -n "$sccache_bin" ]; then
+        echo "seeded $CARGO_CONFIG (jobs = $jobs, rustc-wrapper = $sccache_bin)"
+    else
+        echo "seeded $CARGO_CONFIG (jobs = $jobs; no sccache on this host, wrapper omitted)"
+    fi
+fi
+
+echo "== wasm-pack"
+# Same convention as scripts/setup-macos.sh: cargo install pinned by the
+# repo's .wasm-pack-version (build.rs skips WASM rebuilds under any other
+# version). Non-fatal: CI legs only need wasm-pack when a PR ships stale
+# committed WASM artifacts, so a failure here is a canary-visible gap, not
+# a setup blocker.
+WASM_PIN="$(tr -d '[:space:]' < "$REPO_ROOT/.wasm-pack-version")"
+installed="$(ci_run "$CI_HOME/.cargo/bin/wasm-pack" --version 2>/dev/null | cut -d' ' -f2 || true)"
+if [ "$installed" = "$WASM_PIN" ]; then
+    echo "wasm-pack $installed already pinned"
+else
+    echo "installing wasm-pack $WASM_PIN as $CI_ACCOUNT (cargo install — takes a few minutes)..."
+    force_flag=""
+    if [ -n "$installed" ]; then
+        force_flag="--force"
+    fi
+    if ! ci_run "$CI_HOME/.cargo/bin/cargo" install wasm-pack --version "$WASM_PIN" --locked $force_flag; then
+        echo "WARNING: wasm-pack install failed — CANARY-VISIBLE GAP: a job that" >&2
+        echo "needs a WASM rebuild (stale committed artifacts) will fail on this" >&2
+        echo "account until you re-run this script successfully." >&2
+    fi
+fi
+
+echo "== job hooks"
+install -d -m 0755 "$LIB_DIR" "$LIB_DIR/hooks"
+install -m 0755 "$HERE/hooks/job-started.sh" "$LIB_DIR/hooks/job-started.sh"
+install -m 0755 "$HERE/hooks/job-completed.sh" "$LIB_DIR/hooks/job-completed.sh"
+install -m 0644 "$HERE/hooks/hook-lib.sh" "$LIB_DIR/hooks/hook-lib.sh"
+# The hooks run as the CI account but log under /var/log — pre-create the
+# file so they can append without owning the directory.
+touch "$HOOKS_LOG"
+chown "$CI_ACCOUNT:$CI_GROUP" "$HOOKS_LOG"
+chmod 0644 "$HOOKS_LOG"
+echo "hooks installed to $LIB_DIR/hooks (log: $HOOKS_LOG)"
+
+# Idempotent .env wiring (GitHub reads the runner root's .env at listener
+# startup): a no-op on first setup — migrate-runner-macos.sh wires each
+# runner dir as it moves in — but a re-run after migration re-points
+# already-present dirs at upgraded hooks.
+set_env_kv() {
+    local env_file="$1" key="$2" val="$3"
+    touch "$env_file"
+    if grep -q "^${key}=" "$env_file"; then
+        sed -i '' "s|^${key}=.*|${key}=${val}|" "$env_file"
+    else
+        printf '%s=%s\n' "$key" "$val" >> "$env_file"
+    fi
+}
+for d in "$CI_HOME"/actions-runner-*/; do
+    [ -d "$d" ] || continue
+    set_env_kv "${d%/}/.env" ACTIONS_RUNNER_HOOK_JOB_STARTED "$LIB_DIR/hooks/job-started.sh"
+    set_env_kv "${d%/}/.env" ACTIONS_RUNNER_HOOK_JOB_COMPLETED "$LIB_DIR/hooks/job-completed.sh"
+    chown "$CI_ACCOUNT:$CI_GROUP" "${d%/}/.env"
+    echo "wired hooks into ${d%/}/.env (listener restart required to take effect)"
+done
+
+echo "== verification"
+fail=0
+id "$CI_ACCOUNT"
+
+if dseditgroup -o checkmember -m "$CI_ACCOUNT" admin 2>/dev/null | grep -q "^yes"; then
+    echo "FAIL: $CI_ACCOUNT is in admin" >&2
+    fail=1
+else
+    echo "ok: not in admin"
+fi
+if dseditgroup -o checkmember -m "$CI_ACCOUNT" staff 2>/dev/null | grep -q "^yes"; then
+    echo "FAIL: $CI_ACCOUNT is in staff" >&2
+    fail=1
+else
+    echo "ok: not in staff (primary group: $CI_GROUP)"
+fi
+
+auth_auth="$(dscl . -read "/Users/$CI_ACCOUNT" AuthenticationAuthority 2>/dev/null || true)"
+if echo "$auth_auth" | grep -q "ShadowHash"; then
+    echo "WARN: $CI_ACCOUNT has password material (AuthenticationAuthority: ShadowHash) — expected none" >&2
+else
+    echo "ok: no password login (no ShadowHash authority)"
+fi
+
+# (logical pwd: /var is a symlink to /private/var on macOS, so a physical
+# pwd would report /private/var/ci and false-fail the comparison)
+resolved_home="$(ci_run sh -c 'cd "$HOME" && pwd')"
+if [ "$resolved_home" = "$CI_HOME" ]; then
+    echo "ok: HOME resolves to $resolved_home"
+else
+    echo "FAIL: HOME resolves to '$resolved_home', expected $CI_HOME" >&2
+    fail=1
+fi
+
+# The privacy boundary this account exists for: it must not be able to
+# traverse any human home. Report only — fixing a too-open home is the
+# operator's call (expected mode: 700).
+for home in /Users/*; do
+    [ -d "$home" ] || continue
+    owner_uid="$(stat -f %u "$home" 2>/dev/null || echo 0)"
+    [ "$owner_uid" -ge 500 ] || continue
+    mode="$(stat -f %Lp "$home" 2>/dev/null || echo '?')"
+    if ci_run test -x "$home" 2>/dev/null; then
+        echo "WARN: $CI_ACCOUNT can traverse $home (mode $mode) — the privacy boundary wants: chmod 700 $home" >&2
+    else
+        echo "ok: $home not traversable (mode $mode)"
+    fi
+done
+
+echo "toolchain as $CI_ACCOUNT: $(ci_run rustc -V 2>/dev/null || echo 'rustc MISSING')"
+echo "wasm-pack as $CI_ACCOUNT: $(ci_run wasm-pack --version 2>/dev/null || echo 'MISSING (see gap warning above)')"
+echo "cargo config:"
+sed 's/^/    /' "$CARGO_CONFIG"
+
+if [ "$fail" -ne 0 ]; then
+    echo "verification FAILED — fix the failures above before migrating a listener" >&2
+    exit 1
+fi
+echo "account ready. Next: sudo scripts/ci/migrate-runner-macos.sh <listener-name>"

--- a/scripts/ci/watchdog.conf.example
+++ b/scripts/ci/watchdog.conf.example
@@ -23,15 +23,25 @@ STATE_DIR="/var/db/intendant-ci"        # /var/lib/intendant-ci on Linux
 LOG="/var/log/intendant-ci-watchdog.log"
 
 # Listener control.
-RUNNER_USER=""    # account the listeners run as
+# RUNNER_USER may list several accounts space-separated (mid-migration a
+# host runs LaunchAgent listeners as the operator and LaunchDaemon
+# listeners as the CI service account at the same time).
+RUNNER_USER=""    # account(s) the listeners run as
 
-# macOS (LaunchAgent listeners):
+# macOS (LaunchAgent listeners, gui domain):
 #RUNNER_UID=501
 #RUNNER_LABELS="actions.runner.<org>-<repo>.<runner-name> actions.runner.<org>-<repo>.<runner-name>-b"
 #RUNNER_PLIST_DIR="/Users/<runner-account>/Library/LaunchAgents"
 RUNNER_UID=""
 RUNNER_LABELS=""
 RUNNER_PLIST_DIR=""
+
+# macOS (LaunchDaemon listeners, system domain — the service-account shape
+# migrate-runner-macos.sh installs; it edits these lines itself):
+#RUNNER_DAEMON_LABELS="actions.runner.<org>-<repo>.<runner-name>"
+#RUNNER_DAEMON_PLIST_DIR="/Library/LaunchDaemons"
+RUNNER_DAEMON_LABELS=""
+RUNNER_DAEMON_PLIST_DIR="/Library/LaunchDaemons"
 
 # Linux (systemd listeners):
 #RUNNER_UNITS="actions.runner.<org>-<repo>.<runner-name>.service"


### PR DESCRIPTION
Wave 3 of the CI-hardening program: the versioned host kit that moves the two macOS runner listeners off the operator's account onto a dedicated `_intendant-ci` service account. **Nothing executes at land time — this PR is scripts + docs only; the host cutover is a separate operator action run from landed main.** Everything host-specific (accounts, homes, labels, org/repo) is auto-detected at run time; the only committed name is the generic `_intendant-ci`.

## What each piece does

- **`scripts/ci/setup-ci-account-macos.sh`** (root, idempotent) — creates the hidden role account via `sysadminctl -roleAccount` (UID auto-picked in 200–400, own primary group — not `staff`/`admin` — no password material, `IsHidden`), home at `/var/ci` (role accounts conventionally live outside `/Users`; an empty non-template home also keeps the hermeticity signal clean). Provisions the toolchain *as that account*: rustup pinned to the invoking host's current `rustc -V` (printed; keeps the workflows' `rustc -V`-keyed cache lineage stable), `~/.cargo/config.toml` with the account-level `jobs` cap (mirrors the operator's value, default 6) plus `rustc-wrapper = <sccache>` iff sccache exists at install time, and wasm-pack at the repo's `.wasm-pack-version` pin (install failure is a loud, canary-visible warning, not a blocker). Installs the job hooks and pre-creates their log. Verifies and prints: not in admin/staff, no password login, HOME resolves, and that the account **cannot traverse any human `/Users/<home>`** (expects 700; reports, never chmods).
- **`scripts/ci/migrate-runner-macos.sh <listener-name>`** (root, one listener per invocation) — stops the operator LaunchAgent (`launchctl bootout gui/<uid>/<label>`), waits for the service tree to exit (cmdline + cwd probes), parks the agent plist, moves the runner dir into `/var/ci` and chowns it (**`.runner`/`.credentials` travel with the dir — identity and name preserved, no re-registration**), remaps `.path` onto the CI home, wires the hooks into `.env`, renders a LaunchDaemon **from the runner's own `bin/actions.runner.plist.template`** (the exact template `svc.sh` renders LaunchAgents from, so the load-bearing keys — `runsvc.sh` ProgramArguments, WorkingDirectory, RunAtLoad, log paths, `ACTIONS_RUNNER_SVC=1`, ProcessType Interactive, `SessionCreate` — track the runner release; vendored replica as fallback) with `UserName` swapped and one deliberate divergence: `HOME`/`USER` injected into `EnvironmentVariables`, because system daemons inherit neither and rustup/cargo need `HOME`. Bootstraps in the system domain, polls `gh api .../actions/runners` for `online` when gh is available (prints the verification command otherwise), rewires `watchdog.conf` in the same run, records rollback metadata, and prints the rollback invocation.
- **`scripts/ci/rollback-runner-macos.sh <listener-name>`** (root) — exact metadata-driven inverse: bootout the daemon, wait for tree exit, move the dir back, chown, restore `.path`/`.env`/`.service` (or remove ones the original never had), restore + bootstrap the original LaunchAgent (deferred to next login when no gui session), restore the `watchdog.conf` entries (the CI account and its cache root drop out once no daemon listener remains).
- **`scripts/ci/hooks/`** (`job-started.sh` / `job-completed.sh` + shared `hook-lib.sh`) — wired via the runner-root `.env` (`ACTIONS_RUNNER_HOOK_JOB_STARTED/…_COMPLETED`, the documented mechanism). Bounded by a 60s self-timeout (watchdog subshell — GitHub applies none of its own): wipe `$RUNNER_TEMP` contents, reap stale (>24h) `$TMPDIR`/`~/.intendant` residue (per-account, shared with the other listener's live jobs — hence age-gated), and kill leftover CI-account processes by **ancestry** (no live runner tree owns them), explicitly protecting both listener stacks and the shared sccache server. One summary line per run to `/var/log/intendant-ci-hooks.log` (1MB rotation, truncate-in-place). Always exit 0 — a non-zero started hook fails the job.
- **`scripts/ci/fleet-watchdog.sh`** — extended for system-domain listeners: new `RUNNER_DAEMON_LABELS` / `RUNNER_DAEMON_PLIST_DIR` conf vars, and `RUNNER_USER` may now list several accounts (half-migrated hosts stay fully supervised). Backward compatible with the LaunchAgent form; `watchdog.conf.example` documents the new block.
- **`scripts/ci/README.md`** — new "macOS CI service account" section: privacy rationale, runbook (setup → migrate listener b → canary → migrate listener a → soak), canary expectations, rollback, deferred slices. **CLAUDE.md/AGENTS.md**: the "Dell and Windows runners run as dedicated non-admin ci users" sentence now covers the Mac joining via this kit.

## Canary expectations (fresh account: zero TCC grants, no WindowServer; `SessionCreate=true` gives a security session)

From a suite grep (2026-07-10):

| Class | Expectation |
|---|---|
| `access/certs.rs::p12_imports_via_real_macos_keychain`, `::p12_imports_via_security_cli_auto_detection` | **PASS — watch closest.** Real Keychain machinery against throwaway *file-backed* keychains in tempdirs (never the login keychain); needs securityd + a security session, not TCC/WindowServer. Regression signature: `errSecInteractionNotAllowed` / `security create-keychain` failure. |
| `sandbox.rs` seatbelt tests (3 spawn real `/usr/bin/sandbox-exec`) | PASS — Seatbelt needs no GUI or TCC. |
| `access/cert_server.rs::mobileconfig_profile_is_valid_plist_on_macos` (`plutil`) | PASS — headless-safe. |
| `terminal.rs` PTY suite | PASS — `openpty` needs no controlling terminal. |
| `platform.rs`, `vision.rs`, `computer_use.rs`, `audio_routing.rs`, `transcription.rs`, `recording.rs`, `encode/*`, `clipboard.rs` | PASS — pure logic in tests; none start a live OS surface (clipboard tests never start the NSPasteboard poller). |
| `ax.rs::live_read_frontmost`, `intendant-display::macos_real_capture_stress_cycles`, `live_audio.rs` live tests | Already `#[ignore]`d — not in CI on any account; stay operator-hardware smokes. |
| `tests/e2e` (mock provider, headless) | PASS — hermetic fixtures inject their roots. A failure *only* on the CI account from resolving the real `$HOME` (now an empty `/var/ci`) is an unhermetic-fixture bug to fix, not a migration blocker. |

No non-ignored test calls WindowServer APIs (CGDisplay/ScreenCaptureKit/NSPasteboard/CGEvent-post) — the grep found none; runtime capabilities needing TCC are reduced by design and unused by CI.

## Rollback story

`migrate` prints `sudo scripts/ci/rollback-runner-macos.sh <name>` on completion; rollback is metadata-driven (`/etc/intendant-ci/migration/<label>.meta` + parked plist + dotfile backups), refuses to run mid-job, restores the LaunchAgent and the watchdog entries, and preserves the runner registration in both directions. Watchdog-conf before-images are kept for audit.

## Deliberately deferred (documented in the README)

- PF/private-LAN egress deny for the CI account — needs operator sign-off at apply time.
- Windows host equivalent of the hooks/migration ergonomics.
- sccache cache custody (self-capped at sccache's default; watchdog doesn't manage it yet).

Verification done here: `bash -n` + shellcheck clean on every script; conf-edit round-trip, `.path` remap, plist render (against the real runner template, `plutil -lint` OK, env injection verified), and hook driver normal + timeout paths exercised in a scratch sandbox. No cargo builds needed (scripts + docs only); no workflows touched.
