### PR TITLE
dashboard: composer program — pill/expanded states, conversation peek, target hot-swap

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -28045,7 +28045,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '8ba99e0073c1bc32';
+const INTENDANT_APP_BUILD = '22fcab42c072bcd5';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -102489,6 +102489,14 @@ function handleDisplayRequestResolved(d) {
       // refocus) is not an entry — reopening there would undo an Esc/×
       // dismissal the user just made.
       if (e.relatedTarget instanceof Node && bar.contains(e.relatedTarget)) return;
+      // Focus landing on the target-switch chrome is retargeting intent,
+      // not composition — opening the peek under that popover just stacks
+      // two overlays (and made Esc close the hidden one first).
+      const tsw = document.getElementById('ui2-target-switch');
+      if (e.target instanceof Node && (
+        (tsw && tsw.contains(e.target)) ||
+        (e.target.id === 'task-target-switch-btn')
+      )) return;
       peekDismissed = false;
       peekOpen();
     });
@@ -102499,6 +102507,11 @@ function handleDisplayRequestResolved(d) {
     // closes the peek, the next one reaches the dock.
     window.addEventListener('keydown', (e) => {
       if (e.key !== 'Escape' || !peekIsOpen()) return;
+      // Onion ordering: the target-switch popover is the innermost open
+      // surface — its own Esc handling closes it; consuming here would
+      // close the peek hidden BEHIND the popover instead.
+      const tsw = document.getElementById('ui2-target-switch');
+      if (tsw && !tsw.hidden) return;
       if (e.target instanceof Node && peekBarEl.contains(e.target)) {
         e.preventDefault();
         e.stopImmediatePropagation();

--- a/static/app.html
+++ b/static/app.html
@@ -12727,6 +12727,66 @@ html.ui-v2 .global-task-bar:focus-within {
   border-color: rgba(var(--iris-rgb), .45);
   box-shadow: 0 0 0 3px rgba(var(--iris-rgb), .22), var(--shadow-card);
 }
+
+/* ── composer states: expanded ⇄ pill ─────────────────────────────────
+   ui2WireComposerState stamps data-composer-state on <html>: "expanded"
+   is the full dock; "pill" collapses the same fixed element into a small
+   centered lozenge so immersive surfaces (the per-tab defaults: Live,
+   Station, Terminal, Files) keep the bottom of the viewport. The
+   reservation invariant is untouched — --ui2-composer-h simply measures
+   the pill. The child hide is !important on purpose: chip/attachment
+   children carry inline display toggles and focus-within reveals, and
+   the pill state must override every one of them. */
+html.ui-v2 .ui2-composer-pill { display: none; }
+html.ui-v2 .ui2-composer-collapse {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 26px; height: 26px; flex-shrink: 0; padding: 0;
+  border: 0; border-radius: var(--r-ctl);
+  background: transparent; color: var(--text-3); cursor: pointer;
+}
+html.ui-v2 .ui2-composer-collapse:hover { background: var(--hover-wash); color: var(--text); }
+html.ui-v2 .ui2-composer-collapse svg { transform: rotate(90deg); } /* chev points down */
+html.ui-v2[data-composer-state="pill"] .global-task-bar {
+  width: auto;
+  min-width: 0;
+  max-width: min(340px, calc(100vw - var(--ui2-nav-edge) - var(--ui2-sa-r) - 24px));
+  padding: 8px 16px;
+  border-radius: var(--r-pill);
+  cursor: pointer;
+  justify-content: center;
+}
+html.ui-v2[data-composer-state="pill"] .global-task-bar:hover {
+  background: var(--surface-2);
+  border-color: var(--line-2);
+}
+html.ui-v2[data-composer-state="pill"] .global-task-bar > *:not(.ui2-composer-pill) { display: none !important; }
+html.ui-v2[data-composer-state="pill"] .ui2-composer-pill {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 12.5px; font-weight: 700; color: var(--text-2);
+  white-space: nowrap;
+  pointer-events: none; /* the whole lozenge is the click target */
+}
+html.ui-v2 .ui2-composer-pill-dot {
+  width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+  background: var(--text-3);
+}
+html.ui-v2 .ui2-composer-pill[data-phase="running"] .ui2-composer-pill-dot,
+html.ui-v2 .ui2-composer-pill[data-phase="thinking"] .ui2-composer-pill-dot {
+  background: var(--iris);
+  animation: ui2-pulse 1.3s infinite;
+}
+html.ui-v2 .ui2-composer-pill[data-phase="waiting"] .ui2-composer-pill-dot { background: var(--amber); }
+html.ui-v2 .ui2-composer-pill[data-phase="done"] .ui2-composer-pill-dot { background: var(--green); }
+html.ui-v2 .ui2-composer-pill-draft {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--amber);
+  display: none;
+}
+html.ui-v2 .ui2-composer-pill.has-draft .ui2-composer-pill-draft { display: inline-block; }
+@media (prefers-reduced-motion: reduce) {
+  html.ui-v2 .ui2-composer-pill-dot { animation: none !important; }
+}
+
 /* phase + stop live in the oversight bar under v2 */
 html.ui-v2 .global-task-bar .phase-banner { display: none; }
 html.ui-v2 .global-task-bar .stop-btn { display: none; }
@@ -12847,29 +12907,39 @@ html.ui-v2 .ui2-nav-bottom { flex-shrink: 0; background: var(--bg); }
    ~40% of the viewport; focusing it (or targeting a session) expands the
    full control set. :focus-within covers typing, target chip, attach and
    Direct once expanded. */
-@media (max-width: 500px) {
+@media (max-width: 600px) {
   /* The dock hugs the edge tighter on phones; the #app reservation keeps
      following the measured bar height (the old fixed 64px was smaller
-     than the bar itself — the root of the covered-controls bug). */
+     than the bar itself — the root of the covered-controls bug). The
+     breakpoint is 600, not 500: v1's ≤600 wrap rules force the input
+     onto its own row with Send alone under it — the order/flex resets
+     below re-join them into one compact resting row across the whole
+     band, with the secondary controls appearing on focus. */
   html.ui-v2 { --ui2-composer-off: 8px; }
   html.ui-v2 .global-task-bar {
     width: calc(100vw - var(--ui2-nav-edge) - var(--ui2-sa-r) - 16px);
     padding: 6px 8px;
     flex-wrap: wrap;
   }
+  html.ui-v2 .global-task-bar .global-task-input {
+    order: 0;
+    flex: 1 1 auto;
+    width: auto;
+    font-size: 16px; /* under 16px iOS Safari zooms the page on focus */
+    max-height: 2.4em;
+  }
+  html.ui-v2 .global-task-bar .global-send-btn { order: 0; flex: 0 0 auto; }
   html.ui-v2 .global-task-bar .task-new-session-btn,
   html.ui-v2 .global-task-bar .global-attach-btn,
-  html.ui-v2 .global-task-bar .global-direct-toggle {
+  html.ui-v2 .global-task-bar .global-direct-toggle,
+  html.ui-v2 .global-task-bar .ui2-composer-collapse {
     display: none;
   }
   html.ui-v2 .global-task-bar:focus-within .task-new-session-btn,
   html.ui-v2 .global-task-bar:focus-within .global-attach-btn,
-  html.ui-v2 .global-task-bar:focus-within .global-direct-toggle {
+  html.ui-v2 .global-task-bar:focus-within .global-direct-toggle,
+  html.ui-v2 .global-task-bar:focus-within .ui2-composer-collapse {
     display: inline-flex;
-  }
-  html.ui-v2 .global-task-bar .global-task-input {
-    font-size: 16px; /* under 16px iOS Safari zooms the page on focus */
-    max-height: 2.4em;
   }
   html.ui-v2 .global-task-bar:focus-within .global-task-input {
     max-height: 6em;
@@ -26794,6 +26864,125 @@ function ui2WireComposerMech() {
   }
 }
 
+const UI2_COMPOSER_PILL_DEFAULT_TABS = new Set(['displays', 'station', 'terminal', 'files']);
+
+function ui2WireComposerState() {
+  const bar = document.querySelector('.global-task-bar');
+  if (!bar) return;
+  const rootEl = document.documentElement;
+  const input = document.getElementById('activity-task-input');
+
+  const pill = document.createElement('span');
+  pill.className = 'ui2-composer-pill';
+  const dot = document.createElement('span');
+  dot.className = 'ui2-composer-pill-dot';
+  const pillLabel = document.createElement('span');
+  pillLabel.textContent = 'Ask Intendant';
+  const draftDot = document.createElement('span');
+  draftDot.className = 'ui2-composer-pill-draft';
+  draftDot.title = 'Unsent draft';
+  pill.append(dot, pillLabel, draftDot);
+  bar.appendChild(pill);
+
+  const collapse = document.createElement('button');
+  collapse.type = 'button';
+  collapse.className = 'ui2-composer-collapse';
+  collapse.title = 'Collapse composer (Esc)';
+  collapse.setAttribute('aria-label', 'Collapse composer');
+  collapse.innerHTML = ui2Icon('chev', 14);
+  bar.insertBefore(collapse, document.getElementById('phase-banner'));
+
+  const activeTabId = () => {
+    const pane = document.querySelector('.tab-pane.active');
+    return pane ? pane.id.replace(/^tab-/, '') : 'activity';
+  };
+  const stateKey = (tab) => 'intendant.ui2.composerState.' + tab;
+  const stateFor = (tab) => {
+    try {
+      const o = localStorage.getItem(stateKey(tab));
+      if (o === 'pill' || o === 'expanded') return o;
+    } catch (_) { /* private mode: defaults only */ }
+    return UI2_COMPOSER_PILL_DEFAULT_TABS.has(tab) ? 'pill' : 'expanded';
+  };
+  const syncDraft = () => {
+    pill.classList.toggle('has-draft', !!(input && input.value.trim()));
+  };
+
+  let current = '';
+  const setState = (next, remember = false) => {
+    if (next !== 'pill' && next !== 'expanded') return;
+    if (remember) {
+      try { localStorage.setItem(stateKey(activeTabId()), next); } catch (_) { /* private mode */ }
+    }
+    if (current === next) return;
+    current = next;
+    rootEl.dataset.composerState = next;
+    if (next === 'pill') {
+      // Children go display:none — never leave focus on a hidden control
+      // (it would also pin the keyboard lift).
+      if (bar.contains(document.activeElement)) document.activeElement.blur();
+      bar.setAttribute('role', 'button');
+      bar.setAttribute('tabindex', '0');
+      bar.setAttribute('aria-label', 'Expand composer');
+      syncDraft();
+    } else {
+      bar.removeAttribute('role');
+      bar.removeAttribute('tabindex');
+      bar.removeAttribute('aria-label');
+    }
+    window.dispatchEvent(new CustomEvent('ui2:composer-state', { detail: { state: next } }));
+  };
+
+  const expandAndFocus = (viaTouch) => {
+    setState('expanded', true);
+    // Touch keeps the keyboard down until the user taps the input.
+    if (!viaTouch && input) input.focus();
+  };
+
+  // Programmatic seam for palette/shortcut callers: expand before focusing
+  // (a pilled dock's children are display:none and cannot receive focus).
+  window.ui2ComposerExpand = () => setState('expanded');
+
+  bar.addEventListener('click', (e) => {
+    if (current !== 'pill') return;
+    expandAndFocus(e.pointerType === 'touch');
+  });
+  collapse.addEventListener('click', (e) => {
+    e.stopPropagation();
+    setState('pill', true);
+  });
+  bar.addEventListener('keydown', (e) => {
+    if (current === 'pill' && (e.key === 'Enter' || e.key === ' ')) {
+      e.preventDefault();
+      expandAndFocus(false);
+      return;
+    }
+    // Bubble phase: the peek's capture-phase Esc (close-peek) stops
+    // propagation while the peek is open, so this fires only with no peek
+    // up. Esc is get-out-of-my-way, not a preference — no remember.
+    if (e.key === 'Escape' && current === 'expanded') setState('pill');
+  });
+  if (input) input.addEventListener('input', syncDraft);
+
+  ui2Mirror('phase-banner', (banner) => {
+    pill.dataset.phase = ui2PhaseCategory(banner.className);
+  });
+
+  const applyForTab = (tab) => setState(stateFor(String(tab || '')));
+  if (typeof switchTab === 'function') {
+    // One shared module scope: rebinding the declaration retargets every
+    // caller (nav, palette, router deep links), so the per-tab state rides
+    // every navigation path.
+    const origSwitchTab = switchTab;
+    switchTab = function (tabId) {
+      const r = origSwitchTab.apply(this, arguments);
+      if (r !== false) applyForTab(tabId);
+      return r;
+    };
+  }
+  applyForTab(activeTabId());
+}
+
 ui2BuildNav();
 {
   // Single-boot: a module script executes at readyState 'interactive', so
@@ -26805,6 +26994,7 @@ ui2BuildNav();
     ui2WireMirrors();
     ui2WirePalette();
     ui2WireComposerMech();
+    ui2WireComposerState();
     // Fuel chip: transport-status flips repaint it via the existing
     // #sb-dashboard-transport mirror lane; the interval keeps the lease
     // countdown honest between flips.
@@ -27401,7 +27591,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '9b5f86e4e3030e63';
+const INTENDANT_APP_BUILD = '51f2efdb2b96c3c9';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {

--- a/static/app.html
+++ b/static/app.html
@@ -28045,7 +28045,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '22fcab42c072bcd5';
+const INTENDANT_APP_BUILD = 'eecaf6cd30987a85';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -102380,6 +102380,9 @@ function handleDisplayRequestResolved(d) {
     // A target materializing mid-turn is the first-message case: the send
     // happened before any session existed, so the phase edge fired with
     // nothing to show — open now that there is a transcript to watch.
+    // Same replay guard as the phase edge: rebinds driven by bootstrap
+    // replay are history, not a turn in flight.
+    if (typeof processingLogReplay !== 'undefined' && processingLogReplay) return;
     if (PEEK_WORKING_CATS.has(peekLastPhaseCat) && !peekDismissed && !peekComposerPill()) {
       peekOpen();
     }
@@ -102401,6 +102404,10 @@ function handleDisplayRequestResolved(d) {
       return;
     }
     if (wasWorking || peekDismissed || peekIsOpen() || peekComposerPill()) return;
+    // Bootstrap replay re-drives historical phase edges through the
+    // mirror — auto-opening on those would pop the peek on every page
+    // load of a dashboard with any past task.
+    if (typeof processingLogReplay !== 'undefined' && processingLogReplay) return;
     peekOpen();
   }
 
@@ -102475,6 +102482,12 @@ function handleDisplayRequestResolved(d) {
     });
   }
 
+  // Boot autofocus (and any other programmatic focus before the user has
+  // touched the page) must not open the peek — a sheet popping over the
+  // content on every load of a dashboard with history is a surprise, not
+  // an affordance. Focus counts as intent only after a real gesture.
+  let peekSawUserGesture = false;
+
   const peekWire = () => {
     const root = document.getElementById('ui2-composer-peek');
     const bar = root ? root.closest('.global-task-bar') : null;
@@ -102483,7 +102496,11 @@ function handleDisplayRequestResolved(d) {
     peekBarEl = bar;
     peekBuild(root);
 
+    document.addEventListener('pointerdown', () => { peekSawUserGesture = true; }, { capture: true, passive: true });
+    document.addEventListener('keydown', () => { peekSawUserGesture = true; }, { capture: true });
+
     bar.addEventListener('focusin', (e) => {
+      if (!peekSawUserGesture) return;
       if (peekIsOpen() || peekComposerPill()) return;
       // Focus moving WITHIN the dock (input → Send, the close button's
       // refocus) is not an entry — reopening there would undo an Esc/×

--- a/static/app.html
+++ b/static/app.html
@@ -22745,19 +22745,201 @@ html.ui-v2 .ui2-appearance-note {
    cross-surface sweep). */
 html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
 /* ── static/app/ui2-composer-peek.css ── */
-/* ── composer conversation peek (skeleton contract) ─────────────────────
-   Filled by the peek track. The container floats ABOVE the dock card:
-   the bar is position:fixed, so this absolute child anchors to the card
-   and never contributes to the bar's measured height — the #app bottom
-   reservation follows --ui2-composer-h (the bar box alone), and the peek
-   overlays content like a transient sheet instead of reflowing it.
-   Everything visual beyond this anchoring belongs to the peek fragment. */
+/* ── composer conversation peek ─────────────────────────────────────────
+   The container floats ABOVE the dock card: the bar is position:fixed, so
+   this absolute child anchors to the card and never contributes to the
+   bar's measured height — the #app bottom reservation follows
+   --ui2-composer-h (the bar box alone), and the peek overlays content
+   like a transient sheet instead of reflowing it. It rides the keyboard
+   lift for free (the bar's bottom carries --ui2-kb-inset).
+   Solid surface, no backdrop-filter: fixed chrome can overlap the Station
+   canvases (same rule as the dock card). */
 html.ui-v2 .ui2-composer-peek {
   position: absolute;
   bottom: 100%;
   left: 0;
   right: 0;
   margin-bottom: 10px;
+  display: flex;
+  flex-direction: column;
+  max-height: min(42vh, 380px);
+  max-height: min(42dvh, 380px);
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--surface);
+  box-shadow: var(--shadow-card);
+}
+/* the display:flex above outweighs the UA [hidden] rule — restate it */
+html.ui-v2 .ui2-composer-peek[hidden] { display: none; }
+@keyframes ui2-peek-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: none; }
+}
+html.ui-v2 .ui2-composer-peek:not([hidden]) {
+  animation: ui2-peek-in var(--t-slow) ease;
+}
+
+/* — header: target identity, live phase, jump-to-Activity, close — */
+html.ui-v2 .ui2-peek-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  min-width: 0;
+  padding: 8px 9px 7px 13px;
+  border-bottom: 1px solid var(--line);
+  cursor: pointer;
+}
+html.ui-v2 .ui2-peek-header:hover { background: var(--hover-wash); }
+html.ui-v2 .ui2-peek-target {
+  flex-shrink: 1;
+  min-width: 0;
+  max-width: 220px;
+  font-size: 11px;
+  font-weight: 650;
+}
+html.ui-v2 .ui2-peek-phase {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  font-size: 11px;
+  color: var(--text-3);
+}
+html.ui-v2 .ui2-peek-phase-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--neutral-dot);
+}
+html.ui-v2 .ui2-peek-phase-dot[data-cat="thinking"],
+html.ui-v2 .ui2-peek-phase-dot[data-cat="running"] {
+  background: var(--iris);
+  animation: ui2-pulse 1.3s infinite;
+}
+html.ui-v2 .ui2-peek-phase-dot[data-cat="waiting"] {
+  background: var(--amber);
+  animation: ui2-pulse 2s infinite;
+}
+html.ui-v2 .ui2-peek-phase-dot[data-cat="done"] { background: var(--green); }
+html.ui-v2 .ui2-peek-phase-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+html.ui-v2 .ui2-peek-open {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: auto;
+  flex-shrink: 0;
+  padding: 4px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  background: transparent;
+  color: var(--text-3);
+  font-family: var(--sans);
+  font-size: 11px;
+  font-weight: 650;
+  cursor: pointer;
+}
+html.ui-v2 .ui2-peek-open:hover { color: var(--text); background: var(--surface-2); }
+html.ui-v2 .ui2-peek-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--text-3);
+  font-family: var(--sans);
+  cursor: pointer;
+}
+html.ui-v2 .ui2-peek-close:hover { color: var(--text); background: var(--surface-2); }
+
+/* — transcript tail — */
+html.ui-v2 .ui2-peek-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  /* scroll pinning is managed manually, like the other log scrollers */
+  overflow-anchor: none;
+  overscroll-behavior: contain;
+  padding: 6px 12px 9px;
+}
+html.ui-v2 .ui2-peek-empty {
+  padding: 20px 12px 22px;
+  color: var(--text-3);
+  font-size: 12px;
+  text-align: center;
+}
+
+/* — compact entry density —
+   Clones keep the Activity timeline grammar (ui2-activity.css styles
+   .log-entry globally); the peek drops the ts gutter and the host/session
+   badges (identity lives in the peek header) and tightens type. Track
+   list mirrors the base 7-column template with the hidden columns zeroed
+   so the explicit grid-column placements keep landing. */
+html.ui-v2 .ui2-composer-peek .log-entry {
+  grid-template-columns: 0 16px 0 0 max-content 0 minmax(0, 1fr);
+  padding: 3px 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+/* 12.5px × 1.5 line box ≈ 19px; the 6px dot centers at (19−6)/2 ≈ 6px */
+html.ui-v2 .ui2-composer-peek .log-entry .log-icon { margin-top: 6px; }
+html.ui-v2 .ui2-composer-peek .log-entry .log-ts,
+html.ui-v2 .ui2-composer-peek .log-entry .log-host,
+html.ui-v2 .ui2-composer-peek .log-entry .log-session,
+html.ui-v2 .ui2-composer-peek .log-entry .log-anchor-btn,
+html.ui-v2 .ui2-composer-peek .log-entry .log-copy-entry,
+html.ui-v2 .ui2-composer-peek .log-entry .log-edit-message,
+html.ui-v2 .ui2-composer-peek .log-entry .collapse-toggle {
+  display: none;
+}
+html.ui-v2 .ui2-composer-peek .log-entry pre {
+  font-size: 11.5px;
+  padding: 8px 10px;
+}
+
+/* long payloads clamp; the fade appears only on entries that really clip
+   (JS tags .ui2-peek-clamped — CSS cannot see overflow). The blanket
+   content:none also retires v1's side fade on collapsible entries, whose
+   1.5em clamp the max-height below supersedes inside the peek. */
+html.ui-v2 .ui2-composer-peek .log-entry .log-content {
+  position: relative;
+  max-height: 8.5em;
+  overflow: hidden;
+}
+html.ui-v2 .ui2-composer-peek .log-entry:not(.ui2-peek-clamped) .log-content::after { content: none; }
+html.ui-v2 .ui2-composer-peek .log-entry.ui2-peek-clamped .log-content::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: auto;
+  width: auto;
+  height: 1.8em;
+  background: linear-gradient(to bottom, transparent, var(--surface));
+  pointer-events: none;
+}
+html.ui-v2 .ui2-composer-peek .diff-log-entry .diff-log-body {
+  max-height: 8.5em;
+  overflow: hidden;
+}
+
+/* — phones: keep the header one quiet row — */
+@media (max-width: 500px) {
+  html.ui-v2 .ui2-peek-open .ui2-peek-open-label { display: none; }
+  html.ui-v2 .ui2-peek-open { padding: 4px 8px; }
+  html.ui-v2 .ui2-peek-header { padding: 7px 8px 6px 11px; }
 }
 /* ── static/app/ui2-target-switch.css ── */
 /* ── composer target hot-swap (skeleton contract) ───────────────────────
@@ -27634,7 +27816,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '0af4f095c26f3e7e';
+const INTENDANT_APP_BUILD = '8ddd972d7ad6ff4b';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -101703,13 +101885,436 @@ function handleDisplayRequestResolved(d) {
   }
 }
 /* ── static/app/ui2-composer-peek.js ── */
-// ── composer conversation peek (seam stub — filled by the peek track) ──
-// Contract: render the prompt-target session's transcript tail into
-// #ui2-composer-peek (mounted as the dock's first child; skeleton
-// anchoring in ui2-composer-peek.css), live-following the same entries
-// the session window shows, with tap-through to the Activity window.
+// ── composer conversation peek ─────────────────────────────────────────
+// A transient sheet floating above the dock: the prompt-target session's
+// transcript tail, live, with tap-through to the full Activity view. The
+// peek is a read-only mirror — entries are clones of the target window's
+// log (the appendLogEntryToSessionWindow precedent: cloneNode + strip
+// ids), so it never mutates session state; interactive affordances that
+// need the live wiring (collapse, copy, retry) are hidden by the peek
+// stylesheet in favor of "Open in Activity".
 // Boot follows the ui2-chrome single-boot idiom; every entry point is a
 // no-op when the mount is missing so a stub build stays inert.
+{
+  const PEEK_TAIL_CAP = 12;
+  const PEEK_RENDER_THROTTLE_MS = 120;
+  // Chrome's phase categories that mean "the agent is answering" — the
+  // auto-open signal. `waiting` is excluded: approvals/questions already
+  // have their own attention surfaces.
+  const PEEK_WORKING_CATS = new Set(['thinking', 'running']);
+
+  let peekBarEl = null;
+  let peekRoot = null;
+  let peekList = null;
+  let peekBadge = null;
+  let peekPhaseDot = null;
+  let peekPhaseText = null;
+
+  let peekBoundSid = '';
+  let peekBoundLog = null;
+  let peekRendered = []; // [{ source, clone }] in list order
+  let peekFollow = true;
+  // Explicit close suppresses auto-open until the working streak ends or
+  // the target changes — otherwise the next phase mutation would fight
+  // the user's dismissal.
+  let peekDismissed = false;
+  let peekLastTarget = '';
+  let peekLastPhaseCat = null;
+  let peekFlushTimer = 0;
+  let peekPendingStructural = false;
+  const peekPendingDirty = new Set();
+
+  function peekIsOpen() {
+    return !!peekRoot && !peekRoot.hidden;
+  }
+
+  function peekComposerPill() {
+    return document.documentElement.dataset.composerState === 'pill';
+  }
+
+  function peekTargetSid() {
+    return typeof resolvePromptTargetSessionId === 'function'
+      ? (resolvePromptTargetSessionId() || '') : '';
+  }
+
+  function peekTargetWindow(sid) {
+    return (sid && typeof sessionWindows !== 'undefined')
+      ? (sessionWindows.get(sid) || null) : null;
+  }
+
+  function peekCloneEntry(source) {
+    const clone = source.cloneNode(true);
+    clone.removeAttribute('id');
+    clone.querySelectorAll('[id]').forEach(el => el.removeAttribute('id'));
+    return clone;
+  }
+
+  function peekTailSources() {
+    if (!peekBoundLog) return [];
+    const out = [];
+    for (let node = peekBoundLog.lastElementChild; node && out.length < PEEK_TAIL_CAP; node = node.previousElementSibling) {
+      if (node.classList.contains('session-window-empty')) continue;
+      out.push(node);
+    }
+    return out.reverse();
+  }
+
+  function peekEmptyText() {
+    if (!peekBoundLog) return 'No transcript yet — send a message below.';
+    const ph = peekBoundLog.querySelector('.session-window-empty');
+    if (ph && ph.classList.contains('session-window-empty-loading')) return 'Loading transcript…';
+    if (ph && ph.classList.contains('session-window-empty-error')) return 'Transcript failed to load — open Activity to retry.';
+    return 'No output yet';
+  }
+
+  // CSS cannot see overflow: entries whose body actually clips get the
+  // fade tag; short ones keep their last line un-washed.
+  function peekTagClamped(clone) {
+    const content = clone.querySelector('.log-content');
+    if (content && content.scrollHeight > content.clientHeight + 1) {
+      clone.classList.add('ui2-peek-clamped');
+    }
+  }
+
+  function peekRenderTail() {
+    if (!peekList || !peekIsOpen()) return;
+    const sources = peekTailSources();
+    if (sources.length === 0) {
+      peekRendered = [];
+      peekPendingDirty.clear();
+      const empty = document.createElement('div');
+      empty.className = 'ui2-peek-empty';
+      empty.textContent = peekEmptyText();
+      peekList.replaceChildren(empty);
+      return;
+    }
+    const prev = new Map(peekRendered.map(r => [r.source, r]));
+    const next = [];
+    const fresh = [];
+    for (const source of sources) {
+      const kept = prev.get(source);
+      if (kept && !peekPendingDirty.has(source)) {
+        next.push(kept);
+        continue;
+      }
+      const clone = peekCloneEntry(source);
+      next.push({ source, clone });
+      fresh.push(clone);
+    }
+    peekRendered = next;
+    // Surgical reconcile instead of replaceChildren: kept nodes never
+    // leave the DOM, so the aria-live list announces genuinely new
+    // entries instead of re-reading the whole tail on every append.
+    const keep = new Set(next.map(r => r.clone));
+    for (let child = peekList.firstElementChild; child;) {
+      const drop = child;
+      child = child.nextElementSibling;
+      if (!keep.has(drop)) drop.remove();
+    }
+    let cursor = peekList.firstElementChild;
+    for (const r of next) {
+      if (r.clone === cursor) cursor = cursor.nextElementSibling;
+      else peekList.insertBefore(r.clone, cursor);
+    }
+    for (const clone of fresh) peekTagClamped(clone);
+    peekPendingDirty.clear();
+    if (peekFollow) peekList.scrollTop = peekList.scrollHeight;
+  }
+
+  function peekFlush() {
+    peekFlushTimer = 0;
+    if (!peekIsOpen()) {
+      peekPendingStructural = false;
+      peekPendingDirty.clear();
+      return;
+    }
+    if (peekPendingStructural) {
+      peekPendingStructural = false;
+      peekRenderTail();
+      return;
+    }
+    if (peekPendingDirty.size === 0) return;
+    let touched = false;
+    for (const r of peekRendered) {
+      if (!peekPendingDirty.has(r.source)) continue;
+      const clone = peekCloneEntry(r.source);
+      r.clone.replaceWith(clone);
+      r.clone = clone;
+      peekTagClamped(clone);
+      touched = true;
+    }
+    peekPendingDirty.clear();
+    if (touched && peekFollow) peekList.scrollTop = peekList.scrollHeight;
+  }
+
+  function peekSchedule() {
+    if (peekFlushTimer || !peekIsOpen()) return;
+    peekFlushTimer = setTimeout(peekFlush, PEEK_RENDER_THROTTLE_MS);
+  }
+
+  // Command-output groups and edit/superseded markers mutate entries in
+  // place (no childList change on the log), so the observer watches the
+  // subtree and patches just the touched entries; only additions/removals
+  // on the log itself re-render the tail.
+  const peekLogObserver = new MutationObserver(records => {
+    for (const record of records) {
+      if (record.target === peekBoundLog) {
+        if (record.type === 'childList') peekPendingStructural = true;
+        continue;
+      }
+      let node = record.target;
+      while (node && node.parentNode !== peekBoundLog) node = node.parentNode;
+      if (node) peekPendingDirty.add(node);
+    }
+    if (peekPendingStructural || peekPendingDirty.size) peekSchedule();
+  });
+
+  function peekBind(sid) {
+    if (peekBadge) {
+      peekBadge.hidden = !sid;
+      if (typeof renderSessionIdentity === 'function') {
+        renderSessionIdentity(peekBadge, sid, { order: 'name-id', titlePrefix: 'Prompt target' });
+      }
+      if (typeof applySessionBadgeStyle === 'function') applySessionBadgeStyle(peekBadge, sid);
+    }
+    const win = peekTargetWindow(sid);
+    const log = win ? win.log : null;
+    if (sid === peekBoundSid && log === peekBoundLog) return;
+    peekLogObserver.disconnect();
+    peekBoundSid = sid;
+    peekBoundLog = log;
+    peekRendered = [];
+    peekPendingDirty.clear();
+    peekPendingStructural = false;
+    if (peekBoundLog) {
+      peekLogObserver.observe(peekBoundLog, {
+        childList: true, subtree: true, characterData: true, attributes: true,
+      });
+      if (typeof hydrateSessionWindowIfEmpty === 'function') {
+        Promise.resolve(hydrateSessionWindowIfEmpty(sid)).catch(() => {}).finally(() => {
+          if (peekBoundSid === sid) peekRenderTail();
+        });
+      }
+    }
+    peekRenderTail();
+  }
+
+  function peekOpen() {
+    if (!peekRoot || peekIsOpen() || peekComposerPill()) return;
+    const sid = peekTargetSid();
+    if (!sid) return;
+    peekFollow = true;
+    peekRoot.hidden = false;
+    peekBind(sid);
+    peekRenderTail();
+  }
+
+  function peekClose(dismissed) {
+    if (!peekRoot || peekRoot.hidden) return;
+    peekRoot.hidden = true;
+    if (dismissed) peekDismissed = true;
+    peekLogObserver.disconnect();
+    peekBoundSid = '';
+    peekBoundLog = null;
+    peekRendered = [];
+    peekPendingDirty.clear();
+    peekPendingStructural = false;
+    if (peekFlushTimer) {
+      clearTimeout(peekFlushTimer);
+      peekFlushTimer = 0;
+    }
+    if (peekList) peekList.replaceChildren();
+  }
+
+  function peekOpenInActivity() {
+    peekClose(false);
+    if (typeof routeTo === 'function') routeTo('activity', 'log');
+    if (typeof window.focusForegroundSessionWindow === 'function') {
+      window.focusForegroundSessionWindow();
+    }
+  }
+
+  function peekOnTargetChip() {
+    const sid = peekTargetSid();
+    if (sid !== peekLastTarget) {
+      peekLastTarget = sid;
+      peekDismissed = false;
+    }
+    if (!sid) {
+      peekClose(false);
+      return;
+    }
+    if (peekIsOpen()) {
+      peekBind(sid);
+      return;
+    }
+    // A target materializing mid-turn is the first-message case: the send
+    // happened before any session existed, so the phase edge fired with
+    // nothing to show — open now that there is a transcript to watch.
+    if (PEEK_WORKING_CATS.has(peekLastPhaseCat) && !peekDismissed && !peekComposerPill()) {
+      peekOpen();
+    }
+  }
+
+  function peekOnPhase(banner) {
+    const cat = typeof ui2PhaseCategory === 'function'
+      ? ui2PhaseCategory(banner.className) : 'idle';
+    const label = document.getElementById('phase-text');
+    if (peekPhaseDot) peekPhaseDot.dataset.cat = cat;
+    if (peekPhaseText) {
+      peekPhaseText.textContent = ((label && label.textContent) || 'Idle').trim() || 'Idle';
+    }
+    const wasWorking = PEEK_WORKING_CATS.has(peekLastPhaseCat);
+    const isWorking = PEEK_WORKING_CATS.has(cat);
+    peekLastPhaseCat = cat;
+    if (!isWorking) {
+      if (wasWorking) peekDismissed = false;
+      return;
+    }
+    if (wasWorking || peekDismissed || peekIsOpen() || peekComposerPill()) return;
+    peekOpen();
+  }
+
+  function peekBuild(root) {
+    const icon = (name, size) => (typeof ui2Icon === 'function' ? ui2Icon(name, size) : '');
+    root.setAttribute('role', 'region');
+    root.setAttribute('aria-label', 'Conversation peek');
+
+    const header = document.createElement('div');
+    header.className = 'ui2-peek-header';
+    header.title = 'Open the full transcript in Activity';
+
+    peekBadge = document.createElement('span');
+    peekBadge.className = 'ui2-peek-target task-target-session-badge';
+    peekBadge.hidden = true;
+
+    const phase = document.createElement('span');
+    phase.className = 'ui2-peek-phase';
+    peekPhaseDot = document.createElement('span');
+    peekPhaseDot.className = 'ui2-peek-phase-dot';
+    peekPhaseDot.dataset.cat = 'idle';
+    peekPhaseText = document.createElement('span');
+    peekPhaseText.className = 'ui2-peek-phase-text';
+    peekPhaseText.textContent = 'Idle';
+    phase.appendChild(peekPhaseDot);
+    phase.appendChild(peekPhaseText);
+
+    const openBtn = document.createElement('button');
+    openBtn.type = 'button';
+    openBtn.className = 'ui2-peek-open';
+    openBtn.title = 'Open the full transcript in Activity';
+    openBtn.setAttribute('aria-label', 'Open in Activity');
+    openBtn.innerHTML = icon('external', 12) + '<span class="ui2-peek-open-label">Open in Activity</span>';
+
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'ui2-peek-close';
+    closeBtn.title = 'Close conversation peek';
+    closeBtn.setAttribute('aria-label', 'Close conversation peek');
+    closeBtn.innerHTML = icon('close', 14);
+
+    header.appendChild(peekBadge);
+    header.appendChild(phase);
+    header.appendChild(openBtn);
+    header.appendChild(closeBtn);
+
+    peekList = document.createElement('div');
+    peekList.className = 'ui2-peek-list';
+    peekList.setAttribute('role', 'log');
+    peekList.setAttribute('aria-live', 'polite');
+    peekList.setAttribute('aria-label', 'Recent transcript');
+
+    root.appendChild(header);
+    root.appendChild(peekList);
+
+    header.addEventListener('click', (e) => {
+      if (e.target.closest && e.target.closest('button')) return;
+      peekOpenInActivity();
+    });
+    openBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      peekOpenInActivity();
+    });
+    closeBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      peekClose(true);
+      const input = document.getElementById('activity-task-input');
+      if (input) input.focus({ preventScroll: true });
+    });
+    peekList.addEventListener('scroll', () => {
+      peekFollow = peekList.scrollTop + peekList.clientHeight >= peekList.scrollHeight - 24;
+    });
+  }
+
+  const peekWire = () => {
+    const root = document.getElementById('ui2-composer-peek');
+    const bar = root ? root.closest('.global-task-bar') : null;
+    if (!root || !bar) return;
+    peekRoot = root;
+    peekBarEl = bar;
+    peekBuild(root);
+
+    bar.addEventListener('focusin', (e) => {
+      if (peekIsOpen() || peekComposerPill()) return;
+      // Focus moving WITHIN the dock (input → Send, the close button's
+      // refocus) is not an entry — reopening there would undo an Esc/×
+      // dismissal the user just made.
+      if (e.relatedTarget instanceof Node && bar.contains(e.relatedTarget)) return;
+      peekDismissed = false;
+      peekOpen();
+    });
+
+    // Window-level capture instead of bar-level: capture descends
+    // window → bar, so this preempts the composer state machine's
+    // Esc-to-pill regardless of listener registration order — one Esc
+    // closes the peek, the next one reaches the dock.
+    window.addEventListener('keydown', (e) => {
+      if (e.key !== 'Escape' || !peekIsOpen()) return;
+      if (e.target instanceof Node && peekBarEl.contains(e.target)) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        peekClose(true);
+        return;
+      }
+      peekClose(true);
+    }, true);
+
+    document.addEventListener('pointerdown', (e) => {
+      if (!peekIsOpen()) return;
+      if (e.target instanceof Node && peekBarEl.contains(e.target)) return;
+      peekClose(true);
+    }, true);
+
+    window.addEventListener('ui2:composer-state', (e) => {
+      if (((e && e.detail && e.detail.state) || '') === 'pill') peekClose(false);
+    });
+
+    if (typeof ui2Mirror === 'function') {
+      ui2Mirror('task-target-chip', peekOnTargetChip);
+      ui2Mirror('phase-banner', peekOnPhase);
+    }
+
+    // A cold target may grow its window only later (ensureSessionWindow
+    // on the first live event) — rebind when the grid gains it.
+    const grid = document.getElementById('session-window-grid');
+    if (grid) {
+      new MutationObserver(() => {
+        if (!peekIsOpen() || !peekBoundSid) return;
+        const win = peekTargetWindow(peekBoundSid);
+        if (win && win.log !== peekBoundLog) peekBind(peekBoundSid);
+      }).observe(grid, { childList: true });
+    }
+
+    window.__ui2Peek = {
+      isOpen: peekIsOpen,
+      open: peekOpen,
+      close: () => peekClose(true),
+      sessionId: () => peekBoundSid,
+    };
+  };
+  if (document.readyState === 'complete') peekWire();
+  else document.addEventListener('DOMContentLoaded', peekWire, { once: true });
+}
 /* ── static/app/ui2-target-switch.js ── */
 // ── composer target hot-swap (seam stub — filled by the switch track) ──
 // Contract: reveal + wire #task-target-switch-btn (next to the target

