### PR TITLE
governor: chain flip to RUSTC_WRAPPER — closes the cacheable-miss permit bypass

### DIFF
--- a/crates/rustc-governor/src/config.rs
+++ b/crates/rustc-governor/src/config.rs
@@ -37,9 +37,15 @@ pub struct Config {
     /// Usernames whose invocations are classed `ci`; everyone else is
     /// `local`.
     pub ci_users: Vec<String>,
-    /// Explicit compiler path; when unset the governor resolves
-    /// `$HOME/.cargo/bin/rustc`, then `rustc` from PATH.
-    pub real_rustc: Option<PathBuf>,
+    /// Front of the exec chain for governed *and* fail-open invocations:
+    /// `wrap_with <real-compiler> <args…>` — in production the sccache
+    /// client, whose blocking round-trip is what carries the permit's
+    /// ceiling to server-side compiles. Unset (or written as `""`, which
+    /// the parser normalizes to unset) means "run the compiler directly":
+    /// the governor works without sccache. The real compiler itself is
+    /// never configured here — cargo passes it as argv[1] (the
+    /// RUSTC_WRAPPER contract).
+    pub wrap_with: Option<PathBuf>,
 }
 
 impl Default for Config {
@@ -50,7 +56,7 @@ impl Default for Config {
             local_reserved: 1,
             ci_reserved: 2,
             ci_users: vec!["_intendant-ci".to_string(), "ci".to_string()],
-            real_rustc: None,
+            wrap_with: None,
         }
     }
 }
@@ -94,8 +100,15 @@ pub fn parse(text: &str) -> Result<Config, String> {
             "local_reserved" => cfg.local_reserved = parse_u32(value).map_err(|e| err(&e))?,
             "ci_reserved" => cfg.ci_reserved = parse_u32(value).map_err(|e| err(&e))?,
             "ci_users" => cfg.ci_users = parse_string_array(value).map_err(|e| err(&e))?,
-            "real_rustc" => {
-                cfg.real_rustc = Some(PathBuf::from(parse_string(value).map_err(|e| err(&e))?))
+            "wrap_with" => {
+                // Empty means unset: the installer's here-doc always writes
+                // the key, and operators blank it to unwrap without
+                // deleting the line. (The pre-wrapper-chain `real_rustc`
+                // key needs no arm: unknown keys with well-formed values
+                // are ignored below, so old confs stay parseable and the
+                // key is simply inert.)
+                let s = parse_string(value).map_err(|e| err(&e))?;
+                cfg.wrap_with = (!s.is_empty()).then(|| PathBuf::from(s));
             }
             // Unknown keys are ignored for forward compatibility, but the
             // value must still be one of the shapes we understand — a file
@@ -231,9 +244,16 @@ permit_dir = "/usr/local/var/intendant-governor"
 local_reserved = 1
 ci_reserved = 2   # per-box sizing
 ci_users = ["_intendant-ci", "ci"]
+wrap_with = "/opt/homebrew/bin/sccache"
 "#;
         let cfg = parse(text).unwrap();
-        assert_eq!(cfg, Config::default());
+        assert_eq!(
+            cfg,
+            Config {
+                wrap_with: Some(PathBuf::from("/opt/homebrew/bin/sccache")),
+                ..Config::default()
+            }
+        );
     }
 
     #[test]
@@ -249,7 +269,7 @@ ci_users = ["_intendant-ci", "ci"]
             "local_reserved = 3\n",
             "ci_reserved = 0\n",
             "ci_users = [\"a\", \"b\",]\n",
-            "real_rustc = \"/opt/rustc\"\n",
+            "wrap_with = \"/opt/sccache\"\n",
         );
         let cfg = parse(text).unwrap();
         assert!(!cfg.enabled);
@@ -257,7 +277,23 @@ ci_users = ["_intendant-ci", "ci"]
         assert_eq!(cfg.local_reserved, 3);
         assert_eq!(cfg.ci_reserved, 0);
         assert_eq!(cfg.ci_users, vec!["a".to_string(), "b".to_string()]);
-        assert_eq!(cfg.real_rustc, Some(PathBuf::from("/opt/rustc")));
+        assert_eq!(cfg.wrap_with, Some(PathBuf::from("/opt/sccache")));
+    }
+
+    #[test]
+    fn empty_wrap_with_means_unset() {
+        let cfg = parse("wrap_with = \"\"\n").unwrap();
+        assert_eq!(cfg.wrap_with, None);
+    }
+
+    /// Migration property: confs written before the wrapper-chain flip
+    /// carry `real_rustc`. That key must stay *parseable* (unknown-key
+    /// tolerance) and inert — if it made the file unparseable the governor
+    /// would silently fail open and stop governing the box.
+    #[test]
+    fn legacy_real_rustc_key_is_ignored_not_fatal() {
+        let cfg = parse("real_rustc = \"/opt/toolchain/bin/rustc\"\n").unwrap();
+        assert_eq!(cfg, Config::default());
     }
 
     #[test]

--- a/crates/rustc-governor/src/flock.rs
+++ b/crates/rustc-governor/src/flock.rs
@@ -47,7 +47,8 @@ pub(crate) fn unlock(file: &File) {
 }
 
 /// Rust's std opens every file O_CLOEXEC; a permit's flock must survive the
