### PR TITLE
governor: serialize heavyweight final links (link gate)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,15 @@ settings, and overriding them opts your build out of the machine's
 RAM-protecting compile ceiling (the 2026-07-10 OOM-spiral class).
 Permitted only when deliberately diagnosing the wrapper chain itself.
 
+**Avoid needless final links** — they are the expensive step (a debug
+`intendant` link peaks ~2GiB linker RSS; concurrent final links are what
+swap-storm the box, and the governor serializes them machine-wide, so
+extra links also queue everyone else's): `cargo check` while iterating;
+when you need binaries, name them — `cargo build --bin intendant --bin
+intendant-runtime` covers running the controller (`intendant-connect`
+matters only for Connect work) — and save the all-binaries `cargo build`
+for validation that genuinely needs all three.
+
 **WASM** (`crates/presence-web` → `static/wasm-web/`, `crates/station-web` → `static/wasm-station/`): `build.rs` auto-detects stale WASM in either crate and rebuilds it via `wasm-pack`, then re-embeds, on a normal `cargo build`. wasm-pack is **version-pinned** by `.wasm-pack-version` (releases emit byte-different artifacts, and the artifacts are committed — cross-version rebuilds churn them and conflict concurrent landings): build.rs skips the rebuild under any other version, and the setup scripts install the pin. Manual fallback only if the auto-rebuild fails: `bash scripts/build-wasm.sh`
 (the canonical builder — it carries the registry-path remap that makes
 artifact bytes account-independent; the CI drift gate rebuilds through the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,15 @@ settings, and overriding them opts your build out of the machine's
 RAM-protecting compile ceiling (the 2026-07-10 OOM-spiral class).
 Permitted only when deliberately diagnosing the wrapper chain itself.
 
+**Avoid needless final links** — they are the expensive step (a debug
+`intendant` link peaks ~2GiB linker RSS; concurrent final links are what
+swap-storm the box, and the governor serializes them machine-wide, so
+extra links also queue everyone else's): `cargo check` while iterating;
+when you need binaries, name them — `cargo build --bin intendant --bin
+intendant-runtime` covers running the controller (`intendant-connect`
+matters only for Connect work) — and save the all-binaries `cargo build`
+for validation that genuinely needs all three.
+
 **WASM** (`crates/presence-web` → `static/wasm-web/`, `crates/station-web` → `static/wasm-station/`): `build.rs` auto-detects stale WASM in either crate and rebuilds it via `wasm-pack`, then re-embeds, on a normal `cargo build`. wasm-pack is **version-pinned** by `.wasm-pack-version` (releases emit byte-different artifacts, and the artifacts are committed — cross-version rebuilds churn them and conflict concurrent landings): build.rs skips the rebuild under any other version, and the setup scripts install the pin. Manual fallback only if the auto-rebuild fails: `bash scripts/build-wasm.sh`
 (the canonical builder — it carries the registry-path remap that makes
 artifact bytes account-independent; the CI drift gate rebuilds through the

--- a/crates/rustc-governor/src/config.rs
+++ b/crates/rustc-governor/src/config.rs
@@ -34,6 +34,16 @@ pub struct Config {
     pub local_reserved: u32,
     /// Permits reserved for the CI accounts listed in `ci_users`.
     pub ci_reserved: u32,
+    /// Heavyweight final links (bin / `--test` targets that emit `link`)
+    /// additionally serialize through `link-<i>` slot files — concurrent
+    /// multi-GiB final links are what melt a small box, not ordinary rustc
+    /// concurrency (see link.rs). Machine-GLOBAL, deliberately classless:
+    /// host memory doesn't care whose link it is. `0` disables the link
+    /// gate (heavyweight links then take only their ordinary permit); the
+    /// gate also degrades to that when no slot file is usable (config
+    /// grown past the installer-minted files in a root-owned dir) — link
+    /// gating may degrade, ordinary governance never rides with it.
+    pub link_slots: u32,
     /// Usernames whose invocations are classed `ci`; everyone else is
     /// `local`.
     pub ci_users: Vec<String>,
@@ -56,6 +66,11 @@ impl Default for Config {
             permit_dir: PathBuf::from(DEFAULT_PERMIT_DIR),
             local_reserved: 1,
             ci_reserved: 2,
+            // Default ON at 1: a binary upgrade alone turns the gate on
+            // (the installer never overwrites live configs, and unknown
+            // keys are ignored, so pre-gate configs stay parseable while
+            // this default carries the policy).
+            link_slots: 1,
             ci_users: vec!["_intendant-ci".to_string(), "ci".to_string()],
             wrap_with: None,
         }
@@ -100,6 +115,7 @@ pub fn parse(text: &str) -> Result<Config, String> {
             }
             "local_reserved" => cfg.local_reserved = parse_u32(value).map_err(|e| err(&e))?,
             "ci_reserved" => cfg.ci_reserved = parse_u32(value).map_err(|e| err(&e))?,
+            "link_slots" => cfg.link_slots = parse_u32(value).map_err(|e| err(&e))?,
             "ci_users" => cfg.ci_users = parse_string_array(value).map_err(|e| err(&e))?,
             "wrap_with" => {
                 // Empty means unset: the installer's here-doc always writes
@@ -244,6 +260,7 @@ enabled = true
 permit_dir = "/usr/local/var/intendant-governor"
 local_reserved = 1
 ci_reserved = 2   # per-box sizing
+link_slots = 1
 ci_users = ["_intendant-ci", "ci"]
 wrap_with = "/opt/homebrew/bin/sccache"
 "#;
@@ -269,6 +286,7 @@ wrap_with = "/opt/homebrew/bin/sccache"
             "permit_dir = \"/tmp/x\" # trailing comment\n",
             "local_reserved = 3\n",
             "ci_reserved = 0\n",
+            "link_slots = 4\n",
             "ci_users = [\"a\", \"b\",]\n",
             "wrap_with = \"/opt/sccache\"\n",
         );
@@ -277,8 +295,21 @@ wrap_with = "/opt/homebrew/bin/sccache"
         assert_eq!(cfg.permit_dir, PathBuf::from("/tmp/x"));
         assert_eq!(cfg.local_reserved, 3);
         assert_eq!(cfg.ci_reserved, 0);
+        assert_eq!(cfg.link_slots, 4);
         assert_eq!(cfg.ci_users, vec!["a".to_string(), "b".to_string()]);
         assert_eq!(cfg.wrap_with, Some(PathBuf::from("/opt/sccache")));
+    }
+
+    /// Pre-gate configs carry no `link_slots` key: the code default (1)
+    /// turns the gate on with a binary upgrade alone — the rollout
+    /// property the deploy ordering relies on. `0` is the explicit
+    /// per-box opt-out.
+    #[test]
+    fn link_slots_defaults_on_and_zero_is_the_opt_out() {
+        assert_eq!(parse("enabled = true\n").unwrap().link_slots, 1);
+        assert_eq!(parse("link_slots = 0\n").unwrap().link_slots, 0);
+        assert!(parse("link_slots = -1\n").is_err());
+        assert!(parse("link_slots = many\n").is_err());
     }
 
     #[test]

--- a/crates/rustc-governor/src/govlog.rs
+++ b/crates/rustc-governor/src/govlog.rs
@@ -1,7 +1,10 @@
-//! `<permit_dir>/governor.log`: exactly one line per governed invocation
-//! (bypasses, probes, and fail-open runs are deliberately silent — the log
-//! answers "who waited how long on which permit", and the probe fast path
-//! must not pay even a log write).
+//! `<permit_dir>/governor.log`: one acquisition line per governed
+//! invocation, plus one `kind=link-done` completion line per heavyweight
+//! link (bypasses, probes, and fail-open runs are deliberately silent —
+//! the log answers "who waited how long on which permit", and the probe
+//! fast path must not pay even a log write). The link fields — crate,
+//! classification, both waits, runtime — are the soak telemetry the
+//! link-gate sizing (and any future allowlist/weighting) is justified by.
 //!
 //! Best-effort end to end: logging must never fail the build, so every I/O
 //! error here is swallowed. Rotation is truncate-in-place at 1MB keeping
@@ -23,18 +26,78 @@ pub(crate) const LOG_NAME: &str = "governor.log";
 const MAX_LOG_BYTES: u64 = 1024 * 1024;
 const KEEP_BYTES: u64 = 256 * 1024;
 
-pub(crate) fn log_governed(permit_dir: &Path, class: &str, permit_name: &str, wait_ms: u64) {
+/// How the link gate treated a heavyweight invocation (ordinary compiles
+/// carry `None` and log `kind=compile`).
+pub(crate) enum LinkDisposition<'a> {
+    /// Serialized through a held slot.
+    Gated { slot: &'a str, link_wait_ms: u64 },
+    /// `link_slots = 0`: gated off by configuration.
+    Off,
+    /// No usable slot file: gating degraded, ordinary governance kept.
+    Degraded,
+}
+
+pub(crate) fn log_governed(
+    permit_dir: &Path,
+    class: &str,
+    crate_name: Option<&str>,
+    link: Option<&LinkDisposition>,
+    permit_name: &str,
+    wait_ms: u64,
+) {
+    let kind = match link {
+        None => " kind=compile".to_string(),
+        Some(LinkDisposition::Gated { slot, link_wait_ms }) => {
+            format!(" kind=link link_slot={slot} link_wait_ms={link_wait_ms}")
+        }
+        Some(LinkDisposition::Off) => " kind=link-ungated reason=off".to_string(),
+        Some(LinkDisposition::Degraded) => " kind=link-ungated reason=degraded".to_string(),
+    };
+    append_line(
+        permit_dir,
+        &format!(
+            "class={class} crate={}{kind} permit={permit_name} wait_ms={wait_ms}",
+            printable_crate(crate_name),
+        ),
+    );
+}
+
+/// Completion line for every heavyweight link (gated or not): the runtime
+/// is the number that sizes the gate post-soak.
+pub(crate) fn log_link_done(permit_dir: &Path, crate_name: Option<&str>, runtime_ms: u64) {
+    append_line(
+        permit_dir,
+        &format!(
+            "crate={} kind=link-done runtime_ms={runtime_ms}",
+            printable_crate(crate_name),
+        ),
+    );
+}
+
+/// Crate names come from argv: keep the log single-line and greppable
+/// whatever a hand-run invocation carries (`-` when absent or unusable).
+fn printable_crate(crate_name: Option<&str>) -> String {
+    let cleaned: String = crate_name
+        .unwrap_or("")
+        .chars()
+        .filter(|c| c.is_ascii_graphic())
+        .take(64)
+        .collect();
+    if cleaned.is_empty() {
+        "-".to_string()
+    } else {
+        cleaned
+    }
+}
+
+fn append_line(permit_dir: &Path, rest: &str) {
     let path = permit_dir.join(LOG_NAME);
     rotate_if_oversized(&path);
     let secs = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    let line = format!(
-        "{} pid={} class={class} permit={permit_name} wait_ms={wait_ms}\n",
-        iso8601_utc(secs),
-        std::process::id(),
-    );
+    let line = format!("{} pid={} {rest}\n", iso8601_utc(secs), std::process::id());
     if let Ok(mut f) = OpenOptions::new().append(true).create(true).open(&path) {
         // One short O_APPEND write per invocation: atomic per line.
         let _ = f.write_all(line.as_bytes());
@@ -117,15 +180,81 @@ mod tests {
     #[test]
     fn log_line_appends_and_parses() {
         let dir = tempfile::tempdir().unwrap();
-        log_governed(dir.path(), "local", "permit-ci-1", 230);
+        log_governed(dir.path(), "local", Some("serde"), None, "permit-ci-1", 230);
         let text = std::fs::read_to_string(dir.path().join(LOG_NAME)).unwrap();
         let line = text.trim_end();
         assert!(
-            line.ends_with("class=local permit=permit-ci-1 wait_ms=230"),
+            line.ends_with("class=local crate=serde kind=compile permit=permit-ci-1 wait_ms=230"),
             "{line}"
         );
         assert!(line.contains(&format!("pid={}", std::process::id())));
         assert!(line.starts_with("20"), "timestamp first: {line}");
+    }
+
+    #[test]
+    fn link_lines_carry_the_soak_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        log_governed(
+            dir.path(),
+            "local",
+            Some("intendant"),
+            Some(&LinkDisposition::Gated {
+                slot: "link-0",
+                link_wait_ms: 1200,
+            }),
+            "permit-local-0",
+            5,
+        );
+        log_governed(
+            dir.path(),
+            "ci",
+            Some("intendant_connect"),
+            Some(&LinkDisposition::Off),
+            "permit-ci-0",
+            0,
+        );
+        log_governed(
+            dir.path(),
+            "ci",
+            None,
+            Some(&LinkDisposition::Degraded),
+            "permit-ci-1",
+            0,
+        );
+        log_link_done(dir.path(), Some("intendant"), 48_000);
+        let text = std::fs::read_to_string(dir.path().join(LOG_NAME)).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        assert!(
+            lines[0].contains(
+                "crate=intendant kind=link link_slot=link-0 link_wait_ms=1200 permit=permit-local-0 wait_ms=5"
+            ),
+            "{}",
+            lines[0]
+        );
+        assert!(
+            lines[1].contains("kind=link-ungated reason=off permit=permit-ci-0"),
+            "{}",
+            lines[1]
+        );
+        assert!(
+            lines[2].contains("crate=- kind=link-ungated reason=degraded"),
+            "{}",
+            lines[2]
+        );
+        assert!(
+            lines[3].contains("crate=intendant kind=link-done runtime_ms=48000"),
+            "{}",
+            lines[3]
+        );
+    }
+
+    #[test]
+    fn crate_names_stay_single_line_and_bounded() {
+        assert_eq!(printable_crate(None), "-");
+        assert_eq!(printable_crate(Some("")), "-");
+        assert_eq!(printable_crate(Some("intendant")), "intendant");
+        assert_eq!(printable_crate(Some("a b\nc")), "abc");
+        assert_eq!(printable_crate(Some(&"x".repeat(100))).len(), 64);
     }
 
     #[test]
@@ -139,7 +268,7 @@ mod tests {
             }
         }
         assert!(std::fs::metadata(&path).unwrap().len() > MAX_LOG_BYTES);
-        log_governed(dir.path(), "ci", "permit-ci-0", 7);
+        log_governed(dir.path(), "ci", None, None, "permit-ci-0", 7);
         let text = std::fs::read_to_string(&path).unwrap();
         assert!(
             (text.len() as u64) <= KEEP_BYTES + 128,
@@ -159,7 +288,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join(LOG_NAME);
         std::fs::write(&path, "existing line\n").unwrap();
-        log_governed(dir.path(), "local", "permit-local-0", 0);
+        log_governed(dir.path(), "local", None, None, "permit-local-0", 0);
         let text = std::fs::read_to_string(&path).unwrap();
         assert!(text.starts_with("existing line\n"));
         assert_eq!(text.lines().count(), 2);

--- a/crates/rustc-governor/src/link.rs
+++ b/crates/rustc-governor/src/link.rs
@@ -1,0 +1,297 @@
+//! Heavyweight-link classification: which governed invocations must also
+//! serialize through the machine-global link slots (`permits.rs`).
+//!
+//! The measured failure this gate answers (2026-07-15, 24GB host with a
+//! fixed 16GB guest): the three-permit ordinary ceiling held exactly —
+//! no bypass, no leak — yet two concurrent FINAL LINKS (a debug
+//! `intendant` link peaks ~2GiB linker RSS) drove the host compressor to
+//! 10–11GB with sustained swap in both directions, and a third pushed
+//! swap-out to ~124MiB/s. The causal probe was clean: two links = severe
+//! churn, one link = recovering, zero = idle. Counting rustcs is not
+//! enough when every slot holds a link; the gate serializes the links
+//! themselves and leaves ordinary compiles alone.
+//!
+//! An invocation is a heavyweight link iff it EMITS A LINK ARTIFACT and
+//! TARGETS A FINAL BINARY:
+//!
+//! - emits link: no `--emit` flag at all (rustc's effective default is
+//!   to link), or any `--emit` list contains the `link` kind —
+//!   `--emit=kinds`, split `--emit kinds`, and `kind=path` items all
+//!   count;
+//! - final binary: bare `--test` (the cargo unit-test shape, which
+//!   carries no `--crate-type`), or `bin` among the `--crate-type`
+//!   values (equals / space / comma-list / repeated forms all count).
+//!
+//! Deliberately NOT heavyweight, each pinned by a test:
+//!
+//! - **Build scripts.** cargo compiles every `build.rs` as
+//!   `--crate-name build_script_<stem> --crate-type bin
+//!   --emit=dep-info,link` — dozens of trivial KB-scale links per cold
+//!   build that must not queue on the slot. The `build_script_` prefix
+//!   is a cargo-wide convention, not a project name list (a machine-wide
+//!   governor must not be brittle against one repo's crate names).
+//! - **Library artifacts**: `lib`/`rlib`, `staticlib`, `dylib`,
+//!   `proc-macro` — their `link` emit writes an archive/library, not a
+//!   final binary working set.
+//! - **`cdylib`**: a scoped POLICY decision for the current workload
+//!   (the wasm-pack crates' cdylib links are small), NOT a claim that
+//!   all cdylib links are — revisit with soak data if a heavy cdylib
+//!   appears.
+//!
+//! Blanket bin/`--test` gating (no crate-name allowlist beyond the
+//! build-script convention) is deliberate for the first soak: some
+//! harmless small test links will serialize, and reliability comes
+//! first — the gated log lines (crate, waits, runtime; `govlog.rs`) are
+//! the data a future allowlist or weighting would be justified by.
+//!
+//! Known edges, accepted: bare `rustc main.rs` (no explicit crate-type)
+//! DEFAULTS to a bin link inside rustc but carries no marker this
+//! classifier accepts — cargo always passes `--crate-type`/`--test`,
+//! hand-run one-offs are small, and never-surprise beats completeness.
+//! `@argfile` indirection is not expanded (same limitation as probe.rs);
+//! neither cargo nor sccache uses it for rustc. Probe-only invocations
+//! never reach this classifier: main.rs runs the probe fast path first
+//! (cargo's startup probe carries `--crate-type bin` and would otherwise
+//! resemble a bin invocation).
+
+/// What `classify` learned about a compile invocation.
+pub(crate) struct Classified {
+    /// Must the invocation hold a link slot (in addition to its ordinary
+    /// permit)?
+    pub(crate) heavy: bool,
+    /// The `--crate-name` value, for the governed log lines (`None` on
+    /// direct rustc invocations that carry none).
+    pub(crate) crate_name: Option<String>,
+}
+
+pub(crate) fn classify(args: &[String]) -> Classified {
+    let mut saw_test = false;
+    let mut bin_crate_type = false;
+    let mut saw_emit = false;
+    let mut emit_link = false;
+    let mut crate_name: Option<String> = None;
+    for (i, arg) in args.iter().enumerate() {
+        match arg.as_str() {
+            "--test" => saw_test = true,
+            "--crate-type" => {
+                if let Some(list) = args.get(i + 1) {
+                    bin_crate_type |= crate_type_list_has_bin(list);
+                }
+            }
+            "--emit" => {
+                saw_emit = true;
+                if let Some(list) = args.get(i + 1) {
+                    emit_link |= emit_list_has_link(list);
+                }
+            }
+            "--crate-name" => {
+                if let Some(name) = args.get(i + 1) {
+                    crate_name = Some(name.clone());
+                }
+            }
+            other => {
+                if let Some(list) = other.strip_prefix("--crate-type=") {
+                    bin_crate_type |= crate_type_list_has_bin(list);
+                } else if let Some(list) = other.strip_prefix("--emit=") {
+                    saw_emit = true;
+                    emit_link |= emit_list_has_link(list);
+                } else if let Some(name) = other.strip_prefix("--crate-name=") {
+                    crate_name = Some(name.to_string());
+                }
+            }
+        }
+    }
+    let emits_link = !saw_emit || emit_link;
+    let final_binary = saw_test || bin_crate_type;
+    let build_script = crate_name
+        .as_deref()
+        .is_some_and(|name| name.starts_with("build_script_"));
+    Classified {
+        heavy: emits_link && final_binary && !build_script,
+        crate_name,
+    }
+}
+
+/// `--crate-type` accepts comma lists (`bin,rlib`); any `bin` counts.
+fn crate_type_list_has_bin(list: &str) -> bool {
+    list.split(',').any(|t| t.trim() == "bin")
+}
+
+/// Each `--emit` item is `kind` or `kind=path`.
+fn emit_list_has_link(list: &str) -> bool {
+    list.split(',')
+        .any(|item| item.split('=').next().unwrap_or("").trim() == "link")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn heavy(list: &[&str]) -> bool {
+        classify(&args(list)).heavy
+    }
+
+    /// The production bin-link shape, verbatim off a cargo -v line
+    /// (trimmed): this is the invocation the gate exists for.
+    #[test]
+    fn cargo_bin_link_is_heavy() {
+        assert!(heavy(&[
+            "--crate-name",
+            "intendant",
+            "--edition",
+            "2021",
+            "src/bin/caller/main.rs",
+            "--crate-type",
+            "bin",
+            "--emit=dep-info,link",
+            "-C",
+            "debuginfo=line-tables-only",
+            "--out-dir",
+            "/w/target/debug/deps",
+        ]));
+    }
+
+    /// The observed cargo unit-test shape: bare `--test`, NO --crate-type.
+    #[test]
+    fn cargo_test_binary_is_heavy() {
+        assert!(heavy(&[
+            "--crate-name",
+            "intendant",
+            "--edition",
+            "2021",
+            "src/bin/caller/main.rs",
+            "--emit=dep-info,link",
+            "--test",
+            "--out-dir",
+            "/w/target/debug/deps",
+        ]));
+    }
+
+    #[test]
+    fn emit_forms_all_count() {
+        // Split --emit.
+        assert!(heavy(&["--crate-type", "bin", "--emit", "dep-info,link"]));
+        // kind=path items.
+        assert!(heavy(&[
+            "--crate-type",
+            "bin",
+            "--emit=link=/out/intendant"
+        ]));
+        assert!(heavy(&[
+            "--crate-type",
+            "bin",
+            "--emit",
+            "dep-info,link=/out/x",
+        ]));
+        // No --emit at all: rustc's effective default is to link.
+        assert!(heavy(&["--crate-name", "x", "--crate-type", "bin", "x.rs"]));
+        // --emit present but linkless: nothing to gate.
+        assert!(!heavy(&["--crate-type", "bin", "--emit=metadata"]));
+        assert!(!heavy(&["--crate-type", "bin", "--emit", "dep-info"]));
+    }
+
+    #[test]
+    fn crate_type_forms_all_count() {
+        assert!(heavy(&["--crate-type=bin", "--emit=link"]));
+        assert!(heavy(&["--crate-type", "bin,rlib", "--emit=link"]));
+        assert!(heavy(&["--crate-type=rlib,bin", "--emit=link"]));
+        // Repeated flags accumulate.
+        assert!(heavy(&[
+            "--crate-type",
+            "rlib",
+            "--crate-type",
+            "bin",
+            "--emit=link",
+        ]));
+        assert!(!heavy(&["--crate-type", "rlib,cdylib", "--emit=link"]));
+    }
+
+    /// Build scripts are bin links by shape and exempt by convention —
+    /// a cold build compiles dozens of these trivial KB-scale links.
+    #[test]
+    fn build_scripts_are_exempt() {
+        assert!(!heavy(&[
+            "--crate-name",
+            "build_script_build",
+            "--edition",
+            "2021",
+            "build.rs",
+            "--crate-type",
+            "bin",
+            "--emit=dep-info,link",
+        ]));
+        // `build = "src/main.rs"` style names too: the prefix is the
+        // cargo convention, not the one common filename.
+        assert!(!heavy(&[
+            "--crate-name=build_script_main",
+            "--crate-type",
+            "bin",
+            "--emit=dep-info,link",
+        ]));
+        // A --test build never carries the build-script name; the
+        // exemption must not leak past the prefix.
+        assert!(heavy(&["--crate-name", "build_scripts", "--test"]));
+    }
+
+    /// Library artifacts: pinned non-heavy, one per crate type. cdylib is
+    /// a scoped policy decision (current wasm workload), not a general
+    /// smallness claim.
+    #[test]
+    fn library_crate_types_are_not_heavy() {
+        for ct in ["lib", "rlib", "staticlib", "dylib", "cdylib", "proc-macro"] {
+            assert!(
+                !heavy(&[
+                    "--crate-name",
+                    "x",
+                    "--crate-type",
+                    ct,
+                    "--emit=dep-info,link"
+                ]),
+                "--crate-type {ct} must not classify heavyweight"
+            );
+        }
+        // The wasm-pack shape specifically.
+        assert!(!heavy(&[
+            "--crate-name",
+            "presence_web",
+            "--crate-type",
+            "cdylib",
+            "--emit=dep-info,link",
+            "--target",
+            "wasm32-unknown-unknown",
+        ]));
+        // The cargo rlib shape sccache caches (tests/sccache_chain.rs).
+        assert!(!heavy(&[
+            "--crate-name",
+            "prime",
+            "--crate-type",
+            "lib",
+            "--emit=dep-info,link",
+            "--out-dir",
+            "/tmp/out",
+        ]));
+    }
+
+    #[test]
+    fn crate_name_is_extracted_for_logging() {
+        let c = classify(&args(&["--crate-name", "intendant", "--test"]));
+        assert_eq!(c.crate_name.as_deref(), Some("intendant"));
+        let c = classify(&args(&["--crate-name=serde", "--crate-type", "rlib"]));
+        assert_eq!(c.crate_name.as_deref(), Some("serde"));
+        assert!(classify(&args(&["main.rs"])).crate_name.is_none());
+    }
+
+    /// No explicit marker, no gating: bare invocations (rustc would
+    /// default them to bin) and empty argv stay ordinary — cargo always
+    /// passes --crate-type or --test.
+    #[test]
+    fn unmarked_invocations_are_ordinary() {
+        assert!(!heavy(&[]));
+        assert!(!heavy(&["main.rs"]));
+        assert!(!heavy(&["--crate-name", "x", "main.rs", "-o", "x"]));
+    }
+}

--- a/crates/rustc-governor/src/main.rs
+++ b/crates/rustc-governor/src/main.rs
@@ -58,7 +58,15 @@
 //!      class). Classification runs over argv[2..]; see `probe.rs`.
 //!   3. **Class detection.** The euid's username, matched against the
 //!      config's `ci_users`, splits invocations into `ci` and `local`.
-//!   4. **Permits.** Own-class reservation first, then borrow the other
+//!   4. **The link gate.** A heavyweight final link (bin / `--test` target
+//!      emitting `link` — see `link.rs`) first takes one of the
+//!      machine-global `link_slots` flock slots, BEFORE its ordinary
+//!      permit: a waiter on the link gate holds nothing (no
+//!      ordinary-permit hoarding), and no permit holder ever waits on the
+//!      link slot, so the wait graph is acyclic. Gate failure degrades
+//!      (logged, ordinary governance kept); only the global fail-open
+//!      paths drop governance entirely.
+//!   5. **Permits.** Own-class reservation first, then borrow the other
 //!      class's spare permits iff that class has no registered waiters,
 //!      else register demand and poll — see `permits.rs` for the demand-gate
 //!      protocol. Nothing is ever killed or signalled; borrowed permits
@@ -87,6 +95,8 @@ mod config;
 mod flock;
 #[cfg(unix)]
 mod govlog;
+#[cfg_attr(not(unix), allow(dead_code))]
+mod link;
 #[cfg(unix)]
 mod permits;
 mod probe;
@@ -122,7 +132,7 @@ fn main() {
     let cfg = config::load(&config_path);
     let wrap = usable_wrap_with(cfg.as_ref());
     #[cfg(unix)]
-    run_unix(&real, &args, wrap, cfg, &config_path);
+    run_unix(&real, &args, wrap, cfg, &config_path, &lossy);
     #[cfg(not(unix))]
     run_portable(&real, &args, wrap);
 }
@@ -203,16 +213,17 @@ fn run_unix(
     wrap: Option<PathBuf>,
     cfg: Option<config::Config>,
     config_path: &Path,
+    lossy: &[String],
 ) -> ! {
-    match governed_permit(cfg, config_path) {
-        // Fail-open: no permit is held, so there is no fd whose lifetime
+    match governed_guards(cfg, config_path, lossy) {
+        // Fail-open: nothing is held, so there is no fd whose lifetime
         // must outlast the chain — exec(2) keeps the zero-overhead shape
         // (this process image simply BECOMES the chain, and a disabled
         // governor stays indistinguishable from a plain sccache
         // rustc-wrapper).
         None => exec_wrap_chain(real, args, wrap.as_deref()),
-        // Governed: the permit is parent-held — see `run_governed`.
-        Some(permit) => run_governed(real, args, wrap.as_deref(), permit),
+        // Governed: every lock is parent-held — see `run_governed`.
+        Some(guards) => run_governed(real, args, wrap.as_deref(), guards),
     }
 }
 
@@ -256,21 +267,23 @@ fn exec_wrap_chain(real: &Path, args: &[OsString], wrap: Option<&Path>) -> ! {
 /// and the child orphans and finishes its current compile momentarily
 /// ungoverned.
 #[cfg(unix)]
-fn run_governed(
-    real: &Path,
-    args: &[OsString],
-    wrap: Option<&Path>,
-    permit: permits::AcquiredPermit,
-) -> ! {
+fn run_governed(real: &Path, args: &[OsString], wrap: Option<&Path>, guards: Guards) -> ! {
+    let Guards {
+        permit,
+        link,
+        link_done,
+    } = guards;
+    let started = std::time::Instant::now();
     let Some(mut child) = spawn_chain(real, args, wrap) else {
         // Neither the wrap chain nor the compiler would spawn (messages
         // already printed by spawn_chain).
+        drop(link);
         drop(permit);
         std::process::exit(127);
     };
     // Between spawn and handler install, TERM/INT/HUP still hits the
-    // default disposition: the governor dies, the kernel releases the
-    // permit, the child orphans — the documented crash semantics, for a
+    // default disposition: the governor dies, the kernel releases every
+    // lock, the child orphans — the documented crash semantics, for a
     // few-instruction window.
     CHILD_PID.store(child.id() as i32, Ordering::Release);
     install_signal_forwarders();
@@ -278,10 +291,18 @@ fn run_governed(
     // The child is reaped: its pid is free for reuse, so the forwarders
     // must stop aiming at it before this process does anything else.
     CHILD_PID.store(0, Ordering::Release);
-    // The permit was held for the child's whole run (the fd kept
-    // O_CLOEXEC, so the child never saw it); releasing it now is
-    // release-on-exit made explicit.
+    // Both locks were held for the child's whole run (the fds kept
+    // O_CLOEXEC, so the child never saw them); releasing them now —
+    // before the log write below — is release-on-exit made explicit.
+    drop(link);
     drop(permit);
+    if let Some((permit_dir, crate_name)) = link_done {
+        govlog::log_link_done(
+            &permit_dir,
+            crate_name.as_deref(),
+            started.elapsed().as_millis() as u64,
+        );
+    }
     match status {
         Ok(status) => exit_like_child(status),
         Err(err) => {
@@ -412,20 +433,35 @@ fn exit_like_child(status: std::process::ExitStatus) -> ! {
     std::process::exit(status.code().unwrap_or(1));
 }
 
-/// Decide whether this invocation is governed, and if so acquire its
-/// permit. `None` always means "run ungoverned" — every fail-open path
-/// funnels here, and the caller execs the same `wrap_with` chain,
-/// permitless: a disabled governor must be indistinguishable from a
-/// plain sccache rustc-wrapper. On `Some`, the permit fd deliberately
-/// keeps std's FD_CLOEXEC: the caller stays alive as the permit-holding
-/// parent, and the fd must be invisible to every child — a leaked fd in
-/// a long-lived child (in production: the sccache server the client
-/// daemonizes on demand) keeps the flock held long after the compile.
+/// Everything a governed invocation holds, parent-side, for the chain's
+/// whole run. Every fd keeps std's FD_CLOEXEC and must stay invisible to
+/// every child — a leaked fd in a long-lived child (in production: the
+/// sccache server the client daemonizes on demand) keeps its flock held
+/// long after the compile.
 #[cfg(unix)]
-fn governed_permit(
+struct Guards {
+    permit: permits::AcquiredPermit,
+    /// The held slot for a GATED heavyweight link; `None` for ordinary
+    /// compiles and for heavyweights running with the gate off/degraded.
+    link: Option<permits::AcquiredLinkSlot>,
+    /// `(permit_dir, crate name)` for every heavyweight link, gated or
+    /// not: drives the `kind=link-done` runtime line the soak data needs.
+    link_done: Option<(PathBuf, Option<String>)>,
+}
+
+/// Decide whether this invocation is governed, and if so acquire what it
+/// holds: the machine-global link slot first for heavyweight links (the
+/// no-hoarding order — a link-gate waiter owns nothing), then the ordinary
+/// class permit. `None` always means "run ungoverned" — every fail-open
+/// path funnels here, and the caller execs the same `wrap_with` chain,
+/// lockless: a disabled governor must be indistinguishable from a plain
+/// sccache rustc-wrapper.
+#[cfg(unix)]
+fn governed_guards(
     cfg: Option<config::Config>,
     config_path: &Path,
-) -> Option<permits::AcquiredPermit> {
+    lossy: &[String],
+) -> Option<Guards> {
     // Secondary, per-invocation kill switch (the config file is the primary
     // one). Any value other than "off" is ignored.
     if std::env::var_os("INTENDANT_GOVERNOR").is_some_and(|v| v == "off") {
@@ -437,15 +473,54 @@ fn governed_permit(
     if !cfg.enabled {
         return None;
     }
+    // Zero ordinary permits = the documented "governs nothing" state:
+    // checked before the link gate so a fail-open box never parks a
+    // heavyweight on a slot it would immediately have to drop.
+    if cfg.local_reserved == 0 && cfg.ci_reserved == 0 {
+        return None;
+    }
+    let classified = link::classify(lossy);
+    let (link_slot, link_disposition) = if classified.heavy {
+        match permits::acquire_link_slot(&cfg, config_path) {
+            permits::LinkGate::Held(slot) => (Some(slot), None),
+            permits::LinkGate::Off => (None, Some(govlog::LinkDisposition::Off)),
+            permits::LinkGate::Degraded => (None, Some(govlog::LinkDisposition::Degraded)),
+            permits::LinkGate::FailOpen => return None,
+        }
+    } else {
+        (None, None)
+    };
     let class = permits::classify(permits::current_username().as_deref(), &cfg);
-    let permit = permits::acquire(&cfg, class, config_path)?;
+    let Some(permit) = permits::acquire(&cfg, class, config_path) else {
+        // Mid-wait kill switch or an unusable ordinary pool: the whole
+        // invocation fails open. The link guard is dropped HERE, before
+        // the caller execs — never carried into a fail-open chain.
+        drop(link_slot);
+        return None;
+    };
+    let disposition = match &link_slot {
+        Some(slot) => Some(govlog::LinkDisposition::Gated {
+            slot: &slot.name,
+            link_wait_ms: slot.wait_ms,
+        }),
+        None => link_disposition,
+    };
     govlog::log_governed(
         &cfg.permit_dir,
         class.as_str(),
+        classified.crate_name.as_deref(),
+        disposition.as_ref(),
         &permit.name,
         permit.wait_ms,
     );
-    Some(permit)
+    let link_done = classified
+        .heavy
+        .then(|| (cfg.permit_dir.clone(), classified.crate_name.clone()));
+    Some(Guards {
+        permit,
+        link: link_slot,
+        link_done,
+    })
 }
 
 /// The governor is a Unix (macOS / Linux) tool — flock(2) permit pools

--- a/crates/rustc-governor/src/permits.rs
+++ b/crates/rustc-governor/src/permits.rs
@@ -10,6 +10,9 @@
 //! - `permit-local-<i>`, i < local_reserved  — the interactive reservation
 //! - `permit-ci-<i>`,    i < ci_reserved     — the CI reservation
 //! - `demand-local`, `demand-ci`             — one demand file per class
+//! - `link-<i>`,         i < link_slots      — the heavyweight-link slots
+//!   (machine-global, classless: host memory doesn't care whose link it
+//!   is, so there is no reservation split and no demand gate)
 //!
 //! Protocol:
 //! - Holding a permit = holding LOCK_EX on its file. The governor holds
@@ -31,6 +34,20 @@
 //!   gate for the rest of the wait.
 //! - Nothing is ever killed or signalled; borrowed permits return naturally
 //!   when their holder exits.
+//!
+//! Link-slot ordering invariant (load-bearing — see `acquire_link_slot`):
+//! a heavyweight invocation takes its LINK SLOT FIRST, and only then its
+//! ordinary permit. **No ordinary-permit hoarding**: an invocation queued
+//! on the link gate holds zero ordinary permits, so however many
+//! heavyweights pile up, ordinary compiles keep the rest of the pool
+//! (three simultaneous final links — the observed cargo behavior — pin
+//! one slot and zero permits, not three permits). **Deadlock-free**: an
+//! ordinary-permit holder never waits on the link slot (only heavyweights
+//! do, and they acquired it first), so the wait graph has no cycle. The
+//! cost — a held slot idling while its owner queues for an ordinary
+//! permit — delays other *links* only, which is the acceptable direction.
+//! No FIFO/fairness guarantee exists in the flock+poll design; soak
+//! telemetry (govlog's wait fields) decides whether one is ever needed.
 
 use std::fs::{self, File, OpenOptions};
 use std::io;
@@ -126,12 +143,42 @@ pub(crate) struct AcquiredPermit {
     pub(crate) wait_ms: u64,
 }
 
+/// A held heavyweight-link slot. Exactly the `AcquiredPermit` story:
+/// keeping the `File` open IS the slot, parent-held with O_CLOEXEC intact,
+/// kernel-released on any exit.
+pub(crate) struct AcquiredLinkSlot {
+    pub(crate) _file: File,
+    pub(crate) name: String,
+    pub(crate) wait_ms: u64,
+}
+
+/// Outcome of gating a heavyweight link.
+pub(crate) enum LinkGate {
+    /// Slot held: the link is serialized.
+    Held(AcquiredLinkSlot),
+    /// `link_slots = 0`: the gate is configured off on this box.
+    Off,
+    /// No slot file was usable (config grown past the installer-minted
+    /// files in a root-owned dir, or the dir denies creation). Link
+    /// gating degrades — the caller logs it and proceeds — but ordinary
+    /// governance NEVER rides with it: only the global kill-switch paths
+    /// drop the whole governor.
+    Degraded,
+    /// The config vanished or disabled mid-wait: the whole invocation
+    /// fails open (the caller drops nothing — no slot was acquired).
+    FailOpen,
+}
+
 fn permit_name(class: Class, i: u32) -> String {
     format!("permit-{}-{i}", class.as_str())
 }
 
 fn demand_name(class: Class) -> String {
     format!("demand-{}", class.as_str())
+}
+
+fn link_slot_name(i: u32) -> String {
+    format!("link-{i}")
 }
 
 /// Open (or, where the directory allows it, create) a lock file. flock(2)
@@ -181,6 +228,48 @@ fn foreign_has_no_waiters(demand: &File) -> bool {
         true
     } else {
         false
+    }
+}
+
+/// Acquire one machine-global link slot for a heavyweight link, waiting as
+/// long as it takes. Called BEFORE `acquire` — the ordering invariant in
+/// the module doc: a waiter here holds nothing, so it can hoard no
+/// ordinary capacity and can complete no deadlock cycle. No demand gate:
+/// the slots are classless, and the only takers are heavyweights in this
+/// same single queue. The live kill switch is honored mid-wait exactly
+/// like the permit poll.
+pub(crate) fn acquire_link_slot(cfg: &Config, config_path: &Path) -> LinkGate {
+    if cfg.link_slots == 0 {
+        return LinkGate::Off;
+    }
+    let dir = &cfg.permit_dir;
+    let _ = fs::create_dir_all(dir);
+    let mut slots: Vec<(String, File)> = (0..cfg.link_slots)
+        .filter_map(|i| {
+            let name = link_slot_name(i);
+            open_lock_file(&dir.join(&name)).map(|f| (name, f))
+        })
+        .collect();
+    if slots.is_empty() {
+        return LinkGate::Degraded;
+    }
+    let start = Instant::now();
+    loop {
+        if let Some((name, file)) = try_take(&mut slots) {
+            return LinkGate::Held(AcquiredLinkSlot {
+                _file: file,
+                name,
+                wait_ms: start.elapsed().as_millis() as u64,
+            });
+        }
+        // Same live kill switch as the permit poll below: a flipped
+        // `enabled = false` or a deleted config unwedges link waiters
+        // within one poll tick, fail-open.
+        match config::load(config_path) {
+            Some(live) if live.enabled => {}
+            _ => return LinkGate::FailOpen,
+        }
+        std::thread::sleep(POLL_INTERVAL);
     }
 }
 
@@ -289,6 +378,7 @@ mod tests {
             permit_dir: permit_dir.clone(),
             local_reserved: local,
             ci_reserved: ci,
+            link_slots: 1,
             ci_users: vec!["_intendant-ci".into(), "ci".into()],
             wrap_with: None,
         };
@@ -337,6 +427,56 @@ mod tests {
     fn zero_permits_fails_open() {
         let (_tmp, cfg, path) = rig(0, 0);
         assert!(acquire(&cfg, Class::Local, &path).is_none());
+    }
+
+    #[test]
+    fn link_gate_off_and_degraded_never_block() {
+        let (_tmp, mut cfg, path) = rig(1, 0);
+        cfg.link_slots = 0;
+        assert!(matches!(acquire_link_slot(&cfg, &path), LinkGate::Off));
+        // An unusable permit dir (here: a plain file where the dir should
+        // be) means no slot file can be opened or created: Degraded, so
+        // the caller keeps ordinary governance instead of failing open.
+        cfg.link_slots = 1;
+        cfg.permit_dir = path.clone();
+        assert!(matches!(acquire_link_slot(&cfg, &path), LinkGate::Degraded));
+    }
+
+    #[test]
+    fn link_slots_serialize_and_release() {
+        let (_tmp, cfg, path) = rig(2, 0);
+        let a = match acquire_link_slot(&cfg, &path) {
+            LinkGate::Held(slot) => slot,
+            _ => panic!("first heavyweight must take the slot"),
+        };
+        assert_eq!(a.name, "link-0");
+        // The single slot is held: a second taker polls. Prove it waits
+        // by watching a thread not finish, then release and join.
+        let (cfg2, path2) = (cfg.clone(), path.clone());
+        let waiter = std::thread::spawn(move || acquire_link_slot(&cfg2, &path2));
+        std::thread::sleep(Duration::from_millis(400));
+        assert!(
+            !waiter.is_finished(),
+            "second heavyweight must queue on the held link slot"
+        );
+        drop(a);
+        match waiter.join().unwrap() {
+            LinkGate::Held(slot) => assert_eq!(slot.name, "link-0"),
+            _ => panic!("waiter must acquire after release"),
+        }
+    }
+
+    #[test]
+    fn multiple_link_slots_admit_that_many() {
+        let (_tmp, mut cfg, path) = rig(2, 0);
+        cfg.link_slots = 2;
+        let a = acquire_link_slot(&cfg, &path);
+        let b = acquire_link_slot(&cfg, &path);
+        let (a, b) = match (a, b) {
+            (LinkGate::Held(a), LinkGate::Held(b)) => (a, b),
+            _ => panic!("two slots must admit two links"),
+        };
+        assert_ne!(a.name, b.name);
     }
 
     #[test]

--- a/crates/rustc-governor/tests/acceptance.rs
+++ b/crates/rustc-governor/tests/acceptance.rs
@@ -30,7 +30,12 @@ use std::time::{Duration, Instant};
 const GOVERNOR: &str = env!("CARGO_BIN_EXE_rustc-governor");
 /// Deadline for anything that should happen "promptly" — sized for a box
 /// saturated by parallel agents, not for the typical millisecond case.
-const GENEROUS: Duration = Duration::from_secs(15);
+/// 60s matches tests/sccache_chain.rs: at 15s, a deliberately provoked
+/// spawn storm (two of these suites concurrently on a loaded box) timed
+/// out five tests whose children are one-echo shell scripts. Green runs
+/// never wait on this constant — wait_deadline returns at completion —
+/// so only real failures pay the extra latency.
+const GENEROUS: Duration = Duration::from_secs(60);
 /// How long a should-be-blocked governor is observed before we believe it
 /// is really waiting (several 100ms poll ticks plus load headroom).
 const BLOCKED_OBSERVATION: Duration = Duration::from_millis(1200);
@@ -60,6 +65,8 @@ impl Rig {
     /// the tests never depend on which account actually runs them (CI
     /// fleet accounts are literally named "ci"), so "local" configs list
     /// an impossible username and "ci" configs list the real one.
+    /// `link_slots` stays at the binary's default (1) unless a test says
+    /// otherwise — exactly like a production conf without the key.
     fn config(
         &self,
         name: &str,
@@ -68,7 +75,7 @@ impl Rig {
         ci_user_is_me: bool,
         enabled: bool,
     ) -> PathBuf {
-        self.config_inner(name, local, ci, ci_user_is_me, enabled, None)
+        self.config_inner(name, local, ci, ci_user_is_me, enabled, None, None)
     }
 
     /// Same, plus a `wrap_with` chain front (the sccache stand-in).
@@ -81,9 +88,15 @@ impl Rig {
         enabled: bool,
         wrap: &Path,
     ) -> PathBuf {
-        self.config_inner(name, local, ci, ci_user_is_me, enabled, Some(wrap))
+        self.config_inner(name, local, ci, ci_user_is_me, enabled, Some(wrap), None)
     }
 
+    /// Same, with an explicit `link_slots` key.
+    fn config_with_links(&self, name: &str, local: u32, ci: u32, link_slots: u32) -> PathBuf {
+        self.config_inner(name, local, ci, false, true, None, Some(link_slots))
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn config_inner(
         &self,
         name: &str,
@@ -92,6 +105,7 @@ impl Rig {
         ci_user_is_me: bool,
         enabled: bool,
         wrap: Option<&Path>,
+        link_slots: Option<u32>,
     ) -> PathBuf {
         let ci_users = if ci_user_is_me {
             format!("[\"{}\"]", me())
@@ -104,6 +118,9 @@ impl Rig {
         );
         if let Some(wrap) = wrap {
             text.push_str(&format!("wrap_with = \"{}\"\n", wrap.display()));
+        }
+        if let Some(slots) = link_slots {
+            text.push_str(&format!("link_slots = {slots}\n"));
         }
         let path = self.root.join(name);
         std::fs::write(&path, text).unwrap();
@@ -235,6 +252,16 @@ fn kill_and_reap(mut child: Child) {
     let _ = child.kill();
     let _ = child.wait();
 }
+
+/// The cargo bin-link argv shape (trimmed): classifies heavyweight, so a
+/// spawn with these args must also hold a link slot.
+const HEAVY_ARGS: &[&str] = &[
+    "--crate-name",
+    "x",
+    "--crate-type",
+    "bin",
+    "--emit=dep-info,link",
+];
 
 // ------------------------------------------------------------- tests ----
 
@@ -546,8 +573,11 @@ fn sigterm_forwards_to_child_and_signal_death_propagates() {
         ),
     );
     let config = rig.config("gov.toml", 1, 0, false, true);
-    let mut child = spawn_governor(&config, &script, &[], &[]);
+    // Heavyweight argv: the signal-death path must release the link slot
+    // exactly like the permit.
+    let mut child = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
     wait_for(|| ticks.exists(), GENEROUS, "fixture to start ticking");
+    assert!(is_exclusively_locked(&rig.permit("link-0")));
     // SAFETY: pid was spawned by this test and not yet reaped; kill(2)
     // takes only the pid and signal number.
     let rc = unsafe { libc::kill(child.id() as libc::pid_t, libc::SIGTERM) };
@@ -564,11 +594,14 @@ fn sigterm_forwards_to_child_and_signal_death_propagates() {
         after_settle,
         "tick file still growing: the governed child survived the forwarded SIGTERM"
     );
-    // And the permit came back with the governor's exit.
+    // And both locks came back with the governor's exit.
     wait_for(
-        || !is_exclusively_locked(&rig.permit("permit-local-0")),
+        || {
+            !is_exclusively_locked(&rig.permit("permit-local-0"))
+                && !is_exclusively_locked(&rig.permit("link-0"))
+        },
         GENEROUS,
-        "permit release after signal death",
+        "both locks to release after signal death",
     );
 }
 
@@ -881,6 +914,398 @@ fn zero_permits_fails_open() {
     let mut child = spawn_governor(&config, &script, &[], &[]);
     assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
     assert!(marker.exists());
+}
+
+// ----------------------------------------------------- the link gate ----
+
+/// Serialization: three heavyweight links against link_slots = 1 (the
+/// default — no key in the config) and THREE ordinary permits, so any
+/// serialization observed comes from the link gate alone, never the
+/// permit pool. Concurrency is measured from the fixture's own event
+/// stream, exactly like the global-ceiling test. All three completing is
+/// also the no-deadlock property for slot-then-permit acquisition.
+#[test]
+fn heavyweight_links_serialize_on_the_link_slot() {
+    let rig = Rig::new();
+    let events = rig.root.join("events");
+    let script = rig.script(
+        "link.sh",
+        &format!(
+            "echo start >> {ev}\nsleep 0.4\necho end >> {ev}",
+            ev = events.display()
+        ),
+    );
+    let config = rig.config("gov.toml", 3, 0, false, true);
+
+    let mut kids: Vec<Child> = (0..3)
+        .map(|_| spawn_governor(&config, &script, HEAVY_ARGS, &[]))
+        .collect();
+    let overall = Instant::now();
+    for child in &mut kids {
+        let left = Duration::from_secs(45)
+            .checked_sub(overall.elapsed())
+            .unwrap_or_default();
+        let status = wait_deadline(child, left).expect("heavyweight link must finish");
+        assert!(status.success());
+    }
+
+    let text = std::fs::read_to_string(&events).unwrap();
+    let (mut current, mut max, mut starts) = (0_i32, 0_i32, 0);
+    for line in text.lines() {
+        match line {
+            "start" => {
+                current += 1;
+                starts += 1;
+                max = max.max(current);
+            }
+            "end" => current -= 1,
+            other => panic!("unexpected event line {other:?}"),
+        }
+    }
+    assert_eq!(starts, 3);
+    assert_eq!(
+        max, 1,
+        "link gate violated: {max} concurrent heavyweight links (link_slots = 1)"
+    );
+    // Every run logged as a gated link, and the completion lines carry
+    // the runtime soak data.
+    let log = rig.log();
+    assert_eq!(
+        log.matches("kind=link link_slot=link-0").count(),
+        3,
+        "all three must serialize through the one slot: {log:?}"
+    );
+    assert_eq!(log.matches("kind=link-done runtime_ms=").count(), 3);
+    // Normal exits released everything.
+    assert!(!is_exclusively_locked(&rig.permit("link-0")));
+}
+
+/// No ordinary-permit hoarding (the acquisition-order invariant): an
+/// invocation queued on the link gate holds ZERO ordinary permits, so
+/// ordinary compiles keep the pool, and a probe that superficially
+/// resembles a bin invocation (cargo's startup probe carries
+/// `--crate-type bin`) still bypasses everything.
+#[test]
+fn queued_heavyweight_hoards_no_ordinary_permit() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let config = rig.config("gov.toml", 2, 0, false, true);
+
+    let slot_held = hold_exclusive(&rig.permit("link-0"));
+    let mut heavy = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
+    assert_still_running_for(&mut heavy, BLOCKED_OBSERVATION);
+    assert!(!marker.exists(), "heavyweight ran while the slot was held");
+    assert!(
+        !is_exclusively_locked(&rig.permit("permit-local-0"))
+            && !is_exclusively_locked(&rig.permit("permit-local-1")),
+        "a link-gate waiter must hold no ordinary permit"
+    );
+
+    // Ordinary compiles proceed through the un-hoarded pool…
+    let mut ordinary = spawn_governor(&config, &script, &[], &[]);
+    assert!(wait_deadline(&mut ordinary, GENEROUS).unwrap().success());
+    assert_eq!(
+        std::fs::read_to_string(&marker).unwrap().lines().count(),
+        1,
+        "the ordinary compile must complete while the heavyweight queues"
+    );
+    // …and a probe-shaped invocation carrying --crate-type bin execs
+    // directly (probe classification runs BEFORE link classification).
+    let mut probe = spawn_governor(
+        &config,
+        &script,
+        &[
+            "-",
+            "--crate-name",
+            "___",
+            "--print=file-names",
+            "--crate-type",
+            "bin",
+            "--emit=dep-info",
+            "--print=cfg",
+        ],
+        &[],
+    );
+    assert!(wait_deadline(&mut probe, GENEROUS).unwrap().success());
+
+    drop(slot_held);
+    let status = wait_deadline(&mut heavy, GENEROUS).expect("heavyweight must acquire the slot");
+    assert!(status.success());
+    let log = rig.log();
+    let heavy_line = log
+        .lines()
+        .find(|l| l.contains("kind=link "))
+        .expect("gated heavyweight must log");
+    assert!(
+        heavy_line.contains("crate=x")
+            && heavy_line.contains("link_slot=link-0")
+            && heavy_line.contains("link_wait_ms="),
+        "link line must carry the soak fields: {heavy_line:?}"
+    );
+    assert!(
+        !is_exclusively_locked(&rig.permit("link-0")),
+        "normal exit must release the slot"
+    );
+}
+
+/// While a heavyweight holds the slot and waits for an ordinary permit,
+/// borrowing still works: the composed gate never deadlocks against the
+/// class machinery. (Local reservation held; the idle CI reservation is
+/// borrowable because no CI demand is registered.)
+#[test]
+fn slot_holder_borrows_idle_foreign_permit() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let config = rig.config("gov.toml", 1, 1, false, true);
+
+    let _local_held = hold_exclusive(&rig.permit("permit-local-0"));
+    let mut heavy = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
+    let status = wait_deadline(&mut heavy, GENEROUS)
+        .expect("slot holder must borrow the idle CI permit, not deadlock");
+    assert!(status.success());
+    let log = rig.log();
+    let line = log.lines().find(|l| l.contains("kind=link ")).unwrap();
+    assert!(
+        line.contains("permit=permit-ci-0"),
+        "must have borrowed the idle CI permit: {line:?}"
+    );
+}
+
+/// `link_slots = 0` is the per-box opt-out: heavyweights run ungated
+/// (logged as such) but stay ordinary-governed.
+#[test]
+fn zero_link_slots_disables_the_gate_only() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let config = rig.config_with_links("gov.toml", 1, 0, 0);
+
+    let mut heavy = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
+    assert!(wait_deadline(&mut heavy, GENEROUS).unwrap().success());
+    let log = rig.log();
+    let line = log
+        .lines()
+        .find(|l| l.contains("kind=link-ungated"))
+        .expect("gate-off heavyweight must log its disposition");
+    assert!(
+        line.contains("reason=off") && line.contains("permit=permit-local-0"),
+        "{line:?}"
+    );
+    assert!(
+        log.contains("kind=link-done"),
+        "runtime soak line is wanted even ungated: {log:?}"
+    );
+
+    // And the ordinary ceiling still binds: hold the only permit, the
+    // heavyweight queues.
+    let _held = hold_exclusive(&rig.permit("permit-local-0"));
+    let mut queued = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
+    assert_still_running_for(&mut queued, BLOCKED_OBSERVATION);
+    kill_and_reap(queued);
+}
+
+/// Degraded link gating: the permit dir denies creating the slot files
+/// (the production shape: root-owned dir, config grown past the
+/// installer-minted files). The link gate degrades — logged — but
+/// ordinary governance is KEPT: reviewer contract, "link-gate failure
+/// must not discard ordinary governance".
+#[test]
+fn degraded_link_gate_keeps_ordinary_governance() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let config = rig.config("gov.toml", 1, 0, false, true);
+
+    // Pre-create everything the ordinary path needs (the installer's
+    // job in production), plus the log file — then make the dir
+    // read-only so link-0 cannot be created.
+    for name in [
+        "permit-local-0",
+        "demand-local",
+        "demand-ci",
+        "governor.log",
+    ] {
+        drop(open_rw(&rig.permit(name)));
+    }
+    let mut ro = std::fs::metadata(&rig.permit_dir).unwrap().permissions();
+    ro.set_mode(0o555);
+    std::fs::set_permissions(&rig.permit_dir, ro).unwrap();
+
+    let mut heavy = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
+    let status = wait_deadline(&mut heavy, GENEROUS);
+
+    // Restore permissions FIRST (tempdir cleanup + rig.log both need the
+    // dir readable-writable), then assert.
+    let mut rw = std::fs::metadata(&rig.permit_dir).unwrap().permissions();
+    rw.set_mode(0o755);
+    std::fs::set_permissions(&rig.permit_dir, rw).unwrap();
+
+    assert!(status.expect("degraded gate must not block").success());
+    assert!(marker.exists());
+    let log = rig.log();
+    let line = log
+        .lines()
+        .find(|l| l.contains("kind=link-ungated"))
+        .expect("degraded heavyweight must log its disposition");
+    assert!(
+        line.contains("reason=degraded") && line.contains("permit=permit-local-0"),
+        "ordinary governance must be kept through link-gate degradation: {line:?}"
+    );
+}
+
+/// SIGKILL on a slot-holding governor releases BOTH locks through kernel
+/// semantics (the fds close with the process), exactly like the
+/// permit-only crash test above.
+#[test]
+fn sigkilled_heavy_governor_releases_both_locks() {
+    let rig = Rig::new();
+    let ready = rig.root.join("ready");
+    let script = rig.script(
+        "hold.sh",
+        &format!(
+            "echo $$ >> {}\nwhile :; do sleep 0.05; done",
+            ready.display()
+        ),
+    );
+    let config = rig.config("gov.toml", 1, 0, false, true);
+
+    let mut child = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
+    wait_for(
+        || {
+            std::fs::read_to_string(&ready)
+                .map(|s| s.ends_with('\n'))
+                .unwrap_or(false)
+        },
+        GENEROUS,
+        "holder to start",
+    );
+    assert!(is_exclusively_locked(&rig.permit("link-0")));
+    assert!(is_exclusively_locked(&rig.permit("permit-local-0")));
+    child.kill().unwrap();
+    child.wait().unwrap();
+    wait_for(
+        || {
+            !is_exclusively_locked(&rig.permit("link-0"))
+                && !is_exclusively_locked(&rig.permit("permit-local-0"))
+        },
+        GENEROUS,
+        "both locks to release after SIGKILL",
+    );
+    let orphan: libc::pid_t = std::fs::read_to_string(&ready)
+        .unwrap()
+        .trim()
+        .parse()
+        .expect("fixture wrote its pid");
+    // SAFETY: the pid was reported by the fixture this test (transitively)
+    // spawned; kill(2) takes only the pid and signal number.
+    unsafe {
+        libc::kill(orphan, libc::SIGKILL);
+    }
+}
+
+/// Neither lock fd is inheritable: a long-lived grandchild the chain
+/// leaves behind (the daemonized-sccache-server shape, minus sccache)
+/// must not keep either flock alive past the governor's exit. This is
+/// the general CLOEXEC + parent-held property; the real-sccache
+/// daemonization variant lives in tests/sccache_chain.rs (heavy bin
+/// shapes are non-cacheable there, so the rlib test carries it).
+#[test]
+fn long_lived_grandchild_inherits_neither_lock() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let script = rig.script(
+        "daemonish.sh",
+        &format!(
+            "sleep 3 >/dev/null 2>&1 &\necho spawned >> {}",
+            marker.display()
+        ),
+    );
+    let config = rig.config("gov.toml", 1, 0, false, true);
+
+    let mut child = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
+    assert!(wait_deadline(&mut child, GENEROUS).unwrap().success());
+    assert!(marker.exists());
+    // The governor exited; the backgrounded sleep (reparented, still
+    // alive for ~3s) must hold neither lock.
+    assert!(
+        !is_exclusively_locked(&rig.permit("link-0")),
+        "a grandchild inherited the link-slot fd"
+    );
+    assert!(
+        !is_exclusively_locked(&rig.permit("permit-local-0")),
+        "a grandchild inherited the permit fd"
+    );
+}
+
+/// The live kill switch unwedges LINK-slot waiters exactly like permit
+/// waiters, for every way the config can die: flipped off, deleted, or
+/// replaced with garbage. Fail-open runs are silent in the log, and the
+/// waiter never touched an ordinary permit.
+#[test]
+fn dying_config_unwedges_link_waiters_fail_open() {
+    for way in ["disable", "delete", "garbage"] {
+        let rig = Rig::new();
+        let marker = rig.root.join("marker");
+        let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+        let config = rig.config("gov.toml", 1, 0, false, true);
+
+        let _slot_held = hold_exclusive(&rig.permit("link-0"));
+        let mut heavy = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
+        assert_still_running_for(&mut heavy, Duration::from_millis(600));
+        assert!(
+            !is_exclusively_locked(&rig.permit("permit-local-0")),
+            "[{way}] a link-gate waiter must hold no ordinary permit"
+        );
+
+        match way {
+            "disable" => {
+                rig.config("gov.toml", 1, 0, false, false);
+            }
+            "delete" => std::fs::remove_file(&config).unwrap(),
+            "garbage" => std::fs::write(&config, "enabled = maybe\n").unwrap(),
+            _ => unreachable!(),
+        }
+        let status = wait_deadline(&mut heavy, GENEROUS)
+            .unwrap_or_else(|| panic!("[{way}] link waiter must unwedge, fail-open"));
+        assert!(status.success(), "[{way}]");
+        assert!(marker.exists(), "[{way}]");
+        assert_eq!(rig.log(), "", "[{way}] fail-open must not log");
+    }
+}
+
+/// The config dying while a heavyweight HOLDS the slot but waits for an
+/// ordinary permit: the invocation fails open and the slot is dropped
+/// before the exec — never carried into an ungoverned chain.
+#[test]
+fn dying_config_drops_a_held_slot_before_fail_open() {
+    let rig = Rig::new();
+    let marker = rig.root.join("marker");
+    let script = rig.script("done.sh", &format!("echo done >> {}", marker.display()));
+    let config = rig.config("gov.toml", 1, 0, false, true);
+
+    // The only ordinary permit is held forever; the link slot is free.
+    let _permit_held = hold_exclusive(&rig.permit("permit-local-0"));
+    let mut heavy = spawn_governor(&config, &script, HEAVY_ARGS, &[]);
+    // The heavyweight takes the slot, then queues on the permit.
+    wait_for(
+        || is_exclusively_locked(&rig.permit("link-0")),
+        GENEROUS,
+        "heavyweight to take the link slot",
+    );
+    assert_still_running_for(&mut heavy, Duration::from_millis(600));
+
+    std::fs::remove_file(&config).unwrap();
+    let status =
+        wait_deadline(&mut heavy, GENEROUS).expect("permit waiter must unwedge, fail-open");
+    assert!(status.success());
+    assert!(marker.exists());
+    assert!(
+        !is_exclusively_locked(&rig.permit("link-0")),
+        "the slot must be dropped when its holder fails open"
+    );
+    assert_eq!(rig.log(), "", "fail-open must not log");
 }
 
 // ---------------------------------------------------- wiring guards ----

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -115,10 +115,17 @@ build out of the governor entirely — observed in the wild from an agent
 session (an ungoverned 1.8GB rustc while all permits sat free). The
 box's inhabitants are cooperative agents, so the enforcement stack is
 doctrine (CLAUDE.md forbids the override outside wrapper diagnostics)
-plus observability (the watchdog logs any substantial rustc with
-neither a governor nor an sccache ancestor). Enforcement below cargo's
-overridable layer was considered and deliberately skipped as
-disproportionate.
+plus observability: the watchdog logs any substantial rustc with
+neither a governor nor an sccache ancestor, every tick INCLUDING
+mid-job (an active CI job is precisely when big compiles exist — the
+detector originally sat below the watchdog's job_running early return
+and was blind through every one). The `GOVERNOR_MONITOR` conf knob
+gates it: `auto` (default) runs it only where the governor config file
+exists; governed hosts set `on` explicitly so an accidentally deleted
+governor config — the exact fail-open state worth surfacing — cannot
+silence the detector along with the governor; `off` for hosts that
+will never govern. Enforcement below cargo's overridable layer was
+considered and deliberately skipped as disproportionate.
 
 ### The chain
 
@@ -215,6 +222,45 @@ class has waiters and its reservation is honored. Nothing is ever
 killed or signalled; borrowed permits return naturally when their
 holder exits.
 
+### The link gate: heavyweight final links serialize
+
+The count ceiling alone proved insufficient the day every slot held a
+LINK (2026-07-15, with the governor verified correct — no bypass, no
+leak): a debug `intendant` link peaks ~2GiB linker RSS, and two of them
+concurrently drove the host compressor to 10–11GB with sustained
+two-way swap; a plain `cargo build` then launched three final links at
+once and pushed swap-out to ~124MiB/s. The causal probe was clean (two
+links = severe churn, one = recovering, zero = idle), so the gate
+matches it: ordinary compiles keep the permit pool, heavyweight links
+additionally serialize through `link_slots` machine-GLOBAL flock slots
+(`link-<i>` in the permit dir — classless on purpose: host memory does
+not care whose link it is).
+
+A heavyweight link is a bin / `--test` target that emits `link`
+(including rustc's no-`--emit` default); build scripts
+(`build_script_*` — a cargo-wide convention, dozens of trivial links
+per cold build) and library crate types are exempt, with `cdylib`
+exempt as a *scoped policy call* on today's small wasm links. Blanket
+bin/test gating with no crate allowlist is deliberate for the first
+soak — reliability first; the log's link fields are the data any
+future allowlist or weighting must earn itself with. Full
+classification contract + pinned argv matrix:
+`crates/rustc-governor/src/link.rs`.
+
+Acquisition order is load-bearing: **link slot first, ordinary permit
+second**. A link-gate waiter holds NOTHING — no ordinary-permit
+hoarding (cargo really does launch three links at once; under the
+reverse order they would pin three permits and starve every ordinary
+compile) — and no permit holder ever waits on the link slot, so the
+wait graph is acyclic. The cost, a held slot idling while its owner
+queues for a permit, delays other links only. There is deliberately no
+FIFO/fairness machinery in the flock+poll design; the soak telemetry
+decides whether any is ever needed. Gate failure DEGRADES instead of
+failing open: if no slot file is usable (config grown past the
+installer-minted files), the link runs ungated but still takes its
+ordinary permit — only the global kill-switch paths drop governance
+entirely. `link_slots = 0` is the per-box opt-out.
+
 ### Fail-open doctrine + live kill switch
 
 A governor must never break a build — and, since the wrapper-chain flip,
@@ -226,13 +272,18 @@ chain when it is configured (a disabled governor is indistinguishable
 from a plain sccache rustc-wrapper; only a missing/unparseable config,
 which cannot know `wrap_with`, runs the compiler directly). The config
 is re-read by every invocation (and once per poll tick by in-flight
-waiters), so `/usr/local/etc/intendant-governor.toml` is live: flipping
+waiters — link-slot waiters included), so
+`/usr/local/etc/intendant-governor.toml` is live: flipping
 `enabled = false` drains the governor within ~100ms, no listener
-restarts. Observability: one line per *governed* invocation in
-`<permit_dir>/governor.log` (timestamp, pid, class, permit, wait_ms;
-truncate-in-place rotation at 1MB keeping the last 256K — the hooks-log
-doctrine, because governed accounts can write the pre-created file but
-not create siblings in the root-owned dir).
+restarts. Observability: one acquisition line per *governed* invocation
+in `<permit_dir>/governor.log` — timestamp, pid, class, crate,
+`kind=compile` / `kind=link link_slot=… link_wait_ms=…` /
+`kind=link-ungated reason=off|degraded`, permit, wait_ms — plus one
+`kind=link-done runtime_ms=…` completion line per heavyweight link
+(gated or not): crate, both waits, and runtime are the soak data that
+size the link gate. Truncate-in-place rotation at 1MB keeping the last
+256K — the hooks-log doctrine, because governed accounts can write the
+pre-created file but not create siblings in the root-owned dir.
 
 ### Sizing, install, rollout
 
@@ -240,17 +291,27 @@ Per box: `local_reserved + ci_reserved` = the machine-wide ceiling of
 concurrent rustc processes; the per-account jobs cap still bounds any
 single cargo underneath it. The 24GB two-listener Mac runs 1 + 2.
 Don't set a class to 0 unless it truly never compiles — its members
-would then depend entirely on borrowing.
+would then depend entirely on borrowing. `link_slots` (default 1 in the
+binary, so a binary upgrade turns the gate on with pre-gate configs)
+sizes the heavyweight-link gate per box: keep 1 on small-memory hosts;
+a big-RAM box can raise it — after the installer re-run that mints the
+extra `link-<i>` files — or set 0 to opt out of link gating alone.
 
 ```bash
 cargo build --release -p rustc-governor
 sudo scripts/ci/install-governor-macos.sh   # binary + permit dir + conf
 ```
 
-The installer never edits account cargo configs; it prints the
+The installer mints config and lock assets BEFORE swapping the binary
+(old binaries ignore the new key and files; a new binary must never run
+ahead of the root-minted slot files it gates on), and upgrades deploy
+during a quiescent no-link interval — an already-running old governor
+cannot retroactively acquire a gate it never knew about. It never edits
+account cargo configs; it prints the
 `[build] rustc-wrapper = ".../rustc-governor"` line to set per account
-(replacing sccache as the wrapper — the governor execs sccache itself,
-via the conf's `wrap_with` key) and the legacy `rustc = ".../rustc-governor"`
+(replacing sccache as the wrapper — the governor runs sccache itself as
+a governed CHILD, per the conf's `wrap_with` key: parent-held locks,
+never an exec over them) and the legacy `rustc = ".../rustc-governor"`
 line to REMOVE (cargo passes the real compiler as argv[1] now; a
 leftover rustc= line would hand the governor itself, which it refuses
 with exit 127 rather than exec-looping). The installer never overwrites

--- a/scripts/ci/fleet-watchdog.sh
+++ b/scripts/ci/fleet-watchdog.sh
@@ -55,6 +55,12 @@ MEM_PRESSURE_LEVEL="${MEM_PRESSURE_LEVEL:-4}"
 MEM_PSI_PAUSE="${MEM_PSI_PAUSE:-40}"
 MEM_PAUSE_TICKS="${MEM_PAUSE_TICKS:-2}"
 MEM_RESUME_TICKS="${MEM_RESUME_TICKS:-2}"
+# Ungoverned-rustc detector: on | off | auto (auto = run only where the
+# governor config file exists). Set `on` explicitly on governed hosts so
+# an accidentally deleted governor config — the exact fail-open state the
+# detector should surface — cannot silence the detector with it.
+GOVERNOR_MONITOR="${GOVERNOR_MONITOR:-auto}"
+GOVERNOR_CONF="${GOVERNOR_CONF:-/usr/local/etc/intendant-governor.toml}"
 mkdir -p "$STATE_DIR"
 
 log() {
@@ -198,12 +204,14 @@ evict_until() {
 }
 
 # Policy-ceiling observability: a substantial rustc with neither a
-# rustc-governor nor an sccache ancestor means someone opted out of the
-# governor (env beats config: RUSTC_WRAPPER="" / RUSTC=… — seen in the
-# wild from an agent session). Log-only; the inhabitants are cooperative
-# agents and CLAUDE.md carries the doctrine. Known blind spot: a build
-# run with RUSTC_WRAPPER=sccache (bypassing the governor but keeping
-# sccache) is ancestry-indistinguishable from a governed compile.
+# rustc-governor nor an sccache ancestor means the governor was routed
+# around — env beats config (RUSTC_WRAPPER="" / RUSTC=…, seen in the wild
+# from an agent session), and a missing/disabled/malformed governor
+# config fails the whole governor open (by design) with the same
+# ancestry. Log-only; the inhabitants are cooperative agents and
+# CLAUDE.md carries the doctrine. Known blind spot: a build run with
+# RUSTC_WRAPPER=sccache (bypassing the governor but keeping sccache) is
+# ancestry-indistinguishable from a governed compile.
 detect_ungoverned_rustc() {
     ps -axo pid=,rss=,comm= 2>/dev/null | awk '$3 ~ /rustc$/ && $2 > 512000 {print $1, $2}'     | while read -r rpid rss; do
         p="$rpid" governed=0 hop=0
@@ -214,11 +222,26 @@ detect_ungoverned_rustc() {
             p=$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')
             hop=$((hop + 1))
         done
-        [ "$governed" = 0 ] && log "ungoverned rustc pid=$rpid rss=$((rss / 1024))MB — no governor/sccache ancestor (RUSTC_WRAPPER override?)"
+        [ "$governed" = 0 ] && log "ungoverned rustc pid=$rpid rss=$((rss / 1024))MB — no governor/sccache ancestor (RUSTC_WRAPPER/RUSTC override, or governor config missing/disabled/malformed)"
     done
 }
 
+# The GOVERNOR_MONITOR gate around the detector. Read-only and cheap, so
+# it runs at the very top of every tick — BEFORE the job_running early
+# return: an active CI job is precisely when big compiles exist, and the
+# early return used to blind the detector through every one of them
+# (it also never observed a simultaneous local bypass during CI).
+monitor_ungoverned_rustc() {
+    case "$GOVERNOR_MONITOR" in
+        off) return ;;
+        auto) [ -f "$GOVERNOR_CONF" ] || return ;;
+    esac
+    detect_ungoverned_rustc
+}
+
 main() {
+    monitor_ungoverned_rustc
+
     free=$(free_gb)
 
     # macOS: purgeable space (local Time Machine snapshots) makes the
@@ -246,7 +269,6 @@ main() {
         fi
     fi
 
-    detect_ungoverned_rustc
     prune_stale_keys
     evict_until 0  # steady-state cap enforcement
 

--- a/scripts/ci/install-governor-macos.sh
+++ b/scripts/ci/install-governor-macos.sh
@@ -5,16 +5,24 @@
 #
 # Builds nothing: takes a prebuilt binary (default target/release/rustc-governor,
 # from `cargo build --release -p rustc-governor`). Idempotent: re-running
-# upgrades the binary and tops up permit files for the *effective* config,
+# upgrades the binary and tops up lock files for the *effective* config,
 # and never overwrites an existing /usr/local/etc/intendant-governor.toml —
 # that file is live operator state (the kill switch lives in it).
 #
+# Ordering is deliberate: config and lock assets FIRST, the binary LAST.
+# Old binaries ignore unknown config keys and extra lock files, but a new
+# binary must never run ahead of the root-minted files it gates on (a
+# heavyweight link would degrade to ungated on a box that wanted the
+# gate). Upgrades land during a quiescent interval anyway: an
+# already-running old governor cannot retroactively acquire a gate it
+# never knew about.
+#
 # Deliberately does NOT touch any account's ~/.cargo/config.toml: the
 # governor stays inert until an account's cargo points at it (as
-# `[build] rustc-wrapper`; the governor execs sccache itself via the
-# conf's wrap_with key), and the operator canaries the CI account before
-# wiring their own. This script only prints the lines to set/remove.
-# Doc: scripts/ci/README.md, "Governor".
+# `[build] rustc-wrapper`; the governor then runs sccache as its governed
+# child, per the conf's wrap_with key), and the operator canaries the CI
+# account before wiring their own. This script only prints the lines to
+# set/remove. Doc: scripts/ci/README.md, "Governor".
 set -euo pipefail
 
 if [ "$(id -u)" -ne 0 ]; then
@@ -33,8 +41,6 @@ CONF="/usr/local/etc/intendant-governor.toml"
 PERMIT_DIR_DEFAULT="/usr/local/var/intendant-governor"
 
 install -d -m 0755 "$LIB_BIN_DIR" /usr/local/etc
-install -m 0755 "$BIN_SRC" "$LIB_BIN_DIR/rustc-governor"
-echo "installed $LIB_BIN_DIR/rustc-governor"
 
 if [ ! -f "$CONF" ]; then
     cat > "$CONF" <<'CONF_EOF'
@@ -51,11 +57,16 @@ permit_dir = "/usr/local/var/intendant-governor"
 # interactive agents): 1 local + 2 CI.
 local_reserved = 1
 ci_reserved = 2
+# Heavyweight final links (bin/--test targets that emit link) additionally
+# serialize through this many machine-GLOBAL slots — concurrent multi-GiB
+# final links are what melt a small box, not ordinary rustc concurrency.
+# 0 disables the link gate; absent, the binary defaults it to 1.
+link_slots = 1
 ci_users = ["_intendant-ci", "ci"]
 # Governed invocations spawn `wrap_with <rustc> <args…>` (the sccache
-# client) as a CHILD while the governor itself holds the permit until the
-# child exits — the fd is close-on-exec, so no child (crucially, no
-# daemonized sccache server) can inherit the flock. Unset, empty, or a
+# client) as a CHILD while the governor itself holds its locks until the
+# child exits — the fds are close-on-exec, so no child (crucially, no
+# daemonized sccache server) can inherit a flock. Unset, empty, or a
 # missing path: the compiler runs directly (correct, just uncached).
 wrap_with = "/opt/homebrew/bin/sccache"
 CONF_EOF
@@ -66,7 +77,7 @@ else
     if ! grep -q '^[[:space:]]*wrap_with[[:space:]]*=' "$CONF"; then
         cat <<'WRAP_EOF'
   NOTE: this conf predates the wrapper-chain flip and has no wrap_with key.
-  The governor is now cargo's rustc-wrapper and invokes sccache itself;
+  The governor is now cargo's rustc-wrapper and runs sccache itself;
   without wrap_with, governed builds still work but run UNCACHED. Add to
   the conf by hand:
     wrap_with = "/opt/homebrew/bin/sccache"
@@ -74,19 +85,26 @@ else
   now receives the compiler path from cargo as argv[1].)
 WRAP_EOF
     fi
+    if ! grep -q '^[[:space:]]*link_slots[[:space:]]*=' "$CONF"; then
+        echo "  NOTE: no link_slots key — the binary defaults to 1 (heavyweight final"
+        echo "  links serialize machine-wide). Add 'link_slots = N' to resize, 0 to disable."
+    fi
 fi
 
 # Pre-create the flock files for the *effective* config (an existing conf
-# wins over the defaults above). Non-root accounts can flock(2) a 0644
-# root-owned file through a read-only open, but cannot create files in the
-# 0755 root dir — the installer owns creation. File names mirror
+# wins over the defaults above) BEFORE the binary swap — see the ordering
+# note up top. Non-root accounts can flock(2) a 0644 root-owned file
+# through a read-only open, but cannot create files in the 0755 root dir —
+# the installer owns creation. File names mirror
 # crates/rustc-governor/src/permits.rs (interlock: change both together).
 permit_dir=$(sed -n 's/^permit_dir[[:space:]]*=[[:space:]]*"\(.*\)".*$/\1/p' "$CONF" | tail -n 1)
 local_n=$(sed -n 's/^local_reserved[[:space:]]*=[[:space:]]*\([0-9][0-9]*\).*$/\1/p' "$CONF" | tail -n 1)
 ci_n=$(sed -n 's/^ci_reserved[[:space:]]*=[[:space:]]*\([0-9][0-9]*\).*$/\1/p' "$CONF" | tail -n 1)
+link_n=$(sed -n 's/^link_slots[[:space:]]*=[[:space:]]*\([0-9][0-9]*\).*$/\1/p' "$CONF" | tail -n 1)
 permit_dir="${permit_dir:-$PERMIT_DIR_DEFAULT}"
 local_n="${local_n:-1}"
 ci_n="${ci_n:-2}"
+link_n="${link_n:-1}"   # the binary's default when the key is absent
 
 install -d -m 0755 "$permit_dir"
 create_lock_file() {
@@ -104,13 +122,22 @@ while [ "$i" -lt "$ci_n" ]; do
     create_lock_file "$permit_dir/permit-ci-$i"
     i=$((i + 1))
 done
+i=0
+while [ "$i" -lt "$link_n" ]; do
+    create_lock_file "$permit_dir/link-$i"
+    i=$((i + 1))
+done
 create_lock_file "$permit_dir/demand-local"
 create_lock_file "$permit_dir/demand-ci"
 # Every governed account appends to (and rotates) the log: world-writable.
 [ -f "$permit_dir/governor.log" ] || : > "$permit_dir/governor.log"
 chown root:wheel "$permit_dir/governor.log"
 chmod 0666 "$permit_dir/governor.log"
-echo "permit dir ready: $permit_dir (local=$local_n ci=$ci_n)"
+echo "permit dir ready: $permit_dir (local=$local_n ci=$ci_n link=$link_n)"
+
+# Binary last (see the ordering note up top).
+install -m 0755 "$BIN_SRC" "$LIB_BIN_DIR/rustc-governor"
+echo "installed $LIB_BIN_DIR/rustc-governor"
 
 cat <<'NEXT_EOF'
 
@@ -121,11 +148,11 @@ config points at it. For each account to govern, set under the EXISTING
 [build]
 rustc-wrapper = "/usr/local/lib/intendant-ci/bin/rustc-governor"
 
-replacing any `rustc-wrapper = ".../sccache"` line (the governor execs
-sccache itself, via the conf's wrap_with key), and REMOVE any legacy
-`rustc = ".../rustc-governor"` line — the governor now receives the real
-compiler path from cargo as argv[1]; if cargo hands it the governor
-itself, it refuses with exit 127 rather than exec-looping.
+replacing any `rustc-wrapper = ".../sccache"` line (the governor runs
+sccache itself as a governed child, via the conf's wrap_with key), and
+REMOVE any legacy `rustc = ".../rustc-governor"` line — the governor
+receives the real compiler path from cargo as argv[1]; if cargo hands it
+the governor itself, it refuses with exit 127 rather than exec-looping.
 
 Rollout order (see scripts/ci/README.md "Governor"): the CI account
 first, soak a day of green runs, then the operator account.
@@ -137,6 +164,9 @@ Notes:
 - Kill switch: set `enabled = false` in /usr/local/etc/intendant-governor.toml
   (immediate, machine-wide); a disabled governor still execs the wrap_with
   chain, so caching survives the kill switch. Removing the rustc-wrapper=
-  line fully unwires an account.
+  line fully unwires an account. `link_slots = 0` turns off only the
+  heavyweight-link gate.
 - Watch it: tail -f /usr/local/var/intendant-governor/governor.log
+  (kind=link lines carry link_wait_ms; kind=link-done carries runtime_ms —
+  the link-gate soak data.)
 NEXT_EOF

--- a/scripts/ci/watchdog.conf.example
+++ b/scripts/ci/watchdog.conf.example
@@ -27,6 +27,15 @@ CAP_GB=50         # total per cache root (2 listeners x 25G budget)
 #MEM_PAUSE_TICKS=2      # consecutive pressured ticks before pausing
 #MEM_RESUME_TICKS=2     # consecutive normal ticks before resuming
 
+# Ungoverned-rustc detector (runs every tick, even mid-job — read-only):
+# logs any substantial rustc with neither a rustc-governor nor an sccache
+# ancestor. on | off | auto; auto (the default) runs it only where the
+# governor config file exists. Set `on` explicitly on governed hosts so an
+# accidentally deleted governor config — the exact fail-open state worth
+# surfacing — cannot silence the detector along with the governor.
+#GOVERNOR_MONITOR=auto
+#GOVERNOR_CONF=/usr/local/etc/intendant-governor.toml
+
 VOLUME="/"
 STATE_DIR="/var/db/intendant-ci"        # /var/lib/intendant-ci on Linux
 LOG="/var/log/intendant-ci-watchdog.log"


### PR DESCRIPTION
## What

The rustc governor's count ceiling proved insufficient the day every permit held a final link: with the governor verified correct (no bypass, no leak, permits exact), two concurrent ~2GiB-RSS debug links swap-stormed the host, and a plain `cargo build` launched three final links at once (measured swap-out ~124MiB/s). This adds the reviewer-designed heavyweight-link gate: ordinary compiles keep the permit pool; bin/`--test` targets that emit `link` additionally serialize through `link_slots` machine-global flock slots.

## Design points (review round 6 contract)

- **Acquisition order is load-bearing**: link slot first, ordinary permit second. A link-gate waiter holds zero ordinary permits (no hoarding — cargo really launches three links at once), no permit holder ever waits on the slot (acyclic wait graph), and the flock+poll design deliberately has no FIFO guarantee — soak telemetry decides if fairness is ever needed.
- **One flock inode per slot**: `link-0..N-1` files, `link_slots` config key, binary default 1 (upgrade turns the gate on under pre-gate configs), 0 = per-box opt-out.
- **Degraded ≠ fail-open**: unusable slot files degrade link gating only (logged `reason=degraded`); ordinary governance continues. Only the global kill-switch paths drop governance, and a config dying mid-wait drops a held slot before the fail-open exec.
- **Classification**: `--emit` equals/split/`kind=path` forms + the no-`--emit` default-link case; `--crate-type` equals/space/comma/repeated forms; bare `--test` (the cargo unit-test shape); `build_script_*` exempt (cargo-wide convention, not a project allowlist); library crate types pinned non-heavy with cdylib as a scoped policy call. Blanket bin/test gating for the first soak — no crate allowlist.
- **Telemetry**: every governed line carries crate + kind; gated links carry `link_slot`/`link_wait_ms`; every heavyweight link (gated or not) writes `kind=link-done runtime_ms=…`.
- **Installer ordering**: config + lock assets minted BEFORE the binary swap; stale exec-era sccache wording corrected (parent-held mode spawns sccache).
- **Watchdog**: `detect_ungoverned_rustc` moved above the `job_running` early return (it never observed during active CI jobs — exactly when big compiles exist); `GOVERNOR_MONITOR=on|off|auto` knob (auto = governor config present; governed hosts set `on` so a deleted config can't silence the detector with the governor); message covers fail-open config states.

## Tests

9 new acceptance tests (serialization at slot=1 with permits non-binding, no-hoarding + probe-ordering, borrow composition, gate-off, degraded-keeps-ordinary, SIGKILL/TERM/normal-exit release of both locks, grandchild fd non-inheritance, dying-config unwedging × delete/disable/garbage, held-slot drop before fail-open) + classification/config/govlog/permits unit matrices. `GENEROUS` 15s→60s after a deliberately provoked double-suite spawn storm timed out five one-echo-child tests; green runs never wait on the constant. Full governor suite green ×6 including two concurrent-suite storm runs; `cargo fmt --check` and `clippy --all-targets -D warnings` clean on the crate.