--- a/static/app.html
+++ b/static/app.html
@@ -22674,6 +22674,34 @@ html.ui-v2 .ui2-appearance-note {
 /* Inline code in section subtitles rides the design mono (chrome-audit
    cross-surface sweep). */
 html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
+/* ── static/app/ui2-composer-peek.css ── */
+/* ── composer conversation peek (skeleton contract) ─────────────────────
+   Filled by the peek track. The container floats ABOVE the dock card:
+   the bar is position:fixed, so this absolute child anchors to the card
+   and never contributes to the bar's measured height — the #app bottom
+   reservation follows --ui2-composer-h (the bar box alone), and the peek
+   overlays content like a transient sheet instead of reflowing it.
+   Everything visual beyond this anchoring belongs to the peek fragment. */
+html.ui-v2 .ui2-composer-peek {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  margin-bottom: 10px;
+}
+/* ── static/app/ui2-target-switch.css ── */
+/* ── composer target hot-swap (skeleton contract) ───────────────────────
+   Filled by the target-switch track. Popover anchors to the dock card
+   (absolute child of the fixed bar) and opens UPWARD; it must not add to
+   the bar's measured height (see the peek skeleton note — same rule). */
+html.ui-v2 .ui2-target-switch {
+  position: absolute;
+  bottom: 100%;
+  right: 0;
+  margin-bottom: 10px;
+  min-width: 260px;
+  max-width: min(420px, 100%);
+}
 </style>
 <!-- ── static/app/20-shell.html ── -->
 </head>
@@ -22759,6 +22787,11 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
 
   <!-- Global Task Bar — always visible across tabs -->
   <div class="global-task-bar">
+    <!-- Conversation peek: the prompt-target session's tail, floated above
+         the dock card (absolute → anchors to the bar, never adds to its
+         measured height / the #app reservation). Filled by
+         ui2-composer-peek.js; inert while hidden. -->
+    <div id="ui2-composer-peek" class="ui2-composer-peek" hidden></div>
     <div class="phase-banner phase-idle" id="phase-banner">
       <span class="spinner" id="phase-spinner"></span>
       <span class="phase-text" id="phase-text">Idle</span>
@@ -22766,6 +22799,12 @@ html.ui-v2 #tab-settings .ui-section-sub code { font-family: var(--mono); }
     <button id="stop-btn" class="stop-btn" onclick="sendInterrupt()" title="Interrupt current turn" style="display:none">&#x23F9; Stop</button>
     <button id="task-new-session-btn" class="task-new-session-btn" onclick="openNewSessionFromPrompt()" title="Create a new session" aria-label="Create a new session">+ New</button>
     <button id="task-target-chip" class="task-target-chip" type="button" onclick="focusForegroundSessionWindow()" title="Prompt target" style="display:none"></button>
+    <!-- Target hot-swap: in-place session switcher. Button revealed and
+         both wired by ui2-target-switch.js (display:none keeps them inert
+         if that fragment ever regresses to a stub); the popover anchors to
+         the dock card like the peek. -->
+    <button id="task-target-switch-btn" class="task-target-switch-btn" type="button" title="Choose prompt target" aria-haspopup="listbox" aria-expanded="false" style="display:none">&#x25BE;</button>
+    <div id="ui2-target-switch" class="ui2-target-switch" hidden role="listbox" aria-label="Prompt target sessions"></div>
     <div id="edit-message-chip" class="edit-message-chip hidden" title="Editing a previous user message">
       <span id="edit-message-label">Editing</span>
       <button type="button" id="edit-message-cancel" title="Cancel edit">x</button>
@@ -27362,7 +27401,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '817badba45e13bb5';
+const INTENDANT_APP_BUILD = '9b5f86e4e3030e63';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -101267,6 +101306,22 @@ function handleDisplayRequestResolved(d) {
     hidePanel('display-request-panel');
   }
 }
+/* ── static/app/ui2-composer-peek.js ── */
+// ── composer conversation peek (seam stub — filled by the peek track) ──
+// Contract: render the prompt-target session's transcript tail into
+// #ui2-composer-peek (mounted as the dock's first child; skeleton
+// anchoring in ui2-composer-peek.css), live-following the same entries
+// the session window shows, with tap-through to the Activity window.
+// Boot follows the ui2-chrome single-boot idiom; every entry point is a
+// no-op when the mount is missing so a stub build stays inert.
+/* ── static/app/ui2-target-switch.js ── */
+// ── composer target hot-swap (seam stub — filled by the switch track) ──
+// Contract: reveal + wire #task-target-switch-btn (next to the target
+// chip) and fill #ui2-target-switch with the targetable-session listbox.
+// Selecting a session retargets the composer IN PLACE (focusSessionWindow
+// — it does not switch tabs); listing is gated exactly like the resolver
+// (isPromptTargetSessionUsable). Boot follows the ui2-chrome single-boot
+// idiom; every entry point is a no-op when the mounts are missing.
 /* ── static/app/59-module-alive.js ── */
 // ── Module-death canary (sentinel) ──────────────────────────────────────
 // MUST stay the LAST .js fragment in manifest.txt (only 59-module-close.html

--- a/static/app.html
+++ b/static/app.html
@@ -22942,17 +22942,246 @@ html.ui-v2 .ui2-composer-peek .diff-log-entry .diff-log-body {
   html.ui-v2 .ui2-peek-header { padding: 7px 8px 6px 11px; }
 }
 /* ── static/app/ui2-target-switch.css ── */
-/* ── composer target hot-swap (skeleton contract) ───────────────────────
-   Filled by the target-switch track. Popover anchors to the dock card
-   (absolute child of the fixed bar) and opens UPWARD; it must not add to
-   the bar's measured height (see the peek skeleton note — same rule). */
+/* ── composer target hot-swap ───────────────────────────────────────────
+   Popover anchors to the dock card (absolute child of the fixed bar) and
+   opens UPWARD; position:absolute in every state so it never adds to the
+   bar's measured height — the #app reservation follows --ui2-composer-h,
+   the bar box alone (see the peek skeleton note — same rule). */
+
+/* trigger: revealed by ui2-target-switch.js (inline display cleared) */
+html.ui-v2 .task-target-switch-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  flex-shrink: 0;
+  border: 1px solid var(--line);
+  border-radius: var(--r-ctl);
+  background: transparent;
+  color: var(--text-3);
+  font-family: var(--sans); /* buttons don't inherit */
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+  transition: color var(--t-fast), background var(--t-fast),
+    border-color var(--t-fast), transform var(--t-fast);
+}
+html.ui-v2 .task-target-switch-btn:hover {
+  color: var(--text);
+  background: var(--surface-2);
+}
+html.ui-v2 .task-target-switch-btn:focus-visible {
+  outline: 2px solid var(--iris);
+  outline-offset: 1px;
+}
+/* open: iris tint + the caret flips toward the popover above (the button
+   box is a symmetric square, so rotating the whole control is safe) */
+html.ui-v2 .task-target-switch-btn[aria-expanded="true"] {
+  color: var(--iris-2);
+  border-color: rgba(var(--iris-rgb), .4);
+  background: rgba(var(--iris-rgb), .09);
+  transform: rotate(180deg);
+}
+
 html.ui-v2 .ui2-target-switch {
   position: absolute;
   bottom: 100%;
   right: 0;
   margin-bottom: 10px;
   min-width: 260px;
-  max-width: min(420px, 100%);
+  width: max-content;
+  max-width: min(420px, calc(100vw - 24px));
+  z-index: 3; /* above the peek, its z:auto anchor-mate on the same card */
+  display: flex;
+  flex-direction: column;
+  padding: 6px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--surface);
+  box-shadow: var(--shadow-card);
+  animation: ui2-tsw-in var(--t-med) ease-out;
+}
+html.ui-v2 .ui2-target-switch[hidden] { display: none; }
+@keyframes ui2-tsw-in {
+  from { opacity: 0; transform: translateY(5px); }
+}
+
+html.ui-v2 .ui2-tsw-eyebrow {
+  padding: 7px 12px 4px;
+  font-family: var(--mono);
+  font-size: var(--eyebrow-size);
+  font-weight: 700;
+  letter-spacing: var(--eyebrow-track);
+  text-transform: uppercase;
+  color: var(--text-3);
+  user-select: none;
+}
+
+html.ui-v2 .ui2-tsw-filter {
+  margin: 2px 6px 6px;
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-ctl);
+  background: var(--bg-1);
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 12.5px;
+  outline: none;
+}
+html.ui-v2 .ui2-tsw-filter::placeholder { color: var(--text-3); }
+html.ui-v2 .ui2-tsw-filter:focus {
+  border-color: rgba(var(--iris-rgb), .45);
+  box-shadow: 0 0 0 3px rgba(var(--iris-rgb), .18);
+}
+
+html.ui-v2 .ui2-tsw-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 2px;
+  overflow-y: auto;
+  max-height: min(50vh, 420px);
+  max-height: min(50dvh, 420px);
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+}
+
+html.ui-v2 .ui2-tsw-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 34px;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: var(--r-ctl);
+  background: transparent;
+  color: var(--text-2);
+  font-family: var(--sans); /* buttons don't inherit */
+  font-size: 12.5px;
+  font-weight: 550;
+  text-align: left;
+  cursor: pointer;
+}
+html.ui-v2 .ui2-tsw-row:hover {
+  background: var(--hover-wash);
+  color: var(--text);
+}
+html.ui-v2 .ui2-tsw-row:focus-visible {
+  outline: 2px solid var(--iris);
+  outline-offset: -2px;
+}
+html.ui-v2 .ui2-tsw-row[aria-selected="true"] {
+  color: var(--text);
+  background: rgba(var(--iris-rgb), .08);
+}
+html.ui-v2 .ui2-tsw-row[aria-selected="true"]::after {
+  content: "✓";
+  margin-left: 4px;
+  color: var(--iris-2);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+html.ui-v2 .ui2-tsw-row-main {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  flex: 1;
+  min-width: 0;
+}
+html.ui-v2 .ui2-tsw-row-label { font-weight: 650; }
+html.ui-v2 .ui2-tsw-row-sub {
+  color: var(--text-3);
+  font-size: 11px;
+  font-weight: 450;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+html.ui-v2 .ui2-tsw-row-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+html.ui-v2 .ui2-tsw-badge {
+  flex-shrink: 0;
+  max-width: 96px;
+  padding: 2px 7px;
+  border: 1px solid var(--session-badge-border, rgba(var(--iris-rgb), .35));
+  border-radius: 5px;
+  background: var(--session-badge-bg, rgba(var(--iris-rgb), .08));
+  color: var(--session-badge-fg, var(--iris-2));
+  font-family: var(--mono);
+  font-size: 10.5px;
+  font-weight: 650;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* light theme: applySessionBadgeStyle mints dark-theme pastels — re-derive
+   toward ink while keeping each session's hue (same formula as the chip's
+   light rule in ui2-activity.css, which doesn't cover this class) */
+html.ui-v2[data-theme="light"] .ui2-tsw-badge {
+  color: color-mix(in srgb, var(--session-badge-fg, var(--text-2)) 34%, var(--text));
+  border-color: color-mix(in srgb, var(--session-badge-border, var(--line-2)) 55%, var(--line-2));
+}
+
+html.ui-v2 .ui2-tsw-dot {
+  flex-shrink: 0;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--neutral-dot);
+  opacity: .55;
+}
+html.ui-v2 .ui2-tsw-dot.active {
+  background: var(--green);
+  opacity: 1;
+  animation: ui2-tsw-pulse 2s ease-in-out infinite;
+}
+html.ui-v2 .ui2-tsw-dot.waiting {
+  background: var(--amber);
+  opacity: 1;
+}
+@keyframes ui2-tsw-pulse {
+  50% { opacity: .45; }
+}
+
+html.ui-v2 .ui2-tsw-empty {
+  padding: 14px 12px;
+  color: var(--text-3);
+  font-size: 12px;
+  text-align: center;
+}
+
+html.ui-v2 .ui2-tsw-foot {
+  margin-top: 4px;
+  padding: 4px 2px 0;
+  border-top: 1px solid var(--line);
+}
+html.ui-v2 .ui2-tsw-foot .ui2-tsw-row { color: var(--text-3); }
+html.ui-v2 .ui2-tsw-foot .ui2-tsw-row:hover { color: var(--text); }
+
+/* touch targets (brief: rows ≥44px at ≤820px); 16px input font keeps
+   iOS Safari from zooming the page on focus */
+@media (max-width: 820px) {
+  html.ui-v2 .ui2-tsw-row { min-height: 44px; }
+  html.ui-v2 .ui2-tsw-filter {
+    min-height: 40px;
+    font-size: 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.ui-v2 .ui2-target-switch { animation: none; }
+  html.ui-v2 .ui2-tsw-dot.active { animation: none; }
+  html.ui-v2 .task-target-switch-btn { transition: none; }
 }
 </style>
 <!-- ── static/app/20-shell.html ── -->
@@ -27816,7 +28045,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '8ddd972d7ad6ff4b';
+const INTENDANT_APP_BUILD = '8ba99e0073c1bc32';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -102316,13 +102545,355 @@ function handleDisplayRequestResolved(d) {
   else document.addEventListener('DOMContentLoaded', peekWire, { once: true });
 }
 /* ── static/app/ui2-target-switch.js ── */
-// ── composer target hot-swap (seam stub — filled by the switch track) ──
-// Contract: reveal + wire #task-target-switch-btn (next to the target
-// chip) and fill #ui2-target-switch with the targetable-session listbox.
-// Selecting a session retargets the composer IN PLACE (focusSessionWindow
-// — it does not switch tabs); listing is gated exactly like the resolver
-// (isPromptTargetSessionUsable). Boot follows the ui2-chrome single-boot
-// idiom; every entry point is a no-op when the mounts are missing.
+// ── composer target hot-swap ───────────────────────────────────────────
+// In-place prompt-target switcher for the dock: #task-target-switch-btn
+// toggles a listbox of exactly the sessions the resolver may target
+// (isPromptTargetSessionUsable), plus "Auto" (hand the pick back to the
+// resolver) and "New session…". Selecting retargets via focusSessionWindow
+// — the whole point is that it never leaves the current tab (no route
+// change, no scroll; the chip's own click stays the jump-to-Activity
+// affordance). IIFE: fragments share one script scope and nothing here is
+// consumed by other fragments.
+(() => {
+  const FILTER_AT = 6;   // more rows than this → show the type-to-filter input
+  const POLL_MS = 800;   // open-state refresh: sessions come and go
+
+  let btnEl = null;
+  let popEl = null;
+  let filterEl = null;
+  let rowsEl = null;
+  let isOpen = false;
+  let pollTimer = 0;
+  let filterQuery = '';
+  let lastSig = '';
+
+  const composerPill = () =>
+    document.documentElement.dataset.composerState === 'pill';
+
+  function usableSessionIds() {
+    const ids = [];
+    for (const sid of sessionWindows.keys()) {
+      if (isPromptTargetSessionUsable(sid)) ids.push(sid);
+    }
+    return ids;
+  }
+
+  function rowPhase(sid) {
+    if (hasPendingActiveSessionWindow(sid)) return 'active';
+    const win = sessionWindows.get(sid);
+    return sessionPhaseClass(win?.phase || 'idle') || 'done';
+  }
+
+  // Everything a rendered listing depends on; the open-state poll re-renders
+  // only when this changes (a vanished session, a phase flip, a rename, a
+  // target rebind elsewhere).
+  function currentSignature() {
+    const parts = [
+      resolvePromptTargetSessionId(),
+      explicitForegroundSessionId() ? 'E' : 'A',
+      filterQuery,
+    ];
+    for (const sid of usableSessionIds()) {
+      parts.push(sid, sessionIdentityParts(sid).name, rowPhase(sid));
+    }
+    return parts.join('\u0000');
+  }
+
+  const navRows = () => Array.from(popEl.querySelectorAll('.ui2-tsw-row'));
+
+  function makeRow(key, cls) {
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = cls ? `ui2-tsw-row ${cls}` : 'ui2-tsw-row';
+    row.setAttribute('role', 'option');
+    row.setAttribute('aria-selected', 'false');
+    row.tabIndex = -1;
+    row.dataset.key = key;
+    return row;
+  }
+
+  function buildAutoRow(active) {
+    const row = makeRow('auto', 'ui2-tsw-auto');
+    const main = document.createElement('span');
+    main.className = 'ui2-tsw-row-main';
+    const label = document.createElement('span');
+    label.className = 'ui2-tsw-row-label';
+    label.textContent = 'Auto';
+    const sub = document.createElement('span');
+    sub.className = 'ui2-tsw-row-sub';
+    sub.textContent = 'picks the active session';
+    main.append(label, sub);
+    row.appendChild(main);
+    row.title = 'Let Intendant pick the prompt target';
+    row.setAttribute('aria-label', 'Auto: pick the prompt target for me');
+    if (active) row.setAttribute('aria-selected', 'true');
+    return row;
+  }
+
+  function buildSessionRow(sid, target) {
+    const row = makeRow(`s:${sid}`);
+    const badge = document.createElement('span');
+    badge.className = 'ui2-tsw-badge';
+    renderSessionIdentity(badge, sid, { showName: false });
+    applySessionBadgeStyle(badge, sid);
+    const name = sessionIdentityParts(sid).name;
+    const nameEl = document.createElement('span');
+    nameEl.className = 'ui2-tsw-row-name';
+    nameEl.textContent = name;
+    const phase = rowPhase(sid);
+    const dot = document.createElement('span');
+    dot.className = `ui2-tsw-dot ${phase}`;
+    dot.setAttribute('aria-hidden', 'true');
+    row.append(badge, nameEl, dot);
+    row.title = name ? `${name} · ${sid}` : sid;
+    const phaseWord = phase === 'active' ? 'running' : phase === 'waiting' ? 'waiting' : 'idle';
+    row.setAttribute('aria-label', `${name || shortSessionId(sid)} · ${phaseWord}`);
+    if (sid === target) row.setAttribute('aria-selected', 'true');
+    return row;
+  }
+
+  function buildEmpty(text) {
+    const el = document.createElement('div');
+    el.className = 'ui2-tsw-empty';
+    el.textContent = text;
+    return el;
+  }
+
+  function renderRows() {
+    const usable = usableSessionIds();
+    const target = resolvePromptTargetSessionId();
+    const autoActive = !explicitForegroundSessionId();
+    filterEl.hidden = !(usable.length > FILTER_AT || filterQuery.trim() !== '');
+
+    const active = document.activeElement;
+    const prevKey = popEl.contains(active) && active !== filterEl
+      ? active.dataset?.key || ''
+      : '';
+
+    let list = usable;
+    const q = filterQuery.trim();
+    if (q) {
+      list = usable
+        .map(sid => ({
+          sid,
+          score: Math.max(
+            ui2FuzzyScore(q, sessionIdentityParts(sid).name),
+            ui2FuzzyScore(q, sid),
+          ),
+        }))
+        .filter(x => x.score >= 0)
+        .sort((a, b) => b.score - a.score)
+        .map(x => x.sid);
+    }
+
+    const children = [];
+    if (usable.length) children.push(buildAutoRow(autoActive));
+    for (const sid of list) children.push(buildSessionRow(sid, target));
+    if (!usable.length) children.push(buildEmpty('No targetable sessions'));
+    else if (!list.length) children.push(buildEmpty('No matches'));
+    rowsEl.replaceChildren(...children);
+    lastSig = currentSignature();
+
+    // A refresh can remove the focused row — land on the survivor with the
+    // same key, else the first row, so the keyboard flow never dies.
+    if (prevKey) {
+      const again = navRows().find(r => r.dataset.key === prevKey);
+      (again || navRows()[0])?.focus();
+    }
+  }
+
+  function openPopover() {
+    if (isOpen || composerPill()) return;
+    filterQuery = '';
+    filterEl.value = '';
+    isOpen = true;
+    renderRows();
+    popEl.hidden = false;
+    btnEl.setAttribute('aria-expanded', 'true');
+    const first = popEl.querySelector('.ui2-tsw-row[aria-selected="true"]') || navRows()[0];
+    if (first) {
+      first.focus();
+      first.scrollIntoView({ block: 'nearest' });
+    }
+    document.addEventListener('pointerdown', onDocPointerDown, true);
+    pollTimer = setInterval(pollRefresh, POLL_MS);
+  }
+
+  function closePopover(opts = {}) {
+    if (!isOpen) return;
+    isOpen = false;
+    popEl.hidden = true;
+    btnEl.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('pointerdown', onDocPointerDown, true);
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = 0;
+    }
+    if (opts.refocus) btnEl.focus();
+  }
+
+  function pollRefresh() {
+    if (composerPill()) {
+      closePopover();
+      return;
+    }
+    if (currentSignature() !== lastSig) renderRows();
+  }
+
+  function onDocPointerDown(e) {
+    if (popEl.contains(e.target) || btnEl.contains(e.target)) return;
+    closePopover();
+  }
+
+  function activateRow(key) {
+    if (key === 'auto') {
+      // The explicit pick lives in two refs (foreground + current), possibly
+      // holding different ids — discard until the explicit lane is empty so
+      // the resolver takes over.
+      for (let i = 0; i < 4 && explicitForegroundSessionId(); i++) {
+        discardPromptTargetReference(explicitForegroundSessionId());
+      }
+      updateTaskTargetChip();
+      closePopover({ refocus: true });
+    } else if (key === 'new') {
+      // Close without refocus: openNewSessionFromPrompt focuses the
+      // new-session input on the next frame and must win.
+      openNewSessionFromPrompt();
+      closePopover();
+    } else if (key.startsWith('s:')) {
+      const sid = key.slice(2);
+      if (!isPromptTargetSessionUsable(sid)) {
+        renderRows();
+        return;
+      }
+      focusSessionWindow(sid);
+      closePopover({ refocus: true });
+    }
+  }
+
+  function onPopKeydown(e) {
+    const inFilter = e.target === filterEl;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      closePopover({ refocus: true });
+      return;
+    }
+    if (e.key === 'Tab') {
+      // Close and hand focus back to the button so the default Tab
+      // continues from the composer instead of a removed row.
+      closePopover({ refocus: true });
+      return;
+    }
+    const rows = navRows();
+    if (!rows.length) return;
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      e.stopPropagation();
+      const idx = rows.indexOf(document.activeElement);
+      if (inFilter) {
+        (e.key === 'ArrowDown' ? rows[0] : rows[rows.length - 1]).focus();
+      } else if (e.key === 'ArrowUp' && idx === 0 && !filterEl.hidden) {
+        filterEl.focus();
+      } else {
+        const next = e.key === 'ArrowDown'
+          ? Math.min(rows.length - 1, idx + 1)
+          : Math.max(0, idx - 1);
+        rows[next].focus();
+      }
+      document.activeElement?.scrollIntoView?.({ block: 'nearest' });
+      return;
+    }
+    if ((e.key === 'Home' || e.key === 'End') && !inFilter) {
+      e.preventDefault();
+      e.stopPropagation();
+      (e.key === 'Home' ? rows[0] : rows[rows.length - 1]).focus();
+      document.activeElement?.scrollIntoView?.({ block: 'nearest' });
+      return;
+    }
+    if (e.key === 'Enter' && inFilter) {
+      e.preventDefault();
+      e.stopPropagation();
+      const top = rows.find(r => (r.dataset.key || '').startsWith('s:'));
+      if (top) activateRow(top.dataset.key);
+      return;
+    }
+    if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      // Contain printable keys: the document-level shortcut layer treats
+      // bare letters as approval verbs (y/s/a/n) when focus is not in an
+      // input, and popover rows are buttons. Redirect into the filter when
+      // it is shown — focusing during keydown lands this keystroke there.
+      e.stopPropagation();
+      if (!inFilter && !filterEl.hidden) filterEl.focus();
+    }
+  }
+
+  const wire = () => {
+    btnEl = document.getElementById('task-target-switch-btn');
+    popEl = document.getElementById('ui2-target-switch');
+    if (!btnEl || !popEl) return;
+
+    const eyebrow = document.createElement('div');
+    eyebrow.className = 'ui2-tsw-eyebrow';
+    eyebrow.textContent = 'Prompt target';
+    eyebrow.setAttribute('aria-hidden', 'true');
+
+    filterEl = document.createElement('input');
+    filterEl.type = 'text';
+    filterEl.className = 'ui2-tsw-filter';
+    filterEl.placeholder = 'Filter sessions…';
+    filterEl.setAttribute('aria-label', 'Filter sessions');
+    filterEl.autocomplete = 'off';
+    filterEl.spellcheck = false;
+    filterEl.hidden = true;
+
+    rowsEl = document.createElement('div');
+    rowsEl.className = 'ui2-tsw-rows';
+
+    const foot = document.createElement('div');
+    foot.className = 'ui2-tsw-foot';
+    const newRow = makeRow('new', 'ui2-tsw-new');
+    const newLabel = document.createElement('span');
+    newLabel.className = 'ui2-tsw-row-label';
+    newLabel.textContent = '+ New session…';
+    newRow.appendChild(newLabel);
+    newRow.title = 'Draft a new session from the composer';
+    foot.appendChild(newRow);
+
+    popEl.replaceChildren(eyebrow, filterEl, rowsEl, foot);
+
+    btnEl.style.display = '';
+    btnEl.setAttribute('aria-controls', 'ui2-target-switch');
+
+    btnEl.addEventListener('click', () => {
+      if (isOpen) closePopover({ refocus: true });
+      else openPopover();
+    });
+    btnEl.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        openPopover();
+      } else if (e.key === 'Escape' && isOpen) {
+        e.stopPropagation();
+        closePopover({ refocus: true });
+      }
+    });
+    popEl.addEventListener('keydown', onPopKeydown);
+    popEl.addEventListener('click', (e) => {
+      const row = e.target.closest?.('.ui2-tsw-row');
+      if (row && popEl.contains(row)) activateRow(row.dataset.key || '');
+    });
+    filterEl.addEventListener('input', () => {
+      filterQuery = filterEl.value;
+      renderRows();
+    });
+    window.addEventListener('ui2:composer-state', (e) => {
+      if ((e?.detail?.state || '') === 'pill') closePopover();
+    });
+  };
+  if (document.readyState === 'complete') wire();
+  else document.addEventListener('DOMContentLoaded', wire, { once: true });
+})();
 /* ── static/app/59-module-alive.js ── */
 // ── Module-death canary (sentinel) ──────────────────────────────────────
 // MUST stay the LAST .js fragment in manifest.txt (only 59-module-close.html

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -81,6 +81,11 @@
 
   <!-- Global Task Bar — always visible across tabs -->
   <div class="global-task-bar">
