### PR TITLE
Add durable external-agent model defaults

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -2,8 +2,11 @@
 
 Intendant is configured through three layers, in increasing specificity:
 
-1. **`intendant.toml`** in the project root — the durable, per-project config
-   (structure in `src/bin/caller/project.rs`).
+1. **`intendant.toml`** — in the project root for a rooted daemon, or under
+   the daemon state root (`~/.intendant/intendant.toml` by default) for a
+   projectless daemon such as the bundled app. The latter stores daemon-wide
+   defaults without making the state directory a session project or sandbox
+   root (structure in `src/bin/caller/project.rs`).
 2. **Environment variables** (often via `.env`) — keys, provider/model
    overrides, and a few runtime toggles.
 3. **CLI flags** — per-invocation overrides (see
@@ -50,7 +53,7 @@ for the headless `tests/e2e/` suite and demos) and requires
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `INTENDANT_HOME` | `~/.intendant` | Overrides the daemon state root — the one directory holding session logs, the session-index cache, recordings, quarantine, leased credentials, access certs, the service pidfile, the projectless daemon's Connect config (`connect.toml`), the projectless upload/transfer global store (`global-store/`, pruned after 14 idle days at daemon startup), and the rest of the machine-local daemon state. The value is used verbatim as the root (no `.intendant` component is appended); a relative path resolves against the startup directory. Read once at first use and fixed for the process lifetime. Useful for scratch daemons and hermetic harnesses. Locations that are deliberately *not* under the state root are unaffected: project-local `.intendant/` directories, external-agent homes (`~/.codex`, `~/.claude`), and the platform-data-dir daemon identity key. |
+| `INTENDANT_HOME` | `~/.intendant` | Overrides the daemon state root — the one directory holding session logs, the session-index cache, recordings, quarantine, leased credentials, access certs, the service pidfile, the projectless daemon's general settings (`intendant.toml`) and Connect config (`connect.toml`), the projectless upload/transfer global store (`global-store/`, pruned after 14 idle days at daemon startup), and the rest of the machine-local daemon state. The value is used verbatim as the root (no `.intendant` component is appended); a relative path resolves against the startup directory. Read once at first use and fixed for the process lifetime. Useful for scratch daemons and hermetic harnesses. Locations that are deliberately *not* under the state root are unaffected: project-local `.intendant/` directories, external-agent homes (`~/.codex`, `~/.claude`), and the platform-data-dir daemon identity key. |
 
 ### Model and behavior tuning
 
@@ -128,9 +131,12 @@ sessions spawned in-process via the `spawn_sub_agent` tool (see
 
 ## `intendant.toml`
 
-Create `intendant.toml` in your project root (the git top-level). Every section
-is optional; an absent section uses its defaults. The structure and defaults
-below are taken directly from `src/bin/caller/project.rs`.
+Create `intendant.toml` in your project root (the git top-level). A daemon
+started without a project marker reads and writes the same schema at
+`<INTENDANT_HOME>/intendant.toml`; the dashboard's Settings page uses that
+daemon-wide file while `/api/project-root` remains null. Every section is
+optional; an absent section uses its defaults. The structure and defaults below
+are taken directly from `src/bin/caller/project.rs`.
 
 ### `[memory]`
 
@@ -360,10 +366,10 @@ phrase to manage-grade sessions, and can release the claim binding. The
 the client and overrides the file (the card reports when it does).
 
 **Projectless daemons** (the bundled macOS app's normal shape — no
-`.git`/`intendant.toml` at the launch directory) have no project file to
-persist into; for them the same `[connect]` table lives in the
-daemon-scoped `connect.toml` under the state root (`~/.intendant/`), and
-the toggle and daemon boot both use it. Rooted daemons are unaffected.
+`.git`/`intendant.toml` at the launch directory) keep general defaults in the
+daemon-scoped `intendant.toml`, but Connect's credential-bearing table remains
+in its dedicated owner-only `connect.toml` beside it. The toggle and daemon boot
+both use that dedicated file. Rooted daemons are unaffected.
 
 Hosted Connect uses the same daemon-side settings:
 

--- a/docs/src/external-agent-orchestration.md
+++ b/docs/src/external-agent-orchestration.md
@@ -729,9 +729,11 @@ own away-from-keyboard fallback.
 ## Configuration
 
 External-agent settings live under `[agent]` in `intendant.toml`
