### PR TITLE
dashboard: mobile composer mechanics — measured reservation, keyboard lift, safe-area

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -3,7 +3,13 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+<!-- viewport-fit=cover: layout extends under notches/home indicator so the
+     env(safe-area-inset-*) vars in ui2-chrome.css get real values (they are
+     0 otherwise and the chrome collides with hardware on phones). No
+     user-scalable=no: pinch-zoom is an accessibility escape hatch — iOS
+     focus-zoom is prevented by 16px input font, double-tap zoom by
+     per-element touch-action:manipulation. -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <title>Intendant</title>
 <link rel="icon" type="image/png" sizes="128x128" href="/icon-128.png" id="favicon">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
@@ -12258,11 +12264,34 @@ html.ui-v2 :focus:not(:focus-visible) { outline: none; }
    that never overlaps the Station canvases — the fixed rail and the
    oversight bar sit outside #app's content box, never over the canvas. */
 
-html.ui-v2 { --ui2-nav-w: 244px; --ui2-ovs-h: 48px; }
+html.ui-v2 {
+  --ui2-nav-w: 244px;
+  --ui2-ovs-h: 48px;
+  /* Device cutout / home-indicator insets. viewport-fit=cover makes these
+     nonzero on notched phones (0 everywhere else); they are composed into
+     every fixed-chrome coordinate below so no control sits under hardware. */
+  --ui2-sa-t: env(safe-area-inset-top, 0px);
+  --ui2-sa-r: env(safe-area-inset-right, 0px);
+  --ui2-sa-b: env(safe-area-inset-bottom, 0px);
+  --ui2-sa-l: env(safe-area-inset-left, 0px);
+  /* Left edge of the content area: rail width + left cutout. */
+  --ui2-nav-edge: calc(var(--ui2-nav-w) + var(--ui2-sa-l));
+  /* Composer geometry. --ui2-composer-h is kept at the bar's REAL rendered
+     height by ui2WireComposerMech (the bar wraps and grows: focus expand,
+     attachments row, the 500-600px wrap band) — the old 92px/64px constants
+     under-reserved whenever it did, letting the bar cover the Files save
+     row and the Live control banner. The fallback approximates the at-rest
+     bar for the pre-boot paint. --ui2-kb-inset lifts the bar above the iOS
+     soft keyboard while composing (0 otherwise). */
+  --ui2-composer-off: 16px;
+  --ui2-composer-h: 62px;
+  --ui2-kb-inset: 0px;
+}
 
 html.ui-v2 #app {
-  padding-left: var(--ui2-nav-w);
-  padding-top: var(--ui2-ovs-h);
+  padding-left: var(--ui2-nav-edge);
+  padding-top: calc(var(--ui2-ovs-h) + var(--ui2-sa-t));
+  padding-right: var(--ui2-sa-r);
 }
 html.ui-v2 .tab-bar { display: none; }
 
@@ -12270,7 +12299,9 @@ html.ui-v2 .tab-bar { display: none; }
 html.ui-v2 #ui2-nav {
   position: fixed;
   inset: 0 auto 0 0;
-  width: var(--ui2-nav-w);
+  width: var(--ui2-nav-edge);
+  padding-left: var(--ui2-sa-l);
+  padding-bottom: var(--ui2-sa-b);
   z-index: 40;
   display: flex;
   flex-direction: column;
@@ -12380,11 +12411,11 @@ html.ui-v2 .ui2-identity-sub { font-size: 10.5px; color: var(--text-3); }
 /* ── oversight bar ── */
 html.ui-v2 #ui2-oversight {
   position: fixed;
-  top: 0; left: var(--ui2-nav-w); right: 0;
-  height: var(--ui2-ovs-h);
+  top: 0; left: var(--ui2-nav-edge); right: 0;
+  height: calc(var(--ui2-ovs-h) + var(--ui2-sa-t));
   z-index: 39;
   display: flex; align-items: center; gap: 12px;
-  padding: 0 18px;
+  padding: var(--ui2-sa-t) calc(18px + var(--ui2-sa-r)) 0 18px;
   background: var(--glass);
   -webkit-backdrop-filter: blur(14px);
   backdrop-filter: blur(14px);
