### PR TITLE
Transport S11b (the removal): one spawned-lane binding; removal audit comes back empty

### DIFF
--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -18,41 +18,57 @@ pub(crate) fn spawn_control_request(
     let cancel = CancellationToken::new();
     pending_requests.insert(id.clone(), cancel.clone());
     tokio::spawn(async move {
-        let response = match method.as_str() {
-            "api_session_report" => {
-                api_session_report_task_response(id.clone(), params.as_ref(), &runtime).await
-            }
-            "api_session_current_upload_raw" => {
-                api_session_current_upload_raw_task_response(id.clone(), params.as_ref(), &runtime)
-                    .await
-            }
-            "api_recording_asset" => {
-                api_recording_asset_task_response(id.clone(), params.as_ref(), &runtime).await
-            }
-            "api_session_recording_asset" => {
-                api_session_recording_asset_task_response(id.clone(), params.as_ref()).await
-            }
-            "api_session_frame_asset" => {
-                api_session_frame_asset_task_response(id.clone(), params.as_ref()).await
-            }
-            "api_fs_read" => api_fs_read_task_response(id.clone(), params.as_ref()).await,
-            "api_transfer_download_read" => {
-                api_transfer_download_read_task_response(id.clone(), params.as_ref(), &runtime)
-                    .await
-            }
-            _ => {
-                let frame =
-                    control_request_response(id.clone(), method, params, runtime, cancel).await;
-                ControlTaskResponse {
-                    id,
-                    frame,
-                    byte_stream: None,
-                    done: true,
-                }
-            }
-        };
+        let response = control_request_response(id, method, params, runtime, cancel).await;
         let _ = task_tx.send(response).await;
     });
+}
+
+/// The spawned request lane's one method→handler binding
+/// (transport-unification S11): byte-capable methods answer as complete
+/// task responses (`byte_stream_*` sequences, with their JSON error
+/// shapes riding the same task envelope); every other declared method
+/// produces its single JSON response frame through
+/// [`control_request_frame`], wrapped into the task envelope once at
+/// this seam. Each arm's body is the tunnel's transport edge — param
+/// decode, ambient resolution, the lane adapter — around the shared
+/// neutral core.
+pub(crate) async fn control_request_response(
+    id: String,
+    method: String,
+    params: Option<serde_json::Value>,
+    runtime: ControlRuntime,
+    cancel: CancellationToken,
+) -> ControlTaskResponse {
+    match method.as_str() {
+        "api_session_report" => {
+            api_session_report_task_response(id, params.as_ref(), &runtime).await
+        }
+        "api_session_current_upload_raw" => {
+            api_session_current_upload_raw_task_response(id, params.as_ref(), &runtime).await
+        }
+        "api_recording_asset" => {
+            api_recording_asset_task_response(id, params.as_ref(), &runtime).await
+        }
+        "api_session_recording_asset" => {
+            api_session_recording_asset_task_response(id, params.as_ref()).await
+        }
+        "api_session_frame_asset" => {
+            api_session_frame_asset_task_response(id, params.as_ref()).await
+        }
+        "api_fs_read" => api_fs_read_task_response(id, params.as_ref()).await,
+        "api_transfer_download_read" => {
+            api_transfer_download_read_task_response(id, params.as_ref(), &runtime).await
+        }
+        _ => {
+            let frame = control_request_frame(id.clone(), method, params, runtime, cancel).await;
+            ControlTaskResponse {
+                id,
+                frame,
+                byte_stream: None,
+                done: true,
+            }
+        }
+    }
 }
 
 pub(crate) fn spawn_control_stream(
@@ -160,7 +176,12 @@ pub(crate) async fn api_access_connect_unclaim_response(
     )
 }
 
-pub(crate) async fn control_request_response(
+/// The JSON half of the spawned lane's binding: one arm per method,
+/// each producing the single `response` frame its wire shape has always
+/// been. Split from [`control_request_response`] so the byte-capable
+/// arms above can keep the task-response envelope without re-wrapping
+/// every JSON arm.
+pub(crate) async fn control_request_frame(
     id: String,
     method: String,
     params: Option<serde_json::Value>,


### PR DESCRIPTION
Stage S11b of the transport-unification program (design §6, S11 — the removal half). **Stacks on #229 (S11a)** — contains its commit; will update-branch once #229 merges.

## What changes

- **The spawned request lane's two-level dispatch collapses into one binding**: the seven byte-capable arms (`api_session_report`, `api_session_current_upload_raw`, `api_recording_asset`, `api_session_recording_asset`, `api_session_frame_asset`, `api_fs_read`, `api_transfer_download_read`) move from `spawn_control_request`'s inner match into `control_request_response`, which now returns the full task envelope; the JSON binding keeps its ~70 arms verbatim as `control_request_frame`. `spawn_control_request` is bookkeeping + spawn only. Cancel-at-entry semantics preserved exactly (JSON path checks; byte arms never did).

## The removal audit — empty, and why

The stage was scoped to delete "the moved `api_*_response` bodies, dead `json_body_response` duplicates, and any helper only they used". The audit came back empty because the strangler stages already deleted each family's duplicated bodies as they converted (S2 fs, S4 sessions, S6 access, S7 peers, S8 media, S9 transfers, S10 streams), and `http_wire_response`/`split_http_response` died in S4c (verified: no occurrences). Evidence:

- clean build with zero dead-code warnings;
- crate-wide orphan scan over `web_gateway` + `dashboard_control`: every `api_*_response` wrapper has live non-test callers (and most are additionally pinned by the tunnel/HTTP parity fixtures);
- the remaining `#[allow(dead_code)]` sites are documented deliberate seams (docs-render harness, test-only `_from_home` convenience wrappers in session_catalog, parked audit fields) — deleting the test-only wrappers would require editing the fixtures that call them, which this stage's rules forbid.

Zero wire changes, zero IAM changes; goldens + parity fixtures untouched; the partition pin (union-equality proof) unchanged from #229.

Battery: fmt ✅ nextest 3031/3031 ✅ clippy ✅ e2e 15/15 ✅ dashboard-control local signaling validator exit 0 against this build (fixed script from #230). Hosted/peer validators = operator battery, post-landing.