### PR TITLE
Petnames: the owner's name for a machine, signed into the fleet record

### DIFF
--- a/docs/src/trust-tiers.md
+++ b/docs/src/trust-tiers.md
@@ -242,8 +242,14 @@ stated non-goal:
 - **Lookalike names.** `d-<hash>` labels are deliberately opaque, which
   also means humans cannot eyeball them; a phished lookalike with its own
   valid certificate raises no CT alarm on *your* name, because it is not
-  your name. The mitigation is navigational: reach fleet names from the
-  fleet strip, bookmarks, or the app — never by retyping.
+  your name. Two mitigations now, one navigational and one nominal:
+  reach fleet names from the fleet strip, bookmarks, or the app — never
+  by retyping — and give machines **petnames**: the owner's name for a
+  daemon, signed into the fleet record (payload v5) and keyed to the
+  record's identity, shown first everywhere with the self-reported label
+  demoted to a muted secondary. A lookalike arrives *nameless* — no
+  store, phisher, or self-chosen label can dress it in a name you
+  assigned.
 - **The browser itself.** Every rung assumes the browser and OS are
   honest; an extension with page access reads all tiers alike. Outside
   Intendant's reach — stated so the ladder is not mistaken for covering

--- a/src/bin/connect/fleet.rs
+++ b/src/bin/connect/fleet.rs
@@ -88,6 +88,8 @@ pub(crate) struct FleetTargetInput {
     #[serde(default)]
     tier: String,
     #[serde(default)]
+    petname: String,
+    #[serde(default)]
     origin: String,
     #[serde(default, alias = "connectDaemonId")]
     connect_daemon_id: String,
@@ -350,9 +352,10 @@ pub(crate) fn normalize_fleet_target_input(
         browser_tcp_via_url: clean_fleet_url(&input.browser_tcp_via_url),
         connect_signaling_base: clean_fleet_url(&input.connect_signaling_base),
         enc_fields: clean_fleet_text(&input.enc_fields, FLEET_ENC_MAX),
-        // Signed v4 payload line — relayed verbatim-but-bounded like the
-        // signature fields; the store never interprets the tier.
+        // Signed v4/v5 payload lines — relayed verbatim-but-bounded like
+        // the signature fields; the store interprets neither.
         tier: clean_fleet_token(&input.tier, FLEET_TEXT_MAX),
+        petname: clean_fleet_text(&input.petname, FLEET_LABEL_MAX),
         origin: clean_fleet_url(&input.origin),
         connect_daemon_id: if connect_daemon_id.is_empty() {
             None
@@ -753,6 +756,7 @@ mod tests {
                 host_id: "daemon-1".to_string(),
                 label: "Anchor box".to_string(),
                 tier: "integrated".to_string(),
+                petname: "Muffin".to_string(),
                 record_key: "PubKeyB64u".to_string(),
                 record_sig: "SigB64u".to_string(),
                 record_signed_at_unix_ms: 1_700_000_000_000,
@@ -769,11 +773,13 @@ mod tests {
         assert_eq!(record.record_sig, "SigB64u");
         assert_eq!(record.record_signed_at_unix_ms, 1_700_000_000_000);
         assert_eq!(record.tier, "integrated");
+        assert_eq!(record.petname, "Muffin");
         let view = fleet_target_view(&record);
         assert_eq!(view["record_key"], "PubKeyB64u");
         assert_eq!(view["record_sig"], "SigB64u");
         assert_eq!(view["record_signed_at_unix_ms"], 1_700_000_000_000u64);
         assert_eq!(view["tier"], "integrated");
+        assert_eq!(view["petname"], "Muffin");
 
         // Future timestamps clamp to the sync time instead of trusting the
         // client clock.
@@ -857,6 +863,7 @@ mod tests {
                 connect_signaling_base: String::new(),
                 enc_fields: String::new(),
                 tier: String::new(),
+                petname: String::new(),
                 origin: "https://intendant.dev".to_string(),
                 connect_daemon_id: " daemon ".to_string(),
                 record_key: String::new(),
@@ -934,6 +941,7 @@ mod tests {
                     connect_signaling_base: String::new(),
                     enc_fields: String::new(),
                     tier: String::new(),
+                    petname: String::new(),
                     origin: "https://intendant.dev".to_string(),
                     connect_daemon_id: Some("daemon-1".to_string()),
                     capabilities: Vec::new(),
@@ -966,6 +974,7 @@ mod tests {
                     connect_signaling_base: String::new(),
                     enc_fields: String::new(),
                     tier: String::new(),
+                    petname: String::new(),
                     origin: "https://connect.intendant.dev".to_string(),
                     connect_daemon_id: Some("daemon-1".to_string()),
                     capabilities: Vec::new(),
@@ -998,6 +1007,7 @@ mod tests {
                     connect_signaling_base: String::new(),
                     enc_fields: String::new(),
                     tier: String::new(),
+                    petname: String::new(),
                     origin: "https://intendant.dev".to_string(),
                     connect_daemon_id: None,
                     capabilities: Vec::new(),

--- a/src/bin/connect/main.rs
+++ b/src/bin/connect/main.rs
@@ -853,6 +853,10 @@ struct FleetTargetRecord {
     // it — clients verify it under the record signature.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     tier: String,
+    // Owner-chosen petname (signed v5 line): the anti-lookalike name.
+    // Same relay-blind discipline.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    petname: String,
     #[serde(default)]
     origin: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1180,6 +1184,7 @@ fn fleet_target_view(target: &FleetTargetRecord) -> serde_json::Value {
         "connect_signaling_base": target.connect_signaling_base,
         "enc_fields": target.enc_fields,
         "tier": target.tier,
+        "petname": target.petname,
         "origin": target.origin,
         "connect_daemon_id": target.connect_daemon_id,
         "capabilities": target.capabilities,

--- a/static/app.html
+++ b/static/app.html
@@ -74433,6 +74433,19 @@ function renderPeerAccessRequests(requests) {
     // already means "pinned to a proven daemon key". Unverified and
     // legacy callers carry no claim and render exactly as before.
     const requesterTier = String(req.requester_tier || '').trim();
+    // First-contact naming cue (trust-tiers § lookalike names): a
+    // VERIFIED caller key that matches a fleet record you have petnamed
+    // is a machine you know — say so by your name for it. A verified
+    // key with no petname is honest first contact: no name on file.
+    const callerId = String(req.requester_daemon_id || '').trim();
+    let callerLine = '';
+    if (callerId) {
+      const named = (typeof accessFleetTargets === 'function' ? accessFleetTargets() : [])
+        .find(t => String(t.connect_daemon_id || '').trim() === callerId && String(t.petname || '').trim());
+      callerLine = named
+        ? `caller: your “${escapeHtml(String(named.petname).trim())}” (verified key)`
+        : `caller: verified key ${escapeHtml(callerId.slice(0, 12))}… — no machine you’ve named`;
+    }
     // THE upward-grant alarm case: a self-declared disposable machine
     // asking for authority on this integrated one.
     const upwardAlarm = pending && integratedTier && requesterTier === 'disposable';
@@ -74444,6 +74457,7 @@ function renderPeerAccessRequests(requests) {
         </div>
         <div class="daemon-access-request-meta">Status ${escapeHtml(status)} - ${roleLabel} ${escapeHtml(role.label)}</div>
         <div class="daemon-access-request-meta daemon-role-summary">${escapeHtml(role.summary)}</div>
+        ${callerLine ? `<div class="daemon-access-request-meta" title="The requesting daemon proved this identity key over the doorbell. A petname means it matches a machine YOU named; ‘no machine you’ve named’ means first contact — a lookalike never inherits a familiar name.">${callerLine}</div>` : ''}
         ${requesterTier ? `<div class="daemon-access-request-meta" title="Stated by the requesting daemon inside its verified caller-ID signature — stored and shown only because the signature checked out.">requester says: ${escapeHtml(requesterTier)}</div>` : ''}
         ${upwardAlarm
           ? '<div class="daemon-access-request-meta daemon-access-request-warn" title="Grants flow toward disposable machines, never up. Approving would hand a disposable box authority on this integrated one — the tier bridge the doctrine warns about.">⚠ Upward grant: this is a disposable machine asking for authority on an integrated one. Approving bridges your tiers.</div>'

--- a/static/app.html
+++ b/static/app.html
@@ -999,6 +999,20 @@ html {
   color: var(--peach);
   font-weight: 600;
 }
+/* Petnames (trust-tiers § lookalike names): the muted self-label beside
+   an owner-named machine, and the inline rename affordance. */
+.acc-fleet-selflabel { color: var(--overlay1); font-size: 10.5px; white-space: nowrap; }
+.acc-fleet-rename {
+  background: none; border: none; color: var(--overlay1);
+  font-size: 11px; cursor: pointer; padding: 0 2px; line-height: 1;
+}
+.acc-fleet-rename:hover { color: var(--text); }
+.acc-fleet-rename-input {
+  background: color-mix(in srgb, var(--surface0) 55%, transparent);
+  border: 1px solid var(--glass-hairline-bright); border-radius: 6px;
+  color: var(--text); font-size: 12px; padding: 1px 6px; min-width: 0;
+  width: 12ch;
+}
 
 /* Role badges — warmer = more authority. */
 .acc-badge, .ui-badge {
@@ -25900,12 +25914,16 @@ function accessFleetRecordPayload(record, signedAt, version = 2) {
   // v4 folds the enc line in unconditionally (may be empty) and appends
   // the daemon's owner-set trust tier, so a store cannot relabel an
   // integrated box as disposable without breaking the signature.
+  // v5 appends the owner's PETNAME for the daemon — the name the owner
+  // chose, bound to this record's identity, so a lookalike daemon can
+  // never wear a familiar name the store or a phisher picked.
   const enc = version >= 3 ? String(record.enc_fields || '') : '';
   const blank = version >= 3 && enc;
   const lines = [
-    version >= 4 ? 'intendant-fleet-record-v4'
-      : version >= 3 ? 'intendant-fleet-record-v3'
-        : version >= 2 ? 'intendant-fleet-record-v2' : 'intendant-fleet-record-v1',
+    version >= 5 ? 'intendant-fleet-record-v5'
+      : version >= 4 ? 'intendant-fleet-record-v4'
+        : version >= 3 ? 'intendant-fleet-record-v3'
+          : version >= 2 ? 'intendant-fleet-record-v2' : 'intendant-fleet-record-v1',
     String(record.host_id || record.id || ''),
     String(record.label || ''),
     blank ? '' : String(record.url || ''),
@@ -25918,6 +25936,7 @@ function accessFleetRecordPayload(record, signedAt, version = 2) {
   if (version >= 2) lines.push(String(record.connect_signaling_base || ''));
   if (version >= 3) lines.push(enc);
   if (version >= 4) lines.push(String(record.tier || ''));
+  if (version >= 5) lines.push(String(record.petname || ''));
   lines.push(String(signedAt));
   return new TextEncoder().encode(lines.join('\n'));
 }
@@ -26032,10 +26051,12 @@ async function accessFleetSignRecord(record) {
   const signedAt = Date.now();
   try {
     // Sign at the lowest version that covers the record's fields: a
-    // tier-less record keeps its v2/v3 shape, so a hosted store that
-    // predates the tier field (and would strip it) only downgrades
-    // tier-carrying records to 'unverified', not the whole fleet.
-    const version = String(record.tier || '').trim() ? 4 : (record.enc_fields ? 3 : 2);
+    // record without newer fields keeps its older shape, so a hosted
+    // store that predates a field (and would strip it) only downgrades
+    // the records that carry it, not the whole fleet.
+    const version = String(record.petname || '').trim() ? 5
+      : String(record.tier || '').trim() ? 4
+        : (record.enc_fields ? 3 : 2);
     const signature = await crypto.subtle.sign(
       { name: 'ECDSA', hash: 'SHA-256' },
       identity.privateKey,
@@ -26071,7 +26092,7 @@ async function accessFleetVerifyRecord(record) {
       ['verify']
     );
     let valid = false;
-    for (const version of record.enc_fields ? [4, 3, 2, 1] : [4, 2, 1]) {
+    for (const version of record.enc_fields ? [5, 4, 3, 2, 1] : [5, 4, 2, 1]) {
       valid = await crypto.subtle.verify(
         { name: 'ECDSA', hash: 'SHA-256' },
         publicKey,
@@ -51750,6 +51771,9 @@ function normalizeDashboardAccessTarget(target) {
     // payload and carried in the signed v4 fleet record (never on the
     // public agent card — docs/src/trust-tiers.md § metadata carriers).
     tier: String(target.tier || '').trim(),
+    // Owner-chosen petname (signed v5 record line): the name the OWNER
+    // gave this identity — a lookalike daemon never inherits it.
+    petname: String(target.petname || '').trim(),
     connected: target.connected !== false,
     capabilities,
   };
@@ -52412,8 +52436,43 @@ function dashboardTargetIsLocal(hostId) {
 
 function dashboardTargetLabel(hostId) {
   if (dashboardTargetIsLocal(hostId)) return selfHostLabel || 'This daemon';
-  const peer = daemons.find(d => d.host_id === String(hostId || '').trim());
-  return peer?.label || String(hostId || '').trim();
+  const id = String(hostId || '').trim();
+  const peer = daemons.find(d => d.host_id === id);
+  // Petname first (owner-chosen, identity-bound); the self-reported
+  // label only names machines the owner hasn't named.
+  const record = accessFleetTargets().find(t =>
+    String(t.host_id || t.id || '').trim() === id);
+  const petname = String(record?.petname || '').trim();
+  if (petname) return petname;
+  return peer?.label || id;
+}
+
+/* The owner's petname for a fleet target, '' when unnamed. */
+function accessTargetPetname(target) {
+  return String(target?.petname || '').trim();
+}
+
+/* Set (or clear, with '') the owner's petname for a fleet target and
+   persist it: the record re-signs as payload v5 on the next hosted
+   push, so the name is bound to this identity — a lookalike never
+   inherits it. */
+function accessFleetSetPetname(hostId, petname) {
+  const id = String(hostId || '').trim();
+  if (!id) return false;
+  const cleaned = String(petname || '').trim().slice(0, 120);
+  const targets = accessFleetRead().targets || [];
+  let changed = false;
+  for (const target of targets) {
+    const key = String(target.host_id || target.id || '').trim();
+    if (key !== id) continue;
+    if (String(target.petname || '') === cleaned) break;
+    target.petname = cleaned;
+    target.updated_unix_ms = Date.now();
+    changed = true;
+    break;
+  }
+  if (changed) accessFleetWrite(targets);
+  return changed;
 }
 
 function dashboardAccessRoleLabel(roleId) {
@@ -54887,6 +54946,7 @@ function accessTargetProvenanceChip(target) {
    ids only appear as the subtitle, never as the headline. */
 function accessTargetDisplayName(target, descriptor) {
   const candidates = [
+    accessTargetPetname(target),
     descriptor?.displayName,
     target?.label,
   ];
@@ -55340,6 +55400,52 @@ function renderAccessFleetStrip() {
     name.className = 'acc-fleet-name';
     name.textContent = accessTargetDisplayName(target, descriptor);
     top.append(dot, name);
+    // Petnamed machines keep their self-reported label visible as a
+    // muted secondary — the owner's name never hides what the box calls
+    // itself.
+    const petname = accessTargetPetname(target);
+    if (petname && target.label && petname !== String(target.label).trim()) {
+      const selfLabel = document.createElement('span');
+      selfLabel.className = 'acc-fleet-selflabel';
+      selfLabel.textContent = `· ${target.label}`;
+      top.appendChild(selfLabel);
+    }
+    // Inline rename (✎): the owner's name for this identity, signed
+    // into the v5 fleet record (trust-tiers § lookalike names).
+    if (!target.local && !descriptor.local) {
+      const rename = document.createElement('button');
+      rename.type = 'button';
+      rename.className = 'acc-fleet-rename';
+      rename.textContent = '\u270e';
+      rename.title = petname
+        ? `Rename "${petname}" — your name for this machine, bound to its identity`
+        : 'Name this machine — your name, bound to its identity (a lookalike never inherits it)';
+      rename.addEventListener('click', event => {
+        event.stopPropagation();
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'acc-fleet-rename-input';
+        input.value = petname;
+        input.placeholder = String(target.label || 'name this machine');
+        input.maxLength = 120;
+        const commit = () => {
+          accessFleetSetPetname(target.host_id || target.id, input.value);
+          renderAccessFleetStrip();
+          renderDashboardTargetSummaries();
+        };
+        input.addEventListener('keydown', ev => {
+          if (ev.key === 'Enter') commit();
+          if (ev.key === 'Escape') renderAccessFleetStrip();
+          ev.stopPropagation();
+        });
+        input.addEventListener('blur', commit);
+        input.addEventListener('click', ev => ev.stopPropagation());
+        name.replaceWith(input);
+        input.focus();
+        input.select();
+      });
+      top.appendChild(rename);
+    }
     if (target.local || descriptor.local) {
       const self = document.createElement('span');
       self.className = 'acc-fleet-self';

--- a/static/app/11-styles-access-files.css
+++ b/static/app/11-styles-access-files.css
@@ -110,6 +110,20 @@
   color: var(--peach);
   font-weight: 600;
 }
+/* Petnames (trust-tiers § lookalike names): the muted self-label beside
+   an owner-named machine, and the inline rename affordance. */
+.acc-fleet-selflabel { color: var(--overlay1); font-size: 10.5px; white-space: nowrap; }
+.acc-fleet-rename {
+  background: none; border: none; color: var(--overlay1);
+  font-size: 11px; cursor: pointer; padding: 0 2px; line-height: 1;
+}
+.acc-fleet-rename:hover { color: var(--text); }
+.acc-fleet-rename-input {
+  background: color-mix(in srgb, var(--surface0) 55%, transparent);
+  border: 1px solid var(--glass-hairline-bright); border-radius: 6px;
+  color: var(--text); font-size: 12px; padding: 1px 6px; min-width: 0;
+  width: 12ch;
+}
 
 /* Role badges — warmer = more authority. */
 .acc-badge, .ui-badge {

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -941,12 +941,16 @@ function accessFleetRecordPayload(record, signedAt, version = 2) {
   // v4 folds the enc line in unconditionally (may be empty) and appends
   // the daemon's owner-set trust tier, so a store cannot relabel an
   // integrated box as disposable without breaking the signature.
+  // v5 appends the owner's PETNAME for the daemon — the name the owner
+  // chose, bound to this record's identity, so a lookalike daemon can
+  // never wear a familiar name the store or a phisher picked.
   const enc = version >= 3 ? String(record.enc_fields || '') : '';
   const blank = version >= 3 && enc;
   const lines = [
-    version >= 4 ? 'intendant-fleet-record-v4'
-      : version >= 3 ? 'intendant-fleet-record-v3'
-        : version >= 2 ? 'intendant-fleet-record-v2' : 'intendant-fleet-record-v1',
+    version >= 5 ? 'intendant-fleet-record-v5'
+      : version >= 4 ? 'intendant-fleet-record-v4'
+        : version >= 3 ? 'intendant-fleet-record-v3'
+          : version >= 2 ? 'intendant-fleet-record-v2' : 'intendant-fleet-record-v1',
     String(record.host_id || record.id || ''),
     String(record.label || ''),
     blank ? '' : String(record.url || ''),
@@ -959,6 +963,7 @@ function accessFleetRecordPayload(record, signedAt, version = 2) {
   if (version >= 2) lines.push(String(record.connect_signaling_base || ''));
   if (version >= 3) lines.push(enc);
   if (version >= 4) lines.push(String(record.tier || ''));
+  if (version >= 5) lines.push(String(record.petname || ''));
   lines.push(String(signedAt));
   return new TextEncoder().encode(lines.join('\n'));
 }
@@ -1073,10 +1078,12 @@ async function accessFleetSignRecord(record) {
   const signedAt = Date.now();
   try {
     // Sign at the lowest version that covers the record's fields: a
-    // tier-less record keeps its v2/v3 shape, so a hosted store that
-    // predates the tier field (and would strip it) only downgrades
-    // tier-carrying records to 'unverified', not the whole fleet.
-    const version = String(record.tier || '').trim() ? 4 : (record.enc_fields ? 3 : 2);
+    // record without newer fields keeps its older shape, so a hosted
+    // store that predates a field (and would strip it) only downgrades
+    // the records that carry it, not the whole fleet.
+    const version = String(record.petname || '').trim() ? 5
+      : String(record.tier || '').trim() ? 4
+        : (record.enc_fields ? 3 : 2);
     const signature = await crypto.subtle.sign(
       { name: 'ECDSA', hash: 'SHA-256' },
       identity.privateKey,
@@ -1112,7 +1119,7 @@ async function accessFleetVerifyRecord(record) {
       ['verify']
     );
     let valid = false;
-    for (const version of record.enc_fields ? [4, 3, 2, 1] : [4, 2, 1]) {
+    for (const version of record.enc_fields ? [5, 4, 3, 2, 1] : [5, 4, 2, 1]) {
       valid = await crypto.subtle.verify(
         { name: 'ECDSA', hash: 'SHA-256' },
         publicKey,

--- a/static/app/42-usage-terminal.js
+++ b/static/app/42-usage-terminal.js
@@ -267,6 +267,9 @@ function normalizeDashboardAccessTarget(target) {
     // payload and carried in the signed v4 fleet record (never on the
     // public agent card — docs/src/trust-tiers.md § metadata carriers).
     tier: String(target.tier || '').trim(),
+    // Owner-chosen petname (signed v5 record line): the name the OWNER
+    // gave this identity — a lookalike daemon never inherits it.
+    petname: String(target.petname || '').trim(),
     connected: target.connected !== false,
     capabilities,
   };
@@ -929,8 +932,43 @@ function dashboardTargetIsLocal(hostId) {
 
 function dashboardTargetLabel(hostId) {
   if (dashboardTargetIsLocal(hostId)) return selfHostLabel || 'This daemon';
-  const peer = daemons.find(d => d.host_id === String(hostId || '').trim());
-  return peer?.label || String(hostId || '').trim();
+  const id = String(hostId || '').trim();
+  const peer = daemons.find(d => d.host_id === id);
+  // Petname first (owner-chosen, identity-bound); the self-reported
+  // label only names machines the owner hasn't named.
+  const record = accessFleetTargets().find(t =>
+    String(t.host_id || t.id || '').trim() === id);
+  const petname = String(record?.petname || '').trim();
+  if (petname) return petname;
+  return peer?.label || id;
+}
+
+/* The owner's petname for a fleet target, '' when unnamed. */
+function accessTargetPetname(target) {
+  return String(target?.petname || '').trim();
+}
+
+/* Set (or clear, with '') the owner's petname for a fleet target and
+   persist it: the record re-signs as payload v5 on the next hosted
+   push, so the name is bound to this identity — a lookalike never
+   inherits it. */
+function accessFleetSetPetname(hostId, petname) {
+  const id = String(hostId || '').trim();
+  if (!id) return false;
+  const cleaned = String(petname || '').trim().slice(0, 120);
+  const targets = accessFleetRead().targets || [];
+  let changed = false;
+  for (const target of targets) {
+    const key = String(target.host_id || target.id || '').trim();
+    if (key !== id) continue;
+    if (String(target.petname || '') === cleaned) break;
+    target.petname = cleaned;
+    target.updated_unix_ms = Date.now();
+    changed = true;
+    break;
+  }
+  if (changed) accessFleetWrite(targets);
+  return changed;
 }
 
 function dashboardAccessRoleLabel(roleId) {

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -157,6 +157,7 @@ function accessTargetProvenanceChip(target) {
    ids only appear as the subtitle, never as the headline. */
 function accessTargetDisplayName(target, descriptor) {
   const candidates = [
+    accessTargetPetname(target),
     descriptor?.displayName,
     target?.label,
   ];
@@ -610,6 +611,52 @@ function renderAccessFleetStrip() {
     name.className = 'acc-fleet-name';
     name.textContent = accessTargetDisplayName(target, descriptor);
     top.append(dot, name);
+    // Petnamed machines keep their self-reported label visible as a
+    // muted secondary — the owner's name never hides what the box calls
+    // itself.
+    const petname = accessTargetPetname(target);
+    if (petname && target.label && petname !== String(target.label).trim()) {
+      const selfLabel = document.createElement('span');
+      selfLabel.className = 'acc-fleet-selflabel';
+      selfLabel.textContent = `· ${target.label}`;
+      top.appendChild(selfLabel);
+    }
+    // Inline rename (✎): the owner's name for this identity, signed
+    // into the v5 fleet record (trust-tiers § lookalike names).
+    if (!target.local && !descriptor.local) {
+      const rename = document.createElement('button');
+      rename.type = 'button';
+      rename.className = 'acc-fleet-rename';
+      rename.textContent = '\u270e';
+      rename.title = petname
+        ? `Rename "${petname}" — your name for this machine, bound to its identity`
+        : 'Name this machine — your name, bound to its identity (a lookalike never inherits it)';
+      rename.addEventListener('click', event => {
+        event.stopPropagation();
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.className = 'acc-fleet-rename-input';
+        input.value = petname;
+        input.placeholder = String(target.label || 'name this machine');
+        input.maxLength = 120;
+        const commit = () => {
+          accessFleetSetPetname(target.host_id || target.id, input.value);
+          renderAccessFleetStrip();
+          renderDashboardTargetSummaries();
+        };
+        input.addEventListener('keydown', ev => {
+          if (ev.key === 'Enter') commit();
+          if (ev.key === 'Escape') renderAccessFleetStrip();
+          ev.stopPropagation();
+        });
+        input.addEventListener('blur', commit);
+        input.addEventListener('click', ev => ev.stopPropagation());
+        name.replaceWith(input);
+        input.focus();
+        input.select();
+      });
+      top.appendChild(rename);
+    }
     if (target.local || descriptor.local) {
       const self = document.createElement('span');
       self.className = 'acc-fleet-self';

--- a/static/app/52-peer-display.js
+++ b/static/app/52-peer-display.js
@@ -2019,6 +2019,19 @@ function renderPeerAccessRequests(requests) {
     // already means "pinned to a proven daemon key". Unverified and
     // legacy callers carry no claim and render exactly as before.
     const requesterTier = String(req.requester_tier || '').trim();
+    // First-contact naming cue (trust-tiers § lookalike names): a
+    // VERIFIED caller key that matches a fleet record you have petnamed
+    // is a machine you know — say so by your name for it. A verified
+    // key with no petname is honest first contact: no name on file.
+    const callerId = String(req.requester_daemon_id || '').trim();
+    let callerLine = '';
+    if (callerId) {
+      const named = (typeof accessFleetTargets === 'function' ? accessFleetTargets() : [])
+        .find(t => String(t.connect_daemon_id || '').trim() === callerId && String(t.petname || '').trim());
+      callerLine = named
+        ? `caller: your “${escapeHtml(String(named.petname).trim())}” (verified key)`
+        : `caller: verified key ${escapeHtml(callerId.slice(0, 12))}… — no machine you’ve named`;
+    }
     // THE upward-grant alarm case: a self-declared disposable machine
     // asking for authority on this integrated one.
     const upwardAlarm = pending && integratedTier && requesterTier === 'disposable';
@@ -2030,6 +2043,7 @@ function renderPeerAccessRequests(requests) {
         </div>
         <div class="daemon-access-request-meta">Status ${escapeHtml(status)} - ${roleLabel} ${escapeHtml(role.label)}</div>
         <div class="daemon-access-request-meta daemon-role-summary">${escapeHtml(role.summary)}</div>
+        ${callerLine ? `<div class="daemon-access-request-meta" title="The requesting daemon proved this identity key over the doorbell. A petname means it matches a machine YOU named; ‘no machine you’ve named’ means first contact — a lookalike never inherits a familiar name.">${callerLine}</div>` : ''}
         ${requesterTier ? `<div class="daemon-access-request-meta" title="Stated by the requesting daemon inside its verified caller-ID signature — stored and shown only because the signature checked out.">requester says: ${escapeHtml(requesterTier)}</div>` : ''}
         ${upwardAlarm
           ? '<div class="daemon-access-request-meta daemon-access-request-warn" title="Grants flow toward disposable machines, never up. Approving would hand a disposable box authority on this integrated one — the tier bridge the doctrine warns about.">⚠ Upward grant: this is a disposable machine asking for authority on an integrated one. Approving bridges your tiers.</div>'


### PR DESCRIPTION
The lookalike-names mitigation's nominal half (trust-tiers § lookalike names, amended in-PR): a petname is the owner's name for a daemon, signed into fleet record payload v5 and keyed to the record's identity — no store, phisher, or self-chosen label can dress a lookalike in a name you assigned.

- Payload v5 appends the petname line; sign-at-lowest-covering-version extends (petname→5, tier→4, enc→3); verify tries [5,4,…]. Connect relays blind and bounded (round-trip pinned).
- Display precedence through the existing name helpers, so fleet cards, pane target pickers, and the lane badges all inherit it; the self-reported label stays visible as a muted secondary beside an owner-chosen name.
- Inline rename on fleet cards (✎ → in-place input; ui-v2 idiom, no dialogs).
- First-contact cue on the pairing approval card, composing with #232's verified caller-ID: a verified key you've petnamed shows as *your* machine by *your* name; a verified key you've never named says 'no machine you've named' — the honest first-contact signal.

Battery: 3033 tests, clippy + fmt clean, mock e2e 15/15.