### PR TITLE
ci: dependabot for the SHA-pinned actions (grouped weekly)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Keep the SHA-pinned actions fresh: Dependabot bumps the pin and the
+  # trailing version comment together. Grouped weekly so action bumps
+  # cost one queue cycle, not one PR per action.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Wave 5 supply-chain item: the workflows' actions are SHA-pinned (good), which also means they never move without a deliberate bump (stale). Dependabot bumps the pin and its trailing version comment together, grouped into one weekly PR so action updates cost one queue cycle rather than one per action. (The audit.yml permission split from the same plan item was already done in an earlier pass — `contents: read` plus documented `checks`/`issues` write.)