### PR TITLE
agent loop: deliver steers that reach a session between rounds

### DIFF
--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -2597,6 +2597,66 @@ Proceed with explicit assumptions and continue without additional questions."
     Ok((loop_stats, exit_reason))
 }
 
+/// Claim (remove and return) pending user-steer injections targeted at
+/// this session, optionally narrowed to one steer id. The parked
+/// follow-up drain uses this to rescue steers a dying round's watcher
+/// accepted into `context_injection` — acceptance promised "the next
+/// model checkpoint", and when the round ends first, the parked drain IS
+/// that checkpoint (it starts the round that delivers them). Also the
+/// dedup for the acceptance race: a steer both claimed here and queued
+/// by the watcher's corpse must not deliver twice.
+fn claim_steer_injections(
+    context_injection: &event::ContextInjectionQueue,
+    local_session_id: &Option<String>,
+    steer_id: Option<&str>,
+) -> Vec<event::ContextInjection> {
+    let Ok(mut queue) = context_injection.lock() else {
+        return Vec::new();
+    };
+    let mut claimed = Vec::new();
+    let mut index = 0;
+    while index < queue.len() {
+        let injection = &queue[index];
+        let is_steer = injection.steer_id.is_some();
+        let targets_here = injection
+            .target_session_id
+            .as_deref()
+            .is_none_or(|target| Some(target) == local_session_id.as_deref());
+        let id_matches = steer_id.is_none_or(|want| {
+            injection
+                .steer_id
+                .as_deref()
+                .is_some_and(|have| have == want)
+        });
+        if is_steer && targets_here && id_matches {
+            claimed.push(queue.remove(index));
+        } else {
+            index += 1;
+        }
+    }
+    claimed
+}
+
+/// The parked drain's exit when a steer reaches a between-rounds session:
+/// the synthesized next-round follow-up plus the acceptance the steer
+/// protocol expects (empty ids skip the ack — nothing correlates on "").
+fn steer_follow_up(
+    bus: &EventBus,
+    local_session_id: &Option<String>,
+    text: String,
+    steer_id: String,
+) -> FollowUpMessage {
+    if !steer_id.trim().is_empty() {
+        bus.send(AppEvent::SteerAccepted {
+            session_id: local_session_id.clone(),
+            id: steer_id.clone(),
+            reason: "Delivered to the parked session as the next round".to_string(),
+        });
+    }
+    FollowUpMessage::steer(text, UserAttachments::default(), steer_id)
+        .for_target(local_session_id.clone())
+}
+
 /// Wraps `run_agent_loop` in a multi-round loop that waits for follow-up messages
 /// between rounds. The session continues until the user closes the channel,
 /// budget is exhausted, safety cap is reached, or a non-recoverable exit occurs.
@@ -2687,62 +2747,127 @@ pub(crate) async fn run_round_loop(
                     native_message_count,
                 });
 
