### PR TITLE
setup-ci-account: password material, computed staff, sccache isolation

### DIFF
--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -102,20 +102,28 @@ at run time — nothing beyond the generic `_intendant-ci` name is
 committed):
 
 - **`setup-ci-account-macos.sh`** — creates the hidden role account
-  (`sysadminctl -roleAccount`: UID auto-picked in 200–400, own primary
-  group — not `staff`, not `admin` — no password login, home `/var/ci`;
-  role accounts conventionally live outside `/Users`, and an empty
-  non-template home keeps the hermeticity signal clean). Provisions the
+  (`sysadminctl -roleAccount`: UID auto-picked in 450–499 — the range
+  sysadminctl itself enforces — own primary group, not `admin`, no
+  password material, home `/var/ci`; role accounts conventionally live
+  outside `/Users`, and an empty non-template home keeps the
+  hermeticity signal clean). Two macOS realities, verified live: staff
+  membership is *computed* for every local account (not removable —
+  the boundary is 700 operator homes + no admin), and sysadminctl
+  mints ShadowHashData even with no password argument (the script
+  deletes it; verification fails if it ever reappears). Provisions the
   per-user toolchain **as that account**: rustup pinned to the invoking
   host's current `rustc -V` (printed; the workflows key their cargo
   target caches by it), `~/.cargo/config.toml` with the jobs cap above
-  (mirrors the operator's value; adds `rustc-wrapper = <sccache>` iff
-  sccache exists at install time), wasm-pack at the repo's
-  `.wasm-pack-version` pin (failure is a loud, canary-visible gap, not
-  a blocker). Installs the job hooks. Verifies and prints: not in
-  admin/staff, no password material, HOME resolves, and that the
-  account **cannot traverse any human `/Users/<home>`** (expects 700;
-  reports, never chmods — that fix is the operator's call).
+  (mirrors the operator's value; adds `rustc-wrapper = <sccache>` plus
+  a per-account `SCCACHE_SERVER_PORT`/`SCCACHE_DIR` iff sccache exists
+  — the client/server rendezvous is one machine-wide TCP port, and the
+  operator's server cannot read the CI account's 0750 toolchain).
+  wasm-pack at the repo's `.wasm-pack-version` pin (failure is a loud,
+  canary-visible gap, not a blocker). Installs the job hooks. Verifies
+  and prints: not in admin, no password material, HOME resolves, and
+  that the account **cannot traverse any human `/Users/<home>`**
+  (expects 700; reports, never chmods — that fix is the operator's
+  call).
 - **`migrate-runner-macos.sh <listener-name>`** — one listener per
   invocation. Stops the operator-account LaunchAgent, waits for the
   service tree to exit, moves the runner dir into `/var/ci` (the

--- a/scripts/ci/setup-ci-account-macos.sh
+++ b/scripts/ci/setup-ci-account-macos.sh
@@ -105,6 +105,12 @@ else
     dscl . -create "/Users/$CI_ACCOUNT" UserShell /bin/bash
     # Belt and braces (role accounts are already hidden by UID range):
     dscl . -create "/Users/$CI_ACCOUNT" IsHidden 1
+    # sysadminctl mints real PBKDF2 password material (ShadowHashData) even
+    # with no -password argument (verified live on Darwin 25.4). It is
+    # inert while the record has no AuthenticationAuthority, but a later
+    # tool could add one — delete the hash so password auth has nothing to
+    # verify against, ever.
+    dscl . -delete "/Users/$CI_ACCOUNT" dsAttrTypeNative:ShadowHashData 2>/dev/null || true
 fi
 
 CI_GROUP="$(id -gn "$CI_ACCOUNT")"
@@ -205,6 +211,15 @@ else
         echo "jobs = $jobs"
         if [ -n "$sccache_bin" ]; then
             echo "rustc-wrapper = \"$sccache_bin\""
+            # sccache's client/server rendezvous is one TCP port (default
+            # 4226) for the whole machine: the CI client would attach to
+            # the OPERATOR's server, which then can't read a 0750 /var/ci
+            # toolchain — "failed to execute compile" (live 2026-07-10).
+            # Give the CI account its own port and cache dir.
+            echo ""
+            echo "[env]"
+            echo "SCCACHE_SERVER_PORT = \"4227\""
+            echo "SCCACHE_DIR = \"$CI_HOME/.cache/sccache\""
         fi
     } > "$CARGO_CONFIG"
     chown "$CI_ACCOUNT:$CI_GROUP" "$CARGO_CONFIG"
