### PR TITLE
Transport S9b: /api/transfers rows — resumable transfers over direct HTTP (task #6)

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1989,6 +1989,13 @@ its operation per method/path from `federation_http_operation`.
 | POST | `/api/fs/write` | FilesystemWrite | own origin | ≤ 150 MiB | Write file bytes (scope-checked; sha256-guarded overwrite) |
 | POST | `/api/fs/rename` | FilesystemWrite | own origin | bounded | Move/rename a file or directory (scope-checked) |
 | POST | `/api/fs/delete` | FilesystemWrite | own origin | bounded | Delete a file or directory (scope-checked) |
+| GET | `/api/transfers` | FilesystemRead | own origin | none | List transfer jobs, newest first (`?id=` filters by job id or resume token) |
+| POST | `/api/transfers` | FilesystemWrite | own origin | bounded | Create a transfer job (kind download|upload, path/destination, name, total_size, sha256, conflict; fs-scope-checked on the target path) |
+| POST | `/api/transfers/{id}/chunk` | FilesystemWrite | own origin | streaming | Append one raw-body chunk to an upload job (`?offset=`; ≤ 32 MiB per chunk) |
+| POST | `/api/transfers/{id}/commit` | FilesystemWrite | own origin | bounded | Verify (size + declared sha256) and atomically rename a finished upload into place |
+| DELETE | `/api/transfers/{id}` | FilesystemWrite | own origin | none | Delete a transfer job (cancels partials; removes managed artifacts) |
+| POST | `/api/transfers/{id}/delete` | FilesystemWrite | own origin | none | Delete a transfer job (WKWebView POST fallback) |
+| GET | `/api/transfers/{id}/download` | FilesystemRead | own origin | none | Read download-job bytes (`?offset=&length=` or `Range` → 206; resume metadata echoed as X-Transfer-* headers, X-Content-Sha256 on full reads) |
 | GET | `/api/session/current/changes[/…]` | SessionManage | own origin | none | List the session's changed files, or the unified diff for one file (subpath) |
 | GET | `/api/session/current/history` | SessionManage | own origin | none | Serialized rollback History for the current session |
 | POST | `/api/session/current/rollback` | SessionManage | own origin | bounded | Roll the current session back to a round (optionally reverting files) |

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -218,19 +218,15 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
     // upload-frame-only api_session_current_upload (S4c).
     method("api_sessions_stream", PeerOperation::SessionInspect),
     method("api_session_control_msg", PeerOperation::SessionManage),
-    method("api_transfer_jobs", PeerOperation::FilesystemRead),
-    method("api_transfer_download_read", PeerOperation::FilesystemRead),
     // The api_fs_* methods live as tunnel columns on their route rows
     // (gateway_routes::ROUTES, /api/fs/*) — the first family whose tunnel
-    // ops derive from the rows instead of entries here. The api_transfer_*
-    // methods join them when their HTTP rows land (design §4, task #6).
-    method("api_transfer_job_create", PeerOperation::FilesystemWrite),
-    method("api_transfer_job_delete", PeerOperation::FilesystemWrite),
-    // Transfer chunks arrive only as upload frames; their destination was
-    // path-scoped when the transfer job was created, so the chunk itself
-    // only needs the write operation (`authorize_dashboard_control_upload`).
-    uploadable("api_transfer_upload_chunk", PeerOperation::FilesystemWrite),
-    method("api_transfer_upload_commit", PeerOperation::FilesystemWrite),
+    // ops derive from the rows instead of entries here — and the
+    // api_transfer_* family joined them with its /api/transfers rows
+    // (S9, design §4, task #6). Tunnel-side transfer chunks still arrive
+    // only as upload frames: their destination was path-scoped when the
+    // job was created, so the chunk needs only the write operation
+    // (`authorize_dashboard_control_upload`), which now derives from the
+    // chunk row like everything else.
     method("api_display_bootstrap", PeerOperation::DisplayView),
     method("api_display_webrtc_signal", PeerOperation::DisplayView),
     // api_displays and api_diagnostics_visual_freshness live as tunnel
@@ -3200,10 +3196,13 @@ mod tests {
                 Row,
                 Some(Op::SessionManage),
             ),
-            ("api_transfer_jobs", Residue, Some(Op::FilesystemRead)),
+            // The transfer family flipped Residue → Row with its
+            // /api/transfers rows (S9, task #6): ops now derive from
+            // the rows, same classes as always.
+            ("api_transfer_jobs", Row, Some(Op::FilesystemRead)),
             (
                 "api_transfer_download_read",
-                Residue,
+                Row,
                 Some(Op::FilesystemRead),
             ),
             ("api_fs_stat", Row, Some(Op::FilesystemRead)),
@@ -3211,22 +3210,22 @@ mod tests {
             ("api_fs_read", Row, Some(Op::FilesystemRead)),
             (
                 "api_transfer_job_create",
-                Residue,
+                Row,
                 Some(Op::FilesystemWrite),
             ),
             (
                 "api_transfer_job_delete",
-                Residue,
+                Row,
                 Some(Op::FilesystemWrite),
             ),
             (
                 "api_transfer_upload_chunk",
-                Residue,
+                Row,
                 Some(Op::FilesystemWrite),
             ),
             (
                 "api_transfer_upload_commit",
-                Residue,
+                Row,
                 Some(Op::FilesystemWrite),
             ),
             ("api_fs_mkdir", Row, Some(Op::FilesystemWrite)),

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -204,6 +204,15 @@ pub(crate) enum RouteHandlerId {
     FsWrite,
     FsRename,
     FsDelete,
+    TransferJobs,
+    TransferJobCreate,
+    TransferUploadChunk,
+    TransferUploadCommit,
+    /// Shared by the native DELETE row and the WKWebView POST
+    /// `/delete`-suffix fallback (the session-delete two-shape pattern;
+    /// both shapes capture the same `{id}`).
+    TransferJobDelete,
+    TransferDownloadRead,
     SessionCurrentChanges,
     CurrentHistory,
     CurrentRollback,
@@ -620,6 +629,93 @@ pub(crate) static ROUTES: &[Route] = &[
         "Delete a file or directory (scope-checked)",
     )
     .with_tunnel(tunnel_method("api_fs_delete")),
+    // ── Transfer jobs (design §4, task #6): the resumable jobs protocol
+    //    — create / capped chunk appends / commit / ranged download —
+    //    over direct HTTP, twinning the datachannel api_transfer_*
+    //    methods onto the same neutral cores. Create scope-checks its
+    //    target path (both kinds); the job-addressed rows carry no path
+    //    and act on the destination that check already fixed.
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Exact("/api/transfers"),
+        PeerOperation::FilesystemRead,
+        BodyPolicy::None,
+        RouteHandlerId::TransferJobs,
+        "List transfer jobs, newest first (`?id=` filters by job id or resume token)",
+    )
+    .with_tunnel(tunnel_method("api_transfer_jobs")),
+    op_route(
+        RouteMethod::Post,
+        PathPattern::Exact("/api/transfers"),
+        PeerOperation::FilesystemWrite,
+        BodyPolicy::Default,
+        RouteHandlerId::TransferJobCreate,
+        "Create a transfer job (kind download|upload, path/destination, name, \
+         total_size, sha256, conflict; fs-scope-checked on the target path)",
+    )
+    .with_tunnel(tunnel_method("api_transfer_job_create")),
+    // The chunk row streams its raw body into the same SpooledBody spool
+    // the tunnel's upload frames fill, capped per request at
+    // TRANSFER_HTTP_CHUNK_MAX_BYTES (resumability makes small chunks
+    // cheap). The tunnel twin may also (and in practice only does)
+    // arrive as upload frames.
+    op_route(
+        RouteMethod::Post,
+        PathPattern::Segments(
+            "/api/transfers",
+            &[SegmentSpec::Capture("id"), SegmentSpec::Literal("chunk")],
+        ),
+        PeerOperation::FilesystemWrite,
+        BodyPolicy::Streaming,
+        RouteHandlerId::TransferUploadChunk,
+        "Append one raw-body chunk to an upload job (`?offset=`; \u{2264} 32 MiB per chunk)",
+    )
+    .with_tunnel(tunnel_uploadable("api_transfer_upload_chunk")),
+    op_route(
+        RouteMethod::Post,
+        PathPattern::Segments(
+            "/api/transfers",
+            &[SegmentSpec::Capture("id"), SegmentSpec::Literal("commit")],
+        ),
+        PeerOperation::FilesystemWrite,
+        BodyPolicy::Default,
+        RouteHandlerId::TransferUploadCommit,
+        "Verify (size + declared sha256) and atomically rename a finished upload into place",
+    )
+    .with_tunnel(tunnel_method("api_transfer_upload_commit")),
+    op_route(
+        RouteMethod::Delete,
+        PathPattern::Segments("/api/transfers", &[SegmentSpec::Capture("id")]),
+        PeerOperation::FilesystemWrite,
+        BodyPolicy::None,
+        RouteHandlerId::TransferJobDelete,
+        "Delete a transfer job (cancels partials; removes managed artifacts)",
+    )
+    .with_tunnel(tunnel_method("api_transfer_job_delete")),
+    op_route(
+        RouteMethod::Post,
+        PathPattern::Segments(
+            "/api/transfers",
+            &[SegmentSpec::Capture("id"), SegmentSpec::Literal("delete")],
+        ),
+        PeerOperation::FilesystemWrite,
+        BodyPolicy::None,
+        RouteHandlerId::TransferJobDelete,
+        "Delete a transfer job (WKWebView POST fallback)",
+    ),
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Segments(
+            "/api/transfers",
+            &[SegmentSpec::Capture("id"), SegmentSpec::Literal("download")],
+        ),
+        PeerOperation::FilesystemRead,
+        BodyPolicy::None,
+        RouteHandlerId::TransferDownloadRead,
+        "Read download-job bytes (`?offset=&length=` or `Range` \u{2192} 206; \
+         resume metadata echoed as X-Transfer-* headers, X-Content-Sha256 on full reads)",
+    )
+    .with_tunnel(tunnel_method("api_transfer_download_read")),
     // ── Current-session routes (exact/subtree rows precede the generic
     //    session sub-router rows below).
     op_route(
@@ -2100,6 +2196,7 @@ mod tests {
         // must be contiguous so the sharing is visible in the table.
         let shared: &[RouteHandlerId] = &[
             RouteHandlerId::CurrentUploadsGet,
+            RouteHandlerId::TransferJobDelete,
             RouteHandlerId::SessionDelete,
             RouteHandlerId::SessionSubRouter,
             RouteHandlerId::AccessIamGrants,
@@ -2255,9 +2352,38 @@ mod tests {
             policy("POST", crate::peer::access_request::PUBLIC_REQUEST_PATH),
             BodyPolicy::Streaming
         );
+        // The transfer-chunk row spools its raw body under the handler's
+        // pinned per-chunk cap (the row is Streaming; the constant pin
+        // guards the value the handler enforces).
+        assert_eq!(
+            policy("POST", "/api/transfers/j1/chunk"),
+            BodyPolicy::Streaming
+        );
+        assert_eq!(
+            crate::web_gateway::TRANSFER_HTTP_CHUNK_MAX_BYTES,
+            32 * 1024 * 1024,
+            "the transfer chunk cap is a designed constant (design §4): \
+             it bounds per-request memory/disk while resumability keeps \
+             small chunks cheap — change it deliberately, with the docs",
+        );
         // Everything else that takes a body rides the shared default cap.
         assert_eq!(policy("POST", "/api/settings"), BodyPolicy::Default);
         assert_eq!(policy("POST", "/api/peers"), BodyPolicy::Default);
+        assert_eq!(policy("POST", "/api/transfers"), BodyPolicy::Default);
+        assert_eq!(
+            policy("POST", "/api/transfers/j1/commit"),
+            BodyPolicy::Default
+        );
+        assert_eq!(policy("GET", "/api/transfers"), BodyPolicy::None);
+        assert_eq!(
+            policy("GET", "/api/transfers/j1/download"),
+            BodyPolicy::None
+        );
+        assert_eq!(policy("DELETE", "/api/transfers/j1"), BodyPolicy::None);
+        assert_eq!(
+            policy("POST", "/api/transfers/j1/delete"),
+            BodyPolicy::None
+        );
     }
 
     #[test]
@@ -2407,6 +2533,59 @@ mod tests {
                 }
             }
         }
+        // The transfer rows classify exactly per design §4: reads
+        // FilesystemRead, every mutation FilesystemWrite — the same
+        // classes their datachannel twins have always declared.
+        for (method, path, op) in [
+            ("GET", "/api/transfers", PeerOperation::FilesystemRead),
+            (
+                "GET",
+                "/api/transfers/j1/download",
+                PeerOperation::FilesystemRead,
+            ),
+            ("POST", "/api/transfers", PeerOperation::FilesystemWrite),
+            (
+                "POST",
+                "/api/transfers/j1/chunk",
+                PeerOperation::FilesystemWrite,
+            ),
+            (
+                "POST",
+                "/api/transfers/j1/commit",
+                PeerOperation::FilesystemWrite,
+            ),
+            (
+                "DELETE",
+                "/api/transfers/j1",
+                PeerOperation::FilesystemWrite,
+            ),
+            (
+                "POST",
+                "/api/transfers/j1/delete",
+                PeerOperation::FilesystemWrite,
+            ),
+        ] {
+            match classify(method, path) {
+                TableClassification::Matched(matched) => assert_eq!(
+                    matched,
+                    Some(op),
+                    "{method} {path} must classify {op:?}"
+                ),
+                TableClassification::NoMatch => {
+                    panic!("{method} {path} must classify via table")
+                }
+            }
+        }
+        // Undeclared methods on the family stay unrouted (405 at
+        // dispatch), not silently served.
+        assert!(matches!(
+            classify("PUT", "/api/transfers"),
+            TableClassification::NoMatch
+        ));
+        assert!(matches!(
+            classify("GET", "/api/transfers/j1/chunk"),
+            TableClassification::NoMatch
+        ));
     }
 
     #[test]

