### PR TITLE
external: deliver dashboard image attachments to Claude Code natively

### DIFF
--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -12,9 +12,9 @@ use tokio::sync::{mpsc, Mutex};
 use crate::error::CallerError;
 
 use super::{
-    normalize_plan_status, AgentConfig, AgentEvent, AgentThread, AgentUsageSnapshot,
-    ApprovalCategory, ApprovalDecision, ExternalAgent, GoalActionOutcome, GoalEngine,
-    SubAgentState, ToolCompletionStatus,
+    normalize_plan_status, AgentConfig, AgentEvent, AgentImageAttachment, AgentThread,
+    AgentUsageSnapshot, ApprovalCategory, ApprovalDecision, ExternalAgent, GoalActionOutcome,
+    GoalEngine, SubAgentState, ToolCompletionStatus,
 };
 
 /// Appended to the first user message when an Intendant web port is
@@ -77,11 +77,41 @@ struct CcMessageContent {
     content: Vec<CcContentBlock>,
 }
 
+/// One content block in an outbound user message. Claude Code's stream-json
+/// stdin takes the Anthropic Messages content-block shapes, so images travel
+/// natively as base64 blocks alongside the text (parse acceptance probed
+/// live on 2.1.2xx with the adapter's exact spawn flags).
 #[derive(Serialize)]
