### PR TITLE
access: drop the four dead legacy web-TUI frame rows

### DIFF
--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -513,41 +513,12 @@ pub const FRAME_LANES: &[FrameLaneSpec] = &[
         tunnel: false,
         note: "ICE leg of display_offer",
     },
-    // ---- /ws only: legacy web-TUI lane (dead, preserved verbatim) ----
-    // The embedded web TUI's frame handlers were removed when the TUI was
-    // gutted (84afe9d8); nothing consumes these kinds on /ws anymore, and
-    // no tunnel twin ever existed. The gate rows survive verbatim because
-    // dropping a frame kind changes observable behavior for scoped
-    // clients (denial frame vs silence) — an owner decision, not
-    // refactor fallout.
-    FrameLaneSpec {
-        frame: "key",
-        op: Some(PeerOperation::RuntimeControl),
-        ws: true,
-        tunnel: false,
-        note: "legacy web-TUI keystroke into the daemon's own runtime (handlers gone; see above)",
-    },
-    FrameLaneSpec {
-        frame: "resize",
-        op: Some(PeerOperation::RuntimeControl),
-        ws: true,
-        tunnel: false,
-        note: "legacy web-TUI terminal resize (handlers gone; see above)",
-    },
-    FrameLaneSpec {
-        frame: "term_subscribe",
-        op: Some(PeerOperation::RuntimeControl),
-        ws: true,
-        tunnel: false,
-        note: "legacy web-TUI output subscription (handlers gone; see above)",
-    },
-    FrameLaneSpec {
-        frame: "term_unsubscribe",
-        op: Some(PeerOperation::RuntimeControl),
-        ws: true,
-        tunnel: false,
-        note: "legacy web-TUI output unsubscription (handlers gone; see above)",
-    },
+    // The legacy web-TUI lane (`key`, `resize`, `term_subscribe`,
+    // `term_unsubscribe`) lived here until the owner dropped it
+    // (2026-07-11). Its /ws handlers died when the TUI was gutted
+    // (84afe9d8) and no tunnel twin ever existed; the kinds now take the
+    // unknown-frame path — no denial frame, /ws silence. The golden
+    // mapping pins them at `None` so a merge can't resurrect the rows.
     // ---- /ws only: live voice/media presence machinery ----
     // The tunnel carries this family wrapped in a single presence_frame
     // envelope (its own row below); /ws speaks the kinds raw. Method-lane
@@ -1326,13 +1297,16 @@ mod tests {
             ("set_diagnostics_visual_marker",  Some(DisplayInput),   None),
             ("display_offer",                  Some(DisplayView),    None),
             ("display_ice",                    Some(DisplayView),    None),
-            // -- /ws only: legacy web-TUI lane (handlers gutted with the
-            //    TUI, 84afe9d8; the gate rows survive verbatim — dropping
-            //    the kinds is an owner decision, not refactor fallout) --
-            ("key",                            Some(RuntimeControl), None),
-            ("resize",                         Some(RuntimeControl), None),
-            ("term_subscribe",                 Some(RuntimeControl), None),
-            ("term_unsubscribe",               Some(RuntimeControl), None),
+            // -- dropped: the legacy web-TUI lane (owner decision,
+            //    2026-07-11). Handlers were gutted with the TUI
+            //    (84afe9d8); the gate rows are now gone too, so these
+            //    kinds answer like any unknown kind — no blanket
+            //    authority, no denial frame, /ws unknown-frame silence.
+            //    Pinned at `None` so a merge can't resurrect the rows. --
+            ("key",                            None,                 None),
+            ("resize",                         None,                 None),
+            ("term_subscribe",                 None,                 None),
+            ("term_unsubscribe",               None,                 None),
             // -- /ws only: live voice/media presence machinery --
             ("presence_connect",               Some(RuntimeControl), None),
             ("presence_disconnect",            Some(RuntimeControl), None),


### PR DESCRIPTION
## Owner decision

Drop (decided 2026-07-11): the four dead legacy web-TUI frame rows — `key`, `resize`, `term_subscribe`, `term_unsubscribe` — are removed from `FRAME_LANES` (`src/bin/caller/access/access_policy.rs`). Their /ws handlers were removed when the TUI was gutted (84afe9d8); no tunnel twin ever existed. The rows had been preserved verbatim precisely because dropping them is an IAM-observable change requiring an owner call, not refactor fallout.

## Observable behavior change

A scoped client sending these frame kinds now gets the /ws unknown-frame handling instead of an explicit denial: `ws_frame_operation` answers `None`, so `deny_ws_frame_if_unauthorized` passes the frame through; it matches no dispatch arm, fails the ControlMsg parse (tag `action` absent), and dies in the `Err` arm of `ws_session.rs` with a warn-level presence log — nothing is sent back on the wire. Previously an insufficient grant got an explicit `ws_denied` frame.

## Row counts

- `FRAME_LANES`: 41 → 37 rows.
- Golden mapping (`realtime_frame_operation_golden_mapping_is_frozen`): stays 48 entries — the four kinds are re-pinned at `None` on both lanes with the owner decision recorded, so a botched merge can't silently resurrect the rows.

## Sender audit

Repo-wide sweep (src, crates, static/app, static/wasm glue, docs, scripts, macos-app): nothing sends these kinds. `presence-web` still carries uncalled `send_key`/`send_resize` wasm exports (dead API surface from the same era, zero callers); left untouched here to avoid churning the committed wasm artifacts — follow-up candidate. Docs never documented the frame vocabulary, so no doc edits.

Both per-frame gates (`web_gateway/access_gates.rs`, `dashboard_control/mod.rs`) are table-driven lookups — no per-kind references existed outside the table and its golden.