-(`ExternalAgentConfig` in `project.rs`). `default_backend` selects the mode; the
-per-backend subtables tune each tool. All keys have defaults, so a bare `[agent]`
-with just `default_backend` works.
+(`ExternalAgentConfig` in `project.rs`). An attached project uses its own file;
+a projectless daemon uses `<state-root>/intendant.toml` (normally
+`~/.intendant/intendant.toml`) for daemon-wide defaults. `default_backend`
+selects the mode; the per-backend subtables tune each tool. All keys have
+defaults, so a bare `[agent]` with just `default_backend` works.
 
 ```toml
 [agent]
@@ -741,7 +743,7 @@ default_backend = "codex"
 
 [agent.codex]
 command          = "codex"            # binary on PATH or absolute path
-model            = "gpt-5.6"          # optional; omit to use Codex's default
+model            = "gpt-5.6-sol"      # optional; omit to use Codex's default
 approval_policy  = "on-request"       # untrusted | on-request | never
 sandbox          = "workspace-write"  # read-only | workspace-write | danger-full-access
 reasoning_effort = "medium"           # ""(default) | none | minimal | low | medium | high | xhigh | max | ultra

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -500,17 +500,27 @@ directory is safe to delete; it rebuilds on the next scan.
   External Codex sessions can choose the binary path, a model, a compatible
   reasoning effort, sandbox and approval policies, `managed_context` mode
   (`vanilla` or `managed`), context replay mode, and Fast service tier for that
-  session. The model picker includes the current GPT-5.6 Sol/Terra/Luna family,
-  GPT-5.5, GPT-5.3-Codex-Spark, GPT-5.4, and GPT-5.4-Mini, with a Custom-id
-  escape for staged or account-specific models. Blank inherits the global/Codex
-  default; when a selected model cannot inherit the global effort, the picker
-  explicitly selects that model's advertised default instead. Model and effort
-  pins persist across attach/resume. The external-agent options sit in a fold
+  session. The model picker derives its normal choices and per-model reasoning
+  levels from the signed-in Codex account's `models_cache.json`; hidden entries
+  stay out, and API-key auth also filters subscription-only models exactly as
+  Codex does. A conservative offline catalog and a Custom-id escape cover
+  pre-fetch, staged, or private models. Blank inherits the global/Codex default;
+  when a selected model cannot inherit the global effort, the picker explicitly
+  selects that model's advertised default. Model and effort pins persist across
+  attach/resume. The external-agent options sit in a fold
   that opens when an external backend is selected. Claude Code sessions get per-launch
   dropdowns for the model (version-safe aliases — `fable`, `opus`, `sonnet`,
   `haiku` — that the CLI resolves to the latest release, with a Custom-id escape
   for full model names), the permission mode, and the reasoning effort
   (`low` … `max`).
+
+**Settings → Providers & models** exposes the daemon's global Codex and Claude
+defaults independently of whichever backend is currently selected. With an
+attached project, Save writes that project's `intendant.toml`; a projectless
+daemon writes `<state-root>/intendant.toml` (normally
+`~/.intendant/intendant.toml`) while `/api/project-root` remains `null`. These
+defaults seed new sessions, but an existing session's persisted launch config
+continues to control its next attach/resume.
 
 Internal sessions' window menus additionally expose **Delegate…** — spawn a
 supervised sub-agent (task, optional name, role, backend, worktree isolation)

--- a/src/bin/caller/control_plane.rs
+++ b/src/bin/caller/control_plane.rs
@@ -60,10 +60,10 @@ pub struct ControlPlaneState {
     pub codex_config: SharedCodexConfig,
     pub claude_config: SharedClaudeConfig,
     pub bus: EventBus,
-    /// Project root for `intendant.toml` writes. When set, changes to
-    /// `external_agent` (from any frontend) also persist to the config
-    /// file so the setting survives daemon restarts. `None` in tests
-    /// or when no project context is available.
+    /// Config root for `intendant.toml` writes: the project root on a
+    /// rooted daemon, or the daemon state root when projectless. This is
+    /// persistence scope only and never grants project/sandbox access.
+    /// `None` is reserved for isolated tests or modes with no durable store.
     pub project_root: Option<PathBuf>,
 }
 

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -1024,11 +1024,16 @@ pub(crate) async fn api_settings_save_response(
     runtime: &ControlRuntime,
 ) -> serde_json::Value {
     let body_text = params_body_text(params);
+    let settings_root = {
+        let session = runtime.shared_session.read().await;
+        session.runtime_settings.settings_root.clone()
+    }
+    .or_else(|| runtime.project_root.clone());
     frame_api_response(
         id,
         crate::web_gateway::settings_post_api_response(
             &body_text,
-            runtime.project_root.as_deref(),
+            settings_root.as_deref(),
             &runtime.bus,
         ),
         "settings save",

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -397,7 +397,9 @@ fn control_method_runtime_ready(runtime: &ControlRuntime, method: &str) -> bool 
         | "api_peer_file_transfer_signal"
         | "api_peer_dashboard_control_signal"
         | "api_coordinator_route" => runtime.peer_registry.is_some(),
-        "api_settings_save" => runtime.project_root.is_some(),
+        // Settings have their own durable root even when the daemon is
+        // projectless; method execution resolves it from RuntimeSettingsState.
+        "api_settings_save" => true,
         "api_access_connect_config" | "api_access_connect_unclaim" => {
             runtime.project_root.is_some()
         }
@@ -2899,7 +2901,7 @@ mod tests {
         assert_eq!(status["result"]["api_fs_delete_available"], true);
         assert_eq!(status["result"]["api_sessions_search_available"], true);
         assert_eq!(status["result"]["api_settings_available"], true);
-        assert_eq!(status["result"]["api_settings_save_available"], false);
+        assert_eq!(status["result"]["api_settings_save_available"], true);
         assert_eq!(status["result"]["api_control_msg_available"], true);
         assert_eq!(status["result"]["api_session_control_msg_available"], true);
         assert_eq!(status["result"]["api_dashboard_action_msg_available"], true);

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -3347,6 +3347,29 @@ async fn main() -> Result<(), CallerError> {
     if let Some(ref m) = flags.model {
         env::set_var("MODEL_NAME", m);
     }
+    // Idle web/dashboard startup defaults to the daemon path (the session
+    // supervisor owns all launches). Compute the execution shape before
+    // applying config-derived env so a projectless daemon can first load its
+    // durable machine-wide defaults.
+    let web_daemon_requested =
+        should_start_idle_web_daemon(!flags.no_web && !flags.mcp && !flags.json_output, &flags);
+    // Projectless: a daemon launched from a directory with no project marker
+    // must not adopt cwd as its sandbox/watcher/session root. It does still
+    // load daemon-wide defaults from `<state-root>/intendant.toml`; config
+    // scope and project scope deliberately remain separate.
+    let projectless_daemon = web_daemon_requested && !project_has_marker;
+    let daemon_project_root: Option<PathBuf> = (!projectless_daemon).then(|| project.root.clone());
+    if projectless_daemon {
+        let settings_root = project::daemon_settings_config_root();
+        project.config = Project::from_root(settings_root.clone())?.config;
+        eprintln!(
+            "Projectless daemon: {} has no project marker (.git or intendant.toml) — \
+             running without a default project; sessions choose their own project directory; \
+             daemon defaults load from {}/intendant.toml",
+            project.root.display(),
+            settings_root.display()
+        );
+    }
     // Synthetic display for headless test rigs (INTENDANT_MOCK_DISPLAY=
     // synthetic; fail-closed: honored only under PROVIDER=mock). Evaluated
     // here — after the .env load and the --provider override settle the
@@ -3363,29 +3386,6 @@ async fn main() -> Result<(), CallerError> {
         if let Some(max_out) = project.config.model.max_output_tokens {
             env::set_var("MAX_OUTPUT_TOKENS", max_out.to_string());
         }
-    }
-    // Idle web/dashboard startup defaults to the daemon path (the session
-    // supervisor owns all launches). Computed here — from flags only, which
-    // are not mutated below — because the daemon shape decides resume
-    // ownership, the sandbox write scope, and whether a markerless cwd
-    // becomes a project at all.
-    let web_daemon_requested =
-        should_start_idle_web_daemon(!flags.no_web && !flags.mcp && !flags.json_output, &flags);
-    // Projectless: a daemon launched from a directory with no project marker
-    // (.git / intendant.toml — `project::root_has_project_marker`) runs
-    // without a project instead of adopting cwd; an installed app or service
-    // otherwise inherits an accident of launch directory as its sandbox
-    // scope, watcher root, and default session project. CLI (headless/MCP)
-    // invocations keep cwd-as-project — correct for `intendant "task"`
-    // inside a repo.
-    let projectless_daemon = web_daemon_requested && !project_has_marker;
-    let daemon_project_root: Option<PathBuf> = (!projectless_daemon).then(|| project.root.clone());
-    if projectless_daemon {
-        eprintln!(
-            "Projectless daemon: {} has no project marker (.git or intendant.toml) — \
-             running without a default project; sessions choose their own project directory",
-            project.root.display()
-        );
     }
     // Create or resume session log.
     //

--- a/src/bin/caller/project.rs
+++ b/src/bin/caller/project.rs
@@ -290,15 +290,12 @@ const CODEX_EFFORTS_THROUGH_XHIGH: &[&str] = &["low", "medium", "high", "xhigh"]
 const CODEX_EFFORTS_THROUGH_MAX: &[&str] = &["low", "medium", "high", "xhigh", "max"];
 const CODEX_EFFORTS_THROUGH_ULTRA: &[&str] = &["low", "medium", "high", "xhigh", "max", "ultra"];
 
-/// Current public Codex picker models, with recommended models before the
-/// still-supported "other models" group. Hidden/internal models stay out.
+/// Conservative offline Codex picker fallback. The dashboard replaces this
+/// with Codex's signed-in-account catalog whenever `models_cache.json` is
+/// available. Keep only actual Codex CLI model ids here; account/API aliases
+/// belong in the live catalog (or the picker's custom-id escape), not this
+/// fallback.
 pub const CODEX_MODEL_CATALOG: &[CodexModelCatalogEntry] = &[
-    CodexModelCatalogEntry {
-        id: "gpt-5.6",
-        display_name: "GPT-5.6 (Sol alias)",
-        default_reasoning_effort: "medium",
-        reasoning_efforts: CODEX_EFFORTS_THROUGH_ULTRA,
-    },
     CodexModelCatalogEntry {
         id: "gpt-5.6-sol",
         display_name: "GPT-5.6-Sol",
@@ -791,13 +788,23 @@ struct DaemonConnectFile {
     connect: ConnectConfig,
 }
 
+/// Root carrying durable, daemon-wide settings when no project is attached.
+///
+/// A projectless daemon must not pretend this is a session project (doing so
+/// would widen sandbox and file-watcher scope), but it still needs a durable
+/// place for dashboard defaults. Its `intendant.toml` lives directly under
+/// this state root.
+pub fn daemon_settings_config_root() -> PathBuf {
+    crate::platform::intendant_home()
+}
+
 /// Where a projectless daemon persists its Connect client config. Rooted
 /// daemons keep `[connect]` in the project's `intendant.toml`; a daemon
-/// with no project (the bundled app's normal shape) has no intendant.toml
-/// to write, so the config lives with the rest of the machine-local daemon
-/// state under the state root.
+/// with no project (the bundled app's normal shape) keeps Connect's
+/// credential-bearing table in its existing owner-only file beside the
+/// general daemon settings file.
 pub fn daemon_connect_config_path() -> PathBuf {
-    crate::platform::intendant_home().join("connect.toml")
+    daemon_settings_config_root().join("connect.toml")
 }
 
 /// Load the daemon-scoped Connect config. An absent file is the normal
@@ -2294,6 +2301,10 @@ default_backend = "codex"
         let ids: std::collections::BTreeSet<_> =
             CODEX_MODEL_CATALOG.iter().map(|entry| entry.id).collect();
         assert_eq!(ids.len(), CODEX_MODEL_CATALOG.len(), "duplicate model id");
+        assert!(
+            !ids.contains("gpt-5.6"),
+            "the bare alias Codex does not advertise must not be in the offline fallback"
+        );
         for entry in CODEX_MODEL_CATALOG {
             assert!(
                 entry

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -164,13 +164,16 @@ pub(crate) async fn run_daemon(
 
     let shared_codex_config = shared_codex_config_from_project(project);
     let shared_claude_config = shared_claude_config_from_project(project);
+    let settings_root = project_root
+        .clone()
+        .unwrap_or_else(project::daemon_settings_config_root);
     let _control_plane_handle = control_plane::spawn(control_plane::ControlPlaneState {
         autonomy: autonomy.clone(),
         external_agent: shared_external_agent.clone(),
         codex_config: shared_codex_config.clone(),
         claude_config: shared_claude_config.clone(),
         bus: bus.clone(),
-        project_root: project_root.clone(),
+        project_root: Some(settings_root),
     });
 
     // Session vitals: cache/limits are usage-driven and cover every

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -266,6 +266,10 @@ pub(crate) fn spawn_mode_web_gateway(
     config.external_agent = initial_agent_backend
         .as_ref()
         .map(|backend| backend.as_short_str().to_string());
+    let settings_root = project_root
+        .clone()
+        .unwrap_or_else(crate::project::daemon_settings_config_root);
+    let codex_home = crate::session_config::effective_codex_home().map(PathBuf::from);
     let shared_session = Arc::new(tokio::sync::RwLock::new(web_gateway::ActiveSessionState {
         daemon_session_id: session_log_id(session_log),
         query_ctx,
@@ -278,6 +282,8 @@ pub(crate) fn spawn_mode_web_gateway(
         runtime_settings: web_gateway::RuntimeSettingsState {
             external_agent: Some(shared_external_agent.clone()),
             presence_enabled: Some(runtime_presence_enabled),
+            settings_root: Some(settings_root),
+            codex_home,
         },
         file_watcher: shared_file_watcher.clone(),
     }));

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -875,11 +875,12 @@ pub(crate) async fn serve_http_request(
                 .await;
             }
             RouteHandlerId::SettingsPost => {
+                let settings_root = runtime_settings.settings_root.or(project_root);
                 return handle_settings_post(
                     stream,
                     route_body,
                     bus,
-                    project_root,
+                    settings_root,
                     route.cors,
                     fleet_cors_origin.as_deref(),
                 )

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -150,6 +150,15 @@ pub struct RuntimeSettingsState {
     pub external_agent:
         Option<Arc<tokio::sync::RwLock<Option<crate::external_agent::AgentBackend>>>>,
     pub presence_enabled: Option<bool>,
+    /// Durable config root for the Settings surface. This is the served
+    /// project root on rooted daemons and the daemon state root when
+    /// projectless; it is intentionally independent of
+    /// `project_root_for_changes` so settings never mint file/sandbox scope.
+    pub settings_root: Option<PathBuf>,
+    /// Codex home whose account-scoped model cache should drive pickers.
+    /// Resolved once at gateway startup so tests can inject/omit it without
+    /// settings helpers consulting the machine's live home.
+    pub codex_home: Option<PathBuf>,
 }
 
 /// Context for answering presence tool queries from browser-side live models.

--- a/src/bin/caller/web_gateway/settings.rs
+++ b/src/bin/caller/web_gateway/settings.rs
@@ -3,6 +3,7 @@
 //! set/status, and the thin per-route stream handlers.
 
 use super::*;
+use std::io::Read;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct CodexModelChoice {
@@ -10,6 +11,158 @@ pub struct CodexModelChoice {
     pub display_name: String,
     pub default_reasoning_effort: String,
     pub reasoning_efforts: Vec<String>,
+}
+
+const MAX_CODEX_MODELS_CACHE_BYTES: usize = 8 * 1024 * 1024;
+const MAX_CODEX_AUTH_METADATA_BYTES: usize = 64 * 1024;
+
+#[derive(serde::Deserialize)]
+struct CodexModelsCache {
+    #[serde(default)]
+    models: Vec<CachedCodexModel>,
+}
+
+#[derive(serde::Deserialize)]
+struct CachedCodexModel {
+    slug: String,
+    #[serde(default)]
+    display_name: String,
+    #[serde(default)]
+    default_reasoning_level: Option<String>,
+    #[serde(default)]
+    supported_reasoning_levels: Vec<CachedCodexReasoningLevel>,
+    #[serde(default)]
+    visibility: Option<String>,
+    #[serde(default)]
+    supported_in_api: Option<bool>,
+}
+
+#[derive(serde::Deserialize)]
+struct CachedCodexReasoningLevel {
+    effort: String,
+}
+
+#[derive(serde::Deserialize)]
+struct CodexAuthMetadata {
+    #[serde(default)]
+    auth_mode: Option<String>,
+}
+
+fn read_bounded_file(path: &Path, max_bytes: usize) -> Option<Vec<u8>> {
+    let file = std::fs::File::open(path).ok()?;
+    let mut bytes = Vec::new();
+    file.take((max_bytes + 1) as u64)
+        .read_to_end(&mut bytes)
+        .ok()?;
+    (bytes.len() <= max_bytes).then_some(bytes)
+}
+
+/// Match Codex's picker filter: ChatGPT and agent-identity auth use the
+/// Codex backend and can expose subscription-only models; API-key (or
+/// unknown) auth only gets entries marked `supported_in_api`.
+fn codex_auth_uses_codex_backend(codex_home: &Path) -> bool {
+    let bytes =
+        match read_bounded_file(&codex_home.join("auth.json"), MAX_CODEX_AUTH_METADATA_BYTES) {
+            Some(bytes) => bytes,
+            None => return false,
+        };
+    let auth: CodexAuthMetadata = match serde_json::from_slice(&bytes) {
+        Ok(auth) => auth,
+        Err(_) => return false,
+    };
+    matches!(
+        auth.auth_mode
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("chatgpt" | "chatgptauthtokens" | "agentidentity")
+    )
+}
+
+/// Read the model vocabulary Codex cached for its currently signed-in
+/// account. The cache is advisory UI data only: Codex remains the launch-time
+/// authority, malformed/oversized files fall back to the conservative daemon
+/// catalog, and custom ids remain available in the picker.
+fn codex_model_choices_from_cache(codex_home: &Path) -> Option<Vec<CodexModelChoice>> {
+    let bytes = read_bounded_file(
+        &codex_home.join("models_cache.json"),
+        MAX_CODEX_MODELS_CACHE_BYTES,
+    )?;
+    let cache: CodexModelsCache = serde_json::from_slice(&bytes).ok()?;
+    let uses_codex_backend = codex_auth_uses_codex_backend(codex_home);
+    let mut seen = std::collections::HashSet::new();
+    let mut choices = Vec::new();
+    for cached in cache.models {
+        if cached
+            .visibility
+            .as_deref()
+            .is_some_and(|visibility| !visibility.eq_ignore_ascii_case("list"))
+            || (!uses_codex_backend && cached.supported_in_api == Some(false))
+        {
+            continue;
+        }
+        let id = cached.slug.trim();
+        if id.is_empty() || !seen.insert(id.to_string()) {
+            continue;
+        }
+        let static_entry = crate::project::codex_model_catalog_entry(id);
+        let mut reasoning_efforts = Vec::new();
+        for level in cached.supported_reasoning_levels {
+            let effort = level.effort.trim();
+            if !effort.is_empty()
+                && !reasoning_efforts
+                    .iter()
+                    .any(|existing: &String| existing == effort)
+            {
+                reasoning_efforts.push(effort.to_string());
+            }
+        }
+        if reasoning_efforts.is_empty() {
+            if let Some(entry) = static_entry {
+                reasoning_efforts = entry
+                    .reasoning_efforts
+                    .iter()
+                    .map(|effort| (*effort).to_string())
+                    .collect();
+            }
+        }
+        let mut default_reasoning_effort = cached
+            .default_reasoning_level
+            .as_deref()
+            .map(str::trim)
+            .filter(|effort| !effort.is_empty())
+            .map(str::to_string)
+            .or_else(|| static_entry.map(|entry| entry.default_reasoning_effort.to_string()))
+            .or_else(|| {
+                reasoning_efforts
+                    .iter()
+                    .find(|effort| effort.as_str() == "medium")
+                    .cloned()
+            })
+            .or_else(|| reasoning_efforts.first().cloned())
+            .unwrap_or_default();
+        if !default_reasoning_effort.is_empty()
+            && !reasoning_efforts.contains(&default_reasoning_effort)
+        {
+            reasoning_efforts.push(default_reasoning_effort.clone());
+        }
+        if default_reasoning_effort.is_empty() && !reasoning_efforts.is_empty() {
+            default_reasoning_effort = reasoning_efforts[0].clone();
+        }
+        let display_name = cached.display_name.trim();
+        choices.push(CodexModelChoice {
+            id: id.to_string(),
+            display_name: if display_name.is_empty() {
+                id.to_string()
+            } else {
+                display_name.to_string()
+            },
+            default_reasoning_effort,
+            reasoning_efforts,
+        });
+    }
+    (!choices.is_empty()).then_some(choices)
 }
 
 /// Settings payload for GET/POST /api/settings.
@@ -76,11 +229,11 @@ pub struct SettingsPayload {
     #[serde(default)]
     pub codex_service_tier: Option<String>,
     #[serde(default)]
-    pub codex_web_search: bool,
+    pub codex_web_search: Option<bool>,
     #[serde(default)]
-    pub codex_network_access: bool,
+    pub codex_network_access: Option<bool>,
     #[serde(default)]
-    pub codex_writable_roots: Vec<String>,
+    pub codex_writable_roots: Option<Vec<String>>,
     #[serde(default, alias = "codex_context_recovery")]
     pub codex_managed_context: Option<String>,
     #[serde(default)]
@@ -215,9 +368,9 @@ pub(crate) fn settings_payload_from_config(
         codex_service_tier: crate::project::normalize_codex_service_tier(
             config.agent.codex.service_tier.as_deref(),
         ),
-        codex_web_search: config.agent.codex.web_search,
-        codex_network_access: config.agent.codex.network_access,
-        codex_writable_roots: config.agent.codex.writable_roots.clone(),
+        codex_web_search: Some(config.agent.codex.web_search),
+        codex_network_access: Some(config.agent.codex.network_access),
+        codex_writable_roots: Some(config.agent.codex.writable_roots.clone()),
         codex_managed_context: Some(crate::project::normalize_codex_managed_context(
             &config.agent.codex.managed_context,
         )),
@@ -257,6 +410,22 @@ pub(crate) async fn settings_payload_with_runtime_overrides(
             .as_ref()
             .map(|backend| backend.as_short_str().to_string());
     }
+    if let Some(codex_home) = runtime.codex_home.as_deref() {
+        if let Some(models) = codex_model_choices_from_cache(codex_home) {
+            // Preserve the daemon's canonical custom-id vocabulary, then
+            // append any account-advertised effort that is newer than this
+            // build so the picker remains forward-compatible.
+            for effort in models
+                .iter()
+                .flat_map(|model| model.reasoning_efforts.iter())
+            {
+                if !payload.codex_reasoning_efforts.contains(effort) {
+                    payload.codex_reasoning_efforts.push(effort.clone());
+                }
+            }
+            payload.codex_models = models;
+        }
+    }
     payload
 }
 
@@ -264,7 +433,8 @@ pub(crate) async fn settings_get_response_body(
     project_root: Option<&Path>,
     runtime_settings: &RuntimeSettingsState,
 ) -> String {
-    match project_root {
+    let settings_root = runtime_settings.settings_root.as_deref().or(project_root);
+    match settings_root {
         Some(root) => match crate::project::Project::from_root(root.to_path_buf()) {
             Ok(proj) => {
                 let payload =
@@ -327,9 +497,37 @@ pub(crate) fn apply_settings_payload(
     if let Some(policy) = payload.codex_approval_policy.as_deref() {
         config.agent.codex.approval_policy = crate::project::normalize_approval_policy(policy);
     }
+    if payload.codex_model.is_some() {
+        // Empty clears the override (Codex chooses its account/config
+        // default). Omission leaves the existing value untouched for older
+        // partial API clients.
+        config.agent.codex.model = payload
+            .codex_model
+            .as_deref()
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+            .map(str::to_string);
+    }
+    if payload.codex_reasoning_effort.is_some() {
+        config.agent.codex.reasoning_effort =
+            crate::project::normalize_reasoning_effort(payload.codex_reasoning_effort.as_deref());
+    }
     if payload.codex_service_tier.is_some() {
         config.agent.codex.service_tier =
             crate::project::normalize_codex_service_tier(payload.codex_service_tier.as_deref());
+    }
+    if let Some(enabled) = payload.codex_web_search {
+        config.agent.codex.web_search = enabled;
+    }
+    if let Some(enabled) = payload.codex_network_access {
+        config.agent.codex.network_access = enabled;
+    }
+    if let Some(roots) = payload.codex_writable_roots.as_ref() {
+        config.agent.codex.writable_roots = roots
+            .iter()
+            .map(|root| root.trim().to_string())
+            .filter(|root| !root.is_empty())
+            .collect();
     }
     if let Some(mode) = payload.codex_managed_context.as_deref() {
         config.agent.codex.managed_context = crate::project::normalize_codex_managed_context(mode);
@@ -392,14 +590,14 @@ pub(crate) fn settings_post_result(
     apply_settings_payload(&mut proj.config, &payload);
     match proj.save_config() {
         Ok(()) => {
-            dispatch_codex_settings_control_msgs(bus, &payload);
+            dispatch_agent_settings_control_msgs(bus, &payload);
             (200, serde_json::json!({"ok": true}).to_string())
         }
         Err(e) => (500, serde_json::json!({"error": e.to_string()}).to_string()),
     }
 }
 
-/// Mirror just-persisted `[agent.codex]` settings into the live control plane.
+/// Mirror just-persisted external-agent settings into the live control plane.
 ///
 /// `apply_settings_payload` + `save_config` update the TOML, but session
 /// launches read the live `CodexRuntimeConfig`, which OVERLAYS the TOML
@@ -414,10 +612,14 @@ pub(crate) fn settings_post_result(
 /// own synchronous TOML write (kept above) is what makes an immediate
 /// GET /api/settings read back the saved values.
 ///
-/// Only fields actually present in the payload are dispatched, mirroring
-/// `apply_settings_payload`'s conditional writes; only codex fields with a
-/// live control-plane setter are covered.
-pub(crate) fn dispatch_codex_settings_control_msgs(bus: &EventBus, payload: &SettingsPayload) {
+/// Optional fields dispatch only when present, mirroring
+/// `apply_settings_payload`'s partial-client compatibility. The dashboard's
+/// full payload includes the bool and list fields, while older partial API
+/// clients can omit them without clearing live state.
+pub(crate) fn dispatch_agent_settings_control_msgs(bus: &EventBus, payload: &SettingsPayload) {
+    bus.send(AppEvent::ControlCommand(ControlMsg::SetExternalAgent {
+        agent: payload.external_agent.clone(),
+    }));
     if payload.codex_command.is_some() {
         bus.send(AppEvent::ControlCommand(ControlMsg::SetCodexCommand {
             command: payload.codex_command.clone(),
@@ -440,10 +642,37 @@ pub(crate) fn dispatch_codex_settings_control_msgs(bus: &EventBus, payload: &Set
             ControlMsg::SetCodexApprovalPolicy { policy },
         ));
     }
+    if payload.codex_model.is_some() {
+        bus.send(AppEvent::ControlCommand(ControlMsg::SetCodexModel {
+            model: payload.codex_model.clone(),
+        }));
+    }
+    if payload.codex_reasoning_effort.is_some() {
+        bus.send(AppEvent::ControlCommand(
+            ControlMsg::SetCodexReasoningEffort {
+                effort: payload.codex_reasoning_effort.clone(),
+            },
+        ));
+    }
     if payload.codex_service_tier.is_some() {
         bus.send(AppEvent::ControlCommand(ControlMsg::SetCodexServiceTier {
             service_tier: payload.codex_service_tier.clone(),
         }));
+    }
+    if let Some(enabled) = payload.codex_web_search {
+        bus.send(AppEvent::ControlCommand(ControlMsg::SetCodexWebSearch {
+            enabled,
+        }));
+    }
+    if let Some(enabled) = payload.codex_network_access {
+        bus.send(AppEvent::ControlCommand(
+            ControlMsg::SetCodexNetworkAccess { enabled },
+        ));
+    }
+    if let Some(roots) = payload.codex_writable_roots.clone() {
+        bus.send(AppEvent::ControlCommand(
+            ControlMsg::SetCodexWritableRoots { roots },
+        ));
     }
     if let Some(mode) = payload.codex_managed_context.clone() {
         bus.send(AppEvent::ControlCommand(
@@ -453,6 +682,21 @@ pub(crate) fn dispatch_codex_settings_control_msgs(bus: &EventBus, payload: &Set
     if let Some(mode) = payload.codex_context_archive.clone() {
         bus.send(AppEvent::ControlCommand(
             ControlMsg::SetCodexContextArchive { mode },
+        ));
+    }
+    if payload.claude_model.is_some() {
+        bus.send(AppEvent::ControlCommand(ControlMsg::SetClaudeModel {
+            model: payload.claude_model.clone(),
+        }));
+    }
+    if let Some(mode) = payload.claude_permission_mode.clone() {
+        bus.send(AppEvent::ControlCommand(
+            ControlMsg::SetClaudePermissionMode { mode },
+        ));
+    }
+    if let Some(tools) = payload.claude_allowed_tools.clone() {
+        bus.send(AppEvent::ControlCommand(
+            ControlMsg::SetClaudeAllowedTools { tools },
         ));
     }
 }
@@ -758,6 +1002,124 @@ pub(crate) async fn handle_external_agents(
 mod tests {
     use super::*;
 
+    #[tokio::test]
+    async fn settings_catalog_uses_the_signed_in_codex_account_cache() {
+        let codex_home = tempfile::tempdir().unwrap();
+        std::fs::write(
+            codex_home.path().join("auth.json"),
+            r#"{"auth_mode":"chatgpt"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            codex_home.path().join("models_cache.json"),
+            serde_json::json!({
+                "models": [
+                    {
+                        "slug": "gpt-5.6-sol",
+                        "display_name": "GPT-5.6-Sol",
+                        "default_reasoning_level": "low",
+                        "supported_reasoning_levels": [
+                            {"effort": "low"},
+                            {"effort": "medium"},
+                            {"effort": "ultra"}
+                        ],
+                        "visibility": "list",
+                        "supported_in_api": true
+                    },
+                    {
+                        "slug": "gpt-5.3-codex-spark",
+                        "display_name": "GPT-5.3-Codex-Spark",
+                        "default_reasoning_level": "high",
+                        "supported_reasoning_levels": [{"effort": "high"}],
+                        "visibility": "list",
+                        "supported_in_api": false
+                    },
+                    {
+                        "slug": "gpt-5.6",
+                        "display_name": "GPT-5.6 API alias",
+                        "default_reasoning_level": "medium",
+                        "supported_reasoning_levels": [{"effort": "medium"}],
+                        "visibility": "hide",
+                        "supported_in_api": true
+                    },
+                    {
+                        "slug": "codex-auto-review",
+                        "display_name": "Codex Auto Review",
+                        "visibility": "hide",
+                        "supported_in_api": true
+                    }
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let runtime = RuntimeSettingsState {
+            codex_home: Some(codex_home.path().to_path_buf()),
+            ..Default::default()
+        };
+
+        let payload = settings_payload_with_runtime_overrides(
+            &crate::project::ProjectConfig::default(),
+            &runtime,
+        )
+        .await;
+
+        assert_eq!(
+            payload
+                .codex_models
+                .iter()
+                .map(|model| model.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["gpt-5.6-sol", "gpt-5.3-codex-spark"]
+        );
+        assert_eq!(payload.codex_models[0].default_reasoning_effort, "low");
+        assert_eq!(
+            payload.codex_models[0].reasoning_efforts,
+            vec!["low", "medium", "ultra"]
+        );
+
+        // Codex filters the same cache by auth mode: API-key auth must not
+        // offer subscription-only entries.
+        std::fs::write(
+            codex_home.path().join("auth.json"),
+            r#"{"auth_mode":"apikey"}"#,
+        )
+        .unwrap();
+        let api_payload = settings_payload_with_runtime_overrides(
+            &crate::project::ProjectConfig::default(),
+            &runtime,
+        )
+        .await;
+        assert_eq!(
+            api_payload
+                .codex_models
+                .iter()
+                .map(|model| model.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["gpt-5.6-sol"]
+        );
+    }
+
+    #[tokio::test]
+    async fn settings_get_uses_daemon_settings_root_without_a_project_root() {
+        let settings_root = tempfile::tempdir().unwrap();
+        let mut project =
+            crate::project::Project::from_root(settings_root.path().to_path_buf()).unwrap();
+        project.config.agent.codex.model = Some("gpt-5.6-sol".to_string());
+        project.config.agent.claude_code.model = Some("fable".to_string());
+        project.save_config().unwrap();
+        let runtime = RuntimeSettingsState {
+            settings_root: Some(settings_root.path().to_path_buf()),
+            ..Default::default()
+        };
+
+        let body = settings_get_response_body(None, &runtime).await;
+        let value: serde_json::Value = serde_json::from_str(&body).unwrap();
+
+        assert_eq!(value["codex_model"], "gpt-5.6-sol");
+        assert_eq!(value["claude_model"], "fable");
+    }
+
     #[test]
     fn settings_payload_accepts_settings_tab_save_without_agent_runtime_fields() {
         let body = serde_json::json!({
@@ -910,7 +1272,7 @@ mod tests {
     /// which overrides the file. The gateway does that by re-dispatching
     /// the codex fields as control-plane intents after a successful save.
     #[test]
-    fn settings_post_dispatches_codex_control_msgs_for_live_state() {
+    fn settings_post_dispatches_external_agent_control_msgs_for_live_state() {
         let dir = tempfile::tempdir().unwrap();
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
@@ -937,9 +1299,17 @@ mod tests {
             "codex_command": "/opt/codex/bin/codex",
             "codex_sandbox": "danger-full-access",
             "codex_approval_policy": "never",
+            "codex_model": "gpt-5.6-sol",
+            "codex_reasoning_effort": "high",
             "codex_service_tier": "priority",
+            "codex_web_search": true,
+            "codex_network_access": true,
+            "codex_writable_roots": ["/tmp/work"],
             "codex_managed_context": "managed",
-            "codex_context_archive": "exact"
+            "codex_context_archive": "exact",
+            "claude_model": "fable",
+            "claude_permission_mode": "plan",
+            "claude_allowed_tools": ["Read"]
         })
         .to_string();
 
@@ -949,9 +1319,12 @@ mod tests {
         let mut saw_command = false;
         let mut saw_sandbox = false;
         let mut saw_approval = false;
+        let mut saw_codex_model = false;
         let mut saw_service_tier = false;
         let mut saw_managed = false;
         let mut saw_archive = false;
+        let mut saw_claude_model = false;
+        let mut saw_claude_permission = false;
         while let Ok(event) = rx.try_recv() {
             let AppEvent::ControlCommand(msg) = event else {
                 continue;
@@ -969,6 +1342,10 @@ mod tests {
                     assert_eq!(policy, "never");
                     saw_approval = true;
                 }
+                ControlMsg::SetCodexModel { model } => {
+                    assert_eq!(model.as_deref(), Some("gpt-5.6-sol"));
+                    saw_codex_model = true;
+                }
                 ControlMsg::SetCodexServiceTier { service_tier } => {
                     assert_eq!(service_tier.as_deref(), Some("priority"));
                     saw_service_tier = true;
@@ -981,20 +1358,36 @@ mod tests {
                     assert_eq!(mode, "exact");
                     saw_archive = true;
                 }
+                ControlMsg::SetClaudeModel { model } => {
+                    assert_eq!(model.as_deref(), Some("fable"));
+                    saw_claude_model = true;
+                }
+                ControlMsg::SetClaudePermissionMode { mode } => {
+                    assert_eq!(mode, "plan");
+                    saw_claude_permission = true;
+                }
                 _ => {}
             }
         }
         assert!(saw_command, "SetCodexCommand was not dispatched");
         assert!(saw_sandbox, "SetCodexSandbox was not dispatched");
         assert!(saw_approval, "SetCodexApprovalPolicy was not dispatched");
+        assert!(saw_codex_model, "SetCodexModel was not dispatched");
         assert!(saw_service_tier, "SetCodexServiceTier was not dispatched");
         assert!(saw_managed, "SetCodexManagedContext was not dispatched");
         assert!(saw_archive, "SetCodexContextArchive was not dispatched");
+        assert!(saw_claude_model, "SetClaudeModel was not dispatched");
+        assert!(
+            saw_claude_permission,
+            "SetClaudePermissionMode was not dispatched"
+        );
 
         // The synchronous TOML write still happened (read-after-write
         // consistency for an immediate GET /api/settings).
         let saved = std::fs::read_to_string(dir.path().join("intendant.toml")).unwrap();
         assert!(saved.contains("managed_context = \"managed\""));
+        assert!(saved.contains("model = \"gpt-5.6-sol\""));
+        assert!(saved.contains("model = \"fable\""));
     }
 
     // ── S5 golden transcripts: settings / keys family ──
@@ -1392,9 +1785,17 @@ mod tests {
                         ControlMsg::SetCodexCommand { .. }
                             | ControlMsg::SetCodexSandbox { .. }
                             | ControlMsg::SetCodexApprovalPolicy { .. }
+                            | ControlMsg::SetCodexModel { .. }
+                            | ControlMsg::SetCodexReasoningEffort { .. }
                             | ControlMsg::SetCodexServiceTier { .. }
+                            | ControlMsg::SetCodexWebSearch { .. }
+                            | ControlMsg::SetCodexNetworkAccess { .. }
+                            | ControlMsg::SetCodexWritableRoots { .. }
                             | ControlMsg::SetCodexManagedContext { .. }
                             | ControlMsg::SetCodexContextArchive { .. }
+                            | ControlMsg::SetClaudeModel { .. }
+                            | ControlMsg::SetClaudePermissionMode { .. }
+                            | ControlMsg::SetClaudeAllowedTools { .. }
                     ),
                     "unexpected codex control msg for absent payload field: {msg:?}"
                 );

--- a/src/bin/caller/web_gateway/static_assets.rs
+++ b/src/bin/caller/web_gateway/static_assets.rs
@@ -813,6 +813,24 @@ mod tests {
     }
 
     #[test]
+    fn global_codex_and_claude_model_defaults_are_wired_in_settings() {
+        for id in [
+            "set-codex-model-select",
+            "set-codex-model-custom",
+            "set-codex-reasoning-effort",
+            "set-claude-model-select",
+            "set-claude-model-custom",
+            "set-claude-permission-mode",
+        ] {
+            assert!(APP_HTML.contains(&format!(r#"id="{id}""#)), "missing {id}");
+        }
+        assert!(APP_HTML.contains("codex_model: selectedCodexModel"));
+        assert!(APP_HTML.contains("claude_model: selectedClaudeModel"));
+        assert!(APP_HTML.contains("function populateSettingsCodexModel"));
+        assert!(APP_HTML.contains("function populateSettingsClaudeModel"));
+    }
+
+    #[test]
     fn embedded_codex_picker_fallback_matches_daemon_catalog() {
         fn marker_json(start: &str, end: &str) -> serde_json::Value {
             let json = APP_HTML

--- a/static/app.html
+++ b/static/app.html
@@ -24772,7 +24772,7 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
         <div class="subtab-pane" id="settings-pane-agent">
           <div class="settings-pane-body">
             <p class="settings-note">
-              Settings are saved to <code>intendant.toml</code> and take effect on the next task.
+              Settings are saved to the current project's <code>intendant.toml</code>, or to the daemon-wide <code>~/.intendant/intendant.toml</code> when no project is attached. Agent defaults take effect on the next task.
             </p>
 
             <section class="ui-card" aria-labelledby="settings-external-agent-heading">
@@ -24786,6 +24786,49 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
                   <option value="">None (internal agent)</option>
                   <option value="codex">Codex (OpenAI)</option>
                   <option value="claude-code">Claude Code (Anthropic)</option>
+                </select>
+              </div>
+              <div class="settings-row">
+                <label for="set-codex-model-select">Codex model</label>
+                <select id="set-codex-model-select">
+                  <option value="">Codex account default</option>
+                  <option value="__custom__">Custom model id…</option>
+                </select>
+              </div>
+              <div class="settings-row hidden" id="set-codex-model-custom-row">
+                <label for="set-codex-model-custom">Custom Codex id</label>
+                <input id="set-codex-model-custom" type="text" placeholder="e.g. staged-model-id" autocomplete="off" spellcheck="false">
+              </div>
+              <div class="settings-row">
+                <label for="set-codex-reasoning-effort">Codex reasoning</label>
+                <select id="set-codex-reasoning-effort">
+                  <option value="">Model default</option>
+                </select>
+              </div>
+              <div class="settings-row">
+                <label for="set-claude-model-select">Claude model</label>
+                <select id="set-claude-model-select">
+                  <option value="">Claude account default</option>
+                  <option value="fable">fable — latest Fable</option>
+                  <option value="opus">opus — latest Opus</option>
+                  <option value="sonnet">sonnet — latest Sonnet</option>
+                  <option value="haiku">haiku — latest Haiku</option>
+                  <option value="__custom__">Custom model id…</option>
+                </select>
+              </div>
+              <div class="settings-row hidden" id="set-claude-model-custom-row">
+                <label for="set-claude-model-custom">Custom Claude id</label>
+                <input id="set-claude-model-custom" type="text" placeholder="e.g. claude-haiku-4-5-20251001" autocomplete="off" spellcheck="false">
+              </div>
+              <div class="settings-row">
+                <label for="set-claude-permission-mode">Claude permissions</label>
+                <select id="set-claude-permission-mode">
+                  <option value="default">default</option>
+                  <option value="acceptEdits">acceptEdits</option>
+                  <option value="plan">plan</option>
+                  <option value="auto">auto</option>
+                  <option value="dontAsk">dontAsk</option>
+                  <option value="bypassPermissions">bypassPermissions</option>
                 </select>
               </div>
               <div class="settings-row">
@@ -27265,7 +27308,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '6d87ddcb5f514791';
+const INTENDANT_APP_BUILD = 'eda3448cc9a2ad07';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -42629,14 +42672,13 @@ let newSessionCodexDefaultServiceTier = '';
 let newSessionCodexFastMode = false;
 let newSessionCodexFastModeTouched = false;
 let newSessionCodexLaunchDefaultsLoaded = false;
-// Projectless daemons cannot serve /api/settings until the user chooses a
-// project, so New Session needs an embedded offline catalog. A daemon-side
-// parity test pins this JSON fallback to project::CODEX_MODEL_CATALOG; a
-// successful settings fetch replaces it with the daemon-owned payload.
+// Keep an embedded offline catalog for a settings fetch that has not landed
+// yet (or an older/unreachable daemon). A daemon-side parity test pins this
+// JSON fallback to project::CODEX_MODEL_CATALOG; a successful settings fetch
+// replaces it with the signed-in Codex account's cached catalog.
 const NEW_SESSION_CODEX_MODEL_FALLBACK = Object.freeze(
 /* codex-model-catalog:start */
 [
-  {"id":"gpt-5.6","display_name":"GPT-5.6 (Sol alias)","default_reasoning_effort":"medium","reasoning_efforts":["low","medium","high","xhigh","max","ultra"]},
   {"id":"gpt-5.6-sol","display_name":"GPT-5.6-Sol","default_reasoning_effort":"medium","reasoning_efforts":["low","medium","high","xhigh","max","ultra"]},
   {"id":"gpt-5.6-terra","display_name":"GPT-5.6-Terra","default_reasoning_effort":"medium","reasoning_efforts":["low","medium","high","xhigh","max","ultra"]},
   {"id":"gpt-5.6-luna","display_name":"GPT-5.6-Luna","default_reasoning_effort":"medium","reasoning_efforts":["low","medium","high","xhigh","max"]},
@@ -83739,6 +83781,106 @@ function renderStatsForActiveHost(options = {}) {
 // ── Settings ──
 // settingsLoaded lives with the minimal JS state block (deep-link TDZ).
 
+function settingsCodexModelValue() {
+  const select = document.getElementById('set-codex-model-select');
+  if (!select) return '';
+  if (select.value === '__custom__') {
+    return document.getElementById('set-codex-model-custom')?.value.trim() || '';
+  }
+  return select.value || '';
+}
+
+function settingsCodexCatalogEntry() {
+  const model = settingsCodexModelValue();
+  if (!model) return null;
+  return newSessionCodexModelCatalog
+    .filter(entry => entry.id === model || model.startsWith(`${entry.id}-`))
+    .sort((a, b) => b.id.length - a.id.length)[0] || null;
+}
+
+function updateSettingsCodexCustomModelRow() {
+  const custom = document.getElementById('set-codex-model-select')?.value === '__custom__';
+  document.getElementById('set-codex-model-custom-row')?.classList.toggle('hidden', !custom);
+}
+
+function populateSettingsCodexReasoningEfforts(configuredEffort = null) {
+  const select = document.getElementById('set-codex-reasoning-effort');
+  if (!select) return;
+  const previous = configuredEffort === null ? (select.value || '') : String(configuredEffort || '').trim();
+  const model = settingsCodexCatalogEntry();
+  const efforts = model?.reasoning_efforts?.length
+    ? model.reasoning_efforts
+    : newSessionCodexReasoningEfforts;
+  select.replaceChildren();
+  const inherit = document.createElement('option');
+  inherit.value = '';
+  inherit.textContent = model?.default_reasoning_effort
+    ? `Model default (${model.default_reasoning_effort})`
+    : 'Model / Codex default';
+  select.appendChild(inherit);
+  for (const effort of efforts) {
+    const option = document.createElement('option');
+    option.value = effort;
+    option.textContent = effort === 'ultra'
+      ? 'ultra — automatic task delegation'
+      : effort;
+    select.appendChild(option);
+  }
+  select.value = efforts.includes(previous) ? previous : '';
+}
+
+function populateSettingsCodexModel(configuredModel, configuredEffort) {
+  const select = document.getElementById('set-codex-model-select');
+  const customInput = document.getElementById('set-codex-model-custom');
+  if (!select) return;
+  const model = String(configuredModel || '').trim();
+  select.replaceChildren();
+  const inherit = document.createElement('option');
+  inherit.value = '';
+  inherit.textContent = 'Codex account default';
+  select.appendChild(inherit);
+  for (const entry of newSessionCodexModelCatalog) {
+    const option = document.createElement('option');
+    option.value = entry.id;
+    option.textContent = `${entry.display_name} — ${entry.id}`;
+    select.appendChild(option);
+  }
+  const custom = document.createElement('option');
+  custom.value = '__custom__';
+  custom.textContent = 'Custom model id…';
+  select.appendChild(custom);
+  const isCatalogModel = newSessionCodexModelCatalog.some(entry => entry.id === model);
+  select.value = !model ? '' : (isCatalogModel ? model : '__custom__');
+  if (customInput) customInput.value = model && !isCatalogModel ? model : '';
+  updateSettingsCodexCustomModelRow();
+  populateSettingsCodexReasoningEfforts(configuredEffort);
+}
+
+function settingsClaudeModelValue() {
+  const select = document.getElementById('set-claude-model-select');
+  if (!select) return '';
+  if (select.value === '__custom__') {
+    return document.getElementById('set-claude-model-custom')?.value.trim() || '';
+  }
+  return select.value || '';
+}
+
+function updateSettingsClaudeCustomModelRow() {
+  const custom = document.getElementById('set-claude-model-select')?.value === '__custom__';
+  document.getElementById('set-claude-model-custom-row')?.classList.toggle('hidden', !custom);
+}
+
+function populateSettingsClaudeModel(configuredModel) {
+  const select = document.getElementById('set-claude-model-select');
+  const customInput = document.getElementById('set-claude-model-custom');
+  if (!select) return;
+  const model = String(configuredModel || '').trim();
+  const aliases = ['fable', 'opus', 'sonnet', 'haiku'];
+  select.value = !model ? '' : (aliases.includes(model) ? model : '__custom__');
+  if (customInput) customInput.value = model && !aliases.includes(model) ? model : '';
+  updateSettingsClaudeCustomModelRow();
+}
+
 async function loadSettings() {
   try {
     const d = await fetchDashboardSettings();
@@ -83769,11 +83911,29 @@ async function loadSettings() {
     document.getElementById('set-codex-managed-command').value = d.codex_managed_command || '';
     document.getElementById('set-claude-command').value = d.claude_command || 'claude';
     document.getElementById('set-codex-service-tier').value = normalizeCodexServiceTier(d.codex_service_tier || '');
-    controlCodexConfig.command = d.codex_command || 'codex';
-    controlCodexConfig.service_tier = normalizeCodexServiceTier(d.codex_service_tier || '');
-    controlCodexConfig.managed_context = d.codex_managed_context || 'vanilla';
-    controlCodexConfig.context_archive = d.codex_context_archive || 'summary';
+    controlCodexConfig = {
+      command: d.codex_command || 'codex',
+      managed_command: d.codex_managed_command || '',
+      sandbox: normalizeCodexSandbox(d.codex_sandbox || 'workspace-write'),
+      approval_policy: normalizeCodexApprovalPolicy(d.codex_approval_policy || 'on-request'),
+      model: d.codex_model || '',
+      reasoning_effort: d.codex_reasoning_effort || '',
+      service_tier: normalizeCodexServiceTier(d.codex_service_tier || ''),
+      web_search: !!d.codex_web_search,
+      network_access: !!d.codex_network_access,
+      writable_roots: Array.isArray(d.codex_writable_roots) ? d.codex_writable_roots : [],
+      managed_context: d.codex_managed_context || 'vanilla',
+      context_archive: d.codex_context_archive || 'summary',
+    };
+    controlClaudeConfig = {
+      model: d.claude_model || '',
+      permission_mode: d.claude_permission_mode || 'default',
+      allowed_tools: Array.isArray(d.claude_allowed_tools) ? d.claude_allowed_tools : [],
+    };
     setNewSessionAgentDefaults(d);
+    populateSettingsCodexModel(d.codex_model, d.codex_reasoning_effort);
+    populateSettingsClaudeModel(d.claude_model);
+    document.getElementById('set-claude-permission-mode').value = controlClaudeConfig.permission_mode;
     // External agent: persisted to intendant.toml via `[agent]
     // default_backend`. Sync the Settings dropdown and status bar
     // worker identity here — on a fresh daemon boot there are no
