### PR TITLE
dashboard: fix Activity Focus/Grid layout — resumed sessions, drag-resize, maximize, minimize

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -26169,7 +26169,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '4bfdd4119d3cb415';
+const INTENDANT_APP_BUILD = '1069e3a0dd20e6b2';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {

--- a/static/app.html
+++ b/static/app.html
@@ -18319,18 +18319,32 @@ html.ui-v2 #approval-panel .ui2-approve-category:hover { background: rgba(var(--
 /* the relabeled autonomy escape reads as the power action it is */
 html.ui-v2 #approval-panel .ui2-full-escape { font-size: 12px; color: var(--text-3); }
 
-/* — Focus layout (default): one centered timeline ──────────────────────
-   The session-window grid, its resize handle, and the "Concurrent view"
-   label disappear; the combined stream is the surface. JS keeps the
-   stream mounted (shouldDetachConcurrentLogStream returns false under
-   Focus) — these rules are the visual half of that contract. Grid mode
-   (html[data-ui2-layout="grid"]) leaves v1's machinery fully in charge. */
-html.ui-v2:not([data-ui2-layout="grid"]) #session-window-grid,
+/* — Focus layout (default): the FOREGROUND session's timeline ──────────
+   Two surfaces, selected by data-ui2-focus (stamped by ui2ApplyFocusSurface):
+
+     [data-ui2-focus="session"] — a session is targeted. Its session window
+       is promoted out of the grid and becomes the timeline. The window is
+       the ONLY place a resumed / external session's transcript exists —
+       hydration renders it there and never into the combined stream — so
+       promoting it is what makes Focus work at all after a resume, and it
+       reuses the window's live, deduped, virtualized renderer instead of
+       standing up a second copy of one.
+
+     [data-ui2-focus="all"] — nothing targeted. The combined stream is the
+       surface, as before; it also carries the idle / unfueled empty state,
+       which therefore now appears only when there is genuinely nothing to
+       read.
+
+   Grid mode (html[data-ui2-layout="grid"]) leaves v1's machinery fully in
+   charge in both cases. */
 html.ui-v2:not([data-ui2-layout="grid"]) #session-window-grid-resize-handle,
 html.ui-v2:not([data-ui2-layout="grid"]) #concurrent-log-label { display: none; }
-/* Focus must also neutralize the v1 minimized/maximized pane states —
-   they collapse or hide the very stream Focus promotes (the CSS half of
-   the shouldDetachConcurrentLogStream guard). */
+
+/* — all-sessions surface: the combined stream — */
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="all"] #session-window-grid { display: none; }
+/* Neutralize the v1 minimized/maximized pane states — they collapse or
+   hide the very stream this surface promotes (the CSS half of the
+   shouldDetachConcurrentLogStream guard). */
 html.ui-v2:not([data-ui2-layout="grid"]) .subtab-pane.concurrent-log-minimized .log-stream { display: block; }
 html.ui-v2:not([data-ui2-layout="grid"]) .subtab-pane.concurrent-log-minimized .concurrent-log-region,
 html.ui-v2:not([data-ui2-layout="grid"]) .subtab-pane.concurrent-log-maximized .concurrent-log-region {
@@ -18338,10 +18352,62 @@ html.ui-v2:not([data-ui2-layout="grid"]) .subtab-pane.concurrent-log-maximized .
   min-height: 0;
   border-top: 0;
 }
