### PR TITLE
conversation: message provenance + seq + conversation_message events (message-search F1)

### DIFF
--- a/crates/intendant-core/src/conversation.rs
+++ b/crates/intendant-core/src/conversation.rs
@@ -480,7 +480,6 @@ impl Conversation {
             out.push(synthetic(&id, &name));
             repaired += 1;
         }
-        drop(synthetic);
         self.next_seq = next_seq;
         self.messages = out;
         repaired

--- a/crates/intendant-core/src/conversation.rs
+++ b/crates/intendant-core/src/conversation.rs
@@ -14,6 +14,49 @@ pub enum MessageLayer {
     SubAgent,
 }
 
+/// What kind of entry a [`Message`] is — the provenance axis, independent of
+/// [`MessageLayer`] (which is hierarchical identity / compaction protection).
+/// Drives the session log's `conversation_message` emit/skip decision and the
+/// message-search skip set; see `docs/src/session-logging.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageProvenance {
+    /// The session's initial task.
+    Task,
+    /// The continuation task of a resumed session.
+    ResumeTask,
+    /// An ordinary user follow-up (including `[New Task]` in persistent mode).
+    FollowUp,
+    /// A steer delivered into model context.
+    Steer,
+    /// An accepted askHuman answer.
+    AskHumanAnswer,
+    /// Controller-injected context (working dir, memory, skills, frame
+    /// preludes, nudges, acks) — never user-authored.
+    SystemInjection,
+    /// Tool or agent output, including external-agent stdout wrapped as a
+    /// user message and synthetic results from tool-call repair.
+    ToolOutput,
+    /// A compaction summary replacing dropped turns.
+    ContextSummary,
+    /// An assistant response.
+    Assistant,
+    /// Written before provenance existed (legacy files) — never assigned by
+    /// live code.
+    #[default]
+    Unknown,
+}
+
+impl MessageProvenance {
+    fn is_unknown(&self) -> bool {
+        matches!(self, Self::Unknown)
+    }
+}
+
+fn seq_is_unassigned(seq: &u64) -> bool {
+    *seq == 0
+}
+
 /// Base64-encoded image data attached to a message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImageData {
@@ -59,6 +102,18 @@ pub struct Message {
     /// (e.g. `computer_call_output` for OpenAI, image content block for Anthropic).
     #[serde(skip_serializing_if = "is_false", default)]
     pub is_cu_result: bool,
+    /// Provenance of this message (see [`MessageProvenance`]). `unknown`
+    /// (the default) is skipped on write, so legacy files roundtrip
+    /// byte-stable.
+    #[serde(default, skip_serializing_if = "MessageProvenance::is_unknown")]
+    pub provenance: MessageProvenance,
+    /// Monotonic per-conversation ordinal assigned at append time. `0` means
+    /// "written before `seq` existed" until the resume-time epoch pass
+    /// ([`Conversation::ensure_seqs_assigned`]) renumbers the file. Seqs are
+    /// never reused — truncation does not rewind the counter — so a rewind
+    /// cut (`conversation_rewound.cut_after_seq`) is unambiguous.
+    #[serde(default, skip_serializing_if = "seq_is_unassigned")]
+    pub seq: u64,
     #[serde(skip)]
     pub layer: Option<MessageLayer>,
 }
@@ -69,6 +124,9 @@ pub struct Conversation {
     context_window: u64,
     turn: usize,
     protect_user_layer: bool,
+    /// The next seq to assign. Monotonic for the life of the conversation:
+    /// truncation/rewind never rewinds it (see [`Message::seq`]).
+    next_seq: u64,
 }
 
 impl Conversation {
@@ -77,12 +135,15 @@ impl Conversation {
             messages: vec![Message {
                 role: "system".to_string(),
                 content: system_prompt,
+                provenance: MessageProvenance::SystemInjection,
+                seq: 1,
                 ..Default::default()
             }],
             last_usage: None,
             context_window,
             turn: 0,
             protect_user_layer: false,
+            next_seq: 2,
         }
     }
 
@@ -91,15 +152,31 @@ impl Conversation {
         self.protect_user_layer = protect;
     }
 
