### PR TITLE
docs: staleness corrections batch

### DIFF
--- a/docs/src/presence.md
+++ b/docs/src/presence.md
@@ -339,23 +339,28 @@ model or the browser voice model is driving.
 - **callbacks.rs** — JS callback management for voice/tool events.
 
 Normal `cargo build` checks `crates/presence-web`, `crates/presence-core`, and
-`crates/station-web` and auto-rebuilds stale WASM artifacts with `wasm-pack`
-when it is installed. Manual fallback:
+`crates/station-web` and auto-rebuilds stale WASM artifacts with `wasm-pack` —
+but only when the installed `wasm-pack` matches the version pinned in
+`.wasm-pack-version` (releases emit byte-different artifacts, and the artifacts
+are committed; any other version skips the rebuild with a warning). Manual
+fallback — `scripts/build-wasm.sh` is the canonical builder, rebuilding both
+WASM crates with the same flags as `build.rs`:
 
 ```bash
-cd crates/presence-web
-wasm-pack build --target web --out-dir ../../static/wasm-web --out-name presence_web
+bash scripts/build-wasm.sh
 cargo build --release -p intendant   # re-embed the compiled WASM
 ```
 
-The `static/wasm-web/` files are pre-compiled artifacts. If `wasm-pack` is not
-installed or the build script reports an auto-rebuild failure, run the manual
-command and then `cargo build` to re-embed the compiled WASM.
+The `static/wasm-web/` and `static/wasm-station/` files are pre-compiled,
+committed artifacts. If the pinned `wasm-pack` is not installed or the build
+script reports an auto-rebuild failure, run the script and then `cargo build`
+to re-embed the compiled WASM. Regenerate and commit these artifacts on macOS
+only — the output is not byte-deterministic across host triples.
 
 ## See Also
 
-- [Autonomy & Approvals](./autonomy.md) — how presence narration and approvals surface in
-  the terminal UI.
+- [Autonomy & Approvals](./autonomy.md) — the approval model presence
+  narrates and every frontend surfaces.
 - [Web Dashboard](./web-dashboard.md) — the dashboard host for browser voice.
 - [Computer Use & Live Audio](./computer-use-and-audio.md) — where
   `display_target` / `reference_frame_ids` from `submit_task` route.

--- a/docs/src/windows-support.md
+++ b/docs/src/windows-support.md
@@ -119,7 +119,11 @@ check.
 
 **Optional / runtime / manual** (reported, but never fail `-Check`):
 
-- **wasm-pack** (optional) — for rebuilding the presence-web WASM bundle.
+- **wasm-pack** (optional) — for rebuilding the browser WASM crates
+  (`presence-web`, `station-web`) locally. Only the version pinned in
+  `.wasm-pack-version` will rebuild (`build.rs` skips any other), and
+  regenerating the *committed* `static/wasm-*` artifacts is a macOS-only
+  step — WASM output is not byte-deterministic across host triples.
 - **ffmpeg** — the voice audio bridge shells out to `ffmpeg`/`ffplay`.
 - **Media Foundation** — built into Windows client SKUs; on Windows Server the
   script enables the `Server-Media-Foundation` feature.


### PR DESCRIPTION
Docs staleness corrections batch (alpha-readiness review follow-up), scoped around the in-flight #298 trust-docs rewrite: every item was re-verified against source first, and anything #298 already fixes is skipped here to avoid collisions.

## Fixed here
- **docs/src/presence.md — WASM build guidance**: the manual fallback is now `bash scripts/build-wasm.sh` (the canonical builder covering both `presence-web` and `station-web` with the same flags as `build.rs`); documents the `.wasm-pack-version` pin gating auto-rebuilds, names both committed artifact dirs (`static/wasm-web/`, `static/wasm-station/`), and records macOS-only regeneration of committed artifacts.
- **docs/src/presence.md — See Also**: dropped the claim that approvals surface "in the terminal UI" (the terminal TUI was removed).
- **docs/src/windows-support.md — wasm-pack entry**: names both browser WASM crates, the `.wasm-pack-version` pin (`build.rs` skips any other version), and macOS-only regeneration of the committed `static/wasm-*` artifacts.

## Skipped — already fixed on the #298 branch (checked per-hunk against its head)
- README: "ten tabs" → eleven destinations incl. Vault; Station "prototype" copy; `setup browser` → `setup browsers`; "four execution modes (user)" → the current execution shapes.
- docs/src/getting-started.md: the e2e suite description (keyless mock-provider tests, CI on all three platforms, real-LLM scenarios under `tests/skills/`) and the pinned Rust / wasm-pack toolchain facts. Note for #298: current main has 21 `#[tokio::test]` cases in `tests/e2e/main.rs`; its branch text says 20 and may want a touch-up on its next main merge.
- docs/src/session-logging.md: message-search heading now default-on with `?message_search=off` escape (verified default-on in `static/app/57-sessions-message-search.js`).
- src/bin/caller/main.rs: the `--no-web` help line claiming the terminal TUI, plus stale TUI comments.
- docs/src/external-agent-orchestration.md: the TUI "Question mode" passage.

## Verified already correct — no change needed
- `scripts/intendant-ctl.sh` exists and matches its `docs/src/integrations.md` references (`status`/`approve`/`follow`/`start`; `--control-socket` and the per-pid socket path are live in `main.rs`/`control.rs`) — the "nonexistent script" review claim was stale.
- `docs/src/station.md` intro already describes an operational surface with the immersive presentation in progress; no "prototype" wording.
- `docs/src/architecture.md` / `multi-agent.md` / `configuration.md` mention `run_user_mode` / `INTENDANT_ROLE` only in explicitly historical ("is gone") notes; the execution-shapes table in `multi-agent.md` is current.
- `intendant setup` canonical subcommand is `browsers` (`setup.rs`; singular accepted as alias); all docs besides the #298-owned README row already say `browsers`.

Battery: `cargo test --bins` (3164 + 54 + 83 passed, 0 failed), `cargo clippy` clean, `cargo fmt --check` clean.
