### PR TITLE
Peer-delegation delivery receipts: at-least-once with receiver dedup

### DIFF
--- a/docs/src/peer-federation.md
+++ b/docs/src/peer-federation.md
@@ -283,7 +283,40 @@ shapes with identical semantics:
 label, connection state, capabilities, and the folded per-peer `sessions`
 and `displays` rails above. `peer_send_message` (`peer_id`, `message`, optional `session`)
 sends a message to the peer's agent. `peer_delegate_task` (`peer_id`,
-`instructions`, optional `context`) delegates a task and returns a `task_id`.
+`instructions`, optional `context`) delegates a task and returns a `task_id`
+plus a `delivery` verdict (below).
+
+### Delegation delivery receipts (at-least-once)
+
+A StartTask write proves only that the frame entered the sender's socket —
+the `/ws` control plane echoes nothing back — so delivery is resolved at the
+application level. Every delegation stamps its StartTask frame with a
+`delegation_id`; a receiving daemon that **dispatches** the task (not merely
+reads the frame) answers with a broadcast `task_received` event carrying that
+id and its real local session id, and the sender's `delegate_task` waits
+(bounded) for the correlated receipt:
+
+- **`delivery: "acknowledged"`** — the peer accepted: `task_id` is the peer's
+  real session id, so the id `ctl peer task` prints means "accepted by the
+  peer" and is actionable for follow-ups.
+- **Connection drops before an ack** — the sender re-sends the **same**
+  `delegation_id` a bounded number of times after the actor reconnects; the
+  receiver dedups by that id and re-acks with the *original* session instead
+  of starting a duplicate task (at-least-once with dedup).
+- **`delivery: "unconfirmed"`** — the connection stayed up for the whole
+  grace window with no ack: the old-receiver signature (pre-receipt builds
+  run the task but never ack). The sender falls back to the historical
+  fire-and-forget semantics — synthetic `task-out-{n}` id, clearly marked —
+  and deliberately does **not** re-send, because an old receiver has no
+  dedup and a re-send would duplicate the task.
+
+Responses also carry the `delegation_id` (pass it back as
+`client_correlation_id` to retry a delegation idempotently) and `sends` (how
+many StartTask frames were written; >1 means a reconnect re-send happened).
+Receipts are informational and carry no authority — the receiving daemon's
+IAM evaluates the StartTask exactly as before. The precise wire shapes and
+the old/new compatibility matrix live in the module docs of
+`peer/transport/intendant.rs`.
 
 Delegation keeps the sibling-not-subordinate contract: a delegated task
 executes on the peer's machine, by the peer's own agent, under the peer's own

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -1460,6 +1460,7 @@ mod tests {
             display_target: None,
             attachments: Vec::new(),
             follow_up_id: None,
+            delegation_id: None,
         };
         let approval = ControlMsg::Approve {
             session_id: None,

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -294,6 +294,18 @@ pub enum AppEvent {
         session_id: String,
         task: Option<String>,
     },
+    /// Peer-delegation delivery receipt: the session supervisor accepted a
+    /// `StartTask` that carried a `delegation_id` and dispatched it as
+    /// `session_id`. Broadcast to every connected client as
+    /// `OutboundEvent::TaskReceived`; the delegating daemon's federation
+    /// transport correlates it back to the in-flight
+    /// `PeerOp::DelegateTask` (see `peer::transport::intendant`).
+    /// Re-emitted verbatim (same `session_id`) when a duplicate
+    /// `delegation_id` is deduped instead of dispatched.
+    TaskReceived {
+        delegation_id: String,
+        session_id: String,
+    },
     /// Links an Intendant wrapper/log session to a backend-native
     /// session/thread id. Frontends use this to route backend-specific actions
     /// without confusing the wrapper UUID with the provider's own id.
@@ -1542,6 +1554,22 @@ pub enum ControlMsg {
         /// use it to correlate queued/delivered/failed status updates.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         follow_up_id: Option<String>,
+        /// Peer-delegation delivery-receipt correlation id. Set by a
+        /// federating daemon's `PeerOp::DelegateTask` (see
+        /// `peer::transport::intendant`): when a daemon supervisor
+        /// dispatches a new-session StartTask carrying this id, it
+        /// acknowledges acceptance by emitting
+        /// `OutboundEvent::TaskReceived { delegation_id, session_id }`
+        /// on its broadcast, and it dedups repeats of the same id
+        /// (an already-accepted id re-acks with the original session
+        /// identity instead of starting a duplicate task — the sender
+        /// re-sends the same id after a reconnect). Absent on frames
+        /// from browsers, ctl, and pre-receipt peer builds; receivers
+        /// older than this field ignore it (serde default) and never
+        /// ack. Carries no authority — IAM evaluation on the receiving
+        /// gateway is unchanged.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        delegation_id: Option<String>,
     },
     ResumeSession {
         /// Session source: "intendant", "codex", "claude-code", or "gemini".
@@ -2213,6 +2241,13 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
         AppEvent::SessionStarted { session_id, task } => Some(OutboundEvent::SessionStarted {
             session_id: session_id.clone(),
             task: task.clone(),
+        }),
+        AppEvent::TaskReceived {
+            delegation_id,
+            session_id,
+        } => Some(OutboundEvent::TaskReceived {
+            delegation_id: delegation_id.clone(),
+            session_id: session_id.clone(),
         }),
         AppEvent::SessionIdentity {
             session_id,
@@ -4160,6 +4195,7 @@ mod tests {
                 display_target: None,
                 attachments: vec![],
                 follow_up_id: None,
+                delegation_id: None,
             },
             ControlMsg::FollowUp {
                 session_id: None,
@@ -4732,6 +4768,7 @@ mod tests {
             display_target: Some("user_session".to_string()),
             attachments: vec!["ann-recording-1".to_string(), "ann-recording-2".to_string()],
             follow_up_id: None,
+            delegation_id: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ControlMsg = serde_json::from_str(&json).unwrap();

--- a/src/bin/caller/mcp/commands.rs
+++ b/src/bin/caller/mcp/commands.rs
@@ -1326,6 +1326,7 @@ pub(crate) async fn handle_control_command_mcp(
                         display_target: None,
                         attachments: vec![],
                         follow_up_id: None,
+                        delegation_id: None,
                     }));
                     emit_control_result(
                         control_tx,

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -162,6 +162,7 @@ pub fn spawn_event_listener(
                     | AppEvent::FollowUpCancelRequested { .. }
                     | AppEvent::SessionStopRequested { .. }
                     | AppEvent::SessionRelationship { .. }
+                    | AppEvent::TaskReceived { .. }
                     | AppEvent::SessionGoal { .. }
                     | AppEvent::SessionVitals { .. }
                     | AppEvent::SessionRenameResult { .. }

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -1363,6 +1363,7 @@ impl IntendantServer {
                     display_target: params.display_target,
                     attachments: vec![],
                     follow_up_id: None,
+                    delegation_id: None,
                 }));
             if target_phase
                 .as_ref()
@@ -1395,6 +1396,7 @@ impl IntendantServer {
                     display_target: params.display_target,
                     attachments: vec![],
                     follow_up_id: None,
+                    delegation_id: None,
                 }));
             return "ok (CU task dispatched)".to_string();
         }
@@ -2730,6 +2732,7 @@ pub(crate) mod tests {
                     display_target,
                     attachments,
                     follow_up_id,
+                    delegation_id,
                 }))) => {
                     assert_eq!(session_id.as_deref(), Some("managed-session-1"));
                     assert_eq!(task, "continue existing managed session");
@@ -2739,6 +2742,7 @@ pub(crate) mod tests {
                     assert!(display_target.is_none());
                     assert!(attachments.is_empty());
                     assert!(follow_up_id.is_none());
+                    assert!(delegation_id.is_none());
                 }
                 other => panic!("expected targeted StartTask control event, got {other:?}"),
             }

--- a/src/bin/caller/peer/actor.rs
+++ b/src/bin/caller/peer/actor.rs
@@ -23,16 +23,24 @@
 //! own retry policy.
 
 use crate::peer::card::AgentCard;
-use crate::peer::event::{PeerDisplayInfo, PeerEvent, PeerStatus, SessionInfo, TaggedPeerEvent};
+use crate::peer::event::{
+    PeerDisplayInfo, PeerEvent, PeerStatus, SessionInfo, TaggedPeerEvent, TaskId,
+};
 use crate::peer::handle::{ConnectionState, PeerCommand};
 use crate::peer::id::PeerId;
 use crate::peer::traits::PeerTransport;
 use crate::peer::upcast::{MAX_TRACKED_PEER_DISPLAYS, MAX_TRACKED_PEER_SESSIONS};
 use crate::peer::PeerError;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{broadcast, mpsc, watch};
+
+/// Bound on the delegation-receipt ledger (see [`PeerActor::receipts`]).
+/// Receipts are only needed while a `PeerHandle::delegate_task` call is
+/// awaiting one (seconds), so a small FIFO window is generous; the bound
+/// exists so a chatty or hostile peer can't grow the map without limit.
+pub(crate) const MAX_TRACKED_TASK_RECEIPTS: usize = 64;
 
 // ---------------------------------------------------------------------------
 // Backoff
