### PR TITLE
worktrees: free-disk tile + navigable related-session chips

### DIFF
--- a/crates/intendant-platform/src/platform.rs
+++ b/crates/intendant-platform/src/platform.rs
@@ -1088,6 +1088,131 @@ pub fn metadata_on_disk_bytes(metadata: &std::fs::Metadata) -> u64 {
     }
 }
 
+/// Free/total capacity of the filesystem volume that contains a path.
+///
+/// `free_bytes` is the space available to the calling (unprivileged) user —
+/// `df`'s "Avail", not the superuser-inclusive free count — because callers
+/// surface it to answer "how much can still be written here?".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VolumeSpace {
+    pub free_bytes: u64,
+    pub total_bytes: u64,
+}
+
+/// Query the volume containing `path` (which must exist). Returns `None` on
+/// any query failure — callers treat volume capacity as optional telemetry,
+/// never a correctness input.
+///
+/// - **Apple**: `statfs`, whose block counts are 64-bit on Darwin
+///   (`statvfs`'s `fsblkcnt_t` is 32-bit there and overflows on >16 TiB
+///   volumes).
+/// - **Other Unix**: `statvfs`, sized by `f_frsize` per POSIX.
+/// - **Windows**: `GetDiskFreeSpaceExW` (quota-aware caller-available bytes).
+pub fn volume_space(path: &std::path::Path) -> Option<VolumeSpace> {
+    // The Win32 query only accepts directories; normalize file paths to
+    // their parent so every platform accepts any existing path.
+    let parent_storage;
+    let query_path = match std::fs::symlink_metadata(path) {
+        Ok(meta) if !meta.is_dir() => {
+            parent_storage = path
+                .parent()
+                .filter(|p| !p.as_os_str().is_empty())?
+                .to_path_buf();
+            &parent_storage
+        }
+        _ => path,
+    };
+    volume_space_of_dir(query_path)
+}
+
+fn volume_space_of_dir(path: &std::path::Path) -> Option<VolumeSpace> {
+    #[cfg(target_os = "macos")]
+    {
+        let c_path = std::ffi::CString::new({
+            use std::os::unix::ffi::OsStrExt;
+            path.as_os_str().as_bytes()
+        })
+        .ok()?;
+        // SAFETY: `statfs` is a plain POD out-struct for which the all-zero
+        // bit pattern is a valid value.
+        let mut stat: libc::statfs = unsafe { std::mem::zeroed() };
+        // SAFETY: `c_path` is a valid NUL-terminated path that outlives the
+        // call, and `stat` is a live writable out-pointer of the exact type
+        // the API fills in.
+        if unsafe { libc::statfs(c_path.as_ptr(), &mut stat) } != 0 {
+            return None;
+        }
+        let block = u64::from(stat.f_bsize);
+        Some(VolumeSpace {
+            free_bytes: stat.f_bavail.saturating_mul(block),
+            total_bytes: stat.f_blocks.saturating_mul(block),
+        })
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        let c_path = std::ffi::CString::new({
+            use std::os::unix::ffi::OsStrExt;
+            path.as_os_str().as_bytes()
+        })
+        .ok()?;
+        // SAFETY: `statvfs` is a plain POD out-struct for which the all-zero
+        // bit pattern is a valid value.
+        let mut stat: libc::statvfs = unsafe { std::mem::zeroed() };
+        // SAFETY: `c_path` is a valid NUL-terminated path that outlives the
+        // call, and `stat` is a live writable out-pointer of the exact type
+        // the API fills in.
+        if unsafe { libc::statvfs(c_path.as_ptr(), &mut stat) } != 0 {
+            return None;
+        }
+        // Field widths vary across libc targets (u32 on some 32-bit ABIs,
+        // u64 on glibc LP64), so the widening casts are load-bearing on some
+        // targets and no-ops on others.
+        #[allow(clippy::unnecessary_cast)]
+        let frag = if stat.f_frsize > 0 {
+            stat.f_frsize as u64
+        } else {
+            stat.f_bsize as u64
+        };
+        #[allow(clippy::unnecessary_cast)]
+        Some(VolumeSpace {
+            free_bytes: (stat.f_bavail as u64).saturating_mul(frag),
+            total_bytes: (stat.f_blocks as u64).saturating_mul(frag),
+        })
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Storage::FileSystem::GetDiskFreeSpaceExW;
+
+        let wide: Vec<u16> = path
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        let mut caller_free: u64 = 0;
+        let mut total: u64 = 0;
+        // SAFETY: `wide` is a NUL-terminated wide string that outlives the
+        // call, the two u64 out-pointers are live and writable
+        // (ULARGE_INTEGER-sized), and the final out-param is documented as
+        // optional so null is permitted.
+        let ok = unsafe {
+            GetDiskFreeSpaceExW(
+                wide.as_ptr(),
+                &mut caller_free,
+                &mut total,
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            return None;
+        }
+        Some(VolumeSpace {
+            free_bytes: caller_free,
+            total_bytes: total,
+        })
+    }
+}
+
 /// Stable on-disk identity of a file, independent of its path: the pair the
 /// OS uses to name the underlying object. Two paths with an equal
 /// `FileIdentity` refer to the same file — hardlinks compare equal, a
@@ -1691,6 +1816,31 @@ mod tests {
             (from_meta.volume, from_meta.file_index),
             metadata_dev_ino(&metadata)
         );
+    }
+
+    #[test]
+    fn volume_space_reports_plausible_capacity() {
+        let dir = tempfile::tempdir().unwrap();
+        let space = volume_space(dir.path()).expect("tempdir volume must be queryable");
+        assert!(space.total_bytes > 0, "total capacity must be nonzero");
+        assert!(
+            space.free_bytes <= space.total_bytes,
+            "free ({}) cannot exceed total ({})",
+            space.free_bytes,
+            space.total_bytes
+        );
+        // Files and directories on one volume agree on its identity-free
+        // capacity figure (free space may drift between calls; total not).
+        let file = dir.path().join("f.txt");
+        std::fs::write(&file, b"x").unwrap();
+        let file_space = volume_space(&file).expect("file path must resolve to its volume");
+        assert_eq!(file_space.total_bytes, space.total_bytes);
+    }
+
+    #[test]
+    fn volume_space_missing_path_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(volume_space(&dir.path().join("no-such-entry")), None);
     }
 
     // Windows leg: the handle query must yield a real NTFS identity, shared

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -510,8 +510,13 @@ directory is safe to delete; it rebuilds on the next scan.
   (read-only cards; clicking one hands off to the peer's own dashboard,
   where the peer's own auth applies).
 - **Deep Search** — search across session history.
-- **Worktrees** — the git worktrees in use by sub-agents (same card +
-  Show-more treatment).
+- **Worktrees** — the git worktree inventory (same card + Show-more
+  treatment): per-checkout size, merge/dirty state, and safety verdicts;
+  aggregate tiles including **free disk** on the tightest worktree-hosting
+  volume (amber under 10% free, rose under 5%); and **related-session
+  chips** — the sessions observed inside each checkout, supervised and raw
+  codex/claude alike. Clicking a chip focuses the live session window when
+  one exists, otherwise it lands on Recent with the ID prefilled.
 - **New Session** — start a fresh session from the dashboard.
   Internal-agent launches get an **Execution** control — *Auto* (the
   task-size heuristic decides), *Orchestrate* (delegates to supervised

--- a/src/bin/caller/worktree_inventory.rs
+++ b/src/bin/caller/worktree_inventory.rs
@@ -51,6 +51,13 @@ pub struct WorktreeScanRoot {
     pub repo_count: usize,
     pub truncated: bool,
     pub error: Option<String>,
+    /// Free/total capacity of the volume holding this root (existing roots
+    /// only) — the "can I still write here?" signal next to the worktree
+    /// sizes. `None` when the root is missing or the volume query fails.
+    #[serde(default)]
+    pub volume_free_bytes: Option<u64>,
+    #[serde(default)]
+    pub volume_total_bytes: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -64,6 +71,14 @@ pub struct WorktreeSummary {
     pub stale: usize,
     pub cleanup_candidates: usize,
     pub truncated_sizes: usize,
+    /// The tightest volume hosting the scanned worktrees: free/total of
+    /// whichever such volume has the least free space (what a full disk
+    /// hits first). Worktrees usually share one volume, in which case this
+    /// is simply that volume's capacity.
+    #[serde(default)]
+    pub volume_free_bytes: Option<u64>,
+    #[serde(default)]
+    pub volume_total_bytes: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -597,6 +612,40 @@ fn scan_worktrees_with_size_budget(
         repos: repo_count,
         ..WorktreeSummary::default()
     };
+    // Headline capacity = the tightest volume actually hosting scanned
+    // worktrees. (A roots-based figure would let a session-cwd scan root on
+    // an unrelated, nearly-full mount skew the headline red.) Volumes are
+    // deduped by device id where Metadata exposes one, else by path prefix
+    // (Windows drive letters), so the query runs once per volume, not per
+    // worktree.
+    let mut seen_volumes: HashSet<String> = HashSet::new();
+    for wt in &worktrees {
+        let volume_key = std::fs::symlink_metadata(&wt.path)
+            .ok()
+            .map(|meta| crate::platform::metadata_dev_ino(&meta).0)
+            .filter(|dev| *dev != 0)
+            .map(|dev| format!("dev:{dev}"))
+            .unwrap_or_else(|| {
+                wt.path
+                    .components()
+                    .next()
+                    .map(|c| c.as_os_str().to_string_lossy().into_owned())
+                    .unwrap_or_else(|| wt.path.to_string_lossy().into_owned())
+            });
+        if !seen_volumes.insert(volume_key) {
+            continue;
+        }
+        let Some(volume) = crate::platform::volume_space(&wt.path) else {
+            continue;
+        };
+        if summary
+            .volume_free_bytes
+            .is_none_or(|current| volume.free_bytes < current)
+        {
+            summary.volume_free_bytes = Some(volume.free_bytes);
+            summary.volume_total_bytes = Some(volume.total_bytes);
+        }
+    }
     for wt in &worktrees {
         summary.total_bytes = summary.total_bytes.saturating_add(wt.size_bytes);
         if wt.dirty {
@@ -745,6 +794,11 @@ fn default_scan_roots(
             return;
         }
         let exists = path.exists();
+        let volume = if exists {
+            crate::platform::volume_space(&path)
+        } else {
+            None
+        };
         roots.push(WorktreeScanRoot {
             path,
             kind: kind.to_string(),
@@ -752,6 +806,8 @@ fn default_scan_roots(
             repo_count: 0,
             truncated: false,
             error: None,
+            volume_free_bytes: volume.map(|v| v.free_bytes),
+            volume_total_bytes: volume.map(|v| v.total_bytes),
         });
     };
 
@@ -1787,6 +1843,49 @@ mod tests {
         assert!(!found.dirty);
         assert!(found.safe_to_remove);
         assert!(found.labels.iter().any(|l| l == "cleanup-candidate"));
+    }
+
+    #[test]
+    fn scan_reports_volume_capacity_for_existing_roots() {
+        let tmp = init_repo();
+        let repo = repo_path(&tmp);
+
+        let scan = scan_worktrees(tmp.path(), Some(&repo), &[]);
+
+        let project_root = scan
+            .roots
+            .iter()
+            .find(|root| root.kind == "current-project")
+            .expect("current-project root present");
+        assert!(project_root.exists);
+        let free = project_root
+            .volume_free_bytes
+            .expect("existing root reports volume free space");
+        let total = project_root
+            .volume_total_bytes
+            .expect("existing root reports volume capacity");
+        assert!(total > 0);
+        assert!(free <= total);
+
+        // Missing roots stay None rather than reporting a random volume.
+        for root in scan.roots.iter().filter(|root| !root.exists) {
+            assert_eq!(root.volume_free_bytes, None);
+            assert_eq!(root.volume_total_bytes, None);
+        }
+
+        // The summary carries the tightest volume hosting scanned worktrees;
+        // the fixture repo guarantees at least one worktree exists.
+        assert!(!scan.worktrees.is_empty());
+        let summary_free = scan
+            .summary
+            .volume_free_bytes
+            .expect("summary reports free space when any worktree exists");
+        let summary_total = scan
+            .summary
+            .volume_total_bytes
+            .expect("summary reports capacity when any worktree exists");
+        assert!(summary_total > 0);
+        assert!(summary_free <= summary_total);
     }
 
     #[test]

--- a/static/app.html
+++ b/static/app.html
@@ -7679,6 +7679,8 @@ body.context-focus-active {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.sessions-aggregate .agg-value.v-yellow { color: var(--yellow); }
+.sessions-aggregate .agg-value.v-red { color: var(--red); }
 .sessions-aggregate .agg-card.loading {
   border-color: rgba(137, 180, 250, 0.22);
 }
@@ -7841,6 +7843,46 @@ body.context-focus-active {
   background: color-mix(in srgb, var(--peach) 15%, transparent);
   color: var(--peach);
 }
+.worktree-card .wt-sessions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 6px 0 0;
+}
+.worktree-card .wt-session-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  line-height: 1.5;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--surface2) 60%, transparent);
+  background: color-mix(in srgb, var(--surface1) 35%, transparent);
+  color: var(--subtext0);
+  font-family: inherit;
+}
+button.wt-session-chip { cursor: pointer; }
+button.wt-session-chip:hover,
+button.wt-session-chip:focus-visible {
+  border-color: var(--blue);
+  color: var(--text);
+}
+.worktree-card .wt-session-chip.active {
+  border-color: color-mix(in srgb, var(--yellow) 55%, transparent);
+  color: var(--yellow);
+}
+.worktree-card .wt-session-source {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 9px;
+  letter-spacing: 0.05em;
+}
+.worktree-card .wt-session-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+}
+.worktree-card .wt-session-status { color: var(--overlay1); }
+.worktree-card .wt-session-chip.active .wt-session-status { color: inherit; }
 .worktree-card .wt-command {
   flex: 1 1 auto;
   min-width: 0;
@@ -16754,6 +16796,8 @@ html.ui-v2 #tab-sessions .sessions-aggregate .ui-stat-value {
   letter-spacing: -.01em;
   color: var(--text);
 }
+html.ui-v2 #tab-sessions .sessions-aggregate .ui-stat-value.v-yellow { color: var(--amber); }
+html.ui-v2 #tab-sessions .sessions-aggregate .ui-stat-value.v-red { color: var(--rose); }
 html.ui-v2 #tab-sessions .sessions-aggregate .ui-stat-sub {
   margin-top: 3px;
   font-size: 10.5px;
@@ -17314,6 +17358,33 @@ html.ui-v2 #tab-sessions .worktree-card .wt-label.unknown-merge {
   background: rgba(var(--amber-rgb), .1);
   color: var(--amber);
 }
+html.ui-v2 #tab-sessions .worktree-card .wt-sessions { gap: 5px; margin: 8px 0 0; }
+html.ui-v2 #tab-sessions .worktree-card .wt-session-chip {
+  padding: 2px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--surface-2);
+  color: var(--text-2);
+  font-size: 10.5px;
+}
+html.ui-v2 #tab-sessions button.wt-session-chip:hover,
+html.ui-v2 #tab-sessions button.wt-session-chip:focus-visible {
+  border-color: var(--iris);
+  color: var(--text);
+  background: var(--surface-3);
+}
+html.ui-v2 #tab-sessions .worktree-card .wt-session-chip.active {
+  border-color: rgba(var(--amber-rgb), .5);
+  color: var(--amber);
+}
+html.ui-v2 #tab-sessions .worktree-card .wt-session-source {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: .05em;
+}
+html.ui-v2 #tab-sessions .worktree-card .wt-session-id { font-family: var(--mono); }
+html.ui-v2 #tab-sessions .worktree-card .wt-session-status { color: var(--text-3); }
+html.ui-v2 #tab-sessions .worktree-card .wt-session-chip.active .wt-session-status { color: inherit; }
 html.ui-v2 #tab-sessions .worktree-card .wt-safety {
   margin: 8px 0;
   padding: 7px 10px;
