### PR TITLE
harden macOS TCC/signing resilience: identity escrow, DR drift warning, actionable capture errors

### DIFF
--- a/crates/intendant-display/src/macos.rs
+++ b/crates/intendant-display/src/macos.rs
@@ -573,6 +573,73 @@ fn enumerate_window_display_infos() -> Vec<super::DisplayInfo> {
     windows
 }
 
+/// True when a ScreenCaptureKit failure is the TCC screen-recording denial.
+///
+/// The two shapes Apple surfaces for a missing/invalid grant:
+/// `SCShareableContent::get` fails with "The user declined TCCs for
+/// application, window, display capture", and some paths report
+/// "no shareable content" instead. Matched case-insensitively on the
+/// stable fragments so wording drift around them doesn't break detection.
+fn is_tcc_denied_sck_error(raw: &str) -> bool {
+    let lower = raw.to_ascii_lowercase();
+    lower.contains("declined tcc") || lower.contains("no shareable content")
+}
+
+/// Enrich a ScreenCaptureKit capture-start error with actionable guidance
+/// when it is the TCC denial; every other error passes through unchanged.
+///
+/// The denial is ambiguous at this layer: either Screen Recording was never
+/// granted, or a previous grant was silently invalidated because the binary
+/// was rebuilt/re-signed under a different code-signing identity — macOS
+/// keys TCC grants to the app's signing requirement, and System Settings
+/// keeps showing the toggle ON either way. The appended guidance spells out
+/// both causes and the recovery steps (kept in sync with the re-grant
+/// warning in scripts/bundle-macos.sh).
+fn enrich_sck_capture_error(raw: &str) -> String {
+    if !is_tcc_denied_sck_error(raw) {
+        return raw.to_string();
+    }
+    format!(
+        "{raw} — Screen Recording permission is missing, or a previous grant \
+         was invalidated by a rebuilt/re-signed binary (macOS keys TCC grants \
+         to the app's code signature; System Settings can still show the \
+         toggle ON). Fix: System Settings → Privacy & Security → Screen & \
+         System Audio Recording (\"Screen Recording\" on older macOS) → \
+         toggle Intendant off and back on (re-add it if missing), then \
+         relaunch Intendant — grants are only re-read at launch."
+    )
+}
+
+/// Pop the system Screen Recording prompt at most once per process.
+///
+/// `CGRequestScreenCaptureAccess` shows the "would like to record this
+/// computer's screen" dialog only when the app has no recorded TCC decision
+/// yet, and otherwise just returns the current verdict — so calling it on
+/// the first TCC-denied capture failure gives a fresh install the native
+/// prompt without nagging an already-denied user on every retry. Safe
+/// wrapper from the already-linked `core-graphics` crate (no new FFI).
+fn request_screen_capture_access_once() {
+    static REQUEST: std::sync::Once = std::sync::Once::new();
+    REQUEST.call_once(|| {
+        let granted = core_graphics::access::ScreenCaptureAccess.request();
+        eprintln!(
+            "[display/macos] requested Screen Recording access (granted: {granted}); \
+             re-granting requires relaunching Intendant"
+        );
+    });
+}
+
+/// Wrap an SCK capture-start failure into `CallerError::Display`, enriching
+/// TCC denials with recovery guidance and (once per process) requesting
+/// screen-capture access so the system prompt appears when it can.
+fn sck_capture_error(context: &str, err: impl std::fmt::Display) -> CallerError {
+    let raw = format!("{context}: {err}");
+    if is_tcc_denied_sck_error(&raw) {
+        request_screen_capture_access_once();
+    }
+    CallerError::Display(enrich_sck_capture_error(&raw))
+}
+
 #[async_trait]
 impl DisplayBackend for MacOSBackend {
     async fn start_capture(&self, fps: u32) -> Result<mpsc::Receiver<Frame>, CallerError> {
@@ -587,7 +654,7 @@ impl DisplayBackend for MacOSBackend {
             .with_on_screen_windows_only(matches!(self.target, CaptureTarget::Window(_)))
             .with_exclude_desktop_windows(true)
             .get()
-            .map_err(|e| CallerError::Display(format!("SCShareableContent::get: {e}")))?;
+            .map_err(|e| sck_capture_error("SCShareableContent::get", e))?;
 
         let resolved = resolve_capture_target(&content, self.target)?;
         let width = resolved.width;
@@ -723,7 +790,7 @@ impl DisplayBackend for MacOSBackend {
 
         stream
             .start_capture()
-            .map_err(|e| CallerError::Display(format!("start_capture: {e}")))?;
+            .map_err(|e| sck_capture_error("start_capture", e))?;
 
         *self.capture.lock().await = Some(CaptureState {
             stream,
@@ -970,6 +1037,44 @@ mod tests {
         let point = geometry.point(0.5, 0.25);
         assert_eq!(point.x, 250.0);
         assert_eq!(point.y, 300.0);
+    }
+
+    #[test]
+    fn tcc_denial_detection_matches_known_shapes_case_insensitively() {
+        // Apple's observed wording for the two denial shapes.
+        assert!(is_tcc_denied_sck_error(
+            "The user declined TCCs for application, window, display capture"
+        ));
+        assert!(is_tcc_denied_sck_error("no shareable content available"));
+        assert!(is_tcc_denied_sck_error("Error: No Shareable Content"));
+        // Unrelated SCK failures must not classify as denials.
+        assert!(!is_tcc_denied_sck_error("connection interrupted"));
+        assert!(!is_tcc_denied_sck_error("the stream was stopped"));
+        assert!(!is_tcc_denied_sck_error(""));
+    }
+
+    #[test]
+    fn tcc_denied_errors_keep_original_text_and_gain_guidance() {
+        let raw = "SCShareableContent::get: The user declined TCCs for \
+                   application, window, display capture";
+        let enriched = enrich_sck_capture_error(raw);
+        assert!(
+            enriched.starts_with(raw),
+            "original error text must be preserved verbatim: {enriched}"
+        );
+        // The guidance must name both causes and the recovery path.
+        assert!(enriched.contains("rebuilt/re-signed"));
+        assert!(enriched.contains("Privacy & Security"));
+        assert!(enriched.contains("Screen & System Audio Recording"));
+        assert!(enriched.contains("relaunch"));
+    }
+
+    #[test]
+    fn non_tcc_errors_pass_through_unchanged() {
+        let raw = "SCShareableContent::get: connection interrupted";
+        assert_eq!(enrich_sck_capture_error(raw), raw);
+        let raw = "start_capture: stream failed to start";
+        assert_eq!(enrich_sck_capture_error(raw), raw);
     }
 
     #[test]

--- a/docs/src/computer-use-and-audio.md
+++ b/docs/src/computer-use-and-audio.md
@@ -66,6 +66,38 @@ on HiDPI and under the Wayland portal, which reports its own stream size).
 (2x on Retina) and crops the requested logical region, because detail is the
 point.
 
+### Screen-capture permissions & signing identity (macOS)
+
+macOS TCC keys every permission grant (Screen Recording, Accessibility,
+Apple Events, Microphone, Camera) to the app's **code-signing designated
+requirement** as it was at grant time. If the binary is rebuilt or re-signed
+under a different identity — or the signing *identifier* changes — every
+existing grant silently stops validating: System Settings keeps showing the
+toggle ON while `SCShareableContent::get` fails with "The user declined
+TCCs…". The macOS capture backend classifies that failure and appends the
+recovery path to the error (permission missing **or** invalidated by a
+re-signed build; toggle it off/on under System Settings → Privacy &
+Security → Screen & System Audio Recording, then relaunch — grants are only
+re-read at launch), and requests screen-capture access once per process so
+a fresh install gets the native prompt.
+
+`scripts/bundle-macos.sh` defends the identity's stability:
+
+- The local-dev signing identity ("Intendant Dev", in
+  `~/.intendant/signing.keychain-db`) is **escrowed** to
+  `~/.intendant/signing-identity.p12` (chmod 600) when created, and
+  backfilled from the keychain for identities that predate the escrow. If
+  the keychain is ever lost, the script re-imports that file — same cert,
+  same designated requirement, existing grants keep validating — instead of
+  silently minting a fresh identity that voids them all.
+- When a genuinely new identity must be minted (keychain *and* escrow both
+  gone), the script prints a loud re-grant warning listing the System
+  Settings steps.
+- After every signing run it diffs the bundle's designated requirement
+  against `~/.intendant/last-signed-dr.txt` and prints the same warning on
+  any drift (this also catches signing-identifier changes and dev-cert ↔
+  Developer ID switches), then refreshes the cache.
+
 ### Element Observation (`read_screen`)
 
 `read_screen` is the cheap textual grounding path: a filtered accessibility

--- a/scripts/bundle-macos.sh
+++ b/scripts/bundle-macos.sh
@@ -21,7 +21,11 @@
 #      ~/.intendant/signing.keychain-db. A cert-based Designated
 #      Requirement survives rebuilds, so a one-time TCC grant keeps
 #      working across `./scripts/bundle-macos.sh` re-runs. (Ad-hoc
-#      signing would re-prompt every rebuild.)
+#      signing would re-prompt every rebuild.) The identity is escrowed
+#      to ~/.intendant/signing-identity.p12: TCC keys every grant to the
+#      signing cert, so a lost keychain must re-import the same cert —
+#      silently minting a new one voids all grants (see the signing
+#      section below and the DR drift check after it).
 #   4. Installing the bundle to /Applications/Intendant.app and
 #      refreshing LaunchServices. This is the only location a few
 #      pieces of the stack (Claude Code's computer-use MCP, Dock
@@ -270,6 +274,48 @@ release_codesign() {
     fi
 }
 
+# Loud re-grant instructions, printed whenever this build's signature no
+# longer matches what previous TCC grants were keyed to (a fresh identity
+# was minted, or the designated requirement drifted). macOS keeps the
+# System Settings toggles visually ON while every grant silently stops
+# validating, so without this warning the failure surfaces days later as an
+# opaque "declined TCC" capture error at runtime. Printed at most once in
+# full; later calls in the same run add a one-line note.
+TCC_REGRANT_WARNED=0
+warn_tcc_regrant() {
+    if [ "$TCC_REGRANT_WARNED" = "1" ]; then
+        echo "(TCC re-grant warning above also applies: $1)" >&2
+        return
+    fi
+    TCC_REGRANT_WARNED=1
+    cat >&2 << WARN
+
+============================================================================
+  WARNING: TCC grants from previous Intendant builds are now VOID
+============================================================================
+
+  Why: $1
+
+  macOS keys TCC permissions to the app's code-signing requirement. When it
+  changes, every grant made to earlier builds — Screen Recording,
+  Accessibility, Apple Events / Automation, Microphone, Camera — silently
+  stops validating. System Settings still shows the toggles ON, but capture
+  fails at runtime with "The user declined TCCs".
+
+  Re-grant once this build is installed:
+    1. System Settings → Privacy & Security → Screen & System Audio
+       Recording ("Screen Recording" on older macOS): toggle Intendant
+       OFF, then back ON (remove and re-add it if the toggle seems inert).
+    2. Repeat for Accessibility, and for Automation (Apple Events),
+       Microphone, and Camera if you use those features.
+    3. Relaunch Intendant (open -b com.intendant.app) — TCC grants are
+       re-read at launch, not live.
+
+============================================================================
+
+WARN
+}
+
 # Bundle every non-system dylib the executables reference (today: Homebrew
 # libvpx) into Contents/Frameworks and rewrite the load commands to
 # @executable_path/../Frameworks/. A distributable app cannot reference
@@ -340,18 +386,43 @@ if [ -n "$SIGN_RELEASE_IDENTITY" ]; then
     codesign --verify --deep --strict --verbose=2 "$APP"
     echo "Signed and verified with '$SIGN_RELEASE_IDENTITY'"
 else
-    # Local-dev path (unchanged behavior): sign with a stable self-signed
-    # identity so TCC permissions survive recompiles. Uses a dedicated
-    # keychain at ~/.intendant/signing.keychain-db (works over SSH, no Apple
-    # Developer account needed, no GUI Keychain prompts).
+    # Local-dev path: sign with a stable self-signed identity so TCC
+    # permissions survive recompiles. Uses a dedicated keychain at
+    # ~/.intendant/signing.keychain-db (works over SSH, no Apple Developer
+    # account needed, no GUI Keychain prompts).
     SIGN_IDENTITY="Intendant Dev"
     SIGN_KEYCHAIN="$HOME/.intendant/signing.keychain-db"
     SIGN_KEYCHAIN_PASS="intendant-dev"
+    # PKCS#12 escrow of the signing identity, outside the keychain. The
+    # keychain used to hold the ONLY copy of the private key (the temp cert
+    # dir is deleted right after import), so a lost or recreated keychain
+    # silently minted a brand-new identity — and because macOS TCC keys
+    # every grant to the signing cert, all Screen Recording / Accessibility
+    # / Apple Events grants died with no visible error (2026-07-13
+    # incident). With the escrow, a later run re-imports the SAME identity
+    # instead. Passphrase choice: fixed and public ("intendant", the same
+    # one this script has always used for the import) — this is a
+    # machine-local self-signed cert whose only job is a stable designated
+    # requirement, not a trust anchor. The secret is the key *file*, which
+    # lives chmod-600 under ~/.intendant and never enters the repo tree.
+    SIGN_P12_BACKUP="$HOME/.intendant/signing-identity.p12"
+    SIGN_P12_PASS="intendant"
 
     if ! security find-identity -p codesigning "$SIGN_KEYCHAIN" 2>/dev/null | grep -q "$SIGN_IDENTITY"; then
-        echo "Creating local code signing certificate '$SIGN_IDENTITY'..."
-        CERT_DIR=$(mktemp -d)
-        cat > "$CERT_DIR/cert.conf" << 'CERTCONF'
+        mkdir -p "$(dirname "$SIGN_KEYCHAIN")"
+        security create-keychain -p "$SIGN_KEYCHAIN_PASS" "$SIGN_KEYCHAIN" 2>/dev/null || true
+        security unlock-keychain -p "$SIGN_KEYCHAIN_PASS" "$SIGN_KEYCHAIN"
+        security set-keychain-settings "$SIGN_KEYCHAIN"
+        if [ -f "$SIGN_P12_BACKUP" ]; then
+            # The keychain is gone/empty but the escrow survives: re-import
+            # the same cert + key, so the designated requirement — and every
+            # TCC grant keyed to it — keeps validating.
+            echo "Signing keychain is missing '$SIGN_IDENTITY'; re-importing it from $SIGN_P12_BACKUP (existing TCC grants stay valid)..."
+            security import "$SIGN_P12_BACKUP" -k "$SIGN_KEYCHAIN" -P "$SIGN_P12_PASS" -T /usr/bin/codesign -A
+        else
+            echo "Creating local code signing certificate '$SIGN_IDENTITY'..."
+            CERT_DIR=$(mktemp -d)
+            cat > "$CERT_DIR/cert.conf" << 'CERTCONF'
 [req]
 distinguished_name = req_dn
 x509_extensions = codesign
@@ -362,25 +433,40 @@ CN = Intendant Dev
 keyUsage = digitalSignature
 extendedKeyUsage = codeSigning
 CERTCONF
-        openssl req -x509 -newkey rsa:2048 -nodes \
-            -keyout "$CERT_DIR/key.pem" -out "$CERT_DIR/cert.pem" \
-            -days 3650 -config "$CERT_DIR/cert.conf" 2>/dev/null
-        openssl pkcs12 -export -out "$CERT_DIR/cert.p12" \
-            -inkey "$CERT_DIR/key.pem" -in "$CERT_DIR/cert.pem" \
-            -passout pass:intendant 2>/dev/null
-        mkdir -p "$(dirname "$SIGN_KEYCHAIN")"
-        security create-keychain -p "$SIGN_KEYCHAIN_PASS" "$SIGN_KEYCHAIN" 2>/dev/null || true
-        security unlock-keychain -p "$SIGN_KEYCHAIN_PASS" "$SIGN_KEYCHAIN"
-        security set-keychain-settings "$SIGN_KEYCHAIN"
-        security import "$CERT_DIR/cert.p12" -k "$SIGN_KEYCHAIN" -P "intendant" -T /usr/bin/codesign -A
+            openssl req -x509 -newkey rsa:2048 -nodes \
+                -keyout "$CERT_DIR/key.pem" -out "$CERT_DIR/cert.pem" \
+                -days 3650 -config "$CERT_DIR/cert.conf" 2>/dev/null
+            openssl pkcs12 -export -out "$CERT_DIR/cert.p12" \
+                -inkey "$CERT_DIR/key.pem" -in "$CERT_DIR/cert.pem" \
+                -passout "pass:$SIGN_P12_PASS" 2>/dev/null
+            security import "$CERT_DIR/cert.p12" -k "$SIGN_KEYCHAIN" -P "$SIGN_P12_PASS" -T /usr/bin/codesign -A
+            # Escrow the identity BEFORE deleting the temp dir — the
+            # keychain must never again hold the only copy of the key.
+            cp "$CERT_DIR/cert.p12" "$SIGN_P12_BACKUP"
+            chmod 600 "$SIGN_P12_BACKUP"
+            rm -rf "$CERT_DIR"
+            echo "Certificate created in $SIGN_KEYCHAIN (escrowed to $SIGN_P12_BACKUP)"
+            warn_tcc_regrant "a NEW signing identity was created — no '$SIGN_IDENTITY' in $SIGN_KEYCHAIN and no escrow at $SIGN_P12_BACKUP to recover it from"
+        fi
         security set-key-partition-list -S apple-tool:,apple: -s -k "$SIGN_KEYCHAIN_PASS" "$SIGN_KEYCHAIN" >/dev/null 2>&1
         # Add to search list so codesign can find it (list-keychains -s
         # replaces the whole list, so re-list the existing entries too;
         # word-splitting the quoted paths is intended).
         # shellcheck disable=SC2046
         security list-keychains -d user -s "$SIGN_KEYCHAIN" $(security list-keychains -d user | tr -d '"')
-        rm -rf "$CERT_DIR"
-        echo "Certificate created in $SIGN_KEYCHAIN"
+    elif [ ! -f "$SIGN_P12_BACKUP" ]; then
+        # The identity predates the escrow (or the escrow was deleted):
+        # backfill it from the keychain so a future keychain loss re-imports
+        # instead of minting. Non-fatal — an un-escrowed identity still
+        # signs; it just cannot survive keychain loss.
+        security unlock-keychain -p "$SIGN_KEYCHAIN_PASS" "$SIGN_KEYCHAIN" 2>/dev/null || true
+        if security export -k "$SIGN_KEYCHAIN" -t identities -f pkcs12 -P "$SIGN_P12_PASS" -o "$SIGN_P12_BACKUP" 2>/dev/null; then
+            chmod 600 "$SIGN_P12_BACKUP"
+            echo "Escrowed signing identity to $SIGN_P12_BACKUP"
+        else
+            rm -f "$SIGN_P12_BACKUP"
+            echo "Warning: could not escrow the signing identity to $SIGN_P12_BACKUP; if $SIGN_KEYCHAIN is ever lost, a new identity will be minted and every TCC grant will be void" >&2
+        fi
     fi
 
     echo "Signing app bundle..."
@@ -393,6 +479,30 @@ CERTCONF
         echo "TCC permissions may be invalidated on each recompile"
         codesign --force --deep --sign - "$APP" 2>/dev/null || true
     fi
+fi
+
+# --- TCC drift check: designated requirement vs. the last signed build -------
+# macOS TCC keys each grant to the app's designated requirement (DR) as it
+# was at grant time. ANY DR change — a re-minted signing cert, a changed
+# signing identifier (the 2026-07-10 `Intendant` → `com.intendant.app`
+# identifier move voided grants exactly this way), a dev-cert ↔ Developer ID
+# switch, or ad-hoc's per-build cdhash — voids every existing grant while
+# System Settings keeps showing the toggles ON. Diff this build's DR against
+# the previous signed build's and warn loudly when it moved. Reads only the
+# bundle plus a cache under ~/.intendant — needs no TCC or Full Disk Access.
+DR_CACHE="$HOME/.intendant/last-signed-dr.txt"
+# codesign -d -r- prints the requirement itself ("designated => ...") on
+# stdout and the Executable= header on stderr; unsigned bundles yield empty.
+CURRENT_DR="$(codesign -d -r- "$APP" 2>/dev/null || true)"
+if [ -n "$CURRENT_DR" ]; then
+    PREVIOUS_DR="$(cat "$DR_CACHE" 2>/dev/null || true)"
+    if [ -n "$PREVIOUS_DR" ] && [ "$CURRENT_DR" != "$PREVIOUS_DR" ]; then
+        echo "Designated requirement changed since the last signed build:" >&2
+        printf '  was: %s\n  now: %s\n' "$PREVIOUS_DR" "$CURRENT_DR" >&2
+        warn_tcc_regrant "this build's code-signing designated requirement differs from the last signed build's (cached at $DR_CACHE)"
+    fi
+    mkdir -p "$(dirname "$DR_CACHE")"
+    printf '%s\n' "$CURRENT_DR" > "$DR_CACHE"
 fi
 
 # --- Notarization (optional; requires the release identity) ------------------
@@ -493,4 +603,11 @@ else
     echo ""
     echo "Launch:"
     echo "  open target/Intendant.app"
+fi
+
+# Repeat a one-line pointer at the very end so the full warning can't be
+# scrolled away by the install output above.
+if [ "$TCC_REGRANT_WARNED" = "1" ]; then
+    echo "" >&2
+    echo "⚠️  TCC re-grant required (see the warning above): cycle Screen Recording / Accessibility for Intendant in System Settings, then relaunch." >&2
 fi


### PR DESCRIPTION
Implements the Computer-Use action-visualization layer for the Live display tab plus the remaining design-concept fidelity items, driven by a new display-scoped `cu_action` event lane from the daemon.

## Backend: the `cu_action` lane

`computer_use::execute_actions` (the CU chokepoint; both the sequential X11/macOS path and the Wayland/Windows session path) now emits one event per **successfully executed** action through an optional `CuActionObserver`:

```json
{"event":"cu_action","event_id":"cu-<ts>-<seq>","session_id":"…","display_id":99,
 "kind":"left_click","x":612,"y":233,"ref_w":1280,"ref_h":800,
 "raw":"left_click(612, 233)","ts":1752…}
```

- `kind` vocabulary: `screenshot | zoom | left_click | right_click | middle_click | double_click | triple_click | mouse_down | mouse_up | move | drag | type | paste | key | hold_key | scroll | wait`.
- Coordinates are display pixel space; `ref_w`/`ref_h` carry the resolution they are relative to (the denorm reference / live session resolution) so viewers normalize against their letterboxed frame; `(0,0)` = unknown, viewer falls back to the stream's intrinsic dims.
- `raw` is the feed's mono call string; embedded `type()`/`paste()` text truncates at ~120 chars (presentation only — the Activity log keeps the full trace, so no new exposure).
- Moves coalesce to 10 Hz. Failed actions never emit (no invented clicks).
- **Ephemeral by design**: rides the outbound broadcast (legacy `/ws` + the dashboard-control tunnel, which forwards all broadcast lines) — never written to the session log, never replayed (`cu_action_events_never_reach_the_session_log` pins this).
- `event_id` joins the browser's dual-lane dedupe set: transport-migration double delivery dedupes by id while two real identical clicks (distinct ids) both render.
- Observers wired at: the native agent loop, the ephemeral CU task runner, the `shared_view` capture branch (session-attributed), and the MCP display tools (sessionless — `session_id` omitted).

## Concept element → shipped / deferred

| Concept element | Status |
|---|---|
| Agent cursor (white arrow SVG 24×26 + drop shadow) + verb pill (iris gradient; Look/Move/Click/Type/Scroll/Waiting) | **Shipped** — rAF lerp 0.16 toward each action point, dims to 0.26 while the dashboard user holds input authority, fades after ~6s idle |
| Click ripple (18px, 2px iris border, 14% fill, 0.4→2.8 scale / 0.9→0 opacity over 560ms) | **Shipped** (click-family kinds incl. `mouse_down`; not `mouse_up`) |
| Keypress chips (bottom-center, mono 12px, dark glass, last ~9 chars, space→·, chip-in) | **Shipped** — derived from the event's raw call text; `key`/`hold_key` render the combo as one chip |
| Screenshot flash (full-stage white, peak 0.85, 400ms) | **Shipped** (`screenshot` + `zoom`) |
| Target highlight box + role tag | **Deferred (deliberate)** — no honest element/role data on the wire today; future AX integration |
| LIVE metrics chip | Already shipped pre-PR (getStats sampler) |
| You-have-control banner | Already shipped pre-PR |
| Host identity chip (`{host} · {display}` glass pill + gradient square, bottom-right) | **Shipped** — host from the daemon agent-card label (the status bar's source); hidden in thumb/fullscreen contexts |
| Action stream two-line grammar (friendly + seconds ts; raw mono call below; colored 8px halo dots) | **Shipped** — feed cap 10→50, near-bottom-only autoscroll (≤30px), `cu-row-in` entrance, chronological `role=log` append preserved |
| Concept's semantic friendlies ("Focused the origin field") | **Deferred (deliberate)** — the wire carries coordinates, not element semantics; sentences stay honest/generic ("Clicked at (612, 233)") |
| Action stream play/pause/replay controls | **Deferred (deliberate)** — the lane is live-only; no replay by design |
| Rail approval card (amber, pulsing dot, eyebrow, mono chips, Approve iris / Deny rose outline) | **Shipped, attribution-gated** — renders only when the pending approval's session is the daemon-reported driver (`cu_action.session_id`) of the SELECTED display; Approve/Deny proxy `window.sendApproval` (the panel's own session-scoped ControlMsg); the main approval panel is untouched; no attribution → no card |
| Authority-card avatar (24px circle, initials) | **Shipped** — `YOU` when you hold input, `AI` for agent-side/unclaimed/connecting, `···` for another viewer (holder identity is deliberately not on the wire) |
| Recording elapsed timer (`⏹ mm:ss`) | **Shipped** — ticks from the `applyRecordingState` confirmation; pending/confirmed state machine untouched. Honest limitation: a dashboard reload restarts the visible counter (the daemon does not publish the start timestamp) |

## Known follow-ups (called out, not half-wired)

- **Peer displays render no action overlays**: both peer upcasters deliberately drop `cu_action` (AppEvent→PeerEvent and OutboundEvent→PeerEvent), so federated panes show nothing rather than something half-true.
- Target highlight/role tag needs an AX-grounded element event to exist first.
- `presence-web` (WASM) was touched after all — a one-line no-op `"cu_action" => {}` arm so its unknown-event catch-all doesn't add one debug log line per executed action; the artifact was rebuilt on macOS with the pinned wasm-pack and is committed alongside the source.

## Guardrails honored

- Overlays are absolutely-positioned `pointer-events:none`, `aria-hidden` children of `.display-canvas`; geometry via `surfaceContentBox` (getBoundingClientRect + intrinsic dims, pure letterbox); no borders/padding/transforms on the canvas or media elements; the single-`<video>`-reparented pattern untouched; no `!important` near media dimensions.
- Every animation sits behind `prefers-reduced-motion: no-preference` (CSS) or a `matchMedia` check (rAF-driven cursor/ripple/flash snap or skip).
- Fragments only; `static/app.html` regenerated by the build and committed. Substantial new overlay JS lives in a new fragment (`static/app/45b-cu-overlays.js`) instead of growing the 45-displays-webrtc.js god-file past budget.
- Docs updated (`computer-use-and-audio.md` Dashboard Live workspace; `web-dashboard.md` Live display) — including correcting the now-stale "the wire protocol has no display-keyed click/type event" statements in the same change.

## Tests + verification

- `computer_use.rs`: kind vocabulary, raw-call grammar (concept-exact strings), 120-char truncation + newline flattening + multibyte boundary safety, landing-point extraction (drag end point), display-id mapping, 10 Hz move gate, end-to-end bus emission (fields + sessionless form).
- `event.rs`: wire-shape pin (`{"event":"cu_action",…}`), absent-field omission, session-log exclusion.
- **New headless e2e** (`cu_actions_broadcast_display_scoped_events_over_ws`, in CI): synthetic user display + `ctl cu actions` screenshot → the `cu_action` event on `/ws` with the pinned shape and no session-log trace. (The shared-view default-target e2e's "bus is empty" tail assertion now states its actual intent — no display-0 activation — since the capture's own event rides the bus.)
- Battery run: `cargo nextest run --bins` 3240 passed; `cargo clippy` clean (bins + e2e target); `cargo test --test e2e` 20/20; `node scripts/validate-dashboard.cjs --self-test` PASS.
- **Live browser verification** (isolated mock-provider daemon, synthetic display, real Chromium over CDP): a real `ctl`-driven screenshot rendered the feed row `Looked at the screen / screenshot()` with seconds timestamp, verb pill `Look`, and the stage flash element; synthetic frontend probes confirmed cursor placement at the letterbox-mapped point (opacity 1), keychips `llo·world` for `type("hello world")`, host chip `{host} · Primary display`, engine registration, and the approval card correctly hidden without attribution. Not live-verified: the approval card's *visible* path (needs a pending approval whose session attribution matches — logic reviewed + DOM-driven; hidden-gating verified live) and animation trajectories (transient by nature).
