### PR TITLE
codex parsing: consolidate duplicate parsers onto shared modules (message-search F3 phase 2)

### DIFF
--- a/src/bin/caller/codex_history.rs
+++ b/src/bin/caller/codex_history.rs
@@ -2,9 +2,15 @@
 //! files under `$CODEX_HOME` and reconstructing per-user-turn revision
 //! state from recorded events.
 
-use crate::json_string_field;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+
+// Consolidated (message-search F3 phase 2): the rollout-file shapes this
+// module used to duplicate live in `external_agent`; the local copies had
+// already drifted (whole-file reads vs streaming, a stale injection list).
+// `codex_message_content_text` died outright — its one caller now goes
+// through the shared `codex_payload_text` shape.
+pub(crate) use crate::external_agent::codex::rollout::codex_session_file_id;
 
 pub(crate) fn collect_jsonl_files(root: &Path, out: &mut Vec<PathBuf>) {
     let Ok(entries) = std::fs::read_dir(root) else {
@@ -23,25 +29,6 @@ pub(crate) fn collect_jsonl_files(root: &Path, out: &mut Vec<PathBuf>) {
             out.push(path);
         }
     }
-}
-
-pub(crate) fn codex_session_file_id(path: &Path) -> Option<String> {
-    let contents = std::fs::read_to_string(path).ok()?;
-    for line in contents.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let Ok(obj) = serde_json::from_str::<serde_json::Value>(trimmed) else {
-            continue;
-        };
-        if obj.get("type").and_then(|v| v.as_str()) == Some("session_meta") {
-            return obj
-                .get("payload")
-                .and_then(|payload| json_string_field(payload, "id"));
-        }
-    }
-    None
 }
 
 pub(crate) fn find_codex_session_file_for_main(home: &Path, session_id: &str) -> Option<PathBuf> {
@@ -75,49 +62,36 @@ pub(crate) fn find_codex_session_file_in(
     let mut files = Vec::new();
     collect_jsonl_files(&codex_root.join("sessions"), &mut files);
     collect_jsonl_files(&codex_root.join("archived_sessions"), &mut files);
+    // Codex embeds the session id in rollout filenames — try the cheap
+    // name match before opening every file (ported from the catalog's
+    // finder during consolidation; the id check stays authoritative).
     let found = files
-        .into_iter()
-        .find(|path| codex_session_file_id(path).as_deref() == Some(session_id))?;
+        .iter()
+        .find(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains(session_id))
+                && codex_session_file_id(path).as_deref() == Some(session_id)
+        })
+        .cloned()
+        .or_else(|| {
+            files
+                .into_iter()
+                .find(|path| codex_session_file_id(path).as_deref() == Some(session_id))
+        })?;
     let _ = crate::external_wrapper_index::record_rollout_path(home, "codex", session_id, &found);
     Some(found)
 }
 
