### PR TITLE
web gateway: HTTP/1.1 keep-alive with a fail-closed reuse table

### DIFF
--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -2730,7 +2730,7 @@ mod tests {
         ));
         let (mut client, server) = tokio::io::duplex(1 << 20);
         crate::web_gateway::write_api_response(
-            Box::pin(server),
+            crate::web_gateway::DemuxStream::new(Box::pin(server)),
             response,
             crate::gateway_routes::CorsPosture::OwnOrigin,
             None,

--- a/src/bin/caller/web_gateway/http.rs
+++ b/src/bin/caller/web_gateway/http.rs
@@ -20,28 +20,195 @@ use super::*;
 pub(crate) trait AsyncReadWrite: AsyncRead + AsyncWrite + Unpin + Send {}
 impl<T: AsyncRead + AsyncWrite + Unpin + Send> AsyncReadWrite for T {}
 
-/// Boxed demuxed connection (plain TCP or TLS), used for all post-demux
-/// HTTP/WebSocket handling.
-pub(crate) type DemuxStream = std::pin::Pin<Box<dyn AsyncReadWrite>>;
-
-/// Finalize a one-shot HTTP response on a demuxed stream before it drops.
+/// Demuxed connection (plain TCP or TLS) used for all post-demux
+/// HTTP/WebSocket handling, plus the per-exchange keep-alive state the
+/// request loop and the write edges share (see the `keep_alive` module
+/// docs for the decision table).
 ///
-/// Every dashboard HTTP reply is a single buffered response sent with
-/// `Connection: close`, after which the connection task returns and the
-/// boxed [`DemuxStream`] is dropped. For a plain `TcpStream` that's fine —
-/// the kernel keeps queued bytes and flushes them on close. But the TLS
-/// path's stream is a `tokio_rustls::server::TlsStream`, which buffers
-/// *ciphertext* inside the rustls session: `write_all` only guarantees the
-/// plaintext was accepted into that buffer, not that the encrypted records
-/// reached the socket. Dropping the `TlsStream` without flushing discards
-/// the unwritten tail records, truncating large bodies (e.g. the ~871 KB
+/// Reads serve the `replay` buffer first — the request loop pushes each
+/// follow-up request's already-captured segment there so dispatch (and a
+/// WebSocket upgrade arriving on a kept-alive connection) see the request
+/// from byte zero, exactly as the first request is delivered (kernel
+/// buffer on the plain path, `PrefixedStream` on TLS). Writes delegate
+/// straight to the inner stream.
+pub(crate) struct DemuxStream {
+    inner: std::pin::Pin<Box<dyn AsyncReadWrite>>,
+    replay: Vec<u8>,
+    replay_pos: usize,
+    /// Request leg of the keep-alive verdict (client headers + loop
+    /// budget + segment framing); set by the request loop per request.
+    client_allows_reuse: bool,
+    /// Body leg: the request body was provably consumed in full; set by
+    /// dispatch, reset by [`Self::begin_request`]. Fail-closed default.
+    request_consumed: bool,
+    /// Give-back channel to the request loop: a write edge that finished
+    /// a self-framing response on a reusable exchange parks the stream
+    /// here instead of closing it. `Weak` — only the connection task
+    /// holds the slot strongly, so unarmed streams (handler test
+    /// fixtures, one-shot tools) fail closed to the historical
+    /// write-then-finalize behavior.
+    parked: std::sync::Weak<Mutex<Option<DemuxStream>>>,
+}
+
+/// The request loop's strong handle to the keep-alive give-back slot.
+pub(crate) type ParkedStreamSlot = Arc<Mutex<Option<DemuxStream>>>;
+
+impl DemuxStream {
+    /// Wrap a demuxed transport. Keep-alive starts disarmed: every write
+    /// edge behaves exactly like the historical close-per-request server
+    /// until the request loop arms the slot and begins a request.
+    pub(crate) fn new(inner: std::pin::Pin<Box<dyn AsyncReadWrite>>) -> Self {
+        Self {
+            inner,
+            replay: Vec::new(),
+            replay_pos: 0,
+            client_allows_reuse: false,
+            request_consumed: false,
+            parked: std::sync::Weak::new(),
+        }
+    }
+
+    pub(crate) fn new_parked_slot() -> ParkedStreamSlot {
+        Arc::new(Mutex::new(None))
+    }
+
+    pub(crate) fn arm_keep_alive(&mut self, slot: &ParkedStreamSlot) {
+        self.parked = Arc::downgrade(slot);
+    }
+
+    /// Begin one request/response exchange: record the request leg's
+    /// verdict and reset the body leg (fail-closed until dispatch proves
+    /// the body was consumed).
+    pub(crate) fn begin_request(&mut self, client_allows_reuse: bool) {
+        self.client_allows_reuse = client_allows_reuse;
+        self.request_consumed = false;
+    }
+
+    /// Body leg: dispatch proved this request's body is fully consumed
+    /// (or that there was none to consume).
+    pub(crate) fn mark_request_body_consumed(&mut self) {
+        self.request_consumed = true;
+    }
+
+    /// The verdict a write edge consults before opting in: park (and
+    /// emit `Connection: keep-alive`) only when the request leg, the
+    /// body leg, and a live loop slot all agree. Anything else — and
+    /// every write edge that never asks — closes.
+    pub(crate) fn exchange_reusable(&self) -> bool {
+        self.client_allows_reuse && self.request_consumed && self.parked.strong_count() > 0
+    }
+
+    /// Serve `segment` to readers before the socket (the request loop's
+    /// captured next-request head + any body prefix read with it).
+    pub(crate) fn push_replay(&mut self, segment: &[u8]) {
+        // The previous request drained its replay in full (dispatch
+        // consumes exactly the segment it was handed), so this replaces
+        // rather than appends.
+        debug_assert!(self.replay_pos >= self.replay.len());
+        self.replay = segment.to_vec();
+        self.replay_pos = 0;
+    }
+
+    /// Response-leg opt-in: flush this exchange's response through to
+    /// the socket — rustls buffers ciphertext, so this is the flush half
+    /// of the [`finalize_http_stream`] contract applied per response —
+    /// then hand the stream back to the request loop for the next
+    /// request. Falls back to a clean close when the flush fails or the
+    /// loop is gone (unarmed slot / dead task).
+    pub(crate) async fn park(mut self) {
+        use tokio::io::AsyncWriteExt;
+        if self.flush().await.is_err() {
+            let _ = self.shutdown().await;
+            return;
+        }
+        let Some(slot) = self.parked.upgrade() else {
+            let _ = self.shutdown().await;
+            return;
+        };
+        *slot.lock().unwrap_or_else(|e| e.into_inner()) = Some(self);
+    }
+}
+
+impl AsyncRead for DemuxStream {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let this = self.get_mut();
+        if this.replay_pos < this.replay.len() {
+            let remaining = &this.replay[this.replay_pos..];
+            let n = remaining.len().min(buf.remaining());
+            buf.put_slice(&remaining[..n]);
+            this.replay_pos += n;
+            // Serve only replay bytes on this poll (same shape as
+            // web_tls::PrefixedStream); the next read drains the inner
+            // stream.
+            return std::task::Poll::Ready(Ok(()));
+        }
+        this.inner.as_mut().poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for DemuxStream {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        self.get_mut().inner.as_mut().poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        self.get_mut().inner.as_mut().poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        self.get_mut().inner.as_mut().poll_shutdown(cx)
+    }
+
+    fn poll_write_vectored(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        self.get_mut().inner.as_mut().poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+}
+
+/// Finalize an HTTP connection before its stream drops: flush, then shut
+/// down cleanly.
+///
+/// The flush matters because the TLS path's stream is a
+/// `tokio_rustls::server::TlsStream`, which buffers *ciphertext* inside
+/// the rustls session: `write_all` only guarantees the plaintext was
+/// accepted into that buffer, not that the encrypted records reached the
+/// socket. Dropping the `TlsStream` without flushing discards the
+/// unwritten tail records, truncating large bodies (e.g. the ~871 KB
 /// `app.html` arrived ~19.5 KB short over HTTPS).
 ///
 /// Calling `flush` drives rustls to emit all buffered ciphertext to the
 /// TCP socket; `shutdown` then writes the TLS `close_notify` and the TCP
 /// FIN, closing the session cleanly. On the plain path both delegate
 /// straight through to the `TcpStream` (flush is a no-op, shutdown sends
-/// the FIN we'd send on drop anyway), so behavior there is unchanged.
+/// the FIN we'd send on drop anyway).
+///
+/// With HTTP/1.1 keep-alive this runs at CONNECTION end — after the last
+/// exchange of a kept-alive connection, or immediately after a
+/// `Connection: close` exchange (the historical one-shot shape). Between
+/// kept-alive exchanges the flush half runs per response inside
+/// [`DemuxStream::park`], so a parked response always reaches the client
+/// before the loop waits for the next request.
 pub(crate) async fn finalize_http_stream(stream: &mut DemuxStream) {
     use tokio::io::AsyncWriteExt;
     let _ = stream.flush().await;
@@ -455,6 +622,32 @@ impl HttpResponse {
         self.header("Access-Control-Allow-Origin", "*")
     }
 
+    /// Set this response's connection tail from the exchange's keep-alive
+    /// verdict. A close verdict keeps the historical bytes exactly: an
+    /// existing `Connection` header (every legacy shape bakes `close`) is
+    /// left untouched, and `Connection: close` is appended only when
+    /// absent. A keep-alive verdict replaces any baked tail with
+    /// `Connection: keep-alive` + `Keep-Alive: timeout=N` — emitted only
+    /// by write edges that will actually park the connection (see the
+    /// `keep_alive` module docs).
+    pub(crate) fn connection_reuse(mut self, keep_alive: bool) -> Self {
+        if keep_alive {
+            self.headers.retain(|(name, _)| {
+                !name.eq_ignore_ascii_case("connection") && !name.eq_ignore_ascii_case("keep-alive")
+            });
+            self.header("Connection", "keep-alive")
+                .header("Keep-Alive", keep_alive_header_value())
+        } else if self
+            .headers
+            .iter()
+            .any(|(name, _)| name.eq_ignore_ascii_case("connection"))
+        {
+            self
+        } else {
+            self.header("Connection", "close")
+        }
+    }
+
     /// Fleet-allowlist CORS posture: strip any wildcard, echo the origin
     /// only when it passed the allowlist, and mark `Vary: Origin`. The
     /// one fleet renderer (its string-form ancestor retired with the S6
@@ -839,6 +1032,82 @@ mod tests {
              \r\n\
              {}"
         );
+    }
+
+    #[test]
+    fn connection_reuse_close_is_byte_identical_to_legacy_shapes() {
+        // Close verdict on a shape that bakes `Connection: close`
+        // (every legacy helper): a strict no-op.
+        assert_eq!(
+            HttpResponse::json("200 OK", "{}")
+                .connection_reuse(false)
+                .into_string(),
+            json_response("200 OK", "{}".to_string())
+        );
+        // Close verdict on a shape with no Connection header: one is
+        // appended so the client knows not to reuse.
+        let bare = HttpResponse::with_content("200 OK", "text/plain", "x")
+            .connection_reuse(false)
+            .into_string();
+        assert!(bare.contains("Connection: close\r\n"), "{bare}");
+    }
+
+    #[test]
+    fn connection_reuse_keep_alive_replaces_baked_close() {
+        let text = HttpResponse::json("200 OK", "{}")
+            .connection_reuse(true)
+            .into_string();
+        assert!(!text.contains("Connection: close"), "{text}");
+        assert!(text.contains("Connection: keep-alive\r\n"), "{text}");
+        assert!(
+            text.contains(&format!("Keep-Alive: timeout={KEEP_ALIVE_IDLE_SECS}\r\n")),
+            "{text}"
+        );
+        assert_eq!(text.matches("Connection").count(), 1, "{text}");
+    }
+
+    #[tokio::test]
+    async fn demux_stream_defaults_fail_closed_and_replay_serves_first() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let (mut client, server) = tokio::io::duplex(1024);
+        let mut stream = DemuxStream::new(Box::pin(server));
+        // Fail-closed defaults: no verdict, no armed slot.
+        assert!(!stream.exchange_reusable());
+        stream.begin_request(true);
+        stream.mark_request_body_consumed();
+        // Still not reusable: the parked slot was never armed (the
+        // fixture / one-shot shape), so a park would just close.
+        assert!(!stream.exchange_reusable());
+        let slot = DemuxStream::new_parked_slot();
+        stream.arm_keep_alive(&slot);
+        assert!(stream.exchange_reusable());
+        // begin_request resets the body leg (fail-closed per request).
+        stream.begin_request(true);
+        assert!(!stream.exchange_reusable());
+
+        // Replay bytes are served before the transport's own bytes.
+        client.write_all(b"tail").await.unwrap();
+        stream.push_replay(b"head ");
+        let mut got = [0u8; 9];
+        stream.read_exact(&mut got).await.unwrap();
+        assert_eq!(&got, b"head tail");
+    }
+
+    #[tokio::test]
+    async fn demux_stream_park_hands_the_stream_back_through_the_slot() {
+        let (_client, server) = tokio::io::duplex(64);
+        let mut stream = DemuxStream::new(Box::pin(server));
+        let slot = DemuxStream::new_parked_slot();
+        stream.arm_keep_alive(&slot);
+        stream.begin_request(true);
+        stream.mark_request_body_consumed();
+        stream.park().await;
+        let parked = slot
+            .lock()
+            .unwrap()
+            .take()
+            .expect("park() must hand the stream back through the slot");
+        drop(parked);
     }
 
     #[tokio::test]

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -93,6 +93,15 @@ pub(crate) async fn serve_http_request(
     use tokio::io::AsyncReadExt;
     let _ = stream.read_exact(&mut discard).await;
 
+    // Keep-alive body leg (see the keep_alive module): a request with
+    // no body at all is trivially "fully consumed". Everything below
+    // that DOES read a body under a declared policy upgrades the mark
+    // itself; handlers that drive the stream (BodyPolicy::Streaming)
+    // never do, so their exchanges always close.
+    if request_is_bodyless(header_text) {
+        stream.mark_request_body_consumed();
+    }
+
     // Parse the request target once: the static-asset arms
     // below match on the *exact* path (query stripped), so
     // an API request that merely mentions an asset path in
@@ -154,12 +163,10 @@ pub(crate) async fn serve_http_request(
                     )
                     .header("Access-Control-Max-Age", "86400")
                     .header("Vary", "Origin")
-                    .header("Connection", "close")
-                    .into_string(),
+                    .header("Connection", "close"),
                 None => HttpResponse::new("204 No Content")
                     .header("Vary", "Origin")
-                    .header("Connection", "close")
-                    .into_string(),
+                    .header("Connection", "close"),
             }
         } else if fleet_scoped {
             let methods = table_methods.as_deref().unwrap_or("GET, POST, OPTIONS");
@@ -183,12 +190,10 @@ pub(crate) async fn serve_http_request(
                     )
                     .header("Access-Control-Max-Age", "86400")
                     .header("Vary", "Origin")
-                    .header("Connection", "close")
-                    .into_string(),
+                    .header("Connection", "close"),
                 None => HttpResponse::new("204 No Content")
                     .header("Vary", "Origin")
-                    .header("Connection", "close")
-                    .into_string(),
+                    .header("Connection", "close"),
             }
         } else {
             let methods = table_methods
@@ -203,10 +208,19 @@ pub(crate) async fn serve_http_request(
                 )
                 .header("Access-Control-Max-Age", "86400")
                 .header("Connection", "close")
-                .into_string()
         };
