### PR TITLE
clippy: zero the Linux-cfg surface; flip the gate to -D warnings

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -360,20 +360,23 @@ jobs:
         run: cargo test -p intendant --test e2e --locked --target ${{ matrix.target }}
 
       # ── Quality gates (Linux leg; baselines zeroed 2026-07-11) ──────
-      # fmt is platform-independent, so one leg suffices and it is a
-      # hard gate. clippy is cfg-sensitive: the zero baseline was cut on
-      # macOS, so the Linux-only cfg surface is unproven — the step
-      # reports warnings without failing until its first runs prove the
-      # Linux delta is zero, then it flips to -D warnings (tracked in
-      # the CI hardening program). Both ride the required Linux context;
-      # no ruleset change.
+      # fmt is platform-independent, so one leg suffices. clippy is
+      # cfg-sensitive: the macOS-cut baseline left the Linux-only cfg
+      # surface unproven, so it started report-only; the Linux delta was
+      # zeroed (30 warnings — cfg-shadowed dead code gated, mechanical
+      # rewrites, established-signature allows) and verified with the
+      # exact gate incantation on the fleet's Linux toolchain in the
+      # same change that flipped this to -D warnings. Both ride the
+      # required Linux context; no ruleset change. Non-test targets
+      # only: --all-targets has its own unzeroed baseline (tracked in
+      # the CI hardening program).
       - name: cargo fmt --check
         if: runner.os == 'Linux' && steps.relevance_unix.outputs.relevant != 'false'
         run: cargo fmt --all --check
 
-      - name: cargo clippy (report-only until the Linux delta is proven zero)
+      - name: cargo clippy (-D warnings)
         if: runner.os == 'Linux' && steps.relevance_unix.outputs.relevant != 'false'
-        run: cargo clippy --workspace --locked --target ${{ matrix.target }} || true
+        run: cargo clippy --workspace --locked --target ${{ matrix.target }} -- -D warnings
 
       # ── Linux gate tail: keyless smokes + dashboard-boot ──────────────
       # Formerly smokes.yml's two jobs (deleted 2026-07-11 — coverage

--- a/crates/intendant-display/src/encode/h264_linux.rs
+++ b/crates/intendant-display/src/encode/h264_linux.rs
@@ -287,8 +287,8 @@ impl FfmpegH264Encoder {
             Err(e) => return Err(format!("ffmpeg wait: {e}")),
         }
 
-        let uv_w = ((width + 1) / 2) as usize;
-        let uv_h = ((height + 1) / 2) as usize;
+        let uv_w = width.div_ceil(2) as usize;
+        let uv_h = height.div_ceil(2) as usize;
         let frame_size = (width as usize * height as usize) + 2 * (uv_w * uv_h);
 
         // Spawn a dedicated reader thread that reads ffmpeg stdout in
