### PR TITLE
docs: SECURITY.md + honest single-writer/event-lane narratives + approve-all matrix

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security Policy
+
+Intendant is **alpha software** that operates real machines: it runs an AI
+agent with a shell, a desktop it can see and control, credentials it can
+borrow, and federation to peer machines. Security reports are taken
+seriously and handled with priority.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for an exploitable bug.**
+
+Report privately via GitHub's security advisory flow:
+**[Security → Report a vulnerability](https://github.com/intendant-dev/Intendant/security/advisories/new)**
+on this repository. You'll get an acknowledgment there; expect
+alpha-stage response times (days, not hours) and no bug bounty — credit
+in the advisory and release notes is gladly given.
+
+If the advisory form is unavailable, open a plain issue that says only
+"security report — requesting a private channel" with **no technical
+detail**, and a maintainer will arrange one.
+
+## Scope
+
+Highest-value reports, roughly in order:
+
+- **The runtime/controller boundary** — anything that lets a compromised
+  model conversation reach API keys, or the sandboxed runtime reach model
+  APIs (`intendant-runtime` is Landlock/Seatbelt/restricted-token
+  sandboxed and must never hold keys).
+- **Trust architecture / IAM** — minting or exercising daemon authority
+  without a trusted anchor: hosted/Connect provenance escaping its
+  immutable `role:none`, fleet-name (discovery-only) origins reaching
+  control surfaces, grant/role/ceiling bypasses, org-document or
+  revocation-list forgery.
+- **Credential custody** — vault unsealing without the owner, lease
+  escalation or exfiltration, leaking materialized OAuth files beyond
+  their documented lifetime.
+- **Gateway authentication** — mTLS/loopback/peer-identity bypasses,
+  origin-gate (CSRF/DNS-rebind) escapes, authority surviving revocation.
+- **Sandbox escapes** on any platform, and **federation** trust bypasses
+  between paired daemons.
+- The **release channel**: installer or update-path integrity, artifact
+  substitution the transparency log would not catch.
+
+Out of scope: vulnerabilities in the model providers themselves, social
+engineering of the operator, and reports that require an already-root
+local attacker.
+
+## Supported versions
+
+Alpha: only the **latest tagged release** and current `main` receive
+fixes. There are no backports.
+
+## Honest limits
+
+The documented trust model states its own boundaries — see
+[Trust Architecture](docs/src/trust-architecture.md) and
+[Credential Custody](docs/src/credential-custody.md) for what the system
+does *not* defend against (e.g., the hosted rendezvous is trusted for
+availability and for the browser code and installers it serves). Reports
+that sharpen or contradict those stated limits are welcome too.

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -53,13 +53,31 @@ Two facts about this diagram drive everything below:
 
 1. **Frontends are display-only.** The web dashboard, MCP server, and
    control socket all *render* state and *emit intents* (`ControlMsg`) onto the
-   EventBus. None of them mutate shared state directly. The single writer is the
-   [control plane](./control-plane-and-daemon.md).
-2. **The EventBus is the spine.** It is one `tokio::sync::broadcast` channel
-   (`event.rs`, `EventBus`) carrying `AppEvent`. `ControlMsg` intents travel as
-   `AppEvent::ControlCommand`. Every long-lived subsystem subscribes to the bus;
-   adding a frontend or a backend means adding a subscriber, not rewiring the
-   others.
+   EventBus. For intent handling there is exactly one writer — the
+   [control plane](./control-plane-and-daemon.md) interprets the
+   state-mutating `ControlMsg`s and applies them. The rule governs the
+   intent path, not literally every write to shared state: a few
+   documented paths mutate shared state from their own tasks — approval
+   side effects (the agent loop applies approve-all escalation and the
+   first display-control grant directly to the shared autonomy state,
+   identically from every approval surface), the MCP autonomy/display
+   tools, and platform display activation. Anything beyond those is a
+   bug, not a precedent.
+2. **The EventBus is the spine.** Its main channel is one bounded
+   `tokio::sync::broadcast` (`event.rs`, `EventBus`) carrying `AppEvent`;
+   `ControlMsg` intents travel as `AppEvent::ControlCommand`. Broadcast
+   subscribers are best-effort — a flooded ring drops oldest events
+   (`RecvError::Lagged`) — so the bus also fans out two **lossless
+   lanes**, unbounded per-subscriber mpsc queues fed at the emit point
+   with declared low-volume subsets: `subscribe_intents` (user intents
+   plus the session-bookkeeping events that route them — a flooded ring
+   must never eat an approve/interrupt click) and
+   `subscribe_session_log` (the lifecycle subset persisted to
+   `session.jsonl`; also what durable-state consumers like the fission
+   ledger watcher fold). Every long-lived subsystem subscribes to the
+   bus; adding a frontend or a backend means adding a subscriber, not
+   rewiring the others — but a consumer that *acts durably* on an event
+   must take a lossless lane, never the broadcast ring.
 
 ## Security Model
 

--- a/docs/src/autonomy.md
+++ b/docs/src/autonomy.md
@@ -187,3 +187,21 @@ only the kind and session label, never the reason text). On a headless
 daemon with no owner surface, requests are refused immediately
 (`unavailable`) instead of blocking — the same fail-closed posture as
 headless approvals.
