### PR TITLE
Transport S8 (bytes lanes): live recordings/frames chains onto the neutral api core

### DIFF
--- a/src/bin/caller/dashboard_control/api_media.rs
+++ b/src/bin/caller/dashboard_control/api_media.rs
@@ -5,16 +5,16 @@
 use super::*;
 
 // The recording/frame asset content core — the RecordingAsset vocabulary,
-// its resolvers, safety predicates, and range readers — moved verbatim to
-// web_gateway::session_catalog (transport-unification S4b): both lanes
-// resolve assets through one core; this module keeps the tunnel's ranged
-// byte-stream carriage.
+// its resolvers (including the live-registry resolution the legacy
+// /recordings* chain shares since S8), safety predicates, and range
+// readers — moved verbatim to web_gateway::session_catalog
+// (transport-unification S4b/S8): both lanes resolve assets through one
+// core; this module keeps the tunnel's ranged byte-stream carriage.
 pub(crate) use crate::web_gateway::{
     read_frame_asset_file_range, read_recording_asset_bytes_range,
     read_recording_asset_file_range, recording_asset_name_is_safe,
-    recording_stream_name_is_safe, resolve_recording_asset_from_dir_pair,
-    resolve_session_recording_asset, session_frame_filename_is_safe,
-    RecordingAsset,
+    recording_stream_name_is_safe, resolve_live_recording_asset_in_daemon_dir,
+    resolve_session_recording_asset, session_frame_filename_is_safe, RecordingAsset,
 };
 
 pub(crate) fn media_http_response(id: String, status: u16, body: serde_json::Value) -> serde_json::Value {
@@ -638,10 +638,28 @@ pub(crate) async fn api_media_clip_cancel_response(
 }
 
 pub(crate) async fn api_recordings_response(id: String, runtime: &ControlRuntime) -> serde_json::Value {
+    // Transport edge: resolve the real daemon recordings dir once; the
+    // parity fixture drives the `_in_daemon_dir` variant with an
+    // injected tempdir.
+    api_recordings_response_in_daemon_dir(id, runtime, &crate::debug::daemon_recordings_dir())
+        .await
+}
+
+pub(crate) async fn api_recordings_response_in_daemon_dir(
+    id: String,
+    runtime: &ControlRuntime,
+    daemon_dir: &std::path::Path,
+) -> serde_json::Value {
     let recording_registry = active_recording_registry(runtime).await;
-    json_body_response(
+    // Body-only framing (this method predates the injected-status
+    // envelope); the neutral fn always answers 200 with the listing.
+    frame_api_json_body_response(
         id,
-        crate::web_gateway::recordings_list_response_body(recording_registry).await,
+        crate::web_gateway::recordings_list_api_response_in_daemon_dir(
+            recording_registry,
+            daemon_dir,
+        )
+        .await,
         "recordings",
     )
 }
@@ -674,6 +692,24 @@ pub(crate) async fn api_recording_asset_task_response(
     params: Option<&serde_json::Value>,
     runtime: &ControlRuntime,
 ) -> ControlTaskResponse {
+    // Transport edge: resolve the real daemon recordings dir once; the
+    // parity fixture drives the `_in_daemon_dir` variant with an
+    // injected tempdir.
+    api_recording_asset_task_response_in_daemon_dir(
+        id,
+        params,
+        runtime,
+        &crate::debug::daemon_recordings_dir(),
+    )
+    .await
+}
+
+pub(crate) async fn api_recording_asset_task_response_in_daemon_dir(
+    id: String,
+    params: Option<&serde_json::Value>,
+    runtime: &ControlRuntime,
+    daemon_dir: &std::path::Path,
+) -> ControlTaskResponse {
     let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
     let (stream_name, asset, offset, length) = match recording_asset_request_params(&params) {
         Ok(params) => params,
@@ -688,7 +724,9 @@ pub(crate) async fn api_recording_asset_task_response(
             serde_json::json!({ "ok": false, "error": "recording registry unavailable" }),
         );
     };
-    let resolved = resolve_live_recording_asset(registry, &stream_name, &asset).await;
+    let resolved =
+        resolve_live_recording_asset_in_daemon_dir(registry, daemon_dir, &stream_name, &asset)
+            .await;
     recording_asset_task_response(id, stream_name, asset, offset, length, resolved).await
 }
 
@@ -765,28 +803,6 @@ pub(crate) fn recording_asset_request_params(
     let length = optional_u64_param(params, &["length", "limit"])
         .map_err(|error| (400, serde_json::json!({ "ok": false, "error": error })))?;
     Ok((stream_name, asset, offset, length))
-}
-
-pub(crate) async fn resolve_live_recording_asset(
-    registry: Arc<tokio::sync::RwLock<crate::recording::RecordingRegistry>>,
-    stream_name: &str,
-    asset: &str,
-) -> Result<RecordingAsset, (u16, serde_json::Value)> {
-    let (session_dir, mut segments) = {
-        let reg = registry.read().await;
-        (reg.session_dir().to_path_buf(), reg.segments(stream_name))
-    };
-    if segments.is_empty() {
-        let stream_dir = crate::debug::daemon_recordings_dir().join(stream_name);
-        segments =
-            crate::recording::parse_segment_csv_pub(&stream_dir.join("segments.csv"), &stream_dir);
-    }
-    resolve_recording_asset_from_dir_pair(
-        Some(session_dir.join("recordings").join(stream_name)),
-        Some(crate::debug::daemon_recordings_dir().join(stream_name)),
-        segments,
-        asset,
-    )
 }
 
 pub(crate) async fn recording_asset_task_response(
@@ -1151,6 +1167,137 @@ mod tests {
         }
     }
 
+    // ── S8 parity: the LIVE (daemon-scoped) recordings lanes — the
+    // legacy /recordings* chain shapes and the tunnel residue resolve
+    // through one core over the same injected dirs (no ambient
+    // daemon_recordings_dir read on either lane).
+
+    /// A registry over a temp session dir holding one recorded stream
+    /// ("screen"), plus an injected daemon recordings dir holding
+    /// another ("daemon0") — segments csv + playable bytes each.
+    fn parity_live_fixture() -> (
+        tempfile::TempDir,
+        tempfile::TempDir,
+        Arc<tokio::sync::RwLock<crate::recording::RecordingRegistry>>,
+    ) {
+        let session_dir = tempfile::tempdir().expect("temp session dir");
+        let daemon_dir = tempfile::tempdir().expect("temp daemon dir");
+        for (root, stream, bytes) in [
+            (
+                session_dir.path().join("recordings"),
+                "screen",
+                &b"live session segment bytes"[..],
+            ),
+            (
+                daemon_dir.path().to_path_buf(),
+                "daemon0",
+                &b"daemon-scoped segment bytes"[..],
+            ),
+        ] {
+            let stream_dir = root.join(stream);
+            std::fs::create_dir_all(&stream_dir).unwrap();
+            std::fs::write(stream_dir.join("seg_00001.mp4"), bytes).unwrap();
+            std::fs::write(stream_dir.join("segments.csv"), "seg_00001.mp4,0.0,2.0\n").unwrap();
+        }
+        let registry = Arc::new(tokio::sync::RwLock::new(
+            crate::recording::RecordingRegistry::new(
+                session_dir.path(),
+                crate::project::RecordingConfig::default(),
+            ),
+        ));
+        (session_dir, daemon_dir, registry)
+    }
+
+    #[tokio::test]
+    async fn parity_live_recordings_list_shares_bodies_across_lanes() {
+        let (_session_dir, daemon_dir, registry) = parity_live_fixture();
+        let rt = runtime();
+        {
+            let mut session = rt.shared_session.write().await;
+            session.recording_registry = Some(registry.clone());
+        }
+
+        let (status, http_body) = parity_http_json_body(
+            crate::web_gateway::recordings_list_api_response_in_daemon_dir(
+                Some(registry),
+                daemon_dir.path(),
+            )
+            .await,
+        );
+        assert_eq!(status, 200);
+        assert_eq!(
+            http_body.as_array().map(|entries| entries.len()),
+            Some(2),
+            "{http_body}"
+        );
+
+        let frame = api_recordings_response_in_daemon_dir(
+            "parity-live-list".to_string(),
+            &rt,
+            daemon_dir.path(),
+        )
+        .await;
+        assert_eq!(frame["t"], "response");
+        assert_eq!(frame["ok"], true);
+        // Body-only framing over a json ARRAY — no status injection.
+        assert_eq!(frame["result"], http_body);
+    }
+
+    #[tokio::test]
+    async fn parity_live_recording_assets_share_bytes_across_lanes() {
+        let (_session_dir, daemon_dir, registry) = parity_live_fixture();
+        let rt = runtime();
+        {
+            let mut session = rt.shared_session.write().await;
+            session.recording_registry = Some(registry.clone());
+        }
+
+        // "screen" resolves through the registry's session dir; "daemon0"
+        // exercises the daemon-dir csv fallback — on both lanes.
+        for stream_name in ["screen", "daemon0"] {
+            for asset in ["segments", "playlist.m3u8", "seg_00001.mp4"] {
+                let response = crate::web_gateway::live_recordings_path_api_response(
+                    Some(registry.clone()),
+                    daemon_dir.path(),
+                    &format!("{stream_name}/{asset}"),
+                )
+                .await;
+                let (http_bytes, http_ct) = match response {
+                    crate::web_gateway::ApiResponse::Bytes {
+                        status: 200,
+                        bytes: crate::web_gateway::BytesPayload::InMemory(payload),
+                        content_type,
+                        ..
+                    } => (payload, content_type),
+                    other => panic!(
+                        "{stream_name}/{asset} must ride the bytes lane 200: {:?}",
+                        std::mem::discriminant(&other)
+                    ),
+                };
+
+                let task = api_recording_asset_task_response_in_daemon_dir(
+                    format!("parity-live-{stream_name}-{asset}"),
+                    Some(&serde_json::json!({
+                        "stream_name": stream_name,
+                        "asset": asset,
+                    })),
+                    &rt,
+                    daemon_dir.path(),
+                )
+                .await;
+                let stream = task.byte_stream.expect("tunnel byte stream");
+                assert_eq!(stream.bytes, http_bytes, "{stream_name}/{asset}");
+                assert_eq!(stream.content_type, http_ct, "{stream_name}/{asset}");
+                assert_eq!(stream.result["ok"], true, "{stream_name}/{asset}");
+                assert_eq!(
+                    stream.result["total_size"],
+                    http_bytes.len(),
+                    "{stream_name}/{asset}"
+                );
+            }
+        }
+    }
+
     use crate::dashboard_control::tests::{runtime, test_upload_state};
 
     #[tokio::test]
@@ -1261,7 +1408,12 @@ mod tests {
     async fn recording_rpcs_preserve_shapes_and_status() {
         let rt = runtime();
 
-        let recordings = api_recordings_response("rec1".to_string(), &rt).await;
+        // Injected daemon dir (hermetic — the ambient variant would scan
+        // the machine's real ~/.intendant/recordings).
+        let daemon_dir = tempfile::tempdir().unwrap();
+        let recordings =
+            api_recordings_response_in_daemon_dir("rec1".to_string(), &rt, daemon_dir.path())
+                .await;
         assert_eq!(recordings["t"], "response");
         assert_eq!(recordings["ok"], true);
         assert!(recordings["result"].as_array().is_some());

--- a/src/bin/caller/dashboard_control/api_transfers_fs.rs
+++ b/src/bin/caller/dashboard_control/api_transfers_fs.rs
@@ -348,7 +348,15 @@ pub(crate) async fn transfer_create_recording_asset_download_job(
                 "recording registry unavailable",
             ));
         };
-        resolve_live_recording_asset(registry, &stream_name, &asset).await
+        // Transport edge: resolve the real daemon recordings dir here
+        // (the shared core takes it injected since S8).
+        resolve_live_recording_asset_in_daemon_dir(
+            registry,
+            &crate::debug::daemon_recordings_dir(),
+            &stream_name,
+            &asset,
+        )
+        .await
     }
     .map_err(|(status, body)| {
         crate::transfer_store::TransferStoreError::new(status, transfer_json_error_message(&body))

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1156,7 +1156,8 @@ pub(crate) async fn serve_http_request(
     } else if req_path.starts_with("/frames/") {
         // Serve HQ frame images from the frame registry.
         // URL format: /frames/<frame_id> (not /api/session/*/frames/*)
-        use tokio::io::AsyncWriteExt;
+        // The registry read stays at this edge; the response shapes are
+        // the neutral fn's (goldens pin the historical wire bytes).
         let frame_id = request_line
             .split("/frames/")
             .nth(1)
@@ -1168,22 +1169,13 @@ pub(crate) async fn serve_http_request(
         } else {
             None
         };
-        if let Some(jpeg_data) = data {
-            let header = HttpResponse::new("200 OK")
-                .header("Content-Type", "image/jpeg")
-                .header("Content-Length", jpeg_data.len().to_string())
-                .header("Cache-Control", "public, max-age=31536000, immutable")
-                .header("Connection", "close")
-                .into_string();
-            let _ = stream.write_all(header.as_bytes()).await;
-            let _ = stream.write_all(&jpeg_data).await;
-        } else {
-            let body = "Frame not found";
-            let response = HttpResponse::with_content("404 Not Found", "text/plain", body)
-                .header("Connection", "close")
-                .into_string();
-            let _ = stream.write_all(response.as_bytes()).await;
-        }
+        return write_api_response(
+            stream,
+            frame_hq_api_response(data),
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        )
+        .await;
     } else if req_method == "POST" && req_path == "/session" {
         let result = mint_session_token(&session_provider, &session_model).await;
         let (status, body) = match result {
@@ -1199,148 +1191,40 @@ pub(crate) async fn serve_http_request(
         use tokio::io::AsyncWriteExt;
         let _ = stream.write_all(response.as_bytes()).await;
     } else if req_path.starts_with("/recordings/") {
-        // Serve recording data: segment files and metadata.
-        use tokio::io::AsyncWriteExt;
+        // Serve recording data: segment files and metadata. Path routing
+        // (verbatim post-"/recordings/" token, historically including any
+        // query string) stays at this edge; resolution and the response
+        // shapes are the neutral fn's, shared with the tunnel's
+        // api_recording_asset (goldens pin the historical wire bytes).
         let path_part = request_line
             .split("/recordings/")
             .nth(1)
             .and_then(|s| s.split_whitespace().next())
             .unwrap_or("");
-        let parts: Vec<&str> = path_part.split('/').collect();
-
-        if let Some(ref rec_reg) = recording_registry {
-            let reg = rec_reg.read().await;
-
-            if parts.len() == 2 && parts[1] == "segments" {
-                // GET /recordings/{stream}/segments — check session then daemon dir
-                let stream_name = parts[0];
-                let mut segments = reg.segments(stream_name);
-                if segments.is_empty() {
-                    // Fallback to daemon recordings dir
-                    let daemon_dir = crate::debug::daemon_recordings_dir();
-                    let stream_dir = daemon_dir.join(stream_name);
-                    segments = crate::recording::parse_segment_csv_pub(
-                        &stream_dir.join("segments.csv"),
-                        &stream_dir,
-                    );
-                }
-                let json: Vec<serde_json::Value> = segments
-                    .iter()
-                    .map(|s| {
-                        serde_json::json!({
-                            "filename": s.filename,
-                            "start_secs": s.start_secs,
-                            "end_secs": s.end_secs,
-                        })
-                    })
-                    .collect();
-                let body = serde_json::to_string(&json).unwrap_or("[]".to_string());
-                let response = HttpResponse::with_content("200 OK", "application/json", body)
-                    .header("Cache-Control", "no-cache")
-                    .header("Connection", "close")
-                    .into_string();
-                let _ = stream.write_all(response.as_bytes()).await;
-            } else if parts.len() == 2 && parts[1] == "playlist.m3u8" {
-                // GET /recordings/{stream}/playlist.m3u8 — HLS playlist
-                let stream_name = parts[0];
-                let mut segments = reg.segments(stream_name);
-                if segments.is_empty() {
-                    let daemon_dir = crate::debug::daemon_recordings_dir();
-                    let stream_dir = daemon_dir.join(stream_name);
-                    segments = crate::recording::parse_segment_csv_pub(
-                        &stream_dir.join("segments.csv"),
-                        &stream_dir,
-                    );
-                }
-                let m3u8 = recording_playlist_m3u8(&segments);
-                let response =
-                    HttpResponse::with_content("200 OK", "application/vnd.apple.mpegurl", m3u8)
-                        .header("Cache-Control", "no-cache")
-                        .header("Connection", "close")
-                        .into_string();
-                let _ = stream.write_all(response.as_bytes()).await;
-            } else if parts.len() == 2 {
-                // GET /recordings/{stream}/{filename} — serve segment file
-                let stream_name = parts[0];
-                let filename = parts[1];
-                // Validate filename to prevent path traversal
-                let valid = filename.starts_with("seg_")
-                    && (filename.ends_with(".mp4") || filename.ends_with(".ts"))
-                    && filename.len() < 30
-                    && !filename.contains("..");
-                if valid {
-                    // Check session dir first, then daemon dir
-                    let session_path = reg
-                        .session_dir()
-                        .join("recordings")
-                        .join(stream_name)
-                        .join(filename);
-                    let daemon_path = crate::debug::daemon_recordings_dir()
-                        .join(stream_name)
-                        .join(filename);
-                    let seg_path = if session_path.exists() {
-                        session_path
-                    } else {
-                        daemon_path
-                    };
-                    let content_type = if filename.ends_with(".ts") {
-                        "video/mp2t"
-                    } else {
-                        "video/mp4"
-                    };
-                    match tokio::fs::read(&seg_path).await {
-                        Ok(data) => {
-                            let header = HttpResponse::new("200 OK")
-                                .header("Content-Type", content_type)
-                                .header("Content-Length", data.len().to_string())
-                                .header("Cache-Control", "public, max-age=3600")
-                                .header("Connection", "close")
-                                .into_string();
-                            let _ = stream.write_all(header.as_bytes()).await;
-                            let _ = stream.write_all(&data).await;
-                        }
-                        Err(_) => {
-                            let body = "Segment not found";
-                            let response =
-                                HttpResponse::with_content("404 Not Found", "text/plain", body)
-                                    .header("Connection", "close")
-                                    .into_string();
-                            let _ = stream.write_all(response.as_bytes()).await;
-                        }
-                    }
-                } else {
-                    let body = "Invalid filename";
-                    let response =
-                        HttpResponse::with_content("400 Bad Request", "text/plain", body)
-                            .header("Connection", "close")
-                            .into_string();
-                    let _ = stream.write_all(response.as_bytes()).await;
-                }
-            } else {
-                let body = "Not found";
-                let response = HttpResponse::with_content("404 Not Found", "text/plain", body)
-                    .header("Connection", "close")
-                    .into_string();
-                let _ = stream.write_all(response.as_bytes()).await;
-            }
-        } else {
-            let body = "Recording not available";
-            let response = HttpResponse::with_content("404 Not Found", "text/plain", body)
-                .header("Connection", "close")
-                .into_string();
-            use tokio::io::AsyncWriteExt;
-            let _ = stream.write_all(response.as_bytes()).await;
-        }
+        let response = live_recordings_path_api_response(
+            recording_registry.clone(),
+            &crate::debug::daemon_recordings_dir(),
+            path_part,
+        )
+        .await;
+        return write_api_response(
+            stream,
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        )
+        .await;
     } else if req_path == "/recordings" {
-        // GET /recordings — list all streams (session + daemon-scoped)
-        use tokio::io::AsyncWriteExt;
-
-        let body = recordings_list_response_body(recording_registry.clone()).await;
-        let response = HttpResponse::with_content("200 OK", "application/json", body)
-            .header("Cache-Control", "no-cache")
-            .header("Connection", "close")
-            .into_string();
-        let _ = stream.write_all(response.as_bytes()).await;
+        // GET /recordings — list all streams (session + daemon-scoped),
+        // through the neutral fn the tunnel's api_recordings shares.
+        let response = recordings_list_api_response(recording_registry.clone()).await;
+        return write_api_response(
+            stream,
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        )
+        .await;
     } else if req_path == "/debug" {
         // Debug endpoint: returns agent state + voice connection info
         let state = query_ctx.as_ref().map(|ctx| {

--- a/src/bin/caller/web_gateway/session_catalog/external_rows.rs
+++ b/src/bin/caller/web_gateway/session_catalog/external_rows.rs
@@ -685,16 +685,6 @@ pub(crate) fn list_recording_streams(recordings_dir: &std::path::Path) -> Vec<se
     entries
 }
 
-pub(crate) async fn recordings_list_response_body(
-    recording_registry: Option<Arc<tokio::sync::RwLock<crate::recording::RecordingRegistry>>>,
-) -> String {
-    recordings_list_response_body_in_daemon_dir(
-        recording_registry,
-        &crate::debug::daemon_recordings_dir(),
-    )
-    .await
-}
-
 pub(crate) async fn recordings_list_response_body_in_daemon_dir(
     recording_registry: Option<Arc<tokio::sync::RwLock<crate::recording::RecordingRegistry>>>,
     daemon_dir: &Path,

--- a/src/bin/caller/web_gateway/session_catalog/external_rows.rs
+++ b/src/bin/caller/web_gateway/session_catalog/external_rows.rs
@@ -688,6 +688,17 @@ pub(crate) fn list_recording_streams(recordings_dir: &std::path::Path) -> Vec<se
 pub(crate) async fn recordings_list_response_body(
     recording_registry: Option<Arc<tokio::sync::RwLock<crate::recording::RecordingRegistry>>>,
 ) -> String {
+    recordings_list_response_body_in_daemon_dir(
+        recording_registry,
+        &crate::debug::daemon_recordings_dir(),
+    )
+    .await
+}
+
+pub(crate) async fn recordings_list_response_body_in_daemon_dir(
+    recording_registry: Option<Arc<tokio::sync::RwLock<crate::recording::RecordingRegistry>>>,
+    daemon_dir: &Path,
+) -> String {
     let mut all_entries = Vec::new();
 
     if let Some(rec_reg) = recording_registry {
@@ -714,8 +725,7 @@ pub(crate) async fn recordings_list_response_body(
         }
     }
 
-    let daemon_dir = crate::debug::daemon_recordings_dir();
-    for entry in list_recording_streams(&daemon_dir) {
+    for entry in list_recording_streams(daemon_dir) {
         all_entries.push(entry);
     }
 
@@ -1062,6 +1072,169 @@ pub(crate) fn read_frame_asset_file_range(
     Ok((bytes, total_size, end))
 }
 
+// ── Live (daemon-scoped) recordings + HQ-frame byte lanes
+// (transport-unification S8). The legacy non-API `/recordings*` and
+// `/frames/{id}` chain arms and the tunnel residue methods
+// (`api_recordings`, `api_recording_asset`) share these fns: one store
+// resolution (registry segments with the daemon-recordings-dir CSV
+// fallback, session-dir-first file candidates), rendered per lane — the
+// chain's historical full-body shapes here as [`ApiResponse`]s, the
+// tunnel's ranged byte-stream carriage in
+// `dashboard_control::api_media`. The `_in_daemon_dir` variants are the
+// hermetic cores (tests inject a tempdir); the ambient wrappers resolve
+// `crate::debug::daemon_recordings_dir()` once at the transport edge.
+
+/// The historical `text/plain` error tail the `/recordings*` and
+/// `/frames/*` chain arms answer with (`Connection: close`, nothing
+/// else). Byte lane so the content type survives the render.
+pub(crate) fn live_media_text_plain_api_response(status: u16, body: &str) -> ApiResponse {
+    ApiResponse::Bytes {
+        status,
+        content_type: "text/plain".to_string(),
+        headers: vec![("Connection", "close".to_string())],
+        bytes: BytesPayload::InMemory(body.as_bytes().to_vec()),
+        meta: serde_json::Value::Null,
+    }
+}
+
+/// `GET /recordings` (chain) / tunnel `api_recordings`: every stream the
+/// live registry knows plus the daemon-scoped store, under the
+/// historical `no-cache` json tail.
+pub(crate) async fn recordings_list_api_response(
+    recording_registry: Option<Arc<tokio::sync::RwLock<crate::recording::RecordingRegistry>>>,
+) -> ApiResponse {
+    recordings_list_api_response_in_daemon_dir(
+        recording_registry,
+        &crate::debug::daemon_recordings_dir(),
+    )
+    .await
+}
+
+pub(crate) async fn recordings_list_api_response_in_daemon_dir(
+    recording_registry: Option<Arc<tokio::sync::RwLock<crate::recording::RecordingRegistry>>>,
+    daemon_dir: &Path,
+) -> ApiResponse {
+    let body = recordings_list_response_body_in_daemon_dir(recording_registry, daemon_dir).await;
+    ApiResponse::json(200, JsonBody::PreSerialized(body))
+}
+
+/// Live-registry recording-asset resolution shared by both lanes: the
+/// registry's segments with the daemon-dir CSV fallback when the stream
+/// has none, then the dir-pair candidates (session recordings dir first,
+/// daemon dir second) through the one asset vocabulary
+/// ([`resolve_recording_asset_from_dir_pair`]).
+pub(crate) async fn resolve_live_recording_asset_in_daemon_dir(
+    registry: Arc<tokio::sync::RwLock<crate::recording::RecordingRegistry>>,
+    daemon_dir: &Path,
+    stream_name: &str,
+    asset: &str,
+) -> Result<RecordingAsset, (u16, serde_json::Value)> {
+    let (session_dir, mut segments) = {
+        let reg = registry.read().await;
+        (reg.session_dir().to_path_buf(), reg.segments(stream_name))
+    };
+    if segments.is_empty() {
+        let stream_dir = daemon_dir.join(stream_name);
+        segments =
+            crate::recording::parse_segment_csv_pub(&stream_dir.join("segments.csv"), &stream_dir);
+    }
+    resolve_recording_asset_from_dir_pair(
+        Some(session_dir.join("recordings").join(stream_name)),
+        Some(daemon_dir.join(stream_name)),
+        segments,
+        asset,
+    )
+}
+
+/// `GET /recordings/{stream}/{asset}` (chain): the historical full-body
+/// shapes over the shared live resolution. `path_part` arrives verbatim
+/// from the request line (historically including any query string, which
+/// then fails the asset vocabulary — pinned by the goldens):
+/// segments listing json and the HLS playlist under `no-cache`, segment
+/// files under `public, max-age=3600`, and the `text/plain` error trio
+/// (`Recording not available` / `Not found` / `Invalid filename` /
+/// `Segment not found`).
+pub(crate) async fn live_recordings_path_api_response(
+    recording_registry: Option<Arc<tokio::sync::RwLock<crate::recording::RecordingRegistry>>>,
+    daemon_dir: &Path,
+    path_part: &str,
+) -> ApiResponse {
+    let Some(registry) = recording_registry else {
+        return live_media_text_plain_api_response(404, "Recording not available");
+    };
+    let parts: Vec<&str> = path_part.split('/').collect();
+    if parts.len() != 2 {
+        return live_media_text_plain_api_response(404, "Not found");
+    }
+    let (stream_name, asset) = (parts[0], parts[1]);
+    match resolve_live_recording_asset_in_daemon_dir(registry, daemon_dir, stream_name, asset).await
+    {
+        // Segments listing + HLS playlist: in-memory renders under the
+        // historical no-cache tail (content type from the vocabulary).
+        Ok(RecordingAsset::Bytes {
+            bytes,
+            content_type,
+            filename: _,
+        }) => ApiResponse::Bytes {
+            status: 200,
+            content_type: content_type.to_string(),
+            headers: vec![
+                ("Cache-Control", "no-cache".to_string()),
+                ("Connection", "close".to_string()),
+            ],
+            bytes: BytesPayload::InMemory(bytes),
+            meta: serde_json::Value::Null,
+        },
+        // Segment file: full read under the historical cacheable tail; a
+        // vanished-underfoot file keeps the historical 404 wording.
+        Ok(RecordingAsset::File {
+            path,
+            content_type,
+            filename: _,
+        }) => match tokio::fs::read(&path).await {
+            Ok(data) => ApiResponse::Bytes {
+                status: 200,
+                content_type: content_type.to_string(),
+                headers: vec![
+                    ("Cache-Control", "public, max-age=3600".to_string()),
+                    ("Connection", "close".to_string()),
+                ],
+                bytes: BytesPayload::InMemory(data),
+                meta: serde_json::Value::Null,
+            },
+            Err(_) => live_media_text_plain_api_response(404, "Segment not found"),
+        },
+        // The shared vocabulary's json errors map onto the chain's
+        // historical text/plain wordings: 400 = the asset name failed the
+        // vocabulary ("Invalid filename"), anything else = not found in
+        // either dir ("Segment not found").
+        Err((400, _)) => live_media_text_plain_api_response(400, "Invalid filename"),
+        Err((status, _)) => live_media_text_plain_api_response(status, "Segment not found"),
+    }
+}
+
+/// `GET /frames/{frame_id}` (chain): one HQ frame from the live frame
+/// registry under the historical immutable-cache tail; the registry read
+/// stays at the transport edge (async lock), this renders its result.
+pub(crate) fn frame_hq_api_response(jpeg: Option<Vec<u8>>) -> ApiResponse {
+    match jpeg {
+        Some(data) => ApiResponse::Bytes {
+            status: 200,
+            content_type: "image/jpeg".to_string(),
+            headers: vec![
+                (
+                    "Cache-Control",
+                    "public, max-age=31536000, immutable".to_string(),
+                ),
+                ("Connection", "close".to_string()),
+            ],
+            bytes: BytesPayload::InMemory(data),
+            meta: serde_json::Value::Null,
+        },
+        None => live_media_text_plain_api_response(404, "Frame not found"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1096,6 +1269,297 @@ mod tests {
                 "seg_00001.mp4\n",
                 "#EXT-X-ENDLIST\n",
             )
+        );
+    }
+
+    // ── S8 goldens: the legacy `/recordings*` + `/frames/*` chain wire
+    // bytes. Expected framing is hand-written from the historical inline
+    // chain arms (`http_dispatch.rs`) so the S8 re-plumb onto the neutral
+    // fns above can be proven byte-identical (design §6 S8, risk R1);
+    // store-dependent bodies come from store-layer fns the conversion
+    // does not touch, over injected tempdirs — the ambient
+    // `daemon_recordings_dir()` is never read.
+
+    fn golden_live_transcript(response: ApiResponse) -> String {
+        String::from_utf8_lossy(&crate::web_gateway::api_response_http_bytes(
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        ))
+        .into_owned()
+    }
+
+    fn golden_live_registry(
+        session_dir: &Path,
+    ) -> Arc<tokio::sync::RwLock<crate::recording::RecordingRegistry>> {
+        Arc::new(tokio::sync::RwLock::new(
+            crate::recording::RecordingRegistry::new(
+                session_dir,
+                crate::project::RecordingConfig::default(),
+            ),
+        ))
+    }
+
+    /// One playable stream under `<root>/<stream>`: a csv row plus the
+    /// on-disk segment (`list_recording_streams` skips streams without
+    /// playable bytes).
+    fn golden_seed_stream(root: &Path, stream: &str, filename: &str, bytes: &[u8]) {
+        let stream_dir = root.join(stream);
+        std::fs::create_dir_all(&stream_dir).unwrap();
+        std::fs::write(stream_dir.join(filename), bytes).unwrap();
+        std::fs::write(
+            stream_dir.join("segments.csv"),
+            format!("{filename},0.0,2.0\n"),
+        )
+        .unwrap();
+    }
+
+    fn golden_live_text_plain_transcript(status_line: &str, body: &str) -> String {
+        format!(
+            "HTTP/1.1 {status_line}\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+    }
+
+    #[tokio::test]
+    async fn golden_live_recordings_list_transcript() {
+        let session_dir = tempfile::tempdir().unwrap();
+        let daemon_dir = tempfile::tempdir().unwrap();
+        golden_seed_stream(
+            &session_dir.path().join("recordings"),
+            "screen",
+            "seg_00001.mp4",
+            b"live session segment bytes",
+        );
+        golden_seed_stream(daemon_dir.path(), "daemon0", "seg_00001.mp4", b"daemon segment");
+        let registry = golden_live_registry(session_dir.path());
+
+        // The framing pin: the body is the untouched store listing
+        // (registry streams first, then the daemon-scoped store).
+        let body = recordings_list_response_body_in_daemon_dir(
+            Some(registry.clone()),
+            daemon_dir.path(),
+        )
+        .await;
+        assert!(body.contains("\"stream_name\":\"daemon0\""), "{body}");
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed.as_array().map(|entries| entries.len()), Some(2));
+
+        let transcript = golden_live_transcript(
+            recordings_list_api_response_in_daemon_dir(Some(registry), daemon_dir.path()).await,
+        );
+        assert_eq!(
+            transcript,
+            format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+        );
+
+        // No live registry: the daemon-scoped store still lists.
+        let body =
+            recordings_list_response_body_in_daemon_dir(None, daemon_dir.path()).await;
+        let transcript = golden_live_transcript(
+            recordings_list_api_response_in_daemon_dir(None, daemon_dir.path()).await,
+        );
+        assert!(transcript.ends_with(&body), "{transcript}");
+        assert!(transcript.starts_with("HTTP/1.1 200 OK\r\n"), "{transcript}");
+    }
+
+    #[tokio::test]
+    async fn golden_live_recording_segments_and_playlist_transcripts() {
+        // Registry with no segments for the stream: the daemon-dir csv
+        // fallback resolves (the historical chain's fallback branch).
+        let session_dir = tempfile::tempdir().unwrap();
+        let daemon_dir = tempfile::tempdir().unwrap();
+        golden_seed_stream(daemon_dir.path(), "display_0", "seg_00001.mp4", b"daemon bytes");
+        let registry = golden_live_registry(session_dir.path());
+
+        let expected_body = serde_json::to_string(&vec![serde_json::json!({
+            "filename": "seg_00001.mp4",
+            "start_secs": 0.0,
+            "end_secs": 2.0,
+        })])
+        .unwrap();
+        let transcript = golden_live_transcript(
+            live_recordings_path_api_response(
+                Some(registry.clone()),
+                daemon_dir.path(),
+                "display_0/segments",
+            )
+            .await,
+        );
+        assert_eq!(
+            transcript,
+            format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{expected_body}",
+                expected_body.len()
+            )
+        );
+
+        // HLS playlist over the same segments (store-layer body).
+        let segments = crate::recording::parse_segment_csv_pub(
+            &daemon_dir.path().join("display_0").join("segments.csv"),
+            &daemon_dir.path().join("display_0"),
+        );
+        let expected_playlist = recording_playlist_m3u8(&segments);
+        let transcript = golden_live_transcript(
+            live_recordings_path_api_response(
+                Some(registry),
+                daemon_dir.path(),
+                "display_0/playlist.m3u8",
+            )
+            .await,
+        );
+        assert_eq!(
+            transcript,
+            format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/vnd.apple.mpegurl\r\nContent-Length: {}\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n{expected_playlist}",
+                expected_playlist.len()
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn golden_live_recording_segment_file_transcripts() {
+        // The session recordings dir wins over the daemon dir when both
+        // hold the filename (the historical candidate order), and the
+        // `.ts` leaf serves under `video/mp2t`.
+        let session_dir = tempfile::tempdir().unwrap();
+        let daemon_dir = tempfile::tempdir().unwrap();
+        let session_bytes = b"session segment bytes".to_vec();
+        golden_seed_stream(
+            &session_dir.path().join("recordings"),
+            "display_0",
+            "seg_00001.mp4",
+            &session_bytes,
+        );
+        golden_seed_stream(daemon_dir.path(), "display_0", "seg_00001.mp4", b"daemon copy");
+        std::fs::write(
+            daemon_dir.path().join("display_0").join("seg_00002.ts"),
+            b"transport stream bytes",
+        )
+        .unwrap();
+        let registry = golden_live_registry(session_dir.path());
+
+        let transcript = golden_live_transcript(
+            live_recordings_path_api_response(
+                Some(registry.clone()),
+                daemon_dir.path(),
+                "display_0/seg_00001.mp4",
+            )
+            .await,
+        );
+        let mut expected = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: video/mp4\r\nContent-Length: {}\r\nCache-Control: public, max-age=3600\r\nConnection: close\r\n\r\n",
+            session_bytes.len()
+        );
+        expected.push_str(&String::from_utf8(session_bytes).unwrap());
+        assert_eq!(transcript, expected);
+
+        let transcript = golden_live_transcript(
+            live_recordings_path_api_response(
+                Some(registry),
+                daemon_dir.path(),
+                "display_0/seg_00002.ts",
+            )
+            .await,
+        );
+        assert!(
+            transcript.starts_with(
+                "HTTP/1.1 200 OK\r\nContent-Type: video/mp2t\r\nContent-Length: 22\r\nCache-Control: public, max-age=3600\r\nConnection: close\r\n\r\n"
+            ),
+            "{transcript}"
+        );
+        assert!(transcript.ends_with("transport stream bytes"), "{transcript}");
+    }
+
+    #[tokio::test]
+    async fn golden_live_recording_error_transcripts() {
+        let session_dir = tempfile::tempdir().unwrap();
+        let daemon_dir = tempfile::tempdir().unwrap();
+        let registry = golden_live_registry(session_dir.path());
+
+        // No registry wired: everything under /recordings/ answers 404.
+        let transcript = golden_live_transcript(
+            live_recordings_path_api_response(None, daemon_dir.path(), "display_0/segments")
+                .await,
+        );
+        assert_eq!(
+            transcript,
+            golden_live_text_plain_transcript("404 Not Found", "Recording not available")
+        );
+
+        // Path shapes other than {stream}/{asset} answer 404.
+        for path_part in ["display_0", "a/b/c"] {
+            let transcript = golden_live_transcript(
+                live_recordings_path_api_response(
+                    Some(registry.clone()),
+                    daemon_dir.path(),
+                    path_part,
+                )
+                .await,
+            );
+            assert_eq!(
+                transcript,
+                golden_live_text_plain_transcript("404 Not Found", "Not found"),
+                "{path_part}"
+            );
+        }
+
+        // Asset names outside the vocabulary answer 400 — including the
+        // historical query-string rider (never split off the request
+        // line) and traversal shapes.
+        for path_part in [
+            "display_0/evil.mp4",
+            "display_0/seg_00001.mp4?t=5",
+            "display_0/..",
+        ] {
+            let transcript = golden_live_transcript(
+                live_recordings_path_api_response(
+                    Some(registry.clone()),
+                    daemon_dir.path(),
+                    path_part,
+                )
+                .await,
+            );
+            assert_eq!(
+                transcript,
+                golden_live_text_plain_transcript("400 Bad Request", "Invalid filename"),
+                "{path_part}"
+            );
+        }
+
+        // A valid name that exists in neither dir answers 404.
+        let transcript = golden_live_transcript(
+            live_recordings_path_api_response(
+                Some(registry),
+                daemon_dir.path(),
+                "display_0/seg_09999.mp4",
+            )
+            .await,
+        );
+        assert_eq!(
+            transcript,
+            golden_live_text_plain_transcript("404 Not Found", "Segment not found")
+        );
+    }
+
+    #[test]
+    fn golden_frame_hq_transcripts() {
+        let jpeg = b"hq frame jpeg bytes".to_vec();
+        let transcript = golden_live_transcript(frame_hq_api_response(Some(jpeg.clone())));
+        let mut expected = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: image/jpeg\r\nContent-Length: {}\r\nCache-Control: public, max-age=31536000, immutable\r\nConnection: close\r\n\r\n",
+            jpeg.len()
+        );
+        expected.push_str(&String::from_utf8(jpeg).unwrap());
+        assert_eq!(transcript, expected);
+
+        let transcript = golden_live_transcript(frame_hq_api_response(None));
+        assert_eq!(
+            transcript,
+            golden_live_text_plain_transcript("404 Not Found", "Frame not found")
         );
     }
 


### PR DESCRIPTION
Stage S8 of the transport-unification program (design §6 S8), first PR: the legacy non-API `/recordings*` and `/frames/*` chain arms and the tunnel media residue (`api_recordings`, `api_recording_asset`) converge on shared transport-neutral fns; byte responses ride `ApiResponse::Bytes`.

- **Goldens first**: byte-exact transcripts of every historical chain shape (list, segments, playlist, segment files incl. .ts and session-dir priority, the text/plain error wordings, the immutable frame tail) over injected tempdirs.
- Neutral fns in `session_catalog/external_rows.rs` next to the S4b recording core; `_in_daemon_dir` hermetic seams — the ambient `daemon_recordings_dir()` resolves at transport edges only.
- Chain arms re-plumb onto `write_api_response`; tunnel residue keeps its method names (rows deliberately NOT added — the chain is public no-IAM surface; row-izing it would change classification, an owner decision per §2.7).
- Parity fixtures: tunnel vs HTTP over the same injected stores.