### PR TITLE
provider: prompt-cache the Anthropic conversation + token-spend batch (audit 02/03)

### DIFF
--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -1034,10 +1034,13 @@ pub(crate) async fn run_agent_loop(
             remaining,
         });
 
-        // When CU is enabled, the OpenAI computer tool rejects multiple images.
-        // Strip all but the most recent screenshot before each API call so the
-        // logged context matches the payload sent to the model.
-        if provider.cu_enabled() {
+        // The OpenAI computer tool rejects multiple non-CU images, so
+        // CU-enabled providers that need it get all but the most recent
+        // screenshot stripped before each API call (keeping the logged
+        // context matching the payload). Providers that accept multi-image
+        // histories (Anthropic) opt out: mutating old messages would
+        // invalidate their prompt-cache prefix from the mutation point.
+        if provider.requires_image_stripping() {
             conversation.strip_old_images();
         }
 
@@ -2074,12 +2077,24 @@ pub(crate) async fn run_agent_loop(
                 &batch.nonce_to_call_id,
                 &batch.call_id_names,
             );
+            // The context-budget line is appended once per turn — on the
+            // batch's final result — not on every result: N copies per turn
+            // were pure token filler (~25 tokens each, re-billed with the
+            // whole transcript on every subsequent request) and carried no
+            // extra signal for the model.
             let budget = conversation.budget_summary();
-            for (call_id, tool_name, result_text) in &tool_results {
+            let last_unhandled = tool_results
+                .iter()
+                .rposition(|(call_id, _, _)| !handled_call_ids.contains(call_id));
+            for (i, (call_id, tool_name, result_text)) in tool_results.iter().enumerate() {
                 if handled_call_ids.contains(call_id) {
                     continue;
                 }
-                let text = format!("{}\n\n{}", result_text, budget);
+                let text = if Some(i) == last_unhandled {
+                    format!("{}\n\n{}", result_text, budget)
+                } else {
+                    result_text.clone()
+                };
                 if tool_name == "capture_screen" {
                     if let Some(images) = encode_screenshot(result_text) {
                         conversation.add_tool_result_with_images(call_id, tool_name, &text, images);

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -2083,9 +2083,7 @@ pub(crate) async fn run_agent_loop(
             // whole transcript on every subsequent request) and carried no
             // extra signal for the model.
             let budget = conversation.budget_summary();
-            let last_unhandled = tool_results
-                .iter()
-                .rposition(|(call_id, _, _)| !handled_call_ids.contains(call_id));
+            let last_unhandled = budget_tail_index(&tool_results, &handled_call_ids);
             for (i, (call_id, tool_name, result_text)) in tool_results.iter().enumerate() {
                 if handled_call_ids.contains(call_id) {
                     continue;
@@ -3063,6 +3061,56 @@ pub(crate) async fn run_round_loop(
     }
 
     Ok(cumulative_stats)
+}
+
+/// Index of the batch result that carries the per-turn context-budget line:
+/// the final result not already answered out-of-band (skipped/denied).
+/// `None` — empty batch or every result already handled — means no budget
+/// line is emitted that turn. Exactly one line per turn is the contract:
+/// per-result copies were pure token filler re-billed with the transcript
+/// on every subsequent request.
+fn budget_tail_index(
+    tool_results: &[(String, String, String)],
+    handled_call_ids: &std::collections::HashSet<String>,
+) -> Option<usize> {
+    tool_results
+        .iter()
+        .rposition(|(call_id, _, _)| !handled_call_ids.contains(call_id))
+}
+
+#[cfg(test)]
+mod budget_tail {
+    use super::budget_tail_index;
+    use std::collections::HashSet;
+
+    fn results(ids: &[&str]) -> Vec<(String, String, String)> {
+        ids.iter()
+            .map(|id| (id.to_string(), "exec_command".to_string(), "OK".to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn budget_lands_on_last_unhandled_result_only() {
+        let batch = results(&["call_1", "call_2", "call_3"]);
+        let handled = HashSet::new();
+        assert_eq!(budget_tail_index(&batch, &handled), Some(2));
+
+        // A handled tail moves the budget line to the previous live result.
+        let handled: HashSet<String> = ["call_3".to_string()].into_iter().collect();
+        assert_eq!(budget_tail_index(&batch, &handled), Some(1));
+    }
+
+    #[test]
+    fn no_budget_line_for_empty_or_fully_handled_batches() {
+        let handled = HashSet::new();
+        assert_eq!(budget_tail_index(&[], &handled), None);
+
+        let batch = results(&["call_1", "call_2"]);
+        let handled: HashSet<String> = ["call_1".to_string(), "call_2".to_string()]
+            .into_iter()
+            .collect();
+        assert_eq!(budget_tail_index(&batch, &handled), None);
+    }
 }
 
 #[cfg(test)]

--- a/src/bin/caller/provider/anthropic.rs
+++ b/src/bin/caller/provider/anthropic.rs
@@ -207,9 +207,11 @@ impl AnthropicProvider {
 
     /// Build the messages POST through whichever auth path this instance
     /// carries. `headers` excludes credentials; the relay adds those.
+    /// Takes the request pre-serialized so the body is produced exactly once
+    /// per call (retries memcpy the bytes instead of re-walking the DOM).
     pub(crate) async fn post_messages(
         &self,
-        request_json: &serde_json::Value,
+        request_body: &[u8],
         beta_header: &str,
         streaming: bool,
     ) -> Result<ProviderHttpResponse, CallerError> {
@@ -224,18 +226,18 @@ impl AnthropicProvider {
                         .header("anthropic-version", "2023-06-01")
                         .header("anthropic-beta", beta_header)
                         .header("content-type", "application/json")
-                        .json(request_json);
+                        .body(request_body.to_vec());
                     if streaming {
                         request.timeout(STREAM_TIMEOUT)
                     } else {
                         request
                     }
                 };
-                let response = if streaming {
-                    builder().send().await?
-                } else {
-                    send_with_retry(&self.client, builder, MAX_RETRIES).await?
-                };
+                // Streaming goes through the same retry policy: the status
+                // is known before any body bytes stream, so a 429/529/5xx at
+                // request-open — routine provider throttling — retries with
+                // backoff instead of killing the session turn.
+                let response = send_with_retry(&self.client, builder, MAX_RETRIES).await?;
                 Ok(ProviderHttpResponse::Direct(response))
             }
             ProviderAuth::ClientEgress { kind } => {
@@ -244,8 +246,7 @@ impl AnthropicProvider {
                     ("anthropic-beta".to_string(), beta_header.to_string()),
                     ("content-type".to_string(), "application/json".to_string()),
                 ];
-                let body = serde_json::to_vec(request_json).map_err(CallerError::Json)?;
-                crate::credential_egress::fetch(kind, "POST", &url, headers, body)
+                crate::credential_egress::fetch(kind, "POST", &url, headers, request_body.to_vec())
                     .await
                     .map(ProviderHttpResponse::Egress)
                     .map_err(CallerError::Provider)
@@ -331,7 +332,9 @@ impl ChatProvider for AnthropicProvider {
             stream: false,
         };
 
-        let request_json = serde_json::to_value(&request).map_err(CallerError::Json)?;
+        // Serialize once, straight to bytes — `to_value` + `.json()` walked
+        // the full request (images included) twice per call.
+        let request_body = serde_json::to_vec(&request).map_err(CallerError::Json)?;
 
         let beta_header = if self.cu_enabled {
             "prompt-caching-2024-07-31,computer-use-2025-11-24"
@@ -340,7 +343,7 @@ impl ChatProvider for AnthropicProvider {
         };
 
         let response = self
-            .post_messages(&request_json, beta_header, false)
+            .post_messages(&request_body, beta_header, false)
             .await?;
 
         if !response.status_success() {
@@ -455,6 +458,13 @@ impl ChatProvider for AnthropicProvider {
         self.cu_display = Some(dims);
     }
 
+    /// Anthropic accepts multi-image histories, so superseded screenshots
+    /// stay in place: `strip_old_images` mutates earlier messages, which
+    /// would invalidate the prompt-cache prefix from the mutation point.
+    fn requires_image_stripping(&self) -> bool {
+        false
+    }
+
     fn tools(&self) -> Vec<ToolDefinition> {
         if self.use_tools {
             self.custom_tools
@@ -501,7 +511,7 @@ impl ChatProvider for AnthropicProvider {
             tools,
             stream: true,
         };
-        let request_json = serde_json::to_value(&request).map_err(CallerError::Json)?;
+        let request_body = serde_json::to_vec(&request).map_err(CallerError::Json)?;
 
         let beta_header = if self.cu_enabled {
             "prompt-caching-2024-07-31,computer-use-2025-11-24"
@@ -509,7 +519,7 @@ impl ChatProvider for AnthropicProvider {
             "prompt-caching-2024-07-31"
         };
 
-        let response = self.post_messages(&request_json, beta_header, true).await?;
+        let response = self.post_messages(&request_body, beta_header, true).await?;
 
         if !response.status_success() {
             let status = response.status_line();
@@ -833,6 +843,66 @@ pub(crate) fn anthropic_duration_ms(input: &serde_json::Value, default_ms: u64) 
     }
 }
 
+/// Number of rolling `cache_control` breakpoints placed on the conversation
+/// tail. Two (not one) so the chain survives Anthropic's ~20-content-block
+/// cache lookback: the marker on the previous user turn sits exactly where
+/// last request's tail marker sat, guaranteeing a hit there even when a
+/// large tool batch pushes the newest marker more than 20 blocks forward.
+const ROLLING_CACHE_BREAKPOINTS: usize = 2;
+
+/// Attach `cache_control: {type: "ephemeral"}` to the final content block of
+/// the last [`ROLLING_CACHE_BREAKPOINTS`] user-side messages. Anthropic
+/// caches the prefix up to each breakpoint, so a marker that advances with
+/// the conversation makes every request re-read the previous request's
+/// prefix at ~0.1× input price instead of re-billing the whole transcript
+/// at full rate each turn. Budget: 1 breakpoint on system (which also
+/// covers tools, rendered before it) + 2 rolling here = 3 of the allowed 4.
+fn apply_rolling_cache_breakpoints(api_messages: &mut [AnthropicMessage]) {
+    let mut remaining = ROLLING_CACHE_BREAKPOINTS;
+    for msg in api_messages.iter_mut().rev() {
+        if remaining == 0 {
+            break;
+        }
+        // Anchor on user-side messages only (plain user turns and
+        // tool_result carriers): the last message of every request is
+        // user-side, and anchoring the same two positions across
+        // consecutive requests is what makes the prefix re-readable.
+        if msg.role == "user" && attach_cache_control(&mut msg.content) {
+            remaining -= 1;
+        }
+    }
+}
+
+/// Set `cache_control` on the final content block of a message body.
+/// Plain-string content is promoted to an equivalent single text block
+/// (the API-documented shorthand equivalence, so the promotion itself
+/// never changes the cached prefix). Returns false when the message has
+/// no block to carry the marker (e.g. empty text).
+fn attach_cache_control(content: &mut serde_json::Value) -> bool {
+    let marker = serde_json::json!({"type": "ephemeral"});
+    match content {
+        serde_json::Value::Array(blocks) => match blocks.last_mut() {
+            Some(serde_json::Value::Object(block)) => {
+                block.insert("cache_control".to_string(), marker);
+                true
+            }
+            _ => false,
+        },
+        serde_json::Value::String(text) => {
+            if text.is_empty() {
+                return false;
+            }
+            *content = serde_json::json!([{
+                "type": "text",
+                "text": std::mem::take(text),
+                "cache_control": marker,
+            }]);
+            true
+        }
+        _ => false,
+    }
+}
+
 pub(crate) fn build_anthropic_messages(
     messages: &[Message],
 ) -> (serde_json::Value, Vec<AnthropicMessage>) {
@@ -941,6 +1011,7 @@ pub(crate) fn build_anthropic_messages(
             });
         }
     }
+    apply_rolling_cache_breakpoints(&mut api_messages);
     (system, api_messages)
 }
 
@@ -1264,5 +1335,127 @@ mod tests {
         let tool_result = &content[0];
         // content should be a plain string, not an array
         assert!(tool_result["content"].is_string());
+    }
+
+    // --- Rolling conversation cache breakpoints ---
+
+    fn user_text(text: &str) -> Message {
+        Message {
+            role: "user".to_string(),
+            content: text.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn assistant_text(text: &str) -> Message {
+        Message {
+            role: "assistant".to_string(),
+            content: text.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn tool_result_msg(call_id: &str, text: &str) -> Message {
+        Message {
+            role: "tool".to_string(),
+            content: text.to_string(),
+            tool_call_id: Some(call_id.to_string()),
+            ..Default::default()
+        }
+    }
+
+    /// Final content block of a built message, as an object.
+    fn last_block(msg: &AnthropicMessage) -> &serde_json::Map<String, serde_json::Value> {
+        msg.content
+            .as_array()
+            .and_then(|blocks| blocks.last())
+            .and_then(|b| b.as_object())
+            .expect("anchored message should have a block-array body")
+    }
+
+    fn has_marker(block: &serde_json::Map<String, serde_json::Value>) -> bool {
+        block.get("cache_control") == Some(&serde_json::json!({"type": "ephemeral"}))
+    }
+
+    #[test]
+    fn rolling_breakpoints_land_on_last_two_user_messages() {
+        let messages = vec![
+            Message {
+                role: "system".to_string(),
+                content: "sys".to_string(),
+                ..Default::default()
+            },
+            user_text("turn one"),
+            assistant_text("reply one"),
+            tool_result_msg("call_1", "older result"),
+            assistant_text("reply two"),
+            tool_result_msg("call_2", "newest result"),
+        ];
+        let (system, api_msgs) = build_anthropic_messages(&messages);
+        assert_eq!(api_msgs.len(), 5);
+
+        // The two newest user-side messages carry the marker...
+        assert!(has_marker(last_block(&api_msgs[4])), "newest tool_result");
+        assert!(has_marker(last_block(&api_msgs[2])), "previous tool_result");
+        // ...and it rides the tool_result block itself.
+        assert_eq!(
+            last_block(&api_msgs[4])
+                .get("type")
+                .and_then(|t| t.as_str()),
+            Some("tool_result")
+        );
+
+        // Older user turns and assistant turns stay unmarked (byte-stable
+        // prefix), and assistant bodies remain plain strings.
+        assert!(api_msgs[0].content.is_string(), "older user turn untouched");
+        assert!(api_msgs[1].content.is_string(), "assistant untouched");
+        assert!(api_msgs[3].content.is_string(), "assistant untouched");
+
+        // Whole-request budget: system + 2 rolling = 3 of Anthropic's 4.
+        let serialized = serde_json::to_string(&(system, api_msgs)).unwrap();
+        assert_eq!(serialized.matches("cache_control").count(), 3);
+    }
+
+    #[test]
+    fn rolling_breakpoint_promotes_plain_string_user_message() {
+        let messages = vec![user_text("hello")];
+        let (_system, api_msgs) = build_anthropic_messages(&messages);
+        let block = last_block(&api_msgs[0]);
+        assert_eq!(block.get("type").and_then(|t| t.as_str()), Some("text"));
+        assert_eq!(block.get("text").and_then(|t| t.as_str()), Some("hello"));
+        assert!(has_marker(block));
+    }
+
+    #[test]
+    fn rolling_breakpoint_rides_final_image_block() {
+        let messages = vec![
+            Message {
+                role: "system".to_string(),
+                content: "sys".to_string(),
+                ..Default::default()
+            },
+            tool_msg_with_images(),
+        ];
+        let (_system, api_msgs) = build_anthropic_messages(&messages);
+        // tool_result carrier: the marker goes on the tool_result block
+        // (the message's final block), leaving its inner content intact.
+        let block = last_block(&api_msgs[0]);
+        assert_eq!(
+            block.get("type").and_then(|t| t.as_str()),
+            Some("tool_result")
+        );
+        assert!(has_marker(block));
+        let inner = block["content"].as_array().unwrap();
+        assert_eq!(inner[1]["type"].as_str(), Some("image"));
+        assert!(inner[1].get("cache_control").is_none());
+    }
+
+    #[test]
+    fn rolling_breakpoints_skip_empty_user_messages() {
+        let messages = vec![user_text("real turn"), user_text("")];
+        let (_system, api_msgs) = build_anthropic_messages(&messages);
+        // The empty tail can't carry a marker; the previous turn still does.
+        assert!(api_msgs[1].content.is_string());
+        assert!(has_marker(last_block(&api_msgs[0])));
     }
 }

--- a/src/bin/caller/provider/anthropic.rs
+++ b/src/bin/caller/provider/anthropic.rs
@@ -194,6 +194,25 @@ impl AnthropicProvider {
         }
     }
 
+    /// The `max_tokens` actually sent for this request. Claude models from
+    /// before the 4.5 generation hard-400 when `input + max_tokens` exceeds
+    /// the context window instead of clamping server-side — and with the
+    /// 32K/64K family defaults that fires *below* the loop's 90%
+    /// auto-compact threshold, killing the session on a non-retryable 400
+    /// before compaction can ever run. For those models the ceiling is
+    /// clamped against a conservative input estimate; 4.5+ models pass the
+    /// configured value through untouched.
+    fn effective_max_tokens(&self, messages: &[Message]) -> u64 {
+        if !anthropic_needs_output_clamp(&self.model) {
+            return self.max_output_tokens;
+        }
+        let headroom = self
+            .context_window
+            .saturating_sub(estimated_input_tokens(messages))
+            .saturating_sub(CLAMP_MARGIN_TOKENS);
+        self.max_output_tokens.min(headroom).max(CLAMP_FLOOR_TOKENS)
+    }
+
     /// A tool-less instance forced through the client-egress relay —
     /// the probe path; normal selection converts availability into
     /// `ProviderAuth::ClientEgress` instead.
@@ -289,7 +308,7 @@ impl ChatProvider for AnthropicProvider {
             model: self.model.clone(),
             system,
             messages: api_messages,
-            max_tokens: self.max_output_tokens,
+            max_tokens: self.effective_max_tokens(messages),
             tools,
             stream,
         };
@@ -327,7 +346,7 @@ impl ChatProvider for AnthropicProvider {
             model: self.model.clone(),
             system,
             messages: api_messages,
-            max_tokens: self.max_output_tokens,
+            max_tokens: self.effective_max_tokens(messages),
             tools,
             stream: false,
         };
@@ -507,7 +526,7 @@ impl ChatProvider for AnthropicProvider {
             model: self.model.clone(),
             system,
             messages: api_messages,
-            max_tokens: self.max_output_tokens,
+            max_tokens: self.effective_max_tokens(messages),
             tools,
             stream: true,
         };
@@ -843,32 +862,108 @@ pub(crate) fn anthropic_duration_ms(input: &serde_json::Value, default_ms: u64) 
     }
 }
 
-/// Number of rolling `cache_control` breakpoints placed on the conversation
-/// tail. Two (not one) so the chain survives Anthropic's ~20-content-block
-/// cache lookback: the marker on the previous user turn sits exactly where
-/// last request's tail marker sat, guaranteeing a hit there even when a
-/// large tool batch pushes the newest marker more than 20 blocks forward.
-const ROLLING_CACHE_BREAKPOINTS: usize = 2;
+/// Claude models released before the 4.5 generation reject requests where
+/// `input_tokens + max_tokens` exceeds the context window (no server-side
+/// clamp; 4.5+ models cap gracefully and report
+/// `model_context_window_exceeded`). Matches the Claude 3 family plus the
+/// Opus 4/4.1 and Sonnet 4 pins, dated or aliased.
+fn anthropic_needs_output_clamp(model: &str) -> bool {
+    model.starts_with("claude-3")
+        || model.starts_with("claude-opus-4-0")
+        || model.starts_with("claude-opus-4-1")
+        || model.starts_with("claude-opus-4-2")
+        || model.starts_with("claude-sonnet-4-0")
+        || model.starts_with("claude-sonnet-4-2")
+}
 
-/// Attach `cache_control: {type: "ephemeral"}` to the final content block of
-/// the last [`ROLLING_CACHE_BREAKPOINTS`] user-side messages. Anthropic
-/// caches the prefix up to each breakpoint, so a marker that advances with
-/// the conversation makes every request re-read the previous request's
-/// prefix at ~0.1× input price instead of re-billing the whole transcript
-/// at full rate each turn. Budget: 1 breakpoint on system (which also
-/// covers tools, rendered before it) + 2 rolling here = 3 of the allowed 4.
+/// Headroom subtracted on top of the input estimate when clamping: covers
+/// the native tool schemas (~16K tokens), JSON structure, and estimator
+/// error on dense scripts where chars/4 underestimates.
+const CLAMP_MARGIN_TOKENS: u64 = 24_576;
+
+/// Clamp floor: still a useful completion, and far enough below any real
+/// pre-4.5 context window that a near-full input plus the floor stays
+/// requestable (when input alone genuinely exceeds the window, the request
+/// 400s regardless of `max_tokens` and auto-compact is the remedy).
+const CLAMP_FLOOR_TOKENS: u64 = 4_096;
+
+/// Conservative request-size estimate in tokens, ~chars/4. The compaction
+/// path's budget arithmetic rides API-reported usage held by the
+/// `Conversation`, which the provider seam never sees — so this local
+/// heuristic deliberately overestimates (base64 image bytes count at full
+/// character weight): overestimating only shrinks the output ceiling
+/// toward the floor, while underestimating would re-introduce the 400 the
+/// clamp exists to prevent.
+fn estimated_input_tokens(messages: &[Message]) -> u64 {
+    let chars: usize = messages
+        .iter()
+        .map(|m| {
+            m.content.len()
+                + m.images.as_ref().map_or(0, |imgs| {
+                    imgs.iter()
+                        .map(|i| i.data.len() + i.media_type.len())
+                        .sum::<usize>()
+                })
+                + m.tool_calls.as_ref().map_or(0, |tcs| {
+                    tcs.iter()
+                        .map(|tc| tc.name.len() + tc.arguments.len())
+                        .sum::<usize>()
+                })
+        })
+        .sum();
+    (chars / 4) as u64
+}
+
+/// Attach rolling `cache_control: {type: "ephemeral"}` breakpoints to the
+/// conversation tail. Anthropic caches the prefix up to each breakpoint, so
+/// markers that advance with the conversation make every request re-read
+/// the previous request's prefix at ~0.1× input price instead of re-billing
+/// the whole transcript at full rate each turn.
+///
+/// Placement is turn-boundary based, two markers:
+/// - the final block of the last user-side message (the current request's
+///   tail), and
+/// - the final block of the last user-side message *before the most recent
+///   assistant message* — i.e. exactly the message the previous request
+///   ended with, which is where its tail marker sat.
+///
+/// The second marker is what guarantees continuity for any batch size: a
+/// turn that appends many tool_result messages ("last two user messages"
+/// would land both markers inside the new batch, past Anthropic's
+/// ~20-content-block cache lookback, re-billing the entire history) still
+/// re-reads everything up to the previous turn at cache price; at worst the
+/// new turn's own blocks bill uncached once.
+///
+/// Budget: 1 breakpoint on system (which also covers tools, rendered
+/// before it) + 2 rolling here = 3 of the allowed 4.
 fn apply_rolling_cache_breakpoints(api_messages: &mut [AnthropicMessage]) {
-    let mut remaining = ROLLING_CACHE_BREAKPOINTS;
-    for msg in api_messages.iter_mut().rev() {
-        if remaining == 0 {
+    // Current turn tail: the last user-side message (plain user turn or
+    // tool_result carrier). Walk back over unmarkable bodies (e.g. empty
+    // text) so the marker still lands as close to the tail as possible.
+    let mut tail_marked_at: Option<usize> = None;
+    for idx in (0..api_messages.len()).rev() {
+        if api_messages[idx].role == "user" && attach_cache_control(&mut api_messages[idx].content)
+        {
+            tail_marked_at = Some(idx);
             break;
         }
-        // Anchor on user-side messages only (plain user turns and
-        // tool_result carriers): the last message of every request is
-        // user-side, and anchoring the same two positions across
-        // consecutive requests is what makes the prefix re-readable.
-        if msg.role == "user" && attach_cache_control(&mut msg.content) {
-            remaining -= 1;
+    }
+    let Some(tail_idx) = tail_marked_at else {
+        return;
+    };
+
+    // Previous turn tail: the last user-side message before the most
+    // recent assistant message that precedes the tail marker.
+    let Some(divider) = api_messages[..tail_idx]
+        .iter()
+        .rposition(|m| m.role == "assistant")
+    else {
+        return;
+    };
+    for idx in (0..divider).rev() {
+        if api_messages[idx].role == "user" && attach_cache_control(&mut api_messages[idx].content)
+        {
+            break;
         }
     }
 }
@@ -903,6 +998,43 @@ fn attach_cache_control(content: &mut serde_json::Value) -> bool {
     }
 }
 
+/// Newest image blocks kept in an outgoing Anthropic request. The API
+/// rejects requests around ~100 image blocks (and 32 MB of body) — ceilings
+/// a screenshot-heavy session can reach below the token-based auto-compact
+/// threshold now that Anthropic history is no longer image-stripped every
+/// turn. 40 keeps a comfortable margin under both limits while retaining
+/// far more visual context than the single-image OpenAI policy. Overflow
+/// elides the *oldest* images, replacing each with a fixed placeholder
+/// block — a bounded, rare prefix change (each image flips exactly once,
+/// after which the request is byte-stable again) instead of a hard 400.
+/// Below the cap this path renders identically to an uncapped build.
+const MAX_REQUEST_IMAGES: usize = 40;
+
+/// Render one image as a content block, or as the fixed elision
+/// placeholder while `elide_remaining` is being consumed (oldest first).
+fn push_image_or_placeholder(
+    parts: &mut Vec<serde_json::Value>,
+    img: &crate::conversation::ImageData,
+    elide_remaining: &mut usize,
+) {
+    if *elide_remaining > 0 {
+        *elide_remaining -= 1;
+        parts.push(serde_json::json!({
+            "type": "text",
+            "text": "[image elided: superseded by newer screenshots]",
+        }));
+    } else {
+        parts.push(serde_json::json!({
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": img.media_type,
+                "data": img.data,
+            }
+        }));
+    }
+}
+
 pub(crate) fn build_anthropic_messages(
     messages: &[Message],
 ) -> (serde_json::Value, Vec<AnthropicMessage>) {
@@ -917,6 +1049,15 @@ pub(crate) fn build_anthropic_messages(
         "cache_control": {"type": "ephemeral"}
     }]);
 
+    // Oldest-first elision budget for the image cap: only user-side
+    // messages render images (tool_result carriers and plain user turns).
+    let total_images: usize = messages
+        .iter()
+        .filter(|m| (m.role == "tool" && m.tool_call_id.is_some()) || m.role == "user")
+        .map(|m| m.images.as_ref().map_or(0, |imgs| imgs.len()))
+        .sum();
+    let mut elide_remaining = total_images.saturating_sub(MAX_REQUEST_IMAGES);
+
     let mut api_messages: Vec<AnthropicMessage> = Vec::new();
     for m in messages {
         if m.role == "system" {
@@ -930,14 +1071,7 @@ pub(crate) fn build_anthropic_messages(
                         "text": m.content,
                     })];
                     for img in images {
-                        parts.push(serde_json::json!({
-                            "type": "image",
-                            "source": {
-                                "type": "base64",
-                                "media_type": img.media_type,
-                                "data": img.data,
-                            }
-                        }));
+                        push_image_or_placeholder(&mut parts, img, &mut elide_remaining);
                     }
                     serde_json::Value::Array(parts)
                 } else {
@@ -989,14 +1123,7 @@ pub(crate) fn build_anthropic_messages(
                         "text": m.content,
                     })];
                     for img in images {
-                        parts.push(serde_json::json!({
-                            "type": "image",
-                            "source": {
-                                "type": "base64",
-                                "media_type": img.media_type,
-                                "data": img.data,
-                            }
-                        }));
+                        push_image_or_placeholder(&mut parts, img, &mut elide_remaining);
                     }
                     serde_json::Value::Array(parts)
                 } else {
@@ -1457,5 +1584,140 @@ mod tests {
         // The empty tail can't carry a marker; the previous turn still does.
         assert!(api_msgs[1].content.is_string());
         assert!(has_marker(last_block(&api_msgs[0])));
+    }
+
+    #[test]
+    fn rolling_breakpoints_straddle_a_multi_result_batch() {
+        // One turn appending many tool_result messages must NOT absorb both
+        // markers into the new batch: the second marker belongs on the
+        // previous turn's tail (where the previous request's tail marker
+        // sat), or a big batch pushes both markers past Anthropic's
+        // ~20-block cache lookback and the whole history re-bills.
+        let mut messages = vec![
+            Message {
+                role: "system".to_string(),
+                content: "sys".to_string(),
+                ..Default::default()
+            },
+            user_text("the task"),
+            assistant_text("running a large batch"),
+        ];
+        for i in 0..25 {
+            messages.push(tool_result_msg(
+                &format!("call_{i}"),
+                &format!("result {i}"),
+            ));
+        }
+        let (_system, api_msgs) = build_anthropic_messages(&messages);
+        assert_eq!(api_msgs.len(), 27);
+
+        // Marker on the batch tail…
+        assert!(has_marker(last_block(&api_msgs[26])), "batch tail");
+        // …and on the previous turn's tail (the user task), NOT on the
+        // second-to-last batch result.
+        assert!(has_marker(last_block(&api_msgs[0])), "previous turn tail");
+        for idx in 2..26 {
+            let unmarked = api_msgs[idx]
+                .content
+                .as_array()
+                .and_then(|blocks| blocks.last())
+                .and_then(|b| b.as_object())
+                .is_some_and(|b| !b.contains_key("cache_control"));
+            assert!(unmarked, "batch interior message {idx} must stay unmarked");
+        }
+    }
+
+    // --- Pre-4.5 max_tokens clamp ---
+
+    #[test]
+    fn pre45_models_clamp_max_tokens_to_context_headroom() {
+        let provider = AnthropicProvider::new_plain(
+            "key".to_string(),
+            "claude-opus-4-1-20250805".to_string(),
+            200_000,
+            32_000,
+        );
+        // Moderate history: the family ceiling fits untouched.
+        let small = vec![user_text(&"x".repeat(40_000))]; // est ~10K tokens
+        assert_eq!(provider.effective_max_tokens(&small), 32_000);
+        // Deep history: ceiling shrinks to window − estimate − margin, so
+        // the request stays valid below the 90% auto-compact threshold.
+        let big = vec![user_text(&"x".repeat(600_000))]; // est ~150K tokens
+        assert_eq!(
+            provider.effective_max_tokens(&big),
+            200_000 - 150_000 - CLAMP_MARGIN_TOKENS
+        );
+        // Estimate at/over the window: floor keeps the request shaped.
+        let huge = vec![user_text(&"x".repeat(1_000_000))];
+        assert_eq!(provider.effective_max_tokens(&huge), CLAMP_FLOOR_TOKENS);
+    }
+
+    #[test]
+    fn post45_models_pass_configured_max_tokens_through() {
+        let provider = AnthropicProvider::new_plain(
+            "key".to_string(),
+            "claude-sonnet-4-5-20250929".to_string(),
+            200_000,
+            64_000,
+        );
+        let huge = vec![user_text(&"x".repeat(1_000_000))];
+        assert_eq!(provider.effective_max_tokens(&huge), 64_000);
+
+        // Clamp family membership, dated and alias forms.
+        assert!(anthropic_needs_output_clamp("claude-3-5-sonnet-20241022"));
+        assert!(anthropic_needs_output_clamp("claude-opus-4-0"));
+        assert!(anthropic_needs_output_clamp("claude-opus-4-1"));
+        assert!(anthropic_needs_output_clamp("claude-opus-4-20250514"));
+        assert!(anthropic_needs_output_clamp("claude-sonnet-4-0"));
+        assert!(anthropic_needs_output_clamp("claude-sonnet-4-20250514"));
+        assert!(!anthropic_needs_output_clamp("claude-haiku-4-5-20251001"));
+        assert!(!anthropic_needs_output_clamp("claude-sonnet-4-5-20250929"));
+    }
+
+    // --- Request image cap ---
+
+    #[test]
+    fn image_cap_elides_oldest_beyond_newest_forty() {
+        let mut messages = vec![Message {
+            role: "system".to_string(),
+            content: "sys".to_string(),
+            ..Default::default()
+        }];
+        for i in 0..(MAX_REQUEST_IMAGES + 5) {
+            let mut m = tool_msg_with_images();
+            m.tool_call_id = Some(format!("call_{i}"));
+            messages.push(m);
+        }
+        let (_system, api_msgs) = build_anthropic_messages(&messages);
+        let serialized = serde_json::to_string(&api_msgs).unwrap();
+        assert_eq!(
+            serialized.matches("\"type\":\"image\"").count(),
+            MAX_REQUEST_IMAGES
+        );
+        assert_eq!(serialized.matches("image elided").count(), 5);
+
+        // Oldest carriers hold the placeholder; the newest keeps its image.
+        let first = serde_json::to_string(&api_msgs[0]).unwrap();
+        assert!(first.contains("image elided") && !first.contains("\"type\":\"image\""));
+        let last = serde_json::to_string(api_msgs.last().unwrap()).unwrap();
+        assert!(last.contains("\"type\":\"image\"") && !last.contains("image elided"));
+    }
+
+    #[test]
+    fn image_cap_leaves_under_cap_requests_untouched() {
+        let mut messages = vec![Message {
+            role: "system".to_string(),
+            content: "sys".to_string(),
+            ..Default::default()
+        }];
+        for i in 0..3 {
+            let mut m = tool_msg_with_images();
+            m.tool_call_id = Some(format!("call_{i}"));
+            messages.push(m);
+        }
+        let (_system, api_msgs) = build_anthropic_messages(&messages);
+        let serialized = serde_json::to_string(&api_msgs).unwrap();
+        assert_eq!(serialized.matches("\"type\":\"image\"").count(), 3);
+        assert_eq!(serialized.matches("image elided").count(), 0);
     }
 }

--- a/src/bin/caller/provider/anthropic.rs
+++ b/src/bin/caller/provider/anthropic.rs
@@ -202,15 +202,27 @@ impl AnthropicProvider {
     /// before compaction can ever run. For those models the ceiling is
     /// clamped against a conservative input estimate; 4.5+ models pass the
     /// configured value through untouched.
-    fn effective_max_tokens(&self, messages: &[Message]) -> u64 {
+    ///
+    /// Shape: `min(configured, max(headroom, floor))` — the configured
+    /// value is a hard ceiling and is never raised (an explicit
+    /// `MAX_OUTPUT_TOKENS=1024` override must stay 1024), while a
+    /// sub-floor headroom is still honored up to the floor: the input
+    /// estimate overestimates, so real headroom is at least the computed
+    /// one, and a truncated completion beats a dead session.
+    fn effective_max_tokens(
+        &self,
+        messages: &[Message],
+        tools: Option<&[serde_json::Value]>,
+    ) -> u64 {
         if !anthropic_needs_output_clamp(&self.model) {
             return self.max_output_tokens;
         }
+        let estimated_input = estimated_input_tokens(messages) + estimated_tools_tokens(tools);
         let headroom = self
             .context_window
-            .saturating_sub(estimated_input_tokens(messages))
+            .saturating_sub(estimated_input)
             .saturating_sub(CLAMP_MARGIN_TOKENS);
-        self.max_output_tokens.min(headroom).max(CLAMP_FLOOR_TOKENS)
+        self.max_output_tokens.min(headroom.max(CLAMP_FLOOR_TOKENS))
     }
 
     /// A tool-less instance forced through the client-egress relay —
@@ -308,7 +320,7 @@ impl ChatProvider for AnthropicProvider {
             model: self.model.clone(),
             system,
             messages: api_messages,
-            max_tokens: self.effective_max_tokens(messages),
+            max_tokens: self.effective_max_tokens(messages, tools.as_deref()),
             tools,
             stream,
         };
@@ -346,7 +358,7 @@ impl ChatProvider for AnthropicProvider {
             model: self.model.clone(),
             system,
             messages: api_messages,
-            max_tokens: self.effective_max_tokens(messages),
+            max_tokens: self.effective_max_tokens(messages, tools.as_deref()),
             tools,
             stream: false,
         };
@@ -526,7 +538,7 @@ impl ChatProvider for AnthropicProvider {
             model: self.model.clone(),
             system,
             messages: api_messages,
-            max_tokens: self.effective_max_tokens(messages),
+            max_tokens: self.effective_max_tokens(messages, tools.as_deref()),
             tools,
             stream: true,
         };
@@ -877,15 +889,18 @@ fn anthropic_needs_output_clamp(model: &str) -> bool {
 }
 
 /// Headroom subtracted on top of the input estimate when clamping: covers
-/// the native tool schemas (~16K tokens), JSON structure, and estimator
-/// error on dense scripts where chars/4 underestimates.
-const CLAMP_MARGIN_TOKENS: u64 = 24_576;
+/// request JSON structure and estimator error on dense scripts where
+/// chars/4 underestimates. Tool schemas are measured directly (see
+/// [`estimated_tools_tokens`]), not covered here.
+const CLAMP_MARGIN_TOKENS: u64 = 8_192;
 
-/// Clamp floor: still a useful completion, and far enough below any real
-/// pre-4.5 context window that a near-full input plus the floor stays
-/// requestable (when input alone genuinely exceeds the window, the request
-/// 400s regardless of `max_tokens` and auto-compact is the remedy).
-const CLAMP_FLOOR_TOKENS: u64 = 4_096;
+/// Clamp floor: estimator-noise protection only. Headroom below the floor
+/// is still requested at the floor because the input estimate deliberately
+/// overestimates — real headroom is at least the computed one, so the
+/// floor can truncate but not 400. It is applied to the *headroom*, never
+/// to the configured ceiling: an explicit low `MAX_OUTPUT_TOKENS` override
+/// passes through unraised.
+const CLAMP_FLOOR_TOKENS: u64 = 1_024;
 
 /// Conservative request-size estimate in tokens, ~chars/4. The compaction
 /// path's budget arithmetic rides API-reported usage held by the
@@ -911,6 +926,22 @@ fn estimated_input_tokens(messages: &[Message]) -> u64 {
                 })
         })
         .sum();
+    (chars / 4) as u64
+}
+
+/// The tools payload counted with the same ~chars/4 overestimate
+/// discipline. Runtime-registered MCP tool schemas are unbounded, so a
+/// fixed margin can't stand in for them — a large registered tool set
+/// would silently eat the margin and re-create the overflow 400 the clamp
+/// exists to prevent. Only evaluated on the pre-4.5 clamp path.
+fn estimated_tools_tokens(tools: Option<&[serde_json::Value]>) -> u64 {
+    let chars: usize = tools
+        .map(|defs| {
+            defs.iter()
+                .map(|def| serde_json::to_string(def).map_or(0, |s| s.len()))
+                .sum()
+        })
+        .unwrap_or(0);
     (chars / 4) as u64
 }
 
@@ -999,16 +1030,55 @@ fn attach_cache_control(content: &mut serde_json::Value) -> bool {
 }
 
 /// Newest image blocks kept in an outgoing Anthropic request. The API
-/// rejects requests around ~100 image blocks (and 32 MB of body) — ceilings
-/// a screenshot-heavy session can reach below the token-based auto-compact
+/// rejects requests around ~100 image blocks — a ceiling a
+/// screenshot-heavy session can reach below the token-based auto-compact
 /// threshold now that Anthropic history is no longer image-stripped every
-/// turn. 40 keeps a comfortable margin under both limits while retaining
-/// far more visual context than the single-image OpenAI policy. Overflow
-/// elides the *oldest* images, replacing each with a fixed placeholder
-/// block — a bounded, rare prefix change (each image flips exactly once,
-/// after which the request is byte-stable again) instead of a hard 400.
-/// Below the cap this path renders identically to an uncapped build.
+/// turn. 40 keeps a comfortable margin while retaining far more visual
+/// context than the single-image OpenAI policy. Overflow elides the
+/// *oldest* images, replacing each with a fixed placeholder block instead
+/// of running into a hard 400. Below the cap this path renders identically
+/// to an uncapped build.
 const MAX_REQUEST_IMAGES: usize = 40;
+
+/// Byte budget for the kept images' base64 payload — the count cap alone
+/// doesn't bound the body (a handful of ~5 MiB screenshots base64-expand
+/// past Anthropic's ~32 MB request ceiling while staying far under 40
+/// images). 16 MiB leaves generous room for text, tool schemas, and JSON
+/// structure in the remaining half of the ceiling.
+const MAX_REQUEST_IMAGE_BYTES: usize = 16 * 1024 * 1024;
+
+/// Elision-boundary quantum — the hysteresis that keeps the cap from
+/// permanently defeating the rolling prompt cache. A boundary recomputed
+/// exactly per request would advance by one image every request at steady
+/// state (one new screenshot per turn), changing an early-prefix block
+/// *every* request, so the previous-tail cache marker would never hit
+/// again. Quantizing the boundary to multiples of 8 images means it only
+/// moves once a new step is actually required — the prefix then stays
+/// byte-stable for the next ~8 images (kept count oscillates in
+/// (cap−8, cap]), amortizing invalidation to roughly 1-in-8 requests. The
+/// same stepped boundary serves the byte budget, so byte-driven elision
+/// jumps in the same 8-image steps rather than sliding per request.
+const IMAGE_ELISION_STEP: usize = 8;
+
+/// How many oldest images to elide so the kept tail satisfies both the
+/// count cap and the byte budget, with the boundary quantized to
+/// [`IMAGE_ELISION_STEP`] (see there for why). Always keeps the newest
+/// image, even when it alone exceeds the byte budget — the current screen
+/// is what the model acts on, and a single image cannot realistically
+/// breach the request ceiling the budget protects.
+fn image_elision_count(image_sizes: &[usize]) -> usize {
+    let total = image_sizes.len();
+    let mut boundary = 0usize;
+    while boundary < total {
+        let kept = total - boundary;
+        let kept_bytes: usize = image_sizes[boundary..].iter().sum();
+        if kept <= MAX_REQUEST_IMAGES && kept_bytes <= MAX_REQUEST_IMAGE_BYTES {
+            return boundary;
+        }
+        boundary += IMAGE_ELISION_STEP;
+    }
+    total.saturating_sub(1)
+}
 
 /// Render one image as a content block, or as the fixed elision
 /// placeholder while `elide_remaining` is being consumed (oldest first).
@@ -1049,14 +1119,21 @@ pub(crate) fn build_anthropic_messages(
         "cache_control": {"type": "ephemeral"}
     }]);
 
-    // Oldest-first elision budget for the image cap: only user-side
-    // messages render images (tool_result carriers and plain user turns).
-    let total_images: usize = messages
+    // Oldest-first elision budget for the image cap + byte budget: only
+    // user-side messages render images (tool_result carriers and plain
+    // user turns), in conversation order.
+    let image_sizes: Vec<usize> = messages
         .iter()
         .filter(|m| (m.role == "tool" && m.tool_call_id.is_some()) || m.role == "user")
-        .map(|m| m.images.as_ref().map_or(0, |imgs| imgs.len()))
-        .sum();
-    let mut elide_remaining = total_images.saturating_sub(MAX_REQUEST_IMAGES);
+        .flat_map(|m| {
+            m.images
+                .as_deref()
+                .unwrap_or(&[])
+                .iter()
+                .map(|img| img.data.len())
+        })
+        .collect();
+    let mut elide_remaining = image_elision_count(&image_sizes);
 
     let mut api_messages: Vec<AnthropicMessage> = Vec::new();
     for m in messages {
@@ -1639,17 +1716,65 @@ mod tests {
         );
         // Moderate history: the family ceiling fits untouched.
         let small = vec![user_text(&"x".repeat(40_000))]; // est ~10K tokens
-        assert_eq!(provider.effective_max_tokens(&small), 32_000);
+        assert_eq!(provider.effective_max_tokens(&small, None), 32_000);
         // Deep history: ceiling shrinks to window − estimate − margin, so
         // the request stays valid below the 90% auto-compact threshold.
-        let big = vec![user_text(&"x".repeat(600_000))]; // est ~150K tokens
+        let big = vec![user_text(&"x".repeat(700_000))]; // est ~175K tokens
         assert_eq!(
-            provider.effective_max_tokens(&big),
-            200_000 - 150_000 - CLAMP_MARGIN_TOKENS
+            provider.effective_max_tokens(&big, None),
+            200_000 - 175_000 - CLAMP_MARGIN_TOKENS
         );
-        // Estimate at/over the window: floor keeps the request shaped.
+        // Estimate at/over the window: the floor keeps the request shaped
+        // (the estimate overestimates, so the floor truncates, never 400s).
         let huge = vec![user_text(&"x".repeat(1_000_000))];
-        assert_eq!(provider.effective_max_tokens(&huge), CLAMP_FLOOR_TOKENS);
+        assert_eq!(
+            provider.effective_max_tokens(&huge, None),
+            CLAMP_FLOOR_TOKENS
+        );
+    }
+
+    #[test]
+    fn clamp_never_raises_an_explicit_low_ceiling() {
+        // An explicit MAX_OUTPUT_TOKENS override below the floor is a hard
+        // ceiling: the floor applies to headroom only, never to the
+        // configured value.
+        let provider = AnthropicProvider::new_plain(
+            "key".to_string(),
+            "claude-opus-4-1-20250805".to_string(),
+            200_000,
+            512,
+        );
+        let small = vec![user_text("hi")];
+        assert_eq!(provider.effective_max_tokens(&small, None), 512);
+        let huge = vec![user_text(&"x".repeat(1_000_000))];
+        assert_eq!(provider.effective_max_tokens(&huge, None), 512);
+    }
+
+    #[test]
+    fn clamp_counts_the_tools_payload() {
+        // Runtime-registered MCP schemas are unbounded — a giant tool set
+        // must shrink the ceiling like any other input, or it eats the
+        // fixed margin and re-creates the overflow 400.
+        let provider = AnthropicProvider::new_plain(
+            "key".to_string(),
+            "claude-opus-4-1-20250805".to_string(),
+            200_000,
+            32_000,
+        );
+        let messages = vec![user_text(&"x".repeat(40_000))]; // est ~10K tokens
+        assert_eq!(provider.effective_max_tokens(&messages, None), 32_000);
+        let giant_tool = serde_json::json!({
+            "name": "mcp_bulk",
+            "description": "y".repeat(700_000), // est ~175K tokens
+            "input_schema": {"type": "object"},
+        });
+        let with_tools =
+            provider.effective_max_tokens(&messages, Some(std::slice::from_ref(&giant_tool)));
+        assert!(
+            with_tools < 32_000,
+            "giant tool schema must shrink the ceiling (got {with_tools})"
+        );
+        assert!(with_tools >= CLAMP_FLOOR_TOKENS);
     }
 
     #[test]
@@ -1661,7 +1786,7 @@ mod tests {
             64_000,
         );
         let huge = vec![user_text(&"x".repeat(1_000_000))];
-        assert_eq!(provider.effective_max_tokens(&huge), 64_000);
+        assert_eq!(provider.effective_max_tokens(&huge, None), 64_000);
 
         // Clamp family membership, dated and alias forms.
         assert!(anthropic_needs_output_clamp("claude-3-5-sonnet-20241022"));
@@ -1677,7 +1802,10 @@ mod tests {
     // --- Request image cap ---
 
     #[test]
-    fn image_cap_elides_oldest_beyond_newest_forty() {
+    fn image_cap_elides_oldest_in_quantized_steps() {
+        // 45 single-image tool results: over the 40 cap, the boundary
+        // quantizes to the 8-image step — 8 oldest elided, 37 kept (not a
+        // per-request sliding 5).
         let mut messages = vec![Message {
             role: "system".to_string(),
             content: "sys".to_string(),
@@ -1692,15 +1820,52 @@ mod tests {
         let serialized = serde_json::to_string(&api_msgs).unwrap();
         assert_eq!(
             serialized.matches("\"type\":\"image\"").count(),
-            MAX_REQUEST_IMAGES
+            MAX_REQUEST_IMAGES - 3
         );
-        assert_eq!(serialized.matches("image elided").count(), 5);
+        assert_eq!(
+            serialized.matches("image elided").count(),
+            IMAGE_ELISION_STEP
+        );
 
         // Oldest carriers hold the placeholder; the newest keeps its image.
         let first = serde_json::to_string(&api_msgs[0]).unwrap();
         assert!(first.contains("image elided") && !first.contains("\"type\":\"image\""));
         let last = serde_json::to_string(api_msgs.last().unwrap()).unwrap();
         assert!(last.contains("\"type\":\"image\"") && !last.contains("image elided"));
+
+        // Determinism: the same over-cap conversation builds byte-identical
+        // requests — no per-request drift in the elision pattern.
+        let (_system2, api_msgs2) = build_anthropic_messages(&messages);
+        assert_eq!(serialized, serde_json::to_string(&api_msgs2).unwrap());
+    }
+
+    #[test]
+    fn image_elision_boundary_moves_in_steps_not_per_request() {
+        // Hysteresis: at one-new-image-per-request steady state the
+        // boundary must hold still across a whole step's worth of growth,
+        // then jump — otherwise an early-prefix block changes every
+        // request and the previous-tail cache marker never hits.
+        let sizes = |n: usize| vec![1usize; n];
+        assert_eq!(image_elision_count(&sizes(MAX_REQUEST_IMAGES)), 0);
+        assert_eq!(image_elision_count(&sizes(41)), IMAGE_ELISION_STEP);
+        assert_eq!(image_elision_count(&sizes(45)), IMAGE_ELISION_STEP);
+        assert_eq!(image_elision_count(&sizes(48)), IMAGE_ELISION_STEP);
+        assert_eq!(image_elision_count(&sizes(49)), 2 * IMAGE_ELISION_STEP);
+        assert_eq!(image_elision_count(&sizes(56)), 2 * IMAGE_ELISION_STEP);
+    }
+
+    #[test]
+    fn image_byte_budget_elides_few_but_huge_images() {
+        const MIB: usize = 1024 * 1024;
+        // Four ~6 MiB images: far under the count cap, over the 16 MiB
+        // byte budget → elide down (boundary quantum capped at newest-1).
+        assert_eq!(image_elision_count(&[6 * MIB; 4]), 3);
+        // Two 5 MiB images fit the budget: untouched.
+        assert_eq!(image_elision_count(&[5 * MIB; 2]), 0);
+        // A single over-budget image is still sent: the newest screenshot
+        // is what the model acts on, and one image can't realistically
+        // breach the request ceiling.
+        assert_eq!(image_elision_count(&[20 * MIB]), 0);
     }
 
     #[test]

--- a/src/bin/caller/provider/gemini.rs
+++ b/src/bin/caller/provider/gemini.rs
@@ -103,11 +103,12 @@ impl GeminiProvider {
 
     /// POST a generateContent-family request through whichever auth path
     /// this instance carries. Auth never rides an egress request — the
-    /// relay attaches `x-goog-api-key` from the vault.
+    /// relay attaches `x-goog-api-key` from the vault. Takes the request
+    /// pre-serialized so the body is produced exactly once per call.
     pub(crate) async fn post_generate(
         &self,
         url: &str,
-        request_body: &serde_json::Value,
+        request_body: &[u8],
         streaming: bool,
     ) -> Result<ProviderHttpResponse, CallerError> {
         match &self.auth {
@@ -118,24 +119,23 @@ impl GeminiProvider {
                         .post(url)
                         .header("content-type", "application/json")
                         .header("x-goog-api-key", api_key)
-                        .json(request_body);
+                        .body(request_body.to_vec());
                     if streaming {
                         request.timeout(STREAM_TIMEOUT)
                     } else {
                         request
                     }
                 };
-                let response = if streaming {
-                    builder().send().await?
-                } else {
-                    send_with_retry(&self.client, builder, MAX_RETRIES).await?
-                };
+                // Streaming goes through the same retry policy: the status
+                // is known before any body bytes stream, so a 429/5xx at
+                // request-open retries with backoff instead of killing the
+                // session turn.
+                let response = send_with_retry(&self.client, builder, MAX_RETRIES).await?;
                 Ok(ProviderHttpResponse::Direct(response))
             }
             ProviderAuth::ClientEgress { kind } => {
                 let headers = vec![("content-type".to_string(), "application/json".to_string())];
-                let body = serde_json::to_vec(request_body).map_err(CallerError::Json)?;
-                crate::credential_egress::fetch(kind, "POST", url, headers, body)
+                crate::credential_egress::fetch(kind, "POST", url, headers, request_body.to_vec())
                     .await
                     .map(ProviderHttpResponse::Egress)
                     .map_err(CallerError::Provider)
@@ -161,7 +161,7 @@ impl ChatProvider for GeminiProvider {
         stream: bool,
     ) -> Result<(String, serde_json::Value), CallerError> {
         let _ = stream;
-        let (system_text, _contents, mut request_body) = build_gemini_request_parts(messages, self);
+        let (system_text, mut request_body) = build_gemini_request_parts(messages, self);
 
         if let Some(ref sys) = system_text {
             request_body["systemInstruction"] = serde_json::json!({
@@ -176,7 +176,7 @@ impl ChatProvider for GeminiProvider {
     }
 
     async fn chat(&self, messages: &[Message]) -> Result<ChatResponse, CallerError> {
-        let (system_text, _contents, mut request_body) = build_gemini_request_parts(messages, self);
+        let (system_text, mut request_body) = build_gemini_request_parts(messages, self);
 
         if let Some(ref sys) = system_text {
             request_body["systemInstruction"] = serde_json::json!({
@@ -191,7 +191,8 @@ impl ChatProvider for GeminiProvider {
             self.endpoint, self.model
         );
 
-        let response = self.post_generate(&url, &request_body, false).await?;
+        let body_bytes = serde_json::to_vec(&request_body).map_err(CallerError::Json)?;
+        let response = self.post_generate(&url, &body_bytes, false).await?;
 
         if !response.status_success() {
             let status = response.status_line();
@@ -346,9 +347,8 @@ impl ChatProvider for GeminiProvider {
         messages: &[Message],
         on_event: &(dyn Fn(StreamEvent) + Send + Sync),
     ) -> Result<ChatResponse, CallerError> {
-        let (system_text, contents, request_body_base) = build_gemini_request_parts(messages, self);
+        let (system_text, mut request_body) = build_gemini_request_parts(messages, self);
 
-        let mut request_body = request_body_base;
         if let Some(ref sys) = system_text {
             request_body["systemInstruction"] = serde_json::json!({
                 "parts": [{"text": sys}]
@@ -361,7 +361,8 @@ impl ChatProvider for GeminiProvider {
             self.endpoint, self.model
         );
 
-        let response = self.post_generate(&url, &request_body, true).await?;
+        let body_bytes = serde_json::to_vec(&request_body).map_err(CallerError::Json)?;
+        let response = self.post_generate(&url, &body_bytes, true).await?;
 
         if !response.status_success() {
             let status = response.status_line();
@@ -483,8 +484,12 @@ impl ChatProvider for GeminiProvider {
         }
 
         let content = text_parts.join("");
-        let _ = (contents, system_text); // consumed above
-                                         // Store raw parts for echo-back (preserves thoughtSignature for Gemini CU)
+        // Store raw parts for echo-back (preserves thoughtSignature for
+        // Gemini CU). Adjacent pure-text delta parts are coalesced first:
+        // streaming produced one `{"text": …}` fragment per delta, and
+        // echoing hundreds of them back in every subsequent request body
+        // was pure wire/parse bloat.
+        let raw_model_parts = coalesce_adjacent_text_parts(raw_model_parts);
         let raw_output = if !raw_model_parts.is_empty() {
             Some(raw_model_parts)
         } else {
@@ -504,11 +509,44 @@ impl ChatProvider for GeminiProvider {
     }
 }
 
-/// Build Gemini request parts (shared between streaming and non-streaming).
+/// Merge runs of pure-text parts (objects whose only key is `"text"`) into
+/// single parts. Streaming pushes one raw part per delta, so an echoed-back
+/// model turn otherwise carries hundreds of one-word `{"text": …}`
+/// fragments in every subsequent request. Parts with any other field
+/// (`functionCall`, `thoughtSignature`, `inlineData`, …) are kept verbatim
+/// and act as merge boundaries.
+pub(crate) fn coalesce_adjacent_text_parts(
+    parts: Vec<serde_json::Value>,
+) -> Vec<serde_json::Value> {
+    let is_pure_text = |part: &serde_json::Value| -> bool {
+        part.as_object()
+            .is_some_and(|obj| obj.len() == 1 && obj.get("text").is_some_and(|t| t.is_string()))
+    };
+    let mut out: Vec<serde_json::Value> = Vec::with_capacity(parts.len());
+    for part in parts {
+        if is_pure_text(&part) {
+            if let Some(last) = out.last_mut() {
+                if is_pure_text(last) {
+                    let addition = part["text"].as_str().unwrap_or_default().to_string();
+                    if let Some(serde_json::Value::String(text)) = last.get_mut("text") {
+                        text.push_str(&addition);
+                    }
+                    continue;
+                }
+            }
+        }
+        out.push(part);
+    }
+    out
+}
+
+/// Build the Gemini request body (shared between streaming and
+/// non-streaming): `(system_text, request_body)` with the transcript
+/// already in `request_body["contents"]`.
 pub(crate) fn build_gemini_request_parts(
     messages: &[Message],
     provider: &GeminiProvider,
-) -> (Option<String>, Vec<serde_json::Value>, serde_json::Value) {
+) -> (Option<String>, serde_json::Value) {
     let system_text = messages
         .iter()
         .find(|m| m.role == "system")
@@ -645,11 +683,14 @@ pub(crate) fn build_gemini_request_parts(
     }
 
     let mut request_body = serde_json::json!({
-        "contents": contents,
         "generationConfig": {
             "maxOutputTokens": provider.max_output_tokens,
         }
     });
+    // Move the contents tree into the body: `json!({"contents": contents})`
+    // serialized a deep copy of the whole transcript (base64 screenshots
+    // included) that every caller then dropped.
+    request_body["contents"] = serde_json::Value::Array(contents);
 
     let has_func_tools = provider.use_tools;
     let has_cu = provider.cu_enabled;
@@ -675,7 +716,7 @@ pub(crate) fn build_gemini_request_parts(
         request_body["tools"] = serde_json::Value::Array(tools_arr);
     }
 
-    (system_text, contents, request_body)
+    (system_text, request_body)
 }
 
 /// CU function names used by Gemini's computer_use tool.
@@ -888,10 +929,11 @@ mod tests {
                 ..Default::default()
             },
         ];
-        let (sys, contents, body) = build_gemini_request_parts(&messages, &provider);
+        let (sys, body) = build_gemini_request_parts(&messages, &provider);
         assert_eq!(sys.as_deref(), Some("System"));
+        let contents = body["contents"].as_array().unwrap();
         assert_eq!(contents.len(), 1);
-        assert!(body.get("contents").is_some());
+        assert_eq!(contents[0]["parts"][0]["text"].as_str(), Some("Hi"));
     }
 
     #[test]
@@ -910,7 +952,8 @@ mod tests {
             },
             tool_msg_with_images(),
         ];
-        let (_sys, contents, _body) = build_gemini_request_parts(&messages, &provider);
+        let (_sys, body) = build_gemini_request_parts(&messages, &provider);
+        let contents = body["contents"].as_array().unwrap();
         // Should have functionResponse + user message with inlineData
         assert_eq!(contents.len(), 2);
         let img_msg = &contents[1];
@@ -952,8 +995,41 @@ mod tests {
                 ..Default::default()
             },
         ];
-        let (_sys, contents, _body) = build_gemini_request_parts(&messages, &provider);
+        let (_sys, body) = build_gemini_request_parts(&messages, &provider);
         // Should have only the functionResponse, no user image message
-        assert_eq!(contents.len(), 1);
+        assert_eq!(body["contents"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn coalesce_merges_adjacent_text_runs_only() {
+        let parts = vec![
+            serde_json::json!({"text": "Hel"}),
+            serde_json::json!({"text": "lo "}),
+            serde_json::json!({"text": "world"}),
+            serde_json::json!({"functionCall": {"name": "f", "args": {}}}),
+            serde_json::json!({"text": "tail "}),
+            serde_json::json!({"text": "end"}),
+        ];
+        let out = coalesce_adjacent_text_parts(parts);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0], serde_json::json!({"text": "Hello world"}));
+        assert!(out[1].get("functionCall").is_some());
+        assert_eq!(out[2], serde_json::json!({"text": "tail end"}));
+    }
+
+    #[test]
+    fn coalesce_never_merges_parts_with_extra_fields() {
+        // thoughtSignature must be echoed back verbatim — a part carrying
+        // it is not "pure text" even though it has a text field.
+        let parts = vec![
+            serde_json::json!({"text": "a", "thoughtSignature": "sig1"}),
+            serde_json::json!({"text": "b"}),
+            serde_json::json!({"text": "c"}),
+        ];
+        let out = coalesce_adjacent_text_parts(parts);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0]["thoughtSignature"].as_str(), Some("sig1"));
+        assert_eq!(out[0]["text"].as_str(), Some("a"));
+        assert_eq!(out[1], serde_json::json!({"text": "bc"}));
     }
 }

--- a/src/bin/caller/provider/mod.rs
+++ b/src/bin/caller/provider/mod.rs
@@ -449,13 +449,20 @@ fn default_max_output_tokens(model: &str) -> u64 {
         m if m.starts_with("gpt-5") => 128_000,
         m if m.starts_with("o1") || m.starts_with("o3") || m.starts_with("o4") => 100_000,
         // Anthropic ceilings by family: the Claude 3 generation caps at 8K
-        // and Opus 4/4.1 at 32K, while every 4.5+ model accepts at least
-        // 64K output. The old blanket 8_192 was a Claude-3-era default that
-        // truncated long completions (or forced continuation turns, each
-        // re-billing the full prompt). `max_tokens` is a ceiling, not a
-        // target — raising it costs nothing unless output is generated.
+        // and Opus 4/4.1 at 32K (matched in dated and undated-alias forms:
+        // claude-opus-4-0, claude-opus-4-1-20250805, claude-opus-4-20250514),
+        // while Sonnet 4 and every 4.5+ model accept at least 64K output.
+        // The old blanket 8_192 was a Claude-3-era default that truncated
+        // long completions (or forced continuation turns, each re-billing
+        // the full prompt). `max_tokens` is a ceiling, not a target —
+        // raising it costs nothing unless output is generated.
         m if m.starts_with("claude-3") => 8_192,
-        m if m.starts_with("claude-opus-4-1") || m.starts_with("claude-opus-4-2") => 32_000,
+        m if m.starts_with("claude-opus-4-0")
+            || m.starts_with("claude-opus-4-1")
+            || m.starts_with("claude-opus-4-2") =>
+        {
+            32_000
+        }
         m if m.contains("claude") => 64_000,
         m if m.starts_with("gemini") => 65_536,
         _ => 16_384,
@@ -1296,7 +1303,8 @@ mod tests {
             64_000
         );
         // Older families keep their real ceilings: Claude 3 at 8K,
-        // Opus 4/4.1 at 32K.
+        // Opus 4/4.1 at 32K — in dated AND undated-alias forms (the alias
+        // `claude-opus-4-0` carries no date digits to match on).
         assert_eq!(
             default_max_output_tokens("claude-3-5-sonnet-20241022"),
             8_192
@@ -1305,7 +1313,16 @@ mod tests {
             default_max_output_tokens("claude-opus-4-1-20250805"),
             32_000
         );
+        assert_eq!(default_max_output_tokens("claude-opus-4-1"), 32_000);
         assert_eq!(default_max_output_tokens("claude-opus-4-20250514"), 32_000);
+        assert_eq!(default_max_output_tokens("claude-opus-4-0"), 32_000);
+        // Sonnet 4's real output cap is 64K — the catch-all is correct for
+        // both its dated and alias forms.
+        assert_eq!(default_max_output_tokens("claude-sonnet-4-0"), 64_000);
+        assert_eq!(
+            default_max_output_tokens("claude-sonnet-4-20250514"),
+            64_000
+        );
         assert_eq!(default_max_output_tokens("o1-preview"), 100_000);
     }
 

--- a/src/bin/caller/provider/mod.rs
+++ b/src/bin/caller/provider/mod.rs
@@ -44,22 +44,35 @@ async fn send_with_retry(
     build_request: impl Fn() -> reqwest::RequestBuilder,
     max_retries: u32,
 ) -> Result<reqwest::Response, CallerError> {
-    let mut last_err = None;
+    let mut last_err: Option<CallerError> = None;
     for attempt in 0..=max_retries {
-        let response = build_request().send().await?;
-        if response.status().is_success() || !is_retryable_status(response.status()) {
-            return Ok(response);
+        match build_request().send().await {
+            Ok(response) => {
+                if response.status().is_success() || !is_retryable_status(response.status()) {
+                    return Ok(response);
+                }
+                let status = response.status();
+                let body = response.text().await.unwrap_or_default();
+                last_err = Some(CallerError::Provider(format!(
+                    "{}: {}",
+                    status,
+                    mask_api_keys(&body)
+                )));
+            }
+            // Transport-level failure before a response arrived (connection
+            // reset, refused, DNS): as retryable as a 5xx — nothing was
+            // consumed. Timeouts are excluded: each attempt already waited
+            // the full request timeout, so backoff-retrying them multiplies
+            // a hung endpoint into `timeout × (retries+1)` of wall clock.
+            Err(e) if !e.is_timeout() => last_err = Some(CallerError::Http(e)),
+            Err(e) => return Err(CallerError::Http(e)),
         }
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        last_err = Some(format!("{}: {}", status, mask_api_keys(&body)));
         if attempt < max_retries {
             tokio::time::sleep(backoff_delay(attempt)).await;
         }
     }
-    Err(CallerError::Provider(last_err.unwrap_or_else(|| {
-        "request failed after retries".to_string()
-    })))
+    Err(last_err
+        .unwrap_or_else(|| CallerError::Provider("request failed after retries".to_string())))
 }
 
 /// Parse Server-Sent Events from a byte stream. Returns (event_type, data) pairs.
@@ -372,6 +385,17 @@ pub trait ChatProvider: Send + Sync {
     /// differs from the default (e.g. user's real display vs virtual display).
     fn set_cu_display(&mut self, _dims: (u32, u32)) {}
 
+    /// Whether the agent loop must strip superseded non-CU screenshots from
+    /// the conversation before each request (`Conversation::strip_old_images`).
+    /// The OpenAI `computer` tool rejects requests carrying more than one
+    /// non-CU image, so CU-enabled OpenAI instances require it. Anthropic
+    /// overrides this to `false`: it accepts multi-image histories, and
+    /// mutating old messages would invalidate its prompt-cache prefix from
+    /// the mutation point on every new screenshot.
+    fn requires_image_stripping(&self) -> bool {
+        self.cu_enabled()
+    }
+
     /// Return tool definitions when native tool calling is enabled.
     #[allow(dead_code)]
     fn tools(&self) -> Vec<ToolDefinition> {
@@ -424,7 +448,15 @@ fn default_max_output_tokens(model: &str) -> u64 {
     match model {
         m if m.starts_with("gpt-5") => 128_000,
         m if m.starts_with("o1") || m.starts_with("o3") || m.starts_with("o4") => 100_000,
-        m if m.contains("claude") => 8_192,
+        // Anthropic ceilings by family: the Claude 3 generation caps at 8K
+        // and Opus 4/4.1 at 32K, while every 4.5+ model accepts at least
+        // 64K output. The old blanket 8_192 was a Claude-3-era default that
+        // truncated long completions (or forced continuation turns, each
+        // re-billing the full prompt). `max_tokens` is a ceiling, not a
+        // target — raising it costs nothing unless output is generated.
+        m if m.starts_with("claude-3") => 8_192,
+        m if m.starts_with("claude-opus-4-1") || m.starts_with("claude-opus-4-2") => 32_000,
+        m if m.contains("claude") => 64_000,
         m if m.starts_with("gemini") => 65_536,
         _ => 16_384,
     }
@@ -1253,10 +1285,27 @@ mod tests {
     fn default_max_output_known_models() {
         assert_eq!(default_max_output_tokens("gpt-5.2-codex"), 128_000);
         assert_eq!(default_max_output_tokens("gpt-5"), 128_000);
+        // 4.5-generation Claude models accept 64K output; the old 8_192
+        // blanket default truncated long completions.
         assert_eq!(
             default_max_output_tokens("claude-sonnet-4-5-20250929"),
+            64_000
+        );
+        assert_eq!(
+            default_max_output_tokens("claude-haiku-4-5-20251001"),
+            64_000
+        );
+        // Older families keep their real ceilings: Claude 3 at 8K,
+        // Opus 4/4.1 at 32K.
+        assert_eq!(
+            default_max_output_tokens("claude-3-5-sonnet-20241022"),
             8_192
         );
+        assert_eq!(
+            default_max_output_tokens("claude-opus-4-1-20250805"),
+            32_000
+        );
+        assert_eq!(default_max_output_tokens("claude-opus-4-20250514"), 32_000);
         assert_eq!(default_max_output_tokens("o1-preview"), 100_000);
     }
 

--- a/src/bin/caller/provider/openai.rs
+++ b/src/bin/caller/provider/openai.rs
@@ -148,12 +148,6 @@ pub(crate) struct OpenAIResponsesResponse {
     usage: Option<ResponsesUsage>,
 }
 
-/// Minimal wrapper to capture raw output items as JSON values.
-#[derive(Deserialize)]
-pub(crate) struct OpenAIResponsesRawOutput {
-    output: Option<Vec<serde_json::Value>>,
-}
-
 #[derive(Deserialize)]
 pub(crate) struct ResponsesOutputItem {
     #[serde(rename = "type")]
@@ -353,7 +347,9 @@ impl ChatProvider for OpenAIProvider {
         // Note: OpenAI Responses API uses automatic prompt caching for prompts
         // longer than 1024 tokens. No explicit API changes are needed — caching
         // is applied server-side and reported via usage.prompt_tokens_details.
-        let request_json = serde_json::to_value(&request).map_err(CallerError::Json)?;
+        // Serialize once, straight to bytes — `to_value` + `.json()` walked
+        // the full request (images included) twice per call.
+        let request_body = serde_json::to_vec(&request).map_err(CallerError::Json)?;
         let client = &self.client;
         let api_key = &self.api_key;
         let response = send_with_retry(
@@ -362,7 +358,8 @@ impl ChatProvider for OpenAIProvider {
                 client
                     .post("https://api.openai.com/v1/responses")
                     .header("Authorization", format!("Bearer {}", api_key))
-                    .json(&request_json)
+                    .header("content-type", "application/json")
+                    .body(request_body.clone())
             },
             MAX_RETRIES,
         )
@@ -378,12 +375,13 @@ impl ChatProvider for OpenAIProvider {
             )));
         }
 
-        let body = response.text().await?;
-        let resp: OpenAIResponsesResponse = serde_json::from_str(&body)?;
+        // Parse the body once; the typed view and the raw echo-back items
+        // both project from the same DOM (this used to re-tokenize the
+        // full body a second time).
+        let body: serde_json::Value = serde_json::from_str(&response.text().await?)?;
         // Capture raw output items for verbatim echo-back (reasoning + function_call items)
-        let raw_output = serde_json::from_str::<OpenAIResponsesRawOutput>(&body)
-            .ok()
-            .and_then(|r| r.output);
+        let raw_output = body.get("output").and_then(|o| o.as_array()).cloned();
+        let resp: OpenAIResponsesResponse = serde_json::from_value(body)?;
 
         // Extract function_call and computer_call items from the output array
         let mut tool_calls = Vec::new();
@@ -576,17 +574,26 @@ impl ChatProvider for OpenAIProvider {
             tools,
             stream: true,
         };
-        let request_json = serde_json::to_value(&request).map_err(CallerError::Json)?;
+        let request_body = serde_json::to_vec(&request).map_err(CallerError::Json)?;
         let client = &self.client;
         let api_key = &self.api_key;
 
-        let response = client
-            .post("https://api.openai.com/v1/responses")
-            .header("Authorization", format!("Bearer {}", api_key))
-            .timeout(STREAM_TIMEOUT)
-            .json(&request_json)
-            .send()
-            .await?;
+        // Same retry policy as non-streaming: the status is known before any
+        // body bytes stream, so a 429/5xx at request-open retries with
+        // backoff instead of killing the session turn.
+        let response = send_with_retry(
+            client,
+            || {
+                client
+                    .post("https://api.openai.com/v1/responses")
+                    .header("Authorization", format!("Bearer {}", api_key))
+                    .header("content-type", "application/json")
+                    .timeout(STREAM_TIMEOUT)
+                    .body(request_body.clone())
+            },
+            MAX_RETRIES,
+        )
+        .await?;
 
         if !response.status().is_success() {
             let status = response.status();


### PR DESCRIPTION
Token-spend batch from the efficiency audit (reports 02/03): make Anthropic prompt caching actually cover the conversation, stop the per-turn mutations that fight it, and clean up the request-assembly path for all three providers. **Includes two reconciled review rounds**: round 1 (marker placement, pre-4.5 clamp, alias tiers, image bound, test-count correction) and round 2 on the round-1 guards (clamp floor semantics, tools-aware estimate, image byte budget, elision hysteresis).

## Finding → fix

| # | Finding (audit ref) | Where | Fix |
|---|---|---|---|
| 1 | **Anthropic conversation never prompt-cached** — the only `cache_control` breakpoint sat on the system block, so the growing transcript re-billed at full input rate every turn (~5-10× input cost on the hottest path). Audit 03#1 = 02#1, twice-confirmed. | `src/bin/caller/provider/anthropic.rs` (`build_anthropic_messages`) | Rolling breakpoints, **turn-boundary placement** (review round): one marker on the final block of the current request's last user-side message, one on the last user-side message *before the most recent assistant message* — i.e. exactly where the previous request's tail marker sat. That guarantees the previous-request boundary is re-read at cache price for **any batch size** (the earlier "last two user messages" policy failed when one turn appended many tool_result messages: both markers landed inside the new batch, past Anthropic's ~20-block lookback, re-billing the whole history). At worst a >20-block turn bills its own new blocks uncached once. Plain-string bodies are promoted to the API-documented single-text-block equivalent. Budget: 1 system (covers tools) + 2 rolling = 3 of the allowed 4. |
| 2 | **`budget_summary` appended to every tool result** — ~25 tokens of `[Context: …]` filler per result, N copies per turn, re-billed with the whole transcript on every later request (02#3). | `src/bin/caller/agent_loop.rs` | Budget line appended once per turn, on the batch's final unhandled result (`budget_tail_index`, unit-tested: last-unhandled selection; empty/fully-handled batch → no line). History stays append-only and byte-stable. The legacy text path already emitted once per turn (unchanged). |
| 3 | **`strip_old_images` mutates history for all CU providers** — exists for the OpenAI `computer` tool (rejects multiple non-CU images); under Anthropic each new screenshot rewrote older messages and invalidated the message cache from the mutation point (02#1 caveat). | `agent_loop.rs` + `provider/mod.rs` + `provider/anthropic.rs` | Provider seam `ChatProvider::requires_image_stripping()` (default: `cu_enabled()`, preserving OpenAI/Gemini behavior); Anthropic overrides to `false`. **Bounded by request-side image guards** (review rounds): kept images must satisfy `MAX_REQUEST_IMAGES = 40` **and** `MAX_REQUEST_IMAGE_BYTES = 16 MiB` of base64 payload (count alone does not bound the body: a handful of ~5 MiB screenshots blow the ~32 MB request ceiling under 40 images). Oldest images are replaced with a fixed placeholder block at build time (conversation untouched); the newest image is always sent. The elision boundary is **quantized to 8-image steps** (`IMAGE_ELISION_STEP`) — an exact per-request boundary would advance by one every steady-state turn, changing an early-prefix block each request and permanently defeating the previous-tail cache marker; stepped, it holds still for ~8 images and invalidation amortizes to ~1-in-8 requests. Below both limits the build is byte-identical to an unguarded one. |
| 4 | **Streaming requests had zero 429/5xx retry** — stream opens bypassed `send_with_retry`, so routine throttling at request-open killed the session turn; `send_with_retry` also aborted on transport errors (03#3). | `provider/mod.rs`, `anthropic.rs`, `openai.rs`, `gemini.rs` | All streaming opens go through `send_with_retry` (status is known before any body bytes stream). Pre-response transport errors (reset/refused/DNS) join the retryable set; request-open timeouts still fail fast. See "Retry semantics" below. |
| 5 | **Request serialized struct→Value→bytes on every call** — one avoidable whole-body DOM materialization per LLM call, re-run per retry attempt (03#5). | `anthropic.rs`, `openai.rs`, `gemini.rs` | `serde_json::to_vec(&request)` once; `post_messages`/`post_generate` take pre-serialized bytes (retries memcpy instead of re-walking the DOM). `request_snapshot` keeps its `to_value` (Context-tab contract unchanged). |
| 6 | **Gemini transcript deep-cloned then dropped** — `json!({"contents": contents, …})` copied the whole transcript (base64 screenshots included) while all three callers ignored the returned `Vec` (03#4). | `gemini.rs` (`build_gemini_request_parts`) | `contents` moved into `request_body["contents"]`; the builder returns `(system_text, request_body)`. |
| 7 | **Gemini raw-part echo bloat** — streaming stored one `{"text": …}` fragment per delta, so tool-call turns echoed hundreds of one-word parts back in every subsequent request body (03#4 secondary). | `gemini.rs` | `coalesce_adjacent_text_parts` merges runs of pure-text parts before storing `raw_output`; parts carrying any other field (`functionCall`, `thoughtSignature`, `inlineData`) are kept verbatim and act as merge boundaries. |
| 8 | **OpenAI non-streaming body parsed twice** — full body re-tokenized for the raw echo-back; the presence layer rides this per message (03#8). | `openai.rs` | Parse once to `serde_json::Value`; typed view via `from_value`, raw `output` items cloned from the same DOM. `OpenAIResponsesRawOutput` deleted. |
| 9 | **`default_max_output_tokens` capped every Claude model at 8,192** — long completions truncated or forced continuation turns, each re-billing the full prompt (03 other-findings). | `provider/mod.rs`, `anthropic.rs` | Family-aware defaults: Claude 3 stays 8,192; Opus 4/4.1 → 32,000 **matched in dated and undated-alias forms** (review round: the alias `claude-opus-4-0` carries no date digits — it previously fell to the 64K catch-all, above Opus 4's 32K cap → guaranteed 400); Sonnet 4 and every 4.5+ model → 64,000 (Sonnet 4's real cap is 64K). **Pre-4.5 request-time clamp** (review round): those models hard-400 when `input + max_tokens` exceeds the context window — below the 90% auto-compact threshold with 32K/64K ceilings, a non-retryable 400 that kills the session before compaction can run. `effective_max_tokens = min(configured, max(window − estimated input − margin, 1024))` — the configured value is a hard ceiling and is never raised (an explicit low `MAX_OUTPUT_TOKENS` override passes through), sub-floor headroom is honored up to the 1,024 estimator-noise floor (the estimate overestimates, so the floor truncates rather than 400s). The estimate is a deliberately overestimating ~chars/4 local heuristic (the compaction path's budget arithmetic rides API-reported usage on `Conversation`, which the provider seam never sees) and **includes the serialized tools payload** — runtime-registered MCP schemas are unbounded, so a fixed margin cannot stand in for them (margin right-sized to 8,192 accordingly). 4.5+ models pass the configured value through untouched. |

## Retry semantics (deliberate decisions, reviewer-flagged)

- **Ambiguous POST transport failures are retried.** A connection reset before response headers *can* mean the provider received and even billed the request; retrying risks paying for a discarded response. This follows the standard provider-SDK convention (official SDKs retry connection errors by default) — judged better than failing the whole session turn, which re-pays the entire prompt on the redo anyway.
- **"Timeouts fail fast" applies at request open only.** A mid-stream body timeout surfaces as a chunk error and maps to the **pre-existing** outer `Stream error` retry in `agent_loop.rs` (~1116), which this PR does not touch. Tightening that outer loop is a possible follow-up, out of scope here.

## Cache evidence

Live verification (run a native Anthropic session, then check per-turn `usage`) is **blocked on this box: no `ANTHROPIC_API_KEY` is configured** (repo `.env` carries OpenAI/Gemini only; no `~/.config/intendant/.env`). Expected signature once a key is present, for any multi-turn session:

- turn 1: `cache_creation` ≈ full prompt, `cache_read` = 0
- turn N>1: `cache_read` ≈ turn N−1's full context footprint, uncached `input_tokens` ≈ 0, `cache_creation` ≈ just the new turn's delta

Previously turns 2+ showed `cache_read` frozen at the tools+system size with the entire transcript in uncached `input_tokens`. Placement is pinned by unit tests, including the multi-result-batch case (`rolling_breakpoints_straddle_a_multi_result_batch`).

## Risk notes

- **Anthropic request shape**: history messages carry (and later shed) `cache_control` markers, and marked plain-string bodies are sent as single-text-block arrays. Both are API-documented equivalences; markers are metadata, not hashed prompt content. Auto-compact and context rewinds still invalidate from their mutation point — bounded and expected, as before.
- **Image guards**: sessions over the count cap or byte budget send fixed placeholders for the oldest images — the model loses stale visual context it previously also lost (more aggressively) under `strip_old_images`. The stepped boundary changes the prefix ~once per 8 new images; strictly rarer invalidation than the per-screenshot mutation it replaces.
- **Pre-4.5 clamp**: the chars/4 estimator overestimates on base64-image-heavy histories, which can pull the output ceiling toward the 1,024 floor earlier than strictly necessary on those legacy pins — safe direction (a smaller ceiling, never a 400, and never above the configured value).
- **Raised `max_tokens` ceiling**: no billing change by itself; a genuinely long completion on the 120 s non-streaming path could now run into the HTTP timeout where it previously truncated at 8,192 — the native loop streams (600 s), and short-output surfaces (presence) are unaffected.
- All three providers keep compiling and provider-specific behavior stays inside the provider seam; OpenAI/Gemini/mock keep exact current stripping semantics via the trait default.

## Tests

17 new `#[test]` fns across the PR (6 in the original batch — breakpoint placement ×4, Gemini coalescer ×2; 7 in review round 1 — multi-result-batch placement, clamp ×2, image cap ×2, budget-tail ×2; 4 in review round 2 — explicit-low-ceiling pass-through, tools-payload clamp, stepped elision boundary, byte-budget elision — plus build-determinism assertions folded into the over-cap test), and extended assertions in the existing max-output-defaults test (dated + alias tiers). Full battery green: `cargo fmt --check`, `cargo clippy` (0 warnings), `cargo test --bins` (3343+69+83 passed, 0 failed), `cargo test --test e2e` (21/21).

## Skipped / out of scope (noted for the audit ledger)

- 03#6 SSE hot-loop churn + shared streaming core: owner-excluded (L-track unification).
- 03#7 / 02#5 tool-schema rebuild caching: the safe fix needs a version stamp on `EXTRA_TOOLS` in `tools.rs` (outside this PR's file fence); provider-side-only caching could serve a stale tool set after late MCP registration.
- 03#2 / 02#2 request-snapshot / turn-dump consolidation: PR-B (event.rs / session_log).
- Loop items that are log/dump-path (messages_input pretty-print, conversation save cadence): PR-B.
