### PR TITLE
credential_leases: stage leased-home transcripts before deletion (message-search F6)

### DIFF
--- a/docs/src/credential-custody.md
+++ b/docs/src/credential-custody.md
@@ -310,6 +310,20 @@ Mitigations: the materialization root is outside worktrees and is never
 seen by rewind/snapshot machinery, the file exists only while leased,
 and crash recovery deletes stale materializations at startup.
 
+**Transcript staging at cleanup.** The materialized home also holds the
+agent's session transcripts (Codex `sessions/`, Claude `projects/`), and
+deleting the home would erase them from message search. Cleanup therefore
+first *renames* those transcript subdirectories into a credential-free
+staging area under `~/.intendant/cache/message_search/staging/`
+(same-volume rename — effectively instant), then deletes the home
+immediately (`lease_transcript_staging.rs`). Staging is strictly
+best-effort and never delays secret deletion: on any failure a marker
+records the coverage gap and the deletion proceeds. The startup crash
+sweep stages the same way before removing leftovers, staged entries not
+drained within the search retention window are GC'd at startup, and an
+`active/` registry (one file per materialized home) tells the
+message-search indexer which leased homes are live right now.
+
 **Fallback.** `.env` keeps working untouched (`custody = "local"`, the
 implicit default), so nothing breaks for existing daemons and CI. A
 daemon with no local keys and no lease reports "unfueled" in the

--- a/src/bin/caller/credential_leases.rs
+++ b/src/bin/caller/credential_leases.rs
@@ -237,7 +237,10 @@ recovery sweep covering crashes where neither ran. Non-secret
 configuration (config.toml / settings.json) is copied in so behavior
 is preserved; the user's own auth files never are. The directory
 lives under ~/.intendant, outside any project worktree, so the
-rewind/snapshot machinery never sees it. */
+rewind/snapshot machinery never sees it. Deletion stages the home's
+transcript subdirectories out first (rename-only, best-effort — see
+`lease_transcript_staging`) so leased sessions stay searchable after
+the secret dies; staging failure never delays the deletion. */
 
 fn materialization_root() -> PathBuf {
     crate::platform::intendant_home().join("leased-auth")
@@ -287,6 +290,13 @@ struct MaterializationPlan {
     /// Non-secret config carried over from the agent's real home
     /// (source home, file name) so behavior is preserved.
     carry_over: Option<(PathBuf, &'static str)>,
+    /// Message-search source label for staged transcripts.
+    source: &'static str,
+    /// Transcript subdirectories the agent writes under this home —
+    /// staged out (renamed) before the home is deleted, so leased
+    /// sessions stay searchable after the secret dies
+    /// (`lease_transcript_staging`).
+    transcript_dirs: &'static [&'static str],
 }
 
 fn materialization_plan(kind: &str) -> Option<MaterializationPlan> {
@@ -296,14 +306,36 @@ fn materialization_plan(kind: &str) -> Option<MaterializationPlan> {
             auth_name: "auth.json",
             carry_over: crate::session_config::effective_codex_home()
                 .map(|home| (PathBuf::from(home), "config.toml")),
+            source: "codex",
+            transcript_dirs: &["sessions", "archived_sessions"],
         }),
         "oauth:claude-code" => Some(MaterializationPlan {
             dir_name: "claude-home",
             auth_name: ".credentials.json",
             carry_over: Some((crate::platform::home_dir().join(".claude"), "settings.json")),
+            source: "claude-code",
+            transcript_dirs: &["projects"],
         }),
         _ => None,
     }