@@ -109,6 +117,21 @@ pub(crate) struct PeerActor {
     pub displays_tx: watch::Sender<Arc<Vec<PeerDisplayInfo>>>,
     /// Fold backing `displays_tx`, keyed by display id.
     pub displays: BTreeMap<u32, PeerDisplayInfo>,
+    /// Published delegation-receipt ledger, folded from
+    /// [`PeerEvent::TaskReceipt`]: delegation id → the peer's local
+    /// identity for the accepted task. `PeerHandle::delegate_task`
+    /// awaits an entry here (via `watch::Receiver::wait_for`) to
+    /// resolve at-least-once delivery. Deliberately NOT cleared on
+    /// disconnect, unlike `sessions_tx`/`displays_tx`: a receipt is a
+    /// one-shot correlation fact, not connection-scoped live state —
+    /// clearing would lose an ack that raced the disconnect and force
+    /// a redundant (though harmless, deduped) re-send. Bounded by
+    /// [`MAX_TRACKED_TASK_RECEIPTS`], oldest-inserted evicted.
+    pub receipts_tx: watch::Sender<Arc<HashMap<String, TaskId>>>,
+    /// Fold backing `receipts_tx`, keyed by delegation id.
+    pub receipts: HashMap<String, TaskId>,
+    /// Insertion order for `receipts` eviction.
+    pub receipt_order: VecDeque<String>,
     pub seq: u64,
     /// Operator's via-URL override, preserved across card refreshes.
     ///
@@ -375,6 +398,28 @@ impl PeerActor {
                 if self.displays.remove(display_id).is_some() {
                     self.publish_displays();
                 }
+            }
+            PeerEvent::TaskReceipt {
+                delegation_id,
+                task,
+            } => {
+                // Re-acks for an already-recorded id (receiver-side
+                // dedup answering a re-send) update in place without
+                // burning an eviction slot.
+                if self.receipts.contains_key(delegation_id) {
+                    self.receipts.insert(delegation_id.clone(), task.clone());
+                } else {
+                    while self.receipt_order.len() >= MAX_TRACKED_TASK_RECEIPTS {
+                        if let Some(evicted) = self.receipt_order.pop_front() {
+                            self.receipts.remove(&evicted);
+                        } else {
+                            break;
+                        }
+                    }
+                    self.receipt_order.push_back(delegation_id.clone());
+                    self.receipts.insert(delegation_id.clone(), task.clone());
+                }
+                let _ = self.receipts_tx.send(Arc::new(self.receipts.clone()));
             }
             PeerEvent::Disconnected { .. } => {
                 if !self.sessions.is_empty() {

--- a/src/bin/caller/peer/coordinator.rs
+++ b/src/bin/caller/peer/coordinator.rs
@@ -56,8 +56,15 @@ pub struct TaskRequest {
 pub struct RoutedTask {
     /// Which peer was selected.
     pub peer_id: PeerId,
-    /// The peer-assigned task id (from `PeerOpAck::TaskId`).
+    /// The peer's task identity: its real session id when `confirmed`,
+    /// the transport's synthetic marker otherwise.
     pub task_id: TaskId,
+    /// Whether the peer acknowledged acceptance with a delivery
+    /// receipt (see `PeerHandle::delegate_task`).
+    pub confirmed: bool,
+    /// The delegation's dedup/correlation id — pass it back as
+    /// `client_correlation_id` to retry idempotently.
+    pub delegation_id: String,
 }
 
 /// Errors from the coordinator's routing logic.
@@ -155,7 +162,12 @@ impl Coordinator {
         let peer_id = winner.id().clone();
 
         match winner.delegate_task(request.task).await {
-            Ok(task_id) => Ok(RoutedTask { peer_id, task_id }),
+            Ok(delegation) => Ok(RoutedTask {
+                peer_id,
+                task_id: delegation.task_id,
+                confirmed: delegation.confirmed,
+                delegation_id: delegation.delegation_id,
+            }),
             Err(error) => Err(CoordinatorError::DelegationFailed {
                 peer: peer_id,
                 error,

--- a/src/bin/caller/peer/event.rs
+++ b/src/bin/caller/peer/event.rs
@@ -104,6 +104,19 @@ pub enum PeerEvent {
         update: TaskUpdate,
     },
 
+    /// Delivery receipt for a task delegated *to* this peer: the peer
+    /// accepted (dispatched) the delegation identified by
+    /// `delegation_id` and `task` is the peer's real local identity for
+    /// it (its session id, for Intendant peers). The per-peer actor
+    /// folds these into a bounded ledger that
+    /// [`crate::peer::handle::PeerHandle::delegate_task`] awaits to
+    /// resolve at-least-once delivery; repeats for the same
+    /// `delegation_id` (receiver-side dedup re-acks) are idempotent.
+    TaskReceipt {
+        delegation_id: String,
+        task: TaskId,
+    },
+
     // ---- Approval flow (federated) ----
     /// Peer wants to do something that requires approval. May be forwarded
     /// to a human via the local presence layer or auto-resolved by policy.

--- a/src/bin/caller/peer/handle.rs
+++ b/src/bin/caller/peer/handle.rs
@@ -31,7 +31,9 @@ use crate::peer::id::PeerId;
 use crate::peer::traits::{PeerOp, PeerOpAck, PeerTask, PeerTransport, TransportFeatures};
 use crate::peer::transport::intendant::TransportCredentials;
 use crate::peer::PeerError;
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
 
 // ---------------------------------------------------------------------------
@@ -41,6 +43,43 @@ use tokio::sync::{broadcast, mpsc, oneshot, watch};
 /// Bounded capacity for the per-handle command channel.
 /// Low volume — commands are user/coordinator initiated.
 pub const COMMANDS_CAPACITY: usize = 64;
+
+// ---------------------------------------------------------------------------
+// Delegation delivery-receipt policy
+// ---------------------------------------------------------------------------
+
+/// How long [`PeerHandle::delegate_task`] waits for the peer's
+/// [`PeerEvent::TaskReceipt`] after a StartTask frame was written and
+/// the connection stayed up. Elapsing on a *stable* connection is the
+/// old-receiver signature (pre-receipt builds read the frame but never
+/// ack) → fall back to fire-and-forget semantics, and deliberately do
+/// NOT re-send: the frame was read, and an old receiver has no dedup.
+#[cfg(not(test))]
+const DELEGATION_RECEIPT_GRACE: Duration = Duration::from_secs(5);
+#[cfg(test)]
+const DELEGATION_RECEIPT_GRACE: Duration = Duration::from_millis(900);
+
+/// How long [`PeerHandle::delegate_task`] waits for the actor to
+/// reconnect before re-sending after the connection dropped
+/// mid-delegation (the actor's initial backoff is 500 ms, so a
+/// transient blip retries quickly).
+#[cfg(not(test))]
+const DELEGATION_RECONNECT_WAIT: Duration = Duration::from_secs(10);
+#[cfg(test)]
+const DELEGATION_RECONNECT_WAIT: Duration = Duration::from_secs(3);
+
+/// Upper bound on StartTask writes for one delegation: the first send
+/// plus re-sends after connection loss. Receiver-side dedup by
+/// delegation id keeps the re-sends at-least-once safe.
+const MAX_DELEGATION_SENDS: u32 = 3;
+
+/// Overall wall-clock bound on one `delegate_task` call, so a flapping
+/// link (repeated connect/drop cycles that never consume the send
+/// budget) still terminates in bounded time.
+#[cfg(not(test))]
+const DELEGATION_OVERALL_DEADLINE: Duration = Duration::from_secs(30);
+#[cfg(test)]
+const DELEGATION_OVERALL_DEADLINE: Duration = Duration::from_secs(20);
 
 /// Bounded capacity for the transport→actor event channel.
 /// Sized for streaming model output bursts. When this fills, the
@@ -103,6 +142,107 @@ pub(crate) enum PeerCommand {
 }
 
 // ---------------------------------------------------------------------------
+// Delegation outcome
+// ---------------------------------------------------------------------------
+
+/// What [`PeerHandle::delegate_task`] resolved to.
+///
+/// `confirmed: true` means the peer acknowledged *acceptance* — it
+/// dispatched the task and `task_id` is its real local session
+/// identity, so the id is actionable (follow-ups, session lookups on
+/// the peer). `confirmed: false` is the fire-and-forget fallback
+/// (old-receiver peer, or the link died repeatedly before an ack):
+/// `task_id` is the transport's synthetic `task-out-{n}` marker and
+/// proves only that a frame entered the socket. Callers surface the
+/// difference (`delivery: acknowledged | unconfirmed` on the HTTP /
+/// MCP responses) instead of flattening both to a bare id.
+#[derive(Clone, Debug)]
+pub struct TaskDelegation {
+    /// Peer-local task identity when `confirmed`, synthetic otherwise.
+    pub task_id: TaskId,
+    /// The correlation id every send of this delegation carried; the
+    /// receiver dedups by it, so retrying a delegation with the same
+    /// `client_correlation_id` is idempotent.
+    pub delegation_id: String,
+    /// Whether the peer acknowledged acceptance with a
+    /// [`PeerEvent::TaskReceipt`].
+    pub confirmed: bool,
+    /// StartTask frames written for this delegation (1 = no retries).
+    pub sends: u32,
+}
+
+/// Outcome of one receipt grace window in
+/// [`PeerHandle::delegate_task`].
+enum GraceOutcome {
+    /// The correlated receipt arrived; payload is the peer's task id.
+    Confirmed(TaskId),
+    /// The connection stayed up for the whole grace window with no
+    /// ack — the old-receiver signature.
+    GraceElapsed,
+    /// The connection state changed during the window; the frame may
+    /// have died unread.
+    LinkUnstable,
+    /// The actor task exited (watch senders dropped).
+    ActorGone,
+}
+
+/// Wait until the actor reports `Connected`, bounded by `deadline`.
+/// Returns `false` on timeout or actor exit.
+async fn wait_for_connected(
+    rx: &mut watch::Receiver<ConnectionState>,
+    deadline: tokio::time::Instant,
+) -> bool {
+    let max = deadline
+        .checked_duration_since(tokio::time::Instant::now())
+        .unwrap_or(Duration::ZERO)
+        .min(DELEGATION_RECONNECT_WAIT);
+    matches!(
+        tokio::time::timeout_at(
+            tokio::time::Instant::now() + max,
+            rx.wait_for(|s| matches!(s, ConnectionState::Connected)),
+        )
+        .await,
+        Ok(Ok(_))
+    )
+}
+
+/// One bounded receipt wait: resolves on the correlated receipt, on
+/// any connection-state transition (the caller must have marked the
+/// connection watch as seen before writing the frame), or on
+/// [`DELEGATION_RECEIPT_GRACE`] elapsing.
+async fn wait_receipt_grace(
+    receipts: &mut watch::Receiver<Arc<HashMap<String, TaskId>>>,
+    connection: &mut watch::Receiver<ConnectionState>,
+    delegation_id: &str,
+) -> GraceOutcome {
+    if let Some(task_id) = receipts.borrow().get(delegation_id).cloned() {
+        return GraceOutcome::Confirmed(task_id);
+    }
+    let grace = tokio::time::sleep(DELEGATION_RECEIPT_GRACE);
+    tokio::pin!(grace);
+    loop {
+        tokio::select! {
+            changed = receipts.changed() => {
+                if changed.is_err() {
+                    return GraceOutcome::ActorGone;
+                }
+                if let Some(task_id) = receipts.borrow().get(delegation_id).cloned() {
+                    return GraceOutcome::Confirmed(task_id);
+                }
+                // Another delegation's receipt; keep waiting.
+            }
+            changed = connection.changed() => {
+                return match changed {
+                    Ok(()) => GraceOutcome::LinkUnstable,
+                    Err(_) => GraceOutcome::ActorGone,
+                };
+            }
+            _ = &mut grace => return GraceOutcome::GraceElapsed,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // The handle
 // ---------------------------------------------------------------------------
 
@@ -126,6 +266,12 @@ struct PeerHandleInner {
     /// Folded view of the peer's available displays (see the actor's
     /// `displays_tx` docs — connection-scoped, cleared on disconnect).
     displays: watch::Receiver<Arc<Vec<PeerDisplayInfo>>>,
+    /// Delegation-receipt ledger folded by the actor from
+    /// [`PeerEvent::TaskReceipt`] (delegation id → the peer's local
+    /// task/session identity). [`PeerHandle::delegate_task`] awaits an
+    /// entry here to resolve delivery; NOT cleared on disconnect (see
+    /// the actor's `receipts_tx` docs).
+    receipts: watch::Receiver<Arc<HashMap<String, TaskId>>>,
     commands: mpsc::Sender<PeerCommand>,
     events: broadcast::Sender<PeerEvent>,
     /// Browser-side TCP via URL — immutable for the lifetime of the
@@ -266,16 +412,161 @@ impl PeerHandle {
         }
     }
 
-    pub async fn delegate_task(&self, task: PeerTask) -> Result<TaskId, PeerError> {
+    /// Delegate a task to this peer with at-least-once delivery.
+    ///
+    /// The wire write is fire-and-forget (Intendant's `/ws` control
+    /// plane echoes no request id), so delivery is resolved
+    /// application-level: every send of this delegation carries one
+    /// `delegation_id` (the caller's `client_correlation_id` when
+    /// supplied, freshly minted otherwise), and a receiving daemon
+    /// that *dispatches* the task answers with a correlated
+    /// [`PeerEvent::TaskReceipt`] naming its real local session
+    /// identity. This method waits (bounded) for that receipt:
+    ///
+    /// - **Receipt arrives** → `confirmed: true`, `task_id` is the
+    ///   peer's real session id. "Accepted by the peer."
+    /// - **Connection drops before the receipt** → wait for the
+    ///   actor's reconnect and re-send the SAME delegation id, up to
+    ///   [`MAX_DELEGATION_SENDS`] writes within
+    ///   [`DELEGATION_OVERALL_DEADLINE`]. The receiver dedups by
+    ///   delegation id (a duplicate re-acks with the original session
+    ///   instead of starting a second task), so re-sending is safe.
+    /// - **Connection stays up but no receipt within
+    ///   [`DELEGATION_RECEIPT_GRACE`]** → the old-receiver signature
+    ///   (pre-receipt builds never ack): return `confirmed: false`
+    ///   with the transport's synthetic task id — today's
+    ///   fire-and-forget semantics, clearly marked. Deliberately no
+    ///   re-send in this case: the frame was read, and an old
+    ///   receiver would start a duplicate task.
+    ///
+    /// Receipts carry no authority — the receiving peer's IAM gates
+    /// the StartTask exactly as before; the receipt only reports what
+    /// the receiver already decided to run.
+    pub async fn delegate_task(&self, task: PeerTask) -> Result<TaskDelegation, PeerError> {
         if !self.features().task_delegation {
             return Err(PeerError::UnsupportedCapability("task_delegation".into()));
         }
-        match self.exec(PeerOp::DelegateTask { task }).await? {
-            PeerOpAck::TaskId(id) => Ok(id),
-            other => Err(PeerError::Transport(format!(
-                "expected TaskId ack, got {}",
-                other.name()
-            ))),
+        let delegation_id = task
+            .client_correlation_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("dg-{}", uuid::Uuid::new_v4().simple()));
+        let task = PeerTask {
+            client_correlation_id: Some(delegation_id.clone()),
+            ..task
+        };
+
+        let mut receipts = self.inner.receipts.clone();
+        let mut connection = self.inner.connection.clone();
+        let deadline = tokio::time::Instant::now() + DELEGATION_OVERALL_DEADLINE;
+        let mut fallback_task_id: Option<TaskId> = None;
+        let mut last_send_error: Option<PeerError> = None;
+        let mut sends: u32 = 0;
+
+        loop {
+            // A receipt may already be ledgered: the caller reused a
+            // correlation id an earlier call got acked under, or the
+            // ack landed while we waited out a reconnect below.
+            if let Some(task_id) = receipts.borrow().get(&delegation_id).cloned() {
+                return Ok(TaskDelegation {
+                    task_id,
+                    delegation_id,
+                    confirmed: true,
+                    sends,
+                });
+            }
+            if sends >= MAX_DELEGATION_SENDS || tokio::time::Instant::now() >= deadline {
+                break;
+            }
+
+            // Mark the connection watch as seen BEFORE the send: any
+            // state transition after this point — even a fast
+            // drop→reconnect round-trip back to Connected — wakes the
+            // grace select below, so an unstable link can never
+            // masquerade as the stable-but-silent old-peer signature.
+            let _ = connection.borrow_and_update();
+            sends += 1;
+            match self.exec(PeerOp::DelegateTask { task: task.clone() }).await {
+                Ok(PeerOpAck::TaskId(id)) => fallback_task_id = Some(id),
+                Ok(other) => {
+                    return Err(PeerError::Transport(format!(
+                        "expected TaskId ack, got {}",
+                        other.name()
+                    )))
+                }
+                Err(PeerError::NotConnected) => {
+                    // Actor is mid-reconnect (sends fail fast there) or
+                    // gone. Nothing was written, so this doesn't spend
+                    // a send; wait bounded for a reconnect and retry.
+                    sends -= 1;
+                    if !wait_for_connected(&mut connection, deadline).await {
+                        break;
+                    }
+                    continue;
+                }
+                Err(e @ PeerError::Transport(_)) => {
+                    // Failed write: nothing reached the wire (the
+                    // socket usually died under us). It still burns
+                    // the send so a deterministic failure (e.g.
+                    // serialization) can't spin until the deadline;
+                    // retry after the link settles.
+                    last_send_error = Some(e);
+                    if !wait_for_connected(&mut connection, deadline).await {
+                        break;
+                    }
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
+
+            // Frame written. Bounded wait for: the correlated receipt,
+            // any connection-state transition (link instability ⇒ the
+            // frame may have died unread ⇒ re-send), or grace elapsing
+            // on a stable link (old receiver ⇒ fire-and-forget).
+            match wait_receipt_grace(&mut receipts, &mut connection, &delegation_id).await {
+                GraceOutcome::Confirmed(task_id) => {
+                    return Ok(TaskDelegation {
+                        task_id,
+                        delegation_id,
+                        confirmed: true,
+                        sends,
+                    });
+                }
+                GraceOutcome::GraceElapsed => {
+                    let task_id = fallback_task_id
+                        .take()
+                        .expect("a send preceded every grace wait");
+                    return Ok(TaskDelegation {
+                        task_id,
+                        delegation_id,
+                        confirmed: false,
+                        sends,
+                    });
+                }
+                GraceOutcome::LinkUnstable => {
+                    if !wait_for_connected(&mut connection, deadline).await {
+                        break;
+                    }
+                    continue;
+                }
+                GraceOutcome::ActorGone => break,
+            }
+        }
+
+        // Send budget / deadline exhausted (or the actor exited)
+        // without an ack. If at least one frame was written, report it
+        // as unconfirmed fire-and-forget rather than erroring — the
+        // task may well be running on the peer.
+        match fallback_task_id {
+            Some(task_id) => Ok(TaskDelegation {
+                task_id,
+                delegation_id,
+                confirmed: false,
+                sends,
+            }),
+            None => Err(last_send_error.unwrap_or(PeerError::NotConnected)),
         }
     }
 
@@ -624,6 +915,7 @@ where
     let (card_tx, card_rx) = watch::channel(Arc::new(initial_card));
     let (sessions_tx, sessions_rx) = watch::channel(Arc::new(Vec::new()));
     let (displays_tx, displays_rx) = watch::channel(Arc::new(Vec::new()));
+    let (receipts_tx, receipts_rx) = watch::channel(Arc::new(HashMap::new()));
 
     let transport = build_transport(events_in_tx);
     let features = transport.features();
@@ -642,6 +934,9 @@ where
         sessions: std::collections::BTreeMap::new(),
         displays_tx,
         displays: std::collections::BTreeMap::new(),
+        receipts_tx,
+        receipts: HashMap::new(),
+        receipt_order: std::collections::VecDeque::new(),
         seq: 0,
         via_urls,
         label_override,
@@ -658,6 +953,7 @@ where
             card: card_rx,
             sessions: sessions_rx,
             displays: displays_rx,
+            receipts: receipts_rx,
             commands: commands_tx,
             events: events_out_tx,
             browser_tcp_via_url,
@@ -1163,5 +1459,445 @@ mod tests {
         );
         assert!(handle.snapshot().browser_tcp_via_url.is_none());
         assert!(handle.browser_tcp_via_url().is_none());
+    }
+
+    // -----------------------------------------------------------------
+    // Delegation delivery-receipt rig
+    // -----------------------------------------------------------------
+
+    use crate::event::{AppEvent, ControlMsg, EventBus};
+    use crate::peer::card::{AgentCard, AuthRequirements, TransportSpec};
+    use crate::peer::id::{PeerId, PeerKind};
+    use crate::peer::transport::IntendantWsTransport;
+    use crate::web_gateway::{spawn_web_gateway, ActiveSessionState, WebGatewayConfig};
+
+    /// Spin up a real gateway with its bus + broadcast handles exposed
+    /// so tests can observe delegated StartTask frames server-side and
+    /// script `task_received` acks back over the wire.
+    async fn spawn_receipt_test_gateway() -> (
+        u16,
+        tokio::task::JoinHandle<()>,
+        EventBus,
+        tokio::sync::broadcast::Sender<String>,
+    ) {
+        let bus = EventBus::new();
+        let (broadcast_tx, _) = tokio::sync::broadcast::channel::<String>(64);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let gateway = spawn_web_gateway(
+            listener,
+            bus.clone(),
+            broadcast_tx.clone(),
+            WebGatewayConfig::default(),
+            ActiveSessionState::empty(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Vec::new(),
+            None,
+            AuthRequirements::none(),
+            false,
+            None,
+        );
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        (port, gateway, bus, broadcast_tx)
+    }
+
+    fn receipt_test_card(name: &str, ws_url: &str) -> AgentCard {
+        AgentCard {
+            id: PeerId::new(PeerKind::Intendant, name),
+            label: name.into(),
+            version: "0.0.0".into(),
+            git_sha: None,
+            transports: vec![TransportSpec::IntendantWs { url: ws_url.into() }],
+            capabilities: vec![],
+            auth: AuthRequirements::none(),
+        }
+    }
+
+    fn spawn_handle_for(name: &str, ws_url: &str) -> PeerHandle {
+        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(256);
+        let card = receipt_test_card(name, ws_url);
+        let url = ws_url.to_string();
+        spawn_peer(
+            card.id.clone(),
+            card,
+            Vec::new(),
+            None,
+            None,
+            TransportCredentials::default(),
+            log_tx,
+            move |events_tx| Box::new(IntendantWsTransport::new(url, events_tx)),
+        )
+    }
+
+    async fn wait_connected(handle: &PeerHandle) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while handle.connection_state() != ConnectionState::Connected {
+            assert!(
+                Instant::now() < deadline,
+                "peer never connected (state: {:?})",
+                handle.connection_state()
+            );
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        // Let the gateway per-connection outbound loop subscribe to the
+        // broadcast before any test acks ride it.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+
+    /// Byte-forwarding TCP proxy with a kill switch. Tests point the
+    /// transport at `port`; `kill_live_links()` severs every proxied
+    /// connection (simulating the wire dying mid-delegation) while the
+    /// upstream gateway stays up for the reconnect.
+    struct KillableProxy {
+        port: u16,
+        kill_tx: Arc<tokio::sync::watch::Sender<u64>>,
+        accept_task: tokio::task::JoinHandle<()>,
+    }
+
+    impl KillableProxy {
+        async fn spawn(upstream_port: u16) -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            let (kill_tx, kill_rx) = tokio::sync::watch::channel(0u64);
+            let accept_task = tokio::spawn(async move {
+                loop {
+                    let Ok((client, _)) = listener.accept().await else {
+                        break;
+                    };
+                    let mut kill_rx = kill_rx.clone();
+                    let Ok(upstream) =
+                        tokio::net::TcpStream::connect(("127.0.0.1", upstream_port)).await
+                    else {
+                        continue;
+                    };
+                    tokio::spawn(async move {
+                        let generation = *kill_rx.borrow_and_update();
+                        let (mut client_read, mut client_write) = client.into_split();
+                        let (mut upstream_read, mut upstream_write) = upstream.into_split();
+                        let killed = async move {
+                            loop {
+                                if *kill_rx.borrow() != generation {
+                                    return;
+                                }
+                                if kill_rx.changed().await.is_err() {
+                                    // Proxy dropped at test teardown:
+                                    // treat as a kill.
+                                    return;
+                                }
+                            }
+                        };
+                        tokio::select! {
+                            _ = tokio::io::copy(&mut client_read, &mut upstream_write) => {}
+                            _ = tokio::io::copy(&mut upstream_read, &mut client_write) => {}
+                            _ = killed => {}
+                        }
+                    });
+                }
+            });
+            Self {
+                port,
+                kill_tx: Arc::new(kill_tx),
+                accept_task,
+            }
+        }
+
+        fn killer(&self) -> Arc<tokio::sync::watch::Sender<u64>> {
+            Arc::clone(&self.kill_tx)
+        }
+    }
+
+    impl Drop for KillableProxy {
+        fn drop(&mut self) {
+            self.accept_task.abort();
+        }
+    }
+
+    /// Server-side responder: watches the gateway bus for delegated
+    /// StartTask frames, records every delegation id it sees, kills the
+    /// proxied link for the first `kills_before_ack` deliveries, and
+    /// acknowledges the rest with `task_received` broadcasts. Acks are
+    /// repeated a few times so a just-reconnected outbound loop that
+    /// has not subscribed yet cannot miss them — receipt folds are
+    /// idempotent, so repeats are harmless.
+    fn spawn_delegation_responder(
+        bus: &EventBus,
+        broadcast_tx: tokio::sync::broadcast::Sender<String>,
+        kill: Option<Arc<tokio::sync::watch::Sender<u64>>>,
+        kills_before_ack: usize,
+        ack_session: &str,
+        seen_ids: Arc<std::sync::Mutex<Vec<String>>>,
+    ) -> tokio::task::JoinHandle<()> {
+        let mut rx = bus.subscribe();
+        let ack_session = ack_session.to_string();
+        tokio::spawn(async move {
+            let mut deliveries = 0usize;
+            loop {
+                let event = match rx.recv().await {
+                    Ok(event) => event,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                };
+                let AppEvent::ControlCommand(ControlMsg::StartTask { delegation_id, .. }) = event
+                else {
+                    continue;
+                };
+                let Some(id) = delegation_id else { continue };
+                seen_ids.lock().unwrap().push(id.clone());
+                deliveries += 1;
+                if deliveries <= kills_before_ack {
+                    if let Some(kill) = &kill {
+                        kill.send_modify(|generation| *generation += 1);
+                    }
+                    continue;
+                }
+                let receipt = serde_json::to_string(&crate::types::OutboundEvent::TaskReceived {
+                    delegation_id: id,
+                    session_id: ack_session.clone(),
+                })
+                .unwrap();
+                let tx = broadcast_tx.clone();
+                tokio::spawn(async move {
+                    for _ in 0..5 {
+                        let _ = tx.send(receipt.clone());
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                    }
+                });
+            }
+        })
+    }
+
+    fn delegation_task_payload(correlation: Option<&str>) -> PeerTask {
+        PeerTask {
+            instructions: "delegated work".into(),
+            context: serde_json::Value::Null,
+            client_correlation_id: correlation.map(str::to_string),
+        }
+    }
+
+    /// Happy path: the receiver acknowledges dispatch, and the resolved
+    /// delegation is `confirmed` with the PEER'S real session identity
+    /// (not the synthetic `task-out-{n}` marker), after exactly one
+    /// wire write carrying a freshly minted delegation id.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delegate_task_confirms_on_peer_receipt() {
+        let (port, gateway, bus, broadcast_tx) = spawn_receipt_test_gateway().await;
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let responder =
+            spawn_delegation_responder(&bus, broadcast_tx, None, 0, "peer-sess-42", seen.clone());
+
+        let handle = spawn_handle_for("receipt-happy", &format!("ws://127.0.0.1:{port}/ws"));
+        wait_connected(&handle).await;
+
+        let delegation = handle
+            .delegate_task(delegation_task_payload(None))
+            .await
+            .expect("delegation resolves");
+        assert!(delegation.confirmed, "receipt must confirm: {delegation:?}");
+        assert_eq!(
+            delegation.task_id.0, "peer-sess-42",
+            "confirmed id is the peer's session id"
+        );
+        assert_eq!(delegation.sends, 1, "no retries on a healthy link");
+        assert!(
+            delegation.delegation_id.starts_with("dg-"),
+            "minted id shape: {}",
+            delegation.delegation_id
+        );
+        assert_eq!(
+            seen.lock().unwrap().as_slice(),
+            std::slice::from_ref(&delegation.delegation_id),
+            "the wire frame carried the delegation id exactly once"
+        );
+
+        handle.disconnect().await.unwrap();
+        responder.abort();
+        gateway.abort();
+    }
+
+    /// Old-receiver signature: the frame is read but never acknowledged
+    /// while the connection stays up. The delegation falls back to
+    /// fire-and-forget semantics — `confirmed: false`, the synthetic
+    /// transport id — and critically does NOT re-send (an old receiver
+    /// has no dedup, so a re-send would start a duplicate task).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delegate_task_falls_back_fire_and_forget_without_ack() {
+        let (port, gateway, bus, _broadcast_tx) = spawn_receipt_test_gateway().await;
+        // Observe deliveries but never ack and never kill — this is a
+        // healthy connection to a receiver that ignores delegation_id.
+        let mut bus_rx = bus.subscribe();
+
+        let handle = spawn_handle_for("receipt-old-peer", &format!("ws://127.0.0.1:{port}/ws"));
+        wait_connected(&handle).await;
+
+        let delegation = handle
+            .delegate_task(delegation_task_payload(None))
+            .await
+            .expect("delegation resolves");
+        assert!(
+            !delegation.confirmed,
+            "no ack on a stable link must fall back: {delegation:?}"
+        );
+        assert_eq!(
+            delegation.sends, 1,
+            "stable-but-silent link must NOT trigger re-sends"
+        );
+        assert!(
+            delegation.task_id.0.starts_with("task-out-"),
+            "fallback keeps the synthetic id: {}",
+            delegation.task_id.0
+        );
+
+        // The frame really was delivered (fire-and-forget semantics,
+        // not a lost write).
+        let mut delivered = 0usize;
+        while let Ok(event) = bus_rx.try_recv() {
+            if matches!(
+                event,
+                AppEvent::ControlCommand(ControlMsg::StartTask { .. })
+            ) {
+                delivered += 1;
+            }
+        }
+        assert_eq!(delivered, 1, "exactly one StartTask reached the receiver");
+
+        handle.disconnect().await.unwrap();
+        gateway.abort();
+    }
+
+    /// A caller-supplied correlation id that is already ledgered (an
+    /// idempotent retry of an acked delegation) resolves straight from
+    /// the receipt ledger without writing anything to the wire.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delegate_task_short_circuits_on_ledgered_correlation_id() {
+        let (port, gateway, bus, broadcast_tx) = spawn_receipt_test_gateway().await;
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let responder =
+            spawn_delegation_responder(&bus, broadcast_tx, None, 0, "peer-sess-a", seen.clone());
+
+        let handle = spawn_handle_for("receipt-idem", &format!("ws://127.0.0.1:{port}/ws"));
+        wait_connected(&handle).await;
+
+        let first = handle
+            .delegate_task(delegation_task_payload(Some("corr-idem-1")))
+            .await
+            .expect("first delegation resolves");
+        assert!(first.confirmed);
+        assert_eq!(first.delegation_id, "corr-idem-1");
+        assert_eq!(first.sends, 1);
+
+        let second = handle
+            .delegate_task(delegation_task_payload(Some("corr-idem-1")))
+            .await
+            .expect("second delegation resolves");
+        assert!(second.confirmed);
+        assert_eq!(second.task_id.0, first.task_id.0);
+        assert_eq!(
+            second.sends, 0,
+            "ledgered correlation id must not touch the wire"
+        );
+        assert_eq!(
+            seen.lock().unwrap().len(),
+            1,
+            "the receiver saw exactly one delivery"
+        );
+
+        handle.disconnect().await.unwrap();
+        responder.abort();
+        gateway.abort();
+    }
+
+    /// At-least-once across link loss: the wire dies after the frame is
+    /// written but before any ack; the handle waits out the reconnect
+    /// and re-sends the SAME delegation id (the receiver's dedup key),
+    /// then resolves on the re-send's receipt.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn delegate_task_resends_same_id_across_link_loss() {
+        let (upstream_port, gateway, bus, broadcast_tx) = spawn_receipt_test_gateway().await;
+        let proxy = KillableProxy::spawn(upstream_port).await;
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let responder = spawn_delegation_responder(
+            &bus,
+            broadcast_tx,
+            Some(proxy.killer()),
+            1,
+            "peer-sess-second",
+            seen.clone(),
+        );
+
+        let handle = spawn_handle_for(
+            "receipt-retry",
+            &format!("ws://127.0.0.1:{}/ws", proxy.port),
+        );
+        wait_connected(&handle).await;
+
+        let delegation = handle
+            .delegate_task(delegation_task_payload(None))
+            .await
+            .expect("delegation resolves");
+        assert!(delegation.confirmed, "re-send must confirm: {delegation:?}");
+        assert_eq!(delegation.task_id.0, "peer-sess-second");
+        assert_eq!(delegation.sends, 2, "one loss, one re-send");
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 2, "receiver saw both deliveries: {seen:?}");
+        assert_eq!(
+            seen[0], seen[1],
+            "re-send must reuse the SAME delegation id (the dedup key)"
+        );
+        assert_eq!(seen[0], delegation.delegation_id);
+        drop(seen);
+
+        handle.disconnect().await.unwrap();
+        responder.abort();
+        gateway.abort();
+    }
+
+    /// The re-send budget is bounded: a link that dies after every
+    /// write terminates at [`MAX_DELEGATION_SENDS`] frames and reports
+    /// the delegation unconfirmed instead of retrying forever.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn delegate_task_bounds_resends_when_link_keeps_dying() {
+        let (upstream_port, gateway, bus, broadcast_tx) = spawn_receipt_test_gateway().await;
+        let proxy = KillableProxy::spawn(upstream_port).await;
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        // Kill on every delivery — no ack ever arrives.
+        let responder = spawn_delegation_responder(
+            &bus,
+            broadcast_tx,
+            Some(proxy.killer()),
+            usize::MAX,
+            "never-acked",
+            seen.clone(),
+        );
+
+        let handle = spawn_handle_for(
+            "receipt-bound",
+            &format!("ws://127.0.0.1:{}/ws", proxy.port),
+        );
+        wait_connected(&handle).await;
+
+        let delegation = handle
+            .delegate_task(delegation_task_payload(None))
+            .await
+            .expect("delegation resolves (unconfirmed) rather than erroring");
+        assert!(!delegation.confirmed);
+        assert_eq!(
+            delegation.sends, MAX_DELEGATION_SENDS,
+            "re-sends stop at the budget: {delegation:?}"
+        );
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), MAX_DELEGATION_SENDS as usize);
+        assert!(
+            seen.iter().all(|id| id == &seen[0]),
+            "every re-send reuses the same delegation id: {seen:?}"
+        );
+        drop(seen);
+
+        handle.disconnect().await.unwrap();
+        responder.abort();
+        gateway.abort();
     }
 }

--- a/src/bin/caller/peer/mod.rs
+++ b/src/bin/caller/peer/mod.rs
@@ -113,7 +113,7 @@ pub use coordinator::{Coordinator, CoordinatorError, TaskRequest};
 pub use event::{
     ActivityId, ActivityKind, ActivityOutcome, ApprovalDecision, ApprovalRequest, LogLevel,
     MessageContent, MessageId, MessageRole, ModelUsage, PeerDisplayInfo, PeerEvent, PeerMessage,
-    PeerStatus, SessionInfo, UsageSnapshot, WebRtcSessionId, WebRtcSignal,
+    PeerStatus, SessionInfo, TaskId, UsageSnapshot, WebRtcSessionId, WebRtcSignal,
 };
 pub use handle::{ConnectionState, PeerHandle, PeerSnapshot};
 pub use id::PeerId;

--- a/src/bin/caller/peer/ops.rs
+++ b/src/bin/caller/peer/ops.rs
@@ -94,10 +94,23 @@ pub async fn delegate_task_json(
         client_correlation_id: None,
     };
     match handle.delegate_task(task).await {
-        Ok(task_id) => serde_json::json!({
+        Ok(delegation) => serde_json::json!({
             "ok": true,
-            "task_id": task_id.0,
-            "note": "the peer's agent executes this under its own autonomy and approval policy",
+            "task_id": delegation.task_id.0,
+            "delegation_id": delegation.delegation_id,
+            // "acknowledged": the peer confirmed acceptance and task_id
+            // is its real session id. "unconfirmed": fire-and-forget
+            // fallback (older peer build, or the link kept dropping
+            // before an ack) — task_id is a sender-side marker only.
+            "delivery": if delegation.confirmed { "acknowledged" } else { "unconfirmed" },
+            // StartTask frames written (>1 = re-sent across a reconnect).
+            "sends": delegation.sends,
+            "note": if delegation.confirmed {
+                "accepted by the peer; its agent executes this under its own autonomy and approval policy"
+            } else {
+                "the peer did not acknowledge receipt (pre-receipt build or unstable link); \
+                 delivery is fire-and-forget and the task id is a local marker"
+            },
         })
         .to_string(),
         Err(err) => error_json(err.to_string()),

--- a/src/bin/caller/peer/traits.rs
+++ b/src/bin/caller/peer/traits.rs
@@ -198,12 +198,14 @@ pub struct PeerTask {
     #[allow(dead_code)]
     pub context: serde_json::Value,
 
-    /// Optional caller-supplied correlation id. Unused in phase 1.
-    /// Reserved for idempotent retries after transport timeouts: a
-    /// coordinator that retries a delegation after a timeout passes
-    /// the same id so the peer can deduplicate. Adding the field now
-    /// so the wire type is stable before retry logic lands.
-    #[allow(dead_code)]
+    /// Optional caller-supplied correlation id — the delegation's
+    /// delivery-receipt identity. When present it becomes the
+    /// `delegation_id` stamped on every StartTask write for this
+    /// delegation; when absent, [`crate::peer::handle::PeerHandle::
+    /// delegate_task`] mints one. The receiving daemon dedups by this
+    /// id (a repeat re-acks with the original session instead of
+    /// starting a duplicate task), so a coordinator that retries a
+    /// delegation after a timeout passes the same id for idempotency.
     pub client_correlation_id: Option<String>,
 }
 

--- a/src/bin/caller/peer/transport/intendant.rs
+++ b/src/bin/caller/peer/transport/intendant.rs
@@ -42,7 +42,9 @@
 //! - [`PeerOp::DelegateTask`] → [`ControlMsg::StartTask`] (kicks off
 //!   a fresh agent task). `PeerTask::instructions` maps to
 //!   `task`; the orchestration/direct/reference-frame/display-target
-//!   flags default to absent. Returns a synthetic `TaskId`.
+//!   flags default to absent. Returns a synthetic `TaskId` when the
+//!   frame is written; *delivery* is resolved above the transport —
+//!   see the delivery-receipt contract below.
 //! - [`PeerOp::ResolveApproval`] → [`ControlMsg::Approve`] /
 //!   `ApproveAll` / `Deny` / `Skip` based on
 //!   [`ApprovalDecision`]. Requires `request_id` to parse as `u64`
@@ -53,6 +55,46 @@
 //!   native control plane has no wire primitive for them. These
 //!   come in through other transport adapters (OpenClaw's node
 //!   `invoke`, A2A's task queries) when those land.
+//!
+//! ## Task-delegation delivery receipt
+//!
+//! A bare StartTask write proves only that the frame entered this
+//! side's socket: if the connection dies before the peer reads it,
+//! the actor reconnects but nothing re-sends, and the delegation is
+//! silently lost (at-most-once). The receipt closes that gap at the
+//! application level:
+//!
+//! - **Outbound**: `DelegateTask` stamps the StartTask frame with the
+//!   delegation's correlation id —
+//!   `{"action":"start_task","task":…,"delegation_id":"dg-…"}`.
+//! - **Inbound**: a receiving daemon that *dispatches* the task (not
+//!   merely reads the frame) broadcasts
+//!   `{"event":"task_received","delegation_id":"dg-…",
+//!   "session_id":"<its local session id>"}`, which the drain upcasts
+//!   to [`crate::peer::event::PeerEvent::TaskReceipt`]. The per-peer
+//!   actor folds receipts into a bounded ledger that
+//!   [`crate::peer::handle::PeerHandle::delegate_task`] awaits — the
+//!   retry / grace / fallback policy (at-least-once with receiver-side
+//!   dedup by delegation id) lives there, NOT in the transport, so the
+//!   actor's event pump never blocks on a receipt.
+//! - Receipts are informational: they carry no authority, and IAM
+//!   evaluation on the receiving gateway is unchanged.
+//!
+//! ### Compatibility matrix
+//!
+//! | Sender | Receiver | Behavior |
+//! |---|---|---|
+//! | new | new | Receiver acks on dispatch; sender resolves `confirmed` with the peer's real session id; re-sends after a connection drop are deduped by `delegation_id`. |
+//! | new | old | Receiver ignores the unknown `delegation_id` field (plain serde) and runs the task exactly as today; it never acks. The sender's grace elapses on a stable connection — the old-peer signature — and it reports the fire-and-forget fallback (`confirmed: false`, synthetic id) **without re-sending** (an old receiver has no dedup, so a re-send would duplicate the task). |
+//! | old | new | The frame carries no `delegation_id`; the receiver behaves exactly as today (no ack, no dedup entry). |
+//! | old | old | Unchanged fire-and-forget. |
+//!
+//! One deliberate residue: only *daemon* receivers ack (the session
+//! supervisor is the acceptance point). A new-build receiver running
+//! a non-daemon shape routes StartTask through the legacy dispatcher
+//! and never acks — indistinguishable from an old receiver, and safe
+//! for the same reason (grace → fire-and-forget fallback, no
+//! re-send on a stable link).
 //!
 //! ## Disconnection signaling
 //!
@@ -105,9 +147,14 @@ pub struct IntendantWsTransport {
     /// returned from `send`. Intendant's `/ws` control plane is
     /// fire-and-forget — no wire-level id echoes back — so the
     /// transport fabricates an id so callers have something
-    /// unique to log. Real correlation with subsequent activity
-    /// events happens through the drain path's `ActivityStarted`
-    /// / `Message` emissions.
+    /// unique to log. For messages, real correlation with subsequent
+    /// activity happens through the drain path's `ActivityStarted` /
+    /// `Message` emissions. For task delegation the synthetic id is
+    /// only the *fallback* identity: an application-level receipt
+    /// (`task_received`, upcast to `PeerEvent::TaskReceipt`) replaces
+    /// it with the peer's real session id when the receiver
+    /// acknowledges dispatch — see "Task-delegation delivery receipt"
+    /// in the module docs.
     out_seq: AtomicU64,
 }
 
@@ -566,6 +613,17 @@ impl PeerTransport for IntendantWsTransport {
                     display_target: None,
                     attachments: Vec::new(),
                     follow_up_id: None,
+                    // Delivery-receipt correlation id (see the module
+                    // docs' compatibility matrix). A new receiver that
+                    // dispatches this task answers with
+                    // `{"event":"task_received", "delegation_id":…,
+                    // "session_id":…}` on its broadcast, which the
+                    // drain upcasts to `PeerEvent::TaskReceipt`; an old
+                    // receiver ignores the unknown field and never
+                    // acks. The ack returned below stays synthetic —
+                    // the receipt wait lives on `PeerHandle::
+                    // delegate_task`, not in the transport.
+                    delegation_id: task.client_correlation_id.clone(),
                 })
                 .await?;
                 let seq = self.next_out_seq();
@@ -1012,22 +1070,29 @@ mod tests {
                 task: PeerTask {
                     instructions: "research the federation protocol".into(),
                     context: serde_json::Value::Null,
-                    client_correlation_id: None,
+                    client_correlation_id: Some("corr-wire-1".into()),
                 },
             })
             .await
             .expect("delegate_task succeeds");
         assert!(matches!(ack, PeerOpAck::TaskId(_)));
 
+        // The delivery-receipt correlation id rides the frame as
+        // `delegation_id` (see the module docs' receipt contract);
+        // everything else keeps its legacy shape.
         let event = wait_for_event(&mut bus_rx, |e| {
             matches!(
                 e,
-                AppEvent::ControlCommand(ControlMsg::StartTask { task, .. })
+                AppEvent::ControlCommand(ControlMsg::StartTask { task, delegation_id, .. })
                 if task == "research the federation protocol"
+                    && delegation_id.as_deref() == Some("corr-wire-1")
             )
         })
         .await;
-        assert!(event.is_some(), "StartTask did not land on the bus");
+        assert!(
+            event.is_some(),
+            "StartTask with the delegation id did not land on the bus"
+        );
 
         transport.disconnect().await.unwrap();
         gateway.abort();

--- a/src/bin/caller/peer/upcast.rs
+++ b/src/bin/caller/peer/upcast.rs
@@ -51,7 +51,7 @@ use crate::event::AppEvent;
 use crate::peer::{
     ActivityId, ActivityKind, ActivityOutcome, ApprovalDecision, ApprovalRequest, Capability,
     LogLevel, MessageContent, MessageId, MessageRole, ModelUsage, PeerDisplayInfo, PeerEvent,
-    PeerStatus, SessionInfo, UsageSnapshot,
+    PeerStatus, SessionInfo, TaskId, UsageSnapshot,
 };
 use crate::types::OutboundEvent;
 
@@ -919,6 +919,24 @@ impl AppEventUpcaster {
                 LogLevel::Info,
                 "session",
                 format!("session attached: {} ({})", session_id, source),
+            )],
+
+            // This daemon acknowledged an inbound peer delegation.
+            // Narrate on the log rail only — the receipt's correlation
+            // job happens on the *delegating* side (its wire upcaster
+            // maps `OutboundEvent::TaskReceived` to
+            // `PeerEvent::TaskReceipt`); locally the accepted task
+            // already narrates itself via SessionStarted.
+            AppEvent::TaskReceived {
+                delegation_id,
+                session_id,
+            } => vec![log_event(
+                LogLevel::Info,
+                "session",
+                format!(
+                    "accepted delegated task {} as session {}",
+                    delegation_id, session_id
+                ),
             )],
 
             AppEvent::SessionEnded {
@@ -2300,6 +2318,19 @@ impl WireEventUpcaster {
                 "session",
                 format!("session attached: {} ({})", session_id, source),
             )],
+
+            // Peer-delegation delivery receipt: the peer accepted a
+            // task this side delegated and names its local session for
+            // it. Upcast 1:1 so the per-peer actor can fold it into the
+            // bounded receipt ledger `PeerHandle::delegate_task` awaits
+            // (and so peers.jsonl keeps the durable acceptance record).
+            OutboundEvent::TaskReceived {
+                delegation_id,
+                session_id,
+            } => vec![PeerEvent::TaskReceipt {
+                delegation_id: delegation_id.clone(),
+                task: TaskId(session_id.clone()),
+            }],
 
             OutboundEvent::SessionEnded {
                 session_id, reason, ..

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -46,6 +46,7 @@ pub fn action_to_control_msg(action: &PresenceAction) -> Option<(ControlMsg, Str
                     display_target: envelope.display_target.clone(),
                     attachments: envelope.attachment_frame_ids.clone(),
                     follow_up_id: None,
+                    delegation_id: None,
                 },
                 confirmation,
             ))
@@ -1118,7 +1119,11 @@ pub fn filter_event(event: &AppEvent, last_phase: &mut String) -> Option<Presenc
         | AppEvent::SteerDelivered { .. }
         | AppEvent::SteerCancelRequested { .. }
         | AppEvent::SteerCancelled { .. }
-        | AppEvent::FollowUpCancelRequested { .. } => None,
+        | AppEvent::FollowUpCancelRequested { .. }
+        // Peer-delegation delivery receipts are wire-facing correlation
+        // events (OutboundEvent::TaskReceived); the accepted task
+        // narrates itself through its own session lifecycle.
+        | AppEvent::TaskReceived { .. } => None,
     }
 }
 

--- a/src/bin/caller/session_supervisor/dispatch.rs
+++ b/src/bin/caller/session_supervisor/dispatch.rs
@@ -53,33 +53,34 @@ impl SessionSupervisor {
                                     "/fast creates an idle Codex session; attachments and display metadata were ignored",
                                 );
                             }
-                            self.start_new_session(
-                                String::new(),
-                                name,
-                                project_root,
-                                agent,
-                                agent_command,
-                                None,
-                                None,
-                                None,
-                                codex_model,
-                                codex_reasoning_effort,
-                                codex_sandbox,
-                                codex_approval_policy,
-                                codex_managed_context,
-                                codex_context_archive,
-                                orchestrate,
-                                direct,
-                                Vec::new(),
-                                None,
-                                Vec::new(),
-                                Some(
-                                    crate::external_agent::codex::CODEX_FAST_SERVICE_TIER
-                                        .to_string(),
-                                ),
-                                worktree_request,
-                            )
-                            .await;
+                            let _ = self
+                                .start_new_session(
+                                    String::new(),
+                                    name,
+                                    project_root,
+                                    agent,
+                                    agent_command,
+                                    None,
+                                    None,
+                                    None,
+                                    codex_model,
+                                    codex_reasoning_effort,
+                                    codex_sandbox,
+                                    codex_approval_policy,
+                                    codex_managed_context,
+                                    codex_context_archive,
+                                    orchestrate,
+                                    direct,
+                                    Vec::new(),
+                                    None,
+                                    Vec::new(),
+                                    Some(
+                                        crate::external_agent::codex::CODEX_FAST_SERVICE_TIER
+                                            .to_string(),
+                                    ),
+                                    worktree_request,
+                                )
+                                .await;
                             return;
                         }
                         Ok(_) | Err(_) => {}
