### PR TITLE
display: ordered per-session input queue; idle conversion and clipboard gates

### DIFF
--- a/crates/intendant-display/src/clipboard.rs
+++ b/crates/intendant-display/src/clipboard.rs
@@ -2,7 +2,12 @@
 //! and browser.
 //!
 //! Polls the system clipboard every 500ms and emits changes.  Supports both
-//! text and image content.
+//! text and image content.  Polling is gated on viewer presence: while the
+//! display session has zero connected peers the tick does no clipboard
+//! access at all (see [`ClipboardMonitor::start_watching`]), because on
+//! macOS/Linux every poll otherwise shells out to `pbpaste`/`osascript`/
+//! `xclip`/`wl-paste` — a per-second subprocess tax for a sync with no
+//! recipient.
 //!
 //! Platform support:
 //! - **macOS**: `pbpaste` / `pbcopy`, `osascript` for image clipboard
@@ -51,7 +56,29 @@ impl ClipboardMonitor {
     ///
     /// Returns a receiver that emits `ClipboardContent` whenever it changes.
     /// The polling loop runs every 500ms until `stop()` is called.
-    pub fn start_watching(&self) -> mpsc::Receiver<ClipboardContent> {
+    ///
+    /// `peers_connected` gates the actual clipboard reads (F3, 2026-07-13
+    /// display review): while it returns `false` — the display session has
+    /// zero connected viewers — each tick is a no-op, so no clipboard
+    /// subprocess (`pbpaste`/`osascript`/`xclip`/`wl-paste`) or native
+    /// clipboard open is spawned for a sync nobody receives. Polling
+    /// resumes on the first tick after a peer connects. Content that
+    /// changed **during** the pause is deliberately absorbed without
+    /// emitting (a silent re-baseline): pre-gate behavior broadcast such
+    /// changes to an empty peer set — i.e. delivered them to nobody, ever
+    /// — and the gate preserves exactly that.
+    ///
+    /// Production passes a closure over the session's `peer_count` gauge —
+    /// the same peer-presence signal the encoder pool's presence policy
+    /// keys on. Tests inject an arbitrary closure.
+    ///
+    /// Known follow-up (out of scope here): replace 500ms subprocess
+    /// polling on macOS with an `NSPasteboard.changeCount` probe so even
+    /// the with-viewers steady state stops shelling out twice a second.
+    pub fn start_watching(
+        &self,
+        peers_connected: Arc<dyn Fn() -> bool + Send + Sync>,
+    ) -> mpsc::Receiver<ClipboardContent> {
         let (tx, rx) = mpsc::channel::<ClipboardContent>(4);
         let last_text = Arc::clone(&self.last_text);
         let last_image_hash = Arc::clone(&self.last_image_hash);
@@ -59,10 +86,36 @@ impl ClipboardMonitor {
 
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_millis(500));
+            // Set while paused; the first active tick after a pause
+            // re-baselines silently instead of emitting.
+            let mut rebaseline = false;
             loop {
                 interval.tick().await;
                 if shutdown.load(Ordering::Relaxed) {
                     break;
+                }
+
+                // F3 gate: zero viewers → skip all clipboard access.
+                if !peers_connected() {
+                    rebaseline = true;
+                    continue;
+                }
+                if rebaseline {
+                    rebaseline = false;
+                    // Absorb whatever changed while paused (mirror the
+                    // image-over-text priority of the live poll below)
+                    // so it is not replayed to the peer that just
+                    // connected — matching pre-gate semantics, where a
+                    // zero-peer change was polled, "sent" to an empty
+                    // peer map, and never delivered later.
+                    if let Some((_mime, data)) = read_clipboard_image().await {
+                        *last_image_hash.lock().await = simple_hash(&data);
+                        *last_text.lock().await = String::new();
+                    } else if let Some(text) = read_clipboard_text().await {
+                        *last_text.lock().await = text;
+                        *last_image_hash.lock().await = 0;
+                    }
+                    continue;
                 }
 
                 // Check for image content first (higher priority).
@@ -618,6 +671,42 @@ mod tests {
             data: vec![1, 2, 3],
         };
         assert_eq!(a, b);
+    }
+
+    /// F3 gate: with zero connected peers the watcher must emit nothing —
+    /// the `continue` fires before any platform clipboard read, so this
+    /// test is hermetic (no `pbpaste`/`xclip`/arboard subprocess or native
+    /// clipboard is ever touched). Paused tokio time auto-advances through
+    /// ~10 poll intervals deterministically.
+    #[tokio::test(start_paused = true)]
+    async fn watcher_is_inert_while_no_peers_connected() {
+        let monitor = ClipboardMonitor::new();
+        let mut rx = monitor.start_watching(Arc::new(|| false));
+
+        let emitted = tokio::time::timeout(std::time::Duration::from_secs(5), rx.recv()).await;
+        assert!(
+            emitted.is_err(),
+            "a peer-gated (zero-viewer) watcher must not emit clipboard content"
+        );
+
+        monitor.stop();
+    }
+
+    /// stop() terminates the gated loop: the receiver closes even though
+    /// the peers gate never opened (the shutdown check precedes the gate).
+    #[tokio::test(start_paused = true)]
+    async fn watcher_stops_while_gated() {
+        let monitor = ClipboardMonitor::new();
+        let mut rx = monitor.start_watching(Arc::new(|| false));
+        monitor.stop();
+
+        // The loop notices the shutdown flag on its next tick and drops
+        // the sender, closing the channel.
+        let got = tokio::time::timeout(std::time::Duration::from_secs(10), rx.recv()).await;
+        assert!(
+            matches!(got, Ok(None)),
+            "stop() must end the watcher task even while peer-gated"
+        );
     }
 
     // Windows clipboard image helpers: pure RGBA<->PNG conversions, no live

--- a/crates/intendant-display/src/encode/pool/mod.rs
+++ b/crates/intendant-display/src/encode/pool/mod.rs
@@ -1288,6 +1288,37 @@ impl EncoderPool {
         None
     }
 
+    /// Whether any encoder in the pool would actually do work for a
+    /// pushed frame right now: an **unpaused always-on layer**, or an
+    /// **on-demand encoder with at least one subscriber** (`refcount >
+    /// 0`) that is not paused. The active-encoder universe matches
+    /// [`Self::request_keyframe_all`] (always-on ∪ subscribed
+    /// on-demand), intersected with the pause state the layer-policy
+    /// coordinator drives via [`Self::pause_layer`] /
+    /// [`Self::resume_layer`].
+    ///
+    /// Used by the pool-feed bridge's idle gate (F2, 2026-07-13 display
+    /// review): when this is `false`, pushing a frame would only make
+    /// paused encoder threads drain-and-skip it, so the bridge skips
+    /// the BGRA→I420 conversion that feeds the push entirely. Cheap
+    /// enough for a per-tick call: one `RwLock` read over ≤3 always-on
+    /// handles plus one mutex-guarded scan of the (tiny) on-demand map.
+    pub fn has_active_consumer(&self) -> bool {
+        {
+            let always_on = self.inner.always_on.read().unwrap();
+            if always_on
+                .iter()
+                .any(|handle| !handle.paused.load(Ordering::SeqCst))
+            {
+                return true;
+            }
+        }
+        let on_demand = self.inner.on_demand.lock().unwrap();
+        on_demand
+            .values()
+            .any(|slot| slot.refcount > 0 && !slot.handle.paused.load(Ordering::SeqCst))
+    }
+
     /// Test-only access to the always-on handles. Lets tests verify
     /// pool composition without exposing internals to production code.
     ///
@@ -3349,6 +3380,47 @@ mod tests {
         assert!(
             resumed_again,
             "resume_layer is idempotent on already-active slot"
+        );
+    }
+
+    /// `has_active_consumer` — the pool-feed bridge's idle gate (F2):
+    /// true while any always-on layer is unpaused; false once the
+    /// presence policy has paused everything; true again on resume;
+    /// and false for a pool with no encoders at all (the synthetic /
+    /// empty-bank shape).
+    #[tokio::test]
+    async fn pool_has_active_consumer_tracks_pause_state() {
+        let empty = EncoderPool::new(64, 64, 30, |_, _| vec![], None);
+        assert!(
+            !empty.has_active_consumer(),
+            "a pool with no encoders has no consumer"
+        );
+
+        let pool = EncoderPool::new(64, 64, 30, |w, h| LayerSpec::vp8_simulcast(w, h, 30), None);
+        assert!(
+            pool.has_active_consumer(),
+            "always-on layers start unpaused — the pool is a live consumer"
+        );
+
+        // Presence-policy steady state at zero peers: everything paused.
+        for id in pool.always_on_ids() {
+            assert!(pool.pause_layer(id.codec, id.rid));
+        }
+        assert!(
+            !pool.has_active_consumer(),
+            "with every layer paused, pushing frames would be pure waste"
+        );
+
+        // One layer resuming is enough to demand frames again.
+        let first = pool
+            .always_on_ids()
+            .into_iter()
+            .next()
+            .expect("simulcast pool has layers");
+        assert!(pool.resume_layer(first.codec, first.rid));
+        assert!(
+            pool.has_active_consumer(),
+            "a single resumed layer re-establishes demand"
         );
     }
 

--- a/crates/intendant-display/src/input_queue.rs
+++ b/crates/intendant-display/src/input_queue.rs
@@ -1,0 +1,618 @@
+//! Ordered browser-input queue: one bounded queue and one consumer task
+//! ("pump") per display session.
+//!
+//! ## Why this exists (2026-07-13 display review, F1)
+//!
+//! The browser sends `kd`/`ku`/`md`/`mu` over reliable **ordered** WebRTC
+//! data channels (and the ordered `/ws` socket), but two of the three
+//! daemon input lanes used to dispatch **one `tokio::spawn` per event**,
+//! racing consecutive events across runtime workers. A `kd`/`ku` inversion
+//! re-injects the release before the press — a stuck auto-repeating key
+//! (the historical X11 class); an `md`/`mu` inversion scrambles clicks.
+//! The race window widens under host load, exactly when a user is most
+//! likely to be typing "stop".
+//!
+//! The fix: every browser input lane pushes into this per-session queue
+//! (a sync, non-blocking call — both WebRTC lanes enqueue from sans-I/O
+//! `rtc` poll loops that must never block), and a single pump task drains
+//! it, awaiting each `DisplayBackend::inject_input` to completion before
+//! starting the next. Arrival order in = injection order out.
+//!
+//! ## Coalescing and overflow policy
+//!
+//! * **Latest-wins coalescing** applies to *absolute* pointer motion only:
+//!   a `MouseMove` that lands directly behind a still-pending `MouseMove`
+//!   replaces it (both carry absolute coordinates, so the intermediate
+//!   position is redundant). Adjacency is required — an `mm` never jumps
+//!   over a discrete event, so position-at-click semantics are preserved.
+//!   `Scroll` events are **never** coalesced: their `dx`/`dy` are relative
+//!   deltas, and merging two would change the total scroll distance.
+//! * **Overflow** (queue at [`INPUT_QUEUE_SOFT_CAP`]): the oldest
+//!   *continuous* event (`mm`/`sc`) is evicted first — losing stale pointer
+//!   motion or some scroll distance is recoverable by the user, while a
+//!   dropped discrete event (`kd`/`ku`/`md`/`mu`) wedges a key or button.
+//!   If the backlog is entirely discrete, the queue grows past the soft cap
+//!   rather than dropping a discrete event. Producers cannot apply awaited
+//!   backpressure here — both WebRTC lanes push from inside sans-I/O `rtc`
+//!   poll loops whose contract is "never block" (see the `try_send`
+//!   commentary in `webrtc/driver.rs::drain_outputs` and
+//!   `dashboard_control/wire.rs::drain_control_outputs`), so the pressure
+//!   valve is bounded growth instead of an await. [`INPUT_QUEUE_HARD_CAP`]
+//!   is the absolute memory bound: past it the oldest event is dropped
+//!   (loudly) — at that point injection has been wedged for so long that
+//!   the input stream is already lost, and memory safety wins.
+//!
+//! Authority gating stays where it was: each lane's gate runs *before*
+//! `push`, so a refused event never enters the queue (see
+//! [`crate::gated_input_handler`] and the `/ws` + dashboard-control lanes
+//! in the caller).
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::{input_telemetry, DisplayBackend, InputEvent};
+
+/// Target bound for the queue. Sized for multi-second injection stalls at
+/// human input rates (a fast typist plus pointer motion is well under 100
+/// events/sec after `mm` coalescing) without buffering an unbounded flood.
+pub(crate) const INPUT_QUEUE_SOFT_CAP: usize = 256;
+
+/// Absolute bound. Only reachable when the backlog is entirely discrete
+/// events (an all-`kd`/`ku`/`md`/`mu` queue past the soft cap), which
+/// requires an injection backend wedged for tens of seconds or a hostile
+/// flood on an authorized channel. Past this, the oldest event is dropped.
+pub(crate) const INPUT_QUEUE_HARD_CAP: usize = 1024;
+
+/// Minimum interval between overflow log lines (the counters keep exact
+/// totals; the log is a heads-up, not a ledger).
+const DROP_LOG_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Continuous events carry stream-like state (pointer position, scroll
+/// deltas) and are the sacrificial class under overflow. Discrete events
+/// are edge-triggered pairs whose loss wedges input state.
+fn is_continuous(event: &InputEvent) -> bool {
+    matches!(
+        event,
+        InputEvent::MouseMove { .. } | InputEvent::Scroll { .. }
+    )
+}
+
+struct Inner {
+    queue: VecDeque<InputEvent>,
+    closed: bool,
+    coalesced: u64,
+    dropped_continuous: u64,
+    dropped_discrete: u64,
+    last_drop_log: Option<Instant>,
+}
+
+/// Bounded, order-preserving, mm-coalescing input queue. `push` is sync
+/// and non-blocking (callable from the `rtc` data-channel receive path);
+/// [`InputQueue::recv`] is the single-consumer async side.
+pub(crate) struct InputQueue {
+    inner: Mutex<Inner>,
+    notify: tokio::sync::Notify,
+}
+
+impl InputQueue {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                queue: VecDeque::new(),
+                closed: false,
+                coalesced: 0,
+                dropped_continuous: 0,
+                dropped_discrete: 0,
+                last_drop_log: None,
+            }),
+            notify: tokio::sync::Notify::new(),
+        }
+    }
+
+    /// Enqueue one event, preserving arrival order. Never blocks and never
+    /// awaits — safe from sync contexts (the `rtc` poll loops). Events
+    /// pushed after [`InputQueue::close`] are discarded (session teardown).
+    pub(crate) fn push(&self, event: InputEvent) {
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if inner.closed {
+            return;
+        }
+
+        // Latest-wins coalescing: an absolute mouse-move directly behind a
+        // still-pending mouse-move supersedes it. Tail-adjacency only —
+        // never reorders relative to discrete events or scrolls.
+        if matches!(event, InputEvent::MouseMove { .. })
+            && matches!(inner.queue.back(), Some(InputEvent::MouseMove { .. }))
+        {
+            *inner
+                .queue
+                .back_mut()
+                .expect("back() was Some under the same lock") = event;
+            inner.coalesced = inner.coalesced.wrapping_add(1);
+            drop(inner);
+            input_telemetry::record_queue_coalesced();
+            self.notify.notify_one();
+            return;
+        }
+
+        if inner.queue.len() >= INPUT_QUEUE_SOFT_CAP {
+            if let Some(idx) = inner.queue.iter().position(is_continuous) {
+                // Evict the oldest continuous event to make room.
+                inner.queue.remove(idx);
+                inner.dropped_continuous += 1;
+                Self::log_drop_throttled(&mut inner, "an old continuous event");
+                input_telemetry::record_queue_dropped_continuous();
+            } else if is_continuous(&event) {
+                // All-discrete backlog: a new continuous event is the one
+                // thing we may shed while keeping the queue at the soft
+                // cap — the next mm will carry a fresher position anyway.
+                inner.dropped_continuous += 1;
+                Self::log_drop_throttled(&mut inner, "a new continuous event");
+                drop(inner);
+                input_telemetry::record_queue_dropped_continuous();
+                return;
+            } else if inner.queue.len() >= INPUT_QUEUE_HARD_CAP {
+                // Absolute bound (see module docs): drop the oldest event.
+                inner.queue.pop_front();
+                inner.dropped_discrete += 1;
+                Self::log_drop_throttled(&mut inner, "the oldest DISCRETE event");
+                input_telemetry::record_queue_dropped_discrete();
+            }
+            // else: all-discrete backlog under the hard cap — grow past
+            // the soft cap rather than drop a discrete event (the
+            // producers cannot await; see module docs).
+        }
+
+        inner.queue.push_back(event);
+        drop(inner);
+        self.notify.notify_one();
+    }
+
+    /// Await the next event in arrival order. Returns `None` once the
+    /// queue is closed and drained. Single-consumer by design (the pump);
+    /// cancel-safe — an event is only popped when the future completes.
+    pub(crate) async fn recv(&self) -> Option<InputEvent> {
+        loop {
+            // Register interest BEFORE checking state so a push that lands
+            // between the check and the await still wakes us.
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            {
+                let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+                if let Some(event) = inner.queue.pop_front() {
+                    return Some(event);
+                }
+                if inner.closed {
+                    return None;
+                }
+            }
+            notified.as_mut().await;
+        }
+    }
+
+    /// Close the queue: pending events are discarded, in-flight and future
+    /// `push` calls become no-ops, and `recv` returns `None`. Idempotent.
+    pub(crate) fn close(&self) {
+        let mut inner = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        inner.closed = true;
+        inner.queue.clear();
+        drop(inner);
+        self.notify.notify_one();
+    }
+
+    fn log_drop_throttled(inner: &mut Inner, what: &str) {
+        let now = Instant::now();
+        let due = inner
+            .last_drop_log
+            .is_none_or(|last| now.duration_since(last) >= DROP_LOG_INTERVAL);
+        if due {
+            inner.last_drop_log = Some(now);
+            eprintln!(
+                "[display/input-queue] overflow: dropped {what} \
+                 (totals: continuous_dropped={} discrete_dropped={} coalesced={}) — \
+                 input injection is not keeping up",
+                inner.dropped_continuous, inner.dropped_discrete, inner.coalesced,
+            );
+        }
+    }
+
+    /// Test-only snapshot of the queued events' wire tags, in order.
+    #[cfg(test)]
+    pub(crate) fn queued_tags(&self) -> Vec<&'static str> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .queue
+            .iter()
+            .map(InputEvent::wire_tag)
+            .collect()
+    }
+
+    /// Test-only queue length.
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .queue
+            .len()
+    }
+}
+
+/// Spawn the per-session input pump: the single consumer that drains an
+/// [`InputQueue`] and injects each event into `backend`, sequentially, so
+/// injection order equals arrival order. Exits when `shutdown` fires or
+/// the queue closes. Injection failures are logged and do not stop the
+/// pump (matching the previous per-event dispatch behavior on every lane).
+pub(crate) fn spawn_input_pump(
+    queue: Arc<InputQueue>,
+    backend: Arc<dyn DisplayBackend>,
+    shutdown: CancellationToken,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            let event = tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => break,
+                event = queue.recv() => match event {
+                    Some(event) => event,
+                    None => break,
+                },
+            };
+            let kind = event.wire_tag();
+            input_telemetry::record_inject_started(kind);
+            let started = Instant::now();
+            match backend.inject_input(event).await {
+                Ok(()) => input_telemetry::record_inject_completed(started.elapsed()),
+                Err(e) => {
+                    input_telemetry::record_inject_failed(started.elapsed());
+                    eprintln!("[display/input] input injection failed ({kind}): {e}");
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use intendant_core::error::CallerError;
+    use tokio::sync::mpsc;
+
+    fn kd(code: &str) -> InputEvent {
+        InputEvent::KeyDown {
+            code: code.to_string(),
+            key: code.to_string(),
+            shift: false,
+            ctrl: false,
+            alt: false,
+            meta: false,
+        }
+    }
+
+    fn ku(code: &str) -> InputEvent {
+        InputEvent::KeyUp {
+            code: code.to_string(),
+            key: code.to_string(),
+            shift: false,
+            ctrl: false,
+            alt: false,
+            meta: false,
+        }
+    }
+
+    fn mm(x: f64) -> InputEvent {
+        InputEvent::MouseMove {
+            x,
+            y: 0.5,
+            buttons: 0,
+        }
+    }
+
+    fn md() -> InputEvent {
+        InputEvent::MouseDown {
+            x: 0.5,
+            y: 0.5,
+            b: 0,
+        }
+    }
+
+    fn sc(dy: f64) -> InputEvent {
+        InputEvent::Scroll {
+            x: 0.5,
+            y: 0.5,
+            dx: 0.0,
+            dy,
+        }
+    }
+
+    /// Compact identity for order assertions: the wire tag plus the
+    /// distinguishing payload field.
+    fn ident(event: &InputEvent) -> String {
+        match event {
+            InputEvent::KeyDown { code, .. } => format!("kd:{code}"),
+            InputEvent::KeyUp { code, .. } => format!("ku:{code}"),
+            InputEvent::MouseDown { b, .. } => format!("md:{b}"),
+            InputEvent::MouseUp { b, .. } => format!("mu:{b}"),
+            InputEvent::MouseMove { x, .. } => format!("mm:{x}"),
+            InputEvent::Scroll { dy, .. } => format!("sc:{dy}"),
+        }
+    }
+
+    /// Backend that records the identity of every injected event, in
+    /// injection order, onto a channel the test drains.
+    struct RecordingBackend {
+        injected: mpsc::UnboundedSender<String>,
+    }
+
+    #[async_trait::async_trait]
+    impl DisplayBackend for RecordingBackend {
+        async fn start_capture(
+            &self,
+            _fps: u32,
+        ) -> Result<mpsc::Receiver<crate::Frame>, CallerError> {
+            let (_tx, rx) = mpsc::channel(1);
+            Ok(rx)
+        }
+        async fn stop_capture(&self) {}
+        async fn inject_input(&self, event: InputEvent) -> Result<(), CallerError> {
+            // Yield inside the injection so a racy multi-consumer design
+            // (the bug class this module fixes) would interleave events;
+            // the single pump must still deliver strict arrival order.
+            tokio::task::yield_now().await;
+            let _ = self.injected.send(ident(&event));
+            Ok(())
+        }
+        fn resolution(&self) -> (u32, u32) {
+            (64, 64)
+        }
+        fn kind(&self) -> &'static str {
+            "recording"
+        }
+    }
+
+    fn recording_rig() -> (
+        Arc<InputQueue>,
+        CancellationToken,
+        JoinHandle<()>,
+        mpsc::UnboundedReceiver<String>,
+    ) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let queue = Arc::new(InputQueue::new());
+        let shutdown = CancellationToken::new();
+        let pump = spawn_input_pump(
+            Arc::clone(&queue),
+            Arc::new(RecordingBackend { injected: tx }),
+            shutdown.clone(),
+        );
+        (queue, shutdown, pump, rx)
+    }
+
+    async fn drain_n(rx: &mut mpsc::UnboundedReceiver<String>, n: usize) -> Vec<String> {
+        let mut out = Vec::with_capacity(n);
+        for _ in 0..n {
+            let item = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+                .await
+                .expect("timed out waiting for injected event")
+                .expect("recording channel closed early");
+            out.push(item);
+        }
+        out
+    }
+
+    /// F1 core: events pushed in order are injected in order, even though
+    /// each injection awaits (yields) — the exact shape that used to race
+    /// under one-task-per-event dispatch.
+    #[tokio::test]
+    async fn pump_preserves_arrival_order() {
+        let (queue, shutdown, pump, mut rx) = recording_rig();
+
+        let mut expected = Vec::new();
+        for i in 0..50 {
+            let code = format!("K{i}");
+            queue.push(kd(&code));
+            queue.push(ku(&code));
+            expected.push(format!("kd:{code}"));
+            expected.push(format!("ku:{code}"));
+        }
+
+        let got = drain_n(&mut rx, expected.len()).await;
+        assert_eq!(
+            got, expected,
+            "single-pump injection must preserve arrival order exactly"
+        );
+
+        shutdown.cancel();
+        let _ = pump.await;
+    }
+
+    /// Concurrent producers (the three daemon lanes) each keep their own
+    /// relative order: every producer's event sequence must appear as a
+    /// subsequence of the injected stream.
+    #[tokio::test]
+    async fn pump_preserves_per_producer_order_under_concurrent_enqueue() {
+        let (queue, shutdown, pump, mut rx) = recording_rig();
+
+        let producer = |prefix: &'static str, queue: Arc<InputQueue>| async move {
+            let mut sent = Vec::new();
+            for i in 0..40 {
+                let code = format!("{prefix}{i}");
+                queue.push(kd(&code));
+                sent.push(format!("kd:{code}"));
+                tokio::task::yield_now().await;
+            }
+            sent
+        };
+
+        let (sent_a, sent_b) = tokio::join!(
+            tokio::spawn(producer("A", Arc::clone(&queue))),
+            tokio::spawn(producer("B", Arc::clone(&queue))),
+        );
+        let (sent_a, sent_b) = (sent_a.unwrap(), sent_b.unwrap());
+
+        let got = drain_n(&mut rx, sent_a.len() + sent_b.len()).await;
+
+        let is_subsequence = |needle: &[String], hay: &[String]| {
+            let mut it = hay.iter();
+            needle.iter().all(|n| it.any(|h| h == n))
+        };
+        assert!(
+            is_subsequence(&sent_a, &got),
+            "producer A's events must be injected in A's send order"
+        );
+        assert!(
+            is_subsequence(&sent_b, &got),
+            "producer B's events must be injected in B's send order"
+        );
+
+        shutdown.cancel();
+        let _ = pump.await;
+    }
+
+    /// Latest-wins mm coalescing: adjacent pending mouse-moves collapse to
+    /// the newest one; discrete events break adjacency.
+    #[test]
+    fn mouse_moves_coalesce_to_newest_at_tail() {
+        let queue = InputQueue::new();
+        queue.push(kd("KeyA"));
+        queue.push(mm(0.1));
+        queue.push(mm(0.2));
+        queue.push(mm(0.3));
+        queue.push(md());
+        queue.push(mm(0.4));
+
+        assert_eq!(queue.queued_tags(), vec!["kd", "mm", "md", "mm"]);
+        let inner = queue.inner.lock().unwrap();
+        let coords: Vec<String> = inner.queue.iter().map(ident).collect();
+        assert_eq!(
+            coords,
+            vec!["kd:KeyA", "mm:0.3", "md:0", "mm:0.4"],
+            "the surviving mm before the click must be the NEWEST of the \
+             coalesced run, and the mm after the click must not merge \
+             across the discrete event"
+        );
+        assert_eq!(inner.coalesced, 2);
+    }
+
+    /// Scroll deltas are relative — they must never coalesce, or scroll
+    /// distance would be lost.
+    #[test]
+    fn scrolls_never_coalesce() {
+        let queue = InputQueue::new();
+        queue.push(sc(1.0));
+        queue.push(sc(2.0));
+        queue.push(sc(3.0));
+        assert_eq!(queue.queued_tags(), vec!["sc", "sc", "sc"]);
+    }
+
+    /// Overflow drops the OLDEST continuous event first and never a
+    /// discrete one.
+    #[test]
+    fn overflow_evicts_oldest_continuous_first() {
+        let queue = InputQueue::new();
+        // Interleave so no mm-coalescing happens: mm, kd, mm, kd, ...
+        // (each mm is followed by a kd, so no two mms are adjacent).
+        let mut i = 0;
+        while queue.len() < INPUT_QUEUE_SOFT_CAP {
+            queue.push(mm(i as f64));
+            queue.push(kd(&format!("K{i}")));
+            i += 1;
+        }
+        let before = queue.queued_tags();
+        assert_eq!(before.len(), INPUT_QUEUE_SOFT_CAP);
+        assert_eq!(before[0], "mm", "oldest queued event is continuous");
+
+        queue.push(kd("Overflow"));
+
+        let after = queue.queued_tags();
+        assert_eq!(after.len(), INPUT_QUEUE_SOFT_CAP);
+        assert_eq!(
+            after[0], "kd",
+            "the oldest continuous event (front mm) must have been evicted"
+        );
+        let discrete_before = before.iter().filter(|t| **t == "kd").count();
+        let discrete_after = after.iter().filter(|t| **t == "kd").count();
+        assert_eq!(
+            discrete_after,
+            discrete_before + 1,
+            "every discrete event survives overflow"
+        );
+    }
+
+    /// An all-discrete backlog grows past the soft cap instead of dropping
+    /// discrete events, and is memory-bounded by the hard cap.
+    #[test]
+    fn all_discrete_backlog_grows_to_hard_cap_without_discrete_loss() {
+        let queue = InputQueue::new();
+        for i in 0..INPUT_QUEUE_SOFT_CAP + 10 {
+            queue.push(kd(&format!("K{i}")));
+        }
+        assert_eq!(
+            queue.len(),
+            INPUT_QUEUE_SOFT_CAP + 10,
+            "discrete events must not be dropped at the soft cap"
+        );
+        {
+            let inner = queue.inner.lock().unwrap();
+            assert_eq!(inner.dropped_discrete, 0);
+        }
+
+        // A continuous event arriving into an over-cap all-discrete
+        // backlog is shed instead of growing the queue further.
+        queue.push(mm(0.9));
+        assert_eq!(queue.len(), INPUT_QUEUE_SOFT_CAP + 10);
+
+        // Past the hard cap the oldest event goes (memory bound).
+        for i in 0..INPUT_QUEUE_HARD_CAP {
+            queue.push(kd(&format!("H{i}")));
+        }
+        assert_eq!(queue.len(), INPUT_QUEUE_HARD_CAP);
+        let inner = queue.inner.lock().unwrap();
+        assert!(
+            inner.dropped_discrete > 0,
+            "hard cap must have evicted oldest events"
+        );
+    }
+
+    /// close() drains pending events, makes push a no-op, and unblocks the
+    /// consumer with `None`.
+    #[tokio::test]
+    async fn close_unblocks_consumer_and_discards() {
+        let queue = Arc::new(InputQueue::new());
+        queue.push(kd("KeyA"));
+        queue.close();
+        queue.push(kd("KeyB"));
+        assert!(queue.recv().await.is_none());
+
+        // A consumer already parked in recv() is woken by close().
+        let queue2 = Arc::new(InputQueue::new());
+        let waiter = {
+            let queue2 = Arc::clone(&queue2);
+            tokio::spawn(async move { queue2.recv().await })
+        };
+        tokio::task::yield_now().await;
+        queue2.close();
+        let got = tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("recv must unblock after close")
+            .unwrap();
+        assert!(got.is_none());
+    }
+
+    /// The pump exits on shutdown cancellation.
+    #[tokio::test]
+    async fn pump_exits_on_shutdown() {
+        let (queue, shutdown, pump, _rx) = recording_rig();
+        let _ = &queue;
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(5), pump)
+            .await
+            .expect("pump must exit promptly on shutdown")
+            .expect("pump must not panic");
+    }
+}

