### PR TITLE
Tab presence: api_dashboard_tabs + Access-pane Open dashboards card

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -802,6 +802,23 @@ hints. The browser may refine the local route label to **Intendant Connect**,
 current page was reached, but it should not invent principal/grant/policy
 vocabulary.
 
+`GET /api/dashboard/tabs` / `api_dashboard_tabs` (`access.inspect`) is the
+**tab-presence** surface: every live dashboard connection on either event lane
+(the `/ws` WebSocket or a dashboard-control tunnel session), each entry
+carrying its lane, grant provenance (`local` / `client` / `peer`), grant
+label, remote host, user agent, connect time, and whether it currently holds
+the voice presence or display input authority (with display ids). Browser
+tabs group by a client-declared per-tab id: the SPA mints a random id in
+`sessionStorage` and sends it as `?tab=` on the `/ws` URL and `tab_id` in
+control-tunnel offers. The id is sanitized, display-only, and grants nothing;
+server-internal connection ids never appear in the payload (the same rule the
+input-authority wire follows). The Access **Overview** renders this as the
+**Open dashboards** card — "N tabs connected · this tab · holds voice /
+display input" — refreshed on pane entry and every 15 s while the pane is
+visible; peer-daemon control connections are counted separately from tabs.
+Hosted Connect offers relayed through the rendezvous don't carry the tab id
+yet (the relay envelope drops unknown fields), so those sessions list untagged.
+
 ### Debug
 
 Observer display and browser workspaces (daemon diagnostics and raw event
@@ -2097,6 +2114,7 @@ its operation per method/path from `federation_http_operation`.
 | POST | `/api/access/hosted-ceiling` | AccessManage | fleet allowlist | bounded | Set the hosted-control ceiling role for hosted-provenance sessions |
 | POST | `/api/access/fleet-cert/request` | AccessManage | fleet allowlist | bounded | Request a fleet certificate (publish addresses, run the ACME DNS-01 order; async start) |
 | GET | `/api/dashboard/targets` | AccessInspect | own origin | none | Dashboard target list (this daemon + connected peers) |
+| GET | `/api/dashboard/tabs` | AccessInspect | own origin | none | Live dashboard connections (open tabs) with voice/input-authority holders |
 | POST | `/api/peers/pairing/invite` | federation (per method/path) | own origin | bounded | Issue a peer-scoped mTLS pairing invite |
 | POST | `/api/peers/pairing/request-access` | federation (per method/path) | own origin | bounded | Start an outgoing access request against a remote daemon's doorbell |
 | POST | `/api/peers/pairing/request-access/poll` | federation (per method/path) | own origin | bounded | Poll an outgoing access request (installs the approved identity) |

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -662,6 +662,11 @@ pub(crate) fn control_frame_response(
                     ),
                     "dashboard targets",
                 )),