-        let _ = stream.write_all(response.as_bytes()).await;
-        finalize_http_stream(&mut stream).await;
+        // Preflights participate in keep-alive (204: self-framing, no
+        // body): browsers send the actual request right behind the
+        // preflight, so closing here would double every cross-origin
+        // API call's connection count.
+        let reuse = stream.exchange_reusable();
+        let response = response.connection_reuse(reuse).into_string();
+        let write_ok = stream.write_all(response.as_bytes()).await.is_ok();
+        if reuse && write_ok {
+            stream.park().await;
+        } else {
+            finalize_http_stream(&mut stream).await;
+        }
         return;
     }
 
@@ -379,6 +393,14 @@ pub(crate) async fn serve_http_request(
         }
     }
 
+    // Keep-alive response leg for the fall-through chain below: set by
+    // each participating arm after it wrote a self-framing response
+    // under a reusable exchange; the common tail parks instead of
+    // finalizing when it's set. Arms that never set it — the connect
+    // signaling lane, and any arm added without thinking about
+    // keep-alive — fail safe to the historical close.
+    let mut parked_ok = false;
+
     if let Some((route, route_captures)) = crate::gateway_routes::match_route(req_method, req_path)
     {
         // Table-dispatched routes: every /api/* and /mcp route is
@@ -408,7 +430,25 @@ pub(crate) async fn serve_http_request(
                     _ => crate::gateway_routes::DEFAULT_BODY_CAP_BYTES,
                 };
                 match read_request_body_capped(&mut stream, header_text, cap).await {
-                    Ok(body) => body,
+                    Ok(body) => {
+                        // Keep-alive body leg: dispatch consumed exactly
+                        // the declared body (`read_request_body_capped`
+                        // reads Content-Length bytes), so the exchange
+                        // stays reusable — provided the framing was
+                        // unambiguous (one consistent Content-Length, no
+                        // Transfer-Encoding) AND the captured segment was
+                        // valid UTF-8. The reader does its peeked-body
+                        // accounting on the LOSSY header string; invalid
+                        // bytes inflate to U+FFFD there, skewing the
+                        // byte math and potentially leaving residue in
+                        // the socket — fail toward close in that case.
+                        if request_body_is_delimited(header_text)
+                            && std::str::from_utf8(&discard).is_ok()
+                        {
+                            stream.mark_request_body_consumed();
+                        }
+                        body
+                    }
                     Err((status, body)) => {
                         use tokio::io::AsyncWriteExt;
                         let base = HttpResponse::json(status_reason(status), body);
@@ -1132,7 +1172,10 @@ pub(crate) async fn serve_http_request(
             }
             _ => base,
         };
-        let _ = stream.write_all(&response.into_bytes()).await;
+        let reuse = stream.exchange_reusable();
+        let response = response.connection_reuse(reuse);
+        let write_ok = stream.write_all(&response.into_bytes()).await.is_ok();
+        parked_ok = reuse && write_ok;
     } else if req_method == "GET" && req_path == "/connect/bootstrap" {
         use tokio::io::AsyncWriteExt;
         let body = connect_bootstrap_html();
@@ -1225,15 +1268,18 @@ pub(crate) async fn serve_http_request(
             "/wasm-station/station_web_bg.wasm",
         ],
     ) {
+        let reuse = stream.exchange_reusable();
         let response = build_static_asset_response(
             req_method,
             header_text,
             req_query,
             asset_version(),
             asset.view(),
+            reuse,
         );
         use tokio::io::AsyncWriteExt;
-        let _ = stream.write_all(&response).await;
+        let write_ok = stream.write_all(&response).await.is_ok();
+        parked_ok = reuse && write_ok;
     } else if let Some(asset) = static_asset_arm(
         req_method,
         req_path,
@@ -1246,15 +1292,18 @@ pub(crate) async fn serve_http_request(
             "/manifest.webmanifest",
         ],
     ) {
+        let reuse = stream.exchange_reusable();
         let response = build_static_asset_response(
             req_method,
             header_text,
             req_query,
             asset_version(),
             asset.view(),
+            reuse,
         );
         use tokio::io::AsyncWriteExt;
-        let _ = stream.write_all(&response).await;
+        let write_ok = stream.write_all(&response).await.is_ok();
+        parked_ok = reuse && write_ok;
     } else if req_path.starts_with("/frames/") {
         // Serve HQ frame images from the frame registry.
         // URL format: /frames/<frame_id> (not /api/session/*/frames/*)
@@ -1287,11 +1336,14 @@ pub(crate) async fn serve_http_request(
                 serde_json::json!({"error": msg}).to_string(),
             ),
         };
+        let reuse = stream.exchange_reusable();
         let response = HttpResponse::with_content(status, "application/json", body)
             .header("Connection", "close")
+            .connection_reuse(reuse)
             .into_string();
         use tokio::io::AsyncWriteExt;
-        let _ = stream.write_all(response.as_bytes()).await;
+        let write_ok = stream.write_all(response.as_bytes()).await.is_ok();
+        parked_ok = reuse && write_ok;
     } else if req_path.starts_with("/recordings/") {
         // Serve recording data: segment files and metadata. Path routing
         // (verbatim post-"/recordings/" token, historically including any
@@ -1350,20 +1402,26 @@ pub(crate) async fn serve_http_request(
             "active_connection_id": active_id,
         })
         .to_string();
+        let reuse = stream.exchange_reusable();
         let response = HttpResponse::with_content("200 OK", "application/json", debug_json)
             .header("Connection", "close")
+            .connection_reuse(reuse)
             .into_string();
         use tokio::io::AsyncWriteExt;
