### PR TITLE
runtime: efficiency pass + provider-credential env scrub (audit scope 01)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -73,10 +73,19 @@ const LOG_TAIL_BYTES: u64 = 10 * 1024; // 10KB
 // (see `pty_marker_emit`), so the assembled string is proof of execution.
 const PTY_MARKER_START_PREFIX: &str = "__PTY_START";
 const PTY_MARKER_END_PREFIX: &str = "__PTY_END";
-/// cmd.exe marker-assembly variable (see `PtyShellFlavor::Cmd`).
+/// Prefix of the cmd.exe marker-assembly variable; the per-command variable
+/// is nonce-suffixed (see `pty_cmd_marker_var`).
 const PTY_CMD_MARKER_VAR: &str = "__PTY_MVAR";
 
-/// Emit the shell line(s) that print `{prefix}{suffix}` without the typed
+/// The cmd.exe marker-assembly variable for one command. Nonce-suffixed so
+/// it can never collide with (or clobber) a user variable or a concurrent
+/// harness value, and unset again by `pty_marker_cleanup` once the end
+/// marker has printed.
+fn pty_cmd_marker_var(nonce: u64) -> String {
+    format!("{}_{}", PTY_CMD_MARKER_VAR, nonce)
+}
+
+/// Emit the shell line(s) that print `{prefix}_{nonce}__` without the typed
 /// input ever containing the assembled string. The tty driver echoes raw
 /// input bytes whenever they arrive before a line editor has turned echo
 /// off — guaranteed for bytes racing a fresh shell's startup — so a marker
@@ -87,24 +96,67 @@ const PTY_CMD_MARKER_VAR: &str = "__PTY_MVAR";
 fn pty_marker_emit(
     flavor: crate::utils::PtyShellFlavor,
     prefix: &str,
-    suffix: &str,
+    nonce: u64,
     nl: &str,
 ) -> String {
     use crate::utils::PtyShellFlavor;
     match flavor {
         // Adjacent double-quoted strings concatenate in POSIX shells.
-        PtyShellFlavor::Posix => format!("echo \"{prefix}\"\"{suffix}\"{nl}"),
+        PtyShellFlavor::Posix => format!("echo \"{prefix}\"\"_{nonce}__\"{nl}"),
         // PowerShell string concatenation, parenthesized so echo
         // (Write-Output) receives one argument.
-        PtyShellFlavor::PowerShell => format!("echo (\"{prefix}\" + \"{suffix}\"){nl}"),
+        PtyShellFlavor::PowerShell => format!("echo (\"{prefix}\" + \"_{nonce}__\"){nl}"),
         // cmd.exe cannot concatenate inline; assemble via a variable set on
         // the *previous* line (%X% on the same line would expand at parse
-        // time, before the set runs).
+        // time, before the set runs). The variable is visible to children
+        // the shell spawns while it is set — unavoidable for this
+        // mechanism — but it is nonce-scoped, carries only a marker prefix,
+        // and is unset right after the marker prints.
         PtyShellFlavor::Cmd => format!(
-            "set {var}={prefix}{nl}echo %{var}%{suffix}{nl}",
-            var = PTY_CMD_MARKER_VAR,
+            "set {var}={prefix}{nl}echo %{var}%_{nonce}__{nl}",
+            var = pty_cmd_marker_var(nonce),
         ),
     }
+}
+
+/// Cmd-only epilogue written after the end-marker emit: unset the
+/// nonce-scoped assembly variable so nothing persists in the session once
+/// the command's markers have printed. Empty for shells that never set one.
+fn pty_marker_cleanup(flavor: crate::utils::PtyShellFlavor, nonce: u64, nl: &str) -> String {
+    use crate::utils::PtyShellFlavor;
+    match flavor {
+        PtyShellFlavor::Cmd => format!("set {var}={nl}", var = pty_cmd_marker_var(nonce)),
+        PtyShellFlavor::Posix | PtyShellFlavor::PowerShell => String::new(),
+    }
+}
+
+/// The exact harness line shapes for one command's nonce: the split-form
+/// typed lines (which arrive as tty/readline echoes, possibly with a prompt
+/// prefix — hence tail matching at the call site), the assembled marker
+/// output lines, and the cmd.exe variable lines. Used to strip harness
+/// noise from captured output while leaving user output that merely
+/// mentions a sentinel prefix (e.g. "__PTY_ENDURANCE ready") intact.
+fn pty_harness_line_patterns(flavor: crate::utils::PtyShellFlavor, nonce: u64) -> Vec<String> {
+    let mut patterns = Vec::new();
+    for prefix in [PTY_MARKER_START_PREFIX, PTY_MARKER_END_PREFIX] {
+        for line in pty_marker_emit(flavor, prefix, nonce, "\n").split('\n') {
+            if !line.is_empty() {
+                patterns.push(line.to_string());
+            }
+        }
+        // The assembled marker output line.
+        patterns.push(format!("{prefix}_{nonce}__"));
+    }
+    if flavor == crate::utils::PtyShellFlavor::Cmd {
+        for line in pty_marker_cleanup(flavor, nonce, "\n").split('\n') {
+            if !line.is_empty() {
+                patterns.push(line.to_string());
+            }
+        }
+        // The literal echo output when the variable failed to set.
+        patterns.push(format!("%{}%_{nonce}__", pty_cmd_marker_var(nonce)));
+    }
+    patterns
 }
 
 #[derive(Clone)]
@@ -261,12 +313,29 @@ impl Agent {
         })
     }
 
+    /// Invalidate the completeness manifest BEFORE a merge pass mutates the
+    /// merged file. Crash-consistency: a crash mid-pass must leave "no
+    /// manifest" (re-merge next invocation), never a stale manifest beside
+    /// a merged file whose mtime the partial pass already bumped — that
+    /// combination would certify sources the pass never reached. Returns
+    /// true when invalidation could not be proven (delete failed with
+    /// something other than NotFound); the caller treats that as a pass
+    /// failure so completeness is never certified on top of it.
+    #[cfg(any(test, not(target_os = "macos")))]
+    fn invalidate_xauth_manifest_before_pass(merged: &Path) -> bool {
+        match fs::remove_file(Self::xauth_manifest_path(merged)) {
+            Ok(()) => false,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+            Err(_) => true,
+        }
+    }
+
     /// Conclude a merge pass. Nothing merged → drop the merged file and
     /// manifest (a zero-cookie or stale file must not be served later, and
     /// a nonzero-exit `nmerge` can still have created it). Merged but with
     /// failures → keep the file for this invocation, drop the manifest so
     /// the next invocation retries the missing sources. Fully clean pass →
