### PR TITLE
ci hooks: foreground timeout poll + CI-account gate

### DIFF
--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -202,10 +202,17 @@ them.
 `hooks/hook-lib.sh`) are wired through each runner root's `.env` —
 `ACTIONS_RUNNER_HOOK_JOB_STARTED=…` / `…_JOB_COMPLETED=…`, the
 documented runner mechanism; the runner reads `.env` at listener
-startup, so re-wiring needs a listener restart. Per invocation,
-bounded by a 60s self-timeout (a watchdog subshell reaps hung work —
-GitHub applies no timeout of its own, and a wedged started-hook would
-wedge the job):
+startup, so re-wiring needs a listener restart. Every invocation is
+**account-gated** before anything else: `run_hook` refuses (one log
+line, exit 0) unless `id -un` matches `INTENDANT_CI_HOOK_ACCOUNT`
+from the same `.env` (the migrate script wires it). The rules below
+are only safe inside the dedicated CI account — executed as anyone
+else they apply "everything here is CI residue" to a real user's
+session and daemon state, which is precisely the 2026-07-10 incident.
+Work is bounded by a 60s self-timeout — a foreground poll in the
+hook's own shell, deliberately not a detached timer subshell, which
+bash 3.2 leaked and later fired at recycled pids (GitHub applies no
+timeout of its own, and a wedged started-hook would wedge the job):
 
 - wipe `$RUNNER_TEMP` contents (per-runner, recreated every job);
 - reap stale (>24h) temp/test-home residue — `$TMPDIR` and

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -232,6 +232,24 @@ timeout of its own, and a wedged started-hook would wedge the job):
 Never touched: `~/.cache/intendant-ci` (the watchdog owns the warm
 target caches), `~/.cargo`, `~/.rustup`.
 
+### sccache: one supervised server per account
+
+The account's `rustc-wrapper` clients rendezvous with ONE server on
+the account's port (4227; the operator's server keeps the 4226
+default). Never rely on in-job server spawning: cargo's `[env]` port
+does not reach every in-job sccache invocation (2026-07-10: the rustc
+version probe missed it), and a client racing a dying or job-reaped
+server reads a truncated response header — "failed to fill whole
+buffer", cargo exit 101 within seconds, every job on the listener red.
+Instead `setup-ci-account-macos.sh` installs
+`com.intendant.ci.sccache`, a launchd-supervised **foreground** server
+(`SCCACHE_NO_DAEMON`: a forked server dies with its launchd process
+group; `KeepAlive` revives crashes; idle timeout disabled), and the
+migrate script mirrors `SCCACHE_SERVER_PORT`/`SCCACHE_DIR` into each
+listener's `.env` so every job process agrees. The Linux runner
+accounts still use on-demand servers (a systemd twin of the daemon is
+listed under "Deliberately deferred").
+
 ### Watchdog interplay
 
 `fleet-watchdog.sh` understands both listener shapes at once —
@@ -250,9 +268,14 @@ before-images land in `/etc/intendant-ci/migration/` for audit.
 - **Windows host equivalent** of the hooks + migration ergonomics (the
   Windows runner already runs as a dedicated non-admin user; see the
   watchdog "Windows" note above).
