### PR TITLE
Transport S7a: peers/coordinator goldens + neutral sub-router core (both lanes)

### DIFF
--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -1626,12 +1626,27 @@ pub(crate) async fn api_peer_pairing_join_response(
     http_body_response(id, status, body, "peer pairing join")
 }
 
+// The pairing arms below split transport edge from core (hermeticity
+// convention, the sessions family's `_from_home` shape): the ambient
+// wrapper resolves the daemon's cert store once, the `_from_cert_dir`
+// core is what the parity fixtures drive over injected tempdirs.
+
 pub(crate) async fn api_peer_pairing_request_access_response(
     id: String,
     params: Option<&serde_json::Value>,
 ) -> serde_json::Value {
+    let cert_dir = crate::access::backend::select_backend().cert_dir();
+    api_peer_pairing_request_access_response_from_cert_dir(id, params, &cert_dir).await
+}
+
+pub(crate) async fn api_peer_pairing_request_access_response_from_cert_dir(
+    id: String,
+    params: Option<&serde_json::Value>,
+    cert_dir: &std::path::Path,
+) -> serde_json::Value {
     let body_text = params_body_text(params);
-    let (status, body) = crate::web_gateway::peers_pairing_request_access(&body_text).await;
+    let (status, body) =
+        crate::web_gateway::peers_pairing_request_access(cert_dir, &body_text).await;
     http_body_response(id, status, body, "peer access request")
 }
 
@@ -1640,10 +1655,22 @@ pub(crate) async fn api_peer_pairing_request_access_poll_response(
     params: Option<&serde_json::Value>,
     runtime: &ControlRuntime,
 ) -> serde_json::Value {
+    let cert_dir = crate::access::backend::select_backend().cert_dir();
+    api_peer_pairing_request_access_poll_response_from_cert_dir(id, params, runtime, &cert_dir)
+        .await
+}
+
+pub(crate) async fn api_peer_pairing_request_access_poll_response_from_cert_dir(
+    id: String,
+    params: Option<&serde_json::Value>,
+    runtime: &ControlRuntime,
+    cert_dir: &std::path::Path,
+) -> serde_json::Value {
     let body_text = params_body_text(params);
     let (status, body) = crate::web_gateway::peers_pairing_request_access_poll(
         runtime.peer_registry.as_ref(),
         runtime.project_root.as_deref(),
+        cert_dir,
         &body_text,
     )
     .await;
@@ -1651,13 +1678,30 @@ pub(crate) async fn api_peer_pairing_request_access_poll_response(
 }
 
 pub(crate) async fn api_peer_pairing_requests_response(id: String) -> serde_json::Value {
-    let (status, body) = crate::web_gateway::peers_pairing_requests_list();
+    let cert_dir = crate::access::backend::select_backend().cert_dir();
+    api_peer_pairing_requests_response_from_cert_dir(id, &cert_dir).await
+}
+
+pub(crate) async fn api_peer_pairing_requests_response_from_cert_dir(
+    id: String,
+    cert_dir: &std::path::Path,
+) -> serde_json::Value {
+    let (status, body) = crate::web_gateway::peers_pairing_requests_list(cert_dir);
     http_body_response(id, status, body, "peer access requests")
 }
 
 pub(crate) async fn api_peer_pairing_request_decision_response(
     id: String,
     params: Option<&serde_json::Value>,
+) -> serde_json::Value {
+    let cert_dir = crate::access::backend::select_backend().cert_dir();
+    api_peer_pairing_request_decision_response_from_cert_dir(id, params, &cert_dir).await
+}
+
+pub(crate) async fn api_peer_pairing_request_decision_response_from_cert_dir(
+    id: String,
+    params: Option<&serde_json::Value>,
+    cert_dir: &std::path::Path,
 ) -> serde_json::Value {
     let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
     let request_id = string_param(&params, &["request_id", "requestId", "code", "id"]);
@@ -1672,12 +1716,20 @@ pub(crate) async fn api_peer_pairing_request_decision_response(
     };
     let body_text = serde_json::to_string(&params).unwrap_or_else(|_| "{}".to_string());
     let (status, body) =
-        crate::web_gateway::peers_pairing_request_decision(&request_id, &op, &body_text);
+        crate::web_gateway::peers_pairing_request_decision(cert_dir, &request_id, &op, &body_text);
     http_body_response(id, status, body, "peer access request decision")
 }
 
 pub(crate) async fn api_peer_pairing_identities_response(id: String) -> serde_json::Value {
-    let (status, body) = crate::web_gateway::peers_pairing_identities_list();
+    let cert_dir = crate::access::backend::select_backend().cert_dir();
+    api_peer_pairing_identities_response_from_cert_dir(id, &cert_dir).await
+}
+
+pub(crate) async fn api_peer_pairing_identities_response_from_cert_dir(
+    id: String,
+    cert_dir: &std::path::Path,
+) -> serde_json::Value {
+    let (status, body) = crate::web_gateway::peers_pairing_identities_list_from_cert_dir(cert_dir);
     http_body_response(id, status, body, "peer identities")
 }
 
@@ -1685,8 +1737,18 @@ pub(crate) async fn api_peer_pairing_identity_revoke_response(
     id: String,
     params: Option<&serde_json::Value>,
 ) -> serde_json::Value {
+    let cert_dir = crate::access::backend::select_backend().cert_dir();
+    api_peer_pairing_identity_revoke_response_from_cert_dir(id, params, &cert_dir).await
+}
+
+pub(crate) async fn api_peer_pairing_identity_revoke_response_from_cert_dir(
+    id: String,
+    params: Option<&serde_json::Value>,
+    cert_dir: &std::path::Path,
+) -> serde_json::Value {
     let body_text = params_body_text(params);
-    let (status, body) = crate::web_gateway::peers_pairing_identity_revoke(&body_text);
+    let (status, body) =
+        crate::web_gateway::peers_pairing_identity_revoke_from_cert_dir(cert_dir, &body_text);
     http_body_response(id, status, body, "peer identity revoke")
 }
 

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -1761,8 +1761,16 @@ pub(crate) async fn api_coordinator_route_response(
         return peer_registry_unavailable_response(id);
     };
     let body_text = params_body_text(params);
-    let (status, body) = crate::web_gateway::coordinator_route(registry, &body_text).await;
-    http_body_response(id, status, body, "coordinator route")
+    // The datachannel twin runs the S7 neutral core (POST-shaped by
+    // construction); the registry check above keeps the tunnel's
+    // historical frame-level error instead of the core's 503 body
+    // (divergence #20 in the S7 parity enumeration).
+    frame_api_response(
+        id,
+        crate::web_gateway::coordinator_route_api_response("POST", &body_text, Some(registry))
+            .await,
+        "coordinator route",
+    )
 }
 
 #[cfg(test)]
