### PR TITLE
windows.yml: drop the push-to-main warm runs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,24 +26,20 @@ name: Cross-platform tests
 # end on every platform.
 
 on:
-  push:
-    branches: [main]
-    # Only platform-relevant sources can introduce a compile regression, so
-    # skip pure-docs / static-asset pushes. Mirrors audit.yml's scoping.
-    paths:
-      - "**/*.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "crates/**/Cargo.toml"
-      - ".github/workflows/windows.yml"
+  # NO push trigger (dropped 2026-07-10, after the external per-listener
+  # target caches landed): the push-to-main run was a check-only "warm
+  # pass" whose only value was compile warmth, and the constant PR +
+  # merge-group flow keeps the external caches warm without it — the
+  # merge-group run just validated the identical tree. Same reasoning
+  # that removed smokes.yml's push trigger on 2026-07-07 (~8 fleet
+  # runner-minutes returned per landing).
+  #
   # Required-check trigger #1 — deliberately unfiltered. This job is a
   # required status check, and GitHub only lets a PR *enter* the merge
   # queue once its own required checks have passed: a paths-skipped
   # required check leaves the PR BLOCKED at "Expected" forever (verified
   # live on the first docs-only PR through this repo's queue). Every PR
-  # pays the full matrix; that is the price of a required check. The push
-  # trigger above keeps its paths — push runs are check-only warm passes
-  # (see the fast-path step), not gates.
+  # pays the full matrix; that is the price of a required check.
   pull_request:
     branches: [main]
   # Required-check trigger #2 — the merge-queue revalidation against the
@@ -309,22 +305,15 @@ jobs:
       # actual gate, revalidating the speculative merge state) and the
       # Linux pull_request leg (the one pre-queue runtime signal — most
       # test failures are platform-agnostic, and catching them before the
-      # queue saves a far more expensive group ejection). Everything else
-      # runs a compile check only:
-      #   - non-Linux PR legs (since 2026-07: cross-platform compile
-      #     breakage is the dominant non-Linux regression class, and the
-      #     single Mac hosts both mac runner instances PLUS the
-      #     interactive agents — stacked full-suite runs starved the
-      #     label queue at ~55-minute waits);
-      #   - ALL push-to-main warm runs (since 2026-07-07: the merge-group
-      #     run just built and tested the identical tree on this same
-      #     fleet, so a push-side full suite re-validates nothing — its
-      #     cache-warming value IS the compile, which the constant PR +
-      #     group flow already provides; dropping the Linux push suite
-      #     returned ~19 runner-minutes per landing on the dell, the
-      #     fleet's current bottleneck).
+      # queue saves a far more expensive group ejection). The non-Linux
+      # PR legs run this compile check only (since 2026-07:
+      # cross-platform compile breakage is the dominant non-Linux
+      # regression class, and the single Mac hosts both mac runner
+      # instances PLUS the interactive agents — stacked full-suite runs
+      # starved the label queue at ~55-minute waits). Push-to-main runs
+      # are gone entirely (2026-07-10, the `on:` comment).
       - name: cargo check (fast path)
