### PR TITLE
rustc-governor: machine-wide compile-permit pool (crate + installer + doctrine)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -49,3 +49,11 @@ slow-timeout = { period = "60s", terminate-after = 4 }
 [[profile.default.overrides]]
 filter = 'test(/ctl_peer_mtls_pairing/)'
 slow-timeout = { period = "120s", terminate-after = 3 }
+
+# rustc-governor acceptance tests spawn the real governor binary plus
+# /bin/sh fixtures and hand flock permits between processes with
+# deliberately generous deadlines; pure fork/exec + scheduling headroom on
+# a saturated box (same class as the worktree_inventory override above).
+[[profile.default.overrides]]
+filter = 'package(rustc-governor)'
+slow-timeout = { period = "60s", terminate-after = 4 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4822,6 +4822,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-governor"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "tempfile",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/intendant-platform",
     "crates/presence-core",
     "crates/presence-web",
+    "crates/rustc-governor",
     "crates/station-web",
 ]
 

--- a/crates/rustc-governor/Cargo.toml
+++ b/crates/rustc-governor/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "rustc-governor"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+publish = false
+
+[[bin]]
+name = "rustc-governor"
+path = "src/main.rs"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[dev-dependencies]
+# Acceptance + unit tests build hermetic permit dirs / fake homes in tempdirs.
+tempfile = "3"

--- a/crates/rustc-governor/src/config.rs
+++ b/crates/rustc-governor/src/config.rs
@@ -1,0 +1,298 @@
+//! Governor configuration: a tiny reader for the machine-wide
+//! `/usr/local/etc/intendant-governor.toml` (path overridable via
+//! `INTENDANT_GOVERNOR_CONFIG`, which is how the acceptance tests point the
+//! binary at hermetic tempdir rigs).
+//!
+//! The file is real TOML, but the governor deliberately does not pull
+//! `toml` + `serde` into a binary that fronts every rustc invocation: it
+//! parses the flat subset the installer writes — `key = value` lines with
+//! booleans, non-negative integers, double-quoted strings, and single-line
+//! arrays of double-quoted strings, plus `#` comments and blank lines.
+//! Unknown keys are ignored (forward compatibility), but their values must
+//! still be syntactically well-formed — line noise anywhere makes the whole
+//! file unparseable.
+//!
+//! Doctrine: a missing or unparseable config FAILS OPEN. The governor must
+//! never break a build, so "can't read the rules" means "get out of the
+//! way", not "guess". Every invocation re-reads the file (and in-flight
+//! waiters re-check it once per poll tick), which is what makes
+//! `enabled = false` a live kill switch needing no listener restarts.
+
+use std::path::{Path, PathBuf};
+
+pub const DEFAULT_CONFIG_PATH: &str = "/usr/local/etc/intendant-governor.toml";
+pub const DEFAULT_PERMIT_DIR: &str = "/usr/local/var/intendant-governor";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Config {
+    /// The live kill switch. Defaults to true: a config file's existence
+    /// expresses intent to govern; disabling is always explicit.
+    pub enabled: bool,
+    /// Directory holding the permit/demand flock files and governor.log.
+    pub permit_dir: PathBuf,
+    /// Permits reserved for interactive (non-CI) accounts.
+    pub local_reserved: u32,
+    /// Permits reserved for the CI accounts listed in `ci_users`.
+    pub ci_reserved: u32,
+    /// Usernames whose invocations are classed `ci`; everyone else is
+    /// `local`.
+    pub ci_users: Vec<String>,
+    /// Explicit compiler path; when unset the governor resolves
+    /// `$HOME/.cargo/bin/rustc`, then `rustc` from PATH.
+    pub real_rustc: Option<PathBuf>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            enabled: true,
+            permit_dir: PathBuf::from(DEFAULT_PERMIT_DIR),
+            local_reserved: 1,
+            ci_reserved: 2,
+            ci_users: vec!["_intendant-ci".to_string(), "ci".to_string()],
+            real_rustc: None,
+        }
+    }
+}
+
+/// Path of the config file: the `INTENDANT_GOVERNOR_CONFIG` override, else
+/// the machine-wide default.
+pub fn config_path() -> PathBuf {
+    std::env::var_os("INTENDANT_GOVERNOR_CONFIG")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_CONFIG_PATH))
+}
+
+/// Read and parse the config. `None` means "no usable config" — missing or
+/// unparseable file — and every caller must fail open on it.
+pub fn load(path: &Path) -> Option<Config> {
+    let text = std::fs::read_to_string(path).ok()?;
+    parse(&text).ok()
+}
+
+pub fn parse(text: &str) -> Result<Config, String> {
+    let mut cfg = Config::default();
+    for (idx, raw) in text.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let err = |msg: &str| format!("line {}: {msg}", idx + 1);
+        let (key, value) = line
+            .split_once('=')
+            .ok_or_else(|| err("expected `key = value`"))?;
+        let key = key.trim();
+        let value = value.trim();
+        if key.is_empty() {
+            return Err(err("empty key"));
+        }
+        match key {
+            "enabled" => cfg.enabled = parse_bool(value).map_err(|e| err(&e))?,
+            "permit_dir" => {
+                cfg.permit_dir = PathBuf::from(parse_string(value).map_err(|e| err(&e))?)
+            }
+            "local_reserved" => cfg.local_reserved = parse_u32(value).map_err(|e| err(&e))?,
+            "ci_reserved" => cfg.ci_reserved = parse_u32(value).map_err(|e| err(&e))?,
+            "ci_users" => cfg.ci_users = parse_string_array(value).map_err(|e| err(&e))?,
+            "real_rustc" => {
+                cfg.real_rustc = Some(PathBuf::from(parse_string(value).map_err(|e| err(&e))?))
+            }
+            // Unknown keys are ignored for forward compatibility, but the
+            // value must still be one of the shapes we understand — a file
+            // this parser can't fully read is a file it must not act on.
+            _ => validate_value(value).map_err(|e| err(&e))?,
+        }
+    }
+    Ok(cfg)
+}
+
+/// Cut an *unquoted* value at a trailing `#` comment.
+fn strip_bare_comment(value: &str) -> &str {
+    value.split('#').next().unwrap_or(value)
+}
+
+fn rest_is_blank_or_comment(rest: &str) -> Result<(), String> {
+    let rest = rest.trim_start();
+    if rest.is_empty() || rest.starts_with('#') {
+        Ok(())
+    } else {
+        Err(format!("trailing garbage `{rest}`"))
+    }
+}
+
+fn parse_bool(value: &str) -> Result<bool, String> {
+    match strip_bare_comment(value).trim() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        other => Err(format!("expected true/false, got `{other}`")),
+    }
+}
+
+fn parse_u32(value: &str) -> Result<u32, String> {
+    let bare = strip_bare_comment(value).trim();
+    bare.parse::<u32>()
+        .map_err(|_| format!("expected a non-negative integer, got `{bare}`"))
+}
+
+/// Scan one double-quoted string starting at `s[0]`; returns the parsed
+/// value and the unconsumed remainder.
+fn scan_string(s: &str) -> Result<(String, &str), String> {
+    let mut chars = s.char_indices();
+    if !matches!(chars.next(), Some((_, '"'))) {
+        return Err("expected opening `\"`".to_string());
+    }
+    let mut out = String::new();
+    let mut escaped = false;
+    for (i, c) in chars {
+        if escaped {
+            out.push(match c {
+                '"' => '"',
+                '\\' => '\\',
+                'n' => '\n',
+                't' => '\t',
+                other => return Err(format!("unsupported escape `\\{other}`")),
+            });
+            escaped = false;
+        } else if c == '\\' {
+            escaped = true;
+        } else if c == '"' {
+            return Ok((out, &s[i + 1..]));
+        } else {
+            out.push(c);
+        }
+    }
+    Err("unterminated string".to_string())
+}
+
+fn parse_string(value: &str) -> Result<String, String> {
+    let (s, rest) = scan_string(value.trim_start())?;
+    rest_is_blank_or_comment(rest)?;
+    Ok(s)
+}
+
+/// Single-line `["a", "b"]` arrays (a trailing comma is tolerated).
+fn parse_string_array(value: &str) -> Result<Vec<String>, String> {
+    let mut rest = value
+        .trim_start()
+        .strip_prefix('[')
+        .ok_or_else(|| "expected `[`".to_string())?;
+    let mut out = Vec::new();
+    loop {
+        rest = rest.trim_start();
+        if let Some(after) = rest.strip_prefix(']') {
+            rest_is_blank_or_comment(after)?;
+            return Ok(out);
+        }
+        let (s, after) = scan_string(rest)?;
+        out.push(s);
+        rest = after.trim_start();
+        match rest.strip_prefix(',') {
+            Some(after_comma) => rest = after_comma,
+            None => {
+                // Without a separating comma the next token must close the
+                // array.
+                let after = rest
+                    .strip_prefix(']')
+                    .ok_or_else(|| "expected `,` or `]`".to_string())?;
+                rest_is_blank_or_comment(after)?;
+                return Ok(out);
+            }
+        }
+    }
+}
+
+/// Syntax check for values of keys this version doesn't know.
+fn validate_value(value: &str) -> Result<(), String> {
+    let t = value.trim_start();
+    if t.starts_with('"') {
+        parse_string(value).map(|_| ())
+    } else if t.starts_with('[') {
+        parse_string_array(value).map(|_| ())
+    } else {
+        let bare = strip_bare_comment(value).trim();
+        if bare == "true" || bare == "false" || bare.parse::<i64>().is_ok() {
+            Ok(())
+        } else {
+            Err(format!("unrecognized value `{bare}`"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_the_canonical_installer_config() {
+        let text = r#"
+# Machine-wide rustc concurrency governor — live config.
+enabled = true
+permit_dir = "/usr/local/var/intendant-governor"
+local_reserved = 1
+ci_reserved = 2   # per-box sizing
+ci_users = ["_intendant-ci", "ci"]
+"#;
+        let cfg = parse(text).unwrap();
+        assert_eq!(cfg, Config::default());
+    }
+
+    #[test]
+    fn empty_file_yields_defaults() {
+        assert_eq!(parse("").unwrap(), Config::default());
+    }
+
+    #[test]
+    fn all_keys_override_defaults() {
+        let text = concat!(
+            "enabled = false\n",
+            "permit_dir = \"/tmp/x\" # trailing comment\n",
+            "local_reserved = 3\n",
+            "ci_reserved = 0\n",
+            "ci_users = [\"a\", \"b\",]\n",
+            "real_rustc = \"/opt/rustc\"\n",
+        );
+        let cfg = parse(text).unwrap();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.permit_dir, PathBuf::from("/tmp/x"));
+        assert_eq!(cfg.local_reserved, 3);
+        assert_eq!(cfg.ci_reserved, 0);
+        assert_eq!(cfg.ci_users, vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(cfg.real_rustc, Some(PathBuf::from("/opt/rustc")));
+    }
+
+    #[test]
+    fn string_escapes_are_decoded() {
+        let cfg = parse("permit_dir = \"/tmp/a\\\\b\\\"c\"\n").unwrap();
+        assert_eq!(cfg.permit_dir, PathBuf::from("/tmp/a\\b\"c"));
+    }
+
+    #[test]
+    fn unknown_keys_with_valid_values_are_ignored() {
+        let cfg = parse("future_knob = [\"x\"]\nother = 7\nflag = true\n").unwrap();
+        assert_eq!(cfg, Config::default());
+    }
+
+    #[test]
+    fn garbage_is_unparseable() {
+        // Each of these must fail parsing — the binary fails OPEN on them.
+        for bad in [
+            "enabled = maybe\n",
+            "local_reserved = -1\n",
+            "ci_users = [\"unterminated\n",
+            "not = [valid\n",
+            "just some prose\n",
+            "permit_dir = /unquoted/path\n",
+            "= 3\n",
+            "enabled = true trailing\n",
+            "ci_users = [\"a\" \"b\"]\n",
+        ] {
+            assert!(parse(bad).is_err(), "expected parse failure for {bad:?}");
+        }
+    }
+
+    #[test]
+    fn comments_and_blanks_are_skipped() {
+        let cfg = parse("\n   \n# full-line comment\n  # indented comment\n").unwrap();
+        assert_eq!(cfg, Config::default());
+    }
+}

--- a/crates/rustc-governor/src/flock.rs
+++ b/crates/rustc-governor/src/flock.rs
@@ -1,0 +1,111 @@
+//! Thin flock(2)/fcntl(2) wrappers. The crate's `unsafe` lives here and in
+//! `permits::current_username`, each block wrapping exactly one libc call
+//! (repo convention: minimal, `// SAFETY:`-commented islands).
+//!
+//! flock, not fcntl locks, on purpose: flock locks belong to the open file
+//! description, survive exec(2) (once FD_CLOEXEC is cleared), are inherited
+//! by nothing else we spawn (we spawn nothing), and evaporate when the
+//! holder dies — which is the entire crash-release story. Mode is
+//! irrelevant to flock, so read-only opens of the root-owned 0644 permit
+//! files lock fine for every account.
+
+use std::fs::File;
+use std::io;
+use std::os::unix::io::AsRawFd;
+
+fn flock_op(file: &File, op: libc::c_int) -> io::Result<()> {
+    loop {
+        // SAFETY: `file` owns an fd that stays open for the duration of the
+        // call; flock(2) takes only that fd plus an operation flag and
+        // touches no caller memory.
+        let rc = unsafe { libc::flock(file.as_raw_fd(), op) };
+        if rc == 0 {
+            return Ok(());
+        }
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() != Some(libc::EINTR) {
+            return Err(err);
+        }
+    }
+}
+
+/// LOCK_EX|LOCK_NB: true iff the exclusive lock was taken.
+pub(crate) fn try_lock_exclusive(file: &File) -> bool {
+    flock_op(file, libc::LOCK_EX | libc::LOCK_NB).is_ok()
+}
+
+/// Blocking LOCK_SH, used only to register demand. Bounded in practice: the
+/// only LOCK_EX takers on demand files are gate probes, which release
+/// immediately (permits — where a holder keeps LOCK_EX for a whole compile
+/// — are never locked blocking; the poll loop owns that waiting).
+pub(crate) fn lock_shared_blocking(file: &File) -> bool {
+    flock_op(file, libc::LOCK_SH).is_ok()
+}
+
+pub(crate) fn unlock(file: &File) {
+    let _ = flock_op(file, libc::LOCK_UN);
+}
+
+/// Rust's std opens every file O_CLOEXEC; a permit's flock must survive the
+/// exec into the real rustc (the flock IS the permit). Load-bearing —
+/// covered by the `permit_lock_survives_exec` acceptance test.
+pub(crate) fn clear_cloexec(file: &File) -> io::Result<()> {
+    // SAFETY: the fd is owned by `file` and stays open across both calls;
+    // F_GETFD moves no memory.
+    let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFD) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: as above; F_SETFD only updates the fd's flag word.
+    let rc = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETFD, flags & !libc::FD_CLOEXEC) };
+    if rc < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exclusive_locks_exclude_across_open_descriptions() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("permit");
+        let a = File::create(&path).unwrap();
+        let b = File::open(&path).unwrap();
+        assert!(try_lock_exclusive(&a));
+        // Same process, distinct open file description: still excluded.
+        assert!(!try_lock_exclusive(&b));
+        unlock(&a);
+        assert!(try_lock_exclusive(&b));
+    }
+
+    #[test]
+    fn shared_lock_blocks_exclusive_probe() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("demand");
+        let holder = File::create(&path).unwrap();
+        let prober = File::open(&path).unwrap();
+        assert!(lock_shared_blocking(&holder));
+        assert!(!try_lock_exclusive(&prober));
+        unlock(&holder);
+        assert!(try_lock_exclusive(&prober));
+    }
+
+    #[test]
+    fn clear_cloexec_clears_the_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        let f = File::create(dir.path().join("fd")).unwrap();
+        // SAFETY: `f` owns an open fd; F_GETFD moves no memory.
+        let before = unsafe { libc::fcntl(f.as_raw_fd(), libc::F_GETFD) };
+        assert!(
+            before >= 0 && (before & libc::FD_CLOEXEC) != 0,
+            "std opens O_CLOEXEC"
+        );
+        clear_cloexec(&f).unwrap();
+        // SAFETY: as above.
+        let after = unsafe { libc::fcntl(f.as_raw_fd(), libc::F_GETFD) };
+        assert!(after >= 0 && (after & libc::FD_CLOEXEC) == 0);
+    }
+}