--- a/src/bin/caller/transfer_store.rs
+++ b/src/bin/caller/transfer_store.rs
@@ -101,6 +101,11 @@ pub struct TransferJob {
     pub mime: Option<String>,
     #[serde(default)]
     pub total_size: Option<u64>,
+    /// Expected content hash for upload jobs (lowercase hex), declared
+    /// at create and verified at commit. Absent from serialized jobs
+    /// when unset, so pre-sha256 wire shapes are unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
     #[serde(default)]
     pub completed_bytes: u64,
     #[serde(default)]
@@ -349,6 +354,7 @@ pub fn create_download_job_from_path(
         filename,
         mime: Some(mime.unwrap_or_else(|| content_type_for_path(&display_path))),
         total_size: Some(metadata.len()),
+        sha256: None,
         completed_bytes: 0,
         error: None,
         conflict_policy: TransferConflictPolicy::Fail,
@@ -412,6 +418,7 @@ pub fn create_download_job_from_bytes(
         filename: Some(safe_name),
         mime: Some(mime),
         total_size: Some(bytes.len() as u64),
+        sha256: None,
         completed_bytes: 0,
         error: None,
         conflict_policy: TransferConflictPolicy::Fail,
@@ -512,14 +519,53 @@ fn resolve_upload_destination(
     Ok((final_path, parent))
 }
 
+/// Normalize a declared upload checksum: lowercase hex, 64 chars.
+fn normalize_expected_sha256(raw: Option<String>) -> Result<Option<String>, TransferStoreError> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    let normalized = raw.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return Ok(None);
+    }
+    if normalized.len() != 64 || !normalized.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(TransferStoreError::new(
+            400,
+            "sha256 must be 64 hex characters",
+        ));
+    }
+    Ok(Some(normalized))
+}
+
+/// Streaming content hash of a file (lowercase hex) — commit-time
+/// verification must not buffer a multi-gigabyte partial in memory.
+fn sha256_file_hex(path: &Path) -> Result<String, std::io::Error> {
+    use sha2::{Digest as _, Sha256};
+    let mut file = fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    let digest: [u8; 32] = hasher.finalize().into();
+    Ok(crate::file_watcher::hex_encode(&digest))
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn create_upload_job(
     scope: &StoreScope,
     raw_destination: &str,
     original_name: &str,
     mime: &str,
     total_size: Option<u64>,
+    sha256: Option<String>,
     conflict_policy: TransferConflictPolicy,
 ) -> Result<TransferJob, TransferStoreError> {
+    let sha256 = normalize_expected_sha256(sha256)?;
     let (final_path, parent) =
         resolve_upload_destination(raw_destination, original_name, conflict_policy)?;
     let id = uuid::Uuid::new_v4().to_string();
@@ -558,6 +604,7 @@ pub fn create_upload_job(
             mime.trim().to_string()
         }),
         total_size,
+        sha256,
         completed_bytes: 0,
         error: None,
         conflict_policy,
@@ -683,6 +730,16 @@ pub fn commit_upload_job(
                 409,
                 "upload is not complete enough to commit",
             ));
