### PR TITLE
message_search: intendant extractor (B2) + message-lane e2e

### DIFF
--- a/src/bin/caller/message_search/extract_intendant.rs
+++ b/src/bin/caller/message_search/extract_intendant.rs
@@ -119,6 +119,21 @@ pub(crate) fn extract_intendant_session(log_dir: &Path) -> std::io::Result<Inten
     let mut pending_steers: Vec<(String, String, u64)> = Vec::new(); // (id, text, line_no)
     let mut legacy_task_seen = false;
 
+    // A daemon/parent log mirrors its supervised children's activity as
+    // session-scoped rows (`data.session_id` = the child): those rows are
+    // canonical in the CHILD's own log dir and must not be re-extracted
+    // here. Rows scoped to this session (or unscoped — the classic
+    // single-session shape) stay. Deliberate coverage loss: February-era
+    // MCP multi-task logs scoped their per-task rows to child ids inside
+    // the parent dir; those pre-F1 corpses lose their task rows to this
+    // rule, which is the right trade against double-indexing every
+    // currently-supervised session.
+    let foreign = |data: Option<&serde_json::Value>| -> bool {
+        data.and_then(|data| data.get("session_id"))
+            .and_then(|id| id.as_str())
+            .is_some_and(|id| id != session_id)
+    };
+
     let record_base = |role: Role, ts_ms: i64, text: String, locator: Locator| {
         let (text, truncated) = cap_text(text);
         MessageRecord {
@@ -193,6 +208,9 @@ pub(crate) fn extract_intendant_session(log_dir: &Path) -> std::io::Result<Inten
             }
             // ---- Legacy lane (strictly before the era boundary) ----
             Some("session_started") if position < legacy_end => {
+                if foreign(data) {
+                    continue;
+                }
                 let ts_ms = dater.date_row(ts_ms_field, event);
                 let task = data
                     .and_then(|data| data.get("task"))
@@ -216,6 +234,9 @@ pub(crate) fn extract_intendant_session(log_dir: &Path) -> std::io::Result<Inten
                 }
             }
             Some("steer_requested") if position < legacy_end => {
+                if foreign(data) {
+                    continue;
+                }
                 let Some(data) = data else { continue };
                 if let (Some(id), Some(text)) = (
                     data.get("id").and_then(|id| id.as_str()),
@@ -225,14 +246,16 @@ pub(crate) fn extract_intendant_session(log_dir: &Path) -> std::io::Result<Inten
                 }
             }
             Some("steer_delivered") if position < legacy_end => {
+                if foreign(data) {
+                    continue;
+                }
                 let Some(id) = data
                     .and_then(|data| data.get("id"))
                     .and_then(|id| id.as_str())
                 else {
                     continue;
                 };
-                let Some(slot) = pending_steers.iter().position(|(known, _, _)| known == id)
-                else {
+                let Some(slot) = pending_steers.iter().position(|(known, _, _)| known == id) else {
                     continue; // delivered without a seen request: nothing to say
                 };
                 let (_, text, requested_line) = pending_steers.remove(slot);
@@ -279,6 +302,9 @@ pub(crate) fn extract_intendant_session(log_dir: &Path) -> std::io::Result<Inten
                 );
             }
             Some("model_response") if position < legacy_end => {
+                if foreign(data) {
+                    continue;
+                }
                 let Some(data) = data else { continue };
                 let Some(text) = read_event_span(log_dir, event, data) else {
                     continue;
@@ -395,18 +421,21 @@ fn read_meta(log_dir: &Path) -> Option<SessionMeta> {
     serde_json::from_str(&raw).ok()
 }
 
-/// Read the sidecar span an event references (`file` + `data.model_offset`
-/// + `data.model_bytes`). The read is bounded a little past the record
-/// text cap — a corrupt length must not balloon memory; the overlong tail
-/// is dropped by [`cap_text`] anyway. A short read (bytes the event
-/// promised aren't there) is an anomaly: skip, don't guess.
+/// Read the sidecar span an event references (`file` plus
+/// `data.model_offset`/`data.model_bytes`). The read is bounded a little
+/// past the record text cap — a corrupt length must not balloon memory;
+/// the overlong tail is dropped by [`cap_text`] anyway. A short read
+/// (bytes the event promised aren't there) is an anomaly: skip, don't
+/// guess.
 fn read_event_span(
     log_dir: &Path,
     event: &serde_json::Value,
     data: &serde_json::Value,
 ) -> Option<String> {
     let file = event.get("file").and_then(|file| file.as_str())?;
-    let offset = data.get("model_offset").and_then(|offset| offset.as_u64())?;
+    let offset = data
+        .get("model_offset")
+        .and_then(|offset| offset.as_u64())?;
     let len = data.get("model_bytes").and_then(|len| len.as_u64())?;
     let relative = Path::new(file);
     // The log dir is the trust boundary: never follow an absolute or
@@ -505,10 +534,7 @@ impl LegacyDater {
             return 0;
         };
         let date = if tod < current.time() {
-            current
-                .date()
-                .succ_opt()
-                .unwrap_or_else(|| current.date())
+            current.date().succ_opt().unwrap_or_else(|| current.date())
         } else {
             current.date()
         };
@@ -639,7 +665,11 @@ mod tests {
         assert_eq!(out.shard.records[2].ts_ms, 3_000);
         assert_eq!(out.shard.marks.len(), 1);
         let active = derive_active(&out.shard.records, &out.shard.marks);
-        assert_eq!(active, vec![true, true, false], "seq 3 superseded by the cut");
+        assert_eq!(
+            active,
+            vec![true, true, false],
+            "seq 3 superseded by the cut"
+        );
         assert_eq!(out.cursors.len(), 1);
         assert_eq!(out.cursors[0].check(), CursorCheck::Unchanged);
     }
@@ -782,11 +812,11 @@ mod tests {
                     "data":{"session_id":"sess-mixed","task":"old task"}}),
                 model_response("10:00:02.000", "turns/turn_001_model.txt", 0, 13),
                 serde_json::json!({"ts":"11:00:00.000","ts_ms":100,"event":"conversation_message_epoch",
-                    "data":{"mapping":[
-                        [1, "system", "ffffffffffffffff"],
-                        [2, "user", content_hash_hex16("old task")],
-                        [3, "assistant", content_hash_hex16("legacy answer")],
-                    ]}}),
+                "data":{"mapping":[
+                    [1, "system", "ffffffffffffffff"],
+                    [2, "user", content_hash_hex16("old task")],
+                    [3, "assistant", content_hash_hex16("legacy answer")],
+                ]}}),
                 conversation_message_user(4, 200, "post-resume message"),
                 // Legacy-shaped rows AFTER the marker must be ignored:
                 model_response("11:00:02.000", "turns/turn_001_model.txt", 0, 13),
