### PR TITLE
dashboard: multi-tab hardening — stale-tab reload nudge + visibility quiescence + staleness banner

### DIFF
--- a/crates/app-html-assembler/src/lib.rs
+++ b/crates/app-html-assembler/src/lib.rs
@@ -6,8 +6,9 @@
 //! as typed fragments (`.css` / `.js` / `.html`) under `static/app/`, in the
 //! order fixed by `static/app/manifest.txt`, and this crate concatenates them
 //! back into the tracked artifact. The transform is concatenation plus a
-//! generated-file header, one banner comment per fragment, and exactly one
-//! documented substitution — the vault-kernel hash pin (below) — nothing
+//! generated-file header, one banner comment per fragment, and exactly two
+//! documented substitutions — the vault-kernel hash pin and the build stamp
+//! (both below) — nothing
 //! else: all JS fragments share the single `<script type="module">` scope
 //! exactly as they did in the monolith (the open/close tags live in tiny
 //! wrapper fragments), so hoisting and TDZ order are untouched by
@@ -26,6 +27,18 @@
 //! (`web_gateway/static_assets.rs`) recomputes the hash and asserts the
 //! assembled artifact pins it, so editing the kernel without regenerating
 //! app.html fails the suite.
+//!
+//! **The build stamp.** Any fragment may carry [`APP_BUILD_TOKEN`], and
+//! assembly replaces every occurrence with the first 16 lowercase-hex chars
+//! of the sha256 over the *raw* fragment bytes in manifest order (raw =
+//! placeholders un-substituted, so the stamp is well-defined and
+//! deterministic — the regen gate settles). The daemon extracts the stamp
+//! from its embedded artifact and serves it in `/config`; a dashboard tab
+//! whose own stamp differs is from an older served bundle and nudges itself
+//! to reload (`31-init-identity-fleet.js` declares
+//! `const INTENDANT_APP_BUILD = '__INTENDANT_APP_BUILD__'`). A daemon-side
+//! parity test (`web_gateway/static_assets.rs`) asserts the shipped artifact
+//! carries a minted stamp, never the placeholder.
 //!
 //! Fail-closed: any mismatch between the manifest and the fragment directory
 //! is an error, never a silently dropped fragment — a stale or partial
@@ -51,6 +64,11 @@ pub const VAULT_KERNEL_PATH: &str = "static/vault-kernel.js";
 /// substituted at assembly time (`32-vault-custody.js` declares
 /// `const VAULT_KERNEL_SHA256 = '__VAULT_KERNEL_SHA256__'`).
 pub const VAULT_KERNEL_HASH_TOKEN: &str = "__VAULT_KERNEL_SHA256__";
+/// Placeholder any fragment may carry where the build stamp — the first 16
+/// lowercase-hex chars of the sha256 over the raw manifest-ordered fragment
+/// bytes — is substituted at assembly time. See "The build stamp" in the
+/// crate docs.
+pub const APP_BUILD_TOKEN: &str = "__INTENDANT_APP_BUILD__";
 
 /// Extensions that count as fragments. Anything else in the directory
 /// (README.md, the manifest itself) is ignored by the completeness check;
