### PR TITLE
Coordinator route: unify IAM on PeerUse across both transport lanes

### DIFF
--- a/docs/src/peer-federation.md
+++ b/docs/src/peer-federation.md
@@ -171,6 +171,11 @@ cross-machine display (see below).
   eligible peer — one that is `Connected` *and* whose card advertises every
   required capability — in lexicographic `PeerId` order (deterministic, so
   idempotent retries route to the same peer) and delegates via the handle.
+  Routing through the coordinator (`POST /api/coordinator/route` and its
+  `api_coordinator_route` tunnel twin) is authorized as `peer.use` on both
+  transport lanes, same as the per-peer quick controls: the routed task is
+  delegated under *this daemon's* peer identity, and the receiving peer
+  authorizes it against its own grants for this daemon.
 
 ### Per-peer sessions — the folded `SessionInfo` rail
 

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -652,7 +652,8 @@ and peer federation:
   topology separates `peer.inspect`, `peer.manage`, and `peer.use`.
   `peer.use` is the delegation gate: acting through a connected peer —
   opening a tunnel (dashboard-control, file-transfer, or display signaling)
-  or sending it a message, task, or approval decision — presents *this
+  or sending it a message, task, or approval decision, directly or via
+  coordinator routing — presents *this
   daemon's* peer credentials, and the receiving peer authorizes each action
   against its own grants for this daemon — so relaying is
   never inferred from local capabilities, it is granted by name
@@ -1824,11 +1825,13 @@ Acting through an already-connected peer is gated by `peer.use` instead —
 using a peer relationship is not administering it. That covers the signaling
 relays that open tunnels (`api_peer_webrtc_signal`,
 `api_peer_file_transfer_signal`, `api_peer_dashboard_control_signal`, and
-their `POST /api/peers/{id}/…-webrtc` HTTP twins) and the quick controls
+their `POST /api/peers/{id}/…-webrtc` HTTP twins), the quick controls
 (`api_peer_message`, `api_peer_task`, `api_peer_approval`, and their
-`POST /api/peers/{id}/message|task|approval` HTTP twins): each delegates this
-daemon's peer identity, and the receiving peer authorizes the action against
-its own grants for this daemon.
+`POST /api/peers/{id}/message|task|approval` HTTP twins), and coordinator
+task routing (`api_coordinator_route` and its `POST /api/coordinator/route`
+HTTP twin, which picks the capability-matched peer for you): each delegates
+this daemon's peer identity, and the receiving peer authorizes the action
+against its own grants for this daemon.
 General peer and coordinator controls are covered by the same rule. Peer add,
 remove, eligibility discovery, per-peer message/task/approval, peer-display
 signaling, and coordinator route calls use `api_peer_add`, `api_peer_remove`,

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -967,7 +967,9 @@ pub fn federation_http_operation(method: &str, path: &str) -> Option<PeerOperati
     // for this daemon. Keeping the quick controls on peer.manage would be a
     // hollow boundary anyway — a peer.use principal can reach the same
     // effects through the dashboard-control tunnel it may already open.
-    // Registry and pairing mutations stay peer.manage.
+    // Registry and pairing mutations stay peer.manage. Coordinator
+    // routing (the `/api/coordinator/` branch below) is the same action
+    // class and rides the same doctrine.
     if method == "POST" {
         let mut segments = path
             .strip_prefix("/api/peers/")
@@ -995,8 +997,15 @@ pub fn federation_http_operation(method: &str, path: &str) -> Option<PeerOperati
         }
         return Some(PeerOperation::PeerManage);
     }
+    // Coordinator routing dispatches a task to a capability-matched
+    // connected peer under this daemon's peer identity — the same action
+    // class as the `/api/peers/{id}/task` quick control, so it rides the
+    // peer-use doctrine above. Owner decision 2026-07-11: both transport
+    // lanes gate on PeerUse (this branch previously classified as Task
+    // while the tunnel twin gated on PeerManage — a split that let a
+    // task-authority peer spend this daemon's identity on a third peer).
     if path.starts_with("/api/coordinator/") {
-        return Some(PeerOperation::Task);
+        return Some(PeerOperation::PeerUse);
     }
     if under("/api/sessions") {
         return Some(PeerOperation::SessionInspect);
@@ -1659,6 +1668,37 @@ mod tests {
             "peer-operator",
             PeerOperation::PeerUse
         ));
