### PR TITLE
message_search: shard store — records, cursors, generations, manifest (B1)

### DIFF
--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -47,6 +47,7 @@ mod live_audio;
 mod live_audio_types;
 mod mcp;
 mod mcp_client;
+mod message_search;
 mod peer;
 mod peer_file_transfer;
 pub(crate) use intendant_platform::platform;
@@ -3458,6 +3459,9 @@ async fn main() -> Result<(), CallerError> {
     // anything can spawn an external agent; the timer keeps expiry
     // deleting materializations even when the lease store sees no calls.
     credential_leases::startup_materialization_sweep();
+    // Message-search retention: expired shards die at boot (plan §6 —
+    // the store must not accumulate while no extractor runs).
+    message_search::startup_gc();
     tokio::spawn(async {
         let mut ticker = tokio::time::interval(Duration::from_secs(60));
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);

--- a/src/bin/caller/message_search/cursor.rs
+++ b/src/bin/caller/message_search/cursor.rs
@@ -1,0 +1,240 @@
+//! Per-source-file read cursors (message-search plan §6): enough identity
+//! to distinguish "bytes were appended" (incremental read past the saved
+//! offset) from "the file was rewritten or replaced" (rebuild that
+//! session's shard). `FileIdentity` alone is degenerate on some Windows
+//! filesystems, so the cursor folds len + timestamps exactly like the
+//! catalog's cache keys, plus content hashes that catch in-place prefix
+//! rewrites identity+len+mtime can miss (mtime granularity,
+//! mtime-preserving writers).
+
+use crate::platform::FileIdentity;
+use serde::{Deserialize, Serialize};
+use std::io::{BufRead, Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+/// Bytes hashed from the file head for the prefix fingerprint.
+const PREFIX_HASH_BYTES: usize = 4096;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct SourceCursor {
+    pub path: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<FileIdentity>,
+    pub len: u64,
+    pub mtime_ms: i64,
+    /// Offset just past the last COMPLETE line consumed — a partial
+    /// trailing line (no newline yet) stays unread until it completes.
+    pub last_complete_line_offset: u64,
+    pub prefix_hash16: String,
+    pub parser_version: u32,
+}
+
+/// What a fresh look at the file says relative to a saved cursor.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum CursorCheck {
+    /// Nothing new past the cursor.
+    Unchanged,
+    /// Bytes were appended; read from `last_complete_line_offset`.
+    Appended,
+    /// Identity/len/prefix changed (replacement, truncation, in-place
+    /// rewrite) or the parser version moved: rebuild from scratch.
+    Rewritten,
+    /// The file is gone (source GC / lease cleanup); keep the shard until
+    /// window expiry with `source_gone` coverage (plan §6).
+    Gone,
+}
+
+fn file_mtime_ms(metadata: &std::fs::Metadata) -> i64 {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn prefix_hash16(path: &Path) -> Option<String> {
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut buf = vec![0u8; PREFIX_HASH_BYTES];
+    let mut read = 0usize;
+    loop {
+        match file.read(&mut buf[read..]) {
+            Ok(0) => break,
+            Ok(n) => read += n,
+            Err(_) => return None,
+        }
+        if read == buf.len() {
+            break;
+        }
+    }
+    buf.truncate(read);
+    Some(hash16(&buf))
+}
+
+fn hash16(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(16);
+    for byte in digest.iter().take(8) {
+        out.push_str(&format!("{:02x}", byte));
+    }
+    out
+}
+
+impl SourceCursor {
+    /// Cursor for a file we have consumed through `last_complete_line_offset`.
+    pub(crate) fn capture(path: &Path, last_complete_line_offset: u64) -> Option<Self> {
+        let metadata = std::fs::metadata(path).ok()?;
+        Some(Self {
+            path: path.to_path_buf(),
+            identity: FileIdentity::from_path(path).ok(),
+            len: metadata.len(),
+            mtime_ms: file_mtime_ms(&metadata),
+            last_complete_line_offset,
+            prefix_hash16: prefix_hash16(path)?,
+            parser_version: super::record::PARSER_VERSION,
+        })
+    }
+
+    /// Compare the file on disk against this cursor.
+    pub(crate) fn check(&self) -> CursorCheck {
+        let Ok(metadata) = std::fs::metadata(&self.path) else {
+            return CursorCheck::Gone;
+        };
+        if self.parser_version != super::record::PARSER_VERSION {
+            return CursorCheck::Rewritten;
+        }
+        if metadata.len() < self.len {
+            return CursorCheck::Rewritten;
+        }
+        if let (Some(saved), Ok(current)) = (self.identity, FileIdentity::from_path(&self.path)) {
+            if saved.is_reliable() && current.is_reliable() && saved != current {
+                return CursorCheck::Rewritten;
+            }
+        }
+        match prefix_hash16(&self.path) {
+            Some(hash) => {
+                // The saved and fresh hashes cover the same byte window
+                // only when the saved file already filled the window, or
+                // the length hasn't changed — an append to a small file
+                // widens the hashed window and is NOT comparable (and is
+                // exactly the benign case the offset check below handles).
+                let comparable =
+                    self.len as usize >= PREFIX_HASH_BYTES || metadata.len() == self.len;
+                if comparable && hash != self.prefix_hash16 {
+                    return CursorCheck::Rewritten;
+                }
+            }
+            None => return CursorCheck::Gone,
+        }
+        if metadata.len() > self.last_complete_line_offset {
+            CursorCheck::Appended
+        } else {
+            CursorCheck::Unchanged
+        }
+    }
+}
+
+/// Read complete lines from `path` starting at `offset`; returns the
+/// lines and the offset just past the last complete line (a trailing
+/// partial line is left for the next pass — plan §6).
+pub(crate) fn read_complete_lines_from(
+    path: &Path,
+    offset: u64,
+) -> std::io::Result<(Vec<String>, u64)> {
+    let mut file = std::fs::File::open(path)?;
+    file.seek(SeekFrom::Start(offset))?;
+    let mut reader = std::io::BufReader::new(file);
+    let mut lines = Vec::new();
+    let mut consumed = offset;
+    let mut buf = Vec::new();
+    loop {
+        buf.clear();
+        let bytes = reader.read_until(b'\n', &mut buf)?;
+        if bytes == 0 {
+            break;
+        }
+        if buf.last() != Some(&b'\n') {
+            // Partial trailing line: wait for it to complete.
+            break;
+        }
+        consumed += bytes as u64;
+        let line = String::from_utf8_lossy(&buf);
+        let trimmed = line.trim_end_matches(['\n', '\r']);
+        lines.push(trimmed.to_string());
+    }
+    Ok((lines, consumed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn append_and_partial_line_handling() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.jsonl");
+        std::fs::write(&path, "one\ntwo\npar").unwrap();
+
+        let (lines, consumed) = read_complete_lines_from(&path, 0).unwrap();
+        assert_eq!(lines, vec!["one", "two"]);
+        assert_eq!(consumed, 8);
+
+        let cursor = SourceCursor::capture(&path, consumed).unwrap();
+        assert_eq!(cursor.check(), CursorCheck::Appended); // partial bytes exist
+
+        // Completing the line + appending another becomes readable.
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        file.write_all(b"tial\nthree\n").unwrap();
+        drop(file);
+        let (lines, consumed) = read_complete_lines_from(&path, consumed).unwrap();
+        assert_eq!(lines, vec!["partial", "three"]);
+        let cursor = SourceCursor::capture(&path, consumed).unwrap();
+        assert_eq!(cursor.check(), CursorCheck::Unchanged);
+    }
+
+    #[test]
+    fn truncation_and_replacement_read_as_rewritten() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.jsonl");
+        std::fs::write(&path, "aaaa\nbbbb\n").unwrap();
+        let cursor = SourceCursor::capture(&path, 10).unwrap();
+
+        std::fs::write(&path, "cc\n").unwrap(); // truncated + different bytes
+        assert_eq!(cursor.check(), CursorCheck::Rewritten);
+    }
+
+    #[test]
+    fn same_length_prefix_rewrite_is_detected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.jsonl");
+        std::fs::write(&path, "aaaa\nbbbb\n").unwrap();
+        let cursor = SourceCursor::capture(&path, 10).unwrap();
+        std::fs::write(&path, "zzzz\nbbbb\n").unwrap(); // same len, new head
+        assert_eq!(cursor.check(), CursorCheck::Rewritten);
+    }
+
+    #[test]
+    fn missing_file_reads_as_gone() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.jsonl");
+        std::fs::write(&path, "x\n").unwrap();
+        let cursor = SourceCursor::capture(&path, 2).unwrap();
+        std::fs::remove_file(&path).unwrap();
+        assert_eq!(cursor.check(), CursorCheck::Gone);
+    }
+
+    #[test]
+    fn parser_version_bump_forces_rebuild() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.jsonl");
+        std::fs::write(&path, "x\n").unwrap();
+        let mut cursor = SourceCursor::capture(&path, 2).unwrap();
+        cursor.parser_version = 0;
+        assert_eq!(cursor.check(), CursorCheck::Rewritten);
+    }
+}