@@ -126,19 +144,42 @@ pub fn assemble(repo_root: &Path) -> Result<Outcome, String> {
     // (tests, pre-kernel checkouts) never require the kernel file.
     let mut kernel_hash: Option<String> = None;
 
+    // The build stamp (crate docs): sha256 over the raw fragment bytes in
+    // manifest order, before any substitution — deterministic across
+    // machines and self-consistent (the stamped artifact still hashes the
+    // placeholder form). Fragments are pre-read once and reused below.
+    let mut fragment_bytes: Vec<Vec<u8>> = Vec::with_capacity(entries.len());
+    let mut build_hasher = Sha256::new();
+    for entry in &entries {
+        let path = fragment_dir.join(entry);
+        let bytes = fs::read(&path)
+            .map_err(|e| format!("failed to read fragment {}: {e}", path.display()))?;
+        build_hasher.update(&bytes);
+        fragment_bytes.push(bytes);
+    }
+    let build_stamp = {
+        let mut hex = String::with_capacity(64);
+        for byte in build_hasher.finalize() {
+            hex.push_str(&format!("{byte:02x}"));
+        }
+        hex.truncate(16);
+        hex
+    };
+
     let mut assembled: Vec<u8> = Vec::new();
     assembled.extend_from_slice(GENERATED_HEADER.as_bytes());
     // All .js fragments share one <script type="module"> scope in manifest
     // order; lint them (below) as the single program they become — with the
     // pin already substituted, exactly as the browser will evaluate it.
     let mut js_fragments: Vec<(String, String)> = Vec::new();
-    for (index, entry) in entries.iter().enumerate() {
+    for (index, (entry, raw)) in entries.iter().zip(fragment_bytes).enumerate() {
         if let Some(banner) = fragment_banner(entry, index) {
             assembled.extend_from_slice(banner.as_bytes());
         }
-        let path = fragment_dir.join(entry);
-        let mut bytes = fs::read(&path)
-            .map_err(|e| format!("failed to read fragment {}: {e}", path.display()))?;
+        let mut bytes = raw;
+        if find_subslice(&bytes, APP_BUILD_TOKEN.as_bytes()).is_some() {
+            bytes = replace_subslice(&bytes, APP_BUILD_TOKEN.as_bytes(), build_stamp.as_bytes());
+        }
         if find_subslice(&bytes, VAULT_KERNEL_HASH_TOKEN.as_bytes()).is_some() {
             if kernel_hash.is_none() {
                 let kernel_path = repo_root.join(VAULT_KERNEL_PATH);
@@ -441,6 +482,40 @@ mod tests {
             err.contains("do not exist") && err.contains("90-gone.js"),
             "{err}"
         );
+    }
+
+    #[test]
+    fn build_stamp_substitutes_and_settles() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "static/app/00-a.js",
+            "const INTENDANT_APP_BUILD = '__INTENDANT_APP_BUILD__';\n",
+        );
+        write(dir.path(), "static/app/manifest.txt", "00-a.js\n");
+        assemble(dir.path()).unwrap();
+        let out = fs::read_to_string(dir.path().join(OUTPUT)).unwrap();
+        assert!(
+            !out.contains(APP_BUILD_TOKEN),
+            "placeholder must be substituted"
+        );
+        let stamp1 = out.split("INTENDANT_APP_BUILD = '").nth(1).unwrap()[..16].to_string();
+        assert!(stamp1.bytes().all(|b| b.is_ascii_hexdigit()));
+        // Settles: a rerun is byte-identical.
+        assert!(matches!(
+            assemble(dir.path()).unwrap(),
+            Outcome::Unchanged { .. }
+        ));
+        // Any fragment edit mints a different stamp.
+        write(
+            dir.path(),
+            "static/app/00-a.js",
+            "const INTENDANT_APP_BUILD = '__INTENDANT_APP_BUILD__'; // v2\n",
+        );
+        assemble(dir.path()).unwrap();
+        let out2 = fs::read_to_string(dir.path().join(OUTPUT)).unwrap();
+        let stamp2 = out2.split("INTENDANT_APP_BUILD = '").nth(1).unwrap()[..16].to_string();
+        assert_ne!(stamp1, stamp2);
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/agent_card.rs
+++ b/src/bin/caller/web_gateway/agent_card.rs
@@ -17,13 +17,18 @@ pub fn build_config(
     ice_config: crate::display::IceConfig,
     federation_allow_h264: bool,
 ) -> WebGatewayConfig {
-    build_config_inner(
+    let mut config = build_config_inner(
         live_provider,
         live_model,
         transcription_enabled,
         ice_config.ice_servers,
         federation_allow_h264,
-    )
+    );
+    // Stamped once here — the /config route and the tunnel `config` RPC both
+    // serve this instance, so every lane reports the same served-bundle
+    // build and stale tabs can nudge themselves to reload.
+    config.app_build = super::static_assets::app_build().to_string();
+    config
 }
 
 // ---------------------------------------------------------------------------

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -221,6 +221,12 @@ pub struct WebGatewayConfig {
     /// `[webrtc].federation_allow_h264` in intendant.toml.
     #[serde(default)]
     pub federation_allow_h264: bool,
+    /// Build stamp of the dashboard bundle this daemon serves, extracted at
+    /// startup from the embedded app.html (minted there by
+    /// app-html-assembler). The SPA compares it against its own stamped
+    /// constant and nudges stale tabs to reload after a daemon upgrade.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub app_build: String,
     /// Public peer access-request hardening. This is gateway runtime state,
     /// not browser config, so `/config` intentionally omits it.
     #[serde(skip)]
@@ -243,6 +249,7 @@ impl Default for WebGatewayConfig {
             transcription_enabled: false,
             ice_servers: Vec::new(),
             federation_allow_h264: false,
+            app_build: String::new(),
             peer_access_requests: crate::project::PeerAccessRequestConfig::default(),
             connect: crate::project::ConnectConfig::default(),
         }

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -7,6 +7,28 @@ use super::*;
 
 pub(crate) const APP_HTML: &str = include_str!("../../../../static/app.html");
 
+/// Build stamp of the embedded dashboard bundle — the value
+/// app-html-assembler substituted for `__INTENDANT_APP_BUILD__` (first 16
+/// hex chars of the sha256 over the raw manifest-ordered fragments).
+/// Extracted once from [`APP_HTML`], so the daemon and the SPA it serves
+/// cannot disagree by construction; `/config` reports it and a dashboard
+/// tab whose own stamp differs knows it predates the served bundle. Empty
+/// when the artifact carries no stamp (pre-stamp checkouts) — the SPA
+/// treats an absent value as "no signal", never as a mismatch.
+pub(crate) fn app_build() -> &'static str {
+    static STAMP: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    STAMP.get_or_init(|| extract_app_build(APP_HTML).unwrap_or_default())
+}
+
+fn extract_app_build(html: &str) -> Option<String> {
+    let marker = "const INTENDANT_APP_BUILD = '";
+    let start = html.find(marker)? + marker.len();
+    let rest = &html[start..];
+    let value = &rest[..rest.find('\'')?];
+    (value.len() == 16 && value.bytes().all(|b| b.is_ascii_hexdigit()))
+        .then(|| value.to_string())
+}
+
 // The vault crypto kernel: the small, separately served worker that owns
 // the vault's key material. app.html pins its sha256 (VAULT_KERNEL_SHA256,
 // minted by crates/app-html-assembler) and the page refuses to instantiate
@@ -575,6 +597,26 @@ mod tests {
             .iter()
             .map(|byte| format!("{byte:02x}"))
             .collect()
+    }
+
+    /// The build stamp: the embedded app.html must carry a minted (16-hex)
+    /// `INTENDANT_APP_BUILD` value, never the raw placeholder — otherwise
+    /// every served tab would see a stampless daemon and the stale-tab
+    /// reload nudge goes blind.
+    #[test]
+    fn app_build_stamp_is_minted_in_embedded_artifact() {
+        let stamp = app_build();
+        assert_eq!(
+            stamp.len(),
+            16,
+            "embedded app.html carries no minted INTENDANT_APP_BUILD stamp — \
+             regenerate with `cargo run -p app-html-assembler` and commit"
+        );
+        assert!(stamp.bytes().all(|b| b.is_ascii_hexdigit()));
+        assert!(
+            !APP_HTML.contains("__INTENDANT_APP_BUILD__"),
+            "the raw placeholder must never ship"
+        );
     }
 
     /// The vault-kernel hash pin: the embedded app.html must pin exactly the

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -25,8 +25,7 @@ fn extract_app_build(html: &str) -> Option<String> {
     let start = html.find(marker)? + marker.len();
     let rest = &html[start..];
     let value = &rest[..rest.find('\'')?];
-    (value.len() == 16 && value.bytes().all(|b| b.is_ascii_hexdigit()))
-        .then(|| value.to_string())
+    (value.len() == 16 && value.bytes().all(|b| b.is_ascii_hexdigit())).then(|| value.to_string())
 }
 
 // The vault crypto kernel: the small, separately served worker that owns

--- a/static/app.html
+++ b/static/app.html
@@ -918,6 +918,39 @@ html {
   color: var(--yellow, #f9e2af);
   vertical-align: middle;
 }
+
+/* Stale-build reload nudge + event-lane staleness banner: slim fixed
+   strips at the top of the viewport, above everything, never blocking. */
+#ui-stale-build-banner,
+#ui-event-lane-banner {
+  position: fixed;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--surface1);
+  background: var(--mantle, #181825);
+  color: var(--text);
+  font-size: 12.5px;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
+}
+#ui-stale-build-banner button {
+  border: 1px solid var(--blue);
+  background: transparent;
+  color: var(--blue);
+  border-radius: 6px;
+  padding: 2px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+#ui-event-lane-banner {
+  border-color: var(--yellow, #f9e2af);
+}
 /* ── static/app/11-styles-access-files.css ── */
 /* ── Access redesign components (.acc-*) ──
    The Access surface speaks one visual language: glass cards on the
@@ -25928,6 +25961,59 @@ import init, { PresenceWeb } from '/wasm-web/presence_web.js';
 import stationInit, { StationWeb } from '/wasm-station/station_web.js';
 import * as THREE from '/three.module.min.js';
 
+// ── Build stamp / stale-tab reload nudge ──
+//
+// Minted by app-html-assembler (sha256 over the manifest-ordered raw
+// fragment bytes, first 16 hex chars). The daemon extracts the same value
+// from its embedded artifact and serves it in /config, so a tab whose
+// stamp differs is a dashboard from an OLDER served bundle — after a
+// daemon upgrade, tabs left open would otherwise keep running old code
+// against the new daemon indefinitely (the "stale photograph" multi-tab
+// failure class).
+const INTENDANT_APP_BUILD = '4bfdd4119d3cb415';
+
+let staleBuildNudged = false;
+function maybeNudgeStaleBuild(serverBuild) {
+  const server = String(serverBuild || '').trim();
+  // No signal (stampless daemon or config fetch without the field) is
+  // never a mismatch; a placeholder-carrying page (fragment served raw in
+  // dev) can't compare either.
+  if (!server || INTENDANT_APP_BUILD.startsWith('__')) return;
+  if (server === INTENDANT_APP_BUILD || staleBuildNudged) return;
+  staleBuildNudged = true;
+  console.info(`[dashboard] daemon serves build ${server}; this tab runs ${INTENDANT_APP_BUILD} — reload to update`);
+  // A draft in the composer must never be reload-clobbered; hidden tabs
+  // with nothing in flight self-heal invisibly.
+  const reloadSafe = () =>
+    !(document.getElementById('new-session-input')?.value || '').trim();
+  if (document.hidden && reloadSafe()) {
+    location.reload();
+    return;
+  }
+  const banner = document.createElement('div');
+  banner.id = 'ui-stale-build-banner';
+  const text = document.createElement('span');
+  text.textContent = 'The daemon updated — this dashboard is from an older build.';
+  const btn = document.createElement('button');
+  btn.textContent = 'Reload';
+  btn.addEventListener('click', () => location.reload());
+  banner.appendChild(text);
+  banner.appendChild(btn);
+  document.body.appendChild(banner);
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden && reloadSafe()) location.reload();
+  });
+}
+
+// QA readback (window.qa convention) + one explicit test hook: the build
+// stamp and nudge state are module-scoped, and the mismatch path can only
+// be exercised for real by building a second bundle — the hook lets the
+// lane-verify harness drive it with a synthetic server stamp instead.
+window.qa = Object.assign(window.qa || {}, {
+  buildInfo: () => ({ build: INTENDANT_APP_BUILD, nudged: staleBuildNudged }),
+  __testNudgeStaleBuild: (v) => maybeNudgeStaleBuild(v),
+});
+
 // ── Legacy federation auth compatibility ──
 //
 // When the daemon's `[server.auth] bearer_token` is set, federation
@@ -31544,6 +31630,10 @@ function applyGatewayConfig(config) {
   if (currentExternalAgent === null) {
     currentExternalAgent = normalizeAgentId(cfg.external_agent);
   }
+  // Every lane's config lands here (boot fetch, tunnel config RPC,
+  // reconnect hydration, /ws-reconnect refetch) — the one chokepoint where
+  // a stale tab learns the daemon now serves a newer bundle.
+  if (typeof maybeNudgeStaleBuild === 'function') maybeNudgeStaleBuild(cfg.app_build);
   applyMainBackendStatus();
 }
 
@@ -38854,6 +38944,14 @@ function setServerWebSocketStatus(connected) {
 function setConnectEventStatus(kind, title) {
   setPrimaryEventStatus(kind, 'events', title);
   if (kind === 'ok') clearServerWebSocketErrorStatus();
+}
+
+// Cross-fragment predicate for the visibility quiescence in
+// 49-daemons-multihost.js: a hidden tab with a live voice session is doing
+// real work and must keep its transports healing; `modelConnected` is
+// module-scoped here, so the closure exports the one bit that matters.
+function dashboardVoiceIsLive() {
+  return typeof modelConnected !== 'undefined' && !!modelConnected;
 }
 
 function hideVoiceStatus() {
@@ -69713,7 +69811,21 @@ function dashboardControlTunnelIsPrimaryEventLane() {
 const DASHBOARD_LEGACY_WS_FALLBACK_MS = 3000;
 let dashboardControlAutoFallback = false;
 let dashboardLegacyWsConnected = false;
+let dashboardLegacyWsEverConnected = false;
 let dashboardLegacyWsWatchdog = null;
+// Visibility-aware quiescence: Safari throttles background-tab timers into
+// uselessness, so probing/reconnect churn while hidden mostly burns cycles
+// and mints failures nobody sees. Hidden tabs park; the visibilitychange
+// handler below heals the lane the moment the tab is seen again. A tab
+// with live voice is exempt — it is doing real work while hidden.
+let dashboardTabHidden = typeof document !== 'undefined' && document.hidden === true;
+let dashboardEventLaneDownSince = 0;
+const DASHBOARD_LANE_STALE_GRACE_MS = 8000;
+
+function dashboardTabQuiesced() {
+  if (!dashboardTabHidden) return false;
+  return !(typeof dashboardVoiceIsLive === 'function' && dashboardVoiceIsLive());
+}
 
 // The posture where the /ws is attempted at all (36-voice-wasm-init.js
 // branch order): not hosted Connect, not the packaged-app bundle.
@@ -69726,11 +69838,23 @@ function dashboardLegacyWsPostureApplies() {
 // path arms the watchdog right after connect_server. Open clears the
 // watchdog; closed (re-)arms it.
 function dashboardNoteLegacyWsState(connected) {
+  const reconnected = connected && !dashboardLegacyWsConnected && dashboardLegacyWsEverConnected;
+  if (connected) dashboardLegacyWsEverConnected = true;
   dashboardLegacyWsConnected = !!connected;
   if (connected) {
     if (dashboardLegacyWsWatchdog) {
       clearTimeout(dashboardLegacyWsWatchdog);
       dashboardLegacyWsWatchdog = null;
+    }
+    // A RE-connect usually means the daemon restarted: refetch /config so
+    // the build-stamp comparison (and any other config drift) lands even
+    // in the /ws-only posture, whose lane carries no config on its own.
+    // Boot-time connects skip this — the boot path fetches /config itself.
+    if (reconnected) {
+      fetch('/config')
+        .then(r => r.json())
+        .then(cfg => { if (typeof applyGatewayConfig === 'function') applyGatewayConfig(cfg); })
+        .catch(() => {});
     }
     // The /ws proved able to open after all (e.g. a browser that merely
     // weathered a daemon restart): demote the promotion — autoFallback is
@@ -69749,6 +69873,7 @@ function dashboardNoteLegacyWsState(connected) {
 function dashboardArmLegacyWsWatchdog(reason) {
   if (!dashboardLegacyWsPostureApplies()) return;
   if (dashboardLegacyWsConnected || dashboardLegacyWsWatchdog) return;
+  if (dashboardTabQuiesced()) return;
   dashboardLegacyWsWatchdog = window.setTimeout(() => {
     dashboardLegacyWsWatchdog = null;
     if (dashboardLegacyWsConnected) return;
@@ -69794,8 +69919,60 @@ function dashboardEventLaneQa() {
     autoFallback: dashboardControlAutoFallback,
     watchdogArmed: Boolean(dashboardLegacyWsWatchdog),
     tunnelEventsActive: Boolean(dashboardControlEventsActive),
+    hidden: dashboardTabHidden,
+    laneDownSinceUnixMs: dashboardEventLaneDownSince,
   };
 }
+
+// Content-level staleness truth: while no event lane is up, everything the
+// page shows is a photograph aging in place — say so, instead of letting a
+// dead-feed tab present its last-known world as live. Lane transitions
+// (dashboardUpdateTransportStatus fires on every one) drive this; the slow
+// tick below only advances the grace window on quiet failures.
+function updateEventLaneStalenessBanner() {
+  const now = Date.now();
+  if (dashboardEventLaneUp()) {
+    dashboardEventLaneDownSince = 0;
+  } else if (!dashboardEventLaneDownSince) {
+    dashboardEventLaneDownSince = now;
+  }
+  const show = Boolean(dashboardEventLaneDownSince)
+    && now - dashboardEventLaneDownSince >= DASHBOARD_LANE_STALE_GRACE_MS
+    && !dashboardTabHidden;
+  let banner = document.getElementById('ui-event-lane-banner');
+  if (!show) {
+    if (banner) banner.remove();
+    return;
+  }
+  const since = new Date(dashboardEventLaneDownSince);
+  const hh = String(since.getHours()).padStart(2, '0');
+  const mm = String(since.getMinutes()).padStart(2, '0');
+  const text = `Live updates paused since ${hh}:${mm} — reconnecting. What you see may be stale.`;
+  if (!banner) {
+    banner = document.createElement('div');
+    banner.id = 'ui-event-lane-banner';
+    document.body.appendChild(banner);
+  }
+  if (banner.textContent !== text) banner.textContent = text;
+}
+setInterval(updateEventLaneStalenessBanner, 5000);
+
+function dashboardNoteVisibilityChange() {
+  dashboardTabHidden = document.hidden === true;
+  if (!dashboardTabHidden && !dashboardEventLaneUp()) {
+    // Just became visible with no lane: Safari throttled every timer
+    // while hidden, so probe and heal NOW instead of waiting out
+    // watchdogs and backoff that never ran.
+    if (!dashboardLegacyWsConnected) {
+      dashboardArmLegacyWsWatchdog('tab became visible with no event lane');
+    }
+    if (dashboardControlTunnelWanted() && !dashboardTransport?.canUseRpc?.()) {
+      scheduleDashboardConnectReconnect('tab became visible with no event lane', { delayMs: 0 });
+    }
+  }
+  updateEventLaneStalenessBanner();
+}
+document.addEventListener('visibilitychange', dashboardNoteVisibilityChange);
 
 // Human wording for the active primary event lane, used by the reconnect
 // status copy so app-posture messages don't claim "Hosted Connect".
@@ -69861,6 +70038,7 @@ function dashboardUpdateTransportStatus() {
     refreshFilesDownloadAvailability();
     if (activeTab === 'files') refreshFilesTransferJobs();
     maybeOpenShellAfterTransportReady();
+    updateEventLaneStalenessBanner();
     return;
   }
   dot.className = `conn-dot ${summary.kind}`;
@@ -69878,6 +70056,7 @@ function dashboardUpdateTransportStatus() {
   updateVirtualDisplayAvailabilityUi();
   if (activeTab === 'files') refreshFilesTransferJobs();
   maybeOpenShellAfterTransportReady();
+  updateEventLaneStalenessBanner();
 }
 
 function dashboardTransportStatusSummary(status = {}) {
@@ -70722,6 +70901,7 @@ function dashboardConnectReconnectStatus() {
 // came back; the attempt counter resets on a successful reconnect.
 function scheduleDashboardConnectReconnect(reason = 'dashboard transport disconnected', options = {}) {
   if (!dashboardControlTunnelWanted()) return;
+  if (dashboardTabQuiesced()) return;
   if (dashboardConnectReconnectTimer) return;
   const attempt = dashboardConnectReconnectAttempt;
   const backoffBaseMs = Math.min(

--- a/static/app/10-styles-shell.css
+++ b/static/app/10-styles-shell.css
@@ -848,3 +848,36 @@ html {
   color: var(--yellow, #f9e2af);
   vertical-align: middle;
 }
+
+/* Stale-build reload nudge + event-lane staleness banner: slim fixed
+   strips at the top of the viewport, above everything, never blocking. */
+#ui-stale-build-banner,
+#ui-event-lane-banner {
+  position: fixed;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 14px;
+  border-radius: 8px;
+  border: 1px solid var(--surface1);
+  background: var(--mantle, #181825);
+  color: var(--text);
+  font-size: 12.5px;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
+}
+#ui-stale-build-banner button {
+  border: 1px solid var(--blue);
+  background: transparent;
+  color: var(--blue);
+  border-radius: 6px;
+  padding: 2px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+#ui-event-lane-banner {
+  border-color: var(--yellow, #f9e2af);
+}

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -4,6 +4,59 @@ import init, { PresenceWeb } from '/wasm-web/presence_web.js';
 import stationInit, { StationWeb } from '/wasm-station/station_web.js';
 import * as THREE from '/three.module.min.js';
 
+// ── Build stamp / stale-tab reload nudge ──
+//
+// Minted by app-html-assembler (sha256 over the manifest-ordered raw
+// fragment bytes, first 16 hex chars). The daemon extracts the same value
+// from its embedded artifact and serves it in /config, so a tab whose
+// stamp differs is a dashboard from an OLDER served bundle — after a
+// daemon upgrade, tabs left open would otherwise keep running old code
+// against the new daemon indefinitely (the "stale photograph" multi-tab
+// failure class).
+const INTENDANT_APP_BUILD = '__INTENDANT_APP_BUILD__';
+
+let staleBuildNudged = false;
+function maybeNudgeStaleBuild(serverBuild) {
+  const server = String(serverBuild || '').trim();
+  // No signal (stampless daemon or config fetch without the field) is
+  // never a mismatch; a placeholder-carrying page (fragment served raw in
+  // dev) can't compare either.
+  if (!server || INTENDANT_APP_BUILD.startsWith('__')) return;
+  if (server === INTENDANT_APP_BUILD || staleBuildNudged) return;
+  staleBuildNudged = true;
+  console.info(`[dashboard] daemon serves build ${server}; this tab runs ${INTENDANT_APP_BUILD} — reload to update`);
+  // A draft in the composer must never be reload-clobbered; hidden tabs
+  // with nothing in flight self-heal invisibly.
+  const reloadSafe = () =>
+    !(document.getElementById('new-session-input')?.value || '').trim();
+  if (document.hidden && reloadSafe()) {
+    location.reload();
+    return;
+  }
+  const banner = document.createElement('div');
+  banner.id = 'ui-stale-build-banner';
+  const text = document.createElement('span');
+  text.textContent = 'The daemon updated — this dashboard is from an older build.';
+  const btn = document.createElement('button');
+  btn.textContent = 'Reload';
+  btn.addEventListener('click', () => location.reload());
+  banner.appendChild(text);
+  banner.appendChild(btn);
+  document.body.appendChild(banner);
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden && reloadSafe()) location.reload();
+  });
+}
+
+// QA readback (window.qa convention) + one explicit test hook: the build
+// stamp and nudge state are module-scoped, and the mismatch path can only
+// be exercised for real by building a second bundle — the hook lets the
+// lane-verify harness drive it with a synthetic server stamp instead.
+window.qa = Object.assign(window.qa || {}, {
+  buildInfo: () => ({ build: INTENDANT_APP_BUILD, nudged: staleBuildNudged }),
+  __testNudgeStaleBuild: (v) => maybeNudgeStaleBuild(v),
+});
+
 // ── Legacy federation auth compatibility ──
 //
 // When the daemon's `[server.auth] bearer_token` is set, federation

