### PR TITLE
Transport S10 (streams): one line source behind ApiResponse::Stream for /api/sessions/stream + api_sessions_stream

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1576,11 +1576,14 @@ verified tunnel advertises `terminal_frames`. The daemon attaches the tunnel to
 the same PTY registry used by the WebSocket path, so scrollback and reconnect
 behavior stay consistent.
 
-The first streamed API on this substrate is `api_sessions_stream`, which mirrors
-the existing `/api/sessions/stream` NDJSON event shape (`start`, partial
-`session`, `phase`, final `replace`, `done`). When the verified DataChannel is
-connected, local dashboard session hydration uses that stream and falls back to
-the HTTP stream on safe errors. Peer session lists still use direct peer HTTP.
+The first streamed API on this substrate is `api_sessions_stream`, which shares
+one server-side line source with `/api/sessions/stream` (transport-unification
+S10: the neutral core's `ApiResponse::Stream`) — both lanes carry the identical
+NDJSON event sequence (`start`, partial `session`, `phase`, final `replace`,
+`done`); HTTP writes the lines verbatim, the tunnel wraps each in a
+`stream_event` frame. When the verified DataChannel is connected, local
+dashboard session hydration uses that stream and falls back to the HTTP stream
+on safe errors. Peer session lists still use direct peer HTTP.
 The local daemon identity is available as `api_agent_card`, returning the same
 Agent Card shape served by `/.well-known/agent-card.json`; the HTTP endpoint
 remains the unauthenticated discovery surface.

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -1593,6 +1593,27 @@ mod tests {
         assert_eq!(frames[4].frame["ok"], true);
         assert_eq!(frames[4].frame["result"]["events"], 3);
         assert!(frames[4].done);
+
+        // S10 goldens: the exact frame objects (serde_json's sorted-key
+        // serialization), so the framer's wire shapes — method echo,
+        // seq/chunk_id pairing, the events tally — are pinned byte for
+        // byte across the Stream-lane unification.
+        assert_eq!(
+            frames[0].frame.to_string(),
+            r#"{"id":"stream1","method":"api_sessions_stream","t":"stream_start"}"#
+        );
+        assert_eq!(
+            frames[1].frame.to_string(),
+            r#"{"chunk_id":"stream1:0","event":{"limit":1,"quick_limit":1,"type":"start"},"id":"stream1","seq":0,"t":"stream_event"}"#
+        );
+        assert_eq!(
+            frames[2].frame.to_string(),
+            r#"{"chunk_id":"stream1:1","event":{"partial":true,"session":{"session_id":"s1"},"type":"session"},"id":"stream1","seq":1,"t":"stream_event"}"#
+        );
+        assert_eq!(
+            frames[4].frame.to_string(),
+            r#"{"id":"stream1","ok":true,"result":{"events":3},"t":"stream_end"}"#
+        );
     }
 
     #[test]

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -352,22 +352,41 @@ pub(crate) async fn control_request_response(
     }
 }
 
