### PR TITLE
Wrapper index: explicit state + stored rollout path (message-search F5)

### DIFF
--- a/src/bin/caller/codex_history.rs
+++ b/src/bin/caller/codex_history.rs
@@ -49,12 +49,37 @@ pub(crate) fn find_codex_session_file_for_main(home: &Path, session_id: &str) ->
         .map(PathBuf::from)
         .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| home.join(".codex"));
+    find_codex_session_file_in(&codex, home, session_id)
+}
+
+/// Locate the rollout whose `session_meta.payload.id` is `session_id`
+/// under `codex_root`, consulting the wrapper index's stored rollout path
+/// before paying for the recursive scan (the scan opens EVERY rollout
+/// under `sessions/` + `archived_sessions/` to match the id). The stored
+/// path is trusted only after re-verifying the session id — rollouts
+/// migrate `sessions/` → `archived_sessions/` — and a successful rescan
+/// re-records the fresh location. `codex_root` is resolved by the caller
+/// (the `CODEX_HOME` env edge above); `home` scopes the wrapper index.
+pub(crate) fn find_codex_session_file_in(
+    codex_root: &Path,
+    home: &Path,
+    session_id: &str,
+) -> Option<PathBuf> {
+    if let Some(stored) =
+        crate::external_wrapper_index::resolved_rollout_path(home, "codex", session_id, |path| {
+            codex_session_file_id(path).as_deref() == Some(session_id)
+        })
+    {
+        return Some(stored);
+    }
     let mut files = Vec::new();
-    collect_jsonl_files(&codex.join("sessions"), &mut files);
-    collect_jsonl_files(&codex.join("archived_sessions"), &mut files);
-    files
+    collect_jsonl_files(&codex_root.join("sessions"), &mut files);
+    collect_jsonl_files(&codex_root.join("archived_sessions"), &mut files);
+    let found = files
         .into_iter()
-        .find(|path| codex_session_file_id(path).as_deref() == Some(session_id))
+        .find(|path| codex_session_file_id(path).as_deref() == Some(session_id))?;
+    let _ = crate::external_wrapper_index::record_rollout_path(home, "codex", session_id, &found);
+    Some(found)
 }
 
 pub(crate) fn codex_message_content_text(content: &serde_json::Value) -> Option<String> {
@@ -356,5 +381,92 @@ mod tests {
         assert!(!is_codex_injected_user_text_for_main(
             "please inspect <bash-input> handling"
         ));
+    }
+
+    #[test]
+    fn find_codex_session_file_in_reuses_stored_rollout_path_and_survives_migration() {
+        let home = tempfile::tempdir().unwrap();
+        let session_id = "019ea8b9-0000-7000-8000-00000000dd01";
+        let wrapper_id = "9a411507-4a41-4a37-95a2-6a8f4f9edc01";
+        let log_dir = home.path().join(".intendant").join("logs").join(wrapper_id);
+        std::fs::create_dir_all(&log_dir).unwrap();
+        crate::external_wrapper_index::upsert(
+            home.path(),
+            "codex",
+            session_id,
+            wrapper_id,
+            &log_dir,
+            None,
+        )
+        .unwrap();
+
+        let codex_root = home.path().join("codex-root");
+        let sessions_dir = codex_root.join("sessions").join("2026").join("07");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        let meta = serde_json::json!({
+            "timestamp": "2026-07-11T10:00:00Z",
+            "type": "session_meta",
+            "payload": { "id": session_id }
+        });
+        let decoy = serde_json::json!({
+            "timestamp": "2026-07-11T10:00:00Z",
+            "type": "session_meta",
+            "payload": { "id": "019ea8b9-9999-7000-8000-00000000dd99" }
+        });
+        std::fs::write(sessions_dir.join("decoy.jsonl"), decoy.to_string()).unwrap();
+        let live = sessions_dir.join("rollout.jsonl");
+        std::fs::write(&live, meta.to_string()).unwrap();
+
+        // First resolution scans and records the location.
+        assert_eq!(
+            find_codex_session_file_in(&codex_root, home.path(), session_id),
+            Some(live.clone())
+        );
+        assert_eq!(
+            crate::external_wrapper_index::resolved_rollout_path(
+                home.path(),
+                "codex",
+                session_id,
+                |_| true
+            ),
+            Some(live.clone())
+        );
+
+        // Migration sessions/ -> archived_sessions/: the stored path goes
+        // stale, the scan fallback finds the new home and re-records it.
+        let archived_dir = codex_root.join("archived_sessions");
+        std::fs::create_dir_all(&archived_dir).unwrap();
+        let archived = archived_dir.join("rollout.jsonl");
+        std::fs::rename(&live, &archived).unwrap();
+        assert_eq!(
+            find_codex_session_file_in(&codex_root, home.path(), session_id),
+            Some(archived.clone())
+        );
+        assert_eq!(
+            crate::external_wrapper_index::resolved_rollout_path(
+                home.path(),
+                "codex",
+                session_id,
+                |_| true
+            ),
+            Some(archived.clone())
+        );
+
+        // The stored path short-circuits the scan: a recorded location
+        // outside the scanned roots still resolves, as long as the file
+        // exists and its session id verifies.
+        let outside = codex_root.join("kept.jsonl");
+        std::fs::rename(&archived, &outside).unwrap();
+        crate::external_wrapper_index::record_rollout_path(
+            home.path(),
+            "codex",
+            session_id,
+            &outside,
+        )
+        .unwrap();
+        assert_eq!(
+            find_codex_session_file_in(&codex_root, home.path(), session_id),
+            Some(outside)
+        );
     }
 }