--- a/crates/rustc-governor/src/govlog.rs
+++ b/crates/rustc-governor/src/govlog.rs
@@ -1,0 +1,167 @@
+//! `<permit_dir>/governor.log`: exactly one line per governed invocation
+//! (bypasses, probes, and fail-open runs are deliberately silent — the log
+//! answers "who waited how long on which permit", and the probe fast path
+//! must not pay even a log write).
+//!
+//! Best-effort end to end: logging must never fail the build, so every I/O
+//! error here is swallowed. Rotation is truncate-in-place at 1MB keeping
+//! the last 256KB — the scripts/ci hooks/watchdog doctrine: governed
+//! accounts can write the pre-created 0666 file but cannot create siblings
+//! in the root-owned permit dir, so tmp+rename is off the table. Racing
+//! rotators are serialized by a non-blocking flock on the log itself
+//! (losers skip; worst case a line lands mid-rotation and is lost — a
+//! tolerated cost, same as the hooks log).
+
+use std::fs::OpenOptions;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::flock;
+
+pub(crate) const LOG_NAME: &str = "governor.log";
+const MAX_LOG_BYTES: u64 = 1024 * 1024;
+const KEEP_BYTES: u64 = 256 * 1024;
+
+pub(crate) fn log_governed(permit_dir: &Path, class: &str, permit_name: &str, wait_ms: u64) {
+    let path = permit_dir.join(LOG_NAME);
+    rotate_if_oversized(&path);
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let line = format!(
+        "{} pid={} class={class} permit={permit_name} wait_ms={wait_ms}\n",
+        iso8601_utc(secs),
+        std::process::id(),
+    );
+    if let Ok(mut f) = OpenOptions::new().append(true).create(true).open(&path) {
+        // One short O_APPEND write per invocation: atomic per line.
+        let _ = f.write_all(line.as_bytes());
+    }
+}
+
+fn rotate_if_oversized(path: &Path) {
+    let Ok(mut f) = OpenOptions::new().read(true).write(true).open(path) else {
+        return;
+    };
+    let Ok(len) = f.metadata().map(|m| m.len()) else {
+        return;
+    };
+    if len <= MAX_LOG_BYTES {
+        return;
+    }
+    // Whoever wins the probe rotates; everyone else skips this round.
+    if !flock::try_lock_exclusive(&f) {
+        return;
+    }
+    let mut tail = vec![0_u8; KEEP_BYTES as usize];
+    let read_ok =
+        f.seek(SeekFrom::End(-(KEEP_BYTES as i64))).is_ok() && f.read_exact(&mut tail).is_ok();
+    if read_ok {
+        // Cut to the first line boundary inside the kept tail.
+        let cut = tail
+            .iter()
+            .position(|&b| b == b'\n')
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        // Concurrent O_APPEND writers may interleave lines while the tail
+        // is being written back; bounded and tolerated.
+        if f.set_len(0).is_ok() && f.seek(SeekFrom::Start(0)).is_ok() {
+            let _ = f.write_all(&tail[cut..]);
+        }
+    }
+    flock::unlock(&f);
+}
+
+/// Seconds-since-epoch → `2026-07-10T21:15:04Z`, no chrono/time dependency.
+/// Days→civil conversion is the classic Euclidean-affine algorithm
+/// (Howard Hinnant's `civil_from_days`).
+fn iso8601_utc(secs: u64) -> String {
+    let days = (secs / 86_400) as i64;
+    let rem = secs % 86_400;
+    let (y, m, d) = civil_from_days(days);
+    format!(
+        "{y:04}-{m:02}-{d:02}T{:02}:{:02}:{:02}Z",
+        rem / 3600,
+        (rem % 3600) / 60,
+        rem % 60
+    )
+}
+
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64; // [0, 146096]
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32; // [1, 12]
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iso8601_matches_known_timestamps() {
+        assert_eq!(iso8601_utc(0), "1970-01-01T00:00:00Z");
+        assert_eq!(iso8601_utc(1_000_000_000), "2001-09-09T01:46:40Z");
+        assert_eq!(iso8601_utc(951_782_400), "2000-02-29T00:00:00Z");
+        assert_eq!(iso8601_utc(4_102_444_800), "2100-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn log_line_appends_and_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        log_governed(dir.path(), "local", "permit-ci-1", 230);
+        let text = std::fs::read_to_string(dir.path().join(LOG_NAME)).unwrap();
+        let line = text.trim_end();
+        assert!(
+            line.ends_with("class=local permit=permit-ci-1 wait_ms=230"),
+            "{line}"
+        );
+        assert!(line.contains(&format!("pid={}", std::process::id())));
+        assert!(line.starts_with("20"), "timestamp first: {line}");
+    }
+
+    #[test]
+    fn rotation_truncates_in_place_keeping_a_line_aligned_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(LOG_NAME);
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            for i in 0..40_000 {
+                writeln!(f, "line {i:07} padding-padding-padding-padding").unwrap();
+            }
+        }
+        assert!(std::fs::metadata(&path).unwrap().len() > MAX_LOG_BYTES);
+        log_governed(dir.path(), "ci", "permit-ci-0", 7);
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            (text.len() as u64) <= KEEP_BYTES + 128,
+            "not truncated: {}",
+            text.len()
+        );
+        assert!(
+            text.starts_with("line "),
+            "must cut at a line boundary: {:?}",
+            &text[..24]
+        );
+        assert!(text.trim_end().ends_with("wait_ms=7"));
+    }
+
+    #[test]
+    fn undersized_log_is_left_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(LOG_NAME);
+        std::fs::write(&path, "existing line\n").unwrap();
+        log_governed(dir.path(), "local", "permit-local-0", 0);
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(text.starts_with("existing line\n"));
+        assert_eq!(text.lines().count(), 2);
+    }
+}