-    /// record every source that currently exists as resolved.
+    /// atomically record every source that currently exists as resolved.
     #[cfg(any(test, not(target_os = "macos")))]
     fn finalize_xauth_merge_pass(
         merged: &Path,
@@ -276,11 +345,19 @@ impl Agent {
     ) -> Option<PathBuf> {
         let manifest = Self::xauth_manifest_path(merged);
         if !any_merged {
+            // Best-effort removals: the manifest was already invalidated
+            // before the pass, and a merged file that survives this remove
+            // is harmless — with no manifest, freshness fails and the next
+            // invocation re-runs the pass.
             let _ = fs::remove_file(merged);
             let _ = fs::remove_file(&manifest);
             return None;
         }
         if any_failure {
+            // Normally already gone (pre-pass invalidation); repeat in case
+            // that delete failed. A failure here leaves no manifest to
+            // mislead anyone — the pre-pass step already forced
+            // `any_failure` when it could not prove the delete.
             let _ = fs::remove_file(&manifest);
         } else {
             let listing: String = sources
@@ -288,13 +365,30 @@ impl Agent {
                 .filter(|src| src.exists())
                 .map(|src| format!("{}\n", src.display()))
                 .collect();
-            let _ = fs::write(&manifest, listing);
+            // Atomic publish (tempfile + rename): a crash mid-write must
+            // not leave a torn manifest half-certifying completeness. On
+            // any failure, make sure no manifest survives — "absent" is
+            // always safe (it just re-merges next time).
+            let mut tmp_name = manifest.file_name().unwrap_or_default().to_os_string();
+            tmp_name.push(".tmp");
+            let tmp = manifest.with_file_name(tmp_name);
+            if fs::write(&tmp, listing)
+                .and_then(|()| fs::rename(&tmp, &manifest))
+                .is_err()
+            {
+                let _ = fs::remove_file(&tmp);
+                let _ = fs::remove_file(&manifest);
+            }
         }
         Some(merged.to_path_buf())
     }
 
     /// Merge one cookie listing into the session file; Ok(true) on success,
-    /// Ok(false) when `xauth nmerge` exits nonzero.
+    /// Ok(false) when the cookie write to `xauth nmerge` fails or the
+    /// process exits nonzero. The stdin write result matters: a failed or
+    /// partial write merges nothing (or worse, a truncated cookie) even
+    /// when xauth exits zero after stdin closes — and the child is always
+    /// reaped before the result is reported.
     #[cfg(not(target_os = "macos"))]
     fn xauth_nmerge(merged_path: &Path, cookies: &[u8]) -> std::io::Result<bool> {
         use std::io::Write;
@@ -307,10 +401,12 @@ impl Agent {
             .stderr(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .spawn()?;
-        if let Some(ref mut stdin) = child.stdin {
-            let _ = stdin.write_all(cookies);
-        }
-        Ok(child.wait()?.success())
+        let wrote_ok = match child.stdin.take() {
+            // Taking (and dropping) stdin closes the pipe so xauth sees EOF.
+            Some(mut stdin) => stdin.write_all(cookies).is_ok(),
+            None => false,
+        };
+        Ok(child.wait()?.success() && wrote_ok)
     }
 
     /// Merge xauth cookies from all discovered displays into a session-scoped file.
@@ -348,7 +444,12 @@ impl Agent {
         // written and the next invocation retries. A source that consults
         // cleanly but has no cookies for a display is a resolved outcome,
         // not a failure — its mtime staleness triggers any needed re-merge.
-        let mut any_failure = false;
+        //
+        // The stale manifest is invalidated before the first merge mutation
+        // (crash-consistency: see invalidate_xauth_manifest_before_pass);
+        // an unprovable invalidation seeds `any_failure` so this pass can
+        // never certify completeness over it.
+        let mut any_failure = Self::invalidate_xauth_manifest_before_pass(&merged_path);
         for &disp in displays {
             let display_str = format!(":{}", disp);
             // Try user's own Xauthority
@@ -917,26 +1018,26 @@ impl Agent {
 
         // Generate unique start and end markers (the assembled forms the
         // scanner and extractor look for in executed output).
-        let marker_suffix = format!("_{}__", cmd.nonce);
-        let start_marker = format!("{}{}", PTY_MARKER_START_PREFIX, marker_suffix);
-        let marker = format!("{}{}", PTY_MARKER_END_PREFIX, marker_suffix);
+        let flavor = session.flavor;
+        let start_marker = format!("{}_{}__", PTY_MARKER_START_PREFIX, cmd.nonce);
+        let marker = format!("{}_{}__", PTY_MARKER_END_PREFIX, cmd.nonce);
 
-        // Write: emit start-marker, then command, then emit end-marker. The
-        // marker `echo` lines are written in a *split* form the shell joins
-        // at execution time (see `pty_marker_emit`), so the assembled marker
-        // can only ever appear in executed output — never in the tty's echo
-        // of the typed input. The writer is shared with the reader thread
-        // (which answers DSR queries), so take the lock just for the
-        // duration of this write. Each line is terminated with the platform
-        // PTY submit byte (`\r` on Windows so ConPTY treats it as Enter;
-        // `\n` on Unix, unchanged).
+        // Write: emit start-marker, then command, then emit end-marker (plus
+        // the cmd.exe variable cleanup). The marker `echo` lines are written
+        // in a *split* form the shell joins at execution time (see
+        // `pty_marker_emit`), so the assembled marker can only ever appear
+        // in executed output — never in the tty's echo of the typed input.
+        // The writer is shared with the reader thread (which answers DSR
+        // queries), so take the lock just for the duration of this write.
+        // Each line is terminated with the platform PTY submit byte (`\r` on
+        // Windows so ConPTY treats it as Enter; `\n` on Unix, unchanged).
         let nl = crate::utils::pty_line_ending();
         let pty_input = format!(
-            "{start_emit}{cmd}{nl}{end_emit}",
-            start_emit =
-                pty_marker_emit(session.flavor, PTY_MARKER_START_PREFIX, &marker_suffix, nl),
+            "{start_emit}{cmd}{nl}{end_emit}{cleanup}",
+            start_emit = pty_marker_emit(flavor, PTY_MARKER_START_PREFIX, cmd.nonce, nl),
             cmd = command,
-            end_emit = pty_marker_emit(session.flavor, PTY_MARKER_END_PREFIX, &marker_suffix, nl),
+            end_emit = pty_marker_emit(flavor, PTY_MARKER_END_PREFIX, cmd.nonce, nl),
+            cleanup = pty_marker_cleanup(flavor, cmd.nonce, nl),
             nl = nl,
         );
         {
@@ -1036,16 +1137,18 @@ impl Agent {
             lines.pop();
         }
 
-        // Remove harness lines: assembled marker output lines and the echoed
-        // split-form `echo` input lines all contain a marker prefix, and the
-        // cmd.exe assembly lines contain the marker variable. (A user
-        // command that prints these sentinel prefixes loses those lines —
-        // the pre-existing acceptance for the assembled markers, applied to
-        // the split forms too.)
+        // Remove harness lines — matched against the exact shapes for THIS
+        // call's nonce (assembled marker outputs, the split-form typed
+        // lines, the cmd variable lines). Echoed input can arrive with a
+        // prompt prefix, so lines match by exact trimmed tail. User output
+        // that merely mentions a sentinel prefix (e.g. "__PTY_ENDURANCE
+        // ready") stays intact.
+        let harness_patterns = pty_harness_line_patterns(flavor, cmd.nonce);
         lines.retain(|line| {
-            !line.contains(PTY_MARKER_START_PREFIX)
-                && !line.contains(PTY_MARKER_END_PREFIX)
-                && !line.contains(PTY_CMD_MARKER_VAR)
+            let trimmed = line.trim();
+            !harness_patterns
+                .iter()
+                .any(|pattern| trimmed.ends_with(pattern.as_str()))
         });
 
         let final_output = lines.join("\n");
@@ -2646,7 +2749,8 @@ mod tests {
 
     /// The split-form marker input never contains the assembled marker for
     /// any shell flavor, while the shapes are the exact lines each shell
-    /// needs to print it.
+    /// needs to print it — and cmd's assembly variable is nonce-scoped and
+    /// unset by the cleanup epilogue.
     #[test]
     fn pty_marker_emit_keeps_assembled_marker_out_of_typed_input() {
         use crate::utils::PtyShellFlavor;
@@ -2656,28 +2760,109 @@ mod tests {
             PtyShellFlavor::PowerShell,
             PtyShellFlavor::Cmd,
         ] {
-            let emitted = pty_marker_emit(flavor, PTY_MARKER_END_PREFIX, "_7__", "\n");
+            let emitted = pty_marker_emit(flavor, PTY_MARKER_END_PREFIX, 7, "\n");
             assert!(
                 !emitted.contains(&assembled),
                 "{flavor:?} input must not contain the assembled marker: {emitted:?}"
             );
         }
         assert_eq!(
-            pty_marker_emit(PtyShellFlavor::Posix, PTY_MARKER_END_PREFIX, "_7__", "\n"),
+            pty_marker_emit(PtyShellFlavor::Posix, PTY_MARKER_END_PREFIX, 7, "\n"),
             "echo \"__PTY_END\"\"_7__\"\n"
         );
         assert_eq!(
-            pty_marker_emit(
-                PtyShellFlavor::PowerShell,
-                PTY_MARKER_END_PREFIX,
-                "_7__",
-                "\r"
-            ),
+            pty_marker_emit(PtyShellFlavor::PowerShell, PTY_MARKER_END_PREFIX, 7, "\r"),
             "echo (\"__PTY_END\" + \"_7__\")\r"
         );
         assert_eq!(
-            pty_marker_emit(PtyShellFlavor::Cmd, PTY_MARKER_END_PREFIX, "_7__", "\r"),
-            "set __PTY_MVAR=__PTY_END\recho %__PTY_MVAR%_7__\r"
+            pty_marker_emit(PtyShellFlavor::Cmd, PTY_MARKER_END_PREFIX, 7, "\r"),
+            "set __PTY_MVAR_7=__PTY_END\recho %__PTY_MVAR_7%_7__\r"
+        );
+        // Cleanup epilogue: cmd unsets its nonce-scoped variable so nothing
+        // persists after the markers print; the other shells set none.
+        assert_eq!(
+            pty_marker_cleanup(PtyShellFlavor::Cmd, 7, "\r"),
+            "set __PTY_MVAR_7=\r"
+        );
+        assert_eq!(pty_marker_cleanup(PtyShellFlavor::Posix, 7, "\n"), "");
+        assert_eq!(pty_marker_cleanup(PtyShellFlavor::PowerShell, 7, "\r"), "");
+    }
+
+    /// The harness filter is anchored to the exact nonce-bound line shapes:
+    /// harness lines are stripped (prompt-prefixed or bare), while user
+    /// output that merely mentions a sentinel prefix — or another nonce's
+    /// marker — survives.
+    #[test]
+    fn pty_harness_patterns_spare_user_output() {
+        use crate::utils::PtyShellFlavor;
+        for flavor in [
+            PtyShellFlavor::Posix,
+            PtyShellFlavor::PowerShell,
+            PtyShellFlavor::Cmd,
+        ] {
+            let patterns = pty_harness_line_patterns(flavor, 7);
+            let is_harness = |line: &str| {
+                patterns
+                    .iter()
+                    .any(|pattern| line.trim().ends_with(pattern.as_str()))
+            };
+
+            // Assembled marker outputs and every emitted harness line are
+            // stripped, with or without a prompt prefix.
+            assert!(is_harness("__PTY_START_7__"), "{flavor:?}");
+            assert!(is_harness("__PTY_END_7__"), "{flavor:?}");
+            for prefix in [PTY_MARKER_START_PREFIX, PTY_MARKER_END_PREFIX] {
+                for line in pty_marker_emit(flavor, prefix, 7, "\n")
+                    .split('\n')
+                    .filter(|l| !l.is_empty())
+                {
+                    assert!(is_harness(line), "{flavor:?} emit line: {line}");
+                    assert!(
+                        is_harness(&format!("bash-5.2$ {line}")),
+                        "{flavor:?} prompt-prefixed emit line: {line}"
+                    );
+                }
+            }
+            if flavor == PtyShellFlavor::Cmd {
+                assert!(is_harness("set __PTY_MVAR_7="), "cmd cleanup line");
+                assert!(is_harness("%__PTY_MVAR_7%_7__"), "cmd unset-echo output");
+            }
+
+            // User output mentioning the prefixes is NOT harness noise.
+            assert!(!is_harness("__PTY_ENDURANCE ready"), "{flavor:?}");
+            assert!(!is_harness("__PTY_START_MENU opened"), "{flavor:?}");
+            // Another nonce's marker belongs to another command, not this
+            // filter.
+            assert!(!is_harness("__PTY_END_8__"), "{flavor:?}");
+        }
+    }
+
+    /// User output that mentions harness-like prefixes must come through
+    /// end to end — the cleanup filter is anchored to this call's exact
+    /// marker shapes, not a substring match.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn exec_pty_user_output_mentioning_prefixes_survives() {
+        let (agent, _log) = create_test_agent();
+        let cmd = AgentCommand {
+            function: "execPty".to_string(),
+            nonce: 5,
+            command: Some("echo \"__PTY_ENDURANCE ready\"".to_string()),
+            ..Default::default()
+        };
+        let result = match agent.exec_pty(&cmd).await {
+            Ok(r) => r,
+            Err(AgentError::Process(msg)) if msg.contains("Permission denied") => return,
+            Err(e) => panic!("unexpected exec_pty error: {}", e),
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert!(
+            parsed["output"]
+                .as_str()
+                .unwrap()
+                .contains("__PTY_ENDURANCE ready"),
+            "user output mentioning a sentinel prefix must survive: {}",
+            parsed["output"]
         );
     }
 
@@ -3298,7 +3483,8 @@ mod tests {
         assert!(!Agent::merged_xauthority_is_fresh(&merged, &sources));
 
         // Clean pass: the manifest records existing sources (not missing
-        // ones) and freshness holds.
+        // ones) and freshness holds. The atomic publish leaves no temp
+        // sibling behind.
         let out = Agent::finalize_xauth_merge_pass(&merged, true, false, &sources);
         assert_eq!(out.as_deref(), Some(merged.as_path()));
         let listing = fs::read_to_string(&manifest).unwrap();
@@ -3308,6 +3494,57 @@ mod tests {
             "missing sources are not recorded"
         );
         assert!(Agent::merged_xauthority_is_fresh(&merged, &sources));
+        let tmp_count = fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .count();
+        assert_eq!(tmp_count, 0, "atomic publish must not leave temp files");
+    }
+
+    /// Crash-consistency: the manifest is invalidated BEFORE a pass mutates
+    /// the merged file, so a crash mid-pass leaves "no manifest" — never a
+    /// stale manifest beside a newer merged file that would mask sources
+    /// the pass never reached.
+    #[test]
+    fn xauth_manifest_invalidated_before_merge_pass() {
+        let tmp = TempDir::new().unwrap();
+        let merged = tmp.path().join("session.Xauthority");
+        let source = tmp.path().join("Xauthority");
+        fs::write(&source, "cookie").unwrap();
+        let sources = vec![source.clone()];
+
+        // Start from a certified clean pass.
+        fs::write(&merged, "cookies").unwrap();
+        assert!(Agent::finalize_xauth_merge_pass(&merged, true, false, &sources).is_some());
+        assert!(Agent::merged_xauthority_is_fresh(&merged, &sources));
+
+        // A new pass invalidates first; a crash at any later point (e.g.
+        // after merging display A, before display B) now leaves freshness
+        // false, forcing the next invocation to re-run the pass.
+        assert!(
+            !Agent::invalidate_xauth_manifest_before_pass(&merged),
+            "a provable delete reports no failure"
+        );
+        assert!(!Agent::merged_xauthority_is_fresh(&merged, &sources));
+
+        // Invalidating an absent manifest is not a failure either.
+        assert!(!Agent::invalidate_xauth_manifest_before_pass(&merged));
+
+        // An unprovable delete (manifest's directory unwritable) must
+        // report failure so the pass never certifies completeness over it.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let locked_dir = tmp.path().join("locked");
+            fs::create_dir(&locked_dir).unwrap();
+            let locked_merged = locked_dir.join("session.Xauthority");
+            fs::write(Agent::xauth_manifest_path(&locked_merged), "x\n").unwrap();
+            fs::set_permissions(&locked_dir, fs::Permissions::from_mode(0o555)).unwrap();
+            let failed = Agent::invalidate_xauth_manifest_before_pass(&locked_merged);
+            fs::set_permissions(&locked_dir, fs::Permissions::from_mode(0o755)).unwrap();
+            assert!(failed, "an undeletable manifest must count as a failure");
+        }
     }
 
     #[test]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -29,6 +29,9 @@ static NONCE_RE: LazyLock<regex::Regex> =
     LazyLock::new(|| regex::Regex::new(r"\$NONCE\[(\d+)\]").unwrap());
 
 struct PtySession {
+    // Marker-emission dialect of the shell this session actually spawned
+    // (the Windows primary/fallback differ) — see `pty_marker_emit`.
+    flavor: crate::utils::PtyShellFlavor,
     // Shared with the reader thread so it can answer terminal queries (see
     // below) on the same PTY input stream that `exec_pty` writes commands to.
     writer: Arc<std::sync::Mutex<Box<dyn std::io::Write + Send>>>,
@@ -64,6 +67,45 @@ const DSR_CPR_REPLY: &[u8] = b"\x1b[1;1R";
 
 const HUMAN_POLL_MS: u64 = 500;
 const LOG_TAIL_BYTES: u64 = 10 * 1024; // 10KB
+
+// exec_pty sentinel marker pieces. The assembled per-command markers are
+// `{prefix}_{nonce}__`; the typed input only ever carries a *split* form
+// (see `pty_marker_emit`), so the assembled string is proof of execution.
+const PTY_MARKER_START_PREFIX: &str = "__PTY_START";
+const PTY_MARKER_END_PREFIX: &str = "__PTY_END";
+/// cmd.exe marker-assembly variable (see `PtyShellFlavor::Cmd`).
+const PTY_CMD_MARKER_VAR: &str = "__PTY_MVAR";
+
+/// Emit the shell line(s) that print `{prefix}{suffix}` without the typed
+/// input ever containing the assembled string. The tty driver echoes raw
+/// input bytes whenever they arrive before a line editor has turned echo
+/// off — guaranteed for bytes racing a fresh shell's startup — so a marker
+/// scanner that accepted echoed input would complete a command before it
+/// ran (observed live: `sleep 1; echo done` "completed" instantly with no
+/// `done`, and the following command captured the leftovers). Splitting the
+/// marker in the input confines the assembled form to executed output.
+fn pty_marker_emit(
+    flavor: crate::utils::PtyShellFlavor,
+    prefix: &str,
+    suffix: &str,
+    nl: &str,
+) -> String {
+    use crate::utils::PtyShellFlavor;
+    match flavor {
+        // Adjacent double-quoted strings concatenate in POSIX shells.
+        PtyShellFlavor::Posix => format!("echo \"{prefix}\"\"{suffix}\"{nl}"),
+        // PowerShell string concatenation, parenthesized so echo
+        // (Write-Output) receives one argument.
+        PtyShellFlavor::PowerShell => format!("echo (\"{prefix}\" + \"{suffix}\"){nl}"),
+        // cmd.exe cannot concatenate inline; assemble via a variable set on
+        // the *previous* line (%X% on the same line would expand at parse
+        // time, before the set runs).
+        PtyShellFlavor::Cmd => format!(
+            "set {var}={prefix}{nl}echo %{var}%{suffix}{nl}",
+            var = PTY_CMD_MARKER_VAR,
+        ),
+    }
+}
 
 #[derive(Clone)]
 pub struct Agent {
@@ -173,20 +215,102 @@ impl Agent {
         None
     }
 
-    /// True when the previously merged session Xauthority is at least as new
-    /// as every cookie source that currently exists — later runtime
-    /// invocations in the same session can then skip the merge subprocesses.
-    /// Missing sources constrain nothing (they contribute nothing to a
-    /// merge); a missing merged file is never fresh.
+    /// Sidecar manifest recording the cookie sources a *fully clean* merge
+    /// pass resolved — the freshness check's completeness proof. Written
+    /// only when a pass had no consult/merge failures, deleted otherwise,
+    /// so a partial merge (e.g. one display's `sudo -n xauth` denied) is
+    /// retried on the next runtime invocation instead of being masked by a
+    /// merged file that is mtime-fresh but incomplete.
+    #[cfg(any(test, not(target_os = "macos")))]
+    fn xauth_manifest_path(merged: &Path) -> PathBuf {
+        let mut name = merged.file_name().unwrap_or_default().to_os_string();
+        name.push(".merged");
+        merged.with_file_name(name)
+    }
+
+    /// True when the previously merged session Xauthority can be reused:
+    /// it exists, a completeness manifest from a clean pass covers every
+    /// cookie source that currently exists, and no such source is newer
+    /// than the merged file. Only a `NotFound` source stat is
+    /// unconstraining (a vanished source contributes nothing to a merge);
+    /// any other stat error means the source can't be proven stale-free,
+    /// so the pass re-runs. A missing merged file or manifest is never
+    /// fresh.
     #[cfg(any(test, not(target_os = "macos")))]
     fn merged_xauthority_is_fresh(merged: &Path, sources: &[PathBuf]) -> bool {
         let Ok(merged_mtime) = fs::metadata(merged).and_then(|m| m.modified()) else {
             return false;
         };
+        let Ok(manifest_listing) = fs::read_to_string(Self::xauth_manifest_path(merged)) else {
+            // No completeness proof (prior pass failed or predates the
+            // manifest) — re-run the pass.
+            return false;
+        };
+        let resolved: std::collections::HashSet<PathBuf> = manifest_listing
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(PathBuf::from)
+            .collect();
         sources.iter().all(|src| match fs::metadata(src) {
-            Ok(meta) => matches!(meta.modified(), Ok(mtime) if mtime <= merged_mtime),
-            Err(_) => true,
+            Ok(meta) => {
+                resolved.contains(src)
+                    && matches!(meta.modified(), Ok(mtime) if mtime <= merged_mtime)
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+            Err(_) => false,
         })
+    }
+
+    /// Conclude a merge pass. Nothing merged → drop the merged file and
+    /// manifest (a zero-cookie or stale file must not be served later, and
+    /// a nonzero-exit `nmerge` can still have created it). Merged but with
+    /// failures → keep the file for this invocation, drop the manifest so
+    /// the next invocation retries the missing sources. Fully clean pass →
+    /// record every source that currently exists as resolved.
+    #[cfg(any(test, not(target_os = "macos")))]
+    fn finalize_xauth_merge_pass(
+        merged: &Path,
+        any_merged: bool,
+        any_failure: bool,
+        sources: &[PathBuf],
+    ) -> Option<PathBuf> {
+        let manifest = Self::xauth_manifest_path(merged);
+        if !any_merged {
+            let _ = fs::remove_file(merged);
+            let _ = fs::remove_file(&manifest);
+            return None;
+        }
+        if any_failure {
+            let _ = fs::remove_file(&manifest);
+        } else {
+            let listing: String = sources
+                .iter()
+                .filter(|src| src.exists())
+                .map(|src| format!("{}\n", src.display()))
+                .collect();
+            let _ = fs::write(&manifest, listing);
+        }
+        Some(merged.to_path_buf())
+    }
+
+    /// Merge one cookie listing into the session file; Ok(true) on success,
+    /// Ok(false) when `xauth nmerge` exits nonzero.
+    #[cfg(not(target_os = "macos"))]
+    fn xauth_nmerge(merged_path: &Path, cookies: &[u8]) -> std::io::Result<bool> {
+        use std::io::Write;
+        let mut child = std::process::Command::new("xauth")
+            .arg("-f")
+            .arg(merged_path)
+            .arg("nmerge")
+            .arg("-")
+            .stdin(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .spawn()?;
+        if let Some(ref mut stdin) = child.stdin {
+            let _ = stdin.write_all(cookies);
+        }
+        Ok(child.wait()?.success())
     }
 
     /// Merge xauth cookies from all discovered displays into a session-scoped file.
@@ -218,11 +342,18 @@ impl Agent {
             return Some(merged_path);
         }
 
+        // A "failure" is a consult or merge that errored (spawn failure,
+        // nonzero exit — e.g. `sudo -n` denied): the pass may have merged
+        // some cookies but can't claim completeness, so no manifest is
+        // written and the next invocation retries. A source that consults
+        // cleanly but has no cookies for a display is a resolved outcome,
+        // not a failure — its mtime staleness triggers any needed re-merge.
+        let mut any_failure = false;
         for &disp in displays {
             let display_str = format!(":{}", disp);
             // Try user's own Xauthority
             if user_xauth.exists() {
-                if let Ok(status) = std::process::Command::new("xauth")
+                match std::process::Command::new("xauth")
                     .arg("-f")
                     .arg(&user_xauth)
                     .arg("nlist")
@@ -231,73 +362,43 @@ impl Agent {
                     .stderr(std::process::Stdio::null())
                     .output()
                 {
-                    if !status.stdout.is_empty() {
-                        if let Ok(merge_status) = std::process::Command::new("xauth")
-                            .arg("-f")
-                            .arg(&merged_path)
-                            .arg("nmerge")
-                            .arg("-")
-                            .stdin(std::process::Stdio::piped())
-                            .stderr(std::process::Stdio::null())
-                            .stdout(std::process::Stdio::null())
-                            .spawn()
-                            .and_then(|mut child| {
-                                use std::io::Write;
-                                if let Some(ref mut stdin) = child.stdin {
-                                    let _ = stdin.write_all(&status.stdout);
+                    Ok(listing) if listing.status.success() => {
+                        if !listing.stdout.is_empty() {
+                            match Self::xauth_nmerge(&merged_path, &listing.stdout) {
+                                Ok(true) => {
+                                    any_merged = true;
+                                    continue;
                                 }
-                                child.wait()
-                            })
-                        {
-                            if merge_status.success() {
-                                any_merged = true;
-                                continue;
+                                _ => any_failure = true,
                             }
                         }
                     }
+                    _ => any_failure = true,
                 }
             }
             // Try lightdm root cookie
             let lightdm_path = format!("/var/run/lightdm/root/:{}", disp);
             if Path::new(&lightdm_path).exists() {
-                if let Ok(status) = std::process::Command::new("sudo")
+                match std::process::Command::new("sudo")
                     .args(["-n", "xauth", "-f", &lightdm_path, "nlist", &display_str])
                     .stdout(std::process::Stdio::piped())
                     .stderr(std::process::Stdio::null())
                     .output()
                 {
-                    if !status.stdout.is_empty() {
-                        if let Ok(merge_status) = std::process::Command::new("xauth")
-                            .arg("-f")
-                            .arg(&merged_path)
-                            .arg("nmerge")
-                            .arg("-")
-                            .stdin(std::process::Stdio::piped())
-                            .stderr(std::process::Stdio::null())
-                            .stdout(std::process::Stdio::null())
-                            .spawn()
-                            .and_then(|mut child| {
-                                use std::io::Write;
-                                if let Some(ref mut stdin) = child.stdin {
-                                    let _ = stdin.write_all(&status.stdout);
-                                }
-                                child.wait()
-                            })
-                        {
-                            if merge_status.success() {
-                                any_merged = true;
+                    Ok(listing) if listing.status.success() => {
+                        if !listing.stdout.is_empty() {
+                            match Self::xauth_nmerge(&merged_path, &listing.stdout) {
+                                Ok(true) => any_merged = true,
+                                _ => any_failure = true,
                             }
                         }
                     }
+                    _ => any_failure = true,
                 }
             }
         }
 
-        if any_merged {
-            Some(merged_path)
-        } else {
-            None
-        }
+        Self::finalize_xauth_merge_pass(&merged_path, any_merged, any_failure, &sources)
     }
 
     /// Return the default display number when no explicit display is given and
@@ -720,24 +821,29 @@ impl Agent {
                 }
                 c
             };
-            let (shell, shell_args) = crate::utils::pty_shell_command();
+            let (shell, shell_args, shell_flavor) = crate::utils::pty_shell_command();
             let spawn_result = pair.slave.spawn_command(build_pty_cmd(shell, &shell_args));
-            let spawn_result = match spawn_result {
-                Ok(child) => Ok(child),
+            let (spawn_result, spawned_flavor) = match spawn_result {
+                Ok(child) => (Ok(child), shell_flavor),
                 Err(primary_err) => match crate::utils::pty_shell_fallback() {
-                    Some((fb_shell, fb_args)) => pair
-                        .slave
-                        .spawn_command(build_pty_cmd(fb_shell, &fb_args))
-                        .map_err(|fb_err| {
-                            AgentError::Process(format!(
-                                "Failed to spawn PTY shell '{}' ({}) and fallback '{}' ({})",
-                                shell, primary_err, fb_shell, fb_err
-                            ))
-                        }),
-                    None => Err(AgentError::Process(format!(
-                        "Failed to spawn shell: {}",
-                        primary_err
-                    ))),
+                    Some((fb_shell, fb_args, fb_flavor)) => (
+                        pair.slave
+                            .spawn_command(build_pty_cmd(fb_shell, &fb_args))
+                            .map_err(|fb_err| {
+                                AgentError::Process(format!(
+                                    "Failed to spawn PTY shell '{}' ({}) and fallback '{}' ({})",
+                                    shell, primary_err, fb_shell, fb_err
+                                ))
+                            }),
+                        fb_flavor,
+                    ),
+                    None => (
+                        Err(AgentError::Process(format!(
+                            "Failed to spawn shell: {}",
+                            primary_err
+                        ))),
+                        shell_flavor,
+                    ),
                 },
             };
             spawn_result?;
@@ -796,6 +902,7 @@ impl Agent {
             sessions.insert(
                 shell_id.clone(),
                 PtySession {
+                    flavor: spawned_flavor,
                     writer,
                     output,
                     read_offset: 0,
@@ -808,21 +915,28 @@ impl Agent {
             .get_mut(&shell_id)
             .ok_or_else(|| AgentError::Process("PTY session not found".to_string()))?;
 
-        // Generate unique start and end markers
-        let start_marker = format!("__PTY_START_{}__", cmd.nonce);
-        let marker = format!("__PTY_END_{}__", cmd.nonce);
+        // Generate unique start and end markers (the assembled forms the
+        // scanner and extractor look for in executed output).
+        let marker_suffix = format!("_{}__", cmd.nonce);
+        let start_marker = format!("{}{}", PTY_MARKER_START_PREFIX, marker_suffix);
+        let marker = format!("{}{}", PTY_MARKER_END_PREFIX, marker_suffix);
 
-        // Write: echo start-marker, then command, then echo end-marker. The
-        // writer is shared with the reader thread (which answers DSR queries),
-        // so take the lock just for the duration of this write. Each line is
-        // terminated with the platform PTY submit byte (`\r` on Windows so
-        // ConPTY treats it as Enter; `\n` on Unix, unchanged).
+        // Write: emit start-marker, then command, then emit end-marker. The
+        // marker `echo` lines are written in a *split* form the shell joins
+        // at execution time (see `pty_marker_emit`), so the assembled marker
+        // can only ever appear in executed output — never in the tty's echo
+        // of the typed input. The writer is shared with the reader thread
+        // (which answers DSR queries), so take the lock just for the
+        // duration of this write. Each line is terminated with the platform
+        // PTY submit byte (`\r` on Windows so ConPTY treats it as Enter;
+        // `\n` on Unix, unchanged).
         let nl = crate::utils::pty_line_ending();
         let pty_input = format!(
-            "echo '{start}'{nl}{cmd}{nl}echo '{end}'{nl}",
-            start = start_marker,
+            "{start_emit}{cmd}{nl}{end_emit}",
+            start_emit =
+                pty_marker_emit(session.flavor, PTY_MARKER_START_PREFIX, &marker_suffix, nl),
             cmd = command,
-            end = marker,
+            end_emit = pty_marker_emit(session.flavor, PTY_MARKER_END_PREFIX, &marker_suffix, nl),
             nl = nl,
         );
         {
@@ -922,11 +1036,17 @@ impl Agent {
             lines.pop();
         }
 
-        // Remove lines that mention the markers — both the echoed
-        // `echo '<marker>'` input lines and the marker output lines (a line
-        // containing the echo form necessarily contains the marker itself,
-        // so these two checks subsume the old per-line `format!` pairs).
-        lines.retain(|line| !line.contains(&start_marker) && !line.contains(&marker));
+        // Remove harness lines: assembled marker output lines and the echoed
+        // split-form `echo` input lines all contain a marker prefix, and the
+        // cmd.exe assembly lines contain the marker variable. (A user
+        // command that prints these sentinel prefixes loses those lines —
+        // the pre-existing acceptance for the assembled markers, applied to
+        // the split forms too.)
+        lines.retain(|line| {
+            !line.contains(PTY_MARKER_START_PREFIX)
+                && !line.contains(PTY_MARKER_END_PREFIX)
+                && !line.contains(PTY_CMD_MARKER_VAR)
+        });
 
         let final_output = lines.join("\n");
 
@@ -1708,9 +1828,12 @@ fn cap_pty_output(final_output: String, full_log_path: &Path) -> (String, bool) 
     if final_output.len() <= tail_cap {
         return (final_output, false);
     }
+    // Be honest about data loss: if the full transcript can't be preserved
+    // (disk full, unwritable log dir), the result must say so rather than
+    // silently truncating the only copy.
     let log_note = match fs::write(full_log_path, &final_output) {
         Ok(()) => format!("; full output: {}", full_log_path.display()),
-        Err(_) => String::new(),
+        Err(e) => format!("; full transcript unavailable: {}", e),
     };
     let tail = tail_utf8_by_bytes(&final_output, tail_cap);
     let capped = format!(
@@ -2436,29 +2559,53 @@ mod tests {
         assert!(agent.exec_pty(&cmd).await.is_err());
     }
 
-    /// Run one throwaway command to absorb the fresh-shell echo race: bytes
-    /// written before the shell's line editor turns tty echo off get echoed
-    /// by the tty driver — including the harness's own end-marker line — so
-    /// the FIRST command on a new PTY shell can capture its echoed input
-    /// instead of its output (pre-existing behavior; readline serializes
-    /// echo for every later command). Returns false when PTYs aren't
-    /// available in this environment.
-    #[cfg(unix)]
-    async fn warm_up_pty_shell(agent: &Agent) -> bool {
-        let warmup = AgentCommand {
+    /// The fresh-shell echo race, fixed: bytes written before the shell's
+    /// line editor turns tty echo off get echoed raw by the tty driver — if
+    /// the harness's typed input contained the assembled end marker, the
+    /// scanner would complete the first command before it ran (the live
+    /// repro: `sleep 1; echo first_done` returned instantly with no
+    /// `first_done`). With split-form marker input, completion requires the
+    /// executed output, so the slow first command's result must contain it.
+    #[tokio::test]
+    async fn exec_pty_first_command_on_fresh_shell_waits_for_real_output() {
+        let (agent, _log) = create_test_agent();
+        let cmd = AgentCommand {
             function: "execPty".to_string(),
-            nonce: 9_000,
-            command: Some("echo warm".to_string()),
+            nonce: 1,
+            command: Some("sleep 1; echo first_done".to_string()),
             ..Default::default()
         };
-        match agent.exec_pty(&warmup).await {
-            Ok(_) => true,
-            Err(AgentError::Process(msg)) if msg.contains("Permission denied") => false,
+        let result = match agent.exec_pty(&cmd).await {
+            Ok(r) => r,
+            Err(AgentError::Process(msg)) if msg.contains("Permission denied") => return,
             Err(e) => panic!("unexpected exec_pty error: {}", e),
-        }
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let output = parsed["output"].as_str().unwrap();
+        assert!(
+            output.contains("first_done"),
+            "first command's real output must be captured: {output}"
+        );
+
+        // And the next command must see only its own output — pre-fix, the
+        // leftovers of the mis-completed first command poisoned it.
+        let next = AgentCommand {
+            function: "execPty".to_string(),
+            nonce: 2,
+            command: Some("echo second_done".to_string()),
+            ..Default::default()
+        };
+        let result = agent.exec_pty(&next).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let output = parsed["output"].as_str().unwrap();
+        assert!(output.contains("second_done"), "output: {output}");
+        assert!(
+            !output.contains("first_done"),
+            "second call must not inherit the first call's output: {output}"
+        );
     }
 
-    /// Sequential commands on a warmed shell must each see only their own
+    /// Sequential commands on the same shell must each see only their own
     /// output — pins the read-offset bookkeeping the incremental marker
     /// scan relies on. Unix-only: ConPTY repaints can legitimately re-emit
     /// earlier lines into later byte ranges, which would false-positive the
@@ -2467,16 +2614,17 @@ mod tests {
     #[tokio::test]
     async fn exec_pty_sequential_commands_isolate_output() {
         let (agent, _log) = create_test_agent();
-        if !warm_up_pty_shell(&agent).await {
-            return;
-        }
         let first = AgentCommand {
             function: "execPty".to_string(),
             nonce: 1,
             command: Some("echo first_out".to_string()),
             ..Default::default()
         };
-        let result = agent.exec_pty(&first).await.unwrap();
+        let result = match agent.exec_pty(&first).await {
+            Ok(r) => r,
+            Err(AgentError::Process(msg)) if msg.contains("Permission denied") => return,
+            Err(e) => panic!("unexpected exec_pty error: {}", e),
+        };
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert!(parsed["output"].as_str().unwrap().contains("first_out"));
 
@@ -2496,6 +2644,43 @@ mod tests {
         );
     }
 
+    /// The split-form marker input never contains the assembled marker for
+    /// any shell flavor, while the shapes are the exact lines each shell
+    /// needs to print it.
+    #[test]
+    fn pty_marker_emit_keeps_assembled_marker_out_of_typed_input() {
+        use crate::utils::PtyShellFlavor;
+        let assembled = format!("{}_7__", PTY_MARKER_END_PREFIX);
+        for flavor in [
+            PtyShellFlavor::Posix,
+            PtyShellFlavor::PowerShell,
+            PtyShellFlavor::Cmd,
+        ] {
+            let emitted = pty_marker_emit(flavor, PTY_MARKER_END_PREFIX, "_7__", "\n");
+            assert!(
+                !emitted.contains(&assembled),
+                "{flavor:?} input must not contain the assembled marker: {emitted:?}"
+            );
+        }
+        assert_eq!(
+            pty_marker_emit(PtyShellFlavor::Posix, PTY_MARKER_END_PREFIX, "_7__", "\n"),
+            "echo \"__PTY_END\"\"_7__\"\n"
+        );
+        assert_eq!(
+            pty_marker_emit(
+                PtyShellFlavor::PowerShell,
+                PTY_MARKER_END_PREFIX,
+                "_7__",
+                "\r"
+            ),
+            "echo (\"__PTY_END\" + \"_7__\")\r"
+        );
+        assert_eq!(
+            pty_marker_emit(PtyShellFlavor::Cmd, PTY_MARKER_END_PREFIX, "_7__", "\r"),
+            "set __PTY_MVAR=__PTY_END\recho %__PTY_MVAR%_7__\r"
+        );
+    }
+
     /// Large PTY output is tail-capped for the model conversation, with the
     /// full transcript preserved on disk (mirrors exec_as_agent's 10 KB
     /// tails). Unix-only: the generator loop is bash syntax.
@@ -2503,9 +2688,6 @@ mod tests {
     #[tokio::test]
     async fn exec_pty_output_tail_capped() {
         let (agent, log_dir) = create_test_agent();
-        if !warm_up_pty_shell(&agent).await {
-            return;
-        }
         // ~13 KB across 400 lines — over the 10 KB cap, quick to produce.
         let cmd = AgentCommand {
             function: "execPty".to_string(),
@@ -2516,7 +2698,11 @@ mod tests {
             ),
             ..Default::default()
         };
-        let result = agent.exec_pty(&cmd).await.unwrap();
+        let result = match agent.exec_pty(&cmd).await {
+            Ok(r) => r,
+            Err(AgentError::Process(msg)) if msg.contains("Permission denied") => return,
+            Err(e) => panic!("unexpected exec_pty error: {}", e),
+        };
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert_eq!(parsed["success"], true);
         assert_eq!(parsed["truncated"], true);
@@ -2619,6 +2805,25 @@ mod tests {
         assert!(out.ends_with(&"z".repeat(LOG_TAIL_BYTES as usize)));
         assert!(out.len() < 11 * 1024, "capped len {}", out.len());
         assert_eq!(fs::read_to_string(&log_path).unwrap(), big);
+
+        // Preservation failure is surfaced, not silently swallowed: the
+        // capped result must say the untruncated copy is gone.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let ro_dir = tmp.path().join("ro");
+            fs::create_dir(&ro_dir).unwrap();
+            fs::set_permissions(&ro_dir, fs::Permissions::from_mode(0o555)).unwrap();
+            let (out, truncated) = cap_pty_output("w".repeat(20_000), &ro_dir.join("1_pty.log"));
+            fs::set_permissions(&ro_dir, fs::Permissions::from_mode(0o755)).unwrap();
+            assert!(truncated);
+            assert!(
+                out.contains("full transcript unavailable:"),
+                "write failure must be surfaced: {}",
+                &out[..out.len().min(200)]
+            );
+            assert!(out.ends_with(&"w".repeat(LOG_TAIL_BYTES as usize)));
+        }
     }
 
     // --- storeMemory / recallMemory tests ---
@@ -2981,7 +3186,7 @@ mod tests {
     }
 
     #[test]
-    fn merged_xauthority_freshness() {
+    fn merged_xauthority_freshness_requires_manifest_and_mtimes() {
         let tmp = TempDir::new().unwrap();
         let merged = tmp.path().join("session.Xauthority");
         let source = tmp.path().join("Xauthority");
@@ -2992,6 +3197,13 @@ mod tests {
             f.set_modified(UNIX_EPOCH + Duration::from_secs(secs))
                 .unwrap();
         };
+        let write_manifest = |resolved: &[&Path]| {
+            let listing: String = resolved
+                .iter()
+                .map(|p| format!("{}\n", p.display()))
+                .collect();
+            fs::write(Agent::xauth_manifest_path(&merged), listing).unwrap();
+        };
 
         // No merged file yet: never fresh.
         fs::write(&source, "cookie").unwrap();
@@ -3000,25 +3212,102 @@ mod tests {
             &[source.clone()]
         ));
 
-        // Merged newer than every existing source: fresh (missing sources
-        // constrain nothing).
+        // Merged and mtime-fresh but NO manifest (a prior pass had a
+        // failure — the partial-merge case): not fresh, the pass retries.
         fs::write(&merged, "merged").unwrap();
         set_mtime(&source, 1_000);
         set_mtime(&merged, 2_000);
-        assert!(Agent::merged_xauthority_is_fresh(
-            &merged,
-            &[source.clone(), missing.clone()]
-        ));
-
-        // A source updated after the merge invalidates it.
-        set_mtime(&source, 3_000);
         assert!(!Agent::merged_xauthority_is_fresh(
             &merged,
             &[source.clone()]
         ));
 
+        // Clean-pass manifest covering the source: fresh (missing sources
+        // constrain nothing).
+        write_manifest(&[&source]);
+        assert!(Agent::merged_xauthority_is_fresh(
+            &merged,
+            &[source.clone(), missing.clone()]
+        ));
+
+        // A source the manifest never resolved (appeared after the pass)
+        // forces a re-merge even though mtimes look fresh.
+        let late = tmp.path().join("late-cookie");
+        fs::write(&late, "cookie").unwrap();
+        set_mtime(&late, 1_500);
+        assert!(!Agent::merged_xauthority_is_fresh(
+            &merged,
+            &[source.clone(), late.clone()]
+        ));
+
+        // A source updated after the merge invalidates it even when listed.
+        set_mtime(&source, 3_000);
+        assert!(!Agent::merged_xauthority_is_fresh(
+            &merged,
+            &[source.clone()]
+        ));
+        set_mtime(&source, 1_000);
+
         // Missing sources alone constrain nothing.
         assert!(Agent::merged_xauthority_is_fresh(&merged, &[missing]));
+
+        // A stat error other than NotFound is constraining: the source
+        // exists but can't be proven stale-free, so the pass re-runs.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let locked_dir = tmp.path().join("locked");
+            fs::create_dir(&locked_dir).unwrap();
+            let hidden = locked_dir.join("Xauthority");
+            fs::write(&hidden, "cookie").unwrap();
+            set_mtime(&hidden, 1_000);
+            write_manifest(&[&source, &hidden]);
+            fs::set_permissions(&locked_dir, fs::Permissions::from_mode(0o000)).unwrap();
+            let fresh = Agent::merged_xauthority_is_fresh(&merged, &[hidden.clone()]);
+            fs::set_permissions(&locked_dir, fs::Permissions::from_mode(0o700)).unwrap();
+            assert!(!fresh, "unreadable source stat must force a re-merge");
+        }
+    }
+
+    #[test]
+    fn finalize_xauth_merge_pass_cleanup_and_manifest() {
+        let tmp = TempDir::new().unwrap();
+        let merged = tmp.path().join("session.Xauthority");
+        let manifest = Agent::xauth_manifest_path(&merged);
+        let source = tmp.path().join("Xauthority");
+        fs::write(&source, "cookie").unwrap();
+        let sources = vec![source.clone(), tmp.path().join("gone")];
+
+        // Nothing merged: a file left behind by a failed nmerge (or a stale
+        // earlier session) is deleted along with any manifest.
+        fs::write(&merged, "half-written").unwrap();
+        fs::write(&manifest, "stale\n").unwrap();
+        assert!(Agent::finalize_xauth_merge_pass(&merged, false, true, &sources).is_none());
+        assert!(!merged.exists(), "failed pass must not leave a merged file");
+        assert!(!manifest.exists());
+
+        // Partial merge (some source failed): the merged file is served for
+        // this invocation, but no manifest survives — the next invocation's
+        // freshness check fails and the pass retries the missing sources.
+        fs::write(&merged, "cookies").unwrap();
+        fs::write(&manifest, "stale\n").unwrap();
+        let out = Agent::finalize_xauth_merge_pass(&merged, true, true, &sources);
+        assert_eq!(out.as_deref(), Some(merged.as_path()));
+        assert!(merged.exists());
+        assert!(!manifest.exists(), "partial pass must drop the manifest");
+        assert!(!Agent::merged_xauthority_is_fresh(&merged, &sources));
+
+        // Clean pass: the manifest records existing sources (not missing
+        // ones) and freshness holds.
+        let out = Agent::finalize_xauth_merge_pass(&merged, true, false, &sources);
+        assert_eq!(out.as_deref(), Some(merged.as_path()));
+        let listing = fs::read_to_string(&manifest).unwrap();
+        assert!(listing.contains(&source.display().to_string()));
+        assert!(
+            !listing.contains("gone"),
+            "missing sources are not recorded"
+        );
+        assert!(Agent::merged_xauthority_is_fresh(&merged, &sources));
     }
 
     #[test]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -849,7 +849,7 @@ impl Agent {
         let call_start = session.read_offset;
         let marker_bytes = marker.as_bytes();
         let mut scanned_to = call_start;
-        let mut marker_found = false;
+        let mut marker_found;
 
         loop {
             {

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -173,7 +173,29 @@ impl Agent {
         None
     }
 
+    /// True when the previously merged session Xauthority is at least as new
+    /// as every cookie source that currently exists — later runtime
+    /// invocations in the same session can then skip the merge subprocesses.
+    /// Missing sources constrain nothing (they contribute nothing to a
+    /// merge); a missing merged file is never fresh.
+    #[cfg(any(test, not(target_os = "macos")))]
+    fn merged_xauthority_is_fresh(merged: &Path, sources: &[PathBuf]) -> bool {
+        let Ok(merged_mtime) = fs::metadata(merged).and_then(|m| m.modified()) else {
+            return false;
+        };
+        sources.iter().all(|src| match fs::metadata(src) {
+            Ok(meta) => matches!(meta.modified(), Ok(mtime) if mtime <= merged_mtime),
+            Err(_) => true,
+        })
+    }
+
     /// Merge xauth cookies from all discovered displays into a session-scoped file.
+    ///
+    /// The runtime is spawned fresh for every tool batch, so this runs on
+    /// every invocation; the freshness check keeps the per-display
+    /// `xauth nlist`/`nmerge` subprocess round-trips (plus a `sudo -n xauth`
+    /// attempt for lightdm cookies) to the session's first batch — later
+    /// batches reuse the merged file unless a source cookie file changed.
     #[cfg(not(target_os = "macos"))]
     fn setup_merged_xauthority(displays: &[i32], log_dir: &Path) -> Option<PathBuf> {
         if displays.is_empty() {
@@ -185,6 +207,16 @@ impl Agent {
         // Candidate source paths for xauth cookies
         let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
         let user_xauth = PathBuf::from(&home).join(".Xauthority");
+
+        let mut sources = vec![user_xauth.clone()];
+        sources.extend(
+            displays
+                .iter()
+                .map(|disp| PathBuf::from(format!("/var/run/lightdm/root/:{}", disp))),
+        );
+        if Self::merged_xauthority_is_fresh(&merged_path, &sources) {
+            return Some(merged_path);
+        }
 
         for &disp in displays {
             let display_str = format!(":{}", disp);
@@ -813,25 +845,23 @@ impl Agent {
         // a shell that goes quiet (no output, no EOF) can't wedge us.
         let timeout_duration = Duration::from_secs(30);
         let start = std::time::Instant::now();
-        let mut output = String::new();
-        // Where this call's output ends within the shared buffer; advanced past
-        // the consumed bytes once we're done so the next call starts fresh.
-        let mut consumed_to = session.read_offset;
+        // Where this call's bytes begin within the shared buffer.
+        let call_start = session.read_offset;
+        let marker_bytes = marker.as_bytes();
+        let mut scanned_to = call_start;
+        let mut marker_found = false;
 
         loop {
-            // Snapshot the bytes produced for this call so far.
             {
                 let guard = session
                     .output
                     .lock()
                     .map_err(|_| AgentError::Process("PTY reader buffer poisoned".to_string()))?;
-                if guard.len() > session.read_offset {
-                    output = String::from_utf8_lossy(&guard[session.read_offset..]).into_owned();
-                    consumed_to = guard.len();
-                }
+                marker_found =
+                    incremental_marker_scan(&guard, marker_bytes, call_start, &mut scanned_to);
             }
 
-            if output.contains(&marker) {
+            if marker_found {
                 break;
             }
             if start.elapsed() >= timeout_duration {
@@ -839,8 +869,16 @@ impl Agent {
             }
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
-        // Mark this call's bytes consumed regardless of outcome.
-        session.read_offset = consumed_to;
+        // Mark this call's bytes consumed regardless of outcome, and decode
+        // them once, now that the scan is over.
+        session.read_offset = scanned_to;
+        let output = {
+            let guard = session
+                .output
+                .lock()
+                .map_err(|_| AgentError::Process("PTY reader buffer poisoned".to_string()))?;
+            String::from_utf8_lossy(&guard[call_start..scanned_to]).into_owned()
+        };
 
         // Clean output: strip ANSI escapes and carriage returns
         let cleaned = ANSI_RE.replace_all(&output, "").to_string();
@@ -884,21 +922,24 @@ impl Agent {
             lines.pop();
         }
 
-        // Remove lines that are echo commands for the markers
-        lines.retain(|line| {
-            let trimmed = line.trim();
-            !trimmed.contains(&format!("echo '{}'", start_marker))
-                && !trimmed.contains(&format!("echo '{}'", marker))
-                && !trimmed.contains(&start_marker)
-                && !trimmed.contains(&marker)
-        });
+        // Remove lines that mention the markers — both the echoed
+        // `echo '<marker>'` input lines and the marker output lines (a line
+        // containing the echo form necessarily contains the marker itself,
+        // so these two checks subsume the old per-line `format!` pairs).
+        lines.retain(|line| !line.contains(&start_marker) && !line.contains(&marker));
 
         let final_output = lines.join("\n");
+
+        let (final_output, truncated) = cap_pty_output(
+            final_output,
+            &self.log_dir.join(format!("{}_pty.log", cmd.nonce)),
+        );
 
         Ok(serde_json::json!({
             "success": true,
             "shell_id": shell_id,
-            "output": final_output
+            "output": final_output,
+            "truncated": truncated
         })
         .to_string())
     }
@@ -1485,100 +1526,75 @@ impl Agent {
         .to_string()
     }
 
-    pub async fn process_input(&self, input: AgentInput) -> Result<Vec<String>, AgentError> {
-        let mut results = Vec::new();
+    fn result_or_error(nonce: u64, result: Result<String, AgentError>) -> String {
+        match result {
+            Ok(result) => Self::result_json(nonce, &result),
+            Err(e) => Self::result_json(nonce, &format!("Error: {}", e)),
+        }
+    }
 
-        // Process commands sequentially — each blocks until completion
-        for cmd in input.commands {
-            match cmd.function.as_str() {
+    /// Process commands sequentially, handing each command's JSONL result
+    /// line to `emit` as soon as that command completes. Streaming — rather
+    /// than buffering the whole batch and printing at exit — means the
+    /// caller's hard batch timeout can no longer discard the results of
+    /// commands that already finished (it parses partial stdout), and the
+    /// runtime doesn't peak-hold every result in memory. `emit` returns
+    /// false to stop early (broken pipe: the consumer is gone).
+    pub async fn process_input<F>(&self, input: AgentInput, mut emit: F) -> Result<(), AgentError>
+    where
+        F: FnMut(&str) -> bool,
+    {
+        for mut cmd in input.commands {
+            let line = match cmd.function.as_str() {
                 "execAsAgent" => {
                     let result = self.exec_as_agent(&cmd).await?;
-                    results.push(Self::result_json(cmd.nonce, &result));
+                    Self::result_json(cmd.nonce, &result)
                 }
                 "captureScreen" => {
                     let result = self.capture_screen(&cmd).await?;
-                    results.push(Self::result_json(cmd.nonce, &result));
+                    Self::result_json(cmd.nonce, &result)
                 }
-                "inspectPath" => match self.inspect_path(&cmd) {
-                    Ok(result) => {
-                        results.push(Self::result_json(cmd.nonce, &result));
-                    }
-                    Err(e) => {
-                        results.push(Self::result_json(cmd.nonce, &format!("Error: {}", e)));
-                    }
-                },
-                "editFile" => match self.edit_file(&cmd) {
-                    Ok(result) => {
-                        results.push(Self::result_json(cmd.nonce, &result));
-                    }
-                    Err(e) => {
-                        results.push(Self::result_json(cmd.nonce, &format!("Error: {}", e)));
-                    }
-                },
+                "inspectPath" => Self::result_or_error(cmd.nonce, self.inspect_path(&cmd)),
+                "editFile" => Self::result_or_error(cmd.nonce, self.edit_file(&cmd)),
                 "writeFile" => {
-                    let mut edit_cmd = cmd.clone();
-                    edit_cmd.function = "editFile".to_string();
-                    if edit_cmd.operation.is_none() {
-                        edit_cmd.operation = Some("write".to_string());
+                    // writeFile is editFile with the operation defaulted to
+                    // "write"; rewrite the owned command in place (cloning it
+                    // deep-copied the whole content payload just to rename).
+                    cmd.function = "editFile".to_string();
+                    if cmd.operation.is_none() {
+                        cmd.operation = Some("write".to_string());
                     }
-                    match self.edit_file(&edit_cmd) {
-                        Ok(result) => {
-                            results.push(Self::result_json(cmd.nonce, &result));
-                        }
-                        Err(e) => {
-                            results.push(Self::result_json(cmd.nonce, &format!("Error: {}", e)));
-                        }
-                    }
+                    Self::result_or_error(cmd.nonce, self.edit_file(&cmd))
                 }
-                "browse" => match self.browse(&cmd).await {
-                    Ok(result) => {
-                        results.push(Self::result_json(cmd.nonce, &result));
-                    }
-                    Err(e) => {
-                        results.push(Self::result_json(cmd.nonce, &format!("Error: {}", e)));
-                    }
-                },
-                "askHuman" => match self.ask_human(&cmd).await {
-                    Ok(result) => {
-                        results.push(Self::result_json(cmd.nonce, &result));
-                    }
-                    Err(e) => {
-                        results.push(Self::result_json(cmd.nonce, &format!("Error: {}", e)));
-                    }
-                },
-                "execPty" => match self.exec_pty(&cmd).await {
-                    Ok(result) => {
-                        results.push(Self::result_json(cmd.nonce, &result));
-                    }
-                    Err(e) => {
-                        results.push(Self::result_json(cmd.nonce, &format!("Error: {}", e)));
-                    }
-                },
-                "storeMemory" => match self.store_memory(&cmd) {
-                    Ok(result) => {
-                        results.push(Self::result_json(cmd.nonce, &result));
-                    }
-                    Err(e) => {
-                        results.push(Self::result_json(cmd.nonce, &format!("Error: {}", e)));
-                    }
-                },
-                "recallMemory" => match self.recall_memory(&cmd) {
-                    Ok(result) => {
-                        results.push(Self::result_json(cmd.nonce, &result));
-                    }
-                    Err(e) => {
-                        results.push(Self::result_json(cmd.nonce, &format!("Error: {}", e)));
-                    }
-                },
+                "browse" => Self::result_or_error(cmd.nonce, self.browse(&cmd).await),
+                "askHuman" => Self::result_or_error(cmd.nonce, self.ask_human(&cmd).await),
+                "execPty" => Self::result_or_error(cmd.nonce, self.exec_pty(&cmd).await),
+                "storeMemory" => Self::result_or_error(cmd.nonce, self.store_memory(&cmd)),
+                "recallMemory" => Self::result_or_error(cmd.nonce, self.recall_memory(&cmd)),
                 _ => {
                     return Err(AgentError::Process(format!(
                         "Unknown function: {}",
                         cmd.function
                     )))
                 }
+            };
+            if !emit(&line) {
+                return Ok(());
             }
         }
 
+        Ok(())
+    }
+
+    /// Test helper: run the batch and collect the emitted result lines.
+    #[cfg(test)]
+    async fn process_input_collect(&self, input: AgentInput) -> Result<Vec<String>, AgentError> {
+        let mut results = Vec::new();
+        self.process_input(input, |line| {
+            results.push(line.to_string());
+            true
+        })
+        .await?;
         Ok(results)
     }
 
@@ -1636,6 +1652,75 @@ pub(crate) fn truncate_utf8_by_bytes(s: &str, max: usize) -> &str {
         end -= 1;
     }
     &s[..end]
+}
+
+/// Tail counterpart of `truncate_utf8_by_bytes`: the last `max` bytes of
+/// `s`, nudged forward to the next char boundary.
+fn tail_utf8_by_bytes(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        return s;
+    }
+    let mut start = s.len() - max;
+    while start < s.len() && !s.is_char_boundary(start) {
+        start += 1;
+    }
+    &s[start..]
+}
+
+/// One incremental tick of the PTY end-marker scan: examine only the bytes
+/// beyond `scanned_to` — plus a `marker.len() - 1` overlap (clamped to
+/// `call_start`) so a marker straddling two reader chunks is still found —
+/// advance `scanned_to` to `buf.len()`, and report whether the marker was
+/// seen. Total work across a command is O(bytes) — re-decoding and
+/// re-scanning the whole accumulated buffer on every 20 ms tick was
+/// quadratic on chatty commands. The marker is pure ASCII, so searching the
+/// raw bytes is equivalent to searching the lossy-decoded string.
+fn incremental_marker_scan(
+    buf: &[u8],
+    marker: &[u8],
+    call_start: usize,
+    scanned_to: &mut usize,
+) -> bool {
+    if marker.is_empty() {
+        // Degenerate marker: trivially present (windows(0) would panic).
+        *scanned_to = buf.len();
+        return true;
+    }
+    if buf.len() <= *scanned_to {
+        return false;
+    }
+    let scan_from = scanned_to
+        .saturating_sub(marker.len() - 1)
+        .max(call_start)
+        .min(buf.len());
+    let found = buf[scan_from..].windows(marker.len()).any(|w| w == marker);
+    *scanned_to = buf.len();
+    found
+}
+
+/// Tail-cap a PTY command's output before it returns into the model
+/// conversation, mirroring exec_as_agent's 10 KB stdout/stderr tails — an
+/// uncapped PTY transcript (a cargo build, a full test suite) otherwise
+/// rides in the context for the rest of the session. Over-cap output is
+/// preserved in full at `full_log_path` and the truncation marker names it.
+fn cap_pty_output(final_output: String, full_log_path: &Path) -> (String, bool) {
+    let tail_cap = LOG_TAIL_BYTES as usize;
+    if final_output.len() <= tail_cap {
+        return (final_output, false);
+    }
+    let log_note = match fs::write(full_log_path, &final_output) {
+        Ok(()) => format!("; full output: {}", full_log_path.display()),
+        Err(_) => String::new(),
+    };
+    let tail = tail_utf8_by_bytes(&final_output, tail_cap);
+    let capped = format!(
+        "[execPty output truncated: showing last {} of {} bytes{}]\n{}",
+        tail.len(),
+        final_output.len(),
+        log_note,
+        tail
+    );
+    (capped, true)
 }
 
 #[cfg(test)]
@@ -1867,7 +1952,7 @@ mod tests {
                 ..Default::default()
             }],
         };
-        let results = agent.process_input(input).await.unwrap();
+        let results = agent.process_input_collect(input).await.unwrap();
         assert_eq!(results.len(), 1);
         let parsed: serde_json::Value = serde_json::from_str(&results[0]).unwrap();
         assert_eq!(parsed["type"], "result");
@@ -1888,7 +1973,7 @@ mod tests {
                 ..Default::default()
             }],
         };
-        let result = agent.process_input(input).await;
+        let result = agent.process_input_collect(input).await;
         assert!(result.is_err());
     }
 
@@ -1905,7 +1990,7 @@ mod tests {
                 ..Default::default()
             }],
         };
-        let results = agent.process_input(input).await.unwrap();
+        let results = agent.process_input_collect(input).await.unwrap();
         assert_eq!(results.len(), 1);
         let wrapper: serde_json::Value = serde_json::from_str(&results[0]).unwrap();
         assert_eq!(wrapper["type"], "result");
@@ -1914,6 +1999,39 @@ mod tests {
             serde_json::from_str(wrapper["data"].as_str().unwrap()).unwrap();
         assert_eq!(parsed["exists"], true);
         assert_eq!(parsed["type"], "directory");
+    }
+
+    /// `emit` returning false (broken pipe) stops the batch without error.
+    #[tokio::test]
+    async fn process_input_stops_when_emit_declines() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_str().unwrap().to_string();
+        let (agent, _log) = create_test_agent();
+        let input = AgentInput {
+            commands: vec![
+                AgentCommand {
+                    function: "inspectPath".to_string(),
+                    nonce: 1,
+                    path: Some(dir.clone()),
+                    ..Default::default()
+                },
+                AgentCommand {
+                    function: "inspectPath".to_string(),
+                    nonce: 2,
+                    path: Some(dir),
+                    ..Default::default()
+                },
+            ],
+        };
+        let mut seen = Vec::new();
+        agent
+            .process_input(input, |line| {
+                seen.push(line.to_string());
+                false
+            })
+            .await
+            .unwrap();
+        assert_eq!(seen.len(), 1, "batch must stop after emit declines");
     }
 
     #[tokio::test]
@@ -2192,7 +2310,7 @@ mod tests {
                 ..Default::default()
             }],
         };
-        let results = agent.process_input(input).await.unwrap();
+        let results = agent.process_input_collect(input).await.unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(fs::read_to_string(&fp).unwrap(), "integrated");
     }
@@ -2316,6 +2434,191 @@ mod tests {
             ..Default::default()
         };
         assert!(agent.exec_pty(&cmd).await.is_err());
+    }
+
+    /// Run one throwaway command to absorb the fresh-shell echo race: bytes
+    /// written before the shell's line editor turns tty echo off get echoed
+    /// by the tty driver — including the harness's own end-marker line — so
+    /// the FIRST command on a new PTY shell can capture its echoed input
+    /// instead of its output (pre-existing behavior; readline serializes
+    /// echo for every later command). Returns false when PTYs aren't
+    /// available in this environment.
+    #[cfg(unix)]
+    async fn warm_up_pty_shell(agent: &Agent) -> bool {
+        let warmup = AgentCommand {
+            function: "execPty".to_string(),
+            nonce: 9_000,
+            command: Some("echo warm".to_string()),
+            ..Default::default()
+        };
+        match agent.exec_pty(&warmup).await {
+            Ok(_) => true,
+            Err(AgentError::Process(msg)) if msg.contains("Permission denied") => false,
+            Err(e) => panic!("unexpected exec_pty error: {}", e),
+        }
+    }
+
+    /// Sequential commands on a warmed shell must each see only their own
+    /// output — pins the read-offset bookkeeping the incremental marker
+    /// scan relies on. Unix-only: ConPTY repaints can legitimately re-emit
+    /// earlier lines into later byte ranges, which would false-positive the
+    /// isolation assertion.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn exec_pty_sequential_commands_isolate_output() {
+        let (agent, _log) = create_test_agent();
+        if !warm_up_pty_shell(&agent).await {
+            return;
+        }
+        let first = AgentCommand {
+            function: "execPty".to_string(),
+            nonce: 1,
+            command: Some("echo first_out".to_string()),
+            ..Default::default()
+        };
+        let result = agent.exec_pty(&first).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert!(parsed["output"].as_str().unwrap().contains("first_out"));
+
+        let second = AgentCommand {
+            function: "execPty".to_string(),
+            nonce: 2,
+            command: Some("echo second_out".to_string()),
+            ..Default::default()
+        };
+        let result = agent.exec_pty(&second).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let output = parsed["output"].as_str().unwrap();
+        assert!(output.contains("second_out"), "output: {output}");
+        assert!(
+            !output.contains("first_out"),
+            "second call must not re-consume the first call's bytes: {output}"
+        );
+    }
+
+    /// Large PTY output is tail-capped for the model conversation, with the
+    /// full transcript preserved on disk (mirrors exec_as_agent's 10 KB
+    /// tails). Unix-only: the generator loop is bash syntax.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn exec_pty_output_tail_capped() {
+        let (agent, log_dir) = create_test_agent();
+        if !warm_up_pty_shell(&agent).await {
+            return;
+        }
+        // ~13 KB across 400 lines — over the 10 KB cap, quick to produce.
+        let cmd = AgentCommand {
+            function: "execPty".to_string(),
+            nonce: 77,
+            command: Some(
+                "for i in {1..400}; do printf 'yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\\n'; done"
+                    .to_string(),
+            ),
+            ..Default::default()
+        };
+        let result = agent.exec_pty(&cmd).await.unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["success"], true);
+        assert_eq!(parsed["truncated"], true);
+        let output = parsed["output"].as_str().unwrap();
+        assert!(
+            output.starts_with("[execPty output truncated: showing last "),
+            "capped output must lead with the truncation marker: {}",
+            &output[..output.len().min(120)]
+        );
+        // Marker line + 10 KB tail, nowhere near the full transcript.
+        assert!(output.len() < 11 * 1024, "output len {}", output.len());
+        // The full transcript is preserved on disk.
+        let full = fs::read_to_string(log_dir.path().join("77_pty.log")).unwrap();
+        assert!(
+            full.len() > LOG_TAIL_BYTES as usize,
+            "full log should exceed the cap, got {}",
+            full.len()
+        );
+    }
+
+    #[test]
+    fn tail_utf8_by_bytes_stops_at_char_boundary() {
+        let text = format!("{}{}", "\u{00e9}", "a".repeat(199));
+        // Cutting 200 bytes from the end would split the 2-byte é; the tail
+        // must nudge forward past it.
+        assert_eq!(tail_utf8_by_bytes(&text, 200), "a".repeat(199));
+        assert_eq!(tail_utf8_by_bytes("short", 200), "short");
+        assert_eq!(tail_utf8_by_bytes("abcdef", 3), "def");
+    }
+
+    /// The incremental scan must find markers wholly inside new bytes,
+    /// markers straddling two appends (via the overlap re-scan), and must
+    /// never look before `call_start`.
+    #[test]
+    fn incremental_marker_scan_finds_straddled_markers() {
+        let marker = b"__END__";
+        let mut buf: Vec<u8> = Vec::new();
+        let mut scanned_to = 0usize;
+
+        // Nothing new: not found.
+        assert!(!incremental_marker_scan(&buf, marker, 0, &mut scanned_to));
+
+        // Marker wholly inside the first chunk.
+        buf.extend_from_slice(b"hello __END__ world");
+        assert!(incremental_marker_scan(&buf, marker, 0, &mut scanned_to));
+        assert_eq!(scanned_to, buf.len());
+
+        // Marker straddling two chunks: first half in one append…
+        let mut buf: Vec<u8> = Vec::new();
+        let mut scanned_to = 0usize;
+        buf.extend_from_slice(b"aaaa__EN");
+        assert!(!incremental_marker_scan(&buf, marker, 0, &mut scanned_to));
+        // …second half in the next; the overlap re-scan must catch it.
+        buf.extend_from_slice(b"D__bbbb");
+        assert!(incremental_marker_scan(&buf, marker, 0, &mut scanned_to));
+
+        // A marker entirely before call_start belongs to a previous command
+        // and must not match.
+        let buf = b"__END__ tail".to_vec();
+        let call_start = 7; // just past the marker
+        let mut scanned_to = call_start;
+        assert!(!incremental_marker_scan(
+            &buf,
+            marker,
+            call_start,
+            &mut scanned_to
+        ));
+
+        // A tick with no new bytes reports nothing and keeps the cursor.
+        let mut scanned_to_again = scanned_to;
+        assert!(!incremental_marker_scan(
+            &buf,
+            marker,
+            call_start,
+            &mut scanned_to_again
+        ));
+        assert_eq!(scanned_to_again, scanned_to);
+    }
+
+    /// The tail cap leaves small output untouched and rewrites large output
+    /// as marker + 10 KB tail while preserving the full transcript on disk.
+    #[test]
+    fn cap_pty_output_caps_and_preserves_full_log() {
+        let tmp = TempDir::new().unwrap();
+        let log_path = tmp.path().join("1_pty.log");
+
+        // Under the cap: untouched, no log file.
+        let small = "small output".to_string();
+        let (out, truncated) = cap_pty_output(small.clone(), &log_path);
+        assert_eq!(out, small);
+        assert!(!truncated);
+        assert!(!log_path.exists());
+
+        // Over the cap: marker + tail, full transcript on disk.
+        let big = "z".repeat(20_000);
+        let (out, truncated) = cap_pty_output(big.clone(), &log_path);
+        assert!(truncated);
+        assert!(out.starts_with("[execPty output truncated: showing last "));
+        assert!(out.contains(&log_path.display().to_string()));
+        assert!(out.ends_with(&"z".repeat(LOG_TAIL_BYTES as usize)));
+        assert!(out.len() < 11 * 1024, "capped len {}", out.len());
+        assert_eq!(fs::read_to_string(&log_path).unwrap(), big);
     }
 
     // --- storeMemory / recallMemory tests ---
@@ -2583,7 +2886,7 @@ mod tests {
                 ..Default::default()
             }],
         };
-        let results = agent.process_input(input).await.unwrap();
+        let results = agent.process_input_collect(input).await.unwrap();
         assert_eq!(results.len(), 1);
     }
 
@@ -2601,7 +2904,7 @@ mod tests {
                 ..Default::default()
             }],
         };
-        let results = agent.process_input(input).await.unwrap();
+        let results = agent.process_input_collect(input).await.unwrap();
         assert_eq!(results.len(), 1);
     }
 
@@ -2675,6 +2978,47 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let result = Agent::setup_merged_xauthority(&[], tmp.path());
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn merged_xauthority_freshness() {
+        let tmp = TempDir::new().unwrap();
+        let merged = tmp.path().join("session.Xauthority");
+        let source = tmp.path().join("Xauthority");
+        let missing = tmp.path().join("nope");
+
+        let set_mtime = |path: &Path, secs: u64| {
+            let f = OpenOptions::new().write(true).open(path).unwrap();
+            f.set_modified(UNIX_EPOCH + Duration::from_secs(secs))
+                .unwrap();
+        };
+
+        // No merged file yet: never fresh.
+        fs::write(&source, "cookie").unwrap();
+        assert!(!Agent::merged_xauthority_is_fresh(
+            &merged,
+            &[source.clone()]
+        ));
+
+        // Merged newer than every existing source: fresh (missing sources
+        // constrain nothing).
+        fs::write(&merged, "merged").unwrap();
+        set_mtime(&source, 1_000);
+        set_mtime(&merged, 2_000);
+        assert!(Agent::merged_xauthority_is_fresh(
+            &merged,
+            &[source.clone(), missing.clone()]
+        ));
+
+        // A source updated after the merge invalidates it.
+        set_mtime(&source, 3_000);
+        assert!(!Agent::merged_xauthority_is_fresh(
+            &merged,
+            &[source.clone()]
+        ));
+
+        // Missing sources alone constrain nothing.
+        assert!(Agent::merged_xauthority_is_fresh(&merged, &[missing]));
     }
 
     #[test]

--- a/src/bin/caller/agent_runner.rs
+++ b/src/bin/caller/agent_runner.rs
@@ -114,19 +114,26 @@ fn has_ask_human(json_input: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// True when `line` is a complete runtime protocol line: JSON with a
+/// `type` of `status`/`result` and a numeric `nonce` — the shape
+/// `map_results_to_tool_responses` folds into per-command results.
+fn is_runtime_protocol_line(line: &str) -> bool {
+    let Ok(parsed) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
+        return false;
+    };
+    matches!(
+        parsed.get("type").and_then(|value| value.as_str()),
+        Some("status" | "result")
+    ) && parsed
+        .get("nonce")
+        .and_then(|value| value.as_u64())
+        .is_some()
+}
+
 fn has_parseable_runtime_output(stdout: &[u8]) -> bool {
-    String::from_utf8_lossy(stdout).lines().any(|line| {
-        let Ok(parsed) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
-            return false;
-        };
-        matches!(
-            parsed.get("type").and_then(|value| value.as_str()),
-            Some("status" | "result")
-        ) && parsed
-            .get("nonce")
-            .and_then(|value| value.as_u64())
-            .is_some()
-    })
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .any(is_runtime_protocol_line)
 }
 
 fn output_with_exit_status(
@@ -389,21 +396,28 @@ async fn run_agent_inner(
     }
 }
 
-/// Prepare a timed-out batch's stdout for salvage: drop the partial
-/// trailing line first — the kill can land mid-write, and the result mapper
-/// folds any unparseable line into ordinary output text, so an untruncated
-/// buffer would broadcast a malformed JSON fragment into every tool
-/// response. Complete result lines always end in a newline (the runtime
-/// writes line-buffered JSONL), so cutting at the last newline never drops
-/// a finished command's result. Returns None when nothing parseable
-/// remains (the batch keeps its timeout error).
+/// Prepare a timed-out batch's stdout for salvage. The kill can land
+/// mid-write, and the result mapper folds any unparseable line into
+/// ordinary output text, so a torn trailing fragment must not survive —
+/// but the trailing bytes are not always torn: the runtime's stdout is a
+/// line-buffered writer whose ~1 KiB buffer flushes a large result JSON to
+/// the pipe *before* the separate newline write, so a kill in that window
+/// leaves a COMPLETE result for a command that already ran (possibly with
+/// side effects) — dropping it would make the model redo the command.
+/// Keep the post-newline tail iff it parses as a complete protocol line;
+/// drop it otherwise. Returns None when nothing parseable remains (the
+/// batch keeps its timeout error).
 fn salvage_partial_stdout(mut stdout_buf: Vec<u8>) -> Option<Vec<u8>> {
     let cut = stdout_buf
         .iter()
         .rposition(|&b| b == b'\n')
         .map(|i| i + 1)
         .unwrap_or(0);
-    stdout_buf.truncate(cut);
+    let tail_is_complete_line = std::str::from_utf8(&stdout_buf[cut..])
+        .is_ok_and(|tail| !tail.is_empty() && is_runtime_protocol_line(tail));
+    if !tail_is_complete_line {
+        stdout_buf.truncate(cut);
+    }
     if has_parseable_runtime_output(&stdout_buf) {
         Some(stdout_buf)
     } else {
@@ -567,36 +581,53 @@ mod tests {
         );
     }
 
-    /// Timeout salvage must drop a partial trailing line (a mid-write kill
-    /// otherwise leaks a malformed JSON fragment into the tool responses as
-    /// ordinary text) while keeping every complete result line, and must
-    /// decline when nothing parseable remains.
+    /// Timeout salvage must drop a torn trailing fragment (a mid-write kill
+    /// otherwise leaks malformed JSON into the tool responses as ordinary
+    /// text) while keeping BOTH every newline-terminated result and a
+    /// complete trailing result whose newline never made it out — the
+    /// line-buffered writer flushes a large payload to the pipe before the
+    /// separate newline write, and that command already ran (possibly with
+    /// side effects), so dropping it would make the model redo it.
     #[test]
-    fn salvage_truncates_partial_trailing_line() {
-        let complete = br#"{"type":"result","nonce":1,"data":"first ok"}"#;
-        let mut buf = complete.to_vec();
+    fn salvage_keeps_complete_results_drops_torn_fragments() {
+        let first = br#"{"type":"result","nonce":1,"data":"first ok"}"#;
+        let second_complete = br#"{"type":"result","nonce":2,"data":"second ok"}"#;
+
+        // Torn second result: fragment dropped, first kept.
+        let mut buf = first.to_vec();
         buf.push(b'\n');
         buf.extend_from_slice(br#"{"type":"result","nonce":2,"da"#); // killed mid-write
-
-        let salvaged = salvage_partial_stdout(buf).expect("first result must be salvaged");
-        let text = String::from_utf8(salvaged).unwrap();
-        assert_eq!(text.as_bytes().last(), Some(&b'\n'));
+        let text = String::from_utf8(salvage_partial_stdout(buf).unwrap()).unwrap();
         assert!(text.contains("first ok"));
+        assert!(text.ends_with('\n'));
         assert!(
             !text.contains(r#""nonce":2"#),
-            "no fragment of the killed second result may remain: {text}"
+            "no fragment of the torn second result may remain: {text}"
         );
 
-        // Only a partial line: nothing to salvage.
-        assert!(salvage_partial_stdout(br#"{"type":"result","non"#.to_vec()).is_none());
+        // Complete second result missing only its newline: kept.
+        let mut buf = first.to_vec();
+        buf.push(b'\n');
+        buf.extend_from_slice(second_complete);
+        let text = String::from_utf8(salvage_partial_stdout(buf).unwrap()).unwrap();
+        assert!(text.contains("first ok"));
+        assert!(
+            text.contains("second ok"),
+            "a complete newline-less trailing result must survive: {text}"
+        );
 
-        // A complete-looking line without its trailing newline is
-        // indistinguishable from a truncated longer line — conservatively
-        // dropped.
-        assert!(salvage_partial_stdout(complete.to_vec()).is_none());
+        // A lone complete result with no newline at all: also kept.
+        let text = String::from_utf8(salvage_partial_stdout(first.to_vec()).unwrap()).unwrap();
+        assert!(text.contains("first ok"));
+
+        // Only a torn line: nothing to salvage.
+        assert!(salvage_partial_stdout(br#"{"type":"result","non"#.to_vec()).is_none());
 
         // Unparseable noise lines alone don't qualify for salvage.
         assert!(salvage_partial_stdout(b"panic: something\n".to_vec()).is_none());
+
+        // Noise plus a torn tail: still nothing parseable.
+        assert!(salvage_partial_stdout(b"noise\n{\"type\":\"res".to_vec()).is_none());
     }
 
     /// The spawn boundary is the only place the user-display grant becomes

--- a/src/bin/caller/agent_runner.rs
+++ b/src/bin/caller/agent_runner.rs
@@ -27,6 +27,65 @@ fn apply_user_display_grant_env(cmd: &mut Command, user_display_granted: bool) {
     }
 }
 
+/// Provider-credential env names scrubbed from the runtime child beyond the
+/// authoritative `provider::PROVIDER_KEY_ENV_VARS` list: adjacent
+/// conventional spellings of the same secrets that a user `.env` (loaded
+/// into the controller's process env at startup) may carry, plus the bare
+/// vendor names `exec_as_agent` has always scrubbed from its shells.
+const EXTRA_PROVIDER_CREDENTIAL_ENV_VARS: &[&str] = &[
+    "GOOGLE_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "OPENAI",
+    "ANTHROPIC",
+    "GEMINI",
+];
+
+/// True when `name` names a provider/model-API credential that must not
+/// reach the runtime. `INTENDANT_*` names are the controller→runtime
+/// control channel (the mock-provider e2e rig rides `PROVIDER` +
+/// `INTENDANT_MOCK_*` into children) and are never treated as credentials.
+fn is_provider_credential_env(name: &str) -> bool {
+    if name.starts_with("INTENDANT_") {
+        return false;
+    }
+    crate::provider::PROVIDER_KEY_ENV_VARS.contains(&name)
+        || EXTRA_PROVIDER_CREDENTIAL_ENV_VARS.contains(&name)
+        || name.ends_with("_API_KEY")
+        || name.ends_with("_API_TOKEN")
+}
+
+/// Scrub provider credentials from the runtime child's environment.
+///
+/// The controller loads `.env` provider keys into its own process env at
+/// startup, and a spawned child inherits that env wholesale — without this
+/// scrub the sandboxed runtime (and every exec/PTY shell it spawns) holds
+/// the model API keys, violating the founding runtime/controller boundary
+/// ("the runtime never holds API keys"): a model-invoked
+/// `echo $ANTHROPIC_API_KEY` in a PTY shell would exfiltrate the key into
+/// the conversation. This spawn boundary is the single enforcement point;
+/// `exec_as_agent`'s per-shell env_removes remain as defense in depth.
+/// `inherited_names` is the parent-process env view (injected by the caller
+/// so tests stay hermetic).
+fn scrub_provider_credential_env<'a>(
+    cmd: &mut Command,
+    inherited_names: impl IntoIterator<Item = &'a str>,
+) {
+    // The canonical names are removed unconditionally — even when absent
+    // from the inherited env view — so an explicit `.env()` set can never
+    // reintroduce them.
+    for name in crate::provider::PROVIDER_KEY_ENV_VARS
+        .iter()
+        .chain(EXTRA_PROVIDER_CREDENTIAL_ENV_VARS.iter())
+    {
+        cmd.env_remove(name);
+    }
+    for name in inherited_names {
+        if is_provider_credential_env(name) {
+            cmd.env_remove(name);
+        }
+    }
+}
+
 pub struct AgentOutput {
     pub stdout: String,
     pub stderr: String,
@@ -235,6 +294,13 @@ async fn run_agent_inner(
     #[cfg(target_os = "linux")]
     crate::linux_display_env::apply_to_tokio_command(&mut cmd);
 
+    // The runtime never holds API keys (see the scrub's doc): strip provider
+    // credentials from the child env as the last step before spawn.
+    let inherited_env_names: Vec<String> = std::env::vars_os()
+        .filter_map(|(name, _)| name.into_string().ok())
+        .collect();
+    scrub_provider_credential_env(&mut cmd, inherited_env_names.iter().map(String::as_str));
+
     let mut child = cmd.spawn().map_err(|e| {
         CallerError::Agent(format!("Failed to spawn agent at {:?}: {}", agent_path, e))
     })?;
@@ -336,6 +402,93 @@ mod tests {
             br#"{"type":"result","data":"missing nonce"}"#
         ));
         assert!(!has_parseable_runtime_output(b"panic before json"));
+    }
+
+    #[test]
+    fn provider_credential_env_predicate_covers_keys_not_control_vars() {
+        for name in [
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "MISTRAL_API_KEY",
+            "SOME_SERVICE_API_TOKEN",
+            "ANTHROPIC_AUTH_TOKEN",
+        ] {
+            assert!(is_provider_credential_env(name), "{name} must be scrubbed");
+        }
+        for name in [
+            "PROVIDER",
+            "PATH",
+            "HOME",
+            "DISPLAY",
+            "INTENDANT_MOCK_SCRIPT",
+            "INTENDANT_MOCK_DISPLAY",
+            "INTENDANT_LOG_DIR",
+            "INTENDANT_FAKE_API_KEY", // the INTENDANT_* namespace is never scrubbed
+            "OPENAI_BASE_URL",
+        ] {
+            assert!(!is_provider_credential_env(name), "{name} must survive");
+        }
+    }
+
+    /// The founding invariant: the runtime child's env never carries
+    /// provider API keys, while the mock-provider e2e control vars and the
+    /// runtime's own INTENDANT_* channel survive. Hermetic — the
+    /// inherited-env view is injected; no real keys, no process env.
+    #[test]
+    fn runtime_child_env_scrubs_provider_credentials() {
+        use std::ffi::{OsStr, OsString};
+
+        let mut cmd = Command::new("true");
+        cmd.env("INTENDANT_LOG_DIR", "/tmp/logs");
+        scrub_provider_credential_env(
+            &mut cmd,
+            [
+                "ANTHROPIC_API_KEY",
+                "OPENAI_API_KEY",
+                "GEMINI_API_KEY",
+                "MISTRAL_API_KEY",
+                "CUSTOM_API_TOKEN",
+                "PATH",
+                "HOME",
+                "PROVIDER",
+                "INTENDANT_MOCK_SCRIPT",
+            ],
+        );
+        let envs: std::collections::HashMap<OsString, Option<OsString>> = cmd
+            .as_std()
+            .get_envs()
+            .map(|(k, v)| (k.to_os_string(), v.map(|v| v.to_os_string())))
+            .collect();
+
+        // Removed vars appear as explicit (name, None) child-env entries.
+        for name in [
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "MISTRAL_API_KEY",
+            "CUSTOM_API_TOKEN",
+        ] {
+            assert_eq!(
+                envs.get(OsStr::new(name)),
+                Some(&None),
+                "{name} must be removed from the child env"
+            );
+        }
+        // Preserved vars have no explicit entry at all: they inherit.
+        for name in ["PATH", "HOME", "PROVIDER", "INTENDANT_MOCK_SCRIPT"] {
+            assert!(
+                !envs.contains_key(OsStr::new(name)),
+                "{name} must inherit untouched (no explicit entry)"
+            );
+        }
+        assert_eq!(
+            envs.get(OsStr::new("INTENDANT_LOG_DIR")),
+            Some(&Some(OsString::from("/tmp/logs"))),
+            "runtime control vars set at the spawn boundary must survive the scrub"
+        );
     }
 
     /// The spawn boundary is the only place the user-display grant becomes

--- a/src/bin/caller/agent_runner.rs
+++ b/src/bin/caller/agent_runner.rs
@@ -44,12 +44,19 @@ const EXTRA_PROVIDER_CREDENTIAL_ENV_VARS: &[&str] = &[
 /// reach the runtime. `INTENDANT_*` names are the controller→runtime
 /// control channel (the mock-provider e2e rig rides `PROVIDER` +
 /// `INTENDANT_MOCK_*` into children) and are never treated as credentials.
+///
+/// Classification is done on the ASCII-uppercased name: Windows environment
+/// names are case-insensitive (`%mistral_api_key%` and `%MISTRAL_API_KEY%`
+/// resolve identically inside the runtime's shells), and dotenvy preserves
+/// whatever casing the `.env` file used — a lowercase spelling must not
+/// slip past the scrub.
 fn is_provider_credential_env(name: &str) -> bool {
+    let name = name.to_ascii_uppercase();
     if name.starts_with("INTENDANT_") {
         return false;
     }
-    crate::provider::PROVIDER_KEY_ENV_VARS.contains(&name)
-        || EXTRA_PROVIDER_CREDENTIAL_ENV_VARS.contains(&name)
+    crate::provider::PROVIDER_KEY_ENV_VARS.contains(&name.as_str())
+        || EXTRA_PROVIDER_CREDENTIAL_ENV_VARS.contains(&name.as_str())
         || name.ends_with("_API_KEY")
         || name.ends_with("_API_TOKEN")
 }
@@ -358,12 +365,11 @@ async fn run_agent_inner(
         Err(_) => {
             let _ = child.kill().await;
             // Everything that finished before the deadline is intact JSONL
-            // in the buffer (a possibly truncated trailing line is skipped
-            // by the caller's line-tolerant parser). Salvage it instead of
-            // discarding completed work the model would just redo; commands
-            // with no result line surface as missing downstream.
-            if has_parseable_runtime_output(&stdout_buf) {
-                let stdout = String::from_utf8_lossy(&stdout_buf).to_string();
+            // in the buffer. Salvage it instead of discarding completed
+            // work the model would just redo; commands with no result line
+            // surface as missing downstream.
+            if let Some(salvaged) = salvage_partial_stdout(stdout_buf) {
+                let stdout = String::from_utf8_lossy(&salvaged).to_string();
                 let mut stderr = String::from_utf8_lossy(&stderr_buf).to_string();
                 if !stderr.ends_with('\n') && !stderr.is_empty() {
                     stderr.push('\n');
@@ -380,6 +386,28 @@ async fn run_agent_inner(
                 )))
             }
         }
+    }
+}
+
+/// Prepare a timed-out batch's stdout for salvage: drop the partial
+/// trailing line first — the kill can land mid-write, and the result mapper
+/// folds any unparseable line into ordinary output text, so an untruncated
+/// buffer would broadcast a malformed JSON fragment into every tool
+/// response. Complete result lines always end in a newline (the runtime
+/// writes line-buffered JSONL), so cutting at the last newline never drops
+/// a finished command's result. Returns None when nothing parseable
+/// remains (the batch keeps its timeout error).
+fn salvage_partial_stdout(mut stdout_buf: Vec<u8>) -> Option<Vec<u8>> {
+    let cut = stdout_buf
+        .iter()
+        .rposition(|&b| b == b'\n')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    stdout_buf.truncate(cut);
+    if has_parseable_runtime_output(&stdout_buf) {
+        Some(stdout_buf)
+    } else {
+        None
     }
 }
 
@@ -437,6 +465,15 @@ mod tests {
             "MISTRAL_API_KEY",
             "SOME_SERVICE_API_TOKEN",
             "ANTHROPIC_AUTH_TOKEN",
+            // Windows env names are case-insensitive and dotenvy preserves
+            // the .env file's casing — %mistral_api_key% resolves as
+            // %MISTRAL_API_KEY% inside the runtime, so casing must not
+            // dodge the scrub.
+            "mistral_api_key",
+            "Anthropic_Api_Key",
+            "openai_api_key",
+            "custom_api_token",
+            "anthropic_auth_token",
         ] {
             assert!(is_provider_credential_env(name), "{name} must be scrubbed");
         }
@@ -449,6 +486,7 @@ mod tests {
             "INTENDANT_MOCK_DISPLAY",
             "INTENDANT_LOG_DIR",
             "INTENDANT_FAKE_API_KEY", // the INTENDANT_* namespace is never scrubbed
+            "intendant_fake_api_key", // …in any casing
             "OPENAI_BASE_URL",
         ] {
             assert!(!is_provider_credential_env(name), "{name} must survive");
@@ -473,19 +511,32 @@ mod tests {
                 "GEMINI_API_KEY",
                 "MISTRAL_API_KEY",
                 "CUSTOM_API_TOKEN",
+                "mistral_api_key",
+                "Custom_Api_Token",
                 "PATH",
                 "HOME",
                 "PROVIDER",
                 "INTENDANT_MOCK_SCRIPT",
             ],
         );
-        let envs: std::collections::HashMap<OsString, Option<OsString>> = cmd
+        let envs: Vec<(OsString, Option<OsString>)> = cmd
             .as_std()
             .get_envs()
             .map(|(k, v)| (k.to_os_string(), v.map(|v| v.to_os_string())))
             .collect();
+        // Windows' Command env map is case-insensitive (case-variant keys
+        // collapse into one entry), so match names case-insensitively.
+        let removal_entry_for = |name: &str| {
+            envs.iter()
+                .any(|(k, v)| v.is_none() && k.to_string_lossy().eq_ignore_ascii_case(name))
+        };
+        let any_entry_for = |name: &str| {
+            envs.iter()
+                .any(|(k, _)| k.to_string_lossy().eq_ignore_ascii_case(name))
+        };
 
-        // Removed vars appear as explicit (name, None) child-env entries.
+        // Removed vars appear as explicit (name, None) child-env entries;
+        // mixed-case inherited names are removed too.
         for name in [
             "ANTHROPIC_API_KEY",
             "OPENAI_API_KEY",
@@ -493,25 +544,59 @@ mod tests {
             "GOOGLE_API_KEY",
             "MISTRAL_API_KEY",
             "CUSTOM_API_TOKEN",
+            "mistral_api_key",
+            "Custom_Api_Token",
         ] {
-            assert_eq!(
-                envs.get(OsStr::new(name)),
-                Some(&None),
+            assert!(
+                removal_entry_for(name),
                 "{name} must be removed from the child env"
             );
         }
         // Preserved vars have no explicit entry at all: they inherit.
         for name in ["PATH", "HOME", "PROVIDER", "INTENDANT_MOCK_SCRIPT"] {
             assert!(
-                !envs.contains_key(OsStr::new(name)),
+                !any_entry_for(name),
                 "{name} must inherit untouched (no explicit entry)"
             );
         }
-        assert_eq!(
-            envs.get(OsStr::new("INTENDANT_LOG_DIR")),
-            Some(&Some(OsString::from("/tmp/logs"))),
+        assert!(
+            envs.iter()
+                .any(|(k, v)| k == OsStr::new("INTENDANT_LOG_DIR")
+                    && v.as_deref() == Some(OsStr::new("/tmp/logs"))),
             "runtime control vars set at the spawn boundary must survive the scrub"
         );
+    }
+
+    /// Timeout salvage must drop a partial trailing line (a mid-write kill
+    /// otherwise leaks a malformed JSON fragment into the tool responses as
+    /// ordinary text) while keeping every complete result line, and must
+    /// decline when nothing parseable remains.
+    #[test]
+    fn salvage_truncates_partial_trailing_line() {
+        let complete = br#"{"type":"result","nonce":1,"data":"first ok"}"#;
+        let mut buf = complete.to_vec();
+        buf.push(b'\n');
+        buf.extend_from_slice(br#"{"type":"result","nonce":2,"da"#); // killed mid-write
+
+        let salvaged = salvage_partial_stdout(buf).expect("first result must be salvaged");
+        let text = String::from_utf8(salvaged).unwrap();
+        assert_eq!(text.as_bytes().last(), Some(&b'\n'));
+        assert!(text.contains("first ok"));
+        assert!(
+            !text.contains(r#""nonce":2"#),
+            "no fragment of the killed second result may remain: {text}"
+        );
+
+        // Only a partial line: nothing to salvage.
+        assert!(salvage_partial_stdout(br#"{"type":"result","non"#.to_vec()).is_none());
+
+        // A complete-looking line without its trailing newline is
+        // indistinguishable from a truncated longer line — conservatively
+        // dropped.
+        assert!(salvage_partial_stdout(complete.to_vec()).is_none());
+
+        // Unparseable noise lines alone don't qualify for salvage.
+        assert!(salvage_partial_stdout(b"panic: something\n".to_vec()).is_none());
     }
 
     /// The spawn boundary is the only place the user-display grant becomes

--- a/src/bin/caller/agent_runner.rs
+++ b/src/bin/caller/agent_runner.rs
@@ -316,46 +316,69 @@ async fn run_agent_inner(
     let hard_timeout_secs: u64 = if has_human { u64::MAX / 2 } else { 120 };
     let hard_timeout = Duration::from_secs(hard_timeout_secs);
 
-    // Read stdout and stderr (bounded), then wait for exit, all under a single hard timeout
+    // Read stdout and stderr (bounded), then wait for exit, all under a
+    // single hard timeout. The buffers live outside the timed future so a
+    // hard-timeout kill can still salvage the results of commands that
+    // completed before the deadline — the runtime streams each command's
+    // JSONL result line as that command finishes.
+    let mut stdout_buf: Vec<u8> = Vec::with_capacity(8192);
+    let mut stderr_buf: Vec<u8> = Vec::with_capacity(8192);
+
     let result = timeout(hard_timeout, async {
         let mut stdout = child.stdout.take();
         let mut stderr = child.stderr.take();
 
         let read_stdout = async {
-            let mut buf = Vec::with_capacity(8192);
             if let Some(ref mut out) = stdout {
                 out.take(MAX_OUTPUT_BYTES as u64)
-                    .read_to_end(&mut buf)
+                    .read_to_end(&mut stdout_buf)
                     .await?;
             }
-            Ok::<_, std::io::Error>(buf)
+            Ok::<_, std::io::Error>(())
         };
         let read_stderr = async {
-            let mut buf = Vec::with_capacity(8192);
             if let Some(ref mut err) = stderr {
                 err.take(MAX_OUTPUT_BYTES as u64)
-                    .read_to_end(&mut buf)
+                    .read_to_end(&mut stderr_buf)
                     .await?;
             }
-            Ok::<_, std::io::Error>(buf)
+            Ok::<_, std::io::Error>(())
         };
 
-        let (stdout_buf, stderr_buf, status) = tokio::join!(read_stdout, read_stderr, child.wait());
-        Ok::<_, CallerError>((stdout_buf?, stderr_buf?, status?))
+        let (stdout_res, stderr_res, status) = tokio::join!(read_stdout, read_stderr, child.wait());
+        stdout_res?;
+        stderr_res?;
+        Ok::<_, CallerError>(status?)
     })
     .await;
 
     match result {
-        Ok(Ok((stdout_buf, stderr_buf, status))) => {
-            output_with_exit_status(stdout_buf, stderr_buf, status)
-        }
+        Ok(Ok(status)) => output_with_exit_status(stdout_buf, stderr_buf, status),
         Ok(Err(err)) => Err(err),
         Err(_) => {
             let _ = child.kill().await;
-            Err(CallerError::Agent(format!(
-                "Agent timed out after {}s",
-                hard_timeout_secs
-            )))
+            // Everything that finished before the deadline is intact JSONL
+            // in the buffer (a possibly truncated trailing line is skipped
+            // by the caller's line-tolerant parser). Salvage it instead of
+            // discarding completed work the model would just redo; commands
+            // with no result line surface as missing downstream.
+            if has_parseable_runtime_output(&stdout_buf) {
+                let stdout = String::from_utf8_lossy(&stdout_buf).to_string();
+                let mut stderr = String::from_utf8_lossy(&stderr_buf).to_string();
+                if !stderr.ends_with('\n') && !stderr.is_empty() {
+                    stderr.push('\n');
+                }
+                stderr.push_str(&format!(
+                    "sandboxed runtime killed after the {hard_timeout_secs}s batch hard-timeout; \
+                     results above are from the commands that completed before the deadline"
+                ));
+                Ok(AgentOutput { stdout, stderr })
+            } else {
+                Err(CallerError::Agent(format!(
+                    "Agent timed out after {}s",
+                    hard_timeout_secs
+                )))
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,12 @@ fn write_line(stdout: &mut io::StdoutLock, line: &str) -> bool {
     writeln!(stdout, "{}", line).is_ok() && stdout.flush().is_ok()
 }
 
-#[tokio::main]
+// Single-threaded runtime: the executor runs its batch strictly
+// sequentially (PTY draining runs on dedicated std threads), so the default
+// multi-threaded flavor's per-core worker threads bought nothing while
+// costing startup time and thread stacks on every tool batch — this binary
+// is spawned fresh per batch.
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), AgentError> {
     // Version/provenance probe — MUST run before anything touches stdin
     // (the runtime otherwise blocks reading its one-shot JSON input) and
@@ -151,17 +156,17 @@ async fn main() -> Result<(), AgentError> {
     // Create agent instance
     let agent = Agent::new()?;
 
-    // Process commands sequentially and get results
-    let results = agent.process_input(input).await?;
-
-    // Print results; exit gracefully on broken pipe
+    // Process commands sequentially, streaming each JSONL result line as its
+    // command completes — the caller consumes partial output when the
+    // runtime dies early, so a hard-timeout kill no longer discards the
+    // results of commands that already finished. write_line flushes per
+    // line and returns false on broken pipe (the caller is gone), which
+    // stops the batch gracefully.
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
-    for result in results {
-        if !write_line(&mut stdout, &result) {
-            return Ok(());
-        }
-    }
+    agent
+        .process_input(input, |line| write_line(&mut stdout, line))
+        .await?;
 
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -43,6 +43,32 @@ pub fn agent_shell_command(command: &str) -> (&'static str, Vec<String>) {
     }
 }
 
+/// Marker-emission dialect of a PTY shell: how `exec_pty` writes its
+/// sentinel `echo` lines so that the *typed input* never contains the
+/// assembled marker string while the executed output does. The tty driver
+/// echoes raw input bytes whenever they arrive before (or without) a line
+/// editor that has turned echo off — so a marker scanner that accepts the
+/// echoed input would treat a command as complete before it ran.
+// On non-Windows builds only `Posix` is ever constructed outside tests —
+// the marker-emission code still matches every variant on all platforms,
+// and the Windows build constructs the other two, so keep the lint live
+// there.
+#[cfg_attr(not(windows), allow(dead_code))]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum PtyShellFlavor {
+    /// POSIX-family (`bash`): adjacent double-quoted strings concatenate,
+    /// so `echo "A""B"` types split but prints joined.
+    Posix,
+    /// PowerShell: parenthesized `+` string concatenation,
+    /// `echo ("A" + "B")`.
+    PowerShell,
+    /// `cmd.exe`: no inline concatenation — assemble via a variable set on
+    /// a *preceding* line (`set X=A` then `echo %X%B`; a same-line
+    /// `set … && echo %X%…` would expand `%X%` at parse time, before the
+    /// set runs).
+    Cmd,
+}
+
 /// Select the interactive shell program and argument vector for a PTY-backed
 /// session (the `execPty` path in the runtime).
 ///
@@ -61,13 +87,15 @@ pub fn agent_shell_command(command: &str) -> (&'static str, Vec<String>) {
 ///   analogue of `--norc --noprofile`: it skips profile scripts so the prompt
 ///   and env are deterministic.
 ///
-/// Returns `(program, args)`.
-pub fn pty_shell_command() -> (&'static str, Vec<String>) {
+/// Returns `(program, args, flavor)`; the flavor drives marker emission
+/// (see [`PtyShellFlavor`]).
+pub fn pty_shell_command() -> (&'static str, Vec<String>, PtyShellFlavor) {
     #[cfg(windows)]
     {
         (
             "powershell.exe",
             vec!["-NoLogo".to_string(), "-NoProfile".to_string()],
+            PtyShellFlavor::PowerShell,
         )
     }
     #[cfg(not(windows))]
@@ -75,6 +103,7 @@ pub fn pty_shell_command() -> (&'static str, Vec<String>) {
         (
             "bash",
             vec!["--norc".to_string(), "--noprofile".to_string()],
+            PtyShellFlavor::Posix,
         )
     }
 }
@@ -85,10 +114,10 @@ pub fn pty_shell_command() -> (&'static str, Vec<String>) {
 /// Unix primary (`bash`) has no separate fallback — its absence is a genuine
 /// configuration error there, not a routine condition.
 #[allow(dead_code)]
-pub fn pty_shell_fallback() -> Option<(&'static str, Vec<String>)> {
+pub fn pty_shell_fallback() -> Option<(&'static str, Vec<String>, PtyShellFlavor)> {
     #[cfg(windows)]
     {
-        Some(("cmd.exe", Vec::new()))
+        Some(("cmd.exe", Vec::new(), PtyShellFlavor::Cmd))
     }
     #[cfg(not(windows))]
     {
@@ -155,17 +184,19 @@ mod tests {
 
     #[test]
     fn pty_shell_command_suppresses_startup_files() {
-        let (program, args) = pty_shell_command();
+        let (program, args, flavor) = pty_shell_command();
         #[cfg(windows)]
         {
             assert_eq!(program, "powershell.exe");
             assert!(args.iter().any(|a| a == "-NoProfile"));
+            assert_eq!(flavor, PtyShellFlavor::PowerShell);
         }
         #[cfg(not(windows))]
         {
             assert_eq!(program, "bash");
             assert!(args.iter().any(|a| a == "--norc"));
             assert!(args.iter().any(|a| a == "--noprofile"));
+            assert_eq!(flavor, PtyShellFlavor::Posix);
         }
     }
 
@@ -173,8 +204,9 @@ mod tests {
     fn pty_shell_fallback_is_windows_only() {
         #[cfg(windows)]
         {
-            let (program, _) = pty_shell_fallback().expect("windows has a fallback");
+            let (program, _, flavor) = pty_shell_fallback().expect("windows has a fallback");
             assert_eq!(program, "cmd.exe");
+            assert_eq!(flavor, PtyShellFlavor::Cmd);
         }
         #[cfg(not(windows))]
         {


### PR DESCRIPTION
Implements the S/M-effort findings from the runtime-core efficiency audit (scope 01), plus its security item, plus the fixes from the first review round (Fable + Codex). Each finding was re-verified against current main before implementation.

## Security: runtime child env scrub

The controller loads `.env` provider keys into its own process env (dotenvy), and `agent_runner` spawned `intendant-runtime` with an unscrubbed inherited environment — so the sandboxed runtime (and every exec/PTY shell under it) held the model API keys, violating the founding invariant that the runtime never holds API keys. `exec_as_agent` scrubbed six names from its own shells, but `exec_pty` shells saw everything: a model-invoked `echo $ANTHROPIC_API_KEY` would exfiltrate the key into the conversation.

Fix at the single runtime-spawn boundary (`src/bin/caller/agent_runner.rs`): remove the authoritative `provider::PROVIDER_KEY_ENV_VARS` set, adjacent conventional spellings (`GOOGLE_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, the bare vendor names exec_as_agent already scrubbed), and any inherited `*_API_KEY` / `*_API_TOKEN` name — matched on the ASCII-uppercased name, since Windows env names are case-insensitive and dotenvy preserves the `.env` file's casing (`mistral_api_key=` must not dodge the scrub that `%MISTRAL_API_KEY%` resolution defeats). `INTENDANT_*` (any casing) and `PROVIDER` are never touched, so the mock-provider e2e rig keeps working. External agents (Codex / Claude Code) are spawned by the controller directly, never through `run_agent` (verified: only `agent_loop.rs` calls it), so their auth is unaffected. Hermetic unit tests pin the predicate (mixed-case included) and the child-env effect; no real keys involved.

Deliberate posture note: generic `*_API_KEY` / `*_API_TOKEN` names from a user `.env` (e.g. `MISTRAL_API_KEY`) are now also invisible to runtime shells; previously only the six exec_as_agent names were hidden, and only from exec shells.

## Correctness: the PTY echo race, fixed

Both reviews flagged (and Codex demonstrated live) that the exec_pty marker scanner accepted the end marker inside the tty's **echo of the injected input**: bytes written into a fresh PTY race the shell's echo-off, the tty driver echoes them raw — including the harness's own `echo '__PTY_END…__'` line — and a command "completes" before it ran (`sleep 1; echo first_done` returned instantly with no `first_done`, poisoning the following command too). The race predates this branch, but it is now fixed rather than documented:

Marker echo lines are written in a **split form** the shell joins only at execution time, so the assembled marker is proof of execution:
- bash (POSIX): `echo "__PTY_END""_<nonce>__"` (adjacent-string concatenation)
- PowerShell: `echo ("__PTY_END" + "_<nonce>__")`
- cmd.exe (fallback): `set __PTY_MVAR=__PTY_END` on its own line, then `echo %__PTY_MVAR%_<nonce>__` (same-line `%X%` would expand at parse time, before the set runs)

The spawn table (`src/utils.rs`) now carries each shell's `PtyShellFlavor`, the session records which shell actually spawned (the Windows primary/fallback differ), and the post-capture line cleanup filters the split-form harness lines by marker prefix / cmd variable. The regression test runs Codex's repro as the **first command on a fresh shell**; the emit shapes for all three flavors are pinned hermetically.

## Efficiency findings

| # | Finding | Fix | Where |
|---|---------|-----|-------|
| 1 (S) | `exec_pty` re-decoded + re-scanned the whole accumulated output every 20 ms poll — quadratic on chatty commands (5 MB over 30 s is ~3.75 GB of memcpy+scan under the reader thread's mutex) | `incremental_marker_scan()`: scan only new raw bytes per tick with a `marker.len()-1` overlap for chunk-straddling markers; decode once after the loop (raw-byte search is equivalent for the pure-ASCII marker). Also dropped the two per-line `format!` allocations in the marker-line `retain` | `src/agent.rs` |
| 3 (S) | `execPty` returned its output uncapped into model context (up to the 64 MB stdout ceiling); siblings cap (`exec_as_agent` 10 KB tails, `browse` 50 KB) | `cap_pty_output()`: 10 KB tail (same `LOG_TAIL_BYTES` as exec_as_agent) + leading `[execPty output truncated: showing last N of M bytes; full output: <path>]` marker + a `"truncated"` field; full transcript preserved at `<nonce>_pty.log`. A failed preservation write is surfaced in the result (`full transcript unavailable: <err>`) instead of silently losing the only copy | `src/agent.rs` |
| 4 (S-M) | xauthority cookie re-merge spawned 2-4+ subprocesses (`xauth nlist`/`nmerge`, a `sudo -n xauth` attempt) on every runtime invocation (Linux+X, i.e. per tool batch) | Freshness skip that also proves **completeness**: a fully clean pass writes a sidecar manifest of resolved sources; reuse requires manifest coverage of every existing source plus mtime freshness. A pass with any consult/merge failure (e.g. `sudo -n` denied for one display) drops the manifest so the next invocation retries; a pass that merged nothing deletes the merged file (a nonzero-exit `nmerge` can still create it); only `NotFound` source stats are unconstraining | `src/agent.rs` |
| 5 (S) | Runtime buffered all batch results and printed only at exit; a caller 120 s hard-timeout kill discarded completed commands' results (the caller's timeout arm also dropped its read buffers) | `process_input` now emits each JSONL result line via a sink as the command completes (flushed per line; sink returns false on broken pipe); the caller keeps its read buffers outside the timed future and, on hard-timeout kill, salvages partial stdout — truncated at the last newline first, so a mid-write kill can't broadcast a malformed JSON fragment into tool responses | `src/agent.rs`, `src/main.rs`, `src/bin/caller/agent_runner.rs` |
| 6 (S) | Multi-threaded tokio runtime (worker thread per core) spawned per tool call for a strictly sequential one-shot executor | `#[tokio::main(flavor = "current_thread")]`; verified no `tokio::spawn` / `spawn_blocking` / `block_in_place` anywhere in the runtime binary (PTY draining uses dedicated std threads) | `src/main.rs` |
| 7 (S) | `writeFile` deep-cloned the whole Command including MB-scale `content` just to rename the function and default the operation | iterate `input.commands` by value, rewrite the owned command in place | `src/agent.rs` |

Skipped:
- **Finding 2 (M)** — incremental `Conversation::save_to_file` persistence: lives in `crates/intendant-core/src/conversation.rs` + `agent_loop.rs`, outside this PR's file scope (runtime lane). Flagged for the owning lane.
- **Finding 8 (L)** — persistent per-session runtime process: explicitly excluded (L-track).

## Review round 2 (delta review; fixes 1/2/5 verified incl. a live PTY re-probe) — all applied

- **A (Med) — xauth manifest crash-consistency:** the manifest is invalidated *before* the pass mutates the merged file (a crash after display A, before display B, previously left the old A+B manifest beside a newer merged file — B never retried). Unprovable invalidation (non-NotFound delete error) seeds `any_failure` so the pass can't certify completeness; the clean-pass manifest is published atomically (tempfile+rename, falling back to no-manifest — absent is always safe); `xauth nmerge`'s stdin write result now counts toward merge success, with the child always reaped. Tests: certified→invalidate→not-fresh sequence, undeletable-manifest failure, no temp-file residue.
- **B (Med) — salvage dropped a complete newline-less trailing result:** the runtime's line-buffered stdout can flush a large result JSON before its separate newline write; a kill in that window lost a completed (possibly side-effecting) command → duplicate-retry hazard. The post-newline tail is now kept iff it parses as a complete protocol line (shared `is_runtime_protocol_line` predicate); torn fragments still dropped. Tests cover kept-complete-tail, dropped-torn-tail, and decline cases.
- **C (Med) — PTY harness filter was unanchored:** any line *containing* `__PTY_START`/`__PTY_END`/`__PTY_MVAR` was eaten (user output like `__PTY_ENDURANCE ready` vanished). The filter now matches only the exact nonce-bound harness shapes — assembled marker outputs, split-form typed lines (tail-matched, since echoes carry prompt prefixes), cmd variable lines. Pattern tests pin harness vs user lines (including another nonce's marker surviving); an end-to-end test proves `__PTY_ENDURANCE ready` comes through.
- **D (Low) — cmd marker variable hygiene:** the assembly variable is nonce-scoped (`__PTY_MVAR_<nonce>`), a cleanup line unsets it after the end marker prints, and the unavoidable visibility window to the command's own children is documented at the emit site.

## Review round 1 (Fable APPROVE w/ nits; Codex REQUEST-CHANGES) — all applied

1. **Case-sensitive scrub suffixes** (convergent) → classification on the ASCII-uppercased name; mixed-case tests.
2. **PTY echo race** (Codex blocker, demonstrated live) → split-form marker input per shell flavor; fresh-shell repro test. The earlier "warm the shell in tests" workaround and the "pre-existing race" framing are gone.
3. **Salvage could leak a malformed JSON fragment** → truncate at last newline before parseability; fragment-absence test.
4. **xauth freshness couldn't prove completeness** (convergent) → completeness manifest + failure-aware finalize + merged-file cleanup + `NotFound`-only unconstraining stats. (Implementation note: the review suggested an in-memory resolved-set on the Agent, but the runtime process is spawned fresh per tool batch — in-memory state can never be consulted by the next batch, so the resolved-set lives in a sidecar manifest next to the merged file, which has the same session-scoped lifetime the merged file itself has.)
5. **Silent transcript-preservation failure while truncating** → surfaced in the result text; unwritable-dir test.

## Risk notes

- exec_pty consumers now see at most ~10 KB + marker per command; anything larger moves to `<nonce>_pty.log` (same recovery pattern as exec_as_agent's `<nonce>_stdout.log`).
- Streaming changes runtime stdout timing, not format: same JSONL lines, same order, now flushed per command. On mid-batch hard errors (`execAsAgent`/`captureScreen` spawn failures), already-completed results become visible to the caller instead of discarded; `output_with_exit_status` already handled partial-output-with-nonzero-exit.
- Batch hard-timeout now returns salvaged results plus a stderr note when at least one command completed; commands with no result line surface as missing per-nonce downstream, exactly like the existing crash-exit path.
- current_thread flavor: the runtime is single-batch sequential; PTY reads live on std threads; `tokio::process`, `tokio::time`, TCP connect, and reqwest all run fine on a current-thread runtime.
- xauth: a session's first batch merges as before; healthy configurations skip subprocess spawns on later batches; any consult failure (e.g. a box where `sudo -n` is always denied) retries per batch — the pre-optimization behavior for that box, by design.
- PTY marker lines that a user command itself prints (`__PTY_START*`, `__PTY_END*`, `__PTY_MVAR`) are filtered from output — the pre-existing acceptance for assembled markers, applied to the split forms.

## Battery (all stages re-run after round 2)

- `cargo fmt --check`: clean
- `cargo clippy`: zero warnings/errors
- `cargo test --bins`: 3329 + 69 + 96 passed, 0 failed
- `cargo test --test e2e`: 21 passed (exercises the env scrub + streamed protocol through the real binaries under the mock provider)