@@ -109,30 +110,31 @@ impl SessionSupervisor {
                         .await;
                     return;
                 }
-                self.start_new_session(
-                    task,
-                    name,
-                    project_root,
-                    agent,
-                    agent_command,
-                    claude_model,
-                    claude_permission_mode,
-                    claude_effort,
-                    codex_model,
-                    codex_reasoning_effort,
-                    codex_sandbox,
-                    codex_approval_policy,
-                    codex_managed_context,
-                    codex_context_archive,
-                    orchestrate,
-                    direct,
-                    reference_frame_ids,
-                    display_target,
-                    attachments,
-                    codex_service_tier,
-                    worktree_request,
-                )
-                .await;
+                let _ = self
+                    .start_new_session(
+                        task,
+                        name,
+                        project_root,
+                        agent,
+                        agent_command,
+                        claude_model,
+                        claude_permission_mode,
+                        claude_effort,
+                        codex_model,
+                        codex_reasoning_effort,
+                        codex_sandbox,
+                        codex_approval_policy,
+                        codex_managed_context,
+                        codex_context_archive,
+                        orchestrate,
+                        direct,
+                        reference_frame_ids,
+                        display_target,
+                        attachments,
+                        codex_service_tier,
+                        worktree_request,
+                    )
+                    .await;
             }
             event::ControlMsg::StartTask {
                 session_id: Some(session_id),
@@ -162,7 +164,28 @@ impl SessionSupervisor {
                 display_target,
                 attachments,
                 follow_up_id: _,
+                delegation_id,
             } => {
+                // Peer-delegation dedup: the delegating daemon re-sends
+                // the same delegation_id after a connection drop
+                // (at-least-once delivery). An id this supervisor
+                // already dispatched re-acks with the ORIGINAL session
+                // identity instead of starting a duplicate task.
+                if let Some(id) = delegation_id.as_deref() {
+                    let already = self.state.lock().await.recorded_delegation_session(id);
+                    if let Some(session_id) = already {
+                        self.info(&format!(
+                            "Duplicate peer delegation {} re-acknowledged as session {}",
+                            id,
+                            short_session(&session_id)
+                        ));
+                        self.config.bus.send(AppEvent::TaskReceived {
+                            delegation_id: id.to_string(),
+                            session_id,
+                        });
+                        return;
+                    }
+                }
                 if let Some(parsed) = parse_codex_slash_command(&task) {
                     match parsed {
                         Ok(command) if command.op == "fast" => {
@@ -174,33 +197,39 @@ impl SessionSupervisor {
                                     "/fast creates an idle Codex session; attachments and display metadata were ignored",
                                 );
                             }
-                            self.start_new_session(
-                                String::new(),
-                                None,
-                                None,
-                                Some("codex".to_string()),
-                                None,
-                                None,
-                                None,
-                                None,
-                                None,
-                                None,
-                                None,
-                                None,
-                                None,
-                                None,
-                                orchestrate,
-                                direct,
-                                Vec::new(),
-                                None,
-                                Vec::new(),
-                                Some(
-                                    crate::external_agent::codex::CODEX_FAST_SERVICE_TIER
-                                        .to_string(),
-                                ),
-                                None,
-                            )
-                            .await;
+                            let started = self
+                                .start_new_session(
+                                    String::new(),
+                                    None,
+                                    None,
+                                    Some("codex".to_string()),
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                    None,
+                                    orchestrate,
+                                    direct,
+                                    Vec::new(),
+                                    None,
+                                    Vec::new(),
+                                    Some(
+                                        crate::external_agent::codex::CODEX_FAST_SERVICE_TIER
+                                            .to_string(),
+                                    ),
+                                    None,
+                                )
+                                .await;
+                            if let (Some(id), Some(session_id)) =
+                                (delegation_id.as_deref(), started.as_deref())
+                            {
+                                self.acknowledge_delegation(id, session_id).await;
+                            }
                             return;
                         }
                         Ok(_) | Err(_) => {}
@@ -210,34 +239,51 @@ impl SessionSupervisor {
                             "Slash command dropped reference frame/display metadata; routing to active Codex session",
                         );
                     }
+                    // Slash commands route as follow-ups into an existing
+                    // session — there is no fresh dispatch identity to
+                    // acknowledge, so a delegated slash command is NOT
+                    // acked and the delegating side reports its
+                    // fire-and-forget fallback after the grace window.
                     self.route_follow_up(None, task, direct, attachments, None)
                         .await;
                     return;
                 }
-                self.start_new_session(
-                    task,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    orchestrate,
-                    direct,
-                    reference_frame_ids,
-                    display_target,
-                    attachments,
-                    None,
-                    None,
-                )
-                .await;
+                let started = self
+                    .start_new_session(
+                        task,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        orchestrate,
+                        direct,
+                        reference_frame_ids,
+                        display_target,
+                        attachments,
+                        None,
+                        None,
+                    )
+                    .await;
+                // Acknowledge acceptance only once the task is actually
+                // dispatched (start_new_session returned the launched
+                // session): the receipt means "running here as this
+                // session", never "frame parsed". Failed launches return
+                // None and stay unacked — the delegating side reports
+                // the delegation unconfirmed instead of pointing at a
+                // session that never existed.
+                if let (Some(id), Some(session_id)) = (delegation_id.as_deref(), started.as_deref())
+                {
+                    self.acknowledge_delegation(id, session_id).await;
+                }
             }
             event::ControlMsg::SpawnSubAgent {
                 session_id,
@@ -480,6 +526,29 @@ impl SessionSupervisor {
         }
     }
 