--- a/crates/rustc-governor/src/main.rs
+++ b/crates/rustc-governor/src/main.rs
@@ -1,0 +1,232 @@
+//! rustc-governor — the machine-wide rustc concurrency governor.
+//!
+//! Wired as cargo's `[build] rustc` while `rustc-wrapper` stays sccache, so
+//! the chain is: cargo → sccache client → sccache server → THIS BINARY →
+//! exec(2) of the real rustc. sccache treats the governor as the compiler:
+//! cache hits never execute it (hits never wait); on a miss / non-cacheable
+//! invocation the sccache server spawns it, it acquires a machine-wide
+//! compile permit (flock(2) files shared by every account on the box), and
+//! then replaces itself with the real rustc via exec — exit status and
+//! signal disposition are inherited by construction, and the permit's flock
+//! rides the FD_CLOEXEC-cleared fd until that rustc exits, however it exits.
+//!
+//! Doctrine, in order:
+//!   1. **Fail open.** Missing/unparseable config, `enabled = false`, the
+//!      secondary `INTENDANT_GOVERNOR=off` env override, an unusable permit
+//!      dir, or zero configured permits ⇒ skip permits entirely and exec the
+//!      real rustc. A governor must never break a build. The config file is
+//!      re-read by every invocation (and once per poll tick by in-flight
+//!      waiters), which is what makes it the live kill switch — no listener
+//!      restarts.
+//!   2. **Probe fast path.** `-vV` / `-V` / `--version`, or a `--print`
+//!      request with no codegen, bypasses permits (cargo and sccache issue
+//!      these constantly; they must stay snappy under a full pool). See
+//!      `probe.rs` for the exact classification.
+//!   3. **Class detection.** The euid's username, matched against the
+//!      config's `ci_users`, splits invocations into `ci` and `local`.
+//!   4. **Permits.** Own-class reservation first, then borrow the other
+//!      class's spare permits iff that class has no registered waiters,
+//!      else register demand and poll — see `permits.rs` for the demand-gate
+//!      protocol. Nothing is ever killed or signalled; borrowed permits
+//!      return naturally when their holder exits.
+//!
+//! Config: `/usr/local/etc/intendant-governor.toml`
+//! (`INTENDANT_GOVERNOR_CONFIG` overrides — how the acceptance tests point
+//! the binary at hermetic tempdir rigs). Installer:
+//! `scripts/ci/install-governor-macos.sh`. Operator doc:
+//! `scripts/ci/README.md`, "Governor" section.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+// `config` is the one cross-platform module (the portable fallback below
+// still honors `real_rustc`); the governor proper — flock permits, exec —
+// is Unix-only, so the non-unix build deliberately leaves parts of the
+// config unread.
+#[cfg_attr(not(unix), allow(dead_code))]
+mod config;
+#[cfg(unix)]
+mod flock;
+#[cfg(unix)]
+mod govlog;
+#[cfg(unix)]
+mod permits;
+#[cfg(unix)]
+mod probe;
+
+fn main() {
+    let args: Vec<OsString> = std::env::args_os().skip(1).collect();
+    let config_path = config::config_path();
+    let cfg = config::load(&config_path);
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let real = resolve_real_rustc(cfg.as_ref(), home.as_deref());
+    guard_against_self_exec(&real);
+    #[cfg(unix)]
+    run_unix(args, cfg, &config_path, &real);
+    #[cfg(not(unix))]
+    run_portable(args, &real);
+}
+
+/// Resolution order: `real_rustc` from config; else `$HOME/.cargo/bin/rustc`
+/// when present (the rustup proxy — preserves rust-toolchain.toml and
+/// `+toolchain` resolution exactly as if cargo had invoked rustc itself);
+/// else `rustc` from PATH.
+fn resolve_real_rustc(cfg: Option<&config::Config>, home: Option<&Path>) -> PathBuf {
+    if let Some(explicit) = cfg.and_then(|c| c.real_rustc.clone()) {
+        return explicit;
+    }
+    if let Some(home) = home {
+        let rustup_proxy = home.join(".cargo").join("bin").join("rustc");
+        if rustup_proxy.is_file() {
+            return rustup_proxy;
+        }
+    }
+    PathBuf::from("rustc")
+}
+
+/// A misconfigured chain (`real_rustc` pointing back at the governor, or the
+/// governor installed on PATH under the name `rustc`) would exec(2) itself
+/// in a tight loop — a fork bomb wearing a compiler's clothes. Best-effort
+/// (a bare `rustc` only canonicalizes when it names a cwd-relative file),
+/// and two syscalls per invocation buy the guard.
+fn guard_against_self_exec(real: &Path) {
+    let me = std::env::current_exe()
+        .ok()
+        .and_then(|p| std::fs::canonicalize(p).ok());
+    let target = std::fs::canonicalize(real).ok();
+    if me.is_some() && me == target {
+        eprintln!(
+            "rustc-governor: refusing to exec itself (the resolved real rustc is the governor \
+             binary); fix the real_rustc / [build] rustc wiring"
+        );
+        std::process::exit(127);
+    }
+}
+
+#[cfg(unix)]
+fn run_unix(
+    args: Vec<OsString>,
+    cfg: Option<config::Config>,
+    config_path: &Path,
+    real: &Path,
+) -> ! {
+    use std::os::unix::process::CommandExt as _;
+
+    let permit = governed_permit(&args, cfg, config_path);
+    // exec(2): on success this process IS the real rustc — argv[1..] and the
+    // environment pass through untouched, exit status and signal disposition
+    // propagate by construction, and the permit's flock (if any) rides the
+    // FD_CLOEXEC-cleared fd until that rustc exits. Any exit — clean, panic,
+    // SIGKILL — releases the permit in the kernel.
+    let err = Command::new(real).args(&args).exec();
+    // Reachable only when exec failed (real rustc missing / not executable).
+    drop(permit);
+    eprintln!("rustc-governor: failed to exec {}: {err}", real.display());
+    std::process::exit(127);
+}
+
+/// Decide whether this invocation is governed, and if so acquire its permit.
+/// `None` always means "run ungoverned" — bypass and fail-open share one
+/// path, because both must behave identically: exec the real rustc.
+#[cfg(unix)]
+fn governed_permit(
+    args: &[OsString],
+    cfg: Option<config::Config>,
+    config_path: &Path,
+) -> Option<permits::AcquiredPermit> {
+    // Secondary, per-invocation kill switch (the config file is the primary
+    // one). Any value other than "off" is ignored.
+    if std::env::var_os("INTENDANT_GOVERNOR").is_some_and(|v| v == "off") {
+        return None;
+    }
+    // Missing/unparseable config ⇒ fail open; `enabled = false` ⇒ the live
+    // kill switch.
+    let cfg = cfg?;
+    if !cfg.enabled {
+        return None;
+    }
+    // Probe fast path. Classification only ever inspects well-known ASCII
+    // flags, so lossy UTF-8 conversion is fine — the exec passes the
+    // original OsStrings through untouched.
+    let lossy: Vec<String> = args
+        .iter()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    if probe::is_probe_only(&lossy) {
+        return None;
+    }
+    let class = permits::classify(permits::current_username().as_deref(), &cfg);
+    let permit = permits::acquire(&cfg, class, config_path)?;
+    govlog::log_governed(
+        &cfg.permit_dir,
+        class.as_str(),
+        &permit.name,
+        permit.wait_ms,
+    );
+    // Rust's std opens every file O_CLOEXEC; the permit must survive the
+    // exec (the flock IS the permit). If clearing fails, proceed anyway:
+    // losing the permit at exec oversubscribes the box by one compile,
+    // while failing the compile would break the build — and a governor
+    // must never break a build.
+    let _ = flock::clear_cloexec(&permit.file);
+    Some(permit)
+}
+
+/// The governor is a Unix (macOS / Linux) tool — flock(2) permit pools and
+/// exec(2) semantics don't map onto Windows, and it is never deployed
+/// there. This fallback keeps the workspace building on every first-class
+/// platform (repo policy): degrade gracefully by running the real compiler
+/// ungoverned and propagating its exit code.
+#[cfg(not(unix))]
+fn run_portable(args: Vec<OsString>, real: &Path) -> ! {
+    match Command::new(real).args(&args).status() {
+        Ok(status) => std::process::exit(status.code().unwrap_or(1)),
+        Err(err) => {
+            eprintln!("rustc-governor: failed to run {}: {err}", real.display());
+            std::process::exit(127);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_prefers_config_real_rustc() {
+        let cfg = config::Config {
+            real_rustc: Some(PathBuf::from("/opt/toolchain/bin/rustc")),
+            ..config::Config::default()
+        };
+        assert_eq!(
+            resolve_real_rustc(Some(&cfg), None),
+            PathBuf::from("/opt/toolchain/bin/rustc")
+        );
+    }
+
+    #[test]
+    fn resolve_falls_back_to_home_rustup_proxy_then_path() {
+        let home = tempfile::tempdir().unwrap();
+        // No ~/.cargo/bin/rustc yet: PATH fallback.
+        assert_eq!(
+            resolve_real_rustc(None, Some(home.path())),
+            PathBuf::from("rustc")
+        );
+        // With the rustup proxy present, it wins.
+        let bin = home.path().join(".cargo").join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let proxy = bin.join("rustc");
+        std::fs::write(&proxy, b"#!/bin/sh\n").unwrap();
+        assert_eq!(resolve_real_rustc(None, Some(home.path())), proxy);
+        // Config beats the proxy.
+        let cfg = config::Config {
+            real_rustc: Some(PathBuf::from("/x/rustc")),
+            ..config::Config::default()
+        };
+        assert_eq!(
+            resolve_real_rustc(Some(&cfg), Some(home.path())),
+            PathBuf::from("/x/rustc")
+        );
+    }
+}

--- a/crates/rustc-governor/src/permits.rs
+++ b/crates/rustc-governor/src/permits.rs
@@ -1,0 +1,363 @@
+//! The machine-wide compile-permit pool: flock(2) files with class
+//! reservations and a demand gate.
+//!
+//! Layout inside `permit_dir` (names are minted by
+//! `scripts/ci/install-governor-macos.sh` in production — non-root accounts
+//! cannot create files in the root-owned dir — and created on the fly in
+//! user-writable dirs such as test rigs; interlock: change the naming here
+//! and in the installer together):
+//!
+//! - `permit-local-<i>`, i < local_reserved  — the interactive reservation
+//! - `permit-ci-<i>`,    i < ci_reserved     — the CI reservation
+//! - `demand-local`, `demand-ci`             — one demand file per class
+//!
+//! Protocol:
+//! - Holding a permit = holding LOCK_EX on its file. The lock rides the fd
+//!   across exec(2) into the real rustc and is released by the kernel when
+//!   that process exits, however it exits — crash release is structural.
+//! - A waiter holds LOCK_SH on its OWN class's demand file for the whole
+//!   wait, and releases it the moment it holds a permit.
+//! - Borrowing: before touching a foreign-class permit, probe that class's
+//!   demand file with LOCK_EX|LOCK_NB. Success (released immediately) means
+//!   no waiters ⇒ the class's spare capacity may be borrowed; failure means
+//!   the class has waiters ⇒ its reservation is honored. A failed probe can
+//!   also mean another borrower's probe won the same instant — a transient,
+//!   conservative false "has waiters" (we skip borrowing for one poll tick).
+//! - Waiting is a 100ms LOCK_EX|LOCK_NB poll over every eligible permit —
+//!   never a blocking flock on a permit: blocking flock has no timeout, and
+//!   parking inside the kernel on a foreign permit would bypass the demand
+//!   gate for the rest of the wait.
+//! - Nothing is ever killed or signalled; borrowed permits return naturally
+//!   when their holder exits.
+
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use crate::config::{self, Config};
+use crate::flock;
+
+pub(crate) const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Class {
+    Local,
+    Ci,
+}
+
+impl Class {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Class::Local => "local",
+            Class::Ci => "ci",
+        }
+    }
+
+    fn other(self) -> Class {
+        match self {
+            Class::Local => Class::Ci,
+            Class::Ci => Class::Local,
+        }
+    }
+}
+
+/// Everything not listed in `ci_users` — including an unresolvable
+/// username — is local (the design: CI is the explicit allowlist).
+pub(crate) fn classify(username: Option<&str>, cfg: &Config) -> Class {
+    match username {
+        Some(user) if cfg.ci_users.iter().any(|ci| ci == user) => Class::Ci,
+        _ => Class::Local,
+    }
+}
+
+/// Username of the effective uid via getpwuid_r — deliberately not
+/// `$USER`/`$LOGNAME`, which go stale under sudo/setuid and are trivially
+/// spoofed into the wrong class.
+pub(crate) fn current_username() -> Option<String> {
+    // SAFETY: geteuid(2) has no preconditions and cannot fail.
+    let uid = unsafe { libc::geteuid() };
+    let mut buf = vec![0_u8; 256];
+    loop {
+        // SAFETY: `passwd` is a plain C struct for which all-zero bytes are
+        // a valid (if meaningless) value; getpwuid_r fully initializes it
+        // on success.
+        let mut pwd: libc::passwd = unsafe { std::mem::zeroed() };
+        let mut result: *mut libc::passwd = std::ptr::null_mut();
+        // SAFETY: every pointer references a live local; `buf` outlives the
+        // call and its true length is passed alongside it.
+        let rc = unsafe {
+            libc::getpwuid_r(
+                uid,
+                &mut pwd,
+                buf.as_mut_ptr().cast(),
+                buf.len(),
+                &mut result,
+            )
+        };
+        if rc == libc::ERANGE {
+            if buf.len() >= 64 * 1024 {
+                return None;
+            }
+            buf.resize(buf.len() * 2, 0);
+            continue;
+        }
+        if rc != 0 || result.is_null() {
+            return None;
+        }
+        // SAFETY: on success `result` points at `pwd`, whose pw_name is a
+        // NUL-terminated string inside `buf`; both are still live.
+        let name = unsafe { std::ffi::CStr::from_ptr(pwd.pw_name) };
+        return Some(name.to_string_lossy().into_owned());
+    }
+}
+
+pub(crate) struct AcquiredPermit {
+    /// Keeping this `File` open (with FD_CLOEXEC cleared) across the exec
+    /// IS the permit; the kernel releases the flock when the process exits.
+    pub(crate) file: File,
+    pub(crate) name: String,
+    pub(crate) wait_ms: u64,
+}
+
+fn permit_name(class: Class, i: u32) -> String {
+    format!("permit-{}-{i}", class.as_str())
+}
+
+fn demand_name(class: Class) -> String {
+    format!("demand-{}", class.as_str())
+}
+
+/// Open (or, where the directory allows it, create) a lock file. flock(2)
+/// only needs an open fd — read-only is enough against the root-owned 0644
+/// files of a production install; the create fallback serves tempdir rigs
+/// and any user-writable permit dir. Concurrent creators share the inode
+/// (O_CREAT without O_EXCL), so their locks contend correctly.
+fn open_lock_file(path: &Path) -> Option<File> {
+    match OpenOptions::new().read(true).open(path) {
+        Ok(f) => Some(f),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)
+            .ok(),
+        Err(_) => None,
+    }
+}
+
+/// Open whichever of the class's permit files are usable; the ones that
+/// aren't (e.g. counts grown in config without the installer re-run that
+/// mints the new root-owned files) are simply not part of the pool.
+fn open_permits(dir: &Path, class: Class, count: u32) -> Vec<(String, File)> {
+    (0..count)
+        .filter_map(|i| {
+            let name = permit_name(class, i);
+            open_lock_file(&dir.join(&name)).map(|f| (name, f))
+        })
+        .collect()
+}
+
+/// First lockable permit, moved out of the pool.
+fn try_take(pool: &mut Vec<(String, File)>) -> Option<(String, File)> {
+    let idx = pool
+        .iter()
+        .position(|(_, f)| flock::try_lock_exclusive(f))?;
+    Some(pool.swap_remove(idx))
+}
+
+/// Probe the foreign class's demand gate. Success ⇒ no registered waiters
+/// ⇒ borrowing its spare permits is allowed right now.
+fn foreign_has_no_waiters(demand: &File) -> bool {
+    if flock::try_lock_exclusive(demand) {
+        flock::unlock(demand);
+        true
+    } else {
+        false
+    }
+}
+
+/// Acquire one machine-wide compile permit for `class`, waiting as long as
+/// it takes. `None` always means FAIL OPEN (run ungoverned): zero configured
+/// permits, an unusable permit dir, an unregisterable wait, or the kill
+/// switch flipping mid-wait — never "denied".
+pub(crate) fn acquire(cfg: &Config, class: Class, config_path: &Path) -> Option<AcquiredPermit> {
+    if cfg.local_reserved == 0 && cfg.ci_reserved == 0 {
+        return None;
+    }
+    let dir = &cfg.permit_dir;
+    // Production dirs come from the installer; tempdir rigs (and any
+    // user-writable permit_dir) are created on the fly. Failure is fine —
+    // open_lock_file below decides whether anything is actually usable.
+    let _ = fs::create_dir_all(dir);
+
+    let (own_count, foreign_count) = match class {
+        Class::Local => (cfg.local_reserved, cfg.ci_reserved),
+        Class::Ci => (cfg.ci_reserved, cfg.local_reserved),
+    };
+    let mut own = open_permits(dir, class, own_count);
+    let mut foreign = open_permits(dir, class.other(), foreign_count);
+    if own.is_empty() && foreign.is_empty() {
+        // Nothing lockable at all: fail open.
+        return None;
+    }
+
+    let start = Instant::now();
+    let acquired = |start: Instant, (name, file): (String, File)| {
+        Some(AcquiredPermit {
+            file,
+            name,
+            wait_ms: start.elapsed().as_millis() as u64,
+        })
+    };
+
+    // Own-class reservation first.
+    if let Some(p) = try_take(&mut own) {
+        return acquired(start, p);
+    }
+
+    // Borrow the other class's spare capacity — but only through its demand
+    // gate. An unopenable foreign demand file means the gate cannot be
+    // probed: never borrow blind.
+    let foreign_demand = open_lock_file(&dir.join(demand_name(class.other())));
+    if !foreign.is_empty() {
+        if let Some(gate) = &foreign_demand {
+            if foreign_has_no_waiters(gate) {
+                if let Some(p) = try_take(&mut foreign) {
+                    return acquired(start, p);
+                }
+            }
+        }
+    }
+
+    // Nothing free: register demand — LOCK_SH held for the entire wait so
+    // foreign borrowers keep their hands off this class's reservation —
+    // then poll. If demand can't be registered, fail open rather than wait
+    // unregistered: borrowers couldn't see us, and we could starve behind
+    // them indefinitely.
+    let own_demand = open_lock_file(&dir.join(demand_name(class)))?;
+    if !flock::lock_shared_blocking(&own_demand) {
+        return None;
+    }
+    loop {
+        if let Some(p) = try_take(&mut own) {
+            flock::unlock(&own_demand);
+            return acquired(start, p);
+        }
+        if !foreign.is_empty() {
+            if let Some(gate) = &foreign_demand {
+                if foreign_has_no_waiters(gate) {
+                    if let Some(p) = try_take(&mut foreign) {
+                        flock::unlock(&own_demand);
+                        return acquired(start, p);
+                    }
+                }
+            }
+        }
+        // Live kill switch for in-flight waiters too, not just new
+        // invocations: a flipped `enabled = false` (or a deleted config)
+        // unwedges every governed process within one poll tick, fail-open.
+        // Only `enabled` is honored mid-wait; counts/paths stay as loaded.
+        match config::load(config_path) {
+            Some(live) if live.enabled => {}
+            _ => {
+                flock::unlock(&own_demand);
+                return None;
+            }
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn rig(local: u32, ci: u32) -> (tempfile::TempDir, Config, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let permit_dir = tmp.path().join("permits");
+        let cfg = Config {
+            enabled: true,
+            permit_dir: permit_dir.clone(),
+            local_reserved: local,
+            ci_reserved: ci,
+            ci_users: vec!["_intendant-ci".into(), "ci".into()],
+            real_rustc: None,
+        };
+        let config_path = tmp.path().join("governor.toml");
+        std::fs::write(
+            &config_path,
+            format!(
+                "enabled = true\npermit_dir = \"{}\"\nlocal_reserved = {local}\nci_reserved = {ci}\n",
+                permit_dir.display()
+            ),
+        )
+        .unwrap();
+        (tmp, cfg, config_path)
+    }
+
+    #[test]
+    fn classify_matches_ci_users_and_defaults_local() {
+        let cfg = Config::default();
+        assert_eq!(classify(Some("_intendant-ci"), &cfg), Class::Ci);
+        assert_eq!(classify(Some("ci"), &cfg), Class::Ci);
+        assert_eq!(classify(Some("somebody"), &cfg), Class::Local);
+        assert_eq!(classify(None, &cfg), Class::Local);
+    }
+
+    #[test]
+    fn current_username_resolves() {
+        let name = current_username().expect("euid must resolve to a user");
+        assert!(!name.is_empty());
+    }
+
+    #[test]
+    fn acquire_prefers_own_class_then_borrows_idle_foreign() {
+        let (_tmp, cfg, path) = rig(1, 1);
+        let a = acquire(&cfg, Class::Local, &path).unwrap();
+        assert_eq!(a.name, "permit-local-0");
+        // Own class exhausted, no CI demand registered: borrow.
+        let b = acquire(&cfg, Class::Local, &path).unwrap();
+        assert_eq!(b.name, "permit-ci-0");
+        drop(a);
+        // Own reservation is free again and preferred.
+        let c = acquire(&cfg, Class::Local, &path).unwrap();
+        assert_eq!(c.name, "permit-local-0");
+    }
+
+    #[test]
+    fn zero_permits_fails_open() {
+        let (_tmp, cfg, path) = rig(0, 0);
+        assert!(acquire(&cfg, Class::Local, &path).is_none());
+    }
+
+    #[test]
+    fn waiter_respects_foreign_demand_then_takes_own_release() {
+        let (_tmp, cfg, path) = rig(1, 1);
+        let held = acquire(&cfg, Class::Local, &path).unwrap();
+        assert_eq!(held.name, "permit-local-0");
+        // Register CI demand so Local may not borrow the idle CI permit.
+        let demand_ci = open_lock_file(&cfg.permit_dir.join("demand-ci")).unwrap();
+        assert!(flock::lock_shared_blocking(&demand_ci));
+
+        let (cfg2, path2) = (cfg.clone(), path.clone());
+        let waiter = std::thread::spawn(move || acquire(&cfg2, Class::Local, &path2));
+        // Generous settle time; the waiter must still be polling (the CI
+        // permit is free but demand-gated).
+        std::thread::sleep(Duration::from_millis(400));
+        assert!(
+            !waiter.is_finished(),
+            "local waiter must not borrow a contested CI permit"
+        );
+
+        drop(held);
+        let got = waiter
+            .join()
+            .unwrap()
+            .expect("waiter must acquire after release");
+        assert_eq!(got.name, "permit-local-0");
+        flock::unlock(&demand_ci);
+    }
+}

--- a/crates/rustc-governor/src/probe.rs
+++ b/crates/rustc-governor/src/probe.rs
@@ -1,0 +1,157 @@
+//! Probe fast path: classify invocations that may bypass the permit pool
+//! (they still exec the real rustc — bypass is about *waiting*, never about
+//! *what runs*).
+//!
+//! cargo probes the compiler at every startup (`rustc -vV`, and the target
+//! probe `rustc - --crate-name ___ --print=file-names --print=cfg …`), and
+//! sccache runs its own identification probes; none of those may queue
+//! behind a full permit pool or cargo startup wedges whenever the box is
+//! busy. An invocation is probe-only iff it *cannot* compile anything:
+//!
+//! - it asks for the version (`-vV`, `-V`, `--version`), rustc prints and
+//!   exits regardless of other flags; or
+//! - it carries a `--print` request AND no codegen request — no `-o` /
+//!   `--out-dir`, and no `--emit` kind other than `dep-info` (the design
+//!   names link/metadata/obj as codegen; treating every non-`dep-info`
+//!   kind — asm, llvm-ir, … — as codegen is the same rule extended in the
+//!   conservative direction: never bypass something that does real work).
+//!
+//! A real compilation that merely carries `--print` (e.g.
+//! `--print native-static-libs --emit link`) is NOT probe-only.
+//!
+//! Known limitation, accepted: `@argfile` indirection is not expanded.
+//! Without an explicit `--print`/version flag on the command line there is
+//! no bypass at all, so an argfile can only ever cause a probe to be
+//! governed (harmless), never a compile to slip past the pool — unless a
+//! caller mixes an explicit `--print` with codegen flags hidden in an
+//! argfile, which neither cargo nor sccache does.
+
+/// `--emit` kinds that do not make the invocation a compile.
+const NON_CODEGEN_EMIT_KINDS: &[&str] = &["dep-info"];
+
+pub fn is_probe_only(args: &[String]) -> bool {
+    let mut saw_print = false;
+    let mut saw_codegen = false;
+    for (i, arg) in args.iter().enumerate() {
+        match arg.as_str() {
+            "-vV" | "-V" | "--version" => return true,
+            "--print" => saw_print = true,
+            "-o" | "--out-dir" => saw_codegen = true,
+            "--emit" => {
+                if let Some(list) = args.get(i + 1) {
+                    if emit_has_codegen(list) {
+                        saw_codegen = true;
+                    }
+                }
+            }
+            other => {
+                if other.starts_with("--print=") {
+                    saw_print = true;
+                } else if let Some(list) = other.strip_prefix("--emit=") {
+                    if emit_has_codegen(list) {
+                        saw_codegen = true;
+                    }
+                } else if other.starts_with("--out-dir=") {
+                    saw_codegen = true;
+                } else if other.starts_with("-o") && !other.starts_with("--") {
+                    // rustc's only short flag spelled `-o…` is -o itself
+                    // (attached-value form, `-ofile`); -O is a different
+                    // flag and case-sensitive.
+                    saw_codegen = true;
+                }
+            }
+        }
+    }
+    saw_print && !saw_codegen
+}
+
+fn emit_has_codegen(list: &str) -> bool {
+    list.split(',').any(|item| {
+        // Each item is `kind` or `kind=path`.
+        let kind = item.split('=').next().unwrap_or(item).trim();
+        !kind.is_empty() && !NON_CODEGEN_EMIT_KINDS.contains(&kind)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn version_probes_bypass() {
+        assert!(is_probe_only(&args(&["-vV"])));
+        assert!(is_probe_only(&args(&["--version"])));
+        assert!(is_probe_only(&args(&["--version", "--verbose"])));
+        assert!(is_probe_only(&args(&["-V"])));
+    }
+
+    #[test]
+    fn cargo_target_info_probe_bypasses() {
+        // The shape cargo runs on startup: stdin input, several --print
+        // requests, crate-type flags, no codegen.
+        assert!(is_probe_only(&args(&[
+            "-",
+            "--crate-name",
+            "___",
+            "--print=file-names",
+            "--crate-type",
+            "bin",
+            "--crate-type",
+            "rlib",
+            "--print=sysroot",
+            "--print=split-debuginfo",
+            "--print=crate-name",
+            "--print=cfg",
+        ])));
+        assert!(is_probe_only(&args(&["--print", "cfg"])));
+        // dep-info emission alone is not codegen.
+        assert!(is_probe_only(&args(&["--print=cfg", "--emit=dep-info"])));
+    }
+
+    #[test]
+    fn compiles_carrying_print_are_governed() {
+        assert!(!is_probe_only(&args(&[
+            "--print",
+            "native-static-libs",
+            "--emit",
+            "link",
+            "src/main.rs",
+        ])));
+        assert!(!is_probe_only(&args(&[
+            "--print=native-static-libs",
+            "--emit=dep-info,link",
+            "src/main.rs",
+        ])));
+        assert!(!is_probe_only(&args(&["--print=cfg", "--emit=metadata"])));
+        assert!(!is_probe_only(&args(&["--print=sysroot", "-o", "out"])));
+        assert!(!is_probe_only(&args(&["--print=sysroot", "-oout"])));
+        assert!(!is_probe_only(&args(&["--print=cfg", "--out-dir", "d"])));
+        assert!(!is_probe_only(&args(&["--print=cfg", "--out-dir=d"])));
+        // Conservative extension: exotic emit kinds count as codegen too.
+        assert!(!is_probe_only(&args(&["--print=cfg", "--emit=asm"])));
+    }
+
+    #[test]
+    fn ordinary_compiles_are_governed() {
+        assert!(!is_probe_only(&args(&[])));
+        assert!(!is_probe_only(&args(&[
+            "--crate-name",
+            "foo",
+            "--emit=dep-info,metadata,link",
+            "-o",
+            "foo.o",
+            "src/lib.rs",
+        ])));
+        // No --print and no version flag: governed even without codegen
+        // flags.
+        assert!(!is_probe_only(&args(&[
+            "--crate-name",
+            "foo",
+            "src/lib.rs"
+        ])));
+    }
+}

--- a/crates/rustc-governor/tests/acceptance.rs
+++ b/crates/rustc-governor/tests/acceptance.rs
@@ -1,0 +1,655 @@
+//! Acceptance battery for rustc-governor: spawns the real governor binary
+//! (`CARGO_BIN_EXE_rustc-governor` — the standard mechanism, which is why
+//! this crate carries an integration-test file rather than the repo's usual
+//! inline-only tests: a unit test inside the bin target links the libtest
+//! harness `main`, so there is no governor binary to exec) against hermetic
+//! tempdir rigs wired through `INTENDANT_GOVERNOR_CONFIG`. No machine state
+//! is read or mutated: every permit dir, config, marker, and fake HOME
+//! lives in the test's own tempdir, and the only processes signalled are
+//! the ones a test itself spawned.
+//!
+//! Loaded-box tolerance: assertions use generous deadlines (`GENEROUS`) and
+//! never assert that something happened *fast* — only that invariants hold
+//! (ceilings, gates) and that bounded things complete.
+
+#![cfg(unix)]
+
+use std::fs::{File, OpenOptions};
+use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::io::AsRawFd;
+use std::os::unix::process::ExitStatusExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+const GOVERNOR: &str = env!("CARGO_BIN_EXE_rustc-governor");
+/// Deadline for anything that should happen "promptly" — sized for a box
+/// saturated by parallel agents, not for the typical millisecond case.
+const GENEROUS: Duration = Duration::from_secs(15);
+/// How long a should-be-blocked governor is observed before we believe it
+/// is really waiting (several 100ms poll ticks plus load headroom).
+const BLOCKED_OBSERVATION: Duration = Duration::from_millis(1200);
+
+// ---------------------------------------------------------------- rig ----
+
+struct Rig {
+    _tmp: tempfile::TempDir,
+    root: PathBuf,
+    permit_dir: PathBuf,
+}
+
+impl Rig {
+    fn new() -> Rig {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let permit_dir = root.join("permits");
+        std::fs::create_dir_all(&permit_dir).unwrap();
+        Rig {
+            _tmp: tmp,
+            root,
+            permit_dir,
+        }
+    }
+
+    /// Write a config classing the current user per `ci_user_is_me`:
+    /// the tests never depend on which account actually runs them (CI
+    /// fleet accounts are literally named "ci"), so "local" configs list
+    /// an impossible username and "ci" configs list the real one.
+    fn config(
+        &self,
+        name: &str,
+        local: u32,
+        ci: u32,
+        ci_user_is_me: bool,
+        real_rustc: &Path,
+        enabled: bool,
+    ) -> PathBuf {
+        let ci_users = if ci_user_is_me {
+            format!("[\"{}\"]", me())
+        } else {
+            "[\"governor-test-no-such-user\"]".to_string()
+        };
+        let text = format!(
+            "enabled = {enabled}\npermit_dir = \"{}\"\nlocal_reserved = {local}\nci_reserved = {ci}\nci_users = {ci_users}\nreal_rustc = \"{}\"\n",
+            self.permit_dir.display(),
+            real_rustc.display(),
+        );
+        let path = self.root.join(name);
+        std::fs::write(&path, text).unwrap();
+        path
+    }
+
+    fn script(&self, name: &str, body: &str) -> PathBuf {
+        let path = self.root.join(name);
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).unwrap();
+        path
+    }
+
+    fn permit(&self, name: &str) -> PathBuf {
+        self.permit_dir.join(name)
+    }
+
+    fn log(&self) -> String {
+        std::fs::read_to_string(self.permit_dir.join("governor.log")).unwrap_or_default()
+    }
+}
+
+fn me() -> String {
+    let out = Command::new("id").arg("-un").output().unwrap();
+    String::from_utf8(out.stdout).unwrap().trim().to_string()
+}
+
+fn spawn_governor(config: &Path, args: &[&str], envs: &[(&str, &str)]) -> Child {
+    let mut cmd = Command::new(GOVERNOR);
+    cmd.args(args)
+        .env("INTENDANT_GOVERNOR_CONFIG", config)
+        // Hygiene: never inherit an operator kill switch into the rig.
+        .env_remove("INTENDANT_GOVERNOR")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.spawn().unwrap()
+}
+
+// ------------------------------------------------------- flock helpers ----
+
+fn open_rw(path: &Path) -> File {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+        .unwrap()
+}
+
+fn flock_nb(file: &File, op: libc::c_int) -> bool {
+    // SAFETY: `file` owns an open fd for the duration of the call.
+    unsafe { libc::flock(file.as_raw_fd(), op) == 0 }
+}
+
+/// Take LOCK_EX|LOCK_NB and keep holding it (dropping the File releases).
+fn hold_exclusive(path: &Path) -> File {
+    let f = open_rw(path);
+    assert!(
+        flock_nb(&f, libc::LOCK_EX | libc::LOCK_NB),
+        "test rig could not take {path:?}"
+    );
+    f
+}
+
+/// Register demand the way a waiter does: LOCK_SH held until dropped.
+fn hold_shared(path: &Path) -> File {
+    let f = open_rw(path);
+    assert!(flock_nb(&f, libc::LOCK_SH | libc::LOCK_NB));
+    f
+}
+
+/// True iff someone currently holds the file exclusively (probe + release).
+fn is_exclusively_locked(path: &Path) -> bool {
+    let f = open_rw(path);
+    if flock_nb(&f, libc::LOCK_EX | libc::LOCK_NB) {
+        flock_nb(&f, libc::LOCK_UN);
+        false
+    } else {
+        true
+    }
+}
+
+// ------------------------------------------------------- wait helpers ----
+
+fn wait_deadline(child: &mut Child, deadline: Duration) -> Option<ExitStatus> {
+    let t0 = Instant::now();
+    while t0.elapsed() < deadline {
+        if let Some(status) = child.try_wait().unwrap() {
+            return Some(status);
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    None
+}
+
+/// Assert the child keeps running for the whole observation window.
+fn assert_still_running_for(child: &mut Child, window: Duration) {
+    let t0 = Instant::now();
+    while t0.elapsed() < window {
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "process exited while it should have been waiting for a permit"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn wait_for<F: FnMut() -> bool>(mut cond: F, deadline: Duration, what: &str) {
+    let t0 = Instant::now();
+    while t0.elapsed() < deadline {
+        if cond() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    panic!("timed out waiting for {what}");
+}
+
+fn kill_and_reap(mut child: Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+// ------------------------------------------------------------- tests ----
+
+/// (a) Global ceiling: with local=1 + ci=2, eight concurrent governed
+/// invocations never exceed three simultaneous holders. Concurrency is
+/// measured from the fixture's own start/end event stream (atomic O_APPEND
+/// lines), not wall clocks, so load can stretch time without lying to us.
+#[test]
+fn global_ceiling_bounds_concurrent_holders() {
+    let rig = Rig::new();
+    let events = rig.root.join("events");
+    let script = rig.script(
+        "job.sh",
+        &format!(
+            "echo start >> {ev}\nsleep 0.4\necho end >> {ev}",
+            ev = events.display()
+        ),
+    );
+    let config = rig.config("gov.toml", 1, 2, false, &script, true);
+
+    let mut kids: Vec<Child> = (0..8).map(|_| spawn_governor(&config, &[], &[])).collect();
+    let overall = Instant::now();
+    for child in &mut kids {
+        let left = Duration::from_secs(45)
+            .checked_sub(overall.elapsed())
+            .unwrap_or_default();
+        let status = wait_deadline(child, left).expect("governed job must finish");
+        assert!(status.success());
+    }
+
+    let text = std::fs::read_to_string(&events).unwrap();
+    let (mut current, mut max, mut starts, mut ends) = (0_i32, 0_i32, 0, 0);
+    for line in text.lines() {
+        match line {
+            "start" => {
+                current += 1;
+                starts += 1;
+                max = max.max(current);
+            }
+            "end" => {
+                current -= 1;
+                ends += 1;
+            }
+            other => panic!("unexpected event line {other:?}"),
+        }
+    }
+    assert_eq!((starts, ends), (8, 8));
+    assert!(
+        max <= 3,
+        "ceiling violated: {max} concurrent compile holders (total permits = 3)"
+    );
+}
+
+/// (b) Idle borrowing: with the local reservation exhausted and no CI
+/// demand registered, a local invocation takes a CI-reserved permit.
+#[test]
+fn idle_borrowing_takes_foreign_permit() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let config = rig.config("gov.toml", 1, 2, false, &script, true);
+
+    let _local_held = hold_exclusive(&rig.permit("permit-local-0"));
+    let mut child = spawn_governor(&config, &[], &[]);
+    let status = wait_deadline(&mut child, GENEROUS).expect("borrower must not wait");
+    assert!(status.success());
+    assert!(marker.exists());
+    let log = rig.log();
+    let line = log.lines().last().unwrap_or_default();
+    assert!(
+        line.contains("class=local") && line.contains("permit=permit-ci-"),
+        "expected a borrowed CI permit in the log, got: {line:?}"
+    );
+}
+
+/// (c) Contested split, local side: with CI waiters registered (LOCK_SH on
+/// demand-ci), a local invocation must NOT take a free CI-reserved permit —
+/// it waits for its own class.
+#[test]
+fn contested_ci_reserve_is_not_borrowed_by_local() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let config = rig.config("gov.toml", 1, 2, false, &script, true);
+
+    let local_held = hold_exclusive(&rig.permit("permit-local-0"));
+    // Pre-create the CI permits so their freeness is observable.
+    let (ci0, ci1) = (rig.permit("permit-ci-0"), rig.permit("permit-ci-1"));
+    let (_c0, _c1) = (open_rw(&ci0), open_rw(&ci1));
+    let _ci_waiters = hold_shared(&rig.permit("demand-ci"));
+
+    let mut child = spawn_governor(&config, &[], &[]);
+    assert_still_running_for(&mut child, BLOCKED_OBSERVATION);
+    assert!(
+        !marker.exists(),
+        "governed job ran while it should be waiting"
+    );
+    assert!(
+        !is_exclusively_locked(&ci0) && !is_exclusively_locked(&ci1),
+        "local invocation touched a contested CI reserve"
+    );
+
+    drop(local_held);
+    let status = wait_deadline(&mut child, GENEROUS).expect("waiter must acquire after release");
+    assert!(status.success());
+    assert!(marker.exists());
+    let log = rig.log();
+    assert!(
+        log.lines()
+            .last()
+            .unwrap_or_default()
+            .contains("permit=permit-local-0"),
+        "must have won its own class's permit: {log:?}"
+    );
+}
+
+/// (c) Contested split, CI side: symmetric — local demand protects the
+/// local reservation from CI borrowers.
+#[test]
+fn contested_local_reserve_is_not_borrowed_by_ci() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let config = rig.config("gov.toml", 1, 2, true, &script, true);
+
+    let ci_held_0 = hold_exclusive(&rig.permit("permit-ci-0"));
+    let _ci_held_1 = hold_exclusive(&rig.permit("permit-ci-1"));
+    let local0 = rig.permit("permit-local-0");
+    let _l0 = open_rw(&local0);
+    let _local_waiters = hold_shared(&rig.permit("demand-local"));
+
+    let mut child = spawn_governor(&config, &[], &[]);
+    assert_still_running_for(&mut child, BLOCKED_OBSERVATION);
+    assert!(!marker.exists());
+    assert!(
+        !is_exclusively_locked(&local0),
+        "CI invocation touched a contested local reserve"
+    );
+
+    drop(ci_held_0);
+    let status = wait_deadline(&mut child, GENEROUS).expect("waiter must acquire after release");
+    assert!(status.success());
+    let log = rig.log();
+    let line = log.lines().last().unwrap_or_default();
+    assert!(
+        line.contains("class=ci") && line.contains("permit=permit-ci-"),
+        "must have won a CI permit: {line:?}"
+    );
+}
+
+/// (d) No starvation: a waiter acquires within a bounded time of permits
+/// freeing.
+#[test]
+fn waiter_acquires_promptly_after_release() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let config = rig.config("gov.toml", 1, 0, false, &script, true);
+
+    let held = hold_exclusive(&rig.permit("permit-local-0"));
+    let mut child = spawn_governor(&config, &[], &[]);
+    assert_still_running_for(&mut child, Duration::from_millis(400));
+    drop(held);
+    let status = wait_deadline(&mut child, GENEROUS).expect("waiter starved");
+    assert!(status.success());
+    let log = rig.log();
+    let line = log.lines().last().unwrap_or_default();
+    assert!(
+        line.contains("wait_ms="),
+        "log must carry the wait: {line:?}"
+    );
+}
+
+/// (e) Crash release: SIGKILL a permit holder — the flock evaporates with
+/// the process and the permit is immediately acquirable.
+#[test]
+fn sigkilled_holder_releases_its_permit() {
+    let rig = Rig::new();
+    let ready = rig.root.join("ready");
+    let script = rig.script(
+        "hold.sh",
+        &format!(
+            "echo ready >> {}\nwhile :; do sleep 0.05; done",
+            ready.display()
+        ),
+    );
+    let config = rig.config("gov.toml", 1, 0, false, &script, true);
+    let permit = rig.permit("permit-local-0");
+
+    let mut child = spawn_governor(&config, &[], &[]);
+    wait_for(|| ready.exists(), GENEROUS, "holder to start");
+    assert!(is_exclusively_locked(&permit));
+    child.kill().unwrap();
+    child.wait().unwrap();
+    wait_for(
+        || !is_exclusively_locked(&permit),
+        GENEROUS,
+        "permit release after SIGKILL",
+    );
+
+    // And a fresh governed invocation can take it end to end.
+    let marker = rig.root.join("marker");
+    let quick = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let config2 = rig.config("gov2.toml", 1, 0, false, &quick, true);
+    let mut second = spawn_governor(&config2, &[], &[]);
+    assert!(wait_deadline(&mut second, GENEROUS).unwrap().success());
+    assert!(marker.exists());
+}
+
+/// (f) The flock survives exec(2): once the exec'd fixture is running (it
+/// wrote `ready`), the permit must still be held — FD_CLOEXEC was cleared —
+/// and it frees when that fixture exits.
+#[test]
+fn permit_lock_survives_exec() {
+    let rig = Rig::new();
+    let ready = rig.root.join("ready");
+    let stop = rig.root.join("stop");
+    let script = rig.script(
+        "until_stop.sh",
+        &format!(
+            "echo ready >> {r}\nwhile [ ! -e {s} ]; do sleep 0.05; done",
+            r = ready.display(),
+            s = stop.display()
+        ),
+    );
+    let config = rig.config("gov.toml", 1, 0, false, &script, true);
+    let permit = rig.permit("permit-local-0");
+
+    let mut child = spawn_governor(&config, &[], &[]);
+    wait_for(|| ready.exists(), GENEROUS, "exec'd fixture to start");
+    // The shell fixture is the post-exec process image; the lock must have
+    // ridden through the exec.
+    assert!(
+        is_exclusively_locked(&permit),
+        "permit lock did not survive exec (FD_CLOEXEC not cleared?)"
+    );
+    std::fs::write(&stop, b"").unwrap();
+    assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
+    wait_for(
+        || !is_exclusively_locked(&permit),
+        GENEROUS,
+        "permit release on exit",
+    );
+}
+
+/// (g) Exit status propagates through the exec.
+#[test]
+fn exit_status_propagates() {
+    let rig = Rig::new();
+    let script = rig.script("exit42.sh", "exit 42");
+    let config = rig.config("gov.toml", 1, 0, false, &script, true);
+    let mut child = spawn_governor(&config, &[], &[]);
+    let status = wait_deadline(&mut child, GENEROUS).unwrap();
+    assert_eq!(status.code(), Some(42));
+}
+
+/// (g) Signal disposition propagates: after the exec, the spawned pid IS
+/// the governed program — SIGTERM to it is reflected in the wait status.
+#[test]
+fn signal_disposition_propagates() {
+    let rig = Rig::new();
+    let ready = rig.root.join("ready");
+    let script = rig.script(
+        "hold.sh",
+        &format!(
+            "echo ready >> {}\nwhile :; do sleep 0.05; done",
+            ready.display()
+        ),
+    );
+    let config = rig.config("gov.toml", 1, 0, false, &script, true);
+    let mut child = spawn_governor(&config, &[], &[]);
+    wait_for(|| ready.exists(), GENEROUS, "fixture to start");
+    // SAFETY: pid was spawned by this test and not yet reaped; kill(2)
+    // takes only the pid and signal number.
+    let rc = unsafe { libc::kill(child.id() as libc::pid_t, libc::SIGTERM) };
+    assert_eq!(rc, 0);
+    let status = wait_deadline(&mut child, GENEROUS).unwrap();
+    assert_eq!(status.signal(), Some(libc::SIGTERM));
+}
+
+/// (h) Probe fast path: version and pure --print invocations complete while
+/// every permit is held AND both classes have registered waiters; a real
+/// compile carrying --print does not.
+#[test]
+fn probe_fast_path_ignores_exhausted_pool() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let script = rig.script("probe.sh", &format!("echo probed >> {}", marker.display()));
+    let config = rig.config("gov.toml", 1, 2, false, &script, true);
+
+    let _p0 = hold_exclusive(&rig.permit("permit-local-0"));
+    let _p1 = hold_exclusive(&rig.permit("permit-ci-0"));
+    let _p2 = hold_exclusive(&rig.permit("permit-ci-1"));
+    let _d0 = hold_shared(&rig.permit("demand-local"));
+    let _d1 = hold_shared(&rig.permit("demand-ci"));
+
+    let mut version = spawn_governor(&config, &["-vV"], &[]);
+    assert!(wait_deadline(&mut version, GENEROUS).unwrap().success());
+    let mut print = spawn_governor(&config, &["--print", "cfg"], &[]);
+    assert!(wait_deadline(&mut print, GENEROUS).unwrap().success());
+    let text = std::fs::read_to_string(&marker).unwrap();
+    assert_eq!(text.lines().count(), 2, "both probes must have exec'd");
+
+    // Negative: a compile that merely carries --print is governed — it must
+    // wait behind the exhausted pool, not bypass.
+    let mut governed = spawn_governor(
+        &config,
+        &[
+            "--print",
+            "native-static-libs",
+            "--emit=metadata,link",
+            "lib.rs",
+        ],
+        &[],
+    );
+    assert_still_running_for(&mut governed, BLOCKED_OBSERVATION);
+    assert_eq!(
+        std::fs::read_to_string(&marker).unwrap().lines().count(),
+        2,
+        "a governed compile bypassed the pool"
+    );
+    kill_and_reap(governed);
+}
+
+/// (i) Live kill switch: flipping `enabled = false` mid-flight makes the
+/// next invocation bypass immediately — and unwedges in-flight waiters
+/// within a poll tick (both fail open, permits untouched).
+#[test]
+fn kill_switch_flips_live() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let config = rig.config("gov.toml", 1, 0, false, &script, true);
+
+    let _held = hold_exclusive(&rig.permit("permit-local-0"));
+    let mut waiter = spawn_governor(&config, &[], &[]);
+    assert_still_running_for(&mut waiter, Duration::from_millis(600));
+
+    // Flip the switch in place (same path the running waiter re-reads).
+    rig.config("gov.toml", 1, 0, false, &script, false);
+
+    let status = wait_deadline(&mut waiter, GENEROUS).expect("waiter must unwedge, fail-open");
+    assert!(status.success());
+    let mut next = spawn_governor(&config, &[], &[]);
+    assert!(wait_deadline(&mut next, GENEROUS).unwrap().success());
+    assert_eq!(std::fs::read_to_string(&marker).unwrap().lines().count(), 2);
+}
+
+/// Fail-open: no config at the configured path — the governor skips permits
+/// and execs the real rustc resolved via $HOME/.cargo/bin/rustc.
+#[test]
+fn missing_config_fails_open_via_default_chain() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let home = rig.root.join("home");
+    let bin = home.join(".cargo").join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let fake_rustc = bin.join("rustc");
+    std::fs::write(
+        &fake_rustc,
+        format!("#!/bin/sh\necho fake >> {}\n", marker.display()),
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&fake_rustc).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&fake_rustc, perms).unwrap();
+
+    let missing = rig.root.join("no-such-config.toml");
+    let mut child = spawn_governor(
+        &missing,
+        &["--crate-name", "x"],
+        &[("HOME", home.to_str().unwrap())],
+    );
+    assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
+    assert!(marker.exists(), "fail-open must still exec the real rustc");
+}
+
+/// Fail-open: an unparseable config behaves exactly like a missing one.
+#[test]
+fn unparseable_config_fails_open() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let home = rig.root.join("home");
+    let bin = home.join(".cargo").join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let fake_rustc = bin.join("rustc");
+    std::fs::write(
+        &fake_rustc,
+        format!("#!/bin/sh\necho fake >> {}\n", marker.display()),
+    )
+    .unwrap();
+    let mut perms = std::fs::metadata(&fake_rustc).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&fake_rustc, perms).unwrap();
+
+    let config = rig.root.join("broken.toml");
+    std::fs::write(&config, "enabled = maybe\n").unwrap();
+    let mut child = spawn_governor(&config, &[], &[("HOME", home.to_str().unwrap())]);
+    assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
+    assert!(marker.exists());
+}
+
+/// Fail-open: the secondary per-invocation env override.
+#[test]
+fn env_off_bypasses_permits() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let config = rig.config("gov.toml", 1, 0, false, &script, true);
+    let _held = hold_exclusive(&rig.permit("permit-local-0"));
+    let mut child = spawn_governor(&config, &[], &[("INTENDANT_GOVERNOR", "off")]);
+    assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
+    assert!(marker.exists());
+}
+
+/// Fail-open: a config with zero permits governs nothing.
+#[test]
+fn zero_permits_fails_open() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let config = rig.config("gov.toml", 0, 0, false, &script, true);
+    let mut child = spawn_governor(&config, &[], &[]);
+    assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
+    assert!(marker.exists());
+}
+
+/// Misconfiguration guard: real_rustc pointing back at the governor must
+/// refuse (exit 127) instead of exec-looping into a fork bomb.
+#[test]
+fn refuses_to_exec_itself() {
+    let rig = Rig::new();
+    let config = rig.config("gov.toml", 1, 0, false, Path::new(GOVERNOR), true);
+    let mut child = Command::new(GOVERNOR)
+        .env("INTENDANT_GOVERNOR_CONFIG", &config)
+        .env_remove("INTENDANT_GOVERNOR")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let status = wait_deadline(&mut child, GENEROUS).unwrap();
+    assert_eq!(status.code(), Some(127));
+    let mut stderr = String::new();
+    child
+        .stderr
+        .take()
+        .unwrap()
+        .read_to_string(&mut stderr)
+        .unwrap();
+    assert!(stderr.contains("refusing to exec itself"), "{stderr:?}");
+}

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -87,6 +87,103 @@ Future watchdog enhancement (not yet implemented): gate listener
 resume on `memory_pressure` in addition to disk, so a swap storm
 pauses assignment the way a full disk does.
 
