### PR TITLE
Transport S12 (frame-table unification): FRAME_LANES single declaration for both realtime lanes

### DIFF
--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -369,8 +369,8 @@ pub fn profile_allows_control_msg(profile: &str, ctrl: &ControlMsg) -> bool {
 /// tunnel's WebRTC signaling relay is a transport door, not a single
 /// operation: it opens for an identity that can use at least one of these,
 /// and every method/frame inside is then authorized individually against
-/// the same identity (`dashboard_control_method_operation` /
-/// `dashboard_control_frame_operation` and their `/ws` twins). Presence-
+/// the same identity (`authorize_dashboard_control_method` and the
+/// [`FRAME_LANES`] per-frame gates on both transports). Presence-
 /// and stats-only profiles have nothing reachable inside, so the door
 /// stays shut for them.
 pub const DASHBOARD_CONTROL_TUNNEL_OPERATIONS: &[PeerOperation] = &[
@@ -386,6 +386,395 @@ pub fn profile_allows_dashboard_control_tunnel(profile: &str) -> bool {
     DASHBOARD_CONTROL_TUNNEL_OPERATIONS
         .iter()
         .any(|op| profile_allows_operation(profile, *op))
+}
+
+/// A realtime transport that carries typed frames: the direct `/ws`
+/// WebSocket session or the dashboard-control datachannel tunnel.
+///
+/// The request/response API surface is declared once in
+/// `gateway_routes::ROUTES` (+ the tunnel residue table); realtime frames
+/// stay bespoke per lane — connection-scoped state machines on
+/// latency-sensitive paths (transport design §2.6) — but their IAM mapping
+/// is declared once, in [`FRAME_LANES`], and both lanes' per-frame gates
+/// ([`crate::web_gateway::ws_frame_operation`] and
+/// `dashboard_control::dashboard_control_frame_operation`) are lookups into
+/// it: parity by construction, where hand-kept "Parity:" comments used to
+/// carry it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameLane {
+    /// The direct `/ws` WebSocket session (`web_gateway/ws_session.rs`).
+    Ws,
+    /// The dashboard-control datachannel tunnel (`dashboard_control/`).
+    Tunnel,
+}
+
+/// One realtime frame kind: the floor operation it exercises and the lanes
+/// that carry it.
+pub struct FrameLaneSpec {
+    /// Wire frame type — the frame's `t` tag.
+    pub frame: &'static str,
+    /// Floor operation the frame exercises on the lanes that carry it.
+    /// `None` = the frame carries no blanket authority of its own; `note`
+    /// says why. Floor means floor: handlers still enforce whatever
+    /// stateful checks apply (session visibility, connection binding,
+    /// shell.spawn on fresh terminal_open, …).
+    pub op: Option<PeerOperation>,
+    /// Carried on the direct `/ws` session.
+    pub ws: bool,
+    /// Carried on the dashboard-control tunnel.
+    pub tunnel: bool,
+    /// Why the row is shaped this way — op rationale, `None` reason, or
+    /// single-lane reason. Mandatory; an invariant test pins it non-empty.
+    pub note: &'static str,
+}
+
+/// The single declaration of realtime-frame IAM: every frame kind either
+/// lane's per-frame gate maps, the operation it requires, and which lanes
+/// carry it. A kind absent here (or carried only on the other lane)
+/// answers `None` — no blanket authority, matching the pre-table
+/// behavior: per-frame gating fails open by design for dispatch machinery
+/// and replies, whose authority (if any) is enforced elsewhere (the
+/// method table for `request`, per-delivered-method auth for uploads,
+/// stateful checks in handlers).
+///
+/// Changing a row is an IAM change. The frozen golden test
+/// (`realtime_frame_operation_golden_mapping_is_frozen`) pins the full
+/// mapping on both lanes — update it deliberately, with the grant model
+/// in view, never to satisfy a refactor.
+pub const FRAME_LANES: &[FrameLaneSpec] = &[
+    // ---- carried on both lanes, same floor operation ----
+    FrameLaneSpec {
+        frame: "terminal_open",
+        op: Some(PeerOperation::TerminalView),
+        ws: true,
+        tunnel: true,
+        note: "attach/replay is the floor; opening a session that does not exist yet \
+               additionally requires shell.spawn, enforced statefully in the handlers",
+    },
+    FrameLaneSpec {
+        frame: "terminal_input",
+        op: Some(PeerOperation::TerminalWrite),
+        ws: true,
+        tunnel: true,
+        note: "keystrokes into a visible shell session (session visibility enforced in handlers)",
+    },
+    FrameLaneSpec {
+        frame: "terminal_resize",
+        op: Some(PeerOperation::TerminalWrite),
+        ws: true,
+        tunnel: true,
+        note: "resize mutates the PTY like input does",
+    },
+    FrameLaneSpec {
+        frame: "terminal_close",
+        op: Some(PeerOperation::TerminalWrite),
+        ws: true,
+        tunnel: true,
+        note: "closing a session mutates it",
+    },
+    FrameLaneSpec {
+        frame: "terminal_share",
+        op: Some(PeerOperation::TerminalWrite),
+        ws: true,
+        tunnel: true,
+        note: "sharing re-scopes a session's audience — a mutation, not a view",
+    },
+    FrameLaneSpec {
+        frame: "display_input",
+        op: Some(PeerOperation::DisplayInput),
+        ws: true,
+        tunnel: true,
+        note: "pointer/keyboard injection into a display",
+    },
+    // ---- /ws only: display signaling + diagnostics marker ----
+    FrameLaneSpec {
+        frame: "set_diagnostics_visual_marker",
+        op: Some(PeerOperation::DisplayInput),
+        ws: true,
+        tunnel: false,
+        note: "twin of api_diagnostics_visual_freshness: the marker is stamped pre-encoder \
+               and lands in every viewer's stream — display mutation, not viewing",
+    },
+    FrameLaneSpec {
+        frame: "display_offer",
+        op: Some(PeerOperation::DisplayView),
+        ws: true,
+        tunnel: false,
+        note: "display WebRTC signaling; tunnel twins are the api_display_bootstrap / \
+               api_display_webrtc_signal methods, not frames",
+    },
+    FrameLaneSpec {
+        frame: "display_ice",
+        op: Some(PeerOperation::DisplayView),
+        ws: true,
+        tunnel: false,
+        note: "ICE leg of display_offer",
+    },
+    // ---- /ws only: legacy web-TUI lane (dead, preserved verbatim) ----
+    // The embedded web TUI's frame handlers were removed when the TUI was
+    // gutted (84afe9d8); nothing consumes these kinds on /ws anymore, and
+    // no tunnel twin ever existed. The gate rows survive verbatim because
+    // dropping a frame kind changes observable behavior for scoped
+    // clients (denial frame vs silence) — an owner decision, not
+    // refactor fallout.
+    FrameLaneSpec {
+        frame: "key",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "legacy web-TUI keystroke into the daemon's own runtime (handlers gone; see above)",
+    },
+    FrameLaneSpec {
+        frame: "resize",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "legacy web-TUI terminal resize (handlers gone; see above)",
+    },
+    FrameLaneSpec {
+        frame: "term_subscribe",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "legacy web-TUI output subscription (handlers gone; see above)",
+    },
+    FrameLaneSpec {
+        frame: "term_unsubscribe",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "legacy web-TUI output unsubscription (handlers gone; see above)",
+    },
+    // ---- /ws only: live voice/media presence machinery ----
+    // The tunnel carries this family wrapped in a single presence_frame
+    // envelope (its own row below); /ws speaks the kinds raw. Method-lane
+    // twins: api_voice_session, api_presence_video_frame,
+    // api_media_annotation_*, api_media_clip_*.
+    FrameLaneSpec {
+        frame: "presence_connect",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "joins the live voice/presence session driving the daemon's runtime",
+    },
+    FrameLaneSpec {
+        frame: "presence_disconnect",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "leaves the live presence session",
+    },
+    FrameLaneSpec {
+        frame: "make_active",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "claims the active presence slot (voice handover)",
+    },
+    FrameLaneSpec {
+        frame: "user_audio",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "microphone PCM into transcription + the live session",
+    },
+    FrameLaneSpec {
+        frame: "video_frame",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "camera/screen frame into the live session (twin: api_presence_video_frame)",
+    },
+    FrameLaneSpec {
+        frame: "voice_log",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "browser-side voice transcript/log entry into the session record",
+    },
+    FrameLaneSpec {
+        frame: "voice_diagnostic",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "voice-pipeline diagnostics into the session record",
+    },
+    FrameLaneSpec {
+        frame: "presence_checkpoint",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "checkpoints presence conversation state",
+    },
+    FrameLaneSpec {
+        frame: "live_usage_update",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "browser-metered live-API usage folded into daemon accounting",
+    },
+    FrameLaneSpec {
+        frame: "annotation_attach",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "attaches an annotation image to the worker turn (twin: api_media_annotation_attach)",
+    },
+    FrameLaneSpec {
+        frame: "annotation_submit",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "submits the annotation composition (twin: api_media_annotation_submit)",
+    },
+    FrameLaneSpec {
+        frame: "clip_start",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "starts a media clip capture (twin: api_media_clip_start)",
+    },
+    FrameLaneSpec {
+        frame: "clip_frame",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "appends a clip frame (twin: api_media_clip_frame)",
+    },
+    FrameLaneSpec {
+        frame: "clip_end",
+        op: Some(PeerOperation::RuntimeControl),
+        ws: true,
+        tunnel: false,
+        note: "finalizes the clip (twin: api_media_clip_end)",
+    },
+    // ---- /ws only: presence tool dispatch ----
+    FrameLaneSpec {
+        frame: "tool_request",
+        op: Some(PeerOperation::Message),
+        ws: true,
+        tunnel: false,
+        note: "presence tool dispatch is messaging into the worker (parity: api_mcp_tool_call)",
+    },
+    FrameLaneSpec {
+        frame: "async_query",
+        op: Some(PeerOperation::Message),
+        ws: true,
+        tunnel: false,
+        note: "async presence query — same messaging lane as tool_request",
+    },
+    // ---- /ws only: tunnel-establishment signaling, deliberately open ----
+    FrameLaneSpec {
+        frame: "dashboard_control_offer",
+        op: None,
+        ws: true,
+        tunnel: false,
+        note: "establishing the tunnel carries no authority: the tunnel enforces this very \
+               grant per-frame itself, and scoped clients must be able to reach their \
+               allowed surface through it",
+    },
+    FrameLaneSpec {
+        frame: "dashboard_control_ice",
+        op: None,
+        ws: true,
+        tunnel: false,
+        note: "ICE leg of dashboard_control_offer — same open-by-design rationale",
+    },
+    FrameLaneSpec {
+        frame: "dashboard_control_close",
+        op: None,
+        ws: true,
+        tunnel: false,
+        note: "tearing the tunnel down needs no more authority than opening it",
+    },
+    // ---- tunnel only ----
+    FrameLaneSpec {
+        frame: "presence_frame",
+        op: Some(PeerOperation::Message),
+        ws: false,
+        tunnel: true,
+        note: "the tunnel's envelope for the presence family /ws speaks raw (rows above); \
+               gated as messaging into the presence layer",
+    },
+    FrameLaneSpec {
+        frame: "upload_start",
+        op: None,
+        ws: false,
+        tunnel: true,
+        note: "upload frames carry no blanket authority: upload_start is authorized by the \
+               operation of the method it delivers (a media annotation is runtime control, \
+               a transfer chunk is a filesystem write, …) inside control_upload_start_frame",
+    },
+    FrameLaneSpec {
+        frame: "upload_chunk",
+        op: None,
+        ws: false,
+        tunnel: true,
+        note: "acts only on an entry an authorized upload_start created on this connection",
+    },
+    FrameLaneSpec {
+        frame: "upload_end",
+        op: None,
+        ws: false,
+        tunnel: true,
+        note: "same connection-bound rationale as upload_chunk; delivery re-authorizes as \
+               the method",
+    },
+    FrameLaneSpec {
+        frame: "egress_response",
+        op: Some(PeerOperation::CredentialsManage),
+        ws: false,
+        tunnel: true,
+        note: "client-egress relay answers: only a session that could have registered as a \
+               relay (credentials.manage) may answer, and the handler additionally binds \
+               each frame to the request's own registering session",
+    },
+    FrameLaneSpec {
+        frame: "egress_chunk",
+        op: Some(PeerOperation::CredentialsManage),
+        ws: false,
+        tunnel: true,
+        note: "streamed continuation of egress_response — same gate",
+    },
+    FrameLaneSpec {
+        frame: "egress_end",
+        op: Some(PeerOperation::CredentialsManage),
+        ws: false,
+        tunnel: true,
+        note: "stream terminator — same gate",
+    },
+    FrameLaneSpec {
+        frame: "egress_error",
+        op: Some(PeerOperation::CredentialsManage),
+        ws: false,
+        tunnel: true,
+        note: "error terminator — same gate",
+    },
+    // ---- both lanes: liveness ----
+    FrameLaneSpec {
+        frame: "ping",
+        op: None,
+        ws: true,
+        tunnel: true,
+        note: "liveness probe; no authority",
+    },
+];
+
+/// Map a typed realtime frame to the `PeerOperation` it exercises on the
+/// given lane — the single lookup behind both lanes' per-frame gates.
+/// `None` means the frame carries no blanket authority there (no row, an
+/// op-less row, or a row the lane does not carry).
+pub fn frame_operation(lane: FrameLane, frame_type: &str) -> Option<PeerOperation> {
+    FRAME_LANES
+        .iter()
+        .find(|spec| {
+            spec.frame == frame_type
+                && match lane {
+                    FrameLane::Ws => spec.ws,
+                    FrameLane::Tunnel => spec.tunnel,
+                }
+        })
+        .and_then(|spec| spec.op)
 }
 
 pub fn control_msg_operation(ctrl: &ControlMsg) -> PeerOperation {
@@ -873,10 +1262,40 @@ pub fn normalize_fingerprint(raw: &str) -> Result<String, CallerError> {
 mod tests {
     use super::*;
 
+    /// Structural invariants of [`FRAME_LANES`]: one row per frame kind
+    /// (the lookup takes the first match, so a duplicate would shadow),
+    /// every row carried on at least one lane, and every row annotated —
+    /// the notes are the documentation the old per-arm "Parity:" comments
+    /// used to carry.
+    #[test]
+    fn frame_lanes_rows_are_unique_lane_marked_and_annotated() {
+        let mut seen = std::collections::HashSet::new();
+        for spec in FRAME_LANES {
+            assert!(
+                seen.insert(spec.frame),
+                "duplicate FRAME_LANES row for {:?}",
+                spec.frame
+            );
+            assert!(
+                spec.ws || spec.tunnel,
+                "FRAME_LANES row {:?} is carried on no lane",
+                spec.frame
+            );
+            assert!(
+                !spec.note.trim().is_empty(),
+                "FRAME_LANES row {:?} is missing its note",
+                spec.frame
+            );
+        }
+    }
+
     /// The frozen realtime-frame IAM contract: every frame kind either
-    /// per-frame gate explicitly maps today, on both transports, pinned
-    /// byte-for-byte BEFORE the `FRAME_LANES` unification so the table
-    /// rewrite is provably a pure re-plumbing. Columns: frame kind, the
+    /// per-frame gate explicitly maps, on both transports. The fixture
+    /// was committed byte-for-byte BEFORE the `FRAME_LANES` unification
+    /// (its history proves the table rewrite re-plumbed without
+    /// re-gating) and stays frozen after it: with both gates reading one
+    /// table, this pin is what makes silent re-gating impossible on
+    /// either lane. Columns: frame kind, the
     /// operation `web_gateway::ws_frame_operation` answers (the direct
     /// `/ws` session), the operation
     /// `dashboard_control::dashboard_control_frame_operation` answers

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -873,6 +873,103 @@ pub fn normalize_fingerprint(raw: &str) -> Result<String, CallerError> {
 mod tests {
     use super::*;
 
+    /// The frozen realtime-frame IAM contract: every frame kind either
+    /// per-frame gate explicitly maps today, on both transports, pinned
+    /// byte-for-byte BEFORE the `FRAME_LANES` unification so the table
+    /// rewrite is provably a pure re-plumbing. Columns: frame kind, the
+    /// operation `web_gateway::ws_frame_operation` answers (the direct
+    /// `/ws` session), the operation
+    /// `dashboard_control::dashboard_control_frame_operation` answers
+    /// (the datachannel tunnel). `None` = the frame carries no blanket
+    /// authority on that lane (off-lane kinds, no-authority dispatch
+    /// machinery, and unknown kinds all answer `None` — per-frame gating
+    /// here fails open by design; handlers own the stateful checks).
+    ///
+    /// Changing ANY cell is an IAM change: make it deliberately, with the
+    /// grant model in view — never to satisfy a refactor.
+    #[test]
+    fn realtime_frame_operation_golden_mapping_is_frozen() {
+        use PeerOperation::*;
+        #[rustfmt::skip]
+        const GOLDEN: &[(&str, Option<PeerOperation>, Option<PeerOperation>)] = &[
+            // frame kind                      /ws lane              tunnel lane
+            // -- carried on both lanes, same floor operation --
+            ("terminal_open",                  Some(TerminalView),   Some(TerminalView)),
+            ("terminal_input",                 Some(TerminalWrite),  Some(TerminalWrite)),
+            ("terminal_resize",                Some(TerminalWrite),  Some(TerminalWrite)),
+            ("terminal_close",                 Some(TerminalWrite),  Some(TerminalWrite)),
+            ("terminal_share",                 Some(TerminalWrite),  Some(TerminalWrite)),
+            ("display_input",                  Some(DisplayInput),   Some(DisplayInput)),
+            // -- /ws only: display signaling + diagnostics marker --
+            ("set_diagnostics_visual_marker",  Some(DisplayInput),   None),
+            ("display_offer",                  Some(DisplayView),    None),
+            ("display_ice",                    Some(DisplayView),    None),
+            // -- /ws only: legacy web-TUI lane (handlers gutted with the
+            //    TUI, 84afe9d8; the gate rows survive verbatim — dropping
+            //    the kinds is an owner decision, not refactor fallout) --
+            ("key",                            Some(RuntimeControl), None),
+            ("resize",                         Some(RuntimeControl), None),
+            ("term_subscribe",                 Some(RuntimeControl), None),
+            ("term_unsubscribe",               Some(RuntimeControl), None),
+            // -- /ws only: live voice/media presence machinery --
+            ("presence_connect",               Some(RuntimeControl), None),
+            ("presence_disconnect",            Some(RuntimeControl), None),
+            ("make_active",                    Some(RuntimeControl), None),
+            ("user_audio",                     Some(RuntimeControl), None),
+            ("video_frame",                    Some(RuntimeControl), None),
+            ("voice_log",                      Some(RuntimeControl), None),
+            ("voice_diagnostic",               Some(RuntimeControl), None),
+            ("presence_checkpoint",            Some(RuntimeControl), None),
+            ("live_usage_update",              Some(RuntimeControl), None),
+            ("annotation_attach",              Some(RuntimeControl), None),
+            ("annotation_submit",              Some(RuntimeControl), None),
+            ("clip_start",                     Some(RuntimeControl), None),
+            ("clip_frame",                     Some(RuntimeControl), None),
+            ("clip_end",                       Some(RuntimeControl), None),
+            // -- /ws only: presence tool dispatch --
+            ("tool_request",                   Some(Message),        None),
+            ("async_query",                    Some(Message),        None),
+            // -- /ws only: tunnel-establishment signaling stays open (the
+            //    tunnel enforces this very grant per-frame itself) --
+            ("dashboard_control_offer",        None,                 None),
+            ("dashboard_control_ice",          None,                 None),
+            ("dashboard_control_close",        None,                 None),
+            // -- tunnel only: the presence wrapper envelope --
+            ("presence_frame",                 None,                 Some(Message)),
+            // -- tunnel only: upload frames are authorized by the method
+            //    they deliver, never by a blanket grant --
+            ("upload_start",                   None,                 None),
+            ("upload_chunk",                   None,                 None),
+            ("upload_end",                     None,                 None),
+            // -- tunnel only: client-egress relay answers --
+            ("egress_response",                None,                 Some(CredentialsManage)),
+            ("egress_chunk",                   None,                 Some(CredentialsManage)),
+            ("egress_end",                     None,                 Some(CredentialsManage)),
+            ("egress_error",                   None,                 Some(CredentialsManage)),
+            // -- no-authority dispatch machinery + unknown kinds --
+            ("ping",                           None,                 None),
+            ("hello",                          None,                 None),
+            ("request",                        None,                 None),
+            ("response",                       None,                 None),
+            ("cancel",                         None,                 None),
+            ("credit",                         None,                 None),
+            ("event",                          None,                 None),
+            ("no_such_frame_kind",             None,                 None),
+        ];
+        for (frame, ws_expected, tunnel_expected) in GOLDEN {
+            assert_eq!(
+                crate::web_gateway::ws_frame_operation(frame),
+                *ws_expected,
+                "/ws frame {frame:?} drifted from the golden mapping",
+            );
+            assert_eq!(
+                crate::dashboard_control::dashboard_control_frame_operation(frame),
+                *tunnel_expected,
+                "tunnel frame {frame:?} drifted from the golden mapping",
+            );
+        }
+    }
+
     /// Pins the least-privilege pairing default (owner decision,
     /// 2026-07-08): an unlabeled pairing views displays and never holds
     /// input. Widening this default back to an input-capable profile is a

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -425,6 +425,9 @@ pub struct FrameLaneSpec {
     pub tunnel: bool,
     /// Why the row is shaped this way — op rationale, `None` reason, or
     /// single-lane reason. Mandatory; an invariant test pins it non-empty.
+    /// Documentation-bearing only: no runtime path reads it (the lookup
+    /// keys on `frame` + lanes), hence the targeted allow.
+    #[allow(dead_code)]
     pub note: &'static str,
 }
 

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -1536,7 +1536,9 @@ fn runtime_operation_decision(
     runtime.grant.access_decision(op)
 }
 
-fn dashboard_control_frame_operation(t: &str) -> Option<crate::peer::access_policy::PeerOperation> {
+pub(crate) fn dashboard_control_frame_operation(
+    t: &str,
+) -> Option<crate::peer::access_policy::PeerOperation> {
     use crate::peer::access_policy::PeerOperation;
     match t {
         "display_input" => Some(PeerOperation::DisplayInput),

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -1536,36 +1536,16 @@ fn runtime_operation_decision(
     runtime.grant.access_decision(op)
 }
 
+/// Map a typed tunnel frame to the `PeerOperation` it exercises — the
+/// datachannel lookup into the shared `access_policy::FRAME_LANES`
+/// declaration (`web_gateway::ws_frame_operation` reads the same table),
+/// so the same IAM grant answers the same way whichever transport a client
+/// speaks — parity by construction. `None` means the frame carries no
+/// blanket authority of its own here; each table row's `note` says why.
 pub(crate) fn dashboard_control_frame_operation(
     t: &str,
 ) -> Option<crate::peer::access_policy::PeerOperation> {
-    use crate::peer::access_policy::PeerOperation;
-    match t {
-        "display_input" => Some(PeerOperation::DisplayInput),
-        // Floor operations: terminal_open may additionally require
-        // shell.spawn (when the session doesn't exist yet) and every
-        // terminal frame is scoped to sessions the actor can see — both
-        // enforced statefully in the frame handlers.
-        "terminal_open" => Some(PeerOperation::TerminalView),
-        "terminal_input" | "terminal_resize" | "terminal_close" | "terminal_share" => {
-            Some(PeerOperation::TerminalWrite)
-        }
-        "presence_frame" => Some(PeerOperation::Message),
-        // Upload frames carry no blanket authority: upload_start is
-        // authorized by the operation of the method it delivers (a media
-        // annotation is runtime control, a transfer chunk is a filesystem
-        // write, …) inside control_upload_start_frame, and chunk/end only
-        // act on an entry an authorized start created on this connection.
-        "upload_start" | "upload_chunk" | "upload_end" => None,
-        // Client-egress response frames: only a session that could have
-        // registered as a relay (credentials.manage) may answer, and the
-        // handler additionally binds each frame to the request's own
-        // registering session.
-        "egress_response" | "egress_chunk" | "egress_end" | "egress_error" => {
-            Some(PeerOperation::CredentialsManage)
-        }
-        _ => None,
-    }
+    crate::peer::access_policy::frame_operation(crate::peer::access_policy::FrameLane::Tunnel, t)
 }
 
 /// Paths a filesystem method touches, for scope checks and the audit trail.

--- a/src/bin/caller/web_gateway/access_gates.rs
+++ b/src/bin/caller/web_gateway/access_gates.rs
@@ -202,59 +202,18 @@ pub(crate) fn peer_identity_allows_ws_control(
 }
 
 /// Map a typed `/ws` frame to the `PeerOperation` it exercises — the
-/// direct-WebSocket mirror of `dashboard_control_frame_operation` and
-/// the `CONTROL_ONLY_METHODS` table (dashboard_control/mod.rs), so the same
-/// IAM grant answers the same way whichever transport a client speaks.
-/// `None` means the frame carries no authority of its own: replies, pings,
-/// and the `dashboard_control_*` signaling frames (the tunnel they establish
-/// enforces this very grant per-frame itself, and scoped clients must be
-/// able to reach their allowed surface through it).
+/// `/ws` lookup into the shared [`access_policy::FRAME_LANES`] declaration
+/// (the tunnel's `dashboard_control_frame_operation` reads the same table),
+/// so the same IAM grant answers the same way whichever transport a client
+/// speaks — parity by construction. `None` means the frame carries no
+/// blanket authority of its own here; each table row's `note` says why.
 pub(crate) fn ws_frame_operation(
     frame_type: &str,
 ) -> Option<crate::peer::access_policy::PeerOperation> {
-    use crate::peer::access_policy::PeerOperation;
-    match frame_type {
-        // Same frame names as the dashboard-control tunnel table. Floor
-        // operations: terminal_open may additionally require shell.spawn
-        // (when the session doesn't exist yet) and every terminal frame is
-        // scoped to sessions the actor can see — both enforced statefully
-        // in the frame handlers.
-        "terminal_open" => Some(PeerOperation::TerminalView),
-        "terminal_input" | "terminal_resize" | "terminal_close" | "terminal_share" => {
-            Some(PeerOperation::TerminalWrite)
-        }
-        "display_input" => Some(PeerOperation::DisplayInput),
-        // Parity: api_diagnostics_visual_freshness → DisplayInput. The
-        // marker is stamped pre-encoder and lands in every viewer's stream,
-        // so it is display mutation, not viewing.
-        "set_diagnostics_visual_marker" => Some(PeerOperation::DisplayInput),
-        // Parity: api_display_bootstrap / api_display_webrtc_signal.
-        "display_offer" | "display_ice" => Some(PeerOperation::DisplayView),
-        // The embedded web TUI drives the daemon's own runtime — the direct
-        // twins of the tunnel's tui_* frames.
-        "key" | "resize" | "term_subscribe" | "term_unsubscribe" => {
-            Some(PeerOperation::RuntimeControl)
-        }
-        // Live voice/media session machinery. Parity: api_voice_session,
-        // api_presence_video_frame, api_media_annotation_*, api_media_clip_*.
-        "presence_connect"
-        | "presence_disconnect"
-        | "make_active"
-        | "user_audio"
-        | "video_frame"
-        | "voice_log"
-        | "voice_diagnostic"
-        | "presence_checkpoint"
-        | "live_usage_update"
-        | "annotation_attach"
-        | "annotation_submit"
-        | "clip_start"
-        | "clip_frame"
-        | "clip_end" => Some(PeerOperation::RuntimeControl),
-        // Presence tool dispatch. Parity: api_mcp_tool_call → Message.
-        "tool_request" | "async_query" => Some(PeerOperation::Message),
-        _ => None,
-    }
+    crate::peer::access_policy::frame_operation(
+        crate::peer::access_policy::FrameLane::Ws,
+        frame_type,
+    )
 }
 
 /// Per-frame IAM gate for the direct `/ws` path. Returns `true` when the
@@ -737,64 +696,10 @@ mod tests {
     // /ws bearer enforcement (slice 2d)
     // -----------------------------------------------------------------
 
-    #[test]
-    fn ws_frame_operation_mirrors_dashboard_control_tables() {
-        use crate::peer::access_policy::PeerOperation;
-        assert_eq!(
-            ws_frame_operation("terminal_open"),
-            Some(PeerOperation::TerminalView)
-        );
-        assert_eq!(
-            ws_frame_operation("terminal_input"),
-            Some(PeerOperation::TerminalWrite)
-        );
-        assert_eq!(
-            ws_frame_operation("terminal_share"),
-            Some(PeerOperation::TerminalWrite)
-        );
-        assert_eq!(
-            ws_frame_operation("display_input"),
-            Some(PeerOperation::DisplayInput)
-        );
-        assert_eq!(
-            ws_frame_operation("set_diagnostics_visual_marker"),
-            Some(PeerOperation::DisplayInput)
-        );
-        assert_eq!(
-            ws_frame_operation("display_offer"),
-            Some(PeerOperation::DisplayView)
-        );
-        assert_eq!(
-            ws_frame_operation("key"),
-            Some(PeerOperation::RuntimeControl)
-        );
-        assert_eq!(
-            ws_frame_operation("term_subscribe"),
-            Some(PeerOperation::RuntimeControl)
-        );
-        assert_eq!(
-            ws_frame_operation("presence_connect"),
-            Some(PeerOperation::RuntimeControl)
-        );
-        assert_eq!(
-            ws_frame_operation("user_audio"),
-            Some(PeerOperation::RuntimeControl)
-        );
-        assert_eq!(
-            ws_frame_operation("tool_request"),
-            Some(PeerOperation::Message)
-        );
-        assert_eq!(
-            ws_frame_operation("async_query"),
-            Some(PeerOperation::Message)
-        );
-        // Tunnel signaling stays open: the tunnel enforces the same grant
-        // per-frame itself, and scoped clients must be able to establish it.
-        assert_eq!(ws_frame_operation("dashboard_control_offer"), None);
-        assert_eq!(ws_frame_operation("dashboard_control_ice"), None);
-        assert_eq!(ws_frame_operation("dashboard_control_close"), None);
-        assert_eq!(ws_frame_operation("ping"), None);
-    }
+    // The old ws_frame_operation mirror test lived here; the mapping is
+    // now declared once in `access_policy::FRAME_LANES` and frozen — both
+    // lanes, every kind — by `realtime_frame_operation_golden_mapping_is_frozen`
+    // (access/access_policy.rs).
 
     #[test]
     fn verify_bearer_for_ws_passes_when_no_token_configured() {


### PR DESCRIPTION
Last server stage of the transport-unification program (design §6 S12).

- Golden-first: a frozen fixture pins the CURRENT full frame-kind × operation mapping of both `ws_frame_operation` (/ws) and `dashboard_control_frame_operation` (tunnel) — committed before the table, unchanged after, proving the rewrite is a pure re-plumbing with zero IAM change.
- `FRAME_LANES` single declaration in `access/access_policy.rs`: each realtime frame kind × required operation × lanes that carry it; both per-lane functions become lookups. Parity-by-construction replaces the hand-kept "Parity:" comments.
- Frame *behavior* stays bespoke per lane (design §2.6); only the IAM mapping unifies.