### PR TITLE
transport F6: custody family onto the daemonApi facade with availability honesty

### DIFF
--- a/scripts/validate-client-egress.cjs
+++ b/scripts/validate-client-egress.cjs
@@ -312,7 +312,10 @@ async function main() {
     await page.locator('#register').click();
     await page.waitForFunction(() => !document.getElementById('manage').classList.contains('hidden'), { timeout: START_TIMEOUT_MS });
     await page.locator('#claim').click();
-    await page.waitForFunction(() => document.getElementById('claim-status').textContent.includes('Rendezvous route claimed'), { timeout: START_TIMEOUT_MS });
+    // Two success copies since the first-owner bootstrap landed: a
+    // daemon-minted phrase claims AND enrolls ("…enrolled as its first
+    // owner…"); an account-route claim keeps the original copy.
+    await page.waitForFunction(() => /Rendezvous route claimed|enrolled as its first owner/.test(document.getElementById('claim-status').textContent), { timeout: START_TIMEOUT_MS });
     const me = await page.evaluate(async () => fetch('/api/me').then(r => r.json()));
     writeOperatorIamGrant(daemonHome, me.user || me);
 

--- a/scripts/validate-connect-hosted-mvp.cjs
+++ b/scripts/validate-connect-hosted-mvp.cjs
@@ -405,7 +405,10 @@ async function main() {
     });
 
     await click(page, '#claim');
