### PR TITLE
dashboard: previews retire from search when the message lane serves

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -90843,7 +90843,7 @@ const _sessionSearchTextCache = new WeakMap();
 function sessionSearchText(session, displayStatus, source, shortId, isCurrent) {
   const cached = _sessionSearchTextCache.get(session);
   if (cached && cached.status === displayStatus && cached.current === isCurrent) {
-    return cached.text;
+    return cached;
   }
   const totalBytes = session.total_bytes || 0;
   // Server-side conversation preview (first user/assistant messages) —
@@ -90886,20 +90886,35 @@ function sessionSearchText(session, displayStatus, source, shortId, isCurrent) {
     totalBytes > 0 ? `${_fmtBytes(totalBytes)} size` : '',
     session.total_tokens != null ? `${session.total_tokens} tokens` : '',
     session.estimated_cost != null ? `$${Number(session.estimated_cost).toFixed(4)}` : '',
-    previewText,
   ];
   const text = fields
     .filter(v => v !== null && v !== undefined && v !== '')
     .join(' ')
     .toLowerCase();
-  _sessionSearchTextCache.set(session, { status: displayStatus, current: isCurrent, text });
-  return text;
+  const entry = {
+    status: displayStatus,
+    current: isCurrent,
+    text,
+    // Kept OUT of the metadata haystack: preview text only participates
+    // as the old-daemon fallback (see sessionMatchesSearch).
+    preview: previewText.toLowerCase(),
+  };
+  _sessionSearchTextCache.set(session, entry);
+  return entry;
 }
 
 function sessionMatchesSearch(session, query, displayStatus, source, shortId, isCurrent) {
   if (!query) return true;
-  const haystack = sessionSearchText(session, displayStatus, source, shortId, isCurrent);
-  return query.split(/\s+/).every(term => haystack.includes(term));
+  const entry = sessionSearchText(session, displayStatus, source, shortId, isCurrent);
+  const terms = query.split(/\s+/);
+  if (terms.every(term => entry.text.includes(term))) return true;
+  // Preview fallback (plan §8 retirement): server-side conversation
+  // previews stop participating in search whenever the message-search
+  // lane can serve — the shard index is the authority on message text,
+  // and a preview-only match would contradict its (correct) no-hit
+  // answer. Old daemons / a down tunnel keep the fallback.
+  if (messageSearchSupersedesPreviews()) return false;
+  return entry.preview !== '' && terms.every(term => entry.preview.includes(term));
 }
 
 // Compact tile value + the exact figure for the hover: 144,900,123,456
@@ -94319,6 +94334,23 @@ function messageSearchFlagEnabled() {
   return _msgSearchFlagMemo;
 }
 
+// The preview lane retires from search matching whenever the message
+// lane can serve this host (plan §8): flag on + the daemon-derived
+// availability of api_sessions_message_search. Per-query state is
+// deliberately ignored — an available lane is the authority on message
+// text even when the current query has no hits yet.
+function messageSearchSupersedesPreviews() {
+  if (!messageSearchFlagEnabled()) return false;
+  // Follow the lane's own serving state, not raw availability: a stale
+  // pre-hello "unavailable" answer (typed before the tunnel came up)
+  // must keep the preview fallback, or search would show neither
+  // preview matches nor message hits.
+  if (_sessionMsgSearch.unavailable || _sessionMsgSearch.error) return false;
+  const host = currentSessionsHostId();
+  const target = host && host !== selfPeerId ? host : null;
+  return !!daemonApi.availability('api_sessions_message_search', target).ok;
+}
+
 // Superseded matches are included by default and badged (plan D2); the
 // toolbar toggle (revealed only under the flag) flips the server-side
 // `include_superseded` param. Absent element ⇒ the default (include).
