### PR TITLE
dash: coalesce SPA hot paths flagged by the efficiency audit

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -27790,7 +27790,6 @@ function ui2QueueFocusSurface() {
   requestAnimationFrame(() => {
     ui2FocusSurfaceQueued = false;
     ui2ApplyFocusSurface();
-    ui2TagRawEntries();
   });
 }
 
@@ -27800,31 +27799,64 @@ function ui2QueueFocusSurface() {
 // quiet meta hairlines instead of full-voice rows. Runs over BOTH the
 // combined stream and the session windows — Focus promotes a window, so
 // tagging the stream alone misses everything the user actually reads.
+function ui2TagEntry(e) {
+  if (e.classList.contains('ui2-raw-checked')) return;
+  e.classList.add('ui2-raw-checked');
+  const text = (e.querySelector('.log-content')?.textContent || '').trim();
+  if (/^\[(codex|claude(-code)?|backend) stderr\]/i.test(text)) {
+    e.classList.add('ui2-stderr');
+  }
+  if (e.classList.contains('source-steer')) {
+    e.classList.add('ui2-meta');
+    return;
+  }
+  const level = e.dataset.level || '';
+  if (
+    (level === 'info' || level === 'detail') &&
+    /^(Round \d+ complete|Turn \d+ started|Session (started|attached)|Done signal)/.test(text)
+  ) {
+    e.classList.add('ui2-meta');
+  }
+}
+
 function ui2TagEntriesIn(rootEl) {
   if (!rootEl) return;
-  rootEl.querySelectorAll('.log-entry:not(.ui2-raw-checked)').forEach((e) => {
-    e.classList.add('ui2-raw-checked');
-    const text = (e.querySelector('.log-content')?.textContent || '').trim();
-    if (/^\[(codex|claude(-code)?|backend) stderr\]/i.test(text)) {
-      e.classList.add('ui2-stderr');
-    }
-    if (e.classList.contains('source-steer')) {
-      e.classList.add('ui2-meta');
-      return;
-    }
-    const level = e.dataset.level || '';
-    if (
-      (level === 'info' || level === 'detail') &&
-      /^(Round \d+ complete|Turn \d+ started|Session (started|attached)|Done signal)/.test(text)
-    ) {
-      e.classList.add('ui2-meta');
-    }
-  });
+  rootEl.querySelectorAll('.log-entry:not(.ui2-raw-checked)').forEach(ui2TagEntry);
 }
 
 function ui2TagRawEntries() {
   ui2TagEntriesIn(document.getElementById('log-stream'));
   ui2TagEntriesIn(document.getElementById('session-window-grid'));
+}
+
+// Added-node tagging: the tagger used to re-run the `.log-entry:not(...)`
+// selector over the 10k-cap stream PLUS every window log on every grid
+// mutation — including the 1 Hz goal/vitals ticker text writes, i.e. a
+// full match-test of ~10-15k nodes every second while idle. The observers
+// now hand over exactly what was ADDED; text/attribute churn never queues
+// a pass (their addedNodes are text nodes), and a container insertion
+// (replay fragment, re-rendered window range) scans only its own subtree.
+// Clones inherit the source entry's classes, so re-tagging is a no-op skip.
+let ui2PendingTagNodes = new Set();
+let ui2TagPassQueued = false;
+function ui2QueueEntryTagging(records) {
+  for (const record of records) {
+    for (const node of record.addedNodes) {
+      if (node.nodeType === 1) ui2PendingTagNodes.add(node);
+    }
+  }
+  if (!ui2PendingTagNodes.size || ui2TagPassQueued) return;
+  ui2TagPassQueued = true;
+  requestAnimationFrame(() => {
+    ui2TagPassQueued = false;
+    const nodes = ui2PendingTagNodes;
+    ui2PendingTagNodes = new Set();
+    for (const node of nodes) {
+      if (!node.isConnected) continue;
+      if (node.classList && node.classList.contains('log-entry')) ui2TagEntry(node);
+      else ui2TagEntriesIn(node);
+    }
+  });
 }
 
 // The approval hero names its session — with several agents running,
@@ -27977,22 +28009,35 @@ function ui2RailTick(force) {
     ui2BuildVitalsRail();
     ui2RailTick(true);
     setInterval(() => ui2RailTick(), 1000);
-    // Focus surface + raw-entry hygiene: follow stream appends, target
-    // changes (the chip re-renders on every change), layout flips, and the
-    // session-window grid's own membership — a session resumed from the
-    // Sessions tab materializes its window there, and that is the only
-    // signal Focus gets that the window it must promote now exists.
+    // Focus surface: follow stream appends, target changes (the chip
+    // re-renders on every change), layout flips, and the session-window
+    // grid's own MEMBERSHIP — a session resumed from the Sessions tab
+    // materializes its window there, and that is the only signal Focus
+    // gets that the window it must promote now exists. Membership is
+    // childList on the grid ROOT: appends inside a window's log (or the
+    // per-second ticker text writes) cannot change what Focus promotes,
+    // and routing them here re-ran the promote pass once per frame during
+    // bursts and once per second while idle.
     const stream = document.getElementById('log-stream');
-    if (stream) new MutationObserver(ui2QueueFocusSurface).observe(stream, { childList: true });
+    if (stream) {
+      new MutationObserver((records) => {
+        ui2QueueFocusSurface();
+        ui2QueueEntryTagging(records);
+      }).observe(stream, { childList: true });
+    }
     const chip = document.getElementById('task-target-chip');
     if (chip) new MutationObserver(ui2QueueFocusSurface).observe(chip, {
       childList: true, characterData: true, subtree: true, attributes: true,
     });
-    // subtree: entries append INSIDE window logs — the meta/stderr tagger
-    // must see them, not just window add/remove. ui2QueueFocusSurface is
-    // rAF-debounced, so per-entry firing collapses to one pass a frame.
     const windowGrid = document.getElementById('session-window-grid');
-    if (windowGrid) new MutationObserver(ui2QueueFocusSurface).observe(windowGrid, { childList: true, subtree: true });
+    if (windowGrid) {
+      new MutationObserver(ui2QueueFocusSurface).observe(windowGrid, { childList: true });
+      // subtree: entries append INSIDE window logs — the meta/stderr tagger
+      // must see them, not just window add/remove. It consumes only
+      // addedNodes (see ui2QueueEntryTagging), so ticker text churn and
+      // attribute writes never trigger a scan.
+      new MutationObserver(ui2QueueEntryTagging).observe(windowGrid, { childList: true, subtree: true });
+    }
     ui2ApplyFocusSurface();
     ui2TagRawEntries();
     // Approval hero session identity.
@@ -28028,7 +28073,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'c9799413fe5b0e7e';
+const INTENDANT_APP_BUILD = '79868a67bb6b6b5b';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -35508,6 +35553,9 @@ async function stationRefreshDisplayTelemetry(key, pc) {
   if (!pc || typeof pc.getStats !== 'function') return;
   const stats = await pc.getStats();
   const cached = stationDisplayTelemetry.get(key) || {};
+  // Snapshot the DISPLAYED values before folding the fresh sample in: the
+  // completion below only reschedules when they moved.
+  const labelBefore = stationDisplayTelemetryLabel(cached);
   const codecs = new Map();
   const inbound = [];
   stats.forEach(report => {
@@ -35539,7 +35587,13 @@ async function stationRefreshDisplayTelemetry(key, pc) {
     cached.quality = 'steady';
   }
   stationDisplayTelemetry.set(key, cached);
-  stationScheduleUpdate();
+  // Unconditional rescheduling here made the pipeline self-perpetuating:
+  // snapshot build → telemetry poll (1.5 s throttle) → this completion →
+  // schedule (300 ms) → next build → next poll — a full rebuild every
+  // ~1.8 s on an idle Station tab with any stream open. The snapshot only
+  // renders the ROUNDED label, so reschedule only when that label moved;
+  // real fps/codec/quality changes still repaint.
+  if (stationDisplayTelemetryLabel(cached) !== labelBefore) stationScheduleUpdate();
 }
 
 function stationDisplayRunwayPayload(controlsSummary = null) {
@@ -38571,6 +38625,18 @@ function stationMaybeRefreshTranscript(force = false) {
   const key = stationLatestEventKeyForSession(live.sessionId);
   if (!force && key && key === live.lastEventKey && age < 8000) return;
   if (!force && !key && age < 8000) return;
+  // Idle-arm gate: the ~8 s fallback exists for sessions whose output
+  // never surfaces in the activity stream — but when the stream key is
+  // UNCHANGED and the session itself reports an inactive phase, there is
+  // nothing new to fetch. Skipping here parks the 300-row refetch+rebuild
+  // instead of re-running it forever under an idle open viewer; an
+  // unknown phase keeps the old fallback cadence (fail open).
+  if (!force && key === live.lastEventKey) {
+    const phase = String(
+      (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(live.sessionId)?.phase) || ''
+    );
+    if (phase === 'idle' || phase === 'done' || phase === 'interrupted') return;
+  }
   live.fetchedAt = Date.now();
   live.lastEventKey = key;
   stationOpenTranscript(live.sessionId, { source: live.source, refresh: true });
@@ -42407,6 +42473,10 @@ function processCommands(cmds) {
       if (c.cmd !== 'update_status_bar' && c.cmd !== 'set_phase') {
         pendingStatusPhaseGuard = null;
       }
+      // Per-command isolation: sibling commands in a batch are independent
+      // renders — one throwing handler (e.g. a missing DOM node after a
+      // shell-markup change) must not eat the rest of the batch.
+      try {
       switch (c.cmd) {
       case 'add_log_entry':
         maybeFailNewSessionSpawnFromLog(c);
@@ -42666,6 +42736,9 @@ function processCommands(cmds) {
       case 'peer_dashboard_control_signal':
         handlePeerDashboardControlSignal(c.host_id, c.session_id, c.signal);
         break;
+      }
+      } catch (err) {
+        console.warn('[ui-command]', c?.cmd || 'unknown command', err);
       }
     }
   } finally {
@@ -47774,9 +47847,16 @@ function mergeSessionWindowMetadata(sessionId, meta = {}) {
   const merged = Object.keys(normalized).length > 0
     ? { ...previous, ...normalized }
     : previous;
-  const changed = sessionWindowMetadataSignature(previous) !== sessionWindowMetadataSignature(merged);
+  // The merged signature rides the return value so updateSessionWindow —
+  // reached per rendered log line via inferSessionPhaseFromLog — doesn't
+  // recompute the ~35-field join a third time per call.
+  const previousSignature = sessionWindowMetadataSignature(previous);
+  const signature = merged === previous
+    ? previousSignature
+    : sessionWindowMetadataSignature(merged);
+  const changed = previousSignature !== signature;
   if (sid && changed) sessionMetadataById.set(sid, merged);
-  return { meta: merged, changed };
+  return { meta: merged, changed, signature };
 }
 
 function currentSessionGoalElapsedSeconds(goal) {
@@ -47808,22 +47888,27 @@ function goalStatusClass(status) {
 
 function renderSessionWindowGoal(win, goal) {
   if (!win?.goal || !win?.goalText) return false;
+  // Write-guards throughout: this runs for EVERY window on the 1 Hz goal
+  // ticker, and unconditional textContent/className assignment churns text
+  // nodes (and feeds every subtree MutationObserver watching the grid)
+  // even when the rendered second hasn't rolled over.
+  const setText = (el, prop, value) => { if (el[prop] !== value) el[prop] = value; };
   if (!goal?.objective) {
-    win.goal.className = 'session-window-goal hidden';
-    win.goalText.textContent = '';
-    win.goal.title = '';
+    setText(win.goal, 'className', 'session-window-goal hidden');
+    setText(win.goalText, 'textContent', '');
+    setText(win.goal, 'title', '');
     return false;
   }
   const status = normalizeGoalStatus(goal.status);
   const elapsed = formatGoalElapsed(currentSessionGoalElapsedSeconds(goal));
-  win.goal.className = `session-window-goal ${goalStatusClass(status)}`;
-  win.goalText.textContent = status === 'active'
+  setText(win.goal, 'className', `session-window-goal ${goalStatusClass(status)}`);
+  setText(win.goalText, 'textContent', status === 'active'
     ? `${goal.objective} · ${elapsed}`
-    : `${status} · ${goal.objective} · ${elapsed}`;
+    : `${status} · ${goal.objective} · ${elapsed}`);
   const tokenText = goal.tokensUsed !== null && goal.tokensUsed !== undefined
     ? `\nTokens: ${goal.tokensUsed.toLocaleString()}${goal.tokenBudget ? ` / ${goal.tokenBudget.toLocaleString()}` : ''}`
     : (goal.tokenBudget ? `\nBudget: ${goal.tokenBudget.toLocaleString()} tokens` : '');
-  win.goal.title = `Goal: ${goal.objective}\nStatus: ${status}\nElapsed: ${elapsed}${tokenText}`;
+  setText(win.goal, 'title', `Goal: ${goal.objective}\nStatus: ${status}\nElapsed: ${elapsed}${tokenText}`);
   return status === 'active';
 }
 
@@ -47859,6 +47944,16 @@ function refreshSessionGoalTicker() {
   } else if (!hasActiveGoal && sessionGoalTicker) {
     clearInterval(sessionGoalTicker);
     sessionGoalTicker = null;
+  }
+}
+
+// Arm-only twin for per-window update paths: updateSessionWindow already
+// rendered ITS window's goal — re-rendering every other window's goal per
+// metadata tick (the old refreshSessionGoalTicker call) was pure waste.
+// The 1 s ticker still owns elapsed-time repaints and disarms itself.
+function ensureSessionGoalTickerArmed(hasActiveGoal) {
+  if (hasActiveGoal && !sessionGoalTicker) {
+    sessionGoalTicker = setInterval(refreshSessionGoalTicker, 1000);
   }
 }
 
@@ -48318,6 +48413,7 @@ function renderSessionWindowVitals(win, vitals) {
     win.vitals.replaceChildren();
     win.vitals.removeAttribute('title');
     delete win.vitals.dataset.vitSig;
+    win.vitalsRowTicking = false;
     return false;
   }
   wireVitalsChipRow(win);
@@ -48334,7 +48430,8 @@ function renderSessionWindowVitals(win, vitals) {
       ttlChip.textContent = ttl.text;
       ttlChip.title = ttl.explainLines[0] || ttl.label;
     }
-    return models.some((m) => m.ticking);
+    win.vitalsRowTicking = models.some((m) => m.ticking);
+    return win.vitalsRowTicking;
   }
   win.vitals.dataset.vitSig = signature;
   win.vitals.className = 'session-window-vitals';
@@ -48369,7 +48466,8 @@ function renderSessionWindowVitals(win, vitals) {
     nodes.push(more);
   }
   win.vitals.replaceChildren(...nodes);
-  return models.some((m) => m.ticking);
+  win.vitalsRowTicking = models.some((m) => m.ticking);
+  return win.vitalsRowTicking;
 }
 
 // One delegated listener per window (chips are rebuilt every render).
@@ -48738,10 +48836,36 @@ function showCacheExpiryToast(sid, text) {
   setTimeout(() => { if (toast.parentNode) toast.remove(); }, 12000);
 }
 
+// Cheap per-tick predicate: does this session's vitals row need a 1 Hz
+// repaint at all? True for the warm-cache countdown (the only `ticking`
+// model vitalsChipModels emits) and for status-only rate-limit chips whose
+// "resets in ~Xm" text is time-derived. Everything else changes only on
+// real vitals/metadata events, which re-render directly — so the ticker no
+// longer rebuilds every window's full chip-model array each second just to
+// hit the stable-DOM fast path.
+function sessionVitalsNeedsTick(vitals) {
+  if (!vitals || typeof vitals !== 'object') return false;
+  const remaining = sessionCacheCountdownSeconds(vitals.cache);
+  if (remaining !== null && remaining > 0) return true;
+  const limits = Array.isArray(vitals.limits) ? vitals.limits : [];
+  return limits.some((w) => {
+    // Mirrors the chip model: the reset countdown only renders when the
+    // provider reports no percentage (status-only limits).
+    const pctRaw = Number(w?.usedPct);
+    const hasPct = Number.isFinite(pctRaw) && w?.usedPct !== null && w?.usedPct !== undefined;
+    return !hasPct && Number(w?.resetsAtEpoch) > Date.now() / 1000;
+  });
+}
+
 function refreshSessionVitalsTicker() {
   let ticking = false;
   for (const [sid, win] of sessionWindows) {
     const vitals = (sessionMetadataById.get(sid) || {}).vitals || null;
+    const needsTick = sessionVitalsNeedsTick(vitals);
+    // One trailing render after ticking stops (win.vitalsRowTicking is
+    // maintained by renderSessionWindowVitals on every render path) flips
+    // the countdown chip to its cold glyph instead of freezing mid-count.
+    if (!needsTick && !win.vitalsRowTicking) continue;
     if (renderSessionWindowVitals(win, vitals)) ticking = true;
     maybeAlertCacheExpiry(sid, win, vitals);
   }
@@ -49076,8 +49200,41 @@ function persistedSessionWindowRecord(sessionId, win = null) {
   return record;
 }
 
+// Trailing-debounced twin for the streaming path. updateSessionWindow runs
+// per rendered log line (inferSessionPhaseFromLog flips phase on model/agent
+// lines) and used to re-derive every window's record, JSON.stringify it, and
+// synchronously localStorage.setItem — tens of disk-backed writes per second
+// under load, forever. Metadata churn now coalesces into at most one write
+// per second; structural transitions (open/close/layout ops) keep calling
+// the immediate form, and pagehide/hidden flush a pending write so a closing
+// tab still persists its newest state.
+let sessionWindowPersistTimer = 0;
+function schedulePersistSessionWindowState() {
+  if (restoringPersistedSessionWindows || sessionWindowPersistTimer) return;
+  sessionWindowPersistTimer = window.setTimeout(() => {
+    sessionWindowPersistTimer = 0;
+    persistSessionWindowState();
+  }, 1000);
+}
+
+function flushPendingSessionWindowPersist() {
+  if (!sessionWindowPersistTimer) return;
+  clearTimeout(sessionWindowPersistTimer);
+  sessionWindowPersistTimer = 0;
+  persistSessionWindowState();
+}
+window.addEventListener('pagehide', flushPendingSessionWindowPersist);
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) flushPendingSessionWindowPersist();
+});
+
 function persistSessionWindowState() {
   if (restoringPersistedSessionWindows) return;
+  // A direct persist supersedes any scheduled one.
+  if (sessionWindowPersistTimer) {
+    clearTimeout(sessionWindowPersistTimer);
+    sessionWindowPersistTimer = 0;
+  }
   let windows = [];
   for (const [sid, win] of sessionWindows) {
     const record = persistedSessionWindowRecord(sid, win);
@@ -50229,6 +50386,13 @@ function pruneMainLogContainer(container = currentMainLogContainer()) {
     while (logEntryCount > 10000) {
       const first = container.querySelector('.log-entry, .log-turn-sep');
       if (!first) break;
+      // A pruned command-output group must leave the strong registry too:
+      // commandOutputGroups otherwise pins the detached entry DOM, its
+      // clone views, and the full accumulated copy text for the lifetime
+      // of the page (clearLogs was the only eviction). Live clones keep
+      // the group reachable through their own click closures.
+      const groupId = first.dataset ? first.dataset.outputGroupId : '';
+      if (groupId) commandOutputGroups.delete(groupId);
       first.remove();
       logEntryCount--;
     }
@@ -50563,6 +50727,23 @@ function getLogEntryCopyText(entry) {
   return entry?.querySelector?.('.log-content')?.innerText || '';
 }
 
+// Async twin for capped copy refs: a command-output group whose streamed
+// text outgrew COMMAND_OUTPUT_COPY_TEXT_CAP carries a fetchText resolver
+// (the persisted-output lane) instead of retaining megabytes in the ref.
+// Falls back to the captured prefix if the fetch fails.
+async function resolveLogEntryCopyText(entry) {
+  const ref = entry ? logEntryCopyTextByEntry.get(entry) : null;
+  if (ref && typeof ref.fetchText === 'function') {
+    try {
+      const text = await ref.fetchText();
+      if (text) return String(text);
+    } catch (err) {
+      console.warn('lazy copy-text fetch failed; copying captured prefix', err);
+    }
+  }
+  return getLogEntryCopyText(entry);
+}
+
 function resetLogCopyButton(btn) {
   if (!btn) return;
   btn.classList.remove('copied');
@@ -50577,7 +50758,7 @@ async function onLogCopyButtonClick(ev) {
   const btn = ev.currentTarget;
   const entry = btn.closest('.log-entry');
   try {
-    await copyTextToClipboard(getLogEntryCopyText(entry));
+    await copyTextToClipboard(await resolveLogEntryCopyText(entry));
     btn.classList.add('copied');
     btn.innerHTML = '&#x2713;';
     btn.title = 'Copied';
@@ -52423,16 +52604,34 @@ function updateSessionWindowJumpButton(win) {
   win.jumpBottom.setAttribute('aria-hidden', show ? 'false' : 'true');
 }
 
+// rAF-coalesced per-window bottom-follow (finding: interleaved layout
+// read/write per appended entry). The scrollHeight read forces synchronous
+// layout of the window's scroller; bursts used to pay it once per entry per
+// window. The follow DECISION and flags stay synchronous below — only the
+// scrollTop write (and thus the layout read) coalesces to one per window
+// per frame, re-checking followOutput at flush so a user grab between
+// schedule and flush wins (updateSessionWindowFollowFromScroll clears it).
+const sessionWindowScrollFollowPending = new Set();
+function scheduleSessionWindowScrollToBottom(win) {
+  if (!win || !win.log || sessionWindowScrollFollowPending.has(win)) return;
+  sessionWindowScrollFollowPending.add(win);
+  requestAnimationFrame(() => {
+    sessionWindowScrollFollowPending.delete(win);
+    if (!win.log || !win.followOutput) return;
+    win.log.scrollTop = win.log.scrollHeight;
+  });
+}
+
 function scrollSessionWindowToBottom(win) {
   if (!win || !win.log) return;
   const history = ensureSessionWindowHistory(win);
   if (!sessionWindowIsRenderingTail(win, history.length) || win.renderEnd !== history.length) {
     renderSessionWindowTail(win);
   }
-  win.log.scrollTop = win.log.scrollHeight;
   win.followOutput = true;
   win.pendingOutput = false;
   updateSessionWindowJumpButton(win);
+  scheduleSessionWindowScrollToBottom(win);
 }
 
 function applySessionWindowOutputScroll(win, shouldFollow) {
@@ -53985,6 +54184,27 @@ function ensureSessionWindow(sessionId, meta = {}) {
   return win;
 }
 
+// Applies a phase change to the window chrome: status chip repaint plus the
+// approval-confirm hook. Shared by the wide render below and the phase-only
+// fast path — the hook (maybeConfirmApprovalSendFromWindowPhase) must fire
+// on EVERY phase application, both paths.
+function applySessionWindowPhase(win, sid, phase) {
+  const nextPhase = normalizeSessionPhase(phase);
+  // A real phase transition is fresh evidence about the session; it
+  // retires the "optimistic thinking expired" steer demotion below.
+  if (win.phase !== nextPhase) win.optimisticActiveExpired = false;
+  win.phase = nextPhase;
+  if (win.phase === 'idle' || win.phase === 'done' || win.phase === 'interrupted') {
+    win.pendingActiveUntil = 0;
+  }
+  win.status.textContent = sessionPhaseLabel(win.phase);
+  win.status.title = sessionPhaseLabel(win.phase);
+  win.status.className = 'session-window-status';
+  const cls = sessionPhaseClass(win.phase);
+  if (cls) win.status.classList.add(cls);
+  maybeConfirmApprovalSendFromWindowPhase(sid, win.phase);
+}
+
 function updateSessionWindow(sessionId, meta = {}) {
   const sid = String(sessionId || '').trim();
   if (!sid) return;
@@ -53993,12 +54213,31 @@ function updateSessionWindow(sessionId, meta = {}) {
   const merged = mergeSessionWindowMetadata(sid, meta);
   meta = merged.meta;
   updateSessionWindowRelationshipStyle(sid);
-  const signature = sessionWindowMetadataSignature(meta);
+  const signature = merged.signature;
   if (win.metadataSignature === signature) {
-    persistSessionWindowState();
+    // Nothing rendered from — nothing persisted from. The unconditional
+    // persist here was a synchronous localStorage write per rendered log
+    // line (this early-out is the steady-state exit of the per-line
+    // phase-inference path).
     return;
   }
+  // Phase-only fast path: streaming log lines alternate thinking↔running
+  // several times per turn (inferSessionPhaseFromLog), and phase rides the
+  // metadata signature — so each alternation used to defeat the early-out
+  // and re-run the full header render (identity DOM rebuild, path
+  // elements, goal/tier/vitals, relationship badges, menu visibility).
+  // When the signatures differ ONLY in phase, repaint the status chip and
+  // fire the approval-confirm hook — the only phase consumers here.
+  const signatureNoPhase = sessionWindowMetadataSignature({ ...meta, phase: '' });
+  const phaseOnly = Boolean(win.metadataSignature) &&
+    win.metadataSignatureNoPhase === signatureNoPhase;
   win.metadataSignature = signature;
+  win.metadataSignatureNoPhase = signatureNoPhase;
+  if (phaseOnly) {
+    if (meta.phase) applySessionWindowPhase(win, sid, meta.phase);
+    schedulePersistSessionWindowState();
+    return;
+  }
   renderSessionIdentity(win.id, sid, { order: 'id-name' });
   if (meta.projectRoot) {
     setSessionWindowPathElement(
@@ -54056,25 +54295,14 @@ function updateSessionWindow(sessionId, meta = {}) {
     if (win.ended) win.pendingActiveUntil = 0;
   }
   if (meta.phase) {
-    const nextPhase = normalizeSessionPhase(meta.phase);
-    // A real phase transition is fresh evidence about the session; it
-    // retires the "optimistic thinking expired" steer demotion below.
-    if (win.phase !== nextPhase) win.optimisticActiveExpired = false;
-    win.phase = nextPhase;
-    if (win.phase === 'idle' || win.phase === 'done' || win.phase === 'interrupted') {
-      win.pendingActiveUntil = 0;
-    }
-    win.status.textContent = sessionPhaseLabel(win.phase);
-    win.status.title = sessionPhaseLabel(win.phase);
-    win.status.className = 'session-window-status';
-    const cls = sessionPhaseClass(win.phase);
-    if (cls) win.status.classList.add(cls);
-    maybeConfirmApprovalSendFromWindowPhase(sid, win.phase);
+    applySessionWindowPhase(win, sid, meta.phase);
   }
-  renderSessionWindowGoal(win, meta.goal || null);
+  // Arm-only: this window's goal was just rendered; the 1 s ticker owns
+  // elapsed-time repaints for the rest (re-rendering EVERY window's goal
+  // per metadata update was the waste).
+  ensureSessionGoalTickerArmed(renderSessionWindowGoal(win, meta.goal || null));
   renderSessionWindowTier(win);
   renderSessionWindowVitals(win, (sessionMetadataById.get(sid) || {}).vitals || meta.vitals || null);
-  refreshSessionGoalTicker();
   updateSessionWindowActionMenuVisibility(sid);
   updateControlFastButtonState();
   updateSessionRelationshipBadges(sid);
@@ -54086,7 +54314,7 @@ function updateSessionWindow(sessionId, meta = {}) {
   if (win.log && win.log.firstElementChild?.classList?.contains('session-window-empty')) {
     renderSessionWindowLogPlaceholder(win);
   }
-  persistSessionWindowState();
+  schedulePersistSessionWindowState();
 }
 
 // Worktree badge next to the project path: branch name up front, the full
@@ -55063,6 +55291,23 @@ function createLogScaffold(c, extraClass) {
   return { entry, hostId };
 }
 
+// rAF-coalesced follow for the MAIN stream (finding: interleaved layout
+// read/write per appended entry). Reading scrollHeight right after each
+// append forces a synchronous layout of the 10k-node scroller — N entries
+// in one frame cost N layout passes. One scrollTop write per frame, with
+// the follow flags re-checked at flush so a user grab mid-burst wins.
+let mainLogScrollScheduled = false;
+function scheduleMainLogScrollToBottom() {
+  if (mainLogScrollScheduled) return;
+  mainLogScrollScheduled = true;
+  requestAnimationFrame(() => {
+    mainLogScrollScheduled = false;
+    if (concurrentLogDetachedFragment || !autoScroll) return;
+    const stream = document.getElementById('log-stream');
+    if (stream) stream.scrollTop = stream.scrollHeight;
+  });
+}
+
 function appendLogEntryElement(entry, sessionRecord = null) {
   if (logReplayAppendBatch && !entry.classList.contains('command-output-group')) {
     logReplayAppendBatch.mainFragment.appendChild(entry);
@@ -55091,7 +55336,7 @@ function appendLogEntryElement(entry, sessionRecord = null) {
   updateLogEmptyState();
   pruneMainLogContainer(container);
   if (!concurrentLogDetachedFragment && autoScroll && stream) {
-    stream.scrollTop = stream.scrollHeight;
+    scheduleMainLogScrollToBottom();
   } else if (!processingLogReplay) {
     noteMainLogNewBelow();
   }
@@ -55293,7 +55538,19 @@ function appendCommandOutputChunk(group, c) {
       sessionScrollStates.set(win, sessionWindowShouldFollowNextOutput(win));
     }
   }
-  if (group.copyRef && text) group.copyRef.text += text;
+  if (group.copyRef && text && !group.copyRefCapped) {
+    if (group.copyRef.text.length + text.length > COMMAND_OUTPUT_COPY_TEXT_CAP) {
+      // Stop retaining the concatenation of ALL streamed output in JS heap
+      // for the session's lifetime. The copy button re-fetches the full
+      // text lazily through the persisted-output lane (same source the
+      // expand-after-finalize path loads); the captured prefix stays as
+      // the offline fallback.
+      group.copyRefCapped = true;
+      group.copyRef.fetchText = () => fetchCommandOutputGroupText(group);
+    } else {
+      group.copyRef.text += text;
+    }
+  }
   if (c.output_id && !group.outputIdSet.has(c.output_id)) {
     group.outputIdSet.add(c.output_id);
     group.outputIds.push(c.output_id);
@@ -55374,7 +55631,7 @@ function renderCommandOutputEntry(c) {
   }
   appendCommandOutputChunk(activeCommandOutputGroup, c);
   const stream = document.getElementById('log-stream');
-  if (!concurrentLogDetachedFragment && autoScroll && stream) stream.scrollTop = stream.scrollHeight;
+  if (!concurrentLogDetachedFragment && autoScroll && stream) scheduleMainLogScrollToBottom();
 }
 
 function finalizeCommandOutputGroup(group) {
@@ -55439,6 +55696,22 @@ async function loadCommandOutputIntoBody(group, body) {
   if (!body.childElementCount) {
     body.textContent = 'No persisted output found.';
   }
+}
+
+// Copy-text retention cap for streaming command-output groups (2 MiB of
+// UTF-16 units). Beyond it the copy ref switches to the lazy fetch below.
+const COMMAND_OUTPUT_COPY_TEXT_CAP = 2 * 1024 * 1024;
+
+// Full output text for a capped group's copy button — same persisted-output
+// RPC the finalized expand path uses, joined in stream order.
+async function fetchCommandOutputGroupText(group) {
+  if (!group?.outputIds?.length) return '';
+  const resp = await daemonApi.request('api_session_current_agent_output', { ids: group.outputIds });
+  const json = (resp.body && typeof resp.body === 'object') ? resp.body : {};
+  if (!resp.ok) throw new Error(json.error || `HTTP ${resp.status}`);
+  return (json.outputs || [])
+    .map(out => [out.stdout || '', out.stderr || ''].filter(Boolean).join(out.stdout && out.stderr ? '\n' : ''))
+    .join('');
 }
 
 async function toggleCommandOutputView(group, view) {
@@ -56038,11 +56311,19 @@ function parseUsageJson(raw) {
   try { return JSON.parse(raw); } catch { return null; }
 }
 
+// One full update_usage payload per session ever seen otherwise accumulates
+// for the lifetime of the tab (days-long dashboards → MBs). LRU past the cap:
+// re-inserting on write keeps the actively-updating sessions at the tail.
+const SESSION_USAGE_CACHE_CAP = 500;
 function cacheSessionUsage(c) {
   if (!c || typeof c !== 'object') return;
   const sid = String(c.session_id || '').trim();
   if (sid) {
+    sessionUsageById.delete(sid);
     sessionUsageById.set(sid, c);
+    while (sessionUsageById.size > SESSION_USAGE_CACHE_CAP) {
+      sessionUsageById.delete(sessionUsageById.keys().next().value);
+    }
   } else {
     latestGlobalUsage = c;
   }
@@ -56132,13 +56413,20 @@ function updateStatusBar(d, opts = {}) {
                && relatedSessionIdsForSession(statusSid).has(foreground)))
         : false);
   if (drivesForeground) {
-    if (d.provider) document.getElementById('sb-provider').textContent = d.provider;
-    if (d.model) document.getElementById('sb-model').textContent = d.model;
-    if (d.turn !== undefined && d.turn !== null) document.getElementById('sb-turn').textContent = 'T' + d.turn;
+    // Null-guarded like the rest of the file: this runs mid-UiCommand
+    // batch, and a missing chip must degrade to a skipped write, not an
+    // exception that eats the remaining commands.
+    const providerEl = document.getElementById('sb-provider');
+    if (d.provider && providerEl) providerEl.textContent = d.provider;
+    const modelEl = document.getElementById('sb-model');
+    if (d.model && modelEl) modelEl.textContent = d.model;
+    const turnEl = document.getElementById('sb-turn');
+    if (d.turn !== undefined && d.turn !== null && turnEl) turnEl.textContent = 'T' + d.turn;
     if (d.budget_pct !== undefined && d.budget_pct !== null) setContextUsagePct(d.budget_pct);
   }
-  if (d.autonomy) {
-    const el = document.getElementById('sb-autonomy');
+  const autonomyEl = document.getElementById('sb-autonomy');
+  if (d.autonomy && autonomyEl) {
+    const el = autonomyEl;
     const autonomy = normalizeAutonomyLabel(d.autonomy);
     el.textContent = autonomy;
     const colors = { Low: 'var(--red)', Medium: 'var(--yellow)', High: 'var(--teal)', Full: 'var(--green)' };
@@ -65085,7 +65373,12 @@ class DisplaySlot {
     // is waiting for display signaling to return instead of burning its
     // bounded retry budget on offers that cannot leave the browser.
     this._transportWaitTimer = null;
+    // Presence streaming: dedicated capture canvases per lane, sized on
+    // dimension change only (assigning canvas.width reallocates the backing
+    // store — the old single shared canvas paid two reallocations per tick).
     this._streamCanvas = document.createElement('canvas');
+    this._hqStreamCanvas = document.createElement('canvas');
+    this._streamEncodePending = false;
     this._focusResizeObserver = null;
     this._boundHandlers = {};
     this._fullscreenInertRecords = [];
@@ -66247,6 +66540,31 @@ class DisplaySlot {
   toggleStreaming() {
     if (this.streaming) { this.stopStreaming(); } else { this.startStreaming(); }
   }
+  // Size a capture canvas once per dimension change — width/height
+  // assignment reallocates the backing store even when the value is equal
+  // in some engines, so guard both.
+  static _sizeCanvas(canvas, w, h) {
+    if (canvas.width !== w) canvas.width = w;
+    if (canvas.height !== h) canvas.height = h;
+  }
+  // Async JPEG→base64: toBlob lets the browser encode off the main thread
+  // where it can; only the byte→base64 conversion (chunked) stays on it.
+  // The old toDataURL path blocked the main thread for encode AND base64
+  // (~10-40 ms/tick at retina), on the same thread as remote-control input.
+  static _canvasJpegBase64(canvas, quality) {
+    return new Promise((resolve, reject) => {
+      if (typeof canvas.toBlob !== 'function') {
+        resolve(canvas.toDataURL('image/jpeg', quality).split(',')[1]);
+        return;
+      }
+      canvas.toBlob(blob => {
+        if (!blob) { reject(new Error('canvas JPEG encode failed')); return; }
+        blob.arrayBuffer()
+          .then(buf => resolve(dashboardControlBytesToBase64(new Uint8Array(buf))))
+          .catch(reject);
+      }, 'image/jpeg', quality);
+    });
+  }
   startStreaming() {
     if (this.streaming || !this.connected) return;
     this.streaming = true;
@@ -66255,47 +66573,55 @@ class DisplaySlot {
     this.streamBtn.innerHTML = '&#x1F441; Streaming';
     this.frameIdEl.style.display = '';
     const streamName = 'display_' + this.displayId;
-    const ctx = this._streamCanvas.getContext('2d');
+    const liveCtx = this._streamCanvas.getContext('2d');
+    const hqCtx = this._hqStreamCanvas.getContext('2d');
     this._streamIntervalId = setInterval(() => {
       if (!this.streaming || !this.connected || !app) return;
       const vid = this.videoEl;
       if (!vid.videoWidth || !vid.videoHeight) return;
+      // Last tick's encode still in flight (slow machine / huge retina
+      // frame): skip this tick instead of stacking encodes.
+      if (this._streamEncodePending) return;
       const sw = vid.videoWidth;
       const sh = vid.videoHeight;
       this._streamFrameCounter++;
       const frameId = streamName + '-f' + String(this._streamFrameCounter).padStart(5, '0');
       // Live-res: scale to LIVE_RES maintaining aspect ratio within a square
       const scale = Math.min(LIVE_RES / sw, LIVE_RES / sh);
-      const lw = Math.round(sw * scale);
-      const lh = Math.round(sh * scale);
-      this._streamCanvas.width = lw;
-      this._streamCanvas.height = lh;
-      ctx.drawImage(vid, 0, 0, lw, lh);
-      const liveJpeg = this._streamCanvas.toDataURL('image/jpeg', 0.8);
-      const liveB64 = liveJpeg.split(',')[1];
-      // Skip duplicate frames for voice model — still send HQ to server for archival
-      const sizeDelta = Math.abs(liveB64.length - (this._lastFrameLen || 0)) / (this._lastFrameLen || 1);
-      const frameDup = sizeDelta < 0.02 && this._lastFrameLen > 0;
-      if (!frameDup) {
-        this._lastFrameLen = liveB64.length;
-        app.send_frame(liveB64, frameId);
-        this.frameIdEl.textContent = frameId.split('-').pop();
-        this.frameIdEl.style.color = 'var(--overlay0)';
-        tickerFramesSent++;
-      } else {
-        this.frameIdEl.textContent = frameId.split('-').pop() + ' dropped';
-        this.frameIdEl.style.color = 'var(--yellow)';
-        tickerFramesDropped++;
-        sendDashboardVoiceDiagnostic('frame_skip', 'duplicate frame skipped (delta=' + (sizeDelta * 100).toFixed(1) + '%)');
-      }
-      // HQ: logical resolution — always sent for archival
+      DisplaySlot._sizeCanvas(this._streamCanvas, Math.round(sw * scale), Math.round(sh * scale));
+      liveCtx.drawImage(vid, 0, 0, this._streamCanvas.width, this._streamCanvas.height);
+      // HQ: logical resolution — always sent for archival. Drawn in the
+      // same tick as the live lane so both lanes capture the same instant.
       const dpr = window.devicePixelRatio || 1;
-      this._streamCanvas.width = Math.round(sw / dpr);
-      this._streamCanvas.height = Math.round(sh / dpr);
-      ctx.drawImage(vid, 0, 0, this._streamCanvas.width, this._streamCanvas.height);
-      const hqJpeg = this._streamCanvas.toDataURL('image/jpeg', 0.80);
-      const hqB64 = hqJpeg.split(',')[1];
-      sendDashboardVideoFrameToServer(hqB64, frameId, streamName);
+      DisplaySlot._sizeCanvas(this._hqStreamCanvas, Math.round(sw / dpr), Math.round(sh / dpr));
+      hqCtx.drawImage(vid, 0, 0, this._hqStreamCanvas.width, this._hqStreamCanvas.height);
+      this._streamEncodePending = true;
+      Promise.all([
+        DisplaySlot._canvasJpegBase64(this._streamCanvas, 0.8),
+        DisplaySlot._canvasJpegBase64(this._hqStreamCanvas, 0.80),
+      ]).then(([liveB64, hqB64]) => {
+        if (!this.streaming) return;
+        // Skip duplicate frames for voice model — still send HQ to server for archival
+        const sizeDelta = Math.abs(liveB64.length - (this._lastFrameLen || 0)) / (this._lastFrameLen || 1);
+        const frameDup = sizeDelta < 0.02 && this._lastFrameLen > 0;
+        if (!frameDup) {
+          this._lastFrameLen = liveB64.length;
+          app.send_frame(liveB64, frameId);
+          this.frameIdEl.textContent = frameId.split('-').pop();
+          this.frameIdEl.style.color = 'var(--overlay0)';
+          tickerFramesSent++;
+        } else {
+          this.frameIdEl.textContent = frameId.split('-').pop() + ' dropped';
+          this.frameIdEl.style.color = 'var(--yellow)';
+          tickerFramesDropped++;
+          sendDashboardVoiceDiagnostic('frame_skip', 'duplicate frame skipped (delta=' + (sizeDelta * 100).toFixed(1) + '%)');
+        }
+        sendDashboardVideoFrameToServer(hqB64, frameId, streamName);
+      }).catch(err => {
+        console.warn('[DisplaySlot] stream frame encode failed', err);
+      }).finally(() => {
+        this._streamEncodePending = false;
+      });
     }, 1000);
   }
   stopStreaming() {
@@ -68224,9 +68550,34 @@ function applyDisplayStripState() {
     railRaf = requestAnimationFrame(renderWorkspace);
   }
 
-  function observe(element, options) {
+  // Self-feed filter: the 3 s getStats sampler writes the metrics chip and
+  // the 1 Hz presence-stream tick writes the frame-id chip — both INSIDE
+  // the observed container — so every sample re-rendered the whole rail
+  // forever, even on a tab the user wasn't looking at. Mutations that only
+  // touch those periodic chips are dropped here; every rail-visible state
+  // they correlate with (streaming class flips, status text, connection
+  // classes) still arrives through its own mutation. characterData records
+  // target TEXT nodes — classify by the parent element.
+  const RAIL_SELF_FEED_SELECTOR = '.display-live-metrics, .stream-frame-id';
+  function railMutationIgnored(record) {
+    const target = record.target;
+    const el = target.nodeType === 1 ? target : target.parentElement;
+    return Boolean(el && el.closest && el.closest(RAIL_SELF_FEED_SELECTOR));
+  }
+  function observe(element, options, filterSelfFeed = false) {
     if (!element) return;
-    new MutationObserver(scheduleWorkspace).observe(element, options);
+    if (!filterSelfFeed) {
+      new MutationObserver(scheduleWorkspace).observe(element, options);
+      return;
+    }
+    new MutationObserver((records) => {
+      for (const record of records) {
+        if (!railMutationIgnored(record)) {
+          scheduleWorkspace();
+          return;
+        }
+      }
+    }).observe(element, options);
   }
   // The observer catches legacy direct DOM writes without rebuilding the
   // rail. Keyed rows and stable authority/screen controls preserve focus;
@@ -68238,7 +68589,7 @@ function applyDisplayStripState() {
     characterData: true,
     attributes: true,
     attributeFilter: ['class', 'style', 'aria-pressed', 'disabled'],
-  });
+  }, true);
   observe(document.getElementById('station-peer-chips'), {
     subtree: true,
     childList: true,
@@ -72150,19 +72501,31 @@ async function* extractClipFrames(player, inSecs, outSecs, fps, keyframes, annot
     }
 
     const blob = await new Promise(r => captureCanvas.toBlob(r, 'image/jpeg', quality));
-    const b64 = await new Promise(r => {
-      const reader = new FileReader();
-      reader.onload = () => r(reader.result.split(',')[1]);
-      reader.readAsDataURL(blob);
-    });
+    // Raw bytes are the canonical yield: the tunnel lane uploads them
+    // directly, and only the legacy /ws payload and attach data-URLs
+    // derive base64 (clipFrameBase64) — the old per-frame FileReader
+    // base64 round-tripped 20-60 MB per clip through encode → decode.
+    const bytes = new Uint8Array(await blob.arrayBuffer());
 
-    yield { index: i, total: timestamps.length, t, isKeyframe, annotated: hasAnnotation, b64, blob };
+    yield { index: i, total: timestamps.length, t, isKeyframe, annotated: hasAnnotation, bytes, blob };
   }
+}
+
+// Base64 for the lanes that still speak it (legacy /ws media messages,
+// pending-attachment data URLs). Chunked conversion — see
+// dashboardControlBytesToBase64 (50-control-transport.js).
+function clipFrameBase64(frame) {
+  return dashboardControlBytesToBase64(frame.bytes);
 }
 
 async function generateClipPreview() {
   if (clipInSecs === null || clipOutSecs === null || !recPlayer) return;
   const strip = document.getElementById('clip-preview-strip');
+  // Revoke the previous preview's object URLs before discarding the DOM —
+  // innerHTML='' alone pinned every prior strip's frame blobs until unload.
+  strip.querySelectorAll('img[src^="blob:"]').forEach(img => {
+    try { URL.revokeObjectURL(img.src); } catch (_) {}
+  });
   strip.innerHTML = '';
   strip.classList.remove('hidden');
 
@@ -72277,17 +72640,8 @@ async function submitClip(action) {
       progressText.textContent = `Extracting ${frame.index + 1}/${frame.total}...`;
 
       const frameId = `${clipId}-f${String(frame.index).padStart(3, '0')}`;
-      const framePayload = {
-        t: 'clip_frame',
-        clip_id: clipId,
-        frame_id: frameId,
-        frame_index: frame.index,
-        timestamp_secs: frame.t,
-        is_keyframe: frame.isKeyframe,
-        annotated: frame.annotated,
-        data: frame.b64,
-      };
       if (useMediaTunnel) {
+        // Binary lane: raw bytes straight through — no base64 round trip.
         await uploadDashboardMediaTunnel('api_media_clip_frame', {
           clip_id: clipId,
           frame_id: frameId,
@@ -72295,12 +72649,21 @@ async function submitClip(action) {
           timestamp_secs: frame.t,
           is_keyframe: frame.isKeyframe,
           annotated: frame.annotated,
-        }, dashboardControlBase64ToBytes(frame.b64), 'clip frame');
+        }, frame.bytes, 'clip frame');
       } else {
-        sendLegacyMediaEditorMessage(framePayload);
+        sendLegacyMediaEditorMessage({
+          t: 'clip_frame',
+          clip_id: clipId,
+          frame_id: frameId,
+          frame_index: frame.index,
+          timestamp_secs: frame.t,
+          is_keyframe: frame.isKeyframe,
+          annotated: frame.annotated,
+          data: clipFrameBase64(frame),
+        });
       }
       if (action === 'attach') {
-        sentFrames.push({ frameId, b64: frame.b64 });
+        sentFrames.push({ frameId, b64: clipFrameBase64(frame) });
       }
       frameIndex++;
 
@@ -72981,6 +73344,10 @@ const contextViz = {
   rotationX: 0.34,
   rotationY: -0.48,
   zoom: 38,
+  // Identity of the analyzed snapshot + timeline shape the current Three
+  // scene was built from; contextBuildThree skips the teardown/rebuild
+  // when it matches (48b-context-viz.js).
+  sceneKey: '',
 };
 
 // analyzeContextSnapshot walks the entire raw payload, which is expensive at
@@ -73959,7 +74326,8 @@ function stepContextReplaySnapshot(delta) {
     contextReplayMode = 'replay';
     contextReplayIndexBySession.set(key, next);
     contextSelectedPartId = null;
-    renderContextPane();
+    // Coalesced like the slider: held arrow keys repeat faster than frames.
+    scheduleContextPaneRender();
   }
   return true;
 }
@@ -74060,7 +74428,11 @@ function wireContextPaneListeners() {
     contextReplayMode = 'replay';
     contextReplayIndexBySession.set(key, Math.max(0, Math.min(timeline.length - 1, Number(target.value) || 0)));
     contextSelectedPartId = null;
-    renderContextPane();
+    // rAF-coalesced: range inputs fire per pixel while dragging, and each
+    // distinct index is a different snapshot (full analyze + scene build).
+    // Intermediate positions within one frame render nothing the eye
+    // would have seen; the trailing frame shows the slider's final index.
+    scheduleContextPaneRender();
   });
   document.addEventListener('keydown', ev => {
     if (contextShouldHandleKeyboardEvent(ev)) {
@@ -74092,6 +74464,9 @@ function focusContextPart(partId) {
   contextUpdateMeshSelection();
   contextViz.zoom = Math.min(contextViz.zoom, 28);
   contextRenderThree();
+  // The bob loop runs only while a part is selected — (re)arm it here
+  // (it exits on deselect/tab-away by itself).
+  if (contextPaneVisible()) contextStartThreeAnimation();
 }
 
 function contextDisposeObject(object) {
@@ -74317,13 +74692,45 @@ function contextLabelSprite(text, color = CONTEXT_VIZ_THEME.labelText, scale = 1
   return sprite;
 }
 
+// Label sprites are the GPU-upload churn of a scene rebuild (2D-canvas text
+// rasterize + CanvasTexture upload per label). Text/color/scale triples
+// recur across rebuilds — category lane names, the timeline caption — so
+// cache the sprites and let contextClearThreeRoot detach them undisposed.
+// Eviction disposes only unparented sprites; one still in the scene loses
+// its cached flag instead, so the next root clear disposes it normally.
+const contextLabelSpriteCache = new Map();
+const CONTEXT_LABEL_SPRITE_CACHE_CAP = 96;
+function contextLabelSpriteCached(text, color = CONTEXT_VIZ_THEME.labelText, scale = 1) {
+  // labelBg is read inside contextLabelSprite - key on it too so a theme
+  // flip re-rasterizes instead of serving stale-background sprites.
+  const key = [text, color, scale, CONTEXT_VIZ_THEME.labelBg].join('\u001f');
+  let sprite = contextLabelSpriteCache.get(key);
+  if (sprite) {
+    contextLabelSpriteCache.delete(key);
+    contextLabelSpriteCache.set(key, sprite); // LRU bump
+    return sprite;
+  }
+  sprite = contextLabelSprite(text, color, scale);
+  sprite.userData.cachedLabel = true;
+  contextLabelSpriteCache.set(key, sprite);
+  while (contextLabelSpriteCache.size > CONTEXT_LABEL_SPRITE_CACHE_CAP) {
+    const [oldKey, old] = contextLabelSpriteCache.entries().next().value;
+    contextLabelSpriteCache.delete(oldKey);
+    if (old.parent) old.userData.cachedLabel = false;
+    else contextDisposeObject(old);
+  }
+  return sprite;
+}
+
 function contextClearThreeRoot() {
   if (!contextViz.root) return;
   for (const child of [...contextViz.root.children]) {
     contextViz.root.remove(child);
+    if (child.userData && child.userData.cachedLabel) continue;
     contextDisposeObject(child);
   }
   contextViz.meshes = [];
+  contextViz.sceneKey = '';
 }
 
 function contextPressureColor(pct) {
@@ -74336,8 +74743,30 @@ function contextBuildThree(analysis, snapshot) {
   const empty = document.getElementById('context-scene-empty');
   if (empty) empty.style.display = analysis && analysis.parts.length ? 'none' : 'flex';
   if (!contextInitThree()) return;
+  // Scene identity: analyzed snapshot + the timeline shape the rail bars
+  // render from (+ theme, whose colors bake into materials). Re-renders
+  // for the SAME scene — another session's context_snapshot arriving while
+  // this pane is visible, detail-pane churn, selection changes — used to
+  // tear down and rebuild every geometry, material, and label texture.
+  // Selection highlighting mutates in place (contextUpdateMeshSelection),
+  // so it deliberately stays out of the key.
+  const { timeline } = contextTimelineForForegroundSession();
+  const sceneKey = analysis && analysis.parts.length
+    ? [
+        contextRawRenderKey(snapshot),
+        timeline.length,
+        timeline.indexOf(snapshot),
+        CONTEXT_VIZ_THEME.labelBg,
+      ].join('|')
+    : 'empty';
+  if (contextViz.sceneKey === sceneKey && (sceneKey === 'empty' || contextViz.meshes.length)) {
+    contextUpdateMeshSelection();
+    contextRenderThree();
+    return;
+  }
   contextClearThreeRoot();
   if (!analysis || !analysis.parts.length) {
+    contextViz.sceneKey = 'empty';
     contextRenderThree();
     return;
   }
@@ -74354,7 +74783,7 @@ function contextBuildThree(analysis, snapshot) {
     lane.position.set(x, -0.06, 0);
     root.add(lane);
     const def = CONTEXT_CATEGORY_DEFS[category] || CONTEXT_CATEGORY_DEFS.other;
-    const label = contextLabelSprite(def.label, def.color, 1.25);
+    const label = contextLabelSpriteCached(def.label, def.color, 1.25);
     label.position.set(x, 0.65, -zSpread / 2 - 2.2);
     root.add(label);
   }
@@ -74412,16 +74841,15 @@ function contextBuildThree(analysis, snapshot) {
   );
   fill.position.set(reservoirX, fillHeight / 2, 0);
   root.add(fill);
-  const usageLabel = contextLabelSprite(`${Math.round(pct * 100)}% window`, contextPressureColor(pct), 1.1);
+  const usageLabel = contextLabelSpriteCached(`${Math.round(pct * 100)}% window`, contextPressureColor(pct), 1.1);
   usageLabel.position.set(reservoirX, reservoirHeight + 1.1, 0);
   root.add(usageLabel);
   if (hardWindow && hardWindow !== effectiveWindow) {
-    const hardLabel = contextLabelSprite('hard limit tracked', CONTEXT_VIZ_THEME.pressure.high, 0.9);
+    const hardLabel = contextLabelSpriteCached('hard limit tracked', CONTEXT_VIZ_THEME.pressure.high, 0.9);
     hardLabel.position.set(reservoirX, -0.2, 2.7);
     root.add(hardLabel);
   }
 
-  const { timeline } = contextTimelineForForegroundSession();
   if (timeline.length > 1) {
     const selectedIdx = timeline.indexOf(snapshot);
     const railWidth = Math.min(28, Math.max(10, timeline.length * 0.72));
@@ -74441,11 +74869,12 @@ function contextBuildThree(analysis, snapshot) {
       bar.position.set(x, barHeight / 2, zSpread / 2 + 3.6);
       root.add(bar);
     });
-    const railLabel = contextLabelSprite('session replay timeline', CONTEXT_VIZ_THEME.railLabel, 1.0);
+    const railLabel = contextLabelSpriteCached('session replay timeline', CONTEXT_VIZ_THEME.railLabel, 1.0);
     railLabel.position.set(0, 5.6, zSpread / 2 + 3.6);
     root.add(railLabel);
   }
 
+  contextViz.sceneKey = sceneKey;
   contextUpdateMeshSelection();
   contextRenderThree();
 }
@@ -74493,10 +74922,12 @@ function contextRenderThree(time = 0) {
   if (contextViz.root) {
     contextViz.root.rotation.set(0, 0, 0);
   }
-  if (time && contextViz.meshes.length) {
+  if (contextViz.meshes.length) {
     const t = time * 0.001;
     for (const mesh of contextViz.meshes) {
-      const selected = mesh.userData.partId === contextSelectedPartId;
+      // On-demand renders pass time=0: settle every mesh at its base so a
+      // retired bob loop can't strand the previously-selected mesh mid-arc.
+      const selected = time && mesh.userData.partId === contextSelectedPartId;
       if (selected) {
         mesh.position.y = mesh.userData.baseY + Math.sin(t * 3.2) * 0.08;
       } else {
@@ -74507,13 +74938,25 @@ function contextRenderThree(time = 0) {
   contextViz.renderer.render(contextViz.scene, contextViz.camera);
 }
 
+// The only per-frame animation is the selected-part bob — with nothing
+// selected the scene is static and every interaction (drag, zoom, snapshot,
+// slider) already renders on demand, so the 60 fps loop only runs while a
+// part is selected and stops itself on deselect/tab-away (with one settling
+// render so the bob doesn't freeze mid-arc).
 function contextStartThreeAnimation() {
+  if (!contextSelectedPartId) {
+    contextStopThreeAnimation();
+    contextRenderThree();
+    return;
+  }
   if (contextViz.raf) return;
   const frame = time => {
     contextViz.raf = null;
-    if (activeTab === 'activity' && activeActivitySubtab === 'context') {
+    if (activeTab === 'activity' && activeActivitySubtab === 'context' && contextSelectedPartId) {
       contextRenderThree(time);
       contextViz.raf = requestAnimationFrame(frame);
+    } else {
+      contextRenderThree();
     }
   };
   contextViz.raf = requestAnimationFrame(frame);
@@ -75117,6 +75560,22 @@ async function refreshVirtualDisplayAvailability() {
     }
   }
   updateVirtualDisplayAvailabilityUi();
+}
+
+// Coalesced twin for PROGRESS-driven callers (per-chunk response/byte-stream
+// frames). dashboardUpdateTransportStatus rebuilds the full debugStatus
+// object, re-renders four target summaries, and refreshes several dependent
+// surfaces — running that per 16 KiB chunk burned ~0.3–1 ms of main thread
+// per chunk on large pulls. Steady-state progress coalesces into one
+// trailing 100 ms tick; state TRANSITIONS (open/close/error, stream
+// start/end/complete/reject) keep calling the immediate form.
+let dashboardTransportStatusTickTimer = 0;
+function dashboardScheduleTransportStatusUpdate() {
+  if (dashboardTransportStatusTickTimer) return;
+  dashboardTransportStatusTickTimer = window.setTimeout(() => {
+    dashboardTransportStatusTickTimer = 0;
+    dashboardUpdateTransportStatus();
+  }, 100);
 }
 
 function dashboardUpdateTransportStatus() {
@@ -77577,7 +78036,11 @@ class DashboardControlTransport {
         return;
       }
       if (dashboardServerMessageDispatcher) {
-        dashboardServerMessageDispatcher(JSON.stringify(msg));
+        // Pass the already-parsed frame: the dispatcher and the WASM
+        // handoff accept objects (the tunnel event path below has always
+        // passed payload objects) — re-stringifying here forced a
+        // parse → stringify → parse round trip per PTY output frame.
+        dashboardServerMessageDispatcher(msg);
       }
       return;
     }
@@ -77710,7 +78173,9 @@ class DashboardControlTransport {
     if (!completed && this.chunkedResponses.has(chunkKey)) {
       this.sendChunkCredit(id, 1, chunkKey === id ? null : chunkKey);
     }
-    dashboardUpdateTransportStatus();
+    // Per-chunk progress: coalesced tick. Completion/rejection inside
+    // maybeCompleteChunkedResponse already rendered immediately.
+    dashboardScheduleTransportStatusUpdate();
   }
 
   handleResponseEnd(msg) {
@@ -77841,7 +78306,8 @@ class DashboardControlTransport {
     if (!completed && this.byteStreams.has(streamId)) {
       this.sendChunkCredit(id, 1, streamId === id ? null : streamId);
     }
-    dashboardUpdateTransportStatus();
+    // Per-chunk progress: coalesced tick (transitions render immediately).
+    dashboardScheduleTransportStatusUpdate();
   }
 
   handleByteStreamEnd(msg) {
@@ -78902,11 +79368,14 @@ function dashboardControlBase64ToBytes(value) {
 }
 
 function dashboardControlBytesToBase64(bytes) {
-  let binary = '';
-  for (let i = 0; i < bytes.byteLength; i += 1) {
-    binary += String.fromCharCode(bytes[i]);
+  // Batch via fromCharCode.apply over bounded slices: the per-byte string
+  // concatenation this replaces built ~16k intermediate strings per upload
+  // chunk. 0x8000 stays comfortably under engine argument-count limits.
+  const chunks = [];
+  for (let i = 0; i < bytes.byteLength; i += 0x8000) {
+    chunks.push(String.fromCharCode.apply(null, bytes.subarray(i, i + 0x8000)));
   }
-  return btoa(binary);
+  return btoa(chunks.join(''));
 }
 
 function dashboardControlRequestTimeoutMs(method) {
@@ -80061,6 +80530,23 @@ async function fetchRemoteAgentCard(baseUrl) {
   return card;
 }
 
+// Last-rendered snapshot guards: peer status flips (idle↔working) arrive per
+// remote task activity and used to rebuild the whole daemons list — plus a
+// seven-surface cascade (host filter sweep over up to 10k log entries, three
+// select rebuilds) — even when nothing rendered had changed. The row HTML is
+// its own signature for the list; the pickers' inputs (id/label/connected)
+// get a dedicated one so a mid-row change (e.g. version skew) doesn't churn
+// the selects.
+let daemonsListHostOptionsSig = null;
+
+function daemonsListHostOptionsSignature() {
+  return JSON.stringify([
+    selfPeerId,
+    selfHostLabel,
+    ...daemons.map(d => [d.host_id, d.label || '', d.connected !== false]),
+  ]);
+}
+
 function renderDaemonsList() {
   const el = document.getElementById('daemons-list');
   if (!el) return;
@@ -80079,7 +80565,16 @@ function renderDaemonsList() {
   for (const d of daemons) {
     rows.push(renderDaemonRow(d, false));
   }
-  el.innerHTML = rows.join('');
+  const html = rows.join('');
+  if (el.__intendantRenderedHtml === html) {
+    // Identical rendered list: the existing DOM (with its listeners,
+    // expansion state, approvals section, and attached display panes)
+    // stays — skip straight to the cheap always-on consumers below.
+    renderDaemonsListTail();
+    return;
+  }
+  el.__intendantRenderedHtml = html;
+  el.innerHTML = html;
 
   // Wire remove buttons.
   el.querySelectorAll('.daemon-row .remove-btn').forEach(btn => {
@@ -80159,8 +80654,19 @@ function renderDaemonsList() {
   // attached to the freshly-rendered <video> elements after re-render.
   reapplyPeerDisplayPanes();
 
+  renderDaemonsListTail();
+}
+
+// The always-on consumers of a daemons-list render — run on every call,
+// whether or not the row DOM was rebuilt. The four host pickers rebuild
+// only when their actual inputs changed (see daemonsListHostOptionsSig):
+// refreshHostFilterOptions ends in applyHostFilter, a class-toggle sweep
+// over every retained log entry, and each picker resets its <select>.
+function renderDaemonsListTail() {
   // Keep the Station header's peer-display chips in sync with the same
-  // peer add/remove/state events that re-render this list.
+  // peer add/remove/state events that re-render this list. Cheap
+  // (replaceChildren over a handful of peers) and display lists aren't
+  // fully encoded in the row HTML, so this stays unconditional.
   stationRenderPeerChips();
 
   // Toggle host-badge visibility in the Activity tab. Single-host
@@ -80170,18 +80676,23 @@ function renderDaemonsList() {
     logStream.classList.toggle('show-host-badges', daemons.length > 0);
   }
 
-  // Keep the Activity host filter dropdown in sync with the current
-  // daemon list (options may have been added/removed).
-  refreshHostFilterOptions();
+  const optionsSig = daemonsListHostOptionsSignature();
+  if (daemonsListHostOptionsSig !== optionsSig) {
+    daemonsListHostOptionsSig = optionsSig;
 
-  // Same for the Stats tab host picker.
-  refreshStatsHostPicker();
+    // Keep the Activity host filter dropdown in sync with the current
+    // daemon list (options may have been added/removed).
+    refreshHostFilterOptions();
 
-  // Same for the Files tab download source selector.
-  refreshFilesDownloadHostOptions();
+    // Same for the Stats tab host picker.
+    refreshStatsHostPicker();
 
-  // Same for the Terminal Shell target selector.
-  refreshShellHostOptions();
+    // Same for the Files tab download source selector.
+    refreshFilesDownloadHostOptions();
+
+    // Same for the Terminal Shell target selector.
+    refreshShellHostOptions();
+  }
 
   // Target summaries reuse the same daemon list and should track
   // add/remove/offline transitions immediately.
@@ -89465,6 +89976,11 @@ function filesTransferPersistable(transfer) {
 }
 
 function filesTransferPersistState() {
+  // A direct persist supersedes any scheduled one.
+  if (filesTransferPersistTimer) {
+    clearTimeout(filesTransferPersistTimer);
+    filesTransferPersistTimer = 0;
+  }
   try {
     const state = filesTransfers
       .map(filesTransferPersistable)
@@ -89475,6 +89991,24 @@ function filesTransferPersistState() {
     console.warn('Persist transfer state failed:', err);
   }
 }
+
+// Trailing-throttled twin for the per-chunk progress paths: a fast LAN
+// download lands ~50 chunks/s, and each chunk used to JSON.stringify up to
+// 50 transfer records into a synchronous localStorage.setItem. Progress
+// coalesces to ≤1 write/s; status transitions keep the immediate form, and
+// chunk-level resume state already lives durably in IndexedDB (losing ≤1 s
+// of rangeCount on a crash just re-fetches that tail on resume).
+let filesTransferPersistTimer = 0;
+function filesTransferPersistStateSoon() {
+  if (filesTransferPersistTimer) return;
+  filesTransferPersistTimer = window.setTimeout(() => {
+    filesTransferPersistTimer = 0;
+    filesTransferPersistState();
+  }, 1000);
+}
+window.addEventListener('pagehide', () => {
+  if (filesTransferPersistTimer) filesTransferPersistState();
+});
 
 function restoreFilesTransferState() {
   let state = [];
@@ -90027,74 +90561,143 @@ function renderFilesTransfers() {
     renderFilesTransfersNow();
   });
 }
+// Keyed rows, patched in place. The rAF-coalesced full rebuild above still
+// rebuilt EVERY row — titles, meters, fresh action buttons for ~100 history
+// entries — per animation frame during a fast download. A row's structure
+// (status classes, actions, title) rebuilds only when its structure
+// signature moves; per-chunk progress patches just the meta text and meter
+// width on the existing nodes.
+const filesTransferRowCache = new Map(); // transfer.id → { row, meta, fill, sig }
+
+function filesTransferRowStructureSig(transfer) {
+  return [
+    transfer.status || 'queued',
+    transfer.kind || '',
+    transfer.serverJobId || transfer.resumeToken ? 'server' : '',
+    filesTransferTitle(transfer),
+    transfer.sourceLabel || transfer.path || transfer.file?.name || '',
+    transfer.error || '',
+    transfer.destination || '',
+    // Action-set inputs beyond status/kind:
+    (transfer.kind !== 'upload' || transfer.file || transfer.uploadBlobStored) ? 'resumable-upload' : '',
+    transfer.loaded > 0 ? 'has-progress' : '',
+    transfer.result?.blob ? 'has-blob' : '',
+    transfer.rangeCount > 0 ? 'has-ranges' : '',
+  ].join('|');
+}
+
+function filesTransferRowMetaText(transfer) {
+  const direction = transfer.kind === 'upload' ? 'upload' : 'download';
+  const range = transfer.kind === 'download' && transfer.rangeCount
+    ? ` · ${transfer.rangeCount} range${transfer.rangeCount === 1 ? '' : 's'}`
+    : '';
+  const error = transfer.error ? ` · ${transfer.error}` : '';
+  const destination = transfer.kind === 'upload' && transfer.destination ? ` · ${transfer.destination}` : '';
+  const sourceText = transfer.kind === 'download' ? (transfer.sourceLabel || transfer.path || '') : '';
+  const source = sourceText ? ` · ${sourceText}` : '';
+  return `${direction} · ${filesTransferStatusLabel(transfer.status)} · ${filesTransferProgressText(transfer)}${range}${destination}${source}${error}`;
+}
+
+function filesTransferMeterWidth(transfer) {
+  const total = Number(transfer.totalSize || transfer.file?.size || 0);
+  const loaded = Number(transfer.loaded || 0);
+  return total > 0 ? `${Math.max(0, Math.min(100, loaded * 100 / total))}%` : '0%';
+}
+
+function buildFilesTransferRow(transfer) {
+  const row = document.createElement('div');
+  row.className = `files-transfer-row ${transfer.status || 'queued'}${transfer.serverJobId || transfer.resumeToken ? ' server' : ''}`;
+  row.dataset.transferId = transfer.id;
+  const main = document.createElement('div');
+  main.className = 'files-transfer-main';
+  const title = document.createElement('div');
+  title.className = 'files-transfer-title';
+  title.textContent = filesTransferTitle(transfer);
+  title.title = transfer.sourceLabel || transfer.path || transfer.file?.name || '';
+  const meta = document.createElement('div');
+  meta.className = 'files-transfer-meta';
+  meta.textContent = filesTransferRowMetaText(transfer);
+  const meter = document.createElement('div');
+  meter.className = 'files-transfer-meter';
+  const fill = document.createElement('div');
+  fill.className = 'files-transfer-meter-fill';
+  fill.style.width = filesTransferMeterWidth(transfer);
+  meter.appendChild(fill);
+  main.append(title, meta, meter);
+  const actions = document.createElement('div');
+  actions.className = 'files-transfer-actions';
+  const addAction = (label, handler, className = '') => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = label;
+    btn.className = className ? `ui-btn ${className}` : 'ui-btn';
+    btn.addEventListener('click', () => handler(transfer.id));
+    actions.appendChild(btn);
+  };
+  const canResumeUpload = transfer.kind !== 'upload' || transfer.file || transfer.uploadBlobStored;
+  if (transfer.status === 'running' && transfer.kind === 'download') addAction('Pause', pauseFilesTransfer);
+  if (transfer.status === 'running') addAction('Cancel', cancelFilesTransfer, 'danger');
+  if (transfer.status === 'queued') addAction('Cancel', cancelFilesTransfer, 'danger');
+  if (transfer.status === 'paused' && canResumeUpload) addAction('Resume', resumeFilesTransfer);
+  if (transfer.status === 'failed' && transfer.kind === 'download' && transfer.loaded > 0) addAction('Resume', resumeFilesTransfer);
+  if (['failed', 'cancelled'].includes(transfer.status)) addAction('Retry', retryFilesTransfer);
+  if (transfer.status === 'completed' && transfer.kind === 'download' && transfer.result?.blob) {
+    addAction('Save', () => downloadDashboardBlob(transfer.result.blob, transfer.result.filename, transfer.result.content_type));
+  } else if (transfer.status === 'completed' && transfer.kind === 'download' && transfer.rangeCount > 0) {
+    addAction('Save', saveCompletedFilesDownload);
+  }
+  row.append(main, actions);
+  return { row, meta, fill };
+}
+
 function renderFilesTransfersNow() {
   pruneFinishedFilesTransfers();
   const list = document.getElementById('files-transfer-list');
   if (!list) return;
-  list.innerHTML = '';
   if (filesTransfers.length === 0) {
-    const empty = document.createElement('div');
-    empty.className = 'files-transfer-empty ui-empty compact';
-    empty.innerHTML = '<div class="ui-empty-title">No transfers</div>' +
-      '<div class="ui-empty-hint">Downloads and uploads show up here with live progress.</div>';
-    list.appendChild(empty);
+    filesTransferRowCache.clear();
+    if (!list.querySelector('.files-transfer-empty')) {
+      list.innerHTML = '';
+      const empty = document.createElement('div');
+      empty.className = 'files-transfer-empty ui-empty compact';
+      empty.innerHTML = '<div class="ui-empty-title">No transfers</div>' +
+        '<div class="ui-empty-hint">Downloads and uploads show up here with live progress.</div>';
+      list.appendChild(empty);
+    }
     return;
   }
-  for (const transfer of filesTransfers) {
-    const row = document.createElement('div');
-    row.className = `files-transfer-row ${transfer.status || 'queued'}${transfer.serverJobId || transfer.resumeToken ? ' server' : ''}`;
-    row.dataset.transferId = transfer.id;
-    const main = document.createElement('div');
-    main.className = 'files-transfer-main';
-    const title = document.createElement('div');
-    title.className = 'files-transfer-title';
-    title.textContent = filesTransferTitle(transfer);
-    title.title = transfer.sourceLabel || transfer.path || transfer.file?.name || '';
-    const meta = document.createElement('div');
-    meta.className = 'files-transfer-meta';
-    const direction = transfer.kind === 'upload' ? 'upload' : 'download';
-    const range = transfer.kind === 'download' && transfer.rangeCount
-      ? ` · ${transfer.rangeCount} range${transfer.rangeCount === 1 ? '' : 's'}`
-      : '';
-    const error = transfer.error ? ` · ${transfer.error}` : '';
-    const destination = transfer.kind === 'upload' && transfer.destination ? ` · ${transfer.destination}` : '';
-    const sourceText = transfer.kind === 'download' ? (transfer.sourceLabel || transfer.path || '') : '';
-    const source = sourceText ? ` · ${sourceText}` : '';
-    meta.textContent = `${direction} · ${filesTransferStatusLabel(transfer.status)} · ${filesTransferProgressText(transfer)}${range}${destination}${source}${error}`;
-    const meter = document.createElement('div');
-    meter.className = 'files-transfer-meter';
-    const fill = document.createElement('div');
-    fill.className = 'files-transfer-meter-fill';
-    const total = Number(transfer.totalSize || transfer.file?.size || 0);
-    const loaded = Number(transfer.loaded || 0);
-    fill.style.width = total > 0 ? `${Math.max(0, Math.min(100, loaded * 100 / total))}%` : '0%';
-    meter.appendChild(fill);
-    main.append(title, meta, meter);
-    const actions = document.createElement('div');
-    actions.className = 'files-transfer-actions';
-    const addAction = (label, handler, className = '') => {
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.textContent = label;
-      btn.className = className ? `ui-btn ${className}` : 'ui-btn';
-      btn.addEventListener('click', () => handler(transfer.id));
-      actions.appendChild(btn);
-    };
-    const canResumeUpload = transfer.kind !== 'upload' || transfer.file || transfer.uploadBlobStored;
-    if (transfer.status === 'running' && transfer.kind === 'download') addAction('Pause', pauseFilesTransfer);
-    if (transfer.status === 'running') addAction('Cancel', cancelFilesTransfer, 'danger');
-    if (transfer.status === 'queued') addAction('Cancel', cancelFilesTransfer, 'danger');
-    if (transfer.status === 'paused' && canResumeUpload) addAction('Resume', resumeFilesTransfer);
-    if (transfer.status === 'failed' && transfer.kind === 'download' && transfer.loaded > 0) addAction('Resume', resumeFilesTransfer);
-    if (['failed', 'cancelled'].includes(transfer.status)) addAction('Retry', retryFilesTransfer);
-    if (transfer.status === 'completed' && transfer.kind === 'download' && transfer.result?.blob) {
-      addAction('Save', () => downloadDashboardBlob(transfer.result.blob, transfer.result.filename, transfer.result.content_type));
-    } else if (transfer.status === 'completed' && transfer.kind === 'download' && transfer.rangeCount > 0) {
-      addAction('Save', saveCompletedFilesDownload);
+  list.querySelector('.files-transfer-empty')?.remove();
+  const liveIds = new Set(filesTransfers.map(t => t.id));
+  for (const [id, record] of filesTransferRowCache) {
+    if (!liveIds.has(id)) {
+      record.row.remove();
+      filesTransferRowCache.delete(id);
     }
-    row.append(main, actions);
-    list.appendChild(row);
   }
+  const orderedRows = [];
+  for (const transfer of filesTransfers) {
+    const sig = filesTransferRowStructureSig(transfer);
+    let record = filesTransferRowCache.get(transfer.id);
+    if (!record || record.sig !== sig) {
+      const built = buildFilesTransferRow(transfer);
+      if (record) record.row.replaceWith(built.row);
+      record = { ...built, sig };
+      filesTransferRowCache.set(transfer.id, record);
+    } else {
+      // Progress-only tick: meta text + meter width, guarded writes.
+      const metaText = filesTransferRowMetaText(transfer);
+      if (record.meta.textContent !== metaText) record.meta.textContent = metaText;
+      const width = filesTransferMeterWidth(transfer);
+      if (record.fill.style.width !== width) record.fill.style.width = width;
+    }
+    orderedRows.push(record.row);
+  }
+  // Reconcile order/membership only when it actually changed — moving
+  // nodes re-appends them (listeners survive, but focus does not).
+  const currentRows = Array.from(list.children).filter(el => el.classList.contains('files-transfer-row'));
+  const orderMatches = currentRows.length === orderedRows.length &&
+    currentRows.every((el, i) => el === orderedRows[i]);
+  if (!orderMatches) list.replaceChildren(...orderedRows);
 }
 
 function filesUpdateActiveDownloadSummary(transfer = null) {
@@ -90202,6 +90805,11 @@ function queueDashboardArtifactDownload(artifact, options = {}) {
 }
 
 function resetFilesDownloadTransfer(transfer) {
+  // Capture before zeroing: the persisted rangeCount bounds the IndexedDB
+  // cleanup — the unconditional 512 default issued up to 512 sequential
+  // no-op deletes per reset (IDB delete succeeds on missing keys, so the
+  // early-break never fired).
+  const rangeCount = Number(transfer.rangeCount || 0) || 512;
   transfer.loaded = 0;
   transfer.totalSize = 0;
   transfer.parts = [];
@@ -90214,7 +90822,7 @@ function resetFilesDownloadTransfer(transfer) {
   transfer.cancelRequested = false;
   transfer.abortController = null;
   transfer.debugFailedOnce = false;
-  filesTransferDeleteDownloadParts(transfer.id, 512);
+  filesTransferDeleteDownloadParts(transfer.id, rangeCount);
   filesTransferPersistState();
 }
 
@@ -90418,7 +91026,7 @@ async function runFilesDownloadTransfer(transfer) {
       transfer.parts.push(range.bytes);
       transfer.loaded = range.rangeEnd;
       transfer.rangeCount += 1;
-      filesTransferPersistState();
+      filesTransferPersistStateSoon();
       if (typeof transfer.onProgress === 'function') {
         transfer.onProgress({
           loaded: transfer.loaded,
@@ -90475,7 +91083,6 @@ function settleCompletedFilesDownload(transfer, { resumable }) {
   const result = {
     ok: true,
     blob,
-    parts: transfer.parts.slice(),
     filename: transfer.filename || 'download.bin',
     content_type: transfer.contentType,
     size: blob.size,
@@ -90485,6 +91092,14 @@ function settleCompletedFilesDownload(transfer, { resumable }) {
     range_count: transfer.rangeCount,
     resumable,
   };
+  // Drop the raw chunk arrays now that the Blob owns a snapshot of the
+  // bytes: keeping transfer.parts (plus a second result.parts copy of the
+  // same references) pinned the entire download in JS heap for as long as
+  // the terminal transfer sat in history — one 512 MB download held ~1 GB
+  // until reload. The chunks are durably in IndexedDB; Save-after-eviction
+  // rehydrates through filesTransferLoadDownloadParts, and completion
+  // consumers read result.blob, which stays.
+  transfer.parts = [];
   transfer.result = result;
   filesTransferTransition(transfer, 'completed', { actor: 'runner', result });
   setFilesDownloadProgress(result.size, result.total_size || result.size);
@@ -90847,7 +91462,7 @@ async function runFilesFilesystemUploadTransfer(transfer, controller) {
     filesTransferApplyServerJob(transfer, result.body.job);
     transfer.loaded = Math.max(Number(transfer.loaded || 0), end);
     transfer.uploadChunkCount = Number(transfer.uploadChunkCount || 0) + 1;
-    filesTransferPersistState();
+    filesTransferPersistStateSoon();
     renderFilesTransfers();
     setFilesUploadStatus('warn', `Uploading ${filesTransferProgressText(transfer)}`);
     if (
@@ -91776,20 +92391,10 @@ function renderFilesIdeTree() {
     );
   }
   container.innerHTML = html.join('') || '<div class="files-ide-tree-notice">Empty directory</div>';
-  container.querySelectorAll('.files-ide-tree-row').forEach(rowEl => {
-    const path = rowEl.dataset.path || '';
-    const isDir = rowEl.dataset.dir === '1';
-    const open = () => (isDir ? filesIdeToggleDir(path) : filesIdeOpenFile(filesIdeSelectedHostId(), path));
-    rowEl.addEventListener('click', ev => {
-      if (ev.target.closest('.files-ide-row-act')) return;
-      state.focusedPath = path; // keep the roving tab stop on the clicked row
-      open();
-    });
-    // Keyboard activation (Enter/Space) rides the delegated container
-    // listener (filesIdeTreeKeydown), not a per-row handler.
-    rowEl.querySelector('[data-act="rename"]')?.addEventListener('click', () => filesIdeBeginRename(path, isDir));
-    rowEl.querySelector('[data-act="delete"]')?.addEventListener('click', () => filesIdeDeleteRequested(path, isDir));
-  });
+  // Row and action clicks ride ONE delegated container listener
+  // (filesIdeTreeClick), exactly like keydown always has — the per-row
+  // wiring this replaces attached three fresh listeners per row on every
+  // rebuild (each expand/collapse/arrow-key near the 500-entry cap).
   // Re-renders triggered from the keyboard (expand/collapse/arming) must
   // not dump focus onto <body>: put it back on the roving row. The create
   // and rename inputs are focused below and win when present.
@@ -91908,11 +92513,37 @@ function filesIdeTreeKeydown(ev) {
   ev.preventDefault();
 }
 
+// Delegated click twin of filesIdeTreeKeydown: rows are re-rendered
+// wholesale via innerHTML, so per-row listeners cost three attaches per row
+// per render. Same guards as the old per-row handlers — action buttons
+// resolve before the row, and clicks inside create/rename inputs fall
+// through to the fields.
+function filesIdeTreeClick(ev) {
+  const target = ev.target instanceof Element ? ev.target : null;
+  if (!target || target.closest('input, textarea')) return;
+  const row = target.closest('.files-ide-tree-row');
+  if (!row) return;
+  const path = row.dataset.path || '';
+  const isDir = row.dataset.dir === '1';
+  const act = target.closest('.files-ide-row-act');
+  if (act) {
+    if (act.dataset.act === 'rename') filesIdeBeginRename(path, isDir);
+    else if (act.dataset.act === 'delete') filesIdeDeleteRequested(path, isDir);
+    return;
+  }
+  const state = filesIdeTreeState(filesIdeSelectedHostId());
+  state.focusedPath = path; // keep the roving tab stop on the clicked row
+  if (isDir) filesIdeToggleDir(path);
+  else filesIdeOpenFile(filesIdeSelectedHostId(), path);
+}
+
 // The container survives renders (only its innerHTML is rebuilt), so this
 // attaches exactly once. DOMContentLoaded per the shared-module-script
 // convention for wiring.
 document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('files-ide-tree')?.addEventListener('keydown', filesIdeTreeKeydown);
+  const tree = document.getElementById('files-ide-tree');
+  tree?.addEventListener('keydown', filesIdeTreeKeydown);
+  tree?.addEventListener('click', filesIdeTreeClick);
 });
 
 function filesIdeBeginCreate(kind) {

--- a/static/app.html
+++ b/static/app.html
@@ -28105,7 +28105,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '01176a9b40d476e2';
+const INTENDANT_APP_BUILD = 'a4a0530f37ba73a3';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -38604,6 +38604,13 @@ async function stationOpenTranscript(sessionId, opts = {}) {
   ).trim() || 'intendant';
   const label = stationSessionTask(session) || shortSessionId(sid);
   if (!opts.refresh) stationStatus(`Loading transcript ${shortSessionId(sid)}`);
+  // Settle-edge seed, sampled SYNCHRONOUSLY before the detail fetch: the
+  // phase can flip idle during the await, and seeding from the post-await
+  // value would record an open-while-active session as never-active —
+  // silently skipping its one settling refetch.
+  const phaseAtOpen = String(
+    (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(sid)?.phase) || ''
+  );
   let payload;
   try {
     const data = await fetchSessionDetailPayload(sid, { source, limit: 300 });
@@ -38632,13 +38639,8 @@ async function stationOpenTranscript(sessionId, opts = {}) {
     console.warn('station set_transcript rejected:', err);
   }
   if (accepted) {
-    // Seed the settle-edge tracker from the phase at open, so a session
-    // that goes inactive before the first poll evaluation still gets its
-    // one final refetch (stationMaybeRefreshTranscript maintains it from
-    // here on).
-    const phaseAtOpen = String(
-      (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(sid)?.phase) || ''
-    );
+    // Seed the settle-edge tracker from the pre-fetch phase sample above;
+    // stationMaybeRefreshTranscript maintains it from here on.
     stationTranscriptLive = {
       sessionId: sid,
       source,
@@ -38661,6 +38663,16 @@ async function stationOpenTranscript(sessionId, opts = {}) {
 function stationMaybeRefreshTranscript(force = false) {
   const live = stationTranscriptLive;
   if (!live || !stationRenderedPrimaryActive()) return;
+  // Observe the phase on EVERY call, BEFORE the fetch throttles below can
+  // return: arming is set-only here, so a short turn that starts and
+  // settles entirely inside the 8 s age window (whose calls all early-out
+  // below) still arms the settle edge. The grant is consumed only at an
+  // actual fetch decision, never by an early return.
+  const phase = String(
+    (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(live.sessionId)?.phase) || ''
+  );
+  const inactive = phase === 'idle' || phase === 'done' || phase === 'interrupted';
+  if (phase && !inactive) live.lastActivePhaseSeen = true;
   const age = Date.now() - live.fetchedAt;
   if (!force && age < 1500) return;
   const key = stationLatestEventKeyForSession(live.sessionId);
@@ -38669,22 +38681,16 @@ function stationMaybeRefreshTranscript(force = false) {
   // Idle-arm gate: the ~8 s fallback exists for sessions whose output
   // never surfaces in the activity stream — but when the stream key is
   // UNCHANGED and the session itself reports an inactive phase, there is
-  // nothing new to fetch. One exception, tracked via lastActivePhaseSeen:
+  // nothing new to fetch. One exception, the settle edge armed above:
   // output that lands transcript-only just before the phase settles would
   // otherwise never be fetched (key unchanged forever + phase now
-  // inactive), so the active→inactive TRANSITION grants exactly one final
-  // refetch before the gate parks. Unknown phase keeps the old fallback
-  // cadence (fail open).
-  const phase = String(
-    (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(live.sessionId)?.phase) || ''
-  );
-  const inactive = phase === 'idle' || phase === 'done' || phase === 'interrupted';
+  // inactive), so an observed active→inactive transition grants exactly
+  // one final refetch before the gate parks. Unknown phase keeps the old
+  // fallback cadence (fail open).
   if (inactive) {
     const settleEdge = live.lastActivePhaseSeen === true;
     live.lastActivePhaseSeen = false;
     if (!force && !settleEdge && key === live.lastEventKey) return;
-  } else if (phase) {
-    live.lastActivePhaseSeen = true;
   }
   live.fetchedAt = Date.now();
   live.lastEventKey = key;
@@ -65373,6 +65379,24 @@ const DISPLAY_SLOT_POLICY = {
   },
 };
 
+// Presence-stream generations, keyed by DISPLAY id at module level — not on
+// the slot instance. A removed display slot can be re-granted as a brand-new
+// DisplaySlot object whose stream reuses the same display_N identity; an
+// instance-local counter would let the old object's in-flight encode pass
+// its own generation check and emit stale pre-teardown pixels into the new
+// slot's stream. Bumped on every stream start AND on removeDisplaySlot;
+// completions compare against this map.
+const displayStreamGenerations = new Map();
+function displayStreamGeneration(displayId) {
+  return displayStreamGenerations.get(Number(displayId) || 0) || 0;
+}
+function bumpDisplayStreamGeneration(displayId) {
+  const id = Number(displayId) || 0;
+  const next = (displayStreamGenerations.get(id) || 0) + 1;
+  displayStreamGenerations.set(id, next);
+  return next;
+}
+
 class DisplaySlot {
   constructor(displayId, width, height) {
     this.displayId = displayId;
@@ -65442,10 +65466,6 @@ class DisplaySlot {
     this._streamCanvas = document.createElement('canvas');
     this._hqStreamCanvas = document.createElement('canvas');
     this._streamEncodePending = false;
-    // Monotonic per-start stream generation: a late async encode from
-    // generation N must never emit into (or clobber the pending flag of)
-    // generation N+1 after a quick stop→start.
-    this._streamGeneration = 0;
     this._focusResizeObserver = null;
     this._boundHandlers = {};
     this._fullscreenInertRecords = [];
@@ -66635,12 +66655,13 @@ class DisplaySlot {
   startStreaming() {
     if (this.streaming || !this.connected) return;
     this.streaming = true;
-    // New generation: late completions from a previous run compare against
-    // this and drop; the pending flag belongs to the new run (a leftover
-    // true from a stopped run must not eat the first ticks).
-    this._streamGeneration += 1;
+    // New generation for this DISPLAY id (module-level; see the map above):
+    // late completions from a previous run — same slot object or a removed
+    // predecessor — compare against it and drop; the pending flag belongs
+    // to the new run (a leftover true from a stopped run must not eat the
+    // first ticks).
+    const gen = bumpDisplayStreamGeneration(this.displayId);
     this._streamEncodePending = false;
-    const gen = this._streamGeneration;
     this.streamBtn.classList.add('active');
     this.streamBtn.setAttribute('aria-pressed', 'true');
     this.streamBtn.innerHTML = '&#x1F441; Streaming';
@@ -66673,9 +66694,10 @@ class DisplaySlot {
         DisplaySlot._canvasJpegBase64(this._streamCanvas, 0.8),
         DisplaySlot._canvasJpegBase64(this._hqStreamCanvas, 0.80),
       ]).then(([liveB64, hqB64]) => {
-        // Restarted since capture: these pixels belong to the retired
-        // sequence — never emit them into the new one.
-        if (gen !== this._streamGeneration) return;
+        // Restarted since capture — by this slot object, or by a new slot
+        // re-granted the same display id after this one was removed: these
+        // pixels belong to the retired sequence, never emit them.
+        if (gen !== displayStreamGeneration(this.displayId)) return;
         // Stopped (not restarted): the frame captured pre-stop pixels —
         // still deliver it (it is the stream's final frame), but leave the
         // torn-down chrome (frame-id chip) alone.
@@ -66703,9 +66725,9 @@ class DisplaySlot {
       }).catch(err => {
         console.warn('[DisplaySlot] stream frame encode failed', err);
       }).finally(() => {
-        // Only this generation may clear its own pending flag — a late
+        // Only the live generation may clear its own pending flag — a late
         // completion must not unblock (or race) a restarted stream's ticks.
-        if (gen === this._streamGeneration) this._streamEncodePending = false;
+        if (gen === displayStreamGeneration(this.displayId)) this._streamEncodePending = false;
       });
     }, 1000);
   }
@@ -66977,6 +66999,11 @@ function removeDisplaySlot(displayId) {
   slot.disconnect({ userInitiated: true });
   if (slot.el && slot.el.parentNode) slot.el.parentNode.removeChild(slot.el);
   displaySlots.delete(displayId);
+  // Invalidate the removed slot's stream generation: an in-flight encode
+  // from this slot must not deliver into a successor slot that reuses the
+  // display_N stream identity (the plain stop path deliberately still
+  // delivers its final frame; removal does not).
+  bumpDisplayStreamGeneration(displayId);
   if (typeof window.retireLiveDisplayWorkspaceSlot === 'function') {
     window.retireLiveDisplayWorkspaceSlot(displayId);
   }

--- a/static/app.html
+++ b/static/app.html
@@ -27837,27 +27837,59 @@ function ui2TagRawEntries() {
 // a pass (their addedNodes are text nodes), and a container insertion
 // (replay fragment, re-rendered window range) scans only its own subtree.
 // Clones inherit the source entry's classes, so re-tagging is a no-op skip.
+// Bounded: MutationObservers keep firing in hidden tabs while rAF does not,
+// so an unbounded queue would retain every appended node overnight —
+// including entries the 10k prune already detached, pinned with their full
+// subtrees. Past the cap the queue collapses to one "rescan everything"
+// flag (the flush then runs ui2TagRawEntries, whose class guard makes the
+// sweep idempotent), and hidden tabs flush via setTimeout since their rAF
+// never fires (background timer throttling only delays it; the cap is the
+// memory guarantee either way).
+const UI2_TAG_QUEUE_CAP = 2048;
 let ui2PendingTagNodes = new Set();
 let ui2TagPassQueued = false;
+let ui2TagQueueOverflowed = false;
+function ui2RunEntryTagPass() {
+  ui2TagPassQueued = false;
+  const nodes = ui2PendingTagNodes;
+  ui2PendingTagNodes = new Set();
+  if (ui2TagQueueOverflowed) {
+    ui2TagQueueOverflowed = false;
+    ui2TagRawEntries();
+    return;
+  }
+  for (const node of nodes) {
+    if (!node.isConnected) continue;
+    if (node.classList && node.classList.contains('log-entry')) ui2TagEntry(node);
+    else ui2TagEntriesIn(node);
+  }
+}
 function ui2QueueEntryTagging(records) {
-  for (const record of records) {
-    for (const node of record.addedNodes) {
-      if (node.nodeType === 1) ui2PendingTagNodes.add(node);
+  if (!ui2TagQueueOverflowed) {
+    for (const record of records) {
+      for (const node of record.addedNodes) {
+        if (node.nodeType !== 1) continue;
+        if (ui2PendingTagNodes.size >= UI2_TAG_QUEUE_CAP) {
+          ui2PendingTagNodes.clear();
+          ui2TagQueueOverflowed = true;
+          break;
+        }
+        ui2PendingTagNodes.add(node);
+      }
+      if (ui2TagQueueOverflowed) break;
     }
   }
-  if (!ui2PendingTagNodes.size || ui2TagPassQueued) return;
+  if ((!ui2PendingTagNodes.size && !ui2TagQueueOverflowed) || ui2TagPassQueued) return;
   ui2TagPassQueued = true;
-  requestAnimationFrame(() => {
-    ui2TagPassQueued = false;
-    const nodes = ui2PendingTagNodes;
-    ui2PendingTagNodes = new Set();
-    for (const node of nodes) {
-      if (!node.isConnected) continue;
-      if (node.classList && node.classList.contains('log-entry')) ui2TagEntry(node);
-      else ui2TagEntriesIn(node);
-    }
-  });
+  if (document.hidden) setTimeout(ui2RunEntryTagPass, 250);
+  else requestAnimationFrame(ui2RunEntryTagPass);
 }
+// A pass scheduled on rAF while visible never fires once the tab hides —
+// convert it to a timer flush (ui2RunEntryTagPass tolerates the stale rAF
+// firing later on an already-drained queue).
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden && ui2TagPassQueued) setTimeout(ui2RunEntryTagPass, 250);
+});
 
 // The approval hero names its session — with several agents running,
 // "Approval needed" alone is ambiguous.
@@ -28073,7 +28105,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '79868a67bb6b6b5b';
+const INTENDANT_APP_BUILD = '01176a9b40d476e2';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -38600,11 +38632,20 @@ async function stationOpenTranscript(sessionId, opts = {}) {
     console.warn('station set_transcript rejected:', err);
   }
   if (accepted) {
+    // Seed the settle-edge tracker from the phase at open, so a session
+    // that goes inactive before the first poll evaluation still gets its
+    // one final refetch (stationMaybeRefreshTranscript maintains it from
+    // here on).
+    const phaseAtOpen = String(
+      (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(sid)?.phase) || ''
+    );
     stationTranscriptLive = {
       sessionId: sid,
       source,
       fetchedAt: Date.now(),
       lastEventKey: stationLatestEventKeyForSession(sid),
+      lastActivePhaseSeen: Boolean(phaseAtOpen) &&
+        !['idle', 'done', 'interrupted'].includes(phaseAtOpen),
     };
     if (!opts.refresh) stationStatus(`Transcript ${shortSessionId(sid)} loaded`);
   } else if (opts.refresh && stationTranscriptLive?.sessionId === sid) {
@@ -38628,14 +38669,22 @@ function stationMaybeRefreshTranscript(force = false) {
   // Idle-arm gate: the ~8 s fallback exists for sessions whose output
   // never surfaces in the activity stream — but when the stream key is
   // UNCHANGED and the session itself reports an inactive phase, there is
-  // nothing new to fetch. Skipping here parks the 300-row refetch+rebuild
-  // instead of re-running it forever under an idle open viewer; an
-  // unknown phase keeps the old fallback cadence (fail open).
-  if (!force && key === live.lastEventKey) {
-    const phase = String(
-      (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(live.sessionId)?.phase) || ''
-    );
-    if (phase === 'idle' || phase === 'done' || phase === 'interrupted') return;
+  // nothing new to fetch. One exception, tracked via lastActivePhaseSeen:
+  // output that lands transcript-only just before the phase settles would
+  // otherwise never be fetched (key unchanged forever + phase now
+  // inactive), so the active→inactive TRANSITION grants exactly one final
+  // refetch before the gate parks. Unknown phase keeps the old fallback
+  // cadence (fail open).
+  const phase = String(
+    (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(live.sessionId)?.phase) || ''
+  );
+  const inactive = phase === 'idle' || phase === 'done' || phase === 'interrupted';
+  if (inactive) {
+    const settleEdge = live.lastActivePhaseSeen === true;
+    live.lastActivePhaseSeen = false;
+    if (!force && !settleEdge && key === live.lastEventKey) return;
+  } else if (phase) {
+    live.lastActivePhaseSeen = true;
   }
   live.fetchedAt = Date.now();
   live.lastEventKey = key;
@@ -48413,7 +48462,6 @@ function renderSessionWindowVitals(win, vitals) {
     win.vitals.replaceChildren();
     win.vitals.removeAttribute('title');
     delete win.vitals.dataset.vitSig;
-    win.vitalsRowTicking = false;
     return false;
   }
   wireVitalsChipRow(win);
@@ -48430,8 +48478,7 @@ function renderSessionWindowVitals(win, vitals) {
       ttlChip.textContent = ttl.text;
       ttlChip.title = ttl.explainLines[0] || ttl.label;
     }
-    win.vitalsRowTicking = models.some((m) => m.ticking);
-    return win.vitalsRowTicking;
+    return models.some((m) => m.ticking);
   }
   win.vitals.dataset.vitSig = signature;
   win.vitals.className = 'session-window-vitals';
@@ -48466,8 +48513,7 @@ function renderSessionWindowVitals(win, vitals) {
     nodes.push(more);
   }
   win.vitals.replaceChildren(...nodes);
-  win.vitalsRowTicking = models.some((m) => m.ticking);
-  return win.vitalsRowTicking;
+  return models.some((m) => m.ticking);
 }
 
 // One delegated listener per window (chips are rebuilt every render).
@@ -48862,11 +48908,17 @@ function refreshSessionVitalsTicker() {
   for (const [sid, win] of sessionWindows) {
     const vitals = (sessionMetadataById.get(sid) || {}).vitals || null;
     const needsTick = sessionVitalsNeedsTick(vitals);
-    // One trailing render after ticking stops (win.vitalsRowTicking is
-    // maintained by renderSessionWindowVitals on every render path) flips
-    // the countdown chip to its cold glyph instead of freezing mid-count.
-    if (!needsTick && !win.vitalsRowTicking) continue;
-    if (renderSessionWindowVitals(win, vitals)) ticking = true;
+    // One trailing render after ticking stops (win.vitalsNeededTick holds
+    // the previous pass's verdict) settles the row — the cache chip flips
+    // to its cold glyph and a passed limit-reset drops its "↻~Xm" text —
+    // instead of freezing mid-count.
+    if (!needsTick && !win.vitalsNeededTick) continue;
+    win.vitalsNeededTick = needsTick;
+    renderSessionWindowVitals(win, vitals);
+    // Arm from the predicate, not the render result: the render reports
+    // only cache-ttl models as ticking, which left percentless limit-reset
+    // countdowns frozen because nothing kept the interval alive for them.
+    if (needsTick) ticking = true;
     maybeAlertCacheExpiry(sid, win, vitals);
   }
   if (ticking && !sessionVitalsTicker) {
@@ -54234,7 +54286,18 @@ function updateSessionWindow(sessionId, meta = {}) {
   win.metadataSignature = signature;
   win.metadataSignatureNoPhase = signatureNoPhase;
   if (phaseOnly) {
+    // Relationship badges derive from phases: a parent's "N sub" chip
+    // counts children through sessionRelationshipSubagentIsActive, which
+    // reads the child's win.phase — so a phase change that crosses the
+    // active boundary (running→done, idle→thinking) must refresh this
+    // window's badge AND the parent's. Same-side alternations
+    // (thinking↔running) change no badge-visible state and skip it.
+    const activeBefore = sessionRelationshipSubagentIsActive(sid);
     if (meta.phase) applySessionWindowPhase(win, sid, meta.phase);
+    if (sessionRelationshipSubagentIsActive(sid) !== activeBefore) {
+      updateSessionRelationshipBadges(sid);
+      if (meta.parentId) updateSessionRelationshipBadges(meta.parentId);
+    }
     schedulePersistSessionWindowState();
     return;
   }
@@ -65379,6 +65442,10 @@ class DisplaySlot {
     this._streamCanvas = document.createElement('canvas');
     this._hqStreamCanvas = document.createElement('canvas');
     this._streamEncodePending = false;
+    // Monotonic per-start stream generation: a late async encode from
+    // generation N must never emit into (or clobber the pending flag of)
+    // generation N+1 after a quick stop→start.
+    this._streamGeneration = 0;
     this._focusResizeObserver = null;
     this._boundHandlers = {};
     this._fullscreenInertRecords = [];
@@ -66568,6 +66635,12 @@ class DisplaySlot {
   startStreaming() {
     if (this.streaming || !this.connected) return;
     this.streaming = true;
+    // New generation: late completions from a previous run compare against
+    // this and drop; the pending flag belongs to the new run (a leftover
+    // true from a stopped run must not eat the first ticks).
+    this._streamGeneration += 1;
+    this._streamEncodePending = false;
+    const gen = this._streamGeneration;
     this.streamBtn.classList.add('active');
     this.streamBtn.setAttribute('aria-pressed', 'true');
     this.streamBtn.innerHTML = '&#x1F441; Streaming';
@@ -66600,19 +66673,29 @@ class DisplaySlot {
         DisplaySlot._canvasJpegBase64(this._streamCanvas, 0.8),
         DisplaySlot._canvasJpegBase64(this._hqStreamCanvas, 0.80),
       ]).then(([liveB64, hqB64]) => {
-        if (!this.streaming) return;
+        // Restarted since capture: these pixels belong to the retired
+        // sequence — never emit them into the new one.
+        if (gen !== this._streamGeneration) return;
+        // Stopped (not restarted): the frame captured pre-stop pixels —
+        // still deliver it (it is the stream's final frame), but leave the
+        // torn-down chrome (frame-id chip) alone.
+        const chromeLive = this.streaming;
         // Skip duplicate frames for voice model — still send HQ to server for archival
         const sizeDelta = Math.abs(liveB64.length - (this._lastFrameLen || 0)) / (this._lastFrameLen || 1);
         const frameDup = sizeDelta < 0.02 && this._lastFrameLen > 0;
         if (!frameDup) {
           this._lastFrameLen = liveB64.length;
           app.send_frame(liveB64, frameId);
-          this.frameIdEl.textContent = frameId.split('-').pop();
-          this.frameIdEl.style.color = 'var(--overlay0)';
+          if (chromeLive) {
+            this.frameIdEl.textContent = frameId.split('-').pop();
+            this.frameIdEl.style.color = 'var(--overlay0)';
+          }
           tickerFramesSent++;
         } else {
-          this.frameIdEl.textContent = frameId.split('-').pop() + ' dropped';
-          this.frameIdEl.style.color = 'var(--yellow)';
+          if (chromeLive) {
+            this.frameIdEl.textContent = frameId.split('-').pop() + ' dropped';
+            this.frameIdEl.style.color = 'var(--yellow)';
+          }
           tickerFramesDropped++;
           sendDashboardVoiceDiagnostic('frame_skip', 'duplicate frame skipped (delta=' + (sizeDelta * 100).toFixed(1) + '%)');
         }
@@ -66620,13 +66703,18 @@ class DisplaySlot {
       }).catch(err => {
         console.warn('[DisplaySlot] stream frame encode failed', err);
       }).finally(() => {
-        this._streamEncodePending = false;
+        // Only this generation may clear its own pending flag — a late
+        // completion must not unblock (or race) a restarted stream's ticks.
+        if (gen === this._streamGeneration) this._streamEncodePending = false;
       });
     }, 1000);
   }
   stopStreaming() {
     this.streaming = false;
     if (this._streamIntervalId) { clearInterval(this._streamIntervalId); this._streamIntervalId = null; }
+    // The in-flight encode (if any) still delivers its final frame above;
+    // the flag itself must not leak into a subsequent start.
+    this._streamEncodePending = false;
     this.streamBtn.classList.remove('active');
     this.streamBtn.setAttribute('aria-pressed', 'false');
     this.streamBtn.innerHTML = '&#x1F441; Stream';
@@ -74739,6 +74827,24 @@ function contextPressureColor(pct) {
   return CONTEXT_VIZ_THEME.pressure.ok;
 }
 
+// Per-object token for the scene key: replaceStoredContextSnapshot swaps a
+// compact snapshot for its exact-replay twin while DELIBERATELY preserving
+// __context_key, so the key alone cannot distinguish old from new data —
+// the replacement mints a NEW object, and this token tracks object
+// identity (the analysis memo is likewise object-keyed).
+let contextSceneObjectSeq = 0;
+const contextSceneObjectTokens = new WeakMap();
+function contextSceneObjectToken(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object') return '0';
+  let token = contextSceneObjectTokens.get(snapshot);
+  if (!token) {
+    contextSceneObjectSeq += 1;
+    token = String(contextSceneObjectSeq);
+    contextSceneObjectTokens.set(snapshot, token);
+  }
+  return token;
+}
+
 function contextBuildThree(analysis, snapshot) {
   const empty = document.getElementById('context-scene-empty');
   if (empty) empty.style.display = analysis && analysis.parts.length ? 'none' : 'flex';
@@ -74749,11 +74855,13 @@ function contextBuildThree(analysis, snapshot) {
   // this pane is visible, detail-pane churn, selection changes — used to
   // tear down and rebuild every geometry, material, and label texture.
   // Selection highlighting mutates in place (contextUpdateMeshSelection),
-  // so it deliberately stays out of the key.
+  // so it deliberately stays out of the key. The object token catches
+  // exact-replay replacement, which keeps the key but swaps the data.
   const { timeline } = contextTimelineForForegroundSession();
   const sceneKey = analysis && analysis.parts.length
     ? [
         contextRawRenderKey(snapshot),
+        contextSceneObjectToken(snapshot),
         timeline.length,
         timeline.indexOf(snapshot),
         CONTEXT_VIZ_THEME.labelBg,

--- a/static/app/33-station-core.js
+++ b/static/app/33-station-core.js
@@ -1626,6 +1626,9 @@ async function stationRefreshDisplayTelemetry(key, pc) {
   if (!pc || typeof pc.getStats !== 'function') return;
   const stats = await pc.getStats();
   const cached = stationDisplayTelemetry.get(key) || {};
+  // Snapshot the DISPLAYED values before folding the fresh sample in: the
+  // completion below only reschedules when they moved.
+  const labelBefore = stationDisplayTelemetryLabel(cached);
   const codecs = new Map();
   const inbound = [];
   stats.forEach(report => {
@@ -1657,7 +1660,13 @@ async function stationRefreshDisplayTelemetry(key, pc) {
     cached.quality = 'steady';
   }
   stationDisplayTelemetry.set(key, cached);
-  stationScheduleUpdate();
+  // Unconditional rescheduling here made the pipeline self-perpetuating:
+  // snapshot build → telemetry poll (1.5 s throttle) → this completion →
+  // schedule (300 ms) → next build → next poll — a full rebuild every
+  // ~1.8 s on an idle Station tab with any stream open. The snapshot only
+  // renders the ROUNDED label, so reschedule only when that label moved;
+  // real fps/codec/quality changes still repaint.
+  if (stationDisplayTelemetryLabel(cached) !== labelBefore) stationScheduleUpdate();
 }
 
 function stationDisplayRunwayPayload(controlsSummary = null) {

--- a/static/app/34-station-panes.js
+++ b/static/app/34-station-panes.js
@@ -1905,11 +1905,20 @@ async function stationOpenTranscript(sessionId, opts = {}) {
     console.warn('station set_transcript rejected:', err);
   }
   if (accepted) {
+    // Seed the settle-edge tracker from the phase at open, so a session
+    // that goes inactive before the first poll evaluation still gets its
+    // one final refetch (stationMaybeRefreshTranscript maintains it from
+    // here on).
+    const phaseAtOpen = String(
+      (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(sid)?.phase) || ''
+    );
     stationTranscriptLive = {
       sessionId: sid,
       source,
       fetchedAt: Date.now(),
       lastEventKey: stationLatestEventKeyForSession(sid),
+      lastActivePhaseSeen: Boolean(phaseAtOpen) &&
+        !['idle', 'done', 'interrupted'].includes(phaseAtOpen),
     };
     if (!opts.refresh) stationStatus(`Transcript ${shortSessionId(sid)} loaded`);
   } else if (opts.refresh && stationTranscriptLive?.sessionId === sid) {
@@ -1933,14 +1942,22 @@ function stationMaybeRefreshTranscript(force = false) {
   // Idle-arm gate: the ~8 s fallback exists for sessions whose output
   // never surfaces in the activity stream — but when the stream key is
   // UNCHANGED and the session itself reports an inactive phase, there is
-  // nothing new to fetch. Skipping here parks the 300-row refetch+rebuild
-  // instead of re-running it forever under an idle open viewer; an
-  // unknown phase keeps the old fallback cadence (fail open).
-  if (!force && key === live.lastEventKey) {
-    const phase = String(
-      (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(live.sessionId)?.phase) || ''
-    );
-    if (phase === 'idle' || phase === 'done' || phase === 'interrupted') return;
+  // nothing new to fetch. One exception, tracked via lastActivePhaseSeen:
+  // output that lands transcript-only just before the phase settles would
+  // otherwise never be fetched (key unchanged forever + phase now
+  // inactive), so the active→inactive TRANSITION grants exactly one final
+  // refetch before the gate parks. Unknown phase keeps the old fallback
+  // cadence (fail open).
+  const phase = String(
+    (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(live.sessionId)?.phase) || ''
+  );
+  const inactive = phase === 'idle' || phase === 'done' || phase === 'interrupted';
+  if (inactive) {
+    const settleEdge = live.lastActivePhaseSeen === true;
+    live.lastActivePhaseSeen = false;
+    if (!force && !settleEdge && key === live.lastEventKey) return;
+  } else if (phase) {
+    live.lastActivePhaseSeen = true;
   }
   live.fetchedAt = Date.now();
   live.lastEventKey = key;

--- a/static/app/34-station-panes.js
+++ b/static/app/34-station-panes.js
@@ -1877,6 +1877,13 @@ async function stationOpenTranscript(sessionId, opts = {}) {
   ).trim() || 'intendant';
   const label = stationSessionTask(session) || shortSessionId(sid);
   if (!opts.refresh) stationStatus(`Loading transcript ${shortSessionId(sid)}`);
+  // Settle-edge seed, sampled SYNCHRONOUSLY before the detail fetch: the
+  // phase can flip idle during the await, and seeding from the post-await
+  // value would record an open-while-active session as never-active —
+  // silently skipping its one settling refetch.
+  const phaseAtOpen = String(
+    (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(sid)?.phase) || ''
+  );
   let payload;
   try {
     const data = await fetchSessionDetailPayload(sid, { source, limit: 300 });
@@ -1905,13 +1912,8 @@ async function stationOpenTranscript(sessionId, opts = {}) {
     console.warn('station set_transcript rejected:', err);
   }
   if (accepted) {
-    // Seed the settle-edge tracker from the phase at open, so a session
-    // that goes inactive before the first poll evaluation still gets its
-    // one final refetch (stationMaybeRefreshTranscript maintains it from
-    // here on).
-    const phaseAtOpen = String(
-      (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(sid)?.phase) || ''
-    );
+    // Seed the settle-edge tracker from the pre-fetch phase sample above;
+    // stationMaybeRefreshTranscript maintains it from here on.
     stationTranscriptLive = {
       sessionId: sid,
       source,
@@ -1934,6 +1936,16 @@ async function stationOpenTranscript(sessionId, opts = {}) {
 function stationMaybeRefreshTranscript(force = false) {
   const live = stationTranscriptLive;
   if (!live || !stationRenderedPrimaryActive()) return;
+  // Observe the phase on EVERY call, BEFORE the fetch throttles below can
+  // return: arming is set-only here, so a short turn that starts and
+  // settles entirely inside the 8 s age window (whose calls all early-out
+  // below) still arms the settle edge. The grant is consumed only at an
+  // actual fetch decision, never by an early return.
+  const phase = String(
+    (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(live.sessionId)?.phase) || ''
+  );
+  const inactive = phase === 'idle' || phase === 'done' || phase === 'interrupted';
+  if (phase && !inactive) live.lastActivePhaseSeen = true;
   const age = Date.now() - live.fetchedAt;
   if (!force && age < 1500) return;
   const key = stationLatestEventKeyForSession(live.sessionId);
@@ -1942,22 +1954,16 @@ function stationMaybeRefreshTranscript(force = false) {
   // Idle-arm gate: the ~8 s fallback exists for sessions whose output
   // never surfaces in the activity stream — but when the stream key is
   // UNCHANGED and the session itself reports an inactive phase, there is
-  // nothing new to fetch. One exception, tracked via lastActivePhaseSeen:
+  // nothing new to fetch. One exception, the settle edge armed above:
   // output that lands transcript-only just before the phase settles would
   // otherwise never be fetched (key unchanged forever + phase now
-  // inactive), so the active→inactive TRANSITION grants exactly one final
-  // refetch before the gate parks. Unknown phase keeps the old fallback
-  // cadence (fail open).
-  const phase = String(
-    (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(live.sessionId)?.phase) || ''
-  );
-  const inactive = phase === 'idle' || phase === 'done' || phase === 'interrupted';
+  // inactive), so an observed active→inactive transition grants exactly
+  // one final refetch before the gate parks. Unknown phase keeps the old
+  // fallback cadence (fail open).
   if (inactive) {
     const settleEdge = live.lastActivePhaseSeen === true;
     live.lastActivePhaseSeen = false;
     if (!force && !settleEdge && key === live.lastEventKey) return;
-  } else if (phase) {
-    live.lastActivePhaseSeen = true;
   }
   live.fetchedAt = Date.now();
   live.lastEventKey = key;

--- a/static/app/34-station-panes.js
+++ b/static/app/34-station-panes.js
@@ -1930,6 +1930,18 @@ function stationMaybeRefreshTranscript(force = false) {
   const key = stationLatestEventKeyForSession(live.sessionId);
   if (!force && key && key === live.lastEventKey && age < 8000) return;
   if (!force && !key && age < 8000) return;
+  // Idle-arm gate: the ~8 s fallback exists for sessions whose output
+  // never surfaces in the activity stream — but when the stream key is
+  // UNCHANGED and the session itself reports an inactive phase, there is
+  // nothing new to fetch. Skipping here parks the 300-row refetch+rebuild
+  // instead of re-running it forever under an idle open viewer; an
+  // unknown phase keeps the old fallback cadence (fail open).
+  if (!force && key === live.lastEventKey) {
+    const phase = String(
+      (typeof sessionMetadataById !== 'undefined' && sessionMetadataById.get(live.sessionId)?.phase) || ''
+    );
+    if (phase === 'idle' || phase === 'done' || phase === 'interrupted') return;
+  }
   live.fetchedAt = Date.now();
   live.lastEventKey = key;
   stationOpenTranscript(live.sessionId, { source: live.source, refresh: true });

--- a/static/app/37-uicommand-changes-control.js
+++ b/static/app/37-uicommand-changes-control.js
@@ -10,6 +10,10 @@ function processCommands(cmds) {
       if (c.cmd !== 'update_status_bar' && c.cmd !== 'set_phase') {
         pendingStatusPhaseGuard = null;
       }
+      // Per-command isolation: sibling commands in a batch are independent
+      // renders — one throwing handler (e.g. a missing DOM node after a
+      // shell-markup change) must not eat the rest of the batch.
+      try {
       switch (c.cmd) {
       case 'add_log_entry':
         maybeFailNewSessionSpawnFromLog(c);
@@ -269,6 +273,9 @@ function processCommands(cmds) {
       case 'peer_dashboard_control_signal':
         handlePeerDashboardControlSignal(c.host_id, c.session_id, c.signal);
         break;
+      }
+      } catch (err) {
+        console.warn('[ui-command]', c?.cmd || 'unknown command', err);
       }
     }
   } finally {

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -595,9 +595,16 @@ function mergeSessionWindowMetadata(sessionId, meta = {}) {
   const merged = Object.keys(normalized).length > 0
     ? { ...previous, ...normalized }
     : previous;
-  const changed = sessionWindowMetadataSignature(previous) !== sessionWindowMetadataSignature(merged);
+  // The merged signature rides the return value so updateSessionWindow —
+  // reached per rendered log line via inferSessionPhaseFromLog — doesn't
+  // recompute the ~35-field join a third time per call.
+  const previousSignature = sessionWindowMetadataSignature(previous);
+  const signature = merged === previous
+    ? previousSignature
+    : sessionWindowMetadataSignature(merged);
+  const changed = previousSignature !== signature;
   if (sid && changed) sessionMetadataById.set(sid, merged);
-  return { meta: merged, changed };
+  return { meta: merged, changed, signature };
 }
 
 function currentSessionGoalElapsedSeconds(goal) {
@@ -629,22 +636,27 @@ function goalStatusClass(status) {
 
 function renderSessionWindowGoal(win, goal) {
   if (!win?.goal || !win?.goalText) return false;
+  // Write-guards throughout: this runs for EVERY window on the 1 Hz goal
+  // ticker, and unconditional textContent/className assignment churns text
+  // nodes (and feeds every subtree MutationObserver watching the grid)
+  // even when the rendered second hasn't rolled over.
+  const setText = (el, prop, value) => { if (el[prop] !== value) el[prop] = value; };
   if (!goal?.objective) {
-    win.goal.className = 'session-window-goal hidden';
-    win.goalText.textContent = '';
-    win.goal.title = '';
+    setText(win.goal, 'className', 'session-window-goal hidden');
+    setText(win.goalText, 'textContent', '');
+    setText(win.goal, 'title', '');
     return false;
   }
   const status = normalizeGoalStatus(goal.status);
   const elapsed = formatGoalElapsed(currentSessionGoalElapsedSeconds(goal));
-  win.goal.className = `session-window-goal ${goalStatusClass(status)}`;
-  win.goalText.textContent = status === 'active'
+  setText(win.goal, 'className', `session-window-goal ${goalStatusClass(status)}`);
+  setText(win.goalText, 'textContent', status === 'active'
     ? `${goal.objective} · ${elapsed}`
-    : `${status} · ${goal.objective} · ${elapsed}`;
+    : `${status} · ${goal.objective} · ${elapsed}`);
   const tokenText = goal.tokensUsed !== null && goal.tokensUsed !== undefined
     ? `\nTokens: ${goal.tokensUsed.toLocaleString()}${goal.tokenBudget ? ` / ${goal.tokenBudget.toLocaleString()}` : ''}`
     : (goal.tokenBudget ? `\nBudget: ${goal.tokenBudget.toLocaleString()} tokens` : '');
-  win.goal.title = `Goal: ${goal.objective}\nStatus: ${status}\nElapsed: ${elapsed}${tokenText}`;
+  setText(win.goal, 'title', `Goal: ${goal.objective}\nStatus: ${status}\nElapsed: ${elapsed}${tokenText}`);
   return status === 'active';
 }
 
@@ -680,6 +692,16 @@ function refreshSessionGoalTicker() {
   } else if (!hasActiveGoal && sessionGoalTicker) {
     clearInterval(sessionGoalTicker);
     sessionGoalTicker = null;
+  }
+}
+
+// Arm-only twin for per-window update paths: updateSessionWindow already
+// rendered ITS window's goal — re-rendering every other window's goal per
+// metadata tick (the old refreshSessionGoalTicker call) was pure waste.
+// The 1 s ticker still owns elapsed-time repaints and disarms itself.
+function ensureSessionGoalTickerArmed(hasActiveGoal) {
+  if (hasActiveGoal && !sessionGoalTicker) {
+    sessionGoalTicker = setInterval(refreshSessionGoalTicker, 1000);
   }
 }
 
@@ -1139,6 +1161,7 @@ function renderSessionWindowVitals(win, vitals) {
     win.vitals.replaceChildren();
     win.vitals.removeAttribute('title');
     delete win.vitals.dataset.vitSig;
+    win.vitalsRowTicking = false;
     return false;
   }
   wireVitalsChipRow(win);
@@ -1155,7 +1178,8 @@ function renderSessionWindowVitals(win, vitals) {
       ttlChip.textContent = ttl.text;
       ttlChip.title = ttl.explainLines[0] || ttl.label;
     }
-    return models.some((m) => m.ticking);
+    win.vitalsRowTicking = models.some((m) => m.ticking);
+    return win.vitalsRowTicking;
   }
   win.vitals.dataset.vitSig = signature;
   win.vitals.className = 'session-window-vitals';
@@ -1190,7 +1214,8 @@ function renderSessionWindowVitals(win, vitals) {
     nodes.push(more);
   }
   win.vitals.replaceChildren(...nodes);
-  return models.some((m) => m.ticking);
+  win.vitalsRowTicking = models.some((m) => m.ticking);
+  return win.vitalsRowTicking;
 }
 
 // One delegated listener per window (chips are rebuilt every render).
@@ -1559,10 +1584,36 @@ function showCacheExpiryToast(sid, text) {
   setTimeout(() => { if (toast.parentNode) toast.remove(); }, 12000);
 }
 
+// Cheap per-tick predicate: does this session's vitals row need a 1 Hz
+// repaint at all? True for the warm-cache countdown (the only `ticking`
+// model vitalsChipModels emits) and for status-only rate-limit chips whose
+// "resets in ~Xm" text is time-derived. Everything else changes only on
+// real vitals/metadata events, which re-render directly — so the ticker no
+// longer rebuilds every window's full chip-model array each second just to
+// hit the stable-DOM fast path.
+function sessionVitalsNeedsTick(vitals) {
+  if (!vitals || typeof vitals !== 'object') return false;
+  const remaining = sessionCacheCountdownSeconds(vitals.cache);
+  if (remaining !== null && remaining > 0) return true;
+  const limits = Array.isArray(vitals.limits) ? vitals.limits : [];
+  return limits.some((w) => {
+    // Mirrors the chip model: the reset countdown only renders when the
+    // provider reports no percentage (status-only limits).
+    const pctRaw = Number(w?.usedPct);
+    const hasPct = Number.isFinite(pctRaw) && w?.usedPct !== null && w?.usedPct !== undefined;
+    return !hasPct && Number(w?.resetsAtEpoch) > Date.now() / 1000;
+  });
+}
+
 function refreshSessionVitalsTicker() {
   let ticking = false;
   for (const [sid, win] of sessionWindows) {
     const vitals = (sessionMetadataById.get(sid) || {}).vitals || null;
+    const needsTick = sessionVitalsNeedsTick(vitals);
+    // One trailing render after ticking stops (win.vitalsRowTicking is
+    // maintained by renderSessionWindowVitals on every render path) flips
+    // the countdown chip to its cold glyph instead of freezing mid-count.
+    if (!needsTick && !win.vitalsRowTicking) continue;
     if (renderSessionWindowVitals(win, vitals)) ticking = true;
     maybeAlertCacheExpiry(sid, win, vitals);
   }
@@ -1897,8 +1948,41 @@ function persistedSessionWindowRecord(sessionId, win = null) {
   return record;
 }
 
+// Trailing-debounced twin for the streaming path. updateSessionWindow runs
+// per rendered log line (inferSessionPhaseFromLog flips phase on model/agent
+// lines) and used to re-derive every window's record, JSON.stringify it, and
+// synchronously localStorage.setItem — tens of disk-backed writes per second
+// under load, forever. Metadata churn now coalesces into at most one write
+// per second; structural transitions (open/close/layout ops) keep calling
+// the immediate form, and pagehide/hidden flush a pending write so a closing
+// tab still persists its newest state.
+let sessionWindowPersistTimer = 0;
+function schedulePersistSessionWindowState() {
+  if (restoringPersistedSessionWindows || sessionWindowPersistTimer) return;
+  sessionWindowPersistTimer = window.setTimeout(() => {
+    sessionWindowPersistTimer = 0;
+    persistSessionWindowState();
+  }, 1000);
+}
+
+function flushPendingSessionWindowPersist() {
+  if (!sessionWindowPersistTimer) return;
+  clearTimeout(sessionWindowPersistTimer);
+  sessionWindowPersistTimer = 0;
+  persistSessionWindowState();
+}
+window.addEventListener('pagehide', flushPendingSessionWindowPersist);
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) flushPendingSessionWindowPersist();
+});
+
 function persistSessionWindowState() {
   if (restoringPersistedSessionWindows) return;
+  // A direct persist supersedes any scheduled one.
+  if (sessionWindowPersistTimer) {
+    clearTimeout(sessionWindowPersistTimer);
+    sessionWindowPersistTimer = 0;
+  }
   let windows = [];
   for (const [sid, win] of sessionWindows) {
     const record = persistedSessionWindowRecord(sid, win);
@@ -3050,6 +3134,13 @@ function pruneMainLogContainer(container = currentMainLogContainer()) {
     while (logEntryCount > 10000) {
       const first = container.querySelector('.log-entry, .log-turn-sep');
       if (!first) break;
+      // A pruned command-output group must leave the strong registry too:
+      // commandOutputGroups otherwise pins the detached entry DOM, its
+      // clone views, and the full accumulated copy text for the lifetime
+      // of the page (clearLogs was the only eviction). Live clones keep
+      // the group reachable through their own click closures.
+      const groupId = first.dataset ? first.dataset.outputGroupId : '';
+      if (groupId) commandOutputGroups.delete(groupId);
       first.remove();
       logEntryCount--;
     }
@@ -3384,6 +3475,23 @@ function getLogEntryCopyText(entry) {
   return entry?.querySelector?.('.log-content')?.innerText || '';
 }
 
+// Async twin for capped copy refs: a command-output group whose streamed
+// text outgrew COMMAND_OUTPUT_COPY_TEXT_CAP carries a fetchText resolver
+// (the persisted-output lane) instead of retaining megabytes in the ref.
+// Falls back to the captured prefix if the fetch fails.
+async function resolveLogEntryCopyText(entry) {
+  const ref = entry ? logEntryCopyTextByEntry.get(entry) : null;
+  if (ref && typeof ref.fetchText === 'function') {
+    try {
+      const text = await ref.fetchText();
+      if (text) return String(text);
+    } catch (err) {
+      console.warn('lazy copy-text fetch failed; copying captured prefix', err);
+    }
+  }
+  return getLogEntryCopyText(entry);
+}
+
 function resetLogCopyButton(btn) {
   if (!btn) return;
   btn.classList.remove('copied');
@@ -3398,7 +3506,7 @@ async function onLogCopyButtonClick(ev) {
   const btn = ev.currentTarget;
   const entry = btn.closest('.log-entry');
   try {
-    await copyTextToClipboard(getLogEntryCopyText(entry));
+    await copyTextToClipboard(await resolveLogEntryCopyText(entry));
     btn.classList.add('copied');
     btn.innerHTML = '&#x2713;';
     btn.title = 'Copied';

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -1161,7 +1161,6 @@ function renderSessionWindowVitals(win, vitals) {
     win.vitals.replaceChildren();
     win.vitals.removeAttribute('title');
     delete win.vitals.dataset.vitSig;
-    win.vitalsRowTicking = false;
     return false;
   }
   wireVitalsChipRow(win);
@@ -1178,8 +1177,7 @@ function renderSessionWindowVitals(win, vitals) {
       ttlChip.textContent = ttl.text;
       ttlChip.title = ttl.explainLines[0] || ttl.label;
     }
-    win.vitalsRowTicking = models.some((m) => m.ticking);
-    return win.vitalsRowTicking;
+    return models.some((m) => m.ticking);
   }
   win.vitals.dataset.vitSig = signature;
   win.vitals.className = 'session-window-vitals';
@@ -1214,8 +1212,7 @@ function renderSessionWindowVitals(win, vitals) {
     nodes.push(more);
   }
   win.vitals.replaceChildren(...nodes);
-  win.vitalsRowTicking = models.some((m) => m.ticking);
-  return win.vitalsRowTicking;
+  return models.some((m) => m.ticking);
 }
 
 // One delegated listener per window (chips are rebuilt every render).
@@ -1610,11 +1607,17 @@ function refreshSessionVitalsTicker() {
   for (const [sid, win] of sessionWindows) {
     const vitals = (sessionMetadataById.get(sid) || {}).vitals || null;
     const needsTick = sessionVitalsNeedsTick(vitals);
-    // One trailing render after ticking stops (win.vitalsRowTicking is
-    // maintained by renderSessionWindowVitals on every render path) flips
-    // the countdown chip to its cold glyph instead of freezing mid-count.
-    if (!needsTick && !win.vitalsRowTicking) continue;
-    if (renderSessionWindowVitals(win, vitals)) ticking = true;
+    // One trailing render after ticking stops (win.vitalsNeededTick holds
+    // the previous pass's verdict) settles the row — the cache chip flips
+    // to its cold glyph and a passed limit-reset drops its "↻~Xm" text —
+    // instead of freezing mid-count.
+    if (!needsTick && !win.vitalsNeededTick) continue;
+    win.vitalsNeededTick = needsTick;
+    renderSessionWindowVitals(win, vitals);
+    // Arm from the predicate, not the render result: the render reports
+    // only cache-ttl models as ticking, which left percentless limit-reset
+    // countdowns frozen because nothing kept the interval alive for them.
+    if (needsTick) ticking = true;
     maybeAlertCacheExpiry(sid, win, vitals);
   }
   if (ticking && !sessionVitalsTicker) {

--- a/static/app/40-session-launch.js
+++ b/static/app/40-session-launch.js
@@ -1506,16 +1506,34 @@ function updateSessionWindowJumpButton(win) {
   win.jumpBottom.setAttribute('aria-hidden', show ? 'false' : 'true');
 }
 
+// rAF-coalesced per-window bottom-follow (finding: interleaved layout
+// read/write per appended entry). The scrollHeight read forces synchronous
+// layout of the window's scroller; bursts used to pay it once per entry per
+// window. The follow DECISION and flags stay synchronous below — only the
+// scrollTop write (and thus the layout read) coalesces to one per window
+// per frame, re-checking followOutput at flush so a user grab between
+// schedule and flush wins (updateSessionWindowFollowFromScroll clears it).
+const sessionWindowScrollFollowPending = new Set();
+function scheduleSessionWindowScrollToBottom(win) {
+  if (!win || !win.log || sessionWindowScrollFollowPending.has(win)) return;
+  sessionWindowScrollFollowPending.add(win);
+  requestAnimationFrame(() => {
+    sessionWindowScrollFollowPending.delete(win);
+    if (!win.log || !win.followOutput) return;
+    win.log.scrollTop = win.log.scrollHeight;
+  });
+}
+
 function scrollSessionWindowToBottom(win) {
   if (!win || !win.log) return;
   const history = ensureSessionWindowHistory(win);
   if (!sessionWindowIsRenderingTail(win, history.length) || win.renderEnd !== history.length) {
     renderSessionWindowTail(win);
   }
-  win.log.scrollTop = win.log.scrollHeight;
   win.followOutput = true;
   win.pendingOutput = false;
   updateSessionWindowJumpButton(win);
+  scheduleSessionWindowScrollToBottom(win);
 }
 
 function applySessionWindowOutputScroll(win, shouldFollow) {

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -420,6 +420,27 @@ function ensureSessionWindow(sessionId, meta = {}) {
   return win;
 }
 
+// Applies a phase change to the window chrome: status chip repaint plus the
+// approval-confirm hook. Shared by the wide render below and the phase-only
+// fast path — the hook (maybeConfirmApprovalSendFromWindowPhase) must fire
+// on EVERY phase application, both paths.
+function applySessionWindowPhase(win, sid, phase) {
+  const nextPhase = normalizeSessionPhase(phase);
+  // A real phase transition is fresh evidence about the session; it
+  // retires the "optimistic thinking expired" steer demotion below.
+  if (win.phase !== nextPhase) win.optimisticActiveExpired = false;
+  win.phase = nextPhase;
+  if (win.phase === 'idle' || win.phase === 'done' || win.phase === 'interrupted') {
+    win.pendingActiveUntil = 0;
+  }
+  win.status.textContent = sessionPhaseLabel(win.phase);
+  win.status.title = sessionPhaseLabel(win.phase);
+  win.status.className = 'session-window-status';
+  const cls = sessionPhaseClass(win.phase);
+  if (cls) win.status.classList.add(cls);
+  maybeConfirmApprovalSendFromWindowPhase(sid, win.phase);
+}
+
 function updateSessionWindow(sessionId, meta = {}) {
   const sid = String(sessionId || '').trim();
   if (!sid) return;
@@ -428,12 +449,31 @@ function updateSessionWindow(sessionId, meta = {}) {
   const merged = mergeSessionWindowMetadata(sid, meta);
   meta = merged.meta;
   updateSessionWindowRelationshipStyle(sid);
-  const signature = sessionWindowMetadataSignature(meta);
+  const signature = merged.signature;
   if (win.metadataSignature === signature) {
-    persistSessionWindowState();
+    // Nothing rendered from — nothing persisted from. The unconditional
+    // persist here was a synchronous localStorage write per rendered log
+    // line (this early-out is the steady-state exit of the per-line
+    // phase-inference path).
     return;
   }
+  // Phase-only fast path: streaming log lines alternate thinking↔running
+  // several times per turn (inferSessionPhaseFromLog), and phase rides the
+  // metadata signature — so each alternation used to defeat the early-out
+  // and re-run the full header render (identity DOM rebuild, path
+  // elements, goal/tier/vitals, relationship badges, menu visibility).
+  // When the signatures differ ONLY in phase, repaint the status chip and
+  // fire the approval-confirm hook — the only phase consumers here.
+  const signatureNoPhase = sessionWindowMetadataSignature({ ...meta, phase: '' });
+  const phaseOnly = Boolean(win.metadataSignature) &&
+    win.metadataSignatureNoPhase === signatureNoPhase;
   win.metadataSignature = signature;
+  win.metadataSignatureNoPhase = signatureNoPhase;
+  if (phaseOnly) {
+    if (meta.phase) applySessionWindowPhase(win, sid, meta.phase);
+    schedulePersistSessionWindowState();
+    return;
+  }
   renderSessionIdentity(win.id, sid, { order: 'id-name' });
   if (meta.projectRoot) {
     setSessionWindowPathElement(
@@ -491,25 +531,14 @@ function updateSessionWindow(sessionId, meta = {}) {
     if (win.ended) win.pendingActiveUntil = 0;
   }
   if (meta.phase) {
-    const nextPhase = normalizeSessionPhase(meta.phase);
-    // A real phase transition is fresh evidence about the session; it
-    // retires the "optimistic thinking expired" steer demotion below.
-    if (win.phase !== nextPhase) win.optimisticActiveExpired = false;
-    win.phase = nextPhase;
-    if (win.phase === 'idle' || win.phase === 'done' || win.phase === 'interrupted') {
-      win.pendingActiveUntil = 0;
-    }
-    win.status.textContent = sessionPhaseLabel(win.phase);
-    win.status.title = sessionPhaseLabel(win.phase);
-    win.status.className = 'session-window-status';
-    const cls = sessionPhaseClass(win.phase);
-    if (cls) win.status.classList.add(cls);
-    maybeConfirmApprovalSendFromWindowPhase(sid, win.phase);
+    applySessionWindowPhase(win, sid, meta.phase);
   }
-  renderSessionWindowGoal(win, meta.goal || null);
+  // Arm-only: this window's goal was just rendered; the 1 s ticker owns
+  // elapsed-time repaints for the rest (re-rendering EVERY window's goal
+  // per metadata update was the waste).
+  ensureSessionGoalTickerArmed(renderSessionWindowGoal(win, meta.goal || null));
   renderSessionWindowTier(win);
   renderSessionWindowVitals(win, (sessionMetadataById.get(sid) || {}).vitals || meta.vitals || null);
-  refreshSessionGoalTicker();
   updateSessionWindowActionMenuVisibility(sid);
   updateControlFastButtonState();
   updateSessionRelationshipBadges(sid);
@@ -521,7 +550,7 @@ function updateSessionWindow(sessionId, meta = {}) {
   if (win.log && win.log.firstElementChild?.classList?.contains('session-window-empty')) {
     renderSessionWindowLogPlaceholder(win);
   }
-  persistSessionWindowState();
+  schedulePersistSessionWindowState();
 }
 
 // Worktree badge next to the project path: branch name up front, the full
@@ -1498,6 +1527,23 @@ function createLogScaffold(c, extraClass) {
   return { entry, hostId };
 }
 
+// rAF-coalesced follow for the MAIN stream (finding: interleaved layout
+// read/write per appended entry). Reading scrollHeight right after each
+// append forces a synchronous layout of the 10k-node scroller — N entries
+// in one frame cost N layout passes. One scrollTop write per frame, with
+// the follow flags re-checked at flush so a user grab mid-burst wins.
+let mainLogScrollScheduled = false;
+function scheduleMainLogScrollToBottom() {
+  if (mainLogScrollScheduled) return;
+  mainLogScrollScheduled = true;
+  requestAnimationFrame(() => {
+    mainLogScrollScheduled = false;
+    if (concurrentLogDetachedFragment || !autoScroll) return;
+    const stream = document.getElementById('log-stream');
+    if (stream) stream.scrollTop = stream.scrollHeight;
+  });
+}
+
 function appendLogEntryElement(entry, sessionRecord = null) {
   if (logReplayAppendBatch && !entry.classList.contains('command-output-group')) {
     logReplayAppendBatch.mainFragment.appendChild(entry);
@@ -1526,7 +1572,7 @@ function appendLogEntryElement(entry, sessionRecord = null) {
   updateLogEmptyState();
   pruneMainLogContainer(container);
   if (!concurrentLogDetachedFragment && autoScroll && stream) {
-    stream.scrollTop = stream.scrollHeight;
+    scheduleMainLogScrollToBottom();
   } else if (!processingLogReplay) {
     noteMainLogNewBelow();
   }
@@ -1728,7 +1774,19 @@ function appendCommandOutputChunk(group, c) {
       sessionScrollStates.set(win, sessionWindowShouldFollowNextOutput(win));
     }
   }
-  if (group.copyRef && text) group.copyRef.text += text;
+  if (group.copyRef && text && !group.copyRefCapped) {
+    if (group.copyRef.text.length + text.length > COMMAND_OUTPUT_COPY_TEXT_CAP) {
+      // Stop retaining the concatenation of ALL streamed output in JS heap
+      // for the session's lifetime. The copy button re-fetches the full
+      // text lazily through the persisted-output lane (same source the
+      // expand-after-finalize path loads); the captured prefix stays as
+      // the offline fallback.
+      group.copyRefCapped = true;
+      group.copyRef.fetchText = () => fetchCommandOutputGroupText(group);
+    } else {
+      group.copyRef.text += text;
+    }
+  }
   if (c.output_id && !group.outputIdSet.has(c.output_id)) {
     group.outputIdSet.add(c.output_id);
     group.outputIds.push(c.output_id);
@@ -1809,7 +1867,7 @@ function renderCommandOutputEntry(c) {
   }
   appendCommandOutputChunk(activeCommandOutputGroup, c);
   const stream = document.getElementById('log-stream');
-  if (!concurrentLogDetachedFragment && autoScroll && stream) stream.scrollTop = stream.scrollHeight;
+  if (!concurrentLogDetachedFragment && autoScroll && stream) scheduleMainLogScrollToBottom();
 }
 
 function finalizeCommandOutputGroup(group) {
@@ -1874,6 +1932,22 @@ async function loadCommandOutputIntoBody(group, body) {
   if (!body.childElementCount) {
     body.textContent = 'No persisted output found.';
   }
+}
+
+// Copy-text retention cap for streaming command-output groups (2 MiB of
+// UTF-16 units). Beyond it the copy ref switches to the lazy fetch below.
+const COMMAND_OUTPUT_COPY_TEXT_CAP = 2 * 1024 * 1024;
+
+// Full output text for a capped group's copy button — same persisted-output
+// RPC the finalized expand path uses, joined in stream order.
+async function fetchCommandOutputGroupText(group) {
+  if (!group?.outputIds?.length) return '';
+  const resp = await daemonApi.request('api_session_current_agent_output', { ids: group.outputIds });
+  const json = (resp.body && typeof resp.body === 'object') ? resp.body : {};
+  if (!resp.ok) throw new Error(json.error || `HTTP ${resp.status}`);
+  return (json.outputs || [])
+    .map(out => [out.stdout || '', out.stderr || ''].filter(Boolean).join(out.stdout && out.stderr ? '\n' : ''))
+    .join('');
 }
 
 async function toggleCommandOutputView(group, view) {
@@ -2473,11 +2547,19 @@ function parseUsageJson(raw) {
   try { return JSON.parse(raw); } catch { return null; }
 }
 
+// One full update_usage payload per session ever seen otherwise accumulates
+// for the lifetime of the tab (days-long dashboards → MBs). LRU past the cap:
+// re-inserting on write keeps the actively-updating sessions at the tail.
+const SESSION_USAGE_CACHE_CAP = 500;
 function cacheSessionUsage(c) {
   if (!c || typeof c !== 'object') return;
   const sid = String(c.session_id || '').trim();
   if (sid) {
+    sessionUsageById.delete(sid);
     sessionUsageById.set(sid, c);
+    while (sessionUsageById.size > SESSION_USAGE_CACHE_CAP) {
+      sessionUsageById.delete(sessionUsageById.keys().next().value);
+    }
   } else {
     latestGlobalUsage = c;
   }
@@ -2567,13 +2649,20 @@ function updateStatusBar(d, opts = {}) {
                && relatedSessionIdsForSession(statusSid).has(foreground)))
         : false);
   if (drivesForeground) {
-    if (d.provider) document.getElementById('sb-provider').textContent = d.provider;
-    if (d.model) document.getElementById('sb-model').textContent = d.model;
-    if (d.turn !== undefined && d.turn !== null) document.getElementById('sb-turn').textContent = 'T' + d.turn;
+    // Null-guarded like the rest of the file: this runs mid-UiCommand
+    // batch, and a missing chip must degrade to a skipped write, not an
+    // exception that eats the remaining commands.
+    const providerEl = document.getElementById('sb-provider');
+    if (d.provider && providerEl) providerEl.textContent = d.provider;
+    const modelEl = document.getElementById('sb-model');
+    if (d.model && modelEl) modelEl.textContent = d.model;
+    const turnEl = document.getElementById('sb-turn');
+    if (d.turn !== undefined && d.turn !== null && turnEl) turnEl.textContent = 'T' + d.turn;
     if (d.budget_pct !== undefined && d.budget_pct !== null) setContextUsagePct(d.budget_pct);
   }
-  if (d.autonomy) {
-    const el = document.getElementById('sb-autonomy');
+  const autonomyEl = document.getElementById('sb-autonomy');
+  if (d.autonomy && autonomyEl) {
+    const el = autonomyEl;
     const autonomy = normalizeAutonomyLabel(d.autonomy);
     el.textContent = autonomy;
     const colors = { Low: 'var(--red)', Medium: 'var(--yellow)', High: 'var(--teal)', Full: 'var(--green)' };

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -470,7 +470,18 @@ function updateSessionWindow(sessionId, meta = {}) {
   win.metadataSignature = signature;
   win.metadataSignatureNoPhase = signatureNoPhase;
   if (phaseOnly) {
+    // Relationship badges derive from phases: a parent's "N sub" chip
+    // counts children through sessionRelationshipSubagentIsActive, which
+    // reads the child's win.phase — so a phase change that crosses the
+    // active boundary (running→done, idle→thinking) must refresh this
+    // window's badge AND the parent's. Same-side alternations
+    // (thinking↔running) change no badge-visible state and skip it.
+    const activeBefore = sessionRelationshipSubagentIsActive(sid);
     if (meta.phase) applySessionWindowPhase(win, sid, meta.phase);
+    if (sessionRelationshipSubagentIsActive(sid) !== activeBefore) {
+      updateSessionRelationshipBadges(sid);
+      if (meta.parentId) updateSessionRelationshipBadges(meta.parentId);
+    }
     schedulePersistSessionWindowState();
     return;
   }

--- a/static/app/45-displays-webrtc.js
+++ b/static/app/45-displays-webrtc.js
@@ -245,7 +245,12 @@ class DisplaySlot {
     // is waiting for display signaling to return instead of burning its
     // bounded retry budget on offers that cannot leave the browser.
     this._transportWaitTimer = null;
+    // Presence streaming: dedicated capture canvases per lane, sized on
+    // dimension change only (assigning canvas.width reallocates the backing
+    // store — the old single shared canvas paid two reallocations per tick).
     this._streamCanvas = document.createElement('canvas');
+    this._hqStreamCanvas = document.createElement('canvas');
+    this._streamEncodePending = false;
     this._focusResizeObserver = null;
     this._boundHandlers = {};
     this._fullscreenInertRecords = [];
@@ -1407,6 +1412,31 @@ class DisplaySlot {
   toggleStreaming() {
     if (this.streaming) { this.stopStreaming(); } else { this.startStreaming(); }
   }
+  // Size a capture canvas once per dimension change — width/height
+  // assignment reallocates the backing store even when the value is equal
+  // in some engines, so guard both.
+  static _sizeCanvas(canvas, w, h) {
+    if (canvas.width !== w) canvas.width = w;
+    if (canvas.height !== h) canvas.height = h;
+  }
+  // Async JPEG→base64: toBlob lets the browser encode off the main thread
+  // where it can; only the byte→base64 conversion (chunked) stays on it.
+  // The old toDataURL path blocked the main thread for encode AND base64
+  // (~10-40 ms/tick at retina), on the same thread as remote-control input.
+  static _canvasJpegBase64(canvas, quality) {
+    return new Promise((resolve, reject) => {
+      if (typeof canvas.toBlob !== 'function') {
+        resolve(canvas.toDataURL('image/jpeg', quality).split(',')[1]);
+        return;
+      }
+      canvas.toBlob(blob => {
+        if (!blob) { reject(new Error('canvas JPEG encode failed')); return; }
+        blob.arrayBuffer()
+          .then(buf => resolve(dashboardControlBytesToBase64(new Uint8Array(buf))))
+          .catch(reject);
+      }, 'image/jpeg', quality);
+    });
+  }
   startStreaming() {
     if (this.streaming || !this.connected) return;
     this.streaming = true;
@@ -1415,47 +1445,55 @@ class DisplaySlot {
     this.streamBtn.innerHTML = '&#x1F441; Streaming';
     this.frameIdEl.style.display = '';
     const streamName = 'display_' + this.displayId;
-    const ctx = this._streamCanvas.getContext('2d');
+    const liveCtx = this._streamCanvas.getContext('2d');
+    const hqCtx = this._hqStreamCanvas.getContext('2d');
     this._streamIntervalId = setInterval(() => {
       if (!this.streaming || !this.connected || !app) return;
       const vid = this.videoEl;
       if (!vid.videoWidth || !vid.videoHeight) return;
+      // Last tick's encode still in flight (slow machine / huge retina
+      // frame): skip this tick instead of stacking encodes.
+      if (this._streamEncodePending) return;
       const sw = vid.videoWidth;
       const sh = vid.videoHeight;
       this._streamFrameCounter++;
       const frameId = streamName + '-f' + String(this._streamFrameCounter).padStart(5, '0');
       // Live-res: scale to LIVE_RES maintaining aspect ratio within a square
       const scale = Math.min(LIVE_RES / sw, LIVE_RES / sh);
-      const lw = Math.round(sw * scale);
-      const lh = Math.round(sh * scale);
-      this._streamCanvas.width = lw;
-      this._streamCanvas.height = lh;
-      ctx.drawImage(vid, 0, 0, lw, lh);
-      const liveJpeg = this._streamCanvas.toDataURL('image/jpeg', 0.8);
-      const liveB64 = liveJpeg.split(',')[1];
-      // Skip duplicate frames for voice model — still send HQ to server for archival
-      const sizeDelta = Math.abs(liveB64.length - (this._lastFrameLen || 0)) / (this._lastFrameLen || 1);
-      const frameDup = sizeDelta < 0.02 && this._lastFrameLen > 0;
-      if (!frameDup) {
-        this._lastFrameLen = liveB64.length;
-        app.send_frame(liveB64, frameId);
-        this.frameIdEl.textContent = frameId.split('-').pop();
-        this.frameIdEl.style.color = 'var(--overlay0)';
-        tickerFramesSent++;
-      } else {
-        this.frameIdEl.textContent = frameId.split('-').pop() + ' dropped';
-        this.frameIdEl.style.color = 'var(--yellow)';
-        tickerFramesDropped++;
-        sendDashboardVoiceDiagnostic('frame_skip', 'duplicate frame skipped (delta=' + (sizeDelta * 100).toFixed(1) + '%)');
-      }
-      // HQ: logical resolution — always sent for archival
+      DisplaySlot._sizeCanvas(this._streamCanvas, Math.round(sw * scale), Math.round(sh * scale));
+      liveCtx.drawImage(vid, 0, 0, this._streamCanvas.width, this._streamCanvas.height);
+      // HQ: logical resolution — always sent for archival. Drawn in the
+      // same tick as the live lane so both lanes capture the same instant.
       const dpr = window.devicePixelRatio || 1;
-      this._streamCanvas.width = Math.round(sw / dpr);
-      this._streamCanvas.height = Math.round(sh / dpr);
-      ctx.drawImage(vid, 0, 0, this._streamCanvas.width, this._streamCanvas.height);
-      const hqJpeg = this._streamCanvas.toDataURL('image/jpeg', 0.80);
-      const hqB64 = hqJpeg.split(',')[1];
-      sendDashboardVideoFrameToServer(hqB64, frameId, streamName);
+      DisplaySlot._sizeCanvas(this._hqStreamCanvas, Math.round(sw / dpr), Math.round(sh / dpr));
+      hqCtx.drawImage(vid, 0, 0, this._hqStreamCanvas.width, this._hqStreamCanvas.height);
+      this._streamEncodePending = true;
+      Promise.all([
+        DisplaySlot._canvasJpegBase64(this._streamCanvas, 0.8),
+        DisplaySlot._canvasJpegBase64(this._hqStreamCanvas, 0.80),
+      ]).then(([liveB64, hqB64]) => {
+        if (!this.streaming) return;
+        // Skip duplicate frames for voice model — still send HQ to server for archival
+        const sizeDelta = Math.abs(liveB64.length - (this._lastFrameLen || 0)) / (this._lastFrameLen || 1);
+        const frameDup = sizeDelta < 0.02 && this._lastFrameLen > 0;
+        if (!frameDup) {
+          this._lastFrameLen = liveB64.length;
+          app.send_frame(liveB64, frameId);
+          this.frameIdEl.textContent = frameId.split('-').pop();
+          this.frameIdEl.style.color = 'var(--overlay0)';
+          tickerFramesSent++;
+        } else {
+          this.frameIdEl.textContent = frameId.split('-').pop() + ' dropped';
+          this.frameIdEl.style.color = 'var(--yellow)';
+          tickerFramesDropped++;
+          sendDashboardVoiceDiagnostic('frame_skip', 'duplicate frame skipped (delta=' + (sizeDelta * 100).toFixed(1) + '%)');
+        }
+        sendDashboardVideoFrameToServer(hqB64, frameId, streamName);
+      }).catch(err => {
+        console.warn('[DisplaySlot] stream frame encode failed', err);
+      }).finally(() => {
+        this._streamEncodePending = false;
+      });
     }, 1000);
   }
   stopStreaming() {
@@ -3384,9 +3422,34 @@ function applyDisplayStripState() {
     railRaf = requestAnimationFrame(renderWorkspace);
   }
 
-  function observe(element, options) {
+  // Self-feed filter: the 3 s getStats sampler writes the metrics chip and
+  // the 1 Hz presence-stream tick writes the frame-id chip — both INSIDE
+  // the observed container — so every sample re-rendered the whole rail
+  // forever, even on a tab the user wasn't looking at. Mutations that only
+  // touch those periodic chips are dropped here; every rail-visible state
+  // they correlate with (streaming class flips, status text, connection
+  // classes) still arrives through its own mutation. characterData records
+  // target TEXT nodes — classify by the parent element.
+  const RAIL_SELF_FEED_SELECTOR = '.display-live-metrics, .stream-frame-id';
+  function railMutationIgnored(record) {
+    const target = record.target;
+    const el = target.nodeType === 1 ? target : target.parentElement;
+    return Boolean(el && el.closest && el.closest(RAIL_SELF_FEED_SELECTOR));
+  }
+  function observe(element, options, filterSelfFeed = false) {
     if (!element) return;
-    new MutationObserver(scheduleWorkspace).observe(element, options);
+    if (!filterSelfFeed) {
+      new MutationObserver(scheduleWorkspace).observe(element, options);
+      return;
+    }
+    new MutationObserver((records) => {
+      for (const record of records) {
+        if (!railMutationIgnored(record)) {
+          scheduleWorkspace();
+          return;
+        }
+      }
+    }).observe(element, options);
   }
   // The observer catches legacy direct DOM writes without rebuilding the
   // rail. Keyed rows and stable authority/screen controls preserve focus;
@@ -3398,7 +3461,7 @@ function applyDisplayStripState() {
     characterData: true,
     attributes: true,
     attributeFilter: ['class', 'style', 'aria-pressed', 'disabled'],
-  });
+  }, true);
   observe(document.getElementById('station-peer-chips'), {
     subtree: true,
     childList: true,

--- a/static/app/45-displays-webrtc.js
+++ b/static/app/45-displays-webrtc.js
@@ -251,6 +251,10 @@ class DisplaySlot {
     this._streamCanvas = document.createElement('canvas');
     this._hqStreamCanvas = document.createElement('canvas');
     this._streamEncodePending = false;
+    // Monotonic per-start stream generation: a late async encode from
+    // generation N must never emit into (or clobber the pending flag of)
+    // generation N+1 after a quick stop→start.
+    this._streamGeneration = 0;
     this._focusResizeObserver = null;
     this._boundHandlers = {};
     this._fullscreenInertRecords = [];
@@ -1440,6 +1444,12 @@ class DisplaySlot {
   startStreaming() {
     if (this.streaming || !this.connected) return;
     this.streaming = true;
+    // New generation: late completions from a previous run compare against
+    // this and drop; the pending flag belongs to the new run (a leftover
+    // true from a stopped run must not eat the first ticks).
+    this._streamGeneration += 1;
+    this._streamEncodePending = false;
+    const gen = this._streamGeneration;
     this.streamBtn.classList.add('active');
     this.streamBtn.setAttribute('aria-pressed', 'true');
     this.streamBtn.innerHTML = '&#x1F441; Streaming';
@@ -1472,19 +1482,29 @@ class DisplaySlot {
         DisplaySlot._canvasJpegBase64(this._streamCanvas, 0.8),
         DisplaySlot._canvasJpegBase64(this._hqStreamCanvas, 0.80),
       ]).then(([liveB64, hqB64]) => {
-        if (!this.streaming) return;
+        // Restarted since capture: these pixels belong to the retired
+        // sequence — never emit them into the new one.
+        if (gen !== this._streamGeneration) return;
+        // Stopped (not restarted): the frame captured pre-stop pixels —
+        // still deliver it (it is the stream's final frame), but leave the
+        // torn-down chrome (frame-id chip) alone.
+        const chromeLive = this.streaming;
         // Skip duplicate frames for voice model — still send HQ to server for archival
         const sizeDelta = Math.abs(liveB64.length - (this._lastFrameLen || 0)) / (this._lastFrameLen || 1);
         const frameDup = sizeDelta < 0.02 && this._lastFrameLen > 0;
         if (!frameDup) {
           this._lastFrameLen = liveB64.length;
           app.send_frame(liveB64, frameId);
-          this.frameIdEl.textContent = frameId.split('-').pop();
-          this.frameIdEl.style.color = 'var(--overlay0)';
+          if (chromeLive) {
+            this.frameIdEl.textContent = frameId.split('-').pop();
+            this.frameIdEl.style.color = 'var(--overlay0)';
+          }
           tickerFramesSent++;
         } else {
-          this.frameIdEl.textContent = frameId.split('-').pop() + ' dropped';
-          this.frameIdEl.style.color = 'var(--yellow)';
+          if (chromeLive) {
+            this.frameIdEl.textContent = frameId.split('-').pop() + ' dropped';
+            this.frameIdEl.style.color = 'var(--yellow)';
+          }
           tickerFramesDropped++;
           sendDashboardVoiceDiagnostic('frame_skip', 'duplicate frame skipped (delta=' + (sizeDelta * 100).toFixed(1) + '%)');
         }
@@ -1492,13 +1512,18 @@ class DisplaySlot {
       }).catch(err => {
         console.warn('[DisplaySlot] stream frame encode failed', err);
       }).finally(() => {
-        this._streamEncodePending = false;
+        // Only this generation may clear its own pending flag — a late
+        // completion must not unblock (or race) a restarted stream's ticks.
+        if (gen === this._streamGeneration) this._streamEncodePending = false;
       });
     }, 1000);
   }
   stopStreaming() {
     this.streaming = false;
     if (this._streamIntervalId) { clearInterval(this._streamIntervalId); this._streamIntervalId = null; }
+    // The in-flight encode (if any) still delivers its final frame above;
+    // the flag itself must not leak into a subsequent start.
+    this._streamEncodePending = false;
     this.streamBtn.classList.remove('active');
     this.streamBtn.setAttribute('aria-pressed', 'false');
     this.streamBtn.innerHTML = '&#x1F441; Stream';

--- a/static/app/45-displays-webrtc.js
+++ b/static/app/45-displays-webrtc.js
@@ -182,6 +182,24 @@ const DISPLAY_SLOT_POLICY = {
   },
 };
 
+// Presence-stream generations, keyed by DISPLAY id at module level — not on
+// the slot instance. A removed display slot can be re-granted as a brand-new
+// DisplaySlot object whose stream reuses the same display_N identity; an
+// instance-local counter would let the old object's in-flight encode pass
+// its own generation check and emit stale pre-teardown pixels into the new
+// slot's stream. Bumped on every stream start AND on removeDisplaySlot;
+// completions compare against this map.
+const displayStreamGenerations = new Map();
+function displayStreamGeneration(displayId) {
+  return displayStreamGenerations.get(Number(displayId) || 0) || 0;
+}
+function bumpDisplayStreamGeneration(displayId) {
+  const id = Number(displayId) || 0;
+  const next = (displayStreamGenerations.get(id) || 0) + 1;
+  displayStreamGenerations.set(id, next);
+  return next;
+}
+
 class DisplaySlot {
   constructor(displayId, width, height) {
     this.displayId = displayId;
@@ -251,10 +269,6 @@ class DisplaySlot {
     this._streamCanvas = document.createElement('canvas');
     this._hqStreamCanvas = document.createElement('canvas');
     this._streamEncodePending = false;
-    // Monotonic per-start stream generation: a late async encode from
-    // generation N must never emit into (or clobber the pending flag of)
-    // generation N+1 after a quick stop→start.
-    this._streamGeneration = 0;
     this._focusResizeObserver = null;
     this._boundHandlers = {};
     this._fullscreenInertRecords = [];
@@ -1444,12 +1458,13 @@ class DisplaySlot {
   startStreaming() {
     if (this.streaming || !this.connected) return;
     this.streaming = true;
-    // New generation: late completions from a previous run compare against
-    // this and drop; the pending flag belongs to the new run (a leftover
-    // true from a stopped run must not eat the first ticks).
-    this._streamGeneration += 1;
+    // New generation for this DISPLAY id (module-level; see the map above):
+    // late completions from a previous run — same slot object or a removed
+    // predecessor — compare against it and drop; the pending flag belongs
+    // to the new run (a leftover true from a stopped run must not eat the
+    // first ticks).
+    const gen = bumpDisplayStreamGeneration(this.displayId);
     this._streamEncodePending = false;
-    const gen = this._streamGeneration;
     this.streamBtn.classList.add('active');
     this.streamBtn.setAttribute('aria-pressed', 'true');
     this.streamBtn.innerHTML = '&#x1F441; Streaming';
@@ -1482,9 +1497,10 @@ class DisplaySlot {
         DisplaySlot._canvasJpegBase64(this._streamCanvas, 0.8),
         DisplaySlot._canvasJpegBase64(this._hqStreamCanvas, 0.80),
       ]).then(([liveB64, hqB64]) => {
-        // Restarted since capture: these pixels belong to the retired
-        // sequence — never emit them into the new one.
-        if (gen !== this._streamGeneration) return;
+        // Restarted since capture — by this slot object, or by a new slot
+        // re-granted the same display id after this one was removed: these
+        // pixels belong to the retired sequence, never emit them.
+        if (gen !== displayStreamGeneration(this.displayId)) return;
         // Stopped (not restarted): the frame captured pre-stop pixels —
         // still deliver it (it is the stream's final frame), but leave the
         // torn-down chrome (frame-id chip) alone.
@@ -1512,9 +1528,9 @@ class DisplaySlot {
       }).catch(err => {
         console.warn('[DisplaySlot] stream frame encode failed', err);
       }).finally(() => {
-        // Only this generation may clear its own pending flag — a late
+        // Only the live generation may clear its own pending flag — a late
         // completion must not unblock (or race) a restarted stream's ticks.
-        if (gen === this._streamGeneration) this._streamEncodePending = false;
+        if (gen === displayStreamGeneration(this.displayId)) this._streamEncodePending = false;
       });
     }, 1000);
   }
@@ -1786,6 +1802,11 @@ function removeDisplaySlot(displayId) {
   slot.disconnect({ userInitiated: true });
   if (slot.el && slot.el.parentNode) slot.el.parentNode.removeChild(slot.el);
   displaySlots.delete(displayId);
+  // Invalidate the removed slot's stream generation: an in-flight encode
+  // from this slot must not deliver into a successor slot that reuses the
+  // display_N stream identity (the plain stop path deliberately still
+  // delivers its final frame; removal does not).
+  bumpDisplayStreamGeneration(displayId);
   if (typeof window.retireLiveDisplayWorkspaceSlot === 'function') {
     window.retireLiveDisplayWorkspaceSlot(displayId);
   }

--- a/static/app/47-annotation-clips.js
+++ b/static/app/47-annotation-clips.js
@@ -2205,19 +2205,31 @@ async function* extractClipFrames(player, inSecs, outSecs, fps, keyframes, annot
     }
 
     const blob = await new Promise(r => captureCanvas.toBlob(r, 'image/jpeg', quality));
-    const b64 = await new Promise(r => {
-      const reader = new FileReader();
-      reader.onload = () => r(reader.result.split(',')[1]);
-      reader.readAsDataURL(blob);
-    });
+    // Raw bytes are the canonical yield: the tunnel lane uploads them
+    // directly, and only the legacy /ws payload and attach data-URLs
+    // derive base64 (clipFrameBase64) — the old per-frame FileReader
+    // base64 round-tripped 20-60 MB per clip through encode → decode.
+    const bytes = new Uint8Array(await blob.arrayBuffer());
 
-    yield { index: i, total: timestamps.length, t, isKeyframe, annotated: hasAnnotation, b64, blob };
+    yield { index: i, total: timestamps.length, t, isKeyframe, annotated: hasAnnotation, bytes, blob };
   }
+}
+
+// Base64 for the lanes that still speak it (legacy /ws media messages,
+// pending-attachment data URLs). Chunked conversion — see
+// dashboardControlBytesToBase64 (50-control-transport.js).
+function clipFrameBase64(frame) {
+  return dashboardControlBytesToBase64(frame.bytes);
 }
 
 async function generateClipPreview() {
   if (clipInSecs === null || clipOutSecs === null || !recPlayer) return;
   const strip = document.getElementById('clip-preview-strip');
+  // Revoke the previous preview's object URLs before discarding the DOM —
+  // innerHTML='' alone pinned every prior strip's frame blobs until unload.
+  strip.querySelectorAll('img[src^="blob:"]').forEach(img => {
+    try { URL.revokeObjectURL(img.src); } catch (_) {}
+  });
   strip.innerHTML = '';
   strip.classList.remove('hidden');
 
@@ -2332,17 +2344,8 @@ async function submitClip(action) {
       progressText.textContent = `Extracting ${frame.index + 1}/${frame.total}...`;
 
       const frameId = `${clipId}-f${String(frame.index).padStart(3, '0')}`;
-      const framePayload = {
-        t: 'clip_frame',
-        clip_id: clipId,
-        frame_id: frameId,
-        frame_index: frame.index,
-        timestamp_secs: frame.t,
-        is_keyframe: frame.isKeyframe,
-        annotated: frame.annotated,
-        data: frame.b64,
-      };
       if (useMediaTunnel) {
+        // Binary lane: raw bytes straight through — no base64 round trip.
         await uploadDashboardMediaTunnel('api_media_clip_frame', {
           clip_id: clipId,
           frame_id: frameId,
@@ -2350,12 +2353,21 @@ async function submitClip(action) {
           timestamp_secs: frame.t,
           is_keyframe: frame.isKeyframe,
           annotated: frame.annotated,
-        }, dashboardControlBase64ToBytes(frame.b64), 'clip frame');
+        }, frame.bytes, 'clip frame');
       } else {
-        sendLegacyMediaEditorMessage(framePayload);
+        sendLegacyMediaEditorMessage({
+          t: 'clip_frame',
+          clip_id: clipId,
+          frame_id: frameId,
+          frame_index: frame.index,
+          timestamp_secs: frame.t,
+          is_keyframe: frame.isKeyframe,
+          annotated: frame.annotated,
+          data: clipFrameBase64(frame),
+        });
       }
       if (action === 'attach') {
-        sentFrames.push({ frameId, b64: frame.b64 });
+        sentFrames.push({ frameId, b64: clipFrameBase64(frame) });
       }
       frameIndex++;
 

--- a/static/app/48-router-settings.js
+++ b/static/app/48-router-settings.js
@@ -459,6 +459,10 @@ const contextViz = {
   rotationX: 0.34,
   rotationY: -0.48,
   zoom: 38,
+  // Identity of the analyzed snapshot + timeline shape the current Three
+  // scene was built from; contextBuildThree skips the teardown/rebuild
+  // when it matches (48b-context-viz.js).
+  sceneKey: '',
 };
 
 // analyzeContextSnapshot walks the entire raw payload, which is expensive at

--- a/static/app/48b-context-viz.js
+++ b/static/app/48b-context-viz.js
@@ -1165,6 +1165,24 @@ function contextPressureColor(pct) {
   return CONTEXT_VIZ_THEME.pressure.ok;
 }
 
+// Per-object token for the scene key: replaceStoredContextSnapshot swaps a
+// compact snapshot for its exact-replay twin while DELIBERATELY preserving
+// __context_key, so the key alone cannot distinguish old from new data —
+// the replacement mints a NEW object, and this token tracks object
+// identity (the analysis memo is likewise object-keyed).
+let contextSceneObjectSeq = 0;
+const contextSceneObjectTokens = new WeakMap();
+function contextSceneObjectToken(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object') return '0';
+  let token = contextSceneObjectTokens.get(snapshot);
+  if (!token) {
+    contextSceneObjectSeq += 1;
+    token = String(contextSceneObjectSeq);
+    contextSceneObjectTokens.set(snapshot, token);
+  }
+  return token;
+}
+
 function contextBuildThree(analysis, snapshot) {
   const empty = document.getElementById('context-scene-empty');
   if (empty) empty.style.display = analysis && analysis.parts.length ? 'none' : 'flex';
@@ -1175,11 +1193,13 @@ function contextBuildThree(analysis, snapshot) {
   // this pane is visible, detail-pane churn, selection changes — used to
   // tear down and rebuild every geometry, material, and label texture.
   // Selection highlighting mutates in place (contextUpdateMeshSelection),
-  // so it deliberately stays out of the key.
+  // so it deliberately stays out of the key. The object token catches
+  // exact-replay replacement, which keeps the key but swaps the data.
   const { timeline } = contextTimelineForForegroundSession();
   const sceneKey = analysis && analysis.parts.length
     ? [
         contextRawRenderKey(snapshot),
+        contextSceneObjectToken(snapshot),
         timeline.length,
         timeline.indexOf(snapshot),
         CONTEXT_VIZ_THEME.labelBg,

--- a/static/app/48b-context-viz.js
+++ b/static/app/48b-context-viz.js
@@ -752,7 +752,8 @@ function stepContextReplaySnapshot(delta) {
     contextReplayMode = 'replay';
     contextReplayIndexBySession.set(key, next);
     contextSelectedPartId = null;
-    renderContextPane();
+    // Coalesced like the slider: held arrow keys repeat faster than frames.
+    scheduleContextPaneRender();
   }
   return true;
 }
@@ -853,7 +854,11 @@ function wireContextPaneListeners() {
     contextReplayMode = 'replay';
     contextReplayIndexBySession.set(key, Math.max(0, Math.min(timeline.length - 1, Number(target.value) || 0)));
     contextSelectedPartId = null;
-    renderContextPane();
+    // rAF-coalesced: range inputs fire per pixel while dragging, and each
+    // distinct index is a different snapshot (full analyze + scene build).
+    // Intermediate positions within one frame render nothing the eye
+    // would have seen; the trailing frame shows the slider's final index.
+    scheduleContextPaneRender();
   });
   document.addEventListener('keydown', ev => {
     if (contextShouldHandleKeyboardEvent(ev)) {
@@ -885,6 +890,9 @@ function focusContextPart(partId) {
   contextUpdateMeshSelection();
   contextViz.zoom = Math.min(contextViz.zoom, 28);
   contextRenderThree();
+  // The bob loop runs only while a part is selected — (re)arm it here
+  // (it exits on deselect/tab-away by itself).
+  if (contextPaneVisible()) contextStartThreeAnimation();
 }
 
 function contextDisposeObject(object) {
@@ -1110,13 +1118,45 @@ function contextLabelSprite(text, color = CONTEXT_VIZ_THEME.labelText, scale = 1
   return sprite;
 }
 
+// Label sprites are the GPU-upload churn of a scene rebuild (2D-canvas text
+// rasterize + CanvasTexture upload per label). Text/color/scale triples
+// recur across rebuilds — category lane names, the timeline caption — so
+// cache the sprites and let contextClearThreeRoot detach them undisposed.
+// Eviction disposes only unparented sprites; one still in the scene loses
+// its cached flag instead, so the next root clear disposes it normally.
+const contextLabelSpriteCache = new Map();
+const CONTEXT_LABEL_SPRITE_CACHE_CAP = 96;
+function contextLabelSpriteCached(text, color = CONTEXT_VIZ_THEME.labelText, scale = 1) {
+  // labelBg is read inside contextLabelSprite - key on it too so a theme
+  // flip re-rasterizes instead of serving stale-background sprites.
+  const key = [text, color, scale, CONTEXT_VIZ_THEME.labelBg].join('\u001f');
+  let sprite = contextLabelSpriteCache.get(key);
+  if (sprite) {
+    contextLabelSpriteCache.delete(key);
+    contextLabelSpriteCache.set(key, sprite); // LRU bump
+    return sprite;
+  }
+  sprite = contextLabelSprite(text, color, scale);
+  sprite.userData.cachedLabel = true;
+  contextLabelSpriteCache.set(key, sprite);
+  while (contextLabelSpriteCache.size > CONTEXT_LABEL_SPRITE_CACHE_CAP) {
+    const [oldKey, old] = contextLabelSpriteCache.entries().next().value;
+    contextLabelSpriteCache.delete(oldKey);
+    if (old.parent) old.userData.cachedLabel = false;
+    else contextDisposeObject(old);
+  }
+  return sprite;
+}
+
 function contextClearThreeRoot() {
   if (!contextViz.root) return;
   for (const child of [...contextViz.root.children]) {
     contextViz.root.remove(child);
+    if (child.userData && child.userData.cachedLabel) continue;
     contextDisposeObject(child);
   }
   contextViz.meshes = [];
+  contextViz.sceneKey = '';
 }
 
 function contextPressureColor(pct) {
@@ -1129,8 +1169,30 @@ function contextBuildThree(analysis, snapshot) {
   const empty = document.getElementById('context-scene-empty');
   if (empty) empty.style.display = analysis && analysis.parts.length ? 'none' : 'flex';
   if (!contextInitThree()) return;
+  // Scene identity: analyzed snapshot + the timeline shape the rail bars
+  // render from (+ theme, whose colors bake into materials). Re-renders
+  // for the SAME scene — another session's context_snapshot arriving while
+  // this pane is visible, detail-pane churn, selection changes — used to
+  // tear down and rebuild every geometry, material, and label texture.
+  // Selection highlighting mutates in place (contextUpdateMeshSelection),
+  // so it deliberately stays out of the key.
+  const { timeline } = contextTimelineForForegroundSession();
+  const sceneKey = analysis && analysis.parts.length
+    ? [
+        contextRawRenderKey(snapshot),
+        timeline.length,
+        timeline.indexOf(snapshot),
+        CONTEXT_VIZ_THEME.labelBg,
+      ].join('|')
+    : 'empty';
+  if (contextViz.sceneKey === sceneKey && (sceneKey === 'empty' || contextViz.meshes.length)) {
+    contextUpdateMeshSelection();
+    contextRenderThree();
+    return;
+  }
   contextClearThreeRoot();
   if (!analysis || !analysis.parts.length) {
+    contextViz.sceneKey = 'empty';
     contextRenderThree();
     return;
   }
@@ -1147,7 +1209,7 @@ function contextBuildThree(analysis, snapshot) {
     lane.position.set(x, -0.06, 0);
     root.add(lane);
     const def = CONTEXT_CATEGORY_DEFS[category] || CONTEXT_CATEGORY_DEFS.other;
-    const label = contextLabelSprite(def.label, def.color, 1.25);
+    const label = contextLabelSpriteCached(def.label, def.color, 1.25);
     label.position.set(x, 0.65, -zSpread / 2 - 2.2);
     root.add(label);
   }
@@ -1205,16 +1267,15 @@ function contextBuildThree(analysis, snapshot) {
   );
   fill.position.set(reservoirX, fillHeight / 2, 0);
   root.add(fill);
-  const usageLabel = contextLabelSprite(`${Math.round(pct * 100)}% window`, contextPressureColor(pct), 1.1);
+  const usageLabel = contextLabelSpriteCached(`${Math.round(pct * 100)}% window`, contextPressureColor(pct), 1.1);
   usageLabel.position.set(reservoirX, reservoirHeight + 1.1, 0);
   root.add(usageLabel);
   if (hardWindow && hardWindow !== effectiveWindow) {
-    const hardLabel = contextLabelSprite('hard limit tracked', CONTEXT_VIZ_THEME.pressure.high, 0.9);
+    const hardLabel = contextLabelSpriteCached('hard limit tracked', CONTEXT_VIZ_THEME.pressure.high, 0.9);
     hardLabel.position.set(reservoirX, -0.2, 2.7);
     root.add(hardLabel);
   }
 
-  const { timeline } = contextTimelineForForegroundSession();
   if (timeline.length > 1) {
     const selectedIdx = timeline.indexOf(snapshot);
     const railWidth = Math.min(28, Math.max(10, timeline.length * 0.72));
@@ -1234,11 +1295,12 @@ function contextBuildThree(analysis, snapshot) {
       bar.position.set(x, barHeight / 2, zSpread / 2 + 3.6);
       root.add(bar);
     });
-    const railLabel = contextLabelSprite('session replay timeline', CONTEXT_VIZ_THEME.railLabel, 1.0);
+    const railLabel = contextLabelSpriteCached('session replay timeline', CONTEXT_VIZ_THEME.railLabel, 1.0);
     railLabel.position.set(0, 5.6, zSpread / 2 + 3.6);
     root.add(railLabel);
   }
 
+  contextViz.sceneKey = sceneKey;
   contextUpdateMeshSelection();
   contextRenderThree();
 }
@@ -1286,10 +1348,12 @@ function contextRenderThree(time = 0) {
   if (contextViz.root) {
     contextViz.root.rotation.set(0, 0, 0);
   }
-  if (time && contextViz.meshes.length) {
+  if (contextViz.meshes.length) {
     const t = time * 0.001;
     for (const mesh of contextViz.meshes) {
-      const selected = mesh.userData.partId === contextSelectedPartId;
+      // On-demand renders pass time=0: settle every mesh at its base so a
+      // retired bob loop can't strand the previously-selected mesh mid-arc.
+      const selected = time && mesh.userData.partId === contextSelectedPartId;
       if (selected) {
         mesh.position.y = mesh.userData.baseY + Math.sin(t * 3.2) * 0.08;
       } else {
@@ -1300,13 +1364,25 @@ function contextRenderThree(time = 0) {
   contextViz.renderer.render(contextViz.scene, contextViz.camera);
 }
 
+// The only per-frame animation is the selected-part bob — with nothing
+// selected the scene is static and every interaction (drag, zoom, snapshot,
+// slider) already renders on demand, so the 60 fps loop only runs while a
+// part is selected and stops itself on deselect/tab-away (with one settling
+// render so the bob doesn't freeze mid-arc).
 function contextStartThreeAnimation() {
+  if (!contextSelectedPartId) {
+    contextStopThreeAnimation();
+    contextRenderThree();
+    return;
+  }
   if (contextViz.raf) return;
   const frame = time => {
     contextViz.raf = null;
-    if (activeTab === 'activity' && activeActivitySubtab === 'context') {
+    if (activeTab === 'activity' && activeActivitySubtab === 'context' && contextSelectedPartId) {
       contextRenderThree(time);
       contextViz.raf = requestAnimationFrame(frame);
+    } else {
+      contextRenderThree();
     }
   };
   contextViz.raf = requestAnimationFrame(frame);

--- a/static/app/49-daemons-multihost.js
+++ b/static/app/49-daemons-multihost.js
@@ -464,6 +464,22 @@ async function refreshVirtualDisplayAvailability() {
   updateVirtualDisplayAvailabilityUi();
 }
 
+// Coalesced twin for PROGRESS-driven callers (per-chunk response/byte-stream
+// frames). dashboardUpdateTransportStatus rebuilds the full debugStatus
+// object, re-renders four target summaries, and refreshes several dependent
+// surfaces — running that per 16 KiB chunk burned ~0.3–1 ms of main thread
+// per chunk on large pulls. Steady-state progress coalesces into one
+// trailing 100 ms tick; state TRANSITIONS (open/close/error, stream
+// start/end/complete/reject) keep calling the immediate form.
+let dashboardTransportStatusTickTimer = 0;
+function dashboardScheduleTransportStatusUpdate() {
+  if (dashboardTransportStatusTickTimer) return;
+  dashboardTransportStatusTickTimer = window.setTimeout(() => {
+    dashboardTransportStatusTickTimer = 0;
+    dashboardUpdateTransportStatus();
+  }, 100);
+}
+
 function dashboardUpdateTransportStatus() {
   const group = document.getElementById('sb-dashboard-transport');
   const dot = document.getElementById('sb-dashboard-transport-dot');

--- a/static/app/50-control-transport.js
+++ b/static/app/50-control-transport.js
@@ -280,7 +280,11 @@ class DashboardControlTransport {
         return;
       }
       if (dashboardServerMessageDispatcher) {
-        dashboardServerMessageDispatcher(JSON.stringify(msg));
+        // Pass the already-parsed frame: the dispatcher and the WASM
+        // handoff accept objects (the tunnel event path below has always
+        // passed payload objects) — re-stringifying here forced a
+        // parse → stringify → parse round trip per PTY output frame.
+        dashboardServerMessageDispatcher(msg);
       }
       return;
     }
@@ -413,7 +417,9 @@ class DashboardControlTransport {
     if (!completed && this.chunkedResponses.has(chunkKey)) {
       this.sendChunkCredit(id, 1, chunkKey === id ? null : chunkKey);
     }
-    dashboardUpdateTransportStatus();
+    // Per-chunk progress: coalesced tick. Completion/rejection inside
+    // maybeCompleteChunkedResponse already rendered immediately.
+    dashboardScheduleTransportStatusUpdate();
   }
 
   handleResponseEnd(msg) {
@@ -544,7 +550,8 @@ class DashboardControlTransport {
     if (!completed && this.byteStreams.has(streamId)) {
       this.sendChunkCredit(id, 1, streamId === id ? null : streamId);
     }
-    dashboardUpdateTransportStatus();
+    // Per-chunk progress: coalesced tick (transitions render immediately).
+    dashboardScheduleTransportStatusUpdate();
   }
 
   handleByteStreamEnd(msg) {
@@ -1605,11 +1612,14 @@ function dashboardControlBase64ToBytes(value) {
 }
 
 function dashboardControlBytesToBase64(bytes) {
-  let binary = '';
-  for (let i = 0; i < bytes.byteLength; i += 1) {
-    binary += String.fromCharCode(bytes[i]);
+  // Batch via fromCharCode.apply over bounded slices: the per-byte string
+  // concatenation this replaces built ~16k intermediate strings per upload
+  // chunk. 0x8000 stays comfortably under engine argument-count limits.
+  const chunks = [];
+  for (let i = 0; i < bytes.byteLength; i += 0x8000) {
+    chunks.push(String.fromCharCode.apply(null, bytes.subarray(i, i + 0x8000)));
   }
-  return btoa(binary);
+  return btoa(chunks.join(''));
 }
 
 function dashboardControlRequestTimeoutMs(method) {
@@ -2764,6 +2774,23 @@ async function fetchRemoteAgentCard(baseUrl) {
   return card;
 }
 
+// Last-rendered snapshot guards: peer status flips (idle↔working) arrive per
+// remote task activity and used to rebuild the whole daemons list — plus a
+// seven-surface cascade (host filter sweep over up to 10k log entries, three
+// select rebuilds) — even when nothing rendered had changed. The row HTML is
+// its own signature for the list; the pickers' inputs (id/label/connected)
+// get a dedicated one so a mid-row change (e.g. version skew) doesn't churn
+// the selects.
+let daemonsListHostOptionsSig = null;
+
+function daemonsListHostOptionsSignature() {
+  return JSON.stringify([
+    selfPeerId,
+    selfHostLabel,
+    ...daemons.map(d => [d.host_id, d.label || '', d.connected !== false]),
+  ]);
+}
+
 function renderDaemonsList() {
   const el = document.getElementById('daemons-list');
   if (!el) return;
@@ -2782,7 +2809,16 @@ function renderDaemonsList() {
   for (const d of daemons) {
     rows.push(renderDaemonRow(d, false));
   }
-  el.innerHTML = rows.join('');
+  const html = rows.join('');
+  if (el.__intendantRenderedHtml === html) {
+    // Identical rendered list: the existing DOM (with its listeners,
+    // expansion state, approvals section, and attached display panes)
+    // stays — skip straight to the cheap always-on consumers below.
+    renderDaemonsListTail();
+    return;
+  }
+  el.__intendantRenderedHtml = html;
+  el.innerHTML = html;
 
   // Wire remove buttons.
   el.querySelectorAll('.daemon-row .remove-btn').forEach(btn => {
@@ -2862,8 +2898,19 @@ function renderDaemonsList() {
   // attached to the freshly-rendered <video> elements after re-render.
   reapplyPeerDisplayPanes();
 
+  renderDaemonsListTail();
+}
+
+// The always-on consumers of a daemons-list render — run on every call,
+// whether or not the row DOM was rebuilt. The four host pickers rebuild
+// only when their actual inputs changed (see daemonsListHostOptionsSig):
+// refreshHostFilterOptions ends in applyHostFilter, a class-toggle sweep
+// over every retained log entry, and each picker resets its <select>.
+function renderDaemonsListTail() {
   // Keep the Station header's peer-display chips in sync with the same
-  // peer add/remove/state events that re-render this list.
+  // peer add/remove/state events that re-render this list. Cheap
+  // (replaceChildren over a handful of peers) and display lists aren't
+  // fully encoded in the row HTML, so this stays unconditional.
   stationRenderPeerChips();
 
   // Toggle host-badge visibility in the Activity tab. Single-host
@@ -2873,18 +2920,23 @@ function renderDaemonsList() {
     logStream.classList.toggle('show-host-badges', daemons.length > 0);
   }
 
-  // Keep the Activity host filter dropdown in sync with the current
-  // daemon list (options may have been added/removed).
-  refreshHostFilterOptions();
+  const optionsSig = daemonsListHostOptionsSignature();
+  if (daemonsListHostOptionsSig !== optionsSig) {
+    daemonsListHostOptionsSig = optionsSig;
 
-  // Same for the Stats tab host picker.
-  refreshStatsHostPicker();
+    // Keep the Activity host filter dropdown in sync with the current
+    // daemon list (options may have been added/removed).
+    refreshHostFilterOptions();
 
-  // Same for the Files tab download source selector.
-  refreshFilesDownloadHostOptions();
+    // Same for the Stats tab host picker.
+    refreshStatsHostPicker();
 
-  // Same for the Terminal Shell target selector.
-  refreshShellHostOptions();
+    // Same for the Files tab download source selector.
+    refreshFilesDownloadHostOptions();
+
+    // Same for the Terminal Shell target selector.
+    refreshShellHostOptions();
+  }
 
   // Target summaries reuse the same daemon list and should track
   // add/remove/offline transitions immediately.

--- a/static/app/54b-transfers.js
+++ b/static/app/54b-transfers.js
@@ -367,6 +367,11 @@ function filesTransferPersistable(transfer) {
 }
 
 function filesTransferPersistState() {
+  // A direct persist supersedes any scheduled one.
+  if (filesTransferPersistTimer) {
+    clearTimeout(filesTransferPersistTimer);
+    filesTransferPersistTimer = 0;
+  }
   try {
     const state = filesTransfers
       .map(filesTransferPersistable)
@@ -377,6 +382,24 @@ function filesTransferPersistState() {
     console.warn('Persist transfer state failed:', err);
   }
 }
+
+// Trailing-throttled twin for the per-chunk progress paths: a fast LAN
+// download lands ~50 chunks/s, and each chunk used to JSON.stringify up to
+// 50 transfer records into a synchronous localStorage.setItem. Progress
+// coalesces to ≤1 write/s; status transitions keep the immediate form, and
+// chunk-level resume state already lives durably in IndexedDB (losing ≤1 s
+// of rangeCount on a crash just re-fetches that tail on resume).
+let filesTransferPersistTimer = 0;
+function filesTransferPersistStateSoon() {
+  if (filesTransferPersistTimer) return;
+  filesTransferPersistTimer = window.setTimeout(() => {
+    filesTransferPersistTimer = 0;
+    filesTransferPersistState();
+  }, 1000);
+}
+window.addEventListener('pagehide', () => {
+  if (filesTransferPersistTimer) filesTransferPersistState();
+});
 
 function restoreFilesTransferState() {
   let state = [];
@@ -929,74 +952,143 @@ function renderFilesTransfers() {
     renderFilesTransfersNow();
   });
 }
+// Keyed rows, patched in place. The rAF-coalesced full rebuild above still
+// rebuilt EVERY row — titles, meters, fresh action buttons for ~100 history
+// entries — per animation frame during a fast download. A row's structure
+// (status classes, actions, title) rebuilds only when its structure
+// signature moves; per-chunk progress patches just the meta text and meter
+// width on the existing nodes.
+const filesTransferRowCache = new Map(); // transfer.id → { row, meta, fill, sig }
+
+function filesTransferRowStructureSig(transfer) {
+  return [
+    transfer.status || 'queued',
+    transfer.kind || '',
+    transfer.serverJobId || transfer.resumeToken ? 'server' : '',
+    filesTransferTitle(transfer),
+    transfer.sourceLabel || transfer.path || transfer.file?.name || '',
+    transfer.error || '',
+    transfer.destination || '',
+    // Action-set inputs beyond status/kind:
+    (transfer.kind !== 'upload' || transfer.file || transfer.uploadBlobStored) ? 'resumable-upload' : '',
+    transfer.loaded > 0 ? 'has-progress' : '',
+    transfer.result?.blob ? 'has-blob' : '',
+    transfer.rangeCount > 0 ? 'has-ranges' : '',
+  ].join('|');
+}
+
+function filesTransferRowMetaText(transfer) {
+  const direction = transfer.kind === 'upload' ? 'upload' : 'download';
+  const range = transfer.kind === 'download' && transfer.rangeCount
+    ? ` · ${transfer.rangeCount} range${transfer.rangeCount === 1 ? '' : 's'}`
+    : '';
+  const error = transfer.error ? ` · ${transfer.error}` : '';
+  const destination = transfer.kind === 'upload' && transfer.destination ? ` · ${transfer.destination}` : '';
+  const sourceText = transfer.kind === 'download' ? (transfer.sourceLabel || transfer.path || '') : '';
+  const source = sourceText ? ` · ${sourceText}` : '';
+  return `${direction} · ${filesTransferStatusLabel(transfer.status)} · ${filesTransferProgressText(transfer)}${range}${destination}${source}${error}`;
+}
+
+function filesTransferMeterWidth(transfer) {
+  const total = Number(transfer.totalSize || transfer.file?.size || 0);
+  const loaded = Number(transfer.loaded || 0);
+  return total > 0 ? `${Math.max(0, Math.min(100, loaded * 100 / total))}%` : '0%';
+}
+
+function buildFilesTransferRow(transfer) {
+  const row = document.createElement('div');
+  row.className = `files-transfer-row ${transfer.status || 'queued'}${transfer.serverJobId || transfer.resumeToken ? ' server' : ''}`;
+  row.dataset.transferId = transfer.id;
+  const main = document.createElement('div');
+  main.className = 'files-transfer-main';
+  const title = document.createElement('div');
+  title.className = 'files-transfer-title';
+  title.textContent = filesTransferTitle(transfer);
+  title.title = transfer.sourceLabel || transfer.path || transfer.file?.name || '';
+  const meta = document.createElement('div');
+  meta.className = 'files-transfer-meta';
+  meta.textContent = filesTransferRowMetaText(transfer);
+  const meter = document.createElement('div');
+  meter.className = 'files-transfer-meter';
+  const fill = document.createElement('div');
+  fill.className = 'files-transfer-meter-fill';
+  fill.style.width = filesTransferMeterWidth(transfer);
+  meter.appendChild(fill);
+  main.append(title, meta, meter);
+  const actions = document.createElement('div');
+  actions.className = 'files-transfer-actions';
+  const addAction = (label, handler, className = '') => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = label;
+    btn.className = className ? `ui-btn ${className}` : 'ui-btn';
+    btn.addEventListener('click', () => handler(transfer.id));
+    actions.appendChild(btn);
+  };
+  const canResumeUpload = transfer.kind !== 'upload' || transfer.file || transfer.uploadBlobStored;
+  if (transfer.status === 'running' && transfer.kind === 'download') addAction('Pause', pauseFilesTransfer);
+  if (transfer.status === 'running') addAction('Cancel', cancelFilesTransfer, 'danger');
+  if (transfer.status === 'queued') addAction('Cancel', cancelFilesTransfer, 'danger');
+  if (transfer.status === 'paused' && canResumeUpload) addAction('Resume', resumeFilesTransfer);
+  if (transfer.status === 'failed' && transfer.kind === 'download' && transfer.loaded > 0) addAction('Resume', resumeFilesTransfer);
+  if (['failed', 'cancelled'].includes(transfer.status)) addAction('Retry', retryFilesTransfer);
+  if (transfer.status === 'completed' && transfer.kind === 'download' && transfer.result?.blob) {
+    addAction('Save', () => downloadDashboardBlob(transfer.result.blob, transfer.result.filename, transfer.result.content_type));
+  } else if (transfer.status === 'completed' && transfer.kind === 'download' && transfer.rangeCount > 0) {
+    addAction('Save', saveCompletedFilesDownload);
+  }
+  row.append(main, actions);
+  return { row, meta, fill };
+}
+
 function renderFilesTransfersNow() {
   pruneFinishedFilesTransfers();
   const list = document.getElementById('files-transfer-list');
   if (!list) return;
-  list.innerHTML = '';
   if (filesTransfers.length === 0) {
-    const empty = document.createElement('div');
-    empty.className = 'files-transfer-empty ui-empty compact';
-    empty.innerHTML = '<div class="ui-empty-title">No transfers</div>' +
-      '<div class="ui-empty-hint">Downloads and uploads show up here with live progress.</div>';
-    list.appendChild(empty);
+    filesTransferRowCache.clear();
+    if (!list.querySelector('.files-transfer-empty')) {
+      list.innerHTML = '';
+      const empty = document.createElement('div');
+      empty.className = 'files-transfer-empty ui-empty compact';
+      empty.innerHTML = '<div class="ui-empty-title">No transfers</div>' +
+        '<div class="ui-empty-hint">Downloads and uploads show up here with live progress.</div>';
+      list.appendChild(empty);
+    }
     return;
   }
-  for (const transfer of filesTransfers) {
-    const row = document.createElement('div');
-    row.className = `files-transfer-row ${transfer.status || 'queued'}${transfer.serverJobId || transfer.resumeToken ? ' server' : ''}`;
-    row.dataset.transferId = transfer.id;
-    const main = document.createElement('div');
-    main.className = 'files-transfer-main';
-    const title = document.createElement('div');
-    title.className = 'files-transfer-title';
-    title.textContent = filesTransferTitle(transfer);
-    title.title = transfer.sourceLabel || transfer.path || transfer.file?.name || '';
-    const meta = document.createElement('div');
-    meta.className = 'files-transfer-meta';
-    const direction = transfer.kind === 'upload' ? 'upload' : 'download';
-    const range = transfer.kind === 'download' && transfer.rangeCount
-      ? ` · ${transfer.rangeCount} range${transfer.rangeCount === 1 ? '' : 's'}`
-      : '';
-    const error = transfer.error ? ` · ${transfer.error}` : '';
-    const destination = transfer.kind === 'upload' && transfer.destination ? ` · ${transfer.destination}` : '';
-    const sourceText = transfer.kind === 'download' ? (transfer.sourceLabel || transfer.path || '') : '';
-    const source = sourceText ? ` · ${sourceText}` : '';
-    meta.textContent = `${direction} · ${filesTransferStatusLabel(transfer.status)} · ${filesTransferProgressText(transfer)}${range}${destination}${source}${error}`;
-    const meter = document.createElement('div');
-    meter.className = 'files-transfer-meter';
-    const fill = document.createElement('div');
-    fill.className = 'files-transfer-meter-fill';
-    const total = Number(transfer.totalSize || transfer.file?.size || 0);
-    const loaded = Number(transfer.loaded || 0);
-    fill.style.width = total > 0 ? `${Math.max(0, Math.min(100, loaded * 100 / total))}%` : '0%';
-    meter.appendChild(fill);
-    main.append(title, meta, meter);
-    const actions = document.createElement('div');
-    actions.className = 'files-transfer-actions';
-    const addAction = (label, handler, className = '') => {
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.textContent = label;
-      btn.className = className ? `ui-btn ${className}` : 'ui-btn';
-      btn.addEventListener('click', () => handler(transfer.id));
-      actions.appendChild(btn);
-    };
-    const canResumeUpload = transfer.kind !== 'upload' || transfer.file || transfer.uploadBlobStored;
-    if (transfer.status === 'running' && transfer.kind === 'download') addAction('Pause', pauseFilesTransfer);
-    if (transfer.status === 'running') addAction('Cancel', cancelFilesTransfer, 'danger');
-    if (transfer.status === 'queued') addAction('Cancel', cancelFilesTransfer, 'danger');
-    if (transfer.status === 'paused' && canResumeUpload) addAction('Resume', resumeFilesTransfer);
-    if (transfer.status === 'failed' && transfer.kind === 'download' && transfer.loaded > 0) addAction('Resume', resumeFilesTransfer);
-    if (['failed', 'cancelled'].includes(transfer.status)) addAction('Retry', retryFilesTransfer);
-    if (transfer.status === 'completed' && transfer.kind === 'download' && transfer.result?.blob) {
-      addAction('Save', () => downloadDashboardBlob(transfer.result.blob, transfer.result.filename, transfer.result.content_type));
-    } else if (transfer.status === 'completed' && transfer.kind === 'download' && transfer.rangeCount > 0) {
-      addAction('Save', saveCompletedFilesDownload);
+  list.querySelector('.files-transfer-empty')?.remove();
+  const liveIds = new Set(filesTransfers.map(t => t.id));
+  for (const [id, record] of filesTransferRowCache) {
+    if (!liveIds.has(id)) {
+      record.row.remove();
+      filesTransferRowCache.delete(id);
     }
-    row.append(main, actions);
-    list.appendChild(row);
   }
+  const orderedRows = [];
+  for (const transfer of filesTransfers) {
+    const sig = filesTransferRowStructureSig(transfer);
+    let record = filesTransferRowCache.get(transfer.id);
+    if (!record || record.sig !== sig) {
+      const built = buildFilesTransferRow(transfer);
+      if (record) record.row.replaceWith(built.row);
+      record = { ...built, sig };
+      filesTransferRowCache.set(transfer.id, record);
+    } else {
+      // Progress-only tick: meta text + meter width, guarded writes.
+      const metaText = filesTransferRowMetaText(transfer);
+      if (record.meta.textContent !== metaText) record.meta.textContent = metaText;
+      const width = filesTransferMeterWidth(transfer);
+      if (record.fill.style.width !== width) record.fill.style.width = width;
+    }
+    orderedRows.push(record.row);
+  }
+  // Reconcile order/membership only when it actually changed — moving
+  // nodes re-appends them (listeners survive, but focus does not).
+  const currentRows = Array.from(list.children).filter(el => el.classList.contains('files-transfer-row'));
+  const orderMatches = currentRows.length === orderedRows.length &&
+    currentRows.every((el, i) => el === orderedRows[i]);
+  if (!orderMatches) list.replaceChildren(...orderedRows);
 }
 
 function filesUpdateActiveDownloadSummary(transfer = null) {
@@ -1104,6 +1196,11 @@ function queueDashboardArtifactDownload(artifact, options = {}) {
 }
 
 function resetFilesDownloadTransfer(transfer) {
+  // Capture before zeroing: the persisted rangeCount bounds the IndexedDB
+  // cleanup — the unconditional 512 default issued up to 512 sequential
+  // no-op deletes per reset (IDB delete succeeds on missing keys, so the
+  // early-break never fired).
+  const rangeCount = Number(transfer.rangeCount || 0) || 512;
   transfer.loaded = 0;
   transfer.totalSize = 0;
   transfer.parts = [];
@@ -1116,7 +1213,7 @@ function resetFilesDownloadTransfer(transfer) {
   transfer.cancelRequested = false;
   transfer.abortController = null;
   transfer.debugFailedOnce = false;
-  filesTransferDeleteDownloadParts(transfer.id, 512);
+  filesTransferDeleteDownloadParts(transfer.id, rangeCount);
   filesTransferPersistState();
 }
 
@@ -1320,7 +1417,7 @@ async function runFilesDownloadTransfer(transfer) {
       transfer.parts.push(range.bytes);
       transfer.loaded = range.rangeEnd;
       transfer.rangeCount += 1;
-      filesTransferPersistState();
+      filesTransferPersistStateSoon();
       if (typeof transfer.onProgress === 'function') {
         transfer.onProgress({
           loaded: transfer.loaded,
@@ -1377,7 +1474,6 @@ function settleCompletedFilesDownload(transfer, { resumable }) {
   const result = {
     ok: true,
     blob,
-    parts: transfer.parts.slice(),
     filename: transfer.filename || 'download.bin',
     content_type: transfer.contentType,
     size: blob.size,
@@ -1387,6 +1483,14 @@ function settleCompletedFilesDownload(transfer, { resumable }) {
     range_count: transfer.rangeCount,
     resumable,
   };
+  // Drop the raw chunk arrays now that the Blob owns a snapshot of the
+  // bytes: keeping transfer.parts (plus a second result.parts copy of the
+  // same references) pinned the entire download in JS heap for as long as
+  // the terminal transfer sat in history — one 512 MB download held ~1 GB
+  // until reload. The chunks are durably in IndexedDB; Save-after-eviction
+  // rehydrates through filesTransferLoadDownloadParts, and completion
+  // consumers read result.blob, which stays.
+  transfer.parts = [];
   transfer.result = result;
   filesTransferTransition(transfer, 'completed', { actor: 'runner', result });
   setFilesDownloadProgress(result.size, result.total_size || result.size);
@@ -1749,7 +1853,7 @@ async function runFilesFilesystemUploadTransfer(transfer, controller) {
     filesTransferApplyServerJob(transfer, result.body.job);
     transfer.loaded = Math.max(Number(transfer.loaded || 0), end);
     transfer.uploadChunkCount = Number(transfer.uploadChunkCount || 0) + 1;
-    filesTransferPersistState();
+    filesTransferPersistStateSoon();
     renderFilesTransfers();
     setFilesUploadStatus('warn', `Uploading ${filesTransferProgressText(transfer)}`);
     if (

--- a/static/app/55-files-ide.js
+++ b/static/app/55-files-ide.js
@@ -392,20 +392,10 @@ function renderFilesIdeTree() {
     );
   }
   container.innerHTML = html.join('') || '<div class="files-ide-tree-notice">Empty directory</div>';
-  container.querySelectorAll('.files-ide-tree-row').forEach(rowEl => {
-    const path = rowEl.dataset.path || '';
-    const isDir = rowEl.dataset.dir === '1';
-    const open = () => (isDir ? filesIdeToggleDir(path) : filesIdeOpenFile(filesIdeSelectedHostId(), path));
-    rowEl.addEventListener('click', ev => {
-      if (ev.target.closest('.files-ide-row-act')) return;
-      state.focusedPath = path; // keep the roving tab stop on the clicked row
-      open();
-    });
-    // Keyboard activation (Enter/Space) rides the delegated container
-    // listener (filesIdeTreeKeydown), not a per-row handler.
-    rowEl.querySelector('[data-act="rename"]')?.addEventListener('click', () => filesIdeBeginRename(path, isDir));
-    rowEl.querySelector('[data-act="delete"]')?.addEventListener('click', () => filesIdeDeleteRequested(path, isDir));
-  });
+  // Row and action clicks ride ONE delegated container listener
+  // (filesIdeTreeClick), exactly like keydown always has — the per-row
+  // wiring this replaces attached three fresh listeners per row on every
+  // rebuild (each expand/collapse/arrow-key near the 500-entry cap).
   // Re-renders triggered from the keyboard (expand/collapse/arming) must
   // not dump focus onto <body>: put it back on the roving row. The create
   // and rename inputs are focused below and win when present.
@@ -524,11 +514,37 @@ function filesIdeTreeKeydown(ev) {
   ev.preventDefault();
 }
 
+// Delegated click twin of filesIdeTreeKeydown: rows are re-rendered
+// wholesale via innerHTML, so per-row listeners cost three attaches per row
+// per render. Same guards as the old per-row handlers — action buttons
+// resolve before the row, and clicks inside create/rename inputs fall
+// through to the fields.
+function filesIdeTreeClick(ev) {
+  const target = ev.target instanceof Element ? ev.target : null;
+  if (!target || target.closest('input, textarea')) return;
+  const row = target.closest('.files-ide-tree-row');
+  if (!row) return;
+  const path = row.dataset.path || '';
+  const isDir = row.dataset.dir === '1';
+  const act = target.closest('.files-ide-row-act');
+  if (act) {
+    if (act.dataset.act === 'rename') filesIdeBeginRename(path, isDir);
+    else if (act.dataset.act === 'delete') filesIdeDeleteRequested(path, isDir);
+    return;
+  }
+  const state = filesIdeTreeState(filesIdeSelectedHostId());
+  state.focusedPath = path; // keep the roving tab stop on the clicked row
+  if (isDir) filesIdeToggleDir(path);
+  else filesIdeOpenFile(filesIdeSelectedHostId(), path);
+}
+
 // The container survives renders (only its innerHTML is rebuilt), so this
 // attaches exactly once. DOMContentLoaded per the shared-module-script
 // convention for wiring.
 document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('files-ide-tree')?.addEventListener('keydown', filesIdeTreeKeydown);
+  const tree = document.getElementById('files-ide-tree');
+  tree?.addEventListener('keydown', filesIdeTreeKeydown);
+  tree?.addEventListener('click', filesIdeTreeClick);
 });
 
 function filesIdeBeginCreate(kind) {

--- a/static/app/ui2-activity.js
+++ b/static/app/ui2-activity.js
@@ -263,27 +263,59 @@ function ui2TagRawEntries() {
 // a pass (their addedNodes are text nodes), and a container insertion
 // (replay fragment, re-rendered window range) scans only its own subtree.
 // Clones inherit the source entry's classes, so re-tagging is a no-op skip.
+// Bounded: MutationObservers keep firing in hidden tabs while rAF does not,
+// so an unbounded queue would retain every appended node overnight —
+// including entries the 10k prune already detached, pinned with their full
+// subtrees. Past the cap the queue collapses to one "rescan everything"
+// flag (the flush then runs ui2TagRawEntries, whose class guard makes the
+// sweep idempotent), and hidden tabs flush via setTimeout since their rAF
+// never fires (background timer throttling only delays it; the cap is the
+// memory guarantee either way).
+const UI2_TAG_QUEUE_CAP = 2048;
 let ui2PendingTagNodes = new Set();
 let ui2TagPassQueued = false;
+let ui2TagQueueOverflowed = false;
+function ui2RunEntryTagPass() {
+  ui2TagPassQueued = false;
+  const nodes = ui2PendingTagNodes;
+  ui2PendingTagNodes = new Set();
+  if (ui2TagQueueOverflowed) {
+    ui2TagQueueOverflowed = false;
+    ui2TagRawEntries();
+    return;
+  }
+  for (const node of nodes) {
+    if (!node.isConnected) continue;
+    if (node.classList && node.classList.contains('log-entry')) ui2TagEntry(node);
+    else ui2TagEntriesIn(node);
+  }
+}
 function ui2QueueEntryTagging(records) {
-  for (const record of records) {
-    for (const node of record.addedNodes) {
-      if (node.nodeType === 1) ui2PendingTagNodes.add(node);
+  if (!ui2TagQueueOverflowed) {
+    for (const record of records) {
+      for (const node of record.addedNodes) {
+        if (node.nodeType !== 1) continue;
+        if (ui2PendingTagNodes.size >= UI2_TAG_QUEUE_CAP) {
+          ui2PendingTagNodes.clear();
+          ui2TagQueueOverflowed = true;
+          break;
+        }
+        ui2PendingTagNodes.add(node);
+      }
+      if (ui2TagQueueOverflowed) break;
     }
   }
-  if (!ui2PendingTagNodes.size || ui2TagPassQueued) return;
+  if ((!ui2PendingTagNodes.size && !ui2TagQueueOverflowed) || ui2TagPassQueued) return;
   ui2TagPassQueued = true;
-  requestAnimationFrame(() => {
-    ui2TagPassQueued = false;
-    const nodes = ui2PendingTagNodes;
-    ui2PendingTagNodes = new Set();
-    for (const node of nodes) {
-      if (!node.isConnected) continue;
-      if (node.classList && node.classList.contains('log-entry')) ui2TagEntry(node);
-      else ui2TagEntriesIn(node);
-    }
-  });
+  if (document.hidden) setTimeout(ui2RunEntryTagPass, 250);
+  else requestAnimationFrame(ui2RunEntryTagPass);
 }
+// A pass scheduled on rAF while visible never fires once the tab hides —
+// convert it to a timer flush (ui2RunEntryTagPass tolerates the stale rAF
+// firing later on an already-drained queue).
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden && ui2TagPassQueued) setTimeout(ui2RunEntryTagPass, 250);
+});
 
 // The approval hero names its session — with several agents running,
 // "Approval needed" alone is ambiguous.

--- a/static/app/ui2-activity.js
+++ b/static/app/ui2-activity.js
@@ -216,7 +216,6 @@ function ui2QueueFocusSurface() {
   requestAnimationFrame(() => {
     ui2FocusSurfaceQueued = false;
     ui2ApplyFocusSurface();
-    ui2TagRawEntries();
   });
 }
 
@@ -226,31 +225,64 @@ function ui2QueueFocusSurface() {
 // quiet meta hairlines instead of full-voice rows. Runs over BOTH the
 // combined stream and the session windows — Focus promotes a window, so
 // tagging the stream alone misses everything the user actually reads.
+function ui2TagEntry(e) {
+  if (e.classList.contains('ui2-raw-checked')) return;
+  e.classList.add('ui2-raw-checked');
+  const text = (e.querySelector('.log-content')?.textContent || '').trim();
+  if (/^\[(codex|claude(-code)?|backend) stderr\]/i.test(text)) {
+    e.classList.add('ui2-stderr');
+  }
+  if (e.classList.contains('source-steer')) {
+    e.classList.add('ui2-meta');
+    return;
+  }
+  const level = e.dataset.level || '';
+  if (
+    (level === 'info' || level === 'detail') &&
+    /^(Round \d+ complete|Turn \d+ started|Session (started|attached)|Done signal)/.test(text)
+  ) {
+    e.classList.add('ui2-meta');
+  }
+}
+
 function ui2TagEntriesIn(rootEl) {
   if (!rootEl) return;
-  rootEl.querySelectorAll('.log-entry:not(.ui2-raw-checked)').forEach((e) => {
-    e.classList.add('ui2-raw-checked');
-    const text = (e.querySelector('.log-content')?.textContent || '').trim();
-    if (/^\[(codex|claude(-code)?|backend) stderr\]/i.test(text)) {
-      e.classList.add('ui2-stderr');
-    }
-    if (e.classList.contains('source-steer')) {
-      e.classList.add('ui2-meta');
-      return;
-    }
-    const level = e.dataset.level || '';
-    if (
-      (level === 'info' || level === 'detail') &&
-      /^(Round \d+ complete|Turn \d+ started|Session (started|attached)|Done signal)/.test(text)
-    ) {
-      e.classList.add('ui2-meta');
-    }
-  });
+  rootEl.querySelectorAll('.log-entry:not(.ui2-raw-checked)').forEach(ui2TagEntry);
 }
 
 function ui2TagRawEntries() {
   ui2TagEntriesIn(document.getElementById('log-stream'));
   ui2TagEntriesIn(document.getElementById('session-window-grid'));
+}
+
+// Added-node tagging: the tagger used to re-run the `.log-entry:not(...)`
+// selector over the 10k-cap stream PLUS every window log on every grid
+// mutation — including the 1 Hz goal/vitals ticker text writes, i.e. a
+// full match-test of ~10-15k nodes every second while idle. The observers
+// now hand over exactly what was ADDED; text/attribute churn never queues
+// a pass (their addedNodes are text nodes), and a container insertion
+// (replay fragment, re-rendered window range) scans only its own subtree.
+// Clones inherit the source entry's classes, so re-tagging is a no-op skip.
+let ui2PendingTagNodes = new Set();
+let ui2TagPassQueued = false;
+function ui2QueueEntryTagging(records) {
+  for (const record of records) {
+    for (const node of record.addedNodes) {
+      if (node.nodeType === 1) ui2PendingTagNodes.add(node);
+    }
+  }
+  if (!ui2PendingTagNodes.size || ui2TagPassQueued) return;
+  ui2TagPassQueued = true;
+  requestAnimationFrame(() => {
+    ui2TagPassQueued = false;
+    const nodes = ui2PendingTagNodes;
+    ui2PendingTagNodes = new Set();
+    for (const node of nodes) {
+      if (!node.isConnected) continue;
+      if (node.classList && node.classList.contains('log-entry')) ui2TagEntry(node);
+      else ui2TagEntriesIn(node);
+    }
+  });
 }
 
 // The approval hero names its session — with several agents running,
@@ -403,22 +435,35 @@ function ui2RailTick(force) {
     ui2BuildVitalsRail();
     ui2RailTick(true);
     setInterval(() => ui2RailTick(), 1000);
-    // Focus surface + raw-entry hygiene: follow stream appends, target
-    // changes (the chip re-renders on every change), layout flips, and the
-    // session-window grid's own membership — a session resumed from the
-    // Sessions tab materializes its window there, and that is the only
-    // signal Focus gets that the window it must promote now exists.
+    // Focus surface: follow stream appends, target changes (the chip
+    // re-renders on every change), layout flips, and the session-window
+    // grid's own MEMBERSHIP — a session resumed from the Sessions tab
+    // materializes its window there, and that is the only signal Focus
+    // gets that the window it must promote now exists. Membership is
+    // childList on the grid ROOT: appends inside a window's log (or the
+    // per-second ticker text writes) cannot change what Focus promotes,
+    // and routing them here re-ran the promote pass once per frame during
+    // bursts and once per second while idle.
     const stream = document.getElementById('log-stream');
-    if (stream) new MutationObserver(ui2QueueFocusSurface).observe(stream, { childList: true });
+    if (stream) {
+      new MutationObserver((records) => {
+        ui2QueueFocusSurface();
+        ui2QueueEntryTagging(records);
+      }).observe(stream, { childList: true });
+    }
     const chip = document.getElementById('task-target-chip');
     if (chip) new MutationObserver(ui2QueueFocusSurface).observe(chip, {
       childList: true, characterData: true, subtree: true, attributes: true,
     });
-    // subtree: entries append INSIDE window logs — the meta/stderr tagger
-    // must see them, not just window add/remove. ui2QueueFocusSurface is
-    // rAF-debounced, so per-entry firing collapses to one pass a frame.
     const windowGrid = document.getElementById('session-window-grid');
-    if (windowGrid) new MutationObserver(ui2QueueFocusSurface).observe(windowGrid, { childList: true, subtree: true });
+    if (windowGrid) {
+      new MutationObserver(ui2QueueFocusSurface).observe(windowGrid, { childList: true });
+      // subtree: entries append INSIDE window logs — the meta/stderr tagger
+      // must see them, not just window add/remove. It consumes only
+      // addedNodes (see ui2QueueEntryTagging), so ticker text churn and
+      // attribute writes never trigger a scan.
+      new MutationObserver(ui2QueueEntryTagging).observe(windowGrid, { childList: true, subtree: true });
+    }
     ui2ApplyFocusSurface();
     ui2TagRawEntries();
     // Approval hero session identity.


### PR DESCRIPTION
SPA hot-path lane of the 2026-07-15 efficiency program: implements the S/M-effort findings from audit reports 23 (SPA core) and 24 (SPA panels), verified against current fragments. Fragments only + regenerated `static/app.html` (assembler run twice, clean second pass; full 50-fragment module parses as one ES module).

## Finding → fix

| # | Finding | Fix | Where |
|---|---|---|---|
| 23-1 | Full transport-status render cascade per 16 KiB chunk | Trailing 100 ms coalesced tick for progress; transitions render immediately | `49-daemons-multihost.js:467` (scheduler), `50-control-transport.js:418,551` |
| 23-2 | Sync localStorage persist per log line | Unchanged-path persist dropped; changed-path debounced 1 s with pagehide/hidden flush; merge-computed signature reused (3→1-2 signature builds/call) | `41-session-window-actions.js:449`, `39-session-windows.js:1951,595` |
| 23-3 | Focus-surface observer rescans every `.log-entry` per grid mutation (1 Hz idle + per burst) | Tagger consumes `MutationRecord.addedNodes` only; Focus promote decision watches grid-root childList (no subtree) | `ui2-activity.js:258,437` |
| 23-4 | Scroll-follow layout thrash (scrollHeight read per append) | One rAF-coalesced scroll-to-bottom per container per frame; follow decision/flags stay synchronous; `adjustScrollForRemovedAbove` untouched | `41:1530`, `40-session-launch.js:1509` |
| 23-5 | Phase alternation re-runs the full window-header render per line | Phase-only fast path: status chip + `maybeConfirmApprovalSendFromWindowPhase` (hook kept, both paths); goal ticker arm-only from per-update path | `41:423-505`, `39:698` |
| 23-6 | renderDaemonsList full rebuild + 7-surface cascade per peer push | Row-HTML signature skips rebuild/rewire/reapply; host pickers (incl. the 10k-entry `applyHostFilter` sweep) gated on id/label/connected signature; chips/badges/summaries stay unconditional | `50:2777-2960` |
| 23-7 | commandOutputGroups retains detached DOM + full output text forever | Prune deletes by `outputGroupId`; `copyRef.text` capped at 2 MiB with lazy re-fetch via the existing outputIds lane on copy | `39:3137`, `41:1777,1937` |
| 23-8 | 1 Hz tickers rebuild chip models for every window | Vitals tick skips windows with no time-derived chip (+1 settling render for the cold flip); goal renders write-guarded | `39:1592-1620,637` |
| 23-9 | Terminal frames: parse → stringify → parse → WASM parse | Pass the parsed object (event path precedent; dispatcher + WASM accept objects) | `50:283` |
| 23-o1 | sessionUsageById unbounded | LRU cap 500 (write-reinsert keeps active sessions) | `41:2550` |
| 23-o1b | hostStatsCache unbounded | Verified bounded by fleet size (one entry per host id) — no change | — |
| 23-o2 | Per-byte base64 building | Chunked `String.fromCharCode.apply` over 0x8000-byte slices | `50:1614` |
| 23-o3 | updateStatusBar null guards + per-command isolation | sb-* chips null-guarded; each UiCommand dispatched in try/catch (guard-reset semantics preserved) | `41:2651`, `37:13` |
| 24-1 | Completed downloads pin bytes in heap (~1 GB per 512 MB file) | `transfer.parts` cleared after the Blob snapshot; `result.parts` removed (no consumers); `result.blob` kept (files-IDE et al. read it); Save rehydrates from IndexedDB when evicted | `54b-transfers.js:1398` |
| 24-2 (perf half) | Streaming tick: 2 canvas reallocs + 2 sync `toDataURL` per second | Two dedicated canvases sized on dimension change; async `toBlob` encode + chunked b64; skip-tick-while-encoding; **dup-skip logic and archival-HQ always-send byte-identical** | `45-displays-webrtc.js:1420-1500` |
| 24-3 | Station snapshot loop self-perpetuates (~1.8 s idle rebuilds) | Telemetry completion reschedules only when the rounded label moved | `33-station-core.js:1625` |
| 24-4 | Context pane 60 fps loop while static | Loop runs only while a part is selected; exits with a settling render; interactions/resize already render on demand | `48b-context-viz.js:1379` |
| 24-5 (partial) | Full Three scene rebuild per event / slider tick | Scene keyed by snapshot+timeline identity (cross-session events no longer rebuild); label sprites cached by text/color/scale/theme; slider + arrow scrubs rAF-coalesced. **Left**: keyed-mesh mutation across snapshots (geometry churn on scrub remains, user-paced) | `48b:1129-1210` |
| 24-6 | Transfer list full rebuild per frame + persist per 2 MiB chunk | Keyed rows: structure sig gates rebuild; progress patches meta text + meter width in place; order reconciled only on change; persist throttled 1 Hz + transitions (chunk resume state is already durable in IndexedDB) | `54b:955-1105,369` |
| 24-7 | Live rail re-renders on the 3 s sampler it feeds | Observer drops mutations confined to `.display-live-metrics` / `.stream-frame-id`; every rail-visible state still arrives via its own mutation. **Left**: pausing the sampler itself (it feeds the freeze watchdog) | `45:3455` |
| 24-8 | Clip export round-trips every frame through base64 | Generator yields raw bytes; tunnel uploads bytes directly; b64 derived only for legacy /ws + attach data-URLs; preview no longer computes b64 at all | `47-annotation-clips.js:2207,2346` |
| 24-9 | Transcript viewer refetches 300 rows every 8 s while idle | Idle-arm gate: skip when activity key unchanged AND session phase is idle/done/interrupted (unknown phase keeps the old cadence) | `34-station-panes.js:1933` |
| 24-10 | Files-IDE tree: 3 listeners per row per rebuild | Row/action clicks delegated to one container listener (same pattern as keydown) | `55-files-ide.js:394,527` |
| 24-o3 | Object-URL leak in clip preview | Revoke previous strip's blob URLs before clearing | `47:2231` |
| 24-o4 | Download-part cleanup issues 512 sequential IDB deletes | `resetFilesDownloadTransfer` captures and passes the real rangeCount | `54b:1129` |

## Skipped / out of fence

- **24-2 archival-HQ dup-skip half** — decision-gated, excluded by the program brief. Dup detection (base64-length delta, 24-other-1) kept byte-identical for the same reason.
- **24-other-2 fabricated host metrics** (`stableStationMetric` fake cpu/mem) — the honest fix needs `crates/station-web` to render "n/a" for absent metrics (the HUD formats any number as a percentage meter); WASM is another lane. Flagging for follow-up: drop the hash fallback in `35-station-diff-viewer.js:1949-1950` once the renderer can express absence.
- **23-other listSessionWindowLayouts / markActivityContextRewindByTurnIds** — audit itself rates them acceptable at current call rates; unchanged.

## Parity-risk notes (review focus)

1. **Phase fast path (23-5)**: `maybeConfirmApprovalSendFromWindowPhase` fires on both paths (shared `applySessionWindowPhase`). Fast path skips menu-visibility/fast-button/badges/vitals — none consume phase (verified: menu gates on internal/detached/source; detached flips call `updateSessionWindowActionMenuVisibility` directly). Force-cleared signatures (`win.metadataSignature = ''`, e.g. applySessionGoal) disable the fast path by guard.
2. **Scroll-follow (23-4)**: rAF callbacks run before the next paint, so the coalesced write lands in the same visual frame as the append. Flush re-checks `followOutput`/`autoScroll`, so a user grab between schedule and flush wins (previously the sync write could race the same way in the other direction). Jump-button click gains ≤1 frame latency.
3. **Transport status (23-1)**: chunk progress counters (`pendingChunkedResponses`, files-tab job refresh) now update at ≤10 Hz instead of per chunk; open/close/error/complete/reject render unchanged.
4. **Daemons list (23-6)**: the HTML signature covers every field the rows render; displays/sessions data not encoded in row HTML keeps its unconditional consumers (`stationRenderPeerChips`, `stationScheduleUpdate`, target summaries). Picker selects no longer reset on unrelated pushes (they previously re-created options and re-asserted selection per push).
5. **Vitals ticker (23-8)**: a window whose only time-derived chip is a status-limit reset now freezes its "resets in ~Xm" text when NO window has a warm cache — identical to the pre-existing all-windows-idle behavior (the interval disarms in both).
6. **Station telemetry (24-3) — deliberate staleness**: the fps/codec/quality label now refreshes only on snapshot builds; the completion reschedules a build only when the rounded label moved. This is what kills the self-perpetuating ~1.8 s rebuild loop (the audit-endorsed trade). Consequence: on a fully idle Station tab the label can go stale until the next external trigger (any event-driven snapshot, tab re-activation, or real fps movement - +/-1 fps jitter keeps the cadence alive in practice).
7. **Transcript idle gate (24-9)**: sessions with unknown phase (not in `sessionMetadataById`) keep the 8 s refetch (fail open); external/peer transcripts typically have window metadata.
8. **Streaming rework (24-2)**: frame send now completes ~10-40 ms after the tick (async encode) with a skip-when-busy guard; live/HQ lanes draw in the same tick so both capture the same instant. `send_frame`/`sendDashboardVideoFrameToServer` payloads and cadence unchanged.
9. **Copy cap (23-7)**: copying a >2 MiB streamed output now does an RPC (same lane the expand path uses) with the captured 2 MiB prefix as offline fallback; Station's copy path (`33:2168`) still reads the sync prefix.
10. **Transfers keyed rows (24-6)**: action closures capture the stable transfer object; structure signature includes every action-gating input (status/kind/server-ness/blob/rangeCount/resumable/error/title). Row focus now survives progress ticks (previously destroyed per frame).
11. **UiCommand isolation (23-o3)**: the `update_status_bar`→`set_phase` guard pair still spans commands (reset logic outside the try); a throwing handler now logs `[ui-command]` and continues.
12. **app.html conflict note**: main moved (`14a3566a`) in two CSS fragments after this branch's base — fragment files don't overlap, but the generated `app.html` will need the standard resolve-in-fragments + re-assemble on merge.

## Validation

- `node --check` on all 15 modified fragments, plus the full 50-fragment module concatenation parsed as one ES module (catches cross-fragment redeclarations/TDZ syntax).
- `cargo run -p app-html-assembler` twice; `git status` clean after the second run (app-html CI gate green by construction).
- No Rust changes; no WASM-boundary changes (verified `handle_server_message` accepts objects read-only before 23-9).


## Review round 1 (Codex + Fable, reconciled) — applied on top

| Item | Verdict | Change |
|---|---|---|
| Hidden-tab tag queue leak | Fixed | `ui2PendingTagNodes` capped at 2048 (overflow collapses to one full `ui2TagRawEntries` rescan flag); flush via `setTimeout` when `document.hidden`, plus a visibilitychange handler that converts a stranded rAF flush to a timer (`ui2-activity.js`) |
| Transcript final rows missed at settle | Fixed | `stationTranscriptLive.lastActivePhaseSeen` tracks the active-to-inactive edge; the transition grants exactly one final refetch before the idle gate parks; seeded from the phase at open (`34-station-panes.js`) |
| Streaming stop/restart lifecycle | Fixed | Per-start `_streamGeneration`; late completions from an older generation are dropped entirely; stop-without-restart still delivers the in-flight final frame (pre-stop pixels) while skipping the torn-down chrome; `_streamEncodePending` reset on stop AND start, and only the owning generation may clear it (`45-displays-webrtc.js`) |
| Limit-reset chips never tick / freeze | Fixed | Ticker arms from `sessionVitalsNeedsTick` (the predicate), not the render result (which reports only cache-ttl ticking); `win.vitalsNeededTick` grants passed limit resets the same one trailing render as cold caches (`39-session-windows.js`) |
| Phase fast path vs relationship badges (Codex Med 41:472) | **Confirmed true, fixed** | `sessionRelationshipSubagentIsActive` (40:2167) reads the child's `win.phase`, so the parent's "N sub" chip did derive from child phases. The fast path now evaluates that very helper before/after the phase application and, on an active-boundary crossing, refreshes this window's badge and the parent's; thinking/running alternations (both active) still skip it (`41-session-window-actions.js`) |
| sceneKey vs exact-replay replacement (Codex Med 48b:1182) | **Confirmed true, fixed** | `replaceStoredContextSnapshot` preserves `__context_key` (48b:271) while minting a new object, so the key alone could not see the data swap. A WeakMap-backed per-object token now rides the sceneKey: replacement means a new object, a new token, a rebuild (`48b-context-viz.js`) |

## Live-QA checklist (operator, before/after landing)

- [ ] Focus promote across target switches (session switcher, resume-from-Sessions, composer target hot-swap): window promotes, no blank Focus
- [ ] Approval auto-confirm under streaming (`maybeConfirmApprovalSendFromWindowPhase`): approve while the session streams; the send confirms on the phase flip
- [ ] Hidden-tab memory: leave a busy dashboard hidden >= 1h, check heap growth; return and confirm new entries get stderr/meta tinting within a beat
- [ ] Presence streaming on retina + WKWebView: Stream on/off/on quickly; frame ids advance from the restart; dup-skip diagnostics (`frame_skip`) still appear on a static screen
- [ ] Station transcript freshness: open a transcript, let the session finish; the final rows appear after the phase settles, then the idle viewer stops refetching
- [ ] Fast-LAN transfer: meter/meta update smoothly; row buttons keep focus during progress; pause/resume/cancel intact
- [ ] Command output > 2 MiB: copy button returns the full text (RPC lane); tunnel-down copy falls back to the captured prefix
- [ ] Multi-host: daemons list keeps expansion state and message-input focus across peer idle/working status flips; host filter and pickers keep selection
- [ ] Context pane: scrub the replay slider (smooth, correct final index), select a part (bob animates, settles on deselect), flip theme (labels re-rasterize), load an exact snapshot (scene geometry updates)

---
*Body note: an intermediate edit briefly replaced this description with another lane's text (shared scratchpad filename collision after a host restart); restored from the edit history with the review-round appendix above.*