-        if: github.event_name != 'merge_group' && (runner.os != 'Linux' || github.event_name == 'push') && steps.relevance_unix.outputs.relevant != 'false' && steps.relevance_win.outputs.relevant != 'false'
+        if: github.event_name != 'merge_group' && runner.os != 'Linux' && steps.relevance_unix.outputs.relevant != 'false' && steps.relevance_win.outputs.relevant != 'false'
         run: |
           cargo check -p intendant --bins --locked --target ${{ matrix.target }}
           cargo check -p intendant-core -p intendant-display -p intendant-platform --tests --locked --target ${{ matrix.target }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,13 +350,16 @@ move on; never force it and never resolve the root checkout's state yourself.
 
 ## CI/CD
 
-GitHub Actions on push / PR to `main`, and — for the required checks — on every
+GitHub Actions on PR to `main` and — for the required checks — on every
 `merge_group`. The required-check workflows run **unfiltered on `pull_request`
 and `merge_group`**: GitHub only lets a PR enter the merge queue after its own
 required checks pass, so a paths-skipped required check blocks queue entry
-(and on the group side wedges the entry at "Expected"). Only the push-to-main
-triggers keep paths filters — push runs are check-only warm passes, not gates
-(`smokes.yml` has no push trigger at all).
+(and on the group side wedges the entry at "Expected"). The heavy workflows
+(`windows.yml`, `smokes.yml`) have **no push trigger at all** — a push-to-main
+run would revalidate the identical tree the merge group just validated, and
+the external per-listener build caches stay warm from the constant PR + group
+flow. The remaining push triggers (repo-integrity, app.html, audit, docs
+deploy) are cheap and paths-filtered.
 
 Trusted refs (pushes, merge-queue refs, same-repo PRs) run on the
 **self-hosted fleet** (`dell-206` = `intendant-linux`, `macbook-vm` =
@@ -376,7 +379,7 @@ kit (`_intendant-ci`: hidden role account, LaunchDaemon listeners, job hooks)
 is cut over — and the check *names* stay pinned to the
 `test (ubuntu-latest)`-style contexts the ruleset requires (matrix `os` is
 the name key, `runner` is the fleet placement):
-- **`windows.yml`** — cross-platform `cargo test` (the `intendant` bins + the `intendant-core`/`intendant-display`/`intendant-platform` lib crates) + the headless mock-provider e2e on Windows + macOS + Linux (catches platform-specific build breaks *and* Unix-only test/path assumptions; excludes the WASM crates). Full suites run in exactly two places: the **merge group** (all three platforms — the actual gate) and the **Linux `pull_request` leg** (the pre-queue runtime signal); everything else — non-Linux PR legs, every push-to-main warm run — is `cargo check` only. The Windows and Linux legs build with debuginfo off (`CARGO_PROFILE_DEV_DEBUG=0` — the Linux leg measured ~95% compile+link vs ~12s of test execution; repro locally with default debuginfo when a CI backtrace is too thin). Headless-safe: needs no display or API keys. **Required check.**
+- **`windows.yml`** — cross-platform `cargo test` (the `intendant` bins + the `intendant-core`/`intendant-display`/`intendant-platform` lib crates) + the headless mock-provider e2e on Windows + macOS + Linux (catches platform-specific build breaks *and* Unix-only test/path assumptions; excludes the WASM crates). Full suites run in exactly two places: the **merge group** (all three platforms — the actual gate) and the **Linux `pull_request` leg** (the pre-queue runtime signal); the non-Linux PR legs are `cargo check` only, and there is no push trigger. The Windows and Linux legs build with debuginfo off (`CARGO_PROFILE_DEV_DEBUG=0` — the Linux leg measured ~95% compile+link vs ~12s of test execution; repro locally with default debuginfo when a CI backtrace is too thin). Headless-safe: needs no display or API keys. **Required check.**
 - **`smokes.yml`** — the keyless smokes (session-vitals, native-goal, peer-sessions) against real binaries on Linux only (debug profile with debuginfo off, sharing the runner's warm tree with the test job; the drivers are platform-agnostic protocol probes, so a second platform mostly duplicated coverage while doubling flake surface). PR + merge group only — no push trigger. **Required check.**
 - **`app-html.yml`** — the `static/app/` fragments ↔ generated `static/app.html` regen gate. **Required check.**
 - **`agents-md-sync.yml`** — repo integrity: CLAUDE.md ↔ AGENTS.md byte-parity + actionlint over the workflow files (fleet runner labels are declared in `.github/actionlint.yaml`; shellcheck/pyflakes passes await their own baseline pass). **Required check.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,13 +350,16 @@ move on; never force it and never resolve the root checkout's state yourself.
 
 ## CI/CD
 
-GitHub Actions on push / PR to `main`, and — for the required checks — on every
+GitHub Actions on PR to `main` and — for the required checks — on every
 `merge_group`. The required-check workflows run **unfiltered on `pull_request`
 and `merge_group`**: GitHub only lets a PR enter the merge queue after its own
 required checks pass, so a paths-skipped required check blocks queue entry
-(and on the group side wedges the entry at "Expected"). Only the push-to-main
-triggers keep paths filters — push runs are check-only warm passes, not gates
-(`smokes.yml` has no push trigger at all).
+(and on the group side wedges the entry at "Expected"). The heavy workflows
+(`windows.yml`, `smokes.yml`) have **no push trigger at all** — a push-to-main
+run would revalidate the identical tree the merge group just validated, and
+the external per-listener build caches stay warm from the constant PR + group
+flow. The remaining push triggers (repo-integrity, app.html, audit, docs
+deploy) are cheap and paths-filtered.
 
 Trusted refs (pushes, merge-queue refs, same-repo PRs) run on the
 **self-hosted fleet** (`dell-206` = `intendant-linux`, `macbook-vm` =
@@ -376,7 +379,7 @@ kit (`_intendant-ci`: hidden role account, LaunchDaemon listeners, job hooks)
 is cut over — and the check *names* stay pinned to the
 `test (ubuntu-latest)`-style contexts the ruleset requires (matrix `os` is
 the name key, `runner` is the fleet placement):
-- **`windows.yml`** — cross-platform `cargo test` (the `intendant` bins + the `intendant-core`/`intendant-display`/`intendant-platform` lib crates) + the headless mock-provider e2e on Windows + macOS + Linux (catches platform-specific build breaks *and* Unix-only test/path assumptions; excludes the WASM crates). Full suites run in exactly two places: the **merge group** (all three platforms — the actual gate) and the **Linux `pull_request` leg** (the pre-queue runtime signal); everything else — non-Linux PR legs, every push-to-main warm run — is `cargo check` only. The Windows and Linux legs build with debuginfo off (`CARGO_PROFILE_DEV_DEBUG=0` — the Linux leg measured ~95% compile+link vs ~12s of test execution; repro locally with default debuginfo when a CI backtrace is too thin). Headless-safe: needs no display or API keys. **Required check.**
+- **`windows.yml`** — cross-platform `cargo test` (the `intendant` bins + the `intendant-core`/`intendant-display`/`intendant-platform` lib crates) + the headless mock-provider e2e on Windows + macOS + Linux (catches platform-specific build breaks *and* Unix-only test/path assumptions; excludes the WASM crates). Full suites run in exactly two places: the **merge group** (all three platforms — the actual gate) and the **Linux `pull_request` leg** (the pre-queue runtime signal); the non-Linux PR legs are `cargo check` only, and there is no push trigger. The Windows and Linux legs build with debuginfo off (`CARGO_PROFILE_DEV_DEBUG=0` — the Linux leg measured ~95% compile+link vs ~12s of test execution; repro locally with default debuginfo when a CI backtrace is too thin). Headless-safe: needs no display or API keys. **Required check.**
 - **`smokes.yml`** — the keyless smokes (session-vitals, native-goal, peer-sessions) against real binaries on Linux only (debug profile with debuginfo off, sharing the runner's warm tree with the test job; the drivers are platform-agnostic protocol probes, so a second platform mostly duplicated coverage while doubling flake surface). PR + merge group only — no push trigger. **Required check.**
 - **`app-html.yml`** — the `static/app/` fragments ↔ generated `static/app.html` regen gate. **Required check.**
 - **`agents-md-sync.yml`** — repo integrity: CLAUDE.md ↔ AGENTS.md byte-parity + actionlint over the workflow files (fleet runner labels are declared in `.github/actionlint.yaml`; shellcheck/pyflakes passes await their own baseline pass). **Required check.**


### PR DESCRIPTION
Wave-4 slice, unblocked by #161: the push-to-main warm pass only ever bought compile warmth, which now lives in the external per-listener caches kept warm by the constant PR + merge-group flow. The merge group validates the identical tree moments earlier — the push run is three fleet legs of waste per landing (~8 runner-minutes). Mirrors smokes.yml's 2026-07-07 push-trigger removal. Fast-path `if` loses its unreachable push arm; CLAUDE.md CI chapter updated (AGENTS.md synced). actionlint + YAML clean.

Doubles as the wave-3 canary: listener A is paused, so this PR's macOS legs run on the freshly migrated `_intendant-ci` listener B.