+/// The tunnel's `api_sessions_stream` twin (S10): the transport edge
+/// parses its own limit vocabulary, the S10 neutral core spawns the ONE
+/// line source both lanes share, and the `stream_*` framer below is
+/// this lane's writer.
 pub(crate) async fn stream_sessions_response(
     id: String,
     params: Option<&serde_json::Value>,
     task_tx: mpsc::Sender<ControlTaskResponse>,
     cancel: CancellationToken,
 ) {
-    let request_line = sessions_stream_request_line(params);
-    let (line_tx, line_rx) = mpsc::channel::<String>(64);
-    let stream_task = tokio::task::spawn_blocking(move || {
-        crate::web_gateway::stream_sessions_from_request(&request_line, line_tx);
-    });
+    let requested_limit = sessions_stream_requested_limit(params);
+    let crate::web_gateway::ApiResponse::Stream { stream, .. } =
+        crate::web_gateway::sessions_stream_api_response(requested_limit)
+    else {
+        // The sessions-stream core always answers on the Stream lane; a
+        // buffered response reaching this framer is a wiring bug.
+        let _ = task_tx
+            .send(ControlTaskResponse {
+                id: id.clone(),
+                frame: serde_json::json!({
+                    "t": "stream_end",
+                    "id": id,
+                    "ok": false,
+                    "error": "session stream returned a buffered response",
+                }),
+                byte_stream: None,
+                done: true,
+            })
+            .await;
+        return;
+    };
     stream_json_lines_response(
         id,
         "api_sessions_stream".to_string(),
-        line_rx,
-        stream_task,
+        stream,
         task_tx,
         cancel,
     )
@@ -377,11 +396,14 @@ pub(crate) async fn stream_sessions_response(
 pub(crate) async fn stream_json_lines_response(
     id: String,
     method: String,
-    mut line_rx: mpsc::Receiver<String>,
-    stream_task: tokio::task::JoinHandle<()>,
+    stream: crate::web_gateway::LineStream,
     task_tx: mpsc::Sender<ControlTaskResponse>,
     cancel: CancellationToken,
 ) {
+    let crate::web_gateway::LineStream {
+        lines: mut line_rx,
+        source: stream_task,
+    } = stream;
     if cancel.is_cancelled() {
         return;
     }
@@ -483,36 +505,41 @@ pub(crate) async fn stream_json_lines_response(
     }
 }
 
-pub(crate) fn sessions_stream_request_line(params: Option<&serde_json::Value>) -> String {
-    let Some(params) = params else {
-        return "GET /api/sessions/stream HTTP/1.1".to_string();
-    };
-    let Some(limit_value) = params.get("limit") else {
-        return "GET /api/sessions/stream HTTP/1.1".to_string();
-    };
+/// The tunnel's sessions-stream limit vocabulary, parsed at this
+/// transport's edge into the neutral core's `Option<usize>` (`None` =
+/// unlimited). Byte-for-byte the semantics of the retired
+/// params→request-line synthesis composed with the HTTP lane's
+/// `session_list_limit_from_request` (the equivalence pins live in the
+/// tests): absent `limit` and the "all"/"full" escapes are unlimited;
+/// invalid shapes (zero, negatives, floats, non-numeric strings, other
+/// JSON types — including the historical `"unlimited"` quirk, which
+/// only the HTTP query vocabulary accepts) collapse to
+/// `CONTROL_DEFAULT_SESSION_LIMIT`; everything is capped at the HTTP
+/// lane's `SESSION_LIST_LIMIT`.
+pub(crate) fn sessions_stream_requested_limit(
+    params: Option<&serde_json::Value>,
+) -> Option<usize> {
+    let limit_value = params?.get("limit")?;
     let limit = match limit_value {
         serde_json::Value::String(value) => {
             let value = value.trim();
             if value.eq_ignore_ascii_case("all") || value.eq_ignore_ascii_case("full") {
-                "all".to_string()
-            } else {
-                value
-                    .parse::<usize>()
-                    .ok()
-                    .filter(|limit| *limit > 0)
-                    .unwrap_or(CONTROL_DEFAULT_SESSION_LIMIT)
-                    .to_string()
+                return None;
             }
+            value
+                .parse::<usize>()
+                .ok()
+                .filter(|limit| *limit > 0)
+                .unwrap_or(CONTROL_DEFAULT_SESSION_LIMIT)
         }
         serde_json::Value::Number(value) => value
             .as_u64()
             .and_then(|limit| usize::try_from(limit).ok())
             .filter(|limit| *limit > 0)
-            .unwrap_or(CONTROL_DEFAULT_SESSION_LIMIT)
-            .to_string(),
-        _ => CONTROL_DEFAULT_SESSION_LIMIT.to_string(),
+            .unwrap_or(CONTROL_DEFAULT_SESSION_LIMIT),
+        _ => CONTROL_DEFAULT_SESSION_LIMIT,
     };
-    format!("GET /api/sessions/stream?limit={limit} HTTP/1.1")
+    Some(limit.min(crate::web_gateway::SESSION_LIST_LIMIT))
 }
 
 pub(crate) fn cancelled_control_response(id: String, existed: bool) -> serde_json::Value {
@@ -1565,8 +1592,10 @@ mod tests {
         stream_json_lines_response(
             "stream1".to_string(),
             "api_sessions_stream".to_string(),
-            line_rx,
-            stream_task,
+            crate::web_gateway::LineStream {
+                lines: line_rx,
+                source: stream_task,
+            },
             task_tx,
             CancellationToken::new(),
         )
@@ -1660,18 +1689,6 @@ mod tests {
             vec!["a".to_string(), "b".to_string(), "c".to_string()]
         );
         assert_eq!(
-            sessions_stream_request_line(Some(&serde_json::json!({}))),
-            "GET /api/sessions/stream HTTP/1.1"
-        );
-        assert_eq!(
-            sessions_stream_request_line(Some(&serde_json::json!({"limit": "all"}))),
-            "GET /api/sessions/stream?limit=all HTTP/1.1"
-        );
-        assert_eq!(
-            sessions_stream_request_line(Some(&serde_json::json!({"limit": 25}))),
-            "GET /api/sessions/stream?limit=25 HTTP/1.1"
-        );
-        assert_eq!(
             control_project_filter(&serde_json::json!({"projects": ["a", " b "]})),
             vec!["a".to_string(), "b".to_string()]
         );
@@ -1688,6 +1705,70 @@ mod tests {
                 &serde_json::json!({"capabilities": ["display", "custom:gpu"]})
             ),
             "capability=display&capability=custom:gpu"
+        );
+    }
+
+    /// S10 equivalence pins: `sessions_stream_requested_limit` must
+    /// reproduce, input for input, the retired composition of the
+    /// params→request-line synthesizer with the HTTP lane's
+    /// `session_list_limit_from_request` — including the historical
+    /// asymmetries ("unlimited" is an HTTP-query escape only; zero,
+    /// negatives, floats, and non-numeric shapes collapse to the
+    /// control default; the HTTP list cap applies last).
+    #[test]
+    fn sessions_stream_limit_vocabulary_is_pinned() {
+        let parse = |params: serde_json::Value| sessions_stream_requested_limit(Some(&params));
+        assert_eq!(sessions_stream_requested_limit(None), None);
+        assert_eq!(parse(serde_json::json!({})), None);
+        assert_eq!(parse(serde_json::json!({ "limit": "all" })), None);
+        assert_eq!(parse(serde_json::json!({ "limit": "full" })), None);
+        assert_eq!(parse(serde_json::json!({ "limit": " ALL " })), None);
+        // The HTTP query vocabulary's third escape does NOT exist on the
+        // tunnel — it has always collapsed to the control default.
+        assert_eq!(
+            parse(serde_json::json!({ "limit": "unlimited" })),
+            Some(CONTROL_DEFAULT_SESSION_LIMIT)
+        );
+        assert_eq!(parse(serde_json::json!({ "limit": "25" })), Some(25));
+        assert_eq!(parse(serde_json::json!({ "limit": " 42 " })), Some(42));
+        assert_eq!(
+            parse(serde_json::json!({ "limit": "0" })),
+            Some(CONTROL_DEFAULT_SESSION_LIMIT)
+        );
+        assert_eq!(
+            parse(serde_json::json!({ "limit": "nope" })),
+            Some(CONTROL_DEFAULT_SESSION_LIMIT)
+        );
+        assert_eq!(parse(serde_json::json!({ "limit": 25 })), Some(25));
+        assert_eq!(
+            parse(serde_json::json!({ "limit": 0 })),
+            Some(CONTROL_DEFAULT_SESSION_LIMIT)
+        );
+        assert_eq!(
+            parse(serde_json::json!({ "limit": -3 })),
+            Some(CONTROL_DEFAULT_SESSION_LIMIT)
+        );
+        assert_eq!(
+            parse(serde_json::json!({ "limit": 2.5 })),
+            Some(CONTROL_DEFAULT_SESSION_LIMIT)
+        );
+        assert_eq!(
+            parse(serde_json::json!({ "limit": null })),
+            Some(CONTROL_DEFAULT_SESSION_LIMIT)
+        );
+        assert_eq!(
+            parse(serde_json::json!({ "limit": true })),
+            Some(CONTROL_DEFAULT_SESSION_LIMIT)
+        );
+        // Oversized asks clamp to the HTTP lane's list cap, exactly as
+        // the synthesized query did.
+        assert_eq!(
+            parse(serde_json::json!({ "limit": 9_999_999 })),
+            Some(crate::web_gateway::SESSION_LIST_LIMIT)
+        );
+        assert_eq!(
+            parse(serde_json::json!({ "limit": "9999999" })),
+            Some(crate::web_gateway::SESSION_LIST_LIMIT)
         );
     }
 
@@ -2389,7 +2470,8 @@ mod tests {
                 let crate::web_gateway::BytesPayload::InMemory(payload) = bytes;
                 (payload.clone(), meta.clone())
             }
-            crate::web_gateway::ApiResponse::Json { .. } => panic!("raw read must be bytes"),
+            crate::web_gateway::ApiResponse::Json { .. }
+            | crate::web_gateway::ApiResponse::Stream { .. } => panic!("raw read must be bytes"),
         };
         assert_eq!(http_bytes, payload);
         let raw = api_session_current_upload_raw_task_response(
@@ -2428,5 +2510,203 @@ mod tests {
         assert_eq!(raw.frame["result"]["_httpStatus"], 404);
         assert_eq!(raw.frame["result"]["ok"], false);
         assert_eq!(raw.frame["result"]["error"], "upload not found");
+    }
+
+    // ── S10 parity fixture: the sessions-stream Stream lane ──
+
+    /// Seed a minimal on-disk session the catalog scanners list. The
+    /// recency key is the transcript's mtime at second resolution
+    /// (`session_activity_mtime_secs`), so each seed gets a distinct,
+    /// idx-ordered mtime for a deterministic newest-first order.
+    fn seed_stream_session(logs_dir: &std::path::Path, idx: usize) {
+        let session_id = format!("stream-parity-{idx}");
+        let log_dir = logs_dir.join(&session_id);
+        std::fs::create_dir_all(&log_dir).unwrap();
+        std::fs::write(
+            log_dir.join("session_meta.json"),
+            serde_json::json!({
+                "created_at": format!("2026-07-01T10:0{idx}:00Z"),
+                "task": format!("stream parity task {idx}"),
+                "status": "completed"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let transcript = log_dir.join("session.jsonl");
+        std::fs::write(
+            &transcript,
+            serde_json::json!({
+                "ts": format!("2026-07-01T10:0{idx}:00Z"),
+                "event": "session_start"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let mtime = std::time::UNIX_EPOCH
+            + std::time::Duration::from_secs(1_780_000_000 + idx as u64 * 60);
+        std::fs::File::options()
+            .write(true)
+            .open(&transcript)
+            .unwrap()
+            .set_modified(mtime)
+            .unwrap();
+    }
+
+    /// A [`crate::web_gateway::LineStream`] replaying a captured line
+    /// sequence — the writers-only half of the parity fixture.
+    fn replay_line_stream(lines: Vec<String>) -> crate::web_gateway::LineStream {
+        let (tx, rx) = mpsc::channel::<String>(64);
+        let source = tokio::spawn(async move {
+            for line in lines {
+                if tx.send(line).await.is_err() {
+                    return;
+                }
+            }
+        });
+        crate::web_gateway::LineStream {
+            lines: rx,
+            source,
+        }
+    }
+
+    /// Same params ⇒ same event-line sequence on both lanes (design §8,
+    /// S10). The line SOURCE is shared by construction — both transports
+    /// spawn `stream_sessions_lines` through the one neutral core — so
+    /// the fixture runs it once, hermetically (injected temp store +
+    /// direct hydration scan), pins the NDJSON line shapes, then proves
+    /// each lane's WRITER carries the identical sequence: the HTTP body
+    /// under the pinned head is the lines verbatim, and the tunnel's
+    /// `stream_event` frames wrap the same events in the same order.
+    #[tokio::test]
+    async fn parity_sessions_stream_event_lines_match_across_lanes() {
+        let home = tempfile::tempdir().unwrap();
+        let logs_dir = home.path().join(".intendant").join("logs");
+        std::fs::create_dir_all(&logs_dir).unwrap();
+        for idx in 0..3 {
+            seed_stream_session(&logs_dir, idx);
+        }
+        let requested_limit = Some(2usize);
+
+        // One hermetic run of the shared source.
+        let lines = {
+            let (tx, mut rx) = mpsc::channel::<String>(64);
+            let source_home = home.path().to_path_buf();
+            let hydrate_home = source_home.clone();
+            let source = tokio::task::spawn_blocking(move || {
+                crate::web_gateway::stream_sessions_lines_from_home(
+                    &source_home,
+                    requested_limit,
+                    move || {
+                        crate::web_gateway::list_sessions_from_home_with_limit(
+                            &hydrate_home,
+                            requested_limit,
+                        )
+                    },
+                    tx,
+                );
+            });
+            let mut lines = Vec::new();
+            while let Some(line) = rx.recv().await {
+                lines.push(line);
+            }
+            source.await.unwrap();
+            lines
+        };
+
+        // The line shapes: start → 2 newest-first partial session rows →
+        // hydrating marker → replace (hydrated pair) → done, each a
+        // complete `\n`-terminated NDJSON line.
+        assert!(lines.iter().all(|line| line.ends_with('\n')), "{lines:?}");
+        let events: Vec<serde_json::Value> = lines
+            .iter()
+            .map(|line| serde_json::from_str(line.trim()).unwrap())
+            .collect();
+        assert_eq!(events.len(), 6, "{events:?}");
+        assert_eq!(
+            events[0].to_string(),
+            r#"{"limit":2,"quick_limit":2,"type":"start"}"#
+        );
+        assert_eq!(events[1]["type"], "session");
+        assert_eq!(events[1]["partial"], true);
+        assert_eq!(events[1]["session"]["session_id"], "stream-parity-2");
+        assert_eq!(events[2]["session"]["session_id"], "stream-parity-1");
+        assert_eq!(
+            events[3].to_string(),
+            r#"{"phase":"hydrating","type":"phase"}"#
+        );
+        assert_eq!(events[4]["type"], "replace");
+        let replaced = events[4]["sessions"].as_array().unwrap();
+        assert_eq!(replaced.len(), 2, "{events:?}");
+        assert_eq!(replaced[0]["session_id"], "stream-parity-2");
+        assert_eq!(events[5].to_string(), r#"{"type":"done"}"#);
+
+        // HTTP lane: the real writer over an in-memory stream — the
+        // pinned head, then the captured lines byte for byte.
+        let response = crate::web_gateway::sessions_stream_api_response_from(replay_line_stream(
+            lines.clone(),
+        ));
+        let (mut client, server) = tokio::io::duplex(1 << 20);
+        crate::web_gateway::write_api_response(
+            Box::pin(server),
+            response,
+            crate::gateway_routes::CorsPosture::OwnOrigin,
+            None,
+        )
+        .await;
+        let mut raw = Vec::new();
+        {
+            use tokio::io::AsyncReadExt;
+            client.read_to_end(&mut raw).await.unwrap();
+        }
+        let text = String::from_utf8(raw).unwrap();
+        let head_end = text.find("\r\n\r\n").expect("head/body split") + 4;
+        assert_eq!(
+            &text[..head_end],
+            "HTTP/1.1 200 OK\r\n\
+             Content-Type: application/x-ndjson\r\n\
+             Cache-Control: no-cache\r\n\
+             Access-Control-Allow-Origin: *\r\n\
+             Connection: close\r\n\
+             \r\n"
+        );
+        assert_eq!(&text[head_end..], lines.concat());
+
+        // Tunnel lane: the framer over the same sequence — one
+        // stream_event per line, events byte-identical to the HTTP
+        // lane's parsed lines, under the lifecycle frames.
+        let (task_tx, mut task_rx) = mpsc::channel::<ControlTaskResponse>(64);
+        stream_json_lines_response(
+            "stream-parity".to_string(),
+            "api_sessions_stream".to_string(),
+            replay_line_stream(lines.clone()),
+            task_tx,
+            CancellationToken::new(),
+        )
+        .await;
+        let mut frames = Vec::new();
+        while let Some(task) = task_rx.recv().await {
+            let done = task.done;
+            frames.push(task);
+            if done {
+                break;
+            }
+        }
+        assert_eq!(frames.len(), lines.len() + 2, "start + events + end");
+        assert_eq!(frames[0].frame["t"], "stream_start");
+        for (idx, line) in lines.iter().enumerate() {
+            let frame = &frames[idx + 1].frame;
+            assert_eq!(frame["t"], "stream_event");
+            assert_eq!(frame["seq"], idx as u64);
+            let http_event: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+            assert_eq!(
+                frame["event"].to_string(),
+                http_event.to_string(),
+                "lane divergence at event {idx}"
+            );
+        }
+        let end = &frames[lines.len() + 1].frame;
+        assert_eq!(end["t"], "stream_end");
+        assert_eq!(end["ok"], true);
+        assert_eq!(end["result"]["events"], lines.len() as u64);
     }
 }

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -26,6 +26,15 @@ pub(crate) fn frame_api_response(
             "ok": false,
             "error": format!("{label} returned an unexpected byte response"),
         }),
+        // The Stream lane never renders as a single response frame; its
+        // writer is the stream_* framer (S10). Reaching a buffered
+        // adapter is a wiring bug.
+        crate::web_gateway::ApiResponse::Stream { .. } => serde_json::json!({
+            "t": "response",
+            "id": id,
+            "ok": false,
+            "error": format!("{label} returned an unexpected stream response"),
+        }),
     }
 }
 
@@ -50,6 +59,15 @@ pub(crate) fn frame_api_json_body_response(
             "id": id,
             "ok": false,
             "error": format!("{label} returned an unexpected byte response"),
+        }),
+        // The Stream lane never renders as a single response frame; its
+        // writer is the stream_* framer (S10). Reaching a buffered
+        // adapter is a wiring bug.
+        crate::web_gateway::ApiResponse::Stream { .. } => serde_json::json!({
+            "t": "response",
+            "id": id,
+            "ok": false,
+            "error": format!("{label} returned an unexpected stream response"),
         }),
     }
 }
@@ -98,6 +116,15 @@ pub(crate) fn frame_api_ok_error_response(
             "ok": false,
             "error": format!("{label} returned an unexpected byte response"),
         }),
+        // The Stream lane never renders as a single response frame; its
+        // writer is the stream_* framer (S10). Reaching a buffered
+        // adapter is a wiring bug.
+        crate::web_gateway::ApiResponse::Stream { .. } => serde_json::json!({
+            "t": "response",
+            "id": id,
+            "ok": false,
+            "error": format!("{label} returned an unexpected stream response"),
+        }),
     }
 }
 