@@ -12668,14 +12699,19 @@ html.ui-v2 .ui2-theme-btn:hover { background: var(--surface-2); color: var(--tex
    the bottom — the design's composer. Same element, same ids, all v1
    listeners intact; phase + stop inside it are hidden because the
    oversight bar already mirrors them. Solid surface, no backdrop-filter:
-   fixed chrome overlaps the Station canvases on the Station tab. */
-html.ui-v2 #app { padding-bottom: 92px; }
+   fixed chrome overlaps the Station canvases on the Station tab.
+   The #app bottom reservation tracks the bar's measured height (see the
+   --ui2-composer-h note at the vars block): panes must never draw under
+   the dock, whatever the dock's current size. */
+html.ui-v2 #app {
+  padding-bottom: calc(var(--ui2-composer-h) + var(--ui2-composer-off) + var(--ui2-sa-b) + 14px);
+}
 html.ui-v2 .global-task-bar {
   position: fixed;
-  left: var(--ui2-nav-w);
-  right: 0;
-  bottom: 16px;
-  width: min(920px, calc(100vw - var(--ui2-nav-w) - 36px));
+  left: var(--ui2-nav-edge);
+  right: var(--ui2-sa-r);
+  bottom: calc(var(--ui2-composer-off) + var(--ui2-sa-b) + var(--ui2-kb-inset));
+  width: min(920px, calc(100vw - var(--ui2-nav-edge) - var(--ui2-sa-r) - 36px));
   margin-inline: auto;
   z-index: 70;
   padding: 9px 11px;
@@ -12812,13 +12848,15 @@ html.ui-v2 .ui2-nav-bottom { flex-shrink: 0; background: var(--bg); }
    full control set. :focus-within covers typing, target chip, attach and
    Direct once expanded. */
 @media (max-width: 500px) {
+  /* The dock hugs the edge tighter on phones; the #app reservation keeps
+     following the measured bar height (the old fixed 64px was smaller
+     than the bar itself — the root of the covered-controls bug). */
+  html.ui-v2 { --ui2-composer-off: 8px; }
   html.ui-v2 .global-task-bar {
-    bottom: 8px;
-    width: calc(100vw - var(--ui2-nav-w) - 16px);
+    width: calc(100vw - var(--ui2-nav-edge) - var(--ui2-sa-r) - 16px);
     padding: 6px 8px;
     flex-wrap: wrap;
   }
-  html.ui-v2 #app { padding-bottom: 64px; }
   html.ui-v2 .global-task-bar .task-new-session-btn,
   html.ui-v2 .global-task-bar .global-attach-btn,
   html.ui-v2 .global-task-bar .global-direct-toggle {
@@ -12871,6 +12909,15 @@ html.ui-v2 .ui2-fuel-chip {
   border: 1px solid rgba(var(--green-rgb), .28);
   white-space: nowrap;
 }
+
+/* ── touch behavior ──
+   The viewport meta no longer carries user-scalable=no (pinch-zoom is an
+   accessibility escape hatch and the recovery gesture when a layout goes
+   wrong on a phone). Double-tap-to-zoom on controls is suppressed
+   per-element instead; manipulation still allows pan and pinch. */
+html.ui-v2 :is(button, select, input, textarea, label, .ui2-nav-item, .tab-btn) {
+  touch-action: manipulation;
+}
 /* ── static/app/ui2-voice.css ── */
 /* ── ui-v2 voice: mic button + in-call panel (user-approved design) ────
    All scoped html.ui-v2. The v1 floating overlay stays in the DOM
@@ -12905,8 +12952,8 @@ html.ui-v2 .ui2-micbtn[data-state="error"] .ui2-micbtn-dot { background: var(--r
 
 html.ui-v2 #ui2-voice-panel {
   position: fixed;
-  top: calc(var(--ui2-ovs-h) + 8px);
-  right: 18px;                     /* shares the oversight bar's content edge */
+  top: calc(var(--ui2-ovs-h) + var(--ui2-sa-t) + 8px);
+  right: calc(18px + var(--ui2-sa-r)); /* shares the oversight bar's content edge */
   width: min(320px, calc(100vw - 36px));
   z-index: 90;                     /* above content + composer (70), below ⌘K (100) */
   background: var(--surface);
@@ -26659,6 +26706,55 @@ function ui2FuelChipSync() {
     + (best.kind ? ` (${best.kind})` : '') + '. Display only.';
 }
 
+function ui2WireComposerMech() {
+  const bar = document.querySelector('.global-task-bar');
+  if (!bar) return;
+  const root = document.documentElement.style;
+
+  // Reservation: keep --ui2-composer-h at the bar's real border-box height.
+  // The bar wraps and grows (focus expand, the attachments row, the v1
+  // 500-600px wrap band), and the old constant reservation is exactly what
+  // let it cover the Files save row and the Live control banner on phones.
+  const measure = () => {
+    const h = Math.ceil(bar.getBoundingClientRect().height);
+    if (h > 0) root.setProperty('--ui2-composer-h', h + 'px');
+  };
+  if (typeof ResizeObserver === 'function') {
+    new ResizeObserver(measure).observe(bar);
+  } else {
+    bar.addEventListener('focusin', () => requestAnimationFrame(measure));
+    bar.addEventListener('focusout', () => requestAnimationFrame(measure));
+    window.addEventListener('resize', measure);
+  }
+  measure();
+
+  // Soft-keyboard lift: iOS keeps position:fixed anchored to the layout
+  // viewport, so the opened keyboard covers the bar mid-composition. Track
+  // the visual viewport and lift by the overlap — but only while focus is
+  // inside the bar: lifting for other inputs (the Files editor, a settings
+  // field) would cover the very field being edited. Android resizes the
+  // layout viewport under the keyboard instead, so the overlap computes to
+  // ~0 there and this stays inert.
+  const vv = window.visualViewport;
+  if (vv) {
+    let raf = 0;
+    const apply = () => {
+      raf = 0;
+      const composing = bar.contains(document.activeElement);
+      const overlap = window.innerHeight - vv.height - vv.offsetTop;
+      const inset = composing ? Math.max(0, Math.round(overlap)) : 0;
+      root.setProperty('--ui2-kb-inset', inset + 'px');
+    };
+    const schedule = () => { if (!raf) raf = requestAnimationFrame(apply); };
+    vv.addEventListener('resize', schedule);
+    vv.addEventListener('scroll', schedule);
+    bar.addEventListener('focusin', schedule);
+    // The keyboard retracts after focus leaves; measuring in the same frame
+    // reads the pre-retraction viewport.
+    bar.addEventListener('focusout', () => setTimeout(schedule, 80));
+  }
+}
+
 ui2BuildNav();
 {
   // Single-boot: a module script executes at readyState 'interactive', so
@@ -26669,6 +26765,7 @@ ui2BuildNav();
   const wire = () => {
     ui2WireMirrors();
     ui2WirePalette();
+    ui2WireComposerMech();
     // Fuel chip: transport-status flips repaint it via the existing
     // #sb-dashboard-transport mirror lane; the interval keeps the lease
     // countdown honest between flips.
@@ -27265,7 +27362,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '6d87ddcb5f514791';
+const INTENDANT_APP_BUILD = '817badba45e13bb5';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {

--- a/static/app/00-head.html
+++ b/static/app/00-head.html
@@ -2,7 +2,13 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+<!-- viewport-fit=cover: layout extends under notches/home indicator so the
+     env(safe-area-inset-*) vars in ui2-chrome.css get real values (they are
+     0 otherwise and the chrome collides with hardware on phones). No
+     user-scalable=no: pinch-zoom is an accessibility escape hatch — iOS
+     focus-zoom is prevented by 16px input font, double-tap zoom by
+     per-element touch-action:manipulation. -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <title>Intendant</title>
 <link rel="icon" type="image/png" sizes="128x128" href="/icon-128.png" id="favicon">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">

--- a/static/app/ui2-chrome.css
+++ b/static/app/ui2-chrome.css
@@ -10,11 +10,34 @@
    that never overlaps the Station canvases — the fixed rail and the
    oversight bar sit outside #app's content box, never over the canvas. */
 
-html.ui-v2 { --ui2-nav-w: 244px; --ui2-ovs-h: 48px; }
+html.ui-v2 {
+  --ui2-nav-w: 244px;
+  --ui2-ovs-h: 48px;
+  /* Device cutout / home-indicator insets. viewport-fit=cover makes these
+     nonzero on notched phones (0 everywhere else); they are composed into
+     every fixed-chrome coordinate below so no control sits under hardware. */
+  --ui2-sa-t: env(safe-area-inset-top, 0px);
+  --ui2-sa-r: env(safe-area-inset-right, 0px);
+  --ui2-sa-b: env(safe-area-inset-bottom, 0px);
+  --ui2-sa-l: env(safe-area-inset-left, 0px);
+  /* Left edge of the content area: rail width + left cutout. */
+  --ui2-nav-edge: calc(var(--ui2-nav-w) + var(--ui2-sa-l));
+  /* Composer geometry. --ui2-composer-h is kept at the bar's REAL rendered
+     height by ui2WireComposerMech (the bar wraps and grows: focus expand,
+     attachments row, the 500-600px wrap band) — the old 92px/64px constants
+     under-reserved whenever it did, letting the bar cover the Files save
+     row and the Live control banner. The fallback approximates the at-rest
+     bar for the pre-boot paint. --ui2-kb-inset lifts the bar above the iOS
+     soft keyboard while composing (0 otherwise). */
+  --ui2-composer-off: 16px;
+  --ui2-composer-h: 62px;
+  --ui2-kb-inset: 0px;
+}
 
 html.ui-v2 #app {
-  padding-left: var(--ui2-nav-w);
-  padding-top: var(--ui2-ovs-h);
+  padding-left: var(--ui2-nav-edge);
+  padding-top: calc(var(--ui2-ovs-h) + var(--ui2-sa-t));
+  padding-right: var(--ui2-sa-r);
 }
 html.ui-v2 .tab-bar { display: none; }
 
@@ -22,7 +45,9 @@ html.ui-v2 .tab-bar { display: none; }
 html.ui-v2 #ui2-nav {
   position: fixed;
   inset: 0 auto 0 0;
-  width: var(--ui2-nav-w);
+  width: var(--ui2-nav-edge);
+  padding-left: var(--ui2-sa-l);
+  padding-bottom: var(--ui2-sa-b);
   z-index: 40;
   display: flex;
   flex-direction: column;
@@ -132,11 +157,11 @@ html.ui-v2 .ui2-identity-sub { font-size: 10.5px; color: var(--text-3); }
 /* ── oversight bar ── */
 html.ui-v2 #ui2-oversight {
   position: fixed;
-  top: 0; left: var(--ui2-nav-w); right: 0;
-  height: var(--ui2-ovs-h);
+  top: 0; left: var(--ui2-nav-edge); right: 0;
+  height: calc(var(--ui2-ovs-h) + var(--ui2-sa-t));
   z-index: 39;
   display: flex; align-items: center; gap: 12px;
-  padding: 0 18px;
+  padding: var(--ui2-sa-t) calc(18px + var(--ui2-sa-r)) 0 18px;
   background: var(--glass);
   -webkit-backdrop-filter: blur(14px);
   backdrop-filter: blur(14px);
@@ -420,14 +445,19 @@ html.ui-v2 .ui2-theme-btn:hover { background: var(--surface-2); color: var(--tex
    the bottom — the design's composer. Same element, same ids, all v1
    listeners intact; phase + stop inside it are hidden because the
    oversight bar already mirrors them. Solid surface, no backdrop-filter:
-   fixed chrome overlaps the Station canvases on the Station tab. */
-html.ui-v2 #app { padding-bottom: 92px; }
+   fixed chrome overlaps the Station canvases on the Station tab.
+   The #app bottom reservation tracks the bar's measured height (see the
+   --ui2-composer-h note at the vars block): panes must never draw under
+   the dock, whatever the dock's current size. */
+html.ui-v2 #app {
+  padding-bottom: calc(var(--ui2-composer-h) + var(--ui2-composer-off) + var(--ui2-sa-b) + 14px);
+}
 html.ui-v2 .global-task-bar {
   position: fixed;
-  left: var(--ui2-nav-w);
-  right: 0;
-  bottom: 16px;
-  width: min(920px, calc(100vw - var(--ui2-nav-w) - 36px));
+  left: var(--ui2-nav-edge);
+  right: var(--ui2-sa-r);
+  bottom: calc(var(--ui2-composer-off) + var(--ui2-sa-b) + var(--ui2-kb-inset));
+  width: min(920px, calc(100vw - var(--ui2-nav-edge) - var(--ui2-sa-r) - 36px));
   margin-inline: auto;
   z-index: 70;
   padding: 9px 11px;
@@ -564,13 +594,15 @@ html.ui-v2 .ui2-nav-bottom { flex-shrink: 0; background: var(--bg); }
    full control set. :focus-within covers typing, target chip, attach and
    Direct once expanded. */
 @media (max-width: 500px) {
+  /* The dock hugs the edge tighter on phones; the #app reservation keeps
+     following the measured bar height (the old fixed 64px was smaller
+     than the bar itself — the root of the covered-controls bug). */
+  html.ui-v2 { --ui2-composer-off: 8px; }
   html.ui-v2 .global-task-bar {
-    bottom: 8px;
-    width: calc(100vw - var(--ui2-nav-w) - 16px);
+    width: calc(100vw - var(--ui2-nav-edge) - var(--ui2-sa-r) - 16px);
     padding: 6px 8px;
     flex-wrap: wrap;
   }
-  html.ui-v2 #app { padding-bottom: 64px; }
   html.ui-v2 .global-task-bar .task-new-session-btn,
   html.ui-v2 .global-task-bar .global-attach-btn,
   html.ui-v2 .global-task-bar .global-direct-toggle {
@@ -622,4 +654,13 @@ html.ui-v2 .ui2-fuel-chip {
   color: var(--green);
   border: 1px solid rgba(var(--green-rgb), .28);
   white-space: nowrap;
+}
+
+/* ── touch behavior ──
+   The viewport meta no longer carries user-scalable=no (pinch-zoom is an
+   accessibility escape hatch and the recovery gesture when a layout goes
+   wrong on a phone). Double-tap-to-zoom on controls is suppressed
+   per-element instead; manipulation still allows pan and pinch. */
+html.ui-v2 :is(button, select, input, textarea, label, .ui2-nav-item, .tab-btn) {
+  touch-action: manipulation;
 }

--- a/static/app/ui2-chrome.js
+++ b/static/app/ui2-chrome.js
@@ -864,6 +864,55 @@ function ui2FuelChipSync() {
     + (best.kind ? ` (${best.kind})` : '') + '. Display only.';
 }
 
+function ui2WireComposerMech() {
+  const bar = document.querySelector('.global-task-bar');
+  if (!bar) return;
+  const root = document.documentElement.style;
+
+  // Reservation: keep --ui2-composer-h at the bar's real border-box height.
+  // The bar wraps and grows (focus expand, the attachments row, the v1
+  // 500-600px wrap band), and the old constant reservation is exactly what
+  // let it cover the Files save row and the Live control banner on phones.
+  const measure = () => {
+    const h = Math.ceil(bar.getBoundingClientRect().height);
+    if (h > 0) root.setProperty('--ui2-composer-h', h + 'px');
+  };
+  if (typeof ResizeObserver === 'function') {
+    new ResizeObserver(measure).observe(bar);
+  } else {
+    bar.addEventListener('focusin', () => requestAnimationFrame(measure));
+    bar.addEventListener('focusout', () => requestAnimationFrame(measure));
+    window.addEventListener('resize', measure);
+  }
+  measure();
+
+  // Soft-keyboard lift: iOS keeps position:fixed anchored to the layout
+  // viewport, so the opened keyboard covers the bar mid-composition. Track
+  // the visual viewport and lift by the overlap — but only while focus is
+  // inside the bar: lifting for other inputs (the Files editor, a settings
+  // field) would cover the very field being edited. Android resizes the
+  // layout viewport under the keyboard instead, so the overlap computes to
+  // ~0 there and this stays inert.
+  const vv = window.visualViewport;
+  if (vv) {
+    let raf = 0;
+    const apply = () => {
+      raf = 0;
+      const composing = bar.contains(document.activeElement);
+      const overlap = window.innerHeight - vv.height - vv.offsetTop;
+      const inset = composing ? Math.max(0, Math.round(overlap)) : 0;
+      root.setProperty('--ui2-kb-inset', inset + 'px');
+    };
+    const schedule = () => { if (!raf) raf = requestAnimationFrame(apply); };
+    vv.addEventListener('resize', schedule);
+    vv.addEventListener('scroll', schedule);
+    bar.addEventListener('focusin', schedule);
+    // The keyboard retracts after focus leaves; measuring in the same frame
+    // reads the pre-retraction viewport.
+    bar.addEventListener('focusout', () => setTimeout(schedule, 80));
+  }
+}
+
 ui2BuildNav();
 {
   // Single-boot: a module script executes at readyState 'interactive', so
@@ -874,6 +923,7 @@ ui2BuildNav();
   const wire = () => {
     ui2WireMirrors();
     ui2WirePalette();
+    ui2WireComposerMech();
     // Fuel chip: transport-status flips repaint it via the existing
     // #sb-dashboard-transport mirror lane; the interval keeps the lease
     // countdown honest between flips.

--- a/static/app/ui2-voice.css
+++ b/static/app/ui2-voice.css
@@ -31,8 +31,8 @@ html.ui-v2 .ui2-micbtn[data-state="error"] .ui2-micbtn-dot { background: var(--r
 
 html.ui-v2 #ui2-voice-panel {
   position: fixed;
-  top: calc(var(--ui2-ovs-h) + 8px);
-  right: 18px;                     /* shares the oversight bar's content edge */
+  top: calc(var(--ui2-ovs-h) + var(--ui2-sa-t) + 8px);
+  right: calc(18px + var(--ui2-sa-r)); /* shares the oversight bar's content edge */
   width: min(320px, calc(100vw - 36px));
   z-index: 90;                     /* above content + composer (70), below ⌘K (100) */
   background: var(--surface);


### PR DESCRIPTION
On phones the fixed global task bar covered per-tab bottom UI — the Files save row and the Live control banner sat under it, and the iOS keyboard covered the bar itself while composing. Root cause: the #app bottom reservation was a constant (92px desktop, 64px ≤500px) while the bar wraps and grows — measured 92px tall at rest on a 390px viewport (the v1 ≤600px wrap rules stack under v2), 186px while composing.

- **Measured reservation**: `ResizeObserver` keeps `--ui2-composer-h` at the bar's real border-box height (`ui2WireComposerMech` in ui2-chrome.js); the `#app` bottom padding composes from it. Invariant: panes never draw under the dock, whatever the dock's current size.
- **Soft-keyboard lift**: `visualViewport` drives `--ui2-kb-inset`, applied only while focus is inside the bar — lifting for other inputs (Files editor) would cover the field being edited. Android resizes the layout viewport instead, so the overlap computes to ~0 and this stays inert there.
- **Safe areas**: `viewport-fit=cover` + `env(safe-area-inset-*)` composed into every fixed-chrome coordinate (nav rail, oversight bar, dock, voice panel) — nothing sits under notches or the home indicator; all values are 0 on desktop so nothing moves there.
- **Zoom**: `user-scalable=no` dropped (pinch-zoom is the accessibility escape hatch and the recovery gesture for any broken mobile layout); double-tap zoom suppressed per-element via `touch-action: manipulation`.

Verified with a CDP geometry probe against a live keyless daemon: 12/12 assertions across 390×844 (rest + grown composer, Files save-row clearance), the 560px wrap band, and 1440×900 desktop no-regression (reservation stays in the old 92px band). Follow-up program (composer pill⇄expanded states, conversation peek, target hot-swap) builds on this and lands separately.