+    /// Record an accepted peer delegation in the dedup ledger and
+    /// broadcast the delivery receipt (`AppEvent::TaskReceived` →
+    /// `OutboundEvent::TaskReceived` on every connected client,
+    /// including the delegating daemon's federation transport).
+    /// Duplicate deliveries are answered at the dispatch site via
+    /// [`SupervisorState::recorded_delegation_session`] without
+    /// re-recording.
+    pub(crate) async fn acknowledge_delegation(&self, delegation_id: &str, session_id: &str) {
+        self.state
+            .lock()
+            .await
+            .record_delegation(delegation_id, session_id);
+        self.info(&format!(
+            "Accepted peer delegation {} as session {}",
+            delegation_id,
+            short_session(session_id)
+        ));
+        self.config.bus.send(AppEvent::TaskReceived {
+            delegation_id: delegation_id.to_string(),
+            session_id: session_id.to_string(),
+        });
+    }
+
     pub(crate) async fn should_handle_session_control(&self, msg: &event::ControlMsg) -> bool {
         match msg {
             event::ControlMsg::CreateSession { .. } => true,
@@ -615,7 +684,9 @@ pub(crate) fn control_msg_can_attach_unmanaged_session(msg: &event::ControlMsg) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session_supervisor::tests::{managed_session, test_supervisor};
+    use crate::session_supervisor::tests::{
+        managed_session, test_supervisor, test_supervisor_with_mock_provider,
+    };
 
     #[tokio::test]
     async fn thread_action_fallback_defers_to_advertised_ops() {
@@ -782,5 +853,173 @@ mod tests {
             attachments: Vec::new(),
         };
         assert!(control_msg_can_attach_unmanaged_session(&msg));
+    }
+
+    fn delegated_start_task(delegation_id: &str) -> event::ControlMsg {
+        event::ControlMsg::StartTask {
+            session_id: None,
+            task: "delegated: report project status".to_string(),
+            orchestrate: None,
+            direct: Some(true),
+            reference_frame_ids: vec![],
+            display_target: None,
+            attachments: vec![],
+            follow_up_id: None,
+            delegation_id: Some(delegation_id.to_string()),
+        }
+    }
+
+    /// The receiver half of the peer-delegation delivery receipt: a
+    /// StartTask carrying a `delegation_id` is acknowledged with
+    /// `AppEvent::TaskReceived` naming the session it actually
+    /// dispatched, and an at-least-once re-send of the SAME id re-acks
+    /// with the ORIGINAL session instead of starting a duplicate task.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn peer_delegation_acks_on_dispatch_and_dedups_resend() {
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        let project_dir = tempfile::tempdir().unwrap();
+        let supervisor =
+            test_supervisor_with_mock_provider(project_dir.path().to_path_buf(), bus.clone());
+
+        supervisor
+            .handle_control_msg(delegated_start_task("dg-recv-1"))
+            .await;
+
+        // Collect until the receipt arrives; remember every announced
+        // session so we can pin the receipt to a real launch.
+        let mut started_sessions: Vec<String> = Vec::new();
+        let mut receipt_session: Option<String> = None;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while receipt_session.is_none() {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "no TaskReceived receipt within the deadline (started: {started_sessions:?})"
+            );
+            match tokio::time::timeout(remaining, rx.recv()).await {
+                Ok(Ok(AppEvent::SessionStarted { session_id, .. })) => {
+                    started_sessions.push(session_id);
+                }
+                Ok(Ok(AppEvent::TaskReceived {
+                    delegation_id,
+                    session_id,
+                })) => {
+                    assert_eq!(delegation_id, "dg-recv-1");
+                    receipt_session = Some(session_id);
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                other => panic!("bus closed before the receipt: {other:?}"),
+            }
+        }
+        let receipt_session = receipt_session.unwrap();
+        assert!(
+            started_sessions.contains(&receipt_session),
+            "receipt must name a session that actually started \
+             (receipt: {receipt_session}, started: {started_sessions:?})"
+        );
+
+        // Re-send of the same delegation id (the delegating daemon's
+        // at-least-once retry): re-ack with the original session, and
+        // no second session starts.
+        supervisor
+            .handle_control_msg(delegated_start_task("dg-recv-1"))
+            .await;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let re_ack_session = loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(!remaining.is_zero(), "no re-ack for the duplicate delivery");
+            match tokio::time::timeout(remaining, rx.recv()).await {
+                Ok(Ok(AppEvent::TaskReceived {
+                    delegation_id,
+                    session_id,
+                })) if delegation_id == "dg-recv-1" => break session_id,
+                Ok(Ok(AppEvent::SessionStarted { session_id, .. })) => {
+                    panic!("duplicate delegation must not start a session ({session_id})")
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                other => panic!("bus closed before the re-ack: {other:?}"),
+            }
+        };
+        assert_eq!(
+            re_ack_session, receipt_session,
+            "re-ack must carry the ORIGINAL session identity"
+        );
+
+        // And the dedup really did keep it to one session: nothing new
+        // starts in a short settle window after the re-ack.
+        let settle = std::time::Instant::now() + std::time::Duration::from_millis(400);
+        loop {
+            let remaining = settle.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match tokio::time::timeout(remaining, rx.recv()).await {
+                Ok(Ok(AppEvent::SessionStarted { session_id, .. })) => {
+                    panic!("late duplicate session started: {session_id}")
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                _ => break,
+            }
+        }
+    }
+
+    /// A StartTask without a delegation id (browsers, ctl, pre-receipt
+    /// peers) never emits a receipt — the field is strictly opt-in.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn undelegated_start_task_emits_no_receipt() {
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        let project_dir = tempfile::tempdir().unwrap();
+        let supervisor =
+            test_supervisor_with_mock_provider(project_dir.path().to_path_buf(), bus.clone());
+
+        supervisor
+            .handle_control_msg(event::ControlMsg::StartTask {
+                session_id: None,
+                task: "plain local task".to_string(),
+                orchestrate: None,
+                direct: Some(true),
+                reference_frame_ids: vec![],
+                display_target: None,
+                attachments: vec![],
+                follow_up_id: None,
+                delegation_id: None,
+            })
+            .await;
+
+        // The session starts; give the pipeline a short settle window
+        // and assert no TaskReceived ever fires.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let mut saw_start = false;
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match tokio::time::timeout(remaining, rx.recv()).await {
+                Ok(Ok(AppEvent::TaskReceived { delegation_id, .. })) => {
+                    panic!("undelegated task must not be acked (got {delegation_id})")
+                }
+                Ok(Ok(AppEvent::SessionStarted { .. })) => {
+                    saw_start = true;
+                    // Short settle after the launch, then stop watching.
+                    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+                    while let Ok(event) = rx.try_recv() {
+                        if let AppEvent::TaskReceived { delegation_id, .. } = event {
+                            panic!("undelegated task must not be acked (got {delegation_id})");
+                        }
+                    }
+                    break;
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                _ => break,
+            }
+        }
+        assert!(saw_start, "the plain task should still launch");
     }
 }

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -15,6 +15,11 @@ impl SessionSupervisor {
         }
     }
 