-        let _ = stream.write_all(response.as_bytes()).await;
+        let write_ok = stream.write_all(response.as_bytes()).await.is_ok();
+        parked_ok = reuse && write_ok;
     } else if let Some(response) = dashboard_local_file_response_blocking(request_line).await {
         use tokio::io::AsyncWriteExt;
+        let reuse = stream.exchange_reusable();
         match response {
             DashboardLocalFileResponse::Html { status, body } => {
                 let response = HttpResponse::with_content(status, "text/html; charset=utf-8", body)
                     .header("Cache-Control", "no-cache")
                     .header("Connection", "close")
+                    .connection_reuse(reuse)
                     .into_string();
-                let _ = stream.write_all(response.as_bytes()).await;
+                let write_ok = stream.write_all(response.as_bytes()).await.is_ok();
+                parked_ok = reuse && write_ok;
             }
             DashboardLocalFileResponse::Bytes {
                 status,
@@ -1376,9 +1434,11 @@ pub(crate) async fn serve_http_request(
                     .header("Cache-Control", "no-cache")
                     .header("X-Content-Type-Options", "nosniff")
                     .header("Connection", "close")
+                    .connection_reuse(reuse)
                     .into_string();
-                let _ = stream.write_all(header.as_bytes()).await;
-                let _ = stream.write_all(&bytes).await;
+                let head_ok = stream.write_all(header.as_bytes()).await.is_ok();
+                let body_ok = stream.write_all(&bytes).await.is_ok();
+                parked_ok = reuse && head_ok && body_ok;
             }
         }
     } else if let Some(asset) = static_asset_arm(req_method, req_path, &["/vault-kernel.js"]) {
@@ -1387,10 +1447,11 @@ pub(crate) async fn serve_http_request(
         // binary) always matches. Under the INTENDANT_APP_HTML_PATH dev
         // override the disk sibling wins instead: the overridden app.html
         // pins THAT file's hash.
+        let reuse = stream.exchange_reusable();
         let response = app_html_override
             .as_deref()
             .and_then(|path| {
-                vault_kernel_override_response(req_method, header_text, req_query, path)
+                vault_kernel_override_response(req_method, header_text, req_query, path, reuse)
             })
             .unwrap_or_else(|| {
                 build_static_asset_response(
@@ -1399,10 +1460,12 @@ pub(crate) async fn serve_http_request(
                     req_query,
                     asset_version(),
                     asset.view(),
+                    reuse,
                 )
             });
         use tokio::io::AsyncWriteExt;
-        let _ = stream.write_all(&response).await;
+        let write_ok = stream.write_all(&response).await.is_ok();
+        parked_ok = reuse && write_ok;
     } else if let Some(asset) = static_asset_arm(
         req_method,
         req_path,
@@ -1429,15 +1492,18 @@ pub(crate) async fn serve_http_request(
             "/manifest.webmanifest",
         ],
     ) {
+        let reuse = stream.exchange_reusable();
         let response = build_static_asset_response(
             req_method,
             header_text,
             req_query,
             asset_version(),
             asset.view(),
+            reuse,
         );
         use tokio::io::AsyncWriteExt;
-        let _ = stream.write_all(&response).await;
+        let write_ok = stream.write_all(&response).await.is_ok();
+        parked_ok = reuse && write_ok;
     } else if req_path == "/.well-known/agent-card.json" || req_path == "/config" {
         let body = if req_path == "/.well-known/agent-card.json" {
             // Canonical peer identity + capability surface.
@@ -1453,13 +1519,16 @@ pub(crate) async fn serve_http_request(
         // on this daemon from a page served by a sibling
         // daemon (cross-origin). `*` works because our
         // fetches don't send credentials.
+        let reuse = stream.exchange_reusable();
         let response = HttpResponse::with_content("200 OK", "application/json", body)
             .header("Cache-Control", "no-cache")
             .header("Access-Control-Allow-Origin", "*")
             .header("Connection", "close")
+            .connection_reuse(reuse)
             .into_string();
         use tokio::io::AsyncWriteExt;
-        let _ = stream.write_all(response.as_bytes()).await;
+        let write_ok = stream.write_all(response.as_bytes()).await.is_ok();
+        parked_ok = reuse && write_ok;
     } else if req_method == "GET" || req_method == "HEAD" {
         // Default: serve app.html (also matches /app for
         // backward compat). The entry point stays no-cache —
@@ -1470,8 +1539,9 @@ pub(crate) async fn serve_http_request(
         // unlike the constants behind `embedded_static_asset`.
         // Under INTENDANT_APP_HTML_PATH the disk copy is
         // re-read (and re-tagged) on every request instead.
+        let reuse = stream.exchange_reusable();
         let response = if let Some(path) = app_html_override.as_deref() {
-            app_html_override_response(req_method, header_text, req_query, path)
+            app_html_override_response(req_method, header_text, req_query, path, reuse)
         } else {
             let (etag, gzip) = app_html_cache.get_or_init(|| {
                 (
@@ -1491,10 +1561,12 @@ pub(crate) async fn serve_http_request(
                     gzip: Some(gzip),
                     cache_control: Some("no-cache"),
                 },
+                reuse,
             )
         };
         use tokio::io::AsyncWriteExt;
-        let _ = stream.write_all(&response).await;
+        let write_ok = stream.write_all(&response).await.is_ok();
+        parked_ok = reuse && write_ok;
     } else {
         // Non-GET/HEAD fallback: plain app.html, as before.
         let response =
@@ -1507,16 +1579,21 @@ pub(crate) async fn serve_http_request(
         let _ = stream.write_all(response.as_bytes()).await;
     }
 
-    // Flush + cleanly shut down the stream before this task
-    // returns and drops it. Mandatory for the TLS path so the
-    // final ciphertext records reach the socket (rustls buffers
-    // them; dropping mid-buffer truncates large bodies); a
-    // harmless pass-through on plain TCP. Covers every
-    // fall-through chain arm above in one place; the early
-    // `return`s (OPTIONS / failed federation auth) finalize
-    // inline before returning, and every table-dispatched
-    // handler owns its stream and finalizes it itself.
-    finalize_http_stream(&mut stream).await;
+    // Connection tail for every fall-through chain arm above, in one
+    // place: a participating arm that wrote a self-framing response
+    // under a reusable exchange set `parked_ok`, so the stream goes back
+    // to the listener's request loop (park flushes per response — the
+    // TLS-ciphertext rationale on `finalize_http_stream`). Everything
+    // else — non-participating arms, failed writes, close verdicts —
+    // flushes and cleanly shuts down exactly as before. The early
+    // `return`s (OPTIONS / failed gates / body-cap errors) finish
+    // inline, and every table-dispatched handler owns its stream and
+    // parks or finalizes it itself.
+    if parked_ok {
+        stream.park().await;
+    } else {
+        finalize_http_stream(&mut stream).await;
+    }
 }
 
 /// HTTP adapter for the transport-neutral core (transport-unification
@@ -1613,10 +1690,17 @@ pub(crate) fn stream_response_http_head(
     apply_cors_posture(http, cors, fleet_origin).into_bytes()
 }
 
-/// Write an [`ApiResponse`] to the HTTP lane and finalize the stream —
+/// Write an [`ApiResponse`] to the HTTP lane and finish the exchange —
 /// the whole tail of a converted handler shim. The Stream lane writes
 /// its head then pumps the shared line source until it drains (or the
 /// client hangs up); buffered lanes render in one piece.
+///
+/// Keep-alive: buffered lanes are self-framing (`with_content` always
+/// emits `Content-Length`), so under a reusable exchange the baked
+/// `Connection: close` tail is rewritten to keep-alive and the stream is
+/// parked back to the request loop instead of finalized. The Stream lane
+/// NEVER parks — its body is EOF-delimited by design (`Connection:
+/// close` is pinned in its golden head), so it always finalizes.
 pub(crate) async fn write_api_response(
     mut stream: DemuxStream,
     response: ApiResponse,
@@ -1650,13 +1734,28 @@ pub(crate) async fn write_api_response(
             // finishes instead of deadlocking the join.
             drop(line_rx);
             let _ = source.await;
+            finalize_http_stream(&mut stream).await;
         }
-        buffered => {
+        mut buffered => {
+            let keep = stream.exchange_reusable();
+            if keep {
+                match &mut buffered {
+                    ApiResponse::Json { headers, .. } | ApiResponse::Bytes { headers, .. } => {
+                        apply_keep_alive_header_tail(headers);
+                    }
+                    // The outer match already bound the Stream lane.
+                    ApiResponse::Stream { .. } => {}
+                }
+            }
             let bytes = api_response_http_bytes(buffered, cors, fleet_origin);
-            let _ = stream.write_all(&bytes).await;
+            let write_ok = stream.write_all(&bytes).await.is_ok();
+            if keep && write_ok {
+                stream.park().await;
+            } else {
+                finalize_http_stream(&mut stream).await;
+            }
         }
     }
-    finalize_http_stream(&mut stream).await;
 }
 
 #[cfg(test)]

--- a/src/bin/caller/web_gateway/keep_alive.rs
+++ b/src/bin/caller/web_gateway/keep_alive.rs
@@ -1,0 +1,453 @@
+//! HTTP/1.1 keep-alive: the reusability decision table and the
+//! between-requests head reader for the gateway's per-connection request
+//! loop (`spawn_web_gateway`'s accept task).
+//!
+//! The gateway historically closed the connection after every response
+//! (`Connection: close` on all of them), so a cold dashboard load paid a
+//! TCP+TLS handshake per asset (~16 measured). The request loop reuses
+//! the connection instead — under rules that FAIL TOWARD CLOSE, because
+//! a wrongly kept-alive connection risks protocol corruption (response
+//! bytes mistaken for the next response, request residue parsed as the
+//! next request) while a wrongly closed one only costs a handshake.
+//!
+//! The decision has three independent legs, all of which must pass
+//! before a connection is parked for reuse:
+//!
+//! 1. **Request leg** ([`request_allows_keep_alive`] + the loop's
+//!    request budget + [`segment_is_single_request`]): the client's
+//!    HTTP version and `Connection` tokens permit reuse, the
+//!    per-connection request cap isn't exhausted, and the captured
+//!    request segment carries no pipelined surplus (the head read
+//!    consumes the whole segment, so surplus bytes would be lost —
+//!    closing makes the client resend them, exactly as the
+//!    close-per-request server always did).
+//! 2. **Body leg** ([`DemuxStream::mark_request_body_consumed`], set by
+//!    dispatch): the request body was provably consumed in full — no
+//!    body at all ([`request_is_bodyless`]), or a table route whose
+//!    declared `BodyPolicy` had dispatch read exactly `Content-Length`
+//!    bytes ([`request_body_is_delimited`] guarding the mark).
+//!    `BodyPolicy::Streaming` routes (uploads, transfer chunks, the
+//!    doorbell) never set the mark: their handlers drive the stream
+//!    themselves and may stop mid-body on errors.
+//! 3. **Response leg** (the write edges): only writers that emit
+//!    self-framing responses — a `Content-Length` header, or a
+//!    body-less status (204/304) — opt in, by parking the stream via
+//!    [`DemuxStream::park`] instead of finalizing it. Streaming writers
+//!    (the sessions/search NDJSON lanes, `100 Continue` upload flows,
+//!    hand-rolled multi-write handlers) never park, so an unenumerated
+//!    streaming path fails safe to close, never to corruption.
+//!
+//! The `Connection` response header is derived from the same verdict at
+//! the write edge ([`super::HttpResponse::connection_reuse`],
+//! [`apply_keep_alive_header_tail`]): `keep-alive` + `Keep-Alive:
+//! timeout=N` exactly when the stream will actually be parked, else the
+//! historical `Connection: close`, byte-identical.
+//!
+//! h2 note: ALPN stays pinned to `http/1.1` (`web_tls.rs`); this module
+//! is deliberately HTTP/1.1-only. HTTP/2 would be a server-stack
+//! migration (a different program), not an extension of this loop.
+
+/// Idle seconds the request loop waits between kept-alive requests, and
+/// the value advertised in `Keep-Alive: timeout=N`. Bounds how long an
+/// idle browser pins a connection task; browsers reuse well inside it.
+pub(crate) const KEEP_ALIVE_IDLE_SECS: u64 = 30;
+
+/// Requests served on one connection before the loop stops offering
+/// keep-alive (the final response says `Connection: close`). Bounds
+/// resource pinning by a single pathological client; a page load is a
+/// couple dozen requests, so real dashboards never hit it.
+pub(crate) const KEEP_ALIVE_MAX_REQUESTS: u32 = 500;
+
+/// Cap on a follow-up request head (status line + headers). The first
+/// request is bounded by the demux peek/first-read buffer; this bounds
+/// the loop's accumulating reader the same order of magnitude.
+pub(crate) const NEXT_REQUEST_HEAD_CAP_BYTES: usize = 16 * 1024;
+
+/// The `Keep-Alive` response header value matching the loop's idle
+/// timeout.
+pub(crate) fn keep_alive_header_value() -> String {
+    format!("timeout={KEEP_ALIVE_IDLE_SECS}")
+}
+
+/// Request leg: whether the client's request line + `Connection` tokens
+/// permit reuse. HTTP/1.1 defaults to keep-alive unless a `close` token
+/// is present; HTTP/1.0 requires an explicit `keep-alive` token; any
+/// other (or unparseable) version fails toward close. `Connection` is a
+/// comma-separated token list and may repeat; a `close` token anywhere
+/// wins.
+pub(crate) fn request_allows_keep_alive(header_text: &str) -> bool {
+    let request_line = header_text.lines().next().unwrap_or("");
+    let version = request_line.split_whitespace().nth(2).unwrap_or("");
+    let mut close_token = false;
+    let mut keep_alive_token = false;
+    for line in header_text.lines().skip(1) {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if !name.trim().eq_ignore_ascii_case("connection") {
+            continue;
+        }
+        for token in value.split(',') {
+            let token = token.trim();
+            if token.eq_ignore_ascii_case("close") {
+                close_token = true;
+            } else if token.eq_ignore_ascii_case("keep-alive") {
+                keep_alive_token = true;
+            }
+        }
+    }
+    match version {
+        "HTTP/1.1" => !close_token,
+        "HTTP/1.0" => keep_alive_token && !close_token,
+        _ => false,
+    }
+}
+
+/// Whether any `Transfer-Encoding` header is present. The gateway never
+/// parses transfer-encoded (chunked) request bodies — such a body can't
+/// be delimited, so the exchange must close.
+fn has_transfer_encoding(header_text: &str) -> bool {
+    header_text.lines().skip(1).any(|line| {
+        line.split_once(':')
+            .is_some_and(|(name, _)| name.trim().eq_ignore_ascii_case("transfer-encoding"))
+    })
+}
+
+/// Strict `Content-Length`: `Ok(0)` when absent, `Ok(n)` when every
+/// `Content-Length` header parses to the same `n`, `Err(())` on any
+/// invalid or conflicting value (fail toward close — a request whose
+/// body we can't delimit with certainty must not share a connection).
+fn parsed_content_length(header_text: &str) -> Result<usize, ()> {
+    let mut seen: Option<usize> = None;
+    for line in header_text.lines().skip(1) {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if !name.trim().eq_ignore_ascii_case("content-length") {
+            continue;
+        }
+        let parsed: usize = value.trim().parse().map_err(|_| ())?;
+        match seen {
+            Some(existing) if existing != parsed => return Err(()),
+            _ => seen = Some(parsed),
+        }
+    }
+    Ok(seen.unwrap_or(0))
+}
+
+/// Body leg, well-formedness half: the request's body (possibly empty)
+/// is delimitable by our reader — no `Transfer-Encoding`, and a single
+/// consistent `Content-Length` (or none). Guards the dispatch-side
+/// consumed mark: `read_request_body_capped` reads by the first
+/// `Content-Length` it finds, so the mark is only sound when the strict
+/// parse agrees the request means what that reader read.
+pub(crate) fn request_body_is_delimited(header_text: &str) -> bool {
+    !has_transfer_encoding(header_text) && parsed_content_length(header_text).is_ok()
+}
+
+/// Body leg, trivial half: the request provably has no body at all.
+/// True for the whole static/GET surface; the chain arms and
+/// `BodyPolicy::None` routes use this as their consumed mark.
+pub(crate) fn request_is_bodyless(header_text: &str) -> bool {
+    !has_transfer_encoding(header_text) && parsed_content_length(header_text) == Ok(0)
+}
+
+/// Request leg, framing half: the captured segment (head + any body
+/// prefix the transport read along with it) contains exactly one
+/// request — a complete head and no bytes beyond `Content-Length`.
+/// Pipelined surplus fails toward close: the head read consumed the
+/// segment wholesale, so the surplus can't be replayed to the next
+/// loop iteration; answering `Connection: close` makes the client
+/// resend the surplus request on a fresh connection, which is exactly
+/// the close-per-request behavior this loop replaced.
+pub(crate) fn segment_is_single_request(segment: &[u8]) -> bool {
+    let Some(head_end) = segment.windows(4).position(|w| w == b"\r\n\r\n") else {
+        // Incomplete head in the captured segment: the request is
+        // arriving fragmented and body accounting below would be
+        // guesswork.
+        return false;
+    };
+    let head_text = String::from_utf8_lossy(&segment[..head_end + 4]);
+    if has_transfer_encoding(&head_text) {
+        return false;
+    }
+    let Ok(content_length) = parsed_content_length(&head_text) else {
+        return false;
+    };
+    // The body may extend past the segment (the rest is still in the
+    // socket, and the capped body readers consume exactly the
+    // remainder); only bytes BEYOND head+body make the segment
+    // multi-request.
+    segment.len() <= head_end + 4 + content_length
+}
+
+/// Rewrite an [`ApiResponse`]-style header tail for a kept-alive
+/// exchange: drop any `Connection`/`Keep-Alive` entries the handler
+/// baked in (the historical `close`) and append the keep-alive pair.
+/// Close-path responses never come through here — their tails render
+/// untouched, byte-identical to the pinned goldens.
+pub(crate) fn apply_keep_alive_header_tail(headers: &mut Vec<(&'static str, String)>) {
+    headers.retain(|(name, _)| {
+        !name.eq_ignore_ascii_case("connection") && !name.eq_ignore_ascii_case("keep-alive")
+    });
+    headers.push(("Connection", "keep-alive".to_string()));
+    headers.push(("Keep-Alive", keep_alive_header_value()));
+}
+
+/// Read the next request's segment off a kept-alive connection: bytes
+/// up to and including the first `\r\n\r\n` (plus any body prefix that
+/// arrived in the same reads), bounded by the idle timeout and the head
+/// cap. `None` — clean EOF, timeout, oversize head, or a read error —
+/// means the connection is done and the caller finalizes it.
+pub(crate) async fn read_next_request_head<S: tokio::io::AsyncRead + Unpin>(
+    stream: &mut S,
+    idle_timeout: std::time::Duration,
+) -> Option<Vec<u8>> {
+    use tokio::io::AsyncReadExt;
+    tokio::time::timeout(idle_timeout, async {
+        let mut segment: Vec<u8> = Vec::new();
+        let mut chunk = [0u8; 2048];
+        loop {
+            let n = stream.read(&mut chunk).await.ok()?;
+            if n == 0 {
+                return None;
+            }
+            segment.extend_from_slice(&chunk[..n]);
+            if segment.windows(4).any(|w| w == b"\r\n\r\n") {
+                return Some(segment);
+            }
+            if segment.len() > NEXT_REQUEST_HEAD_CAP_BYTES {
+                return None;
+            }
+        }
+    })
+    .await
+    .ok()
+    .flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Request leg: version + Connection tokens ──
+
+    #[test]
+    fn http11_defaults_to_keep_alive() {
+        assert!(request_allows_keep_alive(
+            "GET /config HTTP/1.1\r\nHost: x\r\n\r\n"
+        ));
+    }
+
+    #[test]
+    fn http11_connection_close_closes() {
+        assert!(!request_allows_keep_alive(
+            "GET / HTTP/1.1\r\nConnection: close\r\n\r\n"
+        ));
+        // Case-insensitive header name and token.
+        assert!(!request_allows_keep_alive(
+            "GET / HTTP/1.1\r\nCONNECTION: Close\r\n\r\n"
+        ));
+        // `close` anywhere in a token list wins.
+        assert!(!request_allows_keep_alive(
+            "GET / HTTP/1.1\r\nConnection: keep-alive, close\r\n\r\n"
+        ));
+        // A second Connection header carrying close also wins.
+        assert!(!request_allows_keep_alive(
+            "GET / HTTP/1.1\r\nConnection: keep-alive\r\nConnection: close\r\n\r\n"
+        ));
+    }
+
+    #[test]
+    fn http11_unrelated_connection_tokens_keep_alive() {
+        // `Connection: Upgrade` (non-WS upgrades land here) is not close.
+        assert!(request_allows_keep_alive(
+            "GET / HTTP/1.1\r\nConnection: Upgrade\r\n\r\n"
+        ));
+    }
+
+    #[test]
+    fn http10_requires_explicit_keep_alive() {
+        assert!(!request_allows_keep_alive(
+            "GET / HTTP/1.0\r\nHost: x\r\n\r\n"
+        ));
+        assert!(request_allows_keep_alive(
+            "GET / HTTP/1.0\r\nConnection: Keep-Alive\r\n\r\n"
+        ));
+        assert!(!request_allows_keep_alive(
+            "GET / HTTP/1.0\r\nConnection: keep-alive, close\r\n\r\n"
+        ));
+    }
+
+    #[test]
+    fn unknown_or_missing_version_closes() {
+        assert!(!request_allows_keep_alive("GET / HTTP/2.0\r\n\r\n"));
+        assert!(!request_allows_keep_alive("GET /\r\n\r\n"));
+        assert!(!request_allows_keep_alive(""));
+        assert!(!request_allows_keep_alive("garbage\r\n\r\n"));
+    }
+
+    // ── Body leg: Content-Length / Transfer-Encoding ──
+
+    #[test]
+    fn bodyless_when_no_content_length() {
+        assert!(request_is_bodyless("GET / HTTP/1.1\r\nHost: x\r\n\r\n"));
+        assert!(request_is_bodyless(
+            "GET / HTTP/1.1\r\nContent-Length: 0\r\n\r\n"
+        ));
+    }
+
+    #[test]
+    fn body_present_or_undelimited_is_not_bodyless() {
+        assert!(!request_is_bodyless(
+            "POST / HTTP/1.1\r\nContent-Length: 12\r\n\r\n"
+        ));
+        assert!(!request_is_bodyless(
+            "POST / HTTP/1.1\r\nContent-Length: nope\r\n\r\n"
+        ));
+        assert!(!request_is_bodyless(
+            "POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n"
+        ));
+    }
+
+    #[test]
+    fn delimited_rejects_conflicts_and_transfer_encoding() {
+        assert!(request_body_is_delimited(
+            "POST / HTTP/1.1\r\nContent-Length: 5\r\n\r\n"
+        ));
+        // Duplicate-but-equal collapses (lenient like intermediaries).
+        assert!(request_body_is_delimited(
+            "POST / HTTP/1.1\r\nContent-Length: 5\r\nContent-Length: 5\r\n\r\n"
+        ));
+        assert!(!request_body_is_delimited(
+            "POST / HTTP/1.1\r\nContent-Length: 5\r\nContent-Length: 6\r\n\r\n"
+        ));
+        assert!(!request_body_is_delimited(
+            "POST / HTTP/1.1\r\nContent-Length: -1\r\n\r\n"
+        ));
+        // Smuggling shape: TE + CL together always closes.
+        assert!(!request_body_is_delimited(
+            "POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\nContent-Length: 5\r\n\r\n"
+        ));
+    }
+
+    // ── Request leg: single-request segment framing ──
+
+    #[test]
+    fn single_request_segment_shapes() {
+        // Bare GET, nothing after the head.
+        assert!(segment_is_single_request(
+            b"GET / HTTP/1.1\r\nHost: x\r\n\r\n"
+        ));
+        // POST whose body is partially (or fully) in the segment.
+        assert!(segment_is_single_request(
+            b"POST / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhel"
+        ));
+        assert!(segment_is_single_request(
+            b"POST / HTTP/1.1\r\nContent-Length: 5\r\n\r\nhello"
+        ));
+    }
+
+    #[test]
+    fn pipelined_or_malformed_segments_close() {
+        // A second pipelined request in the same segment.
+        assert!(!segment_is_single_request(
+            b"GET / HTTP/1.1\r\nHost: x\r\n\r\nGET /b HTTP/1.1\r\n\r\n"
+        ));
+        // Body overrun past Content-Length.
+        assert!(!segment_is_single_request(
+            b"POST / HTTP/1.1\r\nContent-Length: 2\r\n\r\nhello"
+        ));
+        // Incomplete head.
+        assert!(!segment_is_single_request(b"GET / HTTP/1.1\r\nHost: x"));
+        // Undelimitable bodies.
+        assert!(!segment_is_single_request(
+            b"POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n"
+        ));
+        assert!(!segment_is_single_request(
+            b"POST / HTTP/1.1\r\nContent-Length: x\r\n\r\n"
+        ));
+    }
+
+    // ── Header tail rewrite ──
+
+    #[test]
+    fn keep_alive_tail_replaces_baked_close() {
+        let mut headers = vec![
+            ("Cache-Control", "no-cache".to_string()),
+            ("Connection", "close".to_string()),
+        ];
+        apply_keep_alive_header_tail(&mut headers);
+        assert_eq!(
+            headers,
+            vec![
+                ("Cache-Control", "no-cache".to_string()),
+                ("Connection", "keep-alive".to_string()),
+                ("Keep-Alive", format!("timeout={KEEP_ALIVE_IDLE_SECS}")),
+            ]
+        );
+    }
+
+    #[test]
+    fn keep_alive_tail_appends_when_absent() {
+        let mut headers = vec![("Cache-Control", "no-store".to_string())];
+        apply_keep_alive_header_tail(&mut headers);
+        assert_eq!(headers[1].0, "Connection");
+        assert_eq!(headers[1].1, "keep-alive");
+        assert_eq!(headers[2].0, "Keep-Alive");
+    }
+
+    // ── Between-requests head reader ──
+
+    #[tokio::test]
+    async fn next_head_reads_across_fragmented_writes() {
+        let (mut client, mut server) = tokio::io::duplex(1024);
+        use tokio::io::AsyncWriteExt;
+        let writer = tokio::spawn(async move {
+            client.write_all(b"GET /a HTTP/1.1\r\n").await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            client.write_all(b"Host: x\r\n\r\n").await.unwrap();
+            client
+        });
+        let head = read_next_request_head(&mut server, std::time::Duration::from_secs(2))
+            .await
+            .expect("head");
+        assert_eq!(head, b"GET /a HTTP/1.1\r\nHost: x\r\n\r\n");
+        drop(writer.await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn next_head_none_on_eof_timeout_and_oversize() {
+        // Clean EOF (client hung up between requests).
+        let (client, mut server) = tokio::io::duplex(64);
+        drop(client);
+        assert!(
+            read_next_request_head(&mut server, std::time::Duration::from_secs(1))
+                .await
+                .is_none()
+        );
+
+        // Idle timeout: nothing ever arrives.
+        let (_client, mut server) = tokio::io::duplex(64);
+        assert!(
+            read_next_request_head(&mut server, std::time::Duration::from_millis(50))
+                .await
+                .is_none()
+        );
+
+        // Oversize head without a terminator.
+        let (mut client, mut server) = tokio::io::duplex(1 << 20);
+        use tokio::io::AsyncWriteExt;
+        let junk = vec![b'a'; NEXT_REQUEST_HEAD_CAP_BYTES + 4096];
+        let writer = tokio::spawn(async move {
+            let _ = client.write_all(&junk).await;
+            client
+        });
+        assert!(
+            read_next_request_head(&mut server, std::time::Duration::from_secs(2))
+                .await
+                .is_none()
+        );
+        drop(writer.await.unwrap());
+    }
+}

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -986,7 +986,6 @@ pub fn spawn_web_gateway(
                 }
 
                 let buf_owned: Vec<u8>;
-                let n: usize;
                 let mut stream: DemuxStream;
                 let tls_client_cert_present: bool;
                 let tls_client_cert_fingerprint: Option<String>;
@@ -1031,73 +1030,191 @@ pub fn spawn_web_gateway(
                         }
                     };
                     decrypted.truncate(read_n);
-                    n = read_n;
                     buf_owned = decrypted.clone();
                     // Replay the decrypted request head in front of the TLS
                     // stream so the WS upgrade / HTTP body reads downstream
                     // see the request from byte zero.
-                    stream = Box::pin(crate::web_tls::PrefixedStream::new(decrypted, tls_stream));
+                    stream = DemuxStream::new(Box::pin(crate::web_tls::PrefixedStream::new(
+                        decrypted, tls_stream,
+                    )));
                 } else {
                     // Plain HTTP/WS: the peeked bytes are still in the
                     // kernel buffer. Box the raw stream with an empty
                     // replay prefix — a zero-overhead pass-through that
                     // reads the request straight from the socket.
-                    n = peeked;
                     buf_owned = buf[..peeked].to_vec();
                     tls_client_cert_present = false;
                     tls_client_cert_fingerprint = None;
-                    stream = Box::pin(crate::web_tls::PrefixedStream::new(Vec::new(), raw_stream));
+                    stream = DemuxStream::new(Box::pin(crate::web_tls::PrefixedStream::new(
+                        Vec::new(),
+                        raw_stream,
+                    )));
                 }
-                // Downstream code reads `buf[..n]`; point `buf` at the
-                // (decrypted, for TLS) request head we just captured.
-                let buf = buf_owned.as_slice();
+                // ── HTTP/1.1 keep-alive request loop ─────────────────
+                // One accepted connection serves a sequence of requests:
+                // each iteration processes the request head captured in
+                // `head_segment` (request 1: the demux peek / first TLS
+                // read; request N+1: read back below after the previous
+                // response PARKED the stream instead of closing it).
+                // Identity, IAM context, and the origin gates are
+                // re-evaluated PER REQUEST inside `serve_http_request` —
+                // only transport facts (TLS-ness, the client-cert
+                // fingerprint, the peer address) are connection-scoped.
+                // The loop ends when a write edge closes instead of
+                // parking (the keep_alive module holds the decision
+                // table), when the idle timeout / request budget runs
+                // out, or when a WebSocket upgrade hands the whole
+                // connection off below.
+                let parked = DemuxStream::new_parked_slot();
+                stream.arm_keep_alive(&parked);
+                let mut served: u32 = 0;
+                let mut head_segment: Vec<u8> = buf_owned;
+                let (mut stream, header_text, peer_connection_identity, browser_host_ip) = loop {
+                    served += 1;
+                    let n = head_segment.len();
+                    let header_text = String::from_utf8_lossy(&head_segment).to_string();
+                    let peer_connection_identity = match resolve_peer_connection_identity(
+                        &header_text,
+                        tls_client_cert_fingerprint.as_deref(),
+                    ) {
+                        Ok(identity) => identity,
+                        Err((status, body)) => {
+                            use tokio::io::AsyncWriteExt;
+                            let reason = match status {
+                                401 => "Unauthorized",
+                                403 => "Forbidden",
+                                _ => "Error",
+                            };
+                            let response = HttpResponse::with_content(
+                                format!("{} {}", status, reason),
+                                "application/json",
+                                body,
+                            )
+                            .header("Cache-Control", "no-cache")
+                            .header("Connection", "close")
+                            .into_string();
+                            let _ = stream.write_all(response.as_bytes()).await;
+                            finalize_http_stream(&mut stream).await;
+                            return;
+                        }
+                    };
+                    let is_websocket = header_text
+                        .lines()
+                        .any(|l| l.to_lowercase().contains("upgrade: websocket"));
 
-                let header_text = String::from_utf8_lossy(&buf[..n]);
-                let peer_connection_identity = match resolve_peer_connection_identity(
-                    &header_text,
-                    tls_client_cert_fingerprint.as_deref(),
-                ) {
-                    Ok(identity) => identity,
-                    Err((status, body)) => {
-                        use tokio::io::AsyncWriteExt;
-                        let reason = match status {
-                            401 => "Unauthorized",
-                            403 => "Forbidden",
-                            _ => "Error",
-                        };
-                        let response = HttpResponse::with_content(
-                            format!("{} {}", status, reason),
-                            "application/json",
-                            body,
-                        )
-                        .header("Cache-Control", "no-cache")
-                        .header("Connection", "close")
-                        .into_string();
-                        let _ = stream.write_all(response.as_bytes()).await;
+                    // Parse the `Host:` header to learn what address the
+                    // browser thinks reaches us. We use this later as the IP
+                    // for ICE-TCP host candidates: Firefox refuses to pair
+                    // remote loopback candidates, so we need a non-loopback
+                    // address the browser can actually connect to. The only
+                    // one we know for sure the browser can reach is whatever
+                    // it just used to reach us for HTTP — which is exactly
+                    // what the Host header contains. If the user accessed
+                    // via a hostname (`localhost`, `myserver.local`) rather
+                    // than a literal IP, we get None here and skip the TCP
+                    // candidate entirely; those users can still use UDP if
+                    // their topology allows it.
+                    let browser_host_ip: Option<std::net::IpAddr> =
+                        extract_host_header_ip(&header_text);
+
+                    if is_websocket {
+                        // Upgrades never loop: the connection stops being
+                        // HTTP. Hand the WS path everything it needs —
+                        // whether this was request 1 or a kept-alive
+                        // follow-up, the stream delivers the upgrade head
+                        // from byte zero (kernel buffer / PrefixedStream /
+                        // replay).
+                        break (
+                            stream,
+                            header_text,
+                            peer_connection_identity,
+                            browser_host_ip,
+                        );
+                    }
+
+                    // Request leg of the keep-alive verdict; the body and
+                    // response legs are dispatch's and the write edges'.
+                    stream.begin_request(
+                        served < KEEP_ALIVE_MAX_REQUESTS
+                            && request_allows_keep_alive(&header_text)
+                            && segment_is_single_request(&head_segment),
+                    );
+                    let http_ctx = HttpRequestCtx {
+                        bus: bus.clone(),
+                        config_json: config_json.clone(),
+                        session_provider: session_provider.clone(),
+                        session_model: session_model.clone(),
+                        agent_card_json: agent_card_json.clone(),
+                        agent_card_value_for_targets: agent_card_value_for_targets.clone(),
+                        app_html: app_html.clone(),
+                        app_html_override: app_html_override.clone(),
+                        app_html_cache: app_html_cache.clone(),
+                        worktree_inventory_cache: worktree_inventory_cache.clone(),
+                        mcp_server: mcp_server.clone(),
+                        peer_registry: peer_registry.clone(),
+                        project_root: project_root.clone(),
+                        inbound_bearer_token: inbound_bearer_token.clone(),
+                        tls_client_cert_required,
+                        peer_access_request_config: peer_access_request_config.clone(),
+                        active_presence: active_presence.clone(),
+                        voice_debug: voice_debug.clone(),
+                        dashboard_control: Arc::clone(&dashboard_control),
+                        daemon_session_id: daemon_session_id.clone(),
+                        query_ctx: query_ctx.clone(),
+                        frame_registry: frame_registry.clone(),
+                        session_log: session_log.clone(),
+                        recording_registry: recording_registry.clone(),
+                        session_registry: session_registry.clone(),
+                        snapshot_dir: snapshot_dir.clone(),
+                        project_root_for_changes: project_root_for_changes.clone(),
+                        runtime_settings: runtime_settings.clone(),
+                        file_watcher: file_watcher.clone(),
+                    };
+                    serve_http_request(
+                        http_ctx,
+                        stream,
+                        n,
+                        &header_text,
+                        peer_addr,
+                        source_hint.clone(),
+                        is_tls,
+                        tls_client_cert_present,
+                        tls_client_cert_fingerprint.clone(),
+                        peer_connection_identity,
+                    )
+                    .await;
+
+                    // The write edge either parked the stream for reuse
+                    // or closed it (finalize); no parked stream means the
+                    // connection is done.
+                    let Some(back) = parked.lock().unwrap_or_else(|e| e.into_inner()).take() else {
+                        return;
+                    };
+                    stream = back;
+                    let Some(next) = read_next_request_head(
+                        &mut stream,
+                        std::time::Duration::from_secs(KEEP_ALIVE_IDLE_SECS),
+                    )
+                    .await
+                    else {
+                        // Idle timeout, clean client close, or an
+                        // unparseable follow-up: flush + shutdown ends the
+                        // connection (the finalize contract's home is
+                        // connection end now — parked responses were
+                        // already flushed per response).
                         finalize_http_stream(&mut stream).await;
                         return;
-                    }
+                    };
+                    // Serve the captured segment back to readers so
+                    // dispatch (or a WS upgrade) sees the request from
+                    // byte zero, exactly as request 1 arrives.
+                    stream.push_replay(&next);
+                    head_segment = next;
                 };
-                let is_websocket = header_text
-                    .lines()
-                    .any(|l| l.to_lowercase().contains("upgrade: websocket"));
 
-                // Parse the `Host:` header to learn what address the
-                // browser thinks reaches us. We use this later as the IP
-                // for ICE-TCP host candidates: Firefox refuses to pair
-                // remote loopback candidates, so we need a non-loopback
-                // address the browser can actually connect to. The only
-                // one we know for sure the browser can reach is whatever
-                // it just used to reach us for HTTP — which is exactly
-                // what the Host header contains. If the user accessed
-                // via a hostname (`localhost`, `myserver.local`) rather
-                // than a literal IP, we get None here and skip the TCP
-                // candidate entirely; those users can still use UDP if
-                // their topology allows it.
-                let browser_host_ip: Option<std::net::IpAddr> =
-                    extract_host_header_ip(&header_text);
-
-                if is_websocket {
+                // ── WebSocket upgrade path — request 1 or any kept-alive
+                //    follow-up whose head asked to upgrade. ──
+                {
                     if tls_client_cert_required && !tls_client_cert_present {
                         use tokio::io::AsyncWriteExt;
                         let body = serde_json::json!({
@@ -1592,51 +1709,6 @@ pub fn spawn_web_gateway(
 
                     let _ = tokio::join!(inbound, outbound);
                     crate::attention_nudge::dashboard_disconnected();
-                } else {
-                    let http_ctx = HttpRequestCtx {
-                        bus: bus.clone(),
-                        config_json: config_json.clone(),
-                        session_provider: session_provider.clone(),
-                        session_model: session_model.clone(),
-                        agent_card_json: agent_card_json.clone(),
-                        agent_card_value_for_targets: agent_card_value_for_targets.clone(),
-                        app_html: app_html.clone(),
-                        app_html_override: app_html_override.clone(),
-                        app_html_cache: app_html_cache.clone(),
-                        worktree_inventory_cache: worktree_inventory_cache.clone(),
-                        mcp_server: mcp_server.clone(),
-                        peer_registry: peer_registry.clone(),
-                        project_root: project_root.clone(),
-                        inbound_bearer_token: inbound_bearer_token.clone(),
-                        tls_client_cert_required,
-                        peer_access_request_config: peer_access_request_config.clone(),
-                        active_presence: active_presence.clone(),
-                        voice_debug: voice_debug.clone(),
-                        dashboard_control: Arc::clone(&dashboard_control),
-                        daemon_session_id: daemon_session_id.clone(),
-                        query_ctx: query_ctx.clone(),
-                        frame_registry: frame_registry.clone(),
-                        session_log: session_log.clone(),
-                        recording_registry: recording_registry.clone(),
-                        session_registry: session_registry.clone(),
-                        snapshot_dir: snapshot_dir.clone(),
-                        project_root_for_changes: project_root_for_changes.clone(),
-                        runtime_settings: runtime_settings.clone(),
-                        file_watcher: file_watcher.clone(),
-                    };
-                    serve_http_request(
-                        http_ctx,
-                        stream,
-                        n,
-                        &header_text,
-                        peer_addr,
-                        source_hint,
-                        is_tls,
-                        tls_client_cert_present,
-                        tls_client_cert_fingerprint,
-                        peer_connection_identity,
-                    )
-                    .await;
                 }
             });
         }
@@ -2281,7 +2353,7 @@ mod tests {
             .await
             .unwrap();
         stream
-            .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
             .await
             .unwrap();
 
@@ -2341,7 +2413,7 @@ mod tests {
             .await
             .unwrap();
         stream
-            .write_all(b"GET /config HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .write_all(b"GET /config HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
             .await
             .unwrap();
 
@@ -2395,7 +2467,7 @@ mod tests {
             .await
             .unwrap();
         stream
-            .write_all(b"GET /config HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .write_all(b"GET /config HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
             .await
             .unwrap();
         let mut response = Vec::new();
@@ -2474,7 +2546,7 @@ mod tests {
             .await
             .unwrap();
         stream
-            .write_all(b"GET /.well-known/agent-card.json HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .write_all(b"GET /.well-known/agent-card.json HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
             .await
             .unwrap();
         let mut response = Vec::new();
@@ -3190,7 +3262,7 @@ mod tests {
             .await
             .unwrap();
         stream
-            .write_all(b"POST /session HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\n\r\n")
+            .write_all(b"POST /session HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
             .await
             .unwrap();
 
@@ -3248,7 +3320,9 @@ mod tests {
             .await
             .unwrap();
         stream
-            .write_all(b"GET /audio-processor.js HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .write_all(
+                b"GET /audio-processor.js HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+            )
             .await
             .unwrap();
 
@@ -3745,6 +3819,243 @@ mod tests {
             "should not emit duplicate PresenceConnected for already-active browser"
         );
 
+        handle.abort();
+    }
+
+    // ── HTTP/1.1 keep-alive (the per-connection request loop) ──
+
+    /// Spawn a bare test gateway (no session state, no TLS) and return
+    /// its port + task handle — the common preamble of the keep-alive
+    /// tests below.
+    async fn spawn_keep_alive_test_gateway() -> (u16, tokio::task::JoinHandle<()>) {
+        let bus = EventBus::new();
+        let (broadcast_tx, _) = broadcast::channel::<String>(16);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let handle = spawn_web_gateway(
+            listener,
+            bus,
+            broadcast_tx,
+            WebGatewayConfig::default(),
+            ActiveSessionState::empty(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Vec::new(),
+            None,
+            crate::peer::AuthRequirements::none(),
+            false,
+            None,
+        );
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        (port, handle)
+    }
+
+    /// Read exactly ONE HTTP response off a kept-alive connection: the
+    /// head through `\r\n\r\n`, then exactly `Content-Length` body
+    /// bytes. Asserts the server sent nothing beyond the response — on
+    /// a parked connection stray bytes would be protocol corruption.
+    async fn read_one_http_response(stream: &mut tokio::net::TcpStream) -> String {
+        use tokio::io::AsyncReadExt;
+        let mut bytes: Vec<u8> = Vec::new();
+        let mut chunk = [0u8; 4096];
+        let head_end = loop {
+            if let Some(pos) = bytes.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+            let n =
+                tokio::time::timeout(tokio::time::Duration::from_secs(5), stream.read(&mut chunk))
+                    .await
+                    .expect("response head timed out")
+                    .expect("response head read failed");
+            assert!(n > 0, "connection closed mid-head");
+            bytes.extend_from_slice(&chunk[..n]);
+        };
+        let head = String::from_utf8_lossy(&bytes[..head_end]).into_owned();
+        let content_length: usize = head
+            .lines()
+            .find_map(|line| line.strip_prefix("Content-Length: "))
+            .map(|value| value.trim().parse().expect("Content-Length parses"))
+            .unwrap_or(0);
+        while bytes.len() < head_end + content_length {
+            let n =
+                tokio::time::timeout(tokio::time::Duration::from_secs(5), stream.read(&mut chunk))
+                    .await
+                    .expect("response body timed out")
+                    .expect("response body read failed");
+            assert!(n > 0, "connection closed mid-body");
+            bytes.extend_from_slice(&chunk[..n]);
+        }
+        assert_eq!(
+            bytes.len(),
+            head_end + content_length,
+            "server sent bytes beyond the framed response"
+        );
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+
+    #[tokio::test]
+    async fn test_http_keep_alive_reuses_connection() {
+        use tokio::io::AsyncWriteExt;
+        let (port, handle) = spawn_keep_alive_test_gateway().await;
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+            .await
+            .unwrap();
+
+        // Request 1: HTTP/1.1 defaults to keep-alive; the framed JSON
+        // response advertises it and the connection stays open.
+        stream
+            .write_all(b"GET /config HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+        let resp1 = read_one_http_response(&mut stream).await;
+        assert!(resp1.starts_with("HTTP/1.1 200 OK\r\n"), "{resp1}");
+        assert!(resp1.contains("Connection: keep-alive\r\n"), "{resp1}");
+        assert!(
+            resp1.contains(&format!("Keep-Alive: timeout={KEEP_ALIVE_IDLE_SECS}\r\n")),
+            "{resp1}"
+        );
+
+        // Request 2 rides the SAME connection through the route-table
+        // funnel (write_api_response): the rewritten header tail must
+        // advertise keep-alive there too.
+        stream
+            .write_all(b"GET /api/project-root HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+        let resp2 = read_one_http_response(&mut stream).await;
+        assert!(resp2.starts_with("HTTP/1.1 200 OK\r\n"), "{resp2}");
+        assert!(resp2.contains("Connection: keep-alive\r\n"), "{resp2}");
+        assert!(!resp2.contains("Connection: close"), "{resp2}");
+
+        // Request 3: a static-asset chain arm, same connection still.
+        stream
+            .write_all(b"GET /audio-processor.js HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+        let resp3 = read_one_http_response(&mut stream).await;
+        assert!(resp3.starts_with("HTTP/1.1 200 OK\r\n"), "{resp3}");
+        assert!(resp3.contains("Connection: keep-alive\r\n"), "{resp3}");
+
+        // Request 4 says close: the server honors it and the connection
+        // ends cleanly right after the response.
+        stream
+            .write_all(b"GET /config HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+            .await
+            .unwrap();
+        let resp4 = read_one_http_response(&mut stream).await;
+        assert!(resp4.starts_with("HTTP/1.1 200 OK\r\n"), "{resp4}");
+        assert!(resp4.contains("Connection: close\r\n"), "{resp4}");
+        assert!(!resp4.contains("Connection: keep-alive"), "{resp4}");
+        let mut rest = Vec::new();
+        let n = tokio::time::timeout(
+            tokio::time::Duration::from_secs(5),
+            tokio::io::AsyncReadExt::read_to_end(&mut stream, &mut rest),
+        )
+        .await
+        .expect("EOF after Connection: close")
+        .expect("clean EOF read");
+        assert_eq!(n, 0, "no bytes may follow a Connection: close response");
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_http10_request_closes_by_default() {
+        use tokio::io::AsyncWriteExt;
+        let (port, handle) = spawn_keep_alive_test_gateway().await;
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+            .await
+            .unwrap();
+        stream
+            .write_all(b"GET /config HTTP/1.0\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+        let mut response = Vec::new();
+        tokio::time::timeout(
+            tokio::time::Duration::from_secs(5),
+            tokio::io::AsyncReadExt::read_to_end(&mut stream, &mut response),
+        )
+        .await
+        .expect("HTTP/1.0 response must end in EOF promptly")
+        .unwrap();
+        let response = String::from_utf8_lossy(&response);
+        assert!(response.starts_with("HTTP/1.1 200 OK\r\n"), "{response}");
+        assert!(response.contains("Connection: close\r\n"), "{response}");
+        assert!(!response.contains("Connection: keep-alive"), "{response}");
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_ws_upgrade_on_kept_alive_connection() {
+        use tokio::io::AsyncWriteExt;
+        let (port, handle) = spawn_keep_alive_test_gateway().await;
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+            .await
+            .unwrap();
+
+        // Plain request first; the connection parks for reuse.
+        stream
+            .write_all(b"GET /config HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+        let resp = read_one_http_response(&mut stream).await;
+        assert!(resp.contains("Connection: keep-alive\r\n"), "{resp}");
+
+        // A WebSocket upgrade arrives as the SECOND request on the same
+        // connection: the loop replays the captured head to the upgrade
+        // handshake and hands the connection off — it must never keep
+        // looping past an upgrade.
+        let (ws, upgrade_response) =
+            tokio_tungstenite::client_async(format!("ws://127.0.0.1:{port}/ws"), stream)
+                .await
+                .expect("WS upgrade on a kept-alive connection");
+        assert_eq!(
+            upgrade_response.status(),
+            tokio_tungstenite::tungstenite::http::StatusCode::SWITCHING_PROTOCOLS
+        );
+        drop(ws);
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_http_keep_alive_request_budget_closes_at_cap() {
+        use tokio::io::AsyncWriteExt;
+        let (port, handle) = spawn_keep_alive_test_gateway().await;
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+            .await
+            .unwrap();
+        for i in 1..=KEEP_ALIVE_MAX_REQUESTS {
+            stream
+                .write_all(b"GET /config HTTP/1.1\r\nHost: localhost\r\n\r\n")
+                .await
+                .unwrap();
+            let resp = read_one_http_response(&mut stream).await;
+            if i < KEEP_ALIVE_MAX_REQUESTS {
+                assert!(
+                    resp.contains("Connection: keep-alive\r\n"),
+                    "request {i}: {resp}"
+                );
+            } else {
+                // The budget-exhausting request answers close…
+                assert!(
+                    resp.contains("Connection: close\r\n"),
+                    "request {i}: {resp}"
+                );
+            }
+        }
+        // …and the connection really ends.
+        let mut rest = Vec::new();
+        let n = tokio::time::timeout(
+            tokio::time::Duration::from_secs(5),
+            tokio::io::AsyncReadExt::read_to_end(&mut stream, &mut rest),
+        )
+        .await
+        .expect("EOF after the request budget is spent")
+        .expect("clean EOF read");
+        assert_eq!(n, 0);
         handle.abort();
     }
 }

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -27,6 +27,9 @@ pub(crate) use static_assets::*;
 mod http;
 pub(crate) use http::*;
 
+mod keep_alive;
+pub(crate) use keep_alive::*;
+
 mod api_core;
 pub(crate) use api_core::*;
 
@@ -494,7 +497,7 @@ mod tests {
     {
         use tokio::io::AsyncReadExt;
         let (mut client, server) = tokio::io::duplex(1 << 20);
-        run(Box::pin(server)).await;
+        run(DemuxStream::new(Box::pin(server))).await;
         let mut response = Vec::new();
         client
             .read_to_end(&mut response)
@@ -1858,9 +1861,29 @@ mod tests {
         (port, handle)
     }
 
+    /// Insert `Connection: close` after the request line unless the
+    /// request already carries a Connection header (WS upgrades send
+    /// `Connection: Upgrade` and must not gain a second, conflicting
+    /// one).
+    fn pin_connection_close(request: &str) -> String {
+        if request.to_ascii_lowercase().contains("\r\nconnection:") {
+            return request.to_string();
+        }
+        request.replacen("\r\n", "\r\nConnection: close\r\n", 1)
+    }
+
     /// Fire a raw HTTP request and read the response bytes.
+    ///
+    /// One-shot contract: the read runs to EOF, so the request is pinned
+    /// to `Connection: close` here (inserted after the request line) —
+    /// otherwise every keep-alive-eligible response would park the
+    /// connection and this helper would idle out the 2s deadline per
+    /// call. Keep-alive itself is exercised by the dedicated listener
+    /// tests. Requests that already carry a `Connection` header (the WS
+    /// upgrade shapes send `Connection: Upgrade`) pass through verbatim.
     async fn http_request_bytes(port: u16, request: &str) -> Vec<u8> {
         use tokio::io::AsyncWriteExt;
+        let request = pin_connection_close(request);
         let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
             .await
             .unwrap();
@@ -2367,6 +2390,10 @@ mod tests {
             .await
             .unwrap();
         let mut tls = connector.connect(server_name, tcp).await.unwrap();
+        // One-shot contract (same as http_request_bytes): pin the request
+        // to `Connection: close` so a keep-alive-eligible response can't
+        // park the connection and stall the read-to-EOF below.
+        let request = pin_connection_close(request);
         tls.write_all(request.as_bytes()).await.unwrap();
         // Read to EOF under one generous deadline. The old 2s timeout with
         // its result discarded turned this into a load lottery: ~2.8 MB of

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -3698,7 +3698,7 @@ mod tests {
     {
         use tokio::io::AsyncReadExt;
         let (mut client, server) = tokio::io::duplex(1 << 20);
-        run(Box::pin(server)).await;
+        run(DemuxStream::new(Box::pin(server))).await;
         let mut response = Vec::new();
         client
             .read_to_end(&mut response)

--- a/src/bin/caller/web_gateway/routes_files.rs
+++ b/src/bin/caller/web_gateway/routes_files.rs
@@ -3320,7 +3320,7 @@ mod tests {
     {
         use tokio::io::AsyncReadExt;
         let (mut client, server) = tokio::io::duplex(1 << 20);
-        run(Box::pin(server)).await;
+        run(DemuxStream::new(Box::pin(server))).await;
         let mut response = Vec::new();
         client
             .read_to_end(&mut response)
@@ -3985,7 +3985,7 @@ mod tests {
     {
         use tokio::io::AsyncReadExt;
         let (mut client, server) = tokio::io::duplex(1 << 20);
-        run(Box::pin(server)).await;
+        run(DemuxStream::new(Box::pin(server))).await;
         let mut response = Vec::new();
         client.read_to_end(&mut response).await.unwrap();
         response

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -2752,7 +2752,7 @@ mod tests {
     {
         use tokio::io::AsyncReadExt;
         let (mut client, server) = tokio::io::duplex(1 << 20);
-        run(Box::pin(server)).await;
+        run(DemuxStream::new(Box::pin(server))).await;
         let mut response = Vec::new();
         client
             .read_to_end(&mut response)

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -5655,7 +5655,7 @@ mod tests {
     {
         use tokio::io::AsyncReadExt;
         let (mut client, server) = tokio::io::duplex(1 << 20);
-        run(Box::pin(server)).await;
+        run(DemuxStream::new(Box::pin(server))).await;
         let mut response = Vec::new();
         client
             .read_to_end(&mut response)

--- a/src/bin/caller/web_gateway/settings.rs
+++ b/src/bin/caller/web_gateway/settings.rs
@@ -1020,7 +1020,7 @@ mod tests {
     {
         use tokio::io::AsyncReadExt;
         let (mut client, server) = tokio::io::duplex(1 << 20);
-        run(Box::pin(server)).await;
+        run(DemuxStream::new(Box::pin(server))).await;
         let mut response = Vec::new();
         client
             .read_to_end(&mut response)

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -340,12 +340,20 @@ pub(crate) struct StaticAssetView<'a> {
 /// asset: conditional requests (`If-None-Match` → `304 Not Modified` with
 /// an empty body), gzip negotiation via `Accept-Encoding`, HEAD (same
 /// headers as GET, no body), CORS, and the `?v=` Cache-Control policy.
+///
+/// `keep_alive` is the exchange's keep-alive verdict
+/// (`DemuxStream::exchange_reusable` at the serving arm): every shape
+/// this builder emits is self-framing (`Content-Length` on 200, no body
+/// on 304/HEAD), so static assets are prime keep-alive citizens — the
+/// whole point of the request loop is not paying a TCP+TLS handshake
+/// per asset on a cold dashboard load.
 pub(crate) fn build_static_asset_response(
     method: &str,
     header_text: &str,
     query: &str,
     current_version: &str,
     asset: StaticAssetView<'_>,
+    keep_alive: bool,
 ) -> Vec<u8> {
     let cache_control = asset
         .cache_control
@@ -363,7 +371,7 @@ pub(crate) fn build_static_asset_response(
             .header("Cache-Control", cache_control)
             .header_segment(vary)
             .header("Access-Control-Allow-Origin", "*")
-            .header("Connection", "close")
+            .connection_reuse(keep_alive)
             .into_bytes();
     }
     let gzip_body = asset
@@ -381,7 +389,7 @@ pub(crate) fn build_static_asset_response(
         .header("Cache-Control", cache_control)
         .header_segment(vary)
         .header("Access-Control-Allow-Origin", "*")
-        .header("Connection", "close")
+        .connection_reuse(keep_alive)
         .into_bytes();
     if method != "HEAD" {
         response.extend_from_slice(payload);
@@ -470,6 +478,7 @@ pub(crate) fn app_html_override_response(
     header_text: &str,
     query: &str,
     path: &std::path::Path,
+    keep_alive: bool,
 ) -> Vec<u8> {
     match std::fs::read_to_string(path) {
         Ok(html) => {
@@ -487,6 +496,7 @@ pub(crate) fn app_html_override_response(
                     gzip: None,
                     cache_control: Some("no-cache"),
                 },
+                keep_alive,
             )
         }
         Err(err) => {
@@ -505,7 +515,7 @@ pub(crate) fn app_html_override_response(
                 .header("Content-Length", body.len().to_string())
                 .header("Cache-Control", "no-store")
                 .header("Access-Control-Allow-Origin", "*")
-                .header("Connection", "close")
+                .connection_reuse(keep_alive)
                 .into_bytes();
             if method != "HEAD" {
                 response.extend_from_slice(body.as_bytes());
@@ -528,6 +538,7 @@ pub(crate) fn vault_kernel_override_response(
     header_text: &str,
     query: &str,
     app_html_path: &std::path::Path,
+    keep_alive: bool,
 ) -> Option<Vec<u8>> {
     let sibling = app_html_path.parent()?.join("vault-kernel.js");
     let body = std::fs::read(&sibling).ok()?;
@@ -544,6 +555,7 @@ pub(crate) fn vault_kernel_override_response(
             gzip: None,
             cache_control: Some("no-cache"),
         },
+        keep_alive,
     ))
 }
 
@@ -610,13 +622,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let app_html_path = dir.path().join("app.html");
         // No sibling yet: fall back to the embedded kernel.
-        assert!(vault_kernel_override_response("GET", "", "", &app_html_path).is_none());
+        assert!(vault_kernel_override_response("GET", "", "", &app_html_path, false).is_none());
         std::fs::write(
             dir.path().join("vault-kernel.js"),
             b"self.onmessage=null;\n",
         )
         .unwrap();
-        let resp = vault_kernel_override_response("GET", "", "", &app_html_path)
+        let resp = vault_kernel_override_response("GET", "", "", &app_html_path, false)
             .expect("sibling kernel must be served");
         let text = String::from_utf8_lossy(&resp);
         assert!(text.starts_with("HTTP/1.1 200 OK\r\n"));
@@ -823,6 +835,7 @@ mod tests {
             "v=cur",
             "cur",
             test_asset_view(&body, Some(&gz)),
+            false,
         );
         let (head, payload) = split_http_response(&response);
         assert!(head.starts_with("HTTP/1.1 200 OK\r\n"));
@@ -852,6 +865,7 @@ mod tests {
             "",
             "cur",
             test_asset_view(&body, Some(&gz)),
+            false,
         );
         let (head, payload) = split_http_response(&response);
         assert!(head.starts_with("HTTP/1.1 200 OK\r\n"));
@@ -872,6 +886,7 @@ mod tests {
             "",
             "cur",
             test_asset_view(&body, Some(&gz)),
+            false,
         );
         let (head, payload) = split_http_response(&response);
         assert!(head.starts_with("HTTP/1.1 304 Not Modified\r\n"));
@@ -893,6 +908,7 @@ mod tests {
             "",
             "cur",
             test_asset_view(&body, Some(&gz)),
+            false,
         );
         let (head, payload) = split_http_response(&response);
         assert!(head.starts_with("HTTP/1.1 200 OK\r\n"));
@@ -960,7 +976,7 @@ mod tests {
             "<!DOCTYPE html><script src=\"/three.module.min.js\"></script>one",
         )
         .unwrap();
-        let first = app_html_override_response("GET", "", "", &path);
+        let first = app_html_override_response("GET", "", "", &path, false);
         let first = String::from_utf8_lossy(&first);
         assert!(first.starts_with("HTTP/1.1 200 OK\r\n"));
         assert!(first.contains("Content-Type: text/html"));
@@ -970,7 +986,7 @@ mod tests {
 
         // An edit is visible on the very next request — nothing caches it.
         std::fs::write(&path, "<!DOCTYPE html>two").unwrap();
-        let second = app_html_override_response("GET", "", "", &path);
+        let second = app_html_override_response("GET", "", "", &path, false);
         let second = String::from_utf8_lossy(&second);
         assert!(second.ends_with("two"));
 
@@ -981,8 +997,13 @@ mod tests {
             .and_then(|rest| rest.split('"').next())
             .expect("override response carries an ETag")
             .to_string();
-        let third =
-            app_html_override_response("GET", &format!("If-None-Match: \"{etag}\"\r\n"), "", &path);
+        let third = app_html_override_response(
+            "GET",
+            &format!("If-None-Match: \"{etag}\"\r\n"),
+            "",
+            &path,
+            false,
+        );
         assert!(String::from_utf8_lossy(&third).starts_with("HTTP/1.1 304"));
     }
 
@@ -990,13 +1011,13 @@ mod tests {
     fn app_html_override_read_failure_is_a_loud_500() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("missing.html");
-        let resp = app_html_override_response("GET", "", "", &path);
+        let resp = app_html_override_response("GET", "", "", &path, false);
         let text = String::from_utf8_lossy(&resp);
         assert!(text.starts_with("HTTP/1.1 500"));
         assert!(text.contains("INTENDANT_APP_HTML_PATH"));
         assert!(text.contains("missing.html"));
         // HEAD keeps the status but sends headers only.
-        let head = app_html_override_response("HEAD", "", "", &path);
+        let head = app_html_override_response("HEAD", "", "", &path, false);
         let head = String::from_utf8_lossy(&head);
         assert!(head.starts_with("HTTP/1.1 500"));
         assert!(head.ends_with("\r\n\r\n"));

--- a/src/bin/caller/web_tls.rs
+++ b/src/bin/caller/web_tls.rs
@@ -237,7 +237,11 @@ fn server_config_from(
     let mut config = builder.with_cert_resolver(fleet_sni_resolver());
     // The dashboard speaks HTTP/1.1 and upgrades to WebSocket; advertise
     // only http/1.1 so a browser never negotiates h2 (which the gateway's
-    // hand-rolled HTTP/1 handler doesn't implement).
+    // hand-rolled HTTP/1 handler doesn't implement). KEEP THIS PINNED:
+    // connection reuse is HTTP/1.1 keep-alive (web_gateway::keep_alive's
+    // per-connection request loop), deliberately NOT h2 — adopting h2
+    // would mean migrating the whole hand-rolled server stack (demux, WS
+    // upgrade, streaming lanes), a separate program, not a config flip.
     config.alpn_protocols = vec![b"http/1.1".to_vec()];
     Ok(config)
 }


### PR DESCRIPTION
The keep-alive program from the dashboard audit: requests on one connection now reuse it, ending the one-request-per-connection posture that cost a cold dashboard load ~16 TCP+TLS handshakes.

Design is fail-closed on all three legs (module-doc table in web_gateway/keep_alive.rs):
- **Request leg**: HTTP/1.1 without a close token reuses; Connection: close, HTTP/1.0 (absent explicit keep-alive), unknown versions, pipelined surplus, or the 500-requests-per-connection budget all close.
- **Body leg**: only fully-consumed, unambiguously-framed bodies mark consumption; BodyPolicy::Streaming routes never do; TE+CL together (smuggling shape) closes.
- **Response leg is opt-IN**: only self-framing writers park the connection (the buffered JSON/bytes lanes, preflight, static assets, config/agent-card/debug). Streaming writers — deep-search NDJSON, sessions stream, uploads, transfer chunks, doorbell, MCP, recordings/frames sub-router, connect signaling, every early error path — stay Connection: close byte-identically to today. An unenumerated handler therefore fails safe to close, never to protocol corruption.

WS upgrades break out of the loop into the untouched upgrade path, and work on a kept-alive follow-up request via the replay buffer (dedicated test). Idle connections reap at exactly 30s; Keep-Alive: timeout=30 is advertised only when the stream actually parks. ALPN stays pinned http/1.1 with the h2-out-of-scope rationale documented at the pin.

Live evidence on a release build: curl shows "Re-using existing connection"; a 10-URL cold-dashboard shape opens 1 connection instead of 10; the NDJSON lane streams progress over a 4,949-session store and closes cleanly; a held-open socket reaps at 30.0s; validate-dashboard.cjs PASSes against the live daemon.

Battery: nextest 3203/3203, clippy 0 warnings, e2e 19/19, fmt clean; new hermetic suites for the decision table, head reader, DemuxStream defaults/replay/park, byte-identity of unchanged response heads, and 4-request reuse integration.

Soak caveats (deliberate): no live mTLS-browser soak here (needs the two-daemon rig); parked-connection task counts at fleet scale are soak territory; pipelining clients get spec-legal close-then-resend, matching historical behavior.