### PR TITLE
ci kit: setup fixes, fresh-enroll script, sccache health probe, PF doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,7 +383,7 @@ flow. The remaining push triggers (repo-integrity, app.html, audit, docs
 deploy) are cheap and paths-filtered.
 
 Trusted refs (pushes, merge-queue refs, same-repo PRs) run on the
-**self-hosted fleet** (`dell-206` = `intendant-linux`, `macbook-vm` =
+**self-hosted fleet** (`dell-206` = `intendant-linux`, `macbook-a` =
 `intendant-macos`, `samsung-win` = `intendant-windows`) with build state
 in **external per-listener cargo target caches** (`CARGO_TARGET_DIR`
 under the runner account's `~/.cache/intendant-ci/`, keyed by `rustc -V`
@@ -394,10 +394,10 @@ not half-hours.
 `matrix.os` doubles as the hosted label): external code never executes on
 our hardware, yet its required checks really run. Fork-PR workflows also
 need maintainer approval before anything runs (all outside collaborators,
-not just first-timers). The Dell and Windows runners run as dedicated
-non-admin `ci` users — the Mac joins them as the `scripts/ci` service-account
-kit (`_intendant-ci`: hidden role account, LaunchDaemon listeners, job hooks)
-is cut over — and the check *names* stay pinned to the
+not just first-timers). All three platforms' runners run as dedicated
+non-admin `ci` users (the Mac via the `scripts/ci` service-account kit —
+`_intendant-ci`: hidden role account, LaunchDaemon listeners, job hooks),
+and the check *names* stay pinned to the
 `test (ubuntu-latest)`-style contexts the ruleset requires (matrix `os` is
 the name key, `runner` is the fleet placement):
 - **`windows.yml`** — cross-platform `cargo test` (the `intendant` bins + the `intendant-core`/`intendant-display`/`intendant-platform` lib crates) + the headless mock-provider e2e on Windows + macOS + Linux (catches platform-specific build breaks *and* Unix-only test/path assumptions; excludes the WASM crates). Full suites run in exactly two places: the **merge group** (all three platforms — the actual gate) and the **Linux `pull_request` leg** (the pre-queue runtime signal); the non-Linux PR legs are `cargo check` only, and there is no push trigger. The Linux leg is the **whole Linux gate**: after unit tests + e2e it runs the keyless smokes (session-vitals, native-goal, peer-sessions — real binaries under the mock provider) and the dashboard-boot probe (SPA booted in headless Chromium over CDP; promoted from advisory on its 40/40 soak) as tail steps reusing the same checkout and warm tree — these were smokes.yml's jobs until 2026-07-11. The Windows and Linux legs build with debuginfo off (`CARGO_PROFILE_DEV_DEBUG=0` — the Linux leg measured ~95% compile+link vs ~12s of test execution; repro locally with default debuginfo when a CI backtrace is too thin). Jobs are bounded by `timeout-minutes: 60` (no per-test timeout exists under plain `cargo test`, so a single hung test otherwise holds a queue slot indefinitely). Headless-safe: needs no display or API keys. **Required check.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,7 +383,7 @@ flow. The remaining push triggers (repo-integrity, app.html, audit, docs
 deploy) are cheap and paths-filtered.
 
 Trusted refs (pushes, merge-queue refs, same-repo PRs) run on the