+    /// Create and dispatch a new managed session. Returns the launched
+    /// session id once the task is actually dispatched (the peer-
+    /// delegation receipt keys on this — see
+    /// [`Self::acknowledge_delegation`]); `None` on every failure exit,
+    /// which all narrate their own error before returning.
     #[allow(clippy::too_many_arguments)] // established internal signature: the params are distinct dependencies, not a bundle
     pub(crate) async fn start_new_session(
         &self,
@@ -39,12 +44,12 @@ impl SessionSupervisor {
         attachments: Vec<String>,
         codex_service_tier: Option<String>,
         worktree: Option<SessionWorktreeRequest>,
-    ) {
+    ) -> Option<String> {
         let session_name = match normalize_session_name_option(name.as_deref()) {
             Ok(name) => name,
             Err(e) => {
                 self.loop_error(format!("Session create failed: {}", e));
-                return;
+                return None;
             }
         };
         let log_dir = session_log::SessionLog::resolve_path_in_home(&self.logs_home(), None);
@@ -52,7 +57,7 @@ impl SessionSupervisor {
             Ok(log) => Arc::new(Mutex::new(log)),
             Err(e) => {
                 self.loop_error(format!("Session create failed: {}", e));
-                return;
+                return None;
             }
         };
 
@@ -81,11 +86,11 @@ impl SessionSupervisor {
                     reason: format!("error: {reason}"),
                     error_kind: Some(NO_PROJECT_ERROR_KIND.to_string()),
                 });
-                return;
+                return None;
             }
             Err(e) => {
                 self.loop_error(format!("Project load failed: {}", e));
-                return;
+                return None;
             }
         };
         // Worktree launch: branch off the resolved project root's HEAD and