@@ -797,7 +827,11 @@ mod tests {
 
         let out = extract_intendant_session(&dir).unwrap();
         let records = &out.shard.records;
-        assert_eq!(records.len(), 3, "legacy task + legacy span + one canonical");
+        assert_eq!(
+            records.len(),
+            3,
+            "legacy task + legacy span + one canonical"
+        );
         assert_eq!(records[0].seq, Some(2), "correlated through the mapping");
         assert_eq!(records[1].seq, Some(3));
         assert_eq!(records[2].seq, Some(4));
@@ -817,8 +851,10 @@ mod tests {
         write_meta(&dir, "2026-01-01T00:00:00", None, None);
         write_lines(
             &dir,
-            &[serde_json::json!({"ts":"12:00:00.000","ts_ms":42_000,"event":"session_started",
-                "data":{"session_id":"sess-f2","task":"dated task"}})],
+            &[
+                serde_json::json!({"ts":"12:00:00.000","ts_ms":42_000,"event":"session_started",
+                "data":{"session_id":"sess-f2","task":"dated task"}}),
+            ],
         );
         let out = extract_intendant_session(&dir).unwrap();
         assert_eq!(out.shard.records[0].ts_ms, 42_000);
@@ -874,6 +910,44 @@ mod tests {
     }
 
     #[test]
+    fn session_scoped_mirror_rows_are_skipped_as_foreign() {
+        // A daemon/parent log carries its supervised children's rows
+        // tagged with the CHILD's session id — canonical in the child's
+        // own dir, never re-extracted here. Rows scoped to this session
+        // itself stay.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("daemon-root");
+        std::fs::create_dir_all(&dir).unwrap();
+        write_meta(&dir, "2026-07-01T09:00:00", None, None);
+        sidecar(&dir, "turn_000_model.txt", "mirrored child text");
+        write_lines(
+            &dir,
+            &[
+                serde_json::json!({"ts":"09:00:01.000","ts_ms":1,"event":"session_started",
+                    "data":{"session_id":"child-1","task":"the child task"}}),
+                serde_json::json!({"ts":"09:00:02.000","ts_ms":2,"event":"model_response",
+                    "file":"turns/turn_000_model.txt",
+                    "data":{"model_offset":0,"model_bytes":19,"session_id":"child-1"}}),
+                serde_json::json!({"ts":"09:00:03.000","ts_ms":3,"event":"steer_requested",
+                    "data":{"id":"st-1","status":"pending","text":"child steer","session_id":"child-1"}}),
+                serde_json::json!({"ts":"09:00:04.000","ts_ms":4,"event":"steer_delivered",
+                    "data":{"id":"st-1","status":"delivered","session_id":"child-1"}}),
+                // Self-scoped row: kept.
+                serde_json::json!({"ts":"09:00:05.000","ts_ms":5,"event":"session_started",
+                    "data":{"session_id":"daemon-root","task":"the daemon's own task"}}),
+            ],
+        );
+        let out = extract_intendant_session(&dir).unwrap();
+        let texts: Vec<&str> = out
+            .shard
+            .records
+            .iter()
+            .map(|record| record.text.as_str())
+            .collect();
+        assert_eq!(texts, vec!["the daemon's own task"]);
+    }
+
+    #[test]
     fn round_follow_up_parsing_is_strict_about_shape() {
         assert_eq!(
             parse_round_follow_up("Round 3 follow-up: plain text"),
@@ -884,7 +958,10 @@ mod tests {
             Some("with files".to_string())
         );
         assert_eq!(parse_round_follow_up("Round x follow-up: nope"), None);
-        assert_eq!(parse_round_follow_up("Skipped cancelled queued follow-up"), None);
+        assert_eq!(
+            parse_round_follow_up("Skipped cancelled queued follow-up"),
+            None
+        );
         assert_eq!(parse_round_follow_up("Round 12 complete (3 turns)"), None);
     }
 }

--- a/src/bin/caller/message_search/extract_intendant.rs
+++ b/src/bin/caller/message_search/extract_intendant.rs
@@ -1,0 +1,890 @@
+//! B2: the intendant-session extractor (message-search plan §5, intendant
+//! lane). Walks ONE session log dir — `session.jsonl` plus the `turns/`
+//! sidecars its events reference — and derives that session's
+//! [`SessionShard`] + cursors. Pure per-dir: no home/env resolution here;
+//! the wiring edge enumerates the logs root and decides publishing.
+//!
+//! Two eras coexist on disk (plan §4):
+//! - **New era** (post-F1 binaries): canonical `conversation_message`
+//!   rows — user text inline, assistant text as a sidecar span shared
+//!   with the diagnostic `model_response` event. `conversation_rewound`
+//!   rows become [`SupersessionMark::SeqCut`]s.
+//! - **Legacy era** (pre-F1 logs, or the pre-marker segment of a resumed
+//!   session): user text is reconstructed best-effort from
+//!   `session_started` tasks (falling back to `session_meta.json` — a
+//!   top-level session has ONLY the meta copy), delivered steers
+//!   (`steer_requested` ⋈ `steer_delivered` on id), and
+//!   `"Round {N} follow-up:"` info lines; assistant text from
+//!   `model_response` sidecar spans. askHuman answers were never
+//!   persisted pre-F1 — none exist to extract.
+//!
+//! The `conversation_message_epoch` marker is the era boundary: legacy
+//! extraction stops STRICTLY at the first marker, and its
+//! `(seq, role, content-hash)` mapping assigns seqs to legacy-extracted
+//! records so rewind cuts cover them (hash mismatch — preludes, images —
+//! just leaves a record uncorrelated: it stays active, never wrongly
+//! superseded).
+//!
+//! Wrapper sessions (any `session_identity` event) are skipped entirely:
+//! their `model_response` events mirror messages that are canonical in
+//! the external backend's own log (the Codex/Claude extractors' lane) —
+//! extracting them here would double every wrapped message.
+
+use super::cursor::{read_complete_lines_from, SourceCursor};
+use super::record::{
+    cap_text, Locator, MessageRecord, Role, Source, SupersessionMark, MESSAGE_TEXT_CAP_BYTES,
+};
+use super::store::SessionShard;
+use crate::session_log::{content_hash_hex16, SessionMeta};
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Component, Path};
+
+/// One session dir's extraction. `wrapper` sessions deliberately carry an
+/// empty shard (see the module doc); the cursor is still captured so the
+/// wiring edge can avoid rescanning a large wrapper log every sweep.
+pub(crate) struct IntendantExtraction {
+    pub shard: SessionShard,
+    pub cursors: Vec<SourceCursor>,
+    pub wrapper: bool,
+}
+
+/// Extract one intendant session log dir. Missing `session.jsonl` yields
+/// an empty extraction (a dir that never logged has nothing to index).
+pub(crate) fn extract_intendant_session(log_dir: &Path) -> std::io::Result<IntendantExtraction> {
+    let session_jsonl = log_dir.join("session.jsonl");
+    if !session_jsonl.exists() {
+        return Ok(IntendantExtraction {
+            shard: SessionShard::default(),
+            cursors: Vec::new(),
+            wrapper: false,
+        });
+    }
+    let (lines, consumed) = read_complete_lines_from(&session_jsonl, 0)?;
+    let meta = read_meta(log_dir);
+    let session_id = log_dir
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .or_else(|| meta.as_ref().map(|meta| meta.session_id.clone()))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    // Single parse pass; era decisions need whole-file facts (marker
+    // position, wrapper flag, whether any canonical rows exist at all).
+    let mut events: Vec<(u64, serde_json::Value)> = Vec::new();
+    let mut wrapper = false;
+    let mut first_marker: Option<usize> = None;
+    let mut any_conversation_message = false;
+    for (index, line) in lines.iter().enumerate() {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue; // torn or foreign line: not extractable, never fatal
+        };
+        match value.get("event").and_then(|event| event.as_str()) {
+            Some("session_identity") => wrapper = true,
+            Some("conversation_message_epoch") => {
+                first_marker.get_or_insert(events.len());
+            }
+            Some("conversation_message") => any_conversation_message = true,
+            _ => {}
+        }
+        events.push((index as u64 + 1, value));
+    }
+
+    let cursors = SourceCursor::capture(&session_jsonl, consumed)
+        .map(|cursor| vec![cursor])
+        .unwrap_or_default();
+    if wrapper {
+        return Ok(IntendantExtraction {
+            shard: SessionShard::default(),
+            cursors,
+            wrapper: true,
+        });
+    }
+
+    // Era rule: a marker splits explicitly; without one, the presence of
+    // any canonical row means the session was born new-era (its
+    // session_started / follow-up info lines still exist as diagnostics
+    // and MUST NOT be extracted a second time).
+    let legacy_end = match first_marker {
+        Some(marker_index) => marker_index,
+        None if any_conversation_message => 0,
+        None => events.len(),
+    };
+
+    let mut records: Vec<MessageRecord> = Vec::new();
+    let mut marks: Vec<SupersessionMark> = Vec::new();
+    // Full-text hashes of legacy records (index-aligned) for epoch-mapping
+    // correlation; computed BEFORE capping so they match canonical hashes.
+    let mut legacy_hashes: Vec<Option<String>> = Vec::new();
+
+    let mut dater = LegacyDater::new(meta.as_ref());
+    let mut pending_steers: Vec<(String, String, u64)> = Vec::new(); // (id, text, line_no)
+    let mut legacy_task_seen = false;
+
+    let record_base = |role: Role, ts_ms: i64, text: String, locator: Locator| {
+        let (text, truncated) = cap_text(text);
+        MessageRecord {
+            source: Source::Intendant,
+            session_id: session_id.clone(),
+            role,
+            ts_ms,
+            text,
+            locator,
+            seq: None,
+            user_turn: None,
+            item_id: None,
+            subagent: false,
+            generation: 0,
+            truncated,
+        }
+    };
+
+    for (position, (line_no, event)) in events.iter().enumerate() {
+        let name = event.get("event").and_then(|event| event.as_str());
+        let data = event.get("data");
+        let ts_ms_field = event.get("ts_ms").and_then(|ts| ts.as_i64());
+        match name {
+            // ---- Canonical lane (any position; see the era rule) ----
+            Some("conversation_message") => {
+                let Some(data) = data else { continue };
+                let (Some(message_id), Some(seq), Some(role)) = (
+                    data.get("message_id").and_then(|id| id.as_str()),
+                    data.get("message_seq").and_then(|seq| seq.as_u64()),
+                    data.get("role").and_then(|role| role.as_str()),
+                ) else {
+                    continue;
+                };
+                let ts_ms = ts_ms_field.unwrap_or(0);
+                let locator = Locator::NativeMessageId {
+                    message_id: message_id.to_string(),
+                };
+                let mut record = match role {
+                    "user" => {
+                        let Some(text) = data.get("text").and_then(|text| text.as_str()) else {
+                            continue;
+                        };
+                        record_base(Role::User, ts_ms, text.to_string(), locator)
+                    }
+                    "assistant" => {
+                        let Some(text) = read_event_span(log_dir, event, data) else {
+                            continue; // span unreadable: anomaly, skip
+                        };
+                        record_base(Role::Assistant, ts_ms, text, locator)
+                    }
+                    _ => continue,
+                };
+                record.seq = Some(seq);
+                records.push(record);
+                legacy_hashes.push(None);
+            }
+            Some("conversation_rewound") => {
+                let Some(data) = data else { continue };
+                let Some(cut_after_seq) = data.get("cut_after_seq").and_then(|seq| seq.as_u64())
+                else {
+                    continue;
+                };
+                let at_ms = data
+                    .get("superseded_at_ms")
+                    .and_then(|at| at.as_i64())
+                    .or(ts_ms_field)
+                    .unwrap_or(0);
+                marks.push(SupersessionMark::SeqCut {
+                    cut_after_seq,
+                    at_ms,
+                });
+            }
+            // ---- Legacy lane (strictly before the era boundary) ----
+            Some("session_started") if position < legacy_end => {
+                let ts_ms = dater.date_row(ts_ms_field, event);
+                let task = data
+                    .and_then(|data| data.get("task"))
+                    .and_then(|task| task.as_str());
+                if let Some(task) = task {
+                    legacy_task_seen = true;
+                    push_legacy(
+                        &mut records,
+                        &mut legacy_hashes,
+                        record_base(
+                            Role::User,
+                            ts_ms,
+                            task.to_string(),
+                            Locator::NativeEvent {
+                                line_no: *line_no,
+                                content_hash16: content_hash_hex16(task),
+                            },
+                        ),
+                        content_hash_hex16(task),
+                    );
+                }
+            }
+            Some("steer_requested") if position < legacy_end => {
+                let Some(data) = data else { continue };
+                if let (Some(id), Some(text)) = (
+                    data.get("id").and_then(|id| id.as_str()),
+                    data.get("text").and_then(|text| text.as_str()),
+                ) {
+                    pending_steers.push((id.to_string(), text.to_string(), *line_no));
+                }
+            }
+            Some("steer_delivered") if position < legacy_end => {
+                let Some(id) = data
+                    .and_then(|data| data.get("id"))
+                    .and_then(|id| id.as_str())
+                else {
+                    continue;
+                };
+                let Some(slot) = pending_steers.iter().position(|(known, _, _)| known == id)
+                else {
+                    continue; // delivered without a seen request: nothing to say
+                };
+                let (_, text, requested_line) = pending_steers.remove(slot);
+                let ts_ms = dater.date_row(ts_ms_field, event);
+                let hash = content_hash_hex16(&text);
+                push_legacy(
+                    &mut records,
+                    &mut legacy_hashes,
+                    record_base(
+                        Role::User,
+                        ts_ms,
+                        text,
+                        Locator::NativeEvent {
+                            line_no: requested_line,
+                            content_hash16: hash.clone(),
+                        },
+                    ),
+                    hash,
+                );
+            }
+            Some("info") if position < legacy_end => {
+                let Some(text) = event
+                    .get("message")
+                    .and_then(|message| message.as_str())
+                    .and_then(parse_round_follow_up)
+                else {
+                    continue;
+                };
+                let ts_ms = dater.date_row(ts_ms_field, event);
+                let hash = content_hash_hex16(&text);
+                push_legacy(
+                    &mut records,
+                    &mut legacy_hashes,
+                    record_base(
+                        Role::User,
+                        ts_ms,
+                        text,
+                        Locator::NativeEvent {
+                            line_no: *line_no,
+                            content_hash16: hash.clone(),
+                        },
+                    ),
+                    hash,
+                );
+            }
+            Some("model_response") if position < legacy_end => {
+                let Some(data) = data else { continue };
+                let Some(text) = read_event_span(log_dir, event, data) else {
+                    continue;
+                };
+                let (Some(file), Some(offset), Some(len)) = (
+                    event.get("file").and_then(|file| file.as_str()),
+                    data.get("model_offset").and_then(|offset| offset.as_u64()),
+                    data.get("model_bytes").and_then(|len| len.as_u64()),
+                ) else {
+                    continue;
+                };
+                let ts_ms = dater.date_row(ts_ms_field, event);
+                let hash = content_hash_hex16(&text);
+                push_legacy(
+                    &mut records,
+                    &mut legacy_hashes,
+                    record_base(
+                        Role::Assistant,
+                        ts_ms,
+                        text,
+                        Locator::NativeSidecarSpan {
+                            file: file.to_string(),
+                            offset,
+                            len,
+                            content_hash16: hash.clone(),
+                        },
+                    ),
+                    hash,
+                );
+            }
+            _ => {}
+        }
+    }
+
+    // Top-level legacy sessions carry the task only in session_meta.json.
+    if legacy_end == events.len() && !legacy_task_seen {
+        if let Some(task) = meta.as_ref().and_then(|meta| meta.task.as_deref()) {
+            let ts_ms = dater.meta_ts_ms();
+            let hash = content_hash_hex16(task);
+            // line_no 0 = "no event line; sourced from session_meta.json".
+            push_legacy(
+                &mut records,
+                &mut legacy_hashes,
+                record_base(
+                    Role::User,
+                    ts_ms,
+                    task.to_string(),
+                    Locator::NativeEvent {
+                        line_no: 0,
+                        content_hash16: hash.clone(),
+                    },
+                ),
+                hash,
+            );
+        }
+    }
+
+    // Epoch correlation: assign seqs to legacy records by (role, hash),
+    // greedily in mapping order (both sides are in conversation order).
+    for (_, event) in &events {
+        if event.get("event").and_then(|event| event.as_str()) != Some("conversation_message_epoch")
+        {
+            continue;
+        }
+        let Some(mapping) = event
+            .get("data")
+            .and_then(|data| data.get("mapping"))
+            .and_then(|mapping| mapping.as_array())
+        else {
+            continue;
+        };
+        for row in mapping {
+            let (Some(seq), Some(role), Some(hash)) = (
+                row.get(0).and_then(|seq| seq.as_u64()),
+                row.get(1).and_then(|role| role.as_str()),
+                row.get(2).and_then(|hash| hash.as_str()),
+            ) else {
+                continue;
+            };
+            let role = match role {
+                "user" => Role::User,
+                "assistant" => Role::Assistant,
+                _ => continue,
+            };
+            if let Some(index) = (0..records.len()).find(|&index| {
+                records[index].seq.is_none()
+                    && records[index].role == role
+                    && legacy_hashes[index].as_deref() == Some(hash)
+            }) {
+                records[index].seq = Some(seq);
+            }
+        }
+    }
+
+    Ok(IntendantExtraction {
+        shard: SessionShard { records, marks },
+        cursors,
+        wrapper: false,
+    })
+}
+
+fn push_legacy(
+    records: &mut Vec<MessageRecord>,
+    hashes: &mut Vec<Option<String>>,
+    record: MessageRecord,
+    full_text_hash: String,
+) {
+    records.push(record);
+    hashes.push(Some(full_text_hash));
+}
+
+fn read_meta(log_dir: &Path) -> Option<SessionMeta> {
+    let raw = std::fs::read_to_string(log_dir.join("session_meta.json")).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+/// Read the sidecar span an event references (`file` + `data.model_offset`
+/// + `data.model_bytes`). The read is bounded a little past the record
+/// text cap — a corrupt length must not balloon memory; the overlong tail
+/// is dropped by [`cap_text`] anyway. A short read (bytes the event
+/// promised aren't there) is an anomaly: skip, don't guess.
+fn read_event_span(
+    log_dir: &Path,
+    event: &serde_json::Value,
+    data: &serde_json::Value,
+) -> Option<String> {
+    let file = event.get("file").and_then(|file| file.as_str())?;
+    let offset = data.get("model_offset").and_then(|offset| offset.as_u64())?;
+    let len = data.get("model_bytes").and_then(|len| len.as_u64())?;
+    let relative = Path::new(file);
+    // The log dir is the trust boundary: never follow an absolute or
+    // parent-escaping reference out of it.
+    if relative.is_absolute()
+        || relative
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+    {
+        return None;
+    }
+    let bounded = len.min(MESSAGE_TEXT_CAP_BYTES as u64 + 8);
+    let mut spanned = vec![0u8; bounded as usize];
+    let mut handle = std::fs::File::open(log_dir.join(relative)).ok()?;
+    handle.seek(SeekFrom::Start(offset)).ok()?;
+    handle.read_exact(&mut spanned).ok()?;
+    Some(String::from_utf8_lossy(&spanned).into_owned())
+}
+
+/// Parse a legacy `"Round {N} follow-up: {text}"` info line; the optional
+/// `" ({n} attachment(s))"` suffix the emitter appends is stripped.
+/// Best-effort by design: user text that itself ends with that shape loses
+/// the tail (plan §5 records this lane as best-effort).
+fn parse_round_follow_up(message: &str) -> Option<String> {
+    let rest = message.strip_prefix("Round ")?;
+    let space = rest.find(' ')?;
+    if rest[..space].is_empty() || !rest[..space].bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let text = rest[space..].strip_prefix(" follow-up: ")?;
+    if let Some(head) = text.strip_suffix(" attachment(s))") {
+        if let Some(open) = head.rfind(" (") {
+            if head[open + 2..].bytes().all(|byte| byte.is_ascii_digit())
+                && !head[open + 2..].is_empty()
+            {
+                return Some(head[..open].to_string());
+            }
+        }
+    }
+    Some(text.to_string())
+}
+
+/// Dates legacy rows (plan §5): pre-F2 events carry only a local
+/// time-of-day `ts`, so the calendar date comes from
+/// `session_meta.json`'s `created_at` plus midnight-wrap inference (the
+/// date advances whenever the time-of-day decreases between consecutive
+/// dated rows). Naive datetimes are interpreted as UTC unless the meta's
+/// `created_at_ms` reveals the session's true offset — deterministic
+/// everywhere, and at worst hours off on pre-2026-07 sessions, which only
+/// nudges the 14-day retention edge. Rows carrying `ts_ms` use it as-is.
+struct LegacyDater {
+    current: Option<chrono::NaiveDateTime>,
+    offset_ms: i64,
+    meta_ms: i64,
+}
+
+impl LegacyDater {
+    fn new(meta: Option<&SessionMeta>) -> Self {
+        let created_naive = meta.and_then(|meta| {
+            chrono::NaiveDateTime::parse_from_str(&meta.created_at, "%Y-%m-%dT%H:%M:%S").ok()
+        });
+        let created_ms = meta.and_then(|meta| meta.created_at_ms);
+        let offset_ms = match (created_naive, created_ms) {
+            (Some(naive), Some(ms)) => ms - naive.and_utc().timestamp_millis(),
+            _ => 0,
+        };
+        let meta_ms = created_ms
+            .or_else(|| created_naive.map(|naive| naive.and_utc().timestamp_millis()))
+            .unwrap_or(0);
+        Self {
+            current: created_naive,
+            offset_ms,
+            meta_ms,
+        }
+    }
+
+    /// The best timestamp for a record sourced from the meta itself.
+    fn meta_ts_ms(&self) -> i64 {
+        self.meta_ms
+    }
+
+    fn date_row(&mut self, ts_ms: Option<i64>, event: &serde_json::Value) -> i64 {
+        if let Some(ts_ms) = ts_ms {
+            return ts_ms;
+        }
+        let Some(tod) = event
+            .get("ts")
+            .and_then(|ts| ts.as_str())
+            .and_then(parse_time_of_day)
+        else {
+            return self.meta_ms;
+        };
+        let Some(current) = self.current else {
+            // No meta anchor at all (broken dir): undatable, excluded by
+            // retention rather than invented.
+            return 0;
+        };
+        let date = if tod < current.time() {
+            current
+                .date()
+                .succ_opt()
+                .unwrap_or_else(|| current.date())
+        } else {
+            current.date()
+        };
+        let stamped = date.and_time(tod);
+        self.current = Some(stamped);
+        stamped.and_utc().timestamp_millis() + self.offset_ms
+    }
+}
+
+fn parse_time_of_day(ts: &str) -> Option<chrono::NaiveTime> {
+    chrono::NaiveTime::parse_from_str(ts, "%H:%M:%S%.3f")
+        .or_else(|_| chrono::NaiveTime::parse_from_str(ts, "%H:%M:%S"))
+        .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::cursor::CursorCheck;
+    use super::super::record::derive_active;
+    use super::*;
+    use std::io::Write;
+
+    fn write_lines(dir: &Path, lines: &[serde_json::Value]) {
+        let mut body = String::new();
+        for line in lines {
+            body.push_str(&line.to_string());
+            body.push('\n');
+        }
+        std::fs::write(dir.join("session.jsonl"), body).unwrap();
+    }
+
+    fn write_meta(dir: &Path, created_at: &str, created_at_ms: Option<i64>, task: Option<&str>) {
+        let mut meta = serde_json::json!({
+            "session_id": "meta-id",
+            "created_at": created_at,
+        });
+        if let Some(ms) = created_at_ms {
+            meta["created_at_ms"] = serde_json::Value::from(ms);
+        }
+        if let Some(task) = task {
+            meta["task"] = serde_json::Value::from(task);
+        }
+        std::fs::write(dir.join("session_meta.json"), meta.to_string()).unwrap();
+    }
+
+    fn sidecar(dir: &Path, name: &str, body: &str) {
+        std::fs::create_dir_all(dir.join("turns")).unwrap();
+        std::fs::write(dir.join("turns").join(name), body).unwrap();
+    }
+
+    fn conversation_message_user(seq: u64, ts_ms: i64, text: &str) -> serde_json::Value {
+        serde_json::json!({
+            "ts": "10:00:00.000", "ts_ms": ts_ms, "event": "conversation_message",
+            "data": {"message_id": format!("mid-{seq}"), "message_seq": seq,
+                     "role": "user", "provenance": "task", "text": text},
+        })
+    }
+
+    fn conversation_message_assistant(
+        seq: u64,
+        ts_ms: i64,
+        file: &str,
+        offset: u64,
+        len: u64,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "ts": "10:00:01.000", "ts_ms": ts_ms, "event": "conversation_message",
+            "file": file,
+            "data": {"message_id": format!("mid-{seq}"), "message_seq": seq,
+                     "role": "assistant", "provenance": "assistant",
+                     "model_offset": offset, "model_bytes": len},
+        })
+    }
+
+    fn model_response(ts: &str, file: &str, offset: u64, len: u64) -> serde_json::Value {
+        serde_json::json!({
+            "ts": ts, "event": "model_response",
+            "file": file,
+            "data": {"model_offset": offset, "model_bytes": len, "content_length": len},
+        })
+    }
+
+    #[test]
+    fn new_era_session_extracts_canonical_rows_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("sess-new");
+        std::fs::create_dir_all(&dir).unwrap();
+        write_meta(&dir, "2026-07-01T10:00:00", Some(1_780_000_000_000), None);
+        sidecar(&dir, "turn_001_model.txt", "HELLOFULL ASSISTANT TEXT");
+        write_lines(
+            &dir,
+            &[
+                // Diagnostics that must NOT double-extract in a new-era log:
+                serde_json::json!({"ts":"10:00:00.000","ts_ms":1,"event":"session_started",
+                    "data":{"session_id":"sess-new","task":"build the thing"}}),
+                serde_json::json!({"ts":"10:00:00.000","ts_ms":1,"event":"info",
+                    "message":"Round 2 follow-up: also this"}),
+                model_response("10:00:01.000", "turns/turn_001_model.txt", 5, 19),
+                conversation_message_user(1, 1_000, "build the thing"),
+                conversation_message_assistant(2, 2_000, "turns/turn_001_model.txt", 5, 19),
+                conversation_message_user(3, 3_000, "scratch that"),
+                serde_json::json!({"ts":"10:00:05.000","ts_ms":4_000,"event":"conversation_rewound",
+                    "data":{"cut_after_seq":2,"kind":"tail_rollback","superseded_at_ms":4_000}}),
+            ],
+        );
+
+        let out = extract_intendant_session(&dir).unwrap();
+        assert!(!out.wrapper);
+        let texts: Vec<&str> = out
+            .shard
+            .records
+            .iter()
+            .map(|record| record.text.as_str())
+            .collect();
+        assert_eq!(
+            texts,
+            vec!["build the thing", "FULL ASSISTANT TEXT", "scratch that"],
+            "canonical rows only — the legacy diagnostics are not re-extracted"
+        );
+        assert_eq!(out.shard.records[0].seq, Some(1));
+        assert_eq!(out.shard.records[1].role, Role::Assistant);
+        assert_eq!(
+            out.shard.records[1].locator,
+            Locator::NativeMessageId {
+                message_id: "mid-2".into()
+            }
+        );
+        assert_eq!(out.shard.records[2].ts_ms, 3_000);
+        assert_eq!(out.shard.marks.len(), 1);
+        let active = derive_active(&out.shard.records, &out.shard.marks);
+        assert_eq!(active, vec![true, true, false], "seq 3 superseded by the cut");
+        assert_eq!(out.cursors.len(), 1);
+        assert_eq!(out.cursors[0].check(), CursorCheck::Unchanged);
+    }
+
+    #[test]
+    fn wrapper_sessions_yield_an_empty_shard_with_a_cursor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("sess-wrap");
+        std::fs::create_dir_all(&dir).unwrap();
+        sidecar(&dir, "turn_001_model.txt", "wrapped text");
+        write_lines(
+            &dir,
+            &[
+                serde_json::json!({"ts":"09:00:00.000","ts_ms":1,"event":"session_identity",
+                    "data":{"session_id":"sess-wrap","source":"codex","backend_session_id":"abc"}}),
+                model_response("09:00:01.000", "turns/turn_001_model.txt", 0, 12),
+            ],
+        );
+        let out = extract_intendant_session(&dir).unwrap();
+        assert!(out.wrapper);
+        assert!(out.shard.records.is_empty());
+        assert_eq!(out.cursors.len(), 1, "cursor still captured for sweep skip");
+    }
+
+    #[test]
+    fn legacy_session_reconstructs_user_lane_and_spans() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("sess-old");
+        std::fs::create_dir_all(&dir).unwrap();
+        write_meta(&dir, "2026-01-01T23:59:00", None, None);
+        sidecar(&dir, "turn_001_model.txt", "AABBBB");
+        write_lines(
+            &dir,
+            &[
+                serde_json::json!({"ts":"23:59:01.000","event":"session_started",
+                    "data":{"session_id":"sess-old","task":"the legacy task"}}),
+                serde_json::json!({"ts":"23:59:02.000","event":"steer_requested",
+                    "data":{"id":"st-1","status":"pending","text":"go left"}}),
+                serde_json::json!({"ts":"23:59:03.000","event":"steer_requested",
+                    "data":{"id":"st-2","status":"pending","text":"never delivered"}}),
+                model_response("23:59:30.000", "turns/turn_001_model.txt", 0, 2),
+                // Past midnight: the date must wrap forward.
+                serde_json::json!({"ts":"00:00:05.000","event":"steer_delivered",
+                    "data":{"id":"st-1","status":"delivered","mid_turn":false}}),
+                serde_json::json!({"ts":"00:01:00.000","event":"info",
+                    "message":"Round 2 follow-up: try the other door (2 attachment(s))"}),
+                model_response("00:01:30.000", "turns/turn_001_model.txt", 2, 4),
+            ],
+        );
+
+        let out = extract_intendant_session(&dir).unwrap();
+        let records = &out.shard.records;
+        let texts: Vec<&str> = records.iter().map(|record| record.text.as_str()).collect();
+        assert_eq!(
+            texts,
+            vec![
+                "the legacy task",
+                "AA",
+                "go left",
+                "try the other door",
+                "BBBB"
+            ]
+        );
+        // Undelivered steer produced nothing.
+        assert!(!texts.contains(&"never delivered"));
+
+        // Dating: naive-as-UTC off created_at 2026-01-01, wrapping at midnight.
+        let day1 = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+        let day2 = chrono::NaiveDate::from_ymd_opt(2026, 1, 2).unwrap();
+        let expect = |date: chrono::NaiveDate, time: &str| {
+            date.and_time(chrono::NaiveTime::parse_from_str(time, "%H:%M:%S%.3f").unwrap())
+                .and_utc()
+                .timestamp_millis()
+        };
+        assert_eq!(records[0].ts_ms, expect(day1, "23:59:01.000"));
+        assert_eq!(records[2].ts_ms, expect(day2, "00:00:05.000"), "wrapped");
+        assert_eq!(records[3].ts_ms, expect(day2, "00:01:00.000"));
+
+        // Locators: steer anchors on the REQUESTED line (where the text is).
+        assert_eq!(
+            records[2].locator,
+            Locator::NativeEvent {
+                line_no: 2,
+                content_hash16: content_hash_hex16("go left"),
+            }
+        );
+        assert_eq!(
+            records[4].locator,
+            Locator::NativeSidecarSpan {
+                file: "turns/turn_001_model.txt".into(),
+                offset: 2,
+                len: 4,
+                content_hash16: content_hash_hex16("BBBB"),
+            }
+        );
+        // No marks in a legacy session.
+        assert!(out.shard.marks.is_empty());
+    }
+
+    #[test]
+    fn legacy_top_level_task_falls_back_to_meta() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("sess-meta");
+        std::fs::create_dir_all(&dir).unwrap();
+        write_meta(
+            &dir,
+            "2026-01-05T08:00:00",
+            Some(1_767_600_000_000),
+            Some("meta-only task"),
+        );
+        write_lines(
+            &dir,
+            &[serde_json::json!({"ts":"08:00:01.000","event":"info","message":"hello"})],
+        );
+        let out = extract_intendant_session(&dir).unwrap();
+        assert_eq!(out.shard.records.len(), 1);
+        assert_eq!(out.shard.records[0].text, "meta-only task");
+        assert_eq!(out.shard.records[0].ts_ms, 1_767_600_000_000);
+        assert_eq!(
+            out.shard.records[0].locator,
+            Locator::NativeEvent {
+                line_no: 0,
+                content_hash16: content_hash_hex16("meta-only task"),
+            },
+            "line 0 marks a meta-sourced record"
+        );
+    }
+
+    #[test]
+    fn epoch_marker_splits_eras_and_correlates_seqs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("sess-mixed");
+        std::fs::create_dir_all(&dir).unwrap();
+        write_meta(&dir, "2026-06-01T10:00:00", None, None);
+        sidecar(&dir, "turn_001_model.txt", "legacy answer");
+        write_lines(
+            &dir,
+            &[
+                serde_json::json!({"ts":"10:00:01.000","event":"session_started",
+                    "data":{"session_id":"sess-mixed","task":"old task"}}),
+                model_response("10:00:02.000", "turns/turn_001_model.txt", 0, 13),
+                serde_json::json!({"ts":"11:00:00.000","ts_ms":100,"event":"conversation_message_epoch",
+                    "data":{"mapping":[
+                        [1, "system", "ffffffffffffffff"],
+                        [2, "user", content_hash_hex16("old task")],
+                        [3, "assistant", content_hash_hex16("legacy answer")],
+                    ]}}),
+                conversation_message_user(4, 200, "post-resume message"),
+                // Legacy-shaped rows AFTER the marker must be ignored:
+                model_response("11:00:02.000", "turns/turn_001_model.txt", 0, 13),
+                serde_json::json!({"ts":"11:00:03.000","ts_ms":300,"event":"conversation_rewound",
+                    "data":{"cut_after_seq":2,"kind":"tail_rollback","superseded_at_ms":300}}),
+            ],
+        );
+
+        let out = extract_intendant_session(&dir).unwrap();
+        let records = &out.shard.records;
+        assert_eq!(records.len(), 3, "legacy task + legacy span + one canonical");
+        assert_eq!(records[0].seq, Some(2), "correlated through the mapping");
+        assert_eq!(records[1].seq, Some(3));
+        assert_eq!(records[2].seq, Some(4));
+        let active = derive_active(records, &out.shard.marks);
+        assert_eq!(
+            active,
+            vec![true, false, false],
+            "the cut after seq 2 supersedes the correlated legacy assistant too"
+        );
+    }
+
+    #[test]
+    fn rows_with_ts_ms_use_it_directly() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("sess-f2");
+        std::fs::create_dir_all(&dir).unwrap();
+        write_meta(&dir, "2026-01-01T00:00:00", None, None);
+        write_lines(
+            &dir,
+            &[serde_json::json!({"ts":"12:00:00.000","ts_ms":42_000,"event":"session_started",
+                "data":{"session_id":"sess-f2","task":"dated task"}})],
+        );
+        let out = extract_intendant_session(&dir).unwrap();
+        assert_eq!(out.shard.records[0].ts_ms, 42_000);
+    }
+
+    #[test]
+    fn partial_trailing_line_stays_unread_and_missing_log_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("sess-partial");
+        std::fs::create_dir_all(&dir).unwrap();
+        write_meta(&dir, "2026-01-01T00:00:00", None, None);
+        let full = conversation_message_user(1, 1_000, "whole line").to_string();
+        let mut file = std::fs::File::create(dir.join("session.jsonl")).unwrap();
+        writeln!(file, "{full}").unwrap();
+        write!(file, "{{\"event\":\"conversation_message\",\"data\":{{\"te").unwrap();
+        drop(file);
+
+        let out = extract_intendant_session(&dir).unwrap();
+        assert_eq!(out.shard.records.len(), 1);
+        assert_eq!(
+            out.cursors[0].last_complete_line_offset,
+            full.len() as u64 + 1
+        );
+        assert_eq!(out.cursors[0].check(), CursorCheck::Appended);
+
+        let empty = tmp.path().join("sess-none");
+        std::fs::create_dir_all(&empty).unwrap();
+        let out = extract_intendant_session(&empty).unwrap();
+        assert!(out.shard.records.is_empty());
+        assert!(out.cursors.is_empty());
+    }
+
+    #[test]
+    fn span_reads_never_escape_the_log_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("sess-escape");
+        std::fs::create_dir_all(&dir).unwrap();
+        write_meta(&dir, "2026-01-01T00:00:00", None, None);
+        std::fs::write(tmp.path().join("outside.txt"), "SECRET").unwrap();
+        write_lines(
+            &dir,
+            &[
+                serde_json::json!({"ts":"10:00:00.000","event":"model_response",
+                    "file":"../outside.txt",
+                    "data":{"model_offset":0,"model_bytes":6}}),
+                serde_json::json!({"ts":"10:00:01.000","event":"model_response",
+                    "file":"/etc/hosts",
+                    "data":{"model_offset":0,"model_bytes":4}}),
+            ],
+        );
+        let out = extract_intendant_session(&dir).unwrap();
+        assert!(out.shard.records.is_empty());
+    }
+
+    #[test]
+    fn round_follow_up_parsing_is_strict_about_shape() {
+        assert_eq!(
+            parse_round_follow_up("Round 3 follow-up: plain text"),
+            Some("plain text".to_string())
+        );
+        assert_eq!(
+            parse_round_follow_up("Round 3 follow-up: with files (12 attachment(s))"),
+            Some("with files".to_string())
+        );
+        assert_eq!(parse_round_follow_up("Round x follow-up: nope"), None);
+        assert_eq!(parse_round_follow_up("Skipped cancelled queued follow-up"), None);
+        assert_eq!(parse_round_follow_up("Round 12 complete (3 turns)"), None);
+    }
+}

