### PR TITLE
Harden platform pointer handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,7 +2624,6 @@ dependencies = [
  "futures-util",
  "hickory-server",
  "html2text",
- "if-addrs",
  "image",
  "instant-acme",
  "intendant-core",
@@ -2682,7 +2681,6 @@ version = "0.1.0"
 dependencies = [
  "dirs",
  "if-addrs",
- "libc",
  "presence-core",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,12 +230,6 @@ windows = { version = "0.59", features = [
     "Win32_System_JobObjects",
     "Win32_System_Environment",
 ] }
-# Cross-platform network-interface enumeration. On Windows it wraps
-# GetAdaptersAddresses; this backs `lan::routable_local_addrs`, which feeds
-# the web-gateway advertise URLs and WebRTC ICE host-candidate gathering.
-# The unix path keeps its existing direct `getifaddrs(3)` walk via libc.
-if-addrs = "0.15"
-
 [build-dependencies]
 # build.rs assembles static/app.html from the static/app/ fragments before
 # every compile, so `include_str!` embeds an artifact that matches the

--- a/crates/intendant-core/Cargo.toml
+++ b/crates/intendant-core/Cargo.toml
@@ -16,6 +16,8 @@ tokio = { version = "1.0", features = ["net", "sync"] }
 # CallerError carries reqwest::Error in its Http variant; feature set
 # mirrors the caller's so workspace feature unification stays a no-op.
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream", "multipart"], default-features = false }
+# Safe cross-platform local network-interface enumeration.
+if-addrs = "0.15"
 
 [dev-dependencies]
 # autonomy's approval-config tests parse TOML fixtures; frames' tests
@@ -24,10 +26,3 @@ toml = "0.8"
 tempfile = "3"
 # the listener rebind tests drive a real accept loop
 tokio = { version = "1.0", features = ["macros", "net", "rt-multi-thread", "time"] }
-
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
-
-[target.'cfg(windows)'.dependencies]
-# Windows has no getifaddrs(3); if-addrs wraps GetAdaptersAddresses.
-if-addrs = "0.15"

--- a/crates/intendant-core/src/net.rs
+++ b/crates/intendant-core/src/net.rs
@@ -1,9 +1,7 @@
-//! Shared network vocabulary: local interface probes (unix walks
-//! `getifaddrs(3)` via libc; Windows goes through the `if-addrs`
-//! crate), the daemon's canonical gateway port, and the TCP-listener
-//! accept-failure policy + rebind helper shared by the web gateway,
-//! the control socket, and the enrollment cert server. No dependency
-//! on any daemon subsystem.
+//! Shared network vocabulary: safe cross-platform local interface probes,
+//! the daemon's canonical gateway port, and the TCP-listener accept-failure
+//! policy + rebind helper shared by the web gateway, the control socket, and
+//! the enrollment cert server. No dependency on any daemon subsystem.
 
 use tokio::net::TcpListener;
 
@@ -27,84 +25,50 @@ pub const DEFAULT_GATEWAY_PORT: u16 = 8765;
 /// Excludes IPv6 link-local (fe80::/10), IPv4 loopback when
 /// `!include_loopback`, and unspecified addresses (0.0.0.0 / ::) which
 /// aren't real bind targets.
-///
-/// Implementation walks `getifaddrs(3)` directly via libc — same crate
-/// the codebase already depends on for other unix interop.
 pub fn routable_local_addrs(include_loopback: bool) -> Vec<std::net::IpAddr> {
+    let interfaces = if_addrs::get_if_addrs().unwrap_or_default();
+    filtered_interface_addrs(
+        include_loopback,
+        interfaces
+            .into_iter()
+            .map(|interface| (interface.ip(), interface.is_link_local())),
+    )
+}
+
+/// Apply the platform's historical interface-address filters while retaining
+/// the OS enumeration order (and any duplicate entries). Callers rely on that
+/// order when they perform a stable IPv4-before-IPv6 sort.
+fn filtered_interface_addrs(
+    include_loopback: bool,
+    interfaces: impl IntoIterator<Item = (std::net::IpAddr, bool)>,
+) -> Vec<std::net::IpAddr> {
     use std::net::{IpAddr, Ipv4Addr};
 
-    let mut out: Vec<IpAddr> = Vec::new();
+    let mut out = Vec::new();
     if include_loopback {
         out.push(IpAddr::V4(Ipv4Addr::LOCALHOST));
     }
 
-    #[cfg(unix)]
-    {
-        use std::ffi::CStr;
-        unsafe {
-            let mut ifap: *mut libc::ifaddrs = std::ptr::null_mut();
-            if libc::getifaddrs(&mut ifap) == 0 && !ifap.is_null() {
-                let mut cur = ifap;
-                while !cur.is_null() {
-                    let ifa = &*cur;
-                    if !ifa.ifa_addr.is_null() {
-                        let family = (*ifa.ifa_addr).sa_family as i32;
-                        let _name = if ifa.ifa_name.is_null() {
-                            String::new()
-                        } else {
-                            CStr::from_ptr(ifa.ifa_name).to_string_lossy().into_owned()
-                        };
-                        if family == libc::AF_INET {
-                            let sin = ifa.ifa_addr as *const libc::sockaddr_in;
-                            let octets = (*sin).sin_addr.s_addr.to_ne_bytes();
-                            let ip = Ipv4Addr::new(octets[0], octets[1], octets[2], octets[3]);
-                            if !ip.is_loopback() && !ip.is_unspecified() {
-                                out.push(IpAddr::V4(ip));
-                            }
-                        } else if family == libc::AF_INET6 {
-                            let sin6 = ifa.ifa_addr as *const libc::sockaddr_in6;
-                            let segs = (*sin6).sin6_addr.s6_addr;
-                            let ip = std::net::Ipv6Addr::from(segs);
-                            if !ip.is_loopback() && !ip.is_unspecified() && !is_link_local_v6(&ip) {
-                                out.push(IpAddr::V6(ip));
-                            }
-                        }
-                    }
-                    cur = (*cur).ifa_next;
-                }
-                libc::freeifaddrs(ifap);
-            }
+    for (ip, interface_is_link_local) in interfaces {
+        if ip.is_loopback() || ip.is_unspecified() {
+            continue;
         }
-    }
 
-    // Windows has no `getifaddrs(3)`; the OS API is `GetAdaptersAddresses`.
-    // Rather than hand-roll that FFI walk we use the `if-addrs` crate, which
-    // wraps it and yields the same per-interface address list. The filtering
-    // mirrors the unix arm: drop loopback (unless requested), link-local
-    // (IPv6 fe80::/10 and IPv4 169.254/16 — neither is a useful advertised
-    // endpoint), and unspecified addresses. Enumeration order is preserved so
-    // the caller's later stable sort keeps a multi-NIC host's primary NIC
-    // first, matching the unix behaviour.
-    #[cfg(windows)]
-    {
-        if let Ok(ifaces) = if_addrs::get_if_addrs() {
-            for iface in ifaces {
-                if iface.is_link_local() {
-                    continue;
-                }
-                let ip = iface.ip();
-                if ip.is_unspecified() {
-                    continue;
-                }
-                if ip.is_loopback() {
-                    // Loopback is added once up-front (as 127.0.0.1) when
-                    // requested; skip the per-interface loopback entries so
-                    // we don't emit duplicates or ::1 alongside it.
-                    continue;
-                }
-                out.push(ip);
-            }
+        // Preserve the existing platform behavior: Unix historically filtered
+        // IPv6 fe80::/10 but retained IPv4 169.254/16, while the Windows
+        // if-addrs path filtered every address the crate marks link-local.
+        #[cfg(unix)]
+        if matches!(ip, IpAddr::V6(ip) if is_link_local_v6(&ip)) {
+            continue;
         }
+        #[cfg(windows)]
+        if interface_is_link_local {
+            continue;
+        }
+        #[cfg(unix)]
+        let _ = interface_is_link_local;
+
+        out.push(ip);
     }
 
     out
@@ -187,7 +151,58 @@ pub fn rebind_dead_tcp_listener(addr: std::net::SocketAddr) -> std::io::Result<T
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
     use tokio::net::TcpListener;
+
+    #[test]
+    fn interface_filter_preserves_encounter_order_and_duplicates() {
+        let first = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+        let second = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 2));
+        let interfaces = [
+            (IpAddr::V4(Ipv4Addr::UNSPECIFIED), false),
+            (first, false),
+            (IpAddr::V6(Ipv6Addr::LOCALHOST), false),
+            (second, false),
+            (first, false),
+        ];
+
+        assert_eq!(
+            filtered_interface_addrs(true, interfaces),
+            vec![IpAddr::V4(Ipv4Addr::LOCALHOST), first, second, first]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_filter_preserves_historical_link_local_behavior() {
+        let ipv4_link_local = IpAddr::V4(Ipv4Addr::new(169, 254, 1, 2));
+        let ipv6_link_local = IpAddr::V6(Ipv6Addr::new(0xfea0, 0, 0, 0, 0, 0, 0, 1));
+
+        assert_eq!(
+            filtered_interface_addrs(
+                false,
+                [
+                    (ipv4_link_local, true),
+                    // `if-addrs` currently marks only fe80::/16 link-local;
+                    // our historical Unix filter covers the full fe80::/10.
+                    (ipv6_link_local, false),
+                ],
+            ),
+            vec![ipv4_link_local]
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_filter_uses_if_addrs_link_local_classification() {
+        let ipv4_link_local = IpAddr::V4(Ipv4Addr::new(169, 254, 1, 2));
+        let regular = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+
+        assert_eq!(
+            filtered_interface_addrs(false, [(ipv4_link_local, true), (regular, false)]),
+            vec![regular]
+        );
+    }
 
     #[test]
     fn accept_error_classifier_keeps_listener_alive_for_transient_errors() {

--- a/docs/src/windows-support.md
+++ b/docs/src/windows-support.md
@@ -250,10 +250,10 @@ implementations of the cross-platform process and network helpers:
   `ProcessCommandLineInformation` class, falling back to
   `QueryFullProcessImageNameW` (executable path only) when the full command line
   is unavailable.
-- **Routable local addresses** — the **`if-addrs`** crate (wrapping
-  `GetAdaptersAddresses`) backs `access::routable_local_addrs`, which feeds the
-  web-gateway advertise URLs and WebRTC ICE host-candidate gathering. The Unix
-  path keeps its direct `getifaddrs(3)` walk.
+- **Routable local addresses** — the safe cross-platform **`if-addrs`** crate
+  backs `intendant_core::net::routable_local_addrs`, which feeds the web-gateway
+  advertise URLs and WebRTC ICE host-candidate gathering. On Windows the crate
+  wraps `GetAdaptersAddresses`.
 
 ## Known Limitations
 

--- a/src/win_sandbox.rs
+++ b/src/win_sandbox.rs
@@ -67,11 +67,11 @@ use windows::Win32::Security::Authorization::{
 };
 use windows::Win32::Security::{
     AclSizeInformation, CreateRestrictedToken, CreateWellKnownSid, DeleteAce, EqualSid, GetAce,
-    GetAclInformation, WinBuiltinUsersSid, WinRestrictedCodeSid, WinWorldSid, ACCESS_ALLOWED_ACE,
-    ACE_FLAGS, ACL as WIN_ACL, ACL_SIZE_INFORMATION, CONTAINER_INHERIT_ACE,
-    DACL_SECURITY_INFORMATION, DISABLE_MAX_PRIVILEGE, OBJECT_INHERIT_ACE, PSECURITY_DESCRIPTOR,
-    PSID, SECURITY_MAX_SID_SIZE, SID_AND_ATTRIBUTES, TOKEN_ASSIGN_PRIMARY, TOKEN_DUPLICATE,
-    TOKEN_QUERY, WELL_KNOWN_SID_TYPE, WRITE_RESTRICTED,
+    GetAclInformation, IsValidSid, WinBuiltinUsersSid, WinRestrictedCodeSid, WinWorldSid,
+    ACCESS_ALLOWED_ACE, ACE_FLAGS, ACE_HEADER, ACL as WIN_ACL, ACL_SIZE_INFORMATION,
+    CONTAINER_INHERIT_ACE, DACL_SECURITY_INFORMATION, DISABLE_MAX_PRIVILEGE, OBJECT_INHERIT_ACE,
+    PSECURITY_DESCRIPTOR, PSID, SECURITY_MAX_SID_SIZE, SID_AND_ATTRIBUTES, TOKEN_ASSIGN_PRIMARY,
+    TOKEN_DUPLICATE, TOKEN_QUERY, WELL_KNOWN_SID_TYPE, WRITE_RESTRICTED,
 };
 use windows::Win32::Storage::FileSystem::{
     DELETE, FILE_GENERIC_EXECUTE, FILE_GENERIC_READ, FILE_GENERIC_WRITE,
@@ -98,6 +98,21 @@ pub const SANDBOX_APPLIED_ENV: &str = "INTENDANT_SANDBOX_APPLIED";
 /// `FILE_DELETE_CHILD` is not exported as a constant by the crate feature
 /// set we use; its value is stable Win32 ABI (0x40).
 const FILE_DELETE_CHILD: u32 = 0x40;
+
+/// `ACCESS_ALLOWED_ACE_TYPE` is not exported under the Windows feature set
+/// used by this crate. Its Win32 ABI value is stable.
+const ACCESS_ALLOWED_ACE_TYPE_VALUE: u8 = 0;
+
+/// A SID starts with revision + sub-authority count + identifier authority.
+const SID_HEADER_SIZE: usize = 8;
+
+fn access_allowed_ace_size(header: &ACE_HEADER, bytes_available: usize) -> Option<usize> {
+    let ace_size = usize::from(header.AceSize);
+    (header.AceType == ACCESS_ALLOWED_ACE_TYPE_VALUE
+        && ace_size >= std::mem::size_of::<ACCESS_ALLOWED_ACE>()
+        && ace_size <= bytes_available)
+        .then_some(ace_size)
+}
 
 /// Access mask for read-lane grants: read + traverse/execute.
 fn read_mask() -> u32 {
@@ -328,6 +343,11 @@ fn remove_restricted_ace(path: &Path, mask: u32) -> Result<(), String> {
     }
     .map_err(|e| format!("GetAclInformation({}): {e}", path.display()))?;
 
+    let acl_start = dacl as usize;
+    let acl_end = acl_start
+        .checked_add(info.AclBytesInUse as usize)
+        .ok_or_else(|| format!("GetAclInformation({}): invalid ACL size", path.display()))?;
+
     let mut removed = false;
     // Iterate downward so DeleteAce index shifts don't skip entries.
     for i in (0..info.AceCount).rev() {
@@ -336,22 +356,61 @@ fn remove_restricted_ace(path: &Path, mask: u32) -> Result<(), String> {
         if unsafe { GetAce(dacl, i, &mut ace_ptr) }.is_err() {
             continue;
         }
-        // SAFETY: GetAce returned a pointer to an ACE header inside the ACL.
-        let header = unsafe { &*(ace_ptr as *const ACCESS_ALLOWED_ACE) };
-        // ACCESS_ALLOWED_ACE_TYPE — stable Win32 ABI value (0x0); the crate
-        // does not export it under our feature set.
-        if header.Header.AceType != 0u8 {
+        if ace_ptr.is_null() {
             continue;
         }
-        if header.Mask != mask {
+
+        let ace_start = ace_ptr as usize;
+        let Some(header_end) = ace_start.checked_add(std::mem::size_of::<ACE_HEADER>()) else {
+            continue;
+        };
+        if ace_start < acl_start || header_end > acl_end {
             continue;
         }
-        if header.Header.AceFlags & (OBJECT_INHERIT_ACE.0 | CONTAINER_INHERIT_ACE.0) as u8
+        // SAFETY: successful GetAce returned a non-null pointer into this ACL,
+        // and the range check above proves that a complete ACE_HEADER remains
+        // within the ACL buffer. read_unaligned avoids assuming ACE alignment.
+        let header = unsafe { ace_ptr.cast::<ACE_HEADER>().read_unaligned() };
+        let Some(ace_size) = access_allowed_ace_size(&header, acl_end - ace_start) else {
+            continue;
+        };
+        // SAFETY: the header identifies ACCESS_ALLOWED_ACE, and its validated
+        // AceSize covers the full fixed structure inside the ACL buffer.
+        let ace = unsafe { ace_ptr.cast::<ACCESS_ALLOWED_ACE>().read_unaligned() };
+        if ace.Mask != mask {
+            continue;
+        }
+        if header.AceFlags & (OBJECT_INHERIT_ACE.0 | CONTAINER_INHERIT_ACE.0) as u8
             != (OBJECT_INHERIT_ACE.0 | CONTAINER_INHERIT_ACE.0) as u8
         {
             continue;
         }
-        let sid_ptr = PSID(&header.SidStart as *const _ as *mut _);
+
+        let sid_offset = std::mem::offset_of!(ACCESS_ALLOWED_ACE, SidStart);
+        let sid_bytes_available = ace_size - sid_offset;
+        if sid_bytes_available < SID_HEADER_SIZE {
+            continue;
+        }
+        // SAFETY: AceSize and sid_offset were validated against the ACL buffer,
+        // and the SID header fits entirely within this ACE.
+        let sid_bytes = unsafe { ace_ptr.cast::<u8>().add(sid_offset) };
+        // SAFETY: the SID header's second byte is within the validated range.
+        let sub_authority_count = usize::from(unsafe { *sid_bytes.add(1) });
+        let Some(sid_size) = sub_authority_count
+            .checked_mul(std::mem::size_of::<u32>())
+            .and_then(|sub_authorities| SID_HEADER_SIZE.checked_add(sub_authorities))
+        else {
+            continue;
+        };
+        if sid_size > sid_bytes_available {
+            continue;
+        }
+        let sid_ptr = PSID(sid_bytes.cast());
+        // SAFETY: the complete SID length derived from its bounded header fits
+        // inside the validated ACE. IsValidSid performs the ABI-level checks.
+        if !unsafe { IsValidSid(sid_ptr) }.as_bool() {
+            continue;
+        }
         // SAFETY: both SIDs are valid for the comparison; EqualSid reads only.
         let equal = unsafe { EqualSid(sid_ptr, restricted.as_psid()) }.is_ok();
         if equal {
@@ -961,6 +1020,29 @@ mod tests {
     /// The grant table, journal file, and temp-dir ACEs are process-global
     /// — these tests must not interleave.
     static SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn access_allowed_ace_size_requires_matching_type_and_bounded_structure() {
+        let fixed_size = std::mem::size_of::<ACCESS_ALLOWED_ACE>();
+        let header = ACE_HEADER {
+            AceType: ACCESS_ALLOWED_ACE_TYPE_VALUE,
+            AceFlags: 0,
+            AceSize: fixed_size as u16,
+        };
+        assert_eq!(
+            access_allowed_ace_size(&header, fixed_size),
+            Some(fixed_size)
+        );
+        assert_eq!(access_allowed_ace_size(&header, fixed_size - 1), None);
+
+        let mut wrong_type = header;
+        wrong_type.AceType = 1;
+        assert_eq!(access_allowed_ace_size(&wrong_type, fixed_size), None);
+
+        let mut truncated = header;
+        truncated.AceSize = (fixed_size - 1) as u16;
+        assert_eq!(access_allowed_ace_size(&truncated, fixed_size), None);
+    }
 
     /// The restricted token must carry exactly one privilege —
     /// `SeChangeNotifyPrivilege`. Anything else surviving from an elevated


### PR DESCRIPTION
## Summary

- replace the raw Unix `getifaddrs` traversal with the safe cross-platform `if-addrs` API while preserving interface order and filtering behavior
- validate Windows ACL/ACE pointer ranges, declared sizes, and variable-length SIDs before reading or comparing them
- align dependency ownership and Windows support documentation with the safe implementation

## Code scanning

Addresses the two production `rust/access-invalid-pointer` alerts (#23 and #24). The other 24 findings were deterministic cryptographic fixtures inside `#[cfg(test)]`; those were dismissed separately as test-only with an audit comment.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p intendant-core net::tests -- --nocapture` (5 passed)
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`
- pull-request Linux full test/e2e leg passed
- pull-request macOS check passed under the machine-wide governor
- pull-request Windows check compiled the guarded ACE/SID implementation
- the auto-merge tree against current main retains both the governor package and the `intendant-core` dependency move without conflicts

The merge-group matrix will run the full Windows sandbox tests before landing.