-/// exec into the real rustc (the flock IS the permit). Load-bearing —
+/// exec into the governed chain — the sccache client, or the real rustc
+/// when `wrap_with` is unset (the flock IS the permit). Load-bearing —
 /// covered by the `permit_lock_survives_exec` acceptance test.
 pub(crate) fn clear_cloexec(file: &File) -> io::Result<()> {
     // SAFETY: the fd is owned by `file` and stays open across both calls;

--- a/crates/rustc-governor/src/main.rs
+++ b/crates/rustc-governor/src/main.rs
@@ -1,27 +1,54 @@
 //! rustc-governor — the machine-wide rustc concurrency governor.
 //!
-//! Wired as cargo's `[build] rustc` while `rustc-wrapper` stays sccache, so
-//! the chain is: cargo → sccache client → sccache server → THIS BINARY →
-//! exec(2) of the real rustc. sccache treats the governor as the compiler:
-//! cache hits never execute it (hits never wait); on a miss / non-cacheable
-//! invocation the sccache server spawns it, it acquires a machine-wide
-//! compile permit (flock(2) files shared by every account on the box), and
-//! then replaces itself with the real rustc via exec — exit status and
-//! signal disposition are inherited by construction, and the permit's flock
-//! rides the FD_CLOEXEC-cleared fd until that rustc exits, however it exits.
+//! Wired as cargo's `[build] rustc-wrapper` (RUSTC_WRAPPER), so cargo
+//! invokes it as `rustc-governor <real-rustc> <args…>` and the chain is:
+//!
+//! ```text
+//! cargo → THIS BINARY → [flock(2) permit] → exec(2) of
+//!   `wrap_with <real-rustc> <args…>` (the blocking sccache client)
+//!   → sccache server: hits answered from cache, misses compiled
+//!     server-side
+//! ```
+//!
+//! The permit is held by the exec'd sccache *client*, which blocks until
+//! the server answers: at most N outstanding clients ⇒ at most N
+//! server-side compiles, so the machine-wide ceiling holds transitively —
+//! no matter which rustc binary the server resolves and runs. Exit status
+//! and signal disposition are inherited by construction, and the permit's
+//! flock rides the FD_CLOEXEC-cleared fd until the exec'd chain exits,
+//! however it exits. A cache hit occupies its permit only for the client
+//! round-trip (~tens of ms); hits queueing head-of-line behind
+//! miss-saturated permits is an accepted trade (ceiling correctness over
+//! warm-path latency).
+//!
+//! Why wrapper-side: the previous wiring (`[build] rustc = governor`,
+//! `rustc-wrapper = sccache`) made sccache treat the governor as the
+//! compiler — and was silently BYPASSED for cacheable misses. sccache
+//! identifies rustup proxies by probing the compiler with `+stable -vV`;
+//! the governor's probe fast path passed that through to the rustup
+//! proxy, so sccache classified the governor AS a proxy, resolved the
+//! underlying toolchain rustc, and had its server invoke that binary
+//! directly — ungoverned. Wrapper-side, nothing reaches sccache without a
+//! permit, so no compiler-identification cleverness can route around the
+//! pool. Post-mortem: `scripts/ci/README.md`, "Governor" section.
 //!
 //! Doctrine, in order:
 //!   1. **Fail open.** Missing/unparseable config, `enabled = false`, the
 //!      secondary `INTENDANT_GOVERNOR=off` env override, an unusable permit
-//!      dir, or zero configured permits ⇒ skip permits entirely and exec the
-//!      real rustc. A governor must never break a build. The config file is
-//!      re-read by every invocation (and once per poll tick by in-flight
-//!      waiters), which is what makes it the live kill switch — no listener
+//!      dir, or zero configured permits ⇒ skip permits but still exec the
+//!      `wrap_with` chain (the real compiler directly when `wrap_with` is
+//!      unset or won't exec): a disabled governor behaves exactly like a
+//!      plain sccache rustc-wrapper — caching is never dropped, and a
+//!      governor must never break a build. The config file is re-read by
+//!      every invocation (and once per poll tick by in-flight waiters),
+//!      which is what makes it the live kill switch — no listener
 //!      restarts.
 //!   2. **Probe fast path.** `-vV` / `-V` / `--version`, or a `--print`
-//!      request with no codegen, bypasses permits (cargo and sccache issue
-//!      these constantly; they must stay snappy under a full pool). See
-//!      `probe.rs` for the exact classification.
+//!      request with no codegen, execs the real compiler (argv[1])
+//!      directly — bypassing permits AND sccache. cargo issues these at
+//!      every startup; they must stay snappy under a full pool, and they
+//!      must not depend on a healthy sccache server (a real incident
+//!      class). Classification runs over argv[2..]; see `probe.rs`.
 //!   3. **Class detection.** The euid's username, matched against the
 //!      config's `ci_users`, splits invocations into `ci` and `local`.
 //!   4. **Permits.** Own-class reservation first, then borrow the other
@@ -40,10 +67,10 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-// `config` is the one cross-platform module (the portable fallback below
-// still honors `real_rustc`); the governor proper — flock permits, exec —
-// is Unix-only, so the non-unix build deliberately leaves parts of the
-// config unread.
+// `config` and `probe` are cross-platform (the portable fallback below
+// honors `wrap_with` and the probe fast path); the governor proper —
+// flock permits, exec — is Unix-only, so the non-unix build deliberately
+// leaves the permit-sizing parts of the config unread.
 #[cfg_attr(not(unix), allow(dead_code))]
 mod config;
 #[cfg(unix)]
@@ -52,44 +79,74 @@ mod flock;
 mod govlog;
 #[cfg(unix)]
 mod permits;
-#[cfg(unix)]
 mod probe;
 
 fn main() {
-    let args: Vec<OsString> = std::env::args_os().skip(1).collect();
+    let mut argv = std::env::args_os().skip(1);
+    // cargo's RUSTC_WRAPPER contract: argv[1] is the real compiler.
+    let Some(real) = argv.next().map(PathBuf::from) else {
+        eprintln!(
+            "rustc-governor: no compiler to run (argv[1] is missing). This binary is a \
+             cargo RUSTC_WRAPPER: wire it as `[build] rustc-wrapper = \"…/rustc-governor\"` \
+             and cargo invokes it as `rustc-governor <real-rustc> <args…>`"
+        );
+        std::process::exit(127);
+    };
+    let args: Vec<OsString> = argv.collect();
+    guard_against_self_exec(&real);
+
+    // Probe fast path — before permits, before sccache, before even the
+    // config read: probes exec the real compiler directly in every
+    // governor state. Classification only ever inspects well-known ASCII
+    // flags, so lossy UTF-8 conversion is fine — the execs below pass the
+    // original OsStrings through untouched.
+    let lossy: Vec<String> = args
+        .iter()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    if probe::is_probe_only(&lossy) {
+        run_compiler_direct(&real, &args);
+    }
+
     let config_path = config::config_path();
     let cfg = config::load(&config_path);
-    let home = std::env::var_os("HOME").map(PathBuf::from);
-    let real = resolve_real_rustc(cfg.as_ref(), home.as_deref());
-    guard_against_self_exec(&real);
+    let wrap = usable_wrap_with(cfg.as_ref());
     #[cfg(unix)]
-    run_unix(args, cfg, &config_path, &real);
+    run_unix(&real, &args, wrap, cfg, &config_path);
     #[cfg(not(unix))]
-    run_portable(args, &real);
+    run_portable(&real, &args, wrap);
 }
 
-/// Resolution order: `real_rustc` from config; else `$HOME/.cargo/bin/rustc`
-/// when present (the rustup proxy — preserves rust-toolchain.toml and
-/// `+toolchain` resolution exactly as if cargo had invoked rustc itself);
-/// else `rustc` from PATH.
-fn resolve_real_rustc(cfg: Option<&config::Config>, home: Option<&Path>) -> PathBuf {
-    if let Some(explicit) = cfg.and_then(|c| c.real_rustc.clone()) {
-        return explicit;
+/// The `wrap_with` chain target for this invocation, iff usable: present
+/// in a parsed config, non-empty (the parser normalizes `""` to unset),
+/// and not this very binary — a `wrap_with` pointing back at the governor
+/// would exec(2) an identical invocation forever. That misconfiguration
+/// fails OPEN (warn and run the compiler directly, uncached) rather than
+/// hard-erroring like the argv[1] guard below: it is config-file state,
+/// and config-file problems must never break a build.
+fn usable_wrap_with(cfg: Option<&config::Config>) -> Option<PathBuf> {
+    let wrap = cfg?.wrap_with.clone()?;
+    let me = std::env::current_exe()
+        .ok()
+        .and_then(|p| std::fs::canonicalize(p).ok());
+    if me.is_some() && me == std::fs::canonicalize(&wrap).ok() {
+        eprintln!(
+            "rustc-governor: wrap_with points at the governor itself; ignoring it and \
+             running the compiler directly (uncached) — fix wrap_with in the governor config"
+        );
+        return None;
     }
-    if let Some(home) = home {
-        let rustup_proxy = home.join(".cargo").join("bin").join("rustc");
-        if rustup_proxy.is_file() {
-            return rustup_proxy;
-        }
-    }
-    PathBuf::from("rustc")
+    Some(wrap)
 }
 
-/// A misconfigured chain (`real_rustc` pointing back at the governor, or the
-/// governor installed on PATH under the name `rustc`) would exec(2) itself
-/// in a tight loop — a fork bomb wearing a compiler's clothes. Best-effort
-/// (a bare `rustc` only canonicalizes when it names a cwd-relative file),
-/// and two syscalls per invocation buy the guard.
+/// cargo hands the wrapper the real compiler as argv[1]; if that path is
+/// the governor itself, the account's cargo config still carries the
+/// legacy `[build] rustc = …rustc-governor` line alongside the new
+/// `rustc-wrapper` wiring — exec'ing onward would loop (directly, or
+/// laundered once through sccache). Loud exit 127 (cargo surfaces wrapper
+/// failures immediately) instead of a fork bomb wearing a compiler's
+/// clothes. Best-effort (a bare `rustc` only canonicalizes when it names
+/// a cwd-relative file), and two syscalls per invocation buy the guard.
 fn guard_against_self_exec(real: &Path) {
     let me = std::env::current_exe()
         .ok()
@@ -97,41 +154,82 @@ fn guard_against_self_exec(real: &Path) {
     let target = std::fs::canonicalize(real).ok();
     if me.is_some() && me == target {
         eprintln!(
-            "rustc-governor: refusing to exec itself (the resolved real rustc is the governor \
-             binary); fix the real_rustc / [build] rustc wiring"
+            "rustc-governor: refusing to exec itself (argv[1] — the compiler cargo passed — \
+             is the governor binary); remove the legacy `[build] rustc = …rustc-governor` \
+             line: the governor is wired via `rustc-wrapper` now"
         );
         std::process::exit(127);
     }
 }
 
+/// Exec (spawn on non-unix) the real compiler with argv passed through
+/// untouched. Shared by the probe fast path — probes bypass permits and
+/// sccache both — and the last-resort fallback when the wrap chain won't
+/// exec.
+fn run_compiler_direct(real: &Path, args: &[OsString]) -> ! {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt as _;
+        let err = Command::new(real).args(args).exec();
+        eprintln!("rustc-governor: failed to exec {}: {err}", real.display());
+        std::process::exit(127);
+    }
+    #[cfg(not(unix))]
+    {
+        match Command::new(real).args(args).status() {
+            Ok(status) => std::process::exit(status.code().unwrap_or(1)),
+            Err(err) => {
+                eprintln!("rustc-governor: failed to run {}: {err}", real.display());
+                std::process::exit(127);
+            }
+        }
+    }
+}
+
 #[cfg(unix)]
 fn run_unix(
-    args: Vec<OsString>,
+    real: &Path,
+    args: &[OsString],
+    wrap: Option<PathBuf>,
     cfg: Option<config::Config>,
     config_path: &Path,
-    real: &Path,
 ) -> ! {
     use std::os::unix::process::CommandExt as _;
 
-    let permit = governed_permit(&args, cfg, config_path);
-    // exec(2): on success this process IS the real rustc — argv[1..] and the
-    // environment pass through untouched, exit status and signal disposition
-    // propagate by construction, and the permit's flock (if any) rides the
-    // FD_CLOEXEC-cleared fd until that rustc exits. Any exit — clean, panic,
-    // SIGKILL — releases the permit in the kernel.
-    let err = Command::new(real).args(&args).exec();
-    // Reachable only when exec failed (real rustc missing / not executable).
+    let permit = governed_permit(cfg, config_path);
+    // exec(2): on success this process IS the governed chain — the sccache
+    // client when wrap_with is configured, else the real compiler. argv
+    // and the environment pass through untouched, exit status and signal
+    // disposition propagate by construction, and the permit's flock (if
+    // any) rides the FD_CLOEXEC-cleared fd until the exec'd chain exits.
+    // Any exit — clean, panic, SIGKILL — releases the permit in the
+    // kernel.
+    if let Some(wrap) = &wrap {
+        let err = Command::new(wrap).arg(real).args(args).exec();
+        // Reachable only when the wrap exec failed (missing / not
+        // executable): fail open to the direct compiler — the permit is
+        // still held, the build must not break; caching is what's lost.
+        eprintln!(
+            "rustc-governor: failed to exec wrap_with {}: {err}; running {} directly (uncached)",
+            wrap.display(),
+            real.display()
+        );
+    }
+    let err = Command::new(real).args(args).exec();
+    // Reachable only when exec failed (real compiler missing / not
+    // executable).
     drop(permit);
     eprintln!("rustc-governor: failed to exec {}: {err}", real.display());
     std::process::exit(127);
 }
 
-/// Decide whether this invocation is governed, and if so acquire its permit.
-/// `None` always means "run ungoverned" — bypass and fail-open share one
-/// path, because both must behave identically: exec the real rustc.
+/// Decide whether this invocation is governed, and if so acquire its
+/// permit. `None` always means "run ungoverned" — every fail-open path
+/// funnels here, and the caller execs the same `wrap_with` chain either
+/// way: a disabled governor must be indistinguishable from a plain
+/// sccache rustc-wrapper.
 #[cfg(unix)]
 fn governed_permit(
-    args: &[OsString],
     cfg: Option<config::Config>,
     config_path: &Path,
 ) -> Option<permits::AcquiredPermit> {
@@ -144,16 +242,6 @@ fn governed_permit(
     // kill switch.
     let cfg = cfg?;
     if !cfg.enabled {
-        return None;
-    }
-    // Probe fast path. Classification only ever inspects well-known ASCII
-    // flags, so lossy UTF-8 conversion is fine — the exec passes the
-    // original OsStrings through untouched.
-    let lossy: Vec<String> = args
-        .iter()
-        .map(|a| a.to_string_lossy().into_owned())
-        .collect();
-    if probe::is_probe_only(&lossy) {
         return None;
     }
     let class = permits::classify(permits::current_username().as_deref(), &cfg);
@@ -176,17 +264,23 @@ fn governed_permit(
 /// The governor is a Unix (macOS / Linux) tool — flock(2) permit pools and
 /// exec(2) semantics don't map onto Windows, and it is never deployed
 /// there. This fallback keeps the workspace building on every first-class
-/// platform (repo policy): degrade gracefully by running the real compiler
-/// ungoverned and propagating its exit code.
+/// platform (repo policy): degrade gracefully with the same chain shape,
+/// minus permits — spawn `wrap_with <real> <args…>` (the real compiler
+/// directly when `wrap_with` is unset or won't run) and propagate the
+/// exit code.
 #[cfg(not(unix))]
-fn run_portable(args: Vec<OsString>, real: &Path) -> ! {
-    match Command::new(real).args(&args).status() {
-        Ok(status) => std::process::exit(status.code().unwrap_or(1)),
-        Err(err) => {
-            eprintln!("rustc-governor: failed to run {}: {err}", real.display());
-            std::process::exit(127);
+fn run_portable(real: &Path, args: &[OsString], wrap: Option<PathBuf>) -> ! {
+    if let Some(wrap) = &wrap {
+        match Command::new(wrap).arg(real).args(args).status() {
+            Ok(status) => std::process::exit(status.code().unwrap_or(1)),
+            Err(err) => eprintln!(
+                "rustc-governor: failed to run wrap_with {}: {err}; running {} directly (uncached)",
+                wrap.display(),
+                real.display()
+            ),
         }
     }
+    run_compiler_direct(real, args);
 }
 
 #[cfg(test)]
@@ -194,39 +288,32 @@ mod tests {
     use super::*;
 
     #[test]
-    fn resolve_prefers_config_real_rustc() {
+    fn wrap_with_requires_a_parsed_config_key() {
+        assert_eq!(usable_wrap_with(None), None);
+        // A config without the key: the governor works without sccache.
+        assert_eq!(usable_wrap_with(Some(&config::Config::default())), None);
+    }
+
+    #[test]
+    fn wrap_with_passes_through_a_configured_path() {
         let cfg = config::Config {
-            real_rustc: Some(PathBuf::from("/opt/toolchain/bin/rustc")),
+            wrap_with: Some(PathBuf::from("/opt/homebrew/bin/sccache")),
             ..config::Config::default()
         };
         assert_eq!(
-            resolve_real_rustc(Some(&cfg), None),
-            PathBuf::from("/opt/toolchain/bin/rustc")
+            usable_wrap_with(Some(&cfg)),
+            Some(PathBuf::from("/opt/homebrew/bin/sccache"))
         );
     }
 
     #[test]
-    fn resolve_falls_back_to_home_rustup_proxy_then_path() {
-        let home = tempfile::tempdir().unwrap();
-        // No ~/.cargo/bin/rustc yet: PATH fallback.
-        assert_eq!(
-            resolve_real_rustc(None, Some(home.path())),
-            PathBuf::from("rustc")
-        );
-        // With the rustup proxy present, it wins.
-        let bin = home.path().join(".cargo").join("bin");
-        std::fs::create_dir_all(&bin).unwrap();
-        let proxy = bin.join("rustc");
-        std::fs::write(&proxy, b"#!/bin/sh\n").unwrap();
-        assert_eq!(resolve_real_rustc(None, Some(home.path())), proxy);
-        // Config beats the proxy.
+    fn wrap_with_pointing_at_this_binary_is_refused() {
+        // In unit tests current_exe is the test binary — good enough to
+        // prove the canonicalized self-comparison refuses the exec loop.
         let cfg = config::Config {
-            real_rustc: Some(PathBuf::from("/x/rustc")),
+            wrap_with: Some(std::env::current_exe().unwrap()),
             ..config::Config::default()
         };
-        assert_eq!(
-            resolve_real_rustc(Some(&cfg), Some(home.path())),
-            PathBuf::from("/x/rustc")
-        );
+        assert_eq!(usable_wrap_with(Some(&cfg)), None);
     }
 }

--- a/crates/rustc-governor/src/permits.rs
+++ b/crates/rustc-governor/src/permits.rs
@@ -13,8 +13,10 @@
 //!
 //! Protocol:
 //! - Holding a permit = holding LOCK_EX on its file. The lock rides the fd
-//!   across exec(2) into the real rustc and is released by the kernel when
-//!   that process exits, however it exits — crash release is structural.
+//!   across exec(2) into the governed chain (the blocking sccache client,
+//!   or the real rustc when `wrap_with` is unset) and is released by the
+//!   kernel when that process exits, however it exits — crash release is
+//!   structural.
 //! - A waiter holds LOCK_SH on its OWN class's demand file for the whole
 //!   wait, and releases it the moment it holds a permit.
 //! - Borrowing: before touching a foreign-class permit, probe that class's
@@ -284,7 +286,7 @@ mod tests {
             local_reserved: local,
             ci_reserved: ci,
             ci_users: vec!["_intendant-ci".into(), "ci".into()],
-            real_rustc: None,
+            wrap_with: None,
         };
         let config_path = tmp.path().join("governor.toml");
         std::fs::write(

--- a/crates/rustc-governor/src/probe.rs
+++ b/crates/rustc-governor/src/probe.rs
@@ -1,12 +1,15 @@
-//! Probe fast path: classify invocations that may bypass the permit pool
-//! (they still exec the real rustc — bypass is about *waiting*, never about
-//! *what runs*).
+//! Probe fast path: classify invocations that bypass the permit pool AND
+//! the `wrap_with` chain — a probe execs the real compiler (argv[1])
+//! directly, so it neither waits on permits nor depends on a healthy
+//! sccache server.
 //!
 //! cargo probes the compiler at every startup (`rustc -vV`, and the target
-//! probe `rustc - --crate-name ___ --print=file-names --print=cfg …`), and
-//! sccache runs its own identification probes; none of those may queue
-//! behind a full permit pool or cargo startup wedges whenever the box is
-//! busy. An invocation is probe-only iff it *cannot* compile anything:
+//! probe `rustc - --crate-name ___ --print=file-names --print=cfg …`);
+//! none of those may queue behind a full permit pool or cargo startup
+//! wedges whenever the box is busy. (sccache's own compiler-identification
+//! probes no longer pass through the governor at all: sccache sits behind
+//! it in the chain and probes argv[1] itself.) An invocation is probe-only
+//! iff it *cannot* compile anything:
 //!
 //! - it asks for the version (`-vV`, `-V`, `--version`), rustc prints and
 //!   exits regardless of other flags; or

--- a/crates/rustc-governor/tests/acceptance.rs
+++ b/crates/rustc-governor/tests/acceptance.rs
@@ -3,10 +3,14 @@
 //! this crate carries an integration-test file rather than the repo's usual
 //! inline-only tests: a unit test inside the bin target links the libtest
 //! harness `main`, so there is no governor binary to exec) against hermetic
-//! tempdir rigs wired through `INTENDANT_GOVERNOR_CONFIG`. No machine state
-//! is read or mutated: every permit dir, config, marker, and fake HOME
-//! lives in the test's own tempdir, and the only processes signalled are
-//! the ones a test itself spawned.
+//! tempdir rigs wired through `INTENDANT_GOVERNOR_CONFIG`.
+//!
+//! The governor is cargo's RUSTC_WRAPPER, so every spawn follows the
+//! wrapper argv contract: argv[1] is the "real compiler" (a /bin/sh
+//! fixture the rig provides), argv[2..] are its args. No machine state is
+//! read or mutated: every permit dir, config, marker, and fixture lives in
+//! the test's own tempdir, and the only processes signalled are the ones a
+//! test itself spawned.
 //!
 //! Loaded-box tolerance: assertions use generous deadlines (`GENEROUS`) and
 //! never assert that something happened *fast* — only that invariants hold
@@ -62,19 +66,45 @@ impl Rig {
         local: u32,
         ci: u32,
         ci_user_is_me: bool,
-        real_rustc: &Path,
         enabled: bool,
+    ) -> PathBuf {
+        self.config_inner(name, local, ci, ci_user_is_me, enabled, None)
+    }
+
+    /// Same, plus a `wrap_with` chain front (the sccache stand-in).
+    fn config_with_wrap(
+        &self,
+        name: &str,
+        local: u32,
+        ci: u32,
+        ci_user_is_me: bool,
+        enabled: bool,
+        wrap: &Path,
+    ) -> PathBuf {
+        self.config_inner(name, local, ci, ci_user_is_me, enabled, Some(wrap))
+    }
+
+    fn config_inner(
+        &self,
+        name: &str,
+        local: u32,
+        ci: u32,
+        ci_user_is_me: bool,
+        enabled: bool,
+        wrap: Option<&Path>,
     ) -> PathBuf {
         let ci_users = if ci_user_is_me {
             format!("[\"{}\"]", me())
         } else {
             "[\"governor-test-no-such-user\"]".to_string()
         };
-        let text = format!(
-            "enabled = {enabled}\npermit_dir = \"{}\"\nlocal_reserved = {local}\nci_reserved = {ci}\nci_users = {ci_users}\nreal_rustc = \"{}\"\n",
+        let mut text = format!(
+            "enabled = {enabled}\npermit_dir = \"{}\"\nlocal_reserved = {local}\nci_reserved = {ci}\nci_users = {ci_users}\n",
             self.permit_dir.display(),
-            real_rustc.display(),
         );
+        if let Some(wrap) = wrap {
+            text.push_str(&format!("wrap_with = \"{}\"\n", wrap.display()));
+        }
         let path = self.root.join(name);
         std::fs::write(&path, text).unwrap();
         path
@@ -103,9 +133,12 @@ fn me() -> String {
     String::from_utf8(out.stdout).unwrap().trim().to_string()
 }
 
-fn spawn_governor(config: &Path, args: &[&str], envs: &[(&str, &str)]) -> Child {
+/// Spawn the governor under the RUSTC_WRAPPER contract: `real` becomes
+/// argv[1] (the compiler), `args` become argv[2..] (the compiler's args).
+fn spawn_governor(config: &Path, real: &Path, args: &[&str], envs: &[(&str, &str)]) -> Child {
     let mut cmd = Command::new(GOVERNOR);
-    cmd.args(args)
+    cmd.arg(real)
+        .args(args)
         .env("INTENDANT_GOVERNOR_CONFIG", config)
         // Hygiene: never inherit an operator kill switch into the rig.
         .env_remove("INTENDANT_GOVERNOR")
@@ -220,9 +253,11 @@ fn global_ceiling_bounds_concurrent_holders() {
             ev = events.display()
         ),
     );
-    let config = rig.config("gov.toml", 1, 2, false, &script, true);
+    let config = rig.config("gov.toml", 1, 2, false, true);
 
-    let mut kids: Vec<Child> = (0..8).map(|_| spawn_governor(&config, &[], &[])).collect();
+    let mut kids: Vec<Child> = (0..8)
+        .map(|_| spawn_governor(&config, &script, &[], &[]))
+        .collect();
     let overall = Instant::now();
     for child in &mut kids {
         let left = Duration::from_secs(45)
@@ -262,10 +297,10 @@ fn idle_borrowing_takes_foreign_permit() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
     let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
-    let config = rig.config("gov.toml", 1, 2, false, &script, true);
+    let config = rig.config("gov.toml", 1, 2, false, true);
 
     let _local_held = hold_exclusive(&rig.permit("permit-local-0"));
-    let mut child = spawn_governor(&config, &[], &[]);
+    let mut child = spawn_governor(&config, &script, &[], &[]);
     let status = wait_deadline(&mut child, GENEROUS).expect("borrower must not wait");
     assert!(status.success());
     assert!(marker.exists());
@@ -285,7 +320,7 @@ fn contested_ci_reserve_is_not_borrowed_by_local() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
     let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
-    let config = rig.config("gov.toml", 1, 2, false, &script, true);
+    let config = rig.config("gov.toml", 1, 2, false, true);
 
     let local_held = hold_exclusive(&rig.permit("permit-local-0"));
     // Pre-create the CI permits so their freeness is observable.
@@ -293,7 +328,7 @@ fn contested_ci_reserve_is_not_borrowed_by_local() {
     let (_c0, _c1) = (open_rw(&ci0), open_rw(&ci1));
     let _ci_waiters = hold_shared(&rig.permit("demand-ci"));
 
-    let mut child = spawn_governor(&config, &[], &[]);
+    let mut child = spawn_governor(&config, &script, &[], &[]);
     assert_still_running_for(&mut child, BLOCKED_OBSERVATION);
     assert!(
         !marker.exists(),
@@ -325,7 +360,7 @@ fn contested_local_reserve_is_not_borrowed_by_ci() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
     let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
-    let config = rig.config("gov.toml", 1, 2, true, &script, true);
+    let config = rig.config("gov.toml", 1, 2, true, true);
 
     let ci_held_0 = hold_exclusive(&rig.permit("permit-ci-0"));
     let _ci_held_1 = hold_exclusive(&rig.permit("permit-ci-1"));
@@ -333,7 +368,7 @@ fn contested_local_reserve_is_not_borrowed_by_ci() {
     let _l0 = open_rw(&local0);
     let _local_waiters = hold_shared(&rig.permit("demand-local"));
 
-    let mut child = spawn_governor(&config, &[], &[]);
+    let mut child = spawn_governor(&config, &script, &[], &[]);
     assert_still_running_for(&mut child, BLOCKED_OBSERVATION);
     assert!(!marker.exists());
     assert!(
@@ -359,10 +394,10 @@ fn waiter_acquires_promptly_after_release() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
     let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
-    let config = rig.config("gov.toml", 1, 0, false, &script, true);
+    let config = rig.config("gov.toml", 1, 0, false, true);
 
     let held = hold_exclusive(&rig.permit("permit-local-0"));
-    let mut child = spawn_governor(&config, &[], &[]);
+    let mut child = spawn_governor(&config, &script, &[], &[]);
     assert_still_running_for(&mut child, Duration::from_millis(400));
     drop(held);
     let status = wait_deadline(&mut child, GENEROUS).expect("waiter starved");
@@ -388,10 +423,10 @@ fn sigkilled_holder_releases_its_permit() {
             ready.display()
         ),
     );
-    let config = rig.config("gov.toml", 1, 0, false, &script, true);
+    let config = rig.config("gov.toml", 1, 0, false, true);
     let permit = rig.permit("permit-local-0");
 
-    let mut child = spawn_governor(&config, &[], &[]);
+    let mut child = spawn_governor(&config, &script, &[], &[]);
     wait_for(|| ready.exists(), GENEROUS, "holder to start");
     assert!(is_exclusively_locked(&permit));
     child.kill().unwrap();
@@ -405,8 +440,8 @@ fn sigkilled_holder_releases_its_permit() {
     // And a fresh governed invocation can take it end to end.
     let marker = rig.root.join("marker");
     let quick = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
-    let config2 = rig.config("gov2.toml", 1, 0, false, &quick, true);
-    let mut second = spawn_governor(&config2, &[], &[]);
+    let config2 = rig.config("gov2.toml", 1, 0, false, true);
+    let mut second = spawn_governor(&config2, &quick, &[], &[]);
     assert!(wait_deadline(&mut second, GENEROUS).unwrap().success());
     assert!(marker.exists());
 }
@@ -427,10 +462,10 @@ fn permit_lock_survives_exec() {
             s = stop.display()
         ),
     );
-    let config = rig.config("gov.toml", 1, 0, false, &script, true);
+    let config = rig.config("gov.toml", 1, 0, false, true);
     let permit = rig.permit("permit-local-0");
 
-    let mut child = spawn_governor(&config, &[], &[]);
+    let mut child = spawn_governor(&config, &script, &[], &[]);
     wait_for(|| ready.exists(), GENEROUS, "exec'd fixture to start");
     // The shell fixture is the post-exec process image; the lock must have
     // ridden through the exec.
@@ -452,8 +487,8 @@ fn permit_lock_survives_exec() {
 fn exit_status_propagates() {
     let rig = Rig::new();
     let script = rig.script("exit42.sh", "exit 42");
-    let config = rig.config("gov.toml", 1, 0, false, &script, true);
-    let mut child = spawn_governor(&config, &[], &[]);
+    let config = rig.config("gov.toml", 1, 0, false, true);
+    let mut child = spawn_governor(&config, &script, &[], &[]);
     let status = wait_deadline(&mut child, GENEROUS).unwrap();
     assert_eq!(status.code(), Some(42));
 }
@@ -471,8 +506,8 @@ fn signal_disposition_propagates() {
             ready.display()
         ),
     );
-    let config = rig.config("gov.toml", 1, 0, false, &script, true);
-    let mut child = spawn_governor(&config, &[], &[]);
+    let config = rig.config("gov.toml", 1, 0, false, true);
+    let mut child = spawn_governor(&config, &script, &[], &[]);
     wait_for(|| ready.exists(), GENEROUS, "fixture to start");
     // SAFETY: pid was spawned by this test and not yet reaped; kill(2)
     // takes only the pid and signal number.
@@ -490,7 +525,7 @@ fn probe_fast_path_ignores_exhausted_pool() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
     let script = rig.script("probe.sh", &format!("echo probed >> {}", marker.display()));
-    let config = rig.config("gov.toml", 1, 2, false, &script, true);
+    let config = rig.config("gov.toml", 1, 2, false, true);
 
     let _p0 = hold_exclusive(&rig.permit("permit-local-0"));
     let _p1 = hold_exclusive(&rig.permit("permit-ci-0"));
@@ -498,9 +533,9 @@ fn probe_fast_path_ignores_exhausted_pool() {
     let _d0 = hold_shared(&rig.permit("demand-local"));
     let _d1 = hold_shared(&rig.permit("demand-ci"));
 
-    let mut version = spawn_governor(&config, &["-vV"], &[]);
+    let mut version = spawn_governor(&config, &script, &["-vV"], &[]);
     assert!(wait_deadline(&mut version, GENEROUS).unwrap().success());
-    let mut print = spawn_governor(&config, &["--print", "cfg"], &[]);
+    let mut print = spawn_governor(&config, &script, &["--print", "cfg"], &[]);
     assert!(wait_deadline(&mut print, GENEROUS).unwrap().success());
     let text = std::fs::read_to_string(&marker).unwrap();
     assert_eq!(text.lines().count(), 2, "both probes must have exec'd");
@@ -509,6 +544,7 @@ fn probe_fast_path_ignores_exhausted_pool() {
     // wait behind the exhausted pool, not bypass.
     let mut governed = spawn_governor(
         &config,
+        &script,
         &[
             "--print",
             "native-static-libs",
@@ -534,49 +570,222 @@ fn kill_switch_flips_live() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
     let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
-    let config = rig.config("gov.toml", 1, 0, false, &script, true);
+    let config = rig.config("gov.toml", 1, 0, false, true);
 
     let _held = hold_exclusive(&rig.permit("permit-local-0"));
-    let mut waiter = spawn_governor(&config, &[], &[]);
+    let mut waiter = spawn_governor(&config, &script, &[], &[]);
     assert_still_running_for(&mut waiter, Duration::from_millis(600));
 
     // Flip the switch in place (same path the running waiter re-reads).
-    rig.config("gov.toml", 1, 0, false, &script, false);
+    rig.config("gov.toml", 1, 0, false, false);
 
     let status = wait_deadline(&mut waiter, GENEROUS).expect("waiter must unwedge, fail-open");
     assert!(status.success());
-    let mut next = spawn_governor(&config, &[], &[]);
+    let mut next = spawn_governor(&config, &script, &[], &[]);
     assert!(wait_deadline(&mut next, GENEROUS).unwrap().success());
     assert_eq!(std::fs::read_to_string(&marker).unwrap().lines().count(), 2);
 }
 
-/// Fail-open: no config at the configured path — the governor skips permits
-/// and execs the real rustc resolved via $HOME/.cargo/bin/rustc.
+// ------------------------------------------------ wrapper chain shape ----
+
+/// Governed chain shape: with `wrap_with` configured, a governed
+/// invocation acquires its permit and execs `wrap_with <real> <args…>` —
+/// argv order is the sccache client contract (argv[1] = the compiler,
+/// the rest its args, exactly as cargo handed them to the governor).
 #[test]
-fn missing_config_fails_open_via_default_chain() {
+fn governed_invocation_execs_wrap_chain() {
+    let rig = Rig::new();
+    let real_marker = rig.root.join("real");
+    let wrap_marker = rig.root.join("wrap");
+    let real = rig.script(
+        "rustc.sh",
+        &format!("echo \"real $*\" >> {}", real_marker.display()),
+    );
+    // Log the argv the wrap step received, then run it — what the sccache
+    // client does with its compiler argv.
+    let wrap = rig.script(
+        "wrap.sh",
+        &format!("echo \"$*\" >> {}\nexec \"$@\"", wrap_marker.display()),
+    );
+    let config = rig.config_with_wrap("gov.toml", 1, 0, false, true, &wrap);
+
+    let mut child = spawn_governor(&config, &real, &["--crate-name", "x", "lib.rs"], &[]);
+    assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
+
+    let wrap_line = std::fs::read_to_string(&wrap_marker).unwrap();
+    assert_eq!(
+        wrap_line.trim_end(),
+        format!("{} --crate-name x lib.rs", real.display()),
+        "wrap front must receive <real> <args…> verbatim"
+    );
+    let real_line = std::fs::read_to_string(&real_marker).unwrap();
+    assert_eq!(real_line.trim_end(), "real --crate-name x lib.rs");
+    // And the run really was governed: exactly the permit path, logged.
+    assert!(
+        rig.log().contains("permit=permit-local-0"),
+        "governed wrap-chain run must hold a permit: {:?}",
+        rig.log()
+    );
+}
+
+/// Fail-open paths keep the wrap chain: a disabled governor must behave
+/// exactly like a plain sccache rustc-wrapper — caching is never dropped.
+/// Covers the config kill switch, the env override, and zero configured
+/// permits. (Missing/unparseable config cannot know `wrap_with` and runs
+/// the compiler directly — covered by the missing/unparseable tests
+/// below.)
+#[test]
+fn fail_open_paths_still_exec_wrap_chain() {
+    struct Case {
+        name: &'static str,
+        enabled: bool,
+        local: u32,
+        envs: &'static [(&'static str, &'static str)],
+    }
+    for case in [
+        Case {
+            name: "kill-switch",
+            enabled: false,
+            local: 1,
+            envs: &[],
+        },
+        Case {
+            name: "env-off",
+            enabled: true,
+            local: 1,
+            envs: &[("INTENDANT_GOVERNOR", "off")],
+        },
+        Case {
+            name: "zero-permits",
+            enabled: true,
+            local: 0,
+            envs: &[],
+        },
+    ] {
+        let rig = Rig::new();
+        let real_marker = rig.root.join("real");
+        let wrap_marker = rig.root.join("wrap");
+        let real = rig.script(
+            "rustc.sh",
+            &format!("echo real >> {}", real_marker.display()),
+        );
+        let wrap = rig.script(
+            "wrap.sh",
+            &format!("echo wrap >> {}\nexec \"$@\"", wrap_marker.display()),
+        );
+        let config = rig.config_with_wrap("gov.toml", case.local, 0, false, case.enabled, &wrap);
+        // Where a permit exists, hold it: fail-open must not wait on it.
+        let _held = (case.local > 0).then(|| hold_exclusive(&rig.permit("permit-local-0")));
+
+        let mut child = spawn_governor(&config, &real, &[], case.envs);
+        let status = wait_deadline(&mut child, GENEROUS)
+            .unwrap_or_else(|| panic!("[{}] fail-open run must complete", case.name));
+        assert!(status.success(), "[{}] chain must succeed", case.name);
+        assert!(
+            wrap_marker.exists(),
+            "[{}] fail-open dropped the wrap_with chain (caching lost)",
+            case.name
+        );
+        assert!(
+            real_marker.exists(),
+            "[{}] the real compiler never ran",
+            case.name
+        );
+        // Ungoverned runs are silent in the log (doctrine: the log answers
+        // "who waited on which permit").
+        assert_eq!(rig.log(), "", "[{}] fail-open must not log", case.name);
+    }
+}
+
+/// `wrap_with` pointing at a path that doesn't exist must not break the
+/// build: the wrap exec fails, and the governor falls back to running the
+/// compiler directly — still governed (the permit was already held).
+#[test]
+fn missing_wrap_with_falls_back_to_direct_exec() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
-    let home = rig.root.join("home");
-    let bin = home.join(".cargo").join("bin");
-    std::fs::create_dir_all(&bin).unwrap();
-    let fake_rustc = bin.join("rustc");
-    std::fs::write(
-        &fake_rustc,
-        format!("#!/bin/sh\necho fake >> {}\n", marker.display()),
-    )
-    .unwrap();
-    let mut perms = std::fs::metadata(&fake_rustc).unwrap().permissions();
-    perms.set_mode(0o755);
-    std::fs::set_permissions(&fake_rustc, perms).unwrap();
-
-    let missing = rig.root.join("no-such-config.toml");
-    let mut child = spawn_governor(
-        &missing,
-        &["--crate-name", "x"],
-        &[("HOME", home.to_str().unwrap())],
+    let real = rig.script("rustc.sh", &format!("echo real >> {}", marker.display()));
+    let config = rig.config_with_wrap(
+        "gov.toml",
+        1,
+        0,
+        false,
+        true,
+        Path::new("/nonexistent/rustc-governor-test/sccache"),
     );
+    let mut child = spawn_governor(&config, &real, &["--crate-name", "x"], &[]);
     assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
-    assert!(marker.exists(), "fail-open must still exec the real rustc");
+    assert!(marker.exists(), "fallback must still run the compiler");
+    assert!(
+        rig.log().contains("permit=permit-local-0"),
+        "fallback run stays governed: {:?}",
+        rig.log()
+    );
+}
+
+/// `wrap_with` pointing back at the governor binary would exec an
+/// identical invocation forever. It is config-file state, so it fails
+/// OPEN: the chain front is ignored and the compiler runs directly.
+#[test]
+fn wrap_with_pointing_at_governor_falls_back_to_direct_exec() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let real = rig.script("rustc.sh", &format!("echo real >> {}", marker.display()));
+    let config = rig.config_with_wrap("gov.toml", 1, 0, false, true, Path::new(GOVERNOR));
+    let mut child = spawn_governor(&config, &real, &["--crate-name", "x"], &[]);
+    let status =
+        wait_deadline(&mut child, GENEROUS).expect("self-wrap must fall back, not loop or wait");
+    assert!(status.success());
+    assert!(marker.exists(), "the real compiler must still run");
+}
+
+/// Probes exec the real compiler DIRECTLY: no permit, no `wrap_with` —
+/// they must stay snappy under a full pool and must not depend on a
+/// healthy sccache. All permits held + wrap fixture present: `-vV`
+/// completes and the wrap marker stays absent.
+#[test]
+fn probe_bypasses_wrap_chain_and_permits() {
+    let rig = Rig::new();
+    let real_marker = rig.root.join("real");
+    let wrap_marker = rig.root.join("wrap");
+    let real = rig.script(
+        "rustc.sh",
+        &format!("echo real >> {}", real_marker.display()),
+    );
+    let wrap = rig.script(
+        "wrap.sh",
+        &format!("echo wrap >> {}\nexec \"$@\"", wrap_marker.display()),
+    );
+    let config = rig.config_with_wrap("gov.toml", 1, 0, false, true, &wrap);
+    let _held = hold_exclusive(&rig.permit("permit-local-0"));
+
+    let mut probe = spawn_governor(&config, &real, &["-vV"], &[]);
+    assert!(wait_deadline(&mut probe, GENEROUS).unwrap().success());
+    assert!(real_marker.exists(), "probe must exec the real compiler");
+    assert!(
+        !wrap_marker.exists(),
+        "probe must bypass the wrap_with chain (it ran through sccache)"
+    );
+    assert_eq!(rig.log(), "", "probes must not log");
+}
+
+// -------------------------------------------------------- fail open ----
+
+/// Fail-open: no config at the configured path — the governor skips
+/// permits, and with no config there is no `wrap_with` either: it execs
+/// the compiler cargo handed it as argv[1], directly.
+#[test]
+fn missing_config_fails_open_execs_argv1() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let real = rig.script("rustc.sh", &format!("echo fake >> {}", marker.display()));
+    let missing = rig.root.join("no-such-config.toml");
+    let mut child = spawn_governor(&missing, &real, &["--crate-name", "x"], &[]);
+    assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
+    assert!(
+        marker.exists(),
+        "fail-open must still run the real compiler"
+    );
 }
 
 /// Fail-open: an unparseable config behaves exactly like a missing one.
@@ -584,22 +793,10 @@ fn missing_config_fails_open_via_default_chain() {
 fn unparseable_config_fails_open() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
-    let home = rig.root.join("home");
-    let bin = home.join(".cargo").join("bin");
-    std::fs::create_dir_all(&bin).unwrap();
-    let fake_rustc = bin.join("rustc");
-    std::fs::write(
-        &fake_rustc,
-        format!("#!/bin/sh\necho fake >> {}\n", marker.display()),
-    )
-    .unwrap();
-    let mut perms = std::fs::metadata(&fake_rustc).unwrap().permissions();
-    perms.set_mode(0o755);
-    std::fs::set_permissions(&fake_rustc, perms).unwrap();
-
+    let real = rig.script("rustc.sh", &format!("echo fake >> {}", marker.display()));
     let config = rig.root.join("broken.toml");
     std::fs::write(&config, "enabled = maybe\n").unwrap();
-    let mut child = spawn_governor(&config, &[], &[("HOME", home.to_str().unwrap())]);
+    let mut child = spawn_governor(&config, &real, &[], &[]);
     assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
     assert!(marker.exists());
 }
@@ -610,9 +807,9 @@ fn env_off_bypasses_permits() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
     let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
-    let config = rig.config("gov.toml", 1, 0, false, &script, true);
+    let config = rig.config("gov.toml", 1, 0, false, true);
     let _held = hold_exclusive(&rig.permit("permit-local-0"));
-    let mut child = spawn_governor(&config, &[], &[("INTENDANT_GOVERNOR", "off")]);
+    let mut child = spawn_governor(&config, &script, &[], &[("INTENDANT_GOVERNOR", "off")]);
     assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
     assert!(marker.exists());
 }
@@ -623,19 +820,25 @@ fn zero_permits_fails_open() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
     let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
-    let config = rig.config("gov.toml", 0, 0, false, &script, true);
-    let mut child = spawn_governor(&config, &[], &[]);
+    let config = rig.config("gov.toml", 0, 0, false, true);
+    let mut child = spawn_governor(&config, &script, &[], &[]);
     assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
     assert!(marker.exists());
 }
 
-/// Misconfiguration guard: real_rustc pointing back at the governor must
-/// refuse (exit 127) instead of exec-looping into a fork bomb.
+// ---------------------------------------------------- wiring guards ----
+
+/// Misconfiguration guard: cargo handing the governor ITSELF as the
+/// compiler (a legacy `[build] rustc = …rustc-governor` line left next to
+/// the new `rustc-wrapper` wiring) must refuse (exit 127) instead of
+/// exec-looping into a fork bomb.
 #[test]
 fn refuses_to_exec_itself() {
     let rig = Rig::new();
-    let config = rig.config("gov.toml", 1, 0, false, Path::new(GOVERNOR), true);
+    let config = rig.config("gov.toml", 1, 0, false, true);
     let mut child = Command::new(GOVERNOR)
+        .arg(GOVERNOR)
+        .args(["--crate-name", "x"])
         .env("INTENDANT_GOVERNOR_CONFIG", &config)
         .env_remove("INTENDANT_GOVERNOR")
         .stdout(Stdio::null())
@@ -652,4 +855,30 @@ fn refuses_to_exec_itself() {
         .read_to_string(&mut stderr)
         .unwrap();
     assert!(stderr.contains("refusing to exec itself"), "{stderr:?}");
+}
+
+/// No argv[1] at all is not a build (there is nothing to run): loud usage
+/// error, so a mis-wired account is caught immediately instead of
+/// half-working.
+#[test]
+fn missing_compiler_argv_is_a_loud_error() {
+    let rig = Rig::new();
+    let config = rig.config("gov.toml", 1, 0, false, true);
+    let mut child = Command::new(GOVERNOR)
+        .env("INTENDANT_GOVERNOR_CONFIG", &config)
+        .env_remove("INTENDANT_GOVERNOR")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let status = wait_deadline(&mut child, GENEROUS).unwrap();
+    assert_eq!(status.code(), Some(127));
+    let mut stderr = String::new();
+    child
+        .stderr
+        .take()
+        .unwrap()
+        .read_to_string(&mut stderr)
+        .unwrap();
+    assert!(stderr.contains("argv[1]"), "{stderr:?}");
 }

--- a/crates/rustc-governor/tests/sccache_chain.rs
+++ b/crates/rustc-governor/tests/sccache_chain.rs
@@ -1,0 +1,359 @@
+//! Regression test for THE production bypass (2026-07): the governor used
+//! to be wired as cargo's `[build] rustc` with sccache as `rustc-wrapper`,
+//! so sccache treated the governor as the compiler. sccache 0.15
+//! identifies rustup proxies by probing the compiler with `+stable -vV`;
+//! the governor's probe fast path passed that through to the rustup proxy,
+//! so sccache classified the governor AS a proxy, resolved the underlying
+//! toolchain rustc, and had its SERVER invoke that binary directly for
+//! every cacheable miss — ungoverned (verified live: five toolchain rustcs
+//! as sccache-server children while all permits were held). Only
+//! non-cacheable work stayed governed.
+//!
+//! This test drives the REAL sccache binary through the new chain
+//! (governor = rustc-wrapper, `wrap_with` = sccache) against a private
+//! server and asserts the property the old chain silently lost: with the
+//! single permit held, a CACHEABLE rlib miss must NOT complete — it queues
+//! on the permit — while a `-vV` probe still completes promptly.
+//!
+//! THE SHAPE OF THE COMPILE IS LOAD-BEARING. sccache only routes
+//! *cacheable* invocations through its server-side compile path — an rlib
+//! compile with cargo-shaped args (`--crate-name … --crate-type lib
+//! --emit=dep-info,link --out-dir …`). Bin/link shapes (they invoke the
+//! system linker) and metadata-emit shapes are NON-cacheable: sccache runs
+//! those on the client side, which was governed even under the broken
+//! chain. A test built on such a shape passes against the bypass —
+//! silently testing the wrong path, the exact mistake that let the
+//! original bypass ship.
+//!
+//! Hermetic per repo doctrine: private `SCCACHE_DIR` + dedicated
+//! `SCCACHE_SERVER_PORT` in tempdirs, `SCCACHE_IDLE_TIMEOUT=10` as a
+//! belt-and-braces reaper for leaks, the server stopped in cleanup (Drop —
+//! runs on panic too), and the only processes signalled are ones this test
+//! spawned. Skips cleanly — with an explicit message — when sccache is not
+//! installed.
+
+#![cfg(unix)]
+
+use std::fs::File;
+use std::io::Read;
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const GOVERNOR: &str = env!("CARGO_BIN_EXE_rustc-governor");
+/// Deadline for bounded things (server-side compiles included) on a box
+/// saturated by parallel agents.
+const GENEROUS: Duration = Duration::from_secs(60);
+/// How long the saturated miss is observed queued before we believe the
+/// permit really gates it. Completion inside this window = the bypass
+/// regressed. Negative-assertion window, so box load only makes it safer.
+const SATURATION_WINDOW: Duration = Duration::from_secs(8);
+/// Probes must not queue: generous for load, tiny next to a permit wait
+/// that would otherwise last until the permit frees.
+const PROBE_DEADLINE: Duration = Duration::from_secs(15);
+
+// ------------------------------------------------------------ helpers ----
+
+fn find_on_path(name: &str) -> Option<PathBuf> {
+    std::env::split_paths(&std::env::var_os("PATH")?)
+        .map(|dir| dir.join(name))
+        .find(|candidate| candidate.is_file())
+}
+
+fn wait_deadline(child: &mut Child, deadline: Duration) -> Option<ExitStatus> {
+    let t0 = Instant::now();
+    while t0.elapsed() < deadline {
+        if let Some(status) = child.try_wait().unwrap() {
+            return Some(status);
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    None
+}
+
+/// Take LOCK_EX|LOCK_NB and keep holding it (dropping the File releases) —
+/// the rig's stand-in for a running governed compile.
+fn hold_exclusive(path: &Path) -> File {
+    let f = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+        .unwrap();
+    // SAFETY: `f` owns an open fd for the duration of the call.
+    let locked = unsafe { libc::flock(f.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) == 0 };
+    assert!(locked, "test rig could not take {path:?}");
+    f
+}
+
+/// Kill-and-reap on drop, so a mid-test panic never leaks a queued child.
+struct KillOnDrop(Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// A private sccache server: own cache dir, own port, idle-timeout
+/// backstop; stopped on drop. Nothing it does touches the account's real
+/// sccache server (default port) or cache.
+struct SccacheServer {
+    bin: PathBuf,
+    dir: PathBuf,
+    port: u16,
+}
+
+impl SccacheServer {
+    fn start(bin: &Path, dir: &Path) -> SccacheServer {
+        let mut last = String::new();
+        for attempt in 0..3_u32 {
+            let server = SccacheServer {
+                bin: bin.to_path_buf(),
+                dir: dir.to_path_buf(),
+                port: candidate_port(attempt),
+            };
+            let mut cmd = Command::new(bin);
+            cmd.arg("--start-server");
+            server.apply_env(&mut cmd);
+            match cmd.output() {
+                Ok(out) if out.status.success() => return server,
+                Ok(out) => {
+                    last = format!(
+                        "port {}: {}{}",
+                        server.port,
+                        String::from_utf8_lossy(&out.stdout),
+                        String::from_utf8_lossy(&out.stderr)
+                    );
+                }
+                Err(err) => panic!("could not run {}: {err}", bin.display()),
+            }
+        }
+        panic!("could not start a private sccache server (3 ports tried); last: {last}");
+    }
+
+    /// Scrub every inherited SCCACHE_* var, then pin this server's env:
+    /// the spawned process must talk only to the test's own server and
+    /// cache, never the account's.
+    fn apply_env(&self, cmd: &mut Command) {
+        for (key, _) in std::env::vars_os() {
+            if key.to_string_lossy().starts_with("SCCACHE_") {
+                cmd.env_remove(key);
+            }
+        }
+        cmd.env("SCCACHE_DIR", &self.dir)
+            .env("SCCACHE_SERVER_PORT", self.port.to_string())
+            // Belt and braces: even a leaked server exits after 10 idle
+            // seconds.
+            .env("SCCACHE_IDLE_TIMEOUT", "10");
+    }
+}
+
+impl Drop for SccacheServer {
+    fn drop(&mut self) {
+        let mut cmd = Command::new(&self.bin);
+        cmd.arg("--stop-server")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        self.apply_env(&mut cmd);
+        let _ = cmd.status();
+    }
+}
+
+/// Random high port; no rand dependency — nanos + pid spread concurrent
+/// test processes apart, `attempt` walks on a bind collision.
+fn candidate_port(attempt: u32) -> u16 {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .subsec_nanos();
+    let seed = nanos ^ std::process::id().wrapping_mul(2_654_435_761) ^ attempt.wrapping_mul(7_919);
+    (20_000 + seed % 40_000) as u16
+}
+
+/// Spawn `governor <rustc> <cargo-shaped cacheable rlib args>` wired to the
+/// rig's config and the private sccache server. stderr goes to a file:
+/// readable after any failure, and no pipe to deadlock an unread child.
+fn governed_compile(
+    server: &SccacheServer,
+    config: &Path,
+    rustc: &Path,
+    source: &Path,
+    crate_name: &str,
+    out_dir: &Path,
+    stderr_to: &Path,
+) -> Child {
+    let mut cmd = Command::new(GOVERNOR);
+    cmd.arg(rustc)
+        // Cargo-shaped, sccache-CACHEABLE args — see the module doc for
+        // why this exact shape is load-bearing.
+        .args(["--crate-name", crate_name, "--edition", "2021"])
+        .arg(source)
+        .args([
+            "--crate-type",
+            "lib",
+            "--emit=dep-info,link",
+            "-C",
+            "debuginfo=0",
+            "--out-dir",
+        ])
+        .arg(out_dir)
+        .env("INTENDANT_GOVERNOR_CONFIG", config)
+        // Hygiene: never inherit an operator kill switch into the rig.
+        .env_remove("INTENDANT_GOVERNOR")
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(File::create(stderr_to).unwrap()));
+    server.apply_env(&mut cmd);
+    cmd.spawn().unwrap()
+}
+
+fn read(path: &Path) -> String {
+    std::fs::read_to_string(path).unwrap_or_default()
+}
+
+// --------------------------------------------------------------- test ----
+
+#[test]
+fn cacheable_miss_queues_on_the_permit_and_probe_stays_fast() {
+    let Some(sccache) = find_on_path("sccache") else {
+        eprintln!("skipped: sccache not installed");
+        return;
+    };
+    let rustc = find_on_path("rustc").unwrap_or_else(|| PathBuf::from("rustc"));
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let cache_dir = root.join("sccache-cache");
+    let permit_dir = root.join("permits");
+    let out_prime = root.join("out-prime");
+    let out_miss = root.join("out-miss");
+    for dir in [&cache_dir, &permit_dir, &out_prime, &out_miss] {
+        std::fs::create_dir_all(dir).unwrap();
+    }
+    let server = SccacheServer::start(&sccache, &cache_dir);
+
+    // One permit total; the current user classes local (impossible
+    // ci_users name), so that permit is permit-local-0.
+    let config = root.join("governor.toml");
+    std::fs::write(
+        &config,
+        format!(
+            "enabled = true\npermit_dir = \"{}\"\nlocal_reserved = 1\nci_reserved = 0\nci_users = [\"governor-test-no-such-user\"]\nwrap_with = \"{}\"\n",
+            permit_dir.display(),
+            sccache.display(),
+        ),
+    )
+    .unwrap();
+
+    // (1) Prime compiler detection: one governed cacheable compile with
+    // the permit free. The server identifies the compiler here, so the
+    // saturated phase below measures permit queueing, not detection.
+    let prime_src = root.join("prime.rs");
+    std::fs::write(&prime_src, "pub fn prime() {}\n").unwrap();
+    let prime_err = root.join("prime.stderr");
+    let mut prime = governed_compile(
+        &server, &config, &rustc, &prime_src, "prime", &out_prime, &prime_err,
+    );
+    let status = wait_deadline(&mut prime, GENEROUS)
+        .unwrap_or_else(|| panic!("prime compile did not finish: {}", read(&prime_err)));
+    assert!(
+        status.success(),
+        "prime compile failed: {}",
+        read(&prime_err)
+    );
+    assert!(
+        out_prime.join("libprime.rlib").is_file(),
+        "prime compile produced no rlib"
+    );
+    let log = read(&permit_dir.join("governor.log"));
+    assert!(
+        log.contains("permit=permit-local-0"),
+        "prime compile was not governed (rig broken?): {log:?}"
+    );
+
+    // (2) Saturate: hold the single permit like a running compile, then
+    // launch a UNIQUE cacheable rlib miss through the full chain. It must
+    // queue on the permit — any completion inside the window means
+    // cacheable server-side work escaped the pool: the production bypass,
+    // regressed.
+    let held = hold_exclusive(&permit_dir.join("permit-local-0"));
+    let nonce = format!(
+        "uniq_{}_{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let miss_src = root.join("miss.rs");
+    std::fs::write(
+        &miss_src,
+        format!("pub const NONCE: &str = \"{nonce}\";\npub fn miss() {{}}\n"),
+    )
+    .unwrap();
+    let miss_rlib = out_miss.join(format!("lib{nonce}.rlib"));
+    let miss_err = root.join("miss.stderr");
+    let mut miss = KillOnDrop(governed_compile(
+        &server, &config, &rustc, &miss_src, &nonce, &out_miss, &miss_err,
+    ));
+
+    let t0 = Instant::now();
+    while t0.elapsed() < SATURATION_WINDOW {
+        assert!(
+            miss.0.try_wait().unwrap().is_none(),
+            "cacheable miss completed while the only permit was held — \
+             ungoverned server-side compile: the sccache bypass regressed"
+        );
+        assert!(
+            !miss_rlib.exists(),
+            "rlib appeared while the only permit was held — the sccache bypass regressed"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    // (4) Probes must not queue behind the saturated pool — and they no
+    // longer depend on sccache at all: the governor execs the real
+    // compiler directly.
+    let mut probe = Command::new(GOVERNOR)
+        .arg(&rustc)
+        .arg("-vV")
+        .env("INTENDANT_GOVERNOR_CONFIG", &config)
+        .env_remove("INTENDANT_GOVERNOR")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let probe_status = wait_deadline(&mut probe, PROBE_DEADLINE)
+        .expect("-vV probe queued behind a held permit (probe fast path broken)");
+    assert!(probe_status.success());
+    let mut version = String::new();
+    probe
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut version)
+        .unwrap();
+    assert!(
+        version.contains("rustc"),
+        "probe output is not a rustc -vV banner: {version:?}"
+    );
+    assert!(
+        miss.0.try_wait().unwrap().is_none(),
+        "miss must still be queued after the probe"
+    );
+
+    // (3) Release: the queued miss acquires the permit, compiles
+    // server-side, and lands its rlib.
+    drop(held);
+    let status = wait_deadline(&mut miss.0, GENEROUS)
+        .unwrap_or_else(|| panic!("released miss never completed: {}", read(&miss_err)));
+    assert!(
+        status.success(),
+        "released miss failed: {}",
+        read(&miss_err)
+    );
+    assert!(miss_rlib.is_file(), "miss produced no rlib after release");
+}

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -112,32 +112,66 @@ every account on the box.
 ### The chain
 
 ```
-cargo ──[build] rustc=governor──▶ sccache client ──▶ sccache server
-                                        │  cache hit: reply from cache —
-                                        │  the "compiler" never executes
-                                        ▼  miss / non-cacheable
-                                  rustc-governor
-                                        │  acquire flock(2) permit
-                                        ▼
-                                  exec(2) real rustc   (permit rides the
-                                                        fd until exit)
+cargo ──[build] rustc-wrapper=governor──▶ rustc-governor <real rustc> <args…>
+                    │  probe (-vV / pure --print):
+                    │    exec(2) real rustc directly — no permit, no sccache
+                    ▼  compile: acquire flock(2) permit
+              exec(2) sccache <real rustc> <args…>
+                    │    the blocking sccache CLIENT; the permit's flock
+                    │    rides the FD_CLOEXEC-cleared fd until it exits
+                    ▼
+              sccache server ── hit: answer from cache (client exits in
+                    │                ~tens of ms, permit released)
+                    ▼  miss / non-cacheable
+              real rustc runs; the client — and so the permit — blocks
+              until it finishes
 ```
 
-`[build] rustc` points at the governor while `rustc-wrapper` stays
-sccache, so sccache treats the governor as *the compiler*:
+The governor is cargo's `rustc-wrapper`; sccache is no longer the
+wrapper — the governor execs it, prepending the real compiler path cargo
+handed it as argv[1] (the `wrap_with` config key names the sccache
+binary; unset it and the compiler runs directly, governed but uncached):
 
-- **Hits never wait** — sccache answers cache hits without executing
-  the compiler at all, so warm builds feel no governor.
-- **Probes never wait** — `-vV` / `--version` / pure `--print` queries
-  (cargo fires them at every startup, sccache when identifying the
-  compiler) bypass the pool via the probe fast path. A real compile
-  that merely *carries* `--print` (e.g. `--print native-static-libs`
-  with `--emit link`) is still governed.
-- Everything else acquires one machine-wide permit, then `exec(2)`s
-  the real rustc: exit status and signal disposition are inherited by
-  construction, and the permit's flock rides the FD_CLOEXEC-cleared fd
-  until that rustc exits — any exit, including SIGKILL, releases it in
-  the kernel (crash release is structural, nothing to clean up).
+- **The ceiling holds transitively.** The permit is held by the exec'd
+  sccache *client*, which blocks until the server answers: at most N
+  outstanding clients ⇒ at most N server-side compiles, no matter which
+  rustc binary the server resolves and runs.
+- **Probes never wait and never touch sccache** — `-vV` / `--version` /
+  pure `--print` queries (cargo fires them at every startup) exec the
+  real compiler directly: snappy under a full pool, and cargo startup no
+  longer depends on a healthy sccache server (a real incident class). A
+  real compile that merely *carries* `--print` (e.g.
+  `--print native-static-libs` with `--emit link`) is still governed.
+- **Hits hold a permit briefly.** A cache hit occupies its permit for
+  the client round-trip (~tens of ms); under a miss-saturated pool, hits
+  queue head-of-line behind running compiles. Accepted trade, decided
+  with the operator: ceiling correctness over warm-path latency.
+- Exit status and signal disposition are inherited through the exec
+  chain, and the permit's flock rides the FD_CLOEXEC-cleared fd until
+  the chain exits — any exit, including SIGKILL, releases it in the
+  kernel (crash release is structural, nothing to clean up).
+
+#### Why wrapper-side (the 2026-07 bypass post-mortem)
+
+The governor originally sat on the compiler side of sccache
+(`[build] rustc = governor`, `rustc-wrapper = sccache`) so cache hits
+never executed it — and that design was silently bypassed for exactly
+the work it existed to bound. sccache 0.15 identifies rustup proxies by
+probing the compiler with `+stable -vV`; the governor's probe fast path
+passed the probe through to `$HOME/.cargo/bin/rustc` — the rustup proxy,
+which accepts `+toolchain` selectors where a real rustc errors — so
+sccache classified the governor as a rustup proxy, resolved the
+underlying toolchain rustc itself, and had its server invoke that binary
+directly for every cacheable miss: ungoverned (verified live — five
+toolchain rustcs as sccache-server children while all permits were
+held). Only non-cacheable invocations (bin links etc., which the client
+runs locally) stayed governed. Wrapper-side, nothing reaches sccache
+without a permit, so no compiler-identification cleverness can route
+around the pool. The regression test that would have caught it —
+`crates/rustc-governor/tests/sccache_chain.rs` — drives the real sccache
+binary and asserts a *cacheable* rlib miss queues behind a held permit
+(bin/link and metadata-emit shapes are non-cacheable and silently test
+the wrong path).
 
 ### Permits and the demand gate
 
@@ -157,12 +191,16 @@ holder exits.
 
 ### Fail-open doctrine + live kill switch
 
-A governor must never break a build. Missing or unparseable config,
-`enabled = false`, `INTENDANT_GOVERNOR=off` in the env, an unusable
-permit dir, zero configured permits — every degraded state means "run
-ungoverned", never "block". The config is re-read by every invocation
-(and once per poll tick by in-flight waiters), so
-`/usr/local/etc/intendant-governor.toml` is live: flipping
+A governor must never break a build — and, since the wrapper-chain flip,
+must never cost a build its caching either. Missing or unparseable
+config, `enabled = false`, `INTENDANT_GOVERNOR=off` in the env, an
+unusable permit dir, zero configured permits — every degraded state
+means "run ungoverned", never "block", and still execs the `wrap_with`
+chain when it is configured (a disabled governor is indistinguishable
+from a plain sccache rustc-wrapper; only a missing/unparseable config,
+which cannot know `wrap_with`, runs the compiler directly). The config
+is re-read by every invocation (and once per poll tick by in-flight
+waiters), so `/usr/local/etc/intendant-governor.toml` is live: flipping
 `enabled = false` drains the governor within ~100ms, no listener
 restarts. Observability: one line per *governed* invocation in
 `<permit_dir>/governor.log` (timestamp, pid, class, permit, wait_ms;
@@ -184,12 +222,21 @@ sudo scripts/ci/install-governor-macos.sh   # binary + permit dir + conf
 ```
 
 The installer never edits account cargo configs; it prints the
-`[build] rustc = ".../rustc-governor"` line to add per account.
+`[build] rustc-wrapper = ".../rustc-governor"` line to set per account
+(replacing sccache as the wrapper — the governor execs sccache itself,
+via the conf's `wrap_with` key) and the legacy `rustc = ".../rustc-governor"`
+line to REMOVE (cargo passes the real compiler as argv[1] now; a
+leftover rustc= line would hand the governor itself, which it refuses
+with exit 127 rather than exec-looping). The installer never overwrites
+an existing conf, so on upgraded boxes the operator adds
+`wrap_with = "/opt/homebrew/bin/sccache"` by hand — the installer
+prints that reminder when the key is missing.
 **Canary order: the CI account first, soak a day of green runs, then
-the operator account.** Known accepted cost: sccache hashes the
-compiler binary — the governor — into its cache keys, so enablement
-and every governor upgrade invalidate that account's sccache cache
-once (one cold rebuild, warm again after). Resizing the reservations
+the operator account.** Cache keys: sccache hashes the compiler it is
+asked to run — the real rustc again — so enablement and governor
+upgrades no longer invalidate the account's sccache cache (the old
+governor-as-compiler wiring paid one cold rebuild per governor change;
+that cost is gone). Resizing the reservations
 upward needs the installer re-run (or a root `touch` + `chmod 0644`)
 to mint the new permit files; permit files the governor cannot open
 are simply not part of the pool, and if none are usable it fails open.
@@ -405,8 +452,10 @@ before-images land in `/etc/intendant-ci/migration/` for audit.
   create files in the root-owned permit dir). Change the naming or the
   file ACLs in one, change both.
 - The governor's config keys (`enabled`, `permit_dir`,
-  `local_reserved`, `ci_reserved`, `ci_users`, `real_rustc`) are
+  `local_reserved`, `ci_reserved`, `ci_users`, `wrap_with`) are
   written by the installer's here-doc and parsed by
   `crates/rustc-governor/src/config.rs` — a minimal TOML-subset
   reader, so keep the conf flat `key = value` (unknown keys are
-  ignored; malformed lines make the whole file fail open).
+  ignored — which is also why pre-flip confs carrying the retired
+  `real_rustc` key stay parseable; malformed lines make the whole
+  file fail open).

--- a/scripts/ci/install-governor-macos.sh
+++ b/scripts/ci/install-governor-macos.sh
@@ -10,9 +10,11 @@
 # that file is live operator state (the kill switch lives in it).
 #
 # Deliberately does NOT touch any account's ~/.cargo/config.toml: the
-# governor stays inert until an account's cargo points at it, and the
-# operator canaries the CI account before wiring their own. This script
-# only prints the lines to add. Doc: scripts/ci/README.md, "Governor".
+# governor stays inert until an account's cargo points at it (as
+# `[build] rustc-wrapper`; the governor execs sccache itself via the
+# conf's wrap_with key), and the operator canaries the CI account before
+# wiring their own. This script only prints the lines to set/remove.
+# Doc: scripts/ci/README.md, "Governor".
 set -euo pipefail
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -50,13 +52,27 @@ permit_dir = "/usr/local/var/intendant-governor"
 local_reserved = 1
 ci_reserved = 2
 ci_users = ["_intendant-ci", "ci"]
-# real_rustc = "/absolute/path/to/rustc"   # optional; default resolution is
-#                                          # $HOME/.cargo/bin/rustc, else PATH
+# Governed (and fail-open) invocations exec `wrap_with <rustc> <args…>` —
+# the sccache client; the flock permit rides into it and is held for the
+# whole cache round-trip / server-side compile. Unset, empty, or a missing
+# path: the compiler runs directly (correct, just uncached).
+wrap_with = "/opt/homebrew/bin/sccache"
 CONF_EOF
     chmod 0644 "$CONF"
     echo "wrote $CONF"
 else
     echo "keeping existing $CONF (live operator state — edit by hand)"
+    if ! grep -q '^[[:space:]]*wrap_with[[:space:]]*=' "$CONF"; then
+        cat <<'WRAP_EOF'
+  NOTE: this conf predates the wrapper-chain flip and has no wrap_with key.
+  The governor is now cargo's rustc-wrapper and invokes sccache itself;
+  without wrap_with, governed builds still work but run UNCACHED. Add to
+  the conf by hand:
+    wrap_with = "/opt/homebrew/bin/sccache"
+  (Any leftover real_rustc line is inert and can be dropped: the governor
+  now receives the compiler path from cargo as argv[1].)
+WRAP_EOF
+    fi
 fi
 
 # Pre-create the flock files for the *effective* config (an existing conf
@@ -98,21 +114,28 @@ echo "permit dir ready: $permit_dir (local=$local_n ci=$ci_n)"
 cat <<'NEXT_EOF'
 
 The governor is installed but INERT: no account uses it until its cargo
-config points at it. For each account to govern, add under the EXISTING
-[build] table in that account's ~/.cargo/config.toml (keep the
-rustc-wrapper = sccache line exactly as it is):
+config points at it. For each account to govern, set under the EXISTING
+[build] table in that account's ~/.cargo/config.toml:
 
 [build]
-rustc = "/usr/local/lib/intendant-ci/bin/rustc-governor"
+rustc-wrapper = "/usr/local/lib/intendant-ci/bin/rustc-governor"
+
+replacing any `rustc-wrapper = ".../sccache"` line (the governor execs
+sccache itself, via the conf's wrap_with key), and REMOVE any legacy
+`rustc = ".../rustc-governor"` line — the governor now receives the real
+compiler path from cargo as argv[1]; if cargo hands it the governor
+itself, it refuses with exit 127 rather than exec-looping.
 
 Rollout order (see scripts/ci/README.md "Governor"): the CI account
 first, soak a day of green runs, then the operator account.
 
 Notes:
-- sccache hashes the compiler binary (the governor) into its cache keys:
-  first enablement — and every governor upgrade — invalidates that
-  account's sccache cache once.
+- Cache keys are computed against the real rustc again (sccache is asked
+  to run the real compiler, not the governor), so enablement and governor
+  upgrades no longer invalidate the account's sccache cache.
 - Kill switch: set `enabled = false` in /usr/local/etc/intendant-governor.toml
-  (immediate, machine-wide); removing the rustc= line fully unwires an account.
+  (immediate, machine-wide); a disabled governor still execs the wrap_with
+  chain, so caching survives the kill switch. Removing the rustc-wrapper=
+  line fully unwires an account.
 - Watch it: tail -f /usr/local/var/intendant-governor/governor.log
 NEXT_EOF


### PR DESCRIPTION
The production bypass, fixed structurally. sccache 0.15 probes its 'compiler' with `+stable -vV`; the governor's probe fast-path forwarded that to the rustup proxy, so sccache classified the governor AS a rustup proxy, resolved the underlying toolchain rustc, and invoked it directly for cacheable server-side work — ungoverned (verified live: toolchain rustcs as sccache-server children while all permits were held; only links/non-cacheable stayed governed).

New chain: the governor is cargo's **RUSTC_WRAPPER**, sccache behind it — `cargo → governor <rustc> <args> → [permit] → exec sccache <rustc> <args> (blocking client)`. The permit rides the FD_CLOEXEC-cleared fd into the exec'd client, which blocks until the server answers: **≤N outstanding clients ⇒ ≤N server-side compiles**, whatever rustc the server resolves. Hits occupy a permit for ~ms; head-of-line blocking of hits under miss-saturation is the accepted trade (reviewed decision). Probes exec the real compiler directly — no permit, no sccache, so compiler probes no longer depend on a healthy sccache server (Thursday's incident class). Fail-open now preserves the wrap chain: a disabled governor behaves exactly like a plain sccache wrapper. Cache keys return to the real rustc — governor upgrades stop invalidating caches.

**The regression test that would have caught this** (`tests/sccache_chain.rs`, per review requirement): real sccache, private server, one-permit config; primed compiler detection; a unique **cargo-shaped cacheable rlib** miss under a test-flocked permit must stay queued (completion = bypass regressed); probe fast under saturation; release → completes. Ran against sccache 0.15.0 (11s, not skipped). The shape rationale is documented in-test: bin/link and metadata-emit shapes are non-cacheable and silently test the wrong path — the exact probe-design error that let the original ship.

51/51 crate tests, full --bins suite green, clippy zero, fmt clean. Operator rollout (rewire both accounts to `rustc-wrapper = governor`, drop the `rustc =` line, add `wrap_with` to the host conf) follows the landing.