### PR TITLE
dashboard: default message search on

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -93614,8 +93614,12 @@ const SESSION_MSG_SEARCH_TIMEOUT_MS = 15000;
 
 function messageSearchFlagEnabled() {
   if (_msgSearchFlagMemo === null) {
+    // Default ON since the 2026-07-12 soak (real-corpus acceptance +
+    // browser QA green); `?message_search=off` is the escape hatch. The
+    // runtime availability precheck still gates the lane per daemon, so
+    // old daemons degrade to the honest "unavailable" note.
     const raw = new URLSearchParams(window.location.search).get('message_search');
-    _msgSearchFlagMemo = raw === 'on' || raw === '1';
+    _msgSearchFlagMemo = raw !== 'off' && raw !== '0';
   }
   return _msgSearchFlagMemo;
 }

--- a/static/app/57-sessions-message-search.js
+++ b/static/app/57-sessions-message-search.js
@@ -35,8 +35,12 @@ const SESSION_MSG_SEARCH_TIMEOUT_MS = 15000;
 
 function messageSearchFlagEnabled() {
   if (_msgSearchFlagMemo === null) {
+    // Default ON since the 2026-07-12 soak (real-corpus acceptance +
+    // browser QA green); `?message_search=off` is the escape hatch. The
+    // runtime availability precheck still gates the lane per daemon, so
+    // old daemons degrade to the honest "unavailable" note.
     const raw = new URLSearchParams(window.location.search).get('message_search');
-    _msgSearchFlagMemo = raw === 'on' || raw === '1';
+    _msgSearchFlagMemo = raw !== 'off' && raw !== '0';
   }
   return _msgSearchFlagMemo;
 }


### PR DESCRIPTION
Flips the `message_search` flag default after the lane graduated its soak (2026-07-12: real-corpus acceptance — p95 10ms all-ready — plus headless-browser QA of the union UI). `?message_search=off` is the escape hatch; the runtime `api_sessions_message_search_available` precheck still gates the lane per daemon, so old daemons keep degrading to the explicit "unavailable" note rather than erroring. Browser-verified both directions against a live daemon (default URL → flag true; `?message_search=off` → flag false, lane inert).

The preview lane deliberately stays: it is the old-daemon fallback, and the plan gates its retirement on real-use soak of this default.