@@ -27951,7 +28022,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'c5e6718315bccaf7';
+const INTENDANT_APP_BUILD = 'ac074f7638cef9ef';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -97063,7 +97134,7 @@ function renderAggregateStatTiles(el, cards) {
     labelEl.className = 'ui-stat-label agg-label';
     labelEl.textContent = c.label;
     const valueEl = document.createElement('div');
-    valueEl.className = 'ui-stat-value agg-value';
+    valueEl.className = 'ui-stat-value agg-value' + (c.valueClass ? ` ${c.valueClass}` : '');
     valueEl.textContent = c.value;
     card.appendChild(labelEl);
     card.appendChild(valueEl);
@@ -98175,12 +98246,36 @@ function renderWorktreesAggregate(scan, el) {
   const cards = [
     { label: 'Worktrees', value: Number(summary.worktrees || 0).toLocaleString() },
     { label: 'Disk', value: _fmtBytes(summary.total_bytes || 0) },
+  ];
+  const freeDisk = worktreeFreeDiskCard(summary);
+  if (freeDisk) cards.push(freeDisk);
+  cards.push(
     { label: 'Dirty', value: Number(summary.dirty || 0).toLocaleString() },
     { label: 'Unmerged', value: Number(summary.unmerged || 0).toLocaleString() },
     { label: 'Active', value: Number(summary.active || 0).toLocaleString() },
     { label: 'Candidates', value: Number(summary.cleanup_candidates || 0).toLocaleString(), sub: summary.cleanup_candidates > 0 ? 'safe to remove' : '' },
-  ];
+  );
   renderAggregateStatTiles(el, cards);
+}
+
+// Free-space tile for the tightest scanned volume. Tones follow proximity to
+// full: amber under 10% free, rose under 5% — the answer to "will the next
+// build fit?", not just how much the worktrees already consume.
+function worktreeFreeDiskCard(summary) {
+  const free = Number(summary?.volume_free_bytes);
+  const total = Number(summary?.volume_total_bytes);
+  if (!Number.isFinite(free) || !Number.isFinite(total) || total <= 0) return null;
+  const ratio = free / total;
+  let valueClass = '';
+  if (ratio < 0.05) valueClass = 'v-red';
+  else if (ratio < 0.10) valueClass = 'v-yellow';
+  return {
+    label: 'Free disk',
+    value: _fmtBytes(free),
+    sub: `${Math.round(ratio * 100)}% of ${_fmtBytes(total)}`,
+    valueClass,
+    title: 'Free space on the volume hosting the scanned worktrees with the least room (what a full disk hits first)',
+  };
 }
 
 function worktreeDate(value) {
@@ -98247,6 +98342,102 @@ function shellQuote(value) {
 
 function worktreeRemoveCommand(wt) {
   return `git -C ${shellQuote(wt.repo_root)} worktree remove ${shellQuote(wt.path)}`;
+}
+
+// ── Related-session chips on worktree cards. The scan already ties each
+// worktree to the sessions observed inside it (supervised AND raw
+// codex/claude sessions, via the session catalog's observed-path hints);
+// the chips make that linkage navigable instead of a bare count.
+
+const WORKTREE_ACTIVE_SESSION_STATUSES = new Set(['running', 'in_progress', 'thinking']);
+
+// Gemini hints are project-level pseudo-entries, not sessions — nothing to
+// navigate to.
+function worktreeRelatedSessionNavigable(rel) {
+  const sid = String(rel?.session_id || '').trim();
+  return !!sid && !sid.startsWith('gemini-project:');
+}
+
+function openWorktreeRelatedSession(rel) {
+  const sid = String(rel?.session_id || '').trim();
+  if (!sid) return;
+  if (sessionWindows.has(sid)) {
+    focusSessionWindow(sid);
+    return;
+  }
+  // No live window: land on Sessions -> Recent with the ID in the search
+  // box — the catalog lists raw external sessions there too, so the row
+  // offers open/resume for supervised and unsupervised sessions alike.
+  routeTo('sessions', 'recent');
+  const search = document.getElementById('sessions-search');
+  if (search) {
+    search.value = sid;
+    search.dispatchEvent(new Event('input', { bubbles: true }));
+    search.focus();
+  }
+}
+
+function worktreeSessionChip(rel) {
+  const sid = String(rel?.session_id || '').trim();
+  const status = String(rel?.status || '').trim();
+  const navigable = worktreeRelatedSessionNavigable(rel);
+  const active = WORKTREE_ACTIVE_SESSION_STATUSES.has(status);
+  const chip = document.createElement(navigable ? 'button' : 'span');
+  if (navigable) chip.type = 'button';
+  chip.className = 'wt-session-chip'
+    + (active ? ' active' : '')
+    + (navigable ? '' : ' static');
+
+  const source = normalizeAgentId(rel?.source || '') || String(rel?.source || '');
+  const sourceEl = document.createElement('span');
+  sourceEl.className = 'wt-session-source';
+  sourceEl.textContent = prettyAgentName(source) || source || 'session';
+  chip.appendChild(sourceEl);
+
+  const idEl = document.createElement('span');
+  idEl.className = 'wt-session-id';
+  idEl.textContent = sid.startsWith('gemini-project:')
+    ? sid.slice('gemini-project:'.length)
+    : (sid.length > 10 ? `${shortSessionId(sid)}…` : sid);
+  chip.appendChild(idEl);
+
+  if (status) {
+    const statusEl = document.createElement('span');
+    statusEl.className = 'wt-session-status';
+    statusEl.textContent = status;
+    chip.appendChild(statusEl);
+  }
+
+  const when = rel?.updated_at ? ` · ${fmtWorktreeMinute(rel.updated_at)}` : '';
+  chip.title = navigable
+    ? `Open session ${sid}${status ? ` (${status}${when})` : ''}`
+    : `${sid}${status ? ` (${status}${when})` : ''}`;
+  if (navigable) {
+    chip.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      openWorktreeRelatedSession(rel);
+    });
+  }
+  return chip;
+}
+
+function renderWorktreeSessionChips(wt) {
+  const related = Array.isArray(wt?.related_sessions) ? wt.related_sessions : [];
+  if (related.length === 0) return null;
+  const row = document.createElement('div');
+  row.className = 'wt-sessions';
+  for (const rel of related) {
+    row.appendChild(worktreeSessionChip(rel));
+  }
+  const total = Number(wt.related_session_count || 0);
+  if (total > related.length) {
+    const rest = document.createElement('span');
+    rest.className = 'wt-session-chip static wt-session-rest';
+    rest.textContent = `+${(total - related.length).toLocaleString()} more`;
+    rest.title = `${total.toLocaleString()} related sessions total; the inventory ships ${related.length} per worktree`;
+    row.appendChild(rest);
+  }
+  return row;
 }
 
 let worktreeInspectContext = null;