--- a/src/bin/caller/message_search/mod.rs
+++ b/src/bin/caller/message_search/mod.rs
@@ -20,10 +20,12 @@
 #![allow(dead_code, unused_imports)]
 
 mod cursor;
+mod extract_intendant;
 mod record;
 mod store;
 
 pub(crate) use cursor::{read_complete_lines_from, CursorCheck, SourceCursor};
+pub(crate) use extract_intendant::{extract_intendant_session, IntendantExtraction};
 pub(crate) use record::{
     cap_text, derive_active, Locator, MessageRecord, Role, Source, SupersessionMark,
     MESSAGE_TEXT_CAP_BYTES, PARSER_VERSION,

--- a/src/bin/caller/provider_mock.rs
+++ b/src/bin/caller/provider_mock.rs
@@ -83,6 +83,12 @@ struct MockStep {
     /// limit gauges keyless.
     #[serde(default)]
     limit_used_pct: Option<u8>,
+    /// Scripted think-time before this step answers. E2e rigs use it to
+    /// hold a boot-started task's first step until their dashboard
+    /// connection is up — nothing replays missed rail events (e.g.
+    /// `user_question`) to late-joining websockets.
+    #[serde(default)]
+    delay_ms: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -168,42 +174,53 @@ impl ChatProvider for MockProvider {
             .collect::<Vec<_>>()
             .join("\n");
 
-        let mut cursor = self.cursor.lock().expect("mock cursor poisoned");
-        let (profile_index, step_index) = match *cursor {
-            Some(state) => state,
-            None => {
-                let profile = self.select_profile(&transcript).ok_or_else(|| {
-                    CallerError::Config(
-                        "mock script has no profile matching this conversation and no \
-                         fallback profile (empty match)"
-                            .to_string(),
-                    )
-                })?;
-                (profile, 0)
-            }
-        };
+        // The guard protects only the cursor, and it must not live across
+        // the think-time await below — scope it (async-Send analysis does
+        // not credit an explicit drop).
+        let (profile_index, step_index) = {
+            let mut cursor = self.cursor.lock().expect("mock cursor poisoned");
+            let (profile_index, step_index) = match *cursor {
+                Some(state) => state,
+                None => {
+                    let profile = self.select_profile(&transcript).ok_or_else(|| {
+                        CallerError::Config(
+                            "mock script has no profile matching this conversation and no \
+                             fallback profile (empty match)"
+                                .to_string(),
+                        )
+                    })?;
+                    (profile, 0)
+                }
+            };
 
-        let profile = &self.script.profiles[profile_index];
-        let Some(step) = profile.steps.get(step_index) else {
-            return Err(CallerError::Config(format!(
-                "mock script exhausted: profile {profile_index} (match {:?}) has only {} steps \
-                 but the loop asked for step {} — scripts must end in signal_done/submit_result",
-                profile.match_text,
-                profile.steps.len(),
-                step_index + 1,
-            )));
-        };
-
-        if let Some(expected) = &step.expect_transcript_contains {
-            if !transcript.contains(expected) {
+            let profile = &self.script.profiles[profile_index];
+            let Some(step) = profile.steps.get(step_index) else {
                 return Err(CallerError::Config(format!(
-                    "mock expectation failed at profile {profile_index} step {step_index}: \
-                     transcript does not contain {expected:?}"
+                    "mock script exhausted: profile {profile_index} (match {:?}) has only {} steps \
+                     but the loop asked for step {} — scripts must end in signal_done/submit_result",
+                    profile.match_text,
+                    profile.steps.len(),
+                    step_index + 1,
                 )));
-            }
-        }
+            };
 
-        *cursor = Some((profile_index, step_index + 1));
+            if let Some(expected) = &step.expect_transcript_contains {
+                if !transcript.contains(expected) {
+                    return Err(CallerError::Config(format!(
+                        "mock expectation failed at profile {profile_index} step {step_index}: \
+                         transcript does not contain {expected:?}"
+                    )));
+                }
+            }
+
+            *cursor = Some((profile_index, step_index + 1));
+            (profile_index, step_index)
+        };
+        let profile = &self.script.profiles[profile_index];
+        let step = &profile.steps[step_index];
+        if step.delay_ms > 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(step.delay_ms)).await;
+        }
 
         // Plausible non-zero usage so budget and usage accounting run.
         // Cache counters emulate a warm prompt cache (first request writes,

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -2781,3 +2781,623 @@ async fn supervised_session_ask_human_reaches_the_question_rail() {
 
     let _ = child.kill().await;
 }
+
+/// Shared assertions for the message-search wire contract (plan §4/§11):
+/// the intendant extractor consumes exactly these `session.jsonl` shapes,
+/// and its unit tests use fixtures of them — these helpers pin the shapes
+/// to the real binary so schema drift fails here instead of silently
+/// unindexing. Returns the parsed `conversation_message` rows.
+fn canonical_message_rows(rows: &[serde_json::Value]) -> Vec<&serde_json::Value> {
+    let messages: Vec<&serde_json::Value> = rows
+        .iter()
+        .filter(|row| row.get("event").and_then(|v| v.as_str()) == Some("conversation_message"))
+        .collect();
+    for row in &messages {
+        assert!(
+            msg_field(row, "message_id")
+                .as_str()
+                .is_some_and(|id| !id.is_empty()),
+            "conversation_message without a message_id: {row}"
+        );
+        assert!(
+            msg_field(row, "message_seq").as_u64().is_some(),
+            "conversation_message without a message_seq: {row}"
+        );
+        assert!(
+            row.get("ts_ms").and_then(|v| v.as_i64()).is_some(),
+            "conversation_message without ts_ms: {row}"
+        );
+    }
+    let seqs: Vec<u64> = messages
+        .iter()
+        .filter_map(|row| msg_field(row, "message_seq").as_u64())
+        .collect();
+    let mut sorted = seqs.clone();
+    sorted.sort_unstable();
+    sorted.dedup();
+    assert_eq!(
+        seqs.len(),
+        sorted.len(),
+        "message seqs must be unique: {seqs:?}"
+    );
+    messages
+}
+
+fn msg_field(row: &serde_json::Value, name: &str) -> serde_json::Value {
+    row.pointer(&format!("/data/{name}"))
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// The user-side row with exactly this RAW text (no attachment preludes,
+/// no tool-result envelopes, no delivery wrappers).
+fn user_message_row<'rows>(
+    messages: &[&'rows serde_json::Value],
+    text: &str,
+) -> &'rows serde_json::Value {
+    messages
+        .iter()
+        .find(|row| {
+            msg_field(row, "role").as_str() == Some("user")
+                && msg_field(row, "text").as_str() == Some(text)
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "no user conversation_message with raw text {text:?}; rows:\n{}",
+                messages
+                    .iter()
+                    .map(|row| row.to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        })
+}
+
+/// Resolve an assistant row's sidecar span byte-for-byte, exactly like
+/// the extractor does.
+fn resolve_assistant_span(log_dir: &std::path::Path, row: &serde_json::Value) -> String {
+    let file = row
+        .get("file")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("assistant row without a sidecar file: {row}"));
+    let offset = msg_field(row, "model_offset")
+        .as_u64()
+        .unwrap_or_else(|| panic!("assistant row without model_offset: {row}"));
+    let len = msg_field(row, "model_bytes")
+        .as_u64()
+        .unwrap_or_else(|| panic!("assistant row without model_bytes: {row}"));
+    let bytes = std::fs::read(log_dir.join(file)).expect("read sidecar");
+    String::from_utf8_lossy(&bytes[offset as usize..(offset + len) as usize]).into_owned()
+}
+
+fn assert_assistant_spans_resolve(
+    log_dir: &std::path::Path,
+    messages: &[&serde_json::Value],
+    expected: &[&str],
+) {
+    let assistant_texts: Vec<String> = messages
+        .iter()
+        .filter(|row| msg_field(row, "role").as_str() == Some("assistant"))
+        .map(|row| resolve_assistant_span(log_dir, row))
+        .collect();
+    for text in expected {
+        assert!(
+            assistant_texts.iter().any(|resolved| resolved == text),
+            "no assistant span resolved to {text:?}; got {assistant_texts:?}"
+        );
+    }
+}
+
+fn parsed_session_rows(log_dir: &std::path::Path) -> Vec<serde_json::Value> {
+    let log = std::fs::read_to_string(log_dir.join("session.jsonl")).expect("read session.jsonl");
+    log.lines()
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect()
+}
+
+/// Message-lane wire contract, supervised-session half: a create_session
+/// child run through task → askHuman answer → between-rounds steer writes
+/// canonical `conversation_message` rows with RAW user text (provenances
+/// `task` / `ask_human_answer` / `steer`), the askHuman projection's
+/// `ref_seq`, and assistant sidecar spans that resolve byte-for-byte. The
+/// steer rides the supervisor's parked-delivery fallback (`route_steer`
+/// queues an id-carrying steer as a follow-up when no active turn acks
+/// it) — the shape the dashboard uses. Conversation rollback deliberately
+/// lives in the OTHER half: a child parks in `run_round_loop`'s follow-up
+/// drain, which never sees `ConversationRollbackRequested`.
+#[tokio::test]
+async fn supervised_session_writes_task_ask_human_and_steer_message_rows() {
+    use futures_util::SinkExt;
+
+    let rig = TestRig::new();
+    let script = rig.write_script(&serde_json::json!({
+        "profiles": [{
+            "steps": [
+                { "content": "Need input before charting.",
+                  "tool_calls": [{ "name": "ask_human",
+                                   "arguments": { "nonce": 1, "question": "Which payload?" } }] },
+                { "content": "Round one done, payload chosen.",
+                  "expect_transcript_contains": "the emerald payload",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "round one" } }] },
+                { "content": "Steered round two.",
+                  "expect_transcript_contains": "steer toward the vault",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "round two" } }] }
+            ]
+        }]
+    }));
+    let session_project = tempfile::tempdir().expect("session project dir");
+
+    let mut cmd = rig.command();
+    cmd.env("INTENDANT_MOCK_SCRIPT", &script)
+        .args(["--no-tls", "--web", "0"]);
+    let mut child = cmd.spawn().expect("spawn intendant daemon");
+    let stderr_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let stdout_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let _stderr_drain = drain_pipe_into(child.stderr.take().expect("stderr"), stderr_buf.clone());
+    let _stdout_drain = drain_pipe_into(child.stdout.take().expect("stdout"), stdout_buf.clone());
+
+    let stderr_so_far = wait_for_output(&stderr_buf, "Dashboard: http://", RUN_TIMEOUT).await;
+    let port: u16 = stderr_so_far
+        .lines()
+        .find_map(|line| {
+            let url = line.strip_prefix("Dashboard: http://")?;
+            url.rsplit(':').next()?.trim().parse().ok()
+        })
+        .expect("parse the dashboard port from the startup line");
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/ws"))
+        .await
+        .expect("connect /ws");
+
+    // Same startup race + retry shape as the askHuman e2e above.
+    let mut question = None;
+    for _ in 0..6 {
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::json!({
+                "action": "create_session",
+                "task": "chart the payload course",
+                "project_root": session_project.path().to_string_lossy(),
+                "direct": true,
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send create_session");
+        question = next_matching_ws_event(&mut ws, Duration::from_secs(30), |json| {
+            json.get("event").and_then(|v| v.as_str()) == Some("user_question")
+        })
+        .await;
+        if question.is_some() {
+            break;
+        }
+    }
+    let question = question.unwrap_or_else(|| {
+        panic!(
+            "no user_question from the session's askHuman; daemon stderr:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
+        )
+    });
+    let session_id = question
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .expect("user_question carries its session id")
+        .to_string();
+    let question_id = question
+        .get("id")
+        .and_then(|v| v.as_u64())
+        .expect("user_question carries an id");
+    let question_text = question
+        .pointer("/questions/0/question")
+        .and_then(|v| v.as_str())
+        .expect("user_question carries the question text")
+        .to_string();
+
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "answer_question",
+            "session_id": session_id,
+            "id": question_id,
+            "answers": { question_text: "the emerald payload" },
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send answer_question");
+
+    // Round 1 completes (the transcript gate proved the answer landed).
+    next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("round_complete")
+            && json.get("session_id").and_then(|v| v.as_str()) == Some(session_id.as_str())
+    })
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "round 1 never completed; daemon stderr:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
+        )
+    });
+
+    // A between-rounds steer. The id is load-bearing: only an id-carrying
+    // steer arms route_steer's no-active-turn fallback that delivers to a
+    // parked session, and the dashboard always sends one.
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "steer",
+            "session_id": session_id,
+            "id": "steer-e2e-1",
+            "text": "steer toward the vault",
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send steer");
+    next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("round_complete")
+            && json.get("session_id").and_then(|v| v.as_str()) == Some(session_id.as_str())
+    })
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "steered round 2 never completed; daemon stderr:\n{}\nsession logs:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default(),
+            tail(&rig.session_logs(), 6000)
+        )
+    });
+
+    // Both rounds are already consumed above — only the stop half of the
+    // usual completion ritual remains (the session parks by design).
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({ "action": "stop_session", "session_id": session_id })
+            .to_string()
+            .into(),
+    ))
+    .await
+    .expect("send stop_session");
+    next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("session_ended")
+            && json.get("session_id").and_then(|v| v.as_str()) == Some(session_id.as_str())
+    })
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "stopped session never ended; daemon stderr:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
+        )
+    });
+    let _ = child.kill().await;
+
+    // ---- The wire contract the extractor consumes ----
+    let log_dir = rig
+        .home
+        .path()
+        .join(".intendant")
+        .join("logs")
+        .join(&session_id);
+    let rows = parsed_session_rows(&log_dir);
+    let messages = canonical_message_rows(&rows);
+
+    let task_row = user_message_row(&messages, "chart the payload course");
+    assert_eq!(msg_field(task_row, "provenance").as_str(), Some("task"));
+    let answer_row = user_message_row(&messages, "the emerald payload");
+    assert_eq!(
+        msg_field(answer_row, "provenance").as_str(),
+        Some("ask_human_answer")
+    );
+    assert!(
+        msg_field(answer_row, "ref_seq").as_u64().is_some(),
+        "the native-tool askHuman projection must reference its tool result: {answer_row}"
+    );
+    let steer_row = user_message_row(&messages, "steer toward the vault");
+    assert_eq!(msg_field(steer_row, "provenance").as_str(), Some("steer"));
+
+    assert_assistant_spans_resolve(
+        &log_dir,
+        &messages,
+        &[
+            "Need input before charting.",
+            "Round one done, payload chosen.",
+            "Steered round two.",
+        ],
+    );
+}
+
+/// Message-lane wire contract, rollback half: the HEADLESS shape (task on
+/// argv) is the one execution shape whose outer loop (run_with_presence)
+/// handles `ConversationRollbackRequested`, so the round-rollback rail —
+/// `GET /api/session/current/history` + `POST
+/// /api/session/current/rollback` — runs here. Two rounds (boot task with
+/// an askHuman answer, then a second task into the same primary session),
+/// then a conversation-only revert to round 1 must write a
+/// `conversation_rewound` row whose cut keeps round 1 and supersedes
+/// round 2 — exactly the SeqCut semantics the extractor derives
+/// supersession from.
+#[tokio::test]
+async fn headless_rollback_writes_a_conversation_rewound_cut() {
+    use futures_util::SinkExt;
+
+    let rig = TestRig::new();
+    let script = rig.write_script(&serde_json::json!({
+        "profiles": [{
+            "steps": [
+                // The boot task starts before any websocket can connect,
+                // and rail events do not replay to late joiners — the
+                // scripted think-time holds the question back until this
+                // test's connection is up.
+                { "content": "Need input before charting.",
+                  "delay_ms": 8_000,
+                  "tool_calls": [{ "name": "ask_human",
+                                   "arguments": { "nonce": 1, "question": "Which payload?" } }] },
+                { "content": "Round one done, payload chosen.",
+                  "expect_transcript_contains": "the emerald payload",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "round one" } }] },
+                { "content": "Second round response.",
+                  "expect_transcript_contains": "chase the decoy",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "round two" } }] }
+            ]
+        }]
+    }));
+    // The rollback rail needs the file watcher's round history, which a
+    // projectless run turns off — mark the rig project.
+    std::fs::write(rig.project.path().join("intendant.toml"), "").expect("project marker");
+
+    let mut cmd = rig.command();
+    cmd.env("INTENDANT_MOCK_SCRIPT", &script).args([
+        "--no-tls",
+        "--web",
+        "0",
+        "--direct",
+        "chart the payload course",
+    ]);
+    let mut child = cmd.spawn().expect("spawn intendant with a boot task");
+    let stderr_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let stdout_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let _stderr_drain = drain_pipe_into(child.stderr.take().expect("stderr"), stderr_buf.clone());
+    let _stdout_drain = drain_pipe_into(child.stdout.take().expect("stdout"), stdout_buf.clone());
+
+    let stderr_so_far = wait_for_output(&stderr_buf, "Dashboard: http://", RUN_TIMEOUT).await;
+    let port: u16 = stderr_so_far
+        .lines()
+        .find_map(|line| {
+            let url = line.strip_prefix("Dashboard: http://")?;
+            url.rsplit(':').next()?.trim().parse().ok()
+        })
+        .expect("parse the dashboard port from the startup line");
+    // The primary (boot) session announces its id and log dir at startup.
+    let primary_id = stderr_so_far
+        .lines()
+        .find_map(|line| line.strip_prefix("Session ID: "))
+        .expect("parse the primary session id from the startup lines")
+        .trim()
+        .to_string();
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/ws"))
+        .await
+        .expect("connect /ws");
+
+    let question = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("user_question")
+    })
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "no user_question from the boot task's askHuman; daemon stderr:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
+        )
+    });
+    let session_id = question
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&primary_id)
+        .to_string();
+    let question_id = question
+        .get("id")
+        .and_then(|v| v.as_u64())
+        .expect("user_question carries an id");
+    let question_text = question
+        .pointer("/questions/0/question")
+        .and_then(|v| v.as_str())
+        .expect("user_question carries the question text")
+        .to_string();
+
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "answer_question",
+            "session_id": session_id,
+            "id": question_id,
+            "answers": { question_text: "the emerald payload" },
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send answer_question");
+
+    let round_complete_for_primary = |json: &serde_json::Value, session_id: &str| {
+        json.get("event").and_then(|v| v.as_str()) == Some("round_complete")
+            && json
+                .get("session_id")
+                .and_then(|v| v.as_str())
+                .is_none_or(|id| id == session_id)
+    };
+    next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        round_complete_for_primary(json, &session_id)
+    })
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "round 1 never completed; daemon stderr:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
+        )
+    });
+
+    // Round 2: a second task into the SAME primary session (the dispatcher
+    // claims start_task for the primary id; the supervisor would claim an
+    // id-less one as a fresh child session).
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "start_task",
+            "session_id": primary_id,
+            "task": "chase the decoy",
+            "direct": true,
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send start_task");
+    next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        round_complete_for_primary(json, &session_id)
+    })
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "round 2 never completed; daemon stderr:\n{}\nsession logs:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default(),
+            tail(&rig.session_logs(), 6000)
+        )
+    });
+
+    // Conversation-only revert to the first recorded round, through the
+    // dashboard's route (the production `conversation_rewound` path).
+    // Idle-state and history-visibility race the round_complete event, so
+    // poll both.
+    let client = reqwest::Client::new();
+    let stderr_ctx = stderr_buf.clone();
+    let first_round_id = poll_until(
+        "the session history to list its first round",
+        Duration::from_secs(30),
+        || {
+            let client = client.clone();
+            async move {
+                let history = http_get_json(
+                    &client,
+                    &format!("http://127.0.0.1:{port}/api/session/current/history"),
+                )
+                .await?;
+                history
+                    .get("rounds")?
+                    .as_array()?
+                    .first()?
+                    .get("id")?
+                    .as_u64()
+            }
+        },
+        move || stderr_ctx.lock().map(|b| b.clone()).unwrap_or_default(),
+    )
+    .await;
+    let stderr_ctx = stderr_buf.clone();
+    poll_until(
+        "the rollback route to accept the revert",
+        Duration::from_secs(30),
+        || {
+            let client = client.clone();
+            async move {
+                let response = client
+                    .post(format!(
+                        "http://127.0.0.1:{port}/api/session/current/rollback"
+                    ))
+                    .json(&serde_json::json!({
+                        "round_id": first_round_id,
+                        "revert_conversation": true,
+                        "revert_files": false,
+                    }))
+                    .send()
+                    .await
+                    .ok()?;
+                response.status().is_success().then_some(())
+            }
+        },
+        move || stderr_ctx.lock().map(|b| b.clone()).unwrap_or_default(),
+    )
+    .await;
+    next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("conversation_rolled_back")
+    })
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "conversation rollback never completed; daemon stderr:\n{}\nsession logs:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default(),
+            tail(&rig.session_logs(), 6000)
+        )
+    });
+
+    // Every event row is flushed per write; killing the daemon loses
+    // nothing, and the primary session is not user-stoppable anyway.
+    let _ = child.kill().await;
+
+    // ---- The wire contract the extractor consumes ----
+    let log_dir = rig
+        .home
+        .path()
+        .join(".intendant")
+        .join("logs")
+        .join(&session_id);
+    let rows = parsed_session_rows(&log_dir);
+    let messages = canonical_message_rows(&rows);
+
+    let task_row = user_message_row(&messages, "chart the payload course");
+    assert_eq!(msg_field(task_row, "provenance").as_str(), Some("task"));
+    let answer_row = user_message_row(&messages, "the emerald payload");
+    assert_eq!(
+        msg_field(answer_row, "provenance").as_str(),
+        Some("ask_human_answer")
+    );
+    assert!(
+        msg_field(answer_row, "ref_seq").as_u64().is_some(),
+        "the native-tool askHuman projection must reference its tool result: {answer_row}"
+    );
+    let round2_row = user_message_row(&messages, "chase the decoy");
+    assert_assistant_spans_resolve(
+        &log_dir,
+        &messages,
+        &[
+            "Need input before charting.",
+            "Round one done, payload chosen.",
+            "Second round response.",
+        ],
+    );
+
+    // The rollback cut partitions round 2 strictly after the cut, with
+    // all of round 1 surviving — the SeqCut semantics the extractor
+    // derives supersession from.
+    let rewound = rows
+        .iter()
+        .find(|row| row.get("event").and_then(|v| v.as_str()) == Some("conversation_rewound"))
+        .unwrap_or_else(|| {
+            panic!(
+                "no conversation_rewound row; session log:\n{}",
+                tail(&rig.session_logs(), 6000)
+            )
+        });
+    assert_eq!(msg_field(rewound, "kind").as_str(), Some("tail_rollback"));
+    assert!(
+        msg_field(rewound, "superseded_at_ms").as_i64().is_some(),
+        "conversation_rewound must stamp superseded_at_ms: {rewound}"
+    );
+    let cut_after_seq = msg_field(rewound, "cut_after_seq")
+        .as_u64()
+        .expect("conversation_rewound carries cut_after_seq");
+    let round1_max = ["chart the payload course", "the emerald payload"]
+        .iter()
+        .map(|text| {
+            msg_field(user_message_row(&messages, text), "message_seq")
+                .as_u64()
+                .unwrap()
+        })
+        .max()
+        .unwrap();
+    let round2_seq = msg_field(round2_row, "message_seq").as_u64().unwrap();
+    assert!(
+        round1_max <= cut_after_seq && cut_after_seq < round2_seq,
+        "cut_after_seq {cut_after_seq} must keep round 1 (max seq {round1_max}) and \
+         supersede round 2 (seq {round2_seq})"
+    );
+}