--- a/src/bin/caller/external_wrapper_index.rs
+++ b/src/bin/caller/external_wrapper_index.rs
@@ -89,6 +89,12 @@ pub struct ExternalWrapperRecord {
     pub log_path: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub project_root: Option<String>,
+    /// Activity mtime of the wrapper's log dir — EXCEPT that `0` is the
+    /// deliberate supersession sentinel: `upsert` demotes rows that lost an
+    /// identity conflict by zeroing this field (see the demotion loops
+    /// there), which sorts them behind every live row. Never "fix" a zero
+    /// by re-stamping it with a fresh mtime — that resurrects a demoted
+    /// row.
     #[serde(default)]
     pub updated_at_secs: u64,
 }
@@ -195,6 +201,13 @@ pub fn upsert(
     // whether anything actually changed and skip the write when not.
     let mut dirty = false;
 
+    // Demotion, not deletion: rows that conflict with the upserted identity
+    // (same backend session under another wrapper; same wrapper now bound to
+    // another backend session) are kept for history, and `updated_at_secs`
+    // is zeroed as the DELIBERATE supersession sentinel — demoted rows sort
+    // behind every live row in `wrappers_for`. Do not "repair" the zero with
+    // a real mtime; only a fresh upsert of the row's exact identity triple
+    // (the branch below) may make it current again.
     for record in index.wrappers.iter_mut().filter(|record| {
         record.source == source
             && record.backend_session_id == backend_session_id

--- a/src/bin/caller/external_wrapper_index.rs
+++ b/src/bin/caller/external_wrapper_index.rs
@@ -81,6 +81,22 @@ fn note_index_written(home: &Path, index: &ExternalWrapperIndex) {
     );
 }
 
+/// Lifecycle state of a wrapper record. `Superseded` rows lost an identity
+/// conflict (see the demotion loops in [`upsert`]) and are retained for
+/// history; the preference order ([`active_wrapper_in`]) puts `Active` rows
+/// first. Index files written before this field existed — and files
+/// rewritten by older binaries, which drop fields they don't know — carry
+/// no `state`: those rows deserialize as `Active` and their demotions are
+/// still expressed by the legacy `updated_at_secs == 0` sentinel, which the
+/// preference order's timestamp tie-break honors.
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum WrapperState {
+    #[default]
+    Active,
+    Superseded,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExternalWrapperRecord {
     pub source: String,
@@ -94,9 +110,15 @@ pub struct ExternalWrapperRecord {
     /// identity conflict by zeroing this field (see the demotion loops
     /// there), which sorts them behind every live row. Never "fix" a zero
     /// by re-stamping it with a fresh mtime — that resurrects a demoted
-    /// row.
+    /// row. [`WrapperState`] carries the same fact explicitly; the sentinel
+    /// stays written for older readers.
     #[serde(default)]
     pub updated_at_secs: u64,
+    /// Explicit lifecycle state (defaults to `Active` so pre-`state` index
+    /// files parse unchanged). Kept in lockstep with the `updated_at_secs`
+    /// zero-sentinel: demotion sets both, reactivation clears both.
+    #[serde(default)]
+    pub state: WrapperState,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -203,18 +225,21 @@ pub fn upsert(
 
     // Demotion, not deletion: rows that conflict with the upserted identity
     // (same backend session under another wrapper; same wrapper now bound to
-    // another backend session) are kept for history, and `updated_at_secs`
-    // is zeroed as the DELIBERATE supersession sentinel — demoted rows sort
-    // behind every live row in `wrappers_for`. Do not "repair" the zero with
-    // a real mtime; only a fresh upsert of the row's exact identity triple
-    // (the branch below) may make it current again.
+    // another backend session) are kept for history and marked superseded.
+    // `updated_at_secs = 0` is the DELIBERATE legacy supersession sentinel —
+    // it sorts demoted rows behind every live row for readers that predate
+    // the explicit `state` field — so demotion always sets BOTH together.
+    // Do not "repair" the zero with a real mtime; only a fresh upsert of the
+    // row's exact identity triple (the branch below) may make it current
+    // again.
     for record in index.wrappers.iter_mut().filter(|record| {
         record.source == source
             && record.backend_session_id == backend_session_id
             && record.intendant_session_id != stored_intendant_session_id
     }) {
-        dirty |= record.updated_at_secs != 0;
+        dirty |= record.updated_at_secs != 0 || record.state != WrapperState::Superseded;
         record.updated_at_secs = 0;
+        record.state = WrapperState::Superseded;
     }
 
     for record in index.wrappers.iter_mut().filter(|record| {
@@ -222,8 +247,9 @@ pub fn upsert(
             && record.intendant_session_id == stored_intendant_session_id
             && record.backend_session_id != backend_session_id
     }) {
-        dirty |= record.updated_at_secs != 0;
+        dirty |= record.updated_at_secs != 0 || record.state != WrapperState::Superseded;
         record.updated_at_secs = 0;
+        record.state = WrapperState::Superseded;
     }
 
     if let Some(existing) = index.wrappers.iter_mut().find(|record| {
@@ -233,10 +259,15 @@ pub fn upsert(
     }) {
         dirty |= existing.log_path != log_path
             || existing.project_root != project_root
-            || existing.updated_at_secs != updated_at_secs;
+            || existing.updated_at_secs != updated_at_secs
+            || existing.state != WrapperState::Active;
         existing.log_path = log_path;
         existing.project_root = project_root;
+        // Reactivation: an upsert of this exact identity triple makes the
+        // row current again — the mtime refresh already implied that under
+        // the sentinel semantics; `state` follows in lockstep.
         existing.updated_at_secs = updated_at_secs;
+        existing.state = WrapperState::Active;
     } else {
         dirty = true;
         index.wrappers.push(ExternalWrapperRecord {
@@ -246,6 +277,7 @@ pub fn upsert(
             log_path,
             project_root,
             updated_at_secs,
+            state: WrapperState::Active,
         });
     }
 
@@ -255,6 +287,43 @@ pub fn upsert(
     write_index_unlocked(home, &index)?;
     note_index_written(home, &index);
     Ok(())
+}
+
+/// The "active wins" preference order — the single definition every
+/// consumer that picks THE wrapper for a backend session relies on:
+/// explicit `state == Active` first, then the freshest `updated_at_secs`
+/// (which also honors legacy zero-sentinel demotions on rows written
+/// before `state` existed), then the lexically-greatest wrapper session id
+/// as a deterministic tie-break. [`wrappers_for`] / [`wrappers_for_source`]
+/// sort with this, so their first record is the preferred one.
+fn wrapper_preference(a: &ExternalWrapperRecord, b: &ExternalWrapperRecord) -> std::cmp::Ordering {
+    a.state
+        .cmp(&b.state)
+        .then_with(|| b.updated_at_secs.cmp(&a.updated_at_secs))
+        .then_with(|| b.intendant_session_id.cmp(&a.intendant_session_id))
+}
+
+/// The preferred wrapper among `records` under the "active wins" order
+/// ([`wrapper_preference`]). Use this instead of `records[0]` /
+/// `.into_iter().next()` when selecting the wrapper for a backend session
+/// from an already-fetched list, so the selection semantics live here.
+pub fn active_wrapper_in(records: &[ExternalWrapperRecord]) -> Option<&ExternalWrapperRecord> {
+    records.iter().min_by(|a, b| wrapper_preference(a, b))
+}
+
+/// The preferred wrapper record for `(source, backend_session_id)`:
+/// `state == Active` preferred, latest `updated_at_secs` tie-break. Falls
+/// back to the best superseded record when no active row survives
+/// ([`wrappers_for`] drops records whose log dir is gone), so callers keep
+/// resolving historical sessions.
+pub fn active_wrapper_for(
+    home: &Path,
+    source: &str,
+    backend_session_id: &str,
+) -> Option<ExternalWrapperRecord> {
+    wrappers_for(home, source, backend_session_id)
+        .into_iter()
+        .next()
 }
 
 pub fn wrappers_for(
@@ -284,11 +353,7 @@ pub fn wrappers_for(
             })
             .collect()
     });
-    records.sort_by(|a, b| {
-        b.updated_at_secs
-            .cmp(&a.updated_at_secs)
-            .then_with(|| b.intendant_session_id.cmp(&a.intendant_session_id))
-    });
+    records.sort_by(wrapper_preference);
     records
 }
 
@@ -312,11 +377,7 @@ pub fn wrappers_for_source(home: &Path, source: &str) -> Vec<ExternalWrapperReco
             })
             .collect()
     });
-    records.sort_by(|a, b| {
-        b.updated_at_secs
-            .cmp(&a.updated_at_secs)
-            .then_with(|| b.intendant_session_id.cmp(&a.intendant_session_id))
-    });
+    records.sort_by(wrapper_preference);
     records
 }
 
@@ -328,6 +389,7 @@ pub fn record_to_json(record: &ExternalWrapperRecord) -> serde_json::Value {
         "path": record.log_path,
         "project_root": record.project_root,
         "updated_at_secs": record.updated_at_secs,
+        "state": record.state,
     })
 }
 
