### PR TITLE
cu: input-delivery correctness — macOS type rewrite, honest statuses, clipboard restore

### DIFF
--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -627,6 +627,16 @@ impl DisplayMetricsSnapshot {
 // Display backend trait
 // ---------------------------------------------------------------------------
 
+/// What a [`DisplayBackend::paste_text`] did to the clipboard beyond the
+/// paste itself.
+#[derive(Debug, Clone, Default)]
+pub struct PasteOutcome {
+    /// Honest note on the previous clipboard content: restored, cleared, or
+    /// left holding the pasted text (and why). `None` only when there is
+    /// nothing worth reporting.
+    pub clipboard_note: Option<String>,
+}
+
 /// Platform-specific display capture and input injection.
 ///
 /// # Capture lifecycle contract
@@ -721,7 +731,11 @@ pub trait DisplayBackend: Send + Sync + 'static {
     /// Paste literal text via the display's clipboard: set the clipboard,
     /// then press the platform paste chord. Backends without clipboard
     /// access keep this default error.
-    async fn paste_text(&self, text: &str) -> Result<(), CallerError> {
+    ///
+    /// The outcome reports what happened to the *previous* clipboard
+    /// content — restored, cleared, or left holding the pasted text — so
+    /// callers can surface residue honestly instead of guessing.
+    async fn paste_text(&self, text: &str) -> Result<PasteOutcome, CallerError> {
         let _ = text;
         Err(CallerError::Display(format!(
             "the {} display backend does not support clipboard paste — use a type action instead",
@@ -3220,8 +3234,10 @@ impl DisplaySession {
         self.backend.inject_text(text).await
     }
 
-    /// Paste text via the display backend's clipboard.
-    pub async fn paste_text(&self, text: &str) -> Result<(), CallerError> {
+    /// Paste text via the display backend's clipboard. The outcome carries
+    /// the backend's honest note on what happened to the previous clipboard
+    /// content.
+    pub async fn paste_text(&self, text: &str) -> Result<PasteOutcome, CallerError> {
         self.backend.paste_text(text).await
     }
 

--- a/crates/intendant-display/src/wayland.rs
+++ b/crates/intendant-display/src/wayland.rs
@@ -427,7 +427,7 @@ impl DisplayBackend for WaylandBackend {
         Ok(())
     }
 
-    async fn paste_text(&self, text: &str) -> Result<(), CallerError> {
+    async fn paste_text(&self, text: &str) -> Result<super::PasteOutcome, CallerError> {
         // Paste gesture emulation, matching the Windows backend: (1) make
         // exactly `text` the session's current paste payload, (2) press
         // ctrl+v in the already-approved RemoteDesktop session. The payload
@@ -505,7 +505,17 @@ impl DisplayBackend for WaylandBackend {
             ));
         }
 
-        Ok(())
+        // Portal selections are pull-based and the portal offers no way to
+        // read (and thus restore) the previous owner's content — this
+        // session simply stays the selection owner. Report that honestly
+        // instead of pretending the clipboard is untouched.
+        Ok(super::PasteOutcome {
+            clipboard_note: Some(
+                "clipboard: previous content not restored (the Wayland portal clipboard \
+                 is pull-based); the pasted text remains the active selection"
+                    .to_string(),
+            ),
+        })
     }
 
     fn resolution(&self) -> (u32, u32) {

--- a/crates/intendant-display/src/windows.rs
+++ b/crates/intendant-display/src/windows.rs
@@ -78,6 +78,11 @@
 //! 0" desktop) -- see the crate-level Windows-port notes.
 
 use super::{DisplayBackend, Frame, FrameFormat, InputEvent};
+
+/// How long the focused app gets to consume the clipboard after ctrl+v
+/// before the previous content is restored (paste is consumed while the app
+/// processes the chord; a lazy re-read afterwards sees the restored content).
+const PASTE_CONSUME_DELAY: std::time::Duration = std::time::Duration::from_millis(300);
 use async_trait::async_trait;
 use intendant_core::error::CallerError;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering};
@@ -583,17 +588,21 @@ impl DisplayBackend for WindowsBackend {
         Ok(())
     }
 
-    async fn paste_text(&self, text: &str) -> Result<(), CallerError> {
+    async fn paste_text(&self, text: &str) -> Result<super::PasteOutcome, CallerError> {
         // The OS hosts clipboard content on Windows (set-and-forget), so
-        // arboard needs no serving thread. The previous clipboard is not
-        // restored — Windows CU displays are agent-owned sessions.
+        // arboard needs no serving thread — which also makes the previous
+        // *text* content capturable for restore. Non-text content (images,
+        // files) is not readable through this path and cannot be restored.
         let owned = text.to_string();
-        tokio::task::spawn_blocking(move || {
+        let previous = tokio::task::spawn_blocking(move || {
             let mut clipboard = arboard::Clipboard::new()
                 .map_err(|e| CallerError::Display(format!("open clipboard: {e}")))?;
+            // Best-effort capture: Err covers empty and non-text alike.
+            let previous = clipboard.get_text().ok();
             clipboard
                 .set_text(owned)
-                .map_err(|e| CallerError::Display(format!("set clipboard text: {e}")))
+                .map_err(|e| CallerError::Display(format!("set clipboard text: {e}")))?;
+            Ok::<_, CallerError>(previous)
         })
         .await
         .map_err(|e| CallerError::Display(format!("clipboard task join: {e}")))??;
@@ -603,7 +612,46 @@ impl DisplayBackend for WindowsBackend {
         inject_vk(VK_V, false)?;
         inject_vk(VK_V, true)?;
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        inject_vk(VK_CONTROL, true)
+        inject_vk(VK_CONTROL, true)?;
+
+        // Give the focused app time to consume the paste (it reads the
+        // clipboard while processing the chord), then restore. This bounds
+        // the honest race: an app that lazily re-reads the clipboard later
+        // sees the restored content.
+        tokio::time::sleep(PASTE_CONSUME_DELAY).await;
+        let clipboard_note = tokio::task::spawn_blocking(move || match previous {
+            Some(prev) => {
+                let restored = arboard::Clipboard::new().and_then(|mut c| c.set_text(prev));
+                match restored {
+                    Ok(()) => "clipboard: previous text restored after paste".to_string(),
+                    Err(e) => format!(
+                        "clipboard: restore failed ({e}); \
+                         the pasted text remains on the clipboard"
+                    ),
+                }
+            }
+            None => {
+                // Clearing beats leaving the pasted text behind; the
+                // unreadable previous content (if any) was already replaced
+                // by set_text above.
+                let cleared = arboard::Clipboard::new().and_then(|mut c| c.clear());
+                match cleared {
+                    Ok(()) => "clipboard: previous clipboard had no text \
+                         (empty or non-text); cleared after paste"
+                        .to_string(),
+                    Err(e) => format!(
+                        "clipboard: previous clipboard had no text and clearing \
+                         failed ({e}); the pasted text remains on the clipboard"
+                    ),
+                }
+            }
+        })
+        .await
+        .map_err(|e| CallerError::Display(format!("clipboard task join: {e}")))?;
+
+        Ok(super::PasteOutcome {
+            clipboard_note: Some(clipboard_note),
+        })
     }
 
     fn resolution(&self) -> (u32, u32) {

--- a/crates/intendant-display/src/windows.rs
+++ b/crates/intendant-display/src/windows.rs
@@ -78,11 +78,6 @@
 //! 0" desktop) -- see the crate-level Windows-port notes.
 
 use super::{DisplayBackend, Frame, FrameFormat, InputEvent};
-
-/// How long the focused app gets to consume the clipboard after ctrl+v
-/// before the previous content is restored (paste is consumed while the app
-/// processes the chord; a lazy re-read afterwards sees the restored content).
-const PASTE_CONSUME_DELAY: std::time::Duration = std::time::Duration::from_millis(300);
 use async_trait::async_trait;
 use intendant_core::error::CallerError;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering};
@@ -129,6 +124,11 @@ use windows::Win32::UI::WindowsAndMessaging::{
     GetSystemMetrics, SM_CXSCREEN, SM_CXVIRTUALSCREEN, SM_CYSCREEN, SM_CYVIRTUALSCREEN,
     SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, WHEEL_DELTA,
 };
+
+/// How long the focused app gets to consume the clipboard after ctrl+v
+/// before the previous content is restored (paste is consumed while the app
+/// processes the chord; a lazy re-read afterwards sees the restored content).
+const PASTE_CONSUME_DELAY: std::time::Duration = std::time::Duration::from_millis(300);
 
 /// Active capture state: holds the thread handle for cleanup.
 struct CaptureState {

--- a/crates/intendant-display/src/x11_input.rs
+++ b/crates/intendant-display/src/x11_input.rs
@@ -632,10 +632,14 @@ pub async fn type_text(display: &str, text: &str) -> Result<(), String> {
 // ── Clipboard paste ──────────────────────────────────────────────────────────
 
 /// Set the CLIPBOARD selection to `text` (served in-process by the
-/// connection's event thread) and press ctrl+v. The previous clipboard is not
-/// restored — X11 CU displays are agent-owned. The selection keeps being
-/// served after this returns, like a normal clipboard owner, until another
-/// client takes the selection or the daemon exits.
+/// connection's event thread) and press ctrl+v. The previous clipboard is
+/// deliberately not restored: X11 selections are pull-based — the target app
+/// fetches the payload when it processes the chord, possibly after this
+/// returns — so re-owning the selection with the old content would race the
+/// paste itself. (Most CU X11 displays are agent-owned Xvfb anyway; on a
+/// real X11 user session the CU result's detail states the residue.) The
+/// selection keeps being served after this returns, like a normal clipboard
+/// owner, until another client takes the selection or the daemon exits.
 pub async fn paste(display: &str, text: &str) -> Result<(), String> {
     if text.len() > PASTE_MAX_BYTES {
         return Err(format!(

--- a/docs/src/computer-use-and-audio.md
+++ b/docs/src/computer-use-and-audio.md
@@ -23,8 +23,9 @@ and are converted to milliseconds (clamped to 30 s) at parse time.
 The full `CuAction` vocabulary (the same tagged JSON accepted by the MCP
 `execute_cu_actions` tool and `intendant ctl cu actions`):
 `click`, `double_click`, `triple_click`, `mouse_down`, `mouse_up`, `type`,
-`paste` (clipboard + paste chord — fast for long text; restores the previous
-clipboard text on the user's macOS session), `key`, `hold_key`, `scroll`,
+`paste` (clipboard + paste chord — fast for long text; previous clipboard
+text is restored where the platform allows, see "Action results" below),
+`key`, `hold_key`, `scroll`,
 `move_mouse`, `drag`, `screenshot`, `zoom` (region capture at the highest
 resolution the platform can supply — native 2x pixels on Retina), and `wait`.
 `intendant ctl cu actions --help` prints the per-action field shapes with an
@@ -50,9 +51,11 @@ the executor returns an actionable error naming the recovery path. X11 and
 macOS inject input directly — X11 uses a persistent `x11rb`/XTest connection
 with in-process root-window capture and clipboard support; macOS posts
 CoreGraphics `CGEvent`s in-process (no `cliclick`/`osascript` subprocesses; key
-chords use ANSI-US virtual keycodes, unicode typing is layout-independent) —
-and prefer the in-memory frame of a live capture session for screenshots,
-falling back to their platform capture paths when no session exists.
+chords and typed ASCII use ANSI-US virtual keycodes, characters with no
+ANSI-US key ride paced unicode-string events, and typed text is read back via
+AX where possible — see "Action results" below) — and prefer the in-memory
+frame of a live capture session for screenshots, falling back to their
+platform capture paths when no session exists.
 
 **Post-action freshness:** capture backends are damage-driven, so a screenshot
 taken right after an input action waits (bounded, 300 ms) for a frame captured
@@ -65,6 +68,52 @@ on HiDPI and under the Wayland portal, which reports its own stream size).
 `zoom` is the deliberate exception: on macOS it captures raw physical pixels
 (2x on Retina) and crops the requested logical region, because detail is the
 point.
+
+### Action results: dispatch vs. effect
+
+OS input APIs only confirm that events were *dispatched* — not that the
+target app acted on them — so every action result carries an honest status
+(`CuActionStatus`) instead of a bare boolean:
+
+- **`ok`** — the intended effect was verified: screenshots and zooms (the
+  captured bytes are the effect), `wait`, and `type` on the macOS user
+  session when the focused element's AX value was read back and contained
+  the typed text.
+- **`injected`** — events were dispatched to the OS but the effect was not
+  verified. This is the honest ceiling for clicks, keys, scrolls, drags, and
+  typing on backends without read-back; verify from the post-action
+  screenshot. A dispatched-but-ineffective action (a click that only
+  activated an inactive window, a chord swallowed by the wrong app) reports
+  `injected`, never `ok`.
+- **`failed`** — dispatch failed, or verification contradicted the intent: a
+  macOS `type` whose read-back does not contain the typed text returns
+  `failed` with expected-vs-observed evidence rather than pretending
+  success.
+
+Type read-back is bounded and best-effort (two AX reads of the focused
+element): multi-line/control text (Return may submit, Tab may move focus),
+secure fields, and elements without an AX-readable value stay `injected`
+with the reason in the result detail.
+
+**Typing on macOS**: ASCII is delivered as real ANSI-US keycode events (the
+same proven event shape as `key`), newlines as Return and tabs as Tab;
+characters with no ANSI-US key are delivered as paced unicode-string events
+(≤ 20 UTF-16 units per event, payload on both keyDown and keyUp, surrogate
+pairs never split). This replaces the 2026-07-13 failure mode where
+back-to-back `CGEventKeyboardSetUnicodeString` chunks were silently dropped
+by the focused app while the action still reported success.
+
+**Clipboard hygiene (`paste`)**: paste routes through the system clipboard,
+so each backend restores what it can and reports what it did in the result
+detail. macOS captures the previous *text* clipboard (`pbpaste`) and
+restores it ~300 ms after the chord — non-text content (images) cannot be
+captured, so the clipboard is cleared rather than left holding the paste
+payload; Windows does the same via arboard. X11 and Wayland selections are
+pull-based (the target may fetch the payload after the chord returns), so
+restore would race the paste itself: the pasted text deliberately remains
+the active selection and the result detail says so. The restore delay is an
+honest race, not a guarantee — an app that lazily re-reads the clipboard
+later sees the restored content.
 
 ### Screen-capture permissions & signing identity (macOS)
 

--- a/src/bin/caller/ax.rs
+++ b/src/bin/caller/ax.rs
@@ -24,10 +24,11 @@ use std::ffi::c_void;
 
 use accessibility_sys::{
     kAXChildrenAttribute, kAXDescriptionAttribute, kAXEnabledAttribute, kAXErrorSuccess,
-    kAXFocusedAttribute, kAXFocusedWindowAttribute, kAXPositionAttribute, kAXRoleAttribute,
-    kAXSizeAttribute, kAXTitleAttribute, kAXValueAttribute, kAXValueTypeCGPoint,
-    kAXValueTypeCGSize, kAXWindowsAttribute, AXIsProcessTrusted, AXUIElementCopyAttributeValue,
-    AXUIElementCreateApplication, AXUIElementGetTypeID, AXUIElementRef,
+    kAXFocusedAttribute, kAXFocusedUIElementAttribute, kAXFocusedWindowAttribute,
+    kAXPositionAttribute, kAXRoleAttribute, kAXSizeAttribute, kAXTitleAttribute,
+    kAXValueAttribute, kAXValueTypeCGPoint, kAXValueTypeCGSize, kAXWindowsAttribute,
+    AXIsProcessTrusted, AXUIElementCopyAttributeValue, AXUIElementCreateApplication,
+    AXUIElementCreateSystemWide, AXUIElementGetTypeID, AXUIElementRef,
     AXUIElementSetMessagingTimeout, AXValueGetTypeID, AXValueGetValue, AXValueRef,
 };
 use core_foundation::array::{CFArray, CFArrayRef};
@@ -130,6 +131,49 @@ pub fn read_frontmost(max_depth: usize, max_nodes: usize) -> Result<ScreenElemen
         } else {
             Some(notes.join("; "))
         },
+    })
+}
+
+/// The focused element's role and readable value, for bounded `type`
+/// read-back verification.
+pub struct FocusedElementText {
+    /// Normalized role (`AXTextField` → `textfield`), when readable.
+    pub role: Option<String>,
+    /// The element's `AXValue` rendered as text — `None` when the value is
+    /// missing or not a string/number/bool.
+    pub value: Option<String>,
+}
+
+/// Read the system-wide focused UI element's role and value.
+///
+/// Bounded like every AX read in this module (per-element messaging
+/// timeout, two attribute copies). The attribute copies are synchronous IPC
+/// into the focused app — call from `spawn_blocking`.
+pub fn focused_element_text() -> Result<FocusedElementText, String> {
+    if !is_trusted() {
+        return Err(
+            "reading UI elements requires the Accessibility permission — grant Intendant \
+             access in System Settings → Privacy & Security → Accessibility and retry"
+                .to_string(),
+        );
+    }
+    // SAFETY: AXUIElementCreateSystemWide follows the Create rule and has no
+    // preconditions; the wrapper takes ownership and releases on drop.
+    let system = unsafe { AXUIElement::wrap_under_create_rule(AXUIElementCreateSystemWide()) };
+    // SAFETY: system is a valid AXUIElement for the duration of the call.
+    unsafe {
+        AXUIElementSetMessagingTimeout(system.as_concrete_TypeRef(), MESSAGING_TIMEOUT_SECS)
+    };
+    let focused: AXUIElement = copy_attr(&system, kAXFocusedUIElementAttribute)
+        .and_then(|cf| cf.downcast_into())
+        .ok_or_else(|| "no focused UI element".to_string())?;
+    // SAFETY: focused is a valid AXUIElement for the duration of the call.
+    unsafe {
+        AXUIElementSetMessagingTimeout(focused.as_concrete_TypeRef(), MESSAGING_TIMEOUT_SECS)
+    };
+    Ok(FocusedElementText {
+        role: attr_string(&focused, kAXRoleAttribute).map(|r| normalize_role(&r)),
+        value: attr_value_string(&focused),
     })
 }
 

--- a/src/bin/caller/ax.rs
+++ b/src/bin/caller/ax.rs
@@ -25,11 +25,11 @@ use std::ffi::c_void;
 use accessibility_sys::{
     kAXChildrenAttribute, kAXDescriptionAttribute, kAXEnabledAttribute, kAXErrorSuccess,
     kAXFocusedAttribute, kAXFocusedUIElementAttribute, kAXFocusedWindowAttribute,
-    kAXPositionAttribute, kAXRoleAttribute, kAXSizeAttribute, kAXTitleAttribute,
-    kAXValueAttribute, kAXValueTypeCGPoint, kAXValueTypeCGSize, kAXWindowsAttribute,
-    AXIsProcessTrusted, AXUIElementCopyAttributeValue, AXUIElementCreateApplication,
-    AXUIElementCreateSystemWide, AXUIElementGetTypeID, AXUIElementRef,
-    AXUIElementSetMessagingTimeout, AXValueGetTypeID, AXValueGetValue, AXValueRef,
+    kAXPositionAttribute, kAXRoleAttribute, kAXSizeAttribute, kAXTitleAttribute, kAXValueAttribute,
+    kAXValueTypeCGPoint, kAXValueTypeCGSize, kAXWindowsAttribute, AXIsProcessTrusted,
+    AXUIElementCopyAttributeValue, AXUIElementCreateApplication, AXUIElementCreateSystemWide,
+    AXUIElementGetTypeID, AXUIElementRef, AXUIElementSetMessagingTimeout, AXValueGetTypeID,
+    AXValueGetValue, AXValueRef,
 };
 use core_foundation::array::{CFArray, CFArrayRef};
 use core_foundation::base::{CFGetTypeID, CFType, TCFType};
@@ -161,9 +161,7 @@ pub fn focused_element_text() -> Result<FocusedElementText, String> {
     // preconditions; the wrapper takes ownership and releases on drop.
     let system = unsafe { AXUIElement::wrap_under_create_rule(AXUIElementCreateSystemWide()) };
     // SAFETY: system is a valid AXUIElement for the duration of the call.
-    unsafe {
-        AXUIElementSetMessagingTimeout(system.as_concrete_TypeRef(), MESSAGING_TIMEOUT_SECS)
-    };
+    unsafe { AXUIElementSetMessagingTimeout(system.as_concrete_TypeRef(), MESSAGING_TIMEOUT_SECS) };
     let focused: AXUIElement = copy_attr(&system, kAXFocusedUIElementAttribute)
         .and_then(|cf| cf.downcast_into())
         .ok_or_else(|| "no focused UI element".to_string())?;

--- a/src/bin/caller/computer_use.rs
+++ b/src/bin/caller/computer_use.rs
@@ -860,6 +860,10 @@ pub async fn execute_actions(
     let mut last_input_at: Option<std::time::Instant> = None;
 
     for action in actions {
+        // Whether input events were actually dispatched — the Live overlay
+        // renders what the agent DID, so a type whose read-back later
+        // downgrades the result still paints its keypress chip.
+        let mut dispatched_ok: Option<bool> = None;
         let result = match action {
             CuAction::Screenshot => {
                 match capture_screenshot_preferring_session(
@@ -909,13 +913,14 @@ pub async fn execute_actions(
                 if !matches!(action, CuAction::Wait { .. }) {
                     last_input_at = Some(std::time::Instant::now());
                 }
+                dispatched_ok = Some(result.success());
                 verify_action_effect(action, result, effective_backend, target).await
             }
         };
         if let Some(ref s) = result.screenshot {
             last_screenshot = Some(s.clone());
         }
-        if result.success() {
+        if dispatched_ok.unwrap_or_else(|| result.success()) {
             if let Some(obs) = observer {
                 obs.observe(target, observe_ref, action);
             }
@@ -1057,7 +1062,10 @@ async fn verify_macos_type_readback(text: &str, dispatched: CuActionResult) -> C
         };
         let role = snapshot.role.unwrap_or_else(|| "element".to_string());
         if role == "securetextfield" {
-            return unverified(dispatched, "secure field values are not readable".to_string());
+            return unverified(
+                dispatched,
+                "secure field values are not readable".to_string(),
+            );
         }
         let Some(value) = snapshot.value else {
             return unverified(dispatched, format!("focused {role} has no readable value"));
@@ -1653,17 +1661,13 @@ mod macos_input {
         // touching it again.
         tokio::time::sleep(PASTE_CONSUME_DELAY).await;
         let note = match previous {
-            None => {
-                "clipboard: previous content could not be captured; \
+            None => "clipboard: previous content could not be captured; \
                  the pasted text remains on the clipboard"
-                    .to_string()
-            }
+                .to_string(),
             Some(prev) => {
                 let restorable = !prev.is_empty();
                 match (set_clipboard(prev).await, restorable) {
-                    (Ok(()), true) => {
-                        "clipboard: previous text restored after paste".to_string()
-                    }
+                    (Ok(()), true) => "clipboard: previous text restored after paste".to_string(),
                     // Clearing beats leaving the pasted text behind, but
                     // non-text content (e.g. an image) is already gone.
                     (Ok(()), false) => "clipboard: previous clipboard had no text \
@@ -2132,10 +2136,7 @@ mod macos_input {
             assert_eq!(typed_char_keycode('1'), Some((KeyCode::ANSI_1, false)));
             assert_eq!(typed_char_keycode('!'), Some((KeyCode::ANSI_1, true)));
             assert_eq!(typed_char_keycode('~'), Some((KeyCode::ANSI_GRAVE, true)));
-            assert_eq!(
-                typed_char_keycode('"'),
-                Some((KeyCode::ANSI_QUOTE, true))
-            );
+            assert_eq!(typed_char_keycode('"'), Some((KeyCode::ANSI_QUOTE, true)));
             assert_eq!(typed_char_keycode(' '), Some((KeyCode::SPACE, false)));
             assert_eq!(typed_char_keycode('\n'), Some((KeyCode::RETURN, false)));
             assert_eq!(typed_char_keycode('\r'), Some((KeyCode::RETURN, false)));
@@ -2607,10 +2608,7 @@ async fn execute_via_session(
                 results.push(if errors.is_empty() {
                     CuActionResult::injected()
                 } else {
-                    CuActionResult::failed(format!(
-                        "Click injection failed: {}",
-                        errors.join("; ")
-                    ))
+                    CuActionResult::failed(format!("Click injection failed: {}", errors.join("; ")))
                 });
                 needs_auto_screenshot = true;
             }
@@ -2914,10 +2912,7 @@ async fn execute_via_session(
                 results.push(if errors.is_empty() {
                     CuActionResult::injected()
                 } else {
-                    CuActionResult::failed(format!(
-                        "Drag injection failed: {}",
-                        errors.join("; ")
-                    ))
+                    CuActionResult::failed(format!("Drag injection failed: {}", errors.join("; ")))
                 });
                 needs_auto_screenshot = true;
             }
@@ -4417,10 +4412,8 @@ mod tests {
         let type_action = CuAction::Type { text: "hi".into() };
 
         // All verified (e.g. screenshot-only batches) keeps the plain wording.
-        let summary = summarize_results_for_model(
-            &[CuAction::Screenshot],
-            &[CuActionResult::verified()],
-        );
+        let summary =
+            summarize_results_for_model(&[CuAction::Screenshot], &[CuActionResult::verified()]);
         assert_eq!(summary, "Actions executed successfully.");
 
         // Injected-only batches must not read as verified success, and
@@ -4429,11 +4422,19 @@ mod tests {
             &[click.clone(), type_action.clone()],
             &[
                 CuActionResult::injected(),
-                CuActionResult::injected_with("type dispatched; delivery unverified — no focused element"),
+                CuActionResult::injected_with(
+                    "type dispatched; delivery unverified — no focused element",
+                ),
             ],
         );
-        assert!(summary.starts_with("Actions dispatched (2 injected"), "{summary}");
-        assert!(summary.contains("effect not independently verified"), "{summary}");
+        assert!(
+            summary.starts_with("Actions dispatched (2 injected"),
+            "{summary}"
+        );
+        assert!(
+            summary.contains("effect not independently verified"),
+            "{summary}"
+        );
         assert!(
             summary.contains("type: type dispatched; delivery unverified"),
             "{summary}"

--- a/src/bin/caller/computer_use.rs
+++ b/src/bin/caller/computer_use.rs
@@ -222,12 +222,99 @@ pub struct CuCallMetadata {
     pub safety_decision: Option<String>,
 }
 
+/// How far a CU action's outcome was actually confirmed.
+///
+/// OS input APIs only report that events were *dispatched*, not that the
+/// target application acted on them (the live failure class: typed text
+/// silently dropped by the focused app, shortcuts landing in a different
+/// window — both with a clean dispatch). The status keeps that distinction
+/// honest instead of collapsing everything to one boolean.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CuActionStatus {
+    /// The intended effect was confirmed (screenshot bytes captured, wait
+    /// elapsed, type read-back found the text in the focused element).
+    Verified,
+    /// Events were dispatched to the OS but the effect was not verified —
+    /// the honest ceiling for most input injection on every platform.
+    Injected,
+    /// Dispatch failed, or verification observed a different outcome.
+    Failed,
+}
+
+impl CuActionStatus {
+    /// Wire/summary label, as shown to models and in tool output.
+    pub fn label(self) -> &'static str {
+        match self {
+            CuActionStatus::Verified => "ok",
+            CuActionStatus::Injected => "injected",
+            CuActionStatus::Failed => "failed",
+        }
+    }
+}
+
 /// Result of executing a CU action.
 #[derive(Debug)]
 pub struct CuActionResult {
-    pub success: bool,
+    pub status: CuActionStatus,
     pub screenshot: Option<ScreenshotData>,
     pub error: Option<String>,
+    /// Best-effort evidence/context for the status (read-back excerpts,
+    /// clipboard restore notes) — may accompany any status.
+    pub detail: Option<String>,
+}
+
+impl CuActionResult {
+    /// Effect confirmed.
+    pub fn verified() -> Self {
+        Self {
+            status: CuActionStatus::Verified,
+            screenshot: None,
+            error: None,
+            detail: None,
+        }
+    }
+
+    /// A successful capture: the screenshot itself is the verified effect.
+    pub fn captured(screenshot: ScreenshotData) -> Self {
+        Self {
+            screenshot: Some(screenshot),
+            ..Self::verified()
+        }
+    }
+
+    /// Dispatched to the OS; effect unverified.
+    pub fn injected() -> Self {
+        Self {
+            status: CuActionStatus::Injected,
+            screenshot: None,
+            error: None,
+            detail: None,
+        }
+    }
+
+    /// Dispatched to the OS; effect unverified, with context.
+    pub fn injected_with(detail: impl Into<String>) -> Self {
+        Self {
+            detail: Some(detail.into()),
+            ..Self::injected()
+        }
+    }
+
+    /// Dispatch failed, or verification contradicted the intended effect.
+    pub fn failed(error: impl Into<String>) -> Self {
+        Self {
+            status: CuActionStatus::Failed,
+            screenshot: None,
+            error: Some(error.into()),
+            detail: None,
+        }
+    }
+
+    /// Whether the action was dispatched without a hard failure
+    /// (`Verified` or `Injected`).
+    pub fn success(&self) -> bool {
+        self.status != CuActionStatus::Failed
+    }
 }
 
 /// A captured screenshot.
@@ -649,6 +736,36 @@ pub fn cu_action_raw_call(action: &CuAction) -> String {
     }
 }
 
+/// Honest batch summary for the native CU loop's tool results: failures win
+/// the headline, dispatch-only injection is never dressed up as a verified
+/// effect, and per-action evidence (read-back, clipboard notes) rides along.
+/// `results` may carry one trailing auto-screenshot result beyond `actions`.
+pub fn summarize_results_for_model(actions: &[CuAction], results: &[CuActionResult]) -> String {
+    let mut out = if results.iter().all(|r| r.success()) {
+        let injected = results
+            .iter()
+            .filter(|r| r.status == CuActionStatus::Injected)
+            .count();
+        if injected == 0 {
+            "Actions executed successfully.".to_string()
+        } else {
+            format!(
+                "Actions dispatched ({injected} injected: input delivered to the OS, \
+                 effect not independently verified — confirm from the screenshot)."
+            )
+        }
+    } else {
+        let errors: Vec<&str> = results.iter().filter_map(|r| r.error.as_deref()).collect();
+        format!("Some actions failed: {}", errors.join("; "))
+    };
+    for (action, result) in actions.iter().zip(results.iter()) {
+        if let Some(detail) = &result.detail {
+            out.push_str(&format!("\n{}: {}", cu_action_kind(action), detail));
+        }
+    }
+    out
+}
+
 // ── Executor ─────────────────────────────────────────────────────────────────
 
 /// Execute a batch of CU actions on the given display.
@@ -684,11 +801,7 @@ pub async fn execute_actions(
         // (a screenshot-only batch still gets its one denial).
         return actions
             .iter()
-            .map(|_| CuActionResult {
-                success: false,
-                screenshot: None,
-                error: Some(user_session_denied_message().to_string()),
-            })
+            .map(|_| CuActionResult::failed(user_session_denied_message()))
             .collect();
     }
 
@@ -719,15 +832,11 @@ pub async fn execute_actions(
                 )
                 .await;
             }
-            return vec![CuActionResult {
-                success: false,
-                screenshot: None,
-                error: Some(no_session_message(
-                    effective_backend,
-                    &target,
-                    user_session_allowed,
-                )),
-            }];
+            return vec![CuActionResult::failed(no_session_message(
+                effective_backend,
+                &target,
+                user_session_allowed,
+            ))];
         }
         DisplayBackend::X11 | DisplayBackend::MacOS => {} // handled below
     }
@@ -763,16 +872,8 @@ pub async fn execute_actions(
                 )
                 .await
                 {
-                    Ok(s) => CuActionResult {
-                        success: true,
-                        screenshot: Some(s),
-                        error: None,
-                    },
-                    Err(e) => CuActionResult {
-                        success: false,
-                        screenshot: None,
-                        error: Some(e),
-                    },
+                    Ok(s) => CuActionResult::captured(s),
+                    Err(e) => CuActionResult::failed(e),
                 }
             }
             CuAction::Zoom {
@@ -792,16 +893,8 @@ pub async fn execute_actions(
                 )
                 .await
                 {
-                    Ok(s) => CuActionResult {
-                        success: true,
-                        screenshot: Some(s),
-                        error: None,
-                    },
-                    Err(e) => CuActionResult {
-                        success: false,
-                        screenshot: None,
-                        error: Some(e),
-                    },
+                    Ok(s) => CuActionResult::captured(s),
+                    Err(e) => CuActionResult::failed(e),
                 }
             }
             _ => {
@@ -816,13 +909,13 @@ pub async fn execute_actions(
                 if !matches!(action, CuAction::Wait { .. }) {
                     last_input_at = Some(std::time::Instant::now());
                 }
-                result
+                verify_action_effect(action, result, effective_backend, target).await
             }
         };
         if let Some(ref s) = result.screenshot {
             last_screenshot = Some(s.clone());
         }
-        if result.success {
+        if result.success() {
             if let Some(obs) = observer {
                 obs.observe(target, observe_ref, action);
             }
@@ -847,18 +940,10 @@ pub async fn execute_actions(
         match auto {
             Ok(s) => {
                 last_screenshot = Some(s.clone());
-                results.push(CuActionResult {
-                    success: true,
-                    screenshot: Some(s),
-                    error: None,
-                });
+                results.push(CuActionResult::captured(s));
             }
             Err(e) => {
-                results.push(CuActionResult {
-                    success: false,
-                    screenshot: None,
-                    error: Some(e),
-                });
+                results.push(CuActionResult::failed(e));
             }
         }
     }
@@ -872,6 +957,133 @@ pub async fn execute_actions(
     }
 
     results
+}
+
+// ── Post-dispatch verification ───────────────────────────────────────────────
+
+/// Best-effort, bounded verification of a dispatched action's effect.
+///
+/// Deliberately not a postcondition engine: it upgrades/downgrades the one
+/// case where the platform offers cheap evidence — `type` on the macOS user
+/// session, read back from the focused element's AX value — and leaves every
+/// other action at its honest dispatch status (`Injected`).
+async fn verify_action_effect(
+    action: &CuAction,
+    result: CuActionResult,
+    backend: DisplayBackend,
+    target: DisplayTarget,
+) -> CuActionResult {
+    #[cfg(target_os = "macos")]
+    {
+        if let CuAction::Type { text } = action {
+            if backend == DisplayBackend::MacOS && target.is_user_session() && result.success() {
+                return verify_macos_type_readback(text, result).await;
+            }
+        }
+        result
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (action, backend, target);
+        result
+    }
+}
+
+/// The exact string a `type` action should find in the focused element's
+/// value afterwards, or `None` when read-back would be meaningless: empty
+/// input, or text with control characters (`\n` may submit or insert breaks,
+/// `\t` may move focus to a different element).
+#[cfg(any(target_os = "macos", test))]
+fn type_readback_expectation(text: &str) -> Option<&str> {
+    if text.is_empty() || text.chars().any(|c| c.is_control()) {
+        return None;
+    }
+    Some(text)
+}
+
+/// Char-safe excerpt for read-back evidence strings.
+#[cfg(any(target_os = "macos", test))]
+fn excerpt(text: &str, cap: usize) -> String {
+    if text.chars().count() <= cap {
+        return text.to_string();
+    }
+    let cut: String = text.chars().take(cap).collect();
+    format!("{cut}…")
+}
+
+/// Settle before the first read-back attempt (apps commit typed text
+/// asynchronously) and before the single retry (WebKit's field values lag
+/// an IPC round-trip behind the keystrokes).
+#[cfg(target_os = "macos")]
+const TYPE_READBACK_SETTLE: std::time::Duration = std::time::Duration::from_millis(150);
+#[cfg(target_os = "macos")]
+const TYPE_READBACK_RETRY: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Read the focused element's value back after a `type` and adjust the
+/// result honestly: `Verified` when the typed text is present, `Failed`
+/// (with expected-vs-observed evidence) when the element is readable but the
+/// text is not there, and `Injected` with the reason whenever read-back is
+/// unavailable (no AX trust, no focused element, secure field, non-string
+/// value). Bounded: at most two AX reads, one element deep.
+#[cfg(target_os = "macos")]
+async fn verify_macos_type_readback(text: &str, dispatched: CuActionResult) -> CuActionResult {
+    let Some(expected) = type_readback_expectation(text) else {
+        let mut dispatched = dispatched;
+        if dispatched.detail.is_none() {
+            dispatched.detail = Some(
+                "type dispatched; read-back skipped (multi-line or control-character \
+                 text may submit or move focus)"
+                    .to_string(),
+            );
+        }
+        return dispatched;
+    };
+    let unverified = |dispatched: CuActionResult, reason: String| CuActionResult {
+        detail: Some(format!("type dispatched; delivery unverified — {reason}")),
+        ..dispatched
+    };
+    tokio::time::sleep(TYPE_READBACK_SETTLE).await;
+    let mut observed = String::new();
+    for attempt in 0..2 {
+        if attempt > 0 {
+            tokio::time::sleep(TYPE_READBACK_RETRY).await;
+        }
+        // The AX read is blocking IPC into the focused app (same treatment
+        // as `read_screen_elements`).
+        let snapshot = match tokio::task::spawn_blocking(crate::ax::focused_element_text).await {
+            Ok(Ok(snapshot)) => snapshot,
+            Ok(Err(reason)) => return unverified(dispatched, reason),
+            Err(e) => return unverified(dispatched, format!("read-back task failed: {e}")),
+        };
+        let role = snapshot.role.unwrap_or_else(|| "element".to_string());
+        if role == "securetextfield" {
+            return unverified(dispatched, "secure field values are not readable".to_string());
+        }
+        let Some(value) = snapshot.value else {
+            return unverified(dispatched, format!("focused {role} has no readable value"));
+        };
+        if value.contains(expected) {
+            return CuActionResult {
+                status: CuActionStatus::Verified,
+                detail: Some(format!(
+                    "read-back confirmed the typed text in the focused {role}"
+                )),
+                ..dispatched
+            };
+        }
+        observed = value;
+    }
+    CuActionResult {
+        status: CuActionStatus::Failed,
+        error: Some(format!(
+            "type read-back mismatch: expected the focused element's value to contain \
+             \"{}\" but observed \"{}\" — the app dropped or transformed the input; \
+             re-focus the field and retry, or use paste",
+            excerpt(expected, 120),
+            excerpt(&observed, 200),
+        )),
+        ..dispatched
+    }
 }
 
 /// Get the logical display size for the main display. Cached after first call.
@@ -1070,20 +1282,22 @@ async fn execute_single(
         CuAction::Paste { text } => match backend {
             #[cfg(target_os = "macos")]
             DisplayBackend::MacOS => macos_input::paste(text).await,
-            _ => cu_result(x11_cu::paste(display, text).await),
+            _ => match x11_cu::paste(display, text).await {
+                // X11 clipboards are pull-based (the target fetches the
+                // selection when it processes the chord, possibly later), so
+                // restoring the previous owner's content is inherently racy
+                // and `x11_input::paste` deliberately doesn't — say so.
+                Ok(()) => CuActionResult::injected_with(
+                    "clipboard: previous content not restored (X11 selections are \
+                     pull-based); the pasted text remains the CLIPBOARD selection",
+                ),
+                Err(e) => cu_result(Err(e)),
+            },
         },
         CuAction::Screenshot => {
             match take_screenshot(display, backend, screenshot_dir, counter).await {
-                Ok(s) => CuActionResult {
-                    success: true,
-                    screenshot: Some(s),
-                    error: None,
-                },
-                Err(e) => CuActionResult {
-                    success: false,
-                    screenshot: None,
-                    error: Some(e),
-                },
+                Ok(s) => CuActionResult::captured(s),
+                Err(e) => CuActionResult::failed(e),
             }
         }
         CuAction::Zoom {
@@ -1103,25 +1317,14 @@ async fn execute_single(
             )
             .await
             {
-                Ok(s) => CuActionResult {
-                    success: true,
-                    screenshot: Some(s),
-                    error: None,
-                },
-                Err(e) => CuActionResult {
-                    success: false,
-                    screenshot: None,
-                    error: Some(e),
-                },
+                Ok(s) => CuActionResult::captured(s),
+                Err(e) => CuActionResult::failed(e),
             }
         }
         CuAction::Wait { ms } => {
             tokio::time::sleep(std::time::Duration::from_millis(*ms)).await;
-            CuActionResult {
-                success: true,
-                screenshot: None,
-                error: None,
-            }
+            // The elapsed sleep IS the effect — nothing left to verify.
+            CuActionResult::verified()
         }
     }
 }
@@ -1182,18 +1385,11 @@ mod x11_cu {
 
 /// Adapt an `x11_input` result into a `CuActionResult`, attaching the Linux
 /// GUI-environment diagnostic to failures (as the old xdotool wrapper did).
+/// Success means the events were dispatched, nothing more — `Injected`.
 fn cu_result(r: Result<(), String>) -> CuActionResult {
     match r {
-        Ok(()) => CuActionResult {
-            success: true,
-            screenshot: None,
-            error: None,
-        },
-        Err(e) => CuActionResult {
-            success: false,
-            screenshot: None,
-            error: Some(with_linux_gui_env_diagnostic(e)),
-        },
+        Ok(()) => CuActionResult::injected(),
+        Err(e) => CuActionResult::failed(with_linux_gui_env_diagnostic(e)),
     }
 }
 
@@ -1219,12 +1415,14 @@ fn dom_key_sequence(key: &str) -> Result<Vec<(String, bool)>, String> {
 /// binary, no fork per action, a real middle button (cliclick approximated it
 /// as a triple-click), and the same Accessibility (TCC) permission
 /// requirement. Coordinates are logical points, matching the normalized
-/// screenshots. Key chords use ANSI-US virtual keycodes (the same layout
-/// assumption cliclick made); `type_text` posts unicode strings directly and
-/// is layout-independent.
+/// screenshots. Key chords and `type_text`'s ASCII fast path use ANSI-US
+/// virtual keycodes (the same layout assumption cliclick made); characters
+/// with no ANSI-US key are posted as paced unicode-string events, and typed
+/// text is read back from the focused element where AX allows so garbled or
+/// dropped delivery is reported instead of assumed.
 #[cfg(target_os = "macos")]
 mod macos_input {
-    use super::{CuActionResult, MouseButton, ScrollDirection};
+    use super::{CuActionResult, CuActionStatus, MouseButton, ScrollDirection};
     use core_graphics::event::{
         CGEvent, CGEventFlags, CGEventTapLocation, CGEventType, CGKeyCode, CGMouseButton,
         EventField, KeyCode, ScrollEventUnit,
@@ -1241,9 +1439,22 @@ mod macos_input {
     const PRESS_DELAY: Duration = Duration::from_millis(20);
     /// Pause between the two clicks of a double-click.
     const DOUBLE_CLICK_DELAY: Duration = Duration::from_millis(50);
-    /// Unicode-typing chunk size: `CGEventKeyboardSetUnicodeString` accepts
-    /// long strings, but some apps drop oversized injections.
+    /// Unicode-typing chunk size: `CGEventKeyboardSetUnicodeString` has a
+    /// historic ~20-UTF-16-unit practical limit per event; larger payloads
+    /// get truncated or dropped by receivers.
     const TYPE_CHUNK_UTF16: usize = 20;
+    /// Settle before the first keystroke of a `type` action, so the target
+    /// app finishes processing an immediately preceding click / activation
+    /// (the 2026-07-13 failure class: leading events swallowed during a
+    /// focus transition while the tail landed).
+    const TYPE_LEAD_IN: Duration = Duration::from_millis(100);
+    /// Pause between individual typed keystrokes (~hardware typing rate;
+    /// posting the whole text back-to-back outruns slow consumers).
+    const TYPE_KEY_GAP: Duration = Duration::from_millis(8);
+    /// Pause after a unicode-string chunk. These events have no hardware
+    /// analogue and WebKit consumes them noticeably slower than real
+    /// keycodes, so they get more headroom than `TYPE_KEY_GAP`.
+    const TYPE_CHUNK_GAP: Duration = Duration::from_millis(30);
 
     fn source() -> Result<CGEventSource, String> {
         CGEventSource::new(CGEventSourceStateID::HIDSystemState).map_err(|_| {
@@ -1253,25 +1464,19 @@ mod macos_input {
         })
     }
 
-    fn ok() -> CuActionResult {
-        CuActionResult {
-            success: true,
-            screenshot: None,
-            error: None,
-        }
+    /// Events were posted; whether the frontmost app honored them is unknown
+    /// — the honest ceiling for raw CGEvent injection.
+    fn injected() -> CuActionResult {
+        CuActionResult::injected()
     }
 
     fn fail(error: String) -> CuActionResult {
-        CuActionResult {
-            success: false,
-            screenshot: None,
-            error: Some(error),
-        }
+        CuActionResult::failed(error)
     }
 
     fn result(outcome: Result<(), String>) -> CuActionResult {
         match outcome {
-            Ok(()) => ok(),
+            Ok(()) => injected(),
             Err(e) => fail(e),
         }
     }
@@ -1337,7 +1542,7 @@ mod macos_input {
                 return fail(e);
             }
         }
-        ok()
+        injected()
     }
 
     pub async fn move_mouse(x: i32, y: i32) -> CuActionResult {
@@ -1393,13 +1598,25 @@ mod macos_input {
         result(outcome)
     }
 
-    /// Set the clipboard to `text`, press ⌘V, and restore the previous
-    /// clipboard text. Far faster than `type_text` for long strings; note
-    /// that a non-text clipboard (e.g. an image) is not restored.
+    /// How long the frontmost app gets to consume the clipboard after ⌘V
+    /// before the previous content is restored. Paste is consumed while the
+    /// app processes the keypress, so this bounds the honest race: an app
+    /// that lazily re-reads the clipboard later sees the restored content.
+    const PASTE_CONSUME_DELAY: Duration = Duration::from_millis(300);
+
+    /// Set the clipboard to `text`, press ⌘V, then restore the previous
+    /// clipboard text (pbpaste/pbcopy are text-only: non-text content such
+    /// as images cannot be captured, so the clipboard is cleared instead of
+    /// left holding the pasted text). Far faster than `type_text` for long
+    /// strings. The result detail states exactly what happened to the
+    /// clipboard.
     pub async fn paste(text: &str) -> CuActionResult {
         use tokio::io::AsyncWriteExt;
         use tokio::process::Command;
 
+        // `pbpaste` succeeds with empty output for both an empty clipboard
+        // and non-text content — those two are indistinguishable, and
+        // neither yields anything restorable.
         let previous = Command::new("pbpaste")
             .output()
             .await
@@ -1431,14 +1648,42 @@ mod macos_input {
         if let Err(e) = set_clipboard(text.as_bytes().to_vec()).await {
             return fail(e);
         }
-        let paste_result = key("cmd+v").await;
+        let chord = key("cmd+v").await;
         // Give the frontmost app time to consume the clipboard before
-        // restoring what the user had there.
-        tokio::time::sleep(Duration::from_millis(300)).await;
-        if let Some(previous) = previous {
-            let _ = set_clipboard(previous).await;
+        // touching it again.
+        tokio::time::sleep(PASTE_CONSUME_DELAY).await;
+        let note = match previous {
+            None => {
+                "clipboard: previous content could not be captured; \
+                 the pasted text remains on the clipboard"
+                    .to_string()
+            }
+            Some(prev) => {
+                let restorable = !prev.is_empty();
+                match (set_clipboard(prev).await, restorable) {
+                    (Ok(()), true) => {
+                        "clipboard: previous text restored after paste".to_string()
+                    }
+                    // Clearing beats leaving the pasted text behind, but
+                    // non-text content (e.g. an image) is already gone.
+                    (Ok(()), false) => "clipboard: previous clipboard had no text \
+                         (empty or non-text); cleared after paste"
+                        .to_string(),
+                    (Err(e), _) => format!(
+                        "clipboard: restore failed ({e}); \
+                         the pasted text remains on the clipboard"
+                    ),
+                }
+            }
+        };
+        match chord.status {
+            // The restore above ran either way — keep its note on the failure.
+            CuActionStatus::Failed => CuActionResult {
+                detail: Some(note),
+                ..chord
+            },
+            _ => CuActionResult::injected_with(note),
         }
-        paste_result
     }
 
     /// Press at the start point, drag through interpolated positions, and
@@ -1511,39 +1756,172 @@ mod macos_input {
         result(outcome)
     }
 
-    /// Type unicode text. A trailing newline becomes a Return press, matching
-    /// CU models' habit of appending `\n` to mean Enter (and the previous
-    /// cliclick behavior).
+    /// One planned keystroke of a `type` action.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum TypeStep {
+        /// A key that exists on the ANSI-US layout, pressed via its virtual
+        /// keycode (with Shift where needed) — the same proven event shape
+        /// as [`key`]. `\n`/`\r` become Return and `\t` becomes Tab, so apps
+        /// see real keypresses.
+        Keycode { code: CGKeyCode, shift: bool },
+        /// UTF-16 units delivered via `CGEventKeyboardSetUnicodeString` for
+        /// characters with no ANSI-US key. At most [`TYPE_CHUNK_UTF16`]
+        /// units, never splitting a surrogate pair.
+        Unicode(Vec<u16>),
+    }
+
+    /// Plan the keystroke sequence for `text`.
+    ///
+    /// ASCII rides real keycodes because that is the event shape macOS apps
+    /// reliably consume: the 2026-07-13 live run showed Safari dropping
+    /// whole `CGEventKeyboardSetUnicodeString` chunks (keycode 0 + string)
+    /// while plain keycode events (`cmd+v`, chords) always landed. Keycodes
+    /// assume the ANSI-US layout — the documented assumption `key()` already
+    /// makes — and the read-back verification in `execute_actions` catches
+    /// (and reports honestly) the garbled output a non-US layout would
+    /// produce. Everything else falls back to paired, paced unicode-string
+    /// events.
+    fn plan_type_steps(text: &str) -> Vec<TypeStep> {
+        let mut steps = Vec::new();
+        let mut pending: Vec<u16> = Vec::new();
+        let flush = |pending: &mut Vec<u16>, steps: &mut Vec<TypeStep>| {
+            if !pending.is_empty() {
+                steps.push(TypeStep::Unicode(std::mem::take(pending)));
+            }
+        };
+        for ch in text.chars() {
+            if let Some((code, shift)) = typed_char_keycode(ch) {
+                flush(&mut pending, &mut steps);
+                steps.push(TypeStep::Keycode { code, shift });
+            } else {
+                if pending.len() + ch.len_utf16() > TYPE_CHUNK_UTF16 {
+                    flush(&mut pending, &mut steps);
+                }
+                let mut units = [0u16; 2];
+                pending.extend_from_slice(ch.encode_utf16(&mut units));
+            }
+        }
+        flush(&mut pending, &mut steps);
+        steps
+    }
+
+    /// ANSI-US keycode (+ Shift) for a directly typeable character.
+    fn typed_char_keycode(ch: char) -> Option<(CGKeyCode, bool)> {
+        match ch {
+            '\n' | '\r' => return Some((KeyCode::RETURN, false)),
+            '\t' => return Some((KeyCode::TAB, false)),
+            ' ' => return Some((KeyCode::SPACE, false)),
+            _ => {}
+        }
+        if let Some(code) = char_keycode(ch) {
+            return Some((code, false));
+        }
+        if ch.is_ascii_uppercase() {
+            return char_keycode(ch.to_ascii_lowercase()).map(|code| (code, true));
+        }
+        let base = match ch {
+            '!' => '1',
+            '@' => '2',
+            '#' => '3',
+            '$' => '4',
+            '%' => '5',
+            '^' => '6',
+            '&' => '7',
+            '*' => '8',
+            '(' => '9',
+            ')' => '0',
+            '_' => '-',
+            '+' => '=',
+            '{' => '[',
+            '}' => ']',
+            '|' => '\\',
+            ':' => ';',
+            '"' => '\'',
+            '<' => ',',
+            '>' => '.',
+            '?' => '/',
+            '~' => '`',
+            _ => return None,
+        };
+        char_keycode(base).map(|code| (code, true))
+    }
+
+    /// Post one down/up keycode pair (Shift as event flags, like `key()`).
+    fn post_typed_keycode(
+        source: &CGEventSource,
+        code: CGKeyCode,
+        shift: bool,
+    ) -> Result<(), String> {
+        let flags = if shift {
+            CGEventFlags::CGEventFlagShift
+        } else {
+            CGEventFlags::CGEventFlagNull
+        };
+        let down = CGEvent::new_keyboard_event(source.clone(), code, true)
+            .map_err(|_| "CGEvent keyboard event creation failed".to_string())?;
+        down.set_flags(flags);
+        down.post(CGEventTapLocation::HID);
+        let up = CGEvent::new_keyboard_event(source.clone(), code, false)
+            .map_err(|_| "CGEvent keyboard event creation failed".to_string())?;
+        up.set_flags(flags);
+        up.post(CGEventTapLocation::HID);
+        Ok(())
+    }
+
+    /// Post one down/up unicode-string pair. The payload rides on **both**
+    /// events (a lone stringless keycode-0 keyUp reads as an `a` release
+    /// and some consumers ignore the mispaired down).
+    fn post_unicode_chunk(source: &CGEventSource, units: &[u16]) -> Result<(), String> {
+        let down = CGEvent::new_keyboard_event(source.clone(), 0, true)
+            .map_err(|_| "CGEvent keyboard event creation failed".to_string())?;
+        down.set_string_from_utf16_unchecked(units);
+        down.post(CGEventTapLocation::HID);
+        let up = CGEvent::new_keyboard_event(source.clone(), 0, false)
+            .map_err(|_| "CGEvent keyboard event creation failed".to_string())?;
+        up.set_string_from_utf16_unchecked(units);
+        up.post(CGEventTapLocation::HID);
+        Ok(())
+    }
+
+    /// Deliver a planned keystroke sequence. Runs on one thread with one
+    /// event source: posts stay ordered and paced without runtime-scheduling
+    /// jitter between events (`CGEventSource` is also `!Send`, so it cannot
+    /// be held across `await` points).
+    fn deliver_type_steps(steps: &[TypeStep]) -> Result<(), String> {
+        let source = source()?;
+        for step in steps {
+            match step {
+                TypeStep::Keycode { code, shift } => {
+                    post_typed_keycode(&source, *code, *shift)?;
+                    std::thread::sleep(TYPE_KEY_GAP);
+                }
+                TypeStep::Unicode(units) => {
+                    post_unicode_chunk(&source, units)?;
+                    std::thread::sleep(TYPE_CHUNK_GAP);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Type text: real ANSI-US keycode events for characters that have one
+    /// (newlines as Return, tabs as Tab), paced unicode-string events for
+    /// the rest. See [`plan_type_steps`] for why.
+    ///
+    /// Returns `Injected` — delivery into the focused element is verified
+    /// (and the status upgraded/downgraded) by the read-back pass in
+    /// `execute_actions`, which has the display-target context this
+    /// function lacks.
     pub async fn type_text(text: &str) -> CuActionResult {
-        let presses_return = text.ends_with('\n');
-        let clean = text.trim_end_matches('\n');
-        let utf16: Vec<u16> = clean.encode_utf16().collect();
-        for chunk in utf16.chunks(TYPE_CHUNK_UTF16) {
-            let outcome = source().and_then(|source| {
-                let down = CGEvent::new_keyboard_event(source, 0, true)
-                    .map_err(|_| "CGEvent keyboard event creation failed".to_string())?;
-                down.set_string_from_utf16_unchecked(chunk);
-                down.post(CGEventTapLocation::HID);
-                Ok(())
-            });
-            if let Err(e) = outcome {
-                return fail(e);
-            }
-            let outcome = source().and_then(|source| {
-                let up = CGEvent::new_keyboard_event(source, 0, false)
-                    .map_err(|_| "CGEvent keyboard event creation failed".to_string())?;
-                up.post(CGEventTapLocation::HID);
-                Ok(())
-            });
-            if let Err(e) = outcome {
-                return fail(e);
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
+        let steps = plan_type_steps(text);
+        if steps.is_empty() {
+            return CuActionResult::injected_with("empty text; nothing typed");
         }
-        if presses_return {
-            return key("Return").await;
-        }
-        ok()
+        tokio::time::sleep(TYPE_LEAD_IN).await;
+        let outcome = tokio::task::spawn_blocking(move || deliver_type_steps(&steps))
+            .await
+            .unwrap_or_else(|e| Err(format!("type delivery task failed: {e}")));
+        result(outcome)
     }
 
     /// Press an xdotool-style key or chord (e.g. `Return`, `ctrl+shift+t`,
@@ -1745,6 +2123,122 @@ mod macos_input {
             assert_eq!(parse_key("/").unwrap().0, KeyCode::ANSI_SLASH);
             assert!(parse_key("no_such_key").is_err());
             assert!(parse_key("badmod+x").is_err());
+        }
+
+        #[test]
+        fn typed_char_keycode_maps_shift_pairs_and_controls() {
+            assert_eq!(typed_char_keycode('a'), Some((KeyCode::ANSI_A, false)));
+            assert_eq!(typed_char_keycode('A'), Some((KeyCode::ANSI_A, true)));
+            assert_eq!(typed_char_keycode('1'), Some((KeyCode::ANSI_1, false)));
+            assert_eq!(typed_char_keycode('!'), Some((KeyCode::ANSI_1, true)));
+            assert_eq!(typed_char_keycode('~'), Some((KeyCode::ANSI_GRAVE, true)));
+            assert_eq!(
+                typed_char_keycode('"'),
+                Some((KeyCode::ANSI_QUOTE, true))
+            );
+            assert_eq!(typed_char_keycode(' '), Some((KeyCode::SPACE, false)));
+            assert_eq!(typed_char_keycode('\n'), Some((KeyCode::RETURN, false)));
+            assert_eq!(typed_char_keycode('\r'), Some((KeyCode::RETURN, false)));
+            assert_eq!(typed_char_keycode('\t'), Some((KeyCode::TAB, false)));
+            // No ANSI-US key — must fall to the unicode path.
+            assert_eq!(typed_char_keycode('✓'), None);
+            assert_eq!(typed_char_keycode('é'), None);
+        }
+
+        #[test]
+        fn plan_type_steps_ascii_rides_keycodes_with_unicode_residue() {
+            // The live-regression phrase: 27 ASCII chars + one non-keyboard
+            // char. Every ASCII char must become a keycode step (the proven
+            // event shape); only the ✓ may use a unicode-string event.
+            let steps = plan_type_steps("Typed through Intendant CU ✓");
+            assert_eq!(steps.len(), 28);
+            for step in &steps[..27] {
+                assert!(
+                    matches!(step, TypeStep::Keycode { .. }),
+                    "ASCII must use keycodes: {step:?}"
+                );
+            }
+            assert_eq!(steps[27], TypeStep::Unicode(vec![0x2713]));
+            // Shift rides the uppercase letters.
+            assert_eq!(
+                steps[0],
+                TypeStep::Keycode {
+                    code: KeyCode::ANSI_T,
+                    shift: true
+                }
+            );
+            assert_eq!(
+                steps[1],
+                TypeStep::Keycode {
+                    code: KeyCode::ANSI_Y,
+                    shift: false
+                }
+            );
+        }
+
+        #[test]
+        fn plan_type_steps_chunks_unicode_at_twenty_units() {
+            // 28 consecutive non-keyboard chars: the exact shape of the
+            // 2026-07-13 live failure (20-unit chunk + 8-unit tail, first
+            // chunk dropped). The plan must produce both chunks, capped.
+            let text: String = std::iter::repeat('✓').take(28).collect();
+            let steps = plan_type_steps(&text);
+            assert_eq!(
+                steps,
+                vec![
+                    TypeStep::Unicode(vec![0x2713; 20]),
+                    TypeStep::Unicode(vec![0x2713; 8]),
+                ]
+            );
+        }
+
+        #[test]
+        fn plan_type_steps_never_splits_surrogate_pairs() {
+            // 😀 is two UTF-16 units; eleven of them (22 units) must chunk
+            // as 10 pairs + 1 pair, never splitting a pair at the 20-unit
+            // boundary.
+            let text: String = std::iter::repeat('😀').take(11).collect();
+            let steps = plan_type_steps(&text);
+            assert_eq!(steps.len(), 2);
+            let (first, second) = (&steps[0], &steps[1]);
+            let TypeStep::Unicode(first) = first else {
+                panic!("expected unicode step: {first:?}");
+            };
+            let TypeStep::Unicode(second) = second else {
+                panic!("expected unicode step: {second:?}");
+            };
+            assert_eq!(first.len(), 20);
+            assert_eq!(second.len(), 2);
+            // Each chunk decodes cleanly — no lone surrogates.
+            assert!(String::from_utf16(first).is_ok());
+            assert!(String::from_utf16(second).is_ok());
+        }
+
+        #[test]
+        fn plan_type_steps_mixed_text_interleaves_and_flushes() {
+            // Unicode runs flush before and after keycode chars, and
+            // newlines become Return keycodes anywhere in the text.
+            let steps = plan_type_steps("é1\né");
+            assert_eq!(
+                steps,
+                vec![
+                    TypeStep::Unicode("é".encode_utf16().collect()),
+                    TypeStep::Keycode {
+                        code: KeyCode::ANSI_1,
+                        shift: false
+                    },
+                    TypeStep::Keycode {
+                        code: KeyCode::RETURN,
+                        shift: false
+                    },
+                    TypeStep::Unicode("é".encode_utf16().collect()),
+                ]
+            );
+        }
+
+        #[test]
+        fn plan_type_steps_empty_text_plans_nothing() {
+            assert!(plan_type_steps("").is_empty());
         }
     }
 }
@@ -2075,29 +2569,19 @@ async fn execute_via_session(
                                 use base64::Engine;
                                 let base64_png =
                                     base64::engine::general_purpose::STANDARD.encode(&cropped);
-                                CuActionResult {
-                                    success: true,
-                                    screenshot: Some(ScreenshotData {
-                                        path,
-                                        base64_png,
-                                        width: w,
-                                        height: h,
-                                    }),
-                                    error: None,
-                                }
+                                CuActionResult::captured(ScreenshotData {
+                                    path,
+                                    base64_png,
+                                    width: w,
+                                    height: h,
+                                })
                             }
-                            Err(e) => CuActionResult {
-                                success: false,
-                                screenshot: None,
-                                error: Some(format!("Failed to write zoom screenshot: {e}")),
-                            },
+                            Err(e) => CuActionResult::failed(format!(
+                                "Failed to write zoom screenshot: {e}"
+                            )),
                         }
                     }
-                    Err(e) => CuActionResult {
-                        success: false,
-                        screenshot: None,
-                        error: Some(e),
-                    },
+                    Err(e) => CuActionResult::failed(e),
                 };
                 results.push(result);
                 needs_auto_screenshot = false;
@@ -2120,16 +2604,13 @@ async fn execute_via_session(
                 {
                     errors.push(format!("mouse up: {e}"));
                 }
-                let success = errors.is_empty();
-                let error = if success {
-                    None
+                results.push(if errors.is_empty() {
+                    CuActionResult::injected()
                 } else {
-                    Some(format!("Click injection failed: {}", errors.join("; ")))
-                };
-                results.push(CuActionResult {
-                    success,
-                    screenshot: None,
-                    error,
+                    CuActionResult::failed(format!(
+                        "Click injection failed: {}",
+                        errors.join("; ")
+                    ))
                 });
                 needs_auto_screenshot = true;
             }
@@ -2154,18 +2635,13 @@ async fn execute_via_session(
                     }
                     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                 }
-                let success = errors.is_empty();
-                results.push(CuActionResult {
-                    success,
-                    screenshot: None,
-                    error: if success {
-                        None
-                    } else {
-                        Some(format!(
-                            "DoubleClick injection failed: {}",
-                            errors.join("; ")
-                        ))
-                    },
+                results.push(if errors.is_empty() {
+                    CuActionResult::injected()
+                } else {
+                    CuActionResult::failed(format!(
+                        "DoubleClick injection failed: {}",
+                        errors.join("; ")
+                    ))
                 });
                 needs_auto_screenshot = true;
             }
@@ -2190,18 +2666,13 @@ async fn execute_via_session(
                     }
                     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                 }
-                let success = errors.is_empty();
-                results.push(CuActionResult {
-                    success,
-                    screenshot: None,
-                    error: if success {
-                        None
-                    } else {
-                        Some(format!(
-                            "TripleClick injection failed: {}",
-                            errors.join("; ")
-                        ))
-                    },
+                results.push(if errors.is_empty() {
+                    CuActionResult::injected()
+                } else {
+                    CuActionResult::failed(format!(
+                        "TripleClick injection failed: {}",
+                        errors.join("; ")
+                    ))
                 });
                 needs_auto_screenshot = true;
             }
@@ -2212,11 +2683,9 @@ async fn execute_via_session(
                 let result = session
                     .inject_input(crate::display::InputEvent::MouseDown { x: nx, y: ny, b })
                     .await;
-                let success = result.is_ok();
-                results.push(CuActionResult {
-                    success,
-                    screenshot: None,
-                    error: result.err().map(|e| format!("mouse down: {e}")),
+                results.push(match result {
+                    Ok(()) => CuActionResult::injected(),
+                    Err(e) => CuActionResult::failed(format!("mouse down: {e}")),
                 });
                 needs_auto_screenshot = true;
             }
@@ -2227,34 +2696,33 @@ async fn execute_via_session(
                 let result = session
                     .inject_input(crate::display::InputEvent::MouseUp { x: nx, y: ny, b })
                     .await;
-                let success = result.is_ok();
-                results.push(CuActionResult {
-                    success,
-                    screenshot: None,
-                    error: result.err().map(|e| format!("mouse up: {e}")),
+                results.push(match result {
+                    Ok(()) => CuActionResult::injected(),
+                    Err(e) => CuActionResult::failed(format!("mouse up: {e}")),
                 });
                 needs_auto_screenshot = true;
             }
             CuAction::Type { text } => {
                 let result = session.inject_text(text).await;
-                let success = result.is_ok();
-                results.push(CuActionResult {
-                    success,
-                    screenshot: None,
-                    error: result.err().map(|e| e.to_string()),
+                results.push(match result {
+                    Ok(()) => CuActionResult::injected(),
+                    Err(e) => CuActionResult::failed(e.to_string()),
                 });
                 needs_auto_screenshot = true;
             }
             CuAction::Paste { text } => {
                 // Clipboard paste through the backend (Windows: arboard +
                 // ctrl+v; Wayland: portal clipboard). Backends without
-                // clipboard access return the trait-default error.
+                // clipboard access return the trait-default error. The
+                // outcome's note reports what happened to the previous
+                // clipboard content (restored / not restorable).
                 let result = session.paste_text(text).await;
-                let success = result.is_ok();
-                results.push(CuActionResult {
-                    success,
-                    screenshot: None,
-                    error: result.err().map(|e| e.to_string()),
+                results.push(match result {
+                    Ok(outcome) => match outcome.clipboard_note {
+                        Some(note) => CuActionResult::injected_with(note),
+                        None => CuActionResult::injected(),
+                    },
+                    Err(e) => CuActionResult::failed(e.to_string()),
                 });
                 needs_auto_screenshot = true;
             }
@@ -2304,10 +2772,10 @@ async fn execute_via_session(
                         }
                     }
                 }
-                results.push(CuActionResult {
-                    success,
-                    screenshot: None,
-                    error,
+                results.push(if success {
+                    CuActionResult::injected()
+                } else {
+                    CuActionResult::failed(error.unwrap_or_else(|| "key injection failed".into()))
                 });
                 needs_auto_screenshot = true;
             }
@@ -2348,15 +2816,10 @@ async fn execute_via_session(
                         }
                     }
                 }
-                let success = errors.is_empty();
-                results.push(CuActionResult {
-                    success,
-                    screenshot: None,
-                    error: if success {
-                        None
-                    } else {
-                        Some(errors.join("; "))
-                    },
+                results.push(if errors.is_empty() {
+                    CuActionResult::injected()
+                } else {
+                    CuActionResult::failed(errors.join("; "))
                 });
                 needs_auto_screenshot = true;
             }
@@ -2384,10 +2847,9 @@ async fn execute_via_session(
                         dy,
                     })
                     .await;
-                results.push(CuActionResult {
-                    success: r.is_ok(),
-                    screenshot: None,
-                    error: r.err().map(|e| e.to_string()),
+                results.push(match r {
+                    Ok(()) => CuActionResult::injected(),
+                    Err(e) => CuActionResult::failed(e.to_string()),
                 });
                 needs_auto_screenshot = true;
             }
@@ -2401,10 +2863,9 @@ async fn execute_via_session(
                         buttons: 0,
                     })
                     .await;
-                results.push(CuActionResult {
-                    success: r.is_ok(),
-                    screenshot: None,
-                    error: r.err().map(|e| e.to_string()),
+                results.push(match r {
+                    Ok(()) => CuActionResult::injected(),
+                    Err(e) => CuActionResult::failed(e.to_string()),
                 });
                 needs_auto_screenshot = true;
             }
@@ -2450,25 +2911,20 @@ async fn execute_via_session(
                 {
                     errors.push(format!("mouse up: {e}"));
                 }
-                let success = errors.is_empty();
-                results.push(CuActionResult {
-                    success,
-                    screenshot: None,
-                    error: if success {
-                        None
-                    } else {
-                        Some(format!("Drag injection failed: {}", errors.join("; ")))
-                    },
+                results.push(if errors.is_empty() {
+                    CuActionResult::injected()
+                } else {
+                    CuActionResult::failed(format!(
+                        "Drag injection failed: {}",
+                        errors.join("; ")
+                    ))
                 });
                 needs_auto_screenshot = true;
             }
             CuAction::Wait { ms } => {
                 tokio::time::sleep(std::time::Duration::from_millis(*ms)).await;
-                results.push(CuActionResult {
-                    success: true,
-                    screenshot: None,
-                    error: None,
-                });
+                // The elapsed sleep IS the effect — nothing left to verify.
+                results.push(CuActionResult::verified());
             }
         }
         if !matches!(
@@ -2478,7 +2934,7 @@ async fn execute_via_session(
             last_input_at = Some(std::time::Instant::now());
         }
         // Every arm above pushes exactly one result for `action`.
-        if results.last().is_some_and(|r| r.success) {
+        if results.last().is_some_and(|r| r.success()) {
             if let Some(obs) = observer {
                 obs.observe(target, (width, height), action);
             }
@@ -2489,7 +2945,7 @@ async fn execute_via_session(
     if needs_auto_screenshot {
         let auto =
             take_session_screenshot(session, screenshot_dir, action_counter, last_input_at).await;
-        if auto.success {
+        if auto.success() {
             let screenshot = auto.screenshot.clone();
             results.push(auto);
             // Attach to first result if it has no screenshot (convenience for callers).
@@ -2560,16 +3016,8 @@ async fn take_session_screenshot(
     min_fresh: Option<std::time::Instant>,
 ) -> CuActionResult {
     match session_screenshot_data(session, screenshot_dir, counter, min_fresh, false).await {
-        Ok(s) => CuActionResult {
-            success: true,
-            screenshot: Some(s),
-            error: None,
-        },
-        Err(e) => CuActionResult {
-            success: false,
-            screenshot: None,
-            error: Some(e),
-        },
+        Ok(s) => CuActionResult::captured(s),
+        Err(e) => CuActionResult::failed(e),
     }
 }
 
@@ -3414,7 +3862,7 @@ mod tests {
             .await;
             assert_eq!(results.len(), actions.len(), "one result per action");
             for result in results {
-                assert!(!result.success);
+                assert!(!result.success());
                 assert_eq!(
                     result.error.as_deref(),
                     Some(user_session_denied_message()),
@@ -3487,7 +3935,7 @@ mod tests {
             None,
         )
         .await;
-        assert!(!results[0].success);
+        assert!(!results[0].success());
         assert_eq!(
             results[0].error.as_deref(),
             Some(no_session_message(
@@ -3513,7 +3961,7 @@ mod tests {
             None,
         )
         .await;
-        assert!(!results[0].success);
+        assert!(!results[0].success());
         assert!(
             results[0]
                 .error
@@ -3912,5 +4360,94 @@ mod tests {
         assert_eq!(mouse_button_index(MouseButton::Left), 0);
         assert_eq!(mouse_button_index(MouseButton::Middle), 1);
         assert_eq!(mouse_button_index(MouseButton::Right), 2);
+    }
+
+    // ── Result statuses & read-back helpers ─────────────────────────────
+
+    #[test]
+    fn action_status_labels_and_success_are_consistent() {
+        let verified = CuActionResult::verified();
+        assert_eq!(verified.status.label(), "ok");
+        assert!(verified.success());
+
+        let injected = CuActionResult::injected();
+        assert_eq!(injected.status.label(), "injected");
+        assert!(injected.success(), "injected is dispatched, not failed");
+        assert!(injected.error.is_none());
+
+        let with_note = CuActionResult::injected_with("clipboard: restored");
+        assert_eq!(with_note.status, CuActionStatus::Injected);
+        assert_eq!(with_note.detail.as_deref(), Some("clipboard: restored"));
+
+        let failed = CuActionResult::failed("boom");
+        assert_eq!(failed.status.label(), "failed");
+        assert!(!failed.success());
+        assert_eq!(failed.error.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn type_readback_expectation_skips_empty_and_control_text() {
+        // Empty and control-bearing text can submit forms or move focus —
+        // reading the focused element afterwards would verify nothing.
+        assert_eq!(type_readback_expectation(""), None);
+        assert_eq!(type_readback_expectation("hello\n"), None);
+        assert_eq!(type_readback_expectation("a\tb"), None);
+        assert_eq!(type_readback_expectation("line1\nline2"), None);
+        // Plain single-line text (unicode included) is verifiable.
+        assert_eq!(
+            type_readback_expectation("Typed through Intendant CU ✓"),
+            Some("Typed through Intendant CU ✓")
+        );
+    }
+
+    #[test]
+    fn excerpt_truncates_on_char_boundaries() {
+        assert_eq!(excerpt("short", 10), "short");
+        assert_eq!(excerpt("✓✓✓✓", 2), "✓✓…");
+        assert_eq!(excerpt("abcdef", 3), "abc…");
+    }
+
+    #[test]
+    fn summarize_results_distinguishes_dispatch_from_verified() {
+        let click = CuAction::Click {
+            x: 1,
+            y: 2,
+            button: MouseButton::Left,
+        };
+        let type_action = CuAction::Type { text: "hi".into() };
+
+        // All verified (e.g. screenshot-only batches) keeps the plain wording.
+        let summary = summarize_results_for_model(
+            &[CuAction::Screenshot],
+            &[CuActionResult::verified()],
+        );
+        assert_eq!(summary, "Actions executed successfully.");
+
+        // Injected-only batches must not read as verified success, and
+        // per-action details ride along, labeled by action kind.
+        let summary = summarize_results_for_model(
+            &[click.clone(), type_action.clone()],
+            &[
+                CuActionResult::injected(),
+                CuActionResult::injected_with("type dispatched; delivery unverified — no focused element"),
+            ],
+        );
+        assert!(summary.starts_with("Actions dispatched (2 injected"), "{summary}");
+        assert!(summary.contains("effect not independently verified"), "{summary}");
+        assert!(
+            summary.contains("type: type dispatched; delivery unverified"),
+            "{summary}"
+        );
+
+        // Any failure wins the headline and carries the error text.
+        let summary = summarize_results_for_model(
+            &[click, type_action],
+            &[
+                CuActionResult::injected(),
+                CuActionResult::failed("type read-back mismatch: expected \"hi\""),
+            ],
+        );
+        assert!(summary.starts_with("Some actions failed:"), "{summary}");
+        assert!(summary.contains("read-back mismatch"), "{summary}");
     }
 }

--- a/src/bin/caller/display_glue.rs
+++ b/src/bin/caller/display_glue.rs
@@ -1406,8 +1406,7 @@ pub(crate) async fn run_cu_task(
                 .await;
 
                 let last_screenshot = results.iter().rev().find_map(|r| r.screenshot.as_ref());
-                let output =
-                    computer_use::summarize_results_for_model(&cu_call.actions, &results);
+                let output = computer_use::summarize_results_for_model(&cu_call.actions, &results);
 
                 if let Some(screenshot) = last_screenshot {
                     let images = vec![conversation::ImageData {

--- a/src/bin/caller/display_glue.rs
+++ b/src/bin/caller/display_glue.rs
@@ -1406,13 +1406,8 @@ pub(crate) async fn run_cu_task(
                 .await;
 
                 let last_screenshot = results.iter().rev().find_map(|r| r.screenshot.as_ref());
-                let output = if results.iter().all(|r| r.success) {
-                    "Actions executed successfully.".to_string()
-                } else {
-                    let errors: Vec<&str> =
-                        results.iter().filter_map(|r| r.error.as_deref()).collect();
-                    format!("Some actions failed: {}", errors.join("; "))
-                };
+                let output =
+                    computer_use::summarize_results_for_model(&cu_call.actions, &results);
 
                 if let Some(screenshot) = last_screenshot {
                     let images = vec![conversation::ImageData {
@@ -1744,12 +1739,7 @@ pub(crate) async fn execute_cu_calls(
 
         // Find the last screenshot from results
         let last_screenshot = results.iter().rev().find_map(|r| r.screenshot.as_ref());
-        let output = if results.iter().all(|r| r.success) {
-            "Actions executed successfully.".to_string()
-        } else {
-            let errors: Vec<&str> = results.iter().filter_map(|r| r.error.as_deref()).collect();
-            format!("Some actions failed: {}", errors.join("; "))
-        };
+        let output = computer_use::summarize_results_for_model(&cu_call.actions, &results);
 
         if let Some(screenshot) = last_screenshot {
             let images = vec![conversation::ImageData {

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -2031,12 +2031,11 @@ fn format_cu_action_brief(action: &crate::computer_use::CuAction) -> String {
     }
 }
 
+/// The per-action status label shown to models: `ok` (effect verified),
+/// `injected` (dispatched to the OS, effect unverified — the honest ceiling
+/// for most input injection), or `failed`.
 fn cu_result_status(result: &crate::computer_use::CuActionResult) -> &'static str {
-    if result.success && result.error.is_none() {
-        "ok"
-    } else {
-        "failed"
-    }
+    result.status.label()
 }
 
 /// Draw red crosshairs on a screenshot at click/double_click coordinates.
@@ -2305,20 +2304,18 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn cu_result_status_respects_success_flag() {
-        let result = crate::computer_use::CuActionResult {
-            success: false,
-            screenshot: None,
-            error: None,
-        };
-        assert_eq!(cu_result_status(&result), "failed");
-
-        let result = crate::computer_use::CuActionResult {
-            success: true,
-            screenshot: None,
-            error: None,
-        };
-        assert_eq!(cu_result_status(&result), "ok");
+    fn cu_result_status_distinguishes_dispatch_from_verified_effect() {
+        use crate::computer_use::CuActionResult;
+        // Dispatch failure (and verification mismatch) → failed.
+        assert_eq!(cu_result_status(&CuActionResult::failed("boom")), "failed");
+        // Dispatched but unverified must NOT read as an unqualified ok.
+        assert_eq!(cu_result_status(&CuActionResult::injected()), "injected");
+        assert_eq!(
+            cu_result_status(&CuActionResult::injected_with("note")),
+            "injected"
+        );
+        // Only a verified effect earns "ok".
+        assert_eq!(cu_result_status(&CuActionResult::verified()), "ok");
     }
 
     pub(crate) fn spawn_codex_thread_action_result(

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -1024,7 +1024,7 @@ impl IntendantServer {
     }
 
     #[tool(
-        description = "Execute computer-use actions on a display (click, type, scroll, etc). Returns action status plus an MCP image content block for the post-action screenshot. Set coordinate_space to \"normalized_1000\" if coordinates are on a 0-1000 grid."
+        description = "Execute computer-use actions on a display (click, type, scroll, etc). Returns per-action statuses — ok (effect verified, e.g. typed text read back from the focused field), injected (events dispatched to the OS, effect unverified — verify from the screenshot), failed — plus an MCP image content block for the post-action screenshot. Set coordinate_space to \"normalized_1000\" if coordinates are on a 0-1000 grid."
     )]
     pub(crate) async fn execute_cu_actions(
         &self,
@@ -1123,10 +1123,19 @@ impl IntendantServer {
         if let Some(hint) = activation_request.hint() {
             summaries.push(hint.to_string());
         }
+        // Status vocabulary: `ok` = effect verified, `injected` = events
+        // dispatched to the OS but effect unverified (the honest ceiling for
+        // most input injection), `failed` = dispatch failed or verification
+        // contradicted the intent. The detail carries the evidence
+        // (read-back excerpts, clipboard restore notes) or the error.
         for (i, (action, result)) in actions.iter().zip(results.iter()).enumerate() {
             let status = cu_result_status(result);
             let action_desc = format_cu_action_brief(action);
-            let detail = result.error.as_deref().unwrap_or("");
+            let detail = result
+                .error
+                .as_deref()
+                .or(result.detail.as_deref())
+                .unwrap_or("");
             if detail.is_empty() {
                 summaries.push(format!("action[{}] {}: {}", i, action_desc, status));
             } else {
@@ -1141,10 +1150,11 @@ impl IntendantServer {
         // clean MCP success just because a screenshot came along. Every
         // action failing marks the whole call is_error; partial failures get
         // a loud leading line (a "failed" buried mid-list gets skimmed over).
+        // `injected` counts as dispatched, not failed.
         let failed = actions
             .iter()
             .zip(results.iter())
-            .filter(|(_, r)| cu_result_status(r) != "ok")
+            .filter(|(_, r)| !r.success())
             .count();
         let all_failed = failed == actions.len();
         if failed > 0 && !all_failed {

--- a/tests/skills/cu-type-injection/SKILL.md
+++ b/tests/skills/cu-type-injection/SKILL.md
@@ -1,0 +1,80 @@
+# CU type-injection live regression (macOS)
+
+Live proof that `cu type` **delivers every character** and **reports
+honestly** on the macOS user-session display. Guards the 2026-07-13
+defect class: `CGEventKeyboardSetUnicodeString` chunks silently dropped
+by the target app (observed live: the 28-unit phrase below arrived as
+only its post-chunk-boundary suffix `ant CU ✓`, and later runs delivered
+nothing at all) while the action still returned an unqualified ok.
+
+The hermetic twins live in `computer_use.rs` unit tests (keystroke
+planning, chunk boundaries, read-back verdicts, status mapping). This
+smoke covers what those can't: real CGEvent delivery into real apps,
+the AX read-back against a live field, and Safari's address bar.
+
+Not in CI because it injects input into a real user graphical session
+(never run it on a machine someone is actively using) and needs the
+Accessibility + Screen Recording permissions.
+
+## Prerequisites
+
+- macOS box with a live GUI session you are allowed to drive.
+- A controller built from **your own worktree**, with Accessibility
+  and Screen Recording granted to the invoking process tree.
+- A daemon from that build (`./target/release/intendant --no-web` in a
+  scratch session, or drive a running daemon with `intendant ctl`).
+- The user-session display grant (`grant_user_display`, or an owner
+  surface).
+
+## The canonical phrase
+
+Every leg types exactly:
+
+```
+Typed through Intendant CU ✓
+```
+
+28 UTF-16 units: 27 ASCII (keycode path) + `✓` U+2713 (unicode-event
+path). Under the old 20-unit chunking the failure signature was
+delivery of only `ant CU ✓` — if you ever see that suffix alone, the
+first-chunk drop is back.
+
+## The legs
+
+Open TextEdit (or any AX-readable text field) plus Safari. Then, via
+MCP `execute_cu_actions` or `intendant ctl cu actions`, run each leg
+**three times** — the defect was intermittent:
+
+1. **Already-focused field**: click the TextEdit document once
+   manually, then run a lone `type` action with the phrase.
+2. **Immediately-clicked field**: one batch of
+   `click(field) → type(phrase)` with no wait between them.
+3. **Safari address bar**: batch `key(cmd+l) → type(phrase)` with
+   Safari frontmost.
+
+## Expected honest statuses
+
+- Every character of the phrase visible at the target, in order,
+  including the `✓`, on **every** repeat.
+- Legs 1–2 (AX-readable value): `type` reports `ok` with read-back
+  detail. Corrupt the run deliberately (e.g. click a non-text area
+  first) and the result must be `failed` with expected-vs-observed
+  text — never an unqualified ok.
+- Leg 3: `ok` when Safari exposes the field value via AX, otherwise
+  `injected` with a read-back-unavailable note. Never `ok` without
+  qualification when the bar stayed empty.
+- Any other input action (`click`, `key`) reports `injected`, not
+  `ok` — dispatch confirmed, effect unverified.
+
+## Paste-residue leg (CU-08)
+
+With a known text on the clipboard (`echo -n sentinel | pbcopy`):
+
+1. `paste("residue-test ✓")` into the TextEdit field.
+2. The pasted text must appear; the result detail must say the
+   previous clipboard text was restored.
+3. `pbpaste` afterwards must print `sentinel` again.
+4. Repeat with a non-text clipboard (copy an image in Preview): the
+   detail must say the previous content could not be captured/restored
+   and the clipboard must be left cleared, not holding the paste
+   payload.


### PR DESCRIPTION
Fixes three Computer Use input-injection defects from the 2026-07-13 live CU e2e run (macOS / Safari / user-session display).

## CU-01 (P1): macOS `type` silently dropped text
**Root cause**: the type path posted the whole string as back-to-back `CGEventKeyboardSetUnicodeString` events (keycode 0 + 20-UTF-16-unit chunks, 10 ms apart, fresh event source per event, keyUp unpaired/stringless). The live run delivered exactly the post-chunk-boundary suffix of the 28-unit phrase ("ant CU ✓" = units 21–28) — whole leading chunks were dropped by the focused app while plain keycode events (`cmd+v`, chords) on the same targets always landed, and the action still reported ok.

**Fix**: typed ASCII now rides real ANSI-US keycode events (the proven shape; Shift for uppercase/symbols, `\n` → Return, `\t` → Tab); only characters without an ANSI-US key use unicode-string events — properly paired (payload on keyDown *and* keyUp), chunked ≤20 units on char boundaries (surrogate pairs never split), paced, delivered from a single blocking thread with one event source, after a settle so a just-clicked target finishes its focus transition. After dispatch, the focused element's AX value is read back (bounded: 2 reads) and the result is upgraded to verified, downgraded to failed with expected-vs-observed evidence, or annotated dispatched-but-unverified when AX cannot see the value (secure fields, no focused element, non-string values, multi-line text).

## CU-03 (P2): results conflated injection with semantic success
`CuActionResult` now carries `CuActionStatus` (Verified / Injected / Failed) + a `detail` field. `ok` = effect confirmed (captures, wait, verified type read-back); `injected` = dispatched to the OS, effect unverified — the honest ceiling for clicks/keys/scrolls everywhere and for typing on Linux/Windows/Wayland; `failed` = dispatch failed or verification contradicted the intent. MCP summaries, the tool description, and the native-loop formatter all speak the vocabulary; injected does not count as failed in the tool-level failure accounting; the Live-overlay observer keys off dispatch (a downgraded type still painted keystrokes).

## CU-08 (P2): paste clipboard residue
`DisplayBackend::paste_text` returns a `PasteOutcome` with an honest clipboard note. macOS restores the previous text clipboard (or clears it when it was empty/non-text — pbpaste cannot capture images) after a bounded 300 ms consume delay; Windows gains the same save/restore via arboard; X11 and Wayland selections are pull-based, so restore would race the paste itself — behavior kept, residue now stated in the result detail and the rationale codified in `x11_input::paste`.

## Testing
- Hermetic unit tests: keystroke planner (chunk boundary of the live failure, surrogate pairs, shift map, newline/tab mapping), read-back gating, status/label mapping, batch-summary formatter. 3261 passed.
- `cargo fmt --check`, `cargo clippy`, `cargo test --test e2e` (20/20) green locally on macOS.
- `tests/skills/cu-type-injection/SKILL.md` documents the live regression (exact phrase, already-focused / immediately-clicked / address-bar cases, paste-residue leg) — runs post-landing on operator hardware, not in CI.
- Docs: `docs/src/computer-use-and-audio.md` gains an "Action results: dispatch vs. effect" section.