+    <!-- Conversation peek: the prompt-target session's tail, floated above
+         the dock card (absolute → anchors to the bar, never adds to its
+         measured height / the #app reservation). Filled by
+         ui2-composer-peek.js; inert while hidden. -->
+    <div id="ui2-composer-peek" class="ui2-composer-peek" hidden></div>
     <div class="phase-banner phase-idle" id="phase-banner">
       <span class="spinner" id="phase-spinner"></span>
       <span class="phase-text" id="phase-text">Idle</span>
@@ -88,6 +93,12 @@
     <button id="stop-btn" class="stop-btn" onclick="sendInterrupt()" title="Interrupt current turn" style="display:none">&#x23F9; Stop</button>
     <button id="task-new-session-btn" class="task-new-session-btn" onclick="openNewSessionFromPrompt()" title="Create a new session" aria-label="Create a new session">+ New</button>
     <button id="task-target-chip" class="task-target-chip" type="button" onclick="focusForegroundSessionWindow()" title="Prompt target" style="display:none"></button>
+    <!-- Target hot-swap: in-place session switcher. Button revealed and
+         both wired by ui2-target-switch.js (display:none keeps them inert
+         if that fragment ever regresses to a stub); the popover anchors to
+         the dock card like the peek. -->
+    <button id="task-target-switch-btn" class="task-target-switch-btn" type="button" title="Choose prompt target" aria-haspopup="listbox" aria-expanded="false" style="display:none">&#x25BE;</button>
+    <div id="ui2-target-switch" class="ui2-target-switch" hidden role="listbox" aria-label="Prompt target sessions"></div>
     <div id="edit-message-chip" class="edit-message-chip hidden" title="Editing a previous user message">
       <span id="edit-message-label">Editing</span>
       <button type="button" id="edit-message-cancel" title="Cancel edit">x</button>

--- a/static/app/manifest.txt
+++ b/static/app/manifest.txt
@@ -28,6 +28,8 @@ ui2-grid.css
 ui2-live.css
 ui2-usage.css
 ui2-settings.css
+ui2-composer-peek.css
+ui2-target-switch.css
 19-style-close.html
 
 20-shell.html
@@ -99,5 +101,11 @@ ui2-settings.js
 57-attention-notifications.js
 58-shortcuts-boot.js
 58-display-request.js
+# Composer satellites load LAST among features: they consume seams from
+# 31 (sessionWindows), 39 (prompt-target resolver), 41 (focus/append) and
+# ui2-chrome (dock state), and everything they do is boot-callback or
+# event-driven — nothing at top level touches earlier fragments' consts.
+ui2-composer-peek.js
+ui2-target-switch.js
 59-module-alive.js
 59-module-close.html

--- a/static/app/ui2-chrome.css
+++ b/static/app/ui2-chrome.css
@@ -473,6 +473,66 @@ html.ui-v2 .global-task-bar:focus-within {
   border-color: rgba(var(--iris-rgb), .45);
   box-shadow: 0 0 0 3px rgba(var(--iris-rgb), .22), var(--shadow-card);
 }
+
+/* ── composer states: expanded ⇄ pill ─────────────────────────────────
+   ui2WireComposerState stamps data-composer-state on <html>: "expanded"
+   is the full dock; "pill" collapses the same fixed element into a small
+   centered lozenge so immersive surfaces (the per-tab defaults: Live,
+   Station, Terminal, Files) keep the bottom of the viewport. The
+   reservation invariant is untouched — --ui2-composer-h simply measures
+   the pill. The child hide is !important on purpose: chip/attachment
+   children carry inline display toggles and focus-within reveals, and
+   the pill state must override every one of them. */
+html.ui-v2 .ui2-composer-pill { display: none; }
+html.ui-v2 .ui2-composer-collapse {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 26px; height: 26px; flex-shrink: 0; padding: 0;
+  border: 0; border-radius: var(--r-ctl);
+  background: transparent; color: var(--text-3); cursor: pointer;
+}
+html.ui-v2 .ui2-composer-collapse:hover { background: var(--hover-wash); color: var(--text); }
+html.ui-v2 .ui2-composer-collapse svg { transform: rotate(90deg); } /* chev points down */
+html.ui-v2[data-composer-state="pill"] .global-task-bar {
+  width: auto;
+  min-width: 0;
+  max-width: min(340px, calc(100vw - var(--ui2-nav-edge) - var(--ui2-sa-r) - 24px));
+  padding: 8px 16px;
+  border-radius: var(--r-pill);
+  cursor: pointer;
+  justify-content: center;
+}
+html.ui-v2[data-composer-state="pill"] .global-task-bar:hover {
+  background: var(--surface-2);
+  border-color: var(--line-2);
+}
+html.ui-v2[data-composer-state="pill"] .global-task-bar > *:not(.ui2-composer-pill) { display: none !important; }
+html.ui-v2[data-composer-state="pill"] .ui2-composer-pill {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 12.5px; font-weight: 700; color: var(--text-2);
+  white-space: nowrap;
+  pointer-events: none; /* the whole lozenge is the click target */
+}
+html.ui-v2 .ui2-composer-pill-dot {
+  width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+  background: var(--text-3);
+}
+html.ui-v2 .ui2-composer-pill[data-phase="running"] .ui2-composer-pill-dot,
+html.ui-v2 .ui2-composer-pill[data-phase="thinking"] .ui2-composer-pill-dot {
+  background: var(--iris);
+  animation: ui2-pulse 1.3s infinite;
+}
+html.ui-v2 .ui2-composer-pill[data-phase="waiting"] .ui2-composer-pill-dot { background: var(--amber); }
+html.ui-v2 .ui2-composer-pill[data-phase="done"] .ui2-composer-pill-dot { background: var(--green); }
+html.ui-v2 .ui2-composer-pill-draft {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--amber);
+  display: none;
+}
+html.ui-v2 .ui2-composer-pill.has-draft .ui2-composer-pill-draft { display: inline-block; }
+@media (prefers-reduced-motion: reduce) {
+  html.ui-v2 .ui2-composer-pill-dot { animation: none !important; }
+}
+
 /* phase + stop live in the oversight bar under v2 */
 html.ui-v2 .global-task-bar .phase-banner { display: none; }
 html.ui-v2 .global-task-bar .stop-btn { display: none; }