--- a/static/app/32-vault-custody.js
+++ b/static/app/32-vault-custody.js
@@ -3228,6 +3228,10 @@ function applyGatewayConfig(config) {
   if (currentExternalAgent === null) {
     currentExternalAgent = normalizeAgentId(cfg.external_agent);
   }
+  // Every lane's config lands here (boot fetch, tunnel config RPC,
+  // reconnect hydration, /ws-reconnect refetch) — the one chokepoint where
+  // a stale tab learns the daemon now serves a newer bundle.
+  if (typeof maybeNudgeStaleBuild === 'function') maybeNudgeStaleBuild(cfg.app_build);
   applyMainBackendStatus();
 }
 

--- a/static/app/36-voice-wasm-init.js
+++ b/static/app/36-voice-wasm-init.js
@@ -85,6 +85,14 @@ function setConnectEventStatus(kind, title) {
   if (kind === 'ok') clearServerWebSocketErrorStatus();
 }
 
+// Cross-fragment predicate for the visibility quiescence in
+// 49-daemons-multihost.js: a hidden tab with a live voice session is doing
+// real work and must keep its transports healing; `modelConnected` is
+// module-scoped here, so the closure exports the one bit that matters.
+function dashboardVoiceIsLive() {
+  return typeof modelConnected !== 'undefined' && !!modelConnected;
+}
+
 function hideVoiceStatus() {
   document.getElementById('voiceStatus').classList.add('hidden');
 }