-**self-hosted fleet** (`dell-206` = `intendant-linux`, `macbook-vm` =
+**self-hosted fleet** (`dell-206` = `intendant-linux`, `macbook-a` =
 `intendant-macos`, `samsung-win` = `intendant-windows`) with build state
 in **external per-listener cargo target caches** (`CARGO_TARGET_DIR`
 under the runner account's `~/.cache/intendant-ci/`, keyed by `rustc -V`
@@ -394,10 +394,10 @@ not half-hours.
 `matrix.os` doubles as the hosted label): external code never executes on
 our hardware, yet its required checks really run. Fork-PR workflows also
 need maintainer approval before anything runs (all outside collaborators,
-not just first-timers). The Dell and Windows runners run as dedicated
-non-admin `ci` users — the Mac joins them as the `scripts/ci` service-account
-kit (`_intendant-ci`: hidden role account, LaunchDaemon listeners, job hooks)
-is cut over — and the check *names* stay pinned to the
+not just first-timers). All three platforms' runners run as dedicated
+non-admin `ci` users (the Mac via the `scripts/ci` service-account kit —
+`_intendant-ci`: hidden role account, LaunchDaemon listeners, job hooks),
+and the check *names* stay pinned to the
 `test (ubuntu-latest)`-style contexts the ruleset requires (matrix `os` is
 the name key, `runner` is the fleet placement):
 - **`windows.yml`** — cross-platform `cargo test` (the `intendant` bins + the `intendant-core`/`intendant-display`/`intendant-platform` lib crates) + the headless mock-provider e2e on Windows + macOS + Linux (catches platform-specific build breaks *and* Unix-only test/path assumptions; excludes the WASM crates). Full suites run in exactly two places: the **merge group** (all three platforms — the actual gate) and the **Linux `pull_request` leg** (the pre-queue runtime signal); the non-Linux PR legs are `cargo check` only, and there is no push trigger. The Linux leg is the **whole Linux gate**: after unit tests + e2e it runs the keyless smokes (session-vitals, native-goal, peer-sessions — real binaries under the mock provider) and the dashboard-boot probe (SPA booted in headless Chromium over CDP; promoted from advisory on its 40/40 soak) as tail steps reusing the same checkout and warm tree — these were smokes.yml's jobs until 2026-07-11. The Windows and Linux legs build with debuginfo off (`CARGO_PROFILE_DEV_DEBUG=0` — the Linux leg measured ~95% compile+link vs ~12s of test execution; repro locally with default debuginfo when a CI backtrace is too thin). Jobs are bounded by `timeout-minutes: 60` (no per-test timeout exists under plain `cargo test`, so a single hung test otherwise holds a queue slot indefinitely). Headless-safe: needs no display or API keys. **Required check.**

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -350,8 +350,10 @@ committed):
   hermeticity signal clean). Two macOS realities, verified live: staff
   membership is *computed* for every local account (not removable —
   the boundary is 700 operator homes + no admin), and sysadminctl
-  mints ShadowHashData even with no password argument (the script
-  deletes it; verification fails if it ever reappears). Provisions the
+  mints ShadowHashData even with no password argument — and, since
+  Darwin 26, a ShadowHash `AuthenticationAuthority` alongside it (the
+  script deletes both and re-converges them on every run; verification
+  fails only if either survives deletion). Provisions the
   per-user toolchain **as that account**: rustup pinned to the invoking
   host's current `rustc -V` (printed; the workflows key their cargo
   target caches by it), `~/.cargo/config.toml` with the jobs cap above
@@ -365,6 +367,17 @@ committed):
   that the account **cannot traverse any human `/Users/<home>`**
   (expects 700; reports, never chmods — that fix is the operator's
   call).
