### PR TITLE
Transport S6b: IAM grants/enrollment-decide/org-manage onto the neutral api core

### DIFF
--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -2504,6 +2504,199 @@ mod tests {
         assert_eq!(frame["error"], "no rendezvous_url configured");
     }
 
+    // ── S6 tunnel/HTTP parity (second slice): IAM grants / enrollment
+    // decide / org manage ──
+    //
+    // Extends the S6 enumeration above (#10–#14 all apply). The
+    // slice-specific differences, deliberate and pinned:
+    //
+    //  15. Org-manage leaf addressing is transport-owned: HTTP maps the
+    //      request path (issue is the historical default arm), the
+    //      tunnel maps the method name — both land on the ONE
+    //      OrgManageLeaf fan-out over the shared cores.
+    //  16. The HTTP org-manage handler renders EVERY leaf through the
+    //      fleet decorator (the own-origin leaves' inert `Vary: Origin`
+    //      tail, golden-pinned in routes_access.rs) — pure HTTP-lane
+    //      decoration; the tunnel's ok/error envelope carries none of
+    //      it.
+
+    #[tokio::test]
+    async fn parity_iam_grant_mutations_share_cores_over_an_injected_cert_dir() {
+        let tmp = tempfile::tempdir().expect("temp cert dir");
+        let actor =
+            crate::access::iam::AccessPrincipal::root_dashboard_session("parity", "https");
+
+        // Upsert success: same body from the one core on both lanes
+        // (fresh store per lane call is NOT possible — the second call
+        // updates rather than creates — so the pin compares the
+        // mutation's own fields).
+        let upsert = || {
+            serde_json::json!({
+                "kind": "browser_certificate",
+                "label": "Parity browser",
+                "fingerprint": "PA:R1",
+                "role_id": "role:observer"
+            })
+        };
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_iam_upsert_user_client_grant_api_response(
+                tmp.path(),
+                upsert(),
+                &actor,
+            ),
+        );
+        assert_eq!(status, 200);
+        assert_eq!(http_body["created_grant"], serde_json::json!(true));
+        let frame = frame_api_ok_error_response(
+            "parity-iam-upsert".to_string(),
+            crate::web_gateway::access_iam_upsert_user_client_grant_api_response(
+                tmp.path(),
+                upsert(),
+                &actor,
+            ),
+            "iam grant upsert",
+        );
+        assert_eq!(frame["ok"], true);
+        assert!(frame["result"]
+            .as_object()
+            .is_some_and(|map| !map.contains_key("_httpStatus")));
+        // Second upsert of the same fingerprint updates in place.
+        assert_eq!(frame["result"]["created_grant"], serde_json::json!(false));
+        assert_eq!(frame["result"]["schema_version"], http_body["schema_version"]);
+
+        // Update decode error: deterministic serde wording as the HTTP
+        // {"error"} body and the tunnel frame-level error.
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_iam_update_grant_api_response(
+                tmp.path(),
+                serde_json::json!({}),
+                &actor,
+            ),
+        );
+        assert_eq!(status, 400);
+        let frame = frame_api_ok_error_response(
+            "parity-iam-update".to_string(),
+            crate::web_gateway::access_iam_update_grant_api_response(
+                tmp.path(),
+                serde_json::json!({}),
+                &actor,
+            ),
+            "iam grant update",
+        );
+        assert_eq!(frame["ok"], false);
+        assert_eq!(frame["error"], http_body["error"]);
+
+        // Enrollment decide, unknown fingerprint: deterministic error on
+        // both lanes before any store access.
+        let decide = || serde_json::json!({ "fingerprint": "PA:R1:EN", "approve": true });
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_enrollment_decide_api_response(
+                tmp.path(),
+                decide(),
+                &actor,
+            ),
+        );
+        assert_eq!(status, 400);
+        assert_eq!(
+            http_body,
+            serde_json::json!({"error": "no pending enrollment for fingerprint PA:R1:EN"})
+        );
+        let frame = frame_api_ok_error_response(
+            "parity-enroll-decide".to_string(),
+            crate::web_gateway::access_enrollment_decide_api_response(
+                tmp.path(),
+                decide(),
+                &actor,
+            ),
+            "enrollment decide",
+        );
+        assert_eq!(frame["ok"], false);
+        assert_eq!(frame["error"], "no pending enrollment for fingerprint PA:R1:EN");
+    }
+
+    #[tokio::test]
+    async fn parity_org_manage_leaves_share_the_one_fan_out() {
+        use crate::web_gateway::OrgManageLeaf;
+        let tmp = tempfile::tempdir().expect("temp cert dir");
+
+        // Leaf addressing agrees across transports (difference #15).
+        for (method, path) in [
+            ("api_access_org_trust", "/api/access/orgs/trust"),
+            ("api_access_org_revoke", "/api/access/orgs/revoke"),
+            ("api_access_org_issue", "/api/access/org-grants/issue"),
+            (
+                "api_access_org_revoke_member",
+                "/api/access/org-grants/revoke-member",
+            ),
+            (
+                "api_access_org_issuer_init",
+                "/api/access/org-grants/issuers/init",
+            ),
+            (
+                "api_access_org_issuer_delegate",
+                "/api/access/org-grants/issuers/delegate",
+            ),
+            (
+                "api_access_org_issuer_install",
+                "/api/access/org-grants/issuers/install",
+            ),
+        ] {
+            assert_eq!(
+                OrgManageLeaf::from_control_method(method),
+                Some(OrgManageLeaf::from_req_path(path)),
+                "{method} vs {path}"
+            );
+        }
+        assert_eq!(OrgManageLeaf::from_control_method("api_access_org_present"), None);
+
+        // Issue without keys: the deterministic error body on both lanes
+        // from the one fan-out (the signing successes need real org keys
+        // and stay smoke-covered — validate-org-grants).
+        let params = || serde_json::json!({ "handle": "parity-org" });
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_org_manage_api_response(
+                tmp.path(),
+                OrgManageLeaf::Issue,
+                params(),
+            ),
+        );
+        assert_eq!(status, 400);
+        let frame = frame_api_ok_error_response(
+            "parity-org-issue".to_string(),
+            crate::web_gateway::access_org_manage_api_response(
+                tmp.path(),
+                OrgManageLeaf::Issue,
+                params(),
+            ),
+            "org manage",
+        );
+        assert_eq!(frame["ok"], false);
+        assert_eq!(frame["error"], http_body["error"]);
+
+        // Issuer init: both lanes create/read the deputy key under the
+        // injected store — the SAME key once created, so the bodies are
+        // equal across the two calls.
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_org_manage_api_response(
+                tmp.path(),
+                OrgManageLeaf::IssuerInit,
+                params(),
+            ),
+        );
+        assert_eq!(status, 200);
+        let frame = frame_api_ok_error_response(
+            "parity-org-issuer-init".to_string(),
+            crate::web_gateway::access_org_manage_api_response(
+                tmp.path(),
+                OrgManageLeaf::IssuerInit,
+                params(),
+            ),
+            "org manage",
+        );
+        assert_eq!(frame["ok"], true);
+        assert_eq!(frame["result"], http_body);
+    }
+
     use crate::*;
     use crate::dashboard_control::tests::{runtime};
 

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -654,24 +654,15 @@ pub(crate) fn control_frame_response(
                     // Transport edge resolves the ambient cert dir
                     // (hermeticity convention).
                     let cert_dir = crate::access::backend::select_backend().cert_dir();
-                    match crate::web_gateway::access_enrollment_decide_response_value(
-                        &cert_dir,
-                        params,
-                        &runtime.grant.access_principal(),
-                    ) {
-                        Ok(result) => Some(serde_json::json!({
-                            "t": "response",
-                            "id": id,
-                            "ok": true,
-                            "result": result,
-                        })),
-                        Err(error) => Some(serde_json::json!({
-                            "t": "response",
-                            "id": id,
-                            "ok": false,
-                            "error": error,
-                        })),
-                    }
+                    Some(frame_api_ok_error_response(
+                        id,
+                        crate::web_gateway::access_enrollment_decide_api_response(
+                            &cert_dir,
+                            params,
+                            &runtime.grant.access_principal(),
+                        ),
+                        "enrollment decide",
+                    ))
                 }
                 "api_access_connect_status" => Some(frame_api_ok_error_response(
                     id,
@@ -747,51 +738,37 @@ pub(crate) fn control_frame_response(
                         "result": { "started": true, "addresses": addresses },
                     }))
                 }
+                // The seven org-manage twins delegate to the S6 neutral
+                // core (leaf addressed by method name); the signed-org
+                // doorbell quartet below keeps its legacy path until its
+                // own slice ports it.
                 "api_access_org_trust"
                 | "api_access_org_revoke"
                 | "api_access_org_issue"
-                | "api_access_org_present"
                 | "api_access_org_revoke_member"
                 | "api_access_org_issuer_init"
                 | "api_access_org_issuer_delegate"
