### PR TITLE
build: pin the workspace toolchain to 1.96.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,12 @@
+[toolchain]
+# One toolchain for the whole fleet and every dev checkout. Three things
+# only hold on a uniform compiler: the per-listener CI caches (keyed by
+# `rustc -V` — a version skew means a permanently cold key on the odd
+# box), the committed WASM artifacts (byte-sensitive to the compiler),
+# and the fmt/clippy zero-warning baselines (each release adds lints).
+# Verified 2026-07-11: all three runner platforms resolve toolchains via
+# rustup, so a bump here auto-installs everywhere on next use. Bump
+# deliberately: every runner cache re-keys (one cold build per listener)
+# and dev worktrees re-toolchain on their next build.
+channel = "1.96.1"
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Wave 5 prerequisite. The fleet ran three different rustcs (Mac 1.94.0, Dell + Windows 1.96.1 — verified from the runners' rustc-keyed cache dir names) and dev boxes float free. Three things only hold on a uniform compiler: the per-listener CI caches (keyed by `rustc -V`; a skewed box forks its cache key forever), the committed WASM artifacts (byte-sensitive to the compiler — the drift gate lands after this plus an artifact regen), and the fmt/clippy zero-warning baselines (each release adds lints).

rustup is verified on all three runner platforms (`rustup target add` runs on every self-hosted leg today), so the pin auto-installs on next use. Cost: the two Mac listeners each pay one cold build under the new cache key (~30-40 min group leg, inside the 60-min job timeout), and dev worktrees re-toolchain on their next build. Deliberately NOT armed until the two queued CI PRs ahead merge, so their entries don't build speculatively on the cold-Mac toolchain.

Follow-ups sequenced behind this: WASM artifact regen under 1.96.1, then the WASM drift gate; fmt + clippy baselines are being cut against 1.96.1.