@@ -2886,6 +2894,243 @@ mod tests {
             "this daemon has no fleet name — enable Connect against a \
              rendezvous with fleet DNS and let it register first"
         );
+    }
+
+    // ── S7 tunnel/HTTP parity: the peers/coordinator federation
+    // family ──
+    //
+    // Extends the enumeration (#10–#19 in the S6 blocks above). Both
+    // lanes have long shared the peers leaves (`peers_*` in
+    // routes_peers.rs); S7 makes the HTTP side one neutral sub-router
+    // unit and pins the addressing equivalence. The slice-specific
+    // differences, deliberate and pinned:
+    //
+    //  20. Registry-gate shapes are per-lane: the HTTP sub-router and
+    //      coordinator answer 503 {"error":"peer registry not
+    //      configured"}; the tunnel arms pre-check and answer the
+    //      frame-level {ok:false, error:"peer registry unavailable"}
+    //      — a different string AND envelope, both historical.
+    //  21. Addressing is transport-owned: HTTP captures the peer id
+    //      (url-decoded) and the request code/decision from path
+    //      segments and reads eligible capabilities from the query
+    //      string; the tunnel reads params — peer_id under five
+    //      aliases, request_id under four, the decision op defaulting
+    //      to "approve", capabilities as array/CSV
+    //      (control_capability_query) — and answers its own
+    //      missing-param frame when the id is absent.
+    //  22. Envelope split: api_peers (the list) rides the body-only
+    //      envelope (inline dispatch arm — no injected status); every
+    //      other peer method rides the `_httpStatus` injection. The
+    //      family's wildcard-CORS tail and its reason ladder (502 Bad
+    //      Gateway on relay failures) are HTTP-lane decoration only.
+    //  23. Store resolution at the edges: both lanes resolve the
+    //      ambient cert store at their transport edges and share the
+    //      cert-dir-parameterized pairing leaves; fixtures inject
+    //      tempdirs (hermeticity convention).
+
+    fn empty_peer_registry() -> crate::peer::PeerRegistry {
+        let (log_tx, _log_rx) =
+            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(8);
+        crate::peer::PeerRegistry::new(log_tx)
+    }
+
+    #[tokio::test]
+    async fn parity_coordinator_route_shares_the_neutral_core() {
+        // Decode failure: deterministic serde wording through the one
+        // core on both lanes (routing successes need a connected peer
+        // and stay smoke-covered by the peer validators).
+        let registry = empty_peer_registry();
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::coordinator_route_api_response("POST", "{}", Some(&registry))
+                .await,
+        );
+        assert_eq!(status, 400);
+
+        let mut rt = runtime();
+        rt.peer_registry = Some(empty_peer_registry());
+        let frame = api_coordinator_route_response(
+            "parity-coordinator".to_string(),
+            Some(&serde_json::json!({})),
+            &rt,
+        )
+        .await;
+        assert_eq!(frame["ok"], true);
+        let mut result = frame["result"].clone();
+        let map = result.as_object_mut().expect("result object");
+        assert_eq!(map.remove("_httpStatus"), Some(serde_json::json!(400)));
+        assert_eq!(map.remove("_httpOk"), Some(serde_json::json!(false)));
+        assert_eq!(result, http_body);
+    }
+
+    #[tokio::test]
+    async fn parity_registry_unavailable_shapes_stay_per_lane() {
+        // Divergence #20, pinned from both sides.
+        let bus = crate::event::EventBus::new();
+        let tmp = tempfile::tempdir().expect("temp cert dir");
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::peers_sub_router_api_response(
+                "GET",
+                "/api/peers",
+                "",
+                tmp.path(),
+                &bus,
+                None,
+                None,
+            )
+            .await,
+        );
+        assert_eq!(status, 503);
+        assert_eq!(http_body["error"], "peer registry not configured");
+
+        let rt = runtime();
+        let frame =
+            api_peer_add_response("parity-no-registry".to_string(), None, &rt).await;
+        assert_eq!(frame["ok"], false);
+        assert_eq!(frame["error"], "peer registry unavailable");
+    }
+
+    #[tokio::test]
+    async fn parity_pairing_decision_addresses_by_params_on_the_tunnel() {
+        // Divergence #21: HTTP takes the code and decision from path
+        // segments, the tunnel from params; the unknown-decision 404
+        // rises from the one shared leaf over the same injected store.
+        let bus = crate::event::EventBus::new();
+        let tmp = tempfile::tempdir().expect("temp cert dir");
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::peers_sub_router_api_response(
+                "POST",
+                "/api/peers/pairing/requests/zzz/badop",
+                "",
+                tmp.path(),
+                &bus,
+                None,
+                None,
+            )
+            .await,
+        );
+        assert_eq!(status, 404);
+
+        let frame = api_peer_pairing_request_decision_response_from_cert_dir(
+            "parity-decision".to_string(),
+            Some(&serde_json::json!({"request_id": "zzz", "op": "badop"})),
+            tmp.path(),
+        )
+        .await;
+        assert_eq!(frame["ok"], true);
+        let mut result = frame["result"].clone();
+        let map = result.as_object_mut().expect("result object");
+        assert_eq!(map.remove("_httpStatus"), Some(serde_json::json!(404)));
+        assert_eq!(map.remove("_httpOk"), Some(serde_json::json!(false)));
+        assert_eq!(result, http_body);
+
+        // The tunnel's own missing-param frame (no HTTP equivalent —
+        // the path shape cannot omit the code).
+        let frame = api_peer_pairing_request_decision_response_from_cert_dir(
+            "parity-decision-missing".to_string(),
+            Some(&serde_json::json!({})),
+            tmp.path(),
+        )
+        .await;
+        assert_eq!(frame["ok"], false);
+        assert_eq!(frame["error"], "missing request_id");
+    }
+
+    #[tokio::test]
+    async fn parity_pairing_requests_list_shares_the_leaf_store() {
+        let bus = crate::event::EventBus::new();
+        let tmp = tempfile::tempdir().expect("temp cert dir");
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::peers_sub_router_api_response(
+                "GET",
+                "/api/peers/pairing/requests",
+                "",
+                tmp.path(),
+                &bus,
+                None,
+                None,
+            )
+            .await,
+        );
+        assert_eq!(status, 200);
+        assert_eq!(http_body, serde_json::json!({"requests": []}));
+
+        let frame = api_peer_pairing_requests_response_from_cert_dir(
+            "parity-requests".to_string(),
+            tmp.path(),
+        )
+        .await;
+        assert_eq!(frame["ok"], true);
+        let mut result = frame["result"].clone();
+        let map = result.as_object_mut().expect("result object");
+        assert_eq!(map.remove("_httpStatus"), Some(serde_json::json!(200)));
+        assert_eq!(map.remove("_httpOk"), Some(serde_json::json!(true)));
+        assert_eq!(result, http_body);
+    }
+
+    #[tokio::test]
+    async fn parity_eligible_addresses_by_params_on_the_tunnel() {
+        // Divergence #21 on the read side: HTTP's ?capability= query vs
+        // the tunnel's capabilities param (array/CSV), one leaf behind
+        // both. The no-capability 400 is the deterministic shape.
+        let bus = crate::event::EventBus::new();
+        let tmp = tempfile::tempdir().expect("temp cert dir");
+        let registry = empty_peer_registry();
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::peers_sub_router_api_response(
+                "GET",
+                "/api/peers/eligible",
+                "",
+                tmp.path(),
+                &bus,
+                None,
+                Some(&registry),
+            )
+            .await,
+        );
+        assert_eq!(status, 400);
+
+        let mut rt = runtime();
+        rt.peer_registry = Some(empty_peer_registry());
+        let frame = api_peer_eligible_response(
+            "parity-eligible".to_string(),
+            Some(&serde_json::json!({})),
+            &rt,
+        )
+        .await;
+        assert_eq!(frame["ok"], true);
+        let mut result = frame["result"].clone();
+        let map = result.as_object_mut().expect("result object");
+        assert_eq!(map.remove("_httpStatus"), Some(serde_json::json!(400)));
+        assert_eq!(map.remove("_httpOk"), Some(serde_json::json!(false)));
+        assert_eq!(result, http_body);
+
+        // Same params, capability satisfied on both lanes: the empty
+        // registry serves the empty snapshot list.
+        let (status, http_body) = parity_http_status_and_body(
+            crate::web_gateway::peers_sub_router_api_response(
+                "GET",
+                "/api/peers/eligible?capability=display",
+                "",
+                tmp.path(),
+                &bus,
+                None,
+                Some(&registry),
+            )
+            .await,
+        );
+        assert_eq!(status, 200);
+        let frame = api_peer_eligible_response(
+            "parity-eligible-display".to_string(),
+            Some(&serde_json::json!({"capabilities": ["display"]})),
+            &rt,
+        )
+        .await;
+        assert_eq!(frame["ok"], true);
+        let mut result = frame["result"].clone();
+        let map = result.as_object_mut().expect("result object");
+        assert_eq!(map.remove("_httpStatus"), Some(serde_json::json!(200)));
+        assert_eq!(map.remove("_httpOk"), Some(serde_json::json!(true)));
+        assert_eq!(result, http_body);
     }
 
     use crate::*;

