### PR TITLE
message_search: tombstone shards on session deletion

### DIFF
--- a/src/bin/caller/message_search/mod.rs
+++ b/src/bin/caller/message_search/mod.rs
@@ -29,11 +29,15 @@ mod store;
 // locate.rs, plan §7 C2) verifies locators exactly the way the extractors
 // mint them, so it consumes the frozen locator type and the legacy
 // follow-up line parser from here.
+#[cfg(test)]
+pub(crate) use cursor::SourceCursor;
 pub(crate) use extract_intendant::parse_round_follow_up;
 pub(crate) use indexer::{refresh_if_stale, spawn_indexer};
 pub(crate) use query::{parse_sources, run_message_search, MessageSearchParams};
 pub(crate) use record::{Locator, MESSAGE_TEXT_CAP_BYTES};
 pub(crate) use store::Store;
+#[cfg(test)]
+pub(crate) use store::{PublishOutcome, SessionShard};
 
 /// Boot-time retention GC over the production store root (plan §6):
 /// expired shards and tombstones must not accumulate before the first

--- a/src/bin/caller/message_search/store.rs
+++ b/src/bin/caller/message_search/store.rs
@@ -251,8 +251,6 @@ impl Store {
     }
 
     /// Deliberate session deletion: drop the shard and tombstone the key.
-    // Un-wired until the dashboard/API deletion flow lands with C1.
-    #[allow(dead_code)]
     pub(crate) fn delete_session(&self, session_key: &str) -> std::io::Result<()> {
         let _lock = WriterLock::acquire(&self.root)?;
         let mut manifest = self.read_manifest();

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -4203,6 +4203,29 @@ pub(crate) fn managed_context_fission_response_from_home(
 
 /// Delete session data: entire session, media, recordings, frames, or turns.
 /// Returns a JSON result with `ok` and `bytes_freed`.
+/// Best-effort message-search tombstoning for a deliberate session
+/// deletion. Never creates the store (a box that never ran the indexer
+/// has nothing to tombstone) and never fails the deletion.
+fn tombstone_search_shards(home: &Path, session_keys: &[String]) {
+    let root = crate::platform::intendant_home_in(home)
+        .join("cache")
+        .join("message_search")
+        .join("v1");
+    if !root.exists() {
+        return;
+    }
+    match crate::message_search::Store::open(&root) {
+        Ok(store) => {
+            for key in session_keys {
+                if let Err(err) = store.delete_session(key) {
+                    eprintln!("[message-search] tombstone {key} failed: {err}");
+                }
+            }
+        }
+        Err(err) => eprintln!("[message-search] store open for tombstone failed: {err}"),
+    }
+}
+
 pub(crate) fn delete_session_data(home: &Path, session_id: &str, target: &str) -> String {
     // Path traversal protection
     if !session_lookup_id_is_safe(session_id) {
@@ -4248,8 +4271,17 @@ pub(crate) fn delete_session_data(home: &Path, session_id: &str, target: &str) -
         "session" => {
             let bytes = dir_byte_size(&dir);
             let external_delete_target = external_delete_target_for_intendant_session_dir(&dir);
+            // Deliberate deletion also tombstones the message-search
+            // shard(s): the session vanishes from search immediately and
+            // can never resurrect from stale sources (plan §6) — instead
+            // of riding `source_gone` until the retention window expires.
+            let mut search_tombstones = vec![format!("intendant:{session_id}")];
+            if let Some((source, external_id)) = &external_delete_target {
+                search_tombstones.push(format!("{source}:{external_id}"));
+            }
             match std::fs::remove_dir_all(&dir) {
                 Ok(_) => {
+                    tombstone_search_shards(home, &search_tombstones);
                     let mut body =
                         serde_json::json!({"ok": true, "deleted": "session", "bytes_freed": bytes});
                     if let Some((source, external_id)) = external_delete_target {
@@ -4317,6 +4349,50 @@ pub(crate) fn delete_session_data(home: &Path, session_id: &str, target: &str) -
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn deleting_a_session_tombstones_its_search_shards() {
+        use crate::message_search::{PublishOutcome, SessionShard, Store};
+        let home = tempfile::tempdir().unwrap();
+        let session_id = "0d0d0d0d-1111-2222-3333-444444444444";
+        let logs = home.path().join(".intendant").join("logs").join(session_id);
+        std::fs::create_dir_all(&logs).unwrap();
+        std::fs::write(logs.join("session.jsonl"), "{}\n").unwrap();
+
+        // A published shard for the session, in the home-scoped store.
+        let store_root = home
+            .path()
+            .join(".intendant")
+            .join("cache")
+            .join("message_search")
+            .join("v1");
+        let store = Store::open(&store_root).unwrap();
+        let source = home.path().join("src.jsonl");
+        std::fs::write(&source, "line\n".repeat(4)).unwrap();
+        let cursor = crate::message_search::SourceCursor::capture(&source, 5).unwrap();
+        let key = format!("intendant:{session_id}");
+        assert!(matches!(
+            store
+                .publish_session(&key, &SessionShard::default(), vec![cursor.clone()], false)
+                .unwrap(),
+            PublishOutcome::Published
+        ));
+
+        let body = super::delete_session_data(home.path(), session_id, "session");
+        assert!(body.contains("\"ok\":true"), "{body}");
+        assert!(!logs.exists());
+
+        // Shard gone, key tombstoned: a stale republish must be refused.
+        let snapshot = store.snapshot();
+        assert!(!snapshot.manifest.sessions.contains_key(&key));
+        assert!(snapshot.manifest.tombstones.contains_key(&key));
+        assert!(matches!(
+            store
+                .publish_session(&key, &SessionShard::default(), vec![cursor], false)
+                .unwrap(),
+            PublishOutcome::RejectedTombstoned
+        ));
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
Closes the docs-audit finding: `Store::delete_session` (tombstoning) existed but the session-deletion flow never called it, so deliberately deleted sessions kept answering search hits (badged `source_gone`) until the retention window aged them out.

`delete_session_data`'s session arm now tombstones the message-search shard — `intendant:<id>` plus, for wrapper sessions, the external twin's `<source>:<external_id>` (mirroring the existing external-row hiding) — via the home-scoped store root (`intendant_home_in`, so hermetic tests inject tempdir homes). Best-effort: never creates the store on boxes that never indexed, never fails the deletion. The tombstone prevents resurrection from stale sources by design (plan §6), pinned by a new unit test driving the real deletion path against a published shard.

Follow-up docs tweak deliberately deferred: the session-logging chapter's "deleted sessions ride source_gone" sentence is now stale; fixing it rides the next docs pass rather than an app-code PR.

Battery: full nextest (3182), clippy `-D warnings`, fmt.