### PR TITLE
Validators catch up with the TUI removal: drop dead tui_frames probes and assertions

### DIFF
--- a/scripts/validate-connect-hosted-mvp.cjs
+++ b/scripts/validate-connect-hosted-mvp.cjs
@@ -444,8 +444,7 @@ async function main() {
           status?.connected &&
           status?.verifiedBinding?.ok &&
           status?.signalingMode === 'connect-rendezvous' &&
-          status?.terminalFramesAvailable === true &&
-          status?.tuiFramesAvailable === false
+          status?.terminalFramesAvailable === true
         ) {
           return status;
         }
@@ -459,7 +458,6 @@ async function main() {
     assert.strictEqual(connected.verifiedBinding.daemonPublicKey, registered.daemon_public_key);
     assert(connected.sessionGrantSha256, 'Connect dashboard did not bind a session grant');
     assert.strictEqual(connected.terminalFramesAvailable, true, `Connect tunnel did not advertise terminal frames: ${JSON.stringify(connected)}`);
-    assert.strictEqual(connected.tuiFramesAvailable, false, `--no-tui daemon unexpectedly advertised TUI frames: ${JSON.stringify(connected)}`);
     assert.strictEqual(connected.byteStreamsAvailable, true, `Connect tunnel did not advertise byte streams: ${JSON.stringify(connected)}`);
     assert.strictEqual(connected.apiFsReadAvailable, true, `Connect tunnel did not advertise filesystem reads: ${JSON.stringify(connected)}`);
     assert.strictEqual(connected.apiTransferJobsAvailable, true, `Connect tunnel did not advertise transfer jobs: ${JSON.stringify(connected)}`);
@@ -545,17 +543,6 @@ async function main() {
     assert.strictEqual(reloadDownloadResumed.rawText, genericDownloadText, `Reload download resume returned wrong bytes: ${JSON.stringify(reloadDownloadResumed)}`);
 
     await click(page, '.tab-btn[data-tab="terminal"]');
-    await click(page, '#tab-terminal .subtab-btn[data-term-tab="tui"]');
-    await page.waitForFunction(() => {
-      const el = document.getElementById('terminal-tui-unavailable');
-      return Boolean(
-        el &&
-        !el.classList.contains('hidden') &&
-        el.textContent.includes('TUI unavailable for this daemon')
-      );
-    }, {
-      timeout: START_TIMEOUT_MS,
-    });
 
     const shellToken = `connect_shell_${Date.now()}`;
     await click(page, '#tab-terminal .subtab-btn[data-term-tab="shell"]');
@@ -587,7 +574,6 @@ async function main() {
         '_debugProbeDiagnosticsConnectNoHttp',
         '_debugProbeDisplaySignalConnectNoLegacy',
         '_debugProbeDisplayAuthorityConnectNoLegacy',
-        '_debugProbeTuiConnectNoLegacy',
         '_debugProbeShellQueuesUntilOpened',
         '_debugProbeTerminalOutputBypassesDedupe',
         '_debugProbeEventDedupeAllowlist',
@@ -623,10 +609,6 @@ async function main() {
     assert.strictEqual(probes._debugProbeDisplayAuthorityConnectNoLegacy.releaseResult, false, `display authority release unexpectedly succeeded without tunnel support: ${JSON.stringify(probes)}`);
     assert.strictEqual(probes._debugProbeDisplayAuthorityConnectNoLegacy.requestReplayCount, 0, `display authority request used legacy path: ${JSON.stringify(probes)}`);
     assert.strictEqual(probes._debugProbeDisplayAuthorityConnectNoLegacy.releaseReplayCount, 0, `display authority release used legacy path: ${JSON.stringify(probes)}`);
-    assert.strictEqual(probes._debugProbeTuiConnectNoLegacy.keyReplayCount, 0, `TUI key used legacy path: ${JSON.stringify(probes)}`);
-    assert.strictEqual(probes._debugProbeTuiConnectNoLegacy.resizeReplayCount, 0, `TUI resize used legacy path: ${JSON.stringify(probes)}`);
-    assert.strictEqual(probes._debugProbeTuiConnectNoLegacy.wsReplayCount, 0, `TUI subscription used WS fallback: ${JSON.stringify(probes)}`);
-    assert.strictEqual(probes._debugProbeTuiConnectNoLegacy.subscriptionSent, false, `TUI subscription unexpectedly sent over WS: ${JSON.stringify(probes)}`);
     assert.deepStrictEqual(probes._debugProbeShellQueuesUntilOpened.framesBeforeAck, ['terminal_open'], `Shell input was sent before terminal_opened: ${JSON.stringify(probes)}`);
     assert.deepStrictEqual(probes._debugProbeShellQueuesUntilOpened.framesAfterAck, ['terminal_open', 'terminal_resize', 'terminal_input'], `Shell queued input did not flush after terminal_opened: ${JSON.stringify(probes)}`);
     assert.strictEqual(probes._debugProbeShellQueuesUntilOpened.queuedBeforeAck, 'queued-before-open', `Shell probe did not queue input before ACK: ${JSON.stringify(probes)}`);

--- a/scripts/validate-connect-rendezvous.cjs
+++ b/scripts/validate-connect-rendezvous.cjs
@@ -514,7 +514,7 @@ function publicBootstrapHtml() {
       this.pc = new RTCPeerConnection({});
       this.channel = this.pc.createDataChannel('intendant-dashboard-control', { ordered: true });
       this.channel.onopen = () => {
-        this.sendFrame({ t: 'hello', id: this.nextId(), features: ['response_credit', 'byte_streams', 'upload_frames', 'terminal_frames', 'tui_frames'] });
+        this.sendFrame({ t: 'hello', id: this.nextId(), features: ['response_credit', 'byte_streams', 'upload_frames', 'terminal_frames'] });
         paint(this.status());
       };
       this.channel.onmessage = ev => this.handleMessage(ev.data);
@@ -581,12 +581,6 @@ function publicBootstrapHtml() {
       if (msg.t === 'terminal_output' || msg.t === 'terminal_exited' || msg.t === 'terminal_opened' || msg.t === 'terminal_error') {
         try {
           window.dispatchEvent(new CustomEvent('intendant-dashboard-terminal-frame', { detail: msg }));
-        } catch (_) {}
-        return;
-      }
-      if (msg.t === 'tui_term' || msg.t === 'tui_error') {
-        try {
-          window.dispatchEvent(new CustomEvent('intendant-dashboard-tui-frame', { detail: msg }));
         } catch (_) {}
         return;
       }
@@ -990,11 +984,6 @@ function publicBootstrapHtml() {
       this.sendFrame(frame);
       return true;
     },
-    tuiFrame(frame) {
-      if (!this.canUseRpc()) return false;
-      this.sendFrame(frame);
-      return true;
-    },
     stream(method, params = {}, options = {}, onEvent = {}) {
       if (options.signal?.aborted) return Promise.reject(abortError());
       if (!this.canUseRpc()) return Promise.reject(new Error('dashboard control stream is not connected'));
@@ -1102,7 +1091,6 @@ function publicBootstrapHtml() {
         byteStreamsAvailable: this.lastStatus?.byte_streams_available ?? null,
         uploadFramesAvailable: this.lastStatus?.upload_frames_available ?? null,
         terminalFramesAvailable: this.lastStatus?.terminal_frames_available ?? null,
-        tuiFramesAvailable: this.lastStatus?.tui_frames_available ?? null,
         presenceFramesAvailable: this.lastStatus?.presence_frames_available ?? null,
         presenceActiveHandoffAvailable: this.lastStatus?.presence_active_handoff_available ?? null,
         presenceToolRequestAvailable: this.lastStatus?.presence_tool_request_available ?? null,
@@ -1940,65 +1928,6 @@ async function main() {
           window.removeEventListener('intendant-dashboard-terminal-frame', handler);
         }
       };
-      const tui = async () => {
-        const connectionId = `dashboard-tui-rendezvous-${Date.now()}`;
-        const frames = [];
-        const handler = event => frames.push(event.detail || {});
-        const waitFor = (predicate, label) => new Promise((resolve, reject) => {
-          const started = Date.now();
-          const tick = () => {
-            const found = frames.find(predicate);
-            if (found) {
-              resolve(found);
-              return;
-            }
-            if (Date.now() - started > 60000) {
-              reject(new Error(`tui ${label} timed out`));
-              return;
-            }
-            setTimeout(tick, 25);
-          };
-          tick();
-        });
-        window.addEventListener('intendant-dashboard-tui-frame', handler);
-        try {
-          ctl.tuiFrame({
-            t: 'tui_subscribe',
-            connection_id: connectionId,
-            cols: 80,
-            rows: 24,
-          });
-          const frame = await waitFor(item => (
-            item.t === 'tui_term' &&
-            item.connection_id === connectionId &&
-            Boolean(item.base64 || item.d)
-          ), 'term frame');
-          ctl.tuiFrame({
-            t: 'tui_key',
-            connection_id: connectionId,
-            key: 'Tab',
-            ctrl: false,
-            alt: false,
-            shift: false,
-          });
-          ctl.tuiFrame({
-            t: 'tui_unsubscribe',
-            connection_id: connectionId,
-          });
-          ctl.tuiFrame({
-            t: 'tui_close',
-            connection_id: connectionId,
-          });
-          const data = String(frame.base64 || frame.d || '');
-          return {
-            subscribed: true,
-            connectionId,
-            frameBytes: atob(data).length,
-          };
-        } finally {
-          window.removeEventListener('intendant-dashboard-tui-frame', handler);
-        }
-      };
       const status = await ctl.request('status');
       const uploaded = await upload();
       return {
@@ -2061,7 +1990,6 @@ async function main() {
         diagnosticsVisualFreshness: await diagnosticsVisualFreshness(),
         peerPairing: await peerPairing(),
         terminal: await terminal(),
-        tui: status.tui_frames_available ? await tui() : { skipped: true, subscribed: false, frameBytes: 0 },
         sessionsStream: {
           result: streamResult,
           eventTypes: streamEvents.map(event => event.type),
@@ -2633,12 +2561,6 @@ async function main() {
     ), { force: true });
     assert.strictEqual(result.terminal?.opened, true);
     assert.strictEqual(result.terminal?.sawToken, true);
-    if (result.status.tui_frames_available) {
-      assert.strictEqual(result.tui?.subscribed, true);
-      assert(Number(result.tui?.frameBytes || 0) > 0, 'TUI frame did not contain bytes');
-    } else {
-      assert.strictEqual(result.tui?.skipped, true);
-    }
     assert.strictEqual(
       result.status.api_session_current_history_available,
       true,
@@ -2941,7 +2863,6 @@ async function main() {
         byteStreamsAvailable: result.status.byte_streams_available,
         uploadFramesAvailable: result.status.upload_frames_available,
         terminalFramesAvailable: result.status.terminal_frames_available,
-        tuiFramesAvailable: result.status.tui_frames_available,
         apiSessionCurrentUploadsAvailable: result.status.api_session_current_uploads_available,
         apiSessionCurrentUploadAvailable: result.status.api_session_current_upload_available,
         apiSessionCurrentUploadRawAvailable: result.status.api_session_current_upload_raw_available,
@@ -2979,7 +2900,6 @@ async function main() {
         recordingFallbackSkipped: Boolean(result.recordingFallbackPlayback.skipped),
         diagnosticsVisualFreshnessWritten: result.diagnosticsVisualFreshness.written,
         terminalOutputBytes: result.terminal.outputBytes,
-        tuiFrameBytes: result.tui.frameBytes,
         sessionReportStatus: result.sessionReport._httpStatus || 200,
         sessionReportSize: result.sessionReport.byteLength || result.sessionReport.size || 0,
         streamEventCount: result.sessionsStream.eventCount,
@@ -3119,7 +3039,6 @@ async function main() {
       const mediaConnectNoLegacy = await ctl._debugProbeMediaConnectNoLegacy();
       const diagnosticsConnectNoHttp = await ctl._debugProbeDiagnosticsConnectNoHttp();
       const displaySignalConnectNoLegacy = await ctl._debugProbeDisplaySignalConnectNoLegacy();
-      const tuiConnectNoLegacy = ctl._debugProbeTuiConnectNoLegacy();
       const presenceMediaConnectNoLegacy = await ctl._debugProbePresenceMediaConnectNoLegacy();
       const presenceServerSenderConnectNoLegacy = await ctl._debugProbePresenceServerSenderConnectNoLegacy();
       const tunneledPresenceServerCallback = await ctl._debugProbeTunneledPresenceServerCallback();
@@ -3136,7 +3055,6 @@ async function main() {
         mediaConnectNoLegacy,
         diagnosticsConnectNoHttp,
         displaySignalConnectNoLegacy,
-        tuiConnectNoLegacy,
         presenceMediaConnectNoLegacy,
         presenceServerSenderConnectNoLegacy,
         tunneledPresenceServerCallback,
@@ -3278,31 +3196,6 @@ async function main() {
       `real SPA Connect display signaling attempted HTTP fallback: ${JSON.stringify(appResult.displaySignalConnectNoLegacy)}`
     );
     assert.strictEqual(
-      appResult.tuiConnectNoLegacy.skipped,
-      false,
-      `real SPA could not exercise Connect TUI no-legacy path: ${JSON.stringify(appResult.tuiConnectNoLegacy)}`
-    );
-    assert.strictEqual(
-      appResult.tuiConnectNoLegacy.keyReplayCount,
-      0,
-      `real SPA Connect TUI key replayed through legacy app path: ${JSON.stringify(appResult.tuiConnectNoLegacy)}`
-    );
-    assert.strictEqual(
-      appResult.tuiConnectNoLegacy.resizeReplayCount,
-      0,
-      `real SPA Connect TUI resize replayed through legacy app path: ${JSON.stringify(appResult.tuiConnectNoLegacy)}`
-    );
-    assert.strictEqual(
-      appResult.tuiConnectNoLegacy.wsReplayCount,
-      0,
-      `real SPA Connect TUI subscription replayed over /ws: ${JSON.stringify(appResult.tuiConnectNoLegacy)}`
-    );
-    assert.strictEqual(
-      appResult.tuiConnectNoLegacy.subscriptionSent,
-      false,
-      `real SPA Connect TUI subscription claimed legacy transport success: ${JSON.stringify(appResult.tuiConnectNoLegacy)}`
-    );
-    assert.strictEqual(
       appResult.presenceMediaConnectNoLegacy.skipped,
       false,
       `real SPA could not exercise Connect presence/media no-legacy path: ${JSON.stringify(appResult.presenceMediaConnectNoLegacy)}`
@@ -3400,7 +3293,6 @@ async function main() {
         mediaConnectNoLegacy: appResult.mediaConnectNoLegacy,
         diagnosticsConnectNoHttp: appResult.diagnosticsConnectNoHttp,
         displaySignalConnectNoLegacy: appResult.displaySignalConnectNoLegacy,
-        tuiConnectNoLegacy: appResult.tuiConnectNoLegacy,
         presenceMediaConnectNoLegacy: appResult.presenceMediaConnectNoLegacy,
         presenceServerSenderConnectNoLegacy: appResult.presenceServerSenderConnectNoLegacy,
         tunneledPresenceServerCallback: appResult.tunneledPresenceServerCallback,

--- a/scripts/validate-dashboard-control-local-signaling.cjs
+++ b/scripts/validate-dashboard-control-local-signaling.cjs
@@ -553,65 +553,6 @@ async function main() {
           window.removeEventListener('intendant-dashboard-terminal-frame', handler);
         }
       };
-      const tui = async () => {
-        const connectionId = `dashboard-tui-local-${Date.now()}`;
-        const frames = [];
-        const handler = event => frames.push(event.detail || {});
-        const waitFor = (predicate, label) => new Promise((resolve, reject) => {
-          const started = Date.now();
-          const tick = () => {
-            const found = frames.find(predicate);
-            if (found) {
-              resolve(found);
-              return;
-            }
-            if (Date.now() - started > 60000) {
-              reject(new Error(`tui ${label} timed out`));
-              return;
-            }
-            setTimeout(tick, 25);
-          };
-          tick();
-        });
-        window.addEventListener('intendant-dashboard-tui-frame', handler);
-        try {
-          ctl.tuiFrame({
-            t: 'tui_subscribe',
-            connection_id: connectionId,
-            cols: 80,
-            rows: 24,
-          });
-          const frame = await waitFor(item => (
-            item.t === 'tui_term' &&
-            item.connection_id === connectionId &&
-            Boolean(item.base64 || item.d)
-          ), 'term frame');
-          ctl.tuiFrame({
-            t: 'tui_key',
-            connection_id: connectionId,
-            key: 'Tab',
-            ctrl: false,
-            alt: false,
-            shift: false,
-          });
-          ctl.tuiFrame({
-            t: 'tui_unsubscribe',
-            connection_id: connectionId,
-          });
-          ctl.tuiFrame({
-            t: 'tui_close',
-            connection_id: connectionId,
-          });
-          const data = String(frame.base64 || frame.d || '');
-          return {
-            subscribed: true,
-            connectionId,
-            frameBytes: atob(data).length,
-          };
-        } finally {
-          window.removeEventListener('intendant-dashboard-tui-frame', handler);
-        }
-      };
       const status = await ctl.request('status', {}, { timeoutMs: 60000 });
       const uploaded = await upload();
       return {
@@ -661,7 +602,6 @@ async function main() {
         filesystemRead: await filesystemRead(),
         diagnosticsVisualFreshness: await diagnosticsVisualFreshness(),
         terminal: await terminal(),
-        tui: status.tui_frames_available ? await tui() : { skipped: true, subscribed: false, frameBytes: 0 },
         rejectedControlMsg: await labeled('api_control_msg rejected create_session', ctl.request('api_control_msg', {
           message: { action: 'create_session', task: 'noop' },
         }, { timeoutMs: 60000 })),
@@ -821,7 +761,6 @@ async function main() {
     assert.strictEqual(result.finalStatus.byteStreamsAvailable, true);
     assert.strictEqual(result.finalStatus.uploadFramesAvailable, true);
     assert.strictEqual(result.finalStatus.terminalFramesAvailable, true);
-    assert.strictEqual(result.finalStatus.tuiFramesAvailable, result.status.tui_frames_available === true);
     assert.strictEqual(result.finalStatus.apiSessionCurrentUploadsAvailable, true);
     assert.strictEqual(result.finalStatus.apiSessionCurrentUploadAvailable, true);
     assert.strictEqual(result.finalStatus.apiSessionCurrentUploadRawAvailable, true);
@@ -925,12 +864,6 @@ async function main() {
     ), { force: true });
     assert.strictEqual(result.terminal?.opened, true);
     assert.strictEqual(result.terminal?.sawToken, true);
-    if (result.status.tui_frames_available) {
-      assert.strictEqual(result.tui?.subscribed, true);
-      assert(Number(result.tui?.frameBytes || 0) > 0, 'TUI frame did not contain bytes');
-    } else {
-      assert.strictEqual(result.tui?.skipped, true);
-    }
     if (result.sessionReport?.ok === true) {
       assert.strictEqual(result.sessionReport.content_type, 'application/zip');
       assert(String(result.sessionReport.filename || '').endsWith('.zip'), 'session report filename was not a zip');
@@ -1023,7 +956,6 @@ async function main() {
         byteStreamsAvailable: result.finalStatus.byteStreamsAvailable,
         uploadFramesAvailable: result.finalStatus.uploadFramesAvailable,
         terminalFramesAvailable: result.finalStatus.terminalFramesAvailable,
-        tuiFramesAvailable: result.finalStatus.tuiFramesAvailable,
         apiSessionCurrentUploadsAvailable: result.finalStatus.apiSessionCurrentUploadsAvailable,
         apiSessionCurrentUploadAvailable: result.finalStatus.apiSessionCurrentUploadAvailable,
         apiSessionCurrentUploadRawAvailable: result.finalStatus.apiSessionCurrentUploadRawAvailable,
@@ -1058,7 +990,6 @@ async function main() {
         filesystemReadText: result.filesystemRead.text,
         diagnosticsVisualFreshnessWritten: result.diagnosticsVisualFreshness.written,
         terminalOutputBytes: result.terminal.outputBytes,
-        tuiFrameBytes: result.tui.frameBytes,
         sessionReportStatus: result.sessionReport._httpStatus || 200,
         sessionReportSize: result.sessionReport.byteLength || result.sessionReport.size || 0,
         rejectedControlStatus: result.rejectedControlMsg._httpStatus,


### PR DESCRIPTION
Independent fix found while running the S11 battery: the TUI gutting (84afe9d8) removed `tui_frames_available` from status, the SPA's `_debugProbeTuiConnectNoLegacy`, and the terminal pane's tui subtab — but three connect/tunnel validators still probe them, so each hard-fails against any current daemon:

- **validate-dashboard-control-local-signaling**: `finalStatus.tuiFramesAvailable` assertion compares `undefined` to `false`; dead `tui()` probe + gated asserts + summary echoes removed.
- **validate-connect-hosted-mvp**: the capability wait predicate required `tuiFramesAvailable === false` (never satisfiable), the probe sweep called the deleted `_debugProbeTuiConnectNoLegacy` (TypeError), and the terminal step clicked a tui subtab the SPA no longer renders.
- **validate-connect-rendezvous**: same dead probe/assert/echo class in the emulator client and the real-SPA probe set; the emulator hello stops advertising the dead `tui_frames` feature.

Pure deletion of dead probes — no live assertion is weakened; every surviving probe was grep-verified to still exist in `static/app/`.

Verified: `validate-dashboard-control-local-signaling` passes end to end against a current build (exit 0, keyless mock-provider rig); `node --check` on all three.