### PR TITLE
governor: parent-held permits — daemonized sccache servers can no longer inherit the flock

### DIFF
--- a/crates/rustc-governor/src/config.rs
+++ b/crates/rustc-governor/src/config.rs
@@ -37,14 +37,15 @@ pub struct Config {
     /// Usernames whose invocations are classed `ci`; everyone else is
     /// `local`.
     pub ci_users: Vec<String>,
-    /// Front of the exec chain for governed *and* fail-open invocations:
-    /// `wrap_with <real-compiler> <args…>` — in production the sccache
-    /// client, whose blocking round-trip is what carries the permit's
-    /// ceiling to server-side compiles. Unset (or written as `""`, which
-    /// the parser normalizes to unset) means "run the compiler directly":
-    /// the governor works without sccache. The real compiler itself is
-    /// never configured here — cargo passes it as argv[1] (the
-    /// RUSTC_WRAPPER contract).
+    /// Front of the compile chain for governed *and* fail-open
+    /// invocations: `wrap_with <real-compiler> <args…>` — in production
+    /// the sccache client, whose blocking round-trip is what carries the
+    /// permit's ceiling to server-side compiles (governed runs spawn it
+    /// and wait, permit parent-held; fail-open runs exec it). Unset (or
+    /// written as `""`, which the parser normalizes to unset) means "run
+    /// the compiler directly": the governor works without sccache. The
+    /// real compiler itself is never configured here — cargo passes it
+    /// as argv[1] (the RUSTC_WRAPPER contract).
     pub wrap_with: Option<PathBuf>,
 }
 

--- a/crates/rustc-governor/src/flock.rs
+++ b/crates/rustc-governor/src/flock.rs
@@ -1,13 +1,17 @@
-//! Thin flock(2)/fcntl(2) wrappers. The crate's `unsafe` lives here and in
-//! `permits::current_username`, each block wrapping exactly one libc call
-//! (repo convention: minimal, `// SAFETY:`-commented islands).
+//! Thin flock(2) wrappers. The crate's `unsafe` lives here, in
+//! `permits::current_username`, and in `main.rs`'s signal
+//! forwarding/re-raise — minimal, `// SAFETY:`-commented islands (repo
+//! convention).
 //!
-//! flock, not fcntl locks, on purpose: flock locks belong to the open file
-//! description, survive exec(2) (once FD_CLOEXEC is cleared), are inherited
-//! by nothing else we spawn (we spawn nothing), and evaporate when the
-//! holder dies — which is the entire crash-release story. Mode is
-//! irrelevant to flock, so read-only opens of the root-owned 0644 permit
-//! files lock fine for every account.
+//! flock, not fcntl locks, on purpose: flock locks belong to the open
+//! file description and evaporate when the holder dies — the entire
+//! crash-release story. The permit-holding fd is never passed to a
+//! child: it keeps std's O_CLOEXEC, and the governor holds it as the
+//! spawned chain's PARENT (an inherited fd in a long-lived child — the
+//! sccache server the client daemonizes on demand — kept permits locked
+//! for hours in production, 2026-07-12). Mode is irrelevant to flock, so
+//! read-only opens of the root-owned 0644 permit files lock fine for
+//! every account.
 
 use std::fs::File;
 use std::io;
@@ -46,25 +50,6 @@ pub(crate) fn unlock(file: &File) {
     let _ = flock_op(file, libc::LOCK_UN);
 }
 
-/// Rust's std opens every file O_CLOEXEC; a permit's flock must survive the
-/// exec into the governed chain — the sccache client, or the real rustc
-/// when `wrap_with` is unset (the flock IS the permit). Load-bearing —
-/// covered by the `permit_lock_survives_exec` acceptance test.
-pub(crate) fn clear_cloexec(file: &File) -> io::Result<()> {
-    // SAFETY: the fd is owned by `file` and stays open across both calls;
-    // F_GETFD moves no memory.
-    let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFD) };
-    if flags < 0 {
-        return Err(io::Error::last_os_error());
-    }
-    // SAFETY: as above; F_SETFD only updates the fd's flag word.
-    let rc = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETFD, flags & !libc::FD_CLOEXEC) };
-    if rc < 0 {
-        return Err(io::Error::last_os_error());
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -94,19 +79,19 @@ mod tests {
         assert!(try_lock_exclusive(&prober));
     }
 
+    /// The permit fd must stay invisible to children: std's O_CLOEXEC is
+    /// load-bearing for the parent-held permit design (nothing in this
+    /// crate may clear it — a cleared fd inherited by the daemonized
+    /// sccache server is exactly the 2026-07-12 permit leak).
     #[test]
-    fn clear_cloexec_clears_the_flag() {
+    fn std_opens_files_cloexec() {
         let dir = tempfile::tempdir().unwrap();
         let f = File::create(dir.path().join("fd")).unwrap();
         // SAFETY: `f` owns an open fd; F_GETFD moves no memory.
-        let before = unsafe { libc::fcntl(f.as_raw_fd(), libc::F_GETFD) };
+        let flags = unsafe { libc::fcntl(f.as_raw_fd(), libc::F_GETFD) };
         assert!(
-            before >= 0 && (before & libc::FD_CLOEXEC) != 0,
-            "std opens O_CLOEXEC"
+            flags >= 0 && (flags & libc::FD_CLOEXEC) != 0,
+            "std must open files O_CLOEXEC"
         );
-        clear_cloexec(&f).unwrap();
-        // SAFETY: as above.
-        let after = unsafe { libc::fcntl(f.as_raw_fd(), libc::F_GETFD) };
-        assert!(after >= 0 && (after & libc::FD_CLOEXEC) == 0);
     }
 }

--- a/crates/rustc-governor/src/main.rs
+++ b/crates/rustc-governor/src/main.rs
@@ -4,19 +4,26 @@
 //! invokes it as `rustc-governor <real-rustc> <args…>` and the chain is:
 //!
 //! ```text
-//! cargo → THIS BINARY → [flock(2) permit] → exec(2) of
-//!   `wrap_with <real-rustc> <args…>` (the blocking sccache client)
-//!   → sccache server: hits answered from cache, misses compiled
-//!     server-side
+//! cargo → THIS BINARY (acquires + HOLDS the flock(2) permit, waits) →
+//!   spawn of `wrap_with <real-rustc> <args…>` (the blocking sccache
+//!   client) → sccache server: hits answered from cache, misses
+//!   compiled server-side
 //! ```
 //!
-//! The permit is held by the exec'd sccache *client*, which blocks until
-//! the server answers: at most N outstanding clients ⇒ at most N
-//! server-side compiles, so the machine-wide ceiling holds transitively —
-//! no matter which rustc binary the server resolves and runs. Exit status
-//! and signal disposition are inherited by construction, and the permit's
-//! flock rides the FD_CLOEXEC-cleared fd until the exec'd chain exits,
-//! however it exits. A cache hit occupies its permit only for the client
+//! The permit is held by the governor itself, which stays alive as the
+//! spawned chain's parent. The sccache *client* blocks until the server
+//! answers: at most N outstanding clients ⇒ at most N server-side
+//! compiles, so the machine-wide ceiling holds transitively — no matter
+//! which rustc binary the server resolves and runs. The permit fd keeps
+//! FD_CLOEXEC set, so no child — crucially, not even the sccache server
+//! the client daemonizes when none is running — can inherit it: flock
+//! belongs to the open file description, and a long-lived inheritor
+//! keeps the permit held long after the compile exits (the 2026-07-12
+//! production leak; post-mortem in `run_governed`'s doc and
+//! `scripts/ci/README.md`). The child's exit code is propagated, its
+//! signal death is re-raised so cargo observes the same disposition,
+//! and TERM/INT/HUP are forwarded to the child while the governor
+//! waits. A cache hit occupies its permit only for the client
 //! round-trip (~tens of ms); hits queueing head-of-line behind
 //! miss-saturated permits is an accepted trade (ceiling correctness over
 //! warm-path latency).
@@ -65,12 +72,15 @@
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Child, Command};
+#[cfg(unix)]
+use std::sync::atomic::{AtomicI32, Ordering};
 
 // `config` and `probe` are cross-platform (the portable fallback below
 // honors `wrap_with` and the probe fast path); the governor proper —