+The jobs cap is per-*process*; bounding what all cargo processes on the
+box can demand **together** is the governor's job — next section.
+
+## Governor: machine-wide rustc concurrency (`rustc-governor`)
+
+The jobs cap cannot stop several concurrent cargo processes (two CI
+listeners plus interactive agents) from each spawning their capped six:
+concurrent cold builds still oversubscribe RAM, and the link storm →
+swap → `kernel_task` throttle spiral follows. `crates/rustc-governor`
+adds the missing machine-wide bound: a compile-permit pool shared by
+every account on the box.
+
+### The chain
+
+```
+cargo ──[build] rustc=governor──▶ sccache client ──▶ sccache server
+                                        │  cache hit: reply from cache —
+                                        │  the "compiler" never executes
+                                        ▼  miss / non-cacheable
+                                  rustc-governor
+                                        │  acquire flock(2) permit
+                                        ▼
+                                  exec(2) real rustc   (permit rides the
+                                                        fd until exit)
+```
+
+`[build] rustc` points at the governor while `rustc-wrapper` stays
+sccache, so sccache treats the governor as *the compiler*:
+
+- **Hits never wait** — sccache answers cache hits without executing
+  the compiler at all, so warm builds feel no governor.
+- **Probes never wait** — `-vV` / `--version` / pure `--print` queries
+  (cargo fires them at every startup, sccache when identifying the
+  compiler) bypass the pool via the probe fast path. A real compile
+  that merely *carries* `--print` (e.g. `--print native-static-libs`
+  with `--emit link`) is still governed.
+- Everything else acquires one machine-wide permit, then `exec(2)`s
+  the real rustc: exit status and signal disposition are inherited by
+  construction, and the permit's flock rides the FD_CLOEXEC-cleared fd
+  until that rustc exits — any exit, including SIGKILL, releases it in
+  the kernel (crash release is structural, nothing to clean up).
+
+### Permits and the demand gate
+
+`permit_dir` holds one flock file per permit, split into per-class
+reservations — `permit-local-<i>` for interactive accounts,
+`permit-ci-<i>` for the accounts in `ci_users` — plus one demand file
+per class (`demand-local` / `demand-ci`). Holding LOCK_EX on a permit
+file IS the permit. Waiters hold LOCK_SH on their own class's demand
+file for the whole wait and poll every eligible permit at 100ms
+(never a blocking flock — it has no timeout and would bypass the gate).
+Borrowing: before touching a foreign-class permit, probe that class's
+demand file with LOCK_EX|LOCK_NB — success (released immediately)
+means no waiters, so idle capacity is never wasted; failure means the
+class has waiters and its reservation is honored. Nothing is ever
+killed or signalled; borrowed permits return naturally when their
+holder exits.
+
+### Fail-open doctrine + live kill switch
+
+A governor must never break a build. Missing or unparseable config,
+`enabled = false`, `INTENDANT_GOVERNOR=off` in the env, an unusable
+permit dir, zero configured permits — every degraded state means "run
+ungoverned", never "block". The config is re-read by every invocation
+(and once per poll tick by in-flight waiters), so
+`/usr/local/etc/intendant-governor.toml` is live: flipping
+`enabled = false` drains the governor within ~100ms, no listener
+restarts. Observability: one line per *governed* invocation in
+`<permit_dir>/governor.log` (timestamp, pid, class, permit, wait_ms;
+truncate-in-place rotation at 1MB keeping the last 256K — the hooks-log
+doctrine, because governed accounts can write the pre-created file but
+not create siblings in the root-owned dir).
+
+### Sizing, install, rollout
+
+Per box: `local_reserved + ci_reserved` = the machine-wide ceiling of
+concurrent rustc processes; the per-account jobs cap still bounds any
+single cargo underneath it. The 24GB two-listener Mac runs 1 + 2.
+Don't set a class to 0 unless it truly never compiles — its members
+would then depend entirely on borrowing.
+
+```bash
+cargo build --release -p rustc-governor
+sudo scripts/ci/install-governor-macos.sh   # binary + permit dir + conf
+```
+
+The installer never edits account cargo configs; it prints the
+`[build] rustc = ".../rustc-governor"` line to add per account.
+**Canary order: the CI account first, soak a day of green runs, then
+the operator account.** Known accepted cost: sccache hashes the
+compiler binary — the governor — into its cache keys, so enablement
+and every governor upgrade invalidate that account's sccache cache
+once (one cold rebuild, warm again after). Resizing the reservations
+upward needs the installer re-run (or a root `touch` + `chmod 0644`)
+to mint the new permit files; permit files the governor cannot open
+are simply not part of the pool, and if none are usable it fails open.
+
 ## macOS CI service account (`_intendant-ci`)
 
 **Why:** CI jobs on the Mac listeners historically executed as the