-    await page.waitForFunction(() => document.getElementById('claim-status').textContent.includes('Rendezvous route claimed'), {
+    // Two success copies since the first-owner bootstrap landed: a
+    // daemon-minted phrase claims AND enrolls ("…enrolled as its first
+    // owner…"); an account-route claim keeps the original copy.
+    await page.waitForFunction(() => /Rendezvous route claimed|enrolled as its first owner/.test(document.getElementById('claim-status').textContent), {
       timeout: START_TIMEOUT_MS,
     });
 

--- a/scripts/validate-credential-leases.cjs
+++ b/scripts/validate-credential-leases.cjs
@@ -254,7 +254,10 @@ async function main() {
     await page.locator('#register').click();
     await page.waitForFunction(() => !document.getElementById('manage').classList.contains('hidden'), { timeout: START_TIMEOUT_MS });
     await page.locator('#claim').click();
-    await page.waitForFunction(() => document.getElementById('claim-status').textContent.includes('Rendezvous route claimed'), { timeout: START_TIMEOUT_MS });
+    // Two success copies since the first-owner bootstrap landed: a
+    // daemon-minted phrase claims AND enrolls ("…enrolled as its first
+    // owner…"); an account-route claim keeps the original copy.
+    await page.waitForFunction(() => /Rendezvous route claimed|enrolled as its first owner/.test(document.getElementById('claim-status').textContent), { timeout: START_TIMEOUT_MS });
     const me = await page.evaluate(async () => fetch('/api/me').then(r => r.json()));
     writeOperatorIamGrant(daemonHome, me.user || me);
     console.log('PASS lease-claim account registered, daemon claimed, operator grant seeded');
@@ -601,7 +604,9 @@ async function main() {
     // the same flag must not duplicate grants or grow the audit log.
     const ownerHome = path.join(tmp, 'owner-home');
     fs.mkdirSync(ownerHome, { recursive: true });
-    const ownerFp = 'E2E_Owner_Key-Fingerprint';
+    // Must satisfy the daemon's shape check (exactly 43 base64url chars —
+    // startup rejects garbage --owner values since d36f57fe).
+    const ownerFp = 'E2E-Owner-Key-Fingerprint-000000000000000AA';
     // Offset past the org-validator port block (8898/8899).
     const ownerPort = options.daemonPort + 11;
     const ownerIamPath = path.join(ownerHome, '.intendant', 'access-certs', 'iam.json');

--- a/scripts/validate-org-grants.cjs
+++ b/scripts/validate-org-grants.cjs
@@ -399,7 +399,10 @@ async function main() {
     await hosted.locator('#register').click();
     await hosted.waitForFunction(() => !document.getElementById('manage').classList.contains('hidden'), { timeout: START_TIMEOUT_MS });
     await hosted.locator('#claim').click();
-    await hosted.waitForFunction(() => document.getElementById('claim-status').textContent.includes('Rendezvous route claimed'), { timeout: START_TIMEOUT_MS });
+    // Two success copies since the first-owner bootstrap landed: a
+    // daemon-minted phrase claims AND enrolls ("…enrolled as its first
+    // owner…"); an account-route claim keeps the original copy.
+    await hosted.waitForFunction(() => /Rendezvous route claimed|enrolled as its first owner/.test(document.getElementById('claim-status').textContent), { timeout: START_TIMEOUT_MS });
 
     // Phase 5 follow-on: the passkey ceremony evaluated the PRF extension,
     // so this tab holds the fleet-encryption secret.

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -3488,7 +3488,13 @@ mod tests {
         // the pairing set, and the coordinator route). The `api_transfer_*`
         // methods join when their HTTP rows land (task #6, /api/transfers);
         // adding or dropping an entry updates this list in the same change,
-        // deliberately.
+        // deliberately. The F6 credential-custody family (api_credential_*,
+        // api_daemon_vault_*) is deliberately NOT here and stays out:
+        // custody is tunnel-scoped by design with no HTTP rows planned
+        // (docs/src/credential-custody.md; the transport design parks
+        // custody rows as an explicit future decision), so its facade
+        // calls run with no fallback lane — absence below is the contract,
+        // not a gap.
         let expected: std::collections::BTreeSet<&str> = [
             "api_fs_stat",
             "api_fs_list",

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -2958,7 +2958,15 @@ mod tests {
             resp.contains("200 OK"),
             "agent card should serve unauthenticated, got: {resp}"
         );
-        assert!(!resp.contains("401"));
+        // Status line only: the card body embeds ws:// advertise URLs with
+        // the kernel-assigned test port, so scanning the whole response for
+        // "401" flaked whenever the port happened to contain it (seen live
+        // with port 40169 in a merge-group run).
+        let status_line = resp.lines().next().unwrap_or("");
+        assert!(
+            !status_line.contains("401"),
+            "agent card must not challenge for auth, got: {status_line}"
+        );
         handle.abort();
     }
 

--- a/static/app.html
+++ b/static/app.html
@@ -26123,10 +26123,13 @@ async function accessFleetRefreshProvenance() {
 // staged uploads), the F2 sessions-family reads, the F3 settings/keys
 // family (settings GET/POST, api-keys save, key-status, project-root,
 // external-agents, displays), the F4 access dialogs family
-// (overview/enrollment/connect/tier + IAM grant writes), and the F5
+// (overview/enrollment/connect/tier + IAM grant writes), the F5
 // peers/approvals/coordinator family (peer list + quick controls, the
 // pairing dialogs, the coordinator forms, and the peer WebRTC signal
-// relays); the remaining
+// relays), and the F6 credential-custody family (vault leases, the
+// custody trail, the daemon vault store + deposit lane, client-egress
+// registration/probe — tunnel-only methods whose per-cause availability
+// the vault UI surfaces); the remaining
 // `rpcOrHttp`/`jsonFetch` call
 // sites move onto these verbs family by family per the design's frontend
 // track. The boot smoke's window.qa.daemonApi() probe asserts the facade
@@ -26171,7 +26174,12 @@ async function accessFleetRefreshProvenance() {
 // delegate IAM to the federation ladder, S7). The
 // `api_transfer_*` methods are deliberately absent: they have no HTTP rows
 // until the server-track stage that adds /api/transfers (task #6); F1 adds
-// their entries when those rows land.
+// their entries when those rows land. The F6 credential-custody family
+// (api_credential_*, api_daemon_vault_*) is deliberately absent too, and
+// stays so: custody is tunnel-scoped by design — no HTTP rows exist or
+// are planned (docs/src/credential-custody.md; the transport design
+// parks custody HTTP rows as an explicit future decision), so those
+// methods ride the facade with no fallback lane at all.
 // Entry shape: verb + path template (`{name}` segments are lifted from
 // params), `alias` = capture-name -> param-key lift map (the session rows
 // capture `id` while the tunnel's canonical param is `session_id` — the
@@ -27068,6 +27076,10 @@ window.qa = Object.assign(window.qa || {}, {
         api_session_current_upload: daemonApiAvailability('api_session_current_upload'),
         api_sessions: daemonApiAvailability('api_sessions'),
         api_sessions_stream: daemonApiAvailability('api_sessions_stream'),
+        // Tunnel-only custody sample (F6): 'denied' vs 'unsupported' vs
+        // 'transport-down' is directly observable here — no HTTP twin
+        // ever answers for it.
+        api_credential_lease_status: daemonApiAvailability('api_credential_lease_status'),
       },
       descriptor: {
         methods: Object.keys(DAEMON_API_HTTP_MAP).length,
@@ -27146,19 +27158,25 @@ const vaultRevealedEntries = new Set();
    copying between them is an explicit user action, never implicit. */
 function vaultDaemonStoreReady() {
   if (DASHBOARD_CONNECT_MODE) return false; // hosted tabs use the account store
-  try {
-    const status = window.intendantDashboardControl?.status?.();
-    if (!status?.connected || !status?.verifiedBinding?.ok) return false;
-    // An empty feature list means the hello_ack hasn't landed yet: fall
-    // through and let the RPCs answer (mirrors vaultLeaseTransportReady).
-    const features = status.controlFeatures;
-    if (Array.isArray(features) && features.length) {
-      return features.includes('api_daemon_vault_fetch');
-    }
-    return true;
-  } catch {
-    return false;
+  // daemonApi availability (transport F6): the tunnel status boolean when
+  // it has landed (false = this session's role is refused the custody
+  // gate), the hello_ack features list before that (absent = the daemon
+  // predates local vault storage), optimistic only while the handshake is
+  // still in flight — the pre-facade "let the RPCs answer" semantics.
+  return daemonApi.availability('api_daemon_vault_fetch').ok;
+}
+
+/* Why the daemon store is out of reach, for the 'unavailable' status line
+   — the honest split the conflated pre-facade copy could not make. */
+function vaultDaemonStoreUnavailableText() {
+  const reason = daemonApi.availability('api_daemon_vault_fetch').reason;
+  if (reason === 'denied') {
+    return "This session's role lacks credentials.manage, so this daemon's local vault store is out of reach. Hosted Connect dashboards use the account vault instead.";
   }
+  if (reason === 'unsupported') {
+    return 'This daemon predates local vault storage — upgrade it to keep a sealed vault here. Hosted Connect dashboards use the account vault instead.';
+  }
+  return 'No vault store reachable yet: the control channel is still connecting (retries automatically). Hosted Connect dashboards use the account vault instead.';
 }
 
 function vaultBackendKind() {
@@ -27415,6 +27433,9 @@ async function vaultServerFetch() {
       vault: result?.vault || null,
     };
   }
+  // The account store lives on the Connect service, not on any daemon —
+  // deliberately raw fetch, outside the daemonApi facade (the facade
+  // speaks to daemons only; rendezvous calls stay on their own lane).
   const resp = await fetch(accessFleetHostedUrl('/api/vault'));
   if (resp.status === 401) return { authenticated: false };
   const body = await resp.json().catch(() => ({}));
@@ -28206,7 +28227,8 @@ const VAULT_OFFLINE_CHOICES = [
 const VAULT_OFFLINE_DEFAULT_MS = 24 * 60 * 60 * 1000;
 
 const vaultLeaseState = {
-  supported: null,   // null until first probe; false when the daemon lacks the RPCs / gate
+  supported: null,   // null until first verdict; false only on the daemon's own refusal
+  availability: '',  // honest cause: 'denied' | 'unsupported' | 'connected' (transport F6)
   leases: [],
   egress: [],        // active client-egress relays (the path indicator)
   expiredNote: '',
@@ -28380,40 +28402,47 @@ async function vaultOauthAccessTokenMaterial(entry, kind) {
   return vaultOauthAccessMaterial(kind, secretJson);
 }
 
+/* Availability of the lease RPC family here (transport F6, design §3.4):
+   the daemon's own word, before any RPC fires. Reasons the render paths
+   branch on — 'denied' (the status boolean says this session's role is
+   refused credentials.manage; custody methods have no runtime-ready
+   ladder, so false means exactly that), 'unsupported' (the hello_ack
+   features list omits the family — the daemon predates it),
+   'transport-down' (no verified tunnel; custody has no HTTP twin by
+   design, so no other lane can answer), 'connected' (go — optimistically
+   so while the handshake is still digesting, letting the RPCs answer
+   exactly as the pre-facade probes did). */
+function vaultLeaseAvailability() {
+  return daemonApi.availability('api_credential_lease_status');
+}
+
 function vaultLeaseTransportReady() {
-  try {
-    const status = window.intendantDashboardControl?.status?.();
-    if (!status?.connected || !status?.verifiedBinding?.ok) return false;
-    // Leases need the credential RPC family. A daemon that advertises its
-    // control surface but not these methods is too old — report
-    // unsupported instead of firing calls that fail one by one. An empty
-    // list means the hello_ack hasn't landed yet: fall through and let
-    // the RPCs answer.
-    const features = status.controlFeatures;
-    if (Array.isArray(features) && features.length) {
-      return features.includes('api_credential_lease_status');
-    }
-    return true;
-  } catch {
-    return false;
-  }
+  return vaultLeaseAvailability().ok;
 }
 
-function vaultLeaseRpc(method, params = {}) {
-  return window.intendantDashboardControl.request(method, params, { timeoutMs: 15000 });
+/* One custody RPC. Tunnel-only by design (docs/src/credential-custody.md;
+   the transport design keeps the family off HTTP rows), which the facade
+   enforces: no fallback lane exists, so a custody mutation can never
+   replay elsewhere after an ambiguous failure, and a down tunnel rejects
+   immediately. Resolves with the result payload (the pre-facade contract
+   every call site and window.intendantVault.probeEgress keeps);
+   rejections are DaemonApiError, whose `kind` the refreshers classify
+   into availability verdicts. Per-method timeouts live in
+   dashboardControlRequestTimeoutMs — the `{ timeoutMs: 15000 }` option
+   the pre-facade call passed here was silently ignored by the request
+   verb; the custody rows of that table now carry the intent. */
+async function vaultLeaseRpc(method, params = {}) {
+  const { body } = await daemonApi.request(method, params);
+  return body;
 }
 
-/* Whether the tunneled daemon advertises local vault storage — strict
-   (feature must be listed) because this only gates an optional action. */
+/* Whether the tunneled daemon offers local vault storage to THIS session —
+   'connected' only: the daemon must have confirmed the method (status
+   boolean or features list), because this gates an optional action (the
+   sealed-copy button) that a credentials.manage-denied session or an
+   older daemon could only bounce. */
 function vaultTunnelDaemonVaultAvailable() {
-  try {
-    const status = window.intendantDashboardControl?.status?.();
-    if (!status?.connected || !status?.verifiedBinding?.ok) return false;
-    const features = status.controlFeatures;
-    return Array.isArray(features) && features.includes('api_daemon_vault_publish');
-  } catch {
-    return false;
-  }
+  return daemonApi.availability('api_daemon_vault_publish').reason === 'connected';
 }
 
 /* The lease kind a vault entry fuels, or null when it cannot fuel.
@@ -28432,11 +28461,22 @@ function vaultEntryLeaseKind(entry) {
 }
 
 async function vaultRefreshLeases({ force = false } = {}) {
-  if (!vaultLeaseTransportReady()) return;
+  const avail = vaultLeaseAvailability();
+  if (!avail.ok) {
+    // The daemon already answered through features/status — record the
+    // verdict without firing RPCs that can only bounce (the render paths
+    // read the same availability live, so no re-render is needed here).
+    if (avail.reason === 'denied' || avail.reason === 'unsupported') {
+      vaultLeaseState.supported = false;
+      vaultLeaseState.availability = avail.reason;
+    }
+    return;
+  }
   if (!force && Date.now() - vaultLeaseState.fetchedAt < 30_000) return;
   try {
     const result = await vaultLeaseRpc('api_credential_lease_status');
     vaultLeaseState.supported = true;
+    vaultLeaseState.availability = 'connected';
     vaultLeaseState.leases = Array.isArray(result?.leases) ? result.leases : [];
     vaultLeaseState.egress = Array.isArray(result?.egress) ? result.egress : [];
     vaultLeaseState.expiredNote = String(result?.expired_note || '');
@@ -28447,12 +28487,20 @@ async function vaultRefreshLeases({ force = false } = {}) {
     }
     vaultEgressEnsure().catch(() => {});
   } catch (err) {
-    const message = String(err?.message || err);
-    // A daemon predating the lease RPCs, or a session without the
-    // credentials.manage gate, reads as unsupported rather than broken.
-    vaultLeaseState.supported = false;
-    vaultLeaseState.lastError = message;
+    vaultLeaseState.lastError = String(err?.message || err);
     vaultLeaseState.fetchedAt = Date.now();
+    // Availability honesty (transport F6): only the daemon's own refusals
+    // are verdicts about this session or this daemon. 'denied' is the
+    // authorizer refusing the gate, 'unavailable' is a daemon without the
+    // method (races where the pre-flight was still optimistic). A timeout
+    // or a dropped channel says nothing about support — keep the last
+    // known verdict and surface the error text instead of the old
+    // conflated "cannot manage leases" reading.
+    const kind = err?.kind || '';
+    if (kind === 'denied' || kind === 'unavailable') {
+      vaultLeaseState.supported = false;
+      vaultLeaseState.availability = kind === 'denied' ? 'denied' : 'unsupported';
+    }
   }
   renderAccessVaultSection();
   refreshUnfueledEmptyState().catch(() => {});
@@ -28460,20 +28508,41 @@ async function vaultRefreshLeases({ force = false } = {}) {
 }
 
 /* Custody trail: the daemon's own record of lease/relay lifecycle events,
-   fetched over the same credentials.manage-gated channel as the leases. */
-const custodyTrailState = { events: [], supported: null, fetchedAt: 0 };
+   fetched over the same credentials.manage-gated channel as the leases.
+   `availability` carries the honest cause when supported goes false:
+   'denied' (role refused the gate) vs 'unsupported' (daemon predates the
+   trail) — transient lane failures flip neither. */
+const custodyTrailState = { events: [], supported: null, availability: '', fetchedAt: 0 };
 
 async function vaultRefreshCustody({ force = false } = {}) {
-  if (!vaultLeaseTransportReady()) return;
+  const avail = daemonApi.availability('api_credential_custody_trail');
+  if (!avail.ok) {
+    if (avail.reason === 'denied' || avail.reason === 'unsupported') {
+      const changed = custodyTrailState.supported !== false
+        || custodyTrailState.availability !== avail.reason;
+      custodyTrailState.supported = false;
+      custodyTrailState.availability = avail.reason;
+      custodyTrailState.fetchedAt = Date.now();
+      if (changed) renderAccessCustodySection();
+    }
+    return;
+  }
   if (!force && Date.now() - custodyTrailState.fetchedAt < 30_000) return;
   custodyTrailState.fetchedAt = Date.now();
   try {
     const result = await vaultLeaseRpc('api_credential_custody_trail');
     custodyTrailState.events = Array.isArray(result?.events) ? result.events : [];
     custodyTrailState.supported = true;
-  } catch {
-    // Older daemon or a session without credentials.manage.
-    custodyTrailState.supported = false;
+    custodyTrailState.availability = 'connected';
+  } catch (err) {
+    // Verdicts only from the daemon's own refusals (see
+    // vaultRefreshLeases); a timeout or dropped channel keeps whatever
+    // the last connected read established.
+    const kind = err?.kind || '';
+    if (kind === 'denied' || kind === 'unavailable') {
+      custodyTrailState.supported = false;
+      custodyTrailState.availability = kind === 'denied' ? 'denied' : 'unsupported';
+    }
   }
   renderAccessCustodySection();
 }
@@ -28498,7 +28567,10 @@ function renderAccessCustodySection() {
     mount.appendChild(el);
   };
   if (custodyTrailState.supported === false) {
-    note('This session cannot read the custody trail — it needs credentials.manage, or the daemon predates it.');
+    // The honest split (transport F6): the daemon said which it is.
+    note(custodyTrailState.availability === 'unsupported'
+      ? 'This daemon predates the custody trail — upgrade it to see lease and relay lifecycle events.'
+      : "This session can't read the custody trail — its role needs credentials.manage.");
     return;
   }
   if (!custodyTrailState.events.length) {
@@ -29214,21 +29286,32 @@ function vaultRenderFueling(card) {
   head.appendChild(title);
   card.appendChild(head);
 
-  if (!vaultLeaseTransportReady()) {
-    const note = document.createElement('div');
-    note.className = 'vault-note';
-    note.textContent = 'Connect to the daemon to fuel it — leases travel only over the verified tunnel.';
-    card.appendChild(note);
+  const fuelingNote = text => {
+    const el = document.createElement('div');
+    el.className = 'vault-note';
+    el.textContent = text;
+    card.appendChild(el);
+  };
+  // Availability honesty (transport F6): the daemon's features/status
+  // answer BEFORE any RPC fires, so the panel names the actual cause —
+  // a session whose role is refused the gate, a daemon predating the
+  // family, or simply no tunnel yet — instead of the old conflated
+  // "cannot manage leases" catch-all. The stored verdict covers the
+  // race where a still-optimistic pre-flight let an RPC bounce.
+  const avail = vaultLeaseAvailability();
+  if (avail.reason === 'denied' || vaultLeaseState.availability === 'denied') {
+    fuelingNote("This session's role can't manage credential leases — fueling needs credentials.manage.");
+    return;
+  }
+  if (avail.reason === 'unsupported' || vaultLeaseState.availability === 'unsupported') {
+    fuelingNote('This daemon predates credential leases — upgrade it to fuel from the vault.');
+    return;
+  }
+  if (!avail.ok) {
+    fuelingNote('Connect to the daemon to fuel it — leases travel only over the verified tunnel.');
     return;
   }
   vaultRefreshLeases().catch(() => {});
-  if (vaultLeaseState.supported === false) {
-    const note = document.createElement('div');
-    note.className = 'vault-note';
-    note.textContent = `This session cannot manage credential leases: ${vaultLeaseState.lastError || 'the daemon predates leases or this role lacks credentials.manage.'}`;
-    card.appendChild(note);
-    return;
-  }
 
   if (vaultLeaseState.expiredNote) {
     const warning = document.createElement('div');
@@ -29236,7 +29319,9 @@ function vaultRenderFueling(card) {
     warning.textContent = vaultLeaseState.expiredNote;
     card.appendChild(warning);
   }
-  if (vaultLeaseState.lastError && vaultLeaseState.supported) {
+  // Transient lane failures (timeouts, channel drops) are errors, not
+  // support verdicts — show them even before the first successful probe.
+  if (vaultLeaseState.lastError && vaultLeaseState.supported !== false) {
     const error = document.createElement('div');
     error.className = 'vault-error';
     error.textContent = vaultLeaseState.lastError;
@@ -29515,7 +29600,7 @@ function renderAccessVaultSection() {
         ? 'This browser lacks the WebCrypto features the vault needs.'
         : DASHBOARD_CONNECT_MODE
           ? 'The hosted vault store is unreachable right now.'
-          : 'No vault store reachable yet: this daemon predates local vault storage, this session lacks credentials.manage, or the control channel is still connecting (retries automatically). Hosted Connect dashboards use the account vault instead.';
+          : vaultDaemonStoreUnavailableText();
       break;
     case 'signed-out':
       chip.textContent = 'signed out';
@@ -29697,6 +29782,7 @@ window.intendantVault = {
   voiceApiKeyGet: storageKey => voiceApiKeyGet(storageKey),
   leases: () => ({
     supported: vaultLeaseState.supported,
+    availability: vaultLeaseState.availability,
     leases: vaultLeaseState.leases.map(lease => ({ ...lease })),
     expiredNote: vaultLeaseState.expiredNote,
     lastError: vaultLeaseState.lastError,
@@ -29735,6 +29821,7 @@ window.intendantVault = {
   probeEgress: kind => vaultLeaseRpc('api_credential_egress_probe', { kind }),
   custody: () => ({
     supported: custodyTrailState.supported,
+    availability: custodyTrailState.availability,
     events: custodyTrailState.events.map(event => ({ ...event })),
   }),
   refreshCustody: () => vaultRefreshCustody({ force: true }),
@@ -68820,6 +68907,31 @@ function dashboardControlRequestTimeoutMs(method) {
     case 'api_peer_pairing_request_access':
     case 'api_peer_pairing_request_access_poll':
     case 'api_coordinator_route':
+      return 30000;
+    // Credential custody (transport F6): the sealed vault blob rides the
+    // chunked, credit-gated response lane and can run to hundreds of KiB
+    // over a TURN link. The family's pre-facade caller asked for 15 s and
+    // was silently clamped to the 5 s default (this verb ignores
+    // options.timeoutMs) — this table is where that intent actually
+    // lives.
+    case 'api_credential_lease_grant':
+    case 'api_credential_lease_renew':
+    case 'api_credential_lease_revoke':
+    case 'api_credential_lease_status':
+    case 'api_credential_custody_trail':
+    case 'api_credential_egress_register':
+    case 'api_credential_egress_unregister':
+    case 'api_daemon_vault_fetch':
+    case 'api_daemon_vault_publish':
+    case 'api_daemon_vault_deposit_key_fetch':
+    case 'api_daemon_vault_deposit_key_publish':
+    case 'api_daemon_vault_deposits_fetch':
+    case 'api_daemon_vault_deposits_consume':
+      return 15000;
+    // The egress probe reaches beyond this daemon before answering:
+    // daemon -> the relaying browser -> the provider's API -> back. Same
+    // budget as the peer round trips above.
+    case 'api_credential_egress_probe':
       return 30000;
     default:
       return 5000;

--- a/static/app/32-daemon-api.js
+++ b/static/app/32-daemon-api.js
@@ -29,10 +29,13 @@
 // staged uploads), the F2 sessions-family reads, the F3 settings/keys
 // family (settings GET/POST, api-keys save, key-status, project-root,
 // external-agents, displays), the F4 access dialogs family
-// (overview/enrollment/connect/tier + IAM grant writes), and the F5
+// (overview/enrollment/connect/tier + IAM grant writes), the F5
 // peers/approvals/coordinator family (peer list + quick controls, the
 // pairing dialogs, the coordinator forms, and the peer WebRTC signal
-// relays); the remaining
+// relays), and the F6 credential-custody family (vault leases, the
+// custody trail, the daemon vault store + deposit lane, client-egress
+// registration/probe — tunnel-only methods whose per-cause availability
+// the vault UI surfaces); the remaining
 // `rpcOrHttp`/`jsonFetch` call
 // sites move onto these verbs family by family per the design's frontend
 // track. The boot smoke's window.qa.daemonApi() probe asserts the facade
@@ -77,7 +80,12 @@
 // delegate IAM to the federation ladder, S7). The
 // `api_transfer_*` methods are deliberately absent: they have no HTTP rows
 // until the server-track stage that adds /api/transfers (task #6); F1 adds
-// their entries when those rows land.
+// their entries when those rows land. The F6 credential-custody family
+// (api_credential_*, api_daemon_vault_*) is deliberately absent too, and
+// stays so: custody is tunnel-scoped by design — no HTTP rows exist or
+// are planned (docs/src/credential-custody.md; the transport design
+// parks custody HTTP rows as an explicit future decision), so those
+// methods ride the facade with no fallback lane at all.
 // Entry shape: verb + path template (`{name}` segments are lifted from
 // params), `alias` = capture-name -> param-key lift map (the session rows
 // capture `id` while the tunnel's canonical param is `session_id` — the
@@ -974,6 +982,10 @@ window.qa = Object.assign(window.qa || {}, {
         api_session_current_upload: daemonApiAvailability('api_session_current_upload'),
         api_sessions: daemonApiAvailability('api_sessions'),
         api_sessions_stream: daemonApiAvailability('api_sessions_stream'),
+        // Tunnel-only custody sample (F6): 'denied' vs 'unsupported' vs
+        // 'transport-down' is directly observable here — no HTTP twin
+        // ever answers for it.
+        api_credential_lease_status: daemonApiAvailability('api_credential_lease_status'),
       },
       descriptor: {
         methods: Object.keys(DAEMON_API_HTTP_MAP).length,

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -67,19 +67,25 @@ const vaultRevealedEntries = new Set();
    copying between them is an explicit user action, never implicit. */
 function vaultDaemonStoreReady() {
   if (DASHBOARD_CONNECT_MODE) return false; // hosted tabs use the account store
-  try {
-    const status = window.intendantDashboardControl?.status?.();
-    if (!status?.connected || !status?.verifiedBinding?.ok) return false;
-    // An empty feature list means the hello_ack hasn't landed yet: fall
-    // through and let the RPCs answer (mirrors vaultLeaseTransportReady).
-    const features = status.controlFeatures;
-    if (Array.isArray(features) && features.length) {
-      return features.includes('api_daemon_vault_fetch');
-    }
-    return true;
-  } catch {
-    return false;
+  // daemonApi availability (transport F6): the tunnel status boolean when
+  // it has landed (false = this session's role is refused the custody
+  // gate), the hello_ack features list before that (absent = the daemon
+  // predates local vault storage), optimistic only while the handshake is
+  // still in flight — the pre-facade "let the RPCs answer" semantics.
+  return daemonApi.availability('api_daemon_vault_fetch').ok;
+}
+
+/* Why the daemon store is out of reach, for the 'unavailable' status line
+   — the honest split the conflated pre-facade copy could not make. */
+function vaultDaemonStoreUnavailableText() {
+  const reason = daemonApi.availability('api_daemon_vault_fetch').reason;
+  if (reason === 'denied') {
+    return "This session's role lacks credentials.manage, so this daemon's local vault store is out of reach. Hosted Connect dashboards use the account vault instead.";
   }
+  if (reason === 'unsupported') {
+    return 'This daemon predates local vault storage — upgrade it to keep a sealed vault here. Hosted Connect dashboards use the account vault instead.';
+  }
+  return 'No vault store reachable yet: the control channel is still connecting (retries automatically). Hosted Connect dashboards use the account vault instead.';
 }
 
 function vaultBackendKind() {
@@ -336,6 +342,9 @@ async function vaultServerFetch() {
       vault: result?.vault || null,
     };
   }
+  // The account store lives on the Connect service, not on any daemon —
+  // deliberately raw fetch, outside the daemonApi facade (the facade
+  // speaks to daemons only; rendezvous calls stay on their own lane).
   const resp = await fetch(accessFleetHostedUrl('/api/vault'));
   if (resp.status === 401) return { authenticated: false };
   const body = await resp.json().catch(() => ({}));
@@ -1127,7 +1136,8 @@ const VAULT_OFFLINE_CHOICES = [
 const VAULT_OFFLINE_DEFAULT_MS = 24 * 60 * 60 * 1000;
 
 const vaultLeaseState = {
-  supported: null,   // null until first probe; false when the daemon lacks the RPCs / gate
+  supported: null,   // null until first verdict; false only on the daemon's own refusal
+  availability: '',  // honest cause: 'denied' | 'unsupported' | 'connected' (transport F6)
   leases: [],
   egress: [],        // active client-egress relays (the path indicator)
   expiredNote: '',
@@ -1301,40 +1311,47 @@ async function vaultOauthAccessTokenMaterial(entry, kind) {
   return vaultOauthAccessMaterial(kind, secretJson);
 }
 
+/* Availability of the lease RPC family here (transport F6, design §3.4):
+   the daemon's own word, before any RPC fires. Reasons the render paths
+   branch on — 'denied' (the status boolean says this session's role is
+   refused credentials.manage; custody methods have no runtime-ready
+   ladder, so false means exactly that), 'unsupported' (the hello_ack
+   features list omits the family — the daemon predates it),
+   'transport-down' (no verified tunnel; custody has no HTTP twin by
+   design, so no other lane can answer), 'connected' (go — optimistically
+   so while the handshake is still digesting, letting the RPCs answer
+   exactly as the pre-facade probes did). */
+function vaultLeaseAvailability() {
+  return daemonApi.availability('api_credential_lease_status');
+}
+
 function vaultLeaseTransportReady() {
-  try {
-    const status = window.intendantDashboardControl?.status?.();
-    if (!status?.connected || !status?.verifiedBinding?.ok) return false;
-    // Leases need the credential RPC family. A daemon that advertises its
-    // control surface but not these methods is too old — report
-    // unsupported instead of firing calls that fail one by one. An empty
-    // list means the hello_ack hasn't landed yet: fall through and let
-    // the RPCs answer.
-    const features = status.controlFeatures;
-    if (Array.isArray(features) && features.length) {
-      return features.includes('api_credential_lease_status');
-    }
-    return true;
-  } catch {
-    return false;
-  }
+  return vaultLeaseAvailability().ok;
 }
 
-function vaultLeaseRpc(method, params = {}) {
-  return window.intendantDashboardControl.request(method, params, { timeoutMs: 15000 });
+/* One custody RPC. Tunnel-only by design (docs/src/credential-custody.md;
+   the transport design keeps the family off HTTP rows), which the facade
+   enforces: no fallback lane exists, so a custody mutation can never
+   replay elsewhere after an ambiguous failure, and a down tunnel rejects
+   immediately. Resolves with the result payload (the pre-facade contract
+   every call site and window.intendantVault.probeEgress keeps);
+   rejections are DaemonApiError, whose `kind` the refreshers classify
+   into availability verdicts. Per-method timeouts live in
+   dashboardControlRequestTimeoutMs — the `{ timeoutMs: 15000 }` option
+   the pre-facade call passed here was silently ignored by the request
+   verb; the custody rows of that table now carry the intent. */
+async function vaultLeaseRpc(method, params = {}) {
+  const { body } = await daemonApi.request(method, params);
+  return body;
 }
 
-/* Whether the tunneled daemon advertises local vault storage — strict
-   (feature must be listed) because this only gates an optional action. */
+/* Whether the tunneled daemon offers local vault storage to THIS session —
+   'connected' only: the daemon must have confirmed the method (status
+   boolean or features list), because this gates an optional action (the
+   sealed-copy button) that a credentials.manage-denied session or an
+   older daemon could only bounce. */
 function vaultTunnelDaemonVaultAvailable() {
-  try {
-    const status = window.intendantDashboardControl?.status?.();
-    if (!status?.connected || !status?.verifiedBinding?.ok) return false;
-    const features = status.controlFeatures;
-    return Array.isArray(features) && features.includes('api_daemon_vault_publish');
-  } catch {
-    return false;
-  }
+  return daemonApi.availability('api_daemon_vault_publish').reason === 'connected';
 }
 
 /* The lease kind a vault entry fuels, or null when it cannot fuel.
@@ -1353,11 +1370,22 @@ function vaultEntryLeaseKind(entry) {
 }
 
 async function vaultRefreshLeases({ force = false } = {}) {
-  if (!vaultLeaseTransportReady()) return;
+  const avail = vaultLeaseAvailability();
+  if (!avail.ok) {
+    // The daemon already answered through features/status — record the
+    // verdict without firing RPCs that can only bounce (the render paths
+    // read the same availability live, so no re-render is needed here).
+    if (avail.reason === 'denied' || avail.reason === 'unsupported') {
+      vaultLeaseState.supported = false;
+      vaultLeaseState.availability = avail.reason;
+    }
+    return;
+  }
   if (!force && Date.now() - vaultLeaseState.fetchedAt < 30_000) return;
   try {
     const result = await vaultLeaseRpc('api_credential_lease_status');
     vaultLeaseState.supported = true;
+    vaultLeaseState.availability = 'connected';
     vaultLeaseState.leases = Array.isArray(result?.leases) ? result.leases : [];
     vaultLeaseState.egress = Array.isArray(result?.egress) ? result.egress : [];
     vaultLeaseState.expiredNote = String(result?.expired_note || '');
@@ -1368,12 +1396,20 @@ async function vaultRefreshLeases({ force = false } = {}) {
     }
     vaultEgressEnsure().catch(() => {});
   } catch (err) {
-    const message = String(err?.message || err);
-    // A daemon predating the lease RPCs, or a session without the
-    // credentials.manage gate, reads as unsupported rather than broken.
-    vaultLeaseState.supported = false;
-    vaultLeaseState.lastError = message;
+    vaultLeaseState.lastError = String(err?.message || err);
     vaultLeaseState.fetchedAt = Date.now();
+    // Availability honesty (transport F6): only the daemon's own refusals
+    // are verdicts about this session or this daemon. 'denied' is the
+    // authorizer refusing the gate, 'unavailable' is a daemon without the
+    // method (races where the pre-flight was still optimistic). A timeout
+    // or a dropped channel says nothing about support — keep the last
+    // known verdict and surface the error text instead of the old
+    // conflated "cannot manage leases" reading.
+    const kind = err?.kind || '';
+    if (kind === 'denied' || kind === 'unavailable') {
+      vaultLeaseState.supported = false;
+      vaultLeaseState.availability = kind === 'denied' ? 'denied' : 'unsupported';
+    }
   }
   renderAccessVaultSection();
   refreshUnfueledEmptyState().catch(() => {});
@@ -1381,20 +1417,41 @@ async function vaultRefreshLeases({ force = false } = {}) {
 }
 
 /* Custody trail: the daemon's own record of lease/relay lifecycle events,
-   fetched over the same credentials.manage-gated channel as the leases. */
-const custodyTrailState = { events: [], supported: null, fetchedAt: 0 };
+   fetched over the same credentials.manage-gated channel as the leases.
+   `availability` carries the honest cause when supported goes false:
+   'denied' (role refused the gate) vs 'unsupported' (daemon predates the
+   trail) — transient lane failures flip neither. */
+const custodyTrailState = { events: [], supported: null, availability: '', fetchedAt: 0 };
 
 async function vaultRefreshCustody({ force = false } = {}) {
-  if (!vaultLeaseTransportReady()) return;
+  const avail = daemonApi.availability('api_credential_custody_trail');
+  if (!avail.ok) {
+    if (avail.reason === 'denied' || avail.reason === 'unsupported') {
+      const changed = custodyTrailState.supported !== false
+        || custodyTrailState.availability !== avail.reason;
+      custodyTrailState.supported = false;
+      custodyTrailState.availability = avail.reason;
+      custodyTrailState.fetchedAt = Date.now();
+      if (changed) renderAccessCustodySection();
+    }
+    return;
+  }
   if (!force && Date.now() - custodyTrailState.fetchedAt < 30_000) return;
   custodyTrailState.fetchedAt = Date.now();
   try {
     const result = await vaultLeaseRpc('api_credential_custody_trail');
     custodyTrailState.events = Array.isArray(result?.events) ? result.events : [];
     custodyTrailState.supported = true;
-  } catch {
-    // Older daemon or a session without credentials.manage.
-    custodyTrailState.supported = false;
+    custodyTrailState.availability = 'connected';
+  } catch (err) {
+    // Verdicts only from the daemon's own refusals (see
+    // vaultRefreshLeases); a timeout or dropped channel keeps whatever
+    // the last connected read established.
+    const kind = err?.kind || '';
+    if (kind === 'denied' || kind === 'unavailable') {
+      custodyTrailState.supported = false;
+      custodyTrailState.availability = kind === 'denied' ? 'denied' : 'unsupported';
+    }
   }
   renderAccessCustodySection();
 }
@@ -1419,7 +1476,10 @@ function renderAccessCustodySection() {
     mount.appendChild(el);
   };
   if (custodyTrailState.supported === false) {
-    note('This session cannot read the custody trail — it needs credentials.manage, or the daemon predates it.');
+    // The honest split (transport F6): the daemon said which it is.
+    note(custodyTrailState.availability === 'unsupported'
+      ? 'This daemon predates the custody trail — upgrade it to see lease and relay lifecycle events.'
+      : "This session can't read the custody trail — its role needs credentials.manage.");
     return;
   }
   if (!custodyTrailState.events.length) {
@@ -2135,21 +2195,32 @@ function vaultRenderFueling(card) {
   head.appendChild(title);
   card.appendChild(head);
 
-  if (!vaultLeaseTransportReady()) {
-    const note = document.createElement('div');
-    note.className = 'vault-note';
-    note.textContent = 'Connect to the daemon to fuel it — leases travel only over the verified tunnel.';
-    card.appendChild(note);
+  const fuelingNote = text => {
+    const el = document.createElement('div');
+    el.className = 'vault-note';
+    el.textContent = text;
+    card.appendChild(el);
+  };
+  // Availability honesty (transport F6): the daemon's features/status
+  // answer BEFORE any RPC fires, so the panel names the actual cause —
+  // a session whose role is refused the gate, a daemon predating the
+  // family, or simply no tunnel yet — instead of the old conflated
+  // "cannot manage leases" catch-all. The stored verdict covers the
+  // race where a still-optimistic pre-flight let an RPC bounce.
+  const avail = vaultLeaseAvailability();
+  if (avail.reason === 'denied' || vaultLeaseState.availability === 'denied') {
+    fuelingNote("This session's role can't manage credential leases — fueling needs credentials.manage.");
+    return;
+  }
+  if (avail.reason === 'unsupported' || vaultLeaseState.availability === 'unsupported') {
+    fuelingNote('This daemon predates credential leases — upgrade it to fuel from the vault.');
+    return;
+  }
+  if (!avail.ok) {
+    fuelingNote('Connect to the daemon to fuel it — leases travel only over the verified tunnel.');
     return;
   }
   vaultRefreshLeases().catch(() => {});
-  if (vaultLeaseState.supported === false) {
-    const note = document.createElement('div');
-    note.className = 'vault-note';
-    note.textContent = `This session cannot manage credential leases: ${vaultLeaseState.lastError || 'the daemon predates leases or this role lacks credentials.manage.'}`;
-    card.appendChild(note);
-    return;
-  }
 
   if (vaultLeaseState.expiredNote) {
     const warning = document.createElement('div');
@@ -2157,7 +2228,9 @@ function vaultRenderFueling(card) {
     warning.textContent = vaultLeaseState.expiredNote;
     card.appendChild(warning);
   }
-  if (vaultLeaseState.lastError && vaultLeaseState.supported) {
+  // Transient lane failures (timeouts, channel drops) are errors, not
+  // support verdicts — show them even before the first successful probe.
+  if (vaultLeaseState.lastError && vaultLeaseState.supported !== false) {
     const error = document.createElement('div');
     error.className = 'vault-error';
     error.textContent = vaultLeaseState.lastError;
@@ -2436,7 +2509,7 @@ function renderAccessVaultSection() {
         ? 'This browser lacks the WebCrypto features the vault needs.'
         : DASHBOARD_CONNECT_MODE
           ? 'The hosted vault store is unreachable right now.'
-          : 'No vault store reachable yet: this daemon predates local vault storage, this session lacks credentials.manage, or the control channel is still connecting (retries automatically). Hosted Connect dashboards use the account vault instead.';
+          : vaultDaemonStoreUnavailableText();
       break;
     case 'signed-out':
       chip.textContent = 'signed out';
@@ -2618,6 +2691,7 @@ window.intendantVault = {
   voiceApiKeyGet: storageKey => voiceApiKeyGet(storageKey),
   leases: () => ({
     supported: vaultLeaseState.supported,
+    availability: vaultLeaseState.availability,
     leases: vaultLeaseState.leases.map(lease => ({ ...lease })),
     expiredNote: vaultLeaseState.expiredNote,
     lastError: vaultLeaseState.lastError,
@@ -2656,6 +2730,7 @@ window.intendantVault = {
   probeEgress: kind => vaultLeaseRpc('api_credential_egress_probe', { kind }),
   custody: () => ({
     supported: custodyTrailState.supported,
+    availability: custodyTrailState.availability,
     events: custodyTrailState.events.map(event => ({ ...event })),
   }),
   refreshCustody: () => vaultRefreshCustody({ force: true }),

--- a/static/app/50-control-transport.js
+++ b/static/app/50-control-transport.js
@@ -1596,6 +1596,31 @@ function dashboardControlRequestTimeoutMs(method) {
     case 'api_peer_pairing_request_access_poll':
     case 'api_coordinator_route':
       return 30000;
+    // Credential custody (transport F6): the sealed vault blob rides the
+    // chunked, credit-gated response lane and can run to hundreds of KiB
+    // over a TURN link. The family's pre-facade caller asked for 15 s and
+    // was silently clamped to the 5 s default (this verb ignores
+    // options.timeoutMs) — this table is where that intent actually
+    // lives.
+    case 'api_credential_lease_grant':
+    case 'api_credential_lease_renew':
+    case 'api_credential_lease_revoke':
+    case 'api_credential_lease_status':
+    case 'api_credential_custody_trail':
+    case 'api_credential_egress_register':
+    case 'api_credential_egress_unregister':
+    case 'api_daemon_vault_fetch':
+    case 'api_daemon_vault_publish':
+    case 'api_daemon_vault_deposit_key_fetch':
+    case 'api_daemon_vault_deposit_key_publish':
+    case 'api_daemon_vault_deposits_fetch':
+    case 'api_daemon_vault_deposits_consume':
+      return 15000;
+    // The egress probe reaches beyond this daemon before answering:
+    // daemon -> the relaying browser -> the provider's API -> back. Same
+    // budget as the peer round trips above.
+    case 'api_credential_egress_probe':
+      return 30000;
     default:
       return 5000;
   }


### PR DESCRIPTION
Stage F6 of the transport-unification frontend track: the credential-custody family (vault leases, custody trail, daemon vault store + deposit lane, client-egress registration/probe) converts onto the `daemonApi` facade.

## Calls moved
- `vaultLeaseRpc` now rides `daemonApi.request` and unwraps the envelope body, keeping the pre-facade result contract for every custody call site and `window.intendantVault.probeEgress`. All 14 custody methods flow through it (lease grant/renew/revoke/status, custody trail, vault fetch/publish, deposit-key fetch/publish, deposits fetch/consume, egress register/unregister/probe).
- The family is tunnel-only by design (docs/src/credential-custody.md; custody HTTP rows are parked as an explicit future decision), so the facade's policy-as-data refuses any fallback lane: mutations can never replay elsewhere, zero payload changes, no retries (custody uses the JSON request verb only).

## Stayed raw (Connect-targeted or external, out of facade scope)
- The account vault store (`accessFleetHostedUrl('/api/vault')` fetch/publish) — the hosted rendezvous stores the blob, not a daemon.
- Org revocation bulletin publish/courier reads against `dashboardRendezvousBase()`.
- Provider-origin fetches (OAuth token refresh, egress relay jobs) and the `egress_*` realtime frames (their own wire family).

## Availability honesty (the family's design point)
- The three hand-rolled feature probes (`vaultDaemonStoreReady`, `vaultLeaseTransportReady`, `vaultTunnelDaemonVaultAvailable`) become `daemonApi.availability` derivations. The sealed-copy gate requires reason `connected` (confirmed by status boolean or features — a denied session is no longer offered a publish that would only bounce).
- The two conflated `supported=false` verdicts split into their real causes: **denied** (status boolean: this session's role is refused credentials.manage) vs **unsupported** (features list omits the family: the daemon predates it). Transient lane failures (timeout, channel drop) no longer flip the support verdict — they surface as errors while the last honest verdict stands.
- The fueling panel, custody-trail section, and the vault `unavailable` status line each name the actual cause before any RPC fires; `window.intendantVault.leases()`/`custody()` expose the classification for harnesses.

## Timeouts
Custody rows join `dashboardControlRequestTimeoutMs`: 15 s for the family (the pre-facade `{ timeoutMs: 15000 }` was silently ignored by the request verb — the table row is where the intent actually lives), 30 s for the egress probe (daemon → relaying browser → provider round trip, same class as the peer dials).

## Descriptor + pins
`DAEMON_API_HTTP_MAP` stays at **76 entries** — custody is deliberately absent, now codified on both sides of the parity pin (facade coverage comment + the `daemon_api_http_map_mirrors_gateway_routes` coverage-pin comment in dashboard_control/mod.rs, which needed no test change since the family adds no entries). The qa probe gains a tunnel-only custody availability sample (`api_credential_lease_status`).

## Validator repairs (pre-existing staleness, found running the gates)
- Since the first-owner bootstrap (61786b44, 2026-07-07), daemon-minted claims show a new success copy; the four claim-driving validators (credential-leases, client-egress, org-grants, connect-hosted-mvp) now accept either copy.
- The lease validator's `--owner` scenario used a 25-char fake fingerprint; startup rejects non-43-char base64url values since d36f57fe — the fixture is now shape-valid.

## Battery
`cargo nextest run --bins` 2997 passed · clippy clean · assembler regen · `node --check` on every edited script · `validate-dashboard --check-static-scripts` PASS · **validate-credential-leases 16/16 · validate-vault 9/9 · validate-client-egress 6/6** · dashboard boot smoke PASS (module-alive true).