--- a/static/app/49-daemons-multihost.js
+++ b/static/app/49-daemons-multihost.js
@@ -252,7 +252,21 @@ function dashboardControlTunnelIsPrimaryEventLane() {
 const DASHBOARD_LEGACY_WS_FALLBACK_MS = 3000;
 let dashboardControlAutoFallback = false;
 let dashboardLegacyWsConnected = false;
+let dashboardLegacyWsEverConnected = false;
 let dashboardLegacyWsWatchdog = null;
+// Visibility-aware quiescence: Safari throttles background-tab timers into
+// uselessness, so probing/reconnect churn while hidden mostly burns cycles
+// and mints failures nobody sees. Hidden tabs park; the visibilitychange
+// handler below heals the lane the moment the tab is seen again. A tab
+// with live voice is exempt — it is doing real work while hidden.
+let dashboardTabHidden = typeof document !== 'undefined' && document.hidden === true;
+let dashboardEventLaneDownSince = 0;
+const DASHBOARD_LANE_STALE_GRACE_MS = 8000;
+
+function dashboardTabQuiesced() {
+  if (!dashboardTabHidden) return false;
+  return !(typeof dashboardVoiceIsLive === 'function' && dashboardVoiceIsLive());
+}
 
 // The posture where the /ws is attempted at all (36-voice-wasm-init.js
 // branch order): not hosted Connect, not the packaged-app bundle.
@@ -265,11 +279,23 @@ function dashboardLegacyWsPostureApplies() {
 // path arms the watchdog right after connect_server. Open clears the
 // watchdog; closed (re-)arms it.
 function dashboardNoteLegacyWsState(connected) {
+  const reconnected = connected && !dashboardLegacyWsConnected && dashboardLegacyWsEverConnected;
+  if (connected) dashboardLegacyWsEverConnected = true;
   dashboardLegacyWsConnected = !!connected;
   if (connected) {
     if (dashboardLegacyWsWatchdog) {
       clearTimeout(dashboardLegacyWsWatchdog);
       dashboardLegacyWsWatchdog = null;
+    }
+    // A RE-connect usually means the daemon restarted: refetch /config so
+    // the build-stamp comparison (and any other config drift) lands even
+    // in the /ws-only posture, whose lane carries no config on its own.
+    // Boot-time connects skip this — the boot path fetches /config itself.
+    if (reconnected) {
+      fetch('/config')
+        .then(r => r.json())
+        .then(cfg => { if (typeof applyGatewayConfig === 'function') applyGatewayConfig(cfg); })
+        .catch(() => {});
     }
     // The /ws proved able to open after all (e.g. a browser that merely
     // weathered a daemon restart): demote the promotion — autoFallback is
@@ -288,6 +314,7 @@ function dashboardNoteLegacyWsState(connected) {
 function dashboardArmLegacyWsWatchdog(reason) {
   if (!dashboardLegacyWsPostureApplies()) return;
   if (dashboardLegacyWsConnected || dashboardLegacyWsWatchdog) return;
+  if (dashboardTabQuiesced()) return;
   dashboardLegacyWsWatchdog = window.setTimeout(() => {
     dashboardLegacyWsWatchdog = null;
     if (dashboardLegacyWsConnected) return;
@@ -333,8 +360,60 @@ function dashboardEventLaneQa() {
     autoFallback: dashboardControlAutoFallback,
     watchdogArmed: Boolean(dashboardLegacyWsWatchdog),
     tunnelEventsActive: Boolean(dashboardControlEventsActive),
+    hidden: dashboardTabHidden,
+    laneDownSinceUnixMs: dashboardEventLaneDownSince,
   };
 }
+
+// Content-level staleness truth: while no event lane is up, everything the
+// page shows is a photograph aging in place — say so, instead of letting a
+// dead-feed tab present its last-known world as live. Lane transitions
+// (dashboardUpdateTransportStatus fires on every one) drive this; the slow
+// tick below only advances the grace window on quiet failures.
+function updateEventLaneStalenessBanner() {
+  const now = Date.now();
+  if (dashboardEventLaneUp()) {
+    dashboardEventLaneDownSince = 0;
+  } else if (!dashboardEventLaneDownSince) {
+    dashboardEventLaneDownSince = now;
+  }
+  const show = Boolean(dashboardEventLaneDownSince)
+    && now - dashboardEventLaneDownSince >= DASHBOARD_LANE_STALE_GRACE_MS
+    && !dashboardTabHidden;
+  let banner = document.getElementById('ui-event-lane-banner');
+  if (!show) {
+    if (banner) banner.remove();
+    return;
+  }
+  const since = new Date(dashboardEventLaneDownSince);
+  const hh = String(since.getHours()).padStart(2, '0');
+  const mm = String(since.getMinutes()).padStart(2, '0');
+  const text = `Live updates paused since ${hh}:${mm} — reconnecting. What you see may be stale.`;
+  if (!banner) {
+    banner = document.createElement('div');
+    banner.id = 'ui-event-lane-banner';
+    document.body.appendChild(banner);
+  }
+  if (banner.textContent !== text) banner.textContent = text;
+}
+setInterval(updateEventLaneStalenessBanner, 5000);
+
+function dashboardNoteVisibilityChange() {
+  dashboardTabHidden = document.hidden === true;
+  if (!dashboardTabHidden && !dashboardEventLaneUp()) {
+    // Just became visible with no lane: Safari throttled every timer
+    // while hidden, so probe and heal NOW instead of waiting out
+    // watchdogs and backoff that never ran.
+    if (!dashboardLegacyWsConnected) {
+      dashboardArmLegacyWsWatchdog('tab became visible with no event lane');
+    }
+    if (dashboardControlTunnelWanted() && !dashboardTransport?.canUseRpc?.()) {
+      scheduleDashboardConnectReconnect('tab became visible with no event lane', { delayMs: 0 });
+    }
+  }
+  updateEventLaneStalenessBanner();
+}
+document.addEventListener('visibilitychange', dashboardNoteVisibilityChange);
 
 // Human wording for the active primary event lane, used by the reconnect
 // status copy so app-posture messages don't claim "Hosted Connect".
@@ -400,6 +479,7 @@ function dashboardUpdateTransportStatus() {
     refreshFilesDownloadAvailability();
     if (activeTab === 'files') refreshFilesTransferJobs();
     maybeOpenShellAfterTransportReady();
+    updateEventLaneStalenessBanner();
     return;
   }
   dot.className = `conn-dot ${summary.kind}`;
@@ -417,6 +497,7 @@ function dashboardUpdateTransportStatus() {
   updateVirtualDisplayAvailabilityUi();
   if (activeTab === 'files') refreshFilesTransferJobs();
   maybeOpenShellAfterTransportReady();
+  updateEventLaneStalenessBanner();
 }
 
 function dashboardTransportStatusSummary(status = {}) {
@@ -1261,6 +1342,7 @@ function dashboardConnectReconnectStatus() {
 // came back; the attempt counter resets on a successful reconnect.
 function scheduleDashboardConnectReconnect(reason = 'dashboard transport disconnected', options = {}) {
   if (!dashboardControlTunnelWanted()) return;
+  if (dashboardTabQuiesced()) return;
   if (dashboardConnectReconnectTimer) return;
   const attempt = dashboardConnectReconnectAttempt;
   const backoffBaseMs = Math.min(


### PR DESCRIPTION
The multi-tab failure classes from the 2026-07-13 incident review: tabs
from different code eras coexist silently after a daemon upgrade, hidden
tabs rot under Safari's timer throttling and come back wedged or alarmed,
and a dead-feed tab keeps presenting its last-known world as live.

Version handshake / reload nudge:
- app-html-assembler mints a build stamp (first 16 hex of sha256 over the
  raw manifest-ordered fragment bytes; deterministic, regen gate settles)
  substituted for __INTENDANT_APP_BUILD__; 31-init declares the constant.
- The daemon extracts the stamp from its embedded app.html at startup
  (static_assets::app_build, parity-tested) and serves it in /config and
  the tunnel config RPC via the one shared WebGatewayConfig instance.
- applyGatewayConfig compares every lane's config against the page's own
  stamp: a mismatch means this tab predates the served bundle. Hidden tab
  with an empty composer reloads itself; otherwise a slim banner offers
  Reload and the tab self-reloads on its next hidden moment with no draft.
- The /ws-only posture learns about daemon restarts too: a legacy-ws
  REconnect refetches /config (boot connects skip it).

Visibility-aware quiescence + staleness truth:
- Hidden tabs park the capability watchdog and tunnel-reconnect scheduling
  (Safari throttles their timers into uselessness anyway); a tab with live
  voice is exempt. On visibilitychange back to visible, the lane is probed
  and healed immediately instead of waiting out throttled backoff.
- While no event lane is up past an 8s grace, a content-level banner says
  'Live updates paused since HH:MM - reconnecting. What you see may be
  stale.' - a dead-feed tab now labels its photograph instead of
  impersonating a live view. Driven from dashboardUpdateTransportStatus
  transitions plus a slow tick.
- qa.buildInfo() + an explicit __testNudgeStaleBuild hook (mismatch is
  otherwise only reachable by building a second bundle); lane QA gains
  hidden + laneDownSinceUnixMs.

Verified: lane-verify normal mode asserts page/server stamp parity and the
mismatch nudge rendering; all three modes assert no staleness banner in
steady state; 3214 nextest + 29 assembler tests + clippy green.
