### PR TITLE
platform/cu: in-process display probes, blocking-pool pixel pipeline, -R zoom capture, proactive presence compaction

### DIFF
--- a/crates/intendant-core/src/conversation.rs
+++ b/crates/intendant-core/src/conversation.rs
@@ -557,25 +557,28 @@ impl Conversation {
         }
     }
 
-    /// Auto-compact the conversation when usage exceeds 90% of the context window.
+    /// Auto-compact with a configurable threshold and tail size, for
+    /// proactive compaction (e.g. threshold 0.10 for the presence narrator,
+    /// which re-sends its whole transcript on every narration).
     ///
-    /// Keeps the system message, first 2 context messages (working directory + ack),
-    /// and last 4 messages. Summarizes everything in between.
+    /// Keeps the system message, the first 2 context messages (working
+    /// directory + ack), and the last `keep_suffix` messages verbatim;
+    /// everything in between is replaced with a summary marker. The suffix
+    /// is what survives a compaction unchanged — callers whose transcript
+    /// interleaves user chat pick a larger tail than the worker default (4)
+    /// so the user's recent exchange isn't swallowed by the summary.
     /// Returns `true` if compaction occurred.
-    /// Auto-compact with a configurable threshold (e.g. 0.60 for proactive compaction).
-    #[allow(dead_code)]
-    pub fn auto_compact_at(&mut self, threshold: f64) -> bool {
+    pub fn auto_compact_at(&mut self, threshold: f64, keep_suffix: usize) -> bool {
         if self.usage_fraction() < threshold {
             return false;
         }
 
         let len = self.messages.len();
-        if len < 8 {
+        let keep_prefix = 3;
+        if len < keep_prefix + keep_suffix + 1 {
             return false;
         }
 
-        let keep_prefix = 3;
-        let keep_suffix = 4;
         let tail_start = len - keep_suffix;
 
         if keep_prefix >= tail_start {
@@ -600,6 +603,11 @@ impl Conversation {
         true
     }
 
+    /// Auto-compact the conversation when usage exceeds 90% of the context window.
+    ///
+    /// Keeps the system message, first 2 context messages (working directory + ack),
+    /// and last 4 messages. Summarizes everything in between.
+    /// Returns `true` if compaction occurred.
     pub fn auto_compact(&mut self) -> bool {
         const COMPACTION_THRESHOLD: f64 = 0.90;
 
@@ -1647,8 +1655,51 @@ mod tests {
         assert!(!conv.auto_compact());
         let before = conv.len();
         // Custom 0.60 threshold SHOULD trigger
-        assert!(conv.auto_compact_at(0.60));
+        assert!(conv.auto_compact_at(0.60, 4));
         assert!(conv.len() < before);
+    }
+
+    #[test]
+    fn auto_compact_at_custom_keep_suffix_preserves_longer_tail() {
+        let mut conv = Conversation::new("sys".to_string(), 100_000);
+        conv.add_user(MessageProvenance::FollowUp, "ctx1".to_string());
+        conv.add_assistant("ctx1-reply".to_string());
+        for i in 0..10 {
+            conv.add_user(MessageProvenance::FollowUp, format!("middle-{}", i));
+            conv.add_assistant(format!("reply-{}", i));
+        }
+        conv.set_usage(crate::usage::TokenUsage {
+            prompt_tokens: 65_000,
+            completion_tokens: 0,
+            total_tokens: 65_000,
+            ..Default::default()
+        });
+        // 23 messages: 3 prefix + summary + last 8 = 12 expected after.
+        assert!(conv.auto_compact_at(0.60, 8));
+        let msgs = conv.messages();
+        assert_eq!(msgs.len(), 12);
+        assert!(msgs[3].content.contains("[Context Summary]"));
+        // The 8-message tail survives verbatim.
+        assert_eq!(msgs[msgs.len() - 8].content, "middle-6");
+        assert_eq!(msgs[msgs.len() - 1].content, "reply-9");
+    }
+
+    #[test]
+    fn auto_compact_at_keep_suffix_larger_than_history_noop() {
+        let mut conv = Conversation::new("sys".to_string(), 100_000);
+        for i in 0..3 {
+            conv.add_user(MessageProvenance::FollowUp, format!("u{}", i));
+            conv.add_assistant(format!("a{}", i));
+        }
+        conv.set_usage(crate::usage::TokenUsage {
+            prompt_tokens: 95_000,
+            completion_tokens: 0,
+            total_tokens: 95_000,
+            ..Default::default()
+        });
+        // 7 messages, tail of 32 requested — nothing to compact.
+        assert!(!conv.auto_compact_at(0.60, 32));
+        assert_eq!(conv.len(), 7);
     }
 
     #[test]
@@ -1665,7 +1716,7 @@ mod tests {
             ..Default::default()
         });
         // 50% is below 0.60 threshold
-        assert!(!conv.auto_compact_at(0.60));
+        assert!(!conv.auto_compact_at(0.60, 4));
     }
 
     fn tool_call_ref(call_id: &str, name: &str) -> ToolCallRef {

--- a/crates/intendant-core/src/conversation.rs
+++ b/crates/intendant-core/src/conversation.rs
@@ -557,24 +557,40 @@ impl Conversation {
         }
     }
 
-    /// Auto-compact with a configurable threshold and tail size, for
-    /// proactive compaction (e.g. threshold 0.10 for the presence narrator,
-    /// which re-sends its whole transcript on every narration).
+    /// Auto-compact with a configurable threshold, head pin, and tail size,
+    /// for proactive compaction (e.g. threshold 0.10 for the presence
+    /// narrator, which re-sends its whole transcript on every narration).
     ///
-    /// Keeps the system message, the first 2 context messages (working
-    /// directory + ack), and the last `keep_suffix` messages verbatim;
-    /// everything in between is replaced with a summary marker. The suffix
-    /// is what survives a compaction unchanged — callers whose transcript
+    /// Keeps the first `keep_prefix` messages and the last `keep_suffix`
+    /// messages verbatim; everything in between is replaced with a summary
+    /// marker. `keep_prefix` counts from index 0 *including* the system
+    /// message, and is a positional pin, not layer-aware — pick it for the
+    /// conversation's actual shape: the worker uses 3 (system + its
+    /// working-directory/ack context pair), a system-only conversation like
+    /// presence uses 1, otherwise its first ordinary exchange would be
+    /// pinned forever as if it were context. (Index 0 survives regardless —
+    /// `summarize_turns` never removes the system message.) The suffix is
+    /// what survives a compaction unchanged — callers whose transcript
     /// interleaves user chat pick a larger tail than the worker default (4)
     /// so the user's recent exchange isn't swallowed by the summary.
-    /// Returns `true` if compaction occurred.
-    pub fn auto_compact_at(&mut self, threshold: f64, keep_suffix: usize) -> bool {
+    ///
+    /// Deliberate design limit: the "summary" is a static marker, not an
+    /// LLM summary — `Conversation` is a data type and must not call a
+    /// model. Compacted content is therefore dropped, not condensed;
+    /// callers for whom the transcript is memory (rather than narration
+    /// context) must summarize *before* compacting or pick thresholds
+    /// accordingly. Returns `true` if compaction occurred.
+    pub fn auto_compact_at(
+        &mut self,
+        threshold: f64,
+        keep_prefix: usize,
+        keep_suffix: usize,
+    ) -> bool {
         if self.usage_fraction() < threshold {
             return false;
         }
 
         let len = self.messages.len();
-        let keep_prefix = 3;
         if len < keep_prefix + keep_suffix + 1 {
             return false;
         }
@@ -1655,7 +1671,7 @@ mod tests {
         assert!(!conv.auto_compact());
         let before = conv.len();
         // Custom 0.60 threshold SHOULD trigger
-        assert!(conv.auto_compact_at(0.60, 4));
+        assert!(conv.auto_compact_at(0.60, 3, 4));
         assert!(conv.len() < before);
     }
 
@@ -1675,13 +1691,44 @@ mod tests {
             ..Default::default()
         });
         // 23 messages: 3 prefix + summary + last 8 = 12 expected after.
-        assert!(conv.auto_compact_at(0.60, 8));
+        assert!(conv.auto_compact_at(0.60, 3, 8));
         let msgs = conv.messages();
         assert_eq!(msgs.len(), 12);
         assert!(msgs[3].content.contains("[Context Summary]"));
         // The 8-message tail survives verbatim.
         assert_eq!(msgs[msgs.len() - 8].content, "middle-6");
         assert_eq!(msgs[msgs.len() - 1].content, "reply-9");
+    }
+
+    /// Presence-shaped conversations start with only a system message —
+    /// `keep_prefix = 1` must pin just that, and the first ordinary
+    /// exchange (which the worker's prefix of 3 would freeze forever as if
+    /// it were context) must be summarized away like any other old content.
+    #[test]
+    fn auto_compact_at_prefix_one_pins_only_the_system_message() {
+        let mut conv = Conversation::new("presence-sys".to_string(), 100_000);
+        for i in 0..10 {
+            conv.add_user(
+                MessageProvenance::SystemInjection,
+                format!("[Event] e{}", i),
+            );
+            conv.add_assistant(format!("narration-{}", i));
+        }
+        conv.set_usage(crate::usage::TokenUsage {
+            prompt_tokens: 65_000,
+            completion_tokens: 0,
+            total_tokens: 65_000,
+            ..Default::default()
+        });
+        // 21 messages: 1 prefix (system) + summary + last 4 = 6 after.
+        assert!(conv.auto_compact_at(0.60, 1, 4));
+        let msgs = conv.messages();
+        assert_eq!(msgs.len(), 6);
+        assert_eq!(msgs[0].content, "presence-sys");
+        // The first exchange was NOT pinned — the summary sits at index 1.
+        assert!(msgs[1].content.contains("[Context Summary]"));
+        assert_eq!(msgs[2].content, "[Event] e8");
+        assert_eq!(msgs[msgs.len() - 1].content, "narration-9");
     }
 
     #[test]
@@ -1698,7 +1745,7 @@ mod tests {
             ..Default::default()
         });
         // 7 messages, tail of 32 requested — nothing to compact.
-        assert!(!conv.auto_compact_at(0.60, 32));
+        assert!(!conv.auto_compact_at(0.60, 3, 32));
         assert_eq!(conv.len(), 7);
     }
 
@@ -1716,7 +1763,7 @@ mod tests {
             ..Default::default()
         });
         // 50% is below 0.60 threshold
