### PR TITLE
Transport F4b: org panes over the facade; fleet fan-out as explicit remote-http targets

### DIFF
--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -3438,7 +3438,9 @@ mod tests {
     /// (api_control.rs). Four facts per entry: the tunnel twin exists in
     /// `CONTROL_METHODS`; the verb + instantiated path resolve to a
     /// declared route whose verb is declared exactly (never via `Any`);
-    /// the row's IAM operation equals the tunnel method's; and the path
+    /// the row's IAM operation equals the tunnel method's (the signed-org
+    /// doorbell rows are Public on HTTP by design and instead pin their
+    /// documented tunnel op-override); and the path
     /// template restates the row's declared pattern (captures by name).
     /// Plus the exact coverage set, so entries appear and disappear
     /// deliberately. When the route table grows its `tunnel:` column
@@ -3494,9 +3496,11 @@ mod tests {
         // detail, report, context snapshots), the F3 settings/keys
         // family (settings GET/POST, api-keys save, key-status,
         // project-root, external-agents, displays), and the F4 access
-        // dialogs family (overview, IAM state, enrollment reads + decide,
-        // IAM grant upsert/update, the connect admin quartet, the tier
-        // pair, fleet-cert request, dashboard targets). The `api_transfer_*`
+        // family: the dialogs set (overview, IAM state, enrollment reads
+        // + decide, IAM grant upsert/update, the connect admin quartet,
+        // the tier pair, fleet-cert request, dashboard targets) plus the
+        // org set (trust/revoke, issuance, issuer keys, and the
+        // signed-org doorbell quartet). The `api_transfer_*`
         // methods join when their HTTP rows land (task #6, /api/transfers);
         // adding or dropping an entry updates this list in the same change,
         // deliberately.
@@ -3547,6 +3551,17 @@ mod tests {
             "api_access_set_hosted_ceiling",
             "api_fleet_cert_request",
             "api_dashboard_targets",
+            "api_access_org_trust",
+            "api_access_org_revoke",
+            "api_access_org_issue",
+            "api_access_org_revoke_member",
+            "api_access_org_issuer_init",
+            "api_access_org_issuer_delegate",
+            "api_access_org_issuer_install",
+            "api_access_org_present",
+            "api_access_org_renew",
+            "api_access_org_orl",
+            "api_access_org_orl_apply",
         ]
         .into_iter()
         .collect();
@@ -3600,6 +3615,34 @@ mod tests {
                     op, tunnel_op,
                     "{method_name}: tunnel op {tunnel_op:?} != route op {op:?}"
                 ),
+                // The signed-org doorbell rows are Public on HTTP by
+                // design (the signed document is the authorization)
+                // while their tunnel twins gate stricter through
+                // documented op-overrides (F4). Require the row to carry
+                // this method's tunnel column with an override matching
+                // the effective tunnel operation; the override list
+                // itself is pinned closed by the gateway's
+                // tunnel_op_overrides_are_a_closed_documented_enumeration.
+                RouteAuthz::Public => {
+                    let tunnel = route.tunnel.as_ref().unwrap_or_else(|| {
+                        panic!("{method_name}: Public descriptor row lost its tunnel column")
+                    });
+                    assert_eq!(
+                        tunnel.name,
+                        method_name.as_str(),
+                        "{method_name}: resolved Public row carries a different tunnel method"
+                    );
+                    let (override_op, _reason) = tunnel.op_override.unwrap_or_else(|| {
+                        panic!(
+                            "{method_name}: Public twinned rows must carry a \
+                             documented tunnel op-override"
+                        )
+                    });
+                    assert_eq!(
+                        override_op, tunnel_op,
+                        "{method_name}: tunnel op {tunnel_op:?} != declared override {override_op:?}"
+                    );
+                }
                 _ => panic!("{method_name}: twinned rows must be Operation-gated"),
             }
 

--- a/static/app.html
+++ b/static/app.html
@@ -26101,7 +26101,8 @@ async function accessFleetRefreshProvenance() {
 //   daemonApi.upload(method, params, source, opts)   -> {ok, status, body}   (source: Blob | Uint8Array)
 //   daemonApi.stream(method, params, opts, onEvent)  -> completion summary
 //   daemonApi.availability(method, target)           -> {ok, reason}
-//   // opts: { target?: hostId|null, signal?, timeoutMs?, retries?, fallback?: 'auto'|'never' }
+//   // opts: { target?: hostId|{remoteHttp: origin}|null, signal?,
+//   //         timeoutMs?, retries?, fallback?: 'auto'|'never' }
 //
 // `method` is always the tunnel method name; DAEMON_API_HTTP_MAP maps it to
 // the HTTP twin when the direct lane serves the call. Adapters:
@@ -26112,7 +26113,11 @@ async function accessFleetRefreshProvenance() {
 //     authenticates to a peer over HTTP);
 //   - HTTP: `authedFetch` + the descriptor table. Connect mode is policy,
 //     not an adapter: it forces `fallback:'never'` (hosted validators probe
-//     exactly this no-legacy-fallback behavior).
+//     exactly this no-legacy-fallback behavior);
+//   - remote-http (F4): `{remoteHttp: origin}` targets name a FLEET
+//     daemon's own HTTP origin — direct cross-origin fetch under the
+//     fleet-CORS rows, never a tunnel, never a fallback (design §5's F4
+//     caveat: fleet fan-out is explicit, not ambiguous).
 //
 // STATUS: consumed by the F1 family (files IDE fs calls, transfers pump,
 // staged uploads), the F2 sessions-family reads, the F3 settings/keys
@@ -26150,10 +26155,13 @@ async function accessFleetRefreshProvenance() {
 // sessions-family reads (managed-context, worktrees, the session list and
 // its NDJSON stream, search, detail, report, context snapshots), the
 // F3 settings/keys family (settings GET/POST, api-keys save, key-status,
-// project-root, external-agents, displays), and the F4 access dialogs
-// family (overview, IAM state, enrollment reads + decide, IAM grant
-// upsert/update, the connect admin quartet, the tier pair, fleet-cert
-// request, dashboard targets). The
+// project-root, external-agents, displays), and the F4 access family:
+// the dialogs set (overview, IAM state, enrollment reads + decide, IAM
+// grant upsert/update, the connect admin quartet, the tier pair,
+// fleet-cert request, dashboard targets) plus the org set (trust/revoke,
+// issuance, issuer key management, and the signed-org doorbell quartet —
+// present, renew, ORL read, ORL apply, whose HTTP rows are Public by
+// design: the signed document is the authorization). The
 // `api_transfer_*` methods are deliberately absent: they have no HTTP rows
 // until the server-track stage that adds /api/transfers (task #6); F1 adds
 // their entries when those rows land.
@@ -26218,6 +26226,17 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_access_set_hosted_ceiling: { verb: 'POST', path: '/api/access/hosted-ceiling' },
   api_fleet_cert_request: { verb: 'POST', path: '/api/access/fleet-cert/request' },
   api_dashboard_targets: { verb: 'GET', path: '/api/dashboard/targets' },
+  api_access_org_trust: { verb: 'POST', path: '/api/access/orgs/trust' },
+  api_access_org_revoke: { verb: 'POST', path: '/api/access/orgs/revoke' },
+  api_access_org_issue: { verb: 'POST', path: '/api/access/org-grants/issue' },
+  api_access_org_revoke_member: { verb: 'POST', path: '/api/access/org-grants/revoke-member' },
+  api_access_org_issuer_init: { verb: 'POST', path: '/api/access/org-grants/issuers/init' },
+  api_access_org_issuer_delegate: { verb: 'POST', path: '/api/access/org-grants/issuers/delegate' },
+  api_access_org_issuer_install: { verb: 'POST', path: '/api/access/org-grants/issuers/install' },
+  api_access_org_present: { verb: 'POST', path: '/api/access/org-grants' },
+  api_access_org_renew: { verb: 'POST', path: '/api/access/org-grants/renew' },
+  api_access_org_orl: { verb: 'GET', path: '/api/access/orgs/{org_handle}/revocations', alias: { org_handle: 'handle' } },
+  api_access_org_orl_apply: { verb: 'POST', path: '/api/access/orgs/revocations/apply' },
 });
 
 // ── Uniform error shape (§3.5) ────────────────────────────────────────────
@@ -26616,6 +26635,78 @@ async function daemonApiHttpStream(method, params, opts, onEvent) {
   return null;
 }
 
+// ── Remote-http adapter (transport F4) ────────────────────────────────────
+// Cross-daemon fleet calls: the anchor page applies access changes to
+// OTHER daemons by direct cross-origin HTTP — the fleet-CORS rows, with
+// the browser's own identity to that origin (mTLS certificate) as the
+// authentication. This daemon's `authedFetch` bearer stays out of the
+// lane on purpose: nothing minted here carries authority there
+// (trust-architecture: authority is only ever minted by the target
+// daemon's local IAM). Naming the target names the transport — no tunnel
+// is ever attempted, no fallback is ever taken, and a delivered error is
+// final (design §5's F4 caveat: explicit remote-http, never fallback
+// ambiguity). JSON lane only: every fleet-CORS twin is a JSON verb, so
+// the bytes/upload/stream verbs refuse remote-http targets loudly.
+
+// The normalized origin for a `{remoteHttp: origin}` target: '' when the
+// target is not remote-http-shaped (null and string peer ids pass
+// through to the tunnel adapters); a throw when the shape is right but
+// the origin is not a usable absolute http(s) origin — a mis-built
+// target must fail loudly, never drift into another lane.
+function daemonApiRemoteHttpOrigin(target) {
+  if (!target || typeof target !== 'object') return '';
+  const raw = String(target.remoteHttp || '').trim();
+  let origin = '';
+  if (raw) {
+    try {
+      const url = new URL(raw);
+      if (url.protocol === 'https:' || url.protocol === 'http:') origin = url.origin;
+    } catch { /* rejected below */ }
+  }
+  if (!origin) {
+    throw new TypeError(
+      `daemonApi: object targets must carry an absolute http(s) remoteHttp origin (got ${raw || 'nothing'})`
+    );
+  }
+  return origin;
+}
+
+// Fleet links cross networks the local per-method defaults (5 s for the
+// access family) were never sized for — floor the composed timeout at
+// the peer-dial default unless the caller sets one. Still never
+// signal-less (§3.6).
+function daemonApiRemoteHttpSignal(method, opts) {
+  const timeout = Number(opts && opts.timeoutMs);
+  const ms = Number.isFinite(timeout) && timeout > 0
+    ? timeout
+    : Math.max(daemonApiTimeoutMs(method, opts), 30000);
+  return dashboardComposeFetchSignal(opts && opts.signal, ms);
+}
+
+async function daemonApiRemoteHttpRequest(origin, method, params, opts) {
+  const spec = DAEMON_API_HTTP_MAP[method];
+  if (!spec) {
+    throw new DaemonApiError(
+      'unavailable', method, origin,
+      `${method} has no HTTP twin (remote-http targets are direct-HTTP only)`
+    );
+  }
+  const { url, rest } = daemonApiHttpTarget(spec, method, params);
+  const init = { method: spec.verb, mode: 'cors', signal: daemonApiRemoteHttpSignal(method, opts) };
+  if (spec.verb === 'POST' && Object.keys(rest).length > 0) {
+    init.headers = { 'Content-Type': 'application/json' };
+    init.body = JSON.stringify(rest);
+  }
+  let resp;
+  try {
+    resp = await fetch(`${origin}${url}`, init);
+  } catch (err) {
+    throw daemonApiHttpError(err, method, origin);
+  }
+  const body = await resp.json().catch(() => ({}));
+  return { ok: resp.ok, status: resp.status, body: body ?? {} };
+}
+
 // ── Tunnel adapters ───────────────────────────────────────────────────────
 // Local and peer speak the same DashboardControlTransport protocol; the
 // peer adapter resolves (or dials) the per-host connection first. A peer
@@ -26661,6 +26752,8 @@ async function daemonApiTunnelBytes(transport, method, params, opts, target) {
 
 // ── The four verbs ────────────────────────────────────────────────────────
 async function daemonApiRequest(method, params = {}, opts = {}) {
+  const remoteOrigin = daemonApiRemoteHttpOrigin(opts.target);
+  if (remoteOrigin) return daemonApiRemoteHttpRequest(remoteOrigin, method, params, opts);
   const target = opts.target || null;
   if (target) {
     const conn = await daemonApiPeerTransport(target, method);
@@ -26687,6 +26780,13 @@ async function daemonApiRequest(method, params = {}, opts = {}) {
 }
 
 async function daemonApiBytes(method, params = {}, opts = {}) {
+  const remoteOrigin = daemonApiRemoteHttpOrigin(opts.target);
+  if (remoteOrigin) {
+    throw new DaemonApiError(
+      'unavailable', method, remoteOrigin,
+      `${method}: remote-http targets serve JSON request() calls only (no fleet-CORS byte twins exist)`
+    );
+  }
   const target = opts.target || null;
   if (target) {
     const conn = await daemonApiPeerTransport(target, method);
@@ -26710,6 +26810,13 @@ async function daemonApiBytes(method, params = {}, opts = {}) {
 }
 
 async function daemonApiUpload(method, params = {}, source, opts = {}) {
+  const remoteOrigin = daemonApiRemoteHttpOrigin(opts.target);
+  if (remoteOrigin) {
+    throw new DaemonApiError(
+      'unavailable', method, remoteOrigin,
+      `${method}: remote-http targets serve JSON request() calls only (no fleet-CORS upload twins exist)`
+    );
+  }
   const target = opts.target || null;
   if (target) {
     const conn = await daemonApiPeerTransport(target, method);
@@ -26738,6 +26845,13 @@ async function daemonApiUpload(method, params = {}, source, opts = {}) {
 }
 
 async function daemonApiStream(method, params = {}, opts = {}, onEvent = {}) {
+  const remoteOrigin = daemonApiRemoteHttpOrigin(opts.target);
+  if (remoteOrigin) {
+    throw new DaemonApiError(
+      'unavailable', method, remoteOrigin,
+      `${method}: remote-http targets serve JSON request() calls only (no fleet-CORS stream twins exist)`
+    );
+  }
   const target = opts.target || null;
   if (target) {
     const conn = await daemonApiPeerTransport(target, method);
@@ -26806,6 +26920,15 @@ function daemonApiTunnelMethodAvailability(transport, method) {
 }
 
 function daemonApiAvailability(method, target = null) {
+  const remoteOrigin = daemonApiRemoteHttpOrigin(target);
+  if (remoteOrigin) {
+    // A REMOTE origin's reachability is unknowable without a request;
+    // the honest answer is lane presence — the descriptor names the
+    // methods fleet daemons serve over direct HTTP.
+    return DAEMON_API_HTTP_MAP[method]
+      ? { ok: true, reason: 'http-only' }
+      : { ok: false, reason: 'never' };
+  }
   if (target) {
     const conn = peerDashboardControlConnectionsByHost.get(String(target));
     if (conn && conn.canUseRpc()) return daemonApiTunnelMethodAvailability(conn, method);
@@ -29749,7 +29872,7 @@ async function orgRevocationCourier() {
       if (!resp.ok) continue;
       const body = await resp.json().catch(() => ({}));
       if (!body?.orl) continue;
-      const applied = await accessOrgCall('api_access_org_orl_apply', '/api/access/orgs/revocations/apply', body.orl);
+      const applied = await accessOrgCall('api_access_org_orl_apply', body.orl);
       if (applied?.applied?.changed) {
         console.info(`[org] carried @${handle} revocations seq ${applied.applied.seq} to this daemon (${applied.applied.revoked_grants} grants, ${applied.applied.revoked_peer_identities} peer identities revoked)`);
       }
@@ -53569,15 +53692,15 @@ async function accessApplyGrantToTarget(target, payload) {
     if (!resp.ok) throw new Error(resp.body?.error || `request failed (${resp.status})`);
     return resp.body;
   }
-  const resp = await fetch(`${target.origin}/api/access/iam/user-client-grants`, {
-    method: 'POST',
-    mode: 'cors',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
+  // Remote fleet daemon: the explicit remote-http target (transport F4).
+  // Naming the target names the transport — direct cross-origin HTTP to
+  // that daemon's fleet-CORS row, never a tunnel, never a fallback; the
+  // target daemon's own IAM authorizes the write (browser mTLS identity).
+  const resp = await daemonApi.request('api_access_iam_upsert_user_client_grant', payload, {
+    target: { remoteHttp: target.origin },
   });
-  const data = await resp.json().catch(() => ({}));
-  if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
-  return data;
+  if (!resp.ok) throw new Error(resp.body?.error || `request failed (${resp.status})`);
+  return resp.body;
 }
 
 function renderAccessUserClientGrantForm() {
@@ -55064,8 +55187,11 @@ function renderAccessTierCard() {
   if (!mount) return;
   const iam = accessIamModel(accessOverviewModel());
   const tier = accessModelLabel(iam.tier);
-  const canSetTier = dashboardControlTransport?.lastStatus?.api_access_set_tier_available !== false;
-  const canSetCeiling = dashboardControlTransport?.lastStatus?.api_access_set_hosted_ceiling_available !== false;
+  // daemonApi availability (transport F4): tunnel status boolean when
+  // connected, HTTP-twin reachability otherwise — honest in Connect
+  // mode, where a down tunnel means no lane at all.
+  const canSetTier = daemonApi.availability('api_access_set_tier').ok;
+  const canSetCeiling = daemonApi.availability('api_access_set_hosted_ceiling').ok;
 
   mount.textContent = '';
   const head = document.createElement('div');
@@ -55224,9 +55350,10 @@ function renderAccessConnectCard() {
       || !status.claim_code_available;
     if (stale) accessConnectRevealed = null;
   }
-  const canConfig = dashboardControlTransport?.lastStatus?.api_access_connect_config_available !== false;
-  const canReveal = dashboardControlTransport?.lastStatus?.api_access_connect_claim_code_available !== false;
-  const canUnclaim = dashboardControlTransport?.lastStatus?.api_access_connect_unclaim_available !== false;
+  // daemonApi availability (transport F4) — see renderAccessTierCard.
+  const canConfig = daemonApi.availability('api_access_connect_config').ok;
+  const canReveal = daemonApi.availability('api_access_connect_claim_code').ok;
+  const canUnclaim = daemonApi.availability('api_access_connect_unclaim').ok;
 
   const head = document.createElement('div');
   head.className = 'acc-section-head';
@@ -55352,7 +55479,7 @@ function renderAccessConnectCard() {
       chip.title = fleetCert.last_error || 'The last certificate request failed.';
     }
     if (chip.textContent) row.appendChild(chip);
-    const canRequest = dashboardControlTransport?.lastStatus?.api_fleet_cert_request_available !== false;
+    const canRequest = daemonApi.availability('api_fleet_cert_request').ok;
     if (fleetCert.state !== 'requesting' && fleetCert.state !== 'valid') {
       const request = document.createElement('button');
       request.type = 'button';
@@ -55492,7 +55619,7 @@ function renderAccessEnrollmentRequests() {
   if (!mount) return;
   mount.innerHTML = '';
   if (!accessPendingEnrollments.length) return;
-  const canManage = dashboardControlTransport?.lastStatus?.api_access_enrollment_decide_available !== false;
+  const canManage = daemonApi.availability('api_access_enrollment_decide').ok;
 
   const head = document.createElement('div');
   head.className = 'acc-section-head';
@@ -55602,7 +55729,7 @@ function renderAccessPeopleGrants() {
     mount.appendChild(empty);
     return;
   }
-  const canManage = dashboardControlTransport?.lastStatus?.api_access_iam_update_grant_available !== false;
+  const canManage = daemonApi.availability('api_access_iam_update_grant').ok;
   for (const principal of principals) {
     const card = document.createElement('div');
     card.className = 'acc-principal-card';
@@ -55777,15 +55904,17 @@ function renderAccessRoleCatalog() {
 }
 
 /* Advanced: trusted organizations + issuance. */
-async function accessOrgCall(method, path, payload) {
-  const resp = await dashboardJsonFetch(method, payload, () => authedFetch(path, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  }), method, { fallbackAfterRpcFailure: false });
-  const data = await resp.json().catch(() => ({}));
-  if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
-  return data;
+// daemonApi (transport F4): every org call is a POST twin — the fallback
+// policy derives no-replay from the verb, exactly the legacy
+// fallbackAfterRpcFailure:false semantics (a delivered tunnel attempt is
+// never replayed over HTTP; with no tunnel the write goes direct; Connect
+// mode never uses HTTP). The descriptor owns each method's path — the old
+// per-call-site path argument died with the tri-form. IAM-mutating
+// writes: payload shapes unchanged, zero retries.
+async function accessOrgCall(method, payload) {
+  const resp = await daemonApi.request(method, payload ?? {});
+  if (!resp.ok) throw new Error(resp.body?.error || `request failed (${resp.status})`);
+  return resp.body;
 }
 
 function renderAccessOrganizations() {
@@ -55795,7 +55924,7 @@ function renderAccessOrganizations() {
   const iam = accessIamModel(accessOverviewModel());
   const trusted = Array.isArray(iam.trusted_orgs) ? iam.trusted_orgs : [];
   const issuers = Array.isArray(iam.org_issuers) ? iam.org_issuers : [];
-  const canManage = dashboardControlTransport?.lastStatus?.api_access_org_trust_available !== false;
+  const canManage = daemonApi.availability('api_access_org_trust').ok;
 
   const list = document.createElement('div');
   list.className = 'acc-principal-list';
@@ -55838,7 +55967,7 @@ function renderAccessOrganizations() {
         });
         if (!ok) return;
         try {
-          await accessOrgCall('api_access_org_revoke', '/api/access/orgs/revoke', { handle: org.handle });
+          await accessOrgCall('api_access_org_revoke', { handle: org.handle });
           showControlToast?.('success', `Org @${org.handle} revoked`);
         } catch (err) {
           showControlToast?.('error', err?.message || 'Org revoke failed');
@@ -55944,7 +56073,7 @@ function renderAccessOrganizations() {
       return;
     }
     try {
-      await accessOrgCall('api_access_org_trust', '/api/access/orgs/trust', {
+      await accessOrgCall('api_access_org_trust', {
         handle,
         root_key: rootKey,
         max_role: document.getElementById('access-org-trust-cap')?.value || 'role:operator',
@@ -56089,7 +56218,7 @@ function renderAccessOrganizations() {
       try {
         const issueKind = document.getElementById('access-org-issue-kind')?.value || 'client_key';
         const issueFp = document.getElementById('access-org-issue-fingerprint')?.value?.trim();
-        const data = await accessOrgCall('api_access_org_issue', '/api/access/org-grants/issue', {
+        const data = await accessOrgCall('api_access_org_issue', {
           handle: document.getElementById('access-org-issue-handle')?.value,
           client_key_fingerprint: issueKind === 'peer' ? '' : issueFp,
           peer_fingerprint: issueKind === 'peer' ? issueFp : '',
@@ -56188,7 +56317,7 @@ function renderAccessOrganizations() {
         return;
       }
       try {
-        const data = await accessOrgCall('api_access_org_revoke_member', '/api/access/org-grants/revoke-member', {
+        const data = await accessOrgCall('api_access_org_revoke_member', {
           handle: document.getElementById('access-org-orl-handle')?.value,
           ...(grantId ? { grant_id: grantId } : {}),
           ...(subject ? { subject } : {}),
@@ -56264,7 +56393,7 @@ function renderAccessOrganizations() {
         return;
       }
       try {
-        const data = await accessOrgCall('api_access_org_renew', '/api/access/org-grants/renew', doc);
+        const data = await accessOrgCall('api_access_org_renew', doc);
         renewOutput.value = JSON.stringify(data.document, null, 2);
         showControlToast?.('success', 'Document renewed — send it back to the member');
       } catch (err) {
@@ -56335,7 +56464,7 @@ function renderAccessOrganizations() {
     delegateBtn.disabled = !canManage;
     delegateBtn.addEventListener('click', async () => {
       try {
-        const data = await accessOrgCall('api_access_org_issuer_delegate', '/api/access/org-grants/issuers/delegate', {
+        const data = await accessOrgCall('api_access_org_issuer_delegate', {
           handle: document.getElementById('access-org-orl-handle')?.value || document.getElementById('access-org-issue-handle')?.value,
           issuer_key: document.getElementById('access-org-delegate-key')?.value?.trim(),
           label: document.getElementById('access-org-delegate-label')?.value?.trim(),
@@ -56410,7 +56539,7 @@ function renderAccessOrganizations() {
     initBtn.textContent = 'Create / show issuer key';
     initBtn.addEventListener('click', async () => {
       try {
-        const data = await accessOrgCall('api_access_org_issuer_init', '/api/access/org-grants/issuers/init', {
+        const data = await accessOrgCall('api_access_org_issuer_init', {
           handle: handleInput.value?.trim(),
         });
         keyOut.value = data.issuer_key || '';
@@ -56430,7 +56559,7 @@ function renderAccessOrganizations() {
         return;
       }
       try {
-        await accessOrgCall('api_access_org_issuer_install', '/api/access/org-grants/issuers/install', {
+        await accessOrgCall('api_access_org_issuer_install', {
           handle: handleInput.value?.trim(),
           certificate: cert,
         });
@@ -56483,7 +56612,7 @@ function renderAccessOrganizations() {
         return;
       }
       try {
-        const data = await accessOrgCall('api_access_org_orl_apply', '/api/access/orgs/revocations/apply', orl);
+        const data = await accessOrgCall('api_access_org_orl_apply', orl);
         const applied = data.applied || {};
         showControlToast?.(
           'success',
@@ -56504,18 +56633,15 @@ function renderAccessOrganizations() {
 }
 
 /* Fetch an org's current signed revocation list from the daemon holding
-   its root key (RPC in tunnel mode, plain GET otherwise). */
+   its root key. daemonApi (transport F4): GET twin — tunnel first, then
+   the direct-HTTP retry the verb-derived policy allows (the legacy site
+   opted out, but a public idempotent read replays safely; the policy is
+   data, not per-site judgment). The descriptor lifts `handle` into the
+   row's {org_handle} capture. */
 async function accessOrgFetchOrl(handle) {
-  const resp = await dashboardJsonFetch(
-    'api_access_org_orl',
-    { handle },
-    () => authedFetch(`/api/access/orgs/${encodeURIComponent(handle || '')}/revocations`),
-    'api_access_org_orl',
-    { fallbackAfterRpcFailure: false }
-  );
-  const data = await resp.json().catch(() => ({}));
-  if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
-  return data;
+  const resp = await daemonApi.request('api_access_org_orl', { handle });
+  if (!resp.ok) throw new Error(resp.body?.error || `request failed (${resp.status})`);
+  return resp.body;
 }
 
 /* Advanced: local IAM state card with raw links. */
@@ -89681,8 +89807,8 @@ document.getElementById('sb-dashboard-transport')?.addEventListener('click', () 
 document.getElementById('access-link-daemon-btn')?.addEventListener('click', () => routeTo('access', 'peers'));
 
 // Join-with-an-org-grant: present the pasted document to this daemon. The
-// endpoint is public by design (the document is the authorization); using
-// authedFetch keeps it working identically on the trusted paths.
+// HTTP row is public by design (the document is the authorization); the
+// facade rides the tunnel when one is bound and the public row otherwise.
 document.getElementById('access-org-join-btn')?.addEventListener('click', async () => {
   const status = document.getElementById('access-org-join-status');
   const raw = document.getElementById('access-org-join-doc')?.value?.trim();
@@ -89700,7 +89826,7 @@ document.getElementById('access-org-join-btn')?.addEventListener('click', async 
   const stored = orgGrantStore(doc);
   if (status) status.textContent = 'Presenting…';
   try {
-    const data = await accessOrgCall('api_access_org_present', '/api/access/org-grants', doc);
+    const data = await accessOrgCall('api_access_org_present', doc);
     const summary = data.peer_identity
       ? `peer profile ${data.peer_identity.profile} for ${data.peer_identity.label} until ${new Date(Number(data.peer_identity.expires_at_unix || 0) * 1000).toLocaleString()}`
       : `${String(data.grant?.role_id || '').replace(/^role:/, '')} until ${new Date(Number(data.grant?.expires_at_unix_ms || 0)).toLocaleString()}`;

--- a/static/app/32-daemon-api.js
+++ b/static/app/32-daemon-api.js
@@ -7,7 +7,8 @@
 //   daemonApi.upload(method, params, source, opts)   -> {ok, status, body}   (source: Blob | Uint8Array)
 //   daemonApi.stream(method, params, opts, onEvent)  -> completion summary
 //   daemonApi.availability(method, target)           -> {ok, reason}
-//   // opts: { target?: hostId|null, signal?, timeoutMs?, retries?, fallback?: 'auto'|'never' }
+//   // opts: { target?: hostId|{remoteHttp: origin}|null, signal?,
+//   //         timeoutMs?, retries?, fallback?: 'auto'|'never' }
 //
 // `method` is always the tunnel method name; DAEMON_API_HTTP_MAP maps it to
 // the HTTP twin when the direct lane serves the call. Adapters:
@@ -18,7 +19,11 @@
 //     authenticates to a peer over HTTP);
 //   - HTTP: `authedFetch` + the descriptor table. Connect mode is policy,
 //     not an adapter: it forces `fallback:'never'` (hosted validators probe
-//     exactly this no-legacy-fallback behavior).
+//     exactly this no-legacy-fallback behavior);
+//   - remote-http (F4): `{remoteHttp: origin}` targets name a FLEET
+//     daemon's own HTTP origin — direct cross-origin fetch under the
+//     fleet-CORS rows, never a tunnel, never a fallback (design §5's F4
+//     caveat: fleet fan-out is explicit, not ambiguous).
 //
 // STATUS: consumed by the F1 family (files IDE fs calls, transfers pump,
 // staged uploads), the F2 sessions-family reads, the F3 settings/keys
@@ -56,10 +61,13 @@
 // sessions-family reads (managed-context, worktrees, the session list and
 // its NDJSON stream, search, detail, report, context snapshots), the
 // F3 settings/keys family (settings GET/POST, api-keys save, key-status,
-// project-root, external-agents, displays), and the F4 access dialogs
-// family (overview, IAM state, enrollment reads + decide, IAM grant
-// upsert/update, the connect admin quartet, the tier pair, fleet-cert
-// request, dashboard targets). The
+// project-root, external-agents, displays), and the F4 access family:
+// the dialogs set (overview, IAM state, enrollment reads + decide, IAM
+// grant upsert/update, the connect admin quartet, the tier pair,
+// fleet-cert request, dashboard targets) plus the org set (trust/revoke,
+// issuance, issuer key management, and the signed-org doorbell quartet —
+// present, renew, ORL read, ORL apply, whose HTTP rows are Public by
+// design: the signed document is the authorization). The
 // `api_transfer_*` methods are deliberately absent: they have no HTTP rows
 // until the server-track stage that adds /api/transfers (task #6); F1 adds
 // their entries when those rows land.
@@ -124,6 +132,17 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_access_set_hosted_ceiling: { verb: 'POST', path: '/api/access/hosted-ceiling' },
   api_fleet_cert_request: { verb: 'POST', path: '/api/access/fleet-cert/request' },
   api_dashboard_targets: { verb: 'GET', path: '/api/dashboard/targets' },
+  api_access_org_trust: { verb: 'POST', path: '/api/access/orgs/trust' },
+  api_access_org_revoke: { verb: 'POST', path: '/api/access/orgs/revoke' },
+  api_access_org_issue: { verb: 'POST', path: '/api/access/org-grants/issue' },
+  api_access_org_revoke_member: { verb: 'POST', path: '/api/access/org-grants/revoke-member' },
+  api_access_org_issuer_init: { verb: 'POST', path: '/api/access/org-grants/issuers/init' },
+  api_access_org_issuer_delegate: { verb: 'POST', path: '/api/access/org-grants/issuers/delegate' },
+  api_access_org_issuer_install: { verb: 'POST', path: '/api/access/org-grants/issuers/install' },
+  api_access_org_present: { verb: 'POST', path: '/api/access/org-grants' },
+  api_access_org_renew: { verb: 'POST', path: '/api/access/org-grants/renew' },
+  api_access_org_orl: { verb: 'GET', path: '/api/access/orgs/{org_handle}/revocations', alias: { org_handle: 'handle' } },
+  api_access_org_orl_apply: { verb: 'POST', path: '/api/access/orgs/revocations/apply' },
 });
 
 // ── Uniform error shape (§3.5) ────────────────────────────────────────────
@@ -522,6 +541,78 @@ async function daemonApiHttpStream(method, params, opts, onEvent) {
   return null;
 }
 
+// ── Remote-http adapter (transport F4) ────────────────────────────────────
+// Cross-daemon fleet calls: the anchor page applies access changes to
+// OTHER daemons by direct cross-origin HTTP — the fleet-CORS rows, with
+// the browser's own identity to that origin (mTLS certificate) as the
+// authentication. This daemon's `authedFetch` bearer stays out of the
+// lane on purpose: nothing minted here carries authority there
+// (trust-architecture: authority is only ever minted by the target
+// daemon's local IAM). Naming the target names the transport — no tunnel
+// is ever attempted, no fallback is ever taken, and a delivered error is
+// final (design §5's F4 caveat: explicit remote-http, never fallback
+// ambiguity). JSON lane only: every fleet-CORS twin is a JSON verb, so
+// the bytes/upload/stream verbs refuse remote-http targets loudly.
+
+// The normalized origin for a `{remoteHttp: origin}` target: '' when the
+// target is not remote-http-shaped (null and string peer ids pass
+// through to the tunnel adapters); a throw when the shape is right but
+// the origin is not a usable absolute http(s) origin — a mis-built
+// target must fail loudly, never drift into another lane.
+function daemonApiRemoteHttpOrigin(target) {
+  if (!target || typeof target !== 'object') return '';
+  const raw = String(target.remoteHttp || '').trim();
+  let origin = '';
+  if (raw) {
+    try {
+      const url = new URL(raw);
+      if (url.protocol === 'https:' || url.protocol === 'http:') origin = url.origin;
+    } catch { /* rejected below */ }
+  }
+  if (!origin) {
+    throw new TypeError(
+      `daemonApi: object targets must carry an absolute http(s) remoteHttp origin (got ${raw || 'nothing'})`
+    );
+  }
+  return origin;
+}
+
+// Fleet links cross networks the local per-method defaults (5 s for the
+// access family) were never sized for — floor the composed timeout at
+// the peer-dial default unless the caller sets one. Still never
+// signal-less (§3.6).
+function daemonApiRemoteHttpSignal(method, opts) {
+  const timeout = Number(opts && opts.timeoutMs);
+  const ms = Number.isFinite(timeout) && timeout > 0
+    ? timeout
+    : Math.max(daemonApiTimeoutMs(method, opts), 30000);
+  return dashboardComposeFetchSignal(opts && opts.signal, ms);
+}
+
+async function daemonApiRemoteHttpRequest(origin, method, params, opts) {
+  const spec = DAEMON_API_HTTP_MAP[method];
+  if (!spec) {
+    throw new DaemonApiError(
+      'unavailable', method, origin,
+      `${method} has no HTTP twin (remote-http targets are direct-HTTP only)`
+    );
+  }
+  const { url, rest } = daemonApiHttpTarget(spec, method, params);
+  const init = { method: spec.verb, mode: 'cors', signal: daemonApiRemoteHttpSignal(method, opts) };
+  if (spec.verb === 'POST' && Object.keys(rest).length > 0) {
+    init.headers = { 'Content-Type': 'application/json' };
+    init.body = JSON.stringify(rest);
+  }
+  let resp;
+  try {
+    resp = await fetch(`${origin}${url}`, init);
+  } catch (err) {
+    throw daemonApiHttpError(err, method, origin);
+  }
+  const body = await resp.json().catch(() => ({}));
+  return { ok: resp.ok, status: resp.status, body: body ?? {} };
+}
+
 // ── Tunnel adapters ───────────────────────────────────────────────────────
 // Local and peer speak the same DashboardControlTransport protocol; the
 // peer adapter resolves (or dials) the per-host connection first. A peer
@@ -567,6 +658,8 @@ async function daemonApiTunnelBytes(transport, method, params, opts, target) {
 
 // ── The four verbs ────────────────────────────────────────────────────────
 async function daemonApiRequest(method, params = {}, opts = {}) {
+  const remoteOrigin = daemonApiRemoteHttpOrigin(opts.target);
+  if (remoteOrigin) return daemonApiRemoteHttpRequest(remoteOrigin, method, params, opts);
   const target = opts.target || null;
   if (target) {
     const conn = await daemonApiPeerTransport(target, method);
@@ -593,6 +686,13 @@ async function daemonApiRequest(method, params = {}, opts = {}) {
 }
 
 async function daemonApiBytes(method, params = {}, opts = {}) {
+  const remoteOrigin = daemonApiRemoteHttpOrigin(opts.target);
+  if (remoteOrigin) {
+    throw new DaemonApiError(
+      'unavailable', method, remoteOrigin,
+      `${method}: remote-http targets serve JSON request() calls only (no fleet-CORS byte twins exist)`
+    );
+  }
   const target = opts.target || null;
   if (target) {
     const conn = await daemonApiPeerTransport(target, method);
@@ -616,6 +716,13 @@ async function daemonApiBytes(method, params = {}, opts = {}) {
 }
 
 async function daemonApiUpload(method, params = {}, source, opts = {}) {
+  const remoteOrigin = daemonApiRemoteHttpOrigin(opts.target);
+  if (remoteOrigin) {
+    throw new DaemonApiError(
+      'unavailable', method, remoteOrigin,
+      `${method}: remote-http targets serve JSON request() calls only (no fleet-CORS upload twins exist)`
+    );
+  }
   const target = opts.target || null;
   if (target) {
     const conn = await daemonApiPeerTransport(target, method);
@@ -644,6 +751,13 @@ async function daemonApiUpload(method, params = {}, source, opts = {}) {
 }
 
 async function daemonApiStream(method, params = {}, opts = {}, onEvent = {}) {
+  const remoteOrigin = daemonApiRemoteHttpOrigin(opts.target);
+  if (remoteOrigin) {
+    throw new DaemonApiError(
+      'unavailable', method, remoteOrigin,
+      `${method}: remote-http targets serve JSON request() calls only (no fleet-CORS stream twins exist)`
+    );
+  }
   const target = opts.target || null;
   if (target) {
     const conn = await daemonApiPeerTransport(target, method);
@@ -712,6 +826,15 @@ function daemonApiTunnelMethodAvailability(transport, method) {
 }
 
 function daemonApiAvailability(method, target = null) {
+  const remoteOrigin = daemonApiRemoteHttpOrigin(target);
+  if (remoteOrigin) {
+    // A REMOTE origin's reachability is unknowable without a request;
+    // the honest answer is lane presence — the descriptor names the
+    // methods fleet daemons serve over direct HTTP.
+    return DAEMON_API_HTTP_MAP[method]
+      ? { ok: true, reason: 'http-only' }
+      : { ok: false, reason: 'never' };
+  }
   if (target) {
     const conn = peerDashboardControlConnectionsByHost.get(String(target));
     if (conn && conn.canUseRpc()) return daemonApiTunnelMethodAvailability(conn, method);

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -2848,7 +2848,7 @@ async function orgRevocationCourier() {
       if (!resp.ok) continue;
       const body = await resp.json().catch(() => ({}));
       if (!body?.orl) continue;
-      const applied = await accessOrgCall('api_access_org_orl_apply', '/api/access/orgs/revocations/apply', body.orl);
+      const applied = await accessOrgCall('api_access_org_orl_apply', body.orl);
       if (applied?.applied?.changed) {
         console.info(`[org] carried @${handle} revocations seq ${applied.applied.seq} to this daemon (${applied.applied.revoked_grants} grants, ${applied.applied.revoked_peer_identities} peer identities revoked)`);
       }

--- a/static/app/42-usage-terminal.js
+++ b/static/app/42-usage-terminal.js
@@ -2519,15 +2519,15 @@ async function accessApplyGrantToTarget(target, payload) {
     if (!resp.ok) throw new Error(resp.body?.error || `request failed (${resp.status})`);
     return resp.body;
   }
-  const resp = await fetch(`${target.origin}/api/access/iam/user-client-grants`, {
-    method: 'POST',
-    mode: 'cors',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
+  // Remote fleet daemon: the explicit remote-http target (transport F4).
+  // Naming the target names the transport — direct cross-origin HTTP to
+  // that daemon's fleet-CORS row, never a tunnel, never a fallback; the
+  // target daemon's own IAM authorizes the write (browser mTLS identity).
+  const resp = await daemonApi.request('api_access_iam_upsert_user_client_grant', payload, {
+    target: { remoteHttp: target.origin },
   });
-  const data = await resp.json().catch(() => ({}));
-  if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
-  return data;
+  if (!resp.ok) throw new Error(resp.body?.error || `request failed (${resp.status})`);
+  return resp.body;
 }
 
 function renderAccessUserClientGrantForm() {

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -804,8 +804,11 @@ function renderAccessTierCard() {
   if (!mount) return;
   const iam = accessIamModel(accessOverviewModel());
   const tier = accessModelLabel(iam.tier);
-  const canSetTier = dashboardControlTransport?.lastStatus?.api_access_set_tier_available !== false;
-  const canSetCeiling = dashboardControlTransport?.lastStatus?.api_access_set_hosted_ceiling_available !== false;
+  // daemonApi availability (transport F4): tunnel status boolean when
+  // connected, HTTP-twin reachability otherwise — honest in Connect
+  // mode, where a down tunnel means no lane at all.
+  const canSetTier = daemonApi.availability('api_access_set_tier').ok;
+  const canSetCeiling = daemonApi.availability('api_access_set_hosted_ceiling').ok;
 
   mount.textContent = '';
   const head = document.createElement('div');
@@ -964,9 +967,10 @@ function renderAccessConnectCard() {
       || !status.claim_code_available;
     if (stale) accessConnectRevealed = null;
   }
-  const canConfig = dashboardControlTransport?.lastStatus?.api_access_connect_config_available !== false;
-  const canReveal = dashboardControlTransport?.lastStatus?.api_access_connect_claim_code_available !== false;
-  const canUnclaim = dashboardControlTransport?.lastStatus?.api_access_connect_unclaim_available !== false;
+  // daemonApi availability (transport F4) — see renderAccessTierCard.
+  const canConfig = daemonApi.availability('api_access_connect_config').ok;
+  const canReveal = daemonApi.availability('api_access_connect_claim_code').ok;
+  const canUnclaim = daemonApi.availability('api_access_connect_unclaim').ok;
 
   const head = document.createElement('div');
   head.className = 'acc-section-head';
@@ -1092,7 +1096,7 @@ function renderAccessConnectCard() {
       chip.title = fleetCert.last_error || 'The last certificate request failed.';
     }
     if (chip.textContent) row.appendChild(chip);
-    const canRequest = dashboardControlTransport?.lastStatus?.api_fleet_cert_request_available !== false;
+    const canRequest = daemonApi.availability('api_fleet_cert_request').ok;
     if (fleetCert.state !== 'requesting' && fleetCert.state !== 'valid') {
       const request = document.createElement('button');
       request.type = 'button';
@@ -1232,7 +1236,7 @@ function renderAccessEnrollmentRequests() {
   if (!mount) return;
   mount.innerHTML = '';
   if (!accessPendingEnrollments.length) return;
-  const canManage = dashboardControlTransport?.lastStatus?.api_access_enrollment_decide_available !== false;
+  const canManage = daemonApi.availability('api_access_enrollment_decide').ok;
 
   const head = document.createElement('div');
   head.className = 'acc-section-head';
@@ -1342,7 +1346,7 @@ function renderAccessPeopleGrants() {
     mount.appendChild(empty);
     return;
   }
-  const canManage = dashboardControlTransport?.lastStatus?.api_access_iam_update_grant_available !== false;
+  const canManage = daemonApi.availability('api_access_iam_update_grant').ok;
   for (const principal of principals) {
     const card = document.createElement('div');
     card.className = 'acc-principal-card';
@@ -1517,15 +1521,17 @@ function renderAccessRoleCatalog() {
 }
 
 /* Advanced: trusted organizations + issuance. */
-async function accessOrgCall(method, path, payload) {
-  const resp = await dashboardJsonFetch(method, payload, () => authedFetch(path, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  }), method, { fallbackAfterRpcFailure: false });
-  const data = await resp.json().catch(() => ({}));
-  if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
-  return data;
+// daemonApi (transport F4): every org call is a POST twin — the fallback
+// policy derives no-replay from the verb, exactly the legacy
+// fallbackAfterRpcFailure:false semantics (a delivered tunnel attempt is
+// never replayed over HTTP; with no tunnel the write goes direct; Connect
+// mode never uses HTTP). The descriptor owns each method's path — the old
+// per-call-site path argument died with the tri-form. IAM-mutating
+// writes: payload shapes unchanged, zero retries.
+async function accessOrgCall(method, payload) {
+  const resp = await daemonApi.request(method, payload ?? {});
+  if (!resp.ok) throw new Error(resp.body?.error || `request failed (${resp.status})`);
+  return resp.body;
 }
 
 function renderAccessOrganizations() {
@@ -1535,7 +1541,7 @@ function renderAccessOrganizations() {
   const iam = accessIamModel(accessOverviewModel());
   const trusted = Array.isArray(iam.trusted_orgs) ? iam.trusted_orgs : [];
   const issuers = Array.isArray(iam.org_issuers) ? iam.org_issuers : [];
-  const canManage = dashboardControlTransport?.lastStatus?.api_access_org_trust_available !== false;
+  const canManage = daemonApi.availability('api_access_org_trust').ok;
 
   const list = document.createElement('div');
   list.className = 'acc-principal-list';
@@ -1578,7 +1584,7 @@ function renderAccessOrganizations() {
         });
         if (!ok) return;
         try {
-          await accessOrgCall('api_access_org_revoke', '/api/access/orgs/revoke', { handle: org.handle });
+          await accessOrgCall('api_access_org_revoke', { handle: org.handle });
           showControlToast?.('success', `Org @${org.handle} revoked`);
         } catch (err) {
           showControlToast?.('error', err?.message || 'Org revoke failed');
@@ -1684,7 +1690,7 @@ function renderAccessOrganizations() {
       return;
     }
     try {
-      await accessOrgCall('api_access_org_trust', '/api/access/orgs/trust', {
+      await accessOrgCall('api_access_org_trust', {
         handle,
         root_key: rootKey,
         max_role: document.getElementById('access-org-trust-cap')?.value || 'role:operator',
@@ -1829,7 +1835,7 @@ function renderAccessOrganizations() {
       try {
         const issueKind = document.getElementById('access-org-issue-kind')?.value || 'client_key';
         const issueFp = document.getElementById('access-org-issue-fingerprint')?.value?.trim();
-        const data = await accessOrgCall('api_access_org_issue', '/api/access/org-grants/issue', {
+        const data = await accessOrgCall('api_access_org_issue', {
           handle: document.getElementById('access-org-issue-handle')?.value,
           client_key_fingerprint: issueKind === 'peer' ? '' : issueFp,
           peer_fingerprint: issueKind === 'peer' ? issueFp : '',
@@ -1928,7 +1934,7 @@ function renderAccessOrganizations() {
         return;
       }
       try {
-        const data = await accessOrgCall('api_access_org_revoke_member', '/api/access/org-grants/revoke-member', {
+        const data = await accessOrgCall('api_access_org_revoke_member', {
           handle: document.getElementById('access-org-orl-handle')?.value,
           ...(grantId ? { grant_id: grantId } : {}),
           ...(subject ? { subject } : {}),
@@ -2004,7 +2010,7 @@ function renderAccessOrganizations() {
         return;
       }
       try {
-        const data = await accessOrgCall('api_access_org_renew', '/api/access/org-grants/renew', doc);
+        const data = await accessOrgCall('api_access_org_renew', doc);
         renewOutput.value = JSON.stringify(data.document, null, 2);
         showControlToast?.('success', 'Document renewed — send it back to the member');
       } catch (err) {
@@ -2075,7 +2081,7 @@ function renderAccessOrganizations() {
     delegateBtn.disabled = !canManage;
     delegateBtn.addEventListener('click', async () => {
       try {
-        const data = await accessOrgCall('api_access_org_issuer_delegate', '/api/access/org-grants/issuers/delegate', {
+        const data = await accessOrgCall('api_access_org_issuer_delegate', {
           handle: document.getElementById('access-org-orl-handle')?.value || document.getElementById('access-org-issue-handle')?.value,
           issuer_key: document.getElementById('access-org-delegate-key')?.value?.trim(),
           label: document.getElementById('access-org-delegate-label')?.value?.trim(),
@@ -2150,7 +2156,7 @@ function renderAccessOrganizations() {
     initBtn.textContent = 'Create / show issuer key';
     initBtn.addEventListener('click', async () => {
       try {
-        const data = await accessOrgCall('api_access_org_issuer_init', '/api/access/org-grants/issuers/init', {
+        const data = await accessOrgCall('api_access_org_issuer_init', {
           handle: handleInput.value?.trim(),
         });
         keyOut.value = data.issuer_key || '';
@@ -2170,7 +2176,7 @@ function renderAccessOrganizations() {
         return;
       }
       try {
-        await accessOrgCall('api_access_org_issuer_install', '/api/access/org-grants/issuers/install', {
+        await accessOrgCall('api_access_org_issuer_install', {
           handle: handleInput.value?.trim(),
           certificate: cert,
         });
@@ -2223,7 +2229,7 @@ function renderAccessOrganizations() {
         return;
       }
       try {
-        const data = await accessOrgCall('api_access_org_orl_apply', '/api/access/orgs/revocations/apply', orl);
+        const data = await accessOrgCall('api_access_org_orl_apply', orl);
         const applied = data.applied || {};
         showControlToast?.(
           'success',
@@ -2244,18 +2250,15 @@ function renderAccessOrganizations() {
 }
 
 /* Fetch an org's current signed revocation list from the daemon holding
-   its root key (RPC in tunnel mode, plain GET otherwise). */
+   its root key. daemonApi (transport F4): GET twin — tunnel first, then
+   the direct-HTTP retry the verb-derived policy allows (the legacy site
+   opted out, but a public idempotent read replays safely; the policy is
+   data, not per-site judgment). The descriptor lifts `handle` into the
+   row's {org_handle} capture. */
 async function accessOrgFetchOrl(handle) {
-  const resp = await dashboardJsonFetch(
-    'api_access_org_orl',
-    { handle },
-    () => authedFetch(`/api/access/orgs/${encodeURIComponent(handle || '')}/revocations`),
-    'api_access_org_orl',
-    { fallbackAfterRpcFailure: false }
-  );
-  const data = await resp.json().catch(() => ({}));
-  if (!resp.ok) throw new Error(data?.error || `request failed (${resp.status})`);
-  return data;
+  const resp = await daemonApi.request('api_access_org_orl', { handle });
+  if (!resp.ok) throw new Error(resp.body?.error || `request failed (${resp.status})`);
+  return resp.body;
 }
 
 /* Advanced: local IAM state card with raw links. */

--- a/static/app/58-shortcuts-boot.js
+++ b/static/app/58-shortcuts-boot.js
@@ -583,8 +583,8 @@ document.getElementById('sb-dashboard-transport')?.addEventListener('click', () 
 document.getElementById('access-link-daemon-btn')?.addEventListener('click', () => routeTo('access', 'peers'));
 
 // Join-with-an-org-grant: present the pasted document to this daemon. The
-// endpoint is public by design (the document is the authorization); using
-// authedFetch keeps it working identically on the trusted paths.
+// HTTP row is public by design (the document is the authorization); the
+// facade rides the tunnel when one is bound and the public row otherwise.
 document.getElementById('access-org-join-btn')?.addEventListener('click', async () => {
   const status = document.getElementById('access-org-join-status');
   const raw = document.getElementById('access-org-join-doc')?.value?.trim();
@@ -602,7 +602,7 @@ document.getElementById('access-org-join-btn')?.addEventListener('click', async 
   const stored = orgGrantStore(doc);
   if (status) status.textContent = 'Presenting…';
   try {
-    const data = await accessOrgCall('api_access_org_present', '/api/access/org-grants', doc);
+    const data = await accessOrgCall('api_access_org_present', doc);
     const summary = data.peer_identity
       ? `peer profile ${data.peer_identity.profile} for ${data.peer_identity.label} until ${new Date(Number(data.peer_identity.expires_at_unix || 0) * 1000).toLocaleString()}`
       : `${String(data.grant?.role_id || '').replace(/^role:/, '')} until ${new Date(Number(data.grant?.expires_at_unix_ms || 0)).toLocaleString()}`;


### PR DESCRIPTION
Second and final F4 PR unit (transport-unification design §6, frontend track). Stacked on #185 (F4a) — the diff collapses to the F4b delta once that lands.

## What moves
- **43-access-panes.js**: `accessOrgCall` goes onto `daemonApi.request` and **drops its per-call-site path argument** — the descriptor owns each method's HTTP twin. All nine org writes (trust, revoke, issue, revoke-member, issuers init/delegate/install, ORL apply) keep the verb-derived no-replay policy (the legacy `fallbackAfterRpcFailure:false` semantics; payload shapes unchanged, zero retries). `accessOrgFetchOrl` is the family's one GET twin: it gains the policy's direct-HTTP retry after a failed tunnel attempt (previously opted out; a public idempotent read replays safely — policy is data, §3.7). The descriptor's `alias` lifts `handle` into the row's `{org_handle}` capture.
- **58-shortcuts-boot.js**: join-with-an-org-grant present (`api_access_org_present`).
- **32-vault-custody.js**: the revocation courier's `api_access_org_orl_apply`.
- **Availability**: nine hand-rolled `lastStatus.*_available` probes in 43 (tier pair, connect trio, fleet-cert, enrollment decide, grant update, org trust) become `daemonApi.availability(...)` derivations — honest `transport-down` in Connect mode instead of the legacy optimistic default.

## The explicit remote-http target (design §5's F4 caveat)
Cross-daemon fleet fan-out stays **direct HTTP to remote origins** — the facade now models it instead of hiding it: `daemonApi.request(method, params, { target: { remoteHttp: origin } })`.
- Naming the target names the transport: no tunnel is ever attempted, no fallback is ever taken, a delivered error is final.
- Plain cross-origin `fetch` with `mode:'cors'` under the target daemon's fleet-CORS row; the browser's mTLS identity to THAT origin is the authentication — this daemon's `authedFetch` bearer deliberately stays out of the lane (authority is only ever minted by the target daemon's local IAM).
- Composed signal with a 30 s floor replaces the legacy signal-less fetch (§3.6; fleet links cross networks the 5 s family default was never sized for).
- JSON lane only: `bytes`/`upload`/`stream` refuse remote-http targets with an explicit `unavailable` error (no fleet-CORS twins exist on those lanes); `availability` answers lane presence (`http-only`) since a remote origin's reachability is unknowable without a request.
- A malformed object target **throws** (TypeError) rather than drifting into the peer-tunnel lane.
- `accessApplyGrantToTarget`'s remote branch (the grant fan-out) is the first rider.

## Descriptor + pin
`DAEMON_API_HTTP_MAP` grows the 11 org entries (46 → 57 with F4a); the daemon-side parity pin's coverage set extends to match. The pin's authz arm learns the signed-org doorbell shape: a **Public** row must carry this method's tunnel column with a **documented op-override** agreeing with the effective tunnel operation (the override enumeration itself stays pinned closed by `tunnel_op_overrides_are_a_closed_documented_enumeration`). Everything else still requires Operation-gated rows — extension, not weakening.

Completes F4: every access-family call site rides the facade; local calls tunnel-first per verb policy, fleet calls are explicit remote-http.

Battery: assembler regen; `cargo nextest run --bins` 2981 passed; clippy clean on the touched files; `node --check` on all five fragments; `validate-dashboard.cjs --check-static-scripts` PASS.

Gates note: validate-org-grants is environmentally blocked on this box at hosted-Connect passkey registration (pre-existing, proven by differential run) — relying on the parity pins like S6 did.