### PR TITLE
worktrees: Clean target/ — reclaim build output without removing the checkout

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -513,10 +513,14 @@ directory is safe to delete; it rebuilds on the next scan.
 - **Worktrees** — the git worktree inventory (same card + Show-more
   treatment): per-checkout size, merge/dirty state, and safety verdicts;
   aggregate tiles including **free disk** on the tightest worktree-hosting
-  volume (amber under 10% free, rose under 5%); and **related-session
-  chips** — the sessions observed inside each checkout, supervised and raw
-  codex/claude alike. Clicking a chip focuses the live session window when
-  one exists, otherwise it lands on Recent with the ID prefilled.
+  volume (amber under 10% free, rose under 5%) and **reclaimable** build
+  output; and **related-session chips** — the sessions observed inside
+  each checkout, supervised and raw codex/claude alike. Clicking a chip
+  focuses the live session window when one exists, otherwise it lands on
+  Recent with the ID prefilled. Checkouts with a CACHEDIR.TAG-marked Cargo
+  `target/` offer **Clean target/** — delete the build directory to
+  reclaim its bytes without removing the worktree (sources and git state
+  untouched; a warning notes active sessions first).
 - **New Session** — start a fresh session from the dashboard.
   Internal-agent launches get an **Execution** control — *Auto* (the
   task-size heuristic decides), *Orchestrate* (delegates to supervised
@@ -1554,7 +1558,7 @@ family (sub-routes elided where the family is uniform):
 | `POST /api/access/...` | Trust mutations: enrollment decide, IAM grant upsert/update, org trust/revoke, org-grant issue/renew/revoke-member, issuer init/delegate/install, revocation-list apply |
 | `GET /api/peers[/*]`, `POST /api/peers[/*]`, `DELETE /api/peers` | Peer federation: registry reads (GET), pairing + management/signaling (POST), registry removal (DELETE) |
 | `POST /api/coordinator/route` | Multi-agent coordinator task routing (peer lane) |
-| `GET /api/worktrees`, `POST /api/worktrees/{inspect,scan,remove,merge}` | Agent worktree inventory and lifecycle (merge = session-linked worktree finish card) |
+| `GET /api/worktrees`, `POST /api/worktrees/{inspect,scan,remove,clean,merge}` | Agent worktree inventory and lifecycle (clean = reclaim a checkout's Cargo target/; merge = session-linked worktree finish card) |
 | `GET /connect/{bootstrap,status}`, `POST /connect/dashboard/{offer,ice,close}` | Daemon-origin WebRTC control bootstrap: certless only on loopback, remote callers require direct mTLS; fleet SNI and hosted Connect browser APIs cannot open it |
 
 ### Declared API routes
@@ -1630,6 +1634,7 @@ shell only.
 | GET | `/api/managed-context/fission` | SessionInspect | own origin | none | Managed-context fission state |
 | POST | `/api/worktrees/inspect` | SessionInspect | own origin | bounded | Inspect one worktree (branch, ahead/behind, dirty state) |
 | POST | `/api/worktrees/remove` | SessionManage | own origin | bounded | Remove a worktree from the inventory |
+| POST | `/api/worktrees/clean` | SessionManage | own origin | bounded | Delete a worktree's Cargo target/ dir (CACHEDIR.TAG-gated) to reclaim disk, keeping the checkout |
 | POST | `/api/worktrees/merge` | SessionManage | own origin | bounded | Merge a session's linked worktree branch into its base checkout, then remove the checkout |
 | POST | `/api/worktrees/scan` | SessionManage | own origin | none | Rescan the worktree inventory (refreshes the cache) |
 | GET | `/api/worktrees` | SessionInspect | own origin | none | Cached worktree inventory |

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -895,6 +895,33 @@ pub(crate) async fn api_worktrees_remove_response(
     }
 }
 
+pub(crate) async fn api_worktrees_clean_response(
+    id: String,
+    params: Option<&serde_json::Value>,
+    runtime: &ControlRuntime,
+) -> serde_json::Value {
+    let body_text = params_body_text(params);
+    let cache = runtime.worktree_inventory_cache.clone();
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+    let result = tokio::task::spawn_blocking(move || {
+        crate::web_gateway::worktrees_clean_api_response(&home, &body_text, &cache)
+    })
+    .await;
+    match result {
+        Ok(response) => frame_api_response(id, response, "worktree clean"),
+        Err(e) => http_body_response(
+            id,
+            500,
+            serde_json::json!({
+                "ok": false,
+                "error": format!("worktree clean task failed: {e}")
+            })
+            .to_string(),
+            "worktree clean",
+        ),
+    }
+}
+
 pub(crate) async fn api_worktrees_merge_response(
     id: String,
     params: Option<&serde_json::Value>,

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -317,6 +317,7 @@ pub(crate) async fn control_request_frame(
         "api_worktrees_remove" => {
             api_worktrees_remove_response(id, params.as_ref(), &runtime).await
         }
+        "api_worktrees_clean" => api_worktrees_clean_response(id, params.as_ref(), &runtime).await,
         "api_worktrees_merge" => api_worktrees_merge_response(id, params.as_ref(), &runtime).await,
         "api_managed_context_records" => {
             api_managed_context_response(id, "records", params.as_ref(), &runtime).await

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -4155,6 +4155,7 @@ mod tests {
             ("api_session_control_msg", Residue, Some(Op::SessionManage)),
             ("api_worktrees_scan", Row, Some(Op::SessionManage)),
             ("api_worktrees_remove", Row, Some(Op::SessionManage)),
+            ("api_worktrees_clean", Row, Some(Op::SessionManage)),
             ("api_worktrees_merge", Row, Some(Op::SessionManage)),
             ("api_session_current_upload", Row, Some(Op::SessionManage)),
             // The transfer family flipped Residue → Row with its

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -241,6 +241,7 @@ pub(crate) enum RouteHandlerId {
     McFission,
     WorktreesInspect,
     WorktreesRemove,
+    WorktreesClean,
     WorktreesMerge,
     WorktreesScan,
     WorktreesList,
@@ -1114,6 +1115,15 @@ pub(crate) static ROUTES: &[Route] = &[
         "Remove a worktree from the inventory",
     )
     .with_tunnel(tunnel_method("api_worktrees_remove")),
+    op_route(
+        RouteMethod::Post,
+        PathPattern::Exact("/api/worktrees/clean"),
+        PeerOperation::SessionManage,
+        BodyPolicy::Default,
+        RouteHandlerId::WorktreesClean,
+        "Delete a worktree's Cargo target/ dir (CACHEDIR.TAG-gated) to reclaim disk, keeping the checkout",
+    )
+    .with_tunnel(tunnel_method("api_worktrees_clean")),
     op_route(
         RouteMethod::Post,
         PathPattern::Exact("/api/worktrees/merge"),

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -704,6 +704,16 @@ pub(crate) async fn serve_http_request(
                 )
                 .await;
             }
+            RouteHandlerId::WorktreesClean => {
+                return handle_worktrees_clean(
+                    stream,
+                    route_body,
+                    worktree_inventory_cache,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
             RouteHandlerId::WorktreesMerge => {
                 return handle_worktrees_merge(stream, route_body, worktree_inventory_cache).await;
             }

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -417,6 +417,55 @@ pub(crate) fn worktrees_remove_api_response(
     ApiResponse::json(status_line_code(status_line), JsonBody::PreSerialized(body))
 }
 
+pub(crate) fn worktrees_clean_api_response(
+    home: &Path,
+    body_text: &str,
+    cache: &Arc<Mutex<Option<String>>>,
+) -> ApiResponse {
+    let (status_line, body) = clean_worktree_inventory_response(home, body_text);
+    if status_line == "200 OK" {
+        if let Ok(mut guard) = cache.lock() {
+            *guard = None;
+        }
+    }
+    ApiResponse::json(status_line_code(status_line), JsonBody::PreSerialized(body))
+}
+
+pub(crate) fn clean_worktree_inventory_response(
+    home: &Path,
+    body_text: &str,
+) -> (&'static str, String) {
+    let request =
+        match serde_json::from_str::<crate::worktree_inventory::WorktreeCleanRequest>(body_text) {
+            Ok(request) => request,
+            Err(e) => {
+                return (
+                    "400 Bad Request",
+                    serde_json::json!({
+                        "ok": false,
+                        "error": format!("invalid worktree clean request: {e}")
+                    })
+                    .to_string(),
+                );
+            }
+        };
+    let hints = worktree_session_hints_from_home(home);
+    match crate::worktree_inventory::clean_worktree_target_if_safe(request, &hints) {
+        Ok(response) => (
+            "200 OK",
+            serde_json::to_string(&response).unwrap_or_else(|_| "{}".to_string()),
+        ),
+        Err(e) => (
+            "409 Conflict",
+            serde_json::json!({
+                "ok": false,
+                "error": e
+            })
+            .to_string(),
+        ),
+    }
+}
+
 pub(crate) fn inspect_worktree_inventory_response(
     home: &Path,
     body_text: &str,
@@ -3759,6 +3808,34 @@ pub(crate) async fn handle_worktrees_remove(
                 serde_json::json!({
                     "ok": false,
                     "error": format!("worktree removal task failed: {e}")
+                })
+                .to_string(),
+            ),
+        ),
+    };
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+pub(crate) async fn handle_worktrees_clean(
+    stream: DemuxStream,
+    body_text: String,
+    worktree_inventory_cache: Arc<Mutex<Option<String>>>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let home = crate::platform::home_dir();
+    let response = match tokio::task::spawn_blocking(move || {
+        worktrees_clean_api_response(&home, &body_text, &worktree_inventory_cache)
+    })
+    .await
+    {
+        Ok(response) => response,
+        Err(e) => ApiResponse::json(
+            500,
+            JsonBody::PreSerialized(
+                serde_json::json!({
+                    "ok": false,
+                    "error": format!("worktree clean task failed: {e}")
                 })
                 .to_string(),
             ),

--- a/src/bin/caller/worktree_inventory.rs
+++ b/src/bin/caller/worktree_inventory.rs
@@ -71,6 +71,10 @@ pub struct WorktreeSummary {
     pub stale: usize,
     pub cleanup_candidates: usize,
     pub truncated_sizes: usize,
+    /// Sum of the entries' `reclaimable_bytes`: disk the clean endpoint
+    /// could free without removing any checkout.
+    #[serde(default)]
+    pub reclaimable_bytes: u64,
     /// The tightest volume hosting the scanned worktrees: free/total of
     /// whichever such volume has the least free space (what a full disk
     /// hits first). Worktrees usually share one volume, in which case this
@@ -118,6 +122,11 @@ pub struct WorktreeEntry {
     pub file_count: u64,
     pub dir_count: u64,
     pub size_truncated: bool,
+    /// Bytes under the worktree's top-level `target/` when it is a real
+    /// directory carrying Cargo's `CACHEDIR.TAG` marker — build output the
+    /// clean endpoint can delete without touching sources. 0 otherwise.
+    #[serde(default)]
+    pub reclaimable_bytes: u64,
     pub active_sessions: usize,
     pub related_session_count: usize,
     pub related_sessions: Vec<RelatedSession>,
@@ -147,6 +156,27 @@ pub struct WorktreeInspectRequest {
     pub repo_root: PathBuf,
     pub path: PathBuf,
     pub expected_head: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorktreeCleanRequest {
+    pub repo_root: PathBuf,
+    pub path: PathBuf,
+    pub expected_head: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorktreeCleanResponse {
+    pub ok: bool,
+    pub path: PathBuf,
+    pub repo_root: PathBuf,
+    pub branch: Option<String>,
+    /// Bytes actually reclaimed (re-measured on partial deletion).
+    pub freed_bytes: u64,
+    /// True when some entries survived the delete (Windows file locks,
+    /// permissions); the survivors and cause are described in `detail`.
+    pub partial: bool,
+    pub detail: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -224,8 +254,29 @@ struct TreeMeasure {
     bytes: u64,
     files: u64,
     dirs: u64,
+    /// Bytes attributed to the tree's top-level `target/` dir when it is a
+    /// CACHEDIR.TAG-marked Cargo build dir (see `cargo_target_dir`).
+    target_bytes: u64,
     latest_mtime: Option<SystemTime>,
     truncated: bool,
+}
+
+/// The worktree's top-level `target/` when it is deletable build output: a
+/// real directory (never a symlink — deleting through one would reach
+/// outside the checkout) carrying the `CACHEDIR.TAG` marker Cargo writes
+/// into every target dir it creates. The marker distinguishes Cargo build
+/// output from a source directory that merely happens to be named
+/// `target/` (e.g. Maven's).
+fn cargo_target_dir(worktree_root: &Path) -> Option<PathBuf> {
+    let target = worktree_root.join("target");
+    let meta = std::fs::symlink_metadata(&target).ok()?;
+    if !meta.is_dir() {
+        return None;
+    }
+    if !target.join("CACHEDIR.TAG").is_file() {
+        return None;
+    }
+    Some(target)
 }
 
 #[derive(Debug)]
@@ -648,6 +699,9 @@ fn scan_worktrees_with_size_budget(
     }
     for wt in &worktrees {
         summary.total_bytes = summary.total_bytes.saturating_add(wt.size_bytes);
+        summary.reclaimable_bytes = summary
+            .reclaimable_bytes
+            .saturating_add(wt.reclaimable_bytes);
         if wt.dirty {
             summary.dirty += 1;
         }
@@ -772,6 +826,115 @@ pub fn remove_worktree_if_safe(
         head: entry.head,
         size_bytes: entry.size_bytes,
         safety: entry.safety,
+    })
+}
+
+/// Dashboard reclaim path: delete a worktree's Cargo `target/` directory —
+/// keep the checkout, free the build output. Deliberately deletes the
+/// measured directory itself rather than spawning `cargo clean`: the
+/// daemon's environment may carry `CARGO_TARGET_DIR`, under which
+/// `cargo clean` would wipe a shared external build dir instead of this
+/// worktree's, so direct deletion is what frees exactly the bytes the
+/// inventory advertised.
+///
+/// Verification mirrors `remove_worktree_if_safe` (registered worktree of
+/// the claimed repo, optional HEAD pin), then requires the target dir to be
+/// a real, CACHEDIR.TAG-marked Cargo build dir (`cargo_target_dir`).
+/// Activity is intentionally NOT a refusal: cleaning under a live build
+/// only wastes that build — the frontend warns instead.
+pub fn clean_worktree_target_if_safe(
+    request: WorktreeCleanRequest,
+    session_hints: &[WorktreeSessionHint],
+) -> Result<WorktreeCleanResponse, String> {
+    if !request.repo_root.is_absolute() {
+        return Err("repo_root must be an absolute path".to_string());
+    }
+    if !request.path.is_absolute() {
+        return Err("worktree path must be an absolute path".to_string());
+    }
+
+    let repo_root = git_repo_root(&request.repo_root).ok_or_else(|| {
+        format!(
+            "{} is not the root of a Git repository",
+            request.repo_root.display()
+        )
+    })?;
+    if !same_path(&repo_root, &request.repo_root) {
+        return Err(format!(
+            "repo_root resolves to {}; scan again before cleaning",
+            repo_root.display()
+        ));
+    }
+
+    let (listed_root, listed) = list_repo_worktrees(&repo_root)?;
+    let raw = listed
+        .into_iter()
+        .find(|raw| same_path(&raw.path, &request.path))
+        .ok_or_else(|| {
+            format!(
+                "{} is not registered as a worktree for {}",
+                request.path.display(),
+                repo_root.display()
+            )
+        })?;
+
+    let repo_ctx = RepoContext::new(listed_root);
+    if let Some(head) = raw.head.clone() {
+        repo_ctx.prefill_head_times(std::slice::from_ref(&head));
+    }
+    let size_budget = SizeBudget::new(MAX_SIZE_ENTRIES_PER_WORKTREE);
+    let hint_index = HintIndex::new(session_hints);
+    let entry = enrich_worktree(raw, &repo_ctx, &hint_index, &size_budget)?;
+
+    if let Some(expected) = request
+        .expected_head
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        if entry.head.as_deref() != Some(expected) {
+            return Err(
+                "worktree HEAD changed since the last scan; scan again before cleaning".to_string(),
+            );
+        }
+    }
+
+    let target = cargo_target_dir(&entry.path).ok_or_else(|| {
+        format!(
+            "{} has no deletable Cargo target dir (needs a real target/ directory carrying CACHEDIR.TAG)",
+            entry.path.display()
+        )
+    })?;
+
+    let before = measure_tree(&target);
+    let delete_error = std::fs::remove_dir_all(&target).err();
+    let (freed_bytes, partial, detail) = match delete_error {
+        None => (before.bytes, false, None),
+        Some(e) => {
+            // Windows file locks (a live build, rust-analyzer) abort
+            // remove_dir_all partway; report what actually got freed and
+            // leave the survivors for a later pass.
+            let after = if target.exists() {
+                measure_tree(&target)
+            } else {
+                TreeMeasure::default()
+            };
+            (
+                before.bytes.saturating_sub(after.bytes),
+                target.exists(),
+                Some(format!("some entries were not deleted: {e}")),
+            )
+        }
+    };
+
+    Ok(WorktreeCleanResponse {
+        ok: true,
+        path: entry.path,
+        repo_root: entry.repo_root,
+        branch: entry.branch,
+        freed_bytes,
+        partial,
+        detail,
     })
 }
 
@@ -1166,6 +1329,7 @@ fn enrich_worktree(
         file_count: tree.files,
         dir_count: tree.dirs,
         size_truncated: tree.truncated,
+        reclaimable_bytes: tree.target_bytes,
         active_sessions,
         related_session_count: related.len(),
         related_sessions: related.into_iter().take(8).collect(),
@@ -1612,7 +1776,6 @@ fn git_string(path: &Path, args: &[&str]) -> Result<String, String> {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-#[cfg(test)]
 fn measure_tree(root: &Path) -> TreeMeasure {
     let budget = SizeBudget::new(MAX_SIZE_ENTRIES_PER_WORKTREE);
     measure_tree_with_budget(root, &budget)
@@ -1624,6 +1787,10 @@ fn measure_tree_with_budget(root: &Path, size_budget: &SizeBudget) -> TreeMeasur
     let mut visited = 0usize;
     // Track inodes of multiply-linked files so each is counted once.
     let mut seen_inodes: HashSet<(u64, u64)> = HashSet::new();
+    // Attribute bytes under a CACHEDIR.TAG-marked top-level `target/` as
+    // reclaimable build output — same walk, no extra I/O beyond the one
+    // marker probe.
+    let target_dir = cargo_target_dir(root);
     while let Some(path) = stack.pop() {
         if visited >= MAX_SIZE_ENTRIES_PER_WORKTREE || !size_budget.take_entry() {
             measure.truncated = true;
@@ -1665,9 +1832,14 @@ fn measure_tree_with_budget(root: &Path, size_budget: &SizeBudget) -> TreeMeasur
             {
                 continue;
             }
-            measure.bytes = measure
-                .bytes
-                .saturating_add(crate::platform::metadata_on_disk_bytes(&meta));
+            let file_bytes = crate::platform::metadata_on_disk_bytes(&meta);
+            measure.bytes = measure.bytes.saturating_add(file_bytes);
+            if target_dir
+                .as_deref()
+                .is_some_and(|target| path.starts_with(target))
+            {
+                measure.target_bytes = measure.target_bytes.saturating_add(file_bytes);
+            }
         }
     }
     measure
@@ -1886,6 +2058,215 @@ mod tests {
             .expect("summary reports capacity when any worktree exists");
         assert!(summary_total > 0);
         assert!(summary_free <= summary_total);
+    }
+
+    fn write_cargo_target(worktree: &Path, payload_bytes: usize) {
+        let target = worktree.join("target");
+        std::fs::create_dir_all(target.join("debug")).unwrap();
+        std::fs::write(
+            target.join("CACHEDIR.TAG"),
+            "Signature: 8a477f597d28d172789f06886806bc55\n",
+        )
+        .unwrap();
+        std::fs::write(
+            target.join("debug").join("blob.bin"),
+            vec![7u8; payload_bytes],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn scan_attributes_marked_cargo_target_as_reclaimable() {
+        let tmp = init_repo();
+        let repo = repo_path(&tmp);
+        let marked = tmp.path().join("marked-worktree");
+        let unmarked = tmp.path().join("unmarked-worktree");
+        git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "marked",
+                &marked.to_string_lossy(),
+                "main",
+            ],
+        );
+        git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "unmarked",
+                &unmarked.to_string_lossy(),
+                "main",
+            ],
+        );
+        write_cargo_target(&marked, 64 * 1024);
+        // A directory merely named target/ (no CACHEDIR.TAG) is not build
+        // output and must not be counted reclaimable.
+        std::fs::create_dir_all(unmarked.join("target")).unwrap();
+        std::fs::write(unmarked.join("target").join("data.txt"), "source\n").unwrap();
+
+        let scan = scan_worktrees(tmp.path(), Some(&repo), &[]);
+        let find = |branch: &str| {
+            scan.worktrees
+                .iter()
+                .find(|entry| entry.branch.as_deref() == Some(branch))
+                .unwrap_or_else(|| panic!("{branch} worktree found"))
+        };
+        let marked_entry = find("marked");
+        assert!(marked_entry.reclaimable_bytes >= 64 * 1024);
+        assert!(marked_entry.reclaimable_bytes <= marked_entry.size_bytes);
+        assert_eq!(find("unmarked").reclaimable_bytes, 0);
+        assert!(scan.summary.reclaimable_bytes >= marked_entry.reclaimable_bytes);
+    }
+
+    #[test]
+    fn clean_deletes_marked_target_and_keeps_sources() {
+        let tmp = init_repo();
+        let repo = repo_path(&tmp);
+        let wt = tmp.path().join("clean-target-worktree");
+        git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "clean-target",
+                &wt.to_string_lossy(),
+                "main",
+            ],
+        );
+        write_cargo_target(&wt, 32 * 1024);
+
+        let response = clean_worktree_target_if_safe(
+            WorktreeCleanRequest {
+                repo_root: canonical_child_path(&repo),
+                path: canonical_child_path(&wt),
+                expected_head: None,
+            },
+            &[],
+        )
+        .expect("clean succeeds");
+
+        assert!(response.ok);
+        assert!(!response.partial);
+        assert!(response.freed_bytes >= 32 * 1024);
+        assert!(!wt.join("target").exists(), "target dir is gone");
+        assert!(wt.join("README.md").exists(), "sources are untouched");
+        // The checkout is still a registered worktree afterwards.
+        let scan = scan_worktrees(tmp.path(), Some(&repo), &[]);
+        assert!(scan
+            .worktrees
+            .iter()
+            .any(|entry| entry.branch.as_deref() == Some("clean-target")));
+    }
+
+    #[test]
+    fn clean_refuses_unmarked_target() {
+        let tmp = init_repo();
+        let repo = repo_path(&tmp);
+        let wt = tmp.path().join("unmarked-clean-worktree");
+        git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "unmarked-clean",
+                &wt.to_string_lossy(),
+                "main",
+            ],
+        );
+        std::fs::create_dir_all(wt.join("target")).unwrap();
+        std::fs::write(wt.join("target").join("data.txt"), "source\n").unwrap();
+
+        let err = clean_worktree_target_if_safe(
+            WorktreeCleanRequest {
+                repo_root: canonical_child_path(&repo),
+                path: canonical_child_path(&wt),
+                expected_head: None,
+            },
+            &[],
+        )
+        .expect_err("unmarked target must be refused");
+        assert!(err.contains("CACHEDIR.TAG"), "unexpected error: {err}");
+        assert!(wt.join("target").join("data.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn clean_refuses_symlinked_target() {
+        let tmp = init_repo();
+        let repo = repo_path(&tmp);
+        let wt = tmp.path().join("symlink-clean-worktree");
+        git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "symlink-clean",
+                &wt.to_string_lossy(),
+                "main",
+            ],
+        );
+        let outside = tmp.path().join("outside-target");
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(
+            outside.join("CACHEDIR.TAG"),
+            "Signature: 8a477f597d28d172789f06886806bc55\n",
+        )
+        .unwrap();
+        std::os::unix::fs::symlink(&outside, wt.join("target")).unwrap();
+
+        let err = clean_worktree_target_if_safe(
+            WorktreeCleanRequest {
+                repo_root: canonical_child_path(&repo),
+                path: canonical_child_path(&wt),
+                expected_head: None,
+            },
+            &[],
+        )
+        .expect_err("symlinked target must be refused");
+        assert!(err.contains("CACHEDIR.TAG"), "unexpected error: {err}");
+        assert!(
+            outside.join("CACHEDIR.TAG").exists(),
+            "link target untouched"
+        );
+    }
+
+    #[test]
+    fn clean_refuses_stale_head_pin() {
+        let tmp = init_repo();
+        let repo = repo_path(&tmp);
+        let wt = tmp.path().join("stale-head-clean-worktree");
+        git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "stale-head-clean",
+                &wt.to_string_lossy(),
+                "main",
+            ],
+        );
+        write_cargo_target(&wt, 1024);
+
+        let err = clean_worktree_target_if_safe(
+            WorktreeCleanRequest {
+                repo_root: canonical_child_path(&repo),
+                path: canonical_child_path(&wt),
+                expected_head: Some("0000000000000000000000000000000000000000".to_string()),
+            },
+            &[],
+        )
+        .expect_err("stale head pin must be refused");
+        assert!(err.contains("HEAD changed"), "unexpected error: {err}");
+        assert!(wt.join("target").exists());
     }
 
     #[test]

--- a/static/app.html
+++ b/static/app.html
@@ -28022,7 +28022,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'f1c3d0ce811c71ca';
+const INTENDANT_APP_BUILD = '72a02c364cc985d1';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -98249,6 +98249,14 @@ function renderWorktreesAggregate(scan, el) {
   ];
   const freeDisk = worktreeFreeDiskCard(summary);
   if (freeDisk) cards.push(freeDisk);
+  if ((summary.reclaimable_bytes || 0) > 0) {
+    cards.push({
+      label: 'Reclaimable',
+      value: _fmtBytes(summary.reclaimable_bytes),
+      sub: 'cargo target/ dirs',
+      title: 'Build output the per-worktree Clean button can delete without removing any checkout',
+    });
+  }
   cards.push(
     { label: 'Dirty', value: Number(summary.dirty || 0).toLocaleString() },
     { label: 'Unmerged', value: Number(summary.unmerged || 0).toLocaleString() },
@@ -98739,6 +98747,7 @@ function recomputeWorktreeSummary(scan) {
     stale: 0,
     cleanup_candidates: 0,
     truncated_sizes: 0,
+    reclaimable_bytes: 0,
     // Volume capacity comes from the scan, not the rows; carry it through
     // (it only goes stale by the removal that just freed space, in the
     // conservative direction — the next scan refreshes it).
@@ -98747,6 +98756,7 @@ function recomputeWorktreeSummary(scan) {
   };
   for (const wt of rows) {
     summary.total_bytes += Number(wt.size_bytes || 0);
+    summary.reclaimable_bytes += Number(wt.reclaimable_bytes || 0);
     if (wt.dirty) summary.dirty += 1;
     if (wt.merge_status === 'unmerged') summary.unmerged += 1;
     if ((wt.active_sessions || 0) > 0) summary.active += 1;
@@ -98775,6 +98785,75 @@ function setWorktreeRemoveButtonPending(button, state) {
     : mode === 'removing'
     ? 'Removing...'
     : 'Remove worktree...';
+}
+
+// Reclaim a worktree's Cargo target/ without removing the checkout — the
+// middle ground between keeping a fat worktree and deleting it. Cleans are
+// independent per-directory fs deletes, so a per-path pending set suffices
+// (no serialization queue like removals, which contend on git locks).
+const pendingWorktreeCleans = new Set();
+
+async function cleanWorktreeTarget(wt, button) {
+  const pathKey = String(wt.path || '');
+  if (!pathKey || pendingWorktreeCleans.has(pathKey)) return;
+  const activeWarning = (wt.active_sessions || 0) > 0
+    ? `\n\n${wt.active_sessions} session(s) look active in this worktree — a build running there will lose its progress and start over.`
+    : '';
+  const ok = await showDashboardConfirm({
+    title: 'Clean target/',
+    message:
+      `Delete the Cargo build directory of ${wt.branch || wt.head_short || wt.path}?\n\n` +
+      `Path: ${wt.path}/target\n` +
+      `Reclaims about ${_fmtBytes(wt.reclaimable_bytes || 0)}.`,
+    warning:
+      'Sources and git state are untouched; the next build recreates target/ from scratch.' +
+      activeWarning,
+    confirmLabel: 'Clean',
+  });
+  if (!ok) return;
+
+  pendingWorktreeCleans.add(pathKey);
+  if (button) {
+    button.disabled = true;
+    button.classList.add('pending');
+    button.textContent = 'Cleaning...';
+  }
+  setWorktreesActivityNotice('pending', `Cleaning ${wt.path}/target...`);
+  try {
+    const payload = { repo_root: wt.repo_root, path: wt.path, expected_head: wt.head || null };
+    // daemonApi (transport F2): a POST twin — no HTTP replay after an
+    // attempted tunnel send, matching the remove call above.
+    const r = await daemonApi.request('api_worktrees_clean', payload);
+    const result = (r.body && typeof r.body === 'object') ? r.body : {};
+    if (!r.ok || result.ok === false) {
+      throw new Error(result.error || `worktree clean returned ${r.status}`);
+    }
+    const freed = Number(result.freed_bytes || 0);
+    if (_cachedWorktreeScan && Array.isArray(_cachedWorktreeScan.worktrees)) {
+      const entry = _cachedWorktreeScan.worktrees.find(e => e.path === wt.path);
+      if (entry) {
+        entry.size_bytes = Math.max(0, Number(entry.size_bytes || 0) - freed);
+        entry.reclaimable_bytes = result.partial
+          ? Math.max(0, Number(entry.reclaimable_bytes || 0) - freed)
+          : 0;
+      }
+      recomputeWorktreeSummary(_cachedWorktreeScan);
+    }
+    const message = result.partial
+      ? `Cleaned ${_fmtBytes(freed)} from ${wt.path}/target; some entries survived (${result.detail || 'locked files'}).`
+      : `Cleaned ${wt.path}/target. Freed about ${_fmtBytes(freed)}.`;
+    setWorktreesStatus(message, result.partial ? 'error' : '');
+    setWorktreesActivityNotice(result.partial ? 'error' : 'ok', message, result.partial ? 0 : 3500);
+    showControlToast(result.partial ? 'error' : 'success', result.partial ? 'Target partially cleaned.' : 'Target cleaned.');
+  } catch (err) {
+    const message = err.message || 'Worktree clean failed';
+    setWorktreesStatus(message, 'error');
+    setWorktreesActivityNotice('error', message);
+    showControlToast('error', message);
+  } finally {
+    pendingWorktreeCleans.delete(pathKey);
+    if (_cachedWorktreeScan) renderWorktrees(_cachedWorktreeScan);
+  }
 }
 
 async function removeWorktree(wt, button) {
@@ -99016,6 +99095,9 @@ function renderWorktreesList(scan, el) {
     };
     addMeta('repo', wt.repo_name);
     addMeta('size', _fmtBytes(wt.size_bytes || 0) + (wt.size_truncated ? ' +' : ''), wt.safe_to_remove ? 'v-green' : null);
+    if ((wt.reclaimable_bytes || 0) > 0) {
+      addMeta('target/', _fmtBytes(wt.reclaimable_bytes), null, 'Cargo build output the Clean button can reclaim');
+    }
     addMeta('changed', fmtWorktreeMinute(wt.last_changed_at), null, wt.last_changed_at || '');
     addMeta('commit', fmtWorktreeMinute(wt.head_author_time), null, wt.head_author_time || '');
     addMeta('merge', wt.merge_status, wt.merge_status === 'merged' ? 'v-green' : (wt.merge_status === 'unmerged' ? 'v-red' : null));
@@ -99055,6 +99137,21 @@ function renderWorktreesList(scan, el) {
       openWorktreeInspect(wt);
     });
     actions.appendChild(inspectBtn);
+
+    if ((wt.reclaimable_bytes || 0) > 0) {
+      const cleaning = pendingWorktreeCleans.has(pathKey);
+      const cleanBtn = document.createElement('button');
+      cleanBtn.className = 'ui-btn wt-clean-btn';
+      cleanBtn.textContent = cleaning ? 'Cleaning...' : `Clean target/ (${_fmtBytes(wt.reclaimable_bytes)})`;
+      cleanBtn.title = 'Delete the Cargo build directory to reclaim disk without removing the worktree. Sources and git state are untouched; the next build recreates it.';
+      cleanBtn.disabled = cleaning || !!removalState;
+      cleanBtn.classList.toggle('pending', cleaning);
+      cleanBtn.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        cleanWorktreeTarget(wt, cleanBtn);
+      });
+      actions.appendChild(cleanBtn);
+    }
 
     if (wt.safe_to_remove) {
       const command = worktreeRemoveCommand(wt);

--- a/static/app/57-sessions-replay.js
+++ b/static/app/57-sessions-replay.js
@@ -166,6 +166,14 @@ function renderWorktreesAggregate(scan, el) {
   ];
   const freeDisk = worktreeFreeDiskCard(summary);
   if (freeDisk) cards.push(freeDisk);
+  if ((summary.reclaimable_bytes || 0) > 0) {
+    cards.push({
+      label: 'Reclaimable',
+      value: _fmtBytes(summary.reclaimable_bytes),
+      sub: 'cargo target/ dirs',
+      title: 'Build output the per-worktree Clean button can delete without removing any checkout',
+    });
+  }
   cards.push(
     { label: 'Dirty', value: Number(summary.dirty || 0).toLocaleString() },
     { label: 'Unmerged', value: Number(summary.unmerged || 0).toLocaleString() },
@@ -656,6 +664,7 @@ function recomputeWorktreeSummary(scan) {
     stale: 0,
     cleanup_candidates: 0,
     truncated_sizes: 0,
+    reclaimable_bytes: 0,
     // Volume capacity comes from the scan, not the rows; carry it through
     // (it only goes stale by the removal that just freed space, in the
     // conservative direction — the next scan refreshes it).
@@ -664,6 +673,7 @@ function recomputeWorktreeSummary(scan) {
   };
   for (const wt of rows) {
     summary.total_bytes += Number(wt.size_bytes || 0);
+    summary.reclaimable_bytes += Number(wt.reclaimable_bytes || 0);
     if (wt.dirty) summary.dirty += 1;
     if (wt.merge_status === 'unmerged') summary.unmerged += 1;
     if ((wt.active_sessions || 0) > 0) summary.active += 1;
@@ -692,6 +702,75 @@ function setWorktreeRemoveButtonPending(button, state) {
     : mode === 'removing'
     ? 'Removing...'
     : 'Remove worktree...';
+}
+
+// Reclaim a worktree's Cargo target/ without removing the checkout — the
+// middle ground between keeping a fat worktree and deleting it. Cleans are
+// independent per-directory fs deletes, so a per-path pending set suffices
+// (no serialization queue like removals, which contend on git locks).
+const pendingWorktreeCleans = new Set();
+
+async function cleanWorktreeTarget(wt, button) {
+  const pathKey = String(wt.path || '');
+  if (!pathKey || pendingWorktreeCleans.has(pathKey)) return;
+  const activeWarning = (wt.active_sessions || 0) > 0
+    ? `\n\n${wt.active_sessions} session(s) look active in this worktree — a build running there will lose its progress and start over.`
+    : '';
+  const ok = await showDashboardConfirm({
+    title: 'Clean target/',
+    message:
+      `Delete the Cargo build directory of ${wt.branch || wt.head_short || wt.path}?\n\n` +
+      `Path: ${wt.path}/target\n` +
+      `Reclaims about ${_fmtBytes(wt.reclaimable_bytes || 0)}.`,
+    warning:
+      'Sources and git state are untouched; the next build recreates target/ from scratch.' +
+      activeWarning,
+    confirmLabel: 'Clean',
+  });
+  if (!ok) return;
+
+  pendingWorktreeCleans.add(pathKey);
+  if (button) {
+    button.disabled = true;
+    button.classList.add('pending');
+    button.textContent = 'Cleaning...';
+  }
+  setWorktreesActivityNotice('pending', `Cleaning ${wt.path}/target...`);
+  try {
+    const payload = { repo_root: wt.repo_root, path: wt.path, expected_head: wt.head || null };
+    // daemonApi (transport F2): a POST twin — no HTTP replay after an
+    // attempted tunnel send, matching the remove call above.
+    const r = await daemonApi.request('api_worktrees_clean', payload);
+    const result = (r.body && typeof r.body === 'object') ? r.body : {};
+    if (!r.ok || result.ok === false) {
+      throw new Error(result.error || `worktree clean returned ${r.status}`);
+    }
+    const freed = Number(result.freed_bytes || 0);
+    if (_cachedWorktreeScan && Array.isArray(_cachedWorktreeScan.worktrees)) {
+      const entry = _cachedWorktreeScan.worktrees.find(e => e.path === wt.path);
+      if (entry) {
+        entry.size_bytes = Math.max(0, Number(entry.size_bytes || 0) - freed);
+        entry.reclaimable_bytes = result.partial
+          ? Math.max(0, Number(entry.reclaimable_bytes || 0) - freed)
+          : 0;
+      }
+      recomputeWorktreeSummary(_cachedWorktreeScan);
+    }
+    const message = result.partial
+      ? `Cleaned ${_fmtBytes(freed)} from ${wt.path}/target; some entries survived (${result.detail || 'locked files'}).`
+      : `Cleaned ${wt.path}/target. Freed about ${_fmtBytes(freed)}.`;
+    setWorktreesStatus(message, result.partial ? 'error' : '');
+    setWorktreesActivityNotice(result.partial ? 'error' : 'ok', message, result.partial ? 0 : 3500);
+    showControlToast(result.partial ? 'error' : 'success', result.partial ? 'Target partially cleaned.' : 'Target cleaned.');
+  } catch (err) {
+    const message = err.message || 'Worktree clean failed';
+    setWorktreesStatus(message, 'error');
+    setWorktreesActivityNotice('error', message);
+    showControlToast('error', message);
+  } finally {
+    pendingWorktreeCleans.delete(pathKey);
+    if (_cachedWorktreeScan) renderWorktrees(_cachedWorktreeScan);
+  }
 }
 
 async function removeWorktree(wt, button) {
@@ -933,6 +1012,9 @@ function renderWorktreesList(scan, el) {
     };
     addMeta('repo', wt.repo_name);
     addMeta('size', _fmtBytes(wt.size_bytes || 0) + (wt.size_truncated ? ' +' : ''), wt.safe_to_remove ? 'v-green' : null);
+    if ((wt.reclaimable_bytes || 0) > 0) {
+      addMeta('target/', _fmtBytes(wt.reclaimable_bytes), null, 'Cargo build output the Clean button can reclaim');
+    }
     addMeta('changed', fmtWorktreeMinute(wt.last_changed_at), null, wt.last_changed_at || '');
     addMeta('commit', fmtWorktreeMinute(wt.head_author_time), null, wt.head_author_time || '');
     addMeta('merge', wt.merge_status, wt.merge_status === 'merged' ? 'v-green' : (wt.merge_status === 'unmerged' ? 'v-red' : null));
@@ -972,6 +1054,21 @@ function renderWorktreesList(scan, el) {
       openWorktreeInspect(wt);
     });
     actions.appendChild(inspectBtn);
+
+    if ((wt.reclaimable_bytes || 0) > 0) {
+      const cleaning = pendingWorktreeCleans.has(pathKey);
+      const cleanBtn = document.createElement('button');
+      cleanBtn.className = 'ui-btn wt-clean-btn';
+      cleanBtn.textContent = cleaning ? 'Cleaning...' : `Clean target/ (${_fmtBytes(wt.reclaimable_bytes)})`;
+      cleanBtn.title = 'Delete the Cargo build directory to reclaim disk without removing the worktree. Sources and git state are untouched; the next build recreates it.';
+      cleanBtn.disabled = cleaning || !!removalState;
+      cleanBtn.classList.toggle('pending', cleaning);
+      cleanBtn.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        cleanWorktreeTarget(wt, cleanBtn);
+      });
+      actions.appendChild(cleanBtn);
+    }
 
     if (wt.safe_to_remove) {
       const command = worktreeRemoveCommand(wt);


### PR DESCRIPTION
## Sessions → Worktrees: "Clean target/" — reclaim build output without removing the checkout

Follow-up to #325, same motivation (the 2026-07-06 disk-full incident:
worktree `target/` dirs are ~50 GB each). The middle ground between keeping
a fat worktree and deleting it: delete just the Cargo build directory.

### Inventory

- The existing size walk now attributes bytes under a worktree's top-level
  `target/` as `reclaimable_bytes` (per entry + summed in the summary) —
  zero extra I/O beyond one marker probe. Gated on Cargo's `CACHEDIR.TAG`
  marker, so a source directory that merely happens to be named `target/`
  (e.g. Maven's) is never counted or deletable. Symlinked `target/` never
  qualifies (deleting through one would reach outside the checkout).

### Endpoint

- `POST /api/worktrees/clean` (route-table row + `api_worktrees_clean`
  tunnel twin, `SessionManage`, bounded body). The handler re-verifies like
  `remove_worktree_if_safe` (registered worktree of the claimed repo,
  optional `expected_head` pin), re-checks the CACHEDIR.TAG gate, then
  deletes the directory and reports `freed_bytes` (re-measured on partial
  deletion — Windows file locks abort `remove_dir_all` partway; the
  response carries `partial` + detail).
- Deliberately **not** `cargo clean`: the daemon's environment may carry
  `CARGO_TARGET_DIR`, under which `cargo clean` would wipe a shared
  external build dir instead of this worktree's. Deleting the measured
  directory frees exactly the bytes the inventory advertised.
- Activity is a warning, not a refusal: cleaning under a live build only
  wastes that build. The confirm dialog calls out active sessions.

### Dashboard

- Per-card **Clean target/ (N GB)** button (shown when reclaimable > 0)
  with confirm dialog, pending state, cached-entry/summary update on
  success, and partial-deletion reporting.
- **Reclaimable** aggregate tile (shown when > 0) and a `target/` meta line
  on the card.

### Tests

- `scan_attributes_marked_cargo_target_as_reclaimable` (marked counted,
  unmarked not, summary sum)
- `clean_deletes_marked_target_and_keeps_sources` (target gone, sources +
  registration intact, freed ≥ payload)
- `clean_refuses_unmarked_target`, `clean_refuses_symlinked_target` (unix),
  `clean_refuses_stale_head_pin`
- Route-table pins updated: tunnel method partition, docs endpoint table.
