### PR TITLE
wasm-drift probe: exercise the gate's rebuild path

### DIFF
--- a/crates/presence-web/src/lib.rs
+++ b/crates/presence-web/src/lib.rs
@@ -1,4 +1,5 @@
-//! Browser-side presence layer in Rust+WASM.
+//! Browser-side presence layer in Rust+WASM. (Comment-only touch: the
+//! wasm-drift gate's rebuild path was first exercised by this line.)
 //!
 //! Wraps `presence-core` (pure logic) with browser WebSocket transport for:
 //! - Server connection (TUI frames, control messages, tool requests)


### PR DESCRIPTION
Deliberate probe, held out of the queue until its wasm-drift check reports: a comment-only touch to presence-web takes the gate down its rebuild path for the first time (every run so far green-skipped on relevance). Codegen is unchanged by a comment, so a green run proves BOTH the rebuild plumbing (pinned wasm-pack install on the runner account, external cache, diff) AND cross-host byte-determinism (committed artifacts are macOS-built; the gate rebuilds on Linux). Red means macOS-built artifacts can't serve as the committed canon and the gate needs a Linux-regen or an advisory downgrade before promotion.