+
+## "Approve all" scope, by surface
+
+The same two words appear on several surfaces with deliberately different
+blast radii. What each one actually grants:
+
+| Surface | What "approve all" does | Scope | Lifetime |
+|---|---|---|---|
+| Native runtime approvals | Sets the autonomy level to **Full** (`apply_user_approval`) | **Daemon-wide for native sessions** — one shared autonomy state backs every native session | In-memory: until lowered again (autonomy control or restart, which returns to the configured level) |
+| External agents (Codex / Claude Code) | Auto-approves that backend's subsequent approval requests (`approve_all_session`) | **That one external session only** — deliberately never touches native autonomy | The external session's lifetime |
+| Live audio | Does not exist. Every live-audio spawn requires its own explicit human approval; with no approver surface the spawn is denied outright | Per spawn | One consent per spawn |
+| Questions (`ask_user` and kin) | Nothing. Questions are not permissions: no level or approve-all grant answers one, and an `Answer` aimed at a command approval fails closed (denied) | — | — |
+| Display requests (`user_session` rail) | Nothing. The rail lives outside the approval id space; approve/approve-all can never mint a display grant there. (Approving a **DisplayControl-category runtime action** is different: the first such approval grants agent-visible user-display access session-wide — that approval *is* the opt-in) | Rail: per request | Grant durations are the rail's own (this session / 15 min / until revoked) |
+
+The asymmetry between the first two rows is intentional: a native
+approve-all is the operator saying "run autonomously" to *their daemon*,
+while a button on one supervised Codex/Claude session must not escalate
+every other surface of the daemon.

--- a/docs/src/control-plane-and-daemon.md
+++ b/docs/src/control-plane-and-daemon.md
@@ -32,6 +32,16 @@ sent the intent) learns the result by observing the *broadcast* event the
 control plane emits afterward (`AutonomyChanged`, `ExternalAgentChanged`,
 `CodexConfigChanged`, …).
 
+Stated honestly, the invariant covers the **intent path**: no frontend
+mutates shared state from a `ControlMsg` handler. It is not a literal
+single-writer over every piece of shared state — three documented paths
+write from their own tasks: approval side effects (`apply_user_approval`
+applies approve-all escalation and the first display-control grant to the
+shared autonomy state, identically from every approval surface), the MCP
+autonomy/display tools, and platform display activation. Those are
+deliberate carve-outs with one owner each; new shared-state writers
+belong in the control plane.
+
 ```
   Web ─┐  emit ControlMsg          ┌──────────────┐  write    ┌──────────────┐
   MCP ─┼───────────────▶ EventBus ─┤ Control Plane │──────────▶│ shared state │


### PR DESCRIPTION
Alpha-readiness documentation corrections that sit outside the trust
refactor's (#298) file set:

- SECURITY.md: private vulnerability reporting via GitHub security
  advisories, scope (runtime/controller boundary, IAM, custody, gateway
  auth, sandboxes, federation, release channel), alpha support window,
  pointer to the documented honest limits.
- architecture.md + control-plane-and-daemon.md: state the single-writer
  invariant honestly — it governs the ControlMsg intent path, and the
  three deliberate direct-write carve-outs (approval side effects, MCP
  autonomy/display tools, platform display activation) are named instead
  of implied away. architecture.md now also describes the two lossless
  event lanes (intents, session-log subset) next to the bounded broadcast
  ring, with the rule that durable-state consumers take a lossless lane.
- autonomy.md: an 'approve all scope, by surface' matrix — native
  approve-all raises the daemon-wide native autonomy to Full, external
  approve-all is per-session by design, live audio has no approve-all,
  questions and the display-request rail are outside approval semantics.
