### PR TITLE
Transport F4a: access dialogs family over the daemonApi facade

### DIFF
--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -3491,9 +3491,12 @@ mod tests {
         // Coverage pin: the F1 family's twinned methods (fs + staged
         // uploads), the F2 sessions-family reads (managed-context,
         // worktrees, the session list and its NDJSON stream, search,
-        // detail, report, context snapshots), and the F3 settings/keys
+        // detail, report, context snapshots), the F3 settings/keys
         // family (settings GET/POST, api-keys save, key-status,
-        // project-root, external-agents, displays). The `api_transfer_*`
+        // project-root, external-agents, displays), and the F4 access
+        // dialogs family (overview, IAM state, enrollment reads + decide,
+        // IAM grant upsert/update, the connect admin quartet, the tier
+        // pair, fleet-cert request, dashboard targets). The `api_transfer_*`
         // methods join when their HTTP rows land (task #6, /api/transfers);
         // adding or dropping an entry updates this list in the same change,
         // deliberately.
@@ -3530,6 +3533,20 @@ mod tests {
             "api_project_root",
             "api_external_agents",
             "api_displays",
+            "api_access_overview",
+            "api_access_iam_state",
+            "api_access_enrollment_requests",
+            "api_access_enrollment_decide",
+            "api_access_iam_upsert_user_client_grant",
+            "api_access_iam_update_grant",
+            "api_access_connect_status",
+            "api_access_connect_claim_code",
+            "api_access_connect_config",
+            "api_access_connect_unclaim",
+            "api_access_set_tier",
+            "api_access_set_hosted_ceiling",
+            "api_fleet_cert_request",
+            "api_dashboard_targets",
         ]
         .into_iter()
         .collect();

--- a/static/app.html
+++ b/static/app.html
@@ -26115,9 +26115,11 @@ async function accessFleetRefreshProvenance() {
 //     exactly this no-legacy-fallback behavior).
 //
 // STATUS: consumed by the F1 family (files IDE fs calls, transfers pump,
-// staged uploads), the F2 sessions-family reads, and the F3 settings/keys
+// staged uploads), the F2 sessions-family reads, the F3 settings/keys
 // family (settings GET/POST, api-keys save, key-status, project-root,
-// external-agents, displays); the remaining `rpcOrHttp`/`jsonFetch` call
+// external-agents, displays), and the F4 access dialogs family
+// (overview/enrollment/connect/tier + IAM grant writes); the remaining
+// `rpcOrHttp`/`jsonFetch` call
 // sites move onto these verbs family by family per the design's frontend
 // track. The boot smoke's window.qa.daemonApi() probe asserts the facade
 // evaluates.
@@ -26146,9 +26148,12 @@ async function accessFleetRefreshProvenance() {
 //
 // Coverage: the F1 family (filesystem + staged uploads), the F2
 // sessions-family reads (managed-context, worktrees, the session list and
-// its NDJSON stream, search, detail, report, context snapshots), and the
+// its NDJSON stream, search, detail, report, context snapshots), the
 // F3 settings/keys family (settings GET/POST, api-keys save, key-status,
-// project-root, external-agents, displays). The
+// project-root, external-agents, displays), and the F4 access dialogs
+// family (overview, IAM state, enrollment reads + decide, IAM grant
+// upsert/update, the connect admin quartet, the tier pair, fleet-cert
+// request, dashboard targets). The
 // `api_transfer_*` methods are deliberately absent: they have no HTTP rows
 // until the server-track stage that adds /api/transfers (task #6); F1 adds
 // their entries when those rows land.
@@ -26199,6 +26204,20 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_project_root: { verb: 'GET', path: '/api/project-root' },
   api_external_agents: { verb: 'GET', path: '/api/external-agents' },
   api_displays: { verb: 'GET', path: '/api/displays' },
+  api_access_overview: { verb: 'GET', path: '/api/access/overview' },
+  api_access_iam_state: { verb: 'GET', path: '/api/access/iam/state' },
+  api_access_enrollment_requests: { verb: 'GET', path: '/api/access/enrollment-requests' },
+  api_access_enrollment_decide: { verb: 'POST', path: '/api/access/enrollment-requests/decide' },
+  api_access_iam_upsert_user_client_grant: { verb: 'POST', path: '/api/access/iam/user-client-grants' },
+  api_access_iam_update_grant: { verb: 'POST', path: '/api/access/iam/grants/update' },
+  api_access_connect_status: { verb: 'GET', path: '/api/access/connect/status' },
+  api_access_connect_claim_code: { verb: 'GET', path: '/api/access/connect/claim-code' },
+  api_access_connect_config: { verb: 'POST', path: '/api/access/connect/config' },
+  api_access_connect_unclaim: { verb: 'POST', path: '/api/access/connect/unclaim' },
+  api_access_set_tier: { verb: 'POST', path: '/api/access/tier' },
+  api_access_set_hosted_ceiling: { verb: 'POST', path: '/api/access/hosted-ceiling' },
+  api_fleet_cert_request: { verb: 'POST', path: '/api/access/fleet-cert/request' },
+  api_dashboard_targets: { verb: 'GET', path: '/api/dashboard/targets' },
 });
 
 // ── Uniform error shape (§3.5) ────────────────────────────────────────────
@@ -51680,13 +51699,14 @@ function invalidateAccessOverview() {
 
 async function refreshAccessOverviewFromApi(options = {}) {
   try {
-    const resp = await dashboardJsonFetch('api_access_overview', {}, () => authedFetch('/api/access/overview', {
-      cache: 'no-store',
+    // daemonApi (transport F4): GET twin — tunnel first, direct HTTP per
+    // the read fallback policy; Connect mode never falls back.
+    const resp = await daemonApi.request('api_access_overview', {}, {
       signal: options.signal,
-    }), 'api_access_overview', { signal: options.signal });
+      cache: 'no-store',
+    });
     if (!resp.ok) throw new Error(`/api/access/overview returned ${resp.status}`);
-    const payload = await resp.json();
-    return applyAccessOverview(payload);
+    return applyAccessOverview(resp.body);
   } catch (err) {
     if (err?.name === 'AbortError') throw err;
     if (!options.silent) {
@@ -51702,13 +51722,13 @@ let accessPendingEnrollments = [];
 
 async function refreshAccessEnrollments(options = {}) {
   try {
-    const resp = await dashboardJsonFetch('api_access_enrollment_requests', {}, () => authedFetch('/api/access/enrollment-requests', {
-      cache: 'no-store',
+    // daemonApi (transport F4): GET twin — read fallback policy.
+    const resp = await daemonApi.request('api_access_enrollment_requests', {}, {
       signal: options.signal,
-    }), 'api_access_enrollment_requests', { signal: options.signal });
+      cache: 'no-store',
+    });
     if (!resp.ok) throw new Error(`/api/access/enrollment-requests returned ${resp.status}`);
-    const payload = await resp.json();
-    const requests = Array.isArray(payload?.requests) ? payload.requests : [];
+    const requests = Array.isArray(resp.body?.requests) ? resp.body.requests : [];
     const changed = JSON.stringify(requests) !== JSON.stringify(accessPendingEnrollments);
     accessPendingEnrollments = requests;
     if (changed) renderAccessAdminSummaries();
@@ -51726,12 +51746,13 @@ async function accessDecideEnrollment(fingerprint, approve, roleId) {
   const payload = { fingerprint, approve };
   if (approve && roleId) payload.role_id = roleId;
   try {
-    const resp = await dashboardJsonFetch('api_access_enrollment_decide', payload, () => authedFetch('/api/access/enrollment-requests/decide', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    }), 'api_access_enrollment_decide', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
+    // daemonApi (transport F4): POST twin — the fallback policy derives
+    // no-replay from the verb, exactly the legacy
+    // fallbackAfterRpcFailure:false semantics (a delivered tunnel attempt
+    // is never replayed over HTTP; with no tunnel the write goes direct).
+    // IAM-mutating write: the payload shape is unchanged, no retries.
+    const resp = await daemonApi.request('api_access_enrollment_decide', payload);
+    const data = resp.body;
     if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
     showControlToast?.('success', approve ? 'Device approved — it can connect now' : 'Device request denied');
   } catch (err) {
@@ -51751,12 +51772,13 @@ let accessConnectStatus = null;
 
 async function refreshAccessConnectStatus(options = {}) {
   try {
-    const resp = await dashboardJsonFetch('api_access_connect_status', {}, () => authedFetch('/api/access/connect/status', {
-      cache: 'no-store',
+    // daemonApi (transport F4): GET twin — read fallback policy.
+    const resp = await daemonApi.request('api_access_connect_status', {}, {
       signal: options.signal,
-    }), 'api_access_connect_status', { signal: options.signal });
+      cache: 'no-store',
+    });
     if (!resp.ok) throw new Error(`/api/access/connect/status returned ${resp.status}`);
-    const payload = await resp.json();
+    const payload = resp.body;
     const changed = JSON.stringify(payload) !== JSON.stringify(accessConnectStatus);
     accessConnectStatus = payload;
     if (changed) renderAccessAdminSummaries();
@@ -51769,10 +51791,13 @@ async function refreshAccessConnectStatus(options = {}) {
 }
 
 async function accessConnectFetchClaimCode() {
-  const resp = await dashboardJsonFetch('api_access_connect_claim_code', {}, () => authedFetch('/api/access/connect/claim-code', {
-    cache: 'no-store',
-  }), 'api_access_connect_claim_code', { fallbackAfterRpcFailure: false });
-  const data = await resp.json().catch(() => ({}));
+  // daemonApi (transport F4): GET twin, so the derived policy allows the
+  // direct-HTTP retry after a failed tunnel attempt (the legacy call site
+  // opted out via fallbackAfterRpcFailure:false, but a manage-gated
+  // idempotent read replays safely — the policy is data, not per-site
+  // judgment). Connect mode never falls back.
+  const resp = await daemonApi.request('api_access_connect_claim_code', {}, { cache: 'no-store' });
+  const data = resp.body;
   if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
   return data;
 }
@@ -51781,12 +51806,10 @@ async function accessConnectSetEnabled(enabled, rendezvousUrl) {
   const payload = { enabled };
   if (rendezvousUrl) payload.rendezvous_url = rendezvousUrl;
   try {
-    const resp = await dashboardJsonFetch('api_access_connect_config', payload, () => authedFetch('/api/access/connect/config', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    }), 'api_access_connect_config', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
+    // daemonApi (transport F4): POST twin — verb-derived no-replay, the
+    // legacy fallbackAfterRpcFailure:false semantics.
+    const resp = await daemonApi.request('api_access_connect_config', payload);
+    const data = resp.body;
     if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
     showControlToast?.('success', enabled
       ? 'Connect enabled — this daemon is registering with the rendezvous'
@@ -51801,12 +51824,9 @@ async function accessConnectSetEnabled(enabled, rendezvousUrl) {
 async function accessSetTier(tier) {
   const payload = { tier: tier || null };
   try {
-    const resp = await dashboardJsonFetch('api_access_set_tier', payload, () => authedFetch('/api/access/tier', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    }), 'api_access_set_tier', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
+    // daemonApi (transport F4): POST twin — verb-derived no-replay.
+    const resp = await daemonApi.request('api_access_set_tier', payload);
+    const data = resp.body;
     if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
     showControlToast?.('success', tier
       ? `Trust tier set: ${tier}`
@@ -51821,12 +51841,9 @@ async function accessSetTier(tier) {
 async function accessSetHostedCeiling(roleId) {
   const payload = { role_id: roleId };
   try {
-    const resp = await dashboardJsonFetch('api_access_set_hosted_ceiling', payload, () => authedFetch('/api/access/hosted-ceiling', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    }), 'api_access_set_hosted_ceiling', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
+    // daemonApi (transport F4): POST twin — verb-derived no-replay.
+    const resp = await daemonApi.request('api_access_set_hosted_ceiling', payload);
+    const data = resp.body;
     if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
     showControlToast?.('success', roleId === 'role:none'
       ? 'Hosted-origin control refused. Reach this daemon directly, through the app, or from an enrolled peer — a hosted tab can no longer change this back.'
@@ -51840,8 +51857,12 @@ async function accessSetHostedCeiling(roleId) {
 
 async function accessFleetCertRequest() {
   try {
-    const resp = await dashboardJsonFetch('api_fleet_cert_request', {}, () => Promise.reject(new Error('fleet certificate requests ride the control channel — connect to the daemon first')), 'api_fleet_cert_request', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
+    // daemonApi (transport F4): POST twin — verb-derived no-replay. The
+    // tunnel-only reject fallback died with the S6 ROW-NEW
+    // (POST /api/access/fleet-cert/request): a dashboard with no tunnel
+    // now starts the request over direct HTTP instead of erroring.
+    const resp = await daemonApi.request('api_fleet_cert_request', {});
+    const data = resp.body;
     if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
     showControlToast?.('success', 'Certificate request started — publishing DNS records and answering the Let’s Encrypt challenge (usually under a minute).');
   } catch (err) {
@@ -51860,12 +51881,11 @@ async function accessFleetCertRequest() {
 
 async function accessConnectUnclaim() {
   try {
-    const resp = await dashboardJsonFetch('api_access_connect_unclaim', {}, () => authedFetch('/api/access/connect/unclaim', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({}),
-    }), 'api_access_connect_unclaim', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
+    // daemonApi (transport F4): POST twin — verb-derived no-replay. The
+    // empty params ride body-less on HTTP; the unclaim handler never
+    // reads a body.
+    const resp = await daemonApi.request('api_access_connect_unclaim', {});
+    const data = resp.body;
     if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
     showControlToast?.('success', 'Claim released — a fresh claim phrase will mint shortly');
   } catch (err) {
@@ -51934,12 +51954,13 @@ function dashboardAccessTargetForHost(hostId) {
 
 async function refreshDashboardTargetsFromApi(options = {}) {
   try {
-    const resp = await dashboardJsonFetch('api_dashboard_targets', {}, () => authedFetch('/api/dashboard/targets', {
-      cache: 'no-store',
+    // daemonApi (transport F4): GET twin — read fallback policy.
+    const resp = await daemonApi.request('api_dashboard_targets', {}, {
       signal: options.signal,
-    }), 'api_dashboard_targets', { signal: options.signal });
+      cache: 'no-store',
+    });
     if (!resp.ok) throw new Error(`/api/dashboard/targets returned ${resp.status}`);
-    const payload = await resp.json();
+    const payload = resp.body;
     applyDashboardAccessTargets(payload);
     return payload;
   } catch (err) {
@@ -53288,7 +53309,10 @@ function accessAuditGrantCards() {
     const status = accessModelLabel(grant.status, 'active');
     const localIamGrant = accessModelLabel(grant.kind) === 'user_client_local_iam';
     const lifecycleBusy = accessGrantLifecycleSubmitting.has(grantId);
-    const canManage = dashboardControlTransport?.lastStatus?.api_access_iam_update_grant_available !== false;
+    // daemonApi availability (transport F4): tunnel status boolean when
+    // connected, HTTP-twin reachability otherwise — honest in Connect
+    // mode, where a down tunnel means no lane at all.
+    const canManage = daemonApi.availability('api_access_iam_update_grant').ok;
     const actions = [];
     if (localIamGrant && grantId) {
       if (status !== 'active') {
@@ -53538,14 +53562,12 @@ let accessGrantFanoutResults = null;
 
 async function accessApplyGrantToTarget(target, payload) {
   if (target.mode === 'self') {
-    const resp = await dashboardJsonFetch('api_access_iam_upsert_user_client_grant', payload, () => authedFetch('/api/access/iam/user-client-grants', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    }), 'api_access_iam_upsert_user_client_grant', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
-    if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
-    return data;
+    // daemonApi (transport F4): POST twin — verb-derived no-replay, the
+    // legacy fallbackAfterRpcFailure:false semantics. IAM-mutating
+    // write: payload shape unchanged, no retries.
+    const resp = await daemonApi.request('api_access_iam_upsert_user_client_grant', payload);
+    if (!resp.ok) throw new Error(resp.body?.error || `request failed (${resp.status})`);
+    return resp.body;
   }
   const resp = await fetch(`${target.origin}/api/access/iam/user-client-grants`, {
     method: 'POST',
@@ -53578,8 +53600,10 @@ function renderAccessUserClientGrantForm() {
   const overview = accessOverviewModel();
   const iam = accessIamModel(overview);
   const writeApiAvailable = iam?.capabilities?.write_api_available !== false;
-  const rpcAvailable = dashboardControlTransport?.lastStatus?.api_access_iam_upsert_user_client_grant_available;
-  const canSubmit = writeApiAvailable && rpcAvailable !== false;
+  // daemonApi availability (transport F4): folds the tunnel status
+  // boolean and HTTP-twin reachability into one honest answer.
+  const canSubmit = writeApiAvailable
+    && daemonApi.availability('api_access_iam_upsert_user_client_grant').ok;
   const candidate = accessCurrentUserClientCandidate();
   mount.innerHTML = '';
 
@@ -54082,12 +54106,11 @@ async function accessUpdateGrantLifecycle(grantId, changes = {}) {
   accessGrantLifecycleSubmitting.add(id);
   renderAccessAdminSummaries();
   try {
-    const resp = await dashboardJsonFetch('api_access_iam_update_grant', payload, () => authedFetch('/api/access/iam/grants/update', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    }), 'api_access_iam_update_grant', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
+    // daemonApi (transport F4): POST twin — verb-derived no-replay, the
+    // legacy fallbackAfterRpcFailure:false semantics. IAM-mutating
+    // write: payload shape unchanged, no retries.
+    const resp = await daemonApi.request('api_access_iam_update_grant', payload);
+    const data = resp.body;
     if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
     if (data?.iam) {
       dashboardAccessOverview = { ...(dashboardAccessOverview || {}), iam: data.iam };

--- a/static/app/32-daemon-api.js
+++ b/static/app/32-daemon-api.js
@@ -21,9 +21,11 @@
 //     exactly this no-legacy-fallback behavior).
 //
 // STATUS: consumed by the F1 family (files IDE fs calls, transfers pump,
-// staged uploads), the F2 sessions-family reads, and the F3 settings/keys
+// staged uploads), the F2 sessions-family reads, the F3 settings/keys
 // family (settings GET/POST, api-keys save, key-status, project-root,
-// external-agents, displays); the remaining `rpcOrHttp`/`jsonFetch` call
+// external-agents, displays), and the F4 access dialogs family
+// (overview/enrollment/connect/tier + IAM grant writes); the remaining
+// `rpcOrHttp`/`jsonFetch` call
 // sites move onto these verbs family by family per the design's frontend
 // track. The boot smoke's window.qa.daemonApi() probe asserts the facade
 // evaluates.
@@ -52,9 +54,12 @@
 //
 // Coverage: the F1 family (filesystem + staged uploads), the F2
 // sessions-family reads (managed-context, worktrees, the session list and
-// its NDJSON stream, search, detail, report, context snapshots), and the
+// its NDJSON stream, search, detail, report, context snapshots), the
 // F3 settings/keys family (settings GET/POST, api-keys save, key-status,
-// project-root, external-agents, displays). The
+// project-root, external-agents, displays), and the F4 access dialogs
+// family (overview, IAM state, enrollment reads + decide, IAM grant
+// upsert/update, the connect admin quartet, the tier pair, fleet-cert
+// request, dashboard targets). The
 // `api_transfer_*` methods are deliberately absent: they have no HTTP rows
 // until the server-track stage that adds /api/transfers (task #6); F1 adds
 // their entries when those rows land.
@@ -105,6 +110,20 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_project_root: { verb: 'GET', path: '/api/project-root' },
   api_external_agents: { verb: 'GET', path: '/api/external-agents' },
   api_displays: { verb: 'GET', path: '/api/displays' },
+  api_access_overview: { verb: 'GET', path: '/api/access/overview' },
+  api_access_iam_state: { verb: 'GET', path: '/api/access/iam/state' },
+  api_access_enrollment_requests: { verb: 'GET', path: '/api/access/enrollment-requests' },
+  api_access_enrollment_decide: { verb: 'POST', path: '/api/access/enrollment-requests/decide' },
+  api_access_iam_upsert_user_client_grant: { verb: 'POST', path: '/api/access/iam/user-client-grants' },
+  api_access_iam_update_grant: { verb: 'POST', path: '/api/access/iam/grants/update' },
+  api_access_connect_status: { verb: 'GET', path: '/api/access/connect/status' },
+  api_access_connect_claim_code: { verb: 'GET', path: '/api/access/connect/claim-code' },
+  api_access_connect_config: { verb: 'POST', path: '/api/access/connect/config' },
+  api_access_connect_unclaim: { verb: 'POST', path: '/api/access/connect/unclaim' },
+  api_access_set_tier: { verb: 'POST', path: '/api/access/tier' },
+  api_access_set_hosted_ceiling: { verb: 'POST', path: '/api/access/hosted-ceiling' },
+  api_fleet_cert_request: { verb: 'POST', path: '/api/access/fleet-cert/request' },
+  api_dashboard_targets: { verb: 'GET', path: '/api/dashboard/targets' },
 });
 
 // ── Uniform error shape (§3.5) ────────────────────────────────────────────

--- a/static/app/42-usage-terminal.js
+++ b/static/app/42-usage-terminal.js
@@ -649,13 +649,14 @@ function invalidateAccessOverview() {
 
 async function refreshAccessOverviewFromApi(options = {}) {
   try {
-    const resp = await dashboardJsonFetch('api_access_overview', {}, () => authedFetch('/api/access/overview', {
-      cache: 'no-store',
+    // daemonApi (transport F4): GET twin — tunnel first, direct HTTP per
+    // the read fallback policy; Connect mode never falls back.
+    const resp = await daemonApi.request('api_access_overview', {}, {
       signal: options.signal,
-    }), 'api_access_overview', { signal: options.signal });
+      cache: 'no-store',
+    });
     if (!resp.ok) throw new Error(`/api/access/overview returned ${resp.status}`);
-    const payload = await resp.json();
-    return applyAccessOverview(payload);
+    return applyAccessOverview(resp.body);
   } catch (err) {
     if (err?.name === 'AbortError') throw err;
     if (!options.silent) {
@@ -671,13 +672,13 @@ let accessPendingEnrollments = [];
 
 async function refreshAccessEnrollments(options = {}) {
   try {
-    const resp = await dashboardJsonFetch('api_access_enrollment_requests', {}, () => authedFetch('/api/access/enrollment-requests', {
-      cache: 'no-store',
+    // daemonApi (transport F4): GET twin — read fallback policy.
+    const resp = await daemonApi.request('api_access_enrollment_requests', {}, {
       signal: options.signal,
-    }), 'api_access_enrollment_requests', { signal: options.signal });
+      cache: 'no-store',
+    });
     if (!resp.ok) throw new Error(`/api/access/enrollment-requests returned ${resp.status}`);
-    const payload = await resp.json();
-    const requests = Array.isArray(payload?.requests) ? payload.requests : [];
+    const requests = Array.isArray(resp.body?.requests) ? resp.body.requests : [];
     const changed = JSON.stringify(requests) !== JSON.stringify(accessPendingEnrollments);
     accessPendingEnrollments = requests;
     if (changed) renderAccessAdminSummaries();
@@ -695,12 +696,13 @@ async function accessDecideEnrollment(fingerprint, approve, roleId) {
   const payload = { fingerprint, approve };
   if (approve && roleId) payload.role_id = roleId;
   try {
-    const resp = await dashboardJsonFetch('api_access_enrollment_decide', payload, () => authedFetch('/api/access/enrollment-requests/decide', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    }), 'api_access_enrollment_decide', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
+    // daemonApi (transport F4): POST twin — the fallback policy derives
+    // no-replay from the verb, exactly the legacy
+    // fallbackAfterRpcFailure:false semantics (a delivered tunnel attempt
+    // is never replayed over HTTP; with no tunnel the write goes direct).
+    // IAM-mutating write: the payload shape is unchanged, no retries.
+    const resp = await daemonApi.request('api_access_enrollment_decide', payload);
+    const data = resp.body;
     if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
     showControlToast?.('success', approve ? 'Device approved — it can connect now' : 'Device request denied');
   } catch (err) {
@@ -720,12 +722,13 @@ let accessConnectStatus = null;
 
 async function refreshAccessConnectStatus(options = {}) {
   try {
-    const resp = await dashboardJsonFetch('api_access_connect_status', {}, () => authedFetch('/api/access/connect/status', {
-      cache: 'no-store',
+    // daemonApi (transport F4): GET twin — read fallback policy.
+    const resp = await daemonApi.request('api_access_connect_status', {}, {
       signal: options.signal,
-    }), 'api_access_connect_status', { signal: options.signal });
+      cache: 'no-store',
+    });
     if (!resp.ok) throw new Error(`/api/access/connect/status returned ${resp.status}`);
-    const payload = await resp.json();
+    const payload = resp.body;
     const changed = JSON.stringify(payload) !== JSON.stringify(accessConnectStatus);
     accessConnectStatus = payload;
     if (changed) renderAccessAdminSummaries();
@@ -738,10 +741,13 @@ async function refreshAccessConnectStatus(options = {}) {
 }
 
 async function accessConnectFetchClaimCode() {
-  const resp = await dashboardJsonFetch('api_access_connect_claim_code', {}, () => authedFetch('/api/access/connect/claim-code', {
-    cache: 'no-store',
-  }), 'api_access_connect_claim_code', { fallbackAfterRpcFailure: false });
-  const data = await resp.json().catch(() => ({}));
+  // daemonApi (transport F4): GET twin, so the derived policy allows the
+  // direct-HTTP retry after a failed tunnel attempt (the legacy call site
+  // opted out via fallbackAfterRpcFailure:false, but a manage-gated
+  // idempotent read replays safely — the policy is data, not per-site
+  // judgment). Connect mode never falls back.
+  const resp = await daemonApi.request('api_access_connect_claim_code', {}, { cache: 'no-store' });
+  const data = resp.body;
   if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
   return data;
 }
@@ -750,12 +756,10 @@ async function accessConnectSetEnabled(enabled, rendezvousUrl) {
   const payload = { enabled };
   if (rendezvousUrl) payload.rendezvous_url = rendezvousUrl;
   try {
-    const resp = await dashboardJsonFetch('api_access_connect_config', payload, () => authedFetch('/api/access/connect/config', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    }), 'api_access_connect_config', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
+    // daemonApi (transport F4): POST twin — verb-derived no-replay, the
+    // legacy fallbackAfterRpcFailure:false semantics.
+    const resp = await daemonApi.request('api_access_connect_config', payload);
+    const data = resp.body;
     if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
     showControlToast?.('success', enabled
       ? 'Connect enabled — this daemon is registering with the rendezvous'
@@ -770,12 +774,9 @@ async function accessConnectSetEnabled(enabled, rendezvousUrl) {
 async function accessSetTier(tier) {
   const payload = { tier: tier || null };
   try {
-    const resp = await dashboardJsonFetch('api_access_set_tier', payload, () => authedFetch('/api/access/tier', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    }), 'api_access_set_tier', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
+    // daemonApi (transport F4): POST twin — verb-derived no-replay.
+    const resp = await daemonApi.request('api_access_set_tier', payload);
+    const data = resp.body;
     if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
     showControlToast?.('success', tier
       ? `Trust tier set: ${tier}`
@@ -790,12 +791,9 @@ async function accessSetTier(tier) {
 async function accessSetHostedCeiling(roleId) {
   const payload = { role_id: roleId };
   try {
-    const resp = await dashboardJsonFetch('api_access_set_hosted_ceiling', payload, () => authedFetch('/api/access/hosted-ceiling', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    }), 'api_access_set_hosted_ceiling', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
+    // daemonApi (transport F4): POST twin — verb-derived no-replay.
+    const resp = await daemonApi.request('api_access_set_hosted_ceiling', payload);
+    const data = resp.body;
     if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
     showControlToast?.('success', roleId === 'role:none'
       ? 'Hosted-origin control refused. Reach this daemon directly, through the app, or from an enrolled peer — a hosted tab can no longer change this back.'
@@ -809,8 +807,12 @@ async function accessSetHostedCeiling(roleId) {
 
 async function accessFleetCertRequest() {
   try {
-    const resp = await dashboardJsonFetch('api_fleet_cert_request', {}, () => Promise.reject(new Error('fleet certificate requests ride the control channel — connect to the daemon first')), 'api_fleet_cert_request', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
+    // daemonApi (transport F4): POST twin — verb-derived no-replay. The
+    // tunnel-only reject fallback died with the S6 ROW-NEW
+    // (POST /api/access/fleet-cert/request): a dashboard with no tunnel
+    // now starts the request over direct HTTP instead of erroring.
+    const resp = await daemonApi.request('api_fleet_cert_request', {});
+    const data = resp.body;
     if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
     showControlToast?.('success', 'Certificate request started — publishing DNS records and answering the Let’s Encrypt challenge (usually under a minute).');
   } catch (err) {
@@ -829,12 +831,11 @@ async function accessFleetCertRequest() {
 
 async function accessConnectUnclaim() {
   try {
-    const resp = await dashboardJsonFetch('api_access_connect_unclaim', {}, () => authedFetch('/api/access/connect/unclaim', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({}),
-    }), 'api_access_connect_unclaim', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
+    // daemonApi (transport F4): POST twin — verb-derived no-replay. The
+    // empty params ride body-less on HTTP; the unclaim handler never
+    // reads a body.
+    const resp = await daemonApi.request('api_access_connect_unclaim', {});
+    const data = resp.body;
     if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
     showControlToast?.('success', 'Claim released — a fresh claim phrase will mint shortly');
   } catch (err) {
@@ -903,12 +904,13 @@ function dashboardAccessTargetForHost(hostId) {
 
 async function refreshDashboardTargetsFromApi(options = {}) {
   try {
-    const resp = await dashboardJsonFetch('api_dashboard_targets', {}, () => authedFetch('/api/dashboard/targets', {
-      cache: 'no-store',
+    // daemonApi (transport F4): GET twin — read fallback policy.
+    const resp = await daemonApi.request('api_dashboard_targets', {}, {
       signal: options.signal,
-    }), 'api_dashboard_targets', { signal: options.signal });
+      cache: 'no-store',
+    });
     if (!resp.ok) throw new Error(`/api/dashboard/targets returned ${resp.status}`);
-    const payload = await resp.json();
+    const payload = resp.body;
     applyDashboardAccessTargets(payload);
     return payload;
   } catch (err) {
@@ -2257,7 +2259,10 @@ function accessAuditGrantCards() {
     const status = accessModelLabel(grant.status, 'active');
     const localIamGrant = accessModelLabel(grant.kind) === 'user_client_local_iam';
     const lifecycleBusy = accessGrantLifecycleSubmitting.has(grantId);
-    const canManage = dashboardControlTransport?.lastStatus?.api_access_iam_update_grant_available !== false;
+    // daemonApi availability (transport F4): tunnel status boolean when
+    // connected, HTTP-twin reachability otherwise — honest in Connect
+    // mode, where a down tunnel means no lane at all.
+    const canManage = daemonApi.availability('api_access_iam_update_grant').ok;
     const actions = [];
     if (localIamGrant && grantId) {
       if (status !== 'active') {
@@ -2507,14 +2512,12 @@ let accessGrantFanoutResults = null;
 
 async function accessApplyGrantToTarget(target, payload) {
   if (target.mode === 'self') {
-    const resp = await dashboardJsonFetch('api_access_iam_upsert_user_client_grant', payload, () => authedFetch('/api/access/iam/user-client-grants', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    }), 'api_access_iam_upsert_user_client_grant', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
-    if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
-    return data;
+    // daemonApi (transport F4): POST twin — verb-derived no-replay, the
+    // legacy fallbackAfterRpcFailure:false semantics. IAM-mutating
+    // write: payload shape unchanged, no retries.
+    const resp = await daemonApi.request('api_access_iam_upsert_user_client_grant', payload);
+    if (!resp.ok) throw new Error(resp.body?.error || `request failed (${resp.status})`);
+    return resp.body;
   }
   const resp = await fetch(`${target.origin}/api/access/iam/user-client-grants`, {
     method: 'POST',
@@ -2547,8 +2550,10 @@ function renderAccessUserClientGrantForm() {
   const overview = accessOverviewModel();
   const iam = accessIamModel(overview);
   const writeApiAvailable = iam?.capabilities?.write_api_available !== false;
-  const rpcAvailable = dashboardControlTransport?.lastStatus?.api_access_iam_upsert_user_client_grant_available;
-  const canSubmit = writeApiAvailable && rpcAvailable !== false;
+  // daemonApi availability (transport F4): folds the tunnel status
+  // boolean and HTTP-twin reachability into one honest answer.
+  const canSubmit = writeApiAvailable
+    && daemonApi.availability('api_access_iam_upsert_user_client_grant').ok;
   const candidate = accessCurrentUserClientCandidate();
   mount.innerHTML = '';
 
@@ -3051,12 +3056,11 @@ async function accessUpdateGrantLifecycle(grantId, changes = {}) {
   accessGrantLifecycleSubmitting.add(id);
   renderAccessAdminSummaries();
   try {
-    const resp = await dashboardJsonFetch('api_access_iam_update_grant', payload, () => authedFetch('/api/access/iam/grants/update', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    }), 'api_access_iam_update_grant', { fallbackAfterRpcFailure: false });
-    const data = await resp.json().catch(() => ({}));
+    // daemonApi (transport F4): POST twin — verb-derived no-replay, the
+    // legacy fallbackAfterRpcFailure:false semantics. IAM-mutating
+    // write: payload shape unchanged, no retries.
+    const resp = await daemonApi.request('api_access_iam_update_grant', payload);
+    const data = resp.body;
     if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
     if (data?.iam) {
       dashboardAccessOverview = { ...(dashboardAccessOverview || {}), iam: data.iam };


### PR DESCRIPTION
First F4 PR unit (transport-unification design §6, frontend track): the access dialogs family — fragment 42's overview / enrollment / connect-admin / tier / fleet-cert / dashboard-targets / IAM-grant call sites — moves onto the `daemonApi` facade, riding the tunnel rows S6 landed (PRs #176/#180/#183).

## What moves (static/app/42-usage-terminal.js)
- **Reads** — `refreshAccessOverviewFromApi` (`api_access_overview`), `refreshAccessEnrollments` (`api_access_enrollment_requests`), `refreshAccessConnectStatus` (`api_access_connect_status`), `accessConnectFetchClaimCode` (`api_access_connect_claim_code`), `refreshDashboardTargetsFromApi` (`api_dashboard_targets`): GET twins — tunnel first, direct HTTP per the read fallback policy, Connect mode never falls back. Caller cache posture (`no-store`) and abort signals pass through.
- **Writes** — `accessDecideEnrollment`, `accessConnectSetEnabled`, `accessSetTier`, `accessSetHostedCeiling`, `accessConnectUnclaim`, `accessFleetCertRequest`, `accessApplyGrantToTarget` (self mode), `accessUpdateGrantLifecycle`: POST twins — the fallback policy derives no-replay from the verb, exactly the legacy `fallbackAfterRpcFailure:false` semantics. IAM-mutating writes: payload shapes unchanged, zero retries.
- **Availability** — the two hand-rolled `lastStatus.*_available` probes (grant form, audit grant cards) become `daemonApi.availability(...)` derivations: tunnel status boolean when connected, HTTP-twin reachability otherwise, honest `transport-down` in Connect mode instead of the legacy optimistic default.

## Deliberate normalizations (commented in place)
- `api_access_connect_claim_code` is a GET twin: the derived policy allows the direct-HTTP retry after a failed tunnel attempt where the legacy site opted out — an idempotent manage-gated read replays safely; the policy is data, not per-site judgment (design §3.7).
- `api_fleet_cert_request`'s tunnel-only `Promise.reject` fallback dies: the S6c ROW-NEW (`POST /api/access/fleet-cert/request`) gives HTTP-only dashboards a real lane; verb-derived no-replay applies.

## Descriptor + pin
`DAEMON_API_HTTP_MAP` grows the 14 dialog-family entries; the daemon-side parity pin (`daemon_api_http_map_mirrors_gateway_routes`) coverage set extends 32 → 46 — every entry's verb, path template, and IAM operation verify against the route table per-entry as before. `api_access_iam_state` rides along (raw-JSON links in fragment 43 stay `window.open`; the descriptor completes the family for availability honesty).

## Remote fan-out
`accessApplyGrantToTarget`'s **remote** branch (direct cross-origin POST to a fleet daemon) is deliberately untouched here — F4b models it as the facade's explicit `remote-http` target per the design §5 caveat (fleet fan-out stays direct HTTP to remote origins, never a tunnel fallback).

Fragment 43's org panes are F4b.

Battery: assembler regen; `cargo nextest run --bins` 2981 passed; clippy clean on the touched files; `node --check` on both fragments.

Gates note: validate-org-grants is environmentally blocked on this box at hosted-Connect passkey registration (pre-existing, proven by differential run) — relying on the parity pins + goldens like S6 did.