### PR TITLE
ci: wasm-drift name interpolation + rebuild serialization

### DIFF
--- a/.github/workflows/wasm-drift.yml
+++ b/.github/workflows/wasm-drift.yml
@@ -36,11 +36,21 @@ concurrency:
 
 jobs:
   wasm-drift:
-    name: wasm-drift (ubuntu-latest)
+    name: wasm-drift (${{ matrix.os }})
     # Trust-based routing — same rule as windows.yml: trusted refs on the
     # self-hosted fleet, fork PRs on GitHub-hosted runners.
     runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && matrix.os || matrix.runner }}
     timeout-minutes: 30
+    # Serialize the rebuild repo-wide: both Mac listeners share the
+    # account's ~/Library/Caches/.wasm-pack, and two cold jobs
+    # cargo-installing wasm-bindgen concurrently race the final rename
+    # ("Directory not empty", seen live 2026-07-11 when a probe PR and
+    # another PR's gate ran side by side). Warm caches don't race, but
+    # every wasm-bindgen/wasm-opt version bump re-opens the cold window
+    # — queue the jobs instead (they are minutes; skips are seconds).
+    concurrency:
+      group: wasm-drift-rebuild
+      cancel-in-progress: false
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Two fixes from the gate's first live runs: the job name hardcoded `(ubuntu-latest)` from its draft (now interpolates `matrix.os`, giving the clean `wasm-drift (macos-latest)` context the ruleset promotion pins), and rebuilds are serialized repo-wide via a job-level concurrency group — both Mac listeners share the CI account's `.wasm-pack` cache, and two cold jobs cargo-installing wasm-bindgen concurrently raced the rename into the cache (`Directory not empty`, live today when the probe and #213 ran side by side). Warm caches don't race; every wasm-bindgen/wasm-opt bump re-opens the cold window, so the jobs queue instead (minutes at worst, seconds for relevance-skips).