--- a/src/bin/caller/message_search/mod.rs
+++ b/src/bin/caller/message_search/mod.rs
@@ -1,0 +1,53 @@
+//! Message-search shard store (B1 of the message-search program; plan
+//! `~/message-search-plan.md` §5–6, docs/src/session-logging.md for the
+//! event lane it consumes).
+//!
+//! Layering: extractors (B2–B4) derive [`MessageRecord`]s +
+//! [`SupersessionMark`]s per session from the canonical sources and
+//! publish them here; the store owns durability (immutable content-named
+//! generations behind one manifest), multi-daemon coordination (advisory
+//! lock + watermark rejection — see `store.rs`), retention, and stable
+//! snapshots. Matching, normalization, and the byte-budget arena are the
+//! query side's concern (C1) and deliberately absent here. Active vs
+//! superseded is ALWAYS derived at read time ([`derive_active`]) — never
+//! stored — because Codex restores can reactivate messages (plan D2).
+
+// The store's API surface (types AND the re-exports below) is a
+// deliberately parked seed until its consumers land (B2–B4 extractors,
+// C1 query side — the very next program units); `startup_gc` is the one
+// production consumer wired today. Remove both allows as the extractors
+// adopt the API.
+#![allow(dead_code, unused_imports)]
+
+mod cursor;
+mod record;
+mod store;
+
+pub(crate) use cursor::{read_complete_lines_from, CursorCheck, SourceCursor};
+pub(crate) use record::{
+    cap_text, derive_active, Locator, MessageRecord, Role, Source, SupersessionMark,
+    MESSAGE_TEXT_CAP_BYTES, PARSER_VERSION,
+};
+pub(crate) use store::{PublishOutcome, SessionShard, Snapshot, Store, RETENTION_MS};
+
+/// Boot-time retention GC over the production store root (plan §6):
+/// expired shards and tombstones must not accumulate while no extractor
+/// or drainer is running yet.
+pub(crate) fn startup_gc() {
+    let root = Store::default_root();
+    if !root.exists() {
+        return;
+    }
+    match Store::open(&root) {
+        Ok(store) => {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0);
+            if let Err(err) = store.gc(now) {
+                eprintln!("[message-search] startup gc failed: {err}");
+            }
+        }
+        Err(err) => eprintln!("[message-search] store open failed: {err}"),
+    }
+}

