### PR TITLE
Transport S8 (upload spool + media store): SpooledBody lane; /ws media twins onto the shared store fns

### DIFF
--- a/src/bin/caller/dashboard_control/api_media.rs
+++ b/src/bin/caller/dashboard_control/api_media.rs
@@ -82,35 +82,15 @@ pub(crate) async fn dashboard_media_session_handles(
     (session.frame_registry.clone(), session.query_ctx.clone())
 }
 
-pub(crate) async fn register_dashboard_media_frame(
-    registry: Option<Arc<tokio::sync::RwLock<crate::frames::FrameRegistry>>>,
-    frame_id: &str,
-    stream: &str,
-    note: Option<String>,
-    bytes: &[u8],
-    log_label: &str,
-) -> (String, bool) {
-    let Some(registry) = registry else {
-        return (String::new(), false);
-    };
-    let meta = presence_core::FrameMeta {
-        frame_id: frame_id.to_string(),
-        stream: stream.to_string(),
-        timestamp: chrono::Utc::now().to_rfc3339(),
-        sent_to_live: false,
-        live_resolution: None,
-        hq_resolution: None,
-        note,
-    };
-    let mut reg = registry.write().await;
-    match reg.register(meta, bytes) {
-        Ok(path) => (path.display().to_string(), true),
-        Err(e) => {
-            eprintln!("{log_label} frame registry write failed: {e}");
-            (String::new(), false)
-        }
-    }
-}
+// The media store core — frame registration, presence-video
+// register+record, annotation/clip context injection, and the clip
+// operation type — moved verbatim to web_gateway::media_store
+// (transport-unification S8): the /ws media twins commit through the
+// same fns; this module keeps the tunnel's upload-frame carriage and
+// response shapes.
+pub(crate) use crate::web_gateway::{
+    inject_annotation_context, inject_clip_context, register_dashboard_media_frame,
+};
 
 pub(crate) async fn api_presence_video_frame_upload_task_response(
     id: String,
@@ -145,6 +125,9 @@ pub(crate) async fn api_presence_video_frame_upload_task_response(
     )
 }
 
