### PR TITLE
Dashboard: allow per-session Codex model override

### DIFF
--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -794,8 +794,9 @@ shared state (when driven over MCP) → config default → native.
   root, and logs later `thread/settings/updated` cwd notifications so harness
   runs do not silently display a requested root as if Codex had accepted it.
 - **Per-session launch config beats global defaults.** Dashboard-created and
-  dashboard-configured external sessions persist their binary command and, for
-  Codex, `managed_context` mode. Both resume paths — daemon resume/attach and
+  dashboard-configured external sessions persist their binary command and
+  backend-specific launch fields, including a launch-time Codex model pin. Both
+  resume paths — daemon resume/attach and
   CLI `--resume` — rehydrate that persisted per-session config with the same
   precedence: explicit overrides (dashboard launch options or CLI flags), then
   the persisted per-session config, then the global Settings pane /

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -467,12 +467,14 @@ directory is safe to delete; it rebuilds on the next scan.
   banner explains why the internal agent can't start (external agents
   sign in with their own accounts and still work) and deep-links to
   Settings → API Keys — which applies immediately, no restart.
-  External Codex sessions can choose both the binary path and the
-  `managed_context` mode (`vanilla` or `managed`) for that session; the
-  external-agent options sit in a fold that opens when an external
-  backend is selected. Claude Code sessions get per-launch dropdowns for
-  the model (version-safe aliases — `fable`, `opus`, `sonnet`, `haiku` —
-  that the CLI resolves to the latest release, with a Custom-id escape
+  External Codex sessions can choose the binary path, an exact model id,
+  sandbox and approval policies, `managed_context` mode (`vanilla` or
+  `managed`), context replay mode, and Fast service tier for that session.
+  The free-text model field is intentionally account-agnostic; blank inherits
+  the global/Codex default. The external-agent options sit in a fold that opens
+  when an external backend is selected. Claude Code sessions get per-launch
+  dropdowns for the model (version-safe aliases — `fable`, `opus`, `sonnet`,
+  `haiku` — that the CLI resolves to the latest release, with a Custom-id escape
   for full model names), the permission mode, and the reasoning effort
   (`low` … `max`).
 

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -627,6 +627,13 @@ mod tests {
     }
 
     #[test]
+    fn new_session_codex_model_override_is_wired() {
+        assert!(APP_HTML.contains(r#"id="new-session-codex-model""#));
+        assert!(APP_HTML.contains("codexModelInp.disabled = !appliesToCodex;"));
+        assert!(APP_HTML.contains("if (model) msg.codex_model = model;"));
+    }
+
+    #[test]
     fn api_request_mentioning_asset_path_in_query_is_not_shadowed() {
         // Regression: the old `request_line.contains(...)` routing served
         // the station wasm for *any* request line containing its path —

--- a/static/app.html
+++ b/static/app.html
@@ -22379,6 +22379,10 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
                           <button type="button" id="new-session-agent-command-browse" class="sessions-project-browse" onclick="openAgentBinaryPicker()" disabled>Browse</button>
                         </div>
                       </div>
+                      <label class="sessions-new-session-field" for="new-session-codex-model">
+                        Codex model
+                        <input id="new-session-codex-model" type="text" autocomplete="off" spellcheck="false" placeholder="Global setting (e.g. gpt-5.5)" disabled>
+                      </label>
                       <label class="sessions-new-session-field" for="new-session-claude-model-select">
                         Claude model
                         <select id="new-session-claude-model-select" onchange="onNewSessionClaudeModelSelectChange()" disabled>
@@ -22653,7 +22657,6 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
       </div>
 
       <div class="subtab-panes">
-
 <!-- ── static/app/21-access-dialogs.html ── -->
         <!-- ── Overview: who you are, your fleet, how the model works ── -->
         <div class="subtab-pane active" id="access-pane-overview">
@@ -83857,6 +83860,7 @@ function renderNewSessionAgentControls(options = {}) {
   const select = document.getElementById('new-session-agent');
   const commandInput = document.getElementById('new-session-agent-command');
   const browseBtn = document.getElementById('new-session-agent-command-browse');
+  const codexModelInp = document.getElementById('new-session-codex-model');
   const sandboxSel = document.getElementById('new-session-codex-sandbox');
   const approvalSel = document.getElementById('new-session-codex-approval-policy');
   const managedContextSel = document.getElementById('new-session-codex-managed-context');
@@ -83917,6 +83921,11 @@ function renderNewSessionAgentControls(options = {}) {
   const claudeModeSel = document.getElementById('new-session-claude-permission-mode');
   const claudeEffortSel = document.getElementById('new-session-claude-effort');
   const appliesToClaude = effectiveAgent === 'claude-code';
+  const appliesToCodex = effectiveAgent === 'codex';
+  if (codexModelInp) {
+    codexModelInp.disabled = !appliesToCodex;
+    if (!appliesToCodex) codexModelInp.value = '';
+  }
   if (claudeModelSel) {
     claudeModelSel.disabled = !appliesToClaude;
     if (!appliesToClaude) claudeModelSel.value = '';
@@ -83935,27 +83944,22 @@ function renderNewSessionAgentControls(options = {}) {
     if (!appliesToClaude) claudeEffortSel.value = '';
   }
   if (managedContextSel) {
-    const appliesToCodex = effectiveAgent === 'codex';
     managedContextSel.disabled = !appliesToCodex;
     managedContextSel.value = newSessionCodexManagedContext;
   }
   if (sandboxSel) {
-    const appliesToCodex = effectiveAgent === 'codex';
     sandboxSel.disabled = !appliesToCodex;
     sandboxSel.value = normalizeCodexSandbox(newSessionCodexSandbox);
   }
   if (approvalSel) {
-    const appliesToCodex = effectiveAgent === 'codex';
     approvalSel.disabled = !appliesToCodex;
     approvalSel.value = normalizeCodexApprovalPolicy(newSessionCodexApprovalPolicy);
   }
   if (contextArchiveSel) {
-    const appliesToCodex = effectiveAgent === 'codex';
     contextArchiveSel.disabled = !appliesToCodex;
     contextArchiveSel.value = normalizeContextArchiveMode(newSessionCodexContextArchive);
   }
   if (fastToggle) {
-    const appliesToCodex = effectiveAgent === 'codex';
     fastToggle.disabled = !appliesToCodex;
     fastToggle.checked = appliesToCodex && !!newSessionCodexFastMode;
     if (fastWrap) {
@@ -83971,7 +83975,6 @@ function renderNewSessionAgentControls(options = {}) {
   }
   if (managedContextNote) {
     const mode = managedContextSel?.value || newSessionCodexManagedContext;
-    const appliesToCodex = effectiveAgent === 'codex';
     managedContextNote.classList.toggle('warn', appliesToCodex && mode === 'managed');
     managedContextNote.textContent = appliesToCodex && mode === 'managed'
       ? 'Managed requires a patched Codex binary with the managed app-server protocol.'
@@ -84481,6 +84484,8 @@ async function startNewSession() {
     if (effort) msg.claude_effort = effort;
   }
   if (effectiveNewSessionAgentId() === 'codex') {
+    const model = document.getElementById('new-session-codex-model')?.value.trim() || '';
+    if (model) msg.codex_model = model;
     if (newSessionCodexLaunchDefaultsLoaded) {
       msg.codex_sandbox = normalizeCodexSandbox(
         document.getElementById('new-session-codex-sandbox')?.value || newSessionCodexSandbox

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -1437,6 +1437,10 @@
                           <button type="button" id="new-session-agent-command-browse" class="sessions-project-browse" onclick="openAgentBinaryPicker()" disabled>Browse</button>
                         </div>
                       </div>
+                      <label class="sessions-new-session-field" for="new-session-codex-model">
+                        Codex model
+                        <input id="new-session-codex-model" type="text" autocomplete="off" spellcheck="false" placeholder="Global setting (e.g. gpt-5.5)" disabled>
+                      </label>
                       <label class="sessions-new-session-field" for="new-session-claude-model-select">
                         Claude model
                         <select id="new-session-claude-model-select" onchange="onNewSessionClaudeModelSelectChange()" disabled>
@@ -1711,4 +1715,3 @@
       </div>
 
       <div class="subtab-panes">
-

--- a/static/app/55-files-ide.js
+++ b/static/app/55-files-ide.js
@@ -2435,6 +2435,7 @@ function renderNewSessionAgentControls(options = {}) {
   const select = document.getElementById('new-session-agent');
   const commandInput = document.getElementById('new-session-agent-command');
   const browseBtn = document.getElementById('new-session-agent-command-browse');
+  const codexModelInp = document.getElementById('new-session-codex-model');
   const sandboxSel = document.getElementById('new-session-codex-sandbox');
   const approvalSel = document.getElementById('new-session-codex-approval-policy');
   const managedContextSel = document.getElementById('new-session-codex-managed-context');
@@ -2495,6 +2496,11 @@ function renderNewSessionAgentControls(options = {}) {
   const claudeModeSel = document.getElementById('new-session-claude-permission-mode');
   const claudeEffortSel = document.getElementById('new-session-claude-effort');
   const appliesToClaude = effectiveAgent === 'claude-code';
+  const appliesToCodex = effectiveAgent === 'codex';
+  if (codexModelInp) {
+    codexModelInp.disabled = !appliesToCodex;
+    if (!appliesToCodex) codexModelInp.value = '';
+  }
   if (claudeModelSel) {
     claudeModelSel.disabled = !appliesToClaude;
     if (!appliesToClaude) claudeModelSel.value = '';
@@ -2513,27 +2519,22 @@ function renderNewSessionAgentControls(options = {}) {
     if (!appliesToClaude) claudeEffortSel.value = '';
   }
   if (managedContextSel) {
-    const appliesToCodex = effectiveAgent === 'codex';
     managedContextSel.disabled = !appliesToCodex;
     managedContextSel.value = newSessionCodexManagedContext;
   }
   if (sandboxSel) {
-    const appliesToCodex = effectiveAgent === 'codex';
     sandboxSel.disabled = !appliesToCodex;
     sandboxSel.value = normalizeCodexSandbox(newSessionCodexSandbox);
   }
   if (approvalSel) {
-    const appliesToCodex = effectiveAgent === 'codex';
     approvalSel.disabled = !appliesToCodex;
     approvalSel.value = normalizeCodexApprovalPolicy(newSessionCodexApprovalPolicy);
   }
   if (contextArchiveSel) {
-    const appliesToCodex = effectiveAgent === 'codex';
     contextArchiveSel.disabled = !appliesToCodex;
     contextArchiveSel.value = normalizeContextArchiveMode(newSessionCodexContextArchive);
   }
   if (fastToggle) {
-    const appliesToCodex = effectiveAgent === 'codex';
     fastToggle.disabled = !appliesToCodex;
     fastToggle.checked = appliesToCodex && !!newSessionCodexFastMode;
     if (fastWrap) {
@@ -2549,7 +2550,6 @@ function renderNewSessionAgentControls(options = {}) {
   }
   if (managedContextNote) {
     const mode = managedContextSel?.value || newSessionCodexManagedContext;
-    const appliesToCodex = effectiveAgent === 'codex';
     managedContextNote.classList.toggle('warn', appliesToCodex && mode === 'managed');
     managedContextNote.textContent = appliesToCodex && mode === 'managed'
       ? 'Managed requires a patched Codex binary with the managed app-server protocol.'
@@ -3059,6 +3059,8 @@ async function startNewSession() {
     if (effort) msg.claude_effort = effort;
   }
   if (effectiveNewSessionAgentId() === 'codex') {
+    const model = document.getElementById('new-session-codex-model')?.value.trim() || '';
+    if (model) msg.codex_model = model;
     if (newSessionCodexLaunchDefaultsLoaded) {
       msg.codex_sandbox = normalizeCodexSandbox(
         document.getElementById('new-session-codex-sandbox')?.value || newSessionCodexSandbox


### PR DESCRIPTION
## What changed

- add a free-text Codex model override to Sessions → New Session
- enable it only for effective Codex launches and omit blank values so global/default inheritance stays intact
- send the existing launch-only `codex_model` field, regenerate the dashboard bundle, and document the behavior
- add an embedded-dashboard regression test for the control and payload wiring

## Why

The backend already accepted, persisted, and forwarded a per-session `codex_model`, but the New Session dashboard never exposed or serialized it. Accounts without a newly rolled-out default model therefore had no per-launch way to choose an available model.

## Validation

- `cargo test --bins`
- `cargo clippy`
- `cargo fmt --check`
- `node scripts/validate-dashboard.cjs --check-static-scripts --app-html static/app.html`
- generated `static/app.html` verified against all 69 source fragments