--- a/src/bin/caller/message_search/record.rs
+++ b/src/bin/caller/message_search/record.rs
@@ -1,0 +1,355 @@
+//! The shared `MessageRecord` every extractor produces and the store
+//! persists (message-search plan §5). Records carry ORIGINAL text —
+//! normalization and matching live in the query arena (C1) — and never a
+//! stored active/superseded flag: supersession is DERIVED by replaying
+//! [`SupersessionMark`]s, because a Codex same-thread restore can
+//! reactivate previously superseded messages (plan D2).
+
+use serde::{Deserialize, Serialize};
+
+pub(crate) const PARSER_VERSION: u32 = 1;
+
+/// Per-message text cap (plan §5): a pasted blob must not dominate a
+/// shard. S0a measured the current corpus max at 126 KiB, so the cap is
+/// currently free; exceeding it sets `truncated` and counts toward the
+/// coverage report's omitted bytes.
+pub(crate) const MESSAGE_TEXT_CAP_BYTES: usize = 256 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Source {
+    Intendant,
+    Codex,
+    ClaudeCode,
+}
+
+impl Source {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Source::Intendant => "intendant",
+            Source::Codex => "codex",
+            Source::ClaudeCode => "claude-code",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Role {
+    User,
+    Assistant,
+}
+
+/// Where a hit lives in its source — opaque to clients, resolvable by the
+/// session-detail `locate` read (plan §7). Versioned by variant: new
+/// locator kinds are additive, and resolution returns a typed
+/// stale/unavailable result rather than guessing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum Locator {
+    /// New-era native message: the `conversation_message` event's id.
+    NativeMessageId { message_id: String },
+    /// Legacy native user-side event: position + content hash (the event
+    /// stream is append-only, so line identity is stable; the hash
+    /// detects parser-era drift).
+    NativeEvent {
+        line_no: u64,
+        content_hash16: String,
+    },
+    /// Legacy native assistant span in a `turns/*_model.txt` sidecar.
+    NativeSidecarSpan {
+        file: String,
+        offset: u64,
+        len: u64,
+        content_hash16: String,
+    },
+    /// External record with a native id (Claude record `uuid`, Codex
+    /// `response_item` id).
+    ExternalRecordId { record_id: String },
+    /// External record without a native id: file line + content hash;
+    /// `generation` pins which rewrite of the source produced it (Codex
+    /// same-thread restore rewrites the rollout).
+    ExternalLine {
+        generation: u32,
+        line_no: u64,
+        content_hash16: String,
+    },
+}
+
+/// Which branch/generation of the source history a record belongs to.
+/// `0` is the initial generation; Codex restores bump it. The reader
+/// derives per-record active status from marks + membership; membership
+/// alone never implies superseded.
+pub(crate) type Generation = u32;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct MessageRecord {
+    pub source: Source,
+    pub session_id: String,
+    pub role: Role,
+    /// Epoch ms; the retention window keys on this.
+    pub ts_ms: i64,
+    /// ORIGINAL text (possibly capped at [`MESSAGE_TEXT_CAP_BYTES`]).
+    pub text: String,
+    pub locator: Locator,
+    /// Native `Message.seq` (intendant), used by rewind-cut marks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seq: Option<u64>,
+    /// Codex user-turn ordinal, used by turn-count rollback marks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_turn: Option<u32>,
+    /// Source item id (Codex response_item), used by item-anchor marks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub subagent: bool,
+    #[serde(default)]
+    pub generation: Generation,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
+}
+
+/// Supersession inputs, replayed IN ORDER by the reader to derive each
+/// record's active status (plan §5: derived, recomputable, never an
+/// irreversible stamp).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum SupersessionMark {
+    /// Native rewind: records with `seq > cut_after_seq` are superseded.
+    SeqCut { cut_after_seq: u64, at_ms: i64 },
+    /// Codex `thread_rolled_back { num_turns }`: the last N still-active
+    /// user turns (and their following assistant records) supersede.
+    TurnCount { num_turns: u32, at_ms: i64 },
+    /// Codex item-anchor rewind: everything after the anchored item (or
+    /// from it, when `position == "before"`) supersedes.
+    ItemAnchor {
+        item_id: String,
+        /// `"before"` or `"after"` (the anchor's own fate).
+        position: String,
+        at_ms: i64,
+    },
+    /// Codex same-thread restore: a new generation becomes active.
+    /// Records of LATER generations supersede (they belong to a branch
+    /// that was rolled away); records of `active_generation` reactivate.
+    GenerationRestore {
+        active_generation: Generation,
+        at_ms: i64,
+    },
+}
+
+/// Replay `marks` over `records` (both in source order) and return the
+/// derived active flags, index-aligned with `records`.
+///
+/// The model is deliberately simple and total: marks apply to the records
+/// that precede them in source order; a later `GenerationRestore` can
+/// reactivate records a `TurnCount`/`ItemAnchor` superseded only if it
+/// restores their generation (Codex re-writes restored turns into the new
+/// generation, so reactivation-by-rewrite appears as fresh records; the
+/// mark exists so records of abandoned generations stop reading active).
+pub(crate) fn derive_active(records: &[MessageRecord], marks: &[SupersessionMark]) -> Vec<bool> {
+    let mut active: Vec<bool> = records.iter().map(|_| true).collect();
+    let mut active_generation: Generation = records
+        .iter()
+        .map(|record| record.generation)
+        .max()
+        .unwrap_or(0);
+    for mark in marks {
+        match mark {
+            SupersessionMark::SeqCut { cut_after_seq, .. } => {
+                for (index, record) in records.iter().enumerate() {
+                    if record.seq.is_some_and(|seq| seq > *cut_after_seq) {
+                        active[index] = false;
+                    }
+                }
+            }
+            SupersessionMark::TurnCount { num_turns, .. } => {
+                // Collect still-active user turns in order, supersede the
+                // trailing `num_turns` of them (bounded by what exists —
+                // corrupt/huge counts must not loop; plan §5).
+                let mut turns: Vec<u32> = Vec::new();
+                for (index, record) in records.iter().enumerate() {
+                    if active[index] {
+                        if let Some(turn) = record.user_turn {
+                            if !turns.contains(&turn) {
+                                turns.push(turn);
+                            }
+                        }
+                    }
+                }
+                let cut = turns.len().saturating_sub(*num_turns as usize);
+                let superseded: &[u32] = &turns[cut..];
+                for (index, record) in records.iter().enumerate() {
+                    if record
+                        .user_turn
+                        .is_some_and(|turn| superseded.contains(&turn))
+                    {
+                        active[index] = false;
+                    }
+                }
+            }
+            SupersessionMark::ItemAnchor {
+                item_id, position, ..
+            } => {
+                if let Some(anchor_index) = records
+                    .iter()
+                    .position(|record| record.item_id.as_deref() == Some(item_id.as_str()))
+                {
+                    let start = if position == "before" {
+                        anchor_index
+                    } else {
+                        anchor_index + 1
+                    };
+                    for flag in active.iter_mut().skip(start) {
+                        *flag = false;
+                    }
+                }
+            }
+            SupersessionMark::GenerationRestore {
+                active_generation: restored,
+                ..
+            } => {
+                active_generation = *restored;
+            }
+        }
+    }
+    for (index, record) in records.iter().enumerate() {
+        if record.generation > active_generation {
+            active[index] = false;
+        }
+    }
+    active
+}
+
+/// Cap `text` at [`MESSAGE_TEXT_CAP_BYTES`] on a char boundary; returns
+/// the (possibly trimmed) text and whether it was truncated.
+pub(crate) fn cap_text(text: String) -> (String, bool) {
+    if text.len() <= MESSAGE_TEXT_CAP_BYTES {
+        return (text, false);
+    }
+    let mut cut = MESSAGE_TEXT_CAP_BYTES;
+    while cut > 0 && !text.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let mut text = text;
+    text.truncate(cut);
+    (text, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(seq: u64, generation: Generation) -> MessageRecord {
+        MessageRecord {
+            source: Source::Intendant,
+            session_id: "s".into(),
+            role: Role::User,
+            ts_ms: 1,
+            text: format!("m{seq}"),
+            locator: Locator::NativeMessageId {
+                message_id: format!("id-{seq}"),
+            },
+            seq: Some(seq),
+            user_turn: None,
+            item_id: None,
+            subagent: false,
+            generation,
+            truncated: false,
+        }
+    }
+
+    #[test]
+    fn seq_cut_supersedes_later_messages_only() {
+        let records = vec![record(1, 0), record(2, 0), record(3, 0)];
+        let marks = vec![SupersessionMark::SeqCut {
+            cut_after_seq: 2,
+            at_ms: 10,
+        }];
+        assert_eq!(derive_active(&records, &marks), vec![true, true, false]);
+    }
+
+    #[test]
+    fn turn_count_is_bounded_by_existing_turns() {
+        let mut records: Vec<MessageRecord> = (1..=3)
+            .map(|turn| {
+                let mut r = record(turn as u64, 0);
+                r.user_turn = Some(turn);
+                r
+            })
+            .collect();
+        records.push(record(9, 0)); // no user_turn — untouched
+        let marks = vec![SupersessionMark::TurnCount {
+            num_turns: u32::MAX, // corrupt/huge count must not panic or loop
+            at_ms: 10,
+        }];
+        assert_eq!(
+            derive_active(&records, &marks),
+            vec![false, false, false, true]
+        );
+    }
+
+    #[test]
+    fn item_anchor_supersedes_the_tail() {
+        let mut a = record(1, 0);
+        a.item_id = Some("item-a".into());
+        let mut b = record(2, 0);
+        b.item_id = Some("item-b".into());
+        let c = record(3, 0);
+        let records = vec![a, b, c];
+        let after = vec![SupersessionMark::ItemAnchor {
+            item_id: "item-b".into(),
+            position: "after".into(),
+            at_ms: 10,
+        }];
+        assert_eq!(derive_active(&records, &after), vec![true, true, false]);
+        let before = vec![SupersessionMark::ItemAnchor {
+            item_id: "item-b".into(),
+            position: "before".into(),
+            at_ms: 10,
+        }];
+        assert_eq!(derive_active(&records, &before), vec![true, false, false]);
+    }
+
+    #[test]
+    fn generation_restore_reactivates_and_retires_branches() {
+        // gen0 history, a gen1 branch, then a restore back to gen0: the
+        // gen1 branch stops reading active; gen0 records stay active even
+        // if a turn-count mark inside gen1's life had superseded nothing
+        // of theirs.
+        let records = vec![record(1, 0), record(2, 1), record(3, 1)];
+        // Without a restore, the max generation (1) is active: everything
+        // reads active.
+        assert_eq!(
+            derive_active(&records, &[]),
+            vec![true, true, true],
+            "no marks: all generations live"
+        );
+        let marks = vec![SupersessionMark::GenerationRestore {
+            active_generation: 0,
+            at_ms: 10,
+        }];
+        assert_eq!(derive_active(&records, &marks), vec![true, false, false]);
+    }
+
+    #[test]
+    fn cap_text_cuts_on_char_boundary() {
+        let text = "é".repeat(MESSAGE_TEXT_CAP_BYTES); // 2 bytes per char
+        let (capped, truncated) = cap_text(text);
+        assert!(truncated);
+        assert!(capped.len() <= MESSAGE_TEXT_CAP_BYTES);
+        assert!(capped.chars().all(|c| c == 'é'));
+        let (same, truncated) = cap_text("short".into());
+        assert!(!truncated);
+        assert_eq!(same, "short");
+    }
+
+    #[test]
+    fn record_roundtrips_and_skips_defaults() {
+        let r = record(5, 0);
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(!json.contains("subagent"), "false flags are skipped");
+        assert!(!json.contains("item_id"), "absent options are skipped");
+        let back: MessageRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, r);
+    }
+}