-pub(crate) fn codex_message_content_text(content: &serde_json::Value) -> Option<String> {
-    match content {
-        serde_json::Value::String(s) => Some(s.clone()),
-        serde_json::Value::Array(items) => {
-            let parts: Vec<String> = items
-                .iter()
-                .filter_map(|item| {
-                    item.get("text")
-                        .and_then(|v| v.as_str())
-                        .or_else(|| item.get("content").and_then(|v| v.as_str()))
-                        .map(str::to_string)
-                })
-                .collect();
-            if parts.is_empty() {
-                None
-            } else {
-                Some(parts.join("\n"))
-            }
-        }
-        _ => None,
-    }
-}
-
+/// A genuine user message from a `response_item` payload: the shared
+/// `message` shape, filtered to `role == "user"` and stripped of
+/// harness-injected text no human typed.
 pub(crate) fn codex_payload_user_text(payload: &serde_json::Value) -> Option<String> {
-    if payload.get("type").and_then(|v| v.as_str()) != Some("message") {
+    let (role, text) = crate::external_agent::codex::rollout::codex_payload_text(payload)?;
+    if role != "user" || is_codex_injected_user_text_for_main(&text) {
         return None;
     }
-    if payload.get("role").and_then(|v| v.as_str()) != Some("user") {
-        return None;
-    }
-    let text = codex_message_content_text(payload.get("content")?)?;
-    if is_codex_injected_user_text_for_main(&text) {
-        None
-    } else {
-        Some(text)
-    }
+    Some(text)
 }
 
 #[derive(Debug, Clone, Default)]
@@ -211,9 +185,9 @@ impl UserTurnRevisionState {
 }
 
 pub(crate) fn is_codex_injected_user_text_for_main(text: &str) -> bool {
-    // Delegates to the canonical predicate — this was a byte-for-byte copy
-    // that had already drifted from the session-catalog vocabulary.
-    crate::web_gateway::is_injected_external_user_text(text)
+    // Delegates to the canonical predicate at its post-F3 home (this was a
+    // byte-for-byte copy that had already drifted once before).
+    crate::external_agent::transcript_text::is_injected_external_user_text(text)
 }
 
 pub(crate) fn codex_user_turn_state_from_history(

--- a/src/bin/caller/external_agent/codex/rollout.rs
+++ b/src/bin/caller/external_agent/codex/rollout.rs
@@ -202,3 +202,35 @@ pub(crate) fn codex_thread_rollback_anchor(
 pub(crate) fn is_codex_injected_user_text(text: &str) -> bool {
     is_injected_external_user_text(text)
 }
+
+/// The session id a rollout file records (`session_meta.payload.id`),
+/// streaming line-by-line and stopping at the first `session_meta` — the
+/// finder opens EVERY rollout under a Codex home when its caches miss, so
+/// this must not read whole files. Consolidated from the two prior copies
+/// (`codex_history.rs` read the whole file; the catalog's streamed).
+pub(crate) fn codex_session_file_id(path: &std::path::Path) -> Option<String> {
+    use std::io::BufRead;
+    let file = std::fs::File::open(path).ok()?;
+    let mut reader = std::io::BufReader::new(file);
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        let bytes = reader.read_line(&mut line).ok()?;
+        if bytes == 0 {
+            return None;
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(obj) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        if obj.get("type").and_then(|v| v.as_str()) == Some("session_meta") {
+            return obj
+                .get("payload")
+                .and_then(|payload| value_str(payload, "id"));
+        }
+    }
+}

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -272,10 +272,6 @@ pub(crate) fn emit_external_session_loop_error(
     bus.send(AppEvent::LoopError(message));
 }
 
-pub(crate) fn json_string_field(v: &serde_json::Value, key: &str) -> Option<String> {
-    v.get(key).and_then(|x| x.as_str()).map(str::to_string)
-}
-
 /// Resolve external agent backend from an explicit override, falling back to
 /// the project config's `agent.default_backend` setting.
 pub(crate) fn resolve_agent_backend_from_config(

--- a/src/bin/caller/web_gateway/session_catalog/backend_lists.rs
+++ b/src/bin/caller/web_gateway/session_catalog/backend_lists.rs
@@ -926,54 +926,15 @@ pub(crate) fn list_gemini_sessions_with_limit(
     rows
 }
 
-pub(crate) fn codex_session_file_id(path: &Path) -> Option<String> {
-    let file = std::fs::File::open(path).ok()?;
-    let mut reader = std::io::BufReader::new(file);
-    let mut line = String::new();
-
-    loop {
-        line.clear();
-        let bytes = reader.read_line(&mut line).ok()?;
-        if bytes == 0 {
-            return None;
-        }
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let Ok(obj) = serde_json::from_str::<serde_json::Value>(trimmed) else {
-            continue;
-        };
-        if obj.get("type").and_then(|v| v.as_str()) == Some("session_meta") {
-            return obj
-                .get("payload")
-                .and_then(|payload| value_str(payload, "id"));
-        }
-    }
-}
+// Consolidated (message-search F3 phase 2): the streaming id reader moved
+// to `external_agent::codex::rollout` (this file's copy was the canonical
+// body), and the finder delegates to `codex_history`'s engine — which
+// ported this file's filename fast path and adds the wrapper-index
+// stored-path cache, so catalog lookups stop rescanning migrated homes.
+pub(crate) use crate::external_agent::codex::rollout::codex_session_file_id;
 
 pub(crate) fn find_codex_session_file(home: &Path, session_id: &str) -> Option<PathBuf> {
-    let codex = codex_dir(home);
-    let mut files = Vec::new();
-    collect_files(&codex.join("sessions"), ".jsonl", &mut files);
-    collect_files(&codex.join("archived_sessions"), ".jsonl", &mut files);
-
-    if let Some(path) = files
-        .iter()
-        .find(|path| {
-            path.file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.contains(session_id))
-                && codex_session_file_id(path).as_deref() == Some(session_id)
-        })
-        .cloned()
-    {
-        return Some(path);
-    }
-
-    files
-        .into_iter()
-        .find(|path| codex_session_file_id(path).as_deref() == Some(session_id))
+    crate::codex_history::find_codex_session_file_in(&codex_dir(home), home, session_id)
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
Phase 2 of F3 (message-search plan §3): the consolidation commits that phase 1's pure-moves set up. One streaming `codex_session_file_id` (the two prior copies had drifted — whole-file read vs streaming), one rollout finder engine combining the catalog's filename fast path with F5's stored-path cache (catalog lookups gain the cache — deliberate improvement), `codex_payload_user_text` rebuilt on the shared shape, and two dead duplicates deleted outright (`codex_message_content_text`, `json_string_field` — the compiler proved both orphaned).

Deferred to the B-wave: the typed effective-history reducer API (the `transcripts.rs` arm keeps its catalog types until the shard store becomes its second consumer).

Tests: full `nextest --bins` 3076/3076; codex-filtered 342/342; workspace clippy `-D warnings` clean (RUSTC workaround).