-- **sccache cache custody**: the CI account's sccache cache lives in
-  its own `~/Library/Caches` under sccache's default 10G self-cap; the
-  watchdog does not manage it yet.
+- **sccache cache custody**: the CI account's sccache cache lives at
+  `~/.cache/sccache` (pinned by the supervised server's `SCCACHE_DIR`)
+  under sccache's default 10G self-cap; the watchdog does not manage
+  it yet.
+- **Linux twin of the supervised sccache server**: the Dell runner
+  accounts still spawn sccache servers on demand; port a systemd unit
+  of `com.intendant.ci.sccache` when the Linux hosts get the hooks
+  treatment.
 
 ## Interlocks
 

--- a/scripts/ci/hooks/hook-lib.sh
+++ b/scripts/ci/hooks/hook-lib.sh
@@ -184,13 +184,28 @@ reap_orphans() {
     printf 'killed=%s%s' "$n" "${detail:+ [${detail#,}]}"
 }
 
-# The bounded driver: the real work runs in a child subshell so a hung
-# cleanup can be reaped by the timer — GitHub applies no timeout of its own
-# to these hooks, and a wedged started-hook would wedge the job.
+# The bounded driver: the real work runs in a child subshell, bounded by a
+# FOREGROUND one-second poll in the hook's own shell — GitHub applies no
+# timeout of its own to these hooks, and a wedged started-hook would wedge
+# the job.
+#
+# Deliberately NO background timer subshell. The first cutover shipped
+# `( sleep N; kill -TERM "$work" ) &` and it took down two canary jobs
+# (2026-07-10): macOS bash 3.2 defers a TERM sent to a subshell that is
+# waiting on an external command, so the driver's end-of-run `kill $timer`
+# didn't actually kill it — every hook run leaked a live timer holding a
+# stale $work pid. When the leaked sleep later ended (naturally, or TERM'd
+# as an orphan by the NEXT hook's reaper), the subshell fired kill -TERM at
+# a pid macOS had long since recycled INTO the then-current job — 143s
+# mid-hook, and each killed hook leaked its own timer for the next one: a
+# self-sustaining grenade chain. A foreground poll has no detached state:
+# if the hook dies, its pending kill dies with it, and the timeout KILL
+# targets a pid we have verified is still our own child in the same
+# breath.
 run_hook() {
     local phase="$1"
     rotate_log
-    local t0 result_file work timer outcome detail=""
+    local t0 result_file work outcome detail="" waited=0
     t0=$(date +%s)
     result_file=$(mktemp 2>/dev/null) || result_file=""
 
@@ -205,16 +220,23 @@ run_hook() {
         fi
     ) &
     work=$!
-    ( sleep "$HOOK_TIMEOUT_SECS"; kill -TERM "$work" 2>/dev/null ) &
-    timer=$!
 
     outcome=ok
-    wait "$work" 2>/dev/null || outcome=timeout
-    # (The reap-to-kill gap here is a theoretical PID-reuse window only when
-    # the work finishes at exactly the deadline; blast radius is a stray
-    # TERM inside our own account.)
-    kill "$timer" 2>/dev/null
-    wait "$timer" 2>/dev/null
+    while kill -0 "$work" 2>/dev/null; do
+        if [ "$waited" -ge "$HOOK_TIMEOUT_SECS" ]; then
+            outcome=timeout
+            # Parentage check closes the pid-reuse race: only KILL while
+            # the pid is still our own child (janitorial work is
+            # idempotent — no graceful TERM needed at the deadline).
+            if [ "$(ps -o ppid= -p "$work" 2>/dev/null | tr -d ' ')" = "$$" ]; then
+                kill -KILL "$work" 2>/dev/null
+            fi
+            break
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+    wait "$work" 2>/dev/null
 
     if [ -n "$result_file" ]; then
         detail=$(cat "$result_file" 2>/dev/null || true)

--- a/scripts/ci/hooks/hook-lib.sh
+++ b/scripts/ci/hooks/hook-lib.sh
@@ -15,6 +15,15 @@
 #   4. log exactly one summary line to $LOG (rotated), and
 #   5. always exit 0, within HOOK_TIMEOUT_SECS.
 #
+# ALL of it is account-gated: run_hook refuses outright (one log line,
+# exit 0) unless `id -un` matches INTENDANT_CI_HOOK_ACCOUNT from the
+# runner's .env wiring. The payload's safety model is the account
+# boundary — reap_orphans treats every account process outside a live
+# runner tree as residue, and wipe_stale_test_home treats ~/.intendant
+# as fixture escape. Executed under any other account, those same rules
+# dismantle a real login session and delete real daemon state
+# (2026-07-10: a developer-account invocation did exactly that).
+#
 # Never touched: ~/.cache/intendant-ci (the warm external cargo target
 # caches — the fleet watchdog owns those), ~/.cargo, ~/.rustup.
 #
@@ -204,6 +213,17 @@ reap_orphans() {
 # breath.
 run_hook() {
     local phase="$1"
+    # Account gate — refuse anywhere but the dedicated CI account (see
+    # the header). The expected name comes from the runner wiring, not a
+    # hardcoded convention, so the same lib serves any fleet host; unset
+    # or mismatched means an inert janitor and a green job, never a
+    # payload run in the wrong account.
+    local account
+    account=$(id -un 2>/dev/null)
+    if [ -z "${INTENDANT_CI_HOOK_ACCOUNT:-}" ] || [ "$account" != "${INTENDANT_CI_HOOK_ACCOUNT}" ]; then
+        log_line "$phase REFUSED account=${account:-?} expected=${INTENDANT_CI_HOOK_ACCOUNT:-unset} (payload skipped)"
+        exit 0
+    fi
     rotate_log
     local t0 result_file work outcome detail="" waited=0
     t0=$(date +%s)

--- a/scripts/ci/migrate-runner-macos.sh
+++ b/scripts/ci/migrate-runner-macos.sh
@@ -234,6 +234,13 @@ set_env_kv "$DEST/.env" ACTIONS_RUNNER_HOOK_JOB_COMPLETED "$LIB_DIR/hooks/job-co
 # `id -un` matches this — the reaper/wipe rules are only safe inside the
 # dedicated CI account.
 set_env_kv "$DEST/.env" INTENDANT_CI_HOOK_ACCOUNT "$CI_ACCOUNT"
+# sccache: every job process must agree with the account's supervised
+# server (setup-ci-account-macos.sh) — cargo's [env] port does not reach
+# every in-job sccache invocation (2026-07-10: the rustc version probe
+# missed it and wedged every job on this listener), so the port/dir ride
+# the job env explicitly.
+set_env_kv "$DEST/.env" SCCACHE_SERVER_PORT "4227"
+set_env_kv "$DEST/.env" SCCACHE_DIR "$CI_HOME/.cache/sccache"
 chown "$CI_ACCOUNT:$CI_GROUP" "$DEST/.env"
 echo "wired job hooks into .env"
 

--- a/scripts/ci/migrate-runner-macos.sh
+++ b/scripts/ci/migrate-runner-macos.sh
@@ -230,6 +230,10 @@ set_env_kv() {
 }
 set_env_kv "$DEST/.env" ACTIONS_RUNNER_HOOK_JOB_STARTED "$LIB_DIR/hooks/job-started.sh"
 set_env_kv "$DEST/.env" ACTIONS_RUNNER_HOOK_JOB_COMPLETED "$LIB_DIR/hooks/job-completed.sh"
+# The hooks' account gate: hook-lib.sh refuses to run its payload unless
+# `id -un` matches this — the reaper/wipe rules are only safe inside the
+# dedicated CI account.
+set_env_kv "$DEST/.env" INTENDANT_CI_HOOK_ACCOUNT "$CI_ACCOUNT"
 chown "$CI_ACCOUNT:$CI_GROUP" "$DEST/.env"
 echo "wired job hooks into .env"
 

--- a/scripts/ci/setup-ci-account-macos.sh
+++ b/scripts/ci/setup-ci-account-macos.sh
@@ -233,6 +233,58 @@ else
     fi
 fi
 
+# ---- supervised sccache server (one per account, shared by listeners) ----
+# Never rely on in-job server spawning: the cargo [env] port above does
+# not reach every in-job sccache invocation (the rustc version probe
+# failed on the default port, 2026-07-10), and a client racing a dying
+# or job-reaped server reads a truncated response header ("failed to
+# fill whole buffer" — cargo exit 101 within seconds). One
+# launchd-supervised FOREGROUND server owns the account's port instead
+# (SCCACHE_NO_DAEMON: a forked server dies with its launchd process
+# group); job clients only ever connect. The per-listener .env mirrors
+# the port/dir into job env (migrate-runner-macos.sh).
+if [ -n "$sccache_bin" ]; then
+    SCCACHE_LABEL="com.intendant.ci.sccache"
+    SCCACHE_PLIST="/Library/LaunchDaemons/$SCCACHE_LABEL.plist"
+    cat > "$SCCACHE_PLIST.tmp" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$SCCACHE_LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$sccache_bin</string>
+  </array>
+  <key>UserName</key><string>$CI_ACCOUNT</string>
+  <key>GroupName</key><string>$CI_GROUP</string>
+  <key>WorkingDirectory</key><string>$CI_HOME</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key><string>$CI_HOME</string>
+    <key>SCCACHE_START_SERVER</key><string>1</string>
+    <key>SCCACHE_NO_DAEMON</key><string>1</string>
+    <key>SCCACHE_SERVER_PORT</key><string>4227</string>
+    <key>SCCACHE_DIR</key><string>$CI_HOME/.cache/sccache</string>
+    <key>SCCACHE_IDLE_TIMEOUT</key><string>0</string>
+  </dict>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>$CI_HOME/Library/Logs/sccache-server.log</string>
+  <key>StandardErrorPath</key><string>$CI_HOME/Library/Logs/sccache-server.log</string>
+</dict>
+</plist>
+PLIST_EOF
+    mv "$SCCACHE_PLIST.tmp" "$SCCACHE_PLIST"
+    chown root:wheel "$SCCACHE_PLIST"
+    chmod 0644 "$SCCACHE_PLIST"
+    # Idempotent re-run: bootout the old instance first (brief server
+    # blip; this script is a maintenance operation, not a hot path).
+    launchctl bootout "system/$SCCACHE_LABEL" 2>/dev/null || true
+    launchctl bootstrap system "$SCCACHE_PLIST"
+    echo "bootstrapped $SCCACHE_LABEL ($sccache_bin, port 4227, foreground under launchd)"
+fi
+
 echo "== wasm-pack"
 # Same convention as scripts/setup-macos.sh: cargo install pinned by the
 # repo's .wasm-pack-version (build.rs skips WASM rebuilds under any other


### PR DESCRIPTION
Two hardening fixes for the runner job hooks (`scripts/ci/hooks/`), both paid for on 2026-07-10:

**Foreground timeout poll.** The driver bounded its work subshell with a detached timer (`( sleep N; kill $work ) &`) killed at end of run. macOS bash 3.2 defers a TERM sent to a subshell waiting on an external command, so the end-of-run kill never took: every hook run leaked a live timer holding a stale $work pid, and when a leaked sleep later ended, the subshell fired `kill -TERM` at a pid the kernel had recycled into the then-current job — exit 143 mid-hook, and each killed hook leaked its own timer for the next one (took down two canary jobs). The timeout is now a foreground one-second poll: no detached state, and the deadline KILL fires only after verifying the pid is still our own child in the same breath.

**Account gate.** The payload's safety model is the account boundary — `reap_orphans` treats every account process outside a live runner tree as residue, and the test-home wipe treats `~/.intendant` as fixture escape. Those rules are only true on the dedicated CI account; run as anyone else they dismantle a real session and delete real daemon state. `run_hook` now refuses (one REFUSED log line, exit 0) unless `id -un` matches `INTENDANT_CI_HOOK_ACCOUNT` from the runner's `.env` wiring; the migrate script writes the key. Unset or mismatched = inert janitor, green job.

Verified with all four payload functions stubbed to sentinel writes: refusal on unset and mismatched account (zero sentinels), full payload dispatch on match (all four), timeout path leaves no stray processes.