-                | "api_access_org_issuer_install"
+                | "api_access_org_issuer_install" => {
+                    let params = params.unwrap_or_else(|| serde_json::json!({}));
+                    let leaf = crate::web_gateway::OrgManageLeaf::from_control_method(method)
+                        .expect("org-manage arm methods all map to leaves");
+                    // Transport edge resolves the ambient cert dir
+                    // (hermeticity convention).
+                    let cert_dir = crate::access::backend::select_backend().cert_dir();
+                    Some(frame_api_ok_error_response(
+                        id,
+                        crate::web_gateway::access_org_manage_api_response(
+                            &cert_dir, leaf, params,
+                        ),
+                        "org manage",
+                    ))
+                }
+                "api_access_org_present"
                 | "api_access_org_orl"
                 | "api_access_org_orl_apply"
                 | "api_access_org_renew" => {
                     let params = params.unwrap_or_else(|| serde_json::json!({}));
-                    // Transport edge resolves the ambient cert dir
-                    // (hermeticity convention).
-                    let cert_dir = crate::access::backend::select_backend().cert_dir();
                     let result = match method {
-                        "api_access_org_trust" => {
-                            crate::web_gateway::access_org_trust_response_value(&cert_dir, params)
-                        }
-                        "api_access_org_revoke" => {
-                            crate::web_gateway::access_org_revoke_response_value(&cert_dir, params)
-                        }
-                        "api_access_org_issue" => {
-                            crate::web_gateway::access_org_issue_response_value(&cert_dir, params)
-                        }
-                        "api_access_org_revoke_member" => {
-                            crate::web_gateway::access_org_revoke_member_response_value(
-                                &cert_dir, params,
-                            )
-                        }
-                        "api_access_org_issuer_init" => {
-                            crate::web_gateway::access_org_issuer_init_response_value(
-                                &cert_dir, params,
-                            )
-                        }
-                        "api_access_org_issuer_delegate" => {
-                            crate::web_gateway::access_org_issuer_delegate_response_value(
-                                &cert_dir, params,
-                            )
-                        }
-                        "api_access_org_issuer_install" => {
-                            crate::web_gateway::access_org_issuer_install_response_value(
-                                &cert_dir, params,
-                            )
-                        }
                         "api_access_org_orl" => crate::web_gateway::access_org_orl_response_value(
                             params.get("handle").and_then(|v| v.as_str()).unwrap_or(""),
                         ),
@@ -826,48 +803,30 @@ pub(crate) fn control_frame_response(
                     // Transport edge resolves the ambient cert dir
                     // (hermeticity convention).
                     let cert_dir = crate::access::backend::select_backend().cert_dir();
-                    match crate::web_gateway::access_iam_upsert_user_client_grant_response_value_with_cert_dir(
-                        &cert_dir,
-                        params,
-                        &runtime.grant.access_principal(),
-                    ) {
-                        Ok(result) => Some(serde_json::json!({
-                            "t": "response",
-                            "id": id,
-                            "ok": true,
-                            "result": result,
-                        })),
-                        Err(error) => Some(serde_json::json!({
-                            "t": "response",
-                            "id": id,
-                            "ok": false,
-                            "error": error,
-                        })),
-                    }
+                    Some(frame_api_ok_error_response(
+                        id,
+                        crate::web_gateway::access_iam_upsert_user_client_grant_api_response(
+                            &cert_dir,
+                            params,
+                            &runtime.grant.access_principal(),
+                        ),
+                        "iam grant upsert",
+                    ))
                 }
                 "api_access_iam_update_grant" => {
                     let params = params.unwrap_or_else(|| serde_json::json!({}));
                     // Transport edge resolves the ambient cert dir
                     // (hermeticity convention).
                     let cert_dir = crate::access::backend::select_backend().cert_dir();
-                    match crate::web_gateway::access_iam_update_grant_response_value_with_cert_dir(
-                        &cert_dir,
-                        params,
-                        &runtime.grant.access_principal(),
-                    ) {
-                        Ok(result) => Some(serde_json::json!({
-                            "t": "response",
-                            "id": id,
-                            "ok": true,
-                            "result": result,
-                        })),
-                        Err(error) => Some(serde_json::json!({
-                            "t": "response",
-                            "id": id,
-                            "ok": false,
-                            "error": error,
-                        })),
-                    }
+                    Some(frame_api_ok_error_response(
+                        id,
+                        crate::web_gateway::access_iam_update_grant_api_response(
+                            &cert_dir,
+                            params,
+                            &runtime.grant.access_principal(),
+                        ),
+                        "iam grant update",
+                    ))
                 }
                 "subscribe_events" => {
                     runtime.events_subscribed = true;

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -651,7 +651,11 @@ pub(crate) fn control_frame_response(
                 )),
                 "api_access_enrollment_decide" => {
                     let params = params.unwrap_or_else(|| serde_json::json!({}));
+                    // Transport edge resolves the ambient cert dir
+                    // (hermeticity convention).
+                    let cert_dir = crate::access::backend::select_backend().cert_dir();
                     match crate::web_gateway::access_enrollment_decide_response_value(
+                        &cert_dir,
                         params,
                         &runtime.grant.access_principal(),
                     ) {
@@ -755,27 +759,38 @@ pub(crate) fn control_frame_response(
                 | "api_access_org_orl_apply"
                 | "api_access_org_renew" => {
                     let params = params.unwrap_or_else(|| serde_json::json!({}));
+                    // Transport edge resolves the ambient cert dir
+                    // (hermeticity convention).
+                    let cert_dir = crate::access::backend::select_backend().cert_dir();
                     let result = match method {
                         "api_access_org_trust" => {
-                            crate::web_gateway::access_org_trust_response_value(params)
+                            crate::web_gateway::access_org_trust_response_value(&cert_dir, params)
                         }
                         "api_access_org_revoke" => {
-                            crate::web_gateway::access_org_revoke_response_value(params)
+                            crate::web_gateway::access_org_revoke_response_value(&cert_dir, params)
                         }
                         "api_access_org_issue" => {
-                            crate::web_gateway::access_org_issue_response_value(params)
+                            crate::web_gateway::access_org_issue_response_value(&cert_dir, params)
                         }
                         "api_access_org_revoke_member" => {
-                            crate::web_gateway::access_org_revoke_member_response_value(params)
+                            crate::web_gateway::access_org_revoke_member_response_value(
+                                &cert_dir, params,
+                            )
                         }
                         "api_access_org_issuer_init" => {
-                            crate::web_gateway::access_org_issuer_init_response_value(params)
+                            crate::web_gateway::access_org_issuer_init_response_value(
+                                &cert_dir, params,
+                            )
                         }
                         "api_access_org_issuer_delegate" => {
-                            crate::web_gateway::access_org_issuer_delegate_response_value(params)
+                            crate::web_gateway::access_org_issuer_delegate_response_value(
+                                &cert_dir, params,
+                            )
                         }
                         "api_access_org_issuer_install" => {
-                            crate::web_gateway::access_org_issuer_install_response_value(params)
+                            crate::web_gateway::access_org_issuer_install_response_value(
+                                &cert_dir, params,
+                            )
                         }
                         "api_access_org_orl" => crate::web_gateway::access_org_orl_response_value(
                             params.get("handle").and_then(|v| v.as_str()).unwrap_or(""),
@@ -808,7 +823,11 @@ pub(crate) fn control_frame_response(
                 }
                 "api_access_iam_upsert_user_client_grant" => {
                     let params = params.unwrap_or_else(|| serde_json::json!({}));
-                    match crate::web_gateway::access_iam_upsert_user_client_grant_response_value(
+                    // Transport edge resolves the ambient cert dir
+                    // (hermeticity convention).
+                    let cert_dir = crate::access::backend::select_backend().cert_dir();
+                    match crate::web_gateway::access_iam_upsert_user_client_grant_response_value_with_cert_dir(
+                        &cert_dir,
                         params,
                         &runtime.grant.access_principal(),
                     ) {
@@ -828,7 +847,11 @@ pub(crate) fn control_frame_response(
                 }
                 "api_access_iam_update_grant" => {
                     let params = params.unwrap_or_else(|| serde_json::json!({}));
-                    match crate::web_gateway::access_iam_update_grant_response_value(
+                    // Transport edge resolves the ambient cert dir
+                    // (hermeticity convention).
+                    let cert_dir = crate::access::backend::select_backend().cert_dir();
+                    match crate::web_gateway::access_iam_update_grant_response_value_with_cert_dir(
+                        &cert_dir,
                         params,
                         &runtime.grant.access_principal(),
                     ) {

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -187,19 +187,9 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
         PeerOperation::CredentialsManage,
     ),
     method("api_credential_egress_probe", PeerOperation::CredentialsManage),
-    method(
-        "api_access_iam_upsert_user_client_grant",
-        PeerOperation::AccessManage,
-    ),
-    method("api_access_iam_update_grant", PeerOperation::AccessManage),
-    method("api_access_enrollment_decide", PeerOperation::AccessManage),
-    method("api_access_org_trust", PeerOperation::AccessManage),
-    method("api_access_org_revoke", PeerOperation::AccessManage),
-    method("api_access_org_issue", PeerOperation::AccessManage),
-    method("api_access_org_revoke_member", PeerOperation::AccessManage),
-    method("api_access_org_issuer_init", PeerOperation::AccessManage),
-    method("api_access_org_issuer_delegate", PeerOperation::AccessManage),
-    method("api_access_org_issuer_install", PeerOperation::AccessManage),
+    // The IAM grant mutations (upsert/update), enrollment decide, and
+    // the seven org-manage methods live as tunnel columns on their route
+    // rows — their IAM operations derive from the rows (S6).
     // Presenting a signed org document (or list) only requires a session;
     // the document itself is the authorization and is fully re-verified.
     // Same for reading the org's public revocation list and renewing a
@@ -3084,40 +3074,40 @@ mod tests {
             ),
             (
                 "api_access_iam_upsert_user_client_grant",
-                Residue,
+                Row,
                 Some(Op::AccessManage),
             ),
             (
                 "api_access_iam_update_grant",
-                Residue,
+                Row,
                 Some(Op::AccessManage),
             ),
             (
                 "api_access_enrollment_decide",
-                Residue,
+                Row,
                 Some(Op::AccessManage),
             ),
-            ("api_access_org_trust", Residue, Some(Op::AccessManage)),
-            ("api_access_org_revoke", Residue, Some(Op::AccessManage)),
-            ("api_access_org_issue", Residue, Some(Op::AccessManage)),
+            ("api_access_org_trust", Row, Some(Op::AccessManage)),
+            ("api_access_org_revoke", Row, Some(Op::AccessManage)),
+            ("api_access_org_issue", Row, Some(Op::AccessManage)),
             (
                 "api_access_org_revoke_member",
-                Residue,
+                Row,
                 Some(Op::AccessManage),
             ),
             (
                 "api_access_org_issuer_init",
-                Residue,
+                Row,
                 Some(Op::AccessManage),
             ),
             (
                 "api_access_org_issuer_delegate",
-                Residue,
+                Row,
                 Some(Op::AccessManage),
             ),
             (
                 "api_access_org_issuer_install",
-                Residue,
+                Row,
                 Some(Op::AccessManage),
             ),
             ("api_access_org_present", Residue, Some(Op::AccessInspect)),

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -1128,7 +1128,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::AccessIamGrants,
         "Upsert a user-client grant",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_iam_upsert_user_client_grant")),
     fleet_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/access/iam/grants/update"),
@@ -1136,7 +1137,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::AccessIamGrants,
         "Update an IAM grant",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_iam_update_grant")),
     fleet_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/access/orgs/trust"),
@@ -1144,7 +1146,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::AccessOrgManage,
         "Trust an org root key on this daemon",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_org_trust")),
     fleet_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/access/orgs/revoke"),
@@ -1152,7 +1155,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::AccessOrgManage,
         "Withdraw trust in an org root key",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_org_revoke")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/access/org-grants/issue"),
@@ -1160,7 +1164,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::AccessOrgManage,
         "Issue an org grant (org root/issuer key on this daemon)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_org_issue")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/access/org-grants/revoke-member"),
@@ -1168,7 +1173,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::AccessOrgManage,
         "Revoke an org member (appends to the ORL)",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_org_revoke_member")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/access/org-grants/issuers/init"),
@@ -1176,7 +1182,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::AccessOrgManage,
         "Initialize an org issuer key",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_org_issuer_init")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/access/org-grants/issuers/delegate"),
@@ -1184,7 +1191,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::AccessOrgManage,
         "Delegate to an org issuer",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_org_issuer_delegate")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/access/org-grants/issuers/install"),
@@ -1192,7 +1200,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::AccessOrgManage,
         "Install a delegated org issuer key",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_org_issuer_install")),
     fleet_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/access/enrollment-requests/decide"),
@@ -1200,7 +1209,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Default,
         RouteHandlerId::AccessEnrollmentDecide,
         "Approve or deny a pending enrollment request",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_access_enrollment_decide")),
     fleet_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/access/enrollment-requests"),

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -843,7 +843,6 @@ pub(crate) async fn serve_http_request(
                     req_path,
                     cert_dir,
                     http_access_context,
-                    route.cors,
                     fleet_cors_origin.as_deref(),
                 )
                 .await;

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -828,11 +828,11 @@ pub(crate) async fn serve_http_request(
                 return handle_access_iam_grants(
                     stream,
                     route_body,
-                    req_method,
                     req_path,
                     cert_dir,
                     http_access_context,
-                    fleet_cors_origin,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
                 )
                 .await;
             }
@@ -840,11 +840,11 @@ pub(crate) async fn serve_http_request(
                 return handle_access_org_manage(
                     stream,
                     route_body,
-                    req_method,
                     req_path,
                     cert_dir,
                     http_access_context,
-                    fleet_cors_origin,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
                 )
                 .await;
             }
@@ -852,10 +852,10 @@ pub(crate) async fn serve_http_request(
                 return handle_access_enrollment_decide(
                     stream,
                     route_body,
-                    req_method,
                     cert_dir,
                     http_access_context,
-                    fleet_cors_origin,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
                 )
                 .await;
             }

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -830,6 +830,7 @@ pub(crate) async fn serve_http_request(
                     route_body,
                     req_method,
                     req_path,
+                    cert_dir,
                     http_access_context,
                     fleet_cors_origin,
                 )
@@ -841,6 +842,7 @@ pub(crate) async fn serve_http_request(
                     route_body,
                     req_method,
                     req_path,
+                    cert_dir,
                     http_access_context,
                     fleet_cors_origin,
                 )
@@ -851,6 +853,7 @@ pub(crate) async fn serve_http_request(
                     stream,
                     route_body,
                     req_method,
+                    cert_dir,
                     http_access_context,
                     fleet_cors_origin,
                 )

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -300,7 +300,6 @@ pub(crate) async fn handle_access_org_manage(
     req_path: &str,
     cert_dir: std::path::PathBuf,
     http_access_context: HttpAccessContext,
-    cors: crate::gateway_routes::CorsPosture,
     fleet_origin: Option<&str>,
 ) {
     // Belt-and-suspenders manage re-check (see the claim-code shim).
@@ -325,7 +324,22 @@ pub(crate) async fn handle_access_org_manage(
         ),
         Err(error) => *error,
     };
-    write_api_response(stream, response, cors, fleet_origin).await;
+    // Historical framing quirk, byte-pinned by the golden transcripts:
+    // this handler has always rendered through the fleet decorator
+    // regardless of leaf, so the five own-origin leaves (issue,
+    // revoke-member, issuers/*) carry an inert `Vary: Origin` tail and
+    // can never see an echo — dispatch's origin gate refuses foreign
+    // origins on non-fleet paths before dispatch, so `fleet_origin` is
+    // always None for them. Purifying them onto the row posture would
+    // be a (harmless-looking but real) wire change — not part of the S6
+    // conversion.
+    write_api_response(
+        stream,
+        response,
+        crate::gateway_routes::CorsPosture::FleetAllowlist,
+        fleet_origin,
+    )
+    .await;
 }
 
 pub(crate) async fn handle_access_enrollment_decide(
@@ -4098,7 +4112,11 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
 
         // Issue without a root key or issuer cert in the injected store:
-        // the deterministic 400 under the fleet tail (echo case).
+        // the deterministic 400. The issue row is own-origin, so no
+        // foreign origin can ever reach this handler for it (the
+        // pre-dispatch origin gate refuses them) — the reachable shape
+        // is the fleet decorator's inert bare `Vary: Origin` tail, the
+        // handler's historical framing on every leaf.
         let response = collect_access_handler_response(|stream| {
             handle_access_org_manage(
                 stream,
@@ -4106,8 +4124,7 @@ mod tests {
                 "/api/access/org-grants/issue",
                 tmp.path().to_path_buf(),
                 golden_root_context(),
-                org_cors("/api/access/org-grants/issue"),
-                Some(GOLDEN_FLEET_ORIGIN),
+                None,
             )
         })
         .await;
@@ -4117,11 +4134,7 @@ mod tests {
         .to_string();
         assert_eq!(
             golden_access_transcript(&response),
-            golden_access_fleet_json_transcript(
-                "400 Bad Request",
-                &expected_body,
-                Some(GOLDEN_FLEET_ORIGIN)
-            )
+            golden_access_fleet_json_transcript("400 Bad Request", &expected_body, None)
         );
 
         // Delegate without a root key: the deterministic 400. (The
@@ -4134,7 +4147,6 @@ mod tests {
                 "/api/access/org-grants/issuers/delegate",
                 tmp.path().to_path_buf(),
                 golden_root_context(),
-                org_cors("/api/access/org-grants/issuers/delegate"),
                 None,
             )
         })
@@ -4158,7 +4170,6 @@ mod tests {
                 "/api/access/org-grants/issuers/init",
                 tmp.path().to_path_buf(),
                 golden_root_context(),
-                org_cors("/api/access/org-grants/issuers/init"),
                 None,
             )
         })
@@ -4191,7 +4202,6 @@ mod tests {
                 "/api/access/orgs/trust",
                 tmp.path().to_path_buf(),
                 golden_root_context(),
-                org_cors("/api/access/orgs/trust"),
                 Some(GOLDEN_FLEET_ORIGIN),
             )
         })
@@ -4216,7 +4226,6 @@ mod tests {
                 "/api/access/orgs/trust",
                 denied_dir.path().to_path_buf(),
                 context,
-                org_cors("/api/access/orgs/trust"),
                 Some(GOLDEN_FLEET_ORIGIN),
             )
         })

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -250,172 +250,115 @@ pub(crate) async fn handle_access_org_apply_renew(
 }
 
 pub(crate) async fn handle_access_iam_grants(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     body_text: String,
-    req_method: &str,
     req_path: &str,
     cert_dir: std::path::PathBuf,
     http_access_context: HttpAccessContext,
-    fleet_cors_origin: Option<String>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
-    if req_method != "POST" {
-        let response = json_response(
-            "405 Method Not Allowed",
-            serde_json::json!({"error": "method not allowed"}).to_string(),
-        );
-        let _ = stream.write_all(response.as_bytes()).await;
-    } else {
-        let decision =
-            http_access_context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
-        if !decision.allowed {
-            let response = json_response(
-                "403 Forbidden",
-                serde_json::json!({
-                    "error": "principal does not allow this operation",
-                    "principal": http_access_context.principal.as_value(),
-                    "permission": decision.permission,
-                    "reason": decision.reason,
-                })
-                .to_string(),
-            );
-            let _ = stream.write_all(response.as_bytes()).await;
-        } else {
-            let (status, body) = if req_path == "/api/access/iam/grants/update" {
-                access_iam_update_grant_response_body(
+    // Belt-and-suspenders manage re-check (see the claim-code shim):
+    // historical PLAIN 403, own-origin render.
+    let decision =
+        http_access_context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
+    if !decision.allowed {
+        let response = access_manage_denied_api_response(&http_access_context, decision);
+        write_api_response(
+            stream,
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        )
+        .await;
+        return;
+    }
+    let response = match parse_access_request_body(&body_text) {
+        Ok(params) => {
+            if req_path == "/api/access/iam/grants/update" {
+                access_iam_update_grant_api_response(
                     &cert_dir,
-                    &body_text,
+                    params,
                     &http_access_context.principal,
                 )
             } else {
-                access_iam_upsert_user_client_grant_response_body(
+                access_iam_upsert_user_client_grant_api_response(
                     &cert_dir,
-                    &body_text,
+                    params,
                     &http_access_context.principal,
                 )
-            };
-            let response = with_fleet_cors(
-                json_response(status_reason(status), body),
-                fleet_cors_origin.as_deref(),
-            );
-            let _ = stream.write_all(response.as_bytes()).await;
+            }
         }
-    }
-    finalize_http_stream(&mut stream).await;
+        Err(error) => *error,
+    };
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_access_org_manage(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     body_text: String,
-    req_method: &str,
     req_path: &str,
     cert_dir: std::path::PathBuf,
     http_access_context: HttpAccessContext,
-    fleet_cors_origin: Option<String>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
-    if req_method != "POST" {
-        let response = json_response(
-            "405 Method Not Allowed",
-            serde_json::json!({"error": "method not allowed"}).to_string(),
-        );
-        let _ = stream.write_all(response.as_bytes()).await;
-    } else {
-        let decision =
-            http_access_context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
-        if !decision.allowed {
-            let response = json_response(
-                "403 Forbidden",
-                serde_json::json!({
-                    "error": "principal does not allow this operation",
-                    "principal": http_access_context.principal.as_value(),
-                    "permission": decision.permission,
-                    "reason": decision.reason,
-                })
-                .to_string(),
-            );
-            let _ = stream.write_all(response.as_bytes()).await;
-        } else {
-            let handler = match req_path {
-                "/api/access/orgs/trust" => {
-                    access_org_trust_response_value
-                        as fn(
-                            &std::path::Path,
-                            serde_json::Value,
-                        ) -> Result<serde_json::Value, String>
-                }
-                "/api/access/orgs/revoke" => access_org_revoke_response_value,
-                "/api/access/org-grants/revoke-member" => access_org_revoke_member_response_value,
-                "/api/access/org-grants/issuers/init" => access_org_issuer_init_response_value,
-                "/api/access/org-grants/issuers/delegate" => {
-                    access_org_issuer_delegate_response_value
-                }
-                "/api/access/org-grants/issuers/install" => {
-                    access_org_issuer_install_response_value
-                }
-                _ => access_org_issue_response_value,
-            };
-            let (status, body) = match serde_json::from_str::<serde_json::Value>(&body_text)
-                .map_err(|e| format!("invalid request body: {e}"))
-                .and_then(|params| handler(&cert_dir, params))
-            {
-                Ok(value) => (200, value.to_string()),
-                Err(error) => (400, serde_json::json!({"error": error}).to_string()),
-            };
-            let response = with_fleet_cors(
-                json_response(status_reason(status), body),
-                fleet_cors_origin.as_deref(),
-            );
-            let _ = stream.write_all(response.as_bytes()).await;
-        }
+    // Belt-and-suspenders manage re-check (see the claim-code shim).
+    let decision =
+        http_access_context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
+    if !decision.allowed {
+        let response = access_manage_denied_api_response(&http_access_context, decision);
+        write_api_response(
+            stream,
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        )
+        .await;
+        return;
     }
-    finalize_http_stream(&mut stream).await;
+    let response = match parse_access_request_body(&body_text) {
+        Ok(params) => access_org_manage_api_response(
+            &cert_dir,
+            OrgManageLeaf::from_req_path(req_path),
+            params,
+        ),
+        Err(error) => *error,
+    };
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_access_enrollment_decide(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     body_text: String,
-    req_method: &str,
     cert_dir: std::path::PathBuf,
     http_access_context: HttpAccessContext,
-    fleet_cors_origin: Option<String>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
 ) {
-    use tokio::io::AsyncWriteExt;
-    if req_method != "POST" {
-        let response = json_response(
-            "405 Method Not Allowed",
-            serde_json::json!({"error": "method not allowed"}).to_string(),
-        );
-        let _ = stream.write_all(response.as_bytes()).await;
-    } else {
-        let decision =
-            http_access_context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
-        if !decision.allowed {
-            let response = json_response(
-                "403 Forbidden",
-                serde_json::json!({
-                    "error": "principal does not allow this operation",
-                    "principal": http_access_context.principal.as_value(),
-                    "permission": decision.permission,
-                    "reason": decision.reason,
-                })
-                .to_string(),
-            );
-            let _ = stream.write_all(response.as_bytes()).await;
-        } else {
-            let (status, body) = access_enrollment_decide_response_body(
-                &cert_dir,
-                &body_text,
-                &http_access_context.principal,
-            );
-            let response = with_fleet_cors(
-                json_response(status_reason(status), body),
-                fleet_cors_origin.as_deref(),
-            );
-            let _ = stream.write_all(response.as_bytes()).await;
-        }
+    // Belt-and-suspenders manage re-check (see the claim-code shim).
+    let decision =
+        http_access_context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
+    if !decision.allowed {
+        let response = access_manage_denied_api_response(&http_access_context, decision);
+        write_api_response(
+            stream,
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        )
+        .await;
+        return;
     }
-    finalize_http_stream(&mut stream).await;
+    let response = match parse_access_request_body(&body_text) {
+        Ok(params) => access_enrollment_decide_api_response(
+            &cert_dir,
+            params,
+            &http_access_context.principal,
+        ),
+        Err(error) => *error,
+    };
+    write_api_response(stream, response, cors, fleet_origin).await;
 }
 
 pub(crate) async fn handle_access_enrollment_requests(
@@ -801,6 +744,119 @@ pub(crate) fn access_tier_settings_api_response(
         access_set_hosted_ceiling_response_value(cert_dir, params, actor)
     } else {
         access_set_tier_response_value(cert_dir, params, actor)
+    };
+    access_result_api_response(result, 400)
+}
+
+/// Transport-owned body decode for the manage POST shims: the
+/// historical "invalid request body" 400 (rendered under the row's own
+/// posture, matching this family's fleet-decorated value errors).
+fn parse_access_request_body(body_text: &str) -> Result<serde_json::Value, Box<ApiResponse>> {
+    serde_json::from_str(body_text).map_err(|e| {
+        Box::new(ApiResponse::json_error(
+            400,
+            format!("invalid request body: {e}"),
+        ))
+    })
+}
+
+/// POST /api/access/iam/user-client-grants + the tunnel's
+/// `api_access_iam_upsert_user_client_grant`.
+pub(crate) fn access_iam_upsert_user_client_grant_api_response(
+    cert_dir: &std::path::Path,
+    params: serde_json::Value,
+    actor: &crate::access::iam::AccessPrincipal,
+) -> ApiResponse {
+    access_result_api_response(
+        access_iam_upsert_user_client_grant_response_value_with_cert_dir(cert_dir, params, actor),
+        400,
+    )
+}
+
+/// POST /api/access/iam/grants/update + the tunnel's
+/// `api_access_iam_update_grant`.
+pub(crate) fn access_iam_update_grant_api_response(
+    cert_dir: &std::path::Path,
+    params: serde_json::Value,
+    actor: &crate::access::iam::AccessPrincipal,
+) -> ApiResponse {
+    access_result_api_response(
+        access_iam_update_grant_response_value_with_cert_dir(cert_dir, params, actor),
+        400,
+    )
+}
+
+/// POST /api/access/enrollment-requests/decide + the tunnel's
+/// `api_access_enrollment_decide`.
+pub(crate) fn access_enrollment_decide_api_response(
+    cert_dir: &std::path::Path,
+    params: serde_json::Value,
+    actor: &crate::access::iam::AccessPrincipal,
+) -> ApiResponse {
+    access_result_api_response(
+        access_enrollment_decide_response_value(cert_dir, params, actor),
+        400,
+    )
+}
+
+/// The seven org administration leaves, addressed by request path on
+/// HTTP (the historical match, issue as the default arm) and by method
+/// name on the tunnel.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum OrgManageLeaf {
+    Trust,
+    Revoke,
+    Issue,
+    RevokeMember,
+    IssuerInit,
+    IssuerDelegate,
+    IssuerInstall,
+}
+
+impl OrgManageLeaf {
+    pub(crate) fn from_req_path(req_path: &str) -> Self {
+        match req_path {
+            "/api/access/orgs/trust" => OrgManageLeaf::Trust,
+            "/api/access/orgs/revoke" => OrgManageLeaf::Revoke,
+            "/api/access/org-grants/revoke-member" => OrgManageLeaf::RevokeMember,
+            "/api/access/org-grants/issuers/init" => OrgManageLeaf::IssuerInit,
+            "/api/access/org-grants/issuers/delegate" => OrgManageLeaf::IssuerDelegate,
+            "/api/access/org-grants/issuers/install" => OrgManageLeaf::IssuerInstall,
+            _ => OrgManageLeaf::Issue,
+        }
+    }
+
+    pub(crate) fn from_control_method(method: &str) -> Option<Self> {
+        Some(match method {
+            "api_access_org_trust" => OrgManageLeaf::Trust,
+            "api_access_org_revoke" => OrgManageLeaf::Revoke,
+            "api_access_org_issue" => OrgManageLeaf::Issue,
+            "api_access_org_revoke_member" => OrgManageLeaf::RevokeMember,
+            "api_access_org_issuer_init" => OrgManageLeaf::IssuerInit,
+            "api_access_org_issuer_delegate" => OrgManageLeaf::IssuerDelegate,
+            "api_access_org_issuer_install" => OrgManageLeaf::IssuerInstall,
+            _ => return None,
+        })
+    }
+}
+
+/// The seven org-manage rows + their tunnel twins: one leaf fan-out
+/// over the shared cores, one `Result` framing.
+pub(crate) fn access_org_manage_api_response(
+    cert_dir: &std::path::Path,
+    leaf: OrgManageLeaf,
+    params: serde_json::Value,
+) -> ApiResponse {
+    let result = match leaf {
+        OrgManageLeaf::Trust => access_org_trust_response_value(cert_dir, params),
+        OrgManageLeaf::Revoke => access_org_revoke_response_value(cert_dir, params),
+        OrgManageLeaf::Issue => access_org_issue_response_value(cert_dir, params),
+        OrgManageLeaf::RevokeMember => access_org_revoke_member_response_value(cert_dir, params),
+        OrgManageLeaf::IssuerInit => access_org_issuer_init_response_value(cert_dir, params),
+        OrgManageLeaf::IssuerDelegate => {
+            access_org_issuer_delegate_response_value(cert_dir, params)
+        }
+        OrgManageLeaf::IssuerInstall => access_org_issuer_install_response_value(cert_dir, params),
     };
     access_result_api_response(result, 400)
 }
@@ -2110,47 +2166,6 @@ pub(crate) fn access_enrollment_decide_response_value(
     Ok(value)
 }
 
-pub(crate) fn access_enrollment_decide_response_body(
-    cert_dir: &std::path::Path,
-    body_text: &str,
-    actor: &crate::access::iam::AccessPrincipal,
-) -> (u16, String) {
-    let params = match serde_json::from_str::<serde_json::Value>(body_text) {
-        Ok(params) => params,
-        Err(e) => {
-            return (
-                400,
-                serde_json::json!({"error": format!("invalid request body: {e}")}).to_string(),
-            );
-        }
-    };
-    match access_enrollment_decide_response_value(cert_dir, params, actor) {
-        Ok(value) => (200, value.to_string()),
-        Err(error) => (400, serde_json::json!({"error": error}).to_string()),
-    }
-}
-
-pub(crate) fn access_iam_upsert_user_client_grant_response_body(
-    cert_dir: &std::path::Path,
-    body_text: &str,
-    actor: &crate::access::iam::AccessPrincipal,
-) -> (u16, String) {
-    let params = match serde_json::from_str::<serde_json::Value>(body_text) {
-        Ok(params) => params,
-        Err(e) => {
-            return (
-                400,
-                serde_json::json!({"error": format!("invalid request body: {e}")}).to_string(),
-            );
-        }
-    };
-    match access_iam_upsert_user_client_grant_response_value_with_cert_dir(cert_dir, params, actor)
-    {
-        Ok(value) => (200, value.to_string()),
-        Err(error) => (400, serde_json::json!({"error": error}).to_string()),
-    }
-}
-
 pub(crate) fn access_iam_update_grant_response_value_with_cert_dir(
     cert_dir: &std::path::Path,
     params: serde_json::Value,
@@ -2172,26 +2187,6 @@ pub(crate) fn access_iam_update_grant_response_value_with_cert_dir(
         "iam": crate::access::iam::overview_metadata(&loaded),
         "state": loaded.state
     }))
-}
-
-pub(crate) fn access_iam_update_grant_response_body(
-    cert_dir: &std::path::Path,
-    body_text: &str,
-    actor: &crate::access::iam::AccessPrincipal,
-) -> (u16, String) {
-    let params = match serde_json::from_str::<serde_json::Value>(body_text) {
-        Ok(params) => params,
-        Err(e) => {
-            return (
-                400,
-                serde_json::json!({"error": format!("invalid request body: {e}")}).to_string(),
-            );
-        }
-    };
-    match access_iam_update_grant_response_value_with_cert_dir(cert_dir, params, actor) {
-        Ok(value) => (200, value.to_string()),
-        Err(error) => (400, serde_json::json!({"error": error}).to_string()),
-    }
 }
 
 /// The HTTP lane's name for the unified [`RequestAuthority`]
@@ -3882,7 +3877,7 @@ mod tests {
 
     #[tokio::test]
     async fn golden_access_iam_grants_transcripts() {
-        access_route_cors(
+        let cors = access_route_cors(
             "POST",
             "/api/access/iam/user-client-grants",
             crate::gateway_routes::CorsPosture::FleetAllowlist,
@@ -3902,11 +3897,11 @@ mod tests {
             handle_access_iam_grants(
                 stream,
                 "{}".to_string(),
-                "POST",
                 "/api/access/iam/user-client-grants",
                 denied_dir.path().to_path_buf(),
                 context,
-                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+                cors,
+                Some(GOLDEN_FLEET_ORIGIN),
             )
         })
         .await;
@@ -3927,11 +3922,11 @@ mod tests {
             handle_access_iam_grants(
                 stream,
                 invalid.to_string(),
-                "POST",
                 "/api/access/iam/user-client-grants",
                 tmp.path().to_path_buf(),
                 golden_root_context(),
-                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+                cors,
+                Some(GOLDEN_FLEET_ORIGIN),
             )
         })
         .await;
@@ -3956,11 +3951,11 @@ mod tests {
                     "role_id": "role:observer"
                 })
                 .to_string(),
-                "POST",
                 "/api/access/iam/user-client-grants",
                 tmp.path().to_path_buf(),
                 golden_root_context(),
-                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+                cors,
+                Some(GOLDEN_FLEET_ORIGIN),
             )
         })
         .await;
@@ -3987,10 +3982,10 @@ mod tests {
             handle_access_iam_grants(
                 stream,
                 "{}".to_string(),
-                "POST",
                 "/api/access/iam/grants/update",
                 tmp.path().to_path_buf(),
                 golden_root_context(),
+                cors,
                 None,
             )
         })
@@ -4003,7 +3998,7 @@ mod tests {
 
     #[tokio::test]
     async fn golden_access_enrollment_decide_transcripts() {
-        access_route_cors(
+        let cors = access_route_cors(
             "POST",
             "/api/access/enrollment-requests/decide",
             crate::gateway_routes::CorsPosture::FleetAllowlist,
@@ -4020,10 +4015,10 @@ mod tests {
                     "approve": true
                 })
                 .to_string(),
-                "POST",
                 tmp.path().to_path_buf(),
                 golden_root_context(),
-                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+                cors,
+                Some(GOLDEN_FLEET_ORIGIN),
             )
         })
         .await;
@@ -4041,9 +4036,9 @@ mod tests {
             handle_access_enrollment_decide(
                 stream,
                 serde_json::json!({ "fingerprint": "60:1D:EN" }).to_string(),
-                "POST",
                 tmp.path().to_path_buf(),
                 golden_root_context(),
+                cors,
                 None,
             )
         })
@@ -4065,10 +4060,10 @@ mod tests {
             handle_access_enrollment_decide(
                 stream,
                 "{}".to_string(),
-                "POST",
                 denied_dir.path().to_path_buf(),
                 context,
-                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+                cors,
+                Some(GOLDEN_FLEET_ORIGIN),
             )
         })
         .await;
@@ -4080,6 +4075,15 @@ mod tests {
 
     #[tokio::test]
     async fn golden_access_org_manage_transcripts() {
+        let org_cors = |path: &str| {
+            let expected =
+                if matches!(path, "/api/access/orgs/trust" | "/api/access/orgs/revoke") {
+                    crate::gateway_routes::CorsPosture::FleetAllowlist
+                } else {
+                    crate::gateway_routes::CorsPosture::OwnOrigin
+                };
+            access_route_cors("POST", path, expected)
+        };
         for path in [
             "/api/access/orgs/trust",
             "/api/access/orgs/revoke",
@@ -4089,13 +4093,7 @@ mod tests {
             "/api/access/org-grants/issuers/delegate",
             "/api/access/org-grants/issuers/install",
         ] {
-            let expected =
-                if matches!(path, "/api/access/orgs/trust" | "/api/access/orgs/revoke") {
-                    crate::gateway_routes::CorsPosture::FleetAllowlist
-                } else {
-                    crate::gateway_routes::CorsPosture::OwnOrigin
-                };
-            access_route_cors("POST", path, expected);
+            org_cors(path);
         }
         let tmp = tempfile::TempDir::new().unwrap();
 
@@ -4105,11 +4103,11 @@ mod tests {
             handle_access_org_manage(
                 stream,
                 serde_json::json!({ "handle": "golden-org" }).to_string(),
-                "POST",
                 "/api/access/org-grants/issue",
                 tmp.path().to_path_buf(),
                 golden_root_context(),
-                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+                org_cors("/api/access/org-grants/issue"),
+                Some(GOLDEN_FLEET_ORIGIN),
             )
         })
         .await;
@@ -4133,10 +4131,10 @@ mod tests {
             handle_access_org_manage(
                 stream,
                 serde_json::json!({ "handle": "golden-org" }).to_string(),
-                "POST",
                 "/api/access/org-grants/issuers/delegate",
                 tmp.path().to_path_buf(),
                 golden_root_context(),
+                org_cors("/api/access/org-grants/issuers/delegate"),
                 None,
             )
         })
@@ -4157,10 +4155,10 @@ mod tests {
             handle_access_org_manage(
                 stream,
                 serde_json::json!({ "handle": "golden-org" }).to_string(),
-                "POST",
                 "/api/access/org-grants/issuers/init",
                 tmp.path().to_path_buf(),
                 golden_root_context(),
+                org_cors("/api/access/org-grants/issuers/init"),
                 None,
             )
         })
@@ -4190,11 +4188,11 @@ mod tests {
             handle_access_org_manage(
                 stream,
                 invalid.to_string(),
-                "POST",
                 "/api/access/orgs/trust",
                 tmp.path().to_path_buf(),
                 golden_root_context(),
-                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+                org_cors("/api/access/orgs/trust"),
+                Some(GOLDEN_FLEET_ORIGIN),
             )
         })
         .await;