@@ -112,7 +117,7 @@ impl SessionSupervisor {
                             reason: format!("error: {reason}"),
                             error_kind: None,
                         });
-                        return;
+                        return None;
                     }
                 }
             }
@@ -126,7 +131,7 @@ impl SessionSupervisor {
             Ok(project) => project,
             Err(e) => {
                 self.loop_error(format!("Project load failed: {}", e));
-                return;
+                return None;
             }
         };
 
@@ -172,7 +177,8 @@ impl SessionSupervisor {
                 session_id: session_id.clone(),
                 task: Some(task.clone()),
             });
-            return;
+            // Dispatched (as an ephemeral CU task session).
+            return Some(session_id);
         }
 
         let use_direct = direct.unwrap_or(false)
@@ -183,7 +189,7 @@ impl SessionSupervisor {
             Ok(selection) => selection,
             Err(e) => {
                 self.loop_error(format!("Session create failed: {}", e));
-                return;
+                return None;
             }
         };
         let backend = match agent_selection {
@@ -200,7 +206,7 @@ impl SessionSupervisor {
             Ok(project) => project,
             Err(e) => {
                 self.loop_error(format!("Project load failed: {}", e));
-                return;
+                return None;
             }
         };
         let agent_command = normalize_session_agent_command(agent_command.as_deref());
@@ -209,7 +215,7 @@ impl SessionSupervisor {
                 self.loop_error(
                     "Session create failed: agent_command requires an external agent".to_string(),
                 );
-                return;
+                return None;
             };
             apply_session_agent_command(&mut project, backend, command);
         }
@@ -222,11 +228,11 @@ impl SessionSupervisor {
                 self.loop_error(
                     "Session create failed: claude_model requires Claude Code".to_string(),
                 );
-                return;
+                return None;
             };
             if let Err(e) = apply_session_claude_model(&mut project, backend, model.to_string()) {
                 self.loop_error(format!("Session create failed: {}", e));
-                return;
+                return None;
             }
         }
         if let Some(mode) = claude_permission_mode
@@ -239,13 +245,13 @@ impl SessionSupervisor {
                     "Session create failed: claude_permission_mode requires Claude Code"
                         .to_string(),
                 );
-                return;
+                return None;
             };
             if let Err(e) =
                 apply_session_claude_permission_mode(&mut project, backend, mode.to_string())
             {
                 self.loop_error(format!("Session create failed: {}", e));
-                return;
+                return None;
             }
         }
         if let Some(effort) = claude_effort
@@ -257,11 +263,11 @@ impl SessionSupervisor {
                 self.loop_error(
                     "Session create failed: claude_effort requires Claude Code".to_string(),
                 );
-                return;
+                return None;
             };
             if let Err(e) = apply_session_claude_effort(&mut project, backend, effort.to_string()) {
                 self.loop_error(format!("Session create failed: {}", e));
-                return;
+                return None;
             }
         }
         if let Some(model) = codex_model
@@ -271,11 +277,11 @@ impl SessionSupervisor {
         {
             let Some(ref backend) = backend else {
                 self.loop_error("Session create failed: codex_model requires Codex".to_string());
-                return;
+                return None;
             };
             if let Err(e) = apply_session_codex_model(&mut project, backend, model.to_string()) {
                 self.loop_error(format!("Session create failed: {}", e));
-                return;
+                return None;
             }
         }
         if let Some(effort) = codex_reasoning_effort
@@ -289,23 +295,23 @@ impl SessionSupervisor {
                 self.loop_error(
                     "Session create failed: codex_reasoning_effort requires Codex".to_string(),
                 );
-                return;
+                return None;
             };
             if let Err(e) =
                 apply_session_codex_reasoning_effort(&mut project, backend, effort.to_string())
             {
                 self.loop_error(format!("Session create failed: {}", e));
-                return;
+                return None;
             }
         }
         if let Some(mode) = normalize_session_codex_sandbox(codex_sandbox.as_deref()) {
             let Some(ref backend) = backend else {
                 self.loop_error("Session create failed: codex_sandbox requires Codex".to_string());
-                return;
+                return None;
             };
             if let Err(e) = apply_session_codex_sandbox(&mut project, backend, mode) {
                 self.loop_error(format!("Session create failed: {}", e));
-                return;
+                return None;
             }
         }
         if let Some(policy) =