+}
+
+/// Stage a materialized home's transcripts and drop its active-registry
+/// entry — the mandatory prelude to deleting the home. Best-effort by
+/// design: staging failure never blocks the deletion that follows
+/// (custody outranks search completeness).
+fn stage_before_removal(plan: &MaterializationPlan, home: &Path) {
+    let paths = crate::lease_transcript_staging::default_paths();
+    if home.is_dir() {
+        crate::lease_transcript_staging::stage_transcripts(
+            home,
+            plan.dir_name,
+            plan.source,
+            plan.transcript_dirs,
+            &paths.staging,
+        );
+    }
+    crate::lease_transcript_staging::clear_active(&paths.active, plan.dir_name);
 }
 
 fn materialize_kind(root: &Path, kind: &str, material: &str) -> Result<(), String> {
@@ -318,6 +350,10 @@ fn materialize_kind(root: &Path, kind: &str, material: &str) -> Result<(), Strin
     std::fs::write(&auth_path, material.as_bytes())
         .map_err(|e| format!("write {}: {e}", auth_path.display()))?;
     if let Err(err) = restrict_file(&auth_path) {
+        // A re-grant materializes over the existing home, which may already
+        // hold transcripts — stage them before the failure cleanup deletes
+        // the directory.
+        stage_before_removal(&plan, &dir);
         if let Err(cleanup_err) = std::fs::remove_dir_all(&dir) {
             eprintln!(
                 "[credential-leases] cleanup after failed materialization of {} failed: {}",
@@ -340,6 +376,7 @@ fn materialize_kind(root: &Path, kind: &str, material: &str) -> Result<(), Strin
 fn drop_materialization(root: &Path, kind: &str) -> Result<(), String> {
     if let Some(plan) = materialization_plan(kind) {
         let path = root.join(plan.dir_name);
+        stage_before_removal(&plan, &path);
         match std::fs::remove_dir_all(&path) {
             Ok(()) => {}
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
@@ -432,6 +469,14 @@ pub fn sweep_now() {
 pub fn startup_materialization_sweep() {
     let root = materialization_root();
     if root.exists() {
+        // Crash leftovers can hold transcripts from the previous process's
+        // leased sessions — stage them before the sweep deletes the root
+        // (works with no indexer running; the drainer picks them up later).
+        for kind in ["oauth:codex", "oauth:claude-code"] {
+            if let Some(plan) = materialization_plan(kind) {
+                stage_before_removal(&plan, &root.join(plan.dir_name));
+            }
+        }
         if let Err(err) = std::fs::remove_dir_all(&root) {
             eprintln!(
                 "[credential-leases] startup sweep of {} failed: {err}",
@@ -442,6 +487,12 @@ pub fn startup_materialization_sweep() {
             }
         }
     }
+    // Staged transcripts nobody drained within the retention window die
+    // here rather than accumulating forever.
+    crate::lease_transcript_staging::gc_staging(
+        &crate::lease_transcript_staging::default_paths().staging,
+        now_unix_ms() as i64,
+    );
     // A restart is a custody epoch: whatever the trail shows as live
     // before this point died with the old process.
     crate::credential_audit::record_reset();
@@ -563,6 +614,17 @@ pub fn grant(
         return Err(format!("credential materialization failed: {error}"));
     }
     clear_materialization_cleanup(kind);
+    // Register the live home so the message-search indexer can watch it
+    // during the lease (not only recover it at cleanup).
+    if let Some(plan) = materialization_plan(kind) {
+        let paths = crate::lease_transcript_staging::default_paths();
+        crate::lease_transcript_staging::record_active(
+            &paths.active,
+            plan.dir_name,
+            plan.source,
+            &materialization_root().join(plan.dir_name),
+        );
+    }
     let replaced = leases.insert(kind.to_string(), lease).is_some();
     tombstones()
         .write()
@@ -776,6 +838,39 @@ mod tests {
         store().write().unwrap().clear();
         tombstones().write().unwrap().clear();
         pending_materialization_cleanup().write().unwrap().clear();
+    }
+
+    #[test]
+    fn drop_materialization_stages_transcripts_before_deleting() {
+        let _guard = lock();
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("codex-home");
+        let sessions = home.join("sessions");
+        std::fs::create_dir_all(&sessions).unwrap();
+        std::fs::write(home.join("auth.json"), "SECRET").unwrap();
+        let marker = format!("staged-probe-{}.jsonl", uuid::Uuid::new_v4());
+        std::fs::write(sessions.join(&marker), "{}\n").unwrap();
+
+        drop_materialization(tmp.path(), "oauth:codex").unwrap();
+
+        // The home (and the secret) are gone…
+        assert!(!home.exists(), "materialized home deleted");
+        // …and the transcript survived into staging (test-scoped
+        // intendant_home, so this walk is hermetic).
+        let staging = crate::lease_transcript_staging::default_paths().staging;
+        let mut found = false;
+        if let Ok(entries) = std::fs::read_dir(&staging) {
+            for entry in entries.flatten() {
+                let candidate = entry.path().join("sessions").join(&marker);
+                if candidate.exists() {
+                    let raw = std::fs::read_to_string(entry.path().join("manifest.json")).unwrap();
+                    assert!(raw.contains("\"codex\""));
+                    assert!(!entry.path().join("auth.json").exists());
+                    found = true;
+                }
+            }
+        }
+        assert!(found, "staged transcript not found under {staging:?}");
     }
 
     #[test]

--- a/src/bin/caller/credential_leases.rs
+++ b/src/bin/caller/credential_leases.rs
@@ -126,12 +126,13 @@ fn env_kind(env_name: &str) -> Option<&'static str> {
 }
 
 fn sweep_locked(leases: &mut HashMap<String, CredentialLease>, now: u64) {
+    let staging = crate::lease_transcript_staging::default_paths();
     let active_oauth: HashSet<String> = leases
         .iter()
         .filter(|(_, lease)| lease.expires_at_unix_ms() > now)
         .map(|(kind, _)| kind.clone())
         .collect();
-    retry_pending_materialization_cleanup(&materialization_root(), &active_oauth);
+    retry_pending_materialization_cleanup(&materialization_root(), &staging, &active_oauth);
 
     let expired: Vec<String> = leases
         .iter()
@@ -159,7 +160,7 @@ fn sweep_locked(leases: &mut HashMap<String, CredentialLease>, now: u64) {
                 ),
             );
         }
-        if let Err(err) = drop_materialization(&materialization_root(), &kind) {
+        if let Err(err) = drop_materialization(&materialization_root(), &staging, &kind) {
             eprintln!("[credential-leases] expired lease cleanup for {kind} failed: {err}");
             queue_materialization_cleanup(&kind);
         }
@@ -323,9 +324,15 @@ fn materialization_plan(kind: &str) -> Option<MaterializationPlan> {
 /// Stage a materialized home's transcripts and drop its active-registry
 /// entry — the mandatory prelude to deleting the home. Best-effort by
 /// design: staging failure never blocks the deletion that follows
-/// (custody outranks search completeness).
-fn stage_before_removal(plan: &MaterializationPlan, home: &Path) {
-    let paths = crate::lease_transcript_staging::default_paths();
+/// (custody outranks search completeness). `paths` is injected all the
+/// way down (tests pass tempdirs; production edges resolve
+/// `default_paths()`) — resolving globals here made the test
+/// environment-dependent, which CI's threaded `cargo test` punished.
+fn stage_before_removal(
+    plan: &MaterializationPlan,
+    home: &Path,
+    paths: &crate::lease_transcript_staging::StagingPaths,
+) {
     if home.is_dir() {
         crate::lease_transcript_staging::stage_transcripts(
             home,
@@ -338,7 +345,12 @@ fn stage_before_removal(plan: &MaterializationPlan, home: &Path) {
     crate::lease_transcript_staging::clear_active(&paths.active, plan.dir_name);
 }
 
-fn materialize_kind(root: &Path, kind: &str, material: &str) -> Result<(), String> {
+fn materialize_kind(
+    root: &Path,
+    staging: &crate::lease_transcript_staging::StagingPaths,
+    kind: &str,
+    material: &str,
+) -> Result<(), String> {
     let Some(plan) = materialization_plan(kind) else {
         return Ok(());
     };
@@ -353,7 +365,7 @@ fn materialize_kind(root: &Path, kind: &str, material: &str) -> Result<(), Strin
         // A re-grant materializes over the existing home, which may already
         // hold transcripts — stage them before the failure cleanup deletes
         // the directory.
-        stage_before_removal(&plan, &dir);
+        stage_before_removal(&plan, &dir, staging);
         if let Err(cleanup_err) = std::fs::remove_dir_all(&dir) {
             eprintln!(
                 "[credential-leases] cleanup after failed materialization of {} failed: {}",
@@ -373,10 +385,14 @@ fn materialize_kind(root: &Path, kind: &str, material: &str) -> Result<(), Strin
     Ok(())
 }
 
-fn drop_materialization(root: &Path, kind: &str) -> Result<(), String> {
+fn drop_materialization(
+    root: &Path,
+    staging: &crate::lease_transcript_staging::StagingPaths,
+    kind: &str,
+) -> Result<(), String> {
     if let Some(plan) = materialization_plan(kind) {
         let path = root.join(plan.dir_name);
-        stage_before_removal(&plan, &path);
+        stage_before_removal(&plan, &path, staging);
         match std::fs::remove_dir_all(&path) {
             Ok(()) => {}
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
@@ -402,7 +418,11 @@ fn clear_materialization_cleanup(kind: &str) {
         .remove(kind);
 }
 
-fn retry_pending_materialization_cleanup(root: &Path, active_kinds: &HashSet<String>) {
+fn retry_pending_materialization_cleanup(
+    root: &Path,
+    staging: &crate::lease_transcript_staging::StagingPaths,
+    active_kinds: &HashSet<String>,
+) {
     let pending: Vec<String> = pending_materialization_cleanup()
         .read()
         .expect("pending materialization cleanup poisoned")
@@ -413,7 +433,7 @@ fn retry_pending_materialization_cleanup(root: &Path, active_kinds: &HashSet<Str
         if active_kinds.contains(&kind) {
             continue;
         }
-        match drop_materialization(root, &kind) {
+        match drop_materialization(root, staging, &kind) {
             Ok(()) => {
                 clear_materialization_cleanup(&kind);
             }
@@ -468,13 +488,14 @@ pub fn sweep_now() {
 /// may either. Call once at daemon startup.
 pub fn startup_materialization_sweep() {
     let root = materialization_root();
+    let staging = crate::lease_transcript_staging::default_paths();
     if root.exists() {
         // Crash leftovers can hold transcripts from the previous process's
         // leased sessions — stage them before the sweep deletes the root
         // (works with no indexer running; the drainer picks them up later).
         for kind in ["oauth:codex", "oauth:claude-code"] {
             if let Some(plan) = materialization_plan(kind) {
-                stage_before_removal(&plan, &root.join(plan.dir_name));
+                stage_before_removal(&plan, &root.join(plan.dir_name), &staging);
             }
         }
         if let Err(err) = std::fs::remove_dir_all(&root) {
@@ -489,10 +510,7 @@ pub fn startup_materialization_sweep() {
     }
     // Staged transcripts nobody drained within the retention window die
     // here rather than accumulating forever.
-    crate::lease_transcript_staging::gc_staging(
-        &crate::lease_transcript_staging::default_paths().staging,
-        now_unix_ms() as i64,
-    );
+    crate::lease_transcript_staging::gc_staging(&staging.staging, now_unix_ms() as i64);
     // A restart is a custody epoch: whatever the trail shows as live
     // before this point died with the old process.
     crate::credential_audit::record_reset();
@@ -610,16 +628,16 @@ pub fn grant(
     sweep_locked(&mut leases, now);
     // An oauth lease without its materialized auth file is useless to the
     // child process — refuse the grant rather than hold a dead lease.
-    if let Err(error) = materialize_kind(&materialization_root(), kind, material) {
+    let staging = crate::lease_transcript_staging::default_paths();
+    if let Err(error) = materialize_kind(&materialization_root(), &staging, kind, material) {
         return Err(format!("credential materialization failed: {error}"));
     }
     clear_materialization_cleanup(kind);
     // Register the live home so the message-search indexer can watch it
     // during the lease (not only recover it at cleanup).
     if let Some(plan) = materialization_plan(kind) {
-        let paths = crate::lease_transcript_staging::default_paths();
         crate::lease_transcript_staging::record_active(
-            &paths.active,
+            &staging.active,
             plan.dir_name,
             plan.source,
             &materialization_root().join(plan.dir_name),
@@ -719,8 +737,9 @@ pub fn revoke(selector: Option<&str>, actor: &str, via: &str) -> usize {
             });
         }
     }
+    let staging = crate::lease_transcript_staging::default_paths();
     for (kind, label) in dropped {
-        if let Err(err) = drop_materialization(&materialization_root(), &kind) {
+        if let Err(err) = drop_materialization(&materialization_root(), &staging, &kind) {
             eprintln!("[credential-leases] revoked lease cleanup for {kind} failed: {err}");
             queue_materialization_cleanup(&kind);
         }
@@ -842,35 +861,40 @@ mod tests {
 
     #[test]
     fn drop_materialization_stages_transcripts_before_deleting() {
-        let _guard = lock();
+        // Fully injected roots: no env, no globals — the first version of
+        // this test reached the LIVE intendant home through default_paths()
+        // (intendant-core's cfg(test) scratch does not cross the crate
+        // boundary) and flaked under CI's threaded `cargo test`.
         let tmp = tempfile::tempdir().unwrap();
         let home = tmp.path().join("codex-home");
         let sessions = home.join("sessions");
         std::fs::create_dir_all(&sessions).unwrap();
         std::fs::write(home.join("auth.json"), "SECRET").unwrap();
-        let marker = format!("staged-probe-{}.jsonl", uuid::Uuid::new_v4());
-        std::fs::write(sessions.join(&marker), "{}\n").unwrap();
+        std::fs::write(sessions.join("rollout-probe.jsonl"), "{}\n").unwrap();
+        let staging = crate::lease_transcript_staging::StagingPaths {
+            staging: tmp.path().join("staging"),
+            active: tmp.path().join("active"),
+        };
+        std::fs::create_dir_all(&staging.active).unwrap();
+        std::fs::write(staging.active.join("codex-home.json"), "{}").unwrap();
 
-        drop_materialization(tmp.path(), "oauth:codex").unwrap();
+        drop_materialization(tmp.path(), &staging, "oauth:codex").unwrap();
 
         // The home (and the secret) are gone…
         assert!(!home.exists(), "materialized home deleted");
-        // …and the transcript survived into staging (test-scoped
-        // intendant_home, so this walk is hermetic).
-        let staging = crate::lease_transcript_staging::default_paths().staging;
-        let mut found = false;
-        if let Ok(entries) = std::fs::read_dir(&staging) {
-            for entry in entries.flatten() {
-                let candidate = entry.path().join("sessions").join(&marker);
-                if candidate.exists() {
-                    let raw = std::fs::read_to_string(entry.path().join("manifest.json")).unwrap();
-                    assert!(raw.contains("\"codex\""));
-                    assert!(!entry.path().join("auth.json").exists());
-                    found = true;
-                }
-            }
-        }
-        assert!(found, "staged transcript not found under {staging:?}");
+        // …the active-registry entry was cleared…
+        assert!(!staging.active.join("codex-home.json").exists());
+        // …and the transcript survived into staging.
+        let entries: Vec<_> = std::fs::read_dir(&staging.staging)
+            .expect("staging dir created")
+            .flatten()
+            .collect();
+        assert_eq!(entries.len(), 1);
+        let entry = entries[0].path();
+        assert!(entry.join("sessions/rollout-probe.jsonl").exists());
+        assert!(!entry.join("auth.json").exists(), "secret never staged");
+        let raw = std::fs::read_to_string(entry.join("manifest.json")).unwrap();
+        assert!(raw.contains("\"codex\""));
     }
 
     #[test]
@@ -1000,7 +1024,11 @@ mod tests {
     #[test]
     fn oauth_materialization_writes_restricted_auth_and_cleans_up() {
         let root = tempfile::TempDir::new().unwrap();
-        materialize_kind(root.path(), "oauth:codex", r#"{"tokens":{}}"#).unwrap();
+        let staging = crate::lease_transcript_staging::StagingPaths {
+            staging: root.path().join("test-staging"),
+            active: root.path().join("test-active"),
+        };
+        materialize_kind(root.path(), &staging, "oauth:codex", r#"{"tokens":{}}"#).unwrap();
         let auth = root.path().join("codex-home").join("auth.json");
         assert!(auth.is_file());
         assert_eq!(std::fs::read_to_string(&auth).unwrap(), r#"{"tokens":{}}"#);
@@ -1017,25 +1045,35 @@ mod tests {
             assert_eq!(dir_mode, 0o700, "materialization dir must be private");
         }
 
-        materialize_kind(root.path(), "oauth:claude-code", r#"{"claudeAiOauth":{}}"#).unwrap();
+        materialize_kind(
+            root.path(),
+            &staging,
+            "oauth:claude-code",
+            r#"{"claudeAiOauth":{}}"#,
+        )
+        .unwrap();
         let creds = root.path().join("claude-home").join(".credentials.json");
         assert!(creds.is_file());
 
         // API-key kinds are memory-only — nothing materializes.
-        materialize_kind(root.path(), "api_key:anthropic", "sk-ant").unwrap();
-        let dirs: Vec<_> = std::fs::read_dir(root.path()).unwrap().collect();
+        materialize_kind(root.path(), &staging, "api_key:anthropic", "sk-ant").unwrap();
+        let dirs: Vec<_> = std::fs::read_dir(root.path())
+            .unwrap()
+            .flatten()
+            .filter(|entry| !entry.file_name().to_string_lossy().starts_with("test-"))
+            .collect();
         assert_eq!(dirs.len(), 2, "only the two oauth kinds may materialize");
 
-        drop_materialization(root.path(), "oauth:codex").unwrap();
+        drop_materialization(root.path(), &staging, "oauth:codex").unwrap();
         assert!(!root.path().join("codex-home").exists());
         assert!(
             creds.is_file(),
             "dropping one kind must not touch the other"
         );
-        drop_materialization(root.path(), "oauth:claude-code").unwrap();
+        drop_materialization(root.path(), &staging, "oauth:claude-code").unwrap();
         assert!(!root.path().join("claude-home").exists());
         // Dropping an already-gone kind is a quiet no-op.
-        drop_materialization(root.path(), "oauth:claude-code").unwrap();
+        drop_materialization(root.path(), &staging, "oauth:claude-code").unwrap();
     }
 
     #[test]

--- a/src/bin/caller/lease_transcript_staging.rs
+++ b/src/bin/caller/lease_transcript_staging.rs
@@ -15,11 +15,12 @@
 //! a large sessions directory could delay secret deletion, and rename
 //! either succeeds instantly or we accept the coverage gap.
 //!
-//! Every function takes its roots as parameters (tests inject tempdirs);
-//! [`default_paths`] is the transport edge that resolves the real
-//! locations. An `active/` registry (one file per materialized home) tells
-//! the future indexer which leased roots exist RIGHT NOW, so live sessions
-//! are indexed during the lease rather than only at cleanup.
+//! Every function takes its roots as parameters (tests inject tempdirs,
+//! all the way through `credential_leases`' deletion paths);
+//! [`default_paths`] is the production transport edge that resolves the
+//! real locations. An `active/` registry (one file per materialized home)
+//! tells the future indexer which leased roots exist RIGHT NOW, so live
+//! sessions are indexed during the lease rather than only at cleanup.
 
 use std::path::{Path, PathBuf};
 
@@ -35,9 +36,12 @@ pub(crate) struct StagingPaths {
     pub active: PathBuf,
 }
 
-/// The real on-disk locations. `intendant_home()` is test-aware (process
-/// scratch under `cargo test`), so this edge is safe to reach from tests
-/// that exercise the lease flows end to end.
+/// The real on-disk locations — the PRODUCTION transport edge only.
+/// `intendant_home()`'s test scratch is a `#[cfg(test)]` branch inside
+/// intendant-core, which does NOT apply when the caller's test binary
+/// links it as a dependency — a test reaching this function writes to
+/// the live home (and under CI's threaded `cargo test`, races other
+/// tests' env mutations). Tests inject their own `StagingPaths`.
 pub(crate) fn default_paths() -> StagingPaths {
     let base = crate::platform::intendant_home()
         .join("cache")

--- a/src/bin/caller/lease_transcript_staging.rs
+++ b/src/bin/caller/lease_transcript_staging.rs
@@ -1,0 +1,387 @@
+//! Transcript staging for leased OAuth homes — F6 of the message-search
+//! program (see `docs/src/credential-custody.md` and
+//! `docs/src/session-logging.md`).
+//!
+//! A materialized home (the synthesized `CODEX_HOME` / `CLAUDE_CONFIG_DIR`
+//! under `~/.intendant/leased-auth`) holds the borrowed secret AND the
+//! agent's transcripts. Custody demands the secret die on time — cleanup
+//! must never wait on indexing — so cleanup RENAMES the transcript
+//! subdirectories into a credential-free staging area first (same volume,
+//! effectively O(1)) and then deletes the home immediately. The
+//! message-search indexer drains staging asynchronously whenever it runs.
+//! Staging is strictly best-effort: any failure is recorded as a marker
+//! (the index reports `partial(lease_cleanup)` coverage) and deletion
+//! proceeds regardless. There is deliberately NO copy fallback — a copy of
+//! a large sessions directory could delay secret deletion, and rename
+//! either succeeds instantly or we accept the coverage gap.
+//!
+//! Every function takes its roots as parameters (tests inject tempdirs);
+//! [`default_paths`] is the transport edge that resolves the real
+//! locations. An `active/` registry (one file per materialized home) tells
+//! the future indexer which leased roots exist RIGHT NOW, so live sessions
+//! are indexed during the lease rather than only at cleanup.
+
+use std::path::{Path, PathBuf};
+
+/// Staged entries not drained within this window are GC'd — mirrors the
+/// message-search retention window (plan §6); the B-wave shard store owns
+/// the canonical constant once it exists.
+const STAGED_RETENTION_MS: i64 = 14 * 24 * 60 * 60 * 1000;
+
+pub(crate) struct StagingPaths {
+    /// Staged transcript entries: `<staging>/<home-dir-name>-<ms>-<pid>/`.
+    pub staging: PathBuf,
+    /// Active-home registry: `<active>/<home-dir-name>.json`.
+    pub active: PathBuf,
+}
+
+/// The real on-disk locations. `intendant_home()` is test-aware (process
+/// scratch under `cargo test`), so this edge is safe to reach from tests
+/// that exercise the lease flows end to end.
+pub(crate) fn default_paths() -> StagingPaths {
+    let base = crate::platform::intendant_home()
+        .join("cache")
+        .join("message_search");
+    StagingPaths {
+        staging: base.join("staging"),
+        active: base.join("leased-active"),
+    }
+}
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn dir_has_entries(path: &Path) -> bool {
+    std::fs::read_dir(path)
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or(false)
+}
+
+fn restrict_private_dir(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(metadata) = std::fs::metadata(path) {
+            let mut perms = metadata.permissions();
+            perms.set_mode(0o700);
+            let _ = std::fs::set_permissions(path, perms);
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
+fn write_failure_marker(staging_root: &Path, dir_name: &str, reason: &str) {
+    let _ = std::fs::create_dir_all(staging_root);
+    restrict_private_dir(staging_root);
+    let marker = staging_root.join(format!(
+        "failed-{}-{}-{}.json",
+        dir_name,
+        now_ms(),
+        std::process::id()
+    ));
+    let body = serde_json::json!({
+        "schema": 1,
+        "dir_name": dir_name,
+        "failed_at_ms": now_ms(),
+        "reason": reason,
+    });
+    let _ = std::fs::write(
+        &marker,
+        serde_json::to_string_pretty(&body).unwrap_or_default(),
+    );
+}
+
+/// Rename `home`'s transcript subdirectories into a fresh staged entry.
+/// Best-effort and bounded: rename-or-skip, never copy, never block the
+/// caller's deletion. Returns `true` when an entry with at least one
+/// staged directory was created.
+pub(crate) fn stage_transcripts(
+    home: &Path,
+    dir_name: &str,
+    source: &str,
+    transcript_dirs: &[&str],
+    staging_root: &Path,
+) -> bool {
+    let present: Vec<&str> = transcript_dirs
+        .iter()
+        .copied()
+        .filter(|name| dir_has_entries(&home.join(name)))
+        .collect();
+    if present.is_empty() {
+        return false;
+    }
+    let entry = staging_root.join(format!("{}-{}-{}", dir_name, now_ms(), std::process::id()));
+    if let Err(err) = std::fs::create_dir_all(&entry) {
+        eprintln!(
+            "[lease-staging] create {} failed ({err}); transcripts in {} will be lost with the lease",
+            entry.display(),
+            home.display()
+        );
+        write_failure_marker(staging_root, dir_name, &format!("create entry: {err}"));
+        return false;
+    }
+    restrict_private_dir(staging_root);
+    restrict_private_dir(&entry);
+
+    let mut staged: Vec<String> = Vec::new();
+    for name in present {
+        let from = home.join(name);
+        let to = entry.join(name);
+        match std::fs::rename(&from, &to) {
+            Ok(()) => staged.push(name.to_string()),
+            Err(err) => {
+                // Cross-device or permission failure: log, mark, move on —
+                // the secret's deletion must not wait on us.
+                eprintln!(
+                    "[lease-staging] rename {} -> {} failed: {err}",
+                    from.display(),
+                    to.display()
+                );
+                write_failure_marker(staging_root, dir_name, &format!("rename {name}: {err}"));
+            }
+        }
+    }
+    if staged.is_empty() {
+        let _ = std::fs::remove_dir_all(&entry);
+        return false;
+    }
+    let manifest = serde_json::json!({
+        "schema": 1,
+        "dir_name": dir_name,
+        "source": source,
+        "original_home": home.to_string_lossy(),
+        "staged_at_ms": now_ms(),
+        "dirs": staged,
+    });
+    if let Err(err) = std::fs::write(
+        entry.join("manifest.json"),
+        serde_json::to_string_pretty(&manifest).unwrap_or_default(),
+    ) {
+        // The renamed data is still there; the drainer treats a
+        // manifest-less entry as best-effort (dir mtime dates it).
+        eprintln!(
+            "[lease-staging] manifest for {} failed: {err}",
+            entry.display()
+        );
+    }
+    true
+}
+
+/// Record a live materialized home so the indexer can watch it during the
+/// lease. One file per home dir name — leases are keyed by kind, so this
+/// is naturally unique, and concurrent daemons already share the single
+/// materialization path per kind.
+pub(crate) fn record_active(active_root: &Path, dir_name: &str, source: &str, home: &Path) {
+    if let Err(err) = std::fs::create_dir_all(active_root) {
+        eprintln!(
+            "[lease-staging] create {} failed: {err}",
+            active_root.display()
+        );
+        return;
+    }
+    restrict_private_dir(active_root);
+    let body = serde_json::json!({
+        "schema": 1,
+        "dir_name": dir_name,
+        "source": source,
+        "home": home.to_string_lossy(),
+        "materialized_at_ms": now_ms(),
+    });
+    let path = active_root.join(format!("{dir_name}.json"));
+    let tmp = active_root.join(format!("{dir_name}.json.tmp-{}", std::process::id()));
+    let payload = serde_json::to_string_pretty(&body).unwrap_or_default();
+    if std::fs::write(&tmp, payload).is_ok() {
+        let _ = std::fs::rename(&tmp, &path);
+    }
+}
+
+/// Drop the active-registry entry for a home (cleanup ran).
+pub(crate) fn clear_active(active_root: &Path, dir_name: &str) {
+    let path = active_root.join(format!("{dir_name}.json"));
+    match std::fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => eprintln!("[lease-staging] clear {} failed: {err}", path.display()),
+    }
+}
+
+/// Delete staged entries (and failure markers) older than the retention
+/// window. Runs at daemon startup — staged data must not accumulate
+/// unboundedly when no indexer drains it.
+pub(crate) fn gc_staging(staging_root: &Path, now_ms: i64) {
+    let Ok(entries) = std::fs::read_dir(staging_root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let staged_at = staged_at_ms(&path).unwrap_or(0);
+        // Undated entries fall back to filesystem mtime; if even that is
+        // unreadable they are treated as expired rather than immortal.
+        let effective = if staged_at > 0 {
+            staged_at
+        } else {
+            entry
+                .metadata()
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0)
+        };
+        if now_ms.saturating_sub(effective) > STAGED_RETENTION_MS {
+            let result = if path.is_dir() {
+                std::fs::remove_dir_all(&path)
+            } else {
+                std::fs::remove_file(&path)
+            };
+            if let Err(err) = result {
+                eprintln!("[lease-staging] gc {} failed: {err}", path.display());
+            }
+        }
+    }
+}
+
+fn staged_at_ms(entry: &Path) -> Option<i64> {
+    let raw = std::fs::read_to_string(entry.join("manifest.json")).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    value.get("staged_at_ms")?.as_i64()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_home(root: &Path, with_sessions: bool) -> PathBuf {
+        let home = root.join("codex-home");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::write(home.join("auth.json"), "SECRET").unwrap();
+        std::fs::write(home.join("config.toml"), "model = \"gpt\"").unwrap();
+        if with_sessions {
+            let sessions = home.join("sessions").join("2026").join("07");
+            std::fs::create_dir_all(&sessions).unwrap();
+            std::fs::write(sessions.join("rollout-1.jsonl"), "{\"type\":\"x\"}\n").unwrap();
+        }
+        home
+    }
+
+    #[test]
+    fn stages_transcripts_and_never_the_secret() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = fake_home(tmp.path(), true);
+        let staging = tmp.path().join("staging");
+
+        let staged = stage_transcripts(
+            &home,
+            "codex-home",
+            "codex",
+            &["sessions", "archived_sessions"],
+            &staging,
+        );
+        assert!(staged);
+
+        // The transcript moved out; the secret and config stayed behind
+        // for the caller's remove_dir_all.
+        assert!(!home.join("sessions").exists());
+        assert!(home.join("auth.json").exists());
+
+        let entries: Vec<_> = std::fs::read_dir(&staging).unwrap().flatten().collect();
+        assert_eq!(entries.len(), 1);
+        let entry = entries[0].path();
+        assert!(entry.join("sessions/2026/07/rollout-1.jsonl").exists());
+        assert!(!entry.join("auth.json").exists());
+        let manifest: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(entry.join("manifest.json")).unwrap())
+                .unwrap();
+        assert_eq!(manifest["source"].as_str(), Some("codex"));
+        assert_eq!(manifest["dirs"][0].as_str(), Some("sessions"));
+        assert!(manifest["staged_at_ms"].as_i64().unwrap() > 0);
+    }
+
+    #[test]
+    fn empty_or_missing_transcript_dirs_stage_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = fake_home(tmp.path(), false);
+        std::fs::create_dir_all(home.join("sessions")).unwrap(); // exists but empty
+        let staging = tmp.path().join("staging");
+        assert!(!stage_transcripts(
+            &home,
+            "codex-home",
+            "codex",
+            &["sessions", "archived_sessions"],
+            &staging,
+        ));
+        assert!(!staging.exists() || std::fs::read_dir(&staging).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn staging_failure_leaves_marker_and_returns_false() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = fake_home(tmp.path(), true);
+        // A FILE where the staging root should be: entry creation fails.
+        let staging = tmp.path().join("staging");
+        std::fs::write(&staging, "not a dir").unwrap();
+
+        let staged = stage_transcripts(
+            &home,
+            "codex-home",
+            "codex",
+            &["sessions", "archived_sessions"],
+            &staging,
+        );
+        assert!(!staged);
+        // The caller can (and must) still delete the home afterwards.
+        assert!(home.join("sessions").exists());
+        std::fs::remove_dir_all(&home).unwrap();
+        assert!(!home.exists());
+    }
+
+    #[test]
+    fn active_registry_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active = tmp.path().join("active");
+        record_active(&active, "codex-home", "codex", Path::new("/x/codex-home"));
+        let raw = std::fs::read_to_string(active.join("codex-home.json")).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(value["source"].as_str(), Some("codex"));
+        clear_active(&active, "codex-home");
+        assert!(!active.join("codex-home.json").exists());
+        // Clearing an absent entry is quiet.
+        clear_active(&active, "codex-home");
+    }
+
+    #[test]
+    fn gc_removes_only_expired_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let staging = tmp.path().join("staging");
+        std::fs::create_dir_all(&staging).unwrap();
+
+        let old = staging.join("codex-home-1-1");
+        std::fs::create_dir_all(&old).unwrap();
+        std::fs::write(
+            old.join("manifest.json"),
+            format!("{{\"staged_at_ms\": {}}}", 1i64),
+        )
+        .unwrap();
+
+        let now = now_ms();
+        let fresh = staging.join("codex-home-2-2");
+        std::fs::create_dir_all(&fresh).unwrap();
+        std::fs::write(
+            fresh.join("manifest.json"),
+            format!("{{\"staged_at_ms\": {}}}", now),
+        )
+        .unwrap();
+
+        gc_staging(&staging, now);
+        assert!(!old.exists(), "expired entry GC'd");
+        assert!(fresh.exists(), "fresh entry kept");
+    }
+}

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -40,6 +40,7 @@ mod gateway_routes;
 mod global_store;
 mod hosted_verify;
 pub(crate) use intendant_core::knowledge;
+mod lease_transcript_staging;
 mod lineage_ledger;
 mod linux_display_env;
 mod live_audio;


### PR DESCRIPTION
F6 of the message-search program (plan §3, converged after two review rounds — this design replaced an earlier "ingest-before-delete barrier" precisely because custody outranks search completeness).

Materialized OAuth homes hold the borrowed secret AND the agent's transcripts; deletion erased leased sessions from message search entirely — a short-lived leased session could vanish before any indexer saw it. Cleanup now renames the transcript subdirectories (codex `sessions/` + `archived_sessions/`, claude `projects/`) into a credential-free staging area under `~/.intendant/cache/message_search/staging/`, then deletes the home immediately.

**The invariant, enforced structurally:** staging is rename-only (same volume, effectively O(1)), best-effort, with deliberately NO copy fallback — any failure writes a coverage marker (future `partial(lease_cleanup)` state) and deletion proceeds. Secret deletion is never delayed by indexing, on any path: expiry, revocation, shutdown, the materialize-failure edge (a re-grant can fail over a home already holding transcripts), and the startup crash sweep. The sweep also GCs staged entries older than the 14-day retention window, so staged data cannot accumulate while no drainer exists. A `leased-active/` registry (one file per materialized home) gives the future indexer live-lease discovery.

Per-kind transcript-dir knowledge lives on `MaterializationPlan` (the existing single declaration point). All staging functions take roots as parameters; tests are hermetic (the custody integration test exercises `drop_materialization` end-to-end against tempdirs + the test-scoped intendant home). Docs: custody chapter gains the staging paragraph.

Tests: 3056/3056 bins + workspace clippy `-D warnings` clean.