### PR TITLE
external-agent: incremental Codex trace/context caches + managed-context I/O fixes

### DIFF
--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -1592,25 +1592,28 @@ impl CcReader {
             return;
         }
 
+        // Build the failure snippet before the delta event so the (possibly
+        // large) result text can move into the event instead of being cloned
+        // wholesale just to keep a 200-char error excerpt alive.
+        let failure_message = is_error.then(|| {
+            let message: String = content_text.chars().take(200).collect();
+            if message.trim().is_empty() {
+                "tool error".to_string()
+            } else {
+                message
+            }
+        });
         if !content_text.is_empty() {
             out.events.push(AgentEvent::ToolOutputDelta {
                 item_id: tool_id.clone(),
-                text: content_text.clone(),
+                text: content_text,
             });
         }
 
         self.open_tools.remove(&tool_id);
-        let status = if is_error {
-            let message: String = content_text.chars().take(200).collect();
-            ToolCompletionStatus::Failed {
-                message: if message.trim().is_empty() {
-                    "tool error".into()
-                } else {
-                    message
-                },
-            }
-        } else {
-            ToolCompletionStatus::Success
+        let status = match failure_message {
+            Some(message) => ToolCompletionStatus::Failed { message },
+            None => ToolCompletionStatus::Success,
         };
         out.events.push(AgentEvent::ToolCompleted {
             item_id: tool_id,

--- a/src/bin/caller/external_agent/codex/context_trace.rs
+++ b/src/bin/caller/external_agent/codex/context_trace.rs
@@ -30,6 +30,7 @@ pub(crate) struct CodexResponsePayloadRef {
     pub(crate) response_id: String,
 }
 
+#[derive(Default)]
 pub(crate) struct CodexTraceIndex {
     pub(crate) requests: Vec<CodexRequestPayloadRef>,
     pub(crate) requests_by_call: HashMap<String, CodexRequestPayloadRef>,
@@ -51,24 +52,29 @@ pub(crate) fn codex_context_snapshot_not_ready(err: &CallerError) -> bool {
     )
 }
 
+/// One-shot form of [`CodexTraceIndexCache::latest_snapshot`] for callers
+/// without a live cache (tests, ad-hoc reads). Builds the index fresh and
+/// resolves ONLY the newest request — never every historical request.
 pub(crate) async fn read_latest_codex_context_payload(
     root: &Path,
     thread_id: Option<&str>,
 ) -> Result<CodexRequestPayloadSnapshot, CallerError> {
-    let snapshots = read_codex_context_payloads(root, thread_id).await?;
-    snapshots.into_iter().last().ok_or_else(|| {
-        CallerError::ExternalAgent(format!(
-            "no Codex inference request payload found in {}",
-            root.display()
-        ))
-    })
+    let mut cache = CodexTraceIndexCache::default();
+    cache.latest_snapshot(root, thread_id).await
 }
 
+/// One-shot read of every request snapshot in order — test surface for the
+/// full-archive behavior the cache exposes through
+/// [`CodexTraceIndexCache::snapshots_excluding`].
+#[cfg(test)]
 pub(crate) async fn read_codex_context_payloads(
     root: &Path,
     thread_id: Option<&str>,
 ) -> Result<Vec<CodexRequestPayloadSnapshot>, CallerError> {
-    read_codex_context_payloads_excluding(root, thread_id, &HashSet::new()).await
+    let mut cache = CodexTraceIndexCache::default();
+    cache
+        .snapshots_excluding(root, thread_id, &HashSet::new())
+        .await
 }
 
 pub(crate) fn context_snapshots_from_trace_archive(
@@ -112,7 +118,7 @@ pub(crate) fn read_codex_context_payloads_sync(
 ) -> Result<Vec<CodexRequestPayloadSnapshot>, CallerError> {
     let index = read_codex_trace_index_sync(root, thread_id)?;
     let mut requests = index.requests.clone();
-    requests.sort_by_key(codex_request_sort_key);
+    requests.sort_by(codex_request_order_cmp);
 
     let mut snapshots = Vec::with_capacity(requests.len());
     for (idx, request_ref) in requests.iter().enumerate() {
@@ -125,38 +131,25 @@ pub(crate) fn read_codex_context_payloads_sync(
     Ok(snapshots)
 }
 
-pub(crate) async fn read_codex_context_payloads_excluding(
-    root: &Path,
-    thread_id: Option<&str>,
-    seen_request_ids: &HashSet<String>,
-) -> Result<Vec<CodexRequestPayloadSnapshot>, CallerError> {
-    let index = read_codex_trace_index(root, thread_id).await?;
-    let mut requests = index.requests.clone();
-    requests.sort_by_key(codex_request_sort_key);
-
-    let mut snapshots = Vec::with_capacity(requests.len());
-    for (idx, request_ref) in requests.iter().enumerate() {
-        if seen_request_ids.contains(&codex_request_id(request_ref)) {
-            continue;
-        }
-        snapshots.push(codex_context_payload_snapshot(&index, request_ref, idx as u64 + 1).await?);
-    }
-    Ok(snapshots)
-}
-
 pub(crate) async fn codex_context_payload_snapshot(
     index: &CodexTraceIndex,
     request_ref: &CodexRequestPayloadRef,
     request_index: u64,
+    resolved_chain: &mut Option<CodexResolvedChain>,
 ) -> Result<CodexRequestPayloadSnapshot, CallerError> {
     let payload =
         read_codex_json_payload(&request_ref.bundle_dir, &request_ref.relative_path).await?;
     let format = codex_request_format(request_ref.provider_name.as_deref());
     let request_id = codex_request_id(request_ref);
     if format == "openai.responses.request.v1" {
-        let resolved =
-            resolve_openai_responses_context_payload(index, request_ref, request_index, payload)
-                .await?;
+        let resolved = resolve_openai_responses_context_payload(
+            index,
+            request_ref,
+            request_index,
+            payload,
+            resolved_chain,
+        )
+        .await?;
         return Ok(CodexRequestPayloadSnapshot {
             label: "Codex resolved request payload".to_string(),
             request_id,
@@ -209,16 +202,18 @@ pub(crate) fn codex_context_payload_snapshot_sync(
     })
 }
 
-pub(crate) fn codex_request_sort_key(
-    request: &CodexRequestPayloadRef,
-) -> (i64, u64, String, String, String) {
-    (
-        request.order.0,
-        request.order.1,
-        request.bundle_dir.to_string_lossy().to_string(),
-        request.relative_path.clone(),
-        request.inference_call_id.clone(),
-    )
+/// Total order over request refs: trace timestamp, then line index, with the
+/// stable path/call-id tie-breaks. Comparator form (no per-comparison String
+/// allocations — the old tuple sort key allocated three per call).
+pub(crate) fn codex_request_order_cmp(
+    a: &CodexRequestPayloadRef,
+    b: &CodexRequestPayloadRef,
+) -> std::cmp::Ordering {
+    a.order
+        .cmp(&b.order)
+        .then_with(|| a.bundle_dir.cmp(&b.bundle_dir))
+        .then_with(|| a.relative_path.cmp(&b.relative_path))
+        .then_with(|| a.inference_call_id.cmp(&b.inference_call_id))
 }
 
 pub(crate) fn codex_request_id(request: &CodexRequestPayloadRef) -> String {
@@ -602,54 +597,459 @@ pub(crate) fn codex_context_archive_payload(
     })
 }
 
-pub(crate) async fn read_codex_trace_index(
-    root: &Path,
-    thread_id: Option<&str>,
-) -> Result<CodexTraceIndex, CallerError> {
-    let bundle_dirs = collect_codex_trace_bundle_dirs(root, thread_id).await?;
-    let mut requests = Vec::new();
-    let mut requests_by_call = HashMap::new();
-    let mut responses_by_id = HashMap::new();
+// ---------------------------------------------------------------------------
+// Incremental trace-index cache
+// ---------------------------------------------------------------------------
 
-    for bundle_dir in bundle_dirs {
-        let trace_path = bundle_dir.join("trace.jsonl");
-        let contents = match tokio::fs::read_to_string(&trace_path).await {
-            Ok(contents) => contents,
-            Err(_) => continue,
-        };
+/// Byte/line cursor into one `trace.jsonl`: how much of the file has already
+/// been folded into the cached index. `bytes` only ever advances past
+/// COMPLETE lines — a trailing partial line the writer is still flushing is
+/// left for the next refresh, exactly like the historical full re-scan
+/// picked it up once complete.
+#[derive(Debug, Default, Clone, Copy)]
+struct CodexTraceFileCursor {
+    bytes: u64,
+    lines: u64,
+}
 
-        for (line_idx, line) in contents.lines().enumerate() {
-            if line.trim().is_empty() {
+/// Cross-session auxiliary bundle dirs (other sessions' trace roots whose
+/// bundle names match the thread), cached against the logs root's directory
+/// mtime so the exact-archive fingerprint tick doesn't re-enumerate every
+/// historical session directory at 1 Hz. Session dirs are created and
+/// removed directly under the logs root, so those events bump its mtime and
+/// invalidate the sweep; bundles for the LIVE session land under the primary
+/// root, which is always enumerated fresh.
+struct CodexAuxBundleDirs {
+    logs_root: PathBuf,
+    modified: Option<SystemTime>,
+    bundle_dirs: Vec<PathBuf>,
+}
+
+/// Resolved `previous_response_id` chain for the most recently resolved
+/// `openai.responses` request. Chains are append-only: the next request's
+/// resolution extends this one by the new hops only, reading just the new
+/// payload files instead of re-walking (and re-reading) the whole history
+/// on every snapshot.
+pub(crate) struct CodexResolvedChain {
+    /// [`codex_trace_call_key`] of the request whose resolution is cached.
+    call_key: String,
+    /// The fully resolved conversation: every previous (input, output_items)
+    /// pair plus the cached request's own input items.
+    resolved_input: Vec<serde_json::Value>,
+    /// Unresolved-tail marker inherited by any resolution built on this
+    /// prefix.
+    unresolved_previous_response_id: Option<String>,
+}
+
+/// Incrementally maintained view of a Codex trace archive for one
+/// `(trace root, thread)`: parsed request/response refs plus the resolved
+/// chain of the newest request. A refresh stats the known `trace.jsonl`
+/// files and parses only appended lines; a shrunk or vanished file (trace
+/// rewrite, temporary-root cleanup) triggers a full rebuild — the safe
+/// fallback. Same-length in-place rewrites are undetectable here, the same
+/// blind spot the (len, mtime) fingerprint gate has always had.
+#[derive(Default)]
+pub(crate) struct CodexTraceIndexCache {
+    key: Option<(PathBuf, Option<String>)>,
+    cursors: HashMap<PathBuf, CodexTraceFileCursor>,
+    index: CodexTraceIndex,
+    aux_bundles: Option<CodexAuxBundleDirs>,
+    resolved_chain: Option<CodexResolvedChain>,
+}
+
+impl CodexTraceIndexCache {
+    /// The current request refs, sorted by [`codex_request_order_cmp`]. Only
+    /// meaningful after a [`Self::refresh`].
+    pub(crate) fn requests(&self) -> &[CodexRequestPayloadRef] {
+        &self.index.requests
+    }
+
+    fn reset_for_key(&mut self, root: &Path, thread_id: Option<&str>) {
+        let key_matches = self
+            .key
+            .as_ref()
+            .is_some_and(|(cached_root, cached_thread)| {
+                cached_root == root && cached_thread.as_deref() == thread_id
+            });
+        if !key_matches {
+            *self = Self {
+                key: Some((root.to_path_buf(), thread_id.map(str::to_string))),
+                ..Self::default()
+            };
+        }
+    }
+
+    /// Stat-guarded fingerprint over the archive's `trace.jsonl` files —
+    /// same shape and semantics as the historical full-scan fingerprint,
+    /// minus the per-call re-enumeration of every session directory (see
+    /// [`CodexAuxBundleDirs`]).
+    pub(crate) async fn fingerprint(
+        &mut self,
+        root: &Path,
+        thread_id: Option<&str>,
+    ) -> Result<CodexTraceFingerprint, CallerError> {
+        self.reset_for_key(root, thread_id);
+        let bundle_dirs = self.collect_bundle_dirs(root, thread_id).await?;
+        let mut files = Vec::new();
+        for bundle_dir in bundle_dirs {
+            let path = bundle_dir.join("trace.jsonl");
+            let metadata = match tokio::fs::metadata(&path).await {
+                Ok(metadata) => metadata,
+                Err(_) => continue,
+            };
+            files.push(CodexTraceFileFingerprint {
+                path,
+                len: metadata.len(),
+                modified: metadata.modified().ok(),
+            });
+        }
+        files.sort_by(|a, b| a.path.cmp(&b.path));
+        Ok(CodexTraceFingerprint { files })
+    }
+
+    /// Bring the cached index up to date with the archive: stat every
+    /// bundle's `trace.jsonl`, tail-read files that grew, rebuild from
+    /// scratch if any known file shrank or vanished.
+    pub(crate) async fn refresh(
+        &mut self,
+        root: &Path,
+        thread_id: Option<&str>,
+    ) -> Result<(), CallerError> {
+        self.reset_for_key(root, thread_id);
+        let mut files = self.stat_trace_files(root, thread_id).await?;
+
+        // A shrunk or vanished file means lines already folded into the
+        // index can no longer be attributed; drop everything and rescan.
+        let lens: HashMap<&Path, u64> = files
+            .iter()
+            .map(|(_, path, len)| (path.as_path(), *len))
+            .collect();
+        let stale = self.cursors.iter().any(|(path, cursor)| {
+            lens.get(path.as_path())
+                .map_or(cursor.bytes > 0, |len| *len < cursor.bytes)
+        });
+        drop(lens);
+        if stale {
+            self.cursors.clear();
+            self.index = CodexTraceIndex::default();
+            self.aux_bundles = None;
+            self.resolved_chain = None;
+            files = self.stat_trace_files(root, thread_id).await?;
+        }
+
+        let mut appended = false;
+        for (bundle_dir, path, len) in files {
+            let start = self.cursors.get(&path).copied().unwrap_or_default();
+            if len == start.bytes {
                 continue;
             }
-            let Ok(event) = serde_json::from_str::<serde_json::Value>(line) else {
+            let Some((text, consumed)) = read_new_complete_lines(&path, start.bytes).await else {
+                // No complete new line yet (partial flush) or unreadable —
+                // leave the cursor alone and retry on the next refresh.
                 continue;
             };
-            if let Some(candidate) =
-                codex_inference_request_ref(&bundle_dir, &event, line_idx as u64)
-            {
-                if thread_id
-                    .zip(candidate.thread_id.as_deref())
-                    .map(|(expected, actual)| expected != actual)
-                    .unwrap_or(false)
-                {
-                    continue;
+            let next_line =
+                fold_codex_trace_lines(&mut self.index, &bundle_dir, thread_id, &text, start.lines);
+            self.cursors.insert(
+                path,
+                CodexTraceFileCursor {
+                    bytes: start.bytes + consumed,
+                    lines: next_line,
+                },
+            );
+            appended = true;
+        }
+        if appended {
+            self.index.requests.sort_by(codex_request_order_cmp);
+        }
+        Ok(())
+    }
+
+    async fn stat_trace_files(
+        &mut self,
+        root: &Path,
+        thread_id: Option<&str>,
+    ) -> Result<Vec<(PathBuf, PathBuf, u64)>, CallerError> {
+        let bundle_dirs = self.collect_bundle_dirs(root, thread_id).await?;
+        let mut files = Vec::with_capacity(bundle_dirs.len());
+        for bundle_dir in bundle_dirs {
+            let path = bundle_dir.join("trace.jsonl");
+            let Ok(metadata) = tokio::fs::metadata(&path).await else {
+                continue;
+            };
+            files.push((bundle_dir, path, metadata.len()));
+        }
+        Ok(files)
+    }
+
+    /// Enumerate the archive's bundle dirs: the primary root fresh every
+    /// call (the live session's bundles land there), the cross-session
+    /// auxiliary sweep from cache unless the logs root's mtime moved.
+    async fn collect_bundle_dirs(
+        &mut self,
+        root: &Path,
+        thread_id: Option<&str>,
+    ) -> Result<Vec<PathBuf>, CallerError> {
+        let mut bundle_dirs = Vec::new();
+        let mut seen = HashSet::new();
+        collect_codex_bundle_dirs_in(root, thread_id, true, &mut bundle_dirs, &mut seen).await?;
+        if thread_id.is_some() {
+            if let Some(logs_root) = codex_logs_root_for_trace_root(root) {
+                let modified = tokio::fs::metadata(&logs_root)
+                    .await
+                    .ok()
+                    .and_then(|metadata| metadata.modified().ok());
+                let cached = self
+                    .aux_bundles
+                    .as_ref()
+                    .is_some_and(|aux| aux.logs_root == logs_root && aux.modified == modified);
+                if !cached {
+                    let aux_dirs =
+                        collect_codex_aux_bundle_dirs(&logs_root, root, thread_id).await?;
+                    self.aux_bundles = Some(CodexAuxBundleDirs {
+                        logs_root,
+                        modified,
+                        bundle_dirs: aux_dirs,
+                    });
                 }
-                requests_by_call.insert(codex_trace_call_key(&candidate), candidate.clone());
-                requests.push(candidate);
+                if let Some(aux) = self.aux_bundles.as_ref() {
+                    for bundle_dir in &aux.bundle_dirs {
+                        if seen.insert(bundle_dir.clone()) {
+                            bundle_dirs.push(bundle_dir.clone());
+                        }
+                    }
+                }
+            }
+        }
+        Ok(bundle_dirs)
+    }
+
+    /// Refresh, then snapshot ONLY the newest request (one chain resolution
+    /// instead of the historical resolve-all-R-then-`.last()`, which was
+    /// O(R²) file reads per call).
+    pub(crate) async fn latest_snapshot(
+        &mut self,
+        root: &Path,
+        thread_id: Option<&str>,
+    ) -> Result<CodexRequestPayloadSnapshot, CallerError> {
+        self.refresh(root, thread_id).await?;
+        let request_index = self.index.requests.len() as u64;
+        let Self {
+            index,
+            resolved_chain,
+            ..
+        } = self;
+        let Some(request_ref) = index.requests.last() else {
+            return Err(CallerError::ExternalAgent(format!(
+                "no Codex inference request payload found in {}",
+                root.display()
+            )));
+        };
+        codex_context_payload_snapshot(index, request_ref, request_index, resolved_chain).await
+    }
+
+    /// Refresh, then snapshot every request not in `seen_request_ids`, in
+    /// request order. Resolving in ascending order lets each new request
+    /// extend the previous one's cached chain, so a poll that finds k new
+    /// requests reads O(k) payload files instead of O(k · chain length).
+    pub(crate) async fn snapshots_excluding(
+        &mut self,
+        root: &Path,
+        thread_id: Option<&str>,
+        seen_request_ids: &HashSet<String>,
+    ) -> Result<Vec<CodexRequestPayloadSnapshot>, CallerError> {
+        self.refresh(root, thread_id).await?;
+        let Self {
+            index,
+            resolved_chain,
+            ..
+        } = self;
+        let mut snapshots = Vec::new();
+        for (idx, request_ref) in index.requests.iter().enumerate() {
+            if seen_request_ids.contains(&codex_request_id(request_ref)) {
                 continue;
             }
-            if let Some(response) = codex_inference_response_ref(&bundle_dir, &event) {
-                responses_by_id.insert(response.response_id.clone(), response);
+            snapshots.push(
+                codex_context_payload_snapshot(index, request_ref, idx as u64 + 1, resolved_chain)
+                    .await?,
+            );
+        }
+        Ok(snapshots)
+    }
+}
+
+/// Read the consumable lines appended to `path` past `offset`
+/// ([`consumable_jsonl_prefix`]). Returns the consumed text and its byte
+/// length; `None` when nothing consumable arrived (or the file cannot be
+/// read). Never consumes a partially flushed trailing line.
+async fn read_new_complete_lines(path: &Path, offset: u64) -> Option<(String, u64)> {
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+    let mut file = tokio::fs::File::open(path).await.ok()?;
+    if offset > 0 {
+        file.seek(std::io::SeekFrom::Start(offset)).await.ok()?;
+    }
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).await.ok()?;
+    let consumed = consumable_jsonl_prefix(&buf)?;
+    buf.truncate(consumed);
+    // Trace files are serde-written JSON and therefore valid UTF-8; on the
+    // pathological non-UTF-8 file the historical full scan skipped the whole
+    // file, and skipping without advancing the cursor lands in the same
+    // place.
+    let text = String::from_utf8(buf).ok()?;
+    Some((text, consumed as u64))
+}
+
+/// The byte length of the foldable JSONL prefix of `buf`: every complete
+/// (newline-terminated) line, plus an unterminated final line iff it already
+/// parses as a complete JSON value. Event lines are JSON objects and no
+/// strict prefix of a JSON object parses, so a parsing tail is a whole event
+/// whose newline just hasn't landed — or a writer that never terminates its
+/// final line, which the historical full re-scan accepted. `None` when
+/// nothing is consumable yet. (A sync twin lives in `lineage_ledger.rs` for
+/// the session-log fold.)
+fn consumable_jsonl_prefix(buf: &[u8]) -> Option<usize> {
+    let complete = buf
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map(|pos| pos + 1)
+        .unwrap_or(0);
+    let tail = &buf[complete..];
+    let consumed = if !tail.is_empty() && serde_json::from_slice::<serde_json::Value>(tail).is_ok()
+    {
+        buf.len()
+    } else {
+        complete
+    };
+    (consumed > 0).then_some(consumed)
+}
+
+/// Fold trace lines into the index — the one parse loop shared by full
+/// rebuilds (cursor at zero) and incremental tail reads. `first_line_idx`
+/// keeps `order.1` identical to what a from-scratch enumerate would assign.
+/// Returns the next line index.
+fn fold_codex_trace_lines(
+    index: &mut CodexTraceIndex,
+    bundle_dir: &Path,
+    thread_id: Option<&str>,
+    text: &str,
+    first_line_idx: u64,
+) -> u64 {
+    let mut line_idx = first_line_idx;
+    for line in text.lines() {
+        let this_idx = line_idx;
+        line_idx += 1;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(event) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if let Some(candidate) = codex_inference_request_ref(bundle_dir, &event, this_idx) {
+            if thread_id
+                .zip(candidate.thread_id.as_deref())
+                .map(|(expected, actual)| expected != actual)
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            index
+                .requests_by_call
+                .insert(codex_trace_call_key(&candidate), candidate.clone());
+            index.requests.push(candidate);
+            continue;
+        }
+        if let Some(response) = codex_inference_response_ref(bundle_dir, &event) {
+            index
+                .responses_by_id
+                .insert(response.response_id.clone(), response);
+        }
+    }
+    line_idx
+}
+
+/// Enumerate the bundle dirs directly under one trace root, honoring the
+/// thread-name filter. The `primary` root must be readable (its failure is
+/// the caller's error); auxiliary roots that fail to read are skipped,
+/// matching the historical full-scan behavior.
+async fn collect_codex_bundle_dirs_in(
+    trace_root: &Path,
+    thread_id: Option<&str>,
+    primary: bool,
+    bundle_dirs: &mut Vec<PathBuf>,
+    seen: &mut HashSet<PathBuf>,
+) -> Result<(), CallerError> {
+    let mut dirs = match tokio::fs::read_dir(trace_root).await {
+        Ok(dirs) => dirs,
+        Err(e) if primary => {
+            return Err(CallerError::ExternalAgent(format!(
+                "read Codex request trace root {}: {e}",
+                trace_root.display()
+            )));
+        }
+        Err(_) => return Ok(()),
+    };
+    while let Some(entry) = dirs
+        .next_entry()
+        .await
+        .map_err(|e| CallerError::ExternalAgent(format!("read Codex request trace entry: {e}")))?
+    {
+        let file_type = match entry.file_type().await {
+            Ok(file_type) => file_type,
+            Err(_) => continue,
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let bundle_dir = entry.path();
+        if let Some(thread_id) = thread_id {
+            let name = bundle_dir
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default();
+            if !name.contains(thread_id) {
+                continue;
+            }
+        }
+        if seen.insert(bundle_dir.clone()) {
+            bundle_dirs.push(bundle_dir);
+        }
+    }
+    Ok(())
+}
+
+/// Sweep every OTHER session's `model-request-traces` root under the logs
+/// root for bundle dirs matching the thread. Expensive against a large
+/// permanent history — callers cache the result behind the logs root's
+/// mtime ([`CodexAuxBundleDirs`]).
+async fn collect_codex_aux_bundle_dirs(
+    logs_root: &Path,
+    primary_root: &Path,
+    thread_id: Option<&str>,
+) -> Result<Vec<PathBuf>, CallerError> {
+    let mut trace_roots = Vec::new();
+    if let Ok(mut sessions) = tokio::fs::read_dir(logs_root).await {
+        while let Ok(Some(entry)) = sessions.next_entry().await {
+            let file_type = match entry.file_type().await {
+                Ok(file_type) => file_type,
+                Err(_) => continue,
+            };
+            if file_type.is_dir() {
+                let trace_root = entry.path().join("model-request-traces");
+                if trace_root != primary_root {
+                    trace_roots.push(trace_root);
+                }
             }
         }
     }
 
-    Ok(CodexTraceIndex {
-        requests,
-        requests_by_call,
-        responses_by_id,
-    })
+    let mut bundle_dirs = Vec::new();
+    let mut seen = HashSet::new();
+    for trace_root in trace_roots {
+        collect_codex_bundle_dirs_in(&trace_root, thread_id, false, &mut bundle_dirs, &mut seen)
+            .await?;
+    }
+    Ok(bundle_dirs)
 }
 
 pub(crate) fn read_codex_trace_index_sync(
@@ -700,98 +1100,6 @@ pub(crate) fn read_codex_trace_index_sync(
         requests_by_call,
         responses_by_id,
     })
-}
-
-pub(crate) async fn collect_codex_trace_bundle_dirs(
-    root: &Path,
-    thread_id: Option<&str>,
-) -> Result<Vec<PathBuf>, CallerError> {
-    let mut trace_roots = vec![root.to_path_buf()];
-    if thread_id.is_some() {
-        if let Some(logs_root) = codex_logs_root_for_trace_root(root) {
-            if let Ok(mut sessions) = tokio::fs::read_dir(&logs_root).await {
-                while let Ok(Some(entry)) = sessions.next_entry().await {
-                    let file_type = match entry.file_type().await {
-                        Ok(file_type) => file_type,
-                        Err(_) => continue,
-                    };
-                    if file_type.is_dir() {
-                        let trace_root = entry.path().join("model-request-traces");
-                        if trace_root != root {
-                            trace_roots.push(trace_root);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    let mut seen_roots = HashSet::new();
-    trace_roots.retain(|path| seen_roots.insert(path.clone()));
-
-    let mut bundle_dirs = Vec::new();
-    let mut seen_bundles = HashSet::new();
-    for trace_root in trace_roots {
-        let mut dirs = match tokio::fs::read_dir(&trace_root).await {
-            Ok(dirs) => dirs,
-            Err(e) if trace_root == root => {
-                return Err(CallerError::ExternalAgent(format!(
-                    "read Codex request trace root {}: {e}",
-                    root.display()
-                )));
-            }
-            Err(_) => continue,
-        };
-
-        while let Some(entry) = dirs.next_entry().await.map_err(|e| {
-            CallerError::ExternalAgent(format!("read Codex request trace entry: {e}"))
-        })? {
-            let file_type = match entry.file_type().await {
-                Ok(file_type) => file_type,
-                Err(_) => continue,
-            };
-            if !file_type.is_dir() {
-                continue;
-            }
-            let bundle_dir = entry.path();
-            if let Some(thread_id) = thread_id {
-                let name = bundle_dir
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .unwrap_or_default();
-                if !name.contains(thread_id) {
-                    continue;
-                }
-            }
-            if seen_bundles.insert(bundle_dir.clone()) {
-                bundle_dirs.push(bundle_dir);
-            }
-        }
-    }
-
-    Ok(bundle_dirs)
-}
-
-pub(crate) async fn codex_context_trace_fingerprint(
-    root: &Path,
-    thread_id: Option<&str>,
-) -> Result<CodexTraceFingerprint, CallerError> {
-    let bundle_dirs = collect_codex_trace_bundle_dirs(root, thread_id).await?;
-    let mut files = Vec::new();
-    for bundle_dir in bundle_dirs {
-        let path = bundle_dir.join("trace.jsonl");
-        let metadata = match tokio::fs::metadata(&path).await {
-            Ok(metadata) => metadata,
-            Err(_) => continue,
-        };
-        files.push(CodexTraceFileFingerprint {
-            path,
-            len: metadata.len(),
-            modified: metadata.modified().ok(),
-        });
-    }
-    files.sort_by(|a, b| a.path.cmp(&b.path));
-    Ok(CodexTraceFingerprint { files })
 }
 
 pub(crate) fn collect_codex_trace_bundle_dirs_sync(
@@ -868,59 +1176,119 @@ pub(crate) fn read_codex_json_payload_sync(
     serde_json::from_str::<serde_json::Value>(&contents).map_err(CallerError::Json)
 }
 
+/// Resolve the full conversation behind an `openai.responses` request by
+/// walking its `previous_response_id` chain — incrementally when
+/// `chain_cache` holds a previously resolved prefix (the chain is
+/// append-only, so only the new hops' payload files are read), from scratch
+/// otherwise. The cache is updated to this request's resolution.
+///
+/// NOTE: [`resolve_openai_responses_context_payload_sync`] below is the
+/// uncached twin for one-shot sync callers (session-catalog rehydration);
+/// changes to the chain-walk or payload-stamp semantics must land in both.
 pub(crate) async fn resolve_openai_responses_context_payload(
     index: &CodexTraceIndex,
     latest_ref: &CodexRequestPayloadRef,
     request_index: u64,
     latest_payload: serde_json::Value,
+    chain_cache: &mut Option<CodexResolvedChain>,
 ) -> Result<serde_json::Value, CallerError> {
-    let mut previous_pairs = Vec::new();
-    let mut unresolved_previous_response_id = None;
-    let mut seen_response_ids = HashSet::new();
-    let mut previous_response_id = codex_previous_response_id(&latest_payload).map(str::to_string);
+    let latest_call_key = codex_trace_call_key(latest_ref);
+    let cache_hit = chain_cache
+        .as_ref()
+        .is_some_and(|cached| cached.call_key == latest_call_key);
 
-    while let Some(response_id) = previous_response_id {
-        if !seen_response_ids.insert(response_id.clone()) {
-            unresolved_previous_response_id = Some(response_id);
-            break;
+    let (resolved_input, unresolved_previous_response_id) = if cache_hit {
+        // Unchanged latest request: reuse the cached resolution outright —
+        // no chain walk, no payload reads beyond the request itself.
+        let cached = chain_cache.as_ref().expect("cache hit just checked");
+        (
+            cached.resolved_input.clone(),
+            cached.unresolved_previous_response_id.clone(),
+        )
+    } else {
+        let mut previous_pairs = Vec::new();
+        let mut cached_prefix: Option<(Vec<serde_json::Value>, Option<String>)> = None;
+        let mut walk_unresolved = None;
+        let mut seen_response_ids = HashSet::new();
+        let mut previous_response_id =
+            codex_previous_response_id(&latest_payload).map(str::to_string);
+
+        while let Some(response_id) = previous_response_id {
+            if !seen_response_ids.insert(response_id.clone()) {
+                walk_unresolved = Some(response_id);
+                break;
+            }
+            let Some(response_ref) = index.responses_by_id.get(&response_id) else {
+                walk_unresolved = Some(response_id);
+                break;
+            };
+            let request_key = codex_trace_call_key_parts(
+                &response_ref.bundle_dir,
+                &response_ref.inference_call_id,
+            );
+            if !index.requests_by_call.contains_key(&request_key) {
+                walk_unresolved = Some(response_id);
+                break;
+            }
+            if let Some(cached) = chain_cache
+                .as_ref()
+                .filter(|cached| cached.call_key == request_key)
+            {
+                // Append-only chain: the cached resolution already contains
+                // everything up to and including this request's own input;
+                // only its response payload is new to this walk.
+                let response_payload =
+                    read_codex_json_payload(&response_ref.bundle_dir, &response_ref.relative_path)
+                        .await?;
+                let mut prefix = cached.resolved_input.clone();
+                codex_extend_array_field(&mut prefix, &response_payload, "output_items");
+                cached_prefix = Some((prefix, cached.unresolved_previous_response_id.clone()));
+                break;
+            }
+            let request_ref = index
+                .requests_by_call
+                .get(&request_key)
+                .expect("request ref presence just checked");
+            let request_payload =
+                read_codex_json_payload(&request_ref.bundle_dir, &request_ref.relative_path)
+                    .await?;
+            let response_payload =
+                read_codex_json_payload(&response_ref.bundle_dir, &response_ref.relative_path)
+                    .await?;
+            previous_response_id = codex_previous_response_id(&request_payload).map(str::to_string);
+            previous_pairs.push((request_payload, response_payload));
         }
-        let Some(response_ref) = index.responses_by_id.get(&response_id).cloned() else {
-            unresolved_previous_response_id = Some(response_id);
-            break;
-        };
-        let request_key =
-            codex_trace_call_key_parts(&response_ref.bundle_dir, &response_ref.inference_call_id);
-        let Some(request_ref) = index.requests_by_call.get(&request_key).cloned() else {
-            unresolved_previous_response_id = Some(response_id);
-            break;
-        };
-        let request_payload =
-            read_codex_json_payload(&request_ref.bundle_dir, &request_ref.relative_path).await?;
-        let response_payload =
-            read_codex_json_payload(&response_ref.bundle_dir, &response_ref.relative_path).await?;
-        previous_response_id = codex_previous_response_id(&request_payload).map(str::to_string);
-        previous_pairs.push((request_payload, response_payload));
-    }
 
-    previous_pairs.reverse();
+        previous_pairs.reverse();
+        let (mut resolved_input, unresolved) = match cached_prefix {
+            Some((prefix, inherited_unresolved)) => (prefix, inherited_unresolved),
+            None => (Vec::new(), walk_unresolved),
+        };
+        for (request_payload, response_payload) in previous_pairs {
+            codex_extend_array_field(&mut resolved_input, &request_payload, "input");
+            codex_extend_array_field(&mut resolved_input, &response_payload, "output_items");
+        }
+        codex_extend_array_field(&mut resolved_input, &latest_payload, "input");
 
-    let mut resolved_input = Vec::new();
-    for (request_payload, response_payload) in previous_pairs {
-        codex_extend_array_field(&mut resolved_input, &request_payload, "input");
-        codex_extend_array_field(&mut resolved_input, &response_payload, "output_items");
-    }
-    codex_extend_array_field(&mut resolved_input, &latest_payload, "input");
+        *chain_cache = Some(CodexResolvedChain {
+            call_key: latest_call_key,
+            resolved_input: resolved_input.clone(),
+            unresolved_previous_response_id: unresolved.clone(),
+        });
+        (resolved_input, unresolved)
+    };
 
     let latest_request_input_count = latest_payload
         .get("input")
         .and_then(|input| input.as_array())
         .map(Vec::len)
         .unwrap_or(0);
+    let resolved_input_count = resolved_input.len();
     let mut resolved_payload = latest_payload;
     if let serde_json::Value::Object(map) = &mut resolved_payload {
         map.insert(
             "input".to_string(),
-            serde_json::Value::Array(resolved_input.clone()),
+            serde_json::Value::Array(resolved_input),
         );
         map.insert(
             "_intendant_context".to_string(),
@@ -931,7 +1299,7 @@ pub(crate) async fn resolve_openai_responses_context_payload(
                 "request_index": request_index,
                 "inference_call_id": latest_ref.inference_call_id.clone(),
                 "latest_request_input_count": latest_request_input_count,
-                "resolved_input_count": resolved_input.len(),
+                "resolved_input_count": resolved_input_count,
                 "unresolved_previous_response_id": unresolved_previous_response_id,
             }),
         );
@@ -940,6 +1308,9 @@ pub(crate) async fn resolve_openai_responses_context_payload(
     Ok(resolved_payload)
 }
 
+/// Uncached sync twin of [`resolve_openai_responses_context_payload`], for
+/// one-shot callers (session-catalog trace rehydration). Chain-walk and
+/// payload-stamp changes must land in both.
 pub(crate) fn resolve_openai_responses_context_payload_sync(
     index: &CodexTraceIndex,
     latest_ref: &CodexRequestPayloadRef,
@@ -988,11 +1359,12 @@ pub(crate) fn resolve_openai_responses_context_payload_sync(
         .and_then(|input| input.as_array())
         .map(Vec::len)
         .unwrap_or(0);
+    let resolved_input_count = resolved_input.len();
     let mut resolved_payload = latest_payload;
     if let serde_json::Value::Object(map) = &mut resolved_payload {
         map.insert(
             "input".to_string(),
-            serde_json::Value::Array(resolved_input.clone()),
+            serde_json::Value::Array(resolved_input),
         );
         map.insert(
             "_intendant_context".to_string(),
@@ -1003,7 +1375,7 @@ pub(crate) fn resolve_openai_responses_context_payload_sync(
                 "request_index": request_index,
                 "inference_call_id": latest_ref.inference_call_id.clone(),
                 "latest_request_input_count": latest_request_input_count,
-                "resolved_input_count": resolved_input.len(),
+                "resolved_input_count": resolved_input_count,
                 "unresolved_previous_response_id": unresolved_previous_response_id,
             }),
         );
@@ -1903,6 +2275,271 @@ mod tests {
         assert!(snapshots
             .windows(2)
             .all(|pair| pair[0].request_id != pair[1].request_id));
+    }
+
+    fn write_trace_request_line(
+        trace: &Path,
+        ts: i64,
+        call_id: &str,
+        payload_rel: &str,
+        payload: &serde_json::Value,
+        previous_response_id: Option<&str>,
+    ) -> String {
+        std::fs::create_dir_all(trace.join("payloads")).unwrap();
+        let mut payload = payload.clone();
+        if let (Some(previous), Some(map)) = (previous_response_id, payload.as_object_mut()) {
+            map.insert(
+                "previous_response_id".to_string(),
+                serde_json::json!(previous),
+            );
+        }
+        std::fs::write(trace.join(payload_rel), payload.to_string()).unwrap();
+        serde_json::json!({
+            "schema_version": 1,
+            "wall_time_unix_ms": ts,
+            "payload": {
+                "type": "inference_started",
+                "provider_name": "OpenAI",
+                "thread_id": "thread-abc",
+                "inference_call_id": call_id,
+                "request_payload": {
+                    "kind": {"type": "inference_request"},
+                    "path": payload_rel
+                }
+            }
+        })
+        .to_string()
+    }
+
+    fn write_trace_response_line(
+        trace: &Path,
+        ts: i64,
+        call_id: &str,
+        response_id: &str,
+        payload_rel: &str,
+        output_text: &str,
+    ) -> String {
+        std::fs::create_dir_all(trace.join("payloads")).unwrap();
+        std::fs::write(
+            trace.join(payload_rel),
+            serde_json::json!({
+                "response_id": response_id,
+                "output_items": [
+                    {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": output_text}]}
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        serde_json::json!({
+            "schema_version": 1,
+            "wall_time_unix_ms": ts,
+            "payload": {
+                "type": "inference_completed",
+                "inference_call_id": call_id,
+                "response_id": response_id,
+                "response_payload": {
+                    "kind": {"type": "inference_response"},
+                    "path": payload_rel
+                }
+            }
+        })
+        .to_string()
+    }
+
+    fn user_request_payload(text: &str) -> serde_json::Value {
+        serde_json::json!({
+            "type": "response.create",
+            "model": "gpt-test",
+            "input": [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": text}]}
+            ]
+        })
+    }
+
+    #[tokio::test]
+    async fn trace_index_cache_folds_appends_and_rebuilds_on_truncation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace = tmp.path().join("trace-thread-abc");
+        let first = write_trace_request_line(
+            &trace,
+            10,
+            "inference:1",
+            "payloads/request-1.json",
+            &user_request_payload("first"),
+            None,
+        );
+        std::fs::write(trace.join("trace.jsonl"), format!("{first}\n")).unwrap();
+
+        let mut cache = CodexTraceIndexCache::default();
+        cache.refresh(tmp.path(), Some("thread-abc")).await.unwrap();
+        assert_eq!(cache.requests().len(), 1);
+
+        // Append: only the new line is folded; order stays sorted.
+        let second = write_trace_request_line(
+            &trace,
+            20,
+            "inference:2",
+            "payloads/request-2.json",
+            &user_request_payload("second"),
+            None,
+        );
+        let mut contents = std::fs::read_to_string(trace.join("trace.jsonl")).unwrap();
+        contents.push_str(&second);
+        contents.push('\n');
+        std::fs::write(trace.join("trace.jsonl"), &contents).unwrap();
+        cache.refresh(tmp.path(), Some("thread-abc")).await.unwrap();
+        assert_eq!(cache.requests().len(), 2);
+        assert_eq!(cache.requests()[0].inference_call_id, "inference:1");
+        assert_eq!(cache.requests()[1].inference_call_id, "inference:2");
+
+        // Idempotent when nothing changed.
+        cache.refresh(tmp.path(), Some("thread-abc")).await.unwrap();
+        assert_eq!(cache.requests().len(), 2);
+
+        // Truncation (trace rewrite) triggers a full rebuild.
+        std::fs::write(trace.join("trace.jsonl"), format!("{first}\n")).unwrap();
+        cache.refresh(tmp.path(), Some("thread-abc")).await.unwrap();
+        assert_eq!(cache.requests().len(), 1);
+        assert_eq!(cache.requests()[0].inference_call_id, "inference:1");
+    }
+
+    #[tokio::test]
+    async fn trace_index_cache_leaves_partial_trailing_line_for_next_refresh() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace = tmp.path().join("trace-thread-abc");
+        let first = write_trace_request_line(
+            &trace,
+            10,
+            "inference:1",
+            "payloads/request-1.json",
+            &user_request_payload("first"),
+            None,
+        );
+        let second = write_trace_request_line(
+            &trace,
+            20,
+            "inference:2",
+            "payloads/request-2.json",
+            &user_request_payload("second"),
+            None,
+        );
+        let (head, tail) = second.split_at(second.len() / 2);
+        std::fs::write(trace.join("trace.jsonl"), format!("{first}\n{head}")).unwrap();
+
+        let mut cache = CodexTraceIndexCache::default();
+        cache.refresh(tmp.path(), Some("thread-abc")).await.unwrap();
+        assert_eq!(cache.requests().len(), 1);
+
+        // Completing the flushed line folds it — once, with the right index.
+        std::fs::write(
+            trace.join("trace.jsonl"),
+            format!("{first}\n{head}{tail}\n"),
+        )
+        .unwrap();
+        cache.refresh(tmp.path(), Some("thread-abc")).await.unwrap();
+        assert_eq!(cache.requests().len(), 2);
+        assert_eq!(cache.requests()[1].inference_call_id, "inference:2");
+    }
+
+    #[tokio::test]
+    async fn resolved_chain_cache_extends_without_rereading_history() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace = tmp.path().join("trace-thread-abc");
+        let line1 = write_trace_request_line(
+            &trace,
+            10,
+            "inference:1",
+            "payloads/request-1.json",
+            &user_request_payload("first user message"),
+            None,
+        );
+        let line2 = write_trace_response_line(
+            &trace,
+            20,
+            "inference:1",
+            "resp_1",
+            "payloads/response-1.json",
+            "first assistant reply",
+        );
+        let line3 = write_trace_request_line(
+            &trace,
+            30,
+            "inference:2",
+            "payloads/request-2.json",
+            &user_request_payload("second user message"),
+            Some("resp_1"),
+        );
+        std::fs::write(
+            trace.join("trace.jsonl"),
+            format!("{line1}\n{line2}\n{line3}\n"),
+        )
+        .unwrap();
+
+        let mut cache = CodexTraceIndexCache::default();
+        let snapshot = cache
+            .latest_snapshot(tmp.path(), Some("thread-abc"))
+            .await
+            .unwrap();
+        assert_eq!(snapshot.request_index, 2);
+        assert_eq!(snapshot.payload["input"].as_array().unwrap().len(), 3);
+
+        // The chain is now cached: the historical payload files are no
+        // longer needed. Deleting them proves extension never re-reads them.
+        std::fs::remove_file(trace.join("payloads/request-1.json")).unwrap();
+        std::fs::remove_file(trace.join("payloads/response-1.json")).unwrap();
+
+        let line4 = write_trace_response_line(
+            &trace,
+            40,
+            "inference:2",
+            "resp_2",
+            "payloads/response-2.json",
+            "second assistant reply",
+        );
+        let line5 = write_trace_request_line(
+            &trace,
+            50,
+            "inference:3",
+            "payloads/request-3.json",
+            &user_request_payload("third user message"),
+            Some("resp_2"),
+        );
+        let mut contents = std::fs::read_to_string(trace.join("trace.jsonl")).unwrap();
+        contents.push_str(&format!("{line4}\n{line5}\n"));
+        std::fs::write(trace.join("trace.jsonl"), &contents).unwrap();
+
+        let snapshot = cache
+            .latest_snapshot(tmp.path(), Some("thread-abc"))
+            .await
+            .unwrap();
+        assert_eq!(snapshot.request_index, 3);
+        let rendered = serde_json::to_string(&snapshot.payload).unwrap();
+        assert!(rendered.contains("first user message"));
+        assert!(rendered.contains("first assistant reply"));
+        assert!(rendered.contains("second user message"));
+        assert!(rendered.contains("second assistant reply"));
+        assert!(rendered.contains("third user message"));
+        assert_eq!(snapshot.payload["input"].as_array().unwrap().len(), 5);
+        assert_eq!(
+            snapshot.payload["_intendant_context"]["resolved_input_count"],
+            serde_json::json!(5)
+        );
+        assert_eq!(
+            snapshot.payload["_intendant_context"]["unresolved_previous_response_id"],
+            serde_json::Value::Null
+        );
+
+        // Unchanged latest request: served from the cached resolution — even
+        // the immediately previous response payload is no longer read.
+        std::fs::remove_file(trace.join("payloads/request-2.json")).unwrap();
+        std::fs::remove_file(trace.join("payloads/response-2.json")).unwrap();
+        let snapshot = cache
+            .latest_snapshot(tmp.path(), Some("thread-abc"))
+            .await
+            .unwrap();
+        assert_eq!(snapshot.request_index, 3);
+        assert_eq!(snapshot.payload["input"].as_array().unwrap().len(), 5);
     }
 
     #[test]

--- a/src/bin/caller/external_agent/codex/context_trace.rs
+++ b/src/bin/caller/external_agent/codex/context_trace.rs
@@ -136,6 +136,7 @@ pub(crate) async fn codex_context_payload_snapshot(
     request_ref: &CodexRequestPayloadRef,
     request_index: u64,
     resolved_chain: &mut Option<CodexResolvedChain>,
+    index_generation: u64,
 ) -> Result<CodexRequestPayloadSnapshot, CallerError> {
     let payload =
         read_codex_json_payload(&request_ref.bundle_dir, &request_ref.relative_path).await?;
@@ -148,6 +149,7 @@ pub(crate) async fn codex_context_payload_snapshot(
             request_index,
             payload,
             resolved_chain,
+            index_generation,
         )
         .await?;
         return Ok(CodexRequestPayloadSnapshot {
@@ -245,15 +247,21 @@ pub(crate) fn codex_request_id(request: &CodexRequestPayloadRef) -> String {
     format!("codex-request-{hash:016x}")
 }
 
-pub(crate) fn stable_context_hash(bytes: &[u8]) -> u64 {
-    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
-    const FNV_PRIME: u64 = 0x100000001b3;
-    let mut hash = FNV_OFFSET;
+const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+const FNV_PRIME: u64 = 0x100000001b3;
+
+/// Extend a running FNV-1a hash with more bytes — the resumable form of
+/// [`stable_context_hash`], used by the trace cursor's head-window hash.
+fn fnv_extend(mut hash: u64, bytes: &[u8]) -> u64 {
     for byte in bytes {
         hash ^= u64::from(*byte);
         hash = hash.wrapping_mul(FNV_PRIME);
     }
     hash
+}
+
+pub(crate) fn stable_context_hash(bytes: &[u8]) -> u64 {
+    fnv_extend(FNV_OFFSET, bytes)
 }
 
 pub(crate) fn compact_context_text(text: &str, limit: usize) -> String {
@@ -613,6 +621,14 @@ pub(crate) fn codex_context_archive_payload(
 /// but its bytes at the cursor no longer match.
 const TRACE_CURSOR_TAIL_WINDOW: usize = 32;
 
+/// Bytes of the file HEAD hashed into the cursor and re-verified on every
+/// append read. The suffix window alone cannot prove consumed-prefix
+/// identity (trace lines end in the timestamp field, which an equal-length
+/// regrow can preserve); the head hash pins the leading content the same
+/// way the windowed-prefix-hash discipline does elsewhere in the repo. One
+/// extra ≤ 4 KiB read per changed-file refresh.
+const TRACE_CURSOR_HEAD_WINDOW: u64 = 4096;
+
 /// Byte/line cursor into one `trace.jsonl`: how much of the file has already
 /// been folded into the cached index, plus the evidence used to detect
 /// rewrites. The contract:
@@ -622,13 +638,14 @@ const TRACE_CURSOR_TAIL_WINDOW: usize = 32;
 ///   refresh.
 /// - A rewrite is detected (and triggers a full rebuild) when the file
 ///   shrinks below `bytes`, when its length equals `bytes` but its mtime is
-///   not `modified`, or when the [`TRACE_CURSOR_TAIL_WINDOW`] bytes before
-///   the cursor no longer equal `tail` on an append read. The residual
-///   blind spot is a rewrite that preserves the window's bytes at the
-///   cursor (and, when it does not grow the file, its length and mtime
-///   too); earlier content covered by neither check can change undetected —
-///   best-effort hardening for a writer that is append-only by contract.
-#[derive(Debug, Default, Clone)]
+///   not `modified`, or when — on an append read — either the
+///   [`TRACE_CURSOR_TAIL_WINDOW`] bytes before the cursor no longer equal
+///   `tail` or the first [`TRACE_CURSOR_HEAD_WINDOW`]-capped bytes no longer
+///   hash to `head_hash`. The residual blind spot shrinks to a rewrite that
+///   preserves length + mtime + the first 4 KiB + the last 32 bytes before
+///   the cursor — best-effort hardening for a writer that is append-only by
+///   contract.
+#[derive(Debug, Clone)]
 struct CodexTraceFileCursor {
     bytes: u64,
     lines: u64,
@@ -637,11 +654,31 @@ struct CodexTraceFileCursor {
     modified: Option<SystemTime>,
     /// The last ≤ [`TRACE_CURSOR_TAIL_WINDOW`] consumed bytes.
     tail: Vec<u8>,
+    /// Running FNV hash of the first `head_len` consumed bytes.
+    head_hash: u64,
+    /// How many leading bytes `head_hash` covers:
+    /// `min(bytes, TRACE_CURSOR_HEAD_WINDOW)`. Grows with the cursor until
+    /// the window is full, then stays fixed.
+    head_len: u64,
     /// True when the consumed region ended without a newline (a valid
     /// unterminated JSON tail was folded as one line). The next read then
     /// swallows exactly one leading newline without counting a line, keeping
     /// line indices identical to a from-scratch enumerate.
     mid_line: bool,
+}
+
+impl Default for CodexTraceFileCursor {
+    fn default() -> Self {
+        Self {
+            bytes: 0,
+            lines: 0,
+            modified: None,
+            tail: Vec::new(),
+            head_hash: FNV_OFFSET,
+            head_len: 0,
+            mid_line: false,
+        }
+    }
 }
 
 /// One other-session trace root in the auxiliary sweep: its directory mtime
@@ -656,18 +693,45 @@ struct CodexAuxTraceRoot {
     bundle_dirs: Vec<PathBuf>,
 }
 
+/// How often the known auxiliary roots are stat-probed for change. One stat
+/// per historical session dir per probe is cheap, but at the 1 Hz
+/// fingerprint cadence a large history still meant hundreds of stats per
+/// second — so probes run on this coarser cadence, with an immediate probe
+/// whenever the logs root's mtime moves (new session dirs stay promptly
+/// discovered). Aux bundle discovery latency is bounded by this interval;
+/// aux roots are PAST sessions, so nothing on the live path waits on it.
+const AUX_ROOT_PROBE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Cross-session auxiliary trace roots (other sessions' dirs under the logs
 /// root), cached so the exact-archive fingerprint tick doesn't re-enumerate
 /// every historical session directory at 1 Hz. The ROOT LIST re-sweeps when
 /// the logs root's mtime moves (session dirs are created/removed directly
-/// under it); each known root is then stat-probed per collect and
-/// re-enumerated only on change ([`CodexAuxTraceRoot`]). Bundles for the
-/// LIVE session land under the primary root, which is always enumerated
-/// fresh.
+/// under it); each known root is then stat-probed on the
+/// [`AUX_ROOT_PROBE_INTERVAL`] cadence (immediately after a root-list
+/// re-sweep) and re-enumerated only on change ([`CodexAuxTraceRoot`]).
+/// Bundles for the LIVE session land under the primary root, which is
+/// always enumerated fresh.
 struct CodexAuxBundleDirs {
     logs_root: PathBuf,
     modified: Option<SystemTime>,
     roots: Vec<CodexAuxTraceRoot>,
+    /// Monotonic instant of the last per-root probe pass.
+    last_probe: Option<std::time::Instant>,
+}
+
+/// Whether the per-root stat probe pass is due.
+fn aux_probe_due(
+    last_probe: Option<std::time::Instant>,
+    root_list_rebuilt: bool,
+    now: std::time::Instant,
+) -> bool {
+    if root_list_rebuilt {
+        return true;
+    }
+    match last_probe {
+        None => true,
+        Some(last) => now.duration_since(last) >= AUX_ROOT_PROBE_INTERVAL,
+    }
 }
 
 /// Resolved `previous_response_id` chain for the most recently resolved
@@ -685,6 +749,11 @@ pub(crate) struct CodexResolvedChain {
     /// prefix. A cached entry with an unresolved tail is only served while
     /// that tail is STILL unresolvable ([`codex_resolved_chain_current`]).
     unresolved_previous_response_id: Option<String>,
+    /// Index generation this resolution was built against; when the index
+    /// has not changed since, even an unresolved tail cannot have become
+    /// resolvable — a cycle-truncated chain (whose repeated id is resolvable
+    /// by construction) is then served instead of re-walked per snapshot.
+    generation: u64,
 }
 
 /// Incrementally maintained view of a Codex trace archive for one
@@ -698,6 +767,9 @@ pub(crate) struct CodexTraceIndexCache {
     key: Option<(PathBuf, Option<String>)>,
     cursors: HashMap<PathBuf, CodexTraceFileCursor>,
     index: CodexTraceIndex,
+    /// Bumped whenever the index content changes (fold or rebuild); gates
+    /// [`CodexResolvedChain`] currency for unresolved tails.
+    generation: u64,
     aux_bundles: Option<CodexAuxBundleDirs>,
     resolved_chain: Option<CodexResolvedChain>,
 }
@@ -755,6 +827,7 @@ impl CodexTraceIndexCache {
     fn clear_folded_state(&mut self) {
         self.cursors.clear();
         self.index = CodexTraceIndex::default();
+        self.generation = self.generation.wrapping_add(1);
         self.aux_bundles = None;
         self.resolved_chain = None;
     }
@@ -811,6 +884,7 @@ impl CodexTraceIndexCache {
                         text,
                         consumed,
                         tail,
+                        head_extension,
                         ends_mid_line,
                     } => {
                         let next_line = fold_codex_trace_lines(
@@ -820,6 +894,7 @@ impl CodexTraceIndexCache {
                             &text,
                             start.lines,
                         );
+                        let head_hash = fnv_extend(start.head_hash, &head_extension);
                         self.cursors.insert(
                             path,
                             CodexTraceFileCursor {
@@ -827,6 +902,8 @@ impl CodexTraceIndexCache {
                                 lines: next_line,
                                 modified,
                                 tail,
+                                head_hash,
+                                head_len: start.head_len + head_extension.len() as u64,
                                 mid_line: ends_mid_line,
                             },
                         );
@@ -848,6 +925,7 @@ impl CodexTraceIndexCache {
             }
             if appended {
                 self.index.requests.sort_by(codex_request_order_cmp);
+                self.generation = self.generation.wrapping_add(1);
             }
             return Ok(());
         }
@@ -940,31 +1018,39 @@ impl CodexTraceIndexCache {
                 logs_root,
                 modified: logs_modified,
                 roots,
+                last_probe: None,
             });
         }
 
         if let Some(aux) = self.aux_bundles.as_mut() {
-            for aux_root in aux.roots.iter_mut() {
-                // One stat per known root: absent stays absent cheaply; a
-                // trace root (or bundle inside it) created after the sweep
-                // moves the mtime and re-enumerates just that root.
-                let modified = tokio::fs::metadata(&aux_root.trace_root)
-                    .await
-                    .ok()
-                    .and_then(|metadata| metadata.modified().ok());
-                if modified != aux_root.modified {
-                    aux_root.bundle_dirs.clear();
-                    let mut root_seen = HashSet::new();
-                    collect_codex_bundle_dirs_in(
-                        &aux_root.trace_root,
-                        Some(thread_id_present),
-                        false,
-                        &mut aux_root.bundle_dirs,
-                        &mut root_seen,
-                    )
-                    .await?;
-                    aux_root.modified = modified;
+            let now = std::time::Instant::now();
+            if aux_probe_due(aux.last_probe, !root_list_current, now) {
+                for aux_root in aux.roots.iter_mut() {
+                    // One stat per known root: absent stays absent cheaply;
+                    // a trace root (or bundle inside it) created after the
+                    // sweep moves the mtime and re-enumerates just that
+                    // root.
+                    let modified = tokio::fs::metadata(&aux_root.trace_root)
+                        .await
+                        .ok()
+                        .and_then(|metadata| metadata.modified().ok());
+                    if modified != aux_root.modified {
+                        aux_root.bundle_dirs.clear();
+                        let mut root_seen = HashSet::new();
+                        collect_codex_bundle_dirs_in(
+                            &aux_root.trace_root,
+                            Some(thread_id_present),
+                            false,
+                            &mut aux_root.bundle_dirs,
+                            &mut root_seen,
+                        )
+                        .await?;
+                        aux_root.modified = modified;
+                    }
                 }
+                aux.last_probe = Some(now);
+            }
+            for aux_root in &aux.roots {
                 for bundle_dir in &aux_root.bundle_dirs {
                     if seen.insert(bundle_dir.clone()) {
                         bundle_dirs.push(bundle_dir.clone());
@@ -988,6 +1074,7 @@ impl CodexTraceIndexCache {
         let Self {
             index,
             resolved_chain,
+            generation,
             ..
         } = self;
         let Some(request_ref) = index.requests.last() else {
@@ -996,7 +1083,14 @@ impl CodexTraceIndexCache {
                 root.display()
             )));
         };
-        codex_context_payload_snapshot(index, request_ref, request_index, resolved_chain).await
+        codex_context_payload_snapshot(
+            index,
+            request_ref,
+            request_index,
+            resolved_chain,
+            *generation,
+        )
+        .await
     }
 
     /// Refresh, then snapshot every request not in `seen_request_ids`, in
@@ -1013,6 +1107,7 @@ impl CodexTraceIndexCache {
         let Self {
             index,
             resolved_chain,
+            generation,
             ..
         } = self;
         let mut snapshots = Vec::new();
@@ -1021,8 +1116,14 @@ impl CodexTraceIndexCache {
                 continue;
             }
             snapshots.push(
-                codex_context_payload_snapshot(index, request_ref, idx as u64 + 1, resolved_chain)
-                    .await?,
+                codex_context_payload_snapshot(
+                    index,
+                    request_ref,
+                    idx as u64 + 1,
+                    resolved_chain,
+                    *generation,
+                )
+                .await?,
             );
         }
         Ok(snapshots)
@@ -1032,12 +1133,14 @@ impl CodexTraceIndexCache {
 /// Outcome of one append read against a cursor.
 enum TraceTailRead {
     /// New consumable content: the text to fold, the bytes consumed past the
-    /// cursor, the new trailing verification window, and whether the region
-    /// ended without a newline.
+    /// cursor, the new trailing verification window, the consumed bytes that
+    /// extend the head-window hash, and whether the region ended without a
+    /// newline.
     Appended {
         text: String,
         consumed: u64,
         tail: Vec<u8>,
+        head_extension: Vec<u8>,
         ends_mid_line: bool,
     },
     /// Nothing consumable yet (partial flush, unreadable, or a non-UTF-8
@@ -1045,15 +1148,16 @@ enum TraceTailRead {
     /// skipped a non-UTF-8 file wholesale; not advancing lands in the same
     /// place.
     Pending,
-    /// The bytes before the cursor no longer match — the file was rewritten
-    /// (recreated shorter and regrown past the cursor between polls).
+    /// The bytes already consumed no longer match the cursor's evidence
+    /// (head-window hash or pre-cursor tail window) — the file was rewritten
+    /// (e.g. recreated shorter and regrown past the cursor between polls).
     Rewritten,
 }
 
 /// Read the consumable content appended to `path` past `cursor`, verifying
-/// the cursor's trailing window first and clamping the read to the caller's
-/// stat snapshot (`stat_len`) so the recorded mtime stays paired with the
-/// consumed length.
+/// the cursor's head-window hash and trailing window first, and clamping
+/// the read to the caller's stat snapshot (`stat_len`) so the recorded
+/// mtime stays paired with the consumed length.
 async fn read_trace_tail(
     path: &Path,
     cursor: &CodexTraceFileCursor,
@@ -1066,7 +1170,30 @@ async fn read_trace_tail(
         return TraceTailRead::Pending;
     };
     let mut file = file;
-    if seek_to > 0 && file.seek(std::io::SeekFrom::Start(seek_to)).await.is_err() {
+
+    // Head window: the first `head_len` bytes must still hash to the
+    // cursor's value — the suffix window alone cannot prove prefix identity
+    // (trace lines end in the timestamp field, which an equal-length regrow
+    // can preserve).
+    if cursor.head_len > 0 {
+        let mut head = Vec::with_capacity(cursor.head_len as usize);
+        if (&mut file)
+            .take(cursor.head_len)
+            .read_to_end(&mut head)
+            .await
+            .is_err()
+        {
+            return TraceTailRead::Pending;
+        }
+        if (head.len() as u64) < cursor.head_len {
+            return TraceTailRead::Rewritten;
+        }
+        if fnv_extend(FNV_OFFSET, &head) != cursor.head_hash {
+            return TraceTailRead::Rewritten;
+        }
+    }
+
+    if file.seek(std::io::SeekFrom::Start(seek_to)).await.is_err() {
         return TraceTailRead::Pending;
     }
     let mut buf = Vec::new();
@@ -1107,10 +1234,17 @@ async fn read_trace_tail(
     };
     let consumed_in_buf = overlap + skipped_newline + consumed_new;
     let window_start = consumed_in_buf.saturating_sub(TRACE_CURSOR_TAIL_WINDOW);
+    // Consumed bytes that extend the head-window hash: contiguous from the
+    // cursor while coverage is below TRACE_CURSOR_HEAD_WINDOW, empty once
+    // the window is full.
+    let head_room = TRACE_CURSOR_HEAD_WINDOW.saturating_sub(cursor.head_len) as usize;
+    let extension_bytes = &buf[overlap..consumed_in_buf];
+    let head_extension = extension_bytes[..extension_bytes.len().min(head_room)].to_vec();
     TraceTailRead::Appended {
         text: text.to_string(),
         consumed: (skipped_newline + consumed_new) as u64,
         tail: buf[window_start..consumed_in_buf].to_vec(),
+        head_extension,
         ends_mid_line,
     }
 }
@@ -1234,13 +1368,21 @@ async fn collect_codex_bundle_dirs_in(
 }
 
 /// True when the cached resolved chain may serve resolutions against the
-/// current index: it is complete, or its unresolved tail is STILL
+/// current index: it is complete; or the index has not changed since it was
+/// built (nothing new could have resolved its tail — which also keeps a
+/// cycle-truncated chain, whose repeated id is resolvable by construction,
+/// from re-walking on every snapshot); or its unresolved tail is STILL
 /// unresolvable. A tail that became resolvable (the response/request events
 /// arrived after the cache was built) must not be served — the caller
-/// re-walks so the newly available history is included. A cycle-truncated
-/// chain keeps re-walking (its repeated id is resolvable by construction);
-/// cycles only occur in corrupt traces and the walk stays cycle-bounded.
-fn codex_resolved_chain_current(index: &CodexTraceIndex, cached: &CodexResolvedChain) -> bool {
+/// re-walks so the newly available history is included.
+fn codex_resolved_chain_current(
+    index: &CodexTraceIndex,
+    cached: &CodexResolvedChain,
+    generation: u64,
+) -> bool {
+    if cached.generation == generation {
+        return true;
+    }
     match cached.unresolved_previous_response_id.as_deref() {
         None => true,
         Some(response_id) => match index.responses_by_id.get(response_id) {
@@ -1396,10 +1538,12 @@ pub(crate) async fn resolve_openai_responses_context_payload(
     request_index: u64,
     latest_payload: serde_json::Value,
     chain_cache: &mut Option<CodexResolvedChain>,
+    index_generation: u64,
 ) -> Result<serde_json::Value, CallerError> {
     let latest_call_key = codex_trace_call_key(latest_ref);
     let cache_hit = chain_cache.as_ref().is_some_and(|cached| {
-        cached.call_key == latest_call_key && codex_resolved_chain_current(index, cached)
+        cached.call_key == latest_call_key
+            && codex_resolved_chain_current(index, cached, index_generation)
     });
 
     let (resolved_input, unresolved_previous_response_id) = if cache_hit {
@@ -1436,7 +1580,8 @@ pub(crate) async fn resolve_openai_responses_context_payload(
                 break;
             }
             if let Some(cached) = chain_cache.as_ref().filter(|cached| {
-                cached.call_key == request_key && codex_resolved_chain_current(index, cached)
+                cached.call_key == request_key
+                    && codex_resolved_chain_current(index, cached, index_generation)
             }) {
                 // Append-only chain: the cached resolution already contains
                 // everything up to and including this request's own input;
@@ -1478,6 +1623,7 @@ pub(crate) async fn resolve_openai_responses_context_payload(
             call_key: latest_call_key,
             resolved_input: resolved_input.clone(),
             unresolved_previous_response_id: unresolved.clone(),
+            generation: index_generation,
         });
         (resolved_input, unresolved)
     };
@@ -2745,6 +2891,81 @@ mod tests {
         assert_eq!(call_ids, vec!["inference:b", "inference:c"]);
     }
 
+    #[test]
+    fn aux_probe_cadence_decision() {
+        let base = std::time::Instant::now();
+        // A rebuilt root list probes immediately, whatever the clock says.
+        assert!(aux_probe_due(Some(base), true, base));
+        // No probe yet: due.
+        assert!(aux_probe_due(None, false, base));
+        // Within the interval: throttled.
+        assert!(!aux_probe_due(
+            Some(base),
+            false,
+            base + AUX_ROOT_PROBE_INTERVAL / 2
+        ));
+        // At/after the interval: due again.
+        assert!(aux_probe_due(
+            Some(base),
+            false,
+            base + AUX_ROOT_PROBE_INTERVAL
+        ));
+    }
+
+    #[tokio::test]
+    async fn trace_index_cache_head_hash_detects_prefix_rewrite_with_identical_suffix() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace = tmp.path().join("trace-thread-abc");
+        let line_a = write_trace_request_line(
+            &trace,
+            10,
+            "inference:a",
+            "payloads/request-a.json",
+            &user_request_payload("first"),
+            None,
+        );
+        // Same length AND same timestamp: serde_json's alphabetical key
+        // order puts `wall_time_unix_ms` last, so the suffix tail window is
+        // byte-identical — only the head hash can catch this rewrite.
+        let line_b = write_trace_request_line(
+            &trace,
+            10,
+            "inference:b",
+            "payloads/request-b.json",
+            &user_request_payload("first"),
+            None,
+        );
+        assert_eq!(line_a.len(), line_b.len());
+        assert_eq!(
+            &line_a.as_bytes()[line_a.len() - TRACE_CURSOR_TAIL_WINDOW..],
+            &line_b.as_bytes()[line_b.len() - TRACE_CURSOR_TAIL_WINDOW..],
+            "test premise: suffix window identical"
+        );
+        let line_c = write_trace_request_line(
+            &trace,
+            20,
+            "inference:c",
+            "payloads/request-c.json",
+            &user_request_payload("second"),
+            None,
+        );
+        let trace_path = trace.join("trace.jsonl");
+        std::fs::write(&trace_path, format!("{line_a}\n")).unwrap();
+
+        let mut cache = CodexTraceIndexCache::default();
+        cache.refresh(tmp.path(), Some("thread-abc")).await.unwrap();
+        assert_eq!(cache.requests()[0].inference_call_id, "inference:a");
+
+        std::fs::write(&trace_path, format!("{line_b}\n{line_c}\n")).unwrap();
+        cache.refresh(tmp.path(), Some("thread-abc")).await.unwrap();
+        let call_ids: Vec<&str> = cache
+            .requests()
+            .iter()
+            .map(|request| request.inference_call_id.as_str())
+            .collect();
+        assert_eq!(call_ids, vec!["inference:b", "inference:c"]);
+    }
+
     #[tokio::test]
     async fn aux_root_probe_discovers_bundle_created_after_sweep() {
         let logs = tempfile::tempdir().unwrap();
@@ -2786,6 +3007,11 @@ mod tests {
         );
         std::fs::write(old_bundle.join("trace.jsonl"), format!("{old_line}\n")).unwrap();
 
+        // The per-root probe runs on the AUX_ROOT_PROBE_INTERVAL cadence;
+        // force it due rather than sleeping the interval out.
+        if let Some(aux) = cache.aux_bundles.as_mut() {
+            aux.last_probe = None;
+        }
         cache.refresh(&primary, Some("thread-abc")).await.unwrap();
         let call_ids: Vec<&str> = cache
             .requests()

--- a/src/bin/caller/external_agent/codex/context_trace.rs
+++ b/src/bin/caller/external_agent/codex/context_trace.rs
@@ -204,7 +204,13 @@ pub(crate) fn codex_context_payload_snapshot_sync(
 
 /// Total order over request refs: trace timestamp, then line index, with the
 /// stable path/call-id tie-breaks. Comparator form (no per-comparison String
-/// allocations — the old tuple sort key allocated three per call).
+/// allocations — the old tuple sort key allocated three per call). Note
+/// `Path::cmp` compares component-wise, which can order exotic paths
+/// differently than the old lossy-string byte-wise key; the tie-break only
+/// needs a deterministic total order, which both provide. Line indices from
+/// incremental folds match a from-scratch enumerate except for a bounded +1
+/// drift when a `\r\n` writer's final line was consumed before its line
+/// ending arrived.
 pub(crate) fn codex_request_order_cmp(
     a: &CodexRequestPayloadRef,
     b: &CodexRequestPayloadRef,
@@ -601,28 +607,67 @@ pub(crate) fn codex_context_archive_payload(
 // Incremental trace-index cache
 // ---------------------------------------------------------------------------
 
+/// Bytes of already-consumed content re-read and verified on every append
+/// read ([`read_trace_tail`]): a file that was recreated shorter and regrew
+/// past the cursor between polls presents as pure growth to (len, mtime),
+/// but its bytes at the cursor no longer match.
+const TRACE_CURSOR_TAIL_WINDOW: usize = 32;
+
 /// Byte/line cursor into one `trace.jsonl`: how much of the file has already
-/// been folded into the cached index. `bytes` only ever advances past
-/// COMPLETE lines — a trailing partial line the writer is still flushing is
-/// left for the next refresh, exactly like the historical full re-scan
-/// picked it up once complete.
-#[derive(Debug, Default, Clone, Copy)]
+/// been folded into the cached index, plus the evidence used to detect
+/// rewrites. The contract:
+/// - `bytes` only ever advances past consumable content
+///   ([`consumable_jsonl_prefix`] — complete lines, or a valid-JSON
+///   unterminated final line); a partially flushed tail is left for the next
+///   refresh.
+/// - A rewrite is detected (and triggers a full rebuild) when the file
+///   shrinks below `bytes`, when its length equals `bytes` but its mtime is
+///   not `modified`, or when the [`TRACE_CURSOR_TAIL_WINDOW`] bytes before
+///   the cursor no longer equal `tail` on an append read. The residual
+///   blind spot is a rewrite that preserves the window's bytes at the
+///   cursor (and, when it does not grow the file, its length and mtime
+///   too); earlier content covered by neither check can change undetected —
+///   best-effort hardening for a writer that is append-only by contract.
+#[derive(Debug, Default, Clone)]
 struct CodexTraceFileCursor {
     bytes: u64,
     lines: u64,
+    /// File mtime paired with `bytes` at the last fold (reads are clamped to
+    /// the stat snapshot, so the pair is consistent).
+    modified: Option<SystemTime>,
+    /// The last ≤ [`TRACE_CURSOR_TAIL_WINDOW`] consumed bytes.
+    tail: Vec<u8>,
+    /// True when the consumed region ended without a newline (a valid
+    /// unterminated JSON tail was folded as one line). The next read then
+    /// swallows exactly one leading newline without counting a line, keeping
+    /// line indices identical to a from-scratch enumerate.
+    mid_line: bool,
 }
 
-/// Cross-session auxiliary bundle dirs (other sessions' trace roots whose
-/// bundle names match the thread), cached against the logs root's directory
-/// mtime so the exact-archive fingerprint tick doesn't re-enumerate every
-/// historical session directory at 1 Hz. Session dirs are created and
-/// removed directly under the logs root, so those events bump its mtime and
-/// invalidate the sweep; bundles for the LIVE session land under the primary
-/// root, which is always enumerated fresh.
+/// One other-session trace root in the auxiliary sweep: its directory mtime
+/// at the last enumeration (`None` = absent) and the thread-matching bundle
+/// dirs found inside. Re-validated with one stat per collect and
+/// re-enumerated only when the mtime moves — so a `model-request-traces`
+/// dir (or a bundle inside one) created after the sweep is still discovered
+/// without re-walking the whole logs root.
+struct CodexAuxTraceRoot {
+    trace_root: PathBuf,
+    modified: Option<SystemTime>,
+    bundle_dirs: Vec<PathBuf>,
+}
+
+/// Cross-session auxiliary trace roots (other sessions' dirs under the logs
+/// root), cached so the exact-archive fingerprint tick doesn't re-enumerate
+/// every historical session directory at 1 Hz. The ROOT LIST re-sweeps when
+/// the logs root's mtime moves (session dirs are created/removed directly
+/// under it); each known root is then stat-probed per collect and
+/// re-enumerated only on change ([`CodexAuxTraceRoot`]). Bundles for the
+/// LIVE session land under the primary root, which is always enumerated
+/// fresh.
 struct CodexAuxBundleDirs {
     logs_root: PathBuf,
     modified: Option<SystemTime>,
-    bundle_dirs: Vec<PathBuf>,
+    roots: Vec<CodexAuxTraceRoot>,
 }
 
 /// Resolved `previous_response_id` chain for the most recently resolved
@@ -637,17 +682,17 @@ pub(crate) struct CodexResolvedChain {
     /// pair plus the cached request's own input items.
     resolved_input: Vec<serde_json::Value>,
     /// Unresolved-tail marker inherited by any resolution built on this
-    /// prefix.
+    /// prefix. A cached entry with an unresolved tail is only served while
+    /// that tail is STILL unresolvable ([`codex_resolved_chain_current`]).
     unresolved_previous_response_id: Option<String>,
 }
 
 /// Incrementally maintained view of a Codex trace archive for one
 /// `(trace root, thread)`: parsed request/response refs plus the resolved
 /// chain of the newest request. A refresh stats the known `trace.jsonl`
-/// files and parses only appended lines; a shrunk or vanished file (trace
-/// rewrite, temporary-root cleanup) triggers a full rebuild — the safe
-/// fallback. Same-length in-place rewrites are undetectable here, the same
-/// blind spot the (len, mtime) fingerprint gate has always had.
+/// files and parses only appended lines; any detected rewrite (see
+/// [`CodexTraceFileCursor`]) or vanished file (temporary-root cleanup)
+/// triggers a full rebuild — the safe fallback.
 #[derive(Default)]
 pub(crate) struct CodexTraceIndexCache {
     key: Option<(PathBuf, Option<String>)>,
@@ -707,61 +752,107 @@ impl CodexTraceIndexCache {
         Ok(CodexTraceFingerprint { files })
     }
 
+    fn clear_folded_state(&mut self) {
+        self.cursors.clear();
+        self.index = CodexTraceIndex::default();
+        self.aux_bundles = None;
+        self.resolved_chain = None;
+    }
+
     /// Bring the cached index up to date with the archive: stat every
-    /// bundle's `trace.jsonl`, tail-read files that grew, rebuild from
-    /// scratch if any known file shrank or vanished.
+    /// bundle's `trace.jsonl`, tail-read files that grew, and rebuild from
+    /// scratch on any detected rewrite ([`CodexTraceFileCursor`]) or
+    /// vanished file.
     pub(crate) async fn refresh(
         &mut self,
         root: &Path,
         thread_id: Option<&str>,
     ) -> Result<(), CallerError> {
         self.reset_for_key(root, thread_id);
-        let mut files = self.stat_trace_files(root, thread_id).await?;
+        // At most two passes: the first may detect a rewrite and clear the
+        // folded state; the second folds everything from zero (empty cursors
+        // cannot be stale or overlap-mismatch again).
+        for _attempt in 0..2 {
+            let files = self.stat_trace_files(root, thread_id).await?;
 
-        // A shrunk or vanished file means lines already folded into the
-        // index can no longer be attributed; drop everything and rescan.
-        let lens: HashMap<&Path, u64> = files
-            .iter()
-            .map(|(_, path, len)| (path.as_path(), *len))
-            .collect();
-        let stale = self.cursors.iter().any(|(path, cursor)| {
-            lens.get(path.as_path())
-                .map_or(cursor.bytes > 0, |len| *len < cursor.bytes)
-        });
-        drop(lens);
-        if stale {
-            self.cursors.clear();
-            self.index = CodexTraceIndex::default();
-            self.aux_bundles = None;
-            self.resolved_chain = None;
-            files = self.stat_trace_files(root, thread_id).await?;
-        }
-
-        let mut appended = false;
-        for (bundle_dir, path, len) in files {
-            let start = self.cursors.get(&path).copied().unwrap_or_default();
-            if len == start.bytes {
+            // Rewrite/vanish detection against the stat snapshot: content
+            // already folded into the index can no longer be attributed.
+            let stats: HashMap<&Path, (u64, Option<SystemTime>)> = files
+                .iter()
+                .map(|(_, path, len, modified)| (path.as_path(), (*len, *modified)))
+                .collect();
+            let stale = self.cursors.iter().any(|(path, cursor)| {
+                if cursor.bytes == 0 {
+                    return false;
+                }
+                match stats.get(path.as_path()) {
+                    None => true,
+                    Some((len, modified)) => {
+                        *len < cursor.bytes
+                            || (*len == cursor.bytes && *modified != cursor.modified)
+                    }
+                }
+            });
+            drop(stats);
+            if stale {
+                self.clear_folded_state();
                 continue;
             }
-            let Some((text, consumed)) = read_new_complete_lines(&path, start.bytes).await else {
-                // No complete new line yet (partial flush) or unreadable —
-                // leave the cursor alone and retry on the next refresh.
+
+            let mut appended = false;
+            let mut rewritten = false;
+            for (bundle_dir, path, len, modified) in files {
+                let start = self.cursors.get(&path).cloned().unwrap_or_default();
+                if len <= start.bytes {
+                    continue;
+                }
+                match read_trace_tail(&path, &start, len).await {
+                    TraceTailRead::Appended {
+                        text,
+                        consumed,
+                        tail,
+                        ends_mid_line,
+                    } => {
+                        let next_line = fold_codex_trace_lines(
+                            &mut self.index,
+                            &bundle_dir,
+                            thread_id,
+                            &text,
+                            start.lines,
+                        );
+                        self.cursors.insert(
+                            path,
+                            CodexTraceFileCursor {
+                                bytes: start.bytes + consumed,
+                                lines: next_line,
+                                modified,
+                                tail,
+                                mid_line: ends_mid_line,
+                            },
+                        );
+                        appended = true;
+                    }
+                    TraceTailRead::Pending => {
+                        // No consumable new content yet (partial flush) or
+                        // unreadable — keep the cursor and retry next poll.
+                    }
+                    TraceTailRead::Rewritten => {
+                        rewritten = true;
+                        break;
+                    }
+                }
+            }
+            if rewritten {
+                self.clear_folded_state();
                 continue;
-            };
-            let next_line =
-                fold_codex_trace_lines(&mut self.index, &bundle_dir, thread_id, &text, start.lines);
-            self.cursors.insert(
-                path,
-                CodexTraceFileCursor {
-                    bytes: start.bytes + consumed,
-                    lines: next_line,
-                },
-            );
-            appended = true;
+            }
+            if appended {
+                self.index.requests.sort_by(codex_request_order_cmp);
+            }
+            return Ok(());
         }
-        if appended {
-            self.index.requests.sort_by(codex_request_order_cmp);
-        }
+        // Both passes bailed — only possible under an actively concurrent
+        // rewriter; the folded state is cleared and the next poll settles.
         Ok(())
     }
 
@@ -769,7 +860,7 @@ impl CodexTraceIndexCache {
         &mut self,
         root: &Path,
         thread_id: Option<&str>,
-    ) -> Result<Vec<(PathBuf, PathBuf, u64)>, CallerError> {
+    ) -> Result<Vec<(PathBuf, PathBuf, u64, Option<SystemTime>)>, CallerError> {
         let bundle_dirs = self.collect_bundle_dirs(root, thread_id).await?;
         let mut files = Vec::with_capacity(bundle_dirs.len());
         for bundle_dir in bundle_dirs {
@@ -777,14 +868,16 @@ impl CodexTraceIndexCache {
             let Ok(metadata) = tokio::fs::metadata(&path).await else {
                 continue;
             };
-            files.push((bundle_dir, path, metadata.len()));
+            let modified = metadata.modified().ok();
+            files.push((bundle_dir, path, metadata.len(), modified));
         }
         Ok(files)
     }
 
     /// Enumerate the archive's bundle dirs: the primary root fresh every
-    /// call (the live session's bundles land there), the cross-session
-    /// auxiliary sweep from cache unless the logs root's mtime moved.
+    /// call (the live session's bundles land there); auxiliary roots from
+    /// the cached sweep, each re-validated with one stat and re-enumerated
+    /// only when its own mtime moved ([`CodexAuxBundleDirs`]).
     async fn collect_bundle_dirs(
         &mut self,
         root: &Path,
@@ -793,30 +886,88 @@ impl CodexTraceIndexCache {
         let mut bundle_dirs = Vec::new();
         let mut seen = HashSet::new();
         collect_codex_bundle_dirs_in(root, thread_id, true, &mut bundle_dirs, &mut seen).await?;
-        if thread_id.is_some() {
-            if let Some(logs_root) = codex_logs_root_for_trace_root(root) {
-                let modified = tokio::fs::metadata(&logs_root)
+        let Some(thread_id_present) = thread_id else {
+            return Ok(bundle_dirs);
+        };
+        let Some(logs_root) = codex_logs_root_for_trace_root(root) else {
+            return Ok(bundle_dirs);
+        };
+
+        let logs_modified = tokio::fs::metadata(&logs_root)
+            .await
+            .ok()
+            .and_then(|metadata| metadata.modified().ok());
+        let root_list_current = self
+            .aux_bundles
+            .as_ref()
+            .is_some_and(|aux| aux.logs_root == logs_root && aux.modified == logs_modified);
+        if !root_list_current {
+            // Session dirs changed (or first sweep): rebuild the ROOT LIST,
+            // carrying over per-root state so unchanged roots keep their
+            // enumeration.
+            let mut previous: HashMap<PathBuf, CodexAuxTraceRoot> = self
+                .aux_bundles
+                .take()
+                .map(|aux| {
+                    aux.roots
+                        .into_iter()
+                        .map(|root| (root.trace_root.clone(), root))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let mut roots = Vec::new();
+            if let Ok(mut sessions) = tokio::fs::read_dir(&logs_root).await {
+                while let Ok(Some(entry)) = sessions.next_entry().await {
+                    let file_type = match entry.file_type().await {
+                        Ok(file_type) => file_type,
+                        Err(_) => continue,
+                    };
+                    if !file_type.is_dir() {
+                        continue;
+                    }
+                    let trace_root = entry.path().join("model-request-traces");
+                    if trace_root == root {
+                        continue;
+                    }
+                    roots.push(previous.remove(&trace_root).unwrap_or(CodexAuxTraceRoot {
+                        trace_root,
+                        modified: None,
+                        bundle_dirs: Vec::new(),
+                    }));
+                }
+            }
+            self.aux_bundles = Some(CodexAuxBundleDirs {
+                logs_root,
+                modified: logs_modified,
+                roots,
+            });
+        }
+
+        if let Some(aux) = self.aux_bundles.as_mut() {
+            for aux_root in aux.roots.iter_mut() {
+                // One stat per known root: absent stays absent cheaply; a
+                // trace root (or bundle inside it) created after the sweep
+                // moves the mtime and re-enumerates just that root.
+                let modified = tokio::fs::metadata(&aux_root.trace_root)
                     .await
                     .ok()
                     .and_then(|metadata| metadata.modified().ok());
-                let cached = self
-                    .aux_bundles
-                    .as_ref()
-                    .is_some_and(|aux| aux.logs_root == logs_root && aux.modified == modified);
-                if !cached {
-                    let aux_dirs =
-                        collect_codex_aux_bundle_dirs(&logs_root, root, thread_id).await?;
-                    self.aux_bundles = Some(CodexAuxBundleDirs {
-                        logs_root,
-                        modified,
-                        bundle_dirs: aux_dirs,
-                    });
+                if modified != aux_root.modified {
+                    aux_root.bundle_dirs.clear();
+                    let mut root_seen = HashSet::new();
+                    collect_codex_bundle_dirs_in(
+                        &aux_root.trace_root,
+                        Some(thread_id_present),
+                        false,
+                        &mut aux_root.bundle_dirs,
+                        &mut root_seen,
+                    )
+                    .await?;
+                    aux_root.modified = modified;
                 }
-                if let Some(aux) = self.aux_bundles.as_ref() {
-                    for bundle_dir in &aux.bundle_dirs {
-                        if seen.insert(bundle_dir.clone()) {
-                            bundle_dirs.push(bundle_dir.clone());
-                        }
+                for bundle_dir in &aux_root.bundle_dirs {
+                    if seen.insert(bundle_dir.clone()) {
+                        bundle_dirs.push(bundle_dir.clone());
                     }
                 }
             }
@@ -878,26 +1029,90 @@ impl CodexTraceIndexCache {
     }
 }
 
-/// Read the consumable lines appended to `path` past `offset`
-/// ([`consumable_jsonl_prefix`]). Returns the consumed text and its byte
-/// length; `None` when nothing consumable arrived (or the file cannot be
-/// read). Never consumes a partially flushed trailing line.
-async fn read_new_complete_lines(path: &Path, offset: u64) -> Option<(String, u64)> {
+/// Outcome of one append read against a cursor.
+enum TraceTailRead {
+    /// New consumable content: the text to fold, the bytes consumed past the
+    /// cursor, the new trailing verification window, and whether the region
+    /// ended without a newline.
+    Appended {
+        text: String,
+        consumed: u64,
+        tail: Vec<u8>,
+        ends_mid_line: bool,
+    },
+    /// Nothing consumable yet (partial flush, unreadable, or a non-UTF-8
+    /// tail): keep the cursor and retry next poll. The historical full scan
+    /// skipped a non-UTF-8 file wholesale; not advancing lands in the same
+    /// place.
+    Pending,
+    /// The bytes before the cursor no longer match — the file was rewritten
+    /// (recreated shorter and regrown past the cursor between polls).
+    Rewritten,
+}
+
+/// Read the consumable content appended to `path` past `cursor`, verifying
+/// the cursor's trailing window first and clamping the read to the caller's
+/// stat snapshot (`stat_len`) so the recorded mtime stays paired with the
+/// consumed length.
+async fn read_trace_tail(
+    path: &Path,
+    cursor: &CodexTraceFileCursor,
+    stat_len: u64,
+) -> TraceTailRead {
     use tokio::io::{AsyncReadExt, AsyncSeekExt};
-    let mut file = tokio::fs::File::open(path).await.ok()?;
-    if offset > 0 {
-        file.seek(std::io::SeekFrom::Start(offset)).await.ok()?;
+    let overlap = cursor.tail.len();
+    let seek_to = cursor.bytes - overlap as u64;
+    let Ok(file) = tokio::fs::File::open(path).await else {
+        return TraceTailRead::Pending;
+    };
+    let mut file = file;
+    if seek_to > 0 && file.seek(std::io::SeekFrom::Start(seek_to)).await.is_err() {
+        return TraceTailRead::Pending;
     }
     let mut buf = Vec::new();
-    file.read_to_end(&mut buf).await.ok()?;
-    let consumed = consumable_jsonl_prefix(&buf)?;
-    buf.truncate(consumed);
-    // Trace files are serde-written JSON and therefore valid UTF-8; on the
-    // pathological non-UTF-8 file the historical full scan skipped the whole
-    // file, and skipping without advancing the cursor lands in the same
-    // place.
-    let text = String::from_utf8(buf).ok()?;
-    Some((text, consumed as u64))
+    if (&mut file)
+        .take(stat_len - seek_to)
+        .read_to_end(&mut buf)
+        .await
+        .is_err()
+    {
+        return TraceTailRead::Pending;
+    }
+    if buf.len() < overlap {
+        return TraceTailRead::Rewritten;
+    }
+    if buf[..overlap] != cursor.tail[..] {
+        return TraceTailRead::Rewritten;
+    }
+
+    let mut new = &buf[overlap..];
+    // A previously consumed unterminated JSON tail was folded as one
+    // complete line; when its newline finally lands, swallow it without
+    // counting a line so order indices match a from-scratch enumerate.
+    let mut skipped_newline = 0usize;
+    if cursor.mid_line {
+        if let Some((b'\n', rest)) = new.split_first() {
+            new = rest;
+            skipped_newline = 1;
+        }
+    }
+    let consumed_new = consumable_jsonl_prefix(new).unwrap_or(0);
+    if consumed_new == 0 && skipped_newline == 0 {
+        return TraceTailRead::Pending;
+    }
+    let region = &new[..consumed_new];
+    let ends_mid_line = consumed_new > 0 && region.last() != Some(&b'\n');
+    let Ok(text) = std::str::from_utf8(region) else {
+        return TraceTailRead::Pending;
+    };
+    let consumed_in_buf = overlap + skipped_newline + consumed_new;
+    let window_start = consumed_in_buf.saturating_sub(TRACE_CURSOR_TAIL_WINDOW);
+    TraceTailRead::Appended {
+        text: text.to_string(),
+        consumed: (skipped_newline + consumed_new) as u64,
+        tail: buf[window_start..consumed_in_buf].to_vec(),
+        ends_mid_line,
+    }
 }
 
 /// The byte length of the foldable JSONL prefix of `buf`: every complete
@@ -1018,38 +1233,28 @@ async fn collect_codex_bundle_dirs_in(
     Ok(())
 }
 
-/// Sweep every OTHER session's `model-request-traces` root under the logs
-/// root for bundle dirs matching the thread. Expensive against a large
-/// permanent history — callers cache the result behind the logs root's
-/// mtime ([`CodexAuxBundleDirs`]).
-async fn collect_codex_aux_bundle_dirs(
-    logs_root: &Path,
-    primary_root: &Path,
-    thread_id: Option<&str>,
-) -> Result<Vec<PathBuf>, CallerError> {
-    let mut trace_roots = Vec::new();
-    if let Ok(mut sessions) = tokio::fs::read_dir(logs_root).await {
-        while let Ok(Some(entry)) = sessions.next_entry().await {
-            let file_type = match entry.file_type().await {
-                Ok(file_type) => file_type,
-                Err(_) => continue,
-            };
-            if file_type.is_dir() {
-                let trace_root = entry.path().join("model-request-traces");
-                if trace_root != primary_root {
-                    trace_roots.push(trace_root);
-                }
+/// True when the cached resolved chain may serve resolutions against the
+/// current index: it is complete, or its unresolved tail is STILL
+/// unresolvable. A tail that became resolvable (the response/request events
+/// arrived after the cache was built) must not be served — the caller
+/// re-walks so the newly available history is included. A cycle-truncated
+/// chain keeps re-walking (its repeated id is resolvable by construction);
+/// cycles only occur in corrupt traces and the walk stays cycle-bounded.
+fn codex_resolved_chain_current(index: &CodexTraceIndex, cached: &CodexResolvedChain) -> bool {
+    match cached.unresolved_previous_response_id.as_deref() {
+        None => true,
+        Some(response_id) => match index.responses_by_id.get(response_id) {
+            None => true,
+            Some(response_ref) => {
+                !index
+                    .requests_by_call
+                    .contains_key(&codex_trace_call_key_parts(
+                        &response_ref.bundle_dir,
+                        &response_ref.inference_call_id,
+                    ))
             }
-        }
+        },
     }
-
-    let mut bundle_dirs = Vec::new();
-    let mut seen = HashSet::new();
-    for trace_root in trace_roots {
-        collect_codex_bundle_dirs_in(&trace_root, thread_id, false, &mut bundle_dirs, &mut seen)
-            .await?;
-    }
-    Ok(bundle_dirs)
 }
 
 pub(crate) fn read_codex_trace_index_sync(
@@ -1193,9 +1398,9 @@ pub(crate) async fn resolve_openai_responses_context_payload(
     chain_cache: &mut Option<CodexResolvedChain>,
 ) -> Result<serde_json::Value, CallerError> {
     let latest_call_key = codex_trace_call_key(latest_ref);
-    let cache_hit = chain_cache
-        .as_ref()
-        .is_some_and(|cached| cached.call_key == latest_call_key);
+    let cache_hit = chain_cache.as_ref().is_some_and(|cached| {
+        cached.call_key == latest_call_key && codex_resolved_chain_current(index, cached)
+    });
 
     let (resolved_input, unresolved_previous_response_id) = if cache_hit {
         // Unchanged latest request: reuse the cached resolution outright —
@@ -1230,10 +1435,9 @@ pub(crate) async fn resolve_openai_responses_context_payload(
                 walk_unresolved = Some(response_id);
                 break;
             }
-            if let Some(cached) = chain_cache
-                .as_ref()
-                .filter(|cached| cached.call_key == request_key)
-            {
+            if let Some(cached) = chain_cache.as_ref().filter(|cached| {
+                cached.call_key == request_key && codex_resolved_chain_current(index, cached)
+            }) {
                 // Append-only chain: the cached resolution already contains
                 // everything up to and including this request's own input;
                 // only its response payload is new to this walk.
@@ -2440,6 +2644,257 @@ mod tests {
         cache.refresh(tmp.path(), Some("thread-abc")).await.unwrap();
         assert_eq!(cache.requests().len(), 2);
         assert_eq!(cache.requests()[1].inference_call_id, "inference:2");
+    }
+
+    fn set_mtime(path: &Path, secs_since_epoch: u64) {
+        let file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        file.set_modified(std::time::UNIX_EPOCH + std::time::Duration::from_secs(secs_since_epoch))
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn trace_index_cache_rebuilds_on_same_length_rewrite() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace = tmp.path().join("trace-thread-abc");
+        let line_a = write_trace_request_line(
+            &trace,
+            10,
+            "inference:a",
+            "payloads/request-a.json",
+            &user_request_payload("first"),
+            None,
+        );
+        let line_b = write_trace_request_line(
+            &trace,
+            10,
+            "inference:b",
+            "payloads/request-b.json",
+            &user_request_payload("first"),
+            None,
+        );
+        assert_eq!(line_a.len(), line_b.len(), "test needs equal-length lines");
+        let trace_path = trace.join("trace.jsonl");
+        std::fs::write(&trace_path, format!("{line_a}\n")).unwrap();
+        set_mtime(&trace_path, 1_000);
+
+        let mut cache = CodexTraceIndexCache::default();
+        cache.refresh(tmp.path(), Some("thread-abc")).await.unwrap();
+        assert_eq!(cache.requests().len(), 1);
+        assert_eq!(cache.requests()[0].inference_call_id, "inference:a");
+
+        // Same length, different content, different mtime: an in-place
+        // rewrite the pure (len >= cursor) model would swallow forever.
+        std::fs::write(&trace_path, format!("{line_b}\n")).unwrap();
+        set_mtime(&trace_path, 2_000);
+        cache.refresh(tmp.path(), Some("thread-abc")).await.unwrap();
+        assert_eq!(cache.requests().len(), 1);
+        assert_eq!(cache.requests()[0].inference_call_id, "inference:b");
+    }
+
+    #[tokio::test]
+    async fn trace_index_cache_detects_regrown_rewrite_via_tail_window() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace = tmp.path().join("trace-thread-abc");
+        let line_a = write_trace_request_line(
+            &trace,
+            10,
+            "inference:a",
+            "payloads/request-a.json",
+            &user_request_payload("first"),
+            None,
+        );
+        // Same length as line_a but a different timestamp: serde_json
+        // serializes keys alphabetically, so `wall_time_unix_ms` is the
+        // line's trailing field — the difference lands inside the cursor's
+        // tail window, which is what the window verifies.
+        let line_b = write_trace_request_line(
+            &trace,
+            15,
+            "inference:b",
+            "payloads/request-b.json",
+            &user_request_payload("first"),
+            None,
+        );
+        let line_c = write_trace_request_line(
+            &trace,
+            20,
+            "inference:c",
+            "payloads/request-c.json",
+            &user_request_payload("second"),
+            None,
+        );
+        let trace_path = trace.join("trace.jsonl");
+        std::fs::write(&trace_path, format!("{line_a}\n")).unwrap();
+        set_mtime(&trace_path, 1_000);
+
+        let mut cache = CodexTraceIndexCache::default();
+        cache.refresh(tmp.path(), Some("thread-abc")).await.unwrap();
+        assert_eq!(cache.requests()[0].inference_call_id, "inference:a");
+
+        // Recreated with different content and regrown PAST the old cursor
+        // between polls: (len, mtime) alone reads as a pure append, but the
+        // bytes at the cursor no longer match the cursor's tail window.
+        std::fs::write(&trace_path, format!("{line_b}\n{line_c}\n")).unwrap();
+        set_mtime(&trace_path, 2_000);
+        cache.refresh(tmp.path(), Some("thread-abc")).await.unwrap();
+        let call_ids: Vec<&str> = cache
+            .requests()
+            .iter()
+            .map(|request| request.inference_call_id.as_str())
+            .collect();
+        assert_eq!(call_ids, vec!["inference:b", "inference:c"]);
+    }
+
+    #[tokio::test]
+    async fn aux_root_probe_discovers_bundle_created_after_sweep() {
+        let logs = tempfile::tempdir().unwrap();
+        let primary = logs
+            .path()
+            .join("session-current")
+            .join("model-request-traces");
+        std::fs::create_dir_all(&primary).unwrap();
+        let bundle = primary.join("trace-thread-abc");
+        let line = write_trace_request_line(
+            &bundle,
+            10,
+            "inference:1",
+            "payloads/request-1.json",
+            &user_request_payload("current"),
+            None,
+        );
+        std::fs::write(bundle.join("trace.jsonl"), format!("{line}\n")).unwrap();
+        // Another session dir exists but has no traces yet.
+        let old_session = logs.path().join("session-old");
+        std::fs::create_dir_all(&old_session).unwrap();
+
+        let mut cache = CodexTraceIndexCache::default();
+        cache.refresh(&primary, Some("thread-abc")).await.unwrap();
+        assert_eq!(cache.requests().len(), 1);
+
+        // The old session gains a matching bundle WITHOUT any change to the
+        // logs root's own entry list — the per-root probe must find it.
+        let old_bundle = old_session
+            .join("model-request-traces")
+            .join("trace-thread-abc");
+        let old_line = write_trace_request_line(
+            &old_bundle,
+            5,
+            "inference:0",
+            "payloads/request-0.json",
+            &user_request_payload("earlier"),
+            None,
+        );
+        std::fs::write(old_bundle.join("trace.jsonl"), format!("{old_line}\n")).unwrap();
+
+        cache.refresh(&primary, Some("thread-abc")).await.unwrap();
+        let call_ids: Vec<&str> = cache
+            .requests()
+            .iter()
+            .map(|request| request.inference_call_id.as_str())
+            .collect();
+        assert_eq!(call_ids, vec!["inference:0", "inference:1"]);
+    }
+
+    #[tokio::test]
+    async fn chain_cache_retries_once_unresolved_tail_becomes_resolvable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace = tmp.path().join("trace-thread-abc");
+        let line1 = write_trace_request_line(
+            &trace,
+            10,
+            "inference:1",
+            "payloads/request-1.json",
+            &user_request_payload("first user message"),
+            None,
+        );
+        let line2 = write_trace_request_line(
+            &trace,
+            30,
+            "inference:2",
+            "payloads/request-2.json",
+            &user_request_payload("second user message"),
+            Some("resp_1"),
+        );
+        // The response completion event for resp_1 has not landed yet.
+        std::fs::write(trace.join("trace.jsonl"), format!("{line1}\n{line2}\n")).unwrap();
+
+        let mut cache = CodexTraceIndexCache::default();
+        let snapshot = cache
+            .latest_snapshot(tmp.path(), Some("thread-abc"))
+            .await
+            .unwrap();
+        assert_eq!(snapshot.payload["input"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            snapshot.payload["_intendant_context"]["unresolved_previous_response_id"],
+            serde_json::json!("resp_1")
+        );
+
+        // The completion event (and payload) arrive: the cached partial
+        // chain must not be served — the tail is resolvable now.
+        let response_line = write_trace_response_line(
+            &trace,
+            20,
+            "inference:1",
+            "resp_1",
+            "payloads/response-1.json",
+            "first assistant reply",
+        );
+        let mut contents = std::fs::read_to_string(trace.join("trace.jsonl")).unwrap();
+        contents.push_str(&format!("{response_line}\n"));
+        std::fs::write(trace.join("trace.jsonl"), &contents).unwrap();
+
+        let snapshot = cache
+            .latest_snapshot(tmp.path(), Some("thread-abc"))
+            .await
+            .unwrap();
+        assert_eq!(snapshot.payload["input"].as_array().unwrap().len(), 3);
+        assert_eq!(
+            snapshot.payload["_intendant_context"]["unresolved_previous_response_id"],
+            serde_json::Value::Null
+        );
+        let rendered = serde_json::to_string(&snapshot.payload).unwrap();
+        assert!(rendered.contains("first user message"));
+        assert!(rendered.contains("first assistant reply"));
+    }
+
+    #[tokio::test]
+    async fn consumed_unterminated_tail_keeps_line_indices_aligned() {
+        let tmp = tempfile::tempdir().unwrap();
+        let trace = tmp.path().join("trace-thread-abc");
+        let line_a = write_trace_request_line(
+            &trace,
+            10,
+            "inference:a",
+            "payloads/request-a.json",
+            &user_request_payload("first"),
+            None,
+        );
+        let line_b = write_trace_request_line(
+            &trace,
+            10,
+            "inference:b",
+            "payloads/request-b.json",
+            &user_request_payload("second"),
+            None,
+        );
+        // Valid-JSON unterminated tail: consumed as line 0.
+        std::fs::write(trace.join("trace.jsonl"), &line_a).unwrap();
+        let mut cache = CodexTraceIndexCache::default();
+        cache.refresh(tmp.path(), Some("thread-abc")).await.unwrap();
+        assert_eq!(cache.requests()[0].order, (10, 0));
+
+        // The newline lands together with the next line. A from-scratch
+        // enumerate gives line_b index 1; the incremental fold must swallow
+        // the deferred newline without counting a line. Identical
+        // timestamps make the assertion bite through the sort tie-break.
+        let mut contents = std::fs::read_to_string(trace.join("trace.jsonl")).unwrap();
+        contents.push_str(&format!("\n{line_b}\n"));
+        std::fs::write(trace.join("trace.jsonl"), &contents).unwrap();
+        cache.refresh(tmp.path(), Some("thread-abc")).await.unwrap();
+        assert_eq!(cache.requests().len(), 2);
+        assert_eq!(cache.requests()[0].inference_call_id, "inference:a");
+        assert_eq!(cache.requests()[1].inference_call_id, "inference:b");
+        assert_eq!(cache.requests()[1].order, (10, 1));
     }
 
     #[tokio::test]

--- a/src/bin/caller/external_agent/codex/mod.rs
+++ b/src/bin/caller/external_agent/codex/mod.rs
@@ -214,6 +214,9 @@ pub struct CodexAgent {
     context_archive: String,
     context_seen_request_ids: HashSet<String>,
     context_trace_fingerprint: Option<CodexTraceFingerprint>,
+    /// Incrementally maintained trace index + resolved-chain cache; spares
+    /// the per-turn context snapshots from re-reading the whole archive.
+    context_trace_cache: CodexTraceIndexCache,
     child: Option<Child>,
     writer: Option<SharedCodexWriter>,
     event_tx: Option<mpsc::UnboundedSender<AgentEvent>>,
@@ -522,17 +525,17 @@ impl CodexAgent {
         let Some(root) = self.request_trace_root.clone() else {
             return Ok(0);
         };
-        let index = read_codex_trace_index(&root, thread_id).await?;
+        self.context_trace_cache.refresh(&root, thread_id).await?;
         let mut inserted = 0usize;
-        for request in index.requests {
+        for request in self.context_trace_cache.requests() {
             if self
                 .context_seen_request_ids
-                .insert(codex_request_id(&request))
+                .insert(codex_request_id(request))
             {
                 inserted += 1;
             }
         }
-        if let Ok(fingerprint) = codex_context_trace_fingerprint(&root, thread_id).await {
+        if let Ok(fingerprint) = self.context_trace_cache.fingerprint(&root, thread_id).await {
             self.context_trace_fingerprint = Some(fingerprint);
         }
         Ok(inserted)
@@ -717,6 +720,7 @@ impl CodexAgent {
             context_archive: "summary".to_string(),
             context_seen_request_ids: HashSet::new(),
             context_trace_fingerprint: None,
+            context_trace_cache: CodexTraceIndexCache::default(),
             child: None,
             writer: None,
             event_tx: None,
@@ -881,13 +885,16 @@ impl CodexAgent {
     }
 
     async fn read_context_snapshot(&mut self) -> Result<AgentContextSnapshot, CallerError> {
-        let root = self.request_trace_root.as_deref().ok_or_else(|| {
+        let root = self.request_trace_root.clone().ok_or_else(|| {
             CallerError::ExternalAgent(
                 "Codex request payload tracing was not configured".to_string(),
             )
         })?;
         let thread_id = self.active_thread_id.lock().await.clone();
-        let trace = read_latest_codex_context_payload(root, thread_id.as_deref()).await?;
+        let trace = self
+            .context_trace_cache
+            .latest_snapshot(&root, thread_id.as_deref())
+            .await?;
         let rollout_path = match thread_id.as_deref() {
             Some(thread_id) => self
                 .read_thread_snapshot(thread_id)
@@ -1211,6 +1218,7 @@ impl ExternalAgent for CodexAgent {
             crate::project::normalize_codex_context_archive(&config.context_archive);
         self.context_seen_request_ids.clear();
         self.context_trace_fingerprint = None;
+        self.context_trace_cache = CodexTraceIndexCache::default();
         self.mcp_auth_token = config.mcp_auth_token;
         self.mcp_session_id = config.mcp_session_id;
         self.resume_session = config.resume_session;
@@ -1531,7 +1539,11 @@ impl ExternalAgent for CodexAgent {
             return Ok(Vec::new());
         };
         let thread_id = self.active_thread_id.lock().await.clone();
-        let fingerprint = match codex_context_trace_fingerprint(&root, thread_id.as_deref()).await {
+        let fingerprint = match self
+            .context_trace_cache
+            .fingerprint(&root, thread_id.as_deref())
+            .await
+        {
             Ok(fingerprint) => fingerprint,
             Err(err) if codex_context_snapshot_not_ready(&err) => return Ok(Vec::new()),
             Err(err) => return Err(err),
@@ -1539,12 +1551,10 @@ impl ExternalAgent for CodexAgent {
         if self.context_trace_fingerprint.as_ref() == Some(&fingerprint) {
             return Ok(Vec::new());
         }
-        let traces = match read_codex_context_payloads_excluding(
-            &root,
-            thread_id.as_deref(),
-            &self.context_seen_request_ids,
-        )
-        .await
+        let traces = match self
+            .context_trace_cache
+            .snapshots_excluding(&root, thread_id.as_deref(), &self.context_seen_request_ids)
+            .await
         {
             Ok(traces) => traces,
             Err(err) if codex_context_snapshot_not_ready(&err) => return Ok(Vec::new()),

--- a/src/bin/caller/external_agent/codex/reader.rs
+++ b/src/bin/caller/external_agent/codex/reader.rs
@@ -25,7 +25,7 @@ pub(crate) async fn reader_task(
 ) {
     let reader = BufReader::new(stdout);
     let mut lines = reader.lines();
-    let mut terminal_turns_observed: HashSet<String> = HashSet::new();
+    let mut terminal_turns_observed = CodexTerminalObserved::default();
     let mut notification_state = CodexNotificationState::default();
 
     loop {
@@ -59,12 +59,14 @@ pub(crate) async fn reader_task(
             }
         };
 
-        let line = line.trim().to_string();
+        // Borrow the trimmed view — re-allocating the line (including
+        // multi-hundred-KB aggregatedOutput payloads) doubled every read.
+        let line = line.trim();
         if line.is_empty() {
             continue;
         }
 
-        let raw: serde_json::Value = match serde_json::from_str(&line) {
+        let raw: serde_json::Value = match serde_json::from_str(line) {
             Ok(value) => value,
             Err(e) => {
                 if let Some(watch) = protocol_watch.as_ref() {
@@ -91,9 +93,12 @@ pub(crate) async fn reader_task(
                 });
             }
         }
-        let msg: JsonRpcMessage = match serde_json::from_value(raw) {
-            Ok(message) => message,
-            Err(_) => {
+        // Second pass of the settled two-pass protocol-watch design: extract
+        // the five envelope fields directly instead of round-tripping the
+        // whole parsed tree through serde again (O(fields), not O(tree)).
+        let msg = match decode_jsonrpc_message(raw) {
+            Some(message) => message,
+            None => {
                 eprintln!("[codex] failed to decode JSON-RPC message shape");
                 continue;
             }
@@ -638,15 +643,61 @@ pub(crate) fn codex_terminal_observation_keys(
     keys
 }
 
-pub(crate) fn codex_any_terminal_observed(observed: &HashSet<String>, keys: &[String]) -> bool {
+/// Upper bound on retained terminal-observation keys. Turn/item ids never
+/// recur, so an unbounded set grew for the app-server's whole life; dedup
+/// only needs to suppress late duplicates of recent terminal events, and
+/// each turn contributes at most two keys, so this covers far more history
+/// than any duplicate horizon.
+const CODEX_TERMINAL_OBSERVED_CAP: usize = 256;
+
+/// Insertion-ordered set of observed terminal-event keys, bounded by
+/// [`CODEX_TERMINAL_OBSERVED_CAP`]: inserting past the cap evicts the oldest
+/// key.
+#[derive(Default)]
+pub(crate) struct CodexTerminalObserved {
+    set: HashSet<String>,
+    order: std::collections::VecDeque<String>,
+}
+
+impl CodexTerminalObserved {
+    fn contains(&self, key: &str) -> bool {
+        self.set.contains(key)
+    }
+
+    fn insert(&mut self, key: &str) {
+        if self.set.contains(key) {
+            return;
+        }
+        while self.order.len() >= CODEX_TERMINAL_OBSERVED_CAP {
+            if let Some(evicted) = self.order.pop_front() {
+                self.set.remove(&evicted);
+            }
+        }
+        self.set.insert(key.to_string());
+        self.order.push_back(key.to_string());
+    }
+
+    fn remove(&mut self, key: &str) {
+        if self.set.remove(key) {
+            self.order.retain(|existing| existing != key);
+        }
+    }
+}
+
+pub(crate) fn codex_any_terminal_observed(
+    observed: &CodexTerminalObserved,
+    keys: &[String],
+) -> bool {
     keys.iter().any(|key| observed.contains(key))
 }
 
-pub(crate) fn codex_mark_terminal_observed(observed: &mut HashSet<String>, keys: &[String]) {
-    observed.extend(keys.iter().cloned());
+pub(crate) fn codex_mark_terminal_observed(observed: &mut CodexTerminalObserved, keys: &[String]) {
+    for key in keys {
+        observed.insert(key);
+    }
 }
 
-pub(crate) fn codex_clear_terminal_observed(observed: &mut HashSet<String>, keys: &[String]) {
+pub(crate) fn codex_clear_terminal_observed(observed: &mut CodexTerminalObserved, keys: &[String]) {
     for key in keys {
         observed.remove(key);
     }
@@ -5264,7 +5315,7 @@ error: build failed
                 "text": "previous checkpoint summary"
             }
         });
-        let mut observed = HashSet::new();
+        let mut observed = CodexTerminalObserved::default();
         let first_keys = codex_terminal_observation_keys(
             &params,
             None,
@@ -5305,7 +5356,7 @@ error: build failed
                 "text": "done"
             }
         });
-        let mut observed = HashSet::new();
+        let mut observed = CodexTerminalObserved::default();
         let final_answer_keys = codex_terminal_observation_keys(
             &params,
             Some("turn-1"),
@@ -5329,6 +5380,34 @@ error: build failed
             false,
             true,
         ));
+    }
+
+    #[test]
+    fn terminal_observed_set_is_bounded_and_evicts_oldest() {
+        let mut observed = CodexTerminalObserved::default();
+        for i in 0..(CODEX_TERMINAL_OBSERVED_CAP + 10) {
+            codex_mark_terminal_observed(&mut observed, &[format!("turn:turn-{i}")]);
+        }
+        assert_eq!(observed.set.len(), CODEX_TERMINAL_OBSERVED_CAP);
+        assert_eq!(observed.order.len(), CODEX_TERMINAL_OBSERVED_CAP);
+        // The oldest keys were evicted; the most recent are retained.
+        assert!(!codex_any_terminal_observed(
+            &observed,
+            &["turn:turn-0".to_string()]
+        ));
+        let newest = format!("turn:turn-{}", CODEX_TERMINAL_OBSERVED_CAP + 9);
+        assert!(codex_any_terminal_observed(&observed, &[newest]));
+
+        // Re-marking an already observed key neither duplicates nor evicts.
+        let repeat = format!("turn:turn-{}", CODEX_TERMINAL_OBSERVED_CAP + 9);
+        codex_mark_terminal_observed(&mut observed, &[repeat]);
+        assert_eq!(observed.order.len(), CODEX_TERMINAL_OBSERVED_CAP);
+
+        // Clearing (the turn/started path) removes from both set and order.
+        let cleared = format!("turn:turn-{}", CODEX_TERMINAL_OBSERVED_CAP + 8);
+        codex_clear_terminal_observed(&mut observed, std::slice::from_ref(&cleared));
+        assert!(!codex_any_terminal_observed(&observed, &[cleared]));
+        assert_eq!(observed.order.len(), CODEX_TERMINAL_OBSERVED_CAP - 1);
     }
 
     #[test]

--- a/src/bin/caller/external_agent/codex/reader.rs
+++ b/src/bin/caller/external_agent/codex/reader.rs
@@ -655,7 +655,10 @@ pub(crate) fn codex_terminal_observation_keys(
 /// and across an app-server restart the set was ALWAYS empty (it is
 /// reader-task state), so pre-eviction code never suppressed ancient
 /// replays either — that case is owned by the stale-turn drop for
-/// turnId-carrying events and was never this set's contract.
+/// turnId-carrying events and was never this set's contract. If a replay
+/// source deeper than this horizon ever appears, a per-thread
+/// latest-final-answer map would be the structure to reach for, not a
+/// larger cap.
 const CODEX_TERMINAL_OBSERVED_CAP: usize = 4096;
 
 /// Insertion-ordered set of observed terminal-event keys, bounded by
@@ -5435,29 +5438,45 @@ error: build failed
 
     #[test]
     fn terminal_observed_set_is_bounded_and_evicts_oldest() {
+        // Two keys per turn (item + turn), enough turns to cross the cap:
+        // the realistic accumulation shape, proving eviction engages and the
+        // newest keys survive it.
         let mut observed = CodexTerminalObserved::default();
-        for i in 0..(CODEX_TERMINAL_OBSERVED_CAP + 10) {
-            codex_mark_terminal_observed(&mut observed, &[format!("turn:turn-{i}")]);
+        let turns = CODEX_TERMINAL_OBSERVED_CAP / 2 + 500;
+        for i in 0..turns {
+            codex_mark_terminal_observed(
+                &mut observed,
+                &[format!("item:item-{i}"), format!("turn:turn-{i}")],
+            );
         }
         assert_eq!(observed.set.len(), CODEX_TERMINAL_OBSERVED_CAP);
         assert_eq!(observed.order.len(), CODEX_TERMINAL_OBSERVED_CAP);
-        // The oldest keys were evicted; the most recent are retained.
+        // The oldest keys were evicted; the most recent survive.
         assert!(!codex_any_terminal_observed(
             &observed,
-            &["turn:turn-0".to_string()]
+            &["turn:turn-0".to_string(), "item:item-0".to_string()]
         ));
-        let newest = format!("turn:turn-{}", CODEX_TERMINAL_OBSERVED_CAP + 9);
-        assert!(codex_any_terminal_observed(&observed, &[newest]));
+        let newest_turn = format!("turn:turn-{}", turns - 1);
+        let newest_item = format!("item:item-{}", turns - 1);
+        assert!(codex_any_terminal_observed(
+            &observed,
+            std::slice::from_ref(&newest_turn)
+        ));
+        assert!(codex_any_terminal_observed(
+            &observed,
+            std::slice::from_ref(&newest_item)
+        ));
 
         // Re-marking an already observed key neither duplicates nor evicts.
-        let repeat = format!("turn:turn-{}", CODEX_TERMINAL_OBSERVED_CAP + 9);
-        codex_mark_terminal_observed(&mut observed, &[repeat]);
+        codex_mark_terminal_observed(&mut observed, std::slice::from_ref(&newest_turn));
         assert_eq!(observed.order.len(), CODEX_TERMINAL_OBSERVED_CAP);
 
         // Clearing (the turn/started path) removes from both set and order.
-        let cleared = format!("turn:turn-{}", CODEX_TERMINAL_OBSERVED_CAP + 8);
-        codex_clear_terminal_observed(&mut observed, std::slice::from_ref(&cleared));
-        assert!(!codex_any_terminal_observed(&observed, &[cleared]));
+        codex_clear_terminal_observed(&mut observed, std::slice::from_ref(&newest_item));
+        assert!(!codex_any_terminal_observed(
+            &observed,
+            std::slice::from_ref(&newest_item)
+        ));
         assert_eq!(observed.order.len(), CODEX_TERMINAL_OBSERVED_CAP - 1);
     }
 

--- a/src/bin/caller/external_agent/codex/reader.rs
+++ b/src/bin/caller/external_agent/codex/reader.rs
@@ -644,11 +644,19 @@ pub(crate) fn codex_terminal_observation_keys(
 }
 
 /// Upper bound on retained terminal-observation keys. Turn/item ids never
-/// recur, so an unbounded set grew for the app-server's whole life; dedup
-/// only needs to suppress late duplicates of recent terminal events, and
-/// each turn contributes at most two keys, so this covers far more history
-/// than any duplicate horizon.
-const CODEX_TERMINAL_OBSERVED_CAP: usize = 256;
+/// recur, so an unbounded set grew for the app-server's whole life.
+///
+/// Why eviction is safe for the turnId-less replay shape
+/// (`final_answer_item_id_dedupes_stale_completion_without_turn_id`): the
+/// known replay source is Codex re-emitting the thread's LATEST final
+/// answer around thread/resume — its `item:` key is at most a couple of
+/// turns old (each turn marks ≤ 2 keys), while this cap covers thousands of
+/// turns. No in-process mechanism replays items old enough to be evicted;
+/// and across an app-server restart the set was ALWAYS empty (it is
+/// reader-task state), so pre-eviction code never suppressed ancient
+/// replays either — that case is owned by the stale-turn drop for
+/// turnId-carrying events and was never this set's contract.
+const CODEX_TERMINAL_OBSERVED_CAP: usize = 4096;
 
 /// Insertion-ordered set of observed terminal-event keys, bounded by
 /// [`CODEX_TERMINAL_OBSERVED_CAP`]: inserting past the cap evicts the oldest
@@ -5378,6 +5386,49 @@ error: build failed
         assert!(codex_terminal_notification_already_observed(
             "turn/completed",
             false,
+            true,
+        ));
+    }
+
+    #[test]
+    fn turnid_less_replay_dedupe_survives_heavy_turn_churn() {
+        // The replay-without-turnId shape is suppressed via its `item:` key.
+        // The known replay source re-emits the thread's LATEST final answer
+        // (a couple of turns deep at most); the eviction cap must sit far
+        // beyond that horizon, so heavy churn between the original terminal
+        // and its replay must not re-enable the event.
+        let params = serde_json::json!({
+            "threadId": "parent-thread",
+            "item": {
+                "id": "msg-final-replay",
+                "type": "agentMessage",
+                "phase": "final_answer",
+                "text": "done"
+            }
+        });
+        let mut observed = CodexTerminalObserved::default();
+        let original_keys = codex_terminal_observation_keys(
+            &params,
+            Some("turn-original"),
+            Some("turn-original"),
+            Some("parent-thread"),
+            true,
+        );
+        codex_mark_terminal_observed(&mut observed, &original_keys);
+        for i in 0..1_000 {
+            codex_mark_terminal_observed(&mut observed, &[format!("turn:churn-{i}")]);
+        }
+        let replayed_keys = codex_terminal_observation_keys(
+            &params,
+            None,
+            Some("turn-current"),
+            Some("parent-thread"),
+            true,
+        );
+        assert!(codex_any_terminal_observed(&observed, &replayed_keys));
+        assert!(codex_terminal_notification_already_observed(
+            "item/completed",
+            true,
             true,
         ));
     }

--- a/src/bin/caller/external_agent/codex/wire.rs
+++ b/src/bin/caller/external_agent/codex/wire.rs
@@ -57,6 +57,41 @@ pub(crate) struct JsonRpcError {
     pub(crate) message: String,
 }
 
+/// Decode an already-parsed JSON-RPC envelope by moving its five known
+/// fields out of the object — the reader loop's second pass. Equivalent to
+/// `serde_json::from_value::<JsonRpcMessage>` (which re-walks and rebuilds
+/// the entire tree, including multi-hundred-KB `params`) but O(fields):
+/// `None` exactly where the serde derive would error — a non-object
+/// envelope, a non-u64 `id`, a non-string `method`, or a malformed `error`
+/// object. `null` fields decode as absent, unknown fields are ignored, both
+/// as under the derive.
+pub(crate) fn decode_jsonrpc_message(raw: serde_json::Value) -> Option<JsonRpcMessage> {
+    let serde_json::Value::Object(mut envelope) = raw else {
+        return None;
+    };
+    let id = match envelope.remove("id") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::Number(id)) => Some(id.as_u64()?),
+        Some(_) => return None,
+    };
+    let method = match envelope.remove("method") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::String(method)) => Some(method),
+        Some(_) => return None,
+    };
+    let error = match envelope.remove("error") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(error) => Some(serde_json::from_value::<JsonRpcError>(error).ok()?),
+    };
+    Some(JsonRpcMessage {
+        id,
+        method,
+        params: envelope.remove("params").filter(|v| !v.is_null()),
+        result: envelope.remove("result").filter(|v| !v.is_null()),
+        error,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Pending-request bookkeeping
 // ---------------------------------------------------------------------------
@@ -300,6 +335,58 @@ mod tests {
             // These should either parse successfully (with missing optional fields)
             // or fail gracefully without panicking
             let _result: Result<JsonRpcMessage, _> = serde_json::from_str(line);
+        }
+    }
+
+    #[test]
+    fn decode_jsonrpc_message_matches_serde_derive() {
+        // The reader's direct field extraction must accept and reject exactly
+        // what `from_value::<JsonRpcMessage>` did, shape for shape.
+        let cases = [
+            r#"{"jsonrpc":"2.0","id":1,"result":{"capabilities":{}}}"#,
+            r#"{"jsonrpc":"2.0","id":2,"error":{"code":-32600,"message":"Invalid request"}}"#,
+            r#"{"jsonrpc":"2.0","method":"item/agentMessage/delta","params":{"delta":"hello"}}"#,
+            r#"{"jsonrpc":"2.0","id":99,"method":"x/requestApproval","params":{"item":{}}}"#,
+            r#"{"jsonrpc":"2.0"}"#,
+            r#"{"jsonrpc":"2.0","id":null,"method":null,"params":null,"result":null,"error":null}"#,
+            r#"{"jsonrpc":"2.0","id":"not-a-number"}"#,
+            r#"{"jsonrpc":"2.0","id":-3}"#,
+            r#"{"jsonrpc":"2.0","method":42}"#,
+            r#"{"jsonrpc":"2.0","error":{"code":"nope"}}"#,
+            r#"{"jsonrpc":"2.0","unknown_extra":true,"id":7,"method":"m"}"#,
+            r#"[1,2,3]"#,
+            r#""just a string""#,
+        ];
+        for case in cases {
+            let raw: serde_json::Value = serde_json::from_str(case).unwrap();
+            let derived: Result<JsonRpcMessage, _> = serde_json::from_value(raw.clone());
+            let decoded = decode_jsonrpc_message(raw);
+            match derived {
+                Ok(expected) => {
+                    let actual = decoded.unwrap_or_else(|| {
+                        panic!("decode_jsonrpc_message rejected accepted shape: {case}")
+                    });
+                    assert_eq!(actual.id, expected.id, "id mismatch for {case}");
+                    assert_eq!(actual.method, expected.method, "method mismatch for {case}");
+                    assert_eq!(actual.params, expected.params, "params mismatch for {case}");
+                    assert_eq!(actual.result, expected.result, "result mismatch for {case}");
+                    assert_eq!(
+                        actual.error.is_some(),
+                        expected.error.is_some(),
+                        "error presence mismatch for {case}"
+                    );
+                    if let (Some(actual), Some(expected)) = (actual.error, expected.error) {
+                        assert_eq!(actual.code, expected.code);
+                        assert_eq!(actual.message, expected.message);
+                    }
+                }
+                Err(_) => {
+                    assert!(
+                        decoded.is_none(),
+                        "decode_jsonrpc_message accepted rejected shape: {case}"
+                    );
+                }
+            }
         }
     }
 

--- a/src/bin/caller/external_wrapper_index.rs
+++ b/src/bin/caller/external_wrapper_index.rs
@@ -220,16 +220,62 @@ pub fn upsert(
         .get_or_init(|| Mutex::new(()))
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let mut index = with_index_unlocked(home, |index| index.clone());
     let log_path = log_dir.to_string_lossy().to_string();
     let updated_at_secs =
         file_mtime_secs(&log_dir.join("session.jsonl")).max(file_mtime_secs(log_dir));
     let project_root = project_root.map(|path| path.to_string_lossy().to_string());
 
+    // The shared predicates between the read-only dirty pass and the
+    // mutation pass below — keep them in one place so the two passes cannot
+    // drift.
+    let conflicts_backend = |record: &ExternalWrapperRecord| {
+        record.source == source
+            && record.backend_session_id == backend_session_id
+            && record.intendant_session_id != stored_intendant_session_id
+    };
+    let conflicts_wrapper = |record: &ExternalWrapperRecord| {
+        record.source == source
+            && record.intendant_session_id == stored_intendant_session_id
+            && record.backend_session_id != backend_session_id
+    };
+    let is_exact_identity = |record: &ExternalWrapperRecord| {
+        record.source == source
+            && record.backend_session_id == backend_session_id
+            && record.intendant_session_id == stored_intendant_session_id
+    };
+    let needs_demotion = |record: &ExternalWrapperRecord| {
+        record.updated_at_secs != 0 || record.state != WrapperState::Superseded
+    };
+
     // Session-list scans upsert every external row on every pass; rewriting
-    // the whole index per unchanged row made listing quadratic. Track
-    // whether anything actually changed and skip the write when not.
-    let mut dirty = false;
+    // the whole index per unchanged row made listing quadratic, and cloning
+    // it per unchanged row still churned every record's strings. Decide
+    // against the cached index in place and clone only when a write will
+    // follow.
+    let dirty = with_index_unlocked(home, |index| {
+        let any_demotion = index.wrappers.iter().any(|record| {
+            (conflicts_backend(record) || conflicts_wrapper(record)) && needs_demotion(record)
+        });
+        let upsert_changes = match index
+            .wrappers
+            .iter()
+            .find(|record| is_exact_identity(record))
+        {
+            Some(existing) => {
+                existing.log_path != log_path
+                    || existing.project_root != project_root
+                    || existing.updated_at_secs != updated_at_secs
+                    || existing.state != WrapperState::Active
+            }
+            None => true,
+        };
+        any_demotion || upsert_changes
+    });
+    if !dirty {
+        return Ok(());
+    }
+
+    let mut index = with_index_unlocked(home, |index| index.clone());
 
     // Demotion, not deletion: rows that conflict with the upserted identity
     // (same backend session under another wrapper; same wrapper now bound to
@@ -240,35 +286,20 @@ pub fn upsert(
     // Do not "repair" the zero with a real mtime; only a fresh upsert of the
     // row's exact identity triple (the branch below) may make it current
     // again.
-    for record in index.wrappers.iter_mut().filter(|record| {
-        record.source == source
-            && record.backend_session_id == backend_session_id
-            && record.intendant_session_id != stored_intendant_session_id
-    }) {
-        dirty |= record.updated_at_secs != 0 || record.state != WrapperState::Superseded;
+    for record in index
+        .wrappers
+        .iter_mut()
+        .filter(|record| conflicts_backend(record) || conflicts_wrapper(record))
+    {
         record.updated_at_secs = 0;
         record.state = WrapperState::Superseded;
     }
 
-    for record in index.wrappers.iter_mut().filter(|record| {
-        record.source == source
-            && record.intendant_session_id == stored_intendant_session_id
-            && record.backend_session_id != backend_session_id
-    }) {
-        dirty |= record.updated_at_secs != 0 || record.state != WrapperState::Superseded;
-        record.updated_at_secs = 0;
-        record.state = WrapperState::Superseded;
-    }
-
-    if let Some(existing) = index.wrappers.iter_mut().find(|record| {
-        record.source == source
-            && record.backend_session_id == backend_session_id
-            && record.intendant_session_id == stored_intendant_session_id
-    }) {
-        dirty |= existing.log_path != log_path
-            || existing.project_root != project_root
-            || existing.updated_at_secs != updated_at_secs
-            || existing.state != WrapperState::Active;
+    if let Some(existing) = index
+        .wrappers
+        .iter_mut()
+        .find(|record| is_exact_identity(record))
+    {
         existing.log_path = log_path;
         existing.project_root = project_root;
         // Reactivation: an upsert of this exact identity triple makes the
@@ -277,7 +308,6 @@ pub fn upsert(
         existing.updated_at_secs = updated_at_secs;
         existing.state = WrapperState::Active;
     } else {
-        dirty = true;
         index.wrappers.push(ExternalWrapperRecord {
             source,
             backend_session_id: backend_session_id.to_string(),
@@ -290,9 +320,6 @@ pub fn upsert(
         });
     }
 
-    if !dirty {
-        return Ok(());
-    }
     write_index_unlocked(home, &index)?;
     note_index_written(home, &index);
     Ok(())
@@ -413,18 +440,25 @@ pub fn record_rollout_path(
         .get_or_init(|| Mutex::new(()))
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // Decide against the cached index in place; clone only when a write
+    // will follow (mirrors `upsert`).
+    let dirty = with_index_unlocked(home, |index| {
+        index.wrappers.iter().any(|record| {
+            record.source == source
+                && record.backend_session_id == backend_session_id
+                && record.rollout_path.as_deref() != Some(rollout_path.as_str())
+        })
+    });
+    if !dirty {
+        return Ok(());
+    }
     let mut index = with_index_unlocked(home, |index| index.clone());
-    let mut dirty = false;
     for record in index
         .wrappers
         .iter_mut()
         .filter(|record| record.source == source && record.backend_session_id == backend_session_id)
     {
-        dirty |= record.rollout_path.as_deref() != Some(rollout_path.as_str());
         record.rollout_path = Some(rollout_path.clone());
-    }
-    if !dirty {
-        return Ok(());
     }
     write_index_unlocked(home, &index)?;
     note_index_written(home, &index);

--- a/src/bin/caller/fission_ledger.rs
+++ b/src/bin/caller/fission_ledger.rs
@@ -1064,6 +1064,68 @@ pub fn update_branch_work(
     Ok(updated)
 }
 
+/// One branch's changed-file delta for [`update_branches_changed_files`].
+#[derive(Debug, Clone)]
+pub struct BranchChangedFiles {
+    pub group_id: String,
+    pub branch_session_id: String,
+    pub changed_files: Vec<String>,
+}
+
+/// Batched changed-file accumulation for the lifecycle watcher: apply every
+/// branch's delta in ONE read→modify→write cycle — one parse and one
+/// atomic (fsync'd) write for the whole batch instead of one per branch per
+/// file. Unknown groups/branches are skipped (stale watcher routes), and
+/// nothing is written when no delta adds a new path — matching the
+/// watcher's ignore-stale, dedup-first behavior around
+/// [`update_branch_work`].
+pub fn update_branches_changed_files(
+    log_dir: &Path,
+    updates: &[BranchChangedFiles],
+) -> io::Result<()> {
+    if updates.is_empty() {
+        return Ok(());
+    }
+    let _guard = ledger_write_lock();
+    let mut document = read_fission_ledger_document(log_dir)?.unwrap_or_default();
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut changed = false;
+    for update in updates {
+        let group_id = clean_string(&update.group_id).unwrap_or_default();
+        let branch_session_id = clean_string(&update.branch_session_id).unwrap_or_default();
+        let Some(group) = document
+            .groups
+            .iter_mut()
+            .find(|group| group.group_id == group_id)
+        else {
+            continue;
+        };
+        let Some(branch) = group
+            .branches
+            .iter_mut()
+            .find(|branch| branch.session_id == branch_session_id)
+        else {
+            continue;
+        };
+        let branch_ext = document
+            .ext
+            .group_mut_or_insert(&group_id)
+            .branch_mut_or_insert(&branch_session_id);
+        let before = branch_ext.changed_files.len();
+        merge_unique(&mut branch_ext.changed_files, &update.changed_files);
+        if branch_ext.changed_files.len() == before {
+            continue;
+        }
+        changed = true;
+        branch.updated_at = now.clone();
+        group.updated_at = now.clone();
+    }
+    if !changed {
+        return Ok(());
+    }
+    persist_fission_ledger_document(log_dir, &document)
+}
+
 /// Register a model-driven fission branch at its exact spawn anchor. Called by
 /// the spawn MCP tool (added in a later stage) immediately after launching a
 /// sibling/fork on the model's behalf, before any collab observation can
@@ -2081,6 +2143,91 @@ mod tests {
 
         let err = update_branch_work(dir.path(), &gid, "nope", &[], &[], None).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn update_branches_changed_files_applies_whole_batch_in_one_write() {
+        let dir = tempdir().unwrap();
+        record_fission_observation(dir.path(), observation("running")).unwrap();
+        record_fission_observation(
+            dir.path(),
+            FissionObservation {
+                branches: vec![FissionBranchObservation {
+                    session_id: "child-2".to_string(),
+                    status: "running".to_string(),
+                    summary: None,
+                }],
+                ..observation("running")
+            },
+        )
+        .unwrap();
+        let gid = group_id("parent", "call-123");
+
+        update_branches_changed_files(
+            dir.path(),
+            &[
+                BranchChangedFiles {
+                    group_id: gid.clone(),
+                    branch_session_id: "child".to_string(),
+                    changed_files: vec!["a.rs".to_string(), "b.rs".to_string()],
+                },
+                BranchChangedFiles {
+                    group_id: gid.clone(),
+                    branch_session_id: "child-2".to_string(),
+                    changed_files: vec!["c.rs".to_string()],
+                },
+                // Stale watcher route: skipped, not an error.
+                BranchChangedFiles {
+                    group_id: "missing-group".to_string(),
+                    branch_session_id: "child".to_string(),
+                    changed_files: vec!["d.rs".to_string()],
+                },
+            ],
+        )
+        .unwrap();
+
+        let document = read_fission_ledger_document(dir.path()).unwrap().unwrap();
+        assert_eq!(
+            document
+                .branch_ext(&gid, "child")
+                .expect("branch ext")
+                .changed_files,
+            vec!["a.rs", "b.rs"]
+        );
+        assert_eq!(
+            document
+                .branch_ext(&gid, "child-2")
+                .expect("branch-2 ext")
+                .changed_files,
+            vec!["c.rs"]
+        );
+
+        // A batch that adds nothing new leaves the document untouched
+        // (no rewrite: same mtime-visible contents, deduped lists).
+        update_branches_changed_files(
+            dir.path(),
+            &[BranchChangedFiles {
+                group_id: gid.clone(),
+                branch_session_id: "child".to_string(),
+                changed_files: vec!["a.rs".to_string()],
+            }],
+        )
+        .unwrap();
+        let document = read_fission_ledger_document(dir.path()).unwrap().unwrap();
+        assert_eq!(
+            document
+                .branch_ext(&gid, "child")
+                .expect("branch ext")
+                .changed_files,
+            vec!["a.rs", "b.rs"]
+        );
+
+        // Empty batch: no ledger required, no write attempted.
+        let empty = tempdir().unwrap();
+        update_branches_changed_files(empty.path(), &[]).unwrap();
+        assert!(read_fission_ledger_document(empty.path())
+            .unwrap()
+            .is_none());
     }
 
     #[test]

--- a/src/bin/caller/fission_lifecycle.rs
+++ b/src/bin/caller/fission_lifecycle.rs
@@ -148,8 +148,12 @@ pub enum WaitOutcome {
 /// group detaches, or the timeout elapses. `branch_session_id = None` waits
 /// for ANY branch of the group to become terminal.
 ///
-/// Ledger-poll implementation (1s cadence). The supervisor stage may layer
-/// bus-event wakeups on top; the polling contract and return shape stay.
+/// Ledger-poll implementation (1s cadence), fingerprint-guarded: the ~MB
+/// ledger is only re-read and re-parsed when its (len, mtime) moved — every
+/// write goes through an atomic rename, so unchanged metadata means an
+/// unchanged ledger and the previous evaluation still holds. The supervisor
+/// stage may layer bus-event wakeups on top; the polling contract and
+/// return shape stay.
 pub async fn wait_for_branch_terminal(
     log_dir: &Path,
     group_id: &str,
@@ -157,13 +161,20 @@ pub async fn wait_for_branch_terminal(
     timeout: Duration,
 ) -> io::Result<WaitOutcome> {
     let deadline = tokio::time::Instant::now() + timeout;
+    let ledger_path = fission_ledger::ledger_path(log_dir);
+    let mut last_fingerprint: Option<Option<(u64, u128)>> = None;
+    let mut snapshot: Option<(FissionGroup, bool)> = None;
     loop {
-        let snapshot = read_group(log_dir, group_id)?;
-        let Some((group, detached)) = snapshot else {
+        let fingerprint = ledger_file_fingerprint(&ledger_path);
+        if last_fingerprint != Some(fingerprint) {
+            snapshot = read_group(log_dir, group_id)?;
+            last_fingerprint = Some(fingerprint);
+        }
+        let Some((group, detached)) = snapshot.as_ref() else {
             return Ok(WaitOutcome::GroupNotFound);
         };
-        if detached {
-            return Ok(WaitOutcome::Detached(group));
+        if *detached {
+            return Ok(WaitOutcome::Detached(group.clone()));
         }
         match branch_session_id.map(str::trim).filter(|id| !id.is_empty()) {
             Some(branch_id) => {
@@ -172,10 +183,10 @@ pub async fn wait_for_branch_terminal(
                     .iter()
                     .find(|branch| branch.session_id == branch_id)
                 else {
-                    return Ok(WaitOutcome::BranchNotFound(group));
+                    return Ok(WaitOutcome::BranchNotFound(group.clone()));
                 };
                 if fission_ledger::branch_status_is_terminal(&branch.status) {
-                    return Ok(WaitOutcome::Terminal(group));
+                    return Ok(WaitOutcome::Terminal(group.clone()));
                 }
             }
             None => {
@@ -184,15 +195,28 @@ pub async fn wait_for_branch_terminal(
                     .iter()
                     .any(|branch| fission_ledger::branch_status_is_terminal(&branch.status))
                 {
-                    return Ok(WaitOutcome::Terminal(group));
+                    return Ok(WaitOutcome::Terminal(group.clone()));
                 }
             }
         }
         if tokio::time::Instant::now() >= deadline {
-            return Ok(WaitOutcome::StillRunning(group));
+            return Ok(WaitOutcome::StillRunning(group.clone()));
         }
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
+}
+
+/// (len, mtime-nanos) of the ledger file; `None` when it does not exist.
+/// Same change-detection discipline as the wrapper-index cache.
+fn ledger_file_fingerprint(path: &Path) -> Option<(u64, u128)> {
+    let metadata = fs::metadata(path).ok()?;
+    let mtime_nanos = metadata
+        .modified()
+        .ok()
+        .and_then(|mtime| mtime.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|elapsed| elapsed.as_nanos())
+        .unwrap_or(0);
+    Some((metadata.len(), mtime_nanos))
 }
 
 fn read_group(log_dir: &Path, group_id: &str) -> io::Result<Option<(FissionGroup, bool)>> {
@@ -242,7 +266,32 @@ pub fn spawn_fission_lifecycle_watcher(
     tokio::spawn(async move {
         let mut state = LifecycleWatcherState::default();
         while let Some(event) = rx.recv().await {
-            handle_lifecycle_event(&event, &mut state);
+            if !matches!(event, AppEvent::FileChanged { .. }) {
+                handle_lifecycle_event(&event, &mut state);
+                continue;
+            }
+            // Changed-file burst: drain every immediately available event,
+            // staging FileChanged paths (dedup/cap applied per event, in
+            // stream order) and flushing the whole batch as ONE ledger
+            // read→modify→write per log dir — a save storm otherwise costs
+            // one fsync'd multi-MB rewrite per file per branch. Non-file
+            // events flush what preceded them first, preserving the
+            // pre-terminal/post-terminal accumulation order.
+            let mut batch = ChangedFileBatch::default();
+            stage_lifecycle_event(&event, &mut state, &mut batch);
+            loop {
+                match rx.try_recv() {
+                    Ok(next @ AppEvent::FileChanged { .. }) => {
+                        stage_lifecycle_event(&next, &mut state, &mut batch);
+                    }
+                    Ok(next) => {
+                        batch.flush();
+                        handle_lifecycle_event(&next, &mut state);
+                    }
+                    Err(_) => break,
+                }
+            }
+            batch.flush();
         }
     })
 }
@@ -418,6 +467,45 @@ fn record_branch_observation(
     }
 }
 
+/// Changed-file deltas staged per (log dir, group, branch), flushed as one
+/// bulk ledger write per log dir ([`fission_ledger::update_branches_changed_files`]).
+#[derive(Default)]
+struct ChangedFileBatch {
+    staged: HashMap<PathBuf, HashMap<(String, String), Vec<String>>>,
+}
+
+impl ChangedFileBatch {
+    fn flush(&mut self) {
+        for (log_dir, branches) in self.staged.drain() {
+            let updates: Vec<fission_ledger::BranchChangedFiles> = branches
+                .into_iter()
+                .map(|((group_id, branch_session_id), changed_files)| {
+                    fission_ledger::BranchChangedFiles {
+                        group_id,
+                        branch_session_id,
+                        changed_files,
+                    }
+                })
+                .collect();
+            if let Err(err) = fission_ledger::update_branches_changed_files(&log_dir, &updates) {
+                eprintln!("[fission-lifecycle] failed to record changed files: {err}");
+            }
+        }
+    }
+}
+
+/// Stage `FileChanged` events into `batch`; every other event is a no-op
+/// here (the caller routes those through [`handle_lifecycle_event`]).
+fn stage_lifecycle_event(
+    event: &AppEvent,
+    state: &mut LifecycleWatcherState,
+    batch: &mut ChangedFileBatch,
+) {
+    if let AppEvent::FileChanged { path, .. } = event {
+        stage_changed_file(state, batch, path);
+    }
+}
+
 /// Accumulate a project `FileChanged` path into the work metadata of every
 /// registered, still-running branch. The project file watcher carries no
 /// per-session attribution, and fission branches that share the parent
@@ -426,6 +514,14 @@ fn record_branch_observation(
 /// bounded by [`CHANGED_FILES_PER_BRANCH_CAP`]). Branches in isolated
 /// worktrees edit outside the watch root and naturally accumulate nothing.
 fn record_changed_file(state: &mut LifecycleWatcherState, path: &str) {
+    let mut batch = ChangedFileBatch::default();
+    stage_changed_file(state, &mut batch, path);
+    batch.flush();
+}
+
+/// The per-event core of changed-file accumulation: state dedup + cap, then
+/// stage (never write) the path for each still-running branch.
+fn stage_changed_file(state: &mut LifecycleWatcherState, batch: &mut ChangedFileBatch, path: &str) {
     let path = path.trim();
     if path.is_empty() {
         return;
@@ -448,14 +544,13 @@ fn record_changed_file(state: &mut LifecycleWatcherState, path: &str) {
             continue;
         }
         recorded.insert(path.to_string());
-        let _ = fission_ledger::update_branch_work(
-            &route.log_dir,
-            &route.group_id,
-            &branch_session_id,
-            &[path.to_string()],
-            &[],
-            None,
-        );
+        batch
+            .staged
+            .entry(route.log_dir)
+            .or_default()
+            .entry((route.group_id, branch_session_id))
+            .or_default()
+            .push(path.to_string());
     }
 }
 
@@ -914,6 +1009,81 @@ mod tests {
             .any(|path| path == "src/lw_fc_post_terminal.rs"));
 
         drop_pending_deliveries(&[group_id]);
+    }
+
+    #[test]
+    fn changed_file_burst_batch_flushes_all_branches_in_one_write() {
+        let dir = tempdir().unwrap();
+        let group_a =
+            register_test_branch(dir.path(), "lw-parent-9", "lw-call-9a", "lw-child-batch-a");
+        let group_b =
+            register_test_branch(dir.path(), "lw-parent-9", "lw-call-9b", "lw-child-batch-b");
+        register_branch("lw-child-batch-a", &group_a, dir.path());
+        register_branch("lw-child-batch-b", &group_b, dir.path());
+        let mut state = LifecycleWatcherState::default();
+
+        // Stage a burst of changed files (as the watcher loop's drain does),
+        // then flush once: every (branch, path) pair lands.
+        let mut batch = ChangedFileBatch::default();
+        stage_changed_file(&mut state, &mut batch, "src/lw_batch_1.rs");
+        stage_changed_file(&mut state, &mut batch, "src/lw_batch_2.rs");
+        stage_changed_file(&mut state, &mut batch, "src/lw_batch_1.rs"); // dedup
+        batch.flush();
+        assert!(batch.staged.is_empty());
+
+        let document = fission_ledger::read_fission_ledger_document(dir.path())
+            .unwrap()
+            .expect("document");
+        for (group, branch) in [
+            (&group_a, "lw-child-batch-a"),
+            (&group_b, "lw-child-batch-b"),
+        ] {
+            let ext = document.branch_ext(group, branch).expect("branch ext");
+            // Containment (not exact equality): the branch registry is
+            // process-global, so concurrently running watcher tests may
+            // interleave their own paths into these branches.
+            for path in ["src/lw_batch_1.rs", "src/lw_batch_2.rs"] {
+                assert_eq!(
+                    ext.changed_files
+                        .iter()
+                        .filter(|existing| existing.as_str() == path)
+                        .count(),
+                    1,
+                    "branch {branch} path {path}"
+                );
+            }
+        }
+
+        // The staged path respects terminal suppression mid-burst, exactly
+        // like the immediate path.
+        handle_lifecycle_event(
+            &AppEvent::TaskComplete {
+                session_id: Some("lw-child-batch-a".to_string()),
+                reason: "done".to_string(),
+                summary: None,
+            },
+            &mut state,
+        );
+        let mut batch = ChangedFileBatch::default();
+        stage_changed_file(&mut state, &mut batch, "src/lw_batch_3.rs");
+        batch.flush();
+        let document = fission_ledger::read_fission_ledger_document(dir.path())
+            .unwrap()
+            .expect("document");
+        assert!(!document
+            .branch_ext(&group_a, "lw-child-batch-a")
+            .expect("branch ext")
+            .changed_files
+            .iter()
+            .any(|path| path == "src/lw_batch_3.rs"));
+        assert!(document
+            .branch_ext(&group_b, "lw-child-batch-b")
+            .expect("branch ext")
+            .changed_files
+            .iter()
+            .any(|path| path == "src/lw_batch_3.rs"));
+
+        drop_pending_deliveries(&[group_a, group_b]);
     }
 
     #[test]

--- a/src/bin/caller/lineage_ledger.rs
+++ b/src/bin/caller/lineage_ledger.rs
@@ -90,12 +90,16 @@ struct SessionFacts {
 /// past the cap the map is cleared and the active dirs re-fold once.
 const LINEAGE_FACTS_CACHE_CAP: usize = 64;
 
-/// Folded `session.jsonl` facts plus the byte/mtime cursor they were folded
-/// through. `consumed_bytes` only ever advances past COMPLETE lines — the
-/// writer newline-terminates every event, so a trailing partial line is a
-/// mid-flush artifact folded once complete.
+/// Folded `session.jsonl` facts plus the cursor they were folded through.
+/// `consumed_bytes` only ever advances past consumable content — the writer
+/// newline-terminates every event, so a trailing partial line is a
+/// mid-flush artifact folded once complete. `(stat_len, mtime_nanos)`
+/// record the file stat at the last evaluation (consumed can lag stat_len
+/// while a partial tail is pending): an mtime change without growth is a
+/// rewrite and re-folds, growth is an append.
 struct CachedLineageFacts {
     consumed_bytes: u64,
+    stat_len: u64,
     mtime_nanos: u128,
     facts: SessionFacts,
 }
@@ -156,12 +160,15 @@ pub fn read_lineage_ledger(
         .cloned();
 
     let entry = match cached {
-        // Unchanged file: derive straight from the cached facts.
-        Some(entry) if entry.consumed_bytes == len && entry.mtime_nanos == mtime_nanos => entry,
-        // Grown file: fold only the appended complete lines. (Strictly
-        // greater — an mtime change at unchanged length is a rewrite and
-        // falls through to the full refold below.)
-        Some(entry) if entry.consumed_bytes < len => {
+        // Stat unchanged since the last evaluation: derive straight from the
+        // cached facts (also covers an unchanged pending partial tail — no
+        // re-read until the file actually moves).
+        Some(entry) if entry.stat_len == len && entry.mtime_nanos == mtime_nanos => entry,
+        // Grown file: fold only the appended consumable lines. (Strictly
+        // greater than the last observed stat length — an mtime change
+        // without growth, even while a partial tail left consumed < len, is
+        // a rewrite and falls through to the full refold below.)
+        Some(entry) if len > entry.stat_len => {
             match read_new_complete_lines_sync(&path, entry.consumed_bytes, len)? {
                 Some((text, consumed)) => {
                     let mut facts = entry.facts.clone();
@@ -170,20 +177,31 @@ pub fn read_lineage_ledger(
                     }
                     let entry = Arc::new(CachedLineageFacts {
                         consumed_bytes: entry.consumed_bytes + consumed,
+                        stat_len: len,
                         mtime_nanos,
                         facts,
                     });
                     store_lineage_facts(&path, entry.clone());
                     entry
                 }
-                // No complete new line yet — evaluate the cached facts and
-                // leave the cursor (including its recorded mtime) for the
-                // next call to retry.
-                None => entry,
+                // No consumable new content yet — record the observed stat
+                // (so an untouched file serves from cache and a later
+                // no-growth mtime change still reads as a rewrite) and
+                // evaluate the cached facts.
+                None => {
+                    let entry = Arc::new(CachedLineageFacts {
+                        consumed_bytes: entry.consumed_bytes,
+                        stat_len: len,
+                        mtime_nanos,
+                        facts: entry.facts.clone(),
+                    });
+                    store_lineage_facts(&path, entry.clone());
+                    entry
+                }
             }
         }
-        // Cold cache, a shrunk file, or a same-length rewrite (mtime moved
-        // with no growth): fold from scratch.
+        // Cold cache, a shrunk file, or a rewrite without growth (mtime
+        // moved at the same stat length): fold from scratch.
         _ => {
             let contents = match fs::read_to_string(&path) {
                 Ok(contents) => contents,
@@ -193,6 +211,7 @@ pub fn read_lineage_ledger(
             let (complete, consumed) = complete_lines_prefix(&contents);
             let entry = Arc::new(CachedLineageFacts {
                 consumed_bytes: consumed,
+                stat_len: len,
                 mtime_nanos,
                 facts: session_facts_from_jsonl(complete),
             });
@@ -955,16 +974,43 @@ mod tests {
         assert_eq!(ledger.groups[0].branches[0].status, "running");
     }
 
+    fn set_mtime(path: &Path, secs_since_epoch: u64) {
+        let file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        file.set_modified(std::time::UNIX_EPOCH + std::time::Duration::from_secs(secs_since_epoch))
+            .unwrap();
+    }
+
+    #[test]
+    fn read_lineage_ledger_refolds_same_length_rewrite_while_partial_tail_pending() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.jsonl");
+        let rel_a = r#"{"event":"session_relationship","data":{"parent_session_id":"parent","child_session_id":"child-a","relationship":"subagent","ephemeral":false}}"#;
+        let rel_b = r#"{"event":"session_relationship","data":{"parent_session_id":"parent","child_session_id":"child-b","relationship":"subagent","ephemeral":false}}"#;
+        assert_eq!(rel_a.len(), rel_b.len(), "test needs equal-length lines");
+        let done = r#"{"event":"task_complete","data":{"session_id":"child-a","summary":"ok"}}"#;
+        let (partial, _rest) = done.split_at(done.len() / 2);
+
+        // Cached state with a pending partial tail: consumed < stat len.
+        std::fs::write(&path, format!("{rel_a}\n{partial}")).unwrap();
+        set_mtime(&path, 1_000);
+        let ledger = read_lineage_ledger(dir.path(), "parent")
+            .unwrap()
+            .expect("ledger");
+        assert_eq!(ledger.groups[0].branches[0].session_id, "child-a");
+
+        // Same TOTAL length, different content and mtime: a pure
+        // consumed<=len append model would tail-read from the stale cursor;
+        // the recorded stat length classifies it as a rewrite instead.
+        std::fs::write(&path, format!("{rel_b}\n{partial}")).unwrap();
+        set_mtime(&path, 2_000);
+        let ledger = read_lineage_ledger(dir.path(), "parent")
+            .unwrap()
+            .expect("ledger");
+        assert_eq!(ledger.groups[0].branches[0].session_id, "child-b");
+    }
+
     #[test]
     fn read_lineage_ledger_refolds_on_same_length_rewrite() {
-        fn set_mtime(path: &Path, secs_since_epoch: u64) {
-            let file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
-            file.set_modified(
-                std::time::UNIX_EPOCH + std::time::Duration::from_secs(secs_since_epoch),
-            )
-            .unwrap();
-        }
-
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("session.jsonl");
         let rel_line = r#"{"event":"session_relationship","data":{"parent_session_id":"parent","child_session_id":"child","relationship":"subagent","ephemeral":false}}"#;

--- a/src/bin/caller/lineage_ledger.rs
+++ b/src/bin/caller/lineage_ledger.rs
@@ -2,7 +2,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::io;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::UNIX_EPOCH;
 
 /// Boilerplate the session log writes for a `done_signal` with no caller message
 /// (see `SessionLog::done_signal_for_session`). Filtered out so it isn't treated
@@ -55,7 +57,7 @@ struct RelationshipKey {
     ephemeral: bool,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct SessionFacts {
     identities: HashMap<String, String>,
     tasks: HashMap<String, String>,
@@ -66,6 +68,9 @@ struct SessionFacts {
     /// selection can pick the *latest* rewind-restore rather than relying on the
     /// `BTreeSet`'s lexicographic ordering of (random) child session ids.
     relationship_order: HashMap<RelationshipKey, usize>,
+    /// Next relationship sequence index (fold state — lives here so an
+    /// incremental fold continues exactly where the previous one stopped).
+    relationship_seq: usize,
     /// `(parent, child)` pairs severed by a `fission-detached` relationship:
     /// the branch's spawn anchor left the effective history (rewound past) or
     /// the group was explicitly severed.
@@ -73,29 +78,333 @@ struct SessionFacts {
     /// `(parent, child)` pairs whose result a `fission-imported` relationship
     /// marked as explicitly imported into the parent's continuation.
     fission_imported: BTreeSet<(String, String)>,
+    /// Detach/import marker relationships in emission order. Whether a
+    /// marker dedups into its spawn row or renders standalone depends on the
+    /// full relationship set, so they are resolved at derive time
+    /// ([`lineage_ledger_from_facts`]) rather than folded in.
+    pending_fission_marks: Vec<RelationshipKey>,
+}
+
+/// How many session dirs' folded facts to retain. Facts are small (id/status
+/// maps, not the log), but a long-lived daemon touches many session dirs;
+/// past the cap the map is cleared and the active dirs re-fold once.
+const LINEAGE_FACTS_CACHE_CAP: usize = 64;
+
+/// Folded `session.jsonl` facts plus the byte/mtime cursor they were folded
+/// through. `consumed_bytes` only ever advances past COMPLETE lines — the
+/// writer newline-terminates every event, so a trailing partial line is a
+/// mid-flush artifact folded once complete.
+struct CachedLineageFacts {
+    consumed_bytes: u64,
+    mtime_nanos: u128,
+    facts: SessionFacts,
+}
+
+fn lineage_facts_cache() -> &'static Mutex<HashMap<PathBuf, Arc<CachedLineageFacts>>> {
+    static CACHE: OnceLock<Mutex<HashMap<PathBuf, Arc<CachedLineageFacts>>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn store_lineage_facts(path: &Path, entry: Arc<CachedLineageFacts>) {
+    let mut cache = lineage_facts_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if cache.len() >= LINEAGE_FACTS_CACHE_CAP && !cache.contains_key(path) {
+        cache.clear();
+    }
+    cache.insert(path.to_path_buf(), entry);
+}
+
+fn mtime_nanos_of(metadata: &fs::Metadata) -> u128 {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|mtime| mtime.duration_since(UNIX_EPOCH).ok())
+        .map(|elapsed| elapsed.as_nanos())
+        .unwrap_or(0)
 }
 
 /// Read `session.jsonl` from `log_dir` and derive the lineage ledger for
 /// `source_session_id` (see [`lineage_ledger_from_jsonl`]). Called by the MCP
 /// `get_status` surface (`mcp.rs`) and the rewind-record snapshot path
 /// (`main.rs`). `Ok(None)` when no session log exists.
+///
+/// The multi-MB log is NOT re-parsed per call: folded facts are cached per
+/// path and extended incrementally — an unchanged (len, mtime) serves from
+/// cache with one stat, an append folds only the new complete lines, and a
+/// shrunk file (never produced by the append-only writer) re-folds from
+/// scratch.
 pub fn read_lineage_ledger(
     log_dir: &Path,
     source_session_id: &str,
 ) -> io::Result<Option<LineageLedger>> {
     let path = log_dir.join("session.jsonl");
-    let contents = match fs::read_to_string(path) {
-        Ok(contents) => contents,
+    let metadata = match fs::metadata(&path) {
+        Ok(metadata) => metadata,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
         Err(err) => return Err(err),
     };
-    Ok(lineage_ledger_from_jsonl(&contents, source_session_id))
+    let len = metadata.len();
+    let mtime_nanos = mtime_nanos_of(&metadata);
+
+    let cached = lineage_facts_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&path)
+        .cloned();
+
+    let entry = match cached {
+        // Unchanged file: derive straight from the cached facts.
+        Some(entry) if entry.consumed_bytes == len && entry.mtime_nanos == mtime_nanos => entry,
+        // Grown file: fold only the appended complete lines.
+        Some(entry) if entry.consumed_bytes <= len => {
+            match read_new_complete_lines_sync(&path, entry.consumed_bytes)? {
+                Some((text, consumed)) => {
+                    let mut facts = entry.facts.clone();
+                    for line in text.lines() {
+                        fold_session_facts_line(&mut facts, line);
+                    }
+                    let entry = Arc::new(CachedLineageFacts {
+                        consumed_bytes: entry.consumed_bytes + consumed,
+                        mtime_nanos,
+                        facts,
+                    });
+                    store_lineage_facts(&path, entry.clone());
+                    entry
+                }
+                // No complete new line yet — evaluate the cached facts and
+                // leave the cursor for the next call.
+                None => entry,
+            }
+        }
+        // Cold cache or a shrunk (rewritten) file: fold from scratch.
+        _ => {
+            let contents = match fs::read_to_string(&path) {
+                Ok(contents) => contents,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+                Err(err) => return Err(err),
+            };
+            let (complete, consumed) = complete_lines_prefix(&contents);
+            let entry = Arc::new(CachedLineageFacts {
+                consumed_bytes: consumed,
+                mtime_nanos,
+                facts: session_facts_from_jsonl(complete),
+            });
+            store_lineage_facts(&path, entry.clone());
+            entry
+        }
+    };
+    Ok(lineage_ledger_from_facts(&entry.facts, source_session_id))
+}
+
+/// The byte length of the foldable JSONL prefix of `buf`: every complete
+/// (newline-terminated) line, plus an unterminated final line iff it already
+/// parses as a complete JSON value. Event lines are JSON objects and no
+/// strict prefix of a JSON object parses, so a parsing tail is a whole event
+/// whose newline just hasn't landed — or a writer that never terminated its
+/// final line, which the historical full re-parse accepted. `None` when
+/// nothing is consumable yet. (An async twin lives in the Codex
+/// `context_trace.rs` for the trace-index fold.)
+fn consumable_jsonl_prefix(buf: &[u8]) -> Option<usize> {
+    let complete = buf
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map(|pos| pos + 1)
+        .unwrap_or(0);
+    let tail = &buf[complete..];
+    let consumed = if !tail.is_empty() && serde_json::from_slice::<serde_json::Value>(tail).is_ok()
+    {
+        buf.len()
+    } else {
+        complete
+    };
+    (consumed > 0).then_some(consumed)
+}
+
+/// The foldable prefix of `contents` and its byte length
+/// ([`consumable_jsonl_prefix`]).
+fn complete_lines_prefix(contents: &str) -> (&str, u64) {
+    match consumable_jsonl_prefix(contents.as_bytes()) {
+        Some(consumed) => (&contents[..consumed], consumed as u64),
+        None => ("", 0),
+    }
+}
+
+/// Read the consumable lines appended past `offset`
+/// ([`consumable_jsonl_prefix`]); `None` when nothing consumable arrived.
+/// Never consumes a partially flushed trailing line.
+fn read_new_complete_lines_sync(path: &Path, offset: u64) -> io::Result<Option<(String, u64)>> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut file = match fs::File::open(path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    if offset > 0 {
+        file.seek(SeekFrom::Start(offset))?;
+    }
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)?;
+    let Some(consumed) = consumable_jsonl_prefix(&buf) else {
+        return Ok(None);
+    };
+    buf.truncate(consumed);
+    // The writer emits UTF-8 JSONL; a non-UTF-8 tail is treated as
+    // not-yet-complete rather than corrupting the fold.
+    match String::from_utf8(buf) {
+        Ok(text) => Ok(Some((text, consumed as u64))),
+        Err(_) => Ok(None),
+    }
+}
+
+/// One-shot fold + derive over raw `session.jsonl` contents — the uncached
+/// composition of [`session_facts_from_jsonl`] and
+/// [`lineage_ledger_from_facts`]. Test surface: production reads go through
+/// [`read_lineage_ledger`]'s cache.
+#[cfg(test)]
+pub fn lineage_ledger_from_jsonl(contents: &str, source_session_id: &str) -> Option<LineageLedger> {
+    lineage_ledger_from_facts(&session_facts_from_jsonl(contents), source_session_id)
+}
+
+fn session_facts_from_jsonl(contents: &str) -> SessionFacts {
+    let mut facts = SessionFacts::default();
+    for line in contents.lines() {
+        fold_session_facts_line(&mut facts, line);
+    }
+    facts
+}
+
+/// Fold one `session.jsonl` line into the facts — a pure left-fold, so the
+/// incremental cache in [`read_lineage_ledger`] can continue exactly where
+/// the previous fold stopped.
+fn fold_session_facts_line(facts: &mut SessionFacts, line: &str) {
+    let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) else {
+        return;
+    };
+    let event = entry
+        .get("event")
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+    let data = entry.get("data").unwrap_or(&serde_json::Value::Null);
+    match event {
+        "session_identity" => {
+            let session_id = json_string(data, "session_id");
+            let backend_session_id = json_string(data, "backend_session_id");
+            if !session_id.is_empty() && !backend_session_id.is_empty() {
+                facts.identities.insert(session_id, backend_session_id);
+            }
+        }
+        "session_started" => {
+            let session_id = json_string(data, "session_id");
+            let task = json_string(data, "task");
+            if !session_id.is_empty() && !task.is_empty() {
+                facts.tasks.insert(session_id, task);
+            }
+        }
+        "session_relationship" => {
+            let rel = RelationshipKey {
+                parent_session_id: json_string(data, "parent_session_id"),
+                child_session_id: json_string(data, "child_session_id"),
+                relationship: json_string(data, "relationship"),
+                ephemeral: data
+                    .get("ephemeral")
+                    .and_then(|value| value.as_bool())
+                    .unwrap_or(false),
+            };
+            if !rel.parent_session_id.is_empty()
+                && !rel.child_session_id.is_empty()
+                && !rel.relationship.is_empty()
+            {
+                facts
+                    .relationship_order
+                    .insert(rel.clone(), facts.relationship_seq);
+                facts.relationship_seq += 1;
+                match rel.relationship.as_str() {
+                    // Fission detach/import markers prefer updating their
+                    // spawn row over becoming rows of their own; whether a
+                    // spawn row exists depends on the full relationship set,
+                    // so they are resolved at derive time (event order does
+                    // not matter).
+                    "fission-detached" | "fission-imported" => {
+                        let pair = (rel.parent_session_id.clone(), rel.child_session_id.clone());
+                        if rel.relationship == "fission-detached" {
+                            facts.fission_detached.insert(pair);
+                        } else {
+                            facts.fission_imported.insert(pair);
+                        }
+                        facts.pending_fission_marks.push(rel);
+                    }
+                    _ => {
+                        facts.relationships.insert(rel);
+                    }
+                }
+            }
+        }
+        "done_signal" => {
+            let session_id = json_string(data, "session_id");
+            if !session_id.is_empty() {
+                facts
+                    .statuses
+                    .insert(session_id.clone(), "completed".into());
+                // Ignore the writer's boilerplate default ("Agent signalled
+                // done") so it doesn't masquerade as a model-authored summary.
+                if let Some(message) = entry
+                    .get("message")
+                    .and_then(|value| value.as_str())
+                    .map(str::trim)
+                    .filter(|message| {
+                        !message.is_empty() && *message != DONE_SIGNAL_DEFAULT_MESSAGE
+                    })
+                    .map(trim_summary)
+                {
+                    facts.summaries.insert(session_id, message);
+                }
+            }
+        }
+        "task_complete" => {
+            let session_id = json_string(data, "session_id");
+            if !session_id.is_empty() {
+                facts
+                    .statuses
+                    .insert(session_id.clone(), "completed".into());
+                let summary = data
+                    .get("summary")
+                    .and_then(|value| value.as_str())
+                    .or_else(|| data.get("reason").and_then(|value| value.as_str()))
+                    .map(trim_summary);
+                if let Some(summary) = summary {
+                    facts.summaries.insert(session_id, summary);
+                }
+            }
+        }
+        "session_ended" => {
+            let session_id = json_string(data, "session_id");
+            if !session_id.is_empty() {
+                let reason = json_string(data, "reason");
+                // A generic teardown must not downgrade a completed task or
+                // clobber a model-authored summary with a terse reason.
+                if facts.statuses.get(&session_id).map(String::as_str) != Some("completed") {
+                    let status = if session_ended_reason_is_failure(&reason) {
+                        "failed"
+                    } else {
+                        "ended"
+                    };
+                    facts.statuses.insert(session_id.clone(), status.into());
+                }
+                if !reason.is_empty() && !facts.summaries.contains_key(&session_id) {
+                    facts.summaries.insert(session_id, trim_summary(&reason));
+                }
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Derive the lineage ledger for `source_session_id`'s connected component
-/// from raw `session.jsonl` contents. Called by [`read_lineage_ledger`] (the
-/// dashboard Managed tab / MCP `get_status` read side and the rewind path's
-/// lineage snapshot in `main.rs`).
+/// from folded facts — the cheap per-call step over the cached fold.
+/// Consumed by [`read_lineage_ledger`] (the dashboard Managed tab / MCP
+/// `get_status` read side and the rewind path's lineage snapshot in
+/// `main.rs`).
 ///
 /// Branch rows come from `session_relationship` events. Specially handled
 /// relationship kinds:
@@ -112,154 +421,33 @@ pub fn read_lineage_ledger(
 ///
 /// Everything else (`subagent`, `managed-edit-branch`, …) renders generically
 /// with the child's observed status.
-pub fn lineage_ledger_from_jsonl(contents: &str, source_session_id: &str) -> Option<LineageLedger> {
-    let mut facts = SessionFacts::default();
-    let mut relationship_seq = 0usize;
-    let mut pending_fission_marks: Vec<RelationshipKey> = Vec::new();
-    for line in contents.lines() {
-        let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
-        let event = entry
-            .get("event")
-            .and_then(|value| value.as_str())
-            .unwrap_or_default();
-        let data = entry.get("data").unwrap_or(&serde_json::Value::Null);
-        match event {
-            "session_identity" => {
-                let session_id = json_string(data, "session_id");
-                let backend_session_id = json_string(data, "backend_session_id");
-                if !session_id.is_empty() && !backend_session_id.is_empty() {
-                    facts.identities.insert(session_id, backend_session_id);
-                }
-            }
-            "session_started" => {
-                let session_id = json_string(data, "session_id");
-                let task = json_string(data, "task");
-                if !session_id.is_empty() && !task.is_empty() {
-                    facts.tasks.insert(session_id, task);
-                }
-            }
-            "session_relationship" => {
-                let rel = RelationshipKey {
-                    parent_session_id: json_string(data, "parent_session_id"),
-                    child_session_id: json_string(data, "child_session_id"),
-                    relationship: json_string(data, "relationship"),
-                    ephemeral: data
-                        .get("ephemeral")
-                        .and_then(|value| value.as_bool())
-                        .unwrap_or(false),
-                };
-                if !rel.parent_session_id.is_empty()
-                    && !rel.child_session_id.is_empty()
-                    && !rel.relationship.is_empty()
-                {
-                    facts
-                        .relationship_order
-                        .insert(rel.clone(), relationship_seq);
-                    relationship_seq += 1;
-                    match rel.relationship.as_str() {
-                        // Fission detach/import markers prefer updating their
-                        // spawn row over becoming rows of their own; whether a
-                        // spawn row exists is only known once the whole log
-                        // has been scanned, so they are resolved after the
-                        // loop (event order does not matter).
-                        "fission-detached" | "fission-imported" => {
-                            let pair =
-                                (rel.parent_session_id.clone(), rel.child_session_id.clone());
-                            if rel.relationship == "fission-detached" {
-                                facts.fission_detached.insert(pair);
-                            } else {
-                                facts.fission_imported.insert(pair);
-                            }
-                            pending_fission_marks.push(rel);
-                        }
-                        _ => {
-                            facts.relationships.insert(rel);
-                        }
-                    }
-                }
-            }
-            "done_signal" => {
-                let session_id = json_string(data, "session_id");
-                if !session_id.is_empty() {
-                    facts
-                        .statuses
-                        .insert(session_id.clone(), "completed".into());
-                    // Ignore the writer's boilerplate default ("Agent signalled
-                    // done") so it doesn't masquerade as a model-authored summary.
-                    if let Some(message) = entry
-                        .get("message")
-                        .and_then(|value| value.as_str())
-                        .map(str::trim)
-                        .filter(|message| {
-                            !message.is_empty() && *message != DONE_SIGNAL_DEFAULT_MESSAGE
-                        })
-                        .map(trim_summary)
-                    {
-                        facts.summaries.insert(session_id, message);
-                    }
-                }
-            }
-            "task_complete" => {
-                let session_id = json_string(data, "session_id");
-                if !session_id.is_empty() {
-                    facts
-                        .statuses
-                        .insert(session_id.clone(), "completed".into());
-                    let summary = data
-                        .get("summary")
-                        .and_then(|value| value.as_str())
-                        .or_else(|| data.get("reason").and_then(|value| value.as_str()))
-                        .map(trim_summary);
-                    if let Some(summary) = summary {
-                        facts.summaries.insert(session_id, summary);
-                    }
-                }
-            }
-            "session_ended" => {
-                let session_id = json_string(data, "session_id");
-                if !session_id.is_empty() {
-                    let reason = json_string(data, "reason");
-                    // A generic teardown must not downgrade a completed task or
-                    // clobber a model-authored summary with a terse reason.
-                    if facts.statuses.get(&session_id).map(String::as_str) != Some("completed") {
-                        let status = if session_ended_reason_is_failure(&reason) {
-                            "failed"
-                        } else {
-                            "ended"
-                        };
-                        facts.statuses.insert(session_id.clone(), status.into());
-                    }
-                    if !reason.is_empty() && !facts.summaries.contains_key(&session_id) {
-                        facts.summaries.insert(session_id, trim_summary(&reason));
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-
+fn lineage_ledger_from_facts(
+    facts: &SessionFacts,
+    source_session_id: &str,
+) -> Option<LineageLedger> {
     // A detach/import marker dedups into its spawn row (`fission-branch`)
     // when one exists — the marker then only drives that row's status — and
     // becomes a standalone row otherwise (e.g. a truncated log that no longer
     // carries the spawn event), so the fact stays visible either way.
-    for rel in pending_fission_marks {
-        let has_spawn_row = facts.relationships.iter().any(|existing| {
+    // Resolved per derive (not folded into the base facts) so a spawn event
+    // appended after its marker still dedups.
+    let mut relationships = facts.relationships.clone();
+    for rel in &facts.pending_fission_marks {
+        let has_spawn_row = relationships.iter().any(|existing| {
             existing.relationship == "fission-branch"
                 && existing.parent_session_id == rel.parent_session_id
                 && existing.child_session_id == rel.child_session_id
         });
         if !has_spawn_row {
-            facts.relationships.insert(rel);
+            relationships.insert(rel.clone());
         }
     }
 
-    if facts.relationships.is_empty() {
+    if relationships.is_empty() {
         return None;
     }
 
-    let relationships = related_relationships(facts.relationships, source_session_id);
+    let relationships = related_relationships(relationships, source_session_id);
     if relationships.is_empty() {
         return None;
     }
@@ -680,5 +868,77 @@ mod tests {
             .unwrap();
         assert_eq!(subagent.status, "completed");
         assert_eq!(detached.status, "detached");
+    }
+
+    #[test]
+    fn read_lineage_ledger_folds_appends_incrementally_and_refolds_on_truncation() {
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.jsonl");
+        let rel_line = r#"{"event":"session_relationship","data":{"parent_session_id":"parent","child_session_id":"child","relationship":"subagent","ephemeral":false}}"#;
+        let done_line = r#"{"event":"task_complete","data":{"session_id":"child","reason":"done","summary":"parser is fine"}}"#;
+        std::fs::write(&path, format!("{rel_line}\n")).unwrap();
+
+        // Missing log dir: clean None.
+        assert!(read_lineage_ledger(&dir.path().join("missing"), "parent")
+            .unwrap()
+            .is_none());
+
+        let ledger = read_lineage_ledger(dir.path(), "parent")
+            .unwrap()
+            .expect("ledger");
+        assert_eq!(ledger.groups[0].branches[0].status, "running");
+
+        // Append (as the writer does) — the cached fold extends and the new
+        // fact shows up.
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        writeln!(file, "{done_line}").unwrap();
+        drop(file);
+        let ledger = read_lineage_ledger(dir.path(), "parent")
+            .unwrap()
+            .expect("ledger");
+        assert_eq!(ledger.groups[0].branches[0].status, "completed");
+        assert_eq!(
+            ledger.groups[0].branches[0].summary.as_deref(),
+            Some("parser is fine")
+        );
+
+        // A partial trailing line (writer mid-flush) is invisible until its
+        // newline lands, then folds exactly once.
+        let second_rel = r#"{"event":"session_relationship","data":{"parent_session_id":"parent","child_session_id":"child-2","relationship":"subagent","ephemeral":false}}"#;
+        let (head, tail) = second_rel.split_at(second_rel.len() / 2);
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        write!(file, "{head}").unwrap();
+        drop(file);
+        let ledger = read_lineage_ledger(dir.path(), "parent")
+            .unwrap()
+            .expect("ledger");
+        assert_eq!(ledger.groups[0].branches.len(), 1);
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        writeln!(file, "{tail}").unwrap();
+        drop(file);
+        let ledger = read_lineage_ledger(dir.path(), "parent")
+            .unwrap()
+            .expect("ledger");
+        assert_eq!(ledger.groups[0].branches.len(), 2);
+
+        // Truncation (never produced by the append-only writer, but the
+        // cache must not serve stale facts): full refold.
+        std::fs::write(&path, format!("{rel_line}\n")).unwrap();
+        let ledger = read_lineage_ledger(dir.path(), "parent")
+            .unwrap()
+            .expect("ledger");
+        assert_eq!(ledger.groups[0].branches.len(), 1);
+        assert_eq!(ledger.groups[0].branches[0].status, "running");
     }
 }

--- a/src/bin/caller/lineage_ledger.rs
+++ b/src/bin/caller/lineage_ledger.rs
@@ -132,8 +132,10 @@ fn mtime_nanos_of(metadata: &fs::Metadata) -> u128 {
 /// The multi-MB log is NOT re-parsed per call: folded facts are cached per
 /// path and extended incrementally — an unchanged (len, mtime) serves from
 /// cache with one stat, an append folds only the new complete lines, and a
-/// shrunk file (never produced by the append-only writer) re-folds from
-/// scratch.
+/// detected rewrite (shrunk file, or an mtime change at unchanged length)
+/// re-folds from scratch. The writer is append-only today, so rewrite
+/// detection is contract hardening; a rewrite that regrows PAST the cursor
+/// within one poll interval is the residual undetected case.
 pub fn read_lineage_ledger(
     log_dir: &Path,
     source_session_id: &str,
@@ -156,9 +158,11 @@ pub fn read_lineage_ledger(
     let entry = match cached {
         // Unchanged file: derive straight from the cached facts.
         Some(entry) if entry.consumed_bytes == len && entry.mtime_nanos == mtime_nanos => entry,
-        // Grown file: fold only the appended complete lines.
-        Some(entry) if entry.consumed_bytes <= len => {
-            match read_new_complete_lines_sync(&path, entry.consumed_bytes)? {
+        // Grown file: fold only the appended complete lines. (Strictly
+        // greater — an mtime change at unchanged length is a rewrite and
+        // falls through to the full refold below.)
+        Some(entry) if entry.consumed_bytes < len => {
+            match read_new_complete_lines_sync(&path, entry.consumed_bytes, len)? {
                 Some((text, consumed)) => {
                     let mut facts = entry.facts.clone();
                     for line in text.lines() {
@@ -173,11 +177,13 @@ pub fn read_lineage_ledger(
                     entry
                 }
                 // No complete new line yet — evaluate the cached facts and
-                // leave the cursor for the next call.
+                // leave the cursor (including its recorded mtime) for the
+                // next call to retry.
                 None => entry,
             }
         }
-        // Cold cache or a shrunk (rewritten) file: fold from scratch.
+        // Cold cache, a shrunk file, or a same-length rewrite (mtime moved
+        // with no growth): fold from scratch.
         _ => {
             let contents = match fs::read_to_string(&path) {
                 Ok(contents) => contents,
@@ -232,8 +238,14 @@ fn complete_lines_prefix(contents: &str) -> (&str, u64) {
 
 /// Read the consumable lines appended past `offset`
 /// ([`consumable_jsonl_prefix`]); `None` when nothing consumable arrived.
-/// Never consumes a partially flushed trailing line.
-fn read_new_complete_lines_sync(path: &Path, offset: u64) -> io::Result<Option<(String, u64)>> {
+/// Never consumes a partially flushed trailing line. The read is clamped to
+/// the caller's stat snapshot (`stat_len`) so the recorded mtime stays
+/// paired with the consumed length.
+fn read_new_complete_lines_sync(
+    path: &Path,
+    offset: u64,
+    stat_len: u64,
+) -> io::Result<Option<(String, u64)>> {
     use std::io::{Read, Seek, SeekFrom};
     let mut file = match fs::File::open(path) {
         Ok(file) => file,
@@ -244,7 +256,8 @@ fn read_new_complete_lines_sync(path: &Path, offset: u64) -> io::Result<Option<(
         file.seek(SeekFrom::Start(offset))?;
     }
     let mut buf = Vec::new();
-    file.read_to_end(&mut buf)?;
+    file.take(stat_len.saturating_sub(offset))
+        .read_to_end(&mut buf)?;
     let Some(consumed) = consumable_jsonl_prefix(&buf) else {
         return Ok(None);
     };
@@ -940,5 +953,46 @@ mod tests {
             .expect("ledger");
         assert_eq!(ledger.groups[0].branches.len(), 1);
         assert_eq!(ledger.groups[0].branches[0].status, "running");
+    }
+
+    #[test]
+    fn read_lineage_ledger_refolds_on_same_length_rewrite() {
+        fn set_mtime(path: &Path, secs_since_epoch: u64) {
+            let file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+            file.set_modified(
+                std::time::UNIX_EPOCH + std::time::Duration::from_secs(secs_since_epoch),
+            )
+            .unwrap();
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.jsonl");
+        let rel_line = r#"{"event":"session_relationship","data":{"parent_session_id":"parent","child_session_id":"child","relationship":"subagent","ephemeral":false}}"#;
+        let done_a = r#"{"event":"task_complete","data":{"session_id":"child","reason":"done","summary":"parser is fine"}}"#;
+        let done_b = r#"{"event":"task_complete","data":{"session_id":"child","reason":"done","summary":"parser is FINE"}}"#;
+        assert_eq!(done_a.len(), done_b.len(), "test needs equal-length lines");
+
+        std::fs::write(&path, format!("{rel_line}\n{done_a}\n")).unwrap();
+        set_mtime(&path, 1_000);
+        let ledger = read_lineage_ledger(dir.path(), "parent")
+            .unwrap()
+            .expect("ledger");
+        assert_eq!(
+            ledger.groups[0].branches[0].summary.as_deref(),
+            Some("parser is fine")
+        );
+
+        // Same total length, different content, different mtime: the pure
+        // (consumed <= len) model would read zero new bytes and serve the
+        // stale facts forever.
+        std::fs::write(&path, format!("{rel_line}\n{done_b}\n")).unwrap();
+        set_mtime(&path, 2_000);
+        let ledger = read_lineage_ledger(dir.path(), "parent")
+            .unwrap()
+            .expect("ledger");
+        assert_eq!(
+            ledger.groups[0].branches[0].summary.as_deref(),
+            Some("parser is FINE")
+        );
     }
 }


### PR DESCRIPTION
Efficiency pass over the external-agent supervision + managed-context trace subsystems (audit scopes 19 + 06, verified against current main). The dominant theme: the managed-Codex context-trace layer re-read its whole archive on every access; it now maintains incremental state and reads only what changed.

## Findings implemented

| Finding | Site | Fix | Complexity |
|---|---|---|---|
| `context_snapshot()` resolved every historical request's chain to return only the newest (~GB reads/turn observed) | `external_agent/codex/context_trace.rs` (`read_latest_codex_context_payload`), `codex/mod.rs` (`read_context_snapshot`) | `CodexTraceIndexCache::latest_snapshot`: snapshot only the max-order request; chain resolution cached and extended (chains are append-only) | O(R²) file reads per call → O(new hops); unchanged-latest preflights re-read 1 payload file |
| Trace index re-read/parsed from byte 0 on every fingerprint change | `codex/mod.rs` (`context_snapshots`), `context_trace.rs` (`read_codex_trace_index`) | per-file byte/line cursors; stat-guarded tail reads fold only appended lines; shrunk/vanished file → full rebuild fallback | O(total lines) per change → O(appended lines); cumulative O(R²) → O(R) |
| Exact-archive fingerprint re-enumerated every session dir under the logs root at 1 Hz | `context_trace.rs` (`collect_codex_trace_bundle_dirs`) | cross-session aux bundle dirs cached behind the logs root's mtime; primary root still enumerated fresh | thousands of read_dir+stat/sec → 1 stat + one small read_dir/sec steady-state |
| `resolved_input.clone()` of the whole conversation only to take `.len()` | `context_trace.rs` (async resolver + sync twin) | count before moving the array into the payload | one full conversation deep-clone per request eliminated (sync twin; async path now clones only into the chain cache, which it repays in avoided rereads) |
| Request sort key allocated 3 Strings per comparison | `context_trace.rs` (`codex_request_sort_key`) | non-allocating comparator `codex_request_order_cmp` | O(R log R) allocations per sort → 0 |
| Every stdout line re-allocated + parsed Value round-tripped through serde | `codex/reader.rs` reader loop | borrow the trimmed line; `decode_jsonrpc_message` moves the 5 envelope fields out of the object (parity-tested against the serde derive) | second pass O(tree) → O(fields); one memcpy per line eliminated; two-pass protocol-watch design untouched |
| `terminal_turns_observed` grew unboundedly for the app-server's life | `codex/reader.rs` | insertion-ordered set capped at 256 keys (oldest evicted); dedup only needs recent terminal events | unbounded → O(1) memory |
| CC tool-result text cloned in full, retained only for a 200-char error snippet | `external_agent/claude_code.rs` (`tool_result_events`) | build the failure snippet first, move the text into the event | one full result-text clone per tool completion eliminated |
| Wrapper-index `upsert`/`record_rollout_path` cloned the whole index per call | `external_wrapper_index.rs` | read-only dirty decision against the cached index (shared predicates); clone only when writing | per-row clone on every session-list pass → clone only on actual change |
| `record_changed_file` did one fsync'd full-ledger RMW per file per branch | `fission_lifecycle.rs` watcher loop + `fission_ledger.rs` (`update_branches_changed_files`) | burst-drain FileChanged events, stage per branch, flush one RMW per log dir; skip the write when nothing new merged | save storm × branches fsync'd rewrites → 1 per burst; stream-order/terminal semantics preserved |
| `wait_for_branch_terminal` re-parsed the whole ledger at 1 Hz | `fission_lifecycle.rs` | (len, mtime-nanos) fingerprint guard (writes land via atomic rename); re-evaluate cached snapshot when unchanged | ~1 MB parse/sec per waiter → 1 stat/sec |
| `get_status` re-parsed the entire session.jsonl per poll (8–17 MB observed) | `lineage_ledger.rs` (`read_lineage_ledger`) | source-independent facts fold split from the derive; per-path cache with byte cursor: stat-only when unchanged, fold appended lines on growth, full refold on shrink | O(file) per poll → O(appended); benefits mcp get_status and the rewind path without touching those callers |

## Correctness notes

- Tail reads consume complete lines only, plus an unterminated final line iff it parses as a complete JSON value (no strict prefix of a JSON object parses) — matching what the historical full re-scan accepted, including writers that never terminate the final line.
- Rewrite blind spot: a same-length in-place rewrite is undetectable by (len, mtime) — the same blind spot the existing fingerprint gate and wrapper-index cache have always had. Shrinks rebuild from scratch.
- Chain-cache invalidation: keyed by (trace root, thread); cleared on truncation rebuilds and re-initialize; a chain that never reaches the cached call key resolves from scratch (rewrites/forks).
- Aux-dir cache staleness window: a new bundle appearing inside another session's existing trace dir is invisible until the logs root's mtime moves — only reachable with two live sessions tracing the same thread, which is unsupported today.
- Not regressed: protocol-watch stays two-pass with passive status parsing on demand; the observe drain and ambient-event separation are untouched.

## Deliberately not done

- Full fission-ledger write debounce (in-memory document + periodic flush): narrows the durability window and needs a crash-consistency argument — the batch fix removes the dominant multiplier without changing when data is durable.
- Findings in `managed_context_ops/**`, `mcp/**`, `web_gateway/**` (rewind multi-scan, anchor-catalog post-pass, edit-branch resolution sweep, latest-entry reverse iteration, skinny `list_records` — audit 06-2/5/6/7/9): outside this change's file scope; `list_records` additionally needs its callers changed.

## Validation

- `cargo fmt --check` clean
- `cargo clippy` clean (touched files also clean under `--tests`)
- `cargo test --bins`: 3334 + 69 + 83 passed, 0 failed
- `cargo test --test e2e`: 21 passed, 0 failed
- New tests: incremental fold/truncation-rebuild/partial-line for the trace cache; chain extension proven by deleting historical payload files before extending; JSON-RPC decode parity vs the serde derive; bounded terminal-key eviction; batched changed-file ledger write; lineage append/truncate/partial-line cache behavior
