### PR TITLE
Trust tiers: metadata carriers settled — tier on the signed fleet record (v4)

### DIFF
--- a/docs/src/trust-tiers.md
+++ b/docs/src/trust-tiers.md
@@ -271,11 +271,10 @@ the owner's memory. All four are **shipped**:
    on an integrated machine, the peer pairing-approval card warns that
    approving grants a peer authority *here* (the upward-grant alarm), and
    hosted-route device enrollments get an integrated-tier warning chip
-   beside the existing hosted-route one. *Deliberately deferred:*
-   cross-daemon tier visibility (a tier field on fleet records or agent
-   cards, so the granting side can compare both ends' tiers) — that needs
-   a metadata-carrier decision (browser-signed fleet payload v4 vs. the
-   public agent card) and is not required for the local alarm.
+   beside the existing hosted-route one. Same-account cross-daemon
+   visibility ships via the signed fleet record — each fleet card carries
+   its daemon's tier chip, offline daemons included (the carrier
+   reasoning is [Where fleet metadata rides](#where-fleet-metadata-rides)).
 2. **Per-daemon hosted-ceiling knob.** The same card carries "Hosted tabs
    may: Operate / View only / Nothing" — one control writing both
    hosted-provenance `role_ceilings` bindings
@@ -310,3 +309,39 @@ the owner's memory. All four are **shipped**:
    on any serial the daemon never requested. Advisory and fail-open by
    design: a crt.sh outage stamps `ct_last_error` rather than blocking
    renewal.
+
+## Where fleet metadata rides
+
+Fleet facts have three possible carriers, and each datum lands where its
+provenance and audience allow — not where plumbing is cheapest:
+
+- **The public agent card** (`/.well-known/agent-card.json` — unauthenticated,
+  CORS-open) carries operational facts a stranger legitimately needs
+  *before* any trust exists: transports, capabilities, auth requirements,
+  the advertised rendezvous base — and connection hints like ICE servers,
+  should the hosted path ever need browser-side TURN (a parked seed with
+  no consumer today). The card is daemon-asserted and unauthenticated by
+  nature; nothing on it may function as evidence.
+- **The signed fleet record** (browser-signed payload, v4) carries the
+  owner's account-scoped view: labels, daemon URLs (PRF-encrypted), the
+  rendezvous base — and the daemon's **trust tier**. The record is
+  verifiable by the owner's own devices and readable without the daemon
+  being up, which is exactly what tier chips on fleet cards need.
+- **The daemon's authorized payloads** (the dashboard targets response,
+  overview) carry daemon truth to sessions the daemon already admitted —
+  the seam through which the tier reaches the browser to be folded into
+  the record.
+
+Two deliberate absences, so their reasons don't get re-litigated:
+
+- **The tier is not on the public card.** An unauthenticated "integrated"
+  label is a target beacon — it tells an attacker which box is worth the
+  effort — and as a self-assertion it cannot serve the upward-grant
+  guard as evidence anyway.
+- **The pairing doorbell carries no tier claim.** A cross-owner requester
+  asserting "I'm disposable" is unverifiable exactly when it matters;
+  showing it on the approval card would dress an assertion as evidence.
+  Cross-owner tier comparison waits for an authenticated daemon-identity
+  linkage in the doorbell (the requester proving which daemon key it is,
+  so a claim could at least be pinned to an identity) — a prerequisite,
+  not a plumbing gap.

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -2330,12 +2330,12 @@ mod tests {
         // list).
         let card = serde_json::json!({});
         let (status, http_body) = parity_http_status_and_body(
-            crate::web_gateway::dashboard_targets_api_response(&card, None),
+            crate::web_gateway::dashboard_targets_api_response(&card, None, None),
         );
         assert_eq!(status, 200);
         let frame = frame_api_ok_error_response(
             "parity-targets".to_string(),
-            crate::web_gateway::dashboard_targets_api_response(&card, None),
+            crate::web_gateway::dashboard_targets_api_response(&card, None, None),
             "dashboard targets",
         );
         assert_eq!(frame["ok"], true);

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -618,6 +618,10 @@ pub(crate) fn control_frame_response(
                     crate::web_gateway::dashboard_targets_api_response(
                         &runtime.agent_card,
                         runtime.peer_registry.as_ref(),
+                        crate::web_gateway::local_daemon_tier(
+                            &crate::access::backend::select_backend().cert_dir(),
+                        )
+                        .as_deref(),
                     ),
                     "dashboard targets",
                 )),

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -939,12 +939,18 @@ pub(crate) async fn serve_http_request(
                 .await;
             }
             RouteHandlerId::DashboardTargets => {
+                // Transport edge resolves the ambient cert dir (hermeticity
+                // convention) — the handler takes the tier as a parameter.
+                let local_tier = crate::web_gateway::local_daemon_tier(
+                    &crate::access::backend::select_backend().cert_dir(),
+                );
                 return handle_dashboard_targets(
                     stream,
                     peer_registry,
                     agent_card_value_for_targets,
                     route.cors,
                     fleet_cors_origin.as_deref(),
+                    local_tier.as_deref(),
                 )
                 .await;
             }

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -27,6 +27,7 @@ pub(crate) struct PeerConnectionIdentity {
 pub(crate) fn dashboard_targets_response_value(
     agent_card: &serde_json::Value,
     registry: Option<&crate::peer::PeerRegistry>,
+    local_tier: Option<&str>,
 ) -> serde_json::Value {
     let local_id = agent_card
         .get("id")
@@ -68,6 +69,17 @@ pub(crate) fn dashboard_targets_response_value(
         if let Some(value) = agent_card.get(key).and_then(|v| v.as_str()) {
             local_target[key] = serde_json::Value::String(value.to_string());
         }
+    }
+    // Trust tier rides the *targets* payload, deliberately not the public
+    // agent card: the card is unauthenticated and CORS-open, and an
+    // "integrated" label there would advertise which boxes are worth
+    // attacking. Here it reaches only sessions the daemon already
+    // authorized, and the browser folds it into the signed fleet record
+    // (payload v4) so the owner's other devices see each daemon's zone —
+    // offline daemons included — without the store being able to forge it
+    // (docs/src/trust-tiers.md § metadata carriers).
+    if let Some(tier) = local_tier.map(str::trim).filter(|t| !t.is_empty()) {
+        local_target["tier"] = serde_json::Value::String(tier.to_string());
     }
     let mut targets = vec![local_target];
 
@@ -118,8 +130,19 @@ pub(crate) fn dashboard_targets_response_value(
 pub(crate) fn dashboard_targets_response_body(
     agent_card: &serde_json::Value,
     registry: Option<&crate::peer::PeerRegistry>,
+    local_tier: Option<&str>,
 ) -> String {
-    dashboard_targets_response_value(agent_card, registry).to_string()
+    dashboard_targets_response_value(agent_card, registry, local_tier).to_string()
+}
+
+/// The daemon's own trust tier for the targets payload, resolved from
+/// local IAM at request time so a tier change on the Access card shows
+/// up without a daemon restart. Missing/unreadable state reads as no
+/// tier (the doctrine's "unset" — the UI shows nothing).
+pub(crate) fn local_daemon_tier(cert_dir: &std::path::Path) -> Option<String> {
+    crate::access::iam::load_state_for_overview(cert_dir)
+        .state
+        .tier
 }
 
 /// Build the shared access overview model.
@@ -167,9 +190,13 @@ pub(crate) async fn handle_dashboard_targets(
     agent_card_value_for_targets: serde_json::Value,
     cors: crate::gateway_routes::CorsPosture,
     fleet_origin: Option<&str>,
+    local_tier: Option<&str>,
 ) {
-    let response =
-        dashboard_targets_api_response(&agent_card_value_for_targets, peer_registry.as_ref());
+    let response = dashboard_targets_api_response(
+        &agent_card_value_for_targets,
+        peer_registry.as_ref(),
+        local_tier,
+    );
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 
@@ -665,10 +692,13 @@ pub(crate) fn access_manage_denied_api_response(
 pub(crate) fn dashboard_targets_api_response(
     agent_card: &serde_json::Value,
     registry: Option<&crate::peer::PeerRegistry>,
+    local_tier: Option<&str>,
 ) -> ApiResponse {
     ApiResponse::json(
         200,
-        JsonBody::PreSerialized(dashboard_targets_response_body(agent_card, registry)),
+        JsonBody::PreSerialized(dashboard_targets_response_body(
+            agent_card, registry, local_tier,
+        )),
     )
 }
 
@@ -920,7 +950,8 @@ pub(crate) fn access_overview_response_value_with_identities_and_iam(
     iam_state: &crate::access::iam::LoadedIamState,
     current_principal: Option<&crate::access::iam::AccessPrincipal>,
 ) -> serde_json::Value {
-    let targets_value = dashboard_targets_response_value(agent_card, registry);
+    let targets_value =
+        dashboard_targets_response_value(agent_card, registry, iam_state.state.tier.as_deref());
     let targets = targets_value
         .get("targets")
         .and_then(|v| v.as_array())
@@ -2562,6 +2593,29 @@ mod tests {
     }
 
     #[test]
+    fn dashboard_targets_stamp_local_tier_but_never_the_card() {
+        let card = serde_json::json!({
+            "id": "d-abc", "label": "box", "capabilities": []
+        });
+        // Tier set: the local target carries it; peer targets never do.
+        let value = dashboard_targets_response_value(&card, None, Some("integrated"));
+        let targets = value["targets"].as_array().unwrap();
+        assert_eq!(targets[0]["tier"], serde_json::json!("integrated"));
+        // Unset / blank tier: the key is absent, not an empty string.
+        for tier in [None, Some(""), Some("  ")] {
+            let value = dashboard_targets_response_value(&card, None, tier);
+            assert!(
+                value["targets"][0].get("tier").is_none(),
+                "blank tier must not stamp ({tier:?})"
+            );
+        }
+        // The public agent card value itself is never mutated — the tier
+        // reaches only the authorized targets payload (beacon rule,
+        // docs/src/trust-tiers.md § metadata carriers).
+        assert!(card.get("tier").is_none());
+    }
+
+    #[test]
     fn fleet_origin_gate_normalizes_and_allowlists() {
         assert_eq!(
             normalized_origin("WSS://Daemon.Local:8765").as_deref(),
@@ -3430,9 +3484,9 @@ mod tests {
         // An empty agent card and no registry produce the deterministic
         // local-only target list through the untouched builder.
         let card = serde_json::json!({});
-        let body = dashboard_targets_response_body(&card, None);
+        let body = dashboard_targets_response_body(&card, None, None);
         let response = collect_access_handler_response(|stream| {
-            handle_dashboard_targets(stream, None, card.clone(), cors, None)
+            handle_dashboard_targets(stream, None, card.clone(), cors, None, None)
         })
         .await;
         assert_eq!(

--- a/src/bin/connect/fleet.rs
+++ b/src/bin/connect/fleet.rs
@@ -86,6 +86,8 @@ pub(crate) struct FleetTargetInput {
     #[serde(default, alias = "encFields")]
     enc_fields: String,
     #[serde(default)]
+    tier: String,
+    #[serde(default)]
     origin: String,
     #[serde(default, alias = "connectDaemonId")]
     connect_daemon_id: String,
@@ -348,6 +350,9 @@ pub(crate) fn normalize_fleet_target_input(
         browser_tcp_via_url: clean_fleet_url(&input.browser_tcp_via_url),
         connect_signaling_base: clean_fleet_url(&input.connect_signaling_base),
         enc_fields: clean_fleet_text(&input.enc_fields, FLEET_ENC_MAX),
+        // Signed v4 payload line — relayed verbatim-but-bounded like the
+        // signature fields; the store never interprets the tier.
+        tier: clean_fleet_token(&input.tier, FLEET_TEXT_MAX),
         origin: clean_fleet_url(&input.origin),
         connect_daemon_id: if connect_daemon_id.is_empty() {
             None
@@ -744,6 +749,7 @@ mod tests {
                 id: "daemon-1".to_string(),
                 host_id: "daemon-1".to_string(),
                 label: "Anchor box".to_string(),
+                tier: "integrated".to_string(),
                 record_key: "PubKeyB64u".to_string(),
                 record_sig: "SigB64u".to_string(),
                 record_signed_at_unix_ms: 1_700_000_000_000,
@@ -754,14 +760,17 @@ mod tests {
         .expect("record normalizes");
         // The service carries owner signatures verbatim — it never
         // interprets them, and the view exposes them for client-side
-        // verification.
+        // verification. The tier is part of the signed v4 payload, so it
+        // must survive the round trip the same way.
         assert_eq!(record.record_key, "PubKeyB64u");
         assert_eq!(record.record_sig, "SigB64u");
         assert_eq!(record.record_signed_at_unix_ms, 1_700_000_000_000);
+        assert_eq!(record.tier, "integrated");
         let view = fleet_target_view(&record);
         assert_eq!(view["record_key"], "PubKeyB64u");
         assert_eq!(view["record_sig"], "SigB64u");
         assert_eq!(view["record_signed_at_unix_ms"], 1_700_000_000_000u64);
+        assert_eq!(view["tier"], "integrated");
 
         // Future timestamps clamp to the sync time instead of trusting the
         // client clock.
@@ -844,6 +853,7 @@ mod tests {
                 browser_tcp_via_url: "/app?connect=1&daemon_id=daemon".to_string(),
                 connect_signaling_base: String::new(),
                 enc_fields: String::new(),
+                tier: String::new(),
                 origin: "https://intendant.dev".to_string(),
                 connect_daemon_id: " daemon ".to_string(),
                 record_key: String::new(),
@@ -920,6 +930,7 @@ mod tests {
                     browser_tcp_via_url: String::new(),
                     connect_signaling_base: String::new(),
                     enc_fields: String::new(),
+                    tier: String::new(),
                     origin: "https://intendant.dev".to_string(),
                     connect_daemon_id: Some("daemon-1".to_string()),
                     capabilities: Vec::new(),
@@ -951,6 +962,7 @@ mod tests {
                     browser_tcp_via_url: String::new(),
                     connect_signaling_base: String::new(),
                     enc_fields: String::new(),
+                    tier: String::new(),
                     origin: "https://connect.intendant.dev".to_string(),
                     connect_daemon_id: Some("daemon-1".to_string()),
                     capabilities: Vec::new(),
@@ -982,6 +994,7 @@ mod tests {
                     browser_tcp_via_url: String::new(),
                     connect_signaling_base: String::new(),
                     enc_fields: String::new(),
+                    tier: String::new(),
                     origin: "https://intendant.dev".to_string(),
                     connect_daemon_id: None,
                     capabilities: Vec::new(),

--- a/src/bin/connect/main.rs
+++ b/src/bin/connect/main.rs
@@ -828,6 +828,11 @@ struct FleetTargetRecord {
     // service stores it blind.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     enc_fields: String,
+    // Owner-set trust tier (docs/src/trust-tiers.md): part of the signed
+    // v4 record payload, relayed verbatim. The service never interprets
+    // it — clients verify it under the record signature.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    tier: String,
     #[serde(default)]
     origin: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1154,6 +1159,7 @@ fn fleet_target_view(target: &FleetTargetRecord) -> serde_json::Value {
         "browser_tcp_via_url": target.browser_tcp_via_url,
         "connect_signaling_base": target.connect_signaling_base,
         "enc_fields": target.enc_fields,
+        "tier": target.tier,
         "origin": target.origin,
         "connect_daemon_id": target.connect_daemon_id,
         "capabilities": target.capabilities,

--- a/static/app.html
+++ b/static/app.html
@@ -981,6 +981,12 @@ html {
 .acc-chip.route-webrtc { border-color: color-mix(in srgb, var(--teal) 35%, transparent); color: var(--teal); }
 .acc-chip.route-remembered::before { background: transparent; border: 1px dashed var(--overlay0); width: 5px; height: 5px; }
 .acc-chip.route-remembered { border-style: dashed; color: var(--overlay1); }
+/* Trust tier chips on fleet cards (docs/src/trust-tiers.md): integrated
+   is the warm keep-your-guard-up accent, disposable stays muted. */
+.acc-chip.acc-tier-integrated::before { background: var(--peach); }
+.acc-chip.acc-tier-integrated { border-color: color-mix(in srgb, var(--peach) 35%, transparent); color: var(--peach); }
+.acc-chip.acc-tier-disposable::before { background: var(--overlay1); }
+.acc-chip.acc-tier-disposable { color: var(--subtext0); }
 
 /* Role badges — warmer = more authority. */
 .acc-badge, .ui-badge {
@@ -25879,11 +25885,15 @@ function accessFleetRecordPayload(record, signedAt, version = 2) {
   // v3 (encrypted records): the URL fields travel ONLY inside enc_fields,
   // so the signed lines pin them to empty — decrypting into the in-memory
   // record never invalidates the signature.
+  // v4 folds the enc line in unconditionally (may be empty) and appends
+  // the daemon's owner-set trust tier, so a store cannot relabel an
+  // integrated box as disposable without breaking the signature.
   const enc = version >= 3 ? String(record.enc_fields || '') : '';
   const blank = version >= 3 && enc;
   const lines = [
-    version >= 3 ? 'intendant-fleet-record-v3'
-      : version >= 2 ? 'intendant-fleet-record-v2' : 'intendant-fleet-record-v1',
+    version >= 4 ? 'intendant-fleet-record-v4'
+      : version >= 3 ? 'intendant-fleet-record-v3'
+        : version >= 2 ? 'intendant-fleet-record-v2' : 'intendant-fleet-record-v1',
     String(record.host_id || record.id || ''),
     String(record.label || ''),
     blank ? '' : String(record.url || ''),
@@ -25895,6 +25905,7 @@ function accessFleetRecordPayload(record, signedAt, version = 2) {
   // device connects through the daemon's own rendezvous, not a default.
   if (version >= 2) lines.push(String(record.connect_signaling_base || ''));
   if (version >= 3) lines.push(enc);
+  if (version >= 4) lines.push(String(record.tier || ''));
   lines.push(String(signedAt));
   return new TextEncoder().encode(lines.join('\n'));
 }
@@ -26011,7 +26022,7 @@ async function accessFleetSignRecord(record) {
     const signature = await crypto.subtle.sign(
       { name: 'ECDSA', hash: 'SHA-256' },
       identity.privateKey,
-      accessFleetRecordPayload(record, signedAt, record.enc_fields ? 3 : 2)
+      accessFleetRecordPayload(record, signedAt, 4)
     );
     return {
       ...record,
@@ -26043,7 +26054,7 @@ async function accessFleetVerifyRecord(record) {
       ['verify']
     );
     let valid = false;
-    for (const version of record.enc_fields ? [3, 2, 1] : [2, 1]) {
+    for (const version of record.enc_fields ? [4, 3, 2, 1] : [4, 2, 1]) {
       valid = await crypto.subtle.verify(
         { name: 'ECDSA', hash: 'SHA-256' },
         publicKey,
@@ -51278,6 +51289,10 @@ function normalizeDashboardAccessTarget(target) {
     effective_role: String(target.effective_role || target.effectiveRole || '').trim(),
     effective_role_label: String(target.effective_role_label || target.effectiveRoleLabel || '').trim(),
     profile: String(target.profile || '').trim(),
+    // Owner-set trust tier, stamped by the daemon into its own targets
+    // payload and carried in the signed v4 fleet record (never on the
+    // public agent card — docs/src/trust-tiers.md § metadata carriers).
+    tier: String(target.tier || '').trim(),
     connected: target.connected !== false,
     capabilities,
   };
@@ -54844,6 +54859,17 @@ function renderAccessFleetStrip() {
     }
     const provenanceChip = accessTargetProvenanceChip(target);
     if (provenanceChip) meta.appendChild(provenanceChip);
+    // Owner-set trust tier from the signed v4 fleet record (or the live
+    // targets payload for the current daemon) — the fleet's zones at a
+    // glance, offline daemons included. Absent = unset: show nothing.
+    const tierMeta = ACCESS_TIER_META[String(target.tier || '').trim()];
+    if (tierMeta) {
+      const tierChip = document.createElement('span');
+      tierChip.className = `acc-chip acc-tier-${String(target.tier).trim()}`;
+      tierChip.textContent = `${tierMeta.glyph} ${tierMeta.label}`;
+      tierChip.title = tierMeta.short;
+      meta.appendChild(tierChip);
+    }
     // The door to the direct path (docs/src/trust-tiers.md): when the
     // record carries the daemon's own URL, offer it — a direct tab talks
     // straight to that daemon (local vault, no Connect service in the

--- a/static/app.html
+++ b/static/app.html
@@ -26019,10 +26019,15 @@ async function accessFleetSignRecord(record) {
   if (!identity) return record;
   const signedAt = Date.now();
   try {
+    // Sign at the lowest version that covers the record's fields: a
+    // tier-less record keeps its v2/v3 shape, so a hosted store that
+    // predates the tier field (and would strip it) only downgrades
+    // tier-carrying records to 'unverified', not the whole fleet.
+    const version = String(record.tier || '').trim() ? 4 : (record.enc_fields ? 3 : 2);
     const signature = await crypto.subtle.sign(
       { name: 'ECDSA', hash: 'SHA-256' },
       identity.privateKey,
-      accessFleetRecordPayload(record, signedAt, 4)
+      accessFleetRecordPayload(record, signedAt, version)
     );
     return {
       ...record,

--- a/static/app/11-styles-access-files.css
+++ b/static/app/11-styles-access-files.css
@@ -92,6 +92,12 @@
 .acc-chip.route-webrtc { border-color: color-mix(in srgb, var(--teal) 35%, transparent); color: var(--teal); }
 .acc-chip.route-remembered::before { background: transparent; border: 1px dashed var(--overlay0); width: 5px; height: 5px; }
 .acc-chip.route-remembered { border-style: dashed; color: var(--overlay1); }
+/* Trust tier chips on fleet cards (docs/src/trust-tiers.md): integrated
+   is the warm keep-your-guard-up accent, disposable stays muted. */
+.acc-chip.acc-tier-integrated::before { background: var(--peach); }
+.acc-chip.acc-tier-integrated { border-color: color-mix(in srgb, var(--peach) 35%, transparent); color: var(--peach); }
+.acc-chip.acc-tier-disposable::before { background: var(--overlay1); }
+.acc-chip.acc-tier-disposable { color: var(--subtext0); }
 
 /* Role badges — warmer = more authority. */
 .acc-badge, .ui-badge {

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -938,11 +938,15 @@ function accessFleetRecordPayload(record, signedAt, version = 2) {
   // v3 (encrypted records): the URL fields travel ONLY inside enc_fields,
   // so the signed lines pin them to empty — decrypting into the in-memory
   // record never invalidates the signature.
+  // v4 folds the enc line in unconditionally (may be empty) and appends
+  // the daemon's owner-set trust tier, so a store cannot relabel an
+  // integrated box as disposable without breaking the signature.
   const enc = version >= 3 ? String(record.enc_fields || '') : '';
   const blank = version >= 3 && enc;
   const lines = [
-    version >= 3 ? 'intendant-fleet-record-v3'
-      : version >= 2 ? 'intendant-fleet-record-v2' : 'intendant-fleet-record-v1',
+    version >= 4 ? 'intendant-fleet-record-v4'
+      : version >= 3 ? 'intendant-fleet-record-v3'
+        : version >= 2 ? 'intendant-fleet-record-v2' : 'intendant-fleet-record-v1',
     String(record.host_id || record.id || ''),
     String(record.label || ''),
     blank ? '' : String(record.url || ''),
@@ -954,6 +958,7 @@ function accessFleetRecordPayload(record, signedAt, version = 2) {
   // device connects through the daemon's own rendezvous, not a default.
   if (version >= 2) lines.push(String(record.connect_signaling_base || ''));
   if (version >= 3) lines.push(enc);
+  if (version >= 4) lines.push(String(record.tier || ''));
   lines.push(String(signedAt));
   return new TextEncoder().encode(lines.join('\n'));
 }
@@ -1070,7 +1075,7 @@ async function accessFleetSignRecord(record) {
     const signature = await crypto.subtle.sign(
       { name: 'ECDSA', hash: 'SHA-256' },
       identity.privateKey,
-      accessFleetRecordPayload(record, signedAt, record.enc_fields ? 3 : 2)
+      accessFleetRecordPayload(record, signedAt, 4)
     );
     return {
       ...record,
@@ -1102,7 +1107,7 @@ async function accessFleetVerifyRecord(record) {
       ['verify']
     );
     let valid = false;
-    for (const version of record.enc_fields ? [3, 2, 1] : [2, 1]) {
+    for (const version of record.enc_fields ? [4, 3, 2, 1] : [4, 2, 1]) {
       valid = await crypto.subtle.verify(
         { name: 'ECDSA', hash: 'SHA-256' },
         publicKey,

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -1072,10 +1072,15 @@ async function accessFleetSignRecord(record) {
   if (!identity) return record;
   const signedAt = Date.now();
   try {
+    // Sign at the lowest version that covers the record's fields: a
+    // tier-less record keeps its v2/v3 shape, so a hosted store that
+    // predates the tier field (and would strip it) only downgrades
+    // tier-carrying records to 'unverified', not the whole fleet.
+    const version = String(record.tier || '').trim() ? 4 : (record.enc_fields ? 3 : 2);
     const signature = await crypto.subtle.sign(
       { name: 'ECDSA', hash: 'SHA-256' },
       identity.privateKey,
-      accessFleetRecordPayload(record, signedAt, 4)
+      accessFleetRecordPayload(record, signedAt, version)
     );
     return {
       ...record,

--- a/static/app/42-usage-terminal.js
+++ b/static/app/42-usage-terminal.js
@@ -263,6 +263,10 @@ function normalizeDashboardAccessTarget(target) {
     effective_role: String(target.effective_role || target.effectiveRole || '').trim(),
     effective_role_label: String(target.effective_role_label || target.effectiveRoleLabel || '').trim(),
     profile: String(target.profile || '').trim(),
+    // Owner-set trust tier, stamped by the daemon into its own targets
+    // payload and carried in the signed v4 fleet record (never on the
+    // public agent card — docs/src/trust-tiers.md § metadata carriers).
+    tier: String(target.tier || '').trim(),
     connected: target.connected !== false,
     capabilities,
   };

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -627,6 +627,17 @@ function renderAccessFleetStrip() {
     }
     const provenanceChip = accessTargetProvenanceChip(target);
     if (provenanceChip) meta.appendChild(provenanceChip);
+    // Owner-set trust tier from the signed v4 fleet record (or the live
+    // targets payload for the current daemon) — the fleet's zones at a
+    // glance, offline daemons included. Absent = unset: show nothing.
+    const tierMeta = ACCESS_TIER_META[String(target.tier || '').trim()];
+    if (tierMeta) {
+      const tierChip = document.createElement('span');
+      tierChip.className = `acc-chip acc-tier-${String(target.tier).trim()}`;
+      tierChip.textContent = `${tierMeta.glyph} ${tierMeta.label}`;
+      tierChip.title = tierMeta.short;
+      meta.appendChild(tierChip);
+    }
     // The door to the direct path (docs/src/trust-tiers.md): when the
     // record carries the daemon's own URL, offer it — a direct tab talks
     // straight to that daemon (local vault, no Connect service in the


### PR DESCRIPTION
The trust untangle's last open doctrine question: which carrier holds which fleet fact. New trust-tiers.md section (**Where fleet metadata rides**) settles it — operational first-contact facts on the public agent card, owner-scoped verifiable facts on the browser-signed fleet record, daemon truth through authorized payloads — and names the two deliberate absences (no tier on the public card: target beacon + unverifiable; no tier claim in the pairing doorbell: assertion dressed as evidence). The parked ICE-hints task inherits its settled answer (public card, when a consumer exists) and stays parked.

Shipped consumer — same-account cross-daemon tier visibility:

- The daemon stamps its owner-set tier into the **dashboard targets payload** (never the public card — pinned by test), resolved from iam.json at the transport edges so a tier change shows without restart.
- **Fleet record payload v4** signs the tier (uniform shape: enc line always present, then tier), so the hosted store cannot relabel a box's stakes without breaking the signature. Verify tries [4,3,2,1]/[4,2,1]; the skew story matches the v2→v3 enc_fields bump.
- **Connect** relays the field blind and bounded like the signature fields (round-trip pinned).
- **Fleet strip** cards show the tier chip — the fleet's zones at a glance, offline daemons included.

Battery: 2977/2977 unit tests, clippy clean, mock e2e 13/13, app.html regenerated from fragments.