+                "api_dashboard_tabs" => Some(frame_api_ok_error_response(
+                    id,
+                    crate::web_gateway::dashboard_tabs_api_response(&runtime.tabs),
+                    "dashboard tabs",
+                )),
                 "api_access_overview" => {
                     let current_principal = runtime.grant.access_principal();
                     let cert_dir = crate::access::backend::select_backend().cert_dir();

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -435,6 +435,7 @@ pub struct DashboardControlRegistry {
     presence: Option<DashboardPresenceBridge>,
     ice_config: crate::display::IceConfig,
     tcp_peer_registry: Arc<crate::display::webrtc::TcpPeerRegistry>,
+    tabs: crate::web_gateway::DashboardTabsRegistry,
     identity: Mutex<Option<Arc<DaemonIdentity>>>,
     peers: Mutex<HashMap<String, DashboardControlPeer>>,
 }
@@ -481,12 +482,23 @@ pub struct PeerAttribution {
 }
 
 impl DashboardControlGrant {
-    fn label(&self) -> &str {
+    pub(crate) fn label(&self) -> &str {
         match self {
             Self::TrustedLocal => "trusted-local",
             Self::UserClientRoot { principal } => principal.label.as_str(),
             Self::UserClient { principal, .. } => principal.label.as_str(),
             Self::Peer { label, .. } => label.as_str(),
+        }
+    }
+
+    /// Coarse provenance bucket for the tabs-presence surface: the
+    /// owner's own dashboard, an enrolled client key, or a federated
+    /// peer / delegation-lane connection.
+    pub(crate) fn connection_kind(&self) -> &'static str {
+        match self {
+            Self::TrustedLocal => "local",
+            Self::UserClientRoot { .. } | Self::UserClient { .. } => "client",
+            Self::Peer { .. } => "peer",
         }
     }
 
@@ -792,6 +804,7 @@ impl DashboardControlRegistry {
         presence: Option<DashboardPresenceBridge>,
         ice_config: crate::display::IceConfig,
         tcp_peer_registry: Arc<crate::display::webrtc::TcpPeerRegistry>,
+        tabs: crate::web_gateway::DashboardTabsRegistry,
     ) -> Self {
         Self {
             config,
@@ -810,9 +823,23 @@ impl DashboardControlRegistry {
             presence,
             ice_config,
             tcp_peer_registry,
+            tabs,
             identity: Mutex::new(None),
             peers: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// The live tabs-presence registry (shared with the `/ws` lane); the
+    /// HTTP `GET /api/dashboard/tabs` handler reads it through here.
+    pub(crate) fn tabs(&self) -> &crate::web_gateway::DashboardTabsRegistry {
+        &self.tabs
+    }
+
+    /// Annotate a control session with the client-declared tab id from
+    /// its offer body (the offer paths learn the id after `answer_offer`
+    /// has registered the session).
+    pub(crate) fn note_tab_id(&self, session_id: &str, tab_id: &str) {
+        self.tabs.note_tab_id(session_id, tab_id);
     }
 
     #[allow(dead_code)]
@@ -878,6 +905,18 @@ impl DashboardControlRegistry {
         tcp_advertised_addr: Option<SocketAddr>,
     ) -> Result<DashboardControlAnswer, String> {
         let identity = self.identity().await?;
+        // Captured before `grant` moves into the session task; the tab id
+        // (when the offer carried one) is annotated post-answer via
+        // `note_tab_id`.
+        let tab_entry = crate::web_gateway::DashboardTabConnection {
+            lane: crate::web_gateway::DashboardTabLane::ControlTunnel,
+            kind: grant.connection_kind(),
+            label: grant.label().to_string(),
+            tab_id: None,
+            remote: None,
+            user_agent: None,
+            connected_at_unix_ms: crate::web_gateway::now_unix_ms(),
+        };
         let (peer, answer_sdp, binding) = DashboardControlPeer::answer_offer(
             session_id.clone(),
             offer_sdp,
@@ -902,10 +941,12 @@ impl DashboardControlRegistry {
             tcp_advertised_addr,
             identity,
             grant,
+            self.tabs.clone(),
         )
         .await
         .map_err(|e| e.to_string())?;
         self.peers.lock().await.insert(session_id.clone(), peer);
+        self.tabs.register(&session_id, tab_entry);
         Ok(DashboardControlAnswer {
             session_id,
             sdp: answer_sdp,
@@ -927,6 +968,7 @@ impl DashboardControlRegistry {
     }
 
     pub async fn close(&self, session_id: &str) {
+        self.tabs.unregister(session_id);
         if let Some(bridge) = &self.display_authority {
             bridge.cleanup(session_id);
         }
@@ -1065,6 +1107,7 @@ impl DashboardControlPeer {
         tcp_advertised_addr: Option<SocketAddr>,
         identity: Arc<DaemonIdentity>,
         grant: DashboardControlGrant,
+        tabs: crate::web_gateway::DashboardTabsRegistry,
     ) -> Result<(Self, String, DashboardControlBinding), CallerError> {
         let local_ufrag = new_control_ice_fragment();
         let local_pwd = new_control_ice_password();
@@ -1177,6 +1220,7 @@ impl DashboardControlPeer {
             control_frames_tx: None,
             display_peer_id: NEXT_DASHBOARD_DISPLAY_PEER_ID.fetch_add(1, Ordering::Relaxed),
             grant,
+            tabs,
             state_root: crate::platform::intendant_home(),
         };
         let (command_tx, command_rx) = mpsc::channel(COMMAND_CHANNEL);
@@ -1263,6 +1307,9 @@ pub(crate) struct ControlRuntime {
     control_frames_tx: Option<mpsc::UnboundedSender<serde_json::Value>>,
     display_peer_id: crate::display::PeerId,
     grant: DashboardControlGrant,
+    /// The live tabs-presence registry (shared with the `/ws` lane) —
+    /// serves the `api_dashboard_tabs` twin.
+    tabs: crate::web_gateway::DashboardTabsRegistry,
     /// The daemon state root (`intendant_home()`), resolved once at the
     /// control-channel edge. Adapters that fall back to the daemon-global
     /// store (uploads, transfers) resolve their scope against this instead
@@ -2347,6 +2394,10 @@ mod tests {
             control_frames_tx: None,
             display_peer_id: 1,
             grant: DashboardControlGrant::TrustedLocal,
+            tabs: crate::web_gateway::DashboardTabsRegistry::new(
+                Arc::new(std::sync::Mutex::new(None)),
+                Arc::new(std::sync::RwLock::new(HashMap::new())),
+            ),
             // Per-instance scratch (never the machine's real ~/.intendant):
             // projectless adapters resolve the daemon-global store under
             // this root. PID+nanos, per the state_paths uniqueness rule.
@@ -3075,6 +3126,7 @@ mod tests {
                 Some(Op::AccessInspect),
             ),
             ("api_dashboard_targets", Row, Some(Op::AccessInspect)),
+            ("api_dashboard_tabs", Row, Some(Op::AccessInspect)),
             ("api_access_connect_status", Row, Some(Op::AccessInspect)),
             ("api_access_connect_claim_code", Row, Some(Op::AccessManage)),
             ("api_access_connect_config", Row, Some(Op::AccessManage)),
@@ -3574,6 +3626,7 @@ mod tests {
             "api_access_set_hosted_ceiling",
             "api_fleet_cert_request",
             "api_dashboard_targets",
+            "api_dashboard_tabs",
             "api_access_org_trust",
             "api_access_org_revoke",
             "api_access_org_issue",

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -284,6 +284,9 @@ pub(crate) enum RouteHandlerId {
     /// connect status payload).
     AccessFleetCertRequest,
     DashboardTargets,
+    /// Live dashboard connections (tab presence): the tabs registry
+    /// snapshot with voice/input-authority ownership joined in.
+    DashboardTabs,
     /// The whole /api/peers registry + pairing sub-router, moved
     /// verbatim (its internal shapes stay as they were; leaf-shape
     /// declarations are a deliberate follow-up, not part of the
@@ -1509,6 +1512,15 @@ pub(crate) static ROUTES: &[Route] = &[
         "Dashboard target list (this daemon + connected peers)",
     )
     .with_tunnel(tunnel_method("api_dashboard_targets")),
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Exact("/api/dashboard/tabs"),
+        PeerOperation::AccessInspect,
+        BodyPolicy::None,
+        RouteHandlerId::DashboardTabs,
+        "Live dashboard connections (open tabs) with voice/input-authority holders",
+    )
+    .with_tunnel(tunnel_method("api_dashboard_tabs")),
     // ── Federation surface: registry, pairing, quick controls,
     //    capability routing. Carved per-leaf rows (S7) declare each
     //    leaf's datachannel twin — the twin's IAM operation derives from

--- a/src/bin/caller/web_gateway/connect_bootstrap.rs
+++ b/src/bin/caller/web_gateway/connect_bootstrap.rs
@@ -106,6 +106,11 @@ pub(crate) async fn connect_dashboard_offer_response(
         .await
     {
         Ok(answer) => {
+            // Tab presence: annotate the session with the offer's
+            // client-declared tab id, when sent.
+            if let Some(tab) = body.get("tab_id").and_then(|v| v.as_str()) {
+                dashboard_control.note_tab_id(&answer.session_id, tab);
+            }
             let mut response = serde_json::json!({
                 "ok": true,
                 "signaling": "connect-bootstrap-local",

--- a/src/bin/caller/web_gateway/dashboard_tabs.rs
+++ b/src/bin/caller/web_gateway/dashboard_tabs.rs
@@ -246,7 +246,10 @@ mod tests {
     #[test]
     fn register_snapshot_unregister_roundtrip() {
         let reg = empty_registry();
-        reg.register("ws-1", conn(DashboardTabLane::LegacyWs, "trusted-local", 10));
+        reg.register(
+            "ws-1",
+            conn(DashboardTabLane::LegacyWs, "trusted-local", 10),
+        );
         reg.register(
             "sess-1",
             conn(DashboardTabLane::ControlTunnel, "trusted-local", 20),

--- a/src/bin/caller/web_gateway/dashboard_tabs.rs
+++ b/src/bin/caller/web_gateway/dashboard_tabs.rs
@@ -1,0 +1,357 @@
+//! Live dashboard-connection registry: which dashboard tabs (and peer
+//! daemons) hold a connection to this daemon right now, over which
+//! transport lane, and which of them currently hold the voice presence
+//! or display input authority.
+//!
+//! Both event lanes register here at their existing lifecycle seams —
+//! the `/ws` accept path in `listener.rs` and the dashboard-control
+//! registry's `answer_offer`/`close` pair — keyed by the same ids the
+//! presence slot (`ActivePresence.connection_id`) and the input
+//! authority map (`DisplayInputHolder`) already carry, so the snapshot
+//! joins voice/input ownership at query time instead of mirroring it.
+//!
+//! Tab identity is client-declared: the SPA mints a per-tab id in
+//! `sessionStorage` and sends it on both lanes (`?tab=` on the WS URL,
+//! `tab_id` in the control-tunnel offer), so one browser tab holding
+//! both lanes groups into one entry client-side. The id is opaque,
+//! sanitized on ingest, and grants nothing — it exists purely so the
+//! Access pane can say "this tab" and count distinct tabs.
+//!
+//! Deliberately NOT in the wire payload: the server-internal connection
+//! / control-session ids. The input-authority design keeps holder ids
+//! off the browser wire (personalized `you|other|unclaimed` instead) —
+//! this surface follows that decision and identifies entries by their
+//! client-declared tab id, label, and lane only.
+
+use super::*;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DashboardTabLane {
+    /// The legacy `/ws` WebSocket event lane.
+    LegacyWs,
+    /// A dashboard-control (WebRTC datachannel) session.
+    ControlTunnel,
+}
+
+impl DashboardTabLane {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::LegacyWs => "ws",
+            Self::ControlTunnel => "tunnel",
+        }
+    }
+}
+
+/// One live connection, as registered by its transport edge.
+#[derive(Clone, Debug)]
+pub(crate) struct DashboardTabConnection {
+    pub(crate) lane: DashboardTabLane,
+    /// Coarse provenance from the connection's `DashboardControlGrant`:
+    /// `"local"` (owner surface), `"client"` (enrolled browser key), or
+    /// `"peer"` (federated daemon / delegation lane).
+    pub(crate) kind: &'static str,
+    /// The grant label (principal label / peer label / "trusted-local").
+    pub(crate) label: String,
+    /// Client-declared per-tab id (sanitized); `None` when the client
+    /// didn't send one (pre-stamp SPA builds, peer daemons, hosted
+    /// Connect relays).
+    pub(crate) tab_id: Option<String>,
+    /// Remote host as observed by the transport, when known.
+    pub(crate) remote: Option<String>,
+    /// The connection's User-Agent header, when the lane carries one.
+    pub(crate) user_agent: Option<String>,
+    pub(crate) connected_at_unix_ms: u64,
+}
+
+/// Client-declared strings cross a trust boundary: cap and constrain
+/// them on ingest so the Access pane never renders unbounded or
+/// control-character junk. Tab ids are machine-matched (the SPA mints
+/// UUIDs), so the charset is strict; user agents are display-only, so
+/// they keep printable ASCII up to a cap.
+fn sanitize_tab_id(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    let ok = (8..=64).contains(&trimmed.len())
+        && trimmed
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_');
+    ok.then(|| trimmed.to_string())
+}
+
+fn sanitize_user_agent(raw: &str) -> Option<String> {
+    let cleaned: String = raw
+        .trim()
+        .chars()
+        .filter(|c| c.is_ascii_graphic() || *c == ' ')
+        .take(200)
+        .collect();
+    (!cleaned.is_empty()).then_some(cleaned)
+}
+
+pub(crate) fn now_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// The registry: live connections keyed by the transport's internal id
+/// (the `/ws` `connection_id` or the dashboard-control `session_id` —
+/// the same ids the presence slot and authority map hold), plus the two
+/// shared-state handles the snapshot joins against.
+#[derive(Clone)]
+pub(crate) struct DashboardTabsRegistry {
+    inner: Arc<Mutex<HashMap<String, DashboardTabConnection>>>,
+    active_presence: Arc<Mutex<Option<ActivePresence>>>,
+    display_input_authority: Arc<StdRwLock<HashMap<u32, DisplayInputHolder>>>,
+}
+
+impl DashboardTabsRegistry {
+    pub(crate) fn new(
+        active_presence: Arc<Mutex<Option<ActivePresence>>>,
+        display_input_authority: Arc<StdRwLock<HashMap<u32, DisplayInputHolder>>>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+            active_presence,
+            display_input_authority,
+        }
+    }
+
+    pub(crate) fn register(&self, id: &str, mut conn: DashboardTabConnection) {
+        conn.tab_id = conn.tab_id.as_deref().and_then(sanitize_tab_id);
+        conn.user_agent = conn.user_agent.as_deref().and_then(sanitize_user_agent);
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(id.to_string(), conn);
+    }
+
+    /// Annotate an already-registered connection with its client-declared
+    /// tab id (the control-tunnel offer paths learn the id after the
+    /// session is registered). No-op for unknown ids or junk values.
+    pub(crate) fn note_tab_id(&self, id: &str, tab_id: &str) {
+        let Some(clean) = sanitize_tab_id(tab_id) else {
+            return;
+        };
+        if let Some(conn) = self
+            .inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get_mut(id)
+        {
+            conn.tab_id = Some(clean);
+        }
+    }
+
+    pub(crate) fn unregister(&self, id: &str) {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(id);
+    }
+
+    /// The wire payload: every live connection with voice/input
+    /// ownership joined in, ordered oldest-first (deterministic
+    /// label/tab tiebreak). Internal connection ids stay internal.
+    pub(crate) fn snapshot(&self) -> serde_json::Value {
+        let voice_holder: Option<String> = self
+            .active_presence
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .as_ref()
+            .map(|active| active.connection_id.clone());
+        let mut input_by_holder: HashMap<String, Vec<u32>> = HashMap::new();
+        {
+            let map = self
+                .display_input_authority
+                .read()
+                .unwrap_or_else(|e| e.into_inner());
+            for (display_id, holder) in map.iter() {
+                let key = match holder {
+                    DisplayInputHolder::LocalWs { connection_id, .. } => connection_id.clone(),
+                    DisplayInputHolder::DashboardControl { session_id } => session_id.clone(),
+                    // Federated holders belong to peer-daemon display
+                    // sessions, not to a connection this registry tracks.
+                    DisplayInputHolder::FederatedWebRtc { .. } => continue,
+                };
+                input_by_holder.entry(key).or_default().push(*display_id);
+            }
+        }
+
+        let mut rows: Vec<(u64, String, serde_json::Value)> = {
+            let inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+            inner
+                .iter()
+                .map(|(id, conn)| {
+                    let mut input_display_ids =
+                        input_by_holder.get(id).cloned().unwrap_or_default();
+                    input_display_ids.sort_unstable();
+                    let tiebreak = format!(
+                        "{}|{}|{}",
+                        conn.label,
+                        conn.tab_id.as_deref().unwrap_or(""),
+                        conn.lane.as_str()
+                    );
+                    let row = serde_json::json!({
+                        "lane": conn.lane.as_str(),
+                        "kind": conn.kind,
+                        "label": conn.label,
+                        "tab_id": conn.tab_id,
+                        "remote": conn.remote,
+                        "user_agent": conn.user_agent,
+                        "connected_at_unix_ms": conn.connected_at_unix_ms,
+                        "voice_active": voice_holder.as_deref() == Some(id.as_str()),
+                        "input_display_ids": input_display_ids,
+                    });
+                    (conn.connected_at_unix_ms, tiebreak, row)
+                })
+                .collect()
+        };
+        rows.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+        serde_json::json!({
+            "connections": rows.into_iter().map(|(_, _, row)| row).collect::<Vec<_>>(),
+        })
+    }
+}
+
+/// S6 neutral core for `GET /api/dashboard/tabs` and its
+/// `api_dashboard_tabs` tunnel twin.
+pub(crate) fn dashboard_tabs_api_response(tabs: &DashboardTabsRegistry) -> ApiResponse {
+    ApiResponse::json(200, JsonBody::Value(tabs.snapshot()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_registry() -> DashboardTabsRegistry {
+        DashboardTabsRegistry::new(
+            Arc::new(Mutex::new(None)),
+            Arc::new(StdRwLock::new(HashMap::new())),
+        )
+    }
+
+    fn conn(lane: DashboardTabLane, label: &str, at: u64) -> DashboardTabConnection {
+        DashboardTabConnection {
+            lane,
+            kind: "local",
+            label: label.to_string(),
+            tab_id: None,
+            remote: None,
+            user_agent: None,
+            connected_at_unix_ms: at,
+        }
+    }
+
+    #[test]
+    fn register_snapshot_unregister_roundtrip() {
+        let reg = empty_registry();
+        reg.register("ws-1", conn(DashboardTabLane::LegacyWs, "trusted-local", 10));
+        reg.register(
+            "sess-1",
+            conn(DashboardTabLane::ControlTunnel, "trusted-local", 20),
+        );
+        let snap = reg.snapshot();
+        let rows = snap["connections"].as_array().unwrap();
+        assert_eq!(rows.len(), 2);
+        // Oldest first; internal ids never appear anywhere in the payload.
+        assert_eq!(rows[0]["lane"], "ws");
+        assert_eq!(rows[1]["lane"], "tunnel");
+        assert!(!snap.to_string().contains("ws-1"));
+        assert!(!snap.to_string().contains("sess-1"));
+
+        reg.unregister("ws-1");
+        let snap = reg.snapshot();
+        assert_eq!(snap["connections"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn tab_id_and_user_agent_are_sanitized_on_ingest() {
+        let reg = empty_registry();
+        let mut c = conn(DashboardTabLane::LegacyWs, "trusted-local", 1);
+        c.tab_id = Some("  bad id with spaces  ".to_string());
+        c.user_agent = Some(format!("Safari\u{7}/605 {}", "x".repeat(400)));
+        reg.register("ws-1", c);
+        let snap = reg.snapshot();
+        let row = &snap["connections"][0];
+        assert!(row["tab_id"].is_null());
+        let ua = row["user_agent"].as_str().unwrap();
+        assert!(ua.len() <= 200);
+        assert!(!ua.contains('\u{7}'));
+        assert!(ua.starts_with("Safari/605"));
+    }
+
+    #[test]
+    fn note_tab_id_annotates_only_valid_ids_on_known_connections() {
+        let reg = empty_registry();
+        reg.register("sess-1", conn(DashboardTabLane::ControlTunnel, "l", 1));
+        reg.note_tab_id("sess-1", "not valid!");
+        assert!(reg.snapshot()["connections"][0]["tab_id"].is_null());
+        reg.note_tab_id("sess-1", "0d9a4c2e-11ab-4c1d-9e2f-aa55bb66cc77");
+        assert_eq!(
+            reg.snapshot()["connections"][0]["tab_id"],
+            "0d9a4c2e-11ab-4c1d-9e2f-aa55bb66cc77"
+        );
+        // Unknown connection: silently ignored.
+        reg.note_tab_id("sess-2", "0d9a4c2e-11ab-4c1d-9e2f-aa55bb66cc77");
+        assert_eq!(reg.snapshot()["connections"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn snapshot_joins_voice_and_input_authority_by_internal_id() {
+        let active = Arc::new(Mutex::new(None));
+        let authority: Arc<StdRwLock<HashMap<u32, DisplayInputHolder>>> =
+            Arc::new(StdRwLock::new(HashMap::new()));
+        let reg = DashboardTabsRegistry::new(active.clone(), authority.clone());
+        reg.register("ws-1", conn(DashboardTabLane::LegacyWs, "a", 1));
+        reg.register("sess-1", conn(DashboardTabLane::ControlTunnel, "b", 2));
+
+        let (tx, _rx) = mpsc::unbounded_channel::<String>();
+        *active.lock().unwrap() = Some(ActivePresence {
+            connection_id: "ws-1".to_string(),
+            direct_tx: tx.clone(),
+        });
+        {
+            let mut map = authority.write().unwrap();
+            map.insert(
+                7,
+                DisplayInputHolder::DashboardControl {
+                    session_id: "sess-1".to_string(),
+                },
+            );
+            map.insert(
+                3,
+                DisplayInputHolder::DashboardControl {
+                    session_id: "sess-1".to_string(),
+                },
+            );
+            // A federated holder joins no registry entry and is skipped.
+            map.insert(
+                9,
+                DisplayInputHolder::FederatedWebRtc {
+                    federation_connection_id: "f-1".to_string(),
+                    session_id: "fs-1".to_string(),
+                },
+            );
+        }
+
+        let snap = reg.snapshot();
+        let rows = snap["connections"].as_array().unwrap();
+        assert_eq!(rows[0]["voice_active"], true);
+        assert_eq!(rows[0]["input_display_ids"].as_array().unwrap().len(), 0);
+        assert_eq!(rows[1]["voice_active"], false);
+        assert_eq!(
+            rows[1]["input_display_ids"],
+            serde_json::json!([3u32, 7u32])
+        );
+    }
+
+    #[test]
+    fn api_response_is_the_neutral_ok_envelope() {
+        let reg = empty_registry();
+        match dashboard_tabs_api_response(&reg) {
+            ApiResponse::Json { status, .. } => assert_eq!(status, 200),
+            _ => panic!("unexpected response shape"),
+        }
+    }
+}

--- a/src/bin/caller/web_gateway/http.rs
+++ b/src/bin/caller/web_gateway/http.rs
@@ -951,16 +951,41 @@ pub(crate) fn status_reason(status: u16) -> &'static str {
 /// `"GET /ws?token=abc HTTP/1.1"`. Returns the extracted token if
 /// present, `None` if there's no `?token=` parameter.
 pub(crate) fn extract_token_query_param(request_line: &str) -> Option<String> {
+    // No URL-decoding: bearer tokens are typically URL-safe
+    // (hex / base64-url). If a token contains characters that
+    // require encoding, the operator can either pick a
+    // different token or send via Authorization header (which
+    // doesn't have the URL-encoding constraint).
+    extract_query_param(request_line, "token")
+}
+
+/// Extract a named query parameter from an HTTP request line (same
+/// no-URL-decoding contract as the token extractor above — callers pass
+/// URL-safe values).
+pub(crate) fn extract_query_param(request_line: &str, name: &str) -> Option<String> {
     let path_and_query = request_line.split_whitespace().nth(1)?;
     let query = path_and_query.split_once('?')?.1;
     for pair in query.split('&') {
-        if let Some(value) = pair.strip_prefix("token=") {
-            // No URL-decoding: bearer tokens are typically URL-safe
-            // (hex / base64-url). If a token contains characters that
-            // require encoding, the operator can either pick a
-            // different token or send via Authorization header (which
-            // doesn't have the URL-encoding constraint).
+        if let Some(value) = pair
+            .strip_prefix(name)
+            .and_then(|rest| rest.strip_prefix('='))
+        {
             return Some(value.to_string());
+        }
+    }
+    None
+}
+
+/// Case-insensitive lookup of one header's value in a raw HTTP header
+/// block (request line + `Name: value` lines).
+pub(crate) fn extract_header_value(header_text: &str, name: &str) -> Option<String> {
+    for line in header_text.lines().skip(1) {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        if key.trim().eq_ignore_ascii_case(name) {
+            let value = value.trim();
+            return (!value.is_empty()).then(|| value.to_string());
         }
     }
     None

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -1114,6 +1114,13 @@ pub(crate) async fn serve_http_request(
                 )
                 .await;
             }
+            RouteHandlerId::DashboardTabs => {
+                let response =
+                    crate::web_gateway::dashboard_tabs_api_response(dashboard_control.tabs());
+                write_api_response(stream, response, route.cors, fleet_cors_origin.as_deref())
+                    .await;
+                return;
+            }
             RouteHandlerId::PeersSubRouter => {
                 return handle_peers_sub_router(
                     stream,

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -290,6 +290,15 @@ pub fn spawn_web_gateway(
     let display_input_authority: Arc<StdRwLock<HashMap<u32, DisplayInputHolder>>> =
         Arc::new(StdRwLock::new(HashMap::new()));
 
+    // Tab presence (Access pane): live connections on both event lanes,
+    // with voice/input ownership joined from the two handles above at
+    // query time. The /ws lane registers below at accept; the control
+    // tunnel registers inside DashboardControlRegistry's answer/close.
+    let dashboard_tabs = DashboardTabsRegistry::new(
+        active_presence.clone(),
+        display_input_authority.clone(),
+    );
+
     // Phase 5a.1 authority transition channel.  Each per-connection
     // outbound task subscribes; emit sites are the Request/Release
     // ControlMsg handlers, the WS-close cleanup, and the DisplayReady
@@ -487,6 +496,7 @@ pub fn spawn_web_gateway(
         Some(dashboard_presence),
         ice_config.clone(),
         Arc::clone(&tcp_peer_registry),
+        dashboard_tabs.clone(),
     ));
     crate::connect_rendezvous::spawn_connect_rendezvous_client(
         config.connect.clone(),
@@ -777,6 +787,7 @@ pub fn spawn_web_gateway(
             let transcriber = transcriber.clone();
             let active_presence = active_presence.clone();
             let display_input_authority = display_input_authority.clone();
+            let dashboard_tabs = dashboard_tabs.clone();
             let authority_change_tx = authority_change_tx.clone();
             let federated_authority_subscribers = federated_authority_subscribers.clone();
             let last_usage_json = last_usage_json.clone();
@@ -1291,6 +1302,26 @@ pub fn spawn_web_gateway(
                     // Per-connection identity for active/passive tracking
                     let connection_id = uuid::Uuid::new_v4().to_string();
 
+                    // Tab presence: register this event-lane connection.
+                    // The tab id is client-declared (`?tab=` beside the
+                    // token — browsers can't set headers on WebSocket
+                    // opens); ws_inbound_task unregisters on close.
+                    dashboard_tabs.register(
+                        &connection_id,
+                        DashboardTabConnection {
+                            lane: DashboardTabLane::LegacyWs,
+                            kind: dashboard_control_grant_for_ws.connection_kind(),
+                            label: dashboard_control_grant_for_ws.label().to_string(),
+                            tab_id: extract_query_param(
+                                header_text.lines().next().unwrap_or(""),
+                                "tab",
+                            ),
+                            remote: browser_host_ip.map(|ip| ip.to_string()),
+                            user_agent: extract_header_value(&header_text, "user-agent"),
+                            connected_at_unix_ms: now_unix_ms(),
+                        },
+                    );
+
                     // Direct response channel: tool_response and state_snapshot
                     // messages for this specific connection (not broadcast).
                     let (direct_tx, direct_rx) = mpsc::unbounded_channel::<String>();
@@ -1666,6 +1697,7 @@ pub fn spawn_web_gateway(
                         authority_change_tx: authority_change_tx.clone(),
                         federated_authority_subscribers: federated_authority_subscribers.clone(),
                         connection_id: connection_id.clone(),
+                        dashboard_tabs: dashboard_tabs.clone(),
                         frame_registry: frame_registry.clone(),
                         recording_registry: recording_registry.clone(),
                         session_log: session_log.clone(),

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -294,10 +294,8 @@ pub fn spawn_web_gateway(
     // with voice/input ownership joined from the two handles above at
     // query time. The /ws lane registers below at accept; the control
     // tunnel registers inside DashboardControlRegistry's answer/close.
-    let dashboard_tabs = DashboardTabsRegistry::new(
-        active_presence.clone(),
-        display_input_authority.clone(),
-    );
+    let dashboard_tabs =
+        DashboardTabsRegistry::new(active_presence.clone(), display_input_authority.clone());
 
     // Phase 5a.1 authority transition channel.  Each per-connection
     // outbound task subscribes; emit sites are the Request/Release

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -62,6 +62,8 @@ mod dashboard_presence;
 pub(crate) use dashboard_presence::*;
 mod input_authority;
 pub(crate) use input_authority::*;
+mod dashboard_tabs;
+pub(crate) use dashboard_tabs::*;
 mod connect_bootstrap;
 pub(crate) use connect_bootstrap::*;
 mod settings;

--- a/src/bin/caller/web_gateway/ws_session.rs
+++ b/src/bin/caller/web_gateway/ws_session.rs
@@ -1445,8 +1445,7 @@ pub(crate) async fn ws_inbound_task(
                                 // Tab presence: annotate the session with the
                                 // offer's client-declared tab id, when sent.
                                 if let Some(tab) = json["tab_id"].as_str() {
-                                    dashboard_control_inbound
-                                        .note_tab_id(&answer.session_id, tab);
+                                    dashboard_control_inbound.note_tab_id(&answer.session_id, tab);
                                 }
                                 let msg = serde_json::json!({
                                     "t": "dashboard_control_answer",

--- a/src/bin/caller/web_gateway/ws_session.rs
+++ b/src/bin/caller/web_gateway/ws_session.rs
@@ -263,6 +263,7 @@ pub(crate) struct WsInboundCtx {
     pub(crate) authority_change_tx: broadcast::Sender<DisplayInputAuthorityChange>,
     pub(crate) federated_authority_subscribers: FederatedAuthoritySubscribers,
     pub(crate) connection_id: String,
+    pub(crate) dashboard_tabs: DashboardTabsRegistry,
     pub(crate) frame_registry: Option<Arc<tokio::sync::RwLock<crate::frames::FrameRegistry>>>,
     pub(crate) recording_registry:
         Option<Arc<tokio::sync::RwLock<crate::recording::RecordingRegistry>>>,
@@ -305,6 +306,7 @@ pub(crate) async fn ws_inbound_task(
         authority_change_tx: authority_change_tx_inbound,
         federated_authority_subscribers: federated_authority_subscribers_inbound,
         connection_id: connection_id_inbound,
+        dashboard_tabs: dashboard_tabs_inbound,
         frame_registry: frame_registry_inbound,
         recording_registry: recording_registry_inbound,
         session_log: session_log_inbound,
@@ -1440,6 +1442,12 @@ pub(crate) async fn ws_inbound_task(
                         {
                             Ok(answer) => {
                                 dashboard_control_session_ids.push(answer.session_id.clone());
+                                // Tab presence: annotate the session with the
+                                // offer's client-declared tab id, when sent.
+                                if let Some(tab) = json["tab_id"].as_str() {
+                                    dashboard_control_inbound
+                                        .note_tab_id(&answer.session_id, tab);
+                                }
                                 let msg = serde_json::json!({
                                     "t": "dashboard_control_answer",
                                     "session_id": answer.session_id,
@@ -2087,4 +2095,6 @@ pub(crate) async fn ws_inbound_task(
     for session_id in dashboard_control_session_ids {
         dashboard_control_inbound.close(&session_id).await;
     }
+    // Tab presence: this event-lane connection is gone.
+    dashboard_tabs_inbound.unregister(&connection_id_inbound);
 }

--- a/static/app.html
+++ b/static/app.html
@@ -23353,6 +23353,7 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
             <div id="access-identity-hero" class="acc-hero-grid"></div>
             <div id="access-tier-card"></div>
             <div id="access-connect-card"></div>
+            <div id="access-tabs-card"></div>
             <div class="acc-section-head">
               <div class="acc-section-title">Fleet</div>
               <div class="acc-section-sub">Every daemon you can reach from here. Each one still decides locally what you may do.</div>
@@ -26169,7 +26170,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '1069e3a0dd20e6b2';
+const INTENDANT_APP_BUILD = 'eb4d9541ca580e78';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -26204,12 +26205,36 @@ function maybeNudgeStaleBuild(serverBuild) {
   });
 }
 
+// ── Per-tab identity ──
+//
+// A random id minted once per browser tab (sessionStorage is per-tab and
+// survives reloads). Sent on both event lanes — `?tab=` on the /ws URL
+// and `tab_id` in control-tunnel offers — so the daemon's tab-presence
+// surface (`api_dashboard_tabs`, Access pane) can group one tab's
+// connections and this tab can recognize itself in the list. Opaque and
+// authority-free: the daemon sanitizes it and uses it for display only.
+const INTENDANT_TAB_ID = (() => {
+  try {
+    const stored = sessionStorage.getItem('intendant_tab_id') || '';
+    if (/^[A-Za-z0-9_-]{8,64}$/.test(stored)) return stored;
+    const minted = (window.crypto && crypto.randomUUID)
+      ? crypto.randomUUID()
+      : 'tab-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+    sessionStorage.setItem('intendant_tab_id', minted);
+    return minted;
+  } catch (_) {
+    // Private-mode/storage-denied fallback: stable for this page load only.
+    return 'tab-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+  }
+})();
+
 // QA readback (window.qa convention) + one explicit test hook: the build
 // stamp and nudge state are module-scoped, and the mismatch path can only
 // be exercised for real by building a second bundle — the hook lets the
 // lane-verify harness drive it with a synthetic server stamp instead.
 window.qa = Object.assign(window.qa || {}, {
   buildInfo: () => ({ build: INTENDANT_APP_BUILD, nudged: staleBuildNudged }),
+  tabId: () => INTENDANT_TAB_ID,
   __testNudgeStaleBuild: (v) => maybeNudgeStaleBuild(v),
 });
 
@@ -26290,6 +26315,9 @@ function buildWsUrl(path) {
     const sep = url.includes('?') ? '&' : '?';
     url += sep + 'token=' + encodeURIComponent(token);
   }
+  // Tab presence: browsers can't set headers on WebSocket opens, so the
+  // per-tab id rides the URL the same way the token does.
+  url += (url.includes('?') ? '&' : '?') + 'tab=' + encodeURIComponent(INTENDANT_TAB_ID);
   return url;
 }
 
@@ -27609,6 +27637,7 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_access_set_hosted_ceiling: { verb: 'POST', path: '/api/access/hosted-ceiling' },
   api_fleet_cert_request: { verb: 'POST', path: '/api/access/fleet-cert/request' },
   api_dashboard_targets: { verb: 'GET', path: '/api/dashboard/targets' },
+  api_dashboard_tabs: { verb: 'GET', path: '/api/dashboard/tabs' },
   api_access_org_trust: { verb: 'POST', path: '/api/access/orgs/trust' },
   api_access_org_revoke: { verb: 'POST', path: '/api/access/orgs/revoke' },
   api_access_org_issue: { verb: 'POST', path: '/api/access/org-grants/issue' },
@@ -55004,6 +55033,41 @@ async function refreshAccessConnectStatus(options = {}) {
   }
 }
 
+/* Live dashboard connections (tab presence): who else has this daemon's
+   dashboard open, over which lane, and who holds voice / display input.
+   Pull-based like the overview; renderers read the cached payload. */
+let dashboardTabsPresence = null;
+
+async function refreshDashboardTabs(options = {}) {
+  try {
+    // daemonApi (transport F4): GET twin — read fallback policy.
+    const resp = await daemonApi.request('api_dashboard_tabs', {}, {
+      signal: options.signal,
+      cache: 'no-store',
+    });
+    if (!resp.ok) throw new Error(`/api/dashboard/tabs returned ${resp.status}`);
+    const payload = resp.body;
+    const changed = JSON.stringify(payload) !== JSON.stringify(dashboardTabsPresence);
+    dashboardTabsPresence = payload;
+    if (changed) renderAccessAdminSummaries();
+    return payload;
+  } catch (err) {
+    if (err?.name === 'AbortError') throw err;
+    if (!options.silent) console.warn('[dashboard-tabs] refresh failed', err);
+    return null;
+  }
+}
+
+// Presence changes when OTHER tabs connect or leave — nothing pushes that
+// to this tab (v1 is pull-only), so poll gently, and only while the
+// Access pane is actually on screen in a foreground tab.
+setInterval(() => {
+  if (typeof paneIsVisible === 'function' && paneIsVisible('access')
+      && document.visibilityState === 'visible') {
+    refreshDashboardTabs({ silent: true }).catch(() => {});
+  }
+}, 15000);
+
 async function accessConnectFetchClaimCode() {
   // daemonApi (transport F4): GET twin, so the derived policy allows the
   // direct-HTTP retry after a failed tunnel attempt (the legacy call site
@@ -58291,6 +58355,118 @@ function renderAccessIdentityHero() {
   }));
 }
 
+// ── Open dashboards (tab presence) ──
+//
+// Rendered from `dashboardTabsPresence` (42b refresher over
+// api_dashboard_tabs). Browser-tab connections group by their
+// client-declared tab id — one tab can hold both event lanes — and this
+// tab recognizes itself by INTENDANT_TAB_ID. Peer-daemon connections
+// (kind "peer") are counted separately: they're machines, not tabs.
+function accessTabsBrowserName(ua) {
+  if (!ua) return '';
+  if (/Edg\//.test(ua)) return 'Edge';
+  if (/OPR\//.test(ua)) return 'Opera';
+  if (/Chrome\//.test(ua)) return 'Chrome';
+  if (/Firefox\//.test(ua)) return 'Firefox';
+  if (/Safari\//.test(ua)) return 'Safari';
+  return '';
+}
+
+function renderAccessTabsCard() {
+  const mount = document.getElementById('access-tabs-card');
+  if (!mount) return;
+  mount.textContent = '';
+  const payload = dashboardTabsPresence;
+  // Older daemon (no api_dashboard_tabs) or nothing fetched yet: stay
+  // invisible, exactly like the Connect card.
+  if (!payload || !Array.isArray(payload.connections)) return;
+
+  const tabs = new Map();
+  const untagged = [];
+  const peers = [];
+  for (const c of payload.connections) {
+    if (c.kind === 'peer') { peers.push(c); continue; }
+    if (c.tab_id) {
+      if (!tabs.has(c.tab_id)) tabs.set(c.tab_id, []);
+      tabs.get(c.tab_id).push(c);
+    } else {
+      untagged.push(c);
+    }
+  }
+  const groups = [...tabs.values(), ...untagged.map(c => [c])];
+  const tabCount = groups.length;
+
+  const head = document.createElement('div');
+  head.className = 'acc-section-head';
+  const title = document.createElement('div');
+  title.className = 'acc-section-title';
+  title.textContent = 'Open dashboards';
+  const sub = document.createElement('div');
+  sub.className = 'acc-section-sub';
+  const parts = [`${tabCount} ${tabCount === 1 ? 'tab is' : 'tabs are'} connected to this daemon right now.`];
+  if (peers.length) {
+    parts.push(`${peers.length} peer ${peers.length === 1 ? 'daemon holds' : 'daemons hold'} a control connection.`);
+  }
+  sub.textContent = parts.join(' ');
+  head.append(title, sub);
+  mount.appendChild(head);
+
+  const fmtSince = (ms) => {
+    if (!ms) return '';
+    try {
+      return new Date(ms).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    } catch (_) { return ''; }
+  };
+
+  const renderRow = (conns, { isPeer } = {}) => {
+    const first = conns[0];
+    const browser = accessTabsBrowserName(conns.map(c => c.user_agent).find(Boolean));
+    const isThisTab = !isPeer && first.tab_id
+      && typeof INTENDANT_TAB_ID !== 'undefined' && first.tab_id === INTENDANT_TAB_ID;
+
+    const card = document.createElement('div');
+    card.className = 'acc-principal-card';
+    const headRow = document.createElement('div');
+    headRow.className = 'acc-principal-head';
+    const glyphEl = document.createElement('div');
+    glyphEl.className = `acc-principal-glyph kind-${isPeer ? 'peer' : 'local'}`;
+    glyphEl.textContent = isPeer ? 'P' : (browser ? browser[0] : 'T');
+    const nameWrap = document.createElement('div');
+    const name = document.createElement('div');
+    name.className = 'acc-principal-name';
+    name.textContent = isPeer
+      ? `Peer daemon · ${first.label || 'peer'}`
+      : `${browser || 'Dashboard tab'}${isThisTab ? ' — this tab' : ''}`;
+    const kindLine = document.createElement('div');
+    kindLine.className = 'acc-principal-kind';
+    const details = [];
+    if (!isPeer && first.label && first.label !== 'trusted-local') details.push(first.label);
+    const lanes = [...new Set(conns.map(c => c.lane === 'tunnel' ? 'control tunnel' : 'WebSocket'))];
+    details.push(lanes.join(' + '));
+    const since = fmtSince(Math.min(...conns.map(c => Number(c.connected_at_unix_ms) || Infinity)));
+    if (since) details.push(`since ${since}`);
+    const remote = conns.map(c => c.remote).find(Boolean);
+    if (remote) details.push(`from ${remote}`);
+    kindLine.textContent = details.join(' · ');
+    nameWrap.append(name, kindLine);
+    headRow.append(glyphEl, nameWrap);
+    if (conns.some(c => c.voice_active)) {
+      headRow.appendChild(accessRouteChip('webrtc', 'holds voice',
+        'This connection owns the live voice presence; only one tab can at a time.'));
+    }
+    const inputDisplays = [...new Set(conns.flatMap(c => Array.isArray(c.input_display_ids) ? c.input_display_ids : []))].sort((a, b) => a - b);
+    if (inputDisplays.length) {
+      headRow.appendChild(accessRouteChip('mtls', `holds display input (${inputDisplays.join(', ')})`,
+        'This connection holds exclusive input authority on the listed display ids.'));
+    }
+    card.appendChild(headRow);
+    return card;
+  };
+
+  for (const conns of groups) mount.appendChild(renderRow(conns));
+  for (const p of peers) mount.appendChild(renderRow([p], { isPeer: true }));
+}
+
 function renderAccessFleetStrip() {
   const mount = document.getElementById('access-fleet-strip');
   if (!mount) return;
@@ -60179,6 +60355,9 @@ function renderAccessAdminSummaries() {
       avail('api_access_connect_unclaim'), avail('api_fleet_cert_request'),
     ]),
     renderAccessConnectCard);
+  accessGuardedRender('access-tabs-card',
+    accessSectionFp([dashboardTabsPresence]),
+    renderAccessTabsCard);
   accessGuardedRender('access-fleet-strip',
     accessSectionFp([targetsFp, daemonsFp, transportFp, peersFp]),
     renderAccessFleetStrip);
@@ -67951,6 +68130,7 @@ function switchTab(tabId) {
     refreshAccessOverviewFromApi({ silent: true }).catch(() => {});
     refreshAccessEnrollments({ silent: true }).catch(() => {});
     refreshAccessConnectStatus({ silent: true }).catch(() => {});
+    refreshDashboardTabs({ silent: true }).catch(() => {});
     if (activeAccessSubtab === 'diagnostics') renderConnectHealthPanel();
   }
   flushPaneRenders(tabId);
@@ -73377,6 +73557,7 @@ class DashboardControlTransport {
           daemon_id: DASHBOARD_CONNECT_DAEMON_ID,
           sdp,
           client_nonce: this.clientNonce,
+          tab_id: INTENDANT_TAB_ID,
           ...identity,
           ...(orgGrant ? { org_grant: orgGrant } : {}),
         });
@@ -73401,6 +73582,7 @@ class DashboardControlTransport {
       const answer = await this.postLocalSignal('/connect/dashboard/offer', {
         sdp,
         client_nonce: this.clientNonce,
+        tab_id: INTENDANT_TAB_ID,
         ...identity,
         ...(orgGrant ? { org_grant: orgGrant } : {}),
       });
@@ -73412,7 +73594,7 @@ class DashboardControlTransport {
       return answer;
     } catch (err) {
       console.warn('[dashboard-control] local offer signaling failed', err);
-      if (this.sendWsSignal({ t: 'dashboard_control_offer', sdp, client_nonce: this.clientNonce })) {
+      if (this.sendWsSignal({ t: 'dashboard_control_offer', sdp, client_nonce: this.clientNonce, tab_id: INTENDANT_TAB_ID })) {
         this.signalingMode = 'websocket-fallback';
         dashboardUpdateTransportStatus();
         return null;

--- a/static/app/21-access-dialogs.html
+++ b/static/app/21-access-dialogs.html
@@ -5,6 +5,7 @@
             <div id="access-identity-hero" class="acc-hero-grid"></div>
             <div id="access-tier-card"></div>
             <div id="access-connect-card"></div>
+            <div id="access-tabs-card"></div>
             <div class="acc-section-head">
               <div class="acc-section-title">Fleet</div>
               <div class="acc-section-sub">Every daemon you can reach from here. Each one still decides locally what you may do.</div>

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -48,12 +48,36 @@ function maybeNudgeStaleBuild(serverBuild) {
   });
 }
 
+// ── Per-tab identity ──
+//
+// A random id minted once per browser tab (sessionStorage is per-tab and
+// survives reloads). Sent on both event lanes — `?tab=` on the /ws URL
+// and `tab_id` in control-tunnel offers — so the daemon's tab-presence
+// surface (`api_dashboard_tabs`, Access pane) can group one tab's
+// connections and this tab can recognize itself in the list. Opaque and
+// authority-free: the daemon sanitizes it and uses it for display only.
+const INTENDANT_TAB_ID = (() => {
+  try {
+    const stored = sessionStorage.getItem('intendant_tab_id') || '';
+    if (/^[A-Za-z0-9_-]{8,64}$/.test(stored)) return stored;
+    const minted = (window.crypto && crypto.randomUUID)
+      ? crypto.randomUUID()
+      : 'tab-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+    sessionStorage.setItem('intendant_tab_id', minted);
+    return minted;
+  } catch (_) {
+    // Private-mode/storage-denied fallback: stable for this page load only.
+    return 'tab-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+  }
+})();
+
 // QA readback (window.qa convention) + one explicit test hook: the build
 // stamp and nudge state are module-scoped, and the mismatch path can only
 // be exercised for real by building a second bundle — the hook lets the
 // lane-verify harness drive it with a synthetic server stamp instead.
 window.qa = Object.assign(window.qa || {}, {
   buildInfo: () => ({ build: INTENDANT_APP_BUILD, nudged: staleBuildNudged }),
+  tabId: () => INTENDANT_TAB_ID,
   __testNudgeStaleBuild: (v) => maybeNudgeStaleBuild(v),
 });
 
@@ -134,6 +158,9 @@ function buildWsUrl(path) {
     const sep = url.includes('?') ? '&' : '?';
     url += sep + 'token=' + encodeURIComponent(token);
   }
+  // Tab presence: browsers can't set headers on WebSocket opens, so the
+  // per-tab id rides the URL the same way the token does.
+  url += (url.includes('?') ? '&' : '?') + 'tab=' + encodeURIComponent(INTENDANT_TAB_ID);
   return url;
 }
 

--- a/static/app/32-daemon-api.js
+++ b/static/app/32-daemon-api.js
@@ -208,6 +208,7 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_access_set_hosted_ceiling: { verb: 'POST', path: '/api/access/hosted-ceiling' },
   api_fleet_cert_request: { verb: 'POST', path: '/api/access/fleet-cert/request' },
   api_dashboard_targets: { verb: 'GET', path: '/api/dashboard/targets' },
+  api_dashboard_tabs: { verb: 'GET', path: '/api/dashboard/tabs' },
   api_access_org_trust: { verb: 'POST', path: '/api/access/orgs/trust' },
   api_access_org_revoke: { verb: 'POST', path: '/api/access/orgs/revoke' },
   api_access_org_issue: { verb: 'POST', path: '/api/access/org-grants/issue' },

--- a/static/app/42b-access-model.js
+++ b/static/app/42b-access-model.js
@@ -540,6 +540,41 @@ async function refreshAccessConnectStatus(options = {}) {
   }
 }
 
+/* Live dashboard connections (tab presence): who else has this daemon's
+   dashboard open, over which lane, and who holds voice / display input.
+   Pull-based like the overview; renderers read the cached payload. */
+let dashboardTabsPresence = null;
+
+async function refreshDashboardTabs(options = {}) {
+  try {
+    // daemonApi (transport F4): GET twin — read fallback policy.
+    const resp = await daemonApi.request('api_dashboard_tabs', {}, {
+      signal: options.signal,
+      cache: 'no-store',
+    });
+    if (!resp.ok) throw new Error(`/api/dashboard/tabs returned ${resp.status}`);
+    const payload = resp.body;
+    const changed = JSON.stringify(payload) !== JSON.stringify(dashboardTabsPresence);
+    dashboardTabsPresence = payload;
+    if (changed) renderAccessAdminSummaries();
+    return payload;
+  } catch (err) {
+    if (err?.name === 'AbortError') throw err;
+    if (!options.silent) console.warn('[dashboard-tabs] refresh failed', err);
+    return null;
+  }
+}
+
+// Presence changes when OTHER tabs connect or leave — nothing pushes that
+// to this tab (v1 is pull-only), so poll gently, and only while the
+// Access pane is actually on screen in a foreground tab.
+setInterval(() => {
+  if (typeof paneIsVisible === 'function' && paneIsVisible('access')
+      && document.visibilityState === 'visible') {
+    refreshDashboardTabs({ silent: true }).catch(() => {});
+  }
+}, 15000);
+
 async function accessConnectFetchClaimCode() {
   // daemonApi (transport F4): GET twin, so the derived policy allows the
   // direct-HTTP retry after a failed tunnel attempt (the legacy call site

--- a/static/app/43-access-panes.js
+++ b/static/app/43-access-panes.js
@@ -589,6 +589,118 @@ function renderAccessIdentityHero() {
   }));
 }
 
+// ── Open dashboards (tab presence) ──
+//
+// Rendered from `dashboardTabsPresence` (42b refresher over
+// api_dashboard_tabs). Browser-tab connections group by their
+// client-declared tab id — one tab can hold both event lanes — and this
+// tab recognizes itself by INTENDANT_TAB_ID. Peer-daemon connections
+// (kind "peer") are counted separately: they're machines, not tabs.
+function accessTabsBrowserName(ua) {
+  if (!ua) return '';
+  if (/Edg\//.test(ua)) return 'Edge';
+  if (/OPR\//.test(ua)) return 'Opera';
+  if (/Chrome\//.test(ua)) return 'Chrome';
+  if (/Firefox\//.test(ua)) return 'Firefox';
+  if (/Safari\//.test(ua)) return 'Safari';
+  return '';
+}
+
+function renderAccessTabsCard() {
+  const mount = document.getElementById('access-tabs-card');
+  if (!mount) return;
+  mount.textContent = '';
+  const payload = dashboardTabsPresence;
+  // Older daemon (no api_dashboard_tabs) or nothing fetched yet: stay
+  // invisible, exactly like the Connect card.
+  if (!payload || !Array.isArray(payload.connections)) return;
+
+  const tabs = new Map();
+  const untagged = [];
+  const peers = [];
+  for (const c of payload.connections) {
+    if (c.kind === 'peer') { peers.push(c); continue; }
+    if (c.tab_id) {
+      if (!tabs.has(c.tab_id)) tabs.set(c.tab_id, []);
+      tabs.get(c.tab_id).push(c);
+    } else {
+      untagged.push(c);
+    }
+  }
+  const groups = [...tabs.values(), ...untagged.map(c => [c])];
+  const tabCount = groups.length;
+
+  const head = document.createElement('div');
+  head.className = 'acc-section-head';
+  const title = document.createElement('div');
+  title.className = 'acc-section-title';
+  title.textContent = 'Open dashboards';
+  const sub = document.createElement('div');
+  sub.className = 'acc-section-sub';
+  const parts = [`${tabCount} ${tabCount === 1 ? 'tab is' : 'tabs are'} connected to this daemon right now.`];
+  if (peers.length) {
+    parts.push(`${peers.length} peer ${peers.length === 1 ? 'daemon holds' : 'daemons hold'} a control connection.`);
+  }
+  sub.textContent = parts.join(' ');
+  head.append(title, sub);
+  mount.appendChild(head);
+
+  const fmtSince = (ms) => {
+    if (!ms) return '';
+    try {
+      return new Date(ms).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    } catch (_) { return ''; }
+  };
+
+  const renderRow = (conns, { isPeer } = {}) => {
+    const first = conns[0];
+    const browser = accessTabsBrowserName(conns.map(c => c.user_agent).find(Boolean));
+    const isThisTab = !isPeer && first.tab_id
+      && typeof INTENDANT_TAB_ID !== 'undefined' && first.tab_id === INTENDANT_TAB_ID;
+
+    const card = document.createElement('div');
+    card.className = 'acc-principal-card';
+    const headRow = document.createElement('div');
+    headRow.className = 'acc-principal-head';
+    const glyphEl = document.createElement('div');
+    glyphEl.className = `acc-principal-glyph kind-${isPeer ? 'peer' : 'local'}`;
+    glyphEl.textContent = isPeer ? 'P' : (browser ? browser[0] : 'T');
+    const nameWrap = document.createElement('div');
+    const name = document.createElement('div');
+    name.className = 'acc-principal-name';
+    name.textContent = isPeer
+      ? `Peer daemon · ${first.label || 'peer'}`
+      : `${browser || 'Dashboard tab'}${isThisTab ? ' — this tab' : ''}`;
+    const kindLine = document.createElement('div');
+    kindLine.className = 'acc-principal-kind';
+    const details = [];
+    if (!isPeer && first.label && first.label !== 'trusted-local') details.push(first.label);
+    const lanes = [...new Set(conns.map(c => c.lane === 'tunnel' ? 'control tunnel' : 'WebSocket'))];
+    details.push(lanes.join(' + '));
+    const since = fmtSince(Math.min(...conns.map(c => Number(c.connected_at_unix_ms) || Infinity)));
+    if (since) details.push(`since ${since}`);
+    const remote = conns.map(c => c.remote).find(Boolean);
+    if (remote) details.push(`from ${remote}`);
+    kindLine.textContent = details.join(' · ');
+    nameWrap.append(name, kindLine);
+    headRow.append(glyphEl, nameWrap);
+    if (conns.some(c => c.voice_active)) {
+      headRow.appendChild(accessRouteChip('webrtc', 'holds voice',
+        'This connection owns the live voice presence; only one tab can at a time.'));
+    }
+    const inputDisplays = [...new Set(conns.flatMap(c => Array.isArray(c.input_display_ids) ? c.input_display_ids : []))].sort((a, b) => a - b);
+    if (inputDisplays.length) {
+      headRow.appendChild(accessRouteChip('mtls', `holds display input (${inputDisplays.join(', ')})`,
+        'This connection holds exclusive input authority on the listed display ids.'));
+    }
+    card.appendChild(headRow);
+    return card;
+  };
+
+  for (const conns of groups) mount.appendChild(renderRow(conns));
+  for (const p of peers) mount.appendChild(renderRow([p], { isPeer: true }));
+}
+
 function renderAccessFleetStrip() {
   const mount = document.getElementById('access-fleet-strip');
   if (!mount) return;
@@ -2477,6 +2589,9 @@ function renderAccessAdminSummaries() {
       avail('api_access_connect_unclaim'), avail('api_fleet_cert_request'),
     ]),
     renderAccessConnectCard);
+  accessGuardedRender('access-tabs-card',
+    accessSectionFp([dashboardTabsPresence]),
+    renderAccessTabsCard);
   accessGuardedRender('access-fleet-strip',
     accessSectionFp([targetsFp, daemonsFp, transportFp, peersFp]),
     renderAccessFleetStrip);

--- a/static/app/48-router-settings.js
+++ b/static/app/48-router-settings.js
@@ -314,6 +314,7 @@ function switchTab(tabId) {
     refreshAccessOverviewFromApi({ silent: true }).catch(() => {});
     refreshAccessEnrollments({ silent: true }).catch(() => {});
     refreshAccessConnectStatus({ silent: true }).catch(() => {});
+    refreshDashboardTabs({ silent: true }).catch(() => {});
     if (activeAccessSubtab === 'diagnostics') renderConnectHealthPanel();
   }
   flushPaneRenders(tabId);

--- a/static/app/50-control-transport.js
+++ b/static/app/50-control-transport.js
@@ -976,6 +976,7 @@ class DashboardControlTransport {
           daemon_id: DASHBOARD_CONNECT_DAEMON_ID,
           sdp,
           client_nonce: this.clientNonce,
+          tab_id: INTENDANT_TAB_ID,
           ...identity,
           ...(orgGrant ? { org_grant: orgGrant } : {}),
         });
@@ -1000,6 +1001,7 @@ class DashboardControlTransport {
       const answer = await this.postLocalSignal('/connect/dashboard/offer', {
         sdp,
         client_nonce: this.clientNonce,
+        tab_id: INTENDANT_TAB_ID,
         ...identity,
         ...(orgGrant ? { org_grant: orgGrant } : {}),
       });
@@ -1011,7 +1013,7 @@ class DashboardControlTransport {
       return answer;
     } catch (err) {
       console.warn('[dashboard-control] local offer signaling failed', err);
-      if (this.sendWsSignal({ t: 'dashboard_control_offer', sdp, client_nonce: this.clientNonce })) {
+      if (this.sendWsSignal({ t: 'dashboard_control_offer', sdp, client_nonce: this.clientNonce, tab_id: INTENDANT_TAB_ID })) {
         this.signalingMode = 'websocket-fallback';
         dashboardUpdateTransportStatus();
         return null;


### PR DESCRIPTION
Multi-tab program item 3 (follow-up to #286/#287/#288): make dashboard tab presence visible. The daemon now knows which tabs hold it open, and the Access pane says so.

## Daemon

- **`DashboardTabsRegistry`** (`web_gateway/dashboard_tabs.rs`): live connections on both event lanes, registered at the existing lifecycle seams — the `/ws` accept path (unregistered at `ws_inbound_task` end) and `DashboardControlRegistry::answer_offer` / `close`. Entries carry lane, grant provenance (`local`/`client`/`peer`), grant label, remote host, user agent, connect time, and a client-declared per-tab id (sanitized on ingest).
- **Voice/input joined at query time**: the snapshot joins the presence slot (`ActivePresence.connection_id`) and the display-input-authority map by the internal ids they already key on. Internal connection/session ids never appear in the payload — same rule the input-authority wire follows (personalized state, no holder ids).
- **`GET /api/dashboard/tabs`** + **`api_dashboard_tabs`** tunnel twin, declared as one route row (`AccessInspect`, own-origin, no body). Docs table row + prose added to `docs/src/web-dashboard.md`; the frozen tunnel partition and daemonApi HTTP map pins updated in the same change.

## SPA

- Each tab mints a random id in `sessionStorage` (per-tab, survives reloads) and sends it on every lane: `?tab=` beside the token on the `/ws` URL, `tab_id` in all three control-offer signaling paths (local HTTP, hosted Connect, WS relay). One tab holding both lanes groups into one entry; the tab recognizes itself in the list.
- **Access → Overview → "Open dashboards"**: N tabs connected, browser + label + lanes + since + remote per row, "— this tab" marker, `holds voice` / `holds display input (ids)` chips; peer-daemon control connections counted separately. Refreshed on pane entry and every 15 s while the pane is visible in a foreground tab; invisible on older daemons (like the Connect card).
- `qa.tabId()` readback for harnesses.

Hosted-Connect offers relayed through the rendezvous don't carry the tab id yet (the relay envelope drops unknown fields — a connect-service change); those sessions list untagged but still appear.

## Verification

- New unit tests: registry roundtrip/sanitization/no-id-leak, voice+authority join, neutral envelope; all existing pins (tunnel partition, daemonApi map mirror, docs table, route invariants) updated and green — 3200+ unit tests, clippy, fmt.
- CDP harness (three modes against a real daemon + headless Chrome): under the Safari+mTLS hanging-WS signature the tab lists over the **tunnel** lane; normally over **ws**; in opt-in dual-lane mode both lanes group to **one** tab entry via the shared tab id. All modes assert the "Open dashboards" card renders "1 tab is connected" with the this-tab marker, and that no internal ids reach the wire.