--- a/src/bin/caller/message_search/store.rs
+++ b/src/bin/caller/message_search/store.rs
@@ -1,0 +1,656 @@
+//! The rolling shard store (message-search plan §6): per-session
+//! generations of [`MessageRecord`]s published through a single manifest,
+//! safe for the several daemons that share `~/.intendant` on one box.
+//!
+//! Coordination model, kept honest per the plan: shards are
+//! content-deterministic from their sources, so a lost race self-heals on
+//! the next pass — the advisory lock (an `O_EXCL` lockfile with stale
+//! takeover) buys query-visible stability and avoids N-daemon duplicate
+//! work, NOT loss protection. The correctness gate is the publish path:
+//! it re-reads the latest manifest under the lock, merges, and REJECTS
+//! any write that would lower a session's source watermark or downgrade
+//! `parser_version`. Generation files are immutable and content-named,
+//! so an open snapshot keeps reading the files it resolved even while
+//! newer manifests land.
+
+use super::cursor::SourceCursor;
+use super::record::{MessageRecord, SupersessionMark, PARSER_VERSION};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+const MANIFEST_NAME: &str = "manifest.json";
+const LOCK_NAME: &str = "writer.lock";
+/// A lockfile older than this is a crashed holder; take it over. The lock
+/// guards efficiency, not correctness, so takeover errs brisk.
+const LOCK_STALE_MS: i64 = 5 * 60 * 1000;
+/// Retention window (plan v1: fixed 14 days on message `ts_ms`).
+pub(crate) const RETENTION_MS: i64 = 14 * 24 * 60 * 60 * 1000;
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct Manifest {
+    pub schema: u32,
+    pub parser_version: u32,
+    pub updated_at_ms: i64,
+    /// Keyed by `<source>:<session_id>`.
+    #[serde(default)]
+    pub sessions: BTreeMap<String, SessionEntry>,
+    /// Deliberately deleted sessions (dashboard/API flow): the key and
+    /// when. A tombstoned session is never re-published from stale
+    /// sources; tombstones expire with the retention window.
+    #[serde(default)]
+    pub tombstones: BTreeMap<String, i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct SessionEntry {
+    /// Content-named generation file under `generations/`.
+    pub generation_file: String,
+    pub records: usize,
+    pub newest_ts_ms: i64,
+    /// Monotonic per-session source progress: the max
+    /// `last_complete_line_offset` sum the publisher had consumed. A
+    /// publish carrying a LOWER watermark is a stale writer and is
+    /// rejected (plan §6).
+    pub source_watermark: u64,
+    #[serde(default)]
+    pub cursors: Vec<SourceCursor>,
+    /// Coverage niceties surfaced by C1 (plan §7).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub source_gone: bool,
+}
+
+/// One session's shard content — records + supersession marks, from which
+/// readers derive active status (never stored).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct SessionShard {
+    pub records: Vec<MessageRecord>,
+    #[serde(default)]
+    pub marks: Vec<SupersessionMark>,
+}
+
+pub(crate) struct Store {
+    root: PathBuf,
+}
+
+/// A point-in-time view: the manifest as resolved at open time. Generation
+/// files are immutable, so reads through this snapshot are stable across
+/// concurrent publishes (plan §7's snapshot-pinned pagination builds on
+/// this; GC can invalidate very old snapshots, surfaced as missing files).
+pub(crate) struct Snapshot {
+    root: PathBuf,
+    pub manifest: Manifest,
+}
+
+pub(crate) enum PublishOutcome {
+    Published,
+    /// A newer writer got there first (higher watermark or newer parser);
+    /// the caller's derivation is stale — re-derive on the next pass.
+    RejectedStale,
+    /// The session was deliberately deleted; do not resurrect.
+    RejectedTombstoned,
+}
+
+impl Store {
+    pub(crate) fn open(root: &Path) -> std::io::Result<Self> {
+        std::fs::create_dir_all(root.join("generations"))?;
+        Ok(Self {
+            root: root.to_path_buf(),
+        })
+    }
+
+    /// The production root: `~/.intendant/cache/message_search/v1`.
+    pub(crate) fn default_root() -> PathBuf {
+        crate::platform::intendant_home()
+            .join("cache")
+            .join("message_search")
+            .join("v1")
+    }
+
+    fn manifest_path(&self) -> PathBuf {
+        self.root.join(MANIFEST_NAME)
+    }
+
+    fn read_manifest(&self) -> Manifest {
+        let raw = match std::fs::read_to_string(self.manifest_path()) {
+            Ok(raw) => raw,
+            Err(_) => return Manifest::default(),
+        };
+        match serde_json::from_str::<Manifest>(&raw) {
+            Ok(manifest) => manifest,
+            Err(err) => {
+                // Corrupt manifest: quarantine it and rebuild from empty —
+                // generations are re-derivable from sources (plan §6).
+                eprintln!("[message-search] corrupt manifest ({err}); quarantining");
+                let _ = std::fs::rename(
+                    self.manifest_path(),
+                    self.root.join(format!("manifest.corrupt-{}", now_ms())),
+                );
+                Manifest::default()
+            }
+        }
+    }
+
+    /// Open a stable read view.
+    pub(crate) fn snapshot(&self) -> Snapshot {
+        Snapshot {
+            root: self.root.clone(),
+            manifest: self.read_manifest(),
+        }
+    }
+
+    /// Publish one session's freshly derived shard. `watermark` is the
+    /// publisher's consumed-source progress (sum of cursor offsets).
+    pub(crate) fn publish_session(
+        &self,
+        session_key: &str,
+        shard: &SessionShard,
+        cursors: Vec<SourceCursor>,
+        source_gone: bool,
+    ) -> std::io::Result<PublishOutcome> {
+        let _lock = WriterLock::acquire(&self.root)?;
+        let mut manifest = self.read_manifest();
+        if manifest.tombstones.contains_key(session_key) {
+            return Ok(PublishOutcome::RejectedTombstoned);
+        }
+        if manifest.parser_version > PARSER_VERSION {
+            // Never let an older binary clobber a newer format (plan §6
+            // no-downgrade rule).
+            return Ok(PublishOutcome::RejectedStale);
+        }
+        let watermark: u64 = cursors
+            .iter()
+            .map(|cursor| cursor.last_complete_line_offset)
+            .sum();
+        if let Some(existing) = manifest.sessions.get(session_key) {
+            // A lower watermark from the SAME source state is a stale
+            // writer (lost race) — reject; the loser re-derives next pass.
+            // A lower watermark with CHANGED source fingerprints is a
+            // legitimate rebuild of a rewritten/shrunk source — allow.
+            let same_source_state = existing.cursors.iter().all(|old| {
+                cursors
+                    .iter()
+                    .find(|new| new.path == old.path)
+                    .is_none_or(|new| {
+                        new.prefix_hash16 == old.prefix_hash16 && new.identity == old.identity
+                    })
+            });
+            if watermark < existing.source_watermark && same_source_state {
+                return Ok(PublishOutcome::RejectedStale);
+            }
+        }
+
+        let body = serde_json::to_string(shard).map_err(std::io::Error::other)?;
+        let generation_file = format!("{}.json", crate::session_log::content_hash_hex16(&body));
+        let generation_path = self.root.join("generations").join(&generation_file);
+        if !generation_path.exists() {
+            crate::file_watcher::atomic_write(&generation_path, body.as_bytes())?;
+        }
+
+        let newest_ts_ms = shard
+            .records
+            .iter()
+            .map(|record| record.ts_ms)
+            .max()
+            .unwrap_or(0);
+        manifest.sessions.insert(
+            session_key.to_string(),
+            SessionEntry {
+                generation_file,
+                records: shard.records.len(),
+                newest_ts_ms,
+                source_watermark: watermark,
+                cursors,
+                source_gone,
+            },
+        );
+        manifest.schema = 1;
+        manifest.parser_version = PARSER_VERSION;
+        manifest.updated_at_ms = now_ms();
+        self.write_manifest(&manifest)?;
+        Ok(PublishOutcome::Published)
+    }
+
+    /// Flip a session's `source_gone` coverage flag without touching its
+    /// records or watermark (the source file vanished; the shard serves
+    /// "I remember seeing this" until window expiry — plan §6).
+    pub(crate) fn mark_source_gone(&self, session_key: &str) -> std::io::Result<()> {
+        let _lock = WriterLock::acquire(&self.root)?;
+        let mut manifest = self.read_manifest();
+        if let Some(entry) = manifest.sessions.get_mut(session_key) {
+            if !entry.source_gone {
+                entry.source_gone = true;
+                manifest.updated_at_ms = now_ms();
+                self.write_manifest(&manifest)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Deliberate session deletion: drop the shard and tombstone the key.
+    pub(crate) fn delete_session(&self, session_key: &str) -> std::io::Result<()> {
+        let _lock = WriterLock::acquire(&self.root)?;
+        let mut manifest = self.read_manifest();
+        manifest.sessions.remove(session_key);
+        manifest
+            .tombstones
+            .insert(session_key.to_string(), now_ms());
+        manifest.updated_at_ms = now_ms();
+        self.write_manifest(&manifest)?;
+        self.gc_unreferenced_generations(&manifest);
+        Ok(())
+    }
+
+    /// Retention GC (plan §6): drop sessions whose newest message left the
+    /// window, expire old tombstones, delete unreferenced generations.
+    pub(crate) fn gc(&self, now_ms_value: i64) -> std::io::Result<()> {
+        let _lock = WriterLock::acquire(&self.root)?;
+        let mut manifest = self.read_manifest();
+        manifest
+            .sessions
+            .retain(|_, entry| now_ms_value.saturating_sub(entry.newest_ts_ms) <= RETENTION_MS);
+        manifest
+            .tombstones
+            .retain(|_, at| now_ms_value.saturating_sub(*at) <= RETENTION_MS);
+        manifest.updated_at_ms = now_ms_value;
+        self.write_manifest(&manifest)?;
+        self.gc_unreferenced_generations(&manifest);
+        Ok(())
+    }
+
+    fn gc_unreferenced_generations(&self, manifest: &Manifest) {
+        let referenced: std::collections::HashSet<&str> = manifest
+            .sessions
+            .values()
+            .map(|entry| entry.generation_file.as_str())
+            .collect();
+        let Ok(entries) = std::fs::read_dir(self.root.join("generations")) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            if !referenced.contains(name) {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+    }
+
+    fn write_manifest(&self, manifest: &Manifest) -> std::io::Result<()> {
+        let body = serde_json::to_string_pretty(manifest).map_err(std::io::Error::other)?;
+        crate::file_watcher::atomic_write(&self.manifest_path(), body.as_bytes())
+    }
+}
+
+impl Snapshot {
+    pub(crate) fn read_shard(&self, session_key: &str) -> Option<SessionShard> {
+        let entry = self.manifest.sessions.get(session_key)?;
+        let raw =
+            std::fs::read_to_string(self.root.join("generations").join(&entry.generation_file))
+                .ok()?;
+        serde_json::from_str(&raw).ok()
+    }
+}
+
+/// `O_EXCL` lockfile with stale takeover — see the module doc for why
+/// this (and not flock/LockFileEx) is adequate here.
+struct WriterLock {
+    path: PathBuf,
+}
+
+impl WriterLock {
+    fn acquire(root: &Path) -> std::io::Result<Self> {
+        Self::acquire_with(root, LOCK_STALE_MS)
+    }
+
+    fn acquire_with(root: &Path, stale_ms: i64) -> std::io::Result<Self> {
+        let path = root.join(LOCK_NAME);
+        for attempt in 0..50u32 {
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+            {
+                Ok(mut file) => {
+                    use std::io::Write;
+                    let _ = write!(file, "{} {}", std::process::id(), now_ms());
+                    return Ok(Self { path });
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                    // Crashed holder? Take over by age; otherwise wait.
+                    let stale = std::fs::metadata(&path)
+                        .ok()
+                        .and_then(|m| m.modified().ok())
+                        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                        .map(|d| now_ms().saturating_sub(d.as_millis() as i64) > stale_ms)
+                        .unwrap_or(true);
+                    if stale {
+                        let _ = std::fs::remove_file(&path);
+                        continue;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(20 * (attempt as u64 + 1)));
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        Err(std::io::Error::new(
+            std::io::ErrorKind::WouldBlock,
+            "message-search writer lock is busy",
+        ))
+    }
+}
+
+impl Drop for WriterLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::record::{Locator, Role, Source};
+    use super::*;
+
+    fn record(ts_ms: i64, text: &str) -> MessageRecord {
+        MessageRecord {
+            source: Source::Intendant,
+            session_id: "s1".into(),
+            role: Role::User,
+            ts_ms,
+            text: text.into(),
+            locator: Locator::NativeMessageId {
+                message_id: format!("id-{ts_ms}"),
+            },
+            seq: None,
+            user_turn: None,
+            item_id: None,
+            subagent: false,
+            generation: 0,
+            truncated: false,
+        }
+    }
+
+    fn cursor_at(dir: &Path, offset: u64) -> SourceCursor {
+        let path = dir.join("source.jsonl");
+        if !path.exists() {
+            std::fs::write(&path, "line\n".repeat(64)).unwrap();
+        }
+        SourceCursor::capture(&path, offset).unwrap()
+    }
+
+    #[test]
+    fn publish_read_roundtrip_and_snapshot_stability() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let shard = SessionShard {
+            records: vec![record(100, "hello world")],
+            marks: vec![],
+        };
+        let cursors = vec![cursor_at(tmp.path(), 10)];
+        assert!(matches!(
+            store
+                .publish_session("intendant:s1", &shard, cursors, false)
+                .unwrap(),
+            PublishOutcome::Published
+        ));
+
+        let snapshot = store.snapshot();
+        let read = snapshot.read_shard("intendant:s1").unwrap();
+        assert_eq!(read.records[0].text, "hello world");
+
+        // A newer publish lands; the OLD snapshot still resolves its
+        // generation (immutable, content-named files).
+        let shard2 = SessionShard {
+            records: vec![record(100, "hello world"), record(200, "second")],
+            marks: vec![],
+        };
+        let cursors2 = vec![cursor_at(tmp.path(), 20)];
+        store
+            .publish_session("intendant:s1", &shard2, cursors2, false)
+            .unwrap();
+        assert_eq!(
+            snapshot.read_shard("intendant:s1").unwrap().records.len(),
+            1
+        );
+        assert_eq!(
+            store
+                .snapshot()
+                .read_shard("intendant:s1")
+                .unwrap()
+                .records
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn stale_watermark_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let shard = SessionShard {
+            records: vec![record(100, "fresh")],
+            marks: vec![],
+        };
+        store
+            .publish_session(
+                "intendant:s1",
+                &shard,
+                vec![cursor_at(tmp.path(), 50)],
+                false,
+            )
+            .unwrap();
+
+        let stale = SessionShard {
+            records: vec![record(90, "stale")],
+            marks: vec![],
+        };
+        assert!(matches!(
+            store
+                .publish_session(
+                    "intendant:s1",
+                    &stale,
+                    vec![cursor_at(tmp.path(), 10)],
+                    false
+                )
+                .unwrap(),
+            PublishOutcome::RejectedStale
+        ));
+        assert_eq!(
+            store.snapshot().read_shard("intendant:s1").unwrap().records[0].text,
+            "fresh"
+        );
+    }
+
+    #[test]
+    fn rewritten_source_rebuild_may_lower_the_watermark() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let path = tmp.path().join("source.jsonl");
+        std::fs::write(&path, "old content old content\n".repeat(8)).unwrap();
+        let first = SourceCursor::capture(&path, 100).unwrap();
+        let shard = SessionShard {
+            records: vec![record(100, "long history")],
+            marks: vec![],
+        };
+        store
+            .publish_session("intendant:s1", &shard, vec![first], false)
+            .unwrap();
+
+        // The source is rewritten SHORTER (same-thread restore): the
+        // rebuild's watermark is lower, but its prefix fingerprint
+        // changed — allowed.
+        std::fs::write(&path, "new\n").unwrap();
+        let rebuilt_cursor = SourceCursor::capture(&path, 4).unwrap();
+        let rebuilt = SessionShard {
+            records: vec![record(200, "rebuilt view")],
+            marks: vec![],
+        };
+        assert!(matches!(
+            store
+                .publish_session("intendant:s1", &rebuilt, vec![rebuilt_cursor], false)
+                .unwrap(),
+            PublishOutcome::Published
+        ));
+        assert_eq!(
+            store.snapshot().read_shard("intendant:s1").unwrap().records[0].text,
+            "rebuilt view"
+        );
+    }
+
+    #[test]
+    fn mark_source_gone_flips_coverage_without_touching_records() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let shard = SessionShard {
+            records: vec![record(100, "kept")],
+            marks: vec![],
+        };
+        store
+            .publish_session(
+                "intendant:s1",
+                &shard,
+                vec![cursor_at(tmp.path(), 7)],
+                false,
+            )
+            .unwrap();
+        store.mark_source_gone("intendant:s1").unwrap();
+        let snapshot = store.snapshot();
+        let entry = snapshot.manifest.sessions.get("intendant:s1").unwrap();
+        assert!(entry.source_gone);
+        assert_eq!(entry.source_watermark, 7);
+        assert_eq!(
+            snapshot.read_shard("intendant:s1").unwrap().records[0].text,
+            "kept"
+        );
+    }
+
+    #[test]
+    fn tombstoned_sessions_never_resurrect() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let shard = SessionShard {
+            records: vec![record(100, "x")],
+            marks: vec![],
+        };
+        store
+            .publish_session(
+                "intendant:s1",
+                &shard,
+                vec![cursor_at(tmp.path(), 5)],
+                false,
+            )
+            .unwrap();
+        store.delete_session("intendant:s1").unwrap();
+        assert!(store.snapshot().read_shard("intendant:s1").is_none());
+        assert!(matches!(
+            store
+                .publish_session(
+                    "intendant:s1",
+                    &shard,
+                    vec![cursor_at(tmp.path(), 9)],
+                    false
+                )
+                .unwrap(),
+            PublishOutcome::RejectedTombstoned
+        ));
+    }
+
+    #[test]
+    fn gc_drops_expired_sessions_tombstones_and_orphan_generations() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let old = SessionShard {
+            records: vec![record(1_000, "ancient")],
+            marks: vec![],
+        };
+        let fresh_ts = now_ms();
+        let fresh = SessionShard {
+            records: vec![record(fresh_ts, "current")],
+            marks: vec![],
+        };
+        store
+            .publish_session("intendant:old", &old, vec![cursor_at(tmp.path(), 1)], false)
+            .unwrap();
+        store
+            .publish_session(
+                "intendant:new",
+                &fresh,
+                vec![cursor_at(tmp.path(), 2)],
+                false,
+            )
+            .unwrap();
+        store.delete_session("intendant:dead").unwrap();
+
+        store.gc(fresh_ts).unwrap();
+        let snapshot = store.snapshot();
+        assert!(snapshot.read_shard("intendant:old").is_none());
+        assert!(snapshot.read_shard("intendant:new").is_some());
+        assert!(snapshot.manifest.tombstones.contains_key("intendant:dead"));
+
+        // Far future (decisively past the window — the tombstone's stamp
+        // is a few ms after fresh_ts): everything expires.
+        store.gc(fresh_ts + 2 * RETENTION_MS).unwrap();
+        let snapshot = store.snapshot();
+        assert!(snapshot.manifest.sessions.is_empty());
+        assert!(snapshot.manifest.tombstones.is_empty());
+        let generations: Vec<_> = std::fs::read_dir(tmp.path().join("generations"))
+            .unwrap()
+            .flatten()
+            .collect();
+        assert!(generations.is_empty(), "orphan generations GC'd");
+    }
+
+    #[test]
+    fn stale_writer_lock_is_taken_over() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A "crashed" holder left a lockfile.
+        std::fs::write(tmp.path().join(super::LOCK_NAME), "999999 0").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(30));
+        // With an injected 10ms staleness horizon, acquire takes it over
+        // instead of waiting out the full production TTL.
+        let lock = WriterLock::acquire_with(tmp.path(), 10).unwrap();
+        drop(lock);
+        assert!(
+            !tmp.path().join(super::LOCK_NAME).exists(),
+            "lock released on drop"
+        );
+    }
+
+    #[test]
+    fn held_fresh_lock_blocks_until_released() {
+        let tmp = tempfile::tempdir().unwrap();
+        let held = WriterLock::acquire(tmp.path()).unwrap();
+        // A second writer with a tiny retry budget cannot get in while the
+        // fresh lock is held (verifies the wait path, bounded for tests by
+        // takeover-horizon 0 being ineligible — the lock is fresh).
+        let root = tmp.path().to_path_buf();
+        let contender =
+            std::thread::spawn(move || WriterLock::acquire_with(&root, LOCK_STALE_MS).is_ok());
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        drop(held);
+        assert!(contender.join().unwrap(), "acquires after release");
+    }
+
+    #[test]
+    fn corrupt_manifest_is_quarantined_not_fatal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        std::fs::write(tmp.path().join(MANIFEST_NAME), "{not json").unwrap();
+        let snapshot = store.snapshot();
+        assert!(snapshot.manifest.sessions.is_empty());
+        let quarantined = std::fs::read_dir(tmp.path()).unwrap().flatten().any(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .starts_with("manifest.corrupt-")
+        });
+        assert!(quarantined);
+    }
+}


### PR DESCRIPTION
B1 of the message-search program (plan §5–6, converged after two review rounds): the durable store the three extractors (B2–B4) and the query side (C1) build on.

Design points as reviewed: supersession is derived by replaying marks — seq cuts, bounded turn-count and item-anchor rollbacks, generation restores that reactivate — never a stored flag (D2); the advisory lock (O_EXCL + stale takeover) buys stability and work-avoidance while the publish path's watermark/fingerprint rejection is the correctness gate; changed source fingerprints distinguish a legitimate rewrite-rebuild from a stale writer; snapshots read immutable content-named generations, stable across publishes; boot-time retention GC is wired in main.rs so nothing accumulates before the extractors exist.

The unconsumed API surface carries documented parked-seed allows that die with B2–B4/C1 (the next units).

Tests: 20 new (derive-active semantics incl. reactivation + corrupt-count bounds; cursor append/partial-line/truncation/prefix-rewrite/gone/version-bump; store roundtrip + snapshot stability + stale-writer rejection + rewrite-rebuild + tombstones + GC incl. orphan generations + lock takeover/contention) — green under nextest AND plain threaded cargo test. Full `nextest --bins` 3096/3096; workspace clippy `-D warnings` clean (RUSTC workaround).