@@ -593,29 +653,39 @@ html.ui-v2 .ui2-nav-bottom { flex-shrink: 0; background: var(--bg); }
    ~40% of the viewport; focusing it (or targeting a session) expands the
    full control set. :focus-within covers typing, target chip, attach and
    Direct once expanded. */
-@media (max-width: 500px) {
+@media (max-width: 600px) {
   /* The dock hugs the edge tighter on phones; the #app reservation keeps
      following the measured bar height (the old fixed 64px was smaller
-     than the bar itself — the root of the covered-controls bug). */
+     than the bar itself — the root of the covered-controls bug). The
+     breakpoint is 600, not 500: v1's ≤600 wrap rules force the input
+     onto its own row with Send alone under it — the order/flex resets
+     below re-join them into one compact resting row across the whole
+     band, with the secondary controls appearing on focus. */
   html.ui-v2 { --ui2-composer-off: 8px; }
   html.ui-v2 .global-task-bar {
     width: calc(100vw - var(--ui2-nav-edge) - var(--ui2-sa-r) - 16px);
     padding: 6px 8px;
     flex-wrap: wrap;
   }
+  html.ui-v2 .global-task-bar .global-task-input {
+    order: 0;
+    flex: 1 1 auto;
+    width: auto;
+    font-size: 16px; /* under 16px iOS Safari zooms the page on focus */
+    max-height: 2.4em;
+  }
+  html.ui-v2 .global-task-bar .global-send-btn { order: 0; flex: 0 0 auto; }
   html.ui-v2 .global-task-bar .task-new-session-btn,
   html.ui-v2 .global-task-bar .global-attach-btn,
-  html.ui-v2 .global-task-bar .global-direct-toggle {
+  html.ui-v2 .global-task-bar .global-direct-toggle,
+  html.ui-v2 .global-task-bar .ui2-composer-collapse {
     display: none;
   }
   html.ui-v2 .global-task-bar:focus-within .task-new-session-btn,
   html.ui-v2 .global-task-bar:focus-within .global-attach-btn,
-  html.ui-v2 .global-task-bar:focus-within .global-direct-toggle {
+  html.ui-v2 .global-task-bar:focus-within .global-direct-toggle,
+  html.ui-v2 .global-task-bar:focus-within .ui2-composer-collapse {
     display: inline-flex;
-  }
-  html.ui-v2 .global-task-bar .global-task-input {
-    font-size: 16px; /* under 16px iOS Safari zooms the page on focus */
-    max-height: 2.4em;
   }
   html.ui-v2 .global-task-bar:focus-within .global-task-input {
     max-height: 6em;

--- a/static/app/ui2-chrome.js
+++ b/static/app/ui2-chrome.js
@@ -913,6 +913,125 @@ function ui2WireComposerMech() {
   }
 }
 
+const UI2_COMPOSER_PILL_DEFAULT_TABS = new Set(['displays', 'station', 'terminal', 'files']);
+
+function ui2WireComposerState() {
+  const bar = document.querySelector('.global-task-bar');
+  if (!bar) return;
+  const rootEl = document.documentElement;
+  const input = document.getElementById('activity-task-input');
+
+  const pill = document.createElement('span');
+  pill.className = 'ui2-composer-pill';
+  const dot = document.createElement('span');
+  dot.className = 'ui2-composer-pill-dot';
+  const pillLabel = document.createElement('span');
+  pillLabel.textContent = 'Ask Intendant';
+  const draftDot = document.createElement('span');
+  draftDot.className = 'ui2-composer-pill-draft';
+  draftDot.title = 'Unsent draft';
+  pill.append(dot, pillLabel, draftDot);
+  bar.appendChild(pill);
+
+  const collapse = document.createElement('button');
+  collapse.type = 'button';
+  collapse.className = 'ui2-composer-collapse';
+  collapse.title = 'Collapse composer (Esc)';
+  collapse.setAttribute('aria-label', 'Collapse composer');
+  collapse.innerHTML = ui2Icon('chev', 14);
+  bar.insertBefore(collapse, document.getElementById('phase-banner'));
+
+  const activeTabId = () => {
+    const pane = document.querySelector('.tab-pane.active');
+    return pane ? pane.id.replace(/^tab-/, '') : 'activity';
+  };
+  const stateKey = (tab) => 'intendant.ui2.composerState.' + tab;
+  const stateFor = (tab) => {
+    try {
+      const o = localStorage.getItem(stateKey(tab));
+      if (o === 'pill' || o === 'expanded') return o;
+    } catch (_) { /* private mode: defaults only */ }
+    return UI2_COMPOSER_PILL_DEFAULT_TABS.has(tab) ? 'pill' : 'expanded';
+  };
+  const syncDraft = () => {
+    pill.classList.toggle('has-draft', !!(input && input.value.trim()));
+  };
+
+  let current = '';
+  const setState = (next, remember = false) => {
+    if (next !== 'pill' && next !== 'expanded') return;
+    if (remember) {
+      try { localStorage.setItem(stateKey(activeTabId()), next); } catch (_) { /* private mode */ }
+    }
+    if (current === next) return;
+    current = next;
+    rootEl.dataset.composerState = next;
+    if (next === 'pill') {
+      // Children go display:none — never leave focus on a hidden control
+      // (it would also pin the keyboard lift).
+      if (bar.contains(document.activeElement)) document.activeElement.blur();
+      bar.setAttribute('role', 'button');
+      bar.setAttribute('tabindex', '0');
+      bar.setAttribute('aria-label', 'Expand composer');
+      syncDraft();
+    } else {
+      bar.removeAttribute('role');
+      bar.removeAttribute('tabindex');
+      bar.removeAttribute('aria-label');
+    }
+    window.dispatchEvent(new CustomEvent('ui2:composer-state', { detail: { state: next } }));
+  };
+
+  const expandAndFocus = (viaTouch) => {
+    setState('expanded', true);
+    // Touch keeps the keyboard down until the user taps the input.
+    if (!viaTouch && input) input.focus();
+  };
+
+  // Programmatic seam for palette/shortcut callers: expand before focusing
+  // (a pilled dock's children are display:none and cannot receive focus).
+  window.ui2ComposerExpand = () => setState('expanded');
+
+  bar.addEventListener('click', (e) => {
+    if (current !== 'pill') return;
+    expandAndFocus(e.pointerType === 'touch');
+  });
+  collapse.addEventListener('click', (e) => {
+    e.stopPropagation();
+    setState('pill', true);
+  });
+  bar.addEventListener('keydown', (e) => {
+    if (current === 'pill' && (e.key === 'Enter' || e.key === ' ')) {
+      e.preventDefault();
+      expandAndFocus(false);
+      return;
+    }
+    // Bubble phase: the peek's capture-phase Esc (close-peek) stops
+    // propagation while the peek is open, so this fires only with no peek
+    // up. Esc is get-out-of-my-way, not a preference — no remember.
+    if (e.key === 'Escape' && current === 'expanded') setState('pill');
+  });
+  if (input) input.addEventListener('input', syncDraft);
+
+  ui2Mirror('phase-banner', (banner) => {
+    pill.dataset.phase = ui2PhaseCategory(banner.className);
+  });
+
+  const applyForTab = (tab) => setState(stateFor(String(tab || '')));
+  if (typeof switchTab === 'function') {
+    // One shared module scope: rebinding the declaration retargets every
+    // caller (nav, palette, router deep links), so the per-tab state rides
+    // every navigation path.
+    const origSwitchTab = switchTab;
+    switchTab = function (tabId) {
+      const r = origSwitchTab.apply(this, arguments);
+      if (r !== false) applyForTab(tabId);
+      return r;
+    };
+  }
+  applyForTab(activeTabId());
+}
+
 ui2BuildNav();
 {
   // Single-boot: a module script executes at readyState 'interactive', so
@@ -924,6 +1043,7 @@ ui2BuildNav();
     ui2WireMirrors();
     ui2WirePalette();
     ui2WireComposerMech();
+    ui2WireComposerState();
     // Fuel chip: transport-status flips repaint it via the existing
     // #sb-dashboard-transport mirror lane; the interval keeps the lease
     // countdown honest between flips.

--- a/static/app/ui2-composer-peek.css
+++ b/static/app/ui2-composer-peek.css
@@ -1,0 +1,14 @@
+/* ── composer conversation peek (skeleton contract) ─────────────────────
+   Filled by the peek track. The container floats ABOVE the dock card:
+   the bar is position:fixed, so this absolute child anchors to the card
+   and never contributes to the bar's measured height — the #app bottom
+   reservation follows --ui2-composer-h (the bar box alone), and the peek
+   overlays content like a transient sheet instead of reflowing it.
+   Everything visual beyond this anchoring belongs to the peek fragment. */
+html.ui-v2 .ui2-composer-peek {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  margin-bottom: 10px;
+}

--- a/static/app/ui2-composer-peek.css
+++ b/static/app/ui2-composer-peek.css
@@ -1,14 +1,196 @@
-/* ── composer conversation peek (skeleton contract) ─────────────────────
-   Filled by the peek track. The container floats ABOVE the dock card:
-   the bar is position:fixed, so this absolute child anchors to the card
-   and never contributes to the bar's measured height — the #app bottom
-   reservation follows --ui2-composer-h (the bar box alone), and the peek
-   overlays content like a transient sheet instead of reflowing it.
-   Everything visual beyond this anchoring belongs to the peek fragment. */
+/* ── composer conversation peek ─────────────────────────────────────────
+   The container floats ABOVE the dock card: the bar is position:fixed, so
+   this absolute child anchors to the card and never contributes to the
+   bar's measured height — the #app bottom reservation follows
+   --ui2-composer-h (the bar box alone), and the peek overlays content
+   like a transient sheet instead of reflowing it. It rides the keyboard
+   lift for free (the bar's bottom carries --ui2-kb-inset).
+   Solid surface, no backdrop-filter: fixed chrome can overlap the Station
+   canvases (same rule as the dock card). */
 html.ui-v2 .ui2-composer-peek {
   position: absolute;
   bottom: 100%;
   left: 0;
   right: 0;
   margin-bottom: 10px;
+  display: flex;
+  flex-direction: column;
+  max-height: min(42vh, 380px);
+  max-height: min(42dvh, 380px);
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--surface);
+  box-shadow: var(--shadow-card);
+}
+/* the display:flex above outweighs the UA [hidden] rule — restate it */
+html.ui-v2 .ui2-composer-peek[hidden] { display: none; }
+@keyframes ui2-peek-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: none; }
+}
+html.ui-v2 .ui2-composer-peek:not([hidden]) {
+  animation: ui2-peek-in var(--t-slow) ease;
+}
+
+/* — header: target identity, live phase, jump-to-Activity, close — */
+html.ui-v2 .ui2-peek-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  min-width: 0;
+  padding: 8px 9px 7px 13px;
+  border-bottom: 1px solid var(--line);
+  cursor: pointer;
+}
+html.ui-v2 .ui2-peek-header:hover { background: var(--hover-wash); }
+html.ui-v2 .ui2-peek-target {
+  flex-shrink: 1;
+  min-width: 0;
+  max-width: 220px;
+  font-size: 11px;
+  font-weight: 650;
+}
+html.ui-v2 .ui2-peek-phase {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  font-size: 11px;
+  color: var(--text-3);
+}
+html.ui-v2 .ui2-peek-phase-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--neutral-dot);
+}
+html.ui-v2 .ui2-peek-phase-dot[data-cat="thinking"],
+html.ui-v2 .ui2-peek-phase-dot[data-cat="running"] {
+  background: var(--iris);
+  animation: ui2-pulse 1.3s infinite;
+}
+html.ui-v2 .ui2-peek-phase-dot[data-cat="waiting"] {
+  background: var(--amber);
+  animation: ui2-pulse 2s infinite;
+}
+html.ui-v2 .ui2-peek-phase-dot[data-cat="done"] { background: var(--green); }
+html.ui-v2 .ui2-peek-phase-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+html.ui-v2 .ui2-peek-open {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: auto;
+  flex-shrink: 0;
+  padding: 4px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  background: transparent;
+  color: var(--text-3);
+  font-family: var(--sans);
+  font-size: 11px;
+  font-weight: 650;
+  cursor: pointer;
+}
+html.ui-v2 .ui2-peek-open:hover { color: var(--text); background: var(--surface-2); }
+html.ui-v2 .ui2-peek-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--text-3);
+  font-family: var(--sans);
+  cursor: pointer;
+}
+html.ui-v2 .ui2-peek-close:hover { color: var(--text); background: var(--surface-2); }
+
+/* — transcript tail — */
+html.ui-v2 .ui2-peek-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  /* scroll pinning is managed manually, like the other log scrollers */
+  overflow-anchor: none;
+  overscroll-behavior: contain;
+  padding: 6px 12px 9px;
+}
+html.ui-v2 .ui2-peek-empty {
+  padding: 20px 12px 22px;
+  color: var(--text-3);
+  font-size: 12px;
+  text-align: center;
+}
+
+/* — compact entry density —
+   Clones keep the Activity timeline grammar (ui2-activity.css styles
+   .log-entry globally); the peek drops the ts gutter and the host/session
+   badges (identity lives in the peek header) and tightens type. Track
+   list mirrors the base 7-column template with the hidden columns zeroed
+   so the explicit grid-column placements keep landing. */
+html.ui-v2 .ui2-composer-peek .log-entry {
+  grid-template-columns: 0 16px 0 0 max-content 0 minmax(0, 1fr);
+  padding: 3px 0;
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+/* 12.5px × 1.5 line box ≈ 19px; the 6px dot centers at (19−6)/2 ≈ 6px */
+html.ui-v2 .ui2-composer-peek .log-entry .log-icon { margin-top: 6px; }
+html.ui-v2 .ui2-composer-peek .log-entry .log-ts,
+html.ui-v2 .ui2-composer-peek .log-entry .log-host,
+html.ui-v2 .ui2-composer-peek .log-entry .log-session,
+html.ui-v2 .ui2-composer-peek .log-entry .log-anchor-btn,
+html.ui-v2 .ui2-composer-peek .log-entry .log-copy-entry,
+html.ui-v2 .ui2-composer-peek .log-entry .log-edit-message,
+html.ui-v2 .ui2-composer-peek .log-entry .collapse-toggle {
+  display: none;
+}
+html.ui-v2 .ui2-composer-peek .log-entry pre {
+  font-size: 11.5px;
+  padding: 8px 10px;
+}
+
+/* long payloads clamp; the fade appears only on entries that really clip
+   (JS tags .ui2-peek-clamped — CSS cannot see overflow). The blanket
+   content:none also retires v1's side fade on collapsible entries, whose
+   1.5em clamp the max-height below supersedes inside the peek. */
+html.ui-v2 .ui2-composer-peek .log-entry .log-content {
+  position: relative;
+  max-height: 8.5em;
+  overflow: hidden;
+}
+html.ui-v2 .ui2-composer-peek .log-entry:not(.ui2-peek-clamped) .log-content::after { content: none; }
+html.ui-v2 .ui2-composer-peek .log-entry.ui2-peek-clamped .log-content::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: auto;
+  width: auto;
+  height: 1.8em;
+  background: linear-gradient(to bottom, transparent, var(--surface));
+  pointer-events: none;
+}
+html.ui-v2 .ui2-composer-peek .diff-log-entry .diff-log-body {
+  max-height: 8.5em;
+  overflow: hidden;
+}
+
+/* — phones: keep the header one quiet row — */
+@media (max-width: 500px) {
+  html.ui-v2 .ui2-peek-open .ui2-peek-open-label { display: none; }
+  html.ui-v2 .ui2-peek-open { padding: 4px 8px; }
+  html.ui-v2 .ui2-peek-header { padding: 7px 8px 6px 11px; }
 }

