### PR TITLE
access/gateway: share IAM snapshots as Arcs, memoize opening-authority checks, unstarve catalog/search hot paths

### DIFF
--- a/src/bin/caller/access/iam.rs
+++ b/src/bin/caller/access/iam.rs
@@ -20,6 +20,9 @@ pub const IAM_STATE_FILE: &str = "iam.json";
 pub const BROWSER_MTLS_INITIALIZED_FILE: &str = "browser-mtls-root.initialized";
 pub const IAM_SCHEMA_VERSION: u32 = 2;
 const DEFAULT_HOSTED_ORIGIN: &str = "https://connect.intendant.dev";
+/// Newest audit events retained inside `iam.json` (see `normalize`); the
+/// same order of magnitude as the credential custody trail's in-memory cap.
+const IAM_AUDIT_EVENTS_CAP: usize = 300;
 
 fn default_schema_version() -> u32 {
     // A missing version is a legacy state and must run migrations.
@@ -842,6 +845,18 @@ impl LocalIamState {
         self.grants
             .retain(|g| !g.id.trim().is_empty() && !g.principal_id.trim().is_empty());
         self.audit_events.retain(|e| !e.id.trim().is_empty());
+        // Bound the audit trail to a recent tail, mirroring the credential
+        // custody trail's in-memory cap (`credential_audit::MEM_CAP`).
+        // Events are appended chronologically, so the head is the oldest.
+        // The evaluator never reads `audit_events` — retention is a
+        // forensics window, not an authorization input — and an uncapped
+        // vec otherwise rides every request-path load, per-mutation
+        // pretty-print + fsync, and `/api/access/iam/state` response for
+        // the daemon's lifetime.
+        if self.audit_events.len() > IAM_AUDIT_EVENTS_CAP {
+            let excess = self.audit_events.len() - IAM_AUDIT_EVENTS_CAP;
+            self.audit_events.drain(..excess);
+        }
         self
     }
 
@@ -1279,14 +1294,6 @@ pub fn load_state_cached_arc(cert_dir: &Path) -> AccessResult<std::sync::Arc<Loc
     Ok(std::sync::Arc::new(state))
 }
 
