### PR TITLE
Transport S6c: signed-org doorbell twins + the fleet-cert ROW-NEW

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -2059,6 +2059,7 @@ its operation per method/path from `federation_http_operation`.
 | POST | `/api/access/connect/unclaim` | AccessManage | fleet allowlist | bounded | Release this daemon's claim binding at the rendezvous (daemon-signed) |
 | POST | `/api/access/tier` | AccessManage | fleet allowlist | bounded | Set this daemon's trust tier label (integrated/disposable; null clears) |
 | POST | `/api/access/hosted-ceiling` | AccessManage | fleet allowlist | bounded | Set the hosted-control ceiling role for hosted-provenance sessions |
+| POST | `/api/access/fleet-cert/request` | AccessManage | fleet allowlist | bounded | Request a fleet certificate (publish addresses, run the ACME DNS-01 order; async start) |
 | GET | `/api/dashboard/targets` | AccessInspect | own origin | none | Dashboard target list (this daemon + connected peers) |
 | any | `/api/peers[/…]` | federation (per method/path) | own origin | bounded | Peer registry (list/add/remove), pairing (invite/join/requests/identities), eligibility, and per-peer quick controls + signaling relays |
 | POST | `/api/coordinator/route` | federation (per method/path) | own origin | bounded | Capability-based task routing through the Coordinator |