-// flock permits, exec — is Unix-only, so the non-unix build deliberately
-// leaves the permit-sizing parts of the config unread.
+// flock permits, the permit-holding parent — is Unix-only, so the
+// non-unix build deliberately leaves the permit-sizing parts of the
+// config unread.
 #[cfg_attr(not(unix), allow(dead_code))]
 mod config;
 #[cfg(unix)]
@@ -164,8 +174,8 @@ fn guard_against_self_exec(real: &Path) {
 
 /// Exec (spawn on non-unix) the real compiler with argv passed through
 /// untouched. Shared by the probe fast path — probes bypass permits and
-/// sccache both — and the last-resort fallback when the wrap chain won't
-/// exec.
+/// sccache both — and, on unix, the fail-open fallback when the wrap
+/// chain won't exec.
 fn run_compiler_direct(real: &Path, args: &[OsString]) -> ! {
     #[cfg(unix)]
     {
@@ -194,40 +204,223 @@ fn run_unix(
     cfg: Option<config::Config>,
     config_path: &Path,
 ) -> ! {
-    use std::os::unix::process::CommandExt as _;
+    match governed_permit(cfg, config_path) {
+        // Fail-open: no permit is held, so there is no fd whose lifetime
+        // must outlast the chain — exec(2) keeps the zero-overhead shape
+        // (this process image simply BECOMES the chain, and a disabled
+        // governor stays indistinguishable from a plain sccache
+        // rustc-wrapper).
+        None => exec_wrap_chain(real, args, wrap.as_deref()),
+        // Governed: the permit is parent-held — see `run_governed`.
+        Some(permit) => run_governed(real, args, wrap.as_deref(), permit),
+    }
+}
 
-    let permit = governed_permit(cfg, config_path);
-    // exec(2): on success this process IS the governed chain — the sccache
-    // client when wrap_with is configured, else the real compiler. argv
-    // and the environment pass through untouched, exit status and signal
-    // disposition propagate by construction, and the permit's flock (if
-    // any) rides the FD_CLOEXEC-cleared fd until the exec'd chain exits.
-    // Any exit — clean, panic, SIGKILL — releases the permit in the
-    // kernel.
-    if let Some(wrap) = &wrap {
+/// Exec `wrap_with <real> <args…>`, falling back to the real compiler
+/// when the wrap chain won't exec. Fail-open (permitless) invocations
+/// only: on the governed path the governor must outlive the child to
+/// keep holding the permit, so it never execs there.
+#[cfg(unix)]
+fn exec_wrap_chain(real: &Path, args: &[OsString], wrap: Option<&Path>) -> ! {
+    use std::os::unix::process::CommandExt as _;
+    if let Some(wrap) = wrap {
         let err = Command::new(wrap).arg(real).args(args).exec();
         // Reachable only when the wrap exec failed (missing / not
-        // executable): fail open to the direct compiler — the permit is
-        // still held, the build must not break; caching is what's lost.
+        // executable): fail open to the direct compiler — the build must
+        // not break; caching is what's lost.
         eprintln!(
             "rustc-governor: failed to exec wrap_with {}: {err}; running {} directly (uncached)",
             wrap.display(),
             real.display()
         );
     }
-    let err = Command::new(real).args(args).exec();
-    // Reachable only when exec failed (real compiler missing / not
-    // executable).
+    run_compiler_direct(real, args);
+}
+
+/// The governed path: the governor stays alive as the permit-owning
+/// parent — spawn the chain, forward TERM/INT/HUP to it, wait, and exit
+/// the way the child exited.
+///
+/// This shape (vs. exec(2)'ing the chain over a FD_CLOEXEC-cleared
+/// permit fd, the original design) is the fix for the 2026-07-12
+/// production leak: when no sccache server is running, the exec'd
+/// client daemonizes one, and that long-lived server (ppid 1) inherited
+/// the cleared fd — flock belongs to the open file description, so the
+/// permit stayed held for the server's whole lifetime and a 3-permit
+/// pool silently ran as 2 for hours. Parent-held, the fd never leaves
+/// this process.
+///
+/// Crash semantics (accepted — same spirit as the exec design's
+/// any-exit-releases story): SIGKILL on the governor releases the
+/// permit in the kernel the instant the process dies (its fds close),
+/// and the child orphans and finishes its current compile momentarily
+/// ungoverned.
+#[cfg(unix)]
+fn run_governed(
+    real: &Path,
+    args: &[OsString],
+    wrap: Option<&Path>,
+    permit: permits::AcquiredPermit,
+) -> ! {
+    let Some(mut child) = spawn_chain(real, args, wrap) else {
+        // Neither the wrap chain nor the compiler would spawn (messages
+        // already printed by spawn_chain).
+        drop(permit);
+        std::process::exit(127);
+    };
+    // Between spawn and handler install, TERM/INT/HUP still hits the
+    // default disposition: the governor dies, the kernel releases the
+    // permit, the child orphans — the documented crash semantics, for a
+    // few-instruction window.
+    CHILD_PID.store(child.id() as i32, Ordering::Release);
+    install_signal_forwarders();
+    let status = child.wait();
+    // The child is reaped: its pid is free for reuse, so the forwarders
+    // must stop aiming at it before this process does anything else.
+    CHILD_PID.store(0, Ordering::Release);
+    // The permit was held for the child's whole run (the fd kept
+    // O_CLOEXEC, so the child never saw it); releasing it now is
+    // release-on-exit made explicit.
     drop(permit);
-    eprintln!("rustc-governor: failed to exec {}: {err}", real.display());
-    std::process::exit(127);
+    match status {
+        Ok(status) => exit_like_child(status),
+        Err(err) => {
+            eprintln!("rustc-governor: failed to wait for the governed chain: {err}");
+            std::process::exit(127);
+        }
+    }
+}
+
+/// Spawn `wrap_with <real> <args…>` — the real compiler directly when
+/// `wrap_with` is unset or won't spawn — with argv, environment, and
+/// stdio all inherited untouched. `None` only when nothing would spawn
+/// (both failures already reported on stderr).
+fn spawn_chain(real: &Path, args: &[OsString], wrap: Option<&Path>) -> Option<Child> {
+    if let Some(wrap) = wrap {
+        match Command::new(wrap).arg(real).args(args).spawn() {
+            Ok(child) => return Some(child),
+            // Fail open to the direct compiler — the build must not
+            // break; caching is what's lost.
+            Err(err) => eprintln!(
+                "rustc-governor: failed to run wrap_with {}: {err}; running {} directly (uncached)",
+                wrap.display(),
+                real.display()
+            ),
+        }
+    }
+    match Command::new(real).args(args).spawn() {
+        Ok(child) => Some(child),
+        Err(err) => {
+            eprintln!("rustc-governor: failed to run {}: {err}", real.display());
+            None
+        }
+    }
+}
+
+/// Pid of the governed child while the governor waits on it; 0 outside
+/// that window. Read by the signal forwarders (pid_t is i32 on every
+/// supported unix target).
+#[cfg(unix)]
+static CHILD_PID: AtomicI32 = AtomicI32::new(0);
+
+/// Async-signal-safe forwarder installed for SIGTERM/SIGINT/SIGHUP
+/// while the governor waits: relay the same signal to the child and
+/// return — the child's exit (not the handler) drives the governor's
+/// exit, which then re-raises. Chosen over the self-pipe pattern
+/// because the handler's entire job is one kill(2) — which is on the
+/// async-signal-safe list — plus one atomic load; a pipe would add
+/// machinery only to move that same kill out of the handler.
+#[cfg(unix)]
+extern "C" fn forward_to_child(sig: libc::c_int) {
+    let pid = CHILD_PID.load(Ordering::Acquire);
+    if pid > 0 {
+        // SAFETY: kill(2) is async-signal-safe and touches no caller
+        // memory. `pid` is the child this process spawned: until
+        // run_governed's wait reaps it the pid cannot be recycled (a
+        // dead child stays a zombie), and CHILD_PID is zeroed
+        // immediately after that wait returns, so the residual window
+        // in which a stale pid could be signalled is a few
+        // instructions.
+        unsafe {
+            libc::kill(pid as libc::pid_t, sig);
+        }
+    }
+}
+
+/// Install `forward_to_child` for the forwarded signals. SA_RESTART so
+/// the wait in `run_governed` resumes instead of surfacing EINTR (std
+/// retries EINTR anyway; the flag just keeps the interruption out of
+/// the hot path).
+#[cfg(unix)]
+fn install_signal_forwarders() {
+    let handler: extern "C" fn(libc::c_int) = forward_to_child;
+    // SAFETY: sigaction is a plain C struct for which all-zero bytes are
+    // a valid value; every field consulted below is set explicitly.
+    let mut sa: libc::sigaction = unsafe { std::mem::zeroed() };
+    sa.sa_sigaction = handler as libc::sighandler_t;
+    sa.sa_flags = libc::SA_RESTART;
+    // SAFETY: `sa.sa_mask` is a live local; sigemptyset only writes it.
+    unsafe { libc::sigemptyset(&mut sa.sa_mask) };
+    for sig in [libc::SIGTERM, libc::SIGINT, libc::SIGHUP] {
+        // SAFETY: `sa` is fully initialized and the handler it installs
+        // is async-signal-safe (see forward_to_child). A failed install
+        // is tolerated: the signal keeps its default disposition, which
+        // is the documented crash semantics.
+        let _ = unsafe { libc::sigaction(sig, &sa, std::ptr::null_mut()) };
+    }
+}
+
+/// Exit the way the governed child exited: its code when it exited;
+/// its signal re-raised on ourselves when it died by one — after
+/// restoring the default disposition — so cargo observes the same
+/// signal death the exec design produced by construction. exit(128+N)
+/// is the belt-and-braces fallback if the re-raise somehow returns.
+#[cfg(unix)]
+fn exit_like_child(status: std::process::ExitStatus) -> ! {
+    use std::os::unix::process::ExitStatusExt as _;
+    if let Some(sig) = status.signal() {
+        // SAFETY: sigaction is a plain C struct for which all-zero bytes
+        // are a valid value; SIG_DFL needs no other fields set.
+        let mut sa: libc::sigaction = unsafe { std::mem::zeroed() };
+        sa.sa_sigaction = libc::SIG_DFL;
+        // SAFETY: `sa.sa_mask` is a live local; sigemptyset only writes
+        // it.
+        unsafe { libc::sigemptyset(&mut sa.sa_mask) };
+        // SAFETY: restoring SIG_DFL is always sound; failure (e.g.
+        // SIGKILL, which cannot be caught or reset) is tolerated because
+        // raise(2) below delivers such signals regardless.
+        let _ = unsafe { libc::sigaction(sig, &sa, std::ptr::null_mut()) };
+        // SAFETY: sigset_t is a plain C type for which all-zero bytes
+        // are a valid starting value; it is emptied and extended with
+        // `sig` before use, and both calls only write `set`.
+        let mut set: libc::sigset_t = unsafe { std::mem::zeroed() };
+        unsafe {
+            libc::sigemptyset(&mut set);
+            libc::sigaddset(&mut set, sig);
+        }
+        // SAFETY: unblocking `sig` in our own mask; `set` is initialized
+        // and this thread owns its signal mask (defensive — nothing here
+        // blocks signals).
+        let _ = unsafe { libc::sigprocmask(libc::SIG_UNBLOCK, &set, std::ptr::null_mut()) };
+        // SAFETY: raise(2) sends `sig` to this thread; under the default
+        // disposition of a fatal signal it does not return.
+        let _ = unsafe { libc::raise(sig) };
+        // The re-raise returned (the disposition could not be restored):
+        // encode the signal the way shells do.
+        std::process::exit(128 + sig);
+    }
+    std::process::exit(status.code().unwrap_or(1));
 }
 
 /// Decide whether this invocation is governed, and if so acquire its
 /// permit. `None` always means "run ungoverned" — every fail-open path
-/// funnels here, and the caller execs the same `wrap_with` chain either
-/// way: a disabled governor must be indistinguishable from a plain
-/// sccache rustc-wrapper.
+/// funnels here, and the caller execs the same `wrap_with` chain,
+/// permitless: a disabled governor must be indistinguishable from a
+/// plain sccache rustc-wrapper. On `Some`, the permit fd deliberately
+/// keeps std's FD_CLOEXEC: the caller stays alive as the permit-holding
+/// parent, and the fd must be invisible to every child — a leaked fd in
+/// a long-lived child (in production: the sccache server the client
+/// daemonizes on demand) keeps the flock held long after the compile.
 #[cfg(unix)]
 fn governed_permit(
     cfg: Option<config::Config>,
@@ -252,35 +445,27 @@ fn governed_permit(
         &permit.name,
         permit.wait_ms,
     );
-    // Rust's std opens every file O_CLOEXEC; the permit must survive the
-    // exec (the flock IS the permit). If clearing fails, proceed anyway:
-    // losing the permit at exec oversubscribes the box by one compile,
-    // while failing the compile would break the build — and a governor
-    // must never break a build.
-    let _ = flock::clear_cloexec(&permit.file);
     Some(permit)
 }
 
-/// The governor is a Unix (macOS / Linux) tool — flock(2) permit pools and
-/// exec(2) semantics don't map onto Windows, and it is never deployed
-/// there. This fallback keeps the workspace building on every first-class
-/// platform (repo policy): degrade gracefully with the same chain shape,
-/// minus permits — spawn `wrap_with <real> <args…>` (the real compiler
-/// directly when `wrap_with` is unset or won't run) and propagate the
-/// exit code.
+/// The governor is a Unix (macOS / Linux) tool — flock(2) permit pools
+/// don't map onto Windows, and it is never deployed there. This fallback
+/// keeps the workspace building on every first-class platform (repo
+/// policy): degrade gracefully with the same chain shape, minus permits —
+/// structurally the unix governed parent (spawn the chain, wait, exit
+/// like the child) without the permit or the signal forwarding.
 #[cfg(not(unix))]
 fn run_portable(real: &Path, args: &[OsString], wrap: Option<PathBuf>) -> ! {
-    if let Some(wrap) = &wrap {
-        match Command::new(wrap).arg(real).args(args).status() {
-            Ok(status) => std::process::exit(status.code().unwrap_or(1)),
-            Err(err) => eprintln!(
-                "rustc-governor: failed to run wrap_with {}: {err}; running {} directly (uncached)",
-                wrap.display(),
-                real.display()
-            ),
+    let Some(mut child) = spawn_chain(real, args, wrap.as_deref()) else {
+        std::process::exit(127);
+    };
+    match child.wait() {
+        Ok(status) => std::process::exit(status.code().unwrap_or(1)),
+        Err(err) => {
+            eprintln!("rustc-governor: failed to wait for the governed chain: {err}");
+            std::process::exit(127);
         }
     }
-    run_compiler_direct(real, args);
 }
 
 #[cfg(test)]

--- a/crates/rustc-governor/src/permits.rs
+++ b/crates/rustc-governor/src/permits.rs
@@ -12,11 +12,11 @@
 //! - `demand-local`, `demand-ci`             — one demand file per class
 //!
 //! Protocol:
-//! - Holding a permit = holding LOCK_EX on its file. The lock rides the fd
-//!   across exec(2) into the governed chain (the blocking sccache client,
-//!   or the real rustc when `wrap_with` is unset) and is released by the
-//!   kernel when that process exits, however it exits — crash release is
-//!   structural.
+//! - Holding a permit = holding LOCK_EX on its file. The governor holds
+//!   the lock itself for the governed chain's whole run — it stays alive
+//!   as the chain's parent, and the fd keeps std's O_CLOEXEC so no child
+//!   ever inherits it — and the kernel releases it when the governor
+//!   exits, however it exits: crash release is structural.
 //! - A waiter holds LOCK_SH on its OWN class's demand file for the whole
 //!   wait, and releases it the moment it holds a permit.
 //! - Borrowing: before touching a foreign-class permit, probe that class's
@@ -115,9 +115,13 @@ pub(crate) fn current_username() -> Option<String> {
 }
 
 pub(crate) struct AcquiredPermit {
-    /// Keeping this `File` open (with FD_CLOEXEC cleared) across the exec
-    /// IS the permit; the kernel releases the flock when the process exits.
-    pub(crate) file: File,
+    /// Keeping this `File` open IS the permit — held for RAII alone,
+    /// never read: the governor holds it, parent-side, for the governed
+    /// chain's whole run — the fd keeps std's O_CLOEXEC so no child (the
+    /// sccache client, or any server it daemonizes) can inherit it — and
+    /// the kernel releases the flock when the `File` closes (drop, or
+    /// any governor exit).
+    pub(crate) _file: File,
     pub(crate) name: String,
     pub(crate) wait_ms: u64,
 }
@@ -208,7 +212,7 @@ pub(crate) fn acquire(cfg: &Config, class: Class, config_path: &Path) -> Option<
     let start = Instant::now();
     let acquired = |start: Instant, (name, file): (String, File)| {
         Some(AcquiredPermit {
-            file,
+            _file: file,
             name,
             wait_ms: start.elapsed().as_millis() as u64,
         })

--- a/crates/rustc-governor/tests/acceptance.rs
+++ b/crates/rustc-governor/tests/acceptance.rs
@@ -410,16 +410,21 @@ fn waiter_acquires_promptly_after_release() {
     );
 }
 
-/// (e) Crash release: SIGKILL a permit holder — the flock evaporates with
-/// the process and the permit is immediately acquirable.
+/// (e) Crash release: SIGKILL the GOVERNOR — the permit holder — and the
+/// flock evaporates with it: the permit is immediately acquirable even
+/// though the governed child is still running (it never held the fd;
+/// FD_CLOEXEC stays set). The orphaned child finishing its compile
+/// momentarily ungoverned is the documented crash semantics — SIGKILL
+/// cannot be forwarded. The fixture reports its pid so the test can reap
+/// the orphan it deliberately creates.
 #[test]
-fn sigkilled_holder_releases_its_permit() {
+fn sigkilled_governor_releases_its_permit() {
     let rig = Rig::new();
     let ready = rig.root.join("ready");
     let script = rig.script(
         "hold.sh",
         &format!(
-            "echo ready >> {}\nwhile :; do sleep 0.05; done",
+            "echo $$ >> {}\nwhile :; do sleep 0.05; done",
             ready.display()
         ),
     );
@@ -427,7 +432,16 @@ fn sigkilled_holder_releases_its_permit() {
     let permit = rig.permit("permit-local-0");
 
     let mut child = spawn_governor(&config, &script, &[], &[]);
-    wait_for(|| ready.exists(), GENEROUS, "holder to start");
+    // The fixture's pid line (`$$` + newline) doubles as the ready signal.
+    wait_for(
+        || {
+            std::fs::read_to_string(&ready)
+                .map(|s| s.ends_with('\n'))
+                .unwrap_or(false)
+        },
+        GENEROUS,
+        "holder to start",
+    );
     assert!(is_exclusively_locked(&permit));
     child.kill().unwrap();
     child.wait().unwrap();
@@ -436,6 +450,19 @@ fn sigkilled_holder_releases_its_permit() {
         GENEROUS,
         "permit release after SIGKILL",
     );
+
+    // Reap the orphaned fixture (still looping — crash semantics) so the
+    // test leaks no process.
+    let orphan: libc::pid_t = std::fs::read_to_string(&ready)
+        .unwrap()
+        .trim()
+        .parse()
+        .expect("fixture wrote its pid");
+    // SAFETY: the pid was reported by the fixture this test (transitively)
+    // spawned; kill(2) takes only the pid and signal number.
+    unsafe {
+        libc::kill(orphan, libc::SIGKILL);
+    }
 
     // And a fresh governed invocation can take it end to end.
     let marker = rig.root.join("marker");
@@ -446,11 +473,16 @@ fn sigkilled_holder_releases_its_permit() {
     assert!(marker.exists());
 }
 
-/// (f) The flock survives exec(2): once the exec'd fixture is running (it
-/// wrote `ready`), the permit must still be held — FD_CLOEXEC was cleared —
-/// and it frees when that fixture exits.
+/// (f) Parent-held permit: while the governed child runs, the permit is
+/// held — by the governor itself, which stays alive as the child's
+/// parent (the fd keeps FD_CLOEXEC, so the child never holds it) — and
+/// it frees when the chain exits. The exec-era ancestor of this test
+/// (`permit_lock_survives_exec`) pinned the opposite fd story — the
+/// flock riding a FD_CLOEXEC-cleared fd through exec(2) — which is the
+/// design that leaked permits into daemonized sccache servers (see
+/// tests/sccache_chain.rs).
 #[test]
-fn permit_lock_survives_exec() {
+fn permit_held_while_child_runs_and_freed_on_exit() {
     let rig = Rig::new();
     let ready = rig.root.join("ready");
     let stop = rig.root.join("stop");
@@ -466,12 +498,12 @@ fn permit_lock_survives_exec() {
     let permit = rig.permit("permit-local-0");
 
     let mut child = spawn_governor(&config, &script, &[], &[]);
-    wait_for(|| ready.exists(), GENEROUS, "exec'd fixture to start");
-    // The shell fixture is the post-exec process image; the lock must have
-    // ridden through the exec.
+    wait_for(|| ready.exists(), GENEROUS, "governed fixture to start");
+    // The fixture (the governor's child) is running: the waiting governor
+    // parent must be holding the permit.
     assert!(
         is_exclusively_locked(&permit),
-        "permit lock did not survive exec (FD_CLOEXEC not cleared?)"
+        "permit not held while the governed child runs"
     );
     std::fs::write(&stop, b"").unwrap();
     assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
@@ -482,7 +514,7 @@ fn permit_lock_survives_exec() {
     );
 }
 
-/// (g) Exit status propagates through the exec.
+/// (g) Exit status propagates through the governor's wait.
 #[test]
 fn exit_status_propagates() {
     let rig = Rig::new();
@@ -493,28 +525,51 @@ fn exit_status_propagates() {
     assert_eq!(status.code(), Some(42));
 }
 
-/// (g) Signal disposition propagates: after the exec, the spawned pid IS
-/// the governed program — SIGTERM to it is reflected in the wait status.
+/// (g) Signal forwarding + disposition: SIGTERM to the governor is
+/// forwarded to the governed child (the governor is the permit-holding
+/// parent, so a signal aimed at the wrapper pid must reach the real
+/// work), and once the child dies of it the governor re-raises the same
+/// signal on itself — cargo observes the identical signal death the old
+/// exec design produced by construction. The tick stream proves the
+/// child really died of the forwarded signal: a governor that died alone
+/// would orphan the fixture, still ticking. (The fixture self-bounds at
+/// ~30s so a regression can't leak an infinite loop.)
 #[test]
-fn signal_disposition_propagates() {
+fn sigterm_forwards_to_child_and_signal_death_propagates() {
     let rig = Rig::new();
-    let ready = rig.root.join("ready");
+    let ticks = rig.root.join("ticks");
     let script = rig.script(
-        "hold.sh",
+        "tick.sh",
         &format!(
-            "echo ready >> {}\nwhile :; do sleep 0.05; done",
-            ready.display()
+            "i=0\nwhile [ $i -lt 600 ]; do echo tick >> {}; i=$((i+1)); sleep 0.05; done",
+            ticks.display()
         ),
     );
     let config = rig.config("gov.toml", 1, 0, false, true);
     let mut child = spawn_governor(&config, &script, &[], &[]);
-    wait_for(|| ready.exists(), GENEROUS, "fixture to start");
+    wait_for(|| ticks.exists(), GENEROUS, "fixture to start ticking");
     // SAFETY: pid was spawned by this test and not yet reaped; kill(2)
     // takes only the pid and signal number.
     let rc = unsafe { libc::kill(child.id() as libc::pid_t, libc::SIGTERM) };
     assert_eq!(rc, 0);
     let status = wait_deadline(&mut child, GENEROUS).unwrap();
     assert_eq!(status.signal(), Some(libc::SIGTERM));
+    // The child must be dead too: its tick stream stops growing. (Settle
+    // beat first, then a window several fixture periods long.)
+    std::thread::sleep(Duration::from_millis(200));
+    let after_settle = std::fs::metadata(&ticks).unwrap().len();
+    std::thread::sleep(Duration::from_millis(500));
+    assert_eq!(
+        std::fs::metadata(&ticks).unwrap().len(),
+        after_settle,
+        "tick file still growing: the governed child survived the forwarded SIGTERM"
+    );
+    // And the permit came back with the governor's exit.
+    wait_for(
+        || !is_exclusively_locked(&rig.permit("permit-local-0")),
+        GENEROUS,
+        "permit release after signal death",
+    );
 }
 
 /// (h) Probe fast path: version and pure --print invocations complete while
@@ -589,11 +644,12 @@ fn kill_switch_flips_live() {
 // ------------------------------------------------ wrapper chain shape ----
 
 /// Governed chain shape: with `wrap_with` configured, a governed
-/// invocation acquires its permit and execs `wrap_with <real> <args…>` —
-/// argv order is the sccache client contract (argv[1] = the compiler,
-/// the rest its args, exactly as cargo handed them to the governor).
+/// invocation acquires its permit, then spawns `wrap_with <real>
+/// <args…>` and waits — argv order is the sccache client contract
+/// (argv[1] = the compiler, the rest its args, exactly as cargo handed
+/// them to the governor).
 #[test]
-fn governed_invocation_execs_wrap_chain() {
+fn governed_invocation_runs_wrap_chain() {
     let rig = Rig::new();
     let real_marker = rig.root.join("real");
     let wrap_marker = rig.root.join("wrap");
@@ -698,10 +754,11 @@ fn fail_open_paths_still_exec_wrap_chain() {
 }
 
 /// `wrap_with` pointing at a path that doesn't exist must not break the
-/// build: the wrap exec fails, and the governor falls back to running the
-/// compiler directly — still governed (the permit was already held).
+/// build: the wrap spawn fails, and the governor falls back to running
+/// the compiler directly — still governed (the permit was already held,
+/// and stays parent-held for the fallback child too).
 #[test]
-fn missing_wrap_with_falls_back_to_direct_exec() {
+fn missing_wrap_with_falls_back_to_direct_run() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
     let real = rig.script("rustc.sh", &format!("echo real >> {}", marker.display()));
@@ -723,11 +780,11 @@ fn missing_wrap_with_falls_back_to_direct_exec() {
     );
 }
 
-/// `wrap_with` pointing back at the governor binary would exec an
+/// `wrap_with` pointing back at the governor binary would run an
 /// identical invocation forever. It is config-file state, so it fails
 /// OPEN: the chain front is ignored and the compiler runs directly.
 #[test]
-fn wrap_with_pointing_at_governor_falls_back_to_direct_exec() {
+fn wrap_with_pointing_at_governor_falls_back_to_direct_run() {
     let rig = Rig::new();
     let marker = rig.root.join("marker");
     let real = rig.script("rustc.sh", &format!("echo real >> {}", marker.display()));

--- a/crates/rustc-governor/tests/sccache_chain.rs
+++ b/crates/rustc-governor/tests/sccache_chain.rs
@@ -1,19 +1,21 @@
-//! Regression test for THE production bypass (2026-07): the governor used
-//! to be wired as cargo's `[build] rustc` with sccache as `rustc-wrapper`,
-//! so sccache treated the governor as the compiler. sccache 0.15
-//! identifies rustup proxies by probing the compiler with `+stable -vV`;
-//! the governor's probe fast path passed that through to the rustup proxy,
-//! so sccache classified the governor AS a proxy, resolved the underlying
-//! toolchain rustc, and had its SERVER invoke that binary directly for
-//! every cacheable miss — ungoverned (verified live: five toolchain rustcs
-//! as sccache-server children while all permits were held). Only
-//! non-cacheable work stayed governed.
+//! Regression tests that drive the REAL sccache binary through the real
+//! governor chain (governor = rustc-wrapper, `wrap_with` = sccache)
+//! against private rigs — one test per production incident:
 //!
-//! This test drives the REAL sccache binary through the new chain
-//! (governor = rustc-wrapper, `wrap_with` = sccache) against a private
-//! server and asserts the property the old chain silently lost: with the
-//! single permit held, a CACHEABLE rlib miss must NOT complete — it queues
-//! on the permit — while a `-vV` probe still completes promptly.
+//! THE BYPASS (2026-07): the governor used to be wired as cargo's
+//! `[build] rustc` with sccache as `rustc-wrapper`, so sccache treated
+//! the governor as the compiler. sccache 0.15 identifies rustup proxies
+//! by probing the compiler with `+stable -vV`; the governor's probe fast
+//! path passed that through to the rustup proxy, so sccache classified
+//! the governor AS a proxy, resolved the underlying toolchain rustc, and
+//! had its SERVER invoke that binary directly for every cacheable miss —
+//! ungoverned (verified live: five toolchain rustcs as sccache-server
+//! children while all permits were held). Only non-cacheable work stayed
+//! governed. `cacheable_miss_queues_on_the_permit_and_probe_stays_fast`
+//! asserts the property that design silently lost.
+//!
+//! THE PERMIT LEAK (2026-07-12): see
+//! `daemonized_server_does_not_inherit_the_permit`.
 //!
 //! THE SHAPE OF THE COMPILE IS LOAD-BEARING. sccache only routes
 //! *cacheable* invocations through its server-side compile path — an rlib
@@ -28,14 +30,15 @@
 //! Hermetic per repo doctrine: private `SCCACHE_DIR` + dedicated
 //! `SCCACHE_SERVER_PORT` in tempdirs, `SCCACHE_IDLE_TIMEOUT=10` as a
 //! belt-and-braces reaper for leaks, the server stopped in cleanup (Drop —
-//! runs on panic too), and the only processes signalled are ones this test
-//! spawned. Skips cleanly — with an explicit message — when sccache is not
-//! installed.
+//! runs on panic too), and the only processes signalled are ones these
+//! tests spawned. Skips cleanly — with an explicit message — when sccache
+//! is not installed.
 
 #![cfg(unix)]
 
 use std::fs::File;
 use std::io::Read;
+use std::net::{SocketAddr, TcpStream};
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
@@ -98,33 +101,36 @@ impl Drop for KillOnDrop {
     }
 }
 
-/// A private sccache server: own cache dir, own port, idle-timeout
-/// backstop; stopped on drop. Nothing it does touches the account's real
-/// sccache server (default port) or cache.
-struct SccacheServer {
+/// A private sccache endpoint: own cache dir, own port, idle-timeout
+/// backstop; `--stop-server` on drop. Nothing it does touches the
+/// account's real sccache server (default port) or cache. Built either
+/// with the server pre-started (`with_running_server`) or with the port
+/// verified silent (`with_no_server` — the on-demand daemonization rig).
+struct SccacheRig {
     bin: PathBuf,
     dir: PathBuf,
     port: u16,
 }
 
-impl SccacheServer {
-    fn start(bin: &Path, dir: &Path) -> SccacheServer {
+impl SccacheRig {
+    /// Start a private server up front (retrying ports on bind races).
+    fn with_running_server(bin: &Path, dir: &Path) -> SccacheRig {
         let mut last = String::new();
         for attempt in 0..3_u32 {
-            let server = SccacheServer {
+            let rig = SccacheRig {
                 bin: bin.to_path_buf(),
                 dir: dir.to_path_buf(),
                 port: candidate_port(attempt),
             };
             let mut cmd = Command::new(bin);
             cmd.arg("--start-server");
-            server.apply_env(&mut cmd);
+            rig.apply_env(&mut cmd);
             match cmd.output() {
-                Ok(out) if out.status.success() => return server,
+                Ok(out) if out.status.success() => return rig,
                 Ok(out) => {
                     last = format!(
                         "port {}: {}{}",
-                        server.port,
+                        rig.port,
                         String::from_utf8_lossy(&out.stdout),
                         String::from_utf8_lossy(&out.stderr)
                     );
@@ -133,6 +139,23 @@ impl SccacheServer {
             }
         }
         panic!("could not start a private sccache server (3 ports tried); last: {last}");
+    }
+
+    /// Pick a port nothing answers on and do NOT start a server: the
+    /// first governed compile's sccache client will daemonize one on
+    /// demand — the exact production shape that leaked permits.
+    fn with_no_server(bin: &Path, dir: &Path) -> SccacheRig {
+        for attempt in 0..8_u32 {
+            let port = candidate_port(attempt);
+            if !tcp_port_answers(port) {
+                return SccacheRig {
+                    bin: bin.to_path_buf(),
+                    dir: dir.to_path_buf(),
+                    port,
+                };
+            }
+        }
+        panic!("could not find a silent port for the no-server rig (8 tried)");
     }
 
     /// Scrub every inherited SCCACHE_* var, then pin this server's env:
@@ -152,7 +175,7 @@ impl SccacheServer {
     }
 }
 
-impl Drop for SccacheServer {
+impl Drop for SccacheRig {
     fn drop(&mut self) {
         let mut cmd = Command::new(&self.bin);
         cmd.arg("--stop-server")
@@ -174,11 +197,20 @@ fn candidate_port(attempt: u32) -> u16 {
     (20_000 + seed % 40_000) as u16
 }
 
+/// True iff something accepts TCP on 127.0.0.1:`port`.
+fn tcp_port_answers(port: u16) -> bool {
+    TcpStream::connect_timeout(
+        &SocketAddr::from(([127, 0, 0, 1], port)),
+        Duration::from_millis(250),
+    )
+    .is_ok()
+}
+
 /// Spawn `governor <rustc> <cargo-shaped cacheable rlib args>` wired to the
-/// rig's config and the private sccache server. stderr goes to a file:
+/// rig's config and the private sccache endpoint. stderr goes to a file:
 /// readable after any failure, and no pipe to deadlock an unread child.
 fn governed_compile(
-    server: &SccacheServer,
+    server: &SccacheRig,
     config: &Path,
     rustc: &Path,
     source: &Path,
@@ -233,7 +265,7 @@ fn cacheable_miss_queues_on_the_permit_and_probe_stays_fast() {
     for dir in [&cache_dir, &permit_dir, &out_prime, &out_miss] {
         std::fs::create_dir_all(dir).unwrap();
     }
-    let server = SccacheServer::start(&sccache, &cache_dir);
+    let server = SccacheRig::with_running_server(&sccache, &cache_dir);
 
     // One permit total; the current user classes local (impossible
     // ci_users name), so that permit is permit-local-0.
@@ -356,4 +388,150 @@ fn cacheable_miss_queues_on_the_permit_and_probe_stays_fast() {
         read(&miss_err)
     );
     assert!(miss_rlib.is_file(), "miss produced no rlib after release");
+}
+
+/// Regression test for THE production permit leak (2026-07-12): the old
+/// governed path cleared FD_CLOEXEC on the permit fd and exec(2)'d the
+/// sccache client — and when no server was listening, the client
+/// daemonized one, so the long-lived server (ppid 1) inherited the
+/// permit fd through client → server fd inheritance. flock(2) locks
+/// belong to the open file description, so the permit stayed held after
+/// the client exited, for the server's whole lifetime: a 3-permit pool
+/// silently ran as 2 for hours (verified live — a local sccache server
+/// held permit-ci-1 on fd 9; killing it released the permit).
+///
+/// The fix is parent-held permits: the governor keeps the fd (CLOEXEC
+/// set, invisible to every child), spawns the chain, and waits. This
+/// test reproduces the daemonization shape — NO pre-started server, one
+/// governed CACHEABLE compile whose client spins the server up on
+/// demand — and hard-asserts the permit is immediately lockable the
+/// moment the governor exits. Best-effort second half: confirm the
+/// daemonized server exists and (where lsof is available) holds no fd
+/// on the permit file.
+#[test]
+fn daemonized_server_does_not_inherit_the_permit() {
+    let Some(sccache) = find_on_path("sccache") else {
+        eprintln!("skipped: sccache not installed");
+        return;
+    };
+    let rustc = find_on_path("rustc").unwrap_or_else(|| PathBuf::from("rustc"));
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let cache_dir = root.join("sccache-cache");
+    let permit_dir = root.join("permits");
+    let out_dir = root.join("out");
+    for dir in [&cache_dir, &permit_dir, &out_dir] {
+        std::fs::create_dir_all(dir).unwrap();
+    }
+    // NO server pre-started — the rig verified the port is silent, so the
+    // governed compile below is what daemonizes one.
+    let rig = SccacheRig::with_no_server(&sccache, &cache_dir);
+    assert!(
+        !tcp_port_answers(rig.port),
+        "rig port must be silent before the governed compile"
+    );
+
+    // One permit total; the current user classes local (impossible
+    // ci_users name), so that permit is permit-local-0.
+    let config = root.join("governor.toml");
+    std::fs::write(
+        &config,
+        format!(
+            "enabled = true\npermit_dir = \"{}\"\nlocal_reserved = 1\nci_reserved = 0\nci_users = [\"governor-test-no-such-user\"]\nwrap_with = \"{}\"\n",
+            permit_dir.display(),
+            sccache.display(),
+        ),
+    )
+    .unwrap();
+
+    // One governed CACHEABLE compile (the shape is load-bearing — module
+    // doc): its client finds no server and daemonizes one mid-compile.
+    let src = root.join("leak.rs");
+    std::fs::write(&src, "pub fn leak_probe() {}\n").unwrap();
+    let stderr = root.join("leak.stderr");
+    let mut compile =
+        governed_compile(&rig, &config, &rustc, &src, "leak_probe", &out_dir, &stderr);
+    let status = wait_deadline(&mut compile, GENEROUS)
+        .unwrap_or_else(|| panic!("compile did not finish: {}", read(&stderr)));
+    assert!(status.success(), "compile failed: {}", read(&stderr));
+    assert!(
+        out_dir.join("libleak_probe.rlib").is_file(),
+        "compile produced no rlib"
+    );
+    // The run really was governed — a fail-open run holds no permit and
+    // would pass the leak assert vacuously.
+    let log = read(&permit_dir.join("governor.log"));
+    assert!(
+        log.contains("permit=permit-local-0"),
+        "compile was not governed (rig broken?): {log:?}"
+    );
+
+    // THE hard assert: the governor is gone, so the permit must be
+    // immediately lockable. Under the leak, the daemonized server —
+    // ppid 1, lifetime unbounded next to a compile — still holds the
+    // flock right here.
+    let permit = File::open(permit_dir.join("permit-local-0")).unwrap();
+    // SAFETY: `permit` owns an open fd for the duration of the call.
+    let lockable = unsafe { libc::flock(permit.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) == 0 };
+    assert!(
+        lockable,
+        "permit still flocked after the governed compile exited — a child of the \
+         governed chain (the daemonized sccache server) inherited the permit fd: \
+         the 2026-07-12 permit leak regressed"
+    );
+    // SAFETY: as above; LOCK_UN releases the probe lock this test took.
+    unsafe {
+        libc::flock(permit.as_raw_fd(), libc::LOCK_UN);
+    }
+
+    // Best-effort half: the daemonization really happened (a server now
+    // answers stats on the private port)…
+    let mut stats = Command::new(&sccache);
+    stats
+        .arg("--show-stats")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    rig.apply_env(&mut stats);
+    let server_up = stats.status().map(|s| s.success()).unwrap_or(false);
+    assert!(
+        server_up,
+        "no daemonized sccache server answering on the private port — the rig did \
+         not exercise the on-demand daemonization path this regression is about"
+    );
+    // …and, where lsof exists, that server holds no fd on the permit file.
+    if let Some(lsof) = find_on_path("lsof") {
+        match pid_listening_on(&lsof, rig.port) {
+            Some(pid) => {
+                let out = Command::new(&lsof)
+                    .args(["-p", &pid.to_string()])
+                    .output()
+                    .expect("run lsof -p");
+                let table = String::from_utf8_lossy(&out.stdout);
+                let permit_path = permit_dir.join("permit-local-0").display().to_string();
+                assert!(
+                    !table.contains(&permit_path),
+                    "daemonized sccache server (pid {pid}) holds an fd on the permit file:\n{table}"
+                );
+            }
+            None => eprintln!("lsof found no listener pid; skipping the server fd scan"),
+        }
+    } else {
+        eprintln!("lsof not installed; skipping the server fd scan");
+    }
+    // rig Drop stops the daemonized server.
+}
+
+/// Pid listening on 127.0.0.1:`port`, via `lsof -t` (best-effort).
+fn pid_listening_on(lsof: &Path, port: u16) -> Option<i32> {
+    let out = Command::new(lsof)
+        .args(["-t", "-n", "-P", &format!("-iTCP:{port}"), "-sTCP:LISTEN"])
+        .output()
+        .ok()?;
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .next()?
+        .trim()
+        .parse()
+        .ok()
 }

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -116,26 +116,28 @@ cargo ──[build] rustc-wrapper=governor──▶ rustc-governor <real rustc> 
                     │  probe (-vV / pure --print):
                     │    exec(2) real rustc directly — no permit, no sccache
                     ▼  compile: acquire flock(2) permit
-              exec(2) sccache <real rustc> <args…>
-                    │    the blocking sccache CLIENT; the permit's flock
-                    │    rides the FD_CLOEXEC-cleared fd until it exits
+              governor (HOLDS the permit, waits)
+                    │  spawns; the permit fd keeps FD_CLOEXEC —
+                    ▼  no child ever sees it
+              sccache <real rustc> <args…>   (the blocking sccache CLIENT)
                     ▼
               sccache server ── hit: answer from cache (client exits in
                     │                ~tens of ms, permit released)
                     ▼  miss / non-cacheable
-              real rustc runs; the client — and so the permit — blocks
-              until it finishes
+              real rustc runs; the client — and so the waiting governor,
+              and so the permit — blocks until it finishes
 ```
 
 The governor is cargo's `rustc-wrapper`; sccache is no longer the
-wrapper — the governor execs it, prepending the real compiler path cargo
-handed it as argv[1] (the `wrap_with` config key names the sccache
-binary; unset it and the compiler runs directly, governed but uncached):
+wrapper — the governor runs it as its child, prepending the real
+compiler path cargo handed it as argv[1] (the `wrap_with` config key
+names the sccache binary; unset it and the compiler runs directly,
+governed but uncached):
 
-- **The ceiling holds transitively.** The permit is held by the exec'd
-  sccache *client*, which blocks until the server answers: at most N
-  outstanding clients ⇒ at most N server-side compiles, no matter which
-  rustc binary the server resolves and runs.
+- **The ceiling holds transitively.** The permit is held by the
+  governor, whose spawned sccache *client* blocks until the server
+  answers: at most N outstanding clients ⇒ at most N server-side
+  compiles, no matter which rustc binary the server resolves and runs.
 - **Probes never wait and never touch sccache** — `-vV` / `--version` /
   pure `--print` queries (cargo fires them at every startup) exec the
   real compiler directly: snappy under a full pool, and cargo startup no
@@ -146,10 +148,23 @@ binary; unset it and the compiler runs directly, governed but uncached):
   the client round-trip (~tens of ms); under a miss-saturated pool, hits
   queue head-of-line behind running compiles. Accepted trade, decided
   with the operator: ceiling correctness over warm-path latency.
-- Exit status and signal disposition are inherited through the exec
-  chain, and the permit's flock rides the FD_CLOEXEC-cleared fd until
-  the chain exits — any exit, including SIGKILL, releases it in the
-  kernel (crash release is structural, nothing to clean up).
+- **Parent-held permits (the 2026-07-12 leak post-mortem).** The
+  governor originally exec(2)'d the chain over a FD_CLOEXEC-cleared
+  permit fd so the flock rode into the sccache client — but when no
+  server is running, the client *daemonizes* one, and that long-lived
+  server (ppid 1) inherited the fd: flock belongs to the open file
+  description, so the permit stayed held long after the client exited
+  (verified live — a 3-permit pool ran as 2 for hours while a local
+  server held a borrowed CI permit on fd 9). Now the governor stays
+  alive as the chain's parent: the permit fd keeps FD_CLOEXEC and is
+  invisible to every child, the child's exit code is propagated, signal
+  death is re-raised so cargo observes the same disposition, and
+  TERM/INT/HUP are forwarded to the child while the governor waits.
+  Crash semantics, accepted: SIGKILL on the governor releases the
+  permit in the kernel the instant its fds close; the orphaned child
+  finishes its current compile momentarily ungoverned. Regression:
+  `daemonized_server_does_not_inherit_the_permit` in
+  `crates/rustc-governor/tests/sccache_chain.rs`.
 
 #### Why wrapper-side (the 2026-07 bypass post-mortem)
 


### PR DESCRIPTION
Production-confirmed leak, fixed structurally. The exec'd sccache client's permit fd (FD_CLOEXEC deliberately cleared under the old design) was inherited by any sccache server the client **daemonized on demand** — and flock rides the open file description, so the long-lived server retained the permit for hours after the client exited: a 3-permit pool silently ran as 2, with a local server squatting a borrowed CI permit. The ceiling itself stayed safe (the leak direction is conservative); capacity and the class split did not.

The governed path no longer execs: the governor **stays alive as the permit owner** — FD_CLOEXEC left set, so no child can ever inherit the flock — spawns the `wrap_with <real-rustc> <args>` chain, forwards SIGTERM/SIGINT/SIGHUP to the child (async-signal-safe kill from the handler, pid in an atomic), waits, and exits the way the child exited (code propagated; signal death re-raised after restoring SIG_DFL). Probes and the permit-less fail-open paths keep their zero-overhead exec form (verified none touches a permit fd). SIGKILL on the governor releases the permit in the kernel; the child orphans and finishes momentarily ungoverned — documented crash semantics.

**Regression test** (reviewer-specified): a rig with NO pre-started server lets the governed cacheable compile daemonize one mid-flight, then hard-asserts the permit is immediately lockable after the client exits, plus an lsof assert that the daemonized server holds no permit fd. **Negative-validated**: it fails with the leak signature against the old exec code and passes against this. The lock-survives-exec and signal tests are reworked to the parent-held properties (the signal test now fails a governor that dies without forwarding).

52/52 crate tests (regression test RAN against real sccache 0.15, not skipped), full --bins suite 3180/3180, clippy zero, fmt clean. Binary redeploy on the fleet follows the landing; account wiring is unchanged.