-/// Owned compatibility wrapper for callers that intentionally mutate or
-/// retain an independent IAM snapshot. Hot authorization paths should prefer
-/// [`load_state_cached_arc`] so an unchanged state does not deep-clone its
-/// principals, grants, and audit history on every input frame.
-pub fn load_state_cached(cert_dir: &Path) -> AccessResult<LocalIamState> {
-    load_state_cached_arc(cert_dir).map(|state| (*state).clone())
-}
-
 struct UserClientBinding {
     principal_id: String,
     principal_kind: String,
@@ -1301,7 +1308,7 @@ pub fn upsert_user_client_grant(
     request: UserClientGrantUpsertRequest,
     actor: &AccessPrincipal,
 ) -> AccessResult<UserClientGrantUpsertResult> {
-    let fleet_zone = crate::fleet_cert::status_snapshot().zone;
+    let fleet_zone = crate::fleet_cert::fleet_zone();
     upsert_user_client_grant_with_fleet_zone(state, request, actor, fleet_zone.as_deref())
 }
 
@@ -1497,7 +1504,7 @@ pub fn update_user_client_grant(
     request: IamGrantUpdateRequest,
     actor: &AccessPrincipal,
 ) -> AccessResult<IamGrantUpdateResult> {
-    let fleet_zone = crate::fleet_cert::status_snapshot().zone;
+    let fleet_zone = crate::fleet_cert::fleet_zone();
     update_user_client_grant_with_fleet_zone(state, request, actor, fleet_zone.as_deref())
 }
 
@@ -2495,7 +2502,15 @@ pub fn evaluate_principal_operation_with_state(
     principal: &AccessPrincipal,
     op: crate::access::access_policy::PeerOperation,
 ) -> AccessDecision {
-    let fleet_zone = crate::fleet_cert::status_snapshot().zone;
+    // The zone feeds only the client_key origin classification below —
+    // fetch it lazily so every other principal kind (mTLS certificates,
+    // root sessions, peers, agent sessions) skips the fleet-status mutex
+    // on this per-request/per-frame path.
+    let fleet_zone = if principal.authn_kind.as_deref() == Some("client_key") {
+        crate::fleet_cert::fleet_zone()
+    } else {
+        None
+    };
     evaluate_principal_operation_with_state_and_fleet_zone(
         state,
         principal,
@@ -2948,7 +2963,7 @@ pub fn operation_permission_id(op: crate::access::access_policy::PeerOperation) 
 }
 
 pub fn principal_overview_values(state: &LocalIamState) -> Vec<Value> {
-    let fleet_zone = crate::fleet_cert::status_snapshot().zone;
+    let fleet_zone = crate::fleet_cert::fleet_zone();
     principal_overview_values_with_fleet_zone(state, fleet_zone.as_deref())
 }
 
@@ -2993,7 +3008,7 @@ pub(crate) fn principal_overview_values_with_fleet_zone(
 }
 
 pub fn grant_overview_values(state: &LocalIamState, default_target_id: &str) -> Vec<Value> {
-    let fleet_zone = crate::fleet_cert::status_snapshot().zone;
+    let fleet_zone = crate::fleet_cert::fleet_zone();
     grant_overview_values_with_fleet_zone(state, default_target_id, fleet_zone.as_deref())
 }
 
@@ -4262,6 +4277,29 @@ mod tests {
     }
 
     #[test]
+    fn normalize_bounds_audit_events_to_newest_tail() {
+        let mut state = LocalIamState::default();
+        for index in 0..(IAM_AUDIT_EVENTS_CAP + 50) {
+            state.audit_events.push(IamAuditEvent {
+                id: format!("audit:{index}"),
+                at_unix_ms: Some(index as u64),
+                actor_principal_id: "principal:test".to_string(),
+                action: "test".to_string(),
+                target_id: "target".to_string(),
+                summary: format!("event {index}"),
+            });
+        }
+        let state = state.normalize();
+        assert_eq!(state.audit_events.len(), IAM_AUDIT_EVENTS_CAP);
+        // Oldest events dropped, newest retained, order preserved.
+        assert_eq!(state.audit_events.first().unwrap().id, "audit:50");
+        assert_eq!(
+            state.audit_events.last().unwrap().id,
+            format!("audit:{}", IAM_AUDIT_EVENTS_CAP + 49)
+        );
+    }
+
+    #[test]
     fn malformed_state_reports_error_for_overview() {
         let tmp = tempfile::TempDir::new().unwrap();
         std::fs::write(iam_state_path(tmp.path()), b"{not json").unwrap();
@@ -4278,7 +4316,7 @@ mod tests {
 
         // Missing file: same default-state contract as load_state.
         assert_eq!(
-            load_state_cached(tmp.path()).unwrap(),
+            *load_state_cached_arc(tmp.path()).unwrap(),
             load_state(tmp.path()).unwrap()
         );
 
@@ -4298,20 +4336,21 @@ mod tests {
             created_at_unix_ms: Some(1),
         });
         save_state(tmp.path(), &state).unwrap();
-        let cached = load_state_cached(tmp.path()).unwrap();
-        assert_eq!(cached, load_state(tmp.path()).unwrap());
+        let cached = load_state_cached_arc(tmp.path()).unwrap();
+        assert_eq!(*cached, load_state(tmp.path()).unwrap());
         assert!(cached
             .principals
             .iter()
             .any(|p| p.id == "principal:cache-a"));
-        // Second read (a cache hit) is identical.
-        assert_eq!(load_state_cached(tmp.path()).unwrap(), cached);
-        assert_eq!(*load_state_cached_arc(tmp.path()).unwrap(), cached);
+        // Second read (a cache hit) is the same shared snapshot.
+        let hit = load_state_cached_arc(tmp.path()).unwrap();
+        assert!(std::sync::Arc::ptr_eq(&hit, &cached));
+        assert_eq!(*hit, *cached);
 
         // A writer that bypasses save_state (another process, a hand
         // edit) must be picked up by the per-call fingerprint re-check —
         // never trust invalidation.
-        let mut external = cached.clone();
+        let mut external = (*cached).clone();
         for principal in &mut external.principals {
             if principal.id == "principal:cache-a" {
                 principal.label = "Cache A (externally rewritten)".to_string();
@@ -4319,17 +4358,17 @@ mod tests {
         }
         let body = serde_json::to_string_pretty(&external).unwrap();
         std::fs::write(iam_state_path(tmp.path()), body).unwrap();
-        let reread = load_state_cached(tmp.path()).unwrap();
+        let reread = load_state_cached_arc(tmp.path()).unwrap();
         assert!(reread
             .principals
             .iter()
             .any(|p| p.label == "Cache A (externally rewritten)"));
-        assert_eq!(reread, load_state(tmp.path()).unwrap());
+        assert_eq!(*reread, load_state(tmp.path()).unwrap());
 
         // Deleting the file falls back to the default state.
         std::fs::remove_file(iam_state_path(tmp.path())).unwrap();
         assert_eq!(
-            load_state_cached(tmp.path()).unwrap(),
+            *load_state_cached_arc(tmp.path()).unwrap(),
             LocalIamState::default()
         );
     }

--- a/src/bin/caller/access/mod.rs
+++ b/src/bin/caller/access/mod.rs
@@ -40,11 +40,21 @@ pub mod wizard;
 /// Callable from `intendant --web` without running any `access` action,
 /// because the backend's `cert_dir()` is a pure path accessor with no
 /// privileged I/O.
+///
+/// Cached for the process lifetime: resolution shells out to `hostname`
+/// and probes up to three cert-store directories, and callers sit on
+/// request-serving paths (org target ids, peer cards). The label only
+/// changes through `intendant access` runs, which are separate processes.
 pub fn resolve_host_label() -> String {
-    let be = backend::select_backend();
-    let cert_dir = be.cert_dir();
-    let candidates = host_label_candidates(&cert_dir);
-    choose_host_label(candidates, hostname().ok().as_deref())
+    static LABEL: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    LABEL
+        .get_or_init(|| {
+            let be = backend::select_backend();
+            let cert_dir = be.cert_dir();
+            let candidates = host_label_candidates(&cert_dir);
+            choose_host_label(candidates, hostname().ok().as_deref())
+        })
+        .clone()
 }
 
 /// Read the system hostname by shelling out to the platform `hostname` command.

--- a/src/bin/caller/connect_rendezvous.rs
+++ b/src/bin/caller/connect_rendezvous.rs
@@ -626,7 +626,12 @@ async fn run_connect_rendezvous_client(
                                 event,
                             )
                             .await;
-                            continue;
+                            // Fall through to the refresh check below: a
+                            // continuous event stream must not starve the
+                            // periodic re-register (daemon_session_token
+                            // rotation + claim-code refresh), which used to
+                            // be reachable only after an empty poll.
+                            false
                         }
                         Ok(None) => {
                             report_dry_credentials(&client, &base_url, &config, &daemon_id).await;

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -3425,8 +3425,9 @@ mod tests {
         .unwrap();
         DashboardControlGrant::UserClient {
             principal,
-            iam_state: state,
+            iam_state: std::sync::Arc::new(state),
             iam_cert_dir: None,
+            authority_memo: Default::default(),
         }
     }
 
@@ -3435,7 +3436,7 @@ mod tests {
         let DashboardControlGrant::UserClient { iam_state, .. } = &mut grant else {
             unreachable!("observer fixture is a user client")
         };
-        let role = iam_state
+        let role = std::sync::Arc::make_mut(iam_state)
             .roles
             .iter_mut()
             .find(|role| role.id == "role:observer")

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -2792,8 +2792,9 @@ mod tests {
         rt.display_authority = Some(bridge);
         rt.grant = DashboardControlGrant::UserClient {
             principal,
-            iam_state: state.clone(),
+            iam_state: std::sync::Arc::new(state.clone()),
             iam_cert_dir: Some(tmp.path().to_path_buf()),
+            authority_memo: Default::default(),
         };
         let shutdown = CancellationToken::new();
         assert!(dashboard_display_input_remains_authorized(

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -527,9 +527,7 @@ pub(crate) enum DashboardControlSessionMutation {
 ///   semantics): a grant expiring between two events is caught even though
 ///   the state snapshot never changed.
 #[derive(Clone, Debug, Default)]
-pub struct OpeningAuthorityMemo(
-    Arc<std::sync::Mutex<Option<OpeningAuthorityMemoEntry>>>,
-);
+pub struct OpeningAuthorityMemo(Arc<std::sync::Mutex<Option<OpeningAuthorityMemoEntry>>>);
 
 #[derive(Debug)]
 struct OpeningAuthorityMemoEntry {
@@ -566,10 +564,7 @@ impl OpeningAuthorityMemo {
 
     #[cfg(test)]
     fn is_primed(&self) -> bool {
-        self.0
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .is_some()
+        self.0.lock().unwrap_or_else(|e| e.into_inner()).is_some()
     }
 }
 
@@ -690,10 +685,7 @@ impl DashboardControlGrant {
                 if records_current {
                     // Everything except the expiry instant validated true
                     // for this snapshot; hits re-run only the expiry check.
-                    authority_memo.store(
-                        Arc::clone(&current),
-                        current_grant.expires_at_unix_ms,
-                    );
+                    authority_memo.store(Arc::clone(&current), current_grant.expires_at_unix_ms);
                 }
                 // `records_current` covers the grant-status half of
                 // `is_active_at`; the expiry half stays live.

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -452,11 +452,18 @@ pub enum DashboardControlGrant {
     TrustedLocal,
     UserClient {
         principal: crate::access::iam::AccessPrincipal,
-        iam_state: crate::access::iam::LocalIamState,
+        /// The opening IAM snapshot (shared from the stat-fingerprint
+        /// cache — construction must not deep-clone the state per
+        /// connection). Immutable for the session lifetime: liveness
+        /// checks compare it against freshly loaded state.
+        iam_state: std::sync::Arc<crate::access::iam::LocalIamState>,
         /// Production sessions reload this daemon-owned IAM directory through
         /// the stat-fingerprint cache before every authorization decision.
         /// `None` is reserved for hermetic in-memory tests.
         iam_cert_dir: Option<PathBuf>,
+        /// Per-session memo for [`Self::opening_authority_is_current`];
+        /// construct with `Default::default()`.
+        authority_memo: OpeningAuthorityMemo,
     },
     Peer {
         fingerprint: String,
@@ -502,6 +509,70 @@ pub(crate) enum DashboardControlSessionMutation {
     Forbidden,
 }
 
+/// Memo for [`DashboardControlGrant::opening_authority_is_current`]: the
+/// exact IAM state snapshot (by `Arc` identity) the last **successful** full
+/// validation ran against, plus the validated grant's expiry — the only
+/// input of that verdict that changes without a state change. Clones of a
+/// grant share the cell, which is sound because clones carry the identical
+/// opening snapshot.
+///
+/// Trust invariants (do not weaken):
+/// - Only positive verdicts are memoized; any negative outcome re-runs the
+///   full validation on the next call.
+/// - A hit requires `Arc::ptr_eq` with a snapshot this memo keeps alive, so
+///   a match can never be an ABA false positive from a recycled allocation.
+///   Every IAM edit — revocation included — reaches sessions as a *new* Arc
+///   from the stat-fingerprint cache and therefore forces full revalidation.
+/// - The expiry instant is re-checked on every hit (`IamGrant::is_active_at`
+///   semantics): a grant expiring between two events is caught even though
+///   the state snapshot never changed.
+#[derive(Clone, Debug, Default)]
+pub struct OpeningAuthorityMemo(
+    Arc<std::sync::Mutex<Option<OpeningAuthorityMemoEntry>>>,
+);
+
+#[derive(Debug)]
+struct OpeningAuthorityMemoEntry {
+    /// The snapshot the full validation passed against. Holding the Arc
+    /// pins the allocation, making the pointer comparison an identity test.
+    validated: Arc<crate::access::iam::LocalIamState>,
+    /// `expires_at_unix_ms` of the validated current grant.
+    expires_at_unix_ms: Option<u64>,
+}
+
+impl OpeningAuthorityMemo {
+    /// `Some(expires_at_unix_ms)` when `current` is the exact snapshot the
+    /// last successful full validation ran against.
+    fn validated_expiry(
+        &self,
+        current: &Arc<crate::access::iam::LocalIamState>,
+    ) -> Option<Option<u64>> {
+        let memo = self.0.lock().unwrap_or_else(|e| e.into_inner());
+        memo.as_ref()
+            .filter(|entry| Arc::ptr_eq(&entry.validated, current))
+            .map(|entry| entry.expires_at_unix_ms)
+    }
+
+    fn store(
+        &self,
+        validated: Arc<crate::access::iam::LocalIamState>,
+        expires_at_unix_ms: Option<u64>,
+    ) {
+        *self.0.lock().unwrap_or_else(|e| e.into_inner()) = Some(OpeningAuthorityMemoEntry {
+            validated,
+            expires_at_unix_ms,
+        });
+    }
+
+    #[cfg(test)]
+    fn is_primed(&self) -> bool {
+        self.0
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_some()
+    }
+}
+
 /// The verified human identity behind a delegation-lane connection.
 #[derive(Clone, Debug)]
 pub struct PeerAttribution {
@@ -530,7 +601,7 @@ impl DashboardControlGrant {
         match iam_cert_dir {
             Some(cert_dir) => crate::access::iam::load_state_cached_arc(cert_dir)
                 .map_err(|error| format!("reload local IAM state: {error}")),
-            None => Ok(Arc::new(iam_state.clone())),
+            None => Ok(Arc::clone(iam_state)),
         }
     }
 
@@ -539,11 +610,19 @@ impl DashboardControlGrant {
     /// revocation, expiry/ORL materialization, scope edit, deletion, or a
     /// reload error) makes the session stale and forces a reconnect under the
     /// new authority. Unrelated IAM edits do not disturb it.
+    ///
+    /// Called per injected input event and per transfer-pump beat, so the
+    /// full record validation is memoized per state snapshot (see
+    /// [`OpeningAuthorityMemo`] for the trust argument): the state content
+    /// is immutable within one cached `Arc`, revocation liveness arrives as
+    /// a *new* `Arc`, and the expiry instant — the one time-dependent input
+    /// — is re-checked on every call, memo hit or not.
     pub(crate) fn opening_authority_is_current(&self) -> bool {
         match self {
             Self::UserClient {
                 principal,
                 iam_state,
+                authority_memo,
                 ..
             } => {
                 let Some(grant_id) = principal.grant_id.as_deref() else {
@@ -552,6 +631,17 @@ impl DashboardControlGrant {
                 let Ok(current) = self.current_user_client_state() else {
                     return false;
                 };
+                let now_unix_ms = crate::access::client_key::now_unix_ms();
+                if let Some(expires_at_unix_ms) = authority_memo.validated_expiry(&current) {
+                    // This exact snapshot already passed the full validation
+                    // below; only the expiry comparison involves the clock.
+                    // Mirrors `IamGrant::is_active_at` (statuses were
+                    // enforced at memo time and are immutable in-snapshot).
+                    return match expires_at_unix_ms {
+                        Some(expires) => (now_unix_ms as u128) < (expires as u128),
+                        None => true,
+                    };
+                }
                 let Some(opening_grant) =
                     iam_state.grants.iter().find(|grant| grant.id == grant_id)
                 else {
@@ -591,12 +681,27 @@ impl DashboardControlGrant {
                 let hosted_provenance_unchanged = principal.authn_kind.as_deref()
                     != Some("client_key")
                     || iam_state.hosted_origins == current.hosted_origins;
-                opening_grant == current_grant
+                let records_current = opening_grant == current_grant
                     && opening_principal == current_principal
                     && opening_role == current_role
                     && hosted_provenance_unchanged
-                    && current_grant.is_active_at(crate::access::client_key::now_unix_ms())
-                    && crate::access::iam::is_enforced_status(&current_principal.status)
+                    && crate::access::iam::is_enforced_status(&current_grant.status)
+                    && crate::access::iam::is_enforced_status(&current_principal.status);
+                if records_current {
+                    // Everything except the expiry instant validated true
+                    // for this snapshot; hits re-run only the expiry check.
+                    authority_memo.store(
+                        Arc::clone(&current),
+                        current_grant.expires_at_unix_ms,
+                    );
+                }
+                // `records_current` covers the grant-status half of
+                // `is_active_at`; the expiry half stays live.
+                records_current
+                    && match current_grant.expires_at_unix_ms {
+                        Some(expires) => (now_unix_ms as u128) < (expires as u128),
+                        None => true,
+                    }
             }
             Self::Peer {
                 fingerprint,
@@ -1996,8 +2101,9 @@ mod fs_scope_grant_tests {
                 .unwrap();
         DashboardControlGrant::UserClient {
             principal,
-            iam_state: state,
+            iam_state: std::sync::Arc::new(state),
             iam_cert_dir: None,
+            authority_memo: Default::default(),
         }
     }
 
@@ -2094,8 +2200,9 @@ mod fs_scope_grant_tests {
         .unwrap();
         let grant = DashboardControlGrant::UserClient {
             principal,
-            iam_state: state.clone(),
+            iam_state: std::sync::Arc::new(state.clone()),
             iam_cert_dir: Some(tmp.path().to_path_buf()),
+            authority_memo: Default::default(),
         };
         assert!(grant.opening_authority_is_current());
         assert!(grant.has_owner_dashboard_authority());
@@ -2125,6 +2232,116 @@ mod fs_scope_grant_tests {
         let denied = grant.access_decision(PeerOperation::PresenceRead);
         assert!(!denied.allowed);
         assert!(denied.reason.contains("unavailable"), "{}", denied.reason);
+    }
+
+    /// Trust pin for the `OpeningAuthorityMemo` fast path: a memo hit
+    /// (same state `Arc`, no IAM edit in between) must still re-check the
+    /// grant's expiry instant on every call — a grant expiring between two
+    /// input events is caught even though the state snapshot never changed.
+    #[test]
+    fn opening_authority_memo_hit_still_rechecks_expiry_instant() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let actor = crate::access::iam::AccessPrincipal::root_dashboard_session("test", "unit");
+        let mut state = crate::access::iam::LocalIamState::default();
+        // Wide enough that upsert + save + the two pre-expiry assertions
+        // comfortably fit before the instant, even on a loaded CI box;
+        // the post-expiry wait below is bounded by the same margin.
+        let expires_at = crate::access::client_key::now_unix_ms() as u64 + 1_500;
+        crate::access::iam::upsert_user_client_grant(
+            &mut state,
+            crate::access::iam::UserClientGrantUpsertRequest {
+                kind: "browser_certificate".to_string(),
+                fingerprint: Some("AA:57".to_string()),
+                role_id: Some("role:observer".to_string()),
+                expires_at_unix_ms: Some(expires_at),
+                ..Default::default()
+            },
+            &actor,
+        )
+        .unwrap();
+        crate::access::iam::save_state(tmp.path(), &state).unwrap();
+        let principal = crate::access::iam::principal_for_browser_mtls_cert(
+            &state,
+            "AA:57",
+            "webrtc-datachannel",
+        )
+        .unwrap();
+        let memo = OpeningAuthorityMemo::default();
+        let grant = DashboardControlGrant::UserClient {
+            principal,
+            iam_state: std::sync::Arc::new(state.clone()),
+            iam_cert_dir: Some(tmp.path().to_path_buf()),
+            authority_memo: memo.clone(),
+        };
+        // Full validation primes the memo; the repeat call is the hit path.
+        assert!(grant.opening_authority_is_current());
+        assert!(memo.is_primed());
+        assert!(grant.opening_authority_is_current());
+        // Cross the expiry instant WITHOUT touching iam.json: the snapshot
+        // Arc is unchanged, so only the hit path's expiry re-check can (and
+        // must) flip the verdict.
+        while (crate::access::client_key::now_unix_ms() as u64) < expires_at {
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        assert!(memo.is_primed());
+        assert!(!grant.opening_authority_is_current());
+    }
+
+    /// Trust pin for the `OpeningAuthorityMemo` fast path: any IAM edit
+    /// reaches the session as a NEW state `Arc` from the fingerprint cache,
+    /// so a primed memo never carries a stale verdict across a revocation.
+    #[test]
+    fn opening_authority_memo_never_outlives_a_state_change() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let actor = crate::access::iam::AccessPrincipal::root_dashboard_session("test", "unit");
+        let mut state = crate::access::iam::LocalIamState::default();
+        let created = crate::access::iam::upsert_user_client_grant(
+            &mut state,
+            crate::access::iam::UserClientGrantUpsertRequest {
+                kind: "browser_certificate".to_string(),
+                fingerprint: Some("AA:58".to_string()),
+                role_id: Some("role:observer".to_string()),
+                ..Default::default()
+            },
+            &actor,
+        )
+        .unwrap();
+        crate::access::iam::save_state(tmp.path(), &state).unwrap();
+        let principal = crate::access::iam::principal_for_browser_mtls_cert(
+            &state,
+            "AA:58",
+            "webrtc-datachannel",
+        )
+        .unwrap();
+        let memo = OpeningAuthorityMemo::default();
+        let grant = DashboardControlGrant::UserClient {
+            principal,
+            iam_state: std::sync::Arc::new(state.clone()),
+            iam_cert_dir: Some(tmp.path().to_path_buf()),
+            authority_memo: memo.clone(),
+        };
+        // Prime the memo through the full validation, then exercise the
+        // hit path once so the fast path is what the revocation must beat.
+        assert!(grant.opening_authority_is_current());
+        assert!(memo.is_primed());
+        assert!(grant.opening_authority_is_current());
+
+        crate::access::iam::update_user_client_grant(
+            &mut state,
+            crate::access::iam::IamGrantUpdateRequest {
+                grant_id: created.grant.id,
+                status: Some("revoked".to_string()),
+                ..Default::default()
+            },
+            &actor,
+        )
+        .unwrap();
+        crate::access::iam::save_state(tmp.path(), &state).unwrap();
+        // The revoked state loads as a new Arc → pointer mismatch → full
+        // revalidation → stale session.
+        assert!(!grant.opening_authority_is_current());
+        // And the memo must not have been re-primed by the failed check.
+        assert!(!grant.opening_authority_is_current());
     }
 
     #[test]
@@ -2172,8 +2389,9 @@ mod fs_scope_grant_tests {
         .unwrap();
         let grant = DashboardControlGrant::UserClient {
             principal,
-            iam_state: state.clone(),
+            iam_state: std::sync::Arc::new(state.clone()),
             iam_cert_dir: Some(tmp.path().to_path_buf()),
+            authority_memo: Default::default(),
         };
         assert!(grant.opening_authority_is_current());
         assert!(grant.allows_unfiltered_websocket_stream());
@@ -2251,8 +2469,9 @@ mod fs_scope_grant_tests {
         // pre-gate denies it before ICE/close can reach the owner comparison.
         let mut revoked = opening.clone();
         if let DashboardControlGrant::UserClient { iam_state, .. } = &mut revoked {
-            iam_state.grants[0].status = "revoked".to_string();
-            iam_state.grants[0].revoked_at_unix_ms = Some(1);
+            let state = std::sync::Arc::make_mut(iam_state);
+            state.grants[0].status = "revoked".to_string();
+            state.grants[0].revoked_at_unix_ms = Some(1);
         }
         assert!(peer.belongs_to(&revoked));
         assert!(!revoked.has_any_effective_operation());
@@ -2262,8 +2481,9 @@ mod fs_scope_grant_tests {
                 Some("DD:40"),
                 "webrtc-datachannel",
             ),
-            iam_state: crate::access::iam::LocalIamState::default(),
+            iam_state: Default::default(),
             iam_cert_dir: None,
+            authority_memo: Default::default(),
         };
         assert!(!peer.belongs_to(&unknown));
         assert!(!unknown.has_any_effective_operation());
@@ -2381,8 +2601,9 @@ mod fs_scope_grant_tests {
         };
         let scoped = DashboardControlGrant::UserClient {
             principal,
-            iam_state: state.clone(),
+            iam_state: std::sync::Arc::new(state.clone()),
             iam_cert_dir: None,
+            authority_memo: Default::default(),
         };
         let scope = scoped.filesystem().expect("scoped grant exposes fs scope");
         assert_eq!(scope.read_roots, vec![std::path::PathBuf::from(srv_shared)]);
@@ -3274,8 +3495,9 @@ mod tests {
                 .unwrap();
         DashboardControlGrant::UserClient {
             principal,
-            iam_state,
+            iam_state: std::sync::Arc::new(iam_state),
             iam_cert_dir: None,
+            authority_memo: Default::default(),
         }
     }
 

--- a/src/bin/caller/fleet_cert.rs
+++ b/src/bin/caller/fleet_cert.rs
@@ -238,6 +238,18 @@ pub fn status_snapshot() -> FleetCertStatus {
         .clone()
 }
 
+/// The delegated fleet zone alone. The request-path IAM evaluator only ever
+/// reads `.zone`, and [`status_snapshot`] deep-clones the whole struct
+/// (address vectors and CT serial summaries included) under the mutex —
+/// per authorization decision, daemon-wide.
+pub fn fleet_zone() -> Option<String> {
+    registry()
+        .lock()
+        .expect("fleet cert status poisoned")
+        .zone
+        .clone()
+}
+
 fn with_status(update: impl FnOnce(&mut FleetCertStatus)) {
     let mut status = registry().lock().expect("fleet cert status poisoned");
     update(&mut status);

--- a/src/bin/caller/message_search/cursor.rs
+++ b/src/bin/caller/message_search/cursor.rs
@@ -28,6 +28,17 @@ pub(crate) struct SourceCursor {
     /// trailing line (no newline yet) stays unread until it completes.
     pub last_complete_line_offset: u64,
     pub prefix_hash16: String,
+    /// Second rewrite-detection window: hash of the last
+    /// `min(4096, last_complete_line_offset)` bytes ENDING at the consumed
+    /// offset. The head window alone cannot exclude a rewrite past the
+    /// first 4 KiB that also grows the file (it would read as a benign
+    /// append); requiring both windows narrows the undetected residual to
+    /// a rewrite that preserves the head, the pre-consumed tail, AND grows
+    /// the file — accepted and documented. Empty on cursors persisted
+    /// before the field existed: those classify as before but are never
+    /// eligible for incremental resume.
+    #[serde(default)]
+    pub consumed_tail_hash16: String,
     pub parser_version: u32,
 }
 
@@ -78,6 +89,32 @@ pub(crate) fn prefix_hash16_bytes(path: &Path, max_bytes: usize) -> Option<Strin
     Some(hash16(&buf))
 }
 
+/// Hash16 over the `min(4096, end)` bytes ENDING at offset `end` — the
+/// second rewrite-detection window (see `consumed_tail_hash16`). For
+/// consumed ranges under 4 KiB this window covers every consumed byte,
+/// which is what closes the small-file head-mutation hole the prefix
+/// window's "not comparable on growth" rule leaves open.
+pub(crate) fn tail_hash16_ending_at(path: &Path, end: u64) -> Option<String> {
+    let window = end.min(PREFIX_HASH_BYTES as u64);
+    let mut file = std::fs::File::open(path).ok()?;
+    file.seek(SeekFrom::Start(end - window)).ok()?;
+    let mut buf = vec![0u8; window as usize];
+    let mut read = 0usize;
+    loop {
+        if read == buf.len() {
+            break;
+        }
+        match file.read(&mut buf[read..]) {
+            // Shorter than the recorded consumed range: a concurrent
+            // truncation; the caller's length checks classify it.
+            Ok(0) => return None,
+            Ok(n) => read += n,
+            Err(_) => return None,
+        }
+    }
+    Some(hash16(&buf))
+}
+
 fn hash16(bytes: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     let digest = Sha256::digest(bytes);
@@ -99,8 +136,17 @@ impl SourceCursor {
             mtime_ms: file_mtime_ms(&metadata),
             last_complete_line_offset,
             prefix_hash16: prefix_hash16(path)?,
+            consumed_tail_hash16: tail_hash16_ending_at(path, last_complete_line_offset)?,
             parser_version: super::record::PARSER_VERSION,
         })
+    }
+
+    /// Whether this cursor carries the second (consumed-tail) hash window.
+    /// Incremental resume REQUIRES it: cursors persisted before the field
+    /// existed classify exactly as before, but never resume — the next
+    /// full re-parse re-captures with both windows.
+    pub(crate) fn supports_incremental_resume(&self) -> bool {
+        !self.consumed_tail_hash16.is_empty()
     }
 
     /// Compare the file on disk against this cursor.
@@ -147,7 +193,10 @@ impl SourceCursor {
                     // only when the saved file already filled the window, or
                     // the length hasn't changed — an append to a small file
                     // widens the hashed window and is NOT comparable (and is
-                    // exactly the benign case the offset check below handles).
+                    // exactly the benign case the offset check below handles;
+                    // the consumed-tail window below covers every consumed
+                    // byte of such a small file, so a head mutation on a
+                    // grown small file still reads as Rewritten).
                     let comparable =
                         self.len as usize >= PREFIX_HASH_BYTES || metadata.len() == self.len;
                     if comparable && hash != self.prefix_hash16 {
@@ -155,6 +204,19 @@ impl SourceCursor {
                     }
                 }
                 None => return CursorCheck::Gone,
+            }
+            // Second window: the head hash alone cannot exclude a rewrite
+            // past the first 4 KiB that also grows the file — it would
+            // read as a benign append. An honest append never changes
+            // bytes at or before the consumed offset, so a moved tail
+            // window is proof of rewrite. (Both-windows-preserved growth
+            // rewrites remain the documented residual.)
+            if !self.consumed_tail_hash16.is_empty() {
+                match tail_hash16_ending_at(&self.path, self.last_complete_line_offset) {
+                    Some(hash) if hash == self.consumed_tail_hash16 => {}
+                    Some(_) => return CursorCheck::Rewritten,
+                    None => return CursorCheck::Gone,
+                }
             }
         }
         if metadata.len() > self.last_complete_line_offset {
@@ -262,6 +324,58 @@ mod tests {
         let cursor = SourceCursor::capture(&path, 10).unwrap();
         std::fs::write(&path, "zzzz\nbbbb\n").unwrap(); // same len, new head
         assert_eq!(cursor.check(), CursorCheck::Rewritten);
+    }
+
+    #[test]
+    fn post_prefix_rewrite_that_grows_reads_as_rewritten() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.jsonl");
+        // First line fills the 4 KiB prefix window; the second is the
+        // post-prefix content a growth rewrite mutates.
+        let head = format!("{}\n", "h".repeat(PREFIX_HASH_BYTES));
+        let body = format!("{head}old-tail-line\n");
+        std::fs::write(&path, &body).unwrap();
+        let cursor = SourceCursor::capture(&path, body.len() as u64).unwrap();
+        assert!(cursor.supports_incremental_resume());
+
+        // Same head 4 KiB, mutated bytes past it, file GROWN: the head
+        // window matches and the length check passes — only the
+        // consumed-tail window can (and must) catch it.
+        std::fs::write(&path, format!("{head}new-tail-line\nappended line\n")).unwrap();
+        assert_eq!(cursor.check(), CursorCheck::Rewritten);
+    }
+
+    #[test]
+    fn small_file_head_mutating_grow_reads_as_rewritten() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.jsonl");
+        std::fs::write(&path, "aaaa\nbbbb\n").unwrap(); // well under 4 KiB
+        let cursor = SourceCursor::capture(&path, 10).unwrap();
+
+        // Head mutated AND grown: the prefix window is "not comparable"
+        // (saved len < window, length changed), which used to read as a
+        // benign append; the consumed-tail window covers every consumed
+        // byte of a small file and catches it.
+        std::fs::write(&path, "zzzz\nbbbb\ncccc\n").unwrap();
+        assert_eq!(cursor.check(), CursorCheck::Rewritten);
+    }
+
+    #[test]
+    fn honest_append_keeps_both_windows_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.jsonl");
+        let head = format!("{}\n", "h".repeat(PREFIX_HASH_BYTES));
+        let body = format!("{head}tail-line\n");
+        std::fs::write(&path, &body).unwrap();
+        let cursor = SourceCursor::capture(&path, body.len() as u64).unwrap();
+
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        file.write_all(b"appended line\n").unwrap();
+        drop(file);
+        assert_eq!(cursor.check(), CursorCheck::Appended);
     }
 
     #[test]

--- a/src/bin/caller/message_search/cursor.rs
+++ b/src/bin/caller/message_search/cursor.rs
@@ -24,6 +24,15 @@ pub(crate) struct SourceCursor {
     pub identity: Option<FileIdentity>,
     pub len: u64,
     pub mtime_ms: i64,
+    /// Full-precision mtime for the cheap-facts short-circuit: two writes
+    /// inside one millisecond are indistinguishable at `mtime_ms`
+    /// precision, and a same-length rewrite hiding there must not skip
+    /// the hash windows. `0` on cursors persisted before the field —
+    /// those never short-circuit (they hash every sweep, the historical
+    /// behavior). Residual: filesystems with coarse stamps (FAT/exFAT:
+    /// 2 s) keep a same-granule blind spot; nil on APFS/ext4/NTFS.
+    #[serde(default)]
+    pub mtime_ns: u64,
     /// Offset just past the last COMPLETE line consumed — a partial
     /// trailing line (no newline yet) stays unread until it completes.
     pub last_complete_line_offset: u64,
@@ -63,6 +72,15 @@ fn file_mtime_ms(metadata: &std::fs::Metadata) -> i64 {
         .ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn file_mtime_ns(metadata: &std::fs::Metadata) -> u64 {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos() as u64)
         .unwrap_or(0)
 }
 
@@ -134,6 +152,7 @@ impl SourceCursor {
             identity: FileIdentity::from_path(path).ok(),
             len: metadata.len(),
             mtime_ms: file_mtime_ms(&metadata),
+            mtime_ns: file_mtime_ns(&metadata),
             last_complete_line_offset,
             prefix_hash16: prefix_hash16(path)?,
             consumed_tail_hash16: tail_hash16_ending_at(path, last_complete_line_offset)?,
@@ -170,22 +189,30 @@ impl SourceCursor {
             }
             _ => false,
         };
-        let mtime_ms = file_mtime_ms(&metadata);
+        // Full-precision when both sides carry it; ms for legacy cursors.
+        let mtime_moved = if self.mtime_ns != 0 {
+            file_mtime_ns(&metadata) != self.mtime_ns
+        } else {
+            file_mtime_ms(&metadata) != self.mtime_ms
+        };
         // Same length, moved mtime: an in-place rewrite whose changed bytes
         // lie past the hashed prefix window would otherwise read as
         // Unchanged forever (the module doc's "folds len + timestamps"
         // promise). A benign touch(1) costs one idempotent rebuild.
-        if metadata.len() == self.len && mtime_ms != self.mtime_ms {
+        if metadata.len() == self.len && mtime_moved {
             return CursorCheck::Rewritten;
         }
         // Cheap-facts short-circuit: a reliable identity match with
-        // unchanged len + mtime is the steady state of nearly every
-        // in-retention file on every 30s sweep — skip the open + 4 KiB
-        // read + SHA-256 that used to run merely to confirm it. Any
-        // rewrite these facts can miss (same-length mtime-preserving
-        // writer) was equally invisible to the prefix hash past 4 KiB.
-        let hash_needed =
-            !(identity_reliably_same && metadata.len() == self.len && mtime_ms == self.mtime_ms);
+        // unchanged len + FULL-PRECISION mtime is the steady state of
+        // nearly every in-retention file on every 30s sweep — skip the
+        // open + 4 KiB read + SHA-256 that used to run merely to confirm
+        // it. Millisecond precision is NOT enough here (two writes inside
+        // one ms hid a same-length rewrite from an earlier draft), so
+        // legacy cursors without `mtime_ns` never short-circuit.
+        let hash_needed = !(identity_reliably_same
+            && metadata.len() == self.len
+            && self.mtime_ns != 0
+            && !mtime_moved);
         if hash_needed {
             match prefix_hash16(&self.path) {
                 Some(hash) => {

--- a/src/bin/caller/message_search/cursor.rs
+++ b/src/bin/caller/message_search/cursor.rs
@@ -12,8 +12,10 @@ use serde::{Deserialize, Serialize};
 use std::io::{BufRead, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
-/// Bytes hashed from the file head for the prefix fingerprint.
-const PREFIX_HASH_BYTES: usize = 4096;
+/// Bytes hashed from the file head for the prefix fingerprint. Shared
+/// with the session catalog's incremental row accumulators, which use the
+/// same head-hash to distinguish appends from rewrites.
+pub(crate) const PREFIX_HASH_BYTES: usize = 4096;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct SourceCursor {
@@ -54,17 +56,22 @@ fn file_mtime_ms(metadata: &std::fs::Metadata) -> i64 {
 }
 
 fn prefix_hash16(path: &Path) -> Option<String> {
+    prefix_hash16_bytes(path, PREFIX_HASH_BYTES)
+}
+
+/// Hash16 over the first `max_bytes` of `path` (fewer at EOF).
+pub(crate) fn prefix_hash16_bytes(path: &Path, max_bytes: usize) -> Option<String> {
     let mut file = std::fs::File::open(path).ok()?;
-    let mut buf = vec![0u8; PREFIX_HASH_BYTES];
+    let mut buf = vec![0u8; max_bytes];
     let mut read = 0usize;
     loop {
+        if read == buf.len() {
+            break;
+        }
         match file.read(&mut buf[read..]) {
             Ok(0) => break,
             Ok(n) => read += n,
             Err(_) => return None,
-        }
-        if read == buf.len() {
-            break;
         }
     }
     buf.truncate(read);
@@ -107,25 +114,48 @@ impl SourceCursor {
         if metadata.len() < self.len {
             return CursorCheck::Rewritten;
         }
-        if let (Some(saved), Ok(current)) = (self.identity, FileIdentity::from_path(&self.path)) {
-            if saved.is_reliable() && current.is_reliable() && saved != current {
-                return CursorCheck::Rewritten;
-            }
-        }
-        match prefix_hash16(&self.path) {
-            Some(hash) => {
-                // The saved and fresh hashes cover the same byte window
-                // only when the saved file already filled the window, or
-                // the length hasn't changed — an append to a small file
-                // widens the hashed window and is NOT comparable (and is
-                // exactly the benign case the offset check below handles).
-                let comparable =
-                    self.len as usize >= PREFIX_HASH_BYTES || metadata.len() == self.len;
-                if comparable && hash != self.prefix_hash16 {
+        let current_identity = FileIdentity::from_path(&self.path).ok();
+        let identity_reliably_same = match (self.identity, current_identity) {
+            (Some(saved), Some(current)) if saved.is_reliable() && current.is_reliable() => {
+                if saved != current {
                     return CursorCheck::Rewritten;
                 }
+                true
             }
-            None => return CursorCheck::Gone,
+            _ => false,
+        };
+        let mtime_ms = file_mtime_ms(&metadata);
+        // Same length, moved mtime: an in-place rewrite whose changed bytes
+        // lie past the hashed prefix window would otherwise read as
+        // Unchanged forever (the module doc's "folds len + timestamps"
+        // promise). A benign touch(1) costs one idempotent rebuild.
+        if metadata.len() == self.len && mtime_ms != self.mtime_ms {
+            return CursorCheck::Rewritten;
+        }
+        // Cheap-facts short-circuit: a reliable identity match with
+        // unchanged len + mtime is the steady state of nearly every
+        // in-retention file on every 30s sweep — skip the open + 4 KiB
+        // read + SHA-256 that used to run merely to confirm it. Any
+        // rewrite these facts can miss (same-length mtime-preserving
+        // writer) was equally invisible to the prefix hash past 4 KiB.
+        let hash_needed =
+            !(identity_reliably_same && metadata.len() == self.len && mtime_ms == self.mtime_ms);
+        if hash_needed {
+            match prefix_hash16(&self.path) {
+                Some(hash) => {
+                    // The saved and fresh hashes cover the same byte window
+                    // only when the saved file already filled the window, or
+                    // the length hasn't changed — an append to a small file
+                    // widens the hashed window and is NOT comparable (and is
+                    // exactly the benign case the offset check below handles).
+                    let comparable =
+                        self.len as usize >= PREFIX_HASH_BYTES || metadata.len() == self.len;
+                    if comparable && hash != self.prefix_hash16 {
+                        return CursorCheck::Rewritten;
+                    }
+                }
+                None => return CursorCheck::Gone,
+            }
         }
         if metadata.len() > self.last_complete_line_offset {
             CursorCheck::Appended
@@ -135,17 +165,22 @@ impl SourceCursor {
     }
 }
 
-/// Read complete lines from `path` starting at `offset`; returns the
-/// lines and the offset just past the last complete line (a trailing
-/// partial line is left for the next pass — plan §6).
-pub(crate) fn read_complete_lines_from(
+/// Stream complete lines from `path` starting at `offset` through
+/// `consume`; returns the offset just past the last complete line (a
+/// trailing partial line is left for the next pass — plan §6).
+///
+/// Streaming, not collecting: extraction runs on every changed
+/// in-retention source every sweep, and materializing a multi-hundred-MB
+/// rollout as an owned `Vec<String>` was a file-sized allocation spike
+/// per parse. One reused line buffer serves the whole read.
+pub(crate) fn for_each_complete_line_from(
     path: &Path,
     offset: u64,
-) -> std::io::Result<(Vec<String>, u64)> {
+    mut consume: impl FnMut(&str),
+) -> std::io::Result<u64> {
     let mut file = std::fs::File::open(path)?;
     file.seek(SeekFrom::Start(offset))?;
     let mut reader = std::io::BufReader::new(file);
-    let mut lines = Vec::new();
     let mut consumed = offset;
     let mut buf = Vec::new();
     loop {
@@ -160,9 +195,20 @@ pub(crate) fn read_complete_lines_from(
         }
         consumed += bytes as u64;
         let line = String::from_utf8_lossy(&buf);
-        let trimmed = line.trim_end_matches(['\n', '\r']);
-        lines.push(trimmed.to_string());
+        consume(line.trim_end_matches(['\n', '\r']));
     }
+    Ok(consumed)
+}
+
+/// Collected form of [`for_each_complete_line_from`] — tests and small
+/// bounded reads only; extraction paths must stream.
+#[cfg(test)]
+pub(crate) fn read_complete_lines_from(
+    path: &Path,
+    offset: u64,
+) -> std::io::Result<(Vec<String>, u64)> {
+    let mut lines = Vec::new();
+    let consumed = for_each_complete_line_from(path, offset, |line| lines.push(line.to_string()))?;
     Ok((lines, consumed))
 }
 

--- a/src/bin/caller/message_search/cursor.rs
+++ b/src/bin/caller/message_search/cursor.rs
@@ -17,6 +17,13 @@ use std::path::{Path, PathBuf};
 /// same head-hash to distinguish appends from rewrites.
 pub(crate) const PREFIX_HASH_BYTES: usize = 4096;
 
+/// How much older than the check time a stored mtime must be before
+/// timestamp equality is trusted without re-hashing (racy-mtime
+/// distrust). Covers every supported filesystem's stamp granularity —
+/// Linux jiffies (~1-4 ms) through FAT/exFAT (2 s) — with the whole
+/// window as margin.
+const RACY_MTIME_QUIESCENCE: std::time::Duration = std::time::Duration::from_secs(2);
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct SourceCursor {
     pub path: PathBuf,
@@ -24,13 +31,16 @@ pub(crate) struct SourceCursor {
     pub identity: Option<FileIdentity>,
     pub len: u64,
     pub mtime_ms: i64,
-    /// Full-precision mtime for the cheap-facts short-circuit: two writes
-    /// inside one millisecond are indistinguishable at `mtime_ms`
-    /// precision, and a same-length rewrite hiding there must not skip
-    /// the hash windows. `0` on cursors persisted before the field —
-    /// those never short-circuit (they hash every sweep, the historical
-    /// behavior). Residual: filesystems with coarse stamps (FAT/exFAT:
-    /// 2 s) keep a same-granule blind spot; nil on APFS/ext4/NTFS.
+    /// Full-precision mtime for the cheap-facts short-circuit. Precision
+    /// alone cannot carry it — filesystem stamps come from coarse kernel
+    /// clocks (Linux jiffies: ~1-4 ms; FAT/exFAT: 2 s granules), so two
+    /// writes inside one granule are indistinguishable at ANY stored
+    /// precision. The short-circuit therefore also requires the stored
+    /// mtime to be QUIESCENT — at least [`RACY_MTIME_QUIESCENCE`] older
+    /// than the check time (git's racy-index discipline); fresh mtimes
+    /// always fall through to the hash windows. `0` on cursors persisted
+    /// before the field — those never short-circuit (they hash every
+    /// sweep, the historical behavior).
     #[serde(default)]
     pub mtime_ns: u64,
     /// Offset just past the last COMPLETE line consumed — a partial
@@ -170,6 +180,12 @@ impl SourceCursor {
 
     /// Compare the file on disk against this cursor.
     pub(crate) fn check(&self) -> CursorCheck {
+        self.check_at(std::time::SystemTime::now())
+    }
+
+    /// [`Self::check`] with an injectable clock, so tests pin the racy
+    /// mtime-distrust window without sleeping.
+    pub(crate) fn check_at(&self, now: std::time::SystemTime) -> CursorCheck {
         let Ok(metadata) = std::fs::metadata(&self.path) else {
             return CursorCheck::Gone;
         };
@@ -203,16 +219,26 @@ impl SourceCursor {
             return CursorCheck::Rewritten;
         }
         // Cheap-facts short-circuit: a reliable identity match with
-        // unchanged len + FULL-PRECISION mtime is the steady state of
+        // unchanged len + full-precision mtime is the steady state of
         // nearly every in-retention file on every 30s sweep — skip the
         // open + 4 KiB read + SHA-256 that used to run merely to confirm
-        // it. Millisecond precision is NOT enough here (two writes inside
-        // one ms hid a same-length rewrite from an earlier draft), so
-        // legacy cursors without `mtime_ns` never short-circuit.
+        // it. Racy-mtime distrust (git's index discipline): timestamp
+        // equality is only trusted on a QUIESCENT file — the stored mtime
+        // must be comfortably older than the check time. Filesystem
+        // stamps come from coarse kernel clocks (a Linux jiffy is ~1-4 ms;
+        // FAT/exFAT granules are 2 s), so a rewrite landing in the same
+        // granule as the captured write is timestamp-invisible; a fresh
+        // mtime therefore falls through to the hash windows, and only
+        // files untouched for the full window skip them. Legacy cursors
+        // without `mtime_ns` never short-circuit.
+        let stored_mtime_quiescent = now
+            .duration_since(std::time::UNIX_EPOCH + std::time::Duration::from_nanos(self.mtime_ns))
+            .is_ok_and(|age| age >= RACY_MTIME_QUIESCENCE);
         let hash_needed = !(identity_reliably_same
             && metadata.len() == self.len
             && self.mtime_ns != 0
-            && !mtime_moved);
+            && !mtime_moved
+            && stored_mtime_quiescent);
         if hash_needed {
             match prefix_hash16(&self.path) {
                 Some(hash) => {
@@ -343,14 +369,73 @@ mod tests {
         assert_eq!(cursor.check(), CursorCheck::Rewritten);
     }
 
+    /// Sets an explicit whole-second mtime (exactly representable on
+    /// every supported filesystem, so the captured stamp round-trips).
+    fn set_mtime(path: &Path, time: std::time::SystemTime) {
+        std::fs::File::options()
+            .append(true)
+            .open(path)
+            .unwrap()
+            .set_modified(time)
+            .unwrap();
+    }
+
+    fn whole_seconds_now() -> std::time::SystemTime {
+        let secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        std::time::UNIX_EPOCH + std::time::Duration::from_secs(secs)
+    }
+
+    /// Deterministic detection via the moved-mtime rule: explicit DISTINCT
+    /// stamps, no reliance on platform clock granularity.
     #[test]
     fn same_length_prefix_rewrite_is_detected() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("log.jsonl");
+        let t0 = whole_seconds_now() - std::time::Duration::from_secs(10);
         std::fs::write(&path, "aaaa\nbbbb\n").unwrap();
+        set_mtime(&path, t0);
         let cursor = SourceCursor::capture(&path, 10).unwrap();
         std::fs::write(&path, "zzzz\nbbbb\n").unwrap(); // same len, new head
+        set_mtime(&path, t0 + std::time::Duration::from_secs(1));
         assert_eq!(cursor.check(), CursorCheck::Rewritten);
+    }
+
+    /// A rewrite landing in the SAME timestamp granule as the captured
+    /// write (identical mtime, identical length — what a coarse kernel
+    /// clock produces for rapid writes) must still be caught: the racy
+    /// window distrusts fresh mtimes and falls through to the hash
+    /// windows. No sleeps — the check time is injected.
+    #[test]
+    fn same_granule_rewrite_is_caught_inside_the_racy_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("log.jsonl");
+        let stamp = whole_seconds_now();
+        std::fs::write(&path, "aaaa\nbbbb\n").unwrap();
+        set_mtime(&path, stamp);
+        let cursor = SourceCursor::capture(&path, 10).unwrap();
+        assert_eq!(cursor.mtime_ns % 1_000_000_000, 0, "whole-second stamp");
+
+        // Same-granule rewrite: same length, same mtime, new head bytes.
+        std::fs::write(&path, "zzzz\nbbbb\n").unwrap();
+        set_mtime(&path, stamp);
+        assert_eq!(
+            cursor.check_at(stamp + std::time::Duration::from_millis(100)),
+            CursorCheck::Rewritten,
+            "a fresh mtime must fall through to the hash windows"
+        );
+
+        // Quiescent fast path still exists: with the ORIGINAL bytes back
+        // and the same stamp, an old-mtime check trusts the facts.
+        std::fs::write(&path, "aaaa\nbbbb\n").unwrap();
+        set_mtime(&path, stamp);
+        assert_eq!(
+            cursor.check_at(stamp + std::time::Duration::from_secs(3)),
+            CursorCheck::Unchanged,
+            "a quiescent matching file skips the hashes and reads Unchanged"
+        );
     }
 
     #[test]

--- a/src/bin/caller/message_search/extract_claude.rs
+++ b/src/bin/caller/message_search/extract_claude.rs
@@ -17,7 +17,7 @@
 //! cursor check means a full re-extract, never a generation bump — record
 //! identity is the duplicate-free record `uuid`.
 
-use super::cursor::{read_complete_lines_from, SourceCursor};
+use super::cursor::{for_each_complete_line_from, SourceCursor};
 use super::record::{cap_text, Locator, MessageRecord, Role, Source};
 use super::store::SessionShard;
 use crate::external_agent::transcript_text::{is_injected_external_user_text, message_prose_text};
@@ -71,16 +71,24 @@ pub(crate) fn extract_claude_session(
         &mut shard.records,
         &mut cursors,
     )?;
+    for path in claude_transcript_agents(subagent_paths) {
+        walk_transcript(path, session_id, true, &mut shard.records, &mut cursors)?;
+    }
+    Ok((shard, cursors))
+}
+
+/// The subagent paths [`extract_claude_session`] actually consumes, in its
+/// consumption order (transcript-shaped only, sorted, deduped). The
+/// incremental fold matches saved cursors against exactly this set, and
+/// only files in this set can ever change the shard.
+pub(crate) fn claude_transcript_agents(subagent_paths: &[PathBuf]) -> Vec<&PathBuf> {
     let mut agents: Vec<&PathBuf> = subagent_paths
         .iter()
         .filter(|path| is_subagent_transcript(path))
         .collect();
     agents.sort();
     agents.dedup();
-    for path in agents {
-        walk_transcript(path, session_id, true, &mut shard.records, &mut cursors)?;
-    }
-    Ok((shard, cursors))
+    agents
 }
 
 /// Consume every complete line of one transcript file, appending its
@@ -92,12 +100,11 @@ fn walk_transcript(
     records: &mut Vec<MessageRecord>,
     cursors: &mut Vec<SourceCursor>,
 ) -> std::io::Result<()> {
-    let (lines, consumed) = read_complete_lines_from(path, 0)?;
-    for line in &lines {
+    let consumed = for_each_complete_line_from(path, 0, |line| {
         if let Some(record) = record_from_line(line, session_id, subagent) {
             records.push(record);
         }
-    }
+    })?;
     let cursor = SourceCursor::capture(path, consumed).ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -106,6 +113,72 @@ fn walk_transcript(
     })?;
     cursors.push(cursor);
     Ok(())
+}
+
+/// Fold a MAIN-transcript append into the session's previously published
+/// shard, without re-reading the whole corpus. Sound only in the narrow
+/// case the caller verified with cursors: the main file APPENDED (same
+/// identity/prefix), every subagent transcript is byte-unchanged, and the
+/// subagent set itself did not change. Claude records are line-local
+/// ([`record_from_line`] holds no cross-line state), and full extraction
+/// orders records [main lines..., agents by path...], so splicing the
+/// suffix records at the end of the prior MAIN block reproduces the full
+/// re-extraction byte-for-byte — the store's content-named shard files
+/// keep deduping across passes.
+///
+/// Returns `Ok(None)` when the prior shard does not have the expected
+/// main-then-agents partition (never produced by this extractor, but a
+/// foreign store must fall back to the full parse, never mis-splice).
+pub(crate) fn fold_claude_main_append(
+    session_id: &str,
+    main_path: &Path,
+    resume_offset: u64,
+    prior: &SessionShard,
+) -> std::io::Result<Option<(SessionShard, SourceCursor)>> {
+    if !is_strict_jsonl(main_path) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "not a .jsonl transcript (backup/sidecar artifacts are excluded): {}",
+                main_path.display()
+            ),
+        ));
+    }
+    // The prior records must be one main block followed by one agents
+    // block for the splice below to reproduce full-extraction order.
+    let main_block_end = prior
+        .records
+        .iter()
+        .rposition(|record| !record.subagent)
+        .map(|index| index + 1)
+        .unwrap_or(0);
+    if prior.records[..main_block_end]
+        .iter()
+        .any(|record| record.subagent)
+    {
+        return Ok(None);
+    }
+    let mut suffix_records = Vec::new();
+    let consumed = for_each_complete_line_from(main_path, resume_offset, |line| {
+        if let Some(record) = record_from_line(line, session_id, false) {
+            suffix_records.push(record);
+        }
+    })?;
+    let Some(cursor) = SourceCursor::capture(main_path, consumed) else {
+        return Ok(None);
+    };
+    let mut records =
+        Vec::with_capacity(prior.records.len().saturating_add(suffix_records.len()));
+    records.extend_from_slice(&prior.records[..main_block_end]);
+    records.append(&mut suffix_records);
+    records.extend_from_slice(&prior.records[main_block_end..]);
+    Ok(Some((
+        SessionShard {
+            records,
+            marks: prior.marks.clone(),
+        },
+        cursor,
+    )))
 }
 
 /// Parse one transcript line into a [`MessageRecord`], or `None` for
@@ -193,7 +266,7 @@ fn is_subagent_transcript(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::super::cursor::CursorCheck;
+    use super::super::cursor::{read_complete_lines_from, CursorCheck};
     use super::super::record::MESSAGE_TEXT_CAP_BYTES;
     use super::super::store::{PublishOutcome, Store};
     use super::*;
@@ -728,5 +801,110 @@ mod tests {
         assert_eq!(read.records.len(), 1);
         assert_eq!(read.records[0].text, "index me");
         assert!(read.marks.is_empty());
+    }
+
+    /// The incremental fold's soundness invariant: for a main-only append
+    /// with an unchanged subagent set, the folded shard and cursor are
+    /// exactly what a full re-extraction would produce.
+    #[test]
+    fn fold_of_main_append_matches_full_reextraction() {
+        let dir = tempfile::tempdir().unwrap();
+        let main = dir.path().join(format!("{SESSION}.jsonl"));
+        let subagent_dir = dir.path().join(SESSION).join("subagents");
+        std::fs::create_dir_all(&subagent_dir).unwrap();
+        let agent = subagent_dir.join("agent-a1.jsonl");
+        write_transcript(
+            &main,
+            &[
+                message_line(
+                    "user",
+                    "u-1",
+                    "2026-07-10T10:00:00.000Z",
+                    serde_json::json!("first question"),
+                    &[],
+                ),
+                message_line(
+                    "assistant",
+                    "a-1",
+                    "2026-07-10T10:00:05.000Z",
+                    serde_json::json!("first answer"),
+                    &[],
+                ),
+            ],
+        );
+        write_transcript(
+            &agent,
+            &[sidechain_line(
+                "assistant",
+                "s-1",
+                "2026-07-10T10:00:06.000Z",
+                "subagent prose",
+                "a1",
+            )],
+        );
+        let agents = vec![agent.clone()];
+        let (prior, prior_cursors) = extract_claude_session(SESSION, &main, &agents).unwrap();
+        let main_cursor = prior_cursors
+            .iter()
+            .find(|cursor| cursor.path == main)
+            .unwrap()
+            .clone();
+
+        // Append two records to the MAIN transcript only.
+        use std::io::Write as _;
+        let mut file = std::fs::OpenOptions::new().append(true).open(&main).unwrap();
+        writeln!(
+            file,
+            "{}",
+            message_line(
+                "user",
+                "u-2",
+                "2026-07-10T10:01:00.000Z",
+                serde_json::json!("second question"),
+                &[],
+            )
+        )
+        .unwrap();
+        writeln!(
+            file,
+            "{}",
+            message_line(
+                "assistant",
+                "a-2",
+                "2026-07-10T10:01:05.000Z",
+                serde_json::json!("second answer"),
+                &[],
+            )
+        )
+        .unwrap();
+        drop(file);
+        assert_eq!(main_cursor.check(), CursorCheck::Appended);
+
+        let (folded, folded_cursor) = fold_claude_main_append(
+            SESSION,
+            &main,
+            main_cursor.last_complete_line_offset,
+            &prior,
+        )
+        .unwrap()
+        .expect("main-only append is foldable");
+        let (full, full_cursors) = extract_claude_session(SESSION, &main, &agents).unwrap();
+        assert_eq!(folded.records, full.records);
+        assert_eq!(folded.marks, full.marks);
+        assert_eq!(
+            Some(&folded_cursor),
+            full_cursors.iter().find(|cursor| cursor.path == main)
+        );
+        let texts: Vec<&str> = folded.records.iter().map(|r| r.text.as_str()).collect();
+        assert_eq!(
+            texts,
+            vec![
+                "first question",
+                "first answer",
+                "second question",
+                "second answer",
+                "subagent prose",
+            ]
+        );
     }
 }

--- a/src/bin/caller/message_search/extract_claude.rs
+++ b/src/bin/caller/message_search/extract_claude.rs
@@ -17,7 +17,7 @@
 //! cursor check means a full re-extract, never a generation bump — record
 //! identity is the duplicate-free record `uuid`.
 
-use super::cursor::{for_each_complete_line_from, SourceCursor};
+use super::cursor::{for_each_complete_line_from, CursorCheck, SourceCursor};
 use super::record::{cap_text, Locator, MessageRecord, Role, Source};
 use super::store::SessionShard;
 use crate::external_agent::transcript_text::{is_injected_external_user_text, message_prose_text};
@@ -128,11 +128,12 @@ fn walk_transcript(
 ///
 /// Returns `Ok(None)` when the prior shard does not have the expected
 /// main-then-agents partition (never produced by this extractor, but a
-/// foreign store must fall back to the full parse, never mis-splice).
+/// foreign store must fall back to the full parse, never mis-splice), or
+/// when the post-fold revalidation shows the source moved under us.
 pub(crate) fn fold_claude_main_append(
     session_id: &str,
     main_path: &Path,
-    resume_offset: u64,
+    saved: &SourceCursor,
     prior: &SessionShard,
 ) -> std::io::Result<Option<(SessionShard, SourceCursor)>> {
     if !is_strict_jsonl(main_path) {
@@ -159,14 +160,31 @@ pub(crate) fn fold_claude_main_append(
         return Ok(None);
     }
     let mut suffix_records = Vec::new();
-    let consumed = for_each_complete_line_from(main_path, resume_offset, |line| {
-        if let Some(record) = record_from_line(line, session_id, false) {
-            suffix_records.push(record);
-        }
-    })?;
+    let consumed =
+        for_each_complete_line_from(main_path, saved.last_complete_line_offset, |line| {
+            if let Some(record) = record_from_line(line, session_id, false) {
+                suffix_records.push(record);
+            }
+        })?;
     let Some(cursor) = SourceCursor::capture(main_path, consumed) else {
         return Ok(None);
     };
+    // TOCTOU guard: the caller validated the SAVED cursor's windows, then
+    // we read the suffix — a rewrite landing in between would splice new
+    // bytes onto stale prior records, and the freshly captured cursor
+    // above (hashed from the rewritten file) would legitimize the corrupt
+    // shard permanently. Re-running the saved cursor's own check AFTER
+    // the read costs two ≤4 KiB window reads and closes the laundering:
+    // anything but a still-plain append discards the fold. (A rewrite
+    // racing the capture itself leaves a cursor that mismatches the file,
+    // so the next sweep full-rebuilds — either way, no corrupt steady
+    // state.)
+    if !matches!(
+        saved.check(),
+        CursorCheck::Appended | CursorCheck::Unchanged
+    ) {
+        return Ok(None);
+    }
     let mut records = Vec::with_capacity(prior.records.len().saturating_add(suffix_records.len()));
     records.extend_from_slice(&prior.records[..main_block_end]);
     records.append(&mut suffix_records);
@@ -802,6 +820,57 @@ mod tests {
         assert!(read.marks.is_empty());
     }
 
+    /// The post-fold TOCTOU guard: a fold attempted with a saved cursor
+    /// whose windows no longer describe the file (the "rewrite landed
+    /// after the caller validated" interleaving, pinned here by simply
+    /// rewriting before the call) must be discarded — `Ok(None)` — never
+    /// spliced and legitimized.
+    #[test]
+    fn fold_discards_when_the_saved_cursor_no_longer_matches_the_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let main = dir.path().join(format!("{SESSION}.jsonl"));
+        write_transcript(
+            &main,
+            &[message_line(
+                "user",
+                "u-1",
+                "2026-07-15T12:00:00.000Z",
+                serde_json::json!("original history"),
+                &[],
+            )],
+        );
+        let (prior, cursors) = extract_claude_session(SESSION, &main, &[]).unwrap();
+        let saved = cursors[0].clone();
+
+        // The file is rewritten (head mutated, grown) after validation
+        // "happened": the fold must refuse to splice.
+        write_transcript(
+            &main,
+            &[
+                message_line(
+                    "user",
+                    "u-9",
+                    "2026-07-15T12:05:00.000Z",
+                    serde_json::json!("replaced history"),
+                    &[],
+                ),
+                message_line(
+                    "user",
+                    "u-10",
+                    "2026-07-15T12:06:00.000Z",
+                    serde_json::json!("second replaced"),
+                    &[],
+                ),
+            ],
+        );
+        assert!(
+            fold_claude_main_append(SESSION, &main, &saved, &prior)
+                .unwrap()
+                .is_none(),
+            "a fold against a moved source must be discarded"
+        );
+    }
+
     /// The incremental fold's soundness invariant: for a main-only append
     /// with an unchanged subagent set, the folded shard and cursor are
     /// exactly what a full re-extraction would produce.
@@ -882,14 +951,9 @@ mod tests {
         drop(file);
         assert_eq!(main_cursor.check(), CursorCheck::Appended);
 
-        let (folded, folded_cursor) = fold_claude_main_append(
-            SESSION,
-            &main,
-            main_cursor.last_complete_line_offset,
-            &prior,
-        )
-        .unwrap()
-        .expect("main-only append is foldable");
+        let (folded, folded_cursor) = fold_claude_main_append(SESSION, &main, &main_cursor, &prior)
+            .unwrap()
+            .expect("main-only append is foldable");
         let (full, full_cursors) = extract_claude_session(SESSION, &main, &agents).unwrap();
         assert_eq!(folded.records, full.records);
         assert_eq!(folded.marks, full.marks);

--- a/src/bin/caller/message_search/extract_claude.rs
+++ b/src/bin/caller/message_search/extract_claude.rs
@@ -167,8 +167,7 @@ pub(crate) fn fold_claude_main_append(
     let Some(cursor) = SourceCursor::capture(main_path, consumed) else {
         return Ok(None);
     };
-    let mut records =
-        Vec::with_capacity(prior.records.len().saturating_add(suffix_records.len()));
+    let mut records = Vec::with_capacity(prior.records.len().saturating_add(suffix_records.len()));
     records.extend_from_slice(&prior.records[..main_block_end]);
     records.append(&mut suffix_records);
     records.extend_from_slice(&prior.records[main_block_end..]);
@@ -852,7 +851,10 @@ mod tests {
 
         // Append two records to the MAIN transcript only.
         use std::io::Write as _;
-        let mut file = std::fs::OpenOptions::new().append(true).open(&main).unwrap();
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&main)
+            .unwrap();
         writeln!(
             file,
             "{}",

--- a/src/bin/caller/message_search/extract_codex.rs
+++ b/src/bin/caller/message_search/extract_codex.rs
@@ -24,7 +24,7 @@
 //! published shard and a generation number on rewrite detection);
 //! nothing here resolves homes or the environment.
 
-use super::cursor::{read_complete_lines_from, SourceCursor};
+use super::cursor::{for_each_complete_line_from, SourceCursor};
 use super::record::{cap_text, Locator, MessageRecord, Role, Source, SupersessionMark};
 use super::store::SessionShard;
 use crate::external_agent::codex::rollout::{
@@ -60,8 +60,6 @@ pub(crate) fn extract_codex_session(
     prior: Option<&SessionShard>,
     generation: u32,
 ) -> std::io::Result<(SessionShard, Vec<SourceCursor>)> {
-    let (lines, consumed) = read_complete_lines_from(rollout_path, 0)?;
-
     let mut session_id: Option<String> = None;
     let mut records: Vec<MessageRecord> = Vec::new();
     let mut marks: Vec<SupersessionMark> = Vec::new();
@@ -75,20 +73,21 @@ pub(crate) fn extract_codex_session(
     // parseable one forward for (rare) lines missing their own.
     let mut ts_ms: i64 = 0;
 
-    for (index, line) in lines.iter().enumerate() {
-        let line_no = index as u64 + 1;
+    let mut line_no: u64 = 0;
+    let consumed = for_each_complete_line_from(rollout_path, 0, |line| {
+        line_no += 1;
         let trimmed = line.trim();
         if trimmed.is_empty() {
-            continue;
+            return;
         }
         let Ok(obj) = serde_json::from_str::<serde_json::Value>(trimmed) else {
-            continue;
+            return;
         };
         if let Some(parsed) = value_str(&obj, "timestamp").as_deref().and_then(rfc3339_ms) {
             ts_ms = parsed;
         }
         let Some(payload) = obj.get("payload") else {
-            continue;
+            return;
         };
         match obj.get("type").and_then(|v| v.as_str()).unwrap_or("") {
             "session_meta" => {
@@ -125,10 +124,10 @@ pub(crate) fn extract_codex_session(
                 "user_message" => {
                     user_turn = user_turn.saturating_add(1);
                     let Some((_, text)) = codex_event_message_text(payload) else {
-                        continue;
+                        return;
                     };
                     if text.trim().is_empty() || is_codex_injected_user_text(&text) {
-                        continue;
+                        return;
                     }
                     records.push(message_record(
                         Role::User,
@@ -144,12 +143,12 @@ pub(crate) fn extract_codex_session(
             },
             "response_item" => {
                 let Some((role, text)) = codex_payload_text(payload) else {
-                    continue;
+                    return;
                 };
                 // role "user" is the event_msg twin lane (dedup) plus the
                 // machine injections; "developer" is harness config.
                 if role != "assistant" || text.trim().is_empty() {
-                    continue;
+                    return;
                 }
                 let item_id = codex_response_item_id(&obj);
                 // Assistant records carry the ordinal of the user turn
@@ -169,7 +168,7 @@ pub(crate) fn extract_codex_session(
             }
             _ => {}
         }
-    }
+    })?;
 
     let session_id = session_id.unwrap_or_else(|| {
         // Degenerate rollout with no session_meta line: fall back to the

--- a/src/bin/caller/message_search/extract_intendant.rs
+++ b/src/bin/caller/message_search/extract_intendant.rs
@@ -30,7 +30,7 @@
 //! the external backend's own log (the Codex/Claude extractors' lane) —
 //! extracting them here would double every wrapped message.
 
-use super::cursor::{read_complete_lines_from, SourceCursor};
+use super::cursor::{for_each_complete_line_from, SourceCursor};
 use super::record::{
     cap_text, Locator, MessageRecord, Role, Source, SupersessionMark, MESSAGE_TEXT_CAP_BYTES,
 };
@@ -59,7 +59,6 @@ pub(crate) fn extract_intendant_session(log_dir: &Path) -> std::io::Result<Inten
             wrapper: false,
         });
     }
-    let (lines, consumed) = read_complete_lines_from(&session_jsonl, 0)?;
     let meta = read_meta(log_dir);
     let session_id = log_dir
         .file_name()
@@ -67,15 +66,19 @@ pub(crate) fn extract_intendant_session(log_dir: &Path) -> std::io::Result<Inten
         .or_else(|| meta.as_ref().map(|meta| meta.session_id.clone()))
         .unwrap_or_else(|| "unknown".to_string());
 
-    // Single parse pass; era decisions need whole-file facts (marker
-    // position, wrapper flag, whether any canonical rows exist at all).
+    // Single STREAMING parse pass (no whole-file Vec<String>); era
+    // decisions need whole-file facts (marker position, wrapper flag,
+    // whether any canonical rows exist at all), so the parsed events are
+    // still collected.
     let mut events: Vec<(u64, serde_json::Value)> = Vec::new();
     let mut wrapper = false;
     let mut first_marker: Option<usize> = None;
     let mut any_conversation_message = false;
-    for (index, line) in lines.iter().enumerate() {
+    let mut line_no: u64 = 0;
+    let consumed = for_each_complete_line_from(&session_jsonl, 0, |line| {
+        line_no += 1;
         let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue; // torn or foreign line: not extractable, never fatal
+            return; // torn or foreign line: not extractable, never fatal
         };
         match value.get("event").and_then(|event| event.as_str()) {
             Some("session_identity") => wrapper = true,
@@ -85,8 +88,8 @@ pub(crate) fn extract_intendant_session(log_dir: &Path) -> std::io::Result<Inten
             Some("conversation_message") => any_conversation_message = true,
             _ => {}
         }
-        events.push((index as u64 + 1, value));
-    }
+        events.push((line_no, value));
+    })?;
 
     let cursors = SourceCursor::capture(&session_jsonl, consumed)
         .map(|cursor| vec![cursor])

--- a/src/bin/caller/message_search/indexer.rs
+++ b/src/bin/caller/message_search/indexer.rs
@@ -524,11 +524,13 @@ impl Indexer {
                         .unwrap_or(0);
                     // Exact source-set match (no removed transcript may
                     // linger in the fold; a removed source must shrink the
-                    // shard exactly as a full re-extract would).
+                    // shard exactly as a full re-extract would), and the
+                    // main cursor must carry BOTH rewrite-detection
+                    // windows — a pre-tail-window cursor never resumes.
                     let sources_match = saved_for_session == 1 + transcript_agents.len()
-                        && cursor_by_path
-                            .get(&main_path)
-                            .is_some_and(|(key, _)| key == &session_key)
+                        && cursor_by_path.get(&main_path).is_some_and(|(key, cursor)| {
+                            key == &session_key && cursor.supports_incremental_resume()
+                        })
                         && transcript_agents.iter().all(|path| {
                             cursor_by_path
                                 .get(path.as_path())

--- a/src/bin/caller/message_search/indexer.rs
+++ b/src/bin/caller/message_search/indexer.rs
@@ -71,9 +71,15 @@ pub(crate) struct SweepStats {
 /// Cross-sweep in-process memory (see the module doc): sources that
 /// produced nothing publishable, keyed by path with the cursor that
 /// proved it, so unchanged ones are skipped without re-parsing.
+/// Publishes queued per sweep before a batched manifest flush; bounds how
+/// many derived shards sit in memory awaiting the flush.
+const PUBLISH_BATCH_MAX: usize = 16;
+
 #[derive(Default)]
 pub(crate) struct Indexer {
     unpublishable: HashMap<PathBuf, SourceCursor>,
+    /// (source path for failure attribution, queued publish).
+    pending_publishes: Vec<(PathBuf, super::store::PendingPublish)>,
     sweeps: u64,
 }
 
@@ -137,6 +143,9 @@ impl Indexer {
             horizon,
             &mut stats,
         );
+        // Everything derived this sweep persists before the coverage and
+        // drain passes below read `failed_paths` / the on-disk manifest.
+        self.flush_pending_publishes(&store, &mut failed_paths, &mut stats);
 
         // Coverage: a published session whose every source file vanished
         // (lease cleanup, manual deletion) keeps serving from the shard
@@ -473,15 +482,22 @@ impl Indexer {
                 for path in &agent_paths {
                     seen_paths.insert(path.clone());
                 }
-                let all_unchanged =
-                    std::iter::once(&main_path)
-                        .chain(agent_paths.iter())
-                        .all(|path| {
-                            cursor_by_path
-                                .get(path)
-                                .is_some_and(|(_, cursor)| cursor.check() == CursorCheck::Unchanged)
-                        });
-                if all_unchanged {
+                let main_check = cursor_by_path
+                    .get(&main_path)
+                    .map(|(_, cursor)| cursor.check());
+                // Only transcript-shaped agent files can affect the shard
+                // (the extractor filters to exactly this set), so only
+                // they participate in the skip/fold decisions — a foreign
+                // .jsonl under subagents/ no longer forces a re-parse of
+                // an otherwise-unchanged session every sweep.
+                let transcript_agents =
+                    super::extract_claude::claude_transcript_agents(&agent_paths);
+                let agents_unchanged = transcript_agents.iter().all(|path| {
+                    cursor_by_path
+                        .get(path.as_path())
+                        .is_some_and(|(_, cursor)| cursor.check() == CursorCheck::Unchanged)
+                });
+                if matches!(main_check, Some(CursorCheck::Unchanged)) && agents_unchanged {
                     stats.skipped_unchanged += 1;
                     continue;
                 }
@@ -493,6 +509,81 @@ impl Indexer {
                 let session_key = format!("{}:{}", Source::ClaudeCode.as_str(), session_id);
                 if snapshot.manifest.tombstones.contains_key(&session_key) {
                     continue;
+                }
+                // Main-only append with a byte-unchanged, set-unchanged
+                // subagent side: fold the appended suffix into the
+                // published shard (claude records are line-local) instead
+                // of re-parsing tens of MB per live session per sweep.
+                // Every guard failure falls through to the full parse.
+                if matches!(main_check, Some(CursorCheck::Appended)) && agents_unchanged {
+                    let saved_for_session = snapshot
+                        .manifest
+                        .sessions
+                        .get(&session_key)
+                        .map(|entry| entry.cursors.len())
+                        .unwrap_or(0);
+                    // Exact source-set match (no removed transcript may
+                    // linger in the fold; a removed source must shrink the
+                    // shard exactly as a full re-extract would).
+                    let sources_match = saved_for_session == 1 + transcript_agents.len()
+                        && cursor_by_path
+                            .get(&main_path)
+                            .is_some_and(|(key, _)| key == &session_key)
+                        && transcript_agents.iter().all(|path| {
+                            cursor_by_path
+                                .get(path.as_path())
+                                .is_some_and(|(key, _)| key == &session_key)
+                        });
+                    let prior = if sources_match {
+                        snapshot
+                            .read_shard(&session_key)
+                            .filter(|shard| !shard.records.is_empty())
+                    } else {
+                        None
+                    };
+                    if let Some(prior) = prior {
+                        let (_, main_cursor) = cursor_by_path
+                            .get(&main_path)
+                            .expect("main cursor checked above");
+                        match super::extract_claude::fold_claude_main_append(
+                            &session_id,
+                            &main_path,
+                            main_cursor.last_complete_line_offset,
+                            &prior,
+                        ) {
+                            Ok(Some((shard, new_main_cursor))) => {
+                                stats.parsed += 1;
+                                let mut cursors =
+                                    Vec::with_capacity(1 + transcript_agents.len());
+                                cursors.push(new_main_cursor);
+                                cursors.extend(transcript_agents.iter().map(|path| {
+                                    cursor_by_path
+                                        .get(path.as_path())
+                                        .expect("agent cursor checked above")
+                                        .1
+                                        .clone()
+                                }));
+                                self.publish(
+                                    store,
+                                    &session_key,
+                                    shard,
+                                    cursors,
+                                    &main_path,
+                                    failed_paths,
+                                    stats,
+                                );
+                                continue;
+                            }
+                            Ok(None) => {}
+                            Err(err) => {
+                                eprintln!(
+                                    "[message-search] claude incremental fold {} failed \
+                                     (falling back to full parse): {err}",
+                                    main_path.display()
+                                );
+                            }
+                        }
+                    }
                 }
                 stats.parsed += 1;
                 match extract_claude_session(&session_id, &main_path, &agent_paths) {
@@ -562,6 +653,10 @@ impl Indexer {
     }
 
     #[allow(clippy::too_many_arguments)] // one sweep's shared frame, threaded to each lane
+    /// Queue a derived shard for the batched flush; publishing per session
+    /// paid one writer lock + full manifest read + full manifest rewrite
+    /// EACH. Flushes early at [`PUBLISH_BATCH_MAX`] to bound memory.
+    #[allow(clippy::too_many_arguments)] // mirrors the sweep frame it serves
     fn publish(
         &mut self,
         store: &Store,
@@ -572,16 +667,54 @@ impl Indexer {
         failed_paths: &mut Vec<PathBuf>,
         stats: &mut SweepStats,
     ) {
-        match store.publish_session(session_key, &shard, cursors, false) {
-            Ok(PublishOutcome::Published) => stats.published += 1,
-            // A concurrent daemon got there first with fresher progress;
-            // ours was derived from the same sources — nothing lost.
-            Ok(PublishOutcome::RejectedStale) => {}
-            Ok(PublishOutcome::RejectedTombstoned) => {}
-            Err(err) => {
-                eprintln!("[message-search] publish {session_key} failed: {err}");
-                failed_paths.push(source_path.to_path_buf());
-                stats.failures += 1;
+        self.pending_publishes.push((
+            source_path.to_path_buf(),
+            super::store::PendingPublish {
+                session_key: session_key.to_string(),
+                shard,
+                cursors,
+                source_gone: false,
+            },
+        ));
+        if self.pending_publishes.len() >= PUBLISH_BATCH_MAX {
+            self.flush_pending_publishes(store, failed_paths, stats);
+        }
+    }
+
+    fn flush_pending_publishes(
+        &mut self,
+        store: &Store,
+        failed_paths: &mut Vec<PathBuf>,
+        stats: &mut SweepStats,
+    ) {
+        if self.pending_publishes.is_empty() {
+            return;
+        }
+        let staged = std::mem::take(&mut self.pending_publishes);
+        let (source_paths, batch): (Vec<PathBuf>, Vec<super::store::PendingPublish>) =
+            staged.into_iter().unzip();
+        let session_keys: Vec<String> = batch
+            .iter()
+            .map(|pending| pending.session_key.clone())
+            .collect();
+        for ((outcome, source_path), session_key) in store
+            .publish_sessions(batch)
+            .into_iter()
+            .zip(source_paths)
+            .zip(session_keys)
+        {
+            match outcome {
+                Ok(PublishOutcome::Published) => stats.published += 1,
+                // A concurrent daemon got there first with fresher
+                // progress; ours was derived from the same sources —
+                // nothing lost.
+                Ok(PublishOutcome::RejectedStale) => {}
+                Ok(PublishOutcome::RejectedTombstoned) => {}
+                Err(err) => {
+                    eprintln!("[message-search] publish {session_key} failed: {err}");
+                    failed_paths.push(source_path);
+                    stats.failures += 1;
+                }
             }
         }
     }

--- a/src/bin/caller/message_search/indexer.rs
+++ b/src/bin/caller/message_search/indexer.rs
@@ -550,7 +550,7 @@ impl Indexer {
                         match super::extract_claude::fold_claude_main_append(
                             &session_id,
                             &main_path,
-                            main_cursor.last_complete_line_offset,
+                            main_cursor,
                             &prior,
                         ) {
                             Ok(Some((shard, new_main_cursor))) => {

--- a/src/bin/caller/message_search/indexer.rs
+++ b/src/bin/caller/message_search/indexer.rs
@@ -553,8 +553,7 @@ impl Indexer {
                         ) {
                             Ok(Some((shard, new_main_cursor))) => {
                                 stats.parsed += 1;
-                                let mut cursors =
-                                    Vec::with_capacity(1 + transcript_agents.len());
+                                let mut cursors = Vec::with_capacity(1 + transcript_agents.len());
                                 cursors.push(new_main_cursor);
                                 cursors.extend(transcript_agents.iter().map(|path| {
                                     cursor_by_path

--- a/src/bin/caller/message_search/mod.rs
+++ b/src/bin/caller/message_search/mod.rs
@@ -16,7 +16,7 @@
 //! ([`record::derive_active`]) — never stored — because Codex restores
 //! can reactivate messages (plan D2).
 
-mod cursor;
+pub(crate) mod cursor;
 mod extract_claude;
 mod extract_codex;
 mod extract_intendant;

--- a/src/bin/caller/message_search/store.rs
+++ b/src/bin/caller/message_search/store.rs
@@ -175,7 +175,8 @@ impl Store {
     ) -> std::io::Result<PublishOutcome> {
         let _lock = WriterLock::acquire(&self.root)?;
         let mut manifest = self.read_manifest();
-        let outcome = self.apply_publish(&mut manifest, session_key, shard, cursors, source_gone)?;
+        let outcome =
+            self.apply_publish(&mut manifest, session_key, shard, cursors, source_gone)?;
         if matches!(outcome, PublishOutcome::Published) {
             self.write_published_manifest(&mut manifest)?;
         }

--- a/src/bin/caller/message_search/store.rs
+++ b/src/bin/caller/message_search/store.rs
@@ -276,17 +276,33 @@ impl Store {
                     .cursors
                     .iter()
                     .all(|old| cursors.iter().any(|new| new.path == old.path));
-            let same_source_state = same_paths
-                && existing.cursors.iter().all(|old| {
-                    cursors
-                        .iter()
-                        .find(|new| new.path == old.path)
-                        .is_none_or(|new| {
-                            new.prefix_hash16 == old.prefix_hash16 && new.identity == old.identity
-                        })
+            // Same cursor set with a LOWER watermark: either a stale
+            // writer (lost race — an older snapshot of the same growing
+            // byte stream) or a legitimate rebuild after the source
+            // itself changed under the stored cursors. Snapshot-to-
+            // snapshot field comparison cannot tell those apart — two
+            // honest snapshots of a growing file differ in len and in
+            // tail-hash-at-offset, while a prefix-preserving in-place
+            // TRUNCATION kept head hash + identity equal and was
+            // rejected as stale forever (every sweep re-derived and
+            // re-rejected it). Ask the STORED cursors about the live
+            // files instead: while every one still describes its file
+            // (Unchanged/Appended), the incoming lower watermark is a
+            // stale view — once any reads Rewritten/Gone, the source
+            // genuinely changed and the rebuild is the fresher truth.
+            // (Two ≤4 KiB window reads per stored cursor, only on the
+            // rare lower-watermark path, under the writer lock.)
+            if watermark < existing.source_watermark && same_paths {
+                let stored_still_current = existing.cursors.iter().all(|old| {
+                    matches!(
+                        old.check(),
+                        super::cursor::CursorCheck::Unchanged
+                            | super::cursor::CursorCheck::Appended
+                    )
                 });
-            if watermark < existing.source_watermark && same_source_state {
-                return Ok(PublishOutcome::RejectedStale);
+                if stored_still_current {
+                    return Ok(PublishOutcome::RejectedStale);
+                }
             }
         }
 
@@ -487,6 +503,75 @@ mod tests {
             std::fs::write(&path, "line\n".repeat(64)).unwrap();
         }
         SourceCursor::capture(&path, offset).unwrap()
+    }
+
+    /// A prefix-preserving in-place TRUNCATION legitimately lowers the
+    /// watermark: the rebuild must be ACCEPTED (the tail window / len
+    /// prove the source changed), not rejected as a stale writer forever.
+    #[test]
+    fn truncated_source_rebuild_with_lower_watermark_is_accepted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = Store::open(tmp.path()).unwrap();
+        let path = tmp.path().join("truncating.jsonl");
+        // Head fills the 4 KiB prefix window so truncation preserves it.
+        let head = format!("{}\n", "h".repeat(4096));
+        std::fs::write(&path, format!("{head}tail-one\ntail-two\n")).unwrap();
+        let full_len = std::fs::metadata(&path).unwrap().len();
+        let full_cursor = SourceCursor::capture(&path, full_len).unwrap();
+        let shard = SessionShard {
+            records: vec![record(100, "before truncation")],
+            marks: vec![],
+        };
+        assert!(matches!(
+            store
+                .publish_session("intendant:trunc", &shard, vec![full_cursor], false)
+                .unwrap(),
+            PublishOutcome::Published
+        ));
+
+        // In-place truncation, first 4 KiB intact, same inode.
+        let truncated = format!("{head}tail-one\n");
+        std::fs::write(&path, &truncated).unwrap();
+        let short_len = std::fs::metadata(&path).unwrap().len();
+        assert!(short_len < full_len);
+        let short_cursor = SourceCursor::capture(&path, short_len).unwrap();
+        let rebuilt = SessionShard {
+            records: vec![record(101, "after truncation")],
+            marks: vec![],
+        };
+        assert!(
+            matches!(
+                store
+                    .publish_session(
+                        "intendant:trunc",
+                        &rebuilt,
+                        vec![short_cursor.clone()],
+                        false
+                    )
+                    .unwrap(),
+                PublishOutcome::Published
+            ),
+            "a genuinely changed source must accept the lower-watermark rebuild"
+        );
+        // Steady state afterwards: the stored cursor matches the disk, so
+        // the next sweep reads Unchanged — no rebuild loop.
+        assert_eq!(
+            short_cursor.check(),
+            super::super::cursor::CursorCheck::Unchanged
+        );
+        // And a REAL stale writer (same source state, lower watermark)
+        // is still rejected.
+        let stale = SessionShard {
+            records: vec![record(99, "stale race loser")],
+            marks: vec![],
+        };
+        let stale_cursor = SourceCursor::capture(&path, short_len - 9).unwrap();
+        assert!(matches!(
+            store
+                .publish_session("intendant:trunc", &stale, vec![stale_cursor], false)
+                .unwrap(),
+            PublishOutcome::RejectedStale
+        ));
     }
 
     #[test]

--- a/src/bin/caller/message_search/store.rs
+++ b/src/bin/caller/message_search/store.rs
@@ -105,6 +105,14 @@ pub(crate) enum PublishOutcome {
     RejectedTombstoned,
 }
 
+/// One queued session publish for [`Store::publish_sessions`].
+pub(crate) struct PendingPublish {
+    pub session_key: String,
+    pub shard: SessionShard,
+    pub cursors: Vec<SourceCursor>,
+    pub source_gone: bool,
+}
+
 impl Store {
     pub(crate) fn open(root: &Path) -> std::io::Result<Self> {
         std::fs::create_dir_all(root.join("generations"))?;
@@ -155,6 +163,9 @@ impl Store {
 
     /// Publish one session's freshly derived shard. `watermark` is the
     /// publisher's consumed-source progress (sum of cursor offsets).
+    /// Production publishes ride [`Self::publish_sessions`] (one manifest
+    /// write per batch); this single-session form serves the tests.
+    #[cfg(test)]
     pub(crate) fn publish_session(
         &self,
         session_key: &str,
@@ -164,6 +175,81 @@ impl Store {
     ) -> std::io::Result<PublishOutcome> {
         let _lock = WriterLock::acquire(&self.root)?;
         let mut manifest = self.read_manifest();
+        let outcome = self.apply_publish(&mut manifest, session_key, shard, cursors, source_gone)?;
+        if matches!(outcome, PublishOutcome::Published) {
+            self.write_published_manifest(&mut manifest)?;
+        }
+        Ok(outcome)
+    }
+
+    /// Publish a whole batch under ONE writer lock, ONE manifest read and
+    /// (at most) ONE manifest write. The per-session publish used to
+    /// read + parse and pretty-serialize + rewrite the whole manifest for
+    /// every published session, every sweep — measured ~7 GB/day of
+    /// manifest write traffic on a busy box. Staleness/tombstone checks
+    /// run per session against the same locked view they always ran under.
+    pub(crate) fn publish_sessions(
+        &self,
+        batch: Vec<PendingPublish>,
+    ) -> Vec<std::io::Result<PublishOutcome>> {
+        fn replicate_error(error: &std::io::Error) -> std::io::Error {
+            std::io::Error::new(error.kind(), error.to_string())
+        }
+        if batch.is_empty() {
+            return Vec::new();
+        }
+        let _lock = match WriterLock::acquire(&self.root) {
+            Ok(lock) => lock,
+            Err(error) => return batch.iter().map(|_| Err(replicate_error(&error))).collect(),
+        };
+        let mut manifest = self.read_manifest();
+        let mut published_any = false;
+        let outcomes: Vec<std::io::Result<PublishOutcome>> = batch
+            .into_iter()
+            .map(|pending| {
+                let outcome = self.apply_publish(
+                    &mut manifest,
+                    &pending.session_key,
+                    &pending.shard,
+                    pending.cursors,
+                    pending.source_gone,
+                );
+                if matches!(outcome, Ok(PublishOutcome::Published)) {
+                    published_any = true;
+                }
+                outcome
+            })
+            .collect();
+        if published_any {
+            if let Err(error) = self.write_published_manifest(&mut manifest) {
+                // Nothing persisted: report the write failure for every
+                // entry (orphaned generation files are GC'd as
+                // unreferenced).
+                return outcomes
+                    .iter()
+                    .map(|_| Err(replicate_error(&error)))
+                    .collect();
+            }
+        }
+        outcomes
+    }
+
+    fn write_published_manifest(&self, manifest: &mut Manifest) -> std::io::Result<()> {
+        manifest.schema = 1;
+        manifest.parser_version = PARSER_VERSION;
+        manifest.updated_at_ms = now_ms();
+        self.write_manifest(manifest)
+    }
+
+    /// The caller holds the writer lock and owns writing `manifest` back.
+    fn apply_publish(
+        &self,
+        manifest: &mut Manifest,
+        session_key: &str,
+        shard: &SessionShard,
+        cursors: Vec<SourceCursor>,
+        source_gone: bool,
+    ) -> std::io::Result<PublishOutcome> {
         if manifest.tombstones.contains_key(session_key) {
             return Ok(PublishOutcome::RejectedTombstoned);
         }
@@ -227,10 +313,6 @@ impl Store {
                 source_gone,
             },
         );
-        manifest.schema = 1;
-        manifest.parser_version = PARSER_VERSION;
-        manifest.updated_at_ms = now_ms();
-        self.write_manifest(&mut manifest)?;
         Ok(PublishOutcome::Published)
     }
 
@@ -301,7 +383,11 @@ impl Store {
 
     fn write_manifest(&self, manifest: &mut Manifest) -> std::io::Result<()> {
         manifest.revision += 1;
-        let body = serde_json::to_string_pretty(manifest).map_err(std::io::Error::other)?;
+        // Compact, not pretty: the manifest is machine-read only, grows
+        // with session count (1.2 MB at ~1,600 sessions), and is rewritten
+        // on every publish flush — indentation was pure write
+        // amplification.
+        let body = serde_json::to_string(manifest).map_err(std::io::Error::other)?;
         crate::file_watcher::atomic_write(&self.manifest_path(), body.as_bytes())
     }
 }

--- a/src/bin/caller/web_gateway/access_gates.rs
+++ b/src/bin/caller/web_gateway/access_gates.rs
@@ -980,7 +980,9 @@ mod tests {
                 Some("unknown-cert"),
                 "https",
             ),
-            iam_state: Some(crate::access::iam::LocalIamState::default()),
+            iam_state: Some(std::sync::Arc::new(
+                crate::access::iam::LocalIamState::default(),
+            )),
         };
         let root = RequestAuthority {
             principal: crate::access::iam::AccessPrincipal::root_dashboard_session(
@@ -1011,7 +1013,7 @@ mod tests {
         .expect("revoked binding remains attributable");
         let revoked = RequestAuthority {
             principal: revoked_principal,
-            iam_state: Some(revoked_state),
+            iam_state: Some(std::sync::Arc::new(revoked_state)),
         };
 
         for (path, operation) in [

--- a/src/bin/caller/web_gateway/api_core.rs
+++ b/src/bin/caller/web_gateway/api_core.rs
@@ -246,7 +246,11 @@ impl ApiResponse {
 #[derive(Clone, Debug)]
 pub(crate) struct RequestAuthority {
     pub(crate) principal: crate::access::iam::AccessPrincipal,
-    pub(crate) iam_state: Option<crate::access::iam::LocalIamState>,
+    /// Shared snapshot from the stat-fingerprint cache
+    /// (`iam::load_state_cached_arc`): one consistent state per request,
+    /// without deep-cloning principals/grants/audit history per request
+    /// or per context clone (e.g. into `spawn_blocking`).
+    pub(crate) iam_state: Option<std::sync::Arc<crate::access::iam::LocalIamState>>,
 }
 
 impl RequestAuthority {

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -19,7 +19,9 @@ pub(crate) struct HttpRequestCtx {
     pub(crate) session_provider: String,
     pub(crate) session_model: String,
     pub(crate) agent_card_json: String,
-    pub(crate) agent_card_value_for_targets: serde_json::Value,
+    /// Shared, not owned: rebuilt per request under keep-alive, and the
+    /// card is a multi-KB JSON tree most handlers never touch.
+    pub(crate) agent_card_value_for_targets: Arc<serde_json::Value>,
     pub(crate) app_html: Arc<String>,
     pub(crate) app_html_override: Option<Arc<std::path::Path>>,
     pub(crate) app_html_cache: Arc<OnceLock<(String, Vec<u8>)>>,

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -20,6 +20,11 @@ pub(crate) const TLS_FAILURE_LOG_MAX_ENTRIES: usize = 4096;
 #[derive(Debug)]
 pub(crate) struct TlsFailureLogEntry {
     last_logged: std::time::Instant,
+    /// Updated on EVERY hit, suppressed ones included — the eviction
+    /// signal. `last_logged` alone is recency-BLIND for a continuously
+    /// hot suppressed key (it never re-logs inside the window), which
+    /// made exactly the keys the limiter exists for look "oldest".
+    last_seen: std::time::Instant,
     suppressed: u64,
 }
 
@@ -36,20 +41,20 @@ pub(crate) fn log_tls_failure_rate_limited(
     let mut map = state.lock().unwrap_or_else(|e| e.into_inner());
     if map.len() >= TLS_FAILURE_LOG_MAX_ENTRIES && !map.contains_key(&key) {
         map.retain(|_, entry| {
-            now.duration_since(entry.last_logged)
+            now.duration_since(entry.last_seen)
                 < std::time::Duration::from_secs(TLS_FAILURE_LOG_INTERVAL_SECS)
         });
         if map.len() >= TLS_FAILURE_LOG_MAX_ENTRIES {
             // Everything is inside the window (key churn): evict the
-            // stalest entries down to half the cap instead of clearing —
-            // a clear-all would wipe the HOT keys' suppression state and
-            // let them log again every churn cycle. Log-budget only, so
-            // the sort on this rare overflow path is fine.
+            // least-recently-SEEN entries down to half the cap instead of
+            // clearing — a clear-all would wipe the HOT keys' suppression
+            // state and let them log again every churn cycle. Log-budget
+            // only, so the sort on this rare overflow path is fine.
             let mut by_age: Vec<(String, std::time::Instant)> = map
                 .iter()
-                .map(|(key, entry)| (key.clone(), entry.last_logged))
+                .map(|(key, entry)| (key.clone(), entry.last_seen))
                 .collect();
-            by_age.sort_by_key(|(_, last_logged)| *last_logged);
+            by_age.sort_by_key(|(_, last_seen)| *last_seen);
             let excess = map.len().saturating_sub(TLS_FAILURE_LOG_MAX_ENTRIES / 2);
             for (stale_key, _) in by_age.into_iter().take(excess) {
                 map.remove(&stale_key);
@@ -61,11 +66,13 @@ pub(crate) fn log_tls_failure_rate_limited(
             if now.duration_since(entry.last_logged)
                 < std::time::Duration::from_secs(TLS_FAILURE_LOG_INTERVAL_SECS) =>
         {
+            entry.last_seen = now;
             entry.suppressed = entry.suppressed.saturating_add(1);
         }
         Some(entry) => {
             let suppressed = entry.suppressed;
             entry.last_logged = now;
+            entry.last_seen = now;
             entry.suppressed = 0;
             drop(map);
             if suppressed > 0 {
@@ -82,12 +89,63 @@ pub(crate) fn log_tls_failure_rate_limited(
                 key,
                 TlsFailureLogEntry {
                     last_logged: now,
+                    last_seen: now,
                     suppressed: 0,
                 },
             );
             drop(map);
             eprintln!("[web_gateway] {kind} from {peer}: {detail}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tls_log_budget_tests {
+    use super::*;
+
+    /// A continuously hot key whose repeats are all SUPPRESSED (so its
+    /// `last_logged` never moves) must survive an overflow eviction —
+    /// evicting by log recency instead of seen recency recreated the
+    /// original per-cycle log flood for exactly the hottest keys.
+    #[test]
+    fn overflow_eviction_keeps_hot_suppressed_keys() {
+        let state: TlsFailureLogState = Arc::new(Mutex::new(HashMap::new()));
+        log_tls_failure_rate_limited(&state, "10.0.0.1:1", "tls handshake failed", "hot");
+        // Churn: distinct scanner keys fill the map to the cap.
+        for index in 0..(TLS_FAILURE_LOG_MAX_ENTRIES - 1) {
+            log_tls_failure_rate_limited(
+                &state,
+                &format!("10.0.{}.{}:2", index / 256, index % 256),
+                "tls handshake failed",
+                "churn",
+            );
+        }
+        // The hot key keeps hitting — suppressed (inside the interval),
+        // so only `last_seen` moves.
+        log_tls_failure_rate_limited(&state, "10.0.0.1:1", "tls handshake failed", "hot");
+        {
+            let map = state.lock().unwrap();
+            assert_eq!(map.len(), TLS_FAILURE_LOG_MAX_ENTRIES);
+            let hot = map
+                .get("tls handshake failed|10.0.0.1:1|hot")
+                .expect("hot key present before overflow");
+            assert_eq!(hot.suppressed, 1, "second hit rides suppression");
+        }
+        // One more distinct key overflows the cap and triggers eviction.
+        log_tls_failure_rate_limited(&state, "10.9.9.9:3", "tls handshake failed", "overflow");
+        let map = state.lock().unwrap();
+        assert!(
+            map.len() <= TLS_FAILURE_LOG_MAX_ENTRIES / 2 + 1,
+            "eviction trims to half cap (+ the new key), got {}",
+            map.len()
+        );
+        let hot = map
+            .get("tls handshake failed|10.0.0.1:1|hot")
+            .expect("hot suppressed key must survive eviction");
+        assert_eq!(
+            hot.suppressed, 1,
+            "suppression state rides through the eviction"
+        );
     }
 }
 

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -40,7 +40,20 @@ pub(crate) fn log_tls_failure_rate_limited(
                 < std::time::Duration::from_secs(TLS_FAILURE_LOG_INTERVAL_SECS)
         });
         if map.len() >= TLS_FAILURE_LOG_MAX_ENTRIES {
-            map.clear();
+            // Everything is inside the window (key churn): evict the
+            // stalest entries down to half the cap instead of clearing —
+            // a clear-all would wipe the HOT keys' suppression state and
+            // let them log again every churn cycle. Log-budget only, so
+            // the sort on this rare overflow path is fine.
+            let mut by_age: Vec<(String, std::time::Instant)> = map
+                .iter()
+                .map(|(key, entry)| (key.clone(), entry.last_logged))
+                .collect();
+            by_age.sort_by_key(|(_, last_logged)| *last_logged);
+            let excess = map.len().saturating_sub(TLS_FAILURE_LOG_MAX_ENTRIES / 2);
+            for (stale_key, _) in by_age.into_iter().take(excess) {
+                map.remove(&stale_key);
+            }
         }
     }
     match map.get_mut(&key) {

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -10,6 +10,13 @@ use super::*;
 
 pub(crate) const TLS_FAILURE_LOG_INTERVAL_SECS: u64 = 30;
 
+/// Size cap for the rate-limiter map: entries are keyed by
+/// `kind|peer|detail`, so an internet-exposed port collects one entry per
+/// distinct scanner address for the daemon's lifetime. At the cap, entries
+/// stale for a full log interval are swept; if everything is somehow live,
+/// the map is reset (worst case: one duplicate log line per key).
+pub(crate) const TLS_FAILURE_LOG_MAX_ENTRIES: usize = 4096;
+
 #[derive(Debug)]
 pub(crate) struct TlsFailureLogEntry {
     last_logged: std::time::Instant,
@@ -27,6 +34,15 @@ pub(crate) fn log_tls_failure_rate_limited(
     let now = std::time::Instant::now();
     let key = format!("{kind}|{peer}|{detail}");
     let mut map = state.lock().unwrap_or_else(|e| e.into_inner());
+    if map.len() >= TLS_FAILURE_LOG_MAX_ENTRIES && !map.contains_key(&key) {
+        map.retain(|_, entry| {
+            now.duration_since(entry.last_logged)
+                < std::time::Duration::from_secs(TLS_FAILURE_LOG_INTERVAL_SECS)
+        });
+        if map.len() >= TLS_FAILURE_LOG_MAX_ENTRIES {
+            map.clear();
+        }
+    }
     match map.get_mut(&key) {
         Some(entry)
             if now.duration_since(entry.last_logged)
@@ -384,7 +400,9 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
     }
     let agent_card_json =
         serde_json::to_string(&agent_card_value).unwrap_or_else(|_| "{}".to_string());
-    let agent_card_value_for_targets = agent_card_value.clone();
+    // Arc'd once at spawn: the per-request `HttpRequestCtx` rebuild used to
+    // deep-clone this multi-KB JSON tree for every request since keep-alive.
+    let agent_card_value_for_targets = Arc::new(agent_card_value.clone());
     let bootstrap_caches = crate::dashboard_control::DashboardBootstrapCaches::default();
 
     // Warm the session list in the background so the first dashboard
@@ -1718,6 +1736,10 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
                     // Direct response channel: tool_response and state_snapshot
                     // messages for this specific connection (not broadcast).
                     let (direct_tx, direct_rx) = mpsc::unbounded_channel::<String>();
+                    // Bounded PTY-output lane: terminal forwarders park on a
+                    // stalled socket instead of flooding the direct lane.
+                    let (terminal_forward_tx, terminal_forward_rx) =
+                        mpsc::channel::<String>(crate::web_gateway::TERMINAL_FORWARD_LANE_CAP);
 
                     // Subscribe before reading the authority bootstrap. Any
                     // transition racing the snapshot is then either represented
@@ -2106,6 +2128,7 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
                         bus: bus.clone(),
                         query_ctx: query_ctx.clone(),
                         direct_tx: direct_tx.clone(),
+                        terminal_forward_tx,
                         voice_debug: voice_debug.clone(),
                         live_provider: session_provider.clone(),
                         live_model: session_model.clone(),
@@ -2142,6 +2165,7 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
                     let outbound = tokio::spawn(ws_outbound_task(
                         outbound_rx,
                         direct_rx,
+                        terminal_forward_rx,
                         ws_tx,
                         authority_change_rx,
                         connection_id.clone(),

--- a/src/bin/caller/web_gateway/mcp_gate.rs
+++ b/src/bin/caller/web_gateway/mcp_gate.rs
@@ -359,11 +359,17 @@ pub(crate) async fn handle_mcp_http_request(
         }
     };
 
+    // Move, don't clone: tool results can carry multi-MB payloads (fs
+    // reads run under a 16 MB cap) and the original is dropped here anyway.
+    let (result, error) = match result {
+        Ok(value) => (Some(value), None),
+        Err(error) => (None, Some(error)),
+    };
     McpHttpOutcome::Response(McpHttpResponse {
         jsonrpc: "2.0".into(),
         id: request.id,
-        result: result.as_ref().ok().cloned(),
-        error: result.err(),
+        result,
+        error,
     })
 }
 
@@ -444,19 +450,31 @@ pub(crate) async fn handle_mcp_post(
             &mcp_access,
         )
         .await;
+        // Keep-alive opt-in (response leg): both shapes are self-framing
+        // (Content-Length), and dispatch consumed the body under the /mcp
+        // row's cap. Managed Codex/CC backends call /mcp once per tool
+        // call — closing here made every call pay a fresh TCP (+TLS)
+        // handshake, exactly the cost keep-alive removed elsewhere.
+        let reuse = stream.exchange_reusable();
         let http_response = match outcome {
             McpHttpOutcome::Response(resp) => {
                 let json = serde_json::to_string(&resp).unwrap_or_default();
                 HttpResponse::with_content("200 OK", "application/json", json)
                     .header_segment(&mcp_cors)
+                    .connection_reuse(reuse)
                     .into_string()
             }
             McpHttpOutcome::Accepted => HttpResponse::new("202 Accepted")
                 .header_segment(&mcp_cors)
                 .header("Content-Length", "0")
+                .connection_reuse(reuse)
                 .into_string(),
         };
-        let _ = stream.write_all(http_response.as_bytes()).await;
+        let write_ok = stream.write_all(http_response.as_bytes()).await.is_ok();
+        if reuse && write_ok {
+            stream.park().await;
+            return;
+        }
     } else {
         let err =
             r#"{"jsonrpc":"2.0","error":{"code":-32603,"message":"MCP server not available"}}"#;
@@ -472,12 +490,18 @@ pub(crate) async fn handle_mcp_stream(mut stream: DemuxStream, header_text: &str
     // are not supported by our stateless endpoint.  Return 405 so rmcp
     // gracefully falls back (skips SSE / ignores session delete).
     use tokio::io::AsyncWriteExt;
+    let reuse = stream.exchange_reusable();
     let http = HttpResponse::new("405 Method Not Allowed")
         .header_segment(&mcp_cors_header_segment(header_text, is_tls))
         .header("Content-Length", "0")
+        .connection_reuse(reuse)
         .into_string();
-    let _ = stream.write_all(http.as_bytes()).await;
-    finalize_http_stream(&mut stream).await;
+    let write_ok = stream.write_all(http.as_bytes()).await.is_ok();
+    if reuse && write_ok {
+        stream.park().await;
+    } else {
+        finalize_http_stream(&mut stream).await;
+    }
 }
 
 /// Bind a `POST /mcp` request to an access principal, the same way the

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -1780,10 +1780,7 @@ pub(crate) fn fleet_access_origin_allowed(
                 crate::peer::card::TransportSpec::IntendantWs { url } => Some(url.as_str()),
                 _ => None,
             });
-            for candidate in [ws_url, handle.browser_tcp_via_url()]
-                .into_iter()
-                .flatten()
-            {
+            for candidate in [ws_url, handle.browser_tcp_via_url()].into_iter().flatten() {
                 if normalized_origin(candidate).as_deref() == Some(&normalized) {
                     return true;
                 }

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -257,7 +257,7 @@ pub(crate) fn access_overview_inbound_peer_identities(
 pub(crate) async fn handle_dashboard_targets(
     stream: DemuxStream,
     peer_registry: Option<crate::peer::PeerRegistry>,
-    agent_card_value_for_targets: serde_json::Value,
+    agent_card_value_for_targets: std::sync::Arc<serde_json::Value>,
     cors: crate::gateway_routes::CorsPosture,
     fleet_origin: Option<&str>,
     local_tier: Option<&str>,
@@ -272,18 +272,37 @@ pub(crate) async fn handle_dashboard_targets(
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 
+/// Run a synchronous authority-store operation off the async reactor.
+/// `authority_store::with_lock` waits for its process/file locks with
+/// blocking `std::thread::sleep` retries (up to its 2s timeout), so a
+/// daemon+CLI contention window would otherwise park a tokio worker —
+/// and every connection multiplexed on it — for the duration.
+async fn blocking_access_response(
+    task: impl FnOnce() -> ApiResponse + Send + 'static,
+) -> ApiResponse {
+    tokio::task::spawn_blocking(task)
+        .await
+        .unwrap_or_else(|error| {
+            ApiResponse::json_error(500, format!("authority task failed: {error}"))
+        })
+}
+
 pub(crate) async fn handle_access_org_grant_present(
     stream: DemuxStream,
     body_text: String,
     cert_dir: std::path::PathBuf,
-    agent_card_value_for_targets: serde_json::Value,
+    agent_card_value_for_targets: std::sync::Arc<serde_json::Value>,
     cors: crate::gateway_routes::CorsPosture,
 ) {
     // Transport-owned body decode; the doorbell's parse-error 400 rides
     // the same public tail as its value errors.
     let response = match serde_json::from_str::<serde_json::Value>(&body_text) {
         Ok(params) => {
-            access_org_present_api_response(&cert_dir, params, &agent_card_value_for_targets)
+            // Materializes grants — an authority transaction.
+            blocking_access_response(move || {
+                access_org_present_api_response(&cert_dir, params, &agent_card_value_for_targets)
+            })
+            .await
         }
         Err(e) => ApiResponse::json_error(400, format!("invalid JSON: {e}")),
     };
@@ -313,13 +332,18 @@ pub(crate) async fn handle_access_org_apply_renew(
 ) {
     // The per-path caps (ORL vs grant-doc) live on the two table rows;
     // dispatch already read under the right one.
+    let is_orl_apply = req_path == "/api/access/orgs/revocations/apply";
     let response = match serde_json::from_str::<serde_json::Value>(&body_text) {
         Ok(params) => {
-            if req_path == "/api/access/orgs/revocations/apply" {
-                access_org_orl_apply_api_response(&cert_dir, params)
-            } else {
-                access_org_renew_api_response(&cert_dir, params)
-            }
+            // Both leaves run authority transactions.
+            blocking_access_response(move || {
+                if is_orl_apply {
+                    access_org_orl_apply_api_response(&cert_dir, params)
+                } else {
+                    access_org_renew_api_response(&cert_dir, params)
+                }
+            })
+            .await
         }
         Err(e) => ApiResponse::json_error(400, format!("invalid JSON: {e}")),
     };
@@ -350,21 +374,19 @@ pub(crate) async fn handle_access_iam_grants(
         .await;
         return;
     }
+    let is_update = req_path == "/api/access/iam/grants/update";
     let response = match parse_access_request_body(&body_text) {
         Ok(params) => {
-            if req_path == "/api/access/iam/grants/update" {
-                access_iam_update_grant_api_response(
-                    &cert_dir,
-                    params,
-                    &http_access_context.principal,
-                )
-            } else {
-                access_iam_upsert_user_client_grant_api_response(
-                    &cert_dir,
-                    params,
-                    &http_access_context.principal,
-                )
-            }
+            // Grant upsert/update are authority transactions.
+            let actor = http_access_context.principal.clone();
+            blocking_access_response(move || {
+                if is_update {
+                    access_iam_update_grant_api_response(&cert_dir, params, &actor)
+                } else {
+                    access_iam_upsert_user_client_grant_api_response(&cert_dir, params, &actor)
+                }
+            })
+            .await
         }
         Err(error) => *error,
     };
@@ -393,12 +415,15 @@ pub(crate) async fn handle_access_org_manage(
         .await;
         return;
     }
+    let leaf = OrgManageLeaf::from_req_path(req_path);
     let response = match parse_access_request_body(&body_text) {
-        Ok(params) => access_org_manage_api_response(
-            &cert_dir,
-            OrgManageLeaf::from_req_path(req_path),
-            params,
-        ),
+        // Every org-manage leaf mutates or signs authority state.
+        Ok(params) => {
+            blocking_access_response(move || {
+                access_org_manage_api_response(&cert_dir, leaf, params)
+            })
+            .await
+        }
         Err(error) => *error,
     };
     // Historical framing quirk, byte-pinned by the golden transcripts:
@@ -443,7 +468,12 @@ pub(crate) async fn handle_access_enrollment_decide(
     }
     let response = match parse_access_request_body(&body_text) {
         Ok(params) => {
-            access_enrollment_decide_api_response(&cert_dir, params, &http_access_context.principal)
+            // Approval upserts a grant — an authority transaction.
+            let actor = http_access_context.principal.clone();
+            blocking_access_response(move || {
+                access_enrollment_decide_api_response(&cert_dir, params, &actor)
+            })
+            .await
         }
         Err(error) => *error,
     };
@@ -1067,13 +1097,18 @@ pub(crate) async fn handle_fleet_cert_request(
         .await;
         return;
     }
-    let response = if body_text.trim().is_empty() {
-        fleet_cert_request_api_response(serde_json::json!({}))
+    let params = if body_text.trim().is_empty() {
+        Ok(serde_json::json!({}))
     } else {
-        match parse_access_request_body(&body_text) {
-            Ok(params) => fleet_cert_request_api_response(params),
-            Err(error) => *error,
+        parse_access_request_body(&body_text)
+    };
+    let response = match params {
+        // The request path persists fleet-origin provenance under the
+        // authority-store lock.
+        Ok(params) => {
+            blocking_access_response(move || fleet_cert_request_api_response(params)).await
         }
+        Err(error) => *error,
     };
     write_api_response(stream, response, cors, fleet_origin).await;
 }
@@ -1083,7 +1118,7 @@ pub(crate) async fn handle_access_overview(
     cert_dir: std::path::PathBuf,
     http_access_context: HttpAccessContext,
     peer_registry: Option<crate::peer::PeerRegistry>,
-    agent_card_value_for_targets: serde_json::Value,
+    agent_card_value_for_targets: std::sync::Arc<serde_json::Value>,
     cors: crate::gateway_routes::CorsPosture,
     fleet_origin: Option<&str>,
 ) {
@@ -1671,8 +1706,12 @@ pub(crate) async fn handle_access_tier_settings(
             }
         }
     };
-    let response =
-        access_tier_settings_api_response(&cert_dir, params, &http_access_context.principal);
+    // Tier changes are authority transactions.
+    let actor = http_access_context.principal.clone();
+    let response = blocking_access_response(move || {
+        access_tier_settings_api_response(&cert_dir, params, &actor)
+    })
+    .await;
     write_api_response(stream, response, cors, fleet_origin).await;
 }
 
@@ -1730,13 +1769,20 @@ pub(crate) fn fleet_access_origin_allowed(
     };
     if let Some(registry) = peer_registry {
         for handle in registry.list() {
-            let snapshot = handle.snapshot();
-            for candidate in [
-                snapshot.ws_url.as_deref(),
-                snapshot.browser_tcp_via_url.as_deref(),
-            ]
-            .into_iter()
-            .flatten()
+            // Only two URL strings feed this gate — read them straight
+            // off the handle (the card snapshot is an `Arc` clone from
+            // the watch channel) instead of building a full
+            // `PeerSnapshot`, which re-serializes every capability and
+            // clones the folded sessions + displays vectors per peer,
+            // per fleet-CORS request and preflight.
+            let card = handle.card_snapshot();
+            let ws_url = card.transports.iter().find_map(|t| match t {
+                crate::peer::card::TransportSpec::IntendantWs { url } => Some(url.as_str()),
+                _ => None,
+            });
+            for candidate in [ws_url, handle.browser_tcp_via_url()]
+                .into_iter()
+                .flatten()
             {
                 if normalized_origin(candidate).as_deref() == Some(&normalized) {
                     return true;
@@ -2395,10 +2441,10 @@ pub(crate) fn access_enrollment_requests_response_value(
     // Route provenance is classified daemon-side (derive, don't mirror):
     // the browser gets a ready `origin_class` per request instead of
     // re-deriving hosted/fleet membership from its own copies.
-    let hosted_origins = crate::access::iam::load_state(cert_dir)
-        .map(|state| state.hosted_origins)
+    let hosted_origins = crate::access::iam::load_state_cached_arc(cert_dir)
+        .map(|state| state.hosted_origins.clone())
         .unwrap_or_else(|_| crate::access::iam::default_hosted_origins());
-    let fleet_zone = crate::fleet_cert::status_snapshot().zone;
+    let fleet_zone = crate::fleet_cert::fleet_zone();
     let requests: Vec<serde_json::Value> =
         crate::access::enrollment::pending_enrollments(crate::access::client_key::now_unix_ms())
             .into_iter()
@@ -2534,7 +2580,7 @@ pub(crate) type HttpAccessContext = RequestAuthority;
 fn browser_mtls_state_for_request(
     cert_dir: &std::path::Path,
     _fingerprint: &str,
-) -> Result<crate::access::iam::LocalIamState, String> {
+) -> Result<std::sync::Arc<crate::access::iam::LocalIamState>, String> {
     // Compatibility enrollment of the exact daemon-generated owner client.crt
     // runs at trusted web startup. Request authentication may durably apply a
     // fail-closed IAM schema migration, but it cannot mint or grant authority.
@@ -2613,7 +2659,7 @@ pub(crate) fn http_access_context(
 
 pub(crate) fn load_local_iam_state_for_request(
     cert_dir: &std::path::Path,
-) -> Result<Option<crate::access::iam::LocalIamState>, String> {
+) -> Result<Option<std::sync::Arc<crate::access::iam::LocalIamState>>, String> {
     let path = crate::access::iam::iam_state_path(cert_dir);
     if !path.exists() {
         return Ok(None);
@@ -2622,7 +2668,9 @@ pub(crate) fn load_local_iam_state_for_request(
     // statics) under browser mTLS, and the raw load re-reads + re-parses
     // the file every time. The cache re-checks the fingerprint on every
     // call, so out-of-process writers are still picked up immediately.
-    crate::access::iam::load_state_cached(cert_dir)
+    // The shared Arc keeps the per-request path free of deep clones —
+    // every consumer reads one consistent snapshot.
+    crate::access::iam::load_state_cached_arc(cert_dir)
         .map(Some)
         .map_err(|e| format!("local IAM state is invalid: {e}"))
 }
@@ -2655,6 +2703,7 @@ pub(crate) fn dashboard_control_grant_for_client(
                 principal,
                 iam_state: state,
                 iam_cert_dir: Some(cert_dir.to_path_buf()),
+                authority_memo: Default::default(),
             },
         );
     }
@@ -2666,6 +2715,7 @@ pub(crate) fn dashboard_control_grant_for_client(
                 principal,
                 iam_state: state,
                 iam_cert_dir: Some(cert_dir.to_path_buf()),
+                authority_memo: Default::default(),
             },
         );
     }
@@ -3669,6 +3719,7 @@ mod tests {
             principal: scoped.principal.clone(),
             iam_state: scoped.iam_state.clone().expect("scoped iam state"),
             iam_cert_dir: Some(tmp.path().to_path_buf()),
+            authority_memo: Default::default(),
         };
         assert!(!ws_grant_allows_control(&scoped_grant, None, &signal, &bus));
         assert!(!ws_grant_allows_control(
@@ -3849,8 +3900,9 @@ mod tests {
             .expect("bound principal resolves");
         let scoped = crate::dashboard_control::DashboardControlGrant::UserClient {
             principal,
-            iam_state: state,
+            iam_state: std::sync::Arc::new(state),
             iam_cert_dir: None,
+            authority_memo: Default::default(),
         };
 
         let bus = EventBus::new();
@@ -3909,8 +3961,9 @@ mod tests {
                 .expect("bound principal resolves");
         let observer = crate::dashboard_control::DashboardControlGrant::UserClient {
             principal: observer_principal,
-            iam_state: observer_state,
+            iam_state: std::sync::Arc::new(observer_state),
             iam_cert_dir: None,
+            authority_memo: Default::default(),
         };
         assert!(deny_ws_frame_if_unauthorized(
             &observer,
@@ -4140,7 +4193,15 @@ mod tests {
             crate::access::iam::AccessPrincipal::root_dashboard_session("golden-test", "local");
         let body = dashboard_targets_response_body(&card, None, None, Some(&principal));
         let response = collect_access_handler_response(|stream| {
-            handle_dashboard_targets(stream, None, card.clone(), cors, None, None, principal)
+            handle_dashboard_targets(
+                stream,
+                None,
+                std::sync::Arc::new(card.clone()),
+                cors,
+                None,
+                None,
+                principal,
+            )
         })
         .await;
         assert_eq!(
@@ -4217,7 +4278,15 @@ mod tests {
                 iam_state: None,
             };
             let response = collect_access_handler_response(|stream| {
-                handle_access_overview(stream, dir, context, None, card, cors, origin)
+                handle_access_overview(
+                    stream,
+                    dir,
+                    context,
+                    None,
+                    std::sync::Arc::new(card),
+                    cors,
+                    origin,
+                )
             })
             .await;
             assert_eq!(
@@ -4969,7 +5038,7 @@ mod tests {
                 stream,
                 "{}".to_string(),
                 cert_dir.clone(),
-                card.clone(),
+                std::sync::Arc::new(card.clone()),
                 public_cors("POST", "/api/access/org-grants"),
             )
         })
@@ -4989,7 +5058,7 @@ mod tests {
                 stream,
                 invalid.to_string(),
                 cert_dir.clone(),
-                card.clone(),
+                std::sync::Arc::new(card.clone()),
                 public_cors("POST", "/api/access/org-grants"),
             )
         })

--- a/src/bin/caller/web_gateway/routes_files.rs
+++ b/src/bin/caller/web_gateway/routes_files.rs
@@ -1514,6 +1514,17 @@ pub(crate) fn dashboard_fs_read_file(
     raw: &str,
     range_header: Option<&str>,
 ) -> Result<DashboardFsReadResponse, DashboardFsReadError> {
+    dashboard_fs_read_file_with_cap(raw, range_header, UPLOAD_MAX_BYTES as u64)
+}
+
+/// `max_read_bytes` bounds how much of the file ONE request may buffer —
+/// rangeless or ranged alike (tests shrink it; production uses
+/// [`UPLOAD_MAX_BYTES`], the same per-request cap as the tunnel form).
+fn dashboard_fs_read_file_with_cap(
+    raw: &str,
+    range_header: Option<&str>,
+    max_read_bytes: u64,
+) -> Result<DashboardFsReadResponse, DashboardFsReadError> {
     let path = expand_dashboard_fs_path(raw)
         .map_err(|e| DashboardFsReadError::new("400 Bad Request", e))?;
     let canonical = std::fs::canonicalize(&path).map_err(|e| {
@@ -1545,7 +1556,7 @@ pub(crate) fn dashboard_fs_read_file(
             })
         })
         .transpose()?;
-    let (range_start, range_end, partial) = if let Some(range) = requested_range {
+    let (range_start, mut range_end, partial) = if let Some(range) = requested_range {
         (range.start, range.end.saturating_add(1), true)
     } else {
         // Rangeless reads buffer the whole file in daemon memory: hold
@@ -1554,19 +1565,25 @@ pub(crate) fn dashboard_fs_read_file(
         // recording cannot spike RSS by the file size (self-DoS). Larger
         // files stay fully downloadable through ranged requests — the
         // chunked flow the dashboard already uses.
-        if total_size > UPLOAD_MAX_BYTES as u64 {
+        if total_size > max_read_bytes {
             return Err(DashboardFsReadError::new(
                 "413 Payload Too Large",
                 format!(
                     "{} is {} bytes; full reads are capped at {} bytes — use Range requests for larger files",
                     canonical.display(),
                     total_size,
-                    UPLOAD_MAX_BYTES,
+                    max_read_bytes,
                 ),
             ));
         }
         (0, total_size, false)
     };
+    // An open-ended range (`bytes=0-`) resolves to end-of-file, which
+    // would buffer the whole file and defeat the cap above. Clamp the
+    // served window to the cap and answer the valid 206 partial (the
+    // Content-Range built below reflects the clamped window, so ranged
+    // clients simply continue from where this response ends).
+    range_end = range_end.min(range_start.saturating_add(max_read_bytes));
     let read_len = range_end.saturating_sub(range_start);
     let read_len_usize: usize = read_len.try_into().map_err(|_| {
         DashboardFsReadError::new(
@@ -3196,6 +3213,36 @@ mod tests {
 
         assert_eq!(err.status, "416 Range Not Satisfiable");
         assert_eq!(err.total_size, Some(5));
+    }
+
+    #[test]
+    fn dashboard_fs_read_caps_rangeless_and_open_ended_ranged_reads() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("big.bin");
+        std::fs::write(&file, b"0123456789abcdefghij").unwrap(); // 20 bytes
+
+        // Rangeless read beyond the cap: 413 with the remedy text.
+        let err = dashboard_fs_read_file_with_cap(file.to_str().unwrap(), None, 8).unwrap_err();
+        assert_eq!(err.status, "413 Payload Too Large");
+        assert!(err.message.contains("Range requests"));
+
+        // Open-ended range (`bytes=0-`) resolves to EOF and would buffer
+        // the whole file: clamp to the cap and serve the valid partial
+        // with an accurate window.
+        let result =
+            dashboard_fs_read_file_with_cap(file.to_str().unwrap(), Some("bytes=0-"), 8).unwrap();
+        assert!(result.partial);
+        assert_eq!(result.total_size, 20);
+        assert_eq!(result.range_start, 0);
+        assert_eq!(result.range_end, 8);
+        assert_eq!(result.bytes, b"01234567");
+
+        // An explicit sub-cap range is untouched.
+        let result =
+            dashboard_fs_read_file_with_cap(file.to_str().unwrap(), Some("bytes=6-9"), 8).unwrap();
+        assert_eq!(result.range_start, 6);
+        assert_eq!(result.range_end, 10);
+        assert_eq!(result.bytes, b"6789");
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/routes_files.rs
+++ b/src/bin/caller/web_gateway/routes_files.rs
@@ -1548,6 +1548,23 @@ pub(crate) fn dashboard_fs_read_file(
     let (range_start, range_end, partial) = if let Some(range) = requested_range {
         (range.start, range.end.saturating_add(1), true)
     } else {
+        // Rangeless reads buffer the whole file in daemon memory: hold
+        // them to the same per-request cap as the tunnel's offset/length
+        // form ([`UPLOAD_MAX_BYTES`]) so one authorized GET of a huge
+        // recording cannot spike RSS by the file size (self-DoS). Larger
+        // files stay fully downloadable through ranged requests — the
+        // chunked flow the dashboard already uses.
+        if total_size > UPLOAD_MAX_BYTES as u64 {
+            return Err(DashboardFsReadError::new(
+                "413 Payload Too Large",
+                format!(
+                    "{} is {} bytes; full reads are capped at {} bytes — use Range requests for larger files",
+                    canonical.display(),
+                    total_size,
+                    UPLOAD_MAX_BYTES,
+                ),
+            ));
+        }
         (0, total_size, false)
     };
     let read_len = range_end.saturating_sub(range_start);
@@ -2955,7 +2972,7 @@ mod tests {
         (
             HttpAccessContext {
                 principal,
-                iam_state: Some(state.clone()),
+                iam_state: Some(std::sync::Arc::new(state.clone())),
             },
             state,
         )
@@ -2978,7 +2995,7 @@ mod tests {
                 Some("BB:66"),
                 "https",
             ),
-            iam_state: Some(crate::access::iam::LocalIamState::default()),
+            iam_state: Some(Default::default()),
         };
         assert!(authorized_dashboard_local_file_response_blocking(
             &request(&allowed),
@@ -3025,7 +3042,7 @@ mod tests {
         revoked_state.grants[0].revoked_at_unix_ms = Some(1);
         let revoked = HttpAccessContext {
             principal: scoped.principal.clone(),
-            iam_state: Some(revoked_state),
+            iam_state: Some(std::sync::Arc::new(revoked_state)),
         };
         assert!(authorized_dashboard_local_file_response_blocking(
             &request(&allowed),

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -1622,17 +1622,18 @@ pub(crate) async fn handle_peer_dashboard_control_signal(
                 return;
             };
             // Delegation-lane attribution (docs/src/trust-tiers.md § Two
-            // lanes). The transport edge resolves the ambient IAM state;
-            // the resolution itself is the testable core below.
+            // lanes). The transport edge resolves the ambient IAM state
+            // (through the stat-fingerprint cache — this runs per relayed
+            // offer); the resolution itself is the testable core below.
             let cert_dir = crate::access::backend::select_backend().cert_dir();
-            let iam_state = crate::access::iam::load_state(&cert_dir).ok();
+            let iam_state = crate::access::iam::load_state_cached_arc(&cert_dir).ok();
             let attributed = match resolve_peer_offer_attribution(
                 &client_key,
                 registry.local_card_id().as_str(),
                 client_nonce.as_deref().unwrap_or(""),
                 &sdp,
                 crate::access::client_key::now_unix_ms(),
-                iam_state.as_ref(),
+                iam_state.as_deref(),
             ) {
                 Ok(attributed) => attributed,
                 Err(reason) => {

--- a/src/bin/caller/web_gateway/routes_transfers.rs
+++ b/src/bin/caller/web_gateway/routes_transfers.rs
@@ -1511,7 +1511,7 @@ mod tests {
                 grant_id: Some(result.grant.id.clone()),
                 ..crate::access::iam::AccessPrincipal::root_dashboard_session("scoped", "https")
             },
-            iam_state: Some(state),
+            iam_state: Some(std::sync::Arc::new(state)),
         };
         assert!(authorize_http_transfer_access(
             &scoped,

--- a/src/bin/caller/web_gateway/session_catalog/backend_lists.rs
+++ b/src/bin/caller/web_gateway/session_catalog/backend_lists.rs
@@ -453,16 +453,17 @@ pub(crate) fn list_codex_sessions_with_limit(
         }
     }
 
-    let mut files = collect_recent_files(&codex.join("sessions"), ".jsonl", scan_limit);
-    files.extend(collect_recent_files(
+    let mut files = collect_recent_files_keyed(&codex.join("sessions"), ".jsonl", scan_limit);
+    files.extend(collect_recent_files_keyed(
         &codex.join("archived_sessions"),
         ".jsonl",
         scan_limit,
     ));
-    files.sort_by_key(|b| std::cmp::Reverse(file_mtime_secs(b)));
+    // Keys carried out of the walks: no re-stat per comparison.
+    files.sort_by_key(|(mtime, _)| std::cmp::Reverse(*mtime));
     files.truncate(scan_limit);
     let mut summaries = Vec::new();
-    for path in files {
+    for (_, path) in files {
         let Some(summary) = codex_session_list_summary_from_file(&path) else {
             continue;
         };
@@ -611,53 +612,60 @@ pub(crate) fn list_codex_sessions_with_limit(
     rows.into_values().collect()
 }
 
-pub(crate) fn claude_session_list_row_from_file(path: &Path) -> Option<serde_json::Value> {
-    let key = session_list_cache_key("claude-code", path, SESSION_ROW_PREVIEW_FORMAT)?;
-    if let Some(row) = cached_session_list_row(&key) {
-        return Some(row);
-    }
+/// Incremental fold state for [`claude_session_list_row_from_file`]. An
+/// ACTIVE transcript invalidates its (len, mtime, ino) row-cache key on
+/// every append, which used to re-parse the whole multi-MB file per list
+/// rebuild, per live session, for as long as the agent runs — the
+/// dominant steady CPU sink of the catalog. The accumulator checkpoints
+/// the fold + consumed byte offset per path, so an append parses only
+/// the suffix; identity/length/prefix-hash checks downgrade any rewrite
+/// or replacement to the full re-parse.
+#[derive(Clone, Default)]
+struct ClaudeRowAccumulator {
+    identity: Option<crate::platform::FileIdentity>,
+    /// Head-hash over `prefix_hash_bytes` (≤ 4 KiB, and never more than
+    /// the consumed range, so resumed and fresh captures compare the
+    /// same window).
+    prefix_hash16: String,
+    prefix_hash_bytes: usize,
+    /// Offset just past the last COMPLETE line folded.
+    consumed_len: u64,
+    /// Complete lines folded so far — continues the historical 0-based
+    /// `line-{idx}` usage-dedup keys across resumed parses.
+    lines_consumed: u64,
+    created_at: Option<String>,
+    updated_at: Option<String>,
+    session_cwd: Option<String>,
+    cwd: Option<String>,
+    task: Option<String>,
+    model: Option<String>,
+    usage: SessionUsage,
+    daily_usage: BTreeMap<String, SessionUsage>,
+    seen_usage: HashSet<String>,
+    turns: u64,
+    preview: SessionPreviewBuilder,
+}
 
-    let session_id = path
-        .file_stem()
-        .and_then(|n| n.to_str())
-        .unwrap_or_default()
-        .to_string();
-    if session_id.is_empty() {
-        return None;
-    }
-    let file = std::fs::File::open(path).ok()?;
-    let reader = std::io::BufReader::new(file);
-    let mut created_at = None;
-    let mut updated_at = None;
-    let mut session_cwd = None;
-    let mut cwd = None;
-    let mut task = None;
-    let mut model = None;
-    let mut usage = SessionUsage::default();
-    let mut daily_usage: BTreeMap<String, SessionUsage> = BTreeMap::new();
-    let mut seen_usage = HashSet::new();
-    let mut turns = 0u64;
-    let mut preview = SessionPreviewBuilder::default();
-    for (line_idx, line_result) in reader.lines().enumerate() {
-        let Ok(line) = line_result else {
-            continue;
+impl ClaudeRowAccumulator {
+    fn fold_line(&mut self, line: &str) {
+        let line_idx = self.lines_consumed;
+        self.lines_consumed += 1;
+        let Ok(obj) = serde_json::from_str::<serde_json::Value>(line) else {
+            return;
         };
-        let Ok(obj) = serde_json::from_str::<serde_json::Value>(&line) else {
-            continue;
-        };
-        created_at = created_at.or_else(|| value_str(&obj, "timestamp"));
-        updated_at = value_str(&obj, "timestamp").or(updated_at);
+        self.created_at = self.created_at.take().or_else(|| value_str(&obj, "timestamp"));
+        self.updated_at = value_str(&obj, "timestamp").or(self.updated_at.take());
         if let Some(value) = value_str(&obj, "cwd") {
-            if session_cwd.is_none() {
-                session_cwd = Some(value.clone());
+            if self.session_cwd.is_none() {
+                self.session_cwd = Some(value.clone());
             }
-            cwd = Some(value);
+            self.cwd = Some(value);
         }
         let record_type = obj.get("type").and_then(|v| v.as_str());
         let record_is_meta = obj.get("isMeta").and_then(|v| v.as_bool()).unwrap_or(false);
         if record_type == Some("user") {
-            turns += 1;
-            if task.is_none() {
+            self.turns += 1;
+            if self.task.is_none() {
                 if let Some(msg) = obj.get("message") {
                     if let Some(content) = msg.get("content").and_then(message_content_text) {
                         // Supervised sessions carry the Intendant bootstrap
@@ -670,7 +678,7 @@ pub(crate) fn claude_session_list_row_from_file(path: &Path) -> Option<serde_jso
                             .next()
                             .unwrap_or(&content)
                             .trim_end();
-                        task = Some(compact_text(user_text, 180));
+                        self.task = Some(compact_text(user_text, 180));
                     }
                 }
             }
@@ -689,7 +697,7 @@ pub(crate) fn claude_session_list_row_from_file(path: &Path) -> Option<serde_jso
                         .next()
                         .unwrap_or(&content)
                         .trim_end();
-                    preview.push_user(user_text);
+                    self.preview.push_user(user_text);
                 }
             }
         }
@@ -699,12 +707,12 @@ pub(crate) fn claude_session_list_row_from_file(path: &Path) -> Option<serde_jso
                 .and_then(|m| m.get("content"))
                 .and_then(message_prose_text)
             {
-                preview.push_assistant(&content);
+                self.preview.push_assistant(&content);
             }
         }
         if let Some(msg) = obj.get("message") {
-            if model.is_none() {
-                model = msg
+            if self.model.is_none() {
+                self.model = msg
                     .get("model")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string());
@@ -713,46 +721,161 @@ pub(crate) fn claude_session_list_row_from_file(path: &Path) -> Option<serde_jso
                 let key = value_str(&obj, "requestId")
                     .or_else(|| value_str(msg, "id"))
                     .unwrap_or_else(|| format!("line-{line_idx}"));
-                if seen_usage.insert(key) {
-                    usage.add(parsed);
+                if self.seen_usage.insert(key) {
+                    self.usage.add(parsed);
                     if let Some(day) =
                         usage_day_from_timestamp(value_str(&obj, "timestamp").as_deref())
                     {
-                        daily_usage.entry(day).or_default().add(parsed);
+                        self.daily_usage.entry(day).or_default().add(parsed);
                     }
                 }
             }
         }
     }
-    let effective_cwd = cwd.or_else(|| session_cwd.clone());
-    let project_root =
-        derive_project_root_from_cwd(session_cwd.as_deref().or(effective_cwd.as_deref()));
-    let mut session = external_session_json(
-        "claude-code",
-        "Claude Code",
-        session_id.clone(),
-        session_id,
-        created_at
-            .or_else(|| updated_at.clone())
-            .or_else(|| file_mtime_string(path)),
-        file_mtime_string(path).or(updated_at),
-        None,
-        task,
-        "Claude Code",
-        model.clone(),
-        turns,
-        project_root,
-        effective_cwd,
-        Some(path.to_string_lossy().to_string()),
-        file_size(path),
-    );
-    apply_session_usage(&mut session, usage, model.as_deref());
-    apply_session_daily_usage(&mut session, &daily_usage, model.as_deref());
-    if let Some(preview) = preview.into_value() {
-        session["preview"] = preview;
+
+    /// Whether the checkpoint may resume against the file's current state:
+    /// same reliable identity, no truncation, unchanged consumed head.
+    fn resumable_for(&self, path: &Path, current_len: u64) -> bool {
+        if current_len < self.consumed_len {
+            return false;
+        }
+        let identity_ok = match (self.identity, crate::platform::FileIdentity::from_path(path).ok())
+        {
+            (Some(saved), Some(current)) => {
+                saved.is_reliable() && current.is_reliable() && saved == current
+            }
+            _ => false,
+        };
+        if !identity_ok {
+            return false;
+        }
+        crate::message_search::cursor::prefix_hash16_bytes(path, self.prefix_hash_bytes)
+            .as_deref()
+            == Some(self.prefix_hash16.as_str())
+    }
+
+    fn render(self, path: &Path, session_id: String) -> serde_json::Value {
+        let effective_cwd = self.cwd.or_else(|| self.session_cwd.clone());
+        let project_root = derive_project_root_from_cwd(
+            self.session_cwd.as_deref().or(effective_cwd.as_deref()),
+        );
+        let mut session = external_session_json(
+            "claude-code",
+            "Claude Code",
+            session_id.clone(),
+            session_id,
+            self.created_at
+                .or_else(|| self.updated_at.clone())
+                .or_else(|| file_mtime_string(path)),
+            file_mtime_string(path).or(self.updated_at),
+            None,
+            self.task,
+            "Claude Code",
+            self.model.clone(),
+            self.turns,
+            project_root,
+            effective_cwd,
+            Some(path.to_string_lossy().to_string()),
+            file_size(path),
+        );
+        apply_session_usage(&mut session, self.usage, self.model.as_deref());
+        apply_session_daily_usage(&mut session, &self.daily_usage, self.model.as_deref());
+        if let Some(preview) = self.preview.into_value() {
+            session["preview"] = preview;
+        }
+        session
+    }
+}
+
+/// Retained checkpoints for the incremental claude row fold, keyed by
+/// transcript path. Bounded like the sibling row caches.
+fn claude_row_accumulators() -> &'static Mutex<HashMap<PathBuf, ClaudeRowAccumulator>> {
+    static CACHE: OnceLock<Mutex<HashMap<PathBuf, ClaudeRowAccumulator>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+const CLAUDE_ROW_ACCUMULATOR_CAP: usize = 256;
+
+pub(crate) fn claude_session_list_row_from_file(path: &Path) -> Option<serde_json::Value> {
+    let key = session_list_cache_key("claude-code", path, SESSION_ROW_PREVIEW_FORMAT)?;
+    if let Some(row) = cached_session_list_row(&key) {
+        return Some(row);
+    }
+
+    let session_id = path
+        .file_stem()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default()
+        .to_string();
+    if session_id.is_empty() {
+        return None;
+    }
+    let current_len = std::fs::metadata(path).ok()?.len();
+    let checkpoint = claude_row_accumulators()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(path);
+    let mut acc = match checkpoint {
+        Some(saved) if saved.resumable_for(path, current_len) => saved,
+        _ => ClaudeRowAccumulator::default(),
+    };
+    let consumed = crate::message_search::cursor::for_each_complete_line_from(
+        path,
+        acc.consumed_len,
+        |line| acc.fold_line(line),
+    )
+    .ok()?;
+    acc.consumed_len = consumed;
+    acc.identity = crate::platform::FileIdentity::from_path(path).ok();
+    acc.prefix_hash_bytes =
+        consumed.min(crate::message_search::cursor::PREFIX_HASH_BYTES as u64) as usize;
+    acc.prefix_hash16 =
+        crate::message_search::cursor::prefix_hash16_bytes(path, acc.prefix_hash_bytes)?;
+
+    // Parity with the historical whole-file `.lines()` read: an
+    // unterminated trailing line still renders into THIS row, but never
+    // into the retained checkpoint (its bytes re-read once complete).
+    let mut render = acc.clone();
+    if let Some(tail) = read_unterminated_tail(path, consumed) {
+        for piece in tail.split('\n') {
+            let piece = piece.trim_end_matches('\r');
+            if !piece.is_empty() {
+                render.fold_line(piece);
+            }
+        }
+    }
+    let session = render.render(path, session_id);
+
+    {
+        let mut cache = claude_row_accumulators()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if cache.len() >= CLAUDE_ROW_ACCUMULATOR_CAP && !cache.contains_key(path) {
+            cache.clear();
+        }
+        cache.insert(path.to_path_buf(), acc);
     }
     store_session_list_row(key, &session);
     Some(session)
+}
+
+/// Bytes past the last complete line (a live writer mid-append). Bounded:
+/// a torn tail larger than the cap renders on a later rebuild instead.
+fn read_unterminated_tail(path: &Path, from: u64) -> Option<String> {
+    const TAIL_CAP_BYTES: u64 = 4 * 1024 * 1024;
+    use std::io::{Read as _, Seek as _, SeekFrom};
+    let mut file = std::fs::File::open(path).ok()?;
+    let len = file.metadata().ok()?.len();
+    if len <= from || len - from > TAIL_CAP_BYTES {
+        return None;
+    }
+    file.seek(SeekFrom::Start(from)).ok()?;
+    let mut buf = Vec::with_capacity((len - from) as usize);
+    file.take(TAIL_CAP_BYTES).read_to_end(&mut buf).ok()?;
+    if buf.is_empty() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&buf).into_owned())
 }
 
 #[allow(dead_code)]
@@ -2468,6 +2591,151 @@ mod tests {
         assert_eq!(session["total_tokens"].as_u64(), Some(10000));
         let cost = session["estimated_cost"].as_f64().unwrap();
         assert!((cost - 0.0714).abs() < 1e-12, "unexpected cost {cost}");
+    }
+
+    #[test]
+    fn claude_row_fold_resumes_on_append_instead_of_reparsing() {
+        let home = tempfile::tempdir().unwrap();
+        let project_dir = home.path().join(".claude").join("projects").join("-tmp-inc");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let path = project_dir.join("fold-resume-abc.jsonl");
+
+        let first = serde_json::json!({
+            "timestamp": "2026-07-14T10:00:00Z",
+            "type": "user",
+            "cwd": "/tmp/inc",
+            "message": {"content": "first prompt"}
+        });
+        std::fs::write(&path, format!("{first}\n")).unwrap();
+        let row = claude_session_list_row_from_file(&path).unwrap();
+        assert_eq!(row["turns"].as_u64(), Some(1));
+
+        // Poison the retained checkpoint's fold state: if the append path
+        // resumes from the checkpoint (as it must), the poison shows in
+        // the next row; a silent full re-parse would erase it.
+        {
+            let mut cache = claude_row_accumulators()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let acc = cache.get_mut(&path).expect("checkpoint retained");
+            acc.turns += 100;
+        }
+        let second = serde_json::json!({
+            "timestamp": "2026-07-14T10:01:00Z",
+            "type": "user",
+            "message": {"content": "second prompt"}
+        });
+        {
+            use std::io::Write as _;
+            let mut file = std::fs::OpenOptions::new().append(true).open(&path).unwrap();
+            writeln!(file, "{second}").unwrap();
+        }
+        let row = claude_session_list_row_from_file(&path).unwrap();
+        assert_eq!(
+            row["turns"].as_u64(),
+            Some(102),
+            "append must fold into the retained checkpoint (1 + poison 100 + 1)"
+        );
+    }
+
+    #[test]
+    fn claude_row_fold_matches_a_full_parse_and_detects_rewrites() {
+        let home = tempfile::tempdir().unwrap();
+        let project_dir = home.path().join(".claude").join("projects").join("-tmp-par");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let incremental = project_dir.join("fold-parity-abc.jsonl");
+        let fresh = project_dir.join("fold-parity-fresh.jsonl");
+
+        let user = serde_json::json!({
+            "timestamp": "2026-07-14T11:00:00Z",
+            "type": "user",
+            "cwd": "/tmp/par",
+            "message": {"content": "count my usage"}
+        });
+        let assistant = serde_json::json!({
+            "timestamp": "2026-07-14T11:00:02Z",
+            "type": "assistant",
+            "requestId": "req-1",
+            "message": {
+                "id": "msg-1",
+                "model": "claude-sonnet-4-6",
+                "usage": {"input_tokens": 100, "output_tokens": 200}
+            }
+        });
+        let follow_up = serde_json::json!({
+            "timestamp": "2026-07-14T11:01:00Z",
+            "type": "user",
+            "message": {"content": "and again"}
+        });
+        let assistant_two = serde_json::json!({
+            "timestamp": "2026-07-14T11:01:02Z",
+            "type": "assistant",
+            "requestId": "req-2",
+            "message": {
+                "id": "msg-2",
+                "model": "claude-sonnet-4-6",
+                "usage": {"input_tokens": 10, "output_tokens": 20},
+                "content": [{"type": "text", "text": "done again"}]
+            }
+        });
+
+        // Incremental: parse the prefix, then fold the appended suffix.
+        std::fs::write(&incremental, format!("{user}\n{assistant}\n")).unwrap();
+        claude_session_list_row_from_file(&incremental).unwrap();
+        {
+            use std::io::Write as _;
+            let mut file = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&incremental)
+                .unwrap();
+            writeln!(file, "{follow_up}").unwrap();
+            writeln!(file, "{assistant_two}").unwrap();
+        }
+        let folded = claude_session_list_row_from_file(&incremental).unwrap();
+
+        // Fresh: the same final bytes parsed from scratch.
+        std::fs::write(
+            &fresh,
+            format!("{user}\n{assistant}\n{follow_up}\n{assistant_two}\n"),
+        )
+        .unwrap();
+        let full = claude_session_list_row_from_file(&fresh).unwrap();
+
+        for field in [
+            "turns",
+            "task",
+            "model",
+            "prompt_tokens",
+            "completion_tokens",
+            "total_tokens",
+            "preview",
+            "cwd",
+            "project_root",
+            "daily_usage",
+        ] {
+            assert_eq!(
+                folded.get(field),
+                full.get(field),
+                "fold/full divergence on {field}"
+            );
+        }
+
+        // A rewrite (changed head) must fall back to the full re-parse:
+        // nothing folded from the old content may survive.
+        let rewritten_user = serde_json::json!({
+            "timestamp": "2026-07-14T12:00:00Z",
+            "type": "user",
+            "cwd": "/tmp/par",
+            "message": {"content": "brand new history"}
+        });
+        std::fs::write(&incremental, format!("{rewritten_user}\n")).unwrap();
+        let rewritten = claude_session_list_row_from_file(&incremental).unwrap();
+        assert_eq!(rewritten["turns"].as_u64(), Some(1));
+        assert_eq!(
+            rewritten["task"].as_str(),
+            Some("brand new history"),
+            "stale folded state must not survive a rewrite"
+        );
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/session_catalog/backend_lists.rs
+++ b/src/bin/caller/web_gateway/session_catalog/backend_lists.rs
@@ -840,12 +840,42 @@ pub(crate) fn claude_session_list_row_from_file(path: &Path) -> Option<serde_jso
         Some(saved) if saved.resumable_for(path, current_len) => saved,
         _ => ClaudeRowAccumulator::default(),
     };
-    let consumed = crate::message_search::cursor::for_each_complete_line_from(
+    // TOCTOU guard facts: what `resumable_for` just validated. Re-checked
+    // AFTER the fold below — a rewrite landing between the validation and
+    // the suffix read would merge new bytes onto stale fold state, and
+    // re-hashing the rewritten file afterwards would legitimize the
+    // corrupt checkpoint permanently.
+    let resume_guard = (acc.consumed_len > 0).then(|| {
+        (
+            acc.prefix_hash_bytes,
+            acc.prefix_hash16.clone(),
+            acc.consumed_tail_hash16.clone(),
+            acc.consumed_len,
+        )
+    });
+    let mut consumed = crate::message_search::cursor::for_each_complete_line_from(
         path,
         acc.consumed_len,
         |line| acc.fold_line(line),
     )
     .ok()?;
+    if let Some((saved_prefix_bytes, saved_prefix, saved_tail, saved_consumed)) = resume_guard {
+        let still_plain_append =
+            crate::message_search::cursor::prefix_hash16_bytes(path, saved_prefix_bytes).as_deref()
+                == Some(saved_prefix.as_str())
+                && crate::message_search::cursor::tail_hash16_ending_at(path, saved_consumed)
+                    .as_deref()
+                    == Some(saved_tail.as_str());
+        if !still_plain_append {
+            // Discard the merged fold; parse the whole file fresh.
+            acc = ClaudeRowAccumulator::default();
+            consumed =
+                crate::message_search::cursor::for_each_complete_line_from(path, 0, |line| {
+                    acc.fold_line(line)
+                })
+                .ok()?;
+        }
+    }
     acc.consumed_len = consumed;
     acc.identity = crate::platform::FileIdentity::from_path(path).ok();
     acc.prefix_hash_bytes =
@@ -935,17 +965,79 @@ fn read_unterminated_tail(path: &Path, from: u64) -> UnterminatedTail {
     UnterminatedTail::Tail(String::from_utf8_lossy(&buf).into_owned())
 }
 
-/// Full streaming render including a final unterminated line of any size
-/// (the historical `.lines()` semantics) — the oversized-tail fallback.
+/// Largest single record the full-render fallback will buffer. Records
+/// beyond it are SKIPPED with a warning instead of being materialized —
+/// the fallback exists to bound memory, so it must not itself allocate an
+/// arbitrarily large line the way `.lines()` would. Tradeoff, documented:
+/// a >32 MiB record does not contribute to that row's turns/usage/preview
+/// (row-level metadata; message search and transcript serving still see
+/// the file through their own lanes).
+const CLAUDE_ROW_MAX_RECORD_BYTES: usize = 32 * 1024 * 1024;
+
+/// Full streaming render including a final unterminated line (the
+/// historical `.lines()` semantics) — the oversized-tail fallback —
+/// with per-record memory bounded at `max_record_bytes`.
 fn claude_row_full_render(path: &Path, session_id: String) -> Option<serde_json::Value> {
+    claude_row_full_render_with_record_cap(path, session_id, CLAUDE_ROW_MAX_RECORD_BYTES)
+}
+
+fn claude_row_full_render_with_record_cap(
+    path: &Path,
+    session_id: String,
+    max_record_bytes: usize,
+) -> Option<serde_json::Value> {
     use std::io::BufRead as _;
     let file = std::fs::File::open(path).ok()?;
+    let mut reader = std::io::BufReader::new(file);
     let mut acc = ClaudeRowAccumulator::default();
-    for line in std::io::BufReader::new(file).lines() {
-        let Ok(line) = line else {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut skipped_oversized = 0u64;
+    loop {
+        buf.clear();
+        // Capped read: at most max_record_bytes + 1, so an over-cap line
+        // is detected without ever buffering it whole.
+        let bytes = std::io::Read::take(&mut reader, max_record_bytes as u64 + 1)
+            .read_until(b'\n', &mut buf)
+            .ok()?;
+        if bytes == 0 {
+            break;
+        }
+        if buf.len() > max_record_bytes {
+            skipped_oversized += 1;
+            if buf.last() != Some(&b'\n') {
+                // Discard the rest of the over-cap line without buffering.
+                loop {
+                    let available = reader.fill_buf().ok()?;
+                    if available.is_empty() {
+                        break;
+                    }
+                    match available.iter().position(|&byte| byte == b'\n') {
+                        Some(position) => {
+                            reader.consume(position + 1);
+                            break;
+                        }
+                        None => {
+                            let discard = available.len();
+                            reader.consume(discard);
+                        }
+                    }
+                }
+            }
+            buf.clear();
+            // fold_line numbering: the skipped record still occupies a
+            // line slot so `line-{idx}` usage-dedup keys stay aligned
+            // with a hypothetical uncapped parse.
+            acc.lines_consumed += 1;
             continue;
-        };
-        acc.fold_line(&line);
+        }
+        let line = String::from_utf8_lossy(&buf);
+        acc.fold_line(line.trim_end_matches(['\n', '\r']));
+    }
+    if skipped_oversized > 0 {
+        eprintln!(
+            "[session-catalog] {}: skipped {skipped_oversized} record(s) over {max_record_bytes} bytes in the full-render fallback (row metadata omits them)",
+            path.display()
+        );
     }
     Some(acc.render(path, session_id))
 }
@@ -2869,6 +2961,53 @@ mod tests {
         let preview = row["preview"].to_string();
         assert!(preview.contains("new second"), "{preview}");
         assert!(!preview.contains("old second"), "{preview}");
+    }
+
+    /// The full-render fallback is memory-bounded: records over the cap
+    /// are skipped (with a warning), never buffered whole — terminated or
+    /// not — and the surrounding records still fold.
+    #[test]
+    fn full_render_fallback_skips_records_over_the_record_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("capped-abc.jsonl");
+        let small = |uuid: &str, text: &str| {
+            serde_json::json!({
+                "timestamp": "2026-07-15T11:00:00Z",
+                "type": "user",
+                "message": {"content": text},
+                "uuid": uuid,
+            })
+        };
+        let giant_terminated = serde_json::json!({
+            "timestamp": "2026-07-15T11:01:00Z",
+            "type": "user",
+            "message": {"content": "g".repeat(2048)}
+        });
+        let giant_unterminated = serde_json::json!({
+            "timestamp": "2026-07-15T11:03:00Z",
+            "type": "user",
+            "message": {"content": "u".repeat(2048)}
+        });
+        std::fs::write(
+            &path,
+            format!(
+                "{}\n{giant_terminated}\n{}\n{giant_unterminated}",
+                small("u-1", "first"),
+                small("u-2", "second"),
+            ),
+        )
+        .unwrap();
+
+        let row =
+            claude_row_full_render_with_record_cap(&path, "capped-abc".to_string(), 512).unwrap();
+        assert_eq!(
+            row["turns"].as_u64(),
+            Some(2),
+            "both small records fold; both over-cap records are skipped"
+        );
+        let preview = row["preview"].to_string();
+        assert!(!preview.contains("ggg"), "{preview}");
+        assert!(!preview.contains("uuu"), "{preview}");
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/session_catalog/backend_lists.rs
+++ b/src/bin/caller/web_gateway/session_catalog/backend_lists.rs
@@ -628,6 +628,13 @@ struct ClaudeRowAccumulator {
     /// same window).
     prefix_hash16: String,
     prefix_hash_bytes: usize,
+    /// Second rewrite-detection window: hash of the last
+    /// `min(4096, consumed_len)` bytes ENDING at the consumed offset.
+    /// The head window alone cannot exclude a rewrite past the first
+    /// 4 KiB that also grows the file; requiring both narrows the
+    /// undetected residual to a head-and-tail-preserving growth rewrite
+    /// (documented, same contract as the message-search cursor).
+    consumed_tail_hash16: String,
     /// Offset just past the last COMPLETE line folded.
     consumed_len: u64,
     /// Complete lines folded so far — continues the historical 0-based
@@ -737,7 +744,11 @@ impl ClaudeRowAccumulator {
     }
 
     /// Whether the checkpoint may resume against the file's current state:
-    /// same reliable identity, no truncation, unchanged consumed head.
+    /// same reliable identity, no truncation, unchanged consumed head AND
+    /// unchanged consumed tail. Requiring both hash windows narrows the
+    /// undetected rewrite to one that preserves the first 4 KiB, the last
+    /// 4 KiB before the consumed offset, and grows the file — the same
+    /// documented residual as the message-search cursor.
     fn resumable_for(&self, path: &Path, current_len: u64) -> bool {
         if current_len < self.consumed_len {
             return false;
@@ -752,6 +763,13 @@ impl ClaudeRowAccumulator {
             _ => false,
         };
         if !identity_ok {
+            return false;
+        }
+        if self.consumed_tail_hash16.is_empty()
+            || crate::message_search::cursor::tail_hash16_ending_at(path, self.consumed_len)
+                .as_deref()
+                != Some(self.consumed_tail_hash16.as_str())
+        {
             return false;
         }
         crate::message_search::cursor::prefix_hash16_bytes(path, self.prefix_hash_bytes).as_deref()
@@ -834,20 +852,31 @@ pub(crate) fn claude_session_list_row_from_file(path: &Path) -> Option<serde_jso
         consumed.min(crate::message_search::cursor::PREFIX_HASH_BYTES as u64) as usize;
     acc.prefix_hash16 =
         crate::message_search::cursor::prefix_hash16_bytes(path, acc.prefix_hash_bytes)?;
+    acc.consumed_tail_hash16 =
+        crate::message_search::cursor::tail_hash16_ending_at(path, consumed)?;
 
     // Parity with the historical whole-file `.lines()` read: an
     // unterminated trailing line still renders into THIS row, but never
     // into the retained checkpoint (its bytes re-read once complete).
-    let mut render = acc.clone();
-    if let Some(tail) = read_unterminated_tail(path, consumed) {
-        for piece in tail.split('\n') {
-            let piece = piece.trim_end_matches('\r');
-            if !piece.is_empty() {
-                render.fold_line(piece);
+    let session = match read_unterminated_tail(path, consumed) {
+        UnterminatedTail::None => acc.clone().render(path, session_id),
+        UnterminatedTail::Tail(tail) => {
+            let mut render = acc.clone();
+            for piece in tail.split('\n') {
+                let piece = piece.trim_end_matches('\r');
+                if !piece.is_empty() {
+                    render.fold_line(piece);
+                }
             }
+            render.render(path, session_id)
         }
-    }
-    let session = render.render(path, session_id);
+        // A valid final record can legitimately exceed the tail cap (one
+        // huge unterminated paste): silently omitting it would leave the
+        // row permanently short on a stable file. Render such rows from
+        // a full streaming `.lines()` pass instead — the checkpoint
+        // (complete lines only) stays valid either way.
+        UnterminatedTail::Oversized => claude_row_full_render(path, session_id)?,
+    };
 
     {
         let mut cache = claude_row_accumulators()
@@ -862,23 +891,63 @@ pub(crate) fn claude_session_list_row_from_file(path: &Path) -> Option<serde_jso
     Some(session)
 }
 
-/// Bytes past the last complete line (a live writer mid-append). Bounded:
-/// a torn tail larger than the cap renders on a later rebuild instead.
-fn read_unterminated_tail(path: &Path, from: u64) -> Option<String> {
-    const TAIL_CAP_BYTES: u64 = 4 * 1024 * 1024;
+/// In-memory bound on the unterminated-tail fast path; larger tails take
+/// the full streaming render instead of being buffered here.
+const CLAUDE_ROW_TAIL_CAP_BYTES: u64 = 4 * 1024 * 1024;
+
+enum UnterminatedTail {
+    /// The file ends exactly at the consumed offset.
+    None,
+    /// Bytes past the last complete line (a live writer mid-append).
+    Tail(String),
+    /// More tail bytes than the in-memory cap: the caller must render
+    /// via the full streaming pass, never omit the record.
+    Oversized,
+}
+
+fn read_unterminated_tail(path: &Path, from: u64) -> UnterminatedTail {
     use std::io::{Read as _, Seek as _, SeekFrom};
-    let mut file = std::fs::File::open(path).ok()?;
-    let len = file.metadata().ok()?.len();
-    if len <= from || len - from > TAIL_CAP_BYTES {
-        return None;
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return UnterminatedTail::None;
+    };
+    let Ok(metadata) = file.metadata() else {
+        return UnterminatedTail::None;
+    };
+    let len = metadata.len();
+    if len <= from {
+        return UnterminatedTail::None;
     }
-    file.seek(SeekFrom::Start(from)).ok()?;
+    if len - from > CLAUDE_ROW_TAIL_CAP_BYTES {
+        return UnterminatedTail::Oversized;
+    }
+    if file.seek(SeekFrom::Start(from)).is_err() {
+        return UnterminatedTail::None;
+    }
     let mut buf = Vec::with_capacity((len - from) as usize);
-    file.take(TAIL_CAP_BYTES).read_to_end(&mut buf).ok()?;
-    if buf.is_empty() {
-        return None;
+    if file
+        .take(CLAUDE_ROW_TAIL_CAP_BYTES)
+        .read_to_end(&mut buf)
+        .is_err()
+        || buf.is_empty()
+    {
+        return UnterminatedTail::None;
     }
-    Some(String::from_utf8_lossy(&buf).into_owned())
+    UnterminatedTail::Tail(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Full streaming render including a final unterminated line of any size
+/// (the historical `.lines()` semantics) — the oversized-tail fallback.
+fn claude_row_full_render(path: &Path, session_id: String) -> Option<serde_json::Value> {
+    use std::io::BufRead as _;
+    let file = std::fs::File::open(path).ok()?;
+    let mut acc = ClaudeRowAccumulator::default();
+    for line in std::io::BufReader::new(file).lines() {
+        let Ok(line) = line else {
+            continue;
+        };
+        acc.fold_line(&line);
+    }
+    Some(acc.render(path, session_id))
 }
 
 #[allow(dead_code)]
@@ -2749,6 +2818,87 @@ mod tests {
             rewritten["task"].as_str(),
             Some("brand new history"),
             "stale folded state must not survive a rewrite"
+        );
+    }
+
+    #[test]
+    fn claude_row_post_prefix_rewrite_that_grows_falls_back_to_full_parse() {
+        let home = tempfile::tempdir().unwrap();
+        let project_dir = home.path().join(".claude").join("projects").join("-tmp-rw");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let path = project_dir.join("fold-rewrite-abc.jsonl");
+
+        // First record alone fills the 4 KiB head window, so a rewrite
+        // past it leaves the prefix hash intact.
+        let padded = serde_json::json!({
+            "timestamp": "2026-07-15T09:00:00Z",
+            "type": "user",
+            "cwd": "/tmp/rw",
+            "message": {"content": "p".repeat(5000)}
+        });
+        let old_second = serde_json::json!({
+            "timestamp": "2026-07-15T09:01:00Z",
+            "type": "user",
+            "message": {"content": "old second"}
+        });
+        std::fs::write(&path, format!("{padded}\n{old_second}\n")).unwrap();
+        let row = claude_session_list_row_from_file(&path).unwrap();
+        assert_eq!(row["turns"].as_u64(), Some(2));
+
+        // Rewrite past the prefix window AND grow the file (same inode:
+        // fs::write truncates in place). A checkpoint resume here would
+        // fold suffix bytes onto stale totals; the consumed-tail window
+        // must force the full re-parse.
+        let new_second = serde_json::json!({
+            "timestamp": "2026-07-15T09:02:00Z",
+            "type": "user",
+            "message": {"content": "new second"}
+        });
+        let third = serde_json::json!({
+            "timestamp": "2026-07-15T09:03:00Z",
+            "type": "user",
+            "message": {"content": "third prompt"}
+        });
+        std::fs::write(&path, format!("{padded}\n{new_second}\n{third}\n")).unwrap();
+        let row = claude_session_list_row_from_file(&path).unwrap();
+        assert_eq!(
+            row["turns"].as_u64(),
+            Some(3),
+            "stale checkpoint state must not survive a post-prefix rewrite"
+        );
+        let preview = row["preview"].to_string();
+        assert!(preview.contains("new second"), "{preview}");
+        assert!(!preview.contains("old second"), "{preview}");
+    }
+
+    #[test]
+    fn claude_row_renders_an_oversized_unterminated_final_record() {
+        let home = tempfile::tempdir().unwrap();
+        let project_dir = home.path().join(".claude").join("projects").join("-tmp-ov");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let path = project_dir.join("oversized-tail-abc.jsonl");
+
+        let first = serde_json::json!({
+            "timestamp": "2026-07-15T10:00:00Z",
+            "type": "user",
+            "cwd": "/tmp/ov",
+            "message": {"content": "small first"}
+        });
+        // A VALID final record larger than the tail fast-path cap,
+        // WITHOUT a trailing newline: it must still count (the old cap
+        // silently dropped it from the row forever on a stable file).
+        let huge = serde_json::json!({
+            "timestamp": "2026-07-15T10:01:00Z",
+            "type": "user",
+            "message": {"content": "h".repeat(CLAUDE_ROW_TAIL_CAP_BYTES as usize + 4096)}
+        });
+        std::fs::write(&path, format!("{first}\n{huge}")).unwrap();
+
+        let row = claude_session_list_row_from_file(&path).unwrap();
+        assert_eq!(
+            row["turns"].as_u64(),
+            Some(2),
+            "an oversized unterminated final record must render via the full parse"
         );
     }
 

--- a/src/bin/caller/web_gateway/session_catalog/backend_lists.rs
+++ b/src/bin/caller/web_gateway/session_catalog/backend_lists.rs
@@ -653,7 +653,10 @@ impl ClaudeRowAccumulator {
         let Ok(obj) = serde_json::from_str::<serde_json::Value>(line) else {
             return;
         };
-        self.created_at = self.created_at.take().or_else(|| value_str(&obj, "timestamp"));
+        self.created_at = self
+            .created_at
+            .take()
+            .or_else(|| value_str(&obj, "timestamp"));
         self.updated_at = value_str(&obj, "timestamp").or(self.updated_at.take());
         if let Some(value) = value_str(&obj, "cwd") {
             if self.session_cwd.is_none() {
@@ -739,8 +742,10 @@ impl ClaudeRowAccumulator {
         if current_len < self.consumed_len {
             return false;
         }
-        let identity_ok = match (self.identity, crate::platform::FileIdentity::from_path(path).ok())
-        {
+        let identity_ok = match (
+            self.identity,
+            crate::platform::FileIdentity::from_path(path).ok(),
+        ) {
             (Some(saved), Some(current)) => {
                 saved.is_reliable() && current.is_reliable() && saved == current
             }
@@ -749,16 +754,14 @@ impl ClaudeRowAccumulator {
         if !identity_ok {
             return false;
         }
-        crate::message_search::cursor::prefix_hash16_bytes(path, self.prefix_hash_bytes)
-            .as_deref()
+        crate::message_search::cursor::prefix_hash16_bytes(path, self.prefix_hash_bytes).as_deref()
             == Some(self.prefix_hash16.as_str())
     }
 
     fn render(self, path: &Path, session_id: String) -> serde_json::Value {
         let effective_cwd = self.cwd.or_else(|| self.session_cwd.clone());
-        let project_root = derive_project_root_from_cwd(
-            self.session_cwd.as_deref().or(effective_cwd.as_deref()),
-        );
+        let project_root =
+            derive_project_root_from_cwd(self.session_cwd.as_deref().or(effective_cwd.as_deref()));
         let mut session = external_session_json(
             "claude-code",
             "Claude Code",
@@ -2596,7 +2599,11 @@ mod tests {
     #[test]
     fn claude_row_fold_resumes_on_append_instead_of_reparsing() {
         let home = tempfile::tempdir().unwrap();
-        let project_dir = home.path().join(".claude").join("projects").join("-tmp-inc");
+        let project_dir = home
+            .path()
+            .join(".claude")
+            .join("projects")
+            .join("-tmp-inc");
         std::fs::create_dir_all(&project_dir).unwrap();
         let path = project_dir.join("fold-resume-abc.jsonl");
 
@@ -2627,7 +2634,10 @@ mod tests {
         });
         {
             use std::io::Write as _;
-            let mut file = std::fs::OpenOptions::new().append(true).open(&path).unwrap();
+            let mut file = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .unwrap();
             writeln!(file, "{second}").unwrap();
         }
         let row = claude_session_list_row_from_file(&path).unwrap();
@@ -2641,7 +2651,11 @@ mod tests {
     #[test]
     fn claude_row_fold_matches_a_full_parse_and_detects_rewrites() {
         let home = tempfile::tempdir().unwrap();
-        let project_dir = home.path().join(".claude").join("projects").join("-tmp-par");
+        let project_dir = home
+            .path()
+            .join(".claude")
+            .join("projects")
+            .join("-tmp-par");
         std::fs::create_dir_all(&project_dir).unwrap();
         let incremental = project_dir.join("fold-parity-abc.jsonl");
         let fresh = project_dir.join("fold-parity-fresh.jsonl");

--- a/src/bin/caller/web_gateway/session_catalog/caches.rs
+++ b/src/bin/caller/web_gateway/session_catalog/caches.rs
@@ -9,7 +9,16 @@ pub(crate) fn collect_files(root: &Path, suffix: &str, out: &mut Vec<PathBuf>) {
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.is_dir() {
+        // `DirEntry::file_type` rides the readdir data on the major
+        // platforms — the old `path.is_dir()` re-stat'd every entry of
+        // every scan. Symlinks keep the historical follow semantics
+        // through the (rare) explicit stat.
+        let is_dir = match entry.file_type() {
+            Ok(file_type) if file_type.is_symlink() => path.is_dir(),
+            Ok(file_type) => file_type.is_dir(),
+            Err(_) => continue,
+        };
+        if is_dir {
             collect_files(&path, suffix, out);
         } else if path
             .file_name()
@@ -18,6 +27,50 @@ pub(crate) fn collect_files(root: &Path, suffix: &str, out: &mut Vec<PathBuf>) {
             .unwrap_or(false)
         {
             out.push(path);
+        }
+    }
+}
+
+/// [`collect_files`] carrying each match's metadata out of the walk, so
+/// recency sorts and identity dedups don't re-stat (or canonicalize)
+/// every file per rebuild.
+fn collect_files_with_metadata(
+    root: &Path,
+    suffix: &str,
+    out: &mut Vec<(PathBuf, std::fs::Metadata)>,
+) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(_) => continue,
+        };
+        let is_dir = if file_type.is_symlink() {
+            path.is_dir()
+        } else {
+            file_type.is_dir()
+        };
+        if is_dir {
+            collect_files_with_metadata(&path, suffix, out);
+        } else if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.ends_with(suffix))
+            .unwrap_or(false)
+        {
+            // Follow symlinked files (the historical `fs::metadata`
+            // semantics); direct entries reuse the readdir-adjacent stat.
+            let metadata = if file_type.is_symlink() {
+                std::fs::metadata(&path).ok()
+            } else {
+                entry.metadata().ok()
+            };
+            if let Some(metadata) = metadata {
+                out.push((path, metadata));
+            }
         }
     }
 }
@@ -756,15 +809,45 @@ pub(crate) fn store_intendant_session_list_row(
 }
 
 pub(crate) fn collect_recent_files(root: &Path, suffix: &str, limit: usize) -> Vec<PathBuf> {
-    let mut files = Vec::new();
-    collect_files(root, suffix, &mut files);
-    let mut seen = HashSet::new();
-    files.retain(|path| {
-        std::fs::canonicalize(path)
-            .map(|canonical| seen.insert(canonical))
-            .unwrap_or(true)
+    collect_recent_files_keyed(root, suffix, limit)
+        .into_iter()
+        .map(|(_, path)| path)
+        .collect()
+}
+
+/// [`collect_recent_files`] keeping each survivor's mtime key, so callers
+/// merging several roots can re-sort without re-stat'ing every path.
+pub(crate) fn collect_recent_files_keyed(
+    root: &Path,
+    suffix: &str,
+    limit: usize,
+) -> Vec<(u64, PathBuf)> {
+    let mut files: Vec<(PathBuf, std::fs::Metadata)> = Vec::new();
+    collect_files_with_metadata(root, suffix, &mut files);
+    // Dedup path aliases to one file. On Unix, `(dev, ino)` from the
+    // already-held metadata replaces the old canonicalize-per-file storm
+    // (and additionally collapses hardlinked twins, exactly like the
+    // message-search identity dedup); elsewhere `(dev, ino)` is a
+    // constant (0, 0), so the historical realpath dedup stays.
+    let mut seen_identities: HashSet<(u64, u64)> = HashSet::new();
+    let mut seen_canonical: HashSet<PathBuf> = HashSet::new();
+    files.retain(|(path, metadata)| {
+        let identity = crate::platform::metadata_dev_ino(metadata);
+        if identity == (0, 0) {
+            std::fs::canonicalize(path)
+                .map(|canonical| seen_canonical.insert(canonical))
+                .unwrap_or(true)
+        } else {
+            seen_identities.insert(identity)
+        }
     });
-    files.sort_by_key(|b| std::cmp::Reverse(file_mtime_secs(b)));
+    // Decorate-sort-strip: the old `sort_by_key(file_mtime_secs)`
+    // re-stat'd per comparison — O(n log n) metadata syscalls per rebuild.
+    let mut files: Vec<(u64, PathBuf)> = files
+        .into_iter()
+        .map(|(path, metadata)| (metadata_mtime_secs(&metadata), path))
+        .collect();
+    files.sort_by_key(|(mtime, _)| std::cmp::Reverse(*mtime));
     files.truncate(limit);
     files
 }

--- a/src/bin/caller/web_gateway/session_catalog/codex_values.rs
+++ b/src/bin/caller/web_gateway/session_catalog/codex_values.rs
@@ -56,7 +56,7 @@ pub(crate) const SESSION_PREVIEW_MAX_BYTES: usize = 500;
 /// (Intendant rows version through the fingerprint digest byte instead.)
 pub(crate) const SESSION_ROW_PREVIEW_FORMAT: &str = "p1";
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(crate) struct SessionPreviewBuilder {
     entries: Vec<(&'static str, String)>, // chronological (role, text)
     user: usize,

--- a/src/bin/caller/web_gateway/session_catalog/detail_search.rs
+++ b/src/bin/caller/web_gateway/session_catalog/detail_search.rs
@@ -685,38 +685,17 @@ pub(crate) fn session_log_search_file_path(
 }
 
 pub(crate) fn find_claude_session_file(home: &Path, session_id: &str) -> Option<PathBuf> {
-    collect_recent_files(
-        &home.join(".claude").join("projects"),
-        ".jsonl",
-        EXTERNAL_SESSION_SCAN_LIMIT,
-    )
-    .into_iter()
-    .find(|path| path.file_stem().and_then(|n| n.to_str()) == Some(session_id))
+    // Exact-name lookup: the direct per-project probe (and walk
+    // fallback) replaces a store-wide walk + mtime sort whose ordering
+    // never mattered for finding one stem.
+    find_claude_session_file_for_transcript(home, session_id)
 }
 
 pub(crate) fn find_gemini_session_file(home: &Path, session_id: &str) -> Option<PathBuf> {
-    collect_recent_files(
-        &home.join(".gemini").join("tmp"),
-        ".json",
-        EXTERNAL_SESSION_SCAN_LIMIT,
-    )
-    .into_iter()
-    .filter(|path| {
-        path.parent()
-            .and_then(|p| p.file_name())
-            .and_then(|n| n.to_str())
-            == Some("chats")
-    })
-    .find(|path| {
-        let Ok(contents) = std::fs::read_to_string(path) else {
-            return false;
-        };
-        serde_json::from_str::<serde_json::Value>(&contents)
-            .ok()
-            .and_then(|obj| value_str(&obj, "sessionId"))
-            .as_deref()
-            == Some(session_id)
-    })
+    // Exact-id lookup: the cached transcript resolver verifies one
+    // remembered file per repeat fetch instead of read+parsing every
+    // chat in the store under an mtime sort that never mattered here.
+    find_gemini_session_file_for_transcript(home, session_id)
 }
 
 pub(crate) fn search_session_log_file(

--- a/src/bin/caller/web_gateway/session_catalog/mod.rs
+++ b/src/bin/caller/web_gateway/session_catalog/mod.rs
@@ -1106,18 +1106,20 @@ pub(crate) fn extend_codex_observed_worktree_session_hints(
     );
     if files.is_empty() {
         let codex = codex_dir(home);
-        files = collect_recent_files(
+        let mut keyed = collect_recent_files_keyed(
             &codex.join("sessions"),
             ".jsonl",
             WORKTREE_OBSERVED_SESSION_FILE_LIMIT,
         );
-        files.extend(collect_recent_files(
+        keyed.extend(collect_recent_files_keyed(
             &codex.join("archived_sessions"),
             ".jsonl",
             WORKTREE_OBSERVED_SESSION_FILE_LIMIT,
         ));
-        files.sort_by_key(|b| std::cmp::Reverse(file_mtime_secs(b)));
-        files.truncate(WORKTREE_OBSERVED_SESSION_FILE_LIMIT);
+        // Keys carried out of the walks: no re-stat per comparison.
+        keyed.sort_by_key(|(mtime, _)| std::cmp::Reverse(*mtime));
+        keyed.truncate(WORKTREE_OBSERVED_SESSION_FILE_LIMIT);
+        files = keyed.into_iter().map(|(_, path)| path).collect();
     }
 
     for path in files {
@@ -1191,9 +1193,15 @@ pub(crate) fn agent_session_files_from_rows(
             files.push(path);
         }
     }
-    files.sort_by_key(|b| std::cmp::Reverse(file_mtime_secs(b)));
-    files.truncate(limit);
-    files
+    // Decorate once: `sort_by_key(file_mtime_secs)` re-stats per
+    // comparison.
+    let mut keyed: Vec<(u64, PathBuf)> = files
+        .into_iter()
+        .map(|path| (file_mtime_secs(&path), path))
+        .collect();
+    keyed.sort_by_key(|(mtime, _)| std::cmp::Reverse(*mtime));
+    keyed.truncate(limit);
+    keyed.into_iter().map(|(_, path)| path).collect()
 }
 
 pub(crate) fn extend_gemini_observed_worktree_session_hints(

--- a/src/bin/caller/web_gateway/session_catalog/mod.rs
+++ b/src/bin/caller/web_gateway/session_catalog/mod.rs
@@ -1544,7 +1544,7 @@ pub(crate) fn push_session_file_fingerprint_with_metadata(
         .unwrap_or(path)
         .to_string_lossy()
         .to_string();
-    let (dev, ino) = crate::platform::metadata_dev_ino(&metadata);
+    let (dev, ino) = crate::platform::metadata_dev_ino(metadata);
     entries.push(SessionFileFingerprint {
         rel,
         len: metadata.len(),

--- a/src/bin/caller/web_gateway/session_catalog/mod.rs
+++ b/src/bin/caller/web_gateway/session_catalog/mod.rs
@@ -109,7 +109,9 @@ pub(crate) struct ExternalTranscriptCacheKey {
 #[derive(Clone, Debug)]
 pub(crate) struct ExternalTranscriptCacheEntry {
     key: ExternalTranscriptCacheKey,
-    entries: Vec<serde_json::Value>,
+    /// Shared: a cache hit hands out the Arc instead of deep-cloning the
+    /// whole parsed transcript per bootstrap/detail request.
+    entries: std::sync::Arc<Vec<serde_json::Value>>,
 }
 
 #[derive(Clone, Debug)]
@@ -623,7 +625,7 @@ pub(crate) fn hydrate_codex_session_goal_for_row(
         return;
     }
     for id in row_ids {
-        let Some(entries) = external_session_entries_from_home(home, "codex", &id) else {
+        let Some(entries) = external_session_entries_from_home_arc(home, "codex", &id) else {
             continue;
         };
         let Some(goal) = latest_session_goal_from_entries(&entries, &id) else {
@@ -1520,6 +1522,20 @@ pub(crate) fn push_session_file_fingerprint(
     let Ok(metadata) = std::fs::metadata(path) else {
         return;
     };
+    push_session_file_fingerprint_with_metadata(entries, base, path, &metadata, is_dir);
+}
+
+/// [`push_session_file_fingerprint`] for callers already holding the
+/// metadata (dir-entry walks) — the fingerprint sweep covers every
+/// session dir per rebuild, and busy dirs hold thousands of turn/seg
+/// files, so the redundant second stat per file was most of its cost.
+pub(crate) fn push_session_file_fingerprint_with_metadata(
+    entries: &mut Vec<SessionFileFingerprint>,
+    base: &Path,
+    path: &Path,
+    metadata: &std::fs::Metadata,
+    is_dir: bool,
+) {
     if metadata.is_dir() != is_dir {
         return;
     }
@@ -1532,12 +1548,22 @@ pub(crate) fn push_session_file_fingerprint(
     entries.push(SessionFileFingerprint {
         rel,
         len: metadata.len(),
-        mtime_nanos: metadata_mtime_nanos(&metadata),
-        ctime_nanos: metadata_ctime_nanos(&metadata),
+        mtime_nanos: metadata_mtime_nanos(metadata),
+        ctime_nanos: metadata_ctime_nanos(metadata),
         dev,
         ino,
         is_dir,
     });
+}
+
+/// Dir-entry metadata with the platform-standard follow semantics:
+/// symlinks resolve through `fs::metadata`, everything else reuses the
+/// readdir-adjacent stat.
+fn dir_entry_metadata_following(entry: &std::fs::DirEntry) -> std::io::Result<std::fs::Metadata> {
+    match entry.file_type() {
+        Ok(file_type) if file_type.is_symlink() => std::fs::metadata(entry.path()),
+        _ => entry.metadata(),
+    }
 }
 
 pub(crate) fn intendant_session_dir_fingerprint(dir: &Path) -> Option<SessionDirFingerprint> {
@@ -1551,26 +1577,45 @@ pub(crate) fn intendant_session_dir_fingerprint(dir: &Path) -> Option<SessionDir
         "summary.json",
         "conversation.jsonl",
     ] {
-        let path = dir.join(name);
-        if path.is_file() {
-            push_session_file_fingerprint(&mut entries, dir, &path, false);
-        }
+        // No is_file() pre-check: the push validates kind from the one
+        // stat it takes anyway (missing or dir-shaped entries no-op).
+        push_session_file_fingerprint(&mut entries, dir, &dir.join(name), false);
     }
 
     let recordings_dir = dir.join("recordings");
     if let Ok(rd) = std::fs::read_dir(&recordings_dir) {
         for re in rd.flatten() {
             let recording_dir = re.path();
-            if !recording_dir.is_dir() {
+            let Ok(dir_meta) = dir_entry_metadata_following(&re) else {
+                continue;
+            };
+            if !dir_meta.is_dir() {
                 continue;
             }
-            push_session_file_fingerprint(&mut entries, dir, &recording_dir, true);
+            push_session_file_fingerprint_with_metadata(
+                &mut entries,
+                dir,
+                &recording_dir,
+                &dir_meta,
+                true,
+            );
             if let Ok(files) = std::fs::read_dir(&recording_dir) {
                 for file in files.flatten() {
-                    let path = file.path();
                     let name = file.file_name().to_string_lossy().to_string();
-                    if name.starts_with("seg_") && path.is_file() {
-                        push_session_file_fingerprint(&mut entries, dir, &path, false);
+                    if !name.starts_with("seg_") {
+                        continue;
+                    }
+                    let Ok(metadata) = dir_entry_metadata_following(&file) else {
+                        continue;
+                    };
+                    if metadata.is_file() {
+                        push_session_file_fingerprint_with_metadata(
+                            &mut entries,
+                            dir,
+                            &file.path(),
+                            &metadata,
+                            false,
+                        );
                     }
                 }
             }
@@ -1580,9 +1625,17 @@ pub(crate) fn intendant_session_dir_fingerprint(dir: &Path) -> Option<SessionDir
     let frames_dir = dir.join("frames");
     if let Ok(fd) = std::fs::read_dir(&frames_dir) {
         for fe in fd.flatten() {
-            let path = fe.path();
-            if path.is_file() {
-                push_session_file_fingerprint(&mut entries, dir, &path, false);
+            let Ok(metadata) = dir_entry_metadata_following(&fe) else {
+                continue;
+            };
+            if metadata.is_file() {
+                push_session_file_fingerprint_with_metadata(
+                    &mut entries,
+                    dir,
+                    &fe.path(),
+                    &metadata,
+                    false,
+                );
             }
         }
     }
@@ -1590,9 +1643,17 @@ pub(crate) fn intendant_session_dir_fingerprint(dir: &Path) -> Option<SessionDir
     let turns_dir = dir.join("turns");
     if let Ok(td) = std::fs::read_dir(&turns_dir) {
         for te in td.flatten() {
-            let path = te.path();
-            if path.is_file() {
-                push_session_file_fingerprint(&mut entries, dir, &path, false);
+            let Ok(metadata) = dir_entry_metadata_following(&te) else {
+                continue;
+            };
+            if metadata.is_file() {
+                push_session_file_fingerprint_with_metadata(
+                    &mut entries,
+                    dir,
+                    &te.path(),
+                    &metadata,
+                    false,
+                );
             }
         }
     }

--- a/src/bin/caller/web_gateway/session_catalog/replay.rs
+++ b/src/bin/caller/web_gateway/session_catalog/replay.rs
@@ -853,11 +853,11 @@ pub(crate) fn annotate_replay_user_turns_from_external_transcript(
     source: &str,
     session_id: &str,
 ) {
-    let Some(transcript) = external_session_entries_from_home(home, source, session_id) else {
+    let Some(transcript) = external_session_entries_from_home_arc(home, source, session_id) else {
         return;
     };
     let user_turns: Vec<serde_json::Value> = transcript
-        .into_iter()
+        .iter()
         .filter(|entry| entry.get("source").and_then(|v| v.as_str()) == Some("user"))
         .filter(|entry| {
             entry
@@ -869,6 +869,9 @@ pub(crate) fn annotate_replay_user_turns_from_external_transcript(
                     .and_then(|v| v.as_u64())
                     .is_some()
         })
+        // Clone only the matched user turns; the shared transcript
+        // snapshot itself is never deep-cloned on this path anymore.
+        .cloned()
         .collect();
     if user_turns.is_empty() {
         return;

--- a/src/bin/caller/web_gateway/session_catalog/transcripts.rs
+++ b/src/bin/caller/web_gateway/session_catalog/transcripts.rs
@@ -72,7 +72,10 @@ pub(crate) fn store_external_transcript_entries(
     // and a live writer can grow the file past the cap (or past the
     // keyed snapshot) while we parse — caching that parse would pin an
     // oversized vec under a key no future lookup matches. Only cache
-    // when the file still IS the keyed snapshot.
+    // when the file still IS the keyed snapshot. (A metadata-preserving
+    // replacement between parse and re-stat — same len AND mtime with
+    // different bytes — is outside this cache's benign-writer model,
+    // like every (len, mtime)-keyed cache in the catalog.)
     match std::fs::metadata(Path::new(&key.path)) {
         Ok(metadata)
             if metadata.len() == key.len && metadata_mtime_nanos(&metadata) == key.mtime_nanos => {}
@@ -1052,7 +1055,10 @@ pub(crate) fn find_gemini_session_file_for_transcript(
     home: &Path,
     session_id: &str,
 ) -> Option<PathBuf> {
-    let cache_key = (home.to_path_buf(), session_id.to_string());
+    // Normalized once so symlinked/relative spellings of the same home
+    // share one entry instead of duplicating the cache per alias.
+    let home_key = std::fs::canonicalize(home).unwrap_or_else(|_| home.to_path_buf());
+    let cache_key = (home_key, session_id.to_string());
     if let Some(cached) = gemini_transcript_path_cache()
         .lock()
         .unwrap_or_else(|e| e.into_inner())

--- a/src/bin/caller/web_gateway/session_catalog/transcripts.rs
+++ b/src/bin/caller/web_gateway/session_catalog/transcripts.rs
@@ -75,8 +75,7 @@ pub(crate) fn store_external_transcript_entries(
     // when the file still IS the keyed snapshot.
     match std::fs::metadata(Path::new(&key.path)) {
         Ok(metadata)
-            if metadata.len() == key.len
-                && metadata_mtime_nanos(&metadata) == key.mtime_nanos => {}
+            if metadata.len() == key.len && metadata_mtime_nanos(&metadata) == key.mtime_nanos => {}
         _ => return,
     }
     let slot = external_transcript_cache_slot(&key);
@@ -1657,8 +1656,8 @@ mod tests {
             "a parse of bytes that no longer match the keyed snapshot must not be cached"
         );
         // The steady case (file unchanged since the key) still caches.
-        let fresh_key = external_transcript_cache_key("codex", "post-parse-growth", &path)
-            .expect("fresh key");
+        let fresh_key =
+            external_transcript_cache_key("codex", "post-parse-growth", &path).expect("fresh key");
         store_external_transcript_entries(fresh_key.clone(), &entries);
         assert!(cached_external_transcript_entries(&fresh_key).is_some());
     }

--- a/src/bin/caller/web_gateway/session_catalog/transcripts.rs
+++ b/src/bin/caller/web_gateway/session_catalog/transcripts.rs
@@ -68,6 +68,17 @@ pub(crate) fn store_external_transcript_entries(
     if key.len > EXTERNAL_TRANSCRIPT_CACHE_MAX_SOURCE_BYTES {
         return;
     }
+    // Admission re-check AFTER the parse: the key was stat'd before it,
+    // and a live writer can grow the file past the cap (or past the
+    // keyed snapshot) while we parse — caching that parse would pin an
+    // oversized vec under a key no future lookup matches. Only cache
+    // when the file still IS the keyed snapshot.
+    match std::fs::metadata(Path::new(&key.path)) {
+        Ok(metadata)
+            if metadata.len() == key.len
+                && metadata_mtime_nanos(&metadata) == key.mtime_nanos => {}
+        _ => return,
+    }
     let slot = external_transcript_cache_slot(&key);
     let mut cache = external_transcript_cache()
         .lock()
@@ -1009,10 +1020,13 @@ pub(crate) fn find_claude_session_file_for_transcript(
         .find(|path| path.file_stem().and_then(|n| n.to_str()) == Some(session_id))
 }
 
-/// session_id → chat path for gemini lookups, so a repeat fetch verifies
-/// ONE file instead of read+parsing every chat in the store again.
-fn gemini_transcript_path_cache() -> &'static Mutex<HashMap<String, PathBuf>> {
-    static CACHE: OnceLock<Mutex<HashMap<String, PathBuf>>> = OnceLock::new();
+/// (home, session_id) → chat path for gemini lookups, so a repeat fetch
+/// verifies ONE file instead of read+parsing every chat in the store
+/// again. Keyed by the caller-supplied home: the same session id under
+/// two homes (tests inject temp homes; leased stores differ) must
+/// resolve independently.
+fn gemini_transcript_path_cache() -> &'static Mutex<HashMap<(PathBuf, String), PathBuf>> {
+    static CACHE: OnceLock<Mutex<HashMap<(PathBuf, String), PathBuf>>> = OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
@@ -1039,10 +1053,11 @@ pub(crate) fn find_gemini_session_file_for_transcript(
     home: &Path,
     session_id: &str,
 ) -> Option<PathBuf> {
+    let cache_key = (home.to_path_buf(), session_id.to_string());
     if let Some(cached) = gemini_transcript_path_cache()
         .lock()
         .unwrap_or_else(|e| e.into_inner())
-        .get(session_id)
+        .get(&cache_key)
         .cloned()
     {
         // Re-verify the single remembered file (ids are stable but chats
@@ -1059,10 +1074,10 @@ pub(crate) fn find_gemini_session_file_for_transcript(
     let mut cache = gemini_transcript_path_cache()
         .lock()
         .unwrap_or_else(|e| e.into_inner());
-    if cache.len() >= 512 && !cache.contains_key(session_id) {
+    if cache.len() >= 512 && !cache.contains_key(&cache_key) {
         cache.clear();
     }
-    cache.insert(session_id.to_string(), found.clone());
+    cache.insert(cache_key, found.clone());
     Some(found)
 }
 
@@ -1592,6 +1607,61 @@ pub(crate) fn session_ended_id_from_wire(line: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn gemini_transcript_lookup_is_scoped_per_home() {
+        let write_chat = |home: &Path, session_id: &str, text: &str| {
+            let chats = home.join(".gemini").join("tmp").join("proj").join("chats");
+            std::fs::create_dir_all(&chats).unwrap();
+            let body = serde_json::json!({
+                "sessionId": session_id,
+                "messages": [{ "role": "user", "content": text }],
+            });
+            std::fs::write(chats.join("chat-1.json"), body.to_string()).unwrap();
+        };
+        let home_a = tempfile::tempdir().unwrap();
+        let home_b = tempfile::tempdir().unwrap();
+        // The SAME session id exists under both homes: each lookup must
+        // resolve within its own home — a shared id-only cache key would
+        // serve home A's transcript to home B.
+        write_chat(home_a.path(), "shared-id", "from home a");
+        write_chat(home_b.path(), "shared-id", "from home b");
+
+        let found_a = find_gemini_session_file_for_transcript(home_a.path(), "shared-id")
+            .expect("home a chat resolves");
+        assert!(found_a.starts_with(home_a.path()), "{}", found_a.display());
+        // Repeat (cache-hit path) must stay inside home B, not replay A.
+        for _ in 0..2 {
+            let found_b = find_gemini_session_file_for_transcript(home_b.path(), "shared-id")
+                .expect("home b chat resolves");
+            assert!(found_b.starts_with(home_b.path()), "{}", found_b.display());
+        }
+    }
+
+    #[test]
+    fn transcript_cache_admission_rechecks_the_source_after_parse() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout-post-parse.jsonl");
+        std::fs::write(&path, b"{\"type\":\"noise\"}\n").unwrap();
+        // Key stat'd BEFORE the (simulated) parse...
+        let key = external_transcript_cache_key("codex", "post-parse-growth", &path)
+            .expect("key from pre-parse stat");
+        // ...then the file grows mid-parse: caching now would pin the
+        // parse under a key no future lookup matches (and could exceed
+        // the byte gate unnoticed).
+        std::fs::write(&path, b"{\"type\":\"noise\"}\n{\"type\":\"more\"}\n").unwrap();
+        let entries = std::sync::Arc::new(vec![serde_json::json!({ "content": "stale parse" })]);
+        store_external_transcript_entries(key.clone(), &entries);
+        assert!(
+            cached_external_transcript_entries(&key).is_none(),
+            "a parse of bytes that no longer match the keyed snapshot must not be cached"
+        );
+        // The steady case (file unchanged since the key) still caches.
+        let fresh_key = external_transcript_cache_key("codex", "post-parse-growth", &path)
+            .expect("fresh key");
+        store_external_transcript_entries(fresh_key.clone(), &entries);
+        assert!(cached_external_transcript_entries(&fresh_key).is_some());
+    }
 
     #[test]
     fn external_transcript_cache_invalidates_when_source_file_changes() {

--- a/src/bin/caller/web_gateway/session_catalog/transcripts.rs
+++ b/src/bin/caller/web_gateway/session_catalog/transcripts.rs
@@ -44,7 +44,7 @@ pub(crate) fn external_transcript_cache_slot(key: &ExternalTranscriptCacheKey) -
 
 pub(crate) fn cached_external_transcript_entries(
     key: &ExternalTranscriptCacheKey,
-) -> Option<Vec<serde_json::Value>> {
+) -> Option<std::sync::Arc<Vec<serde_json::Value>>> {
     let slot = external_transcript_cache_slot(key);
     let cache = external_transcript_cache()
         .lock()
@@ -52,13 +52,22 @@ pub(crate) fn cached_external_transcript_entries(
     cache
         .get(&slot)
         .filter(|entry| &entry.key == key)
-        .map(|entry| entry.entries.clone())
+        .map(|entry| std::sync::Arc::clone(&entry.entries))
 }
+
+/// Byte-admission gate: parses of sources beyond this size are served but
+/// never cached. 32 unbounded slots otherwise pin several GB once a few
+/// multi-hundred-MB rollouts cycle through (parsed `Value`s outweigh
+/// their source bytes), and whales evict every warm small entry.
+pub(crate) const EXTERNAL_TRANSCRIPT_CACHE_MAX_SOURCE_BYTES: u64 = 32 * 1024 * 1024;
 
 pub(crate) fn store_external_transcript_entries(
     key: ExternalTranscriptCacheKey,
-    entries: &[serde_json::Value],
+    entries: &std::sync::Arc<Vec<serde_json::Value>>,
 ) {
+    if key.len > EXTERNAL_TRANSCRIPT_CACHE_MAX_SOURCE_BYTES {
+        return;
+    }
     let slot = external_transcript_cache_slot(&key);
     let mut cache = external_transcript_cache()
         .lock()
@@ -70,7 +79,7 @@ pub(crate) fn store_external_transcript_entries(
         slot,
         ExternalTranscriptCacheEntry {
             key,
-            entries: entries.to_vec(),
+            entries: std::sync::Arc::clone(entries),
         },
     );
 }
@@ -382,8 +391,10 @@ pub(crate) fn parse_codex_session_entries(path: &Path) -> Option<Vec<serde_json:
     let mut current_turn_id: Option<String> = None;
     let mut synthetic_item_seq = 0_u64;
     let mut command_calls: HashMap<String, serde_json::Value> = HashMap::new();
-    let canonical_user_message_events = codex_session_has_user_message_events(path);
-    let canonical_assistant_response_items = codex_session_has_assistant_response_items(path);
+    // One combined probe pass (early-exits once both lanes are proven)
+    // instead of two independent full-file scans before the main parse.
+    let (canonical_user_message_events, canonical_assistant_response_items) =
+        codex_session_canonical_lanes(path);
     // (count_before, count_after) entry-count boundaries for each rollout item id,
     // so an item-anchor rewind can supersede exactly the entries after the anchor.
     let mut item_entry_boundaries: std::collections::HashMap<String, (usize, usize)> =
@@ -682,68 +693,63 @@ pub(crate) fn parse_codex_session_entries(path: &Path) -> Option<Vec<serde_json:
     Some(entries)
 }
 
-pub(crate) fn codex_session_has_user_message_events(path: &Path) -> bool {
+/// Whole-file facts the codex projection needs before line 1:
+/// `(has canonical user_message events, has canonical assistant
+/// response_items)`. One scan answers both — the two independent probe
+/// passes each read the rollout to EOF whenever their answer was "no" —
+/// and it stops as soon as both lanes are proven.
+pub(crate) fn codex_session_canonical_lanes(path: &Path) -> (bool, bool) {
     let Ok(file) = std::fs::File::open(path) else {
-        return false;
+        return (false, false);
     };
     let reader = std::io::BufReader::new(file);
+    let mut has_user_message_events = false;
+    let mut has_assistant_response_items = false;
     for line in reader.lines() {
         let Ok(line) = line else {
             continue;
         };
         let trimmed = line.trim();
-        if trimmed.is_empty() || !trimmed.contains("\"user_message\"") {
+        if trimmed.is_empty() {
+            continue;
+        }
+        // Substring prefilters keep the JSON parse off unrelated lines,
+        // exactly as the split probes did.
+        let user_candidate = !has_user_message_events && trimmed.contains("\"user_message\"");
+        let assistant_candidate =
+            !has_assistant_response_items && trimmed.contains("\"assistant\"");
+        if !user_candidate && !assistant_candidate {
             continue;
         }
         let Ok(obj) = serde_json::from_str::<serde_json::Value>(trimmed) else {
             continue;
         };
-        if obj.get("type").and_then(|v| v.as_str()) == Some("event_msg")
+        if user_candidate
+            && obj.get("type").and_then(|v| v.as_str()) == Some("event_msg")
             && obj
                 .get("payload")
                 .and_then(|payload| payload.get("type"))
                 .and_then(|v| v.as_str())
                 == Some("user_message")
         {
-            return true;
+            has_user_message_events = true;
+        }
+        if assistant_candidate && obj.get("type").and_then(|v| v.as_str()) == Some("response_item")
+        {
+            if let Some(payload) = obj.get("payload") {
+                if payload.get("type").and_then(|v| v.as_str()) == Some("message")
+                    && payload.get("role").and_then(|v| v.as_str()) == Some("assistant")
+                    && codex_payload_text(payload).is_some()
+                {
+                    has_assistant_response_items = true;
+                }
+            }
+        }
+        if has_user_message_events && has_assistant_response_items {
+            break;
         }
     }
-    false
-}
-
-pub(crate) fn codex_session_has_assistant_response_items(path: &Path) -> bool {
-    let Ok(file) = std::fs::File::open(path) else {
-        return false;
-    };
-    let reader = std::io::BufReader::new(file);
-    for line in reader.lines() {
-        let Ok(line) = line else {
-            continue;
-        };
-        let trimmed = line.trim();
-        if trimmed.is_empty() || !trimmed.contains("\"assistant\"") {
-            continue;
-        }
-        let Ok(obj) = serde_json::from_str::<serde_json::Value>(trimmed) else {
-            continue;
-        };
-        if obj.get("type").and_then(|v| v.as_str()) != Some("response_item") {
-            continue;
-        }
-        let Some(payload) = obj.get("payload") else {
-            continue;
-        };
-        if payload.get("type").and_then(|v| v.as_str()) != Some("message") {
-            continue;
-        }
-        if payload.get("role").and_then(|v| v.as_str()) != Some("assistant") {
-            continue;
-        }
-        if codex_payload_text(payload).is_some() {
-            return true;
-        }
-    }
-    false
+    (has_user_message_events, has_assistant_response_items)
 }
 
 /// Rebuild Activity entries from Claude Code's native `~/.claude` session
@@ -982,37 +988,82 @@ pub(crate) fn find_claude_session_file_for_transcript(
     home: &Path,
     session_id: &str,
 ) -> Option<PathBuf> {
+    // Fast path: mains live at `projects/<project>/<session_id>.jsonl` —
+    // one stat per project dir instead of a full recursive walk of the
+    // store (>1,000 files on a busy box) per WS bootstrap / detail fetch.
+    let projects = home.join(".claude").join("projects");
+    let file_name = format!("{session_id}.jsonl");
+    if let Ok(project_dirs) = std::fs::read_dir(&projects) {
+        for project in project_dirs.flatten() {
+            let candidate = project.path().join(&file_name);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    // Fallback: the historical exhaustive walk (unusual nesting).
     let mut files = Vec::new();
-    collect_files(&home.join(".claude").join("projects"), ".jsonl", &mut files);
+    collect_files(&projects, ".jsonl", &mut files);
     files
         .into_iter()
         .find(|path| path.file_stem().and_then(|n| n.to_str()) == Some(session_id))
+}
+
+/// session_id → chat path for gemini lookups, so a repeat fetch verifies
+/// ONE file instead of read+parsing every chat in the store again.
+fn gemini_transcript_path_cache() -> &'static Mutex<HashMap<String, PathBuf>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, PathBuf>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn gemini_chat_file_matches(path: &Path, session_id: &str) -> bool {
+    if path
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        != Some("chats")
+    {
+        return false;
+    }
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    serde_json::from_str::<serde_json::Value>(&contents)
+        .ok()
+        .and_then(|obj| value_str(&obj, "sessionId"))
+        .as_deref()
+        == Some(session_id)
 }
 
 pub(crate) fn find_gemini_session_file_for_transcript(
     home: &Path,
     session_id: &str,
 ) -> Option<PathBuf> {
+    if let Some(cached) = gemini_transcript_path_cache()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(session_id)
+        .cloned()
+    {
+        // Re-verify the single remembered file (ids are stable but chats
+        // can be deleted or rewritten); a miss falls through to the scan.
+        if gemini_chat_file_matches(&cached, session_id) {
+            return Some(cached);
+        }
+    }
     let mut files = Vec::new();
     collect_files(&home.join(".gemini").join("tmp"), ".json", &mut files);
-    files.into_iter().find(|path| {
-        if path
-            .parent()
-            .and_then(|p| p.file_name())
-            .and_then(|n| n.to_str())
-            != Some("chats")
-        {
-            return false;
-        }
-        let Ok(contents) = std::fs::read_to_string(path) else {
-            return false;
-        };
-        serde_json::from_str::<serde_json::Value>(&contents)
-            .ok()
-            .and_then(|obj| value_str(&obj, "sessionId"))
-            .as_deref()
-            == Some(session_id)
-    })
+    let found = files
+        .into_iter()
+        .find(|path| gemini_chat_file_matches(path, session_id))?;
+    let mut cache = gemini_transcript_path_cache()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    if cache.len() >= 512 && !cache.contains_key(session_id) {
+        cache.clear();
+    }
+    cache.insert(session_id.to_string(), found.clone());
+    Some(found)
 }
 
 pub(crate) fn parse_external_session_entries_from_file(
@@ -1028,11 +1079,13 @@ pub(crate) fn parse_external_session_entries_from_file(
     }
 }
 
-pub(crate) fn external_session_entries_from_file(
+/// Shared-snapshot form: read-only consumers take the cache's Arc
+/// directly instead of deep-cloning the whole parsed transcript per hit.
+pub(crate) fn external_session_entries_from_file_arc(
     source: &str,
     session_id: &str,
     path: &Path,
-) -> Option<Vec<serde_json::Value>> {
+) -> Option<std::sync::Arc<Vec<serde_json::Value>>> {
     let key = external_transcript_cache_key(source, session_id, path)?;
     if let Some(entries) = cached_external_transcript_entries(&key) {
         return Some(entries);
@@ -1040,15 +1093,16 @@ pub(crate) fn external_session_entries_from_file(
 
     let mut entries = parse_external_session_entries_from_file(source, session_id, path)?;
     annotate_external_transcript_entries(source, session_id, &mut entries);
+    let entries = std::sync::Arc::new(entries);
     store_external_transcript_entries(key, &entries);
     Some(entries)
 }
 
-pub(crate) fn external_session_entries_from_home(
+pub(crate) fn external_session_entries_from_home_arc(
     home: &Path,
     source: &str,
     session_id: &str,
-) -> Option<Vec<serde_json::Value>> {
+) -> Option<std::sync::Arc<Vec<serde_json::Value>>> {
     let source = crate::session_names::normalize_source(source);
     let path = match source.as_str() {
         "codex" => find_codex_session_file(home, session_id),
@@ -1057,7 +1111,16 @@ pub(crate) fn external_session_entries_from_home(
         _ => None,
     }?;
 
-    external_session_entries_from_file(&source, session_id, &path)
+    external_session_entries_from_file_arc(&source, session_id, &path)
+}
+
+pub(crate) fn external_session_entries_from_home(
+    home: &Path,
+    source: &str,
+    session_id: &str,
+) -> Option<Vec<serde_json::Value>> {
+    external_session_entries_from_home_arc(home, source, session_id)
+        .map(|entries| (*entries).clone())
 }
 
 #[allow(dead_code)]

--- a/src/bin/caller/web_gateway/ws_session.rs
+++ b/src/bin/caller/web_gateway/ws_session.rs
@@ -142,6 +142,13 @@ pub(crate) fn bootstrap_cache_resync_lines(
     lines
 }
 
+/// Capacity of the per-connection bounded PTY-output lane. Entries are one
+/// JSON-wrapped base64 chunk each (terminal.rs merges output up to 64 KiB
+/// per entry), so the lane holds ~1.4 MiB worst-case — the same order as
+/// terminal.rs's own 1 MiB per-listener bound that takes over (drop-oldest)
+/// once this lane fills and the forwarders park.
+pub(crate) const TERMINAL_FORWARD_LANE_CAP: usize = 16;
+
 /// Outbound half of a local `/ws` session: broadcast + direct responses ->
 /// the WebSocket, converting each input-authority change into a personalized
 /// `display_input_authority_state` wire message. Connection IDs never leave
@@ -163,6 +170,7 @@ pub(crate) fn bootstrap_cache_resync_lines(
 pub(crate) async fn ws_outbound_task(
     mut outbound_rx: broadcast::Receiver<String>,
     mut direct_rx: mpsc::UnboundedReceiver<String>,
+    mut terminal_forward_rx: mpsc::Receiver<String>,
     mut ws_tx: futures_util::stream::SplitSink<
         tokio_tungstenite::WebSocketStream<DemuxStream>,
         Message,
@@ -177,6 +185,7 @@ pub(crate) async fn ws_outbound_task(
     session_cancel: CancellationToken,
 ) {
     let mut bootstrap_flushed = false;
+    let mut terminal_lane_open = true;
     let mut authority_tick =
         tokio::time::interval(crate::dashboard_control::LIVE_AUTHORITY_RECHECK_INTERVAL);
     authority_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -208,6 +217,35 @@ pub(crate) async fn ws_outbound_task(
                         }
                     }
                     None => break,
+                }
+            }
+            // PTY output rides its own small BOUNDED lane: when this send
+            // stalls on TCP backpressure (frozen tab), the lane fills, the
+            // per-terminal forwarders' `send().await` parks, and
+            // terminal.rs's per-listener drop-oldest bound re-engages —
+            // instead of the output flood growing the unbounded direct
+            // lane at PTY rate. Ordered after `direct_rx` so control
+            // responses (e.g. `terminal_opened`) keep draining first.
+            msg = terminal_forward_rx.recv(), if terminal_lane_open => {
+                match msg {
+                    Some(line) => {
+                        if !grant.opening_authority_is_current() {
+                            let _ = ws_tx.send(Message::Close(None)).await;
+                            session_cancel.cancel();
+                            break;
+                        }
+                        if ws_tx
+                            .send(Message::Text(line.into()))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    // All senders gone (inbound task tore down): stop
+                    // polling this lane; the other lanes keep serving
+                    // until the session cancel arm ends the loop.
+                    None => terminal_lane_open = false,
                 }
             }
             _ = &mut bootstrap_flushed_rx, if !bootstrap_flushed => {
@@ -403,6 +441,10 @@ pub(crate) struct WsInboundCtx {
     pub(crate) bus: EventBus,
     pub(crate) query_ctx: Option<WebQueryCtx>,
     pub(crate) direct_tx: mpsc::UnboundedSender<String>,
+    /// Bounded PTY-output lane (see `ws_outbound_task`): per-terminal
+    /// forwarders `send().await` here so a stalled socket re-engages
+    /// terminal.rs's drop-oldest bound instead of growing `direct_tx`.
+    pub(crate) terminal_forward_tx: mpsc::Sender<String>,
     pub(crate) voice_debug: Arc<Mutex<VoiceDebugState>>,
     pub(crate) live_provider: String,
     pub(crate) live_model: String,
@@ -447,6 +489,7 @@ pub(crate) async fn ws_inbound_task(
         bus: bus_inbound,
         query_ctx: query_ctx_inbound,
         direct_tx: direct_tx_inbound,
+        terminal_forward_tx: terminal_forward_tx_inbound,
         voice_debug: voice_debug_inbound,
         live_provider,
         live_model,
@@ -535,9 +578,11 @@ pub(crate) async fn ws_inbound_task(
             break;
         }
         if let Message::Text(text) = msg {
-            // Re-derive after the live IAM check above so a root→scoped
-            // change can never retain the root terminal visibility lane.
-            let ws_terminal_actor = dashboard_control_grant_inbound.terminal_actor();
+            // The terminal actor is re-derived inside each terminal_* arm —
+            // still after the live IAM check above, so a root→scoped change
+            // can never retain the root terminal visibility lane — but
+            // lazily, so pointer/keystroke/audio frames skip the extra IAM
+            // load + grant scan it costs.
             let trimmed = text.trim();
             if trimmed.is_empty() {
                 continue;
@@ -1717,6 +1762,7 @@ pub(crate) async fn ws_inbound_task(
                     }
                     Some("terminal_open") => {
                         // {"t":"terminal_open","host_id":"local","terminal_id":"shell-0","cols":80,"rows":24}
+                        let ws_terminal_actor = dashboard_control_grant_inbound.terminal_actor();
                         let host_id = json["host_id"].as_str().unwrap_or("local").to_string();
                         let terminal_id = json["terminal_id"]
                             .as_str()
@@ -1755,13 +1801,32 @@ pub(crate) async fn ws_inbound_task(
                             .await
                         {
                             Ok((session, _created)) => {
+                                // Ack before the forwarder spawns so
+                                // `terminal_opened` is enqueued ahead of any
+                                // output frame (the outbound task drains the
+                                // direct lane before the terminal lane).
+                                let ack = serde_json::json!({
+                                    "t": "terminal_opened",
+                                    "host_id": host_id,
+                                    "terminal_id": terminal_id,
+                                    "shared": session.shared(),
+                                    "can_share": session
+                                        .managed_by(&ws_terminal_actor),
+                                });
+                                let _ = direct_tx_inbound.send(ack.to_string());
+
                                 // Spawn a forwarder task that drains the session's
                                 // per-listener queue (coalesced + bounded in
                                 // terminal.rs) and sends base64-encoded
-                                // output to this WS connection.
+                                // output to this WS connection over the
+                                // BOUNDED terminal lane: when the socket
+                                // stalls, `send().await` parks this task and
+                                // terminal.rs's drop-oldest bound holds the
+                                // memory line instead of the direct lane
+                                // growing at PTY rate.
                                 let mut rx = session.attach();
 
-                                let forwarder_tx = direct_tx_inbound.clone();
+                                let forwarder_tx = terminal_forward_tx_inbound.clone();
                                 let fwd_host = host_id.clone();
                                 let fwd_term = terminal_id.clone();
                                 tokio::spawn(async move {
@@ -1787,21 +1852,11 @@ pub(crate) async fn ws_inbound_task(
                                                 })
                                             }
                                         };
-                                        if forwarder_tx.send(msg.to_string()).is_err() {
+                                        if forwarder_tx.send(msg.to_string()).await.is_err() {
                                             break;
                                         }
                                     }
                                 });
-
-                                let ack = serde_json::json!({
-                                    "t": "terminal_opened",
-                                    "host_id": host_id,
-                                    "terminal_id": terminal_id,
-                                    "shared": session.shared(),
-                                    "can_share": session
-                                        .managed_by(&ws_terminal_actor),
-                                });
-                                let _ = direct_tx_inbound.send(ack.to_string());
                             }
                             Err(e) => {
                                 let err = serde_json::json!({
@@ -1816,6 +1871,7 @@ pub(crate) async fn ws_inbound_task(
                     }
                     Some("terminal_input") => {
                         // {"t":"terminal_input","host_id":"local","terminal_id":"shell-0","data":"<base64>"}
+                        let ws_terminal_actor = dashboard_control_grant_inbound.terminal_actor();
                         let host_id = json["host_id"].as_str().unwrap_or("local").to_string();
                         let terminal_id = json["terminal_id"]
                             .as_str()
@@ -1839,6 +1895,7 @@ pub(crate) async fn ws_inbound_task(
                     }
                     Some("terminal_resize") => {
                         // {"t":"terminal_resize","host_id":"local","terminal_id":"shell-0","cols":N,"rows":N}
+                        let ws_terminal_actor = dashboard_control_grant_inbound.terminal_actor();
                         let host_id = json["host_id"].as_str().unwrap_or("local").to_string();
                         let terminal_id = json["terminal_id"]
                             .as_str()
@@ -1859,6 +1916,7 @@ pub(crate) async fn ws_inbound_task(
                     }
                     Some("terminal_close") => {
                         // {"t":"terminal_close","host_id":"local","terminal_id":"shell-0"}
+                        let ws_terminal_actor = dashboard_control_grant_inbound.terminal_actor();
                         let host_id = json["host_id"].as_str().unwrap_or("local").to_string();
                         let terminal_id = json["terminal_id"]
                             .as_str()
@@ -1874,6 +1932,7 @@ pub(crate) async fn ws_inbound_task(
                     }
                     Some("terminal_share") => {
                         // {"t":"terminal_share","host_id":"local","terminal_id":"shell-0","shared":true}
+                        let ws_terminal_actor = dashboard_control_grant_inbound.terminal_actor();
                         let host_id = json["host_id"].as_str().unwrap_or("local").to_string();
                         let terminal_id = json["terminal_id"]
                             .as_str()
@@ -2638,8 +2697,9 @@ mod signaling_ownership_tests {
                 .unwrap();
         let grant = crate::dashboard_control::DashboardControlGrant::UserClient {
             principal,
-            iam_state: state,
+            iam_state: std::sync::Arc::new(state),
             iam_cert_dir: None,
+            authority_memo: Default::default(),
         };
         assert!(
             grant


### PR DESCRIPTION
Efficiency-audit implementation for the gateway/IAM/catalog lane (audit scopes 09, 10, 11, 18; verified against current main). No authorization check is removed, reordered, or weakened; IAM stays fail-closed; CORS/origin semantics are untouched (the origin-gate change below is allocation-only — which origins pass is byte-identical).

## TRUST REVIEW REQUESTED: opening-authority memoization

`DashboardControlGrant::opening_authority_is_current()` runs per injected input event and per transfer-pump beat. It now memoizes its full record validation per IAM state snapshot (`OpeningAuthorityMemo`, `dashboard_control/mod.rs`):

- Only **positive** verdicts are memoized; every negative outcome re-runs the full validation.
- A hit requires `Arc::ptr_eq` with a snapshot the memo **keeps alive** — a match is an identity test, never an ABA false positive from a recycled allocation.
- Revocation liveness is preserved exactly: every IAM edit reaches sessions as a **new** Arc from the stat-fingerprint cache, forcing full revalidation (`opening_authority_memo_never_outlives_a_state_change` pins it).
- The expiry instant — the only time-dependent input — is re-checked on **every** call, hit or not (`opening_authority_memo_hit_still_rechecks_expiry_instant` pins it: the verdict flips at expiry with zero state change).
- The decomposition of `IamGrant::is_active_at` into a static half (statuses, memoized) and the live expiry compare is commented at both sites; the hit path mirrors `is_active_at`'s exact `u128` comparison.

Related, same commit: `UserClient.iam_state` becomes `Arc<LocalIamState>` (the opening snapshot is immutable for the session lifetime and was deep-cloned per signaling call).

## Finding → fix

| Audit finding | Fix | Where |
|---|---|---|
| 18#1 / 09#2 / 10#7 — full `LocalIamState` deep-cloned per authenticated request (three-agent convergence) | `RequestAuthority.iam_state: Option<Arc<LocalIamState>>` via `load_state_cached_arc`; dead owned wrapper `load_state_cached` removed; `routes_files` spawn_blocking context clone now an Arc clone; uncached request-path loads (`routes_peers.rs` offer attribution, enrollment-requests `hosted_origins`) moved onto the cache | `web_gateway/api_core.rs:249`, `routes_access.rs:2614+`, `mcp_gate.rs:537-663`, `routes_peers.rs:1628`, `access/iam.rs:1256+` |
| 18#2 — `audit_events` unbounded inside iam.json | Bounded in `normalize()` to the newest **300** (`IAM_AUDIT_EVENTS_CAP`, mirroring `credential_audit::MEM_CAP`). Retention decision, stated explicitly: the bound is **durable and retroactive on first persist** — the first load+save cycle after upgrade trims an over-300 trail in `iam.json` permanently. The evaluator never reads `audit_events` (no authorization semantics change), and the dashboard's audit view shows the newest tail, which is what it effectively showed anyway. Test pins newest-tail retention. | `access/iam.rs:24,858` |
| 18#3 — eager full `FleetCertStatus` clone per IAM evaluation | `fleet_cert::fleet_zone()` reads just the zone under the mutex; the evaluator fetches it **lazily** inside the `client_key` authn branch (mTLS/root/peer/agent principals skip the mutex entirely); upsert/update/overview call sites use the light accessor | `fleet_cert.rs:241`, `access/iam.rs:2493+` |
| 18#4 — `opening_authority_is_current()` six finds + record equality per input event | Memoized per snapshot — see trust section above; two pinning tests | `dashboard_control/mod.rs:505-716` |
| 18-other — `authority_store::with_lock` spin-sleeps on the tokio runtime | The seven mutation-bearing access handlers (iam grants, enrollment decide, org manage, org present, ORL apply/renew, tier, fleet-cert request) run their transaction cores in `spawn_blocking` | `routes_access.rs` handlers |
| 18-other — connect re-register starved by a continuous event stream | The event branch now falls through to the same `last_register.elapsed()` check instead of `continue`ing past it | `connect_rendezvous.rs:614-651` |
| 18-other — `resolve_host_label()` subprocess + 3 dir probes per call | Process-lifetime `OnceLock` cache (label changes happen via separate CLI processes) | `access/mod.rs:43` |
| 09#1 — terminal forwarder defeats terminal.rs's 1 MiB bound via the unbounded direct lane | PTY output rides a per-connection **bounded** lane (`TERMINAL_FORWARD_LANE_CAP` 16 ≈ 1.4 MiB); a stalled socket parks the forwarders and re-engages terminal.rs's drop-oldest. Outbound select drains direct before terminal, and the `terminal_opened` ack is enqueued before the forwarder spawns, so acks still precede output | `ws_session.rs`, `listener.rs` |
| 09#3 — `terminal_actor()` (IAM load + grant scan + principal clone) computed per inbound text frame | Derived lazily inside the five `terminal_*` arms — still after the per-message liveness gate; pointer/keystroke/audio frames skip it | `ws_session.rs:537+` |
| 09#5 — /mcp closes the connection per request | POST + 405 lanes opt into the standard park contract (self-framing responses, table-cap body, derived `Connection` header) — managed Codex/CC backends stop paying TCP+TLS per tool call | `mcp_gate.rs` |
| 09#6 — MCP tool result deep-cloned into the JSON-RPC envelope | Moved | `mcp_gate.rs:362` |
| 09#7 — per-request ctx rebuild deep-clones the agent card JSON tree | Card value Arc'd once at gateway spawn; the three handlers take the Arc | `listener.rs`, `http_dispatch.rs`, `routes_access.rs` |
| 09-other — TLS-failure rate-limiter map never evicts | Stale-sweep at a 4096-entry cap | `listener.rs:21` |
| 10#6 (S half) — `/api/fs/read` rangeless reads buffer whole files uncapped | Same 100 MB per-request cap as the tunnel's offset/length form (413 with remedy text); the dashboard's chunked ranged download flow is untouched | `routes_files.rs:1560` |
| 10#8 — fleet-CORS origin gate builds full `PeerSnapshot`s per request/preflight | Reads the Arc'd card snapshot + via-URL accessor — the two URL strings it always compared; **which origins pass is unchanged** | `routes_access.rs:1717` |
| 11#1 — claude list rows re-parse the whole transcript per append | Checkpointed incremental accumulator (`ClaudeRowAccumulator`): resumes from the consumed offset under identity + prefix-hash guards; unterminated tails render without entering the checkpoint; rewrites fall back to the full parse. Usage/turn totals stay exact — pinned against a from-scratch parse (excerpting was rejected: it would shrink totals). Poison-pin test proves appends fold rather than re-parse | `session_catalog/backend_lists.rs:615+` |
| 11#2 — message_search ignores its cursor; collect-then-slice | (a) extraction **streams** lines (`for_each_complete_line_from`) — no more file-sized `Vec<String>` per parse; (b) claude sessions **fold main-file appends** into the published shard under narrow guards (line-local records; byte-for-byte equal to full re-extraction, pinned by test). Codex/intendant keep the full parse: their extractors carry cross-line state (`user_turn` ordinals, `line_no` locators, era decisions) a cursor resume cannot reproduce without a parser-version bump — see residuals | `message_search/{cursor,extract_*,indexer}.rs` |
| 11#3 — external transcript cache: 3 passes per codex parse, deep clone per hit, unbounded entries | Cache stores `Arc<Vec<Value>>` (hits share; read-only consumers converted); the two codex probe passes fold into one early-exit scan; >32 MiB sources are served but not admitted | `session_catalog/transcripts.rs` |
| 11#4 — stat/canonicalize storms in list scans | `collect_files` rides `DirEntry::file_type`; `collect_recent_files` carries metadata out of the walk — `(dev,ino)` dedup on Unix replaces canonicalize-per-file, decorate-sort-strip replaces the `sort_by_key(file_mtime_secs)` O(n log n) re-stats (incl. both codex two-root merges and `agent_session_files_from_rows`) | `session_catalog/caches.rs` etc. |
| 11#5 — manifest rewritten (1.2 MB, pretty) per published session (~7 GB/day measured) | Publishes batch under one writer lock + one read + at most one write per flush (`PUBLISH_BATCH_MAX` 16, bounded memory); manifest serializes compact. Staleness/tombstone checks unchanged, per session, under the same lock | `message_search/{store,indexer}.rs` |
| 11#7 (S half) — fingerprint walk stats every file twice | Metadata-carrying pushes from the dir-entry walks | `session_catalog/mod.rs:1516+` |
| 11#8 — claude/gemini transcript lookup walks (gemini: parses) the whole store per fetch | Claude: one stat per project dir + walk fallback; gemini: id→path cache re-verifying one file; `detail_search` variants route through the same resolvers | `session_catalog/{transcripts,detail_search}.rs` |
| 11#9 + 11-correctness — sweep-cadence prefix-hash opens; `check()` never compares mtime | Cheap-facts short-circuit (reliable identity + len + mtime ⇒ skip the open+4 KiB+SHA-256); same-length mtime-moved rewrites now read as `Rewritten` (the module doc's promise). Timestamp equality is trusted only on a QUIESCENT file — stored mtime ≥2 s older than the check time (git's racy-index discipline; see the round-3 note below): fresh mtimes always fall through to the hash windows, which covers every supported filesystem's stamp granularity (Linux jiffies through FAT/exFAT 2 s granules) | `message_search/cursor.rs:100` |

## Skipped / residual (with reasons)

- **routes_sessions.rs findings (10#1-#5, #9)** — excluded per lane split (another lane owns the file).
- **Wildcard-CORS / plain-HTTP-lane auth semantics (10-other)** — decision-gated, untouched.
- **09#4 broadcast `Arc<WireLine>` fanout + dashboard_presence re-parse** — same lane as the EventBus Arc conversions (later lane).
- **09#8 route-table double scan** — the dedup seam (a shared route→operation classifier) lives in `gateway_routes.rs`, outside this lane's fence; skipped rather than mirroring `classify()`'s authz mapping into dispatch.
- **11#2b for codex/intendant** — append-folding needs per-record file provenance / resumable extractor state (parser-version bump); flagged as follow-up.
- **11#6 sessions-stream quick phase, 11#10 locate= replay-cache reads** — deferred (S items; not reached this pass).
- **11-design cache eviction (clear() at cap → LRU)** — pre-existing design note; the new caches mirror the sibling pattern for consistency.
- **10#6 M half** (streamed `BytesPayload` variant) — the S cap closes the unbounded-memory hole; streaming download lane left as follow-up.
- `session_list_path_key` canonicalize-per-cache-key remains (bounded, per-row); the per-walk canonicalize storm is gone.

## Out-of-fence touches (reported)

- `fleet_cert.rs`: the `fleet_zone()` accessor (named by the audit item; the lightweight read needs the private registry).
- `dashboard_control/dispatch.rs` + `dashboard_control/api_control.rs`: one `#[cfg(test)]` grant-constructor literal each (unavoidable for the new enum field), plus `Arc::make_mut` in one test helper.
- `message_search/**` treated as in-lane (its findings are this lane's assigned scope-11 items).

## Review round 1 (applied)

Both reviews verified the trust lane sound (memo ABA-proof via kept-alive Arc identity, every IAM mutation mints a new Arc, expiry semantics exact, fail-closed intact) — **no trust code changed this round**. Fixes applied (commit `search/catalog/gateway: review-round fixes`):

1. **Second rewrite window (convergent)** — cursor + claude-row accumulator record a hash of the last `min(4096, consumed)` bytes ending at the consumed offset; BOTH windows are required before any incremental resume, and the under-4 KiB "not comparable" carve-out closes (the tail window covers every consumed byte there). Legacy cursors without the field classify as before but never resume. Documented residual: a growth rewrite preserving both windows. Tests: post-prefix grow-rewrite ⇒ `Rewritten`; small-file head-mutating grow ⇒ `Rewritten`; honest append ⇒ `Appended`; accumulator post-prefix rewrite ⇒ full re-parse.
2. **Oversized unterminated tail** — >4 MiB valid final records render via a full streaming pass instead of being silently omitted; test pins the record counting.
3. **Gemini path cache keyed `(home, session_id)`** — per-home resolution pinned by test.
4. **Transcript-cache admission re-stats after parse** — a source that grew (or changed at all) during the parse is served but never cached; test pins it.
5. **TLS log-budget map** — still-over-cap fallback evicts oldest-first down to half cap instead of clearing (hot keys keep suppression state under key churn).
6. **`/api/fs/read` open-ended ranges** — `bytes=0-` clamps to the same 100 MB cap and serves the accurate 206 partial; explicit sub-cap ranges untouched; test drives the cap via an injected limit.

## Review round 2 (applied)

Trust lane untouched again. Delta-review residuals fixed (commit `round-2 review fixes`):

- **A (High) — store truncation loop:** the lower-watermark rejection now asks the STORED cursors about the live files (all still `Unchanged`/`Appended` ⇒ stale writer, reject; any `Rewritten`/`Gone` ⇒ source genuinely changed, accept the rebuild). Snapshot-field comparison could not carry this: folding len/tail-at-offset would have broken the growing-file race protection (two honest snapshots always differ there), while the old prefix-only compare rejected prefix-preserving truncations forever. Test pins accept-on-truncation, quiet steady state, and reject-real-stale.
- **B (Medium) — validate→read TOCTOU:** `fold_claude_main_append` takes the saved cursor and re-runs `check()` AFTER reading the suffix (two ≤4 KiB window reads); anything but a still-plain append discards the fold. The row accumulator re-verifies its resumed checkpoint's windows post-fold and falls back to a fresh full parse. A rewrite racing the final capture leaves a cursor that mismatches the file, so the next sweep full-rebuilds — no permanently laundered state on any interleaving. Pinned by a fold-discard test (rewrite before the call = the interleaving's observable half).
- **C (Medium) — eviction recency:** log-budget entries track `last_seen` (updated on suppressed hits too); the age sweep and oldest-first eviction key on it. Test: a continuously hot suppressed key survives an overflow eviction with suppression state intact.
- **D (Medium) — bounded fallback:** the full-render fallback replaces `.lines()` with a capped reusable-buffer reader (32 MiB/record); over-cap records are skipped with a warning + line-slot placeholder (documented row-metadata-only loss). Changed oversized tails re-render at the existing list-rebuild cadence (row cache keys on len/mtime/ino). Test drives the cap via an injected limit.
- **Low:** gemini path-cache home key canonicalized once.
- **Accepted/documented:** post-parse re-stat ABA (metadata-preserving replacement) noted as outside the catalog's benign-writer cache model; ns-mtime legacy cursors never short-circuit (historical behavior), already documented on the field.

## Round 3 (CI-found, applied)

The Linux PR leg failed `same_length_prefix_rewrite_is_detected`: Linux file timestamps ride the coarse kernel clock (jiffy ~1-4 ms), so two same-length writes inside one granule carry IDENTICAL `mtime_ns` and the round-2 short-circuit read the rewrite as `Unchanged` — ns precision alone cannot close this on any platform. Fix (`search: distrust fresh mtimes...`): racy-index discipline — the (len, mtime_ns) short-circuit is trusted only when the stored mtime is ≥2 s older than the check time; fresh mtimes always hash. Actively-written files get hashed, quiet files skip (the 30 s sweep steady state), and the FAT/exFAT residual is subsumed. Tests: the same-length rewrite test now uses explicit distinct `set_modified` stamps (deterministic everywhere); a new same-granule test pins the racy window via an injected check time (`check_at`, no sleeps) plus the quiescent fast path. Cursor suite run 20× locally.

## Validation

- `cargo fmt --check` clean
- `cargo clippy` clean (pre-existing test-cfg warnings in untouched files remain)
- `cargo nextest run --bins`: **3497 passed, 0 failed** after round 3 (cursor tests additionally run 20×) (route-table invariant tests and `tunnel_method_partition_is_pinned` green, untouched)
- `cargo test --test e2e`: **21 passed, 0 failed** (re-run after the review round)
- The suite itself caught one review-round regression before it shipped: ms-precision mtime let two same-millisecond writes defeat the new cheap-facts short-circuit — fixed with a full-precision `mtime_ns` field (legacy cursors hash every sweep, as before)
- New tests: memo expiry re-check pin, memo revocation pin, iam audit-tail bound, cache Arc identity, claude row fold-vs-full parity + poison-pin resume + rewrite fallback, message-search fold ≡ full re-extraction