### PR DESCRIPTION
B2 of the message-search program (plan v2.2 §5, intendant lane), on the frozen B1 store API.

**Extractor** (`message_search/extract_intendant.rs`): walks one session log dir into a `SessionShard` + cursors.
- Canonical lane: `conversation_message` rows — user text inline, assistant text resolved from the shared sidecar span (bounded reads, confined to the log dir); `conversation_rewound` → `SupersessionMark::SeqCut`.
- Legacy lane (strictly before the `conversation_message_epoch` marker, or whole-file when no canonical rows exist): `session_started` task with `session_meta.json` fallback (top-level sessions carry only the meta copy), delivered steers (`steer_requested` ⋈ `steer_delivered` on id), best-effort `Round {N} follow-up:` info lines, `model_response` sidecar spans. Epoch-mapping correlation assigns seqs to legacy records by (role, content-hash) so rewind cuts cover them; uncorrelated records stay active, never wrongly superseded.
- Legacy dating: per-row `ts_ms` when present, else `created_at` + midnight-wrap inference with the meta's true offset when `created_at_ms` reveals it.
- Skips: wrapper sessions entirely (`session_identity` = the external backend's log is canonical), and session-scoped mirror rows (`data.session_id` ≠ this session) — a daemon/parent log mirrors its supervised children's tasks/steers/spans verbatim, and extracting them would double-index every supervised session (found live by the e2e below).

**E2e** (rides this PR, plan §11): two tests pin the wire contract to the real binary under the mock provider, so schema drift fails in CI instead of silently unindexing.
- Supervised half: task → askHuman answer (raw text + `ref_seq` projection) → parked steer (the supervisor's id-carrying fallback) → provenance-labelled rows + byte-resolved assistant spans + unique seqs.
- Rollback half: the headless boot-task shape (the one execution shape whose outer loop serves the round-rollback rail) — two rounds, then a conversation-only revert writes a `conversation_rewound` cut that keeps round 1 and supersedes round 2.
- The mock provider gains an optional per-step `delay_ms` (a boot-started task races any dashboard websocket; rail events don't replay to late joiners).

Battery: full `cargo nextest run --bins` (3106 passed), plain threaded `cargo test --bin intendant message_search`, full `cargo test --test e2e` (17 passed), `cargo clippy --workspace --locked -- -D warnings`, `cargo fmt --check`.

Notes for reviewers: the module-level parked-seed `#![allow(dead_code, unused_imports)]` in `message_search/mod.rs` stays until the wiring unit consumes the extractors (B3/B4 land next and touch the same mod lines). Two behavior observations recorded while rigging the e2e, reported separately: a between-rounds steer without an `id` never reaches a parked supervised session (no fallback arms), and conversation rollback is only handled by the headless primary-session loop — supervised children park in a drain that never sees the signal.