--- a/static/app/ui2-composer-peek.js
+++ b/static/app/ui2-composer-peek.js
@@ -1,7 +1,430 @@
-// ── composer conversation peek (seam stub — filled by the peek track) ──
-// Contract: render the prompt-target session's transcript tail into
-// #ui2-composer-peek (mounted as the dock's first child; skeleton
-// anchoring in ui2-composer-peek.css), live-following the same entries
-// the session window shows, with tap-through to the Activity window.
+// ── composer conversation peek ─────────────────────────────────────────
+// A transient sheet floating above the dock: the prompt-target session's
+// transcript tail, live, with tap-through to the full Activity view. The
+// peek is a read-only mirror — entries are clones of the target window's
+// log (the appendLogEntryToSessionWindow precedent: cloneNode + strip
+// ids), so it never mutates session state; interactive affordances that
+// need the live wiring (collapse, copy, retry) are hidden by the peek
+// stylesheet in favor of "Open in Activity".
 // Boot follows the ui2-chrome single-boot idiom; every entry point is a
 // no-op when the mount is missing so a stub build stays inert.
+{
+  const PEEK_TAIL_CAP = 12;
+  const PEEK_RENDER_THROTTLE_MS = 120;
+  // Chrome's phase categories that mean "the agent is answering" — the
+  // auto-open signal. `waiting` is excluded: approvals/questions already
+  // have their own attention surfaces.
+  const PEEK_WORKING_CATS = new Set(['thinking', 'running']);
+
+  let peekBarEl = null;
+  let peekRoot = null;
+  let peekList = null;
+  let peekBadge = null;
+  let peekPhaseDot = null;
+  let peekPhaseText = null;
+
+  let peekBoundSid = '';
+  let peekBoundLog = null;
+  let peekRendered = []; // [{ source, clone }] in list order
+  let peekFollow = true;
+  // Explicit close suppresses auto-open until the working streak ends or
+  // the target changes — otherwise the next phase mutation would fight
+  // the user's dismissal.
+  let peekDismissed = false;
+  let peekLastTarget = '';
+  let peekLastPhaseCat = null;
+  let peekFlushTimer = 0;
+  let peekPendingStructural = false;
+  const peekPendingDirty = new Set();
+
+  function peekIsOpen() {
+    return !!peekRoot && !peekRoot.hidden;
+  }
+
+  function peekComposerPill() {
+    return document.documentElement.dataset.composerState === 'pill';
+  }
+
+  function peekTargetSid() {
+    return typeof resolvePromptTargetSessionId === 'function'
+      ? (resolvePromptTargetSessionId() || '') : '';
+  }
+
+  function peekTargetWindow(sid) {
+    return (sid && typeof sessionWindows !== 'undefined')
+      ? (sessionWindows.get(sid) || null) : null;
+  }
+
+  function peekCloneEntry(source) {
+    const clone = source.cloneNode(true);
+    clone.removeAttribute('id');
+    clone.querySelectorAll('[id]').forEach(el => el.removeAttribute('id'));
+    return clone;
+  }
+
+  function peekTailSources() {
+    if (!peekBoundLog) return [];
+    const out = [];
+    for (let node = peekBoundLog.lastElementChild; node && out.length < PEEK_TAIL_CAP; node = node.previousElementSibling) {
+      if (node.classList.contains('session-window-empty')) continue;
+      out.push(node);
+    }
+    return out.reverse();
+  }
+
+  function peekEmptyText() {
+    if (!peekBoundLog) return 'No transcript yet — send a message below.';
+    const ph = peekBoundLog.querySelector('.session-window-empty');
+    if (ph && ph.classList.contains('session-window-empty-loading')) return 'Loading transcript…';
+    if (ph && ph.classList.contains('session-window-empty-error')) return 'Transcript failed to load — open Activity to retry.';
+    return 'No output yet';
+  }
+
+  // CSS cannot see overflow: entries whose body actually clips get the
+  // fade tag; short ones keep their last line un-washed.
+  function peekTagClamped(clone) {
+    const content = clone.querySelector('.log-content');
+    if (content && content.scrollHeight > content.clientHeight + 1) {
+      clone.classList.add('ui2-peek-clamped');
+    }
+  }
+
+  function peekRenderTail() {
+    if (!peekList || !peekIsOpen()) return;
+    const sources = peekTailSources();
+    if (sources.length === 0) {
+      peekRendered = [];
+      peekPendingDirty.clear();
+      const empty = document.createElement('div');
+      empty.className = 'ui2-peek-empty';
+      empty.textContent = peekEmptyText();
+      peekList.replaceChildren(empty);
+      return;
+    }
+    const prev = new Map(peekRendered.map(r => [r.source, r]));
+    const next = [];
+    const fresh = [];
+    for (const source of sources) {
+      const kept = prev.get(source);
+      if (kept && !peekPendingDirty.has(source)) {
+        next.push(kept);
+        continue;
+      }
+      const clone = peekCloneEntry(source);
+      next.push({ source, clone });
+      fresh.push(clone);
+    }
+    peekRendered = next;
+    // Surgical reconcile instead of replaceChildren: kept nodes never
+    // leave the DOM, so the aria-live list announces genuinely new
+    // entries instead of re-reading the whole tail on every append.
+    const keep = new Set(next.map(r => r.clone));
+    for (let child = peekList.firstElementChild; child;) {
+      const drop = child;
+      child = child.nextElementSibling;
+      if (!keep.has(drop)) drop.remove();
+    }
+    let cursor = peekList.firstElementChild;
+    for (const r of next) {
+      if (r.clone === cursor) cursor = cursor.nextElementSibling;
+      else peekList.insertBefore(r.clone, cursor);
+    }
+    for (const clone of fresh) peekTagClamped(clone);
+    peekPendingDirty.clear();
+    if (peekFollow) peekList.scrollTop = peekList.scrollHeight;
+  }
+
+  function peekFlush() {
+    peekFlushTimer = 0;
+    if (!peekIsOpen()) {
+      peekPendingStructural = false;
+      peekPendingDirty.clear();
+      return;
+    }
+    if (peekPendingStructural) {
+      peekPendingStructural = false;
+      peekRenderTail();
+      return;
+    }
+    if (peekPendingDirty.size === 0) return;
+    let touched = false;
+    for (const r of peekRendered) {
+      if (!peekPendingDirty.has(r.source)) continue;
+      const clone = peekCloneEntry(r.source);
+      r.clone.replaceWith(clone);
+      r.clone = clone;
+      peekTagClamped(clone);
+      touched = true;
+    }
+    peekPendingDirty.clear();
+    if (touched && peekFollow) peekList.scrollTop = peekList.scrollHeight;
+  }
+
+  function peekSchedule() {
+    if (peekFlushTimer || !peekIsOpen()) return;
+    peekFlushTimer = setTimeout(peekFlush, PEEK_RENDER_THROTTLE_MS);
+  }
+
+  // Command-output groups and edit/superseded markers mutate entries in
+  // place (no childList change on the log), so the observer watches the
+  // subtree and patches just the touched entries; only additions/removals
+  // on the log itself re-render the tail.
+  const peekLogObserver = new MutationObserver(records => {
+    for (const record of records) {
+      if (record.target === peekBoundLog) {
+        if (record.type === 'childList') peekPendingStructural = true;
+        continue;
+      }
+      let node = record.target;
+      while (node && node.parentNode !== peekBoundLog) node = node.parentNode;
+      if (node) peekPendingDirty.add(node);
+    }
+    if (peekPendingStructural || peekPendingDirty.size) peekSchedule();
+  });
+
+  function peekBind(sid) {
+    if (peekBadge) {
+      peekBadge.hidden = !sid;
+      if (typeof renderSessionIdentity === 'function') {
+        renderSessionIdentity(peekBadge, sid, { order: 'name-id', titlePrefix: 'Prompt target' });
+      }
+      if (typeof applySessionBadgeStyle === 'function') applySessionBadgeStyle(peekBadge, sid);
+    }
+    const win = peekTargetWindow(sid);
+    const log = win ? win.log : null;
+    if (sid === peekBoundSid && log === peekBoundLog) return;
+    peekLogObserver.disconnect();
+    peekBoundSid = sid;
+    peekBoundLog = log;
+    peekRendered = [];
+    peekPendingDirty.clear();
+    peekPendingStructural = false;
+    if (peekBoundLog) {
+      peekLogObserver.observe(peekBoundLog, {
+        childList: true, subtree: true, characterData: true, attributes: true,
+      });
+      if (typeof hydrateSessionWindowIfEmpty === 'function') {
+        Promise.resolve(hydrateSessionWindowIfEmpty(sid)).catch(() => {}).finally(() => {
+          if (peekBoundSid === sid) peekRenderTail();
+        });
+      }
+    }
+    peekRenderTail();
+  }
+
+  function peekOpen() {
+    if (!peekRoot || peekIsOpen() || peekComposerPill()) return;
+    const sid = peekTargetSid();
+    if (!sid) return;
+    peekFollow = true;
+    peekRoot.hidden = false;
+    peekBind(sid);
+    peekRenderTail();
+  }
+
+  function peekClose(dismissed) {
+    if (!peekRoot || peekRoot.hidden) return;
+    peekRoot.hidden = true;
+    if (dismissed) peekDismissed = true;
+    peekLogObserver.disconnect();
+    peekBoundSid = '';
+    peekBoundLog = null;
+    peekRendered = [];
+    peekPendingDirty.clear();
+    peekPendingStructural = false;
+    if (peekFlushTimer) {
+      clearTimeout(peekFlushTimer);
+      peekFlushTimer = 0;
+    }
+    if (peekList) peekList.replaceChildren();
+  }
+
+  function peekOpenInActivity() {
+    peekClose(false);
+    if (typeof routeTo === 'function') routeTo('activity', 'log');
+    if (typeof window.focusForegroundSessionWindow === 'function') {
+      window.focusForegroundSessionWindow();
+    }
+  }
+
+  function peekOnTargetChip() {
+    const sid = peekTargetSid();
+    if (sid !== peekLastTarget) {
+      peekLastTarget = sid;
+      peekDismissed = false;
+    }
+    if (!sid) {
+      peekClose(false);
+      return;
+    }
+    if (peekIsOpen()) {
+      peekBind(sid);
+      return;
+    }
+    // A target materializing mid-turn is the first-message case: the send
+    // happened before any session existed, so the phase edge fired with
+    // nothing to show — open now that there is a transcript to watch.
+    if (PEEK_WORKING_CATS.has(peekLastPhaseCat) && !peekDismissed && !peekComposerPill()) {
+      peekOpen();
+    }
+  }
+
+  function peekOnPhase(banner) {
+    const cat = typeof ui2PhaseCategory === 'function'
+      ? ui2PhaseCategory(banner.className) : 'idle';
+    const label = document.getElementById('phase-text');
+    if (peekPhaseDot) peekPhaseDot.dataset.cat = cat;
+    if (peekPhaseText) {
+      peekPhaseText.textContent = ((label && label.textContent) || 'Idle').trim() || 'Idle';
+    }
+    const wasWorking = PEEK_WORKING_CATS.has(peekLastPhaseCat);
+    const isWorking = PEEK_WORKING_CATS.has(cat);
+    peekLastPhaseCat = cat;
+    if (!isWorking) {
+      if (wasWorking) peekDismissed = false;
+      return;
+    }
+    if (wasWorking || peekDismissed || peekIsOpen() || peekComposerPill()) return;
+    peekOpen();
+  }
+
+  function peekBuild(root) {
+    const icon = (name, size) => (typeof ui2Icon === 'function' ? ui2Icon(name, size) : '');
+    root.setAttribute('role', 'region');
+    root.setAttribute('aria-label', 'Conversation peek');
+
+    const header = document.createElement('div');
+    header.className = 'ui2-peek-header';
+    header.title = 'Open the full transcript in Activity';
+
+    peekBadge = document.createElement('span');
+    peekBadge.className = 'ui2-peek-target task-target-session-badge';
+    peekBadge.hidden = true;
+
+    const phase = document.createElement('span');
+    phase.className = 'ui2-peek-phase';
+    peekPhaseDot = document.createElement('span');
+    peekPhaseDot.className = 'ui2-peek-phase-dot';
+    peekPhaseDot.dataset.cat = 'idle';
+    peekPhaseText = document.createElement('span');
+    peekPhaseText.className = 'ui2-peek-phase-text';
+    peekPhaseText.textContent = 'Idle';
+    phase.appendChild(peekPhaseDot);
+    phase.appendChild(peekPhaseText);
+
+    const openBtn = document.createElement('button');
+    openBtn.type = 'button';
+    openBtn.className = 'ui2-peek-open';
+    openBtn.title = 'Open the full transcript in Activity';
+    openBtn.setAttribute('aria-label', 'Open in Activity');
+    openBtn.innerHTML = icon('external', 12) + '<span class="ui2-peek-open-label">Open in Activity</span>';
+
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.className = 'ui2-peek-close';
+    closeBtn.title = 'Close conversation peek';
+    closeBtn.setAttribute('aria-label', 'Close conversation peek');
+    closeBtn.innerHTML = icon('close', 14);
+
+    header.appendChild(peekBadge);
+    header.appendChild(phase);
+    header.appendChild(openBtn);
+    header.appendChild(closeBtn);
+
+    peekList = document.createElement('div');
+    peekList.className = 'ui2-peek-list';
+    peekList.setAttribute('role', 'log');
+    peekList.setAttribute('aria-live', 'polite');
+    peekList.setAttribute('aria-label', 'Recent transcript');
+
+    root.appendChild(header);
+    root.appendChild(peekList);
+
+    header.addEventListener('click', (e) => {
+      if (e.target.closest && e.target.closest('button')) return;
+      peekOpenInActivity();
+    });
+    openBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      peekOpenInActivity();
+    });
+    closeBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      peekClose(true);
+      const input = document.getElementById('activity-task-input');
+      if (input) input.focus({ preventScroll: true });
+    });
+    peekList.addEventListener('scroll', () => {
+      peekFollow = peekList.scrollTop + peekList.clientHeight >= peekList.scrollHeight - 24;
+    });
+  }
+
+  const peekWire = () => {
+    const root = document.getElementById('ui2-composer-peek');
+    const bar = root ? root.closest('.global-task-bar') : null;
+    if (!root || !bar) return;
+    peekRoot = root;
+    peekBarEl = bar;
+    peekBuild(root);
+
+    bar.addEventListener('focusin', (e) => {
+      if (peekIsOpen() || peekComposerPill()) return;
+      // Focus moving WITHIN the dock (input → Send, the close button's
+      // refocus) is not an entry — reopening there would undo an Esc/×
+      // dismissal the user just made.
+      if (e.relatedTarget instanceof Node && bar.contains(e.relatedTarget)) return;
+      peekDismissed = false;
+      peekOpen();
+    });
+
+    // Window-level capture instead of bar-level: capture descends
+    // window → bar, so this preempts the composer state machine's
+    // Esc-to-pill regardless of listener registration order — one Esc
+    // closes the peek, the next one reaches the dock.
+    window.addEventListener('keydown', (e) => {
+      if (e.key !== 'Escape' || !peekIsOpen()) return;
+      if (e.target instanceof Node && peekBarEl.contains(e.target)) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        peekClose(true);
+        return;
+      }
+      peekClose(true);
+    }, true);
+
+    document.addEventListener('pointerdown', (e) => {
+      if (!peekIsOpen()) return;
+      if (e.target instanceof Node && peekBarEl.contains(e.target)) return;
+      peekClose(true);
+    }, true);
+
+    window.addEventListener('ui2:composer-state', (e) => {
+      if (((e && e.detail && e.detail.state) || '') === 'pill') peekClose(false);
+    });
+
+    if (typeof ui2Mirror === 'function') {
+      ui2Mirror('task-target-chip', peekOnTargetChip);
+      ui2Mirror('phase-banner', peekOnPhase);
+    }
+
+    // A cold target may grow its window only later (ensureSessionWindow
+    // on the first live event) — rebind when the grid gains it.
+    const grid = document.getElementById('session-window-grid');
+    if (grid) {
+      new MutationObserver(() => {
+        if (!peekIsOpen() || !peekBoundSid) return;
+        const win = peekTargetWindow(peekBoundSid);
+        if (win && win.log !== peekBoundLog) peekBind(peekBoundSid);
+      }).observe(grid, { childList: true });
+    }
+
+    window.__ui2Peek = {
+      isOpen: peekIsOpen,
+      open: peekOpen,
+      close: () => peekClose(true),
+      sessionId: () => peekBoundSid,
+    };
+  };
+  if (document.readyState === 'complete') peekWire();
+  else document.addEventListener('DOMContentLoaded', peekWire, { once: true });
+}