@@ -4215,11 +4213,11 @@ mod tests {
             handle_access_org_manage(
                 stream,
                 "{}".to_string(),
-                "POST",
                 "/api/access/orgs/trust",
                 denied_dir.path().to_path_buf(),
                 context,
-                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+                org_cors("/api/access/orgs/trust"),
+                Some(GOLDEN_FLEET_ORIGIN),
             )
         })
         .await;

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -254,6 +254,7 @@ pub(crate) async fn handle_access_iam_grants(
     body_text: String,
     req_method: &str,
     req_path: &str,
+    cert_dir: std::path::PathBuf,
     http_access_context: HttpAccessContext,
     fleet_cors_origin: Option<String>,
 ) {
@@ -281,9 +282,14 @@ pub(crate) async fn handle_access_iam_grants(
             let _ = stream.write_all(response.as_bytes()).await;
         } else {
             let (status, body) = if req_path == "/api/access/iam/grants/update" {
-                access_iam_update_grant_response_body(&body_text, &http_access_context.principal)
+                access_iam_update_grant_response_body(
+                    &cert_dir,
+                    &body_text,
+                    &http_access_context.principal,
+                )
             } else {
                 access_iam_upsert_user_client_grant_response_body(
+                    &cert_dir,
                     &body_text,
                     &http_access_context.principal,
                 )
@@ -303,6 +309,7 @@ pub(crate) async fn handle_access_org_manage(
     body_text: String,
     req_method: &str,
     req_path: &str,
+    cert_dir: std::path::PathBuf,
     http_access_context: HttpAccessContext,
     fleet_cors_origin: Option<String>,
 ) {
@@ -332,7 +339,10 @@ pub(crate) async fn handle_access_org_manage(
             let handler = match req_path {
                 "/api/access/orgs/trust" => {
                     access_org_trust_response_value
-                        as fn(serde_json::Value) -> Result<serde_json::Value, String>
+                        as fn(
+                            &std::path::Path,
+                            serde_json::Value,
+                        ) -> Result<serde_json::Value, String>
                 }
                 "/api/access/orgs/revoke" => access_org_revoke_response_value,
                 "/api/access/org-grants/revoke-member" => access_org_revoke_member_response_value,
@@ -347,7 +357,7 @@ pub(crate) async fn handle_access_org_manage(
             };
             let (status, body) = match serde_json::from_str::<serde_json::Value>(&body_text)
                 .map_err(|e| format!("invalid request body: {e}"))
-                .and_then(handler)
+                .and_then(|params| handler(&cert_dir, params))
             {
                 Ok(value) => (200, value.to_string()),
                 Err(error) => (400, serde_json::json!({"error": error}).to_string()),
@@ -366,6 +376,7 @@ pub(crate) async fn handle_access_enrollment_decide(
     mut stream: DemuxStream,
     body_text: String,
     req_method: &str,
+    cert_dir: std::path::PathBuf,
     http_access_context: HttpAccessContext,
     fleet_cors_origin: Option<String>,
 ) {
@@ -392,8 +403,11 @@ pub(crate) async fn handle_access_enrollment_decide(
             );
             let _ = stream.write_all(response.as_bytes()).await;
         } else {
-            let (status, body) =
-                access_enrollment_decide_response_body(&body_text, &http_access_context.principal);
+            let (status, body) = access_enrollment_decide_response_body(
+                &cert_dir,
+                &body_text,
+                &http_access_context.principal,
+            );
             let response = with_fleet_cors(
                 json_response(status_reason(status), body),
                 fleet_cors_origin.as_deref(),
@@ -1290,14 +1304,6 @@ pub(crate) fn access_iam_state_response_body(cert_dir: &std::path::Path) -> Stri
     access_iam_state_response_value(cert_dir).to_string()
 }
 
-pub(crate) fn access_iam_upsert_user_client_grant_response_value(
-    params: serde_json::Value,
-    actor: &crate::access::iam::AccessPrincipal,
-) -> Result<serde_json::Value, String> {
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    access_iam_upsert_user_client_grant_response_value_with_cert_dir(&cert_dir, params, actor)
-}
-
 pub(crate) fn access_iam_upsert_user_client_grant_response_value_with_cert_dir(
     cert_dir: &std::path::Path,
     params: serde_json::Value,
@@ -1587,7 +1593,10 @@ pub(crate) fn access_org_present_response_value(
     Ok(response)
 }
 
+/// `cert_dir` arrives from the transport edges (hermeticity convention)
+/// — as on every org fn below.
 pub(crate) fn access_org_trust_response_value(
+    cert_dir: &std::path::Path,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let handle = params
@@ -1601,8 +1610,7 @@ pub(crate) fn access_org_trust_response_value(
         .unwrap_or("")
         .to_string();
     let max_role = params.get("max_role").and_then(|v| v.as_str());
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    let mut state = crate::access::iam::load_state(&cert_dir)
+    let mut state = crate::access::iam::load_state(cert_dir)
         .map_err(|e| format!("load local IAM state: {e}"))?;
     let entry = crate::access::org::trust_org(
         &mut state,
@@ -1613,9 +1621,9 @@ pub(crate) fn access_org_trust_response_value(
         crate::access::client_key::now_unix_ms() as u64,
     )
     .map_err(|e| e.to_string())?;
-    crate::access::iam::save_state(&cert_dir, &state)
+    crate::access::iam::save_state(cert_dir, &state)
         .map_err(|e| format!("save local IAM state: {e}"))?;
-    let loaded = crate::access::iam::load_state_for_overview(&cert_dir);
+    let loaded = crate::access::iam::load_state_for_overview(cert_dir);
     Ok(serde_json::json!({
         "schema_version": 1,
         "org": entry,
@@ -1624,6 +1632,7 @@ pub(crate) fn access_org_trust_response_value(
 }
 
 pub(crate) fn access_org_revoke_response_value(
+    cert_dir: &std::path::Path,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let handle = params
@@ -1631,19 +1640,18 @@ pub(crate) fn access_org_revoke_response_value(
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    let mut state = crate::access::iam::load_state(&cert_dir)
+    let mut state = crate::access::iam::load_state(cert_dir)
         .map_err(|e| format!("load local IAM state: {e}"))?;
     let revoked = crate::access::org::revoke_org(
         &mut state,
-        &cert_dir,
+        cert_dir,
         &handle,
         crate::access::client_key::now_unix_ms() as u64,
     )
     .map_err(|e| e.to_string())?;
-    crate::access::iam::save_state(&cert_dir, &state)
+    crate::access::iam::save_state(cert_dir, &state)
         .map_err(|e| format!("save local IAM state: {e}"))?;
-    let loaded = crate::access::iam::load_state_for_overview(&cert_dir);
+    let loaded = crate::access::iam::load_state_for_overview(cert_dir);
     Ok(serde_json::json!({
         "schema_version": 1,
         "revoked_grants": revoked,
@@ -1652,6 +1660,7 @@ pub(crate) fn access_org_revoke_response_value(
 }
 
 pub(crate) fn access_org_issue_response_value(
+    cert_dir: &std::path::Path,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let handle = params
@@ -1660,12 +1669,11 @@ pub(crate) fn access_org_issue_response_value(
         .unwrap_or("")
         .trim()
         .to_string();
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    let root_identity = crate::access::org::load_org_identity(&cert_dir, &handle)?;
+    let root_identity = crate::access::org::load_org_identity(cert_dir, &handle)?;
     let deputy = if root_identity.is_none() {
         match (
-            crate::access::org::load_issuer_identity(&cert_dir, &handle)?,
-            crate::access::org::load_issuer_cert(&cert_dir, &handle)?,
+            crate::access::org::load_issuer_identity(cert_dir, &handle)?,
+            crate::access::org::load_issuer_cert(cert_dir, &handle)?,
         ) {
             (Some(issuer), Some(cert)) => Some((issuer, cert)),
             _ => None,
@@ -1678,7 +1686,7 @@ pub(crate) fn access_org_issue_response_value(
             "this daemon holds no root key or installed issuer certificate for org {handle:?}; run `intendant org init {handle}` on the org's designated daemon, or initialize + install a delegated issuer here"
         ));
     }
-    let state = crate::access::iam::load_state(&cert_dir)
+    let state = crate::access::iam::load_state(cert_dir)
         .map_err(|e| format!("load local IAM state: {e}"))?;
     let targets = params
         .get("targets")
@@ -1736,6 +1744,7 @@ pub(crate) fn access_org_issue_response_value(
 /// org. The key grants nothing until the org root signs a certificate
 /// for it and it is installed here.
 pub(crate) fn access_org_issuer_init_response_value(
+    cert_dir: &std::path::Path,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let handle = params
@@ -1744,9 +1753,8 @@ pub(crate) fn access_org_issuer_init_response_value(
         .unwrap_or("")
         .trim()
         .to_string();
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    let issuer = crate::access::org::load_or_create_issuer_identity(&cert_dir, &handle)?;
-    let cert = crate::access::org::load_issuer_cert(&cert_dir, &handle)?;
+    let issuer = crate::access::org::load_or_create_issuer_identity(cert_dir, &handle)?;
+    let cert = crate::access::org::load_issuer_cert(cert_dir, &handle)?;
     Ok(serde_json::json!({
         "schema_version": 1,
         "handle": handle,
@@ -1757,6 +1765,7 @@ pub(crate) fn access_org_issuer_init_response_value(
 
 /// Root-daemon action: sign a delegation certificate for an issuer key.
 pub(crate) fn access_org_issuer_delegate_response_value(
+    cert_dir: &std::path::Path,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let handle = params
@@ -1765,8 +1774,7 @@ pub(crate) fn access_org_issuer_delegate_response_value(
         .unwrap_or("")
         .trim()
         .to_string();
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    let identity = crate::access::org::load_org_identity(&cert_dir, &handle)?.ok_or_else(|| {
+    let identity = crate::access::org::load_org_identity(cert_dir, &handle)?.ok_or_else(|| {
         format!("this daemon holds no root key for org {handle:?}; delegate from the org's designated daemon")
     })?;
     let cert = crate::access::org::delegate_org_issuer(
@@ -1793,6 +1801,7 @@ pub(crate) fn access_org_issuer_delegate_response_value(
 /// Deputy action: install the root-signed certificate for the local
 /// issuer key.
 pub(crate) fn access_org_issuer_install_response_value(
+    cert_dir: &std::path::Path,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let handle = params
@@ -1808,9 +1817,8 @@ pub(crate) fn access_org_issuer_install_response_value(
             .ok_or_else(|| "certificate is required".to_string())?,
     )
     .map_err(|e| format!("invalid issuer certificate: {e}"))?;
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
     crate::access::org::install_issuer_cert(
-        &cert_dir,
+        cert_dir,
         &handle,
         &cert,
         crate::access::client_key::now_unix_ms() as u64,
@@ -1877,6 +1885,7 @@ pub(crate) fn access_org_orl_apply_response_value(
 /// it to this daemon's own IAM as a best-effort courtesy when it trusts
 /// its own org, so the org daemon never lags its own list.
 pub(crate) fn access_org_revoke_member_response_value(
+    cert_dir: &std::path::Path,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let handle = params
@@ -1927,8 +1936,7 @@ pub(crate) fn access_org_revoke_member_response_value(
     if let Some(key) = params.get("issuer_key").and_then(|v| v.as_str()) {
         issuer_keys.push(key.to_string());
     }
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    let identity = crate::access::org::load_org_identity(&cert_dir, &handle)?.ok_or_else(|| {
+    let identity = crate::access::org::load_org_identity(cert_dir, &handle)?.ok_or_else(|| {
         format!(
             "this daemon holds no root key for org {handle:?}; revoke members from the org's designated daemon"
         )
@@ -1936,19 +1944,19 @@ pub(crate) fn access_org_revoke_member_response_value(
     let now = crate::access::client_key::now_unix_ms() as u64;
     let orl = crate::access::org::orl_revoke(
         &identity,
-        &cert_dir,
+        cert_dir,
         &handle,
         &grant_ids,
         &subjects,
         &issuer_keys,
         now,
     )?;
-    let applied = crate::access::iam::load_state(&cert_dir)
+    let applied = crate::access::iam::load_state(cert_dir)
         .ok()
         .and_then(|mut state| {
-            let applied = crate::access::org::apply_orl(&mut state, &cert_dir, &orl, now).ok()?;
+            let applied = crate::access::org::apply_orl(&mut state, cert_dir, &orl, now).ok()?;
             if applied.changed {
-                crate::access::iam::save_state(&cert_dir, &state).ok()?;
+                crate::access::iam::save_state(cert_dir, &state).ok()?;
             }
             Some(applied)
         });
@@ -2040,6 +2048,7 @@ pub(crate) fn access_enrollment_requests_response_body(cert_dir: &std::path::Pat
 /// route origin attached, so ceilings and audit behave exactly as if the
 /// owner had typed the grant by hand.
 pub(crate) fn access_enrollment_decide_response_value(
+    cert_dir: &std::path::Path,
     params: serde_json::Value,
     actor: &crate::access::iam::AccessPrincipal,
 ) -> Result<serde_json::Value, String> {
@@ -2092,7 +2101,8 @@ pub(crate) fn access_enrollment_decide_response_value(
             if pending.transport.is_empty() { "dashboard" } else { pending.transport.as_str() }
         ),
     });
-    let mut value = access_iam_upsert_user_client_grant_response_value(upsert, actor)?;
+    let mut value =
+        access_iam_upsert_user_client_grant_response_value_with_cert_dir(cert_dir, upsert, actor)?;
     if let Some(object) = value.as_object_mut() {
         object.insert("decided".to_string(), serde_json::json!(true));
         object.insert("approved".to_string(), serde_json::json!(true));
@@ -2101,6 +2111,7 @@ pub(crate) fn access_enrollment_decide_response_value(
 }
 
 pub(crate) fn access_enrollment_decide_response_body(
+    cert_dir: &std::path::Path,
     body_text: &str,
     actor: &crate::access::iam::AccessPrincipal,
 ) -> (u16, String) {
@@ -2113,13 +2124,14 @@ pub(crate) fn access_enrollment_decide_response_body(
             );
         }
     };
-    match access_enrollment_decide_response_value(params, actor) {
+    match access_enrollment_decide_response_value(cert_dir, params, actor) {
         Ok(value) => (200, value.to_string()),
         Err(error) => (400, serde_json::json!({"error": error}).to_string()),
     }
 }
 
 pub(crate) fn access_iam_upsert_user_client_grant_response_body(
+    cert_dir: &std::path::Path,
     body_text: &str,
     actor: &crate::access::iam::AccessPrincipal,
 ) -> (u16, String) {
@@ -2132,18 +2144,11 @@ pub(crate) fn access_iam_upsert_user_client_grant_response_body(
             );
         }
     };
-    match access_iam_upsert_user_client_grant_response_value(params, actor) {
+    match access_iam_upsert_user_client_grant_response_value_with_cert_dir(cert_dir, params, actor)
+    {
         Ok(value) => (200, value.to_string()),
         Err(error) => (400, serde_json::json!({"error": error}).to_string()),
     }
-}
-
-pub(crate) fn access_iam_update_grant_response_value(
-    params: serde_json::Value,
-    actor: &crate::access::iam::AccessPrincipal,
-) -> Result<serde_json::Value, String> {
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    access_iam_update_grant_response_value_with_cert_dir(&cert_dir, params, actor)
 }
 
 pub(crate) fn access_iam_update_grant_response_value_with_cert_dir(
@@ -2170,6 +2175,7 @@ pub(crate) fn access_iam_update_grant_response_value_with_cert_dir(
 }
 
 pub(crate) fn access_iam_update_grant_response_body(
+    cert_dir: &std::path::Path,
     body_text: &str,
     actor: &crate::access::iam::AccessPrincipal,
 ) -> (u16, String) {
@@ -2182,7 +2188,7 @@ pub(crate) fn access_iam_update_grant_response_body(
             );
         }
     };
-    match access_iam_update_grant_response_value(params, actor) {
+    match access_iam_update_grant_response_value_with_cert_dir(cert_dir, params, actor) {
         Ok(value) => (200, value.to_string()),
         Err(error) => (400, serde_json::json!({"error": error}).to_string()),
     }
@@ -3851,6 +3857,375 @@ mod tests {
                 r#"{"error":"role_id is required"}"#,
                 None
             )
+        );
+    }
+
+    // ── S6 golden transcripts (second slice): IAM grants / enrollment
+    // decide / org manage ──
+    //
+    // Same discipline as the first S6 slice above: framing hand-written,
+    // fleet-origin echo covered on the family shapes, store-backed
+    // bodies over injected tempdir cert stores only, and the historical
+    // PLAIN-tail belt-403 pinned per handler. Store-mutating successes
+    // pin the framing and assert the mutation's own fields (the `iam`
+    // metadata carries store fingerprints); the org signing successes
+    // need real org keys and stay smoke-covered (validate-org-grants).
+
+    fn golden_root_context() -> HttpAccessContext {
+        HttpAccessContext {
+            principal: crate::access::iam::AccessPrincipal::root_dashboard_session(
+                "golden", "https",
+            ),
+            iam_state: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn golden_access_iam_grants_transcripts() {
+        access_route_cors(
+            "POST",
+            "/api/access/iam/user-client-grants",
+            crate::gateway_routes::CorsPosture::FleetAllowlist,
+        );
+        access_route_cors(
+            "POST",
+            "/api/access/iam/grants/update",
+            crate::gateway_routes::CorsPosture::FleetAllowlist,
+        );
+
+        // Denied: the belt-and-suspenders re-check, PLAIN tail even with
+        // an allowlisted origin present.
+        let denied_dir = tempfile::TempDir::new().unwrap();
+        let context = golden_denied_manage_context(denied_dir.path());
+        let body = golden_denied_manage_body(&context);
+        let response = collect_access_handler_response(|stream| {
+            handle_access_iam_grants(
+                stream,
+                "{}".to_string(),
+                "POST",
+                "/api/access/iam/user-client-grants",
+                denied_dir.path().to_path_buf(),
+                context,
+                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_canonical_json_transcript("403 Forbidden", &body)
+        );
+
+        // Parse error: 400 under the fleet tail (this family's parse
+        // errors ride the same decoration as its value errors).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let invalid = "not json";
+        let serde_error = serde_json::from_str::<serde_json::Value>(invalid).unwrap_err();
+        let expected_body =
+            serde_json::json!({"error": format!("invalid request body: {serde_error}")})
+                .to_string();
+        let response = collect_access_handler_response(|stream| {
+            handle_access_iam_grants(
+                stream,
+                invalid.to_string(),
+                "POST",
+                "/api/access/iam/user-client-grants",
+                tmp.path().to_path_buf(),
+                golden_root_context(),
+                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_fleet_json_transcript(
+                "400 Bad Request",
+                &expected_body,
+                Some(GOLDEN_FLEET_ORIGIN)
+            )
+        );
+
+        // Upsert success over the injected store: framing pinned, body
+        // asserted through the parse.
+        let response = collect_access_handler_response(|stream| {
+            handle_access_iam_grants(
+                stream,
+                serde_json::json!({
+                    "kind": "browser_certificate",
+                    "label": "Golden browser",
+                    "fingerprint": "AB:CD",
+                    "role_id": "role:observer"
+                })
+                .to_string(),
+                "POST",
+                "/api/access/iam/user-client-grants",
+                tmp.path().to_path_buf(),
+                golden_root_context(),
+                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+            )
+        })
+        .await;
+        let text = golden_access_transcript(&response);
+        let (_, body) = split_transcript(&text);
+        assert_eq!(
+            text,
+            golden_access_fleet_json_transcript("200 OK", body, Some(GOLDEN_FLEET_ORIGIN))
+        );
+        let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed["schema_version"], 1);
+        assert_eq!(parsed["created_grant"], serde_json::json!(true), "{body}");
+
+        // Update with an undecodable request: the value-level decode 400
+        // (deterministic serde wording), fleet tail without an origin.
+        let update_error = serde_json::from_value::<crate::access::iam::IamGrantUpdateRequest>(
+            serde_json::json!({}),
+        )
+        .expect_err("empty update request must not decode");
+        let expected_body =
+            serde_json::json!({"error": format!("invalid request body: {update_error}")})
+                .to_string();
+        let response = collect_access_handler_response(|stream| {
+            handle_access_iam_grants(
+                stream,
+                "{}".to_string(),
+                "POST",
+                "/api/access/iam/grants/update",
+                tmp.path().to_path_buf(),
+                golden_root_context(),
+                None,
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_fleet_json_transcript("400 Bad Request", &expected_body, None)
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_access_enrollment_decide_transcripts() {
+        access_route_cors(
+            "POST",
+            "/api/access/enrollment-requests/decide",
+            crate::gateway_routes::CorsPosture::FleetAllowlist,
+        );
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // Unknown fingerprint: deterministic 400 before any store access
+        // (the pending-enrollment queue is in-process), fleet echo case.
+        let response = collect_access_handler_response(|stream| {
+            handle_access_enrollment_decide(
+                stream,
+                serde_json::json!({
+                    "fingerprint": "60:1D:EN",
+                    "approve": true
+                })
+                .to_string(),
+                "POST",
+                tmp.path().to_path_buf(),
+                golden_root_context(),
+                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_fleet_json_transcript(
+                "400 Bad Request",
+                r#"{"error":"no pending enrollment for fingerprint 60:1D:EN"}"#,
+                Some(GOLDEN_FLEET_ORIGIN)
+            )
+        );
+
+        // Missing approve flag: the validation 400.
+        let response = collect_access_handler_response(|stream| {
+            handle_access_enrollment_decide(
+                stream,
+                serde_json::json!({ "fingerprint": "60:1D:EN" }).to_string(),
+                "POST",
+                tmp.path().to_path_buf(),
+                golden_root_context(),
+                None,
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_fleet_json_transcript(
+                "400 Bad Request",
+                r#"{"error":"approve must be true or false"}"#,
+                None
+            )
+        );
+
+        // Denied: the belt 403, PLAIN tail.
+        let denied_dir = tempfile::TempDir::new().unwrap();
+        let context = golden_denied_manage_context(denied_dir.path());
+        let body = golden_denied_manage_body(&context);
+        let response = collect_access_handler_response(|stream| {
+            handle_access_enrollment_decide(
+                stream,
+                "{}".to_string(),
+                "POST",
+                denied_dir.path().to_path_buf(),
+                context,
+                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_canonical_json_transcript("403 Forbidden", &body)
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_access_org_manage_transcripts() {
+        for path in [
+            "/api/access/orgs/trust",
+            "/api/access/orgs/revoke",
+            "/api/access/org-grants/issue",
+            "/api/access/org-grants/revoke-member",
+            "/api/access/org-grants/issuers/init",
+            "/api/access/org-grants/issuers/delegate",
+            "/api/access/org-grants/issuers/install",
+        ] {
+            let expected =
+                if matches!(path, "/api/access/orgs/trust" | "/api/access/orgs/revoke") {
+                    crate::gateway_routes::CorsPosture::FleetAllowlist
+                } else {
+                    crate::gateway_routes::CorsPosture::OwnOrigin
+                };
+            access_route_cors("POST", path, expected);
+        }
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // Issue without a root key or issuer cert in the injected store:
+        // the deterministic 400 under the fleet tail (echo case).
+        let response = collect_access_handler_response(|stream| {
+            handle_access_org_manage(
+                stream,
+                serde_json::json!({ "handle": "golden-org" }).to_string(),
+                "POST",
+                "/api/access/org-grants/issue",
+                tmp.path().to_path_buf(),
+                golden_root_context(),
+                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+            )
+        })
+        .await;
+        let expected_body = serde_json::json!({
+            "error": "this daemon holds no root key or installed issuer certificate for org \"golden-org\"; run `intendant org init golden-org` on the org's designated daemon, or initialize + install a delegated issuer here"
+        })
+        .to_string();
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_fleet_json_transcript(
+                "400 Bad Request",
+                &expected_body,
+                Some(GOLDEN_FLEET_ORIGIN)
+            )
+        );
+
+        // Delegate without a root key: the deterministic 400. (The
+        // issue/delegate rows are own-origin — deliberately not fleet
+        // rows — so no echo shapes exist for them.)
+        let response = collect_access_handler_response(|stream| {
+            handle_access_org_manage(
+                stream,
+                serde_json::json!({ "handle": "golden-org" }).to_string(),
+                "POST",
+                "/api/access/org-grants/issuers/delegate",
+                tmp.path().to_path_buf(),
+                golden_root_context(),
+                None,
+            )
+        })
+        .await;
+        let expected_body = serde_json::json!({
+            "error": "this daemon holds no root key for org \"golden-org\"; delegate from the org's designated daemon"
+        })
+        .to_string();
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_fleet_json_transcript("400 Bad Request", &expected_body, None)
+        );
+
+        // Issuer init over the injected store: creates the deputy key in
+        // the tempdir — framing pinned, generated key asserted through
+        // the parse.
+        let response = collect_access_handler_response(|stream| {
+            handle_access_org_manage(
+                stream,
+                serde_json::json!({ "handle": "golden-org" }).to_string(),
+                "POST",
+                "/api/access/org-grants/issuers/init",
+                tmp.path().to_path_buf(),
+                golden_root_context(),
+                None,
+            )
+        })
+        .await;
+        let text = golden_access_transcript(&response);
+        let (_, body) = split_transcript(&text);
+        assert_eq!(
+            text,
+            golden_access_fleet_json_transcript("200 OK", body, None)
+        );
+        let parsed: serde_json::Value = serde_json::from_str(body).unwrap();
+        assert_eq!(parsed["schema_version"], 1);
+        assert_eq!(parsed["handle"], "golden-org");
+        assert_eq!(parsed["certificate_installed"], serde_json::json!(false));
+        assert!(
+            parsed["issuer_key"].as_str().is_some_and(|k| !k.is_empty()),
+            "{body}"
+        );
+
+        // Parse error: 400 under the fleet tail.
+        let invalid = "not json";
+        let serde_error = serde_json::from_str::<serde_json::Value>(invalid).unwrap_err();
+        let expected_body =
+            serde_json::json!({"error": format!("invalid request body: {serde_error}")})
+                .to_string();
+        let response = collect_access_handler_response(|stream| {
+            handle_access_org_manage(
+                stream,
+                invalid.to_string(),
+                "POST",
+                "/api/access/orgs/trust",
+                tmp.path().to_path_buf(),
+                golden_root_context(),
+                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_fleet_json_transcript(
+                "400 Bad Request",
+                &expected_body,
+                Some(GOLDEN_FLEET_ORIGIN)
+            )
+        );
+
+        // Denied: the belt 403, PLAIN tail.
+        let denied_dir = tempfile::TempDir::new().unwrap();
+        let context = golden_denied_manage_context(denied_dir.path());
+        let body = golden_denied_manage_body(&context);
+        let response = collect_access_handler_response(|stream| {
+            handle_access_org_manage(
+                stream,
+                "{}".to_string(),
+                "POST",
+                "/api/access/orgs/trust",
+                denied_dir.path().to_path_buf(),
+                context,
+                Some(GOLDEN_FLEET_ORIGIN.to_string()),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_canonical_json_transcript("403 Forbidden", &body)
         );
     }
 }


### PR DESCRIPTION
Second S6 PR unit (transport-unification design §6 S6): the IAM grant mutations (upsert/update), enrollment decide, and the seven org-manage twins (trust, revoke, issue, revoke-member, issuers init/delegate/install).

Follows the S6a template, commits in the established order:
1. hermetic seams + golden transcripts — the grant/enrollment/org cores are cert-dir-parameterized (the ambient upsert/update wrappers die); goldens pin the current wire bytes over injected tempdirs, fleet-origin echo covered, the belt-403 PLAIN tail pinned per handler
2. HTTP side: transport-neutral `*_api_response` fns + an `OrgManageLeaf` fan-out (path-addressed on HTTP, method-addressed on the tunnel); handlers become shims; the dead `(u16, String)` body helpers fall away
3. golden catch, kept as its own commit: the org-manage handler historically renders EVERY leaf through the fleet decorator — the five own-origin leaves carry an inert `Vary: Origin` tail — so the shim keeps that framing (documented in place) instead of silently changing the wire
4. tunnel side: the ten twins delegate under the historical ok/error envelope; parity fixtures extend the S6 enumeration (#15 transport-owned leaf addressing, #16 HTTP-only decoration)
5. route rows gain `tunnel:` columns; CONTROL_METHODS sheds the ten entries; partition pin flips (all AccessManage, no overrides)

No wire change on either lane; goldens + parity fixtures are the proof. Battery: cargo nextest 2975 passed, clippy clean on the touched files.