@@ -292,3 +389,14 @@ before-images land in `/etc/intendant-ci/migration/` for audit.
   `RUNNER_DAEMON_LABELS`, multi-account `RUNNER_USER`). Change the
   conf schema, change `migrate-runner-macos.sh` /
   `rollback-runner-macos.sh` in the same commit.
+- The governor's permit/demand file names and permissions are minted
+  by `install-governor-macos.sh` but consumed by
+  `crates/rustc-governor/src/permits.rs` (non-root accounts cannot
+  create files in the root-owned permit dir). Change the naming or the
+  file ACLs in one, change both.
+- The governor's config keys (`enabled`, `permit_dir`,
+  `local_reserved`, `ci_reserved`, `ci_users`, `real_rustc`) are
+  written by the installer's here-doc and parsed by
+  `crates/rustc-governor/src/config.rs` — a minimal TOML-subset
+  reader, so keep the conf flat `key = value` (unknown keys are
+  ignored; malformed lines make the whole file fail open).

--- a/scripts/ci/install-governor-macos.sh
+++ b/scripts/ci/install-governor-macos.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Install the machine-wide rustc concurrency governor on a macOS box
+# (run with sudo from a repo checkout:
+#   sudo scripts/ci/install-governor-macos.sh [path/to/rustc-governor]).
+#
+# Builds nothing: takes a prebuilt binary (default target/release/rustc-governor,
+# from `cargo build --release -p rustc-governor`). Idempotent: re-running
+# upgrades the binary and tops up permit files for the *effective* config,
+# and never overwrites an existing /usr/local/etc/intendant-governor.toml —
+# that file is live operator state (the kill switch lives in it).
+#
+# Deliberately does NOT touch any account's ~/.cargo/config.toml: the
+# governor stays inert until an account's cargo points at it, and the
+# operator canaries the CI account before wiring their own. This script
+# only prints the lines to add. Doc: scripts/ci/README.md, "Governor".
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "run with sudo" >&2
+    exit 1
+fi
+
+BIN_SRC="${1:-target/release/rustc-governor}"
+if [ ! -f "$BIN_SRC" ]; then
+    echo "no governor binary at $BIN_SRC — build one first: cargo build --release -p rustc-governor" >&2
+    exit 1
+fi
+
+LIB_BIN_DIR="/usr/local/lib/intendant-ci/bin"
+CONF="/usr/local/etc/intendant-governor.toml"
+PERMIT_DIR_DEFAULT="/usr/local/var/intendant-governor"
+
+install -d -m 0755 "$LIB_BIN_DIR" /usr/local/etc
+install -m 0755 "$BIN_SRC" "$LIB_BIN_DIR/rustc-governor"
+echo "installed $LIB_BIN_DIR/rustc-governor"
+
+if [ ! -f "$CONF" ]; then
+    cat > "$CONF" <<'CONF_EOF'
+# Machine-wide rustc concurrency governor (rustc-governor) — live config.
+# Every governed rustc invocation re-reads this file, so edits take effect
+# immediately: `enabled = false` is the kill switch (no listener restarts;
+# in-flight waiters fail open within one poll tick). A missing or
+# unparseable file also fails OPEN — builds run ungoverned, never break.
+# Doc: scripts/ci/README.md ("Governor") in the Intendant repo.
+enabled = true
+permit_dir = "/usr/local/var/intendant-governor"
+# Per-box sizing: local_reserved + ci_reserved = the machine-wide ceiling
+# of concurrent rustc processes. This Mac (24GB, two CI listeners plus
+# interactive agents): 1 local + 2 CI.
+local_reserved = 1
+ci_reserved = 2
+ci_users = ["_intendant-ci", "ci"]
+# real_rustc = "/absolute/path/to/rustc"   # optional; default resolution is
+#                                          # $HOME/.cargo/bin/rustc, else PATH
+CONF_EOF
+    chmod 0644 "$CONF"
+    echo "wrote $CONF"
+else
+    echo "keeping existing $CONF (live operator state — edit by hand)"
+fi
+
+# Pre-create the flock files for the *effective* config (an existing conf
+# wins over the defaults above). Non-root accounts can flock(2) a 0644
+# root-owned file through a read-only open, but cannot create files in the
+# 0755 root dir — the installer owns creation. File names mirror
+# crates/rustc-governor/src/permits.rs (interlock: change both together).
+permit_dir=$(sed -n 's/^permit_dir[[:space:]]*=[[:space:]]*"\(.*\)".*$/\1/p' "$CONF" | tail -n 1)
+local_n=$(sed -n 's/^local_reserved[[:space:]]*=[[:space:]]*\([0-9][0-9]*\).*$/\1/p' "$CONF" | tail -n 1)
+ci_n=$(sed -n 's/^ci_reserved[[:space:]]*=[[:space:]]*\([0-9][0-9]*\).*$/\1/p' "$CONF" | tail -n 1)
+permit_dir="${permit_dir:-$PERMIT_DIR_DEFAULT}"
+local_n="${local_n:-1}"
+ci_n="${ci_n:-2}"
+
+install -d -m 0755 "$permit_dir"
+create_lock_file() {
+    [ -f "$1" ] || : > "$1"
+    chown root:wheel "$1"
+    chmod 0644 "$1"
+}
+i=0
+while [ "$i" -lt "$local_n" ]; do
+    create_lock_file "$permit_dir/permit-local-$i"
+    i=$((i + 1))
+done
+i=0
+while [ "$i" -lt "$ci_n" ]; do
+    create_lock_file "$permit_dir/permit-ci-$i"
+    i=$((i + 1))
+done
+create_lock_file "$permit_dir/demand-local"
+create_lock_file "$permit_dir/demand-ci"
+# Every governed account appends to (and rotates) the log: world-writable.
+[ -f "$permit_dir/governor.log" ] || : > "$permit_dir/governor.log"
+chown root:wheel "$permit_dir/governor.log"
+chmod 0666 "$permit_dir/governor.log"
+echo "permit dir ready: $permit_dir (local=$local_n ci=$ci_n)"
+
+cat <<'NEXT_EOF'
+
+The governor is installed but INERT: no account uses it until its cargo
+config points at it. For each account to govern, add under the EXISTING
+[build] table in that account's ~/.cargo/config.toml (keep the
+rustc-wrapper = sccache line exactly as it is):
+
+[build]
+rustc = "/usr/local/lib/intendant-ci/bin/rustc-governor"
+
+Rollout order (see scripts/ci/README.md "Governor"): the CI account
+first, soak a day of green runs, then the operator account.
+
+Notes:
+- sccache hashes the compiler binary (the governor) into its cache keys:
+  first enablement — and every governor upgrade — invalidates that
+  account's sccache cache once.
+- Kill switch: set `enabled = false` in /usr/local/etc/intendant-governor.toml
+  (immediate, machine-wide); removing the rustc= line fully unwires an account.
+- Watch it: tail -f /usr/local/var/intendant-governor/governor.log
+NEXT_EOF


