### PR TITLE
Release transparency: releases commit to the public log; hosted-verify --releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,21 @@ name: macOS app release
 # rather than silently shipping a less-signed artifact. Provisioning ceremony
 # (exporting the p12, minting the notary key): docs/src/getting-started.md,
 # "Signed releases".
+#
+# Release transparency (docs/src/self-hosted-rendezvous.md, "Release
+# transparency"): after publishing, tag builds commit the released
+# artifacts' hashes to the rendezvous's public transparency log. One more
+# repo secret, exactly:
+#
+#   CONNECT_RELEASE_TOKEN    bearer token the rendezvous was started with
+#                            (--release-token / INTENDANT_CONNECT_RELEASE_TOKEN
+#                            on intendant-connect) — authorizes ONLY
+#                            release-manifest submission, nothing else
+#
+# When the secret is absent (forks, dry runs) the submission step logs
+# that it is skipping and no-ops. The optional CONNECT_RELEASE_URL repo
+# *variable* points self-hosted forks at their own rendezvous (default
+# https://intendant.dev).
 
 on:
   push:
@@ -249,6 +264,60 @@ jobs:
               --title "Intendant $tag" \
               --notes-file "$RUNNER_TEMP/release-notes.md"
           fi
+
+      # Commit what was just published to the public transparency log:
+      # sha256 + size of every artifact uploaded to the GitHub release,
+      # POSTed as a release_manifest (docs/src/self-hosted-rendezvous.md,
+      # "Release transparency"). `intendant hosted-verify --releases`
+      # checks the two sides against each other out of band. Runs AFTER
+      # the publish step so the log commits exactly the uploaded bytes;
+      # if submission fails, the run goes red so the operator notices a
+      # published-but-unlogged release. Skips with a clear line when the
+      # CONNECT_RELEASE_TOKEN repo secret is not configured.
+      - name: Submit release manifest to the transparency log
+        if: github.ref_type == 'tag'
+        shell: bash
+        env:
+          CONNECT_RELEASE_TOKEN: ${{ secrets.CONNECT_RELEASE_TOKEN }}
+          CONNECT_RELEASE_URL: ${{ vars.CONNECT_RELEASE_URL || 'https://intendant.dev' }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "$CONNECT_RELEASE_TOKEN" ]; then
+            echo "CONNECT_RELEASE_TOKEN is not configured — skipping transparency-log submission (expected on forks and dry runs)."
+            exit 0
+          fi
+          manifest="$RUNNER_TEMP/release-manifest.json"
+          python3 - "$RELEASE_TAG" dist/* > "$manifest" <<'PY'
+          import hashlib, json, os, sys
+          tag, *paths = sys.argv[1:]
+          artifacts = []
+          for path in sorted(paths, key=os.path.basename):
+              digest = hashlib.sha256()
+              with open(path, "rb") as fh:
+                  for chunk in iter(lambda: fh.read(1 << 20), b""):
+                      digest.update(chunk)
+              artifacts.append({
+                  "name": os.path.basename(path),
+                  "sha256": digest.hexdigest(),
+                  "size": os.path.getsize(path),
+              })
+          print(json.dumps({
+              "tag": tag,
+              "version": tag.removeprefix("v"),
+              "platforms": ["macos-arm64"],
+              "artifacts": artifacts,
+          }, indent=2))
+          PY
+          echo "release manifest for $RELEASE_TAG:"
+          cat "$manifest"
+          curl -sS --fail-with-body -X POST \
+            "$CONNECT_RELEASE_URL/api/log/release-manifest" \
+            -H "Authorization: Bearer $CONNECT_RELEASE_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data-binary @"$manifest"
+          echo
+          echo "release manifest committed to $CONNECT_RELEASE_URL/api/log/release-manifest"
 
       # Manual dispatch has no tag to hang a release on; keep the artifact
       # on the workflow run instead.

--- a/docs/src/self-hosted-rendezvous.md
+++ b/docs/src/self-hosted-rendezvous.md
@@ -311,11 +311,11 @@ they would the hosted one.
 Every name binding the service hands out is committed to an append-only
 RFC 6962-shaped Merkle log: which public key a computer had when it was
 claimed, handle creations, org revocation-list publications, verified
-badges, handle reclamations — and the served-artifact manifests
-described below. The signed tree head is public (`/api/log/sth`, ES256
-key auto-generated into the state file) along with entries, inclusion
-proofs, and consistency proofs
-(`/api/log/{entries,proof,consistency,find,artifact-manifest}`).
+badges, handle reclamations — and the served-artifact and release
+manifests described below. The signed tree head is public
+(`/api/log/sth`, ES256 key auto-generated into the state file) along
+with entries, inclusion proofs, and consistency proofs
+(`/api/log/{entries,proof,consistency,find,artifact-manifest,release-manifest}`).
 Browsers pin the tree head and verify consistency on every visit
 (Advanced → Transparency log), so rewriting history is detectable, not
 merely forbidden.
@@ -394,6 +394,53 @@ comparing clean against the logged hashes ties the served bytes to
 reviewable source. The embedded pages are deterministic functions of
 the public origin, reproducible by running `intendant-connect` locally
 with the same `--origin` and hashing what it serves.
+
+### Release transparency
+
+The same log commits **what the project releases**, closing the update
+channel's side of the story ([Trust Tiers](./trust-tiers.md)): after
+publishing to GitHub Releases, the tag-triggered release pipeline
+(`.github/workflows/release.yml`) hashes every uploaded artifact and
+submits a `release_manifest` entry — `tag`, `version`, `platforms`, and
+a name-sorted `artifacts` list of `{name, sha256, size}` (lowercase-hex
+hashes, comparable to `sha256sum` output), plus `manifest_hash`: sha256
+over the canonical byte string `intendant-release-manifest-v1\n{tag}\n`
+then `{name}\t{sha256}\t{size}\n` per artifact. Submission is
+`POST /api/log/release-manifest`, gated by a dedicated bearer token
+(`--release-token` / `INTENDANT_CONNECT_RELEASE_TOKEN`; the pipeline
+holds it as the `CONNECT_RELEASE_TOKEN` repository secret). The token
+is deliberately not the operator `daemon_token`: the CI credential can
+only ever append release manifests. With no token configured the
+endpoint answers 503; identical re-submissions dedupe; a *changed*
+manifest for an existing tag appends a new entry — republished
+artifacts become public history, never silent replacement. Reads stay
+public: `GET /api/log/release-manifest[?tag=<tag>]` returns the latest
+entry (for a tag) with its index, inclusion proof, and signed tree
+head, coherently.
+
+```bash
+intendant hosted-verify --releases              # the latest logged release
+intendant hosted-verify --releases v0.3.0       # this tag MUST be logged
+intendant hosted-verify --releases v0.3.0 --download
+```
+
+The default mode verifies the log legs exactly like the bundle check
+(tree-head signature, inclusion proof, consistency against the same
+per-host pin), then compares the logged artifact list against the
+GitHub release's asset *metadata* — names, sizes, and the sha256
+digests the API reports — without downloading multi-hundred-MB
+artifacts; assets on the release that the log never blessed are flagged
+too. `--download` upgrades to fetching every artifact and hashing it
+against the log — the strongest check. With an explicit tag, a release
+absent from the log is a failure (exit 1): an unlogged release is
+exactly what the check exists to catch. (`--repo <owner/name>` points
+self-hosted forks at their own repository, and the optional
+`CONNECT_RELEASE_URL` repository *variable* points their pipeline at
+their own rendezvous.) The macOS app's update check (launch and "Check
+for Updates…") also asks the log about the release it is offering and
+appends a "publicly committed / NOT committed / couldn't check"
+advisory line — fail-open like the bundle tripwire: a log outage never
+blocks updating, and the error is surfaced instead of swallowed.
 
 Dormant-handle reclamation is stated policy: an account with zero
 claimed daemons and no sign-in for the configured window loses its

--- a/docs/src/trust-tiers.md
+++ b/docs/src/trust-tiers.md
@@ -232,11 +232,13 @@ stated non-goal:
   *serving* channel the evidence leg is shipped: served-artifact
   manifests live in the rendezvous's public transparency log, verified
   out of band by `hosted-verify` and advisorily by every daemon's
-  bundle tripwire. The *release* channel is thinner: app builds ship as
-  GitHub releases (public source, public workflow runs, and — once
-  signing is provisioned — Developer ID + notarization), but release
-  artifacts are not yet committed to the same transparency log. That
-  tie is the remaining open thread here.
+  bundle tripwire. The *release* channel now carries the same tie: app
+  builds ship as GitHub releases (public source, public workflow runs,
+  and — once signing is provisioned — Developer ID + notarization),
+  the release pipeline commits every artifact's hash to the same log
+  (`release_manifest` entries), `hosted-verify --releases` checks the
+  log against GitHub out of band, and the app's update check surfaces
+  logged / not-logged as a fail-open advisory.
 - **Lookalike names.** `d-<hash>` labels are deliberately opaque, which
   also means humans cannot eyeball them; a phished lookalike with its own
   valid certificate raises no CT alarm on *your* name, because it is not

--- a/macos-app/UpdateChecker.swift
+++ b/macos-app/UpdateChecker.swift
@@ -63,6 +63,89 @@ enum UpdateChecker {
         return false
     }
 
+    /// Origin of the hosted rendezvous whose public transparency log
+    /// commits this repo's releases (`release_manifest` entries;
+    /// docs/src/self-hosted-rendezvous.md, "Release transparency").
+    static let transparencyLogOrigin = "https://intendant.dev"
+
+    /// Advisory verdict on whether a release tag is committed to the
+    /// public transparency log. Fail-open like the CT/bundle tripwires:
+    /// a log outage must never block an update, so `unknown` carries
+    /// the error for display instead of failing anything.
+    enum ReleaseLogStatus {
+        case logged(artifactCount: Int)
+        case notLogged
+        case unknown(String)
+    }
+
+    private static func releaseLogAPI(tag: String) -> URL? {
+        var components = URLComponents(string: "\(transparencyLogOrigin)/api/log/release-manifest")
+        components?.queryItems = [URLQueryItem(name: "tag", value: tag)]
+        return components?.url
+    }
+
+    /// Ask the transparency log whether it commits a release manifest for
+    /// `tag`. Presence-only by design: the installed .app is the extracted
+    /// tree, not the downloaded zip, so its release hash is not computable
+    /// at runtime — the meaningful in-app advisory is whether the release
+    /// is publicly committed at all. `intendant hosted-verify --releases`
+    /// is the full out-of-band check. Completion runs on the main queue.
+    static func fetchReleaseLogStatus(tag: String, completion: @escaping (ReleaseLogStatus) -> Void) {
+        guard let url = releaseLogAPI(tag: tag) else {
+            DispatchQueue.main.async { completion(.unknown("could not build log URL")) }
+            return
+        }
+        var request = URLRequest(
+            url: url,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 15
+        )
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            var status = ReleaseLogStatus.unknown("unexpected response")
+            if let error = error {
+                status = .unknown(error.localizedDescription)
+            } else if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+                status = .unknown("HTTP \(http.statusCode)")
+            } else if let data = data,
+                      let object = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+                      object["ok"] as? Bool == true {
+                if object["found"] as? Bool == true {
+                    var artifactCount = 0
+                    if let leafData = (object["leaf_json"] as? String)?.data(using: .utf8),
+                       let leaf = (try? JSONSerialization.jsonObject(with: leafData)) as? [String: Any],
+                       let artifacts = leaf["artifacts"] as? [[String: Any]] {
+                        artifactCount = artifacts.count
+                    }
+                    status = .logged(artifactCount: artifactCount)
+                } else {
+                    status = .notLogged
+                }
+            }
+            DispatchQueue.main.async { completion(status) }
+        }.resume()
+    }
+
+    /// The advisory line the update alerts append — honest in all three
+    /// states, blocking in none (the unknown case surfaces the error
+    /// instead of hiding it).
+    static func advisoryLine(for status: ReleaseLogStatus, tag: String) -> String {
+        switch status {
+        case .logged(let count):
+            return "Transparency log: release \(tag) is publicly committed"
+                + " (\(count) artifact\(count == 1 ? "" : "s"))."
+                + " Full out-of-band check: intendant hosted-verify --releases \(tag)"
+        case .notLogged:
+            return "Transparency log: release \(tag) is NOT committed to the public log at"
+                + " \(transparencyLogOrigin) — treat the download with suspicion and verify its"
+                + " sha256 against the release page before opening it."
+        case .unknown(let error):
+            return "Transparency log: couldn't check release \(tag) (\(error))."
+                + " Updating is not blocked; verify later with:"
+                + " intendant hosted-verify --releases \(tag)"
+        }
+    }
+
     /// Fetch the latest published release. Completion runs on the main queue;
     /// `nil` means "couldn't determine" (offline, rate-limited, no releases
     /// published yet, unexpected payload) — callers decide whether that is

--- a/macos-app/main.swift
+++ b/macos-app/main.swift
@@ -621,7 +621,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
             guard let self = self,
                   let release = release,
                   UpdateChecker.isNewer(remote: release.tag, than: local) else { return }
-            self.presentUpdatePrompt(release: release, interactive: false)
+            // Advisory transparency-log check on the release being
+            // offered — fail-open: every outcome still shows the prompt,
+            // annotated with logged / not logged / couldn't check.
+            UpdateChecker.fetchReleaseLogStatus(tag: release.tag) { [weak self] status in
+                self?.presentUpdatePrompt(release: release, logStatus: status, interactive: false)
+            }
         }
     }
 
@@ -644,28 +649,43 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, WKUIDelega
                 return
             }
             let local = UpdateChecker.bundledVersion()
-            if UpdateChecker.isNewer(remote: release.tag, than: local) {
-                self.presentUpdatePrompt(release: release, interactive: true)
-            } else {
-                let alert = NSAlert()
-                alert.messageText = "No update available"
-                alert.informativeText =
-                    "This app is version \(local). The latest published release is \(release.tag)."
-                alert.addButton(withTitle: "OK")
-                alert.runModal()
+            // The explicit check also reports the transparency-log
+            // advisory for the latest release, whichever branch answers.
+            UpdateChecker.fetchReleaseLogStatus(tag: release.tag) { [weak self] status in
+                guard let self = self else { return }
+                if UpdateChecker.isNewer(remote: release.tag, than: local) {
+                    self.presentUpdatePrompt(release: release, logStatus: status, interactive: true)
+                } else {
+                    let alert = NSAlert()
+                    alert.messageText = "No update available"
+                    alert.informativeText =
+                        "This app is version \(local). The latest published release is \(release.tag).\n\n"
+                        + UpdateChecker.advisoryLine(for: status, tag: release.tag)
+                    alert.addButton(withTitle: "OK")
+                    alert.runModal()
+                }
             }
         }
     }
 
     /// The prompt never downloads anything: "View Release" opens the GitHub
     /// release page in the default browser and the user takes it from there.
-    func presentUpdatePrompt(release: UpdateChecker.Release, interactive: Bool) {
+    /// `logStatus` rides along as an advisory line — whether the offered
+    /// release is committed to the public transparency log (never gates
+    /// the prompt; docs/src/self-hosted-rendezvous.md, "Release
+    /// transparency").
+    func presentUpdatePrompt(
+        release: UpdateChecker.Release,
+        logStatus: UpdateChecker.ReleaseLogStatus,
+        interactive: Bool
+    ) {
         let alert = NSAlert()
         alert.messageText = "Intendant \(release.tag) is available"
         alert.informativeText =
             "This app is version \(UpdateChecker.bundledVersion()). "
             + "Updating is manual: View Release opens the GitHub release page in your browser — "
-            + "nothing is downloaded or installed automatically."
+            + "nothing is downloaded or installed automatically.\n\n"
+            + UpdateChecker.advisoryLine(for: logStatus, tag: release.tag)
         alert.addButton(withTitle: "View Release")
         alert.addButton(withTitle: "Not Now")
         let handle: (NSApplication.ModalResponse) -> Void = { response in

--- a/src/bin/caller/hosted_verify.rs
+++ b/src/bin/caller/hosted_verify.rs
@@ -545,7 +545,11 @@ async fn fetch_json(client: &reqwest::Client, url: Url) -> Result<serde_json::Va
 /// Fetch one artifact, hashing as it streams. Transport errors bubble as
 /// `Err` (the whole run becomes Unavailable); HTTP error statuses and
 /// oversize bodies are verdicts, not failures.
-async fn fetch_artifact(client: &reqwest::Client, url: Url) -> Result<ArtifactFetch, String> {
+async fn fetch_artifact(
+    client: &reqwest::Client,
+    url: Url,
+    byte_cap: usize,
+) -> Result<ArtifactFetch, String> {
     use futures_util::StreamExt as _;
     let response = client
         .get(url.clone())
@@ -562,7 +566,7 @@ async fn fetch_artifact(client: &reqwest::Client, url: Url) -> Result<ArtifactFe
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|e| format!("GET {url}: {e}"))?;
         total += chunk.len();
-        if total > ARTIFACT_BYTE_CAP {
+        if total > byte_cap {
             return Ok(ArtifactFetch::TooLarge);
         }
         hasher.update(&chunk);
@@ -573,29 +577,31 @@ async fn fetch_artifact(client: &reqwest::Client, url: Url) -> Result<ArtifactFe
     })
 }
 
-/// The full out-of-band check against one rendezvous origin. On success
-/// the tree head is (re-)pinned under `state_root`.
-pub(crate) async fn verify_hosted_bundle(
+/// A log-endpoint response carried through the shared first half of the
+/// ritual: the tree head stands on its signature, the leaf is IN the
+/// tree the head signs, and the head extends the pinned one. The caller
+/// finishes its own artifact comparison, then advances the pin by
+/// writing `pin_candidate` to `pin_file` — only after everything held.
+struct VerifiedLogEntry {
+    index: u64,
+    leaf_json: String,
+    sth: Sth,
+    pin_file: PathBuf,
+    pinned_from_size: Option<u64>,
+    pin_candidate: SthPin,
+}
+
+async fn verify_logged_entry(
+    client: &reqwest::Client,
     base: &Url,
     state_root: &Path,
-) -> Result<VerifyReport, VerifyFailure> {
+    response: &serde_json::Value,
+) -> Result<VerifiedLogEntry, VerifyFailure> {
     use VerifyFailure::{Unavailable, Verification};
     let verification = |summary: String| Verification {
         summary,
         mismatches: Vec::new(),
     };
-    let client = http_client().map_err(Unavailable)?;
-    let manifest_url = crate::connect_rendezvous::join_url(base, "api/log/artifact-manifest")
-        .map_err(Unavailable)?;
-    let response = fetch_json(&client, manifest_url).await.map_err(Unavailable)?;
-    if response.get("ok").and_then(|v| v.as_bool()) != Some(true) {
-        return Err(Unavailable("artifact-manifest endpoint returned an error".to_string()));
-    }
-    if response.get("found").and_then(|v| v.as_bool()) != Some(true) {
-        return Err(Unavailable(
-            "this rendezvous logs no artifact manifest (older intendant-connect?)".to_string(),
-        ));
-    }
 
     // 1. The signed tree head stands on its own signature.
     let sth = Sth::parse(response.get("sth").unwrap_or(&serde_json::Value::Null))
@@ -668,12 +674,57 @@ pub(crate) async fn verify_hosted_bundle(
         }
     }
 
-    // 4. The manifest self-verifies, then the live bytes match it.
-    let leaf = parse_manifest_leaf(leaf_json).map_err(verification)?;
+    let pin_candidate = SthPin {
+        size: sth.size,
+        root: sth.root_b64u.clone(),
+        public_key: sth.public_key_b64u.clone(),
+        pinned_unix_ms: pin.map(|p| p.pinned_unix_ms).unwrap_or_else(now_unix_ms),
+    };
+    Ok(VerifiedLogEntry {
+        index,
+        leaf_json: leaf_json.to_string(),
+        sth,
+        pin_file,
+        pinned_from_size,
+        pin_candidate,
+    })
+}
+
+/// The full out-of-band check against one rendezvous origin. On success
+/// the tree head is (re-)pinned under `state_root`.
+pub(crate) async fn verify_hosted_bundle(
+    base: &Url,
+    state_root: &Path,
+) -> Result<VerifyReport, VerifyFailure> {
+    use VerifyFailure::{Unavailable, Verification};
+    let verification = |summary: String| Verification {
+        summary,
+        mismatches: Vec::new(),
+    };
+    let client = http_client().map_err(Unavailable)?;
+    let manifest_url = crate::connect_rendezvous::join_url(base, "api/log/artifact-manifest")
+        .map_err(Unavailable)?;
+    let response = fetch_json(&client, manifest_url).await.map_err(Unavailable)?;
+    if response.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+        return Err(Unavailable("artifact-manifest endpoint returned an error".to_string()));
+    }
+    if response.get("found").and_then(|v| v.as_bool()) != Some(true) {
+        return Err(Unavailable(
+            "this rendezvous logs no artifact manifest (older intendant-connect?)".to_string(),
+        ));
+    }
+
+    // The tree head, inclusion, and pin consistency — the shared ritual.
+    let entry = verify_logged_entry(&client, base, state_root, &response).await?;
+
+    // The manifest self-verifies, then the live bytes match it.
+    let leaf = parse_manifest_leaf(&entry.leaf_json).map_err(verification)?;
     let mut mismatches = Vec::new();
     for artifact in &leaf.artifacts {
         let url = crate::connect_rendezvous::join_url(base, &artifact.path).map_err(Unavailable)?;
-        let fetched = fetch_artifact(&client, url).await.map_err(Unavailable)?;
+        let fetched = fetch_artifact(&client, url, ARTIFACT_BYTE_CAP)
+            .await
+            .map_err(Unavailable)?;
         if let Some(diff) = artifact_mismatch(artifact, &fetched) {
             mismatches.push(diff);
         }
@@ -689,27 +740,458 @@ pub(crate) async fn verify_hosted_bundle(
         });
     }
 
-    // 5. Everything held — advance the pin.
-    save_pin(
-        &pin_file,
-        &SthPin {
-            size: sth.size,
-            root: sth.root_b64u.clone(),
-            public_key: sth.public_key_b64u.clone(),
-            pinned_unix_ms: pin.map(|p| p.pinned_unix_ms).unwrap_or_else(now_unix_ms),
-        },
-    )
-    .map_err(Unavailable)?;
+    // Everything held — advance the pin.
+    save_pin(&entry.pin_file, &entry.pin_candidate).map_err(Unavailable)?;
 
     Ok(VerifyReport {
-        log_size: sth.size,
-        manifest_index: index,
+        log_size: entry.sth.size,
+        manifest_index: entry.index,
         manifest_unix_ms: leaf.unix_ms,
         bundle_version: leaf.bundle_version,
         git_sha: leaf.git_sha,
         manifest_hash: leaf.manifest_hash,
         artifact_count: leaf.artifacts.len(),
-        pinned_from_size,
+        pinned_from_size: entry.pinned_from_size,
+    })
+}
+
+// ── Release transparency (`release_manifest` entries) ──
+//
+// The same log also commits the project's app releases: the
+// tag-triggered release pipeline submits a `release_manifest` (tag,
+// version, platforms, per-artifact name + sha256 + size) after
+// publishing to GitHub Releases. `--releases` verifies that leg: the
+// manifest's inclusion and the pinned tree head exactly as above, then
+// the GitHub release's asset METADATA (names, sizes, and the API's
+// sha256 digests where present) against the logged list — release
+// artifacts run to hundreds of MB, so the default path never downloads
+// them; `--download` upgrades to full fetch-and-hash verification.
+
+/// Repository whose GitHub releases the hosted log's release manifests
+/// describe (`macos-app/UpdateChecker.swift` twins this slug);
+/// `--repo` overrides for self-hosted forks.
+const DEFAULT_RELEASE_REPO: &str = "intendant-dev/Intendant";
+const GITHUB_API_BASE: &str = "https://api.github.com";
+
+/// `--download` re-fetches whole release artifacts, which are allowed to
+/// be far bigger than dashboard bundles.
+const RELEASE_DOWNLOAD_BYTE_CAP: usize = 2 * 1024 * 1024 * 1024;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ReleaseArtifact {
+    name: String,
+    sha256: String,
+    size: u64,
+}
+
+/// Canonical release-manifest hash — REPLICATES
+/// `bin/connect/transparency.rs::release_manifest_hash_hex` (golden twin
+/// below): sha256 (lowercase hex) over `intendant-release-manifest-v1\n`
+/// `{tag}\n` then `{name}\t{sha256}\t{size}\n` per artifact in list order.
+fn release_manifest_hash_hex(tag: &str, artifacts: &[ReleaseArtifact]) -> String {
+    let mut canonical = String::from("intendant-release-manifest-v1\n");
+    canonical.push_str(tag);
+    canonical.push('\n');
+    for artifact in artifacts {
+        canonical.push_str(&artifact.name);
+        canonical.push('\t');
+        canonical.push_str(&artifact.sha256);
+        canonical.push('\t');
+        canonical.push_str(&artifact.size.to_string());
+        canonical.push('\n');
+    }
+    sha256_hex(canonical.as_bytes())
+}
+
+/// The parsed `release_manifest` leaf, self-integrity verified (the
+/// carried `manifest_hash` recomputes from the carried list).
+#[derive(Clone, Debug)]
+struct ReleaseLeaf {
+    unix_ms: u64,
+    tag: String,
+    version: String,
+    platforms: Vec<String>,
+    manifest_hash: String,
+    artifacts: Vec<ReleaseArtifact>,
+}
+
+fn parse_release_leaf(leaf_json: &str) -> Result<ReleaseLeaf, String> {
+    let leaf: serde_json::Value =
+        serde_json::from_str(leaf_json).map_err(|e| format!("release leaf is not JSON: {e}"))?;
+    if leaf.get("kind").and_then(|v| v.as_str()) != Some("release_manifest") {
+        return Err("leaf is not a release_manifest entry".to_string());
+    }
+    let tag = leaf
+        .get("tag")
+        .and_then(|v| v.as_str())
+        .filter(|t| !t.is_empty())
+        .ok_or("release leaf missing tag")?
+        .to_string();
+    let artifacts: Vec<ReleaseArtifact> = leaf
+        .get("artifacts")
+        .and_then(|v| v.as_array())
+        .ok_or("release leaf missing artifacts")?
+        .iter()
+        .map(|entry| {
+            let name = entry
+                .get("name")
+                .and_then(|v| v.as_str())
+                .filter(|n| !n.is_empty())
+                .ok_or("artifact missing name")?
+                .to_string();
+            let sha256 = entry
+                .get("sha256")
+                .and_then(|v| v.as_str())
+                .ok_or("artifact missing sha256")?
+                .to_string();
+            let size = entry
+                .get("size")
+                .and_then(|v| v.as_u64())
+                .ok_or("artifact missing size")?;
+            Ok(ReleaseArtifact { name, sha256, size })
+        })
+        .collect::<Result<_, String>>()?;
+    if artifacts.is_empty() {
+        return Err("release leaf lists no artifacts".to_string());
+    }
+    let manifest_hash = leaf
+        .get("manifest_hash")
+        .and_then(|v| v.as_str())
+        .ok_or("release leaf missing manifest_hash")?
+        .to_string();
+    if release_manifest_hash_hex(&tag, &artifacts) != manifest_hash {
+        return Err("manifest_hash does not recompute from the carried artifact list".to_string());
+    }
+    Ok(ReleaseLeaf {
+        unix_ms: leaf.get("unix_ms").and_then(|v| v.as_u64()).unwrap_or(0),
+        tag,
+        version: leaf
+            .get("version")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string(),
+        platforms: leaf
+            .get("platforms")
+            .and_then(|v| v.as_array())
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        manifest_hash,
+        artifacts,
+    })
+}
+
+/// One asset as the GitHub releases API reports it. `digest`
+/// (`sha256:<hex>`) is what makes the no-download default meaningful;
+/// it is absent on assets uploaded before GitHub grew the field.
+#[derive(Clone, Debug)]
+struct GithubAsset {
+    name: String,
+    size: u64,
+    sha256: Option<String>,
+    download_url: Option<String>,
+}
+
+fn parse_github_assets(release: &serde_json::Value) -> Result<Vec<GithubAsset>, String> {
+    release
+        .get("assets")
+        .and_then(|v| v.as_array())
+        .ok_or("GitHub release response missing assets")?
+        .iter()
+        .map(|asset| {
+            let name = asset
+                .get("name")
+                .and_then(|v| v.as_str())
+                .filter(|n| !n.is_empty())
+                .ok_or("GitHub asset missing name")?
+                .to_string();
+            let size = asset
+                .get("size")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| format!("GitHub asset {name} missing size"))?;
+            let sha256 = asset
+                .get("digest")
+                .and_then(|v| v.as_str())
+                .and_then(|digest| digest.strip_prefix("sha256:"))
+                .map(str::to_string);
+            let download_url = asset
+                .get("browser_download_url")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            Ok(GithubAsset {
+                name,
+                size,
+                sha256,
+                download_url,
+            })
+        })
+        .collect()
+}
+
+/// What the metadata comparison of one logged artifact proved.
+#[derive(Debug, PartialEq, Eq)]
+enum AssetCheck {
+    /// GitHub reports a sha256 digest and it matches the log.
+    DigestVerified,
+    /// Present with the logged size, but GitHub exposes no digest for
+    /// it — presence and size only (upgrade with `--download`).
+    PresenceOnly,
+}
+
+/// The per-artifact metadata verdict: `Err` = a mismatch line.
+fn check_release_artifact(
+    artifact: &ReleaseArtifact,
+    assets: &[GithubAsset],
+) -> Result<AssetCheck, String> {
+    let Some(asset) = assets.iter().find(|a| a.name == artifact.name) else {
+        return Err(format!("{}: not on the GitHub release", artifact.name));
+    };
+    if asset.size != artifact.size {
+        return Err(format!(
+            "{}: logged {} bytes · GitHub reports {}",
+            artifact.name, artifact.size, asset.size
+        ));
+    }
+    match &asset.sha256 {
+        Some(digest) if *digest == artifact.sha256 => Ok(AssetCheck::DigestVerified),
+        Some(digest) => Err(format!(
+            "{}: logged sha256 {} · GitHub digest {}",
+            artifact.name,
+            short_hash(&artifact.sha256),
+            short_hash(digest),
+        )),
+        None => Ok(AssetCheck::PresenceOnly),
+    }
+}
+
+/// Assets on the release the log never blessed are loud in both modes:
+/// a quietly added artifact is exactly the equivocation this check
+/// exists to catch.
+fn unlogged_assets(logged: &[ReleaseArtifact], assets: &[GithubAsset]) -> Vec<String> {
+    assets
+        .iter()
+        .filter(|asset| logged.iter().all(|artifact| artifact.name != asset.name))
+        .map(|asset| {
+            format!(
+                "{}: on the GitHub release but not in the logged manifest",
+                asset.name
+            )
+        })
+        .collect()
+}
+
+/// GitHub API fetch that keeps the HTTP status: 404 is a verdict for
+/// the caller (log commits a release GitHub does not have), everything
+/// else transport-ish. Sends the API's preferred Accept header.
+async fn fetch_github_json(
+    client: &reqwest::Client,
+    url: Url,
+) -> Result<(u16, Option<serde_json::Value>), String> {
+    let response = client
+        .get(url.clone())
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .send()
+        .await
+        .map_err(|e| format!("GET {url}: {e}"))?;
+    let status = response.status().as_u16();
+    let body = response.json::<serde_json::Value>().await.ok();
+    Ok((status, body))
+}
+
+#[derive(Debug)]
+pub(crate) struct ReleaseVerifyReport {
+    pub log_size: u64,
+    pub manifest_index: u64,
+    pub manifest_unix_ms: u64,
+    pub tag: String,
+    pub version: String,
+    pub platforms: Vec<String>,
+    pub manifest_hash: String,
+    pub artifact_count: usize,
+    /// Metadata mode: how many artifacts GitHub's API sha256 digests
+    /// confirmed, vs. presence+size only.
+    pub digest_verified: usize,
+    pub presence_only: usize,
+    /// `--download` mode: artifacts re-downloaded and hash-verified.
+    pub downloaded: usize,
+    /// `None` = first contact (this run created the pin).
+    pub pinned_from_size: Option<u64>,
+}
+
+/// The out-of-band release check: the logged manifest (latest, or for
+/// one tag) against the log's proofs and the GitHub release. Shares the
+/// per-host tree-head pin with the bundle check — one log, one pin.
+pub(crate) async fn verify_hosted_release(
+    base: &Url,
+    github_api: &Url,
+    repo: &str,
+    tag: Option<&str>,
+    download: bool,
+    state_root: &Path,
+) -> Result<ReleaseVerifyReport, VerifyFailure> {
+    use VerifyFailure::{Unavailable, Verification};
+    let verification = |summary: String| Verification {
+        summary,
+        mismatches: Vec::new(),
+    };
+    let client = http_client().map_err(Unavailable)?;
+    let mut manifest_url = crate::connect_rendezvous::join_url(base, "api/log/release-manifest")
+        .map_err(Unavailable)?;
+    if let Some(tag) = tag {
+        let query: String = url::form_urlencoded::Serializer::new(String::new())
+            .append_pair("tag", tag)
+            .finish();
+        manifest_url.set_query(Some(&query));
+    }
+    let response = fetch_json(&client, manifest_url).await.map_err(Unavailable)?;
+    if response.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+        return Err(Unavailable(
+            "release-manifest endpoint returned an error".to_string(),
+        ));
+    }
+    if response.get("found").and_then(|v| v.as_bool()) != Some(true) {
+        // Asking for a SPECIFIC tag asserts "this release is logged" —
+        // absence is the failure this mode exists to catch. Bare
+        // `--releases` against a log with no release entries yet is
+        // just nothing to verify.
+        return Err(match tag {
+            Some(tag) => verification(format!(
+                "release {tag} is not committed to the transparency log"
+            )),
+            None => Unavailable(
+                "this rendezvous logs no release manifests (older intendant-connect, or none submitted yet)"
+                    .to_string(),
+            ),
+        });
+    }
+
+    // The tree head, inclusion, and pin consistency — the shared ritual.
+    let entry = verify_logged_entry(&client, base, state_root, &response).await?;
+
+    // The manifest self-verifies and answers what was asked for.
+    let leaf = parse_release_leaf(&entry.leaf_json).map_err(verification)?;
+    if let Some(tag) = tag {
+        if leaf.tag != tag {
+            return Err(verification(format!(
+                "log returned a manifest for {} when {tag} was requested",
+                leaf.tag
+            )));
+        }
+    }
+
+    // GitHub's view of the same release.
+    let release_url = crate::connect_rendezvous::join_url(
+        github_api,
+        &format!("repos/{repo}/releases/tags/{}", leaf.tag),
+    )
+    .map_err(Unavailable)?;
+    let release_url_display = release_url.to_string();
+    let (status, release) = fetch_github_json(&client, release_url).await.map_err(Unavailable)?;
+    let release = match (status, release) {
+        (200, Some(release)) => release,
+        (200, None) => {
+            return Err(Unavailable(format!(
+                "GET {release_url_display}: response was not JSON"
+            )))
+        }
+        (404, _) => {
+            return Err(verification(format!(
+                "GitHub has no release {} at {repo}, though the log commits one",
+                leaf.tag
+            )))
+        }
+        (status, _) => {
+            return Err(Unavailable(format!(
+                "GET {release_url_display}: HTTP {status}"
+            )))
+        }
+    };
+    let assets = parse_github_assets(&release).map_err(Unavailable)?;
+
+    let mut mismatches = Vec::new();
+    let mut digest_verified = 0usize;
+    let mut presence_only = 0usize;
+    let mut downloaded = 0usize;
+    for artifact in &leaf.artifacts {
+        match check_release_artifact(artifact, &assets) {
+            Ok(AssetCheck::DigestVerified) => digest_verified += 1,
+            Ok(AssetCheck::PresenceOnly) => presence_only += 1,
+            Err(diff) => mismatches.push(diff),
+        }
+    }
+    mismatches.extend(unlogged_assets(&leaf.artifacts, &assets));
+
+    if download {
+        for artifact in &leaf.artifacts {
+            let Some(asset) = assets.iter().find(|a| a.name == artifact.name) else {
+                continue; // already a mismatch above
+            };
+            let Some(download_url) = asset.download_url.as_deref() else {
+                mismatches.push(format!(
+                    "{}: GitHub exposes no download URL for the asset",
+                    artifact.name
+                ));
+                continue;
+            };
+            let url = Url::parse(download_url)
+                .map_err(|e| Unavailable(format!("asset URL {download_url}: {e}")))?;
+            match fetch_artifact(&client, url, RELEASE_DOWNLOAD_BYTE_CAP)
+                .await
+                .map_err(Unavailable)?
+            {
+                ArtifactFetch::Hashed { sha256_hex } if sha256_hex == artifact.sha256 => {
+                    downloaded += 1;
+                }
+                ArtifactFetch::Hashed { sha256_hex } => mismatches.push(format!(
+                    "{}: logged sha256 {} · downloaded {}",
+                    artifact.name,
+                    short_hash(&artifact.sha256),
+                    short_hash(&sha256_hex),
+                )),
+                ArtifactFetch::HttpStatus(status) => {
+                    mismatches.push(format!("{}: download HTTP {status}", artifact.name))
+                }
+                ArtifactFetch::TooLarge => mismatches.push(format!(
+                    "{}: download exceeded {} GiB",
+                    artifact.name,
+                    RELEASE_DOWNLOAD_BYTE_CAP / (1024 * 1024 * 1024),
+                )),
+            }
+        }
+    }
+
+    if !mismatches.is_empty() {
+        return Err(Verification {
+            summary: format!(
+                "release {} diverges from the transparency log ({} finding{})",
+                leaf.tag,
+                mismatches.len(),
+                if mismatches.len() == 1 { "" } else { "s" },
+            ),
+            mismatches,
+        });
+    }
+
+    // Everything held — advance the pin.
+    save_pin(&entry.pin_file, &entry.pin_candidate).map_err(Unavailable)?;
+
+    Ok(ReleaseVerifyReport {
+        log_size: entry.sth.size,
+        manifest_index: entry.index,
+        manifest_unix_ms: leaf.unix_ms,
+        tag: leaf.tag,
+        version: leaf.version,
+        platforms: leaf.platforms,
+        manifest_hash: leaf.manifest_hash,
+        artifact_count: leaf.artifacts.len(),
+        digest_verified,
+        presence_only,
+        downloaded,
+        pinned_from_size: entry.pinned_from_size,
     })
 }
 
@@ -782,31 +1264,72 @@ pub(crate) fn spawn_hosted_bundle_monitor() {
 // ── The CLI front door: `intendant hosted-verify` ──
 
 const CLI_HELP: &str = "\
-Verify that a hosted rendezvous serves the dashboard code its public
-transparency log commits to (docs/src/self-hosted-rendezvous.md).
+Verify a hosted rendezvous against its public transparency log
+(docs/src/self-hosted-rendezvous.md).
 
 Usage: intendant hosted-verify [--connect <url>]
+       intendant hosted-verify --releases [tag] [--download]
+                               [--repo <owner/name>] [--connect <url>]
 
   --connect <url>   Rendezvous origin to verify (default: the
                     INTENDANT_CONNECT_RENDEZVOUS_URL environment
                     variable, then the hosted default)
+  --releases [tag]  Verify app RELEASE artifacts instead of the served
+                    dashboard: fetches the release manifest logged for
+                    <tag> (default: the latest logged release) with its
+                    inclusion proof and signed tree head, verifies the
+                    tree head extends the pin, then compares the logged
+                    artifact list against the GitHub release's asset
+                    metadata — names, sizes, and the sha256 digests the
+                    API reports. This proves the release is committed to
+                    the append-only log and GitHub's metadata agrees; it
+                    does NOT re-download the artifacts. With an explicit
+                    <tag>, a release absent from the log FAILS (exit 1):
+                    an unlogged release is what this mode exists to catch.
+  --download        With --releases: additionally download every logged
+                    artifact from the GitHub release and verify its
+                    sha256 against the log — the strongest check, at
+                    full artifact bandwidth.
+  --repo <owner/name>
+                    With --releases: the GitHub repository the logged
+                    releases ship from (default intendant-dev/Intendant;
+                    self-hosted forks override)
 
-Fetches the logged artifact manifest with its inclusion proof and signed
-tree head, verifies the tree head extends the one pinned under the daemon
-state root (~/.intendant/hosted-verify/, honoring $INTENDANT_HOME), then
-downloads every listed artifact exactly as a browser would and compares
-hashes. Exit codes: 0 verified · 1 divergence or proof failure ·
-2 usage · 3 could not check (network / older service).";
+Without --releases: fetches the logged artifact manifest with its
+inclusion proof and signed tree head, verifies the tree head extends the
+one pinned under the daemon state root (~/.intendant/hosted-verify/,
+honoring $INTENDANT_HOME — releases share the same pin), then downloads
+every listed artifact exactly as a browser would and compares hashes.
+Exit codes: 0 verified · 1 divergence or proof failure · 2 usage ·
+3 could not check (network / older service).";
 
 pub(crate) async fn run_cli(args: Vec<String>) -> i32 {
     let mut connect: Option<String> = None;
-    let mut iter = args.into_iter();
+    let mut releases = false;
+    let mut release_tag: Option<String> = None;
+    let mut download = false;
+    let mut repo: Option<String> = None;
+    let mut iter = args.into_iter().peekable();
     while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--connect" => match iter.next() {
                 Some(value) => connect = Some(value),
                 None => {
                     eprintln!("error: --connect requires a URL");
+                    return 2;
+                }
+            },
+            "--releases" => {
+                releases = true;
+                if iter.peek().map(|next| !next.starts_with('-')).unwrap_or(false) {
+                    release_tag = iter.next();
+                }
+            }
+            "--download" => download = true,
+            "--repo" => match iter.next() {
+                Some(value) => repo = Some(value),
+                None => {
+                    eprintln!("error: --repo requires owner/name");
                     return 2;
                 }
             },
@@ -819,6 +1342,10 @@ pub(crate) async fn run_cli(args: Vec<String>) -> i32 {
                 return 2;
             }
         }
+    }
+    if (download || repo.is_some()) && !releases {
+        eprintln!("error: --download and --repo only apply with --releases");
+        return 2;
     }
     let base_raw = connect
         .or_else(|| {
@@ -835,6 +1362,19 @@ pub(crate) async fn run_cli(args: Vec<String>) -> i32 {
             return 2;
         }
     };
+    if releases {
+        let repo = repo.unwrap_or_else(|| DEFAULT_RELEASE_REPO.to_string());
+        let github_api = Url::parse(GITHUB_API_BASE).expect("static GitHub API base URL");
+        return run_release_cli(
+            &base,
+            &base_raw,
+            &github_api,
+            &repo,
+            release_tag.as_deref(),
+            download,
+        )
+        .await;
+    }
     println!("hosted-verify: {}", base_raw.trim_end_matches('/'));
     match verify_hosted_bundle(&base, &crate::platform::intendant_home()).await {
         Ok(report) => {
@@ -842,16 +1382,11 @@ pub(crate) async fn run_cli(args: Vec<String>) -> i32 {
                 "tree head: {} entries — signature OK",
                 report.log_size
             );
-            match report.pinned_from_size {
-                Some(size) => println!("pin: consistent with pinned size {size} — pin advanced"),
-                None => println!("pin: first contact — this tree head is now pinned"),
-            }
-            let logged_at = chrono::DateTime::from_timestamp_millis(report.manifest_unix_ms as i64)
-                .map(|t| t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
-                .unwrap_or_else(|| format!("{} (unix ms)", report.manifest_unix_ms));
+            print_pin_line(report.pinned_from_size);
             println!(
-                "manifest: log index {} · logged {logged_at} · bundle {} ({}) · {} artifacts · hash {}",
+                "manifest: log index {} · logged {} · bundle {} ({}) · {} artifacts · hash {}",
                 report.manifest_index,
+                format_logged_at(report.manifest_unix_ms),
                 report.bundle_version,
                 report.git_sha,
                 report.artifact_count,
@@ -864,21 +1399,119 @@ pub(crate) async fn run_cli(args: Vec<String>) -> i32 {
             println!("PASS — what this origin serves is what its transparency log commits to");
             0
         }
-        Err(VerifyFailure::Verification { summary, mismatches }) => {
+        Err(failure) => print_failure(
+            failure,
+            "If you did not expect a deploy just now, treat hosted tabs against this \
+             rendezvous as compromised and reach your daemons directly.",
+        ),
+    }
+}
+
+fn print_pin_line(pinned_from_size: Option<u64>) {
+    match pinned_from_size {
+        Some(size) => println!("pin: consistent with pinned size {size} — pin advanced"),
+        None => println!("pin: first contact — this tree head is now pinned"),
+    }
+}
+
+fn format_logged_at(unix_ms: u64) -> String {
+    chrono::DateTime::from_timestamp_millis(unix_ms as i64)
+        .map(|t| t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+        .unwrap_or_else(|| format!("{unix_ms} (unix ms)"))
+}
+
+fn print_failure(failure: VerifyFailure, advice: &str) -> i32 {
+    match failure {
+        VerifyFailure::Verification { summary, mismatches } => {
             eprintln!("FAIL — {summary}");
             for line in &mismatches {
                 eprintln!("  {line}");
             }
-            eprintln!(
-                "If you did not expect a deploy just now, treat hosted tabs against this \
-                 rendezvous as compromised and reach your daemons directly."
-            );
+            eprintln!("{advice}");
             1
         }
-        Err(VerifyFailure::Unavailable(error)) => {
+        VerifyFailure::Unavailable(error) => {
             eprintln!("could not check: {error}");
             3
         }
+    }
+}
+
+async fn run_release_cli(
+    base: &Url,
+    base_raw: &str,
+    github_api: &Url,
+    repo: &str,
+    tag: Option<&str>,
+    download: bool,
+) -> i32 {
+    println!(
+        "hosted-verify --releases: {} · repo {repo}{}",
+        base_raw.trim_end_matches('/'),
+        tag.map(|t| format!(" · tag {t}")).unwrap_or_default(),
+    );
+    match verify_hosted_release(
+        base,
+        github_api,
+        repo,
+        tag,
+        download,
+        &crate::platform::intendant_home(),
+    )
+    .await
+    {
+        Ok(report) => {
+            println!("tree head: {} entries — signature OK", report.log_size);
+            print_pin_line(report.pinned_from_size);
+            println!(
+                "release: {} (version {}) · platforms {} · log index {} · logged {} · {} artifacts · hash {}",
+                report.tag,
+                report.version,
+                if report.platforms.is_empty() {
+                    "unknown".to_string()
+                } else {
+                    report.platforms.join(",")
+                },
+                report.manifest_index,
+                format_logged_at(report.manifest_unix_ms),
+                report.artifact_count,
+                short_hash(&report.manifest_hash),
+            );
+            if download {
+                println!(
+                    "artifacts: {}/{} downloaded and sha256-verified against the log",
+                    report.downloaded, report.artifact_count
+                );
+                println!(
+                    "PASS — this release is committed to the public transparency log and the \
+                     published artifacts hash to what it commits"
+                );
+            } else {
+                println!(
+                    "artifacts: {} logged · {} sha256-verified via GitHub API digests · {} presence+size only",
+                    report.artifact_count, report.digest_verified, report.presence_only
+                );
+                if report.presence_only > 0 {
+                    println!(
+                        "note: GitHub reports no digest for {} artifact(s) — rerun with --download \
+                         for full hash verification",
+                        report.presence_only
+                    );
+                }
+                println!(
+                    "PASS — this release is committed to the public transparency log and \
+                     GitHub's release metadata matches it (artifacts not re-downloaded; use \
+                     --download for the strongest check)"
+                );
+            }
+            0
+        }
+        Err(failure) => print_failure(
+            failure,
+            "If a release you installed is not in the log, or its artifacts diverge, treat the \
+             download as untrusted: verify its sha256 against the release page and the log \
+             before running it.",
+        ),
     }
 }
 
@@ -1157,6 +1790,536 @@ mod tests {
         assert!(pin_decision(Some(&pin), &sth(3, root_a, "key1")).is_err());
         assert!(pin_decision(Some(&pin), &sth(4, [9u8; 32], "key1")).is_err());
         assert!(pin_decision(Some(&pin), &sth(7, [2u8; 32], "key2")).is_err());
+    }
+
+    /// Golden twin of `bin/connect/transparency.rs`'s release-manifest
+    /// canonicalization (pinned there in
+    /// `release_manifest_hash_is_canonical_and_pinned`; change both
+    /// together).
+    #[test]
+    fn replicated_release_hash_twins_the_service() {
+        let artifacts = vec![
+            ReleaseArtifact {
+                name: "Intendant-v1.2.3.zip".to_string(),
+                sha256: sha256_hex(b"hello"),
+                size: 5,
+            },
+            ReleaseArtifact {
+                name: "Intendant-v1.2.3.zip.sha256".to_string(),
+                sha256: sha256_hex(b"world"),
+                size: 99,
+            },
+        ];
+        assert_eq!(
+            release_manifest_hash_hex("v1.2.3", &artifacts),
+            "050b3579a283790ed739544295c4120ab5457a557fefc72ed374847e8af83030"
+        );
+    }
+
+    fn release_leaf_fixture(tag: &str, artifacts: &[ReleaseArtifact]) -> String {
+        serde_json::json!({
+            "kind": "release_manifest",
+            "unix_ms": 4242,
+            "tag": tag,
+            "version": tag.trim_start_matches('v'),
+            "platforms": ["macos-arm64"],
+            "manifest_hash": release_manifest_hash_hex(tag, artifacts),
+            "artifacts": artifacts
+                .iter()
+                .map(|a| serde_json::json!({ "name": a.name, "sha256": a.sha256, "size": a.size }))
+                .collect::<Vec<_>>(),
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn release_leaf_parses_and_self_verifies() {
+        let artifacts = vec![ReleaseArtifact {
+            name: "Intendant-v1.2.3.zip".to_string(),
+            sha256: sha256_hex(b"app zip"),
+            size: 7,
+        }];
+        let good = release_leaf_fixture("v1.2.3", &artifacts);
+        let leaf = parse_release_leaf(&good).unwrap();
+        assert_eq!(leaf.tag, "v1.2.3");
+        assert_eq!(leaf.version, "1.2.3");
+        assert_eq!(leaf.platforms, vec!["macos-arm64".to_string()]);
+        assert_eq!(leaf.unix_ms, 4242);
+        assert_eq!(leaf.artifacts, artifacts);
+
+        // A tampered artifact hash no longer matches the manifest_hash.
+        let tampered = good.replace(&sha256_hex(b"app zip"), &sha256_hex(b"evil zip"));
+        assert!(parse_release_leaf(&tampered).is_err());
+        // Wrong kind is rejected.
+        assert!(parse_release_leaf(&good.replace("release_manifest", "artifact_manifest")).is_err());
+        // No artifacts is rejected.
+        let empty = serde_json::json!({
+            "kind": "release_manifest",
+            "tag": "v1.2.3",
+            "manifest_hash": release_manifest_hash_hex("v1.2.3", &[]),
+            "artifacts": [],
+        })
+        .to_string();
+        assert!(parse_release_leaf(&empty).is_err());
+    }
+
+    #[test]
+    fn release_asset_metadata_comparison_flags_divergence() {
+        let logged = ReleaseArtifact {
+            name: "Intendant-v1.2.3.zip".to_string(),
+            sha256: sha256_hex(b"the released zip"),
+            size: 16,
+        };
+        let asset = |size: u64, digest: Option<String>| GithubAsset {
+            name: "Intendant-v1.2.3.zip".to_string(),
+            size,
+            sha256: digest,
+            download_url: None,
+        };
+        // Digest present and matching: fully verified from metadata.
+        assert_eq!(
+            check_release_artifact(&logged, &[asset(16, Some(sha256_hex(b"the released zip")))]),
+            Ok(AssetCheck::DigestVerified)
+        );
+        // No digest: presence + size only.
+        assert_eq!(
+            check_release_artifact(&logged, &[asset(16, None)]),
+            Ok(AssetCheck::PresenceOnly)
+        );
+        // Missing from the release.
+        let diff = check_release_artifact(&logged, &[]).unwrap_err();
+        assert!(diff.contains("not on the GitHub release"), "diff was {diff}");
+        // Size divergence.
+        let diff = check_release_artifact(&logged, &[asset(17, None)]).unwrap_err();
+        assert!(diff.contains("logged 16 bytes"), "diff was {diff}");
+        // Digest divergence.
+        let diff = check_release_artifact(&logged, &[asset(16, Some(sha256_hex(b"a swapped zip")))])
+            .unwrap_err();
+        assert!(diff.contains("logged sha256"), "diff was {diff}");
+        // An asset the log never blessed is loud.
+        let extra = GithubAsset {
+            name: "extra-payload.zip".to_string(),
+            size: 3,
+            sha256: None,
+            download_url: None,
+        };
+        let lines = unlogged_assets(&[logged.clone()], &[asset(16, None), extra]);
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("extra-payload.zip"), "line was {}", lines[0]);
+        assert!(unlogged_assets(&[logged], &[asset(16, None)]).is_empty());
+    }
+
+    // ── Hermetic full-flow fixtures: a real Merkle log + signed tree
+    // head served from 127.0.0.1, twinned GitHub API included, so the
+    // release flow runs end to end with injected base URLs and no
+    // external network. ──
+
+    struct FixtureLog {
+        leaves_json: Vec<String>,
+        keypair: ring::signature::EcdsaKeyPair,
+        rng: ring::rand::SystemRandom,
+    }
+
+    impl FixtureLog {
+        fn new(leaves_json: Vec<String>) -> Self {
+            let rng = ring::rand::SystemRandom::new();
+            let document = ring::signature::EcdsaKeyPair::generate_pkcs8(
+                &ring::signature::ECDSA_P256_SHA256_FIXED_SIGNING,
+                &rng,
+            )
+            .unwrap();
+            let keypair = ring::signature::EcdsaKeyPair::from_pkcs8(
+                &ring::signature::ECDSA_P256_SHA256_FIXED_SIGNING,
+                document.as_ref(),
+                &rng,
+            )
+            .unwrap();
+            Self {
+                leaves_json,
+                keypair,
+                rng,
+            }
+        }
+
+        fn leaves(&self) -> Vec<[u8; 32]> {
+            self.leaves_json.iter().map(|leaf| leaf_hash(leaf)).collect()
+        }
+
+        fn sth_json(&self) -> serde_json::Value {
+            use ring::signature::KeyPair as _;
+            let leaves = self.leaves();
+            let root_b64u = crate::daemon_identity::b64u(&tree_root(&leaves));
+            let unix_ms = 1_700_000_000_000u64;
+            let payload = sth_payload(leaves.len() as u64, &root_b64u, unix_ms);
+            let signature = self.keypair.sign(&self.rng, payload.as_bytes()).unwrap();
+            serde_json::json!({
+                "size": leaves.len(),
+                "root": root_b64u,
+                "unix_ms": unix_ms,
+                "signature": crate::daemon_identity::b64u(signature.as_ref()),
+                "public_key": crate::daemon_identity::b64u(self.keypair.public_key().as_ref()),
+            })
+        }
+
+        fn manifest_response(&self, index: usize) -> serde_json::Value {
+            let leaves = self.leaves();
+            let proof: Vec<String> = inclusion_proof(index, &leaves)
+                .iter()
+                .map(|hash| crate::daemon_identity::b64u(hash))
+                .collect();
+            serde_json::json!({
+                "ok": true,
+                "found": true,
+                "index": index,
+                "kind": "release_manifest",
+                "unix_ms": 4242,
+                "leaf_json": self.leaves_json[index],
+                "proof": proof,
+                "sth": self.sth_json(),
+            })
+        }
+
+        fn consistency_response(&self, old: usize) -> serde_json::Value {
+            let leaves = self.leaves();
+            let proof: Vec<String> = consistency_proof(old, &leaves)
+                .iter()
+                .map(|hash| crate::daemon_identity::b64u(hash))
+                .collect();
+            serde_json::json!({ "ok": true, "proof": proof })
+        }
+    }
+
+    struct Fixture {
+        log: FixtureLog,
+        manifest_index: usize,
+        release_status: u16,
+        release_body: serde_json::Value,
+        downloads: std::collections::HashMap<String, Vec<u8>>,
+    }
+
+    /// Serve the fixture over loopback; both the "rendezvous" and the
+    /// "GitHub API" live on the same ephemeral listener.
+    async fn spawn_fixture_server(
+        fixture: std::sync::Arc<std::sync::Mutex<Fixture>>,
+    ) -> (Url, tokio::task::JoinHandle<()>) {
+        use axum::extract::{Path as AxumPath, Query as AxumQuery};
+        let manifest_fixture = fixture.clone();
+        let consistency_fixture = fixture.clone();
+        let release_fixture = fixture.clone();
+        let download_fixture = fixture.clone();
+        let router = axum::Router::new()
+            .route(
+                "/api/log/release-manifest",
+                axum::routing::get(move || {
+                    let fixture = manifest_fixture.clone();
+                    async move {
+                        let fixture = fixture.lock().unwrap();
+                        axum::Json(fixture.log.manifest_response(fixture.manifest_index))
+                    }
+                }),
+            )
+            .route(
+                "/api/log/consistency",
+                axum::routing::get(
+                    move |AxumQuery(params): AxumQuery<
+                        std::collections::HashMap<String, String>,
+                    >| {
+                        let fixture = consistency_fixture.clone();
+                        async move {
+                            let old: usize =
+                                params.get("old").and_then(|v| v.parse().ok()).unwrap_or(0);
+                            let fixture = fixture.lock().unwrap();
+                            axum::Json(fixture.log.consistency_response(old))
+                        }
+                    },
+                ),
+            )
+            .route(
+                "/repos/{owner}/{repo}/releases/tags/{tag}",
+                axum::routing::get(move || {
+                    let fixture = release_fixture.clone();
+                    async move {
+                        let fixture = fixture.lock().unwrap();
+                        (
+                            axum::http::StatusCode::from_u16(fixture.release_status).unwrap(),
+                            axum::Json(fixture.release_body.clone()),
+                        )
+                    }
+                }),
+            )
+            .route(
+                "/dl/{name}",
+                axum::routing::get(move |AxumPath(name): AxumPath<String>| {
+                    let fixture = download_fixture.clone();
+                    async move {
+                        let fixture = fixture.lock().unwrap();
+                        fixture.downloads.get(&name).cloned().unwrap_or_default()
+                    }
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = Url::parse(&format!("http://{}", listener.local_addr().unwrap())).unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        (url, handle)
+    }
+
+    fn release_json(assets: Vec<serde_json::Value>) -> serde_json::Value {
+        serde_json::json!({ "tag_name": "v1.2.3", "assets": assets })
+    }
+
+    #[tokio::test]
+    async fn release_flow_verifies_and_advances_pin_end_to_end() {
+        let bytes = b"app bytes v1".to_vec();
+        let artifact = ReleaseArtifact {
+            name: "Intendant-v1.2.3.zip".to_string(),
+            sha256: sha256_hex(&bytes),
+            size: bytes.len() as u64,
+        };
+        let leaves = vec![
+            serde_json::json!({ "kind": "daemon_claimed", "daemon_id": "d1" }).to_string(),
+            release_leaf_fixture("v1.2.3", &[artifact.clone()]),
+        ];
+        let fixture = std::sync::Arc::new(std::sync::Mutex::new(Fixture {
+            log: FixtureLog::new(leaves),
+            manifest_index: 1,
+            release_status: 200,
+            release_body: serde_json::Value::Null,
+            downloads: std::collections::HashMap::new(),
+        }));
+        let (base, server) = spawn_fixture_server(fixture.clone()).await;
+        fixture.lock().unwrap().release_body = release_json(vec![serde_json::json!({
+            "name": artifact.name,
+            "size": artifact.size,
+            "digest": format!("sha256:{}", artifact.sha256),
+            "browser_download_url": format!("{base}dl/{}", artifact.name),
+        })]);
+        let state_root = tempfile::tempdir().unwrap();
+
+        // First contact: full metadata verification, pin created.
+        let report = verify_hosted_release(
+            &base,
+            &base,
+            "test/repo",
+            Some("v1.2.3"),
+            false,
+            state_root.path(),
+        )
+        .await
+        .expect("first release verification passes");
+        assert_eq!(report.log_size, 2);
+        assert_eq!(report.manifest_index, 1);
+        assert_eq!(report.tag, "v1.2.3");
+        assert_eq!(report.version, "1.2.3");
+        assert_eq!(report.platforms, vec!["macos-arm64".to_string()]);
+        assert_eq!(report.artifact_count, 1);
+        assert_eq!(report.digest_verified, 1);
+        assert_eq!(report.presence_only, 0);
+        assert_eq!(report.downloaded, 0);
+        assert_eq!(report.pinned_from_size, None);
+        let pin = load_pin(&pin_path(state_root.path(), &base)).expect("pin created");
+        assert_eq!(pin.size, 2);
+
+        // The log grows: the rerun must fetch and verify consistency
+        // from the pinned head, then advance the pin.
+        fixture
+            .lock()
+            .unwrap()
+            .log
+            .leaves_json
+            .push(serde_json::json!({ "kind": "daemon_claimed", "daemon_id": "d2" }).to_string());
+        let report = verify_hosted_release(
+            &base,
+            &base,
+            "test/repo",
+            Some("v1.2.3"),
+            false,
+            state_root.path(),
+        )
+        .await
+        .expect("grown-log verification passes via consistency proof");
+        assert_eq!(report.log_size, 3);
+        assert_eq!(report.pinned_from_size, Some(2));
+        assert_eq!(load_pin(&pin_path(state_root.path(), &base)).unwrap().size, 3);
+
+        // History rewritten (log shrank below the pin): loud failure.
+        fixture.lock().unwrap().log.leaves_json.truncate(2);
+        match verify_hosted_release(
+            &base,
+            &base,
+            "test/repo",
+            Some("v1.2.3"),
+            false,
+            state_root.path(),
+        )
+        .await
+        {
+            Err(VerifyFailure::Verification { summary, .. }) => {
+                assert!(summary.contains("shrank"), "summary was {summary}")
+            }
+            other => panic!("shrunken log must fail verification, got {other:?}"),
+        }
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn release_flow_flags_divergence_unlogged_assets_and_missing_release() {
+        let artifact = ReleaseArtifact {
+            name: "Intendant-v1.2.3.zip".to_string(),
+            sha256: sha256_hex(b"the logged zip"),
+            size: 14,
+        };
+        let leaves = vec![release_leaf_fixture("v1.2.3", &[artifact.clone()])];
+        let fixture = std::sync::Arc::new(std::sync::Mutex::new(Fixture {
+            log: FixtureLog::new(leaves),
+            manifest_index: 0,
+            release_status: 200,
+            release_body: serde_json::Value::Null,
+            downloads: std::collections::HashMap::new(),
+        }));
+        let (base, server) = spawn_fixture_server(fixture.clone()).await;
+        // GitHub reports a different digest AND an asset the log never
+        // blessed.
+        fixture.lock().unwrap().release_body = release_json(vec![
+            serde_json::json!({
+                "name": artifact.name,
+                "size": artifact.size,
+                "digest": format!("sha256:{}", sha256_hex(b"a swapped zip")),
+            }),
+            serde_json::json!({ "name": "extra-payload.zip", "size": 3 }),
+        ]);
+        let state_root = tempfile::tempdir().unwrap();
+        match verify_hosted_release(&base, &base, "test/repo", None, false, state_root.path())
+            .await
+        {
+            Err(VerifyFailure::Verification { summary, mismatches }) => {
+                assert!(summary.contains("v1.2.3"), "summary was {summary}");
+                assert_eq!(mismatches.len(), 2, "mismatches were {mismatches:?}");
+                assert!(mismatches[0].contains("logged sha256"));
+                assert!(mismatches[1].contains("extra-payload.zip"));
+            }
+            other => panic!("divergence must fail verification, got {other:?}"),
+        }
+        // A verification failure must NOT advance (or create) the pin.
+        assert!(load_pin(&pin_path(state_root.path(), &base)).is_none());
+
+        // GitHub not having the release at all is a verdict, not an
+        // availability problem: the log commits something GitHub denies.
+        fixture.lock().unwrap().release_status = 404;
+        match verify_hosted_release(&base, &base, "test/repo", None, false, state_root.path())
+            .await
+        {
+            Err(VerifyFailure::Verification { summary, .. }) => {
+                assert!(summary.contains("no release"), "summary was {summary}")
+            }
+            other => panic!("missing GitHub release must fail verification, got {other:?}"),
+        }
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn release_flow_download_mode_hashes_artifacts() {
+        let bytes = b"real artifact bytes".to_vec();
+        let artifact = ReleaseArtifact {
+            name: "Intendant-v1.2.3.zip".to_string(),
+            sha256: sha256_hex(&bytes),
+            size: bytes.len() as u64,
+        };
+        let leaves = vec![release_leaf_fixture("v1.2.3", &[artifact.clone()])];
+        let fixture = std::sync::Arc::new(std::sync::Mutex::new(Fixture {
+            log: FixtureLog::new(leaves),
+            manifest_index: 0,
+            release_status: 200,
+            release_body: serde_json::Value::Null,
+            downloads: std::collections::HashMap::from([(artifact.name.clone(), bytes.clone())]),
+        }));
+        let (base, server) = spawn_fixture_server(fixture.clone()).await;
+        // No digest from the API: the default path can only prove
+        // presence+size; --download proves the bytes.
+        fixture.lock().unwrap().release_body = release_json(vec![serde_json::json!({
+            "name": artifact.name,
+            "size": artifact.size,
+            "browser_download_url": format!("{base}dl/{}", artifact.name),
+        })]);
+        let state_root = tempfile::tempdir().unwrap();
+
+        let report =
+            verify_hosted_release(&base, &base, "test/repo", None, false, state_root.path())
+                .await
+                .expect("metadata-only run passes as presence-only");
+        assert_eq!(report.presence_only, 1);
+        assert_eq!(report.digest_verified, 0);
+        assert_eq!(report.downloaded, 0);
+
+        let report =
+            verify_hosted_release(&base, &base, "test/repo", None, true, state_root.path())
+                .await
+                .expect("download run hash-verifies the artifact");
+        assert_eq!(report.downloaded, 1);
+
+        // Served bytes that hash differently from the log are caught.
+        fixture
+            .lock()
+            .unwrap()
+            .downloads
+            .insert(artifact.name.clone(), b"tampered artifact bytes".to_vec());
+        match verify_hosted_release(&base, &base, "test/repo", None, true, state_root.path()).await
+        {
+            Err(VerifyFailure::Verification { mismatches, .. }) => {
+                assert_eq!(mismatches.len(), 1);
+                assert!(mismatches[0].contains("downloaded"), "was {}", mismatches[0]);
+            }
+            other => panic!("tampered download must fail verification, got {other:?}"),
+        }
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn release_flow_absence_is_loud_only_for_explicit_tags() {
+        let router = axum::Router::new().route(
+            "/api/log/release-manifest",
+            axum::routing::get(|| async {
+                axum::Json(serde_json::json!({ "ok": true, "found": false }))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = Url::parse(&format!("http://{}", listener.local_addr().unwrap())).unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, router).await.ok();
+        });
+        let state_root = tempfile::tempdir().unwrap();
+        // An explicit tag missing from the log is the alarm this mode
+        // exists for…
+        match verify_hosted_release(
+            &base,
+            &base,
+            "test/repo",
+            Some("v9.9.9"),
+            false,
+            state_root.path(),
+        )
+        .await
+        {
+            Err(VerifyFailure::Verification { summary, .. }) => {
+                assert!(
+                    summary.contains("not committed"),
+                    "summary was {summary}"
+                );
+            }
+            other => panic!("explicit missing tag must fail verification, got {other:?}"),
+        }
+        // …while a log with no release entries at all is just nothing to
+        // verify (older service).
+        match verify_hosted_release(&base, &base, "test/repo", None, false, state_root.path())
+            .await
+        {
+            Err(VerifyFailure::Unavailable(error)) => {
+                assert!(error.contains("no release manifests"), "error was {error}")
+            }
+            other => panic!("bare --releases on an empty log is unavailable, got {other:?}"),
+        }
+        server.abort();
     }
 
     #[test]

--- a/src/bin/caller/hosted_verify.rs
+++ b/src/bin/caller/hosted_verify.rs
@@ -650,7 +650,7 @@ async fn verify_logged_entry(
                     url.set_query(Some(&format!("old={old_size}&new={}", sth.size)));
                     url
                 })?;
-            let consistency = fetch_json(&client, url).await.map_err(Unavailable)?;
+            let consistency = fetch_json(client, url).await.map_err(Unavailable)?;
             let consistency_proof: Vec<[u8; 32]> = consistency
                 .get("proof")
                 .and_then(|v| v.as_array())

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -350,7 +350,7 @@ fn print_help() {
     println!("SUBCOMMANDS:");
     println!("    ctl                   Control a running Intendant daemon over MCP");
     println!("    access                Configure dashboard TLS/mTLS access certificates");
-    println!("    hosted-verify         Verify a rendezvous serves the code its transparency log commits to");
+    println!("    hosted-verify         Verify a rendezvous serves the code its transparency log commits to (--releases: app release artifacts)");
     println!("    org                   Create or print a local org root key");
     println!("    peer                  Pair and configure federated Intendant peers");
     println!("    service               Install, remove, inspect, or run the boot service");

--- a/src/bin/connect/fleet.rs
+++ b/src/bin/connect/fleet.rs
@@ -1022,6 +1022,7 @@ mod tests {
             static_root: PathBuf::from("static"),
             data_file: PathBuf::from("state.json"),
             daemon_token: None,
+            release_token: None,
             invite_required: false,
             open_daemon_registration: false,
             cookie_secure: true,

--- a/src/bin/connect/main.rs
+++ b/src/bin/connect/main.rs
@@ -219,6 +219,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "/api/log/artifact-manifest",
             get(log_artifact_manifest).options(orl_preflight),
         )
+        .route(
+            "/api/log/release-manifest",
+            get(log_release_manifest)
+                .post(release_manifest_submit)
+                .options(orl_preflight),
+        )
         .route("/api/push/vapid-public-key", get(push_vapid_public_key))
         .route("/api/push/subscribe", post(push_subscribe))
         .route("/api/push/unsubscribe", post(push_unsubscribe))
@@ -273,6 +279,12 @@ struct ServiceConfig {
     static_root: PathBuf,
     data_file: PathBuf,
     daemon_token: Option<String>,
+    /// Bearer token for release-manifest submissions (the release
+    /// pipeline's credential). Deliberately separate from the operator
+    /// `daemon_token`: a CI secret that can only append release
+    /// manifests to the public log must not double as the admin key.
+    /// Unset = the submission endpoint answers 503 (reads stay public).
+    release_token: Option<String>,
     cookie_secure: bool,
     /// Refuse new-account registration without a valid invite code.
     /// Off by default so self-hosted instances stay zero-friction; the
@@ -324,6 +336,10 @@ impl ServiceConfig {
             .ok()
             .map(|v| v.trim().to_string())
             .filter(|v| !v.is_empty());
+        let mut release_token = std::env::var("INTENDANT_CONNECT_RELEASE_TOKEN")
+            .ok()
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty());
         let mut open_daemon_registration = std::env::var("INTENDANT_CONNECT_OPEN_REGISTRATION")
             .map(|v| matches!(v.trim(), "1" | "true" | "yes"))
             .unwrap_or(false);
@@ -370,6 +386,9 @@ impl ServiceConfig {
                 }
                 "--daemon-token" => {
                     daemon_token = Some(args.next().ok_or("--daemon-token requires a token")?);
+                }
+                "--release-token" => {
+                    release_token = Some(args.next().ok_or("--release-token requires a token")?);
                 }
                 "--invite-required" => {
                     invite_required = true;
@@ -432,6 +451,7 @@ impl ServiceConfig {
             static_root,
             data_file,
             daemon_token,
+            release_token,
             invite_required,
             open_daemon_registration,
             cookie_secure,
@@ -448,6 +468,7 @@ fn print_help() {
          \n\
          Env: INTENDANT_CONNECT_LISTEN, INTENDANT_CONNECT_ORIGIN, INTENDANT_CONNECT_RP_ID,\n\
               INTENDANT_CONNECT_STATIC_ROOT, INTENDANT_CONNECT_DATA_FILE, INTENDANT_CONNECT_TOKEN,\n\
+              INTENDANT_CONNECT_RELEASE_TOKEN (--release-token: gates POST /api/log/release-manifest),\n\
               INTENDANT_CONNECT_INVITE_REQUIRED, INTENDANT_CONNECT_OPEN_REGISTRATION,\n\
               INTENDANT_CONNECT_DNS_ZONE, INTENDANT_CONNECT_DNS_NS_NAME, INTENDANT_CONNECT_DNS_LISTEN\n\
               (--dns-zone fleet.example.com --dns-ns-name ns-fleet.example.com --dns-listen 0.0.0.0:53\n\

--- a/src/bin/connect/transparency.rs
+++ b/src/bin/connect/transparency.rs
@@ -708,6 +708,387 @@ pub(crate) async fn log_artifact_manifest(
     ))
 }
 
+// ── Release transparency: app release artifacts, committed ──
+//
+// The `artifact_manifest` entries above commit what the service SERVES;
+// these commit what the project RELEASES (trust-tiers.md's "update
+// channel" thread). The tag-triggered release pipeline
+// (.github/workflows/release.yml) hashes every artifact it published to
+// the GitHub release and submits a `release_manifest` here, gated by a
+// dedicated bearer token (`--release-token` /
+// INTENDANT_CONNECT_RELEASE_TOKEN — deliberately not the operator
+// `daemon_token`, so the CI secret can only ever append release
+// manifests). Reads and proofs are public like every other log
+// endpoint; `intendant hosted-verify --releases` is the out-of-band
+// monitor, and the macOS app's update check surfaces logged/not-logged
+// as an advisory. Strictly additive: one more entry kind in a tree
+// that only ever grows.
+
+pub(crate) const RELEASE_MANIFEST_KIND: &str = "release_manifest";
+
+/// Serialized-body cap for a submitted release manifest (the ORL
+/// bulletin's bound; a release names a handful of artifacts).
+pub(crate) const MAX_RELEASE_MANIFEST_BYTES: usize = 64 * 1024;
+const RELEASE_TAG_MAX: usize = 100;
+const RELEASE_ARTIFACT_LIMIT: usize = 256;
+const RELEASE_ARTIFACT_NAME_MAX: usize = 200;
+const RELEASE_PLATFORM_LIMIT: usize = 32;
+
+/// One released artifact: the GitHub release asset's file name, the
+/// lowercase-hex sha256 of its exact bytes, and its size in bytes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ReleaseArtifactRecord {
+    pub name: String,
+    pub sha256: String,
+    pub size: u64,
+}
+
+/// Canonical release-manifest hash: sha256 (lowercase hex) over
+///
+/// ```text
+/// intendant-release-manifest-v1\n
+/// {tag}\n
+/// {name}\t{sha256}\t{size}\n      (per artifact, sorted by name, byte order)
+/// ```
+///
+/// The artifact-manifest discipline: independent of JSON serialization
+/// so external monitors can recompute it from any faithful copy.
+/// REPLICATED in `bin/caller/hosted_verify.rs`; golden tests twin the
+/// two implementations.
+pub(crate) fn release_manifest_hash_hex(tag: &str, artifacts: &[ReleaseArtifactRecord]) -> String {
+    let mut canonical = String::from("intendant-release-manifest-v1\n");
+    canonical.push_str(tag);
+    canonical.push('\n');
+    for artifact in artifacts {
+        canonical.push_str(&artifact.name);
+        canonical.push('\t');
+        canonical.push_str(&artifact.sha256);
+        canonical.push('\t');
+        canonical.push_str(&artifact.size.to_string());
+        canonical.push('\n');
+    }
+    sha256_hex(canonical.as_bytes())
+}
+
+/// Bearer gate for release-manifest submission. Mirrors
+/// `require_admin_auth`'s stance: an unset token must not mean an open
+/// submission endpoint, so unconfigured → 503, wrong/missing → 401.
+/// Pure over the configured value so tests need no `AppState`.
+pub(crate) fn check_release_token(configured: Option<&str>, headers: &HeaderMap) -> ApiResult<()> {
+    let Some(token) = configured.map(str::trim).filter(|t| !t.is_empty()) else {
+        return Err(ApiError::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "release submission requires the service to be started with --release-token",
+        ));
+    };
+    let expected = format!("Bearer {token}");
+    if headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|h| h.to_str().ok())
+        == Some(expected.as_str())
+    {
+        Ok(())
+    } else {
+        Err(ApiError::unauthorized(
+            "missing or invalid release bearer token",
+        ))
+    }
+}
+
+/// A validated, canonicalized (name-sorted) release manifest as it will
+/// be committed to the log.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ValidatedReleaseManifest {
+    pub tag: String,
+    pub version: String,
+    pub platforms: Vec<String>,
+    /// Sorted by name — the canonical order the hash covers.
+    pub artifacts: Vec<ReleaseArtifactRecord>,
+    pub manifest_hash: String,
+}
+
+/// Tags, versions, platform labels, and artifact names share one strict
+/// vocabulary: ASCII alphanumerics plus `. _ - +`, no leading `-`/`.`.
+/// Every value the pipeline actually submits fits; nothing that could
+/// smuggle a path, header, or control character does.
+fn valid_release_component(value: &str, max_len: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= max_len
+        && !value.starts_with(['-', '.'])
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '+'))
+}
+
+fn valid_sha256_hex(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .chars()
+            .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
+}
+
+/// Shape-validate a submitted release manifest and canonicalize it
+/// (artifacts name-sorted, manifest hash computed). Every rejection is
+/// a message suitable for a 400 body.
+pub(crate) fn validate_release_manifest(
+    body: &serde_json::Value,
+) -> Result<ValidatedReleaseManifest, String> {
+    let tag = body
+        .get("tag")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if !valid_release_component(&tag, RELEASE_TAG_MAX) {
+        return Err("tag must be 1-100 chars of [A-Za-z0-9._+-], not starting with '-' or '.'".to_string());
+    }
+    let version = body
+        .get("version")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if !valid_release_component(&version, RELEASE_TAG_MAX) {
+        return Err("version must be 1-100 chars of [A-Za-z0-9._+-]".to_string());
+    }
+    let platforms: Vec<String> = body
+        .get("platforms")
+        .and_then(|v| v.as_array())
+        .ok_or("platforms must be an array of target labels")?
+        .iter()
+        .map(|entry| {
+            let platform = entry.as_str().unwrap_or("").trim().to_string();
+            if valid_release_component(&platform, RELEASE_TAG_MAX) {
+                Ok(platform)
+            } else {
+                Err(format!("invalid platform label {entry}"))
+            }
+        })
+        .collect::<Result<_, String>>()?;
+    if platforms.is_empty() || platforms.len() > RELEASE_PLATFORM_LIMIT {
+        return Err(format!(
+            "platforms must name 1-{RELEASE_PLATFORM_LIMIT} targets"
+        ));
+    }
+    let mut artifacts: Vec<ReleaseArtifactRecord> = body
+        .get("artifacts")
+        .and_then(|v| v.as_array())
+        .ok_or("artifacts must be an array")?
+        .iter()
+        .map(|entry| {
+            let name = entry
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            if !valid_release_component(&name, RELEASE_ARTIFACT_NAME_MAX) {
+                return Err(format!("invalid artifact name {:?}", name));
+            }
+            let sha256 = entry
+                .get("sha256")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            if !valid_sha256_hex(&sha256) {
+                return Err(format!(
+                    "artifact {name}: sha256 must be 64 lowercase hex chars"
+                ));
+            }
+            let size = entry
+                .get("size")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| format!("artifact {name}: size must be a non-negative integer"))?;
+            Ok(ReleaseArtifactRecord { name, sha256, size })
+        })
+        .collect::<Result<_, String>>()?;
+    if artifacts.is_empty() || artifacts.len() > RELEASE_ARTIFACT_LIMIT {
+        return Err(format!(
+            "artifacts must list 1-{RELEASE_ARTIFACT_LIMIT} files"
+        ));
+    }
+    artifacts.sort_by(|a, b| a.name.cmp(&b.name));
+    if artifacts.windows(2).any(|pair| pair[0].name == pair[1].name) {
+        return Err("artifact names must be unique".to_string());
+    }
+    let manifest_hash = release_manifest_hash_hex(&tag, &artifacts);
+    Ok(ValidatedReleaseManifest {
+        tag,
+        version,
+        platforms,
+        artifacts,
+        manifest_hash,
+    })
+}
+
+/// Where a submission landed: a fresh log entry, or the index of the
+/// identical one already there (re-runs of the pipeline are idempotent).
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ReleaseRecordOutcome {
+    Logged { index: usize },
+    Duplicate { index: usize },
+}
+
+/// Append a `release_manifest` entry unless the latest entry for this
+/// tag already carries the same manifest hash. A CHANGED manifest for a
+/// tag is deliberately appended, not rejected: republished artifacts are
+/// exactly the history the log exists to evidence. The caller persists.
+pub(crate) fn record_release_manifest(
+    store: &mut Store,
+    manifest: &ValidatedReleaseManifest,
+) -> ReleaseRecordOutcome {
+    let existing = store
+        .log_entries
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, entry)| {
+            entry.kind == RELEASE_MANIFEST_KIND
+                && serde_json::from_str::<serde_json::Value>(&entry.leaf_json)
+                    .ok()
+                    .and_then(|leaf| {
+                        leaf.get("tag").and_then(|t| t.as_str()).map(str::to_string)
+                    })
+                    .as_deref()
+                    == Some(manifest.tag.as_str())
+        });
+    if let Some((index, entry)) = existing {
+        let same_hash = serde_json::from_str::<serde_json::Value>(&entry.leaf_json)
+            .ok()
+            .and_then(|leaf| {
+                leaf.get("manifest_hash")
+                    .and_then(|h| h.as_str())
+                    .map(str::to_string)
+            })
+            .as_deref()
+            == Some(manifest.manifest_hash.as_str());
+        if same_hash {
+            return ReleaseRecordOutcome::Duplicate { index };
+        }
+    }
+    append_log_entry(
+        store,
+        RELEASE_MANIFEST_KIND,
+        json!({
+            "tag": manifest.tag,
+            "version": manifest.version,
+            "platforms": manifest.platforms,
+            "manifest_hash": manifest.manifest_hash,
+            "artifacts": manifest.artifacts,
+        }),
+    );
+    ReleaseRecordOutcome::Logged {
+        index: store.log_entries.len() - 1,
+    }
+}
+
+/// `POST /api/log/release-manifest` — the release pipeline commits what
+/// it published. Token-authed (`check_release_token`), shape-validated,
+/// size-bounded; the log stays public to READ.
+pub(crate) async fn release_manifest_submit(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<serde_json::Value>,
+) -> ApiResult<Response> {
+    check_rate_limit(&state, &headers, "release_submit", 30, 60_000).await?;
+    check_release_token(state.config.release_token.as_deref(), &headers)?;
+    if serde_json::to_string(&body)
+        .map(|s| s.len())
+        .unwrap_or(usize::MAX)
+        > MAX_RELEASE_MANIFEST_BYTES
+    {
+        return Err(ApiError::bad_request("release manifest is too large"));
+    }
+    let manifest = validate_release_manifest(&body).map_err(ApiError::bad_request)?;
+    let mut store = state.store.lock().await;
+    let (logged, index) = match record_release_manifest(&mut store, &manifest) {
+        ReleaseRecordOutcome::Logged { index } => (true, index),
+        ReleaseRecordOutcome::Duplicate { index } => (false, index),
+    };
+    if logged {
+        persist_locked(&state, &store)?;
+        eprintln!(
+            "[connect] release manifest logged: {} ({} artifacts, {})",
+            manifest.tag,
+            manifest.artifacts.len(),
+            &manifest.manifest_hash[..12.min(manifest.manifest_hash.len())],
+        );
+    }
+    Ok(orl_cors(
+        Json(json!({
+            "ok": true,
+            "logged": logged,
+            "index": index,
+            "tag": manifest.tag,
+            "manifest_hash": manifest.manifest_hash,
+            "size": store.log_entries.len(),
+        }))
+        .into_response(),
+    ))
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ReleaseManifestQuery {
+    #[serde(default)]
+    tag: String,
+}
+
+/// `GET /api/log/release-manifest[?tag=<tag>]` — the latest release
+/// manifest (for a tag, or overall) with everything an out-of-band
+/// monitor needs in one response: the exact leaf bytes, its index, an
+/// inclusion proof, and the signed tree head — all under one store lock
+/// so they cohere (the `log_artifact_manifest` shape).
+pub(crate) async fn log_release_manifest(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Query(query): Query<ReleaseManifestQuery>,
+) -> ApiResult<Response> {
+    check_rate_limit(&state, &headers, "log_read", 240, 60_000).await?;
+    let tag = query.tag.trim();
+    let store = state.store.lock().await;
+    let found = store
+        .log_entries
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, entry)| {
+            if entry.kind != RELEASE_MANIFEST_KIND {
+                return false;
+            }
+            if tag.is_empty() {
+                return true;
+            }
+            serde_json::from_str::<serde_json::Value>(&entry.leaf_json)
+                .ok()
+                .and_then(|leaf| leaf.get("tag").and_then(|t| t.as_str()).map(str::to_string))
+                .as_deref()
+                == Some(tag)
+        });
+    let Some((index, entry)) = found else {
+        return Ok(orl_cors(
+            Json(json!({ "ok": true, "found": false })).into_response(),
+        ));
+    };
+    let leaves = log_leaves(&store);
+    let proof: Vec<String> = log_inclusion_proof(index, &leaves)
+        .iter()
+        .map(|hash| b64u(hash))
+        .collect();
+    Ok(orl_cors(
+        Json(json!({
+            "ok": true,
+            "found": true,
+            "index": index,
+            "kind": entry.kind,
+            "unix_ms": entry.unix_ms,
+            "leaf_json": entry.leaf_json,
+            "proof": proof,
+            "sth": signed_tree_head_fields(&state, &store),
+        }))
+        .into_response(),
+    ))
+}
+
 /// The exact byte string an org root signs over its revocation list —
 /// mirrors `access::org::orl_signing_payload` in the daemon. Stable
 /// protocol, replicated rather than shared: this binary interprets the
@@ -987,6 +1368,7 @@ mod tests {
             static_root: static_root.to_path_buf(),
             data_file: static_root.join("state.json"),
             daemon_token: None,
+            release_token: None,
             cookie_secure: true,
             invite_required: false,
             open_daemon_registration: false,
@@ -1136,6 +1518,231 @@ mod tests {
             &proof,
             &root,
         ));
+    }
+
+    fn release_fixture() -> ValidatedReleaseManifest {
+        validate_release_manifest(&json!({
+            "tag": "v1.2.3",
+            "version": "1.2.3",
+            "platforms": ["macos-arm64"],
+            "artifacts": [
+                { "name": "Intendant-v1.2.3.zip", "sha256": sha256_hex(b"app zip"), "size": 5 },
+                { "name": "Intendant-v1.2.3.zip.sha256", "sha256": sha256_hex(b"hash file"), "size": 3 },
+            ],
+        }))
+        .unwrap()
+    }
+
+    /// Golden release-manifest hash — TWINNED byte-for-byte in
+    /// `bin/caller/hosted_verify.rs` (the verifier replicates the
+    /// canonicalization; change both together).
+    #[test]
+    fn release_manifest_hash_is_canonical_and_pinned() {
+        let artifacts = vec![
+            ReleaseArtifactRecord {
+                name: "Intendant-v1.2.3.zip".to_string(),
+                sha256: sha256_hex(b"hello"),
+                size: 5,
+            },
+            ReleaseArtifactRecord {
+                name: "Intendant-v1.2.3.zip.sha256".to_string(),
+                sha256: sha256_hex(b"world"),
+                size: 99,
+            },
+        ];
+        assert_eq!(
+            release_manifest_hash_hex("v1.2.3", &artifacts),
+            "050b3579a283790ed739544295c4120ab5457a557fefc72ed374847e8af83030"
+        );
+        // Order-, tag-, and size-sensitive by design.
+        let reversed = vec![artifacts[1].clone(), artifacts[0].clone()];
+        assert_ne!(
+            release_manifest_hash_hex("v1.2.3", &reversed),
+            release_manifest_hash_hex("v1.2.3", &artifacts)
+        );
+        assert_ne!(
+            release_manifest_hash_hex("v1.2.4", &artifacts),
+            release_manifest_hash_hex("v1.2.3", &artifacts)
+        );
+        let mut resized = artifacts.clone();
+        resized[0].size = 6;
+        assert_ne!(
+            release_manifest_hash_hex("v1.2.3", &resized),
+            release_manifest_hash_hex("v1.2.3", &artifacts)
+        );
+    }
+
+    #[test]
+    fn release_manifest_validation_canonicalizes_and_rejects_bad_shapes() {
+        let manifest = release_fixture();
+        assert_eq!(manifest.tag, "v1.2.3");
+        assert_eq!(manifest.version, "1.2.3");
+        assert_eq!(manifest.platforms, vec!["macos-arm64".to_string()]);
+        // Artifacts come out name-sorted and the hash covers that order.
+        assert_eq!(manifest.artifacts[0].name, "Intendant-v1.2.3.zip");
+        assert_eq!(
+            manifest.manifest_hash,
+            release_manifest_hash_hex(&manifest.tag, &manifest.artifacts)
+        );
+
+        let base = json!({
+            "tag": "v1.2.3",
+            "version": "1.2.3",
+            "platforms": ["macos-arm64"],
+            "artifacts": [{ "name": "a.zip", "sha256": sha256_hex(b"x"), "size": 1 }],
+        });
+        let mutate = |key: &str, value: serde_json::Value| {
+            let mut body = base.clone();
+            body[key] = value;
+            body
+        };
+        assert!(validate_release_manifest(&base).is_ok());
+        for bad in [
+            mutate("tag", json!("")),
+            mutate("tag", json!("-rc1")),
+            mutate("tag", json!("v1/../etc")),
+            mutate("tag", json!("v".repeat(101))),
+            mutate("version", json!("")),
+            mutate("platforms", json!([])),
+            mutate("platforms", json!(["ok", "bad platform!"])),
+            mutate("platforms", json!("macos")),
+            mutate("artifacts", json!([])),
+            mutate("artifacts", json!("nope")),
+            mutate(
+                "artifacts",
+                json!([{ "name": "a.zip", "sha256": "abc", "size": 1 }]),
+            ),
+            mutate(
+                "artifacts",
+                json!([{ "name": "a.zip", "sha256": sha256_hex(b"x").to_uppercase(), "size": 1 }]),
+            ),
+            mutate(
+                "artifacts",
+                json!([{ "name": "../evil.zip", "sha256": sha256_hex(b"x"), "size": 1 }]),
+            ),
+            mutate(
+                "artifacts",
+                json!([{ "name": "a.zip", "sha256": sha256_hex(b"x") }]),
+            ),
+            mutate(
+                "artifacts",
+                json!([
+                    { "name": "a.zip", "sha256": sha256_hex(b"x"), "size": 1 },
+                    { "name": "a.zip", "sha256": sha256_hex(b"y"), "size": 2 },
+                ]),
+            ),
+        ] {
+            assert!(
+                validate_release_manifest(&bad).is_err(),
+                "must reject {bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn release_manifest_entries_append_dedupe_and_prove() {
+        let mut store = Store::default();
+        append_log_entry(&mut store, "daemon_claimed", json!({ "daemon_id": "d1" }));
+        let manifest = release_fixture();
+
+        // First submission appends…
+        assert_eq!(
+            record_release_manifest(&mut store, &manifest),
+            ReleaseRecordOutcome::Logged { index: 1 }
+        );
+        // …an identical re-run dedupes to the same index…
+        assert_eq!(
+            record_release_manifest(&mut store, &manifest),
+            ReleaseRecordOutcome::Duplicate { index: 1 }
+        );
+        assert_eq!(store.log_entries.len(), 2);
+        // …a different tag appends…
+        let mut next = manifest.clone();
+        next.tag = "v1.2.4".to_string();
+        next.manifest_hash = release_manifest_hash_hex(&next.tag, &next.artifacts);
+        assert_eq!(
+            record_release_manifest(&mut store, &next),
+            ReleaseRecordOutcome::Logged { index: 2 }
+        );
+        // …and republished artifacts under an EXISTING tag append too
+        // (history, not replacement).
+        let mut republished = manifest.clone();
+        republished.artifacts[0].sha256 = sha256_hex(b"rebuilt zip");
+        republished.manifest_hash =
+            release_manifest_hash_hex(&republished.tag, &republished.artifacts);
+        assert_eq!(
+            record_release_manifest(&mut store, &republished),
+            ReleaseRecordOutcome::Logged { index: 3 }
+        );
+        // The republished entry is now the latest for that tag.
+        assert_eq!(
+            record_release_manifest(&mut store, &republished),
+            ReleaseRecordOutcome::Duplicate { index: 3 }
+        );
+
+        // Round-trip the entry: the leaf carries the list, the manifest
+        // hash recomputes from it, and the inclusion proof verifies.
+        let entry = &store.log_entries[1];
+        assert_eq!(entry.kind, RELEASE_MANIFEST_KIND);
+        let leaf: serde_json::Value = serde_json::from_str(&entry.leaf_json).unwrap();
+        assert_eq!(
+            leaf.get("kind").and_then(|v| v.as_str()),
+            Some(RELEASE_MANIFEST_KIND)
+        );
+        assert!(leaf.get("unix_ms").and_then(|v| v.as_u64()).is_some());
+        assert_eq!(leaf.get("tag").and_then(|v| v.as_str()), Some("v1.2.3"));
+        assert_eq!(leaf.get("version").and_then(|v| v.as_str()), Some("1.2.3"));
+        assert_eq!(
+            leaf.get("platforms").and_then(|v| v.as_array()).map(Vec::len),
+            Some(1)
+        );
+        let artifacts: Vec<ReleaseArtifactRecord> =
+            serde_json::from_value(leaf.get("artifacts").cloned().unwrap()).unwrap();
+        assert_eq!(
+            leaf.get("manifest_hash").and_then(|v| v.as_str()),
+            Some(release_manifest_hash_hex("v1.2.3", &artifacts).as_str()),
+            "manifest_hash must recompute from the carried list"
+        );
+
+        let leaves = log_leaves(&store);
+        let proof = log_inclusion_proof(1, &leaves);
+        let root = log_tree_root(&leaves);
+        assert!(log_verify_inclusion(
+            &log_leaf_hash(&entry.leaf_json),
+            1,
+            leaves.len(),
+            &proof,
+            &root,
+        ));
+    }
+
+    #[test]
+    fn release_token_gate_rejects_missing_and_wrong_tokens() {
+        let with_auth = |value: Option<&str>| {
+            let mut headers = HeaderMap::new();
+            if let Some(value) = value {
+                headers.insert(
+                    axum::http::header::AUTHORIZATION,
+                    axum::http::HeaderValue::from_str(value).unwrap(),
+                );
+            }
+            headers
+        };
+        // No token configured: submissions are OFF (503), even with a
+        // guessed header — an unset token must not mean an open endpoint.
+        let err = check_release_token(None, &with_auth(Some("Bearer anything"))).unwrap_err();
+        assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE);
+        let err = check_release_token(Some("  "), &with_auth(None)).unwrap_err();
+        assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE);
+        // Configured: missing and wrong bearers are 401.
+        let err = check_release_token(Some("s3cret"), &with_auth(None)).unwrap_err();
+        assert_eq!(err.status, StatusCode::UNAUTHORIZED);
+        let err = check_release_token(Some("s3cret"), &with_auth(Some("Bearer nope"))).unwrap_err();
+        assert_eq!(err.status, StatusCode::UNAUTHORIZED);
+        let err = check_release_token(Some("s3cret"), &with_auth(Some("s3cret"))).unwrap_err();
+        assert_eq!(err.status, StatusCode::UNAUTHORIZED, "bare token without Bearer");
+        // The right bearer passes.
+        assert!(check_release_token(Some("s3cret"), &with_auth(Some("Bearer s3cret"))).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
App release artifacts now commit to the same public transparency log that covers served dashboard bundles, and the out-of-band verifier learns releases — the served-artifact pattern, copied.

**Connect** (`src/bin/connect/transparency.rs`): new additive `release_manifest` entry kind — `tag`, `version`, `platforms`, name-sorted `artifacts` of `{name, sha256, size}`, and a canonical `manifest_hash` (`intendant-release-manifest-v1\n{tag}\n` + `{name}\t{sha256}\t{size}\n` per artifact). `POST /api/log/release-manifest` is shape-validated, size-bounded (64 KiB), rate-limited, and gated by a dedicated bearer token (`--release-token` / `INTENDANT_CONNECT_RELEASE_TOKEN`) — deliberately not the operator `daemon_token`, so the CI credential can only append release manifests (503 unconfigured, 401 wrong). Identical re-submissions dedupe; a changed manifest for an existing tag appends as history. Reads stay public: `GET /api/log/release-manifest[?tag=]` returns leaf + index + inclusion proof + STH, the artifact-manifest shape.

**Release pipeline** (`.github/workflows/release.yml`): after publishing, tag builds hash every `dist/*` artifact and POST the manifest using the **`CONNECT_RELEASE_TOKEN` repo secret** (to provision: start the rendezvous with the same value as `--release-token`). Absent secret → clearly-logged no-op (forks, dry runs); optional `CONNECT_RELEASE_URL` repo variable for self-hosted forks. Submission failure fails the run so a published-but-unlogged release is noticed.

**Verifier**: `intendant hosted-verify --releases [tag] [--download] [--repo <owner/name>]`. Default mode proves the release is committed to the append-only log (tree-head signature, inclusion, consistency against the same per-host pin as the bundle check — the shared ritual is factored into `verify_logged_entry` and reused by both modes) and that GitHub's asset **metadata** (names, sizes, API sha256 digests where present) matches — it never downloads multi-hundred-MB artifacts. `--download` upgrades to fetching and hashing every artifact. Explicit-tag absence from the log fails loud (exit 1); unlogged extra assets are flagged. Exit codes unchanged: 0/1/2/3.

**Update check** (`macos-app/UpdateChecker.swift` + `main.swift`): the launch and menu checks ask the log about the release being offered and append an advisory line — publicly committed / NOT committed / couldn't check (error surfaced) — fail-open like the CT/bundle tripwires; a log outage never blocks updating. Presence-only by design: the installed .app is the extracted tree, not the downloaded zip, so its release hash is not computable at runtime.

**Docs**: `self-hosted-rendezvous.md` gains a Release transparency section; `trust-tiers.md`'s update-channel bullet moves from "remaining open thread" to shipped.

**Verified**: connect + verifier unit suites (append/dedup/proofs, token gate 503/401, canonical-hash golden twins, hermetic full-flow release verification against a local axum log fixture with real Merkle proofs and a signed STH, incl. consistency advance, shrink detection, divergence, --download, absence semantics); live smoke against real binaries (submission auth, dedup, read-back, `hosted-verify --releases` and bundle-mode PASS against a local rendezvous); swiftc typecheck; actionlint.