--- a/src/bin/caller/access/org.rs
+++ b/src/bin/caller/access/org.rs
@@ -1064,6 +1064,7 @@ pub fn present_org_grant_state(
 /// document is the authorization on all of them, and a failure changes
 /// nothing.
 pub fn present_org_grant_value(
+    cert_dir: &std::path::Path,
     doc_value: &serde_json::Value,
     extra_daemon_ids: &[String],
     now_unix_ms: u64,
@@ -1071,18 +1072,17 @@ pub fn present_org_grant_value(
     if !presentation_rate_ok(now_unix_ms) {
         return Err("too many org grant presentations; retry shortly".to_string());
     }
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    let mut state = crate::access::iam::load_state(&cert_dir)
+    let mut state = crate::access::iam::load_state(cert_dir)
         .map_err(|e| format!("load local IAM state: {e}"))?;
     let outcome = present_org_grant_state(
         &mut state,
-        &cert_dir,
+        cert_dir,
         doc_value,
         extra_daemon_ids,
         now_unix_ms,
     )?;
     if outcome.changed() {
-        crate::access::iam::save_state(&cert_dir, &state)
+        crate::access::iam::save_state(cert_dir, &state)
             .map_err(|e| format!("save local IAM state: {e}"))?;
     }
     Ok(outcome)

--- a/src/bin/caller/connect_rendezvous.rs
+++ b/src/bin/caller/connect_rendezvous.rs
@@ -1174,6 +1174,7 @@ async fn handle_event(
                 .filter(|doc| !doc.is_null())
                 .and_then(|doc| {
                     crate::access::org::present_org_grant_value(
+                        &crate::access::backend::select_backend().cert_dir(),
                         doc,
                         &[daemon_id.to_string()],
                         crate::access::client_key::now_unix_ms() as u64,

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -2790,6 +2790,32 @@ mod tests {
         assert_eq!(frame["error"], http_body["error"]);
     }
 
+    #[tokio::test]
+    async fn parity_fleet_cert_request_shares_the_no_name_error() {
+        // The S6 ROW-NEW: both lanes run the one neutral fn. The test
+        // process holds no fleet name, so the deterministic error is
+        // the shared shape (explicit addresses keep the fixture off the
+        // NIC-enumeration default; the no-name path never spawns the
+        // ACME flow).
+        let params = || serde_json::json!({ "addresses": ["192.0.2.10"] });
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::fleet_cert_request_api_response(params()),
+        );
+        assert_eq!(status, 400);
+        let frame = frame_api_ok_error_response(
+            "parity-fleet-cert".to_string(),
+            crate::web_gateway::fleet_cert_request_api_response(params()),
+            "fleet cert request",
+        );
+        assert_eq!(frame["ok"], false);
+        assert_eq!(frame["error"], http_body["error"]);
+        assert_eq!(
+            frame["error"],
+            "this daemon has no fleet name — enable Connect against a \
+             rendezvous with fleet DNS and let it register first"
+        );
+    }
+
     use crate::*;
     use crate::dashboard_control::tests::{runtime};
 

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -2697,6 +2697,99 @@ mod tests {
         assert_eq!(frame["result"], http_body);
     }
 
+    // ── S6 tunnel/HTTP parity (third slice): the signed-org doorbell
+    // quartet ──
+    //
+    // Extends the S6 enumeration (#10–#16 apply). The slice-specific
+    // differences, deliberate and pinned:
+    //
+    //  17. Authority is the documented op-override pair (design §2.7):
+    //      the HTTP rows are Public (the signed document/list IS the
+    //      authorization, rate-limited and size-capped), while the
+    //      tunnel methods gate on a bound session's operation —
+    //      AccessInspect for present/orl/renew, PresenceRead for the
+    //      orl-apply courier — declared as `op_override`s on the rows
+    //      and pinned closed by
+    //      `tunnel_op_overrides_are_a_closed_documented_enumeration`.
+    //  18. ORL addressing is transport-owned: HTTP captures the org
+    //      handle from the path, the tunnel reads `params.handle`.
+    //  19. The ORL error is the historical 404 on HTTP; the tunnel
+    //      frame carries the same error string with no status.
+
+    #[tokio::test]
+    async fn parity_org_doorbell_shares_cores_over_an_injected_cert_dir() {
+        let tmp = tempfile::tempdir().expect("temp cert dir");
+
+        // Present, undecodable document: same core error on both lanes
+        // (the verify successes need real signed documents — smoke-
+        // covered by validate-org-grants).
+        let card = serde_json::json!({});
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_org_present_api_response(
+                tmp.path(),
+                serde_json::json!({}),
+                &card,
+            ),
+        );
+        assert_eq!(status, 400);
+        let frame = frame_api_ok_error_response(
+            "parity-org-present".to_string(),
+            crate::web_gateway::access_org_present_api_response(
+                tmp.path(),
+                serde_json::json!({}),
+                &card,
+            ),
+            "org doorbell",
+        );
+        assert_eq!(frame["ok"], false);
+        assert_eq!(frame["error"], http_body["error"]);
+
+        // ORL for an unheld org: 404 on HTTP, the same error string as
+        // the tunnel's ok:false frame (differences #18/#19).
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_org_orl_api_response(tmp.path(), "parity-org"),
+        );
+        assert_eq!(status, 404);
+        let frame = frame_api_ok_error_response(
+            "parity-org-orl".to_string(),
+            crate::web_gateway::access_org_orl_api_response(tmp.path(), "parity-org"),
+            "org doorbell",
+        );
+        assert_eq!(frame["ok"], false);
+        assert_eq!(frame["error"], http_body["error"]);
+
+        // Apply + renew decode errors: one core wording per leaf.
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_org_orl_apply_api_response(
+                tmp.path(),
+                serde_json::json!({}),
+            ),
+        );
+        assert_eq!(status, 400);
+        let frame = frame_api_ok_error_response(
+            "parity-org-orl-apply".to_string(),
+            crate::web_gateway::access_org_orl_apply_api_response(
+                tmp.path(),
+                serde_json::json!({}),
+            ),
+            "org doorbell",
+        );
+        assert_eq!(frame["ok"], false);
+        assert_eq!(frame["error"], http_body["error"]);
+
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::access_org_renew_api_response(tmp.path(), serde_json::json!({})),
+        );
+        assert_eq!(status, 400);
+        let frame = frame_api_ok_error_response(
+            "parity-org-renew".to_string(),
+            crate::web_gateway::access_org_renew_api_response(tmp.path(), serde_json::json!({})),
+            "org doorbell",
+        );
+        assert_eq!(frame["ok"], false);
+        assert_eq!(frame["error"], http_body["error"]);
+    }
+
     use crate::*;
     use crate::dashboard_control::tests::{runtime};
 

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -703,40 +703,12 @@ pub(crate) fn control_frame_response(
                     ))
                 }
                 "api_fleet_cert_request" => {
-                    // Optional explicit addresses; default = every
-                    // routable local address (the LAN is the point).
-                    let addresses: Vec<String> = params
-                        .as_ref()
-                        .and_then(|p| p.get("addresses"))
-                        .and_then(|v| v.as_array())
-                        .map(|list| {
-                            list.iter()
-                                .filter_map(|v| v.as_str().map(str::to_string))
-                                .collect()
-                        })
-                        .filter(|list: &Vec<String>| !list.is_empty())
-                        .unwrap_or_else(crate::fleet_cert::default_publish_addresses);
-                    if crate::fleet_cert::status_snapshot().name.is_none() {
-                        return Some(dashboard_control_error_response(
-                            id,
-                            "this daemon has no fleet name — enable Connect against a \
-                             rendezvous with fleet DNS and let it register first",
-                        ));
-                    }
-                    let spawned_addresses = addresses.clone();
-                    tokio::spawn(async move {
-                        if let Err(error) =
-                            crate::fleet_cert::request_certificate(spawned_addresses).await
-                        {
-                            eprintln!("[fleet-cert] request failed: {error}");
-                        }
-                    });
-                    Some(serde_json::json!({
-                        "t": "response",
-                        "id": id,
-                        "ok": true,
-                        "result": { "started": true, "addresses": addresses },
-                    }))
+                    let params = params.unwrap_or_else(|| serde_json::json!({}));
+                    Some(frame_api_ok_error_response(
+                        id,
+                        crate::web_gateway::fleet_cert_request_api_response(params),
+                        "fleet cert request",
+                    ))
                 }
                 // The seven org-manage twins delegate to the S6 neutral
                 // core (leaf addressed by method name); the signed-org

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -768,17 +768,24 @@ pub(crate) fn control_frame_response(
                 | "api_access_org_orl_apply"
                 | "api_access_org_renew" => {
                     let params = params.unwrap_or_else(|| serde_json::json!({}));
+                    // Transport edge resolves the ambient cert dir
+                    // (hermeticity convention).
+                    let cert_dir = crate::access::backend::select_backend().cert_dir();
                     let result = match method {
                         "api_access_org_orl" => crate::web_gateway::access_org_orl_response_value(
+                            &cert_dir,
                             params.get("handle").and_then(|v| v.as_str()).unwrap_or(""),
                         ),
                         "api_access_org_orl_apply" => {
-                            crate::web_gateway::access_org_orl_apply_response_value(params)
+                            crate::web_gateway::access_org_orl_apply_response_value(
+                                &cert_dir, params,
+                            )
                         }
                         "api_access_org_renew" => {
-                            crate::web_gateway::access_org_renew_response_value(params)
+                            crate::web_gateway::access_org_renew_response_value(&cert_dir, params)
                         }
                         _ => crate::web_gateway::access_org_present_response_value(
+                            &cert_dir,
                             params,
                             &runtime.agent_card,
                         ),

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -763,6 +763,12 @@ pub(crate) fn control_frame_response(
                         "org manage",
                     ))
                 }
+                // The signed-org doorbell twins delegate to the S6
+                // neutral cores under the family's ok/error envelope.
+                // Their route rows are Public — the tunnel methods gate
+                // stricter on purpose (documented op overrides on the
+                // rows): a bound session is required to courier a
+                // document through the tunnel.
                 "api_access_org_present"
                 | "api_access_org_orl"
                 | "api_access_org_orl_apply"
@@ -771,39 +777,29 @@ pub(crate) fn control_frame_response(
                     // Transport edge resolves the ambient cert dir
                     // (hermeticity convention).
                     let cert_dir = crate::access::backend::select_backend().cert_dir();
-                    let result = match method {
-                        "api_access_org_orl" => crate::web_gateway::access_org_orl_response_value(
+                    let response = match method {
+                        "api_access_org_orl" => crate::web_gateway::access_org_orl_api_response(
                             &cert_dir,
+                            // Transport-owned addressing: the tunnel
+                            // names the org in params; HTTP by path
+                            // capture.
                             params.get("handle").and_then(|v| v.as_str()).unwrap_or(""),
                         ),
                         "api_access_org_orl_apply" => {
-                            crate::web_gateway::access_org_orl_apply_response_value(
+                            crate::web_gateway::access_org_orl_apply_api_response(
                                 &cert_dir, params,
                             )
                         }
                         "api_access_org_renew" => {
-                            crate::web_gateway::access_org_renew_response_value(&cert_dir, params)
+                            crate::web_gateway::access_org_renew_api_response(&cert_dir, params)
                         }
-                        _ => crate::web_gateway::access_org_present_response_value(
+                        _ => crate::web_gateway::access_org_present_api_response(
                             &cert_dir,
                             params,
                             &runtime.agent_card,
                         ),
                     };
-                    match result {
-                        Ok(result) => Some(serde_json::json!({
-                            "t": "response",
-                            "id": id,
-                            "ok": true,
-                            "result": result,
-                        })),
-                        Err(error) => Some(serde_json::json!({
-                            "t": "response",
-                            "id": id,
-                            "ok": false,
-                            "error": error,
-                        })),
-                    }
+                    Some(frame_api_ok_error_response(id, response, "org doorbell"))
                 }
                 "api_access_iam_upsert_user_client_grant" => {
                     let params = params.unwrap_or_else(|| serde_json::json!({}));

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -190,17 +190,10 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
     // The IAM grant mutations (upsert/update), enrollment decide, and
     // the seven org-manage methods live as tunnel columns on their route
     // rows — their IAM operations derive from the rows (S6).
-    // Presenting a signed org document (or list) only requires a session;
-    // the document itself is the authorization and is fully re-verified.
-    // Same for reading the org's public revocation list and renewing a
-    // still-valid document.
-    method("api_access_org_present", PeerOperation::AccessInspect),
-    method("api_access_org_orl", PeerOperation::AccessInspect),
-    method("api_access_org_renew", PeerOperation::AccessInspect),
-    // Applying a root-signed revocation list mirrors a PUBLIC doorbell
-    // (`POST /api/access/orgs/revocations/apply`): the signature is the
-    // authority, so any session may courier one through the tunnel.
-    method("api_access_org_orl_apply", PeerOperation::PresenceRead),
+    // The signed-org doorbell methods (present, orl, orl_apply, renew)
+    // live as tunnel columns on their PUBLIC route rows with documented
+    // op overrides — session-gated on the tunnel by design (S6; the
+    // override enumeration test in gateway_routes pins the set).
     method("api_peer_pairing_requests", PeerOperation::AccessInspect),
     method("api_peer_pairing_identities", PeerOperation::AccessInspect),
     method(
@@ -3110,10 +3103,10 @@ mod tests {
                 Row,
                 Some(Op::AccessManage),
             ),
-            ("api_access_org_present", Residue, Some(Op::AccessInspect)),
-            ("api_access_org_orl", Residue, Some(Op::AccessInspect)),
-            ("api_access_org_renew", Residue, Some(Op::AccessInspect)),
-            ("api_access_org_orl_apply", Residue, Some(Op::PresenceRead)),
+            ("api_access_org_present", Row, Some(Op::AccessInspect)),
+            ("api_access_org_orl", Row, Some(Op::AccessInspect)),
+            ("api_access_org_renew", Row, Some(Op::AccessInspect)),
+            ("api_access_org_orl_apply", Row, Some(Op::PresenceRead)),
             (
                 "api_peer_pairing_requests",
                 Residue,

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -149,10 +149,9 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
     // trust-tier pair (set_tier, set_hosted_ceiling) live as tunnel
     // columns on their route rows — their IAM operations derive from the
     // rows (S6).
-    // Fleet certificate: publish this daemon's addresses for its fleet
-    // name and run the ACME DNS-01 order (fleet_cert.rs). Slow flow,
-    // started async; progress rides the connect status payload.
-    method("api_fleet_cert_request", PeerOperation::AccessManage),
+    // api_fleet_cert_request lives as a tunnel column on its ROW-NEW
+    // (POST /api/access/fleet-cert/request — S6 closed the family's one
+    // missing HTTP twin).
     // Credential custody (vault leases + client egress): granting, renewing,
     // revoking, and even reading lease status all sit behind the dedicated
     // gate — a scoped guest session can neither fuel nor drain a daemon, nor
@@ -2994,7 +2993,7 @@ mod tests {
                 Row,
                 Some(Op::AccessManage),
             ),
-            ("api_fleet_cert_request", Residue, Some(Op::AccessManage)),
+            ("api_fleet_cert_request", Row, Some(Op::AccessManage)),
             (
                 "api_credential_lease_grant",
                 Residue,

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -321,6 +321,23 @@ const fn tunnel_method(name: &'static str) -> TunnelSpec {
     }
 }
 
+/// Advertised tunnel twin whose IAM operation deliberately diverges
+/// from the row (design §2.7): `op` gates the tunnel method, `reason`
+/// documents why, and the override enumeration test pins the set
+/// closed.
+const fn tunnel_method_with_op(
+    name: &'static str,
+    op: PeerOperation,
+    reason: &'static str,
+) -> TunnelSpec {
+    TunnelSpec {
+        name,
+        op_override: Some((op, reason)),
+        advertised: true,
+        upload: false,
+    }
+}
+
 /// Advertised tunnel twin that may also arrive as an upload frame.
 const fn tunnel_uploadable(name: &'static str) -> TunnelSpec {
     TunnelSpec {
@@ -1091,7 +1108,12 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::Capped(crate::access::org::MAX_ORG_GRANT_DOC_BYTES),
         RouteHandlerId::AccessOrgGrantPresent,
         "Present a signed org grant document (verified against locally trusted org keys)",
-    ),
+    )
+    .with_tunnel(tunnel_method_with_op(
+        "api_access_org_present",
+        PeerOperation::AccessInspect,
+        "Public doorbell on HTTP (the signed document is the authorization); the tunnel requires a bound session — stricter on purpose",
+    )),
     public_route(
         RouteMethod::Get,
         PathPattern::Segments(
@@ -1104,21 +1126,36 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::AccessOrgRevocations,
         "Org revocation list (ORL) for a trusted org",
-    ),
+    )
+    .with_tunnel(tunnel_method_with_op(
+        "api_access_org_orl",
+        PeerOperation::AccessInspect,
+        "Public read on HTTP; the tunnel requires a bound session — stricter on purpose",
+    )),
     public_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/access/orgs/revocations/apply"),
         BodyPolicy::Capped(crate::access::org::MAX_ORG_ORL_BYTES),
         RouteHandlerId::AccessOrgApplyRenew,
         "Apply a signed org revocation list",
-    ),
+    )
+    .with_tunnel(tunnel_method_with_op(
+        "api_access_org_orl_apply",
+        PeerOperation::PresenceRead,
+        "Public doorbell on HTTP (the root signature is the authority); any bound session may courier one through the tunnel",
+    )),
     public_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/access/org-grants/renew"),
         BodyPolicy::Capped(crate::access::org::MAX_ORG_GRANT_DOC_BYTES),
         RouteHandlerId::AccessOrgApplyRenew,
         "Renew an org grant document (signed payload)",
-    ),
+    )
+    .with_tunnel(tunnel_method_with_op(
+        "api_access_org_renew",
+        PeerOperation::AccessInspect,
+        "Public doorbell on HTTP (the signed document is the authorization); the tunnel requires a bound session — stricter on purpose",
+    )),
     // ── Access administration (fleet-CORS where the anchor page needs
     //    to read responses; own-origin otherwise).
     fleet_route(
@@ -2104,14 +2141,18 @@ mod tests {
     /// The op-override slot is a closed, documented enumeration (design
     /// §2.7 / risk R2): every override names its reason, and this test
     /// pins the exact set so a tunnel/HTTP divergence can only ever be
-    /// added deliberately. Empty today — S0 (PR #128) settled the two
-    /// formerly-divergent twins identically on both lanes, so the first
-    /// legitimate entries arrive with the signed-org doorbell rows
-    /// (Public on HTTP, session-gated on the tunnel) when their family
-    /// ports.
+    /// added deliberately. The occupants are the signed-org doorbell
+    /// twins (S6): Public rows on HTTP — the signed document/list is
+    /// the authorization — while the tunnel methods deliberately gate
+    /// on a bound session's operation.
     #[test]
     fn tunnel_op_overrides_are_a_closed_documented_enumeration() {
-        let documented: &[&str] = &[];
+        let documented: &[&str] = &[
+            "api_access_org_orl",
+            "api_access_org_orl_apply",
+            "api_access_org_present",
+            "api_access_org_renew",
+        ];
         let mut actual: Vec<&str> = Vec::new();
         for (_, spec) in tunnel_specs() {
             if let Some((_, reason)) = spec.op_override {

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -267,6 +267,9 @@ pub(crate) enum RouteHandlerId {
     /// tier label and the hosted-control ceiling knob. One handler, two
     /// paths, switched on `req_path`.
     AccessTierSettings,
+    /// Fleet certificate request (async-start; progress rides the
+    /// connect status payload).
+    AccessFleetCertRequest,
     DashboardTargets,
     /// The whole /api/peers registry + pairing sub-router, moved
     /// verbatim (its internal shapes stay as they were; leaf-shape
@@ -1333,6 +1336,15 @@ pub(crate) static ROUTES: &[Route] = &[
         "Set the hosted-control ceiling role for hosted-provenance sessions",
     )
     .with_tunnel(tunnel_method("api_access_set_hosted_ceiling")),
+    fleet_route(
+        RouteMethod::Post,
+        PathPattern::Exact("/api/access/fleet-cert/request"),
+        PeerOperation::AccessManage,
+        BodyPolicy::Default,
+        RouteHandlerId::AccessFleetCertRequest,
+        "Request a fleet certificate (publish addresses, run the ACME DNS-01 order; async start)",
+    )
+    .with_tunnel(tunnel_method("api_fleet_cert_request")),
     op_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/dashboard/targets"),

--- a/src/bin/caller/web_gateway/connect_bootstrap.rs
+++ b/src/bin/caller/web_gateway/connect_bootstrap.rs
@@ -55,6 +55,7 @@ pub(crate) async fn connect_dashboard_offer_response(
         .filter(|doc| !doc.is_null())
         .and_then(|doc| {
             crate::access::org::present_org_grant_value(
+                &crate::access::backend::select_backend().cert_dir(),
                 doc,
                 &org_target_agent_card_ids(agent_card),
                 crate::access::client_key::now_unix_ms() as u64,

--- a/src/bin/caller/web_gateway/http.rs
+++ b/src/bin/caller/web_gateway/http.rs
@@ -449,8 +449,9 @@ impl HttpResponse {
     }
 
     /// Fleet-allowlist CORS posture: strip any wildcard, echo the origin
-    /// only when it passed the allowlist, and mark `Vary: Origin` — the
-    /// builder form of `with_fleet_cors`.
+    /// only when it passed the allowlist, and mark `Vary: Origin`. The
+    /// one fleet renderer (its string-form ancestor retired with the S6
+    /// access-family conversion).
     pub(crate) fn fleet_cors(mut self, allowed_origin: Option<&str>) -> Self {
         self.headers
             .retain(|(name, _)| !name.eq_ignore_ascii_case("access-control-allow-origin"));
@@ -666,33 +667,6 @@ pub(crate) fn with_public_cors(response: String) -> String {
     format!("{head}\r\nAccess-Control-Allow-Origin: *{rest}")
 }
 
-/// Rewrite a JSON response's CORS posture for the fleet Access APIs: echo
-/// the specific origin only when it passed the fleet allowlist (stripping
-/// any pre-existing ACAO — duplicates are invalid to browsers). These six
-/// routes must never be wildcard-readable — a cert-installed browser would
-/// happily authenticate reads for any website.
-pub(crate) fn with_fleet_cors(response: String, allowed_origin: Option<&str>) -> String {
-    let Some(split) = response.find("\r\n\r\n") else {
-        return response;
-    };
-    let (head, rest) = response.split_at(split);
-    let mut lines: Vec<&str> = head
-        .split("\r\n")
-        .filter(|line| {
-            !line
-                .to_ascii_lowercase()
-                .starts_with("access-control-allow-origin:")
-        })
-        .collect();
-    let echo;
-    if let Some(origin) = allowed_origin {
-        echo = format!("Access-Control-Allow-Origin: {origin}");
-        lines.push(&echo);
-    }
-    lines.push("Vary: Origin");
-    format!("{}{rest}", lines.join("\r\n"))
-}
-
 /// Body cap for the public /connect/dashboard signaling arms (SDP offers
 /// and ICE batches stay far below this; the lane is reachable before any
 /// authentication, so it must never buffer unbounded input).
@@ -816,7 +790,10 @@ mod tests {
              \r\n\
              <h1>gone</h1>"
         );
-        // The builder's CORS postures match the string post-processors.
+        // The builder's CORS postures match the historical
+        // post-processor bytes (the string-form fleet helper is gone —
+        // the builder is the one fleet renderer, so its shapes are
+        // pinned literally).
         assert_eq!(
             HttpResponse::json("200 OK", "{}")
                 .public_cors()
@@ -827,16 +804,28 @@ mod tests {
             HttpResponse::json("200 OK", "{}")
                 .fleet_cors(Some("https://fleet.example"))
                 .into_string(),
-            with_fleet_cors(
-                json_response("200 OK", "{}".to_string()),
-                Some("https://fleet.example")
-            )
+            "HTTP/1.1 200 OK\r\n\
+             Content-Type: application/json\r\n\
+             Content-Length: 2\r\n\
+             Cache-Control: no-cache\r\n\
+             Connection: close\r\n\
+             Access-Control-Allow-Origin: https://fleet.example\r\n\
+             Vary: Origin\r\n\
+             \r\n\
+             {}"
         );
         assert_eq!(
             HttpResponse::json("200 OK", "{}")
                 .fleet_cors(None)
                 .into_string(),
-            with_fleet_cors(json_response("200 OK", "{}".to_string()), None)
+            "HTTP/1.1 200 OK\r\n\
+             Content-Type: application/json\r\n\
+             Content-Length: 2\r\n\
+             Cache-Control: no-cache\r\n\
+             Connection: close\r\n\
+             Vary: Origin\r\n\
+             \r\n\
+             {}"
         );
     }
 
@@ -964,19 +953,19 @@ mod tests {
         assert!(!is_fleet_cors_access_path("/api/access/org-grants"));
         assert!(!is_fleet_cors_access_path("/api/access/org-grants/issue"));
 
-        // The generic helper's wildcard must be REPLACED, never duplicated.
-        let with = with_fleet_cors(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\n\r\n{}".to_string(),
-            Some("https://daemon.local:8765"),
-        );
+        // A pre-existing wildcard must be REPLACED, never duplicated.
+        let with = HttpResponse::with_content("200 OK", "application/json", "{}")
+            .header("Access-Control-Allow-Origin", "*")
+            .fleet_cors(Some("https://daemon.local:8765"))
+            .into_string();
         assert_eq!(with.matches("Access-Control-Allow-Origin").count(), 1);
         assert!(with.contains("Access-Control-Allow-Origin: https://daemon.local:8765"));
         assert!(with.contains("Vary: Origin"));
         assert!(with.ends_with("\r\n\r\n{}"));
-        let without = with_fleet_cors(
-            "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\n\r\n{}".to_string(),
-            None,
-        );
+        let without = HttpResponse::with_content("200 OK", "application/json", "{}")
+            .header("Access-Control-Allow-Origin", "*")
+            .fleet_cors(None)
+            .into_string();
         assert!(!without.contains("Access-Control-Allow-Origin"));
         assert!(without.contains("Vary: Origin"));
     }

--- a/src/bin/caller/web_gateway/http.rs
+++ b/src/bin/caller/web_gateway/http.rs
@@ -934,6 +934,11 @@ mod tests {
 
     #[test]
     fn fleet_cors_paths_cover_exactly_the_access_apis() {
+        // is_fleet_cors_access_path derives from the route table (S6):
+        // every FleetAllowlist row's path answers true — a new fleet
+        // row (the fleet-cert ROW-NEW is the first) joins the write-side
+        // origin gate by declaration instead of by remembering to edit
+        // a hand-kept list.
         for path in [
             "/api/access/overview",
             "/api/access/iam/state",
@@ -941,15 +946,23 @@ mod tests {
             "/api/access/enrollment-requests/decide",
             "/api/access/iam/user-client-grants",
             "/api/access/iam/grants/update",
+            "/api/access/orgs/trust",
+            "/api/access/orgs/revoke",
             "/api/access/connect/status",
             "/api/access/connect/claim-code",
             "/api/access/connect/config",
             "/api/access/connect/unclaim",
+            "/api/access/tier",
+            "/api/access/hosted-ceiling",
+            "/api/access/fleet-cert/request",
         ] {
             assert!(is_fleet_cors_access_path(path), "{path}");
         }
         assert!(!is_fleet_cors_access_path("/api/peers"));
         assert!(!is_fleet_cors_access_path("/config"));
+        // Public and own-origin access rows stay out of the fleet set.
+        assert!(!is_fleet_cors_access_path("/api/access/org-grants"));
+        assert!(!is_fleet_cors_access_path("/api/access/org-grants/issue"));
 
         // The generic helper's wildcard must be REPLACED, never duplicated.
         let with = with_fleet_cors(

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -813,16 +813,23 @@ pub(crate) async fn serve_http_request(
                     stream,
                     route_body,
                     req_method,
+                    cert_dir,
                     agent_card_value_for_targets,
                 )
                 .await;
             }
             RouteHandlerId::AccessOrgRevocations => {
-                return handle_access_org_revocations(stream, req_path).await;
+                return handle_access_org_revocations(stream, req_path, cert_dir).await;
             }
             RouteHandlerId::AccessOrgApplyRenew => {
-                return handle_access_org_apply_renew(stream, route_body, req_method, req_path)
-                    .await;
+                return handle_access_org_apply_renew(
+                    stream,
+                    route_body,
+                    req_method,
+                    req_path,
+                    cert_dir,
+                )
+                .await;
             }
             RouteHandlerId::AccessIamGrants => {
                 return handle_access_iam_grants(

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -812,22 +812,23 @@ pub(crate) async fn serve_http_request(
                 return handle_access_org_grant_present(
                     stream,
                     route_body,
-                    req_method,
                     cert_dir,
                     agent_card_value_for_targets,
+                    route.cors,
                 )
                 .await;
             }
             RouteHandlerId::AccessOrgRevocations => {
-                return handle_access_org_revocations(stream, req_path, cert_dir).await;
+                return handle_access_org_revocations(stream, req_path, cert_dir, route.cors)
+                    .await;
             }
             RouteHandlerId::AccessOrgApplyRenew => {
                 return handle_access_org_apply_renew(
                     stream,
                     route_body,
-                    req_method,
                     req_path,
                     cert_dir,
+                    route.cors,
                 )
                 .await;
             }

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -934,6 +934,16 @@ pub(crate) async fn serve_http_request(
                 )
                 .await;
             }
+            RouteHandlerId::AccessFleetCertRequest => {
+                return handle_fleet_cert_request(
+                    stream,
+                    route_body,
+                    http_access_context,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
             RouteHandlerId::AccessOverview => {
                 return handle_access_overview(
                     stream,

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -246,8 +246,8 @@ impl Default for WebGatewayConfig {
 
 // Deliberately no Access-Control-Allow-Origin here: API responses are
 // same-origin by default. Cross-origin readability is opt-in — the fleet
-// Access APIs echo allowlisted origins (`with_fleet_cors`) and the public
-// bootstrap surfaces use `with_public_cors`. A blanket wildcard would let
+// Access APIs echo allowlisted origins (`HttpResponse::fleet_cors`) and the
+// public bootstrap surfaces use `with_public_cors`. A blanket wildcard would let
 // any website read cert-authenticated responses through a visitor's
 // browser (see docs/src/trust-architecture.md).
 

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -174,85 +174,59 @@ pub(crate) async fn handle_dashboard_targets(
 }
 
 pub(crate) async fn handle_access_org_grant_present(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     body_text: String,
-    req_method: &str,
     cert_dir: std::path::PathBuf,
     agent_card_value_for_targets: serde_json::Value,
+    cors: crate::gateway_routes::CorsPosture,
 ) {
-    use tokio::io::AsyncWriteExt;
-    let response = if req_method != "POST" {
-        json_response(
-            "405 Method Not Allowed",
-            serde_json::json!({"error": "method not allowed"}).to_string(),
-        )
-    } else {
-        let (status, body) = match serde_json::from_str::<serde_json::Value>(&body_text)
-            .map_err(|e| format!("invalid JSON: {e}"))
-            .and_then(|params| {
-                access_org_present_response_value(&cert_dir, params, &agent_card_value_for_targets)
-            }) {
-            Ok(value) => (200, value.to_string()),
-            Err(error) => (400, serde_json::json!({"error": error}).to_string()),
-        };
-        with_public_cors(json_response(status_reason(status), body))
+    // Transport-owned body decode; the doorbell's parse-error 400 rides
+    // the same public tail as its value errors.
+    let response = match serde_json::from_str::<serde_json::Value>(&body_text) {
+        Ok(params) => access_org_present_api_response(
+            &cert_dir,
+            params,
+            &agent_card_value_for_targets,
+        ),
+        Err(e) => ApiResponse::json_error(400, format!("invalid JSON: {e}")),
     };
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    write_api_response(stream, response, cors, None).await;
 }
 
 pub(crate) async fn handle_access_org_revocations(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     req_path: &str,
     cert_dir: std::path::PathBuf,
+    cors: crate::gateway_routes::CorsPosture,
 ) {
-    use tokio::io::AsyncWriteExt;
     let handle = req_path
         .strip_prefix("/api/access/orgs/")
         .and_then(|rest| rest.strip_suffix("/revocations"))
         .unwrap_or("");
-    let (status, body) = match access_org_orl_response_value(&cert_dir, handle) {
-        Ok(value) => (200, value.to_string()),
-        Err(error) => (404, serde_json::json!({"error": error}).to_string()),
-    };
-    let response = with_public_cors(json_response(status_reason(status), body));
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    let response = access_org_orl_api_response(&cert_dir, handle);
+    write_api_response(stream, response, cors, None).await;
 }
 
 pub(crate) async fn handle_access_org_apply_renew(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     body_text: String,
-    req_method: &str,
     req_path: &str,
     cert_dir: std::path::PathBuf,
+    cors: crate::gateway_routes::CorsPosture,
 ) {
-    use tokio::io::AsyncWriteExt;
-    let response = if req_method != "POST" {
-        json_response(
-            "405 Method Not Allowed",
-            serde_json::json!({"error": "method not allowed"}).to_string(),
-        )
-    } else {
-        // The per-path caps (ORL vs grant-doc) live on the two table rows;
-        // dispatch already read under the right one.
-        let handler = if req_path == "/api/access/orgs/revocations/apply" {
-            access_org_orl_apply_response_value
-                as fn(&std::path::Path, serde_json::Value) -> Result<serde_json::Value, String>
-        } else {
-            access_org_renew_response_value
-        };
-        let (status, body) = match serde_json::from_str::<serde_json::Value>(&body_text)
-            .map_err(|e| format!("invalid JSON: {e}"))
-            .and_then(|params| handler(&cert_dir, params))
-        {
-            Ok(value) => (200, value.to_string()),
-            Err(error) => (400, serde_json::json!({"error": error}).to_string()),
-        };
-        with_public_cors(json_response(status_reason(status), body))
+    // The per-path caps (ORL vs grant-doc) live on the two table rows;
+    // dispatch already read under the right one.
+    let response = match serde_json::from_str::<serde_json::Value>(&body_text) {
+        Ok(params) => {
+            if req_path == "/api/access/orgs/revocations/apply" {
+                access_org_orl_apply_api_response(&cert_dir, params)
+            } else {
+                access_org_renew_api_response(&cert_dir, params)
+            }
+        }
+        Err(e) => ApiResponse::json_error(400, format!("invalid JSON: {e}")),
     };
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    write_api_response(stream, response, cors, None).await;
 }
 
 pub(crate) async fn handle_access_iam_grants(
@@ -879,6 +853,47 @@ pub(crate) fn access_org_manage_api_response(
         OrgManageLeaf::IssuerInstall => access_org_issuer_install_response_value(cert_dir, params),
     };
     access_result_api_response(result, 400)
+}
+
+/// POST /api/access/org-grants + the tunnel's `api_access_org_present`
+/// (the doorbell class: the signed document is the authorization).
+pub(crate) fn access_org_present_api_response(
+    cert_dir: &std::path::Path,
+    params: serde_json::Value,
+    agent_card: &serde_json::Value,
+) -> ApiResponse {
+    access_result_api_response(
+        access_org_present_response_value(cert_dir, params, agent_card),
+        400,
+    )
+}
+
+/// GET /api/access/orgs/{handle}/revocations + the tunnel's
+/// `api_access_org_orl` — the one doorbell leaf whose error is the
+/// historical 404 (unknown org / no root key held).
+pub(crate) fn access_org_orl_api_response(
+    cert_dir: &std::path::Path,
+    handle: &str,
+) -> ApiResponse {
+    access_result_api_response(access_org_orl_response_value(cert_dir, handle), 404)
+}
+
+/// POST /api/access/orgs/revocations/apply + the tunnel's
+/// `api_access_org_orl_apply`.
+pub(crate) fn access_org_orl_apply_api_response(
+    cert_dir: &std::path::Path,
+    params: serde_json::Value,
+) -> ApiResponse {
+    access_result_api_response(access_org_orl_apply_response_value(cert_dir, params), 400)
+}
+
+/// POST /api/access/org-grants/renew + the tunnel's
+/// `api_access_org_renew`.
+pub(crate) fn access_org_renew_api_response(
+    cert_dir: &std::path::Path,
+    params: serde_json::Value,
+) -> ApiResponse {
+    access_result_api_response(access_org_renew_response_value(cert_dir, params), 400)
 }
 
 pub(crate) async fn handle_access_overview(
@@ -1525,23 +1540,17 @@ pub(crate) async fn handle_access_tier_settings(
 /// used by harmless bootstrap endpoints. The same allowlist doubles as a
 /// write-side origin gate: browser-attached mTLS certificates would
 /// otherwise let any website fire state-changing requests cross-site.
+///
+/// Derived from the route table (derive, don't mirror): a path is
+/// fleet-scoped exactly when its rows declare
+/// [`crate::gateway_routes::CorsPosture::FleetAllowlist`] — the same
+/// declaration that drives dispatch rendering and the preflight, so a
+/// new fleet row's write-side origin gate can never lag its posture
+/// (the hand-kept list this replaces silently missed exactly that way).
 pub(crate) fn is_fleet_cors_access_path(req_path: &str) -> bool {
     matches!(
-        req_path,
-        "/api/access/overview"
-            | "/api/access/iam/state"
-            | "/api/access/enrollment-requests"
-            | "/api/access/enrollment-requests/decide"
-            | "/api/access/iam/user-client-grants"
-            | "/api/access/iam/grants/update"
-            | "/api/access/orgs/trust"
-            | "/api/access/orgs/revoke"
-            | "/api/access/connect/status"
-            | "/api/access/connect/claim-code"
-            | "/api/access/connect/config"
-            | "/api/access/connect/unclaim"
-            | "/api/access/tier"
-            | "/api/access/hosted-ceiling"
+        crate::gateway_routes::preflight_posture(req_path),
+        Some(crate::gateway_routes::CorsPosture::FleetAllowlist)
     )
 }
 
@@ -4270,13 +4279,16 @@ mod tests {
 
     #[tokio::test]
     async fn golden_access_org_doorbell_transcripts() {
+        let public_cors = |method: &str, path: &str| {
+            access_route_cors(method, path, crate::gateway_routes::CorsPosture::Public)
+        };
         for (method, path) in [
             ("POST", "/api/access/org-grants"),
             ("GET", "/api/access/orgs/golden-org/revocations"),
             ("POST", "/api/access/orgs/revocations/apply"),
             ("POST", "/api/access/org-grants/renew"),
         ] {
-            access_route_cors(method, path, crate::gateway_routes::CorsPosture::Public);
+            public_cors(method, path);
         }
         let tmp = tempfile::TempDir::new().unwrap();
         let cert_dir = tmp.path().to_path_buf();
@@ -4293,9 +4305,9 @@ mod tests {
             handle_access_org_grant_present(
                 stream,
                 "{}".to_string(),
-                "POST",
                 cert_dir.clone(),
                 card.clone(),
+                public_cors("POST", "/api/access/org-grants"),
             )
         })
         .await;
@@ -4313,9 +4325,9 @@ mod tests {
             handle_access_org_grant_present(
                 stream,
                 invalid.to_string(),
-                "POST",
                 cert_dir.clone(),
                 card.clone(),
+                public_cors("POST", "/api/access/org-grants"),
             )
         })
         .await;
@@ -4331,6 +4343,7 @@ mod tests {
                 stream,
                 "/api/access/orgs/golden-org/revocations",
                 cert_dir.clone(),
+                public_cors("GET", "/api/access/orgs/golden-org/revocations"),
             )
         })
         .await;
@@ -4356,9 +4369,9 @@ mod tests {
             handle_access_org_apply_renew(
                 stream,
                 "{}".to_string(),
-                "POST",
                 "/api/access/orgs/revocations/apply",
                 cert_dir.clone(),
+                public_cors("POST", "/api/access/orgs/revocations/apply"),
             )
         })
         .await;
@@ -4379,9 +4392,9 @@ mod tests {
             handle_access_org_apply_renew(
                 stream,
                 "{}".to_string(),
-                "POST",
                 "/api/access/org-grants/renew",
                 cert_dir.clone(),
+                public_cors("POST", "/api/access/org-grants/renew"),
             )
         })
         .await;

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -177,6 +177,7 @@ pub(crate) async fn handle_access_org_grant_present(
     mut stream: DemuxStream,
     body_text: String,
     req_method: &str,
+    cert_dir: std::path::PathBuf,
     agent_card_value_for_targets: serde_json::Value,
 ) {
     use tokio::io::AsyncWriteExt;
@@ -189,7 +190,7 @@ pub(crate) async fn handle_access_org_grant_present(
         let (status, body) = match serde_json::from_str::<serde_json::Value>(&body_text)
             .map_err(|e| format!("invalid JSON: {e}"))
             .and_then(|params| {
-                access_org_present_response_value(params, &agent_card_value_for_targets)
+                access_org_present_response_value(&cert_dir, params, &agent_card_value_for_targets)
             }) {
             Ok(value) => (200, value.to_string()),
             Err(error) => (400, serde_json::json!({"error": error}).to_string()),
@@ -200,13 +201,17 @@ pub(crate) async fn handle_access_org_grant_present(
     finalize_http_stream(&mut stream).await;
 }
 
-pub(crate) async fn handle_access_org_revocations(mut stream: DemuxStream, req_path: &str) {
+pub(crate) async fn handle_access_org_revocations(
+    mut stream: DemuxStream,
+    req_path: &str,
+    cert_dir: std::path::PathBuf,
+) {
     use tokio::io::AsyncWriteExt;
     let handle = req_path
         .strip_prefix("/api/access/orgs/")
         .and_then(|rest| rest.strip_suffix("/revocations"))
         .unwrap_or("");
-    let (status, body) = match access_org_orl_response_value(handle) {
+    let (status, body) = match access_org_orl_response_value(&cert_dir, handle) {
         Ok(value) => (200, value.to_string()),
         Err(error) => (404, serde_json::json!({"error": error}).to_string()),
     };
@@ -220,6 +225,7 @@ pub(crate) async fn handle_access_org_apply_renew(
     body_text: String,
     req_method: &str,
     req_path: &str,
+    cert_dir: std::path::PathBuf,
 ) {
     use tokio::io::AsyncWriteExt;
     let response = if req_method != "POST" {
@@ -232,13 +238,13 @@ pub(crate) async fn handle_access_org_apply_renew(
         // dispatch already read under the right one.
         let handler = if req_path == "/api/access/orgs/revocations/apply" {
             access_org_orl_apply_response_value
-                as fn(serde_json::Value) -> Result<serde_json::Value, String>
+                as fn(&std::path::Path, serde_json::Value) -> Result<serde_json::Value, String>
         } else {
             access_org_renew_response_value
         };
         let (status, body) = match serde_json::from_str::<serde_json::Value>(&body_text)
             .map_err(|e| format!("invalid JSON: {e}"))
-            .and_then(handler)
+            .and_then(|params| handler(&cert_dir, params))
         {
             Ok(value) => (200, value.to_string()),
             Err(error) => (400, serde_json::json!({"error": error}).to_string()),
@@ -1637,11 +1643,15 @@ pub(crate) fn is_public_org_grant_path(request_line: &str) -> bool {
 /// is the authorization (verified against locally trusted org keys), so
 /// this sits in the doorbell class: unauthenticated, rate-limited, and
 /// size-capped; a failure changes nothing.
+/// `cert_dir` arrives from the transport edges (hermeticity convention)
+/// — as on the other doorbell fns below.
 pub(crate) fn access_org_present_response_value(
+    cert_dir: &std::path::Path,
     params: serde_json::Value,
     agent_card: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let outcome = crate::access::org::present_org_grant_value(
+        cert_dir,
         &params,
         &org_target_agent_card_ids(agent_card),
         crate::access::client_key::now_unix_ms() as u64,
@@ -1904,15 +1914,17 @@ pub(crate) fn access_org_issuer_install_response_value(
 /// Public: the org daemon's current signed revocation list (signed empty
 /// seq-0 list when nothing was revoked yet). Only meaningful on the
 /// daemon holding the org root key.
-pub(crate) fn access_org_orl_response_value(handle: &str) -> Result<serde_json::Value, String> {
+pub(crate) fn access_org_orl_response_value(
+    cert_dir: &std::path::Path,
+    handle: &str,
+) -> Result<serde_json::Value, String> {
     let handle = handle.trim();
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    let identity = crate::access::org::load_org_identity(&cert_dir, handle)?.ok_or_else(|| {
+    let identity = crate::access::org::load_org_identity(cert_dir, handle)?.ok_or_else(|| {
         format!("this daemon holds no root key for org {handle:?}; fetch the revocation list from the org's daemon")
     })?;
     let orl = crate::access::org::load_or_init_orl(
         &identity,
-        &cert_dir,
+        cert_dir,
         handle,
         crate::access::client_key::now_unix_ms() as u64,
     )?;
@@ -1923,6 +1935,7 @@ pub(crate) fn access_org_orl_response_value(handle: &str) -> Result<serde_json::
 /// signature is the authority and a stale `seq` is refused, so the
 /// courier is irrelevant. A failure changes nothing.
 pub(crate) fn access_org_orl_apply_response_value(
+    cert_dir: &std::path::Path,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let now = crate::access::client_key::now_unix_ms() as u64;
@@ -1938,13 +1951,12 @@ pub(crate) fn access_org_orl_apply_response_value(
     }
     let orl: crate::access::org::OrgRevocationList =
         serde_json::from_value(params).map_err(|e| format!("invalid org revocation list: {e}"))?;
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    let mut state = crate::access::iam::load_state(&cert_dir)
+    let mut state = crate::access::iam::load_state(cert_dir)
         .map_err(|e| format!("load local IAM state: {e}"))?;
-    let applied = crate::access::org::apply_orl(&mut state, &cert_dir, &orl, now)
+    let applied = crate::access::org::apply_orl(&mut state, cert_dir, &orl, now)
         .map_err(|e| e.to_string())?;
     if applied.changed {
-        crate::access::iam::save_state(&cert_dir, &state)
+        crate::access::iam::save_state(cert_dir, &state)
             .map_err(|e| format!("save local IAM state: {e}"))?;
     }
     Ok(serde_json::json!({ "schema_version": 1, "applied": applied }))
@@ -2041,6 +2053,7 @@ pub(crate) fn access_org_revoke_member_response_value(
 /// a fresh window. Same grant_id, original lifetime span; the org's own
 /// revocation list gates it.
 pub(crate) fn access_org_renew_response_value(
+    cert_dir: &std::path::Path,
     params: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
     let now = crate::access::client_key::now_unix_ms() as u64;
@@ -2057,13 +2070,12 @@ pub(crate) fn access_org_renew_response_value(
     let doc: crate::access::org::OrgGrantDocument =
         serde_json::from_value(params).map_err(|e| format!("invalid org grant document: {e}"))?;
     let handle = doc.org.handle.trim().to_string();
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    let identity = crate::access::org::load_org_identity(&cert_dir, &handle)?.ok_or_else(|| {
+    let identity = crate::access::org::load_org_identity(cert_dir, &handle)?.ok_or_else(|| {
         format!(
             "this daemon holds no root key for org {handle:?}; renew against the org's designated daemon"
         )
     })?;
-    let orl = crate::access::org::load_or_init_orl(&identity, &cert_dir, &handle, now)?;
+    let orl = crate::access::org::load_or_init_orl(&identity, cert_dir, &handle, now)?;
     let renewed = crate::access::org::renew_org_grant(&identity, &orl, &doc, now)?;
     Ok(serde_json::json!({
         "schema_version": 1,
@@ -4233,6 +4245,149 @@ mod tests {
         assert_eq!(
             golden_access_transcript(&response),
             golden_access_canonical_json_transcript("403 Forbidden", &body)
+        );
+    }
+
+    // ── S6 golden transcripts (third slice): the signed-org doorbell
+    // quartet ──
+    //
+    // Public rows by design (the signed document/list is the
+    // authorization): the historical framing is the canonical tail plus
+    // the wildcard `Access-Control-Allow-Origin: *` appended LAST
+    // (`with_public_cors`), pinned byte-exact here. Error bodies whose
+    // wording rises from the shared cores are derived through those
+    // same cores over injected tempdir stores; the verify/materialize
+    // successes need real signed documents and stay smoke-covered
+    // (validate-org-grants).
+
+    /// The public-CORS JSON framing: canonical tail, wildcard ACAO last.
+    fn golden_access_public_json_transcript(status_line: &str, body: &str) -> String {
+        format!(
+            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\n{body}",
+            body.len()
+        )
+    }
+
+    #[tokio::test]
+    async fn golden_access_org_doorbell_transcripts() {
+        for (method, path) in [
+            ("POST", "/api/access/org-grants"),
+            ("GET", "/api/access/orgs/golden-org/revocations"),
+            ("POST", "/api/access/orgs/revocations/apply"),
+            ("POST", "/api/access/org-grants/renew"),
+        ] {
+            access_route_cors(method, path, crate::gateway_routes::CorsPosture::Public);
+        }
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cert_dir = tmp.path().to_path_buf();
+
+        // Present, undecodable document: the error wording rises from
+        // the shared present core (derived through it over the same
+        // tempdir store); 400 under the public tail.
+        let card = serde_json::json!({});
+        let expected_error =
+            access_org_present_response_value(&cert_dir, serde_json::json!({}), &card)
+                .expect_err("empty org grant document must not verify");
+        let expected_body = serde_json::json!({"error": expected_error}).to_string();
+        let response = collect_access_handler_response(|stream| {
+            handle_access_org_grant_present(
+                stream,
+                "{}".to_string(),
+                "POST",
+                cert_dir.clone(),
+                card.clone(),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_public_json_transcript("400 Bad Request", &expected_body)
+        );
+
+        // Present, unparseable body: the handler's own decode 400.
+        let invalid = "not json";
+        let serde_error = serde_json::from_str::<serde_json::Value>(invalid).unwrap_err();
+        let expected_body =
+            serde_json::json!({"error": format!("invalid JSON: {serde_error}")}).to_string();
+        let response = collect_access_handler_response(|stream| {
+            handle_access_org_grant_present(
+                stream,
+                invalid.to_string(),
+                "POST",
+                cert_dir.clone(),
+                card.clone(),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_public_json_transcript("400 Bad Request", &expected_body)
+        );
+
+        // Served revocation list for an org this daemon holds no root
+        // key for: the deterministic 404 under the public tail.
+        let response = collect_access_handler_response(|stream| {
+            handle_access_org_revocations(
+                stream,
+                "/api/access/orgs/golden-org/revocations",
+                cert_dir.clone(),
+            )
+        })
+        .await;
+        let expected_body = serde_json::json!({
+            "error": "this daemon holds no root key for org \"golden-org\"; fetch the revocation list from the org's daemon"
+        })
+        .to_string();
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_public_json_transcript("404 Not Found", &expected_body)
+        );
+
+        // Apply, undecodable list: the shared core's serde wording,
+        // derived through the same decode; 400 under the public tail.
+        let orl_error = serde_json::from_value::<crate::access::org::OrgRevocationList>(
+            serde_json::json!({}),
+        )
+        .expect_err("empty revocation list must not decode");
+        let expected_body =
+            serde_json::json!({"error": format!("invalid org revocation list: {orl_error}")})
+                .to_string();
+        let response = collect_access_handler_response(|stream| {
+            handle_access_org_apply_renew(
+                stream,
+                "{}".to_string(),
+                "POST",
+                "/api/access/orgs/revocations/apply",
+                cert_dir.clone(),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_public_json_transcript("400 Bad Request", &expected_body)
+        );
+
+        // Renew, undecodable document: same discipline on the renew leaf.
+        let doc_error = serde_json::from_value::<crate::access::org::OrgGrantDocument>(
+            serde_json::json!({}),
+        )
+        .expect_err("empty org grant document must not decode");
+        let expected_body =
+            serde_json::json!({"error": format!("invalid org grant document: {doc_error}")})
+                .to_string();
+        let response = collect_access_handler_response(|stream| {
+            handle_access_org_apply_renew(
+                stream,
+                "{}".to_string(),
+                "POST",
+                "/api/access/org-grants/renew",
+                cert_dir.clone(),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_public_json_transcript("400 Bad Request", &expected_body)
         );
     }
 }

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -896,6 +896,77 @@ pub(crate) fn access_org_renew_api_response(
     access_result_api_response(access_org_renew_response_value(cert_dir, params), 400)
 }
 
+/// POST /api/access/fleet-cert/request + the tunnel's
+/// `api_fleet_cert_request` (the S6 ROW-NEW: the tunnel method finally
+/// gets its HTTP twin): publish this daemon's routable addresses under
+/// its fleet name and start the ACME DNS-01 order (fleet_cert.rs).
+/// Async-start semantics preserved — the flow is spawned and progress
+/// rides the connect status payload. Explicit `addresses` in params
+/// override the routable-local-address default.
+pub(crate) fn fleet_cert_request_api_response(params: serde_json::Value) -> ApiResponse {
+    let addresses: Vec<String> = params
+        .get("addresses")
+        .and_then(|v| v.as_array())
+        .map(|list| {
+            list.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .filter(|list: &Vec<String>| !list.is_empty())
+        .unwrap_or_else(crate::fleet_cert::default_publish_addresses);
+    if crate::fleet_cert::status_snapshot().name.is_none() {
+        return ApiResponse::json_error(
+            400,
+            "this daemon has no fleet name — enable Connect against a \
+             rendezvous with fleet DNS and let it register first",
+        );
+    }
+    let spawned_addresses = addresses.clone();
+    tokio::spawn(async move {
+        if let Err(error) = crate::fleet_cert::request_certificate(spawned_addresses).await {
+            eprintln!("[fleet-cert] request failed: {error}");
+        }
+    });
+    ApiResponse::json(
+        200,
+        JsonBody::Value(serde_json::json!({ "started": true, "addresses": addresses })),
+    )
+}
+
+/// HTTP shim for the fleet-cert request row: manage-belt + empty-body
+/// tolerance (`{}`), matching the access admin family.
+pub(crate) async fn handle_fleet_cert_request(
+    stream: DemuxStream,
+    body_text: String,
+    http_access_context: HttpAccessContext,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    // Belt-and-suspenders manage re-check (see the claim-code shim).
+    let decision =
+        http_access_context.decision(crate::peer::access_policy::PeerOperation::AccessManage);
+    if !decision.allowed {
+        let response = access_manage_denied_api_response(&http_access_context, decision);
+        write_api_response(
+            stream,
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        )
+        .await;
+        return;
+    }
+    let response = if body_text.trim().is_empty() {
+        fleet_cert_request_api_response(serde_json::json!({}))
+    } else {
+        match parse_access_request_body(&body_text) {
+            Ok(params) => fleet_cert_request_api_response(params),
+            Err(error) => *error,
+        }
+    };
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
 pub(crate) async fn handle_access_overview(
     stream: DemuxStream,
     cert_dir: std::path::PathBuf,
@@ -4401,6 +4472,92 @@ mod tests {
         assert_eq!(
             golden_access_transcript(&response),
             golden_access_public_json_transcript("400 Bad Request", &expected_body)
+        );
+    }
+
+    // ── S6 golden transcripts: the fleet-cert ROW-NEW ──
+    //
+    // A new HTTP surface (design §2.7 ROW-NEW), so these pins DEFINE the
+    // wire rather than preserve one: the family-standard fleet framing,
+    // the belt-403, and the deterministic no-fleet-name error. Explicit
+    // addresses keep every fixture off the NIC-enumeration default, and
+    // the no-name error path never spawns the ACME flow — the live
+    // order stays smoke-covered.
+
+    #[tokio::test]
+    async fn golden_fleet_cert_request_transcripts() {
+        let cors = access_route_cors(
+            "POST",
+            "/api/access/fleet-cert/request",
+            crate::gateway_routes::CorsPosture::FleetAllowlist,
+        );
+
+        // No fleet name in the process-global status (the test process
+        // never registered against a rendezvous): the deterministic 400
+        // under the fleet tail, both origin shapes.
+        for origin in [None, Some(GOLDEN_FLEET_ORIGIN)] {
+            let response = collect_access_handler_response(|stream| {
+                handle_fleet_cert_request(
+                    stream,
+                    serde_json::json!({ "addresses": ["192.0.2.10"] }).to_string(),
+                    golden_root_context(),
+                    cors,
+                    origin,
+                )
+            })
+            .await;
+            assert_eq!(
+                golden_access_transcript(&response),
+                golden_access_fleet_json_transcript(
+                    "400 Bad Request",
+                    r#"{"error":"this daemon has no fleet name — enable Connect against a rendezvous with fleet DNS and let it register first"}"#,
+                    origin
+                )
+            );
+        }
+
+        // Parse error: the family-standard 400 under the fleet tail.
+        let invalid = "not json";
+        let serde_error = serde_json::from_str::<serde_json::Value>(invalid).unwrap_err();
+        let expected_body =
+            serde_json::json!({"error": format!("invalid request body: {serde_error}")})
+                .to_string();
+        let response = collect_access_handler_response(|stream| {
+            handle_fleet_cert_request(
+                stream,
+                invalid.to_string(),
+                golden_root_context(),
+                cors,
+                Some(GOLDEN_FLEET_ORIGIN),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_fleet_json_transcript(
+                "400 Bad Request",
+                &expected_body,
+                Some(GOLDEN_FLEET_ORIGIN)
+            )
+        );
+
+        // Denied: the belt 403, PLAIN tail (family convention).
+        let denied_dir = tempfile::TempDir::new().unwrap();
+        let context = golden_denied_manage_context(denied_dir.path());
+        let body = golden_denied_manage_body(&context);
+        let response = collect_access_handler_response(|stream| {
+            handle_fleet_cert_request(
+                stream,
+                serde_json::json!({ "addresses": ["192.0.2.10"] }).to_string(),
+                context,
+                cors,
+                Some(GOLDEN_FLEET_ORIGIN),
+            )
+        })
+        .await;
+        assert_eq!(
+            golden_access_transcript(&response),
+            golden_access_canonical_json_transcript("403 Forbidden", &body)
         );
     }
 }


### PR DESCRIPTION
Third S6 PR unit (transport-unification design §6 S6): the signed-org doorbell quartet (present, orl, orl-apply, renew) and `POST /api/access/fleet-cert/request` — the family's ROW-NEW.

Follows the established template:
1. hermetic seams + golden transcripts — `present_org_grant_value` and the doorbell cores take cert_dir (the offer ride-along callers resolve ambient at their own edges); goldens pin the public-row framing byte-exact (canonical tail + wildcard ACAO last)
2. HTTP side: neutral `*_api_response` fns; the three public handlers become shims; **`is_fleet_cors_access_path` now derives from the route table** (derive, don't mirror) — the write-side origin gate can no longer lag a new fleet row's posture
3. tunnel side: the quartet delegates under the historical ok/error envelope; parity fixtures extend the enumeration (#17 op-override authority, #18 ORL addressing, #19 the 404-vs-frame-error shape)
4. rows: the four Public rows carry `tunnel_method_with_op` columns — **the op-override enumeration opens** with exactly these occupants (AccessInspect ×3, PresenceRead for the orl-apply courier; session-gated on the tunnel by design, each reason on the row) — and the partition pins flip with operations unchanged
5. the fleet-cert ROW-NEW: neutral core extracted verbatim from the tunnel arm, new fleet row + tunnel column (IAM derives from the row), docs endpoint table regenerated, goldens define the new wire, CONTROL_METHODS sheds the entry
6. the string-form `with_fleet_cors` retires (test-only after the conversion); its invariant assertions port to the builder

No wire change on the four existing twins (goldens + parity are the proof); the HTTP row for fleet-cert is additive. Battery: cargo nextest 2979 passed, clippy clean on the touched files.