### PR TITLE
Document the message lane and message-search subsystem in session-logging.md

### DIFF
--- a/docs/src/session-logging.md
+++ b/docs/src/session-logging.md
@@ -6,9 +6,11 @@ Every `intendant` invocation gets a structured session log directory. It is the
 single source of truth for what happened in a session: a line-per-event JSONL
 stream, full per-turn artifacts, the agent's stdout/stderr, file-history
 snapshots, and (in headless/web/MCP runs) the controller's own console output.
-It serves three audiences: a human debugging after the fact, the dashboard
-replaying a session into the browser, and the resume path rehydrating a
-conversation to continue work.
+It serves four audiences: a human debugging after the fact, the dashboard
+replaying a session into the browser, the resume path rehydrating a
+conversation to continue work, and the message-search indexer deriving its
+rolling index from the canonical message lane (see
+[Message Search](#message-search-the-rolling-message-index)).
 
 The implementation lives in the `session_log/` module: `mod.rs` (the
 `SessionLog` core — open/meta/discovery, emit, CU events, summaries, turn
@@ -128,23 +130,57 @@ Each is written by a typed method on `SessionLog` (e.g. `turn_start`,
 
 `conversation_message` is the canonical append-only record of what was
 *actually said* in the native worker conversation — the source the
-message-search index consumes. One record per genuine entry: the task
-(provenance `task`), resume continuations (`resume_task`), follow-ups
-(`follow_up`), steers delivered into model context (`steer`), accepted
-askHuman answers (`ask_human_answer`), and non-empty assistant responses
-(`assistant` — emitted by the same call that writes the `turns/*_model.txt`
-sidecar span the record references via `file` + `data.model_offset`/
-`data.model_bytes`). System injections, tool output, context summaries, the
-CU sub-conversation, and presence never emit it. `data.text` carries the RAW
-user text (no attachment preludes or `[New Task]`-style wrappers);
-`data.message_seq` is the conversation's monotonic ordinal (`Message.seq`);
-`data.ref_seq` marks a projection (a native-tool askHuman answer riding a
-tool result). `conversation_rewound { cut_after_seq, kind }` marks messages
-past a rewind cut as superseded — compaction deliberately does NOT emit it.
-`conversation_message_epoch` records the resume-time seq assignment for
-legacy files (`mapping: [[seq, role, content-hash16], …]`); extractors use
-legacy extraction strictly before the marker and `conversation_message`
-records after it.
+message-search index consumes (see
+[Message Search](#message-search-the-rolling-message-index)). One record per
+genuine entry, written by two typed methods in `bus_events.rs`:
+
+- **User side** (`conversation_message_user`): the task (provenance `task`),
+  resume continuations (`resume_task`), follow-ups (`follow_up`), steers
+  delivered into model context (`steer`), and accepted askHuman answers
+  (`ask_human_answer`). `data.text` carries the RAW user text — attachment
+  preludes and `[Session resumed]`/`[New Task]`/`[User]` wrappers are the
+  conversation's concern, not the record's. askHuman answers arrive on two
+  paths: the loop-level answer is an ordinary user message plus its record
+  (closing the audit hole where `human_response_sent` carries no text), while
+  the native-tool answer enters the conversation as a *tool result* and is
+  **projected** into the lane — `data.ref_seq` references that result's seq so
+  rewind cuts cover it.
+- **Assistant side** (`model_response_with_message`): one call writes the
+  `turns/*_model.txt` sidecar span, the diagnostic `model_response` event, and
+  the canonical record referencing the same bytes (`file` +
+  `data.model_offset`/`data.model_bytes`) — no crash window between diagnostic
+  and canonical, no second copy of the text. It fires whenever
+  `response.content` is non-empty, on both the plain and the tool-call branch
+  (assistant prose regularly accompanies tool calls). External-agent wrapper
+  sessions keep plain `model_response`: their messages are canonical in the
+  external backend's own log, and indexing skips the mirror.
+
+System injections, tool output, context summaries, the CU sub-conversation,
+and presence never emit it. The emit/skip decision is driven by
+`MessageProvenance` (`crates/intendant-core/src/conversation.rs`), a
+serialized per-message provenance axis
+(`task | resume_task | follow_up | steer | ask_human_answer |
+system_injection | tool_output | context_summary | assistant | unknown` —
+`unknown` only in legacy files). `data.message_seq` is `Message.seq`: a
+monotonic per-conversation ordinal assigned at append time and **never
+reused** — truncation does not rewind the counter — so a cut is unambiguous.
+
+Two companion events complete the lane:
+
+- `conversation_rewound { cut_after_seq, kind, superseded_at_ms }` marks
+  messages with `seq > cut_after_seq` as superseded. The daemon's
+  round-rollback rail emits it with kind `tail_rollback` (`run_modes.rs`);
+  consumers key on `cut_after_seq` alone, so `kind` is an open vocabulary.
+  Compaction (`drop_turns`/`summarize_turns`) deliberately does NOT emit it —
+  a compacted message was still said and remains canonical history.
+- `conversation_message_epoch` is the mixed-version cutover marker: on resume,
+  `Conversation::ensure_seqs_assigned` renumbers a legacy file (any loaded
+  message with `seq == 0`) `1..=N` and the marker records the ordered
+  `mapping: [[seq, role, content-hash16], …]`. Extractors use legacy
+  extraction strictly before the marker and `conversation_message` records
+  after it, correlating legacy records through the hashes. The pass is a
+  deliberate no-op for files whose seqs are all assigned — renumbering a pure
+  new-era file would break prior event references.
 
 ### Querying
 
@@ -162,6 +198,10 @@ cat "$S/turns/turn_003_reasoning.txt"
 
 # Every batch of commands sent to the runtime
 grep '"event":"agent_input"' "$S/session.jsonl" | jq -r '.message'
+
+# What was actually said (the canonical message lane)
+grep '"event":"conversation_message"' "$S/session.jsonl" \
+  | jq -r '[.data.message_seq, .data.provenance, .data.text // "(sidecar span)"] | @tsv'
 
 # Approvals and how they resolved
 grep -E '"event":"(approval|approval_resolved|auto_approved)"' "$S/session.jsonl" | jq .
@@ -283,6 +323,318 @@ Live events then continue to stream over the same WebSocket. See
 [Control Plane & Persistent Daemon](./control-plane-and-daemon.md) for the event
 producers (session supervisor, file watcher) behind the stream.
 
+## Message Search: The Rolling Message Index
+
+The message-search subsystem (`message_search/` — every module carries a doc
+header worth reading before changing it) maintains a rolling, message-only
+index over the last **14 days** of conversations on this box: native sessions
+via the message lane above, plus the supervised backends' own transcripts
+(Codex rollouts, Claude Code project files). It backs the dashboard's
+quick-search message lane and the ⌘K command palette, answering "where did we
+say X"
+from pre-extracted shards instead of raw-log scans. The exhaustive audit path
+over full logs remains Deep Search (`GET /api/sessions/search`).
+
+Three layers: per-source **extractors** derive `MessageRecord`s plus
+supersession marks per session; the **indexer** sweep enumerates this box's
+sources and publishes shards to the **store**, which owns durability,
+multi-daemon coordination, retention, and stable snapshots; the **query** side
+owns matching, normalization, and the resident fold arena.
+
+### The shard store
+
+`Store::default_root()` is `~/.intendant/cache/message_search/v1`; the
+adjacent lease-staging dirs (below) share the parent:
+
+```
+~/.intendant/cache/message_search/
+├── v1/
+│   ├── manifest.json       # the single mutable file — swapped by atomic rename
+│   ├── writer.lock         # advisory O_EXCL lockfile (5-minute stale takeover)
+│   └── generations/
+│       └── <hash16>.json   # immutable, content-named: one session's records + marks
+├── staging/                # lease-cleanup transcript remnants awaiting drain
+└── leased-active/          # registry of live leased homes (one JSON per home)
+```
+
+- **Generations are immutable and content-named** (hash of the shard body), so
+  an open snapshot keeps reading the files it resolved even while newer
+  manifests land — the query side's pagination builds on this.
+- **The manifest** carries `schema`, `parser_version`, a monotonic `revision`
+  counter (the query side's snapshot watermark — `updated_at_ms` alone cannot
+  pin a snapshot, since two writes inside one clock millisecond read as
+  unchanged), the session map keyed `<source>:<session_id>` (each entry:
+  generation file, record count, `newest_ts_ms`, `source_watermark`, cursors,
+  `source_gone`), and deletion tombstones.
+- **The writer lock is efficiency, not correctness**: shards are
+  content-deterministic from their sources, so a lost race self-heals on the
+  next pass — the lock buys query-visible stability and avoids N-daemon
+  duplicate work. The correctness gate is the publish path: it re-reads the
+  latest manifest under the lock, rejects a publish whose watermark (summed
+  consumed-source offsets) is *lower over the same source state* (a stale
+  writer that lost a race), and never lets an older `parser_version` clobber a
+  newer manifest. A lower watermark with changed source fingerprints or a
+  changed cursor set is a legitimate rebuild (rewritten/shrunk source, or a
+  publisher that stopped double-counting a file) and is accepted.
+- **Tombstones** make deliberate deletion sticky: `Store::delete_session`
+  drops the shard and tombstones the key so a stale source can never
+  resurrect it. The session-deletion flow does not call it yet — today a
+  deleted session's sources just vanish, the next sweep flips the shard to
+  `source_gone`, and the shard keeps serving until the window expires it.
+- **Retention**: sessions whose newest message left the 14-day `ts_ms` window
+  are dropped, tombstones expire with the window, and unreferenced generation
+  files are deleted — at boot (`message_search::startup_gc`) and on every
+  120th sweep (hourly at the 30 s cadence). A corrupt manifest is quarantined
+  (`manifest.corrupt-<ms>`) and rebuilt from empty; generations are
+  re-derivable from their sources.
+
+### Records, supersession, and locators
+
+Every extractor produces the shared `MessageRecord` (`record.rs`): source,
+session id, role (`user`/`assistant`), `ts_ms`, the ORIGINAL text (capped at
+256 KiB on a char boundary; `truncated` flags the cut), a locator, and the
+identity fields the marks key on — `seq` (native `Message.seq`), `user_turn` /
+`item_id` (Codex), `generation`, `subagent`.
+
+**Active vs. superseded is never stored.** It is derived at read time by
+replaying the shard's `SupersessionMark`s over the records in source order
+(`record::derive_active`), because a Codex same-thread restore can reactivate
+previously superseded messages — supersession must stay recomputable, never an
+irreversible stamp. Mark kinds:
+
+| Mark | Source | Effect |
+|---|---|---|
+| `SeqCut { cut_after_seq }` | native `conversation_rewound` | records with `seq > cut_after_seq` supersede |
+| `TurnCount { num_turns }` | Codex `thread_rolled_back` | the last N still-active user turns (and their assistant records) supersede — bounded by what exists, so corrupt counts cannot loop |
+| `ItemAnchor { item_id, position }` | Codex item-anchored rewind | everything after the anchored item (or from it, `position: "before"`) supersedes |
+| `GenerationRestore { active_generation }` | Codex same-thread restore | records of generations newer than the restored one stop reading active |
+
+Locators say where a hit lives in its source — opaque to clients, versioned by
+variant, and **frozen** (resolution verifies exactly the way extraction
+minted): `native_message_id` (a `conversation_message` id),
+`native_event` (legacy user-side: line number + content hash),
+`native_sidecar_span` (legacy assistant: file/offset/len + hash),
+`external_record_id` (Claude record `uuid`, Codex `response_item` id), and
+`external_line` (generation + line + hash, for external records without a
+native id).
+
+### The extractors
+
+All three are hermetic — every entry point takes its paths as parameters; only
+the indexer's production edge resolves the real environment.
+
+- **Intendant** (`extract_intendant.rs`) — walks one session log dir
+  (`session.jsonl` + the `turns/` sidecars its events reference). Two eras
+  coexist on disk. New era: canonical `conversation_message` rows, with
+  `conversation_rewound` becoming `SeqCut` marks. Legacy era (pre-lane logs,
+  or the pre-marker segment of a resumed session): user text is reconstructed
+  best-effort from `session_started` tasks (falling back to
+  `session_meta.json`), delivered steers (`steer_requested` joined with
+  `steer_delivered` on id), and `"Round {N} follow-up:"` info lines; assistant
+  text from `model_response` sidecar spans; legacy timestamps recover from
+  meta `created_at` + time-of-day with midnight-wrap inference. The epoch
+  marker splits the eras explicitly; without one, the presence of any
+  canonical row means the session was born new-era, and its info lines are
+  diagnostics that must not be extracted a second time. **Wrapper sessions
+  (any `session_identity` event) are skipped entirely** — their
+  `model_response` events mirror messages that are canonical in the external
+  backend's own log.
+- **Codex** (`extract_codex.rs`) — walks one rollout file (under `sessions/`
+  or `archived_sessions/`). The user lane is dual-represented in the rollout:
+  `event_msg`/`user_message` is canonical here (it twins a user-role
+  `response_item` 99.3% of the time, full-text exact), and `response_item`
+  user items are skipped entirely — which also drops the machine injections
+  that ride that lane with no event twin (AGENTS.md dumps,
+  `<environment_context>`, `<turn_aborted>`, … — 39% of naive user-lane
+  bytes). Assistant prose is canonical on assistant-role `response_item`
+  `message` items (`developer`-role items are harness config, skipped).
+  `thread_rolled_back` events become `TurnCount` and/or `ItemAnchor` marks.
+  **Generations**: a same-thread restore rewrites the rollout in place; the
+  cursor detects the rewrite, the fresh parse gets a bumped generation, and
+  the previously published records are retained and republished alongside it
+  with a `GenerationRestore` mark naming the fresh branch active — messages
+  from pre-restore generations stay findable. Prior `TurnCount`/`ItemAnchor`
+  marks are deliberately not carried across the merge (replayed over the
+  merged record vec they would alias onto the new generation's frame); dropping
+  them fails safe toward active.
+- **Claude Code** (`extract_claude.rs`) — one main `<uuid>.jsonl` plus its
+  `<uuid>/subagents/agent-*.jsonl` transcripts, joined by session uuid
+  corpus-wide (a subagent dir can live under a *different* project dir than
+  its main after a worktree relocation). Subagent records are indexed under
+  the parent session, tagged `subagent`; hardlinked twins of the same
+  subagent transcripts (one session observed under both its real project path
+  and a volume-alias path) are deduped by `FileIdentity` in the indexer.
+  Strict `.jsonl` only (`.jsonl.backup`/`.bak-*` siblings refused); prose is
+  the explicit text blocks (`message_prose_text` structurally rejects
+  `tool_result` blocks, so the parent's copy of a subagent's final report is
+  never double-indexed). This extractor **never emits supersession marks**:
+  Claude Code has no rollback mechanism, and compaction is not supersession.
+
+### The indexer sweep
+
+`spawn_indexer` (wired unconditionally in `main.rs`'s startup prologue) runs a
+background sweep every **30 seconds**; the first sweep runs one full interval
+after boot, so one-shot CLI runs exit before ever paying for it. Sweeps do
+real file I/O and run under `spawn_blocking`. One sweep:
+
+- enumerates `~/.intendant/logs/*/session.jsonl`, the Codex roots (the user's
+  Codex home plus leased-active homes and staged lease entries), and the
+  Claude project roots (`~/.claude/projects` plus the leased/staged
+  equivalents);
+- checks each known file against its stored cursor (`cursor.rs`:
+  `FileIdentity` + length + mtime + a 4 KiB prefix hash +
+  `last_complete_line_offset`) — `Unchanged` skips without reading,
+  `Appended` reads incrementally past the offset (a partial trailing line
+  stays unconsumed until it completes), `Rewritten` rebuilds (for Codex: the
+  generation bump above), `Gone` leaves the shard serving with the
+  `source_gone` coverage flag until retention expires it;
+- remembers sources that publish nothing — wrapper session logs, rollouts
+  with no message content yet — in an in-process cache rather than the store
+  (an empty shard's `newest_ts_ms` of 0 would be GC-evicted and re-parsed
+  forever);
+- drains staged lease entries: deletes an entry once every transcript file
+  inside it has been published.
+
+**Leased homes and custody** (`lease_transcript_staging.rs`): OAuth leases
+materialize private `CODEX_HOME`/`CLAUDE_CONFIG_DIR` roots that hold the
+borrowed secret *and* the agent's transcripts. Live homes are registered under
+`leased-active/` and indexed during the lease; on cleanup
+(expiry/revocation/shutdown/crash sweep) the transcript subdirectories are
+**renamed** into `staging/` (same volume, effectively O(1)) and the auth root
+is deleted immediately — **secret deletion never waits on indexing**, and
+there is deliberately no copy fallback. Staging failures are markers, not
+blockers: deletion proceeds regardless.
+
+Freshness needs no event plumbing: the steady-state sweep is cheap (metadata
+plus a prefix hash per known file), and the query edge shares the same
+indexer instance through `refresh_if_stale(1_000)` — a query first sweeps if
+the last completed sweep is older than a second, which meets ~1 s freshness
+for native and supervised sessions. That refresh is deliberately a no-op
+before the first boot sweep completes (the backfill can take seconds and must
+never run inline with a query); until then coverage reports `building`.
+
+### The query route
+
+`GET /api/sessions/message-search` is declared as a `gateway_routes.rs` row
+(`PeerOperation::SessionInspect`, `BodyPolicy::None`, tunnel twin
+`api_sessions_message_search`) — it appears in the derived endpoint table in
+[Web Dashboard](./web-dashboard.md). The gateway edge
+(`sessions_message_search_api_response` in `web_gateway/routes_sessions.rs`)
+owns transport, the freshness refresh, and a per-daemon concurrency cap of 2
+(excess answers 429 `busy`); the pure query core is
+`message_search::run_message_search`.
+
+| Param | Meaning |
+|---|---|
+| `q` | required; ≤ 256 bytes, ≤ 8 whitespace-separated terms — **all terms must match within one message** |
+| `source` | comma list of `intendant`, `codex`, `claude-code`; empty or `all` = every source |
+| `include_superseded` | default `true`: superseded hits are included and badged, hideable by the client |
+| `subagents` | default `true`: include Claude subagent records |
+| `cursor` | opaque continuation cursor from the previous page |
+| `limit` | sessions per page, clamped 1–50, default 20 |
+
+Mechanics (constants in `query.rs`):
+
+- **Matching**: needle and haystack are folded identically — per-char simple
+  lowercase plus Unicode canonical decomposition (NFD; matches the same pairs
+  as NFC + case-fold while keeping the folded→original offset map exact per
+  original char). Highlight `ranges` are **byte offsets into the ORIGINAL
+  text**; the client never re-derives them. Each hit carries a snippet
+  (≤ 280 bytes around the earliest highlight) plus `snippet_offset_bytes`.
+- **Ordering**: sessions by best-hit `ts_ms` descending (tiebreak session
+  key), ≤ 3 most-recent hits per session, `total_hits` on the group. The
+  manifest scan walks sessions newest-first with an early exit once the page
+  can no longer improve, so broad terms are limit-bounded rather than
+  full-corpus.
+- **Snapshot-bound pagination**: the cursor pins the query/filter fingerprint
+  and the manifest `revision` it was minted against. Any manifest change
+  between pages answers 410 `cursor_expired` and the client restarts —
+  stricter than the design minimum (a page can never silently skip a session
+  that moved), and cheap to loosen later.
+- **Budgets**: a 150 ms per-query time budget (`state: "partial"`,
+  `partial_reason: "timeout"`; deliberately *no* continuation cursor — a
+  timeout page scanned an unknown subset, so the client retries the whole
+  query against a then-warm arena); a 256 KiB response budget and a 48 MiB
+  per-query fresh-load ceiling (`partial_reason: "budget"`, with a
+  continuation cursor). Parsed + folded shards stay resident in a 192 MiB
+  byte-bounded LRU arena keyed by content-named generation file, with derived
+  active flags computed once at load.
+- **Response**: `state` (`ready` | `building` — nothing published yet |
+  `partial`), `window_days`, session groups (`session_key`, `source`,
+  `session_id`, `best_ts_ms`, `total_hits`, `source_gone`, `hits` with role /
+  `ts_ms` / `seq` / `superseded` / `truncated` / `subagent` / snippet /
+  `ranges` / `locator`), the continuation `cursor`, and a `coverage` block:
+  per-source session counts with oldest/newest indexed `ts_ms` and
+  `source_gone` counts, plus the legacy matrix (below).
+- **Privacy**: responses are `Cache-Control: no-store` (the canonical
+  envelope's `no-cache` still allows caching), and `q` is never logged —
+  neither the HTTP lane nor the tunnel logs request lines or params.
+
+### Jump-to-hit: `locate=` on the session detail read
+
+Every hit carries its locator, and the session detail read resolves it:
+`GET /api/session/{id}?locate=<locator>` accepts the locator JSON itself
+(URL-encoded) or base64url of it — the tunnel twin may pass the object
+directly (`web_gateway/session_catalog/locate.rs`). The response is the
+normal paged detail body plus an additive `locate` object:
+
+- `resolved` — the served page is centered on the anchored entry;
+  `entry_index` is its position in the response's `entries`, `total_index`
+  its position in the full list, and `anchor` is `"exact"`, or `"nearest"`
+  when the located row renders no entry of its own (canonical
+  `conversation_message` rows — their diagnostic twins are what the detail
+  view shows) and the closest rendered neighbor anchors it.
+- `stale` — the source no longer matches the locator (content-hash mismatch,
+  rewritten/rolled-back external thread, truncated log). The page is served
+  exactly as an unanchored request, with the reason.
+- `unavailable` — well-formed but nothing resolvable backs it (missing
+  file/record, locator kind vs. source mismatch).
+
+A malformed `locate` parameter is a 400 like any bad parameter; every
+well-formed locator degrades typed, so the dashboard can open the detail view
+unanchored and say why. Sidecar reads never escape the session directory.
+
+### Dashboard integration (`?message_search=on`)
+
+The dashboard side ships behind a URL flag (`?message_search=on` or `=1` —
+the Station world-panes precedent), inert when off. Two surfaces
+(`static/app/57-sessions-message-search.js`, `ui2-chrome.js`): the Recent
+list's quick search gains a full-text message lane *under* the immediate
+metadata lane — ≥ 2 characters, ~225 ms debounce, in-flight aborts and
+stale-response rejection, hits attached to their session cards with role,
+timestamp, best snippet with server-anchored highlights, and
+superseded/truncated/subagent badges (a toolbar toggle flips
+`include_superseded`); and the ⌘K palette's Messages section (which queries
+with `include_superseded: false`). Availability is the derived per-method
+boolean (`api_sessions_message_search_available`, from the tunnel method
+table) — an older daemon hides the lane rather than erroring.
+
+### What is never indexed
+
+By construction (enforced by provenance on the native side and the extractor
+skip rules on the external side):
+
+- tool output — except the askHuman-answer projection (`ref_seq`);
+- reasoning content (`turns/*_reasoning.txt` stays a diagnostic);
+- meta and sidecar records (Claude `isMeta`/`isCompactSummary` rows, sidecar
+  state types, records without `uuid`/`timestamp`);
+- system injections — working-dir/memory/skills preludes, nudges, acks,
+  agent-stdout-as-user, Codex machine injections, Claude harness envelopes
+  (`is_injected_external_user_text`);
+- context summaries (compaction output);
+- the CU sub-conversation — excluded by construction in both eras
+  (`run_cu_task` writes only `info` and `cu_*` events, never
+  `model_response`);
+- presence conversations;
+- wrapper-mirrored external messages (canonical in the backend's own log;
+  the wrapper session is skipped wholesale).
+
+**The legacy matrix** — what sessions written before the message lane
+(pre-2026-07) can ever yield, surfaced verbatim in the coverage block:
+askHuman answers **none** (they were never persisted — the audit hole the
+lane closed); follow-ups **best-effort** (reconstructed from
+`"Round {N} follow-up:"` info lines).
+
 ## Test Coverage
 
 Session logging is exercised by inline `#[cfg(test)]` tests in `session_log/`
@@ -290,6 +642,15 @@ and `session_names.rs`: turn-file creation and pretty-printing, separate
 stdout/stderr files, skipping empty stderr, `json_extracted` function extraction,
 reasoning-file writes, span-based chunk reads that avoid re-reading whole turn
 files, intendant-meta renames, and external-source overlay application.
+
+The message-search subsystem carries its own inline suites (`message_search/`):
+per-source extractor fixtures across both eras, store coverage (crash-safe
+publish, corrupt-manifest quarantine, stale-writer rejection, tombstones,
+retention GC, lock takeover), snapshot-cursor stability under concurrent
+publishes, and fold/highlight offset mapping. Two headless e2e tests pin the
+message-lane wire contract against the real binary
+(`supervised_session_writes_task_ask_human_and_steer_message_rows`,
+`headless_rollback_writes_a_conversation_rewound_cut` in `tests/e2e/`).
 
 Integration tests in `tests/e2e/` spawn the real binary and exercise the full
 stack (see [Architecture](./architecture.md)):


### PR DESCRIPTION
Docs-only: brings `docs/src/session-logging.md` up to date with the fully landed message-lane persistence and message-search subsystem.

**Chapter changes**
- Overview: the log directory now serves four audiences (message-search indexer added).
- `The message lane` subsection expanded: the two writer methods (`conversation_message_user`, `model_response_with_message` — one call, sidecar span + diagnostic + canonical record), `MessageProvenance` vocabulary, `Message.seq` monotonicity, both askHuman paths (`ref_seq` projection), `conversation_rewound` (kind `tail_rollback`; compaction deliberately silent), `conversation_message_epoch` / `ensure_seqs_assigned`.
- New major section **Message Search: The Rolling Message Index**: the shard store under `~/.intendant/cache/message_search/v1` (content-named generations, manifest `revision` watermark, writer lock as efficiency-not-correctness, watermark/fingerprint publish gate, tombstones, 14-day retention); derived supersession (`derive_active`, mark table) and the frozen locator variants; the three extractors (intendant eras + wrapper skip, Codex event-lane canonicity + generations/restores, Claude subagent joins + hardlink-twin dedup); the 30 s indexer sweep (cursors, unpublishable cache, leased-active homes + staged lease drain — secret deletion never waits on indexing); the query route `GET /api/sessions/message-search` (params, NFD+lowercase folding with original-byte highlights, snapshot-bound cursors + `cursor_expired`, budgets, coverage block, no-store, `q` never logged); `locate=` anchored detail reads (resolved|stale|unavailable); the `?message_search=on` dashboard flag; a *what is never indexed* list + the legacy matrix.
- Test Coverage: the `message_search/` inline suites and the two e2e wire-contract pins.

Every claim was verified against current main source (bus_events.rs, conversation.rs, message_search/*, session_catalog/locate.rs, gateway_routes.rs, the app fragments). `mdbook build docs` is clean; in-page anchors verified against the rendered HTML. The generated endpoint table in web-dashboard.md is untouched (this chapter links to it).