+/// Tunnel edge of the presence-video store op: read the registries off
+/// the shared session, then commit through the neutral store fn the
+/// `/ws` `video_frame` twin shares.
 pub(crate) async fn register_dashboard_presence_video_frame(
     runtime: &ControlRuntime,
     frame_id: &str,
@@ -155,124 +138,15 @@ pub(crate) async fn register_dashboard_presence_video_frame(
     let frame_registry = session.frame_registry.clone();
     let recording_registry = session.recording_registry.clone();
     drop(session);
-
-    let mut registered = false;
-    if let Some(registry) = frame_registry {
-        let meta = presence_core::FrameMeta {
-            frame_id: frame_id.to_string(),
-            stream: stream.to_string(),
-            timestamp: chrono::Utc::now().to_rfc3339(),
-            sent_to_live: true,
-            live_resolution: Some("768x768".to_string()),
-            hq_resolution: None,
-            note: None,
-        };
-        let mut reg = registry.write().await;
-        match reg.register(meta, jpeg_bytes) {
-            Ok(_) => registered = true,
-            Err(e) => eprintln!("presence video frame registry write failed: {e}"),
-        }
-    }
-
-    let mut recorded = false;
-    if let Some(registry) = recording_registry {
-        let mut rec = registry.write().await;
-        if rec.is_enabled() {
-            if !rec.is_recording(stream) && crate::recording::is_ffmpeg_available() {
-                match rec.start_stream(stream).await {
-                    Ok(()) => {
-                        runtime.bus.send(AppEvent::RecordingStarted {
-                            stream_name: stream.to_string(),
-                        });
-                    }
-                    Err(e) => eprintln!("presence video recording start failed: {e}"),
-                }
-            }
-            if let Err(e) = rec.feed_frame(stream, jpeg_bytes).await {
-                eprintln!("presence video recording frame failed: {e}");
-            } else {
-                recorded = true;
-            }
-        }
-    }
-
-    (registered, recorded)
-}
-
-pub(crate) fn inject_annotation_context(
-    query_ctx: Option<&crate::web_gateway::WebQueryCtx>,
-    note: &str,
-    data_b64: String,
-) -> bool {
-    let Some(ctx) = query_ctx else {
-        return false;
-    };
-    let Some(ciq) = ctx.context_injection.as_ref() else {
-        return false;
-    };
-    let Ok(mut queue) = ciq.lock() else {
-        return false;
-    };
-    let label = if note.is_empty() {
-        "[User Annotation] User highlighted something on the screen.".to_string()
-    } else {
-        format!("[User Annotation] {note}")
-    };
-    queue.push(crate::event::ContextInjection {
-        text: label,
-        images: vec![crate::conversation::ImageData {
-            media_type: "image/jpeg".to_string(),
-            data: data_b64,
-        }],
-        source: crate::event::InjectionSource::User,
-        target_session_id: None,
-        steer_id: None,
-    });
-    true
-}
-
-pub(crate) fn inject_clip_context(
-    query_ctx: Option<&crate::web_gateway::WebQueryCtx>,
-    _clip_id: &str,
-    clip: &DashboardMediaClipOperation,
-) -> bool {
-    let Some(ctx) = query_ctx else {
-        return false;
-    };
-    let Some(ciq) = ctx.context_injection.as_ref() else {
-        return false;
-    };
-    let Ok(mut queue) = ciq.lock() else {
-        return false;
-    };
-    let frames_registered = clip.frames.len();
-    let label = if clip.note.is_empty() {
-        format!(
-            "[Video Clip] {} {:.1}s-{:.1}s ({} frames, {}fps)",
-            clip.stream, clip.in_secs, clip.out_secs, frames_registered, clip.fps,
-        )
-    } else {
-        format!(
-            "[Video Clip] {} {:.1}s-{:.1}s ({} frames, {}fps). {}",
-            clip.stream, clip.in_secs, clip.out_secs, frames_registered, clip.fps, clip.note,
-        )
-    };
-    let images = clip
-        .frames
-        .iter()
-        .map(|(_, data)| crate::conversation::ImageData {
-            media_type: "image/jpeg".to_string(),
-            data: data.clone(),
-        })
-        .collect();
-    queue.push(crate::event::ContextInjection {
-        text: label,
-        images,
-        source: crate::event::InjectionSource::User,
-        target_session_id: None,
-        steer_id: None,
-    });
-    true
+    crate::web_gateway::register_presence_video_frame(
+        frame_registry,
+        recording_registry,
+        &runtime.bus,
+        frame_id,
+        stream,
+        jpeg_bytes,
+    )
+    .await
 }
 
 pub(crate) async fn api_media_annotation_upload_task_response(

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -855,7 +855,10 @@ pub(crate) async fn api_session_current_upload_task_response(
     upload: InboundUploadState,
     runtime: ControlRuntime,
 ) -> ControlTaskResponse {
-    let params = upload.params.clone();
+    // The tunnel edge of the Streaming lane (S8): frame params parsed
+    // here in their wire form, the spool handed to the same neutral
+    // commit the HTTP staged-upload POST feeds its socket spool.
+    let (params, body) = upload.into_spooled_body();
     let name = optional_string_param(&params, &["name", "filename", "file_name"])
         .unwrap_or_else(|| "upload.bin".to_string());
     let mime = optional_string_param(&params, &["mime", "content_type", "contentType"])
@@ -883,8 +886,7 @@ pub(crate) async fn api_session_current_upload_task_response(
             &name,
             &mime,
             requested_destination,
-            upload.tmp,
-            upload.received_bytes,
+            body,
             &bus,
         )
     })
@@ -1388,8 +1390,10 @@ mod tests {
             "listed.txt",
             "text/plain",
             crate::upload_store::UploadDestination::Task,
-            tmp,
-            bytes.len(),
+            crate::web_gateway::SpooledBody {
+                tmp,
+                len: bytes.len(),
+            },
             &rt.bus,
         );
         assert_eq!(status, "200 OK");
@@ -1423,8 +1427,10 @@ mod tests {
             "raw.txt",
             "text/plain",
             crate::upload_store::UploadDestination::Task,
-            tmp,
-            bytes.len(),
+            crate::web_gateway::SpooledBody {
+                tmp,
+                len: bytes.len(),
+            },
             &rt.bus,
         );
         assert_eq!(status, "200 OK");
@@ -1513,8 +1519,10 @@ mod tests {
             "projectless.txt",
             "text/plain",
             crate::upload_store::UploadDestination::Task,
-            tmp,
-            bytes.len(),
+            crate::web_gateway::SpooledBody {
+                tmp,
+                len: bytes.len(),
+            },
             &rt.bus,
         );
         assert_eq!(status, "200 OK");
@@ -2329,8 +2337,10 @@ mod tests {
                 "parity.txt",
                 "text/plain",
                 crate::upload_store::UploadDestination::Task,
-                tmp,
-                payload.len(),
+                crate::web_gateway::SpooledBody {
+                    tmp,
+                    len: payload.len(),
+                },
                 &rt.bus,
             ),
         );

--- a/src/bin/caller/dashboard_control/api_transfers_fs.rs
+++ b/src/bin/caller/dashboard_control/api_transfers_fs.rs
@@ -1800,8 +1800,10 @@ mod tests {
             "raw.txt",
             "text/plain",
             crate::upload_store::UploadDestination::Task,
-            tmp,
-            bytes.len(),
+            crate::web_gateway::SpooledBody {
+                tmp,
+                len: bytes.len(),
+            },
             &rt.bus,
         );
         assert_eq!(status, "200 OK");

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -1266,6 +1266,24 @@ pub(crate) struct InboundUploadState {
     received_bytes: usize,
 }
 
+impl InboundUploadState {
+    /// The upload-frame spool as the Streaming lane's common handle
+    /// (transport-unification S8): the frame params plus the spooled
+    /// bytes, for handlers that commit the spool wholesale — the staged
+    /// upload today, the S9 transfer-chunk appends next. The media
+    /// handlers keep reading the tempfile in-memory instead (their
+    /// stores take byte slices).
+    pub(crate) fn into_spooled_body(self) -> (serde_json::Value, crate::web_gateway::SpooledBody) {
+        (
+            self.params,
+            crate::web_gateway::SpooledBody {
+                tmp: self.tmp,
+                len: self.received_bytes,
+            },
+        )
+    }
+}
+
 pub(crate) struct OutboundControlQueue {
     frames: VecDeque<QueuedControlFrame>,
 }

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -1192,17 +1192,10 @@ pub(crate) struct ControlRuntime {
     state_root: PathBuf,
 }
 