@@ -282,18 +297,31 @@ if dseditgroup -o checkmember -m "$CI_ACCOUNT" admin 2>/dev/null | grep -q "^yes
 else
     echo "ok: not in admin"
 fi
+# staff(20) membership is COMPUTED for every local account on macOS
+# (opendirectoryd implicit membership — /Groups/staff lists only root;
+# there is no per-user record to delete, verified live on Darwin 25.4).
+# The effective boundary is 700 operator homes + no admin, checked below.
 if dseditgroup -o checkmember -m "$CI_ACCOUNT" staff 2>/dev/null | grep -q "^yes"; then
-    echo "FAIL: $CI_ACCOUNT is in staff" >&2
-    fail=1
+    echo "note: staff membership is macOS-computed for all local accounts (not removable; boundary = home modes + no admin)"
 else
     echo "ok: not in staff (primary group: $CI_GROUP)"
 fi
 
+# Password material: check the hash data itself, not just the authority
+# list — sysadminctl mints ShadowHashData unasked. Idempotent runs
+# converge (delete) rather than warn.
+if dscl . -read "/Users/$CI_ACCOUNT" dsAttrTypeNative:ShadowHashData >/dev/null 2>&1; then
+    dscl . -delete "/Users/$CI_ACCOUNT" dsAttrTypeNative:ShadowHashData 2>/dev/null || true
+fi
 auth_auth="$(dscl . -read "/Users/$CI_ACCOUNT" AuthenticationAuthority 2>/dev/null || true)"
-if echo "$auth_auth" | grep -q "ShadowHash"; then
-    echo "WARN: $CI_ACCOUNT has password material (AuthenticationAuthority: ShadowHash) — expected none" >&2
+if dscl . -read "/Users/$CI_ACCOUNT" dsAttrTypeNative:ShadowHashData >/dev/null 2>&1; then
+    echo "FAIL: $CI_ACCOUNT still has ShadowHashData after delete" >&2
+    fail=1
+elif echo "$auth_auth" | grep -q "ShadowHash"; then
+    echo "FAIL: $CI_ACCOUNT has a ShadowHash AuthenticationAuthority" >&2
+    fail=1
 else
-    echo "ok: no password login (no ShadowHash authority)"
+    echo "ok: no password material (no ShadowHashData, no ShadowHash authority)"
 fi
 
 # (logical pwd: /var is a symlink to /private/var on macOS, so a physical


### PR DESCRIPTION
Round 3 of live-cutover findings (after #178 UID range, #179 cwd/home-record):

1. **ShadowHashData minted unasked** — real PBKDF2 material despite no `-password`. Deleted at creation; verification converges and fails only if it survives or an authority appears.
2. **staff is computed** for all local accounts (`/Groups/staff` lists only root) — the not-in-staff FAIL could never pass. Now a documented note; the real boundary (no admin, 700 operator homes) stays enforced.
3. **sccache cross-user breakage**: one machine-wide rendezvous port meant CI builds attached to the operator's server, which can't exec the 0750 `/var/ci` toolchain. Seeded config gains `[env] SCCACHE_SERVER_PORT=4227` + per-account `SCCACHE_DIR` — this is also what failed the wasm-pack install.

`bash -n` clean; script + README only.