### PR TITLE
Dashboard: reconcile Computer Use live workspace design

### DIFF
--- a/docs/src/computer-use-and-audio.md
+++ b/docs/src/computer-use-and-audio.md
@@ -207,6 +207,44 @@ user-session target only for a granted or owner caller instead of flipping
 the grant themselves. Sharing an agent-owned virtual display never touches
 the user-display grant.
 
+### Dashboard Live workspace
+
+The dashboard's **Live** tab presents local Computer Use as one selected
+display stage. Every active `DisplaySlot` and its WebRTC connection remain
+alive, but only the selected slot is visible; the rail switches that
+projection without recreating the capture or video element. Agent-requested
+shared views select their target when the current stage has no active human
+work. They remain advisory when the user is controlling, awaiting input,
+annotating, calling out, or viewing full-screen; the banner and rail keep the
+requested target discoverable without discarding that work. Peer-display
+launchers are different: they route to the peer-aware **Station** surface
+before opening the stream rather than pretending a federated pane is local.
+
+Input authority in the stage and rail is always the browser-relative server
+state: **you**, **another viewer**, **available** (unclaimed), or connecting.
+Take is last-take-wins; no holder identity or approval ceremony is inferred.
+Only one hidden-input hazard is handled locally: selecting another display or
+leaving Live releases an actively bound slot after flushing held keys, then
+removes its keyboard, pointer, and document-level paste listeners. Annotation
+and armed-callout state is editable work, so display and tab navigation is
+blocked with a visible explanation until the user finishes or closes it.
+Pending Take requests and already-held-but-locally-unbound authority are also
+cancelled before a surface can be hidden. Activity's shared-view **Take input**
+returns to the full Live stage before requesting authority; thumbnails remain
+view-only.
+
+The rail's per-display activity is deliberately a browser-observed lifecycle
+feed (stream connection, authority, private/share mode, presence streaming,
+recording, annotation, and shared-view focus). It is not an agent action trace:
+the current wire protocol has no display-keyed click/type event, and typed text
+must never be reconstructed from general logs. Recording transitions enter the
+feed only after the daemon confirms them; Start, Stop, and Delete remain pending
+and retain the last confirmed state on transport error or timeout. At narrow
+widths the same rail becomes a keyboard-accessible modal drawer; the stage
+toolbar remains the fallback for primary controls. In-page full screen similarly
+contains focus, hides its background from assistive technology, supports Escape,
+and restores the invoking control.
+
 ### CU-First Routing
 
 > **Status note (vaulted 2026-07-04):** the all-tasks CU-first interception —

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -336,17 +336,37 @@ An embedded xterm.js terminal hosting an interactive **Shell** session on the
 daemon (or a selected peer). Session monitoring and control live in the
 Activity/Station tabs, not here.
 
-### Video
+### Live display
 
-WebRTC display viewers for the agent's graphical displays, with interactive
-control (see [Display Pipeline](./display-pipeline.md)):
+The Computer Use workspace combines a selected WebRTC stage with a live rail
+for displays, input authority, browser-observed display activity, peer
+launchers, and the user's own screen (see
+[Display Pipeline](./display-pipeline.md)):
 
 - **View mode** (default) — watch the agent's display in real time
 - **Take Control** — forward mouse and keyboard events to the agent's display
 - **Release** — relinquish control, with an optional note
-- **Display picker** — choose which monitor to view when several are present
+- **Selected display stage** — switch among active local displays without
+  recreating their capture sessions or video elements. A shared-view request
+  selects its target once unless that would interrupt active human input,
+  annotation, callout, or full-screen work; later manual selection is
+  respected.
+- **Input authority** — the toolbar and rail project the same server truth:
+  you, another viewer, available, or connecting. Hiding an interactive or
+  pending display releases it before input listeners are removed. Editable
+  annotation/callout work blocks navigation instead of being discarded.
+- **Display activity** — reports real connection, authority, visibility,
+  streaming, recording, annotation, callout, and shared-view transitions. It
+  does not invent agent click/type history that the display protocol does not
+  publish.
+- **Peer displays** — open on Station, whose viewer understands federated
+  display targets, rather than masquerading as local stages.
+- **Responsive controls** — below the desktop breakpoint the rail becomes a
+  keyboard-accessible **Displays & input** drawer; primary controls remain in
+  the stage toolbar.
 - **Recording replay** — browse and play back recorded sessions with timeline
-  seeking and speed control (1x / 2x / 4x)
+  seeking and speed control (1x / 2x / 4x). Live recording controls show a
+  pending command but change REC/activity state only on daemon confirmation.
 
 The live rail's **Your screen** card keeps the three screen-on-the-wire
 concepts separate (see

--- a/scripts/validate-dashboard.cjs
+++ b/scripts/validate-dashboard.cjs
@@ -64,6 +64,7 @@ const STATIC_IDENTITY_ASSETS = [
   { urlPath: '/icon-128.png', file: path.join('static', 'icon-128.png'), kind: 'binary' },
 ];
 const APP_HTML_CACHEBUSTED_ASSET_PATHS = [
+  '/xterm.css',
   '/wasm-web/presence_web.js',
   '/wasm-web/presence_web_bg.wasm',
   '/wasm-station/station_web.js',
@@ -72,6 +73,10 @@ const APP_HTML_CACHEBUSTED_ASSET_PATHS = [
   '/codemirror-bundle.js',
   '/codemirror-bundle.css',
   '/icon-128.png',
+  '/fonts/hanken-grotesk-latin.woff2',
+  '/fonts/hanken-grotesk-latin-ext.woff2',
+  '/fonts/jetbrains-mono-latin.woff2',
+  '/fonts/jetbrains-mono-latin-ext.woff2',
 ];
 
 const BROWSER_EXECUTABLE_ENVS = [

--- a/src/bin/caller/display_glue.rs
+++ b/src/bin/caller/display_glue.rs
@@ -1598,7 +1598,12 @@ pub(crate) async fn handle_shared_view_calls(
                 }
             }
             "input" => {
-                bus.send(emit("input", None));
+                // `input` is the tool-call vocabulary; the browser event
+                // vocabulary is `input_request` (shared with the MCP path).
+                // Keeping that boundary canonical makes the dashboard show
+                // its user-clicked Take input affordance without granting
+                // authority automatically.
+                bus.send(emit("input_request", None));
                 format!(
                     "Input authority requested for {label}. The user must accept from the \
                      dashboard control — continue only after they take over or respond."
@@ -2067,6 +2072,7 @@ mod tests {
                 serde_json::json!({"action": "show", "display_target": "user_session"}),
             ),
             ("c4".to_string(), serde_json::json!({"action": "bogus"})),
+            ("c5".to_string(), serde_json::json!({"action": "input"})),
         ];
         handle_shared_view_calls(
             &calls,
@@ -2086,7 +2092,7 @@ mod tests {
             .iter()
             .filter(|m| m.role == "tool")
             .collect();
-        assert_eq!(results.len(), 4, "one result per call");
+        assert_eq!(results.len(), 5, "one result per call");
         assert!(
             results[0].content.contains("dismissed"),
             "{}",
@@ -2107,9 +2113,14 @@ mod tests {
             "{}",
             results[3].content
         );
+        assert!(
+            results[4].content.contains("Input authority requested"),
+            "{}",
+            results[4].content
+        );
 
-        // Only the valid hide emitted a SharedView event; the gated and
-        // invalid calls must not reach the dashboard.
+        // The valid hide and advisory input request emit SharedView events;
+        // gated and invalid calls must not reach the dashboard.
         match rx.try_recv() {
             Ok(AppEvent::SharedView {
                 action, session_id, ..
@@ -2118,6 +2129,15 @@ mod tests {
                 assert_eq!(session_id.as_deref(), Some("sess-1"));
             }
             other => panic!("expected SharedView hide event, got {other:?}"),
+        }
+        match rx.try_recv() {
+            Ok(AppEvent::SharedView {
+                action, session_id, ..
+            }) => {
+                assert_eq!(action, "input_request");
+                assert_eq!(session_id.as_deref(), Some("sess-1"));
+            }
+            other => panic!("expected SharedView input_request event, got {other:?}"),
         }
         assert!(rx.try_recv().is_err(), "no further events expected");
     }

--- a/src/bin/caller/display_glue.rs
+++ b/src/bin/caller/display_glue.rs
@@ -1483,22 +1483,29 @@ pub(crate) async fn handle_shared_view_calls(
             ))
         });
 
-        let resolved_target = mcp::shared_view_display_target(display_target, None);
-        let display_id = mcp::shared_view_display_id(resolved_target.as_deref(), None);
-        let label = mcp::shared_view_target_label(display_id, resolved_target.as_deref());
-
         // The user's own screen is an explicit opt-in path: require the
         // existing display grant instead of flipping it from a tool call.
         // Only display-exposing verbs gate — focus/input/hide operate on
         // whatever view is already shown.
         let user_display_granted = autonomy.read().await.user_display_granted;
+        let resolved =
+            mcp::resolve_concrete_shared_view_target(display_target, None).or_else(|| {
+                if action == "hide" {
+                    None
+                } else {
+                    Some(mcp::concrete_shared_view_target(resolve_cu_display_target(
+                        user_display_granted,
+                    )))
+                }
+            });
+        let resolved_target = resolved.as_ref().map(|(target, _)| target.clone());
+        let display_id = resolved.map(|(_, id)| id);
+        let label = mcp::shared_view_target_label(display_id, resolved_target.as_deref());
+
         let effective_user_display = match display_id {
             Some(0) => true,
             Some(_) => false,
-            None => matches!(
-                resolve_cu_display_target(user_display_granted),
-                computer_use::DisplayTarget::UserSession
-            ),
+            None => false,
         };
         if matches!(action, "show" | "capture") && effective_user_display && !user_display_granted {
             conversation.add_tool_result(
@@ -1748,6 +1755,27 @@ pub(crate) async fn execute_cu_calls(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct DisplayEnvGuard {
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl DisplayEnvGuard {
+        fn set(value: &str) -> Self {
+            let previous = std::env::var_os("DISPLAY");
+            std::env::set_var("DISPLAY", value);
+            Self { previous }
+        }
+    }
+
+    impl Drop for DisplayEnvGuard {
+        fn drop(&mut self) {
+            match self.previous.take() {
+                Some(value) => std::env::set_var("DISPLAY", value),
+                None => std::env::remove_var("DISPLAY"),
+            }
+        }
+    }
 
     #[tokio::test]
     async fn resolve_attachments_includes_uploaded_files_and_images() {
@@ -2052,6 +2080,8 @@ mod tests {
 
     #[tokio::test]
     async fn shared_view_calls_validate_and_gate_user_session() {
+        let _env_lock = crate::test_support::TEST_ENV_LOCK.lock().await;
+        let _display = DisplayEnvGuard::set(":99");
         let tmp = tempfile::tempdir().unwrap();
         let session_log: SharedSessionLog = Arc::new(Mutex::new(
             session_log::SessionLog::open(tmp.path().to_path_buf()).unwrap(),
@@ -2132,10 +2162,16 @@ mod tests {
         }
         match rx.try_recv() {
             Ok(AppEvent::SharedView {
-                action, session_id, ..
+                action,
+                session_id,
+                display_target,
+                display_id,
+                ..
             }) => {
                 assert_eq!(action, "input_request");
                 assert_eq!(session_id.as_deref(), Some("sess-1"));
+                assert_eq!(display_target.as_deref(), Some(":99"));
+                assert_eq!(display_id, Some(99));
             }
             other => panic!("expected SharedView input_request event, got {other:?}"),
         }

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -871,33 +871,40 @@ impl UserSessionDisplayActivationRequest {
     }
 }
 
-pub(crate) fn shared_view_display_target(
-    display_target: Option<String>,
-    display_id: Option<u32>,
-) -> Option<String> {
-    display_target
-        .map(|target| target.trim().to_string())
-        .filter(|target| !target.is_empty())
-        .or_else(|| display_id.map(|id| format!(":{}", id)))
+/// Canonical dashboard wire representation for an already-resolved display
+/// target. Shared-view callers that omit their target must resolve it before
+/// emitting an event: otherwise the browser has to guess among its streamed
+/// displays, and `capture` can show one display while screenshotting another.
+pub(crate) fn concrete_shared_view_target(
+    target: crate::computer_use::DisplayTarget,
+) -> (String, u32) {
+    match target {
+        crate::computer_use::DisplayTarget::UserSession => ("user_session".to_string(), 0),
+        crate::computer_use::DisplayTarget::Virtual { id } => (format!(":{id}"), id),
+    }
 }
 
-pub(crate) fn shared_view_display_id(
-    display_target: Option<&str>,
+/// Resolve the two public shared-view target aliases into one canonical
+/// target/id pair. `display_id` is documented as the preferred field, so it
+/// wins when both are supplied; deriving both outputs from that one choice
+/// prevents dashboard activation and screenshot capture from diverging.
+pub(crate) fn resolve_concrete_shared_view_target(
+    display_target: Option<String>,
     display_id: Option<u32>,
-) -> Option<u32> {
-    if display_id.is_some() {
-        return display_id;
+) -> Option<(String, u32)> {
+    if let Some(id) = display_id {
+        let target = if id == 0 {
+            crate::computer_use::DisplayTarget::UserSession
+        } else {
+            crate::computer_use::DisplayTarget::Virtual { id }
+        };
+        return Some(concrete_shared_view_target(target));
     }
-    let target = display_target?.trim();
-    if target.eq_ignore_ascii_case("user_session") || target.eq_ignore_ascii_case("primary") {
-        return Some(0);
-    }
-    target
-        .strip_prefix(':')
-        .or_else(|| target.strip_prefix("display_"))
-        .unwrap_or(target)
-        .parse::<u32>()
-        .ok()
+
+    let target = display_target
+        .map(|target| target.trim().to_string())
+        .filter(|target| !target.is_empty())?;
+    Some(concrete_shared_view_target(resolve_display_target(&target)))
 }
 
 pub(crate) fn shared_view_target_label(
@@ -947,7 +954,10 @@ fn shared_view_user_display_id(
         .map(str::trim)
         .filter(|target| !target.is_empty())
     else {
-        return Some(0);
+        // Omission means availability-aware auto-detection, never an
+        // implicit user-session request. Shared-view entry points resolve
+        // it before reaching this activation helper.
+        return None;
     };
     if target.eq_ignore_ascii_case("user_session")
         || target.eq_ignore_ascii_case("user")
@@ -2401,6 +2411,22 @@ pub(crate) mod tests {
         assert_eq!(
             shared_view_target_label(Some(99), Some(":99")),
             "display 99"
+        );
+    }
+
+    #[test]
+    fn shared_view_target_aliases_resolve_from_one_preferred_field() {
+        assert_eq!(
+            resolve_concrete_shared_view_target(Some("user_session".to_string()), Some(99)),
+            Some((":99".to_string(), 99))
+        );
+        assert_eq!(
+            resolve_concrete_shared_view_target(Some(":99".to_string()), Some(0)),
+            Some(("user_session".to_string(), 0))
+        );
+        assert_eq!(
+            resolve_concrete_shared_view_target(Some("user".to_string()), None),
+            Some(("user_session".to_string(), 0))
         );
     }
 

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -665,14 +665,36 @@ impl IntendantServer {
         Ok(())
     }
 
+    /// Resolve the optional shared-view target once, before both dashboard
+    /// presentation and any capture side effect. The default is derived from
+    /// the same live display registry as ordinary MCP computer-use calls, so
+    /// the event and screenshot cannot drift onto different displays.
+    async fn resolve_shared_view_target(
+        &self,
+        display_target: Option<String>,
+        display_id: Option<u32>,
+    ) -> (Option<String>, Option<u32>) {
+        if let Some((display_target, display_id)) =
+            resolve_concrete_shared_view_target(display_target, display_id)
+        {
+            return (Some(display_target), Some(display_id));
+        }
+
+        let session_registry = self.state.read().await.session_registry.clone();
+        let default_target = crate::computer_use::default_display_target(&session_registry).await;
+        let (display_target, display_id) = concrete_shared_view_target(default_target);
+        (Some(display_target), Some(display_id))
+    }
+
     pub(crate) async fn show_shared_view_for_session(
         &self,
         params: ShowSharedViewParams,
         session_id: Option<&str>,
         caller: ToolCallerTrust,
     ) -> String {
-        let display_target = shared_view_display_target(params.display_target, params.display_id);
-        let display_id = shared_view_display_id(display_target.as_deref(), params.display_id);
+        let (display_target, display_id) = self
+            .resolve_shared_view_target(params.display_target, params.display_id)
+            .await;
         let region = params.focus_region.map(normalize_shared_view_region);
         if let Err(denied) = self
             .ensure_shared_view_display_active(display_target.as_deref(), display_id, caller)
@@ -728,8 +750,9 @@ impl IntendantServer {
         session_id: Option<&str>,
         caller: ToolCallerTrust,
     ) -> String {
-        let display_target = shared_view_display_target(params.display_target, params.display_id);
-        let display_id = shared_view_display_id(display_target.as_deref(), params.display_id);
+        let (display_target, display_id) = self
+            .resolve_shared_view_target(params.display_target, params.display_id)
+            .await;
         if let Err(denied) = self
             .ensure_shared_view_display_active(display_target.as_deref(), display_id, caller)
             .await
@@ -766,8 +789,9 @@ impl IntendantServer {
         session_id: Option<&str>,
         caller: ToolCallerTrust,
     ) -> String {
-        let display_target = shared_view_display_target(params.display_target, params.display_id);
-        let display_id = shared_view_display_id(display_target.as_deref(), params.display_id);
+        let (display_target, display_id) = self
+            .resolve_shared_view_target(params.display_target, params.display_id)
+            .await;
         if let Err(denied) = self
             .ensure_shared_view_display_active(display_target.as_deref(), display_id, caller)
             .await
@@ -805,8 +829,9 @@ impl IntendantServer {
         compact_output: bool,
         caller: ToolCallerTrust,
     ) -> Result<CallToolResult, McpError> {
-        let display_target = shared_view_display_target(params.display_target, params.display_id);
-        let display_id = shared_view_display_id(display_target.as_deref(), params.display_id);
+        let (display_target, display_id) = self
+            .resolve_shared_view_target(params.display_target, params.display_id)
+            .await;
         if let Err(denied) = self
             .ensure_shared_view_display_active(display_target.as_deref(), display_id, caller)
             .await
@@ -1389,7 +1414,9 @@ impl IntendantServer {
 mod tests {
     use super::*;
     use crate::autonomy::{self, AutonomyState};
-    use crate::mcp::tests::{test_session_registry_with_display, test_state};
+    use crate::mcp::tests::{
+        test_session_registry_with_display, test_state, test_state_with_log_dir,
+    };
     use tokio::time::{timeout, Duration};
 
     /// A fragment unique to the user-session opt-in refusal
@@ -1474,6 +1501,110 @@ mod tests {
             let autonomy = { server.state.read().await.autonomy.clone() };
             assert!(!autonomy.read().await.user_display_granted);
         });
+    }
+
+    #[tokio::test]
+    async fn omitted_shared_view_targets_use_the_live_virtual_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_with_log_dir(tmp.path().join("session"));
+        state.write().await.session_registry =
+            Some(test_session_registry_with_display(99, 1280, 720));
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        let server = IntendantServer::new(state, bus);
+
+        macro_rules! assert_shared_event {
+            ($expected_action:literal) => {
+                match timeout(Duration::from_secs(1), rx.recv()).await {
+                    Ok(Ok(AppEvent::SharedView {
+                        action,
+                        display_target,
+                        display_id,
+                        session_id,
+                        ..
+                    })) => {
+                        assert_eq!(action, $expected_action);
+                        assert_eq!(display_target.as_deref(), Some(":99"));
+                        assert_eq!(display_id, Some(99));
+                        assert_eq!(session_id.as_deref(), Some("session-default"));
+                    }
+                    other => panic!(
+                        "expected concrete {} SharedView event, got {other:?}",
+                        $expected_action
+                    ),
+                }
+            };
+        }
+
+        server
+            .show_shared_view_for_session(
+                ShowSharedViewParams {
+                    display_target: None,
+                    display_id: None,
+                    reason: Some("show the active workspace".to_string()),
+                    focus_region: None,
+                },
+                Some("session-default"),
+                ToolCallerTrust::Scoped,
+            )
+            .await;
+        assert_shared_event!("show");
+
+        server
+            .focus_shared_view_for_session(
+                FocusSharedViewParams {
+                    display_target: None,
+                    display_id: None,
+                    region: SharedViewRegionParams {
+                        x: 0.1,
+                        y: 0.2,
+                        width: 0.3,
+                        height: 0.4,
+                    },
+                    note: Some("look here".to_string()),
+                },
+                Some("session-default"),
+                ToolCallerTrust::Scoped,
+            )
+            .await;
+        assert_shared_event!("focus");
+
+        server
+            .request_shared_view_input_for_session(
+                RequestSharedViewInputParams {
+                    display_target: None,
+                    display_id: None,
+                    reason: Some("please take over".to_string()),
+                },
+                Some("session-default"),
+                ToolCallerTrust::Scoped,
+            )
+            .await;
+        assert_shared_event!("input_request");
+
+        let capture = server
+            .capture_shared_view_frame_for_session(
+                CaptureSharedViewFrameParams {
+                    display_target: None,
+                    display_id: None,
+                    reason: Some("capture the active workspace".to_string()),
+                },
+                Some("session-default"),
+                true,
+                ToolCallerTrust::Scoped,
+            )
+            .await
+            .expect("capture handler should return an MCP result");
+        assert_shared_event!("capture");
+        let rendered = serde_json::to_string(&capture).unwrap_or_default();
+        assert!(
+            !rendered.contains(opt_in_refusal_marker()),
+            "capture must use virtual display 99, not fall through to the user display: {rendered}"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "no display-0 activation was emitted"
+        );
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -691,6 +691,117 @@ mod tests {
     }
 
     #[test]
+    fn live_workspace_input_is_released_before_its_surface_is_hidden() {
+        fn section(start: &str, end: &str) -> &'static str {
+            APP_HTML
+                .split_once(start)
+                .and_then(|(_, rest)| rest.split_once(end).map(|(body, _)| body))
+                .unwrap_or_else(|| panic!("missing app.html section {start:?} .. {end:?}"))
+        }
+
+        fn assert_before(body: &str, first: &str, second: &str) {
+            let first_at = body
+                .find(first)
+                .unwrap_or_else(|| panic!("missing {first:?} in app.html section"));
+            let second_at = body
+                .find(second)
+                .unwrap_or_else(|| panic!("missing {second:?} in app.html section"));
+            assert!(
+                first_at < second_at,
+                "{first:?} must precede {second:?} in app.html section"
+            );
+        }
+
+        // Closing a display must flush held-key keyups while the input gate is
+        // still open, then release server-side authority.
+        let disconnect = section(
+            "  disconnect({ userInitiated = false } = {}) {",
+            "\n}\n\nfunction removeDisplaySlot",
+        );
+        assert_before(
+            disconnect,
+            "this._exitInteractive(userInitiated);",
+            "this._releaseAuthority();",
+        );
+
+        // Both ways a live projection can be hidden must release active input,
+        // cancel an in-flight Take, and relinquish authority already granted.
+        for body in [
+            section(
+                "  function teardownSelectedSurface(slot) {",
+                "\n  function selectLiveDisplay(",
+            ),
+            section(
+                "  window.deactivateLiveDisplayWorkspace = function() {",
+                "\n  function reconcileSelectedDisplay(",
+            ),
+        ] {
+            for required in [
+                "slot.interactive",
+                "slot._takeControlPending",
+                "slot.authorityState === 'you'",
+                "slot.releaseControl();",
+            ] {
+                assert!(
+                    body.contains(required),
+                    "live-surface teardown must contain {required:?}"
+                );
+            }
+        }
+
+        // Tab navigation must deactivate Live while it is still the active
+        // workspace, before the pane is hidden.
+        let switch_tab = section(
+            "function switchTab(tabId) {",
+            "\nfunction contextResolveVizTheme(",
+        );
+        assert_before(
+            switch_tab,
+            "window.deactivateLiveDisplayWorkspace()",
+            "activeTab = tabId;",
+        );
+
+        // A shared-view Take originating in Activity or Station must enter the
+        // Live workspace before selecting the target and requesting authority.
+        let shared_take = section(
+            "function takeSharedViewInput() {",
+            "\nfunction handleSharedViewEvent(",
+        );
+        assert_before(
+            shared_take,
+            "routeTo('displays')",
+            "window.selectLiveDisplay(",
+        );
+        assert_before(
+            shared_take,
+            "window.selectLiveDisplay(",
+            "slot.takeControl();",
+        );
+    }
+
+    #[test]
+    fn dashboard_validator_cachebuster_catalog_matches_the_daemon() {
+        const VALIDATOR: &str = include_str!("../../../../scripts/validate-dashboard.cjs");
+        let marker = "const APP_HTML_CACHEBUSTED_ASSET_PATHS = [";
+        let body = VALIDATOR
+            .split_once(marker)
+            .and_then(|(_, rest)| rest.split_once("];"))
+            .map(|(body, _)| body)
+            .expect("validator cachebuster catalog");
+        let validator_paths = body
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(|line| line.trim_end_matches(',').trim_matches('\'').to_string())
+            .collect::<Vec<_>>();
+        let daemon_paths = APP_HTML_VERSIONED_ASSETS
+            .iter()
+            .map(|path| (*path).to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(validator_paths, daemon_paths);
+    }
+
+    #[test]
     fn new_session_codex_model_override_is_wired() {
         assert!(APP_HTML.contains(r#"id="new-session-codex-model""#));
         assert!(APP_HTML.contains(r#"id="new-session-codex-model-select""#));

--- a/static/app.html
+++ b/static/app.html
@@ -18985,11 +18985,11 @@ html.ui-v2[data-theme="light"] .session-window-id {
   border-color: color-mix(in srgb, var(--session-badge-border, var(--line-2)) 55%, var(--line-2));
 }
 /* ── static/app/ui2-live.css ── */
-/* ── ui-v2 Live display (Video tab) re-skin (design-overhaul P2) ───────
-   Everything here is scoped under `html.ui-v2` and restyles the EXISTING
-   displays DOM (display-slot toolbars/stages, banners, recording replay,
-   annotation + clip editors, peer-display pane controls) to the v2
-   design language — v1 stays pixel-identical.
+/* ── ui-v2 Live display / Computer Use workspace ──────────────────────
+   `html.ui-v2` is the permanent dashboard namespace. This sheet reconciles
+   the stage-first CU concept with the production display lifecycle:
+   selected local display, input authority, sharing, recording, annotation,
+   peer launchers, and the private-vs-agent-visible user-screen grant.
 
    HARD GUARDRAILS honoured throughout (audit §5, displays.md):
    - No CSS touches video/canvas element DIMENSIONS with !important, and
@@ -19012,14 +19012,27 @@ html.ui-v2[data-theme="light"] .session-window-id {
      displacement (no request/approve ceremony), and the third state —
      another viewer holding input — renders as an amber chip + rail row.
 
-   The right rail (.ui2-live-rail) is injected by the ui2Enabled()-gated
-   mirror block at the end of 45-displays-webrtc.js: it renders FROM the
-   existing slot DOM / station peer chips / sb-display-access chip and
-   proxies clicks to the existing controls. Display-only, v1 untouched. */
+   The semantic right rail lives in 20-shell.html. The stable keyed
+   projection at the end of 45-displays-webrtc.js renders from displaySlots,
+   Station peer chips, and the user-display grant without replacing focused
+   controls on every metrics update. */
 
-/* ── tab scaffold: content column + fixed right rail ── */
-html.ui-v2 #tab-displays { padding-right: 284px; }
-html.ui-v2 #tab-displays > :not(.ui2-live-rail) { min-width: 0; }
+/* ── tab scaffold: stage/recording column + semantic right rail ── */
+html.ui-v2 #tab-displays.active {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  overflow: hidden;
+}
+html.ui-v2 .ui2-live-main {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+html.ui-v2 .ui2-live-mobile-bar,
+html.ui-v2 .ui2-live-rail-scrim,
+html.ui-v2 .ui2-live-rail-close { display: none; }
 
 /* ── degraded state: macOS capture-approval banner (amber = needs you) ── */
 html.ui-v2 .display-approval-banner {
@@ -19112,8 +19125,14 @@ html.ui-v2 .shared-view-banner-compact {
 }
 
 /* ── displays container + empty state ── */
-html.ui-v2 .displays-container { padding: 2px 16px 14px; }
+html.ui-v2 .displays-container { padding: 2px 0 0; }
 html.ui-v2 .displays-container:not(.has-displays) { padding: 24px 16px; }
+html.ui-v2 .displays-container.ui2-live-single-stage > .display-slot.ui2-live-inactive {
+  display: none;
+}
+html.ui-v2 .displays-container.ui2-live-single-stage > .display-slot.ui2-live-selected {
+  display: flex;
+}
 html.ui-v2 #tab-displays .ui-empty-glyph {
   width: 40px;
   height: 40px;
@@ -19169,23 +19188,35 @@ html.ui-v2 .display-slot + .display-slot { margin-top: 8px; }
 html.ui-v2 .display-toolbar {
   background: transparent;
   border-bottom: 0;
-  padding: 10px 2px 10px;
-  gap: 8px;
-  /* v1 never wraps; at narrow widths the trailing buttons (incl. Take
-     Control) clipped off the right edge with no scroll. Wrap instead. */
-  flex-wrap: wrap;
+  padding: 14px 16px 10px;
+  gap: 14px;
+  flex-wrap: nowrap;
+  min-width: 0;
 }
-/* display name wears the design's picker-button look (static: every
-   granted display renders simultaneously — no dropdown to fake) */
+html.ui-v2 .display-toolbar-meta {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px 10px;
+}
+html.ui-v2 .display-toolbar-actions {
+  min-width: 0;
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
+}
+/* Display selection lives in the real rail. The stage label is therefore
+   an honest heading, not a non-interactive span styled as a dropdown. */
 html.ui-v2 .display-label {
   font-family: var(--sans);
-  font-size: 13px;
-  font-weight: 700;
+  font-size: 15px;
+  font-weight: 800;
   color: var(--text);
-  padding: 6px 12px;
-  border: 1px solid var(--line);
-  border-radius: 9px;
-  background: var(--surface);
   max-width: 260px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -19275,8 +19306,31 @@ html.ui-v2 .display-input-authority.unclaimed {
   color: var(--text-2);
 }
 
+html.ui-v2 .display-visibility {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border-radius: var(--r-pill);
+  border: 1px solid var(--line-2);
+  font-family: var(--sans);
+  font-size: 10.5px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+html.ui-v2 .display-visibility.private {
+  color: var(--green);
+  border-color: rgba(var(--green-rgb), .26);
+  background: rgba(var(--green-rgb), .1);
+}
+html.ui-v2 .display-visibility.agent {
+  color: var(--amber);
+  border-color: rgba(var(--amber-rgb), .28);
+  background: rgba(var(--amber-rgb), .11);
+}
+
 /* toolbar buttons: quiet secondaries by default */
 html.ui-v2 .display-toolbar button {
+  flex: 0 0 auto;
   min-height: 0;
   padding: 6px 11px;
   border: 1px solid var(--line);
@@ -19288,6 +19342,7 @@ html.ui-v2 .display-toolbar button {
   font-weight: 600;
   transition: background var(--t-fast), color var(--t-fast), border-color var(--t-fast), filter var(--t-fast);
 }
+html.ui-v2 .display-toolbar-actions .take-control-btn { margin-left: 0; }
 html.ui-v2 .display-toolbar button:hover {
   background: var(--surface-2);
   border-color: var(--line-2);
@@ -19377,6 +19432,7 @@ html.ui-v2 .display-toolbar .delete-recording-btn:hover {
   color: var(--rose);
 }
 html.ui-v2 .display-toolbar .release-note {
+  flex: 0 0 150px;
   border: 1px solid var(--line-2);
   border-radius: 9px;
   background: var(--surface-2);
@@ -19399,6 +19455,7 @@ html.ui-v2 .display-canvas {
   display: flex;
   align-items: center;
   justify-content: center;
+  margin: 0 16px 16px;
   border-radius: 16px;
   overflow: hidden;
   background: radial-gradient(120% 120% at 30% 0%, #10131b, #070810 70%);
@@ -19407,6 +19464,55 @@ html.ui-v2 .display-canvas {
     inset 0 1px 0 rgba(255, 255, 255, .04),
     0 24px 60px rgba(0, 0, 0, .5);
 }
+html.ui-v2 .display-canvas:has(video:focus-visible) {
+  box-shadow:
+    inset 0 0 0 2px var(--iris),
+    inset 0 1px 0 rgba(255, 255, 255, .04),
+    0 24px 60px rgba(0, 0, 0, .5);
+}
+
+/* Explicit feedback that input listeners are bound to THIS stage. The
+   server authority chip remains the source of truth; this banner only
+   appears after DisplaySlot._enterInteractive has installed the capture
+   stack (including the document paste handler). */
+html.ui-v2 .display-control-banner {
+  display: none;
+  position: absolute;
+  z-index: 8;
+  top: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: calc(100% - 210px);
+  padding: 6px 12px 6px 26px;
+  border: 1px solid rgba(var(--green-rgb), .34);
+  border-radius: var(--r-pill);
+  background: rgba(11, 12, 16, .76);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, .28);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  color: var(--green);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.25;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
+}
+html.ui-v2 .display-control-banner::before {
+  content: '';
+  position: absolute;
+  left: 11px;
+  top: 50%;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green);
+  transform: translateY(-50%);
+  box-shadow: 0 0 0 3px rgba(var(--green-rgb), .16);
+}
+html.ui-v2 .display-slot.is-interactive .display-control-banner { display: block; }
 /* LIVE pill — pure CSS, derived from the real connection state; any
    reconnect/degraded state drops .connected and the pill vanishes. */
 html.ui-v2 .display-slot:has(.display-status.connected) .display-canvas::after {
@@ -19596,6 +19702,7 @@ html.ui-v2[data-theme="light"] .display-slot.shared-view-active .display-canvas 
 /* contexts that must NOT wear the stage chrome: activity thumbnails and
    in-page fullscreen (the reparented canvas keeps its geometry honest) */
 html.ui-v2 .activity-display-thumb > .display-canvas {
+  margin: 0;
   border-radius: 3px;
   box-shadow: none;
 }
@@ -19608,6 +19715,7 @@ html.ui-v2 .activity-display-thumb .display-live-metrics {
 }
 html.ui-v2 .display-slot.display-fullscreen { background: var(--bg); }
 html.ui-v2 .display-slot.display-fullscreen .display-canvas {
+  margin: 0 14px 14px;
   border-radius: 0;
   box-shadow: none;
 }
@@ -20037,13 +20145,27 @@ html.ui-v2 .thumb-label {
 /* ── user-display picker popover (opens from the status-bar chip; the
       rail's "Your screen" card proxies the same control) ── */
 html.ui-v2 .display-picker {
+  display: none;
+  min-width: 260px;
+  max-width: min(360px, calc(100vw - 24px));
+  max-height: min(440px, calc(100vh - 24px));
+  overflow-y: auto;
   background: linear-gradient(180deg, var(--surface-2), var(--surface));
   border: 1px solid var(--line-2);
   border-radius: var(--r-card);
   padding: 5px;
   box-shadow: var(--shadow-overlay);
 }
+html.ui-v2 .display-picker.visible { display: block; }
 html.ui-v2 .display-picker-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  font-family: var(--sans);
+  text-align: left;
+  cursor: pointer;
   border-radius: 8px;
   font-size: 12.5px;
   font-weight: 600;
@@ -20051,6 +20173,13 @@ html.ui-v2 .display-picker-item {
   padding: 8px 11px;
 }
 html.ui-v2 .display-picker-item:hover { background: rgba(var(--iris-rgb), .1); }
+html.ui-v2 .display-picker-item.dp-action {
+  margin-top: 5px;
+  padding-top: 11px;
+  border-top: 1px solid var(--line);
+  border-radius: 0 0 8px 8px;
+  color: var(--iris-2);
+}
 html.ui-v2 .display-picker-item .dp-primary {
   font-family: var(--mono);
   font-size: 10px;
@@ -20216,38 +20345,80 @@ html.ui-v2 .peer-display-pane .live-annotation-overlay {
 html.ui-v2 .peer-display-pane .live-annotation-source { z-index: 4; background: #000; }
 html.ui-v2 .peer-display-pane .live-annotation-overlay { z-index: 5; }
 
-/* ── right rail (injected, display-only mirror) ── */
+/* ── Computer Use right rail ── */
 html.ui-v2 .ui2-live-rail {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: 284px;
+  position: relative;
+  z-index: 20;
+  min-width: 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: 22px;
-  padding: 20px 18px;
   overflow-y: auto;
+  overscroll-behavior: contain;
   border-left: 1px solid var(--line);
   background: var(--bg-1);
 }
+html.ui-v2 .ui2-live-rail-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px;
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--bg-1) 92%, transparent);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+}
+html.ui-v2 .ui2-live-rail-kicker,
+html.ui-v2 .ui2-live-mobile-kicker {
+  display: block;
+  color: var(--text-3);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+html.ui-v2 .ui2-live-rail-header h2 {
+  margin: 2px 0 0;
+  color: var(--text);
+  font-size: 16px;
+  font-weight: 800;
+  line-height: 1.2;
+}
+html.ui-v2 .ui2-live-rail > section {
+  flex: 0 0 auto;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--line);
+}
+html.ui-v2 .ui2-live-rail > section:last-child { border-bottom: 0; }
 html.ui-v2 .ui2-live-rail-eyebrow {
+  margin: 0 0 10px;
+  color: var(--text-3);
   font-size: 10.5px;
   font-weight: 700;
   letter-spacing: .1em;
   text-transform: uppercase;
-  color: var(--text-3);
-  margin-bottom: 10px;
 }
-html.ui-v2 .ui2-live-rail-list { display: flex; flex-direction: column; gap: 8px; }
-html.ui-v2 .ui2-live-rail-empty { font-size: 11.5px; color: var(--text-3); line-height: 1.5; }
+html.ui-v2 .ui2-live-rail-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+html.ui-v2 .ui2-live-rail-empty {
+  color: var(--text-3);
+  font-size: 11.5px;
+  line-height: 1.5;
+}
 html.ui-v2 .ui2-live-row {
   display: flex;
   align-items: center;
   gap: 10px;
   width: 100%;
-  min-height: 0;
-  padding: 11px 12px;
+  min-height: 50px;
+  padding: 10px 11px;
   border: 1px solid var(--line);
   border-radius: 11px;
   background: var(--surface);
@@ -20255,14 +20426,28 @@ html.ui-v2 .ui2-live-row {
   font-family: var(--sans);
   text-align: left;
   cursor: pointer;
-  transition: border-color var(--t-fast), background var(--t-fast);
+  transition:
+    border-color var(--t-fast),
+    background var(--t-fast),
+    box-shadow var(--t-fast);
 }
-html.ui-v2 .ui2-live-row:hover { border-color: var(--line-2); background: var(--surface-2); }
-html.ui-v2 .ui2-live-row:disabled { opacity: .55; cursor: default; }
-html.ui-v2 .ui2-live-row:disabled:hover { border-color: var(--line); background: var(--surface); }
-html.ui-v2 .ui2-live-row.viewing {
+html.ui-v2 .ui2-live-row:hover {
+  border-color: var(--line-2);
+  background: var(--surface-2);
+}
+html.ui-v2 .ui2-live-row:disabled {
+  opacity: .55;
+  cursor: default;
+}
+html.ui-v2 .ui2-live-row:disabled:hover {
+  border-color: var(--line);
+  background: var(--surface);
+}
+html.ui-v2 .ui2-live-row.viewing,
+html.ui-v2 .ui2-live-row.selected {
   border-color: var(--iris);
   background: rgba(var(--iris-rgb), .08);
+  box-shadow: inset 3px 0 0 var(--iris);
 }
 html.ui-v2 .ui2-live-row-dot {
   width: 7px;
@@ -20286,79 +20471,124 @@ html.ui-v2 .ui2-live-row-main {
   flex-direction: column;
 }
 html.ui-v2 .ui2-live-row-title {
+  overflow: hidden;
+  color: var(--text);
   font-size: 13px;
   font-weight: 700;
-  white-space: nowrap;
-  overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 html.ui-v2 .ui2-live-row-meta {
   margin-top: 2px;
-  font-family: var(--mono);
-  font-size: 10.5px;
-  color: var(--text-3);
-  white-space: nowrap;
   overflow: hidden;
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 10px;
   text-overflow: ellipsis;
+  white-space: nowrap;
+}
+html.ui-v2 .ui2-live-row-tags {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
 }
 html.ui-v2 .ui2-live-row-tag {
-  flex: 0 0 auto;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: .05em;
   color: var(--iris-2);
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: .05em;
 }
-html.ui-v2 .ui2-live-row-chev { flex: 0 0 auto; color: var(--text-3); font-size: 14px; }
+html.ui-v2 .ui2-live-row-privacy { color: var(--green); }
+html.ui-v2 .ui2-live-row-chev {
+  flex: 0 0 auto;
+  color: var(--text-3);
+  font-size: 14px;
+}
 
 html.ui-v2 .ui2-live-card {
+  padding: 14px 15px;
   border: 1px solid var(--line);
   border-radius: var(--r-card);
   background: var(--surface);
-  padding: 14px 15px;
 }
-html.ui-v2 .ui2-live-card-title { font-size: 13.5px; font-weight: 800; color: var(--text); }
+html.ui-v2 .ui2-live-card-title {
+  color: var(--text);
+  font-size: 13.5px;
+  font-weight: 800;
+}
 html.ui-v2 .ui2-live-card-sub {
-  margin-top: 6px;
-  font-size: 11.5px;
-  line-height: 1.55;
+  margin-top: 5px;
   color: var(--text-2);
+  font-size: 11.5px;
+  line-height: 1.5;
+}
+html.ui-v2 .ui2-live-authority-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+}
+html.ui-v2 .ui2-live-authority-copy {
+  flex: 1;
+  min-width: 0;
+}
+html.ui-v2 .ui2-live-authority-dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: var(--neutral-dot);
+  box-shadow: 0 0 0 3px rgba(var(--text-rgb), .06);
+}
+html.ui-v2 .ui2-live-authority-card.state-you .ui2-live-authority-dot {
+  background: var(--green);
+  box-shadow: 0 0 0 3px rgba(var(--green-rgb), .16);
+}
+html.ui-v2 .ui2-live-authority-card.state-other .ui2-live-authority-dot {
+  background: var(--amber);
+  box-shadow: 0 0 0 3px rgba(var(--amber-rgb), .16);
 }
 html.ui-v2 .ui2-live-auth-row {
   display: flex;
   align-items: center;
   gap: 8px;
   margin-top: 11px;
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
 }
 html.ui-v2 .ui2-live-auth-name {
   flex: 1;
   min-width: 0;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text);
-  white-space: nowrap;
   overflow: hidden;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 650;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 html.ui-v2 .ui2-live-state-pill {
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
-  padding: 2px 9px;
-  border-radius: var(--r-pill);
+  padding: 2px 8px;
   border: 1px solid var(--line-2);
+  border-radius: var(--r-pill);
   background: var(--surface-3);
   color: var(--text-2);
-  font-size: 10.5px;
+  font-size: 10px;
   font-weight: 700;
+  white-space: nowrap;
 }
 html.ui-v2 .ui2-live-state-pill.you {
-  background: rgba(var(--green-rgb), .12);
   border-color: rgba(var(--green-rgb), .26);
+  background: rgba(var(--green-rgb), .12);
   color: var(--green);
 }
 html.ui-v2 .ui2-live-state-pill.other {
-  background: rgba(var(--amber-rgb), .14);
   border-color: rgba(var(--amber-rgb), .26);
+  background: rgba(var(--amber-rgb), .14);
   color: var(--amber);
 }
 html.ui-v2 .ui2-live-card-btn {
@@ -20366,47 +20596,263 @@ html.ui-v2 .ui2-live-card-btn {
   align-items: center;
   justify-content: center;
   width: 100%;
-  min-height: 0;
+  min-height: 38px;
   margin-top: 9px;
   padding: 9px;
   border: 0;
   border-radius: var(--r-ctl);
   background: linear-gradient(180deg, var(--iris), var(--iris-deep));
+  box-shadow: 0 6px 16px rgba(var(--iris-rgb), .32);
   color: var(--on-accent);
   font-family: var(--sans);
   font-size: 12.5px;
   font-weight: 800;
-  box-shadow: 0 6px 16px rgba(var(--iris-rgb), .32);
-  transition: filter var(--t-med);
+  transition: filter var(--t-med), background var(--t-fast), border-color var(--t-fast);
 }
 html.ui-v2 .ui2-live-card-btn:hover { filter: brightness(1.08); }
+html.ui-v2 .ui2-live-card-btn:disabled {
+  opacity: .55;
+  cursor: wait;
+  filter: none;
+}
 html.ui-v2 .ui2-live-card-btn.release {
-  background: rgba(var(--amber-rgb), .14);
   border: 1px solid rgba(var(--amber-rgb), .32);
-  color: var(--amber);
+  background: rgba(var(--amber-rgb), .14);
   box-shadow: none;
+  color: var(--amber);
 }
 html.ui-v2 .ui2-live-card-btn.secondary {
-  background: var(--surface-2);
   border: 1px solid var(--line);
+  background: var(--surface-2);
+  box-shadow: none;
   color: var(--text);
-  box-shadow: none;
   font-weight: 700;
 }
-html.ui-v2 .ui2-live-card-btn.secondary:hover { background: var(--surface-3); border-color: var(--line-2); filter: none; }
+html.ui-v2 .ui2-live-card-btn.secondary:hover {
+  border-color: var(--line-2);
+  background: var(--surface-3);
+  filter: none;
+}
 html.ui-v2 .ui2-live-card-btn.danger {
-  background: transparent;
   border: 1px solid rgba(var(--rose-rgb), .4);
-  color: var(--rose);
+  background: transparent;
   box-shadow: none;
+  color: var(--rose);
   font-weight: 700;
 }
-html.ui-v2 .ui2-live-card-btn.danger:hover { background: rgba(var(--rose-rgb), .1); filter: none; }
+html.ui-v2 .ui2-live-card-btn.danger:hover {
+  background: rgba(var(--rose-rgb), .1);
+  filter: none;
+}
+html.ui-v2 .ui2-live-screen-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+html.ui-v2 .ui2-live-screen-head .ui2-live-card-title {
+  flex: 1;
+  min-width: 0;
+}
+html.ui-v2 .ui2-live-screen-actions {
+  display: flex;
+  flex-direction: column;
+}
 
-/* narrow: the rail yields to the stage */
-@media (max-width: 1100px) {
-  html.ui-v2 #tab-displays { padding-right: 0; }
-  html.ui-v2 .ui2-live-rail { display: none; }
+html.ui-v2 .ui2-live-activity {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+html.ui-v2 .ui2-live-activity-row {
+  display: grid;
+  grid-template-columns: 7px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 31px;
+  padding: 5px 2px;
+  border-bottom: 1px solid var(--line);
+}
+html.ui-v2 .ui2-live-activity-row:last-child { border-bottom: 0; }
+html.ui-v2 .ui2-live-activity-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--neutral-dot);
+}
+html.ui-v2 .ui2-live-activity-row.kind-live .ui2-live-activity-dot,
+html.ui-v2 .ui2-live-activity-row.kind-control .ui2-live-activity-dot {
+  background: var(--green);
+}
+html.ui-v2 .ui2-live-activity-row.kind-attention .ui2-live-activity-dot {
+  background: var(--amber);
+}
+html.ui-v2 .ui2-live-activity-row.kind-error .ui2-live-activity-dot,
+html.ui-v2 .ui2-live-activity-row.kind-recording .ui2-live-activity-dot {
+  background: var(--rose);
+}
+html.ui-v2 .ui2-live-activity-row.kind-focus .ui2-live-activity-dot {
+  background: var(--iris);
+}
+html.ui-v2 .ui2-live-activity-row.kind-share .ui2-live-activity-dot {
+  background: var(--sky);
+}
+html.ui-v2 .ui2-live-activity-row.kind-private .ui2-live-activity-dot {
+  background: var(--green);
+}
+html.ui-v2 .ui2-live-activity-text {
+  min-width: 0;
+  color: var(--text-2);
+  font-size: 11px;
+  line-height: 1.35;
+}
+html.ui-v2 .ui2-live-activity-time {
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 9.5px;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 1279px) {
+  html.ui-v2 #tab-displays.active { display: block; }
+  html.ui-v2 .ui2-live-main { height: 100%; }
+  html.ui-v2 .ui2-live-mobile-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex: 0 0 auto;
+    padding: 9px 14px;
+    border-bottom: 1px solid var(--line);
+    background: var(--bg-1);
+  }
+  html.ui-v2 .ui2-live-mobile-summary {
+    display: block;
+    max-width: 52vw;
+    margin-top: 1px;
+    overflow: hidden;
+    color: var(--text-2);
+    font-size: 11.5px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  html.ui-v2 .ui2-live-rail-toggle {
+    flex: 0 0 auto;
+    min-height: 36px;
+    padding: 7px 12px;
+    border: 1px solid var(--line-2);
+    border-radius: var(--r-ctl);
+    background: var(--surface);
+    color: var(--text);
+    font-family: var(--sans);
+    font-size: 12px;
+    font-weight: 750;
+  }
+  html.ui-v2 .ui2-live-rail {
+    position: absolute;
+    inset: 0 0 0 auto;
+    z-index: 61;
+    width: min(360px, calc(100% - 20px));
+    border-left: 1px solid var(--line-2);
+    box-shadow: var(--shadow-overlay);
+    visibility: hidden;
+    transform: translateX(102%);
+    transition: transform var(--t-slow), visibility 0s linear var(--t-slow);
+  }
+  html.ui-v2 #tab-displays.ui2-live-rail-open .ui2-live-rail {
+    visibility: visible;
+    transform: translateX(0);
+    transition-delay: 0s;
+  }
+  html.ui-v2 .ui2-live-rail-close {
+    display: grid;
+    place-items: center;
+    width: 34px;
+    height: 34px;
+    border: 1px solid var(--line);
+    border-radius: var(--r-ctl);
+    background: var(--surface);
+    color: var(--text-2);
+    font-size: 18px;
+  }
+  html.ui-v2 .ui2-live-rail-close:hover {
+    border-color: rgba(var(--rose-rgb), .4);
+    background: rgba(var(--rose-rgb), .08);
+    color: var(--rose);
+  }
+  html.ui-v2 .ui2-live-rail-scrim {
+    position: absolute;
+    inset: 0;
+    z-index: 60;
+    display: block;
+    padding: 0;
+    border: 0;
+    background: rgba(5, 6, 10, .58);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity var(--t-slow), visibility 0s linear var(--t-slow);
+  }
+  html.ui-v2 #tab-displays.ui2-live-rail-open .ui2-live-rail-scrim {
+    opacity: 1;
+    visibility: visible;
+    transition-delay: 0s;
+  }
+}
+
+@media (max-width: 820px) {
+  html.ui-v2 .display-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 10px 8px;
+  }
+  html.ui-v2 .display-toolbar-meta {
+    flex: 0 0 auto;
+    min-height: 30px;
+  }
+  html.ui-v2 .display-toolbar-actions {
+    width: 100%;
+    margin-left: 0;
+    padding: 1px 0 4px;
+  }
+  html.ui-v2 .display-toolbar-actions .take-control-btn,
+  html.ui-v2 .display-toolbar-actions .release-control-btn {
+    order: -2;
+  }
+  html.ui-v2 .display-toolbar button {
+    min-height: 36px;
+    padding: 7px 11px;
+  }
+  html.ui-v2 .display-toolbar .release-note {
+    flex-basis: 145px;
+    min-height: 36px;
+  }
+  html.ui-v2 .display-canvas { margin: 0 10px 10px; }
+  html.ui-v2 .display-control-banner {
+    top: auto;
+    right: 10px;
+    bottom: 10px;
+    left: 10px;
+    max-width: none;
+    transform: none;
+  }
+  html.ui-v2 .display-live-metrics {
+    max-width: calc(100% - 28px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+@media (max-width: 520px) {
+  html.ui-v2 .ui2-live-rail { width: 100%; }
+  html.ui-v2 .ui2-live-mobile-kicker { display: none; }
+  html.ui-v2 .ui2-live-mobile-summary { max-width: 46vw; }
+  html.ui-v2 .ui2-live-rail > section { padding: 14px; }
+  html.ui-v2 .ui2-live-rail-header { padding: 14px; }
+}
+
+@media (max-height: 680px) {
+  html.ui-v2 .ui2-live-rail-header { padding-top: 12px; padding-bottom: 12px; }
+  html.ui-v2 .ui2-live-rail > section { padding-top: 12px; padding-bottom: 12px; }
 }
 /* ── static/app/ui2-usage.css ── */
 /* ── ui-v2 Usage (Stats) tab re-skin (design-overhaul P2) ──────────────
@@ -21639,7 +22085,7 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
     <span class="display-toggle-wrap">
       <span class="field-label" id="sb-display-label" onclick="toggleUserDisplay(event)" title="Your display — click to grant/revoke agent access to your screen for computer use tasks">your display</span>
       <span id="sb-display-access" onclick="toggleUserDisplay(event)" title="Your display — click to grant/revoke agent access to your screen for computer use tasks">off</span>
-      <div class="display-picker" id="display-picker"></div>
+      <div class="display-picker" id="display-picker" aria-hidden="true"></div>
     </span>
     <span class="sep">|</span>
     <span class="field-label">Intendant session</span>
@@ -22585,6 +23031,17 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
 
     <!-- Displays Tab -->
     <div id="tab-displays" class="tab-pane">
+      <div class="ui2-live-main" id="ui2-live-main">
+      <div class="ui2-live-mobile-bar">
+        <div>
+          <span class="ui2-live-mobile-kicker">Computer use</span>
+          <span class="ui2-live-mobile-summary" id="ui2-live-mobile-summary">No display selected</span>
+        </div>
+        <button class="ui2-live-rail-toggle" id="ui2-live-rail-toggle" type="button"
+                aria-controls="ui2-live-rail" aria-expanded="false">
+          Displays &amp; input
+        </button>
+      </div>
       <div class="display-approval-banner hidden" id="display-approval-banner">
         <div class="icon">&#x26A0;</div>
         <div class="text">
@@ -22714,6 +23171,40 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
           <button id="rec-clip-btn" title="Send Clip (C)">&#127916; Clip</button>
         </div>
       </div>
+      </div>
+      <button class="ui2-live-rail-scrim" id="ui2-live-rail-scrim" type="button"
+              aria-label="Close live display controls" tabindex="-1"></button>
+      <aside class="ui2-live-rail" id="ui2-live-rail" aria-labelledby="ui2-live-rail-title">
+        <header class="ui2-live-rail-header">
+          <div>
+            <div class="ui2-live-rail-kicker">Live workspace</div>
+            <h2 id="ui2-live-rail-title">Computer use</h2>
+          </div>
+          <button class="ui2-live-rail-close" id="ui2-live-rail-close" type="button"
+                  aria-label="Close live display controls">&times;</button>
+        </header>
+        <section aria-labelledby="ui2-live-displays-heading">
+          <h3 class="ui2-live-rail-eyebrow" id="ui2-live-displays-heading">Displays</h3>
+          <div class="ui2-live-rail-list" id="ui2-live-displays-list" role="group" aria-label="Live displays"></div>
+        </section>
+        <section aria-labelledby="ui2-live-authority-heading">
+          <h3 class="ui2-live-rail-eyebrow" id="ui2-live-authority-heading">Input authority</h3>
+          <div id="ui2-live-authority-card" aria-live="polite" aria-atomic="true"></div>
+        </section>
+        <section aria-labelledby="ui2-live-activity-heading">
+          <h3 class="ui2-live-rail-eyebrow" id="ui2-live-activity-heading">Display activity</h3>
+          <div class="ui2-live-activity" id="ui2-live-activity" role="log"
+               aria-live="polite" aria-relevant="additions text"></div>
+        </section>
+        <section aria-labelledby="ui2-live-peer-heading">
+          <h3 class="ui2-live-rail-eyebrow" id="ui2-live-peer-heading">Peer displays</h3>
+          <div class="ui2-live-rail-list" id="ui2-live-peer-list" role="group" aria-label="Peer displays"></div>
+        </section>
+        <section aria-labelledby="ui2-live-yourscreen-heading">
+          <h3 class="ui2-live-rail-eyebrow" id="ui2-live-yourscreen-heading">Your screen</h3>
+          <div id="ui2-live-yourscreen"></div>
+        </section>
+      </aside>
     </div>
 
     <!-- Sessions Tab -->
@@ -26169,7 +26660,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '1069e3a0dd20e6b2';
+const INTENDANT_APP_BUILD = '6a47fd04d68d454e';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -32970,6 +33461,8 @@ function stationRenderPeerChips() {
         const chip = document.createElement('button');
         chip.type = 'button';
         chip.className = 'station-peer-chip';
+        chip.dataset.hostId = hostId;
+        chip.dataset.displayId = String(displayId);
         chip.disabled = !d.connected;
         chip.title = d.connected
           ? `Open a live view of display ${displayId}${size} on ${name}`
@@ -32990,6 +33483,8 @@ function stationRenderPeerChips() {
     const chip = document.createElement('button');
     chip.type = 'button';
     chip.className = 'station-peer-chip';
+    chip.dataset.hostId = hostId;
+    chip.dataset.displayId = String(displayId);
     chip.disabled = !d.connected;
     chip.title = d.connected
       ? `Open a live view of display ${displayId} on ${name}`
@@ -34736,7 +35231,6 @@ async function stationApplyManagedAction(op, id = '', sessionId = '') {
     }
   }
 }
-
 /* ── static/app/34-station-panes.js ── */
 async function stationSelectChange(path) {
   stationSelectedChangePath = path || stationSelectedChangePath || activeChangesFile || '';
@@ -39967,19 +40461,19 @@ async function main() {
       if (d.event === 'recording_started' && d.stream_name) {
         serverMsgStep(d, 'recording_started', () => {
           const slot = slotForRecordingStream(d.stream_name);
-          if (slot) { slot.recordingStreamName = d.stream_name; slot.recording = true; slot.recordBtn.innerHTML = '&#x23F9; Stop'; slot.recordBtn.classList.add('active'); slot.deleteRecBtn.style.display = 'none'; }
+          if (slot) { slot.recordingStreamName = d.stream_name; slot.recording = true; slot.recordBtn.innerHTML = '&#x23F9; Stop'; slot.recordBtn.classList.add('active'); slot.recordBtn.setAttribute('aria-pressed', 'true'); slot.deleteRecBtn.style.display = 'none'; }
           handleDebugRecordingEvent(d); // debug tab's Record button tracks its display's streams
         });
       } else if (d.event === 'recording_stopped' && d.stream_name) {
         serverMsgStep(d, 'recording_stopped', () => {
           const slot = slotForRecordingStream(d.stream_name);
-          if (slot) { slot.recordingStreamName = d.stream_name; slot.recording = false; slot.recordBtn.innerHTML = '&#x23FA; Record'; slot.recordBtn.classList.remove('active'); slot.deleteRecBtn.style.display = ''; }
+          if (slot) { slot.recordingStreamName = d.stream_name; slot.recording = false; slot.recordBtn.innerHTML = '&#x23FA; Record'; slot.recordBtn.classList.remove('active'); slot.recordBtn.setAttribute('aria-pressed', 'false'); slot.deleteRecBtn.style.display = ''; }
           handleDebugRecordingEvent(d);
         });
       } else if (d.event === 'recording_deleted' && d.stream_name) {
         serverMsgStep(d, 'recording_deleted', () => {
           const slot = slotForRecordingStream(d.stream_name);
-          if (slot) { if (slot.recordingStreamName === d.stream_name) slot.recordingStreamName = null; slot.recording = false; slot.recordBtn.innerHTML = '&#x23FA; Record'; slot.recordBtn.classList.remove('active'); slot.deleteRecBtn.style.display = 'none'; }
+          if (slot) { if (slot.recordingStreamName === d.stream_name) slot.recordingStreamName = null; slot.recording = false; slot.recordBtn.innerHTML = '&#x23FA; Record'; slot.recordBtn.classList.remove('active'); slot.recordBtn.setAttribute('aria-pressed', 'false'); slot.deleteRecBtn.style.display = 'none'; }
           deleteRecordingStream(d.stream_name);
         });
       }
@@ -40477,7 +40971,6 @@ async function main() {
     if (modelConnected && app) disconnectDashboardVoice();
   });
 }
-
 /* ── static/app/37-uicommand-changes-control.js ── */
 // ── UiCommand Processor ──
 function processCommands(cmds) {
@@ -62201,25 +62694,34 @@ class DisplaySlot {
     this.el.className = 'display-slot';
     const label = displayLabel(displayId);
     this.el.innerHTML = `
-      <div class="display-toolbar">
-        <span class="display-label">${label}</span>
-        <span class="display-visibility" id="ds-visibility-${displayId}" style="display:none"></span>
-        <span class="display-status" id="ds-status-${displayId}">Connecting...</span>
-        <span class="display-input-authority" id="ds-authority-${displayId}" style="display:none" title="Input authority for this display: who can drive keyboard/mouse. Phase 5c."></span>
-        <input class="release-note" id="ds-note-${displayId}" placeholder="Note (optional)" style="display:none">
-        <button class="stream-btn" id="ds-stream-${displayId}" title="Continuously send screenshots of this display to the live presence (voice) model. Main agents are not affected.">Stream</button>
-        <button class="ann-attach-btn" id="ds-attach-${displayId}" title="Capture current frame and attach to next task">Attach</button>
-        <button class="annotate-btn" id="ds-annotate-${displayId}" title="Freeze current frame and annotate it">&#9998; Annotate</button>
-        <button class="callout-btn" id="ds-callout-${displayId}" aria-pressed="false" disabled title="Call out a region: arm, then drag a rectangle on the frame to attach it to the next task (needs input control)">&#x2316; Callout</button>
-        <button class="record-btn" id="ds-record-${displayId}" title="Record this display (ffmpeg)">Record</button>
-        <button class="display-fullscreen-btn" id="ds-fullscreen-${displayId}" title="Full screen">&#x26F6;</button>
-        <button class="display-close-btn" id="ds-close-${displayId}" title="Close this display stream">&times;</button>
-        <button class="take-control-btn" id="ds-take-${displayId}" title="Take interactive control of this display (keyboard and mouse)">Take Control</button>
-        <button class="release-control-btn" id="ds-release-${displayId}" style="display:none" title="Release control and return display to view-only mode">Release</button>
-        <button class="delete-recording-btn" id="ds-delete-rec-${displayId}" style="display:none" title="Delete recording files for this display">Delete</button>
-        <span class="stream-frame-id" id="ds-frame-${displayId}" style="display:none;font-size:10px;color:var(--overlay0);margin-left:auto"></span>
+      <div class="display-toolbar" role="group">
+        <div class="display-toolbar-meta">
+          <span class="display-label"></span>
+          <span class="display-visibility" id="ds-visibility-${displayId}" style="display:none"></span>
+          <span class="display-status" id="ds-status-${displayId}" role="status" aria-live="polite" aria-atomic="true">Connecting...</span>
+          <span class="display-input-authority" id="ds-authority-${displayId}" role="status" aria-live="polite" aria-atomic="true" style="display:none" title="Input authority for this display: who can drive keyboard and pointer input."></span>
+        </div>
+        <div class="display-toolbar-actions">
+          <input class="release-note" id="ds-note-${displayId}" aria-label="Note to the agent when releasing this display" placeholder="Note (optional)" style="display:none">
+          <button class="stream-btn" id="ds-stream-${displayId}" type="button" aria-pressed="false" title="Continuously send screenshots of this display to the live presence (voice) model. Main agents are not affected.">Stream</button>
+          <button class="ann-attach-btn" id="ds-attach-${displayId}" type="button" title="Capture current frame and attach to next task">Attach</button>
+          <button class="annotate-btn" id="ds-annotate-${displayId}" type="button" aria-pressed="false" title="Freeze current frame and annotate it">&#9998; Annotate</button>
+          <button class="callout-btn" id="ds-callout-${displayId}" type="button" aria-pressed="false" disabled title="Call out a region: arm, then drag a rectangle on the frame to attach it to the next task (needs input control)">&#x2316; Callout</button>
+          <button class="record-btn" id="ds-record-${displayId}" type="button" aria-pressed="false" title="Record this display (ffmpeg)">Record</button>
+          <button class="display-fullscreen-btn" id="ds-fullscreen-${displayId}" type="button" aria-label="Open display full screen" title="Full screen">&#x26F6;</button>
+          <button class="display-close-btn" id="ds-close-${displayId}" type="button" aria-label="Close this display stream" title="Close this display stream">&times;</button>
+          <button class="take-control-btn" id="ds-take-${displayId}" type="button" title="Take interactive control of this display (keyboard and mouse)">Take control</button>
+          <button class="release-control-btn" id="ds-release-${displayId}" type="button" style="display:none" title="Release control and return display to view-only mode">Release</button>
+          <button class="delete-recording-btn" id="ds-delete-rec-${displayId}" type="button" style="display:none" title="Delete recording files for this display">Delete</button>
+          <span class="stream-frame-id" id="ds-frame-${displayId}" style="display:none;font-size:10px;color:var(--overlay0)"></span>
+        </div>
       </div>
       <div class="display-canvas" id="display-canvas-${displayId}"></div>`;
+    this.el.setAttribute('aria-label', label);
+    const labelEl = this.el.querySelector('.display-label');
+    if (labelEl) labelEl.textContent = label;
+    const toolbarEl = this.el.querySelector('.display-toolbar');
+    if (toolbarEl) toolbarEl.setAttribute('aria-label', `${label} controls`);
     this.statusEl = this.el.querySelector(`#ds-status-${displayId}`);
     this.visibilityEl = this.el.querySelector(`#ds-visibility-${displayId}`);
     this.authorityEl = this.el.querySelector(`#ds-authority-${displayId}`);
@@ -62245,6 +62747,8 @@ class DisplaySlot {
     this.videoEl.muted = true;
     this.videoEl.style.width = '100%';
     this.videoEl.style.backgroundColor = '#000';
+    this.videoEl.setAttribute('aria-label', `Live view of ${label}`);
+    this.videoEl.setAttribute('aria-describedby', `ds-status-${displayId} ds-authority-${displayId}`);
     this.canvasEl.appendChild(this.videoEl);
     // In-stage connection status overlay (time-to-first-frame): staged
     // copy while negotiating ("Negotiating…" → "Waiting for first
@@ -62262,7 +62766,14 @@ class DisplaySlot {
     this.metricsEl = document.createElement('div');
     this.metricsEl.className = 'display-live-metrics';
     this.metricsEl.style.display = 'none';
+    this.metricsEl.setAttribute('aria-hidden', 'true');
     this.canvasEl.appendChild(this.metricsEl);
+    this.controlBannerEl = document.createElement('div');
+    this.controlBannerEl.className = 'display-control-banner';
+    this.controlBannerEl.setAttribute('role', 'status');
+    this.controlBannerEl.setAttribute('aria-live', 'polite');
+    this.controlBannerEl.textContent = 'You have control — keyboard and pointer input drive this display.';
+    this.canvasEl.appendChild(this.controlBannerEl);
     const rerenderSharedFocus = () => {
       if (!sharedViewState.visible) return;
       if (sharedViewState.displayId !== null && Number(this.displayId) !== sharedViewState.displayId) return;
@@ -62316,6 +62827,8 @@ class DisplaySlot {
     if (this.fullscreenBtn) {
       this.fullscreenBtn.innerHTML = want ? '&times;' : '&#x26F6;';
       this.fullscreenBtn.title = want ? 'Exit full screen' : 'Full screen';
+      this.fullscreenBtn.setAttribute('aria-label', want ? 'Exit display full screen' : 'Open display full screen');
+      this.fullscreenBtn.setAttribute('aria-pressed', want ? 'true' : 'false');
     }
   }
 
@@ -62810,7 +63323,8 @@ class DisplaySlot {
     if (this.takeBtn) {
       this.takeBtn.disabled = pending;
       this.takeBtn.classList.toggle('is-pending', pending);
-      this.takeBtn.textContent = pending ? 'Requesting…' : 'Take Control';
+      this.takeBtn.textContent = pending ? 'Requesting…' : 'Take control';
+      this.takeBtn.setAttribute('aria-busy', pending ? 'true' : 'false');
     }
     if (pending) {
       this._takePendingTimer = window.setTimeout(() => {
@@ -62837,6 +63351,7 @@ class DisplaySlot {
   _enterInteractive() {
     if (this.interactive) return;
     this.interactive = true;
+    this.el.classList.add('is-interactive');
     this.noteInput.style.display = '';
     const res = this.width > 0 ? ` ${this.width}x${this.height}` : '';
     this.statusEl.textContent = `Interactive${res}`;
@@ -62942,6 +63457,7 @@ class DisplaySlot {
   _exitInteractive(userInitiated) {
     if (!this.interactive) return;
     this.interactive = false;
+    this.el.classList.remove('is-interactive');
     // Item 3: flush synthetic keyups for every held key BEFORE the
     // listeners are removed. Server-driven demotion never fires blur, so
     // without this any held key (modifier or not) stays latched down on
@@ -62961,6 +63477,7 @@ class DisplaySlot {
       }
     }
     this._boundHandlers = {};
+    vid.removeAttribute('tabindex');
     const note = this.noteInput.value.trim() || undefined;
     this.noteInput.value = ''; this.noteInput.style.display = 'none';
     this.statusEl.textContent = this.connected ? 'Connected (view-only)' : 'Disconnected';
@@ -63070,6 +63587,7 @@ class DisplaySlot {
     if (this.streaming || !this.connected) return;
     this.streaming = true;
     this.streamBtn.classList.add('active');
+    this.streamBtn.setAttribute('aria-pressed', 'true');
     this.streamBtn.innerHTML = '&#x1F441; Streaming';
     this.frameIdEl.style.display = '';
     const streamName = 'display_' + this.displayId;
@@ -63121,6 +63639,7 @@ class DisplaySlot {
     this.streaming = false;
     if (this._streamIntervalId) { clearInterval(this._streamIntervalId); this._streamIntervalId = null; }
     this.streamBtn.classList.remove('active');
+    this.streamBtn.setAttribute('aria-pressed', 'false');
     this.streamBtn.innerHTML = '&#x1F441; Stream';
     this.frameIdEl.style.display = 'none';
     this.frameIdEl.textContent = '';
@@ -63134,6 +63653,7 @@ class DisplaySlot {
       this.recording = false;
       this.recordBtn.innerHTML = '&#x23FA; Record';
       this.recordBtn.classList.remove('active');
+      this.recordBtn.setAttribute('aria-pressed', 'false');
       this.deleteRecBtn.style.display = '';
     } else {
       dispatchDashboardActionMsg({ action: 'start_recording', stream_name: baseStream });
@@ -63141,6 +63661,7 @@ class DisplaySlot {
       this.recording = true;
       this.recordBtn.innerHTML = '&#x23F9; Stop';
       this.recordBtn.classList.add('active');
+      this.recordBtn.setAttribute('aria-pressed', 'true');
       this.deleteRecBtn.style.display = 'none';
     }
   }
@@ -63388,6 +63909,12 @@ function applySharedViewToSlot(slot) {
   if (sharedViewState.displayId !== null && Number(slot.displayId) !== sharedViewState.displayId) {
     return;
   }
+  // The Live workspace is a selected-display stage. Agent-requested
+  // shared views must foreground their real target rather than leaving
+  // the focus box mounted on a hidden slot.
+  if (typeof window.selectLiveDisplay === 'function') {
+    window.selectLiveDisplay(slot.displayId, { source: 'shared-view' });
+  }
   updateSharedViewBanner();
   slot.el.classList.add('shared-view-active');
   renderSharedViewFocus(slot, sharedViewState.region, sharedViewState.note);
@@ -63423,7 +63950,12 @@ function takeSharedViewInput() {
 }
 
 function handleSharedViewEvent(evt) {
-  const action = String(evt.action || 'show');
+  // Native shared_view historically emitted `input`; MCP already emits
+  // the presentation-level `input_request`. Canonicalize at the browser
+  // boundary so mixed-version daemons still expose the real Take input
+  // affordance without ever granting authority automatically.
+  const rawAction = String(evt.action || 'show');
+  const action = rawAction === 'input' ? 'input_request' : rawAction;
   if (action === 'hide') {
     hideSharedView();
     return;
@@ -63699,308 +64231,808 @@ function applyDisplayStripState() {
 }
 
 
-// ── ui-v2 Live-display right rail (design-overhaul P2) ─────────────────
-// Display-only mirror chrome, active only under the ?ui=v2 flag: renders
-// rail rows FROM existing state (displaySlots + slot DOM, the Station
-// peer-display chips, the sb-display-access grant chip) via
-// MutationObservers, and proxies every click to the existing controls.
-// It owns no state, sends no messages, and never touches the WebRTC
-// slots, the single-reparented <video> elements, or v1 markup. Honest
-// authority copy: taking control is last-take-wins displacement between
-// viewers (no request/approve ceremony), and "another viewer has input"
-// is a first-class rendered state.
+// ── Live display workspace ──────────────────────────────────────────────
+// The standalone CU concept is the presentation target; the production
+// displaySlots map remains the source of truth. This projection adds one
+// selected local stage, selected-slot authority controls, responsive rail
+// access, and a small feed of REAL browser-observed display lifecycle
+// changes. It never invents agent clicks, typed text, holder identities, or
+// display-scoped approvals: those do not exist in the current wire contract.
+//
+// Key safety rule: a hidden interactive slot would keep its document-level
+// paste handler. Selecting another display therefore releases the old slot
+// through DisplaySlot.releaseControl(), which flushes held keys before
+// releasing server authority. Live annotation/callout ownership is torn
+// down through the existing provider lifecycle before that slot is hidden.
 (() => {
   const tab = document.getElementById('tab-displays');
-  if (!tab) return;
-  const rail = document.createElement('aside');
-  rail.className = 'ui2-live-rail';
-  rail.id = 'ui2-live-rail';
-  rail.innerHTML = `
-    <section>
-      <div class="ui2-live-rail-eyebrow">Displays</div>
-      <div class="ui2-live-rail-list" id="ui2-live-displays-list"></div>
-    </section>
-    <section>
-      <div class="ui2-live-rail-eyebrow">Input authority</div>
-      <div id="ui2-live-authority-card"></div>
-    </section>
-    <section>
-      <div class="ui2-live-rail-eyebrow">Peer displays</div>
-      <div class="ui2-live-rail-list" id="ui2-live-peer-list"></div>
-    </section>
-    <section>
-      <div class="ui2-live-rail-eyebrow">Your screen</div>
-      <div id="ui2-live-yourscreen"></div>
-    </section>`;
-  tab.appendChild(rail);
-  const displaysList = rail.querySelector('#ui2-live-displays-list');
-  const authorityCard = rail.querySelector('#ui2-live-authority-card');
-  const peerList = rail.querySelector('#ui2-live-peer-list');
-  const yourScreen = rail.querySelector('#ui2-live-yourscreen');
-
-  const emptyHint = (text) => {
-    const div = document.createElement('div');
-    div.className = 'ui2-live-rail-empty';
-    div.textContent = text;
-    return div;
-  };
-
-  function renderDisplayRows() {
-    displaysList.textContent = '';
-    const slots = Array.from(displaySlots.values());
-    if (!slots.length) {
-      displaysList.appendChild(emptyHint('No displays active. They appear here when the agent launches a GUI or you share your screen.'));
-      return;
-    }
-    for (const slot of slots) {
-      const row = document.createElement('button');
-      row.type = 'button';
-      const err = slot.statusEl && slot.statusEl.classList.contains('error');
-      row.className = 'ui2-live-row' + (slot.connected ? ' ok viewing' : (err ? ' err' : ''));
-      const dot = document.createElement('span');
-      dot.className = 'ui2-live-row-dot';
-      const main = document.createElement('span');
-      main.className = 'ui2-live-row-main';
-      const title = document.createElement('span');
-      title.className = 'ui2-live-row-title';
-      const labelEl = slot.el && slot.el.querySelector('.display-label');
-      title.textContent = (labelEl && labelEl.textContent) || `Display ${slot.displayId}`;
-      const meta = document.createElement('span');
-      meta.className = 'ui2-live-row-meta';
-      meta.textContent = (slot.statusEl && slot.statusEl.textContent) || '';
-      main.appendChild(title);
-      main.appendChild(meta);
-      row.appendChild(dot);
-      row.appendChild(main);
-      if (displayAgentVisibility.get(Number(slot.displayId)) === false) {
-        const tag = document.createElement('span');
-        tag.className = 'ui2-live-row-tag';
-        tag.textContent = 'PRIVATE';
-        tag.title = 'Private view — the agent cannot see this display';
-        row.appendChild(tag);
-      }
-      if (slot.connected) {
-        const tag = document.createElement('span');
-        tag.className = 'ui2-live-row-tag';
-        tag.textContent = 'VIEWING';
-        row.appendChild(tag);
-      }
-      row.title = 'Scroll this display into view';
-      row.addEventListener('click', () => {
-        if (slot.el && slot.el.isConnected) slot.el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-      });
-      displaysList.appendChild(row);
-    }
-  }
+  const container = document.getElementById('displays-container');
+  const rail = document.getElementById('ui2-live-rail');
+  const displaysList = document.getElementById('ui2-live-displays-list');
+  const authorityCard = document.getElementById('ui2-live-authority-card');
+  const activityList = document.getElementById('ui2-live-activity');
+  const peerList = document.getElementById('ui2-live-peer-list');
+  const yourScreen = document.getElementById('ui2-live-yourscreen');
+  const mobileSummary = document.getElementById('ui2-live-mobile-summary');
+  const railToggle = document.getElementById('ui2-live-rail-toggle');
+  const railClose = document.getElementById('ui2-live-rail-close');
+  const railScrim = document.getElementById('ui2-live-rail-scrim');
+  if (!tab || !container || !rail || !displaysList || !authorityCard ||
+      !activityList || !peerList || !yourScreen) return;
 
   const AUTH_LABEL = {
     you: 'you',
     other: 'another viewer',
-    unclaimed: 'shared',
-    unknown: 'view-only',
+    unclaimed: 'available',
+    unknown: 'connecting',
   };
-  function renderAuthorityCard() {
-    authorityCard.textContent = '';
-    const card = document.createElement('div');
-    card.className = 'ui2-live-card';
-    const title = document.createElement('div');
-    title.className = 'ui2-live-card-title';
-    const sub = document.createElement('div');
-    sub.className = 'ui2-live-card-sub';
-    const slots = Array.from(displaySlots.values());
-    if (!slots.length) {
-      title.textContent = 'No live display';
-      sub.textContent = 'Input authority appears here once a display is streaming.';
-      card.appendChild(title);
-      card.appendChild(sub);
-      authorityCard.appendChild(card);
-      return;
-    }
-    const anyYou = slots.some(s => s.authorityState === 'you');
-    const anyOther = slots.some(s => s.authorityState === 'other');
-    title.textContent = anyYou
-      ? 'You have input control'
-      : anyOther
-        ? 'Another viewer has input'
-        : 'You have view-only';
-    sub.textContent = 'Take control forwards your mouse and keyboard to the display. It displaces whoever holds input — last take wins, there is no approval step. Release hands the display back.';
-    card.appendChild(title);
-    card.appendChild(sub);
-    for (const slot of slots) {
-      const row = document.createElement('div');
-      row.className = 'ui2-live-auth-row';
-      const name = document.createElement('span');
-      name.className = 'ui2-live-auth-name';
-      const labelEl = slot.el && slot.el.querySelector('.display-label');
-      name.textContent = (labelEl && labelEl.textContent) || `Display ${slot.displayId}`;
-      const pill = document.createElement('span');
-      const st = slot.authorityState || 'unknown';
-      pill.className = 'ui2-live-state-pill' + (st === 'you' ? ' you' : st === 'other' ? ' other' : '');
-      pill.textContent = AUTH_LABEL[st] || AUTH_LABEL.unknown;
-      row.appendChild(name);
-      row.appendChild(pill);
-      card.appendChild(row);
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      if (st === 'you') {
-        btn.className = 'ui2-live-card-btn release';
-        btn.textContent = 'Release control';
-        btn.title = 'Release input and return this display to view-only';
-        btn.addEventListener('click', () => {
-          const b = document.getElementById(`ds-release-${slot.displayId}`);
-          if (b) b.click();
-        });
-      } else {
-        btn.className = 'ui2-live-card-btn';
-        btn.textContent = st === 'other' ? 'Take control anyway' : 'Take control';
-        btn.title = st === 'other'
-          ? 'Takes input immediately and displaces the current viewer'
-          : 'Take interactive control of this display (keyboard and mouse)';
-        btn.addEventListener('click', () => {
-          const b = document.getElementById(`ds-take-${slot.displayId}`);
-          if (b) b.click();
-        });
-      }
-      card.appendChild(btn);
-    }
-    authorityCard.appendChild(card);
+  const displayRows = new Map();
+  const peerRows = new Map();
+  const peerSources = new Map();
+  const slotSnapshots = new Map();
+  const activityByDisplay = new Map();
+  const drawerMedia = window.matchMedia('(max-width: 1279px)');
+  let selectedDisplayId = null;
+  let railOpen = false;
+  let railRaf = 0;
+  let activitySeq = 0;
+  let lastActivitySignature = '';
+  let lastAuthoritySignature = '';
+  let lastScreenSignature = '';
+
+  function slotLabel(slot) {
+    const labelEl = slot && slot.el && slot.el.querySelector('.display-label');
+    return (labelEl && labelEl.textContent) || displayLabel(slot && slot.displayId);
   }
 
-  function renderPeerRows() {
-    peerList.textContent = '';
-    const chips = document.querySelectorAll('#station-peer-chips .station-peer-chip');
-    if (!chips.length) {
-      peerList.appendChild(emptyHint('No peer displays advertised. Paired daemons that share a display appear here.'));
+  function selectedSlot() {
+    return selectedDisplayId === null ? null : displaySlots.get(selectedDisplayId) || null;
+  }
+
+  function emptyHint(textValue) {
+    const div = document.createElement('div');
+    div.className = 'ui2-live-rail-empty';
+    div.textContent = textValue;
+    return div;
+  }
+
+  function setSelectedProjection() {
+    const slots = Array.from(displaySlots.values());
+    const selectedExists = selectedDisplayId !== null && displaySlots.has(selectedDisplayId);
+    container.classList.toggle('ui2-live-single-stage', slots.length > 0);
+    container.dataset.activeDisplayId = selectedExists ? String(selectedDisplayId) : '';
+    for (const slot of slots) {
+      const active = selectedExists && Number(slot.displayId) === selectedDisplayId;
+      slot.el.classList.toggle('ui2-live-selected', active);
+      slot.el.classList.toggle('ui2-live-inactive', !active);
+      slot.el.setAttribute('aria-hidden', active ? 'false' : 'true');
+      slot.el.inert = !active;
+    }
+  }
+
+  function teardownSelectedSurface(slot) {
+    if (!slot) return;
+    // releaseControl is the only safe ordering: held-key keyups are sent
+    // before the server-side authority release closes the input gate.
+    if (slot.interactive) slot.releaseControl();
+    if (typeof teardownLiveSurfaceForOwner === 'function') {
+      teardownLiveSurfaceForOwner(slot);
+    }
+  }
+
+  function selectLiveDisplay(displayId, options) {
+    const opts = options || {};
+    const id = Number(displayId);
+    const next = Number.isFinite(id) ? displaySlots.get(id) : null;
+    if (!next) return false;
+    if (selectedDisplayId !== id) {
+      teardownSelectedSurface(selectedSlot());
+      selectedDisplayId = id;
+    }
+    setSelectedProjection();
+    scheduleWorkspace();
+    if (opts.focusStage && next.el && next.el.isConnected) {
+      requestAnimationFrame(() => {
+        try { next.el.scrollIntoView({ block: 'nearest', inline: 'nearest' }); } catch (_) {}
+      });
+    }
+    return true;
+  }
+  window.selectLiveDisplay = selectLiveDisplay;
+
+  function reconcileSelectedDisplay(slots) {
+    const shared = slots.find(slot => slot.el && slot.el.classList.contains('shared-view-active'));
+    if (shared && Number(shared.displayId) !== selectedDisplayId) {
+      selectLiveDisplay(shared.displayId, { source: 'shared-view' });
       return;
     }
-    chips.forEach((chip) => {
-      const row = document.createElement('button');
-      row.type = 'button';
-      row.className = 'ui2-live-row' + (chip.disabled ? '' : ' ok');
-      row.disabled = chip.disabled;
-      row.title = chip.title || '';
-      const dot = document.createElement('span');
-      dot.className = 'ui2-live-row-dot';
-      const main = document.createElement('span');
-      main.className = 'ui2-live-row-main';
-      const title = document.createElement('span');
-      title.className = 'ui2-live-row-title';
-      title.textContent = chip.textContent || '';
-      const meta = document.createElement('span');
-      meta.className = 'ui2-live-row-meta';
-      meta.textContent = chip.disabled ? 'peer offline' : 'peer · view display';
-      main.appendChild(title);
-      main.appendChild(meta);
-      const chev = document.createElement('span');
-      chev.className = 'ui2-live-row-chev';
-      chev.textContent = '›';
-      row.appendChild(dot);
-      row.appendChild(main);
-      row.appendChild(chev);
-      row.addEventListener('click', () => chip.click());
-      peerList.appendChild(row);
+    if (selectedDisplayId !== null && displaySlots.has(selectedDisplayId)) {
+      setSelectedProjection();
+      return;
+    }
+    selectedDisplayId = slots.length ? Number(slots[0].displayId) : null;
+    setSelectedProjection();
+  }
+
+  function createDisplayRow(id) {
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = 'ui2-live-row';
+    row.dataset.displayId = String(id);
+    row.innerHTML =
+      '<span class="ui2-live-row-dot" aria-hidden="true"></span>' +
+      '<span class="ui2-live-row-main">' +
+        '<span class="ui2-live-row-title"></span>' +
+        '<span class="ui2-live-row-meta"></span>' +
+      '</span>' +
+      '<span class="ui2-live-row-tags" aria-hidden="true">' +
+        '<span class="ui2-live-row-tag ui2-live-row-privacy"></span>' +
+        '<span class="ui2-live-row-tag ui2-live-row-current"></span>' +
+      '</span>';
+    row.addEventListener('click', () => {
+      selectLiveDisplay(id, { focusStage: true, source: 'rail' });
+      if (drawerMedia.matches) setRailOpen(false, true);
+    });
+    return {
+      row,
+      title: row.querySelector('.ui2-live-row-title'),
+      meta: row.querySelector('.ui2-live-row-meta'),
+      privacy: row.querySelector('.ui2-live-row-privacy'),
+      current: row.querySelector('.ui2-live-row-current'),
+    };
+  }
+
+  function orderRows(parent, records) {
+    records.forEach((record, index) => {
+      const current = parent.children[index] || null;
+      if (current !== record.row) parent.insertBefore(record.row, current);
     });
   }
 
-  function renderYourScreen() {
-    yourScreen.textContent = '';
-    const card = document.createElement('div');
-    card.className = 'ui2-live-card';
-    const head = document.createElement('div');
-    head.style.display = 'flex';
-    head.style.alignItems = 'center';
-    head.style.gap = '8px';
-    const title = document.createElement('div');
-    title.className = 'ui2-live-card-title';
-    title.style.flex = '1';
-    title.textContent = 'Your screen';
-    // Two distinct things can be active here, and the card never
-    // conflates them:
-    //  - a PRIVATE VIEW ("View this machine"): remote view/control of
-    //    this machine from the dashboard; the agent cannot see it;
-    //  - an AGENT SHARE ("Share with agent"): the screen is visible to
-    //    the agent for computer-use tasks.
-    // (Streaming frames to the live presence/voice model is a third,
-    // separate control -- the Stream button on the display tile.)
-    const granted = userDisplayGranted;
-    const shared = granted && userDisplayAgentVisible;
-    const pill = document.createElement('span');
-    pill.className = 'ui2-live-state-pill'
-      + (shared ? ' other' : granted ? ' you' : '');
-    pill.textContent = shared ? 'agent can see this' : granted ? 'private view' : 'off';
-    head.appendChild(title);
-    head.appendChild(pill);
-    const sub = document.createElement('div');
-    sub.className = 'ui2-live-card-sub';
-    sub.textContent = shared
-      ? 'The agent can see and drive this screen for computer-use tasks until you revoke access.'
-      : granted
-        ? 'Streaming to your dashboard only. The agent cannot see this display.'
-        : 'View and control this machine’s display from here, or share it with the agent for computer-use tasks. You choose the display and can stop at any time.';
-    card.appendChild(head);
-    card.appendChild(sub);
-    const addBtn = (label, cls, title, onClick) => {
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.className = 'ui2-live-card-btn ' + cls;
-      btn.textContent = label;
-      btn.title = title;
-      btn.addEventListener('click', (e) => {
-        e.stopPropagation();
-        onClick();
-      });
-      card.appendChild(btn);
-      return btn;
-    };
-    if (!granted) {
-      // Primary: private remote view. Secondary: the agent share.
-      addBtn('View this machine', 'secondary',
-        'Watch and control this machine’s display from the dashboard. Private: the agent cannot see it.',
-        () => { if (typeof startUserDisplayGrantFlow === 'function') startUserDisplayGrantFlow('view'); });
-      addBtn('Share with agent…', 'secondary',
-        'Make this screen visible to the agent for computer-use tasks. Revocable at any time.',
-        () => { if (typeof startUserDisplayGrantFlow === 'function') startUserDisplayGrantFlow('share'); });
-    } else if (!shared) {
-      addBtn('Stop viewing', 'danger',
-        'Close the private view of this machine.',
-        () => { if (typeof revokeUserDisplayNow === 'function') revokeUserDisplayNow(); });
-      addBtn('Share with agent', 'secondary',
-        'Upgrade this private view: make the display visible to the agent for computer-use tasks.',
-        () => { if (typeof shareUserDisplayWithAgent === 'function') shareUserDisplayWithAgent(); });
-    } else {
-      addBtn('Revoke access', 'danger',
-        'Take the display away from the agent and stop streaming it.',
-        () => { if (typeof revokeUserDisplayNow === 'function') revokeUserDisplayNow(); });
+  function syncDisplayRows(slots) {
+    const liveIds = new Set(slots.map(slot => Number(slot.displayId)));
+    for (const [id, record] of displayRows) {
+      if (liveIds.has(id)) continue;
+      record.row.remove();
+      displayRows.delete(id);
+      slotSnapshots.delete(id);
+      activityByDisplay.delete(id);
     }
-    yourScreen.appendChild(card);
+
+    let empty = displaysList.querySelector('.ui2-live-rail-empty');
+    if (!slots.length) {
+      if (!empty) {
+        empty = emptyHint('No displays active. Agent workspaces and screens you choose to view appear here.');
+        displaysList.appendChild(empty);
+      }
+      return;
+    }
+    if (empty) empty.remove();
+
+    const ordered = [];
+    for (const slot of slots) {
+      const id = Number(slot.displayId);
+      let record = displayRows.get(id);
+      if (!record) {
+        record = createDisplayRow(id);
+        displayRows.set(id, record);
+      }
+      const label = slotLabel(slot);
+      const state = slot.authorityState || 'unknown';
+      const status = (slot.statusEl && slot.statusEl.textContent.trim()) || 'Connecting';
+      const error = Boolean(slot.statusEl && slot.statusEl.classList.contains('error'));
+      const active = id === selectedDisplayId;
+      const privateView = displayAgentVisibility.get(id) === false;
+
+      record.row.classList.toggle('ok', Boolean(slot.connected));
+      record.row.classList.toggle('err', error);
+      record.row.classList.toggle('viewing', active);
+      record.row.classList.toggle('selected', active);
+      record.row.setAttribute('aria-pressed', active ? 'true' : 'false');
+      if (active) record.row.setAttribute('aria-current', 'true');
+      else record.row.removeAttribute('aria-current');
+      record.row.title = active ? label + ' is shown on the stage' : 'Show ' + label + ' on the stage';
+      record.row.setAttribute('aria-label',
+        label + ', ' + status + ', input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown));
+      record.title.textContent = label;
+      record.meta.textContent = status + ' · input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown);
+      record.privacy.textContent = privateView ? 'PRIVATE' : '';
+      record.privacy.title = privateView ? 'The agent cannot see this private view' : '';
+      record.current.textContent = active ? 'VIEWING' : (slot.connected ? 'LIVE' : '');
+      ordered.push(record);
+    }
+    orderRows(displaysList, ordered);
   }
 
-  let railRaf = 0;
-  function renderRail() {
-    railRaf = 0;
-    renderDisplayRows();
-    renderAuthorityCard();
-    renderPeerRows();
-    renderYourScreen();
+  authorityCard.innerHTML =
+    '<div class="ui2-live-card ui2-live-authority-card">' +
+      '<div class="ui2-live-authority-head">' +
+        '<span class="ui2-live-authority-dot" aria-hidden="true"></span>' +
+        '<div class="ui2-live-authority-copy">' +
+          '<div class="ui2-live-card-title"></div>' +
+          '<div class="ui2-live-card-sub"></div>' +
+        '</div>' +
+        '<span class="ui2-live-state-pill"></span>' +
+      '</div>' +
+      '<div class="ui2-live-auth-row">' +
+        '<span class="ui2-live-auth-name"></span>' +
+      '</div>' +
+      '<button class="ui2-live-card-btn" type="button"></button>' +
+    '</div>';
+  const authorityBox = authorityCard.querySelector('.ui2-live-card');
+  const authorityTitle = authorityCard.querySelector('.ui2-live-card-title');
+  const authoritySub = authorityCard.querySelector('.ui2-live-card-sub');
+  const authorityPill = authorityCard.querySelector('.ui2-live-state-pill');
+  const authorityName = authorityCard.querySelector('.ui2-live-auth-name');
+  const authorityButton = authorityCard.querySelector('.ui2-live-card-btn');
+  authorityButton.addEventListener('click', () => {
+    const slot = selectedSlot();
+    if (!slot) return;
+    if (slot.authorityState === 'you' && !slot.interactive) {
+      // Selection-away releases bound input immediately. During the
+      // authority round-trip (or after a failed release), let the holder
+      // safely re-bind listeners instead of trapping it behind a Release-
+      // only toolbar state.
+      slot.takeControl();
+      return;
+    }
+    const source = slot.authorityState === 'you' ? slot.releaseBtn : slot.takeBtn;
+    if (source && !source.disabled) source.click();
+  });
+
+  function syncAuthorityCard() {
+    const slot = selectedSlot();
+    const signature = slot
+      ? [
+          selectedDisplayId,
+          slotLabel(slot),
+          slot.authorityState || 'unknown',
+          Boolean(slot.interactive),
+          Boolean(slot._takeControlPending),
+          Boolean(slot.pc),
+        ].join('|')
+      : 'none';
+    if (signature === lastAuthoritySignature) return;
+    lastAuthoritySignature = signature;
+    authorityBox.className = 'ui2-live-card ui2-live-authority-card';
+    authorityPill.className = 'ui2-live-state-pill';
+    authorityButton.className = 'ui2-live-card-btn';
+    if (!slot) {
+      authorityTitle.textContent = 'No live display';
+      authoritySub.textContent = 'Choose or share a display to see and control it here.';
+      authorityPill.textContent = 'offline';
+      authorityName.textContent = 'Input is scoped to one display at a time.';
+      authorityButton.hidden = true;
+      return;
+    }
+
+    const state = slot.authorityState || 'unknown';
+    const pending = Boolean(slot._takeControlPending);
+    authorityName.textContent = slotLabel(slot);
+    authorityButton.hidden = false;
+    authorityButton.disabled = !slot.pc || pending;
+    authorityButton.setAttribute('aria-busy', pending ? 'true' : 'false');
+    authorityBox.classList.add('state-' + state);
+    if (state === 'you') {
+      authorityTitle.textContent = slot.interactive
+        ? 'You are driving this display'
+        : 'You hold input authority';
+      authoritySub.textContent =
+        'Keyboard, pointer, and paste input are scoped to this display. Release it before handing control back.';
+      authorityPill.classList.add('you');
+      authorityPill.textContent = 'you';
+      if (slot.interactive) {
+        authorityButton.classList.add('release');
+        authorityButton.textContent = 'Release control';
+        authorityButton.title = 'Release input and return this display to view-only';
+      } else {
+        authorityButton.textContent = 'Resume control';
+        authorityButton.title = 'Bind keyboard, pointer, and paste input to this display again';
+      }
+    } else if (state === 'other') {
+      authorityTitle.textContent = 'Another viewer has input';
+      authoritySub.textContent =
+        'Taking control is immediate and displaces the current viewer. Last take wins; there is no approval step.';
+      authorityPill.classList.add('other');
+      authorityPill.textContent = 'another viewer';
+      authorityButton.textContent = pending ? 'Requesting…' : 'Take control anyway';
+      authorityButton.title = 'Take input immediately and displace the current viewer';
+    } else if (state === 'unclaimed') {
+      authorityTitle.textContent = 'Input is available';
+      authoritySub.textContent =
+        'No dashboard viewer holds exclusive input. Take control to bind keyboard, pointer, and paste input here.';
+      authorityPill.textContent = 'available';
+      authorityButton.textContent = pending ? 'Requesting…' : 'Take control';
+      authorityButton.title = 'Take interactive control of this display';
+    } else {
+      authorityTitle.textContent = 'View only while input connects';
+      authoritySub.textContent =
+        'The stream can be watched now. Input controls become available when the authority state arrives.';
+      authorityPill.textContent = 'connecting';
+      authorityButton.textContent = pending ? 'Requesting…' : 'Take control';
+      authorityButton.title = 'Input authority is not available yet';
+    }
   }
-  function scheduleRail() {
-    if (railRaf) return;
-    railRaf = requestAnimationFrame(renderRail);
+
+  function visibilityMode(id) {
+    const visible = displayAgentVisibility.get(id);
+    if (visible === false) return 'private';
+    if (visible === true && userDisplayIds.has(id)) return 'agent';
+    return 'workspace';
   }
-  const observe = (el, opts) => {
-    if (!el) return;
-    new MutationObserver(scheduleRail).observe(el, opts);
+
+  function snapshotSlot(slot) {
+    const statusEl = slot.statusEl;
+    const mode = slot.interactive
+      ? 'interactive'
+      : slot.connected
+        ? 'connected'
+        : statusEl && statusEl.classList.contains('error')
+          ? 'error'
+          : statusEl && statusEl.classList.contains('warn')
+            ? 'warn'
+            : 'connecting';
+    return {
+      mode,
+      authority: slot.authorityState || 'unknown',
+      streaming: Boolean(slot.streaming),
+      recording: Boolean(slot.recording),
+      visibility: visibilityMode(Number(slot.displayId)),
+      shared: Boolean(slot.el && slot.el.classList.contains('shared-view-active')),
+      annotating: Boolean(slot.annotateBtn && slot.annotateBtn.classList.contains('active')),
+      callout: Boolean(slot.calloutBtn && slot.calloutBtn.getAttribute('aria-pressed') === 'true'),
+    };
+  }
+
+  function addDisplayActivity(displayId, kind, textValue) {
+    const id = Number(displayId);
+    const entries = activityByDisplay.get(id) || [];
+    const last = entries[entries.length - 1];
+    if (last && last.kind === kind && last.text === textValue) return;
+    entries.push({
+      seq: ++activitySeq,
+      kind,
+      text: textValue,
+      at: new Date(),
+    });
+    if (entries.length > 10) entries.splice(0, entries.length - 10);
+    activityByDisplay.set(id, entries);
+  }
+
+  function captureSlotActivity(slot) {
+    const id = Number(slot.displayId);
+    const next = snapshotSlot(slot);
+    const prev = slotSnapshots.get(id);
+    if (!prev) {
+      addDisplayActivity(id, 'neutral', 'Display became available');
+      if (next.mode === 'connected') addDisplayActivity(id, 'live', 'Live stream connected');
+      else if (next.mode === 'interactive') addDisplayActivity(id, 'control', 'Interactive input is active');
+      else if (next.mode === 'error') addDisplayActivity(id, 'error', 'The stream needs attention');
+      if (next.visibility === 'private') addDisplayActivity(id, 'private', 'Private dashboard view started');
+      if (next.visibility === 'agent') addDisplayActivity(id, 'share', 'Display shared with the agent');
+      if (next.authority === 'you') addDisplayActivity(id, 'control', 'This dashboard holds input authority');
+      if (next.authority === 'other') addDisplayActivity(id, 'attention', 'Another viewer holds input authority');
+      if (next.shared) addDisplayActivity(id, 'focus', 'Agent shared this display with you');
+      slotSnapshots.set(id, next);
+      return;
+    }
+
+    if (prev.mode !== next.mode) {
+      if (next.mode === 'connected') addDisplayActivity(id, 'live', 'Live stream connected');
+      else if (next.mode === 'interactive') addDisplayActivity(id, 'control', 'Interactive input is active');
+      else if (next.mode === 'error') addDisplayActivity(id, 'error', 'The stream needs attention');
+      else if (next.mode === 'warn') addDisplayActivity(id, 'attention', 'The stream is reconnecting');
+      else addDisplayActivity(id, 'neutral', 'Connecting to the display');
+    }
+    if (prev.authority !== next.authority) {
+      if (next.authority === 'you') addDisplayActivity(id, 'control', 'You took input control');
+      else if (next.authority === 'other') addDisplayActivity(id, 'attention', 'Another viewer took input control');
+      else if (next.authority === 'unclaimed') addDisplayActivity(id, 'neutral', 'Input control was released');
+      else addDisplayActivity(id, 'neutral', 'Input authority is reconnecting');
+    }
+    if (prev.streaming !== next.streaming) {
+      addDisplayActivity(id, next.streaming ? 'share' : 'neutral',
+        next.streaming ? 'Presence stream started' : 'Presence stream stopped');
+    }
+    if (prev.recording !== next.recording) {
+      addDisplayActivity(id, next.recording ? 'recording' : 'neutral',
+        next.recording ? 'Recording started' : 'Recording stopped');
+    }
+    if (prev.visibility !== next.visibility) {
+      if (next.visibility === 'private') addDisplayActivity(id, 'private', 'Display changed to a private view');
+      else if (next.visibility === 'agent') addDisplayActivity(id, 'share', 'Display shared with the agent');
+      else addDisplayActivity(id, 'neutral', 'Agent display workspace active');
+    }
+    if (prev.shared !== next.shared) {
+      addDisplayActivity(id, next.shared ? 'focus' : 'neutral',
+        next.shared ? 'Agent shared this display with you' : 'Shared view ended');
+    }
+    if (prev.annotating !== next.annotating) {
+      addDisplayActivity(id, next.annotating ? 'focus' : 'neutral',
+        next.annotating ? 'Annotation editor opened' : 'Annotation editor closed');
+    }
+    if (prev.callout !== next.callout) {
+      addDisplayActivity(id, next.callout ? 'focus' : 'neutral',
+        next.callout ? 'Region callout armed' : 'Region callout cleared');
+    }
+    slotSnapshots.set(id, next);
+  }
+
+  function syncActivityList() {
+    const entries = selectedDisplayId === null
+      ? []
+      : activityByDisplay.get(selectedDisplayId) || [];
+    const signature = String(selectedDisplayId) + ':' +
+      entries.map(entry => String(entry.seq)).join(',');
+    if (signature === lastActivitySignature) return;
+    lastActivitySignature = signature;
+    activityList.replaceChildren();
+    if (!entries.length) {
+      activityList.appendChild(emptyHint(
+        selectedDisplayId === null
+          ? 'Select a display to see its connection, authority, sharing, and recording events.'
+          : 'Display events will appear here as its real state changes.'));
+      return;
+    }
+
+    for (const entry of entries.slice().reverse()) {
+      const row = document.createElement('div');
+      row.className = 'ui2-live-activity-row kind-' + entry.kind;
+      const dot = document.createElement('span');
+      dot.className = 'ui2-live-activity-dot';
+      dot.setAttribute('aria-hidden', 'true');
+      const textEl = document.createElement('span');
+      textEl.className = 'ui2-live-activity-text';
+      textEl.textContent = entry.text;
+      const time = document.createElement('time');
+      time.className = 'ui2-live-activity-time';
+      time.dateTime = entry.at.toISOString();
+      time.textContent = entry.at.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      row.appendChild(dot);
+      row.appendChild(textEl);
+      row.appendChild(time);
+      activityList.appendChild(row);
+    }
+  }
+
+  yourScreen.innerHTML =
+    '<div class="ui2-live-card ui2-live-screen-card">' +
+      '<div class="ui2-live-screen-head">' +
+        '<div class="ui2-live-card-title">Your screen</div>' +
+        '<span class="ui2-live-state-pill"></span>' +
+      '</div>' +
+      '<div class="ui2-live-card-sub"></div>' +
+      '<div class="ui2-live-screen-actions">' +
+        '<button class="ui2-live-card-btn secondary" type="button"></button>' +
+        '<button class="ui2-live-card-btn secondary" type="button"></button>' +
+      '</div>' +
+    '</div>';
+  const screenPill = yourScreen.querySelector('.ui2-live-state-pill');
+  const screenSub = yourScreen.querySelector('.ui2-live-card-sub');
+  const screenButtons = Array.from(yourScreen.querySelectorAll('.ui2-live-card-btn'));
+
+  function runScreenAction(action) {
+    if (action === 'view' && typeof startUserDisplayGrantFlow === 'function') {
+      startUserDisplayGrantFlow('view');
+    } else if (action === 'share' && typeof startUserDisplayGrantFlow === 'function') {
+      startUserDisplayGrantFlow('share');
+    } else if (action === 'upgrade' && typeof shareUserDisplayWithAgent === 'function') {
+      shareUserDisplayWithAgent();
+    } else if (action === 'revoke' && typeof revokeUserDisplayNow === 'function') {
+      revokeUserDisplayNow();
+    }
+  }
+  screenButtons.forEach(button => {
+    button.addEventListener('click', event => {
+      event.stopPropagation();
+      runScreenAction(button.dataset.action || '');
+    });
+  });
+
+  function setScreenButton(button, config) {
+    if (!config) {
+      button.hidden = true;
+      button.dataset.action = '';
+      return;
+    }
+    button.hidden = false;
+    button.dataset.action = config.action;
+    button.textContent = config.label;
+    button.title = config.title;
+    button.className = 'ui2-live-card-btn ' + config.className;
+  }
+
+  function syncYourScreen() {
+    const granted = userDisplayGranted;
+    const shared = granted && userDisplayAgentVisible;
+    const signature = granted ? (shared ? 'agent' : 'private') : 'off';
+    if (signature === lastScreenSignature) return;
+    lastScreenSignature = signature;
+    screenPill.className = 'ui2-live-state-pill' + (shared ? ' other' : granted ? ' you' : '');
+    screenPill.textContent = shared ? 'agent can see this' : granted ? 'private view' : 'off';
+    if (!granted) {
+      screenSub.textContent =
+        'View this machine privately, or explicitly share a chosen screen with the agent for computer-use tasks.';
+      setScreenButton(screenButtons[0], {
+        action: 'view',
+        label: 'View this machine',
+        title: 'Private dashboard view. The agent cannot see this screen.',
+        className: 'secondary',
+      });
+      setScreenButton(screenButtons[1], {
+        action: 'share',
+        label: 'Share with agent…',
+        title: 'Choose a screen to share with the agent. Revocable at any time.',
+        className: 'secondary',
+      });
+    } else if (!shared) {
+      screenSub.textContent =
+        'This is a private dashboard view. The agent cannot enumerate, capture, or drive it.';
+      setScreenButton(screenButtons[0], {
+        action: 'revoke',
+        label: 'Stop viewing',
+        title: 'Close this private display view.',
+        className: 'danger',
+      });
+      setScreenButton(screenButtons[1], {
+        action: 'upgrade',
+        label: 'Share with agent',
+        title: 'Make this display visible to the agent for computer-use tasks.',
+        className: 'secondary',
+      });
+    } else {
+      screenSub.textContent =
+        'The agent can see and drive this screen for computer-use tasks until you revoke access.';
+      setScreenButton(screenButtons[0], {
+        action: 'revoke',
+        label: 'Revoke access',
+        title: 'Stop sharing this screen with the agent.',
+        className: 'danger',
+      });
+      setScreenButton(screenButtons[1], null);
+    }
+  }
+
+  function peerKey(chip, index) {
+    const host = chip.dataset.hostId || '';
+    const display = chip.dataset.displayId || '';
+    return host || display
+      ? host + ':' + display
+      : (chip.getAttribute('aria-label') || chip.textContent || String(index));
+  }
+
+  function createPeerRow(key) {
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = 'ui2-live-row';
+    row.innerHTML =
+      '<span class="ui2-live-row-dot" aria-hidden="true"></span>' +
+      '<span class="ui2-live-row-main">' +
+        '<span class="ui2-live-row-title"></span>' +
+        '<span class="ui2-live-row-meta">peer · opens in Station</span>' +
+      '</span>' +
+      '<span class="ui2-live-row-chev" aria-hidden="true">›</span>';
+    row.addEventListener('click', () => {
+      const chip = peerSources.get(key);
+      if (!chip || chip.disabled) return;
+      const hostId = chip.dataset.hostId || '';
+      const displayId = Number(chip.dataset.displayId || 0);
+      if (typeof routeTo === 'function') routeTo('station');
+      if (hostId && typeof stationOpenDisplay === 'function') {
+        stationOpenDisplay(hostId, displayId);
+      } else {
+        chip.click();
+      }
+    });
+    return {
+      row,
+      title: row.querySelector('.ui2-live-row-title'),
+    };
+  }
+
+  function syncPeerRows() {
+    const chips = Array.from(document.querySelectorAll('#station-peer-chips .station-peer-chip'));
+    peerSources.clear();
+    const liveKeys = new Set();
+    const ordered = [];
+    chips.forEach((chip, index) => {
+      const key = peerKey(chip, index);
+      liveKeys.add(key);
+      peerSources.set(key, chip);
+      let record = peerRows.get(key);
+      if (!record) {
+        record = createPeerRow(key);
+        peerRows.set(key, record);
+      }
+      record.row.disabled = chip.disabled;
+      record.row.classList.toggle('ok', !chip.disabled);
+      record.row.title = chip.disabled
+        ? (chip.title || 'Peer unavailable')
+        : (chip.title || 'Open this peer display in Station');
+      record.row.setAttribute('aria-label', chip.getAttribute('aria-label') || chip.textContent || 'Peer display');
+      record.title.textContent = chip.textContent || 'Peer display';
+      ordered.push(record);
+    });
+    for (const [key, record] of peerRows) {
+      if (liveKeys.has(key)) continue;
+      record.row.remove();
+      peerRows.delete(key);
+    }
+
+    let empty = peerList.querySelector('.ui2-live-rail-empty');
+    if (!ordered.length) {
+      if (!empty) {
+        empty = emptyHint('No peer displays advertised. Connected peers open in the Station workspace.');
+        peerList.appendChild(empty);
+      }
+      return;
+    }
+    if (empty) empty.remove();
+    orderRows(peerList, ordered);
+  }
+
+  function syncMobileSummary() {
+    if (!mobileSummary) return;
+    const slot = selectedSlot();
+    if (!slot) {
+      mobileSummary.textContent = 'No display selected';
+      return;
+    }
+    const state = slot.authorityState || 'unknown';
+    mobileSummary.textContent = slotLabel(slot) + ' · input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown);
+  }
+
+  function drawerFocusable() {
+    return Array.from(rail.querySelectorAll(
+      'button:not([disabled]):not([hidden]), input:not([disabled]):not([hidden]), select:not([disabled]):not([hidden]), [tabindex]:not([tabindex="-1"])'
+    )).filter(element => element.getClientRects().length > 0);
+  }
+
+  function syncDrawerState(restoreFocus) {
+    const drawer = drawerMedia.matches;
+    const visible = !drawer || railOpen;
+    tab.classList.toggle('ui2-live-rail-open', drawer && railOpen);
+    rail.inert = !visible;
+    if (visible) rail.removeAttribute('aria-hidden');
+    else rail.setAttribute('aria-hidden', 'true');
+    if (railToggle) railToggle.setAttribute('aria-expanded', drawer && railOpen ? 'true' : 'false');
+    if (railScrim) {
+      railScrim.tabIndex = drawer && railOpen ? 0 : -1;
+      railScrim.setAttribute('aria-hidden', drawer && railOpen ? 'false' : 'true');
+    }
+    if (restoreFocus && railToggle && drawer) railToggle.focus();
+  }
+
+  function setRailOpen(open, restoreFocus) {
+    railOpen = drawerMedia.matches && Boolean(open);
+    syncDrawerState(Boolean(restoreFocus));
+    if (railOpen) {
+      requestAnimationFrame(() => {
+        const focusable = drawerFocusable();
+        (railClose || focusable[0] || rail).focus();
+      });
+    }
+  }
+
+  if (railToggle) railToggle.addEventListener('click', () => setRailOpen(!railOpen, false));
+  if (railClose) railClose.addEventListener('click', () => setRailOpen(false, true));
+  if (railScrim) railScrim.addEventListener('click', () => setRailOpen(false, true));
+  rail.addEventListener('keydown', event => {
+    if (!drawerMedia.matches || !railOpen || event.key !== 'Tab') return;
+    const focusable = drawerFocusable();
+    if (!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  });
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape' && drawerMedia.matches && railOpen) {
+      event.preventDefault();
+      setRailOpen(false, true);
+    }
+  });
+  const onDrawerMediaChange = () => {
+    railOpen = false;
+    syncDrawerState(false);
   };
-  // Slots come and go / status text + authority chips restyle in place.
-  observe(document.getElementById('displays-container'),
-    { subtree: true, childList: true, attributes: true, attributeFilter: ['class', 'style'], characterData: true });
-  // Station peer chips re-render on peer_display_ready/removed.
-  observe(document.getElementById('station-peer-chips'),
-    { subtree: true, childList: true, attributes: true, attributeFilter: ['class', 'disabled', 'title'] });
-  // user_session grant chip flips text + .granted.
-  observe(document.getElementById('sb-display-access'),
-    { childList: true, attributes: true, attributeFilter: ['class'], characterData: true, subtree: true });
-  renderRail();
+  if (typeof drawerMedia.addEventListener === 'function') {
+    drawerMedia.addEventListener('change', onDrawerMediaChange);
+  } else if (typeof drawerMedia.addListener === 'function') {
+    drawerMedia.addListener(onDrawerMediaChange);
+  }
+
+  function renderWorkspace() {
+    railRaf = 0;
+    const slots = Array.from(displaySlots.values());
+    reconcileSelectedDisplay(slots);
+    for (const slot of slots) captureSlotActivity(slot);
+    syncDisplayRows(slots);
+    syncAuthorityCard();
+    syncActivityList();
+    syncPeerRows();
+    syncYourScreen();
+    syncMobileSummary();
+  }
+
+  function scheduleWorkspace() {
+    if (railRaf) return;
+    railRaf = requestAnimationFrame(renderWorkspace);
+  }
+
+  function observe(element, options) {
+    if (!element) return;
+    new MutationObserver(scheduleWorkspace).observe(element, options);
+  }
+  // The observer catches legacy direct DOM writes without rebuilding the
+  // rail. Keyed rows and stable authority/screen controls preserve focus;
+  // activity rendering is signature-gated, so the 3s metrics sampler is a
+  // no-op unless a real display state changed.
+  observe(container, {
+    subtree: true,
+    childList: true,
+    characterData: true,
+    attributes: true,
+    attributeFilter: ['class', 'style', 'aria-pressed', 'disabled'],
+  });
+  observe(document.getElementById('station-peer-chips'), {
+    subtree: true,
+    childList: true,
+    characterData: true,
+    attributes: true,
+    attributeFilter: ['class', 'disabled', 'title', 'aria-label', 'data-host-id', 'data-display-id'],
+  });
+  observe(document.getElementById('sb-display-access'), {
+    subtree: true,
+    childList: true,
+    characterData: true,
+    attributes: true,
+    attributeFilter: ['class'],
+  });
+
+  // Stable, side-effect-free browser QA surface. CDP cannot read the
+  // module-scoped displaySlots map directly, so dashboard acceptance
+  // probes use this documented window.qa convention.
+  window.qa = Object.assign(window.qa || {}, {
+    liveDisplay() {
+      return {
+        activeTab,
+        selectedDisplayId,
+        layout: drawerMedia.matches ? 'drawer' : 'rail',
+        railOpen: !drawerMedia.matches || railOpen,
+        userDisplayMode: userDisplayGranted
+          ? (userDisplayAgentVisible ? 'agent' : 'private')
+          : 'off',
+        slots: Array.from(displaySlots.values()).map(slot => {
+          const id = Number(slot.displayId);
+          return {
+            displayId: id,
+            selected: id === selectedDisplayId,
+            connected: Boolean(slot.connected),
+            firstFrameSeen: Boolean(slot._firstFrameSeen),
+            intrinsicWidth: Number(slot.videoEl && slot.videoEl.videoWidth) || 0,
+            intrinsicHeight: Number(slot.videoEl && slot.videoEl.videoHeight) || 0,
+            authorityState: slot.authorityState || 'unknown',
+            interactive: Boolean(slot.interactive),
+            agentVisible: displayAgentVisibility.has(id)
+              ? displayAgentVisibility.get(id)
+              : null,
+            streaming: Boolean(slot.streaming),
+            recording: Boolean(slot.recording),
+            activityCount: (activityByDisplay.get(id) || []).length,
+          };
+        }),
+      };
+    },
+  });
+
+  syncDrawerState(false);
+  renderWorkspace();
 })();
 /* ── static/app/46-recording-replay.js ── */
 // ── Recording Replay ──
@@ -65365,6 +66397,7 @@ function setLiveAnnotationButton(provider, active) {
     : null;
   if (!btn) return;
   btn.classList.toggle('active', !!active);
+  btn.setAttribute('aria-pressed', active ? 'true' : 'false');
   btn.innerHTML = active ? '&#x2715; Annotating' : '&#9998; Annotate';
   btn.title = active ? 'Exit live annotation' : 'Freeze current frame and annotate it';
 }
@@ -67633,7 +68666,6 @@ document.getElementById('recording-timeline').addEventListener('contextmenu', (e
     deleteClipAnnotationLayer(layerId);
   }
 });
-
 /* ── static/app/48-router-settings.js ── */
 // ── Tab Switching ──
 document.querySelectorAll('.tab-btn').forEach(btn => {
@@ -96453,6 +97485,7 @@ function updateDisplayMetrics(d) {
 // declared in fragment 32 next to the display maps: earlier fragments
 // render against them at load time.)
 let displayPickerVisible = false;
+let displayPickerReturnFocus = null;
 // Which action the open picker performs: 'share' (agent access) or
 // 'view' (private remote view; the agent cannot see the display).
 let displayPickerMode = 'share';
@@ -96461,15 +97494,30 @@ var cachedDisplays = null;
 function hideDisplayPicker() {
   const picker = document.getElementById('display-picker');
   picker.classList.remove('visible');
+  picker.setAttribute('aria-hidden', 'true');
   displayPickerVisible = false;
+  const returnFocus = displayPickerReturnFocus;
+  displayPickerReturnFocus = null;
+  if (returnFocus && returnFocus.isConnected && typeof returnFocus.focus === 'function') {
+    returnFocus.focus();
+  }
 }
 
 function showDisplayPicker(displays, mode) {
   displayPickerMode = mode === 'view' ? 'view' : 'share';
   const picker = document.getElementById('display-picker');
+  displayPickerReturnFocus = document.activeElement instanceof HTMLElement
+    ? document.activeElement
+    : null;
   picker.innerHTML = '';
+  picker.setAttribute('role', 'dialog');
+  picker.setAttribute('aria-modal', 'false');
+  picker.setAttribute('aria-label', displayPickerMode === 'view'
+    ? 'Choose a screen for your private dashboard view'
+    : 'Choose a screen to share with the agent');
   for (const d of displays) {
-    const item = document.createElement('div');
+    const item = document.createElement('button');
+    item.type = 'button';
     item.className = 'display-picker-item';
     const label = d.name + ' (' + d.width + 'x' + d.height + ')';
     item.textContent = label;
@@ -96495,7 +97543,8 @@ function showDisplayPicker(displays, mode) {
   if (displayPickerMode !== 'view' && virtualDisplaysAvailableNow()) {
     // Virtual displays are agent workspaces — offering one from the
     // private "View this machine" flow would conflate the two concepts.
-    const createItem = document.createElement('div');
+    const createItem = document.createElement('button');
+    createItem.type = 'button';
     createItem.className = 'display-picker-item dp-action';
     createItem.textContent = 'New virtual display';
     createItem.title = 'Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed.';
@@ -96532,7 +97581,9 @@ function showDisplayPicker(displays, mode) {
     }
   }
   picker.classList.add('visible');
+  picker.setAttribute('aria-hidden', 'false');
   displayPickerVisible = true;
+  requestAnimationFrame(() => picker.querySelector('.display-picker-item')?.focus());
 }
 
 // Keyless "new virtual display": the daemon launches an Xvfb and registers

--- a/static/app.html
+++ b/static/app.html
@@ -19017,6 +19017,30 @@ html.ui-v2[data-theme="light"] .session-window-id {
    Station peer chips, and the user-display grant without replacing focused
    controls on every metrics update. */
 
+/* Semantic ink is separate from tint RGB. The base design tokens work on
+   dark surfaces; light mode needs darker foregrounds to keep small status
+   text above WCAG AA against the same 10–14% semantic fills. */
+html.ui-v2 {
+  --cu-green-ink: var(--green);
+  --cu-amber-ink: var(--amber);
+  --cu-rose-ink: var(--rose);
+  --cu-sky-ink: var(--sky);
+  --cu-control-outline: #5c6474;
+  --cu-stage-text: #eaecf2;
+  --cu-stage-text-2: #a7aebe;
+  --cu-stage-rose: #ec6a85;
+  --cu-stage-green: #58c08c;
+  --cu-stage-amber: #e4a85b;
+  --cu-stage-line: rgba(230, 236, 247, .14);
+}
+html.ui-v2[data-theme="light"] {
+  --cu-green-ink: #0d633b;
+  --cu-amber-ink: #774000;
+  --cu-rose-ink: #a01f3b;
+  --cu-sky-ink: #15568c;
+  --cu-control-outline: #818899;
+}
+
 /* ── tab scaffold: stage/recording column + semantic right rail ── */
 html.ui-v2 #tab-displays.active {
   display: grid;
@@ -19059,7 +19083,7 @@ html.ui-v2 .display-approval-banner .icon {
 html.ui-v2 .display-approval-banner .title {
   font-size: 13px;
   font-weight: 800;
-  color: var(--amber);
+  color: var(--cu-amber-ink);
   margin-bottom: 3px;
 }
 html.ui-v2 .display-approval-banner .subtitle { font-size: 12px; color: var(--text-2); }
@@ -19075,7 +19099,7 @@ html.ui-v2 .shared-view-banner {
   font-size: 12.5px;
 }
 html.ui-v2 .shared-view-kicker {
-  color: var(--sky);
+  color: var(--cu-sky-ink);
   font-size: 10.5px;
   font-weight: 700;
   letter-spacing: .08em;
@@ -19099,9 +19123,9 @@ html.ui-v2 .shared-view-action:hover {
   filter: brightness(1.08);
 }
 html.ui-v2 .shared-view-close {
-  width: 26px;
-  min-height: 26px;
-  border: 1px solid var(--line);
+  width: 36px;
+  min-height: 36px;
+  border: 1px solid var(--cu-control-outline);
   border-radius: 8px;
   background: transparent;
   color: var(--text-2);
@@ -19110,7 +19134,7 @@ html.ui-v2 .shared-view-close {
 }
 html.ui-v2 .shared-view-close:hover {
   border-color: rgba(var(--rose-rgb), .4);
-  color: var(--rose);
+  color: var(--cu-rose-ink);
   background: rgba(var(--rose-rgb), .08);
 }
 /* compact variant docks flush inside the activity strip */
@@ -19190,10 +19214,11 @@ html.ui-v2 .display-toolbar {
   border-bottom: 0;
   padding: 14px 16px 10px;
   gap: 14px;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   min-width: 0;
 }
 html.ui-v2 .display-toolbar-meta {
+  flex: 1 1 260px;
   min-width: 0;
   display: flex;
   align-items: center;
@@ -19201,14 +19226,15 @@ html.ui-v2 .display-toolbar-meta {
   gap: 7px 10px;
 }
 html.ui-v2 .display-toolbar-actions {
+  flex: 1 1 680px;
   min-width: 0;
   margin-left: auto;
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 7px;
-  overflow-x: auto;
-  overscroll-behavior-x: contain;
-  scrollbar-width: thin;
+  overflow-x: visible;
 }
 /* Display selection lives in the real rail. The stage label is therefore
    an honest heading, not a non-interactive span styled as a dropdown. */
@@ -19252,7 +19278,7 @@ html.ui-v2 .display-status.error {
   border: 1px solid rgba(var(--rose-rgb), .26);
   border-radius: var(--r-pill);
   background: rgba(var(--rose-rgb), .10);
-  color: var(--rose);
+  color: var(--cu-rose-ink);
   font-weight: 700;
   font-size: 11.5px;
 }
@@ -19264,7 +19290,7 @@ html.ui-v2 .display-status.warn {
   border: 1px solid rgba(var(--amber-rgb), .26);
   border-radius: var(--r-pill);
   background: rgba(var(--amber-rgb), .12);
-  color: var(--amber);
+  color: var(--cu-amber-ink);
   font-weight: 700;
   font-size: 11.5px;
 }
@@ -19293,12 +19319,12 @@ html.ui-v2 .display-input-authority {
 html.ui-v2 .display-input-authority.you {
   background: rgba(var(--green-rgb), .12);
   border-color: rgba(var(--green-rgb), .26);
-  color: var(--green);
+  color: var(--cu-green-ink);
 }
 html.ui-v2 .display-input-authority.other {
   background: rgba(var(--amber-rgb), .14);
   border-color: rgba(var(--amber-rgb), .26);
-  color: var(--amber);
+  color: var(--cu-amber-ink);
 }
 html.ui-v2 .display-input-authority.unclaimed {
   background: var(--surface-3);
@@ -19318,12 +19344,12 @@ html.ui-v2 .display-visibility {
   white-space: nowrap;
 }
 html.ui-v2 .display-visibility.private {
-  color: var(--green);
+  color: var(--cu-green-ink);
   border-color: rgba(var(--green-rgb), .26);
   background: rgba(var(--green-rgb), .1);
 }
 html.ui-v2 .display-visibility.agent {
-  color: var(--amber);
+  color: var(--cu-amber-ink);
   border-color: rgba(var(--amber-rgb), .28);
   background: rgba(var(--amber-rgb), .11);
 }
@@ -19333,7 +19359,7 @@ html.ui-v2 .display-toolbar button {
   flex: 0 0 auto;
   min-height: 0;
   padding: 6px 11px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--cu-control-outline);
   border-radius: var(--r-ctl);
   background: transparent;
   color: var(--text-2);
@@ -19343,17 +19369,18 @@ html.ui-v2 .display-toolbar button {
   transition: background var(--t-fast), color var(--t-fast), border-color var(--t-fast), filter var(--t-fast);
 }
 html.ui-v2 .display-toolbar-actions .take-control-btn { margin-left: 0; }
+html.ui-v2 .display-toolbar-actions .display-fullscreen-btn { margin-left: 6px; }
 html.ui-v2 .display-toolbar button:hover {
   background: var(--surface-2);
-  border-color: var(--line-2);
+  border-color: var(--text-2);
   color: var(--text);
 }
 /* streaming to the presence model = sky (live/info) while active */
-html.ui-v2 .display-toolbar .stream-btn:hover { color: var(--sky); border-color: rgba(var(--sky-rgb), .4); background: rgba(var(--sky-rgb), .08); }
+html.ui-v2 .display-toolbar .stream-btn:hover { color: var(--cu-sky-ink); border-color: rgba(var(--sky-rgb), .4); background: rgba(var(--sky-rgb), .08); }
 html.ui-v2 .display-toolbar .stream-btn.active {
   background: rgba(var(--sky-rgb), .14);
   border-color: rgba(var(--sky-rgb), .32);
-  color: var(--sky);
+  color: var(--cu-sky-ink);
   font-weight: 700;
 }
 html.ui-v2 .display-toolbar .annotate-btn:hover,
@@ -19367,13 +19394,13 @@ html.ui-v2 .display-toolbar .annotate-btn.active {
    dot would double it.) */
 html.ui-v2 .display-toolbar .record-btn {
   border-color: rgba(var(--rose-rgb), .4);
-  color: var(--rose);
+  color: var(--cu-rose-ink);
   font-weight: 700;
 }
 html.ui-v2 .display-toolbar .record-btn:hover {
   background: rgba(var(--rose-rgb), .10);
   border-color: rgba(var(--rose-rgb), .55);
-  color: var(--rose);
+  color: var(--cu-rose-ink);
 }
 html.ui-v2 .display-toolbar .record-btn.active {
   background: var(--rose);
@@ -19389,7 +19416,7 @@ html.ui-v2 .display-toolbar .display-close-btn {
 html.ui-v2 .display-toolbar .display-close-btn:hover {
   background: rgba(var(--rose-rgb), .08);
   border-color: rgba(var(--rose-rgb), .4);
-  color: var(--rose);
+  color: var(--cu-rose-ink);
 }
 /* Take control — the design's iris primary. The verb is honest: it takes
    (displacing any other viewer), it does not request. */
@@ -19413,27 +19440,27 @@ html.ui-v2 .display-toolbar .take-control-btn:hover {
 html.ui-v2 .display-toolbar .release-control-btn {
   background: rgba(var(--amber-rgb), .14);
   border-color: rgba(var(--amber-rgb), .32);
-  color: var(--amber);
+  color: var(--cu-amber-ink);
   font-weight: 700;
 }
 html.ui-v2 .display-toolbar .release-control-btn:hover {
   background: rgba(var(--amber-rgb), .2);
   border-color: rgba(var(--amber-rgb), .45);
-  color: var(--amber);
+  color: var(--cu-amber-ink);
 }
 html.ui-v2 .display-toolbar .delete-recording-btn {
   border-color: rgba(var(--rose-rgb), .4);
-  color: var(--rose);
+  color: var(--cu-rose-ink);
   font-size: 11.5px;
 }
 html.ui-v2 .display-toolbar .delete-recording-btn:hover {
   background: rgba(var(--rose-rgb), .10);
   border-color: rgba(var(--rose-rgb), .55);
-  color: var(--rose);
+  color: var(--cu-rose-ink);
 }
 html.ui-v2 .display-toolbar .release-note {
   flex: 0 0 150px;
-  border: 1px solid var(--line-2);
+  border: 1px solid var(--cu-control-outline);
   border-radius: 9px;
   background: var(--surface-2);
   color: var(--text);
@@ -19460,7 +19487,7 @@ html.ui-v2 .display-canvas {
   overflow: hidden;
   background: radial-gradient(120% 120% at 30% 0%, #10131b, #070810 70%);
   box-shadow:
-    inset 0 0 0 1px var(--line-2),
+    inset 0 0 0 1px var(--cu-stage-line),
     inset 0 1px 0 rgba(255, 255, 255, .04),
     0 24px 60px rgba(0, 0, 0, .5);
 }
@@ -19490,7 +19517,7 @@ html.ui-v2 .display-control-banner {
   box-shadow: 0 8px 24px rgba(0, 0, 0, .28);
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
-  color: var(--green);
+  color: var(--cu-stage-green);
   font-size: 11px;
   font-weight: 700;
   line-height: 1.25;
@@ -19508,7 +19535,7 @@ html.ui-v2 .display-control-banner::before {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--green);
+  background: var(--cu-stage-green);
   transform: translateY(-50%);
   box-shadow: 0 0 0 3px rgba(var(--green-rgb), .16);
 }
@@ -19524,10 +19551,10 @@ html.ui-v2 .display-slot:has(.display-status.connected) .display-canvas::after {
   padding: 5px 11px 5px 24px;
   border-radius: var(--r-pill);
   background: rgba(11, 12, 16, .72);
-  border: 1px solid var(--line-2);
+  border: 1px solid var(--cu-stage-line);
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
-  color: var(--rose);
+  color: var(--cu-stage-rose);
   font-family: var(--sans);
   font-size: 11px;
   font-weight: 700;
@@ -19544,7 +19571,7 @@ html.ui-v2 .display-slot:has(.display-status.connected) .display-canvas::before 
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--rose);
+  background: var(--cu-stage-rose);
   animation: ui2-pulse 1.4s infinite;
   pointer-events: none;
 }
@@ -19574,7 +19601,7 @@ html.ui-v2 .stage-overlay-inner {
   text-align: center;
   border-radius: 12px;
   background: rgba(11, 12, 16, .72);
-  border: 1px solid var(--line-2);
+  border: 1px solid var(--cu-stage-line);
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
 }
@@ -19583,15 +19610,15 @@ html.ui-v2 .stage-overlay-text {
   font-size: 12.5px;
   font-weight: 600;
   line-height: 1.5;
-  color: var(--text-2);
+  color: var(--cu-stage-text-2);
 }
-html.ui-v2 .display-stage-overlay.error .stage-overlay-text { color: var(--rose); }
+html.ui-v2 .display-stage-overlay.error .stage-overlay-text { color: var(--cu-stage-rose); }
 html.ui-v2 .stage-overlay-spinner {
   width: 16px;
   height: 16px;
   flex: 0 0 auto;
   border-radius: 50%;
-  border: 2px solid var(--line-2);
+  border: 2px solid var(--cu-stage-line);
   border-top-color: var(--iris);
   animation: ui2-stage-spin .8s linear infinite;
 }
@@ -19627,10 +19654,10 @@ html.ui-v2 .display-live-metrics {
   padding: 5px 11px;
   border-radius: var(--r-pill);
   background: rgba(11, 12, 16, .72);
-  border: 1px solid var(--line-2);
+  border: 1px solid var(--cu-stage-line);
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
-  color: var(--text-2);
+  color: var(--cu-stage-text-2);
   font-family: var(--mono);
   font-size: 10.5px;
   font-weight: 600;
@@ -19645,7 +19672,7 @@ html.ui-v2 .display-live-metrics::before {
   height: 7px;
   flex: 0 0 auto;
   border-radius: 50%;
-  background: var(--rose);
+  background: var(--cu-stage-rose);
   animation: ui2-pulse 1.4s infinite;
 }
 html.ui-v2 .display-slot:has(.display-live-metrics.active) .display-canvas::after,
@@ -19672,7 +19699,7 @@ html.ui-v2 .display-slot.shared-view-active .display-canvas {
 }
 html.ui-v2 .shared-view-focus-box {
   border-radius: 6px;
-  border-color: var(--amber);
+  border-color: var(--cu-stage-amber);
   background: rgba(var(--amber-rgb), .06);
   box-shadow:
     0 0 0 1px rgba(7, 8, 16, .72),
@@ -19681,14 +19708,15 @@ html.ui-v2 .shared-view-focus-box {
 html.ui-v2 .shared-view-focus-box::after {
   border-radius: 8px;
   background: rgba(11, 13, 18, .92);
-  border-color: rgba(var(--amber-rgb), .5);
+  border-color: rgba(228, 168, 91, .5);
+  color: var(--cu-stage-text);
   font-family: var(--sans);
 }
 /* light theme: the stage stays a dark viewport, but its .5-black drop
    shadow is dark-tuned — soften toward the light elevation vocabulary. */
 html.ui-v2[data-theme="light"] .display-canvas {
   box-shadow:
-    inset 0 0 0 1px var(--line-2),
+    inset 0 0 0 1px var(--cu-stage-line),
     inset 0 1px 0 rgba(255, 255, 255, .04),
     0 24px 60px rgba(23, 28, 50, .22);
 }
@@ -19720,6 +19748,21 @@ html.ui-v2 .display-slot.display-fullscreen .display-canvas {
   box-shadow: none;
 }
 html.ui-v2 .display-slot.display-fullscreen .display-toolbar { padding: 10px 14px; }
+/* Interaction focus outranks the shared-view/fullscreen state rings above. */
+html.ui-v2 .display-slot.shared-view-active .display-canvas:has(video:focus-visible),
+html.ui-v2 .display-slot.display-fullscreen .display-canvas:has(video:focus-visible) {
+  box-shadow:
+    inset 0 0 0 2px var(--iris),
+    inset 0 1px 0 rgba(255, 255, 255, .04),
+    0 24px 60px rgba(0, 0, 0, .5);
+}
+html.ui-v2[data-theme="light"] .display-slot.shared-view-active .display-canvas:has(video:focus-visible),
+html.ui-v2[data-theme="light"] .display-slot.display-fullscreen .display-canvas:has(video:focus-visible) {
+  box-shadow:
+    inset 0 0 0 2px var(--iris),
+    inset 0 1px 0 rgba(255, 255, 255, .04),
+    0 24px 60px rgba(23, 28, 50, .22);
+}
 
 /* ── collapse bar + split handles ── */
 html.ui-v2 .displays-collapse-bar {
@@ -20170,6 +20213,7 @@ html.ui-v2 .display-picker-item {
   font-size: 12.5px;
   font-weight: 600;
   color: var(--text);
+  min-height: 44px;
   padding: 8px 11px;
 }
 html.ui-v2 .display-picker-item:hover { background: rgba(var(--iris-rgb), .1); }
@@ -20271,13 +20315,13 @@ html.ui-v2 .display-toolbar .callout-btn:hover,
 html.ui-v2 .peer-display-controls .callout-btn:hover {
   background: rgba(var(--amber-rgb), .10);
   border-color: rgba(var(--amber-rgb), .45);
-  color: var(--amber);
+  color: var(--cu-amber-ink);
 }
 html.ui-v2 .display-toolbar .callout-btn[aria-pressed="true"],
 html.ui-v2 .peer-display-controls .callout-btn[aria-pressed="true"] {
   background: rgba(var(--amber-rgb), .16);
   border-color: rgba(var(--amber-rgb), .5);
-  color: var(--amber);
+  color: var(--cu-amber-ink);
   font-weight: 700;
   box-shadow: 0 0 0 3px rgba(var(--amber-rgb), .12);
 }
@@ -20310,7 +20354,7 @@ html.ui-v2 .callout-arm-overlay {
 }
 html.ui-v2 .callout-arm-rect {
   position: absolute;
-  border: 2px solid var(--amber);
+  border: 2px solid var(--cu-stage-amber);
   background: rgba(var(--amber-rgb), .12);
   box-shadow: 0 0 0 1px rgba(0, 0, 0, .35);
   pointer-events: none;
@@ -20324,8 +20368,8 @@ html.ui-v2 .callout-arm-hint {
   padding: 4px 10px;
   border-radius: var(--r-pill);
   background: rgba(11, 12, 16, .72);
-  border: 1px solid var(--line-2);
-  color: var(--amber);
+  border: 1px solid var(--cu-stage-line);
+  color: var(--cu-stage-amber);
   font-size: 11px;
   font-weight: 600;
   white-space: nowrap;
@@ -20419,7 +20463,7 @@ html.ui-v2 .ui2-live-row {
   width: 100%;
   min-height: 50px;
   padding: 10px 11px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--cu-control-outline);
   border-radius: 11px;
   background: var(--surface);
   color: var(--text);
@@ -20500,7 +20544,9 @@ html.ui-v2 .ui2-live-row-tag {
   font-weight: 800;
   letter-spacing: .05em;
 }
-html.ui-v2 .ui2-live-row-privacy { color: var(--green); }
+html.ui-v2 .ui2-live-row-privacy { color: var(--cu-green-ink); }
+html.ui-v2 .ui2-live-row-media.streaming { color: var(--cu-sky-ink); }
+html.ui-v2 .ui2-live-row-media.recording { color: var(--cu-rose-ink); }
 html.ui-v2 .ui2-live-row-chev {
   flex: 0 0 auto;
   color: var(--text-3);
@@ -20584,19 +20630,19 @@ html.ui-v2 .ui2-live-state-pill {
 html.ui-v2 .ui2-live-state-pill.you {
   border-color: rgba(var(--green-rgb), .26);
   background: rgba(var(--green-rgb), .12);
-  color: var(--green);
+  color: var(--cu-green-ink);
 }
 html.ui-v2 .ui2-live-state-pill.other {
   border-color: rgba(var(--amber-rgb), .26);
   background: rgba(var(--amber-rgb), .14);
-  color: var(--amber);
+  color: var(--cu-amber-ink);
 }
 html.ui-v2 .ui2-live-card-btn {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 100%;
-  min-height: 38px;
+  min-height: 44px;
   margin-top: 9px;
   padding: 9px;
   border: 0;
@@ -20610,6 +20656,7 @@ html.ui-v2 .ui2-live-card-btn {
   transition: filter var(--t-med), background var(--t-fast), border-color var(--t-fast);
 }
 html.ui-v2 .ui2-live-card-btn:hover { filter: brightness(1.08); }
+html.ui-v2 .ui2-live-card-btn[hidden] { display: none; }
 html.ui-v2 .ui2-live-card-btn:disabled {
   opacity: .55;
   cursor: wait;
@@ -20619,10 +20666,10 @@ html.ui-v2 .ui2-live-card-btn.release {
   border: 1px solid rgba(var(--amber-rgb), .32);
   background: rgba(var(--amber-rgb), .14);
   box-shadow: none;
-  color: var(--amber);
+  color: var(--cu-amber-ink);
 }
 html.ui-v2 .ui2-live-card-btn.secondary {
-  border: 1px solid var(--line);
+  border: 1px solid var(--cu-control-outline);
   background: var(--surface-2);
   box-shadow: none;
   color: var(--text);
@@ -20637,7 +20684,7 @@ html.ui-v2 .ui2-live-card-btn.danger {
   border: 1px solid rgba(var(--rose-rgb), .4);
   background: transparent;
   box-shadow: none;
-  color: var(--rose);
+  color: var(--cu-rose-ink);
   font-weight: 700;
 }
 html.ui-v2 .ui2-live-card-btn.danger:hover {
@@ -20662,6 +20709,9 @@ html.ui-v2 .ui2-live-activity {
   display: flex;
   flex-direction: column;
   gap: 1px;
+  max-height: 190px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 html.ui-v2 .ui2-live-activity-row {
   display: grid;
@@ -20737,9 +20787,9 @@ html.ui-v2 .ui2-live-activity-time {
   }
   html.ui-v2 .ui2-live-rail-toggle {
     flex: 0 0 auto;
-    min-height: 36px;
+    min-height: 44px;
     padding: 7px 12px;
-    border: 1px solid var(--line-2);
+    border: 1px solid var(--cu-control-outline);
     border-radius: var(--r-ctl);
     background: var(--surface);
     color: var(--text);
@@ -20766,9 +20816,9 @@ html.ui-v2 .ui2-live-activity-time {
   html.ui-v2 .ui2-live-rail-close {
     display: grid;
     place-items: center;
-    width: 34px;
-    height: 34px;
-    border: 1px solid var(--line);
+    width: 44px;
+    height: 44px;
+    border: 1px solid var(--cu-control-outline);
     border-radius: var(--r-ctl);
     background: var(--surface);
     color: var(--text-2);
@@ -20810,22 +20860,24 @@ html.ui-v2 .ui2-live-activity-time {
     min-height: 30px;
   }
   html.ui-v2 .display-toolbar-actions {
+    flex: 0 0 auto;
     width: 100%;
     margin-left: 0;
     padding: 1px 0 4px;
   }
-  html.ui-v2 .display-toolbar-actions .take-control-btn,
-  html.ui-v2 .display-toolbar-actions .release-control-btn {
-    order: -2;
-  }
   html.ui-v2 .display-toolbar button {
-    min-height: 36px;
+    min-height: 44px;
     padding: 7px 11px;
   }
   html.ui-v2 .display-toolbar .release-note {
     flex-basis: 145px;
-    min-height: 36px;
+    min-height: 44px;
   }
+  html.ui-v2 .display-toolbar .display-fullscreen-btn,
+  html.ui-v2 .display-toolbar .display-close-btn { width: 44px; }
+  html.ui-v2 .shared-view-action,
+  html.ui-v2 .shared-view-close { min-height: 44px; }
+  html.ui-v2 .shared-view-close { width: 44px; }
   html.ui-v2 .display-canvas { margin: 0 10px 10px; }
   html.ui-v2 .display-control-banner {
     top: auto;
@@ -22252,12 +22304,14 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
               <button class="strip-minimize-btn" id="strip-minimize" type="button" title="Minimize displays" aria-label="Minimize displays" aria-pressed="false">&minus;</button>
               <button class="strip-toggle-btn" id="strip-toggle" title="Expand displays">&#x25BE;</button>
             </div>
-            <div class="shared-view-banner shared-view-banner-compact hidden" id="activity-shared-view-banner" data-shared-view-banner>
+            <div class="shared-view-banner shared-view-banner-compact hidden" id="activity-shared-view-banner"
+                 data-shared-view-banner role="status" aria-live="polite" aria-atomic="true">
               <span class="shared-view-kicker">Shared view</span>
               <span class="shared-view-message" data-shared-view-message></span>
               <span class="shared-view-actions">
                 <button class="shared-view-action" type="button" style="display:none" data-shared-view-take-input title="Take input authority for the focused display">Take input</button>
-                <button class="shared-view-close" type="button" data-shared-view-close title="Hide shared view">&times;</button>
+                <button class="shared-view-close" type="button" data-shared-view-close
+                        aria-label="Hide shared view" title="Hide shared view">&times;</button>
               </span>
             </div>
             <div class="activity-display-row" id="activity-display-row"></div>
@@ -23042,19 +23096,21 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
           Displays &amp; input
         </button>
       </div>
-      <div class="display-approval-banner hidden" id="display-approval-banner">
+      <div class="display-approval-banner hidden" id="display-approval-banner" role="alert" aria-atomic="true">
         <div class="icon">&#x26A0;</div>
         <div class="text">
           <div class="title">Screen sharing approval needed</div>
           <div class="subtitle">A dialog should be visible on the guest desktop — approve it to start the video stream.</div>
         </div>
       </div>
-      <div class="shared-view-banner hidden" id="shared-view-banner" data-shared-view-banner>
+      <div class="shared-view-banner hidden" id="shared-view-banner" data-shared-view-banner
+           role="status" aria-live="polite" aria-atomic="true">
         <span class="shared-view-kicker">Shared view</span>
         <span class="shared-view-message" id="shared-view-message" data-shared-view-message></span>
         <span class="shared-view-actions">
           <button class="shared-view-action" id="shared-view-take-input" type="button" style="display:none" data-shared-view-take-input title="Take input authority for the focused display">Take input</button>
-          <button class="shared-view-close" type="button" id="shared-view-close" data-shared-view-close title="Hide shared view">&times;</button>
+          <button class="shared-view-close" type="button" id="shared-view-close" data-shared-view-close
+                  aria-label="Hide shared view" title="Hide shared view">&times;</button>
         </span>
       </div>
       <div class="displays-container" id="displays-container">
@@ -23189,7 +23245,7 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
         </section>
         <section aria-labelledby="ui2-live-authority-heading">
           <h3 class="ui2-live-rail-eyebrow" id="ui2-live-authority-heading">Input authority</h3>
-          <div id="ui2-live-authority-card" aria-live="polite" aria-atomic="true"></div>
+          <div id="ui2-live-authority-card"></div>
         </section>
         <section aria-labelledby="ui2-live-activity-heading">
           <h3 class="ui2-live-rail-eyebrow" id="ui2-live-activity-heading">Display activity</h3>
@@ -26660,7 +26716,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '6a47fd04d68d454e';
+const INTENDANT_APP_BUILD = 'f0423bced4ed7ce0';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -40461,20 +40517,26 @@ async function main() {
       if (d.event === 'recording_started' && d.stream_name) {
         serverMsgStep(d, 'recording_started', () => {
           const slot = slotForRecordingStream(d.stream_name);
-          if (slot) { slot.recordingStreamName = d.stream_name; slot.recording = true; slot.recordBtn.innerHTML = '&#x23F9; Stop'; slot.recordBtn.classList.add('active'); slot.recordBtn.setAttribute('aria-pressed', 'true'); slot.deleteRecBtn.style.display = 'none'; }
+          if (slot) slot.applyRecordingState(true, d.stream_name);
           handleDebugRecordingEvent(d); // debug tab's Record button tracks its display's streams
         });
       } else if (d.event === 'recording_stopped' && d.stream_name) {
         serverMsgStep(d, 'recording_stopped', () => {
           const slot = slotForRecordingStream(d.stream_name);
-          if (slot) { slot.recordingStreamName = d.stream_name; slot.recording = false; slot.recordBtn.innerHTML = '&#x23FA; Record'; slot.recordBtn.classList.remove('active'); slot.recordBtn.setAttribute('aria-pressed', 'false'); slot.deleteRecBtn.style.display = ''; }
+          if (slot) slot.applyRecordingState(false, d.stream_name);
           handleDebugRecordingEvent(d);
         });
       } else if (d.event === 'recording_deleted' && d.stream_name) {
         serverMsgStep(d, 'recording_deleted', () => {
           const slot = slotForRecordingStream(d.stream_name);
-          if (slot) { if (slot.recordingStreamName === d.stream_name) slot.recordingStreamName = null; slot.recording = false; slot.recordBtn.innerHTML = '&#x23FA; Record'; slot.recordBtn.classList.remove('active'); slot.recordBtn.setAttribute('aria-pressed', 'false'); slot.deleteRecBtn.style.display = 'none'; }
+          if (slot) slot.applyRecordingState(false, d.stream_name, true);
           deleteRecordingStream(d.stream_name);
+        });
+      } else if (d.event === 'recording_error' && d.stream_name) {
+        serverMsgStep(d, 'recording_error', () => {
+          const slot = slotForRecordingStream(d.stream_name);
+          if (slot) slot._failRecordingCommand(d.message || 'Recording failed');
+          handleDebugRecordingEvent(d);
         });
       }
       // Display transport metrics (per-display sections)
@@ -62663,6 +62725,11 @@ class DisplaySlot {
     this.connected = false;
     this.streaming = false;
     this.recordingStreamName = null;
+    this._recordingPendingAction = null;
+    this._recordingPendingTimer = null;
+    this._recordingDeletePending = false;
+    this._recordingDeleteStream = null;
+    this._recordingDeleteTimer = null;
     this._answerApplied = false;     // true after setRemoteDescription completes
     this._pendingCandidates = [];    // queued until answer is applied
     this._reconnectAttempts = 0;     // ICE failure reconnect counter
@@ -62690,6 +62757,8 @@ class DisplaySlot {
     this._streamCanvas = document.createElement('canvas');
     this._focusResizeObserver = null;
     this._boundHandlers = {};
+    this._fullscreenInertRecords = [];
+    this._fullscreenReturnFocus = null;
     this.el = document.createElement('div');
     this.el.className = 'display-slot';
     const label = displayLabel(displayId);
@@ -62699,20 +62768,20 @@ class DisplaySlot {
           <span class="display-label"></span>
           <span class="display-visibility" id="ds-visibility-${displayId}" style="display:none"></span>
           <span class="display-status" id="ds-status-${displayId}" role="status" aria-live="polite" aria-atomic="true">Connecting...</span>
-          <span class="display-input-authority" id="ds-authority-${displayId}" role="status" aria-live="polite" aria-atomic="true" style="display:none" title="Input authority for this display: who can drive keyboard and pointer input."></span>
+          <span class="display-input-authority" id="ds-authority-${displayId}" style="display:none" title="Input authority for this display: who can drive keyboard and pointer input."></span>
         </div>
         <div class="display-toolbar-actions">
+          <button class="take-control-btn" id="ds-take-${displayId}" type="button" title="Take interactive control of this display (keyboard and mouse)">Take control</button>
+          <button class="release-control-btn" id="ds-release-${displayId}" type="button" style="display:none" title="Release control and return display to view-only mode">Release</button>
           <input class="release-note" id="ds-note-${displayId}" aria-label="Note to the agent when releasing this display" placeholder="Note (optional)" style="display:none">
           <button class="stream-btn" id="ds-stream-${displayId}" type="button" aria-pressed="false" title="Continuously send screenshots of this display to the live presence (voice) model. Main agents are not affected.">Stream</button>
           <button class="ann-attach-btn" id="ds-attach-${displayId}" type="button" title="Capture current frame and attach to next task">Attach</button>
           <button class="annotate-btn" id="ds-annotate-${displayId}" type="button" aria-pressed="false" title="Freeze current frame and annotate it">&#9998; Annotate</button>
           <button class="callout-btn" id="ds-callout-${displayId}" type="button" aria-pressed="false" disabled title="Call out a region: arm, then drag a rectangle on the frame to attach it to the next task (needs input control)">&#x2316; Callout</button>
           <button class="record-btn" id="ds-record-${displayId}" type="button" aria-pressed="false" title="Record this display (ffmpeg)">Record</button>
-          <button class="display-fullscreen-btn" id="ds-fullscreen-${displayId}" type="button" aria-label="Open display full screen" title="Full screen">&#x26F6;</button>
-          <button class="display-close-btn" id="ds-close-${displayId}" type="button" aria-label="Close this display stream" title="Close this display stream">&times;</button>
-          <button class="take-control-btn" id="ds-take-${displayId}" type="button" title="Take interactive control of this display (keyboard and mouse)">Take control</button>
-          <button class="release-control-btn" id="ds-release-${displayId}" type="button" style="display:none" title="Release control and return display to view-only mode">Release</button>
           <button class="delete-recording-btn" id="ds-delete-rec-${displayId}" type="button" style="display:none" title="Delete recording files for this display">Delete</button>
+          <button class="display-fullscreen-btn" id="ds-fullscreen-${displayId}" type="button" aria-label="Open display full screen" aria-pressed="false" title="Full screen">&#x26F6;</button>
+          <button class="display-close-btn" id="ds-close-${displayId}" type="button" aria-label="Close this display stream" title="Close this display stream">&times;</button>
           <span class="stream-frame-id" id="ds-frame-${displayId}" style="display:none;font-size:10px;color:var(--overlay0)"></span>
         </div>
       </div>
@@ -62770,8 +62839,6 @@ class DisplaySlot {
     this.canvasEl.appendChild(this.metricsEl);
     this.controlBannerEl = document.createElement('div');
     this.controlBannerEl.className = 'display-control-banner';
-    this.controlBannerEl.setAttribute('role', 'status');
-    this.controlBannerEl.setAttribute('aria-live', 'polite');
     this.controlBannerEl.textContent = 'You have control — keyboard and pointer input drive this display.';
     this.canvasEl.appendChild(this.controlBannerEl);
     const rerenderSharedFocus = () => {
@@ -62797,6 +62864,7 @@ class DisplaySlot {
     this.attachBtn.addEventListener('click', () => this.attachCurrentFrame());
     this.annotateBtn.addEventListener('click', () => this.annotateCurrentFrame());
     this.calloutBtn.addEventListener('click', () => this.toggleCallout());
+    this.el.addEventListener('keydown', event => this._handleFullscreenKeydown(event));
   }
 
   // Same budget as PeerDisplayConnection.NO_TRACK_TIMEOUT_MS — both are
@@ -62812,12 +62880,13 @@ class DisplaySlot {
     if (want) {
       for (const slot of displaySlots.values()) {
         if (slot === this) continue;
-        slot.el.classList.remove('display-fullscreen');
-        if (slot.fullscreenBtn) {
-          slot.fullscreenBtn.innerHTML = '&#x26F6;';
-          slot.fullscreenBtn.title = 'Full screen';
-        }
+        if (slot.el.classList.contains('display-fullscreen')) slot.toggleFullscreen(false);
       }
+    }
+    if (want && !this.el.classList.contains('display-fullscreen')) {
+      this._enterFullscreenA11y();
+    } else if (!want && this.el.classList.contains('display-fullscreen')) {
+      this._exitFullscreenA11y();
     }
     this.el.classList.toggle('display-fullscreen', want);
     const anyFullscreen = want || Array.from(displaySlots.values()).some(slot =>
@@ -62829,6 +62898,78 @@ class DisplaySlot {
       this.fullscreenBtn.title = want ? 'Exit full screen' : 'Full screen';
       this.fullscreenBtn.setAttribute('aria-label', want ? 'Exit display full screen' : 'Open display full screen');
       this.fullscreenBtn.setAttribute('aria-pressed', want ? 'true' : 'false');
+    }
+    if (want && this.fullscreenBtn) this.fullscreenBtn.focus();
+  }
+
+  _enterFullscreenA11y() {
+    this._fullscreenReturnFocus = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    this._fullscreenInertRecords = [];
+    let branch = this.el;
+    while (branch && branch.parentElement) {
+      const parent = branch.parentElement;
+      for (const sibling of parent.children) {
+        if (sibling === branch || !(sibling instanceof HTMLElement)) continue;
+        this._fullscreenInertRecords.push({
+          element: sibling,
+          inert: sibling.inert,
+          ariaHidden: sibling.getAttribute('aria-hidden'),
+        });
+        sibling.inert = true;
+        sibling.setAttribute('aria-hidden', 'true');
+      }
+      branch = parent;
+      if (parent === document.body) break;
+    }
+    this.el.setAttribute('role', 'dialog');
+    this.el.setAttribute('aria-modal', 'true');
+  }
+
+  _exitFullscreenA11y() {
+    for (const record of this._fullscreenInertRecords) {
+      record.element.inert = record.inert;
+      if (record.ariaHidden === null) record.element.removeAttribute('aria-hidden');
+      else record.element.setAttribute('aria-hidden', record.ariaHidden);
+    }
+    this._fullscreenInertRecords = [];
+    this.el.removeAttribute('role');
+    this.el.removeAttribute('aria-modal');
+    // A responsive breakpoint may have changed while fullscreen owned the
+    // background. Re-project the drawer's current media-query state instead
+    // of leaving stale inert/aria-hidden snapshots on its rail or stage.
+    if (typeof window.syncLiveDisplayDrawerState === 'function') {
+      window.syncLiveDisplayDrawerState();
+    }
+    const returnFocus = this._fullscreenReturnFocus;
+    this._fullscreenReturnFocus = null;
+    if (returnFocus && returnFocus.isConnected && typeof returnFocus.focus === 'function') {
+      requestAnimationFrame(() => returnFocus.focus());
+    }
+  }
+
+  _handleFullscreenKeydown(event) {
+    if (!this.el.classList.contains('display-fullscreen')) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      this.toggleFullscreen(false);
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    const focusable = Array.from(this.el.querySelectorAll(
+      'button:not([disabled]), input:not([disabled]), video[tabindex], [tabindex]:not([tabindex="-1"])'
+    )).filter(element => element.getClientRects().length > 0);
+    if (!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
     }
   }
 
@@ -63350,6 +63491,13 @@ class DisplaySlot {
   // entry into interactive mode.
   _enterInteractive() {
     if (this.interactive) return;
+    // Activity thumbnails and hidden single-stage projections are
+    // deliberately view-only. A late authority reply must never bind
+    // keyboard/pointer/paste listeners after navigation hid its surface.
+    if (activeTab !== 'displays' || this.el.classList.contains('ui2-live-inactive')) {
+      this._releaseAuthority();
+      return;
+    }
     this.interactive = true;
     this.el.classList.add('is-interactive');
     this.noteInput.style.display = '';
@@ -63645,28 +63793,113 @@ class DisplaySlot {
     this.frameIdEl.textContent = '';
   }
   toggleRecording() {
-    if (!app) return;
+    if (!app || this._recordingPendingAction || this._recordingDeletePending) return;
     const baseStream = 'display_' + this.displayId;
     const stream = this.recordingStreamName || baseStream;
-    if (this.recording) {
-      dispatchDashboardActionMsg({ action: 'stop_recording', stream_name: stream });
-      this.recording = false;
-      this.recordBtn.innerHTML = '&#x23FA; Record';
-      this.recordBtn.classList.remove('active');
-      this.recordBtn.setAttribute('aria-pressed', 'false');
-      this.deleteRecBtn.style.display = '';
-    } else {
-      dispatchDashboardActionMsg({ action: 'start_recording', stream_name: baseStream });
-      this.recordingStreamName = baseStream;
-      this.recording = true;
-      this.recordBtn.innerHTML = '&#x23F9; Stop';
-      this.recordBtn.classList.add('active');
-      this.recordBtn.setAttribute('aria-pressed', 'true');
-      this.deleteRecBtn.style.display = 'none';
+    const action = this.recording ? 'stop_recording' : 'start_recording';
+    const targetStream = this.recording ? stream : baseStream;
+    this._setRecordingPending(action);
+    const fail = error => {
+      // A late RPC failure must not roll back or toast over a newer server
+      // event that already confirmed and cleared this exact command.
+      if (this._recordingPendingAction !== action) return;
+      this._failRecordingCommand(
+        error?.message || `Could not ${this.recording ? 'stop' : 'start'} recording`
+      );
+    };
+    const sent = dispatchDashboardActionMsg(
+      { action, stream_name: targetStream },
+      { onError: fail }
+    );
+    if (!sent) {
+      fail(new Error('Dashboard control connection is unavailable'));
+      return;
     }
+    this._recordingPendingTimer = window.setTimeout(() => {
+      this._recordingPendingTimer = null;
+      if (!this._recordingPendingAction) return;
+      this._failRecordingCommand('No recording confirmation arrived — check the display activity and retry.');
+    }, 10000);
+  }
+
+  _setRecordingPending(action) {
+    this._recordingPendingAction = action;
+    this._renderRecordingControls();
+  }
+
+  _clearRecordingPending(render = true) {
+    if (this._recordingPendingTimer) {
+      window.clearTimeout(this._recordingPendingTimer);
+      this._recordingPendingTimer = null;
+    }
+    this._recordingPendingAction = null;
+    if (render) this._renderRecordingControls();
+  }
+
+  _clearRecordingDeletePending(render = true) {
+    if (this._recordingDeleteTimer) {
+      window.clearTimeout(this._recordingDeleteTimer);
+      this._recordingDeleteTimer = null;
+    }
+    this._recordingDeletePending = false;
+    this._recordingDeleteStream = null;
+    if (render) this._renderRecordingControls();
+  }
+
+  _renderRecordingControls() {
+    const action = this._recordingPendingAction;
+    const deleting = this._recordingDeletePending;
+    this.recordBtn.disabled = Boolean(action || deleting);
+    this.recordBtn.setAttribute('aria-busy', action ? 'true' : 'false');
+    this.recordBtn.innerHTML = action
+      ? (action === 'stop_recording' ? 'Stopping…' : 'Starting…')
+      : (this.recording ? '&#x23F9; Stop' : '&#x23FA; Record');
+    this.recordBtn.classList.toggle('active', this.recording);
+    this.recordBtn.setAttribute('aria-pressed', this.recording ? 'true' : 'false');
+    this.deleteRecBtn.disabled = Boolean(deleting || action);
+    this.deleteRecBtn.setAttribute('aria-busy', deleting ? 'true' : 'false');
+    this.deleteRecBtn.textContent = deleting ? 'Deleting…' : 'Delete';
+    this.deleteRecBtn.style.display = this.recording || !this.recordingStreamName ? 'none' : '';
+  }
+
+  applyRecordingState(recording, streamName, deleted = false) {
+    const sameAsCurrent = !this.recordingStreamName || !streamName ||
+      this.recordingStreamName === streamName;
+    // Recording events are base-mapped to slots, so a late stop/delete for
+    // an older suffixed stream must not turn off a newer active recording.
+    // Likewise, a negative event cannot confirm an in-flight Start.
+    if ((!recording && this.recordingStreamName && !sameAsCurrent) ||
+        (!recording && this._recordingPendingAction === 'start_recording')) {
+      if (deleted && this._recordingDeletePending &&
+          this._recordingDeleteStream === streamName) {
+        this._clearRecordingDeletePending();
+      }
+      return false;
+    }
+
+    const confirmsRecordingCommand = recording
+      ? this._recordingPendingAction === 'start_recording'
+      : this._recordingPendingAction === 'stop_recording';
+    if (confirmsRecordingCommand) this._clearRecordingPending(false);
+    if (deleted && this._recordingDeletePending &&
+        this._recordingDeleteStream === streamName) {
+      this._clearRecordingDeletePending(false);
+    }
+    this.recording = Boolean(recording);
+    this.recordingStreamName = deleted ? null : (streamName || this.recordingStreamName);
+    this._renderRecordingControls();
+    return true;
+  }
+
+  _failRecordingCommand(message) {
+    this._clearRecordingPending(false);
+    this._clearRecordingDeletePending(false);
+    // The last server-confirmed state remains authoritative.
+    this._renderRecordingControls();
+    if (typeof showControlToast === 'function') showControlToast('error', message);
   }
   async deleteRecording() {
-    if (!app) return;
+    if (!app || this._recordingDeletePending || this._recordingPendingAction || this.recording) return;
     const stream = this.recordingStreamName || ('display_' + this.displayId);
     const ok = await showDashboardConfirm({
       title: 'Delete recording',
@@ -63675,9 +63908,29 @@ class DisplaySlot {
       confirmLabel: 'Delete',
     });
     if (!ok) return;
-    dispatchDashboardActionMsg({ action: 'delete_recording', stream_name: stream });
-    this.deleteRecBtn.style.display = 'none';
-    this.recordingStreamName = null;
+    // State can change while the confirmation dialog is open.
+    if (this._recordingDeletePending || this._recordingPendingAction || this.recording ||
+        this.recordingStreamName !== stream) return;
+    this._recordingDeletePending = true;
+    this._recordingDeleteStream = stream;
+    this._renderRecordingControls();
+    const fail = error => {
+      if (!this._recordingDeletePending) return;
+      this._failRecordingCommand(error?.message || 'Could not delete the recording');
+    };
+    const sent = dispatchDashboardActionMsg(
+      { action: 'delete_recording', stream_name: stream },
+      { onError: fail }
+    );
+    if (!sent) {
+      fail(new Error('Dashboard control connection is unavailable'));
+      return;
+    }
+    this._recordingDeleteTimer = window.setTimeout(() => {
+      this._recordingDeleteTimer = null;
+      if (!this._recordingDeletePending) return;
+      this._failRecordingCommand('No delete confirmation arrived — the recording is still listed.');
+    }, 10000);
   }
   // Phase 5c: teardown.  `userInitiated` separates the user-close path
   // (display toggled off, `removeDisplaySlot`, etc.) from transient
@@ -63705,10 +63958,9 @@ class DisplaySlot {
     this._clearNoTrackWatchdog();
     this._stopStatsSampler();
     this._setStageOverlay(null);
+    this._clearRecordingPending();
+    this._clearRecordingDeletePending();
     this.stopStreaming();
-    if (userInitiated) {
-      this._releaseAuthority();
-    }
     // Flip `connected` BEFORE `_exitInteractive` so its status-text
     // ternary writes 'Disconnected' (not the stale 'Connected (view-
     // only)') on the way out — otherwise the chip flickers through
@@ -63716,6 +63968,12 @@ class DisplaySlot {
     // assignment overwrote it.
     this.connected = false;
     this._exitInteractive(userInitiated);
+    if (userInitiated) {
+      // Held-key keyups from `_exitInteractive` must cross the input gate
+      // before the authority release closes it. This is the same ordering
+      // as releaseControl(); close/remove paths cannot safely reverse it.
+      this._releaseAuthority();
+    }
     if (this.controlChannel) { this.controlChannel.close(); this.controlChannel = null; }
     if (this.pointerChannel) { this.pointerChannel.close(); this.pointerChannel = null; }
     if (this.clipboardChannel) { this.clipboardChannel.close(); this.clipboardChannel = null; }
@@ -63746,6 +64004,9 @@ function removeDisplaySlot(displayId) {
   slot.disconnect({ userInitiated: true });
   if (slot.el && slot.el.parentNode) slot.el.parentNode.removeChild(slot.el);
   displaySlots.delete(displayId);
+  if (typeof window.retireLiveDisplayWorkspaceSlot === 'function') {
+    window.retireLiveDisplayWorkspaceSlot(displayId);
+  }
   if (sharedViewState.displayId === displayId) {
     clearSharedViewDecorations();
   }
@@ -63906,19 +64167,27 @@ function updateSharedViewBanner() {
 
 function applySharedViewToSlot(slot) {
   if (!sharedViewState.visible || !slot) return;
+  // Current daemons resolve auto-detect to a concrete target. A legacy null
+  // event is only safe to bind when handleSharedViewEvent saw exactly one
+  // existing stream; never guess here while bootstrap slots are still arriving.
+  if (sharedViewState.displayId === null) return;
   if (sharedViewState.displayId !== null && Number(slot.displayId) !== sharedViewState.displayId) {
     return;
   }
-  // The Live workspace is a selected-display stage. Agent-requested
-  // shared views must foreground their real target rather than leaving
-  // the focus box mounted on a hidden slot.
+  // The Live workspace is a selected-display stage. Foreground a new
+  // advisory target only when doing so will not discard active human work;
+  // the banner and row decoration still make a deferred target discoverable.
+  let foregrounded = true;
   if (typeof window.selectLiveDisplay === 'function') {
-    window.selectLiveDisplay(slot.displayId, { source: 'shared-view' });
+    foregrounded = window.selectLiveDisplay(slot.displayId, {
+      source: 'shared-view',
+      advisory: true,
+    });
   }
   updateSharedViewBanner();
   slot.el.classList.add('shared-view-active');
   renderSharedViewFocus(slot, sharedViewState.region, sharedViewState.note);
-  if (activeTab === 'displays') {
+  if (activeTab === 'displays' && foregrounded) {
     requestAnimationFrame(() => {
       try { slot.el.scrollIntoView({ block: 'nearest', inline: 'nearest' }); } catch (_) {}
     });
@@ -63946,7 +64215,21 @@ function hideSharedView() {
 function takeSharedViewInput() {
   if (sharedViewState.displayId === null) return;
   const slot = displaySlots.get(sharedViewState.displayId);
-  if (slot) slot.takeControl();
+  if (!slot) return;
+  // This click is an explicit human decision, unlike the agent's advisory
+  // shared-view event: select the requested surface (safely releasing the
+  // previous one) before asking for its input authority.
+  if (activeTab !== 'displays' && typeof routeTo === 'function') {
+    if (routeTo('displays') === false) return;
+  }
+  if (typeof window.selectLiveDisplay === 'function') {
+    const selected = window.selectLiveDisplay(slot.displayId, {
+      source: 'shared-view-input',
+      focusStage: true,
+    });
+    if (!selected) return;
+  }
+  slot.takeControl();
 }
 
 function handleSharedViewEvent(evt) {
@@ -63968,6 +64251,14 @@ function handleSharedViewEvent(evt) {
   sharedViewState.note = String(evt.note || '');
   sharedViewState.region = evt.region || null;
 
+  const slot = sharedViewState.displayId !== null
+    ? displaySlots.get(sharedViewState.displayId)
+    : displaySlots.size === 1
+      ? displaySlots.values().next().value
+      : null;
+  if (slot && sharedViewState.displayId === null) {
+    sharedViewState.displayId = Number(slot.displayId);
+  }
   clearSharedViewDecorations();
   updateSharedViewBanner();
   if (activeTab !== 'displays' && (activeTab !== 'activity' || activeActivitySubtab !== 'log')) {
@@ -63977,9 +64268,6 @@ function handleSharedViewEvent(evt) {
   if (activeTab === 'activity' && activeActivitySubtab === 'log' && activityStrip) {
     activityStrip.classList.remove('hidden');
   }
-  const slot = sharedViewState.displayId !== null
-    ? displaySlots.get(sharedViewState.displayId)
-    : displaySlots.values().next().value;
   if (slot) applySharedViewToSlot(slot);
 }
 
@@ -64077,7 +64365,11 @@ function addDisplayThumb(displayId) {
 
   const thumb = document.createElement('div');
   thumb.className = 'activity-display-thumb';
-  thumb.innerHTML = `<span class="thumb-label">${displayLabel(displayId, true)}</span>`;
+  const thumbLabel = document.createElement('span');
+  thumbLabel.className = 'thumb-label';
+  // Window titles come from the OS and are not trusted markup.
+  thumbLabel.textContent = displayLabel(displayId, true);
+  thumb.appendChild(thumbLabel);
   thumb.addEventListener('click', (e) => { e.stopPropagation(); toggleDisplayStrip(); }, true);
 
   displayThumbs.set(displayId, thumb);
@@ -64246,6 +64538,7 @@ function applyDisplayStripState() {
 // down through the existing provider lifecycle before that slot is hidden.
 (() => {
   const tab = document.getElementById('tab-displays');
+  const main = document.getElementById('ui2-live-main');
   const container = document.getElementById('displays-container');
   const rail = document.getElementById('ui2-live-rail');
   const displaysList = document.getElementById('ui2-live-displays-list');
@@ -64271,11 +64564,13 @@ function applyDisplayStripState() {
   const peerSources = new Map();
   const slotSnapshots = new Map();
   const activityByDisplay = new Map();
+  const activityRows = new Map();
   const drawerMedia = window.matchMedia('(max-width: 1279px)');
   let selectedDisplayId = null;
   let railOpen = false;
   let railRaf = 0;
   let activitySeq = 0;
+  let activityRenderedDisplayId = null;
   let lastActivitySignature = '';
   let lastAuthoritySignature = '';
   let lastScreenSignature = '';
@@ -64287,6 +64582,39 @@ function applyDisplayStripState() {
 
   function selectedSlot() {
     return selectedDisplayId === null ? null : displaySlots.get(selectedDisplayId) || null;
+  }
+
+  function slotHasActiveUserWork(slot) {
+    if (!slot) return false;
+    return Boolean(
+      slot.interactive ||
+      slot._takeControlPending ||
+      slot.authorityState === 'you' ||
+      slot.el?.classList.contains('display-fullscreen') ||
+      slot.el?.contains(document.activeElement) ||
+      rail.contains(document.activeElement) ||
+      (typeof shouldSuppressDisplayInputForAnnotation === 'function' &&
+        shouldSuppressDisplayInputForAnnotation(slot)) ||
+      (typeof liveCalloutArmedFor === 'function' && liveCalloutArmedFor(slot))
+    );
+  }
+
+  function slotHasBlockingSurfaceWork(slot) {
+    if (!slot) return false;
+    return Boolean(
+      (typeof shouldSuppressDisplayInputForAnnotation === 'function' &&
+        shouldSuppressDisplayInputForAnnotation(slot)) ||
+      (typeof liveCalloutArmedFor === 'function' && liveCalloutArmedFor(slot))
+    );
+  }
+
+  function announceBlockedSurfaceSwitch() {
+    if (typeof showControlToast === 'function') {
+      showControlToast(
+        'info',
+        'Finish or close the current annotation/callout before changing displays.'
+      );
+    }
   }
 
   function emptyHint(textValue) {
@@ -64313,8 +64641,18 @@ function applyDisplayStripState() {
   function teardownSelectedSurface(slot) {
     if (!slot) return;
     // releaseControl is the only safe ordering: held-key keyups are sent
-    // before the server-side authority release closes the input gate.
-    if (slot.interactive) slot.releaseControl();
+    // before the server-side authority release closes the input gate. A
+    // pending Take must also be cancelled: its late `you` reply would
+    // otherwise install document-level paste and input listeners on the
+    // display after this projection has hidden it. Releasing an already-
+    // held but locally unbound authority is idempotent and avoids leaving
+    // a hidden display reserved during the server round trip.
+    if (slot.interactive || slot._takeControlPending || slot.authorityState === 'you') {
+      slot.releaseControl();
+    }
+    if (slot.el?.classList.contains('display-fullscreen')) {
+      slot.toggleFullscreen(false);
+    }
     if (typeof teardownLiveSurfaceForOwner === 'function') {
       teardownLiveSurfaceForOwner(slot);
     }
@@ -64326,7 +64664,13 @@ function applyDisplayStripState() {
     const next = Number.isFinite(id) ? displaySlots.get(id) : null;
     if (!next) return false;
     if (selectedDisplayId !== id) {
-      teardownSelectedSurface(selectedSlot());
+      const current = selectedSlot();
+      if (opts.advisory && slotHasActiveUserWork(current)) return false;
+      if (slotHasBlockingSurfaceWork(current)) {
+        announceBlockedSurfaceSwitch();
+        return false;
+      }
+      teardownSelectedSurface(current);
       selectedDisplayId = id;
     }
     setSelectedProjection();
@@ -64339,18 +64683,53 @@ function applyDisplayStripState() {
     return true;
   }
   window.selectLiveDisplay = selectLiveDisplay;
+  window.retireLiveDisplayWorkspaceSlot = function(displayId) {
+    const id = Number(displayId);
+    const record = displayRows.get(id);
+    if (record) record.row.remove();
+    displayRows.delete(id);
+    slotSnapshots.delete(id);
+    activityByDisplay.delete(id);
+    if (selectedDisplayId === id) selectedDisplayId = null;
+    lastActivitySignature = '';
+    lastAuthoritySignature = '';
+    scheduleWorkspace();
+  };
+  window.canDeactivateLiveDisplayWorkspace = function(options) {
+    const blocking = Array.from(displaySlots.values()).find(slotHasBlockingSurfaceWork);
+    if (!blocking) return true;
+    if (!options || options.announce !== false) announceBlockedSurfaceSwitch();
+    return false;
+  };
+  window.deactivateLiveDisplayWorkspace = function() {
+    if (!window.canDeactivateLiveDisplayWorkspace()) return false;
+    for (const slot of displaySlots.values()) {
+      if (slot.interactive || slot._takeControlPending || slot.authorityState === 'you') {
+        slot.releaseControl();
+      }
+      if (slot.el?.classList.contains('display-fullscreen')) {
+        slot.toggleFullscreen(false);
+      }
+      if (typeof teardownLiveSurfaceForOwner === 'function') {
+        teardownLiveSurfaceForOwner(slot);
+      }
+    }
+    scheduleWorkspace();
+    return true;
+  };
 
   function reconcileSelectedDisplay(slots) {
-    const shared = slots.find(slot => slot.el && slot.el.classList.contains('shared-view-active'));
-    if (shared && Number(shared.displayId) !== selectedDisplayId) {
-      selectLiveDisplay(shared.displayId, { source: 'shared-view' });
-      return;
-    }
     if (selectedDisplayId !== null && displaySlots.has(selectedDisplayId)) {
       setSelectedProjection();
       return;
     }
-    selectedDisplayId = slots.length ? Number(slots[0].displayId) : null;
+    // applySharedViewToSlot selects a newly requested shared-view target
+    // once. If the workspace initializes after that event, prefer its
+    // decorated slot only for this initial/fallback choice. Never force it
+    // again: the user must remain free to inspect another live display.
+    const shared = slots.find(slot => slot.el && slot.el.classList.contains('shared-view-active'));
+    const fallback = shared || slots[0];
+    selectedDisplayId = fallback ? Number(fallback.displayId) : null;
     setSelectedProjection();
   }
 
@@ -64367,17 +64746,19 @@ function applyDisplayStripState() {
       '</span>' +
       '<span class="ui2-live-row-tags" aria-hidden="true">' +
         '<span class="ui2-live-row-tag ui2-live-row-privacy"></span>' +
+        '<span class="ui2-live-row-tag ui2-live-row-media"></span>' +
         '<span class="ui2-live-row-tag ui2-live-row-current"></span>' +
       '</span>';
     row.addEventListener('click', () => {
-      selectLiveDisplay(id, { focusStage: true, source: 'rail' });
-      if (drawerMedia.matches) setRailOpen(false, true);
+      const selected = selectLiveDisplay(id, { focusStage: true, source: 'rail' });
+      if (selected && drawerMedia.matches) setRailOpen(false, true);
     });
     return {
       row,
       title: row.querySelector('.ui2-live-row-title'),
       meta: row.querySelector('.ui2-live-row-meta'),
       privacy: row.querySelector('.ui2-live-row-privacy'),
+      media: row.querySelector('.ui2-live-row-media'),
       current: row.querySelector('.ui2-live-row-current'),
     };
   }
@@ -64423,6 +64804,25 @@ function applyDisplayStripState() {
       const error = Boolean(slot.statusEl && slot.statusEl.classList.contains('error'));
       const active = id === selectedDisplayId;
       const privateView = displayAgentVisibility.get(id) === false;
+      const presenceStreaming = Boolean(slot.streaming);
+      const recording = Boolean(slot.recording);
+      const current = selectedSlot();
+      const releasesControl = !active && Boolean(
+        current && (current.interactive || current._takeControlPending || current.authorityState === 'you')
+      );
+      const blocksForEdit = !active && slotHasBlockingSurfaceWork(current);
+      const visibilityLabel = privateView
+        ? 'private dashboard view; agent cannot see it'
+        : (displayAgentVisibility.get(id) === true && userDisplayIds.has(id))
+          ? 'shared with the agent'
+          : 'agent workspace';
+      const stateLabels = [
+        visibilityLabel,
+        presenceStreaming ? 'streaming frames to the presence model' : '',
+        recording ? 'recording' : '',
+        releasesControl ? 'switching here releases current input control' : '',
+        blocksForEdit ? 'finish the current annotation or callout before switching' : '',
+      ].filter(Boolean);
 
       record.row.classList.toggle('ok', Boolean(slot.connected));
       record.row.classList.toggle('err', error);
@@ -64431,13 +64831,23 @@ function applyDisplayStripState() {
       record.row.setAttribute('aria-pressed', active ? 'true' : 'false');
       if (active) record.row.setAttribute('aria-current', 'true');
       else record.row.removeAttribute('aria-current');
-      record.row.title = active ? label + ' is shown on the stage' : 'Show ' + label + ' on the stage';
+      record.row.title = active
+        ? label + ' is shown on the stage'
+        : blocksForEdit
+          ? 'Finish the current annotation or callout before showing ' + label
+          : 'Show ' + label + ' on the stage' +
+            (releasesControl ? ' and release current input control' : '');
       record.row.setAttribute('aria-label',
-        label + ', ' + status + ', input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown));
+        label + ', ' + status + ', input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown) +
+        ', ' + stateLabels.join(', '));
       record.title.textContent = label;
       record.meta.textContent = status + ' · input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown);
       record.privacy.textContent = privateView ? 'PRIVATE' : '';
       record.privacy.title = privateView ? 'The agent cannot see this private view' : '';
+      record.media.textContent = [presenceStreaming ? 'STREAM' : '', recording ? 'REC' : '']
+        .filter(Boolean).join(' · ');
+      record.media.classList.toggle('streaming', presenceStreaming);
+      record.media.classList.toggle('recording', recording);
       record.current.textContent = active ? 'VIEWING' : (slot.connected ? 'LIVE' : '');
       ordered.push(record);
     }
@@ -64473,10 +64883,12 @@ function applyDisplayStripState() {
       // authority round-trip (or after a failed release), let the holder
       // safely re-bind listeners instead of trapping it behind a Release-
       // only toolbar state.
+      if (drawerMedia.matches) setRailOpen(false, true);
       slot.takeControl();
       return;
     }
     const source = slot.authorityState === 'you' ? slot.releaseBtn : slot.takeBtn;
+    if (source === slot.takeBtn && drawerMedia.matches) setRailOpen(false, true);
     if (source && !source.disabled) source.click();
   });
 
@@ -64563,17 +64975,16 @@ function applyDisplayStripState() {
 
   function snapshotSlot(slot) {
     const statusEl = slot.statusEl;
-    const mode = slot.interactive
-      ? 'interactive'
-      : slot.connected
-        ? 'connected'
-        : statusEl && statusEl.classList.contains('error')
-          ? 'error'
-          : statusEl && statusEl.classList.contains('warn')
-            ? 'warn'
-            : 'connecting';
+    const connection = slot.connected
+      ? 'connected'
+      : statusEl && statusEl.classList.contains('error')
+        ? 'error'
+        : statusEl && statusEl.classList.contains('warn')
+          ? 'warn'
+          : 'connecting';
     return {
-      mode,
+      connection,
+      interactive: Boolean(slot.interactive),
       authority: slot.authorityState || 'unknown',
       streaming: Boolean(slot.streaming),
       recording: Boolean(slot.recording),
@@ -64605,9 +65016,9 @@ function applyDisplayStripState() {
     const prev = slotSnapshots.get(id);
     if (!prev) {
       addDisplayActivity(id, 'neutral', 'Display became available');
-      if (next.mode === 'connected') addDisplayActivity(id, 'live', 'Live stream connected');
-      else if (next.mode === 'interactive') addDisplayActivity(id, 'control', 'Interactive input is active');
-      else if (next.mode === 'error') addDisplayActivity(id, 'error', 'The stream needs attention');
+      if (next.connection === 'connected') addDisplayActivity(id, 'live', 'Live stream connected');
+      else if (next.connection === 'error') addDisplayActivity(id, 'error', 'The stream needs attention');
+      if (next.interactive) addDisplayActivity(id, 'control', 'Interactive input is active');
       if (next.visibility === 'private') addDisplayActivity(id, 'private', 'Private dashboard view started');
       if (next.visibility === 'agent') addDisplayActivity(id, 'share', 'Display shared with the agent');
       if (next.authority === 'you') addDisplayActivity(id, 'control', 'This dashboard holds input authority');
@@ -64617,12 +65028,15 @@ function applyDisplayStripState() {
       return;
     }
 
-    if (prev.mode !== next.mode) {
-      if (next.mode === 'connected') addDisplayActivity(id, 'live', 'Live stream connected');
-      else if (next.mode === 'interactive') addDisplayActivity(id, 'control', 'Interactive input is active');
-      else if (next.mode === 'error') addDisplayActivity(id, 'error', 'The stream needs attention');
-      else if (next.mode === 'warn') addDisplayActivity(id, 'attention', 'The stream is reconnecting');
+    if (prev.connection !== next.connection) {
+      if (next.connection === 'connected') addDisplayActivity(id, 'live', 'Live stream connected');
+      else if (next.connection === 'error') addDisplayActivity(id, 'error', 'The stream needs attention');
+      else if (next.connection === 'warn') addDisplayActivity(id, 'attention', 'The stream is reconnecting');
       else addDisplayActivity(id, 'neutral', 'Connecting to the display');
+    }
+    if (prev.interactive !== next.interactive) {
+      addDisplayActivity(id, next.interactive ? 'control' : 'neutral',
+        next.interactive ? 'Interactive input is active' : 'Interactive input ended');
     }
     if (prev.authority !== next.authority) {
       if (next.authority === 'you') addDisplayActivity(id, 'control', 'You took input control');
@@ -64666,16 +65080,32 @@ function applyDisplayStripState() {
       entries.map(entry => String(entry.seq)).join(',');
     if (signature === lastActivitySignature) return;
     lastActivitySignature = signature;
-    activityList.replaceChildren();
+    if (activityRenderedDisplayId !== selectedDisplayId) {
+      activityRenderedDisplayId = selectedDisplayId;
+      activityRows.clear();
+      activityList.replaceChildren();
+    }
     if (!entries.length) {
-      activityList.appendChild(emptyHint(
-        selectedDisplayId === null
-          ? 'Select a display to see its connection, authority, sharing, and recording events.'
-          : 'Display events will appear here as its real state changes.'));
+      if (!activityList.querySelector('.ui2-live-rail-empty')) {
+        activityList.appendChild(emptyHint(
+          selectedDisplayId === null
+            ? 'Select a display to see its connection, authority, sharing, and recording events.'
+            : 'Display events will appear here as its real state changes.'));
+      }
       return;
     }
-
-    for (const entry of entries.slice().reverse()) {
+    activityList.querySelector('.ui2-live-rail-empty')?.remove();
+    const liveSeqs = new Set(entries.map(entry => entry.seq));
+    for (const [seq, row] of activityRows) {
+      if (liveSeqs.has(seq)) continue;
+      row.remove();
+      activityRows.delete(seq);
+    }
+    // role=log expects chronological DOM order so only the newly appended
+    // row is announced. Rebuilding newest-first made every state change
+    // sound like ten new events to screen readers.
+    for (const entry of entries) {
+      if (activityRows.has(entry.seq)) continue;
       const row = document.createElement('div');
       row.className = 'ui2-live-activity-row kind-' + entry.kind;
       const dot = document.createElement('span');
@@ -64692,6 +65122,7 @@ function applyDisplayStripState() {
       row.appendChild(textEl);
       row.appendChild(time);
       activityList.appendChild(row);
+      activityRows.set(entry.seq, row);
     }
   }
 
@@ -64817,7 +65248,8 @@ function applyDisplayStripState() {
       if (!chip || chip.disabled) return;
       const hostId = chip.dataset.hostId || '';
       const displayId = Number(chip.dataset.displayId || 0);
-      if (typeof routeTo === 'function') routeTo('station');
+      if (typeof routeTo === 'function' && routeTo('station') === false) return;
+      if (drawerMedia.matches) setRailOpen(false, false);
       if (hostId && typeof stationOpenDisplay === 'function') {
         stationOpenDisplay(hostId, displayId);
       } else {
@@ -64879,7 +65311,17 @@ function applyDisplayStripState() {
       return;
     }
     const state = slot.authorityState || 'unknown';
-    mobileSummary.textContent = slotLabel(slot) + ' · input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown);
+    const slots = Array.from(displaySlots.values());
+    const streamingCount = slots.filter(item => item.streaming).length;
+    const recordingCount = slots.filter(item => item.recording).length;
+    const parts = [
+      slotLabel(slot),
+      'input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown),
+      streamingCount ? streamingCount + ' presence stream' + (streamingCount === 1 ? '' : 's') : '',
+      recordingCount ? recordingCount + ' recording' + (recordingCount === 1 ? '' : 's') : '',
+    ].filter(Boolean);
+    mobileSummary.textContent = parts.join(' · ');
+    mobileSummary.title = parts.join(', ');
   }
 
   function drawerFocusable() {
@@ -64888,20 +65330,34 @@ function applyDisplayStripState() {
     )).filter(element => element.getClientRects().length > 0);
   }
 
-  function syncDrawerState(restoreFocus) {
+  function syncDrawerState(restoreFocus, force) {
+    if (!force && document.body.classList.contains('display-fullscreen-open')) return;
     const drawer = drawerMedia.matches;
     const visible = !drawer || railOpen;
     tab.classList.toggle('ui2-live-rail-open', drawer && railOpen);
     rail.inert = !visible;
     if (visible) rail.removeAttribute('aria-hidden');
     else rail.setAttribute('aria-hidden', 'true');
+    if (drawer) {
+      rail.setAttribute('role', 'dialog');
+      rail.setAttribute('aria-modal', railOpen ? 'true' : 'false');
+    } else {
+      rail.removeAttribute('role');
+      rail.removeAttribute('aria-modal');
+    }
+    if (main) {
+      main.inert = drawer && railOpen;
+      if (drawer && railOpen) main.setAttribute('aria-hidden', 'true');
+      else main.removeAttribute('aria-hidden');
+    }
     if (railToggle) railToggle.setAttribute('aria-expanded', drawer && railOpen ? 'true' : 'false');
     if (railScrim) {
-      railScrim.tabIndex = drawer && railOpen ? 0 : -1;
+      railScrim.tabIndex = -1;
       railScrim.setAttribute('aria-hidden', drawer && railOpen ? 'false' : 'true');
     }
     if (restoreFocus && railToggle && drawer) railToggle.focus();
   }
+  window.syncLiveDisplayDrawerState = () => syncDrawerState(false, true);
 
   function setRailOpen(open, restoreFocus) {
     railOpen = drawerMedia.matches && Boolean(open);
@@ -64933,13 +65389,22 @@ function applyDisplayStripState() {
   });
   document.addEventListener('keydown', event => {
     if (event.key === 'Escape' && drawerMedia.matches && railOpen) {
+      // The portalled display picker is above the drawer and owns the
+      // first Escape. Its later fragment closes it and restores focus;
+      // leave the underlying controls drawer in place.
+      if (document.getElementById('display-picker')?.classList.contains('visible')) return;
       event.preventDefault();
       setRailOpen(false, true);
     }
   });
   const onDrawerMediaChange = () => {
+    const focusWasInRail = rail.contains(document.activeElement);
+    if (typeof hideDisplayPicker === 'function' && displayPickerVisible) {
+      hideDisplayPicker(false);
+    }
     railOpen = false;
     syncDrawerState(false);
+    if (drawerMedia.matches && focusWasInRail && railToggle) railToggle.focus();
   };
   if (typeof drawerMedia.addEventListener === 'function') {
     drawerMedia.addEventListener('change', onDrawerMediaChange);
@@ -65923,9 +66388,7 @@ function deleteRecordingStream(streamName) {
     if (slot.recordingStreamName === streamName) {
       slot.recordingStreamName = null;
       slot.recording = false;
-      slot.recordBtn.innerHTML = '&#x23FA; Record';
-      slot.recordBtn.classList.remove('active');
-      slot.deleteRecBtn.style.display = 'none';
+      slot._renderRecordingControls();
     }
   }
 
@@ -66088,7 +66551,6 @@ async function reconcileRecordingStreams() {
     }
   } catch { /* no recordings available */ }
 }
-
 /* ── static/app/47-annotation-clips.js ── */
 // ── Annotation Drawing ──
 /** Draw an array of annotation shapes onto a canvas context.
@@ -68850,6 +69312,14 @@ function tabDomMatches(tab) {
 // is used (or preserved if it's already the active one).
 function routeTo(tab, subtab) {
   if (tab === 'access' && subtab) subtab = normalizeAccessSubtab(subtab);
+  // A live annotation/callout is editable state, not navigation chrome.
+  // Refuse the route before changing the URL so a tab click cannot silently
+  // discard it or leave the hash claiming a pane we did not open.
+  if (activeTab === 'displays' && tab !== 'displays' &&
+      typeof window.canDeactivateLiveDisplayWorkspace === 'function' &&
+      !window.canDeactivateLiveDisplayWorkspace()) {
+    return false;
+  }
   const target = subtab ? `${tab}/${subtab}` : tab;
   if (DASHBOARD_ACCESS_PAGE_MODE && tab !== 'access') {
     window.location.href = daemonDashboardHref(`#${target}`);
@@ -68880,6 +69350,7 @@ function routeTo(tab, subtab) {
   if (tab === 'stats' && !switched) {
     renderStatsForActiveHost({ forceSessions: true });
   }
+  return true;
 }
 
 // Apply the URL's current hash to the actual DOM. Called on initial
@@ -68897,7 +69368,13 @@ function applyCurrentRoute() {
   const switched = tab !== activeTab;
   const needsDomApply = !tabDomMatches(tab);
   if (switched || needsDomApply) {
-    switchTab(tab);
+    if (switchTab(tab) === false) {
+      // Back/forward or a manually edited hash can bypass routeTo's
+      // preflight. Keep the editable Live surface active and restore the
+      // URL without creating another history entry.
+      history.replaceState(null, '', '#displays');
+      return;
+    }
   }
   if (tab === 'activity' && subtab) {
     switchActivitySubtab(subtab);
@@ -68921,6 +69398,16 @@ window.addEventListener('popstate', applyCurrentRoute);
 window.addEventListener('hashchange', applyCurrentRoute);
 
 function switchTab(tabId) {
+  // Interactive display input includes a document-level paste handler.
+  // Never leave it bound to a stage that is about to become hidden on
+  // Station, Sessions, Settings, etc. Activity already moves the canvas
+  // into a thumbnail and historically released there; this single entry
+  // point makes every navigation path follow the same held-key-flush →
+  // authority-release ordering.
+  if (activeTab === 'displays' && tabId !== 'displays' &&
+      typeof window.deactivateLiveDisplayWorkspace === 'function') {
+    if (window.deactivateLiveDisplayWorkspace() === false) return false;
+  }
   activeTab = tabId;
   document.querySelectorAll('.tab-btn').forEach(b => b.classList.toggle('active', b.dataset.tab === tabId));
   document.querySelectorAll('.tab-pane').forEach(p => p.classList.toggle('active', p.id === 'tab-' + tabId));
@@ -68986,6 +69473,7 @@ function switchTab(tabId) {
     if (activeAccessSubtab === 'diagnostics') renderConnectHealthPanel();
   }
   flushPaneRenders(tabId);
+  return true;
 }
 
 // ── Settings sub-tabs ──
@@ -69160,6 +69648,7 @@ function switchActivitySubtab(name) {
   if (name === 'control') {
     refreshControlPane();
   }
+  return true;
 }
 
 let activeSessionsSubtab = 'recent';
@@ -69338,7 +69827,6 @@ if (document.readyState === 'loading') {
 } else {
   applyInitialRouteFromHash();
 }
-
 /* ── static/app/48b-context-viz.js ── */
 // ── Context visualizer (Activity → Context pane) ──
 // Snapshot store/replay, payload analysis, and the Three.js scene for
@@ -97486,21 +97974,72 @@ function updateDisplayMetrics(d) {
 // render against them at load time.)
 let displayPickerVisible = false;
 let displayPickerReturnFocus = null;
+let displayPickerPositionRaf = 0;
+let displayPickerDrawerModal = false;
 // Which action the open picker performs: 'share' (agent access) or
 // 'view' (private remote view; the agent cannot see the display).
 let displayPickerMode = 'share';
 var cachedDisplays = null;
 
-function hideDisplayPicker() {
+function hideDisplayPicker(restoreFocus = true) {
   const picker = document.getElementById('display-picker');
   picker.classList.remove('visible');
   picker.setAttribute('aria-hidden', 'true');
   displayPickerVisible = false;
+  if (displayPickerDrawerModal) {
+    const rail = document.getElementById('ui2-live-rail');
+    const railOpen = document.getElementById('tab-displays')?.classList.contains('ui2-live-rail-open');
+    if (rail) {
+      rail.inert = !railOpen;
+      if (railOpen) rail.removeAttribute('aria-hidden');
+      else rail.setAttribute('aria-hidden', 'true');
+      rail.setAttribute('aria-modal', railOpen ? 'true' : 'false');
+    }
+    displayPickerDrawerModal = false;
+  }
   const returnFocus = displayPickerReturnFocus;
   displayPickerReturnFocus = null;
-  if (returnFocus && returnFocus.isConnected && typeof returnFocus.focus === 'function') {
+  if (restoreFocus && returnFocus && returnFocus.isConnected &&
+      typeof returnFocus.focus === 'function' && !returnFocus.closest('[inert]')) {
     returnFocus.focus();
   }
+}
+
+function positionDisplayPicker() {
+  const picker = document.getElementById('display-picker');
+  if (!displayPickerVisible || picker.parentElement !== document.body) return;
+  const anchor = document.getElementById('ui2-live-yourscreen');
+  const rect = anchor ? anchor.getBoundingClientRect() : null;
+  const margin = 12;
+  const gap = 8;
+  const width = picker.offsetWidth;
+  const height = picker.offsetHeight;
+  picker.style.position = 'fixed';
+  picker.style.zIndex = '95';
+  picker.style.right = 'auto';
+  picker.style.transform = 'none';
+  if (rect && rect.width) {
+    const maxLeft = Math.max(margin, window.innerWidth - width - margin);
+    const left = Math.min(Math.max(margin, rect.left), maxLeft);
+    let top = rect.bottom + gap;
+    if (top + height > window.innerHeight - margin && rect.top - height - gap >= margin) {
+      top = rect.top - height - gap;
+    }
+    const maxTop = Math.max(margin, window.innerHeight - height - margin);
+    picker.style.left = `${Math.round(left)}px`;
+    picker.style.top = `${Math.round(Math.min(Math.max(margin, top), maxTop))}px`;
+  } else {
+    picker.style.left = `${Math.round(Math.max(margin, (window.innerWidth - width) / 2))}px`;
+    picker.style.top = `${Math.round(Math.min(96, Math.max(margin, window.innerHeight - height - margin)))}px`;
+  }
+}
+
+function scheduleDisplayPickerPosition() {
+  if (!displayPickerVisible || displayPickerPositionRaf) return;
+  displayPickerPositionRaf = requestAnimationFrame(() => {
+    displayPickerPositionRaf = 0;
+    positionDisplayPicker();
+  });
 }
 
 function showDisplayPicker(displays, mode) {
@@ -97534,7 +98073,7 @@ function showDisplayPicker(displays, mode) {
     }
     item.addEventListener('click', (e) => {
       e.stopPropagation();
-      hideDisplayPicker();
+      hideDisplayPicker(true);
       if (!app) return;
       grantUserDisplayTarget(d, displayPickerMode !== 'view');
     });
@@ -97550,7 +98089,7 @@ function showDisplayPicker(displays, mode) {
     createItem.title = 'Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed.';
     createItem.addEventListener('click', (e) => {
       e.stopPropagation();
-      hideDisplayPicker();
+      hideDisplayPicker(true);
       createVirtualDisplay();
     });
     picker.appendChild(createItem);
@@ -97564,25 +98103,22 @@ function showDisplayPicker(displays, mode) {
     document.body.appendChild(picker);
   }
   if (picker.parentElement === document.body) {
-    const anchor = document.getElementById('ui2-live-yourscreen');
-    const rect = anchor ? anchor.getBoundingClientRect() : null;
-    picker.style.position = 'fixed';
-    picker.style.zIndex = '95';
-    if (rect && rect.width) {
-      picker.style.left = `${Math.round(rect.left)}px`;
-      picker.style.top = `${Math.round(rect.bottom + 8)}px`;
-      picker.style.right = 'auto';
-      picker.style.transform = 'none';
-    } else {
-      picker.style.left = '50%';
-      picker.style.top = '96px';
-      picker.style.right = 'auto';
-      picker.style.transform = 'translateX(-50%)';
+    const drawerOpen = document.getElementById('tab-displays')?.classList.contains('ui2-live-rail-open');
+    picker.setAttribute('aria-modal', drawerOpen ? 'true' : 'false');
+    displayPickerDrawerModal = Boolean(drawerOpen);
+    if (displayPickerDrawerModal) {
+      const rail = document.getElementById('ui2-live-rail');
+      if (rail) {
+        rail.inert = true;
+        rail.setAttribute('aria-hidden', 'true');
+        rail.setAttribute('aria-modal', 'false');
+      }
     }
   }
   picker.classList.add('visible');
   picker.setAttribute('aria-hidden', 'false');
   displayPickerVisible = true;
+  positionDisplayPicker();
   requestAnimationFrame(() => picker.querySelector('.display-picker-item')?.focus());
 }
 
@@ -97758,11 +98294,35 @@ function setUserDisplayState(granted, agentVisible = true) {
 document.addEventListener('click', (e) => {
   if (!displayPickerVisible) return;
   const picker = document.getElementById('display-picker');
-  if (!picker.contains(e.target)) hideDisplayPicker();
+  if (!picker.contains(e.target)) hideDisplayPicker(false);
 });
 document.addEventListener('keydown', (e) => {
-  if (e.key === 'Escape' && displayPickerVisible) hideDisplayPicker();
-});
+  if (!displayPickerVisible) return;
+  const picker = document.getElementById('display-picker');
+  if (e.key === 'Escape') {
+    // Capture owns the first Escape so annotation/callout/drawer layers
+    // underneath cannot consume the same keystroke.
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    hideDisplayPicker(true);
+    return;
+  }
+  if (e.key !== 'Tab' || picker.getAttribute('aria-modal') !== 'true') return;
+  const focusable = Array.from(picker.querySelectorAll('button:not([disabled])'))
+    .filter(element => element.getClientRects().length > 0);
+  if (!focusable.length) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (e.shiftKey && (document.activeElement === first || !picker.contains(document.activeElement))) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && (document.activeElement === last || !picker.contains(document.activeElement))) {
+    e.preventDefault();
+    first.focus();
+  }
+}, true);
+window.addEventListener('resize', scheduleDisplayPickerPosition);
+document.addEventListener('scroll', scheduleDisplayPickerPosition, true);
 
 // Rollback modal: Escape closes, click on the backdrop (outside the
 // dialog) also closes — follows the same dismissal pattern as the

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -195,12 +195,14 @@
               <button class="strip-minimize-btn" id="strip-minimize" type="button" title="Minimize displays" aria-label="Minimize displays" aria-pressed="false">&minus;</button>
               <button class="strip-toggle-btn" id="strip-toggle" title="Expand displays">&#x25BE;</button>
             </div>
-            <div class="shared-view-banner shared-view-banner-compact hidden" id="activity-shared-view-banner" data-shared-view-banner>
+            <div class="shared-view-banner shared-view-banner-compact hidden" id="activity-shared-view-banner"
+                 data-shared-view-banner role="status" aria-live="polite" aria-atomic="true">
               <span class="shared-view-kicker">Shared view</span>
               <span class="shared-view-message" data-shared-view-message></span>
               <span class="shared-view-actions">
                 <button class="shared-view-action" type="button" style="display:none" data-shared-view-take-input title="Take input authority for the focused display">Take input</button>
-                <button class="shared-view-close" type="button" data-shared-view-close title="Hide shared view">&times;</button>
+                <button class="shared-view-close" type="button" data-shared-view-close
+                        aria-label="Hide shared view" title="Hide shared view">&times;</button>
               </span>
             </div>
             <div class="activity-display-row" id="activity-display-row"></div>
@@ -985,19 +987,21 @@
           Displays &amp; input
         </button>
       </div>
-      <div class="display-approval-banner hidden" id="display-approval-banner">
+      <div class="display-approval-banner hidden" id="display-approval-banner" role="alert" aria-atomic="true">
         <div class="icon">&#x26A0;</div>
         <div class="text">
           <div class="title">Screen sharing approval needed</div>
           <div class="subtitle">A dialog should be visible on the guest desktop — approve it to start the video stream.</div>
         </div>
       </div>
-      <div class="shared-view-banner hidden" id="shared-view-banner" data-shared-view-banner>
+      <div class="shared-view-banner hidden" id="shared-view-banner" data-shared-view-banner
+           role="status" aria-live="polite" aria-atomic="true">
         <span class="shared-view-kicker">Shared view</span>
         <span class="shared-view-message" id="shared-view-message" data-shared-view-message></span>
         <span class="shared-view-actions">
           <button class="shared-view-action" id="shared-view-take-input" type="button" style="display:none" data-shared-view-take-input title="Take input authority for the focused display">Take input</button>
-          <button class="shared-view-close" type="button" id="shared-view-close" data-shared-view-close title="Hide shared view">&times;</button>
+          <button class="shared-view-close" type="button" id="shared-view-close" data-shared-view-close
+                  aria-label="Hide shared view" title="Hide shared view">&times;</button>
         </span>
       </div>
       <div class="displays-container" id="displays-container">
@@ -1132,7 +1136,7 @@
         </section>
         <section aria-labelledby="ui2-live-authority-heading">
           <h3 class="ui2-live-rail-eyebrow" id="ui2-live-authority-heading">Input authority</h3>
-          <div id="ui2-live-authority-card" aria-live="polite" aria-atomic="true"></div>
+          <div id="ui2-live-authority-card"></div>
         </section>
         <section aria-labelledby="ui2-live-activity-heading">
           <h3 class="ui2-live-rail-eyebrow" id="ui2-live-activity-heading">Display activity</h3>

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -28,7 +28,7 @@
     <span class="display-toggle-wrap">
       <span class="field-label" id="sb-display-label" onclick="toggleUserDisplay(event)" title="Your display — click to grant/revoke agent access to your screen for computer use tasks">your display</span>
       <span id="sb-display-access" onclick="toggleUserDisplay(event)" title="Your display — click to grant/revoke agent access to your screen for computer use tasks">off</span>
-      <div class="display-picker" id="display-picker"></div>
+      <div class="display-picker" id="display-picker" aria-hidden="true"></div>
     </span>
     <span class="sep">|</span>
     <span class="field-label">Intendant session</span>
@@ -974,6 +974,17 @@
 
     <!-- Displays Tab -->
     <div id="tab-displays" class="tab-pane">
+      <div class="ui2-live-main" id="ui2-live-main">
+      <div class="ui2-live-mobile-bar">
+        <div>
+          <span class="ui2-live-mobile-kicker">Computer use</span>
+          <span class="ui2-live-mobile-summary" id="ui2-live-mobile-summary">No display selected</span>
+        </div>
+        <button class="ui2-live-rail-toggle" id="ui2-live-rail-toggle" type="button"
+                aria-controls="ui2-live-rail" aria-expanded="false">
+          Displays &amp; input
+        </button>
+      </div>
       <div class="display-approval-banner hidden" id="display-approval-banner">
         <div class="icon">&#x26A0;</div>
         <div class="text">
@@ -1103,6 +1114,40 @@
           <button id="rec-clip-btn" title="Send Clip (C)">&#127916; Clip</button>
         </div>
       </div>
+      </div>
+      <button class="ui2-live-rail-scrim" id="ui2-live-rail-scrim" type="button"
+              aria-label="Close live display controls" tabindex="-1"></button>
+      <aside class="ui2-live-rail" id="ui2-live-rail" aria-labelledby="ui2-live-rail-title">
+        <header class="ui2-live-rail-header">
+          <div>
+            <div class="ui2-live-rail-kicker">Live workspace</div>
+            <h2 id="ui2-live-rail-title">Computer use</h2>
+          </div>
+          <button class="ui2-live-rail-close" id="ui2-live-rail-close" type="button"
+                  aria-label="Close live display controls">&times;</button>
+        </header>
+        <section aria-labelledby="ui2-live-displays-heading">
+          <h3 class="ui2-live-rail-eyebrow" id="ui2-live-displays-heading">Displays</h3>
+          <div class="ui2-live-rail-list" id="ui2-live-displays-list" role="group" aria-label="Live displays"></div>
+        </section>
+        <section aria-labelledby="ui2-live-authority-heading">
+          <h3 class="ui2-live-rail-eyebrow" id="ui2-live-authority-heading">Input authority</h3>
+          <div id="ui2-live-authority-card" aria-live="polite" aria-atomic="true"></div>
+        </section>
+        <section aria-labelledby="ui2-live-activity-heading">
+          <h3 class="ui2-live-rail-eyebrow" id="ui2-live-activity-heading">Display activity</h3>
+          <div class="ui2-live-activity" id="ui2-live-activity" role="log"
+               aria-live="polite" aria-relevant="additions text"></div>
+        </section>
+        <section aria-labelledby="ui2-live-peer-heading">
+          <h3 class="ui2-live-rail-eyebrow" id="ui2-live-peer-heading">Peer displays</h3>
+          <div class="ui2-live-rail-list" id="ui2-live-peer-list" role="group" aria-label="Peer displays"></div>
+        </section>
+        <section aria-labelledby="ui2-live-yourscreen-heading">
+          <h3 class="ui2-live-rail-eyebrow" id="ui2-live-yourscreen-heading">Your screen</h3>
+          <div id="ui2-live-yourscreen"></div>
+        </section>
+      </aside>
     </div>
 
     <!-- Sessions Tab -->

--- a/static/app/33-station-core.js
+++ b/static/app/33-station-core.js
@@ -986,6 +986,8 @@ function stationRenderPeerChips() {
         const chip = document.createElement('button');
         chip.type = 'button';
         chip.className = 'station-peer-chip';
+        chip.dataset.hostId = hostId;
+        chip.dataset.displayId = String(displayId);
         chip.disabled = !d.connected;
         chip.title = d.connected
           ? `Open a live view of display ${displayId}${size} on ${name}`
@@ -1006,6 +1008,8 @@ function stationRenderPeerChips() {
     const chip = document.createElement('button');
     chip.type = 'button';
     chip.className = 'station-peer-chip';
+    chip.dataset.hostId = hostId;
+    chip.dataset.displayId = String(displayId);
     chip.disabled = !d.connected;
     chip.title = d.connected
       ? `Open a live view of display ${displayId} on ${name}`
@@ -2752,4 +2756,3 @@ async function stationApplyManagedAction(op, id = '', sessionId = '') {
     }
   }
 }
-

--- a/static/app/36-voice-wasm-init.js
+++ b/static/app/36-voice-wasm-init.js
@@ -907,20 +907,26 @@ async function main() {
       if (d.event === 'recording_started' && d.stream_name) {
         serverMsgStep(d, 'recording_started', () => {
           const slot = slotForRecordingStream(d.stream_name);
-          if (slot) { slot.recordingStreamName = d.stream_name; slot.recording = true; slot.recordBtn.innerHTML = '&#x23F9; Stop'; slot.recordBtn.classList.add('active'); slot.recordBtn.setAttribute('aria-pressed', 'true'); slot.deleteRecBtn.style.display = 'none'; }
+          if (slot) slot.applyRecordingState(true, d.stream_name);
           handleDebugRecordingEvent(d); // debug tab's Record button tracks its display's streams
         });
       } else if (d.event === 'recording_stopped' && d.stream_name) {
         serverMsgStep(d, 'recording_stopped', () => {
           const slot = slotForRecordingStream(d.stream_name);
-          if (slot) { slot.recordingStreamName = d.stream_name; slot.recording = false; slot.recordBtn.innerHTML = '&#x23FA; Record'; slot.recordBtn.classList.remove('active'); slot.recordBtn.setAttribute('aria-pressed', 'false'); slot.deleteRecBtn.style.display = ''; }
+          if (slot) slot.applyRecordingState(false, d.stream_name);
           handleDebugRecordingEvent(d);
         });
       } else if (d.event === 'recording_deleted' && d.stream_name) {
         serverMsgStep(d, 'recording_deleted', () => {
           const slot = slotForRecordingStream(d.stream_name);
-          if (slot) { if (slot.recordingStreamName === d.stream_name) slot.recordingStreamName = null; slot.recording = false; slot.recordBtn.innerHTML = '&#x23FA; Record'; slot.recordBtn.classList.remove('active'); slot.recordBtn.setAttribute('aria-pressed', 'false'); slot.deleteRecBtn.style.display = 'none'; }
+          if (slot) slot.applyRecordingState(false, d.stream_name, true);
           deleteRecordingStream(d.stream_name);
+        });
+      } else if (d.event === 'recording_error' && d.stream_name) {
+        serverMsgStep(d, 'recording_error', () => {
+          const slot = slotForRecordingStream(d.stream_name);
+          if (slot) slot._failRecordingCommand(d.message || 'Recording failed');
+          handleDebugRecordingEvent(d);
         });
       }
       // Display transport metrics (per-display sections)

--- a/static/app/36-voice-wasm-init.js
+++ b/static/app/36-voice-wasm-init.js
@@ -907,19 +907,19 @@ async function main() {
       if (d.event === 'recording_started' && d.stream_name) {
         serverMsgStep(d, 'recording_started', () => {
           const slot = slotForRecordingStream(d.stream_name);
-          if (slot) { slot.recordingStreamName = d.stream_name; slot.recording = true; slot.recordBtn.innerHTML = '&#x23F9; Stop'; slot.recordBtn.classList.add('active'); slot.deleteRecBtn.style.display = 'none'; }
+          if (slot) { slot.recordingStreamName = d.stream_name; slot.recording = true; slot.recordBtn.innerHTML = '&#x23F9; Stop'; slot.recordBtn.classList.add('active'); slot.recordBtn.setAttribute('aria-pressed', 'true'); slot.deleteRecBtn.style.display = 'none'; }
           handleDebugRecordingEvent(d); // debug tab's Record button tracks its display's streams
         });
       } else if (d.event === 'recording_stopped' && d.stream_name) {
         serverMsgStep(d, 'recording_stopped', () => {
           const slot = slotForRecordingStream(d.stream_name);
-          if (slot) { slot.recordingStreamName = d.stream_name; slot.recording = false; slot.recordBtn.innerHTML = '&#x23FA; Record'; slot.recordBtn.classList.remove('active'); slot.deleteRecBtn.style.display = ''; }
+          if (slot) { slot.recordingStreamName = d.stream_name; slot.recording = false; slot.recordBtn.innerHTML = '&#x23FA; Record'; slot.recordBtn.classList.remove('active'); slot.recordBtn.setAttribute('aria-pressed', 'false'); slot.deleteRecBtn.style.display = ''; }
           handleDebugRecordingEvent(d);
         });
       } else if (d.event === 'recording_deleted' && d.stream_name) {
         serverMsgStep(d, 'recording_deleted', () => {
           const slot = slotForRecordingStream(d.stream_name);
-          if (slot) { if (slot.recordingStreamName === d.stream_name) slot.recordingStreamName = null; slot.recording = false; slot.recordBtn.innerHTML = '&#x23FA; Record'; slot.recordBtn.classList.remove('active'); slot.deleteRecBtn.style.display = 'none'; }
+          if (slot) { if (slot.recordingStreamName === d.stream_name) slot.recordingStreamName = null; slot.recording = false; slot.recordBtn.innerHTML = '&#x23FA; Record'; slot.recordBtn.classList.remove('active'); slot.recordBtn.setAttribute('aria-pressed', 'false'); slot.deleteRecBtn.style.display = 'none'; }
           deleteRecordingStream(d.stream_name);
         });
       }
@@ -1417,4 +1417,3 @@ async function main() {
     if (modelConnected && app) disconnectDashboardVoice();
   });
 }
-

--- a/static/app/45-displays-webrtc.js
+++ b/static/app/45-displays-webrtc.js
@@ -241,25 +241,34 @@ class DisplaySlot {
     this.el.className = 'display-slot';
     const label = displayLabel(displayId);
     this.el.innerHTML = `
-      <div class="display-toolbar">
-        <span class="display-label">${label}</span>
-        <span class="display-visibility" id="ds-visibility-${displayId}" style="display:none"></span>
-        <span class="display-status" id="ds-status-${displayId}">Connecting...</span>
-        <span class="display-input-authority" id="ds-authority-${displayId}" style="display:none" title="Input authority for this display: who can drive keyboard/mouse. Phase 5c."></span>
-        <input class="release-note" id="ds-note-${displayId}" placeholder="Note (optional)" style="display:none">
-        <button class="stream-btn" id="ds-stream-${displayId}" title="Continuously send screenshots of this display to the live presence (voice) model. Main agents are not affected.">Stream</button>
-        <button class="ann-attach-btn" id="ds-attach-${displayId}" title="Capture current frame and attach to next task">Attach</button>
-        <button class="annotate-btn" id="ds-annotate-${displayId}" title="Freeze current frame and annotate it">&#9998; Annotate</button>
-        <button class="callout-btn" id="ds-callout-${displayId}" aria-pressed="false" disabled title="Call out a region: arm, then drag a rectangle on the frame to attach it to the next task (needs input control)">&#x2316; Callout</button>
-        <button class="record-btn" id="ds-record-${displayId}" title="Record this display (ffmpeg)">Record</button>
-        <button class="display-fullscreen-btn" id="ds-fullscreen-${displayId}" title="Full screen">&#x26F6;</button>
-        <button class="display-close-btn" id="ds-close-${displayId}" title="Close this display stream">&times;</button>
-        <button class="take-control-btn" id="ds-take-${displayId}" title="Take interactive control of this display (keyboard and mouse)">Take Control</button>
-        <button class="release-control-btn" id="ds-release-${displayId}" style="display:none" title="Release control and return display to view-only mode">Release</button>
-        <button class="delete-recording-btn" id="ds-delete-rec-${displayId}" style="display:none" title="Delete recording files for this display">Delete</button>
-        <span class="stream-frame-id" id="ds-frame-${displayId}" style="display:none;font-size:10px;color:var(--overlay0);margin-left:auto"></span>
+      <div class="display-toolbar" role="group">
+        <div class="display-toolbar-meta">
+          <span class="display-label"></span>
+          <span class="display-visibility" id="ds-visibility-${displayId}" style="display:none"></span>
+          <span class="display-status" id="ds-status-${displayId}" role="status" aria-live="polite" aria-atomic="true">Connecting...</span>
+          <span class="display-input-authority" id="ds-authority-${displayId}" role="status" aria-live="polite" aria-atomic="true" style="display:none" title="Input authority for this display: who can drive keyboard and pointer input."></span>
+        </div>
+        <div class="display-toolbar-actions">
+          <input class="release-note" id="ds-note-${displayId}" aria-label="Note to the agent when releasing this display" placeholder="Note (optional)" style="display:none">
+          <button class="stream-btn" id="ds-stream-${displayId}" type="button" aria-pressed="false" title="Continuously send screenshots of this display to the live presence (voice) model. Main agents are not affected.">Stream</button>
+          <button class="ann-attach-btn" id="ds-attach-${displayId}" type="button" title="Capture current frame and attach to next task">Attach</button>
+          <button class="annotate-btn" id="ds-annotate-${displayId}" type="button" aria-pressed="false" title="Freeze current frame and annotate it">&#9998; Annotate</button>
+          <button class="callout-btn" id="ds-callout-${displayId}" type="button" aria-pressed="false" disabled title="Call out a region: arm, then drag a rectangle on the frame to attach it to the next task (needs input control)">&#x2316; Callout</button>
+          <button class="record-btn" id="ds-record-${displayId}" type="button" aria-pressed="false" title="Record this display (ffmpeg)">Record</button>
+          <button class="display-fullscreen-btn" id="ds-fullscreen-${displayId}" type="button" aria-label="Open display full screen" title="Full screen">&#x26F6;</button>
+          <button class="display-close-btn" id="ds-close-${displayId}" type="button" aria-label="Close this display stream" title="Close this display stream">&times;</button>
+          <button class="take-control-btn" id="ds-take-${displayId}" type="button" title="Take interactive control of this display (keyboard and mouse)">Take control</button>
+          <button class="release-control-btn" id="ds-release-${displayId}" type="button" style="display:none" title="Release control and return display to view-only mode">Release</button>
+          <button class="delete-recording-btn" id="ds-delete-rec-${displayId}" type="button" style="display:none" title="Delete recording files for this display">Delete</button>
+          <span class="stream-frame-id" id="ds-frame-${displayId}" style="display:none;font-size:10px;color:var(--overlay0)"></span>
+        </div>
       </div>
       <div class="display-canvas" id="display-canvas-${displayId}"></div>`;
+    this.el.setAttribute('aria-label', label);
+    const labelEl = this.el.querySelector('.display-label');
+    if (labelEl) labelEl.textContent = label;
+    const toolbarEl = this.el.querySelector('.display-toolbar');
+    if (toolbarEl) toolbarEl.setAttribute('aria-label', `${label} controls`);
     this.statusEl = this.el.querySelector(`#ds-status-${displayId}`);
     this.visibilityEl = this.el.querySelector(`#ds-visibility-${displayId}`);
     this.authorityEl = this.el.querySelector(`#ds-authority-${displayId}`);
@@ -285,6 +294,8 @@ class DisplaySlot {
     this.videoEl.muted = true;
     this.videoEl.style.width = '100%';
     this.videoEl.style.backgroundColor = '#000';
+    this.videoEl.setAttribute('aria-label', `Live view of ${label}`);
+    this.videoEl.setAttribute('aria-describedby', `ds-status-${displayId} ds-authority-${displayId}`);
     this.canvasEl.appendChild(this.videoEl);
     // In-stage connection status overlay (time-to-first-frame): staged
     // copy while negotiating ("Negotiating…" → "Waiting for first
@@ -302,7 +313,14 @@ class DisplaySlot {
     this.metricsEl = document.createElement('div');
     this.metricsEl.className = 'display-live-metrics';
     this.metricsEl.style.display = 'none';
+    this.metricsEl.setAttribute('aria-hidden', 'true');
     this.canvasEl.appendChild(this.metricsEl);
+    this.controlBannerEl = document.createElement('div');
+    this.controlBannerEl.className = 'display-control-banner';
+    this.controlBannerEl.setAttribute('role', 'status');
+    this.controlBannerEl.setAttribute('aria-live', 'polite');
+    this.controlBannerEl.textContent = 'You have control — keyboard and pointer input drive this display.';
+    this.canvasEl.appendChild(this.controlBannerEl);
     const rerenderSharedFocus = () => {
       if (!sharedViewState.visible) return;
       if (sharedViewState.displayId !== null && Number(this.displayId) !== sharedViewState.displayId) return;
@@ -356,6 +374,8 @@ class DisplaySlot {
     if (this.fullscreenBtn) {
       this.fullscreenBtn.innerHTML = want ? '&times;' : '&#x26F6;';
       this.fullscreenBtn.title = want ? 'Exit full screen' : 'Full screen';
+      this.fullscreenBtn.setAttribute('aria-label', want ? 'Exit display full screen' : 'Open display full screen');
+      this.fullscreenBtn.setAttribute('aria-pressed', want ? 'true' : 'false');
     }
   }
 
@@ -850,7 +870,8 @@ class DisplaySlot {
     if (this.takeBtn) {
       this.takeBtn.disabled = pending;
       this.takeBtn.classList.toggle('is-pending', pending);
-      this.takeBtn.textContent = pending ? 'Requesting…' : 'Take Control';
+      this.takeBtn.textContent = pending ? 'Requesting…' : 'Take control';
+      this.takeBtn.setAttribute('aria-busy', pending ? 'true' : 'false');
     }
     if (pending) {
       this._takePendingTimer = window.setTimeout(() => {
@@ -877,6 +898,7 @@ class DisplaySlot {
   _enterInteractive() {
     if (this.interactive) return;
     this.interactive = true;
+    this.el.classList.add('is-interactive');
     this.noteInput.style.display = '';
     const res = this.width > 0 ? ` ${this.width}x${this.height}` : '';
     this.statusEl.textContent = `Interactive${res}`;
@@ -982,6 +1004,7 @@ class DisplaySlot {
   _exitInteractive(userInitiated) {
     if (!this.interactive) return;
     this.interactive = false;
+    this.el.classList.remove('is-interactive');
     // Item 3: flush synthetic keyups for every held key BEFORE the
     // listeners are removed. Server-driven demotion never fires blur, so
     // without this any held key (modifier or not) stays latched down on
@@ -1001,6 +1024,7 @@ class DisplaySlot {
       }
     }
     this._boundHandlers = {};
+    vid.removeAttribute('tabindex');
     const note = this.noteInput.value.trim() || undefined;
     this.noteInput.value = ''; this.noteInput.style.display = 'none';
     this.statusEl.textContent = this.connected ? 'Connected (view-only)' : 'Disconnected';
@@ -1110,6 +1134,7 @@ class DisplaySlot {
     if (this.streaming || !this.connected) return;
     this.streaming = true;
     this.streamBtn.classList.add('active');
+    this.streamBtn.setAttribute('aria-pressed', 'true');
     this.streamBtn.innerHTML = '&#x1F441; Streaming';
     this.frameIdEl.style.display = '';
     const streamName = 'display_' + this.displayId;
@@ -1161,6 +1186,7 @@ class DisplaySlot {
     this.streaming = false;
     if (this._streamIntervalId) { clearInterval(this._streamIntervalId); this._streamIntervalId = null; }
     this.streamBtn.classList.remove('active');
+    this.streamBtn.setAttribute('aria-pressed', 'false');
     this.streamBtn.innerHTML = '&#x1F441; Stream';
     this.frameIdEl.style.display = 'none';
     this.frameIdEl.textContent = '';
@@ -1174,6 +1200,7 @@ class DisplaySlot {
       this.recording = false;
       this.recordBtn.innerHTML = '&#x23FA; Record';
       this.recordBtn.classList.remove('active');
+      this.recordBtn.setAttribute('aria-pressed', 'false');
       this.deleteRecBtn.style.display = '';
     } else {
       dispatchDashboardActionMsg({ action: 'start_recording', stream_name: baseStream });
@@ -1181,6 +1208,7 @@ class DisplaySlot {
       this.recording = true;
       this.recordBtn.innerHTML = '&#x23F9; Stop';
       this.recordBtn.classList.add('active');
+      this.recordBtn.setAttribute('aria-pressed', 'true');
       this.deleteRecBtn.style.display = 'none';
     }
   }
@@ -1428,6 +1456,12 @@ function applySharedViewToSlot(slot) {
   if (sharedViewState.displayId !== null && Number(slot.displayId) !== sharedViewState.displayId) {
     return;
   }
+  // The Live workspace is a selected-display stage. Agent-requested
+  // shared views must foreground their real target rather than leaving
+  // the focus box mounted on a hidden slot.
+  if (typeof window.selectLiveDisplay === 'function') {
+    window.selectLiveDisplay(slot.displayId, { source: 'shared-view' });
+  }
   updateSharedViewBanner();
   slot.el.classList.add('shared-view-active');
   renderSharedViewFocus(slot, sharedViewState.region, sharedViewState.note);
@@ -1463,7 +1497,12 @@ function takeSharedViewInput() {
 }
 
 function handleSharedViewEvent(evt) {
-  const action = String(evt.action || 'show');
+  // Native shared_view historically emitted `input`; MCP already emits
+  // the presentation-level `input_request`. Canonicalize at the browser
+  // boundary so mixed-version daemons still expose the real Take input
+  // affordance without ever granting authority automatically.
+  const rawAction = String(evt.action || 'show');
+  const action = rawAction === 'input' ? 'input_request' : rawAction;
   if (action === 'hide') {
     hideSharedView();
     return;
@@ -1739,306 +1778,806 @@ function applyDisplayStripState() {
 }
 
 
-// ── ui-v2 Live-display right rail (design-overhaul P2) ─────────────────
-// Display-only mirror chrome, active only under the ?ui=v2 flag: renders
-// rail rows FROM existing state (displaySlots + slot DOM, the Station
-// peer-display chips, the sb-display-access grant chip) via
-// MutationObservers, and proxies every click to the existing controls.
-// It owns no state, sends no messages, and never touches the WebRTC
-// slots, the single-reparented <video> elements, or v1 markup. Honest
-// authority copy: taking control is last-take-wins displacement between
-// viewers (no request/approve ceremony), and "another viewer has input"
-// is a first-class rendered state.
+// ── Live display workspace ──────────────────────────────────────────────
+// The standalone CU concept is the presentation target; the production
+// displaySlots map remains the source of truth. This projection adds one
+// selected local stage, selected-slot authority controls, responsive rail
+// access, and a small feed of REAL browser-observed display lifecycle
+// changes. It never invents agent clicks, typed text, holder identities, or
+// display-scoped approvals: those do not exist in the current wire contract.
+//
+// Key safety rule: a hidden interactive slot would keep its document-level
+// paste handler. Selecting another display therefore releases the old slot
+// through DisplaySlot.releaseControl(), which flushes held keys before
+// releasing server authority. Live annotation/callout ownership is torn
+// down through the existing provider lifecycle before that slot is hidden.
 (() => {
   const tab = document.getElementById('tab-displays');
-  if (!tab) return;
-  const rail = document.createElement('aside');
-  rail.className = 'ui2-live-rail';
-  rail.id = 'ui2-live-rail';
-  rail.innerHTML = `
-    <section>
-      <div class="ui2-live-rail-eyebrow">Displays</div>
-      <div class="ui2-live-rail-list" id="ui2-live-displays-list"></div>
-    </section>
-    <section>
-      <div class="ui2-live-rail-eyebrow">Input authority</div>
-      <div id="ui2-live-authority-card"></div>
-    </section>
-    <section>
-      <div class="ui2-live-rail-eyebrow">Peer displays</div>
-      <div class="ui2-live-rail-list" id="ui2-live-peer-list"></div>
-    </section>
-    <section>
-      <div class="ui2-live-rail-eyebrow">Your screen</div>
-      <div id="ui2-live-yourscreen"></div>
-    </section>`;
-  tab.appendChild(rail);
-  const displaysList = rail.querySelector('#ui2-live-displays-list');
-  const authorityCard = rail.querySelector('#ui2-live-authority-card');
-  const peerList = rail.querySelector('#ui2-live-peer-list');
-  const yourScreen = rail.querySelector('#ui2-live-yourscreen');
-
-  const emptyHint = (text) => {
-    const div = document.createElement('div');
-    div.className = 'ui2-live-rail-empty';
-    div.textContent = text;
-    return div;
-  };
-
-  function renderDisplayRows() {
-    displaysList.textContent = '';
-    const slots = Array.from(displaySlots.values());
-    if (!slots.length) {
-      displaysList.appendChild(emptyHint('No displays active. They appear here when the agent launches a GUI or you share your screen.'));
-      return;
-    }
-    for (const slot of slots) {
-      const row = document.createElement('button');
-      row.type = 'button';
-      const err = slot.statusEl && slot.statusEl.classList.contains('error');
-      row.className = 'ui2-live-row' + (slot.connected ? ' ok viewing' : (err ? ' err' : ''));
-      const dot = document.createElement('span');
-      dot.className = 'ui2-live-row-dot';
-      const main = document.createElement('span');
-      main.className = 'ui2-live-row-main';
-      const title = document.createElement('span');
-      title.className = 'ui2-live-row-title';
-      const labelEl = slot.el && slot.el.querySelector('.display-label');
-      title.textContent = (labelEl && labelEl.textContent) || `Display ${slot.displayId}`;
-      const meta = document.createElement('span');
-      meta.className = 'ui2-live-row-meta';
-      meta.textContent = (slot.statusEl && slot.statusEl.textContent) || '';
-      main.appendChild(title);
-      main.appendChild(meta);
-      row.appendChild(dot);
-      row.appendChild(main);
-      if (displayAgentVisibility.get(Number(slot.displayId)) === false) {
-        const tag = document.createElement('span');
-        tag.className = 'ui2-live-row-tag';
-        tag.textContent = 'PRIVATE';
-        tag.title = 'Private view — the agent cannot see this display';
-        row.appendChild(tag);
-      }
-      if (slot.connected) {
-        const tag = document.createElement('span');
-        tag.className = 'ui2-live-row-tag';
-        tag.textContent = 'VIEWING';
-        row.appendChild(tag);
-      }
-      row.title = 'Scroll this display into view';
-      row.addEventListener('click', () => {
-        if (slot.el && slot.el.isConnected) slot.el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-      });
-      displaysList.appendChild(row);
-    }
-  }
+  const container = document.getElementById('displays-container');
+  const rail = document.getElementById('ui2-live-rail');
+  const displaysList = document.getElementById('ui2-live-displays-list');
+  const authorityCard = document.getElementById('ui2-live-authority-card');
+  const activityList = document.getElementById('ui2-live-activity');
+  const peerList = document.getElementById('ui2-live-peer-list');
+  const yourScreen = document.getElementById('ui2-live-yourscreen');
+  const mobileSummary = document.getElementById('ui2-live-mobile-summary');
+  const railToggle = document.getElementById('ui2-live-rail-toggle');
+  const railClose = document.getElementById('ui2-live-rail-close');
+  const railScrim = document.getElementById('ui2-live-rail-scrim');
+  if (!tab || !container || !rail || !displaysList || !authorityCard ||
+      !activityList || !peerList || !yourScreen) return;
 
   const AUTH_LABEL = {
     you: 'you',
     other: 'another viewer',
-    unclaimed: 'shared',
-    unknown: 'view-only',
+    unclaimed: 'available',
+    unknown: 'connecting',
   };
-  function renderAuthorityCard() {
-    authorityCard.textContent = '';
-    const card = document.createElement('div');
-    card.className = 'ui2-live-card';
-    const title = document.createElement('div');
-    title.className = 'ui2-live-card-title';
-    const sub = document.createElement('div');
-    sub.className = 'ui2-live-card-sub';
-    const slots = Array.from(displaySlots.values());
-    if (!slots.length) {
-      title.textContent = 'No live display';
-      sub.textContent = 'Input authority appears here once a display is streaming.';
-      card.appendChild(title);
-      card.appendChild(sub);
-      authorityCard.appendChild(card);
-      return;
-    }
-    const anyYou = slots.some(s => s.authorityState === 'you');
-    const anyOther = slots.some(s => s.authorityState === 'other');
-    title.textContent = anyYou
-      ? 'You have input control'
-      : anyOther
-        ? 'Another viewer has input'
-        : 'You have view-only';
-    sub.textContent = 'Take control forwards your mouse and keyboard to the display. It displaces whoever holds input — last take wins, there is no approval step. Release hands the display back.';
-    card.appendChild(title);
-    card.appendChild(sub);
-    for (const slot of slots) {
-      const row = document.createElement('div');
-      row.className = 'ui2-live-auth-row';
-      const name = document.createElement('span');
-      name.className = 'ui2-live-auth-name';
-      const labelEl = slot.el && slot.el.querySelector('.display-label');
-      name.textContent = (labelEl && labelEl.textContent) || `Display ${slot.displayId}`;
-      const pill = document.createElement('span');
-      const st = slot.authorityState || 'unknown';
-      pill.className = 'ui2-live-state-pill' + (st === 'you' ? ' you' : st === 'other' ? ' other' : '');
-      pill.textContent = AUTH_LABEL[st] || AUTH_LABEL.unknown;
-      row.appendChild(name);
-      row.appendChild(pill);
-      card.appendChild(row);
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      if (st === 'you') {
-        btn.className = 'ui2-live-card-btn release';
-        btn.textContent = 'Release control';
-        btn.title = 'Release input and return this display to view-only';
-        btn.addEventListener('click', () => {
-          const b = document.getElementById(`ds-release-${slot.displayId}`);
-          if (b) b.click();
-        });
-      } else {
-        btn.className = 'ui2-live-card-btn';
-        btn.textContent = st === 'other' ? 'Take control anyway' : 'Take control';
-        btn.title = st === 'other'
-          ? 'Takes input immediately and displaces the current viewer'
-          : 'Take interactive control of this display (keyboard and mouse)';
-        btn.addEventListener('click', () => {
-          const b = document.getElementById(`ds-take-${slot.displayId}`);
-          if (b) b.click();
-        });
-      }
-      card.appendChild(btn);
-    }
-    authorityCard.appendChild(card);
+  const displayRows = new Map();
+  const peerRows = new Map();
+  const peerSources = new Map();
+  const slotSnapshots = new Map();
+  const activityByDisplay = new Map();
+  const drawerMedia = window.matchMedia('(max-width: 1279px)');
+  let selectedDisplayId = null;
+  let railOpen = false;
+  let railRaf = 0;
+  let activitySeq = 0;
+  let lastActivitySignature = '';
+  let lastAuthoritySignature = '';
+  let lastScreenSignature = '';
+
+  function slotLabel(slot) {
+    const labelEl = slot && slot.el && slot.el.querySelector('.display-label');
+    return (labelEl && labelEl.textContent) || displayLabel(slot && slot.displayId);
   }
 
-  function renderPeerRows() {
-    peerList.textContent = '';
-    const chips = document.querySelectorAll('#station-peer-chips .station-peer-chip');
-    if (!chips.length) {
-      peerList.appendChild(emptyHint('No peer displays advertised. Paired daemons that share a display appear here.'));
+  function selectedSlot() {
+    return selectedDisplayId === null ? null : displaySlots.get(selectedDisplayId) || null;
+  }
+
+  function emptyHint(textValue) {
+    const div = document.createElement('div');
+    div.className = 'ui2-live-rail-empty';
+    div.textContent = textValue;
+    return div;
+  }
+
+  function setSelectedProjection() {
+    const slots = Array.from(displaySlots.values());
+    const selectedExists = selectedDisplayId !== null && displaySlots.has(selectedDisplayId);
+    container.classList.toggle('ui2-live-single-stage', slots.length > 0);
+    container.dataset.activeDisplayId = selectedExists ? String(selectedDisplayId) : '';
+    for (const slot of slots) {
+      const active = selectedExists && Number(slot.displayId) === selectedDisplayId;
+      slot.el.classList.toggle('ui2-live-selected', active);
+      slot.el.classList.toggle('ui2-live-inactive', !active);
+      slot.el.setAttribute('aria-hidden', active ? 'false' : 'true');
+      slot.el.inert = !active;
+    }
+  }
+
+  function teardownSelectedSurface(slot) {
+    if (!slot) return;
+    // releaseControl is the only safe ordering: held-key keyups are sent
+    // before the server-side authority release closes the input gate.
+    if (slot.interactive) slot.releaseControl();
+    if (typeof teardownLiveSurfaceForOwner === 'function') {
+      teardownLiveSurfaceForOwner(slot);
+    }
+  }
+
+  function selectLiveDisplay(displayId, options) {
+    const opts = options || {};
+    const id = Number(displayId);
+    const next = Number.isFinite(id) ? displaySlots.get(id) : null;
+    if (!next) return false;
+    if (selectedDisplayId !== id) {
+      teardownSelectedSurface(selectedSlot());
+      selectedDisplayId = id;
+    }
+    setSelectedProjection();
+    scheduleWorkspace();
+    if (opts.focusStage && next.el && next.el.isConnected) {
+      requestAnimationFrame(() => {
+        try { next.el.scrollIntoView({ block: 'nearest', inline: 'nearest' }); } catch (_) {}
+      });
+    }
+    return true;
+  }
+  window.selectLiveDisplay = selectLiveDisplay;
+
+  function reconcileSelectedDisplay(slots) {
+    const shared = slots.find(slot => slot.el && slot.el.classList.contains('shared-view-active'));
+    if (shared && Number(shared.displayId) !== selectedDisplayId) {
+      selectLiveDisplay(shared.displayId, { source: 'shared-view' });
       return;
     }
-    chips.forEach((chip) => {
-      const row = document.createElement('button');
-      row.type = 'button';
-      row.className = 'ui2-live-row' + (chip.disabled ? '' : ' ok');
-      row.disabled = chip.disabled;
-      row.title = chip.title || '';
-      const dot = document.createElement('span');
-      dot.className = 'ui2-live-row-dot';
-      const main = document.createElement('span');
-      main.className = 'ui2-live-row-main';
-      const title = document.createElement('span');
-      title.className = 'ui2-live-row-title';
-      title.textContent = chip.textContent || '';
-      const meta = document.createElement('span');
-      meta.className = 'ui2-live-row-meta';
-      meta.textContent = chip.disabled ? 'peer offline' : 'peer · view display';
-      main.appendChild(title);
-      main.appendChild(meta);
-      const chev = document.createElement('span');
-      chev.className = 'ui2-live-row-chev';
-      chev.textContent = '›';
-      row.appendChild(dot);
-      row.appendChild(main);
-      row.appendChild(chev);
-      row.addEventListener('click', () => chip.click());
-      peerList.appendChild(row);
+    if (selectedDisplayId !== null && displaySlots.has(selectedDisplayId)) {
+      setSelectedProjection();
+      return;
+    }
+    selectedDisplayId = slots.length ? Number(slots[0].displayId) : null;
+    setSelectedProjection();
+  }
+
+  function createDisplayRow(id) {
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = 'ui2-live-row';
+    row.dataset.displayId = String(id);
+    row.innerHTML =
+      '<span class="ui2-live-row-dot" aria-hidden="true"></span>' +
+      '<span class="ui2-live-row-main">' +
+        '<span class="ui2-live-row-title"></span>' +
+        '<span class="ui2-live-row-meta"></span>' +
+      '</span>' +
+      '<span class="ui2-live-row-tags" aria-hidden="true">' +
+        '<span class="ui2-live-row-tag ui2-live-row-privacy"></span>' +
+        '<span class="ui2-live-row-tag ui2-live-row-current"></span>' +
+      '</span>';
+    row.addEventListener('click', () => {
+      selectLiveDisplay(id, { focusStage: true, source: 'rail' });
+      if (drawerMedia.matches) setRailOpen(false, true);
+    });
+    return {
+      row,
+      title: row.querySelector('.ui2-live-row-title'),
+      meta: row.querySelector('.ui2-live-row-meta'),
+      privacy: row.querySelector('.ui2-live-row-privacy'),
+      current: row.querySelector('.ui2-live-row-current'),
+    };
+  }
+
+  function orderRows(parent, records) {
+    records.forEach((record, index) => {
+      const current = parent.children[index] || null;
+      if (current !== record.row) parent.insertBefore(record.row, current);
     });
   }
 
-  function renderYourScreen() {
-    yourScreen.textContent = '';
-    const card = document.createElement('div');
-    card.className = 'ui2-live-card';
-    const head = document.createElement('div');
-    head.style.display = 'flex';
-    head.style.alignItems = 'center';
-    head.style.gap = '8px';
-    const title = document.createElement('div');
-    title.className = 'ui2-live-card-title';
-    title.style.flex = '1';
-    title.textContent = 'Your screen';
-    // Two distinct things can be active here, and the card never
-    // conflates them:
-    //  - a PRIVATE VIEW ("View this machine"): remote view/control of
-    //    this machine from the dashboard; the agent cannot see it;
-    //  - an AGENT SHARE ("Share with agent"): the screen is visible to
-    //    the agent for computer-use tasks.
-    // (Streaming frames to the live presence/voice model is a third,
-    // separate control -- the Stream button on the display tile.)
-    const granted = userDisplayGranted;
-    const shared = granted && userDisplayAgentVisible;
-    const pill = document.createElement('span');
-    pill.className = 'ui2-live-state-pill'
-      + (shared ? ' other' : granted ? ' you' : '');
-    pill.textContent = shared ? 'agent can see this' : granted ? 'private view' : 'off';
-    head.appendChild(title);
-    head.appendChild(pill);
-    const sub = document.createElement('div');
-    sub.className = 'ui2-live-card-sub';
-    sub.textContent = shared
-      ? 'The agent can see and drive this screen for computer-use tasks until you revoke access.'
-      : granted
-        ? 'Streaming to your dashboard only. The agent cannot see this display.'
-        : 'View and control this machine’s display from here, or share it with the agent for computer-use tasks. You choose the display and can stop at any time.';
-    card.appendChild(head);
-    card.appendChild(sub);
-    const addBtn = (label, cls, title, onClick) => {
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.className = 'ui2-live-card-btn ' + cls;
-      btn.textContent = label;
-      btn.title = title;
-      btn.addEventListener('click', (e) => {
-        e.stopPropagation();
-        onClick();
-      });
-      card.appendChild(btn);
-      return btn;
-    };
-    if (!granted) {
-      // Primary: private remote view. Secondary: the agent share.
-      addBtn('View this machine', 'secondary',
-        'Watch and control this machine’s display from the dashboard. Private: the agent cannot see it.',
-        () => { if (typeof startUserDisplayGrantFlow === 'function') startUserDisplayGrantFlow('view'); });
-      addBtn('Share with agent…', 'secondary',
-        'Make this screen visible to the agent for computer-use tasks. Revocable at any time.',
-        () => { if (typeof startUserDisplayGrantFlow === 'function') startUserDisplayGrantFlow('share'); });
-    } else if (!shared) {
-      addBtn('Stop viewing', 'danger',
-        'Close the private view of this machine.',
-        () => { if (typeof revokeUserDisplayNow === 'function') revokeUserDisplayNow(); });
-      addBtn('Share with agent', 'secondary',
-        'Upgrade this private view: make the display visible to the agent for computer-use tasks.',
-        () => { if (typeof shareUserDisplayWithAgent === 'function') shareUserDisplayWithAgent(); });
-    } else {
-      addBtn('Revoke access', 'danger',
-        'Take the display away from the agent and stop streaming it.',
-        () => { if (typeof revokeUserDisplayNow === 'function') revokeUserDisplayNow(); });
+  function syncDisplayRows(slots) {
+    const liveIds = new Set(slots.map(slot => Number(slot.displayId)));
+    for (const [id, record] of displayRows) {
+      if (liveIds.has(id)) continue;
+      record.row.remove();
+      displayRows.delete(id);
+      slotSnapshots.delete(id);
+      activityByDisplay.delete(id);
     }
-    yourScreen.appendChild(card);
+
+    let empty = displaysList.querySelector('.ui2-live-rail-empty');
+    if (!slots.length) {
+      if (!empty) {
+        empty = emptyHint('No displays active. Agent workspaces and screens you choose to view appear here.');
+        displaysList.appendChild(empty);
+      }
+      return;
+    }
+    if (empty) empty.remove();
+
+    const ordered = [];
+    for (const slot of slots) {
+      const id = Number(slot.displayId);
+      let record = displayRows.get(id);
+      if (!record) {
+        record = createDisplayRow(id);
+        displayRows.set(id, record);
+      }
+      const label = slotLabel(slot);
+      const state = slot.authorityState || 'unknown';
+      const status = (slot.statusEl && slot.statusEl.textContent.trim()) || 'Connecting';
+      const error = Boolean(slot.statusEl && slot.statusEl.classList.contains('error'));
+      const active = id === selectedDisplayId;
+      const privateView = displayAgentVisibility.get(id) === false;
+
+      record.row.classList.toggle('ok', Boolean(slot.connected));
+      record.row.classList.toggle('err', error);
+      record.row.classList.toggle('viewing', active);
+      record.row.classList.toggle('selected', active);
+      record.row.setAttribute('aria-pressed', active ? 'true' : 'false');
+      if (active) record.row.setAttribute('aria-current', 'true');
+      else record.row.removeAttribute('aria-current');
+      record.row.title = active ? label + ' is shown on the stage' : 'Show ' + label + ' on the stage';
+      record.row.setAttribute('aria-label',
+        label + ', ' + status + ', input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown));
+      record.title.textContent = label;
+      record.meta.textContent = status + ' · input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown);
+      record.privacy.textContent = privateView ? 'PRIVATE' : '';
+      record.privacy.title = privateView ? 'The agent cannot see this private view' : '';
+      record.current.textContent = active ? 'VIEWING' : (slot.connected ? 'LIVE' : '');
+      ordered.push(record);
+    }
+    orderRows(displaysList, ordered);
   }
 
-  let railRaf = 0;
-  function renderRail() {
-    railRaf = 0;
-    renderDisplayRows();
-    renderAuthorityCard();
-    renderPeerRows();
-    renderYourScreen();
+  authorityCard.innerHTML =
+    '<div class="ui2-live-card ui2-live-authority-card">' +
+      '<div class="ui2-live-authority-head">' +
+        '<span class="ui2-live-authority-dot" aria-hidden="true"></span>' +
+        '<div class="ui2-live-authority-copy">' +
+          '<div class="ui2-live-card-title"></div>' +
+          '<div class="ui2-live-card-sub"></div>' +
+        '</div>' +
+        '<span class="ui2-live-state-pill"></span>' +
+      '</div>' +
+      '<div class="ui2-live-auth-row">' +
+        '<span class="ui2-live-auth-name"></span>' +
+      '</div>' +
+      '<button class="ui2-live-card-btn" type="button"></button>' +
+    '</div>';
+  const authorityBox = authorityCard.querySelector('.ui2-live-card');
+  const authorityTitle = authorityCard.querySelector('.ui2-live-card-title');
+  const authoritySub = authorityCard.querySelector('.ui2-live-card-sub');
+  const authorityPill = authorityCard.querySelector('.ui2-live-state-pill');
+  const authorityName = authorityCard.querySelector('.ui2-live-auth-name');
+  const authorityButton = authorityCard.querySelector('.ui2-live-card-btn');
+  authorityButton.addEventListener('click', () => {
+    const slot = selectedSlot();
+    if (!slot) return;
+    if (slot.authorityState === 'you' && !slot.interactive) {
+      // Selection-away releases bound input immediately. During the
+      // authority round-trip (or after a failed release), let the holder
+      // safely re-bind listeners instead of trapping it behind a Release-
+      // only toolbar state.
+      slot.takeControl();
+      return;
+    }
+    const source = slot.authorityState === 'you' ? slot.releaseBtn : slot.takeBtn;
+    if (source && !source.disabled) source.click();
+  });
+
+  function syncAuthorityCard() {
+    const slot = selectedSlot();
+    const signature = slot
+      ? [
+          selectedDisplayId,
+          slotLabel(slot),
+          slot.authorityState || 'unknown',
+          Boolean(slot.interactive),
+          Boolean(slot._takeControlPending),
+          Boolean(slot.pc),
+        ].join('|')
+      : 'none';
+    if (signature === lastAuthoritySignature) return;
+    lastAuthoritySignature = signature;
+    authorityBox.className = 'ui2-live-card ui2-live-authority-card';
+    authorityPill.className = 'ui2-live-state-pill';
+    authorityButton.className = 'ui2-live-card-btn';
+    if (!slot) {
+      authorityTitle.textContent = 'No live display';
+      authoritySub.textContent = 'Choose or share a display to see and control it here.';
+      authorityPill.textContent = 'offline';
+      authorityName.textContent = 'Input is scoped to one display at a time.';
+      authorityButton.hidden = true;
+      return;
+    }
+
+    const state = slot.authorityState || 'unknown';
+    const pending = Boolean(slot._takeControlPending);
+    authorityName.textContent = slotLabel(slot);
+    authorityButton.hidden = false;
+    authorityButton.disabled = !slot.pc || pending;
+    authorityButton.setAttribute('aria-busy', pending ? 'true' : 'false');
+    authorityBox.classList.add('state-' + state);
+    if (state === 'you') {
+      authorityTitle.textContent = slot.interactive
+        ? 'You are driving this display'
+        : 'You hold input authority';
+      authoritySub.textContent =
+        'Keyboard, pointer, and paste input are scoped to this display. Release it before handing control back.';
+      authorityPill.classList.add('you');
+      authorityPill.textContent = 'you';
+      if (slot.interactive) {
+        authorityButton.classList.add('release');
+        authorityButton.textContent = 'Release control';
+        authorityButton.title = 'Release input and return this display to view-only';
+      } else {
+        authorityButton.textContent = 'Resume control';
+        authorityButton.title = 'Bind keyboard, pointer, and paste input to this display again';
+      }
+    } else if (state === 'other') {
+      authorityTitle.textContent = 'Another viewer has input';
+      authoritySub.textContent =
+        'Taking control is immediate and displaces the current viewer. Last take wins; there is no approval step.';
+      authorityPill.classList.add('other');
+      authorityPill.textContent = 'another viewer';
+      authorityButton.textContent = pending ? 'Requesting…' : 'Take control anyway';
+      authorityButton.title = 'Take input immediately and displace the current viewer';
+    } else if (state === 'unclaimed') {
+      authorityTitle.textContent = 'Input is available';
+      authoritySub.textContent =
+        'No dashboard viewer holds exclusive input. Take control to bind keyboard, pointer, and paste input here.';
+      authorityPill.textContent = 'available';
+      authorityButton.textContent = pending ? 'Requesting…' : 'Take control';
+      authorityButton.title = 'Take interactive control of this display';
+    } else {
+      authorityTitle.textContent = 'View only while input connects';
+      authoritySub.textContent =
+        'The stream can be watched now. Input controls become available when the authority state arrives.';
+      authorityPill.textContent = 'connecting';
+      authorityButton.textContent = pending ? 'Requesting…' : 'Take control';
+      authorityButton.title = 'Input authority is not available yet';
+    }
   }
-  function scheduleRail() {
-    if (railRaf) return;
-    railRaf = requestAnimationFrame(renderRail);
+
+  function visibilityMode(id) {
+    const visible = displayAgentVisibility.get(id);
+    if (visible === false) return 'private';
+    if (visible === true && userDisplayIds.has(id)) return 'agent';
+    return 'workspace';
   }
-  const observe = (el, opts) => {
-    if (!el) return;
-    new MutationObserver(scheduleRail).observe(el, opts);
+
+  function snapshotSlot(slot) {
+    const statusEl = slot.statusEl;
+    const mode = slot.interactive
+      ? 'interactive'
+      : slot.connected
+        ? 'connected'
+        : statusEl && statusEl.classList.contains('error')
+          ? 'error'
+          : statusEl && statusEl.classList.contains('warn')
+            ? 'warn'
+            : 'connecting';
+    return {
+      mode,
+      authority: slot.authorityState || 'unknown',
+      streaming: Boolean(slot.streaming),
+      recording: Boolean(slot.recording),
+      visibility: visibilityMode(Number(slot.displayId)),
+      shared: Boolean(slot.el && slot.el.classList.contains('shared-view-active')),
+      annotating: Boolean(slot.annotateBtn && slot.annotateBtn.classList.contains('active')),
+      callout: Boolean(slot.calloutBtn && slot.calloutBtn.getAttribute('aria-pressed') === 'true'),
+    };
+  }
+
+  function addDisplayActivity(displayId, kind, textValue) {
+    const id = Number(displayId);
+    const entries = activityByDisplay.get(id) || [];
+    const last = entries[entries.length - 1];
+    if (last && last.kind === kind && last.text === textValue) return;
+    entries.push({
+      seq: ++activitySeq,
+      kind,
+      text: textValue,
+      at: new Date(),
+    });
+    if (entries.length > 10) entries.splice(0, entries.length - 10);
+    activityByDisplay.set(id, entries);
+  }
+
+  function captureSlotActivity(slot) {
+    const id = Number(slot.displayId);
+    const next = snapshotSlot(slot);
+    const prev = slotSnapshots.get(id);
+    if (!prev) {
+      addDisplayActivity(id, 'neutral', 'Display became available');
+      if (next.mode === 'connected') addDisplayActivity(id, 'live', 'Live stream connected');
+      else if (next.mode === 'interactive') addDisplayActivity(id, 'control', 'Interactive input is active');
+      else if (next.mode === 'error') addDisplayActivity(id, 'error', 'The stream needs attention');
+      if (next.visibility === 'private') addDisplayActivity(id, 'private', 'Private dashboard view started');
+      if (next.visibility === 'agent') addDisplayActivity(id, 'share', 'Display shared with the agent');
+      if (next.authority === 'you') addDisplayActivity(id, 'control', 'This dashboard holds input authority');
+      if (next.authority === 'other') addDisplayActivity(id, 'attention', 'Another viewer holds input authority');
+      if (next.shared) addDisplayActivity(id, 'focus', 'Agent shared this display with you');
+      slotSnapshots.set(id, next);
+      return;
+    }
+
+    if (prev.mode !== next.mode) {
+      if (next.mode === 'connected') addDisplayActivity(id, 'live', 'Live stream connected');
+      else if (next.mode === 'interactive') addDisplayActivity(id, 'control', 'Interactive input is active');
+      else if (next.mode === 'error') addDisplayActivity(id, 'error', 'The stream needs attention');
+      else if (next.mode === 'warn') addDisplayActivity(id, 'attention', 'The stream is reconnecting');
+      else addDisplayActivity(id, 'neutral', 'Connecting to the display');
+    }
+    if (prev.authority !== next.authority) {
+      if (next.authority === 'you') addDisplayActivity(id, 'control', 'You took input control');
+      else if (next.authority === 'other') addDisplayActivity(id, 'attention', 'Another viewer took input control');
+      else if (next.authority === 'unclaimed') addDisplayActivity(id, 'neutral', 'Input control was released');
+      else addDisplayActivity(id, 'neutral', 'Input authority is reconnecting');
+    }
+    if (prev.streaming !== next.streaming) {
+      addDisplayActivity(id, next.streaming ? 'share' : 'neutral',
+        next.streaming ? 'Presence stream started' : 'Presence stream stopped');
+    }
+    if (prev.recording !== next.recording) {
+      addDisplayActivity(id, next.recording ? 'recording' : 'neutral',
+        next.recording ? 'Recording started' : 'Recording stopped');
+    }
+    if (prev.visibility !== next.visibility) {
+      if (next.visibility === 'private') addDisplayActivity(id, 'private', 'Display changed to a private view');
+      else if (next.visibility === 'agent') addDisplayActivity(id, 'share', 'Display shared with the agent');
+      else addDisplayActivity(id, 'neutral', 'Agent display workspace active');
+    }
+    if (prev.shared !== next.shared) {
+      addDisplayActivity(id, next.shared ? 'focus' : 'neutral',
+        next.shared ? 'Agent shared this display with you' : 'Shared view ended');
+    }
+    if (prev.annotating !== next.annotating) {
+      addDisplayActivity(id, next.annotating ? 'focus' : 'neutral',
+        next.annotating ? 'Annotation editor opened' : 'Annotation editor closed');
+    }
+    if (prev.callout !== next.callout) {
+      addDisplayActivity(id, next.callout ? 'focus' : 'neutral',
+        next.callout ? 'Region callout armed' : 'Region callout cleared');
+    }
+    slotSnapshots.set(id, next);
+  }
+
+  function syncActivityList() {
+    const entries = selectedDisplayId === null
+      ? []
+      : activityByDisplay.get(selectedDisplayId) || [];
+    const signature = String(selectedDisplayId) + ':' +
+      entries.map(entry => String(entry.seq)).join(',');
+    if (signature === lastActivitySignature) return;
+    lastActivitySignature = signature;
+    activityList.replaceChildren();
+    if (!entries.length) {
+      activityList.appendChild(emptyHint(
+        selectedDisplayId === null
+          ? 'Select a display to see its connection, authority, sharing, and recording events.'
+          : 'Display events will appear here as its real state changes.'));
+      return;
+    }
+
+    for (const entry of entries.slice().reverse()) {
+      const row = document.createElement('div');
+      row.className = 'ui2-live-activity-row kind-' + entry.kind;
+      const dot = document.createElement('span');
+      dot.className = 'ui2-live-activity-dot';
+      dot.setAttribute('aria-hidden', 'true');
+      const textEl = document.createElement('span');
+      textEl.className = 'ui2-live-activity-text';
+      textEl.textContent = entry.text;
+      const time = document.createElement('time');
+      time.className = 'ui2-live-activity-time';
+      time.dateTime = entry.at.toISOString();
+      time.textContent = entry.at.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      row.appendChild(dot);
+      row.appendChild(textEl);
+      row.appendChild(time);
+      activityList.appendChild(row);
+    }
+  }
+
+  yourScreen.innerHTML =
+    '<div class="ui2-live-card ui2-live-screen-card">' +
+      '<div class="ui2-live-screen-head">' +
+        '<div class="ui2-live-card-title">Your screen</div>' +
+        '<span class="ui2-live-state-pill"></span>' +
+      '</div>' +
+      '<div class="ui2-live-card-sub"></div>' +
+      '<div class="ui2-live-screen-actions">' +
+        '<button class="ui2-live-card-btn secondary" type="button"></button>' +
+        '<button class="ui2-live-card-btn secondary" type="button"></button>' +
+      '</div>' +
+    '</div>';
+  const screenPill = yourScreen.querySelector('.ui2-live-state-pill');
+  const screenSub = yourScreen.querySelector('.ui2-live-card-sub');
+  const screenButtons = Array.from(yourScreen.querySelectorAll('.ui2-live-card-btn'));
+
+  function runScreenAction(action) {
+    if (action === 'view' && typeof startUserDisplayGrantFlow === 'function') {
+      startUserDisplayGrantFlow('view');
+    } else if (action === 'share' && typeof startUserDisplayGrantFlow === 'function') {
+      startUserDisplayGrantFlow('share');
+    } else if (action === 'upgrade' && typeof shareUserDisplayWithAgent === 'function') {
+      shareUserDisplayWithAgent();
+    } else if (action === 'revoke' && typeof revokeUserDisplayNow === 'function') {
+      revokeUserDisplayNow();
+    }
+  }
+  screenButtons.forEach(button => {
+    button.addEventListener('click', event => {
+      event.stopPropagation();
+      runScreenAction(button.dataset.action || '');
+    });
+  });
+
+  function setScreenButton(button, config) {
+    if (!config) {
+      button.hidden = true;
+      button.dataset.action = '';
+      return;
+    }
+    button.hidden = false;
+    button.dataset.action = config.action;
+    button.textContent = config.label;
+    button.title = config.title;
+    button.className = 'ui2-live-card-btn ' + config.className;
+  }
+
+  function syncYourScreen() {
+    const granted = userDisplayGranted;
+    const shared = granted && userDisplayAgentVisible;
+    const signature = granted ? (shared ? 'agent' : 'private') : 'off';
+    if (signature === lastScreenSignature) return;
+    lastScreenSignature = signature;
+    screenPill.className = 'ui2-live-state-pill' + (shared ? ' other' : granted ? ' you' : '');
+    screenPill.textContent = shared ? 'agent can see this' : granted ? 'private view' : 'off';
+    if (!granted) {
+      screenSub.textContent =
+        'View this machine privately, or explicitly share a chosen screen with the agent for computer-use tasks.';
+      setScreenButton(screenButtons[0], {
+        action: 'view',
+        label: 'View this machine',
+        title: 'Private dashboard view. The agent cannot see this screen.',
+        className: 'secondary',
+      });
+      setScreenButton(screenButtons[1], {
+        action: 'share',
+        label: 'Share with agent…',
+        title: 'Choose a screen to share with the agent. Revocable at any time.',
+        className: 'secondary',
+      });
+    } else if (!shared) {
+      screenSub.textContent =
+        'This is a private dashboard view. The agent cannot enumerate, capture, or drive it.';
+      setScreenButton(screenButtons[0], {
+        action: 'revoke',
+        label: 'Stop viewing',
+        title: 'Close this private display view.',
+        className: 'danger',
+      });
+      setScreenButton(screenButtons[1], {
+        action: 'upgrade',
+        label: 'Share with agent',
+        title: 'Make this display visible to the agent for computer-use tasks.',
+        className: 'secondary',
+      });
+    } else {
+      screenSub.textContent =
+        'The agent can see and drive this screen for computer-use tasks until you revoke access.';
+      setScreenButton(screenButtons[0], {
+        action: 'revoke',
+        label: 'Revoke access',
+        title: 'Stop sharing this screen with the agent.',
+        className: 'danger',
+      });
+      setScreenButton(screenButtons[1], null);
+    }
+  }
+
+  function peerKey(chip, index) {
+    const host = chip.dataset.hostId || '';
+    const display = chip.dataset.displayId || '';
+    return host || display
+      ? host + ':' + display
+      : (chip.getAttribute('aria-label') || chip.textContent || String(index));
+  }
+
+  function createPeerRow(key) {
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = 'ui2-live-row';
+    row.innerHTML =
+      '<span class="ui2-live-row-dot" aria-hidden="true"></span>' +
+      '<span class="ui2-live-row-main">' +
+        '<span class="ui2-live-row-title"></span>' +
+        '<span class="ui2-live-row-meta">peer · opens in Station</span>' +
+      '</span>' +
+      '<span class="ui2-live-row-chev" aria-hidden="true">›</span>';
+    row.addEventListener('click', () => {
+      const chip = peerSources.get(key);
+      if (!chip || chip.disabled) return;
+      const hostId = chip.dataset.hostId || '';
+      const displayId = Number(chip.dataset.displayId || 0);
+      if (typeof routeTo === 'function') routeTo('station');
+      if (hostId && typeof stationOpenDisplay === 'function') {
+        stationOpenDisplay(hostId, displayId);
+      } else {
+        chip.click();
+      }
+    });
+    return {
+      row,
+      title: row.querySelector('.ui2-live-row-title'),
+    };
+  }
+
+  function syncPeerRows() {
+    const chips = Array.from(document.querySelectorAll('#station-peer-chips .station-peer-chip'));
+    peerSources.clear();
+    const liveKeys = new Set();
+    const ordered = [];
+    chips.forEach((chip, index) => {
+      const key = peerKey(chip, index);
+      liveKeys.add(key);
+      peerSources.set(key, chip);
+      let record = peerRows.get(key);
+      if (!record) {
+        record = createPeerRow(key);
+        peerRows.set(key, record);
+      }
+      record.row.disabled = chip.disabled;
+      record.row.classList.toggle('ok', !chip.disabled);
+      record.row.title = chip.disabled
+        ? (chip.title || 'Peer unavailable')
+        : (chip.title || 'Open this peer display in Station');
+      record.row.setAttribute('aria-label', chip.getAttribute('aria-label') || chip.textContent || 'Peer display');
+      record.title.textContent = chip.textContent || 'Peer display';
+      ordered.push(record);
+    });
+    for (const [key, record] of peerRows) {
+      if (liveKeys.has(key)) continue;
+      record.row.remove();
+      peerRows.delete(key);
+    }
+
+    let empty = peerList.querySelector('.ui2-live-rail-empty');
+    if (!ordered.length) {
+      if (!empty) {
+        empty = emptyHint('No peer displays advertised. Connected peers open in the Station workspace.');
+        peerList.appendChild(empty);
+      }
+      return;
+    }
+    if (empty) empty.remove();
+    orderRows(peerList, ordered);
+  }
+
+  function syncMobileSummary() {
+    if (!mobileSummary) return;
+    const slot = selectedSlot();
+    if (!slot) {
+      mobileSummary.textContent = 'No display selected';
+      return;
+    }
+    const state = slot.authorityState || 'unknown';
+    mobileSummary.textContent = slotLabel(slot) + ' · input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown);
+  }
+
+  function drawerFocusable() {
+    return Array.from(rail.querySelectorAll(
+      'button:not([disabled]):not([hidden]), input:not([disabled]):not([hidden]), select:not([disabled]):not([hidden]), [tabindex]:not([tabindex="-1"])'
+    )).filter(element => element.getClientRects().length > 0);
+  }
+
+  function syncDrawerState(restoreFocus) {
+    const drawer = drawerMedia.matches;
+    const visible = !drawer || railOpen;
+    tab.classList.toggle('ui2-live-rail-open', drawer && railOpen);
+    rail.inert = !visible;
+    if (visible) rail.removeAttribute('aria-hidden');
+    else rail.setAttribute('aria-hidden', 'true');
+    if (railToggle) railToggle.setAttribute('aria-expanded', drawer && railOpen ? 'true' : 'false');
+    if (railScrim) {
+      railScrim.tabIndex = drawer && railOpen ? 0 : -1;
+      railScrim.setAttribute('aria-hidden', drawer && railOpen ? 'false' : 'true');
+    }
+    if (restoreFocus && railToggle && drawer) railToggle.focus();
+  }
+
+  function setRailOpen(open, restoreFocus) {
+    railOpen = drawerMedia.matches && Boolean(open);
+    syncDrawerState(Boolean(restoreFocus));
+    if (railOpen) {
+      requestAnimationFrame(() => {
+        const focusable = drawerFocusable();
+        (railClose || focusable[0] || rail).focus();
+      });
+    }
+  }
+
+  if (railToggle) railToggle.addEventListener('click', () => setRailOpen(!railOpen, false));
+  if (railClose) railClose.addEventListener('click', () => setRailOpen(false, true));
+  if (railScrim) railScrim.addEventListener('click', () => setRailOpen(false, true));
+  rail.addEventListener('keydown', event => {
+    if (!drawerMedia.matches || !railOpen || event.key !== 'Tab') return;
+    const focusable = drawerFocusable();
+    if (!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  });
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape' && drawerMedia.matches && railOpen) {
+      event.preventDefault();
+      setRailOpen(false, true);
+    }
+  });
+  const onDrawerMediaChange = () => {
+    railOpen = false;
+    syncDrawerState(false);
   };
-  // Slots come and go / status text + authority chips restyle in place.
-  observe(document.getElementById('displays-container'),
-    { subtree: true, childList: true, attributes: true, attributeFilter: ['class', 'style'], characterData: true });
-  // Station peer chips re-render on peer_display_ready/removed.
-  observe(document.getElementById('station-peer-chips'),
-    { subtree: true, childList: true, attributes: true, attributeFilter: ['class', 'disabled', 'title'] });
-  // user_session grant chip flips text + .granted.
-  observe(document.getElementById('sb-display-access'),
-    { childList: true, attributes: true, attributeFilter: ['class'], characterData: true, subtree: true });
-  renderRail();
+  if (typeof drawerMedia.addEventListener === 'function') {
+    drawerMedia.addEventListener('change', onDrawerMediaChange);
+  } else if (typeof drawerMedia.addListener === 'function') {
+    drawerMedia.addListener(onDrawerMediaChange);
+  }
+
+  function renderWorkspace() {
+    railRaf = 0;
+    const slots = Array.from(displaySlots.values());
+    reconcileSelectedDisplay(slots);
+    for (const slot of slots) captureSlotActivity(slot);
+    syncDisplayRows(slots);
+    syncAuthorityCard();
+    syncActivityList();
+    syncPeerRows();
+    syncYourScreen();
+    syncMobileSummary();
+  }
+
+  function scheduleWorkspace() {
+    if (railRaf) return;
+    railRaf = requestAnimationFrame(renderWorkspace);
+  }
+
+  function observe(element, options) {
+    if (!element) return;
+    new MutationObserver(scheduleWorkspace).observe(element, options);
+  }
+  // The observer catches legacy direct DOM writes without rebuilding the
+  // rail. Keyed rows and stable authority/screen controls preserve focus;
+  // activity rendering is signature-gated, so the 3s metrics sampler is a
+  // no-op unless a real display state changed.
+  observe(container, {
+    subtree: true,
+    childList: true,
+    characterData: true,
+    attributes: true,
+    attributeFilter: ['class', 'style', 'aria-pressed', 'disabled'],
+  });
+  observe(document.getElementById('station-peer-chips'), {
+    subtree: true,
+    childList: true,
+    characterData: true,
+    attributes: true,
+    attributeFilter: ['class', 'disabled', 'title', 'aria-label', 'data-host-id', 'data-display-id'],
+  });
+  observe(document.getElementById('sb-display-access'), {
+    subtree: true,
+    childList: true,
+    characterData: true,
+    attributes: true,
+    attributeFilter: ['class'],
+  });
+
+  // Stable, side-effect-free browser QA surface. CDP cannot read the
+  // module-scoped displaySlots map directly, so dashboard acceptance
+  // probes use this documented window.qa convention.
+  window.qa = Object.assign(window.qa || {}, {
+    liveDisplay() {
+      return {
+        activeTab,
+        selectedDisplayId,
+        layout: drawerMedia.matches ? 'drawer' : 'rail',
+        railOpen: !drawerMedia.matches || railOpen,
+        userDisplayMode: userDisplayGranted
+          ? (userDisplayAgentVisible ? 'agent' : 'private')
+          : 'off',
+        slots: Array.from(displaySlots.values()).map(slot => {
+          const id = Number(slot.displayId);
+          return {
+            displayId: id,
+            selected: id === selectedDisplayId,
+            connected: Boolean(slot.connected),
+            firstFrameSeen: Boolean(slot._firstFrameSeen),
+            intrinsicWidth: Number(slot.videoEl && slot.videoEl.videoWidth) || 0,
+            intrinsicHeight: Number(slot.videoEl && slot.videoEl.videoHeight) || 0,
+            authorityState: slot.authorityState || 'unknown',
+            interactive: Boolean(slot.interactive),
+            agentVisible: displayAgentVisibility.has(id)
+              ? displayAgentVisibility.get(id)
+              : null,
+            streaming: Boolean(slot.streaming),
+            recording: Boolean(slot.recording),
+            activityCount: (activityByDisplay.get(id) || []).length,
+          };
+        }),
+      };
+    },
+  });
+
+  syncDrawerState(false);
+  renderWorkspace();
 })();

--- a/static/app/45-displays-webrtc.js
+++ b/static/app/45-displays-webrtc.js
@@ -210,6 +210,11 @@ class DisplaySlot {
     this.connected = false;
     this.streaming = false;
     this.recordingStreamName = null;
+    this._recordingPendingAction = null;
+    this._recordingPendingTimer = null;
+    this._recordingDeletePending = false;
+    this._recordingDeleteStream = null;
+    this._recordingDeleteTimer = null;
     this._answerApplied = false;     // true after setRemoteDescription completes
     this._pendingCandidates = [];    // queued until answer is applied
     this._reconnectAttempts = 0;     // ICE failure reconnect counter
@@ -237,6 +242,8 @@ class DisplaySlot {
     this._streamCanvas = document.createElement('canvas');
     this._focusResizeObserver = null;
     this._boundHandlers = {};
+    this._fullscreenInertRecords = [];
+    this._fullscreenReturnFocus = null;
     this.el = document.createElement('div');
     this.el.className = 'display-slot';
     const label = displayLabel(displayId);
@@ -246,20 +253,20 @@ class DisplaySlot {
           <span class="display-label"></span>
           <span class="display-visibility" id="ds-visibility-${displayId}" style="display:none"></span>
           <span class="display-status" id="ds-status-${displayId}" role="status" aria-live="polite" aria-atomic="true">Connecting...</span>
-          <span class="display-input-authority" id="ds-authority-${displayId}" role="status" aria-live="polite" aria-atomic="true" style="display:none" title="Input authority for this display: who can drive keyboard and pointer input."></span>
+          <span class="display-input-authority" id="ds-authority-${displayId}" style="display:none" title="Input authority for this display: who can drive keyboard and pointer input."></span>
         </div>
         <div class="display-toolbar-actions">
+          <button class="take-control-btn" id="ds-take-${displayId}" type="button" title="Take interactive control of this display (keyboard and mouse)">Take control</button>
+          <button class="release-control-btn" id="ds-release-${displayId}" type="button" style="display:none" title="Release control and return display to view-only mode">Release</button>
           <input class="release-note" id="ds-note-${displayId}" aria-label="Note to the agent when releasing this display" placeholder="Note (optional)" style="display:none">
           <button class="stream-btn" id="ds-stream-${displayId}" type="button" aria-pressed="false" title="Continuously send screenshots of this display to the live presence (voice) model. Main agents are not affected.">Stream</button>
           <button class="ann-attach-btn" id="ds-attach-${displayId}" type="button" title="Capture current frame and attach to next task">Attach</button>
           <button class="annotate-btn" id="ds-annotate-${displayId}" type="button" aria-pressed="false" title="Freeze current frame and annotate it">&#9998; Annotate</button>
           <button class="callout-btn" id="ds-callout-${displayId}" type="button" aria-pressed="false" disabled title="Call out a region: arm, then drag a rectangle on the frame to attach it to the next task (needs input control)">&#x2316; Callout</button>
           <button class="record-btn" id="ds-record-${displayId}" type="button" aria-pressed="false" title="Record this display (ffmpeg)">Record</button>
-          <button class="display-fullscreen-btn" id="ds-fullscreen-${displayId}" type="button" aria-label="Open display full screen" title="Full screen">&#x26F6;</button>
-          <button class="display-close-btn" id="ds-close-${displayId}" type="button" aria-label="Close this display stream" title="Close this display stream">&times;</button>
-          <button class="take-control-btn" id="ds-take-${displayId}" type="button" title="Take interactive control of this display (keyboard and mouse)">Take control</button>
-          <button class="release-control-btn" id="ds-release-${displayId}" type="button" style="display:none" title="Release control and return display to view-only mode">Release</button>
           <button class="delete-recording-btn" id="ds-delete-rec-${displayId}" type="button" style="display:none" title="Delete recording files for this display">Delete</button>
+          <button class="display-fullscreen-btn" id="ds-fullscreen-${displayId}" type="button" aria-label="Open display full screen" aria-pressed="false" title="Full screen">&#x26F6;</button>
+          <button class="display-close-btn" id="ds-close-${displayId}" type="button" aria-label="Close this display stream" title="Close this display stream">&times;</button>
           <span class="stream-frame-id" id="ds-frame-${displayId}" style="display:none;font-size:10px;color:var(--overlay0)"></span>
         </div>
       </div>
@@ -317,8 +324,6 @@ class DisplaySlot {
     this.canvasEl.appendChild(this.metricsEl);
     this.controlBannerEl = document.createElement('div');
     this.controlBannerEl.className = 'display-control-banner';
-    this.controlBannerEl.setAttribute('role', 'status');
-    this.controlBannerEl.setAttribute('aria-live', 'polite');
     this.controlBannerEl.textContent = 'You have control — keyboard and pointer input drive this display.';
     this.canvasEl.appendChild(this.controlBannerEl);
     const rerenderSharedFocus = () => {
@@ -344,6 +349,7 @@ class DisplaySlot {
     this.attachBtn.addEventListener('click', () => this.attachCurrentFrame());
     this.annotateBtn.addEventListener('click', () => this.annotateCurrentFrame());
     this.calloutBtn.addEventListener('click', () => this.toggleCallout());
+    this.el.addEventListener('keydown', event => this._handleFullscreenKeydown(event));
   }
 
   // Same budget as PeerDisplayConnection.NO_TRACK_TIMEOUT_MS — both are
@@ -359,12 +365,13 @@ class DisplaySlot {
     if (want) {
       for (const slot of displaySlots.values()) {
         if (slot === this) continue;
-        slot.el.classList.remove('display-fullscreen');
-        if (slot.fullscreenBtn) {
-          slot.fullscreenBtn.innerHTML = '&#x26F6;';
-          slot.fullscreenBtn.title = 'Full screen';
-        }
+        if (slot.el.classList.contains('display-fullscreen')) slot.toggleFullscreen(false);
       }
+    }
+    if (want && !this.el.classList.contains('display-fullscreen')) {
+      this._enterFullscreenA11y();
+    } else if (!want && this.el.classList.contains('display-fullscreen')) {
+      this._exitFullscreenA11y();
     }
     this.el.classList.toggle('display-fullscreen', want);
     const anyFullscreen = want || Array.from(displaySlots.values()).some(slot =>
@@ -376,6 +383,78 @@ class DisplaySlot {
       this.fullscreenBtn.title = want ? 'Exit full screen' : 'Full screen';
       this.fullscreenBtn.setAttribute('aria-label', want ? 'Exit display full screen' : 'Open display full screen');
       this.fullscreenBtn.setAttribute('aria-pressed', want ? 'true' : 'false');
+    }
+    if (want && this.fullscreenBtn) this.fullscreenBtn.focus();
+  }
+
+  _enterFullscreenA11y() {
+    this._fullscreenReturnFocus = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    this._fullscreenInertRecords = [];
+    let branch = this.el;
+    while (branch && branch.parentElement) {
+      const parent = branch.parentElement;
+      for (const sibling of parent.children) {
+        if (sibling === branch || !(sibling instanceof HTMLElement)) continue;
+        this._fullscreenInertRecords.push({
+          element: sibling,
+          inert: sibling.inert,
+          ariaHidden: sibling.getAttribute('aria-hidden'),
+        });
+        sibling.inert = true;
+        sibling.setAttribute('aria-hidden', 'true');
+      }
+      branch = parent;
+      if (parent === document.body) break;
+    }
+    this.el.setAttribute('role', 'dialog');
+    this.el.setAttribute('aria-modal', 'true');
+  }
+
+  _exitFullscreenA11y() {
+    for (const record of this._fullscreenInertRecords) {
+      record.element.inert = record.inert;
+      if (record.ariaHidden === null) record.element.removeAttribute('aria-hidden');
+      else record.element.setAttribute('aria-hidden', record.ariaHidden);
+    }
+    this._fullscreenInertRecords = [];
+    this.el.removeAttribute('role');
+    this.el.removeAttribute('aria-modal');
+    // A responsive breakpoint may have changed while fullscreen owned the
+    // background. Re-project the drawer's current media-query state instead
+    // of leaving stale inert/aria-hidden snapshots on its rail or stage.
+    if (typeof window.syncLiveDisplayDrawerState === 'function') {
+      window.syncLiveDisplayDrawerState();
+    }
+    const returnFocus = this._fullscreenReturnFocus;
+    this._fullscreenReturnFocus = null;
+    if (returnFocus && returnFocus.isConnected && typeof returnFocus.focus === 'function') {
+      requestAnimationFrame(() => returnFocus.focus());
+    }
+  }
+
+  _handleFullscreenKeydown(event) {
+    if (!this.el.classList.contains('display-fullscreen')) return;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      this.toggleFullscreen(false);
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    const focusable = Array.from(this.el.querySelectorAll(
+      'button:not([disabled]), input:not([disabled]), video[tabindex], [tabindex]:not([tabindex="-1"])'
+    )).filter(element => element.getClientRects().length > 0);
+    if (!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
     }
   }
 
@@ -897,6 +976,13 @@ class DisplaySlot {
   // entry into interactive mode.
   _enterInteractive() {
     if (this.interactive) return;
+    // Activity thumbnails and hidden single-stage projections are
+    // deliberately view-only. A late authority reply must never bind
+    // keyboard/pointer/paste listeners after navigation hid its surface.
+    if (activeTab !== 'displays' || this.el.classList.contains('ui2-live-inactive')) {
+      this._releaseAuthority();
+      return;
+    }
     this.interactive = true;
     this.el.classList.add('is-interactive');
     this.noteInput.style.display = '';
@@ -1192,28 +1278,113 @@ class DisplaySlot {
     this.frameIdEl.textContent = '';
   }
   toggleRecording() {
-    if (!app) return;
+    if (!app || this._recordingPendingAction || this._recordingDeletePending) return;
     const baseStream = 'display_' + this.displayId;
     const stream = this.recordingStreamName || baseStream;
-    if (this.recording) {
-      dispatchDashboardActionMsg({ action: 'stop_recording', stream_name: stream });
-      this.recording = false;
-      this.recordBtn.innerHTML = '&#x23FA; Record';
-      this.recordBtn.classList.remove('active');
-      this.recordBtn.setAttribute('aria-pressed', 'false');
-      this.deleteRecBtn.style.display = '';
-    } else {
-      dispatchDashboardActionMsg({ action: 'start_recording', stream_name: baseStream });
-      this.recordingStreamName = baseStream;
-      this.recording = true;
-      this.recordBtn.innerHTML = '&#x23F9; Stop';
-      this.recordBtn.classList.add('active');
-      this.recordBtn.setAttribute('aria-pressed', 'true');
-      this.deleteRecBtn.style.display = 'none';
+    const action = this.recording ? 'stop_recording' : 'start_recording';
+    const targetStream = this.recording ? stream : baseStream;
+    this._setRecordingPending(action);
+    const fail = error => {
+      // A late RPC failure must not roll back or toast over a newer server
+      // event that already confirmed and cleared this exact command.
+      if (this._recordingPendingAction !== action) return;
+      this._failRecordingCommand(
+        error?.message || `Could not ${this.recording ? 'stop' : 'start'} recording`
+      );
+    };
+    const sent = dispatchDashboardActionMsg(
+      { action, stream_name: targetStream },
+      { onError: fail }
+    );
+    if (!sent) {
+      fail(new Error('Dashboard control connection is unavailable'));
+      return;
     }
+    this._recordingPendingTimer = window.setTimeout(() => {
+      this._recordingPendingTimer = null;
+      if (!this._recordingPendingAction) return;
+      this._failRecordingCommand('No recording confirmation arrived — check the display activity and retry.');
+    }, 10000);
+  }
+
+  _setRecordingPending(action) {
+    this._recordingPendingAction = action;
+    this._renderRecordingControls();
+  }
+
+  _clearRecordingPending(render = true) {
+    if (this._recordingPendingTimer) {
+      window.clearTimeout(this._recordingPendingTimer);
+      this._recordingPendingTimer = null;
+    }
+    this._recordingPendingAction = null;
+    if (render) this._renderRecordingControls();
+  }
+
+  _clearRecordingDeletePending(render = true) {
+    if (this._recordingDeleteTimer) {
+      window.clearTimeout(this._recordingDeleteTimer);
+      this._recordingDeleteTimer = null;
+    }
+    this._recordingDeletePending = false;
+    this._recordingDeleteStream = null;
+    if (render) this._renderRecordingControls();
+  }
+
+  _renderRecordingControls() {
+    const action = this._recordingPendingAction;
+    const deleting = this._recordingDeletePending;
+    this.recordBtn.disabled = Boolean(action || deleting);
+    this.recordBtn.setAttribute('aria-busy', action ? 'true' : 'false');
+    this.recordBtn.innerHTML = action
+      ? (action === 'stop_recording' ? 'Stopping…' : 'Starting…')
+      : (this.recording ? '&#x23F9; Stop' : '&#x23FA; Record');
+    this.recordBtn.classList.toggle('active', this.recording);
+    this.recordBtn.setAttribute('aria-pressed', this.recording ? 'true' : 'false');
+    this.deleteRecBtn.disabled = Boolean(deleting || action);
+    this.deleteRecBtn.setAttribute('aria-busy', deleting ? 'true' : 'false');
+    this.deleteRecBtn.textContent = deleting ? 'Deleting…' : 'Delete';
+    this.deleteRecBtn.style.display = this.recording || !this.recordingStreamName ? 'none' : '';
+  }
+
+  applyRecordingState(recording, streamName, deleted = false) {
+    const sameAsCurrent = !this.recordingStreamName || !streamName ||
+      this.recordingStreamName === streamName;
+    // Recording events are base-mapped to slots, so a late stop/delete for
+    // an older suffixed stream must not turn off a newer active recording.
+    // Likewise, a negative event cannot confirm an in-flight Start.
+    if ((!recording && this.recordingStreamName && !sameAsCurrent) ||
+        (!recording && this._recordingPendingAction === 'start_recording')) {
+      if (deleted && this._recordingDeletePending &&
+          this._recordingDeleteStream === streamName) {
+        this._clearRecordingDeletePending();
+      }
+      return false;
+    }
+
+    const confirmsRecordingCommand = recording
+      ? this._recordingPendingAction === 'start_recording'
+      : this._recordingPendingAction === 'stop_recording';
+    if (confirmsRecordingCommand) this._clearRecordingPending(false);
+    if (deleted && this._recordingDeletePending &&
+        this._recordingDeleteStream === streamName) {
+      this._clearRecordingDeletePending(false);
+    }
+    this.recording = Boolean(recording);
+    this.recordingStreamName = deleted ? null : (streamName || this.recordingStreamName);
+    this._renderRecordingControls();
+    return true;
+  }
+
+  _failRecordingCommand(message) {
+    this._clearRecordingPending(false);
+    this._clearRecordingDeletePending(false);
+    // The last server-confirmed state remains authoritative.
+    this._renderRecordingControls();
+    if (typeof showControlToast === 'function') showControlToast('error', message);
   }
   async deleteRecording() {
-    if (!app) return;
+    if (!app || this._recordingDeletePending || this._recordingPendingAction || this.recording) return;
     const stream = this.recordingStreamName || ('display_' + this.displayId);
     const ok = await showDashboardConfirm({
       title: 'Delete recording',
@@ -1222,9 +1393,29 @@ class DisplaySlot {
       confirmLabel: 'Delete',
     });
     if (!ok) return;
-    dispatchDashboardActionMsg({ action: 'delete_recording', stream_name: stream });
-    this.deleteRecBtn.style.display = 'none';
-    this.recordingStreamName = null;
+    // State can change while the confirmation dialog is open.
+    if (this._recordingDeletePending || this._recordingPendingAction || this.recording ||
+        this.recordingStreamName !== stream) return;
+    this._recordingDeletePending = true;
+    this._recordingDeleteStream = stream;
+    this._renderRecordingControls();
+    const fail = error => {
+      if (!this._recordingDeletePending) return;
+      this._failRecordingCommand(error?.message || 'Could not delete the recording');
+    };
+    const sent = dispatchDashboardActionMsg(
+      { action: 'delete_recording', stream_name: stream },
+      { onError: fail }
+    );
+    if (!sent) {
+      fail(new Error('Dashboard control connection is unavailable'));
+      return;
+    }
+    this._recordingDeleteTimer = window.setTimeout(() => {
+      this._recordingDeleteTimer = null;
+      if (!this._recordingDeletePending) return;
+      this._failRecordingCommand('No delete confirmation arrived — the recording is still listed.');
+    }, 10000);
   }
   // Phase 5c: teardown.  `userInitiated` separates the user-close path
   // (display toggled off, `removeDisplaySlot`, etc.) from transient
@@ -1252,10 +1443,9 @@ class DisplaySlot {
     this._clearNoTrackWatchdog();
     this._stopStatsSampler();
     this._setStageOverlay(null);
+    this._clearRecordingPending();
+    this._clearRecordingDeletePending();
     this.stopStreaming();
-    if (userInitiated) {
-      this._releaseAuthority();
-    }
     // Flip `connected` BEFORE `_exitInteractive` so its status-text
     // ternary writes 'Disconnected' (not the stale 'Connected (view-
     // only)') on the way out — otherwise the chip flickers through
@@ -1263,6 +1453,12 @@ class DisplaySlot {
     // assignment overwrote it.
     this.connected = false;
     this._exitInteractive(userInitiated);
+    if (userInitiated) {
+      // Held-key keyups from `_exitInteractive` must cross the input gate
+      // before the authority release closes it. This is the same ordering
+      // as releaseControl(); close/remove paths cannot safely reverse it.
+      this._releaseAuthority();
+    }
     if (this.controlChannel) { this.controlChannel.close(); this.controlChannel = null; }
     if (this.pointerChannel) { this.pointerChannel.close(); this.pointerChannel = null; }
     if (this.clipboardChannel) { this.clipboardChannel.close(); this.clipboardChannel = null; }
@@ -1293,6 +1489,9 @@ function removeDisplaySlot(displayId) {
   slot.disconnect({ userInitiated: true });
   if (slot.el && slot.el.parentNode) slot.el.parentNode.removeChild(slot.el);
   displaySlots.delete(displayId);
+  if (typeof window.retireLiveDisplayWorkspaceSlot === 'function') {
+    window.retireLiveDisplayWorkspaceSlot(displayId);
+  }
   if (sharedViewState.displayId === displayId) {
     clearSharedViewDecorations();
   }
@@ -1453,19 +1652,27 @@ function updateSharedViewBanner() {
 
 function applySharedViewToSlot(slot) {
   if (!sharedViewState.visible || !slot) return;
+  // Current daemons resolve auto-detect to a concrete target. A legacy null
+  // event is only safe to bind when handleSharedViewEvent saw exactly one
+  // existing stream; never guess here while bootstrap slots are still arriving.
+  if (sharedViewState.displayId === null) return;
   if (sharedViewState.displayId !== null && Number(slot.displayId) !== sharedViewState.displayId) {
     return;
   }
-  // The Live workspace is a selected-display stage. Agent-requested
-  // shared views must foreground their real target rather than leaving
-  // the focus box mounted on a hidden slot.
+  // The Live workspace is a selected-display stage. Foreground a new
+  // advisory target only when doing so will not discard active human work;
+  // the banner and row decoration still make a deferred target discoverable.
+  let foregrounded = true;
   if (typeof window.selectLiveDisplay === 'function') {
-    window.selectLiveDisplay(slot.displayId, { source: 'shared-view' });
+    foregrounded = window.selectLiveDisplay(slot.displayId, {
+      source: 'shared-view',
+      advisory: true,
+    });
   }
   updateSharedViewBanner();
   slot.el.classList.add('shared-view-active');
   renderSharedViewFocus(slot, sharedViewState.region, sharedViewState.note);
-  if (activeTab === 'displays') {
+  if (activeTab === 'displays' && foregrounded) {
     requestAnimationFrame(() => {
       try { slot.el.scrollIntoView({ block: 'nearest', inline: 'nearest' }); } catch (_) {}
     });
@@ -1493,7 +1700,21 @@ function hideSharedView() {
 function takeSharedViewInput() {
   if (sharedViewState.displayId === null) return;
   const slot = displaySlots.get(sharedViewState.displayId);
-  if (slot) slot.takeControl();
+  if (!slot) return;
+  // This click is an explicit human decision, unlike the agent's advisory
+  // shared-view event: select the requested surface (safely releasing the
+  // previous one) before asking for its input authority.
+  if (activeTab !== 'displays' && typeof routeTo === 'function') {
+    if (routeTo('displays') === false) return;
+  }
+  if (typeof window.selectLiveDisplay === 'function') {
+    const selected = window.selectLiveDisplay(slot.displayId, {
+      source: 'shared-view-input',
+      focusStage: true,
+    });
+    if (!selected) return;
+  }
+  slot.takeControl();
 }
 
 function handleSharedViewEvent(evt) {
@@ -1515,6 +1736,14 @@ function handleSharedViewEvent(evt) {
   sharedViewState.note = String(evt.note || '');
   sharedViewState.region = evt.region || null;
 
+  const slot = sharedViewState.displayId !== null
+    ? displaySlots.get(sharedViewState.displayId)
+    : displaySlots.size === 1
+      ? displaySlots.values().next().value
+      : null;
+  if (slot && sharedViewState.displayId === null) {
+    sharedViewState.displayId = Number(slot.displayId);
+  }
   clearSharedViewDecorations();
   updateSharedViewBanner();
   if (activeTab !== 'displays' && (activeTab !== 'activity' || activeActivitySubtab !== 'log')) {
@@ -1524,9 +1753,6 @@ function handleSharedViewEvent(evt) {
   if (activeTab === 'activity' && activeActivitySubtab === 'log' && activityStrip) {
     activityStrip.classList.remove('hidden');
   }
-  const slot = sharedViewState.displayId !== null
-    ? displaySlots.get(sharedViewState.displayId)
-    : displaySlots.values().next().value;
   if (slot) applySharedViewToSlot(slot);
 }
 
@@ -1624,7 +1850,11 @@ function addDisplayThumb(displayId) {
 
   const thumb = document.createElement('div');
   thumb.className = 'activity-display-thumb';
-  thumb.innerHTML = `<span class="thumb-label">${displayLabel(displayId, true)}</span>`;
+  const thumbLabel = document.createElement('span');
+  thumbLabel.className = 'thumb-label';
+  // Window titles come from the OS and are not trusted markup.
+  thumbLabel.textContent = displayLabel(displayId, true);
+  thumb.appendChild(thumbLabel);
   thumb.addEventListener('click', (e) => { e.stopPropagation(); toggleDisplayStrip(); }, true);
 
   displayThumbs.set(displayId, thumb);
@@ -1793,6 +2023,7 @@ function applyDisplayStripState() {
 // down through the existing provider lifecycle before that slot is hidden.
 (() => {
   const tab = document.getElementById('tab-displays');
+  const main = document.getElementById('ui2-live-main');
   const container = document.getElementById('displays-container');
   const rail = document.getElementById('ui2-live-rail');
   const displaysList = document.getElementById('ui2-live-displays-list');
@@ -1818,11 +2049,13 @@ function applyDisplayStripState() {
   const peerSources = new Map();
   const slotSnapshots = new Map();
   const activityByDisplay = new Map();
+  const activityRows = new Map();
   const drawerMedia = window.matchMedia('(max-width: 1279px)');
   let selectedDisplayId = null;
   let railOpen = false;
   let railRaf = 0;
   let activitySeq = 0;
+  let activityRenderedDisplayId = null;
   let lastActivitySignature = '';
   let lastAuthoritySignature = '';
   let lastScreenSignature = '';
@@ -1834,6 +2067,39 @@ function applyDisplayStripState() {
 
   function selectedSlot() {
     return selectedDisplayId === null ? null : displaySlots.get(selectedDisplayId) || null;
+  }
+
+  function slotHasActiveUserWork(slot) {
+    if (!slot) return false;
+    return Boolean(
+      slot.interactive ||
+      slot._takeControlPending ||
+      slot.authorityState === 'you' ||
+      slot.el?.classList.contains('display-fullscreen') ||
+      slot.el?.contains(document.activeElement) ||
+      rail.contains(document.activeElement) ||
+      (typeof shouldSuppressDisplayInputForAnnotation === 'function' &&
+        shouldSuppressDisplayInputForAnnotation(slot)) ||
+      (typeof liveCalloutArmedFor === 'function' && liveCalloutArmedFor(slot))
+    );
+  }
+
+  function slotHasBlockingSurfaceWork(slot) {
+    if (!slot) return false;
+    return Boolean(
+      (typeof shouldSuppressDisplayInputForAnnotation === 'function' &&
+        shouldSuppressDisplayInputForAnnotation(slot)) ||
+      (typeof liveCalloutArmedFor === 'function' && liveCalloutArmedFor(slot))
+    );
+  }
+
+  function announceBlockedSurfaceSwitch() {
+    if (typeof showControlToast === 'function') {
+      showControlToast(
+        'info',
+        'Finish or close the current annotation/callout before changing displays.'
+      );
+    }
   }
 
   function emptyHint(textValue) {
@@ -1860,8 +2126,18 @@ function applyDisplayStripState() {
   function teardownSelectedSurface(slot) {
     if (!slot) return;
     // releaseControl is the only safe ordering: held-key keyups are sent
-    // before the server-side authority release closes the input gate.
-    if (slot.interactive) slot.releaseControl();
+    // before the server-side authority release closes the input gate. A
+    // pending Take must also be cancelled: its late `you` reply would
+    // otherwise install document-level paste and input listeners on the
+    // display after this projection has hidden it. Releasing an already-
+    // held but locally unbound authority is idempotent and avoids leaving
+    // a hidden display reserved during the server round trip.
+    if (slot.interactive || slot._takeControlPending || slot.authorityState === 'you') {
+      slot.releaseControl();
+    }
+    if (slot.el?.classList.contains('display-fullscreen')) {
+      slot.toggleFullscreen(false);
+    }
     if (typeof teardownLiveSurfaceForOwner === 'function') {
       teardownLiveSurfaceForOwner(slot);
     }
@@ -1873,7 +2149,13 @@ function applyDisplayStripState() {
     const next = Number.isFinite(id) ? displaySlots.get(id) : null;
     if (!next) return false;
     if (selectedDisplayId !== id) {
-      teardownSelectedSurface(selectedSlot());
+      const current = selectedSlot();
+      if (opts.advisory && slotHasActiveUserWork(current)) return false;
+      if (slotHasBlockingSurfaceWork(current)) {
+        announceBlockedSurfaceSwitch();
+        return false;
+      }
+      teardownSelectedSurface(current);
       selectedDisplayId = id;
     }
     setSelectedProjection();
@@ -1886,18 +2168,53 @@ function applyDisplayStripState() {
     return true;
   }
   window.selectLiveDisplay = selectLiveDisplay;
+  window.retireLiveDisplayWorkspaceSlot = function(displayId) {
+    const id = Number(displayId);
+    const record = displayRows.get(id);
+    if (record) record.row.remove();
+    displayRows.delete(id);
+    slotSnapshots.delete(id);
+    activityByDisplay.delete(id);
+    if (selectedDisplayId === id) selectedDisplayId = null;
+    lastActivitySignature = '';
+    lastAuthoritySignature = '';
+    scheduleWorkspace();
+  };
+  window.canDeactivateLiveDisplayWorkspace = function(options) {
+    const blocking = Array.from(displaySlots.values()).find(slotHasBlockingSurfaceWork);
+    if (!blocking) return true;
+    if (!options || options.announce !== false) announceBlockedSurfaceSwitch();
+    return false;
+  };
+  window.deactivateLiveDisplayWorkspace = function() {
+    if (!window.canDeactivateLiveDisplayWorkspace()) return false;
+    for (const slot of displaySlots.values()) {
+      if (slot.interactive || slot._takeControlPending || slot.authorityState === 'you') {
+        slot.releaseControl();
+      }
+      if (slot.el?.classList.contains('display-fullscreen')) {
+        slot.toggleFullscreen(false);
+      }
+      if (typeof teardownLiveSurfaceForOwner === 'function') {
+        teardownLiveSurfaceForOwner(slot);
+      }
+    }
+    scheduleWorkspace();
+    return true;
+  };
 
   function reconcileSelectedDisplay(slots) {
-    const shared = slots.find(slot => slot.el && slot.el.classList.contains('shared-view-active'));
-    if (shared && Number(shared.displayId) !== selectedDisplayId) {
-      selectLiveDisplay(shared.displayId, { source: 'shared-view' });
-      return;
-    }
     if (selectedDisplayId !== null && displaySlots.has(selectedDisplayId)) {
       setSelectedProjection();
       return;
     }
-    selectedDisplayId = slots.length ? Number(slots[0].displayId) : null;
+    // applySharedViewToSlot selects a newly requested shared-view target
+    // once. If the workspace initializes after that event, prefer its
+    // decorated slot only for this initial/fallback choice. Never force it
+    // again: the user must remain free to inspect another live display.
+    const shared = slots.find(slot => slot.el && slot.el.classList.contains('shared-view-active'));
+    const fallback = shared || slots[0];
+    selectedDisplayId = fallback ? Number(fallback.displayId) : null;
     setSelectedProjection();
   }
 
@@ -1914,17 +2231,19 @@ function applyDisplayStripState() {
       '</span>' +
       '<span class="ui2-live-row-tags" aria-hidden="true">' +
         '<span class="ui2-live-row-tag ui2-live-row-privacy"></span>' +
+        '<span class="ui2-live-row-tag ui2-live-row-media"></span>' +
         '<span class="ui2-live-row-tag ui2-live-row-current"></span>' +
       '</span>';
     row.addEventListener('click', () => {
-      selectLiveDisplay(id, { focusStage: true, source: 'rail' });
-      if (drawerMedia.matches) setRailOpen(false, true);
+      const selected = selectLiveDisplay(id, { focusStage: true, source: 'rail' });
+      if (selected && drawerMedia.matches) setRailOpen(false, true);
     });
     return {
       row,
       title: row.querySelector('.ui2-live-row-title'),
       meta: row.querySelector('.ui2-live-row-meta'),
       privacy: row.querySelector('.ui2-live-row-privacy'),
+      media: row.querySelector('.ui2-live-row-media'),
       current: row.querySelector('.ui2-live-row-current'),
     };
   }
@@ -1970,6 +2289,25 @@ function applyDisplayStripState() {
       const error = Boolean(slot.statusEl && slot.statusEl.classList.contains('error'));
       const active = id === selectedDisplayId;
       const privateView = displayAgentVisibility.get(id) === false;
+      const presenceStreaming = Boolean(slot.streaming);
+      const recording = Boolean(slot.recording);
+      const current = selectedSlot();
+      const releasesControl = !active && Boolean(
+        current && (current.interactive || current._takeControlPending || current.authorityState === 'you')
+      );
+      const blocksForEdit = !active && slotHasBlockingSurfaceWork(current);
+      const visibilityLabel = privateView
+        ? 'private dashboard view; agent cannot see it'
+        : (displayAgentVisibility.get(id) === true && userDisplayIds.has(id))
+          ? 'shared with the agent'
+          : 'agent workspace';
+      const stateLabels = [
+        visibilityLabel,
+        presenceStreaming ? 'streaming frames to the presence model' : '',
+        recording ? 'recording' : '',
+        releasesControl ? 'switching here releases current input control' : '',
+        blocksForEdit ? 'finish the current annotation or callout before switching' : '',
+      ].filter(Boolean);
 
       record.row.classList.toggle('ok', Boolean(slot.connected));
       record.row.classList.toggle('err', error);
@@ -1978,13 +2316,23 @@ function applyDisplayStripState() {
       record.row.setAttribute('aria-pressed', active ? 'true' : 'false');
       if (active) record.row.setAttribute('aria-current', 'true');
       else record.row.removeAttribute('aria-current');
-      record.row.title = active ? label + ' is shown on the stage' : 'Show ' + label + ' on the stage';
+      record.row.title = active
+        ? label + ' is shown on the stage'
+        : blocksForEdit
+          ? 'Finish the current annotation or callout before showing ' + label
+          : 'Show ' + label + ' on the stage' +
+            (releasesControl ? ' and release current input control' : '');
       record.row.setAttribute('aria-label',
-        label + ', ' + status + ', input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown));
+        label + ', ' + status + ', input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown) +
+        ', ' + stateLabels.join(', '));
       record.title.textContent = label;
       record.meta.textContent = status + ' · input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown);
       record.privacy.textContent = privateView ? 'PRIVATE' : '';
       record.privacy.title = privateView ? 'The agent cannot see this private view' : '';
+      record.media.textContent = [presenceStreaming ? 'STREAM' : '', recording ? 'REC' : '']
+        .filter(Boolean).join(' · ');
+      record.media.classList.toggle('streaming', presenceStreaming);
+      record.media.classList.toggle('recording', recording);
       record.current.textContent = active ? 'VIEWING' : (slot.connected ? 'LIVE' : '');
       ordered.push(record);
     }
@@ -2020,10 +2368,12 @@ function applyDisplayStripState() {
       // authority round-trip (or after a failed release), let the holder
       // safely re-bind listeners instead of trapping it behind a Release-
       // only toolbar state.
+      if (drawerMedia.matches) setRailOpen(false, true);
       slot.takeControl();
       return;
     }
     const source = slot.authorityState === 'you' ? slot.releaseBtn : slot.takeBtn;
+    if (source === slot.takeBtn && drawerMedia.matches) setRailOpen(false, true);
     if (source && !source.disabled) source.click();
   });
 
@@ -2110,17 +2460,16 @@ function applyDisplayStripState() {
 
   function snapshotSlot(slot) {
     const statusEl = slot.statusEl;
-    const mode = slot.interactive
-      ? 'interactive'
-      : slot.connected
-        ? 'connected'
-        : statusEl && statusEl.classList.contains('error')
-          ? 'error'
-          : statusEl && statusEl.classList.contains('warn')
-            ? 'warn'
-            : 'connecting';
+    const connection = slot.connected
+      ? 'connected'
+      : statusEl && statusEl.classList.contains('error')
+        ? 'error'
+        : statusEl && statusEl.classList.contains('warn')
+          ? 'warn'
+          : 'connecting';
     return {
-      mode,
+      connection,
+      interactive: Boolean(slot.interactive),
       authority: slot.authorityState || 'unknown',
       streaming: Boolean(slot.streaming),
       recording: Boolean(slot.recording),
@@ -2152,9 +2501,9 @@ function applyDisplayStripState() {
     const prev = slotSnapshots.get(id);
     if (!prev) {
       addDisplayActivity(id, 'neutral', 'Display became available');
-      if (next.mode === 'connected') addDisplayActivity(id, 'live', 'Live stream connected');
-      else if (next.mode === 'interactive') addDisplayActivity(id, 'control', 'Interactive input is active');
-      else if (next.mode === 'error') addDisplayActivity(id, 'error', 'The stream needs attention');
+      if (next.connection === 'connected') addDisplayActivity(id, 'live', 'Live stream connected');
+      else if (next.connection === 'error') addDisplayActivity(id, 'error', 'The stream needs attention');
+      if (next.interactive) addDisplayActivity(id, 'control', 'Interactive input is active');
       if (next.visibility === 'private') addDisplayActivity(id, 'private', 'Private dashboard view started');
       if (next.visibility === 'agent') addDisplayActivity(id, 'share', 'Display shared with the agent');
       if (next.authority === 'you') addDisplayActivity(id, 'control', 'This dashboard holds input authority');
@@ -2164,12 +2513,15 @@ function applyDisplayStripState() {
       return;
     }
 
-    if (prev.mode !== next.mode) {
-      if (next.mode === 'connected') addDisplayActivity(id, 'live', 'Live stream connected');
-      else if (next.mode === 'interactive') addDisplayActivity(id, 'control', 'Interactive input is active');
-      else if (next.mode === 'error') addDisplayActivity(id, 'error', 'The stream needs attention');
-      else if (next.mode === 'warn') addDisplayActivity(id, 'attention', 'The stream is reconnecting');
+    if (prev.connection !== next.connection) {
+      if (next.connection === 'connected') addDisplayActivity(id, 'live', 'Live stream connected');
+      else if (next.connection === 'error') addDisplayActivity(id, 'error', 'The stream needs attention');
+      else if (next.connection === 'warn') addDisplayActivity(id, 'attention', 'The stream is reconnecting');
       else addDisplayActivity(id, 'neutral', 'Connecting to the display');
+    }
+    if (prev.interactive !== next.interactive) {
+      addDisplayActivity(id, next.interactive ? 'control' : 'neutral',
+        next.interactive ? 'Interactive input is active' : 'Interactive input ended');
     }
     if (prev.authority !== next.authority) {
       if (next.authority === 'you') addDisplayActivity(id, 'control', 'You took input control');
@@ -2213,16 +2565,32 @@ function applyDisplayStripState() {
       entries.map(entry => String(entry.seq)).join(',');
     if (signature === lastActivitySignature) return;
     lastActivitySignature = signature;
-    activityList.replaceChildren();
+    if (activityRenderedDisplayId !== selectedDisplayId) {
+      activityRenderedDisplayId = selectedDisplayId;
+      activityRows.clear();
+      activityList.replaceChildren();
+    }
     if (!entries.length) {
-      activityList.appendChild(emptyHint(
-        selectedDisplayId === null
-          ? 'Select a display to see its connection, authority, sharing, and recording events.'
-          : 'Display events will appear here as its real state changes.'));
+      if (!activityList.querySelector('.ui2-live-rail-empty')) {
+        activityList.appendChild(emptyHint(
+          selectedDisplayId === null
+            ? 'Select a display to see its connection, authority, sharing, and recording events.'
+            : 'Display events will appear here as its real state changes.'));
+      }
       return;
     }
-
-    for (const entry of entries.slice().reverse()) {
+    activityList.querySelector('.ui2-live-rail-empty')?.remove();
+    const liveSeqs = new Set(entries.map(entry => entry.seq));
+    for (const [seq, row] of activityRows) {
+      if (liveSeqs.has(seq)) continue;
+      row.remove();
+      activityRows.delete(seq);
+    }
+    // role=log expects chronological DOM order so only the newly appended
+    // row is announced. Rebuilding newest-first made every state change
+    // sound like ten new events to screen readers.
+    for (const entry of entries) {
+      if (activityRows.has(entry.seq)) continue;
       const row = document.createElement('div');
       row.className = 'ui2-live-activity-row kind-' + entry.kind;
       const dot = document.createElement('span');
@@ -2239,6 +2607,7 @@ function applyDisplayStripState() {
       row.appendChild(textEl);
       row.appendChild(time);
       activityList.appendChild(row);
+      activityRows.set(entry.seq, row);
     }
   }
 
@@ -2364,7 +2733,8 @@ function applyDisplayStripState() {
       if (!chip || chip.disabled) return;
       const hostId = chip.dataset.hostId || '';
       const displayId = Number(chip.dataset.displayId || 0);
-      if (typeof routeTo === 'function') routeTo('station');
+      if (typeof routeTo === 'function' && routeTo('station') === false) return;
+      if (drawerMedia.matches) setRailOpen(false, false);
       if (hostId && typeof stationOpenDisplay === 'function') {
         stationOpenDisplay(hostId, displayId);
       } else {
@@ -2426,7 +2796,17 @@ function applyDisplayStripState() {
       return;
     }
     const state = slot.authorityState || 'unknown';
-    mobileSummary.textContent = slotLabel(slot) + ' · input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown);
+    const slots = Array.from(displaySlots.values());
+    const streamingCount = slots.filter(item => item.streaming).length;
+    const recordingCount = slots.filter(item => item.recording).length;
+    const parts = [
+      slotLabel(slot),
+      'input ' + (AUTH_LABEL[state] || AUTH_LABEL.unknown),
+      streamingCount ? streamingCount + ' presence stream' + (streamingCount === 1 ? '' : 's') : '',
+      recordingCount ? recordingCount + ' recording' + (recordingCount === 1 ? '' : 's') : '',
+    ].filter(Boolean);
+    mobileSummary.textContent = parts.join(' · ');
+    mobileSummary.title = parts.join(', ');
   }
 
   function drawerFocusable() {
@@ -2435,20 +2815,34 @@ function applyDisplayStripState() {
     )).filter(element => element.getClientRects().length > 0);
   }
 
-  function syncDrawerState(restoreFocus) {
+  function syncDrawerState(restoreFocus, force) {
+    if (!force && document.body.classList.contains('display-fullscreen-open')) return;
     const drawer = drawerMedia.matches;
     const visible = !drawer || railOpen;
     tab.classList.toggle('ui2-live-rail-open', drawer && railOpen);
     rail.inert = !visible;
     if (visible) rail.removeAttribute('aria-hidden');
     else rail.setAttribute('aria-hidden', 'true');
+    if (drawer) {
+      rail.setAttribute('role', 'dialog');
+      rail.setAttribute('aria-modal', railOpen ? 'true' : 'false');
+    } else {
+      rail.removeAttribute('role');
+      rail.removeAttribute('aria-modal');
+    }
+    if (main) {
+      main.inert = drawer && railOpen;
+      if (drawer && railOpen) main.setAttribute('aria-hidden', 'true');
+      else main.removeAttribute('aria-hidden');
+    }
     if (railToggle) railToggle.setAttribute('aria-expanded', drawer && railOpen ? 'true' : 'false');
     if (railScrim) {
-      railScrim.tabIndex = drawer && railOpen ? 0 : -1;
+      railScrim.tabIndex = -1;
       railScrim.setAttribute('aria-hidden', drawer && railOpen ? 'false' : 'true');
     }
     if (restoreFocus && railToggle && drawer) railToggle.focus();
   }
+  window.syncLiveDisplayDrawerState = () => syncDrawerState(false, true);
 
   function setRailOpen(open, restoreFocus) {
     railOpen = drawerMedia.matches && Boolean(open);
@@ -2480,13 +2874,22 @@ function applyDisplayStripState() {
   });
   document.addEventListener('keydown', event => {
     if (event.key === 'Escape' && drawerMedia.matches && railOpen) {
+      // The portalled display picker is above the drawer and owns the
+      // first Escape. Its later fragment closes it and restores focus;
+      // leave the underlying controls drawer in place.
+      if (document.getElementById('display-picker')?.classList.contains('visible')) return;
       event.preventDefault();
       setRailOpen(false, true);
     }
   });
   const onDrawerMediaChange = () => {
+    const focusWasInRail = rail.contains(document.activeElement);
+    if (typeof hideDisplayPicker === 'function' && displayPickerVisible) {
+      hideDisplayPicker(false);
+    }
     railOpen = false;
     syncDrawerState(false);
+    if (drawerMedia.matches && focusWasInRail && railToggle) railToggle.focus();
   };
   if (typeof drawerMedia.addEventListener === 'function') {
     drawerMedia.addEventListener('change', onDrawerMediaChange);

--- a/static/app/46-recording-replay.js
+++ b/static/app/46-recording-replay.js
@@ -886,9 +886,7 @@ function deleteRecordingStream(streamName) {
     if (slot.recordingStreamName === streamName) {
       slot.recordingStreamName = null;
       slot.recording = false;
-      slot.recordBtn.innerHTML = '&#x23FA; Record';
-      slot.recordBtn.classList.remove('active');
-      slot.deleteRecBtn.style.display = 'none';
+      slot._renderRecordingControls();
     }
   }
 
@@ -1051,4 +1049,3 @@ async function reconcileRecordingStreams() {
     }
   } catch { /* no recordings available */ }
 }
-

--- a/static/app/47-annotation-clips.js
+++ b/static/app/47-annotation-clips.js
@@ -305,6 +305,7 @@ function setLiveAnnotationButton(provider, active) {
     : null;
   if (!btn) return;
   btn.classList.toggle('active', !!active);
+  btn.setAttribute('aria-pressed', active ? 'true' : 'false');
   btn.innerHTML = active ? '&#x2715; Annotating' : '&#9998; Annotate';
   btn.title = active ? 'Exit live annotation' : 'Freeze current frame and annotate it';
 }
@@ -2573,4 +2574,3 @@ document.getElementById('recording-timeline').addEventListener('contextmenu', (e
     deleteClipAnnotationLayer(layerId);
   }
 });
-

--- a/static/app/48-router-settings.js
+++ b/static/app/48-router-settings.js
@@ -181,6 +181,14 @@ function tabDomMatches(tab) {
 // is used (or preserved if it's already the active one).
 function routeTo(tab, subtab) {
   if (tab === 'access' && subtab) subtab = normalizeAccessSubtab(subtab);
+  // A live annotation/callout is editable state, not navigation chrome.
+  // Refuse the route before changing the URL so a tab click cannot silently
+  // discard it or leave the hash claiming a pane we did not open.
+  if (activeTab === 'displays' && tab !== 'displays' &&
+      typeof window.canDeactivateLiveDisplayWorkspace === 'function' &&
+      !window.canDeactivateLiveDisplayWorkspace()) {
+    return false;
+  }
   const target = subtab ? `${tab}/${subtab}` : tab;
   if (DASHBOARD_ACCESS_PAGE_MODE && tab !== 'access') {
     window.location.href = daemonDashboardHref(`#${target}`);
@@ -211,6 +219,7 @@ function routeTo(tab, subtab) {
   if (tab === 'stats' && !switched) {
     renderStatsForActiveHost({ forceSessions: true });
   }
+  return true;
 }
 
 // Apply the URL's current hash to the actual DOM. Called on initial
@@ -228,7 +237,13 @@ function applyCurrentRoute() {
   const switched = tab !== activeTab;
   const needsDomApply = !tabDomMatches(tab);
   if (switched || needsDomApply) {
-    switchTab(tab);
+    if (switchTab(tab) === false) {
+      // Back/forward or a manually edited hash can bypass routeTo's
+      // preflight. Keep the editable Live surface active and restore the
+      // URL without creating another history entry.
+      history.replaceState(null, '', '#displays');
+      return;
+    }
   }
   if (tab === 'activity' && subtab) {
     switchActivitySubtab(subtab);
@@ -252,6 +267,16 @@ window.addEventListener('popstate', applyCurrentRoute);
 window.addEventListener('hashchange', applyCurrentRoute);
 
 function switchTab(tabId) {
+  // Interactive display input includes a document-level paste handler.
+  // Never leave it bound to a stage that is about to become hidden on
+  // Station, Sessions, Settings, etc. Activity already moves the canvas
+  // into a thumbnail and historically released there; this single entry
+  // point makes every navigation path follow the same held-key-flush →
+  // authority-release ordering.
+  if (activeTab === 'displays' && tabId !== 'displays' &&
+      typeof window.deactivateLiveDisplayWorkspace === 'function') {
+    if (window.deactivateLiveDisplayWorkspace() === false) return false;
+  }
   activeTab = tabId;
   document.querySelectorAll('.tab-btn').forEach(b => b.classList.toggle('active', b.dataset.tab === tabId));
   document.querySelectorAll('.tab-pane').forEach(p => p.classList.toggle('active', p.id === 'tab-' + tabId));
@@ -317,6 +342,7 @@ function switchTab(tabId) {
     if (activeAccessSubtab === 'diagnostics') renderConnectHealthPanel();
   }
   flushPaneRenders(tabId);
+  return true;
 }
 
 // ── Settings sub-tabs ──
@@ -491,6 +517,7 @@ function switchActivitySubtab(name) {
   if (name === 'control') {
     refreshControlPane();
   }
+  return true;
 }
 
 let activeSessionsSubtab = 'recent';
@@ -669,4 +696,3 @@ if (document.readyState === 'loading') {
 } else {
   applyInitialRouteFromHash();
 }
-

--- a/static/app/58-shortcuts-boot.js
+++ b/static/app/58-shortcuts-boot.js
@@ -210,6 +210,7 @@ function updateDisplayMetrics(d) {
 // declared in fragment 32 next to the display maps: earlier fragments
 // render against them at load time.)
 let displayPickerVisible = false;
+let displayPickerReturnFocus = null;
 // Which action the open picker performs: 'share' (agent access) or
 // 'view' (private remote view; the agent cannot see the display).
 let displayPickerMode = 'share';
@@ -218,15 +219,30 @@ var cachedDisplays = null;
 function hideDisplayPicker() {
   const picker = document.getElementById('display-picker');
   picker.classList.remove('visible');
+  picker.setAttribute('aria-hidden', 'true');
   displayPickerVisible = false;
+  const returnFocus = displayPickerReturnFocus;
+  displayPickerReturnFocus = null;
+  if (returnFocus && returnFocus.isConnected && typeof returnFocus.focus === 'function') {
+    returnFocus.focus();
+  }
 }
 
 function showDisplayPicker(displays, mode) {
   displayPickerMode = mode === 'view' ? 'view' : 'share';
   const picker = document.getElementById('display-picker');
+  displayPickerReturnFocus = document.activeElement instanceof HTMLElement
+    ? document.activeElement
+    : null;
   picker.innerHTML = '';
+  picker.setAttribute('role', 'dialog');
+  picker.setAttribute('aria-modal', 'false');
+  picker.setAttribute('aria-label', displayPickerMode === 'view'
+    ? 'Choose a screen for your private dashboard view'
+    : 'Choose a screen to share with the agent');
   for (const d of displays) {
-    const item = document.createElement('div');
+    const item = document.createElement('button');
+    item.type = 'button';
     item.className = 'display-picker-item';
     const label = d.name + ' (' + d.width + 'x' + d.height + ')';
     item.textContent = label;
@@ -252,7 +268,8 @@ function showDisplayPicker(displays, mode) {
   if (displayPickerMode !== 'view' && virtualDisplaysAvailableNow()) {
     // Virtual displays are agent workspaces — offering one from the
     // private "View this machine" flow would conflate the two concepts.
-    const createItem = document.createElement('div');
+    const createItem = document.createElement('button');
+    createItem.type = 'button';
     createItem.className = 'display-picker-item dp-action';
     createItem.textContent = 'New virtual display';
     createItem.title = 'Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed.';
@@ -289,7 +306,9 @@ function showDisplayPicker(displays, mode) {
     }
   }
   picker.classList.add('visible');
+  picker.setAttribute('aria-hidden', 'false');
   displayPickerVisible = true;
+  requestAnimationFrame(() => picker.querySelector('.display-picker-item')?.focus());
 }
 
 // Keyless "new virtual display": the daemon launches an Xvfb and registers

--- a/static/app/58-shortcuts-boot.js
+++ b/static/app/58-shortcuts-boot.js
@@ -211,21 +211,72 @@ function updateDisplayMetrics(d) {
 // render against them at load time.)
 let displayPickerVisible = false;
 let displayPickerReturnFocus = null;
+let displayPickerPositionRaf = 0;
+let displayPickerDrawerModal = false;
 // Which action the open picker performs: 'share' (agent access) or
 // 'view' (private remote view; the agent cannot see the display).
 let displayPickerMode = 'share';
 var cachedDisplays = null;
 
-function hideDisplayPicker() {
+function hideDisplayPicker(restoreFocus = true) {
   const picker = document.getElementById('display-picker');
   picker.classList.remove('visible');
   picker.setAttribute('aria-hidden', 'true');
   displayPickerVisible = false;
+  if (displayPickerDrawerModal) {
+    const rail = document.getElementById('ui2-live-rail');
+    const railOpen = document.getElementById('tab-displays')?.classList.contains('ui2-live-rail-open');
+    if (rail) {
+      rail.inert = !railOpen;
+      if (railOpen) rail.removeAttribute('aria-hidden');
+      else rail.setAttribute('aria-hidden', 'true');
+      rail.setAttribute('aria-modal', railOpen ? 'true' : 'false');
+    }
+    displayPickerDrawerModal = false;
+  }
   const returnFocus = displayPickerReturnFocus;
   displayPickerReturnFocus = null;
-  if (returnFocus && returnFocus.isConnected && typeof returnFocus.focus === 'function') {
+  if (restoreFocus && returnFocus && returnFocus.isConnected &&
+      typeof returnFocus.focus === 'function' && !returnFocus.closest('[inert]')) {
     returnFocus.focus();
   }
+}
+
+function positionDisplayPicker() {
+  const picker = document.getElementById('display-picker');
+  if (!displayPickerVisible || picker.parentElement !== document.body) return;
+  const anchor = document.getElementById('ui2-live-yourscreen');
+  const rect = anchor ? anchor.getBoundingClientRect() : null;
+  const margin = 12;
+  const gap = 8;
+  const width = picker.offsetWidth;
+  const height = picker.offsetHeight;
+  picker.style.position = 'fixed';
+  picker.style.zIndex = '95';
+  picker.style.right = 'auto';
+  picker.style.transform = 'none';
+  if (rect && rect.width) {
+    const maxLeft = Math.max(margin, window.innerWidth - width - margin);
+    const left = Math.min(Math.max(margin, rect.left), maxLeft);
+    let top = rect.bottom + gap;
+    if (top + height > window.innerHeight - margin && rect.top - height - gap >= margin) {
+      top = rect.top - height - gap;
+    }
+    const maxTop = Math.max(margin, window.innerHeight - height - margin);
+    picker.style.left = `${Math.round(left)}px`;
+    picker.style.top = `${Math.round(Math.min(Math.max(margin, top), maxTop))}px`;
+  } else {
+    picker.style.left = `${Math.round(Math.max(margin, (window.innerWidth - width) / 2))}px`;
+    picker.style.top = `${Math.round(Math.min(96, Math.max(margin, window.innerHeight - height - margin)))}px`;
+  }
+}
+
+function scheduleDisplayPickerPosition() {
+  if (!displayPickerVisible || displayPickerPositionRaf) return;
+  displayPickerPositionRaf = requestAnimationFrame(() => {
+    displayPickerPositionRaf = 0;
+    positionDisplayPicker();
+  });
 }
 
 function showDisplayPicker(displays, mode) {
@@ -259,7 +310,7 @@ function showDisplayPicker(displays, mode) {
     }
     item.addEventListener('click', (e) => {
       e.stopPropagation();
-      hideDisplayPicker();
+      hideDisplayPicker(true);
       if (!app) return;
       grantUserDisplayTarget(d, displayPickerMode !== 'view');
     });
@@ -275,7 +326,7 @@ function showDisplayPicker(displays, mode) {
     createItem.title = 'Launch a virtual display (Xvfb) on the daemon host — no agent or API key needed.';
     createItem.addEventListener('click', (e) => {
       e.stopPropagation();
-      hideDisplayPicker();
+      hideDisplayPicker(true);
       createVirtualDisplay();
     });
     picker.appendChild(createItem);
@@ -289,25 +340,22 @@ function showDisplayPicker(displays, mode) {
     document.body.appendChild(picker);
   }
   if (picker.parentElement === document.body) {
-    const anchor = document.getElementById('ui2-live-yourscreen');
-    const rect = anchor ? anchor.getBoundingClientRect() : null;
-    picker.style.position = 'fixed';
-    picker.style.zIndex = '95';
-    if (rect && rect.width) {
-      picker.style.left = `${Math.round(rect.left)}px`;
-      picker.style.top = `${Math.round(rect.bottom + 8)}px`;
-      picker.style.right = 'auto';
-      picker.style.transform = 'none';
-    } else {
-      picker.style.left = '50%';
-      picker.style.top = '96px';
-      picker.style.right = 'auto';
-      picker.style.transform = 'translateX(-50%)';
+    const drawerOpen = document.getElementById('tab-displays')?.classList.contains('ui2-live-rail-open');
+    picker.setAttribute('aria-modal', drawerOpen ? 'true' : 'false');
+    displayPickerDrawerModal = Boolean(drawerOpen);
+    if (displayPickerDrawerModal) {
+      const rail = document.getElementById('ui2-live-rail');
+      if (rail) {
+        rail.inert = true;
+        rail.setAttribute('aria-hidden', 'true');
+        rail.setAttribute('aria-modal', 'false');
+      }
     }
   }
   picker.classList.add('visible');
   picker.setAttribute('aria-hidden', 'false');
   displayPickerVisible = true;
+  positionDisplayPicker();
   requestAnimationFrame(() => picker.querySelector('.display-picker-item')?.focus());
 }
 
@@ -483,11 +531,35 @@ function setUserDisplayState(granted, agentVisible = true) {
 document.addEventListener('click', (e) => {
   if (!displayPickerVisible) return;
   const picker = document.getElementById('display-picker');
-  if (!picker.contains(e.target)) hideDisplayPicker();
+  if (!picker.contains(e.target)) hideDisplayPicker(false);
 });
 document.addEventListener('keydown', (e) => {
-  if (e.key === 'Escape' && displayPickerVisible) hideDisplayPicker();
-});
+  if (!displayPickerVisible) return;
+  const picker = document.getElementById('display-picker');
+  if (e.key === 'Escape') {
+    // Capture owns the first Escape so annotation/callout/drawer layers
+    // underneath cannot consume the same keystroke.
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    hideDisplayPicker(true);
+    return;
+  }
+  if (e.key !== 'Tab' || picker.getAttribute('aria-modal') !== 'true') return;
+  const focusable = Array.from(picker.querySelectorAll('button:not([disabled])'))
+    .filter(element => element.getClientRects().length > 0);
+  if (!focusable.length) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (e.shiftKey && (document.activeElement === first || !picker.contains(document.activeElement))) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && (document.activeElement === last || !picker.contains(document.activeElement))) {
+    e.preventDefault();
+    first.focus();
+  }
+}, true);
+window.addEventListener('resize', scheduleDisplayPickerPosition);
+document.addEventListener('scroll', scheduleDisplayPickerPosition, true);
 
 // Rollback modal: Escape closes, click on the backdrop (outside the
 // dialog) also closes — follows the same dismissal pattern as the

--- a/static/app/ui2-live.css
+++ b/static/app/ui2-live.css
@@ -30,6 +30,30 @@
    Station peer chips, and the user-display grant without replacing focused
    controls on every metrics update. */
 
+/* Semantic ink is separate from tint RGB. The base design tokens work on
+   dark surfaces; light mode needs darker foregrounds to keep small status
+   text above WCAG AA against the same 10–14% semantic fills. */
+html.ui-v2 {
+  --cu-green-ink: var(--green);
+  --cu-amber-ink: var(--amber);
+  --cu-rose-ink: var(--rose);
+  --cu-sky-ink: var(--sky);
+  --cu-control-outline: #5c6474;
+  --cu-stage-text: #eaecf2;
+  --cu-stage-text-2: #a7aebe;
+  --cu-stage-rose: #ec6a85;
+  --cu-stage-green: #58c08c;
+  --cu-stage-amber: #e4a85b;
+  --cu-stage-line: rgba(230, 236, 247, .14);
+}
+html.ui-v2[data-theme="light"] {
+  --cu-green-ink: #0d633b;
+  --cu-amber-ink: #774000;
+  --cu-rose-ink: #a01f3b;
+  --cu-sky-ink: #15568c;
+  --cu-control-outline: #818899;
+}
+
 /* ── tab scaffold: stage/recording column + semantic right rail ── */
 html.ui-v2 #tab-displays.active {
   display: grid;
@@ -72,7 +96,7 @@ html.ui-v2 .display-approval-banner .icon {
 html.ui-v2 .display-approval-banner .title {
   font-size: 13px;
   font-weight: 800;
-  color: var(--amber);
+  color: var(--cu-amber-ink);
   margin-bottom: 3px;
 }
 html.ui-v2 .display-approval-banner .subtitle { font-size: 12px; color: var(--text-2); }
@@ -88,7 +112,7 @@ html.ui-v2 .shared-view-banner {
   font-size: 12.5px;
 }
 html.ui-v2 .shared-view-kicker {
-  color: var(--sky);
+  color: var(--cu-sky-ink);
   font-size: 10.5px;
   font-weight: 700;
   letter-spacing: .08em;
@@ -112,9 +136,9 @@ html.ui-v2 .shared-view-action:hover {
   filter: brightness(1.08);
 }
 html.ui-v2 .shared-view-close {
-  width: 26px;
-  min-height: 26px;
-  border: 1px solid var(--line);
+  width: 36px;
+  min-height: 36px;
+  border: 1px solid var(--cu-control-outline);
   border-radius: 8px;
   background: transparent;
   color: var(--text-2);
@@ -123,7 +147,7 @@ html.ui-v2 .shared-view-close {
 }
 html.ui-v2 .shared-view-close:hover {
   border-color: rgba(var(--rose-rgb), .4);
-  color: var(--rose);
+  color: var(--cu-rose-ink);
   background: rgba(var(--rose-rgb), .08);
 }
 /* compact variant docks flush inside the activity strip */
@@ -203,10 +227,11 @@ html.ui-v2 .display-toolbar {
   border-bottom: 0;
   padding: 14px 16px 10px;
   gap: 14px;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   min-width: 0;
 }
 html.ui-v2 .display-toolbar-meta {
+  flex: 1 1 260px;
   min-width: 0;
   display: flex;
   align-items: center;
@@ -214,14 +239,15 @@ html.ui-v2 .display-toolbar-meta {
   gap: 7px 10px;
 }
 html.ui-v2 .display-toolbar-actions {
+  flex: 1 1 680px;
   min-width: 0;
   margin-left: auto;
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 7px;
-  overflow-x: auto;
-  overscroll-behavior-x: contain;
-  scrollbar-width: thin;
+  overflow-x: visible;
 }
 /* Display selection lives in the real rail. The stage label is therefore
    an honest heading, not a non-interactive span styled as a dropdown. */
@@ -265,7 +291,7 @@ html.ui-v2 .display-status.error {
   border: 1px solid rgba(var(--rose-rgb), .26);
   border-radius: var(--r-pill);
   background: rgba(var(--rose-rgb), .10);
-  color: var(--rose);
+  color: var(--cu-rose-ink);
   font-weight: 700;
   font-size: 11.5px;
 }
@@ -277,7 +303,7 @@ html.ui-v2 .display-status.warn {
   border: 1px solid rgba(var(--amber-rgb), .26);
   border-radius: var(--r-pill);
   background: rgba(var(--amber-rgb), .12);
-  color: var(--amber);
+  color: var(--cu-amber-ink);
   font-weight: 700;
   font-size: 11.5px;
 }
@@ -306,12 +332,12 @@ html.ui-v2 .display-input-authority {
 html.ui-v2 .display-input-authority.you {
   background: rgba(var(--green-rgb), .12);
   border-color: rgba(var(--green-rgb), .26);
-  color: var(--green);
+  color: var(--cu-green-ink);
 }
 html.ui-v2 .display-input-authority.other {
   background: rgba(var(--amber-rgb), .14);
   border-color: rgba(var(--amber-rgb), .26);
-  color: var(--amber);
+  color: var(--cu-amber-ink);
 }
 html.ui-v2 .display-input-authority.unclaimed {
   background: var(--surface-3);
@@ -331,12 +357,12 @@ html.ui-v2 .display-visibility {
   white-space: nowrap;
 }
 html.ui-v2 .display-visibility.private {
-  color: var(--green);
+  color: var(--cu-green-ink);
   border-color: rgba(var(--green-rgb), .26);
   background: rgba(var(--green-rgb), .1);
 }
 html.ui-v2 .display-visibility.agent {
-  color: var(--amber);
+  color: var(--cu-amber-ink);
   border-color: rgba(var(--amber-rgb), .28);
   background: rgba(var(--amber-rgb), .11);
 }
@@ -346,7 +372,7 @@ html.ui-v2 .display-toolbar button {
   flex: 0 0 auto;
   min-height: 0;
   padding: 6px 11px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--cu-control-outline);
   border-radius: var(--r-ctl);
   background: transparent;
   color: var(--text-2);
@@ -356,17 +382,18 @@ html.ui-v2 .display-toolbar button {
   transition: background var(--t-fast), color var(--t-fast), border-color var(--t-fast), filter var(--t-fast);
 }
 html.ui-v2 .display-toolbar-actions .take-control-btn { margin-left: 0; }
+html.ui-v2 .display-toolbar-actions .display-fullscreen-btn { margin-left: 6px; }
 html.ui-v2 .display-toolbar button:hover {
   background: var(--surface-2);
-  border-color: var(--line-2);
+  border-color: var(--text-2);
   color: var(--text);
 }
 /* streaming to the presence model = sky (live/info) while active */
-html.ui-v2 .display-toolbar .stream-btn:hover { color: var(--sky); border-color: rgba(var(--sky-rgb), .4); background: rgba(var(--sky-rgb), .08); }
+html.ui-v2 .display-toolbar .stream-btn:hover { color: var(--cu-sky-ink); border-color: rgba(var(--sky-rgb), .4); background: rgba(var(--sky-rgb), .08); }
 html.ui-v2 .display-toolbar .stream-btn.active {
   background: rgba(var(--sky-rgb), .14);
   border-color: rgba(var(--sky-rgb), .32);
-  color: var(--sky);
+  color: var(--cu-sky-ink);
   font-weight: 700;
 }
 html.ui-v2 .display-toolbar .annotate-btn:hover,
@@ -380,13 +407,13 @@ html.ui-v2 .display-toolbar .annotate-btn.active {
    dot would double it.) */
 html.ui-v2 .display-toolbar .record-btn {
   border-color: rgba(var(--rose-rgb), .4);
-  color: var(--rose);
+  color: var(--cu-rose-ink);
   font-weight: 700;
 }
 html.ui-v2 .display-toolbar .record-btn:hover {
   background: rgba(var(--rose-rgb), .10);
   border-color: rgba(var(--rose-rgb), .55);
-  color: var(--rose);
+  color: var(--cu-rose-ink);
 }
 html.ui-v2 .display-toolbar .record-btn.active {
   background: var(--rose);
@@ -402,7 +429,7 @@ html.ui-v2 .display-toolbar .display-close-btn {
 html.ui-v2 .display-toolbar .display-close-btn:hover {
   background: rgba(var(--rose-rgb), .08);
   border-color: rgba(var(--rose-rgb), .4);
-  color: var(--rose);
+  color: var(--cu-rose-ink);
 }
 /* Take control — the design's iris primary. The verb is honest: it takes
    (displacing any other viewer), it does not request. */
@@ -426,27 +453,27 @@ html.ui-v2 .display-toolbar .take-control-btn:hover {
 html.ui-v2 .display-toolbar .release-control-btn {
   background: rgba(var(--amber-rgb), .14);
   border-color: rgba(var(--amber-rgb), .32);
-  color: var(--amber);
+  color: var(--cu-amber-ink);
   font-weight: 700;
 }
 html.ui-v2 .display-toolbar .release-control-btn:hover {
   background: rgba(var(--amber-rgb), .2);
   border-color: rgba(var(--amber-rgb), .45);
-  color: var(--amber);
+  color: var(--cu-amber-ink);
 }
 html.ui-v2 .display-toolbar .delete-recording-btn {
   border-color: rgba(var(--rose-rgb), .4);
-  color: var(--rose);
+  color: var(--cu-rose-ink);
   font-size: 11.5px;
 }
 html.ui-v2 .display-toolbar .delete-recording-btn:hover {
   background: rgba(var(--rose-rgb), .10);
   border-color: rgba(var(--rose-rgb), .55);
-  color: var(--rose);
+  color: var(--cu-rose-ink);
 }
 html.ui-v2 .display-toolbar .release-note {
   flex: 0 0 150px;
-  border: 1px solid var(--line-2);
+  border: 1px solid var(--cu-control-outline);
   border-radius: 9px;
   background: var(--surface-2);
   color: var(--text);
@@ -473,7 +500,7 @@ html.ui-v2 .display-canvas {
   overflow: hidden;
   background: radial-gradient(120% 120% at 30% 0%, #10131b, #070810 70%);
   box-shadow:
-    inset 0 0 0 1px var(--line-2),
+    inset 0 0 0 1px var(--cu-stage-line),
     inset 0 1px 0 rgba(255, 255, 255, .04),
     0 24px 60px rgba(0, 0, 0, .5);
 }
@@ -503,7 +530,7 @@ html.ui-v2 .display-control-banner {
   box-shadow: 0 8px 24px rgba(0, 0, 0, .28);
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
-  color: var(--green);
+  color: var(--cu-stage-green);
   font-size: 11px;
   font-weight: 700;
   line-height: 1.25;
@@ -521,7 +548,7 @@ html.ui-v2 .display-control-banner::before {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--green);
+  background: var(--cu-stage-green);
   transform: translateY(-50%);
   box-shadow: 0 0 0 3px rgba(var(--green-rgb), .16);
 }
@@ -537,10 +564,10 @@ html.ui-v2 .display-slot:has(.display-status.connected) .display-canvas::after {
   padding: 5px 11px 5px 24px;
   border-radius: var(--r-pill);
   background: rgba(11, 12, 16, .72);
-  border: 1px solid var(--line-2);
+  border: 1px solid var(--cu-stage-line);
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
-  color: var(--rose);
+  color: var(--cu-stage-rose);
   font-family: var(--sans);
   font-size: 11px;
   font-weight: 700;
@@ -557,7 +584,7 @@ html.ui-v2 .display-slot:has(.display-status.connected) .display-canvas::before 
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--rose);
+  background: var(--cu-stage-rose);
   animation: ui2-pulse 1.4s infinite;
   pointer-events: none;
 }
@@ -587,7 +614,7 @@ html.ui-v2 .stage-overlay-inner {
   text-align: center;
   border-radius: 12px;
   background: rgba(11, 12, 16, .72);
-  border: 1px solid var(--line-2);
+  border: 1px solid var(--cu-stage-line);
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
 }
@@ -596,15 +623,15 @@ html.ui-v2 .stage-overlay-text {
   font-size: 12.5px;
   font-weight: 600;
   line-height: 1.5;
-  color: var(--text-2);
+  color: var(--cu-stage-text-2);
 }
-html.ui-v2 .display-stage-overlay.error .stage-overlay-text { color: var(--rose); }
+html.ui-v2 .display-stage-overlay.error .stage-overlay-text { color: var(--cu-stage-rose); }
 html.ui-v2 .stage-overlay-spinner {
   width: 16px;
   height: 16px;
   flex: 0 0 auto;
   border-radius: 50%;
-  border: 2px solid var(--line-2);
+  border: 2px solid var(--cu-stage-line);
   border-top-color: var(--iris);
   animation: ui2-stage-spin .8s linear infinite;
 }
@@ -640,10 +667,10 @@ html.ui-v2 .display-live-metrics {
   padding: 5px 11px;
   border-radius: var(--r-pill);
   background: rgba(11, 12, 16, .72);
-  border: 1px solid var(--line-2);
+  border: 1px solid var(--cu-stage-line);
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
-  color: var(--text-2);
+  color: var(--cu-stage-text-2);
   font-family: var(--mono);
   font-size: 10.5px;
   font-weight: 600;
@@ -658,7 +685,7 @@ html.ui-v2 .display-live-metrics::before {
   height: 7px;
   flex: 0 0 auto;
   border-radius: 50%;
-  background: var(--rose);
+  background: var(--cu-stage-rose);
   animation: ui2-pulse 1.4s infinite;
 }
 html.ui-v2 .display-slot:has(.display-live-metrics.active) .display-canvas::after,
@@ -685,7 +712,7 @@ html.ui-v2 .display-slot.shared-view-active .display-canvas {
 }
 html.ui-v2 .shared-view-focus-box {
   border-radius: 6px;
-  border-color: var(--amber);
+  border-color: var(--cu-stage-amber);
   background: rgba(var(--amber-rgb), .06);
   box-shadow:
     0 0 0 1px rgba(7, 8, 16, .72),
@@ -694,14 +721,15 @@ html.ui-v2 .shared-view-focus-box {
 html.ui-v2 .shared-view-focus-box::after {
   border-radius: 8px;
   background: rgba(11, 13, 18, .92);
-  border-color: rgba(var(--amber-rgb), .5);
+  border-color: rgba(228, 168, 91, .5);
+  color: var(--cu-stage-text);
   font-family: var(--sans);
 }
 /* light theme: the stage stays a dark viewport, but its .5-black drop
    shadow is dark-tuned — soften toward the light elevation vocabulary. */
 html.ui-v2[data-theme="light"] .display-canvas {
   box-shadow:
-    inset 0 0 0 1px var(--line-2),
+    inset 0 0 0 1px var(--cu-stage-line),
     inset 0 1px 0 rgba(255, 255, 255, .04),
     0 24px 60px rgba(23, 28, 50, .22);
 }
@@ -733,6 +761,21 @@ html.ui-v2 .display-slot.display-fullscreen .display-canvas {
   box-shadow: none;
 }
 html.ui-v2 .display-slot.display-fullscreen .display-toolbar { padding: 10px 14px; }
+/* Interaction focus outranks the shared-view/fullscreen state rings above. */
+html.ui-v2 .display-slot.shared-view-active .display-canvas:has(video:focus-visible),
+html.ui-v2 .display-slot.display-fullscreen .display-canvas:has(video:focus-visible) {
+  box-shadow:
+    inset 0 0 0 2px var(--iris),
+    inset 0 1px 0 rgba(255, 255, 255, .04),
+    0 24px 60px rgba(0, 0, 0, .5);
+}
+html.ui-v2[data-theme="light"] .display-slot.shared-view-active .display-canvas:has(video:focus-visible),
+html.ui-v2[data-theme="light"] .display-slot.display-fullscreen .display-canvas:has(video:focus-visible) {
+  box-shadow:
+    inset 0 0 0 2px var(--iris),
+    inset 0 1px 0 rgba(255, 255, 255, .04),
+    0 24px 60px rgba(23, 28, 50, .22);
+}
 
 /* ── collapse bar + split handles ── */
 html.ui-v2 .displays-collapse-bar {
@@ -1183,6 +1226,7 @@ html.ui-v2 .display-picker-item {
   font-size: 12.5px;
   font-weight: 600;
   color: var(--text);
+  min-height: 44px;
   padding: 8px 11px;
 }
 html.ui-v2 .display-picker-item:hover { background: rgba(var(--iris-rgb), .1); }
@@ -1284,13 +1328,13 @@ html.ui-v2 .display-toolbar .callout-btn:hover,
 html.ui-v2 .peer-display-controls .callout-btn:hover {
   background: rgba(var(--amber-rgb), .10);
   border-color: rgba(var(--amber-rgb), .45);
-  color: var(--amber);
+  color: var(--cu-amber-ink);
 }
 html.ui-v2 .display-toolbar .callout-btn[aria-pressed="true"],
 html.ui-v2 .peer-display-controls .callout-btn[aria-pressed="true"] {
   background: rgba(var(--amber-rgb), .16);
   border-color: rgba(var(--amber-rgb), .5);
-  color: var(--amber);
+  color: var(--cu-amber-ink);
   font-weight: 700;
   box-shadow: 0 0 0 3px rgba(var(--amber-rgb), .12);
 }
@@ -1323,7 +1367,7 @@ html.ui-v2 .callout-arm-overlay {
 }
 html.ui-v2 .callout-arm-rect {
   position: absolute;
-  border: 2px solid var(--amber);
+  border: 2px solid var(--cu-stage-amber);
   background: rgba(var(--amber-rgb), .12);
   box-shadow: 0 0 0 1px rgba(0, 0, 0, .35);
   pointer-events: none;
@@ -1337,8 +1381,8 @@ html.ui-v2 .callout-arm-hint {
   padding: 4px 10px;
   border-radius: var(--r-pill);
   background: rgba(11, 12, 16, .72);
-  border: 1px solid var(--line-2);
-  color: var(--amber);
+  border: 1px solid var(--cu-stage-line);
+  color: var(--cu-stage-amber);
   font-size: 11px;
   font-weight: 600;
   white-space: nowrap;
@@ -1432,7 +1476,7 @@ html.ui-v2 .ui2-live-row {
   width: 100%;
   min-height: 50px;
   padding: 10px 11px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--cu-control-outline);
   border-radius: 11px;
   background: var(--surface);
   color: var(--text);
@@ -1513,7 +1557,9 @@ html.ui-v2 .ui2-live-row-tag {
   font-weight: 800;
   letter-spacing: .05em;
 }
-html.ui-v2 .ui2-live-row-privacy { color: var(--green); }
+html.ui-v2 .ui2-live-row-privacy { color: var(--cu-green-ink); }
+html.ui-v2 .ui2-live-row-media.streaming { color: var(--cu-sky-ink); }
+html.ui-v2 .ui2-live-row-media.recording { color: var(--cu-rose-ink); }
 html.ui-v2 .ui2-live-row-chev {
   flex: 0 0 auto;
   color: var(--text-3);
@@ -1597,19 +1643,19 @@ html.ui-v2 .ui2-live-state-pill {
 html.ui-v2 .ui2-live-state-pill.you {
   border-color: rgba(var(--green-rgb), .26);
   background: rgba(var(--green-rgb), .12);
-  color: var(--green);
+  color: var(--cu-green-ink);
 }
 html.ui-v2 .ui2-live-state-pill.other {
   border-color: rgba(var(--amber-rgb), .26);
   background: rgba(var(--amber-rgb), .14);
-  color: var(--amber);
+  color: var(--cu-amber-ink);
 }
 html.ui-v2 .ui2-live-card-btn {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 100%;
-  min-height: 38px;
+  min-height: 44px;
   margin-top: 9px;
   padding: 9px;
   border: 0;
@@ -1623,6 +1669,7 @@ html.ui-v2 .ui2-live-card-btn {
   transition: filter var(--t-med), background var(--t-fast), border-color var(--t-fast);
 }
 html.ui-v2 .ui2-live-card-btn:hover { filter: brightness(1.08); }
+html.ui-v2 .ui2-live-card-btn[hidden] { display: none; }
 html.ui-v2 .ui2-live-card-btn:disabled {
   opacity: .55;
   cursor: wait;
@@ -1632,10 +1679,10 @@ html.ui-v2 .ui2-live-card-btn.release {
   border: 1px solid rgba(var(--amber-rgb), .32);
   background: rgba(var(--amber-rgb), .14);
   box-shadow: none;
-  color: var(--amber);
+  color: var(--cu-amber-ink);
 }
 html.ui-v2 .ui2-live-card-btn.secondary {
-  border: 1px solid var(--line);
+  border: 1px solid var(--cu-control-outline);
   background: var(--surface-2);
   box-shadow: none;
   color: var(--text);
@@ -1650,7 +1697,7 @@ html.ui-v2 .ui2-live-card-btn.danger {
   border: 1px solid rgba(var(--rose-rgb), .4);
   background: transparent;
   box-shadow: none;
-  color: var(--rose);
+  color: var(--cu-rose-ink);
   font-weight: 700;
 }
 html.ui-v2 .ui2-live-card-btn.danger:hover {
@@ -1675,6 +1722,9 @@ html.ui-v2 .ui2-live-activity {
   display: flex;
   flex-direction: column;
   gap: 1px;
+  max-height: 190px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 html.ui-v2 .ui2-live-activity-row {
   display: grid;
@@ -1750,9 +1800,9 @@ html.ui-v2 .ui2-live-activity-time {
   }
   html.ui-v2 .ui2-live-rail-toggle {
     flex: 0 0 auto;
-    min-height: 36px;
+    min-height: 44px;
     padding: 7px 12px;
-    border: 1px solid var(--line-2);
+    border: 1px solid var(--cu-control-outline);
     border-radius: var(--r-ctl);
     background: var(--surface);
     color: var(--text);
@@ -1779,9 +1829,9 @@ html.ui-v2 .ui2-live-activity-time {
   html.ui-v2 .ui2-live-rail-close {
     display: grid;
     place-items: center;
-    width: 34px;
-    height: 34px;
-    border: 1px solid var(--line);
+    width: 44px;
+    height: 44px;
+    border: 1px solid var(--cu-control-outline);
     border-radius: var(--r-ctl);
     background: var(--surface);
     color: var(--text-2);
@@ -1823,22 +1873,24 @@ html.ui-v2 .ui2-live-activity-time {
     min-height: 30px;
   }
   html.ui-v2 .display-toolbar-actions {
+    flex: 0 0 auto;
     width: 100%;
     margin-left: 0;
     padding: 1px 0 4px;
   }
-  html.ui-v2 .display-toolbar-actions .take-control-btn,
-  html.ui-v2 .display-toolbar-actions .release-control-btn {
-    order: -2;
-  }
   html.ui-v2 .display-toolbar button {
-    min-height: 36px;
+    min-height: 44px;
     padding: 7px 11px;
   }
   html.ui-v2 .display-toolbar .release-note {
     flex-basis: 145px;
-    min-height: 36px;
+    min-height: 44px;
   }
+  html.ui-v2 .display-toolbar .display-fullscreen-btn,
+  html.ui-v2 .display-toolbar .display-close-btn { width: 44px; }
+  html.ui-v2 .shared-view-action,
+  html.ui-v2 .shared-view-close { min-height: 44px; }
+  html.ui-v2 .shared-view-close { width: 44px; }
   html.ui-v2 .display-canvas { margin: 0 10px 10px; }
   html.ui-v2 .display-control-banner {
     top: auto;

--- a/static/app/ui2-live.css
+++ b/static/app/ui2-live.css
@@ -1,8 +1,8 @@
-/* ── ui-v2 Live display (Video tab) re-skin (design-overhaul P2) ───────
-   Everything here is scoped under `html.ui-v2` and restyles the EXISTING
-   displays DOM (display-slot toolbars/stages, banners, recording replay,
-   annotation + clip editors, peer-display pane controls) to the v2
-   design language — v1 stays pixel-identical.
+/* ── ui-v2 Live display / Computer Use workspace ──────────────────────
+   `html.ui-v2` is the permanent dashboard namespace. This sheet reconciles
+   the stage-first CU concept with the production display lifecycle:
+   selected local display, input authority, sharing, recording, annotation,
+   peer launchers, and the private-vs-agent-visible user-screen grant.
 
    HARD GUARDRAILS honoured throughout (audit §5, displays.md):
    - No CSS touches video/canvas element DIMENSIONS with !important, and
@@ -25,14 +25,27 @@
      displacement (no request/approve ceremony), and the third state —
      another viewer holding input — renders as an amber chip + rail row.
 
-   The right rail (.ui2-live-rail) is injected by the ui2Enabled()-gated
-   mirror block at the end of 45-displays-webrtc.js: it renders FROM the
-   existing slot DOM / station peer chips / sb-display-access chip and
-   proxies clicks to the existing controls. Display-only, v1 untouched. */
+   The semantic right rail lives in 20-shell.html. The stable keyed
+   projection at the end of 45-displays-webrtc.js renders from displaySlots,
+   Station peer chips, and the user-display grant without replacing focused
+   controls on every metrics update. */
 
-/* ── tab scaffold: content column + fixed right rail ── */
-html.ui-v2 #tab-displays { padding-right: 284px; }
-html.ui-v2 #tab-displays > :not(.ui2-live-rail) { min-width: 0; }
+/* ── tab scaffold: stage/recording column + semantic right rail ── */
+html.ui-v2 #tab-displays.active {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  overflow: hidden;
+}
+html.ui-v2 .ui2-live-main {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+html.ui-v2 .ui2-live-mobile-bar,
+html.ui-v2 .ui2-live-rail-scrim,
+html.ui-v2 .ui2-live-rail-close { display: none; }
 
 /* ── degraded state: macOS capture-approval banner (amber = needs you) ── */
 html.ui-v2 .display-approval-banner {
@@ -125,8 +138,14 @@ html.ui-v2 .shared-view-banner-compact {
 }
 
 /* ── displays container + empty state ── */
-html.ui-v2 .displays-container { padding: 2px 16px 14px; }
+html.ui-v2 .displays-container { padding: 2px 0 0; }
 html.ui-v2 .displays-container:not(.has-displays) { padding: 24px 16px; }
+html.ui-v2 .displays-container.ui2-live-single-stage > .display-slot.ui2-live-inactive {
+  display: none;
+}
+html.ui-v2 .displays-container.ui2-live-single-stage > .display-slot.ui2-live-selected {
+  display: flex;
+}
 html.ui-v2 #tab-displays .ui-empty-glyph {
   width: 40px;
   height: 40px;
@@ -182,23 +201,35 @@ html.ui-v2 .display-slot + .display-slot { margin-top: 8px; }
 html.ui-v2 .display-toolbar {
   background: transparent;
   border-bottom: 0;
-  padding: 10px 2px 10px;
-  gap: 8px;
-  /* v1 never wraps; at narrow widths the trailing buttons (incl. Take
-     Control) clipped off the right edge with no scroll. Wrap instead. */
-  flex-wrap: wrap;
+  padding: 14px 16px 10px;
+  gap: 14px;
+  flex-wrap: nowrap;
+  min-width: 0;
 }
-/* display name wears the design's picker-button look (static: every
-   granted display renders simultaneously — no dropdown to fake) */
+html.ui-v2 .display-toolbar-meta {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px 10px;
+}
+html.ui-v2 .display-toolbar-actions {
+  min-width: 0;
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
+}
+/* Display selection lives in the real rail. The stage label is therefore
+   an honest heading, not a non-interactive span styled as a dropdown. */
 html.ui-v2 .display-label {
   font-family: var(--sans);
-  font-size: 13px;
-  font-weight: 700;
+  font-size: 15px;
+  font-weight: 800;
   color: var(--text);
-  padding: 6px 12px;
-  border: 1px solid var(--line);
-  border-radius: 9px;
-  background: var(--surface);
   max-width: 260px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -288,8 +319,31 @@ html.ui-v2 .display-input-authority.unclaimed {
   color: var(--text-2);
 }
 
+html.ui-v2 .display-visibility {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border-radius: var(--r-pill);
+  border: 1px solid var(--line-2);
+  font-family: var(--sans);
+  font-size: 10.5px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+html.ui-v2 .display-visibility.private {
+  color: var(--green);
+  border-color: rgba(var(--green-rgb), .26);
+  background: rgba(var(--green-rgb), .1);
+}
+html.ui-v2 .display-visibility.agent {
+  color: var(--amber);
+  border-color: rgba(var(--amber-rgb), .28);
+  background: rgba(var(--amber-rgb), .11);
+}
+
 /* toolbar buttons: quiet secondaries by default */
 html.ui-v2 .display-toolbar button {
+  flex: 0 0 auto;
   min-height: 0;
   padding: 6px 11px;
   border: 1px solid var(--line);
@@ -301,6 +355,7 @@ html.ui-v2 .display-toolbar button {
   font-weight: 600;
   transition: background var(--t-fast), color var(--t-fast), border-color var(--t-fast), filter var(--t-fast);
 }
+html.ui-v2 .display-toolbar-actions .take-control-btn { margin-left: 0; }
 html.ui-v2 .display-toolbar button:hover {
   background: var(--surface-2);
   border-color: var(--line-2);
@@ -390,6 +445,7 @@ html.ui-v2 .display-toolbar .delete-recording-btn:hover {
   color: var(--rose);
 }
 html.ui-v2 .display-toolbar .release-note {
+  flex: 0 0 150px;
   border: 1px solid var(--line-2);
   border-radius: 9px;
   background: var(--surface-2);
@@ -412,6 +468,7 @@ html.ui-v2 .display-canvas {
   display: flex;
   align-items: center;
   justify-content: center;
+  margin: 0 16px 16px;
   border-radius: 16px;
   overflow: hidden;
   background: radial-gradient(120% 120% at 30% 0%, #10131b, #070810 70%);
@@ -420,6 +477,55 @@ html.ui-v2 .display-canvas {
     inset 0 1px 0 rgba(255, 255, 255, .04),
     0 24px 60px rgba(0, 0, 0, .5);
 }
+html.ui-v2 .display-canvas:has(video:focus-visible) {
+  box-shadow:
+    inset 0 0 0 2px var(--iris),
+    inset 0 1px 0 rgba(255, 255, 255, .04),
+    0 24px 60px rgba(0, 0, 0, .5);
+}
+
+/* Explicit feedback that input listeners are bound to THIS stage. The
+   server authority chip remains the source of truth; this banner only
+   appears after DisplaySlot._enterInteractive has installed the capture
+   stack (including the document paste handler). */
+html.ui-v2 .display-control-banner {
+  display: none;
+  position: absolute;
+  z-index: 8;
+  top: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: calc(100% - 210px);
+  padding: 6px 12px 6px 26px;
+  border: 1px solid rgba(var(--green-rgb), .34);
+  border-radius: var(--r-pill);
+  background: rgba(11, 12, 16, .76);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, .28);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+  color: var(--green);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.25;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
+}
+html.ui-v2 .display-control-banner::before {
+  content: '';
+  position: absolute;
+  left: 11px;
+  top: 50%;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green);
+  transform: translateY(-50%);
+  box-shadow: 0 0 0 3px rgba(var(--green-rgb), .16);
+}
+html.ui-v2 .display-slot.is-interactive .display-control-banner { display: block; }
 /* LIVE pill — pure CSS, derived from the real connection state; any
    reconnect/degraded state drops .connected and the pill vanishes. */
 html.ui-v2 .display-slot:has(.display-status.connected) .display-canvas::after {
@@ -609,6 +715,7 @@ html.ui-v2[data-theme="light"] .display-slot.shared-view-active .display-canvas 
 /* contexts that must NOT wear the stage chrome: activity thumbnails and
    in-page fullscreen (the reparented canvas keeps its geometry honest) */
 html.ui-v2 .activity-display-thumb > .display-canvas {
+  margin: 0;
   border-radius: 3px;
   box-shadow: none;
 }
@@ -621,6 +728,7 @@ html.ui-v2 .activity-display-thumb .display-live-metrics {
 }
 html.ui-v2 .display-slot.display-fullscreen { background: var(--bg); }
 html.ui-v2 .display-slot.display-fullscreen .display-canvas {
+  margin: 0 14px 14px;
   border-radius: 0;
   box-shadow: none;
 }
@@ -1050,13 +1158,27 @@ html.ui-v2 .thumb-label {
 /* ── user-display picker popover (opens from the status-bar chip; the
       rail's "Your screen" card proxies the same control) ── */
 html.ui-v2 .display-picker {
+  display: none;
+  min-width: 260px;
+  max-width: min(360px, calc(100vw - 24px));
+  max-height: min(440px, calc(100vh - 24px));
+  overflow-y: auto;
   background: linear-gradient(180deg, var(--surface-2), var(--surface));
   border: 1px solid var(--line-2);
   border-radius: var(--r-card);
   padding: 5px;
   box-shadow: var(--shadow-overlay);
 }
+html.ui-v2 .display-picker.visible { display: block; }
 html.ui-v2 .display-picker-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  font-family: var(--sans);
+  text-align: left;
+  cursor: pointer;
   border-radius: 8px;
   font-size: 12.5px;
   font-weight: 600;
@@ -1064,6 +1186,13 @@ html.ui-v2 .display-picker-item {
   padding: 8px 11px;
 }
 html.ui-v2 .display-picker-item:hover { background: rgba(var(--iris-rgb), .1); }
+html.ui-v2 .display-picker-item.dp-action {
+  margin-top: 5px;
+  padding-top: 11px;
+  border-top: 1px solid var(--line);
+  border-radius: 0 0 8px 8px;
+  color: var(--iris-2);
+}
 html.ui-v2 .display-picker-item .dp-primary {
   font-family: var(--mono);
   font-size: 10px;
@@ -1229,38 +1358,80 @@ html.ui-v2 .peer-display-pane .live-annotation-overlay {
 html.ui-v2 .peer-display-pane .live-annotation-source { z-index: 4; background: #000; }
 html.ui-v2 .peer-display-pane .live-annotation-overlay { z-index: 5; }
 
-/* ── right rail (injected, display-only mirror) ── */
+/* ── Computer Use right rail ── */
 html.ui-v2 .ui2-live-rail {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: 284px;
+  position: relative;
+  z-index: 20;
+  min-width: 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: 22px;
-  padding: 20px 18px;
   overflow-y: auto;
+  overscroll-behavior: contain;
   border-left: 1px solid var(--line);
   background: var(--bg-1);
 }
+html.ui-v2 .ui2-live-rail-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px;
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--bg-1) 92%, transparent);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+}
+html.ui-v2 .ui2-live-rail-kicker,
+html.ui-v2 .ui2-live-mobile-kicker {
+  display: block;
+  color: var(--text-3);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .1em;
+  text-transform: uppercase;
+}
+html.ui-v2 .ui2-live-rail-header h2 {
+  margin: 2px 0 0;
+  color: var(--text);
+  font-size: 16px;
+  font-weight: 800;
+  line-height: 1.2;
+}
+html.ui-v2 .ui2-live-rail > section {
+  flex: 0 0 auto;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--line);
+}
+html.ui-v2 .ui2-live-rail > section:last-child { border-bottom: 0; }
 html.ui-v2 .ui2-live-rail-eyebrow {
+  margin: 0 0 10px;
+  color: var(--text-3);
   font-size: 10.5px;
   font-weight: 700;
   letter-spacing: .1em;
   text-transform: uppercase;
-  color: var(--text-3);
-  margin-bottom: 10px;
 }
-html.ui-v2 .ui2-live-rail-list { display: flex; flex-direction: column; gap: 8px; }
-html.ui-v2 .ui2-live-rail-empty { font-size: 11.5px; color: var(--text-3); line-height: 1.5; }
+html.ui-v2 .ui2-live-rail-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+html.ui-v2 .ui2-live-rail-empty {
+  color: var(--text-3);
+  font-size: 11.5px;
+  line-height: 1.5;
+}
 html.ui-v2 .ui2-live-row {
   display: flex;
   align-items: center;
   gap: 10px;
   width: 100%;
-  min-height: 0;
-  padding: 11px 12px;
+  min-height: 50px;
+  padding: 10px 11px;
   border: 1px solid var(--line);
   border-radius: 11px;
   background: var(--surface);
@@ -1268,14 +1439,28 @@ html.ui-v2 .ui2-live-row {
   font-family: var(--sans);
   text-align: left;
   cursor: pointer;
-  transition: border-color var(--t-fast), background var(--t-fast);
+  transition:
+    border-color var(--t-fast),
+    background var(--t-fast),
+    box-shadow var(--t-fast);
 }
-html.ui-v2 .ui2-live-row:hover { border-color: var(--line-2); background: var(--surface-2); }
-html.ui-v2 .ui2-live-row:disabled { opacity: .55; cursor: default; }
-html.ui-v2 .ui2-live-row:disabled:hover { border-color: var(--line); background: var(--surface); }
-html.ui-v2 .ui2-live-row.viewing {
+html.ui-v2 .ui2-live-row:hover {
+  border-color: var(--line-2);
+  background: var(--surface-2);
+}
+html.ui-v2 .ui2-live-row:disabled {
+  opacity: .55;
+  cursor: default;
+}
+html.ui-v2 .ui2-live-row:disabled:hover {
+  border-color: var(--line);
+  background: var(--surface);
+}
+html.ui-v2 .ui2-live-row.viewing,
+html.ui-v2 .ui2-live-row.selected {
   border-color: var(--iris);
   background: rgba(var(--iris-rgb), .08);
+  box-shadow: inset 3px 0 0 var(--iris);
 }
 html.ui-v2 .ui2-live-row-dot {
   width: 7px;
@@ -1299,79 +1484,124 @@ html.ui-v2 .ui2-live-row-main {
   flex-direction: column;
 }
 html.ui-v2 .ui2-live-row-title {
+  overflow: hidden;
+  color: var(--text);
   font-size: 13px;
   font-weight: 700;
-  white-space: nowrap;
-  overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 html.ui-v2 .ui2-live-row-meta {
   margin-top: 2px;
-  font-family: var(--mono);
-  font-size: 10.5px;
-  color: var(--text-3);
-  white-space: nowrap;
   overflow: hidden;
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 10px;
   text-overflow: ellipsis;
+  white-space: nowrap;
+}
+html.ui-v2 .ui2-live-row-tags {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
 }
 html.ui-v2 .ui2-live-row-tag {
-  flex: 0 0 auto;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: .05em;
   color: var(--iris-2);
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: .05em;
 }
-html.ui-v2 .ui2-live-row-chev { flex: 0 0 auto; color: var(--text-3); font-size: 14px; }
+html.ui-v2 .ui2-live-row-privacy { color: var(--green); }
+html.ui-v2 .ui2-live-row-chev {
+  flex: 0 0 auto;
+  color: var(--text-3);
+  font-size: 14px;
+}
 
 html.ui-v2 .ui2-live-card {
+  padding: 14px 15px;
   border: 1px solid var(--line);
   border-radius: var(--r-card);
   background: var(--surface);
-  padding: 14px 15px;
 }
-html.ui-v2 .ui2-live-card-title { font-size: 13.5px; font-weight: 800; color: var(--text); }
+html.ui-v2 .ui2-live-card-title {
+  color: var(--text);
+  font-size: 13.5px;
+  font-weight: 800;
+}
 html.ui-v2 .ui2-live-card-sub {
-  margin-top: 6px;
-  font-size: 11.5px;
-  line-height: 1.55;
+  margin-top: 5px;
   color: var(--text-2);
+  font-size: 11.5px;
+  line-height: 1.5;
+}
+html.ui-v2 .ui2-live-authority-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+}
+html.ui-v2 .ui2-live-authority-copy {
+  flex: 1;
+  min-width: 0;
+}
+html.ui-v2 .ui2-live-authority-dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: var(--neutral-dot);
+  box-shadow: 0 0 0 3px rgba(var(--text-rgb), .06);
+}
+html.ui-v2 .ui2-live-authority-card.state-you .ui2-live-authority-dot {
+  background: var(--green);
+  box-shadow: 0 0 0 3px rgba(var(--green-rgb), .16);
+}
+html.ui-v2 .ui2-live-authority-card.state-other .ui2-live-authority-dot {
+  background: var(--amber);
+  box-shadow: 0 0 0 3px rgba(var(--amber-rgb), .16);
 }
 html.ui-v2 .ui2-live-auth-row {
   display: flex;
   align-items: center;
   gap: 8px;
   margin-top: 11px;
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
 }
 html.ui-v2 .ui2-live-auth-name {
   flex: 1;
   min-width: 0;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text);
-  white-space: nowrap;
   overflow: hidden;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 650;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 html.ui-v2 .ui2-live-state-pill {
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
-  padding: 2px 9px;
-  border-radius: var(--r-pill);
+  padding: 2px 8px;
   border: 1px solid var(--line-2);
+  border-radius: var(--r-pill);
   background: var(--surface-3);
   color: var(--text-2);
-  font-size: 10.5px;
+  font-size: 10px;
   font-weight: 700;
+  white-space: nowrap;
 }
 html.ui-v2 .ui2-live-state-pill.you {
-  background: rgba(var(--green-rgb), .12);
   border-color: rgba(var(--green-rgb), .26);
+  background: rgba(var(--green-rgb), .12);
   color: var(--green);
 }
 html.ui-v2 .ui2-live-state-pill.other {
-  background: rgba(var(--amber-rgb), .14);
   border-color: rgba(var(--amber-rgb), .26);
+  background: rgba(var(--amber-rgb), .14);
   color: var(--amber);
 }
 html.ui-v2 .ui2-live-card-btn {
@@ -1379,45 +1609,261 @@ html.ui-v2 .ui2-live-card-btn {
   align-items: center;
   justify-content: center;
   width: 100%;
-  min-height: 0;
+  min-height: 38px;
   margin-top: 9px;
   padding: 9px;
   border: 0;
   border-radius: var(--r-ctl);
   background: linear-gradient(180deg, var(--iris), var(--iris-deep));
+  box-shadow: 0 6px 16px rgba(var(--iris-rgb), .32);
   color: var(--on-accent);
   font-family: var(--sans);
   font-size: 12.5px;
   font-weight: 800;
-  box-shadow: 0 6px 16px rgba(var(--iris-rgb), .32);
-  transition: filter var(--t-med);
+  transition: filter var(--t-med), background var(--t-fast), border-color var(--t-fast);
 }
 html.ui-v2 .ui2-live-card-btn:hover { filter: brightness(1.08); }
+html.ui-v2 .ui2-live-card-btn:disabled {
+  opacity: .55;
+  cursor: wait;
+  filter: none;
+}
 html.ui-v2 .ui2-live-card-btn.release {
-  background: rgba(var(--amber-rgb), .14);
   border: 1px solid rgba(var(--amber-rgb), .32);
-  color: var(--amber);
+  background: rgba(var(--amber-rgb), .14);
   box-shadow: none;
+  color: var(--amber);
 }
 html.ui-v2 .ui2-live-card-btn.secondary {
-  background: var(--surface-2);
   border: 1px solid var(--line);
+  background: var(--surface-2);
+  box-shadow: none;
   color: var(--text);
-  box-shadow: none;
   font-weight: 700;
 }
-html.ui-v2 .ui2-live-card-btn.secondary:hover { background: var(--surface-3); border-color: var(--line-2); filter: none; }
+html.ui-v2 .ui2-live-card-btn.secondary:hover {
+  border-color: var(--line-2);
+  background: var(--surface-3);
+  filter: none;
+}
 html.ui-v2 .ui2-live-card-btn.danger {
-  background: transparent;
   border: 1px solid rgba(var(--rose-rgb), .4);
-  color: var(--rose);
+  background: transparent;
   box-shadow: none;
+  color: var(--rose);
   font-weight: 700;
 }
-html.ui-v2 .ui2-live-card-btn.danger:hover { background: rgba(var(--rose-rgb), .1); filter: none; }
+html.ui-v2 .ui2-live-card-btn.danger:hover {
+  background: rgba(var(--rose-rgb), .1);
+  filter: none;
+}
+html.ui-v2 .ui2-live-screen-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+html.ui-v2 .ui2-live-screen-head .ui2-live-card-title {
+  flex: 1;
+  min-width: 0;
+}
+html.ui-v2 .ui2-live-screen-actions {
+  display: flex;
+  flex-direction: column;
+}
 
-/* narrow: the rail yields to the stage */
-@media (max-width: 1100px) {
-  html.ui-v2 #tab-displays { padding-right: 0; }
-  html.ui-v2 .ui2-live-rail { display: none; }
+html.ui-v2 .ui2-live-activity {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+html.ui-v2 .ui2-live-activity-row {
+  display: grid;
+  grid-template-columns: 7px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 31px;
+  padding: 5px 2px;
+  border-bottom: 1px solid var(--line);
+}
+html.ui-v2 .ui2-live-activity-row:last-child { border-bottom: 0; }
+html.ui-v2 .ui2-live-activity-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--neutral-dot);
+}
+html.ui-v2 .ui2-live-activity-row.kind-live .ui2-live-activity-dot,
+html.ui-v2 .ui2-live-activity-row.kind-control .ui2-live-activity-dot {
+  background: var(--green);
+}
+html.ui-v2 .ui2-live-activity-row.kind-attention .ui2-live-activity-dot {
+  background: var(--amber);
+}
+html.ui-v2 .ui2-live-activity-row.kind-error .ui2-live-activity-dot,
+html.ui-v2 .ui2-live-activity-row.kind-recording .ui2-live-activity-dot {
+  background: var(--rose);
+}
+html.ui-v2 .ui2-live-activity-row.kind-focus .ui2-live-activity-dot {
+  background: var(--iris);
+}
+html.ui-v2 .ui2-live-activity-row.kind-share .ui2-live-activity-dot {
+  background: var(--sky);
+}
+html.ui-v2 .ui2-live-activity-row.kind-private .ui2-live-activity-dot {
+  background: var(--green);
+}
+html.ui-v2 .ui2-live-activity-text {
+  min-width: 0;
+  color: var(--text-2);
+  font-size: 11px;
+  line-height: 1.35;
+}
+html.ui-v2 .ui2-live-activity-time {
+  color: var(--text-3);
+  font-family: var(--mono);
+  font-size: 9.5px;
+  font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 1279px) {
+  html.ui-v2 #tab-displays.active { display: block; }
+  html.ui-v2 .ui2-live-main { height: 100%; }
+  html.ui-v2 .ui2-live-mobile-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex: 0 0 auto;
+    padding: 9px 14px;
+    border-bottom: 1px solid var(--line);
+    background: var(--bg-1);
+  }
+  html.ui-v2 .ui2-live-mobile-summary {
+    display: block;
+    max-width: 52vw;
+    margin-top: 1px;
+    overflow: hidden;
+    color: var(--text-2);
+    font-size: 11.5px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  html.ui-v2 .ui2-live-rail-toggle {
+    flex: 0 0 auto;
+    min-height: 36px;
+    padding: 7px 12px;
+    border: 1px solid var(--line-2);
+    border-radius: var(--r-ctl);
+    background: var(--surface);
+    color: var(--text);
+    font-family: var(--sans);
+    font-size: 12px;
+    font-weight: 750;
+  }
+  html.ui-v2 .ui2-live-rail {
+    position: absolute;
+    inset: 0 0 0 auto;
+    z-index: 61;
+    width: min(360px, calc(100% - 20px));
+    border-left: 1px solid var(--line-2);
+    box-shadow: var(--shadow-overlay);
+    visibility: hidden;
+    transform: translateX(102%);
+    transition: transform var(--t-slow), visibility 0s linear var(--t-slow);
+  }
+  html.ui-v2 #tab-displays.ui2-live-rail-open .ui2-live-rail {
+    visibility: visible;
+    transform: translateX(0);
+    transition-delay: 0s;
+  }
+  html.ui-v2 .ui2-live-rail-close {
+    display: grid;
+    place-items: center;
+    width: 34px;
+    height: 34px;
+    border: 1px solid var(--line);
+    border-radius: var(--r-ctl);
+    background: var(--surface);
+    color: var(--text-2);
+    font-size: 18px;
+  }
+  html.ui-v2 .ui2-live-rail-close:hover {
+    border-color: rgba(var(--rose-rgb), .4);
+    background: rgba(var(--rose-rgb), .08);
+    color: var(--rose);
+  }
+  html.ui-v2 .ui2-live-rail-scrim {
+    position: absolute;
+    inset: 0;
+    z-index: 60;
+    display: block;
+    padding: 0;
+    border: 0;
+    background: rgba(5, 6, 10, .58);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity var(--t-slow), visibility 0s linear var(--t-slow);
+  }
+  html.ui-v2 #tab-displays.ui2-live-rail-open .ui2-live-rail-scrim {
+    opacity: 1;
+    visibility: visible;
+    transition-delay: 0s;
+  }
+}
+
+@media (max-width: 820px) {
+  html.ui-v2 .display-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 10px 8px;
+  }
+  html.ui-v2 .display-toolbar-meta {
+    flex: 0 0 auto;
+    min-height: 30px;
+  }
+  html.ui-v2 .display-toolbar-actions {
+    width: 100%;
+    margin-left: 0;
+    padding: 1px 0 4px;
+  }
+  html.ui-v2 .display-toolbar-actions .take-control-btn,
+  html.ui-v2 .display-toolbar-actions .release-control-btn {
+    order: -2;
+  }
+  html.ui-v2 .display-toolbar button {
+    min-height: 36px;
+    padding: 7px 11px;
+  }
+  html.ui-v2 .display-toolbar .release-note {
+    flex-basis: 145px;
+    min-height: 36px;
+  }
+  html.ui-v2 .display-canvas { margin: 0 10px 10px; }
+  html.ui-v2 .display-control-banner {
+    top: auto;
+    right: 10px;
+    bottom: 10px;
+    left: 10px;
+    max-width: none;
+    transform: none;
+  }
+  html.ui-v2 .display-live-metrics {
+    max-width: calc(100% - 28px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+@media (max-width: 520px) {
+  html.ui-v2 .ui2-live-rail { width: 100%; }
+  html.ui-v2 .ui2-live-mobile-kicker { display: none; }
+  html.ui-v2 .ui2-live-mobile-summary { max-width: 46vw; }
+  html.ui-v2 .ui2-live-rail > section { padding: 14px; }
+  html.ui-v2 .ui2-live-rail-header { padding: 14px; }
+}
+
+@media (max-height: 680px) {
+  html.ui-v2 .ui2-live-rail-header { padding-top: 12px; padding-bottom: 12px; }
+  html.ui-v2 .ui2-live-rail > section { padding-top: 12px; padding-bottom: 12px; }
 }


### PR DESCRIPTION
## Summary

- make Live a selected-display Computer Use workspace while retaining the existing WebRTC/display lifecycle
- add a semantic rail for displays, input authority, real display activity, peer launches, and the user's screen
- preserve private-view vs agent-share semantics, recording, annotation, callout, shared-view focus, and multi-viewer authority
- add responsive drawer/fullscreen focus containment and wrapped touch-safe controls
- canonicalize shared-view targets so dashboard presentation and capture always use one concrete target
- make recording controls server-confirmed and race-safe
- pin dashboard validator cache-busted asset parity to the Rust source of truth

## Safety / truthfulness

- authority remains server-owned (`you | other | unclaimed | unknown`) and last-take-wins
- hiding or switching an interactive slot flushes held keys and releases bound input first
- pending Take responses cannot leave a hidden surface interactive
- the activity rail only reflects browser-observed lifecycle state; it does not invent agent clicks, typed text, holder identities, or approvals
- media geometry remains border/padding/transform-free and the existing video node is never cloned
- recording UI changes only on daemon confirmation and stale stream events cannot overwrite newer state

## Validation

- `cargo test --bins --locked` — 3,218 tests passed, 9 ignored
- `cargo clippy --bin intendant --locked`
- `cargo test -p app-html-assembler --locked`
- focused shared-view and static-asset parity tests
- `node scripts/validate-dashboard.cjs --self-test`
- `node scripts/validate-dashboard.cjs --check-static-scripts --json`
- `cargo fmt --check` and `git diff --check`
- real synthetic WebRTC desktop, drawer, and mobile acceptance
- server-confirmed Start/Stop recording cycle
- late-Take/navigation race acceptance
