### PR TITLE
Conversation rollback for supervised sessions

### DIFF
--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -2685,6 +2685,11 @@ pub(crate) async fn run_round_loop(
     let mut xvfb_guard: Option<vision::XvfbGuard> = None;
     let local_session_id = session_log_id(&session_log);
     let mut follow_up_cancel_rx = bus.subscribe();
+    // Per-session round ledger: (round number, native message count at its
+    // end) — the parked drain resolves targeted conversation rollbacks
+    // from it (the supervised twin of the headless shape's file-watcher
+    // History lookup; round numbers are the ones RoundComplete broadcast).
+    let mut round_ledger: Vec<(usize, u32)> = Vec::new();
     let mut cancelled_follow_ups: HashSet<String> = HashSet::new();
 
     loop {
@@ -2740,6 +2745,7 @@ pub(crate) async fn run_round_loop(
                 // truncate the tail back to this point.
                 let turns_in_round = stats.turns;
                 let native_message_count = Some(conversation.messages().len() as u32);
+                round_ledger.push((round, conversation.messages().len() as u32));
                 bus.send(AppEvent::RoundComplete {
                     session_id: local_session_id.clone(),
                     round,
@@ -2844,6 +2850,79 @@ pub(crate) async fn run_round_loop(
                                             text,
                                             id,
                                         ));
+                                    }
+                                    Ok(AppEvent::ConversationRollbackRequested {
+                                        session_id: Some(target),
+                                        round_id,
+                                        ..
+                                    }) if event_targets_session(
+                                        &Some(target.clone()),
+                                        &local_session_id,
+                                    ) =>
+                                    {
+                                        // Targeted conversation rollback:
+                                        // this parked drain is the
+                                        // supervised session's rollback
+                                        // executor. Resolve the round from
+                                        // the local ledger and truncate;
+                                        // the dashboard observes the
+                                        // completion event (the HTTP
+                                        // response never waited, same as
+                                        // the legacy path).
+                                        let target_count = round_ledger
+                                            .iter()
+                                            .find(|(number, _)| *number as u64 == round_id)
+                                            .map(|(_, count)| *count);
+                                        let removed = match target_count {
+                                            Some(count) => {
+                                                // Capture the surviving
+                                                // tail's seq BEFORE the
+                                                // truncate: truncate_to
+                                                // appends synthetic
+                                                // dangling-call repairs
+                                                // with fresh seqs that must
+                                                // not shift the cut (same
+                                                // rule as the headless
+                                                // path).
+                                                let clamped = (count as usize)
+                                                    .max(1)
+                                                    .min(conversation.len());
+                                                let cut_after_seq = conversation
+                                                    .messages()
+                                                    .get(clamped - 1)
+                                                    .map(|m| m.seq)
+                                                    .unwrap_or(0);
+                                                let removed = conversation
+                                                    .truncate_to(count as usize);
+                                                if removed > 0 {
+                                                    slog(&session_log, |l| {
+                                                        l.conversation_rewound(
+                                                            cut_after_seq,
+                                                            "tail_rollback",
+                                                        )
+                                                    });
+                                                }
+                                                round_ledger.retain(|(number, _)| {
+                                                    *number as u64 <= round_id
+                                                });
+                                                round = round_id as usize;
+                                                removed
+                                            }
+                                            // Unknown round: emit a 0-turn
+                                            // completion so the dashboard
+                                            // clears its pending state (the
+                                            // legacy path does the same
+                                            // when it cannot truncate).
+                                            None => 0,
+                                        };
+                                        bus.send(AppEvent::ConversationRolledBack {
+                                            session_id: local_session_id.clone(),
+                                            round_id,
+                                            turns_removed: removed as u32,
+                                            backend: "native".into(),
+                                            method: "truncated".into(),
+                                        });
+                                        continue;
                                     }
                                     Ok(_) => {}
                                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -913,6 +913,14 @@ pub enum AppEvent {
     /// (from `HistoryRound`) and `turn_count`; both are passed through
     /// here so the consumer doesn't have to look them up again.
     ConversationRollbackRequested {
+        /// Target session. `None` preserves the legacy shape: the
+        /// daemon's current/boot session (the headless outer loop).
+        /// `Some(id)` targets a supervised session's parked drain, which
+        /// resolves the round from its own ledger — delivery is
+        /// drain-time (a mid-round session is not listening; the
+        /// dashboard observes `ConversationRolledBack` for completion,
+        /// as it already does on the legacy path).
+        session_id: Option<String>,
         /// The round we are rolling back to. Echoed through to the
         /// completion event for UI correlation.
         round_id: u64,
@@ -928,6 +936,9 @@ pub enum AppEvent {
 
     /// Conversation was rolled back to a specific round.
     ConversationRolledBack {
+        /// The session that rolled back; `None` = the legacy
+        /// current-session shape.
+        session_id: Option<String>,
         round_id: u64,
         /// Number of messages/turns removed from the conversation.
         /// Semantics are backend-dependent:
@@ -2801,11 +2812,13 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
             bytes_freed: *bytes_freed,
         }),
         AppEvent::ConversationRolledBack {
+            session_id,
             round_id,
             turns_removed,
             backend,
             method,
         } => Some(OutboundEvent::ConversationRolledBack {
+            session_id: session_id.clone(),
             round_id: *round_id,
             turns_removed: *turns_removed,
             backend: backend.clone(),
@@ -3439,6 +3452,7 @@ fn write_event_to_session_log(session_log: &crate::SharedSessionLog, event: &App
             log.history_pruned(*branches_removed, *bytes_freed);
         }
         AppEvent::ConversationRolledBack {
+            session_id: _,
             round_id,
             turns_removed,
             backend,

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -400,14 +400,19 @@ pub(crate) async fn run_with_presence(
                     }
                 }
                 Ok(AppEvent::ConversationRollbackRequested {
+                    session_id,
                     round_id,
                     target_native_message_count,
                     turns_to_drop,
-                }) => OuterSignal::ConversationRollback {
-                    round_id,
-                    target_native_message_count,
-                    turns_to_drop,
-                },
+                }) if session_id.is_none()
+                    || event_targets_session(&session_id, &local_session_id) =>
+                {
+                    OuterSignal::ConversationRollback {
+                        round_id,
+                        target_native_message_count,
+                        turns_to_drop,
+                    }
+                }
                 Ok(AppEvent::InterruptRequested { session_id })
                     if event_targets_session(&session_id, &local_session_id) =>
                 {
@@ -1519,6 +1524,7 @@ pub(crate) async fn run_with_presence(
                     match agent.rollback_turns(turns_to_drop).await {
                         Ok(()) => {
                             bus.send(AppEvent::ConversationRolledBack {
+                                session_id: local_session_id.clone(),
                                 round_id,
                                 turns_removed: turns_to_drop,
                                 backend: backend_name,
@@ -1545,6 +1551,7 @@ pub(crate) async fn run_with_presence(
                             persistent_codex_config = None;
                             persistent_claude_config = None;
                             bus.send(AppEvent::ConversationRolledBack {
+                                session_id: local_session_id.clone(),
                                 round_id,
                                 turns_removed: turns_to_drop,
                                 backend: backend_name,
@@ -1579,6 +1586,7 @@ pub(crate) async fn run_with_presence(
                         None => 0,
                     };
                     bus.send(AppEvent::ConversationRolledBack {
+                        session_id: local_session_id.clone(),
                         round_id,
                         turns_removed: removed as u32,
                         backend: "native".into(),
@@ -1588,6 +1596,7 @@ pub(crate) async fn run_with_presence(
                     // No conversation to revert — emit completion
                     // anyway so the dashboard doesn't wait forever.
                     bus.send(AppEvent::ConversationRolledBack {
+                        session_id: local_session_id.clone(),
                         round_id,
                         turns_removed: 0,
                         backend: "native".into(),

--- a/src/bin/caller/types.rs
+++ b/src/bin/caller/types.rs
@@ -862,6 +862,8 @@ pub enum OutboundEvent {
     /// (native / Codex `thread/rollback`) or "session-reset"
     /// (CC / Gemini re-init).
     ConversationRolledBack {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session_id: Option<String>,
         round_id: u64,
         turns_removed: u32,
         backend: String,

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -2233,6 +2233,78 @@ pub(crate) async fn handle_history_get(
     ("200 OK", body)
 }
 
+/// Targeted conversation rollback for a supervised session (additive
+/// shape on `POST /api/session/current/rollback`): body carries
+/// `session_id` + `round_id` (the session's round number as broadcast by
+/// its `round_complete` events) + `revert_conversation: true`. The
+/// session's parked drain resolves the round from its own ledger and
+/// truncates; delivery is drain-time and the dashboard observes
+/// `ConversationRolledBack` for completion, exactly like the legacy
+/// current-session path. The file half stays legacy-only — per-session
+/// file rollback needs per-root watchers that don't exist yet.
+fn handle_targeted_conversation_rollback(
+    body_text: &str,
+    session_id: String,
+    bus: &EventBus,
+) -> (&'static str, String) {
+    let parsed: serde_json::Value = match serde_json::from_str(body_text) {
+        Ok(v) => v,
+        Err(e) => {
+            return (
+                "400 Bad Request",
+                serde_json::json!({"error": format!("invalid body: {}", e)}).to_string(),
+            );
+        }
+    };
+    let Some(round_id) = parsed.get("round_id").and_then(|v| v.as_u64()) else {
+        return (
+            "400 Bad Request",
+            serde_json::json!({"error": "missing round_id"}).to_string(),
+        );
+    };
+    let revert_files = parsed
+        .get("revert_files")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    let revert_conversation = parsed
+        .get("revert_conversation")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if revert_files {
+        return (
+            "400 Bad Request",
+            serde_json::json!({
+                "error": "revert_files is not supported for a targeted session; \
+                 pass revert_files: false"
+            })
+            .to_string(),
+        );
+    }
+    if !revert_conversation {
+        return (
+            "400 Bad Request",
+            serde_json::json!({"error": "targeted rollback requires revert_conversation: true"})
+                .to_string(),
+        );
+    }
+    bus.send(AppEvent::ConversationRollbackRequested {
+        session_id: Some(session_id.clone()),
+        round_id,
+        target_native_message_count: None,
+        turns_to_drop: 0,
+    });
+    (
+        "200 OK",
+        serde_json::json!({
+            "to_round_id": round_id,
+            "files_reverted": 0,
+            "session_id": session_id,
+            "conversation": "requested",
+        })
+        .to_string(),
+    )
+}
+
 /// POST /api/session/current/rollback — body:
 /// ```json
 /// { "round_id": N,
@@ -2259,6 +2331,24 @@ pub(crate) async fn handle_history_rollback(
     agent_state: Option<&Arc<Mutex<AgentStateSnapshot>>>,
     bus: &EventBus,
 ) -> (&'static str, String) {
+    // Targeted shape: roll back a SUPERVISED session's conversation
+    // (see handle_targeted_conversation_rollback). Peeked
+    // non-destructively so every historical request (no session_id)
+    // keeps its exact guard order and transcripts (golden-pinned:
+    // watcher-less daemons answer 503 before body validation).
+    let targeted_session: Option<String> = serde_json::from_str::<serde_json::Value>(body_text)
+        .ok()
+        .and_then(|v| {
+            v.get("session_id")
+                .and_then(|id| id.as_str())
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(str::to_string)
+        });
+    if let Some(session_id) = targeted_session {
+        return handle_targeted_conversation_rollback(body_text, session_id, bus);
+    }
+
     let Some(fw) = file_watcher else {
         return (
             "503 Service Unavailable",
@@ -2302,45 +2392,6 @@ pub(crate) async fn handle_history_rollback(
             "400 Bad Request",
             serde_json::json!({
                 "error": "at least one of revert_files / revert_conversation must be true"
-            })
-            .to_string(),
-        );
-    }
-
-    // Targeted shape: roll back a SUPERVISED session's conversation. The
-    // session's own parked drain resolves the round from its ledger and
-    // performs the truncation (delivery is drain-time; the dashboard
-    // observes ConversationRolledBack, as on the legacy path). The file
-    // half stays legacy-only: per-session file rollback needs per-root
-    // watchers that don't exist yet.
-    if let Some(session_id) = parsed
-        .get("session_id")
-        .and_then(|v| v.as_str())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-    {
-        if revert_files {
-            return (
-                "400 Bad Request",
-                serde_json::json!({
-                    "error": "revert_files is not supported for a targeted session;                               pass revert_files: false"
-                })
-                .to_string(),
-            );
-        }
-        bus.send(AppEvent::ConversationRollbackRequested {
-            session_id: Some(session_id.to_string()),
-            round_id,
-            target_native_message_count: None,
-            turns_to_drop: 0,
-        });
-        return (
-            "200 OK",
-            serde_json::json!({
-                "to_round_id": round_id,
-                "files_reverted": 0,
-                "session_id": session_id,
-                "conversation": "requested",
             })
             .to_string(),
         );

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -2307,6 +2307,45 @@ pub(crate) async fn handle_history_rollback(
         );
     }
 
+    // Targeted shape: roll back a SUPERVISED session's conversation. The
+    // session's own parked drain resolves the round from its ledger and
+    // performs the truncation (delivery is drain-time; the dashboard
+    // observes ConversationRolledBack, as on the legacy path). The file
+    // half stays legacy-only: per-session file rollback needs per-root
+    // watchers that don't exist yet.
+    if let Some(session_id) = parsed
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        if revert_files {
+            return (
+                "400 Bad Request",
+                serde_json::json!({
+                    "error": "revert_files is not supported for a targeted session;                               pass revert_files: false"
+                })
+                .to_string(),
+            );
+        }
+        bus.send(AppEvent::ConversationRollbackRequested {
+            session_id: Some(session_id.to_string()),
+            round_id,
+            target_native_message_count: None,
+            turns_to_drop: 0,
+        });
+        return (
+            "200 OK",
+            serde_json::json!({
+                "to_round_id": round_id,
+                "files_reverted": 0,
+                "session_id": session_id,
+                "conversation": "requested",
+            })
+            .to_string(),
+        );
+    }
+
     // Resolve conversation-rollback parameters before we mutate any
     // state so a downstream failure doesn't leave files half-reverted
     // with no event emitted. Reading the history requires the same
@@ -2379,6 +2418,7 @@ pub(crate) async fn handle_history_rollback(
     // up and emits `ConversationRolledBack` when done.
     if let Some((target_msg_count, turns_to_drop)) = conv_params {
         bus.send(AppEvent::ConversationRollbackRequested {
+            session_id: None,
             round_id,
             target_native_message_count: target_msg_count,
             turns_to_drop,

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -3234,6 +3234,225 @@ async fn parked_session_delivers_an_id_less_steer() {
     assert_eq!(msg_field(steer_row, "provenance").as_str(), Some("steer"));
 }
 
+/// Targeted conversation rollback: a SUPERVISED session's parked drain
+/// executes `POST /api/session/current/rollback { session_id, round_id,
+/// revert_conversation: true, revert_files: false }` — previously the
+/// signal was only handled by the headless boot-session loop, so the
+/// pure-daemon rollback rail was dead (the gap the B2 message-lane e2e
+/// documented). Two rounds run, the conversation rolls back to round 1,
+/// and a third round proves the session keeps working on the truncated
+/// conversation; the session log carries the same `conversation_rewound`
+/// cut the message-search extractor derives supersession from, and the
+/// completion event carries the session id.
+#[tokio::test]
+async fn supervised_session_rolls_back_conversation_to_a_round() {
+    use futures_util::SinkExt;
+
+    let rig = TestRig::new();
+    let script = rig.write_script(&serde_json::json!({
+        "profiles": [{
+            "steps": [
+                { "content": "Round one done.",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "round one" } }] },
+                { "content": "Round two done.",
+                  "expect_transcript_contains": "start round two",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "round two" } }] },
+                { "content": "Post-rollback round done.",
+                  "expect_transcript_contains": "after the rewind",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "round three" } }] }
+            ]
+        }]
+    }));
+    let session_project = tempfile::tempdir().expect("session project dir");
+
+    let mut cmd = rig.command();
+    cmd.env("INTENDANT_MOCK_SCRIPT", &script)
+        .args(["--no-tls", "--web", "0"]);
+    let mut child = cmd.spawn().expect("spawn intendant daemon");
+    let stderr_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let stdout_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    let _stderr_drain = drain_pipe_into(child.stderr.take().expect("stderr"), stderr_buf.clone());
+    let _stdout_drain = drain_pipe_into(child.stdout.take().expect("stdout"), stdout_buf.clone());
+
+    let stderr_so_far = wait_for_output(&stderr_buf, "Dashboard: http://", RUN_TIMEOUT).await;
+    let port: u16 = stderr_so_far
+        .lines()
+        .find_map(|line| {
+            let url = line.strip_prefix("Dashboard: http://")?;
+            url.rsplit(':').next()?.trim().parse().ok()
+        })
+        .expect("parse the dashboard port from the startup line");
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/ws"))
+        .await
+        .expect("connect /ws");
+
+    // Same startup race + retry shape as the sibling tests.
+    let mut completed = None;
+    for _ in 0..6 {
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::json!({
+                "action": "create_session",
+                "task": "run round one",
+                "project_root": session_project.path().to_string_lossy(),
+                "direct": true,
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send create_session");
+        completed = next_matching_ws_event(&mut ws, Duration::from_secs(30), |json| {
+            json.get("event").and_then(|v| v.as_str()) == Some("round_complete")
+        })
+        .await;
+        if completed.is_some() {
+            break;
+        }
+    }
+    let completed = completed.unwrap_or_else(|| {
+        panic!(
+            "round 1 never completed; daemon stderr:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
+        )
+    });
+    let session_id = completed
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .expect("round_complete carries its session id")
+        .to_string();
+
+    // Round 2 via a follow-up steer (id-carrying, the delivered path).
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "steer",
+            "session_id": session_id,
+            "id": "rollback-e2e-steer-1",
+            "text": "start round two",
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send round-2 steer");
+    next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("round_complete")
+            && json.get("session_id").and_then(|v| v.as_str()) == Some(session_id.as_str())
+            && json.get("round").and_then(|v| v.as_u64()) == Some(2)
+    })
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "round 2 never completed; daemon stderr:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default()
+        )
+    });
+
+    // Targeted conversation rollback to round 1 through the route.
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!(
+            "http://127.0.0.1:{port}/api/session/current/rollback"
+        ))
+        .json(&serde_json::json!({
+            "session_id": session_id,
+            "round_id": 1,
+            "revert_conversation": true,
+            "revert_files": false,
+        }))
+        .send()
+        .await
+        .expect("send targeted rollback");
+    assert!(
+        response.status().is_success(),
+        "targeted rollback rejected: {:?}",
+        response.text().await
+    );
+    let rolled = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("conversation_rolled_back")
+            && json.get("session_id").and_then(|v| v.as_str()) == Some(session_id.as_str())
+    })
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "targeted rollback never completed; daemon stderr:\n{}\nsession logs:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default(),
+            tail(&rig.session_logs(), 6000)
+        )
+    });
+    assert!(
+        rolled
+            .get("turns_removed")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0)
+            > 0,
+        "rollback must remove round 2's messages: {rolled}"
+    );
+
+    // The session still works: round 3 on the truncated conversation.
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "steer",
+            "session_id": session_id,
+            "id": "rollback-e2e-steer-2",
+            "text": "after the rewind",
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send post-rollback steer");
+    next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("round_complete")
+            && json.get("session_id").and_then(|v| v.as_str()) == Some(session_id.as_str())
+            && json.get("round").and_then(|v| v.as_u64()) == Some(2)
+    })
+    .await
+    .unwrap_or_else(|| {
+        panic!(
+            "post-rollback round never completed; daemon stderr:\n{}\nsession logs:\n{}",
+            stderr_buf.lock().map(|b| b.clone()).unwrap_or_default(),
+            tail(&rig.session_logs(), 6000)
+        )
+    });
+    let _ = child.kill().await;
+
+    // The wire contract: the cut partitions round 2, round 3's steer rides
+    // after it with a fresh seq.
+    let log_dir = rig
+        .home
+        .path()
+        .join(".intendant")
+        .join("logs")
+        .join(&session_id);
+    let rows = parsed_session_rows(&log_dir);
+    let messages = canonical_message_rows(&rows);
+    let round2_seq = msg_field(
+        user_message_row(&messages, "start round two"),
+        "message_seq",
+    )
+    .as_u64()
+    .unwrap();
+    let round3_seq = msg_field(
+        user_message_row(&messages, "after the rewind"),
+        "message_seq",
+    )
+    .as_u64()
+    .unwrap();
+    let rewound = rows
+        .iter()
+        .find(|row| row.get("event").and_then(|v| v.as_str()) == Some("conversation_rewound"))
+        .expect("conversation_rewound row exists");
+    let cut_after_seq = msg_field(rewound, "cut_after_seq").as_u64().unwrap();
+    assert!(
+        cut_after_seq < round2_seq && round2_seq < round3_seq,
+        "cut {cut_after_seq} must supersede round 2 (seq {round2_seq}) and precede          round 3 (seq {round3_seq})"
+    );
+}
+
 /// Message-lane wire contract, rollback half: the HEADLESS shape (task on
 /// argv) is the one execution shape whose outer loop (run_with_presence)
 /// handles `ConversationRollbackRequested`, so the round-rollback rail —


### PR DESCRIPTION
Closes the daemon-rollback gap the B2 message-lane e2e documented: `ConversationRollbackRequested` was only handled by the headless boot-session's outer loop, so in the pure-daemon world (every session a supervised child) the rollback rail was dead.

**Design** — the supervised session's parked follow-up drain becomes the rollback executor, the same pattern as the parked-steer fix (#262):
- `ConversationRollbackRequested`/`ConversationRolledBack` gain `session_id: Option<String>` (`None` = the legacy current-session shape, byte-identical behavior — golden transcripts pass unchanged; the completion event now carries the session for dashboard attribution).
- `POST /api/session/current/rollback` accepts `session_id` (peeked non-destructively so historical requests keep their exact guard order): the targeted shape is conversation-only (`revert_files: false` required — per-session file rollback needs per-root watchers that don't exist) and emits the targeted event; delivery is drain-time and the dashboard observes `ConversationRolledBack`, exactly like the legacy path's async completion.
- The drain resolves the round from a **local ledger** fed by its own `RoundComplete` emissions (round number + native message count) — no cross-module state, no global History entanglement — and truncates with the same capture-cut-seq-before-truncate rule as the headless path, writing the same `conversation_rewound` supersession cut the message-search extractor consumes.

**E2e**: a supervised child runs two rounds, rolls back to round 1 through the route (completion event carries the session id and a non-zero turns-removed), then runs a post-rollback round proving the session keeps working on the truncated conversation; the log's `conversation_rewound` cut partitions round 2's seq below round 3's.

Battery: full `cargo nextest run --bins` (3180, incl. the golden route transcripts), full e2e (19), clippy `-D warnings`, fmt.