--- a/static/app/ui2-composer-peek.js
+++ b/static/app/ui2-composer-peek.js
@@ -1,0 +1,7 @@
+// ── composer conversation peek (seam stub — filled by the peek track) ──
+// Contract: render the prompt-target session's transcript tail into
+// #ui2-composer-peek (mounted as the dock's first child; skeleton
+// anchoring in ui2-composer-peek.css), live-following the same entries
+// the session window shows, with tap-through to the Activity window.
+// Boot follows the ui2-chrome single-boot idiom; every entry point is a
+// no-op when the mount is missing so a stub build stays inert.

--- a/static/app/ui2-composer-peek.js
+++ b/static/app/ui2-composer-peek.js
@@ -264,6 +264,9 @@
     // A target materializing mid-turn is the first-message case: the send
     // happened before any session existed, so the phase edge fired with
     // nothing to show — open now that there is a transcript to watch.
+    // Same replay guard as the phase edge: rebinds driven by bootstrap
+    // replay are history, not a turn in flight.
+    if (typeof processingLogReplay !== 'undefined' && processingLogReplay) return;
     if (PEEK_WORKING_CATS.has(peekLastPhaseCat) && !peekDismissed && !peekComposerPill()) {
       peekOpen();
     }
@@ -285,6 +288,10 @@
       return;
     }
     if (wasWorking || peekDismissed || peekIsOpen() || peekComposerPill()) return;
