### PR TITLE
dashboard: truthful transport chip + self-healing opt-in tunnel + reachable diagnostics

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -1704,6 +1704,15 @@ html {
   padding: 12px 16px;
   margin: 0 0 16px;
 }
+/* One-shot attention pulse for deep links that land on a panel
+   (openConnectionDiagnostics); removed by the caller after it plays. */
+@keyframes ui-attention-flash {
+  0% { box-shadow: 0 0 0 3px var(--blue); }
+  100% { box-shadow: 0 0 0 3px transparent; }
+}
+.ui-attention-flash {
+  animation: ui-attention-flash 1.6s ease-out;
+}
 .settings-group legend {
   color: var(--blue);
   font-size: 13px;
@@ -24738,7 +24747,7 @@ function ui2WireMirrors() {
     conn.dataset.state = /err|fail/.test(cls) ? 'err' : /warn|reconnect|checking|relay/i.test(cls) ? 'warn' : /ok|ready/i.test(cls) ? 'ok' : '';
   });
   const conn = document.getElementById('ui2-conn');
-  if (conn) conn.addEventListener('click', () => routeTo('access', 'diagnostics'));
+  if (conn) conn.addEventListener('click', () => openConnectionDiagnostics());
 
   // Autonomy chip: level text mirrored (+ the truthful short tag); click
   // opens Settings → Autonomy & approvals (the design's behavior —
@@ -69644,6 +69653,26 @@ function dashboardConnectModeEnabled() {
   return DASHBOARD_CONNECT_MODE;
 }
 
+// The explicit localStorage opt-in on its own: an opt-in tunnel is a lane
+// the user asked for, so it self-heals like a primary lane even while the
+// legacy /ws carries events (a dead optional lane that never comes back
+// is how the transport chip gets stuck red forever).
+function dashboardControlUserOptInEnabled() {
+  if (dashboardConnectModeEnabled()) return false;
+  try {
+    return localStorage.getItem(DASHBOARD_TRANSPORT_KEY) === 'webrtc-control';
+  } catch {
+    return false;
+  }
+}
+
+// "Should a dead tunnel be brought back?" — yes when it is the primary
+// event lane (events depend on it) or explicitly opted in (the user asked
+// for it). Gate for the reconnect machinery.
+function dashboardControlTunnelWanted() {
+  return dashboardControlTunnelIsPrimaryEventLane() || dashboardControlUserOptInEnabled();
+}
+
 // True when the dashboard-control tunnel is the PRIMARY event lane — the
 // postures where losing the tunnel means losing events entirely:
 //   - hosted Connect dashboards (?connect=1),
@@ -69860,6 +69889,29 @@ function dashboardTransportStatusSummary(status = {}) {
     };
   }
 
+  // Lane-aware framing: this chip reports dashboard ACCESS, not one
+  // transport's health. While the legacy /ws carries events (and the
+  // tunnel is not the primary lane), access is fine regardless of the
+  // optional tunnel's condition — report Ready and relegate the tunnel
+  // state to the detail title instead of alarming over a lane nothing
+  // depends on right now. A healthy connected tunnel falls through to
+  // the richer connected arm below.
+  if (dashboardLegacyWsConnected
+      && !dashboardControlTunnelIsPrimaryEventLane()
+      && !(status.connected && status.verifiedBinding?.ok)) {
+    const pcNow = String(status.pcState || '').toLowerCase();
+    const tunnelNote = status.reconnecting
+      ? 'the optional control tunnel is reconnecting'
+      : (String(status.lastError || status.error || '').trim() || pcNow === 'failed' || pcNow === 'closed')
+        ? 'the optional control tunnel is down'
+        : 'the optional control tunnel is idle';
+    return {
+      kind: 'ok',
+      label: 'Ready',
+      title: `Dashboard access is ready — events ride the WebSocket; ${tunnelNote}. Open Connection Diagnostics for transport details.`,
+    };
+  }
+
   const pcState = String(status.pcState || '').toLowerCase();
   const channelState = String(status.channelState || '').toLowerCase();
   const lastError = String(status.lastError || status.error || '').trim();