-/* v1 hides these with !important while the grid is maximized; the grid
-   itself is gone under Focus, so counter at the same weight. */
-html.ui-v2:not([data-ui2-layout="grid"]) .session-window-grid.maximized ~ .concurrent-log-region { display: flex !important; }
-html.ui-v2:not([data-ui2-layout="grid"]) .session-window-grid.maximized ~ .scroll-bottom-btn.visible { display: flex !important; }
+/* v1 hides these with !important while the grid is maximized; on this
+   surface the grid is gone, so counter at the same weight. */
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="all"] .session-window-grid.maximized ~ .concurrent-log-region { display: flex !important; }
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="all"] .session-window-grid.maximized ~ .scroll-bottom-btn.visible { display: flex !important; }
+
+/* — session surface: promote that window into the timeline column — */
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="session"] .concurrent-log-region,
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="session"] #scroll-bottom { display: none; }
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="session"] #session-window-grid {
+  display: flex;
+  flex: 1 1 auto;
+  height: auto;
+  min-height: 0;
+  max-height: none;
+  padding: 0;
+  border-bottom: 0;
+  background: transparent;
+  overflow: hidden;
+}
+/* Only the promoted window renders — this outranks v1's .maximized rules,
+   which would otherwise pick a different window. */
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="session"] #session-window-grid .session-window { display: none; }
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="session"] #session-window-grid .session-window.ui2-focus-window {
+  display: flex;
+  flex: 1 1 auto;
+  align-self: stretch;
+  width: 100%;
+  min-height: 0;
+  max-height: none;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  cursor: default;
+}
+/* The window's log becomes the design's centered timeline column — the same
+   880px measure and padding #log-stream uses on the all-sessions surface.
+   The .log-entry grammar at the top of this file already styles both. */
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="session"] .session-window.ui2-focus-window .session-window-log {
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: none;
+  width: 100%;
+  max-width: 880px;
+  margin-inline: auto;
+  padding: 18px 24px 24px;
+}
+/* The card header keeps carrying session identity, phase, and the window
+   controls; it reads as the timeline's header bar, not as a card's. */
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="session"] .session-window.ui2-focus-window .session-window-header {
+  width: 100%;
+  max-width: 880px;
+  margin-inline: auto;
+  background: transparent;
+  border-bottom: 1px solid var(--line);
+}
 
 /* turn separators read as quiet time breaks */
 html.ui-v2 .log-turn-sep {
@@ -18444,7 +18510,6 @@ html.ui-v2 .ui2-rail-advanced:hover { background: var(--surface-2); color: var(-
 
 /* — Focus filter + raw-entry hygiene + hero identity (corrective batch,
      2026-07-08 product-owner review) — */
-html.ui-v2 .log-entry.hidden-by-focus { display: none; }
 html.ui-v2 .log-entry.ui2-stderr .log-content {
   font-family: var(--mono);
   font-size: 10.5px;
@@ -24836,8 +24901,13 @@ function ui2WireMirrors() {
   const switcher = document.getElementById('ui2-session-switcher');
   const rebuildSwitcher = () => {
     if (!switcher || typeof sessionWindows === 'undefined') return;
-    const target = typeof resolvePromptTargetSessionId === 'function'
-      ? (resolvePromptTargetSessionId() || '') : '';
+    // Must be the SAME selector Focus promotes with (ui2ApplyFocusSurface),
+    // or the switcher reads "all sessions" while Focus is showing exactly one
+    // session's transcript.
+    const target = typeof ui2FocusSessionId === 'function'
+      ? (ui2FocusSessionId() || '')
+      : (typeof resolvePromptTargetSessionId === 'function'
+        ? (resolvePromptTargetSessionId() || '') : '');
     const options = [['', 'all sessions']];
     for (const [sid] of sessionWindows) {
       let label = sid.slice(0, 8);
@@ -24869,7 +24939,7 @@ function ui2WireMirrors() {
         if (current) discardPromptTargetReference(current);
         if (typeof updatePromptTargetSessionHighlight === 'function') updatePromptTargetSessionHighlight();
       }
-      if (typeof ui2ApplyFocusFilter === 'function') ui2ApplyFocusFilter();
+      if (typeof ui2ApplyFocusSurface === 'function') ui2ApplyFocusSurface();
     });
     ui2Mirror('task-target-chip', rebuildSwitcher);
     const grid = document.getElementById('session-window-grid');
@@ -25718,7 +25788,7 @@ function ui2ApplyLayout(mode) {
   // returns a number and touches nothing, so entering Grid left the grid unsized and
   // its controls unsynced until some unrelated path happened to apply them.
   if (grid && typeof applySessionWindowGridHeight === 'function') applySessionWindowGridHeight();
-  if (typeof ui2ApplyFocusFilter === 'function') ui2ApplyFocusFilter();
+  if (typeof ui2ApplyFocusSurface === 'function') ui2ApplyFocusSurface();
 }
 
 function ui2WireLayoutToggle() {
@@ -25740,31 +25810,107 @@ function ui2DressComposer() {
   if (attach && typeof ui2Icon === 'function') attach.innerHTML = ui2Icon('attach', 15);
 }
 
-// ── Focus filter: Focus shows the FOREGROUND session's timeline ────────
-// The original product decision: "Focus timeline + session switcher".
-// Entries from other sessions hide; daemon-level entries (no session id)
-// always show. No target selected ("all sessions") = the combined
-// stream. Grid mode never filters — the concurrent view is combined by
-// definition.
-function ui2ApplyFocusFilter() {
-  const stream = document.getElementById('log-stream');
-  if (!stream) return;
-  const focusMode = document.documentElement.dataset.ui2Layout !== 'grid';
-  const sid = (focusMode && typeof resolvePromptTargetSessionId === 'function'
-    && resolvePromptTargetSessionId()) || '';
-  stream.querySelectorAll('.log-entry').forEach((e) => {
-    const esid = e.dataset.sessionId || '';
-    e.classList.toggle('hidden-by-focus', !!sid && !!esid && esid !== sid);
-  });
+// ── Focus surface: Focus shows the FOREGROUND session's transcript ─────
+// The product decision: "Focus timeline + session switcher".
+//
+// Focus used to implement that as a FILTER over #log-stream — the combined
+// ("Concurrent view") stream — hiding entries belonging to other sessions.
+// But that stream only ever carries entries the live event feed delivered.
+// A resumed session's transcript is fetched and rendered straight into its
+// session window (hydrateRestoredSessionWindow → renderRestoredSessionWindow-
+// Entries, which touches the main stream nowhere), so it never enters the
+// stream at all — and Focus rendered a blank page for precisely the sessions
+// the user had just reopened, while Grid showed them fine.
+//
+// The session window already IS the per-session timeline: hydrated (external
+// and restored sessions included), signature-deduped, virtualized, paginated,
+// and live. So Focus PROMOTES that window rather than rendering a second copy
+// of it — one renderer, one DOM, and a resumed session appears in Focus
+// because it is the very node Grid draws.
+//
+// With no session targeted, Focus falls back to the combined stream (the
+// "all sessions" reading) — which is also where the idle / unfueled empty
+// state lives, so that notice now shows only when there is genuinely
+// nothing to read.
+function ui2FocusSessionId() {
+  // The canonical target first — the same resolver the composer and the
+  // session switcher use.
+  if (typeof resolvePromptTargetSessionId === 'function') {
+    const sid = resolvePromptTargetSessionId();
+    if (sid) return sid;
+  }
+  const windows = typeof sessionWindows !== 'undefined' ? sessionWindows : null;
+  if (!windows || windows.size === 0) return '';
+  // That resolver gates every candidate on STEERABILITY (isPromptTargetSession-
+  // Usable: may I send this session a message?). Focus asks the weaker
+  // question — what am I READING? — and a session that has ended, or is still
+  // spinning up, is perfectly readable while not being steerable. So fall back
+  // past that gate: the window the user explicitly opened, and then an
+  // unambiguous single window (the same "one candidate" rule the resolver
+  // applies, minus the steerability filter). Without this, resuming a single
+  // session left Focus on the all-sessions surface — i.e. blank, since a
+  // resumed transcript never enters the combined stream.
+  if (typeof foregroundSessionFullId !== 'undefined'
+      && foregroundSessionFullId && windows.has(foregroundSessionFullId)) {
+    return foregroundSessionFullId;
+  }
+  if (windows.size === 1) return windows.keys().next().value;
+  return '';
 }
 
-let ui2FocusFilterQueued = false;
-function ui2QueueFocusFilter() {
-  if (ui2FocusFilterQueued) return;
-  ui2FocusFilterQueued = true;
+function ui2ApplyFocusSurface() {
+  const root = document.documentElement;
+  const focusMode = root.dataset.ui2Layout !== 'grid';
+  const sid = focusMode ? ui2FocusSessionId() : '';
+  const windows = typeof sessionWindows !== 'undefined' ? sessionWindows : null;
+  const win = (sid && windows) ? windows.get(sid) : null;
+  if (windows) {
+    for (const [id, w] of windows) {
+      w?.el?.classList.toggle('ui2-focus-window', !!win && id === sid);
+    }
+  }
+  // CSS is the single reader: "session" promotes the marked window and
+  // retires the combined stream; "all" is the pre-existing combined view.
+  root.dataset.ui2Focus = win ? 'session' : 'all';
+  // A session promoted straight into Focus may never have been opened in
+  // Grid, so its window can still be empty. Hydration is idempotent (it
+  // no-ops on non-empty history and on an in-flight fetch), which makes
+  // Focus on its own enough to reopen a session.
+  if (win && typeof hydrateSessionWindowIfEmpty === 'function') {
+    Promise.resolve(hydrateSessionWindowIfEmpty(sid)).catch(() => {});
+  }
+}
+
+// QA readback (window.qa convention): the Focus surface's inputs and its
+// verdict. The interesting regression is silent — Focus renders an empty
+// page — so the probe exposes what it resolved and what it promoted.
+window.qa = Object.assign(window.qa || {}, {
+  focusSurface: () => ({
+    layout: document.documentElement.dataset.ui2Layout || 'focus',
+    surface: document.documentElement.dataset.ui2Focus || '',
+    sessionId: ui2FocusSessionId(),
+    promptTarget: typeof resolvePromptTargetSessionId === 'function'
+      ? (resolvePromptTargetSessionId() || '') : '',
+    foreground: typeof foregroundSessionFullId !== 'undefined' ? (foregroundSessionFullId || '') : '',
+    railSessionId: ui2RailForegroundSessionId(),
+    railTicks: ui2RailTickCount,
+    windows: typeof sessionWindows !== 'undefined' ? [...sessionWindows.keys()] : [],
+    promotedEntries: (() => {
+      const log = document.querySelector(
+        '#session-window-grid .session-window.ui2-focus-window .session-window-log'
+      );
+      return log ? log.querySelectorAll('.log-entry').length : 0;
+    })(),
+  }),
+});
+
+let ui2FocusSurfaceQueued = false;
+function ui2QueueFocusSurface() {
+  if (ui2FocusSurfaceQueued) return;
+  ui2FocusSurfaceQueued = true;
   requestAnimationFrame(() => {
-    ui2FocusFilterQueued = false;
-    ui2ApplyFocusFilter();
+    ui2FocusSurfaceQueued = false;
+    ui2ApplyFocusSurface();
     ui2TagRawEntries();
   });
 }
@@ -25848,20 +25994,27 @@ function ui2BuildVitalsRail() {
   });
 }
 
-// The rail describes the FOREGROUND session — prompt target, then the
-// current session, then the daemon's own. Same fallback chain the v1
-// composer targeting uses.
+// The rail describes the session Focus is SHOWING, so it derives from the
+// same selector the Focus surface promotes with (and the session switcher
+// displays) — one source, three readers. It previously stopped at
+// resolvePromptTargetSessionId, whose steerability gate rejects an ended or
+// still-starting session, and so read "No session yet" while a perfectly
+// live session was on screen beside it. The daemon's own session stays the
+// last resort.
 function ui2RailForegroundSessionId() {
-  if (typeof resolvePromptTargetSessionId === 'function') {
-    const sid = resolvePromptTargetSessionId();
-    if (sid) return sid;
-  }
-  if (typeof currentSessionFullId !== 'undefined' && currentSessionFullId) return currentSessionFullId;
+  const sid = ui2FocusSessionId();
+  if (sid) return sid;
   if (typeof daemonSessionFullId !== 'undefined' && daemonSessionFullId) return daemonSessionFullId;
   return '';
 }
 
+// The rail repaints on a 1s interval, so any probe of it races that interval —
+// reading it right after load shows the boot tick's values and looks exactly
+// like a broken selector. The counter lets a probe wait deterministically
+// (window.qa.focusSurface().railTicks) instead of sleeping and guessing.
+let ui2RailTickCount = 0;
 function ui2RailTick(force) {
+  ui2RailTickCount++;
   const rail = document.getElementById('ui2-vitals-rail');
   if (!rail) return;
   // hidden: other tab/subtab, grid layout, or <1180px — skip the interval
@@ -25926,15 +26079,20 @@ function ui2RailTick(force) {
     ui2BuildVitalsRail();
     ui2RailTick(true);
     setInterval(() => ui2RailTick(), 1000);
-    // Focus filter + raw-entry hygiene: follow stream appends, target
-    // changes (the chip re-renders on every change), and layout flips.
+    // Focus surface + raw-entry hygiene: follow stream appends, target
+    // changes (the chip re-renders on every change), layout flips, and the
+    // session-window grid's own membership — a session resumed from the
+    // Sessions tab materializes its window there, and that is the only
+    // signal Focus gets that the window it must promote now exists.
     const stream = document.getElementById('log-stream');
-    if (stream) new MutationObserver(ui2QueueFocusFilter).observe(stream, { childList: true });
+    if (stream) new MutationObserver(ui2QueueFocusSurface).observe(stream, { childList: true });
     const chip = document.getElementById('task-target-chip');
-    if (chip) new MutationObserver(ui2QueueFocusFilter).observe(chip, {
+    if (chip) new MutationObserver(ui2QueueFocusSurface).observe(chip, {
       childList: true, characterData: true, subtree: true, attributes: true,
     });
-    ui2ApplyFocusFilter();
+    const windowGrid = document.getElementById('session-window-grid');
+    if (windowGrid) new MutationObserver(ui2QueueFocusSurface).observe(windowGrid, { childList: true });
+    ui2ApplyFocusSurface();
     ui2TagRawEntries();
     // Approval hero session identity.
     const panel = document.getElementById('approval-panel');

--- a/static/app.html
+++ b/static/app.html
@@ -4497,13 +4497,27 @@ body.context-focus-active {
 /* Idle notice for the live log: absolute overlay so the stream's scroll
    geometry is untouched; pointer-events none so clicks reach the log and
    the approval/human panels are unaffected. Below .concurrent-log-label
-   (z-index 2), which must stay on top. */
+   (z-index 2), which must stay on top.
+
+   overflow:hidden is load-bearing: this notice is ~180px tall once the
+   unfueled copy adds a hint paragraph and an "Add a provider key" button,
+   and it is centered inside a region that can be far shorter than that
+   (minimized, or squeezed by a tall session grid). Uncontained, the
+   surplus escaped the region — which outranks the grid in the stacking
+   order (z-index 3 vs 1) — and painted the notice straight over the
+   session windows. `safe center` degrades to top-aligned instead of
+   clipping the title off both ends when the room runs out. */
 .log-empty-overlay {
   position: absolute;
   inset: 0;
   z-index: 1;
-  align-content: center;
+  align-content: safe center;
+  overflow: hidden;
   pointer-events: none;
+}
+/* A 30px strip has no room for an empty state at all. */
+.subtab-pane.concurrent-log-minimized .log-empty-overlay {
+  display: none;
 }
 .concurrent-log-label {
   position: absolute;
@@ -18605,16 +18619,37 @@ html.ui-v2 .session-window-grid {
   border-bottom: 1px solid var(--line);
   background: var(--bg);
 }
-/* Resized grid: v1 pins a fixed height with overflow:visible, and a
-   definite height COMPRESSES the auto rows — at 5-6 windows row 1's
-   cards painted over row 2 (measured: 320px cards in 298px tracks;
-   ledger finding #4). Under v2 the dragged size is a CAP the area
-   scrolls within, so tracks keep content size and rows never overlap.
-   Cost: a ⋯ menu taller than the remaining grid area scrolls instead of
-   escaping — the lesser evil vs overlapping cards. */
-html.ui-v2 .session-window-grid.resized {
-  height: auto;
-  max-height: var(--session-window-grid-height);
+/* Resized grid: the dragged size is a DEFINITE height, as v1 intends —
+   the grid claims exactly the share the user dragged, and the concurrent
+   view gets the rest.
+
+   grid-auto-rows is the load-bearing declaration. The row-overlap that
+   ledger finding #4 recorded (5-6 windows: row 1's cards painted over
+   row 2 — "320px cards in 298px tracks") is a TRACK-SIZING effect: `auto`
+   rows in a definite-height grid have that height distributed across
+   them, so two rows in a 620px grid size to ~292px each while the cards
+   — which are content-sized, since
+   `.session-window:not(.header-collapsed):not(.minimized)` clears the
+   320px cap — stay ~320px and spill out of their track onto the next row.
+   Pinning the rows to max-content takes the container height out of track
+   sizing entirely: every row is exactly as tall as its cards, the surplus
+   becomes scrollable overflow, and rows can never collide.
+   (align-content does NOT help here — it distributes leftover space after
+   tracks are sized, so it never sees the compression. Measured.)
+
+   The earlier fix — height:auto + the dragged size as a max-height cap —
+   did dodge the overlap, but only by making the height indefinite, which
+   silently removed drag-to-grow: an auto-height grid can never exceed its
+   content, so dragging the handle down just moved a cap nothing was
+   pressing against, and in fit mode (where the cap IS the content height)
+   the drag was a pure no-op. It also outranked v1's `.maximized` and
+   `.concurrent-log-minimized` geometry, so neither state could resize the
+   grid — hence the :not() scoping here. */
+html.ui-v2 .subtab-pane:not(.concurrent-log-minimized) .session-window-grid.resized:not(.maximized) {
+  height: var(--session-window-grid-height);
+  max-height: none;
+  grid-auto-rows: max-content;
+  align-content: start;
   overflow-y: auto;
   overflow-x: hidden;
 }
@@ -25676,7 +25711,13 @@ function ui2ApplyLayout(mode) {
   if (fBtn) fBtn.setAttribute('aria-pressed', String(!grid));
   if (gBtn) gBtn.setAttribute('aria-pressed', String(grid));
   if (typeof syncConcurrentLogStreamMount === 'function') syncConcurrentLogStreamMount();
-  if (grid && typeof fitSessionWindowGridHeight === 'function') fitSessionWindowGridHeight();
+  // applySessionWindowGridHeight is the APPLIER (sets --session-window-grid-height,
+  // the .resized class, and — via syncSessionWindowGridControls — unhides the drag
+  // handle and stamps the pane's concurrent-log mode classes).
+  // fitSessionWindowGridHeight, which used to be called here, is a pure getter: it
+  // returns a number and touches nothing, so entering Grid left the grid unsized and
+  // its controls unsynced until some unrelated path happened to apply them.
+  if (grid && typeof applySessionWindowGridHeight === 'function') applySessionWindowGridHeight();
   if (typeof ui2ApplyFocusFilter === 'function') ui2ApplyFocusFilter();
 }
 

--- a/static/app/12-styles-tasks-log.css
+++ b/static/app/12-styles-tasks-log.css
@@ -773,13 +773,27 @@ body.context-focus-active {
 /* Idle notice for the live log: absolute overlay so the stream's scroll
    geometry is untouched; pointer-events none so clicks reach the log and
    the approval/human panels are unaffected. Below .concurrent-log-label
-   (z-index 2), which must stay on top. */
+   (z-index 2), which must stay on top.
+
+   overflow:hidden is load-bearing: this notice is ~180px tall once the
+   unfueled copy adds a hint paragraph and an "Add a provider key" button,
+   and it is centered inside a region that can be far shorter than that
+   (minimized, or squeezed by a tall session grid). Uncontained, the
+   surplus escaped the region — which outranks the grid in the stacking
+   order (z-index 3 vs 1) — and painted the notice straight over the
+   session windows. `safe center` degrades to top-aligned instead of
+   clipping the title off both ends when the room runs out. */
 .log-empty-overlay {
   position: absolute;
   inset: 0;
   z-index: 1;
-  align-content: center;
+  align-content: safe center;
+  overflow: hidden;
   pointer-events: none;
+}
+/* A 30px strip has no room for an empty state at all. */
+.subtab-pane.concurrent-log-minimized .log-empty-overlay {
+  display: none;
 }
 .concurrent-log-label {
   position: absolute;

--- a/static/app/ui2-activity.css
+++ b/static/app/ui2-activity.css
@@ -262,18 +262,32 @@ html.ui-v2 #approval-panel .ui2-approve-category:hover { background: rgba(var(--
 /* the relabeled autonomy escape reads as the power action it is */
 html.ui-v2 #approval-panel .ui2-full-escape { font-size: 12px; color: var(--text-3); }
 
-/* — Focus layout (default): one centered timeline ──────────────────────
-   The session-window grid, its resize handle, and the "Concurrent view"
-   label disappear; the combined stream is the surface. JS keeps the
-   stream mounted (shouldDetachConcurrentLogStream returns false under
-   Focus) — these rules are the visual half of that contract. Grid mode
-   (html[data-ui2-layout="grid"]) leaves v1's machinery fully in charge. */
-html.ui-v2:not([data-ui2-layout="grid"]) #session-window-grid,
+/* — Focus layout (default): the FOREGROUND session's timeline ──────────
+   Two surfaces, selected by data-ui2-focus (stamped by ui2ApplyFocusSurface):
+
+     [data-ui2-focus="session"] — a session is targeted. Its session window
+       is promoted out of the grid and becomes the timeline. The window is
+       the ONLY place a resumed / external session's transcript exists —
+       hydration renders it there and never into the combined stream — so
+       promoting it is what makes Focus work at all after a resume, and it
+       reuses the window's live, deduped, virtualized renderer instead of
+       standing up a second copy of one.
+
+     [data-ui2-focus="all"] — nothing targeted. The combined stream is the
+       surface, as before; it also carries the idle / unfueled empty state,
+       which therefore now appears only when there is genuinely nothing to
+       read.
+
+   Grid mode (html[data-ui2-layout="grid"]) leaves v1's machinery fully in
+   charge in both cases. */
 html.ui-v2:not([data-ui2-layout="grid"]) #session-window-grid-resize-handle,
 html.ui-v2:not([data-ui2-layout="grid"]) #concurrent-log-label { display: none; }
-/* Focus must also neutralize the v1 minimized/maximized pane states —
-   they collapse or hide the very stream Focus promotes (the CSS half of
-   the shouldDetachConcurrentLogStream guard). */
+
+/* — all-sessions surface: the combined stream — */
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="all"] #session-window-grid { display: none; }
+/* Neutralize the v1 minimized/maximized pane states — they collapse or
+   hide the very stream this surface promotes (the CSS half of the
+   shouldDetachConcurrentLogStream guard). */
 html.ui-v2:not([data-ui2-layout="grid"]) .subtab-pane.concurrent-log-minimized .log-stream { display: block; }
 html.ui-v2:not([data-ui2-layout="grid"]) .subtab-pane.concurrent-log-minimized .concurrent-log-region,
 html.ui-v2:not([data-ui2-layout="grid"]) .subtab-pane.concurrent-log-maximized .concurrent-log-region {
@@ -281,10 +295,62 @@ html.ui-v2:not([data-ui2-layout="grid"]) .subtab-pane.concurrent-log-maximized .
   min-height: 0;
   border-top: 0;
 }
-/* v1 hides these with !important while the grid is maximized; the grid
-   itself is gone under Focus, so counter at the same weight. */
-html.ui-v2:not([data-ui2-layout="grid"]) .session-window-grid.maximized ~ .concurrent-log-region { display: flex !important; }
-html.ui-v2:not([data-ui2-layout="grid"]) .session-window-grid.maximized ~ .scroll-bottom-btn.visible { display: flex !important; }
+/* v1 hides these with !important while the grid is maximized; on this
+   surface the grid is gone, so counter at the same weight. */
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="all"] .session-window-grid.maximized ~ .concurrent-log-region { display: flex !important; }
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="all"] .session-window-grid.maximized ~ .scroll-bottom-btn.visible { display: flex !important; }
+
+/* — session surface: promote that window into the timeline column — */
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="session"] .concurrent-log-region,
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="session"] #scroll-bottom { display: none; }
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="session"] #session-window-grid {
+  display: flex;
+  flex: 1 1 auto;
+  height: auto;
+  min-height: 0;
+  max-height: none;
+  padding: 0;
+  border-bottom: 0;
+  background: transparent;
+  overflow: hidden;
+}
+/* Only the promoted window renders — this outranks v1's .maximized rules,
+   which would otherwise pick a different window. */
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="session"] #session-window-grid .session-window { display: none; }
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="session"] #session-window-grid .session-window.ui2-focus-window {
+  display: flex;
+  flex: 1 1 auto;
+  align-self: stretch;
+  width: 100%;
+  min-height: 0;
+  max-height: none;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  cursor: default;
+}
+/* The window's log becomes the design's centered timeline column — the same
+   880px measure and padding #log-stream uses on the all-sessions surface.
+   The .log-entry grammar at the top of this file already styles both. */
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="session"] .session-window.ui2-focus-window .session-window-log {
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: none;
+  width: 100%;
+  max-width: 880px;
+  margin-inline: auto;
+  padding: 18px 24px 24px;
+}
+/* The card header keeps carrying session identity, phase, and the window
+   controls; it reads as the timeline's header bar, not as a card's. */
+html.ui-v2:not([data-ui2-layout="grid"])[data-ui2-focus="session"] .session-window.ui2-focus-window .session-window-header {
+  width: 100%;
+  max-width: 880px;
+  margin-inline: auto;
+  background: transparent;
+  border-bottom: 1px solid var(--line);
+}
 
 /* turn separators read as quiet time breaks */
 html.ui-v2 .log-turn-sep {
@@ -387,7 +453,6 @@ html.ui-v2 .ui2-rail-advanced:hover { background: var(--surface-2); color: var(-
 
 /* — Focus filter + raw-entry hygiene + hero identity (corrective batch,
      2026-07-08 product-owner review) — */
-html.ui-v2 .log-entry.hidden-by-focus { display: none; }
 html.ui-v2 .log-entry.ui2-stderr .log-content {
   font-family: var(--mono);
   font-size: 10.5px;

--- a/static/app/ui2-activity.js
+++ b/static/app/ui2-activity.js
@@ -86,7 +86,13 @@ function ui2ApplyLayout(mode) {
   if (fBtn) fBtn.setAttribute('aria-pressed', String(!grid));
   if (gBtn) gBtn.setAttribute('aria-pressed', String(grid));
   if (typeof syncConcurrentLogStreamMount === 'function') syncConcurrentLogStreamMount();
-  if (grid && typeof fitSessionWindowGridHeight === 'function') fitSessionWindowGridHeight();
+  // applySessionWindowGridHeight is the APPLIER (sets --session-window-grid-height,
+  // the .resized class, and — via syncSessionWindowGridControls — unhides the drag
+  // handle and stamps the pane's concurrent-log mode classes).
+  // fitSessionWindowGridHeight, which used to be called here, is a pure getter: it
+  // returns a number and touches nothing, so entering Grid left the grid unsized and
+  // its controls unsynced until some unrelated path happened to apply them.
+  if (grid && typeof applySessionWindowGridHeight === 'function') applySessionWindowGridHeight();
   if (typeof ui2ApplyFocusFilter === 'function') ui2ApplyFocusFilter();
 }
 

--- a/static/app/ui2-activity.js
+++ b/static/app/ui2-activity.js
@@ -93,7 +93,7 @@ function ui2ApplyLayout(mode) {
   // returns a number and touches nothing, so entering Grid left the grid unsized and
   // its controls unsynced until some unrelated path happened to apply them.
   if (grid && typeof applySessionWindowGridHeight === 'function') applySessionWindowGridHeight();
-  if (typeof ui2ApplyFocusFilter === 'function') ui2ApplyFocusFilter();
+  if (typeof ui2ApplyFocusSurface === 'function') ui2ApplyFocusSurface();
 }
 
 function ui2WireLayoutToggle() {
@@ -115,31 +115,107 @@ function ui2DressComposer() {
   if (attach && typeof ui2Icon === 'function') attach.innerHTML = ui2Icon('attach', 15);
 }
 
-// ── Focus filter: Focus shows the FOREGROUND session's timeline ────────
-// The original product decision: "Focus timeline + session switcher".
-// Entries from other sessions hide; daemon-level entries (no session id)
-// always show. No target selected ("all sessions") = the combined
-// stream. Grid mode never filters — the concurrent view is combined by
-// definition.
-function ui2ApplyFocusFilter() {
-  const stream = document.getElementById('log-stream');
-  if (!stream) return;
-  const focusMode = document.documentElement.dataset.ui2Layout !== 'grid';
-  const sid = (focusMode && typeof resolvePromptTargetSessionId === 'function'
-    && resolvePromptTargetSessionId()) || '';
-  stream.querySelectorAll('.log-entry').forEach((e) => {
-    const esid = e.dataset.sessionId || '';
-    e.classList.toggle('hidden-by-focus', !!sid && !!esid && esid !== sid);
-  });
+// ── Focus surface: Focus shows the FOREGROUND session's transcript ─────
+// The product decision: "Focus timeline + session switcher".
+//
+// Focus used to implement that as a FILTER over #log-stream — the combined
+// ("Concurrent view") stream — hiding entries belonging to other sessions.
+// But that stream only ever carries entries the live event feed delivered.
+// A resumed session's transcript is fetched and rendered straight into its
+// session window (hydrateRestoredSessionWindow → renderRestoredSessionWindow-
+// Entries, which touches the main stream nowhere), so it never enters the
+// stream at all — and Focus rendered a blank page for precisely the sessions
+// the user had just reopened, while Grid showed them fine.
+//
+// The session window already IS the per-session timeline: hydrated (external
+// and restored sessions included), signature-deduped, virtualized, paginated,
+// and live. So Focus PROMOTES that window rather than rendering a second copy
+// of it — one renderer, one DOM, and a resumed session appears in Focus
+// because it is the very node Grid draws.
+//
+// With no session targeted, Focus falls back to the combined stream (the
+// "all sessions" reading) — which is also where the idle / unfueled empty
+// state lives, so that notice now shows only when there is genuinely
+// nothing to read.
+function ui2FocusSessionId() {
+  // The canonical target first — the same resolver the composer and the
+  // session switcher use.
+  if (typeof resolvePromptTargetSessionId === 'function') {
+    const sid = resolvePromptTargetSessionId();
+    if (sid) return sid;
+  }
+  const windows = typeof sessionWindows !== 'undefined' ? sessionWindows : null;
+  if (!windows || windows.size === 0) return '';
+  // That resolver gates every candidate on STEERABILITY (isPromptTargetSession-
+  // Usable: may I send this session a message?). Focus asks the weaker
+  // question — what am I READING? — and a session that has ended, or is still
+  // spinning up, is perfectly readable while not being steerable. So fall back
+  // past that gate: the window the user explicitly opened, and then an
+  // unambiguous single window (the same "one candidate" rule the resolver
+  // applies, minus the steerability filter). Without this, resuming a single
+  // session left Focus on the all-sessions surface — i.e. blank, since a
+  // resumed transcript never enters the combined stream.
+  if (typeof foregroundSessionFullId !== 'undefined'
+      && foregroundSessionFullId && windows.has(foregroundSessionFullId)) {
+    return foregroundSessionFullId;
+  }
+  if (windows.size === 1) return windows.keys().next().value;
+  return '';
 }
 
-let ui2FocusFilterQueued = false;
-function ui2QueueFocusFilter() {
-  if (ui2FocusFilterQueued) return;
-  ui2FocusFilterQueued = true;
+function ui2ApplyFocusSurface() {
+  const root = document.documentElement;
+  const focusMode = root.dataset.ui2Layout !== 'grid';
+  const sid = focusMode ? ui2FocusSessionId() : '';
+  const windows = typeof sessionWindows !== 'undefined' ? sessionWindows : null;
+  const win = (sid && windows) ? windows.get(sid) : null;
+  if (windows) {
+    for (const [id, w] of windows) {
+      w?.el?.classList.toggle('ui2-focus-window', !!win && id === sid);
+    }
+  }
+  // CSS is the single reader: "session" promotes the marked window and
+  // retires the combined stream; "all" is the pre-existing combined view.
+  root.dataset.ui2Focus = win ? 'session' : 'all';
+  // A session promoted straight into Focus may never have been opened in
+  // Grid, so its window can still be empty. Hydration is idempotent (it
+  // no-ops on non-empty history and on an in-flight fetch), which makes
+  // Focus on its own enough to reopen a session.
+  if (win && typeof hydrateSessionWindowIfEmpty === 'function') {
+    Promise.resolve(hydrateSessionWindowIfEmpty(sid)).catch(() => {});
+  }
+}
+
+// QA readback (window.qa convention): the Focus surface's inputs and its
+// verdict. The interesting regression is silent — Focus renders an empty
+// page — so the probe exposes what it resolved and what it promoted.
+window.qa = Object.assign(window.qa || {}, {
+  focusSurface: () => ({
+    layout: document.documentElement.dataset.ui2Layout || 'focus',
+    surface: document.documentElement.dataset.ui2Focus || '',
+    sessionId: ui2FocusSessionId(),
+    promptTarget: typeof resolvePromptTargetSessionId === 'function'
+      ? (resolvePromptTargetSessionId() || '') : '',
+    foreground: typeof foregroundSessionFullId !== 'undefined' ? (foregroundSessionFullId || '') : '',
+    railSessionId: ui2RailForegroundSessionId(),
+    railTicks: ui2RailTickCount,
+    windows: typeof sessionWindows !== 'undefined' ? [...sessionWindows.keys()] : [],
+    promotedEntries: (() => {
+      const log = document.querySelector(
+        '#session-window-grid .session-window.ui2-focus-window .session-window-log'
+      );
+      return log ? log.querySelectorAll('.log-entry').length : 0;
+    })(),
+  }),
+});
+
+let ui2FocusSurfaceQueued = false;
+function ui2QueueFocusSurface() {
+  if (ui2FocusSurfaceQueued) return;
+  ui2FocusSurfaceQueued = true;
   requestAnimationFrame(() => {
-    ui2FocusFilterQueued = false;
-    ui2ApplyFocusFilter();
+    ui2FocusSurfaceQueued = false;
+    ui2ApplyFocusSurface();
     ui2TagRawEntries();
   });
 }
@@ -223,20 +299,27 @@ function ui2BuildVitalsRail() {
   });
 }
 
-// The rail describes the FOREGROUND session — prompt target, then the
-// current session, then the daemon's own. Same fallback chain the v1
-// composer targeting uses.
+// The rail describes the session Focus is SHOWING, so it derives from the
+// same selector the Focus surface promotes with (and the session switcher
+// displays) — one source, three readers. It previously stopped at
+// resolvePromptTargetSessionId, whose steerability gate rejects an ended or
+// still-starting session, and so read "No session yet" while a perfectly
+// live session was on screen beside it. The daemon's own session stays the
+// last resort.
 function ui2RailForegroundSessionId() {
-  if (typeof resolvePromptTargetSessionId === 'function') {
-    const sid = resolvePromptTargetSessionId();
-    if (sid) return sid;
-  }
-  if (typeof currentSessionFullId !== 'undefined' && currentSessionFullId) return currentSessionFullId;
+  const sid = ui2FocusSessionId();
+  if (sid) return sid;
   if (typeof daemonSessionFullId !== 'undefined' && daemonSessionFullId) return daemonSessionFullId;
   return '';
 }
 
+// The rail repaints on a 1s interval, so any probe of it races that interval —
+// reading it right after load shows the boot tick's values and looks exactly
+// like a broken selector. The counter lets a probe wait deterministically
+// (window.qa.focusSurface().railTicks) instead of sleeping and guessing.
+let ui2RailTickCount = 0;
 function ui2RailTick(force) {
+  ui2RailTickCount++;
   const rail = document.getElementById('ui2-vitals-rail');
   if (!rail) return;
   // hidden: other tab/subtab, grid layout, or <1180px — skip the interval
@@ -301,15 +384,20 @@ function ui2RailTick(force) {
     ui2BuildVitalsRail();
     ui2RailTick(true);
     setInterval(() => ui2RailTick(), 1000);
-    // Focus filter + raw-entry hygiene: follow stream appends, target
-    // changes (the chip re-renders on every change), and layout flips.
+    // Focus surface + raw-entry hygiene: follow stream appends, target
+    // changes (the chip re-renders on every change), layout flips, and the
+    // session-window grid's own membership — a session resumed from the
+    // Sessions tab materializes its window there, and that is the only
+    // signal Focus gets that the window it must promote now exists.
     const stream = document.getElementById('log-stream');
-    if (stream) new MutationObserver(ui2QueueFocusFilter).observe(stream, { childList: true });
+    if (stream) new MutationObserver(ui2QueueFocusSurface).observe(stream, { childList: true });
     const chip = document.getElementById('task-target-chip');
-    if (chip) new MutationObserver(ui2QueueFocusFilter).observe(chip, {
+    if (chip) new MutationObserver(ui2QueueFocusSurface).observe(chip, {
       childList: true, characterData: true, subtree: true, attributes: true,
     });
-    ui2ApplyFocusFilter();
+    const windowGrid = document.getElementById('session-window-grid');
+    if (windowGrid) new MutationObserver(ui2QueueFocusSurface).observe(windowGrid, { childList: true });
+    ui2ApplyFocusSurface();
     ui2TagRawEntries();
     // Approval hero session identity.
     const panel = document.getElementById('approval-panel');

--- a/static/app/ui2-chrome.js
+++ b/static/app/ui2-chrome.js
@@ -222,8 +222,13 @@ function ui2WireMirrors() {
   const switcher = document.getElementById('ui2-session-switcher');
   const rebuildSwitcher = () => {
     if (!switcher || typeof sessionWindows === 'undefined') return;
-    const target = typeof resolvePromptTargetSessionId === 'function'
-      ? (resolvePromptTargetSessionId() || '') : '';
+    // Must be the SAME selector Focus promotes with (ui2ApplyFocusSurface),
+    // or the switcher reads "all sessions" while Focus is showing exactly one
+    // session's transcript.
+    const target = typeof ui2FocusSessionId === 'function'
+      ? (ui2FocusSessionId() || '')
+      : (typeof resolvePromptTargetSessionId === 'function'
+        ? (resolvePromptTargetSessionId() || '') : '');
     const options = [['', 'all sessions']];
     for (const [sid] of sessionWindows) {
       let label = sid.slice(0, 8);
@@ -255,7 +260,7 @@ function ui2WireMirrors() {
         if (current) discardPromptTargetReference(current);
         if (typeof updatePromptTargetSessionHighlight === 'function') updatePromptTargetSessionHighlight();
       }
-      if (typeof ui2ApplyFocusFilter === 'function') ui2ApplyFocusFilter();
+      if (typeof ui2ApplyFocusSurface === 'function') ui2ApplyFocusSurface();
     });
     ui2Mirror('task-target-chip', rebuildSwitcher);
     const grid = document.getElementById('session-window-grid');

--- a/static/app/ui2-grid.css
+++ b/static/app/ui2-grid.css
@@ -16,16 +16,37 @@ html.ui-v2 .session-window-grid {
   border-bottom: 1px solid var(--line);
   background: var(--bg);
 }
-/* Resized grid: v1 pins a fixed height with overflow:visible, and a
-   definite height COMPRESSES the auto rows — at 5-6 windows row 1's
-   cards painted over row 2 (measured: 320px cards in 298px tracks;
-   ledger finding #4). Under v2 the dragged size is a CAP the area
-   scrolls within, so tracks keep content size and rows never overlap.
-   Cost: a ⋯ menu taller than the remaining grid area scrolls instead of
-   escaping — the lesser evil vs overlapping cards. */
-html.ui-v2 .session-window-grid.resized {
-  height: auto;
-  max-height: var(--session-window-grid-height);
+/* Resized grid: the dragged size is a DEFINITE height, as v1 intends —
+   the grid claims exactly the share the user dragged, and the concurrent
+   view gets the rest.
+
+   grid-auto-rows is the load-bearing declaration. The row-overlap that
+   ledger finding #4 recorded (5-6 windows: row 1's cards painted over
+   row 2 — "320px cards in 298px tracks") is a TRACK-SIZING effect: `auto`
+   rows in a definite-height grid have that height distributed across
+   them, so two rows in a 620px grid size to ~292px each while the cards
+   — which are content-sized, since
+   `.session-window:not(.header-collapsed):not(.minimized)` clears the
+   320px cap — stay ~320px and spill out of their track onto the next row.
+   Pinning the rows to max-content takes the container height out of track
+   sizing entirely: every row is exactly as tall as its cards, the surplus
+   becomes scrollable overflow, and rows can never collide.
+   (align-content does NOT help here — it distributes leftover space after
+   tracks are sized, so it never sees the compression. Measured.)
+
+   The earlier fix — height:auto + the dragged size as a max-height cap —
+   did dodge the overlap, but only by making the height indefinite, which
+   silently removed drag-to-grow: an auto-height grid can never exceed its
+   content, so dragging the handle down just moved a cap nothing was
+   pressing against, and in fit mode (where the cap IS the content height)
+   the drag was a pure no-op. It also outranked v1's `.maximized` and
+   `.concurrent-log-minimized` geometry, so neither state could resize the
+   grid — hence the :not() scoping here. */
+html.ui-v2 .subtab-pane:not(.concurrent-log-minimized) .session-window-grid.resized:not(.maximized) {
+  height: var(--session-window-grid-height);
+  max-height: none;
+  grid-auto-rows: max-content;
+  align-content: start;
   overflow-y: auto;
   overflow-x: hidden;
 }


### PR DESCRIPTION
Reported: resuming a session leaves **Focus completely empty** (only Grid shows the window); the grid is swamped by the concurrent view and **can't be drag-resized** without first clicking "restore previous concurrent view size"; a session window **doesn't truly maximize**; **concurrent-view minimize does nothing**; and the "no fuel yet" notice **overlaps** the session windows.

All six trace to two seams where the ui-v2 Activity layer was put over v1's session-window machinery without reconciling it.

## Seam 1 — the `.resized` rule hijacked v1's state geometry

`html.ui-v2 .session-window-grid.resized` (0,3,1) outranks v1's `.maximized` (0,2,0) and `.concurrent-log-minimized .session-window-grid` (0,3,0), so it overrode **both** states: a "maximized" window stayed capped at the dragged grid height, and minimizing the concurrent view could not expand the grid. Scoped it to the normal state with `:not()` so those rules govern their own states again.

The same rule had also redefined the dragged size from a **definite height** into a **max-height cap on an auto-height box**. An auto-height grid can never exceed its content, so dragging only moved a cap nothing was pressing against — and in fit mode, where the cap *is* the content height, the drag was a pure no-op. That is also why the concurrent view kept all the space, and why clicking the fit button (which leaves fit mode) appeared to "unlock" dragging.

Restored the definite height, and killed the row-overlap the cap was working around **at its actual root** — see the verification note below.

Also: `ui2ApplyLayout` called `fitSessionWindowGridHeight()`, a **pure getter** that computes a height and touches nothing. The applier is `applySessionWindowGridHeight()` (it sets `--session-window-grid-height` + `.resized`, and via `syncSessionWindowGridControls()` unhides the drag handle and stamps the pane's concurrent-log mode classes). Entering Grid therefore left the grid unsized and its controls unsynced.

Finally, the idle/unfueled notice is an `inset:0` overlay inside the concurrent region, which outranks the grid in the stacking order (z-index 3 vs 1). It is ~180px tall once the unfueled copy adds a hint and an "Add a provider key" button, and it was uncontained — in a shorter region the surplus escaped and painted over the session windows. Clipped it, degraded centering to `safe center`, and hid it outright in the 30px minimized strip.

## Seam 2 — Focus read a stream that structurally cannot contain a resumed session

Focus was a **filter over `#log-stream`** — the combined "Concurrent view" stream — hiding other sessions' entries. That stream only ever carries what the live event feed delivered. A resumed session's transcript is fetched and rendered straight into its **session window** (`hydrateRestoredSessionWindow` → `renderRestoredSessionWindowEntries`, which touches the main stream nowhere), so it never enters the stream at all. Focus rendered a blank page for exactly the sessions the user had just reopened, while Grid showed them fine. The same gap held `logEntryCount` at zero, which is why the unfueled empty state stayed up over the top of it.

The session window already **is** the per-session timeline — hydrated (external and restored sessions included), signature-deduped, virtualized, paginated, and live. So Focus now **promotes that window** instead of rendering a second copy of it: one renderer, one DOM, and a resumed session appears in Focus because it is the very node Grid draws. A new `data-ui2-focus` on `<html>` picks the surface — `session` promotes the marked window and retires the combined stream (and with it the empty state, which now shows only when there is genuinely nothing to read); `all` is the previous combined view, still the reading when no session is targeted.

**Selecting the session needed care.** `resolvePromptTargetSessionId()` gates every candidate on **steerability** (*may I send this session a message?*). Focus must not inherit that gate — it asks the weaker question, *what am I reading?*, and a session that has ended or is still spinning up is perfectly readable while not being steerable. Resuming a single session therefore left the prompt target empty and Focus on the all-sessions surface, i.e. blank. `ui2FocusSessionId()` falls back past that gate, and is now the one selector the Focus surface, the vitals rail, and the session switcher all derive from — which also fixes the rail reading "No session yet" beside the live session it was supposed to be describing.

## Verification

Driven against a real dashboard over CDP (mock provider, real session), not just reasoned about:

| | before | after |
|---|---|---|
| dragged height | `height: 25px`, `max-height: 200px` (collapsed to content) | `height: 220px` — definite, honored |
| maximized | `max-height: 200px` — capped | `680px`, `max-height: none` — fills pane |
| concurrent minimized | `max-height: 200px` — could not expand | `640px` — grid expands |
| unfueled overlay | `overflow: visible` — bled over the grid | contained; `display: none` when minimized |
| Focus after resume | blank | renders the transcript |

The resume case is exercised directly: with the combined stream emptied — precisely the state a resumed session leaves behind — Focus still renders the session's transcript, where it previously rendered nothing.

**Two things I believed that the browser disproved**, worth knowing since both nearly shipped:

1. My first overlap fix used `align-content: start`. Measured: it does **nothing** here. Track *sizing* compresses before alignment ever runs — a definite-height grid distributes that height across its `auto` rows (`grid-template-rows: 291.5px 291.5px` while the content-sized cards stay ~320px, since `.session-window:not(.header-collapsed):not(.minimized)` clears the 320px cap). That is exactly the ledger's "320px cards in 298px tracks". The real fix is `grid-auto-rows: max-content`, which takes the container height out of track sizing entirely. Six cramped cards now produce **0 overlapping pairs** with the surplus scrolling (previously 3 column-aligned pairs overlapping by ~298px).
2. The vitals rail looked broken; it was my probe racing its 1s repaint interval. Added a `window.qa.focusSurface()` readback (incl. `railTicks`) so a probe can wait deterministically instead of sleeping and guessing.

`cargo test --bins` — 3078 + 54 + 81 pass, 0 failed. `cargo clippy` clean. No Rust changed; `static/app.html` is the build.rs-regenerated artifact, committed alongside its fragments for the app-html gate.

## Known, pre-existing, NOT fixed here

The **ui-v2 session switcher never populates** — 0 options, its rebuild never completes (`dataset.sig` never set). Reproduced **identically on unmodified main** with a live session window present, so it is not from this change. Focus's selector alignment above is in place for when it is fixed; worth its own PR.