@@ -315,11 +321,11 @@ impl SessionSupervisor {
                 self.loop_error(
                     "Session create failed: codex_approval_policy requires Codex".to_string(),
                 );
-                return;
+                return None;
             };
             if let Err(e) = apply_session_codex_approval_policy(&mut project, backend, policy) {
                 self.loop_error(format!("Session create failed: {}", e));
-                return;
+                return None;
             }
         }
         if let Some(mode) =
@@ -329,11 +335,11 @@ impl SessionSupervisor {
                 self.loop_error(
                     "Session create failed: codex_managed_context requires Codex".to_string(),
                 );
-                return;
+                return None;
             };
             if let Err(e) = apply_session_codex_managed_context(&mut project, backend, mode) {
                 self.loop_error(format!("Session create failed: {}", e));
-                return;
+                return None;
             }
         }
         if let Some(mode) =
@@ -343,11 +349,11 @@ impl SessionSupervisor {
                 self.loop_error(
                     "Session create failed: codex_context_archive requires Codex".to_string(),
                 );
-                return;
+                return None;
             };
             if let Err(e) = apply_session_codex_context_archive(&mut project, backend, mode) {
                 self.loop_error(format!("Session create failed: {}", e));
-                return;
+                return None;
             }
         }
         let codex_service_tier =
@@ -359,7 +365,7 @@ impl SessionSupervisor {
                     self.loop_error(
                         "Session create failed: codex_service_tier requires Codex".to_string(),
                     );
-                    return;
+                    return None;
                 }
             }
         }
@@ -414,6 +420,7 @@ impl SessionSupervisor {
         if !task.trim().is_empty() {
             emit_task_dispatched_log(&self.config.bus, &session_log, &task, attachments.len());
         }
+        let launched_session_id = session_id.clone();
         self.spawn_agent_session(
             session_id,
             source,
@@ -434,6 +441,7 @@ impl SessionSupervisor {
             None,
         )
         .await;
+        Some(launched_session_id)
     }
 
     #[allow(clippy::too_many_arguments)] // established internal signature: the params are distinct dependencies, not a bundle

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -80,6 +80,11 @@ pub struct SessionSupervisor {
 const EXTERNAL_ATTACH_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const SESSION_STOP_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 const SESSION_RESTART_DEDUPE_WINDOW: std::time::Duration = std::time::Duration::from_secs(5);
+/// Bound on the peer-delegation dedup ledger (`delegation_receipts`).
+/// Entries only need to outlive the delegating side's bounded re-send
+/// window (~30 s), so a FIFO of this size is generous; the bound keeps
+/// a peer that mints endless delegation ids from growing the map.
+const MAX_DELEGATION_RECEIPTS: usize = 128;
 const EXTERNAL_ATTACH_DEDUPE_WINDOW: std::time::Duration = EXTERNAL_ATTACH_READY_TIMEOUT;
 #[cfg(not(test))]
 const EDIT_ATTACH_ROUTE_TIMEOUT: std::time::Duration = EXTERNAL_ATTACH_READY_TIMEOUT;
@@ -111,6 +116,15 @@ pub(crate) struct SupervisorState {
     /// The fallback responder defers to the advertising loop for exactly
     /// these ops instead of false-rejecting non-external sessions.
     advertised_thread_actions: HashMap<String, std::collections::HashSet<String>>,
+    /// Peer-delegation dedup ledger: delegation id → the session the
+    /// task was dispatched as. A `StartTask` re-sent with an
+    /// already-recorded `delegation_id` (the delegating daemon's
+    /// at-least-once retry after a connection drop) re-acks with the
+    /// original session instead of starting a duplicate task. Bounded
+    /// by [`MAX_DELEGATION_RECEIPTS`], oldest-accepted evicted
+    /// (tracked in `delegation_receipt_order`).
+    delegation_receipts: HashMap<String, String>,
+    delegation_receipt_order: std::collections::VecDeque<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -407,6 +421,32 @@ impl SupervisorState {
             self.external_attach_dedupe.remove(key);
         }
     }
+
+    /// The session a delegation id was already dispatched as, if any.
+    fn recorded_delegation_session(&self, delegation_id: &str) -> Option<String> {
+        self.delegation_receipts.get(delegation_id).cloned()
+    }
+
+    /// Record an accepted delegation for dedup, evicting the oldest
+    /// entry beyond [`MAX_DELEGATION_RECEIPTS`]. First writer wins —
+    /// a delegation id is never re-pointed at a different session.
+    fn record_delegation(&mut self, delegation_id: &str, session_id: &str) {
+        if self.delegation_receipts.contains_key(delegation_id) {
+            return;
+        }
+        while self.delegation_receipt_order.len() >= MAX_DELEGATION_RECEIPTS {
+            match self.delegation_receipt_order.pop_front() {
+                Some(evicted) => {
+                    self.delegation_receipts.remove(&evicted);
+                }
+                None => break,
+            }
+        }
+        self.delegation_receipt_order
+            .push_back(delegation_id.to_string());
+        self.delegation_receipts
+            .insert(delegation_id.to_string(), session_id.to_string());
+    }
 }
 
 impl SessionSupervisor {
@@ -697,6 +737,43 @@ mod tests {
                 as Box<dyn provider::ChatProvider>
         }));
         SessionSupervisor::new(config)
+    }
+
+    /// The delegation dedup ledger: first writer wins for a given id,
+    /// and the FIFO bound evicts the oldest acceptance, never the
+    /// newest.
+    #[test]
+    fn delegation_ledger_dedups_bounds_and_first_writer_wins() {
+        let mut state = SupervisorState::default();
+        state.record_delegation("dg-a", "sess-original");
+        // A re-record for the same id must NOT re-point it — the
+        // re-ack contract promises the ORIGINAL session identity.
+        state.record_delegation("dg-a", "sess-imposter");
+        assert_eq!(
+            state.recorded_delegation_session("dg-a").as_deref(),
+            Some("sess-original")
+        );
+
+        for i in 0..MAX_DELEGATION_RECEIPTS {
+            state.record_delegation(&format!("dg-fill-{i}"), &format!("sess-{i}"));
+        }
+        assert_eq!(
+            state.recorded_delegation_session("dg-a"),
+            None,
+            "oldest entry is evicted at the bound"
+        );
+        assert!(
+            state
+                .recorded_delegation_session(&format!("dg-fill-{}", MAX_DELEGATION_RECEIPTS - 1))
+                .is_some(),
+            "newest entry survives"
+        );
+        assert!(state.delegation_receipts.len() <= MAX_DELEGATION_RECEIPTS);
+        assert_eq!(
+            state.delegation_receipts.len(),
+            state.delegation_receipt_order.len(),
+            "map and eviction order stay in lockstep"
+        );
     }
 
     #[test]

--- a/src/bin/caller/task_dispatch.rs
+++ b/src/bin/caller/task_dispatch.rs
@@ -97,6 +97,14 @@ impl Dispatcher {
                 display_target,
                 attachments,
                 follow_up_id,
+                // The legacy single-session dispatcher deliberately does
+                // NOT acknowledge peer delegations: it routes into an
+                // existing loop (presence/task/follow-up channels), so
+                // there is no fresh dispatch identity to report. A
+                // delegating daemon falls back to its fire-and-forget
+                // path exactly as against a pre-receipt build — see the
+                // compatibility matrix in peer::transport::intendant.
+                delegation_id: _,
             } => {
                 let is_direct = direct.unwrap_or(false) || orchestrate == Some(false);
                 let has_metadata = !reference_frame_ids.is_empty()
@@ -358,6 +366,7 @@ mod tests {
             display_target: None,
             attachments: vec![],
             follow_up_id: None,
+            delegation_id: None,
         }));
 
         let envelope = tokio::time::timeout(std::time::Duration::from_millis(200), task_rx.recv())
@@ -397,6 +406,7 @@ mod tests {
             display_target: None,
             attachments: vec![],
             follow_up_id: None,
+            delegation_id: None,
         }));
 
         let text = tokio::time::timeout(std::time::Duration::from_millis(200), presence_rx.recv())
@@ -431,6 +441,7 @@ mod tests {
             display_target: None,
             attachments: vec![],
             follow_up_id: None,
+            delegation_id: None,
         }));
 
         let envelope = tokio::time::timeout(std::time::Duration::from_millis(200), task_rx.recv())
@@ -524,6 +535,7 @@ mod tests {
             display_target: None,
             attachments: vec![],
             follow_up_id: None,
+            delegation_id: None,
         }));
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         assert!(follow_up_rx.try_recv().is_err());
@@ -553,6 +565,7 @@ mod tests {
             display_target: None,
             attachments: vec![],
             follow_up_id: None,
+            delegation_id: None,
         }));
 
         let envelope = tokio::time::timeout(std::time::Duration::from_millis(200), task_rx.recv())

--- a/src/bin/caller/types.rs
+++ b/src/bin/caller/types.rs
@@ -317,6 +317,20 @@ pub enum OutboundEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         task: Option<String>,
     },