+- **`enroll-runner-macos.sh <name> <token> <version> [labels] [url]`** —
+  FRESH enrollment: creates a listener where none exists (a new host,
+  extra capacity) directly as the CI account + system-domain
+  LaunchDaemon; `migrate-runner-macos.sh` is for moving an existing
+  operator-account listener instead. Same `.env`/`.path` wiring and
+  template-rendered plist as migrate (change them together). Mind the
+  runner-release gotcha it encodes: the tarball ships `runsvc.sh` only
+  under `bin/` (`svc.sh install` copies it up as a side effect, but the
+  daemon path doesn't use svc.sh) — without the copy the daemon
+  spawn-loops with `EX_CONFIG` (78) and empty runner logs. Registration
+  tokens: `gh api -X POST repos/<org>/<repo>/actions/runners/registration-token --jq .token`.
 - **`migrate-runner-macos.sh <listener-name>`** — one listener per
   invocation. Stops the operator-account LaunchAgent, waits for the
   service tree to exit, moves the runner dir into `/var/ci` (the
@@ -501,11 +514,59 @@ several accounts, so a half-migrated host stays fully supervised. The
 migrate/rollback scripts edit `watchdog.conf` themselves; the
 before-images land in `/etc/intendant-ci/migration/` for audit.
 
+### PF egress policy for the CI account (optional)
+
+Deny-by-default outbound for the CI uid, allowing only DNS + web — the
+runner long-poll, actions downloads, crates.io, and git-over-HTTPS are
+all 443, and the supervised sccache server is loopback. Blocks the
+noisy exfil/probe class (reverse shells on odd ports, LAN scans from
+PR-shaped code); HTTPS-side exfil is out of scope (domain-level control
+needs a proxy). `/etc/pf.anchors/intendant-ci`:
+
+```
+pass out quick on lo0 all flags any no state
+pass out quick proto { tcp, udp } to any port { 53, 80, 443 } user 450 keep state
+block return out quick proto { tcp, udp } all user 450
+```
+
+referenced from `/etc/pf.conf` as `anchor "intendant-ci"` + `load
+anchor`. pf user/group rules match tcp/udp sockets only, so kernel and
+forwarded traffic are untouched. Two traps, both paid for live
+(2026-07-15):
+
+- **The loopback rule must pass ALL flags, stateless.** A uid-scoped
+  egress block also matches the uid's *servers*: their SYN-ACKs are
+  outbound-on-lo0 packets too, and a SYN-only (`flags S/SA`) loopback
+  pass lets the client handshake out but drops the server's reply —
+  silently killing every connection INTO the account's services (the
+  supervised sccache server: process healthy, socket listening, every
+  governed compile timing out). Verify uid-scoped rules in BOTH
+  directions: the account as client *and* as server.
+- **Never bare-reload `pfctl -f /etc/pf.conf` on a host that carries
+  Virtualization.framework guests.** Guest NAT lives in a *dynamically
+  attached* top-level anchor (`com.apple.internet-sharing`, inserted at
+  VM start, absent from the stock file): a bare reload rebuilds the
+  main ruleset without the attach point, orphaning the anchor — its
+  rules survive but stop being evaluated, established flows keep
+  working on state entries, and every NEW guest connection blackholes
+  (a delayed-fuse breakage; the stock file's header warns about it).
+  Reference the anchor explicitly in `/etc/pf.conf`
+  (`nat-anchor`/`rdr-anchor`/`anchor "com.apple.internet-sharing"`) so
+  every future reload re-attaches it; reload the egress anchor alone
+  with `pfctl -a intendant-ci -f <file>`, which never touches the main
+  ruleset.
+
+### Supervised-server health probe
+
+The watchdog TCP-connects `127.0.0.1:$SCCACHE_HEALTH_PORT` every tick
+(including mid-job — an unreachable cache server is already failing the
+running job's every compile) and bounces `$SCCACHE_HEALTH_SERVICE` on
+failure. The probe is a full connect, not a process check, because the
+observed failure mode is exactly "process fine, listener present,
+connects time out". Empty port (default) disables it.
+
 ### Deliberately deferred
 
-- **PF / private-LAN egress deny for the CI account** (packet-filter
-  rules keyed to `_intendant-ci`'s uid, so PR code can't probe the
-  LAN): needs operator sign-off at apply time — not part of this kit.
 - **Windows host equivalent** of the hooks + migration ergonomics (the
   Windows runner already runs as a dedicated non-admin user; see the
   watchdog "Windows" note above).

--- a/scripts/ci/enroll-runner-macos.sh
+++ b/scripts/ci/enroll-runner-macos.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# Enroll ONE fresh GitHub Actions listener on this macOS host as the
+# dedicated CI service account, running as a system-domain LaunchDaemon
+# (run with sudo from a repo checkout:
+#   sudo scripts/ci/enroll-runner-macos.sh <name> <registration-token> \
+#       <runner-version> [labels] [repo-url]).
+#
+# Fresh-enrollment sibling of migrate-runner-macos.sh: that script MOVES an
+# existing operator-account listener onto the CI account; this one creates a
+# listener where none exists (a new host, or extra capacity). The .env/.path
+# wiring and plist rendering are kept in lockstep with the migrate script —
+# change them together.
+#
+# Registration tokens are minted per enrollment (expire ~1h):
+#   gh api -X POST repos/<org>/<repo>/actions/runners/registration-token --jq .token
+#
+# Gotcha this script exists to remember: the runner tarball ships runsvc.sh
+# only under bin/; `svc.sh install` (the gui-domain path we do not use)
+# copies it to the runner root as a side effect. A daemon whose
+# ProgramArguments point at <root>/runsvc.sh without that copy spawn-loops
+# with EX_CONFIG (78) and nothing in the runner's own logs (live
+# 2026-07-15).
+set -euo pipefail
+die() { echo "error: $*" >&2; exit 1; }
+[ "$(id -u)" -eq 0 ] || die "run with sudo"
+[ "$(uname -s)" = "Darwin" ] || die "macOS only"
+
+NAME="${1:?usage: enroll-runner-macos.sh <name> <registration-token> <runner-version> [labels] [repo-url]}"
+TOKEN="${2:?registration token (gh api -X POST repos/<org>/<repo>/actions/runners/registration-token --jq .token)}"
+VER="${3:?runner version, no leading v (gh api repos/actions/runner/releases/latest --jq .tag_name)}"
+LABELS="${4:-intendant-macos}"
+URL="${5:-https://github.com/intendant-dev/Intendant}"
+case "$NAME" in
+    */* | *[[:space:]]*) die "runner name must be a bare word" ;;
+esac
+VER="${VER#v}"
+
+CI_ACCOUNT="${INTENDANT_CI_ACCOUNT:-_intendant-ci}"
+dscl . -read "/Users/$CI_ACCOUNT" UniqueID >/dev/null 2>&1 \
+    || die "account $CI_ACCOUNT does not exist — run setup-ci-account-macos.sh first"
+CI_HOME="$(dscl . -read "/Users/$CI_ACCOUNT" NFSHomeDirectory | awk '{print $2}')"
+CI_GROUP="$(id -gn "$CI_ACCOUNT")"
+LIB_DIR="/usr/local/lib/intendant-ci"
+ORG_REPO="${URL#https://github.com/}"
+LABEL="actions.runner.$(echo "$ORG_REPO" | tr '/' '-').$NAME"
+DEST="$CI_HOME/actions-runner-$NAME"
+DAEMON_PLIST="/Library/LaunchDaemons/$LABEL.plist"
+ARCH="$(uname -m | sed 's/x86_64/x64/; s/arm64/arm64/')"
+TARBALL="/tmp/actions-runner-osx-$ARCH-$VER.tar.gz"
+
+[ -x "$CI_HOME/.cargo/bin/rustc" ] || die "$CI_ACCOUNT has no toolchain — run setup-ci-account-macos.sh first"
+[ -x "$LIB_DIR/hooks/job-started.sh" ] || die "job hooks not installed — run setup-ci-account-macos.sh first"
+[ ! -e "$DEST" ] || die "$DEST already exists"
+[ ! -e "$DAEMON_PLIST" ] || die "$DAEMON_PLIST already exists"
+
+# Run as the CI account from a cwd it can read (sudo starts children in the
+# invoker's cwd, typically a 700 operator home, where the CI account cannot
+# even getcwd — rustup/cargo/tar all abort on that).
+ci_sh() {
+    sudo -u "$CI_ACCOUNT" -H env HOME="$CI_HOME" \
+        PATH="$CI_HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        sh -c "cd '$CI_HOME' && $1"
+}
+
+if [ ! -f "$TARBALL" ]; then
+    echo "downloading runner v$VER ($ARCH)..."
+    curl -sSfL -o "$TARBALL" \
+        "https://github.com/actions/runner/releases/download/v$VER/actions-runner-osx-$ARCH-$VER.tar.gz"
+fi
+chmod 0644 "$TARBALL"
+
+install -d -o "$CI_ACCOUNT" -g "$CI_GROUP" -m 0750 "$DEST"
+ci_sh "cd '$DEST' && tar xzf '$TARBALL'"
+echo "extracted runner v$VER into $DEST"
+
+ci_sh "cd '$DEST' && ./config.sh --unattended --url '$URL' --token '$TOKEN' \
+    --name '$NAME' --labels '$LABELS' --replace" || die "config.sh failed for $NAME"
+[ -f "$DEST/.runner" ] || die "registration produced no .runner"
+
+# The EX_CONFIG gotcha from the header: put runsvc.sh where the daemon
+# plist (and svc.sh convention) expects it.
+ci_sh "cd '$DEST' && cp bin/runsvc.sh runsvc.sh && chmod +x runsvc.sh"
+
+# Job env: hooks (account-gated) + the account's supervised sccache server
+# coordinates — cargo's [env] port does not reach every in-job sccache
+# invocation (2026-07-10), so they ride the job env explicitly. Mirrors
+# migrate-runner-macos.sh.
+set_env_kv() {
+    local env_file="$1" key="$2" val="$3"
+    touch "$env_file"
+    if grep -q "^${key}=" "$env_file"; then
+        sed -i '' "s|^${key}=.*|${key}=${val}|" "$env_file"
+    else
+        printf '%s=%s\n' "$key" "$val" >> "$env_file"
+    fi
+}
+set_env_kv "$DEST/.env" ACTIONS_RUNNER_HOOK_JOB_STARTED "$LIB_DIR/hooks/job-started.sh"
+set_env_kv "$DEST/.env" ACTIONS_RUNNER_HOOK_JOB_COMPLETED "$LIB_DIR/hooks/job-completed.sh"
+set_env_kv "$DEST/.env" INTENDANT_CI_HOOK_ACCOUNT "$CI_ACCOUNT"
+set_env_kv "$DEST/.env" SCCACHE_SERVER_PORT "4227"
+set_env_kv "$DEST/.env" SCCACHE_DIR "$CI_HOME/.cache/sccache"
+chown "$CI_ACCOUNT:$CI_GROUP" "$DEST/.env"
+
+# .path is the PATH runsvc.sh exports to every job step.
+printf '%s\n' "$CI_HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" > "$DEST/.path"
+chown "$CI_ACCOUNT:$CI_GROUP" "$DEST/.path"
+
+# LaunchDaemon rendered from the runner's own template (same substitution
+# svc.sh performs), with HOME/USER injected — system-domain daemons inherit
+# neither, and rustup/cargo/the hooks need HOME. Mirrors
+# migrate-runner-macos.sh.
+install -d -o "$CI_ACCOUNT" -g "$CI_GROUP" -m 0755 "$CI_HOME/Library/Logs/$LABEL"
+TEMPLATE="$DEST/bin/actions.runner.plist.template"
+[ -f "$TEMPLATE" ] || die "runner template missing at $TEMPLATE (release layout changed?)"
+sed -e "s|{{User}}|$CI_ACCOUNT|g" \
+    -e "s|{{SvcName}}|$LABEL|g" \
+    -e "s|{{RunnerRoot}}|$DEST|g" \
+    -e "s|{{UserHome}}|$CI_HOME|g" \
+    "$TEMPLATE" > "$DAEMON_PLIST.tmp"
+add_env() {
+    /usr/libexec/PlistBuddy -c "Add :EnvironmentVariables:$1 string $2" "$DAEMON_PLIST.tmp" 2>/dev/null \
+        || /usr/libexec/PlistBuddy -c "Set :EnvironmentVariables:$1 $2" "$DAEMON_PLIST.tmp"
+}
+/usr/libexec/PlistBuddy -c "Add :EnvironmentVariables dict" "$DAEMON_PLIST.tmp" 2>/dev/null || true
+add_env HOME "$CI_HOME"
+add_env USER "$CI_ACCOUNT"
+plutil -lint "$DAEMON_PLIST.tmp" >/dev/null || die "generated plist failed plutil -lint"
+mv "$DAEMON_PLIST.tmp" "$DAEMON_PLIST"
+chown root:wheel "$DAEMON_PLIST"
+chmod 0644 "$DAEMON_PLIST"
+printf '%s\n' "$DAEMON_PLIST" > "$DEST/.service"
+chown "$CI_ACCOUNT:$CI_GROUP" "$DEST/.service"
+
+launchctl bootout "system/$LABEL" 2>/dev/null || true
+launchctl bootstrap system "$DAEMON_PLIST"
+echo "bootstrapped $LABEL (logs: $CI_HOME/Library/Logs/$LABEL/)"
+
+# Wait for the listener to report online (best-effort; mirrors the migrate
+# script's tail).
+GH_BIN=""
+for cand in /opt/homebrew/bin/gh /usr/local/bin/gh /usr/bin/gh; do
+    [ -x "$cand" ] && { GH_BIN="$cand"; break; }
+done
+if [ -n "${SUDO_USER:-}" ] && [ -n "$GH_BIN" ]; then
+    echo "waiting for $NAME to report online..."
+    status=""
+    for _ in $(seq 1 24); do
+        status="$(sudo -u "$SUDO_USER" -H "$GH_BIN" api "repos/$ORG_REPO/actions/runners" --paginate \
+            --jq ".runners[] | select(.name==\"$NAME\") | .status" 2>/dev/null | head -1 || true)"
+        [ "$status" = "online" ] && break
+        sleep 5
+    done
+    if [ "$status" = "online" ]; then
+        echo "listener $NAME is ONLINE as $CI_ACCOUNT"
+    else
+        echo "not online yet (last: '${status:-unknown}') — check:"
+        echo "  tail -f $CI_HOME/Library/Logs/$LABEL/stderr.log"
+        echo "  sudo launchctl print system/$LABEL | grep -E 'state|last exit'"
+    fi
+else
+    echo "verify: gh api repos/$ORG_REPO/actions/runners --jq '.runners[] | \"\\(.name) \\(.status)\"'"
+fi
+echo "remember: add $LABEL to RUNNER_DAEMON_LABELS in /etc/intendant-ci/watchdog.conf"

--- a/scripts/ci/fleet-watchdog.sh
+++ b/scripts/ci/fleet-watchdog.sh
@@ -61,6 +61,13 @@ MEM_RESUME_TICKS="${MEM_RESUME_TICKS:-2}"
 # detector should surface — cannot silence the detector with it.
 GOVERNOR_MONITOR="${GOVERNOR_MONITOR:-auto}"
 GOVERNOR_CONF="${GOVERNOR_CONF:-/usr/local/etc/intendant-governor.toml}"
+# Supervised sccache server health probe: port to check (empty = probe
+# disabled) and the service to bounce on failure (launchd label / systemd
+# unit). A server can wedge or be firewalled ALIVE — process running,
+# socket listening, connects timing out — which fails every governed
+# compile while the supervisor sees a healthy child (live 2026-07-15).
+SCCACHE_HEALTH_PORT="${SCCACHE_HEALTH_PORT:-}"
+SCCACHE_HEALTH_SERVICE="${SCCACHE_HEALTH_SERVICE:-com.intendant.ci.sccache}"
 mkdir -p "$STATE_DIR"
 
 log() {
@@ -239,8 +246,25 @@ monitor_ungoverned_rustc() {
     detect_ungoverned_rustc
 }
 
+# Accept-probe the supervised sccache server and bounce it when dead. Runs
+# every tick INCLUDING mid-job: an unreachable cache server is failing the
+# running job's every compile already — a restart is strictly better. The
+# probe is a full TCP connect, not a process check: the observed failure
+# mode is exactly "process fine, connects time out".
+check_sccache_health() {
+    [ -n "$SCCACHE_HEALTH_PORT" ] || return 0
+    nc -z -w 5 127.0.0.1 "$SCCACHE_HEALTH_PORT" >/dev/null 2>&1 && return 0
+    log "sccache server on 127.0.0.1:$SCCACHE_HEALTH_PORT not accepting — bouncing $SCCACHE_HEALTH_SERVICE"
+    if is_macos; then
+        launchctl kickstart -k "system/$SCCACHE_HEALTH_SERVICE" 2>/dev/null             || log "kickstart failed for $SCCACHE_HEALTH_SERVICE — check manually"
+    else
+        systemctl restart "$SCCACHE_HEALTH_SERVICE" 2>/dev/null             || log "restart failed for $SCCACHE_HEALTH_SERVICE — check manually"
+    fi
+}
+
 main() {
     monitor_ungoverned_rustc
+    check_sccache_health
 
     free=$(free_gb)
 

--- a/scripts/ci/setup-ci-account-macos.sh
+++ b/scripts/ci/setup-ci-account-macos.sh
@@ -113,6 +113,11 @@ else
     # dsAttrTypeNative: prefix (which reads print) makes the delete a
     # silent no-op.
     dscl . -delete "/Users/$CI_ACCOUNT" ShadowHashData 2>/dev/null || true
+    # Darwin 26 sysadminctl also mints a ShadowHash AuthenticationAuthority
+    # for role accounts (observed live 2026-07-15; Darwin 25 did not). A
+    # role account needs no authority entries at all — delete the attribute
+    # so no password path can ever be re-derived.
+    dscl . -delete "/Users/$CI_ACCOUNT" AuthenticationAuthority 2>/dev/null || true
 fi
 
 CI_GROUP="$(id -gn "$CI_ACCOUNT")"
@@ -185,6 +190,16 @@ ci_run "$CI_HOME/.cargo/bin/rustup" default "$PIN"
 
 echo "== cargo config"
 CARGO_CONFIG="$CI_HOME/.cargo/config.toml"
+# Detected OUTSIDE the seed-once branch: the supervised-server block below
+# needs it on every run, and under `set -u` an idempotent re-run (config
+# already present) otherwise dies on the unbound variable (live 2026-07-15).
+sccache_bin=""
+for cand in /opt/homebrew/bin/sccache /usr/local/bin/sccache; do
+    if [ -x "$cand" ]; then
+        sccache_bin="$cand"
+        break
+    fi
+done
 if [ -f "$CARGO_CONFIG" ]; then
     echo "keeping existing $CARGO_CONFIG"
 else
@@ -200,13 +215,6 @@ else
         fi
     fi
     jobs="${jobs:-6}"
-    sccache_bin=""
-    for cand in /opt/homebrew/bin/sccache /usr/local/bin/sccache; do
-        if [ -x "$cand" ]; then
-            sccache_bin="$cand"
-            break
-        fi
-    done
     {
         echo "# Account-level cargo cap — scripts/ci/README.md, \"Cargo parallelism cap\"."
         echo "[build]"
@@ -375,6 +383,13 @@ if shadow_present; then
     dscl . -delete "/Users/$CI_ACCOUNT" ShadowHashData 2>/dev/null || true
 fi
 auth_auth="$(dscl . -read "/Users/$CI_ACCOUNT" AuthenticationAuthority 2>/dev/null || true)"
+# Converge rather than fail: newer Darwin mints this attribute (see the
+# creation block); idempotent re-runs on hosts set up before the fix must
+# repair it, not report it.
+if echo "$auth_auth" | grep -q "ShadowHash"; then
+    dscl . -delete "/Users/$CI_ACCOUNT" AuthenticationAuthority 2>/dev/null || true
+    auth_auth="$(dscl . -read "/Users/$CI_ACCOUNT" AuthenticationAuthority 2>/dev/null || true)"
+fi
 if shadow_present; then
     echo "FAIL: $CI_ACCOUNT still has ShadowHashData after delete" >&2
     fail=1

--- a/scripts/ci/watchdog.conf.example
+++ b/scripts/ci/watchdog.conf.example
@@ -36,6 +36,13 @@ CAP_GB=50         # total per cache root (2 listeners x 25G budget)
 #GOVERNOR_MONITOR=auto
 #GOVERNOR_CONF=/usr/local/etc/intendant-governor.toml
 
+# Supervised sccache server health probe (see README): TCP-connect the
+# server every tick, bounce the service when it stops accepting. Empty
+# port (the default) disables the probe; set it on hosts running the
+# supervised per-account server.
+#SCCACHE_HEALTH_PORT=4227
+#SCCACHE_HEALTH_SERVICE=com.intendant.ci.sccache
+
 VOLUME="/"
 STATE_DIR="/var/db/intendant-ci"        # /var/lib/intendant-ci on Linux
 LOG="/var/log/intendant-ci-watchdog.log"

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -94,6 +94,28 @@ check_core() {
         all_ok=false
     fi
 
+    # -sys crate link deps (parity with setup-linux.sh APT_PACKAGES:
+    # pkg-config + libvpx-dev; opus for the audio stack). Without these a
+    # plain `cargo build` dies in the crates' build scripts — a fresh CI
+    # host proved it (env-libvpx-sys panic, 2026-07-15).
+    if has_cmd pkg-config; then
+        ok "pkg-config"
+    else
+        miss "pkg-config" "brew install pkgconf"
+        all_ok=false
+    fi
+    local lib formula
+    for lib in vpx:libvpx opus:opus; do
+        formula="${lib#*:}"
+        lib="${lib%%:*}"
+        if pkg-config --exists "$lib" 2>/dev/null; then
+            ok "lib$lib ($(pkg-config --modversion "$lib" 2>/dev/null))"
+        else
+            miss "lib$lib" "brew install $formula"
+            all_ok=false
+        fi
+    done
+
     $all_ok
 }
 
@@ -465,6 +487,9 @@ run_install() {
 
     # Phase 2: Homebrew packages
     info "installing Homebrew packages..."
+    brew_install pkgconf
+    brew_install libvpx
+    brew_install opus
     brew_install ffmpeg
     brew_install switchaudio-osx
     brew_install sox


### PR DESCRIPTION
## What

Four kit hardenings from operating the macOS service-account kit, plus docs:

- **setup-ci-account-macos.sh**: `sccache_bin` unbound-variable crash on idempotent re-runs (`set -u`; the supervised-server block reads it outside the seed-once branch); newer Darwin's sysadminctl mints a ShadowHash `AuthenticationAuthority` for role accounts — now deleted at creation and converged on re-runs instead of hard-failing verification.
- **enroll-runner-macos.sh** (new): fresh enrollment where no listener exists — the migrate script's sibling, same `.env`/`.path` wiring and template-rendered LaunchDaemon, encoding the `runsvc.sh`-ships-only-under-`bin/` gotcha (daemon spawn-loops `EX_CONFIG` without the copy).
- **fleet-watchdog.sh**: supervised-sccache **health probe** — full TCP connect each tick (mid-job included), bounce the service on failure. Catches the process-fine/listener-present/connects-time-out class that fails every governed compile while the supervisor sees a healthy child.
- **README**: PF egress recipe for the CI account with both live-verified traps (uid-scoped blocks also match the uid's *servers* on loopback → `pass on lo0 flags any no state`; never bare-reload `pf.conf` on hosts carrying Virtualization.framework guests → reference `com.apple.internet-sharing` explicitly, reload the egress anchor alone).
- **CLAUDE.md/AGENTS.md**: fleet naming + runner-account sentence refresh.

Shell + docs only; `bash -n` clean on all three scripts.