@@ -83815,13 +83975,11 @@ async function loadSettings() {
 async function saveSettings() {
   const g = id => document.getElementById(id);
   const selectedCodexServiceTier = normalizeCodexServiceTier(g('set-codex-service-tier')?.value ?? controlCodexConfig.service_tier ?? '');
+  const selectedCodexModel = settingsCodexModelValue();
+  const selectedCodexReasoningEffort = g('set-codex-reasoning-effort')?.value || '';
+  const selectedClaudeModel = settingsClaudeModelValue();
+  const selectedClaudePermissionMode = g('set-claude-permission-mode')?.value || 'default';
   const selectedClaudeCommand = (g('set-claude-command')?.value || '').trim() || 'claude';
-  controlCodexConfig.service_tier = selectedCodexServiceTier;
-  newSessionCodexDefaultServiceTier = selectedCodexServiceTier;
-  newSessionAgentCommands['claude-code'] = selectedClaudeCommand;
-  if (!newSessionCodexFastModeTouched) {
-    newSessionCodexFastMode = codexServiceTierIsFast(selectedCodexServiceTier);
-  }
   const payload = {
     cu_provider: g('set-cu-provider').value || null,
     cu_model: g('set-cu-model').value || null,
@@ -83849,8 +84007,10 @@ async function saveSettings() {
     claude_command: selectedClaudeCommand,
     codex_sandbox: controlCodexConfig.sandbox || 'workspace-write',
     codex_approval_policy: controlCodexConfig.approval_policy || 'on-request',
-    codex_model: controlCodexConfig.model || null,
-    codex_reasoning_effort: controlCodexConfig.reasoning_effort || null,
+    // Empty strings are explicit clears. `null`/omission means "leave this
+    // field untouched" to partial API clients on the daemon.
+    codex_model: selectedCodexModel,
+    codex_reasoning_effort: selectedCodexReasoningEffort,
     codex_service_tier: selectedCodexServiceTier,
     codex_web_search: !!controlCodexConfig.web_search,
     codex_network_access: !!controlCodexConfig.network_access,
@@ -83859,7 +84019,13 @@ async function saveSettings() {
       : [],
     codex_managed_context: controlCodexConfig.managed_context || 'vanilla',
     codex_context_archive: controlCodexConfig.context_archive || 'summary',
+    claude_model: selectedClaudeModel,
+    claude_permission_mode: selectedClaudePermissionMode,
+    claude_allowed_tools: Array.isArray(controlClaudeConfig.allowed_tools)
+      ? controlClaudeConfig.allowed_tools
+      : [],
   };
+  let settingsSaved = false;
   try {
     // daemonApi (transport F3): POST twin — the fallback policy derives
     // no-replay from the verb, exactly the legacy
@@ -83870,6 +84036,7 @@ async function saveSettings() {
     const data = resp.body;
     const status = g('settings-status');
     if (data.ok) {
+      settingsSaved = true;
       status.textContent = 'Saved';
       status.style.color = 'var(--green)';
     } else {
@@ -83889,12 +84056,27 @@ async function saveSettings() {
     }
     showControlToast?.('error', 'Settings save failed: ' + (e?.message || 'network error'));
   }
+  if (!settingsSaved) return;
+  // Commit the browser-side mirrors only after persistence succeeds. A
+  // failed POST must not make New Session behave as though the defaults had
+  // been saved.
+  controlCodexConfig.model = selectedCodexModel;
+  controlCodexConfig.reasoning_effort = selectedCodexReasoningEffort;
+  controlCodexConfig.service_tier = selectedCodexServiceTier;
+  controlClaudeConfig.model = selectedClaudeModel;
+  controlClaudeConfig.permission_mode = selectedClaudePermissionMode;
+  newSessionCodexDefaultServiceTier = selectedCodexServiceTier;
+  newSessionCodexGlobalModel = selectedCodexModel;
+  newSessionCodexGlobalReasoningEffort = selectedCodexReasoningEffort;
+  newSessionAgentCommands['claude-code'] = selectedClaudeCommand;
+  if (!newSessionCodexFastModeTouched) {
+    newSessionCodexFastMode = codexServiceTierIsFast(selectedCodexServiceTier);
+  }
   // Also emit the control messages so the in-memory shared state
   // updates immediately (without waiting for the next daemon restart
   // to re-read the TOML). The POST above persists — and the gateway
-  // re-dispatches the codex fields server-side too — but keep this
-  // list complete so the dashboard never depends on that, and cover
-  // every codex field with a live control-plane setter.
+  // re-dispatches the external-agent fields server-side too — but keep
+  // this list complete so the dashboard never depends on that path.
   const agentVal = g('set-external-agent').value || null;
   dispatchControlMsg({ action: 'set_external_agent', agent: agentVal });
   dispatchControlMsg({
@@ -83904,6 +84086,16 @@ async function saveSettings() {
   dispatchControlMsg({
     action: 'set_codex_managed_command',
     command: (g('set-codex-managed-command').value || '').trim() || null,
+  });
+  dispatchControlMsg({ action: 'set_codex_sandbox', mode: controlCodexConfig.sandbox || 'workspace-write' });
+  dispatchControlMsg({ action: 'set_codex_approval_policy', policy: controlCodexConfig.approval_policy || 'on-request' });
+  dispatchControlMsg({ action: 'set_codex_model', model: selectedCodexModel || null });
+  dispatchControlMsg({ action: 'set_codex_reasoning_effort', effort: selectedCodexReasoningEffort || null });
+  dispatchControlMsg({ action: 'set_codex_web_search', enabled: !!controlCodexConfig.web_search });
+  dispatchControlMsg({ action: 'set_codex_network_access', enabled: !!controlCodexConfig.network_access });
+  dispatchControlMsg({
+    action: 'set_codex_writable_roots',
+    roots: Array.isArray(controlCodexConfig.writable_roots) ? controlCodexConfig.writable_roots : [],
   });
   dispatchControlMsg({
     action: 'set_codex_managed_context',
@@ -83917,10 +84109,24 @@ async function saveSettings() {
     action: 'set_codex_service_tier',
     service_tier: selectedCodexServiceTier || null,
   });
+  dispatchControlMsg({ action: 'set_claude_model', model: selectedClaudeModel || null });
+  dispatchControlMsg({ action: 'set_claude_permission_mode', mode: selectedClaudePermissionMode });
+  dispatchControlMsg({
+    action: 'set_claude_allowed_tools',
+    tools: Array.isArray(controlClaudeConfig.allowed_tools) ? controlClaudeConfig.allowed_tools : [],
+  });
 }
 
 document.getElementById('settings-save-btn').addEventListener('click', saveSettings);
 document.getElementById('settings-reset-btn').addEventListener('click', () => { settingsLoaded = false; loadSettings(); });
+document.getElementById('set-codex-model-select')?.addEventListener('change', () => {
+  updateSettingsCodexCustomModelRow();
+  populateSettingsCodexReasoningEfforts();
+});
+document.getElementById('set-codex-model-custom')?.addEventListener('input', () => {
+  populateSettingsCodexReasoningEfforts();
+});
+document.getElementById('set-claude-model-select')?.addEventListener('change', updateSettingsClaudeCustomModelRow);
 document.getElementById('download-session-report-btn')?.addEventListener('click', downloadSessionReportViaDashboardControl);
 document.getElementById('connect-self-test-btn')?.addEventListener('click', () => {
   runConnectSelfTests().catch(err => {
@@ -85688,7 +85894,6 @@ function focusActivityForSessionEvent(options = {}) {
     showBadge('activity', '\u2022');
   }
 }
-
 /* ── static/app/ui2-settings.js ── */
 // ── ui-v2 Settings: 4-section layout + autonomy & approvals ────────────
 // Design-overhaul P2. Under the ui-v2 flag the Settings tab becomes the
@@ -86113,7 +86318,8 @@ function ui2SettingsBuild() {
     if (keys) panes.providers.appendChild(keys);
 
     // External agent → "Managed backend" with a segmented proxy over the
-    // existing select + an Advanced fold for binaries and tier.
+    // existing select, daemon-wide model defaults for both backends, and an
+    // Advanced fold for binaries and tier.
     const ext = cardOf('settings-external-agent-heading');
     if (ext) {
       panes.providers.appendChild(ext);
@@ -86130,7 +86336,7 @@ function ui2SettingsBuild() {
         'set-codex-command', 'set-codex-managed-command', 'set-claude-command', 'set-codex-service-tier',
       ]);
       const link = ui2SettingsEl('p', 'settings-note ui2-crosslink');
-      link.innerHTML = 'Live backend controls — sandbox, approval policy, model override, thread actions — stay in <a href="#activity/control">Activity → Control</a>.';
+      link.innerHTML = 'Advanced live controls — sandbox, approval policy, allowed tools, and thread actions — are in <a href="#activity/control">Activity → Control</a>.';
       ext.appendChild(link);
     }
 

--- a/static/app/21-access-dialogs.html
+++ b/static/app/21-access-dialogs.html
@@ -351,7 +351,7 @@
         <div class="subtab-pane" id="settings-pane-agent">
           <div class="settings-pane-body">
             <p class="settings-note">
-              Settings are saved to <code>intendant.toml</code> and take effect on the next task.
+              Settings are saved to the current project's <code>intendant.toml</code>, or to the daemon-wide <code>~/.intendant/intendant.toml</code> when no project is attached. Agent defaults take effect on the next task.
             </p>
 
             <section class="ui-card" aria-labelledby="settings-external-agent-heading">
@@ -365,6 +365,49 @@
                   <option value="">None (internal agent)</option>
                   <option value="codex">Codex (OpenAI)</option>
                   <option value="claude-code">Claude Code (Anthropic)</option>
+                </select>
+              </div>
+              <div class="settings-row">
+                <label for="set-codex-model-select">Codex model</label>
+                <select id="set-codex-model-select">
+                  <option value="">Codex account default</option>
+                  <option value="__custom__">Custom model id…</option>
+                </select>
+              </div>
+              <div class="settings-row hidden" id="set-codex-model-custom-row">
+                <label for="set-codex-model-custom">Custom Codex id</label>
+                <input id="set-codex-model-custom" type="text" placeholder="e.g. staged-model-id" autocomplete="off" spellcheck="false">
+              </div>
+              <div class="settings-row">
+                <label for="set-codex-reasoning-effort">Codex reasoning</label>
+                <select id="set-codex-reasoning-effort">
+                  <option value="">Model default</option>
+                </select>
+              </div>
+              <div class="settings-row">
+                <label for="set-claude-model-select">Claude model</label>
+                <select id="set-claude-model-select">
+                  <option value="">Claude account default</option>
+                  <option value="fable">fable — latest Fable</option>
+                  <option value="opus">opus — latest Opus</option>
+                  <option value="sonnet">sonnet — latest Sonnet</option>
+                  <option value="haiku">haiku — latest Haiku</option>
+                  <option value="__custom__">Custom model id…</option>
+                </select>
+              </div>
+              <div class="settings-row hidden" id="set-claude-model-custom-row">
+                <label for="set-claude-model-custom">Custom Claude id</label>
+                <input id="set-claude-model-custom" type="text" placeholder="e.g. claude-haiku-4-5-20251001" autocomplete="off" spellcheck="false">
+              </div>
+              <div class="settings-row">
+                <label for="set-claude-permission-mode">Claude permissions</label>
+                <select id="set-claude-permission-mode">
+                  <option value="default">default</option>
+                  <option value="acceptEdits">acceptEdits</option>
+                  <option value="plan">plan</option>
+                  <option value="auto">auto</option>
+                  <option value="dontAsk">dontAsk</option>
+                  <option value="bypassPermissions">bypassPermissions</option>
                 </select>
               </div>
               <div class="settings-row">

--- a/static/app/37-uicommand-changes-control.js
+++ b/static/app/37-uicommand-changes-control.js
@@ -1002,14 +1002,13 @@ let newSessionCodexDefaultServiceTier = '';
 let newSessionCodexFastMode = false;
 let newSessionCodexFastModeTouched = false;
 let newSessionCodexLaunchDefaultsLoaded = false;
-// Projectless daemons cannot serve /api/settings until the user chooses a
-// project, so New Session needs an embedded offline catalog. A daemon-side
-// parity test pins this JSON fallback to project::CODEX_MODEL_CATALOG; a
-// successful settings fetch replaces it with the daemon-owned payload.
+// Keep an embedded offline catalog for a settings fetch that has not landed
+// yet (or an older/unreachable daemon). A daemon-side parity test pins this
+// JSON fallback to project::CODEX_MODEL_CATALOG; a successful settings fetch
+// replaces it with the signed-in Codex account's cached catalog.
 const NEW_SESSION_CODEX_MODEL_FALLBACK = Object.freeze(
 /* codex-model-catalog:start */
 [
-  {"id":"gpt-5.6","display_name":"GPT-5.6 (Sol alias)","default_reasoning_effort":"medium","reasoning_efforts":["low","medium","high","xhigh","max","ultra"]},
   {"id":"gpt-5.6-sol","display_name":"GPT-5.6-Sol","default_reasoning_effort":"medium","reasoning_efforts":["low","medium","high","xhigh","max","ultra"]},
   {"id":"gpt-5.6-terra","display_name":"GPT-5.6-Terra","default_reasoning_effort":"medium","reasoning_efforts":["low","medium","high","xhigh","max","ultra"]},
   {"id":"gpt-5.6-luna","display_name":"GPT-5.6-Luna","default_reasoning_effort":"medium","reasoning_efforts":["low","medium","high","xhigh","max"]},

--- a/static/app/53-stats-settings.js
+++ b/static/app/53-stats-settings.js
@@ -149,6 +149,106 @@ function renderStatsForActiveHost(options = {}) {
 // ── Settings ──
 // settingsLoaded lives with the minimal JS state block (deep-link TDZ).
 
+function settingsCodexModelValue() {
+  const select = document.getElementById('set-codex-model-select');
+  if (!select) return '';
+  if (select.value === '__custom__') {
+    return document.getElementById('set-codex-model-custom')?.value.trim() || '';
+  }
+  return select.value || '';
+}
+
+function settingsCodexCatalogEntry() {
+  const model = settingsCodexModelValue();
+  if (!model) return null;
+  return newSessionCodexModelCatalog
+    .filter(entry => entry.id === model || model.startsWith(`${entry.id}-`))
+    .sort((a, b) => b.id.length - a.id.length)[0] || null;
+}
+
+function updateSettingsCodexCustomModelRow() {
+  const custom = document.getElementById('set-codex-model-select')?.value === '__custom__';
+  document.getElementById('set-codex-model-custom-row')?.classList.toggle('hidden', !custom);
+}
+
+function populateSettingsCodexReasoningEfforts(configuredEffort = null) {
+  const select = document.getElementById('set-codex-reasoning-effort');
+  if (!select) return;
+  const previous = configuredEffort === null ? (select.value || '') : String(configuredEffort || '').trim();
+  const model = settingsCodexCatalogEntry();
+  const efforts = model?.reasoning_efforts?.length
+    ? model.reasoning_efforts
+    : newSessionCodexReasoningEfforts;
+  select.replaceChildren();
+  const inherit = document.createElement('option');
+  inherit.value = '';
+  inherit.textContent = model?.default_reasoning_effort
+    ? `Model default (${model.default_reasoning_effort})`
+    : 'Model / Codex default';
+  select.appendChild(inherit);
+  for (const effort of efforts) {
+    const option = document.createElement('option');
+    option.value = effort;
+    option.textContent = effort === 'ultra'
+      ? 'ultra — automatic task delegation'
+      : effort;
+    select.appendChild(option);
+  }
+  select.value = efforts.includes(previous) ? previous : '';
+}
+
+function populateSettingsCodexModel(configuredModel, configuredEffort) {
+  const select = document.getElementById('set-codex-model-select');
+  const customInput = document.getElementById('set-codex-model-custom');
+  if (!select) return;
+  const model = String(configuredModel || '').trim();
+  select.replaceChildren();
+  const inherit = document.createElement('option');
+  inherit.value = '';
+  inherit.textContent = 'Codex account default';
+  select.appendChild(inherit);
+  for (const entry of newSessionCodexModelCatalog) {
+    const option = document.createElement('option');
+    option.value = entry.id;
+    option.textContent = `${entry.display_name} — ${entry.id}`;
+    select.appendChild(option);
+  }
+  const custom = document.createElement('option');
+  custom.value = '__custom__';
+  custom.textContent = 'Custom model id…';
+  select.appendChild(custom);
+  const isCatalogModel = newSessionCodexModelCatalog.some(entry => entry.id === model);
+  select.value = !model ? '' : (isCatalogModel ? model : '__custom__');
+  if (customInput) customInput.value = model && !isCatalogModel ? model : '';
+  updateSettingsCodexCustomModelRow();
+  populateSettingsCodexReasoningEfforts(configuredEffort);
+}
+
+function settingsClaudeModelValue() {
+  const select = document.getElementById('set-claude-model-select');
+  if (!select) return '';
+  if (select.value === '__custom__') {
+    return document.getElementById('set-claude-model-custom')?.value.trim() || '';
+  }
+  return select.value || '';
+}
+
+function updateSettingsClaudeCustomModelRow() {
+  const custom = document.getElementById('set-claude-model-select')?.value === '__custom__';
+  document.getElementById('set-claude-model-custom-row')?.classList.toggle('hidden', !custom);
+}
+
+function populateSettingsClaudeModel(configuredModel) {
+  const select = document.getElementById('set-claude-model-select');
+  const customInput = document.getElementById('set-claude-model-custom');
+  if (!select) return;
+  const model = String(configuredModel || '').trim();
+  const aliases = ['fable', 'opus', 'sonnet', 'haiku'];
+  select.value = !model ? '' : (aliases.includes(model) ? model : '__custom__');
+  if (customInput) customInput.value = model && !aliases.includes(model) ? model : '';
+  updateSettingsClaudeCustomModelRow();
+}
+
 async function loadSettings() {
   try {
     const d = await fetchDashboardSettings();
@@ -179,11 +279,29 @@ async function loadSettings() {
     document.getElementById('set-codex-managed-command').value = d.codex_managed_command || '';
     document.getElementById('set-claude-command').value = d.claude_command || 'claude';
     document.getElementById('set-codex-service-tier').value = normalizeCodexServiceTier(d.codex_service_tier || '');
-    controlCodexConfig.command = d.codex_command || 'codex';
-    controlCodexConfig.service_tier = normalizeCodexServiceTier(d.codex_service_tier || '');
-    controlCodexConfig.managed_context = d.codex_managed_context || 'vanilla';
-    controlCodexConfig.context_archive = d.codex_context_archive || 'summary';
+    controlCodexConfig = {
+      command: d.codex_command || 'codex',
+      managed_command: d.codex_managed_command || '',
+      sandbox: normalizeCodexSandbox(d.codex_sandbox || 'workspace-write'),
+      approval_policy: normalizeCodexApprovalPolicy(d.codex_approval_policy || 'on-request'),
+      model: d.codex_model || '',
+      reasoning_effort: d.codex_reasoning_effort || '',
+      service_tier: normalizeCodexServiceTier(d.codex_service_tier || ''),
+      web_search: !!d.codex_web_search,
+      network_access: !!d.codex_network_access,
+      writable_roots: Array.isArray(d.codex_writable_roots) ? d.codex_writable_roots : [],
+      managed_context: d.codex_managed_context || 'vanilla',
+      context_archive: d.codex_context_archive || 'summary',
+    };
+    controlClaudeConfig = {
+      model: d.claude_model || '',
+      permission_mode: d.claude_permission_mode || 'default',
+      allowed_tools: Array.isArray(d.claude_allowed_tools) ? d.claude_allowed_tools : [],
+    };
     setNewSessionAgentDefaults(d);
+    populateSettingsCodexModel(d.codex_model, d.codex_reasoning_effort);
+    populateSettingsClaudeModel(d.claude_model);
+    document.getElementById('set-claude-permission-mode').value = controlClaudeConfig.permission_mode;
     // External agent: persisted to intendant.toml via `[agent]
     // default_backend`. Sync the Settings dropdown and status bar
     // worker identity here — on a fresh daemon boot there are no
@@ -225,13 +343,11 @@ async function loadSettings() {
 async function saveSettings() {
   const g = id => document.getElementById(id);
   const selectedCodexServiceTier = normalizeCodexServiceTier(g('set-codex-service-tier')?.value ?? controlCodexConfig.service_tier ?? '');
+  const selectedCodexModel = settingsCodexModelValue();
+  const selectedCodexReasoningEffort = g('set-codex-reasoning-effort')?.value || '';
+  const selectedClaudeModel = settingsClaudeModelValue();
+  const selectedClaudePermissionMode = g('set-claude-permission-mode')?.value || 'default';
   const selectedClaudeCommand = (g('set-claude-command')?.value || '').trim() || 'claude';
-  controlCodexConfig.service_tier = selectedCodexServiceTier;
-  newSessionCodexDefaultServiceTier = selectedCodexServiceTier;
-  newSessionAgentCommands['claude-code'] = selectedClaudeCommand;
-  if (!newSessionCodexFastModeTouched) {
-    newSessionCodexFastMode = codexServiceTierIsFast(selectedCodexServiceTier);
-  }
   const payload = {
     cu_provider: g('set-cu-provider').value || null,
     cu_model: g('set-cu-model').value || null,
@@ -259,8 +375,10 @@ async function saveSettings() {
     claude_command: selectedClaudeCommand,
     codex_sandbox: controlCodexConfig.sandbox || 'workspace-write',
     codex_approval_policy: controlCodexConfig.approval_policy || 'on-request',
-    codex_model: controlCodexConfig.model || null,
-    codex_reasoning_effort: controlCodexConfig.reasoning_effort || null,
+    // Empty strings are explicit clears. `null`/omission means "leave this
+    // field untouched" to partial API clients on the daemon.
+    codex_model: selectedCodexModel,
+    codex_reasoning_effort: selectedCodexReasoningEffort,
     codex_service_tier: selectedCodexServiceTier,
     codex_web_search: !!controlCodexConfig.web_search,
     codex_network_access: !!controlCodexConfig.network_access,
@@ -269,7 +387,13 @@ async function saveSettings() {
       : [],
     codex_managed_context: controlCodexConfig.managed_context || 'vanilla',
     codex_context_archive: controlCodexConfig.context_archive || 'summary',
+    claude_model: selectedClaudeModel,
+    claude_permission_mode: selectedClaudePermissionMode,
+    claude_allowed_tools: Array.isArray(controlClaudeConfig.allowed_tools)
+      ? controlClaudeConfig.allowed_tools
+      : [],
   };
+  let settingsSaved = false;
   try {
     // daemonApi (transport F3): POST twin — the fallback policy derives
     // no-replay from the verb, exactly the legacy
@@ -280,6 +404,7 @@ async function saveSettings() {
     const data = resp.body;
     const status = g('settings-status');
     if (data.ok) {
+      settingsSaved = true;
       status.textContent = 'Saved';
       status.style.color = 'var(--green)';
     } else {
@@ -299,12 +424,27 @@ async function saveSettings() {
     }
     showControlToast?.('error', 'Settings save failed: ' + (e?.message || 'network error'));
   }
+  if (!settingsSaved) return;
+  // Commit the browser-side mirrors only after persistence succeeds. A
+  // failed POST must not make New Session behave as though the defaults had
+  // been saved.
+  controlCodexConfig.model = selectedCodexModel;
+  controlCodexConfig.reasoning_effort = selectedCodexReasoningEffort;
+  controlCodexConfig.service_tier = selectedCodexServiceTier;
+  controlClaudeConfig.model = selectedClaudeModel;
+  controlClaudeConfig.permission_mode = selectedClaudePermissionMode;
+  newSessionCodexDefaultServiceTier = selectedCodexServiceTier;
+  newSessionCodexGlobalModel = selectedCodexModel;
+  newSessionCodexGlobalReasoningEffort = selectedCodexReasoningEffort;
+  newSessionAgentCommands['claude-code'] = selectedClaudeCommand;
+  if (!newSessionCodexFastModeTouched) {
+    newSessionCodexFastMode = codexServiceTierIsFast(selectedCodexServiceTier);
+  }
   // Also emit the control messages so the in-memory shared state
   // updates immediately (without waiting for the next daemon restart
   // to re-read the TOML). The POST above persists — and the gateway
-  // re-dispatches the codex fields server-side too — but keep this
-  // list complete so the dashboard never depends on that, and cover
-  // every codex field with a live control-plane setter.
+  // re-dispatches the external-agent fields server-side too — but keep
+  // this list complete so the dashboard never depends on that path.
   const agentVal = g('set-external-agent').value || null;
   dispatchControlMsg({ action: 'set_external_agent', agent: agentVal });
   dispatchControlMsg({
@@ -314,6 +454,16 @@ async function saveSettings() {
   dispatchControlMsg({
     action: 'set_codex_managed_command',
     command: (g('set-codex-managed-command').value || '').trim() || null,
+  });
+  dispatchControlMsg({ action: 'set_codex_sandbox', mode: controlCodexConfig.sandbox || 'workspace-write' });
+  dispatchControlMsg({ action: 'set_codex_approval_policy', policy: controlCodexConfig.approval_policy || 'on-request' });
+  dispatchControlMsg({ action: 'set_codex_model', model: selectedCodexModel || null });
+  dispatchControlMsg({ action: 'set_codex_reasoning_effort', effort: selectedCodexReasoningEffort || null });
+  dispatchControlMsg({ action: 'set_codex_web_search', enabled: !!controlCodexConfig.web_search });
+  dispatchControlMsg({ action: 'set_codex_network_access', enabled: !!controlCodexConfig.network_access });
+  dispatchControlMsg({
+    action: 'set_codex_writable_roots',
+    roots: Array.isArray(controlCodexConfig.writable_roots) ? controlCodexConfig.writable_roots : [],
   });
   dispatchControlMsg({
     action: 'set_codex_managed_context',
@@ -327,10 +477,24 @@ async function saveSettings() {
     action: 'set_codex_service_tier',
     service_tier: selectedCodexServiceTier || null,
   });
+  dispatchControlMsg({ action: 'set_claude_model', model: selectedClaudeModel || null });
+  dispatchControlMsg({ action: 'set_claude_permission_mode', mode: selectedClaudePermissionMode });
+  dispatchControlMsg({
+    action: 'set_claude_allowed_tools',
+    tools: Array.isArray(controlClaudeConfig.allowed_tools) ? controlClaudeConfig.allowed_tools : [],
+  });
 }
 
 document.getElementById('settings-save-btn').addEventListener('click', saveSettings);
 document.getElementById('settings-reset-btn').addEventListener('click', () => { settingsLoaded = false; loadSettings(); });
+document.getElementById('set-codex-model-select')?.addEventListener('change', () => {
+  updateSettingsCodexCustomModelRow();
+  populateSettingsCodexReasoningEfforts();
+});
+document.getElementById('set-codex-model-custom')?.addEventListener('input', () => {
+  populateSettingsCodexReasoningEfforts();
+});
+document.getElementById('set-claude-model-select')?.addEventListener('change', updateSettingsClaudeCustomModelRow);
 document.getElementById('download-session-report-btn')?.addEventListener('click', downloadSessionReportViaDashboardControl);
 document.getElementById('connect-self-test-btn')?.addEventListener('click', () => {
   runConnectSelfTests().catch(err => {
@@ -2098,4 +2262,3 @@ function focusActivityForSessionEvent(options = {}) {
     showBadge('activity', '\u2022');
   }
 }
-

--- a/static/app/ui2-settings.js
+++ b/static/app/ui2-settings.js
@@ -421,7 +421,8 @@ function ui2SettingsBuild() {
     if (keys) panes.providers.appendChild(keys);
 
     // External agent → "Managed backend" with a segmented proxy over the
-    // existing select + an Advanced fold for binaries and tier.
+    // existing select, daemon-wide model defaults for both backends, and an
+    // Advanced fold for binaries and tier.
     const ext = cardOf('settings-external-agent-heading');
     if (ext) {
       panes.providers.appendChild(ext);
@@ -438,7 +439,7 @@ function ui2SettingsBuild() {
         'set-codex-command', 'set-codex-managed-command', 'set-claude-command', 'set-codex-service-tier',
       ]);
       const link = ui2SettingsEl('p', 'settings-note ui2-crosslink');
-      link.innerHTML = 'Live backend controls — sandbox, approval policy, model override, thread actions — stay in <a href="#activity/control">Activity → Control</a>.';
+      link.innerHTML = 'Advanced live controls — sandbox, approval policy, allowed tools, and thread actions — are in <a href="#activity/control">Activity → Control</a>.';
       ext.appendChild(link);
     }
 

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -712,6 +712,15 @@ async fn projectless_daemon_serves_and_requires_an_explicit_session_project() {
     use futures_util::SinkExt;
 
     let rig = TestRig::new();
+    // Projectless daemons keep durable dashboard defaults under their state
+    // root without turning that root into a session project.
+    let daemon_state = rig.home.path().join(".intendant");
+    std::fs::create_dir_all(&daemon_state).expect("create daemon state root");
+    std::fs::write(
+        daemon_state.join("intendant.toml"),
+        "[agent.codex]\nmodel = \"gpt-5.6-sol\"\n\n[agent.claude_code]\nmodel = \"fable\"\n",
+    )
+    .expect("seed daemon-wide settings");
     let script = rig.write_script(&serde_json::json!({
         "profiles": [{
             "steps": [
@@ -782,6 +791,42 @@ async fn projectless_daemon_serves_and_requires_an_explicit_session_project() {
             .is_some_and(|v| v.is_null()),
         "projectless daemon must report project_root: null, got {project_root_body}"
     );
+
+    // Config scope is independent of project scope: Settings loads and saves
+    // against the daemon root while /api/project-root remains null.
+    let mut settings: serde_json::Value = http
+        .get(format!("{base}/api/settings"))
+        .send()
+        .await
+        .expect("GET projectless settings")
+        .error_for_status()
+        .expect("projectless settings status")
+        .json()
+        .await
+        .expect("projectless settings JSON");
+    assert_eq!(settings["codex_model"], "gpt-5.6-sol");
+    assert_eq!(settings["claude_model"], "fable");
+    assert!(settings["codex_models"]
+        .as_array()
+        .is_some_and(|models| models.iter().all(|model| model["id"] != "gpt-5.6")));
+    settings["codex_model"] = serde_json::json!("gpt-5.6-terra");
+    settings["claude_model"] = serde_json::json!("sonnet");
+    let save: serde_json::Value = http
+        .post(format!("{base}/api/settings"))
+        .json(&settings)
+        .send()
+        .await
+        .expect("POST projectless settings")
+        .error_for_status()
+        .expect("projectless settings save status")
+        .json()
+        .await
+        .expect("projectless settings save JSON");
+    assert_eq!(save["ok"], true);
+    let saved = std::fs::read_to_string(daemon_state.join("intendant.toml"))
+        .expect("read daemon-wide settings");
+    assert!(saved.contains("model = \"gpt-5.6-terra\""), "{saved}");
+    assert!(saved.contains("model = \"sonnet\""), "{saved}");
 
     let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/ws"))
         .await


### PR DESCRIPTION
## Summary
- derive Codex model choices and reasoning levels from the active signed-in account cache, applying Codex's own auth-mode filter and removing the invalid bare GPT-5.6 fallback alias
- expose persistent global Codex and Claude defaults in Settings, including on projectless daemons
- keep projectless config persistence separate from project, watcher, and sandbox scope

## Validation
- `cargo test --bins` (3,306 passed; 9 ignored)
- `cargo clippy --bins -- -D warnings`
- focused projectless daemon E2E
- generated-dashboard script parse and headed Settings boot probe with current-static verification