-                // Wait for follow-up message, while accepting queued
-                // cancellation requests before the next turn consumes them.
-                let Some(message) = (loop {
-                    while let Ok(AppEvent::FollowUpCancelRequested {
-                        session_id,
-                        id,
-                        reason,
-                    }) = follow_up_cancel_rx.try_recv()
-                    {
-                        if event_targets_session(&session_id, &local_session_id) {
-                            record_cancelled_follow_up_id(
-                                &mut cancelled_follow_ups,
-                                bus,
-                                local_session_id.as_deref(),
-                                id,
-                                &reason,
-                            );
+                // Parked-steer pickup, half 1 (see claim_steer_injections):
+                // a steer accepted by the dying round's watcher sits in
+                // `context_injection` with no next checkpoint — deliver it
+                // as the next round now. The fresh subscription below is
+                // created BEFORE the sweep so a steer cannot land between
+                // sweep and subscribe: it is either already in the queue
+                // (the sweep finds it) or observable on the subscription
+                // (the select arm finds it). It must be fresh — the
+                // round-long `follow_up_cancel_rx` backlog replays
+                // mid-round SteerRequested events the live watcher already
+                // handled.
+                let mut parked_steer_rx = bus.subscribe();
+                let mut orphaned =
+                    claim_steer_injections(context_injection, &local_session_id, None);
+                // One steer round per drain pass: deliver the first, put
+                // the rest back for the next pass (each delivery loops
+                // back through this drain).
+                if orphaned.len() > 1 {
+                    if let Ok(mut queue) = context_injection.lock() {
+                        for injection in orphaned.drain(1..).rev() {
+                            queue.insert(0, injection);
                         }
                     }
-                    tokio::select! {
-                        biased;
-                        bus_event = follow_up_cancel_rx.recv() => {
-                            match bus_event {
-                                Ok(AppEvent::FollowUpCancelRequested { session_id, id, reason })
-                                    if event_targets_session(&session_id, &local_session_id) =>
-                                {
-                                    record_cancelled_follow_up_id(
-                                        &mut cancelled_follow_ups,
-                                        bus,
-                                        local_session_id.as_deref(),
-                                        id,
-                                        &reason,
-                                    );
-                                }
-                                Ok(_) => {}
-                                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
-                                Err(tokio::sync::broadcast::error::RecvError::Closed) => {}
+                }
+
+                // Wait for follow-up message, while accepting queued
+                // cancellation requests before the next turn consumes them.
+                let Some(message) = (if let Some(injection) = orphaned.into_iter().next() {
+                    let steer_id = injection.steer_id.clone().unwrap_or_default();
+                    Some(steer_follow_up(
+                        bus,
+                        &local_session_id,
+                        injection.text,
+                        steer_id,
+                    ))
+                } else {
+                    loop {
+                        while let Ok(AppEvent::FollowUpCancelRequested {
+                            session_id,
+                            id,
+                            reason,
+                        }) = follow_up_cancel_rx.try_recv()
+                        {
+                            if event_targets_session(&session_id, &local_session_id) {
+                                record_cancelled_follow_up_id(
+                                    &mut cancelled_follow_ups,
+                                    bus,
+                                    local_session_id.as_deref(),
+                                    id,
+                                    &reason,
+                                );
                             }
                         }
-                        maybe_message = follow_up_rx.recv() => {
-                            match maybe_message {
-                                Some(message) => {
-                                    if follow_up_message_was_cancelled(
-                                        &mut cancelled_follow_ups,
-                                        &message,
-                                    ) {
-                                        slog(&session_log, |l| {
-                                            l.info("Skipped cancelled queued follow-up")
-                                        });
-                                        continue;
+                        tokio::select! {
+                            biased;
+                            bus_event = follow_up_cancel_rx.recv() => {
+                                match bus_event {
+                                    Ok(AppEvent::FollowUpCancelRequested { session_id, id, reason })
+                                        if event_targets_session(&session_id, &local_session_id) =>
+                                    {
+                                        record_cancelled_follow_up_id(
+                                            &mut cancelled_follow_ups,
+                                            bus,
+                                            local_session_id.as_deref(),
+                                            id,
+                                            &reason,
+                                        );
                                     }
-                                    break Some(message);
+                                    Ok(_) => {}
+                                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {}
                                 }
-                                None => {
-                                    // Channel closed — user quit or sender dropped
-                                    break None;
+                            }
+                            steer_event = parked_steer_rx.recv() => {
+                                match steer_event {
+                                    Ok(AppEvent::SteerRequested { session_id, text, id })
+                                        if event_targets_session(&session_id, &local_session_id) =>
+                                    {
+                                        // Parked-steer pickup, half 2: this
+                                        // drain is the steer's checkpoint.
+                                        // Claim any same-id injection the
+                                        // dying watcher's corpse pushed so it
+                                        // cannot deliver a second time at the
+                                        // next round's turn-top drain.
+                                        if !id.trim().is_empty() {
+                                            let _ = claim_steer_injections(
+                                                context_injection,
+                                                &local_session_id,
+                                                Some(id.as_str()),
+                                            );
+                                        }
+                                        break Some(steer_follow_up(
+                                            bus,
+                                            &local_session_id,
+                                            text,
+                                            id,
+                                        ));
+                                    }
+                                    Ok(_) => {}
+                                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {}
+                                }
+                            }
+                            maybe_message = follow_up_rx.recv() => {
+                                match maybe_message {
+                                    Some(message) => {
+                                        if follow_up_message_was_cancelled(
+                                            &mut cancelled_follow_ups,
+                                            &message,
+                                        ) {
+                                            slog(&session_log, |l| {
+                                                l.info("Skipped cancelled queued follow-up")
+                                            });
+                                            continue;
+                                        }
+                                        break Some(message);
+                                    }
+                                    None => {
+                                        // Channel closed — user quit or sender dropped
+                                        break None;
+                                    }
                                 }
                             }
                         }
@@ -2765,6 +2890,17 @@ pub(crate) async fn run_round_loop(
                         }
                     ))
                 });
+                // Acceptance-race dedup: if the dying watcher's corpse
+                // pushed this steer's injection AFTER the drain arm looked,
+                // claim it now — the text is about to enter the
+                // conversation through this follow-up.
+                if let Some(id) = message
+                    .steer_id
+                    .as_deref()
+                    .filter(|id| !id.trim().is_empty())
+                {
+                    let _ = claim_steer_injections(context_injection, &local_session_id, Some(id));
+                }
                 // A between-rounds steer is delivered through this path
                 // (steer_id set); classify it as such rather than follow_up.
                 let followup_provenance = if message.steer_id.is_some() {

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -3109,6 +3109,131 @@ async fn supervised_session_writes_task_ask_human_and_steer_message_rows() {
     );
 }
 
+/// A steer WITHOUT an id delivered to a parked session must still start
+/// the next round (regression: nothing consumed SteerRequested for a
+/// parked session — the supervisor's queue-as-follow-up fallback only
+/// arms for id-carrying steers, and the round watcher dies with its
+/// round — so id-less steers, the API/MCP default, vanished silently;
+/// the parked drain now picks them up directly). Also covers the
+/// round-boundary acceptance race: a steer arriving as the round dies
+/// may be "accepted" by the doomed watcher, and the drain must deliver
+/// it anyway.
+#[tokio::test]
+async fn parked_session_delivers_an_id_less_steer() {
+    use futures_util::SinkExt;
+
+    let rig = TestRig::new();
+    let script = rig.write_script(&serde_json::json!({
+        "profiles": [{
+            "steps": [
+                { "content": "Round one answer.",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "round one" } }] },
+                { "content": "Steered onward.",
+                  "expect_transcript_contains": "quiet steer text",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "round two" } }] }
+            ]
+        }]
+    }));
+    let session_project = tempfile::tempdir().expect("session project dir");
+
+    let mut cmd = rig.command();
+    cmd.env("INTENDANT_MOCK_SCRIPT", &script)
+        .args(["--no-tls", "--web", "0"]);
+    let mut child = cmd.spawn().expect("spawn intendant daemon");
+    let stderr_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let stdout_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let _stderr_drain = drain_pipe_into(child.stderr.take().expect("stderr"), stderr_buf.clone());
+    let _stdout_drain = drain_pipe_into(child.stdout.take().expect("stdout"), stdout_buf.clone());
+
+    let stderr_so_far = wait_for_output(&stderr_buf, "Dashboard: http://", RUN_TIMEOUT).await;
+    let port: u16 = stderr_so_far
+        .lines()
+        .find_map(|line| {
+            let url = line.strip_prefix("Dashboard: http://")?;
+            url.rsplit(':').next()?.trim().parse().ok()
+        })
+        .expect("parse the dashboard port from the startup line");
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/ws"))
+        .await
+        .expect("connect /ws");
+
+    // Same startup race + retry shape as the sibling tests.
+    let mut completed = None;
+    for _ in 0..6 {
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::json!({
+                "action": "create_session",
+                "task": "run the first round",
+                "project_root": session_project.path().to_string_lossy(),
+                "direct": true,
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send create_session");
+        completed = next_matching_ws_event(&mut ws, Duration::from_secs(30), |json| {
+            json.get("event").and_then(|v| v.as_str()) == Some("round_complete")
+        })
+        .await;
+        if completed.is_some() {
+            break;
+        }
+    }
+    let completed = completed.unwrap_or_else(|| {
+        panic!(
+            "round 1 never completed; daemon stderr:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
+        )
+    });
+    let session_id = completed
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .expect("round_complete carries its session id")
+        .to_string();
+
+    // The id-less steer (API/MCP default shape) to the parked session.
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "steer",
+            "session_id": session_id,
+            "text": "quiet steer text",
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send steer");
+    next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("round_complete")
+            && json.get("session_id").and_then(|v| v.as_str()) == Some(session_id.as_str())
+    })
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "id-less steered round never completed; daemon stderr:\n{}\nsession logs:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default(),
+            tail(&rig.session_logs(), 6000)
+        )
+    });
+    let _ = child.kill().await;
+
+    // The steer text entered the message lane with steer provenance.
+    let log_dir = rig
+        .home
+        .path()
+        .join(".intendant")
+        .join("logs")
+        .join(&session_id);
+    let rows = parsed_session_rows(&log_dir);
+    let messages = canonical_message_rows(&rows);
+    let steer_row = user_message_row(&messages, "quiet steer text");
+    assert_eq!(msg_field(steer_row, "provenance").as_str(), Some("steer"));
+}
+
 /// Message-lane wire contract, rollback half: the HEADLESS shape (task on
 /// argv) is the one execution shape whose outer loop (run_with_presence)
 /// handles `ConversationRollbackRequested`, so the round-rollback rail —


### PR DESCRIPTION
Fixes the round-boundary steer race that ejected three PRs from the merge queue today, plus the id-less parked-steer gap.

**The race, proven live** (daemon log, 1ms apart, then 180s of silence):
```
round_complete (round 1)
steer_requested (id steer-e2e-1)
steer_accepted "Queued for the next model checkpoint"   ← the dead round's watcher
```
`run_agent_loop`'s steer watcher is aborted when the round exits, but `abort()` is asynchronous — under scheduler latency the doomed task still wins the broadcast race, acks the steer (which kills the supervisor's 2s queue-as-follow-up fallback), and pushes the text onto `context_injection`, whose next drain point never comes. The steer is silently lost while reporting "accepted". Reproduced locally at will under load; it hit the queue's macOS and Windows legs three times today.

**The gap**: a steer WITHOUT an id (the API/MCP default — the dashboard always sends one) to a parked session was never delivered at all: the fallback only arms for id-carrying steers, and a parked session has no watcher.

**Fix — the parked follow-up drain becomes the steer's checkpoint**:
- At drain entry it claims orphaned steer injections (steers the corpse accepted before the drain armed — including ones accepted on the round's final turn, which had the same no-next-checkpoint loss) and delivers the first as the next round, re-queueing extras one round at a time.
- It listens for `SteerRequested` on a fresh subscription (fresh deliberately: the round-long cancel subscription's backlog would replay mid-round steers the live watcher already handled) and synthesizes the follow-up directly — immediate delivery instead of the 2s fallback wait.
- Id-carrying steers are acked so the fallback stands down; same-id injections are claimed at both pickup points and at round start, so the acceptance race cannot deliver the text twice.

New e2e pins the id-less parked path (`parked_session_delivers_an_id_less_steer`); the existing steer e2e — the one that exposed the race — pins the id-carrying path, and now passes in ~4s instead of ~7s (no fallback timeout) across repeated runs.

Battery: full `cargo nextest run --bins` (3135), full `cargo test --test e2e` (18), clippy `-D warnings`, fmt.