### PR TITLE
event bus: share ContextSnapshot payloads via Arc

### DIFF
--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -1049,7 +1049,7 @@ pub(crate) async fn run_agent_loop(
                     context_window: Some(conversation.context_window()),
                     hard_context_window: Some(conversation.context_window()),
                     item_count: provider_request_item_count(&raw_context),
-                    raw: raw_context,
+                    raw: std::sync::Arc::new(raw_context),
                 });
             }
             Err(e) => {

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -692,7 +692,11 @@ pub enum AppEvent {
         context_window: Option<u64>,
         hard_context_window: Option<u64>,
         item_count: Option<usize>,
-        raw: serde_json::Value,
+        /// The whole serialized provider request context — multi-MB for a
+        /// long session. `Arc`'d so the broadcast ring slot and every
+        /// subscriber's `AppEvent::clone` share one allocation instead of
+        /// deep-copying the payload per subscriber.
+        raw: Arc<serde_json::Value>,
     },
 
     /// Proactive status broadcast (emitted on turn start, phase change, etc.)
@@ -5561,7 +5565,7 @@ mod tests {
             context_window: Some(128000),
             hard_context_window: Some(128000),
             item_count: Some(2),
-            raw: serde_json::json!({"thread": {"turns": []}}),
+            raw: Arc::new(serde_json::json!({"thread": {"turns": []}})),
         };
         let outbound = app_event_to_outbound(&event).unwrap();
         let json = serde_json::to_string(&outbound).unwrap();
@@ -5570,6 +5574,40 @@ mod tests {
         assert!(json.contains("\"source\":\"codex\""));
         assert!(json.contains("\"request_index\":7"));
         assert!(json.contains("\"raw\""));
+    }
+
+    /// The whole point of `Arc`-ing `ContextSnapshot::raw`: every bus
+    /// subscriber receives the event via `AppEvent::clone`, and that clone
+    /// must share the (multi-MB) payload allocation, not deep-copy it.
+    #[test]
+    fn context_snapshot_clone_shares_raw_allocation() {
+        let event = AppEvent::ContextSnapshot {
+            session_id: Some("sess-ctx".to_string()),
+            source: "native".to_string(),
+            label: "Internal agent request payload".to_string(),
+            request_id: Some("req-share".to_string()),
+            request_index: Some(1),
+            turn: Some(1),
+            format: "openai.responses.resolved_request.v1".to_string(),
+            token_count: None,
+            token_count_kind: None,
+            context_window: Some(128000),
+            hard_context_window: Some(128000),
+            item_count: Some(1),
+            raw: Arc::new(serde_json::json!({"input": [{"role": "user"}]})),
+        };
+        let cloned = event.clone();
+        let (
+            AppEvent::ContextSnapshot { raw: original, .. },
+            AppEvent::ContextSnapshot { raw: copy, .. },
+        ) = (&event, &cloned)
+        else {
+            panic!("expected two context snapshots");
+        };
+        assert!(
+            Arc::ptr_eq(original, copy),
+            "cloning a ContextSnapshot must refcount the raw payload, not deep-copy it"
+        );
     }
 
     #[test]
@@ -5588,10 +5626,10 @@ mod tests {
             context_window: Some(128000),
             hard_context_window: Some(128000),
             item_count: Some(1),
-            raw: serde_json::json!({
+            raw: Arc::new(serde_json::json!({
                 "input": [{"role": "user", "content": large_text}],
                 "model": "codex",
-            }),
+            })),
         };
 
         let outbound = app_event_to_outbound(&event).unwrap();

--- a/src/bin/caller/managed_context_ops/pressure.rs
+++ b/src/bin/caller/managed_context_ops/pressure.rs
@@ -178,7 +178,10 @@ pub(crate) fn latest_external_context_snapshot_from_log(
             context_window,
             hard_context_window,
             item_count,
-            raw,
+            // The event was just built from the log entry, so this Arc is
+            // uniquely held and try_unwrap recovers the Value without a
+            // deep clone; the fallback only fires if that ever changes.
+            raw: std::sync::Arc::try_unwrap(raw).unwrap_or_else(|arc| (*arc).clone()),
         });
     }
 
@@ -977,7 +980,7 @@ pub(crate) async fn emit_external_context_snapshot_if_changed(
                     context_window: snapshot.context_window,
                     hard_context_window: snapshot.hard_context_window,
                     item_count: snapshot.item_count,
-                    raw: snapshot.raw,
+                    raw: std::sync::Arc::new(snapshot.raw),
                 });
                 if let Some(main) = usage {
                     emit_external_context_usage_snapshot_from_usage(config, main);

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -2543,7 +2543,7 @@ mod tests {
                 context_window: Some(258_400),
                 hard_context_window: Some(272_000),
                 item_count: Some(300),
-                raw: serde_json::json!({ "model": "gpt-5.2-codex" }),
+                raw: std::sync::Arc::new(serde_json::json!({ "model": "gpt-5.2-codex" })),
             },
         );
         let pressure = s.context_pressure_snapshot();
@@ -3361,7 +3361,7 @@ mod tests {
                         context_window: Some(1_000),
                         hard_context_window: Some(1_200),
                         item_count: Some(12),
-                        raw: serde_json::json!({ "model": "gpt-5.2-codex" }),
+                        raw: std::sync::Arc::new(serde_json::json!({ "model": "gpt-5.2-codex" })),
                     },
                 );
             }

--- a/src/bin/caller/session_log/replay.rs
+++ b/src/bin/caller/session_log/replay.rs
@@ -320,7 +320,7 @@ pub fn session_log_entry_to_app_event(
                 context_window,
                 hard_context_window,
                 item_count,
-                raw,
+                raw: std::sync::Arc::new(raw),
             })
         }
 


### PR DESCRIPTION
Multi-MB per-turn context snapshots were deep-cloned per bus subscriber (~10) and squatted in the 4096-slot broadcast ring — the audit's periodic-RSS-spike finding. The variant's raw field is now Arc<Value>: subscriber clones are refcounts, the ring shares one allocation. The outbound-edge compactor takes &Value and never mutates, so it compacts the shared copy directly (output pinned by the existing large-raw test); the one owned-Value consumer recovers it via Arc::try_unwrap on a uniquely-held Arc (zero copies, deep-clone fallback defensive only). New test pins allocation sharing across AppEvent::clone. cargo test --bins green, e2e 18/18, clippy clean.