-        assert!(!conv.auto_compact_at(0.60, 4));
+        assert!(!conv.auto_compact_at(0.60, 3, 4));
     }
 
     fn tool_call_ref(call_id: &str, name: &str) -> ToolCallRef {

--- a/crates/intendant-platform/src/platform.rs
+++ b/crates/intendant-platform/src/platform.rs
@@ -90,7 +90,19 @@ pub fn process_alive(pid: u32) -> bool {
     std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
 }
 
-/// Return the main display's pixel dimensions on macOS.
+/// Return the main display's dimensions on macOS, in **points** (the
+/// logical/global display coordinate space), not backing pixels.
+///
+/// The name follows the CoreGraphics functions it wraps —
+/// `CGDisplayPixelsWide/High` — whose pre-Retina names lie on scaled
+/// displays: they track the current display *mode's* point size.
+/// Empirically pinned 2026-07-15 on a 2x display: these returned 1024x640
+/// while `CGDisplayModeGetPixelWidth/Height` reported a 2048x1280 backing
+/// store (see `main_display_size_is_points_not_backing_pixels`, the
+/// `#[ignore]` probe test below, to re-adjudicate on new hardware/OS).
+/// Every caller relies on the points contract: CU treats this as the
+/// input-injection coordinate space, the Retina downscale target, and the
+/// `screencapture -R` rect space.
 ///
 /// Other platforms return `None`; callers should use their normal fallback.
 #[cfg(target_os = "macos")]
@@ -1464,6 +1476,55 @@ pub fn kill_process_group(pid: u32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Adjudication probe for the [`main_display_pixel_size`] unit contract
+    /// (points, not backing pixels): run manually on new hardware/macOS
+    /// versions with `cargo test -p intendant-platform -- --ignored
+    /// main_display_size`. `#[ignore]` because it queries the live display —
+    /// machine state — which the hermetic suite must not touch. Empirical
+    /// baseline 2026-07-15, 2x display: points 1024x640, backing 2048x1280.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore]
+    fn main_display_size_is_points_not_backing_pixels() {
+        #[link(name = "CoreGraphics", kind = "framework")]
+        extern "C" {
+            fn CGMainDisplayID() -> u32;
+            fn CGDisplayCopyDisplayMode(d: u32) -> *mut core::ffi::c_void;
+            fn CGDisplayModeGetWidth(mode: *mut core::ffi::c_void) -> usize;
+            fn CGDisplayModeGetHeight(mode: *mut core::ffi::c_void) -> usize;
+            fn CGDisplayModeGetPixelWidth(mode: *mut core::ffi::c_void) -> usize;
+            fn CGDisplayModeGetPixelHeight(mode: *mut core::ffi::c_void) -> usize;
+            fn CGDisplayModeRelease(mode: *mut core::ffi::c_void);
+        }
+
+        let reported = main_display_pixel_size().expect("a display is attached");
+        // SAFETY: CGMainDisplayID takes no arguments; CGDisplayCopyDisplayMode
+        // returns an owned mode reference (or null) for that display id, whose
+        // scalar getters take the mode pointer unchanged, and which is
+        // released exactly once below.
+        let (points, backing) = unsafe {
+            let mode = CGDisplayCopyDisplayMode(CGMainDisplayID());
+            assert!(!mode.is_null(), "main display has a mode");
+            let points = (
+                CGDisplayModeGetWidth(mode) as u32,
+                CGDisplayModeGetHeight(mode) as u32,
+            );
+            let backing = (
+                CGDisplayModeGetPixelWidth(mode) as u32,
+                CGDisplayModeGetPixelHeight(mode) as u32,
+            );
+            CGDisplayModeRelease(mode);
+            (points, backing)
+        };
+        println!("main_display_pixel_size = {reported:?}, mode points = {points:?}, mode backing pixels = {backing:?}");
+        assert_eq!(
+            reported, points,
+            "CGDisplayPixelsWide/High must track the mode's POINT size; if this \
+             ever reports backing pixels, the CU logical coordinate space and \
+             the screencapture -R clamp are both wrong — re-adjudicate"
+        );
+    }
 
     /// Drop an executable named `name` (plus the `.exe` suffix Windows
     /// resolution probes for) into `dir` and return its path.

--- a/src/bin/caller/computer_use.rs
+++ b/src/bin/caller/computer_use.rs
@@ -3377,17 +3377,31 @@ where
     T: Send + 'static,
     F: FnOnce() -> Result<T, String> + Send + 'static,
 {
-    static GATE: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(PIXEL_OFFLOAD_PERMITS);
-    // Held across the spawn_blocking await, releasing when the job's result
-    // is in. acquire() only errors if the semaphore is closed, which this
-    // static never is — degrade with an error rather than unwrap regardless.
-    let _permit = GATE
-        .acquire()
+    static GATE: std::sync::LazyLock<std::sync::Arc<tokio::sync::Semaphore>> =
+        std::sync::LazyLock::new(|| {
+            std::sync::Arc::new(tokio::sync::Semaphore::new(PIXEL_OFFLOAD_PERMITS))
+        });
+    // The permit must ride INSIDE the blocking closure: spawn_blocking work
+    // cannot be aborted once started, so if the permit stayed with this
+    // future, a caller cancelled mid-job would release it while the
+    // detached job kept running — repeated cancelled CU/MCP requests could
+    // then stack unbounded pixel jobs and defeat the cap. Owned by the
+    // closure, the permit lives exactly as long as the work does. The
+    // acquire is non-recursive by construction: no pixel closure calls
+    // back into `offload_pixels`. acquire only errors if the semaphore is
+    // closed, which this static never is — degrade with an error rather
+    // than unwrap regardless.
+    let permit = GATE
+        .clone()
+        .acquire_owned()
         .await
         .map_err(|e| format!("pixel gate closed: {e}"))?;
-    tokio::task::spawn_blocking(work)
-        .await
-        .map_err(|e| format!("screenshot task failed: {e}"))?
+    tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        work()
+    })
+    .await
+    .map_err(|e| format!("screenshot task failed: {e}"))?
 }
 
 /// Finalize a raw RGBA capture into a [`ScreenshotData`]: optional