@@ -428,11 +490,15 @@ mod tests {
             "ec5865e5-a5af-4b8c-81a1-545a3a6f8ba9"
         );
         assert_eq!(wrappers[0].log_path, new_log_dir.to_string_lossy());
+        assert_eq!(wrappers[0].state, WrapperState::Active);
         assert_eq!(
             wrappers[1].intendant_session_id,
             "e9532107-8c7f-4c1f-b88d-410d6d365505"
         );
+        // Demotion sets BOTH the legacy zero-sentinel (for older readers)
+        // and the explicit state.
         assert_eq!(wrappers[1].updated_at_secs, 0);
+        assert_eq!(wrappers[1].state, WrapperState::Superseded);
 
         let source_wrappers = wrappers_for_source(home.path(), "codex");
         assert_eq!(
@@ -441,6 +507,20 @@ mod tests {
                 .map(|record| record.intendant_session_id.as_str()),
             Some("ec5865e5-a5af-4b8c-81a1-545a3a6f8ba9")
         );
+
+        // Pin the on-disk shape: the persisted JSON carries the zero
+        // sentinel AND the explicit state, so both old and new readers see
+        // the demotion.
+        let raw = std::fs::read_to_string(index_path(home.path())).unwrap();
+        let disk: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let demoted = disk["wrappers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["intendant_session_id"] == "e9532107-8c7f-4c1f-b88d-410d6d365505")
+            .expect("demoted row persisted");
+        assert_eq!(demoted["updated_at_secs"], 0);
+        assert_eq!(demoted["state"], "superseded");
     }
 
     #[test]
@@ -479,7 +559,189 @@ mod tests {
         assert_eq!(source_wrappers.len(), 2);
         assert_eq!(source_wrappers[0].backend_session_id, new_backend_id);
         assert_eq!(source_wrappers[0].intendant_session_id, wrapper_id);
+        assert_eq!(source_wrappers[0].state, WrapperState::Active);
         assert_eq!(source_wrappers[1].backend_session_id, old_backend_id);
         assert_eq!(source_wrappers[1].updated_at_secs, 0);
+        assert_eq!(source_wrappers[1].state, WrapperState::Superseded);
+    }
+
+    #[test]
+    fn upsert_reactivates_previously_demoted_row() {
+        let home = tempfile::tempdir().unwrap();
+        let log_dir = home
+            .path()
+            .join(".intendant")
+            .join("logs")
+            .join("7b57f807-59a5-4bc5-9c2f-2f6b7f7f2a10");
+        std::fs::create_dir_all(&log_dir).unwrap();
+        let old_backend_id = "019ea99e-af1d-7c23-a57a-55a89c77f90b";
+        let new_backend_id = "019ea9cc-76d0-7153-94cf-e98948d8ee8a";
+        let wrapper_id = "7b57f807-59a5-4bc5-9c2f-2f6b7f7f2a10";
+
+        upsert(
+            home.path(),
+            "codex",
+            old_backend_id,
+            wrapper_id,
+            &log_dir,
+            None,
+        )
+        .unwrap();
+        upsert(
+            home.path(),
+            "codex",
+            new_backend_id,
+            wrapper_id,
+            &log_dir,
+            None,
+        )
+        .unwrap();
+        // Re-upserting the demoted identity triple makes it current again —
+        // sentinel and state move in lockstep in both directions.
+        upsert(
+            home.path(),
+            "codex",
+            old_backend_id,
+            wrapper_id,
+            &log_dir,
+            None,
+        )
+        .unwrap();
+
+        let source_wrappers = wrappers_for_source(home.path(), "codex");
+        assert_eq!(source_wrappers.len(), 2);
+        assert_eq!(source_wrappers[0].backend_session_id, old_backend_id);
+        assert_eq!(source_wrappers[0].state, WrapperState::Active);
+        assert!(source_wrappers[0].updated_at_secs > 0);
+        assert_eq!(source_wrappers[1].backend_session_id, new_backend_id);
+        assert_eq!(source_wrappers[1].state, WrapperState::Superseded);
+        assert_eq!(source_wrappers[1].updated_at_secs, 0);
+    }
+
+    /// Pre-`state` index files (no `state`, no `rollout_path`) parse with
+    /// every row active — the serde defaults are the compatibility
+    /// contract for existing `external_wrapper_index.json` files.
+    #[test]
+    fn old_format_index_rows_parse_as_active() {
+        let home = tempfile::tempdir().unwrap();
+        let wrapper_id = "0d9f75e1-93a4-49df-8f56-1f2f7ce1a001";
+        let log_dir = home.path().join(".intendant").join("logs").join(wrapper_id);
+        std::fs::create_dir_all(&log_dir).unwrap();
+        let backend_id = "019ea8b9-0000-7000-8000-00000000aa01";
+        let body = serde_json::json!({
+            "version": 1,
+            "wrappers": [{
+                "source": "codex",
+                "backend_session_id": backend_id,
+                "intendant_session_id": wrapper_id,
+                "log_path": log_dir.to_string_lossy(),
+                "updated_at_secs": 1234,
+            }],
+        });
+        let path = index_path(home.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, serde_json::to_string_pretty(&body).unwrap()).unwrap();
+
+        let wrappers = wrappers_for(home.path(), "codex", backend_id);
+        assert_eq!(wrappers.len(), 1);
+        assert_eq!(wrappers[0].state, WrapperState::Active);
+        assert_eq!(wrappers[0].updated_at_secs, 1234);
+    }
+
+    /// "Active wins": explicit state beats a fresher timestamp; among
+    /// active rows the latest `updated_at_secs` wins (beating the lexical
+    /// id tie-break); with no active row the best superseded row is the
+    /// fallback.
+    #[test]
+    fn active_wrapper_prefers_state_active_then_latest_updated() {
+        let home = tempfile::tempdir().unwrap();
+        let backend_id = "019ea8b9-0000-7000-8000-00000000bb02";
+        let logs = home.path().join(".intendant").join("logs");
+        let rows: Vec<serde_json::Value> = [
+            // Superseded row with the freshest timestamp AND the greatest
+            // id: only the explicit state keeps it from winning.
+            (
+                "cccc0000-0000-4000-8000-000000000003",
+                9_999_999_999_u64,
+                "superseded",
+            ),
+            ("bbbb0000-0000-4000-8000-000000000002", 100, "active"),
+            // Lexically smallest id, but the latest active timestamp: wins.
+            ("aaaa0000-0000-4000-8000-000000000001", 200, "active"),
+        ]
+        .into_iter()
+        .map(|(wrapper_id, updated_at_secs, state)| {
+            let log_dir = logs.join(wrapper_id);
+            std::fs::create_dir_all(&log_dir).unwrap();
+            serde_json::json!({
+                "source": "codex",
+                "backend_session_id": backend_id,
+                "intendant_session_id": wrapper_id,
+                "log_path": log_dir.to_string_lossy(),
+                "updated_at_secs": updated_at_secs,
+                "state": state,
+            })
+        })
+        .collect();
+        let path = index_path(home.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            serde_json::json!({ "version": 1, "wrappers": rows }).to_string(),
+        )
+        .unwrap();
+
+        let wrappers = wrappers_for(home.path(), "codex", backend_id);
+        assert_eq!(
+            wrappers
+                .iter()
+                .map(|record| record.intendant_session_id.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "aaaa0000-0000-4000-8000-000000000001",
+                "bbbb0000-0000-4000-8000-000000000002",
+                "cccc0000-0000-4000-8000-000000000003",
+            ]
+        );
+        assert_eq!(
+            active_wrapper_in(&wrappers).map(|record| record.intendant_session_id.as_str()),
+            Some("aaaa0000-0000-4000-8000-000000000001")
+        );
+        assert_eq!(
+            active_wrapper_for(home.path(), "codex", backend_id)
+                .map(|record| record.intendant_session_id),
+            Some("aaaa0000-0000-4000-8000-000000000001".to_string())
+        );
+
+        // All-superseded fallback: the best superseded row still resolves.
+        let backend_two = "019ea8b9-0000-7000-8000-00000000bb03";
+        let rows: Vec<serde_json::Value> = [
+            ("dddd0000-0000-4000-8000-000000000004", 0_u64),
+            ("eeee0000-0000-4000-8000-000000000005", 50),
+        ]
+        .into_iter()
+        .map(|(wrapper_id, updated_at_secs)| {
+            let log_dir = logs.join(wrapper_id);
+            std::fs::create_dir_all(&log_dir).unwrap();
+            serde_json::json!({
+                "source": "codex",
+                "backend_session_id": backend_two,
+                "intendant_session_id": wrapper_id,
+                "log_path": log_dir.to_string_lossy(),
+                "updated_at_secs": updated_at_secs,
+                "state": "superseded",
+            })
+        })
+        .collect();
+        std::fs::write(
+            &path,
+            serde_json::json!({ "version": 1, "wrappers": rows }).to_string(),
+        )
+        .unwrap();
+        assert_eq!(
+            active_wrapper_for(home.path(), "codex", backend_two)
+                .map(|record| record.intendant_session_id),
+            Some("eeee0000-0000-4000-8000-000000000005".to_string())
+        );
     }
 }