--- a/crates/intendant-display/src/input_telemetry.rs
+++ b/crates/intendant-display/src/input_telemetry.rs
@@ -51,6 +51,34 @@ pub(crate) fn record_authority_drop(kind: &'static str) {
     telemetry.maybe_report();
 }
 
+pub(crate) fn record_queue_coalesced() {
+    let Some(telemetry) = telemetry() else {
+        return;
+    };
+    telemetry.queue_coalesced.fetch_add(1, Ordering::Relaxed);
+    telemetry.maybe_report();
+}
+
+pub(crate) fn record_queue_dropped_continuous() {
+    let Some(telemetry) = telemetry() else {
+        return;
+    };
+    telemetry
+        .queue_dropped_continuous
+        .fetch_add(1, Ordering::Relaxed);
+    telemetry.maybe_report();
+}
+
+pub(crate) fn record_queue_dropped_discrete() {
+    let Some(telemetry) = telemetry() else {
+        return;
+    };
+    telemetry
+        .queue_dropped_discrete
+        .fetch_add(1, Ordering::Relaxed);
+    telemetry.maybe_report();
+}
+
 pub(crate) fn record_inject_started(kind: &'static str) {
     let Some(telemetry) = telemetry() else {
         return;
@@ -124,6 +152,9 @@ struct InputTelemetry {
     dc_unknown_events: AtomicU64,
     dc_parse_errors: AtomicU64,
     authority_drops: AtomicU64,
+    queue_coalesced: AtomicU64,
+    queue_dropped_continuous: AtomicU64,
+    queue_dropped_discrete: AtomicU64,
     inject_started: AtomicU64,
     inject_ok: AtomicU64,
     inject_err: AtomicU64,
@@ -151,6 +182,9 @@ impl InputTelemetry {
             dc_unknown_events: AtomicU64::new(0),
             dc_parse_errors: AtomicU64::new(0),
             authority_drops: AtomicU64::new(0),
+            queue_coalesced: AtomicU64::new(0),
+            queue_dropped_continuous: AtomicU64::new(0),
+            queue_dropped_discrete: AtomicU64::new(0),
             inject_started: AtomicU64::new(0),
             inject_ok: AtomicU64::new(0),
             inject_err: AtomicU64::new(0),
@@ -196,7 +230,8 @@ impl InputTelemetry {
 
         eprintln!(
             "[display/input-telemetry] dc=control:{}/{}B pointer:{}/{}B unknown:{} parse_err:{} \
-             auth_drop:{} inject=start:{} ok:{} err:{} avg_us:{} max_us:{} \
+             auth_drop:{} queue=coalesced:{} drop_cont:{} drop_disc:{} \
+             inject=start:{} ok:{} err:{} avg_us:{} max_us:{} \
              events=kd:{} ku:{} md:{} mu:{} mm:{} sc:{} \
              macos_post=n:{} avg_us:{} max_us:{}",
             snapshot.dc_control_events,
@@ -206,6 +241,9 @@ impl InputTelemetry {
             snapshot.dc_unknown_events,
             snapshot.dc_parse_errors,
             snapshot.authority_drops,
+            snapshot.queue_coalesced,
+            snapshot.queue_dropped_continuous,
+            snapshot.queue_dropped_discrete,
             snapshot.inject_started,
             snapshot.inject_ok,
             snapshot.inject_err,
@@ -235,6 +273,9 @@ impl InputTelemetry {
             dc_unknown_events: take(&self.dc_unknown_events),
             dc_parse_errors: take(&self.dc_parse_errors),
             authority_drops: take(&self.authority_drops),
+            queue_coalesced: take(&self.queue_coalesced),
+            queue_dropped_continuous: take(&self.queue_dropped_continuous),
+            queue_dropped_discrete: take(&self.queue_dropped_discrete),
             inject_started: take(&self.inject_started),
             inject_ok: take(&self.inject_ok),
             inject_err: take(&self.inject_err),
@@ -261,6 +302,9 @@ struct InputTelemetrySnapshot {
     dc_unknown_events: u64,
     dc_parse_errors: u64,
     authority_drops: u64,
+    queue_coalesced: u64,
+    queue_dropped_continuous: u64,
+    queue_dropped_discrete: u64,
     inject_started: u64,
     inject_ok: u64,
     inject_err: u64,
@@ -284,6 +328,9 @@ impl InputTelemetrySnapshot {
             + self.dc_unknown_events
             + self.dc_parse_errors
             + self.authority_drops
+            + self.queue_coalesced
+            + self.queue_dropped_continuous
+            + self.queue_dropped_discrete
             + self.inject_started
             + self.inject_ok
             + self.inject_err

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -41,6 +41,7 @@ pub mod capture;
 pub mod clipboard;
 pub mod encode;
 pub mod forward;
+pub(crate) mod input_queue;
 pub mod input_telemetry;
 pub mod keymap;
 #[cfg(target_os = "macos")]
@@ -426,6 +427,13 @@ pub struct DisplayMetricsCounters {
     /// Current number of connected WebRTC peers.
     pub peer_count: AtomicU64,
 
+    /// BGRA→I420 conversions performed by the pool-feed bridge. The
+    /// bridge skips conversion entirely while the encoder pool has no
+    /// active (unpaused, subscribed) consumer — this counter is how the
+    /// idle-cost gate is observable (and unit-testable) without exposing
+    /// bridge internals.
+    pub pool_feed_conversions: AtomicU64,
+
     /// Tile-stream damage samples processed in the current metrics window.
     pub tile_damage_samples: AtomicU64,
     /// Total dirty rects reported by the damage source in the current window.
@@ -470,6 +478,7 @@ impl DisplayMetricsCounters {
             encode_freshness_us_sum: AtomicU64::new(0),
             peer_drops: Arc::new(AtomicU64::new(0)),
             peer_count: AtomicU64::new(0),
+            pool_feed_conversions: AtomicU64::new(0),
             tile_damage_samples: AtomicU64::new(0),
             tile_dirty_rects: AtomicU64::new(0),
             tile_dirty_tiles: AtomicU64::new(0),
@@ -747,6 +756,21 @@ pub struct DisplaySession {
     clipboard_monitor: Arc<clipboard::ClipboardMonitor>,
     /// Handle for the clipboard forwarding task (remote -> browser).
     clipboard_handle: Mutex<Option<JoinHandle<()>>>,
+    /// Ordered browser-input queue (see [`input_queue`]). Every browser
+    /// input lane — the WebRTC data channels, the dashboard-control
+    /// tunnel, and the legacy `/ws` socket — enqueues here via
+    /// [`Self::enqueue_input`]; a single pump task drains it so
+    /// injection order equals wire arrival order. Direct
+    /// [`Self::inject_input`] stays available for callers that need
+    /// completion semantics (computer use awaits the injection before
+    /// screenshotting).
+    input_queue: Arc<input_queue::InputQueue>,
+    /// Lazy-spawn guard for the input pump (first enqueue spawns it).
+    input_pump_started: AtomicBool,
+    /// Join handle for the input pump. `std` mutex: taken from the sync
+    /// `enqueue_input` path (spawn) and briefly from async `stop()`
+    /// (join) — never held across an await.
+    input_pump_handle: std::sync::Mutex<Option<JoinHandle<()>>>,
     /// Wakes the pool-feed bridge to open a peer-join burst window
     /// when a new pool peer attaches. `Some` after
     /// [`Self::spawn_pool_feed_bridge`] has run (eagerly from
@@ -1255,6 +1279,9 @@ impl DisplaySession {
             metrics_epoch: Mutex::new(Instant::now()),
             clipboard_monitor: Arc::new(clipboard::ClipboardMonitor::new()),
             clipboard_handle: Mutex::new(None),
+            input_queue: Arc::new(input_queue::InputQueue::new()),
+            input_pump_started: AtomicBool::new(false),
+            input_pump_handle: std::sync::Mutex::new(None),
             pool_feed_keyframe_tx: Mutex::new(None),
             pool: std::sync::OnceLock::new(),
             pool_feed_bridge_handle: Mutex::new(None),
@@ -1762,12 +1789,28 @@ impl DisplaySession {
     pub async fn stop(&self) {
         self.shutdown.cancel();
         self.clipboard_monitor.stop();
+        // Close the input queue so the pump (which also observes the
+        // shutdown token) drains to a deterministic stop and any
+        // late-arriving lane pushes become no-ops.
+        self.input_queue.close();
         self.backend.stop_capture().await;
 
         if let Some(h) = self.capture_handle.lock().await.take() {
             let _ = h.await;
         }
         if let Some(h) = self.clipboard_handle.lock().await.take() {
+            let _ = h.await;
+        }
+        // Input pump: same deterministic-teardown parity as the other
+        // session-owned tasks. The std-mutex guard is dropped before the
+        // await (a held guard across `.await` would be the classic
+        // deadlock-on-poll hazard).
+        let input_pump = self
+            .input_pump_handle
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take();
+        if let Some(h) = input_pump {
             let _ = h.await;
         }
         // 3c.3b.3c-followup: the pool-feed bridge observes
@@ -2175,8 +2218,11 @@ impl DisplaySession {
             ))
         })?;
 
+        // Input flows through the session's ordered queue (F1): the
+        // handler gates then pushes; the pump injects in arrival order.
+        self.ensure_input_pump();
         let input_handler =
-            gated_input_handler(Arc::clone(&self.backend), input_authorized.clone());
+            gated_input_handler(Arc::clone(&self.input_queue), input_authorized.clone());
 
         let clipboard_monitor = Arc::clone(&self.clipboard_monitor);
         let clipboard_handler: Arc<dyn Fn(clipboard::ClipboardContent) + Send + Sync> =
@@ -2647,6 +2693,19 @@ impl DisplaySession {
     /// re-pushes the latest frame once per second so the encoder's
     /// GOP cadence keeps producing decodable references.
     ///
+    /// **Demand gate (F2, 2026-07-13 display review).** BGRA→I420
+    /// conversion only runs while the pool has an **active consumer**
+    /// ([`EncoderPool::has_active_consumer`](crate::encode::pool::EncoderPool::has_active_consumer):
+    /// an unpaused always-on layer or a subscribed on-demand encoder)
+    /// or a peer-join burst window is open. With zero viewers the
+    /// presence policy pauses every layer, and the bridge then reduces
+    /// to an `Arc` stash per captured frame — an agent-only session no
+    /// longer pays full-resolution conversion at capture rate for a
+    /// stream nobody decodes. The newest unconverted frame is retained
+    /// (`pending_bgra`), so the first tick after a viewer joins
+    /// converts on demand and forwards immediately; heartbeat and
+    /// burst behavior above are unchanged whenever demand exists.
+    ///
     /// **Peer-join burst channel.** The bridge listens on
     /// `pool_feed_keyframe_tx` and opens a 1.5s burst window when
     /// signaled. Required because `force_keyframe` on a long-running
@@ -2713,6 +2772,10 @@ impl DisplaySession {
         // peer-join can wait many seconds for a natural GOP boundary.
         let (kf_tx, mut kf_rx) = mpsc::unbounded_channel::<()>();
         *self.pool_feed_keyframe_tx.lock().await = Some(kf_tx);
+        // Conversion-count telemetry for the idle gate (F2, 2026-07-13
+        // display review): lets tests (and operators) observe that no
+        // BGRA→I420 work happens while the pool has no active consumer.
+        let counters = Arc::clone(&self.counters);
         let task = tokio::spawn(async move {
             // Heartbeat cadence. 1 second strikes the balance
             // between "encoder stays healthy on idle" and "encoder
@@ -2733,6 +2796,16 @@ impl DisplaySession {
             // instead of the `Vec<u8>` clone the simpler
             // pre-3c.3b.3b-followup version did.
             let mut latest_i420: Option<(Arc<Vec<u8>>, Instant)> = None;
+            // F2 (2026-07-13 display review): the newest BGRA that has
+            // NOT been converted yet. Frames land here on arrival (a
+            // cheap `Arc` stash, latest-wins) and are converted in the
+            // tick arm ONLY when the pool has an active consumer (an
+            // unpaused always-on layer, a subscribed on-demand encoder,
+            // or an open peer-join burst window). An agent-only session
+            // whose layers the presence policy paused therefore pays
+            // zero conversion cost at capture rate, while the retained
+            // frame still seeds the first post-join push immediately.
+            let mut pending_bgra: Option<(Arc<Frame>, Instant)> = None;
             // `generation` bumps on every replacement; `last_sent_gen`
             // is what we last forwarded. Mismatch = "buffer changed
             // since last send" (i.e. real damage on a damage-driven
@@ -2748,14 +2821,15 @@ impl DisplaySession {
             // `PEER_JOIN_BURST` past the deadline.
             let mut burst_until: Option<Instant> = None;
 
-            // 3c.3b.3c-followup seed: convert the most recent BGRA
-            // the capture has already produced (if any) so the first
-            // tick has something to push even if no new BGRA arrives
-            // before the heartbeat. Closes the "first pool peer
-            // arrives after the capture went idle" black-screen path.
-            // Bumps `generation`; the very first tick sees
-            // `last_sent_gen=None != Some(1)` → forwards immediately,
-            // not waiting for IDLE_HEARTBEAT.
+            // 3c.3b.3c-followup seed: stash the most recent BGRA the
+            // capture has already produced (if any) so the first
+            // demand-tick has something to convert and push even if no
+            // new BGRA arrives before the heartbeat. Closes the "first
+            // pool peer arrives after the capture went idle"
+            // black-screen path. Since the F2 idle gate, the seed does
+            // NOT convert eagerly — the first tick with an active pool
+            // consumer converts it (`pending` → `changed` → forwarded
+            // immediately, not waiting for IDLE_HEARTBEAT).
             //
             // enc_w/enc_h are also seeded from the snapshotted
             // frame's actual dimensions. Without that, the first
@@ -2801,35 +2875,7 @@ impl DisplaySession {
                             });
                         }
                     }
-                    let frame_arc = Arc::clone(&frame);
-                    let arrived = Instant::now();
-                    // Pass NORMALIZED dims (frame_w / frame_h, computed
-                    // above with `& !1`) instead of raw frame.width /
-                    // frame.height. Odd raw dims would produce odd-dim
-                    // I420 from `bgra_to_i420`'s ceil-chroma sizing,
-                    // which then hits the layer-encode `downscale_i420`
-                    // path with an unencodable source layout (downscale
-                    // requires even source AND dest). The pool was
-                    // constructed at the same normalized dims, so
-                    // passing odd here would also be a bridge↔pool
-                    // dimension desync (silent black-screen class).
-                    // Cropping the rightmost column / bottom row at
-                    // this stage is invisible at display.
-                    let i420_result = tokio::task::spawn_blocking({
-                        move || {
-                            convert_for_pool_feed(
-                                &frame_arc.data,
-                                frame_w,
-                                frame_h,
-                                frame_arc.stride,
-                            )
-                        }
-                    })
-                    .await;
-                    if let Ok(i420) = i420_result {
-                        generation = generation.wrapping_add(1);
-                        latest_i420 = Some((Arc::new(i420), arrived));
-                    }
+                    pending_bgra = Some((frame, Instant::now()));
                 }
             }
 
@@ -2887,38 +2933,79 @@ impl DisplaySession {
                             }
                             enc_w = frame_w;
                             enc_h = frame_h;
-                            // Drop stale buffer: it's at the old
+                            // Drop stale buffers: they're at the old
                             // dimensions; pool's encoders have already
                             // been respawned by `pool.on_resize` and
                             // would either reject or mis-encode an
-                            // old-dim frame.
+                            // old-dim frame. (`pending_bgra` is about
+                            // to be replaced by this frame anyway.)
                             latest_i420 = None;
                             last_sent_gen = None;
                         }
 
-                        let frame_arc = Arc::clone(&frame);
-                        let arrived = Instant::now();
-                        // Same normalized-dims rationale as the seed
-                        // path above: pass `frame_w` / `frame_h`
-                        // (rounded to even with `& !1` at the top of
-                        // this branch) so I420 dims match what
-                        // `downscale_i420` and the pool's encoders
-                        // expect.
-                        let i420_result = tokio::task::spawn_blocking({
-                            move || convert_for_pool_feed(
-                                &frame_arc.data,
-                                frame_w,
-                                frame_h,
-                                frame_arc.stride,
-                            )
-                        })
-                        .await;
-                        if let Ok(i420) = i420_result {
-                            generation = generation.wrapping_add(1);
-                            latest_i420 = Some((Arc::new(i420), arrived));
-                        }
+                        // F2 idle gate: do NOT convert here. Stash the
+                        // frame (cheap Arc clone, latest-wins) and let
+                        // the tick arm convert it if — and only if —
+                        // the pool has an active consumer then. This
+                        // is what makes a zero-viewer session's
+                        // conversion cost zero at capture rate, and it
+                        // also naturally caps conversion at tick rate
+                        // when a backend captures faster than the
+                        // bridge forwards.
+                        pending_bgra = Some((frame, Instant::now()));
                     }
                     _ = tick.tick() => {
+                        // F2 demand gate: everything downstream of this
+                        // point exists to feed encoders. When the pool
+                        // has no active consumer — every always-on
+                        // layer paused by the presence policy and no
+                        // subscribed on-demand encoder — and no
+                        // peer-join burst is open, skip the tick
+                        // entirely: no conversion, no push. The stashed
+                        // `pending_bgra` (and `latest_frame` upstream)
+                        // keeps the newest content ready, so the first
+                        // tick after demand returns converts on the
+                        // spot and forwards immediately. The burst
+                        // window counts as demand on its own because
+                        // the peer-join signal can beat the layer
+                        // coordinator's resume vote by up to one poll
+                        // interval — the burst pushes keep the encoder
+                        // clocked through that gap exactly as before.
+                        let in_burst = burst_until
+                            .is_some_and(|u| Instant::now() < u);
+                        if !in_burst && !pool.has_active_consumer() {
+                            continue;
+                        }
+
+                        // Convert the newest stashed BGRA, if any.
+                        // Same normalized-dims rationale as always:
+                        // pass even dims so I420 dims match what
+                        // `downscale_i420` and the pool's encoders
+                        // expect (odd raw dims would produce odd-dim
+                        // I420 from `bgra_to_i420`'s ceil-chroma
+                        // sizing; cropping the rightmost column /
+                        // bottom row is invisible at display).
+                        if let Some((frame, arrived)) = pending_bgra.take() {
+                            let frame_w = frame.width & !1;
+                            let frame_h = frame.height & !1;
+                            let i420_result = tokio::task::spawn_blocking(
+                                move || convert_for_pool_feed(
+                                    &frame.data,
+                                    frame_w,
+                                    frame_h,
+                                    frame.stride,
+                                )
+                            )
+                            .await;
+                            if let Ok(i420) = i420_result {
+                                counters
+                                    .pool_feed_conversions
+                                    .fetch_add(1, Ordering::Relaxed);
+                                generation = generation.wrapping_add(1);
+                                latest_i420 = Some((Arc::new(i420), arrived));
+                            }
+                        }
+
                         // Forward latest_i420 if anything's worth
                         // forwarding. "Worth forwarding" = a fresher
                         // buffer than last sent, OR the heartbeat is
@@ -2938,8 +3025,6 @@ impl DisplaySession {
                         let changed = last_sent_gen != Some(generation);
                         let heartbeat_due =
                             last_send_at.elapsed() >= IDLE_HEARTBEAT;
-                        let in_burst = burst_until
-                            .is_some_and(|u| Instant::now() < u);
                         if !(changed || heartbeat_due || in_burst) {
                             continue;
                         }
@@ -2977,14 +3062,22 @@ impl DisplaySession {
     /// Ensure a clipboard forwarding task is running.
     ///
     /// Starts watching the system clipboard and forwards changes to all
-    /// connected peers via their clipboard data channel.
+    /// connected peers via their clipboard data channel. The monitor's
+    /// polling is gated on this session's `peer_count` gauge (the same
+    /// attach/reap-maintained signal the presence policy's peers map
+    /// mirrors), so a session whose viewers have all left stops paying
+    /// the per-500ms clipboard subprocess tax until the next peer joins
+    /// (F3, 2026-07-13 display review).
     async fn ensure_clipboard_forwarding(&self) {
         let mut handle = self.clipboard_handle.lock().await;
         if handle.is_some() {
             return; // already running
         }
 
-        let mut rx = self.clipboard_monitor.start_watching();
+        let peer_gauge = Arc::clone(&self.counters);
+        let mut rx = self.clipboard_monitor.start_watching(Arc::new(move || {
+            peer_gauge.peer_count.load(Ordering::Relaxed) > 0
+        }));
         let peers = Arc::clone(&self.peers);
         let shutdown = self.shutdown.clone();
 
@@ -3075,9 +3168,51 @@ impl DisplaySession {
         self.peers.read().await.get(&peer_id).cloned()
     }
 
-    /// Inject an input event into the display backend.
+    /// Inject an input event into the display backend, awaiting its
+    /// completion.
+    ///
+    /// This is the **synchronous-completion** path: the event is injected
+    /// before the future resolves, so a caller can act on the result
+    /// (computer use clicks then screenshots). Browser input lanes must
+    /// use [`Self::enqueue_input`] instead — calling this concurrently
+    /// from per-event tasks is exactly the ordering race the input queue
+    /// exists to fix.
     pub async fn inject_input(&self, event: InputEvent) -> Result<(), CallerError> {
         self.backend.inject_input(event).await
+    }
+
+    /// Enqueue a browser input event onto this session's ordered input
+    /// queue (fire-and-forget). Sync and non-blocking — callable from the
+    /// `rtc` data-channel receive path and the `/ws` read loop without
+    /// stalling them. A single pump task injects queued events strictly
+    /// in arrival order; see [`input_queue`] for the coalescing and
+    /// overflow policy. Injection failures are logged by the pump.
+    ///
+    /// Authority gating is the caller's job (each lane gates before
+    /// enqueue), matching the pre-queue convention.
+    ///
+    /// Must be called from within a tokio runtime (all input lanes are);
+    /// the first call spawns the pump.
+    pub fn enqueue_input(&self, event: InputEvent) {
+        self.ensure_input_pump();
+        self.input_queue.push(event);
+    }
+
+    /// Spawn the input pump exactly once. Sync (used from the sync
+    /// enqueue path); requires a tokio runtime context.
+    fn ensure_input_pump(&self) {
+        if self.input_pump_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let handle = input_queue::spawn_input_pump(
+            Arc::clone(&self.input_queue),
+            Arc::clone(&self.backend),
+            self.shutdown.clone(),
+        );
+        *self
+            .input_pump_handle
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = Some(handle);
     }
 
     /// Inject literal text into the display backend.
@@ -3205,22 +3340,29 @@ impl SessionRegistry {
 ///
 /// 1. consults the `input_authorized` closure (Phase 5a.1 gate) and
 ///    silently drops the event if it returns `false`;
-/// 2. otherwise spawns the existing async `inject_input` dispatch onto
-///    the tokio runtime.
+/// 2. otherwise pushes the event onto the session's ordered
+///    [`input_queue::InputQueue`], whose single pump task injects
+///    events strictly in arrival order.
+///
+/// The push replaces the previous per-event `tokio::spawn`: the browser
+/// sends `kd`/`ku`/`md`/`mu` over reliable **ordered** channels, and
+/// one-task-per-event racing across runtime workers could invert
+/// adjacent events (stuck-auto-repeat keys, scrambled clicks) — the
+/// 2026-07-13 display-review F1 class. The caller is responsible for
+/// having the pump running ([`DisplaySession::handle_offer_pool_mode`]
+/// calls `ensure_input_pump` before building the handler).
 ///
 /// Extracted so the gate logic is unit-testable without standing up a
 /// full `DisplaySession` + `WebRtcPeer` + offer.  Keeping it free-
 /// standing rather than a method on `DisplaySession` means tests can
-/// build it from any backend stub in the test module without going
-/// through the offer plumbing.
+/// build it from any queue in the test module without going through
+/// the offer plumbing.
 ///
 /// The closure is `Arc<dyn Fn(InputEvent) + Send + Sync>`, sync-callable
-/// from rtc's data-channel receive context (which is sync); the async
-/// injection is `tokio::spawn`-ed because `DisplayBackend::inject_input`
-/// is async.  This shape predates phase 5a.1 — the gate just sits in
-/// front of it.
+/// from rtc's data-channel receive context (which is sync); the queue
+/// push is sync and non-blocking, so the rtc poll loop is never stalled.
 pub(crate) fn gated_input_handler(
-    backend: Arc<dyn DisplayBackend>,
+    queue: Arc<input_queue::InputQueue>,
     input_authorized: Arc<dyn Fn() -> bool + Send + Sync>,
 ) -> Arc<dyn Fn(InputEvent) + Send + Sync> {
     Arc::new(move |event: InputEvent| {
@@ -3232,22 +3374,13 @@ pub(crate) fn gated_input_handler(
         // `display_input_authority_state` notification).  Unclaimed
         // and "this peer holds it" both resolve to `true` — see the
         // closure builder in `web_gateway::spawn_web_gateway`.
+        // Gating happens BEFORE enqueue, so a refused event never
+        // enters the queue.
         if !input_authorized() {
             input_telemetry::record_authority_drop(kind);
             return;
         }
-        input_telemetry::record_inject_started(kind);
-        let backend = Arc::clone(&backend);
-        tokio::spawn(async move {
-            let started = std::time::Instant::now();
-            match backend.inject_input(event).await {
-                Ok(()) => input_telemetry::record_inject_completed(started.elapsed()),
-                Err(e) => {
-                    input_telemetry::record_inject_failed(started.elapsed());
-                    eprintln!("[display] input injection failed: {e}");
-                }
-            }
-        });
+        queue.push(event);
     })
 }
 
@@ -5053,6 +5186,92 @@ mod tests {
         session.shutdown.cancel();
     }
 
+    /// **F2 regression test (2026-07-13 display review).** With zero
+    /// viewers — every pool layer paused, no on-demand subscription —
+    /// the pool-feed bridge must not convert BGRA→I420 at all (pre-fix
+    /// it converted every captured frame at full resolution forever),
+    /// yet it must retain the newest BGRA so a joining viewer is seeded
+    /// by an on-demand conversion without waiting for new capture
+    /// activity. Observable via the `pool_feed_conversions` counter.
+    ///
+    /// VP8-specific (gated off Windows) like the other bridge tests:
+    /// subscribes with a VP8 preference to observe encoded output.
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn pool_feed_bridge_skips_conversion_without_active_consumer() {
+        let backend = Arc::new(StubBackend {
+            width: 64,
+            height: 64,
+        });
+        let session = DisplaySession::new(0, backend);
+        // Deliberately NO peer registered: the session starts viewerless.
+        session
+            .start(30, None, None)
+            .await
+            .expect("start must succeed");
+
+        let pool = session.pool.get().expect("pool initialized after start");
+        // Reach the zero-viewer steady state deterministically (the
+        // layer coordinator converges here on its own at zero peers;
+        // pausing manually removes the poll-interval race): every
+        // always-on layer paused.
+        for id in pool.always_on_ids() {
+            assert!(pool.pause_layer(id.codec, id.rid));
+        }
+
+        // Capture keeps producing while nobody watches.
+        for _ in 0..4 {
+            let _ = session.frame_tx.send(Arc::new(make_test_bgra(64, 64)));
+            tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+        }
+        // Sit past the 1s idle heartbeat: pre-F2 the bridge converted
+        // every arriving frame AND kept heartbeat-pushing.
+        tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
+        assert_eq!(
+            session
+                .counters
+                .pool_feed_conversions
+                .load(Ordering::Relaxed),
+            0,
+            "no BGRA→I420 conversion may run while the pool has no \
+             active consumer"
+        );
+
+        // A viewer joins: model the real sequence — peer registered
+        // (so the layer coordinator keeps demand up once it polls),
+        // subscription taken, layers resumed. The retained BGRA must
+        // convert on demand and reach the encoder with NO new capture
+        // activity.
+        register_test_peer_demanding_all_layers(&session).await;
+        let prefs = encode::pool::PeerCodecPreferences::new(vec![encode::pool::CodecKind::Vp8]);
+        let (subs, _lease) = pool.subscribe(&prefs).expect("VP8 always-on subscribe");
+        let mut frame_rx = subs
+            .into_iter()
+            .next()
+            .expect("at least one subscription")
+            .frames;
+        for id in pool.always_on_ids() {
+            assert!(pool.resume_layer(id.codec, id.rid));
+        }
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), frame_rx.recv()).await;
+        assert!(
+            result.is_ok() && result.as_ref().unwrap().is_ok(),
+            "the retained frame must be converted on demand and encoded \
+             once a consumer exists — got timeout/recv error within 2s"
+        );
+        assert!(
+            session
+                .counters
+                .pool_feed_conversions
+                .load(Ordering::Relaxed)
+                >= 1,
+            "demand-return must trigger the deferred conversion"
+        );
+
+        session.shutdown.cancel();
+    }
+
     /// `signal_peer_join_burst` must send `()` on
     /// `pool_feed_keyframe_tx` whenever the channel is installed.
     /// Pins the contract that `handle_offer_pool_mode`'s tail relies
@@ -5153,19 +5372,48 @@ mod tests {
         }
     }
 
+    /// Build the queue + pump rig the production offer path assembles
+    /// (`ensure_input_pump` + `gated_input_handler`), against an
+    /// injection-counting backend. Returns the pieces tests need.
+    #[allow(clippy::type_complexity)] // test-rig tuple, not a production type
+    fn gated_handler_rig(
+        counter: &Arc<std::sync::atomic::AtomicU64>,
+        input_authorized: Arc<dyn Fn() -> bool + Send + Sync>,
+    ) -> (
+        Arc<dyn Fn(InputEvent) + Send + Sync>,
+        Arc<input_queue::InputQueue>,
+        CancellationToken,
+    ) {
+        let backend: Arc<dyn DisplayBackend> = Arc::new(InjectCountingBackend {
+            width: 64,
+            height: 64,
+            inject_count: Arc::clone(counter),
+        });
+        let queue = Arc::new(input_queue::InputQueue::new());
+        let shutdown = CancellationToken::new();
+        let _pump = input_queue::spawn_input_pump(Arc::clone(&queue), backend, shutdown.clone());
+        let handler = super::gated_input_handler(Arc::clone(&queue), input_authorized);
+        (handler, queue, shutdown)
+    }
+
+    /// Give the pump a chance to drain the queue before asserting.
+    /// Yield several times to defeat the single-poll-then-check race
+    /// that a single yield_now occasionally exhibits under heavy
+    /// multi-test contention.
+    async fn settle_pump() {
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+
     /// Closure returns `true` → events reach `inject_input`.  This is
     /// the unclaimed-or-this-peer-holds-it case from the per-`/ws`
     /// closure builder; both resolve to `true` there.
     #[tokio::test]
     async fn gated_input_handler_passes_event_when_authorized() {
         let counter = Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let backend: Arc<dyn DisplayBackend> = Arc::new(InjectCountingBackend {
-            width: 64,
-            height: 64,
-            inject_count: Arc::clone(&counter),
-        });
-        let input_authorized: Arc<dyn Fn() -> bool + Send + Sync> = Arc::new(|| true);
-        let handler = super::gated_input_handler(Arc::clone(&backend), input_authorized);
+        let (handler, _queue, shutdown) = gated_handler_rig(&counter, Arc::new(|| true));
 
         handler(InputEvent::MouseMove {
             x: 0.5,
@@ -5173,39 +5421,26 @@ mod tests {
             buttons: 0,
         });
 
-        // The handler `tokio::spawn`s the async injection — give the
-        // runtime a chance to run the spawned task before asserting.
-        // Yield twice to defeat the single-poll-then-check race that a
-        // single yield_now occasionally exhibits under heavy multi-test
-        // contention; if the spawned future has been polled to
-        // completion and pumped through any pending wakers, the counter
-        // increment is visible.
-        for _ in 0..8 {
-            tokio::task::yield_now().await;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        settle_pump().await;
         assert_eq!(
             counter.load(std::sync::atomic::Ordering::SeqCst),
             1,
             "authorized event should reach the backend"
         );
+        shutdown.cancel();
     }
 
     /// Closure returns `false` → events are silently dropped, matching
     /// the `/ws display_input` gate convention (no per-message denial
     /// feedback).  This is the "another connection holds the slot"
     /// case, plus the federated deny-by-default until federation
-    /// authority lands as its own slice.
+    /// authority lands as its own slice.  With the ordered queue, the
+    /// gate runs BEFORE enqueue — a refused event must never even
+    /// enter the queue.
     #[tokio::test]
     async fn gated_input_handler_drops_event_when_unauthorized() {
         let counter = Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let backend: Arc<dyn DisplayBackend> = Arc::new(InjectCountingBackend {
-            width: 64,
-            height: 64,
-            inject_count: Arc::clone(&counter),
-        });
-        let input_authorized: Arc<dyn Fn() -> bool + Send + Sync> = Arc::new(|| false);
-        let handler = super::gated_input_handler(Arc::clone(&backend), input_authorized);
+        let (handler, queue, shutdown) = gated_handler_rig(&counter, Arc::new(|| false));
 
         handler(InputEvent::MouseMove {
             x: 0.5,
@@ -5221,62 +5456,55 @@ mod tests {
             meta: false,
         });
 
-        for _ in 0..8 {
-            tokio::task::yield_now().await;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert_eq!(queue.len(), 0, "gate-refused events must never be enqueued");
+        settle_pump().await;
         assert_eq!(
             counter.load(std::sync::atomic::Ordering::SeqCst),
             0,
             "unauthorized events must not reach the backend at all"
         );
+        shutdown.cancel();
     }
 
     /// The closure can change its decision over time — required for
     /// the live grant/release flow, where the same `WebRtcPeer` lives
     /// across multiple authority transitions.  Verifies the gate reads
     /// fresh state on each event, not a captured snapshot.
+    ///
+    /// Uses discrete key events: mouse-moves are latest-wins coalesced
+    /// by the queue when adjacent, which would make the injected count
+    /// scheduling-dependent here; key events are never coalesced.
     #[tokio::test]
     async fn gated_input_handler_re_evaluates_authorization_per_event() {
         let counter = Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let backend: Arc<dyn DisplayBackend> = Arc::new(InjectCountingBackend {
-            width: 64,
-            height: 64,
-            inject_count: Arc::clone(&counter),
-        });
         let allow = Arc::new(AtomicBool::new(true));
         let allow_for_closure = Arc::clone(&allow);
         let input_authorized: Arc<dyn Fn() -> bool + Send + Sync> =
             Arc::new(move || allow_for_closure.load(std::sync::atomic::Ordering::SeqCst));
-        let handler = super::gated_input_handler(Arc::clone(&backend), input_authorized);
+        let (handler, _queue, shutdown) = gated_handler_rig(&counter, input_authorized);
 
-        handler(InputEvent::MouseMove {
-            x: 0.0,
-            y: 0.0,
-            buttons: 0,
-        });
+        let key = |code: &str| InputEvent::KeyDown {
+            code: code.into(),
+            key: code.into(),
+            shift: false,
+            ctrl: false,
+            alt: false,
+            meta: false,
+        };
+
+        handler(key("KeyA"));
         allow.store(false, std::sync::atomic::Ordering::SeqCst);
-        handler(InputEvent::MouseMove {
-            x: 0.1,
-            y: 0.1,
-            buttons: 0,
-        });
+        handler(key("KeyB"));
         allow.store(true, std::sync::atomic::Ordering::SeqCst);
-        handler(InputEvent::MouseMove {
-            x: 0.2,
-            y: 0.2,
-            buttons: 0,
-        });
+        handler(key("KeyC"));
 
-        for _ in 0..8 {
-            tokio::task::yield_now().await;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        settle_pump().await;
         assert_eq!(
             counter.load(std::sync::atomic::Ordering::SeqCst),
             2,
             "gate must check authorization on every event, not at construction time"
         );
+        shutdown.cancel();
     }
 
     // -----------------------------------------------------------------------

--- a/docs/src/display-pipeline.md
+++ b/docs/src/display-pipeline.md
@@ -136,7 +136,14 @@ requires every active policy to agree**:
 
 - **Presence policy** — pauses all layers after the display sits at zero peers
   for a 5 s debounce (absorbs browser refreshes and federation reconnect blips),
-  resumes on the first peer.
+  resumes on the first peer. The pool-feed bridge keys its **conversion idle
+  gate** off the resulting pool state: while the pool has no active consumer
+  (no unpaused always-on layer, no subscribed on-demand encoder) and no
+  peer-join burst window is open, the bridge skips BGRA→I420 conversion
+  entirely — an agent-only session retains only the newest captured frame
+  (cheap `Arc` stash) instead of converting at capture rate for a stream
+  nobody decodes, and the first tick after a viewer joins converts that
+  retained frame on demand.
 - **Aggregate-TWCC policy** — per-peer cascaded loss. On sustained packet loss it
   pauses the top layer first, then the middle, reversing on recovery. This is the
   actionable signal source on the current `rtc` 0.9 + WKWebView stack.
@@ -366,6 +373,33 @@ synthetic backends in CI, and each real OS backend has an `#[ignore]`d
 start/stop stress test for operator hardware
 (`cargo test -p intendant-display --lib -- --ignored real_capture_stress`).
 
+## Remote Input Path
+
+Browser keyboard/mouse events (`kd`/`ku`/`md`/`mu`/`mm`/`sc` — key and mouse
+button edges, absolute mouse moves, relative scroll deltas) reach the daemon on
+three lanes: the per-peer WebRTC data channels (`control`/`pointer`, reliable
+and ordered), the dashboard-control tunnel (hosted Connect), and the legacy
+`/ws` gateway socket. All three converge on a **per-display-session ordered
+input queue** (`crates/intendant-display/src/input_queue.rs`): each lane's
+authority gate runs first (a refused event never enqueues), the enqueue is a
+sync non-blocking push (the two WebRTC lanes push from inside sans-I/O `rtc`
+poll loops that must never block), and a **single pump task per session**
+drains the queue, awaiting each injection to completion before the next —
+so injection order always equals wire arrival order. (The pre-queue design
+dispatched one `tokio::spawn` per event, which could reorder adjacent events
+under load — a `kd`/`ku` inversion presents as a stuck auto-repeating key.)
+
+The queue coalesces **adjacent** pending mouse-moves latest-wins (both carry
+absolute coordinates; an `mm` never jumps over a discrete event, preserving
+position-at-click semantics). Scroll events are never coalesced — their
+deltas are relative, and merging would change total scroll distance. On
+overflow (soft cap 256) the oldest *continuous* event (`mm`/`sc`) is evicted
+first; discrete events are never sacrificed for continuous ones — an
+all-discrete backlog instead grows to a hard cap (1024) before the oldest
+event is dropped loudly. Computer-use actions bypass the queue via
+`DisplaySession::inject_input`, which awaits completion (a CU click must be
+injected before the follow-up screenshot).
+
 > **Browser input is physical-key-only (Phase 1).** Injected key events use the
 > DOM `code` field (physical key position), not `key`. Non-US keyboard layouts
 > therefore produce incorrect character output until a future phase adds
@@ -379,6 +413,10 @@ The `ClipboardMonitor` (`display/clipboard.rs`) polls the system clipboard every
 supports text and images (PNG, capped at 5 MB). On copy in the browser, content is
 pushed to the display's clipboard; on copy in the display, content is pushed to
 the browser. The per-platform read/write tools are listed in the matrix above.
+Polling is **gated on viewer presence**: with zero connected peers each tick is
+a no-op (no `pbpaste`/`osascript`/`xclip`/`wl-paste` subprocess is spawned for a
+sync nobody receives), and content that changed during the pause is re-baselined
+silently on resume rather than replayed to the next viewer.
 
 ## Multi-Monitor
 

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -197,6 +197,7 @@ pub(crate) fn control_frame_response(
     inbound_uploads: &mut HashMap<String, InboundUploadState>,
     terminal_events_tx: &mpsc::UnboundedSender<serde_json::Value>,
     terminal_forwarders: &mut HashMap<(String, String), tokio::task::JoinHandle<()>>,
+    display_input_tx: &mpsc::UnboundedSender<serde_json::Value>,
 ) -> Option<serde_json::Value> {
     let parsed: serde_json::Value = serde_json::from_str(text).ok()?;
     let t = parsed.get("t").and_then(|v| v.as_str()).unwrap_or("");
@@ -236,7 +237,12 @@ pub(crate) fn control_frame_response(
             "unix_ms": chrono::Utc::now().timestamp_millis(),
         })),
         "display_input" => {
-            spawn_dashboard_display_input(parsed, runtime.clone());
+            // Ordered handoff to the per-connection forwarder (see
+            // `spawn_display_input_forwarder`): the wire loop dispatches
+            // frames sequentially and this send preserves that order —
+            // never a per-event spawn, which would race events across
+            // runtime workers and could invert kd/ku or md/mu pairs.
+            let _ = display_input_tx.send(parsed);
             None
         }
         "terminal_open" => {
@@ -2024,42 +2030,81 @@ pub(crate) async fn dashboard_async_query(frame: serde_json::Value, runtime: Con
     );
 }
 
-pub(crate) fn spawn_dashboard_display_input(frame: serde_json::Value, runtime: ControlRuntime) {
+/// Spawn the per-connection display-input forwarder (F1, 2026-07-13
+/// display review): ONE task per control connection that consumes
+/// `display_input` frames from an ordered channel and routes each to the
+/// display session's ordered input queue.
+///
+/// The previous shape — one `tokio::spawn` per input event — discarded
+/// the data channel's wire ordering: two spawned tasks race across
+/// runtime workers, and a `kd`/`ku` or `md`/`mu` inversion wedges a key
+/// or scrambles a click (the window widens under host load). The wire
+/// loop (`drain_control_outputs`) dispatches frames sequentially, its
+/// `unbounded_send` into this channel preserves that order, and the
+/// single consumer here preserves it into `enqueue_input` — whose
+/// per-session pump preserves it into the backend.
+///
+/// The forwarder ends when the wire loop drops the sender (connection
+/// teardown) or the shared shutdown token fires.
+pub(crate) fn spawn_display_input_forwarder(
+    runtime: ControlRuntime,
+    shutdown: CancellationToken,
+) -> mpsc::UnboundedSender<serde_json::Value> {
+    let (tx, mut rx) = mpsc::unbounded_channel::<serde_json::Value>();
     tokio::spawn(async move {
-        let display_id = frame
-            .get("display_id")
-            .and_then(|value| value.as_u64())
-            .and_then(|value| u32::try_from(value).ok())
-            .unwrap_or(0);
-        let Some(event) = frame.get("event").cloned() else {
-            return;
-        };
-        let Ok(input_event) = serde_json::from_value::<crate::display::InputEvent>(event) else {
-            return;
-        };
-        let Some(bridge) = runtime.display_authority.as_ref() else {
-            return;
-        };
-        if !bridge.input_authorized(&runtime.session_id, display_id) {
-            return;
-        }
-        let session_registry = {
-            let session = runtime.shared_session.read().await;
-            session.session_registry.clone()
-        };
-        let Some(session_registry) = session_registry else {
-            return;
-        };
-        let display_session = {
-            let registry = session_registry.read().await;
-            registry.get(display_id)
-        };
-        if let Some(display_session) = display_session {
-            if let Err(e) = display_session.inject_input(input_event).await {
-                eprintln!("[dashboard/control] display input injection failed: {e}");
-            }
+        loop {
+            let frame = tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => break,
+                frame = rx.recv() => match frame {
+                    Some(frame) => frame,
+                    None => break,
+                },
+            };
+            forward_dashboard_display_input(frame, &runtime).await;
         }
     });
+    tx
+}
+
+/// Route one `display_input` frame: parse, authority-gate, resolve the
+/// display session, and enqueue onto its ordered input queue. Gating
+/// happens before enqueue (per-event, so authority revocation applies to
+/// every later event), preserving the pre-queue semantics.
+async fn forward_dashboard_display_input(frame: serde_json::Value, runtime: &ControlRuntime) {
+    let display_id = frame
+        .get("display_id")
+        .and_then(|value| value.as_u64())
+        .and_then(|value| u32::try_from(value).ok())
+        .unwrap_or(0);
+    let Some(event) = frame.get("event").cloned() else {
+        return;
+    };
+    let Ok(input_event) = serde_json::from_value::<crate::display::InputEvent>(event) else {
+        return;
+    };
+    let Some(bridge) = runtime.display_authority.as_ref() else {
+        return;
+    };
+    if !bridge.input_authorized(&runtime.session_id, display_id) {
+        return;
+    }
+    let session_registry = {
+        let session = runtime.shared_session.read().await;
+        session.session_registry.clone()
+    };
+    let Some(session_registry) = session_registry else {
+        return;
+    };
+    let display_session = {
+        let registry = session_registry.read().await;
+        registry.get(display_id)
+    };
+    if let Some(display_session) = display_session {
+        // Fire-and-forget: the session's input pump injects queued
+        // events in order and logs failures.
+        display_session.enqueue_input(input_event);
+    }
 }
 
 pub(crate) fn cached_bootstrap_events_response_frame(
@@ -2595,6 +2640,7 @@ mod tests {
         let mut inbound_uploads = HashMap::new();
         let (terminal_tx, _terminal_rx) = mpsc::unbounded_channel();
         let mut terminal_forwarders = HashMap::new();
+        let (display_input_tx, _display_input_rx) = mpsc::unbounded_channel();
         let bytes = b"hello upload";
         let first = &bytes[..6];
         let second = &bytes[6..];
@@ -2621,6 +2667,7 @@ mod tests {
             &mut inbound_uploads,
             &terminal_tx,
             &mut terminal_forwarders,
+            &display_input_tx,
         )
         .is_none());
         assert!(pending.contains_key("up1"));
@@ -2641,6 +2688,7 @@ mod tests {
                 &mut inbound_uploads,
                 &terminal_tx,
                 &mut terminal_forwarders,
+                &display_input_tx,
             )
             .is_none());
         }
@@ -2659,6 +2707,7 @@ mod tests {
             &mut inbound_uploads,
             &terminal_tx,
             &mut terminal_forwarders,
+            &display_input_tx,
         )
         .is_none());
 
@@ -2703,6 +2752,7 @@ mod tests {
         let mut inbound_uploads = HashMap::new();
         let (terminal_tx, _terminal_rx) = mpsc::unbounded_channel();
         let mut terminal_forwarders = HashMap::new();
+        let (display_input_tx, _display_input_rx) = mpsc::unbounded_channel();
 
         let start = serde_json::json!({
             "t": "upload_start",
@@ -2726,6 +2776,7 @@ mod tests {
             &mut inbound_uploads,
             &terminal_tx,
             &mut terminal_forwarders,
+            &display_input_tx,
         )
         .is_none());
         assert!(pending.contains_key("up-empty"));
@@ -2744,6 +2795,7 @@ mod tests {
             &mut inbound_uploads,
             &terminal_tx,
             &mut terminal_forwarders,
+            &display_input_tx,
         )
         .is_none());
 
@@ -2774,6 +2826,7 @@ mod tests {
         let mut inbound_uploads = HashMap::new();
         let (terminal_tx, mut terminal_rx) = mpsc::unbounded_channel();
         let mut terminal_forwarders = HashMap::new();
+        let (display_input_tx, _display_input_rx) = mpsc::unbounded_channel();
         let terminal_id = "dash-control-test-shell";
 
         let open = serde_json::json!({
@@ -2792,6 +2845,7 @@ mod tests {
             &mut inbound_uploads,
             &terminal_tx,
             &mut terminal_forwarders,
+            &display_input_tx,
         )
         .is_none());
 
@@ -2868,6 +2922,7 @@ mod tests {
             &mut inbound_uploads,
             &terminal_tx,
             &mut terminal_forwarders,
+            &display_input_tx,
         )
         .is_none());
 
@@ -2890,6 +2945,7 @@ mod tests {
             &mut inbound_uploads,
             &terminal_tx,
             &mut terminal_forwarders,
+            &display_input_tx,
         );
         for (_, handle) in terminal_forwarders {
             handle.abort();
@@ -2911,6 +2967,7 @@ mod tests {
         let mut inbound_uploads = HashMap::new();
         let (terminal_tx, _terminal_rx) = mpsc::unbounded_channel();
         let mut terminal_forwarders = HashMap::new();
+        let (display_input_tx, _display_input_rx) = mpsc::unbounded_channel();
         let mut frame = |text: &str,
                          rt: &mut ControlRuntime,
                          pending: &mut HashMap<String, CancellationToken>,
@@ -2925,6 +2982,7 @@ mod tests {
                 inbound,
                 &terminal_tx,
                 &mut terminal_forwarders,
+                &display_input_tx,
             )
         };
 

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -2463,6 +2463,7 @@ mod tests {
         let mut inbound_uploads = HashMap::new();
         let (terminal_tx, _terminal_rx) = mpsc::unbounded_channel();
         let mut terminal_forwarders = HashMap::new();
+        let (display_input_tx, _display_input_rx) = mpsc::unbounded_channel();
         control_frame_response(
             text,
             runtime,
@@ -2472,6 +2473,7 @@ mod tests {
             &mut inbound_uploads,
             &terminal_tx,
             &mut terminal_forwarders,
+            &display_input_tx,
         )
     }
 

--- a/src/bin/caller/dashboard_control/wire.rs
+++ b/src/bin/caller/dashboard_control/wire.rs
@@ -65,6 +65,13 @@ pub(crate) async fn control_driver<I: rtc::interceptor::Interceptor + Send + Syn
     runtime.control_frames_tx = Some(terminal_events_tx.clone());
     let mut terminal_forwarders: HashMap<(String, String), tokio::task::JoinHandle<()>> =
         HashMap::new();
+    // Per-connection ordered display-input lane (F1): `display_input`
+    // frames are handed to ONE forwarder task in dispatch order instead
+    // of spawning a task per event (which raced kd/ku / md/mu pairs
+    // across runtime workers). Dropping `display_input_tx` when this
+    // driver exits ends the forwarder; the shared shutdown token covers
+    // the cancel path.
+    let display_input_tx = spawn_display_input_forwarder(runtime.clone(), shutdown.clone());
     let mut display_authority_rx = runtime
         .display_authority
         .as_ref()
@@ -85,6 +92,7 @@ pub(crate) async fn control_driver<I: rtc::interceptor::Interceptor + Send + Syn
             &mut inbound_uploads,
             &terminal_events_tx,
             &mut terminal_forwarders,
+            &display_input_tx,
         )
         .await
         {
@@ -396,6 +404,7 @@ pub(crate) async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
     inbound_uploads: &mut HashMap<String, InboundUploadState>,
     terminal_events_tx: &mpsc::UnboundedSender<serde_json::Value>,
     terminal_forwarders: &mut HashMap<(String, String), tokio::task::JoinHandle<()>>,
+    display_input_tx: &mpsc::UnboundedSender<serde_json::Value>,
 ) -> Result<Instant, ()> {
     while let Some(t) = rtc.poll_write() {
         // Route by connection first, engine stamp second: rtc < 0.9.1
@@ -469,6 +478,7 @@ pub(crate) async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
             inbound_uploads,
             terminal_events_tx,
             terminal_forwarders,
+            display_input_tx,
         ) {
             send_control_frame(
                 rtc,

--- a/src/bin/caller/web_gateway/ws_session.rs
+++ b/src/bin/caller/web_gateway/ws_session.rs
@@ -1679,10 +1679,11 @@ pub(crate) async fn ws_inbound_task(
                     }
                     Some("display_input") => {
                         // Input event (keyboard/mouse) for a display session.
-                        // Drop the registry read lock before the inject
-                        // (which runs xdotool/cliclick subprocesses) so a
-                        // concurrent deactivate can take the write lock
-                        // without waiting on subprocess exits.
+                        // Enqueued onto the session's ordered input queue
+                        // (single pump per display injects in arrival
+                        // order); the enqueue is sync and non-blocking, so
+                        // this read loop never stalls on slow injection and
+                        // the registry read lock is released immediately.
                         let display_id = json["display_id"].as_u64().unwrap_or(0) as u32;
 
                         // Phase 5 authority gate: if someone has claimed
@@ -1723,12 +1724,10 @@ pub(crate) async fn ws_inbound_task(
                                         None => None,
                                     };
                                 if let Some(session) = session {
-                                    if let Err(e) = session.inject_input(input_event).await {
-                                        eprintln!(
-                                            "[web_gateway] display input injection failed: {}",
-                                            e
-                                        );
-                                    }
+                                    // Fire-and-forget: injection failures
+                                    // are logged by the session's input
+                                    // pump.
+                                    session.enqueue_input(input_event);
                                 }
                             }
                         }


### PR DESCRIPTION
Implements the daemon-side input-ordering and idle-cost fixes from the 2026-07-13 display-system review. All three findings verified against the source before fixing.

## F1 (P1) — per-event `tokio::spawn` discarded wire ordering on two of three input lanes

**Finding (verified):** the browser sends `kd`/`ku`/`md`/`mu` over reliable *ordered* channels, but the dashboard-control tunnel (`spawn_dashboard_display_input`) and the WebRTC datachannel lane (`gated_input_handler`) spawned one task per event, racing adjacent events across runtime workers — a `kd`/`ku` inversion is a stuck auto-repeating key, an `md`/`mu` inversion a scrambled click. Only the legacy `/ws` lane awaited inline (ordered). The tunnel lane additionally raced its session-registry lookups, so its inversion window was wider than the injection call alone.

**Fix:** a per-display-session ordered input queue with a single consumer (`crates/intendant-display/src/input_queue.rs`):

- `DisplaySession::enqueue_input` — sync, non-blocking push; one pump task per session drains it, awaiting each `inject_input` to completion, so injection order = arrival order. All three lanes route through it (`/ws` included: it was already ordered, and enqueueing keeps it ordered while also unblocking its read loop from slow injections).
- Tunnel lane: `display_input` frames now hand off to **one forwarder task per control connection** (`spawn_display_input_forwarder`) via an ordered channel — dispatch order preserved end to end; parse → authority gate → registry lookup → enqueue all happen serially per connection.
- Datachannel lane: `gated_input_handler` keeps its per-event authority gate exactly where it was (before enqueue; refused events never enqueue, `record_authority_drop` unchanged) and pushes instead of spawning.
- **Coalescing:** adjacent pending `mm` events collapse latest-wins (absolute coordinates; never across a discrete event, so position-at-click is preserved). `sc` is **never** coalesced — verified `Scroll { dx, dy }` carries relative deltas.
- **Overflow:** soft cap 256 — evict the oldest *continuous* (`mm`/`sc`) event first; discrete events are never dropped in favor of continuous ones. An all-discrete backlog grows past the soft cap to a hard cap of 1024, past which the oldest event is dropped loudly (telemetry + throttled log).
- `DisplaySession::inject_input` (awaited completion) remains for computer use, which needs click-before-screenshot semantics.

**Deviation from the review brief, deliberate:** the brief prescribed await-send backpressure when the queue is full of discrete events. Both offending producers are sans-I/O `rtc` poll loops whose documented contract is *never block* (see the `try_send` commentary in `webrtc/driver.rs::drain_outputs` and `dashboard_control/wire.rs::drain_control_outputs`) — an awaited send there stalls that peer's media pump / the whole control channel behind a wedged input backend. Bounded growth (4× soft cap) preserves the real invariant — discrete events are not dropped and memory stays bounded — without violating the poll-loop contract.

## F2 (P2) — pool-feed bridge converted BGRA→I420 at capture rate with zero demand

**Finding (verified):** the bridge's broadcast arm converted every captured frame regardless of encoder-pool state; the presence policy pauses encoder *threads* only, so an agent-only session paid full-resolution conversion continuously for zero viewers.

**Fix:** conversion moved behind a demand gate in the tick arm. New `EncoderPool::has_active_consumer()` (unpaused always-on layer ∪ subscribed-and-unpaused on-demand encoder — the same active-encoder universe as `request_keyframe_all`). With no active consumer and no peer-join burst window open, a captured frame is just stashed (`Arc`, latest-wins). The first tick after demand returns converts the retained frame on the spot and forwards immediately — the seed path, 1 Hz idle heartbeat, and peer-join burst behavior are unchanged whenever demand exists (the burst window counts as demand on its own, covering the layer coordinator's resume-vote latency). Conversions are now also naturally capped at tick rate. Observable via a new `pool_feed_conversions` counter.

## F3 (P2) — clipboard monitor subprocess-polled every 500 ms per session, forever

**Finding (verified):** `ClipboardMonitor::start_watching` polled unconditionally from first offer to teardown; each macOS tick spawns `osascript` (+ `pbpaste`), Linux `xclip`/`wl-paste`.

**Fix (cheap gate only, per the brief):** polling is gated on a `peers_connected` closure over the session's `peer_count` gauge (the same attach/reap-maintained peer-presence signal the presence policy's peers map mirrors). Zero viewers → the tick does no clipboard access at all. On resume, the first tick re-baselines silently so content changed during the pause is not replayed to the joining viewer (pre-gate behavior delivered such changes to nobody). Teardown unchanged. Follow-up noted in-code: replace macOS subprocess polling with an `NSPasteboard.changeCount` probe (out of scope here).

## Tests

- `input_queue.rs`: arrival-order preservation through the pump (injections yield internally — the exact shape that raced before), per-producer order under concurrent enqueue, tail-`mm` coalescing (newest wins, never across discrete events), `sc` never coalesced, overflow evicts oldest-continuous-first with all discretes surviving, all-discrete growth to the hard cap without discrete loss, close/shutdown semantics.
- `gated_input_handler`: gate pass / drop / per-event re-evaluation rewritten against the queue rig; refused events asserted to never enqueue.
- F2: `pool_feed_bridge_skips_conversion_without_active_consumer` (zero conversions while paused; retained frame converts on demand and reaches the encoder after resume) + `pool_has_active_consumer_tracks_pause_state`; the three pre-existing seed/heartbeat/burst bridge tests still pin the with-demand behavior.
- F3: hermetic watcher tests (paused-time): inert while gated (no platform clipboard access on that path), stop() works while gated.

All hermetic — stub backends, injected closures/channels, no display or native capture.

## Battery

- `cargo fmt --check` clean
- `cargo nextest run --bins` — 3251 passed / 9 skipped
- `cargo nextest run -p intendant-display` — 513 passed / 2 skipped
- `cargo clippy --workspace --locked -- -D warnings` clean
- `cargo test --test e2e` — 20 passed / 0 failed

Docs: `docs/src/display-pipeline.md` gains a "Remote Input Path" section (queue + coalescing + overflow policy) and updated presence-policy/clipboard paragraphs.