+    }
+
+    /// Owner decision 2026-07-11: coordinator routing is peer *use* on
+    /// both transport lanes. `POST /api/coordinator/route` dispatches a
+    /// task to a capability-matched connected peer under this daemon's
+    /// peer identity — the same action class as the `/api/peers/{id}/task`
+    /// quick control — so the federation ladder classifies it as PeerUse;
+    /// the tunnel twin derives the same operation from its route row
+    /// (pinned by gateway_routes'
+    /// `peers_family_tunnel_ops_assert_against_the_federation_ladder`).
+    /// Supersedes the historical per-lane split (HTTP: Task, tunnel:
+    /// PeerManage): among peer profiles only peer-root holds PeerUse, so a
+    /// task-runner or peer-operator peer can no longer spend this daemon's
+    /// identity on a third peer through the coordinator — the
+    /// transitive-delegation seam the Task classification left open.
+    #[test]
+    fn coordinator_routing_classifies_as_peer_use() {
+        assert_eq!(
+            federation_http_operation("POST", "/api/coordinator/route"),
+            Some(PeerOperation::PeerUse)
+        );
+        // The gate is delegation authority, not task authority: the
+        // task-running profiles hold Task but not PeerUse.
+        assert!(profile_allows_operation(
+            "peer-root",
+            PeerOperation::PeerUse
+        ));
+        for profile in ["task-runner", "peer-operator"] {
+            assert!(profile_allows_operation(profile, PeerOperation::Task));
+            assert!(!profile_allows_operation(profile, PeerOperation::PeerUse));
+        }
     }
 
     #[test]

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -2346,9 +2346,11 @@ pub(crate) fn status_response_frame(id: String, runtime: &ControlRuntime) -> ser
             peer_registry_available && peer_use,
         ),
         ("api_peer_pairing_available", peer_manage || access_manage),