--- a/src/bin/caller/web_gateway/http.rs
+++ b/src/bin/caller/web_gateway/http.rs
@@ -732,6 +732,11 @@ pub(crate) fn status_reason(status: u16) -> &'static str {
         416 => "416 Range Not Satisfiable",
         429 => "429 Too Many Requests",
         500 => "500 Internal Server Error",
+        // The peers family's relay-failure class (peer_error_response,
+        // coordinator delegation): NotConnected/Transport/Auth/Rejected
+        // answer 502 through the shared renderer since the S7
+        // conversion.
+        502 => "502 Bad Gateway",
         503 => "503 Service Unavailable",
         _ => "500 Internal Server Error",
     }

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -972,6 +972,7 @@ pub(crate) async fn serve_http_request(
                     route_body,
                     request_line,
                     req_method,
+                    cert_dir,
                     bus,
                     project_root,
                     peer_registry,

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -77,6 +77,7 @@ fn peers_family_api_response(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn handle_peers_sub_router(
     stream: DemuxStream,
     body_text: String,

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -53,8 +53,32 @@ pub(crate) async fn handle_doorbell(
     finalize_http_stream(&mut stream).await;
 }
 
+/// The peers family's historical JSON framing: the family predates the
+/// posture-derived CORS renderers, so its wildcard tail (`Cache-Control`,
+/// `Access-Control-Allow-Origin: *`, the per-handler `Allow-Methods`
+/// list, `Allow-Headers`, `Connection: close`) rides the response
+/// headers verbatim — the row posture (`OwnOrigin`) appends nothing on
+/// top. The golden transcripts pin these bytes.
+fn peers_family_api_response(
+    status: u16,
+    body: String,
+    allow_methods: &'static str,
+) -> ApiResponse {
+    ApiResponse::Json {
+        status,
+        body: JsonBody::PreSerialized(body),
+        headers: vec![
+            ("Cache-Control", "no-cache".to_string()),
+            ("Access-Control-Allow-Origin", "*".to_string()),
+            ("Access-Control-Allow-Methods", allow_methods.to_string()),
+            ("Access-Control-Allow-Headers", "Content-Type".to_string()),
+            ("Connection", "close".to_string()),
+        ],
+    }
+}
+
 pub(crate) async fn handle_peers_sub_router(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     body_text: String,
     request_line: &str,
     req_method: &str,
@@ -63,32 +87,67 @@ pub(crate) async fn handle_peers_sub_router(
     project_root: Option<PathBuf>,
     peer_registry: Option<crate::peer::PeerRegistry>,
 ) {
-    // Peer registry endpoints. Dispatch:
-    //   GET    /api/peers                  → list
-    //   POST   /api/peers                  → add
-    //   DELETE /api/peers                  → remove
-    //   POST   /api/peers/pairing/invite   → issue pairing invite
-    //   POST   /api/peers/pairing/join     → import pairing invite
-    //   POST   /api/peers/{id}/message     → send message
-    //   POST   /api/peers/{id}/task        → delegate task
-    //   POST   /api/peers/{id}/approval    → resolve approval
-    //
-    // When no registry is wired in (test call sites
-    // that pass None), every request returns 503 so
-    // the dashboard can render "peers unavailable"
-    // instead of the empty list that a working-but-
-    // empty registry would produce.
-    use tokio::io::AsyncWriteExt;
-
-    // Extract subpath after `/api/peers`. The list/
-    // add/remove ops have an empty subpath; per-peer
-    // ops have `/{id}/{op}`. Extract the *path*
-    // token from the request line first (the second
-    // whitespace-separated word) — splitting on
-    // `/api/peers` directly would walk into the
-    // ` HTTP/1.1` suffix and mistake `HTTP` and `1.1`
-    // for path segments.
+    // Extract the *path* token from the request line (the second
+    // whitespace-separated word) — splitting on `/api/peers` directly
+    // would walk into the ` HTTP/1.1` suffix and mistake `HTTP` and
+    // `1.1` for path segments.
     let path_token = request_line.split_whitespace().nth(1).unwrap_or("");
+    let response = peers_sub_router_api_response(
+        req_method,
+        path_token,
+        &body_text,
+        &cert_dir,
+        &bus,
+        project_root.as_deref(),
+        peer_registry.as_ref(),
+    )
+    .await;
+    write_api_response(
+        stream,
+        response,
+        crate::gateway_routes::CorsPosture::OwnOrigin,
+        None,
+    )
+    .await;
+}
+
+/// The peers sub-router, transport-neutral (transport-unification S7):
+/// one handler unit — per-leaf resolution (path-addressed here; the
+/// datachannel twins address the same leaves by method name and
+/// params) plus the family's historical envelope. Deliberately still
+/// one function: the leaves stay intact and the handler keeps owning
+/// the JSON 404/405 shapes for garbage subpaths (design §2.7; per-leaf
+/// route rows exist for declaration, the `Any` catch-all row keeps
+/// dispatch behavior).
+///
+/// Dispatch:
+///   GET    /api/peers                  → list
+///   POST   /api/peers                  → add
+///   DELETE /api/peers                  → remove
+///   GET    /api/peers/eligible         → capability-filtered list
+///   POST   /api/peers/pairing/invite   → issue pairing invite
+///   POST   /api/peers/pairing/join     → import pairing invite
+///   POST   /api/peers/pairing/request-access[/poll] → doorbell client
+///   GET    /api/peers/pairing/requests|identities   → pairing reads
+///   POST   /api/peers/pairing/requests/{code}/{op}  → decision
+///   POST   /api/peers/pairing/identities/revoke     → revoke identity
+///   POST   /api/peers/{id}/message|task|approval    → quick controls
+///   POST   /api/peers/{id}/webrtc|file-transfer-webrtc|
+///          dashboard-control-webrtc                 → signaling relays
+///
+/// When no registry is wired in (test call sites that pass None),
+/// every registry-backed leaf returns 503 so the dashboard can render
+/// "peers unavailable" instead of the empty list that a working-but-
+/// empty registry would produce.
+pub(crate) async fn peers_sub_router_api_response(
+    req_method: &str,
+    path_token: &str,
+    body_text: &str,
+    cert_dir: &Path,
+    bus: &EventBus,
+    project_root: Option<&Path>,
+    peer_registry: Option<&crate::peer::PeerRegistry>,
+) -> ApiResponse {
     // Split path from query string. `/api/peers/eligible
     // ?capability=display` needs the query stripped before
     // we extract subpath segments.
@@ -103,31 +162,25 @@ pub(crate) async fn handle_peers_sub_router(
     let segments: Vec<&str> = subpath.split('/').filter(|s| !s.is_empty()).collect();
 
     let (status, body) = if segments == ["pairing", "invite"] && req_method == "POST" {
-        peers_pairing_invite(&body_text)
+        peers_pairing_invite(body_text)
     } else if segments == ["pairing", "request-access"] && req_method == "POST" {
-        peers_pairing_request_access(&cert_dir, &body_text).await
+        peers_pairing_request_access(cert_dir, body_text).await
     } else if segments == ["pairing", "request-access", "poll"] && req_method == "POST" {
-        peers_pairing_request_access_poll(
-            peer_registry.as_ref(),
-            project_root.as_deref(),
-            &cert_dir,
-            &body_text,
-        )
-        .await
+        peers_pairing_request_access_poll(peer_registry, project_root, cert_dir, body_text).await
     } else if segments == ["pairing", "requests"] && req_method == "GET" {
-        peers_pairing_requests_list(&cert_dir)
+        peers_pairing_requests_list(cert_dir)
     } else if segments == ["pairing", "identities"] && req_method == "GET" {
-        peers_pairing_identities_list_from_cert_dir(&cert_dir)
+        peers_pairing_identities_list_from_cert_dir(cert_dir)
     } else if segments == ["pairing", "identities", "revoke"] && req_method == "POST" {
-        peers_pairing_identity_revoke_from_cert_dir(&cert_dir, &body_text)
+        peers_pairing_identity_revoke_from_cert_dir(cert_dir, body_text)
     } else if segments.len() == 4
         && segments[0] == "pairing"
         && segments[1] == "requests"
         && req_method == "POST"
     {
-        peers_pairing_request_decision(&cert_dir, segments[2], segments[3], &body_text)
+        peers_pairing_request_decision(cert_dir, segments[2], segments[3], body_text)
     } else {
-        match peer_registry.as_ref() {
+        match peer_registry {
             None => (
                 503,
                 serde_json::json!({
@@ -142,9 +195,9 @@ pub(crate) async fn handle_peers_sub_router(
                 if segments.is_empty() && (req_method == "POST" || req_method == "DELETE") =>
             {
                 if req_method == "POST" {
-                    peers_add(registry, project_root.as_deref(), &body_text).await
+                    peers_add(registry, project_root, body_text).await
                 } else {
-                    peers_remove(registry, &body_text).await
+                    peers_remove(registry, body_text).await
                 }
             }
             Some(registry) if segments == ["eligible"] && req_method == "GET" => {
@@ -159,21 +212,21 @@ pub(crate) async fn handle_peers_sub_router(
                 peers_eligible(registry, query_str)
             }
             Some(registry) if segments == ["pairing", "join"] && req_method == "POST" => {
-                peers_pairing_join(registry, project_root.as_deref(), &body_text).await
+                peers_pairing_join(registry, project_root, body_text).await
             }
             Some(registry) if segments.len() == 2 && req_method == "POST" => {
                 let id = url_path_decode(segments[0]);
                 let op = segments[1];
                 match op {
-                    "message" => peers_send_message(registry, &id, &body_text).await,
-                    "task" => peers_delegate_task(registry, &id, &body_text).await,
-                    "approval" => peers_resolve_approval(registry, &id, &body_text).await,
-                    "webrtc" => peers_webrtc_signal(registry, &id, &body_text, &bus).await,
+                    "message" => peers_send_message(registry, &id, body_text).await,
+                    "task" => peers_delegate_task(registry, &id, body_text).await,
+                    "approval" => peers_resolve_approval(registry, &id, body_text).await,
+                    "webrtc" => peers_webrtc_signal(registry, &id, body_text, bus).await,
                     "file-transfer-webrtc" => {
-                        peers_file_transfer_signal(registry, &id, &body_text, &bus).await
+                        peers_file_transfer_signal(registry, &id, body_text, bus).await
                     }
                     "dashboard-control-webrtc" => {
-                        peers_dashboard_control_signal(registry, &id, &body_text, &bus).await
+                        peers_dashboard_control_signal(registry, &id, body_text, bus).await
                     }
                     other => (
                         404,
@@ -195,30 +248,14 @@ pub(crate) async fn handle_peers_sub_router(
             ),
         }
     };
-    let reason = match status {
-        200 => "OK",
-        400 => "Bad Request",
-        404 => "Not Found",
-        405 => "Method Not Allowed",
-        500 => "Internal Server Error",
-        502 => "Bad Gateway",
-        503 => "Service Unavailable",
-        _ => "Error",
-    };
-    let response =
-        HttpResponse::with_content(format!("{} {}", status, reason), "application/json", body)
-            .header("Cache-Control", "no-cache")
-            .header("Access-Control-Allow-Origin", "*")
-            .header("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
-            .header("Access-Control-Allow-Headers", "Content-Type")
-            .header("Connection", "close")
-            .into_string();
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    // The family reason ladder is status_reason's: every status the
+    // leaves produce (200/400/404/405/500/502/503) maps identically,
+    // pinned by peers_family_reason_ladder_is_preserved below.
+    peers_family_api_response(status, body, "GET, POST, DELETE, OPTIONS")
 }
 
 pub(crate) async fn handle_coordinator_route(
-    mut stream: DemuxStream,
+    stream: DemuxStream,
     body_text: String,
     req_method: &str,
     peer_registry: Option<crate::peer::PeerRegistry>,
@@ -230,8 +267,26 @@ pub(crate) async fn handle_coordinator_route(
     // ..., "client_correlation_id": "..."}}.
     // Response: {"peer_id": "...", "task_id": "..."}
     // on success, structured error otherwise.
-    use tokio::io::AsyncWriteExt;
-    let (status, body) = match peer_registry.as_ref() {
+    let response =
+        coordinator_route_api_response(req_method, &body_text, peer_registry.as_ref()).await;
+    write_api_response(
+        stream,
+        response,
+        crate::gateway_routes::CorsPosture::OwnOrigin,
+        None,
+    )
+    .await;
+}
+
+/// The coordinator route, transport-neutral (transport-unification
+/// S7): the same core the `api_coordinator_route` datachannel twin
+/// runs, under the family's historical envelope.
+pub(crate) async fn coordinator_route_api_response(
+    req_method: &str,
+    body_text: &str,
+    peer_registry: Option<&crate::peer::PeerRegistry>,
+) -> ApiResponse {
+    let (status, body) = match peer_registry {
         None => (
             503,
             serde_json::json!({
@@ -246,28 +301,9 @@ pub(crate) async fn handle_coordinator_route(
             })
             .to_string(),
         ),
-        Some(registry) => coordinator_route(registry, &body_text).await,
+        Some(registry) => coordinator_route(registry, body_text).await,
     };
-    let reason = match status {
-        200 => "OK",
-        400 => "Bad Request",
-        404 => "Not Found",
-        405 => "Method Not Allowed",
-        500 => "Internal Server Error",
-        502 => "Bad Gateway",
-        503 => "Service Unavailable",
-        _ => "Error",
-    };
-    let response =
-        HttpResponse::with_content(format!("{} {}", status, reason), "application/json", body)
-            .header("Cache-Control", "no-cache")
-            .header("Access-Control-Allow-Origin", "*")
-            .header("Access-Control-Allow-Methods", "POST, OPTIONS")
-            .header("Access-Control-Allow-Headers", "Content-Type")
-            .header("Connection", "close")
-            .into_string();
-    let _ = stream.write_all(response.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    peers_family_api_response(status, body, "POST, OPTIONS")
 }
 
 /// Wrapper for the `GET /api/peers` JSON body.
@@ -2710,6 +2746,28 @@ mod tests {
                 &serde_json::json!({"error": "unknown pairing request decision"}).to_string(),
             )
         );
+    }
+
+    /// The family's pre-conversion handlers carried their own reason
+    /// ladder; the neutral core renders through the shared
+    /// `status_reason`. For every status the leaves can produce
+    /// (peer_error_response's 404/405/502/500, the decode 400s, the
+    /// registry 503s, and 200) the two ladders agree — pinned here so
+    /// the 502 relay class (unreachable in a hermetic fixture) keeps
+    /// its historical `Bad Gateway` status line.
+    #[test]
+    fn peers_family_reason_ladder_is_preserved() {
+        for (status, legacy_reason) in [
+            (200, "OK"),
+            (400, "Bad Request"),
+            (404, "Not Found"),
+            (405, "Method Not Allowed"),
+            (500, "Internal Server Error"),
+            (502, "Bad Gateway"),
+            (503, "Service Unavailable"),
+        ] {
+            assert_eq!(status_reason(status), format!("{status} {legacy_reason}"));
+        }
     }
 
     #[tokio::test]

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -58,6 +58,7 @@ pub(crate) async fn handle_peers_sub_router(
     body_text: String,
     request_line: &str,
     req_method: &str,
+    cert_dir: PathBuf,
     bus: EventBus,
     project_root: Option<PathBuf>,
     peer_registry: Option<crate::peer::PeerRegistry>,
@@ -104,26 +105,27 @@ pub(crate) async fn handle_peers_sub_router(
     let (status, body) = if segments == ["pairing", "invite"] && req_method == "POST" {
         peers_pairing_invite(&body_text)
     } else if segments == ["pairing", "request-access"] && req_method == "POST" {
-        peers_pairing_request_access(&body_text).await
+        peers_pairing_request_access(&cert_dir, &body_text).await
     } else if segments == ["pairing", "request-access", "poll"] && req_method == "POST" {
         peers_pairing_request_access_poll(
             peer_registry.as_ref(),
             project_root.as_deref(),
+            &cert_dir,
             &body_text,
         )
         .await
     } else if segments == ["pairing", "requests"] && req_method == "GET" {
-        peers_pairing_requests_list()
+        peers_pairing_requests_list(&cert_dir)
     } else if segments == ["pairing", "identities"] && req_method == "GET" {
-        peers_pairing_identities_list()
+        peers_pairing_identities_list_from_cert_dir(&cert_dir)
     } else if segments == ["pairing", "identities", "revoke"] && req_method == "POST" {
-        peers_pairing_identity_revoke(&body_text)
+        peers_pairing_identity_revoke_from_cert_dir(&cert_dir, &body_text)
     } else if segments.len() == 4
         && segments[0] == "pairing"
         && segments[1] == "requests"
         && req_method == "POST"
     {
-        peers_pairing_request_decision(segments[2], segments[3], &body_text)
+        peers_pairing_request_decision(&cert_dir, segments[2], segments[3], &body_text)
     } else {
         match peer_registry.as_ref() {
             None => (
@@ -555,7 +557,13 @@ pub(crate) fn peer_access_request_status(request_id: &str) -> (u16, String) {
     }
 }
 
-pub(crate) async fn peers_pairing_request_access(body_text: &str) -> (u16, String) {
+/// `cert_dir` arrives from the transport edges (hermeticity convention)
+/// — as on the other pairing leaves below: the HTTP dispatch arm and
+/// the tunnel arms resolve the ambient store; fixtures inject tempdirs.
+pub(crate) async fn peers_pairing_request_access(
+    cert_dir: &Path,
+    body_text: &str,
+) -> (u16, String) {
     let req: PairingAccessRequestStart = match serde_json::from_str(body_text) {
         Ok(r) => r,
         Err(e) => {
@@ -571,9 +579,8 @@ pub(crate) async fn peers_pairing_request_access(body_text: &str) -> (u16, Strin
             serde_json::json!({"error": "target_url is required"}).to_string(),
         );
     }
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
     match crate::peer::access_request::initiate_access_request(
-        &cert_dir,
+        cert_dir,
         crate::peer::access_request::InitiateAccessRequestOptions {
             target_url: req.target_url,
             requester_label: req.label,
@@ -605,6 +612,7 @@ pub(crate) async fn peers_pairing_request_access(body_text: &str) -> (u16, Strin
 pub(crate) async fn peers_pairing_request_access_poll(
     registry: Option<&crate::peer::PeerRegistry>,
     project_root: Option<&Path>,
+    cert_dir: &Path,
     body_text: &str,
 ) -> (u16, String) {
     let req: PairingAccessRequestPoll = match serde_json::from_str(body_text) {
@@ -622,14 +630,13 @@ pub(crate) async fn peers_pairing_request_access_poll(
             serde_json::json!({"error": "project root not available"}).to_string(),
         );
     };
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
     let mut project = match crate::project::Project::from_root(project_root.to_path_buf()) {
         Ok(project) => project,
         Err(e) => return (500, serde_json::json!({"error": e.to_string()}).to_string()),
     };
     match crate::peer::access_request::poll_access_request(
         &mut project,
-        &cert_dir,
+        cert_dir,
         req.request_id.trim(),
         req.label.as_deref(),
     )
@@ -706,9 +713,8 @@ pub(crate) async fn peers_pairing_request_access_poll(
     }
 }
 
-pub(crate) fn peers_pairing_requests_list() -> (u16, String) {
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    match crate::peer::access_request::list_requests(&cert_dir) {
+pub(crate) fn peers_pairing_requests_list(cert_dir: &Path) -> (u16, String) {
+    match crate::peer::access_request::list_requests(cert_dir) {
         Ok(requests) => {
             let items: Vec<serde_json::Value> = requests
                 .into_iter()
@@ -724,6 +730,7 @@ pub(crate) fn peers_pairing_requests_list() -> (u16, String) {
 }
 
 pub(crate) fn peers_pairing_request_decision(
+    cert_dir: &Path,
     code_or_id: &str,
     op: &str,
     body_text: &str,
@@ -741,14 +748,13 @@ pub(crate) fn peers_pairing_request_decision(
             }
         }
     };
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
     let result = match op {
         "approve" => crate::peer::access_request::approve_request(
-            &cert_dir,
+            cert_dir,
             code_or_id,
             body.profile.as_deref(),
         ),
-        "deny" => crate::peer::access_request::deny_request(&cert_dir, code_or_id),
+        "deny" => crate::peer::access_request::deny_request(cert_dir, code_or_id),
         _ => {
             return (
                 404,
@@ -763,11 +769,6 @@ pub(crate) fn peers_pairing_request_decision(
             serde_json::json!({"error": pairing_error_message(&e)}).to_string(),
         ),
     }
-}
-
-pub(crate) fn peers_pairing_identities_list() -> (u16, String) {
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    peers_pairing_identities_list_from_cert_dir(&cert_dir)
 }
 
 pub(crate) fn peers_pairing_identities_list_from_cert_dir(cert_dir: &Path) -> (u16, String) {
@@ -785,11 +786,6 @@ pub(crate) fn peers_pairing_identities_list_from_cert_dir(cert_dir: &Path) -> (u
             serde_json::json!({"error": pairing_error_message(&e)}).to_string(),
         ),
     }
-}
-
-pub(crate) fn peers_pairing_identity_revoke(body_text: &str) -> (u16, String) {
-    let cert_dir = crate::access::backend::select_backend().cert_dir();
-    peers_pairing_identity_revoke_from_cert_dir(&cert_dir, body_text)
 }
 
 pub(crate) fn peers_pairing_identity_revoke_from_cert_dir(
@@ -2482,6 +2478,289 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert_eq!(parsed["identities"][0]["status"], "revoked");
         assert!(parsed["identities"][0]["revoked_at_unix"].is_number());
+    }
+
+    // ── S7 golden transcripts: the peers sub-router + coordinator ──
+    //
+    // Byte pins captured BEFORE the family's neutral-core conversion
+    // (design §6 S7, risk R1). The family predates the posture-derived
+    // CORS renderers: both handlers answer under a hand-rolled
+    // wildcard tail — `Cache-Control`, `Access-Control-Allow-Origin: *`,
+    // a per-handler `Access-Control-Allow-Methods` list,
+    // `Access-Control-Allow-Headers: Content-Type`, `Connection: close`
+    // — with the family's own reason ladder (notably `502 Bad Gateway`,
+    // which the relay-failure paths produce; those need a connected
+    // failing peer and stay smoke-covered by the peer validators).
+    // Store-dependent leaves run over injected tempdir cert stores and
+    // a fresh in-memory registry (hermeticity convention) — never the
+    // machine's real peer or cert state.
+
+    async fn collect_peers_handler_response<Fut>(run: impl FnOnce(DemuxStream) -> Fut) -> String
+    where
+        Fut: std::future::Future<Output = ()>,
+    {
+        use tokio::io::AsyncReadExt;
+        let (mut client, server) = tokio::io::duplex(1 << 20);
+        run(Box::pin(server)).await;
+        let mut response = Vec::new();
+        client
+            .read_to_end(&mut response)
+            .await
+            .expect("collect handler response");
+        String::from_utf8_lossy(&response).into_owned()
+    }
+
+    /// The peers sub-router's historical JSON framing, spelled out
+    /// literally.
+    fn golden_peers_transcript(status_line: &str, body: &str) -> String {
+        format!(
+            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: GET, POST, DELETE, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+    }
+
+    /// The coordinator's historical framing: same tail, POST-only
+    /// methods list.
+    fn golden_coordinator_transcript(status_line: &str, body: &str) -> String {
+        format!(
+            "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: POST, OPTIONS\r\nAccess-Control-Allow-Headers: Content-Type\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+    }
+
+    fn empty_test_registry() -> crate::peer::PeerRegistry {
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(8);
+        crate::peer::PeerRegistry::new(log_tx)
+    }
+
+    async fn peers_sub_router_transcript(
+        method: &str,
+        path: &str,
+        body: &str,
+        cert_dir: &Path,
+        registry: Option<crate::peer::PeerRegistry>,
+    ) -> String {
+        let request_line = format!("{method} {path} HTTP/1.1");
+        let cert_dir = cert_dir.to_path_buf();
+        let body = body.to_string();
+        collect_peers_handler_response(move |stream| async move {
+            handle_peers_sub_router(
+                stream,
+                body,
+                &request_line,
+                method,
+                cert_dir,
+                EventBus::new(),
+                None,
+                registry,
+            )
+            .await;
+        })
+        .await
+    }
+
+    #[tokio::test]
+    async fn golden_peers_sub_router_transcripts() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cert_dir = tmp.path();
+
+        // No registry wired in: every non-pairing leaf answers the
+        // deterministic 503.
+        let response = peers_sub_router_transcript("GET", "/api/peers", "", cert_dir, None).await;
+        assert_eq!(
+            response,
+            golden_peers_transcript(
+                "503 Service Unavailable",
+                &serde_json::json!({"error": "peer registry not configured"}).to_string(),
+            )
+        );
+
+        // Empty in-memory registry: the list leaf's 200.
+        let response = peers_sub_router_transcript(
+            "GET",
+            "/api/peers",
+            "",
+            cert_dir,
+            Some(empty_test_registry()),
+        )
+        .await;
+        assert_eq!(
+            response,
+            golden_peers_transcript("200 OK", &serde_json::json!({"peers": []}).to_string())
+        );
+
+        // Unknown per-peer op: the handler-owned JSON 404.
+        let response = peers_sub_router_transcript(
+            "POST",
+            "/api/peers/nope/badop",
+            "{}",
+            cert_dir,
+            Some(empty_test_registry()),
+        )
+        .await;
+        assert_eq!(
+            response,
+            golden_peers_transcript(
+                "404 Not Found",
+                &serde_json::json!({"error": "unknown peer op: badop"}).to_string(),
+            )
+        );
+
+        // Absent peer on a quick control (body decodes first): the
+        // peer_handle_or_404 shape.
+        let response = peers_sub_router_transcript(
+            "POST",
+            "/api/peers/nope/message",
+            &serde_json::json!({"text": "hi"}).to_string(),
+            cert_dir,
+            Some(empty_test_registry()),
+        )
+        .await;
+        assert_eq!(
+            response,
+            golden_peers_transcript(
+                "404 Not Found",
+                &serde_json::json!({"error": "peer not found: nope"}).to_string(),
+            )
+        );
+
+        // Undeclared method on the registry root: the handler-owned 405.
+        let response = peers_sub_router_transcript(
+            "PUT",
+            "/api/peers",
+            "",
+            cert_dir,
+            Some(empty_test_registry()),
+        )
+        .await;
+        assert_eq!(
+            response,
+            golden_peers_transcript(
+                "405 Method Not Allowed",
+                &serde_json::json!({"error": "method not allowed"}).to_string(),
+            )
+        );
+
+        // Eligible without a capability: the query-string 400 (also
+        // pins the path/query split on the request-line token).
+        let response = peers_sub_router_transcript(
+            "GET",
+            "/api/peers/eligible",
+            "",
+            cert_dir,
+            Some(empty_test_registry()),
+        )
+        .await;
+        assert_eq!(
+            response,
+            golden_peers_transcript(
+                "400 Bad Request",
+                &serde_json::json!({"error": "at least one ?capability=... is required"})
+                    .to_string(),
+            )
+        );
+
+        // Pairing invite, unparseable body: the decode 400 (answers
+        // before any store or listener state is touched).
+        let invalid = "{not-json";
+        let serde_error = serde_json::from_str::<PairingInviteRequest>(invalid)
+            .err()
+            .expect("invite body must not decode");
+        let response =
+            peers_sub_router_transcript("POST", "/api/peers/pairing/invite", invalid, cert_dir, None)
+                .await;
+        assert_eq!(
+            response,
+            golden_peers_transcript(
+                "400 Bad Request",
+                &serde_json::json!({"error": format!("invalid request body: {serde_error}")})
+                    .to_string(),
+            )
+        );
+
+        // Pairing reads over the injected empty store.
+        let response =
+            peers_sub_router_transcript("GET", "/api/peers/pairing/requests", "", cert_dir, None)
+                .await;
+        assert_eq!(
+            response,
+            golden_peers_transcript("200 OK", &serde_json::json!({"requests": []}).to_string())
+        );
+        let response =
+            peers_sub_router_transcript("GET", "/api/peers/pairing/identities", "", cert_dir, None)
+                .await;
+        assert_eq!(
+            response,
+            golden_peers_transcript("200 OK", &serde_json::json!({"identities": []}).to_string())
+        );
+
+        // Unknown pairing decision op: the handler's own 404.
+        let response = peers_sub_router_transcript(
+            "POST",
+            "/api/peers/pairing/requests/zzz/badop",
+            "",
+            cert_dir,
+            None,
+        )
+        .await;
+        assert_eq!(
+            response,
+            golden_peers_transcript(
+                "404 Not Found",
+                &serde_json::json!({"error": "unknown pairing request decision"}).to_string(),
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_coordinator_route_transcripts() {
+        async fn coordinator_transcript(
+            method: &str,
+            body: &str,
+            registry: Option<crate::peer::PeerRegistry>,
+        ) -> String {
+            let method = method.to_string();
+            let body = body.to_string();
+            collect_peers_handler_response(move |stream| async move {
+                handle_coordinator_route(stream, body, &method, registry).await;
+            })
+            .await
+        }
+
+        // No registry: the deterministic 503.
+        let response = coordinator_transcript("POST", "{}", None).await;
+        assert_eq!(
+            response,
+            golden_coordinator_transcript(
+                "503 Service Unavailable",
+                &serde_json::json!({"error": "peer registry not configured"}).to_string(),
+            )
+        );
+
+        // Wrong method with a registry: the handler-owned 405.
+        let response = coordinator_transcript("GET", "", Some(empty_test_registry())).await;
+        assert_eq!(
+            response,
+            golden_coordinator_transcript(
+                "405 Method Not Allowed",
+                &serde_json::json!({"error": "method not allowed"}).to_string(),
+            )
+        );
+
+        // Unparseable body: the decode 400.
+        let invalid = "{not-json";
+        let serde_error = serde_json::from_str::<CoordinatorRouteRequest>(invalid)
+            .err()
+            .expect("coordinator body must not decode");
+        let response = coordinator_transcript("POST", invalid, Some(empty_test_registry())).await;
+        assert_eq!(
+            response,
+            golden_coordinator_transcript(
+                "400 Bad Request",
+                &serde_json::json!({"error": format!("invalid request body: {serde_error}")})
+                    .to_string(),
+            )
+        );
     }
 
     /// Same `session_id` → same `PeerId` on every call. The Offer


### PR DESCRIPTION
Stage S7 (first of two PRs) of the transport-unification program (~/transport-unification-design.md §6): the peers/coordinator family.

- Commit 1: golden HTTP transcripts pin the family's hand-rolled wildcard-CORS envelope byte-exact before any conversion; hermetic seams (cert_dir threading) so fixtures never touch real peer/cert stores.
- Coming in this PR: the sub-router handler + coordinator go transport-neutral (one handler each, leaves intact) as write_api_response shims; tunnel/HTTP parity fixtures + the S7 divergence enumeration (#20+).
- PR 2 (S7b) moves the 19 twinned methods onto rows with federation-ladder-derived ops.

Note for review: `federation_http_operation("POST", "/api/coordinator/route")` classifies as `Task` (access_policy.rs:603) while the tunnel's `api_coordinator_route` has always gated on `PeerManage` (dashboard_control/mod.rs:228) — a live per-lane divergence this program surfaces; S7b preserves both mappings exactly (documented op-override) rather than silently re-gating either lane.