-struct CcContentBlock {
+#[serde(tag = "type", rename_all = "lowercase")]
+enum CcContentBlock {
+    Text { text: String },
+    Image { source: CcImageSource },
+}
+
+/// Anthropic-style base64 image source:
+/// `{"type":"base64","media_type":…,"data":…}`.
+#[derive(Serialize)]
+struct CcImageSource {
     #[serde(rename = "type")]
-    block_type: String,
-    text: String,
+    source_type: String,
+    media_type: String,
+    data: String,
+}
+
+impl CcContentBlock {
+    fn text(text: impl Into<String>) -> Self {
+        CcContentBlock::Text { text: text.into() }
+    }
+
+    fn image(img: &AgentImageAttachment) -> Self {
+        CcContentBlock::Image {
+            source: CcImageSource {
+                source_type: "base64".into(),
+                media_type: img.mime_type.clone(),
+                data: img.base64.clone(),
+            },
+        }
+    }
 }
 
 /// Control response written to stdin, answering a CLI→client
@@ -2306,14 +2336,21 @@ impl ClaudeCodeAgent {
     }
 
     async fn write_user_message(&self, text: &str) -> Result<(), CallerError> {
+        self.write_user_message_blocks(vec![CcContentBlock::text(text)])
+            .await
+    }
+
+    /// Write a user message with an explicit content-block list (the text
+    /// prompt plus any base64 image blocks).
+    async fn write_user_message_blocks(
+        &self,
+        content: Vec<CcContentBlock>,
+    ) -> Result<(), CallerError> {
         let user_msg = CcUserMessage {
             msg_type: "user".into(),
             message: CcMessageContent {
                 role: "user".into(),
-                content: vec![CcContentBlock {
-                    block_type: "text".into(),
-                    text: text.to_string(),
-                }],
+                content,
             },
             parent_tool_use_id: None,
         };
@@ -2582,8 +2619,17 @@ impl ExternalAgent for ClaudeCodeAgent {
 
     async fn send_message(
         &mut self,
+        thread: &AgentThread,
+        message: &str,
+    ) -> Result<(), CallerError> {
+        self.send_message_with_images(thread, message, &[]).await
+    }
+
+    async fn send_message_with_images(
+        &mut self,
         _thread: &AgentThread,
         message: &str,
+        images: &[AgentImageAttachment],
     ) -> Result<(), CallerError> {
         // A goal update made while idle rides the next prompt instead of
         // paying for its own turn.
@@ -2605,7 +2651,14 @@ impl ExternalAgent for ClaudeCodeAgent {
         // when a "result" message appears. No deadlock risk because the
         // approval flow uses the same stdout stream (control_request), not
         // a blocking request/response pair.
-        self.write_user_message(&augmented).await
+        let mut content = Vec::with_capacity(images.len() + 1);
+        content.push(CcContentBlock::text(augmented));
+        content.extend(images.iter().map(CcContentBlock::image));
+        self.write_user_message_blocks(content).await
+    }
+
+    fn supports_image_input(&self) -> bool {
+        true
     }
 
     async fn steer_turn(&mut self, text: &str) -> Result<(), CallerError> {
@@ -2942,10 +2995,7 @@ mod tests {
             msg_type: "user".into(),
             message: CcMessageContent {
                 role: "user".into(),
-                content: vec![CcContentBlock {
-                    block_type: "text".into(),
-                    text: "fix the bug".into(),
-                }],
+                content: vec![CcContentBlock::text("fix the bug")],
             },
             parent_tool_use_id: None,
         };
@@ -2956,6 +3006,39 @@ mod tests {
         assert_eq!(json["message"]["content"][0]["text"], "fix the bug");
         // The field must serialize (as null) — the CLI expects its presence.
         assert!(json.as_object().unwrap().contains_key("parent_tool_use_id"));
+    }
+
+    #[test]
+    fn user_message_with_image_blocks_serialization() {
+        let img = AgentImageAttachment {
+            local_path: None,
+            base64: "aGVsbG8=".into(),
+            mime_type: "image/png".into(),
+        };
+        let msg = CcUserMessage {
+            msg_type: "user".into(),
+            message: CcMessageContent {
+                role: "user".into(),
+                content: vec![
+                    CcContentBlock::text("what color?"),
+                    CcContentBlock::image(&img),
+                ],
+            },
+            parent_tool_use_id: None,
+        };
+        let json = serde_json::to_value(&msg).unwrap();
+        assert_eq!(json["message"]["content"][0]["type"], "text");
+        assert_eq!(json["message"]["content"][0]["text"], "what color?");
+        // Anthropic Messages image-block shape, exactly.
+        assert_eq!(json["message"]["content"][1]["type"], "image");
+        assert_eq!(json["message"]["content"][1]["source"]["type"], "base64");
+        assert_eq!(
+            json["message"]["content"][1]["source"]["media_type"],
+            "image/png"
+        );
+        assert_eq!(json["message"]["content"][1]["source"]["data"], "aGVsbG8=");
+        // Tagged-enum shape: image blocks must not leak a stray `text` field.
+        assert!(json["message"]["content"][1].get("text").is_none());
     }
 
     #[test]

--- a/src/bin/caller/external_agent/codex/mod.rs
+++ b/src/bin/caller/external_agent/codex/mod.rs
@@ -1460,6 +1460,10 @@ impl ExternalAgent for CodexAgent {
         self.send_message_with_images(thread, message, &[]).await
     }
 
+    fn supports_image_input(&self) -> bool {
+        true
+    }
+
     async fn send_message_with_images(
         &mut self,
         thread: &AgentThread,

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -1288,6 +1288,15 @@ pub trait ExternalAgent: Send + Sync {
         self.send_message(thread, message).await
     }
 
+    /// Whether this backend delivers image attachments natively through its
+    /// wire protocol. The supervisor consults this before sending a message
+    /// that carries images, so undeliverable images produce a visible
+    /// session-log warning instead of vanishing (the
+    /// `send_message_with_images` default forwards text only).
+    fn supports_image_input(&self) -> bool {
+        false
+    }
+
     /// Return the latest exact model request payload captured at the provider
     /// boundary. Backends without such a payload return `None`; callers should
     /// not synthesize transcript-shaped replacements.
@@ -1955,6 +1964,14 @@ mod tests {
         async fn shutdown(&mut self) -> Result<(), CallerError> {
             Ok(())
         }
+    }
+
+    #[test]
+    fn default_backend_reports_no_image_input_support() {
+        assert!(
+            !DefaultOnlyBackend.supports_image_input(),
+            "backends must opt in to image delivery explicitly"
+        );
     }
 
     #[tokio::test]

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -7,6 +7,30 @@
 // is the deferred cosmetic pass (see the god-file split design).
 use crate::*;
 
+/// Surface a visible warning when an outbound message carries image
+/// attachments the backend cannot deliver natively (the
+/// `send_message_with_images` default forwards text only). Non-image files
+/// always travel via the staged-path prelude, so images are the only
+/// attachment kind that can silently vanish on an unsupporting backend.
+fn warn_undeliverable_images(
+    session_log: &SharedSessionLog,
+    agent_name: &str,
+    supports_images: bool,
+    attachments: &[external_agent::AgentAttachment],
+) {
+    if supports_images {
+        return;
+    }
+    let dropped = attachments.iter().filter(|a| a.is_image()).count();
+    if dropped > 0 {
+        slog(session_log, |l| {
+            l.warn(&format!(
+                "{agent_name} backend does not deliver image attachments; {dropped} image(s) will not reach the agent (text and staged file paths still sent)"
+            ));
+        });
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_external_agent_mode(
     backend: external_agent::AgentBackend,
@@ -1156,6 +1180,12 @@ pub(crate) async fn run_external_agent_mode(
             let send_result = if attachments.is_empty() {
                 agent.send_message(&side_thread, &merged).await
             } else {
+                warn_undeliverable_images(
+                    &session_log,
+                    agent.name(),
+                    agent.supports_image_input(),
+                    &attachments.items,
+                );
                 agent
                     .send_message_with_attachments(&side_thread, &merged, &attachments.items)
                     .await
@@ -1273,6 +1303,12 @@ pub(crate) async fn run_external_agent_mode(
             let send_result = if attachments.is_empty() {
                 agent.send_message(&subagent_thread, &merged).await
             } else {
+                warn_undeliverable_images(
+                    &session_log,
+                    agent.name(),
+                    agent.supports_image_input(),
+                    &attachments.items,
+                );
                 agent
                     .send_message_with_attachments(&subagent_thread, &merged, &attachments.items)
                     .await
@@ -1960,6 +1996,12 @@ pub(crate) async fn run_external_agent_mode(
         let send_result = if attachments.is_empty() {
             agent.send_message(&thread, &merged).await
         } else {
+            warn_undeliverable_images(
+                &session_log,
+                agent.name(),
+                agent.supports_image_input(),
+                &attachments.items,
+            );
             agent
                 .send_message_with_attachments(&thread, &merged, &attachments.items)
                 .await


### PR DESCRIPTION
## What broke

Images attached from the dashboard to a supervised Claude Code session were silently discarded. Resolution worked (`AgentAttachment::Image` with base64 + path; the session log even said "sent with N attachment(s)"), but the `ExternalAgent::send_message_with_images` **default** forwards text only (`let _ = images`), and `ClaudeCodeAgent` never overrode it — its stdin writer hardcoded a single `text` content block. Never-implemented rather than a regression: the dropping default and Codex's `localImage` override landed together, and the CC backend was born text-only the next day. Non-image files were unaffected (staged-path prelude).

## The fix

- `CcContentBlock` becomes a tagged enum (`Text` | `Image` with an Anthropic-style base64 `source`); `write_user_message` delegates to a block-list writer. CC's stream-json stdin takes the Anthropic Messages content-block shapes — parse acceptance probed live on 2.1.2xx with the adapter's exact spawn flags.
- `send_message` now delegates to `send_message_with_images` (the Codex shape), so the goal-notice/bootstrap preludes and turn accounting stay in one place and image blocks ride the same user message.
- New `ExternalAgent::supports_image_input` capability (default `false`; `true` for Claude Code and Codex). All **three** `external_mode` send sites (main, side, subagent) log a visible session warning when a message carries images the backend cannot deliver — this failure class can never be silent again.

## Validation

- `cargo check`, `cargo clippy`, `cargo fmt --check` clean; external_agent unit suite 373/373 (new serialization test pins the exact image-block wire shape; a mod.rs test pins the fail-closed capability default).
- Live end-to-end vision probe (real `claude` CLI, image block on stdin, model names the image color) — running post-usage-window; PR flips from draft once it passes.