### PR TITLE
watcher: proportional round scans, bounded history, watcher-served changes/history

### DIFF
--- a/crates/intendant-platform/src/platform.rs
+++ b/crates/intendant-platform/src/platform.rs
@@ -1326,6 +1326,90 @@ impl FileIdentity {
     }
 }
 
+/// A file's platform change signal plus its [`FileIdentity`], for
+/// fingerprint caches that must catch mtime-preserving rewrites (size and
+/// mtime alone are spoofable via `touch -r` / `SetFileTime`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileChangeStamp {
+    /// Platform change signal:
+    ///
+    /// - **Unix**: inode ctime in nanoseconds since the epoch — bumped by
+    ///   every content or metadata write and not settable by
+    ///   mtime-preserving tools.
+    /// - **Windows**: `FILE_BASIC_INFO.ChangeTime` (100ns intervals since
+    ///   1601) — NTFS bumps it on every write, and unlike the three
+    ///   timestamps `SetFileTime` covers, it cannot be set through that API.
+    pub change_signal: i128,
+    /// Real file identity (volume + file index / inode), so a
+    /// replace-by-rename never aliases the file it replaced.
+    pub identity: FileIdentity,
+}
+
+/// Best-available change stamp for the file at `path`.
+///
+/// Unix reads both fields from `metadata` (no extra I/O). Windows needs an
+/// open handle (`GetFileInformationByHandleEx`), so the query can fail —
+/// locked file, permissions, or a filesystem without ChangeTime — and on
+/// platforms that are neither Unix nor Windows there is no signal at all.
+/// `None` means **no signal**: fingerprint caches must treat it as
+/// untrusted (re-read), never as "unchanged".
+pub fn file_change_stamp(
+    path: &std::path::Path,
+    metadata: &std::fs::Metadata,
+) -> Option<FileChangeStamp> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let _ = path;
+        Some(FileChangeStamp {
+            change_signal: (metadata.ctime() as i128) * 1_000_000_000
+                + metadata.ctime_nsec() as i128,
+            identity: FileIdentity {
+                volume: metadata.dev(),
+                file_index: metadata.ino(),
+            },
+        })
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::Storage::FileSystem::{
+            FileBasicInfo, GetFileInformationByHandleEx, FILE_BASIC_INFO,
+        };
+
+        let _ = metadata;
+        let file = std::fs::File::open(path).ok()?;
+        // SAFETY: FILE_BASIC_INFO is a plain Win32 POD struct (five i64/u32
+        // fields), for which the all-zero bit pattern is a valid value.
+        let mut info: FILE_BASIC_INFO = unsafe { std::mem::zeroed() };
+        // SAFETY: `file` keeps its handle open and valid for the duration of
+        // the call; `info` is a live writable out-pointer of exactly
+        // `dwbuffersize` bytes, the size the API contract fills for the
+        // `FileBasicInfo` information class.
+        let ok = unsafe {
+            GetFileInformationByHandleEx(
+                file.as_raw_handle(),
+                FileBasicInfo,
+                (&mut info as *mut FILE_BASIC_INFO).cast(),
+                std::mem::size_of::<FILE_BASIC_INFO>() as u32,
+            )
+        };
+        if ok == 0 {
+            return None;
+        }
+        let identity = FileIdentity::from_file(&file).ok()?;
+        Some(FileChangeStamp {
+            change_signal: i128::from(info.ChangeTime),
+            identity,
+        })
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (path, metadata);
+        None
+    }
+}
+
 // The state-path seam (home_dir, intendant_home, intendant_home_in) lives
 // in intendant-core::state_paths so content modules there can use it too;
 // re-exported here where every existing platform:: caller expects it.
@@ -1779,6 +1863,36 @@ mod tests {
         assert_ne!(
             FileIdentity::from_path(&a).unwrap(),
             FileIdentity::from_path(&b).unwrap()
+        );
+    }
+
+    /// The change stamp exists on Unix and Windows, moves on every content
+    /// write (even when the write leaves size and mtime untouched), and
+    /// keeps the file's identity stable across in-place rewrites.
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn file_change_stamp_moves_on_rewrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stamped.txt");
+        std::fs::write(&path, b"one!").unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        let first = file_change_stamp(&path, &meta).expect("stamp available");
+
+        // Cross the platform's change-time tick (Windows ~15.6ms; Unix
+        // filesystems are ns-to-1s — CI runs ns-resolution ext4/APFS/NTFS,
+        // and the sleep keeps even coarse ticks distinct in spirit).
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        std::fs::write(&path, b"two!").unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        let second = file_change_stamp(&path, &meta).expect("stamp available");
+
+        assert_ne!(
+            first.change_signal, second.change_signal,
+            "a content rewrite must move the change signal"
+        );
+        assert_eq!(
+            first.identity, second.identity,
+            "an in-place rewrite must keep the file identity"
         );
     }
 

