### PR TITLE
session_log: add epoch-ms timestamps to events and session meta

### DIFF
--- a/docs/src/session-logging.md
+++ b/docs/src/session-logging.md
@@ -66,6 +66,7 @@ Turn files are named `turn_{NNN}_{suffix}` with `NNN` zero-padded to three digit
 {
   "session_id": "a1b2c3d4-...",
   "created_at": "2026-05-24T10:30:00",
+  "created_at_ms": 1782808200123,
   "project_root": "/home/user/myproject",
   "name": "Fix auth bug",
   "task": "Fix the authentication bug",
@@ -85,14 +86,16 @@ drives `--continue` (most-recent session for the project) and `--resume <id>`
 ## The `session.jsonl` Event Stream
 
 `session.jsonl` is the spine: one `LogEvent` JSON object per line. Each event
-carries a timestamp, an optional turn number, the event name, an optional level,
-an optional human message, optional structured `data`, and optional `file` /
-`file2` references pointing at the full-content turn files (so the line stays
-small and the bulk lives in `turns/`).
+carries a local time-of-day timestamp plus a machine-readable epoch-ms UTC
+timestamp (`ts_ms`; events written before 2026-07 lack it — recover their date
+from `session_meta.json`), an optional turn number, the event name, an optional
+level, an optional human message, optional structured `data`, and optional
+`file` / `file2` references pointing at the full-content turn files (so the
+line stays small and the bulk lives in `turns/`).
 
 ```rust
 struct LogEvent {
-    ts: String, turn: Option<usize>, event: String,
+    ts: String, ts_ms: i64, turn: Option<usize>, event: String,
     level: Option<String>, message: Option<String>,
     data: Option<serde_json::Value>,
     file: Option<String>, file2: Option<String>,

--- a/src/bin/caller/session_log/bus_events.rs
+++ b/src/bin/caller/session_log/bus_events.rs
@@ -19,6 +19,7 @@ impl SessionLog {
             .map(|session_id| serde_json::json!({ "session_id": session_id }));
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: if self.current_turn > 0 {
                 Some(self.current_turn)
             } else {
@@ -49,6 +50,7 @@ impl SessionLog {
         }
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "task_complete".to_string(),
             level: Some("info".to_string()),
@@ -128,6 +130,7 @@ impl SessionLog {
 
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: if self.current_turn > 0 {
                 Some(self.current_turn)
             } else {
@@ -253,6 +256,7 @@ impl SessionLog {
         }
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: if self.current_turn > 0 {
                 Some(self.current_turn)
             } else {
@@ -311,6 +315,7 @@ impl SessionLog {
         data.insert("ts_ms".to_string(), serde_json::Value::from(ts_ms));
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: if self.current_turn > 0 {
                 Some(self.current_turn)
             } else {
@@ -329,6 +334,7 @@ impl SessionLog {
     pub fn session_started(&mut self, session_id: &str, task: Option<&str>) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "session_started".to_string(),
             level: Some("info".to_string()),
@@ -346,6 +352,7 @@ impl SessionLog {
     pub fn session_identity(&mut self, session_id: &str, source: &str, backend_session_id: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "session_identity".to_string(),
             level: Some("info".to_string()),
@@ -373,6 +380,7 @@ impl SessionLog {
     pub fn session_attached(&mut self, session_id: &str, source: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "session_attached".to_string(),
             level: Some("info".to_string()),
@@ -396,6 +404,7 @@ impl SessionLog {
     ) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "session_relationship".to_string(),
             level: Some("info".to_string()),
@@ -422,6 +431,7 @@ impl SessionLog {
     ) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "session_capabilities".to_string(),
             level: Some("info".to_string()),
@@ -439,6 +449,7 @@ impl SessionLog {
     pub fn session_goal(&mut self, session_id: &str, goal: Option<&crate::types::SessionGoal>) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "session_goal".to_string(),
             level: Some("info".to_string()),
@@ -458,6 +469,7 @@ impl SessionLog {
     pub fn session_vitals(&mut self, session_id: &str, vitals: &crate::types::SessionVitals) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "session_vitals".to_string(),
             level: Some("debug".to_string()),
@@ -475,6 +487,7 @@ impl SessionLog {
     pub fn session_ended(&mut self, session_id: &str, reason: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "session_ended".to_string(),
             level: Some("info".to_string()),
@@ -518,6 +531,7 @@ impl SessionLog {
         }
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: Some(turn),
             event: "agent_started".to_string(),
             level: Some("info".to_string()),
@@ -536,6 +550,7 @@ impl SessionLog {
     pub fn auto_approved(&mut self, preview: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: if self.current_turn > 0 {
                 Some(self.current_turn)
             } else {
@@ -562,6 +577,7 @@ impl SessionLog {
         self.last_approval_resolved = Some((id, action.to_string()));
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: Some(id as usize),
             event: "approval_resolved".to_string(),
             level: Some("info".to_string()),
@@ -576,6 +592,7 @@ impl SessionLog {
     pub fn human_question(&mut self, question: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: if self.current_turn > 0 {
                 Some(self.current_turn)
             } else {
@@ -594,6 +611,7 @@ impl SessionLog {
     pub fn human_response_sent(&mut self) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: if self.current_turn > 0 {
                 Some(self.current_turn)
             } else {
@@ -612,6 +630,7 @@ impl SessionLog {
     pub fn round_complete(&mut self, round: usize, turns_in_round: usize) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "round_complete".to_string(),
             level: Some("info".to_string()),
@@ -633,6 +652,7 @@ impl SessionLog {
     pub fn snapshot_created(&mut self, round_id: u64) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "snapshot_created".to_string(),
             level: Some("info".to_string()),
@@ -647,6 +667,7 @@ impl SessionLog {
     pub fn rolled_back(&mut self, from_id: u64, to_id: u64, files_reverted: u32) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "rolled_back".to_string(),
             level: Some("info".to_string()),
@@ -668,6 +689,7 @@ impl SessionLog {
     pub fn redone(&mut self, to_id: u64) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "redone".to_string(),
             level: Some("info".to_string()),
@@ -682,6 +704,7 @@ impl SessionLog {
     pub fn history_pruned(&mut self, branches_removed: u32, bytes_freed: u64) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "history_pruned".to_string(),
             level: Some("info".to_string()),
@@ -708,6 +731,7 @@ impl SessionLog {
     ) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "conversation_rolled_back".to_string(),
             level: Some("info".to_string()),
@@ -731,6 +755,7 @@ impl SessionLog {
     pub fn display_ready(&mut self, display_id: u32, width: u32, height: u32, agent_visible: bool) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "display_ready".to_string(),
             level: Some("info".to_string()),
@@ -760,6 +785,7 @@ impl SessionLog {
     pub fn display_resize(&mut self, display_id: u32, width: u32, height: u32) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "display_resize".to_string(),
             level: Some("info".to_string()),
@@ -781,6 +807,7 @@ impl SessionLog {
     pub fn display_taken(&mut self, display_id: u32) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "display_taken".to_string(),
             level: Some("info".to_string()),
@@ -795,6 +822,7 @@ impl SessionLog {
     pub fn display_released(&mut self, display_id: u32, note: Option<&str>) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "display_released".to_string(),
             level: Some("info".to_string()),
@@ -816,6 +844,7 @@ impl SessionLog {
     pub fn debug_screen_ready(&mut self, display_id: u32) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "debug_screen_ready".to_string(),
             level: Some("info".to_string()),
@@ -832,6 +861,7 @@ impl SessionLog {
     pub fn debug_screen_torn_down(&mut self, display_id: u32) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "debug_screen_torn_down".to_string(),
             level: Some("info".to_string()),
@@ -846,6 +876,7 @@ impl SessionLog {
     pub fn safety_cap_reached(&mut self) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: if self.current_turn > 0 {
                 Some(self.current_turn)
             } else {
@@ -864,6 +895,7 @@ impl SessionLog {
     pub fn recording_started(&mut self, stream_name: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "recording_started".to_string(),
             level: Some("info".to_string()),
@@ -878,6 +910,7 @@ impl SessionLog {
     pub fn recording_stopped(&mut self, stream_name: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "recording_stopped".to_string(),
             level: Some("info".to_string()),
@@ -892,6 +925,7 @@ impl SessionLog {
     pub fn recording_error(&mut self, stream_name: &str, message: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "recording_error".to_string(),
             level: Some("warn".to_string()),
@@ -909,6 +943,7 @@ impl SessionLog {
     pub fn recording_deleted(&mut self, stream_name: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "recording_deleted".to_string(),
             level: Some("info".to_string()),
@@ -923,6 +958,7 @@ impl SessionLog {
     pub fn sub_agent_result(&mut self, summary: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: if self.current_turn > 0 {
                 Some(self.current_turn)
             } else {
@@ -941,6 +977,7 @@ impl SessionLog {
     pub fn presence_log(&mut self, message: &str, level: Option<&str>) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "presence_log".to_string(),
             level: Some(level.unwrap_or("info").to_string()),
@@ -962,6 +999,7 @@ impl SessionLog {
     ) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "presence_usage_update".to_string(),
             level: Some("debug".to_string()),
@@ -992,6 +1030,7 @@ impl SessionLog {
         }
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "live_usage_update".to_string(),
             level: Some("debug".to_string()),
@@ -1013,6 +1052,7 @@ impl SessionLog {
     pub fn live_audio_started(&mut self, id: &str, provider: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "live_audio_started".to_string(),
             level: Some("info".to_string()),
@@ -1036,6 +1076,7 @@ impl SessionLog {
     ) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "live_audio_progress".to_string(),
             level: Some("debug".to_string()),
@@ -1057,6 +1098,7 @@ impl SessionLog {
     pub fn live_audio_completed(&mut self, id: &str, status: &str, quarantine_count: usize) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "live_audio_completed".to_string(),
             level: Some("info".to_string()),
@@ -1079,6 +1121,7 @@ impl SessionLog {
     pub fn tool_request(&mut self, tool: &str, args: &serde_json::Value) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "tool_request".to_string(),
             level: Some("debug".to_string()),
@@ -1106,6 +1149,7 @@ impl SessionLog {
         };
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "tool_response".to_string(),
             level: Some("debug".to_string()),
@@ -1119,6 +1163,7 @@ impl SessionLog {
     pub fn error(&mut self, msg: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: if self.current_turn > 0 {
                 Some(self.current_turn)
             } else {
@@ -1136,6 +1181,7 @@ impl SessionLog {
     pub fn debug(&mut self, msg: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: if self.current_turn > 0 {
                 Some(self.current_turn)
             } else {
@@ -1155,6 +1201,7 @@ impl SessionLog {
         self.current_turn = turn;
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: Some(turn),
             event: "turn_start".to_string(),
             level: Some("info".to_string()),
@@ -1173,6 +1220,7 @@ impl SessionLog {
         let file = self.write_turn_file("messages.json", messages_json);
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: Some(self.current_turn),
             event: "messages_input".to_string(),
             level: Some("debug".to_string()),
@@ -1257,6 +1305,7 @@ impl SessionLog {
             .unwrap_or_default();
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: effective_turn,
             event: "context_snapshot".to_string(),
             level: Some("debug".to_string()),
@@ -1345,6 +1394,7 @@ impl SessionLog {
         }
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: Some(self.current_turn),
             event: "model_response".to_string(),
             level: Some("info".to_string()),
@@ -1380,6 +1430,7 @@ impl SessionLog {
 
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: Some(self.current_turn),
             event: "agent_input".to_string(),
             level: Some("info".to_string()),
@@ -1456,6 +1507,7 @@ impl SessionLog {
         }
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: Some(self.current_turn),
             event: "agent_output".to_string(),
             level: if stderr.is_empty() {
@@ -1479,6 +1531,7 @@ impl SessionLog {
         let file = full_content.and_then(|c| self.append_turn_file("reasoning.txt", c));
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: Some(self.current_turn),
             event: "reasoning".to_string(),
             level: Some("info".to_string()),
@@ -1497,6 +1550,7 @@ impl SessionLog {
     pub fn approval(&mut self, category: &str, preview: &str, decision: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: Some(self.current_turn),
             event: "approval".to_string(),
             level: Some("warn".to_string()),
@@ -1533,6 +1587,7 @@ impl SessionLog {
 
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: Some(self.current_turn),
             event: "json_extracted".to_string(),
             level: Some("debug".to_string()),
@@ -1604,6 +1659,7 @@ impl SessionLog {
 
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "session_end".to_string(),
             level: Some("info".to_string()),

--- a/src/bin/caller/session_log/mod.rs
+++ b/src/bin/caller/session_log/mod.rs
@@ -1,5 +1,5 @@
 use crate::types::truncate_str;
-use chrono::Local;
+use chrono::{Local, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs::{self, File, OpenOptions};
@@ -20,6 +20,11 @@ mod bus_events;
 #[derive(Serialize)]
 struct LogEvent {
     ts: String,
+    /// Epoch milliseconds (UTC) captured alongside `ts`. `ts` is local
+    /// time-of-day only — without this field an event's calendar date must
+    /// be reconstructed from `session_meta.json` plus midnight-wrap
+    /// inference, which breaks across DST folds and multi-day sessions.
+    ts_ms: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     turn: Option<usize>,
     event: String,
@@ -58,6 +63,13 @@ pub struct AgentOutputChunk {
 pub struct SessionMeta {
     pub session_id: String,
     pub created_at: String,
+    /// Epoch milliseconds (UTC) captured with `created_at` — the
+    /// machine-readable timestamp (`created_at` is local and offset-less).
+    /// Additive: metas written before 2026-07 lack it. Mirrors
+    /// `created_at`'s existing rewrite semantics (re-stamped on every meta
+    /// write).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at_ms: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub project_root: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -319,6 +331,7 @@ impl SessionLog {
         };
         log.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "session_start".to_string(),
             level: Some("info".to_string()),
@@ -380,6 +393,7 @@ impl SessionLog {
         let meta = SessionMeta {
             session_id: self.session_id.clone(),
             created_at: Local::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
+            created_at_ms: Some(Self::ts_ms()),
             project_root: project_root.map(|p| p.to_string_lossy().to_string()),
             name: name.map(|n| n.to_string()).or(existing_name),
             task: task.map(|t| t.to_string()),
@@ -563,6 +577,10 @@ impl SessionLog {
         Local::now().format("%H:%M:%S%.3f").to_string()
     }
 
+    fn ts_ms() -> i64 {
+        Utc::now().timestamp_millis()
+    }
+
     fn emit(&mut self, event: LogEvent) {
         if let Ok(json) = serde_json::to_string(&event) {
             if let Err(e) = writeln!(self.writer, "{}", json) {
@@ -597,6 +615,7 @@ impl SessionLog {
         self.summary_builder.current_cu_turns = 0;
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "cu_task_start".to_string(),
             level: Some("info".to_string()),
@@ -629,6 +648,7 @@ impl SessionLog {
         self.summary_builder.current_cu_turns = turn;
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "cu_turn".to_string(),
             level: Some("info".to_string()),
@@ -664,6 +684,7 @@ impl SessionLog {
         self.summary_builder.current_cu_turns = 0;
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "cu_task_complete".to_string(),
             level: Some("info".to_string()),
@@ -687,6 +708,7 @@ impl SessionLog {
         });
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "cu_task_error".to_string(),
             level: Some("warn".to_string()),
@@ -718,6 +740,7 @@ impl SessionLog {
         });
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: if self.current_turn > 0 {
                 Some(self.current_turn)
             } else {
@@ -895,6 +918,7 @@ impl SessionLog {
     pub fn info(&mut self, msg: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: if self.current_turn > 0 {
                 Some(self.current_turn)
             } else {
@@ -912,6 +936,7 @@ impl SessionLog {
     pub fn warn(&mut self, msg: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: if self.current_turn > 0 {
                 Some(self.current_turn)
             } else {
@@ -930,6 +955,7 @@ impl SessionLog {
     pub fn voice_log(&mut self, text: &str, seq: u64, tool_context: Option<&str>) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "voice_log".to_string(),
             level: Some("info".to_string()),
@@ -954,6 +980,7 @@ impl SessionLog {
         self.flush_voice_utterance();
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "user_transcript".to_string(),
             level: Some("info".to_string()),
@@ -975,6 +1002,7 @@ impl SessionLog {
     pub fn presence_checkpoint(&mut self, summary: &str, last_event_seq: u64) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "presence_checkpoint".to_string(),
             level: Some("info".to_string()),
@@ -998,6 +1026,7 @@ impl SessionLog {
         }
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "presence_connected".to_string(),
             level: Some("info".to_string()),
@@ -1019,6 +1048,7 @@ impl SessionLog {
     pub fn presence_disconnected(&mut self) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: "presence_disconnected".to_string(),
             level: Some("info".to_string()),
@@ -1238,6 +1268,7 @@ impl SessionLog {
     fn emit_voice(&mut self, event: &str, level: &str, kind: &str, detail: &str) {
         self.emit(LogEvent {
             ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
             turn: None,
             event: event.to_string(),
             level: Some(level.to_string()),
@@ -1322,6 +1353,7 @@ mod tests {
         let meta = SessionMeta {
             session_id: "test-session-123".to_string(),
             created_at: "2026-01-01T00:00:00".to_string(),
+            created_at_ms: None,
             project_root: None,
             name: None,
             task: None,
@@ -1430,6 +1462,7 @@ mod tests {
         let meta1 = SessionMeta {
             session_id: "session-1".to_string(),
             created_at: "2026-01-01T00:00:00".to_string(),
+            created_at_ms: None,
             project_root: Some("/tmp/project".to_string()),
             name: None,
             task: Some("task 1".to_string()),
@@ -1450,6 +1483,7 @@ mod tests {
         let meta2 = SessionMeta {
             session_id: "session-2".to_string(),
             created_at: "2026-01-02T00:00:00".to_string(),
+            created_at_ms: None,
             project_root: Some("/tmp/project".to_string()),
             name: None,
             task: Some("task 2".to_string()),
@@ -1511,6 +1545,7 @@ mod tests {
         let meta = SessionMeta {
             session_id: "session".to_string(),
             created_at: "2026-05-29T00:00:00".to_string(),
+            created_at_ms: None,
             project_root: Some("/tmp".to_string()),
             name: None,
             task: Some("task".to_string()),
@@ -1646,5 +1681,43 @@ mod tests {
             .into_iter()
             .last()
             .unwrap_or_else(|| panic!("no {} event found", event_type))
+    }
+
+    #[test]
+    fn events_carry_epoch_ms_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut log = SessionLog::open(dir.path().to_path_buf()).unwrap();
+        log.info("hello");
+        drop(log);
+
+        let before = Utc::now().timestamp_millis();
+        let event = read_last_event(dir.path(), "session_start");
+        let ts_ms = event["ts_ms"].as_i64().expect("ts_ms is an i64");
+        assert!(
+            ts_ms > before - 60_000 && ts_ms <= before,
+            "ts_ms {} not within a minute before {}",
+            ts_ms,
+            before
+        );
+        assert!(
+            event["ts"].as_str().is_some(),
+            "time-of-day ts still present"
+        );
+    }
+
+    #[test]
+    fn meta_carries_epoch_ms_and_reads_legacy_metas() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = SessionLog::open(dir.path().to_path_buf()).unwrap();
+        log.write_meta(None, Some("task"));
+        let raw = fs::read_to_string(dir.path().join("session_meta.json")).unwrap();
+        let meta: SessionMeta = serde_json::from_str(&raw).unwrap();
+        let ms = meta.created_at_ms.expect("created_at_ms stamped");
+        assert!(ms > 0);
+
+        // Metas written before the field existed must still parse.
+        let legacy = r#"{"session_id":"old","created_at":"2026-01-01T00:00:00"}"#;
+        let meta: SessionMeta = serde_json::from_str(legacy).unwrap();
+        assert_eq!(meta.created_at_ms, None);
     }
 }


### PR DESCRIPTION
LogEvent gains `ts_ms` (epoch milliseconds UTC) alongside the local time-of-day `ts`; SessionMeta gains an additive `created_at_ms` (serde-default — older metas still parse). `ts` alone cannot date an event: consumers currently reconstruct dates from `session_meta.json` plus midnight-wrap inference, which breaks across DST folds and multi-day sessions.

This is F2 of the message-search program (rolling message-only Quick Search index): the retention window and message records key on `ts_ms`. Purely additive — both fields are new keys on existing JSON shapes; all session.jsonl consumers parse loose `Value`s.

Notes:
- `created_at_ms` deliberately mirrors `created_at`'s existing rewrite semantics (re-stamped on every meta write). Whether meta rewrites should preserve the original creation stamp is left as a follow-up decision — `--continue` picks the most-recent session by `created_at` ordering, so changing that value's semantics is a behavior change this PR does not smuggle in.
- Docs chapter (`session-logging.md`) updated: LogEvent snippet, meta example, and a note that pre-2026-07 events lack `ts_ms`.
- Tests: events carry a sane `ts_ms`; meta stamps `created_at_ms`; legacy meta JSON without the field still deserializes.