--- a/src/bin/caller/computer_use.rs
+++ b/src/bin/caller/computer_use.rs
@@ -3354,17 +3354,37 @@ async fn execute_via_session(
 /// poll. Either way the frame served is at most this stale.
 const FRESH_FRAME_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(300);
 
+/// At most this many pixel jobs run concurrently on the blocking pool.
+/// A Retina-size decode/resize/encode holds a ~30-60MB working set; without
+/// a bound, concurrent CU sessions' captures multiply peak memory and can
+/// monopolize the shared blocking pool (which also serves AX walks, type
+/// delivery, and tokio::fs). Three permits keep two busy sessions plus one
+/// straggler flowing while capping transient pixel memory under ~200MB.
+const PIXEL_OFFLOAD_PERMITS: usize = 3;
+
 /// Run CPU/disk-heavy pixel work (PNG decode/encode, resize, annotate,
 /// artifact writes, base64) on the blocking pool instead of a tokio worker:
 /// a single Retina-size decode or encode costs 50-300ms, which would
 /// otherwise stall a runtime thread that also serves the gateway, WebRTC,
 /// and the event bus. The AX and input paths in this module already use
 /// `spawn_blocking`; this gives the pixel pipeline the same treatment.
+///
+/// Await-inline semantics: the caller waits for the result either way — the
+/// permit + blocking pool only bound *whose threads* do the work and how
+/// many pixel jobs run at once ([`PIXEL_OFFLOAD_PERMITS`]).
 async fn offload_pixels<T, F>(work: F) -> Result<T, String>
 where
     T: Send + 'static,
     F: FnOnce() -> Result<T, String> + Send + 'static,
 {
+    static GATE: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(PIXEL_OFFLOAD_PERMITS);
+    // Held across the spawn_blocking await, releasing when the job's result
+    // is in. acquire() only errors if the semaphore is closed, which this
+    // static never is — degrade with an error rather than unwrap regardless.
+    let _permit = GATE
+        .acquire()
+        .await
+        .map_err(|e| format!("pixel gate closed: {e}"))?;
     tokio::task::spawn_blocking(work)
         .await
         .map_err(|e| format!("screenshot task failed: {e}"))?
@@ -3574,6 +3594,13 @@ async fn capture_zoom_screenshot(
         // validated/clamped up front so offscreen requests keep the crop
         // path's actionable error instead of depending on screencapture's
         // out-of-bounds behavior.
+        //
+        // Unit contract (empirically pinned 2026-07-15 on a 2x display —
+        // see `main_display_pixel_size`'s docs and its `#[ignore]` probe
+        // test): `logical_display_size()` returns POINTS (1024x640 while
+        // the mode's backing store was 2048x1280), `-R` consumes POINTS,
+        // and `-R0,0,100,100` produced a 200x200px artifact — exactly what
+        // the old physical-capture + scale-2 crop produced for that region.
         DisplayBackend::MacOS => {
             let (x, y, w, h) = clamp_zoom_region_to_display(region)?;
             *counter += 1;
@@ -3594,18 +3621,21 @@ async fn capture_zoom_screenshot(
                     String::from_utf8_lossy(&output.stderr)
                 )));
             }
-            let bytes = tokio::fs::read(&path)
-                .await
-                .map_err(|e| format!("read zoom capture: {e}"))?;
-            let (width, height) = png_dimensions(&bytes).unwrap_or((0, 0));
-            use base64::Engine;
-            let base64_png = base64::engine::general_purpose::STANDARD.encode(&bytes);
-            Ok(ScreenshotData {
-                path,
-                base64_png,
-                width,
-                height,
+            // Read + base64 on the blocking pool like every other pixel
+            // site — a large-region native-res capture is still multi-MB.
+            offload_pixels(move || {
+                let bytes = std::fs::read(&path).map_err(|e| format!("read zoom capture: {e}"))?;
+                let (width, height) = png_dimensions(&bytes).unwrap_or((0, 0));
+                use base64::Engine;
+                let base64_png = base64::engine::general_purpose::STANDARD.encode(&bytes);
+                Ok(ScreenshotData {
+                    path,
+                    base64_png,
+                    width,
+                    height,
+                })
             })
+            .await
         }
         // Subprocess flavor: the source is PNG bytes (one decode, one
         // encode). The model saw the capture at native size — the region

--- a/src/bin/caller/computer_use.rs
+++ b/src/bin/caller/computer_use.rs
@@ -1147,10 +1147,16 @@ pub async fn execute_actions(
     .await;
 
     // Attach the final screenshot to the first result if it doesn't have one
-    // (convenience for callers that just want the latest screenshot from the batch).
-    let last_screenshot = results.iter().rev().find_map(|r| r.screenshot.clone());
-    if let (Some(screenshot), Some(first)) = (last_screenshot, results.first_mut()) {
-        if first.screenshot.is_none() {
+    // (convenience for callers that just want the latest screenshot from the
+    // batch). Check need before cloning: the clone carries a multi-MB base64
+    // payload, so a batch whose first result already captured (or a batch
+    // with no screenshot at all) must not pay for a clone it drops.
+    if results
+        .first()
+        .is_some_and(|first| first.screenshot.is_none())
+    {
+        let last_screenshot = results.iter().rev().find_map(|r| r.screenshot.clone());
+        if let (Some(screenshot), Some(first)) = (last_screenshot, results.first_mut()) {
             first.screenshot = Some(screenshot);
         }
     }
@@ -1505,9 +1511,14 @@ async fn verify_macos_type_readback(text: &str, dispatched: CuActionResult) -> C
     }
 }
 
-/// Get the logical display size for the main display. Cached after first call.
+/// Get the logical display size for the main display.
 /// Used to map CU model coordinates (which are in a normalized 1024-wide space)
 /// to actual logical points for input injection.
+///
+/// Re-queried per call rather than cached: the CoreGraphics lookup is an
+/// in-process call measured in microseconds, and a forever-cached value goes
+/// stale on display reconfiguration (dock/undock, resolution change),
+/// desyncing model coordinates from injection space on the fallback paths.
 ///
 /// This is a platform-agnostic *fallback* used when no active capture session
 /// is available for the target display. Prefer [`target_pixel_size`] for any
@@ -1515,15 +1526,8 @@ async fn verify_macos_type_readback(text: &str, dispatched: CuActionResult) -> C
 /// true stream/display resolution from the live session registry, which on
 /// Wayland is the only way to get the portal-granted stream size.
 pub fn logical_display_size() -> (u32, u32) {
-    use std::sync::OnceLock;
-    static SIZE: OnceLock<(u32, u32)> = OnceLock::new();
-    *SIZE.get_or_init(|| {
-        if let Some(size) = crate::platform::main_display_pixel_size() {
-            return size;
-        }
-        // Fallback: assume 1:1 mapping
-        (1024, 768)
-    })
+    // Fallback when the platform query is unavailable: assume 1:1 mapping.
+    crate::platform::main_display_pixel_size().unwrap_or((1024, 768))
 }
 
 /// Resolve the reference pixel size for denormalizing 0-1000 model coordinates.
@@ -2704,35 +2708,39 @@ async fn take_screenshot(
         }
     };
 
-    let (raw_w, raw_h) = png_dimensions(&raw_bytes).unwrap_or((0, 0));
+    let marks = marks.to_vec();
+    offload_pixels(move || {
+        let (raw_w, raw_h) = png_dimensions(&raw_bytes).unwrap_or((0, 0));
 
-    // Transform only when needed — a Retina capture to downscale to logical
-    // coordinates (macOS-only; on X11 the capture resolution IS the
-    // input-injection space) or opt-in click markers. The transform decodes
-    // once and re-encodes once via `finalize_rgba_screenshot`, which also
-    // overwrites the disk artifact so disk == model payload; the common
-    // no-transform path serves the capture bytes untouched.
-    let needs_resize = cfg!(target_os = "macos") && {
-        let (logical_w, logical_h) = logical_display_size();
-        raw_w > logical_w && logical_w > 0 && logical_h > 0
-    };
-    if needs_resize || !marks.is_empty() {
-        // Best-effort: an undecodable capture is served raw rather than
-        // failing the action over a transform.
-        if let Ok(decoded) = image::load_from_memory(&raw_bytes) {
-            return finalize_rgba_screenshot(decoded.to_rgba8(), true, marks, path);
+        // Transform only when needed — a Retina capture to downscale to logical
+        // coordinates (macOS-only; on X11 the capture resolution IS the
+        // input-injection space) or opt-in click markers. The transform decodes
+        // once and re-encodes once via `finalize_rgba_screenshot`, which also
+        // overwrites the disk artifact so disk == model payload; the common
+        // no-transform path serves the capture bytes untouched.
+        let needs_resize = cfg!(target_os = "macos") && {
+            let (logical_w, logical_h) = logical_display_size();
+            raw_w > logical_w && logical_w > 0 && logical_h > 0
+        };
+        if needs_resize || !marks.is_empty() {
+            // Best-effort: an undecodable capture is served raw rather than
+            // failing the action over a transform.
+            if let Ok(decoded) = image::load_from_memory(&raw_bytes) {
+                return finalize_rgba_screenshot(decoded.to_rgba8(), true, &marks, path);
+            }
         }
-    }
 
-    use base64::Engine;
-    let base64_png = base64::engine::general_purpose::STANDARD.encode(&raw_bytes);
+        use base64::Engine;
+        let base64_png = base64::engine::general_purpose::STANDARD.encode(&raw_bytes);
 
-    Ok(ScreenshotData {
-        path,
-        base64_png,
-        width: raw_w,
-        height: raw_h,
+        Ok(ScreenshotData {
+            path,
+            base64_png,
+            width: raw_w,
+            height: raw_h,
+        })
     })
+    .await
 }
 
 /// Extract width and height from a PNG file header.
@@ -2963,37 +2971,36 @@ async fn execute_via_session(
                     Some(ts) => session.fresh_frame(ts, FRESH_FRAME_TIMEOUT).await,
                     None => session.current_frame().await,
                 };
-                let result = match capture
-                    .map_err(|e| format!("Screenshot failed: {e}"))
-                    .and_then(|frame| {
-                        crate::display::frame_to_rgba_image(&frame)
-                            .map_err(|e| format!("decode capture: {e}"))
-                    })
-                    .and_then(|img| crop_rgba_region(&img, (*x, *y, *zw, *zh), (width, height)))
-                    .and_then(|cropped| {
-                        let bytes = crate::cu_observation::encode_rgba_png(&cropped)?;
-                        Ok((cropped.width(), cropped.height(), bytes))
-                    }) {
-                    Ok((w, h, cropped)) => {
-                        *action_counter += 1;
-                        let path = screenshot_dir.join(format!("cu_zoom_{}.png", action_counter));
-                        match std::fs::write(&path, &cropped) {
-                            Ok(()) => {
-                                use base64::Engine;
-                                let base64_png =
-                                    base64::engine::general_purpose::STANDARD.encode(&cropped);
-                                CuActionResult::captured(ScreenshotData {
-                                    path,
-                                    base64_png,
-                                    width: w,
-                                    height: h,
-                                })
-                            }
-                            Err(e) => CuActionResult::failed(format!(
-                                "Failed to write zoom screenshot: {e}"
-                            )),
-                        }
+                *action_counter += 1;
+                let path = screenshot_dir.join(format!("cu_zoom_{}.png", action_counter));
+                let region = (*x, *y, *zw, *zh);
+                // Decode/crop/encode/write on the blocking pool — the frame
+                // is a full stream-resolution capture.
+                let transformed = match capture.map_err(|e| format!("Screenshot failed: {e}")) {
+                    Ok(frame) => {
+                        offload_pixels(move || {
+                            let img = crate::display::frame_to_rgba_image(&frame)
+                                .map_err(|e| format!("decode capture: {e}"))?;
+                            let cropped = crop_rgba_region(&img, region, (width, height))?;
+                            let bytes = crate::cu_observation::encode_rgba_png(&cropped)?;
+                            std::fs::write(&path, &bytes)
+                                .map_err(|e| format!("Failed to write zoom screenshot: {e}"))?;
+                            use base64::Engine;
+                            let base64_png =
+                                base64::engine::general_purpose::STANDARD.encode(&bytes);
+                            Ok(ScreenshotData {
+                                path,
+                                base64_png,
+                                width: cropped.width(),
+                                height: cropped.height(),
+                            })
+                        })
+                        .await
                     }
+                    Err(e) => Err(e),
+                };
+                let result = match transformed {
+                    Ok(shot) => CuActionResult::captured(shot),
                     Err(e) => CuActionResult::failed(e),
                 };
                 results.push(result);
@@ -3347,10 +3354,29 @@ async fn execute_via_session(
 /// poll. Either way the frame served is at most this stale.
 const FRESH_FRAME_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(300);
 
+/// Run CPU/disk-heavy pixel work (PNG decode/encode, resize, annotate,
+/// artifact writes, base64) on the blocking pool instead of a tokio worker:
+/// a single Retina-size decode or encode costs 50-300ms, which would
+/// otherwise stall a runtime thread that also serves the gateway, WebRTC,
+/// and the event bus. The AX and input paths in this module already use
+/// `spawn_blocking`; this gives the pixel pipeline the same treatment.
+async fn offload_pixels<T, F>(work: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+{
+    tokio::task::spawn_blocking(work)
+        .await
+        .map_err(|e| format!("screenshot task failed: {e}"))?
+}
+
 /// Finalize a raw RGBA capture into a [`ScreenshotData`]: optional
 /// logical-space resize (macOS Retina), optional opt-in click markers, then
 /// exactly one PNG encode, one disk write, and one base64 encode. The disk
 /// artifact and the model payload are the same bytes by construction.
+///
+/// Pixel-heavy and synchronous by design — async callers run it (and any
+/// preceding decode) inside [`offload_pixels`].
 fn finalize_rgba_screenshot(
     mut img: image::RgbaImage,
     normalize_to_logical: bool,
@@ -3427,9 +3453,13 @@ async fn session_screenshot_data(
         None => session.current_frame().await,
     }
     .map_err(|e| format!("Screenshot failed: {}", e))?;
-    let img = crate::display::frame_to_rgba_image(&frame)
-        .map_err(|e| format!("Screenshot failed: {e}"))?;
-    finalize_rgba_screenshot(img, normalize_to_logical, marks, path)
+    let marks = marks.to_vec();
+    offload_pixels(move || {
+        let img = crate::display::frame_to_rgba_image(&frame)
+            .map_err(|e| format!("Screenshot failed: {e}"))?;
+        finalize_rgba_screenshot(img, normalize_to_logical, &marks, path)
+    })
+    .await
 }
 
 /// Capture a PNG screenshot from a `DisplaySession`.
@@ -3519,24 +3549,41 @@ async fn capture_zoom_screenshot(
                 None => session.current_frame().await,
             }
             .map_err(|e| format!("Screenshot failed: {e}"))?;
-            let img = crate::display::frame_to_rgba_image(&frame)
-                .map_err(|e| format!("Screenshot failed: {e}"))?;
-            let crop_ref = (img.width(), img.height());
-            let cropped = crop_rgba_region(&img, region, crop_ref)?;
-            let bytes = crate::cu_observation::encode_rgba_png(&cropped)?;
-            return write_zoom_screenshot(bytes, screenshot_dir, counter);
+            *counter += 1;
+            let path = screenshot_dir.join(format!("cu_zoom_{}.png", counter));
+            return offload_pixels(move || {
+                let img = crate::display::frame_to_rgba_image(&frame)
+                    .map_err(|e| format!("Screenshot failed: {e}"))?;
+                let crop_ref = (img.width(), img.height());
+                let cropped = crop_rgba_region(&img, region, crop_ref)?;
+                let bytes = crate::cu_observation::encode_rgba_png(&cropped)?;
+                write_zoom_screenshot(bytes, path)
+            })
+            .await;
         }
     }
 
-    // Subprocess flavor: the source is PNG bytes (one decode, one encode).
-    let raw = match backend {
-        // Raw capture, deliberately without the logical-size downscale
-        // (zoom's whole point is native detail).
+    match backend {
+        // Region capture (`screencapture -R`), deliberately without the
+        // logical-size downscale (zoom's whole point is native detail). The
+        // rect is in logical points — the same space the model's region is
+        // in — and the capture lands at native backing resolution (2x on
+        // Retina), so the artifact matches what the old flow produced by
+        // capturing the whole display (8-20MB on Retina), writing it, reading
+        // it back, decoding, cropping, and re-encoding. The region is
+        // validated/clamped up front so offscreen requests keep the crop
+        // path's actionable error instead of depending on screencapture's
+        // out-of-bounds behavior.
         DisplayBackend::MacOS => {
+            let (x, y, w, h) = clamp_zoom_region_to_display(region)?;
             *counter += 1;
-            let path = screenshot_dir.join(format!("cu_zoom_raw_{}.png", counter));
+            let path = screenshot_dir.join(format!("cu_zoom_{}.png", counter));
             let output = Command::new("screencapture")
-                .args(["-x", &path.to_string_lossy()])
+                .args([
+                    "-x",
+                    &format!("-R{},{},{},{}", x, y, w, h),
+                    &path.to_string_lossy(),
+                ])
                 .output()
                 .await
                 .map_err(|e| format!("screencapture exec error: {e}"))?;
@@ -3550,35 +3597,76 @@ async fn capture_zoom_screenshot(
             let bytes = tokio::fs::read(&path)
                 .await
                 .map_err(|e| format!("read zoom capture: {e}"))?;
-            let _ = tokio::fs::remove_file(&path).await;
-            bytes
+            let (width, height) = png_dimensions(&bytes).unwrap_or((0, 0));
+            use base64::Engine;
+            let base64_png = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            Ok(ScreenshotData {
+                path,
+                base64_png,
+                width,
+                height,
+            })
         }
-        _ => x11_cu::screenshot_png(display)
+        // Subprocess flavor: the source is PNG bytes (one decode, one
+        // encode). The model saw the capture at native size — the region
+        // already is in capture pixels (scale = 1).
+        _ => {
+            let raw = x11_cu::screenshot_png(display)
+                .await
+                .map_err(|e| format!("zoom capture failed: {e}"))?;
+            *counter += 1;
+            let path = screenshot_dir.join(format!("cu_zoom_{}.png", counter));
+            offload_pixels(move || {
+                let crop_ref = png_dimensions(&raw).unwrap_or_else(logical_display_size);
+                let cropped = crop_png_region(&raw, region, crop_ref)?;
+                write_zoom_screenshot(cropped, path)
+            })
             .await
-            .map_err(|e| format!("zoom capture failed: {e}"))?,
-    };
-
-    // Crop reference: on macOS the model's region is in logical points while
-    // `raw` may be a physical-resolution capture (2x Retina), so the region
-    // must be scaled up. Everywhere else the model saw the capture at native
-    // size — the region already is in capture pixels (scale = 1).
-    let crop_ref = match backend {
-        DisplayBackend::MacOS => logical_display_size(),
-        _ => png_dimensions(&raw).unwrap_or_else(logical_display_size),
-    };
-    let cropped = crop_png_region(&raw, region, crop_ref)?;
-    write_zoom_screenshot(cropped, screenshot_dir, counter)
+        }
+    }
 }
 
-/// Write encoded zoom PNG bytes to the next `cu_zoom_N.png` artifact and
-/// package the [`ScreenshotData`].
-fn write_zoom_screenshot(
-    cropped: Vec<u8>,
-    screenshot_dir: &Path,
-    counter: &mut u64,
-) -> Result<ScreenshotData, String> {
-    *counter += 1;
-    let path = screenshot_dir.join(format!("cu_zoom_{}.png", counter));
+/// Validate and clamp a zoom region (logical points) against the logical
+/// display bounds, mirroring [`crop_rgba_region`]'s rules so the macOS `-R`
+/// region capture keeps the same actionable errors the crop path produced.
+fn clamp_zoom_region_to_display(
+    region: (i32, i32, u32, u32),
+) -> Result<(i32, i32, u32, u32), String> {
+    clamp_zoom_region(region, logical_display_size())
+}
+
+/// Pure core of [`clamp_zoom_region_to_display`]: `display` is the logical
+/// display size. When the display size is unknown (`0`, platform query
+/// failed) the region is passed through and `screencapture` performs its
+/// own intersection.
+fn clamp_zoom_region(
+    region: (i32, i32, u32, u32),
+    display: (u32, u32),
+) -> Result<(i32, i32, u32, u32), String> {
+    let (x, y, w, h) = region;
+    if w == 0 || h == 0 {
+        return Err("zoom region must have a non-zero width and height".to_string());
+    }
+    let (dw, dh) = display;
+    let cx = x.max(0);
+    let cy = y.max(0);
+    if dw == 0 || dh == 0 {
+        return Ok((cx, cy, w, h));
+    }
+    if cx >= dw as i32 || cy >= dh as i32 {
+        return Err(format!(
+            "zoom region ({x},{y} {w}x{h}) lies outside the {dw}x{dh} display"
+        ));
+    }
+    let cw = w.min(dw - cx as u32).max(1);
+    let ch = h.min(dh - cy as u32).max(1);
+    Ok((cx, cy, cw, ch))
+}
+
+/// Write encoded zoom PNG bytes to the `cu_zoom_N.png` artifact at `path`
+/// and package the [`ScreenshotData`]. Synchronous (disk write + base64) —
+/// async callers run it inside [`offload_pixels`].
+fn write_zoom_screenshot(cropped: Vec<u8>, path: PathBuf) -> Result<ScreenshotData, String> {
     std::fs::write(&path, &cropped).map_err(|e| format!("write zoom screenshot: {e}"))?;
     let (width, height) = png_dimensions(&cropped).unwrap_or((0, 0));
     use base64::Engine;
@@ -3890,6 +3978,41 @@ mod tests {
         assert_eq!(normalized_to_pixels(0, 0, 1440, 900), (0, 0));
         assert_eq!(normalized_to_pixels(999, 999, 1440, 900), (1440, 900));
         assert_eq!(normalized_to_pixels(500, 500, 1440, 900), (721, 450));
+    }
+
+    #[test]
+    fn clamp_zoom_region_rejects_empty_and_offscreen() {
+        assert!(clamp_zoom_region((10, 10, 0, 40), (1440, 900)).is_err());
+        assert!(clamp_zoom_region((10, 10, 40, 0), (1440, 900)).is_err());
+        // Fully offscreen: same actionable-error class the crop path had.
+        let err = clamp_zoom_region((2000, 10, 40, 40), (1440, 900)).unwrap_err();
+        assert!(err.contains("lies outside"), "{err}");
+        assert!(clamp_zoom_region((10, 900, 40, 40), (1440, 900)).is_err());
+    }
+
+    #[test]
+    fn clamp_zoom_region_clamps_to_bounds() {
+        // In-bounds region passes through untouched.
+        assert_eq!(
+            clamp_zoom_region((10, 20, 300, 200), (1440, 900)),
+            Ok((10, 20, 300, 200))
+        );
+        // Negative origin clamps to 0 (mirrors `crop_rgba_region`'s
+        // `x.max(0)`), size clamps to the remaining span.
+        assert_eq!(
+            clamp_zoom_region((-50, -5, 300, 200), (1440, 900)),
+            Ok((0, 0, 300, 200))
+        );
+        // Overhanging region shrinks to the display edge, min 1px.
+        assert_eq!(
+            clamp_zoom_region((1400, 880, 300, 200), (1440, 900)),
+            Ok((1400, 880, 40, 20))
+        );
+        // Unknown display size: passed through for screencapture to clip.
+        assert_eq!(
+            clamp_zoom_region((10, 20, 5000, 5000), (0, 0)),
+            Ok((10, 20, 5000, 5000))
+        );
     }
 
     fn leaf(role: &str, label: Option<&str>, frame: (i32, i32, u32, u32)) -> UiElement {

--- a/src/bin/caller/linux_display_env.rs
+++ b/src/bin/caller/linux_display_env.rs
@@ -30,8 +30,13 @@ pub struct GuiEnvAdoption {
 }
 
 /// How often the probe may re-fork `systemctl --user show-environment`
-/// while no display variable has appeared yet (daemon started before
-/// graphical login). Bounds how stale a fresh login's env can look.
+/// while the env is not settled — i.e. until a successful probe has seen
+/// the complete managed set. This cadence-gates EVERY unsettled call: a
+/// daemon started before graphical login upgrades within one interval of
+/// the user logging in, and a host whose env can never complete (a pure
+/// X11 desktop has no `WAYLAND_DISPLAY` to adopt, however healthy its
+/// display) keeps probing at this rate forever — one fork per interval is
+/// the accepted cost of staying able to adopt late-appearing session vars.
 #[cfg(target_os = "linux")]
 const PROBE_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 

--- a/src/bin/caller/linux_display_env.rs
+++ b/src/bin/caller/linux_display_env.rs
@@ -41,14 +41,14 @@ mod probe_gate {
     use std::sync::Mutex;
     use std::time::Instant;
 
-    /// Set once a probe has run while a display variable (`DISPLAY` /
-    /// `WAYLAND_DISPLAY`) was present in the process env — whether inherited
-    /// or adopted by that probe. From that point the graphical session is
-    /// up, and keys still missing (e.g. `WAYLAND_DISPLAY` on an X11
-    /// desktop) will never appear, so re-forking is pure waste.
+    /// Set once a probe has run **successfully** while the post-adoption
+    /// env was complete (every managed key present). Only then is there
+    /// provably nothing left for a future probe to do. A partial env —
+    /// e.g. a daemon that inherited `DISPLAY=:0` before the user bus was
+    /// ready — must NOT settle: later probes can still adopt XAUTHORITY /
+    /// WAYLAND_DISPLAY / DBUS vars, so it stays on the retry cadence.
     pub(super) static SETTLED: AtomicBool = AtomicBool::new(false);
-    /// When the probe last forked, for rate-limiting the waiting-for-login
-    /// retry loop.
+    /// When the probe last forked, for rate-limiting unsettled retries.
     pub(super) static LAST_ATTEMPT: Mutex<Option<Instant>> = Mutex::new(None);
 }
 
@@ -64,9 +64,13 @@ pub fn ensure_gui_session_env(context: &str) -> GuiEnvAdoption {
     // the steady-state path:
     //
     // 1. Complete env: every managed key is set — nothing to adopt, free.
-    // 2. Settled: see `probe_gate::SETTLED` — never fork again.
-    // 3. Waiting for login: no display variable yet — keep probing, but at
-    //    most once per `PROBE_RETRY_INTERVAL` instead of per call.
+    // 2. Settled: a successful probe already saw the complete env — never
+    //    fork again (see `probe_gate::SETTLED`).
+    // 3. Otherwise: probe at most once per `PROBE_RETRY_INTERVAL` instead
+    //    of per call. Environments that can never complete (a pure-X11
+    //    desktop has no WAYLAND_DISPLAY to adopt) keep this cadence
+    //    forever — one fork per interval is the accepted cost of staying
+    //    able to adopt late-appearing session vars.
     if probe_gate::SETTLED.load(Ordering::Relaxed) || gui_env_complete() {
         return GuiEnvAdoption::default();
     }
@@ -75,18 +79,18 @@ pub fn ensure_gui_session_env(context: &str) -> GuiEnvAdoption {
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         let now = std::time::Instant::now();
-        if !display_env_present() {
-            if let Some(prev) = *last {
-                if now.duration_since(prev) < PROBE_RETRY_INTERVAL {
-                    return GuiEnvAdoption::default();
-                }
+        if let Some(prev) = *last {
+            if now.duration_since(prev) < PROBE_RETRY_INTERVAL {
+                return GuiEnvAdoption::default();
             }
         }
         *last = Some(now);
     }
 
-    let report = match read_systemd_user_environment() {
-        Some(systemd_env) => adopt_from_map(&systemd_env),
+    let systemd_env = read_systemd_user_environment();
+    let probe_succeeded = systemd_env.is_some();
+    let report = match systemd_env {
+        Some(env) => adopt_from_map(&env),
         None => GuiEnvAdoption::default(),
     };
     if !report.adopted.is_empty() {
@@ -103,30 +107,27 @@ pub fn ensure_gui_session_env(context: &str) -> GuiEnvAdoption {
             report.skipped.join(", ")
         );
     }
-    if display_env_present() {
+    if probe_succeeded && gui_env_complete() {
         probe_gate::SETTLED.store(true, Ordering::Relaxed);
     }
     report
 }
 
-/// Whether a display variable is present in the process env. Mirrors
-/// `adopt_from_map`'s skip test (`var_os(..).is_some()`): a set-but-empty
-/// value is one the probe could not replace anyway.
-#[cfg(target_os = "linux")]
-fn display_env_present() -> bool {
-    std::env::var_os("DISPLAY").is_some() || std::env::var_os("WAYLAND_DISPLAY").is_some()
-}
-
 /// Whether every variable the probe manages is already set — including
 /// `INTENDANT_USER_DISPLAY`, which `adopt_from_map` derives from the
 /// systemd `DISPLAY`. When true the probe cannot adopt anything, by
-/// construction.
+/// construction (`adopt_from_map` skips keys that are set).
 #[cfg(target_os = "linux")]
 fn gui_env_complete() -> bool {
-    GUI_ENV_KEYS
-        .iter()
-        .all(|key| std::env::var_os(key).is_some())
-        && std::env::var_os("INTENDANT_USER_DISPLAY").is_some()
+    gui_env_complete_with(|key| std::env::var_os(key).is_some())
+}
+
+/// Pure core of [`gui_env_complete`]: `is_set` reports whether an env key
+/// is present. Split out so the completeness predicate is testable without
+/// touching the real process environment.
+#[cfg(target_os = "linux")]
+fn gui_env_complete_with(is_set: impl Fn(&str) -> bool) -> bool {
+    GUI_ENV_KEYS.iter().all(|key| is_set(key)) && is_set("INTENDANT_USER_DISPLAY")
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -327,6 +328,21 @@ fn parse_local_display_number(display: &str) -> Option<u32> {
 #[cfg(target_os = "linux")]
 mod tests {
     use super::*;
+
+    /// A partial env (e.g. DISPLAY inherited before the user bus is ready)
+    /// must not read as complete — settling on it would permanently stop
+    /// the probe from adopting the still-missing session vars.
+    #[test]
+    fn gui_env_completeness_requires_every_managed_key() {
+        // Display var alone: incomplete.
+        assert!(!gui_env_complete_with(|key| key == "DISPLAY"));
+        // Everything except one managed key: still incomplete.
+        assert!(!gui_env_complete_with(|key| key != "XAUTHORITY"));
+        // The derived key counts too.
+        assert!(!gui_env_complete_with(|key| key != "INTENDANT_USER_DISPLAY"));
+        // Full set: complete.
+        assert!(gui_env_complete_with(|_| true));
+    }
 
     #[test]
     fn parses_systemd_show_environment() {

--- a/src/bin/caller/linux_display_env.rs
+++ b/src/bin/caller/linux_display_env.rs
@@ -29,12 +29,66 @@ pub struct GuiEnvAdoption {
     pub source: Option<String>,
 }
 
+/// How often the probe may re-fork `systemctl --user show-environment`
+/// while no display variable has appeared yet (daemon started before
+/// graphical login). Bounds how stale a fresh login's env can look.
+#[cfg(target_os = "linux")]
+const PROBE_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+
+#[cfg(target_os = "linux")]
+mod probe_gate {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Mutex;
+    use std::time::Instant;
+
+    /// Set once a probe has run while a display variable (`DISPLAY` /
+    /// `WAYLAND_DISPLAY`) was present in the process env — whether inherited
+    /// or adopted by that probe. From that point the graphical session is
+    /// up, and keys still missing (e.g. `WAYLAND_DISPLAY` on an X11
+    /// desktop) will never appear, so re-forking is pure waste.
+    pub(super) static SETTLED: AtomicBool = AtomicBool::new(false);
+    /// When the probe last forked, for rate-limiting the waiting-for-login
+    /// retry loop.
+    pub(super) static LAST_ATTEMPT: Mutex<Option<Instant>> = Mutex::new(None);
+}
+
 #[cfg(target_os = "linux")]
 pub fn ensure_gui_session_env(context: &str) -> GuiEnvAdoption {
-    let Some(systemd_env) = read_systemd_user_environment() else {
+    use std::sync::atomic::Ordering;
+
+    // `adopt_from_map` never overwrites a variable that is already set, so
+    // re-running the probe helps only while adoptable keys are missing AND
+    // the systemd user environment could still gain them. This used to fork
+    // `systemctl --user show-environment` unconditionally — on every runtime
+    // spawn, CU action batch, and screenshot. Three tiers keep the fork off
+    // the steady-state path:
+    //
+    // 1. Complete env: every managed key is set — nothing to adopt, free.
+    // 2. Settled: see `probe_gate::SETTLED` — never fork again.
+    // 3. Waiting for login: no display variable yet — keep probing, but at
+    //    most once per `PROBE_RETRY_INTERVAL` instead of per call.
+    if probe_gate::SETTLED.load(Ordering::Relaxed) || gui_env_complete() {
         return GuiEnvAdoption::default();
+    }
+    {
+        let mut last = probe_gate::LAST_ATTEMPT
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let now = std::time::Instant::now();
+        if !display_env_present() {
+            if let Some(prev) = *last {
+                if now.duration_since(prev) < PROBE_RETRY_INTERVAL {
+                    return GuiEnvAdoption::default();
+                }
+            }
+        }
+        *last = Some(now);
+    }
+
+    let report = match read_systemd_user_environment() {
+        Some(systemd_env) => adopt_from_map(&systemd_env),
+        None => GuiEnvAdoption::default(),
     };
-    let report = adopt_from_map(&systemd_env);
     if !report.adopted.is_empty() {
         eprintln!(
             "[linux_display_env] {context}: adopted GUI env from {}: {}",
@@ -49,7 +103,30 @@ pub fn ensure_gui_session_env(context: &str) -> GuiEnvAdoption {
             report.skipped.join(", ")
         );
     }
+    if display_env_present() {
+        probe_gate::SETTLED.store(true, Ordering::Relaxed);
+    }
     report
+}
+
+/// Whether a display variable is present in the process env. Mirrors
+/// `adopt_from_map`'s skip test (`var_os(..).is_some()`): a set-but-empty
+/// value is one the probe could not replace anyway.
+#[cfg(target_os = "linux")]
+fn display_env_present() -> bool {
+    std::env::var_os("DISPLAY").is_some() || std::env::var_os("WAYLAND_DISPLAY").is_some()
+}
+
+/// Whether every variable the probe manages is already set — including
+/// `INTENDANT_USER_DISPLAY`, which `adopt_from_map` derives from the
+/// systemd `DISPLAY`. When true the probe cannot adopt anything, by
+/// construction.
+#[cfg(target_os = "linux")]
+fn gui_env_complete() -> bool {
+    GUI_ENV_KEYS
+        .iter()
+        .all(|key| std::env::var_os(key).is_some())
+        && std::env::var_os("INTENDANT_USER_DISPLAY").is_some()
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -1149,12 +1149,26 @@ async fn maybe_auto_launch_xvfb(
     // Memoized accessible-display verdict: this function runs on every
     // exec/captureScreen batch, `is_display_accessible()` forks `xdpyinfo`
     // per call on Linux, and the probe result feeds only the one-time log
-    // line below. Only the accessible outcome is sticky — while no display
+    // line below. Only the accessible outcome is memoized — while no display
     // exists we keep probing, so a machine that gains an X server later (or
-    // retries after a failed Xvfb launch) is still picked up.
-    static EXISTING_DISPLAY: std::sync::OnceLock<(u32, u32, u32)> = std::sync::OnceLock::new();
-    if EXISTING_DISPLAY.get().is_some() {
-        return;
+    // retries after a failed Xvfb launch) is still picked up. The memo is
+    // NOT blindly sticky: before trusting it, revalidate fork-free that the
+    // display is still alive (`existing_display_memo_still_valid`) — a
+    // session can latch onto another session's Xvfb, and once that owner's
+    // guard kills the server, a sticky memo would pin every later batch to
+    // a dead display and auto-launch could never self-heal.
+    static EXISTING_DISPLAY: std::sync::Mutex<Option<(u32, u32, u32)>> =
+        std::sync::Mutex::new(None);
+    {
+        let mut memo = EXISTING_DISPLAY.lock().unwrap_or_else(|e| e.into_inner());
+        if memo.is_some() {
+            if existing_display_memo_still_valid() {
+                return;
+            }
+            // The memoized display died — clear and fall through to the
+            // full probe so Xvfb auto-launch can recover.
+            *memo = None;
+        }
     }
     // If a display is already accessible (e.g. DISPLAY was set before launch,
     // or on macOS where the native display is always available), skip Xvfb.
@@ -1168,7 +1182,8 @@ async fn maybe_auto_launch_xvfb(
             .and_then(|d| d.trim_start_matches(':').parse::<u32>().ok())
             .unwrap_or(default_display);
         let (width, height) = query_display_resolution(display_id);
-        let _ = EXISTING_DISPLAY.set((display_id, width, height));
+        *EXISTING_DISPLAY.lock().unwrap_or_else(|e| e.into_inner()) =
+            Some((display_id, width, height));
         slog(session_log, |l| {
             l.info(&format!(
                 "Using existing display :{} ({}x{}) — no web slot (no DisplaySession)",
@@ -1211,6 +1226,36 @@ async fn maybe_auto_launch_xvfb(
             });
         }
     }
+}
+
+/// Whether the display the accessible-display memo trusted is still
+/// plausibly alive, without forking a probe.
+///
+/// macOS: the native display is always accessible
+/// (`vision::is_display_accessible` is constant `true` there), so the memo
+/// cannot go stale. X11: stat the current `DISPLAY`'s socket — an Xvfb
+/// killed by its owning session's `XvfbGuard` removes `/tmp/.X11-unix/X<n>`.
+/// Non-local `DISPLAY` values (ssh forwarding, `host:10.0`) have no socket
+/// to stat: treat as not-validated so the full probe re-runs each batch,
+/// matching pre-memo behavior for those setups.
+fn existing_display_memo_still_valid() -> bool {
+    if cfg!(target_os = "macos") {
+        return true;
+    }
+    match std::env::var("DISPLAY") {
+        Ok(display) => x11_socket_path_in(std::path::Path::new("/tmp/.X11-unix"), &display)
+            .map(|path| path.exists())
+            .unwrap_or(false),
+        Err(_) => false,
+    }
+}
+
+/// `<socket_dir>/X<n>` for a local `:<n>[.screen]` DISPLAY value; `None`
+/// for non-local forms (anything not starting with `:`).
+fn x11_socket_path_in(socket_dir: &std::path::Path, display: &str) -> Option<std::path::PathBuf> {
+    let rest = display.strip_prefix(':')?;
+    let num: u32 = rest.split('.').next()?.parse().ok()?;
+    Some(socket_dir.join(format!("X{num}")))
 }
 
 /// Query the resolution of the native display.
@@ -1423,6 +1468,35 @@ fn normalize_command_batch(json_str: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The accessible-display memo must stop being trusted the moment the
+    /// memoized X display's socket disappears (another session's XvfbGuard
+    /// killing its server), so the probe path is re-entered and auto-launch
+    /// can self-heal. `x11_socket_path_in` is the fork-free liveness check
+    /// behind `existing_display_memo_still_valid`.
+    #[test]
+    fn x11_socket_liveness_tracks_socket_file() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Local display forms resolve to their socket path.
+        let sock = x11_socket_path_in(dir.path(), ":99").unwrap();
+        assert_eq!(sock, dir.path().join("X99"));
+        assert_eq!(
+            x11_socket_path_in(dir.path(), ":0.0").unwrap(),
+            dir.path().join("X0")
+        );
+        // Non-local / malformed forms have no socket to stat.
+        assert!(x11_socket_path_in(dir.path(), "localhost:10.0").is_none());
+        assert!(x11_socket_path_in(dir.path(), "").is_none());
+        assert!(x11_socket_path_in(dir.path(), ":abc").is_none());
+
+        // Memo-trust flow: socket present → still valid; socket removed
+        // (guard killed the Xvfb) → stale, probe path re-entered.
+        std::fs::write(&sock, b"").unwrap();
+        assert!(sock.exists());
+        std::fs::remove_file(&sock).unwrap();
+        assert!(!sock.exists());
+    }
 
     /// The idle queued-steer flush synthesizes an EMPTY task envelope per
     /// flush; logging it produced spurious "[runtime] Task dispatched: "

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -1146,6 +1146,16 @@ async fn maybe_auto_launch_xvfb(
     if !has_capture_screen_command(json_str) && !has_exec_command(json_str) {
         return;
     }
+    // Memoized accessible-display verdict: this function runs on every
+    // exec/captureScreen batch, `is_display_accessible()` forks `xdpyinfo`
+    // per call on Linux, and the probe result feeds only the one-time log
+    // line below. Only the accessible outcome is sticky — while no display
+    // exists we keep probing, so a machine that gains an X server later (or
+    // retries after a failed Xvfb launch) is still picked up.
+    static EXISTING_DISPLAY: std::sync::OnceLock<(u32, u32, u32)> = std::sync::OnceLock::new();
+    if EXISTING_DISPLAY.get().is_some() {
+        return;
+    }
     // If a display is already accessible (e.g. DISPLAY was set before launch,
     // or on macOS where the native display is always available), skip Xvfb.
     // Don't emit DisplayReady — no DisplaySession exists, so the web dashboard
@@ -1158,6 +1168,7 @@ async fn maybe_auto_launch_xvfb(
             .and_then(|d| d.trim_start_matches(':').parse::<u32>().ok())
             .unwrap_or(default_display);
         let (width, height) = query_display_resolution(display_id);
+        let _ = EXISTING_DISPLAY.set((display_id, width, height));
         slog(session_log, |l| {
             l.info(&format!(
                 "Using existing display :{} ({}x{}) — no web slot (no DisplaySession)",
@@ -1202,25 +1213,19 @@ async fn maybe_auto_launch_xvfb(
     }
 }
 
-/// Query the resolution of the native display via system_profiler.
-/// Returns the logical (point) resolution, not device pixels.
-/// Uses CoreGraphics via swift, which returns logical resolution directly
+/// Query the resolution of the native display.
+/// Returns the logical (point) resolution, not device pixels
 /// (e.g. 1339x837 on a Retina display, not the 2x device pixel size).
-/// Falls back to system_profiler, then a default.
+/// Primary method is an in-process CoreGraphics query; falls back to
+/// system_profiler, then a default.
 #[cfg(target_os = "macos")]
 pub(crate) fn query_display_resolution(_display_id: u32) -> (u32, u32) {
-    // Primary method: CoreGraphics (works in VMs where system_profiler is empty)
-    if let Ok(out) = std::process::Command::new("swift")
-        .args(["-e", "import CoreGraphics; let d = CGMainDisplayID(); print(\"\\(CGDisplayPixelsWide(d))x\\(CGDisplayPixelsHigh(d))\")"])
-        .output()
-    {
-        let text = String::from_utf8_lossy(&out.stdout).trim().to_string();
-        let parts: Vec<&str> = text.split('x').collect();
-        if parts.len() == 2 {
-            if let (Ok(w), Ok(h)) = (parts[0].parse(), parts[1].parse()) {
-                return (w, h);
-            }
-        }
+    // Primary method: in-process CoreGraphics (works in VMs where
+    // system_profiler is empty). Same CGDisplayPixels* calls the retired
+    // `swift -e` subprocess made — that spawn JIT-compiled a Swift snippet
+    // (~0.5-2s) per query; the FFI call is microseconds and topology-fresh.
+    if let Some((w, h)) = platform::main_display_pixel_size() {
+        return (w, h);
     }
     // Fallback: system_profiler (may be empty in VMs)
     if let Ok(out) = std::process::Command::new("system_profiler")

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -101,6 +101,25 @@ pub fn presence_tools() -> Vec<crate::tools::ToolDefinition> {
 const NARRATION_DEBOUNCE: std::time::Duration =
     std::time::Duration::from_millis(NARRATION_DEBOUNCE_MS);
 
+/// Proactive compaction threshold for the presence conversation, as a
+/// fraction of the context window. Presence re-sends its entire transcript
+/// on every narration (≥1 model call per pushed event, forever, in a
+/// long-lived daemon), so the shared 90% default — ~944k tokens on the
+/// default 1M-token window — would let every narration carry a nearly full
+/// window before anything was trimmed. 10% caps the steady-state narration
+/// prompt at ~105k tokens on the default window and scales down with
+/// smaller configured windows.
+const PRESENCE_COMPACT_THRESHOLD: f64 = 0.10;
+
+/// How many trailing messages survive a presence compaction verbatim.
+/// The worker default (4) is tuned for tool-loop transcripts whose state is
+/// re-derivable; presence interleaves *user chat* with event narrations,
+/// and the compaction summary is a generic marker, not a real summary — a
+/// 4-message tail would routinely swallow the user's last exchange
+/// mid-conversation. 32 keeps the last few minutes of narration plus any
+/// recent chat intact.
+const PRESENCE_COMPACT_KEEP_SUFFIX: usize = 32;
+
 /// The running presence layer instance (platform-specific, uses tokio + ChatProvider).
 pub struct PresenceLayer {
     provider: Box<dyn ChatProvider>,
@@ -287,8 +306,10 @@ impl PresenceLayer {
                 Some(crate::types::LogLevel::Detail),
             );
 
-            let messages = self.conversation.messages().to_vec();
-            let response = self.provider.chat(&messages).await?;
+            // Borrow the transcript directly — `chat` takes `&[Message]`,
+            // and a `to_vec()` here deep-cloned every message string per
+            // model round.
+            let response = self.provider.chat(self.conversation.messages()).await?;
 
             self.plog(
                 format!(
@@ -305,7 +326,8 @@ impl PresenceLayer {
             self.cumulative_cached += response.usage.cached_tokens;
             self.cumulative_cache_creation += response.usage.cache_creation_tokens;
             self.conversation.set_usage(response.usage.clone());
-            self.conversation.auto_compact();
+            self.conversation
+                .auto_compact_at(PRESENCE_COMPACT_THRESHOLD, PRESENCE_COMPACT_KEEP_SUFFIX);
 
             if response.tool_calls.is_empty() {
                 if !response.content.is_empty() {
@@ -1226,6 +1248,16 @@ pub fn is_agent_idle(phase: &str) -> bool {
     ) || phase.starts_with("done")
 }
 
+/// First `max_chars` characters of `s` as a borrowed slice (char-boundary
+/// safe). Unlike [`truncate`] this allocates nothing and never appends an
+/// ellipsis — callers pass the result through `truncate` for that.
+fn clip_chars(s: &str, max_chars: usize) -> &str {
+    match s.char_indices().nth(max_chars) {
+        Some((i, _)) => &s[..i],
+        None => s,
+    }
+}
+
 pub fn update_agent_state(event: &AppEvent, state: &Arc<Mutex<AgentStateSnapshot>>) {
     let mut s = state.lock().unwrap_or_else(|e| e.into_inner());
     match event {
@@ -1248,11 +1280,16 @@ pub fn update_agent_state(event: &AppEvent, state: &Arc<Mutex<AgentStateSnapshot
             s.pending_question = None;
         }
         AppEvent::AgentOutput { stdout, stderr, .. } => {
-            // Keep a truncated summary
+            // Keep a truncated summary. Clip each stream to the summary
+            // window before combining — command output can run to hundreds
+            // of KB per event and only the first 500 chars ever survive, so
+            // cloning the full payload was pure waste. Clipping at max+1
+            // chars preserves `truncate`'s exact output, including the
+            // ellipsis decision.
             let combined = if stderr.is_empty() {
-                stdout.clone()
+                clip_chars(stdout, 501).to_string()
             } else {
-                format!("{}\n{}", stdout, stderr)
+                format!("{}\n{}", clip_chars(stdout, 501), clip_chars(stderr, 501))
             };
             s.last_output_summary = truncate(&combined, 500);
         }
@@ -1736,6 +1773,33 @@ mod tests {
     #[test]
     fn truncate_long_string() {
         assert_eq!(truncate("hello world", 5), "hello...");
+    }
+
+    /// The clip-before-combine fast path in `update_agent_state` must
+    /// produce byte-identical summaries to truncating the full combined
+    /// output, including the ellipsis decision at every boundary.
+    #[test]
+    fn clip_chars_combine_matches_full_truncate() {
+        let cases = [0usize, 1, 498, 499, 500, 501, 502, 2000];
+        for &a_len in &cases {
+            for &b_len in &cases {
+                let stdout = "a".repeat(a_len);
+                let stderr = "é".repeat(b_len); // multi-byte chars
+                let full = format!("{}\n{}", stdout, stderr);
+                let clipped = format!("{}\n{}", clip_chars(&stdout, 501), clip_chars(&stderr, 501));
+                assert_eq!(
+                    truncate(&clipped, 500),
+                    truncate(&full, 500),
+                    "a_len={a_len} b_len={b_len}"
+                );
+                // stderr-empty arm: clip alone must match too.
+                assert_eq!(
+                    truncate(clip_chars(&stdout, 501), 500),
+                    truncate(&stdout, 500),
+                    "a_len={a_len}"
+                );
+            }
+        }
     }
 
     // ── PresenceSession tests ──

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -109,7 +109,24 @@ const NARRATION_DEBOUNCE: std::time::Duration =
 /// window before anything was trimmed. 10% caps the steady-state narration
 /// prompt at ~105k tokens on the default window and scales down with
 /// smaller configured windows.
+///
+/// Deliberate design limit (decided, not an oversight): compaction replaces
+/// the middle of the transcript with a static marker — no LLM summarization
+/// happens (`Conversation` is a data type and must not call a model), so
+/// presence context older than the kept tail is dropped un-summarized.
+/// That is acceptable here because presence is *narration, not memory*:
+/// the worker session's own context remains authoritative, and presence
+/// tools re-query live state. If standing user instructions to presence
+/// need to survive indefinitely, a real summarization pass before
+/// compaction is the follow-up, not a bigger window.
 const PRESENCE_COMPACT_THRESHOLD: f64 = 0.10;
+
+/// How many leading messages a presence compaction pins verbatim. The
+/// presence conversation starts with only its system message — unlike the
+/// worker (which pins 3: system + its working-directory/ack context pair),
+/// pinning more here would freeze the first user/assistant exchange
+/// forever as if it were context.
+const PRESENCE_COMPACT_KEEP_PREFIX: usize = 1;
 
 /// How many trailing messages survive a presence compaction verbatim.
 /// The worker default (4) is tuned for tool-loop transcripts whose state is
@@ -326,8 +343,11 @@ impl PresenceLayer {
             self.cumulative_cached += response.usage.cached_tokens;
             self.cumulative_cache_creation += response.usage.cache_creation_tokens;
             self.conversation.set_usage(response.usage.clone());
-            self.conversation
-                .auto_compact_at(PRESENCE_COMPACT_THRESHOLD, PRESENCE_COMPACT_KEEP_SUFFIX);
+            self.conversation.auto_compact_at(
+                PRESENCE_COMPACT_THRESHOLD,
+                PRESENCE_COMPACT_KEEP_PREFIX,
+                PRESENCE_COMPACT_KEEP_SUFFIX,
+            );
 
             if response.tool_calls.is_empty() {
                 if !response.content.is_empty() {

--- a/src/bin/caller/session_config.rs
+++ b/src/bin/caller/session_config.rs
@@ -980,11 +980,26 @@ fn find_wrapper_config_for_external_session(
     }
 
     let entries = std::fs::read_dir(logs_dir).ok()?;
-    for entry in entries.flatten() {
-        let dir = entry.path();
-        if !dir.is_dir() {
-            continue;
-        }
+    // Newest first: a resumed session is almost always among the most recent
+    // stores, and the per-directory identity check below can end up reading
+    // session logs — in readdir order a hit near the end pays that cost
+    // across the whole store.
+    let mut dirs: Vec<(std::time::SystemTime, std::path::PathBuf)> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let dir = entry.path();
+            if !dir.is_dir() {
+                return None;
+            }
+            let modified = entry
+                .metadata()
+                .and_then(|meta| meta.modified())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+            Some((modified, dir))
+        })
+        .collect();
+    dirs.sort_by_key(|entry| std::cmp::Reverse(entry.0));
+    for (_, dir) in dirs {
         let Some(mut config) = read_log_dir_config(&dir) else {
             continue;
         };

--- a/src/bin/caller/session_config.rs
+++ b/src/bin/caller/session_config.rs
@@ -983,7 +983,12 @@ fn find_wrapper_config_for_external_session(
     // Newest first: a resumed session is almost always among the most recent
     // stores, and the per-directory identity check below can end up reading
     // session logs — in readdir order a hit near the end pays that cost
-    // across the whole store.
+    // across the whole store. The sort key is the wrapper CONFIG file's
+    // mtime, not the directory's: unrelated bookkeeping rewrites bump a
+    // store dir's mtime, while the config file only changes when the launch
+    // config itself is (re)written. Directories without a config sort last
+    // (epoch) but stay in the scan — the loop below skips them exactly as
+    // before, preserving the exhaustive-until-exact-match semantics.
     let mut dirs: Vec<(std::time::SystemTime, std::path::PathBuf)> = entries
         .flatten()
         .filter_map(|entry| {
@@ -991,8 +996,7 @@ fn find_wrapper_config_for_external_session(
             if !dir.is_dir() {
                 return None;
             }
-            let modified = entry
-                .metadata()
+            let modified = std::fs::metadata(dir.join(SESSION_AGENT_CONFIG_FILE))
                 .and_then(|meta| meta.modified())
                 .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
             Some((modified, dir))

--- a/src/bin/caller/session_config.rs
+++ b/src/bin/caller/session_config.rs
@@ -986,10 +986,11 @@ fn find_wrapper_config_for_external_session(
     // across the whole store. The sort key is the wrapper CONFIG file's
     // mtime, not the directory's: unrelated bookkeeping rewrites bump a
     // store dir's mtime, while the config file only changes when the launch
-    // config itself is (re)written. Directories without a config sort last
-    // (epoch) but stay in the scan — the loop below skips them exactly as
-    // before, preserving the exhaustive-until-exact-match semantics.
-    let mut dirs: Vec<(std::time::SystemTime, std::path::PathBuf)> = entries
+    // config itself is (re)written. Directories without a config carry
+    // `None` and sort after every configured store — even one restored with
+    // a pre-epoch mtime — but stay in the scan: the loop below skips them
+    // exactly as before, preserving exhaustive-until-exact-match semantics.
+    let mut dirs: Vec<(Option<std::time::SystemTime>, PathBuf)> = entries
         .flatten()
         .filter_map(|entry| {
             let dir = entry.path();
@@ -998,11 +999,11 @@ fn find_wrapper_config_for_external_session(
             }
             let modified = std::fs::metadata(dir.join(SESSION_AGENT_CONFIG_FILE))
                 .and_then(|meta| meta.modified())
-                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+                .ok();
             Some((modified, dir))
         })
         .collect();
-    dirs.sort_by_key(|entry| std::cmp::Reverse(entry.0));
+    resume_scan_order(&mut dirs);
     for (_, dir) in dirs {
         let Some(mut config) = read_log_dir_config(&dir) else {
             continue;
@@ -1023,6 +1024,16 @@ fn find_wrapper_config_for_external_session(
         }
     }
     None
+}
+
+/// Ordering for the resume scan's candidate stores: configured stores
+/// newest-first by their config file's mtime; configless stores (`None`)
+/// after every configured one — `None` orders below `Some(_)`, so under the
+/// descending `Reverse` sort it lands last even against a config restored
+/// with a pre-epoch mtime. The sort is stable, so equal keys keep readdir
+/// order.
+fn resume_scan_order(dirs: &mut [(Option<std::time::SystemTime>, PathBuf)]) {
+    dirs.sort_by_key(|entry| std::cmp::Reverse(entry.0));
 }
 
 /// A wrapper config belongs to an external thread only when persisted
@@ -1064,6 +1075,30 @@ fn wrapper_config_matches_external_session(dir: &Path, source: &str, ids: &[Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pins the resume-scan ordering invariant exactly: configured stores
+    /// newest-first, and a configless store sorts after EVERY configured
+    /// one — including a config restored with a pre-epoch mtime, which the
+    /// old epoch-sentinel key would have (wrongly) ordered behind it.
+    #[test]
+    fn resume_scan_orders_configured_newest_first_then_configless() {
+        use std::time::{Duration, UNIX_EPOCH};
+        let recent = UNIX_EPOCH + Duration::from_secs(2_000_000_000);
+        let older = UNIX_EPOCH + Duration::from_secs(1_000_000_000);
+        let pre_epoch = UNIX_EPOCH - Duration::from_secs(86_400);
+        let mut dirs = vec![
+            (None, PathBuf::from("configless")),
+            (Some(pre_epoch), PathBuf::from("restored-pre-epoch")),
+            (Some(recent), PathBuf::from("recent")),
+            (Some(older), PathBuf::from("older")),
+        ];
+        resume_scan_order(&mut dirs);
+        let order: Vec<&str> = dirs.iter().map(|(_, dir)| dir.to_str().unwrap()).collect();
+        assert_eq!(
+            order,
+            ["recent", "older", "restored-pre-epoch", "configless"]
+        );
+    }
 
     #[test]
     fn normalizes_codex_wire_config() {


### PR DESCRIPTION
Efficiency-audit implementation lane: platform blocking calls + CU pixel pipeline + presence token growth (audit reports 04/15/16, S/M items). Every finding re-verified against current main before changing anything.

## Implemented

| Finding (report) | Where | Fix |
|---|---|---|
| macOS display probe spawns `swift -e` (a 0.5-2s JIT compile) per exec batch; Linux forks `xdpyinfo` twice per batch (04 #1) | `src/bin/caller/main.rs:1137` (`maybe_auto_launch_xvfb`), `:1216` (`query_display_resolution`) | macOS arm now calls the existing in-process `platform::main_display_pixel_size()` (the same CGDisplayPixels* queries the swift snippet ran — microseconds, topology-fresh); the accessible-display verdict is memoized process-wide, sticky only on the accessible outcome so a display appearing later is still detected. The "Using existing display" line now logs once per process instead of per batch. |
| `ensure_gui_session_env` forks `systemctl --user show-environment` unconditionally per runtime spawn / CU batch / screenshot (04 #2, 15 #5) | `src/bin/caller/linux_display_env.rs:63` | Three-tier gate: free early-return when every managed key is set; sticky settle once a probe has run with a display variable present (`set_var` never overwrites, so later forks cannot adopt anything); 30s retry interval while waiting for a graphical login — a daemon started at boot still adopts the session after login, with bounded staleness. |
| CU image pipeline (decode / Retina resize / markers / PNG encode / artifact write / base64) runs inline on tokio workers, 50-300ms per capture (15 #2) | `src/bin/caller/computer_use.rs:3364` (`offload_pixels`) + every capture/zoom site | All pixel work now runs under `spawn_blocking` through one `offload_pixels` seam: `session_screenshot_data`, `take_screenshot`'s transform tail, both `capture_zoom_screenshot` flavors, and the session-path zoom arm. Matches the module's existing AX/input `spawn_blocking` convention. |
| macOS zoom captures the whole display (8-20MB Retina PNG), then decodes + crops + re-encodes for a small region (15 #7) | `src/bin/caller/computer_use.rs:3577` | `screencapture -x -R<x,y,w,h>` captures just the region (still native 2x detail) directly into the final `cu_zoom_N.png` — no temp file, no decode, no re-encode. The region is validated/clamped in logical space with the crop path's rules first (`clamp_zoom_region`, unit-tested), so zero/offscreen regions keep actionable errors. The `cu_zoom_raw_N.png` intermediate artifact no longer exists. |
| Multi-MB base64 `ScreenshotData` cloned per batch before checking whether the first result needs it (15 #6, S variant) | `src/bin/caller/computer_use.rs:1149` | Need-check before clone: screenshot-only batches (first result already carries one) and screenshot-less batches no longer pay a clone they drop. The remaining clone is the actual attach; the `Arc<str>` ripple is out of this lane's scope (consumers live in display_glue/mcp). |
| `logical_display_size()` caches forever; stale on dock/undock, desyncing model coordinates on fallback paths (15, other findings) | `src/bin/caller/computer_use.rs:1526` | Dropped the `OnceLock` — the CoreGraphics query is an in-process call measured in microseconds; re-queried per call, always topology-fresh. |
| Resume config scan walks the whole log store in readdir order, reading configs and session logs per directory (04 resume-scan item) | `src/bin/caller/session_config.rs:988` (`find_wrapper_config_for_external_session`) | Sort candidate stores by mtime, newest first; the existing first-match early exit then lands within the first few directories for the overwhelmingly common recent-session resume. Miss-case cost unchanged. |
| Presence narrates against an ever-growing transcript; compaction only fires at 90% of a 1M window (~944k tokens) (16 #1) | `src/bin/caller/presence.rs:104`, `crates/intendant-core/src/conversation.rs:560` | Wired the previously dead `Conversation::auto_compact_at` at threshold **0.10** (~105k steady-state tokens on the default 1M window, scaling with configured windows). `auto_compact_at` gains a `keep_suffix` parameter; presence passes **32**. `auto_compact()` (the worker 90%/4 path) is byte-for-byte unchanged. |
| Presence deep-clones the full conversation every model round (16 #5) | `src/bin/caller/presence.rs:311` | Pass `conversation.messages()` directly — `chat` takes `&[Message]`; the disjoint field borrow compiles. |
| Agent-state pump clones entire `AgentOutput` payloads (up to hundreds of KB) before truncating to 500 chars (16 #6) | `src/bin/caller/presence.rs:1291` | Clip each stream to 501 chars (borrowed, char-boundary safe) before combining; a unit test pins byte-identical output vs. the full-clone-then-truncate across boundary lengths and multi-byte chars. |

## Risk notes

- **Presence compaction keep-suffix (explicit call-out).** The compaction summary is a generic marker, not an LLM summary — compacted middle content is *lost*. Presence interleaves user chat with event narrations, so the worker default tail of 4 messages would routinely swallow the user's last exchange mid-conversation (the audit flags this med-risk for exactly that reason). Chosen: **keep_suffix = 32** — the tail survives verbatim, covering the last few minutes of narration plus any recent user exchange, while compaction still frees the bulk of the transcript. Threshold 0.10 sits in the audit's blessed 0.1-0.2 band. The alternative lever (capping presence's effective window below the configured model window) was deliberately not taken: `context_window` is a user-visible config knob that also drives the dashboard usage-meter denominator.
- **Zoom `-R` semantics.** Output content is equivalent (Retina backing scale is exactly what the old crop preserved). Two deliberate edge deltas: the offscreen error now names the logical display bounds rather than the raw capture bounds, and on a multi-display Mac a rect outside the main display now resolves per `screencapture`'s global-coordinate handling rather than erroring against a main-display capture (CU's macOS subprocess path is main-display scoped anyway). Validation/clamping is pinned by unit tests.
- **Probe memoization visibility.** The "Using existing display" info line logs once per daemon process now (first session), not per session/batch; it fed no state, only the log.
- **Zoom artifact numbering** can now skip an index when a zoom fails after capture (counter increments before the offloaded transform); numbering was only ever a uniqueness scheme.
- **`ensure_gui_session_env` report:** fast paths return `GuiEnvAdoption::default()`; every current caller discards the report (verified), and the eprintln diagnostics still fire on any probe that adopts/skips.

## Verified but not implemented here (with reasons)

- **CU screenshot provider-size cap (15 #1, the audit's top item).** Not safely implementable inside this lane's file fence, and arguably not without a design pass: the default CU coordinate contract is *absolute pixels in the screenshot the model saw* (`coordinate_space:"normalized_1000"` is opt-in), and today screenshot space == injection space on every backend by construction (X11 native, macOS logical via `resize_rgba_to_logical`, session paths via `session.resolution()`). Capping captures below injection space breaks every absolute-coordinate client unless a *stable, provider-keyed* capped-to-injection scale is threaded through injection (`execute_single`, the session normalizer) **and** the AX observation tree (whose coordinates are logical screen points — `observe=ax`/`auto`, the managed default, would otherwise hand the model mixed coordinate spaces across observation modes). Provider identity isn't available at the capture site; the tool's declared display size lives in the MCP layer; `ax.rs`/`display_glue.rs`/`mcp/*` are other lanes' files. The audit itself marks coordinate exactness must-hold with per-provider verification (needs live API runs). Recommend a dedicated design+implementation pass; the surfaces it must touch are listed above.
- **macOS screenshot fallback in-process capture (15 #4).** Skipped per the audit's own conditional: `CGDisplayCreateImage` → RGBA needs CGDataProvider/bitmap-context FFI with CF lifetime management — not comparable to the small scalar-query FFI islands `platform.rs` documents, and the natural home for a one-shot in-process grab (SCK) lives in `crates/intendant-display`, outside this lane. M-effort follow-up; the fork + double disk round-trip remains only on the no-live-session path.
- **Worktree creation inline on the supervisor loop.** Verified still true: `worktree::create` runs `git worktree add` synchronously inside the async supervisor (`prepare_session_worktree` → `session_supervisor/launch.rs:1383`), plus the sub-agent (`session_supervisor/sub_agents.rs:232`) and fission (`thread_actions.rs:1313`) spawn paths. The clean fix is async-ifying those call sites — all outside this lane's fence. A signature-preserving `block_in_place` inside `worktree.rs` was considered and rejected: it panics when reached from a current-thread runtime or a blocking-pool thread, an assumption a leaf utility must not bake in.
- **macOS paste via arboard (15 #10).** In-fence but skipped: audit impact Low (the 300ms consume-delay dominates the pb* forks), and the real value is a clipboard-restore *behavior* change (non-text content) that deserves its own review, not a perf-lane rider.
- Out-of-fence report items left to their owning lanes: external diff tracker re-reads (04 #3), EventBus Arc payloads (04 #4), batch JSON re-parsing (04 #5), frame-registry guard across disk reads (04 #6), AX multi-attribute copy (15 #3), AT-SPI probes (15 #8), settle FNV hash (15 #9), live-audio items (16 #2-4, #7-8).

## Review round (both reviews reconciled; two contradictions adjudicated empirically)

- **Adjudicated — zoom clamp units (`-R` vs `CGDisplayPixelsWide`).** Measured on a 2x scaled display: `CGDisplayPixelsWide/High` = **1024x640**, equal to `CGDisplayModeGetWidth/Height` (points), while `CGDisplayModeGetPixelWidth/Height` = **2048x1280** (backing store). So `main_display_pixel_size()` returns **points**, the same space `screencapture -R` consumes — the clamp was unit-correct. Artifact contract also verified: `-R0,0,100,100` produced a **200x200px** PNG, byte-dimension-identical to the old whole-display(2048px)+scale-2-crop output for that region. The contract is now pinned in `main_display_pixel_size`'s docs, an `#[ignore]` live probe test (`main_display_size_is_points_not_backing_pixels`, passes on this hardware), and the `-R` arm's comment.
- **Fixed — sticky memo broke Xvfb self-heal.** The accessible-display memo is now a clearable slot revalidated before trust: macOS unconditional (native display can't die; `is_display_accessible` is constant true), X11 stats the current `DISPLAY`'s `/tmp/.X11-unix/X<n>` socket fork-free and clears the memo when it's gone, re-entering the probe/auto-launch path. Socket-liveness parsing unit-tested (incl. non-local `host:10.0` forms, which never validate and so keep pre-memo behavior).
- **Fixed — SETTLED latched on partial env.** Settling now requires a successful probe AND the complete-env predicate (same as the tier-1 free return); everything else stays on the 30s cadence, which now gates every unsettled call. A pure-X11 box therefore probes once per 30s forever — accepted cost, documented. Completeness predicate is lookup-injected and tested for the partial-env case (`DISPLAY` inherited, bus vars missing).
- **Fixed — pixel-offload concurrency bound.** `offload_pixels` acquires one of **3** static semaphore permits (`PIXEL_OFFLOAD_PERMITS`, rationale in code: ~30-60MB working set per Retina job, caps transient pixel memory under ~200MB and stops CU bursts monopolizing the shared blocking pool) before `spawn_blocking`; await-inline semantics unchanged.
- **Fixed — `-R` arm's read+base64** moved into the offload closure like every other pixel site.
- **Fixed — resume scan sort key** is now the wrapper config file's mtime (dir mtime gets bumped by unrelated bookkeeping); configless dirs sort last but remain in the exhaustive scan.
- **Adjudicated — presence compaction design.** (b) The 3-message head pin was worker-shaped and wrongly froze presence's first exchange forever: `auto_compact_at` gains a `keep_prefix` parameter; presence pins **1** (its system message), the worker path is unchanged; new test pins the presence shape. (a) The static (non-LLM) summary marker is **kept** — `Conversation` is a data type and must not call a model, and presence is narration, not memory (the worker's own context stays authoritative). This limit is now documented prominently in `auto_compact_at`'s docs and at `PRESENCE_COMPACT_THRESHOLD`: presence context older than the kept tail is dropped un-summarized; a real summarization pass before compaction is the named follow-up if standing presence instructions must survive indefinitely.
- **Noted, no action:** zoom artifact numbering can skip an index on failure — cosmetic; the counter only guarantees uniqueness.

## Final round (delta-review residuals)

- **Permit rides inside the blocking closure.** `offload_pixels` now uses `acquire_owned` and moves the permit into the `spawn_blocking` closure: a caller cancelled after the job started previously released the permit while the detached (unabortable) blocking work kept running, letting repeated cancelled CU/MCP requests defeat the 3-job cap. The permit now lives exactly as long as the work; all six call-site closures are pure pixel work (none re-enter `offload_pixels`), so no deadlock.
- **Resume-sort sentinel exact.** Sort key is `Option<SystemTime>` (`None` = configless), so a config restored with a pre-epoch mtime still orders before every configless dir — the epoch sentinel contradicted the comment there. `resume_scan_order` + a direction-pinning test (incl. the pre-epoch case); scan stays exhaustive.
- **`PROBE_RETRY_INTERVAL` doc** updated to the settled-gate contract: the cadence gates every unsettled call, and pure-X11 hosts that can never complete the managed set probe once per interval forever (accepted tradeoff).

## Battery

Final round: `cargo fmt --check` clean; `cargo clippy` zero warnings; `cargo test --bins` 3331+69+83 passed, 0 failed; `cargo test -p intendant-core --lib` 200 passed; `cargo test -p intendant-platform --lib` 25 passed (+ the `#[ignore]` display probe passes when run explicitly); `cargo test --test e2e` 21 passed, 0 failed (the CU observe-mode and session e2es exercise the offloaded capture paths against the synthetic display backend).
