### PR TITLE
ci: advisory CodeQL scanning (rust + actions)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,57 @@
+name: CodeQL
+
+# Advisory security scanning: Rust (GA build-free analysis) plus the
+# Actions workflow files. Deliberately NOT a required check and NOT
+# per-PR — findings surface on pushes to main and a weekly cron, while
+# landing latency stays owned by the deterministic suites. GitHub-hosted
+# runners on purpose: the analysis needs no fleet warmth, and advisory
+# scans should never occupy fleet slots the required gates are waiting
+# for.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/**"
+  schedule:
+    # Mondays 09:00 UTC — an hour after the cargo-audit cron, so the two
+    # advisory reports land as one Monday-morning batch, not two pings.
+    - cron: "0 9 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: codeql (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: rust
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Wave 5 tail item. Build-free Rust CodeQL is GA (CodeQL 2.23.3+), so no build orchestration is needed. Advisory by design: **pushes to main + weekly cron, on GitHub-hosted runners** — never per-PR (landing latency stays with the deterministic suites), never a required context, never occupying fleet slots. Rust + the `actions` language (workflow-file analysis). Findings land in the Security tab; the weekly cron is an hour after audit.yml's so Monday advisories arrive as one batch.