### PR TITLE
message_search: real-corpus soak fixes (arena, scan order, twin dedup)

### DIFF
--- a/src/bin/caller/message_search/indexer.rs
+++ b/src/bin/caller/message_search/indexer.rs
@@ -439,7 +439,28 @@ impl Indexer {
             }
 
             for (session_id, main_path) in mains {
-                let agent_paths = subagents.remove(&session_id).unwrap_or_default();
+                let mut agent_paths = subagents.remove(&session_id).unwrap_or_default();
+                // Relocated project dirs can carry HARDLINKED twins of the
+                // same subagent transcripts (one session observed under
+                // both its real project path and a volume-alias path, same
+                // inodes) — extracting both would duplicate every subagent
+                // record. Dedup by file identity, path as the fallback.
+                agent_paths.sort();
+                agent_paths.dedup();
+                let mut seen_identities: Vec<crate::platform::FileIdentity> = Vec::new();
+                agent_paths.retain(
+                    |path| match crate::platform::FileIdentity::from_path(path) {
+                        Ok(identity) if identity.is_reliable() => {
+                            if seen_identities.contains(&identity) {
+                                false
+                            } else {
+                                seen_identities.push(identity);
+                                true
+                            }
+                        }
+                        _ => true,
+                    },
+                );
                 let newest_mtime = std::iter::once(&main_path)
                     .chain(agent_paths.iter())
                     .map(|path| file_mtime_ms(path))

--- a/src/bin/caller/message_search/query.rs
+++ b/src/bin/caller/message_search/query.rs
@@ -38,7 +38,11 @@ const HIT_OVERHEAD_BYTES: usize = 320;
 const SNIPPET_BEFORE_BYTES: usize = 120;
 const SNIPPET_TOTAL_BYTES: usize = 280;
 /// Byte budget for shards resident in the fold arena (LRU beyond it).
-const ARENA_BUDGET_BYTES: usize = 64 * 1024 * 1024;
+/// Calibrated on the real corpus (soak 2026-07-12): 1.4k sessions cost
+/// ~2x their 36MB of shard JSON with the ASCII fast path — a budget
+/// smaller than the working set makes every query re-load and re-fold
+/// under its time budget, answering `partial` forever.
+const ARENA_BUDGET_BYTES: usize = 192 * 1024 * 1024;
 /// Per-query ceiling on freshly loaded shard bytes: a query that would
 /// have to page the whole arena through memory ends early with
 /// `partial: "budget"` instead of thrashing.
@@ -147,12 +151,36 @@ pub(crate) fn run_message_search(
     let mut partial_reason: Option<&'static str> = None;
     let mut loaded_bytes: usize = 0;
 
-    // Scan pass: match every (source-filtered) session, keep its summary.
+    // Scan newest-first with an early exit: a session's best hit can
+    // never be newer than its entry's newest_ts_ms, so once the page is
+    // full and the next entry is older than the page's worst kept best
+    // hit, nothing later can displace it. Broad terms become
+    // limit-bounded instead of full-corpus (soak 2026-07-12: key-order
+    // scanning answered `partial` forever on the real corpus, and a
+    // timeout cut could drop the newest sessions from the page).
+    let mut ordered: Vec<(&String, &super::store::SessionEntry)> =
+        snapshot.manifest.sessions.iter().collect();
+    ordered.sort_by(|a, b| {
+        b.1.newest_ts_ms
+            .cmp(&a.1.newest_ts_ms)
+            .then_with(|| a.0.cmp(b.0))
+    });
     let mut matched: Vec<SessionMatch> = Vec::new();
-    for (session_key, entry) in &snapshot.manifest.sessions {
+    let mut kept_past_cursor = 0usize;
+    for (session_key, entry) in ordered {
         if std::time::Instant::now() >= deadline {
             partial_reason = Some("timeout");
             break;
+        }
+        if kept_past_cursor > limit {
+            let worst_kept = matched
+                .iter()
+                .map(|m| m.best_ts_ms)
+                .min()
+                .unwrap_or(i64::MIN);
+            if entry.newest_ts_ms < worst_kept {
+                break;
+            }
         }
         let Some(source) = source_of_key(session_key) else {
             continue;
@@ -176,7 +204,7 @@ pub(crate) fn run_message_search(
             partial_reason = Some("budget");
             break;
         }
-        let active = derive_active(&shard.shard.records, &shard.shard.marks);
+        let active = &shard.active;
         let mut hits: Vec<Hit> = Vec::new();
         for (index, record) in shard.shard.records.iter().enumerate() {
             if record.ts_ms < horizon_ms {
@@ -211,6 +239,16 @@ pub(crate) fn run_message_search(
         });
         hits.truncate(HITS_PER_SESSION);
         let best_ts_ms = shard.shard.records[hits[0].record_index].ts_ms;
+        let past_cursor = match &after {
+            None => true,
+            Some(after) => {
+                best_ts_ms < after.best_ts_ms
+                    || (best_ts_ms == after.best_ts_ms && *session_key > after.session_key)
+            }
+        };
+        if past_cursor {
+            kept_past_cursor += 1;
+        }
         matched.push(SessionMatch {
             session_key: session_key.clone(),
             source,
@@ -495,12 +533,23 @@ fn decode_cursor(raw: &str, expected_fingerprint: &str) -> Result<DecodedCursor,
 /// Folded text with an exact folded-byte → original-byte-offset map.
 pub(crate) struct FoldedText {
     folded: String,
-    /// Original char START offset for each folded byte.
+    /// Original char START offset for each folded byte. EMPTY when the
+    /// fold is byte-aligned (pure-ASCII text: lowercasing is 1:1, and
+    /// canonical decomposition of ASCII is identity) — the map is the
+    /// arena's dominant cost (4 bytes per folded byte), and the corpus
+    /// is overwhelmingly ASCII.
     starts: Vec<u32>,
     original_len: u32,
 }
 
 pub(crate) fn fold_text(text: &str) -> FoldedText {
+    if text.is_ascii() {
+        return FoldedText {
+            folded: text.to_ascii_lowercase(),
+            starts: Vec::new(),
+            original_len: text.len() as u32,
+        };
+    }
     let mut folded = String::with_capacity(text.len());
     let mut starts = Vec::with_capacity(text.len());
     for (offset, ch) in text.char_indices() {
@@ -524,6 +573,13 @@ impl FoldedText {
     /// is the producing char's start; the end extends to the end of the
     /// original char that produced the last folded byte.
     fn original_range(&self, folded_start: usize, folded_end: usize) -> (u32, u32) {
+        if self.starts.is_empty() {
+            // Byte-aligned fold (ASCII fast path): offsets are identity.
+            return (
+                (folded_start as u32).min(self.original_len),
+                (folded_end as u32).min(self.original_len),
+            );
+        }
         let start = self
             .starts
             .get(folded_start)
@@ -554,6 +610,11 @@ impl FoldedText {
 pub(crate) struct LoadedShard {
     pub shard: SessionShard,
     pub folded: Vec<FoldedText>,
+    /// Derived active flags, index-aligned with `records` — pure per
+    /// content-named generation file, so computed once at load instead
+    /// of per query (rare terms scan every session; per-query
+    /// derive_active dominated their cost on the real corpus).
+    pub active: Vec<bool>,
     cost_bytes: usize,
 }
 
@@ -602,6 +663,7 @@ fn arena_load(store_root: &Path, generation_file: &str) -> Option<(Arc<LoadedSha
         .iter()
         .map(|record| fold_text(&record.text))
         .collect();
+    let active = derive_active(&shard.records, &shard.marks);
     let cost_bytes = raw.len()
         + folded
             .iter()
@@ -610,6 +672,7 @@ fn arena_load(store_root: &Path, generation_file: &str) -> Option<(Arc<LoadedSha
     let loaded = Arc::new(LoadedShard {
         shard,
         folded,
+        active,
         cost_bytes,
     });
 

--- a/src/bin/caller/message_search/store.rs
+++ b/src/bin/caller/message_search/store.rs
@@ -179,16 +179,25 @@ impl Store {
         if let Some(existing) = manifest.sessions.get(session_key) {
             // A lower watermark from the SAME source state is a stale
             // writer (lost race) — reject; the loser re-derives next pass.
-            // A lower watermark with CHANGED source fingerprints is a
-            // legitimate rebuild of a rewritten/shrunk source — allow.
-            let same_source_state = existing.cursors.iter().all(|old| {
-                cursors
+            // A lower watermark with CHANGED source fingerprints OR a
+            // changed cursor set is a legitimate rebuild (rewritten/
+            // shrunk source, or a publisher that stopped double-counting
+            // a source file — the soak's hardlink-twin dedup halved a
+            // session's watermark and must not be rejected forever).
+            let same_paths = existing.cursors.len() == cursors.len()
+                && existing
+                    .cursors
                     .iter()
-                    .find(|new| new.path == old.path)
-                    .is_none_or(|new| {
-                        new.prefix_hash16 == old.prefix_hash16 && new.identity == old.identity
-                    })
-            });
+                    .all(|old| cursors.iter().any(|new| new.path == old.path));
+            let same_source_state = same_paths
+                && existing.cursors.iter().all(|old| {
+                    cursors
+                        .iter()
+                        .find(|new| new.path == old.path)
+                        .is_none_or(|new| {
+                            new.prefix_hash16 == old.prefix_hash16 && new.identity == old.identity
+                        })
+                });
             if watermark < existing.source_watermark && same_source_state {
                 return Ok(PublishOutcome::RejectedStale);
             }
@@ -511,6 +520,51 @@ mod tests {
         assert_eq!(
             store.snapshot().read_shard("intendant:s1").unwrap().records[0].text,
             "rebuilt view"
+        );
+    }
+
+    #[test]
+    fn changed_cursor_set_republish_may_lower_the_watermark() {
+        // A publisher that stops double-counting a source (the soak's
+        // hardlink-twin dedup) publishes FEWER cursors summing to a lower
+        // watermark over unchanged files — a legitimate rebuild, not a
+        // stale writer.
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let path = tmp.path().join("main.jsonl");
+        std::fs::write(&path, "line\n".repeat(64)).unwrap();
+        let twin = SourceCursor::capture(&path, 100).unwrap();
+        let shard = SessionShard {
+            records: vec![record(100, "doubled")],
+            marks: vec![],
+        };
+        store
+            .publish_session(
+                "claude-code:s1",
+                &shard,
+                vec![twin.clone(), twin.clone()],
+                false,
+            )
+            .unwrap();
+
+        let deduped = SessionShard {
+            records: vec![record(100, "single")],
+            marks: vec![],
+        };
+        assert!(matches!(
+            store
+                .publish_session("claude-code:s1", &deduped, vec![twin], false)
+                .unwrap(),
+            PublishOutcome::Published
+        ));
+        assert_eq!(
+            store
+                .snapshot()
+                .read_shard("claude-code:s1")
+                .unwrap()
+                .records[0]
+                .text,
+            "single"
         );
     }
 


### PR DESCRIPTION
Findings and fixes from soaking the complete pipeline against this box's live 14-day corpus (1,375 sessions / 36MB of shards / three sources) — the fixture-scale tests couldn't see any of these.

1. **Arena thrash → eternal `partial`.** The 64MiB fold arena was smaller than the corpus's resident cost, so every query re-loaded shards into its 150ms budget. Fix: ASCII identity fast path (byte-aligned folds need no offset map — the map was 4 bytes/folded byte, the dominant cost) + budget calibrated to 192MiB (~2× corpus).
2. **Key-order scan → recency-broken partial pages.** Broad terms did full-corpus work and a timeout cut could drop the newest sessions. Fix: newest-first scan with an early exit once the page can't change — broad terms are now limit-bounded (2ms measured) and partial pages are recency-correct.
3. **Per-query `derive_active`.** Active flags are pure per content-named generation file; now computed once at arena load. Rare terms (unavoidable full scans) drop 150ms→~10ms.
4. **Hardlinked subagent twins double-indexed.** Relocated Claude project dirs can carry hardlinked copies of the same subagent transcripts (observed live: real path + volume-alias path, same inodes) — every subagent record duplicated. The indexer dedups by `FileIdentity`, and the store's stale-writer gate now treats a changed cursor **set** as a legitimate rebuild (the dedup halves the watermark over unchanged files; the old gate would have rejected the corrected shard forever — new store test pins it).

Soak results on the real corpus (also exercised: multi-daemon coordination with pre-published shards, snapshot-cursor pagination + 410, q limits, `no-store`, locate round trip from a live hit → `resolved`/exact anchor, and headless-browser QA of the flagged dashboard — typed query → 20 ready sessions rendered; flag off → lane inert):
- warm latency **p50 5ms / p95 10ms / max 12ms, all `ready`** (acceptance target: p95 <100ms)
- tool output / reasoning correctly never found (verified against a transcript where the probe phrase exists only in tool_use/thinking blocks)

Battery: full `cargo nextest run --bins` (3180), full e2e (18), clippy `-D warnings`, fmt.