+        }
+    }
+    // Verify the declared checksum before the partial is placed — a
+    // mismatch leaves the job resumable-from-scratch (delete + retry)
+    // rather than a corrupt file at the destination.
+    if let Some(expected) = &job.sha256 {
+        let actual = sha256_file_hex(&temp_path)
+            .map_err(|e| TransferStoreError::new(500, format!("hash upload partial: {e}")))?;
+        if &actual != expected {
+            return Err(TransferStoreError::new(409, "upload sha256 mismatch"));
         }
     }
     if destination.exists() {
@@ -1002,6 +1059,7 @@ mod tests {
             "out.txt",
             "text/plain",
             Some(11),
+            None,
             TransferConflictPolicy::Fail,
         )
         .unwrap();
@@ -1050,6 +1108,7 @@ mod tests {
             "out.txt",
             "text/plain",
             Some(3),
+            None,
             TransferConflictPolicy::Fail,
         )
         .unwrap_err();
@@ -1061,6 +1120,7 @@ mod tests {
             "out.txt",
             "text/plain",
             Some(3),
+            None,
             TransferConflictPolicy::Rename,
         )
         .unwrap();
@@ -1087,6 +1147,7 @@ mod tests {
             "out.txt",
             "text/plain",
             Some(3),
+            None,
             TransferConflictPolicy::Fail,
         )
         .unwrap_err();
@@ -1105,6 +1166,73 @@ mod tests {
     }
 
     #[test]
+    fn upload_commit_verifies_declared_sha256() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        let dest_dir = tmp.path().join("dest");
+        fs::create_dir_all(&project).unwrap();
+        fs::create_dir_all(&dest_dir).unwrap();
+        let payload = b"hello world";
+        let good_hash =
+            crate::file_watcher::hex_encode(&crate::file_watcher::sha256_hash(payload));
+
+        // Malformed declarations refuse at create.
+        let err = create_upload_job(
+            &scope(&project),
+            dest_dir.join("bad-decl.bin").to_str().unwrap(),
+            "bad-decl.bin",
+            "application/octet-stream",
+            Some(payload.len() as u64),
+            Some("not-a-hash".to_string()),
+            TransferConflictPolicy::Fail,
+        )
+        .unwrap_err();
+        assert_eq!(err.status, 400);
+        assert_eq!(err.message, "sha256 must be 64 hex characters");
+
+        // A wrong declared hash refuses at commit; the partial and job
+        // survive (delete + retry, never a corrupt destination).
+        let wrong = create_upload_job(
+            &scope(&project),
+            dest_dir.join("wrong.bin").to_str().unwrap(),
+            "wrong.bin",
+            "application/octet-stream",
+            Some(payload.len() as u64),
+            Some("0".repeat(64)),
+            TransferConflictPolicy::Fail,
+        )
+        .unwrap();
+        let wrong =
+            append_upload_tempfile(&scope(&project), &wrong.id, 0, write_chunk(payload), 11)
+                .unwrap();
+        let err = commit_upload_job(&scope(&project), &wrong.id).unwrap_err();
+        assert_eq!(err.status, 409);
+        assert_eq!(err.message, "upload sha256 mismatch");
+        assert!(!dest_dir.join("wrong.bin").exists());
+        assert!(wrong.temp_path.unwrap().exists());
+
+        // The correct hash (declared uppercase — normalized at create)
+        // commits, and the job carries the normalized value.
+        let good = create_upload_job(
+            &scope(&project),
+            dest_dir.join("good.bin").to_str().unwrap(),
+            "good.bin",
+            "application/octet-stream",
+            Some(payload.len() as u64),
+            Some(good_hash.to_ascii_uppercase()),
+            TransferConflictPolicy::Fail,
+        )
+        .unwrap();
+        assert_eq!(good.sha256.as_deref(), Some(good_hash.as_str()));
+        let good =
+            append_upload_tempfile(&scope(&project), &good.id, 0, write_chunk(payload), 11)
+                .unwrap();
+        let committed = commit_upload_job(&scope(&project), &good.id).unwrap();
+        assert_eq!(committed.status, TransferStatus::Completed);
+        assert_eq!(fs::read(dest_dir.join("good.bin")).unwrap(), payload);
+    }
+
+    #[test]
     fn duplicate_already_persisted_upload_chunk_is_idempotent() {
         let tmp = tempfile::tempdir().unwrap();
         let project = tmp.path().join("project");
@@ -1118,6 +1246,7 @@ mod tests {
             "out.txt",
             "text/plain",
             Some(6),
+            None,
             TransferConflictPolicy::Fail,
         )
         .unwrap();
@@ -1146,6 +1275,7 @@ mod tests {
             "out.txt",
             "text/plain",
             Some(3),
+            None,
             TransferConflictPolicy::Overwrite,
         )
         .unwrap();
@@ -1178,6 +1308,7 @@ mod tests {
             "out.txt",
             "text/plain",
             Some(3),
+            None,
             TransferConflictPolicy::Overwrite,
         )
         .unwrap_err();

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -379,7 +379,7 @@ pub(crate) async fn serve_http_request(
         }
     }
 
