### PR TITLE
Transfer tunnel availability: drop the stale project_root gate

### DIFF
--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -3069,6 +3069,11 @@ mod tests {
         std::fs::write(&source, b"durable download fixture").unwrap();
 
         let mut rt = runtime();
+        // Transfer availability must not require a project root: the store
+        // falls back to the daemon-global scope (Wave 1F), and the HTTP rows
+        // serve projectless — both lanes advertise alike.
+        let projectless = status_response_frame("transfer-status-projectless".to_string(), &rt);
+        assert_eq!(projectless["result"]["api_transfer_jobs_available"], true);
         rt.project_root = Some(project.clone());
 
         let status = status_response_frame("transfer-status".to_string(), &rt);

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -364,7 +364,10 @@ fn control_method_runtime_ready(runtime: &ControlRuntime, method: &str) -> bool 
             runtime.project_root.is_some()
         }
         "api_mcp_tool_call" => runtime.mcp_server.is_some(),
-        method if method.starts_with("api_transfer_") => runtime.project_root.is_some(),
+        // api_transfer_* deliberately has no project_root gate: the store
+        // resolves through StoreScope (daemon-global fallback on projectless
+        // daemons), and the S9 HTTP rows already serve projectless — the
+        // old gate made the tunnel lane lie about the same store.
         method if method.starts_with("api_display_input_authority_") => {
             runtime.display_authority.is_some()
         }
@@ -2690,20 +2693,23 @@ mod tests {
             status["result"]["api_session_current_upload_delete_available"],
             true
         );
-        assert_eq!(status["result"]["api_transfer_jobs_available"], false);
-        assert_eq!(status["result"]["api_transfer_job_create_available"], false);
-        assert_eq!(status["result"]["api_transfer_job_delete_available"], false);
+        // Projectless runtime: transfers stay available — the store resolves
+        // through the daemon-global StoreScope fallback, matching the S9
+        // HTTP rows (the old project_root gate made the tunnel lane lie).
+        assert_eq!(status["result"]["api_transfer_jobs_available"], true);
+        assert_eq!(status["result"]["api_transfer_job_create_available"], true);
+        assert_eq!(status["result"]["api_transfer_job_delete_available"], true);
         assert_eq!(
             status["result"]["api_transfer_download_read_available"],
-            false
+            true
         );
         assert_eq!(
             status["result"]["api_transfer_upload_chunk_available"],
-            false
+            true
         );
         assert_eq!(
             status["result"]["api_transfer_upload_commit_available"],
-            false
+            true
         );
         assert_eq!(status["result"]["api_fs_stat_available"], true);
         assert_eq!(status["result"]["api_fs_list_available"], true);


### PR DESCRIPTION
The tunnel's `control_method_runtime_ready` still gated `api_transfer_*` on `project_root` — pre-Wave-1F semantics. The store resolves through `StoreScope::resolve_in` with the daemon-global fallback, and the S9 HTTP rows serve projectless daemons from the same store, so the gate only made the tunnel lane lie about availability. Found by F1c's live verification (projectless dashboards rode HTTP jobs with a live tunnel up).

One match arm deleted + the two test pins flipped to the daemon-global truth (with a projectless assertion added ahead of the with-project leg). `cargo nextest run --bins` 3015/3015; clippy clean.