### PR TITLE
displays api: inject the enumeration at the edge; hermetic display tests

### DIFF
--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -2242,16 +2242,32 @@ mod tests {
 
     #[tokio::test]
     async fn parity_displays_serves_the_same_body_on_both_transports() {
-        // No session registry on either lane: both render the ONE
-        // neutral enumeration (annotations need a registry; the OS
-        // display set is stable across the two back-to-back calls).
-        let rt = runtime();
+        // Injected display set on both lanes (a fixture must never
+        // enumerate the machine's real displays — on a session-less CI
+        // account the macOS enumeration never completes); no session
+        // registry on either lane, so both render the ONE neutral body
+        // through the `_from` core the production edges delegate to.
+        let displays = vec![crate::display::DisplayInfo {
+            id: 1,
+            platform_id: 7,
+            name: "Fixture Display".to_string(),
+            width: 1280,
+            height: 720,
+            is_primary: true,
+            kind: crate::display::DisplayInfoKind::Display,
+            application_name: None,
+            window_title: None,
+        }];
         let (status, http_body) = parity_http_status_and_body(
-            crate::web_gateway::displays_api_response(&None).await,
+            crate::web_gateway::displays_api_response_from(displays.clone(), &None).await,
         );
         assert_eq!(status, 200);
         assert!(http_body["displays"].is_array(), "{http_body}");
-        let frame = api_displays_response("parity-displays".to_string(), &rt).await;
+        let frame = frame_api_json_body_response(
+            "parity-displays".to_string(),
+            crate::web_gateway::displays_api_response_from(displays, &None).await,
+            "displays",
+        );
         assert_eq!(frame["ok"], true);
         assert!(frame["result"]
             .as_object()

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -314,10 +314,16 @@ fn ensure_idle(
 }
 
 
-pub(crate) async fn displays_response_body(
+/// Transport-neutral core of the displays body, given an
+/// already-enumerated display set: the OS enumeration resolves at the
+/// production edge (`displays_api_response`), so tests inject a fixture
+/// set — a real enumeration is machine state (tests-are-hermetic
+/// convention), and on a session-less CI account macOS's
+/// SCShareableContent call never completes at all.
+pub(crate) async fn displays_response_body_from(
+    displays: Vec<crate::display::DisplayInfo>,
     session_registry: &Option<crate::display::SharedSessionRegistry>,
 ) -> String {
-    let displays = crate::display::enumerate_displays_with_sessions(session_registry).await;
     // This route serves the owner's dashboards (the display picker), so
     // each entry is annotated with its live capture state via the
     // unfiltered registry view: `capture_active` plus `agent_visible`

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -3517,11 +3517,25 @@ pub(crate) async fn handle_worktrees_list(
 
 /// GET /api/displays + the tunnel's `api_displays`: the OS display
 /// enumeration annotated with live capture state, under the
-/// wildcard-CORS tail (transport-unification design §2.1, S5).
+/// wildcard-CORS tail (transport-unification design §2.1, S5). The
+/// enumeration resolves HERE at the production edge; the `_from` core
+/// below takes the set as a parameter so tests inject a fixture
+/// instead of touching machine display state.
 pub(crate) async fn displays_api_response(
     session_registry: &Option<crate::display::SharedSessionRegistry>,
 ) -> ApiResponse {
-    session_wildcard_json_response(200, displays_response_body(session_registry).await)
+    let displays = crate::display::enumerate_displays_with_sessions(session_registry).await;
+    displays_api_response_from(displays, session_registry).await
+}
+
+pub(crate) async fn displays_api_response_from(
+    displays: Vec<crate::display::DisplayInfo>,
+    session_registry: &Option<crate::display::SharedSessionRegistry>,
+) -> ApiResponse {
+    session_wildcard_json_response(
+        200,
+        crate::web_gateway::displays_response_body_from(displays, session_registry).await,
+    )
 }
 
 pub(crate) async fn handle_displays(
@@ -6255,13 +6269,30 @@ mod tests {
     // Second S5 slice (info/displays/diagnostics), same discipline as
     // the sets above: captured before the transport-neutral conversion.
 
+    fn golden_fixture_displays() -> Vec<crate::display::DisplayInfo> {
+        vec![crate::display::DisplayInfo {
+            id: 1,
+            platform_id: 7,
+            name: "Fixture Display".to_string(),
+            width: 1280,
+            height: 720,
+            is_primary: true,
+            kind: crate::display::DisplayInfoKind::Display,
+            application_name: None,
+            window_title: None,
+        }]
+    }
+
     #[tokio::test]
     async fn golden_displays_transcript() {
-        // The display list is an OS enumeration (machine-dependent
-        // body), so it is computed through the untouched builder with
-        // no session registry and spliced — the wildcard-CORS 200
-        // framing is the byte-exact pin.
-        let body = displays_response_body(&None).await;
+        // Injected display set (a fixture must never enumerate the
+        // machine's real displays: the body is machine-dependent, and
+        // on a session-less CI account the macOS enumeration never
+        // completes) — the wildcard-CORS 200 framing around the same
+        // `_from` core the production edge delegates to is the
+        // byte-exact pin.
+        let displays = golden_fixture_displays();
+        let body = displays_response_body_from(displays.clone(), &None).await;
         let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert!(parsed["displays"].is_array(), "displays array: {body}");
         assert!(
@@ -6272,9 +6303,16 @@ mod tests {
             .expect("displays route declared")
             .0
             .cors;
-        let response =
-            collect_session_handler_response(|stream| handle_displays(stream, None, cors, None))
-                .await;
+        let response = collect_session_handler_response(|stream| async move {
+            write_api_response(
+                stream,
+                displays_api_response_from(displays, &None).await,
+                cors,
+                None,
+            )
+            .await
+        })
+        .await;
         assert_eq!(
             golden_transcript(&response),
             golden_session_wildcard_json_transcript("200 OK", &body)


### PR DESCRIPTION
The displays core resolved the OS display enumeration itself, so the S5 transport-parity test and the golden displays transcript walked the machine's real display stack. On a desktop that was merely unhermetic; on the dedicated CI account's session-less LaunchDaemon context, macOS's `SCShareableContent` call **never completes**, and `cargo test` wedged forever at `parity_displays_serves_the_same_body_on_both_transports` — found by the first full-suite merge-group leg on the migrated runner. Until this lands, any queued entry's macOS group leg hangs (no job timeout yet), so this wants to merge ahead of the waiting PRs.

Fix follows the neighbouring S5 cores' DI shape (path-parameterized fixtures): the enumeration resolves once at the production edge (`displays_api_response`), and `displays_response_body_from` / `displays_api_response_from` take the display set as a parameter. Both tests inject a fixture list and never touch machine display state (tests-are-hermetic convention). The golden test pins the same wildcard-CORS framing through `write_api_response` around the `_from` core the production edge delegates to.

Verified: the display test filter passes locally, and the full `cargo test --bins` battery was run headless as the CI service account (the context that hung) before queueing.