@@ -504,11 +504,8 @@ impl Encoder for FfmpegH264Encoder {
             .iter()
             .any(|n| n.nal_type == 1 || n.nal_type == 5);
 
-        loop {
-            let nal = match self.nal_rx.try_recv() {
-                Ok(n) => n,
-                Err(_) => break, // no more NALs right now
-            };
+        // Drain until the channel is empty (`Err` = no more NALs right now).
+        while let Ok(nal) = self.nal_rx.try_recv() {
             // Cache parameter sets as they flow through. libx264 emits
             // SPS+PPS at stream start (and on encoder resets), so the
             // cache populates on the first complete IDR access unit and
@@ -591,8 +588,8 @@ impl Drop for FfmpegH264Encoder {
 /// `GOP_PERIOD_FRAMES` frames. At the 30 fps feed rate, 60 frames is a
 /// keyframe every ~2 s — short enough that a fresh peer or a
 /// post-loss-burst decoder recovers promptly, long enough that periodic
-/// IDRs don't dominate the bitrate. Combined with the quarter-resolution
-/// + capped-bitrate federated layer (`encode/pool/types.rs`), each such IDR is
+/// IDRs don't dominate the bitrate. Combined with the quarter-resolution +
+/// capped-bitrate federated layer (`encode/pool/types.rs`), each such IDR is
 /// only a handful of RTP packets, so it survives the lossy relay it has
 /// to cross. Replaces the earlier intra-refresh experiment, which left a
 /// desynced decoder with no clean recovery point (Linux ffmpeg ignores
@@ -840,16 +837,10 @@ fn nal_reader_thread(
         // A NAL is complete when we find the *next* start code after it.
         // Any data before the first start code is discarded (shouldn't
         // happen in practice with ffmpeg, but defensive).
-        loop {
-            // Find the first start code in buf.
-            let first = match find_start_code(&buf, 0) {
-                Some(pos) => pos,
-                None => {
-                    // No start code at all -- keep buffering.
-                    break;
-                }
-            };
-
+        //
+        // Find the first start code in buf; no start code at all means
+        // keep buffering.
+        while let Some(first) = find_start_code(&buf, 0) {
             // Discard any bytes before the first start code.
             if first.offset > 0 {
                 buf.drain(..first.offset);
@@ -1495,8 +1486,8 @@ mod tests {
             Ok(e) => e,
             Err(e) => panic!("no H.264 encoder available on this host: {e}"),
         };
-        let uv_w = ((w + 1) / 2) as usize;
-        let uv_h = ((h + 1) / 2) as usize;
+        let uv_w = w.div_ceil(2) as usize;
+        let uv_h = h.div_ceil(2) as usize;
         let frame_size = (w as usize * h as usize) + 2 * (uv_w * uv_h);
 
         let mut keyframes = 0usize;

--- a/crates/intendant-display/src/wayland.rs
+++ b/crates/intendant-display/src/wayland.rs
@@ -85,6 +85,12 @@ impl WaylandBackend {
     }
 }
 
+impl Default for WaylandBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[async_trait]
 impl DisplayBackend for WaylandBackend {
     async fn start_capture(&self, fps: u32) -> Result<mpsc::Receiver<Frame>, CallerError> {
@@ -585,11 +591,11 @@ async fn verify_remote_interaction(
     remote_desktop
         .notify_pointer_motion(session, 1.0, 0.0)
         .await
-        .map_err(|e| wayland_remote_interaction_error(e))?;
+        .map_err(wayland_remote_interaction_error)?;
     remote_desktop
         .notify_pointer_motion(session, -1.0, 0.0)
         .await
-        .map_err(|e| wayland_remote_interaction_error(e))?;
+        .map_err(wayland_remote_interaction_error)?;
     Ok(())
 }
 
@@ -670,6 +676,7 @@ fn mmap_fd_and_read(
 /// This function blocks until the `shutdown` flag is set or the PipeWire
 /// connection is lost. Frames are sent to `tx` via `try_send()` -- if the
 /// channel is full the frame is dropped (backpressure).
+#[allow(clippy::too_many_arguments)] // established internal signature: the params are distinct dependencies, not a bundle
 fn run_pipewire_capture(
     pw_fd: std::os::fd::OwnedFd,
     node_id: u32,

--- a/crates/intendant-display/src/x11.rs
+++ b/crates/intendant-display/src/x11.rs
@@ -151,7 +151,7 @@ fn parse_xrandr_output(text: &str) -> Vec<super::DisplayInfo> {
         }
 
         let output_name = parts[0];
-        let is_primary = parts.iter().any(|p| *p == "primary");
+        let is_primary = parts.contains(&"primary");
 
         // Find the resolution+offset token: "WxH+X+Y".
         let mode_token = parts.iter().find(|p| {
@@ -370,6 +370,7 @@ fn x11_button_from_browser(b: u8) -> u8 {
 ///
 /// Connects to the X server, sets up XShm (or falls back to XGetImage),
 /// and loops at the target framerate sending frames via `try_send()`.
+#[allow(clippy::too_many_arguments)] // established internal signature: the params are distinct dependencies, not a bundle
 fn run_x11_capture(
     display_str: String,
     tx: mpsc::Sender<Frame>,
@@ -459,6 +460,7 @@ fn query_root_geometry(conn: &impl x11rb::connection::Connection, root: u32) -> 
 }
 
 /// XShm-based capture loop.
+#[allow(clippy::too_many_arguments)] // established internal signature: the params are distinct dependencies, not a bundle
 fn run_shm_capture(
     conn: &impl x11rb::connection::Connection,
     root: u32,
@@ -542,7 +544,7 @@ fn run_shm_capture(
         let start = std::time::Instant::now();
 
         // Periodically check for root window resize (e.g. xrandr change).
-        if frame_count > 0 && frame_count % GEOMETRY_CHECK_INTERVAL == 0 {
+        if frame_count > 0 && frame_count.is_multiple_of(GEOMETRY_CHECK_INTERVAL) {
             if let Some((new_w, new_h)) = query_root_geometry(conn, root) {
                 if new_w != width || new_h != height {
                     eprintln!(
@@ -623,7 +625,7 @@ fn run_shm_capture(
                 };
 
                 frame_count += 1;
-                if frame_count == 1 || frame_count % 300 == 0 {
+                if frame_count == 1 || frame_count.is_multiple_of(300) {
                     eprintln!(
                         "[display/x11] shm frame #{} {}x{} stride={} size={}B depth={}",
                         frame_count, width, height, stride, data_len, reply.depth
@@ -656,6 +658,7 @@ fn run_shm_capture(
 }
 
 /// Fallback XGetImage-based capture loop (no shared memory).
+#[allow(clippy::too_many_arguments)] // established internal signature: the params are distinct dependencies, not a bundle
 fn run_getimage_capture(
     conn: &impl x11rb::connection::Connection,
     root: u32,
@@ -685,7 +688,7 @@ fn run_getimage_capture(
         let start = std::time::Instant::now();
 
         // Periodically check for root window resize.
-        if frame_count > 0 && frame_count % GEOMETRY_CHECK_INTERVAL == 0 {
+        if frame_count > 0 && frame_count.is_multiple_of(GEOMETRY_CHECK_INTERVAL) {
             if let Some((new_w, new_h)) = query_root_geometry(conn, root) {
                 if new_w != width || new_h != height {
                     eprintln!(
@@ -742,7 +745,7 @@ fn run_getimage_capture(
                 };
 
                 frame_count += 1;
-                if frame_count == 1 || frame_count % 300 == 0 {
+                if frame_count == 1 || frame_count.is_multiple_of(300) {
                     eprintln!(
                         "[display/x11] getimage frame #{} {}x{} stride={} size={}B",
                         frame_count,

--- a/crates/intendant-display/src/x11_input.rs
+++ b/crates/intendant-display/src/x11_input.rs
@@ -764,11 +764,11 @@ fn event_loop(dc: Arc<DisplayConn>) {
                         .send_event(false, req.requestor, xproto::EventMask::NO_EVENT, notify);
                 let _ = dc.conn.flush();
             }
-            Event::SelectionClear(clear) => {
-                if clear.owner == dc.selection_window && clear.selection == dc.atoms.clipboard {
-                    // Another client took the clipboard; stop serving.
-                    *dc.serving.lock().unwrap() = None;
-                }
+            Event::SelectionClear(clear)
+                if clear.owner == dc.selection_window && clear.selection == dc.atoms.clipboard =>
+            {
+                // Another client took the clipboard; stop serving.
+                *dc.serving.lock().unwrap() = None;
             }
             _ => {}
         }

--- a/crates/intendant-platform/src/platform.rs
+++ b/crates/intendant-platform/src/platform.rs
@@ -26,12 +26,13 @@ pub fn ensure_tool_paths() {
 
         // Directories that hold user-installed CLIs but are commonly absent
         // from PATH in non-login launch contexts. Order = search priority.
-        let mut candidates: Vec<PathBuf> = vec![home_dir().join(".local/bin")];
-        #[cfg(target_os = "macos")]
-        {
-            candidates.push(PathBuf::from("/opt/homebrew/bin"));
-            candidates.push(PathBuf::from("/usr/local/bin"));
-        }
+        let candidates: Vec<PathBuf> = vec![
+            home_dir().join(".local/bin"),
+            #[cfg(target_os = "macos")]
+            PathBuf::from("/opt/homebrew/bin"),
+            #[cfg(target_os = "macos")]
+            PathBuf::from("/usr/local/bin"),
+        ];
 
         let current = std::env::var_os("PATH").unwrap_or_default();
         let additions: Vec<PathBuf> = candidates

--- a/src/bin/caller/browser_workspace.rs
+++ b/src/bin/caller/browser_workspace.rs
@@ -16,7 +16,10 @@ static GLOBAL_BROWSER_WORKSPACES: OnceLock<SharedBrowserWorkspaceRegistry> = Onc
 const CDP_STARTUP_TIMEOUT: Duration = Duration::from_secs(8);
 const BROWSER_EXECUTABLE_ENV: &str = "INTENDANT_BROWSER_WORKSPACE_EXECUTABLE";
 const LEGACY_BROWSER_EXECUTABLE_ENV: &str = "INTENDANT_BROWSER_EXECUTABLE";
+// macOS-only system-browser escape hatch; other platforms' discovery path never consults it.
+#[cfg(target_os = "macos")]
 const ALLOW_SYSTEM_BROWSER_ENV: &str = "INTENDANT_BROWSER_WORKSPACE_ALLOW_SYSTEM_BROWSER";
+#[cfg(target_os = "macos")]
 const LEGACY_ALLOW_SYSTEM_BROWSER_ENV: &str = "INTENDANT_BROWSER_WORKSPACE_ALLOW_SYSTEM_CHROME";
 const CHROME_FOR_TESTING_DOWNLOADS_URL: &str =
     "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json";
@@ -909,10 +912,13 @@ fn configured_browser_executable() -> Option<(&'static str, PathBuf)> {
     None
 }
 
+// macOS-only system-browser escape hatch; other platforms' discovery path never consults it.
+#[cfg(target_os = "macos")]
 fn allow_system_browser() -> bool {
     env_truthy(ALLOW_SYSTEM_BROWSER_ENV) || env_truthy(LEGACY_ALLOW_SYSTEM_BROWSER_ENV)
 }
 
+#[cfg(target_os = "macos")]
 fn env_truthy(env_name: &str) -> bool {
     std::env::var(env_name)
         .ok()
@@ -920,6 +926,8 @@ fn env_truthy(env_name: &str) -> bool {
         .unwrap_or(false)
 }
 
+// Also compiled under `test`: the truthy-vocabulary unit test pins it on every platform.
+#[cfg(any(target_os = "macos", test))]
 fn env_value_truthy(value: &str) -> bool {
     matches!(
         value.trim().to_ascii_lowercase().as_str(),

--- a/src/bin/caller/computer_use.rs
+++ b/src/bin/caller/computer_use.rs
@@ -709,6 +709,8 @@ pub async fn target_pixel_size(
 /// Screenshots are resized to logical display size before sending to the model,
 /// so model coordinates are already in logical (input-injection) space.
 /// This function is a no-op but kept as the single place to adjust if needed.
+// Every call site lives in a `DisplayBackend::MacOS` match arm, so the seam is macOS-gated too.
+#[cfg(target_os = "macos")]
 fn scale_coords(x: i32, y: i32) -> (i32, i32) {
     (x, y)
 }

--- a/src/bin/caller/display_glue.rs
+++ b/src/bin/caller/display_glue.rs
@@ -990,7 +990,7 @@ pub(crate) fn frame_has_visible_rgb(frame: &display::Frame) -> bool {
     for y in 0..frame.height as usize {
         let row = y * stride;
         for x in 0..frame.width as usize {
-            if pixel_index % step == 0 {
+            if pixel_index.is_multiple_of(step) {
                 let px = row + x * 4;
                 if frame.data[px] > 3 || frame.data[px + 1] > 3 || frame.data[px + 2] > 3 {
                     return true;
@@ -1051,13 +1051,14 @@ pub(crate) fn detect_wayland_socket() -> Option<String> {
         let name = entry.file_name();
         let name = name.to_string_lossy();
         // Match "wayland-0", "wayland-1", etc. but not ".lock" files
-        if name.starts_with("wayland-") && !name.ends_with(".lock") {
-            if entry.file_type().ok().is_some_and(|ft| {
+        if name.starts_with("wayland-")
+            && !name.ends_with(".lock")
+            && entry.file_type().ok().is_some_and(|ft| {
                 use std::os::unix::fs::FileTypeExt;
                 ft.is_socket() || ft.is_file()
-            }) {
-                return Some(name.to_string());
-            }
+            })
+        {
+            return Some(name.to_string());
         }
     }
     None


### PR DESCRIPTION
The report-only clippy step's first run surfaced exactly what it existed to find: a 30-warning delta in `#[cfg(linux)]` code the macOS-cut baseline never linted (Wayland/X11/pipewire display code, plus cfg-shadowed dead-code false positives). All 30 resolved per class — cfg-gates for macOS-only helpers the Linux build can't see (never deletion; they're live code on their platforms), mechanical rewrites (`is_multiple_of`, `div_ceil`, while-let, doc rewrap, redundant closures, `Default` impl, collapsible match), and established-signature `too_many_arguments` allows matching the baseline's 96 precedents.

**Pre-verified on the fleet's Linux toolchain** with the exact gate incantation (`cargo clippy --workspace --locked --target x86_64-unknown-linux-gnu`): 0 warnings, 0 errors — plus `--all-targets` compiles clean (the `any(macos, test)` gate on `env_value_truthy` keeps its un-gated unit test building everywhere). macOS battery: clippy zero, fmt clean, nextest 3031/3031.

Second commit flips the gate to `-D warnings` atomically, so there is no window where enforcement and surface disagree. This PR's own Linux leg runs the enforcing gate on the zeroed tree — self-proving.