+        // Coordinator routing acts *through* a peer too (owner decision
+        // 2026-07-11): the aggregate follows the method's PeerUse gate.
         (
             "api_coordinator_available",
-            peer_registry_available && peer_manage,
+            peer_registry_available && peer_use,
         ),
         // Host capability, not a grant: dashboards derive the "New virtual
         // display" affordance from this (Xvfb-based, Linux-only).

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -234,9 +234,10 @@ const CONTROL_ONLY_METHODS: &[ControlMethodSpec] = &[
     // on its row's canonical leaf — acting through a connected peer
     // (quick controls + signaling relays) classifies as peer use, not
     // peer administration, exactly as the HTTP gate has always ruled.
-    // api_coordinator_route carries the family's one documented op
-    // override (PeerManage; the ladder says Task) — see the closed
-    // enumeration in gateway_routes.
+    // Coordinator routing joined that rule on the 2026-07-11 owner
+    // decision: it delegates this daemon's peer identity like the quick
+    // controls, so both lanes gate on PeerUse (its historical
+    // PeerManage-tunnel / Task-HTTP op override is gone).
     // The sessions read-core methods (api_sessions, api_sessions_search,
     // api_session_detail, api_session_agent_output,
     // api_session_context_snapshot) live as tunnel columns on their
@@ -3146,9 +3147,10 @@ mod tests {
                 Row,
                 Some(Op::PeerManage),
             ),
-            // The coordinator's PeerManage rides its documented op
-            // override (the ladder classifies the HTTP leaf as Task).
-            ("api_coordinator_route", Row, Some(Op::PeerManage)),
+            // Coordinator routing derives PeerUse from the ladder like
+            // the quick controls (owner decision 2026-07-11; its
+            // historical PeerManage override is gone).
+            ("api_coordinator_route", Row, Some(Op::PeerUse)),
             ("api_sessions", Row, Some(Op::SessionInspect)),
             ("api_sessions_stream", Row, Some(Op::SessionInspect)),
             ("api_session_detail", Row, Some(Op::SessionInspect)),
@@ -3351,8 +3353,8 @@ mod tests {
     /// the row's IAM operation equals the tunnel method's (the signed-org
     /// doorbell rows are Public on HTTP by design and instead pin their
     /// documented tunnel op-override; the peers/coordinator federation
-    /// rows pin the row's own derivation — ladder on the canonical leaf,
-    /// or the coordinator's documented override); and the path
+    /// rows pin the row's own derivation — the federation ladder on the
+    /// canonical leaf); and the path
     /// template restates the row's declared pattern (captures by name).
     /// Plus the exact coverage set, so entries appear and disappear
     /// deliberately. When the route table grows its `tunnel:` column
@@ -3621,14 +3623,12 @@ mod tests {
                 // The peers/coordinator family rows delegate HTTP authz to
                 // the federation ladder (F5). Their tunnel op derives from
                 // the row itself — `Route::tunnel_operation` applies the
-                // same ladder to the row's canonical leaf, or the
-                // documented override (api_coordinator_route: the ladder
-                // classifies the HTTP leaf as Task while the tunnel method
-                // has always gated on PeerManage — a preserved per-lane
-                // divergence the descriptor must not paper over). Require
-                // the resolved row to carry THIS method's tunnel column
-                // and its derivation to equal the effective tunnel
-                // operation.
+                // same ladder to the row's canonical leaf
+                // (api_coordinator_route included: both of its lanes gate
+                // on PeerUse since the 2026-07-11 owner decision retired
+                // its historical PeerManage override). Require the
+                // resolved row to carry THIS method's tunnel column and
+                // its derivation to equal the effective tunnel operation.
                 RouteAuthz::PeerFederation => {
                     let tunnel = route.tunnel.as_ref().unwrap_or_else(|| {
                         panic!("{method_name}: federation descriptor row lost its tunnel column")

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -1738,12 +1738,14 @@ pub(crate) static ROUTES: &[Route] = &[
         RouteHandlerId::PeersSubRouter,
         "Peers sub-router catch-all (handler-owned JSON 404/405 for unknown subpaths and undeclared methods)",
     ),
-    // The coordinator twin carries a documented op override: the ladder
-    // classifies POST /api/coordinator/* as Task (a federated peer
-    // routing work here needs task authority), while the tunnel method
-    // has always gated on PeerManage for dashboard sessions. The
-    // override preserves both historical mappings exactly — see the
-    // enumeration test — pending an owner decision on unifying them.
+    // Owner decision 2026-07-11: coordinator routing gates on PeerUse on
+    // both transport lanes (the quick-controls doctrine — routing a task
+    // through the coordinator dispatches it to a capability-matched peer
+    // under this daemon's peer identity, the same action class as
+    // POST /api/peers/{id}/task). The tunnel twin derives from the
+    // federation ladder like every other twinned method here; this
+    // supersedes the previously preserved per-lane split (HTTP: Task,
+    // tunnel: PeerManage via a documented op override).
     federation_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/coordinator/route"),
@@ -1751,15 +1753,7 @@ pub(crate) static ROUTES: &[Route] = &[
         RouteHandlerId::CoordinatorRoute,
         "Capability-based task routing through the Coordinator",
     )
-    .with_tunnel(tunnel_method_with_op(
-        "api_coordinator_route",
-        PeerOperation::PeerManage,
-        "historical per-lane divergence, preserved: the federation ladder \
-         classifies POST /api/coordinator/* as Task for the HTTP lane, but \
-         the datachannel method has always required PeerManage of a \
-         dashboard session — re-gating either lane is an owner decision, \
-         not a migration rider",
-    )),
+    .with_tunnel(tunnel_method("api_coordinator_route")),
     // ── MCP Streamable HTTP (token-bound inside the handler; the
     //    per-tool IAM gate lives in the MCP layer).
     Route {
@@ -2632,10 +2626,10 @@ mod tests {
     /// added deliberately. The occupants: the signed-org doorbell twins
     /// (S6) — Public rows on HTTP (the signed document/list is the
     /// authorization) while the tunnel methods deliberately gate on a
-    /// bound session's operation — and the coordinator twin (S7), whose
-    /// historical PeerManage gate diverges from the federation ladder's
-    /// Task classification; the override preserves both lanes' historical
-    /// mappings verbatim (see
+    /// bound session's operation. The coordinator twin's historical
+    /// override (tunnel PeerManage vs the ladder's Task) left the set on
+    /// the 2026-07-11 owner decision unifying coordinator routing on
+    /// PeerUse — both lanes now derive from the federation ladder (see
     /// `peers_family_tunnel_ops_assert_against_the_federation_ladder`).
     #[test]
     fn tunnel_op_overrides_are_a_closed_documented_enumeration() {
@@ -2644,7 +2638,6 @@ mod tests {
             "api_access_org_orl_apply",
             "api_access_org_present",
             "api_access_org_renew",
-            "api_coordinator_route",
         ];
         let mut actual: Vec<&str> = Vec::new();
         for (_, spec) in tunnel_specs() {
@@ -2673,8 +2666,9 @@ mod tests {
     /// reproduces it, and (c) the canonical leaf really is served by
     /// this row (first match), so the leaf a twin is derived from can
     /// never silently belong to a different row. The coordinator twin
-    /// is the documented exception: the ladder says Task, the tunnel
-    /// stays PeerManage via its pinned override.
+    /// joined the derivation on the 2026-07-11 owner decision (PeerUse
+    /// on both lanes) and is asserted in the tail — it lives on its own
+    /// handler, so it stays out of the PeersSubRouter loop.
     #[test]
     fn peers_family_tunnel_ops_assert_against_the_federation_ladder() {
         use crate::peer::access_policy::{federation_http_operation, PeerOperation as Op};
@@ -2805,19 +2799,40 @@ mod tests {
             );
             assert_eq!(matched.handler, RouteHandlerId::PeersSubRouter, "{name}");
         }
-        // The one deliberate exception, pinned from both directions: the
-        // HTTP lane classifies coordinator routing as Task, the tunnel
-        // twin keeps its historical PeerManage through the documented
-        // override (the enumeration test above pins the override set).
+        // Owner decision 2026-07-11: coordinator routing dispatches a
+        // task to a capability-matched connected peer under this daemon's
+        // peer identity — the quick-controls action class — so both lanes
+        // gate on PeerUse. This supersedes the preserved per-lane split
+        // (HTTP: Task, tunnel: PeerManage via a documented override),
+        // which let a task-authority peer spend this daemon's identity on
+        // a third peer over HTTP. Pinned from both directions, same
+        // (a)/(b)/(c) facts as the loop above (the coordinator lives on
+        // its own handler, not the peers sub-router).
         assert_eq!(
             federation_http_operation("POST", "/api/coordinator/route"),
-            Some(Op::Task),
+            Some(Op::PeerUse),
         );
         let (route, spec) = tunnel_specs()
             .find(|(_, spec)| spec.name == "api_coordinator_route")
             .expect("coordinator twin declared");
-        assert!(spec.op_override.is_some(), "coordinator override present");
-        assert_eq!(route.tunnel_operation(), Some(Op::PeerManage));
+        assert!(
+            spec.op_override.is_none(),
+            "the coordinator twin derives from the ladder — its historical \
+             override was retired by the 2026-07-11 owner decision",
+        );
+        assert_eq!(route.tunnel_operation(), Some(Op::PeerUse));
+        assert_eq!(
+            route.canonical_leaf(),
+            Some(("POST", "/api/coordinator/route".to_string())),
+        );
+        let (matched, _) = match_route("POST", "/api/coordinator/route")
+            .expect("no route matches POST /api/coordinator/route");
+        assert!(
+            std::ptr::eq(matched, route),
+            "the coordinator leaf is served by a different row than the one \
+             declaring the twin",
+        );
+        assert_eq!(matched.handler, RouteHandlerId::CoordinatorRoute);
     }
 
     /// The docs chapter's generated endpoint table must equal the one

--- a/src/bin/caller/web_gateway/access_gates.rs
+++ b/src/bin/caller/web_gateway/access_gates.rs
@@ -605,10 +605,13 @@ mod tests {
         assert_eq!(dashboard_http_operation("POST", "/api/fs/deleted"), None);
         // Historically unclassified (browsers ungated); the table row
         // delegates to federation_http_operation, closing the gap the
-        // federation bearer gate already closed for peers.
+        // federation bearer gate already closed for peers. PeerUse since
+        // the 2026-07-11 owner decision: coordinator routing spends this
+        // daemon's peer identity, like the /api/peers/{id}/task quick
+        // control.
         assert_eq!(
             dashboard_http_operation("POST", "/api/coordinator/route"),
-            Some(PeerOperation::Task)
+            Some(PeerOperation::PeerUse)
         );
         assert_eq!(dashboard_http_operation("GET", "/config"), None);
         // The prefix families use the same boundary rule as dispatch:

--- a/static/app.html
+++ b/static/app.html
@@ -26363,12 +26363,13 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_peer_pairing_request_decision: { verb: 'POST', path: '/api/peers/pairing/requests/{code}/{decision}', alias: { code: 'request_id', decision: 'op' } },
   api_peer_pairing_identities: { verb: 'GET', path: '/api/peers/pairing/identities' },
   api_peer_pairing_identity_revoke: { verb: 'POST', path: '/api/peers/pairing/identities/revoke' },
-  // The coordinator twin carries the program's one live per-lane IAM
-  // divergence, preserved on purpose: the HTTP row classifies through the
-  // federation ladder as Task, while the datachannel method has always
-  // gated on PeerManage (documented op-override on the route row). The
-  // descriptor only names the twin's verb + path — it must not paper over
-  // that divergence, and the daemon-side parity pin asserts the override.
+  // Both coordinator lanes gate on peer.use (owner decision 2026-07-11):
+  // routing a task through the coordinator delegates this daemon's peer
+  // identity to a capability-matched peer — the same action class as the
+  // per-peer task quick control. The unification retired the program's
+  // last live per-lane IAM divergence (HTTP: Task via the federation
+  // ladder; tunnel: PeerManage via a documented op-override); the tunnel
+  // twin now derives from the route row like every other twinned method.
   api_coordinator_route: { verb: 'POST', path: '/api/coordinator/route' },
 });
 
@@ -74931,9 +74932,9 @@ async function routeTask() {
       task: { instructions },
     };
     // Coordinator routing is a mutation (transport F5): verb-derived
-    // no-replay. The method's per-lane IAM divergence (HTTP: Task via the
-    // federation ladder; tunnel: PeerManage, documented op-override) is
-    // preserved on the rows — the facade only names the twin.
+    // no-replay. Both lanes gate on peer.use (owner decision 2026-07-11:
+    // the coordinator spends this daemon's peer identity, like the
+    // per-peer task quick control) — the facade only names the twin.
     const resp = await daemonApi.request('api_coordinator_route', payload);
     const result = resp.body || {};
     if (resp.ok) {

--- a/static/app/32-daemon-api.js
+++ b/static/app/32-daemon-api.js
@@ -236,12 +236,13 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_peer_pairing_request_decision: { verb: 'POST', path: '/api/peers/pairing/requests/{code}/{decision}', alias: { code: 'request_id', decision: 'op' } },
   api_peer_pairing_identities: { verb: 'GET', path: '/api/peers/pairing/identities' },
   api_peer_pairing_identity_revoke: { verb: 'POST', path: '/api/peers/pairing/identities/revoke' },
-  // The coordinator twin carries the program's one live per-lane IAM
-  // divergence, preserved on purpose: the HTTP row classifies through the
-  // federation ladder as Task, while the datachannel method has always
-  // gated on PeerManage (documented op-override on the route row). The
-  // descriptor only names the twin's verb + path — it must not paper over
-  // that divergence, and the daemon-side parity pin asserts the override.
+  // Both coordinator lanes gate on peer.use (owner decision 2026-07-11):
+  // routing a task through the coordinator delegates this daemon's peer
+  // identity to a capability-matched peer — the same action class as the
+  // per-peer task quick control. The unification retired the program's
+  // last live per-lane IAM divergence (HTTP: Task via the federation
+  // ladder; tunnel: PeerManage via a documented op-override); the tunnel
+  // twin now derives from the route row like every other twinned method.
   api_coordinator_route: { verb: 'POST', path: '/api/coordinator/route' },
 });
 

--- a/static/app/52-peer-display.js
+++ b/static/app/52-peer-display.js
@@ -2384,9 +2384,9 @@ async function routeTask() {
       task: { instructions },
     };
     // Coordinator routing is a mutation (transport F5): verb-derived
-    // no-replay. The method's per-lane IAM divergence (HTTP: Task via the
-    // federation ladder; tunnel: PeerManage, documented op-override) is
-    // preserved on the rows — the facade only names the twin.
+    // no-replay. Both lanes gate on peer.use (owner decision 2026-07-11:
+    // the coordinator spends this daemon's peer identity, like the
+    // per-peer task quick control) — the facade only names the twin.
     const resp = await daemonApi.request('api_coordinator_route', payload);
     const result = resp.body || {};
     if (resp.ok) {


### PR DESCRIPTION
## What

Implements the 2026-07-11 owner decision: `POST /api/coordinator/route` gates on **`PeerOperation::PeerUse` in both transport lanes**, replacing the historical per-lane split (HTTP lane: `Task` via the federation ladder; dashboard-control tunnel: `PeerManage` via the program's last live op override).

## Why

Coordinator routing dispatches a task to a capability-matched connected peer **under this daemon's peer identity** — the same action class as the `/api/peers/{id}/task` quick control, which the access ladder deliberately classifies as `PeerUse` (acting through a connected peer is peer *use*, not peer administration; the receiving peer authorizes the action against its own grants for this daemon). Unifying on PeerUse closes a transitive-delegation seam: a task-runner-profile peer could previously make this daemon spend its peer identity on a third peer via the HTTP lane.

## Behavior changes (deliberate)

- **HTTP lane tightens** (`Task` → `PeerUse`):
  - `task-runner` and `peer-operator` profile **peers** lose HTTP-lane coordinator access — among peer profiles only `peer-root` holds PeerUse. No such callers exist in tests/skills/e2e (verified 2026-07-11).
  - Custom IAM roles holding `task.run` without `peer.use` lose HTTP access.
- **Tunnel lane loosens** (`PeerManage` → `PeerUse`): `operator` and `peer-user` IAM clients **gain** tunnel access. `peer.manage` implies `peer.use` in IAM, so every previous tunnel caller keeps access.
- The `api_coordinator_available` status aggregate follows the method's gate (`peer.use` instead of `peer.manage`), consistent with `api_peer_quick_controls_available`.

## How

- `access/access_policy.rs`: the `/api/coordinator/` federation-ladder branch returns `PeerUse` and is folded into the quick-controls doctrine comment; new dated test `coordinator_routing_classifies_as_peer_use` pins the classification and the profile consequences.
- `gateway_routes.rs`: the coordinator row's tunnel twin is now the plain derived form (`tunnel_method("api_coordinator_route")`) — `Route::tunnel_operation` applies the same ladder to the row's canonical leaf, so the two lanes cannot drift again. The op-override enumeration shrinks to the signed-org doorbell quartet (the intended occupants); `peers_family_tunnel_ops_assert_against_the_federation_ladder` pins the coordinator's PeerUse from both directions (ladder + row derivation + first-match routing, no override).
- `dashboard_control/`: tunnel method-partition pin updated (`PeerManage` → `PeerUse`); residue-table and parity-test comments updated.
- SPA fragments (`32-daemon-api.js` divergence comment, `52-peer-display.js`) and docs (`web-dashboard.md` peer.use passages, `peer-federation.md` Coordinator section) state the unification; `app.html` regenerated from fragments via the assembler.