@@ -141,6 +168,19 @@ pub(crate) fn frame_api_task_response(
         json @ crate::web_gateway::ApiResponse::Json { .. } => ControlTaskResponse {
             id: id.clone(),
             frame: frame_api_response(id, json, label),
+            byte_stream: None,
+            done: true,
+        },
+        // The Stream lane's writer is the stream_* framer (S10); a
+        // byte-capable buffered method never answers on it.
+        crate::web_gateway::ApiResponse::Stream { .. } => ControlTaskResponse {
+            id: id.clone(),
+            frame: serde_json::json!({
+                "t": "response",
+                "id": id,
+                "ok": false,
+                "error": format!("{label} returned an unexpected stream response"),
+            }),
             byte_stream: None,
             done: true,
         },

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -214,9 +214,9 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
     // api_session_frame_asset), api_session_delete, and the worktrees
     // quartet live as tunnel columns on their route rows (S4b), and so
     // does the whole current-session family — history/rollback/redo/
-    // prune, changes, agent-output, uploads list/raw/delete, and the
-    // upload-frame-only api_session_current_upload (S4c).
-    method("api_sessions_stream", PeerOperation::SessionInspect),
+    // prune, changes, agent-output, uploads list/raw/delete, the
+    // upload-frame-only api_session_current_upload (S4c), and the
+    // Stream-lane api_sessions_stream (S10).
     method("api_session_control_msg", PeerOperation::SessionManage),
     // The api_fs_* methods live as tunnel columns on their route rows
     // (gateway_routes::ROUTES, /api/fs/*) — the first family whose tunnel
@@ -3126,7 +3126,7 @@ mod tests {
             // override (the ladder classifies the HTTP leaf as Task).
             ("api_coordinator_route", Row, Some(Op::PeerManage)),
             ("api_sessions", Row, Some(Op::SessionInspect)),
-            ("api_sessions_stream", Residue, Some(Op::SessionInspect)),
+            ("api_sessions_stream", Row, Some(Op::SessionInspect)),
             ("api_session_detail", Row, Some(Op::SessionInspect)),
             ("api_session_report", Row, Some(Op::SessionInspect)),
             ("api_session_agent_output", Row, Some(Op::SessionInspect)),

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -1137,7 +1137,8 @@ pub(crate) static ROUTES: &[Route] = &[
         BodyPolicy::None,
         RouteHandlerId::SessionsStream,
         "NDJSON stream of the session list",
-    ),
+    )
+    .with_tunnel(tunnel_method("api_sessions_stream")),
     op_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/sessions/search"),

--- a/src/bin/caller/web_gateway/api_core.rs
+++ b/src/bin/caller/web_gateway/api_core.rs
@@ -153,6 +153,20 @@ pub(crate) enum BytesPayload {
     InMemory(Vec<u8>),
 }
 
+/// The Stream lane's one line source (design §2.5, S10): the neutral
+/// handler spawns the producer and hands both transports this handle —
+/// the HTTP adapter writes the received lines verbatim under the
+/// response head; the tunnel framer wraps each in a `stream_event`
+/// frame between `stream_start`/`stream_end`. Items are complete
+/// NDJSON lines (trailing `\n` included). `source` is the producer
+/// task: writers drop `lines` first (hanging up unblocks a producer
+/// still sending after an early exit), then await it, so a panicked
+/// source is observable as the lane's error tail.
+pub(crate) struct LineStream {
+    pub(crate) lines: tokio::sync::mpsc::Receiver<String>,
+    pub(crate) source: tokio::task::JoinHandle<()>,
+}
+
 /// One API response, however it will leave the daemon. The HTTP adapter
 /// renders it byte-identically to the historical handler output (the
 /// golden transcripts prove it); the tunnel adapter (S2) frames `Json`
@@ -182,6 +196,19 @@ pub(crate) enum ApiResponse {
         /// the transfer rows (S9) define meta's HTTP rendering. `Null`
         /// when the response has no sidecar.
         meta: serde_json::Value,
+    },
+    /// NDJSON line stream (`GET /api/sessions/stream`, tunnel twin
+    /// `api_sessions_stream`): an unbounded-length response fed line by
+    /// line from one source task. The HTTP adapter writes the head
+    /// (EOF-delimited — no Content-Length) then each line verbatim; the
+    /// tunnel framer emits `stream_start`/`stream_event`/`stream_end`
+    /// and consumes only the lines.
+    Stream {
+        status: u16,
+        content_type: String,
+        /// Same contract as `Json::headers` (HTTP-lane decoration).
+        headers: Vec<(&'static str, String)>,
+        stream: LineStream,
     },
 }
 

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -787,7 +787,13 @@ pub(crate) async fn serve_http_request(
                 .await;
             }
             RouteHandlerId::SessionsStream => {
-                return handle_sessions_stream(stream, request_line).await;
+                return handle_sessions_stream(
+                    stream,
+                    request_line,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
             }
             RouteHandlerId::SessionsSearch => {
                 return handle_sessions_search(
@@ -1542,17 +1548,57 @@ pub(crate) fn api_response_http_bytes(
             }
             http
         }
+        // A line stream cannot be buffered — `write_api_response` owns
+        // that lane before delegating here. Reaching this arm is a
+        // wiring bug; fail closed with the canonical 500.
+        ApiResponse::Stream { .. } => {
+            debug_assert!(false, "ApiResponse::Stream reached the buffered HTTP renderer");
+            HttpResponse::json(
+                status_reason(500),
+                serde_json::json!({ "error": "stream response on the buffered lane" })
+                    .to_string(),
+            )
+        }
     };
-    let http = match cors {
+    apply_cors_posture(http, cors, fleet_origin).into_bytes()
+}
+
+/// The row-declared CORS posture, applied to a rendered response — one
+/// place for both the buffered renderer and the Stream-lane head.
+fn apply_cors_posture(
+    http: HttpResponse,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) -> HttpResponse {
+    match cors {
         crate::gateway_routes::CorsPosture::OwnOrigin => http,
         crate::gateway_routes::CorsPosture::Public => http.public_cors(),
         crate::gateway_routes::CorsPosture::FleetAllowlist => http.fleet_cors(fleet_origin),
-    };
-    http.into_bytes()
+    }
+}
+
+/// Head of a Stream-lane response: status line + Content-Type + the
+/// carried header tail under the row's CORS posture. Deliberately no
+/// Content-Length — the body is EOF-delimited (`Connection: close`)
+/// NDJSON lines the writer appends as they arrive.
+pub(crate) fn stream_response_http_head(
+    status: u16,
+    content_type: &str,
+    headers: Vec<(&'static str, String)>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) -> Vec<u8> {
+    let mut http = HttpResponse::new(status_reason(status)).header("Content-Type", content_type);
+    for (name, value) in headers {
+        http = http.header(name, value);
+    }
+    apply_cors_posture(http, cors, fleet_origin).into_bytes()
 }
 
 /// Write an [`ApiResponse`] to the HTTP lane and finalize the stream —
-/// the whole tail of a converted handler shim.
+/// the whole tail of a converted handler shim. The Stream lane writes
+/// its head then pumps the shared line source until it drains (or the
+/// client hangs up); buffered lanes render in one piece.
 pub(crate) async fn write_api_response(
     mut stream: DemuxStream,
     response: ApiResponse,
@@ -1560,8 +1606,37 @@ pub(crate) async fn write_api_response(
     fleet_origin: Option<&str>,
 ) {
     use tokio::io::AsyncWriteExt;
-    let bytes = api_response_http_bytes(response, cors, fleet_origin);
-    let _ = stream.write_all(&bytes).await;
+    match response {
+        ApiResponse::Stream {
+            status,
+            content_type,
+            headers,
+            stream: line_stream,
+        } => {
+            let head = stream_response_http_head(status, &content_type, headers, cors, fleet_origin);
+            let LineStream {
+                lines: mut line_rx,
+                source,
+            } = line_stream;
+            if stream.write_all(&head).await.is_ok() {
+                while let Some(line) = line_rx.recv().await {
+                    if stream.write_all(line.as_bytes()).await.is_err() {
+                        break;
+                    }
+                }
+            }
+            // Hang up before joining: after an early exit above (client
+            // gone) the source may still be sending into the channel;
+            // dropping the receiver fails those sends so the producer
+            // finishes instead of deadlocking the join.
+            drop(line_rx);
+            let _ = source.await;
+        }
+        buffered => {
+            let bytes = api_response_http_bytes(buffered, cors, fleet_origin);
+            let _ = stream.write_all(&bytes).await;
+        }
+    }
     finalize_http_stream(&mut stream).await;
 }
 
@@ -1658,15 +1733,30 @@ mod tests {
          Connection: close\r\n\
          \r\n";
 
-    #[test]
-    fn golden_sessions_stream_http_head_is_pinned() {
-        // The exact builder chain the legacy handler wrote its head with.
-        let legacy = HttpResponse::new("200 OK")
-            .header("Content-Type", "application/x-ndjson")
-            .header("Cache-Control", "no-cache")
-            .header("Access-Control-Allow-Origin", "*")
-            .header("Connection", "close")
-            .into_string();
-        assert_eq!(legacy, SESSIONS_STREAM_HEAD_GOLDEN);
+    #[tokio::test]
+    async fn golden_sessions_stream_http_head_is_pinned() {
+        // The Stream-lane head the neutral core declares, rendered under
+        // the row's declared posture, byte-identical to the retired
+        // hand-rolled header block.
+        let (_line_tx, lines) = tokio::sync::mpsc::channel::<String>(1);
+        let crate::web_gateway::ApiResponse::Stream {
+            status,
+            content_type,
+            headers,
+            stream,
+        } = crate::web_gateway::sessions_stream_api_response_from(crate::web_gateway::LineStream {
+            lines,
+            source: tokio::spawn(async {}),
+        })
+        else {
+            panic!("sessions stream core must answer on the Stream lane");
+        };
+        drop(stream);
+        let row_cors = crate::gateway_routes::match_route("GET", "/api/sessions/stream")
+            .expect("sessions stream route declared")
+            .0
+            .cors;
+        let head = stream_response_http_head(status, &content_type, headers, row_cors, None);
+        assert_eq!(String::from_utf8(head).unwrap(), SESSIONS_STREAM_HEAD_GOLDEN);
     }
 }

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1641,4 +1641,32 @@ mod tests {
         assert!(!text.contains("Access-Control-Allow-Origin"), "{text}");
         assert!(text.contains("Vary: Origin\r\n"), "{text}");
     }
+
+    // ── S10 golden: the sessions-stream NDJSON head (design §8) ──
+    // Captured from the hand-rolled `handle_sessions_stream` header
+    // block before the Stream-lane conversion: no Content-Length, no
+    // Transfer-Encoding — the response is EOF-delimited
+    // (`Connection: close`), with the wildcard-CORS tail the sessions
+    // family bakes into its responses (the row's posture is OwnOrigin;
+    // the header is response decoration, exactly like `/api/sessions`).
+
+    /// The historical head, byte for byte.
+    pub(super) const SESSIONS_STREAM_HEAD_GOLDEN: &str = "HTTP/1.1 200 OK\r\n\
+         Content-Type: application/x-ndjson\r\n\
+         Cache-Control: no-cache\r\n\
+         Access-Control-Allow-Origin: *\r\n\
+         Connection: close\r\n\
+         \r\n";
+
+    #[test]
+    fn golden_sessions_stream_http_head_is_pinned() {
+        // The exact builder chain the legacy handler wrote its head with.
+        let legacy = HttpResponse::new("200 OK")
+            .header("Content-Type", "application/x-ndjson")
+            .header("Cache-Control", "no-cache")
+            .header("Access-Control-Allow-Origin", "*")
+            .header("Connection", "close")
+            .into_string();
+        assert_eq!(legacy, SESSIONS_STREAM_HEAD_GOLDEN);
+    }
 }

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -3319,28 +3319,51 @@ pub(crate) async fn handle_mc_fission(
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 
-pub(crate) async fn handle_sessions_stream(mut stream: DemuxStream, request_line: &str) {
-    let request_line_for_stream = request_line.to_string();
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(64);
-    let stream_task = tokio::task::spawn_blocking(move || {
-        stream_sessions_from_request(&request_line_for_stream, tx);
+/// Transport-neutral core of the session-list stream
+/// (`GET /api/sessions/stream`, tunnel twin `api_sessions_stream`, S10):
+/// spawn the ONE line source — quick skeleton, hydrating marker,
+/// replace, done — onto the blocking pool and hand its handle to the
+/// caller's transport writer under the historical NDJSON head (the
+/// wildcard-CORS tail is response decoration on the OwnOrigin row,
+/// exactly like `/api/sessions`).
+pub(crate) fn sessions_stream_api_response(requested_limit: Option<usize>) -> ApiResponse {
+    let (tx, lines) = tokio::sync::mpsc::channel::<String>(64);
+    let source = tokio::task::spawn_blocking(move || {
+        stream_sessions_lines(requested_limit, tx);
     });
-    let response = HttpResponse::new("200 OK")
-        .header("Content-Type", "application/x-ndjson")
-        .header("Cache-Control", "no-cache")
-        .header("Access-Control-Allow-Origin", "*")
-        .header("Connection", "close")
-        .into_string();
-    use tokio::io::AsyncWriteExt;
-    if stream.write_all(response.as_bytes()).await.is_ok() {
-        while let Some(line) = rx.recv().await {
-            if stream.write_all(line.as_bytes()).await.is_err() {
-                break;
-            }
-        }
+    sessions_stream_api_response_from(LineStream { lines, source })
+}
+
+/// The stream envelope over an already-running line source — the
+/// hermetic seam ([`sessions_stream_api_response`] is the ambient-home
+/// production entry; fixtures inject their own source).
+pub(crate) fn sessions_stream_api_response_from(stream: LineStream) -> ApiResponse {
+    ApiResponse::Stream {
+        status: 200,
+        content_type: "application/x-ndjson".to_string(),
+        headers: vec![
+            ("Cache-Control", "no-cache".to_string()),
+            ("Access-Control-Allow-Origin", "*".to_string()),
+            ("Connection", "close".to_string()),
+        ],
+        stream,
     }
-    let _ = stream_task.await;
-    finalize_http_stream(&mut stream).await;
+}
+
+pub(crate) async fn handle_sessions_stream(
+    stream: DemuxStream,
+    request_line: &str,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let requested_limit = session_list_limit_from_request(request_line);
+    write_api_response(
+        stream,
+        sessions_stream_api_response(requested_limit),
+        cors,
+        fleet_origin,
+    )
+    .await;
 }
 
 /// Transport-neutral core of `GET /api/sessions/search` (tunnel twin

--- a/src/bin/caller/web_gateway/routes_transfers.rs
+++ b/src/bin/caller/web_gateway/routes_transfers.rs
@@ -861,7 +861,9 @@ mod tests {
                 };
                 (*status, serde_json::from_str(&text).unwrap())
             }
-            ApiResponse::Bytes { .. } => panic!("expected a JSON response"),
+            ApiResponse::Bytes { .. } | ApiResponse::Stream { .. } => {
+                panic!("expected a JSON response")
+            }
         }
     }
 
@@ -883,6 +885,7 @@ mod tests {
                     JsonBody::Value(value) => value.to_string(),
                 }
             ),
+            ApiResponse::Stream { .. } => panic!("expected a bytes response, got a stream"),
         }
     }
 
@@ -1426,7 +1429,9 @@ mod tests {
                     Some("bytes */14")
                 );
             }
-            ApiResponse::Bytes { .. } => panic!("expected the 416 JSON shape"),
+            ApiResponse::Bytes { .. } | ApiResponse::Stream { .. } => {
+                panic!("expected the 416 JSON shape")
+            }
         }
 
         // Unknown job on the header form resolves before parsing.