--- a/crates/intendant-platform/src/platform.rs
+++ b/crates/intendant-platform/src/platform.rs
@@ -1397,7 +1397,17 @@ pub fn file_change_stamp(
         if ok == 0 {
             return None;
         }
+        // FAT-family and some network filesystems report no ChangeTime
+        // (zero) and/or no real file identity — that is "no signal", never
+        // a comparable value (a shared zero would compare equal across
+        // rewrites, exactly the stale-hit this helper exists to prevent).
+        if info.ChangeTime == 0 {
+            return None;
+        }
         let identity = FileIdentity::from_file(&file).ok()?;
+        if !identity.is_reliable() {
+            return None;
+        }
         Some(FileChangeStamp {
             change_signal: i128::from(info.ChangeTime),
             identity,

--- a/skills/intendant-log-search/references/artifact-map.md
+++ b/skills/intendant-log-search/references/artifact-map.md
@@ -188,12 +188,17 @@ file_snapshots/
   history.json
 ```
 
-`history.json` schema:
+`history.json` schema (format 2 — a slim index; `"format": 2` marks it):
 
 - `current_head_id`: active round id.
-- `rounds[]`: `id`, `parent_id`, `summary`, `timestamp_unix`, `files_changed`, `files_at_end`, optional `all_files_at_end`, optional `turn_count`, optional `native_message_count`.
+- `rounds[]`: `id`, `parent_id`, `summary`, `timestamp_unix`, `files_changed`, optional `turn_count`, optional `native_message_count`, optional `maps_from_round`. Round stubs carry no path→hash maps — the per-round maps live in `rounds/round_<id>/manifest.json` (below). A round may exceptionally retain inline `files_at_end`/`all_files_at_end` when its manifest write failed; the index stays authoritative for it until a later load migrates it.
 - `abandoned_branches[]`: rollback-then-new-action branches with `branched_from_id`, `rounds`, `created_at_unix`.
 - `next_id`: next round id.
+- `store_epoch`: identity stamp binding this index to its manifests.
+
+`rounds/round_<id>/manifest.json` (load-bearing since format 2): the full `HistoryRound` for that round — `files_at_end` (restorable path → sha256) and `all_files_at_end` (display mirror) inline, stamped with `store_epoch`. A no-op round (tree identical to an earlier round) writes a tiny stub whose `maps_from_round` names the round holding the maps inline (backreferences are depth-1). Restore refuses manifests whose `id` or `store_epoch` doesn't match the index (fails closed rather than restoring a wrong tree).
+
+Legacy (pre-format-2) `history.json` files carried every round's maps inline; they are migrated to stamped manifests on the next load.
 
 Snapshots ignore common generated directories and binary/image/archive extensions. Files above the snapshot size cap are represented by hash/metadata, not restorable text content.
 

--- a/skills/intendant-log-search/references/artifact-map.md
+++ b/skills/intendant-log-search/references/artifact-map.md
@@ -186,15 +186,21 @@ file_snapshots/
   objects/
   rounds/
   history.json
+  store.lock
 ```
+
+`store.lock` is the store's advisory cross-process lock (held for the owning
+watcher's lifetime; a second process opens the store read-only). A
+`history.json.damaged-<ts>` file is a previous index that failed to parse,
+preserved verbatim when a fresh timeline was started.
 
 `history.json` schema (format 2 — a slim index; `"format": 2` marks it):
 
 - `current_head_id`: active round id.
-- `rounds[]`: `id`, `parent_id`, `summary`, `timestamp_unix`, `files_changed`, optional `turn_count`, optional `native_message_count`, optional `maps_from_round`. Round stubs carry no path→hash maps — the per-round maps live in `rounds/round_<id>/manifest.json` (below). A round may exceptionally retain inline `files_at_end`/`all_files_at_end` when its manifest write failed; the index stays authoritative for it until a later load migrates it.
+- `rounds[]`: `id`, `parent_id`, `summary`, `timestamp_unix`, `files_changed`, optional `turn_count`, optional `native_message_count`, optional `maps_from_round`. Round stubs carry no path→hash maps — the per-round maps live in `rounds/round_<id>/manifest.json` (below). A round may exceptionally retain inline `files_at_end`/`all_files_at_end` when its manifest write failed, marked by `maps_inline: true` (the marker is what keeps an empty-tree retention alive, since empty maps serialize to nothing); the index stays authoritative for it until a later load migrates it.
 - `abandoned_branches[]`: rollback-then-new-action branches with `branched_from_id`, `rounds`, `created_at_unix`.
 - `next_id`: next round id.
-- `store_epoch`: identity stamp binding this index to its manifests.
+- `store_epoch`: identity stamp binding this index to its manifests. Absent on a pre-epoch store whose manifest stamping has not completed yet; while absent, restores are guarded by content binding (the manifest's scalars must match its index row) instead.
 
 `rounds/round_<id>/manifest.json` (load-bearing since format 2): the full `HistoryRound` for that round — `files_at_end` (restorable path → sha256) and `all_files_at_end` (display mirror) inline, stamped with `store_epoch`. A no-op round (tree identical to an earlier round) writes a tiny stub whose `maps_from_round` names the round holding the maps inline (backreferences are depth-1). Restore refuses manifests whose `id` or `store_epoch` doesn't match the index (fails closed rather than restoring a wrong tree).
 

--- a/skills/intendant-log-search/references/artifact-map.md
+++ b/skills/intendant-log-search/references/artifact-map.md
@@ -191,13 +191,15 @@ file_snapshots/
 
 `store.lock` is the store's advisory cross-process lock (held for the owning
 watcher's lifetime; a second process opens the store read-only). A
-`history.json.damaged-<ts>` file is a previous index that failed to parse,
-preserved verbatim when a fresh timeline was started.
+`history.json.damaged-<ts>-<pid>-<seq>` file is a previous index that failed
+to parse, preserved verbatim when a fresh timeline was started (forensic
+only: the fresh timeline reuses round ids, and its epoch/maps-hash binding
+already makes the old manifests unresolvable).
 
 `history.json` schema (format 2 — a slim index; `"format": 2` marks it):
 
 - `current_head_id`: active round id.
-- `rounds[]`: `id`, `parent_id`, `summary`, `timestamp_unix`, `files_changed`, optional `turn_count`, optional `native_message_count`, optional `maps_from_round`. Round stubs carry no path→hash maps — the per-round maps live in `rounds/round_<id>/manifest.json` (below). A round may exceptionally retain inline `files_at_end`/`all_files_at_end` when its manifest write failed, marked by `maps_inline: true` (the marker is what keeps an empty-tree retention alive, since empty maps serialize to nothing); the index stays authoritative for it until a later load migrates it.
+- `rounds[]`: `id`, `parent_id`, `summary`, `timestamp_unix`, `files_changed`, optional `turn_count`, optional `native_message_count`, optional `maps_from_round`, optional `maps_hash` (content hash of the round's maps — the resolver refuses a manifest whose payload doesn't hash to it). Round stubs carry no path→hash maps — the per-round maps live in `rounds/round_<id>/manifest.json` (below). A round may exceptionally retain inline `files_at_end`/`all_files_at_end` when its manifest write failed, marked by `maps_inline: true` (the marker is what keeps an empty-tree retention alive, since empty maps serialize to nothing); the index stays authoritative for it until a later load migrates it.
 - `abandoned_branches[]`: rollback-then-new-action branches with `branched_from_id`, `rounds`, `created_at_unix`.
 - `next_id`: next round id.
 - `store_epoch`: identity stamp binding this index to its manifests. Absent on a pre-epoch store whose manifest stamping has not completed yet; while absent, restores are guarded by content binding (the manifest's scalars must match its index row) instead.

--- a/src/bin/caller/file_watcher.rs
+++ b/src/bin/caller/file_watcher.rs
@@ -117,6 +117,44 @@ pub struct HistoryRound {
     /// be unreachable. `false` everywhere else (stubs, manifests, legacy).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub maps_inline: bool,
+    /// Content hash of this round's maps (the actual restore payload),
+    /// recorded in the slim index row when the manifest is written. The
+    /// resolver verifies a manifest's maps against this before serving —
+    /// scalar binding alone would bless a manifest whose scalars match but
+    /// whose maps were replaced. `None` only on rows that predate the
+    /// field (verification is skipped for them; every write path stamps
+    /// it, and the restamp sweep backfills it).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maps_hash: Option<String>,
+}
+
+/// Canonical content hash of a round's two maps: length-prefixed,
+/// domain-separated, key-sorted — independent of `HashMap` iteration order
+/// and JSON formatting.
+fn maps_content_hash(
+    files_at_end: &HashMap<String, String>,
+    all_files_at_end: &HashMap<String, String>,
+) -> String {
+    fn fold_map(hasher: &mut Sha256, label: &[u8], map: &HashMap<String, String>) {
+        hasher.update(label);
+        hasher.update((map.len() as u64).to_le_bytes());
+        let mut keys: Vec<&String> = map.keys().collect();
+        keys.sort();
+        for key in keys {
+            hasher.update((key.len() as u64).to_le_bytes());
+            hasher.update(key.as_bytes());
+            let value = &map[key];
+            hasher.update((value.len() as u64).to_le_bytes());
+            hasher.update(value.as_bytes());
+        }
+    }
+    let mut hasher = Sha256::new();
+    fold_map(&mut hasher, b"files_at_end", files_at_end);
+    fold_map(&mut hasher, b"all_files_at_end", all_files_at_end);
+    let digest = hasher.finalize();
+    let mut raw = [0u8; 32];
+    raw.copy_from_slice(&digest);
+    hex_encode(&raw)
 }
 
 /// Whether an index row is currently the authoritative carrier of its own
@@ -640,6 +678,10 @@ pub(crate) fn atomic_write(path: &Path, content: &[u8]) -> io::Result<()> {
 /// "no rollback offered" downgrade instead of restoring from empty maps.
 const HISTORY_INDEX_FORMAT: u64 = 2;
 
+/// Per-process sequence for damaged-index backup names (see
+/// `load_history_from_disk`): keeps same-second backups from colliding.
+static DAMAGED_BACKUP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Path of the on-disk manifest carrying one round's full snapshot record.
 fn round_manifest_path(snapshot_dir: &Path, round_id: u64) -> PathBuf {
     snapshot_dir
@@ -710,9 +752,30 @@ fn load_history_from_disk(snapshot_dir: &Path, read_only: bool) -> LoadedHistory
             if read_only {
                 return LoadedHistory::read_only_with(History::default());
             }
-            let damaged_path = snapshot_dir.join(format!("history.json.damaged-{}", now_unix()));
+            // Collision-proof backup name (std rename REPLACES an existing
+            // file): time + pid + per-process sequence, existence-checked —
+            // sound because the store lock makes us the only writer.
+            let damaged_path = loop {
+                let seq = DAMAGED_BACKUP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let candidate = snapshot_dir.join(format!(
+                    "history.json.damaged-{}-{}-{}",
+                    now_unix(),
+                    std::process::id(),
+                    seq
+                ));
+                if !candidate.exists() {
+                    break candidate;
+                }
+            };
             match std::fs::rename(&history_path, &damaged_path) {
                 Ok(()) => {
+                    // Residual, documented: the fresh timeline reuses round
+                    // ids from 0, so new manifests will overwrite the damaged
+                    // timeline's rounds/round_N files as rounds accrue. With
+                    // epoch + maps-hash binding those old manifests are
+                    // already unresolvable by this fresh index — the damaged
+                    // JSON is preserved for forensics, not for automatic
+                    // recovery.
                     eprintln!(
                         "[file_watcher] history.json was unreadable; preserved it at {} and \
                          starting a fresh timeline",
@@ -744,7 +807,12 @@ fn load_history_from_disk(snapshot_dir: &Path, read_only: bool) -> LoadedHistory
     if history.store_epoch.is_none() {
         let epoch = mint_store_epoch(snapshot_dir);
         let restamped_ok = format < HISTORY_INDEX_FORMAT
-            || restamp_manifests_for_new_epoch(&history, snapshot_dir, &epoch);
+            || restamp_manifests_for_new_epoch(
+                &mut history,
+                snapshot_dir,
+                &epoch,
+                &mut needs_persist,
+            );
         if restamped_ok {
             history.store_epoch = Some(epoch);
             needs_persist = true;
@@ -814,10 +882,12 @@ fn migrate_inline_round_maps(
         // Always rewrite from the inline maps — they are the authoritative
         // copy; a pre-existing manifest at this id is not trusted (it may be
         // unparseable, unstamped, or a foreign timeline's).
+        let maps_hash = maps_content_hash(&round.files_at_end, &round.all_files_at_end);
         let manifest = HistoryRound {
             store_epoch: epoch.clone(),
             maps_from_round: None,
             maps_inline: false,
+            maps_hash: Some(maps_hash.clone()),
             ..round.clone()
         };
         let manifest_path = round_manifest_path(snapshot_dir, round.id);
@@ -829,6 +899,7 @@ fn migrate_inline_round_maps(
             round.all_files_at_end = HashMap::new();
             round.maps_from_round = None;
             round.maps_inline = false;
+            round.maps_hash = Some(maps_hash);
             *needs_persist = true;
         } else if !round.maps_inline {
             round.maps_inline = true;
@@ -850,28 +921,41 @@ fn migrate_inline_round_maps(
 /// stamped when its content BINDS to its index row
 /// ([`manifest_binds_to_round`]) — identity alone never blesses a manifest,
 /// so one poisoned by a pre-format-2 binary (same id, different round)
-/// stays unstamped and fails closed at resolve time. Returns `false` when
-/// any binding manifest could not be written — the caller must then defer
-/// epoch adoption (see FIX in `load_history_from_disk`).
-fn restamp_manifests_for_new_epoch(history: &History, snapshot_dir: &Path, epoch: &str) -> bool {
+/// stays unstamped and fails closed at resolve time. Rows that predate
+/// `maps_hash` are backfilled from the binding manifest's maps, freezing
+/// the payload against later tampering. Returns `false` when any binding
+/// manifest could not be written OR read (a transiently unreadable correct
+/// manifest must defer epoch adoption exactly like a failed write —
+/// otherwise the persisted epoch would orphan it permanently).
+fn restamp_manifests_for_new_epoch(
+    history: &mut History,
+    snapshot_dir: &Path,
+    epoch: &str,
+    needs_persist: &mut bool,
+) -> bool {
     let mut all_ok = true;
-    let rounds = history
-        .rounds
-        .iter()
-        .chain(history.abandoned_branches.iter().flat_map(|b| &b.rounds));
-    for round in rounds {
+    let mut restamp_round = |round: &mut HistoryRound| {
         if round_has_inline_maps(round) {
             // Retained in the index; no manifest of ours to stamp.
-            continue;
+            return true;
         }
         let manifest_path = round_manifest_path(snapshot_dir, round.id);
-        let Ok(bytes) = std::fs::read(&manifest_path) else {
-            // Missing: unresolvable with or without an epoch — not a stamp
-            // failure.
-            continue;
+        let bytes = match std::fs::read(&manifest_path) {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                // Missing: unresolvable with or without an epoch — not a
+                // stamp failure.
+                return true;
+            }
+            Err(_) => {
+                // Transient read failure (permissions, I/O): the manifest
+                // may be perfectly correct — adopting the epoch now would
+                // orphan it. Defer.
+                return false;
+            }
         };
         let Ok(mut manifest) = serde_json::from_slice::<HistoryRound>(&bytes) else {
-            continue;
+            return true;
         };
         if !manifest_binds_to_round(&manifest, round) {
             eprintln!(
@@ -879,17 +963,29 @@ fn restamp_manifests_for_new_epoch(history: &History, snapshot_dir: &Path, epoch
                  damaged write?) — leaving it unstamped; restores of that round will refuse",
                 round.id
             );
-            continue;
+            return true;
+        }
+        if round.maps_hash.is_none() {
+            round.maps_hash = Some(maps_content_hash(
+                &manifest.files_at_end,
+                &manifest.all_files_at_end,
+            ));
+            *needs_persist = true;
         }
         if manifest.store_epoch.as_deref() == Some(epoch) {
-            continue;
+            return true;
         }
         manifest.store_epoch = Some(epoch.to_string());
-        let written = serde_json::to_vec_pretty(&manifest)
+        serde_json::to_vec_pretty(&manifest)
             .ok()
-            .is_some_and(|stamped| atomic_write(&manifest_path, &stamped).is_ok());
-        if !written {
-            all_ok = false;
+            .is_some_and(|stamped| atomic_write(&manifest_path, &stamped).is_ok())
+    };
+    for round in &mut history.rounds {
+        all_ok &= restamp_round(round);
+    }
+    for branch in &mut history.abandoned_branches {
+        for round in &mut branch.rounds {
+            all_ok &= restamp_round(round);
         }
     }
     all_ok
@@ -960,7 +1056,13 @@ fn reconcile_baseline_dir(baseline_dir: &Path, manifest: &BaselineManifest) -> b
                 continue;
             }
         };
-        for entry in entries.flatten() {
+        for entry in entries {
+            // Per-entry iteration errors matter: a hidden stale file is a
+            // divergence between the on-disk universe and the manifest.
+            let Ok(entry) = entry else {
+                ok = false;
+                continue;
+            };
             let path = entry.path();
             let ft = match entry.file_type() {
                 Ok(ft) => ft,
@@ -969,11 +1071,18 @@ fn reconcile_baseline_dir(baseline_dir: &Path, manifest: &BaselineManifest) -> b
                     continue;
                 }
             };
-            if ft.is_dir() {
-                stack.push(path);
+            // baseline/ only ever contains regular files and directories we
+            // wrote ourselves — a symlink (or any other type) is a foreign
+            // leftover. The fallback scan's reads would FOLLOW a file
+            // symlink, so it must go like any other stale entry.
+            if ft.is_symlink() || (!ft.is_dir() && !ft.is_file()) {
+                if std::fs::remove_file(&path).is_err() && std::fs::remove_dir(&path).is_err() {
+                    ok = false;
+                }
                 continue;
             }
-            if !ft.is_file() {
+            if ft.is_dir() {
+                stack.push(path);
                 continue;
             }
             let rel = match path.strip_prefix(baseline_dir) {
@@ -1267,12 +1376,10 @@ impl FileWatcher {
         bus: EventBus,
     ) -> Result<Self, CallerError> {
         let baseline_dir = snapshot_dir.join("baseline");
-        std::fs::create_dir_all(&baseline_dir)
+        // Only the store root exists before the lock: the lockfile needs a
+        // home, and a read-only loser must create nothing else.
+        std::fs::create_dir_all(&snapshot_dir)
             .map_err(|e| CallerError::Config(format!("create snapshot dir: {}", e)))?;
-        std::fs::create_dir_all(snapshot_dir.join("objects"))
-            .map_err(|e| CallerError::Config(format!("create objects dir: {}", e)))?;
-        std::fs::create_dir_all(snapshot_dir.join("rounds"))
-            .map_err(|e| CallerError::Config(format!("create rounds dir: {}", e)))?;
 
         // Cross-process exclusion, acquired before any store write: a second
         // watcher on the same store (another daemon resuming this session)
@@ -1284,6 +1391,13 @@ impl FileWatcher {
                  rewind runs read-only in this instance",
                 snapshot_dir.display()
             );
+        } else {
+            std::fs::create_dir_all(&baseline_dir)
+                .map_err(|e| CallerError::Config(format!("create baseline dir: {}", e)))?;
+            std::fs::create_dir_all(snapshot_dir.join("objects"))
+                .map_err(|e| CallerError::Config(format!("create objects dir: {}", e)))?;
+            std::fs::create_dir_all(snapshot_dir.join("rounds"))
+                .map_err(|e| CallerError::Config(format!("create rounds dir: {}", e)))?;
         }
 
         let mut baseline_manifest = BaselineManifest::new();
@@ -1815,6 +1929,9 @@ impl FileWatcher {
 
         let id = self.history.next_id;
         self.history.next_id += 1;
+        // Recorded in the index row so the resolver can verify a manifest's
+        // maps (the restore payload) before ever serving them.
+        let maps_hash = maps_content_hash(&files_at_end, &all_files_at_end);
         let stub = HistoryRound {
             id,
             parent_id,
@@ -1828,6 +1945,7 @@ impl FileWatcher {
             maps_from_round: maps_source_id,
             store_epoch: None,
             maps_inline: false,
+            maps_hash: Some(maps_hash),
         };
 
         // Write the per-round manifest — the durable home of the maps,
@@ -1909,7 +2027,7 @@ impl FileWatcher {
 
         // Refresh in-memory hash/baseline mirrors so the watcher doesn't
         // re-emit spurious "modified" events for paths we just rewrote.
-        self.refresh_hashes_from_tree();
+        let _ = self.refresh_hashes_from_tree();
 
         self.history.current_head_id = Some(target_id);
         self.head_maps = Some(HeadMapsCache {
@@ -1961,7 +2079,7 @@ impl FileWatcher {
             ))
         })?;
         let files_reverted = self.restore_to_state(&next_maps.files_at_end)?;
-        self.refresh_hashes_from_tree();
+        let _ = self.refresh_hashes_from_tree();
 
         self.history.current_head_id = Some(next_id);
         self.head_maps = Some(HeadMapsCache {
@@ -2189,6 +2307,7 @@ impl FileWatcher {
         // Prefer the in-memory stub's backreference (skips one manifest
         // read); the chain below re-verifies every hop against its own
         // index row anyway.
+        let expected_maps_hash = stub.maps_hash.clone();
         let mut source_id = stub.maps_from_round.unwrap_or(round_id);
         // Backreferences are written depth-1; the visited set and bound are
         // defense against corrupt or foreign manifests.
@@ -2235,6 +2354,18 @@ impl FileWatcher {
             match manifest.maps_from_round {
                 Some(next) => source_id = next,
                 None => {
+                    // Payload binding: the maps we are about to serve must
+                    // hash to what the requested round's index row recorded
+                    // — scalar binding alone would bless a manifest whose
+                    // scalars match but whose maps were replaced. Rows
+                    // predating the field (`None`) skip this check.
+                    if let Some(expected) = expected_maps_hash.as_deref() {
+                        let actual =
+                            maps_content_hash(&manifest.files_at_end, &manifest.all_files_at_end);
+                        if actual != expected {
+                            return None;
+                        }
+                    }
                     return Some(ResolvedRoundMaps {
                         source_round_id: source_id,
                         files_at_end: manifest.files_at_end,
@@ -2407,7 +2538,13 @@ impl FileWatcher {
     /// Cache-aware: `restore_to_state` refreshed the scan cache for every
     /// path it touched, so this walk is stats plus reads of only the files
     /// that changed outside the restore.
-    fn refresh_hashes_from_tree(&mut self) {
+    ///
+    /// Returns `false` — and degrades the live index — when a subtree could
+    /// not be enumerated (non-NotFound `read_dir` failure): the rebuilt
+    /// mirrors would silently omit whatever lives there. Per-file races
+    /// (a path deleted mid-walk) are benign; the next event covers them.
+    fn refresh_hashes_from_tree(&mut self) -> bool {
+        let mut ok = true;
         let mut new_hashes = HashMap::new();
         let mut large_file_fingerprints = HashMap::new();
         let mut next_cache: HashMap<PathBuf, ScanCacheEntry> =
@@ -2416,7 +2553,12 @@ impl FileWatcher {
         while let Some(dir) = stack.pop() {
             let entries = match std::fs::read_dir(&dir) {
                 Ok(e) => e,
-                Err(_) => continue,
+                Err(err) => {
+                    if err.kind() != std::io::ErrorKind::NotFound {
+                        ok = false;
+                    }
+                    continue;
+                }
             };
             for entry in entries.flatten() {
                 let path = entry.path();
@@ -2501,6 +2643,10 @@ impl FileWatcher {
         self.hashes = new_hashes;
         self.large_file_fingerprints = large_file_fingerprints;
         self.round_scan_cache = next_cache;
+        if !ok {
+            self.live_index_degraded = true;
+        }
+        ok
     }
 
     /// Persist `history.json` atomically via tmp + rename.
@@ -2646,23 +2792,22 @@ async fn run_watcher_loop(
     // Close the scan-to-watch gap: the construction scan ran before the
     // watch registration above, so a change landing between them has no
     // event. Re-sync the hash mirrors from disk (a fingerprint walk), drain
-    // whatever raced in meanwhile, and only then mark the index healthy.
-    {
-        let mut w = shared.lock().await;
-        w.refresh_hashes_from_tree();
-    }
+    // whatever raced in meanwhile, and only then — and only if every one of
+    // those steps succeeded — mark the index healthy.
+    let resync_ok = { shared.lock().await.refresh_hashes_from_tree() };
+    let mut drain_ok = true;
     while let Ok(res) = rx.try_recv() {
-        apply_notify_result(&shared, res).await;
+        drain_ok &= apply_notify_result(&shared, res).await;
     }
     {
         let mut w = shared.lock().await;
-        if !w.live_index_disabled {
+        if resync_ok && drain_ok && !w.live_index_disabled {
             w.live_index_degraded = false;
         }
     }
 
     while let Some(res) = rx.recv().await {
-        apply_notify_result(&shared, res).await;
+        let _ = apply_notify_result(&shared, res).await;
     }
 
     shared.lock().await.live_index_degraded = true;
@@ -2671,24 +2816,29 @@ async fn run_watcher_loop(
 
 /// Apply one notify callback result to the shared watcher: rescan-flagged
 /// events re-sync the hash mirrors first (the backend dropped events);
-/// errors degrade the live index for the rest of the process.
+/// errors degrade the live index for the rest of the process. Returns
+/// whether the result was applied cleanly (a failed rescan re-sync or a
+/// notify error both degrade and return `false`).
 async fn apply_notify_result(
     shared: &SharedFileWatcher,
     res: Result<notify::Event, notify::Error>,
-) {
+) -> bool {
     match res {
         Ok(notify_event) => {
             let mut w = shared.lock().await;
+            let mut ok = true;
             if notify_event.need_rescan() {
-                w.refresh_hashes_from_tree();
+                ok = w.refresh_hashes_from_tree();
             }
             for path in &notify_event.paths {
                 w.process_change(path, &notify_event.kind);
             }
+            ok
         }
         Err(err) => {
             eprintln!("[file_watcher] notify error, live index degraded: {}", err);
             shared.lock().await.live_index_degraded = true;
+            false
         }
     }
 }
@@ -3260,6 +3410,7 @@ mod tests {
                 maps_from_round: None,
                 store_epoch: None,
                 maps_inline: false,
+                maps_hash: None,
             };
             w.history.abandoned_branches.push(AbandonedBranch {
                 branched_from_id: r1,
@@ -3506,6 +3657,7 @@ mod tests {
             round.files_at_end = maps.files_at_end;
             round.all_files_at_end = maps.all_files_at_end;
             round.maps_from_round = None;
+            round.maps_hash = None;
         }
         drop(w);
         std::fs::remove_dir_all(tmp_snap.path().join("rounds")).unwrap();
@@ -3747,6 +3899,7 @@ mod tests {
             round.files_at_end = maps.files_at_end;
             round.all_files_at_end = maps.all_files_at_end;
             round.maps_from_round = None;
+            round.maps_hash = None;
         }
         drop(w);
         let rounds_dir = tmp_snap.path().join("rounds");
@@ -3802,6 +3955,149 @@ mod tests {
         let other = TempDir::new().unwrap();
         assert!(live_watcher_for(other.path(), tmp_snap.path()).is_none());
         assert!(live_watcher_for(tmp_proj.path(), other.path()).is_none());
+    }
+
+    /// FIX (round 3): a manifest whose scalars all bind but whose MAPS —
+    /// the actual restore payload — were replaced must be refused: the
+    /// index row records a content hash of the maps and the resolver
+    /// verifies it before serving.
+    #[test]
+    fn map_only_poison_is_refused() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        std::fs::write(root.join("a.txt"), b"v1").unwrap();
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1".into(), None, None).unwrap();
+        let r1 = w.history.current_head_id.unwrap();
+        std::fs::write(root.join("a.txt"), b"v2").unwrap();
+        w.on_round_complete("R2".into(), None, None).unwrap();
+        drop(w);
+
+        // Poison ONLY the payload: every scalar and the epoch stay intact.
+        let manifest_path = round_manifest_path(tmp_snap.path(), r1);
+        let mut manifest: HistoryRound =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        let poison_hash = hex_encode(&sha256_hash(b"attacker content"));
+        manifest.files_at_end = HashMap::from([("a.txt".to_string(), poison_hash.clone())]);
+        manifest.all_files_at_end = HashMap::from([("a.txt".to_string(), poison_hash)]);
+        atomic_write(
+            &manifest_path,
+            &serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let mut resumed = make_watcher(root, tmp_snap.path());
+        assert!(
+            resumed.resolved_round_maps(r1).is_none(),
+            "a map-only poison must fail the payload hash, not be served"
+        );
+        assert!(resumed.rollback(r1).is_err());
+        assert_eq!(std::fs::read(root.join("a.txt")).unwrap(), b"v2");
+    }
+
+    /// FIX (round 3): a transiently UNREADABLE manifest defers epoch
+    /// adoption exactly like a failed write — otherwise the persisted epoch
+    /// would orphan a perfectly correct manifest.
+    #[cfg(unix)]
+    #[test]
+    fn unreadable_manifest_defers_epoch_adoption() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        std::fs::write(root.join("a.txt"), b"v1").unwrap();
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1".into(), None, None).unwrap();
+        let r1 = w.history.current_head_id.unwrap();
+        drop(w);
+
+        // Pre-epoch layout + an unreadable (but correct) manifest.
+        let index_path = tmp_snap.path().join("history.json");
+        let mut index: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&index_path).unwrap()).unwrap();
+        index.as_object_mut().unwrap().remove("store_epoch");
+        atomic_write(&index_path, &serde_json::to_vec_pretty(&index).unwrap()).unwrap();
+        let manifest_path = round_manifest_path(tmp_snap.path(), r1);
+        std::fs::set_permissions(&manifest_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let deferred = make_watcher(root, tmp_snap.path());
+        assert_eq!(
+            deferred.history.store_epoch, None,
+            "an unreadable manifest must defer epoch adoption like a failed write"
+        );
+        drop(deferred);
+
+        // Readable again: the next load completes the mint and restamps.
+        std::fs::set_permissions(&manifest_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let adopted = make_watcher(root, tmp_snap.path());
+        assert!(adopted.history.store_epoch.is_some());
+        assert!(adopted.resolved_round_maps(r1).is_some());
+    }
+
+    /// FIX (round 3): a symlink left under baseline/ (which only ever holds
+    /// regular files we wrote) is a foreign leftover — reconciliation
+    /// removes it, keeping the fallback scan's key universe identical to
+    /// the watcher index's.
+    #[cfg(unix)]
+    #[test]
+    fn symlink_baseline_leftover_is_reconciled() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        std::fs::write(root.join("real.rs"), b"tracked").unwrap();
+        let first = make_watcher(root, tmp_snap.path());
+        drop(first);
+
+        // Plant a symlink leftover pointing at live content.
+        let target = root.join("real.rs");
+        let link = tmp_snap.path().join("baseline").join("ghost.rs");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let mut second = make_watcher(root, tmp_snap.path());
+        assert!(
+            !link.exists() && std::fs::symlink_metadata(&link).is_err(),
+            "the symlink leftover must be removed"
+        );
+        second.mark_live_index_healthy_for_tests();
+        assert!(
+            second.changes_index_snapshot().is_some(),
+            "a successful reconciliation (including symlink removal) keeps the fast path"
+        );
+    }
+
+    /// FIX (round 3): if the post-watch re-sync cannot enumerate part of
+    /// the tree, the live index must STAY degraded — never marked healthy
+    /// over silently missing subtrees.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn resync_failure_keeps_index_degraded() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path().to_path_buf();
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+        std::fs::write(root.join("sub/inner.rs"), b"content").unwrap();
+        let w = make_watcher(&root, tmp_snap.path());
+
+        // Make the subtree unenumerable between construction and watch.
+        std::fs::set_permissions(root.join("sub"), std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let (shared, _watcher_handle, _round_handle) = w.start_shared();
+        // The healthy transition (if it were wrongly taken) happens right
+        // after spawn; give it ample time, asserting it never happens.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        while std::time::Instant::now() < deadline {
+            assert!(
+                shared.lock().await.changes_index_snapshot().is_none(),
+                "a failed re-sync must keep the index degraded"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        std::fs::set_permissions(root.join("sub"), std::fs::Permissions::from_mode(0o755)).unwrap();
     }
 
     /// Windows: a same-length rewrite whose mtime is backdated OUTSIDE the
@@ -4025,6 +4321,7 @@ mod tests {
             round.all_files_at_end = maps.all_files_at_end;
             round.maps_from_round = None;
             round.maps_inline = false;
+            round.maps_hash = None;
         }
         assert!(legacy.rounds[0].files_at_end.is_empty(), "empty-tree round");
         drop(w);

--- a/src/bin/caller/file_watcher.rs
+++ b/src/bin/caller/file_watcher.rs
@@ -101,6 +101,14 @@ pub struct HistoryRound {
     /// `None` for rounds with inline maps and for legacy manifests.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub maps_from_round: Option<u64>,
+    /// Store-epoch stamp carried by per-round manifests (see
+    /// [`History::store_epoch`]). The resolver refuses a manifest whose
+    /// stamp differs from the index's, so a manifest overwritten by a
+    /// pre-format-2 binary (whose restarted round ids collide with ours) is
+    /// an explicit "cannot restore" instead of a silently wrong tree.
+    /// `None` on index round stubs and on legacy data.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub store_epoch: Option<String>,
 }
 
 /// A branch of rounds that was replaced by a rollback-then-new-action. Kept
@@ -119,6 +127,13 @@ pub struct History {
     pub rounds: Vec<HistoryRound>,
     pub abandoned_branches: Vec<AbandonedBranch>,
     pub next_id: u64,
+    /// Identity of this snapshot store, minted the first time the history
+    /// loads under format 2 and stamped into every per-round manifest
+    /// written since. Binds manifests to this index: the resolver refuses a
+    /// manifest carrying a different (or no) stamp, so nothing can restore
+    /// from a manifest some other timeline wrote over ours.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub store_epoch: Option<String>,
 }
 
 /// Result of a successful rollback.
@@ -166,7 +181,88 @@ pub(crate) struct BaselineFileMeta {
 
 pub(crate) type BaselineManifest = HashMap<String, BaselineFileMeta>;
 
-type FileFingerprint = (u64, Option<u128>);
+/// Metadata identity used to decide whether a file may have changed without
+/// re-reading it. Size and mtime alone are spoofable (mtime-preserving
+/// writers, coarse timestamp granules), so the fingerprint also carries the
+/// platform's best change signal and file identity:
+///
+/// - Unix: inode ctime (bumped by every content write; not settable by
+///   `touch -r`/`rsync -t` style tools) plus `(dev, ino)`.
+/// - Windows: the file's creation time (stable std exposes no ChangeTime) —
+///   catches replace-by-rename writers; in-place mtime-backdated rewrites
+///   are left to the racy-distrust window below.
+/// - Elsewhere: `None`s — the mtime requirement still applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FileFingerprint {
+    size: u64,
+    /// Modification time in nanos since the epoch; `None` when unreadable.
+    mtime_nanos: Option<u128>,
+    /// Platform change signal (see type docs); `None` where unavailable.
+    change_signal: Option<i128>,
+    /// `(dev, inode)` on Unix; `None` where unavailable.
+    file_id: Option<(u64, u64)>,
+}
+
+impl FileFingerprint {
+    /// True when `other` plausibly describes the same file state. Requires a
+    /// *known, equal* mtime on both sides — a fingerprint with an unreadable
+    /// timestamp never matches anything, so unreadable stats always fall
+    /// toward re-reading.
+    fn matches(&self, other: &FileFingerprint) -> bool {
+        self.size == other.size
+            && self.mtime_nanos.is_some()
+            && self.mtime_nanos == other.mtime_nanos
+            && self.change_signal == other.change_signal
+            && self.file_id == other.file_id
+    }
+}
+
+/// Racy-write distrust window, git-style: a cache entry whose mtime is not
+/// comfortably older than the moment the entry was recorded could have been
+/// rewritten in the same timestamp granule after we hashed it — such entries
+/// are treated as misses and re-read. 2s covers the coarsest real granule
+/// (FAT's 2s; Windows ~15ms; Linux jiffies ~4-10ms), so only files modified
+/// within 2s before their recording walk pay a re-read on the next walk.
+const FINGERPRINT_RACY_WINDOW_NANOS: u128 = 2_000_000_000;
+
+fn now_nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        // Clock before epoch: record 0 so every entry looks racy and gets
+        // re-read — the safe direction.
+        .unwrap_or(0)
+}
+
+#[cfg(unix)]
+fn metadata_change_signal(meta: &std::fs::Metadata) -> Option<i128> {
+    use std::os::unix::fs::MetadataExt;
+    Some((meta.ctime() as i128) * 1_000_000_000 + meta.ctime_nsec() as i128)
+}
+
+#[cfg(windows)]
+fn metadata_change_signal(meta: &std::fs::Metadata) -> Option<i128> {
+    use std::os::windows::fs::MetadataExt;
+    // 100ns intervals since 1601-01-01; creation time is the best change
+    // signal stable std exposes on Windows (see FileFingerprint docs).
+    Some(meta.creation_time() as i128)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn metadata_change_signal(_meta: &std::fs::Metadata) -> Option<i128> {
+    None
+}
+
+#[cfg(unix)]
+fn metadata_file_id(meta: &std::fs::Metadata) -> Option<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+    Some((meta.dev(), meta.ino()))
+}
+
+#[cfg(not(unix))]
+fn metadata_file_id(_meta: &std::fs::Metadata) -> Option<(u64, u64)> {
+    None
+}
 
 /// `(restorable, display_mirror)` maps from a snapshot object scan: relative
 /// path → object hash.
@@ -326,12 +422,17 @@ fn sha256_file(path: &Path) -> std::io::Result<[u8; 32]> {
 }
 
 fn metadata_fingerprint(meta: &std::fs::Metadata) -> FileFingerprint {
-    let modified_nanos = meta
+    let mtime_nanos = meta
         .modified()
         .ok()
         .and_then(|mtime| mtime.duration_since(UNIX_EPOCH).ok())
         .map(|duration| duration.as_nanos());
-    (meta.len(), modified_nanos)
+    FileFingerprint {
+        size: meta.len(),
+        mtime_nanos,
+        change_signal: metadata_change_signal(meta),
+        file_id: metadata_file_id(meta),
+    }
 }
 
 pub(crate) fn inspect_file(path: &Path) -> std::io::Result<InspectedFile> {
@@ -527,49 +628,115 @@ fn round_manifest_path(snapshot_dir: &Path, round_id: u64) -> PathBuf {
         .join("manifest.json")
 }
 
-/// Load `history.json`, migrating legacy full-fat files (per-round maps
-/// inline) to per-round manifests so the maps stay restorable after the
-/// in-memory copy goes slim. Returns a `History` whose rounds carry scalars
-/// and `files_changed` only.
-fn load_history_from_disk(snapshot_dir: &Path) -> History {
-    let history_path = snapshot_dir.join("history.json");
-    let Ok(bytes) = std::fs::read(&history_path) else {
-        return History::default();
-    };
-    let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
-        return History::default();
-    };
-    let format = value.get("format").and_then(|v| v.as_u64()).unwrap_or(0);
-    let Ok(mut history) = serde_json::from_value::<History>(value) else {
-        return History::default();
-    };
-    if format < HISTORY_INDEX_FORMAT {
-        migrate_legacy_history_maps(&mut history, snapshot_dir);
-    } else {
-        // Defensive: a format-2 index never carries maps, but strip any that
-        // slipped in so the in-memory invariant (slim rounds) always holds.
-        strip_round_maps(&mut history);
-    }
-    history
+/// Result of loading `history.json`: the (slim) history plus whether the
+/// index changed in ways that must be persisted immediately (minted epoch,
+/// migrated maps, format upgrade) — before any new manifest is stamped with
+/// state the on-disk index doesn't know yet.
+struct LoadedHistory {
+    history: History,
+    needs_persist: bool,
 }
 
-/// Write a per-round manifest for every legacy round that has inline maps
-/// but no manifest on disk (manifests have been written since the feature
-/// shipped, so this normally touches nothing), then drop the inline maps
-/// from memory. Rounds inside abandoned branches migrate too.
-fn migrate_legacy_history_maps(history: &mut History, snapshot_dir: &Path) {
-    let migrate_round = |round: &mut HistoryRound| {
-        let manifest_path = round_manifest_path(snapshot_dir, round.id);
-        if !manifest_path.exists() {
-            // Write even when the maps are empty: an explicit "empty tree"
-            // record keeps restore-to-empty semantics distinct from a
-            // missing manifest (which rollback refuses).
-            if let Ok(bytes) = serde_json::to_vec_pretty(&round) {
-                let _ = atomic_write(&manifest_path, &bytes);
+/// Load `history.json`, minting the store epoch when absent and migrating
+/// any round that still carries inline maps (legacy pre-format-2 files, or
+/// rounds retained after an earlier failed migration) into stamped
+/// per-round manifests. Rounds whose manifest write fails KEEP their inline
+/// maps — the index remains the authoritative carrier for them until a
+/// later load succeeds.
+fn load_history_from_disk(snapshot_dir: &Path) -> LoadedHistory {
+    let history_path = snapshot_dir.join("history.json");
+    let (mut history, format) = match std::fs::read(&history_path) {
+        Ok(bytes) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
+            Ok(value) => {
+                let format = value.get("format").and_then(|v| v.as_u64()).unwrap_or(0);
+                match serde_json::from_value::<History>(value) {
+                    Ok(history) => (history, format),
+                    Err(_) => (History::default(), HISTORY_INDEX_FORMAT),
+                }
             }
+            Err(_) => (History::default(), HISTORY_INDEX_FORMAT),
+        },
+        Err(_) => (History::default(), HISTORY_INDEX_FORMAT),
+    };
+
+    let mut needs_persist = format < HISTORY_INDEX_FORMAT;
+    let minted_epoch = history.store_epoch.is_none();
+    if minted_epoch {
+        history.store_epoch = Some(mint_store_epoch(snapshot_dir));
+        needs_persist = true;
+        if format >= HISTORY_INDEX_FORMAT {
+            // An epoch-less format-2 index (written by the brief pre-epoch
+            // revision): its manifests are presumptively ours — re-stamp the
+            // parseable, id-matching ones with the new epoch so they stay
+            // resolvable.
+            restamp_manifests_for_new_epoch(&history, snapshot_dir);
         }
-        round.files_at_end = HashMap::new();
-        round.all_files_at_end = HashMap::new();
+    }
+
+    // Legacy files carry every round's state inline — even an empty map is
+    // an explicit "empty tree" record that must become a manifest (distinct
+    // from a missing manifest, which rollback refuses). Format-2 rounds with
+    // empty maps are ordinary slim stubs.
+    let treat_empty_as_inline = format < HISTORY_INDEX_FORMAT;
+    migrate_inline_round_maps(
+        &mut history,
+        snapshot_dir,
+        treat_empty_as_inline,
+        &mut needs_persist,
+    );
+
+    LoadedHistory {
+        history,
+        needs_persist,
+    }
+}
+
+/// Mint a fresh store epoch: unique per (time, process, store path).
+fn mint_store_epoch(snapshot_dir: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(now_nanos().to_le_bytes());
+    hasher.update(std::process::id().to_le_bytes());
+    hasher.update(snapshot_dir.as_os_str().as_encoded_bytes());
+    let digest = hasher.finalize();
+    let mut raw = [0u8; 32];
+    raw.copy_from_slice(&digest);
+    hex_encode(&raw)[..16].to_string()
+}
+
+/// Move every round's inline maps into a stamped per-round manifest. On a
+/// successful write the inline maps are dropped from the index; on failure
+/// (or a serialization error) they are KEPT so the data stays authoritative
+/// in the index and migration retries on the next load.
+fn migrate_inline_round_maps(
+    history: &mut History,
+    snapshot_dir: &Path,
+    treat_empty_as_inline: bool,
+    needs_persist: &mut bool,
+) {
+    let epoch = history.store_epoch.clone();
+    let mut migrate_round = |round: &mut HistoryRound| {
+        let has_inline = !round.files_at_end.is_empty() || !round.all_files_at_end.is_empty();
+        if !has_inline && !treat_empty_as_inline {
+            return;
+        }
+        // Always rewrite from the inline maps — they are the authoritative
+        // copy; a pre-existing manifest at this id is not trusted (it may be
+        // unparseable, unstamped, or a foreign timeline's).
+        let manifest = HistoryRound {
+            store_epoch: epoch.clone(),
+            maps_from_round: None,
+            ..round.clone()
+        };
+        let manifest_path = round_manifest_path(snapshot_dir, round.id);
+        let written = serde_json::to_vec_pretty(&manifest)
+            .ok()
+            .is_some_and(|bytes| atomic_write(&manifest_path, &bytes).is_ok());
+        if written {
+            round.files_at_end = HashMap::new();
+            round.all_files_at_end = HashMap::new();
+            round.maps_from_round = None;
+            *needs_persist = true;
+        }
     };
     for round in &mut history.rounds {
         migrate_round(round);
@@ -581,15 +748,29 @@ fn migrate_legacy_history_maps(history: &mut History, snapshot_dir: &Path) {
     }
 }
 
-fn strip_round_maps(history: &mut History) {
-    for round in &mut history.rounds {
-        round.files_at_end = HashMap::new();
-        round.all_files_at_end = HashMap::new();
-    }
-    for branch in &mut history.abandoned_branches {
-        for round in &mut branch.rounds {
-            round.files_at_end = HashMap::new();
-            round.all_files_at_end = HashMap::new();
+/// Re-stamp existing manifests with a freshly minted epoch (epoch-less
+/// format-2 index only — see `load_history_from_disk`). Only parseable
+/// manifests whose recorded id matches their path are touched; anything
+/// else is left to fail closed at resolve time.
+fn restamp_manifests_for_new_epoch(history: &History, snapshot_dir: &Path) {
+    let rounds = history
+        .rounds
+        .iter()
+        .chain(history.abandoned_branches.iter().flat_map(|b| &b.rounds));
+    for round in rounds {
+        let manifest_path = round_manifest_path(snapshot_dir, round.id);
+        let Ok(bytes) = std::fs::read(&manifest_path) else {
+            continue;
+        };
+        let Ok(mut manifest) = serde_json::from_slice::<HistoryRound>(&bytes) else {
+            continue;
+        };
+        if manifest.id != round.id {
+            continue;
+        }
+        manifest.store_epoch = history.store_epoch.clone();
+        if let Ok(stamped) = serde_json::to_vec_pretty(&manifest) {
+            let _ = atomic_write(&manifest_path, &stamped);
         }
     }
 }
@@ -607,6 +788,45 @@ fn hex_decode_hash(hex: &str) -> Option<[u8; 32]> {
         out[i] = ((hi << 4) | lo) as u8;
     }
     Some(out)
+}
+
+/// Remove `baseline/` files that are not supported-text entries of the
+/// current baseline manifest — leftovers from a previous run whose source
+/// files were deleted (or stopped being text) before this resume. Keeps the
+/// on-disk baseline key universe identical to the manifest's, so the
+/// full-scan and watcher-index changes paths agree.
+fn reconcile_baseline_dir(baseline_dir: &Path, manifest: &BaselineManifest) {
+    let mut stack = vec![baseline_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let ft = match entry.file_type() {
+                Ok(ft) => ft,
+                Err(_) => continue,
+            };
+            if ft.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if !ft.is_file() {
+                continue;
+            }
+            let rel = match path.strip_prefix(baseline_dir) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+            let keep = manifest
+                .get(&rel_path_key(rel))
+                .is_some_and(|meta| meta.supported_text);
+            if !keep {
+                let _ = std::fs::remove_file(&path);
+            }
+        }
+    }
 }
 
 /// Recursively sum file bytes under `path`.
@@ -712,9 +932,17 @@ pub(crate) struct ChangesIndexSnapshot {
 /// re-hash the ones whose fingerprint moved, so per-round work is
 /// proportional to actual changes instead of the whole tree.
 ///
-/// The fingerprint is always taken from a stat performed *before* the
-/// content read it describes, so a write racing the read can only cause a
-/// spurious cache miss (extra work), never a stale hit.
+/// Staleness contract (this is *detection*, not proof): a hit requires the
+/// full fingerprint (size, mtime, platform change signal, file id) to match
+/// AND the entry to pass the racy-distrust window below. The fingerprint is
+/// taken from a stat performed *before* the content read it describes, so a
+/// racing write can make the stored fingerprint only older than the hashed
+/// content — combined with the window, a same-granule rewrite is re-read on
+/// the next walk, and (on Unix) an mtime-backdated rewrite is caught by
+/// ctime/inode. A write that defeats all of those at once (same length,
+/// restored mtime, same change signal, same inode) is not detectable from
+/// metadata; the live notify event for it still refreshes this cache via
+/// `process_change`.
 #[derive(Debug, Clone)]
 struct ScanCacheEntry {
     fingerprint: FileFingerprint,
@@ -724,6 +952,22 @@ struct ScanCacheEntry {
     /// and restorable); false for inspected-but-unsupported files that only
     /// feed the display mirror.
     restorable: bool,
+    /// When this entry was recorded (walk start for scan-recorded entries),
+    /// for the racy-distrust check.
+    recorded_at_nanos: u128,
+}
+
+impl ScanCacheEntry {
+    /// True when this entry can be trusted for a file currently stat'ing as
+    /// `current`: full fingerprint match plus the racy-distrust window (the
+    /// entry's mtime must be comfortably older than when the entry was
+    /// recorded, or a same-granule rewrite could hide behind it).
+    fn trustworthy_for(&self, current: &FileFingerprint) -> bool {
+        self.fingerprint.matches(current)
+            && self.fingerprint.mtime_nanos.is_some_and(|mtime| {
+                mtime.saturating_add(FINGERPRINT_RACY_WINDOW_NANOS) < self.recorded_at_nanos
+            })
+    }
 }
 
 /// The maps of the round `current_head_id` points at, kept in memory so the
@@ -766,6 +1010,16 @@ pub struct FileWatcher {
     /// Per-file fingerprint → hash cache for round scans and post-restore
     /// re-syncs. Rebuilt on every walk so deleted paths fall out.
     round_scan_cache: HashMap<PathBuf, ScanCacheEntry>,
+    /// True until the notify watcher is confirmed running, and again after a
+    /// notify error or loop exit. While degraded, `changes_index_snapshot`
+    /// returns `None` so the gateway's changes fast path stands down and the
+    /// full scan serves (correct, just slower). A rescan-flagged notify
+    /// event triggers a full re-sync instead of degrading.
+    live_index_degraded: bool,
+    /// Test-only observability: how many files the last
+    /// `scan_and_store_objects` walk actually read (cache misses).
+    #[cfg(test)]
+    pub(crate) files_read_in_last_scan: usize,
     /// Maps of the current head round (see [`HeadMapsCache`]).
     head_maps: Option<HeadMapsCache>,
     /// Running estimate of bytes under `snapshot_dir`, maintained from the
@@ -902,10 +1156,19 @@ impl FileWatcher {
             .map_err(|e| CallerError::Config(format!("baseline manifest serialize: {}", e)))?;
         atomic_write(&manifest_path, &manifest_bytes).map_err(CallerError::Io)?;
 
+        // Drop baseline/ files left over from a previous run whose sources
+        // no longer exist: stale copies otherwise make the full-scan changes
+        // path report phantom "deleted" files this session never had.
+        reconcile_baseline_dir(&baseline_dir, &baseline_manifest);
+
         // Load history.json if it exists (session resume / restart). Legacy
         // full-fat files (per-round maps inline) are migrated to per-round
-        // manifests + a slim index on the next persist.
-        let history = load_history_from_disk(&snapshot_dir);
+        // manifests + a slim index; the store epoch is minted on first
+        // format-2 load.
+        let LoadedHistory {
+            history,
+            needs_persist,
+        } = load_history_from_disk(&snapshot_dir);
 
         // One boot-time walk seeds the size estimate the soft-cap check
         // maintains incrementally afterwards (it used to re-walk per round).
@@ -914,7 +1177,7 @@ impl FileWatcher {
             .map(|meta| meta.len())
             .unwrap_or(0);
 
-        Ok(Self {
+        let mut watcher = Self {
             project_root,
             snapshot_dir,
             bus,
@@ -922,11 +1185,20 @@ impl FileWatcher {
             hashes,
             large_file_fingerprints,
             round_scan_cache: HashMap::new(),
+            live_index_degraded: true,
+            #[cfg(test)]
+            files_read_in_last_scan: 0,
             head_maps: None,
             snapshot_dir_size_estimate,
             last_history_index_bytes,
             history,
-        })
+        };
+        if needs_persist {
+            // Make the minted epoch / migrated maps durable before any new
+            // manifest is stamped against them.
+            watcher.persist_history()?;
+        }
+        Ok(watcher)
     }
 
     /// Read-only accessor for the history state. Callers hold the mutex for
@@ -940,15 +1212,31 @@ impl FileWatcher {
     /// Snapshot the state the changes endpoint needs to compute the
     /// changed-key set without walking the project tree. Cheap relative to
     /// a tree read (two O(files) map clones), taken under the watcher lock.
-    pub(crate) fn changes_index_snapshot(&self) -> ChangesIndexSnapshot {
-        ChangesIndexSnapshot {
+    ///
+    /// `None` while the live index is degraded — before the notify watcher
+    /// has confirmed it is running, or after a notify error — so callers
+    /// fall back to their full-scan path instead of serving from a hash
+    /// mirror that may be missing events.
+    pub(crate) fn changes_index_snapshot(&self) -> Option<ChangesIndexSnapshot> {
+        if self.live_index_degraded {
+            return None;
+        }
+        Some(ChangesIndexSnapshot {
             baseline_manifest: self.baseline_manifest.clone(),
             current_hashes: self
                 .hashes
                 .iter()
                 .map(|(rel, hash)| (rel_path_key(rel), hex_encode(hash)))
                 .collect(),
-        }
+        })
+    }
+
+    /// Test hook: pretend the notify watcher is confirmed healthy, so unit
+    /// tests can exercise the watcher-index fast path without spawning the
+    /// real filesystem-event loop.
+    #[cfg(test)]
+    pub(crate) fn mark_live_index_healthy_for_tests(&mut self) {
+        self.live_index_degraded = false;
     }
 
     /// Wrap `self` in an async-mutex-backed shared handle and spawn the
@@ -1062,21 +1350,38 @@ impl FileWatcher {
 
         match change_kind {
             FileChangeKind::Created | FileChangeKind::Modified => {
-                let large_file_fingerprint = match std::fs::metadata(abs_path) {
-                    Ok(meta) if meta.len() > SNAPSHOT_MAX_FILE_BYTES => {
-                        let fingerprint = metadata_fingerprint(&meta);
-                        if self.large_file_fingerprints.get(&rel) == Some(&fingerprint) {
-                            return;
-                        }
-                        Some(fingerprint)
-                    }
-                    Ok(_) => None,
+                // Stat before the read below, so the fingerprint recorded in
+                // the scan cache is never newer than the content it hashes.
+                let meta = match std::fs::metadata(abs_path) {
+                    Ok(meta) => meta,
                     Err(_) => return,
                 };
+                let fingerprint = metadata_fingerprint(&meta);
+                if meta.len() > SNAPSHOT_MAX_FILE_BYTES
+                    && self
+                        .large_file_fingerprints
+                        .get(&rel)
+                        .is_some_and(|prev| prev.matches(&fingerprint))
+                {
+                    return;
+                }
 
                 match inspect_file(abs_path) {
                     Ok(InspectedFile::Text(snapshot)) => {
                         self.large_file_fingerprints.remove(&rel);
+                        // Live events are the freshest signal — refresh the
+                        // round-scan cache even when the content hash proves
+                        // unchanged (the fingerprint may still have moved).
+                        self.round_scan_cache.insert(
+                            rel.clone(),
+                            ScanCacheEntry {
+                                fingerprint,
+                                hash: snapshot.hash,
+                                hash_hex: snapshot.hash_hex.clone(),
+                                restorable: true,
+                                recorded_at_nanos: now_nanos(),
+                            },
+                        );
                         if self.hashes.get(&rel) == Some(&snapshot.hash) {
                             return; // no actual change
                         }
@@ -1100,17 +1405,21 @@ impl FileWatcher {
                     }
                     Ok(InspectedFile::Unsupported(snapshot)) => {
                         if snapshot.size > SNAPSHOT_MAX_FILE_BYTES {
-                            let fingerprint = large_file_fingerprint.or_else(|| {
-                                std::fs::metadata(abs_path)
-                                    .ok()
-                                    .map(|meta| metadata_fingerprint(&meta))
-                            });
-                            if let Some(fingerprint) = fingerprint {
-                                self.large_file_fingerprints
-                                    .insert(rel.clone(), fingerprint);
-                            }
+                            self.large_file_fingerprints
+                                .insert(rel.clone(), fingerprint);
+                            self.round_scan_cache.remove(&rel);
                         } else {
                             self.large_file_fingerprints.remove(&rel);
+                            self.round_scan_cache.insert(
+                                rel.clone(),
+                                ScanCacheEntry {
+                                    fingerprint,
+                                    hash: snapshot.hash,
+                                    hash_hex: snapshot.hash_hex.clone(),
+                                    restorable: false,
+                                    recorded_at_nanos: now_nanos(),
+                                },
+                            );
                         }
                         if self.hashes.get(&rel) == Some(&snapshot.hash) {
                             return; // no actual change
@@ -1141,6 +1450,7 @@ impl FileWatcher {
                 }
                 self.hashes.remove(&rel);
                 self.large_file_fingerprints.remove(&rel);
+                self.round_scan_cache.remove(&rel);
             }
         }
     }
@@ -1219,17 +1529,24 @@ impl FileWatcher {
             turn_count,
             native_message_count,
             maps_from_round: maps_source_id,
+            store_epoch: None,
         };
 
-        // Write the per-round manifest — the durable home of the maps. A
-        // no-op round writes a tiny backreference stub; a changed round
+        // Write the per-round manifest — the durable home of the maps,
+        // stamped with the store epoch so the resolver can tell our
+        // manifests from anything a foreign timeline wrote at the same id.
+        // A no-op round writes a tiny backreference stub; a changed round
         // inlines its maps.
         let manifest = if maps_source_id.is_some() {
-            stub.clone()
+            HistoryRound {
+                store_epoch: self.history.store_epoch.clone(),
+                ..stub.clone()
+            }
         } else {
             HistoryRound {
                 files_at_end: files_at_end.clone(),
                 all_files_at_end: all_files_at_end.clone(),
+                store_epoch: self.history.store_epoch.clone(),
                 ..stub.clone()
             }
         };
@@ -1394,10 +1711,11 @@ impl FileWatcher {
     /// the display mirror. Ignored and oversized files are skipped.
     ///
     /// Fingerprint-cached: every file is stat'd, but only files whose
-    /// (size, mtime) moved since the last walk are re-read and re-hashed.
-    /// A cached restorable entry is only trusted when its object blob still
-    /// exists on disk, so every hash recorded in `files_at_end` is
-    /// restorable by construction.
+    /// fingerprint moved since the last walk (see [`ScanCacheEntry`] for the
+    /// exact staleness contract) are re-read and re-hashed. A cached
+    /// restorable entry is only trusted when its object blob still exists on
+    /// disk, so every hash recorded in `files_at_end` is restorable by
+    /// construction.
     fn scan_and_store_objects(&mut self) -> Result<SnapshotObjectMaps, CallerError> {
         let mut out: HashMap<String, String> = HashMap::new();
         let mut all: HashMap<String, String> = HashMap::new();
@@ -1406,6 +1724,14 @@ impl FileWatcher {
             .map_err(|e| CallerError::Config(format!("create objects dir: {}", e)))?;
         let mut next_cache: HashMap<PathBuf, ScanCacheEntry> =
             HashMap::with_capacity(self.round_scan_cache.len());
+        // Entries recorded during this walk carry the walk's start time: the
+        // racy-distrust check compares a file's mtime against it, and the
+        // start is the most conservative bound (recording happens later).
+        let walk_started_nanos = now_nanos();
+        #[cfg(test)]
+        {
+            self.files_read_in_last_scan = 0;
+        }
 
         let mut stack = vec![self.project_root.clone()];
         while let Some(dir) = stack.pop() {
@@ -1448,7 +1774,7 @@ impl FileWatcher {
                 // newer than what a subsequent read returns.
                 let fingerprint = metadata_fingerprint(&meta);
                 if let Some(cached) = self.round_scan_cache.get(&rel) {
-                    if cached.fingerprint == fingerprint {
+                    if cached.trustworthy_for(&fingerprint) {
                         let key = rel_path_key(&rel);
                         if cached.restorable {
                             if objects_dir.join(&cached.hash_hex).exists() {
@@ -1465,6 +1791,10 @@ impl FileWatcher {
                             continue;
                         }
                     }
+                }
+                #[cfg(test)]
+                {
+                    self.files_read_in_last_scan += 1;
                 }
                 let snapshot = match inspect_file(&path) {
                     Ok(snapshot) => snapshot,
@@ -1488,6 +1818,7 @@ impl FileWatcher {
                                 hash: snapshot.hash,
                                 hash_hex: snapshot.hash_hex.clone(),
                                 restorable: true,
+                                recorded_at_nanos: walk_started_nanos,
                             },
                         );
                         out.insert(rel_path_key(&rel), snapshot.hash_hex);
@@ -1501,6 +1832,7 @@ impl FileWatcher {
                                 hash: snapshot.hash,
                                 hash_hex: snapshot.hash_hex,
                                 restorable: false,
+                                recorded_at_nanos: walk_started_nanos,
                             },
                         );
                     }
@@ -1517,10 +1849,18 @@ impl FileWatcher {
         std::fs::read_to_string(self.snapshot_dir.join("baseline").join(rel)).ok()
     }
 
-    /// Resolve one round's maps: from the head cache when it matches, else
-    /// from the round's on-disk manifest, following its (depth-1)
-    /// `maps_from_round` backreference. `None` when the round is unknown or
-    /// its manifest chain is missing/unreadable.
+    /// Resolve one round's maps: from the head cache when it matches, from
+    /// inline maps retained in the index (a round whose migration to a
+    /// manifest hasn't succeeded yet), else from the round's on-disk
+    /// manifest, following its (depth-1) `maps_from_round` backreference.
+    ///
+    /// Fails closed (`None` — callers surface "cannot restore") when the
+    /// round is unknown, the manifest chain is missing/unreadable/cyclic
+    /// (including a self-referential backreference), a manifest's `id`
+    /// doesn't match its path, or a manifest's `store_epoch` stamp doesn't
+    /// match the index's — the last guards against a pre-format-2 binary
+    /// having overwritten manifests with same-id rounds of a different
+    /// timeline (its restarted ids collide with ours).
     fn resolved_round_maps(&self, round_id: u64) -> Option<ResolvedRoundMaps> {
         if let Some(cache) = &self.head_maps {
             if cache.round_id == round_id {
@@ -1531,24 +1871,57 @@ impl FileWatcher {
                 });
             }
         }
+        let stub = self.history.rounds.iter().find(|r| r.id == round_id)?;
+        // Inline maps retained after a failed migration are authoritative.
+        if !stub.files_at_end.is_empty() || !stub.all_files_at_end.is_empty() {
+            return Some(ResolvedRoundMaps {
+                source_round_id: stub.id,
+                files_at_end: stub.files_at_end.clone(),
+                all_files_at_end: stub.all_files_at_end.clone(),
+            });
+        }
         // Prefer the in-memory stub's backreference (skips one manifest
         // read); fall back to whatever the manifest chain says so maps stay
         // resolvable even if the index was rebuilt from scratch.
-        let stub_source = self
-            .history
-            .rounds
-            .iter()
-            .find(|r| r.id == round_id)
-            .and_then(|r| r.maps_from_round);
-        let mut source_id = stub_source.unwrap_or(round_id);
-        // Backreferences are written depth-1; the bound is purely defensive.
+        let mut source_id = stub.maps_from_round.unwrap_or(round_id);
+        // Backreferences are written depth-1; the visited set and bound are
+        // defense against corrupt or foreign manifests.
+        let mut visited: HashSet<u64> = HashSet::new();
         for _ in 0..32 {
+            if !visited.insert(source_id) {
+                // Cycle (including a manifest that references itself):
+                // corrupt data — refuse rather than resolve to a wrong or
+                // empty tree.
+                return None;
+            }
+            // A referenced round whose own migration is still pending keeps
+            // its maps inline in the index — serve those (its manifest does
+            // not exist yet).
+            if let Some(inline) = self
+                .history
+                .rounds
+                .iter()
+                .find(|r| r.id == source_id)
+                .filter(|r| !r.files_at_end.is_empty() || !r.all_files_at_end.is_empty())
+            {
+                return Some(ResolvedRoundMaps {
+                    source_round_id: inline.id,
+                    files_at_end: inline.files_at_end.clone(),
+                    all_files_at_end: inline.all_files_at_end.clone(),
+                });
+            }
             let manifest_path = round_manifest_path(&self.snapshot_dir, source_id);
             let bytes = std::fs::read(&manifest_path).ok()?;
             let manifest = serde_json::from_slice::<HistoryRound>(&bytes).ok()?;
+            if manifest.id != source_id {
+                return None;
+            }
+            if manifest.store_epoch.as_deref() != self.history.store_epoch.as_deref() {
+                return None;
+            }
             match manifest.maps_from_round {
-                Some(next) if next != source_id => source_id = next,
-                _ => {
+                Some(next) => source_id = next,
+                None => {
                     return Some(ResolvedRoundMaps {
                         source_round_id: source_id,
                         files_at_end: manifest.files_at_end,
@@ -1564,10 +1937,11 @@ impl FileWatcher {
     /// delete any tracked file absent from `target`, restore any file whose
     /// hash differs (or doesn't exist). Returns the count of paths touched.
     ///
-    /// Fingerprint-cached like the round scan: unchanged files contribute
-    /// their cached hash from a stat instead of a full read. After each
-    /// restore/delete the cache is updated so the follow-up
-    /// [`Self::refresh_hashes_from_tree`] walk is also mostly stats.
+    /// Fingerprint-cached like the round scan: files untouched since a
+    /// comfortably-old walk contribute their cached hash from a stat instead
+    /// of a full read; recently-modified and just-restored files are
+    /// (re-)read — the racy-distrust window deliberately keeps fresh entries
+    /// untrusted, so the walks after a restore re-verify what was written.
     fn restore_to_state(&mut self, target: &HashMap<String, String>) -> Result<u32, CallerError> {
         let objects_dir = self.snapshot_dir.join("objects");
         // Build the current tree's path set (restorable text files only,
@@ -1612,7 +1986,7 @@ impl FileWatcher {
                 }
                 let fingerprint = metadata_fingerprint(&meta);
                 if let Some(cached) = self.round_scan_cache.get(&rel) {
-                    if cached.fingerprint == fingerprint {
+                    if cached.trustworthy_for(&fingerprint) {
                         if cached.restorable {
                             current.insert(rel_path_key(&rel), cached.hash);
                         }
@@ -1629,6 +2003,7 @@ impl FileWatcher {
                                 hash: snapshot.hash,
                                 hash_hex: snapshot.hash_hex,
                                 restorable: false,
+                                recorded_at_nanos: now_nanos(),
                             },
                         );
                         continue;
@@ -1642,6 +2017,7 @@ impl FileWatcher {
                         hash: snapshot.hash,
                         hash_hex: snapshot.hash_hex,
                         restorable: true,
+                        recorded_at_nanos: now_nanos(),
                     },
                 );
                 current.insert(rel_path_key(&rel), snapshot.hash);
@@ -1661,8 +2037,10 @@ impl FileWatcher {
             if atomic_write(&abs, &bytes).is_err() {
                 return false;
             }
-            // Record the restored content in the scan cache so the
-            // post-restore re-sync walk does not re-read it.
+            // Record the restored content in the scan cache. The entry is
+            // freshly written, so the racy-distrust window will still force
+            // one verification re-read on the next walk — correct, and the
+            // cost is bounded by the number of restored files.
             if let (Ok(meta), Some(hash)) = (std::fs::metadata(&abs), hex_decode_hash(target_hex)) {
                 watcher.round_scan_cache.insert(
                     PathBuf::from(rel),
@@ -1671,6 +2049,7 @@ impl FileWatcher {
                         hash,
                         hash_hex: target_hex.to_string(),
                         restorable: true,
+                        recorded_at_nanos: now_nanos(),
                     },
                 );
             }
@@ -1758,7 +2137,10 @@ impl FileWatcher {
                     // changed oversized file gets one streaming re-hash.
                     let hash = match self.hashes.get(&rel) {
                         Some(prev)
-                            if self.large_file_fingerprints.get(&rel) == Some(&fingerprint) =>
+                            if self
+                                .large_file_fingerprints
+                                .get(&rel)
+                                .is_some_and(|old| old.matches(&fingerprint)) =>
                         {
                             Some(*prev)
                         }
@@ -1772,7 +2154,7 @@ impl FileWatcher {
                 }
                 let fingerprint = metadata_fingerprint(&meta);
                 if let Some(cached) = self.round_scan_cache.get(&rel) {
-                    if cached.fingerprint == fingerprint {
+                    if cached.trustworthy_for(&fingerprint) {
                         new_hashes.insert(rel.clone(), cached.hash);
                         next_cache.insert(rel, cached.clone());
                         continue;
@@ -1793,6 +2175,7 @@ impl FileWatcher {
                             hash,
                             hash_hex,
                             restorable,
+                            recorded_at_nanos: now_nanos(),
                         },
                     );
                 }
@@ -1916,6 +2299,13 @@ impl FileWatcher {
 /// Run the notify-based filesystem watcher. Shared state is updated under the
 /// async mutex on each event so snapshot / rollback operations see a
 /// consistent view.
+///
+/// Health protocol: the watcher starts degraded; only once `watch()` has
+/// succeeded is the live index marked healthy (enabling the gateway's
+/// changes fast path). A rescan-flagged event (the backend dropped events)
+/// triggers a full hash re-sync and stays healthy; a notify error or loop
+/// exit degrades the index for the rest of the process — the fast path
+/// stands down and the full scan serves.
 async fn run_watcher_loop(
     shared: SharedFileWatcher,
     project_root: PathBuf,
@@ -1925,9 +2315,7 @@ async fn run_watcher_loop(
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
     let mut watcher =
         notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
-            if let Ok(event) = res {
-                let _ = tx.send(event);
-            }
+            let _ = tx.send(res);
         })
         .map_err(|e| CallerError::Config(format!("notify watcher init: {}", e)))?;
 
@@ -1937,15 +2325,29 @@ async fn run_watcher_loop(
 
     let _watcher = watcher;
 
-    while let Some(notify_event) = rx.recv().await {
-        let paths = notify_event.paths.clone();
-        let kind = notify_event.kind;
-        let mut w = shared.lock().await;
-        for path in &paths {
-            w.process_change(path, &kind);
+    shared.lock().await.live_index_degraded = false;
+
+    while let Some(res) = rx.recv().await {
+        match res {
+            Ok(notify_event) => {
+                let mut w = shared.lock().await;
+                if notify_event.need_rescan() {
+                    // The backend dropped events; re-sync the hash mirrors
+                    // from disk before processing anything further.
+                    w.refresh_hashes_from_tree();
+                }
+                for path in &notify_event.paths {
+                    w.process_change(path, &notify_event.kind);
+                }
+            }
+            Err(err) => {
+                eprintln!("[file_watcher] notify error, live index degraded: {}", err);
+                shared.lock().await.live_index_degraded = true;
+            }
         }
     }
 
+    shared.lock().await.live_index_degraded = true;
     Ok(())
 }
 
@@ -2514,6 +2916,7 @@ mod tests {
                 turn_count: None,
                 native_message_count: None,
                 maps_from_round: None,
+                store_epoch: None,
             };
             w.history.abandoned_branches.push(AbandonedBranch {
                 branched_from_id: r1,
@@ -2545,13 +2948,12 @@ mod tests {
         assert_eq!(w.history.current_head_id, Some(r1));
     }
 
-    /// Round scans must not re-read files whose (size, mtime) fingerprint is
-    /// unchanged. Proven through the short-circuit's one observable: content
-    /// rewritten at identical length with a restored mtime keeps the
-    /// previously recorded hash (nothing re-read it), while a rewrite whose
-    /// mtime moves is picked up again.
+    /// A same-length rewrite with a restored mtime must be DETECTED and
+    /// re-read, never served stale from the fingerprint cache: the
+    /// racy-distrust window refuses to trust entries whose mtime sits near
+    /// their recording walk, which is exactly where such rewrites land.
     #[test]
-    fn round_scan_short_circuits_unchanged_fingerprints() {
+    fn same_length_mtime_restored_rewrite_is_detected() {
         let tmp_proj = TempDir::new().unwrap();
         let tmp_snap = TempDir::new().unwrap();
         let root = tmp_proj.path();
@@ -2561,36 +2963,103 @@ mod tests {
         w.on_round_complete("R1".into(), None, None).unwrap();
         let r1 = w.history.current_head_id.unwrap();
         let r1_hash = w.resolved_round_maps(r1).unwrap().files_at_end["a.txt"].clone();
+        assert_eq!(r1_hash, hex_encode(&sha256_hash(b"round-1!")));
 
+        // Same length, mtime restored to the pre-rewrite value: the stat
+        // fingerprint alone cannot tell the difference.
         let original_mtime = std::fs::metadata(&file).unwrap().modified().unwrap();
         std::fs::write(&file, b"round-2!").unwrap();
         let handle = std::fs::File::options().write(true).open(&file).unwrap();
         handle.set_modified(original_mtime).unwrap();
         drop(handle);
+
         w.on_round_complete("R2".into(), None, None).unwrap();
         let r2 = w.history.current_head_id.unwrap();
         assert_eq!(
             w.resolved_round_maps(r2).unwrap().files_at_end["a.txt"],
-            r1_hash,
-            "fingerprint-unchanged file must be served from the cache, not re-hashed"
+            hex_encode(&sha256_hash(b"round-2!")),
+            "a same-length mtime-restored rewrite must be re-read, not served stale"
+        );
+    }
+
+    /// Unix: a same-length rewrite whose mtime is backdated far OUTSIDE the
+    /// racy window is still detected via the ctime component of the
+    /// fingerprint (mtime-preserving tools cannot preserve ctime).
+    #[cfg(unix)]
+    #[test]
+    fn mtime_backdated_rewrite_is_detected_via_ctime() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        let file = root.join("a.txt");
+        std::fs::write(&file, b"round-1!").unwrap();
+        // Backdate the mtime a full hour so cache entries recorded for this
+        // file are comfortably outside the racy-distrust window.
+        let past = std::time::SystemTime::now() - std::time::Duration::from_secs(3600);
+        let handle = std::fs::File::options().write(true).open(&file).unwrap();
+        handle.set_modified(past).unwrap();
+        drop(handle);
+
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1".into(), None, None).unwrap();
+        let r1 = w.history.current_head_id.unwrap();
+        assert_eq!(
+            w.resolved_round_maps(r1).unwrap().files_at_end["a.txt"],
+            hex_encode(&sha256_hash(b"round-1!"))
         );
 
-        std::fs::write(&file, b"round-3!").unwrap();
+        // Guard against coarse (1s) ctime granularity: make sure the rewrite
+        // below cannot share the original write's ctime tick.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+
+        // Same length, mtime backdated to the exact same past value — only
+        // the ctime betrays the rewrite.
+        std::fs::write(&file, b"round-2!").unwrap();
         let handle = std::fs::File::options().write(true).open(&file).unwrap();
-        handle
-            .set_modified(original_mtime + std::time::Duration::from_secs(5))
-            .unwrap();
+        handle.set_modified(past).unwrap();
         drop(handle);
-        w.on_round_complete("R3".into(), None, None).unwrap();
-        let r3 = w.history.current_head_id.unwrap();
-        let r3_maps = w.resolved_round_maps(r3).unwrap();
-        assert_ne!(
-            r3_maps.files_at_end["a.txt"], r1_hash,
-            "a moved fingerprint must be re-read"
-        );
+
+        w.on_round_complete("R2".into(), None, None).unwrap();
+        let r2 = w.history.current_head_id.unwrap();
         assert_eq!(
-            r3_maps.files_at_end["a.txt"],
-            hex_encode(&sha256_hash(b"round-3!"))
+            w.resolved_round_maps(r2).unwrap().files_at_end["a.txt"],
+            hex_encode(&sha256_hash(b"round-2!")),
+            "an mtime-backdated rewrite must be caught by the ctime fingerprint"
+        );
+    }
+
+    /// Efficiency pin: a round scan reads only files whose fingerprint
+    /// moved. Files are backdated an hour so their cache entries are
+    /// trustworthy (outside the racy-distrust window) — an untouched tree
+    /// then costs zero reads, and touching one file costs one.
+    #[test]
+    fn round_scan_reads_only_changed_files() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        let past = std::time::SystemTime::now() - std::time::Duration::from_secs(3600);
+        for name in ["a.txt", "b.txt", "c.txt"] {
+            let path = root.join(name);
+            std::fs::write(&path, format!("content of {name}\n")).unwrap();
+            let handle = std::fs::File::options().write(true).open(&path).unwrap();
+            handle.set_modified(past).unwrap();
+        }
+
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1".into(), None, None).unwrap();
+        assert_eq!(w.files_read_in_last_scan, 3, "first scan reads everything");
+
+        w.on_round_complete("R2".into(), None, None).unwrap();
+        assert_eq!(
+            w.files_read_in_last_scan, 0,
+            "an untouched tree must cost zero reads"
+        );
+
+        std::fs::write(root.join("b.txt"), "changed content\n").unwrap();
+        w.on_round_complete("R3".into(), None, None).unwrap();
+        assert_eq!(
+            w.files_read_in_last_scan, 1,
+            "only the touched file is re-read"
         );
     }
 
@@ -2680,8 +3149,9 @@ mod tests {
         let r2 = w.history.current_head_id.unwrap();
 
         // Rebuild the pre-format-2 on-disk layout: maps inline in
-        // history.json (no format marker), no round manifests.
+        // history.json (no format marker, no epoch), no round manifests.
         let mut legacy = w.history.clone();
+        legacy.store_epoch = None;
         for round in &mut legacy.rounds {
             let maps = w.resolved_round_maps(round.id).unwrap();
             round.files_at_end = maps.files_at_end;
@@ -2762,8 +3232,10 @@ mod tests {
         std::fs::write(root.join("big.csv"), &big).unwrap();
         std::fs::write(root.join("a.txt"), b"v1").unwrap();
         let mut w = make_watcher(root, tmp_snap.path());
+        w.mark_live_index_healthy_for_tests();
         let big_hash_before = w
             .changes_index_snapshot()
+            .expect("healthy index")
             .current_hashes
             .get("big.csv")
             .cloned()
@@ -2774,12 +3246,194 @@ mod tests {
         w.on_round_complete("R2".into(), None, None).unwrap();
 
         w.rollback(r1).unwrap();
-        let index = w.changes_index_snapshot();
+        let index = w.changes_index_snapshot().expect("healthy index");
         assert_eq!(
             index.current_hashes.get("big.csv"),
             Some(&big_hash_before),
             "rollback re-sync must not drop oversized files from the hash index"
         );
+    }
+
+    /// The changes index refuses to serve while the live-event lane is
+    /// unconfirmed or degraded — callers must fall back to the full scan.
+    #[test]
+    fn degraded_live_index_serves_no_snapshot() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        std::fs::write(tmp_proj.path().join("a.txt"), b"hello").unwrap();
+        let mut w = make_watcher(tmp_proj.path(), tmp_snap.path());
+        assert!(
+            w.changes_index_snapshot().is_none(),
+            "a watcher whose notify loop is unconfirmed must not serve the index"
+        );
+        w.mark_live_index_healthy_for_tests();
+        assert!(w.changes_index_snapshot().is_some());
+    }
+
+    /// A manifest whose store-epoch stamp doesn't match the index (e.g. a
+    /// pre-format-2 binary overwrote it with a same-id round of a different
+    /// timeline) makes restore refuse — an error, never a wrong tree.
+    #[test]
+    fn manifest_epoch_mismatch_refuses_restore() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        std::fs::write(root.join("a.txt"), b"v1").unwrap();
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1".into(), None, None).unwrap();
+        let r1 = w.history.current_head_id.unwrap();
+        std::fs::write(root.join("a.txt"), b"v2").unwrap();
+        w.on_round_complete("R2".into(), None, None).unwrap();
+        drop(w);
+
+        // Tamper: restamp round 1's manifest with a foreign epoch.
+        let manifest_path = round_manifest_path(tmp_snap.path(), r1);
+        let mut manifest: HistoryRound =
+            serde_json::from_slice(&std::fs::read(&manifest_path).unwrap()).unwrap();
+        manifest.store_epoch = Some("f00df00df00df00d".to_string());
+        atomic_write(
+            &manifest_path,
+            &serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let mut resumed = make_watcher(root, tmp_snap.path());
+        assert!(
+            resumed.resolved_round_maps(r1).is_none(),
+            "foreign-epoch manifest must not resolve"
+        );
+        assert!(resumed.rollback(r1).is_err());
+        assert_eq!(
+            std::fs::read(root.join("a.txt")).unwrap(),
+            b"v2",
+            "a refused rollback must not touch the tree"
+        );
+
+        // An unstamped manifest (what an old binary writes) is refused too.
+        manifest.store_epoch = None;
+        atomic_write(
+            &manifest_path,
+            &serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        let mut resumed = make_watcher(root, tmp_snap.path());
+        assert!(resumed.resolved_round_maps(r1).is_none());
+        assert!(resumed.rollback(r1).is_err());
+    }
+
+    /// Corrupt backreference chains — a manifest referencing itself, or a
+    /// two-manifest cycle — must fail closed to "cannot restore" instead of
+    /// resolving to an empty (or wrong) tree.
+    #[test]
+    fn self_referential_and_cyclic_backrefs_fail_closed() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        std::fs::write(root.join("a.txt"), b"v1").unwrap();
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1".into(), None, None).unwrap();
+        let r1 = w.history.current_head_id.unwrap();
+        std::fs::write(root.join("a.txt"), b"v2").unwrap();
+        w.on_round_complete("R2".into(), None, None).unwrap();
+        let r2 = w.history.current_head_id.unwrap();
+        std::fs::write(root.join("a.txt"), b"v3").unwrap();
+        w.on_round_complete("R3".into(), None, None).unwrap();
+        let r3 = w.history.current_head_id.unwrap();
+        drop(w);
+
+        let tamper = |id: u64, backref: u64| {
+            let path = round_manifest_path(tmp_snap.path(), id);
+            let mut manifest: HistoryRound =
+                serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+            manifest.maps_from_round = Some(backref);
+            manifest.files_at_end = HashMap::new();
+            manifest.all_files_at_end = HashMap::new();
+            atomic_write(&path, &serde_json::to_vec_pretty(&manifest).unwrap()).unwrap();
+        };
+        // r1 references itself; r2 and r3 form a 2-cycle.
+        tamper(r1, r1);
+        tamper(r2, r3);
+        tamper(r3, r2);
+
+        let mut resumed = make_watcher(root, tmp_snap.path());
+        assert!(
+            resumed.resolved_round_maps(r1).is_none(),
+            "self-referential manifest must fail closed, not resolve to an empty tree"
+        );
+        assert!(resumed.resolved_round_maps(r2).is_none());
+        assert!(resumed.resolved_round_maps(r3).is_none());
+        assert!(resumed.rollback(r1).is_err());
+        assert_eq!(
+            std::fs::read(root.join("a.txt")).unwrap(),
+            b"v3",
+            "no tracked file may be touched by a refused rollback"
+        );
+    }
+
+    /// When the per-round manifest cannot be written (unwritable rounds
+    /// dir), migration must keep the inline maps in the index — restore
+    /// still works from them, and a later load with a writable dir migrates
+    /// them for real.
+    #[cfg(unix)]
+    #[test]
+    fn failed_migration_keeps_inline_maps_and_still_restores() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        std::fs::write(root.join("a.txt"), b"v1").unwrap();
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1".into(), None, None).unwrap();
+        let r1 = w.history.current_head_id.unwrap();
+        std::fs::write(root.join("a.txt"), b"v2").unwrap();
+        w.on_round_complete("R2".into(), None, None).unwrap();
+
+        // Rebuild the legacy layout (maps inline, no manifests)...
+        let mut legacy = w.history.clone();
+        legacy.store_epoch = None;
+        for round in &mut legacy.rounds {
+            let maps = w.resolved_round_maps(round.id).unwrap();
+            round.files_at_end = maps.files_at_end;
+            round.all_files_at_end = maps.all_files_at_end;
+            round.maps_from_round = None;
+        }
+        drop(w);
+        let rounds_dir = tmp_snap.path().join("rounds");
+        std::fs::remove_dir_all(&rounds_dir).unwrap();
+        std::fs::create_dir_all(&rounds_dir).unwrap();
+        atomic_write(
+            &tmp_snap.path().join("history.json"),
+            &serde_json::to_vec_pretty(&legacy).unwrap(),
+        )
+        .unwrap();
+        // ...and make the manifest home unwritable.
+        std::fs::set_permissions(&rounds_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let mut blocked = make_watcher(root, tmp_snap.path());
+        assert!(
+            !blocked.history.rounds[0].files_at_end.is_empty(),
+            "failed migration must keep the authoritative inline maps"
+        );
+        let persisted = std::fs::read_to_string(tmp_snap.path().join("history.json")).unwrap();
+        assert!(
+            persisted.contains("files_at_end"),
+            "retained inline maps must stay durable in the index"
+        );
+        blocked.rollback(r1).unwrap();
+        assert_eq!(std::fs::read(root.join("a.txt")).unwrap(), b"v1");
+        drop(blocked);
+
+        // Writable again: the next load migrates for real.
+        std::fs::set_permissions(&rounds_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let migrated = make_watcher(root, tmp_snap.path());
+        assert!(migrated
+            .history
+            .rounds
+            .iter()
+            .all(|r| r.files_at_end.is_empty()));
+        assert!(round_manifest_path(tmp_snap.path(), r1).exists());
+        assert!(migrated.resolved_round_maps(r1).is_some());
     }
 
     /// `start_shared` registers the watcher; the registry resolves it by

--- a/src/bin/caller/file_watcher.rs
+++ b/src/bin/caller/file_watcher.rs
@@ -109,6 +109,36 @@ pub struct HistoryRound {
     /// `None` on index round stubs and on legacy data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub store_epoch: Option<String>,
+    /// Marker that this round's maps live inline in THIS record — set on an
+    /// index row when its manifest write failed and the maps were retained.
+    /// Load-bearing for empty trees: an empty inline map serializes to
+    /// nothing, so without the marker a retained empty-tree round would
+    /// reload as an ordinary slim stub and its restore-to-empty state would
+    /// be unreachable. `false` everywhere else (stubs, manifests, legacy).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub maps_inline: bool,
+}
+
+/// Whether an index row is currently the authoritative carrier of its own
+/// maps (retained after a failed migration, or a legacy row not yet
+/// migrated) — as opposed to a slim stub whose maps live in a manifest.
+fn round_has_inline_maps(round: &HistoryRound) -> bool {
+    round.maps_inline || !round.files_at_end.is_empty() || !round.all_files_at_end.is_empty()
+}
+
+/// Content binding between a per-round manifest and its index row: every
+/// scalar the index records must agree. Identity (`id`) alone is never
+/// enough — a pre-format-2 binary restarts ids at 0, so a manifest it
+/// overwrote carries one of our ids with a different round's content.
+fn manifest_binds_to_round(manifest: &HistoryRound, stub: &HistoryRound) -> bool {
+    manifest.id == stub.id
+        && manifest.parent_id == stub.parent_id
+        && manifest.summary == stub.summary
+        && manifest.timestamp_unix == stub.timestamp_unix
+        && manifest.files_changed == stub.files_changed
+        && manifest.turn_count == stub.turn_count
+        && manifest.native_message_count == stub.native_message_count
+        && manifest.maps_from_round == stub.maps_from_round
 }
 
 /// A branch of rounds that was replaced by a rollback-then-new-action. Kept
@@ -184,35 +214,47 @@ pub(crate) type BaselineManifest = HashMap<String, BaselineFileMeta>;
 /// Metadata identity used to decide whether a file may have changed without
 /// re-reading it. Size and mtime alone are spoofable (mtime-preserving
 /// writers, coarse timestamp granules), so the fingerprint also carries the
-/// platform's best change signal and file identity:
+/// platform's change signal and file identity from
+/// [`crate::platform::file_change_stamp`]:
 ///
 /// - Unix: inode ctime (bumped by every content write; not settable by
 ///   `touch -r`/`rsync -t` style tools) plus `(dev, ino)`.
-/// - Windows: the file's creation time (stable std exposes no ChangeTime) —
-///   catches replace-by-rename writers; in-place mtime-backdated rewrites
-///   are left to the racy-distrust window below.
-/// - Elsewhere: `None`s — the mtime requirement still applies.
+/// - Windows: NTFS `ChangeTime` via `GetFileInformationByHandleEx` (bumped
+///   by every write; not settable through `SetFileTime`) plus the volume +
+///   file-index identity.
+/// - Elsewhere: no signal exists — see [`FileFingerprint::matches`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct FileFingerprint {
     size: u64,
     /// Modification time in nanos since the epoch; `None` when unreadable.
     mtime_nanos: Option<u128>,
-    /// Platform change signal (see type docs); `None` where unavailable.
+    /// Platform change signal (see type docs); `None` when the platform
+    /// query failed (Windows handle open/query) or offers no signal.
     change_signal: Option<i128>,
-    /// `(dev, inode)` on Unix; `None` where unavailable.
+    /// Real file identity `(volume/dev, index/inode)`; `None` alongside a
+    /// `None` change signal.
     file_id: Option<(u64, u64)>,
 }
 
 impl FileFingerprint {
     /// True when `other` plausibly describes the same file state. Requires a
     /// *known, equal* mtime on both sides — a fingerprint with an unreadable
-    /// timestamp never matches anything, so unreadable stats always fall
-    /// toward re-reading.
+    /// timestamp never matches anything — and, on platforms that have a
+    /// change signal (Unix, Windows), a *present, equal* signal: a failed
+    /// signal query never matches, so degraded stats always fall toward
+    /// re-reading.
     fn matches(&self, other: &FileFingerprint) -> bool {
+        let change_signal_ok = match (self.change_signal, other.change_signal) {
+            (Some(a), Some(b)) => a == b,
+            // Where a signal is expected, its absence is a failed query,
+            // never proof of anything.
+            (None, None) => !cfg!(any(unix, windows)),
+            _ => false,
+        };
         self.size == other.size
             && self.mtime_nanos.is_some()
             && self.mtime_nanos == other.mtime_nanos
-            && self.change_signal == other.change_signal
+            && change_signal_ok
             && self.file_id == other.file_id
     }
 }
@@ -232,36 +274,6 @@ fn now_nanos() -> u128 {
         // Clock before epoch: record 0 so every entry looks racy and gets
         // re-read — the safe direction.
         .unwrap_or(0)
-}
-
-#[cfg(unix)]
-fn metadata_change_signal(meta: &std::fs::Metadata) -> Option<i128> {
-    use std::os::unix::fs::MetadataExt;
-    Some((meta.ctime() as i128) * 1_000_000_000 + meta.ctime_nsec() as i128)
-}
-
-#[cfg(windows)]
-fn metadata_change_signal(meta: &std::fs::Metadata) -> Option<i128> {
-    use std::os::windows::fs::MetadataExt;
-    // 100ns intervals since 1601-01-01; creation time is the best change
-    // signal stable std exposes on Windows (see FileFingerprint docs).
-    Some(meta.creation_time() as i128)
-}
-
-#[cfg(not(any(unix, windows)))]
-fn metadata_change_signal(_meta: &std::fs::Metadata) -> Option<i128> {
-    None
-}
-
-#[cfg(unix)]
-fn metadata_file_id(meta: &std::fs::Metadata) -> Option<(u64, u64)> {
-    use std::os::unix::fs::MetadataExt;
-    Some((meta.dev(), meta.ino()))
-}
-
-#[cfg(not(unix))]
-fn metadata_file_id(_meta: &std::fs::Metadata) -> Option<(u64, u64)> {
-    None
 }
 
 /// `(restorable, display_mirror)` maps from a snapshot object scan: relative
@@ -421,17 +433,25 @@ fn sha256_file(path: &Path) -> std::io::Result<[u8; 32]> {
     Ok(out)
 }
 
-fn metadata_fingerprint(meta: &std::fs::Metadata) -> FileFingerprint {
+/// Fingerprint the file at `path`. Unix derives everything from `meta`;
+/// Windows additionally opens a handle for the ChangeTime + identity query
+/// (a failed query yields `None` fields, which [`FileFingerprint::matches`]
+/// treats as never-matching). Call with a stat taken *before* any content
+/// read the fingerprint will describe.
+fn file_fingerprint(path: &Path, meta: &std::fs::Metadata) -> FileFingerprint {
     let mtime_nanos = meta
         .modified()
         .ok()
         .and_then(|mtime| mtime.duration_since(UNIX_EPOCH).ok())
         .map(|duration| duration.as_nanos());
+    let stamp = crate::platform::file_change_stamp(path, meta);
     FileFingerprint {
         size: meta.len(),
         mtime_nanos,
-        change_signal: metadata_change_signal(meta),
-        file_id: metadata_file_id(meta),
+        change_signal: stamp.as_ref().map(|s| s.change_signal),
+        file_id: stamp
+            .as_ref()
+            .map(|s| (s.identity.volume, s.identity.file_index)),
     }
 }
 
@@ -628,55 +648,125 @@ fn round_manifest_path(snapshot_dir: &Path, round_id: u64) -> PathBuf {
         .join("manifest.json")
 }
 
-/// Result of loading `history.json`: the (slim) history plus whether the
-/// index changed in ways that must be persisted immediately (minted epoch,
-/// migrated maps, format upgrade) — before any new manifest is stamped with
-/// state the on-disk index doesn't know yet.
+/// Result of loading `history.json`: the (slim) history, whether the index
+/// changed in ways that must be persisted immediately (adopted epoch,
+/// migrated maps) — before any new manifest is stamped with state the
+/// on-disk index doesn't know yet — and whether the store must be treated
+/// as read-only because an existing `history.json` was damaged and could
+/// not be set aside (it must never be overwritten).
 struct LoadedHistory {
     history: History,
     needs_persist: bool,
+    force_read_only: bool,
+}
+
+impl LoadedHistory {
+    fn read_only_with(history: History) -> Self {
+        Self {
+            history,
+            needs_persist: false,
+            force_read_only: true,
+        }
+    }
 }
 
 /// Load `history.json`, minting the store epoch when absent and migrating
 /// any round that still carries inline maps (legacy pre-format-2 files, or
 /// rounds retained after an earlier failed migration) into stamped
 /// per-round manifests. Rounds whose manifest write fails KEEP their inline
-/// maps — the index remains the authoritative carrier for them until a
-/// later load succeeds.
-fn load_history_from_disk(snapshot_dir: &Path) -> LoadedHistory {
+/// maps — marked via `maps_inline` so even empty trees survive — and the
+/// index remains the authoritative carrier for them until a later load
+/// succeeds.
+///
+/// A present-but-unparseable `history.json` is never overwritten: it is
+/// renamed aside (`history.json.damaged-<ts>`) and a fresh timeline starts;
+/// if even the rename fails, the watcher runs read-only.
+///
+/// With `read_only` (another process owns the store lock), the file is
+/// parsed as-is: no mint, no migration, no renames, no persist.
+fn load_history_from_disk(snapshot_dir: &Path, read_only: bool) -> LoadedHistory {
     let history_path = snapshot_dir.join("history.json");
-    let (mut history, format) = match std::fs::read(&history_path) {
+    // Ok(Some(..)) = parsed; Ok(None) = absent (fresh store); Err(()) =
+    // present but unreadable/unparseable — the damaged case.
+    let parsed: Result<Option<(History, u64)>, ()> = match std::fs::read(&history_path) {
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(_) => Err(()),
         Ok(bytes) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
+            Err(_) => Err(()),
             Ok(value) => {
                 let format = value.get("format").and_then(|v| v.as_u64()).unwrap_or(0);
                 match serde_json::from_value::<History>(value) {
-                    Ok(history) => (history, format),
-                    Err(_) => (History::default(), HISTORY_INDEX_FORMAT),
+                    Ok(history) => Ok(Some((history, format))),
+                    Err(_) => Err(()),
                 }
             }
-            Err(_) => (History::default(), HISTORY_INDEX_FORMAT),
         },
-        Err(_) => (History::default(), HISTORY_INDEX_FORMAT),
     };
 
-    let mut needs_persist = format < HISTORY_INDEX_FORMAT;
-    let minted_epoch = history.store_epoch.is_none();
-    if minted_epoch {
-        history.store_epoch = Some(mint_store_epoch(snapshot_dir));
-        needs_persist = true;
-        if format >= HISTORY_INDEX_FORMAT {
-            // An epoch-less format-2 index (written by the brief pre-epoch
-            // revision): its manifests are presumptively ours — re-stamp the
-            // parseable, id-matching ones with the new epoch so they stay
-            // resolvable.
-            restamp_manifests_for_new_epoch(&history, snapshot_dir);
+    let (mut history, format) = match parsed {
+        Ok(Some((history, format))) => (history, format),
+        Ok(None) => (History::default(), HISTORY_INDEX_FORMAT),
+        Err(()) => {
+            if read_only {
+                return LoadedHistory::read_only_with(History::default());
+            }
+            let damaged_path = snapshot_dir.join(format!("history.json.damaged-{}", now_unix()));
+            match std::fs::rename(&history_path, &damaged_path) {
+                Ok(()) => {
+                    eprintln!(
+                        "[file_watcher] history.json was unreadable; preserved it at {} and \
+                         starting a fresh timeline",
+                        damaged_path.display()
+                    );
+                    (History::default(), HISTORY_INDEX_FORMAT)
+                }
+                Err(err) => {
+                    eprintln!(
+                        "[file_watcher] history.json is unreadable and could not be set aside \
+                         ({}); rewind runs read-only so it is never overwritten",
+                        err
+                    );
+                    return LoadedHistory::read_only_with(History::default());
+                }
+            }
+        }
+    };
+
+    if read_only {
+        return LoadedHistory {
+            history,
+            needs_persist: false,
+            force_read_only: false,
+        };
+    }
+
+    let mut needs_persist = false;
+    if history.store_epoch.is_none() {
+        let epoch = mint_store_epoch(snapshot_dir);
+        let restamped_ok = format < HISTORY_INDEX_FORMAT
+            || restamp_manifests_for_new_epoch(&history, snapshot_dir, &epoch);
+        if restamped_ok {
+            history.store_epoch = Some(epoch);
+            needs_persist = true;
+        } else {
+            // A content-binding manifest could not be restamped (e.g. a
+            // transiently unwritable dir). Adopting the epoch now would make
+            // that correct manifest permanently unresolvable once the index
+            // persists — so stay epoch-less this load (the resolver falls
+            // back to content binding under a `None` epoch) and retry the
+            // mint on the next load.
+            eprintln!(
+                "[file_watcher] could not stamp every round manifest with the new store epoch; \
+                 deferring epoch adoption to the next load"
+            );
         }
     }
 
     // Legacy files carry every round's state inline — even an empty map is
     // an explicit "empty tree" record that must become a manifest (distinct
     // from a missing manifest, which rollback refuses). Format-2 rounds with
-    // empty maps are ordinary slim stubs.
+    // empty maps are ordinary slim stubs unless their `maps_inline` marker
+    // says otherwise.
     let treat_empty_as_inline = format < HISTORY_INDEX_FORMAT;
     migrate_inline_round_maps(
         &mut history,
@@ -688,6 +778,7 @@ fn load_history_from_disk(snapshot_dir: &Path) -> LoadedHistory {
     LoadedHistory {
         history,
         needs_persist,
+        force_read_only: false,
     }
 }
 
@@ -705,8 +796,10 @@ fn mint_store_epoch(snapshot_dir: &Path) -> String {
 
 /// Move every round's inline maps into a stamped per-round manifest. On a
 /// successful write the inline maps are dropped from the index; on failure
-/// (or a serialization error) they are KEPT so the data stays authoritative
-/// in the index and migration retries on the next load.
+/// (or a serialization error) they are KEPT and the row is marked
+/// `maps_inline`, so the data — including an empty tree, which serializes
+/// no maps of its own — stays authoritative in the index and migration
+/// retries on the next load.
 fn migrate_inline_round_maps(
     history: &mut History,
     snapshot_dir: &Path,
@@ -714,9 +807,8 @@ fn migrate_inline_round_maps(
     needs_persist: &mut bool,
 ) {
     let epoch = history.store_epoch.clone();
-    let mut migrate_round = |round: &mut HistoryRound| {
-        let has_inline = !round.files_at_end.is_empty() || !round.all_files_at_end.is_empty();
-        if !has_inline && !treat_empty_as_inline {
+    let migrate_round = |round: &mut HistoryRound, needs_persist: &mut bool| {
+        if !round_has_inline_maps(round) && !treat_empty_as_inline {
             return;
         }
         // Always rewrite from the inline maps — they are the authoritative
@@ -725,6 +817,7 @@ fn migrate_inline_round_maps(
         let manifest = HistoryRound {
             store_epoch: epoch.clone(),
             maps_from_round: None,
+            maps_inline: false,
             ..round.clone()
         };
         let manifest_path = round_manifest_path(snapshot_dir, round.id);
@@ -735,43 +828,100 @@ fn migrate_inline_round_maps(
             round.files_at_end = HashMap::new();
             round.all_files_at_end = HashMap::new();
             round.maps_from_round = None;
+            round.maps_inline = false;
+            *needs_persist = true;
+        } else if !round.maps_inline {
+            round.maps_inline = true;
             *needs_persist = true;
         }
     };
     for round in &mut history.rounds {
-        migrate_round(round);
+        migrate_round(round, needs_persist);
     }
     for branch in &mut history.abandoned_branches {
         for round in &mut branch.rounds {
-            migrate_round(round);
+            migrate_round(round, needs_persist);
         }
     }
 }
 
 /// Re-stamp existing manifests with a freshly minted epoch (epoch-less
-/// format-2 index only — see `load_history_from_disk`). Only parseable
-/// manifests whose recorded id matches their path are touched; anything
-/// else is left to fail closed at resolve time.
-fn restamp_manifests_for_new_epoch(history: &History, snapshot_dir: &Path) {
+/// format-2 index only — see `load_history_from_disk`). A manifest is only
+/// stamped when its content BINDS to its index row
+/// ([`manifest_binds_to_round`]) — identity alone never blesses a manifest,
+/// so one poisoned by a pre-format-2 binary (same id, different round)
+/// stays unstamped and fails closed at resolve time. Returns `false` when
+/// any binding manifest could not be written — the caller must then defer
+/// epoch adoption (see FIX in `load_history_from_disk`).
+fn restamp_manifests_for_new_epoch(history: &History, snapshot_dir: &Path, epoch: &str) -> bool {
+    let mut all_ok = true;
     let rounds = history
         .rounds
         .iter()
         .chain(history.abandoned_branches.iter().flat_map(|b| &b.rounds));
     for round in rounds {
+        if round_has_inline_maps(round) {
+            // Retained in the index; no manifest of ours to stamp.
+            continue;
+        }
         let manifest_path = round_manifest_path(snapshot_dir, round.id);
         let Ok(bytes) = std::fs::read(&manifest_path) else {
+            // Missing: unresolvable with or without an epoch — not a stamp
+            // failure.
             continue;
         };
         let Ok(mut manifest) = serde_json::from_slice::<HistoryRound>(&bytes) else {
             continue;
         };
-        if manifest.id != round.id {
+        if !manifest_binds_to_round(&manifest, round) {
+            eprintln!(
+                "[file_watcher] round {} manifest does not match the index (a foreign or \
+                 damaged write?) — leaving it unstamped; restores of that round will refuse",
+                round.id
+            );
             continue;
         }
-        manifest.store_epoch = history.store_epoch.clone();
-        if let Ok(stamped) = serde_json::to_vec_pretty(&manifest) {
-            let _ = atomic_write(&manifest_path, &stamped);
+        if manifest.store_epoch.as_deref() == Some(epoch) {
+            continue;
         }
+        manifest.store_epoch = Some(epoch.to_string());
+        let written = serde_json::to_vec_pretty(&manifest)
+            .ok()
+            .is_some_and(|stamped| atomic_write(&manifest_path, &stamped).is_ok());
+        if !written {
+            all_ok = false;
+        }
+    }
+    all_ok
+}
+
+/// Advisory exclusive lock on the snapshot store, held for the watcher's
+/// lifetime (released when the returned `File` drops). Locks a dedicated
+/// `store.lock` file — never `history.json` itself, whose reads Windows'
+/// LockFileEx would otherwise block. `(lock, read_only)`: any failure to
+/// acquire — held by another process, or a filesystem that cannot lock —
+/// yields read-only, the safe direction (no writes can interleave).
+fn acquire_store_lock(snapshot_dir: &Path) -> (Option<std::fs::File>, bool) {
+    let path = snapshot_dir.join("store.lock");
+    let file = match std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&path)
+    {
+        Ok(file) => file,
+        Err(err) => {
+            eprintln!(
+                "[file_watcher] could not open store lock {}: {} — rewind runs read-only",
+                path.display(),
+                err
+            );
+            return (None, true);
+        }
+    };
+    match file.try_lock() {
+        Ok(()) => (Some(file), false),
+        Err(_) => (None, true),
     }
 }
 
@@ -795,18 +945,29 @@ fn hex_decode_hash(hex: &str) -> Option<[u8; 32]> {
 /// files were deleted (or stopped being text) before this resume. Keeps the
 /// on-disk baseline key universe identical to the manifest's, so the
 /// full-scan and watcher-index changes paths agree.
-fn reconcile_baseline_dir(baseline_dir: &Path, manifest: &BaselineManifest) {
+///
+/// Returns `false` on any failure (unreadable subdir, undeletable stale
+/// file): the key universes may then diverge, and the caller must disable
+/// the watcher-index fast path rather than serve divergent views.
+fn reconcile_baseline_dir(baseline_dir: &Path, manifest: &BaselineManifest) -> bool {
+    let mut ok = true;
     let mut stack = vec![baseline_dir.to_path_buf()];
     while let Some(dir) = stack.pop() {
         let entries = match std::fs::read_dir(&dir) {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(_) => {
+                ok = false;
+                continue;
+            }
         };
         for entry in entries.flatten() {
             let path = entry.path();
             let ft = match entry.file_type() {
                 Ok(ft) => ft,
-                Err(_) => continue,
+                Err(_) => {
+                    ok = false;
+                    continue;
+                }
             };
             if ft.is_dir() {
                 stack.push(path);
@@ -822,11 +983,47 @@ fn reconcile_baseline_dir(baseline_dir: &Path, manifest: &BaselineManifest) {
             let keep = manifest
                 .get(&rel_path_key(rel))
                 .is_some_and(|meta| meta.supported_text);
-            if !keep {
-                let _ = std::fs::remove_file(&path);
+            if !keep && std::fs::remove_file(&path).is_err() {
+                ok = false;
             }
         }
     }
+    ok
+}
+
+/// Clear wrong-typed leftovers from a previous run before writing a
+/// baseline file at `baseline_path`: a stale FILE occupying a path that now
+/// needs to be a directory (project `foo` became `foo/bar`), or a stale
+/// DIRECTORY occupying a path that now needs to be a file (`foo/bar`
+/// became file `foo`). Best-effort — a leftover this cannot clear makes
+/// the subsequent baseline write fail loudly.
+fn clear_stale_baseline_slot(baseline_dir: &Path, baseline_path: &Path) {
+    let mut blocking_files: Vec<&Path> = Vec::new();
+    let mut cursor = baseline_path.parent();
+    while let Some(dir) = cursor {
+        if dir == baseline_dir {
+            break;
+        }
+        blocking_files.push(dir);
+        cursor = dir.parent();
+    }
+    for ancestor in blocking_files {
+        if ancestor.is_file() {
+            let _ = std::fs::remove_file(ancestor);
+        }
+    }
+    if baseline_path.is_dir() {
+        let _ = std::fs::remove_dir_all(baseline_path);
+    }
+}
+
+/// The on-disk baseline manifest, for read-only instances that must adopt
+/// the store owner's baseline state instead of writing their own.
+fn read_baseline_manifest_file(snapshot_dir: &Path) -> BaselineManifest {
+    std::fs::read(snapshot_dir.join(BASELINE_MANIFEST_FILE))
+        .ok()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+        .unwrap_or_default()
 }
 
 /// Recursively sum file bytes under `path`.
@@ -952,21 +1149,33 @@ struct ScanCacheEntry {
     /// and restorable); false for inspected-but-unsupported files that only
     /// feed the display mirror.
     restorable: bool,
-    /// When this entry was recorded (walk start for scan-recorded entries),
-    /// for the racy-distrust check.
+    /// Wall-clock time this entry was recorded (walk start for
+    /// scan-recorded entries), compared against the file's mtime — same
+    /// clock domain as filesystem timestamps.
     recorded_at_nanos: u128,
+    /// Monotonic recording instant: the primary racy-distrust gate, immune
+    /// to wall-clock steps (in-memory only, never serialized).
+    recorded_at_instant: std::time::Instant,
 }
 
 impl ScanCacheEntry {
     /// True when this entry can be trusted for a file currently stat'ing as
-    /// `current`: full fingerprint match plus the racy-distrust window (the
-    /// entry's mtime must be comfortably older than when the entry was
-    /// recorded, or a same-granule rewrite could hide behind it).
-    fn trustworthy_for(&self, current: &FileFingerprint) -> bool {
+    /// `current`: full fingerprint match plus the racy-distrust window,
+    /// gated both ways —
+    ///
+    /// 1. monotonically: at least `window` of real time must have passed
+    ///    since the entry was hashed (a backward wall-clock step cannot
+    ///    fake this), and
+    /// 2. on the wall clock: the entry's mtime must be comfortably older
+    ///    than its recording time (a same-granule rewrite lands near the
+    ///    recording moment and fails this).
+    fn trustworthy_for(&self, current: &FileFingerprint, window_nanos: u128) -> bool {
         self.fingerprint.matches(current)
-            && self.fingerprint.mtime_nanos.is_some_and(|mtime| {
-                mtime.saturating_add(FINGERPRINT_RACY_WINDOW_NANOS) < self.recorded_at_nanos
-            })
+            && self.recorded_at_instant.elapsed().as_nanos() >= window_nanos
+            && self
+                .fingerprint
+                .mtime_nanos
+                .is_some_and(|mtime| mtime.saturating_add(window_nanos) < self.recorded_at_nanos)
     }
 }
 
@@ -1016,6 +1225,23 @@ pub struct FileWatcher {
     /// full scan serves (correct, just slower). A rescan-flagged notify
     /// event triggers a full re-sync instead of degrading.
     live_index_degraded: bool,
+    /// Sticky sibling of `live_index_degraded`: set when this watcher can
+    /// never trust its live index for the rest of the process (read-only
+    /// mode, a failed baseline reconciliation). Never cleared.
+    live_index_disabled: bool,
+    /// True when another process holds this store's lock (or the store was
+    /// damaged in a way we could not set aside): this watcher serves reads
+    /// (/history, the legacy changes scan) but refuses every mutation —
+    /// round recording, rollback/redo/prune, index persists.
+    read_only: bool,
+    /// Advisory store lock (a dedicated `store.lock` file — never
+    /// `history.json` itself; Windows LockFileEx blocks reads of the locked
+    /// file). Held for the watcher's lifetime; released on drop.
+    _store_lock: Option<std::fs::File>,
+    /// Racy-distrust window (see [`ScanCacheEntry::trustworthy_for`]).
+    /// `FINGERPRINT_RACY_WINDOW_NANOS` in production; tests shrink it to
+    /// exercise fingerprint mechanics without multi-second sleeps.
+    racy_window_nanos: u128,
     /// Test-only observability: how many files the last
     /// `scan_and_store_objects` walk actually read (cache misses).
     #[cfg(test)]
@@ -1048,127 +1274,169 @@ impl FileWatcher {
         std::fs::create_dir_all(snapshot_dir.join("rounds"))
             .map_err(|e| CallerError::Config(format!("create rounds dir: {}", e)))?;
 
+        // Cross-process exclusion, acquired before any store write: a second
+        // watcher on the same store (another daemon resuming this session)
+        // must never interleave baseline/manifest/index writes with ours.
+        let (store_lock, lock_read_only) = acquire_store_lock(&snapshot_dir);
+        if lock_read_only {
+            eprintln!(
+                "[file_watcher] snapshot store {} is locked by another intendant process — \
+                 rewind runs read-only in this instance",
+                snapshot_dir.display()
+            );
+        }
+
         let mut baseline_manifest = BaselineManifest::new();
         let mut hashes = HashMap::new();
         let mut large_file_fingerprints = HashMap::new();
+        let mut reconcile_failed = false;
         let mut files_seen: usize = 0;
         let mut bytes_seen: u64 = 0;
 
-        let mut stack = vec![project_root.clone()];
-        while let Some(dir) = stack.pop() {
-            let entries = match std::fs::read_dir(&dir) {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
-            for entry in entries.flatten() {
-                let path = entry.path();
-                let ft = match entry.file_type() {
-                    Ok(ft) => ft,
+        if lock_read_only {
+            // Write nothing: adopt the owning process's on-disk baseline
+            // state so reads (the legacy changes scan, FileChanged line
+            // counts) stay consistent with the store we serve.
+            baseline_manifest = read_baseline_manifest_file(&snapshot_dir);
+            for (key, meta) in &baseline_manifest {
+                if let Some(hash) = hex_decode_hash(&meta.hash) {
+                    hashes.insert(PathBuf::from(key), hash);
+                }
+            }
+        } else {
+            let mut stack = vec![project_root.clone()];
+            while let Some(dir) = stack.pop() {
+                let entries = match std::fs::read_dir(&dir) {
+                    Ok(e) => e,
                     Err(_) => continue,
                 };
-                if ft.is_dir() {
-                    // Check if this directory should be ignored.
-                    if let Ok(rel) = path.strip_prefix(&project_root) {
-                        if !should_ignore(rel) {
-                            stack.push(path);
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    let ft = match entry.file_type() {
+                        Ok(ft) => ft,
+                        Err(_) => continue,
+                    };
+                    if ft.is_dir() {
+                        // Check if this directory should be ignored.
+                        if let Ok(rel) = path.strip_prefix(&project_root) {
+                            if !should_ignore(rel) {
+                                stack.push(path);
+                            }
                         }
+                        continue;
                     }
-                    continue;
-                }
-                if !ft.is_file() {
-                    continue;
-                }
-                let rel = match path.strip_prefix(&project_root) {
-                    Ok(r) => r.to_path_buf(),
-                    Err(_) => continue,
-                };
-                if should_ignore(&rel) {
-                    continue;
-                }
-                let rel_key = rel_path_key(&rel);
-                files_seen += 1;
-                if tree_budget_exceeded(files_seen, bytes_seen) {
-                    return Err(CallerError::Config(format!(
-                        "initial snapshot budget exceeded under {} ({files_seen} files / \
+                    if !ft.is_file() {
+                        continue;
+                    }
+                    let rel = match path.strip_prefix(&project_root) {
+                        Ok(r) => r.to_path_buf(),
+                        Err(_) => continue,
+                    };
+                    if should_ignore(&rel) {
+                        continue;
+                    }
+                    let rel_key = rel_path_key(&rel);
+                    files_seen += 1;
+                    if tree_budget_exceeded(files_seen, bytes_seen) {
+                        return Err(CallerError::Config(format!(
+                            "initial snapshot budget exceeded under {} ({files_seen} files / \
                          {bytes_seen} bytes so far; caps {SNAPSHOT_MAX_TREE_FILES} files / \
                          {SNAPSHOT_MAX_TREE_BYTES} bytes) — rewind snapshots stay off for \
                          this run rather than shadow-copying a tree that large",
-                        project_root.display()
-                    )));
-                }
-                match inspect_file(&path) {
-                    Ok(InspectedFile::Text(snapshot)) => {
-                        bytes_seen = bytes_seen.saturating_add(snapshot.size);
-                        let baseline_path = baseline_dir.join(&rel);
-                        if let Some(parent) = baseline_path.parent() {
-                            std::fs::create_dir_all(parent).map_err(|e| {
-                                CallerError::Config(format!(
-                                    "create baseline parent {}: {}",
-                                    parent.display(),
-                                    e
-                                ))
-                            })?;
-                        }
-                        std::fs::write(&baseline_path, snapshot.text.as_bytes()).map_err(|e| {
-                            CallerError::Config(format!(
-                                "write baseline {}: {}",
-                                baseline_path.display(),
-                                e
-                            ))
-                        })?;
-                        hashes.insert(rel, snapshot.hash);
-                        baseline_manifest.insert(
-                            rel_key,
-                            BaselineFileMeta {
-                                supported_text: true,
-                                hash: snapshot.hash_hex,
-                                size: snapshot.size,
-                                reason: None,
-                            },
-                        );
+                            project_root.display()
+                        )));
                     }
-                    Ok(InspectedFile::Unsupported(snapshot)) => {
-                        bytes_seen = bytes_seen.saturating_add(snapshot.size);
-                        if snapshot.size > SNAPSHOT_MAX_FILE_BYTES {
-                            if let Ok(meta) = std::fs::metadata(&path) {
-                                large_file_fingerprints
-                                    .insert(rel.clone(), metadata_fingerprint(&meta));
+                    match inspect_file(&path) {
+                        Ok(InspectedFile::Text(snapshot)) => {
+                            bytes_seen = bytes_seen.saturating_add(snapshot.size);
+                            let baseline_path = baseline_dir.join(&rel);
+                            // A previous run may have baselined a FILE where this
+                            // run needs a directory (or vice versa): clear the
+                            // wrong-typed leftover before writing.
+                            clear_stale_baseline_slot(&baseline_dir, &baseline_path);
+                            if let Some(parent) = baseline_path.parent() {
+                                std::fs::create_dir_all(parent).map_err(|e| {
+                                    CallerError::Config(format!(
+                                        "create baseline parent {}: {}",
+                                        parent.display(),
+                                        e
+                                    ))
+                                })?;
                             }
+                            std::fs::write(&baseline_path, snapshot.text.as_bytes()).map_err(
+                                |e| {
+                                    CallerError::Config(format!(
+                                        "write baseline {}: {}",
+                                        baseline_path.display(),
+                                        e
+                                    ))
+                                },
+                            )?;
+                            hashes.insert(rel, snapshot.hash);
+                            baseline_manifest.insert(
+                                rel_key,
+                                BaselineFileMeta {
+                                    supported_text: true,
+                                    hash: snapshot.hash_hex,
+                                    size: snapshot.size,
+                                    reason: None,
+                                },
+                            );
                         }
-                        hashes.insert(rel, snapshot.hash);
-                        baseline_manifest.insert(
-                            rel_key,
-                            BaselineFileMeta {
-                                supported_text: false,
-                                hash: snapshot.hash_hex,
-                                size: snapshot.size,
-                                reason: Some(snapshot.reason),
-                            },
-                        );
+                        Ok(InspectedFile::Unsupported(snapshot)) => {
+                            bytes_seen = bytes_seen.saturating_add(snapshot.size);
+                            if snapshot.size > SNAPSHOT_MAX_FILE_BYTES {
+                                if let Ok(meta) = std::fs::metadata(&path) {
+                                    large_file_fingerprints
+                                        .insert(rel.clone(), file_fingerprint(&path, &meta));
+                                }
+                            }
+                            hashes.insert(rel, snapshot.hash);
+                            baseline_manifest.insert(
+                                rel_key,
+                                BaselineFileMeta {
+                                    supported_text: false,
+                                    hash: snapshot.hash_hex,
+                                    size: snapshot.size,
+                                    reason: Some(snapshot.reason),
+                                },
+                            );
+                        }
+                        Err(_) => continue,
                     }
-                    Err(_) => continue,
                 }
             }
+
+            let manifest_path = snapshot_dir.join(BASELINE_MANIFEST_FILE);
+            let manifest_bytes = serde_json::to_vec_pretty(&baseline_manifest)
+                .map_err(|e| CallerError::Config(format!("baseline manifest serialize: {}", e)))?;
+            atomic_write(&manifest_path, &manifest_bytes).map_err(CallerError::Io)?;
+
+            // Drop baseline/ files left over from a previous run whose sources
+            // no longer exist: stale copies otherwise make the full-scan changes
+            // path report phantom "deleted" files this session never had. Any
+            // reconciliation failure permanently disables the changes fast path
+            // (the full scan would diverge from the watcher index otherwise).
+            reconcile_failed = !reconcile_baseline_dir(&baseline_dir, &baseline_manifest);
+            if reconcile_failed {
+                eprintln!(
+                    "[file_watcher] baseline reconciliation under {} failed — the changes fast \
+                 path is disabled for this run",
+                    baseline_dir.display()
+                );
+            }
         }
-
-        let manifest_path = snapshot_dir.join(BASELINE_MANIFEST_FILE);
-        let manifest_bytes = serde_json::to_vec_pretty(&baseline_manifest)
-            .map_err(|e| CallerError::Config(format!("baseline manifest serialize: {}", e)))?;
-        atomic_write(&manifest_path, &manifest_bytes).map_err(CallerError::Io)?;
-
-        // Drop baseline/ files left over from a previous run whose sources
-        // no longer exist: stale copies otherwise make the full-scan changes
-        // path report phantom "deleted" files this session never had.
-        reconcile_baseline_dir(&baseline_dir, &baseline_manifest);
 
         // Load history.json if it exists (session resume / restart). Legacy
         // full-fat files (per-round maps inline) are migrated to per-round
         // manifests + a slim index; the store epoch is minted on first
-        // format-2 load.
+        // format-2 load. Read-only instances parse without mutating.
         let LoadedHistory {
             history,
             needs_persist,
-        } = load_history_from_disk(&snapshot_dir);
+            force_read_only,
+        } = load_history_from_disk(&snapshot_dir, lock_read_only);
+        let read_only = lock_read_only || force_read_only;
 
         // One boot-time walk seeds the size estimate the soft-cap check
         // maintains incrementally afterwards (it used to re-walk per round).
@@ -1186,6 +1454,10 @@ impl FileWatcher {
             large_file_fingerprints,
             round_scan_cache: HashMap::new(),
             live_index_degraded: true,
+            live_index_disabled: read_only || reconcile_failed,
+            read_only,
+            _store_lock: store_lock,
+            racy_window_nanos: FINGERPRINT_RACY_WINDOW_NANOS,
             #[cfg(test)]
             files_read_in_last_scan: 0,
             head_maps: None,
@@ -1193,8 +1465,8 @@ impl FileWatcher {
             last_history_index_bytes,
             history,
         };
-        if needs_persist {
-            // Make the minted epoch / migrated maps durable before any new
+        if needs_persist && !watcher.read_only {
+            // Make the adopted epoch / migrated maps durable before any new
             // manifest is stamped against them.
             watcher.persist_history()?;
         }
@@ -1209,6 +1481,20 @@ impl FileWatcher {
         &self.history
     }
 
+    /// Refuse store mutations in read-only mode (another process owns the
+    /// store lock, or a damaged `history.json` could not be set aside).
+    fn ensure_writable(&self) -> Result<(), CallerError> {
+        if self.read_only {
+            return Err(CallerError::Config(
+                "snapshot store is read-only in this instance (held by another intendant \
+                 process, or a damaged history.json) — round recording and rollback are \
+                 disabled here"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     /// Snapshot the state the changes endpoint needs to compute the
     /// changed-key set without walking the project tree. Cheap relative to
     /// a tree read (two O(files) map clones), taken under the watcher lock.
@@ -1218,7 +1504,7 @@ impl FileWatcher {
     /// fall back to their full-scan path instead of serving from a hash
     /// mirror that may be missing events.
     pub(crate) fn changes_index_snapshot(&self) -> Option<ChangesIndexSnapshot> {
-        if self.live_index_degraded {
+        if self.live_index_degraded || self.live_index_disabled {
             return None;
         }
         Some(ChangesIndexSnapshot {
@@ -1233,10 +1519,18 @@ impl FileWatcher {
 
     /// Test hook: pretend the notify watcher is confirmed healthy, so unit
     /// tests can exercise the watcher-index fast path without spawning the
-    /// real filesystem-event loop.
+    /// real filesystem-event loop. Deliberately leaves the sticky
+    /// `live_index_disabled` flag alone — tests assert its precedence.
     #[cfg(test)]
     pub(crate) fn mark_live_index_healthy_for_tests(&mut self) {
         self.live_index_degraded = false;
+    }
+
+    /// Test hook: shrink the racy-distrust window so fingerprint mechanics
+    /// can be pinned without multi-second sleeps.
+    #[cfg(test)]
+    pub(crate) fn set_racy_window_for_tests(&mut self, nanos: u128) {
+        self.racy_window_nanos = nanos;
     }
 
     /// Wrap `self` in an async-mutex-backed shared handle and spawn the
@@ -1356,7 +1650,7 @@ impl FileWatcher {
                     Ok(meta) => meta,
                     Err(_) => return,
                 };
-                let fingerprint = metadata_fingerprint(&meta);
+                let fingerprint = file_fingerprint(abs_path, &meta);
                 if meta.len() > SNAPSHOT_MAX_FILE_BYTES
                     && self
                         .large_file_fingerprints
@@ -1380,6 +1674,7 @@ impl FileWatcher {
                                 hash_hex: snapshot.hash_hex.clone(),
                                 restorable: true,
                                 recorded_at_nanos: now_nanos(),
+                                recorded_at_instant: std::time::Instant::now(),
                             },
                         );
                         if self.hashes.get(&rel) == Some(&snapshot.hash) {
@@ -1418,6 +1713,7 @@ impl FileWatcher {
                                     hash_hex: snapshot.hash_hex.clone(),
                                     restorable: false,
                                     recorded_at_nanos: now_nanos(),
+                                    recorded_at_instant: std::time::Instant::now(),
                                 },
                             );
                         }
@@ -1474,6 +1770,7 @@ impl FileWatcher {
         turn_count: Option<u32>,
         native_message_count: Option<u32>,
     ) -> Result<(), CallerError> {
+        self.ensure_writable()?;
         // Walk the project and compute file hashes + write any new objects.
         // Fingerprint-cached: unchanged files are stat'd, not re-read.
         let (files_at_end, all_files_at_end) = self.scan_and_store_objects()?;
@@ -1530,6 +1827,7 @@ impl FileWatcher {
             native_message_count,
             maps_from_round: maps_source_id,
             store_epoch: None,
+            maps_inline: false,
         };
 
         // Write the per-round manifest — the durable home of the maps,
@@ -1585,6 +1883,7 @@ impl FileWatcher {
     /// happens if a NEW round is created after the rollback (see
     /// [`on_round_complete`]).
     pub fn rollback(&mut self, target_round_id: u64) -> Result<RollbackResult, CallerError> {
+        self.ensure_writable()?;
         let target_idx = self
             .history
             .rounds
@@ -1637,6 +1936,7 @@ impl FileWatcher {
     /// restoring file state accordingly. Errors if already at the latest
     /// round.
     pub fn redo(&mut self) -> Result<RedoResult, CallerError> {
+        self.ensure_writable()?;
         let head_id = self
             .history
             .current_head_id
@@ -1683,6 +1983,7 @@ impl FileWatcher {
     /// Delete all abandoned branches and garbage-collect any orphaned blobs
     /// under `objects/`.
     pub fn prune_abandoned(&mut self) -> Result<PruneResult, CallerError> {
+        self.ensure_writable()?;
         let branches_removed = self.history.abandoned_branches.len() as u32;
         self.history.abandoned_branches.clear();
 
@@ -1728,6 +2029,7 @@ impl FileWatcher {
         // racy-distrust check compares a file's mtime against it, and the
         // start is the most conservative bound (recording happens later).
         let walk_started_nanos = now_nanos();
+        let walk_started_instant = std::time::Instant::now();
         #[cfg(test)]
         {
             self.files_read_in_last_scan = 0;
@@ -1772,9 +2074,9 @@ impl FileWatcher {
                 }
                 // Stat-before-read: this fingerprint describes content no
                 // newer than what a subsequent read returns.
-                let fingerprint = metadata_fingerprint(&meta);
+                let fingerprint = file_fingerprint(&path, &meta);
                 if let Some(cached) = self.round_scan_cache.get(&rel) {
-                    if cached.trustworthy_for(&fingerprint) {
+                    if cached.trustworthy_for(&fingerprint, self.racy_window_nanos) {
                         let key = rel_path_key(&rel);
                         if cached.restorable {
                             if objects_dir.join(&cached.hash_hex).exists() {
@@ -1819,6 +2121,7 @@ impl FileWatcher {
                                 hash_hex: snapshot.hash_hex.clone(),
                                 restorable: true,
                                 recorded_at_nanos: walk_started_nanos,
+                                recorded_at_instant: walk_started_instant,
                             },
                         );
                         out.insert(rel_path_key(&rel), snapshot.hash_hex);
@@ -1833,6 +2136,7 @@ impl FileWatcher {
                                 hash_hex: snapshot.hash_hex,
                                 restorable: false,
                                 recorded_at_nanos: walk_started_nanos,
+                                recorded_at_instant: walk_started_instant,
                             },
                         );
                     }
@@ -1872,8 +2176,10 @@ impl FileWatcher {
             }
         }
         let stub = self.history.rounds.iter().find(|r| r.id == round_id)?;
-        // Inline maps retained after a failed migration are authoritative.
-        if !stub.files_at_end.is_empty() || !stub.all_files_at_end.is_empty() {
+        // Inline maps retained after a failed migration are authoritative —
+        // including the explicit `maps_inline` marker, which is how an
+        // empty-tree retention survives (empty maps serialize to nothing).
+        if round_has_inline_maps(stub) {
             return Some(ResolvedRoundMaps {
                 source_round_id: stub.id,
                 files_at_end: stub.files_at_end.clone(),
@@ -1881,8 +2187,8 @@ impl FileWatcher {
             });
         }
         // Prefer the in-memory stub's backreference (skips one manifest
-        // read); fall back to whatever the manifest chain says so maps stay
-        // resolvable even if the index was rebuilt from scratch.
+        // read); the chain below re-verifies every hop against its own
+        // index row anyway.
         let mut source_id = stub.maps_from_round.unwrap_or(round_id);
         // Backreferences are written depth-1; the visited set and bound are
         // defense against corrupt or foreign manifests.
@@ -1894,30 +2200,37 @@ impl FileWatcher {
                 // empty tree.
                 return None;
             }
+            // Every hop must have an index row of its own (backreference
+            // targets are always linear-path ancestors).
+            let hop_stub = self.history.rounds.iter().find(|r| r.id == source_id)?;
             // A referenced round whose own migration is still pending keeps
             // its maps inline in the index — serve those (its manifest does
             // not exist yet).
-            if let Some(inline) = self
-                .history
-                .rounds
-                .iter()
-                .find(|r| r.id == source_id)
-                .filter(|r| !r.files_at_end.is_empty() || !r.all_files_at_end.is_empty())
-            {
+            if round_has_inline_maps(hop_stub) {
                 return Some(ResolvedRoundMaps {
-                    source_round_id: inline.id,
-                    files_at_end: inline.files_at_end.clone(),
-                    all_files_at_end: inline.all_files_at_end.clone(),
+                    source_round_id: hop_stub.id,
+                    files_at_end: hop_stub.files_at_end.clone(),
+                    all_files_at_end: hop_stub.all_files_at_end.clone(),
                 });
             }
             let manifest_path = round_manifest_path(&self.snapshot_dir, source_id);
             let bytes = std::fs::read(&manifest_path).ok()?;
             let manifest = serde_json::from_slice::<HistoryRound>(&bytes).ok()?;
-            if manifest.id != source_id {
+            // Content binding: the manifest must be the round the index
+            // recorded, not merely a file at the right path (a pre-format-2
+            // binary restarts ids at 0 and can overwrite manifests with
+            // same-id rounds of a different timeline).
+            if !manifest_binds_to_round(&manifest, hop_stub) {
                 return None;
             }
-            if manifest.store_epoch.as_deref() != self.history.store_epoch.as_deref() {
-                return None;
+            // Epoch binding: with an adopted epoch, the stamp must match
+            // exactly. An epoch-less index (a pre-epoch store whose stamping
+            // hasn't completed yet) accepts any stamp — content binding
+            // above is the guard for that window.
+            if let Some(epoch) = self.history.store_epoch.as_deref() {
+                if manifest.store_epoch.as_deref() != Some(epoch) {
+                    return None;
+                }
             }
             match manifest.maps_from_round {
                 Some(next) => source_id = next,
@@ -1984,9 +2297,9 @@ impl FileWatcher {
                 if meta.len() > SNAPSHOT_MAX_FILE_BYTES {
                     continue;
                 }
-                let fingerprint = metadata_fingerprint(&meta);
+                let fingerprint = file_fingerprint(&path, &meta);
                 if let Some(cached) = self.round_scan_cache.get(&rel) {
-                    if cached.trustworthy_for(&fingerprint) {
+                    if cached.trustworthy_for(&fingerprint, self.racy_window_nanos) {
                         if cached.restorable {
                             current.insert(rel_path_key(&rel), cached.hash);
                         }
@@ -2004,6 +2317,7 @@ impl FileWatcher {
                                 hash_hex: snapshot.hash_hex,
                                 restorable: false,
                                 recorded_at_nanos: now_nanos(),
+                                recorded_at_instant: std::time::Instant::now(),
                             },
                         );
                         continue;
@@ -2018,6 +2332,7 @@ impl FileWatcher {
                         hash_hex: snapshot.hash_hex,
                         restorable: true,
                         recorded_at_nanos: now_nanos(),
+                        recorded_at_instant: std::time::Instant::now(),
                     },
                 );
                 current.insert(rel_path_key(&rel), snapshot.hash);
@@ -2045,11 +2360,12 @@ impl FileWatcher {
                 watcher.round_scan_cache.insert(
                     PathBuf::from(rel),
                     ScanCacheEntry {
-                        fingerprint: metadata_fingerprint(&meta),
+                        fingerprint: file_fingerprint(&abs, &meta),
                         hash,
                         hash_hex: target_hex.to_string(),
                         restorable: true,
                         recorded_at_nanos: now_nanos(),
+                        recorded_at_instant: std::time::Instant::now(),
                     },
                 );
             }
@@ -2130,7 +2446,7 @@ impl FileWatcher {
                     continue;
                 };
                 if meta.len() > SNAPSHOT_MAX_FILE_BYTES {
-                    let fingerprint = metadata_fingerprint(&meta);
+                    let fingerprint = file_fingerprint(&path, &meta);
                     // Keep the last-known hash when the file is untouched
                     // (its fingerprint matches) so the change index doesn't
                     // treat it as deleted after a restore; a genuinely
@@ -2152,9 +2468,9 @@ impl FileWatcher {
                     large_file_fingerprints.insert(rel, fingerprint);
                     continue;
                 }
-                let fingerprint = metadata_fingerprint(&meta);
+                let fingerprint = file_fingerprint(&path, &meta);
                 if let Some(cached) = self.round_scan_cache.get(&rel) {
-                    if cached.trustworthy_for(&fingerprint) {
+                    if cached.trustworthy_for(&fingerprint, self.racy_window_nanos) {
                         new_hashes.insert(rel.clone(), cached.hash);
                         next_cache.insert(rel, cached.clone());
                         continue;
@@ -2176,6 +2492,7 @@ impl FileWatcher {
                             hash_hex,
                             restorable,
                             recorded_at_nanos: now_nanos(),
+                            recorded_at_instant: std::time::Instant::now(),
                         },
                     );
                 }
@@ -2196,6 +2513,7 @@ impl FileWatcher {
     /// without `files_at_end` and fall back to an empty history — no
     /// rollback offered, never a restore from an empty map.
     fn persist_history(&mut self) -> Result<(), CallerError> {
+        self.ensure_writable()?;
         let path = self.snapshot_dir.join("history.json");
         let mut value = serde_json::to_value(&self.history)
             .map_err(|e| CallerError::Config(format!("history serialize: {}", e)))?;
@@ -2325,30 +2643,54 @@ async fn run_watcher_loop(
 
     let _watcher = watcher;
 
-    shared.lock().await.live_index_degraded = false;
+    // Close the scan-to-watch gap: the construction scan ran before the
+    // watch registration above, so a change landing between them has no
+    // event. Re-sync the hash mirrors from disk (a fingerprint walk), drain
+    // whatever raced in meanwhile, and only then mark the index healthy.
+    {
+        let mut w = shared.lock().await;
+        w.refresh_hashes_from_tree();
+    }
+    while let Ok(res) = rx.try_recv() {
+        apply_notify_result(&shared, res).await;
+    }
+    {
+        let mut w = shared.lock().await;
+        if !w.live_index_disabled {
+            w.live_index_degraded = false;
+        }
+    }
 
     while let Some(res) = rx.recv().await {
-        match res {
-            Ok(notify_event) => {
-                let mut w = shared.lock().await;
-                if notify_event.need_rescan() {
-                    // The backend dropped events; re-sync the hash mirrors
-                    // from disk before processing anything further.
-                    w.refresh_hashes_from_tree();
-                }
-                for path in &notify_event.paths {
-                    w.process_change(path, &notify_event.kind);
-                }
-            }
-            Err(err) => {
-                eprintln!("[file_watcher] notify error, live index degraded: {}", err);
-                shared.lock().await.live_index_degraded = true;
-            }
-        }
+        apply_notify_result(&shared, res).await;
     }
 
     shared.lock().await.live_index_degraded = true;
     Ok(())
+}
+
+/// Apply one notify callback result to the shared watcher: rescan-flagged
+/// events re-sync the hash mirrors first (the backend dropped events);
+/// errors degrade the live index for the rest of the process.
+async fn apply_notify_result(
+    shared: &SharedFileWatcher,
+    res: Result<notify::Event, notify::Error>,
+) {
+    match res {
+        Ok(notify_event) => {
+            let mut w = shared.lock().await;
+            if notify_event.need_rescan() {
+                w.refresh_hashes_from_tree();
+            }
+            for path in &notify_event.paths {
+                w.process_change(path, &notify_event.kind);
+            }
+        }
+        Err(err) => {
+            eprintln!("[file_watcher] notify error, live index degraded: {}", err);
+            shared.lock().await.live_index_degraded = true;
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2917,6 +3259,7 @@ mod tests {
                 native_message_count: None,
                 maps_from_round: None,
                 store_epoch: None,
+                maps_inline: false,
             };
             w.history.abandoned_branches.push(AbandonedBranch {
                 branched_from_id: r1,
@@ -3001,6 +3344,9 @@ mod tests {
         drop(handle);
 
         let mut w = make_watcher(root, tmp_snap.path());
+        // Disable the racy window: this test pins that the CHANGE SIGNAL
+        // alone catches the rewrite (the window is exercised separately).
+        w.set_racy_window_for_tests(0);
         w.on_round_complete("R1".into(), None, None).unwrap();
         let r1 = w.history.current_head_id.unwrap();
         assert_eq!(
@@ -3046,6 +3392,9 @@ mod tests {
         }
 
         let mut w = make_watcher(root, tmp_snap.path());
+        // Pin pure fingerprint mechanics: the racy-distrust window (tested
+        // separately) would force re-reads between back-to-back rounds.
+        w.set_racy_window_for_tests(0);
         w.on_round_complete("R1".into(), None, None).unwrap();
         assert_eq!(w.files_read_in_last_scan, 3, "first scan reads everything");
 
@@ -3308,6 +3657,7 @@ mod tests {
             b"v2",
             "a refused rollback must not touch the tree"
         );
+        drop(resumed);
 
         // An unstamped manifest (what an old binary writes) is refused too.
         manifest.store_epoch = None;
@@ -3452,5 +3802,443 @@ mod tests {
         let other = TempDir::new().unwrap();
         assert!(live_watcher_for(other.path(), tmp_snap.path()).is_none());
         assert!(live_watcher_for(tmp_proj.path(), other.path()).is_none());
+    }
+
+    /// Windows: a same-length rewrite whose mtime is backdated OUTSIDE the
+    /// racy window is still detected via the NTFS ChangeTime component of
+    /// the fingerprint (SetFileTime cannot set ChangeTime).
+    #[cfg(windows)]
+    #[test]
+    fn mtime_backdated_rewrite_is_detected_via_change_signal() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        let file = root.join("a.txt");
+        std::fs::write(&file, b"round-1!").unwrap();
+        let past = std::time::SystemTime::now() - std::time::Duration::from_secs(3600);
+        let handle = std::fs::File::options().write(true).open(&file).unwrap();
+        handle.set_modified(past).unwrap();
+        drop(handle);
+
+        let mut w = make_watcher(root, tmp_snap.path());
+        // Pin the change signal itself; the racy window is tested separately.
+        w.set_racy_window_for_tests(0);
+        w.on_round_complete("R1".into(), None, None).unwrap();
+        let r1 = w.history.current_head_id.unwrap();
+        assert_eq!(
+            w.resolved_round_maps(r1).unwrap().files_at_end["a.txt"],
+            hex_encode(&sha256_hash(b"round-1!"))
+        );
+
+        // Cross the NTFS timestamp tick (~15.6ms) so the rewrite cannot
+        // share the original write's ChangeTime.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        std::fs::write(&file, b"round-2!").unwrap();
+        let handle = std::fs::File::options().write(true).open(&file).unwrap();
+        handle.set_modified(past).unwrap();
+        drop(handle);
+
+        w.on_round_complete("R2".into(), None, None).unwrap();
+        let r2 = w.history.current_head_id.unwrap();
+        assert_eq!(
+            w.resolved_round_maps(r2).unwrap().files_at_end["a.txt"],
+            hex_encode(&sha256_hash(b"round-2!")),
+            "an mtime-backdated rewrite must be caught by the ChangeTime fingerprint"
+        );
+    }
+
+    /// FIX 1: an epoch-less (pre-epoch draft) format-2 store never blesses a
+    /// manifest on identity alone — a poisoned manifest (right id, wrong
+    /// content, e.g. written by a pre-format-2 binary) is left unstamped and
+    /// restore refuses, while a content-binding sibling is stamped and keeps
+    /// working.
+    #[test]
+    fn restamp_refuses_poisoned_manifest() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        std::fs::write(root.join("a.txt"), b"v1").unwrap();
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1".into(), None, None).unwrap();
+        let r1 = w.history.current_head_id.unwrap();
+        std::fs::write(root.join("a.txt"), b"v2").unwrap();
+        w.on_round_complete("R2".into(), None, None).unwrap();
+        let r2 = w.history.current_head_id.unwrap();
+        drop(w);
+
+        // Rebuild the epoch-less pre-fix layout: strip the epoch from the
+        // index and from both manifests.
+        let index_path = tmp_snap.path().join("history.json");
+        let mut index: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&index_path).unwrap()).unwrap();
+        index.as_object_mut().unwrap().remove("store_epoch");
+        atomic_write(&index_path, &serde_json::to_vec_pretty(&index).unwrap()).unwrap();
+        for id in [r1, r2] {
+            let path = round_manifest_path(tmp_snap.path(), id);
+            let mut manifest: HistoryRound =
+                serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+            manifest.store_epoch = None;
+            atomic_write(&path, &serde_json::to_vec_pretty(&manifest).unwrap()).unwrap();
+        }
+        // Poison r1's manifest the way an old binary would: same id,
+        // different round content entirely.
+        let poison_path = round_manifest_path(tmp_snap.path(), r1);
+        let mut poison: HistoryRound =
+            serde_json::from_slice(&std::fs::read(&poison_path).unwrap()).unwrap();
+        poison.summary = "Round 1".to_string();
+        poison.timestamp_unix = 12345;
+        poison.files_changed = vec!["other.txt".to_string()];
+        poison.files_at_end = HashMap::from([(
+            "other.txt".to_string(),
+            hex_encode(&sha256_hash(b"foreign content")),
+        )]);
+        atomic_write(&poison_path, &serde_json::to_vec_pretty(&poison).unwrap()).unwrap();
+
+        let mut resumed = make_watcher(root, tmp_snap.path());
+        assert!(
+            resumed.history.store_epoch.is_some(),
+            "the epoch mint must complete (poison refusal is not a write failure)"
+        );
+        let stamped: HistoryRound = serde_json::from_slice(
+            &std::fs::read(round_manifest_path(tmp_snap.path(), r2)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            stamped.store_epoch, resumed.history.store_epoch,
+            "the binding sibling manifest must be adopted"
+        );
+        let unstamped: HistoryRound =
+            serde_json::from_slice(&std::fs::read(&poison_path).unwrap()).unwrap();
+        assert_eq!(
+            unstamped.store_epoch, None,
+            "a poisoned manifest must never be blessed on identity alone"
+        );
+        assert!(resumed.resolved_round_maps(r1).is_none());
+        assert!(resumed.rollback(r1).is_err());
+        assert_eq!(
+            std::fs::read(root.join("a.txt")).unwrap(),
+            b"v2",
+            "a refused restore must not touch the tree"
+        );
+        assert!(
+            resumed.resolved_round_maps(r2).is_some(),
+            "the healthy round must keep resolving"
+        );
+    }
+
+    /// FIX 3: a second watcher on the same store cannot interleave writes —
+    /// it constructs read-only: reads serve, every mutation refuses, and the
+    /// lock releases with the owner.
+    #[test]
+    fn second_watcher_is_read_only_until_lock_released() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        std::fs::write(root.join("a.txt"), b"v1").unwrap();
+        let mut owner = make_watcher(root, tmp_snap.path());
+        owner.on_round_complete("R1".into(), None, None).unwrap();
+        let r1 = owner.history.current_head_id.unwrap();
+
+        let mut second = make_watcher(root, tmp_snap.path());
+        assert!(second.read_only, "a locked store must yield read-only");
+        assert_eq!(
+            second.history.rounds.len(),
+            1,
+            "read-only instances still serve the on-disk history"
+        );
+        let err = second
+            .on_round_complete("R2".into(), None, None)
+            .expect_err("round recording must refuse in read-only mode");
+        assert!(err.to_string().contains("read-only"), "clear error: {err}");
+        assert!(second.rollback(r1).is_err());
+        assert!(second.redo().is_err());
+        assert!(second.prune_abandoned().is_err());
+        second.mark_live_index_healthy_for_tests();
+        assert!(
+            second.changes_index_snapshot().is_none(),
+            "read-only instances must not serve the changes fast path"
+        );
+        drop(second);
+        drop(owner);
+
+        let mut reclaimed = make_watcher(root, tmp_snap.path());
+        assert!(!reclaimed.read_only);
+        reclaimed
+            .on_round_complete("R2".into(), None, None)
+            .unwrap();
+    }
+
+    /// FIX 4: a change landing between the construction scan and the notify
+    /// watch registration has no event — the pre-healthy re-sync must pick
+    /// it up before the fast path serves.
+    #[tokio::test]
+    async fn scan_to_watch_gap_is_resynced_before_healthy() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path().to_path_buf();
+        std::fs::write(root.join("a.txt"), b"scanned-1").unwrap();
+        let w = make_watcher(&root, tmp_snap.path());
+
+        // Mutate in the gap: the watcher scanned, notify is not running yet.
+        std::fs::write(root.join("a.txt"), b"gap-write").unwrap();
+
+        let (shared, _watcher_handle, _round_handle) = w.start_shared();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        let index = loop {
+            if let Some(index) = shared.lock().await.changes_index_snapshot() {
+                break index;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "watcher never became healthy"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        };
+        assert_eq!(
+            index.current_hashes.get("a.txt"),
+            Some(&hex_encode(&sha256_hash(b"gap-write"))),
+            "the gap write must be visible the moment the index is healthy"
+        );
+    }
+
+    /// FIX 5: a retained EMPTY-tree round (failed migration of a legacy
+    /// round with no files) keeps its authority across reloads via the
+    /// explicit `maps_inline` marker — restore-to-empty still works.
+    #[cfg(unix)]
+    #[test]
+    fn retained_empty_tree_round_survives_reload() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        // R1 records a genuinely empty tree.
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1 empty".into(), None, None).unwrap();
+        let r1 = w.history.current_head_id.unwrap();
+
+        let mut legacy = w.history.clone();
+        legacy.store_epoch = None;
+        for round in &mut legacy.rounds {
+            let maps = w.resolved_round_maps(round.id).unwrap();
+            round.files_at_end = maps.files_at_end;
+            round.all_files_at_end = maps.all_files_at_end;
+            round.maps_from_round = None;
+            round.maps_inline = false;
+        }
+        assert!(legacy.rounds[0].files_at_end.is_empty(), "empty-tree round");
+        drop(w);
+        let rounds_dir = tmp_snap.path().join("rounds");
+        std::fs::remove_dir_all(&rounds_dir).unwrap();
+        std::fs::create_dir_all(&rounds_dir).unwrap();
+        atomic_write(
+            &tmp_snap.path().join("history.json"),
+            &serde_json::to_vec_pretty(&legacy).unwrap(),
+        )
+        .unwrap();
+        std::fs::set_permissions(&rounds_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let blocked = make_watcher(root, tmp_snap.path());
+        assert!(
+            blocked.history.rounds[0].maps_inline,
+            "a retained empty-tree round must carry the explicit inline marker"
+        );
+        let persisted = std::fs::read_to_string(tmp_snap.path().join("history.json")).unwrap();
+        assert!(
+            persisted.contains("maps_inline"),
+            "the marker must be durable: {persisted}"
+        );
+        drop(blocked);
+
+        // Reload (manifest dir still unwritable): the marker alone must keep
+        // the round restorable — rolling back to the empty tree deletes the
+        // file created since.
+        let mut reloaded = make_watcher(root, tmp_snap.path());
+        std::fs::write(root.join("late.txt"), b"created later").unwrap();
+        reloaded.rollback(r1).unwrap();
+        assert!(
+            !root.join("late.txt").exists(),
+            "restore-to-empty must still be exact after reload"
+        );
+
+        std::fs::set_permissions(&rounds_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    /// FIX 6: when a binding manifest cannot be restamped (transiently
+    /// unwritable dir), the epoch mint is deferred — never persisted over a
+    /// store whose manifests it would orphan — and the store keeps working
+    /// epoch-less until a later load succeeds.
+    #[cfg(unix)]
+    #[test]
+    fn failed_restamp_defers_epoch_adoption() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        std::fs::write(root.join("a.txt"), b"v1").unwrap();
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1".into(), None, None).unwrap();
+        let r1 = w.history.current_head_id.unwrap();
+        std::fs::write(root.join("a.txt"), b"v2").unwrap();
+        w.on_round_complete("R2".into(), None, None).unwrap();
+        drop(w);
+
+        // Strip the epoch everywhere (pre-epoch store) and make the
+        // manifest home unwritable so the restamp cannot land.
+        let index_path = tmp_snap.path().join("history.json");
+        let mut index: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&index_path).unwrap()).unwrap();
+        index.as_object_mut().unwrap().remove("store_epoch");
+        atomic_write(&index_path, &serde_json::to_vec_pretty(&index).unwrap()).unwrap();
+        for id in [r1, r1 + 1] {
+            let path = round_manifest_path(tmp_snap.path(), id);
+            let mut manifest: HistoryRound =
+                serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+            manifest.store_epoch = None;
+            atomic_write(&path, &serde_json::to_vec_pretty(&manifest).unwrap()).unwrap();
+        }
+        let rounds_dir = tmp_snap.path().join("rounds");
+        std::fs::set_permissions(&rounds_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+        // Manifest subdirs must stay readable but unwritable too.
+        for id in [r1, r1 + 1] {
+            let dir = rounds_dir.join(format!("round_{id}"));
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+        }
+
+        let mut deferred = make_watcher(root, tmp_snap.path());
+        assert_eq!(
+            deferred.history.store_epoch, None,
+            "epoch adoption must be deferred when a binding manifest cannot be stamped"
+        );
+        let on_disk = std::fs::read_to_string(&index_path).unwrap();
+        assert!(
+            !on_disk.contains("store_epoch"),
+            "no epoch may persist over unstamped manifests: {on_disk}"
+        );
+        // The store still works epoch-less: content binding guards resolves.
+        assert!(deferred.resolved_round_maps(r1).is_some());
+        deferred.rollback(r1).unwrap();
+        assert_eq!(std::fs::read(root.join("a.txt")).unwrap(), b"v1");
+        drop(deferred);
+
+        // Writable again: the next load completes the mint.
+        for id in [r1, r1 + 1] {
+            let dir = rounds_dir.join(format!("round_{id}"));
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        std::fs::set_permissions(&rounds_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let adopted = make_watcher(root, tmp_snap.path());
+        assert!(adopted.history.store_epoch.is_some());
+        let stamped: HistoryRound = serde_json::from_slice(
+            &std::fs::read(round_manifest_path(tmp_snap.path(), r1)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(stamped.store_epoch, adopted.history.store_epoch);
+        assert!(adopted.resolved_round_maps(r1).is_some());
+    }
+
+    /// FIX 7: a present-but-unparseable history.json is never overwritten —
+    /// it is preserved aside and a fresh timeline starts.
+    #[test]
+    fn damaged_history_json_is_preserved_not_overwritten() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        std::fs::write(root.join("a.txt"), b"v1").unwrap();
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1".into(), None, None).unwrap();
+        drop(w);
+
+        let garbage = b"{not json at all";
+        atomic_write(&tmp_snap.path().join("history.json"), garbage).unwrap();
+
+        let resumed = make_watcher(root, tmp_snap.path());
+        assert!(resumed.history.rounds.is_empty(), "fresh timeline");
+        let damaged: Vec<_> = std::fs::read_dir(tmp_snap.path())
+            .unwrap()
+            .flatten()
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("history.json.damaged-")
+            })
+            .collect();
+        assert_eq!(damaged.len(), 1, "damaged index preserved aside");
+        assert_eq!(
+            std::fs::read(damaged[0].path()).unwrap(),
+            garbage,
+            "the damaged bytes must survive untouched"
+        );
+    }
+
+    /// FIX 9a: any baseline-reconciliation failure permanently disables the
+    /// changes fast path (the full scan would diverge from the index
+    /// otherwise) — even after the notify loop reports healthy.
+    #[cfg(unix)]
+    #[test]
+    fn reconcile_failure_disables_fast_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+        std::fs::write(root.join("sub/stale.rs"), b"leftover").unwrap();
+        let first = make_watcher(root, tmp_snap.path());
+        drop(first);
+
+        // The source disappears between runs; the stale baseline copy is
+        // made undeletable.
+        std::fs::remove_file(root.join("sub/stale.rs")).unwrap();
+        let locked_dir = tmp_snap.path().join("baseline").join("sub");
+        std::fs::set_permissions(&locked_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let mut second = make_watcher(root, tmp_snap.path());
+        second.mark_live_index_healthy_for_tests();
+        assert!(
+            second.changes_index_snapshot().is_none(),
+            "a failed reconciliation must disable the fast path for good"
+        );
+
+        std::fs::set_permissions(&locked_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    /// FIX 9b: path-type changes between runs are reconciled — a stale
+    /// baseline FILE where this run needs a directory, and a stale baseline
+    /// DIRECTORY where this run needs a file.
+    #[test]
+    fn baseline_path_type_changes_are_reconciled() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+
+        // Run 1: `thing` is a file.
+        std::fs::write(root.join("thing"), b"i am a file").unwrap();
+        let first = make_watcher(root, tmp_snap.path());
+        drop(first);
+
+        // Run 2: `thing` became a directory.
+        std::fs::remove_file(root.join("thing")).unwrap();
+        std::fs::create_dir_all(root.join("thing")).unwrap();
+        std::fs::write(root.join("thing/inner.rs"), b"nested now").unwrap();
+        let second = make_watcher(root, tmp_snap.path());
+        assert!(second.baseline_manifest.contains_key("thing/inner.rs"));
+        assert_eq!(
+            std::fs::read(tmp_snap.path().join("baseline/thing/inner.rs")).unwrap(),
+            b"nested now"
+        );
+        drop(second);
+
+        // Run 3: `thing` is a file again.
+        std::fs::remove_dir_all(root.join("thing")).unwrap();
+        std::fs::write(root.join("thing"), b"file again").unwrap();
+        let third = make_watcher(root, tmp_snap.path());
+        assert!(third.baseline_manifest.contains_key("thing"));
+        assert_eq!(
+            std::fs::read(tmp_snap.path().join("baseline/thing")).unwrap(),
+            b"file again"
+        );
     }
 }

--- a/src/bin/caller/file_watcher.rs
+++ b/src/bin/caller/file_watcher.rs
@@ -12,6 +12,15 @@
 //! available). A new action after rollback branches off the abandoned path and
 //! stores it in
 //! `abandoned_branches` for later pruning.
+//!
+//! Cost model: round scans are fingerprint-cached — every file is stat'd,
+//! only files whose (size, mtime) moved are re-read and re-hashed — so
+//! per-round work is proportional to actual changes. Durable state is split
+//! between a slim `history.json` index (round scalars + changed paths,
+//! format 2) and one `rounds/round_{id}/manifest.json` per round holding
+//! that round's full path→hash maps; a no-op round writes a tiny
+//! `maps_from_round` backreference instead of duplicating maps. Only the
+//! head round's maps stay in memory.
 
 use crate::error::CallerError;
 use crate::event::{AppEvent, EventBus};
@@ -57,11 +66,18 @@ pub struct HistoryRound {
     /// Full restorable state at the end of this round: supported,
     /// non-ignored text files under `SNAPSHOT_MAX_FILE_BYTES`, path → sha256
     /// hex. Rollback restores exactly this map.
+    ///
+    /// Populated when this struct is a per-round manifest
+    /// (`rounds/round_{id}/manifest.json`) with inline maps. The in-memory
+    /// `History` and the persisted `history.json` index keep it empty — the
+    /// manifests are the durable source; see [`FileWatcher`]'s head-maps
+    /// cache and `resolved_round_maps`.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub files_at_end: HashMap<String, String>,
     /// Display-state mirror that also includes non-restorable tracked files
     /// that were inspected but not stored as text blobs. Rollback still uses
     /// `files_at_end`; this lets timeline counts match what the Changes tab
-    /// reports.
+    /// reports. Same manifest-only population as `files_at_end`.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub all_files_at_end: HashMap<String, String>,
     /// Number of agent turns executed in this round (from `RoundComplete.turns_in_round`).
@@ -77,6 +93,14 @@ pub struct HistoryRound {
     /// rollback instead.
     #[serde(default)]
     pub native_message_count: Option<u32>,
+    /// When this round's tree state is identical to an earlier round's
+    /// (a no-op round — e.g. a `RoundComplete` that changed no files), the
+    /// maps are not duplicated: this names the round whose manifest holds
+    /// them inline. Backreferences are written depth-1 (they point at the
+    /// nearest round with inline maps, never at another backreference).
+    /// `None` for rounds with inline maps and for legacy manifests.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maps_from_round: Option<u64>,
 }
 
 /// A branch of rounds that was replaced by a rollback-then-new-action. Kept
@@ -150,7 +174,8 @@ type SnapshotObjectMaps = (HashMap<String, String>, HashMap<String, String>);
 
 #[derive(Debug, Clone)]
 pub(crate) struct TextFileSnapshot {
-    pub bytes: Vec<u8>,
+    /// UTF-8 content. The raw bytes are exactly `text.as_bytes()` — the
+    /// snapshot deliberately holds one copy, not a bytes+text pair.
     pub text: String,
     pub hash: [u8; 32],
     pub hash_hex: String,
@@ -336,7 +361,7 @@ pub(crate) fn inspect_file(path: &Path) -> std::io::Result<InspectedFile> {
         }));
     }
 
-    let text = match String::from_utf8(bytes.clone()) {
+    let text = match String::from_utf8(bytes) {
         Ok(text) => text,
         Err(_) => {
             return Ok(InspectedFile::Unsupported(UnsupportedFileSnapshot {
@@ -349,7 +374,6 @@ pub(crate) fn inspect_file(path: &Path) -> std::io::Result<InspectedFile> {
     };
 
     Ok(InspectedFile::Text(TextFileSnapshot {
-        bytes,
         text,
         hash,
         hash_hex,
@@ -390,6 +414,48 @@ fn now_unix() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0)
+}
+
+/// Compute the list of paths whose content in `current` differs from the
+/// parent round's display mirror (or restorable map for legacy rounds
+/// recorded before the mirror existed), or from the baseline when there is
+/// no resolvable parent round.
+fn compute_files_changed(
+    parent: Option<&ResolvedRoundMaps>,
+    current: &HashMap<String, String>,
+    baseline_manifest: &BaselineManifest,
+) -> Vec<String> {
+    let mut changed = Vec::new();
+    let baseline_hex: HashMap<String, String>;
+    let prev: &HashMap<String, String> = match parent {
+        Some(parent) => {
+            if parent.all_files_at_end.is_empty() {
+                &parent.files_at_end
+            } else {
+                &parent.all_files_at_end
+            }
+        }
+        None => {
+            // First round (or unresolvable parent): compare against the
+            // baseline manifest, which records a hash for every inspected
+            // file at session start.
+            baseline_hex = baseline_manifest
+                .iter()
+                .map(|(path, meta)| (path.clone(), meta.hash.clone()))
+                .collect();
+            &baseline_hex
+        }
+    };
+    let mut keys: HashSet<&String> = prev.keys().collect();
+    keys.extend(current.keys());
+    for k in keys {
+        match (prev.get(k), current.get(k)) {
+            (Some(a), Some(b)) if a == b => continue,
+            _ => changed.push(k.clone()),
+        }
+    }
+    changed.sort();
+    changed
 }
 
 /// Persist a named tempfile at `dest_path`, using an atomic rename when the
@@ -446,6 +512,103 @@ pub(crate) fn atomic_write(path: &Path, content: &[u8]) -> io::Result<()> {
     Ok(())
 }
 
+/// Format tag stamped into `history.json` since it became a slim index
+/// (round scalars + `files_changed` only; the per-round path→hash maps live
+/// in `rounds/round_{id}/manifest.json`). Older binaries fail to parse a
+/// round without `files_at_end` and fall back to an empty history — a safe
+/// "no rollback offered" downgrade instead of restoring from empty maps.
+const HISTORY_INDEX_FORMAT: u64 = 2;
+
+/// Path of the on-disk manifest carrying one round's full snapshot record.
+fn round_manifest_path(snapshot_dir: &Path, round_id: u64) -> PathBuf {
+    snapshot_dir
+        .join("rounds")
+        .join(format!("round_{}", round_id))
+        .join("manifest.json")
+}
+
+/// Load `history.json`, migrating legacy full-fat files (per-round maps
+/// inline) to per-round manifests so the maps stay restorable after the
+/// in-memory copy goes slim. Returns a `History` whose rounds carry scalars
+/// and `files_changed` only.
+fn load_history_from_disk(snapshot_dir: &Path) -> History {
+    let history_path = snapshot_dir.join("history.json");
+    let Ok(bytes) = std::fs::read(&history_path) else {
+        return History::default();
+    };
+    let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return History::default();
+    };
+    let format = value.get("format").and_then(|v| v.as_u64()).unwrap_or(0);
+    let Ok(mut history) = serde_json::from_value::<History>(value) else {
+        return History::default();
+    };
+    if format < HISTORY_INDEX_FORMAT {
+        migrate_legacy_history_maps(&mut history, snapshot_dir);
+    } else {
+        // Defensive: a format-2 index never carries maps, but strip any that
+        // slipped in so the in-memory invariant (slim rounds) always holds.
+        strip_round_maps(&mut history);
+    }
+    history
+}
+
+/// Write a per-round manifest for every legacy round that has inline maps
+/// but no manifest on disk (manifests have been written since the feature
+/// shipped, so this normally touches nothing), then drop the inline maps
+/// from memory. Rounds inside abandoned branches migrate too.
+fn migrate_legacy_history_maps(history: &mut History, snapshot_dir: &Path) {
+    let migrate_round = |round: &mut HistoryRound| {
+        let manifest_path = round_manifest_path(snapshot_dir, round.id);
+        if !manifest_path.exists() {
+            // Write even when the maps are empty: an explicit "empty tree"
+            // record keeps restore-to-empty semantics distinct from a
+            // missing manifest (which rollback refuses).
+            if let Ok(bytes) = serde_json::to_vec_pretty(&round) {
+                let _ = atomic_write(&manifest_path, &bytes);
+            }
+        }
+        round.files_at_end = HashMap::new();
+        round.all_files_at_end = HashMap::new();
+    };
+    for round in &mut history.rounds {
+        migrate_round(round);
+    }
+    for branch in &mut history.abandoned_branches {
+        for round in &mut branch.rounds {
+            migrate_round(round);
+        }
+    }
+}
+
+fn strip_round_maps(history: &mut History) {
+    for round in &mut history.rounds {
+        round.files_at_end = HashMap::new();
+        round.all_files_at_end = HashMap::new();
+    }
+    for branch in &mut history.abandoned_branches {
+        for round in &mut branch.rounds {
+            round.files_at_end = HashMap::new();
+            round.all_files_at_end = HashMap::new();
+        }
+    }
+}
+
+/// Decode a 64-char lowercase/uppercase hex sha256 into raw bytes.
+fn hex_decode_hash(hex: &str) -> Option<[u8; 32]> {
+    let bytes = hex.as_bytes();
+    if bytes.len() != 64 {
+        return None;
+    }
+    let mut out = [0u8; 32];
+    for (i, chunk) in bytes.chunks_exact(2).enumerate() {
+        let hi = (chunk[0] as char).to_digit(16)?;
+        let lo = (chunk[1] as char).to_digit(16)?;
+        out[i] = ((hi << 4) | lo) as u8;
+    }
+    Some(out)
+}
+
 /// Recursively sum file bytes under `path`.
 fn dir_byte_size(path: &Path) -> u64 {
     let mut total = 0u64;
@@ -482,13 +645,117 @@ fn dir_byte_size(path: &Path) -> u64 {
 /// coordinate without racing.
 pub type SharedFileWatcher = Arc<AsyncMutex<FileWatcher>>;
 
+/// One registry row: (project_root, snapshot_dir, watcher).
+type LiveWatcherEntry = (PathBuf, PathBuf, std::sync::Weak<AsyncMutex<FileWatcher>>);
+
+/// Registry of live watchers, keyed by (project_root, snapshot_dir). A
+/// daemon runs at most one, but the key keeps concurrent in-process tests
+/// isolated. The gateway's changes endpoint uses it to serve change lists
+/// from watcher state instead of re-reading the whole project per request;
+/// entries are `Weak`, so a dropped watcher unregisters itself.
+static LIVE_WATCHERS: std::sync::OnceLock<std::sync::Mutex<Vec<LiveWatcherEntry>>> =
+    std::sync::OnceLock::new();
+
+fn live_watchers() -> &'static std::sync::Mutex<Vec<LiveWatcherEntry>> {
+    LIVE_WATCHERS.get_or_init(|| std::sync::Mutex::new(Vec::new()))
+}
+
+fn register_live_watcher(project_root: PathBuf, snapshot_dir: PathBuf, shared: &SharedFileWatcher) {
+    let Ok(mut registry) = live_watchers().lock() else {
+        return;
+    };
+    registry.retain(|(_, _, weak)| weak.strong_count() > 0);
+    registry.push((project_root, snapshot_dir, Arc::downgrade(shared)));
+}
+
+/// Compare paths tolerating symlinked spellings (`/tmp` vs `/private/tmp`
+/// on macOS) by canonicalizing when possible.
+fn watcher_paths_match(a: &Path, b: &Path) -> bool {
+    if a == b {
+        return true;
+    }
+    let canon = |p: &Path| p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
+    canon(a) == canon(b)
+}
+
+/// Look up the live watcher covering exactly this (project_root,
+/// snapshot_dir) pair. `None` when no watcher matches — callers fall back
+/// to their disk-scan path (external session targets, watcher-less
+/// daemons).
+pub(crate) fn live_watcher_for(
+    project_root: &Path,
+    snapshot_dir: &Path,
+) -> Option<SharedFileWatcher> {
+    let registry = live_watchers().lock().ok()?;
+    for (root, snap, weak) in registry.iter() {
+        if watcher_paths_match(root, project_root) && watcher_paths_match(snap, snapshot_dir) {
+            if let Some(shared) = weak.upgrade() {
+                return Some(shared);
+            }
+        }
+    }
+    None
+}
+
+/// Point-in-time view of the watcher state the changes endpoint needs to
+/// compute the changed-key set without touching the project tree: the
+/// session-start baseline metadata and the last-known content hash per
+/// tracked path.
+pub(crate) struct ChangesIndexSnapshot {
+    pub(crate) baseline_manifest: BaselineManifest,
+    /// Relative path key → lowercase sha256 hex of last-known content.
+    pub(crate) current_hashes: HashMap<String, String>,
+}
+
+/// Cached result of hashing one tracked file, keyed by its metadata
+/// fingerprint. Round scans stat every file (cheap) and only re-read and
+/// re-hash the ones whose fingerprint moved, so per-round work is
+/// proportional to actual changes instead of the whole tree.
+///
+/// The fingerprint is always taken from a stat performed *before* the
+/// content read it describes, so a write racing the read can only cause a
+/// spurious cache miss (extra work), never a stale hit.
+#[derive(Debug, Clone)]
+struct ScanCacheEntry {
+    fingerprint: FileFingerprint,
+    hash: [u8; 32],
+    hash_hex: String,
+    /// True when the file was a supported text file (stored in `objects/`
+    /// and restorable); false for inspected-but-unsupported files that only
+    /// feed the display mirror.
+    restorable: bool,
+}
+
+/// The maps of the round `current_head_id` points at, kept in memory so the
+/// next round's diff does not have to re-read a manifest. All other rounds'
+/// maps live only on disk in `rounds/round_{id}/manifest.json`.
+#[derive(Debug, Clone)]
+struct HeadMapsCache {
+    round_id: u64,
+    /// The round whose manifest holds these maps inline (`round_id` itself
+    /// for changed rounds; an earlier round for no-op rounds recorded via
+    /// `maps_from_round` backreferences).
+    source_round_id: u64,
+    files_at_end: HashMap<String, String>,
+    all_files_at_end: HashMap<String, String>,
+}
+
+/// Maps of one round resolved from the head cache or its on-disk manifest.
+struct ResolvedRoundMaps {
+    /// Round whose manifest carries the maps inline.
+    source_round_id: u64,
+    files_at_end: HashMap<String, String>,
+    all_files_at_end: HashMap<String, String>,
+}
+
 pub struct FileWatcher {
     project_root: PathBuf,
     snapshot_dir: PathBuf,
     bus: EventBus,
-    /// Baseline file content (original at session start), keyed by relative path.
-    baselines: HashMap<PathBuf, Vec<u8>>,
     /// Metadata for every non-ignored file that existed at session start.
+    /// Baseline *content* is not held in memory: the `baseline/` shadow copy
+    /// written at startup is read on demand (per changed file), so RSS no
+    /// longer scales with project size for the daemon's lifetime.
     baseline_manifest: BaselineManifest,
     /// SHA-256 hashes of last-known content, for change deduplication.
     hashes: HashMap<PathBuf, [u8; 32]>,
@@ -496,6 +763,18 @@ pub struct FileWatcher {
     /// not snapshotted, and duplicate notify events can otherwise re-hash tens
     /// of megabytes repeatedly while an editor writes temp files.
     large_file_fingerprints: HashMap<PathBuf, FileFingerprint>,
+    /// Per-file fingerprint → hash cache for round scans and post-restore
+    /// re-syncs. Rebuilt on every walk so deleted paths fall out.
+    round_scan_cache: HashMap<PathBuf, ScanCacheEntry>,
+    /// Maps of the current head round (see [`HeadMapsCache`]).
+    head_maps: Option<HeadMapsCache>,
+    /// Running estimate of bytes under `snapshot_dir`, maintained from the
+    /// writes/GCs this watcher performs. The soft-cap check walks the real
+    /// tree only when the estimate crosses the cap.
+    snapshot_dir_size_estimate: u64,
+    /// Size of the last persisted `history.json`, so rewrites adjust the
+    /// estimate by the delta instead of double-counting.
+    last_history_index_bytes: u64,
     /// Persistent session history of per-round snapshots.
     history: History,
 }
@@ -515,7 +794,6 @@ impl FileWatcher {
         std::fs::create_dir_all(snapshot_dir.join("rounds"))
             .map_err(|e| CallerError::Config(format!("create rounds dir: {}", e)))?;
 
-        let mut baselines = HashMap::new();
         let mut baseline_manifest = BaselineManifest::new();
         let mut hashes = HashMap::new();
         let mut large_file_fingerprints = HashMap::new();
@@ -577,14 +855,13 @@ impl FileWatcher {
                                 ))
                             })?;
                         }
-                        std::fs::write(&baseline_path, &snapshot.bytes).map_err(|e| {
+                        std::fs::write(&baseline_path, snapshot.text.as_bytes()).map_err(|e| {
                             CallerError::Config(format!(
                                 "write baseline {}: {}",
                                 baseline_path.display(),
                                 e
                             ))
                         })?;
-                        baselines.insert(rel.clone(), snapshot.bytes);
                         hashes.insert(rel, snapshot.hash);
                         baseline_manifest.insert(
                             rel_key,
@@ -625,30 +902,53 @@ impl FileWatcher {
             .map_err(|e| CallerError::Config(format!("baseline manifest serialize: {}", e)))?;
         atomic_write(&manifest_path, &manifest_bytes).map_err(CallerError::Io)?;
 
-        // Load history.json if it exists (session resume / restart).
-        let history_path = snapshot_dir.join("history.json");
-        let history = match std::fs::read(&history_path) {
-            Ok(bytes) => serde_json::from_slice::<History>(&bytes).unwrap_or_default(),
-            Err(_) => History::default(),
-        };
+        // Load history.json if it exists (session resume / restart). Legacy
+        // full-fat files (per-round maps inline) are migrated to per-round
+        // manifests + a slim index on the next persist.
+        let history = load_history_from_disk(&snapshot_dir);
+
+        // One boot-time walk seeds the size estimate the soft-cap check
+        // maintains incrementally afterwards (it used to re-walk per round).
+        let snapshot_dir_size_estimate = dir_byte_size(&snapshot_dir);
+        let last_history_index_bytes = std::fs::metadata(snapshot_dir.join("history.json"))
+            .map(|meta| meta.len())
+            .unwrap_or(0);
 
         Ok(Self {
             project_root,
             snapshot_dir,
             bus,
-            baselines,
             baseline_manifest,
             hashes,
             large_file_fingerprints,
+            round_scan_cache: HashMap::new(),
+            head_maps: None,
+            snapshot_dir_size_estimate,
+            last_history_index_bytes,
             history,
         })
     }
 
     /// Read-only accessor for the history state. Callers hold the mutex for
     /// the duration, so callers should clone the result if they need to use
-    /// it after releasing the lock.
+    /// it after releasing the lock. Rounds are slim (scalars +
+    /// `files_changed`); the per-round maps live in the round manifests.
     pub fn history(&self) -> &History {
         &self.history
+    }
+
+    /// Snapshot the state the changes endpoint needs to compute the
+    /// changed-key set without walking the project tree. Cheap relative to
+    /// a tree read (two O(files) map clones), taken under the watcher lock.
+    pub(crate) fn changes_index_snapshot(&self) -> ChangesIndexSnapshot {
+        ChangesIndexSnapshot {
+            baseline_manifest: self.baseline_manifest.clone(),
+            current_hashes: self
+                .hashes
+                .iter()
+                .map(|(rel, hash)| (rel_path_key(rel), hex_encode(hash)))
+                .collect(),
+        }
     }
 
     /// Wrap `self` in an async-mutex-backed shared handle and spawn the
@@ -657,7 +957,9 @@ impl FileWatcher {
     pub fn start_shared(self) -> (SharedFileWatcher, JoinHandle<()>, JoinHandle<()>) {
         let bus = self.bus.clone();
         let project_root = self.project_root.clone();
+        let snapshot_dir = self.snapshot_dir.clone();
         let shared = Arc::new(AsyncMutex::new(self));
+        register_live_watcher(project_root.clone(), snapshot_dir, &shared);
 
         let watcher_handle = {
             let shared = shared.clone();
@@ -675,6 +977,14 @@ impl FileWatcher {
             tokio::task::spawn(async move {
                 loop {
                     match rx.recv().await {
+                        // Deliberately unfiltered by `session_id`: the event
+                        // carries one, but nothing on the bus maps a session
+                        // to its working root, so rounds from sessions in
+                        // other roots (worktrees, external backends) also
+                        // land here — a known attribution wart. Since the
+                        // fingerprint cache + backreference manifests, such
+                        // foreign rounds cost a stat-walk and an O(1)
+                        // persist, not a tree re-read.
                         Ok(AppEvent::RoundComplete {
                             round,
                             turns_in_round,
@@ -711,7 +1021,7 @@ impl FileWatcher {
         watcher_handle
     }
 
-    fn process_change(&mut self, abs_path: &Path, kind: &notify::EventKind) {
+    pub(crate) fn process_change(&mut self, abs_path: &Path, kind: &notify::EventKind) {
         // Compute relative path.
         let rel = match abs_path.strip_prefix(&self.project_root) {
             Ok(r) => r.to_path_buf(),
@@ -723,8 +1033,7 @@ impl FileWatcher {
         }
 
         let rel_key = rel_path_key(&rel);
-        let existed_at_baseline =
-            self.baselines.contains_key(&rel) || self.baseline_manifest.contains_key(&rel_key);
+        let existed_at_baseline = self.baseline_manifest.contains_key(&rel_key);
         let known_file = existed_at_baseline || self.hashes.contains_key(&rel);
         let change_kind = match kind {
             notify::EventKind::Create(_) => {
@@ -774,8 +1083,7 @@ impl FileWatcher {
                         self.hashes.insert(rel.clone(), snapshot.hash);
 
                         let (lines_added, lines_removed) =
-                            if let Some(baseline_bytes) = self.baselines.get(&rel) {
-                                let baseline_str = String::from_utf8_lossy(baseline_bytes);
+                            if let Some(baseline_str) = self.baseline_text_for(&rel) {
                                 diff_stats(&baseline_str, &snapshot.text)
                             } else if existed_at_baseline {
                                 (0, 0)
@@ -821,9 +1129,8 @@ impl FileWatcher {
             FileChangeKind::Deleted => {
                 if known_file {
                     let lines_removed = self
-                        .baselines
-                        .get(&rel)
-                        .map(|bytes| String::from_utf8_lossy(bytes).lines().count() as u32)
+                        .baseline_text_for(&rel)
+                        .map(|text| text.lines().count() as u32)
                         .unwrap_or(0);
                     self.bus.send(AppEvent::FileChanged {
                         path: rel_key,
@@ -857,16 +1164,35 @@ impl FileWatcher {
         turn_count: Option<u32>,
         native_message_count: Option<u32>,
     ) -> Result<(), CallerError> {
-        // Walk project and compute file hashes + write objects.
+        // Walk the project and compute file hashes + write any new objects.
+        // Fingerprint-cached: unchanged files are stat'd, not re-read.
         let (files_at_end, all_files_at_end) = self.scan_and_store_objects()?;
 
         // Determine parent + files_changed by diffing against previous round
         // (or baseline if first round).
         let parent_id = self.history.current_head_id;
-        let files_changed = self.compute_files_changed(parent_id, &all_files_at_end);
+        let parent_maps = parent_id.and_then(|pid| self.resolved_round_maps(pid));
+        let files_changed = compute_files_changed(
+            parent_maps.as_ref(),
+            &all_files_at_end,
+            &self.baseline_manifest,
+        );
+
+        // A no-op round (tree identical to the parent's recorded state)
+        // records a depth-1 backreference instead of duplicating the maps.
+        // Compared directly (not via files_changed) so legacy parents whose
+        // display mirror predates `all_files_at_end` never alias.
+        let maps_source_id = parent_maps
+            .as_ref()
+            .filter(|parent| {
+                parent.files_at_end == files_at_end && parent.all_files_at_end == all_files_at_end
+            })
+            .map(|parent| parent.source_round_id);
 
         // If current head is not the last round, branch: move trailing rounds
-        // into abandoned_branches before appending.
+        // into abandoned_branches before appending. (Backreference targets
+        // are always ancestors of the rounds that reference them, so a
+        // drained tail never strands a live round's maps.)
         if let Some(head_id) = self.history.current_head_id {
             if let Some(pos) = self.history.rounds.iter().position(|r| r.id == head_id) {
                 if pos + 1 < self.history.rounds.len() {
@@ -882,30 +1208,47 @@ impl FileWatcher {
 
         let id = self.history.next_id;
         self.history.next_id += 1;
-        let round = HistoryRound {
+        let stub = HistoryRound {
             id,
             parent_id,
             summary,
             timestamp_unix: now_unix(),
             files_changed,
-            files_at_end,
-            all_files_at_end,
+            files_at_end: HashMap::new(),
+            all_files_at_end: HashMap::new(),
             turn_count,
             native_message_count,
+            maps_from_round: maps_source_id,
         };
 
-        // Write per-round manifest.
-        let manifest_path = self
-            .snapshot_dir
-            .join("rounds")
-            .join(format!("round_{}", id))
-            .join("manifest.json");
-        let manifest_bytes = serde_json::to_vec_pretty(&round)
+        // Write the per-round manifest — the durable home of the maps. A
+        // no-op round writes a tiny backreference stub; a changed round
+        // inlines its maps.
+        let manifest = if maps_source_id.is_some() {
+            stub.clone()
+        } else {
+            HistoryRound {
+                files_at_end: files_at_end.clone(),
+                all_files_at_end: all_files_at_end.clone(),
+                ..stub.clone()
+            }
+        };
+        let manifest_path = round_manifest_path(&self.snapshot_dir, id);
+        let manifest_bytes = serde_json::to_vec_pretty(&manifest)
             .map_err(|e| CallerError::Config(format!("manifest serialize: {}", e)))?;
         atomic_write(&manifest_path, &manifest_bytes).map_err(CallerError::Io)?;
+        self.snapshot_dir_size_estimate = self
+            .snapshot_dir_size_estimate
+            .saturating_add(manifest_bytes.len() as u64);
 
-        self.history.rounds.push(round);
+        self.history.rounds.push(stub);
         self.history.current_head_id = Some(id);
+        self.head_maps = Some(HeadMapsCache {
+            round_id: id,
+            source_round_id: maps_source_id.unwrap_or(id),
+            files_at_end,
+            all_files_at_end,
+        });
 
         self.persist_history()?;
 
@@ -937,26 +1280,38 @@ impl FileWatcher {
                 ))
             })?;
 
-        let target = self.history.rounds[target_idx].clone();
-        let from_id = self.history.current_head_id.unwrap_or(target.id);
+        let target_id = self.history.rounds[target_idx].id;
+        let from_id = self.history.current_head_id.unwrap_or(target_id);
+        let target_maps = self.resolved_round_maps(target_id).ok_or_else(|| {
+            CallerError::Config(format!(
+                "round {} snapshot manifest is missing or unreadable — cannot restore",
+                target_id
+            ))
+        })?;
 
-        let files_reverted = self.restore_to_state(&target.files_at_end)?;
+        let files_reverted = self.restore_to_state(&target_maps.files_at_end)?;
 
         // Refresh in-memory hash/baseline mirrors so the watcher doesn't
         // re-emit spurious "modified" events for paths we just rewrote.
         self.refresh_hashes_from_tree();
 
-        self.history.current_head_id = Some(target.id);
+        self.history.current_head_id = Some(target_id);
+        self.head_maps = Some(HeadMapsCache {
+            round_id: target_id,
+            source_round_id: target_maps.source_round_id,
+            files_at_end: target_maps.files_at_end,
+            all_files_at_end: target_maps.all_files_at_end,
+        });
         self.persist_history()?;
 
         self.bus.send(AppEvent::RolledBack {
             from_id,
-            to_id: target.id,
+            to_id: target_id,
             files_reverted,
         });
 
         Ok(RollbackResult {
-            to_round_id: target.id,
+            to_round_id: target_id,
             files_reverted,
         })
     }
@@ -981,17 +1336,29 @@ impl FileWatcher {
             return Err(CallerError::Config("nothing to redo".to_string()));
         }
 
-        let next = self.history.rounds[pos + 1].clone();
-        let files_reverted = self.restore_to_state(&next.files_at_end)?;
+        let next_id = self.history.rounds[pos + 1].id;
+        let next_maps = self.resolved_round_maps(next_id).ok_or_else(|| {
+            CallerError::Config(format!(
+                "round {} snapshot manifest is missing or unreadable — cannot restore",
+                next_id
+            ))
+        })?;
+        let files_reverted = self.restore_to_state(&next_maps.files_at_end)?;
         self.refresh_hashes_from_tree();
 
-        self.history.current_head_id = Some(next.id);
+        self.history.current_head_id = Some(next_id);
+        self.head_maps = Some(HeadMapsCache {
+            round_id: next_id,
+            source_round_id: next_maps.source_round_id,
+            files_at_end: next_maps.files_at_end,
+            all_files_at_end: next_maps.all_files_at_end,
+        });
         self.persist_history()?;
 
-        self.bus.send(AppEvent::Redone { to_id: next.id });
+        self.bus.send(AppEvent::Redone { to_id: next_id });
 
         Ok(RedoResult {
-            to_round_id: next.id,
+            to_round_id: next_id,
             files_reverted,
         })
     }
@@ -1003,6 +1370,8 @@ impl FileWatcher {
         self.history.abandoned_branches.clear();
 
         let bytes_freed = self.gc_orphaned_objects();
+        self.snapshot_dir_size_estimate =
+            self.snapshot_dir_size_estimate.saturating_sub(bytes_freed);
 
         self.persist_history()?;
 
@@ -1023,12 +1392,20 @@ impl FileWatcher {
     /// Supported text files under the size cap are written to `objects/{hash}`
     /// and appear in both maps; inspected non-restorable files appear only in
     /// the display mirror. Ignored and oversized files are skipped.
-    fn scan_and_store_objects(&self) -> Result<SnapshotObjectMaps, CallerError> {
+    ///
+    /// Fingerprint-cached: every file is stat'd, but only files whose
+    /// (size, mtime) moved since the last walk are re-read and re-hashed.
+    /// A cached restorable entry is only trusted when its object blob still
+    /// exists on disk, so every hash recorded in `files_at_end` is
+    /// restorable by construction.
+    fn scan_and_store_objects(&mut self) -> Result<SnapshotObjectMaps, CallerError> {
         let mut out: HashMap<String, String> = HashMap::new();
         let mut all: HashMap<String, String> = HashMap::new();
         let objects_dir = self.snapshot_dir.join("objects");
         std::fs::create_dir_all(&objects_dir)
             .map_err(|e| CallerError::Config(format!("create objects dir: {}", e)))?;
+        let mut next_cache: HashMap<PathBuf, ScanCacheEntry> =
+            HashMap::with_capacity(self.round_scan_cache.len());
 
         let mut stack = vec![self.project_root.clone()];
         while let Some(dir) = stack.pop() {
@@ -1060,11 +1437,34 @@ impl FileWatcher {
                 if should_ignore(&rel) {
                     continue;
                 }
-                if std::fs::metadata(&path)
-                    .map(|meta| meta.len() > SNAPSHOT_MAX_FILE_BYTES)
-                    .unwrap_or(false)
-                {
+                let meta = match std::fs::metadata(&path) {
+                    Ok(meta) => meta,
+                    Err(_) => continue,
+                };
+                if meta.len() > SNAPSHOT_MAX_FILE_BYTES {
                     continue;
+                }
+                // Stat-before-read: this fingerprint describes content no
+                // newer than what a subsequent read returns.
+                let fingerprint = metadata_fingerprint(&meta);
+                if let Some(cached) = self.round_scan_cache.get(&rel) {
+                    if cached.fingerprint == fingerprint {
+                        let key = rel_path_key(&rel);
+                        if cached.restorable {
+                            if objects_dir.join(&cached.hash_hex).exists() {
+                                all.insert(key.clone(), cached.hash_hex.clone());
+                                out.insert(key, cached.hash_hex.clone());
+                                next_cache.insert(rel, cached.clone());
+                                continue;
+                            }
+                            // Object missing (fresh objects dir, failed
+                            // write): fall through and re-store it.
+                        } else {
+                            all.insert(key, cached.hash_hex.clone());
+                            next_cache.insert(rel, cached.clone());
+                            continue;
+                        }
+                    }
                 }
                 let snapshot = match inspect_file(&path) {
                     Ok(snapshot) => snapshot,
@@ -1074,77 +1474,104 @@ impl FileWatcher {
                     InspectedFile::Text(snapshot) => {
                         all.insert(rel_path_key(&rel), snapshot.hash_hex.clone());
                         let obj_path = objects_dir.join(&snapshot.hash_hex);
-                        if !obj_path.exists() {
-                            let _ = atomic_write(&obj_path, &snapshot.bytes);
+                        if !obj_path.exists()
+                            && atomic_write(&obj_path, snapshot.text.as_bytes()).is_ok()
+                        {
+                            self.snapshot_dir_size_estimate = self
+                                .snapshot_dir_size_estimate
+                                .saturating_add(snapshot.size);
                         }
+                        next_cache.insert(
+                            rel.clone(),
+                            ScanCacheEntry {
+                                fingerprint,
+                                hash: snapshot.hash,
+                                hash_hex: snapshot.hash_hex.clone(),
+                                restorable: true,
+                            },
+                        );
                         out.insert(rel_path_key(&rel), snapshot.hash_hex);
                     }
                     InspectedFile::Unsupported(snapshot) => {
-                        all.insert(rel_path_key(&rel), snapshot.hash_hex);
+                        all.insert(rel_path_key(&rel), snapshot.hash_hex.clone());
+                        next_cache.insert(
+                            rel,
+                            ScanCacheEntry {
+                                fingerprint,
+                                hash: snapshot.hash,
+                                hash_hex: snapshot.hash_hex,
+                                restorable: false,
+                            },
+                        );
                     }
                 }
             }
         }
+        self.round_scan_cache = next_cache;
         Ok((out, all))
     }
 
-    /// Compute the list of paths whose content in `current` differs from the
-    /// previous round's display mirror (or restorable map for older history
-    /// files), or from the baseline when there is no previous round.
-    fn compute_files_changed(
-        &self,
-        parent_id: Option<u64>,
-        current: &HashMap<String, String>,
-    ) -> Vec<String> {
-        let mut changed = Vec::new();
-        if let Some(pid) = parent_id {
-            if let Some(parent) = self.history.rounds.iter().find(|r| r.id == pid) {
-                let prev = if parent.all_files_at_end.is_empty() {
-                    &parent.files_at_end
-                } else {
-                    &parent.all_files_at_end
-                };
-                // Union of keys from both sides.
-                let mut keys: HashSet<&String> = prev.keys().collect();
-                keys.extend(current.keys());
-                for k in keys {
-                    match (prev.get(k), current.get(k)) {
-                        (Some(a), Some(b)) if a == b => continue,
-                        _ => changed.push(k.clone()),
-                    }
+    /// Read one baseline file's text from the on-disk `baseline/` shadow
+    /// copy. `None` when the path had no supported-text baseline.
+    fn baseline_text_for(&self, rel: &Path) -> Option<String> {
+        std::fs::read_to_string(self.snapshot_dir.join("baseline").join(rel)).ok()
+    }
+
+    /// Resolve one round's maps: from the head cache when it matches, else
+    /// from the round's on-disk manifest, following its (depth-1)
+    /// `maps_from_round` backreference. `None` when the round is unknown or
+    /// its manifest chain is missing/unreadable.
+    fn resolved_round_maps(&self, round_id: u64) -> Option<ResolvedRoundMaps> {
+        if let Some(cache) = &self.head_maps {
+            if cache.round_id == round_id {
+                return Some(ResolvedRoundMaps {
+                    source_round_id: cache.source_round_id,
+                    files_at_end: cache.files_at_end.clone(),
+                    all_files_at_end: cache.all_files_at_end.clone(),
+                });
+            }
+        }
+        // Prefer the in-memory stub's backreference (skips one manifest
+        // read); fall back to whatever the manifest chain says so maps stay
+        // resolvable even if the index was rebuilt from scratch.
+        let stub_source = self
+            .history
+            .rounds
+            .iter()
+            .find(|r| r.id == round_id)
+            .and_then(|r| r.maps_from_round);
+        let mut source_id = stub_source.unwrap_or(round_id);
+        // Backreferences are written depth-1; the bound is purely defensive.
+        for _ in 0..32 {
+            let manifest_path = round_manifest_path(&self.snapshot_dir, source_id);
+            let bytes = std::fs::read(&manifest_path).ok()?;
+            let manifest = serde_json::from_slice::<HistoryRound>(&bytes).ok()?;
+            match manifest.maps_from_round {
+                Some(next) if next != source_id => source_id = next,
+                _ => {
+                    return Some(ResolvedRoundMaps {
+                        source_round_id: source_id,
+                        files_at_end: manifest.files_at_end,
+                        all_files_at_end: manifest.all_files_at_end,
+                    });
                 }
-                changed.sort();
-                return changed;
             }
         }
-        // First round: compare against baseline in-memory mirror.
-        let mut baseline_hex: HashMap<String, String> = HashMap::new();
-        for (path, meta) in &self.baseline_manifest {
-            baseline_hex.insert(path.clone(), meta.hash.clone());
-        }
-        for (rel, bytes) in &self.baselines {
-            baseline_hex
-                .entry(rel_path_key(rel))
-                .or_insert_with(|| hex_encode(&sha256_hash(bytes)));
-        }
-        let mut keys: HashSet<&String> = baseline_hex.keys().collect();
-        keys.extend(current.keys());
-        for k in keys {
-            match (baseline_hex.get(k), current.get(k)) {
-                (Some(a), Some(b)) if a == b => continue,
-                _ => changed.push(k.clone()),
-            }
-        }
-        changed.sort();
-        changed
+        None
     }
 
     /// Reconcile the on-disk project tree with the given `target` state:
     /// delete any tracked file absent from `target`, restore any file whose
     /// hash differs (or doesn't exist). Returns the count of paths touched.
-    fn restore_to_state(&self, target: &HashMap<String, String>) -> Result<u32, CallerError> {
+    ///
+    /// Fingerprint-cached like the round scan: unchanged files contribute
+    /// their cached hash from a stat instead of a full read. After each
+    /// restore/delete the cache is updated so the follow-up
+    /// [`Self::refresh_hashes_from_tree`] walk is also mostly stats.
+    fn restore_to_state(&mut self, target: &HashMap<String, String>) -> Result<u32, CallerError> {
         let objects_dir = self.snapshot_dir.join("objects");
-        // Build the current tree's path set.
+        // Build the current tree's path set (restorable text files only,
+        // exactly like the round scan's `files_at_end`).
         let mut current: HashMap<String, [u8; 32]> = HashMap::new();
         let mut stack = vec![self.project_root.clone()];
         while let Some(dir) = stack.pop() {
@@ -1176,21 +1603,79 @@ impl FileWatcher {
                 if should_ignore(&rel) {
                     continue;
                 }
-                if std::fs::metadata(&path)
-                    .map(|meta| meta.len() > SNAPSHOT_MAX_FILE_BYTES)
-                    .unwrap_or(false)
-                {
+                let meta = match std::fs::metadata(&path) {
+                    Ok(meta) => meta,
+                    Err(_) => continue,
+                };
+                if meta.len() > SNAPSHOT_MAX_FILE_BYTES {
                     continue;
+                }
+                let fingerprint = metadata_fingerprint(&meta);
+                if let Some(cached) = self.round_scan_cache.get(&rel) {
+                    if cached.fingerprint == fingerprint {
+                        if cached.restorable {
+                            current.insert(rel_path_key(&rel), cached.hash);
+                        }
+                        continue;
+                    }
                 }
                 let snapshot = match inspect_file(&path) {
                     Ok(InspectedFile::Text(snapshot)) => snapshot,
-                    Ok(InspectedFile::Unsupported(_)) | Err(_) => continue,
+                    Ok(InspectedFile::Unsupported(snapshot)) => {
+                        self.round_scan_cache.insert(
+                            rel,
+                            ScanCacheEntry {
+                                fingerprint,
+                                hash: snapshot.hash,
+                                hash_hex: snapshot.hash_hex,
+                                restorable: false,
+                            },
+                        );
+                        continue;
+                    }
+                    Err(_) => continue,
                 };
+                self.round_scan_cache.insert(
+                    rel.clone(),
+                    ScanCacheEntry {
+                        fingerprint,
+                        hash: snapshot.hash,
+                        hash_hex: snapshot.hash_hex,
+                        restorable: true,
+                    },
+                );
                 current.insert(rel_path_key(&rel), snapshot.hash);
             }
         }
 
         let mut touched: u32 = 0;
+        let restore_one = |watcher: &mut Self, rel: &str, target_hex: &str| -> bool {
+            let obj = objects_dir.join(target_hex);
+            let Ok(bytes) = std::fs::read(&obj) else {
+                return false;
+            };
+            let abs = watcher.project_root.join(rel);
+            if let Some(parent) = abs.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            if atomic_write(&abs, &bytes).is_err() {
+                return false;
+            }
+            // Record the restored content in the scan cache so the
+            // post-restore re-sync walk does not re-read it.
+            if let (Ok(meta), Some(hash)) = (std::fs::metadata(&abs), hex_decode_hash(target_hex)) {
+                watcher.round_scan_cache.insert(
+                    PathBuf::from(rel),
+                    ScanCacheEntry {
+                        fingerprint: metadata_fingerprint(&meta),
+                        hash,
+                        hash_hex: target_hex.to_string(),
+                        restorable: true,
+                    },
+                );
+            }
+            true
+        };
 
         // 1. For each current file: if not in target → delete. If hash differs → restore.
         for (rel, cur_hash) in &current {
@@ -1200,19 +1685,11 @@ impl FileWatcher {
                     let abs = self.project_root.join(rel);
                     if std::fs::remove_file(&abs).is_ok() {
                         touched += 1;
+                        self.round_scan_cache.remove(Path::new(rel));
                     }
                 }
                 Some(target_hex) if target_hex != &cur_hex => {
-                    let obj = objects_dir.join(target_hex);
-                    if let Ok(bytes) = std::fs::read(&obj) {
-                        let abs = self.project_root.join(rel);
-                        if let Some(parent) = abs.parent() {
-                            let _ = std::fs::create_dir_all(parent);
-                        }
-                        if atomic_write(&abs, &bytes).is_ok() {
-                            touched += 1;
-                        }
-                    }
+                    touched += u32::from(restore_one(self, rel, target_hex));
                 }
                 _ => {}
             }
@@ -1220,17 +1697,8 @@ impl FileWatcher {
 
         // 2. For each target file not currently present → restore.
         for (rel, target_hex) in target {
-            if !current.contains_key(rel) {
-                let obj = objects_dir.join(target_hex);
-                if let Ok(bytes) = std::fs::read(&obj) {
-                    let abs = self.project_root.join(rel);
-                    if let Some(parent) = abs.parent() {
-                        let _ = std::fs::create_dir_all(parent);
-                    }
-                    if atomic_write(&abs, &bytes).is_ok() {
-                        touched += 1;
-                    }
-                }
+            if !current.contains_key(rel) && restore_one(self, rel, target_hex) {
+                touched += 1;
             }
         }
 
@@ -1240,9 +1708,15 @@ impl FileWatcher {
     /// After a bulk restore, walk the tree again to re-sync our in-memory
     /// hash mirror. Prevents the watcher from emitting spurious
     /// `FileChanged` events for paths we just rewrote.
+    ///
+    /// Cache-aware: `restore_to_state` refreshed the scan cache for every
+    /// path it touched, so this walk is stats plus reads of only the files
+    /// that changed outside the restore.
     fn refresh_hashes_from_tree(&mut self) {
         let mut new_hashes = HashMap::new();
         let mut large_file_fingerprints = HashMap::new();
+        let mut next_cache: HashMap<PathBuf, ScanCacheEntry> =
+            HashMap::with_capacity(self.round_scan_cache.len());
         let mut stack = vec![self.project_root.clone()];
         while let Some(dir) = stack.pop() {
             let entries = match std::fs::read_dir(&dir) {
@@ -1273,46 +1747,114 @@ impl FileWatcher {
                 if should_ignore(&rel) {
                     continue;
                 }
-                if let Ok(meta) = std::fs::metadata(&path) {
-                    if meta.len() > SNAPSHOT_MAX_FILE_BYTES {
-                        large_file_fingerprints.insert(rel, metadata_fingerprint(&meta));
+                let Ok(meta) = std::fs::metadata(&path) else {
+                    continue;
+                };
+                if meta.len() > SNAPSHOT_MAX_FILE_BYTES {
+                    let fingerprint = metadata_fingerprint(&meta);
+                    // Keep the last-known hash when the file is untouched
+                    // (its fingerprint matches) so the change index doesn't
+                    // treat it as deleted after a restore; a genuinely
+                    // changed oversized file gets one streaming re-hash.
+                    let hash = match self.hashes.get(&rel) {
+                        Some(prev)
+                            if self.large_file_fingerprints.get(&rel) == Some(&fingerprint) =>
+                        {
+                            Some(*prev)
+                        }
+                        _ => sha256_file(&path).ok(),
+                    };
+                    if let Some(hash) = hash {
+                        new_hashes.insert(rel.clone(), hash);
+                    }
+                    large_file_fingerprints.insert(rel, fingerprint);
+                    continue;
+                }
+                let fingerprint = metadata_fingerprint(&meta);
+                if let Some(cached) = self.round_scan_cache.get(&rel) {
+                    if cached.fingerprint == fingerprint {
+                        new_hashes.insert(rel.clone(), cached.hash);
+                        next_cache.insert(rel, cached.clone());
                         continue;
                     }
                 }
                 if let Ok(snapshot) = inspect_file(&path) {
-                    let hash = match snapshot {
-                        InspectedFile::Text(snapshot) => snapshot.hash,
-                        InspectedFile::Unsupported(snapshot) => snapshot.hash,
+                    let (hash, hash_hex, restorable) = match snapshot {
+                        InspectedFile::Text(snapshot) => (snapshot.hash, snapshot.hash_hex, true),
+                        InspectedFile::Unsupported(snapshot) => {
+                            (snapshot.hash, snapshot.hash_hex, false)
+                        }
                     };
-                    new_hashes.insert(rel, hash);
+                    new_hashes.insert(rel.clone(), hash);
+                    next_cache.insert(
+                        rel,
+                        ScanCacheEntry {
+                            fingerprint,
+                            hash,
+                            hash_hex,
+                            restorable,
+                        },
+                    );
                 }
             }
         }
         self.hashes = new_hashes;
         self.large_file_fingerprints = large_file_fingerprints;
+        self.round_scan_cache = next_cache;
     }
 
     /// Persist `history.json` atomically via tmp + rename.
-    fn persist_history(&self) -> Result<(), CallerError> {
+    ///
+    /// The file is a slim index (format 2): round scalars + `files_changed`,
+    /// never the per-round path→hash maps — those live once per round in
+    /// `rounds/round_{id}/manifest.json`. The rewrite therefore stays small
+    /// and roughly constant per round instead of growing with
+    /// rounds × files. Binaries from before format 2 fail to parse a round
+    /// without `files_at_end` and fall back to an empty history — no
+    /// rollback offered, never a restore from an empty map.
+    fn persist_history(&mut self) -> Result<(), CallerError> {
         let path = self.snapshot_dir.join("history.json");
-        let bytes = serde_json::to_vec_pretty(&self.history)
+        let mut value = serde_json::to_value(&self.history)
+            .map_err(|e| CallerError::Config(format!("history serialize: {}", e)))?;
+        value["format"] = serde_json::Value::from(HISTORY_INDEX_FORMAT);
+        let bytes = serde_json::to_vec_pretty(&value)
             .map_err(|e| CallerError::Config(format!("history serialize: {}", e)))?;
         atomic_write(&path, &bytes).map_err(CallerError::Io)?;
+        let new_len = bytes.len() as u64;
+        self.snapshot_dir_size_estimate = self
+            .snapshot_dir_size_estimate
+            .saturating_sub(self.last_history_index_bytes)
+            .saturating_add(new_len);
+        self.last_history_index_bytes = new_len;
         Ok(())
     }
 
     /// Collect the set of hashes that are still referenced by any live round
     /// (active path) plus the baseline, and delete any `objects/{hash}` file
     /// not in that set. Returns bytes freed.
+    ///
+    /// Referenced hashes resolve through the per-round manifests (deduped by
+    /// backreference source). Fail-safe: if any live round's maps cannot be
+    /// resolved, nothing is deleted — an unreadable manifest must never
+    /// orphan objects a rollback still needs.
     fn gc_orphaned_objects(&self) -> u64 {
         let mut referenced: HashSet<String> = HashSet::new();
-        for r in &self.history.rounds {
-            for h in r.files_at_end.values() {
-                referenced.insert(h.clone());
-            }
+        let sources: HashSet<u64> = self
+            .history
+            .rounds
+            .iter()
+            .map(|r| r.maps_from_round.unwrap_or(r.id))
+            .collect();
+        for source_id in sources {
+            let Some(maps) = self.resolved_round_maps(source_id) else {
+                return 0;
+            };
+            referenced.extend(maps.files_at_end.into_values());
         }
-        for bytes in self.baselines.values() {
-            referenced.insert(hex_encode(&sha256_hash(bytes)));
+        for meta in self.baseline_manifest.values() {
+            if meta.supported_text {
+                referenced.insert(meta.hash.clone());
+            }
         }
 
         let objects_dir = self.snapshot_dir.join("objects");
@@ -1340,8 +1882,16 @@ impl FileWatcher {
     /// Enforce the soft cap on total snapshot dir size. Drops oldest
     /// abandoned branches first, then GCs their orphaned objects. Active
     /// rounds are never touched.
+    ///
+    /// Gated on the incrementally maintained size estimate: the authoritative
+    /// full-tree walk only runs when the estimate crosses the cap (it used to
+    /// run on every round).
     fn enforce_soft_cap(&mut self) -> Result<(), CallerError> {
+        if self.snapshot_dir_size_estimate <= SNAPSHOT_DIR_SOFT_CAP_BYTES {
+            return Ok(());
+        }
         let mut size = dir_byte_size(&self.snapshot_dir);
+        self.snapshot_dir_size_estimate = size;
         if size <= SNAPSHOT_DIR_SOFT_CAP_BYTES {
             return Ok(());
         }
@@ -1353,6 +1903,7 @@ impl FileWatcher {
             self.history.abandoned_branches.remove(0);
             let freed = self.gc_orphaned_objects();
             size = size.saturating_sub(freed);
+            self.snapshot_dir_size_estimate = self.snapshot_dir_size_estimate.saturating_sub(freed);
             if freed == 0 {
                 break;
             }
@@ -1505,7 +2056,7 @@ mod tests {
             other => panic!("unexpected event: {other:?}"),
         }
         assert!(!snap.path().join("baseline").join("empty.txt").exists());
-        assert!(!watcher.baselines.contains_key(Path::new("empty.txt")));
+        assert!(!watcher.baseline_manifest.contains_key("empty.txt"));
     }
 
     #[test]
@@ -1672,15 +2223,19 @@ mod tests {
         watcher
             .on_round_complete("created files".to_string(), None, None)
             .unwrap();
+        let round_id = watcher.history.rounds.last().expect("round").id;
         let round = watcher.history.rounds.last().expect("round");
 
         assert_eq!(
             round.files_changed,
             vec!["data.dat".to_string(), "text.txt".to_string()]
         );
-        assert!(round.files_at_end.contains_key("text.txt"));
-        assert!(!round.files_at_end.contains_key("data.dat"));
-        assert!(round.all_files_at_end.contains_key("data.dat"));
+        let maps = watcher
+            .resolved_round_maps(round_id)
+            .expect("resolved maps");
+        assert!(maps.files_at_end.contains_key("text.txt"));
+        assert!(!maps.files_at_end.contains_key("data.dat"));
+        assert!(maps.all_files_at_end.contains_key("data.dat"));
     }
 
     #[test]
@@ -1910,11 +2465,8 @@ mod tests {
 
         // The "branch-only-content" hash exists in objects/.
         let target = w
-            .history
-            .rounds
-            .iter()
-            .find(|r| r.id == r2)
-            .unwrap()
+            .resolved_round_maps(r2)
+            .expect("resolved maps")
             .files_at_end
             .get("a.txt")
             .cloned()
@@ -1961,6 +2513,7 @@ mod tests {
                 all_files_at_end: HashMap::new(),
                 turn_count: None,
                 native_message_count: None,
+                maps_from_round: None,
             };
             w.history.abandoned_branches.push(AbandonedBranch {
                 branched_from_id: r1,
@@ -1990,5 +2543,260 @@ mod tests {
         // Active history (r1) still intact.
         assert_eq!(w.history.rounds.len(), 1);
         assert_eq!(w.history.current_head_id, Some(r1));
+    }
+
+    /// Round scans must not re-read files whose (size, mtime) fingerprint is
+    /// unchanged. Proven through the short-circuit's one observable: content
+    /// rewritten at identical length with a restored mtime keeps the
+    /// previously recorded hash (nothing re-read it), while a rewrite whose
+    /// mtime moves is picked up again.
+    #[test]
+    fn round_scan_short_circuits_unchanged_fingerprints() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        let file = root.join("a.txt");
+        std::fs::write(&file, b"round-1!").unwrap();
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1".into(), None, None).unwrap();
+        let r1 = w.history.current_head_id.unwrap();
+        let r1_hash = w.resolved_round_maps(r1).unwrap().files_at_end["a.txt"].clone();
+
+        let original_mtime = std::fs::metadata(&file).unwrap().modified().unwrap();
+        std::fs::write(&file, b"round-2!").unwrap();
+        let handle = std::fs::File::options().write(true).open(&file).unwrap();
+        handle.set_modified(original_mtime).unwrap();
+        drop(handle);
+        w.on_round_complete("R2".into(), None, None).unwrap();
+        let r2 = w.history.current_head_id.unwrap();
+        assert_eq!(
+            w.resolved_round_maps(r2).unwrap().files_at_end["a.txt"],
+            r1_hash,
+            "fingerprint-unchanged file must be served from the cache, not re-hashed"
+        );
+
+        std::fs::write(&file, b"round-3!").unwrap();
+        let handle = std::fs::File::options().write(true).open(&file).unwrap();
+        handle
+            .set_modified(original_mtime + std::time::Duration::from_secs(5))
+            .unwrap();
+        drop(handle);
+        w.on_round_complete("R3".into(), None, None).unwrap();
+        let r3 = w.history.current_head_id.unwrap();
+        let r3_maps = w.resolved_round_maps(r3).unwrap();
+        assert_ne!(
+            r3_maps.files_at_end["a.txt"], r1_hash,
+            "a moved fingerprint must be re-read"
+        );
+        assert_eq!(
+            r3_maps.files_at_end["a.txt"],
+            hex_encode(&sha256_hash(b"round-3!"))
+        );
+    }
+
+    /// A no-op round (tree identical to its parent) records a depth-1
+    /// `maps_from_round` backreference instead of duplicating the maps;
+    /// chains of no-ops keep pointing at the nearest changed round; and
+    /// rollback to a no-op round restores exactly the referenced state.
+    #[test]
+    fn noop_rounds_backreference_and_stay_restorable() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        std::fs::write(root.join("a.txt"), b"v1").unwrap();
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1".into(), None, None).unwrap();
+        let r1 = w.history.current_head_id.unwrap();
+        w.on_round_complete("R2 noop".into(), None, None).unwrap();
+        let r2 = w.history.current_head_id.unwrap();
+        w.on_round_complete("R3 noop".into(), None, None).unwrap();
+
+        assert_eq!(w.history.rounds[1].maps_from_round, Some(r1));
+        assert_eq!(
+            w.history.rounds[2].maps_from_round,
+            Some(r1),
+            "no-op chains compress to the nearest changed round (depth-1)"
+        );
+        let manifest_bytes =
+            std::fs::read(round_manifest_path(tmp_snap.path(), r2)).expect("noop manifest");
+        let manifest: HistoryRound = serde_json::from_slice(&manifest_bytes).unwrap();
+        assert!(manifest.files_at_end.is_empty());
+        assert_eq!(manifest.maps_from_round, Some(r1));
+
+        std::fs::write(root.join("a.txt"), b"v4").unwrap();
+        w.on_round_complete("R4".into(), None, None).unwrap();
+        w.rollback(r2).unwrap();
+        assert_eq!(std::fs::read(root.join("a.txt")).unwrap(), b"v1");
+    }
+
+    /// history.json is a slim format-2 index: no per-round maps regardless
+    /// of round count, while the maps stay resolvable via the round
+    /// manifests.
+    #[test]
+    fn history_json_is_a_slim_format2_index() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        std::fs::write(root.join("a.txt"), b"one").unwrap();
+        std::fs::write(root.join("b.txt"), b"two").unwrap();
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1".into(), Some(1), None).unwrap();
+        std::fs::write(root.join("a.txt"), b"one-more").unwrap();
+        w.on_round_complete("R2".into(), Some(2), None).unwrap();
+        let r2 = w.history.current_head_id.unwrap();
+
+        let text = std::fs::read_to_string(tmp_snap.path().join("history.json")).unwrap();
+        assert!(text.contains("\"format\": 2"));
+        assert!(
+            !text.contains("files_at_end"),
+            "the index must not carry per-round maps: {text}"
+        );
+
+        let parsed: History = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed.rounds.len(), 2);
+        assert_eq!(parsed.rounds[1].turn_count, Some(2));
+
+        let maps = w.resolved_round_maps(r2).unwrap();
+        assert_eq!(maps.files_at_end.len(), 2);
+        assert_eq!(
+            maps.files_at_end["a.txt"],
+            hex_encode(&sha256_hash(b"one-more"))
+        );
+    }
+
+    /// A legacy (pre-format-2) history.json with inline maps still rolls
+    /// back exactly: loading migrates the maps into per-round manifests.
+    #[test]
+    fn legacy_history_json_migrates_and_rolls_back() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        std::fs::write(root.join("a.txt"), b"v1").unwrap();
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1".into(), Some(1), Some(3)).unwrap();
+        let r1 = w.history.current_head_id.unwrap();
+        std::fs::write(root.join("a.txt"), b"v2").unwrap();
+        w.on_round_complete("R2".into(), Some(1), Some(5)).unwrap();
+        let r2 = w.history.current_head_id.unwrap();
+
+        // Rebuild the pre-format-2 on-disk layout: maps inline in
+        // history.json (no format marker), no round manifests.
+        let mut legacy = w.history.clone();
+        for round in &mut legacy.rounds {
+            let maps = w.resolved_round_maps(round.id).unwrap();
+            round.files_at_end = maps.files_at_end;
+            round.all_files_at_end = maps.all_files_at_end;
+            round.maps_from_round = None;
+        }
+        drop(w);
+        std::fs::remove_dir_all(tmp_snap.path().join("rounds")).unwrap();
+        let legacy_bytes = serde_json::to_vec_pretty(&legacy).unwrap();
+        atomic_write(&tmp_snap.path().join("history.json"), &legacy_bytes).unwrap();
+
+        let mut resumed = make_watcher(root, tmp_snap.path());
+        assert!(
+            round_manifest_path(tmp_snap.path(), r1).exists(),
+            "legacy load must materialize round manifests"
+        );
+        assert_eq!(resumed.history.rounds.len(), 2);
+        assert!(resumed
+            .history
+            .rounds
+            .iter()
+            .all(|r| r.files_at_end.is_empty()));
+        assert_eq!(resumed.history.rounds[1].native_message_count, Some(5));
+        assert_eq!(resumed.history.current_head_id, Some(r2));
+
+        resumed.rollback(r1).unwrap();
+        assert_eq!(std::fs::read(root.join("a.txt")).unwrap(), b"v1");
+    }
+
+    /// Rollback and redo still work after a restart: a fresh watcher over
+    /// the same snapshot dir reloads the slim index and resolves maps from
+    /// the manifests (head cache starts cold), and the next round diffs
+    /// against the resolved parent.
+    #[test]
+    fn resumed_watcher_rolls_back_and_redoes_from_manifests() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        std::fs::write(root.join("a.txt"), b"v1").unwrap();
+        let mut w = make_watcher(root, tmp_snap.path());
+        w.on_round_complete("R1".into(), None, None).unwrap();
+        let r1 = w.history.current_head_id.unwrap();
+        std::fs::write(root.join("a.txt"), b"v2").unwrap();
+        std::fs::write(root.join("b.txt"), b"new").unwrap();
+        w.on_round_complete("R2".into(), None, None).unwrap();
+        let r2 = w.history.current_head_id.unwrap();
+        drop(w);
+
+        let mut resumed = make_watcher(root, tmp_snap.path());
+        resumed.rollback(r1).unwrap();
+        assert_eq!(std::fs::read(root.join("a.txt")).unwrap(), b"v1");
+        assert!(!root.join("b.txt").exists());
+
+        let redo = resumed.redo().unwrap();
+        assert_eq!(redo.to_round_id, r2);
+        assert_eq!(std::fs::read(root.join("a.txt")).unwrap(), b"v2");
+        assert_eq!(std::fs::read(root.join("b.txt")).unwrap(), b"new");
+
+        std::fs::write(root.join("a.txt"), b"v3").unwrap();
+        resumed.on_round_complete("R3".into(), None, None).unwrap();
+        let r3_round = resumed.history.rounds.last().unwrap();
+        assert_eq!(
+            r3_round.files_changed,
+            vec!["a.txt".to_string()],
+            "post-resume rounds must diff against the resolved parent maps"
+        );
+    }
+
+    /// Oversized files keep their last-known hash across a rollback's
+    /// hash re-sync, so the changes index does not misreport them as
+    /// deleted (they are stat'd, not re-hashed, when untouched).
+    #[test]
+    fn oversized_hash_survives_rollback_resync() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        let root = tmp_proj.path();
+        let big = vec![b'x'; SNAPSHOT_MAX_FILE_BYTES as usize + 1];
+        std::fs::write(root.join("big.csv"), &big).unwrap();
+        std::fs::write(root.join("a.txt"), b"v1").unwrap();
+        let mut w = make_watcher(root, tmp_snap.path());
+        let big_hash_before = w
+            .changes_index_snapshot()
+            .current_hashes
+            .get("big.csv")
+            .cloned()
+            .expect("oversized file hashed at baseline");
+        w.on_round_complete("R1".into(), None, None).unwrap();
+        let r1 = w.history.current_head_id.unwrap();
+        std::fs::write(root.join("a.txt"), b"v2").unwrap();
+        w.on_round_complete("R2".into(), None, None).unwrap();
+
+        w.rollback(r1).unwrap();
+        let index = w.changes_index_snapshot();
+        assert_eq!(
+            index.current_hashes.get("big.csv"),
+            Some(&big_hash_before),
+            "rollback re-sync must not drop oversized files from the hash index"
+        );
+    }
+
+    /// `start_shared` registers the watcher; the registry resolves it by
+    /// the exact (project_root, snapshot_dir) pair and nothing else.
+    #[tokio::test]
+    async fn live_watcher_registry_resolves_exact_pair() {
+        let tmp_proj = TempDir::new().unwrap();
+        let tmp_snap = TempDir::new().unwrap();
+        std::fs::write(tmp_proj.path().join("a.txt"), b"hello").unwrap();
+        let w = make_watcher(tmp_proj.path(), tmp_snap.path());
+        let (shared, _watcher_handle, _round_handle) = w.start_shared();
+
+        let found = live_watcher_for(tmp_proj.path(), tmp_snap.path()).expect("registered watcher");
+        assert!(Arc::ptr_eq(&found, &shared));
+
+        let other = TempDir::new().unwrap();
+        assert!(live_watcher_for(other.path(), tmp_snap.path()).is_none());
+        assert!(live_watcher_for(tmp_proj.path(), other.path()).is_none());
     }
 }

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -1577,12 +1577,49 @@ pub(crate) fn change_record_detail_json(record: &ChangeRecord) -> serde_json::Va
 }
 
 /// List all files that have changed since the session baseline.
+///
+/// When the live watcher covers exactly this (project_root, snapshot_dir),
+/// the changed-key set comes from watcher state and only changed files are
+/// read; otherwise (external session targets, watcher-less daemons,
+/// momentary lock contention) the legacy full-tree scan runs.
 pub(crate) fn handle_changes_list(
     snapshot_dir: &Path,
     baseline_dir: &Path,
     project_root: &Path,
     include_project_external_logs: bool,
 ) -> String {
+    let mut changes =
+        changes_list_summaries_via_live_watcher(snapshot_dir, baseline_dir, project_root)
+            .unwrap_or_else(|| changes_list_summaries_full_scan(baseline_dir, project_root));
+    let existing_paths: HashSet<String> = changes
+        .iter()
+        .filter_map(|value| {
+            value
+                .get("path")
+                .and_then(|path| path.as_str())
+                .map(str::to_string)
+        })
+        .collect();
+    for record in load_external_change_records(
+        snapshot_dir,
+        project_root,
+        false,
+        include_project_external_logs,
+    ) {
+        if !existing_paths.contains(&record.path) {
+            changes.push(change_record_summary_json(&record));
+        }
+    }
+    serde_json::to_string(&changes).unwrap_or_else(|_| "[]".to_string())
+}
+
+/// Legacy change-list body: read and hash every file under the project
+/// root, plus every baseline file, and diff per key. Kept as the fallback
+/// for targets the live watcher does not cover.
+fn changes_list_summaries_full_scan(
+    baseline_dir: &Path,
+    project_root: &Path,
+) -> Vec<serde_json::Value> {
     let baseline_manifest = load_baseline_manifest(baseline_dir);
     let baseline_paths = collect_baseline_text_paths(baseline_dir);
     let current_states = collect_current_change_states(project_root);
@@ -1607,26 +1644,69 @@ pub(crate) fn handle_changes_list(
             changes.push(change_record_summary_json(&record));
         }
     }
-    let existing_paths: HashSet<String> = changes
-        .iter()
-        .filter_map(|value| {
-            value
-                .get("path")
-                .and_then(|path| path.as_str())
-                .map(str::to_string)
-        })
-        .collect();
-    for record in load_external_change_records(
-        snapshot_dir,
+    changes
+}
+
+/// Watcher-state fast path: `None` when no live watcher matches this
+/// target (or its lock is contended right now) — the caller falls back to
+/// the full scan, so correctness never depends on the fast path.
+fn changes_list_summaries_via_live_watcher(
+    snapshot_dir: &Path,
+    baseline_dir: &Path,
+    project_root: &Path,
+) -> Option<Vec<serde_json::Value>> {
+    let watcher = crate::file_watcher::live_watcher_for(project_root, snapshot_dir)?;
+    // This runs on sync paths (HTTP handler inline, tunnel twin inside
+    // spawn_blocking), so it must not await; try_lock keeps the fast path
+    // opportunistic and contention falls back to the scan.
+    let index = watcher.try_lock().ok()?.changes_index_snapshot();
+    Some(changes_list_summaries_from_index(
+        baseline_dir,
         project_root,
-        false,
-        include_project_external_logs,
-    ) {
-        if !existing_paths.contains(&record.path) {
+        &index,
+    ))
+}
+
+/// Compute change-list summaries from a watcher index snapshot: the
+/// changed-key set is derived by comparing baseline hashes against the
+/// watcher's last-known content hashes (no tree walk), then only those
+/// candidate files are read so each record — kind, line counts, unsupported
+/// reasons — is computed from disk truth by the exact per-key logic the
+/// full scan uses.
+fn changes_list_summaries_from_index(
+    baseline_dir: &Path,
+    project_root: &Path,
+    index: &crate::file_watcher::ChangesIndexSnapshot,
+) -> Vec<serde_json::Value> {
+    let mut candidates: Vec<&String> = Vec::new();
+    let mut keys: HashSet<&String> = index.baseline_manifest.keys().collect();
+    keys.extend(index.current_hashes.keys());
+    for key in keys {
+        let baseline_hash = index.baseline_manifest.get(key).map(|meta| &meta.hash);
+        match (baseline_hash, index.current_hashes.get(key)) {
+            (Some(baseline), Some(current)) if baseline == current => continue,
+            _ => candidates.push(key),
+        }
+    }
+    candidates.sort();
+
+    let mut changes = Vec::new();
+    for key in candidates {
+        if crate::file_watcher::should_ignore(Path::new(key)) {
+            continue;
+        }
+        let current = inspect_current_change_state(project_root, key);
+        if let Some(record) = compute_change_record(
+            key,
+            baseline_dir,
+            current.as_ref(),
+            &index.baseline_manifest,
+            false,
+        ) {
             changes.push(change_record_summary_json(&record));
         }
     }
-    serde_json::to_string(&changes).unwrap_or_else(|_| "[]".to_string())
+    changes
 }
 
 /// Return a unified diff for a single file.
@@ -2269,6 +2349,15 @@ pub(crate) fn append_managed_context_fission_groups_from_dir(
 }
 
 /// GET /api/session/current/history — returns serialized `History` JSON.
+///
+/// The response is the timeline view every consumer actually reads:
+/// `current_head_id`, `next_id`, and per round `id` / `parent_id` /
+/// `summary` / `timestamp_unix` / `files_changed` / `turn_count` /
+/// `native_message_count` (plus abandoned branches of the same shape). The
+/// per-round path→hash rollback maps (`files_at_end` / `all_files_at_end`)
+/// are no longer serialized — they made a long session's response grow to
+/// tens of MB while no client read them; they remain on disk in the
+/// session's `file_snapshots/rounds/round_{id}/manifest.json`.
 pub(crate) async fn handle_history_get(
     file_watcher: Option<&crate::file_watcher::SharedFileWatcher>,
 ) -> (&'static str, String) {
@@ -2278,8 +2367,10 @@ pub(crate) async fn handle_history_get(
             serde_json::json!({"error": "file watcher not active"}).to_string(),
         );
     };
-    let w = fw.lock().await;
-    let body = serde_json::to_string(w.history()).unwrap_or_else(|_| "{}".to_string());
+    // Clone the (slim) history under the lock, serialize outside it, so a
+    // large timeline never stalls event processing behind serialization.
+    let history = fw.lock().await.history().clone();
+    let body = serde_json::to_string(&history).unwrap_or_else(|_| "{}".to_string());
     ("200 OK", body)
 }
 
@@ -5716,6 +5807,124 @@ mod tests {
 
         assert_eq!(status, "400 Bad Request");
         assert_eq!(json["error"], "invalid path");
+    }
+
+    /// The watcher-index fast path must produce byte-identical change-list
+    /// summaries to the legacy full scan across every record kind: created,
+    /// modified, deleted, unchanged (absent), and unsupported files.
+    #[test]
+    fn changes_index_fast_path_matches_full_scan() {
+        let project = tempfile::TempDir::new().unwrap();
+        let snapshot = tempfile::TempDir::new().unwrap();
+        let root = project.path();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/modified.rs"), "old line\nshared\n").unwrap();
+        std::fs::write(root.join("src/unchanged.rs"), "keep\n").unwrap();
+        std::fs::write(root.join("src/deleted.rs"), "goes away\nsoon\n").unwrap();
+        // `.dat` is not an ignored extension, so unsupported (binary) files
+        // are exercised rather than filtered out.
+        std::fs::write(root.join("data.dat"), b"static\0binary").unwrap();
+
+        let mut watcher = crate::file_watcher::FileWatcher::new(
+            root.to_path_buf(),
+            snapshot.path().to_path_buf(),
+            crate::event::EventBus::new(),
+        )
+        .expect("watcher");
+
+        // Mutate the tree and feed the watcher the matching events, the way
+        // the notify loop would.
+        let modify = notify::EventKind::Modify(notify::event::ModifyKind::Data(
+            notify::event::DataChange::Any,
+        ));
+        std::fs::write(root.join("src/modified.rs"), "new line\nshared\nplus\n").unwrap();
+        watcher.process_change(&root.join("src/modified.rs"), &modify);
+        std::fs::write(root.join("src/created.rs"), "brand new\n").unwrap();
+        watcher.process_change(
+            &root.join("src/created.rs"),
+            &notify::EventKind::Create(notify::event::CreateKind::File),
+        );
+        std::fs::write(root.join("new.dat"), b"fresh\0binary").unwrap();
+        watcher.process_change(
+            &root.join("new.dat"),
+            &notify::EventKind::Create(notify::event::CreateKind::File),
+        );
+        std::fs::remove_file(root.join("src/deleted.rs")).unwrap();
+        watcher.process_change(
+            &root.join("src/deleted.rs"),
+            &notify::EventKind::Remove(notify::event::RemoveKind::File),
+        );
+
+        let baseline_dir = snapshot.path().join("baseline");
+        let index = watcher.changes_index_snapshot();
+        let fast = changes_list_summaries_from_index(&baseline_dir, root, &index);
+        let full = changes_list_summaries_full_scan(&baseline_dir, root);
+        assert_eq!(
+            serde_json::to_string(&fast).unwrap(),
+            serde_json::to_string(&full).unwrap(),
+            "fast path and full scan must agree"
+        );
+
+        let paths: Vec<&str> = fast
+            .iter()
+            .map(|value| value["path"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            paths,
+            vec![
+                "new.dat",
+                "src/created.rs",
+                "src/deleted.rs",
+                "src/modified.rs"
+            ],
+            "unchanged files must be absent; the rest sorted"
+        );
+        let modified = fast
+            .iter()
+            .find(|v| v["path"] == "src/modified.rs")
+            .unwrap();
+        assert_eq!(modified["kind"], "modified");
+        assert_eq!(modified["lines_added"], 2);
+        assert_eq!(modified["lines_removed"], 1);
+        let created_bin = fast.iter().find(|v| v["path"] == "new.dat").unwrap();
+        assert_eq!(created_bin["kind"], "created");
+        assert_eq!(created_bin["diff_available"], false);
+    }
+
+    /// GET /api/session/current/history serves the slim timeline: round
+    /// scalars and changed paths, never the per-round rollback maps.
+    #[tokio::test]
+    async fn history_get_serves_slim_timeline() {
+        let project = tempfile::TempDir::new().unwrap();
+        let snapshot = tempfile::TempDir::new().unwrap();
+        let mut watcher = crate::file_watcher::FileWatcher::new(
+            project.path().to_path_buf(),
+            snapshot.path().to_path_buf(),
+            crate::event::EventBus::new(),
+        )
+        .expect("watcher");
+        // Created after the baseline scan so round 1 records it as changed.
+        std::fs::write(project.path().join("a.txt"), "hello\n").unwrap();
+        watcher
+            .on_round_complete("R1".into(), Some(2), Some(7))
+            .expect("round");
+        let shared: crate::file_watcher::SharedFileWatcher =
+            Arc::new(tokio::sync::Mutex::new(watcher));
+
+        let (status, body) = handle_history_get(Some(&shared)).await;
+        assert_eq!(status, "200 OK");
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let rounds = json["rounds"].as_array().unwrap();
+        assert_eq!(rounds.len(), 1);
+        assert_eq!(rounds[0]["summary"], "R1");
+        assert_eq!(rounds[0]["turn_count"], 2);
+        assert_eq!(rounds[0]["native_message_count"], 7);
+        assert_eq!(rounds[0]["files_changed"], serde_json::json!(["a.txt"]));
+        assert_eq!(json["current_head_id"], rounds[0]["id"]);
+        assert!(
+            rounds[0].get("files_at_end").is_none(),
+            "wire view must not carry rollback maps: {body}"
+        );
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -1648,8 +1648,9 @@ fn changes_list_summaries_full_scan(
 }
 
 /// Watcher-state fast path: `None` when no live watcher matches this
-/// target (or its lock is contended right now) — the caller falls back to
-/// the full scan, so correctness never depends on the fast path.
+/// target, its lock is contended right now, or its live index is degraded
+/// (notify not yet confirmed running, or a notify error) — the caller falls
+/// back to the full scan, so correctness never depends on the fast path.
 fn changes_list_summaries_via_live_watcher(
     snapshot_dir: &Path,
     baseline_dir: &Path,
@@ -1659,7 +1660,7 @@ fn changes_list_summaries_via_live_watcher(
     // This runs on sync paths (HTTP handler inline, tunnel twin inside
     // spawn_blocking), so it must not await; try_lock keeps the fast path
     // opportunistic and contention falls back to the scan.
-    let index = watcher.try_lock().ok()?.changes_index_snapshot();
+    let index = watcher.try_lock().ok()?.changes_index_snapshot()?;
     Some(changes_list_summaries_from_index(
         baseline_dir,
         project_root,
@@ -5856,7 +5857,8 @@ mod tests {
         );
 
         let baseline_dir = snapshot.path().join("baseline");
-        let index = watcher.changes_index_snapshot();
+        watcher.mark_live_index_healthy_for_tests();
+        let index = watcher.changes_index_snapshot().expect("healthy index");
         let fast = changes_list_summaries_from_index(&baseline_dir, root, &index);
         let full = changes_list_summaries_full_scan(&baseline_dir, root);
         assert_eq!(
@@ -5889,6 +5891,51 @@ mod tests {
         let created_bin = fast.iter().find(|v| v["path"] == "new.dat").unwrap();
         assert_eq!(created_bin["kind"], "created");
         assert_eq!(created_bin["diff_available"], false);
+    }
+
+    /// Resume-after-delete: a file baselined by a previous run and deleted
+    /// before this one must not surface as a phantom "deleted" row — the
+    /// stale `baseline/` copy is reconciled away at watcher construction,
+    /// keeping the full scan and the watcher-index fast path in agreement.
+    #[test]
+    fn resume_after_delete_reconciles_stale_baselines() {
+        let project = tempfile::TempDir::new().unwrap();
+        let snapshot = tempfile::TempDir::new().unwrap();
+        let root = project.path();
+        std::fs::write(root.join("keep.rs"), "kept\n").unwrap();
+        std::fs::write(root.join("stale.rs"), "left over\n").unwrap();
+        let first = crate::file_watcher::FileWatcher::new(
+            root.to_path_buf(),
+            snapshot.path().to_path_buf(),
+            crate::event::EventBus::new(),
+        )
+        .expect("first watcher");
+        drop(first);
+
+        // The file disappears between runs.
+        std::fs::remove_file(root.join("stale.rs")).unwrap();
+
+        let mut resumed = crate::file_watcher::FileWatcher::new(
+            root.to_path_buf(),
+            snapshot.path().to_path_buf(),
+            crate::event::EventBus::new(),
+        )
+        .expect("resumed watcher");
+        resumed.mark_live_index_healthy_for_tests();
+
+        let baseline_dir = snapshot.path().join("baseline");
+        let full = changes_list_summaries_full_scan(&baseline_dir, root);
+        let index = resumed.changes_index_snapshot().expect("healthy index");
+        let fast = changes_list_summaries_from_index(&baseline_dir, root, &index);
+        assert_eq!(
+            serde_json::to_string(&fast).unwrap(),
+            serde_json::to_string(&full).unwrap(),
+            "fast path and full scan must agree after a resume-after-delete"
+        );
+        assert!(
+            full.iter().all(|row| row["path"] != "stale.rs"),
+            "no phantom deleted row for a file this session never had: {full:?}"
+        );
     }
 
     /// GET /api/session/current/history serves the slim timeline: round


### PR DESCRIPTION
Watcher/history efficiency pass (audit scope 08 #1/#3, scope 10 #1/#3): make per-round snapshot work proportional to actual changes, bound the watcher's memory and persistence, and stop the gateway's changes/history endpoints from re-reading or re-serializing the world per request. Rollback/redo/rewind semantics are preserved exactly (invariants below).

## Finding → fix

| Audit finding | Site | Fix |
|---|---|---|
| Every `RoundComplete` re-read + re-hashed the full tree (scope 08 #1) | `src/bin/caller/file_watcher.rs` `scan_and_store_objects` | Fingerprint cache: unchanged files are stat'd, not read. A hit requires the full fingerprint — size, mtime-ns, the platform change signal (ctime on Unix, creation time on Windows), file identity (dev/inode on Unix) — to match, AND the entry to sit outside a 2s racy-distrust window relative to its recording walk (git-style), so mtime-preserving writers and same-granule rewrites are re-read, never served stale. Unreadable mtimes never match. `process_change` refreshes the cache on every live event. A cached restorable hash is only trusted when its `objects/` blob exists, so every hash recorded in `files_at_end` stays restorable by construction. Same caching for `restore_to_state`'s pre-walk and the post-restore `refresh_hashes_from_tree` re-sync. |
| `history.json` rewritten at O(rounds × files) per round, growing unboundedly (scope 08 #1) | `persist_history` / `on_round_complete` | `history.json` is now a slim format-2 index (round scalars + `files_changed`); the per-round path→hash maps live once in `rounds/round_{id}/manifest.json` (already written today, now load-bearing). A no-op round — e.g. another session's `RoundComplete` that changed nothing — writes a ~200-byte manifest with a depth-1 `maps_from_round` backreference instead of duplicating maps. Legacy full-fat `history.json` files are migrated on load (missing manifests are materialized from the inline maps before they are dropped from memory). Old binaries reading a format-2 file fail closed to an empty history (no rollback offered) — they can never restore from an absent map. |
| Full history (all rounds × 2 maps) held in RAM for the daemon lifetime (scope 08 #1) | `FileWatcher::history` | In-memory rounds are slim; only the current head round's maps stay cached (`HeadMapsCache`). Rollback/redo/GC resolve maps from the manifests on demand. |
| Baseline file content held in RAM forever (scope 08 #3, `baselines: HashMap<PathBuf, Vec<u8>>`) | `FileWatcher` struct | Field removed. Per-event diff stats and delete line-counts read the on-disk `baseline/` shadow copy (written at startup, immutable) on demand — one small read per actually-changed file. |
| `enforce_soft_cap` re-walked the whole snapshot dir every round (scope 08 #1) | `enforce_soft_cap` | Incremental size estimate maintained from the watcher's own writes/GCs; the authoritative walk only runs when the estimate crosses the 500 MB cap. |
| `inspect_file` double-buffered bytes + text (scope 10 #1 tail note) | `inspect_file` / `TextFileSnapshot` | `bytes` field removed; UTF-8 conversion consumes the read buffer (`text.as_bytes()` at the two write sites). |
| `GET /api/session/current/changes` re-read + re-hashed + double-buffered the entire project per request, per tab, at a 250 ms debounce (scope 10 #1) | `src/bin/caller/web_gateway/routes_sessions.rs` `handle_changes_list` | When the live watcher covers exactly the requested (project_root, snapshot_dir) — resolved via a Weak registry keyed on both paths — the changed-key set is computed from watcher state (baseline manifest vs last-known content hashes, no tree walk) and only the changed files are read; each record still comes from the exact per-key disk logic the full scan uses (`compute_change_record`), so record contents are identical (pinned by a parity test). External targets, watcher-less daemons, and momentary lock contention fall back to the unchanged full scan. |
| `GET /api/session/current/history` serialized O(rounds × files) maps no client reads, under the watcher lock (scope 10 #3) | `handle_history_get` | Response is the timeline view (round scalars + `files_changed` + abandoned branches) — the fields the SPA, e2e, and tunnel twin actually consume; the rollback maps are no longer on the wire (they remain on disk in the round manifests). History is cloned under the lock and serialized outside it. |
| Round listener ignores `session_id` (scope 08 #1 / other-findings) | `start_shared` round listener | Documented, not fixed here: nothing on the event bus maps a session to its working root, and the emitters/supervisor wiring are outside this change's file fence. Foreign-session rounds now cost a stat-walk plus an O(1) no-op persist instead of a full tree re-read and an O(rounds × files) rewrite. Follow-up below. |

## Preserved invariants (rewind / rollback semantics)

- **Rollback-to-round-N restores exactly the recorded state.** `files_at_end` content is unchanged; it now lives in the round manifest (or the head cache) instead of the in-memory `History`. Every hash recorded in a round is backed by an `objects/` blob at scan time (the cache re-verifies blob existence before trusting a hit). Restores after daemon restart are covered by tests (`resumed_watcher_rolls_back_and_redoes_from_manifests`, `legacy_history_json_migrates_and_rolls_back`).
- **Conversation rollback arithmetic is untouched.** Every round — including no-op rounds — still appends a `HistoryRound` with its `turn_count` and `native_message_count`, so `handle_history_rollback`'s `turns_to_drop` sum over (target, head] and the target's `native_message_count` are computed from the same data as before.
- **Round identity, branching, redo, prune, GC:** ids still come from `next_id`; rollback still only moves `current_head_id`; post-rollback rounds still drain the tail into `abandoned_branches`; backreference targets are always ancestors on the active path, so draining a tail never strands a live round's maps. GC's referenced set now resolves through manifests and **fails safe**: if any live round's maps cannot be resolved, nothing is deleted.
- **Restore-to-empty vs missing data:** a legacy round whose maps were genuinely empty migrates to an explicit empty-map manifest (restoring it still empties the tracked tree, as before); a *missing/unreadable* manifest makes rollback return an error instead of guessing.
- **Event stream:** `SnapshotCreated` / `RolledBack` / `Redone` / `HistoryPruned` emission points and payloads unchanged.
- **Changes endpoint:** response shape and per-record values unchanged (`changes_index_fast_path_matches_full_scan` pins fast path == full scan across created/modified/deleted/unsupported/unchanged); the single-file diff endpoint and the external-diff merge are untouched. `session_wildcard_json_response` (CORS/auth envelope) untouched. Freshness nuance, stated for the record: the changed-key *set* now reflects the watcher's last-processed events rather than an instantaneous rescan. The dashboard's refresh is itself driven by those events (`file_changed` → debounced fetch), so the served view is self-consistent, and every candidate record is still computed from disk truth at request time. The one divergence: a change whose notify event was lost stays out of the list until the watcher's next event (the old path would have surfaced it on the next full rescan, e.g. a manual tab open). The watcher's own hash mirror already had this property for its `file_changed`/round accounting; the endpoint now shares it instead of paying a full tree read per request to paper over it.
- **History endpoint:** all fields any consumer reads are still present (`current_head_id`, `next_id`, per-round `id`/`parent_id`/`summary`/`timestamp_unix`/`files_changed`/`turn_count`/`native_message_count`, abandoned branches). Verified consumers: SPA timeline (`static/app/37-uicommand-changes-control.js` — reads only those fields), e2e (`headless_rollback_writes_a_conversation_rewound_cut` — reads `rounds[0].id`), tunnel twin (shared core). The 503 watcher-less shape is unchanged.

## Cost before → after

- Round snapshot (per `RoundComplete`, any session): full tree read + hash (~1.7k files on this repo) + `history.json` rewrite carrying every prior round's two full maps (~0.4 MB/round, ~40 MB/rewrite by round 100 per the audit) → stat-walk + read of changed files only; `history.json` stays a few hundred bytes per round; a no-op round persists O(1).
- `GET /changes` (per request, 250 ms-debounced per tab while an agent edits): whole-project read+hash with all file contents resident + a baseline read per key (worst case ~2 GiB I/O per the audit) → in-memory hash compare + reads of changed files only.
- `GET /history`: ~25–50 MB JSON per fetch on long sessions (audit) → KB-scale timeline.
- Watcher RSS: project text baseline (tens of MB typical, up to the 2 GiB budget) + O(rounds × files) history maps → baseline metadata + one head round's maps + a per-file fingerprint cache.

## Review round 1 (two independent reviews, reconciled) — all applied in 4b53ee4c

1. **Fingerprint staleness (blocker)** — fingerprint widened with the platform change signal + file id; 2s racy-distrust window on cache hits; `(size, None)` never matches; `process_change` refreshes cache entries; comments state the real detection contract. The test that pinned the stale behavior now pins detection: `same_length_mtime_restored_rewrite_is_detected` (racy window, portable) and `mtime_backdated_rewrite_is_detected_via_ctime` (Unix ctime defense); `round_scan_reads_only_changed_files` keeps the efficiency pin via a test-only read counter.
2. **Old-binary manifest clobber (blocker)** — per-store `store_epoch` minted at load, persisted in the index, stamped into every manifest (including load-migration stamping); the resolver verifies manifest id + epoch and fails **closed** to "cannot restore". Test: `manifest_epoch_mismatch_refuses_restore` (foreign epoch and stripped epoch both refuse; tree untouched).
3. **Migration write-failure handling** — the write result is checked; on failure the round keeps its authoritative inline maps in the index (they serve restores, including as backreference targets) and migration retries next load; legacy migration always rewrites manifests from inline maps instead of trusting existing files. Test: `failed_migration_keeps_inline_maps_and_still_restores` (unwritable rounds dir → inline maps survive, rollback works, later load migrates).
4. **Self-referential `maps_from_round` (contradiction adjudicated)** — Codex was right: a self-referencing manifest resolved as a terminal manifest with omitted (empty) maps → rollback would delete tracked files; the bounded loop only protected cycles of length ≥ 2. Resolution now keeps a visited set — any cycle, self-reference included, fails closed. Test: `self_referential_and_cyclic_backrefs_fail_closed` (self-ref + 2-cycle; refused rollback touches nothing).
5. **Fast-path health + key universe** — the watcher starts degraded and only serves the changes index after `notify::watch()` succeeds; notify errors degrade it permanently (full scan serves); rescan-flagged events trigger a full re-sync. Stale `baseline/` files from pre-resume deletions are reconciled away at construction, killing the full scan's phantom "deleted" rows and keeping fast == full under contention flicker. Tests: `degraded_live_index_serves_no_snapshot`, `resume_after_delete_reconciles_stale_baselines`.
6. **Docs** — `skills/intendant-log-search/references/artifact-map.md` now documents the format-2 index, load-bearing round manifests, `maps_from_round`, and `store_epoch`.

## Review round 2 (delta re-review) — all nine applied in 26fa61c1

1. **Restamp content-binding (blocker)** — restamping an epoch-less store now requires the manifest's scalars to bind to its index row (`manifest_binds_to_round`: parent/summary/timestamp/files_changed/turn counts/backref), and the resolver enforces the same binding per hop — identity alone never blesses a manifest, with or without an epoch. Test: `restamp_refuses_poisoned_manifest` (poisoned id-matching manifest stays unstamped, restore refuses, binding sibling keeps working). Population note: epoch-less format-2 stores exist only from pre-fix-round draft binaries; the fix is principled regardless.
2. **Windows change signal (blocker)** — new `platform::file_change_stamp` in `crates/intendant-platform` (fence granted): NTFS `ChangeTime` via `GetFileInformationByHandleEx` (moves on every write; not settable through `SetFileTime`) + real (volume, file-index) identity, minimal `unsafe` with SAFETY comments and RAII handles per the platform-island rules; Unix rides the same helper (ctime + dev/ino). A failed handle query never matches — degraded stats fall toward re-reading. Tests: `file_change_stamp_moves_on_rewrite` (platform crate, unix+windows), `mtime_backdated_rewrite_is_detected_via_change_signal` (cfg(windows) twin of the Unix ctime test).
3. **Cross-process store exclusion** — advisory lock on a dedicated `store.lock` (never `history.json`; Windows LockFileEx blocks reads of the locked file), acquired before any store write, held for the watcher's lifetime. Lock conflict → read-only instance: history/changes serve, round recording + rollback/redo/prune + persists refuse with a clear error, fast path stays down; read-only construction writes nothing (adopts the owner's on-disk baseline state). Test: `second_watcher_is_read_only_until_lock_released` (real double-construction against one store; flock/LockFileEx conflict is per-open-description so the same-process test is faithful).
4. **Scan-to-watch gap** — after `watch()` succeeds the loop runs a full `refresh_hashes_from_tree`, drains events that raced in during the resync, and only then clears degraded. Test: `scan_to_watch_gap_is_resynced_before_healthy` (mutation between construction and `start_shared` is visible the moment the index turns healthy).
5. **Empty-tree retention** — retained rounds carry an explicit `maps_inline` marker (empty maps serialize to nothing, so the marker is the survivor); the resolver serves marked rounds inline, including as backreference targets. Test: `retained_empty_tree_round_survives_reload` (restore-to-empty exact after reload under an unwritable manifest dir).
6. **Deferred epoch adoption** — every restamp/migration write result is checked; if any *binding* manifest cannot be restamped, the epoch mint is deferred entirely (no epoch persists over manifests it would orphan) and retried next load; epoch-less operation stays guarded by resolver content-binding. Migration failures retain-inline per (5). Test: `failed_restamp_defers_epoch_adoption` (no epoch persisted while blocked; store still restores; next writable load completes the mint).
7. **Damaged `history.json` preserved** — present-but-unparseable indexes are renamed aside (`history.json.damaged-<ts>`) before a fresh timeline starts; absent stays the fresh-store path; if even the rename fails, the watcher runs read-only rather than ever overwriting. Test: `damaged_history_json_is_preserved_not_overwritten` (damaged bytes survive verbatim).
8. **Monotonic racy gate** — cache trust now requires the racy window of *monotonic* (`Instant`) age since hashing in addition to the wall-clock mtime-vs-recording check, so a backward clock step cannot make a fresh write look old. Tests pin fingerprint mechanics via a test-only window override instead of multi-second sleeps.
9. **Baseline reconciliation hardening** — any reconcile failure (unreadable subdir, undeletable stale file) permanently disables the changes fast path (sticky flag; the full scan serves); wrong-typed leftovers (stale file blocking a directory path and vice versa) are cleared before baseline writes. Tests: `reconcile_failure_disables_fast_path`, `baseline_path_type_changes_are_reconciled`.

## Review round 3 (focused delta) — all seven applied

1. **Map-payload binding (the substantive one)** — scalar binding alone would bless a manifest whose scalars match but whose maps were replaced. Every index row now records `maps_hash` — a canonical (key-sorted, length-prefixed, domain-separated) content hash of the round's two maps — stamped by the write path, migration, and the restamp sweep (which also backfills rows that predate the field, freezing their payloads); the resolver verifies the terminal manifest's maps against the requested round's recorded hash before serving, on top of the scalar + epoch checks. Rows with no recorded hash (pre-field, never revisited by a restamp) skip the payload check — tolerated residual, population is draft-build stores only. Test: `map_only_poison_is_refused` (scalars + epoch intact, maps replaced → refused, tree untouched).
2. **Transient manifest READ failures defer the epoch** — restamp now distinguishes NotFound (skip; unresolvable either way) from other read errors (defer epoch adoption exactly like write failures), so a temporarily permission-denied correct manifest can never be orphaned by a persisted epoch. Test: `unreadable_manifest_defers_epoch_adoption` (0o000 manifest → no epoch persisted; readable again → next load completes the mint).
3. **Reconciliation error-hiding + symlinks** — per-entry `ReadDir` results are checked explicitly (any error → reconcile failure → sticky fast-path disable), and symlink/other-typed leftovers under `baseline/` (which only ever holds regular files the watcher wrote) are removed like stale files — the fallback scan would otherwise follow a file symlink and diverge. Test: `symlink_baseline_leftover_is_reconciled` (removed; fast path stays enabled on success).
4. **Windows zero/unsupported ChangeTime fails closed** — `file_change_stamp` returns `None` for a zero `ChangeTime` (FAT-family/network filesystems) and for an unreliable file identity, and an absent signal on Unix/Windows never matches — a shared zero can never compare equal across rewrites. (No portable synthetic test for FAT exists; the guard is two explicit conditions with the invariant documented.)
5. **Healthy transition gates on re-sync + drain success** — `refresh_hashes_from_tree` reports enumeration holes (non-NotFound `read_dir` failures) and degrades the index itself; the post-watch transition only clears degraded when the re-sync AND the queued-event drain both succeeded. Test: `resync_failure_keeps_index_degraded` (unenumerable subtree between construction and watch → never marked healthy).
6. **Damaged-backup name collisions** — backups are `history.json.damaged-<ts>-<pid>-<seq>` with an existence check (sound: the store lock makes the renamer the only writer), so `std::fs::rename` can never replace an earlier backup. The round-0-manifest-overwrite-after-fresh-start residual is documented in code and below — with epoch + maps-hash binding the damaged timeline's manifests are already unresolvable; the preserved JSON is forensic.
7. **No pre-lock store writes** — only the store root directory (the lockfile's home) is created before the lock; `baseline/`, `objects/`, `rounds/` are created by the lock owner. A read-only loser creates nothing beyond the lockfile probe.

## Accepted residuals (reviewer-triaged, documented)

- **Read-only instances never upgrade in-process** — a watcher that lost the store lock stays read-only for its lifetime; a fresh construction after the owner exits acquires normally.
- **A permanently-unwritable store stays epoch-less** — availability degradation only: resolves remain guarded by content + payload binding; the mint retries every load.
- **Fresh-timeline round ids reuse 0..** after a damaged-index reset, overwriting the damaged timeline's manifests as rounds accrue — those manifests are already unresolvable by any index (epoch + maps-hash), the preserved damaged JSON is forensic only.
- **The production racy gate anchors to walk start** (most conservative recording bound); the test-only window override is `#[cfg(test)]`-gated and unreachable in production builds.
- **Epoched draft-build rows without `maps_hash`** (never revisited by a restamp sweep) resolve without the payload check — scalar + epoch binding still apply; population is this branch's own draft stores.

## Evidence

- `same_length_mtime_restored_rewrite_is_detected` / `mtime_backdated_rewrite_is_detected_via_ctime` — spoofed fingerprints are re-read, never served stale.
- `round_scan_reads_only_changed_files` — efficiency pin: untouched tree = 0 reads, one touched file = 1 read.
- `noop_rounds_backreference_and_stay_restorable` — no-op rounds write backreference manifests, chains compress to depth-1, rollback to a no-op round restores exactly.
- `history_json_is_a_slim_format2_index` — the index carries no maps at any round count; maps resolve via manifests.
- `legacy_history_json_migrates_and_rolls_back` + `resumed_watcher_rolls_back_and_redoes_from_manifests` — migration and restart paths restore exactly.
- `manifest_epoch_mismatch_refuses_restore`, `self_referential_and_cyclic_backrefs_fail_closed`, `failed_migration_keeps_inline_maps_and_still_restores` — corrupted/foreign/unwritable stores fail closed, never restore a wrong tree.
- `oversized_hash_survives_rollback_resync` — >1 MB files keep hash continuity across restores (no phantom "deleted" entries).
- `changes_index_fast_path_matches_full_scan` + `resume_after_delete_reconciles_stale_baselines` — fast path output is identical to the full scan, including after resume-after-delete.
- `degraded_live_index_serves_no_snapshot` — the fast path stands down until notify is confirmed healthy.
- `history_get_serves_slim_timeline` — wire view keeps every consumed field, drops the maps.
- e2e `headless_rollback_writes_a_conversation_rewound_cut` (real binaries, mock provider) exercises GET /history + POST rollback against this code and stays green.

Battery (after round 3): `cargo fmt --check` clean; `cargo clippy` clean (bins + intendant-platform); `cargo test --bins` 3,354 + 69 + 83 passed / 0 failed (plus `cargo nextest run --bins` 3,506/3,506 under process isolation); `cargo test -p intendant-platform` 26 passed; `cargo test --test e2e` 21/21. The cfg(windows) code paths compile-gate on this PR's Windows check leg; the cfg(windows) tests execute in the merge group (and `file_change_stamp` has a unix-equivalent test running everywhere). Observed once during the round-3 battery: `mcp_gate::…authority-store lock` timing out at 2s under full-suite parallel load on a shared box — an untouched subsystem, passes 5/5 in isolation and under nextest; known load-flake class.

## Follow-ups (out of this change's file fence)

- **Per-session scoping of the round listener** needs either `RoundComplete` carrying the session's working root or supervisor wiring into the watcher (emitters in `run_modes.rs`/`external_mode.rs`/`agent_loop.rs`, wiring in `startup/wiring.rs`). Until then rounds from sessions in other roots still interleave into the daemon-root timeline (pre-existing attribution wart, audit scope 08 "other findings").
- **Threading the watcher handle through dispatch** (`http_dispatch.rs` arm + `dashboard_control` twin) would replace the registry lookup with explicit parameter passing, and would let `GET /history` accept an explicit `?full=1` for an on-wire full blob (the full data is on disk in the round manifests meanwhile).
- `skills/intendant-log-search/references/artifact-map.md` documents the old `history.json` schema (`files_at_end` inline per round) — needs the format-2 note.