--- a/src/bin/caller/external_wrapper_index.rs
+++ b/src/bin/caller/external_wrapper_index.rs
@@ -119,6 +119,14 @@ pub struct ExternalWrapperRecord {
     /// zero-sentinel: demotion sets both, reactivation clears both.
     #[serde(default)]
     pub state: WrapperState,
+    /// Resolved native backend log (e.g. the Codex rollout file) for this
+    /// record's backend session, cached by [`record_rollout_path`] the
+    /// first time a consumer pays for the full scan. Never trust it
+    /// blindly: resolve through [`resolved_rollout_path`], which re-checks
+    /// existence plus a caller-supplied identity predicate — native files
+    /// migrate (Codex `sessions/` → `archived_sessions/`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rollout_path: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -278,6 +286,7 @@ pub fn upsert(
             project_root,
             updated_at_secs,
             state: WrapperState::Active,
+            rollout_path: None,
         });
     }
 
@@ -379,6 +388,100 @@ pub fn wrappers_for_source(home: &Path, source: &str) -> Vec<ExternalWrapperReco
     });
     records.sort_by(wrapper_preference);
     records
+}
+
+/// Remember the resolved native backend log (e.g. a Codex rollout file)
+/// for `(source, backend_session_id)`. The path is stamped on EVERY record
+/// of that backend session — the native file is a property of the backend
+/// session, not of one wrapper — so resolution keeps working after the
+/// current wrapper row is later demoted. No-op when the index has no
+/// record for the session (the caller's scan fallback simply runs again
+/// next time).
+pub fn record_rollout_path(
+    home: &Path,
+    source: &str,
+    backend_session_id: &str,
+    rollout_path: &Path,
+) -> Result<(), String> {
+    let source = crate::session_names::normalize_source(source);
+    let backend_session_id = backend_session_id.trim();
+    let rollout_path = rollout_path.to_string_lossy().to_string();
+    if source.is_empty() || backend_session_id.is_empty() || rollout_path.is_empty() {
+        return Ok(());
+    }
+    let _guard = INDEX_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut index = with_index_unlocked(home, |index| index.clone());
+    let mut dirty = false;
+    for record in index
+        .wrappers
+        .iter_mut()
+        .filter(|record| record.source == source && record.backend_session_id == backend_session_id)
+    {
+        dirty |= record.rollout_path.as_deref() != Some(rollout_path.as_str());
+        record.rollout_path = Some(rollout_path.clone());
+    }
+    if !dirty {
+        return Ok(());
+    }
+    write_index_unlocked(home, &index)?;
+    note_index_written(home, &index);
+    Ok(())
+}
+
+/// The stored native-log path for `(source, backend_session_id)`, verified
+/// before trust: the file must still exist and `verify` (typically "does
+/// its session id still match?") must accept it — otherwise `None`, and
+/// the caller falls back to its scan (native files migrate, e.g. Codex
+/// `sessions/` → `archived_sessions/`) and re-records the fresh location.
+/// Stored candidates are tried in the "active wins" preference order;
+/// `verify` runs outside the index lock (it may read a large file). Stale
+/// paths are not cleared here — the caller's post-scan
+/// [`record_rollout_path`] overwrite is the heal.
+pub fn resolved_rollout_path(
+    home: &Path,
+    source: &str,
+    backend_session_id: &str,
+    verify: impl Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    let source = crate::session_names::normalize_source(source);
+    let backend_session_id = backend_session_id.trim();
+    if source.is_empty() || backend_session_id.is_empty() {
+        return None;
+    }
+    let mut candidates: Vec<String> = {
+        let _guard = INDEX_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        with_index_unlocked(home, |index| {
+            let mut records: Vec<&ExternalWrapperRecord> = index
+                .wrappers
+                .iter()
+                .filter(|record| {
+                    record.source == source
+                        && record.backend_session_id == backend_session_id
+                        && record.rollout_path.is_some()
+                })
+                .collect();
+            records.sort_by(|a, b| wrapper_preference(a, b));
+            records
+                .into_iter()
+                .filter_map(|record| record.rollout_path.clone())
+                .collect()
+        })
+    };
+    let mut seen = std::collections::HashSet::new();
+    candidates.retain(|candidate| seen.insert(candidate.clone()));
+    for candidate in candidates {
+        let path = PathBuf::from(candidate);
+        if path.is_file() && verify(&path) {
+            return Some(path);
+        }
+    }
+    None
 }
 
 pub fn record_to_json(record: &ExternalWrapperRecord) -> serde_json::Value {
@@ -645,6 +748,7 @@ mod tests {
         let wrappers = wrappers_for(home.path(), "codex", backend_id);
         assert_eq!(wrappers.len(), 1);
         assert_eq!(wrappers[0].state, WrapperState::Active);
+        assert_eq!(wrappers[0].rollout_path, None);
         assert_eq!(wrappers[0].updated_at_secs, 1234);
     }
 
@@ -742,6 +846,56 @@ mod tests {
             active_wrapper_for(home.path(), "codex", backend_two)
                 .map(|record| record.intendant_session_id),
             Some("eeee0000-0000-4000-8000-000000000005".to_string())
+        );
+    }
+
+    #[test]
+    fn rollout_path_roundtrip_and_stale_fallback() {
+        let home = tempfile::tempdir().unwrap();
+        let wrapper_id = "5f8a33fe-6cbb-49f0-8d2a-52a4de17c001";
+        let log_dir = home.path().join(".intendant").join("logs").join(wrapper_id);
+        std::fs::create_dir_all(&log_dir).unwrap();
+        let backend_id = "019ea8b9-0000-7000-8000-00000000cc01";
+        upsert(home.path(), "codex", backend_id, wrapper_id, &log_dir, None).unwrap();
+
+        let rollout = home.path().join("rollouts").join("r.jsonl");
+        std::fs::create_dir_all(rollout.parent().unwrap()).unwrap();
+        std::fs::write(&rollout, "{\"type\":\"session_meta\"}\n").unwrap();
+
+        // Unknown backend session: the setter no-ops, the resolver stays
+        // empty — callers just keep scanning.
+        let unknown_backend = "019ea8b9-ffff-7000-8000-00000000cc99";
+        record_rollout_path(home.path(), "codex", unknown_backend, &rollout).unwrap();
+        assert_eq!(
+            resolved_rollout_path(home.path(), "codex", unknown_backend, |_| true),
+            None
+        );
+
+        // Roundtrip.
+        record_rollout_path(home.path(), "codex", backend_id, &rollout).unwrap();
+        assert_eq!(
+            resolved_rollout_path(home.path(), "codex", backend_id, |_| true),
+            Some(rollout.clone())
+        );
+        // The caller's identity re-verification is a veto.
+        assert_eq!(
+            resolved_rollout_path(home.path(), "codex", backend_id, |_| false),
+            None
+        );
+        // The stored path is persisted, not cache-only.
+        let raw = std::fs::read_to_string(index_path(home.path())).unwrap();
+        let disk: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            disk["wrappers"][0]["rollout_path"],
+            serde_json::Value::String(rollout.to_string_lossy().to_string())
+        );
+
+        // Stale path (file deleted): the resolver declines even with a
+        // permissive verify, so callers fall back to the scan.
+        std::fs::remove_file(&rollout).unwrap();
+        assert_eq!(
+            resolved_rollout_path(home.path(), "codex", backend_id, |_| true),
+            None
         );
     }
 }

