### PR TITLE
governor: policy-ceiling honesty — doctrine, detector, stale-comment fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,12 @@ cargo nextest run --bins  # same tests, much faster: one process per test
 cargo clippy              # lint
 ```
 
+Never clear `RUSTC_WRAPPER` or set `RUSTC` for builds in this repo: the
+box-wide compile governor (scripts/ci/README.md, "Governor") rides those
+settings, and overriding them opts your build out of the machine's
+RAM-protecting compile ceiling (the 2026-07-10 OOM-spiral class).
+Permitted only when deliberately diagnosing the wrapper chain itself.
+
 **WASM** (`crates/presence-web` → `static/wasm-web/`, `crates/station-web` → `static/wasm-station/`): `build.rs` auto-detects stale WASM in either crate and rebuilds it via `wasm-pack`, then re-embeds, on a normal `cargo build`. wasm-pack is **version-pinned** by `.wasm-pack-version` (releases emit byte-different artifacts, and the artifacts are committed — cross-version rebuilds churn them and conflict concurrent landings): build.rs skips the rebuild under any other version, and the setup scripts install the pin. Manual fallback only if the auto-rebuild fails: `bash scripts/build-wasm.sh`
 (the canonical builder — it carries the registry-path remap that makes
 artifact bytes account-independent; the CI drift gate rebuilds through the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,12 @@ cargo nextest run --bins  # same tests, much faster: one process per test
 cargo clippy              # lint
 ```
 
+Never clear `RUSTC_WRAPPER` or set `RUSTC` for builds in this repo: the
+box-wide compile governor (scripts/ci/README.md, "Governor") rides those
+settings, and overriding them opts your build out of the machine's
+RAM-protecting compile ceiling (the 2026-07-10 OOM-spiral class).
+Permitted only when deliberately diagnosing the wrapper chain itself.
+
 **WASM** (`crates/presence-web` → `static/wasm-web/`, `crates/station-web` → `static/wasm-station/`): `build.rs` auto-detects stale WASM in either crate and rebuilds it via `wasm-pack`, then re-embeds, on a normal `cargo build`. wasm-pack is **version-pinned** by `.wasm-pack-version` (releases emit byte-different artifacts, and the artifacts are committed — cross-version rebuilds churn them and conflict concurrent landings): build.rs skips the rebuild under any other version, and the setup scripts install the pin. Manual fallback only if the auto-rebuild fails: `bash scripts/build-wasm.sh`
 (the canonical builder — it carries the registry-path remap that makes
 artifact bytes account-independent; the CI drift gate rebuilds through the

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -109,6 +109,17 @@ swap → `kernel_task` throttle spiral follows. `crates/rustc-governor`
 adds the missing machine-wide bound: a compile-permit pool shared by
 every account on the box.
 
+This is a **policy ceiling, not a hard one**: cargo's env layer beats
+config, so `RUSTC_WRAPPER=""` (or a direct `RUSTC=…` override) opts a
+build out of the governor entirely — observed in the wild from an agent
+session (an ungoverned 1.8GB rustc while all permits sat free). The
+box's inhabitants are cooperative agents, so the enforcement stack is
+doctrine (CLAUDE.md forbids the override outside wrapper diagnostics)
+plus observability (the watchdog logs any substantial rustc with
+neither a governor nor an sccache ancestor). Enforcement below cargo's
+overridable layer was considered and deliberately skipped as
+disproportionate.
+
 ### The chain
 
 ```

--- a/scripts/ci/fleet-watchdog.sh
+++ b/scripts/ci/fleet-watchdog.sh
@@ -197,6 +197,27 @@ evict_until() {
     done
 }
 
+# Policy-ceiling observability: a substantial rustc with neither a
+# rustc-governor nor an sccache ancestor means someone opted out of the
+# governor (env beats config: RUSTC_WRAPPER="" / RUSTC=… — seen in the
+# wild from an agent session). Log-only; the inhabitants are cooperative
+# agents and CLAUDE.md carries the doctrine. Known blind spot: a build
+# run with RUSTC_WRAPPER=sccache (bypassing the governor but keeping
+# sccache) is ancestry-indistinguishable from a governed compile.
+detect_ungoverned_rustc() {
+    ps -axo pid=,rss=,comm= 2>/dev/null | awk '$3 ~ /rustc$/ && $2 > 512000 {print $1, $2}'     | while read -r rpid rss; do
+        p="$rpid" governed=0 hop=0
+        while [ "$hop" -lt 10 ] && [ -n "$p" ] && [ "$p" -gt 1 ] 2>/dev/null; do
+            case "$(ps -o comm= -p "$p" 2>/dev/null)" in
+                *rustc-governor* | *sccache*) governed=1; break ;;
+            esac
+            p=$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')
+            hop=$((hop + 1))
+        done
+        [ "$governed" = 0 ] && log "ungoverned rustc pid=$rpid rss=$((rss / 1024))MB — no governor/sccache ancestor (RUSTC_WRAPPER override?)"
+    done
+}
+
 main() {
     free=$(free_gb)
 
@@ -225,6 +246,7 @@ main() {
         fi
     fi
 
+    detect_ungoverned_rustc
     prune_stale_keys
     evict_until 0  # steady-state cap enforcement
 

--- a/scripts/ci/install-governor-macos.sh
+++ b/scripts/ci/install-governor-macos.sh
@@ -52,10 +52,11 @@ permit_dir = "/usr/local/var/intendant-governor"
 local_reserved = 1
 ci_reserved = 2
 ci_users = ["_intendant-ci", "ci"]
-# Governed (and fail-open) invocations exec `wrap_with <rustc> <args…>` —
-# the sccache client; the flock permit rides into it and is held for the
-# whole cache round-trip / server-side compile. Unset, empty, or a missing
-# path: the compiler runs directly (correct, just uncached).
+# Governed invocations spawn `wrap_with <rustc> <args…>` (the sccache
+# client) as a CHILD while the governor itself holds the permit until the
+# child exits — the fd is close-on-exec, so no child (crucially, no
+# daemonized sccache server) can inherit the flock. Unset, empty, or a
+# missing path: the compiler runs directly (correct, just uncached).
 wrap_with = "/opt/homebrew/bin/sccache"
 CONF_EOF
     chmod 0644 "$CONF"


### PR DESCRIPTION
Follow-ups from the reviewer's post-#269 verification (which confirmed parent-held permits working across 130 samples). They caught a real bypass class the permit machinery cannot see: **cargo's env layer beats config** — `RUSTC_WRAPPER=""` (observed live: an ungoverned 1.8GB rustc while all permits sat free) or direct `RUSTC=…` opts a build out entirely.

Response is doctrine + observability, deliberately not enforcement below cargo's overridable layer (the box's inhabitants are cooperative agents): CLAUDE.md forbids the override outside wrapper diagnostics; the fleet watchdog logs any substantial rustc with neither a governor nor an sccache ancestor (blind spot documented: `RUSTC_WRAPPER=sccache` bypasses are ancestry-indistinguishable); the README qualifies the ceiling as a **policy ceiling** and records the decision; and the installer's conf here-doc loses its stale permit-rides-the-exec comment (parent-held since #269).

Also validated per the same review: #273's flock serialization exercised locally with concurrent instances (second holder entered only after the first released — CI runs so far had all green-skipped the lock path).