### PR TITLE
dashboard: restore the live pane host and composer dock base rules

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -148,6 +148,17 @@ html {
 
 /* ── Tab buttons (shared contract: the ui-v2 rail stamps .tab-btn on its
    nav items so the router binds them) ── */
+
+/* ── Tab Content ──
+   Live v2 pane host, not v1 chrome: html/body/#app are unpositioned, so this
+   is the containing block that keeps the absolute .tab-pane children inside
+   #app's padded content area (under the ui2 rail/oversight/composer
+   reservations). */
+.tab-content {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
 .tab-pane {
   display: none;
   flex-direction: column;
@@ -4123,8 +4134,23 @@ body.context-focus-active {
   display: block;
 }
 
-/* Stop button — interrupt the current agent turn. Lives in the Activity
-   toolbar and is shown only while a turn is in flight. */
+/* ── Global Task Bar ──
+   Base layout for the composer dock: html.ui-v2 .global-task-bar
+   (ui2-chrome.css) restyles the floating card but deliberately re-declares
+   no display/gap/align — the dock's row layout (flex textarea, content-sized
+   Direct toggle) lives here. */
+.global-task-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: var(--glass-bg);
+  border-bottom: 1px solid var(--glass-hairline);
+  -webkit-backdrop-filter: var(--glass-blur);
+  backdrop-filter: var(--glass-blur);
+  box-shadow: var(--glass-highlight);
+  flex-shrink: 0;
+}
 .task-target-chip {
   display: inline-flex;
   align-items: center;
@@ -28028,7 +28054,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'c9799413fe5b0e7e';
+const INTENDANT_APP_BUILD = 'b5bde076807fe312';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {

--- a/static/app/10-styles-shell.css
+++ b/static/app/10-styles-shell.css
@@ -72,6 +72,17 @@ html {
 
 /* ── Tab buttons (shared contract: the ui-v2 rail stamps .tab-btn on its
    nav items so the router binds them) ── */
+
+/* ── Tab Content ──
+   Live v2 pane host, not v1 chrome: html/body/#app are unpositioned, so this
+   is the containing block that keeps the absolute .tab-pane children inside
+   #app's padded content area (under the ui2 rail/oversight/composer
+   reservations). */
+.tab-content {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
 .tab-pane {
   display: none;
   flex-direction: column;

--- a/static/app/12-styles-tasks-log.css
+++ b/static/app/12-styles-tasks-log.css
@@ -414,8 +414,23 @@ body.context-focus-active {
   display: block;
 }
 
-/* Stop button — interrupt the current agent turn. Lives in the Activity
-   toolbar and is shown only while a turn is in flight. */
+/* ── Global Task Bar ──
+   Base layout for the composer dock: html.ui-v2 .global-task-bar
+   (ui2-chrome.css) restyles the floating card but deliberately re-declares
+   no display/gap/align — the dock's row layout (flex textarea, content-sized
+   Direct toggle) lives here. */
+.global-task-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: var(--glass-bg);
+  border-bottom: 1px solid var(--glass-hairline);
+  -webkit-backdrop-filter: var(--glass-blur);
+  backdrop-filter: var(--glass-blur);
+  box-shadow: var(--glass-highlight);
+  flex-shrink: 0;
+}
 .task-target-chip {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## What broke

v1 deletion phase 2 (`86e40074`, #323) classed two live rule families as dead v1 chrome and deleted them, breaking the dashboard on every tab:

- **`.tab-content`** (10-styles-shell.css) is the containing block for the absolute `.tab-pane { position:absolute; inset:0 }` children. `html`/`body`/`#app` are unpositioned, so without it every pane anchors to the viewport and slides under the fixed ui2 rail, oversight bar, and composer dock — pane content is clipped/covered on every tab.
- **`.global-task-bar`** (12-styles-tasks-log.css) carries the composer dock's row layout. `html.ui-v2 .global-task-bar` (ui2-chrome.css) restyles the floating card but deliberately re-declares no `display`/`gap`/`align-items` — the phase 2 commit message itself listed this family as untouched, but the diff removed it. In block flow the textarea's `flex:1` goes inert (the prompt input collapses to intrinsic width) and `.global-direct-toggle`'s `display:flex` makes it a block-level box stretching across the dock, covering it (its hover tooltip then pops anywhere over the strip).

## The fix

Restore both blocks verbatim, with guard comments stating what consumes them so the next dead-rule sweep doesn't re-delete them, and replace the stop-button comment phase 2 orphaned above `.task-target-chip` with the restored section header. `static/app.html` regenerated via the assembler.

## Audit of the remaining phase 2 deletions

Checked every other deleted family for the same failure class — all genuinely inert under v2: the shed `:root` vars are each redefined by the 16-tokens alias layer (verified name-by-name); `.tab-btn`, `.stop-btn`, `.phase-banner`, `.voice-dot` are restyled, hidden, or `hidden`-wrapped data nodes under v2; the ≤600px status-bar/ticker clamps lost their DOM in phase 3; `.budget-bar .bar-track` was a scoped clamp and the surviving `.clip-progress`/`.mse-loading-inner` scoped rules cover live users. No other rule in any fragment declares `display`/`position` on these two elements, so the restored declarations are the deciding ones at desktop widths.