### PR TITLE
Transport S11a (the flip): spec-derived tunnel dispatch; CONTROL_METHODS -> CONTROL_ONLY_METHODS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ SysPrompt*.md   # per-role system prompts (base, tools, user, orchestrator, rese
 - **Derive, don't mirror.** Daemon truth a frontend needs — permission
   catalogs, feature lists, availability booleans, option vocabularies — is
   declared once and derived everywhere else (exemplar: the tunnel method
-  table — `gateway_routes::ROUTES` tunnel columns ∪ the `CONTROL_METHODS`
+  table — `gateway_routes::ROUTES` tunnel columns ∪ the `CONTROL_ONLY_METHODS`
   residue in `dashboard_control/mod.rs` — drives the authorizer, the
   `features` list, and the per-method availability booleans). When a static
   frontend fallback copy is unavoidable (app.html's IAM catalog, the
@@ -183,7 +183,7 @@ SysPrompt*.md   # per-role system prompts (base, tools, user, orchestrator, rese
   request-body policy (dispatch reads and caps the body before the handler
   runs). A route's dashboard-control (datachannel) twin is declared on the
   same row: tunnel-twinned methods get the row's `tunnel:` column
-  (`TunnelSpec`) — never a `CONTROL_METHODS` entry; that table is the residue
+  (`TunnelSpec`) — never a `CONTROL_ONLY_METHODS` entry; that table is the residue
   for tunnel-only methods, and the tunnel derives each twinned method's IAM
   operation from its row. Unit tests enforce the table invariants, pin the
   docs chapter, pin every route-specific body cap, and freeze the tunnel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ SysPrompt*.md   # per-role system prompts (base, tools, user, orchestrator, rese
 - **Derive, don't mirror.** Daemon truth a frontend needs — permission
   catalogs, feature lists, availability booleans, option vocabularies — is
   declared once and derived everywhere else (exemplar: the tunnel method
-  table — `gateway_routes::ROUTES` tunnel columns ∪ the `CONTROL_METHODS`
+  table — `gateway_routes::ROUTES` tunnel columns ∪ the `CONTROL_ONLY_METHODS`
   residue in `dashboard_control/mod.rs` — drives the authorizer, the
   `features` list, and the per-method availability booleans). When a static
   frontend fallback copy is unavoidable (app.html's IAM catalog, the
@@ -183,7 +183,7 @@ SysPrompt*.md   # per-role system prompts (base, tools, user, orchestrator, rese
   request-body policy (dispatch reads and caps the body before the handler
   runs). A route's dashboard-control (datachannel) twin is declared on the
   same row: tunnel-twinned methods get the row's `tunnel:` column
-  (`TunnelSpec`) — never a `CONTROL_METHODS` entry; that table is the residue
+  (`TunnelSpec`) — never a `CONTROL_ONLY_METHODS` entry; that table is the residue
   for tunnel-only methods, and the tunnel derives each twinned method's IAM
   operation from its row. Unit tests enforce the table invariants, pin the
   docs chapter, pin every route-specific body cap, and freeze the tunnel

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -888,92 +888,19 @@ pub(crate) fn control_frame_response(
                     );
                     None
                 }
-                "api_sessions"
-                | "api_session_detail"
-                | "api_session_report"
-                | "api_session_delete"
-                | "api_session_agent_output"
-                | "api_session_current_agent_output"
-                | "api_session_current_history"
-                | "api_session_current_rollback"
-                | "api_session_current_redo"
-                | "api_session_current_prune"
-                | "api_session_current_changes"
-                | "api_session_context_snapshot"
-                | "api_session_current_uploads"
-                | "api_session_current_upload_raw"
-                | "api_session_current_upload_delete"
-                | "api_transfer_jobs"
-                | "api_transfer_job_create"
-                | "api_transfer_job_delete"
-                | "api_transfer_download_read"
-                | "api_transfer_upload_commit"
-                | "api_media_clip_start"
-                | "api_media_clip_end"
-                | "api_media_clip_cancel"
-                | "api_fs_stat"
-                | "api_fs_list"
-                | "api_fs_mkdir"
-                | "api_fs_rename"
-                | "api_fs_delete"
-                | "api_fs_read"
-                | "api_sessions_search"
-                | "api_settings"
-                | "api_settings_save"
-                | "api_control_msg"
-                | "api_session_control_msg"
-                | "api_dashboard_action_msg"
-                | "api_diagnostics_visual_freshness"
-                | "api_key_status"
-                | "api_api_keys_save"
-                | "api_external_agents"
-                | "api_voice_session"
-                | "api_project_root"
-                | "api_displays"
-                | "api_recordings"
-                | "api_recording_asset"
-                | "api_session_recordings"
-                | "api_session_recording_asset"
-                | "api_session_frame_asset"
-                | "api_browser_workspace_snapshot"
-                | "api_state_snapshot"
-                | "api_display_bootstrap"
-                | "api_display_webrtc_signal"
-                | "api_display_input_authority_snapshot"
-                | "api_display_input_authority_request"
-                | "api_display_input_authority_release"
-                | "api_session_log_replay"
-                | "api_external_session_activity_replay"
-                | "api_dashboard_bootstrap"
-                | "api_worktrees"
-                | "api_worktrees_inspect"
-                | "api_worktrees_scan"
-                | "api_worktrees_remove"
-                | "api_worktrees_merge"
-                | "api_managed_context_records"
-                | "api_managed_context_anchors"
-                | "api_managed_context_fission"
-                | "api_mcp_tool_call"
-                | "api_peer_add"
-                | "api_peer_remove"
-                | "api_peer_eligible"
-                | "api_peer_message"
-                | "api_peer_task"
-                | "api_peer_approval"
-                | "api_peer_webrtc_signal"
-                | "api_peer_file_transfer_signal"
-                | "api_peer_dashboard_control_signal"
-                | "api_peer_pairing_invite"
-                | "api_peer_pairing_join"
-                | "api_peer_pairing_request_access"
-                | "api_peer_pairing_request_access_poll"
-                | "api_peer_pairing_requests"
-                | "api_peer_pairing_request_decision"
-                | "api_peer_pairing_identities"
-                | "api_peer_pairing_identity_revoke"
-                | "api_credential_egress_probe"
-                | "api_access_connect_unclaim"
-                | "api_coordinator_route" => {
+                // Every other declared method rides the spawned request
+                // lane (transport-unification S11): the authorizer above
+                // fail-closes undeclared names against the effective
+                // method table (route-row tunnel specs ∪ the
+                // `CONTROL_ONLY_METHODS` residue), so reaching this arm
+                // means the method is declared — the per-name mirror list
+                // this arm replaces could only drift out of sync with
+                // those declarations. The spawned lane owns the
+                // method→handler binding (byte-stream tasks and JSON
+                // arms alike); a declared name it does not bind answers
+                // with the same `unknown method` shape this match used to
+                // return inline.
+                _ => {
                     spawn_control_request(
                         id,
                         method.to_string(),
@@ -984,12 +911,6 @@ pub(crate) fn control_frame_response(
                     );
                     None
                 }
-                _ => Some(serde_json::json!({
-                    "t": "response",
-                    "id": id,
-                    "ok": false,
-                    "error": format!("unknown method: {method}"),
-                })),
             }
         }
         "cancel" => {
@@ -1052,16 +973,13 @@ pub(crate) fn control_upload_start_frame(
         return Some(control_upload_error_response(id, 400, "missing request id"));
     }
     let method = frame.get("method").and_then(|v| v.as_str()).unwrap_or("");
-    if !matches!(
-        method,
-        "api_session_current_upload"
-            | "api_transfer_upload_chunk"
-            | "api_fs_write"
-            | "api_media_annotation_attach"
-            | "api_media_annotation_submit"
-            | "api_media_clip_frame"
-            | "api_presence_video_frame"
-    ) {
+    // Derived, not mirrored (transport-unification S11): a method is
+    // upload-deliverable iff its declaration says so — the `upload` flag
+    // on its route-row tunnel spec or `CONTROL_ONLY_METHODS` residue
+    // entry — replacing the per-name list this gate used to restate.
+    // Undeclared names keep the historical 400 shape; the operation gate
+    // below answers 403 like every other authorization failure.
+    if !control_method_spec(method).is_some_and(|spec| spec.upload) {
         return Some(control_upload_error_response(
             id,
             400,
@@ -2369,7 +2287,7 @@ pub(crate) fn status_response_frame(id: String, runtime: &ControlRuntime) -> ser
 
     // Every gated api_* method derives its `<method>_available` boolean from
     // the effective method table (route-row tunnel specs ∪ the
-    // CONTROL_METHODS residue): operation granted && backing subsystem wired
+    // CONTROL_ONLY_METHODS residue): operation granted && backing subsystem wired
     // (`control_method_runtime_ready`). One boolean per advertised RPC lets
     // the SPA distinguish "denied for this session" from "unsupported
     // daemon" (feature list) without probing calls.

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -73,9 +73,9 @@ static NEXT_DASHBOARD_DISPLAY_PEER_ID: AtomicU64 = AtomicU64::new(1);
 /// sync in the others. It is the union of two declaration sources, resolved
 /// rows-first: tunnel columns on `gateway_routes::ROUTES` rows (twinned
 /// methods, whose IAM operation derives from the route row — transport-
-/// unification design §2.2) and the residue `CONTROL_METHODS` below (methods
-/// whose family has not yet ported, plus tunnel-only methods with no HTTP
-/// twin). The `tunnel_method_partition_is_pinned` differential test freezes
+/// unification design §2.2) and the residue `CONTROL_ONLY_METHODS` below
+/// (tunnel-only methods with no HTTP twin). The
+/// `tunnel_method_partition_is_pinned` differential test freezes
 /// which methods live on which side. Composite rollup booleans the SPA also
 /// reads (peer mutations, managed context, …) stay hand-written next to the
 /// derived block in `status_response_frame`.
@@ -122,15 +122,19 @@ const fn uploadable(name: &'static str, op: PeerOperation) -> ControlMethodSpec 
     }
 }
 
-/// The residue half of the tunnel method table: methods not (yet) declared
-/// as a `tunnel:` column on a `gateway_routes::ROUTES` row. Do NOT add a
-/// method here if its HTTP twin has a route row — declare it on the row
-/// (`Route::with_tunnel`) so its IAM operation derives from the shared
-/// declaration; this list is for tunnel-only methods and families the
-/// migration has not reached. Never read directly outside this module's
-/// union plumbing and pins — consume `all_control_methods()` /
-/// `control_method_spec()`.
-const CONTROL_METHODS: &[ControlMethodSpec] = &[
+/// The residue half of the tunnel method table: methods with no HTTP twin
+/// — transport/handshake, credential custody (tunnel-scoped by design),
+/// connection-scoped signaling/authority RPCs whose HTTP-era twin is the
+/// `/ws` socket, `ControlMsg` intent lanes, media/clip upload lanes, and
+/// the bootstrap/replay reads (the tunnel-only set the transport-
+/// unification program's S11 removal stage left behind; `/session`,
+/// `/recordings*`, and custody HTTP rows stay parked future decisions —
+/// design §2.7). Do NOT add a method here if its HTTP twin has a route
+/// row — declare it on the row (`Route::with_tunnel`) so its IAM
+/// operation derives from the shared declaration. Never read directly
+/// outside this module's union plumbing and pins — consume
+/// `all_control_methods()` / `control_method_spec()`.
+const CONTROL_ONLY_METHODS: &[ControlMethodSpec] = &[
     ControlMethodSpec {
         name: "ping",
         op: None,
@@ -308,7 +312,7 @@ const CONTROL_METHODS: &[ControlMethodSpec] = &[
 
 /// The effective method table: route-row tunnel specs first (in ROUTES
 /// declaration order, with the IAM operation derived from each row —
-/// `Route::tunnel_operation`), then the residue `CONTROL_METHODS`.
+/// `Route::tunnel_operation`), then the residue `CONTROL_ONLY_METHODS`.
 /// Materialized once; every consumer sees the same union. Resolution is
 /// deterministic — rows win — so even the (unlandable, pin-tested) state
 /// of a method declared on both sides cannot flap between operations. A
@@ -330,7 +334,7 @@ fn all_control_methods() -> &'static [ControlMethodSpec] {
                 })
             })
             .collect();
-        methods.extend_from_slice(CONTROL_METHODS);
+        methods.extend_from_slice(CONTROL_ONLY_METHODS);
         methods
     })
 }
@@ -358,7 +362,7 @@ const CONTROL_WIRE_FEATURES: &[&str] = &[
 ];
 
 /// The advertised `features` list: every advertised method in the
-/// effective table (route-row tunnel specs ∪ the `CONTROL_METHODS`
+/// effective table (route-row tunnel specs ∪ the `CONTROL_ONLY_METHODS`
 /// residue) plus the wire features. Consumers membership-test — order
 /// carries no meaning.
 fn control_features() -> &'static [&'static str] {
@@ -1618,7 +1622,7 @@ fn authorize_dashboard_control_method(
     params: Option<&serde_json::Value>,
 ) -> Result<(), String> {
     // Fail closed: a method must be declared — as a route row's tunnel
-    // column or a residue `CONTROL_METHODS` entry — to be callable at
+    // column or a residue `CONTROL_ONLY_METHODS` entry — to be callable at
     // all; a dispatch arm added without a declaration is denied here
     // instead of shipping ungated.
     let Some(spec) = control_method_spec(method) else {
@@ -1712,7 +1716,7 @@ fn authorize_dashboard_control_upload(
     method: &str,
 ) -> Result<(), String> {
     // Fail closed twice over: the method must be declared upload-deliverable
-    // (route-row tunnel column or residue `CONTROL_METHODS` entry), and
+    // (route-row tunnel column or residue `CONTROL_ONLY_METHODS` entry), and
     // upload methods are always operation-gated.
     let Some(op) = control_method_spec(method)
         .filter(|spec| spec.upload)
@@ -2915,7 +2919,7 @@ mod tests {
     }
 
     /// The operation a method's declaration carries (route-row tunnel
-    /// column or residue `CONTROL_METHODS` entry — the effective table).
+    /// column or residue `CONTROL_ONLY_METHODS` entry — the effective table).
     fn method_operation(method: &str) -> Option<crate::peer::access_policy::PeerOperation> {
         control_method_spec(method).and_then(|spec| spec.op)
     }
@@ -2957,7 +2961,7 @@ mod tests {
     #[test]
     fn control_method_table_is_coherent() {
         // Coherence holds over the effective union (route-row tunnel
-        // specs ∪ the CONTROL_METHODS residue): a name declared on both
+        // specs ∪ the CONTROL_ONLY_METHODS residue): a name declared on both
         // sides is a duplicate here just like two residue rows were.
         let mut seen = HashSet::new();
         for spec in all_control_methods() {
@@ -2985,15 +2989,18 @@ mod tests {
     /// R2/R4): the complete tunnel-method partition — every wire method
     /// name, the declaration source that carries it (`Row` = a `tunnel:`
     /// column on a `gateway_routes::ROUTES` row, `Residue` = a
-    /// `CONTROL_METHODS` entry), and the IAM operation gating it —
+    /// `CONTROL_ONLY_METHODS` entry), and the IAM operation gating it —
     /// frozen as a literal table. Re-gating a method (operation change
     /// on either side), losing one (gone from both sources), duplicating
     /// one (declared on both), or moving one between sources fails here
     /// until this table is updated in the same change, deliberately.
-    /// Permanent program infrastructure: the migration stages move
-    /// families from `Residue` to `Row` by flipping tags here alongside
-    /// their declarations, and the removal stage shrinks the residue to
-    /// the tunnel-only set — the union below never changes by accident.
+    /// Permanent program infrastructure, and the S11 flip's union-
+    /// equality proof: the assertions below check the live union against
+    /// the frozen partition in BOTH directions (every pinned name lives
+    /// with the pinned source and operation; every live name is pinned),
+    /// so the full name × operation union is provably unchanged by the
+    /// dispatch flip — the residue below is the final tunnel-only set,
+    /// and the union never changes by accident.
     #[test]
     fn tunnel_method_partition_is_pinned() {
         use crate::peer::access_policy::PeerOperation as Op;
@@ -3307,11 +3314,11 @@ mod tests {
                 spec.name
             );
         }
-        for spec in CONTROL_METHODS {
+        for spec in CONTROL_ONLY_METHODS {
             assert!(
                 live.insert(spec.name, (Residue, spec.op)).is_none(),
                 "{} is declared BOTH as a route-row tunnel column and in \
-                 CONTROL_METHODS — remove the residue entry",
+                 CONTROL_ONLY_METHODS — remove the residue entry",
                 spec.name
             );
         }
@@ -3357,7 +3364,7 @@ mod tests {
     /// against the table — same pattern as
     /// `spa_action_msg_rpc_set_mirrors_dashboard_action_allowlist`
     /// (api_control.rs). Four facts per entry: the tunnel twin exists in
-    /// `CONTROL_METHODS`; the verb + instantiated path resolve to a
+    /// `CONTROL_ONLY_METHODS`; the verb + instantiated path resolve to a
     /// declared route whose verb is declared exactly (never via `Any`);
     /// the row's IAM operation equals the tunnel method's (the signed-org
     /// doorbell rows are Public on HTTP by design and instead pin their
@@ -3544,7 +3551,7 @@ mod tests {
 
         for (method_name, (verb, template)) in &entries {
             let spec = control_method_spec(method_name).unwrap_or_else(|| {
-                panic!("{method_name}: descriptor entry has no CONTROL_METHODS row")
+                panic!("{method_name}: descriptor entry has no CONTROL_ONLY_METHODS row")
             });
             let tunnel_op = spec
                 .op

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -21,7 +21,7 @@
 //! 5. **Tunnel exposure** — a row's optional [`TunnelSpec`] declares its
 //!    dashboard-control datachannel twin. The tunnel's method table
 //!    (`dashboard_control::control_method_spec`) resolves these rows
-//!    first, then its residue `CONTROL_METHODS`, so a twinned method's
+//!    first, then its residue `CONTROL_ONLY_METHODS`, so a twinned method's
 //!    IAM operation derives from the same declaration HTTP gates on
 //!    (transport-unification design §2.2) instead of a second table that
 //!    can drift.
@@ -296,7 +296,7 @@ pub(crate) enum RouteHandlerId {
 
 /// Datachannel (dashboard-control tunnel) twin of a route row — the
 /// `tunnel:` column of the transport-unification design (§2.2). The wire
-/// method name is unchanged from its legacy `CONTROL_METHODS` entry: the
+/// method name is unchanged from its legacy `CONTROL_ONLY_METHODS` entry: the
 /// datachannel wire never changes; the name becomes an alias of this
 /// row. The IAM operation gating the tunnel method is **derived from the
 /// row** ([`Route::tunnel_operation`]) — declaring it once is the point
@@ -385,11 +385,10 @@ pub(crate) struct Route {
     /// One line, becomes the docs endpoint-table row. Required — an
     /// empty doc string fails the invariant test.
     pub(crate) doc: &'static str,
-    /// Datachannel exposure of this row. `None` = HTTP-only, or the
-    /// tunnel twin has not yet ported out of `CONTROL_METHODS` (the
-    /// transitional state the migration drains family by family; the
-    /// differential pin test in `dashboard_control` freezes which
-    /// methods live where).
+    /// Datachannel exposure of this row. `None` = HTTP-only. Methods
+    /// with no HTTP twin live in `CONTROL_ONLY_METHODS` instead (the
+    /// residue half of the tunnel method table; the differential pin
+    /// test in `dashboard_control` freezes which methods live where).
     pub(crate) tunnel: Option<TunnelSpec>,
 }
 
@@ -559,7 +558,7 @@ pub(crate) static ROUTES: &[Route] = &[
     //    trio is additionally pre-gated by peer_filesystem_query_request).
     //    First family carrying the tunnel column: the datachannel twins'
     //    IAM operations derive from these rows (their legacy
-    //    CONTROL_METHODS entries are gone).
+    //    CONTROL_ONLY_METHODS entries are gone).
     op_route(
         RouteMethod::Get,
         PathPattern::Exact("/api/fs/stat"),
@@ -1889,7 +1888,7 @@ pub(crate) fn classify(req_method: &str, req_path: &str) -> TableClassification 
 
 /// Every (route, tunnel spec) pair, in declaration order — the ROW half
 /// of the tunnel method partition. `dashboard_control` unions this with
-/// its residue `CONTROL_METHODS` (rows first) to build the effective
+/// its residue `CONTROL_ONLY_METHODS` (rows first) to build the effective
 /// method table; its differential pin test freezes exactly which methods
 /// live on which side.
 pub(crate) fn tunnel_specs() -> impl Iterator<Item = (&'static Route, &'static TunnelSpec)> {

--- a/src/bin/caller/web_gateway/access_gates.rs
+++ b/src/bin/caller/web_gateway/access_gates.rs
@@ -203,7 +203,7 @@ pub(crate) fn peer_identity_allows_ws_control(
 
 /// Map a typed `/ws` frame to the `PeerOperation` it exercises — the
 /// direct-WebSocket mirror of `dashboard_control_frame_operation` and
-/// the `CONTROL_METHODS` table (dashboard_control/mod.rs), so the same
+/// the `CONTROL_ONLY_METHODS` table (dashboard_control/mod.rs), so the same
 /// IAM grant answers the same way whichever transport a client speaks.
 /// `None` means the frame carries no authority of its own: replies, pings,
 /// and the `dashboard_control_*` signaling frames (the tunnel they establish

--- a/static/app.html
+++ b/static/app.html
@@ -27084,7 +27084,7 @@ function daemonApiTunnelMethodAvailability(transport, method) {
   }
   if (features.length) {
     // Upload-only methods are not named in `features` — they advertise
-    // through the upload_frames umbrella (CONTROL_METHODS upload_only).
+    // through the upload_frames umbrella (CONTROL_ONLY_METHODS upload_only).
     const advertised = features.includes(method) || (lane === 'upload' && features.includes('upload_frames'));
     return advertised ? { ok: true, reason: 'connected' } : { ok: false, reason: 'unsupported' };
   }

--- a/static/app/32-daemon-api.js
+++ b/static/app/32-daemon-api.js
@@ -978,7 +978,7 @@ function daemonApiTunnelMethodAvailability(transport, method) {
   }
   if (features.length) {
     // Upload-only methods are not named in `features` — they advertise
-    // through the upload_frames umbrella (CONTROL_METHODS upload_only).
+    // through the upload_frames umbrella (CONTROL_ONLY_METHODS upload_only).
     const advertised = features.includes(method) || (lane === 'upload' && features.includes('upload_frames'));
     return advertised ? { ok: true, reason: 'connected' } : { ok: false, reason: 'unsupported' };
   }


### PR DESCRIPTION
Stage S11a of the transport-unification program (design §6, S11 — the flip half).

## What changes

- **The ~85-name spawn mirror in `control_frame_response`'s request arm dies.** The authorizer already fail-closes undeclared names against the effective method table (route-row tunnel specs ∪ residue), so any declared method not answered inline (sync residue arms: status/config/subscribe/agent-card/cached-bootstrap, credential custody, api_peers, the access family) or on the stream lane now dispatches on the spawned request lane by default. A declared name the lane does not bind answers with the byte-identical `unknown method: …` shape the match used to return inline. Adding a route row's tunnel column now suffices for dispatch — the class where a declared method also needed a hand-kept name-list entry is gone.
- **The `upload_start` seven-name literal dies**: upload deliverability derives from the declaration's `upload` flag. Undeclared names keep the historical 400 shape (pinned by `dashboard_uploads_flow_end_to_end`); the operation gate keeps answering 403.
- **`CONTROL_METHODS` → `CONTROL_ONLY_METHODS`**: the table holds only the residue — tunnel-only methods with no HTTP twin (custody, /ws-twin signaling+authority, ControlMsg lanes, media/clip lanes, bootstrap/replay, transport/handshake). Transitional "family not yet ported" language updated at the table, `Route::tunnel`, and the fragment/CLAUDE.md references (mechanical rename edits; app.html regenerated).

## What proves it

- `tunnel_method_partition_is_pinned` — the differential pin's frozen partition is **untouched**; it asserts the live union in both directions, so the full name × operation union is provably unchanged (the union-equality proof).
- Goldens + tunnel/HTTP parity fixtures untouched and green; `tunnel_op_overrides_are_a_closed_documented_enumeration` unchanged.
- Zero wire changes, zero IAM changes. Sync-vs-spawned lanes are preserved per method (every method keeps today's lane; the only dispatch-shape change is that a *declared-but-unbound* request-lane name — the upload-only septet and `ping` sent as `t:"request"` — now answers its unknown-method frame from the spawned lane instead of inline, same JSON).

Battery: fmt ✅ nextest ✅ clippy ✅ e2e ✅ boot smoke ✅ (results in comments as they land). Hosted/peer validators are the operator battery, post-landing.

S11b (the removal: spawned-lane binding collapse + orphan sweep) stacks on this.