--- a/src/bin/caller/mcp/tool_params.rs
+++ b/src/bin/caller/mcp/tool_params.rs
@@ -850,9 +850,7 @@ pub(crate) fn persisted_log_dir_for_session_in_home(
     ["codex", "claude-code", "gemini"]
         .into_iter()
         .find_map(|source| {
-            crate::external_wrapper_index::wrappers_for(home, source, session_id)
-                .into_iter()
-                .next()
+            crate::external_wrapper_index::active_wrapper_for(home, source, session_id)
                 .map(|record| std::path::PathBuf::from(record.log_path))
         })
 }

--- a/src/bin/caller/web_gateway/session_catalog/external_rows.rs
+++ b/src/bin/caller/web_gateway/session_catalog/external_rows.rs
@@ -298,13 +298,13 @@ pub(crate) fn apply_external_wrapper_index_to_session(
         return;
     };
     let wrappers = crate::external_wrapper_index::wrappers_for(home, &source, &backend_session_id);
-    if wrappers.is_empty() {
+    // "Active wins" selection lives in the wrapper index, not here.
+    let Some(latest) = crate::external_wrapper_index::active_wrapper_in(&wrappers) else {
         return;
-    }
+    };
     let Some(obj) = session.as_object_mut() else {
         return;
     };