--- a/src/bin/caller/web_gateway/session_catalog/mod.rs
+++ b/src/bin/caller/web_gateway/session_catalog/mod.rs
@@ -2350,15 +2350,44 @@ pub(crate) fn send_session_stream_rows(
     true
 }
 
-pub(crate) fn stream_sessions_from_request(
-    request_line: &str,
+/// The session-list stream's ONE line source (transport-unification
+/// S10): quick skeleton rows, the hydrating phase marker, the
+/// cache-hydrated replace, done — pushed as complete NDJSON lines into
+/// `tx`. Both transports spawn exactly this function (via
+/// `sessions_stream_api_response`) and own only their writers. This
+/// production entry resolves the ambient home and hydrates through the
+/// process-wide session-list caches; the parity fixture injects a temp
+/// store and the direct scan through `stream_sessions_lines_from_home`.
+pub(crate) fn stream_sessions_lines(
+    requested_limit: Option<usize>,
     tx: tokio::sync::mpsc::Sender<String>,
 ) {
-    let requested_limit = session_list_limit_from_request(request_line);
+    stream_sessions_lines_from_home(
+        &crate::platform::home_dir(),
+        requested_limit,
+        || {
+            requested_limit
+                .map(cached_list_sessions_with_limit)
+                .unwrap_or_else(cached_list_sessions)
+        },
+        tx,
+    )
+}
+
+/// Root-injected body of [`stream_sessions_lines`] (hermetic-test
+/// convention: the quick phase scans `home`; the replace phase's
+/// hydrated list body comes from `hydrated_body` — the response caches
+/// in production, a direct `list_sessions_from_home_with_limit` scan in
+/// fixtures).
+pub(crate) fn stream_sessions_lines_from_home(
+    home: &Path,
+    requested_limit: Option<usize>,
+    hydrated_body: impl FnOnce() -> String,
+    tx: tokio::sync::mpsc::Sender<String>,
+) {
     let quick_limit = requested_limit
         .unwrap_or(SESSION_LIST_LIMIT)
         .min(SESSION_LIST_STREAM_QUICK_LIMIT);
-    let home = crate::platform::home_dir();
     if !send_session_stream_event(
         &tx,
         serde_json::json!({
@@ -2372,14 +2401,14 @@ pub(crate) fn stream_sessions_from_request(
 
     let mut quick_rows = Vec::new();
     quick_rows.extend(list_intendant_skeleton_sessions_with_limit(
-        &home,
+        home,
         quick_limit,
     ));
     quick_rows.extend(list_codex_index_skeleton_sessions_with_limit(
-        &home,
+        home,
         quick_limit,
     ));
-    merge_quick_session_rows_with_wrapper_index(&home, &mut quick_rows);
+    merge_quick_session_rows_with_wrapper_index(home, &mut quick_rows);
     sort_sessions_newest_first(&mut quick_rows);
     truncate_sessions_preserving_sources_to(&mut quick_rows, quick_limit);
     if !send_session_stream_rows(&tx, quick_rows, true) {
@@ -2395,9 +2424,7 @@ pub(crate) fn stream_sessions_from_request(
         return;
     }
 
-    let body = requested_limit
-        .map(cached_list_sessions_with_limit)
-        .unwrap_or_else(cached_list_sessions);
+    let body = hydrated_body();
     let rows = serde_json::from_str::<Vec<serde_json::Value>>(&body).unwrap_or_default();
     let _ = send_session_stream_event(
         &tx,

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -1391,6 +1391,71 @@ async fn transfer_jobs_round_trip_over_direct_http() {
     assert_eq!(fallback["deleted"], true, "{fallback}");
 }
 
+/// The Stream lane over direct HTTP (transport-unification S10):
+/// `GET /api/sessions/stream` answers the NDJSON head (EOF-delimited,
+/// `application/x-ndjson`) and the shared line source's lifecycle —
+/// start, the hydrating phase marker, the replace payload, done — as
+/// parseable one-object lines, against the real daemon binary.
+#[tokio::test]
+async fn sessions_stream_serves_ndjson_over_direct_http() {
+    let idle_script = serde_json::json!({
+        "profiles": [{
+            "steps": [
+                { "content": "fallback profile (unexpected session)",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "unexpected session" } }] }
+            ]
+        }]
+    });
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("http client");
+    let port = free_loopback_port();
+    let daemon = spawn_daemon(&client, &idle_script, port).await;
+
+    let response = client
+        .get(format!(
+            "http://127.0.0.1:{port}/api/sessions/stream?limit=50"
+        ))
+        .send()
+        .await
+        .expect("stream response");
+    assert_eq!(response.status().as_u16(), 200, "{}", daemon.log_tail());
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok()),
+        Some("application/x-ndjson")
+    );
+    // EOF-delimited: no Content-Length on the streamed head.
+    assert!(response.headers().get("content-length").is_none());
+
+    let body = response.text().await.expect("stream body");
+    let events: Vec<serde_json::Value> = body
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("one JSON object per NDJSON line"))
+        .collect();
+    assert!(events.len() >= 3, "{body}");
+    assert_eq!(events.first().unwrap()["type"], "start", "{body}");
+    assert_eq!(events.first().unwrap()["limit"], 50, "{body}");
+    assert!(
+        events
+            .iter()
+            .any(|event| event["type"] == "phase" && event["phase"] == "hydrating"),
+        "{body}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event["type"] == "replace" && event["sessions"].is_array()),
+        "{body}"
+    );
+    assert_eq!(events.last().unwrap()["type"], "done", "{body}");
+}
+
 /// The display-request rail end to end: a caller rings the user-display
 /// doorbell (`ctl display request` → the `request_user_display` tool), a
 /// dashboard surface (here: a raw `/ws` client) receives the dedicated


### PR DESCRIPTION
Stage S10 of the transport-unification program (design §6): the session-list stream's two lanes — HTTP NDJSON (`GET /api/sessions/stream`) and the tunnel's `stream_*` frames (`api_sessions_stream`) — now flow through ONE line source behind `ApiResponse::Stream`; each transport owns only its writer.

**Goldens first** (commit 1, pinned before the conversion, unchanged after):
- HTTP head byte-exact: EOF-delimited (`Connection: close`, no Content-Length), `application/x-ndjson`, the historical wildcard-CORS tail.
- Tunnel frame objects byte-exact: `stream_start` method echo, `stream_event` seq/chunk_id pairing, `stream_end` events tally.

**The unification** (commit 2):
- `api_core`: `LineStream` (line receiver + source task) under a new `ApiResponse::Stream` variant; the buffered frame adapters and buffered HTTP renderer fail closed on it.
- `session_catalog`: `stream_sessions_from_request` → `stream_sessions_lines` (the one source both lanes spawn) + a root-injected `_from_home` seam for hermetic fixtures; limit parsing moves to the transport edges.
- `routes_sessions`: `sessions_stream_api_response` neutral core; the HTTP handler is a parse-limit + `write_api_response` shim.
- `http_dispatch`: `write_api_response` owns the Stream lane (pinned head → verbatim lines → hang-up-then-join). **Fixes a latent connection-task deadlock**: the old handler awaited the source with the receiver still alive after a client disconnect, wedging once the 64-line channel filled. `apply_cors_posture` factored for both renderers.
- Tunnel edge: `sessions_stream_requested_limit` parses the tunnel's limit vocabulary natively — equivalence-pinned against the retired params→request-line synthesis, including the historical `"unlimited"` asymmetry and the `SESSION_LIST_LIMIT` cap; `stream_json_lines_response` consumes the shared `LineStream`.
- **Row flip**: `api_sessions_stream` leaves the `CONTROL_METHODS` residue and becomes the `tunnel:` column on the `/api/sessions/stream` row. IAM op unchanged (SessionInspect on both sides, now derived); partition pin Residue → Row. No op overrides.
- **Parity fixture** (hermetic): an injected temp session store drives the shared source once; both writers carry the identical event sequence — HTTP body lines byte-equal, tunnel `stream_event` objects byte-equal.
- New e2e: `GET /api/sessions/stream` against the real daemon answers the NDJSON head + start/hydrating/replace/done lifecycle.

**Battery**: `cargo nextest run --bins` 3015 passed · `cargo clippy` no new warnings · `cargo test --test e2e` 15 passed (incl. the new stream probe).

**Wire**: zero change on both lanes (goldens + parity prove it). Operator-battery gates (validate-dashboard streamed-hydration probes, rendezvous validator chunked-stream pass) remain post-landing per the S10 gate list.