@@ -98528,6 +98719,11 @@ function recomputeWorktreeSummary(scan) {
     stale: 0,
     cleanup_candidates: 0,
     truncated_sizes: 0,
+    // Volume capacity comes from the scan, not the rows; carry it through
+    // (it only goes stale by the removal that just freed space, in the
+    // conservative direction — the next scan refreshes it).
+    volume_free_bytes: scan?.summary?.volume_free_bytes,
+    volume_total_bytes: scan?.summary?.volume_total_bytes,
   };
   for (const wt of rows) {
     summary.total_bytes += Number(wt.size_bytes || 0);
@@ -98810,11 +99006,11 @@ function renderWorktreesList(scan, el) {
       addMeta('tracking', formatWorktreeDivergence(wt.upstream, wt.ahead, wt.behind), null, wt.upstream);
     }
     if (wt.dirty) addMeta('changes', `${wt.staged || 0} staged, ${wt.unstaged || 0} unstaged, ${wt.untracked || 0} untracked`, 'v-red');
-    if ((wt.active_sessions || 0) > 0 || (wt.related_session_count || 0) > 0) {
-      addMeta('sessions', `${wt.active_sessions || 0} active / ${wt.related_session_count || 0} related`, (wt.active_sessions || 0) > 0 ? 'v-yellow' : null);
-    }
     addMeta('files', `${Number(wt.file_count || 0).toLocaleString()} files`);
     card.appendChild(meta);
+
+    const sessionsRow = renderWorktreeSessionChips(wt);
+    if (sessionsRow) card.appendChild(sessionsRow);
 
     const actions = document.createElement('div');
     actions.className = 'sc-actions';

--- a/static/app.html
+++ b/static/app.html
@@ -28022,7 +28022,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'ac074f7638cef9ef';
+const INTENDANT_APP_BUILD = 'f1c3d0ce811c71ca';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -98701,6 +98701,26 @@ function worktreeInspectOpenFiles() {
 window.closeWorktreeInspectModal = closeWorktreeInspectModal;
 window.worktreeInspectOpenShell = worktreeInspectOpenShell;
 window.worktreeInspectOpenFiles = worktreeInspectOpenFiles;
+
+// QA readback (window.qa convention) + one explicit test hook: headless
+// probes can't ride the control tunnel (the first-visit forced scan is a
+// tunnel-only POST twin), so the worktrees pane exposes its rendered state
+// and a scan-injection hook that runs the exact production render path on
+// caller-supplied data.
+window.qa = Object.assign(window.qa || {}, {
+  worktreesPane: () => ({
+    tiles: [...document.querySelectorAll('#worktrees-aggregate .agg-card')]
+      .map(card => card.textContent.trim().replace(/\s+/g, ' ')),
+    chips: [...document.querySelectorAll('#worktrees-list .wt-session-chip')]
+      .map(chip => ({ tag: chip.tagName, text: chip.textContent.trim().replace(/\s+/g, ' ') })),
+    status: document.getElementById('worktrees-status')?.textContent || '',
+  }),
+  worktreesRenderScan: (scan) => {
+    _cachedWorktreeScan = scan;
+    renderWorktrees(scan);
+    return window.qa.worktreesPane();
+  },
+});
 
 function formatWorktreeDivergence(target, ahead, behind) {
   const label = target ? `${target} ` : '';

--- a/static/app/13-styles-sessions-terminal.css
+++ b/static/app/13-styles-sessions-terminal.css
@@ -851,6 +851,8 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.sessions-aggregate .agg-value.v-yellow { color: var(--yellow); }
+.sessions-aggregate .agg-value.v-red { color: var(--red); }
 .sessions-aggregate .agg-card.loading {
   border-color: rgba(137, 180, 250, 0.22);
 }
@@ -1013,6 +1015,46 @@
   background: color-mix(in srgb, var(--peach) 15%, transparent);
   color: var(--peach);
 }
+.worktree-card .wt-sessions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 6px 0 0;
+}
+.worktree-card .wt-session-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  line-height: 1.5;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--surface2) 60%, transparent);
+  background: color-mix(in srgb, var(--surface1) 35%, transparent);
+  color: var(--subtext0);
+  font-family: inherit;
+}
+button.wt-session-chip { cursor: pointer; }
+button.wt-session-chip:hover,
+button.wt-session-chip:focus-visible {
+  border-color: var(--blue);
+  color: var(--text);
+}
+.worktree-card .wt-session-chip.active {
+  border-color: color-mix(in srgb, var(--yellow) 55%, transparent);
+  color: var(--yellow);
+}
+.worktree-card .wt-session-source {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 9px;
+  letter-spacing: 0.05em;
+}
+.worktree-card .wt-session-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+}
+.worktree-card .wt-session-status { color: var(--overlay1); }
+.worktree-card .wt-session-chip.active .wt-session-status { color: inherit; }
 .worktree-card .wt-command {
   flex: 1 1 auto;
   min-width: 0;

--- a/static/app/56-debug-sessions.js
+++ b/static/app/56-debug-sessions.js
@@ -2258,7 +2258,7 @@ function renderAggregateStatTiles(el, cards) {
     labelEl.className = 'ui-stat-label agg-label';
     labelEl.textContent = c.label;
     const valueEl = document.createElement('div');
-    valueEl.className = 'ui-stat-value agg-value';
+    valueEl.className = 'ui-stat-value agg-value' + (c.valueClass ? ` ${c.valueClass}` : '');
     valueEl.textContent = c.value;
     card.appendChild(labelEl);
     card.appendChild(valueEl);

--- a/static/app/57-sessions-replay.js
+++ b/static/app/57-sessions-replay.js
@@ -163,12 +163,36 @@ function renderWorktreesAggregate(scan, el) {
   const cards = [
     { label: 'Worktrees', value: Number(summary.worktrees || 0).toLocaleString() },
     { label: 'Disk', value: _fmtBytes(summary.total_bytes || 0) },
+  ];
+  const freeDisk = worktreeFreeDiskCard(summary);
+  if (freeDisk) cards.push(freeDisk);
+  cards.push(
     { label: 'Dirty', value: Number(summary.dirty || 0).toLocaleString() },
     { label: 'Unmerged', value: Number(summary.unmerged || 0).toLocaleString() },
     { label: 'Active', value: Number(summary.active || 0).toLocaleString() },
     { label: 'Candidates', value: Number(summary.cleanup_candidates || 0).toLocaleString(), sub: summary.cleanup_candidates > 0 ? 'safe to remove' : '' },
-  ];
+  );
   renderAggregateStatTiles(el, cards);
+}
+
+// Free-space tile for the tightest scanned volume. Tones follow proximity to
+// full: amber under 10% free, rose under 5% — the answer to "will the next
+// build fit?", not just how much the worktrees already consume.
+function worktreeFreeDiskCard(summary) {
+  const free = Number(summary?.volume_free_bytes);
+  const total = Number(summary?.volume_total_bytes);
+  if (!Number.isFinite(free) || !Number.isFinite(total) || total <= 0) return null;
+  const ratio = free / total;
+  let valueClass = '';
+  if (ratio < 0.05) valueClass = 'v-red';
+  else if (ratio < 0.10) valueClass = 'v-yellow';
+  return {
+    label: 'Free disk',
+    value: _fmtBytes(free),
+    sub: `${Math.round(ratio * 100)}% of ${_fmtBytes(total)}`,
+    valueClass,
+    title: 'Free space on the volume hosting the scanned worktrees with the least room (what a full disk hits first)',
+  };
 }
 
 function worktreeDate(value) {
@@ -235,6 +259,102 @@ function shellQuote(value) {
 
 function worktreeRemoveCommand(wt) {
   return `git -C ${shellQuote(wt.repo_root)} worktree remove ${shellQuote(wt.path)}`;
+}
+
+// ── Related-session chips on worktree cards. The scan already ties each
+// worktree to the sessions observed inside it (supervised AND raw
+// codex/claude sessions, via the session catalog's observed-path hints);
+// the chips make that linkage navigable instead of a bare count.
+
+const WORKTREE_ACTIVE_SESSION_STATUSES = new Set(['running', 'in_progress', 'thinking']);
+
+// Gemini hints are project-level pseudo-entries, not sessions — nothing to
+// navigate to.
+function worktreeRelatedSessionNavigable(rel) {
+  const sid = String(rel?.session_id || '').trim();
+  return !!sid && !sid.startsWith('gemini-project:');
+}
+
+function openWorktreeRelatedSession(rel) {
+  const sid = String(rel?.session_id || '').trim();
+  if (!sid) return;
+  if (sessionWindows.has(sid)) {
+    focusSessionWindow(sid);
+    return;
+  }
+  // No live window: land on Sessions -> Recent with the ID in the search
+  // box — the catalog lists raw external sessions there too, so the row
+  // offers open/resume for supervised and unsupervised sessions alike.
+  routeTo('sessions', 'recent');
+  const search = document.getElementById('sessions-search');
+  if (search) {
+    search.value = sid;
+    search.dispatchEvent(new Event('input', { bubbles: true }));
+    search.focus();
+  }
+}
+
+function worktreeSessionChip(rel) {
+  const sid = String(rel?.session_id || '').trim();
+  const status = String(rel?.status || '').trim();
+  const navigable = worktreeRelatedSessionNavigable(rel);
+  const active = WORKTREE_ACTIVE_SESSION_STATUSES.has(status);
+  const chip = document.createElement(navigable ? 'button' : 'span');
+  if (navigable) chip.type = 'button';
+  chip.className = 'wt-session-chip'
+    + (active ? ' active' : '')
+    + (navigable ? '' : ' static');
+
+  const source = normalizeAgentId(rel?.source || '') || String(rel?.source || '');
+  const sourceEl = document.createElement('span');
+  sourceEl.className = 'wt-session-source';
+  sourceEl.textContent = prettyAgentName(source) || source || 'session';
+  chip.appendChild(sourceEl);
+
+  const idEl = document.createElement('span');
+  idEl.className = 'wt-session-id';
+  idEl.textContent = sid.startsWith('gemini-project:')
+    ? sid.slice('gemini-project:'.length)
+    : (sid.length > 10 ? `${shortSessionId(sid)}…` : sid);
+  chip.appendChild(idEl);
+
+  if (status) {
+    const statusEl = document.createElement('span');
+    statusEl.className = 'wt-session-status';
+    statusEl.textContent = status;
+    chip.appendChild(statusEl);
+  }
+
+  const when = rel?.updated_at ? ` · ${fmtWorktreeMinute(rel.updated_at)}` : '';
+  chip.title = navigable
+    ? `Open session ${sid}${status ? ` (${status}${when})` : ''}`
+    : `${sid}${status ? ` (${status}${when})` : ''}`;
+  if (navigable) {
+    chip.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      openWorktreeRelatedSession(rel);
+    });
+  }
+  return chip;
+}
+
+function renderWorktreeSessionChips(wt) {
+  const related = Array.isArray(wt?.related_sessions) ? wt.related_sessions : [];
+  if (related.length === 0) return null;
+  const row = document.createElement('div');
+  row.className = 'wt-sessions';
+  for (const rel of related) {
+    row.appendChild(worktreeSessionChip(rel));
+  }
+  const total = Number(wt.related_session_count || 0);
+  if (total > related.length) {
+    const rest = document.createElement('span');
+    rest.className = 'wt-session-chip static wt-session-rest';
+    rest.textContent = `+${(total - related.length).toLocaleString()} more`;
+    rest.title = `${total.toLocaleString()} related sessions total; the inventory ships ${related.length} per worktree`;
+    row.appendChild(rest);
+  }
+  return row;
 }
 
 let worktreeInspectContext = null;
@@ -516,6 +636,11 @@ function recomputeWorktreeSummary(scan) {
     stale: 0,
     cleanup_candidates: 0,
     truncated_sizes: 0,
+    // Volume capacity comes from the scan, not the rows; carry it through
+    // (it only goes stale by the removal that just freed space, in the
+    // conservative direction — the next scan refreshes it).
+    volume_free_bytes: scan?.summary?.volume_free_bytes,
+    volume_total_bytes: scan?.summary?.volume_total_bytes,
   };
   for (const wt of rows) {
     summary.total_bytes += Number(wt.size_bytes || 0);
@@ -798,11 +923,11 @@ function renderWorktreesList(scan, el) {
       addMeta('tracking', formatWorktreeDivergence(wt.upstream, wt.ahead, wt.behind), null, wt.upstream);
     }
     if (wt.dirty) addMeta('changes', `${wt.staged || 0} staged, ${wt.unstaged || 0} unstaged, ${wt.untracked || 0} untracked`, 'v-red');
-    if ((wt.active_sessions || 0) > 0 || (wt.related_session_count || 0) > 0) {
-      addMeta('sessions', `${wt.active_sessions || 0} active / ${wt.related_session_count || 0} related`, (wt.active_sessions || 0) > 0 ? 'v-yellow' : null);
-    }
     addMeta('files', `${Number(wt.file_count || 0).toLocaleString()} files`);
     card.appendChild(meta);
+
+    const sessionsRow = renderWorktreeSessionChips(wt);
+    if (sessionsRow) card.appendChild(sessionsRow);
 
     const actions = document.createElement('div');
     actions.className = 'sc-actions';

--- a/static/app/57-sessions-replay.js
+++ b/static/app/57-sessions-replay.js
@@ -619,6 +619,26 @@ window.closeWorktreeInspectModal = closeWorktreeInspectModal;
 window.worktreeInspectOpenShell = worktreeInspectOpenShell;
 window.worktreeInspectOpenFiles = worktreeInspectOpenFiles;
 
+// QA readback (window.qa convention) + one explicit test hook: headless
+// probes can't ride the control tunnel (the first-visit forced scan is a
+// tunnel-only POST twin), so the worktrees pane exposes its rendered state
+// and a scan-injection hook that runs the exact production render path on
+// caller-supplied data.
+window.qa = Object.assign(window.qa || {}, {
+  worktreesPane: () => ({
+    tiles: [...document.querySelectorAll('#worktrees-aggregate .agg-card')]
+      .map(card => card.textContent.trim().replace(/\s+/g, ' ')),
+    chips: [...document.querySelectorAll('#worktrees-list .wt-session-chip')]
+      .map(chip => ({ tag: chip.tagName, text: chip.textContent.trim().replace(/\s+/g, ' ') })),
+    status: document.getElementById('worktrees-status')?.textContent || '',
+  }),
+  worktreesRenderScan: (scan) => {
+    _cachedWorktreeScan = scan;
+    renderWorktrees(scan);
+    return window.qa.worktreesPane();
+  },
+});
+
 function formatWorktreeDivergence(target, ahead, behind) {
   const label = target ? `${target} ` : '';
   return `${label}+${Number(ahead || 0).toLocaleString()} / -${Number(behind || 0).toLocaleString()}`;

--- a/static/app/ui2-sessions.css
+++ b/static/app/ui2-sessions.css
@@ -295,6 +295,8 @@ html.ui-v2 #tab-sessions .sessions-aggregate .ui-stat-value {
   letter-spacing: -.01em;
   color: var(--text);
 }
+html.ui-v2 #tab-sessions .sessions-aggregate .ui-stat-value.v-yellow { color: var(--amber); }
+html.ui-v2 #tab-sessions .sessions-aggregate .ui-stat-value.v-red { color: var(--rose); }
 html.ui-v2 #tab-sessions .sessions-aggregate .ui-stat-sub {
   margin-top: 3px;
   font-size: 10.5px;
@@ -855,6 +857,33 @@ html.ui-v2 #tab-sessions .worktree-card .wt-label.unknown-merge {
   background: rgba(var(--amber-rgb), .1);
   color: var(--amber);
 }
+html.ui-v2 #tab-sessions .worktree-card .wt-sessions { gap: 5px; margin: 8px 0 0; }
+html.ui-v2 #tab-sessions .worktree-card .wt-session-chip {
+  padding: 2px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--surface-2);
+  color: var(--text-2);
+  font-size: 10.5px;
+}
+html.ui-v2 #tab-sessions button.wt-session-chip:hover,
+html.ui-v2 #tab-sessions button.wt-session-chip:focus-visible {
+  border-color: var(--iris);
+  color: var(--text);
+  background: var(--surface-3);
+}
+html.ui-v2 #tab-sessions .worktree-card .wt-session-chip.active {
+  border-color: rgba(var(--amber-rgb), .5);
+  color: var(--amber);
+}
+html.ui-v2 #tab-sessions .worktree-card .wt-session-source {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: .05em;
+}
+html.ui-v2 #tab-sessions .worktree-card .wt-session-id { font-family: var(--mono); }
+html.ui-v2 #tab-sessions .worktree-card .wt-session-status { color: var(--text-3); }
+html.ui-v2 #tab-sessions .worktree-card .wt-session-chip.active .wt-session-status { color: inherit; }
 html.ui-v2 #tab-sessions .worktree-card .wt-safety {
   margin: 8px 0;
   padding: 7px 10px;