-    if let Some((route, _route_captures)) = crate::gateway_routes::match_route(req_method, req_path)
+    if let Some((route, route_captures)) = crate::gateway_routes::match_route(req_method, req_path)
     {
         // Table-dispatched routes: every /api/* and /mcp route is
         // declared once in gateway_routes::ROUTES (which the IAM
@@ -426,6 +426,14 @@ pub(crate) async fn serve_http_request(
                 }
             }
         };
+        // The transfer rows' `{id}` capture (both delete shapes capture
+        // exactly the id — the literal segments don't capture).
+        let transfer_job_id = || {
+            route_captures
+                .first()
+                .map(|id| id.to_string())
+                .unwrap_or_default()
+        };
         match route.handler {
             RouteHandlerId::FsWrite => {
                 return handle_fs_write(
@@ -434,6 +442,78 @@ pub(crate) async fn serve_http_request(
                     http_access_context,
                     peer_connection_identity,
                     bus,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
+            RouteHandlerId::TransferJobs => {
+                return handle_transfer_jobs(
+                    stream,
+                    request_line,
+                    project_root_for_changes,
+                    http_access_context,
+                    peer_connection_identity,
+                    bus,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
+            RouteHandlerId::TransferJobCreate => {
+                return handle_transfer_job_create(
+                    stream,
+                    route_body,
+                    project_root_for_changes,
+                    http_access_context,
+                    peer_connection_identity,
+                    bus,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
+            RouteHandlerId::TransferUploadChunk => {
+                return handle_transfer_upload_chunk(
+                    stream,
+                    header_text,
+                    request_line,
+                    discard,
+                    transfer_job_id(),
+                    project_root_for_changes,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
+            RouteHandlerId::TransferUploadCommit => {
+                return handle_transfer_upload_commit(
+                    stream,
+                    route_body,
+                    transfer_job_id(),
+                    project_root_for_changes,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
+            RouteHandlerId::TransferJobDelete => {
+                return handle_transfer_job_delete(
+                    stream,
+                    transfer_job_id(),
+                    project_root_for_changes,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
+            RouteHandlerId::TransferDownloadRead => {
+                return handle_transfer_download_read(
+                    stream,
+                    header_text,
+                    request_line,
+                    transfer_job_id(),
+                    project_root_for_changes,
                     route.cors,
                     fleet_cors_origin.as_deref(),
                 )

--- a/src/bin/caller/web_gateway/routes_transfers.rs
+++ b/src/bin/caller/web_gateway/routes_transfers.rs
@@ -19,6 +19,14 @@ use super::*;
 use crate::global_store::StoreScope;
 use crate::transfer_store::{TransferJob, TransferKind, TransferStoreError};
 
+/// Per-request body cap for `POST /api/transfers/{id}/chunk` (design
+/// §4): bounds what one chunk may spool to memory/disk. Deliberately
+/// far under the staged-attachment cap — resumability makes small
+/// chunks cheap, and N capped chunks + commit is exactly how an
+/// over-100-MiB upload rides direct HTTP (task #6). Pinned (with the
+/// row's `Streaming` policy) by the gateway body-cap test.
+pub(crate) const TRANSFER_HTTP_CHUNK_MAX_BYTES: usize = 32 * 1024 * 1024;
+
 /// The job-handle aliases every transfer method accepts, `id` first
 /// (the tunnel's historical precedence). A resume token works anywhere
 /// an id does — `transfer_store::find_job` resolves either.
@@ -134,18 +142,18 @@ pub(crate) fn classify_transfer_create(
 
 /// The upload-create params, decoded with the tunnel's historical
 /// lenient alias reads.
-fn upload_create_params(
-    params: &serde_json::Value,
-) -> Result<
-    (
-        String,
-        String,
-        String,
-        Option<u64>,
-        crate::transfer_store::TransferConflictPolicy,
-    ),
-    TransferStoreError,
-> {
+struct UploadCreateParams {
+    destination: String,
+    original_name: String,
+    mime: String,
+    total_size: Option<u64>,
+    /// Declared content hash, verified at commit (design §4; the store
+    /// normalizes/validates it).
+    sha256: Option<String>,
+    conflict_policy: crate::transfer_store::TransferConflictPolicy,
+}
+
+fn upload_create_params(params: &serde_json::Value) -> Result<UploadCreateParams, TransferStoreError> {
     let destination = string_param(
         params,
         &["destination", "destination_path", "destinationPath", "path"],
@@ -178,6 +186,7 @@ fn upload_create_params(
         ],
     )
     .map_err(|error| TransferStoreError::new(400, error))?;
+    let sha256 = optional_string_param(params, &["sha256"]);
     let conflict = optional_string_param(
         params,
         &[
@@ -194,7 +203,14 @@ fn upload_create_params(
             .ok_or_else(|| {
                 TransferStoreError::new(400, "conflict policy must be fail, rename, or overwrite")
             })?;
-    Ok((destination, original_name, mime, total_size, conflict_policy))
+    Ok(UploadCreateParams {
+        destination,
+        original_name,
+        mime,
+        total_size,
+        sha256,
+        conflict_policy,
+    })
 }
 
 /// The path a path-based create targets — the download source (its
@@ -202,9 +218,6 @@ fn upload_create_params(
 /// the caller's lane gate scope-checks at create; the job-addressed
 /// methods (chunk/commit/delete/download) act on that already-scoped
 /// destination and carry no path of their own.
-// Consumed by the S9b HTTP rows' create gate (this allow leaves with
-// them).
-#[allow(dead_code)]
 pub(crate) fn transfer_create_target_path(
     params: &serde_json::Value,
     kind: TransferKind,
@@ -241,19 +254,19 @@ pub(crate) async fn transfer_path_create_api_response(
             .await
         }
         TransferKind::Upload => {
-            let (destination, original_name, mime, total_size, conflict_policy) =
-                match upload_create_params(&params) {
-                    Ok(decoded) => decoded,
-                    Err(error) => return transfer_store_error_api_response(error),
-                };
+            let decoded = match upload_create_params(&params) {
+                Ok(decoded) => decoded,
+                Err(error) => return transfer_store_error_api_response(error),
+            };
             tokio::task::spawn_blocking(move || {
                 crate::transfer_store::create_upload_job(
                     &scope,
-                    &destination,
-                    &original_name,
-                    &mime,
-                    total_size,
-                    conflict_policy,
+                    &decoded.destination,
+                    &decoded.original_name,
+                    &decoded.mime,
+                    decoded.total_size,
+                    decoded.sha256,
+                    decoded.conflict_policy,
                 )
             })
             .await
@@ -271,9 +284,6 @@ pub(crate) async fn transfer_path_create_api_response(
 /// reads live session handles the HTTP edge deliberately lacks). Path
 /// authorization is the caller's lane gate, on
 /// [`transfer_create_target_path`].
-// Consumed by the S9b `POST /api/transfers` row (pinned by the parity
-// fixtures meanwhile; this allow leaves with the row).
-#[allow(dead_code)]
 pub(crate) async fn transfer_job_create_http_api_response(
     scope: StoreScope,
     params: serde_json::Value,
@@ -517,6 +527,312 @@ async fn resolve_transfer_range_header(
     }
 }
 
+// ── The HTTP lane: thin adapters over the cores above (S9b, the §4
+//    rows). Transport edges only — query/body/Range parsing, the
+//    transfer-family authorization mirror, store-scope resolution —
+//    every response body comes from the shared fns. ──
+
+/// The transfer family's fs gate, mirroring the tunnel's
+/// `authorize_dashboard_control_filesystem` exactly:
+///
+/// - **create** names a target path (`Some`) — scope-checked (+
+///   audited) through [`authorize_http_filesystem_access`], write-kind
+///   for both job kinds, exactly as the tunnel derives kind from the
+///   method's operation;
+/// - the **job-addressed** methods carry no path (`None`): a
+///   scope-restricted caller — a peer identity or an fs-scoped grant —
+///   is denied fail-closed with the tunnel's wording (its destination
+///   was scoped at create, but a scoped principal must never reach
+///   job-addressed reads/writes it could not have created), while
+///   unrestricted principals pass on the row's operation alone.
+fn authorize_http_transfer_access(
+    access: &HttpAccessContext,
+    identity: Option<&PeerConnectionIdentity>,
+    op: crate::peer::access_policy::PeerOperation,
+    target_path: Option<&str>,
+    bus: &EventBus,
+) -> Result<(), String> {
+    if let Some(path) = target_path {
+        return authorize_http_filesystem_access(
+            access,
+            identity,
+            op,
+            crate::peer::access_policy::FilesystemAccessKind::Write,
+            path,
+            bus,
+        );
+    }
+    let denied = "filesystem request missing path".to_string();
+    if let Some(identity) = identity {
+        audit_peer_filesystem_access(bus, identity, op, "", false, &denied);
+        return Err(denied);
+    }
+    let scoped = access
+        .iam_state
+        .as_ref()
+        .and_then(|state| crate::access::iam::fs_scope_for_principal(state, &access.principal))
+        .is_some();
+    if scoped {
+        bus.send(AppEvent::PresenceLog {
+            message: format!(
+                "[grant-fs] denied principal={} op={:?} path= detail={}",
+                access.principal.label, op, denied
+            ),
+            level: Some(LogLevel::Warn),
+            turn: None,
+        });
+        return Err(denied);
+    }
+    Ok(())
+}
+
+/// Transport edge: where transfer jobs persist for this daemon — the
+/// project store when rooted, the daemon-global fallback otherwise
+/// (`transfer_store_scope`'s HTTP twin; the cores take the result
+/// injected).
+fn http_transfer_scope(project_root: Option<&std::path::Path>) -> StoreScope {
+    StoreScope::resolve(project_root)
+}
+
+/// `GET /api/transfers` — list jobs (`?id=`/`?resume_token=` filter).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn handle_transfer_jobs(
+    stream: DemuxStream,
+    request_line: &str,
+    project_root: Option<std::path::PathBuf>,
+    http_access_context: HttpAccessContext,
+    peer_connection_identity: Option<PeerConnectionIdentity>,
+    bus: EventBus,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let mut params = serde_json::Map::new();
+    for key in ["id", "resume_token"] {
+        if let Some(value) = query_param(request_line, key) {
+            params.insert(key.to_string(), serde_json::Value::String(value));
+        }
+    }
+    let params = serde_json::Value::Object(params);
+    let response = match authorize_http_transfer_access(
+        &http_access_context,
+        peer_connection_identity.as_ref(),
+        crate::peer::access_policy::PeerOperation::FilesystemRead,
+        None,
+        &bus,
+    ) {
+        Ok(()) => {
+            transfer_jobs_api_response(http_transfer_scope(project_root.as_deref()), &params).await
+        }
+        Err(message) => transfer_error_api_response(403, message),
+    };
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+/// `POST /api/transfers` — create a job from the JSON body (the
+/// tunnel's params shape verbatim). The target path is scope-checked
+/// here, at create, for both kinds; artifact-shaped creates are
+/// tunnel-only (divergence #24).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn handle_transfer_job_create(
+    stream: DemuxStream,
+    body_text: String,
+    project_root: Option<std::path::PathBuf>,
+    http_access_context: HttpAccessContext,
+    peer_connection_identity: Option<PeerConnectionIdentity>,
+    bus: EventBus,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let response = match serde_json::from_str::<serde_json::Value>(&body_text) {
+        Ok(params) if params.is_object() => {
+            // The scope gate sees the path the create will actually
+            // target (kind-aware aliases); a kind that fails to parse
+            // falls through pathless — fail-closed for scoped callers,
+            // the shared 400 for everyone else.
+            let target = classify_transfer_create(&params)
+                .ok()
+                .and_then(|request| match request {
+                    TransferCreateRequest::Path(kind) => {
+                        transfer_create_target_path(&params, kind)
+                    }
+                    TransferCreateRequest::Artifact(_) => None,
+                });
+            match authorize_http_transfer_access(
+                &http_access_context,
+                peer_connection_identity.as_ref(),
+                crate::peer::access_policy::PeerOperation::FilesystemWrite,
+                target.as_deref(),
+                &bus,
+            ) {
+                Ok(()) => {
+                    transfer_job_create_http_api_response(
+                        http_transfer_scope(project_root.as_deref()),
+                        params,
+                    )
+                    .await
+                }
+                Err(message) => transfer_error_api_response(403, message),
+            }
+        }
+        Ok(_) => transfer_error_api_response(400, "request body must be a JSON object"),
+        Err(e) => transfer_error_api_response(400, format!("invalid JSON: {e}")),
+    };
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+/// `POST /api/transfers/{id}/chunk?offset=N[&resume_token=…]` — spool
+/// the raw body (S8's `SpooledBody` lane, capped at
+/// [`TRANSFER_HTTP_CHUNK_MAX_BYTES`]) and append it through the shared
+/// core. Chunk auth needs only the row's operation — the destination
+/// was path-scoped at create (the tunnel's upload-frame model).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn handle_transfer_upload_chunk(
+    mut stream: DemuxStream,
+    header_text: &str,
+    request_line: &str,
+    discard: Vec<u8>,
+    job_id: String,
+    project_root: Option<std::path::PathBuf>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    use tokio::io::AsyncWriteExt;
+    let mut params = serde_json::Map::new();
+    params.insert("id".to_string(), serde_json::Value::String(job_id));
+    for key in ["offset", "resume_token"] {
+        if let Some(value) = query_param(request_line, key) {
+            params.insert(key.to_string(), serde_json::Value::String(value));
+        }
+    }
+    let params = serde_json::Value::Object(params);
+    if header_text
+        .lines()
+        .any(|l| l.trim().eq_ignore_ascii_case("expect: 100-continue"))
+    {
+        let _ = stream.write_all(b"HTTP/1.1 100 Continue\r\n\r\n").await;
+    }
+    let response = match stream_body_to_tempfile(
+        header_text,
+        &discard,
+        &mut stream,
+        TRANSFER_HTTP_CHUNK_MAX_BYTES,
+    )
+    .await
+    {
+        Err(e) => {
+            let status = if e.contains("too large") { 413 } else { 400 };
+            transfer_error_api_response(status, e)
+        }
+        Ok(body) => {
+            transfer_upload_chunk_api_response(
+                http_transfer_scope(project_root.as_deref()),
+                &params,
+                body,
+            )
+            .await
+        }
+    };
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+/// `POST /api/transfers/{id}/commit` — verify and place the finished
+/// upload. An optional JSON body may carry extra params; the path
+/// capture is the job handle.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn handle_transfer_upload_commit(
+    stream: DemuxStream,
+    body_text: String,
+    job_id: String,
+    project_root: Option<std::path::PathBuf>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let params = if body_text.trim().is_empty() {
+        Ok(serde_json::Map::new())
+    } else {
+        match serde_json::from_str::<serde_json::Value>(&body_text) {
+            Ok(serde_json::Value::Object(map)) => Ok(map),
+            Ok(_) => Err("request body must be a JSON object".to_string()),
+            Err(e) => Err(format!("invalid JSON: {e}")),
+        }
+    };
+    let response = match params {
+        Ok(mut params) => {
+            params.insert("id".to_string(), serde_json::Value::String(job_id));
+            transfer_upload_commit_api_response(
+                http_transfer_scope(project_root.as_deref()),
+                &serde_json::Value::Object(params),
+            )
+            .await
+        }
+        Err(message) => transfer_error_api_response(400, message),
+    };
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+/// `DELETE /api/transfers/{id}` (+ the WKWebView POST
+/// `/api/transfers/{id}/delete` fallback — both shapes capture the same
+/// id and share this handler).
+pub(crate) async fn handle_transfer_job_delete(
+    stream: DemuxStream,
+    job_id: String,
+    project_root: Option<std::path::PathBuf>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let response = transfer_job_delete_api_response(
+        http_transfer_scope(project_root.as_deref()),
+        &serde_json::json!({ "id": job_id }),
+    )
+    .await;
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+/// `GET /api/transfers/{id}/download` — ranged read: an HTTP `Range`
+/// header takes precedence (it is the protocol's range mechanism);
+/// otherwise `?offset=&length=`; otherwise the full (capped) extent.
+pub(crate) async fn handle_transfer_download_read(
+    stream: DemuxStream,
+    header_text: &str,
+    request_line: &str,
+    job_id: String,
+    project_root: Option<std::path::PathBuf>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let params = serde_json::json!({ "id": job_id });
+    let range = if let Some(header) = dashboard_http_header_value(header_text, "range") {
+        Ok(ByteRange::HttpHeader(header.to_string()))
+    } else {
+        let query = serde_json::json!({
+            "offset": query_param(request_line, "offset"),
+            "length": query_param(request_line, "length"),
+        });
+        match (
+            optional_u64_param(&query, &["offset"]),
+            optional_u64_param(&query, &["length"]),
+        ) {
+            (Ok(offset), Ok(length)) => Ok(ByteRange::OffsetLength {
+                offset: offset.unwrap_or(0),
+                length,
+            }),
+            (Err(error), _) | (_, Err(error)) => Err(error),
+        }
+    };
+    let response = match range {
+        Ok(range) => {
+            transfer_download_read_api_response(
+                http_transfer_scope(project_root.as_deref()),
+                &params,
+                range,
+            )
+            .await
+        }
+        Err(message) => transfer_error_api_response(400, message),
+    };
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -698,6 +1014,270 @@ mod tests {
                 .await,
         );
         assert_eq!(again["deleted"], false);
+    }
+
+    /// The HTTP lane's transfer-family gate mirrors the tunnel's
+    /// `authorize_dashboard_control_filesystem` exactly: unrestricted
+    /// principals pass on the row's operation; scope-restricted callers
+    /// (fs-scoped grants, peer identities) are scope-checked on the
+    /// create target and denied fail-closed on the pathless
+    /// job-addressed rows with the tunnel's wording.
+    #[test]
+    fn transfer_authorization_mirrors_the_tunnel_fail_closed_rule() {
+        use crate::peer::access_policy::PeerOperation;
+        let bus = crate::event::EventBus::new();
+        let dir = tempfile::tempdir().unwrap();
+        let in_scope = dir.path().join("shared");
+        std::fs::create_dir_all(&in_scope).unwrap();
+
+        // Unrestricted (root-session) context: pathless rows and any
+        // create target pass on the operation alone.
+        let root = HttpAccessContext {
+            principal: crate::access::iam::AccessPrincipal::root_dashboard_session(
+                "unit-test", "https",
+            ),
+            iam_state: None,
+        };
+        assert!(authorize_http_transfer_access(
+            &root,
+            None,
+            PeerOperation::FilesystemRead,
+            None,
+            &bus
+        )
+        .is_ok());
+        assert!(authorize_http_transfer_access(
+            &root,
+            None,
+            PeerOperation::FilesystemWrite,
+            Some(&in_scope.join("up.bin").to_string_lossy()),
+            &bus
+        )
+        .is_ok());
+
+        // An fs-scoped user-client grant: in-scope create passes,
+        // out-of-scope create is refused, and the pathless rows are
+        // denied fail-closed exactly as the tunnel denies them.
+        let mut state = crate::access::iam::LocalIamState::default();
+        let actor =
+            crate::access::iam::AccessPrincipal::root_dashboard_session("admin", "https");
+        let result = crate::access::iam::upsert_user_client_grant(
+            &mut state,
+            crate::access::iam::UserClientGrantUpsertRequest {
+                kind: "browser_certificate".to_string(),
+                fingerprint: Some("AA:11".to_string()),
+                role_id: Some("role:operator".to_string()),
+                fs_write_roots: vec![in_scope.to_string_lossy().to_string()],
+                fs_read_roots: vec![in_scope.to_string_lossy().to_string()],
+                ..Default::default()
+            },
+            &actor,
+        )
+        .unwrap();
+        let scoped = HttpAccessContext {
+            principal: crate::access::iam::AccessPrincipal {
+                grant_id: Some(result.grant.id.clone()),
+                ..crate::access::iam::AccessPrincipal::root_dashboard_session("scoped", "https")
+            },
+            iam_state: Some(state),
+        };
+        assert!(authorize_http_transfer_access(
+            &scoped,
+            None,
+            PeerOperation::FilesystemWrite,
+            Some(&in_scope.join("up.bin").to_string_lossy()),
+            &bus
+        )
+        .is_ok());
+        assert!(authorize_http_transfer_access(
+            &scoped,
+            None,
+            PeerOperation::FilesystemWrite,
+            Some("/etc/shadow-copy"),
+            &bus
+        )
+        .is_err());
+        for op in [
+            PeerOperation::FilesystemRead,
+            PeerOperation::FilesystemWrite,
+        ] {
+            assert_eq!(
+                authorize_http_transfer_access(&scoped, None, op, None, &bus).unwrap_err(),
+                "filesystem request missing path",
+                "{op:?}"
+            );
+        }
+
+        // A peer identity is scope-restricted by construction: pathless
+        // rows are denied even under a permissive-looking policy.
+        let peer = PeerConnectionIdentity {
+            fingerprint: "aabbccdd".to_string(),
+            label: "peer".to_string(),
+            profile: "file-operator".to_string(),
+            filesystem: Default::default(),
+        };
+        assert_eq!(
+            authorize_http_transfer_access(
+                &root,
+                Some(&peer),
+                PeerOperation::FilesystemRead,
+                None,
+                &bus
+            )
+            .unwrap_err(),
+            "filesystem request missing path"
+        );
+    }
+
+    /// Raw HTTP transcripts for the rows' distinctive wire shapes
+    /// (design §8 goldens: status lines, header order, bodies): the
+    /// download row's 200/206/416 forms and the commit row's
+    /// sha-mismatch 409, rendered through the one HTTP adapter the
+    /// dispatch arms use.
+    #[tokio::test]
+    async fn golden_http_transcripts_pin_download_and_commit_shapes() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path().join("project");
+        let dest_dir = dir.path().join("dest");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(&dest_dir).unwrap();
+        let scope = project_scope(&project);
+        let source = dir.path().join("payload.txt");
+        std::fs::write(&source, b"hello transfer").unwrap();
+        let job =
+            crate::transfer_store::create_download_job(&scope, source.to_str().unwrap()).unwrap();
+        let params = serde_json::json!({ "id": job.id });
+        let transcript = |response: ApiResponse| {
+            String::from_utf8(crate::web_gateway::api_response_http_bytes(
+                response,
+                crate::gateway_routes::CorsPosture::OwnOrigin,
+                None,
+            ))
+            .unwrap()
+        };
+
+        // Full read: exact head (status line + header order) and body.
+        let full = transcript(
+            transfer_download_read_api_response(
+                scope.clone(),
+                &params,
+                ByteRange::OffsetLength {
+                    offset: 0,
+                    length: None,
+                },
+            )
+            .await,
+        );
+        let sha = fs_sha256_hex(b"hello transfer");
+        let expected_full = format!(
+            "HTTP/1.1 200 OK\r\n\
+             Content-Type: text/plain; charset=utf-8\r\n\
+             Content-Length: 14\r\n\
+             Accept-Ranges: bytes\r\n\
+             X-Transfer-Range-Start: 0\r\n\
+             X-Transfer-Range-End: 14\r\n\
+             X-Transfer-Total-Size: 14\r\n\
+             X-Transfer-Resumable: true\r\n\
+             X-Content-Sha256: {sha}\r\n\
+             Content-Disposition: attachment; filename=\"payload.txt\"\r\n\
+             Cache-Control: no-cache\r\n\
+             Connection: close\r\n\
+             \r\n\
+             hello transfer"
+        );
+        assert_eq!(full, expected_full);
+
+        // Partial read: 206 with Content-Range before the resume echoes.
+        let partial = transcript(
+            transfer_download_read_api_response(
+                scope.clone(),
+                &params,
+                ByteRange::HttpHeader("bytes=6-13".to_string()),
+            )
+            .await,
+        );
+        let expected_partial = "HTTP/1.1 206 Partial Content\r\n\
+             Content-Type: text/plain; charset=utf-8\r\n\
+             Content-Length: 8\r\n\
+             Accept-Ranges: bytes\r\n\
+             Content-Range: bytes 6-13/14\r\n\
+             X-Transfer-Range-Start: 6\r\n\
+             X-Transfer-Range-End: 14\r\n\
+             X-Transfer-Total-Size: 14\r\n\
+             X-Transfer-Resumable: true\r\n\
+             Content-Disposition: attachment; filename=\"payload.txt\"\r\n\
+             Cache-Control: no-cache\r\n\
+             Connection: close\r\n\
+             \r\n\
+             transfer";
+        assert_eq!(partial, expected_partial);
+
+        // Unsatisfiable header: 416 with the probing Content-Range tail.
+        let unsatisfiable = transcript(
+            transfer_download_read_api_response(
+                scope.clone(),
+                &params,
+                ByteRange::HttpHeader("bytes=99-".to_string()),
+            )
+            .await,
+        );
+        let expected_416 = "HTTP/1.1 416 Range Not Satisfiable\r\n\
+             Content-Type: application/json\r\n\
+             Content-Length: 51\r\n\
+             Content-Range: bytes */14\r\n\
+             Accept-Ranges: bytes\r\n\
+             Cache-Control: no-cache\r\n\
+             Connection: close\r\n\
+             \r\n\
+             {\"error\":\"range is not satisfiable\",\"ok\":false}";
+        // serde_json object key order is alphabetical for json! literals
+        // built in one shot; compute the length from the actual body to
+        // keep the pin honest.
+        let body = expected_416.split("\r\n\r\n").nth(1).unwrap();
+        assert_eq!(
+            unsatisfiable,
+            expected_416.replace(
+                "Content-Length: 51",
+                &format!("Content-Length: {}", body.len())
+            )
+        );
+
+        // Commit sha mismatch: the 409 wire shape end to end.
+        let upload = crate::transfer_store::create_upload_job(
+            &scope,
+            dest_dir.join("sum.bin").to_str().unwrap(),
+            "sum.bin",
+            "application/octet-stream",
+            Some(4),
+            Some("0".repeat(64)),
+            crate::transfer_store::TransferConflictPolicy::Fail,
+        )
+        .unwrap();
+        let chunked = transfer_upload_chunk_api_response(
+            scope.clone(),
+            &serde_json::json!({ "id": upload.id, "offset": 0 }),
+            spooled(b"data"),
+        )
+        .await;
+        let (status, body) = json_body(&chunked);
+        assert_eq!(status, 200, "{body}");
+        let mismatch = transcript(
+            transfer_upload_commit_api_response(
+                scope.clone(),
+                &serde_json::json!({ "id": upload.id }),
+            )
+            .await,
+        );
+        assert_eq!(
+            mismatch,
+            "HTTP/1.1 409 Conflict\r\n\
+             Content-Type: application/json\r\n\
+             Content-Length: 45\r\n\
+             Cache-Control: no-cache\r\n\
+             Connection: close\r\n\
+             \r\n\
+             {\"error\":\"upload sha256 mismatch\",\"ok\":false}"
+        );
     }
 
     #[tokio::test]

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1177,6 +1177,220 @@ async fn ctl_session_note_posts_a_display_only_note_with_image() {
     .await;
 }
 
+/// Task #6 end to end, against the real binaries: a resumable upload
+/// rides direct HTTP as job create → capped raw chunks → commit,
+/// survives a "client restart" (re-list by handle, resume at the
+/// received extent, wrong-offset refusal), verifies the declared
+/// sha256 at commit, and the finished file rides back out over the
+/// download row — full read with `X-Content-Sha256`, then a `Range`
+/// request answering 206 with the `X-Transfer-*` resume echoes. Both
+/// delete shapes (native DELETE + the WKWebView POST fallback) tear the
+/// jobs down.
+#[tokio::test]
+async fn transfer_jobs_round_trip_over_direct_http() {
+    use sha2::Digest as _;
+
+    let idle_script = serde_json::json!({
+        "profiles": [{
+            "steps": [
+                { "content": "fallback profile (unexpected session)",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "unexpected session" } }] }
+            ]
+        }]
+    });
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("http client");
+    let port = free_loopback_port();
+    let daemon = spawn_daemon(&client, &idle_script, port).await;
+    let base = format!("http://127.0.0.1:{port}");
+
+    // Two uneven chunks force a mid-file resume boundary.
+    let payload: Vec<u8> = (0..300_000u32).map(|i| (i % 251) as u8).collect();
+    let (head, tail_bytes) = payload.split_at(180_000);
+    let sha256 = {
+        let digest = sha2::Sha256::digest(&payload);
+        digest.iter().map(|b| format!("{b:02x}")).collect::<String>()
+    };
+    let dest = daemon.rig.project.path().join("received").join("big.bin");
+    std::fs::create_dir_all(dest.parent().expect("dest parent")).expect("mk dest dir");
+
+    // Create the upload job (declared size + checksum).
+    let created: serde_json::Value = client
+        .post(format!("{base}/api/transfers"))
+        .json(&serde_json::json!({
+            "kind": "upload",
+            "destination": dest.to_string_lossy(),
+            "name": "big.bin",
+            "total_size": payload.len(),
+            "sha256": sha256,
+        }))
+        .send()
+        .await
+        .expect("create upload job")
+        .json()
+        .await
+        .expect("create body");
+    assert_eq!(created["ok"], true, "{created}");
+    let job_id = created["job"]["id"].as_str().expect("job id").to_string();
+    let resume_token = created["job"]["resume_token"]
+        .as_str()
+        .expect("resume token")
+        .to_string();
+    assert_eq!(created["job"]["completed_bytes"], 0, "{created}");
+
+    // First chunk.
+    let first = client
+        .post(format!("{base}/api/transfers/{job_id}/chunk?offset=0"))
+        .body(head.to_vec())
+        .send()
+        .await
+        .expect("first chunk");
+    assert_eq!(first.status().as_u16(), 200);
+    let first: serde_json::Value = first.json().await.expect("first chunk body");
+    assert_eq!(first["job"]["status"], "running", "{first}");
+    assert_eq!(first["job"]["completed_bytes"], head.len(), "{first}");
+
+    // "Client restart": re-list by handle and read the received extent.
+    let listed: serde_json::Value = client
+        .get(format!("{base}/api/transfers?id={job_id}"))
+        .send()
+        .await
+        .expect("list jobs")
+        .json()
+        .await
+        .expect("list body");
+    let jobs = listed["jobs"].as_array().expect("jobs array");
+    assert_eq!(jobs.len(), 1, "{listed}");
+    let boundary = jobs[0]["completed_bytes"].as_u64().expect("extent") as usize;
+    assert_eq!(boundary, head.len(), "{listed}");
+
+    // A wrong-offset chunk that overlaps the persisted extent without
+    // being covered by it is refused — the resume contract (a fully
+    // covered duplicate would be answered idempotently instead).
+    let conflict = client
+        .post(format!(
+            "{base}/api/transfers/{job_id}/chunk?offset={}",
+            boundary - 1
+        ))
+        .body(tail_bytes.to_vec())
+        .send()
+        .await
+        .expect("conflicting chunk");
+    assert_eq!(conflict.status().as_u16(), 409);
+
+    // Resume at the boundary, addressing the job by resume token.
+    let second = client
+        .post(format!(
+            "{base}/api/transfers/{resume_token}/chunk?offset={boundary}"
+        ))
+        .body(tail_bytes.to_vec())
+        .send()
+        .await
+        .expect("second chunk");
+    assert_eq!(second.status().as_u16(), 200);
+    let second: serde_json::Value = second.json().await.expect("second chunk body");
+    assert_eq!(second["job"]["status"], "ready", "{second}");
+
+    // Commit verifies size + sha256 and renames into place.
+    let committed = client
+        .post(format!("{base}/api/transfers/{job_id}/commit"))
+        .send()
+        .await
+        .expect("commit");
+    assert_eq!(committed.status().as_u16(), 200);
+    let committed: serde_json::Value = committed.json().await.expect("commit body");
+    assert_eq!(committed["job"]["status"], "completed", "{committed}");
+    assert_eq!(std::fs::read(&dest).expect("committed file"), payload);
+
+    // Round-trip back out: a download job over the same lane.
+    let download: serde_json::Value = client
+        .post(format!("{base}/api/transfers"))
+        .json(&serde_json::json!({
+            "kind": "download",
+            "path": dest.to_string_lossy(),
+        }))
+        .send()
+        .await
+        .expect("create download job")
+        .json()
+        .await
+        .expect("download job body");
+    assert_eq!(download["ok"], true, "{download}");
+    let download_id = download["job"]["id"].as_str().expect("dl id").to_string();
+
+    // Full read: 200 with the content hash + resume echoes.
+    let full = client
+        .get(format!("{base}/api/transfers/{download_id}/download"))
+        .send()
+        .await
+        .expect("full download");
+    assert_eq!(full.status().as_u16(), 200);
+    assert_eq!(
+        full.headers()
+            .get("X-Content-Sha256")
+            .and_then(|value| value.to_str().ok()),
+        Some(sha256.as_str())
+    );
+    assert_eq!(
+        full.headers()
+            .get("X-Transfer-Total-Size")
+            .and_then(|value| value.to_str().ok()),
+        Some(payload.len().to_string().as_str())
+    );
+    assert_eq!(full.bytes().await.expect("full body").as_ref(), payload);
+
+    // Ranged read: standard 206/Content-Range plus the end-exclusive
+    // X-Transfer resume echoes.
+    let ranged = client
+        .get(format!("{base}/api/transfers/{download_id}/download"))
+        .header("Range", "bytes=100-199")
+        .send()
+        .await
+        .expect("ranged download");
+    assert_eq!(ranged.status().as_u16(), 206);
+    assert_eq!(
+        ranged
+            .headers()
+            .get("Content-Range")
+            .and_then(|value| value.to_str().ok()),
+        Some(format!("bytes 100-199/{}", payload.len()).as_str())
+    );
+    assert_eq!(
+        ranged
+            .headers()
+            .get("X-Transfer-Range-End")
+            .and_then(|value| value.to_str().ok()),
+        Some("200")
+    );
+    assert_eq!(
+        ranged.bytes().await.expect("ranged body").as_ref(),
+        &payload[100..200]
+    );
+
+    // Teardown over both delete shapes.
+    let deleted: serde_json::Value = client
+        .delete(format!("{base}/api/transfers/{job_id}"))
+        .send()
+        .await
+        .expect("native delete")
+        .json()
+        .await
+        .expect("delete body");
+    assert_eq!(deleted["deleted"], true, "{deleted}");
+    let fallback: serde_json::Value = client
+        .post(format!("{base}/api/transfers/{download_id}/delete"))
+        .send()
+        .await
+        .expect("fallback delete")
+        .json()
+        .await
+        .expect("fallback delete body");
+    assert_eq!(fallback["deleted"], true, "{fallback}");
+}
+
 /// The display-request rail end to end: a caller rings the user-display
 /// doorbell (`ctl display request` → the `request_user_display` tool), a
 /// dashboard surface (here: a raw `/ws` client) receives the dedicated


### PR DESCRIPTION
Second S9 PR (stacked on #195; retargets to main when it lands). Design §4 verbatim: the six transfer rows + handlers over the S9a neutral cores, TRANSFER_HTTP_CHUNK_MAX_BYTES = 32 MiB pinned, tunnel columns + partition-pin flips, sha256 create/commit contract, docs regen, HTTP transcript goldens, and a full resume-flow e2e.