+    // Bootstrap replay re-drives historical phase edges through the
+    // mirror — auto-opening on those would pop the peek on every page
+    // load of a dashboard with any past task.
+    if (typeof processingLogReplay !== 'undefined' && processingLogReplay) return;
     peekOpen();
   }
 
@@ -359,6 +366,12 @@
     });
   }
 
+  // Boot autofocus (and any other programmatic focus before the user has
+  // touched the page) must not open the peek — a sheet popping over the
+  // content on every load of a dashboard with history is a surprise, not
+  // an affordance. Focus counts as intent only after a real gesture.
+  let peekSawUserGesture = false;
+
   const peekWire = () => {
     const root = document.getElementById('ui2-composer-peek');
     const bar = root ? root.closest('.global-task-bar') : null;
@@ -367,12 +380,24 @@
     peekBarEl = bar;
     peekBuild(root);
 
+    document.addEventListener('pointerdown', () => { peekSawUserGesture = true; }, { capture: true, passive: true });
+    document.addEventListener('keydown', () => { peekSawUserGesture = true; }, { capture: true });
+
     bar.addEventListener('focusin', (e) => {
+      if (!peekSawUserGesture) return;
       if (peekIsOpen() || peekComposerPill()) return;
       // Focus moving WITHIN the dock (input → Send, the close button's
       // refocus) is not an entry — reopening there would undo an Esc/×
       // dismissal the user just made.
       if (e.relatedTarget instanceof Node && bar.contains(e.relatedTarget)) return;
+      // Focus landing on the target-switch chrome is retargeting intent,
+      // not composition — opening the peek under that popover just stacks
+      // two overlays (and made Esc close the hidden one first).
+      const tsw = document.getElementById('ui2-target-switch');
+      if (e.target instanceof Node && (
+        (tsw && tsw.contains(e.target)) ||
+        (e.target.id === 'task-target-switch-btn')
+      )) return;
       peekDismissed = false;
       peekOpen();
     });
@@ -383,6 +408,11 @@
     // closes the peek, the next one reaches the dock.
     window.addEventListener('keydown', (e) => {
       if (e.key !== 'Escape' || !peekIsOpen()) return;
+      // Onion ordering: the target-switch popover is the innermost open
+      // surface — its own Esc handling closes it; consuming here would
+      // close the peek hidden BEHIND the popover instead.
+      const tsw = document.getElementById('ui2-target-switch');
+      if (tsw && !tsw.hidden) return;
       if (e.target instanceof Node && peekBarEl.contains(e.target)) {
         e.preventDefault();
         e.stopImmediatePropagation();

--- a/static/app/ui2-target-switch.css
+++ b/static/app/ui2-target-switch.css
@@ -1,12 +1,241 @@
-/* ── composer target hot-swap (skeleton contract) ───────────────────────
-   Filled by the target-switch track. Popover anchors to the dock card
-   (absolute child of the fixed bar) and opens UPWARD; it must not add to
-   the bar's measured height (see the peek skeleton note — same rule). */
+/* ── composer target hot-swap ───────────────────────────────────────────
+   Popover anchors to the dock card (absolute child of the fixed bar) and
+   opens UPWARD; position:absolute in every state so it never adds to the
+   bar's measured height — the #app reservation follows --ui2-composer-h,
+   the bar box alone (see the peek skeleton note — same rule). */
+
+/* trigger: revealed by ui2-target-switch.js (inline display cleared) */
+html.ui-v2 .task-target-switch-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  flex-shrink: 0;
+  border: 1px solid var(--line);
+  border-radius: var(--r-ctl);
+  background: transparent;
+  color: var(--text-3);
+  font-family: var(--sans); /* buttons don't inherit */
+  font-size: 11px;
+  line-height: 1;
+  cursor: pointer;
+  transition: color var(--t-fast), background var(--t-fast),
+    border-color var(--t-fast), transform var(--t-fast);
+}
+html.ui-v2 .task-target-switch-btn:hover {
+  color: var(--text);
+  background: var(--surface-2);
+}
+html.ui-v2 .task-target-switch-btn:focus-visible {
+  outline: 2px solid var(--iris);
+  outline-offset: 1px;
+}
+/* open: iris tint + the caret flips toward the popover above (the button
+   box is a symmetric square, so rotating the whole control is safe) */
+html.ui-v2 .task-target-switch-btn[aria-expanded="true"] {
+  color: var(--iris-2);
+  border-color: rgba(var(--iris-rgb), .4);
+  background: rgba(var(--iris-rgb), .09);
+  transform: rotate(180deg);
+}
+
 html.ui-v2 .ui2-target-switch {
   position: absolute;
   bottom: 100%;
   right: 0;
   margin-bottom: 10px;
   min-width: 260px;
-  max-width: min(420px, 100%);
+  width: max-content;
+  max-width: min(420px, calc(100vw - 24px));
+  z-index: 3; /* above the peek, its z:auto anchor-mate on the same card */
+  display: flex;
+  flex-direction: column;
+  padding: 6px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--surface);
+  box-shadow: var(--shadow-card);
+  animation: ui2-tsw-in var(--t-med) ease-out;
+}
+html.ui-v2 .ui2-target-switch[hidden] { display: none; }
+@keyframes ui2-tsw-in {
+  from { opacity: 0; transform: translateY(5px); }
+}
+
+html.ui-v2 .ui2-tsw-eyebrow {
+  padding: 7px 12px 4px;
+  font-family: var(--mono);
+  font-size: var(--eyebrow-size);
+  font-weight: 700;
+  letter-spacing: var(--eyebrow-track);
+  text-transform: uppercase;
+  color: var(--text-3);
+  user-select: none;
+}
+
+html.ui-v2 .ui2-tsw-filter {
+  margin: 2px 6px 6px;
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-ctl);
+  background: var(--bg-1);
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 12.5px;
+  outline: none;
+}
+html.ui-v2 .ui2-tsw-filter::placeholder { color: var(--text-3); }
+html.ui-v2 .ui2-tsw-filter:focus {
+  border-color: rgba(var(--iris-rgb), .45);
+  box-shadow: 0 0 0 3px rgba(var(--iris-rgb), .18);
+}
+
+html.ui-v2 .ui2-tsw-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 2px;
+  overflow-y: auto;
+  max-height: min(50vh, 420px);
+  max-height: min(50dvh, 420px);
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+}
+
+html.ui-v2 .ui2-tsw-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 34px;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: var(--r-ctl);
+  background: transparent;
+  color: var(--text-2);
+  font-family: var(--sans); /* buttons don't inherit */
+  font-size: 12.5px;
+  font-weight: 550;
+  text-align: left;
+  cursor: pointer;
+}
+html.ui-v2 .ui2-tsw-row:hover {
+  background: var(--hover-wash);
+  color: var(--text);
+}
+html.ui-v2 .ui2-tsw-row:focus-visible {
+  outline: 2px solid var(--iris);
+  outline-offset: -2px;
+}
+html.ui-v2 .ui2-tsw-row[aria-selected="true"] {
+  color: var(--text);
+  background: rgba(var(--iris-rgb), .08);
+}
+html.ui-v2 .ui2-tsw-row[aria-selected="true"]::after {
+  content: "✓";
+  margin-left: 4px;
+  color: var(--iris-2);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+html.ui-v2 .ui2-tsw-row-main {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  flex: 1;
+  min-width: 0;
+}
+html.ui-v2 .ui2-tsw-row-label { font-weight: 650; }
+html.ui-v2 .ui2-tsw-row-sub {
+  color: var(--text-3);
+  font-size: 11px;
+  font-weight: 450;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+html.ui-v2 .ui2-tsw-row-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+html.ui-v2 .ui2-tsw-badge {
+  flex-shrink: 0;
+  max-width: 96px;
+  padding: 2px 7px;
+  border: 1px solid var(--session-badge-border, rgba(var(--iris-rgb), .35));
+  border-radius: 5px;
+  background: var(--session-badge-bg, rgba(var(--iris-rgb), .08));
+  color: var(--session-badge-fg, var(--iris-2));
+  font-family: var(--mono);
+  font-size: 10.5px;
+  font-weight: 650;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* light theme: applySessionBadgeStyle mints dark-theme pastels — re-derive
+   toward ink while keeping each session's hue (same formula as the chip's
+   light rule in ui2-activity.css, which doesn't cover this class) */
+html.ui-v2[data-theme="light"] .ui2-tsw-badge {
+  color: color-mix(in srgb, var(--session-badge-fg, var(--text-2)) 34%, var(--text));
+  border-color: color-mix(in srgb, var(--session-badge-border, var(--line-2)) 55%, var(--line-2));
+}
+
+html.ui-v2 .ui2-tsw-dot {
+  flex-shrink: 0;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--neutral-dot);
+  opacity: .55;
+}
+html.ui-v2 .ui2-tsw-dot.active {
+  background: var(--green);
+  opacity: 1;
+  animation: ui2-tsw-pulse 2s ease-in-out infinite;
+}
+html.ui-v2 .ui2-tsw-dot.waiting {
+  background: var(--amber);
+  opacity: 1;
+}
+@keyframes ui2-tsw-pulse {
+  50% { opacity: .45; }
+}
+
+html.ui-v2 .ui2-tsw-empty {
+  padding: 14px 12px;
+  color: var(--text-3);
+  font-size: 12px;
+  text-align: center;
+}
+
+html.ui-v2 .ui2-tsw-foot {
+  margin-top: 4px;
+  padding: 4px 2px 0;
+  border-top: 1px solid var(--line);
+}
+html.ui-v2 .ui2-tsw-foot .ui2-tsw-row { color: var(--text-3); }
+html.ui-v2 .ui2-tsw-foot .ui2-tsw-row:hover { color: var(--text); }
+
+/* touch targets (brief: rows ≥44px at ≤820px); 16px input font keeps
+   iOS Safari from zooming the page on focus */
+@media (max-width: 820px) {
+  html.ui-v2 .ui2-tsw-row { min-height: 44px; }
+  html.ui-v2 .ui2-tsw-filter {
+    min-height: 40px;
+    font-size: 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.ui-v2 .ui2-target-switch { animation: none; }
+  html.ui-v2 .ui2-tsw-dot.active { animation: none; }
+  html.ui-v2 .task-target-switch-btn { transition: none; }
 }

--- a/static/app/ui2-target-switch.css
+++ b/static/app/ui2-target-switch.css
@@ -1,0 +1,12 @@
+/* ── composer target hot-swap (skeleton contract) ───────────────────────
+   Filled by the target-switch track. Popover anchors to the dock card
+   (absolute child of the fixed bar) and opens UPWARD; it must not add to
+   the bar's measured height (see the peek skeleton note — same rule). */
+html.ui-v2 .ui2-target-switch {
+  position: absolute;
+  bottom: 100%;
+  right: 0;
+  margin-bottom: 10px;
+  min-width: 260px;
+  max-width: min(420px, 100%);
+}

--- a/static/app/ui2-target-switch.js
+++ b/static/app/ui2-target-switch.js
@@ -1,0 +1,7 @@
+// ── composer target hot-swap (seam stub — filled by the switch track) ──
+// Contract: reveal + wire #task-target-switch-btn (next to the target
+// chip) and fill #ui2-target-switch with the targetable-session listbox.
+// Selecting a session retargets the composer IN PLACE (focusSessionWindow
+// — it does not switch tabs); listing is gated exactly like the resolver
+// (isPromptTargetSessionUsable). Boot follows the ui2-chrome single-boot
+// idiom; every entry point is a no-op when the mounts are missing.

--- a/static/app/ui2-target-switch.js
+++ b/static/app/ui2-target-switch.js
@@ -1,7 +1,349 @@
-// ── composer target hot-swap (seam stub — filled by the switch track) ──
-// Contract: reveal + wire #task-target-switch-btn (next to the target
-// chip) and fill #ui2-target-switch with the targetable-session listbox.
-// Selecting a session retargets the composer IN PLACE (focusSessionWindow
-// — it does not switch tabs); listing is gated exactly like the resolver
-// (isPromptTargetSessionUsable). Boot follows the ui2-chrome single-boot
-// idiom; every entry point is a no-op when the mounts are missing.
+// ── composer target hot-swap ───────────────────────────────────────────
+// In-place prompt-target switcher for the dock: #task-target-switch-btn
+// toggles a listbox of exactly the sessions the resolver may target
+// (isPromptTargetSessionUsable), plus "Auto" (hand the pick back to the
+// resolver) and "New session…". Selecting retargets via focusSessionWindow
+// — the whole point is that it never leaves the current tab (no route
+// change, no scroll; the chip's own click stays the jump-to-Activity
+// affordance). IIFE: fragments share one script scope and nothing here is
+// consumed by other fragments.
+(() => {
+  const FILTER_AT = 6;   // more rows than this → show the type-to-filter input
+  const POLL_MS = 800;   // open-state refresh: sessions come and go
+
+  let btnEl = null;
+  let popEl = null;
+  let filterEl = null;
+  let rowsEl = null;
+  let isOpen = false;
+  let pollTimer = 0;
+  let filterQuery = '';
+  let lastSig = '';
+
+  const composerPill = () =>
+    document.documentElement.dataset.composerState === 'pill';
+
+  function usableSessionIds() {
+    const ids = [];
+    for (const sid of sessionWindows.keys()) {
+      if (isPromptTargetSessionUsable(sid)) ids.push(sid);
+    }
+    return ids;
+  }
+
+  function rowPhase(sid) {
+    if (hasPendingActiveSessionWindow(sid)) return 'active';
+    const win = sessionWindows.get(sid);
+    return sessionPhaseClass(win?.phase || 'idle') || 'done';
+  }
+
+  // Everything a rendered listing depends on; the open-state poll re-renders
+  // only when this changes (a vanished session, a phase flip, a rename, a
+  // target rebind elsewhere).
+  function currentSignature() {
+    const parts = [
+      resolvePromptTargetSessionId(),
+      explicitForegroundSessionId() ? 'E' : 'A',
+      filterQuery,
+    ];
+    for (const sid of usableSessionIds()) {
+      parts.push(sid, sessionIdentityParts(sid).name, rowPhase(sid));
+    }
+    return parts.join('\u0000');
+  }
+
+  const navRows = () => Array.from(popEl.querySelectorAll('.ui2-tsw-row'));
+
+  function makeRow(key, cls) {
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = cls ? `ui2-tsw-row ${cls}` : 'ui2-tsw-row';
+    row.setAttribute('role', 'option');
+    row.setAttribute('aria-selected', 'false');
+    row.tabIndex = -1;
+    row.dataset.key = key;
+    return row;
+  }
+
+  function buildAutoRow(active) {
+    const row = makeRow('auto', 'ui2-tsw-auto');
+    const main = document.createElement('span');
+    main.className = 'ui2-tsw-row-main';
+    const label = document.createElement('span');
+    label.className = 'ui2-tsw-row-label';
+    label.textContent = 'Auto';
+    const sub = document.createElement('span');
+    sub.className = 'ui2-tsw-row-sub';
+    sub.textContent = 'picks the active session';
+    main.append(label, sub);
+    row.appendChild(main);
+    row.title = 'Let Intendant pick the prompt target';
+    row.setAttribute('aria-label', 'Auto: pick the prompt target for me');
+    if (active) row.setAttribute('aria-selected', 'true');
+    return row;
+  }
+
+  function buildSessionRow(sid, target) {
+    const row = makeRow(`s:${sid}`);
+    const badge = document.createElement('span');
+    badge.className = 'ui2-tsw-badge';
+    renderSessionIdentity(badge, sid, { showName: false });
+    applySessionBadgeStyle(badge, sid);
+    const name = sessionIdentityParts(sid).name;
+    const nameEl = document.createElement('span');
+    nameEl.className = 'ui2-tsw-row-name';
+    nameEl.textContent = name;
+    const phase = rowPhase(sid);
+    const dot = document.createElement('span');
+    dot.className = `ui2-tsw-dot ${phase}`;
+    dot.setAttribute('aria-hidden', 'true');
+    row.append(badge, nameEl, dot);
+    row.title = name ? `${name} · ${sid}` : sid;
+    const phaseWord = phase === 'active' ? 'running' : phase === 'waiting' ? 'waiting' : 'idle';
+    row.setAttribute('aria-label', `${name || shortSessionId(sid)} · ${phaseWord}`);
+    if (sid === target) row.setAttribute('aria-selected', 'true');
+    return row;
+  }
+
+  function buildEmpty(text) {
+    const el = document.createElement('div');
+    el.className = 'ui2-tsw-empty';
+    el.textContent = text;
+    return el;
+  }
+
+  function renderRows() {
+    const usable = usableSessionIds();
+    const target = resolvePromptTargetSessionId();
+    const autoActive = !explicitForegroundSessionId();
+    filterEl.hidden = !(usable.length > FILTER_AT || filterQuery.trim() !== '');
+
+    const active = document.activeElement;
+    const prevKey = popEl.contains(active) && active !== filterEl
+      ? active.dataset?.key || ''
+      : '';
+
+    let list = usable;
+    const q = filterQuery.trim();
+    if (q) {
+      list = usable
+        .map(sid => ({
+          sid,
+          score: Math.max(
+            ui2FuzzyScore(q, sessionIdentityParts(sid).name),
+            ui2FuzzyScore(q, sid),
+          ),
+        }))
+        .filter(x => x.score >= 0)
+        .sort((a, b) => b.score - a.score)
+        .map(x => x.sid);
+    }
+
+    const children = [];
+    if (usable.length) children.push(buildAutoRow(autoActive));
+    for (const sid of list) children.push(buildSessionRow(sid, target));
+    if (!usable.length) children.push(buildEmpty('No targetable sessions'));
+    else if (!list.length) children.push(buildEmpty('No matches'));
+    rowsEl.replaceChildren(...children);
+    lastSig = currentSignature();
+
+    // A refresh can remove the focused row — land on the survivor with the
+    // same key, else the first row, so the keyboard flow never dies.
+    if (prevKey) {
+      const again = navRows().find(r => r.dataset.key === prevKey);
+      (again || navRows()[0])?.focus();
+    }
+  }
+
+  function openPopover() {
+    if (isOpen || composerPill()) return;
+    filterQuery = '';
+    filterEl.value = '';
+    isOpen = true;
+    renderRows();
+    popEl.hidden = false;
+    btnEl.setAttribute('aria-expanded', 'true');
+    const first = popEl.querySelector('.ui2-tsw-row[aria-selected="true"]') || navRows()[0];
+    if (first) {
+      first.focus();
+      first.scrollIntoView({ block: 'nearest' });
+    }
+    document.addEventListener('pointerdown', onDocPointerDown, true);
+    pollTimer = setInterval(pollRefresh, POLL_MS);
+  }
+
+  function closePopover(opts = {}) {
+    if (!isOpen) return;
+    isOpen = false;
+    popEl.hidden = true;
+    btnEl.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('pointerdown', onDocPointerDown, true);
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = 0;
+    }
+    if (opts.refocus) btnEl.focus();
+  }
+
+  function pollRefresh() {
+    if (composerPill()) {
+      closePopover();
+      return;
+    }
+    if (currentSignature() !== lastSig) renderRows();
+  }
+
+  function onDocPointerDown(e) {
+    if (popEl.contains(e.target) || btnEl.contains(e.target)) return;
+    closePopover();
+  }
+
+  function activateRow(key) {
+    if (key === 'auto') {
+      // The explicit pick lives in two refs (foreground + current), possibly
+      // holding different ids — discard until the explicit lane is empty so
+      // the resolver takes over.
+      for (let i = 0; i < 4 && explicitForegroundSessionId(); i++) {
+        discardPromptTargetReference(explicitForegroundSessionId());
+      }
+      updateTaskTargetChip();
+      closePopover({ refocus: true });
+    } else if (key === 'new') {
+      // Close without refocus: openNewSessionFromPrompt focuses the
+      // new-session input on the next frame and must win.
+      openNewSessionFromPrompt();
+      closePopover();
+    } else if (key.startsWith('s:')) {
+      const sid = key.slice(2);
+      if (!isPromptTargetSessionUsable(sid)) {
+        renderRows();
+        return;
+      }
+      focusSessionWindow(sid);
+      closePopover({ refocus: true });
+    }
+  }
+
+  function onPopKeydown(e) {
+    const inFilter = e.target === filterEl;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      closePopover({ refocus: true });
+      return;
+    }
+    if (e.key === 'Tab') {
+      // Close and hand focus back to the button so the default Tab
+      // continues from the composer instead of a removed row.
+      closePopover({ refocus: true });
+      return;
+    }
+    const rows = navRows();
+    if (!rows.length) return;
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      e.stopPropagation();
+      const idx = rows.indexOf(document.activeElement);
+      if (inFilter) {
+        (e.key === 'ArrowDown' ? rows[0] : rows[rows.length - 1]).focus();
+      } else if (e.key === 'ArrowUp' && idx === 0 && !filterEl.hidden) {
+        filterEl.focus();
+      } else {
+        const next = e.key === 'ArrowDown'
+          ? Math.min(rows.length - 1, idx + 1)
+          : Math.max(0, idx - 1);
+        rows[next].focus();
+      }
+      document.activeElement?.scrollIntoView?.({ block: 'nearest' });
+      return;
+    }
+    if ((e.key === 'Home' || e.key === 'End') && !inFilter) {
+      e.preventDefault();
+      e.stopPropagation();
+      (e.key === 'Home' ? rows[0] : rows[rows.length - 1]).focus();
+      document.activeElement?.scrollIntoView?.({ block: 'nearest' });
+      return;
+    }
+    if (e.key === 'Enter' && inFilter) {
+      e.preventDefault();
+      e.stopPropagation();
+      const top = rows.find(r => (r.dataset.key || '').startsWith('s:'));
+      if (top) activateRow(top.dataset.key);
+      return;
+    }
+    if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      // Contain printable keys: the document-level shortcut layer treats
+      // bare letters as approval verbs (y/s/a/n) when focus is not in an
+      // input, and popover rows are buttons. Redirect into the filter when
+      // it is shown — focusing during keydown lands this keystroke there.
+      e.stopPropagation();
+      if (!inFilter && !filterEl.hidden) filterEl.focus();
+    }
+  }
+
+  const wire = () => {
+    btnEl = document.getElementById('task-target-switch-btn');
+    popEl = document.getElementById('ui2-target-switch');
+    if (!btnEl || !popEl) return;
+
+    const eyebrow = document.createElement('div');
+    eyebrow.className = 'ui2-tsw-eyebrow';
+    eyebrow.textContent = 'Prompt target';
+    eyebrow.setAttribute('aria-hidden', 'true');
+
+    filterEl = document.createElement('input');
+    filterEl.type = 'text';
+    filterEl.className = 'ui2-tsw-filter';
+    filterEl.placeholder = 'Filter sessions…';
+    filterEl.setAttribute('aria-label', 'Filter sessions');
+    filterEl.autocomplete = 'off';
+    filterEl.spellcheck = false;
+    filterEl.hidden = true;
+
+    rowsEl = document.createElement('div');
+    rowsEl.className = 'ui2-tsw-rows';
+
+    const foot = document.createElement('div');
+    foot.className = 'ui2-tsw-foot';
+    const newRow = makeRow('new', 'ui2-tsw-new');
+    const newLabel = document.createElement('span');
+    newLabel.className = 'ui2-tsw-row-label';
+    newLabel.textContent = '+ New session…';
+    newRow.appendChild(newLabel);
+    newRow.title = 'Draft a new session from the composer';
+    foot.appendChild(newRow);
+
+    popEl.replaceChildren(eyebrow, filterEl, rowsEl, foot);
+
+    btnEl.style.display = '';
+    btnEl.setAttribute('aria-controls', 'ui2-target-switch');
+
+    btnEl.addEventListener('click', () => {
+      if (isOpen) closePopover({ refocus: true });
+      else openPopover();
+    });
+    btnEl.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        openPopover();
+      } else if (e.key === 'Escape' && isOpen) {
+        e.stopPropagation();
+        closePopover({ refocus: true });
+      }
+    });
+    popEl.addEventListener('keydown', onPopKeydown);
+    popEl.addEventListener('click', (e) => {
+      const row = e.target.closest?.('.ui2-tsw-row');
+      if (row && popEl.contains(row)) activateRow(row.dataset.key || '');
+    });
+    filterEl.addEventListener('input', () => {
+      filterQuery = filterEl.value;
+      renderRows();
+    });
+    window.addEventListener('ui2:composer-state', (e) => {
+      if ((e?.detail?.state || '') === 'pill') closePopover();
+    });
+  };
+  if (document.readyState === 'complete') wire();
+  else document.addEventListener('DOMContentLoaded', wire, { once: true });
+})();