-    pub fn add_user(&mut self, content: String) {
+    fn assign_seq(&mut self) -> u64 {
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        seq
+    }
+
+    pub fn add_user(&mut self, provenance: MessageProvenance, content: String) -> u64 {
+        let seq = self.assign_seq();
         self.messages.push(Message {
             role: "user".to_string(),
             content,
+            provenance,
+            seq,
             ..Default::default()
         });
+        seq
     }
 
-    pub fn add_user_with_images(&mut self, content: String, images: Vec<ImageData>) {
+    pub fn add_user_with_images(
+        &mut self,
+        provenance: MessageProvenance,
+        content: String,
+        images: Vec<ImageData>,
+    ) -> u64 {
+        let seq = self.assign_seq();
         self.messages.push(Message {
             role: "user".to_string(),
             content,
@@ -108,27 +185,43 @@ impl Conversation {
             } else {
                 Some(images)
             },
+            provenance,
+            seq,
             ..Default::default()
         });
+        seq
     }
 
     #[allow(dead_code)]
-    pub fn add_user_with_layer(&mut self, content: String, layer: MessageLayer) {
+    pub fn add_user_with_layer(
+        &mut self,
+        provenance: MessageProvenance,
+        content: String,
+        layer: MessageLayer,
+    ) -> u64 {
+        let seq = self.assign_seq();
         self.messages.push(Message {
             role: "user".to_string(),
             content,
+            provenance,
+            seq,
             layer: Some(layer),
             ..Default::default()
         });
+        seq
     }
 
-    pub fn add_assistant(&mut self, content: String) {
+    pub fn add_assistant(&mut self, content: String) -> u64 {
+        let seq = self.assign_seq();
         self.messages.push(Message {
             role: "assistant".to_string(),
             content,
+            provenance: MessageProvenance::Assistant,
+            seq,
             layer: None,
             ..Default::default()
         });
+        seq
     }
 
     /// Add an assistant message that includes tool calls.
@@ -137,27 +230,35 @@ impl Conversation {
         content: String,
         tool_calls: Vec<ToolCallRef>,
         raw_output: Option<Vec<serde_json::Value>>,
-    ) {
+    ) -> u64 {
+        let seq = self.assign_seq();
         self.messages.push(Message {
             role: "assistant".to_string(),
             content,
             tool_calls: Some(tool_calls),
             raw_output,
+            provenance: MessageProvenance::Assistant,
+            seq,
             layer: None,
             ..Default::default()
         });
+        seq
     }
 
     /// Add a tool result message.
-    pub fn add_tool_result(&mut self, call_id: &str, name: &str, output: &str) {
+    pub fn add_tool_result(&mut self, call_id: &str, name: &str, output: &str) -> u64 {
+        let seq = self.assign_seq();
         self.messages.push(Message {
             role: "tool".to_string(),
             content: output.to_string(),
             tool_call_id: Some(call_id.to_string()),
             tool_name: Some(name.to_string()),
+            provenance: MessageProvenance::ToolOutput,
+            seq,
             layer: None,
             ..Default::default()
         });
+        seq
     }
 
     /// Add a tool result message with attached images.
@@ -167,7 +268,8 @@ impl Conversation {
         name: &str,
         output: &str,
         images: Vec<ImageData>,
-    ) {
+    ) -> u64 {
+        let seq = self.assign_seq();
         self.messages.push(Message {
             role: "tool".to_string(),
             content: output.to_string(),
@@ -178,13 +280,17 @@ impl Conversation {
             } else {
                 Some(images)
             },
+            provenance: MessageProvenance::ToolOutput,
+            seq,
             layer: None,
             ..Default::default()
         });
+        seq
     }
 
     /// Add a native computer-use tool result with a screenshot image.
-    pub fn add_cu_result(&mut self, call_id: &str, output: &str, images: Vec<ImageData>) {
+    pub fn add_cu_result(&mut self, call_id: &str, output: &str, images: Vec<ImageData>) -> u64 {
+        let seq = self.assign_seq();
         self.messages.push(Message {
             role: "tool".to_string(),
             content: output.to_string(),
@@ -196,19 +302,46 @@ impl Conversation {
                 Some(images)
             },
             is_cu_result: true,
+            provenance: MessageProvenance::ToolOutput,
+            seq,
             layer: None,
             ..Default::default()
         });
+        seq
     }
 
     #[allow(dead_code)]
-    pub fn add_assistant_with_layer(&mut self, content: String, layer: MessageLayer) {
+    pub fn add_assistant_with_layer(&mut self, content: String, layer: MessageLayer) -> u64 {
+        let seq = self.assign_seq();
         self.messages.push(Message {
             role: "assistant".to_string(),
             content,
+            provenance: MessageProvenance::Assistant,
+            seq,
             layer: Some(layer),
             ..Default::default()
         });
+        seq
+    }
+
+    /// Resume-time epoch pass: if any loaded message predates `seq`
+    /// (`seq == 0`), renumber EVERY message `1..=N` in vector order and reset
+    /// the counter. Returns whether a renumber happened — the caller then
+    /// emits the `conversation_message_epoch` marker carrying the resulting
+    /// `(seq, role, content-hash)` mapping so historical extractors can
+    /// correlate. Deliberately a no-op when every seq is already assigned:
+    /// renumbering a pure new-era file would break prior event references.
+    pub fn ensure_seqs_assigned(&mut self) -> bool {
+        if self.messages.iter().all(|m| m.seq != 0) {
+            return false;
+        }
+        let mut seq = 0u64;
+        for msg in &mut self.messages {
+            seq += 1;
+            msg.seq = seq;
+        }
+        self.next_seq = seq + 1;
+        true
     }
 
     /// Resolve any dangling tool calls at the end of the conversation.
@@ -292,13 +425,23 @@ impl Conversation {
         // Unanswered (id, name) pairs from the most recent assistant
         // tool-call batch; any non-tool message closes the batch.
         let mut open: Vec<(String, String)> = Vec::new();
-        let synthetic = |call_id: &str, name: &str| Message {
-            role: "tool".to_string(),
-            content: "[dropped] The result of this tool call was removed by context management."
-                .to_string(),
-            tool_call_id: Some(call_id.to_string()),
-            tool_name: Some(name.to_string()),
-            ..Default::default()
+        // Synthetic repairs get fresh seqs from the same monotonic counter;
+        // the counter is written back after the pass.
+        let mut next_seq = self.next_seq;
+        let mut synthetic = |call_id: &str, name: &str| {
+            let seq = next_seq;
+            next_seq += 1;
+            Message {
+                role: "tool".to_string(),
+                content:
+                    "[dropped] The result of this tool call was removed by context management."
+                        .to_string(),
+                tool_call_id: Some(call_id.to_string()),
+                tool_name: Some(name.to_string()),
+                provenance: MessageProvenance::ToolOutput,
+                seq,
+                ..Default::default()
+            }
         };
         for msg in old {
             if msg.role == "tool" {
@@ -337,6 +480,8 @@ impl Conversation {
             out.push(synthetic(&id, &name));
             repaired += 1;
         }
+        drop(synthetic);
+        self.next_seq = next_seq;
         self.messages = out;
         repaired
     }
@@ -534,6 +679,9 @@ impl Conversation {
     /// `target_len == 0`, we leave the system message alone and
     /// return `messages.len() - 1`. Callers should never request
     /// truncation below 1, but this is defensive.
+    /// Truncate to the first `target_len` messages (tail rollback). The seq
+    /// counter is deliberately NOT rewound — freed seqs are never reused, so
+    /// a `conversation_rewound { cut_after_seq }` marker stays unambiguous.
     pub fn truncate_to(&mut self, target_len: usize) -> usize {
         let current = self.messages.len();
         let target = target_len.max(1).min(current);
@@ -619,11 +767,14 @@ impl Conversation {
             self.messages.remove(i);
         }
 
+        let seq = self.assign_seq();
         self.messages.insert(
             insert_pos,
             Message {
                 role: "user".to_string(),
                 content: format!("[Context Summary] {}", summary),
+                provenance: MessageProvenance::ContextSummary,
+                seq,
                 ..Default::default()
             },
         );
@@ -667,6 +818,15 @@ impl Conversation {
 
         // Count non-system user+assistant pairs to estimate turn count
         let turn = messages.iter().filter(|m| m.role == "assistant").count();
+        // Resume the monotonic counter past the highest persisted seq
+        // (all-zero legacy files start at 1; `ensure_seqs_assigned` is the
+        // resume-time renumber pass for those).
+        let next_seq = messages
+            .iter()
+            .map(|m| m.seq)
+            .max()
+            .unwrap_or(0)
+            .saturating_add(1);
 
         Ok(Self {
             messages,
@@ -674,6 +834,7 @@ impl Conversation {
             context_window,
             turn,
             protect_user_layer: false,
+            next_seq,
         })
     }
 }
@@ -709,7 +870,7 @@ mod tests {
     #[test]
     fn add_user_message() {
         let mut conv = Conversation::new("system".to_string(), 128_000);
-        conv.add_user("hello".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "hello".to_string());
         let msgs = conv.messages();
         assert_eq!(msgs.len(), 2);
         assert_eq!(msgs[1].role, "user");
@@ -729,9 +890,9 @@ mod tests {
     #[test]
     fn conversation_ordering() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("msg1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "msg1".to_string());
         conv.add_assistant("resp1".to_string());
-        conv.add_user("msg2".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "msg2".to_string());
         let msgs = conv.messages();
         assert_eq!(msgs.len(), 4);
         assert_eq!(msgs[0].role, "system");
@@ -756,11 +917,11 @@ mod tests {
     #[test]
     fn drop_turns_protects_system_and_last_two() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("u1".to_string()); // 1
+        conv.add_user(MessageProvenance::FollowUp, "u1".to_string()); // 1
         conv.add_assistant("a1".to_string()); // 2
-        conv.add_user("u2".to_string()); // 3
+        conv.add_user(MessageProvenance::FollowUp, "u2".to_string()); // 3
         conv.add_assistant("a2".to_string()); // 4
-        conv.add_user("u3".to_string()); // 5
+        conv.add_user(MessageProvenance::FollowUp, "u3".to_string()); // 5
         conv.add_assistant("a3".to_string()); // 6
 
         // Try to drop system (0), middle messages (1,2), and last two (5,6)
@@ -776,7 +937,7 @@ mod tests {
     #[test]
     fn drop_turns_empty_indices() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("u1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u1".to_string());
         conv.drop_turns(&[]);
         assert_eq!(conv.len(), 2);
     }
@@ -784,9 +945,9 @@ mod tests {
     #[test]
     fn drop_turns_duplicate_indices() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("u1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u1".to_string());
         conv.add_assistant("a1".to_string());
-        conv.add_user("u2".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u2".to_string());
         conv.add_assistant("a2".to_string());
 
         conv.drop_turns(&[1, 1, 1]);
@@ -796,11 +957,11 @@ mod tests {
     #[test]
     fn summarize_turns_replaces_range() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("u1".to_string()); // 1
+        conv.add_user(MessageProvenance::FollowUp, "u1".to_string()); // 1
         conv.add_assistant("a1".to_string()); // 2
-        conv.add_user("u2".to_string()); // 3
+        conv.add_user(MessageProvenance::FollowUp, "u2".to_string()); // 3
         conv.add_assistant("a2".to_string()); // 4
-        conv.add_user("u3".to_string()); // 5
+        conv.add_user(MessageProvenance::FollowUp, "u3".to_string()); // 5
         conv.add_assistant("a3".to_string()); // 6
 
         conv.summarize_turns(&[1, 2, 3, 4], "Set up the environment");
@@ -819,7 +980,7 @@ mod tests {
     #[test]
     fn summarize_turns_empty() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("u1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u1".to_string());
         conv.summarize_turns(&[], "summary");
         assert_eq!(conv.len(), 2);
     }
@@ -827,9 +988,9 @@ mod tests {
     #[test]
     fn truncate_to_drops_tail() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("u1".to_string()); // 1
+        conv.add_user(MessageProvenance::FollowUp, "u1".to_string()); // 1
         conv.add_assistant("a1".to_string()); // 2
-        conv.add_user("u2".to_string()); // 3
+        conv.add_user(MessageProvenance::FollowUp, "u2".to_string()); // 3
         conv.add_assistant("a2".to_string()); // 4
 
         // Truncate to first 3 messages (keep system + u1 + a1).
@@ -844,7 +1005,7 @@ mod tests {
     #[test]
     fn truncate_to_noop_when_already_shorter() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("u1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u1".to_string());
 
         // Target longer than current — no-op.
         let removed = conv.truncate_to(100);
@@ -855,7 +1016,7 @@ mod tests {
     #[test]
     fn truncate_to_preserves_system_even_when_zero_requested() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("u1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u1".to_string());
         conv.add_assistant("a1".to_string());
 
         // Caller passes 0 — we still preserve the system message.
@@ -871,7 +1032,7 @@ mod tests {
         // tool_calls (leaving the tool result behind), we must inject
         // synthetic tool results so the next API request isn't rejected.
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("do something".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "do something".to_string());
         conv.add_assistant_tool_calls(
             "calling tool".to_string(),
             vec![ToolCallRef {
@@ -900,7 +1061,7 @@ mod tests {
     #[test]
     fn summarize_turns_protects_system_and_last_two() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("u1".to_string()); // 1
+        conv.add_user(MessageProvenance::FollowUp, "u1".to_string()); // 1
         conv.add_assistant("a1".to_string()); // 2
 
         // Try to summarize all — system (0) and last two (1,2) are protected
@@ -927,7 +1088,11 @@ mod tests {
     #[test]
     fn add_user_with_layer() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user_with_layer("hello".to_string(), MessageLayer::User);
+        conv.add_user_with_layer(
+            MessageProvenance::FollowUp,
+            "hello".to_string(),
+            MessageLayer::User,
+        );
         assert_eq!(conv.messages()[1].layer, Some(MessageLayer::User));
     }
 
@@ -942,11 +1107,15 @@ mod tests {
     fn drop_turns_protects_user_layer() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
         conv.set_protect_user_layer(true);
-        conv.add_user_with_layer("user msg".to_string(), MessageLayer::User); // 1
+        conv.add_user_with_layer(
+            MessageProvenance::FollowUp,
+            "user msg".to_string(),
+            MessageLayer::User,
+        ); // 1
         conv.add_assistant("orch status".to_string()); // 2
-        conv.add_user("orch output".to_string()); // 3
+        conv.add_user(MessageProvenance::FollowUp, "orch output".to_string()); // 3
         conv.add_assistant("more output".to_string()); // 4
-        conv.add_user("final".to_string()); // 5
+        conv.add_user(MessageProvenance::FollowUp, "final".to_string()); // 5
         conv.add_assistant("done".to_string()); // 6
 
         // Try to drop index 1 (User-layer) and 2 (no layer)
@@ -961,9 +1130,13 @@ mod tests {
     fn drop_turns_without_protection_removes_user_layer() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
         // protect_user_layer is false by default
-        conv.add_user_with_layer("user msg".to_string(), MessageLayer::User); // 1
+        conv.add_user_with_layer(
+            MessageProvenance::FollowUp,
+            "user msg".to_string(),
+            MessageLayer::User,
+        ); // 1
         conv.add_assistant("response".to_string()); // 2
-        conv.add_user("msg".to_string()); // 3
+        conv.add_user(MessageProvenance::FollowUp, "msg".to_string()); // 3
         conv.add_assistant("resp".to_string()); // 4
 
         conv.drop_turns(&[1]);
@@ -974,11 +1147,15 @@ mod tests {
     fn summarize_turns_protects_user_layer() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
         conv.set_protect_user_layer(true);
-        conv.add_user_with_layer("user task".to_string(), MessageLayer::User); // 1
+        conv.add_user_with_layer(
+            MessageProvenance::FollowUp,
+            "user task".to_string(),
+            MessageLayer::User,
+        ); // 1
         conv.add_assistant("status 1".to_string()); // 2
-        conv.add_user("agent output 1".to_string()); // 3
+        conv.add_user(MessageProvenance::FollowUp, "agent output 1".to_string()); // 3
         conv.add_assistant("status 2".to_string()); // 4
-        conv.add_user("latest".to_string()); // 5
+        conv.add_user(MessageProvenance::FollowUp, "latest".to_string()); // 5
         conv.add_assistant("done".to_string()); // 6
 
         conv.summarize_turns(&[1, 2, 3], "Early progress");
@@ -1187,9 +1364,9 @@ mod tests {
         let path = dir.path().join("conversation.jsonl");
 
         let mut conv = Conversation::new("You are a helper.".to_string(), 200_000);
-        conv.add_user("Hello".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "Hello".to_string());
         conv.add_assistant("Hi there!".to_string());
-        conv.add_user("What is 2+2?".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "What is 2+2?".to_string());
         conv.add_assistant("4".to_string());
         conv.increment_turn();
         conv.increment_turn();
@@ -1270,7 +1447,7 @@ mod tests {
     fn auto_compact_below_threshold_noop() {
         let mut conv = Conversation::new("sys".to_string(), 200_000);
         for i in 0..20 {
-            conv.add_user(format!("msg {}", i));
+            conv.add_user(MessageProvenance::FollowUp, format!("msg {}", i));
             conv.add_assistant(format!("resp {}", i));
         }
         // No usage set → 0% → no compaction
@@ -1282,10 +1459,10 @@ mod tests {
     fn auto_compact_triggers_at_90_percent() {
         let mut conv = Conversation::new("sys".to_string(), 100_000);
         // system + 2 context msgs + many middle msgs + 4 tail = need 8+
-        conv.add_user("working dir".to_string()); // 1 - context
+        conv.add_user(MessageProvenance::FollowUp, "working dir".to_string()); // 1 - context
         conv.add_assistant("ack".to_string()); // 2 - context
         for i in 0..10 {
-            conv.add_user(format!("msg {}", i));
+            conv.add_user(MessageProvenance::FollowUp, format!("msg {}", i));
             conv.add_assistant(format!("resp {}", i));
         }
         conv.increment_turn();
@@ -1317,15 +1494,15 @@ mod tests {
     #[test]
     fn auto_compact_preserves_system_and_tail() {
         let mut conv = Conversation::new("system prompt".to_string(), 10_000);
-        conv.add_user("ctx1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "ctx1".to_string());
         conv.add_assistant("ctx2".to_string());
         for _ in 0..8 {
-            conv.add_user("middle".to_string());
+            conv.add_user(MessageProvenance::FollowUp, "middle".to_string());
             conv.add_assistant("middle_resp".to_string());
         }
-        conv.add_user("tail1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "tail1".to_string());
         conv.add_assistant("tail2".to_string());
-        conv.add_user("tail3".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "tail3".to_string());
         conv.add_assistant("tail4".to_string());
         conv.set_usage(TokenUsage {
             prompt_tokens: 9_500,
@@ -1348,9 +1525,9 @@ mod tests {
     #[test]
     fn auto_compact_too_few_messages_noop() {
         let mut conv = Conversation::new("sys".to_string(), 1_000);
-        conv.add_user("u1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u1".to_string());
         conv.add_assistant("a1".to_string());
-        conv.add_user("u2".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u2".to_string());
         conv.add_assistant("a2".to_string());
         conv.set_usage(TokenUsage {
             prompt_tokens: 950,
@@ -1454,10 +1631,10 @@ mod tests {
     fn auto_compact_at_custom_threshold() {
         let mut conv = Conversation::new("sys".to_string(), 100_000);
         // Build up enough messages (system + 2 context + middle + 4 tail = 8+ needed)
-        conv.add_user("ctx1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "ctx1".to_string());
         conv.add_assistant("ctx1-reply".to_string());
         for i in 0..10 {
-            conv.add_user(format!("middle-{}", i));
+            conv.add_user(MessageProvenance::FollowUp, format!("middle-{}", i));
             conv.add_assistant(format!("reply-{}", i));
         }
         // Set usage at 65% — above 0.60 threshold but below 0.90
@@ -1479,7 +1656,7 @@ mod tests {
     fn auto_compact_at_below_custom_threshold_noop() {
         let mut conv = Conversation::new("sys".to_string(), 100_000);
         for i in 0..10 {
-            conv.add_user(format!("u{}", i));
+            conv.add_user(MessageProvenance::FollowUp, format!("u{}", i));
             conv.add_assistant(format!("a{}", i));
         }
         conv.set_usage(crate::usage::TokenUsage {
@@ -1507,7 +1684,7 @@ mod tests {
     /// with a protected tail.
     fn conversation_with_two_tool_turns() -> Conversation {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("first task".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "first task".to_string());
         conv.add_assistant_tool_calls(
             "running one".to_string(),
             vec![tool_call_ref("call_1", "exec_command")],
@@ -1515,14 +1692,14 @@ mod tests {
         );
         conv.add_tool_result("call_1", "exec_command", "output one");
         conv.add_assistant("done one".to_string());
-        conv.add_user("second task".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "second task".to_string());
         conv.add_assistant_tool_calls(
             "running two".to_string(),
             vec![tool_call_ref("call_2", "write_file")],
             None,
         );
         conv.add_tool_result("call_2", "write_file", "output two");
-        conv.add_user("wrap up".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "wrap up".to_string());
         conv.add_assistant("all done".to_string());
         conv
     }
@@ -1620,7 +1797,7 @@ mod tests {
     #[test]
     fn resolve_dangling_tool_calls_adds_synthetic_results() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("do something".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "do something".to_string());
         conv.add_assistant_tool_calls(
             "I'll run two commands.".to_string(),
             vec![
@@ -1656,7 +1833,7 @@ mod tests {
     #[test]
     fn resolve_dangling_tool_calls_partial() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("do something".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "do something".to_string());
         conv.add_assistant_tool_calls(
             "Running.".to_string(),
             vec![
@@ -1696,7 +1873,7 @@ mod tests {
     #[test]
     fn resolve_dangling_tool_calls_noop_when_complete() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("do something".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "do something".to_string());
         conv.add_assistant_tool_calls(
             "Running.".to_string(),
             vec![ToolCallRef {
@@ -1716,10 +1893,99 @@ mod tests {
     #[test]
     fn resolve_dangling_tool_calls_noop_on_text_only() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("hello".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "hello".to_string());
         conv.add_assistant("hi there".to_string());
 
         let resolved = conv.resolve_dangling_tool_calls();
         assert_eq!(resolved, 0);
+    }
+
+    #[test]
+    fn seqs_are_monotonic_across_message_kinds() {
+        let mut conv = Conversation::new("sys".to_string(), 128_000);
+        let s1 = conv.add_user(MessageProvenance::Task, "task".to_string());
+        let s2 = conv.add_assistant("reply".to_string());
+        let s3 = conv.add_tool_result("c1", "exec", "out");
+        let s4 = conv.add_user(MessageProvenance::FollowUp, "next".to_string());
+        assert_eq!((s1, s2, s3, s4), (2, 3, 4, 5)); // system prompt took 1
+        let seqs: Vec<u64> = conv.messages().iter().map(|m| m.seq).collect();
+        assert_eq!(seqs, vec![1, 2, 3, 4, 5]);
+        assert_eq!(conv.messages()[1].provenance, MessageProvenance::Task,);
+        assert_eq!(conv.messages()[2].provenance, MessageProvenance::Assistant,);
+        assert_eq!(conv.messages()[3].provenance, MessageProvenance::ToolOutput,);
+    }
+
+    #[test]
+    fn truncate_never_reuses_seqs() {
+        let mut conv = Conversation::new("sys".to_string(), 128_000);
+        conv.add_user(MessageProvenance::Task, "task".to_string());
+        conv.add_assistant("a1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "f1".to_string());
+        conv.add_assistant("a2".to_string()); // seq 5
+        conv.truncate_to(3); // rewind to [system, task, a1]
+        let s = conv.add_user(MessageProvenance::FollowUp, "post-rewind".to_string());
+        assert!(s > 5, "seq {} reused after truncation", s);
+    }
+
+    #[test]
+    fn provenance_and_seq_roundtrip_and_legacy_loads() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("conversation.jsonl");
+
+        let mut conv = Conversation::new("sys".to_string(), 128_000);
+        conv.add_user(MessageProvenance::Task, "task".to_string());
+        conv.add_assistant("reply".to_string());
+        conv.save_to_file(&path).unwrap();
+
+        let loaded = Conversation::load_from_file(&path, 128_000).unwrap();
+        assert_eq!(loaded.messages()[1].provenance, MessageProvenance::Task);
+        assert_eq!(loaded.messages()[2].seq, 3);
+        // Counter resumes past the highest persisted seq.
+        let mut loaded = loaded;
+        assert!(
+            !loaded.ensure_seqs_assigned(),
+            "new-era file must not renumber"
+        );
+        let s = loaded.add_user(MessageProvenance::FollowUp, "next".to_string());
+        assert_eq!(s, 4);
+
+        // Legacy file: no provenance/seq keys at all.
+        let legacy = concat!(
+            "{\"role\":\"system\",\"content\":\"sys\"}\n",
+            "{\"role\":\"user\",\"content\":\"old task\"}\n",
+            "{\"role\":\"assistant\",\"content\":\"old reply\"}\n",
+        );
+        std::fs::write(&path, legacy).unwrap();
+        let mut legacy = Conversation::load_from_file(&path, 128_000).unwrap();
+        assert_eq!(legacy.messages()[1].provenance, MessageProvenance::Unknown);
+        assert_eq!(legacy.messages()[1].seq, 0);
+        assert!(legacy.ensure_seqs_assigned(), "legacy file renumbers");
+        let seqs: Vec<u64> = legacy.messages().iter().map(|m| m.seq).collect();
+        assert_eq!(seqs, vec![1, 2, 3]);
+        let s = legacy.add_user(MessageProvenance::FollowUp, "resumed".to_string());
+        assert_eq!(s, 4);
+    }
+
+    #[test]
+    fn summary_and_repair_messages_get_provenance_and_seqs() {
+        let mut conv = Conversation::new("sys".to_string(), 128_000);
+        conv.add_user(MessageProvenance::Task, "task".to_string());
+        conv.add_assistant("a1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "f1".to_string());
+        conv.add_assistant("a2".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "f2".to_string());
+        conv.add_assistant("a3".to_string()); // len 7, protected tail = last 2
+        conv.summarize_turns(&[1, 2], "summary of early turns");
+        let summary = conv
+            .messages()
+            .iter()
+            .find(|m| m.content.starts_with("[Context Summary]"))
+            .expect("summary message present");
+        assert_eq!(summary.provenance, MessageProvenance::ContextSummary);
+        assert!(
+            summary.seq > 7,
+            "summary got a fresh seq, found {}",
+            summary.seq
+        );
     }
 }

--- a/docs/src/session-logging.md
+++ b/docs/src/session-logging.md
@@ -109,6 +109,7 @@ The event vocabulary is broad and grows with the system. Grouped by area
 |------|--------|
 | Lifecycle | `session_start`, `session_started`, `agent_started`, `turn_start`, `round_complete`, `task_complete`, `done_signal`, `safety_cap_reached`, `session_end`, `session_ended` |
 | Model I/O | `messages_input`, `model_response`, `reasoning`, `json_extracted` |
+| Message lane | `conversation_message`, `conversation_rewound`, `conversation_message_epoch` |
 | Runtime | `agent_input`, `agent_output` |
 | Approvals | `approval`, `approval_resolved`, `auto_approved`, `human_question`, `human_response_sent` |
 | Context | `context_snapshot`, `snapshot_created`, `conversation_rolled_back`, `rolled_back`, `redone`, `history_pruned` |
@@ -122,6 +123,28 @@ The event vocabulary is broad and grows with the system. Grouped by area
 Each is written by a typed method on `SessionLog` (e.g. `turn_start`,
 `model_response`, `agent_input`, `agent_output`, `approval`, `json_extracted`,
 `reasoning_content`), not by hand-formatting JSON.
+
+### The message lane (`conversation_message`)
+
+`conversation_message` is the canonical append-only record of what was
+*actually said* in the native worker conversation — the source the
+message-search index consumes. One record per genuine entry: the task
+(provenance `task`), resume continuations (`resume_task`), follow-ups
+(`follow_up`), steers delivered into model context (`steer`), accepted
+askHuman answers (`ask_human_answer`), and non-empty assistant responses
+(`assistant` — emitted by the same call that writes the `turns/*_model.txt`
+sidecar span the record references via `file` + `data.model_offset`/
+`data.model_bytes`). System injections, tool output, context summaries, the
+CU sub-conversation, and presence never emit it. `data.text` carries the RAW
+user text (no attachment preludes or `[New Task]`-style wrappers);
+`data.message_seq` is the conversation's monotonic ordinal (`Message.seq`);
+`data.ref_seq` marks a projection (a native-tool askHuman answer riding a
+tool result). `conversation_rewound { cut_after_seq, kind }` marks messages
+past a rewind cut as superseded — compaction deliberately does NOT emit it.
+`conversation_message_epoch` records the resume-time seq assignment for
+legacy files (`mapping: [[seq, role, content-hash16], …]`); extractors use
+legacy extraction strictly before the marker and `conversation_message`
+records after it.
 
 ### Querying
 

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -982,10 +982,18 @@ pub(crate) async fn run_agent_loop(
                     ("System", MessageProvenance::SystemInjection)
                 };
                 let text = format!("[{}] {}", prefix, inj.text);
-                if inj.images.is_empty() {
-                    conversation.add_user(provenance, text.clone());
+                let seq = if inj.images.is_empty() {
+                    conversation.add_user(provenance, text.clone())
                 } else {
-                    conversation.add_user_with_images(provenance, text.clone(), inj.images);
+                    conversation.add_user_with_images(provenance, text.clone(), inj.images)
+                };
+                // Delivered steers are message-lane; system injections are
+                // not. The record carries the raw steer text, not the
+                // `[User]`-prefixed conversation string.
+                if provenance == MessageProvenance::Steer {
+                    slog(&session_log, |l| {
+                        let _ = l.conversation_message_user(seq, provenance, &inj.text, None);
+                    });
                 }
                 slog(&session_log, |l| {
                     l.info(&format!("Context injected: {}", inj.text))
@@ -1181,7 +1189,7 @@ pub(crate) async fn run_agent_loop(
         // Store assistant message — with or without tool calls
         let has_tool_calls = !response.tool_calls.is_empty();
         let has_cu_calls = !response.cu_calls.is_empty();
-        if has_tool_calls || has_cu_calls {
+        let assistant_seq = if has_tool_calls || has_cu_calls {
             let refs: Vec<conversation::ToolCallRef> = response
                 .tool_calls
                 .iter()
@@ -1196,21 +1204,35 @@ pub(crate) async fn run_agent_loop(
                 response.content.clone(),
                 refs,
                 response.raw_output.clone(),
-            );
-        } else {
-            conversation.add_assistant(response.content.clone());
-        }
-
-        // Log the full model response (no truncation)
-        slog(&session_log, |l| {
-            l.model_response(
-                &response.content,
-                response.usage.prompt_tokens,
-                response.usage.completion_tokens,
-                response.usage.total_tokens,
-                response.usage.cached_tokens,
-                None,
             )
+        } else {
+            conversation.add_assistant(response.content.clone())
+        };
+
+        // Log the full model response (no truncation). Non-empty content —
+        // on BOTH branches: assistant prose regularly accompanies tool
+        // calls — also gets its canonical conversation_message record,
+        // written by the same call as the sidecar span (no crash window).
+        slog(&session_log, |l| {
+            if response.content.trim().is_empty() {
+                let _ = l.model_response(
+                    &response.content,
+                    response.usage.prompt_tokens,
+                    response.usage.completion_tokens,
+                    response.usage.total_tokens,
+                    response.usage.cached_tokens,
+                    None,
+                );
+            } else {
+                let _ = l.model_response_with_message(
+                    assistant_seq,
+                    &response.content,
+                    response.usage.prompt_tokens,
+                    response.usage.completion_tokens,
+                    response.usage.total_tokens,
+                    response.usage.cached_tokens,
+                );
+            }
         });
 
         // Log reasoning content if available
@@ -1703,19 +1725,38 @@ pub(crate) async fn run_agent_loop(
                             .unwrap_or_default(),
                         Ok(_) | Err(_) => String::new(),
                     };
-                    let reply = if answer.trim().is_empty() {
+                    let answered = !answer.trim().is_empty();
+                    let reply = if answered {
+                        slog(&session_log, |l| l.human_response_sent());
+                        answer
+                    } else {
                         "The user dismissed the question without answering. Proceed with \
                          your best judgment; you can re-ask later if it is still relevant."
                             .to_string()
-                    } else {
-                        slog(&session_log, |l| l.human_response_sent());
-                        answer
                     };
+                    let mut first_result_seq: Option<u64> = None;
                     for (call_id, tool_name) in &batch.call_id_names {
                         if handled_call_ids.contains(call_id) {
                             continue;
                         }
-                        conversation.add_tool_result(call_id, tool_name, &reply);
+                        let seq = conversation.add_tool_result(call_id, tool_name, &reply);
+                        first_result_seq.get_or_insert(seq);
+                    }
+                    // Native-tool askHuman answers enter the conversation as
+                    // tool results; project the raw answer into the message
+                    // lane referencing that result's seq (rewind cuts cover
+                    // it through ref_seq).
+                    if answered {
+                        if let Some(seq) = first_result_seq {
+                            slog(&session_log, |l| {
+                                let _ = l.conversation_message_user(
+                                    seq,
+                                    MessageProvenance::AskHumanAnswer,
+                                    &reply,
+                                    Some(seq),
+                                );
+                            });
+                        }
                     }
                     continue;
                 }
@@ -2225,10 +2266,20 @@ Proceed with explicit assumptions and continue without additional questions."
                     );
                 } else {
                     slog(&session_log, |l| l.human_response_sent());
-                    conversation.add_user(
+                    let seq = conversation.add_user(
                         MessageProvenance::AskHumanAnswer,
                         format!("The user's answer to your question: {answer}"),
                     );
+                    // The canonical record carries the raw answer, closing
+                    // the audit hole where human_response_sent has no text.
+                    slog(&session_log, |l| {
+                        let _ = l.conversation_message_user(
+                            seq,
+                            MessageProvenance::AskHumanAnswer,
+                            &answer,
+                            None,
+                        );
+                    });
                 }
                 continue;
             }
@@ -2708,15 +2759,30 @@ pub(crate) async fn run_round_loop(
                         }
                     ))
                 });
-                if followup_images.is_empty() {
-                    conversation.add_user(MessageProvenance::FollowUp, followup_text);
+                // A between-rounds steer is delivered through this path
+                // (steer_id set); classify it as such rather than follow_up.
+                let followup_provenance = if message.steer_id.is_some() {
+                    MessageProvenance::Steer
+                } else {
+                    MessageProvenance::FollowUp
+                };
+                let followup_seq = if followup_images.is_empty() {
+                    conversation.add_user(followup_provenance, followup_text)
                 } else {
                     conversation.add_user_with_images(
-                        MessageProvenance::FollowUp,
+                        followup_provenance,
                         followup_text,
                         followup_images,
+                    )
+                };
+                slog(&session_log, |l| {
+                    let _ = l.conversation_message_user(
+                        followup_seq,
+                        followup_provenance,
+                        &message.text,
+                        None,
                     );
-                }
+                });
                 if let Some(id) = message.steer_id {
                     bus.send(AppEvent::SteerDelivered {
                         session_id: local_session_id.clone(),
@@ -2744,4 +2810,69 @@ pub(crate) async fn run_round_loop(
     }
 
     Ok(cumulative_stats)
+}
+
+#[cfg(test)]
+mod provenance_parity {
+    //! Emission-site parity: every conversation entry point must declare a
+    //! provenance, and new call sites must be consciously added to the
+    //! pinned counts (message-search plan §3 F1). This is the drift guard
+    //! for the `conversation_message` emit/skip allowlist.
+
+    fn source(file: &str) -> String {
+        let path = format!("{}/src/bin/caller/{}", env!("CARGO_MANIFEST_DIR"), file);
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {}", path, e))
+    }
+
+    /// Every add_user-family call's first argument must be a provenance
+    /// expression (`MessageProvenance::…` or a `*provenance` variable).
+    /// Patterns are assembled with `concat!` — and this comment avoids
+    /// spelling them — so the module never matches itself.
+    fn assert_classified(file: &str, pattern: &str, expected: usize) {
+        let text = source(file);
+        let mut count = 0;
+        let mut from = 0;
+        while let Some(pos) = text[from..].find(pattern) {
+            let arg_start = from + pos + pattern.len();
+            let rest: String = text[arg_start..]
+                .chars()
+                .skip_while(|c| c.is_whitespace())
+                .take(80)
+                .collect();
+            let first_arg = rest.split(',').next().unwrap_or("");
+            assert!(
+                first_arg.contains("rovenance"),
+                "{}: `{}` call with unclassified first argument `{}` — every \
+                 conversation entry point declares a MessageProvenance",
+                file,
+                pattern,
+                first_arg
+            );
+            count += 1;
+            from = arg_start;
+        }
+        assert_eq!(
+            count, expected,
+            "{}: expected {} `{}` sites, found {} — a conversation entry \
+             point was added or removed; reconcile the emission map \
+             (message-search plan §4) and re-pin",
+            file, expected, pattern, count
+        );
+    }
+
+    #[test]
+    fn conversation_entry_points_are_classified_and_pinned() {
+        let add_user = concat!(".add_", "user(");
+        let add_user_with_images = concat!(".add_", "user_with_images(");
+        for (file, users, with_images) in [
+            ("agent_loop.rs", 9usize, 2usize),
+            ("main.rs", 17, 1),
+            ("run_modes.rs", 5, 3),
+            ("display_glue.rs", 1, 2),
+            ("presence.rs", 2, 0),
+        ] {
+            assert_classified(file, add_user, users);
+            assert_classified(file, add_user_with_images, with_images);
+        }
+    }
 }

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -5,6 +5,7 @@
 //! submit_result).
 
 use crate::conversation;
+use crate::conversation::MessageProvenance;
 use crate::external_agent;
 use crate::provider;
 use crate::{ExternalToolFailureLogLimiter, ExternalToolOutputLimiter};
@@ -975,16 +976,16 @@ pub(crate) async fn run_agent_loop(
         // always used.
         if let Ok(mut q) = context_injection.lock() {
             for inj in q.drain(..) {
-                let prefix = if inj.steer_id.is_some() {
-                    "User"
+                let (prefix, provenance) = if inj.steer_id.is_some() {
+                    ("User", MessageProvenance::Steer)
                 } else {
-                    "System"
+                    ("System", MessageProvenance::SystemInjection)
                 };
                 let text = format!("[{}] {}", prefix, inj.text);
                 if inj.images.is_empty() {
-                    conversation.add_user(text.clone());
+                    conversation.add_user(provenance, text.clone());
                 } else {
-                    conversation.add_user_with_images(text.clone(), inj.images);
+                    conversation.add_user_with_images(provenance, text.clone(), inj.images);
                 }
                 slog(&session_log, |l| {
                     l.info(&format!("Context injected: {}", inj.text))
@@ -2126,7 +2127,10 @@ pub(crate) async fn run_agent_loop(
                         l.debug(&format!("Turn {}: context management only", turn))
                     });
                     bus.send(AppEvent::ContextManagement { turn });
-                    conversation.add_user("Context updated.".to_string());
+                    conversation.add_user(
+                        MessageProvenance::SystemInjection,
+                        "Context updated.".to_string(),
+                    );
                     continue;
                 } else {
                     empty_command_streak += 1;
@@ -2153,6 +2157,7 @@ pub(crate) async fn run_agent_loop(
                         )
                     });
                     conversation.add_user(
+                        MessageProvenance::SystemInjection,
                         "No commands were produced. If the task is complete, respond with JSON containing done=true. Otherwise provide commands.".to_string(),
                     );
                     continue;
@@ -2169,6 +2174,7 @@ pub(crate) async fn run_agent_loop(
                     l.warn("askHuman requested in headless mode; prompting model to continue")
                 });
                 conversation.add_user(
+                    MessageProvenance::SystemInjection,
                     "askHuman is unavailable in headless mode (--no-tui or non-interactive stdin). \
 Proceed with explicit assumptions and continue without additional questions."
                         .to_string(),
@@ -2212,13 +2218,17 @@ Proceed with explicit assumptions and continue without additional questions."
                 };
                 if answer.trim().is_empty() {
                     conversation.add_user(
+                        MessageProvenance::SystemInjection,
                         "The user dismissed the question without answering. Proceed with \
                          your best judgment; you can re-ask later if it is still relevant."
                             .to_string(),
                     );
                 } else {
                     slog(&session_log, |l| l.human_response_sent());
-                    conversation.add_user(format!("The user's answer to your question: {answer}"));
+                    conversation.add_user(
+                        MessageProvenance::AskHumanAnswer,
+                        format!("The user's answer to your question: {answer}"),
+                    );
                 }
                 continue;
             }
@@ -2459,7 +2469,10 @@ Proceed with explicit assumptions and continue without additional questions."
             }
 
             if should_skip {
-                conversation.add_user("Command skipped by user.".to_string());
+                conversation.add_user(
+                    MessageProvenance::SystemInjection,
+                    "Command skipped by user.".to_string(),
+                );
                 continue;
             }
 
@@ -2503,7 +2516,7 @@ Proceed with explicit assumptions and continue without additional questions."
                 user_msg.push_str(&format!("\nStderr:\n{}", output.stderr));
             }
             user_msg.push_str(&format!("\n\n{}", conversation.budget_summary()));
-            conversation.add_user(user_msg);
+            conversation.add_user(MessageProvenance::ToolOutput, user_msg);
         } // end tool_calls vs text branch
 
         // Auto-save conversation for resume capability
@@ -2696,9 +2709,13 @@ pub(crate) async fn run_round_loop(
                     ))
                 });
                 if followup_images.is_empty() {
-                    conversation.add_user(followup_text);
+                    conversation.add_user(MessageProvenance::FollowUp, followup_text);
                 } else {
-                    conversation.add_user_with_images(followup_text, followup_images);
+                    conversation.add_user_with_images(
+                        MessageProvenance::FollowUp,
+                        followup_text,
+                        followup_images,
+                    );
                 }
                 if let Some(id) = message.steer_id {
                     bus.send(AppEvent::SteerDelivered {

--- a/src/bin/caller/display_glue.rs
+++ b/src/bin/caller/display_glue.rs
@@ -1194,6 +1194,7 @@ pub(crate) async fn run_cu_task(
     // Inject reference frames
     if !reference_images.is_empty() {
         conv.add_user_with_images(
+            MessageProvenance::SystemInjection,
             "The user was looking at this screen when they made their request:".to_string(),
             reference_images,
         );
@@ -1204,12 +1205,16 @@ pub(crate) async fn run_cu_task(
 
     // Inject context images
     if !context_images.is_empty() {
-        conv.add_user_with_images("Additional context:".to_string(), context_images);
+        conv.add_user_with_images(
+            MessageProvenance::SystemInjection,
+            "Additional context:".to_string(),
+            context_images,
+        );
         conv.add_assistant("Noted.".to_string());
     }
 
     // Add the task
-    conv.add_user(task.to_string());
+    conv.add_user(MessageProvenance::Task, task.to_string());
 
     slog(session_log, |l| {
         l.cu_task_start(

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -123,7 +123,7 @@ mod display_glue;
 pub(crate) use display_glue::*;
 
 use autonomy::{AutonomyLevel, AutonomyState, SharedAutonomy};
-use conversation::Conversation;
+use conversation::{Conversation, MessageProvenance};
 use error::CallerError;
 use event::{AppEvent, ControlMsg, EventBus};
 use project::Project;
@@ -1522,11 +1522,11 @@ Also: {"source": "bare"}"#;
     #[test]
     fn apply_context_directives_drop_turns() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("u1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u1".to_string());
         conv.add_assistant("a1".to_string());
-        conv.add_user("u2".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u2".to_string());
         conv.add_assistant("a2".to_string());
-        conv.add_user("u3".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u3".to_string());
         conv.add_assistant("a3".to_string());
 
         let json = r#"{"commands":[{"function":"execAsAgent","nonce":1,"command":"ls"}],"context":{"drop_turns":[1,2]}}"#;
@@ -1544,11 +1544,11 @@ Also: {"source": "bare"}"#;
     #[test]
     fn apply_context_directives_summarize() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("u1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u1".to_string());
         conv.add_assistant("a1".to_string());
-        conv.add_user("u2".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u2".to_string());
         conv.add_assistant("a2".to_string());
-        conv.add_user("u3".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u3".to_string());
         conv.add_assistant("a3".to_string());
 
         let json = r#"{"commands":[{"function":"execAsAgent","nonce":1,"command":"ls"}],"context":{"summarize":{"turns":[1,2,3,4],"summary":"Setup phase"}}}"#;
@@ -1563,11 +1563,11 @@ Also: {"source": "bare"}"#;
     #[test]
     fn apply_context_directives_context_only() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("u1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u1".to_string());
         conv.add_assistant("a1".to_string());
-        conv.add_user("u2".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u2".to_string());
         conv.add_assistant("a2".to_string());
-        conv.add_user("u3".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u3".to_string());
         conv.add_assistant("a3".to_string());
 
         let json = r#"{"commands":[],"context":{"drop_turns":[1,2]}}"#;
@@ -1579,7 +1579,7 @@ Also: {"source": "bare"}"#;
     #[test]
     fn apply_context_directives_no_context() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("u1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u1".to_string());
         conv.add_assistant("a1".to_string());
 
         let json = r#"{"commands":[{"function":"execAsAgent","nonce":1,"command":"ls"}]}"#;
@@ -1592,7 +1592,7 @@ Also: {"source": "bare"}"#;
     #[test]
     fn apply_context_directives_empty_commands_no_context() {
         let mut conv = Conversation::new("sys".to_string(), 128_000);
-        conv.add_user("u1".to_string());
+        conv.add_user(MessageProvenance::FollowUp, "u1".to_string());
         conv.add_assistant("a1".to_string());
 
         let json = r#"{"commands":[]}"#;
@@ -2692,18 +2692,21 @@ Also: {"source": "bare"}"#;
 /// Used by both `setup_fresh_conversation` and the persistent presence conversation.
 fn setup_fresh_conversation_no_task(conv: &mut Conversation, project: &Project) {
     // Inject project root so the model knows which directory to work in
-    conv.add_user(format!(
-        "Working directory: {}\nThis is the project you should examine and modify. \
+    conv.add_user(
+        MessageProvenance::SystemInjection,
+        format!(
+            "Working directory: {}\nThis is the project you should examine and modify. \
 All relative paths and commands execute from this directory.",
-        project.root.display()
-    ));
+            project.root.display()
+        ),
+    );
     conv.add_assistant(
         "Understood. I will work within the specified project directory.".to_string(),
     );
 
     // Inject INTENDANT.md instructions
     if let Some(instructions) = prompts::load_project_instructions(Some(&project.root)) {
-        conv.add_user(instructions);
+        conv.add_user(MessageProvenance::SystemInjection, instructions);
         conv.add_assistant("Acknowledged. I will follow the project instructions.".to_string());
     }
 
@@ -2713,7 +2716,7 @@ All relative paths and commands execute from this directory.",
             let refs: Vec<&_> = kstore.entries.iter().collect();
             let msg = knowledge::format_for_injection(&refs);
             if !msg.is_empty() {
-                conv.add_user(msg);
+                conv.add_user(MessageProvenance::SystemInjection, msg);
                 conv.add_assistant(
                     "Acknowledged. I have loaded the project knowledge.".to_string(),
                 );
@@ -2725,7 +2728,7 @@ All relative paths and commands execute from this directory.",
     let discovered_skills = skills::discover_skills(Some(&project.root));
     if !discovered_skills.is_empty() {
         let catalog = skills::format_skill_catalog(&discovered_skills);
-        conv.add_user(catalog);
+        conv.add_user(MessageProvenance::SystemInjection, catalog);
         conv.add_assistant("Acknowledged. I see the available skills.".to_string());
     }
 }
@@ -2734,7 +2737,7 @@ All relative paths and commands execute from this directory.",
 #[allow(dead_code)]
 fn setup_fresh_conversation(conv: &mut Conversation, project: &Project, task: &str) {
     setup_fresh_conversation_no_task(conv, project);
-    conv.add_user(task.to_string());
+    conv.add_user(MessageProvenance::Task, task.to_string());
 }
 
 /// Set up a fresh conversation with project context, memory, skills, task, and
@@ -2748,9 +2751,9 @@ fn setup_fresh_conversation_with_attachments(
 ) {
     setup_fresh_conversation_no_task(conv, project);
     if images.is_empty() {
-        conv.add_user(task.to_string());
+        conv.add_user(MessageProvenance::Task, task.to_string());
     } else {
-        conv.add_user_with_images(task.to_string(), images);
+        conv.add_user_with_images(MessageProvenance::Task, task.to_string(), images);
     }
 }
 

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -2735,25 +2735,27 @@ All relative paths and commands execute from this directory.",
 
 /// Set up a fresh conversation with project context, memory, skills, and task.
 #[allow(dead_code)]
-fn setup_fresh_conversation(conv: &mut Conversation, project: &Project, task: &str) {
+fn setup_fresh_conversation(conv: &mut Conversation, project: &Project, task: &str) -> u64 {
     setup_fresh_conversation_no_task(conv, project);
-    conv.add_user(MessageProvenance::Task, task.to_string());
+    conv.add_user(MessageProvenance::Task, task.to_string())
 }
 
 /// Set up a fresh conversation with project context, memory, skills, task, and
 /// optional user-attached images.  When images are present, they are added to
 /// the same user message as the task so the model sees them as inline context.
+/// Returns the seq of the task message, so callers can emit its canonical
+/// `conversation_message` record (this helper has no session-log handle).
 fn setup_fresh_conversation_with_attachments(
     conv: &mut Conversation,
     project: &Project,
     task: &str,
     images: Vec<conversation::ImageData>,
-) {
+) -> u64 {
     setup_fresh_conversation_no_task(conv, project);
     if images.is_empty() {
-        conv.add_user(MessageProvenance::Task, task.to_string());
+        conv.add_user(MessageProvenance::Task, task.to_string())
     } else {
-        conv.add_user_with_images(MessageProvenance::Task, task.to_string(), images);
+        conv.add_user_with_images(MessageProvenance::Task, task.to_string(), images)
     }
 }
 

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -1,4 +1,4 @@
-use crate::conversation::Conversation;
+use crate::conversation::{Conversation, MessageProvenance};
 use crate::error::CallerError;
 use crate::event::{AppEvent, ControlMsg, EventBus};
 use crate::knowledge::{self, KnowledgeQuery};
@@ -190,7 +190,8 @@ impl PresenceLayer {
             return Ok(String::new());
         }
         self.turn += 1;
-        self.conversation.add_user(input.to_string());
+        self.conversation
+            .add_user(MessageProvenance::FollowUp, input.to_string());
         let result = self.run_model_loop().await;
         self.emit_usage_update();
         result
@@ -253,8 +254,10 @@ impl PresenceLayer {
         }
         self.turn += 1;
         let event_text = format_event(&event);
-        self.conversation
-            .add_user(format!("[Event] {}", event_text));
+        self.conversation.add_user(
+            MessageProvenance::SystemInjection,
+            format!("[Event] {}", event_text),
+        );
         let response = self.run_model_loop().await?;
         if response.trim().is_empty() {
             Ok(None)

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -1559,7 +1559,22 @@ pub(crate) async fn run_with_presence(
                     // emit a 0-turn event so the dashboard clears the
                     // pending state.
                     let removed = match target_native_message_count {
-                        Some(n) => conv.truncate_to(n as usize),
+                        Some(n) => {
+                            // Capture the surviving tail's seq BEFORE the
+                            // truncate: truncate_to appends synthetic
+                            // dangling-call repairs with fresh (higher)
+                            // seqs that must not shift the cut.
+                            let clamped = (n as usize).max(1).min(conv.len());
+                            let cut_after_seq =
+                                conv.messages().get(clamped - 1).map(|m| m.seq).unwrap_or(0);
+                            let removed = conv.truncate_to(n as usize);
+                            if removed > 0 {
+                                slog(&session_log, |l| {
+                                    l.conversation_rewound(cut_after_seq, "tail_rollback")
+                                });
+                            }
+                            removed
+                        }
                         None => 0,
                     };
                     bus.send(AppEvent::ConversationRolledBack {
@@ -2740,15 +2755,23 @@ pub(crate) async fn run_with_presence(
                 // image content the model should see alongside the task.
                 let mut combined_images = frame_images;
                 combined_images.extend(attachment_images.iter().cloned());
-                if combined_images.is_empty() {
-                    conv.add_user(MessageProvenance::Task, task_text.clone());
+                let task_seq = if combined_images.is_empty() {
+                    conv.add_user(MessageProvenance::Task, task_text.clone())
                 } else {
                     conv.add_user_with_images(
                         MessageProvenance::Task,
                         task_text.clone(),
                         combined_images,
+                    )
+                };
+                slog(&session_log, |l| {
+                    let _ = l.conversation_message_user(
+                        task_seq,
+                        MessageProvenance::Task,
+                        &task_text,
+                        None,
                     );
-                }
+                });
 
                 persistent_project = Some(proj);
                 persistent_provider = Some(task_provider);
@@ -2771,18 +2794,26 @@ pub(crate) async fn run_with_presence(
 
                 let mut combined_images = frame_images;
                 combined_images.extend(attachment_images.iter().cloned());
-                if combined_images.is_empty() {
+                let task_seq = if combined_images.is_empty() {
                     conv.add_user(
                         MessageProvenance::FollowUp,
                         format!("[New Task] {}", task_text),
-                    );
+                    )
                 } else {
                     conv.add_user_with_images(
                         MessageProvenance::FollowUp,
                         format!("[New Task] {}", task_text),
                         combined_images,
+                    )
+                };
+                slog(&session_log, |l| {
+                    let _ = l.conversation_message_user(
+                        task_seq,
+                        MessageProvenance::FollowUp,
+                        &task_text,
+                        None,
                     );
-                }
+                });
             }
 
             if let Some(id) = envelope.steer_id.as_deref() {
@@ -2979,6 +3010,23 @@ pub(crate) async fn run_direct_mode(
     let mut conversation = if conv_path.exists() {
         match Conversation::load_from_file(&conv_path, provider.context_window()) {
             Ok(mut conv) => {
+                // Mixed-version cutover: a legacy file (no seqs) gets them
+                // assigned once, and the epoch marker records the mapping so
+                // extractors can correlate (message-search plan §4).
+                if conv.ensure_seqs_assigned() {
+                    let mapping: Vec<(u64, String, String)> = conv
+                        .messages()
+                        .iter()
+                        .map(|m| {
+                            (
+                                m.seq,
+                                m.role.clone(),
+                                session_log::content_hash_hex16(&m.content),
+                            )
+                        })
+                        .collect();
+                    slog(&session_log, |l| l.conversation_message_epoch(&mapping));
+                }
                 slog(&session_log, |l| {
                     l.info(&format!(
                         "Resumed conversation ({} messages, turn {})",
@@ -2989,15 +3037,23 @@ pub(crate) async fn run_direct_mode(
                 // Append the new task as a continuation message
                 let resume_msg = attachments
                     .text_with_file_prelude(&format!("[Session resumed] Continue with: {}", task));
-                if attachment_images.is_empty() {
-                    conv.add_user(MessageProvenance::ResumeTask, resume_msg);
+                let resume_seq = if attachment_images.is_empty() {
+                    conv.add_user(MessageProvenance::ResumeTask, resume_msg)
                 } else {
                     conv.add_user_with_images(
                         MessageProvenance::ResumeTask,
                         resume_msg,
                         attachment_images.clone(),
+                    )
+                };
+                slog(&session_log, |l| {
+                    let _ = l.conversation_message_user(
+                        resume_seq,
+                        MessageProvenance::ResumeTask,
+                        &task,
+                        None,
                     );
-                }
+                });
                 conv
             }
             Err(e) => {
@@ -3009,24 +3065,31 @@ pub(crate) async fn run_direct_mode(
                 });
                 fresh_conversation = true;
                 let mut conv = Conversation::new(system_prompt, provider.context_window());
-                setup_fresh_conversation_with_attachments(
+                let task_seq = setup_fresh_conversation_with_attachments(
                     &mut conv,
                     &project,
                     &attachments.text_with_file_prelude(&task),
                     attachment_images.clone(),
                 );
+                slog(&session_log, |l| {
+                    let _ =
+                        l.conversation_message_user(task_seq, MessageProvenance::Task, &task, None);
+                });
                 conv
             }
         }
     } else {
         fresh_conversation = true;
         let mut conv = Conversation::new(system_prompt, provider.context_window());
-        setup_fresh_conversation_with_attachments(
+        let task_seq = setup_fresh_conversation_with_attachments(
             &mut conv,
             &project,
             &attachments.text_with_file_prelude(&task),
             attachment_images.clone(),
         );
+        slog(&session_log, |l| {
+            let _ = l.conversation_message_user(task_seq, MessageProvenance::Task, &task, None);
+        });
         conv
     };
 

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -2723,12 +2723,15 @@ pub(crate) async fn run_with_presence(
 
                 // Frame directory awareness
                 let frames_dir = log_dir.join("frames");
-                conv.add_user(format!(
-                    "[System] Video frames from the user's camera are stored at: {}\n\
+                conv.add_user(
+                    MessageProvenance::SystemInjection,
+                    format!(
+                        "[System] Video frames from the user's camera are stored at: {}\n\
                      Each frame is a JPEG named by frame ID (e.g., cam0-f00001.jpg).\n\
                      When you receive frame references, you can read them from this path.",
-                    frames_dir.display()
-                ));
+                        frames_dir.display()
+                    ),
+                );
                 conv.add_assistant("Understood.".to_string());
 
                 // Add task with optional frame images. Combine context-hint
@@ -2738,9 +2741,13 @@ pub(crate) async fn run_with_presence(
                 let mut combined_images = frame_images;
                 combined_images.extend(attachment_images.iter().cloned());
                 if combined_images.is_empty() {
-                    conv.add_user(task_text.clone());
+                    conv.add_user(MessageProvenance::Task, task_text.clone());
                 } else {
-                    conv.add_user_with_images(task_text.clone(), combined_images);
+                    conv.add_user_with_images(
+                        MessageProvenance::Task,
+                        task_text.clone(),
+                        combined_images,
+                    );
                 }
 
                 persistent_project = Some(proj);
@@ -2765,9 +2772,16 @@ pub(crate) async fn run_with_presence(
                 let mut combined_images = frame_images;
                 combined_images.extend(attachment_images.iter().cloned());
                 if combined_images.is_empty() {
-                    conv.add_user(format!("[New Task] {}", task_text));
+                    conv.add_user(
+                        MessageProvenance::FollowUp,
+                        format!("[New Task] {}", task_text),
+                    );
                 } else {
-                    conv.add_user_with_images(format!("[New Task] {}", task_text), combined_images);
+                    conv.add_user_with_images(
+                        MessageProvenance::FollowUp,
+                        format!("[New Task] {}", task_text),
+                        combined_images,
+                    );
                 }
             }
 
@@ -2976,9 +2990,13 @@ pub(crate) async fn run_direct_mode(
                 let resume_msg = attachments
                     .text_with_file_prelude(&format!("[Session resumed] Continue with: {}", task));
                 if attachment_images.is_empty() {
-                    conv.add_user(resume_msg);
+                    conv.add_user(MessageProvenance::ResumeTask, resume_msg);
                 } else {
-                    conv.add_user_with_images(resume_msg, attachment_images.clone());
+                    conv.add_user_with_images(
+                        MessageProvenance::ResumeTask,
+                        resume_msg,
+                        attachment_images.clone(),
+                    );
                 }
                 conv
             }
@@ -3019,7 +3037,7 @@ pub(crate) async fn run_direct_mode(
             let refs: Vec<&_> = kstore.entries.iter().collect();
             let msg = knowledge::format_for_injection(&refs);
             if !msg.is_empty() {
-                conversation.add_user(msg);
+                conversation.add_user(MessageProvenance::SystemInjection, msg);
                 conversation.add_assistant(
                     "Acknowledged. I have loaded the project knowledge.".to_string(),
                 );

--- a/src/bin/caller/session_log/bus_events.rs
+++ b/src/bin/caller/session_log/bus_events.rs
@@ -1342,7 +1342,7 @@ impl SessionLog {
         total_tokens: u64,
         cached_tokens: u64,
         source: Option<&str>,
-    ) {
+    ) -> Option<TurnFileSpan> {
         self.model_response_for_session(
             None,
             content,
@@ -1351,9 +1351,13 @@ impl SessionLog {
             total_tokens,
             cached_tokens,
             source,
-        );
+        )
     }
 
+    /// Returns the sidecar span the response text was appended to, so the
+    /// combined op ([`Self::model_response_with_message`]) can reference the
+    /// same bytes from the canonical `conversation_message` record without a
+    /// second write.
     #[allow(clippy::too_many_arguments)] // established internal signature: the params are distinct dependencies, not a bundle
     pub fn model_response_for_session(
         &mut self,
@@ -1364,7 +1368,7 @@ impl SessionLog {
         total_tokens: u64,
         cached_tokens: u64,
         source: Option<&str>,
-    ) {
+    ) -> Option<TurnFileSpan> {
         self.summary_builder.total_tokens += total_tokens;
         // Codex fires multiple `model_response` events per turn (one per
         // assistant message in the same turn). Appending keeps the full
@@ -1401,6 +1405,162 @@ impl SessionLog {
             message: Some(preview),
             data: Some(data),
             file,
+            file2: None,
+        });
+        span
+    }
+
+    /// Combined assistant logging op (message-search plan §4): ONE call
+    /// writes the sidecar span, the diagnostic `model_response` event, and
+    /// the canonical `conversation_message` record — no crash window between
+    /// diagnostic and canonical, and no second copy of the text. Native
+    /// acceptance-point only; external wrappers keep plain `model_response`
+    /// (their messages are canonical in the NATIVE backend logs, and the
+    /// intendant extractor skips wrapper sessions to avoid duplicates).
+    pub fn model_response_with_message(
+        &mut self,
+        seq: u64,
+        content: &str,
+        prompt_tokens: u64,
+        completion_tokens: u64,
+        total_tokens: u64,
+        cached_tokens: u64,
+    ) -> String {
+        let span = self.model_response_for_session(
+            None,
+            content,
+            prompt_tokens,
+            completion_tokens,
+            total_tokens,
+            cached_tokens,
+            None,
+        );
+        let message_id = Uuid::new_v4().to_string();
+        let mut data = serde_json::json!({
+            "message_id": message_id,
+            "message_seq": seq,
+            "role": "assistant",
+            "provenance": crate::conversation::MessageProvenance::Assistant,
+        });
+        let file = span.as_ref().map(|span| {
+            data["model_offset"] = serde_json::Value::from(span.offset);
+            data["model_bytes"] = serde_json::Value::from(span.len);
+            span.relative.clone()
+        });
+        let preview: String = content.chars().take(200).collect();
+        self.emit(LogEvent {
+            ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
+            turn: Some(self.current_turn),
+            event: "conversation_message".to_string(),
+            level: Some("info".to_string()),
+            message: Some(preview),
+            data: Some(data),
+            file,
+            file2: None,
+        });
+        message_id
+    }
+
+    /// Canonical message-lane record for a user-side conversation entry
+    /// (task / resume task / follow-up / delivered steer / askHuman answer).
+    /// Emitted only where text genuinely enters the worker conversation;
+    /// system injections, tool output, and context summaries are
+    /// deliberately absent. `text` is the RAW user text — attachment
+    /// preludes and `[Session resumed]`/`[New Task]`/`[User]` wrappers are
+    /// the conversation's concern, not the record's. `ref_seq` marks a
+    /// projection: the text entered the conversation inside another entry
+    /// (the native-tool askHuman answer rides a tool result) whose seq it
+    /// references for rewind-cut semantics.
+    pub fn conversation_message_user(
+        &mut self,
+        seq: u64,
+        provenance: crate::conversation::MessageProvenance,
+        text: &str,
+        ref_seq: Option<u64>,
+    ) -> String {
+        let message_id = Uuid::new_v4().to_string();
+        let mut data = serde_json::json!({
+            "message_id": message_id,
+            "message_seq": seq,
+            "role": "user",
+            "provenance": provenance,
+            "text": text,
+        });
+        if let Some(ref_seq) = ref_seq {
+            data["ref_seq"] = serde_json::Value::from(ref_seq);
+        }
+        let preview: String = text.chars().take(200).collect();
+        self.emit(LogEvent {
+            ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
+            turn: if self.current_turn > 0 {
+                Some(self.current_turn)
+            } else {
+                None
+            },
+            event: "conversation_message".to_string(),
+            level: Some("info".to_string()),
+            message: Some(preview),
+            data: Some(data),
+            file: None,
+            file2: None,
+        });
+        message_id
+    }
+
+    /// A rewind/tail-rollback cut: messages with `seq > cut_after_seq` are
+    /// superseded. Compaction (`drop_turns`/`summarize_turns`) deliberately
+    /// does NOT emit this — a compacted message was still said and remains
+    /// canonical history (message-search plan D2).
+    pub fn conversation_rewound(&mut self, cut_after_seq: u64, kind: &str) {
+        self.emit(LogEvent {
+            ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
+            turn: if self.current_turn > 0 {
+                Some(self.current_turn)
+            } else {
+                None
+            },
+            event: "conversation_rewound".to_string(),
+            level: Some("info".to_string()),
+            message: Some(format!(
+                "Conversation rewound ({}): messages after seq {} superseded",
+                kind, cut_after_seq
+            )),
+            data: Some(serde_json::json!({
+                "cut_after_seq": cut_after_seq,
+                "kind": kind,
+                "superseded_at_ms": Self::ts_ms(),
+            })),
+            file: None,
+            file2: None,
+        });
+    }
+
+    /// Mixed-version cutover marker: emitted when a resumed legacy
+    /// conversation gets seqs assigned (`ensure_seqs_assigned`). `mapping`
+    /// is `(seq, role, content-hash)` per message, in order — extractors use
+    /// legacy extraction strictly before this marker and only
+    /// `conversation_message` records after it, correlating legacy records
+    /// through the hashes.
+    pub fn conversation_message_epoch(&mut self, mapping: &[(u64, String, String)]) {
+        let rows: Vec<serde_json::Value> = mapping
+            .iter()
+            .map(|(seq, role, hash)| serde_json::json!([seq, role, hash]))
+            .collect();
+        self.emit(LogEvent {
+            ts: Self::ts(),
+            ts_ms: Self::ts_ms(),
+            turn: None,
+            event: "conversation_message_epoch".to_string(),
+            level: Some("info".to_string()),
+            message: Some(format!(
+                "Assigned seqs to {} legacy conversation messages",
+                mapping.len()
+            )),
+            data: Some(serde_json::json!({ "mapping": rows })),
+            file: None,
             file2: None,
         });
     }

--- a/src/bin/caller/session_log/mod.rs
+++ b/src/bin/caller/session_log/mod.rs
@@ -43,10 +43,23 @@ struct LogEvent {
 }
 
 #[derive(Debug, Clone)]
-struct TurnFileSpan {
+pub(crate) struct TurnFileSpan {
     relative: String,
     offset: u64,
     len: u64,
+}
+
+/// First 16 hex chars of the SHA-256 of `text` — the content fingerprint the
+/// `conversation_message_epoch` mapping carries so historical extractors can
+/// correlate legacy-extracted messages with resume-time seq assignments.
+pub(crate) fn content_hash_hex16(text: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(text.as_bytes());
+    let mut out = String::with_capacity(16);
+    for byte in digest.iter().take(8) {
+        out.push_str(&format!("{:02x}", byte));
+    }
+    out
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1719,5 +1732,84 @@ mod tests {
         let legacy = r#"{"session_id":"old","created_at":"2026-01-01T00:00:00"}"#;
         let meta: SessionMeta = serde_json::from_str(legacy).unwrap();
         assert_eq!(meta.created_at_ms, None);
+    }
+
+    #[test]
+    fn conversation_message_user_event_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut log = SessionLog::open(dir.path().to_path_buf()).unwrap();
+        let id = log.conversation_message_user(
+            7,
+            crate::conversation::MessageProvenance::AskHumanAnswer,
+            "the raw answer",
+            Some(6),
+        );
+        drop(log);
+        let event = read_last_event(dir.path(), "conversation_message");
+        assert_eq!(event["data"]["message_id"].as_str(), Some(id.as_str()));
+        assert_eq!(event["data"]["message_seq"].as_u64(), Some(7));
+        assert_eq!(event["data"]["role"].as_str(), Some("user"));
+        assert_eq!(
+            event["data"]["provenance"].as_str(),
+            Some("ask_human_answer")
+        );
+        assert_eq!(event["data"]["text"].as_str(), Some("the raw answer"));
+        assert_eq!(event["data"]["ref_seq"].as_u64(), Some(6));
+        assert!(event["ts_ms"].as_i64().is_some());
+    }
+
+    #[test]
+    fn model_response_with_message_shares_one_span() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut log = SessionLog::open(dir.path().to_path_buf()).unwrap();
+        log.model_response_with_message(3, "the full assistant text", 10, 5, 15, 0);
+        drop(log);
+
+        let diag = read_last_event(dir.path(), "model_response");
+        let canon = read_last_event(dir.path(), "conversation_message");
+        assert_eq!(canon["data"]["role"].as_str(), Some("assistant"));
+        assert_eq!(canon["data"]["provenance"].as_str(), Some("assistant"));
+        assert_eq!(canon["data"]["message_seq"].as_u64(), Some(3));
+        // Both events reference the SAME sidecar bytes — one write.
+        assert_eq!(canon["file"], diag["file"]);
+        assert_eq!(canon["data"]["model_offset"], diag["data"]["model_offset"]);
+        assert_eq!(canon["data"]["model_bytes"], diag["data"]["model_bytes"]);
+        // And the span resolves to the full text.
+        let relative = canon["file"].as_str().expect("sidecar file recorded");
+        let bytes = fs::read(dir.path().join(relative)).unwrap();
+        let offset = canon["data"]["model_offset"].as_u64().unwrap() as usize;
+        let len = canon["data"]["model_bytes"].as_u64().unwrap() as usize;
+        assert_eq!(&bytes[offset..offset + len], b"the full assistant text");
+    }
+
+    #[test]
+    fn conversation_rewound_and_epoch_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut log = SessionLog::open(dir.path().to_path_buf()).unwrap();
+        log.conversation_rewound(5, "tail_rollback");
+        log.conversation_message_epoch(&[
+            (1, "system".to_string(), "aaaa".to_string()),
+            (2, "user".to_string(), "bbbb".to_string()),
+        ]);
+        drop(log);
+
+        let rewound = read_last_event(dir.path(), "conversation_rewound");
+        assert_eq!(rewound["data"]["cut_after_seq"].as_u64(), Some(5));
+        assert_eq!(rewound["data"]["kind"].as_str(), Some("tail_rollback"));
+        assert!(rewound["data"]["superseded_at_ms"].as_i64().is_some());
+
+        let epoch = read_last_event(dir.path(), "conversation_message_epoch");
+        let mapping = epoch["data"]["mapping"].as_array().unwrap();
+        assert_eq!(mapping.len(), 2);
+        assert_eq!(mapping[1][0].as_u64(), Some(2));
+        assert_eq!(mapping[1][1].as_str(), Some("user"));
+        assert_eq!(mapping[1][2].as_str(), Some("bbbb"));
+    }
+
+    #[test]
+    fn content_hash_hex16_is_stable() {
+        assert_eq!(content_hash_hex16("hello"), content_hash_hex16("hello"));
+        assert_ne!(content_hash_hex16("hello"), content_hash_hex16("hello!"));
+        assert_eq!(content_hash_hex16("x").len(), 16);
     }
 }

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -2941,7 +2941,7 @@ pub(crate) fn persist_external_model_response_for_session_if_needed(
     }
     if !content.is_empty() {
         slog(config.session_log, |l| {
-            l.model_response_for_session(
+            let _ = l.model_response_for_session(
                 session_id,
                 content,
                 0,
@@ -2949,7 +2949,7 @@ pub(crate) fn persist_external_model_response_for_session_if_needed(
                 0,
                 0,
                 config.agent_source.as_deref(),
-            )
+            );
         });
     }
     if let Some(reasoning) = reasoning.filter(|text| !text.is_empty()) {


### PR DESCRIPTION
F1 of the message-search program, in two phases on this branch:

**F1a (this commit):** `Message` gains a serialized `MessageProvenance` and a monotonic per-conversation `seq`. The parked `MessageLayer` seed is untouched (provenance is an orthogonal axis — plan D1). Every conversation entry point now declares its provenance, replacing bracket-prefix string conventions: the injection drain splits steer-vs-system on `steer_id`, askHuman answers vs dismissals are distinguished, agent-stdout-as-user is typed `tool_output`, compaction summaries and synthetic tool-call repairs are typed. Seqs are never reused (truncation doesn't rewind the counter — loop turn numbers restart every round, so `turn` cannot anchor rewinds); `ensure_seqs_assigned()` is the resume-time renumber pass for legacy files.

**F1b (following commits):** append-only `conversation_message` / `conversation_rewound` / epoch-marker session-log events emitted from the classified entry points; combined assistant logging op (sidecar span + diagnostic + canonical record in one call); emission-site parity test.

Design note: the core crate owns `seq` (structural, deterministic); `message_id` minting stays caller-side with the session log — keeps `intendant-core` dependency-free (no uuid dep added).

Plan: `~/message-search-plan.md` v2.2 §3-4 (two review rounds, converged).