@@ -94900,6 +94932,7 @@ function buildSessionMessageSearchStubCard(m, ctx) {
 window.qa = Object.assign(window.qa || {}, {
   messageSearch: () => ({
     flag: messageSearchFlagEnabled(),
+    supersedesPreviews: messageSearchSupersedesPreviews(),
     query: _sessionMsgSearch.query,
     active: _sessionMsgSearch.active,
     loading: _sessionMsgSearch.loading,

--- a/static/app/56-debug-sessions.js
+++ b/static/app/56-debug-sessions.js
@@ -2069,7 +2069,7 @@ const _sessionSearchTextCache = new WeakMap();
 function sessionSearchText(session, displayStatus, source, shortId, isCurrent) {
   const cached = _sessionSearchTextCache.get(session);
   if (cached && cached.status === displayStatus && cached.current === isCurrent) {
-    return cached.text;
+    return cached;
   }
   const totalBytes = session.total_bytes || 0;
   // Server-side conversation preview (first user/assistant messages) —
@@ -2112,20 +2112,35 @@ function sessionSearchText(session, displayStatus, source, shortId, isCurrent) {
     totalBytes > 0 ? `${_fmtBytes(totalBytes)} size` : '',
     session.total_tokens != null ? `${session.total_tokens} tokens` : '',
     session.estimated_cost != null ? `$${Number(session.estimated_cost).toFixed(4)}` : '',
-    previewText,
   ];
   const text = fields
     .filter(v => v !== null && v !== undefined && v !== '')
     .join(' ')
     .toLowerCase();
-  _sessionSearchTextCache.set(session, { status: displayStatus, current: isCurrent, text });
-  return text;
+  const entry = {
+    status: displayStatus,
+    current: isCurrent,
+    text,
+    // Kept OUT of the metadata haystack: preview text only participates
+    // as the old-daemon fallback (see sessionMatchesSearch).
+    preview: previewText.toLowerCase(),
+  };
+  _sessionSearchTextCache.set(session, entry);
+  return entry;
 }
 
 function sessionMatchesSearch(session, query, displayStatus, source, shortId, isCurrent) {
   if (!query) return true;
-  const haystack = sessionSearchText(session, displayStatus, source, shortId, isCurrent);
-  return query.split(/\s+/).every(term => haystack.includes(term));
+  const entry = sessionSearchText(session, displayStatus, source, shortId, isCurrent);
+  const terms = query.split(/\s+/);
+  if (terms.every(term => entry.text.includes(term))) return true;
+  // Preview fallback (plan §8 retirement): server-side conversation
+  // previews stop participating in search whenever the message-search
+  // lane can serve — the shard index is the authority on message text,
+  // and a preview-only match would contradict its (correct) no-hit
+  // answer. Old daemons / a down tunnel keep the fallback.
+  if (messageSearchSupersedesPreviews()) return false;
+  return entry.preview !== '' && terms.every(term => entry.preview.includes(term));
 }
 
 // Compact tile value + the exact figure for the hover: 144,900,123,456

--- a/static/app/57-sessions-message-search.js
+++ b/static/app/57-sessions-message-search.js
@@ -45,6 +45,23 @@ function messageSearchFlagEnabled() {
   return _msgSearchFlagMemo;
 }
 
+// The preview lane retires from search matching whenever the message
+// lane can serve this host (plan §8): flag on + the daemon-derived
+// availability of api_sessions_message_search. Per-query state is
+// deliberately ignored — an available lane is the authority on message
+// text even when the current query has no hits yet.
+function messageSearchSupersedesPreviews() {
+  if (!messageSearchFlagEnabled()) return false;
+  // Follow the lane's own serving state, not raw availability: a stale
+  // pre-hello "unavailable" answer (typed before the tunnel came up)
+  // must keep the preview fallback, or search would show neither
+  // preview matches nor message hits.
+  if (_sessionMsgSearch.unavailable || _sessionMsgSearch.error) return false;
+  const host = currentSessionsHostId();
+  const target = host && host !== selfPeerId ? host : null;
+  return !!daemonApi.availability('api_sessions_message_search', target).ok;
+}
+
 // Superseded matches are included by default and badged (plan D2); the
 // toolbar toggle (revealed only under the flag) flips the server-side
 // `include_superseded` param. Absent element ⇒ the default (include).
@@ -626,6 +643,7 @@ function buildSessionMessageSearchStubCard(m, ctx) {
 window.qa = Object.assign(window.qa || {}, {
   messageSearch: () => ({
     flag: messageSearchFlagEnabled(),
+    supersedesPreviews: messageSearchSupersedesPreviews(),
     query: _sessionMsgSearch.query,
     active: _sessionMsgSearch.active,
     loading: _sessionMsgSearch.loading,


### PR DESCRIPTION
The final message-search program item: server-side conversation previews (2+2 × 160 chars) stop participating in search matching whenever the message-search lane can serve — the shard index is the authority on message text, and a preview-only match would contradict its correct no-hit answers. Previews stay fully intact as the old-daemon fallback (plan §8), and the fallback also holds when the tunnel is down or the lane's current answer is unavailable/error.

That last clause was earned in live browser verification: gating retirement on *raw availability* raced the tunnel hello — a query typed pre-hello stores the lane's "unavailable" answer while availability flips true moments later, leaving search with neither preview matches nor message hits. The retirement now follows the lane's own serving state. The `window.qa.messageSearch()` probe gains `supersedesPreviews`, and the headless-browser pass asserts both directions: fallback active through every pre-hello unavailable state, retirement active once the lane answers `ready` (20 sessions on the live corpus).

Mechanically: the per-row haystack memo now carries preview text separately (metadata-only primary match; conditional preview fallback), so the retirement costs nothing per keystroke.

Battery: full nextest (3181), clippy `-D warnings`, fmt, app.html regen gates, browser verification above.