-#[derive(Debug)]
-pub(crate) struct DashboardMediaClipOperation {
-    stream: String,
-    note: String,
-    inject: bool,
-    in_secs: f64,
-    out_secs: f64,
-    fps: u32,
-    expected_frames: usize,
-    frames: Vec<(String, String)>,
-}
+// The clip-operation type moved to web_gateway::media_store
+// (transport-unification S8): the /ws lane accumulates with the same
+// type the tunnel's media_clip_ops map stores.
+pub(crate) use crate::web_gateway::DashboardMediaClipOperation;
 
 pub(crate) enum ControlCommand {
     AddIceCandidate(String),

--- a/src/bin/caller/web_gateway/api_core.rs
+++ b/src/bin/caller/web_gateway/api_core.rs
@@ -14,12 +14,32 @@
 ///
 /// Deliberately not carried yet: the acting [`RequestAuthority`] (the
 /// pre-dispatch gates stay the enforcement point until a converted
-/// family consumes actor identity in-handler) and the raw-body spool
-/// for `Streaming` routes (the S8 upload lane).
+/// family consumes actor identity in-handler). The `Streaming`-lane
+/// raw-body spool flows as a [`SpooledBody`] argument to its neutral
+/// fns (the staged-upload commit) rather than a field here — each
+/// transport parses its own wire form (query pairs + Content-Type vs
+/// upload-frame params) at the edge; a `raw_body` field lands when the
+/// S9 transfer-chunk rows move body consumption into dispatch.
 pub(crate) struct ApiRequest {
     pub(crate) params: serde_json::Value,
     /// Byte-range request (fs read; transfer download from S9).
     pub(crate) range: Option<ByteRange>,
+}
+
+/// The `Streaming`-lane raw-body spool (design §2.1/§2.5): however the
+/// bytes arrived — HTTP spooling the socket
+/// ([`crate::web_gateway::stream_body_to_tempfile`]), the tunnel
+/// spooling `upload_start/chunk/end` frames (`InboundUploadState`) —
+/// both end in this one tempfile handle, which the neutral handler
+/// commits (atomic rename into the store). Today's consumer is the
+/// staged-upload commit; the S9 transfer-chunk rows reuse this lane
+/// for their offset-addressed appends.
+pub(crate) struct SpooledBody {
+    pub(crate) tmp: tempfile::NamedTempFile,
+    /// Spooled byte count, as counted by the transport's spooler (HTTP
+    /// asserts it equals `Content-Length`; the tunnel counts received
+    /// chunk bytes).
+    pub(crate) len: usize,
 }
 
 impl ApiRequest {

--- a/src/bin/caller/web_gateway/http.rs
+++ b/src/bin/caller/web_gateway/http.rs
@@ -283,10 +283,11 @@ mod host_header_tests {
 /// Stream the body of an HTTP request into a fresh tempfile, honouring
 /// `Content-Length` and bailing out early if the body exceeds `max_bytes`.
 ///
-/// Returns `(tempfile, size)` on success. Designed so the caller can then
-/// commit the tempfile into the upload store via
-/// [`crate::upload_store::commit_upload`], which atomically renames it
-/// into place.
+/// Returns the [`SpooledBody`] handle on success — the HTTP side of the
+/// Streaming lane (transport-unification S8): the tunnel's upload-frame
+/// spool ends in the same handle, and the shared neutral fns commit it
+/// into the store via [`crate::upload_store::commit_upload`], which
+/// atomically renames it into place.
 ///
 /// This is the binary counterpart to `read_request_body_capped` — same peek-then-
 /// stream pattern, but sinks to disk instead of a UTF-8 `String`.
@@ -295,7 +296,7 @@ pub(crate) async fn stream_body_to_tempfile<S: AsyncRead + Unpin>(
     initial_request_bytes: &[u8],
     stream: &mut S,
     max_bytes: usize,
-) -> Result<(tempfile::NamedTempFile, usize), String> {
+) -> Result<SpooledBody, String> {
     use std::io::Write;
     use tokio::io::AsyncReadExt;
 
@@ -352,7 +353,7 @@ pub(crate) async fn stream_body_to_tempfile<S: AsyncRead + Unpin>(
     tmp.as_file_mut()
         .flush()
         .map_err(|e| format!("flush tempfile: {e}"))?;
-    Ok((tmp, written))
+    Ok(SpooledBody { tmp, len: written })
 }
 
 pub(crate) fn initial_body_bytes(initial_request_bytes: &[u8]) -> Result<&[u8], String> {

--- a/src/bin/caller/web_gateway/media_store.rs
+++ b/src/bin/caller/web_gateway/media_store.rs
@@ -1,0 +1,201 @@
+//! Media/frame-registry store core shared across the media lanes
+//! (transport-unification S8): HQ-frame registration, presence-video
+//! register+record, and the annotation/clip context injections. The
+//! datachannel tunnel's `api_media_*` residue handlers and their `/ws`
+//! twins (`video_frame`, `annotation_attach/submit`, `clip_*`) commit
+//! through these fns — the store behavior is written once; each lane
+//! keeps its own wire framing, response shapes, and log strings.
+//! Moved from `dashboard_control::api_media` (which re-exports them for
+//! its callers); the clip-operation type moved from
+//! `dashboard_control::mod` with its fields widened for the `/ws`
+//! accumulator.
+
+use std::sync::Arc;
+
+/// One in-flight clip operation: `clip_start` metadata plus the
+/// accumulated `(frame_id, base64_jpeg)` frames, injected into the agent
+/// context at `clip_end` when requested. The tunnel keeps these in the
+/// runtime-shared `media_clip_ops` map; the `/ws` lane accumulates
+/// per-connection.
+#[derive(Debug)]
+pub(crate) struct DashboardMediaClipOperation {
+    pub(crate) stream: String,
+    pub(crate) note: String,
+    pub(crate) inject: bool,
+    pub(crate) in_secs: f64,
+    pub(crate) out_secs: f64,
+    pub(crate) fps: u32,
+    pub(crate) expected_frames: usize,
+    pub(crate) frames: Vec<(String, String)>,
+}
+
+/// Register one media frame (annotation, clip frame) in the HQ frame
+/// registry. Returns the saved path and whether registration happened —
+/// a missing registry degrades to `("", false)`, exactly as every lane
+/// always treated it.
+pub(crate) async fn register_dashboard_media_frame(
+    registry: Option<Arc<tokio::sync::RwLock<crate::frames::FrameRegistry>>>,
+    frame_id: &str,
+    stream: &str,
+    note: Option<String>,
+    bytes: &[u8],
+    log_label: &str,
+) -> (String, bool) {
+    let Some(registry) = registry else {
+        return (String::new(), false);
+    };
+    let meta = presence_core::FrameMeta {
+        frame_id: frame_id.to_string(),
+        stream: stream.to_string(),
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        sent_to_live: false,
+        live_resolution: None,
+        hq_resolution: None,
+        note,
+    };
+    let mut reg = registry.write().await;
+    match reg.register(meta, bytes) {
+        Ok(path) => (path.display().to_string(), true),
+        Err(e) => {
+            eprintln!("{log_label} frame registry write failed: {e}");
+            (String::new(), false)
+        }
+    }
+}
+
+/// Register a presence/camera video frame in the HQ frame registry and
+/// feed it to the recording pipeline (auto-starting the stream's
+/// recorder on first frame when enabled and ffmpeg is present,
+/// broadcasting `RecordingStarted`). Returns `(registered, recorded)`.
+pub(crate) async fn register_presence_video_frame(
+    frame_registry: Option<Arc<tokio::sync::RwLock<crate::frames::FrameRegistry>>>,
+    recording_registry: Option<Arc<tokio::sync::RwLock<crate::recording::RecordingRegistry>>>,
+    bus: &crate::event::EventBus,
+    frame_id: &str,
+    stream: &str,
+    jpeg_bytes: &[u8],
+) -> (bool, bool) {
+    let mut registered = false;
+    if let Some(registry) = frame_registry {
+        let meta = presence_core::FrameMeta {
+            frame_id: frame_id.to_string(),
+            stream: stream.to_string(),
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            sent_to_live: true,
+            live_resolution: Some("768x768".to_string()),
+            hq_resolution: None,
+            note: None,
+        };
+        let mut reg = registry.write().await;
+        match reg.register(meta, jpeg_bytes) {
+            Ok(_) => registered = true,
+            Err(e) => eprintln!("presence video frame registry write failed: {e}"),
+        }
+    }
+
+    let mut recorded = false;
+    if let Some(registry) = recording_registry {
+        let mut rec = registry.write().await;
+        if rec.is_enabled() {
+            if !rec.is_recording(stream) && crate::recording::is_ffmpeg_available() {
+                match rec.start_stream(stream).await {
+                    Ok(()) => {
+                        bus.send(crate::event::AppEvent::RecordingStarted {
+                            stream_name: stream.to_string(),
+                        });
+                    }
+                    Err(e) => eprintln!("presence video recording start failed: {e}"),
+                }
+            }
+            if let Err(e) = rec.feed_frame(stream, jpeg_bytes).await {
+                eprintln!("presence video recording frame failed: {e}");
+            } else {
+                recorded = true;
+            }
+        }
+    }
+
+    (registered, recorded)
+}
+
+/// Queue a submitted annotation (note + jpeg) into the agent's context
+/// injection queue. Returns whether the injection actually landed (no
+/// presence/agent connected degrades to `false`).
+pub(crate) fn inject_annotation_context(
+    query_ctx: Option<&crate::web_gateway::WebQueryCtx>,
+    note: &str,
+    data_b64: String,
+) -> bool {
+    let Some(ctx) = query_ctx else {
+        return false;
+    };
+    let Some(ciq) = ctx.context_injection.as_ref() else {
+        return false;
+    };
+    let Ok(mut queue) = ciq.lock() else {
+        return false;
+    };
+    let label = if note.is_empty() {
+        "[User Annotation] User highlighted something on the screen.".to_string()
+    } else {
+        format!("[User Annotation] {note}")
+    };
+    queue.push(crate::event::ContextInjection {
+        text: label,
+        images: vec![crate::conversation::ImageData {
+            media_type: "image/jpeg".to_string(),
+            data: data_b64,
+        }],
+        source: crate::event::InjectionSource::User,
+        target_session_id: None,
+        steer_id: None,
+    });
+    true
+}
+
+/// Queue a completed clip (accumulated frames + metadata) into the
+/// agent's context injection queue. Returns whether the injection
+/// actually landed.
+pub(crate) fn inject_clip_context(
+    query_ctx: Option<&crate::web_gateway::WebQueryCtx>,
+    _clip_id: &str,
+    clip: &DashboardMediaClipOperation,
+) -> bool {
+    let Some(ctx) = query_ctx else {
+        return false;
+    };
+    let Some(ciq) = ctx.context_injection.as_ref() else {
+        return false;
+    };
+    let Ok(mut queue) = ciq.lock() else {
+        return false;
+    };
+    let frames_registered = clip.frames.len();
+    let label = if clip.note.is_empty() {
+        format!(
+            "[Video Clip] {} {:.1}s-{:.1}s ({} frames, {}fps)",
+            clip.stream, clip.in_secs, clip.out_secs, frames_registered, clip.fps,
+        )
+    } else {
+        format!(
+            "[Video Clip] {} {:.1}s-{:.1}s ({} frames, {}fps). {}",
+            clip.stream, clip.in_secs, clip.out_secs, frames_registered, clip.fps, clip.note,
+        )
+    };
+    let images = clip
+        .frames
+        .iter()
+        .map(|(_, data)| crate::conversation::ImageData {
+            media_type: "image/jpeg".to_string(),
+            data: data.clone(),
+        })
+        .collect();
+    queue.push(crate::event::ContextInjection {
+        text: label,
+        images,
+        source: crate::event::InjectionSource::User,
+        target_session_id: None,
+        steer_id: None,
+    });
+    true
+}

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -34,6 +34,9 @@ pub(crate) use api_core::*;
 mod session_catalog;
 pub(crate) use session_catalog::*;
 
+mod media_store;
+pub(crate) use media_store::*;
+
 mod routes_files;
 pub(crate) use routes_files::*;
 

--- a/src/bin/caller/web_gateway/routes_files.rs
+++ b/src/bin/caller/web_gateway/routes_files.rs
@@ -111,6 +111,9 @@ pub(crate) fn pending_upload_session_dir(
 /// the transport edge resolves the real `intendant_home()`, tests inject
 /// a tempdir so a projectless commit never writes the machine's real
 /// global store. Project-rooted commits never read it.
+///
+/// `body` is the Streaming lane's common spool handle (S8): HTTP spools
+/// the socket, the tunnel spools upload frames — same commit either way.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn current_upload_commit_response_body(
     state_root: &std::path::Path,
@@ -120,8 +123,7 @@ pub(crate) fn current_upload_commit_response_body(
     name: &str,
     mime: &str,
     requested_destination: crate::upload_store::UploadDestination,
-    tmp: tempfile::NamedTempFile,
-    size: usize,
+    body: SpooledBody,
     bus: &crate::event::EventBus,
 ) -> (&'static str, String) {
     let scope = crate::global_store::StoreScope::resolve_in(project_root, state_root);
@@ -144,10 +146,10 @@ pub(crate) fn current_upload_commit_response_body(
     };
     let destination = effective_upload_destination(requested_destination, session_log.is_some());
     match crate::upload_store::commit_upload(
-        tmp,
+        body.tmp,
         name,
         mime,
-        size as u64,
+        body.len as u64,
         destination,
         &session_dir,
         &session_id,
@@ -207,9 +209,10 @@ pub(crate) fn current_upload_delete_response_body(
 
 /// Transport-neutral core of the staged-upload commit (`POST
 /// /api/session/current/uploads` once its transport has spooled the raw
-/// body; tunnel twin `api_session_current_upload`'s upload_end leg): the
-/// shared (status, body) commit core — session-dir resolution, store
-/// commit, `UploadReady` broadcast — under the wildcard-CORS tail.
+/// body into the [`SpooledBody`] handle; tunnel twin
+/// `api_session_current_upload`'s upload_end leg): the shared
+/// (status, body) commit core — session-dir resolution, store commit,
+/// `UploadReady` broadcast — under the wildcard-CORS tail.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn current_upload_commit_api_response(
     state_root: &std::path::Path,
@@ -219,8 +222,7 @@ pub(crate) fn current_upload_commit_api_response(
     name: &str,
     mime: &str,
     requested_destination: crate::upload_store::UploadDestination,
-    tmp: tempfile::NamedTempFile,
-    size: usize,
+    body: SpooledBody,
     bus: &crate::event::EventBus,
 ) -> ApiResponse {
     let (status, body) = current_upload_commit_response_body(
@@ -231,8 +233,7 @@ pub(crate) fn current_upload_commit_api_response(
         name,
         mime,
         requested_destination,
-        tmp,
-        size,
+        body,
         bus,
     );
     session_wildcard_json_response(status_line_code(status), body)
@@ -2693,7 +2694,7 @@ pub(crate) async fn handle_current_uploads_post_in_state_root(
                 let status = if e.contains("too large") { 413 } else { 400 };
                 session_wildcard_json_error(status, &e)
             }
-            Ok((tmp, size)) => current_upload_commit_api_response(
+            Ok(body) => current_upload_commit_api_response(
                 state_root,
                 project_root_for_changes.as_deref(),
                 session_log.as_ref(),
@@ -2701,8 +2702,7 @@ pub(crate) async fn handle_current_uploads_post_in_state_root(
                 &name,
                 &mime,
                 requested_destination,
-                tmp,
-                size,
+                body,
                 &bus,
             ),
         };

--- a/src/bin/caller/web_gateway/ws_session.rs
+++ b/src/bin/caller/web_gateway/ws_session.rs
@@ -210,18 +210,9 @@ pub(crate) async fn ws_inbound_task(
     let mut is_active = false;
 
     // Per-connection clip accumulators for batched clip_frame messages
-    struct ClipAccumulator {
-        stream: String,
-        note: String,
-        inject: bool,
-        in_secs: f64,
-        out_secs: f64,
-        fps: u32,
-        #[allow(dead_code)]
-        expected: usize,
-        frames: Vec<(String, String)>, // (frame_id, base64_data)
-    }
-    let mut clip_accumulators: std::collections::HashMap<String, ClipAccumulator> =
+    // Per-connection accumulators, in the same clip-operation shape the
+    // tunnel's media_clip_ops map stores (web_gateway::media_store).
+    let mut clip_accumulators: std::collections::HashMap<String, DashboardMediaClipOperation> =
         std::collections::HashMap::new();
 
     // Display IDs this peer has WebRTC connections to,
@@ -715,7 +706,11 @@ pub(crate) async fn ws_inbound_task(
                         }
                     }
                     Some("video_frame") => {
-                        // Browser sends a video frame for HQ archival in the frame registry.
+                        // Browser sends a video frame for HQ archival in the
+                        // frame registry plus the recording pipeline
+                        // (auto-starts on first frame) — the same store fn
+                        // the tunnel's api_presence_video_frame commits
+                        // through (fire-and-forget: no response frame).
                         let frame_id = json["frame_id"].as_str().unwrap_or("").to_string();
                         let stream = json["stream"].as_str().unwrap_or("cam0").to_string();
                         if let Some(data_b64) = json["data"].as_str() {
@@ -723,40 +718,15 @@ pub(crate) async fn ws_inbound_task(
                             if let Ok(jpeg_bytes) =
                                 base64::engine::general_purpose::STANDARD.decode(data_b64)
                             {
-                                // Register in frame registry
-                                if let Some(ref registry) = frame_registry_inbound {
-                                    let meta = presence_core::FrameMeta {
-                                        frame_id: frame_id.clone(),
-                                        stream: stream.clone(),
-                                        timestamp: chrono::Utc::now().to_rfc3339(),
-                                        sent_to_live: true,
-                                        live_resolution: Some("768x768".to_string()),
-                                        hq_resolution: None,
-                                        note: None,
-                                    };
-                                    let mut reg = registry.write().await;
-                                    if let Err(e) = reg.register(meta, &jpeg_bytes) {
-                                        eprintln!("frame registry write failed: {}", e);
-                                    }
-                                }
-                                // Feed into recording pipeline (auto-starts on first frame)
-                                if let Some(ref rec_reg) = recording_registry_inbound {
-                                    let mut rreg = rec_reg.write().await;
-                                    if rreg.is_enabled() {
-                                        if !rreg.is_recording(&stream)
-                                            && crate::recording::is_ffmpeg_available()
-                                        {
-                                            if let Err(e) = rreg.start_stream(&stream).await {
-                                                eprintln!("camera recording start failed: {}", e);
-                                            } else {
-                                                bus_inbound.send(AppEvent::RecordingStarted {
-                                                    stream_name: stream.clone(),
-                                                });
-                                            }
-                                        }
-                                        let _ = rreg.feed_frame(&stream, &jpeg_bytes).await;
-                                    }
-                                }
+                                let _ = register_presence_video_frame(
+                                    frame_registry_inbound.clone(),
+                                    recording_registry_inbound.clone(),
+                                    &bus_inbound,
+                                    &frame_id,
+                                    &stream,
+                                    &jpeg_bytes,
+                                )
+                                .await;
                             }
                         }
                     }
@@ -767,7 +737,8 @@ pub(crate) async fn ws_inbound_task(
                         // a pending attachment and submits it with the next task.
                         //
                         // Works regardless of presence/agent state — attachments
-                        // are independent of any running task.
+                        // are independent of any running task. Same store fn as
+                        // the tunnel's api_media_annotation_attach.
                         let frame_id = json["frame_id"].as_str().unwrap_or("").to_string();
                         let stream = json["stream"].as_str().unwrap_or("annotation").to_string();
                         let note = json["note"].as_str().unwrap_or("").to_string();
@@ -776,34 +747,19 @@ pub(crate) async fn ws_inbound_task(
                             if let Ok(jpeg_bytes) =
                                 base64::engine::general_purpose::STANDARD.decode(data_b64)
                             {
-                                let mut saved_path = String::new();
-                                let mut registered = false;
-                                if let Some(ref registry) = frame_registry_inbound {
-                                    let meta = presence_core::FrameMeta {
-                                        frame_id: frame_id.clone(),
-                                        stream: stream.clone(),
-                                        timestamp: chrono::Utc::now().to_rfc3339(),
-                                        sent_to_live: false,
-                                        live_resolution: None,
-                                        hq_resolution: None,
-                                        note: if note.is_empty() {
-                                            None
-                                        } else {
-                                            Some(note.clone())
-                                        },
-                                    };
-                                    let mut reg = registry.write().await;
-                                    match reg.register(meta, &jpeg_bytes) {
-                                        Ok(path) => {
-                                            saved_path = path.display().to_string();
-                                            registered = true;
-                                        }
-                                        Err(e) => eprintln!(
-                                            "annotation_attach frame registry write failed: {}",
-                                            e
-                                        ),
-                                    }
-                                }
+                                let (saved_path, registered) = register_dashboard_media_frame(
+                                    frame_registry_inbound.clone(),
+                                    &frame_id,
+                                    &stream,
+                                    if note.is_empty() {
+                                        None
+                                    } else {
+                                        Some(note.clone())
+                                    },
+                                    &jpeg_bytes,
+                                    "annotation_attach",
+                                )
+                                .await;
                                 let _ = direct_tx_inbound.send(
                                     serde_json::json!({
                                         "t": "annotation_attached",
@@ -827,7 +783,10 @@ pub(crate) async fn ws_inbound_task(
                         }
                     }
                     Some("annotation_submit") => {
-                        // User drew annotations on a frame and submitted it with a note.
+                        // User drew annotations on a frame and submitted it
+                        // with a note — register + optional context injection
+                        // through the same store fns as the tunnel's
+                        // api_media_annotation_submit.
                         let frame_id = json["frame_id"].as_str().unwrap_or("").to_string();
                         let stream = json["stream"].as_str().unwrap_or("annotation").to_string();
                         let note = json["note"].as_str().unwrap_or("").to_string();
@@ -837,57 +796,25 @@ pub(crate) async fn ws_inbound_task(
                             if let Ok(jpeg_bytes) =
                                 base64::engine::general_purpose::STANDARD.decode(data_b64)
                             {
-                                // Register in frame registry
-                                let mut saved_path = String::new();
-                                if let Some(ref registry) = frame_registry_inbound {
-                                    let meta = presence_core::FrameMeta {
-                                        frame_id: frame_id.clone(),
-                                        stream: stream.clone(),
-                                        timestamp: chrono::Utc::now().to_rfc3339(),
-                                        sent_to_live: false,
-                                        live_resolution: None,
-                                        hq_resolution: None,
-                                        note: if note.is_empty() {
-                                            None
-                                        } else {
-                                            Some(note.clone())
-                                        },
-                                    };
-                                    let mut reg = registry.write().await;
-                                    match reg.register(meta, &jpeg_bytes) {
-                                        Ok(path) => saved_path = path.display().to_string(),
-                                        Err(e) => eprintln!(
-                                            "annotation frame registry write failed: {}",
-                                            e
-                                        ),
-                                    }
-                                }
-                                // Optionally inject into agent conversation
-                                let mut injected_to_queue = false;
-                                if inject {
-                                    if let Some(ref ctx) = query_ctx_inbound {
-                                        if let Some(ref ciq) = ctx.context_injection {
-                                            if let Ok(mut q) = ciq.lock() {
-                                                let label = if note.is_empty() {
-                                                    "[User Annotation] User highlighted something on the screen.".to_string()
-                                                } else {
-                                                    format!("[User Annotation] {}", note)
-                                                };
-                                                q.push(crate::event::ContextInjection {
-                                                    text: label,
-                                                    images: vec![crate::conversation::ImageData {
-                                                        media_type: "image/jpeg".to_string(),
-                                                        data: data_b64.to_string(),
-                                                    }],
-                                                    source: crate::event::InjectionSource::User,
-                                                    target_session_id: None,
-                                                    steer_id: None,
-                                                });
-                                                injected_to_queue = true;
-                                            }
-                                        }
-                                    }
-                                }
+                                let (saved_path, _registered) = register_dashboard_media_frame(
+                                    frame_registry_inbound.clone(),
+                                    &frame_id,
+                                    &stream,
+                                    if note.is_empty() {
+                                        None
+                                    } else {
+                                        Some(note.clone())
+                                    },
+                                    &jpeg_bytes,
+                                    "annotation",
+                                )
+                                .await;
+                                let injected_to_queue = inject
+                                    && inject_annotation_context(
+                                        query_ctx_inbound.as_ref(),
+                                        &note,
+                                        data_b64.to_string(),
+                                    );
                                 // Send path back to browser. Report whether the injection
                                 // actually landed in the queue (not just whether the user
                                 // pressed Send), so the UI doesn't lie when no presence is
@@ -932,14 +859,14 @@ pub(crate) async fn ws_inbound_task(
                         let total = json["total_frames"].as_u64().unwrap_or(0) as usize;
                         clip_accumulators.insert(
                             clip_id.clone(),
-                            ClipAccumulator {
+                            DashboardMediaClipOperation {
                                 stream,
                                 note,
                                 inject,
                                 in_secs,
                                 out_secs,
                                 fps,
-                                expected: total,
+                                expected_frames: total,
                                 frames: Vec::with_capacity(total),
                             },
                         );
@@ -956,26 +883,21 @@ pub(crate) async fn ws_inbound_task(
                         let clip_id = json["clip_id"].as_str().unwrap_or("").to_string();
                         let frame_id = json["frame_id"].as_str().unwrap_or("").to_string();
                         if let Some(data_b64) = json["data"].as_str() {
-                            // Register frame in frame registry
+                            // Register frame in frame registry — the same
+                            // store fn as the tunnel's api_media_clip_frame.
                             use base64::Engine;
                             if let Ok(jpeg_bytes) =
                                 base64::engine::general_purpose::STANDARD.decode(data_b64)
                             {
-                                if let Some(ref registry) = frame_registry_inbound {
-                                    let meta = presence_core::FrameMeta {
-                                        frame_id: frame_id.clone(),
-                                        stream: format!("clip:{}", clip_id),
-                                        timestamp: chrono::Utc::now().to_rfc3339(),
-                                        sent_to_live: false,
-                                        live_resolution: None,
-                                        hq_resolution: None,
-                                        note: None,
-                                    };
-                                    let mut reg = registry.write().await;
-                                    if let Err(e) = reg.register(meta, &jpeg_bytes) {
-                                        eprintln!("clip frame registry write failed: {}", e);
-                                    }
-                                }
+                                let _ = register_dashboard_media_frame(
+                                    frame_registry_inbound.clone(),
+                                    &frame_id,
+                                    &format!("clip:{}", clip_id),
+                                    None,
+                                    &jpeg_bytes,
+                                    "clip",
+                                )
+                                .await;
                             }
                             // Accumulate for context injection
                             if let Some(acc) = clip_accumulators.get_mut(&clip_id) {
@@ -985,51 +907,17 @@ pub(crate) async fn ws_inbound_task(
                     }
                     Some("clip_end") => {
                         let clip_id = json["clip_id"].as_str().unwrap_or("").to_string();
-                        let mut injected = false;
 
                         if let Some(acc) = clip_accumulators.remove(&clip_id) {
                             let frames_registered = acc.frames.len();
-                            if acc.inject {
-                                if let Some(ref ctx) = query_ctx_inbound {
-                                    if let Some(ref ciq) = ctx.context_injection {
-                                        if let Ok(mut q) = ciq.lock() {
-                                            let label = if acc.note.is_empty() {
-                                                format!(
-                                                    "[Video Clip] {} {:.1}s-{:.1}s ({} frames, {}fps)",
-                                                    acc.stream,
-                                                    acc.in_secs,
-                                                    acc.out_secs,
-                                                    frames_registered, acc.fps,
-                                                )
-                                            } else {
-                                                format!(
-                                                    "[Video Clip] {} {:.1}s-{:.1}s ({} frames, {}fps). {}",
-                                                    acc.stream,
-                                                    acc.in_secs,
-                                                    acc.out_secs,
-                                                    frames_registered, acc.fps, acc.note,
-                                                )
-                                            };
-                                            let images: Vec<crate::conversation::ImageData> = acc
-                                                .frames
-                                                .iter()
-                                                .map(|(_, b64)| crate::conversation::ImageData {
-                                                    media_type: "image/jpeg".to_string(),
-                                                    data: b64.clone(),
-                                                })
-                                                .collect();
-                                            q.push(crate::event::ContextInjection {
-                                                text: label,
-                                                images,
-                                                source: crate::event::InjectionSource::User,
-                                                target_session_id: None,
-                                                steer_id: None,
-                                            });
-                                            injected = true;
-                                        }
-                                    }
-                                }
-                            }
+                            // Optional context injection through the same
+                            // store fn as the tunnel's api_media_clip_end.
+                            let injected = acc.inject
+                                && inject_clip_context(
+                                    query_ctx_inbound.as_ref(),
+                                    &clip_id,
+                                    &acc,
+                                );
 
                             let _ = direct_tx_inbound.send(
                                 serde_json::json!({


### PR DESCRIPTION
Stage S8 of the transport-unification program (design §6 S8), second PR:

- **SpooledBody** (design §2.1/§2.5): the Streaming lane's common raw-body handle — HTTP socket spool and tunnel upload-frame spool end in the same tempfile handle, committed by the one neutral staged-upload fn. S9's transfer-chunk rows reuse this exact lane (seam documented on the type).
- **Media store convergence**: the media/frame-registry store fns (frame registration, presence video register+record, annotation/clip context injection) move to a neutral web_gateway home; the /ws twins (`video_frame`, `annotation_*`, `clip_*`) stop duplicating them inline and call the same store code the tunnel residue (`api_media_*`) calls. Wire frames byte-identical on both lanes; residue keeps its names, no rows added.

Depends on #189 (branched from transport-s8a).