-    let latest = &wrappers[0];
     obj.insert(
         "intendant_session_id".to_string(),
         serde_json::Value::String(latest.intendant_session_id.clone()),


### PR DESCRIPTION
## What

Message-search lane F5 (`~/message-search-plan.md` §3): make the external wrapper index's supersession explicit and stop paying a full `$CODEX_HOME` scan on every wrapper→rollout join. Three commits:

1. **Document the deliberate `updated_at_secs == 0` supersession sentinel** where it is set (comment-only; the sentinel semantics are unchanged and stay written for older readers).
2. **Explicit `state: active | superseded` on `ExternalWrapperRecord`** — serde-default `active`, so existing index files (and files rewritten by older binaries, which drop unknown fields) parse unchanged. Demotion sets state and the zero-sentinel together; re-upserting a demoted identity triple reactivates both. "Active wins, latest `updated_at_secs` tie-break" becomes one shared preference order: `wrappers_for`/`wrappers_for_source` sort with it, and `active_wrapper_for`/`active_wrapper_in` expose the selection. Adopted at the two call sites that picked wrappers ad hoc (session-catalog row annotation's `&wrappers[0]`, MCP persisted-log-dir resolver's `.next()`); the replay/candidate-dir consumers (transcripts.rs, detail_search.rs, anchors.rs) deliberately collect every wrapper dir and are left as-is. `record_to_json` now carries `state`, so `intendant_wrappers` rows are self-describing.
3. **`rollout_path: Option<String>` + `record_rollout_path` / `resolved_rollout_path`** — the resolved native rollout location is remembered on every record of the backend session and trusted only after re-verification (file exists + caller's session-id predicate). `find_codex_session_file_for_main` splits into the `CODEX_HOME` env edge and roots-as-parameters `find_codex_session_file_in`, which consults the stored path before scanning and re-records after a successful scan (rollouts migrate `sessions/` → `archived_sessions/`).

## Why

Every wrapper→rollout join re-resolved the native file by recursively scanning all of `$CODEX_HOME`, opening every rollout to match `session_meta.payload.id` (a 14 GB corpus on the dev box). And "which wrapper is current" was implicit in a sort order that consumers re-derived per call site — the message-search program (supervised dedup: "active wrapper wins") needs it explicit and in one place.

## Tests

Inline hermetic tests (tempdir homes threaded through the existing `home: &Path` seams; no env mutation): old-format JSON parses as active; demotion writes sentinel + state together (pinned on the persisted JSON); preference order beats a fresher superseded timestamp, picks latest among actives, all-superseded fallback; reactivation restores both fields; rollout roundtrip, verify-veto, deleted-file fallback, unknown-session no-op; codex_history join reuses the stored path, survives the `sessions/` → `archived_sessions/` migration, and short-circuits the scan.

Ran: focused suites under plain `cargo test --bin intendant` (10/10 pass), full `CARGO_PROFILE_DEV_DEBUG=0 cargo nextest run --bins`, and CI-exact `cargo clippy --workspace --locked -- -D warnings`.