+    /// Peer-delegation delivery receipt. Emitted when a daemon
+    /// supervisor *dispatches* (not merely reads) a `StartTask` frame
+    /// that carried a `delegation_id`: `session_id` is the receiver's
+    /// real local session identity for the accepted task. The
+    /// delegating daemon's federation transport correlates it back to
+    /// the in-flight `PeerOp::DelegateTask` by `delegation_id` (see
+    /// `peer::transport::intendant` for the wire contract and the
+    /// old-peer compatibility matrix). Re-emitted with the original
+    /// `session_id` when a duplicate `delegation_id` is deduped.
+    /// Informational only — carries no authority.
+    TaskReceived {
+        delegation_id: String,
+        session_id: String,
+    },
     SessionIdentity {
         session_id: String,
         source: String,

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -3246,8 +3246,13 @@ mod tests {
     }
 
     /// `POST /api/peers/{id}/task` with `{instructions}` returns 200 +
-    /// `task_id`. Wire-level encoding covered by
-    /// `peer::transport::intendant::tests::delegate_task_writes_start_task_control_msg`.
+    /// `task_id` + the delivery-receipt fields. The target here is a bare
+    /// gateway with no session supervisor, i.e. a receiver that never
+    /// acks — the canonical old-peer/fire-and-forget shape, so `delivery`
+    /// must read `unconfirmed` after exactly one send (no retry storm
+    /// against a stable-but-silent receiver). Wire-level encoding covered
+    /// by `peer::transport::intendant::tests::delegate_task_writes_start_task_control_msg`;
+    /// the acknowledged shape by `peer::handle::tests::delegate_task_confirms_on_peer_receipt`.
     #[tokio::test]
     async fn test_api_peers_delegate_task_returns_200() {
         let (dash_port, peer_id, target_handle, dash_handle) = setup_peer_op_test().await;
@@ -3268,6 +3273,22 @@ mod tests {
         assert!(
             parsed["task_id"].as_str().is_some(),
             "expected task_id in response: {resp_body}"
+        );
+        assert_eq!(
+            parsed["delivery"].as_str(),
+            Some("unconfirmed"),
+            "a supervisor-less receiver never acks: {resp_body}"
+        );
+        assert!(
+            parsed["delegation_id"]
+                .as_str()
+                .is_some_and(|id| !id.is_empty()),
+            "expected delegation_id in response: {resp_body}"
+        );
+        assert_eq!(
+            parsed["sends"].as_u64(),
+            Some(1),
+            "stable-but-silent receiver must not trigger re-sends: {resp_body}"
         );
 
         target_handle.abort();

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -2248,7 +2248,20 @@ pub(crate) async fn peers_delegate_task(
         Err(resp) => return resp,
     };
     match handle.delegate_task(task).await {
-        Ok(task_id) => (200, serde_json::json!({"task_id": task_id.0}).to_string()),
+        // `delivery` distinguishes a peer-acknowledged dispatch
+        // ("acknowledged": task_id is the peer's real session id) from
+        // the fire-and-forget fallback ("unconfirmed": older peer or
+        // repeatedly dropped link; task_id is a sender-side marker).
+        Ok(delegation) => (
+            200,
+            serde_json::json!({
+                "task_id": delegation.task_id.0,
+                "delegation_id": delegation.delegation_id,
+                "delivery": if delegation.confirmed { "acknowledged" } else { "unconfirmed" },
+                "sends": delegation.sends,
+            })
+            .to_string(),
+        ),
         Err(e) => peer_error_response(e),
     }
 }
@@ -2407,6 +2420,8 @@ pub(crate) async fn coordinator_route(
             serde_json::json!({
                 "peer_id": routed.peer_id.as_str(),
                 "task_id": routed.task_id.0,
+                "delegation_id": routed.delegation_id,
+                "delivery": if routed.confirmed { "acknowledged" } else { "unconfirmed" },
             })
             .to_string(),
         ),

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -44,24 +44,12 @@ const DAEMON_START_TIMEOUT: Duration = Duration::from_secs(180);
 /// suite's wall-clock cost is bounded by how fast the waits *succeed*, not
 /// by this deadline, so be generous. (The Windows leg blew even 240s on the
 /// task-completion wait on 2026-07-12; that incident's likely mechanism — a
-/// lost fire-and-forget StartTask — is addressed structurally with an
-/// arrival gate plus one re-delegation, see [`PEER_TASK_ARRIVAL_GRACE`],
-/// rather than by inflating this bound.)
+/// StartTask lost to a fire-and-forget wire — is now fixed at the product
+/// level: delegation resolves through an application delivery receipt with
+/// at-least-once re-send + receiver dedup, so by the time `ctl peer task`
+/// reports `delivery: "acknowledged"` the task is dispatched on B and this
+/// deadline only covers the scripted run itself.)
 const PEER_WAIT_TIMEOUT: Duration = Duration::from_secs(240);
-
-/// Grace window for a delegated peer task to *arrive* on the receiving
-/// daemon: session launch writes "[runtime] Task dispatched: <task>" into
-/// its session.jsonl before any model turn runs, so arrival needs only the
-/// StartTask frame crossing loopback plus a session launch — much less than
-/// the full scripted run [`PEER_WAIT_TIMEOUT`] budgets for. When this
-/// window closes with no trace of the task on the peer, the delegation is
-/// treated as lost in flight (the /ws control plane is fire-and-forget; the
-/// task id `ctl peer task` prints is minted by the *sender* after the WS
-/// write, so it never proves receipt) and the test re-delegates once.
-/// Guessing wrong on a merely-slow runner is harmless: the mock provider
-/// matches profiles per session, so a duplicate delegation just runs the
-/// same scripted steps in a second session.
-const PEER_TASK_ARRIVAL_GRACE: Duration = Duration::from_secs(60);
 
 fn intendant_bin() -> &'static str {
     // Referencing the runtime binary's env var makes Cargo build it too —
@@ -250,21 +238,30 @@ impl DaemonRig {
     }
 
     /// Tail of the daemon's durable federated peer-event record
-    /// (`.intendant/logs/peers.jsonl` under the isolated home; see
-    /// `peer::spawn_peer_log_writer`), for failure context: connection
+    /// (`peers.jsonl`; see `peer::spawn_peer_log_writer`), for failure
+    /// context AND for the delivery-receipt assertion: connection
     /// transitions and delegation-time activity live here, on the
     /// *sending* daemon, where a lost cross-daemon message leaves its
-    /// only trace.
+    /// only trace. The file lives in the daemon's *session* log dir —
+    /// `build_and_hydrate_peer_registry(log_dir, …)` is called with the
+    /// daemon session's directory (startup/wiring.rs), not the logs
+    /// root — so scan every session dir like [`TestRig::session_logs`]
+    /// does. (This helper originally read a flat
+    /// `.intendant/logs/peers.jsonl` that nothing writes, so the
+    /// forensics rail dumped empty; the receipt assertion made that
+    /// visible.)
     fn peer_log_tail(&self) -> String {
-        let path = self
-            .rig
-            .home
-            .path()
-            .join(".intendant")
-            .join("logs")
-            .join("peers.jsonl");
-        let contents = std::fs::read_to_string(&path).unwrap_or_default();
-        tail(&contents, 4000)
+        let logs_dir = self.rig.home.path().join(".intendant").join("logs");
+        let mut combined = String::new();
+        if let Ok(entries) = std::fs::read_dir(&logs_dir) {
+            for entry in entries.flatten() {
+                if let Ok(contents) = std::fs::read_to_string(entry.path().join("peers.jsonl")) {
+                    combined.push_str(&contents);
+                    combined.push('\n');
+                }
+            }
+        }
+        tail(&combined, 4000)
     }
 }
 
@@ -2210,7 +2207,15 @@ async fn ctl_peer_list_and_task_drive_a_federated_peer_daemon() {
         text_of(&list)
     );
 
-    // Delegate a task to B through A; the command must print a task id.
+    // Delegate a task to B through A. Delegation now resolves through the
+    // application-level delivery receipt (`delegation_id` on the StartTask
+    // frame; B acks with `task_received` when it actually dispatches):
+    // `delivery: "acknowledged"` means the task is running on B and
+    // `task_id` is B's real session id — not the sender-minted
+    // `task-out-{n}` marker of the fire-and-forget era. A StartTask lost
+    // before B reads it is re-sent under the same delegation id and B
+    // dedups, so this test's former arrival gate + one-shot re-delegation
+    // is retired: the product owns the retry now.
     let instructions = format!("{TASK_MARK} - run the scripted delegated steps");
     let task = ctl(&a, &["peer", "task", &peer_id, &instructions]).await;
     assert!(task.status.success(), "{}", text_of(&task));
@@ -2218,57 +2223,67 @@ async fn ctl_peer_list_and_task_drive_a_federated_peer_daemon() {
     let task_id = task_json
         .get("task_id")
         .and_then(|v| v.as_str())
-        .unwrap_or_default();
+        .unwrap_or_default()
+        .to_string();
     assert!(
         !task_id.is_empty(),
         "ctl peer task did not print a task_id:\n{}",
         text_of(&task)
     );
-
-    // That task_id proves less than it looks like: it is minted on A
-    // *after* the StartTask frame enters A's socket (the /ws control plane
-    // is fire-and-forget — nothing echoes back from B; see
-    // `IntendantWsTransport::send` in src/bin/caller/peer/transport/
-    // intendant.rs). If the connection dies before B reads the frame, A's
-    // actor quietly reconnects with backoff but nothing re-sends the
-    // delegation — the completion wait below would then run out its whole
-    // deadline against a daemon that was never asked to do anything
-    // (Windows CI 2026-07-12: 240s blown by a tree that passes locally in
-    // ~6s). B's session launch writes "[runtime] Task dispatched: <task>"
-    // into session.jsonl before any model turn, so use that as the arrival
-    // signal: if it hasn't appeared within the grace window, re-confirm the
-    // connection and re-delegate once (harmless if the first delegation
-    // was merely slow — see PEER_TASK_ARRIVAL_GRACE).
-    let arrived = try_poll_until(PEER_TASK_ARRIVAL_GRACE, || {
-        let logs = b.rig.session_logs();
-        async move { logs.contains(TASK_MARK).then_some(()) }
-    })
-    .await
-    .is_some();
-    if !arrived {
-        eprintln!(
-            "delegated task shows no trace on daemon B after \
-             {PEER_TASK_ARRIVAL_GRACE:?}; treating the fire-and-forget \
-             StartTask as lost and re-delegating once"
-        );
-        poll_until(
-            "daemon A reporting peer B connected before re-delegating",
-            PEER_WAIT_TIMEOUT,
-            || {
-                let client = client.clone();
-                async move { connected_peer(&client, port_a).await }
-            },
-            &dump_daemons,
-        )
-        .await;
-        let retry = ctl(&a, &["peer", "task", &peer_id, &instructions]).await;
-        assert!(
-            retry.status.success(),
-            "re-delegating the peer task failed:\n{}\n{}",
-            text_of(&retry),
-            dump_daemons()
-        );
-    }
+    assert_eq!(
+        task_json.get("delivery").and_then(|v| v.as_str()),
+        Some("acknowledged"),
+        "peer delegation was not acknowledged by B:\n{}\n{}",
+        text_of(&task),
+        dump_daemons()
+    );
+    let delegation_id = task_json
+        .get("delegation_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        !delegation_id.is_empty(),
+        "acknowledged delegation must report its delegation_id:\n{}",
+        text_of(&task)
+    );
+    assert!(
+        !task_id.starts_with("task-out-"),
+        "acknowledged delivery must carry B's session id, not the \
+         sender-side marker {task_id}:\n{}",
+        dump_daemons()
+    );
+    // The acknowledged id is real on B: its session log directory exists
+    // (created before dispatch, so by receipt time it must be on disk).
+    assert!(
+        b.rig
+            .home
+            .path()
+            .join(".intendant")
+            .join("logs")
+            .join(&task_id)
+            .join("session.jsonl")
+            .exists(),
+        "B has no session log for acknowledged session {task_id}:\n{}",
+        dump_daemons()
+    );
+    // And the receipt leaves a durable trace on A's federated peer-event
+    // record (`peers.jsonl`, the forensics rail dump_daemons reads). The
+    // actor writes it via the async log sink, so it may trail the ctl
+    // response by a beat — poll briefly.
+    poll_until(
+        "the task_receipt landing in daemon A's peers.jsonl",
+        Duration::from_secs(30),
+        || {
+            let tail = a.peer_log_tail();
+            let delegation_id = delegation_id.clone();
+            async move {
+                (tail.contains("task_receipt") && tail.contains(&delegation_id)).then_some(())
+            }
+        },
+        &dump_daemons,
+    )
+    .await;
 
     // B really ran it: only the TASK_MARK-matched profile emits the done
     // message, and the mock releases it only after the runtime's echo


### PR DESCRIPTION
## The gap

Peer task delegation was at-most-once with no failure signal. `PeerOp::DelegateTask` wrote a single `ControlMsg::StartTask` frame and fabricated the task id sender-side (`task-out-{seq}`) — the "ack" proved only the WebSocket write. If the socket died before the peer read the frame, the sender's actor reconnected indefinitely but nothing re-sent the task: the delegation was silently lost while `ctl peer task` reported a task id (the likely mechanism behind the 2026-07-12 Windows e2e timeout; found in the PR #272 investigation).

## The fix: application-level delivery receipt

**Wire shapes** (both additive):

```json
{"action":"start_task","task":"…","delegation_id":"dg-<uuid>"}
{"event":"task_received","delegation_id":"dg-<uuid>","session_id":"<receiver session id>"}
```

- The sender stamps every StartTask for one delegation with one `delegation_id` (`PeerTask.client_correlation_id` when supplied — idempotent coordinator retries — else freshly minted).
- The receiving daemon acks **on acceptance**: when the session supervisor actually dispatches the task (`start_new_session` returns the launched session), never on merely parsing the frame. Failed launches stay unacked.
- The receipt flows back on the normal broadcast; the wire upcaster maps it to `PeerEvent::TaskReceipt`, the per-peer actor folds a bounded receipt ledger (kept across reconnects), and `PeerHandle::delegate_task` awaits the correlated entry — the actor's event pump never blocks on a receipt.
- **At-least-once with dedup**: on connection loss before an ack, the sender re-sends the SAME `delegation_id` after reconnect (bounded: 3 sends / 30 s overall). The receiver dedups by delegation id and re-acks with the *original* session instead of starting a duplicate.
- **Old-peer fallback**: a connection that stays up through the 5 s grace with no ack is the pre-receipt-receiver signature → the sender reports today's fire-and-forget semantics, clearly marked, and deliberately does **not** re-send (an old receiver has no dedup).

**Compatibility matrix** (full version in `peer/transport/intendant.rs` module docs):

| Sender | Receiver | Behavior |
|---|---|---|
| new | new | Ack on dispatch; `delivery: "acknowledged"`, task_id = peer's real session id; re-sends deduped |
| new | old | Unknown field ignored (plain serde), task runs as today, never acks → grace elapses on the stable link → `delivery: "unconfirmed"`, synthetic id, **no re-send** |
| old | new | No `delegation_id` on the frame → receiver behaves exactly as today (no ack, no dedup entry) |
| old | old | Unchanged fire-and-forget |

**Trust model unchanged**: receipts are informational and carry no authority; IAM evaluation on the receiving gateway sits exactly where it did.

**Response surfaces** (`POST /api/peers/{id}/task` + tunnel twin, `/api/coordinator/route`, MCP `peer_delegate_task`, `ctl peer task`) now carry `delegation_id`, `delivery: "acknowledged"|"unconfirmed"`, and `sends`; `task_id` semantics upgrade to "accepted by the peer" when acknowledged.

## Tests

- Hermetic unit coverage: receipt correlation; ledgered-correlation-id short-circuit (0 wire writes); old-peer fallback (no ack → unconfirmed after exactly 1 send — no retry storm); same-id re-send across link loss via a killable TCP proxy; bounded re-send budget; receiver-side dedup + re-ack + no duplicate session; ledger FIFO bounds (both sides); `delegation_id` wire stamp.
- The peer e2e (`ctl_peer_list_and_task_drive_a_federated_peer_daemon`) now asserts `delivery: "acknowledged"`, that the reported id is B's real session log dir, and the durable `task_receipt` line on A — replacing the former test-side arrival gate + one-shot re-delegation (the product owns the retry now). Both-daemon failure forensics kept.
- Drive-by fix the new assertion exposed: the e2e `peer_log_tail` forensics helper read a flat `.intendant/logs/peers.jsonl` that nothing writes (the writer targets the daemon session's log dir); it now scans session dirs like `session_logs()`.

## Behavior notes

- `delegate_task` against an old/receiver-less peer now takes the 5 s grace before returning (was instant); against acking peers it resolves in milliseconds.
- Deliberate residue, documented in the module-doc matrix: only daemon receivers ack — a new build in a non-daemon shape routes StartTask through the legacy dispatcher and looks like an old receiver (safe for the same reason). Delegated Codex slash-commands route as follow-ups and are likewise not acked.