### PR DESCRIPTION
The governor wave, as reviewed and amended with the side agent's requirements. A 504KB shim wired as cargo's RUSTC (wrapper stays sccache): sccache executes it only on cache misses/non-cacheable requests, so **hits and probes never wait**; on real compiles it takes one of the machine's flock permits (auto-released on any death), clears FD_CLOEXEC (std opens O_CLOEXEC — a naive exec would drop the lock mid-compile), and execs the real rustc, inheriting exit status and signal disposition by construction.

Class policy without a scheduler: own-class permits first; borrowing gated on the other class's demand file (waiters hold LOCK_SH; borrowers probe EX|NB) — reservation, borrowing, and natural hand-back with zero shared mutable state. Fail-open everywhere (missing/unparseable config, env override, zero permits); the config file is a **live kill switch** re-read every invocation and every 100ms poll tick, so it unwedges in-flight waiters too. Probe classification is strict both ways (`--print native-static-libs --emit link` stays governed).

41/41 hermetic acceptance tests (ceiling, borrowing, contested split, starvation bound, SIGKILL release, lock-survives-exec, exit/signal propagation, probe latency under a fully-held pool, kill switch, fail-opens, self-exec guard) + full workspace battery green (3031 tests, clippy zero, fmt clean). Not wired anywhere by this PR — the installer (`scripts/ci/install-governor-macos.sh`) and per-account `[build] rustc` lines are operator steps, canaried CI-account-first per the README's Governor section. Known accepted cost: sccache hashes the shim, so each governor update invalidates the compile cache once.