### PR DESCRIPTION
The global task bar becomes a real conversational surface instead of a fixed input strip: always reachable, never in the way, and no longer typing-blind. Three coordinated pieces on top of #315's mobile mechanics (measured reservation, keyboard lift, safe areas):

## Pill ⇄ expanded state machine (`ui2-chrome`)

`data-composer-state` on `<html>` switches the same fixed dock between the full composer and a small centered "Ask Intendant" lozenge. Immersive surfaces default to the pill (Live display, Station, Terminal, Files); conversational ones stay expanded. A manual pill/expand choice is remembered per tab (localStorage); Esc collapses transiently without recording a preference. The reservation invariant from #315 is untouched — `--ui2-composer-h` simply measures the pill (37px vs 54–186px), so every tab gains bottom viewport on the immersive defaults and panes still never draw under the dock. The pill face carries the phase dot (pulsing while thinking/running, amber while waiting) and an unsent-draft marker; while pilled the dock is `role=button`/`tabindex=0` so keyboard users can reach and expand it. `ui2:composer-state` (CustomEvent) + `window.ui2ComposerExpand` are the satellite contract. `switchTab` is rebound in the shared module scope so per-tab state rides every navigation path (nav, palette, router deep links). The phone compact-row block widens 500→600px with order/flex resets, ending the v1/v2 disagreement that split input and Send onto separate rows in that band.

## Conversation peek (`ui2-composer-peek`)

A transient sheet floating above the dock showing the prompt-target session's transcript tail — the answer to composing blind from a non-Activity tab. Read-only clone mirror of the target window's log (the `appendLogEntryToSessionWindow` precedent: cloneNode + strip ids), tail capped at 12, 120ms-throttled MutationObserver with in-place patching so command output streams live; surgical DOM reconcile keeps the `role="log" aria-live` list announcing only genuinely new entries. Opens on focus entering the dock or on the thinking/running phase edge; closes on Esc (window-capture with a dock-target guard so one Esc closes the peek and the next pills the dock), outside tap, retarget-to-nothing, or the pill state. An explicit dismissal latches until the working streak ends or the target changes, so auto-open never fights the user. Header: target badge, live phase, Open in Activity (routes + focuses the real window), close. Compact peek-scoped density overrides (timeline columns zeroed, 12.5px type, 8.5em payload clamp with an overflow-detected fade).

## Target hot-swap (`ui2-target-switch`)

The chip's only affordance was "jump to the Activity window" — there was no way to change the prompt target without leaving the current tab. A caret next to the chip opens an upward listbox: rows are exactly the resolver-usable sessions (`isPromptTargetSessionUsable`) with identity badge, name, and phase dot; pinned "Auto" (hands control back to the resolver) and "New session…" entries. Selecting calls `focusSessionWindow` — retargets in place, never switches tabs (asserted from the Files tab). Keyboard-complete: Enter/Space/arrows open, roving focus, Home/End, type-to-filter through `ui2FuzzyScore` beyond 6 rows, Esc back to the button, Tab closes-and-continues. Printable keys are contained while open — the document-level shortcut layer reads bare `y/s/a/n` as approval verbs. An 800ms signature poll re-renders the open list when sessions appear/rename/end, with focus-survivor recovery.

## Integration findings (fixed in the final commit)

The integrated battery caught three interaction bugs no single track could see, all in surface layering and boot semantics:
- **Onion Esc ordering** — with the popover open, the peek's window-capture Esc consumed the key to close *itself*, hidden behind the popover. The peek now yields to an open popover: Esc closes popover → peek → pills the dock.
- **Overlay stacking** — focus entering the dock via the switch caret opened the peek underneath the popover. Retargeting intent no longer counts as composition intent.
- **Phantom peek on page load** — the SPA autofocuses the composer at boot and bootstrap replay re-drives historical phase edges; either popped the peek over the content on every load of a dashboard with history. Auto-open now requires a real user gesture and ignores `processingLogReplay`; live working phases (e.g. a presence turn on connect) still open it, verified by trace.

## Verification

Every track probed against live keyless daemons (real Chrome headless over CDP), desktop 1440×900 + phone 390×844; all rerun green on the final integrated tree:
- Wave-1 geometry regression: 12/12 (rest + grown composer clearance, 560px wrap band, desktop reservation parity). Side effect of the ≤600 fix: the phone at-rest bar shrank 92→50px measured.
- State machine: 16/16 (defaults, remember semantics, draft dot, keyboard expand, contract events, reservation follow).
- Peek track probe: 22/22 (styled tail, live streaming into the open peek, Esc containment, reservation byte-identical open-vs-closed).
- Target-switch track probe: 41/41 (with/without target, Files-tab in-place retarget, keyboard round trip, Auto semantics, live list updates via a second tab).
- Integrated cross-track battery: 24/24 (three-surface onion ordering, pill suppression of both satellites, caret-vs-composition focus semantics, retarget-from-Files staying in place, reload-with-history boot semantics, phone sheet + save-row clearance; zero console errors and zero pageerrors).

Plus `cargo fmt --check`, `clippy`, the full `nextest` unit battery, and the complete mock-provider e2e suite locally.