@@ -69982,6 +70034,23 @@ function connectHealthState(statusArg = null, summaryArg = null) {
       { label: 'Events', value: status.eventsActive ? 'active' : 'inactive', kind: connectHealthKindForBoolean(status.eventsActive) },
     ],
   };
+}
+
+// Chip-click affordance: land the user ON the diagnostics panel — a bare
+// routeTo leaves the panel below the fold with nothing announcing itself,
+// which reads as "clicking did nothing".
+function openConnectionDiagnostics() {
+  routeTo('access', 'diagnostics');
+  // The pane switch may render-defer the panel mount; give it a beat.
+  setTimeout(() => {
+    const panel = document.getElementById('connect-health-panel');
+    if (!panel) return;
+    try { panel.scrollIntoView({ behavior: 'smooth', block: 'start' }); } catch (_) {}
+    panel.classList.remove('ui-attention-flash');
+    void panel.offsetWidth;
+    panel.classList.add('ui-attention-flash');
+    setTimeout(() => panel.classList.remove('ui-attention-flash'), 1800);
+  }, 250);
 }
 
 function renderConnectHealthPanel(statusArg = null, summaryArg = null) {
@@ -70652,7 +70721,7 @@ function dashboardConnectReconnectStatus() {
 // (±25%) keeps a fleet of tabs from thundering-herding a daemon that just
 // came back; the attempt counter resets on a successful reconnect.
 function scheduleDashboardConnectReconnect(reason = 'dashboard transport disconnected', options = {}) {
-  if (!dashboardControlTunnelIsPrimaryEventLane()) return;
+  if (!dashboardControlTunnelWanted()) return;
   if (dashboardConnectReconnectTimer) return;
   const attempt = dashboardConnectReconnectAttempt;
   const backoffBaseMs = Math.min(
@@ -70668,7 +70737,12 @@ function scheduleDashboardConnectReconnect(reason = 'dashboard transport disconn
   dashboardConnectReconnectReason = String(reason || 'dashboard transport disconnected');
   dashboardConnectReconnectNextUnixMs = Date.now() + delayMs;
   dashboardSetControlLastError('');
-  setConnectEventStatus('warn', `Reconnecting dashboard events through ${dashboardEventLaneDescription()}`);
+  // The primary-event chip belongs to whichever lane carries events: only
+  // narrate this reconnect there when the tunnel IS that lane — an opt-in
+  // tunnel healing beside a healthy /ws must not stomp the ws status.
+  if (dashboardControlTunnelIsPrimaryEventLane()) {
+    setConnectEventStatus('warn', `Reconnecting dashboard events through ${dashboardEventLaneDescription()}`);
+  }
   dashboardUpdateTransportStatus();
   dashboardConnectReconnectTimer = window.setTimeout(() => {
     dashboardConnectReconnectTimer = null;
@@ -70680,7 +70754,7 @@ function scheduleDashboardConnectReconnect(reason = 'dashboard transport disconn
 }
 
 async function runDashboardConnectReconnect(reason = 'dashboard transport disconnected') {
-  if (!dashboardControlTunnelIsPrimaryEventLane() || dashboardConnectReconnectInFlight) return;
+  if (!dashboardControlTunnelWanted() || dashboardConnectReconnectInFlight) return;
   // The transport healed while the retry timer was pending (ICE
   // `disconnected` is often a transient blip that recovers on its own) —
   // tearing it down now would drop a healthy tunnel. Treat as success.
@@ -70689,9 +70763,11 @@ async function runDashboardConnectReconnect(reason = 'dashboard transport discon
     dashboardConnectReconnectReason = '';
     dashboardConnectReconnectNextUnixMs = 0;
     dashboardSetControlLastError('');
-    setConnectEventStatus('ok', dashboardConnectModeEnabled()
-      ? 'Dashboard events are live through verified Hosted Connect'
-      : 'Dashboard events are live through the control tunnel');
+    if (dashboardControlTunnelIsPrimaryEventLane()) {
+      setConnectEventStatus('ok', dashboardConnectModeEnabled()
+        ? 'Dashboard events are live through verified Hosted Connect'
+        : 'Dashboard events are live through the control tunnel');
+    }
     dashboardUpdateTransportStatus();
     return;
   }
@@ -70699,7 +70775,9 @@ async function runDashboardConnectReconnect(reason = 'dashboard transport discon
   dashboardConnectReconnectReason = String(reason || 'dashboard transport disconnected');
   let retryReason = '';
   dashboardSetControlLastError('');
-  setConnectEventStatus('warn', `Reconnecting dashboard events through ${dashboardEventLaneDescription()}`);
+  if (dashboardControlTunnelIsPrimaryEventLane()) {
+    setConnectEventStatus('warn', `Reconnecting dashboard events through ${dashboardEventLaneDescription()}`);
+  }
   dashboardUpdateTransportStatus();
   try {
     const previous = dashboardControlTransport;
@@ -70729,16 +70807,20 @@ async function runDashboardConnectReconnect(reason = 'dashboard transport discon
     dashboardConnectReconnectReason = '';
     dashboardConnectReconnectNextUnixMs = 0;
     dashboardSetControlLastError('');
-    setConnectEventStatus('ok', dashboardConnectModeEnabled()
-      ? 'Dashboard events are live through verified Hosted Connect'
-      : 'Dashboard events are live through the control tunnel');
+    if (dashboardControlTunnelIsPrimaryEventLane()) {
+      setConnectEventStatus('ok', dashboardConnectModeEnabled()
+        ? 'Dashboard events are live through verified Hosted Connect'
+        : 'Dashboard events are live through the control tunnel');
+    }
   } catch (err) {
     retryReason = err?.message || String(err);
     console.warn('[dashboard-control] event-lane reconnect failed', err);
     dashboardSetControlLastError(retryReason, err?.controlErrorKind || '');
-    setConnectEventStatus('err', dashboardConnectModeEnabled()
-      ? 'Hosted Connect dashboard reconnect failed'
-      : 'Dashboard control tunnel reconnect failed');
+    if (dashboardControlTunnelIsPrimaryEventLane()) {
+      setConnectEventStatus('err', dashboardConnectModeEnabled()
+        ? 'Hosted Connect dashboard reconnect failed'
+        : 'Dashboard control tunnel reconnect failed');
+    }
   } finally {
     dashboardConnectReconnectInFlight = false;
     dashboardUpdateTransportStatus();
@@ -72101,14 +72183,16 @@ class DashboardControlTransport {
   }
 
   scheduleReconnect(reason, options = {}) {
-    // Reconnect whenever this tunnel is the PRIMARY event lane: hosted
-    // Connect dashboards and the macOS-app mTLS posture (where the legacy
-    // WebSocket can never connect, so a dropped tunnel would otherwise
-    // kill events until app relaunch). The localStorage webrtc-control
-    // opt-in keeps the legacy /ws lane as primary and stays out of this
-    // path. suppressReconnect marks explicit closes (user disable,
+    // Reconnect whenever this tunnel is WANTED: the primary event lane
+    // (hosted Connect, the macOS-app mTLS posture, the capability
+    // fallback — losing the tunnel there means losing events entirely)
+    // or the explicit localStorage webrtc-control opt-in (the /ws still
+    // carries events, but a lane the user asked for must self-heal
+    // rather than sit dead behind a permanently red chip). Reconnect
+    // status only narrates on the primary-event chip when the tunnel is
+    // that lane. suppressReconnect marks explicit closes (user disable,
     // deliberate teardown before a replacement connect).
-    if (!this.primaryDashboardControl || this.suppressReconnect || !dashboardControlTunnelIsPrimaryEventLane()) return;
+    if (!this.primaryDashboardControl || this.suppressReconnect || !dashboardControlTunnelWanted()) return;
     scheduleDashboardConnectReconnect(reason, options);
   }
 
@@ -96394,7 +96478,7 @@ document.getElementById('sb-hosts-group').addEventListener('click', () => {
   else window.location.href = accessHomeHref('daemons');
 });
 document.getElementById('sb-access-page-link')?.addEventListener('click', openAccessHome);
-document.getElementById('sb-dashboard-transport')?.addEventListener('click', () => routeTo('access', 'diagnostics'));
+document.getElementById('sb-dashboard-transport')?.addEventListener('click', () => openConnectionDiagnostics());
 document.getElementById('access-link-daemon-btn')?.addEventListener('click', () => routeTo('access', 'peers'));
 
 // Join-with-an-org-grant: present the pasted document to this daemon. The

--- a/static/app/11-styles-access-files.css
+++ b/static/app/11-styles-access-files.css
@@ -783,6 +783,15 @@
   padding: 12px 16px;
   margin: 0 0 16px;
 }
+/* One-shot attention pulse for deep links that land on a panel
+   (openConnectionDiagnostics); removed by the caller after it plays. */
+@keyframes ui-attention-flash {
+  0% { box-shadow: 0 0 0 3px var(--blue); }
+  100% { box-shadow: 0 0 0 3px transparent; }
+}
+.ui-attention-flash {
+  animation: ui-attention-flash 1.6s ease-out;
+}
 .settings-group legend {
   color: var(--blue);
   font-size: 13px;

--- a/static/app/49-daemons-multihost.js
+++ b/static/app/49-daemons-multihost.js
@@ -192,6 +192,26 @@ function dashboardConnectModeEnabled() {
   return DASHBOARD_CONNECT_MODE;
 }
 
+// The explicit localStorage opt-in on its own: an opt-in tunnel is a lane
+// the user asked for, so it self-heals like a primary lane even while the
+// legacy /ws carries events (a dead optional lane that never comes back
+// is how the transport chip gets stuck red forever).
+function dashboardControlUserOptInEnabled() {
+  if (dashboardConnectModeEnabled()) return false;
+  try {
+    return localStorage.getItem(DASHBOARD_TRANSPORT_KEY) === 'webrtc-control';
+  } catch {
+    return false;
+  }
+}
+
+// "Should a dead tunnel be brought back?" — yes when it is the primary
+// event lane (events depend on it) or explicitly opted in (the user asked
+// for it). Gate for the reconnect machinery.
+function dashboardControlTunnelWanted() {
+  return dashboardControlTunnelIsPrimaryEventLane() || dashboardControlUserOptInEnabled();
+}
+
 // True when the dashboard-control tunnel is the PRIMARY event lane — the
 // postures where losing the tunnel means losing events entirely:
 //   - hosted Connect dashboards (?connect=1),
@@ -408,6 +428,29 @@ function dashboardTransportStatusSummary(status = {}) {
     };
   }
 
+  // Lane-aware framing: this chip reports dashboard ACCESS, not one
+  // transport's health. While the legacy /ws carries events (and the
+  // tunnel is not the primary lane), access is fine regardless of the
+  // optional tunnel's condition — report Ready and relegate the tunnel
+  // state to the detail title instead of alarming over a lane nothing
+  // depends on right now. A healthy connected tunnel falls through to
+  // the richer connected arm below.
+  if (dashboardLegacyWsConnected
+      && !dashboardControlTunnelIsPrimaryEventLane()
+      && !(status.connected && status.verifiedBinding?.ok)) {
+    const pcNow = String(status.pcState || '').toLowerCase();
+    const tunnelNote = status.reconnecting
+      ? 'the optional control tunnel is reconnecting'
+      : (String(status.lastError || status.error || '').trim() || pcNow === 'failed' || pcNow === 'closed')
+        ? 'the optional control tunnel is down'
+        : 'the optional control tunnel is idle';
+    return {
+      kind: 'ok',
+      label: 'Ready',
+      title: `Dashboard access is ready — events ride the WebSocket; ${tunnelNote}. Open Connection Diagnostics for transport details.`,
+    };
+  }
+
   const pcState = String(status.pcState || '').toLowerCase();
   const channelState = String(status.channelState || '').toLowerCase();
   const lastError = String(status.lastError || status.error || '').trim();
@@ -530,6 +573,23 @@ function connectHealthState(statusArg = null, summaryArg = null) {
       { label: 'Events', value: status.eventsActive ? 'active' : 'inactive', kind: connectHealthKindForBoolean(status.eventsActive) },
     ],
   };
+}
+
+// Chip-click affordance: land the user ON the diagnostics panel — a bare
+// routeTo leaves the panel below the fold with nothing announcing itself,
+// which reads as "clicking did nothing".
+function openConnectionDiagnostics() {
+  routeTo('access', 'diagnostics');
+  // The pane switch may render-defer the panel mount; give it a beat.
+  setTimeout(() => {
+    const panel = document.getElementById('connect-health-panel');
+    if (!panel) return;
+    try { panel.scrollIntoView({ behavior: 'smooth', block: 'start' }); } catch (_) {}
+    panel.classList.remove('ui-attention-flash');
+    void panel.offsetWidth;
+    panel.classList.add('ui-attention-flash');
+    setTimeout(() => panel.classList.remove('ui-attention-flash'), 1800);
+  }, 250);
 }
 
 function renderConnectHealthPanel(statusArg = null, summaryArg = null) {
@@ -1200,7 +1260,7 @@ function dashboardConnectReconnectStatus() {
 // (±25%) keeps a fleet of tabs from thundering-herding a daemon that just
 // came back; the attempt counter resets on a successful reconnect.
 function scheduleDashboardConnectReconnect(reason = 'dashboard transport disconnected', options = {}) {
-  if (!dashboardControlTunnelIsPrimaryEventLane()) return;
+  if (!dashboardControlTunnelWanted()) return;
   if (dashboardConnectReconnectTimer) return;
   const attempt = dashboardConnectReconnectAttempt;
   const backoffBaseMs = Math.min(
@@ -1216,7 +1276,12 @@ function scheduleDashboardConnectReconnect(reason = 'dashboard transport disconn
   dashboardConnectReconnectReason = String(reason || 'dashboard transport disconnected');
   dashboardConnectReconnectNextUnixMs = Date.now() + delayMs;
   dashboardSetControlLastError('');
-  setConnectEventStatus('warn', `Reconnecting dashboard events through ${dashboardEventLaneDescription()}`);
+  // The primary-event chip belongs to whichever lane carries events: only
+  // narrate this reconnect there when the tunnel IS that lane — an opt-in
+  // tunnel healing beside a healthy /ws must not stomp the ws status.
+  if (dashboardControlTunnelIsPrimaryEventLane()) {
+    setConnectEventStatus('warn', `Reconnecting dashboard events through ${dashboardEventLaneDescription()}`);
+  }
   dashboardUpdateTransportStatus();
   dashboardConnectReconnectTimer = window.setTimeout(() => {
     dashboardConnectReconnectTimer = null;
@@ -1228,7 +1293,7 @@ function scheduleDashboardConnectReconnect(reason = 'dashboard transport disconn
 }
 
 async function runDashboardConnectReconnect(reason = 'dashboard transport disconnected') {
-  if (!dashboardControlTunnelIsPrimaryEventLane() || dashboardConnectReconnectInFlight) return;
+  if (!dashboardControlTunnelWanted() || dashboardConnectReconnectInFlight) return;
   // The transport healed while the retry timer was pending (ICE
   // `disconnected` is often a transient blip that recovers on its own) —
   // tearing it down now would drop a healthy tunnel. Treat as success.
@@ -1237,9 +1302,11 @@ async function runDashboardConnectReconnect(reason = 'dashboard transport discon
     dashboardConnectReconnectReason = '';
     dashboardConnectReconnectNextUnixMs = 0;
     dashboardSetControlLastError('');
-    setConnectEventStatus('ok', dashboardConnectModeEnabled()
-      ? 'Dashboard events are live through verified Hosted Connect'
-      : 'Dashboard events are live through the control tunnel');
+    if (dashboardControlTunnelIsPrimaryEventLane()) {
+      setConnectEventStatus('ok', dashboardConnectModeEnabled()
+        ? 'Dashboard events are live through verified Hosted Connect'
+        : 'Dashboard events are live through the control tunnel');
+    }
     dashboardUpdateTransportStatus();
     return;
   }
@@ -1247,7 +1314,9 @@ async function runDashboardConnectReconnect(reason = 'dashboard transport discon
   dashboardConnectReconnectReason = String(reason || 'dashboard transport disconnected');
   let retryReason = '';
   dashboardSetControlLastError('');
-  setConnectEventStatus('warn', `Reconnecting dashboard events through ${dashboardEventLaneDescription()}`);
+  if (dashboardControlTunnelIsPrimaryEventLane()) {
+    setConnectEventStatus('warn', `Reconnecting dashboard events through ${dashboardEventLaneDescription()}`);
+  }
   dashboardUpdateTransportStatus();
   try {
     const previous = dashboardControlTransport;
@@ -1277,16 +1346,20 @@ async function runDashboardConnectReconnect(reason = 'dashboard transport discon
     dashboardConnectReconnectReason = '';
     dashboardConnectReconnectNextUnixMs = 0;
     dashboardSetControlLastError('');
-    setConnectEventStatus('ok', dashboardConnectModeEnabled()
-      ? 'Dashboard events are live through verified Hosted Connect'
-      : 'Dashboard events are live through the control tunnel');
+    if (dashboardControlTunnelIsPrimaryEventLane()) {
+      setConnectEventStatus('ok', dashboardConnectModeEnabled()
+        ? 'Dashboard events are live through verified Hosted Connect'
+        : 'Dashboard events are live through the control tunnel');
+    }
   } catch (err) {
     retryReason = err?.message || String(err);
     console.warn('[dashboard-control] event-lane reconnect failed', err);
     dashboardSetControlLastError(retryReason, err?.controlErrorKind || '');
-    setConnectEventStatus('err', dashboardConnectModeEnabled()
-      ? 'Hosted Connect dashboard reconnect failed'
-      : 'Dashboard control tunnel reconnect failed');
+    if (dashboardControlTunnelIsPrimaryEventLane()) {
+      setConnectEventStatus('err', dashboardConnectModeEnabled()
+        ? 'Hosted Connect dashboard reconnect failed'
+        : 'Dashboard control tunnel reconnect failed');
+    }
   } finally {
     dashboardConnectReconnectInFlight = false;
     dashboardUpdateTransportStatus();

--- a/static/app/50-control-transport.js
+++ b/static/app/50-control-transport.js
@@ -161,14 +161,16 @@ class DashboardControlTransport {
   }
 
   scheduleReconnect(reason, options = {}) {
-    // Reconnect whenever this tunnel is the PRIMARY event lane: hosted
-    // Connect dashboards and the macOS-app mTLS posture (where the legacy
-    // WebSocket can never connect, so a dropped tunnel would otherwise
-    // kill events until app relaunch). The localStorage webrtc-control
-    // opt-in keeps the legacy /ws lane as primary and stays out of this
-    // path. suppressReconnect marks explicit closes (user disable,
+    // Reconnect whenever this tunnel is WANTED: the primary event lane
+    // (hosted Connect, the macOS-app mTLS posture, the capability
+    // fallback — losing the tunnel there means losing events entirely)
+    // or the explicit localStorage webrtc-control opt-in (the /ws still
+    // carries events, but a lane the user asked for must self-heal
+    // rather than sit dead behind a permanently red chip). Reconnect
+    // status only narrates on the primary-event chip when the tunnel is
+    // that lane. suppressReconnect marks explicit closes (user disable,
     // deliberate teardown before a replacement connect).
-    if (!this.primaryDashboardControl || this.suppressReconnect || !dashboardControlTunnelIsPrimaryEventLane()) return;
+    if (!this.primaryDashboardControl || this.suppressReconnect || !dashboardControlTunnelWanted()) return;
     scheduleDashboardConnectReconnect(reason, options);
   }
 

--- a/static/app/58-shortcuts-boot.js
+++ b/static/app/58-shortcuts-boot.js
@@ -614,7 +614,7 @@ document.getElementById('sb-hosts-group').addEventListener('click', () => {
   else window.location.href = accessHomeHref('daemons');
 });
 document.getElementById('sb-access-page-link')?.addEventListener('click', openAccessHome);
-document.getElementById('sb-dashboard-transport')?.addEventListener('click', () => routeTo('access', 'diagnostics'));
+document.getElementById('sb-dashboard-transport')?.addEventListener('click', () => openConnectionDiagnostics());
 document.getElementById('access-link-daemon-btn')?.addEventListener('click', () => routeTo('access', 'peers'));
 
 // Join-with-an-org-grant: present the pasted document to this daemon. The

--- a/static/app/ui2-chrome.js
+++ b/static/app/ui2-chrome.js
@@ -159,7 +159,7 @@ function ui2WireMirrors() {
     conn.dataset.state = /err|fail/.test(cls) ? 'err' : /warn|reconnect|checking|relay/i.test(cls) ? 'warn' : /ok|ready/i.test(cls) ? 'ok' : '';
   });
   const conn = document.getElementById('ui2-conn');
-  if (conn) conn.addEventListener('click', () => routeTo('access', 'diagnostics'));
+  if (conn) conn.addEventListener('click', () => openConnectionDiagnostics());
 
   // Autonomy chip: level text mirrored (+ the truthful short tag); click
   // opens Settings → Autonomy & approvals (the design's behavior —


### PR DESCRIPTION
Live follow-up from the Safari event-lane incident: on the fixed build the
/ws connected after all (TLS session resumption carries the mTLS client
identity, so WebKit's WebSocket works exactly when a resumable ticket
exists - one more reason lane selection must be capability-derived), the
opted-in tunnel later died at the ICE layer, and the dashboard - fully
functional on the /ws lane - alarmed 'WebRTC failed' with a diagnostics
click that landed below the fold.

- The transport chip reports dashboard ACCESS, not one transport's
  corpse: while the /ws carries events and the tunnel is not the primary
  lane, a dead/idle/reconnecting optional tunnel renders Ready with the
  tunnel condition relegated to the detail title.
- An explicitly opted-in tunnel self-heals: dashboardControlTunnelWanted
  (primary event lane OR localStorage opt-in) now gates the reconnect
  machinery, so a lane the user asked for never sits dead behind a red
  chip. Reconnect status only narrates on the primary-event chip when
  the tunnel is that lane - an opt-in heal beside a healthy /ws no
  longer stomps the ws status.
- Chip click routes through openConnectionDiagnostics(): scrolls the
  Connection Diagnostics panel into view with a one-shot attention
  flash instead of dumping the user at the top of the Access pane.

Verified: lane-verify optin mode (dual lanes, pc.close() out from under
the tunnel -> self-heal, chip pinned Ready throughout, composer spawn
confirms); hang + normal modes unchanged and green.