### PR DESCRIPTION
## Sessions → Worktrees: free-disk tile + navigable related-session chips

Two operator affordances for the worktrees inventory, both motivated by the
2026-07-06 disk-full incident (multi-GB worktree `target/` dirs) and by the
scan's session linkage being computed but not surfaced.

### Free disk space

- New `platform::volume_space(path)` (`VolumeSpace { free_bytes, total_bytes }`):
  `statfs` on Apple (64-bit block counts; `statvfs`'s `fsblkcnt_t` is 32-bit
  on Darwin and overflows >16 TiB volumes), `statvfs` on other Unix,
  `GetDiskFreeSpaceExW` on Windows (quota-aware caller-available bytes).
  File paths normalize to their parent so all platforms accept any existing
  path. `// SAFETY:`-commented FFI islands per the platform.rs convention.
- `WorktreeScanRoot` carries `volume_free_bytes`/`volume_total_bytes` for
  existing roots; `WorktreeSummary` carries the tightest volume actually
  hosting scanned worktrees (deduped by device id / drive prefix, so one
  query per volume) — a roots-based figure would let a session-cwd root on
  an unrelated, nearly-full mount skew the headline red.
  `#[serde(default)]` for older cached scans.
- Dashboard: a "Free disk" aggregate tile with percent-of-total sub-line;
  amber under 10% free, rose under 5% (`valueClass` support on
  `renderAggregateStatTiles`, carried through the client-side summary
  recompute after removals).

### Related-session chips

The scan already ties each worktree to the sessions observed inside it —
supervised and raw codex/claude sessions alike, via the session catalog's
observed-path hints — but the UI only showed a count. Each worktree card now
renders its `related_sessions` as chips (source, short id, status; amber
accent while active):

- Click focuses the live session window when one exists, otherwise routes to
  Sessions → Recent with the ID prefilled in the search box (where the
  catalog lists raw external sessions too, one click from open/resume).
- Gemini `gemini-project:*` pseudo-entries render as static labels — they
  are project aliases, not sessions.
- The backend ships at most 8 related sessions per worktree; a static
  "+N more" chip reports the remainder against `related_session_count`.
- Replaces the old "sessions: N active / M related" meta text (the chips are
  strictly more informative).

### Tests

- `platform::tests::volume_space_reports_plausible_capacity` /
  `volume_space_missing_path_is_none`
- `worktree_inventory::tests::scan_reports_volume_capacity_for_existing_roots`
  (existing roots report capacity, missing roots stay `None`, summary
  reports the worktree-hosting volume)
