### PR TITLE
display: hot-path efficiency batch (tile diff, I420, RTP fan-out, capture cadence)

### DIFF
--- a/crates/intendant-display/src/capture/frame_diff.rs
+++ b/crates/intendant-display/src/capture/frame_diff.rs
@@ -9,7 +9,6 @@
 use super::super::tile::grid::{TileGrid, TileId};
 use super::super::{Frame, FrameFormat};
 use super::damage::Rect;
-use std::collections::HashMap;
 
 const FNV_OFFSET: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x100000001b3;
@@ -34,7 +33,14 @@ impl std::error::Error for FrameDiffError {}
 pub struct FrameDiffDamageTracker {
     tile_size_px: u16,
     last_geometry: Option<(u32, u32, u32, FrameFormat)>,
-    last_hashes: HashMap<TileId, u64>,
+    /// Per-tile hash of the previous frame, indexed
+    /// `ty * width_tiles + tx`. A flat vector (not a map): the grid is
+    /// dense and this runs for every tile of every diffed frame, so
+    /// hashing a `TileId` key per tile would dominate the bookkeeping.
+    last_hashes: Vec<u64>,
+    /// False until the first full pass after construction or a geometry
+    /// change; while false every tile is dirty regardless of its hash.
+    has_baseline: bool,
 }
 
 impl FrameDiffDamageTracker {
@@ -42,7 +48,8 @@ impl FrameDiffDamageTracker {
         Self {
             tile_size_px,
             last_geometry: None,
-            last_hashes: HashMap::new(),
+            last_hashes: Vec::new(),
+            has_baseline: false,
         }
     }
 
@@ -54,6 +61,9 @@ impl FrameDiffDamageTracker {
         let geometry_changed = self.last_geometry != Some(geometry);
         if geometry_changed {
             self.last_hashes.clear();
+            self.last_hashes
+                .resize(grid.width_tiles as usize * grid.height_tiles as usize, 0);
+            self.has_baseline = false;
             self.last_geometry = Some(geometry);
         }
 
@@ -62,13 +72,15 @@ impl FrameDiffDamageTracker {
             for tx in 0..grid.width_tiles {
                 let tile = TileId::new(tx, ty);
                 let hash = hash_tile(frame, &grid, tile)?;
-                let changed = self.last_hashes.get(&tile).is_none_or(|prev| *prev != hash);
-                self.last_hashes.insert(tile, hash);
+                let idx = ty as usize * grid.width_tiles as usize + tx as usize;
+                let changed = !self.has_baseline || self.last_hashes[idx] != hash;
+                self.last_hashes[idx] = hash;
                 if changed {
                     dirty.push(tile_rect(&grid, tile));
                 }
             }
         }
+        self.has_baseline = true;
         Ok(dirty)
     }
 }
@@ -93,12 +105,29 @@ fn hash_tile(frame: &Frame, grid: &TileGrid, tile: TileId) -> Result<u64, FrameD
     let copy_w = frame.width.saturating_sub(start_x).min(ts) as usize;
     let copy_h = frame.height.saturating_sub(start_y).min(ts) as usize;
 
+    // FNV-1a over 8-byte words instead of single bytes: the multiply is
+    // the serial dependency, so folding 8 bytes per round is ~8× fewer
+    // dependent multiplies over the same pixels. This changes the hash
+    // *values* relative to byte-wise FNV, which is fine — hashes are
+    // only ever compared against hashes of the previous frame computed
+    // by the same code in the same process.
     let mut hash = FNV_OFFSET;
     for y in 0..copy_h {
         let row_start = (start_y as usize + y) * frame.stride as usize + start_x as usize * 4;
         let row = &frame.data[row_start..row_start + copy_w * 4];
-        for b in row {
-            hash ^= *b as u64;
+        let mut words = row.chunks_exact(8);
+        for w in words.by_ref() {
+            // Native endianness: the hash never leaves this process.
+            hash ^= u64::from_ne_bytes(w.try_into().expect("chunks_exact(8) yields 8 bytes"));
+            hash = hash.wrapping_mul(FNV_PRIME);
+        }
+        let rem = words.remainder();
+        if !rem.is_empty() {
+            // Tail (row byte width not a multiple of 8): zero-pad into
+            // one final word. Rows of equal content still hash equal.
+            let mut tail = [0u8; 8];
+            tail[..rem.len()].copy_from_slice(rem);
+            hash ^= u64::from_ne_bytes(tail);
             hash = hash.wrapping_mul(FNV_PRIME);
         }
     }

--- a/crates/intendant-display/src/encode/mod.rs
+++ b/crates/intendant-display/src/encode/mod.rs
@@ -711,11 +711,7 @@ pub fn bgra_to_i420_into(bgra: &[u8], width: u32, height: u32, stride: u32, out:
 /// Load one BGRA pixel as `(b, g, r)` i32 components.
 #[inline]
 fn bgra_px(bgra: &[u8], idx: usize) -> (i32, i32, i32) {
-    (
-        bgra[idx] as i32,
-        bgra[idx + 1] as i32,
-        bgra[idx + 2] as i32,
-    )
+    (bgra[idx] as i32, bgra[idx + 1] as i32, bgra[idx + 2] as i32)
 }
 
 #[inline]
@@ -847,7 +843,14 @@ pub fn downscale_i420_into(
 /// rounds the same direction as `f32::round` on the only possible
 /// fractions .0/.25/.5/.75) several times faster and without per-pixel
 /// float math. Everything else takes the generic bilinear path.
-fn downscale_plane(src: &[u8], src_w: usize, src_h: usize, dst: &mut [u8], dst_w: usize, dst_h: usize) {
+fn downscale_plane(
+    src: &[u8],
+    src_w: usize,
+    src_h: usize,
+    dst: &mut [u8],
+    dst_w: usize,
+    dst_h: usize,
+) {
     if src_w == dst_w * 2 && src_h == dst_h * 2 && dst_w > 0 && dst_h > 0 {
         downscale_plane_box2x(src, src_w, dst, dst_w, dst_h);
     } else {

--- a/crates/intendant-display/src/encode/mod.rs
+++ b/crates/intendant-display/src/encode/mod.rs
@@ -765,6 +765,24 @@ fn rounded_fixed_avg_clamped_u8(n: i32, count: i32) -> u8 {
 /// CPU budget actually binds, swapping the per-plane loop to a libyuv call
 /// is local — the function signature and output shape don't change.
 pub fn downscale_i420(src: &[u8], src_w: u32, src_h: u32, dst_w: u32, dst_h: u32) -> Vec<u8> {
+    let mut out = Vec::new();
+    downscale_i420_into(src, src_w, src_h, dst_w, dst_h, &mut out);
+    out
+}
+
+/// [`downscale_i420`] into a caller-provided buffer (resized to fit; a
+/// buffer already at the right length is overwritten in place) — the
+/// per-layer encoder threads call this per frame, and a fresh
+/// multi-hundred-KB zeroed allocation per frame per layer was pure
+/// allocator churn.
+pub fn downscale_i420_into(
+    src: &[u8],
+    src_w: u32,
+    src_h: u32,
+    dst_w: u32,
+    dst_h: u32,
+    out: &mut Vec<u8>,
+) {
     debug_assert!(
         src_w.is_multiple_of(2) && src_h.is_multiple_of(2),
         "downscale_i420: src dims must be even, got {src_w}x{src_h}"
@@ -791,15 +809,19 @@ pub fn downscale_i420(src: &[u8], src_w: u32, src_h: u32, dst_w: u32, dst_h: u32
 
     let dst_y_size = dst_w * dst_h;
     let dst_uv_size = (dst_w / 2) * (dst_h / 2);
-    let mut out = vec![0u8; dst_y_size + 2 * dst_uv_size];
+    let total = dst_y_size + 2 * dst_uv_size;
+    if out.len() != total {
+        out.clear();
+        out.resize(total, 0);
+    }
 
     let (src_y, src_uv) = src.split_at(src_y_size);
     let (src_u, src_v) = src_uv.split_at(src_uv_size);
     let (dst_y_plane, dst_uv) = out.split_at_mut(dst_y_size);
     let (dst_u_plane, dst_v_plane) = dst_uv.split_at_mut(dst_uv_size);
 
-    downscale_plane_bilinear(src_y, src_w, src_h, dst_y_plane, dst_w, dst_h);
-    downscale_plane_bilinear(
+    downscale_plane(src_y, src_w, src_h, dst_y_plane, dst_w, dst_h);
+    downscale_plane(
         src_u,
         src_w / 2,
         src_h / 2,
@@ -807,7 +829,7 @@ pub fn downscale_i420(src: &[u8], src_w: u32, src_h: u32, dst_w: u32, dst_h: u32
         dst_w / 2,
         dst_h / 2,
     );
-    downscale_plane_bilinear(
+    downscale_plane(
         src_v,
         src_w / 2,
         src_h / 2,
@@ -815,8 +837,40 @@ pub fn downscale_i420(src: &[u8], src_w: u32, src_h: u32, dst_w: u32, dst_h: u32
         dst_w / 2,
         dst_h / 2,
     );
+}
 
-    out
+/// Per-plane downscale dispatch: the common simulcast case is an exact
+/// integer 2× reduction (full → half layer), where bilinear sampling
+/// at pixel centers degenerates to an equal-weight 2×2 box average —
+/// the integer box filter computes the identical bytes (the +0.5
+/// sampling puts every weight at exactly ¼, and `(sum + 2) >> 2`
+/// rounds the same direction as `f32::round` on the only possible
+/// fractions .0/.25/.5/.75) several times faster and without per-pixel
+/// float math. Everything else takes the generic bilinear path.
+fn downscale_plane(src: &[u8], src_w: usize, src_h: usize, dst: &mut [u8], dst_w: usize, dst_h: usize) {
+    if src_w == dst_w * 2 && src_h == dst_h * 2 && dst_w > 0 && dst_h > 0 {
+        downscale_plane_box2x(src, src_w, dst, dst_w, dst_h);
+    } else {
+        downscale_plane_bilinear(src, src_w, src_h, dst, dst_w, dst_h);
+    }
+}
+
+/// Exact 2× reduction: equal-weight 2×2 box average in integer math.
+/// See [`downscale_plane`] for the bilinear-equivalence argument.
+fn downscale_plane_box2x(src: &[u8], src_w: usize, dst: &mut [u8], dst_w: usize, dst_h: usize) {
+    for dy in 0..dst_h {
+        let s0 = (dy * 2) * src_w;
+        let s1 = s0 + src_w;
+        let d = dy * dst_w;
+        for dx in 0..dst_w {
+            let sx = dx * 2;
+            let sum = src[s0 + sx] as u16
+                + src[s0 + sx + 1] as u16
+                + src[s1 + sx] as u16
+                + src[s1 + sx + 1] as u16;
+            dst[d + dx] = ((sum + 2) >> 2) as u8;
+        }
+    }
 }
 
 /// Bilinear single-plane downscale. The `dst` slice is written in

--- a/crates/intendant-display/src/encode/mod.rs
+++ b/crates/intendant-display/src/encode/mod.rs
@@ -1575,4 +1575,94 @@ a=fmtp:97 profile-level-id=640032;packetization-mode=1\r\n";
             );
         }
     }
+
+    /// Deterministic pseudo-random plane bytes (LCG) — non-constant
+    /// input for the exact-2× equivalence pins below.
+    fn lcg_plane(len: usize, mut seed: u32) -> Vec<u8> {
+        let mut out = Vec::with_capacity(len);
+        for _ in 0..len {
+            seed = seed.wrapping_mul(1664525).wrapping_add(1013904223);
+            out.push((seed >> 24) as u8);
+        }
+        out
+    }
+
+    /// Pin for `downscale_plane_box2x`'s bilinear equivalence claim: at
+    /// an exact 2× reduction the integer box filter must produce
+    /// byte-identical output to the pixel-center bilinear sampler on
+    /// arbitrary (non-constant) content. The constant-color tests never
+    /// reach the interesting rounding paths; this randomized plane does
+    /// — and pins the equivalence against future edits to either
+    /// implementation.
+    #[test]
+    fn downscale_plane_box2x_matches_bilinear_bit_for_bit() {
+        let (src_w, src_h, dst_w, dst_h) = (64usize, 32usize, 32usize, 16usize);
+        let src = lcg_plane(src_w * src_h, 0xD15C0DE);
+
+        let mut via_box = vec![0u8; dst_w * dst_h];
+        downscale_plane_box2x(&src, src_w, &mut via_box, dst_w, dst_h);
+
+        let mut via_bilinear = vec![0u8; dst_w * dst_h];
+        downscale_plane_bilinear(&src, src_w, src_h, &mut via_bilinear, dst_w, dst_h);
+
+        assert_eq!(
+            via_box, via_bilinear,
+            "exact-2× box filter must be bit-identical to bilinear",
+        );
+    }
+
+    /// End-to-end exact-2× I420 downscale on a gradient: every plane
+    /// (Y and the half-size U/V) satisfies `src == 2*dst`, so all
+    /// three take the box2x path, and every output byte must be the
+    /// rounded 2×2 box average of its source block.
+    #[test]
+    fn downscale_i420_exact_2x_gradient_takes_box_average() {
+        let (src_w, src_h, dst_w, dst_h) = (16u32, 8u32, 8u32, 4u32);
+        let y_size = (src_w * src_h) as usize;
+        let uv_size = (src_w / 2 * src_h / 2) as usize;
+        let src = lcg_plane(y_size + 2 * uv_size, 0xBEEF);
+
+        let out = downscale_i420(&src, src_w, src_h, dst_w, dst_h);
+
+        // Reference: rounded equal-weight 2×2 box average per plane.
+        let box_avg = |plane: &[u8], w: usize, dx: usize, dy: usize| -> u8 {
+            let s0 = (dy * 2) * w + dx * 2;
+            let s1 = s0 + w;
+            let sum =
+                plane[s0] as u16 + plane[s0 + 1] as u16 + plane[s1] as u16 + plane[s1 + 1] as u16;
+            ((sum + 2) >> 2) as u8
+        };
+
+        let (src_y, src_uv) = src.split_at(y_size);
+        let (src_u, src_v) = src_uv.split_at(uv_size);
+        let dst_y_size = (dst_w * dst_h) as usize;
+        let dst_uv_size = (dst_w / 2 * dst_h / 2) as usize;
+        let (out_y, out_uv) = out.split_at(dst_y_size);
+        let (out_u, out_v) = out_uv.split_at(dst_uv_size);
+
+        for dy in 0..dst_h as usize {
+            for dx in 0..dst_w as usize {
+                assert_eq!(
+                    out_y[dy * dst_w as usize + dx],
+                    box_avg(src_y, src_w as usize, dx, dy),
+                    "Y plane ({dx},{dy})",
+                );
+            }
+        }
+        for dy in 0..(dst_h / 2) as usize {
+            for dx in 0..(dst_w / 2) as usize {
+                let idx = dy * (dst_w / 2) as usize + dx;
+                assert_eq!(
+                    out_u[idx],
+                    box_avg(src_u, (src_w / 2) as usize, dx, dy),
+                    "U plane ({dx},{dy})",
+                );
+                assert_eq!(
+                    out_v[idx],
+                    box_avg(src_v, (src_w / 2) as usize, dx, dy),
+                    "V plane ({dx},{dy})",
+                );
+            }
+        }
+    }
 }

--- a/crates/intendant-display/src/encode/mod.rs
+++ b/crates/intendant-display/src/encode/mod.rs
@@ -591,7 +591,25 @@ pub fn sampled_avg_byte(data: &[u8]) -> u32 {
 /// The output layout is: Y plane (width*height) followed by U plane
 /// (width/2 * height/2) followed by V plane (width/2 * height/2).
 /// U and V are subsampled 2x2 by averaging the four contributing pixels.
+///
+/// Allocates a fresh output buffer; per-frame callers should prefer
+/// [`bgra_to_i420_into`] with a recycled buffer.
 pub fn bgra_to_i420(bgra: &[u8], width: u32, height: u32, stride: u32) -> Vec<u8> {
+    let mut out = Vec::new();
+    bgra_to_i420_into(bgra, width, height, stride, &mut out);
+    out
+}
+
+/// [`bgra_to_i420`] into a caller-provided buffer (resized to fit; a
+/// buffer already at the right length is overwritten without the
+/// zero-fill a fresh `vec![0; …]` would pay).
+///
+/// **Single fused pass:** luma for a pair of rows and the 2×2-averaged
+/// chroma for that row pair are computed together, so the (large) BGRA
+/// source streams through the cache once — the previous split Y-then-UV
+/// implementation read every pixel twice. Fixed-point BT.601 math is
+/// unchanged, so output bytes are identical.
+pub fn bgra_to_i420_into(bgra: &[u8], width: u32, height: u32, stride: u32, out: &mut Vec<u8>) {
     let w = width as usize;
     let h = height as usize;
     let s = stride as usize;
@@ -601,61 +619,103 @@ pub fn bgra_to_i420(bgra: &[u8], width: u32, height: u32, stride: u32) -> Vec<u8
 
     let y_size = w * h;
     let uv_size = uv_w * uv_h;
-    let mut out = vec![0u8; y_size + 2 * uv_size];
+    let total = y_size + 2 * uv_size;
+    if out.len() != total {
+        out.clear();
+        out.resize(total, 0);
+    }
 
     let (y_plane, uv_planes) = out.split_at_mut(y_size);
     let (u_plane, v_plane) = uv_planes.split_at_mut(uv_size);
 
-    // Compute luma in row-major order. This is the largest plane and the
-    // most cache-sensitive loop; fixed-point math avoids the old per-pixel
-    // floating-point conversions while preserving the BT.601 coefficients.
-    for row in 0..h {
-        let row_start = row * s;
-        let y_row_start = row * w;
-        for col in 0..w {
-            let px = row_start + col * 4;
-            y_plane[y_row_start + col] =
-                rgb_to_y(bgra[px + 2] as i32, bgra[px + 1] as i32, bgra[px] as i32);
+    // Full 2×2 interior blocks (even spans). Odd right column / bottom
+    // row are handled separately below so this hot loop stays
+    // branch-free per block.
+    let w2 = w & !1;
+    let h2 = h & !1;
+
+    for uv_row in 0..h2 / 2 {
+        let row0 = uv_row * 2;
+        let src0 = row0 * s;
+        let src1 = src0 + s;
+        let y0 = row0 * w;
+        let y1 = y0 + w;
+        let uv_base = uv_row * uv_w;
+        for uv_col in 0..w2 / 2 {
+            let x = uv_col * 8;
+            let p00 = src0 + x;
+            let p01 = p00 + 4;
+            let p10 = src1 + x;
+            let p11 = p10 + 4;
+
+            let (b00, g00, r00) = bgra_px(bgra, p00);
+            let (b01, g01, r01) = bgra_px(bgra, p01);
+            let (b10, g10, r10) = bgra_px(bgra, p10);
+            let (b11, g11, r11) = bgra_px(bgra, p11);
+
+            let col = uv_col * 2;
+            y_plane[y0 + col] = rgb_to_y(r00, g00, b00);
+            y_plane[y0 + col + 1] = rgb_to_y(r01, g01, b01);
+            y_plane[y1 + col] = rgb_to_y(r10, g10, b10);
+            y_plane[y1 + col + 1] = rgb_to_y(r11, g11, b11);
+
+            let sum_r = r00 + r01 + r10 + r11;
+            let sum_g = g00 + g01 + g10 + g11;
+            let sum_b = b00 + b01 + b10 + b11;
+            u_plane[uv_base + uv_col] = rgb_sum_to_u(sum_r, sum_g, sum_b, 4);
+            v_plane[uv_base + uv_col] = rgb_sum_to_v(sum_r, sum_g, sum_b, 4);
+        }
+
+        // Odd width: rightmost column contributes a 1×2 block.
+        if w2 < w {
+            let col = w - 1;
+            let p0 = src0 + col * 4;
+            let p1 = src1 + col * 4;
+            let (b0, g0, r0) = bgra_px(bgra, p0);
+            let (b1, g1, r1) = bgra_px(bgra, p1);
+            y_plane[y0 + col] = rgb_to_y(r0, g0, b0);
+            y_plane[y1 + col] = rgb_to_y(r1, g1, b1);
+            u_plane[uv_base + uv_w - 1] = rgb_sum_to_u(r0 + r1, g0 + g1, b0 + b1, 2);
+            v_plane[uv_base + uv_w - 1] = rgb_sum_to_v(r0 + r1, g0 + g1, b0 + b1, 2);
         }
     }
 
-    // Compute U, V by averaging 2x2 blocks.
-    for uv_row in 0..uv_h {
-        for uv_col in 0..uv_w {
-            let mut sum_r: i32 = 0;
-            let mut sum_g: i32 = 0;
-            let mut sum_b: i32 = 0;
-            let mut count: i32 = 0;
-
-            for dy in 0..2usize {
-                let row = uv_row * 2 + dy;
-                if row >= h {
-                    continue;
-                }
-                let row_start = row * s;
-                for dx in 0..2usize {
-                    let col = uv_col * 2 + dx;
-                    if col >= w {
-                        continue;
-                    }
-                    let px = row_start + col * 4;
-                    let b = bgra[px] as i32;
-                    let g = bgra[px + 1] as i32;
-                    let r = bgra[px + 2] as i32;
-                    sum_b += b;
-                    sum_g += g;
-                    sum_r += r;
-                    count += 1;
-                }
-            }
-
-            let idx = uv_row * uv_w + uv_col;
-            u_plane[idx] = rgb_sum_to_u(sum_r, sum_g, sum_b, count);
-            v_plane[idx] = rgb_sum_to_v(sum_r, sum_g, sum_b, count);
+    // Odd height: bottom row contributes 2×1 blocks (and a 1×1 corner
+    // when the width is odd too).
+    if h2 < h {
+        let row = h - 1;
+        let src = row * s;
+        let y_row = row * w;
+        let uv_base = (uv_h - 1) * uv_w;
+        for uv_col in 0..w2 / 2 {
+            let col = uv_col * 2;
+            let p0 = src + col * 4;
+            let p1 = p0 + 4;
+            let (b0, g0, r0) = bgra_px(bgra, p0);
+            let (b1, g1, r1) = bgra_px(bgra, p1);
+            y_plane[y_row + col] = rgb_to_y(r0, g0, b0);
+            y_plane[y_row + col + 1] = rgb_to_y(r1, g1, b1);
+            u_plane[uv_base + uv_col] = rgb_sum_to_u(r0 + r1, g0 + g1, b0 + b1, 2);
+            v_plane[uv_base + uv_col] = rgb_sum_to_v(r0 + r1, g0 + g1, b0 + b1, 2);
+        }
+        if w2 < w {
+            let col = w - 1;
+            let (b, g, r) = bgra_px(bgra, src + col * 4);
+            y_plane[y_row + col] = rgb_to_y(r, g, b);
+            u_plane[uv_base + uv_w - 1] = rgb_sum_to_u(r, g, b, 1);
+            v_plane[uv_base + uv_w - 1] = rgb_sum_to_v(r, g, b, 1);
         }
     }
+}
 
-    out
+/// Load one BGRA pixel as `(b, g, r)` i32 components.
+#[inline]
+fn bgra_px(bgra: &[u8], idx: usize) -> (i32, i32, i32) {
+    (
+        bgra[idx] as i32,
+        bgra[idx + 1] as i32,
+        bgra[idx + 2] as i32,
+    )
 }
 
 #[inline]

--- a/crates/intendant-display/src/encode/mod.rs
+++ b/crates/intendant-display/src/encode/mod.rs
@@ -881,7 +881,8 @@ impl EncodedPacket {
     /// Convert to the shared `EncodedFrame` type used by the display session.
     pub fn into_encoded_frame(self) -> EncodedFrame {
         EncodedFrame {
-            data: self.data,
+            // Vec -> Bytes is an ownership move, not a copy.
+            data: self.data.into(),
             pts_ms: self.pts_ms,
             duration_ms: self.duration_ms,
             is_keyframe: self.is_keyframe,

--- a/crates/intendant-display/src/encode/pool/mod.rs
+++ b/crates/intendant-display/src/encode/pool/mod.rs
@@ -686,10 +686,13 @@ impl EncoderPool {
 
     /// Push one I420 frame with an optional diagnostic visual-marker value.
     ///
-    /// The bridge stamps the source I420 frame before broadcasting to the pool.
-    /// Downscaled layers would otherwise shrink that marker, so encoder
-    /// threads re-stamp the same value after per-layer downscale when this is
-    /// `Some`.
+    /// When this is `Some`, the bridge has already stamped the marker into
+    /// `data` (a per-push copy of its cache, so heartbeat re-pushes of a
+    /// static desktop each carry a fresh value). Downscaling shrinks that
+    /// stamp, so encoder threads re-stamp the same value after per-layer
+    /// downscale — and only then: source-dimension encoders must use the
+    /// shared frame as-is (it is already stamped, and cloning it per
+    /// encoder is exactly the cost this contract removes).
     pub fn push_i420_frame_with_visual_marker(
         &self,
         data: Arc<Vec<u8>>,

--- a/crates/intendant-display/src/encode/pool/worker.rs
+++ b/crates/intendant-display/src/encode/pool/worker.rs
@@ -297,6 +297,10 @@ pub(crate) fn spawn_encoder_thread_with(
         // encoder's lifetime is owned entirely by this thread from here.
         drop(startup_tx);
         let mut watchdog = WatchdogState::new();
+        // Per-thread downscale scratch, reused across frames — the
+        // half/quarter layers otherwise allocate a fresh multi-hundred-
+        // KB buffer per frame at capture rate.
+        let mut scaled_buf: Vec<u8> = Vec::new();
         // Windows black-frame diagnostic: count encode calls so the
         // hop-by-hop avg-byte logging below self-limits to the first few
         // frames (then stays off the hot path).
@@ -399,15 +403,15 @@ pub(crate) fn spawn_encoder_thread_with(
             // check is computed once at thread spawn, so the hot path
             // for the source-dim layer (always-on full + every
             // on-demand on-source-dim layer) pays nothing.
-            let mut scaled_buf;
             let mut stamped_buf;
             let i420_for_encode: &[u8] = if needs_downscale {
-                scaled_buf = crate::encode::downscale_i420(
+                crate::encode::downscale_i420_into(
                     &frame.data,
                     downscale_src_w,
                     downscale_src_h,
                     downscale_dst_w,
                     downscale_dst_h,
+                    &mut scaled_buf,
                 );
                 if let Some(value) = frame.visual_marker_value {
                     let y_len = (downscale_dst_w as usize) * (downscale_dst_h as usize);

--- a/crates/intendant-display/src/encode/pool/worker.rs
+++ b/crates/intendant-display/src/encode/pool/worker.rs
@@ -403,7 +403,6 @@ pub(crate) fn spawn_encoder_thread_with(
             // check is computed once at thread spawn, so the hot path
             // for the source-dim layer (always-on full + every
             // on-demand on-source-dim layer) pays nothing.
-            let mut stamped_buf;
             let i420_for_encode: &[u8] = if needs_downscale {
                 crate::encode::downscale_i420_into(
                     &frame.data,
@@ -413,6 +412,13 @@ pub(crate) fn spawn_encoder_thread_with(
                     downscale_dst_h,
                     &mut scaled_buf,
                 );
+                // The bridge stamps the source frame at push time, but
+                // downscaling shrinks that stamp; re-stamp at output
+                // resolution (the full-size restamp rect covers the
+                // shrunk remnant). Source-dimension layers must NOT
+                // stamp: the shared frame already carries the marker,
+                // and cloning a multi-MB frame per encoder to re-stamp
+                // it was the old cost here.
                 if let Some(value) = frame.visual_marker_value {
                     let y_len = (downscale_dst_w as usize) * (downscale_dst_h as usize);
                     if let Some(y) = scaled_buf.get_mut(0..y_len) {
@@ -425,18 +431,6 @@ pub(crate) fn spawn_encoder_thread_with(
                     }
                 }
                 &scaled_buf
-            } else if let Some(value) = frame.visual_marker_value {
-                stamped_buf = frame.data.as_ref().clone();
-                let y_len = (downscale_dst_w as usize) * (downscale_dst_h as usize);
-                if let Some(y) = stamped_buf.get_mut(0..y_len) {
-                    visual_marker::stamp_y_plane(
-                        y,
-                        downscale_dst_w as usize,
-                        downscale_dst_h as usize,
-                        value,
-                    );
-                }
-                &stamped_buf
             } else {
                 &frame.data
             };

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -713,7 +713,11 @@ pub struct DisplayMetricsCounters {
     pub tile_dirty_tiles: AtomicU64,
     /// Sum of dirty fractions in parts-per-million for averaging.
     pub tile_dirty_fraction_ppm_sum: AtomicU64,
-    /// Dirty tile updates skipped by the source cadence cap.
+    /// Capture ticks the delta cadence gate deferred while known
+    /// (OS-reported or in-frame) damage was pending. On platforms
+    /// using the frame-diff fallback the diff itself runs at the
+    /// delta cadence, so deferred ticks there carry no known damage
+    /// and are not counted.
     pub tile_delta_cadence_skips: AtomicU64,
     /// Tile records packed into delta frames.
     pub tile_delta_records: AtomicU64,
@@ -1184,8 +1188,20 @@ pub struct DisplaySession {
 /// time, so heartbeat re-sends of a static desktop still carry a fresh marker
 /// timestamp and downscaled layers get a marker in their final output
 /// resolution.
-fn convert_for_pool_feed(bgra: &[u8], width: u32, height: u32, stride: u32) -> Vec<u8> {
-    let i420 = encode::bgra_to_i420(bgra, width, height, stride);
+///
+/// `reuse` is a retired I420 buffer to convert into (pass an empty
+/// `Vec` when none is available) — the bridge recycles buffers whose
+/// broadcast refcount has drained so the steady state performs no
+/// multi-MB allocation per frame.
+fn convert_for_pool_feed(
+    bgra: &[u8],
+    width: u32,
+    height: u32,
+    stride: u32,
+    reuse: Vec<u8>,
+) -> Vec<u8> {
+    let mut i420 = reuse;
+    encode::bgra_to_i420_into(bgra, width, height, stride, &mut i420);
 
     // Windows black-frame diagnostic (hop A of the capture → encoder chain):
     // log the average byte of the BGRA going INTO bgra_to_i420 and the I420
@@ -2764,8 +2780,11 @@ impl DisplaySession {
 
         let task = tokio::spawn(async move {
             let mut damage = make_damage_backend(initial_w, initial_h, backend_kind);
-            let mut frame_diff =
-                capture::frame_diff::FrameDiffDamageTracker::new(TILE_STREAM_TILE_SIZE_PX);
+            // `Option` so the tracker can round-trip through the
+            // spawn_blocking diff below (moved in, moved back out).
+            let mut frame_diff: Option<capture::frame_diff::FrameDiffDamageTracker> = Some(
+                capture::frame_diff::FrameDiffDamageTracker::new(TILE_STREAM_TILE_SIZE_PX),
+            );
             let mut grid: Option<tile::grid::TileGrid> = None;
             let mut synthetic_dirty = tile::synthetic_dirty::SyntheticDirtySources::new()
                 .with_marker((0, 0), visual_marker::MARKER_W as u32);
@@ -2773,7 +2792,12 @@ impl DisplaySession {
             let mut tile_policy = tile::policy::TilePolicy::new(Instant::now());
             let mut tile_mode = tile::policy::TileMode::Tiles;
             let mut next_snapshot_at = Instant::now() + tile_snapshot_period(tile_mode);
-            let mut last_delta_sent_at: Option<Instant> = None;
+            let mut last_delta_tick_at: Option<Instant> = None;
+            // Damage collected from the cheap per-frame sources
+            // (in-frame dirty rects, OS damage events) on ticks the
+            // delta cadence gate skipped; flushed into the next
+            // allowed tick so no damage is ever dropped by the gate.
+            let mut pending_rects: Vec<capture::damage::Rect> = Vec::new();
             let mut seq: u32 = 1;
 
             loop {
@@ -2796,7 +2820,8 @@ impl DisplaySession {
                             tile_policy = tile::policy::TilePolicy::new(Instant::now());
                             tile_mode = tile::policy::TileMode::Tiles;
                             next_snapshot_at = Instant::now() + tile_snapshot_period(tile_mode);
-                            last_delta_sent_at = None;
+                            last_delta_tick_at = None;
+                            pending_rects.clear();
                             continue;
                         }
 
@@ -2810,7 +2835,8 @@ impl DisplaySession {
                             grid = Some(next_grid);
                             tile_policy = tile::policy::TilePolicy::new(Instant::now());
                             tile_mode = tile::policy::TileMode::Tiles;
-                            last_delta_sent_at = None;
+                            last_delta_tick_at = None;
+                            pending_rects.clear();
                             synthetic_dirty.reset_cursor();
                             last_cursor = None;
                             let resize = tile::transport::TileFrame::Resize {
@@ -2852,41 +2878,109 @@ impl DisplaySession {
                             continue;
                         }
 
-                        let cursor_pos = damage.cursor_position();
-                        let cursor_changed = cursor_pos.is_some() && cursor_pos != last_cursor;
-                        if cursor_changed {
-                            last_cursor = cursor_pos;
-                        }
-
-                        let mut rects = if let Some(rects) = frame.dirty_rects.clone() {
-                            rects
-                        } else {
-                            match damage.capability() {
-                                capture::damage::DamageCapability::OsLevel => {
-                                    match damage.poll_damage() {
-                                        Ok(rects) => rects,
-                                        Err(e) => {
-                                            eprintln!(
-                                                "[display/tile] display {display_id} damage poll failed: {e}"
-                                            );
-                                            Vec::new()
-                                        }
-                                    }
-                                }
+                        // Collect the cheap damage sources on every
+                        // captured frame so nothing is lost across
+                        // delta-cadence skips: in-frame dirty rects are
+                        // per-frame data, and polling the OS damage
+                        // backend clears its server-side accumulation.
+                        // Skipped ticks accumulate into `pending_rects`;
+                        // the next allowed tick flushes the union.
+                        // (Before this accumulator the cadence gate sat
+                        // *after* the damage poll and discarded its
+                        // rects on skipped ticks — a change landing on
+                        // a skipped frame stayed stale until the 30s
+                        // snapshot.)
+                        let uses_frame_diff = frame.dirty_rects.is_none()
+                            && matches!(
+                                damage.capability(),
                                 capture::damage::DamageCapability::FrameDiff
-                                | capture::damage::DamageCapability::None => {
-                                    match frame_diff.diff_frame(&frame) {
-                                        Ok(rects) => rects,
-                                        Err(e) => {
-                                            eprintln!(
-                                                "[display/tile] display {display_id} frame-diff failed: {e}"
-                                            );
-                                            Vec::new()
-                                        }
-                                    }
+                                    | capture::damage::DamageCapability::None
+                            );
+                        if let Some(rects) = frame.dirty_rects.clone() {
+                            pending_rects.extend(rects);
+                        } else if !uses_frame_diff {
+                            match damage.poll_damage() {
+                                Ok(rects) => pending_rects.extend(rects),
+                                Err(e) => {
+                                    eprintln!(
+                                        "[display/tile] display {display_id} damage poll failed: {e}"
+                                    );
                                 }
                             }
-                        };
+                        }
+
+                        // Delta cadence gate — ahead of the frame-diff
+                        // fallback and the per-tick policy work, so both
+                        // run at the delta cadence (≤15fps), not at
+                        // capture rate. The clock advances on every
+                        // allowed tick (idle ones included): the gate
+                        // bounds the whole diff+encode pipeline, and
+                        // deltas can only be emitted on allowed ticks,
+                        // so the wire cadence cap is unchanged.
+                        let now = Instant::now();
+                        if !should_emit_tile_delta(
+                            now,
+                            last_delta_tick_at,
+                            tile_delta_min_interval(),
+                        ) {
+                            if tile_mode == tile::policy::TileMode::Tiles
+                                && !pending_rects.is_empty()
+                            {
+                                counters.record_tile_delta_cadence_skip();
+                            }
+                            continue;
+                        }
+                        last_delta_tick_at = Some(now);
+
+                        let mut rects = std::mem::take(&mut pending_rects);
+
+                        // Frame-diff fallback (macOS/Windows/Wayland —
+                        // the platforms without an OS damage source):
+                        // hash every tile of the frame and diff against
+                        // the previous baseline. This walks the whole
+                        // frame, so it runs on the blocking pool, never
+                        // inline on the runtime, and only on allowed
+                        // ticks. Skipping frames is safe: the baseline
+                        // only advances when a diff runs, so a change
+                        // landing on a skipped frame is caught by the
+                        // next diff.
+                        if uses_frame_diff {
+                            let tracker = frame_diff.take().unwrap_or_else(|| {
+                                capture::frame_diff::FrameDiffDamageTracker::new(
+                                    TILE_STREAM_TILE_SIZE_PX,
+                                )
+                            });
+                            let diff_result = tokio::task::spawn_blocking({
+                                let frame = Arc::clone(&frame);
+                                move || {
+                                    let mut tracker = tracker;
+                                    let rects = tracker.diff_frame(&frame);
+                                    (tracker, rects)
+                                }
+                            })
+                            .await;
+                            match diff_result {
+                                Ok((tracker, Ok(diff_rects))) => {
+                                    frame_diff = Some(tracker);
+                                    rects.extend(diff_rects);
+                                }
+                                Ok((tracker, Err(e))) => {
+                                    frame_diff = Some(tracker);
+                                    eprintln!(
+                                        "[display/tile] display {display_id} frame-diff failed: {e}"
+                                    );
+                                }
+                                Err(e) => {
+                                    // Tracker lost with the cancelled/
+                                    // panicked task; the replacement
+                                    // re-baselines (all tiles dirty) on
+                                    // the next allowed tick.
+                                    eprintln!(
+                                        "[display/tile] display {display_id} frame-diff task failed: {e}"
+                                    );
+                                }
+                            }
+                        }
 
                         let policy_dirty = next_grid.dirty_tiles(&rects);
                         let dirty_fraction = next_grid.dirty_fraction(policy_dirty.len());
@@ -2895,7 +2989,7 @@ impl DisplaySession {
                             let epoch = tile_epoch.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
                             seq = 1;
                             tile_mode = next_mode;
-                            last_delta_sent_at = None;
+                            last_delta_tick_at = None;
                             next_snapshot_at = Instant::now() + tile_snapshot_period(tile_mode);
                             match tile_mode {
                                 tile::policy::TileMode::Video => {
@@ -2946,6 +3040,18 @@ impl DisplaySession {
                             continue;
                         }
 
+                        // Cursor: sampled at the delta cadence, not at
+                        // capture rate — on X11 this is a synchronous
+                        // QueryPointer round-trip per sample, and both
+                        // consumers (the CursorState control frame and
+                        // the synthetic dirty boxes) only act on
+                        // allowed ticks anyway.
+                        let cursor_pos = damage.cursor_position();
+                        let cursor_changed = cursor_pos.is_some() && cursor_pos != last_cursor;
+                        if cursor_changed {
+                            last_cursor = cursor_pos;
+                        }
+
                         synthetic_dirty.set_marker_enabled(visual_marker_value.is_some());
                         rects.extend(
                             synthetic_dirty.collect(cursor_pos, visual_marker_value.is_some()),
@@ -2992,17 +3098,6 @@ impl DisplaySession {
                             dirty.len(),
                             next_grid.dirty_fraction(dirty.len()),
                         );
-
-                        let now = Instant::now();
-                        if !should_emit_tile_delta(
-                            now,
-                            last_delta_sent_at,
-                            tile_delta_min_interval(),
-                        ) {
-                            counters.record_tile_delta_cadence_skip();
-                            continue;
-                        }
-                        last_delta_sent_at = Some(now);
 
                         let epoch = tile_epoch.load(Ordering::Relaxed);
                         let encode_result = tokio::task::spawn_blocking({
@@ -3217,6 +3312,15 @@ impl DisplaySession {
             let mut generation: u64 = 0;
             let mut last_sent_gen: Option<u64> = None;
             let mut last_send_at = Instant::now();
+            // Retired `latest_i420` buffers awaiting their broadcast
+            // refcount to drain. The pool's I420 broadcast ring holds
+            // the last I420_BROADCAST_CAPACITY (4) sent frames, so an
+            // entry becomes reclaimable (`Arc::try_unwrap`) once ~4
+            // newer frames have shipped; one extra slot of headroom
+            // keeps the steady state allocation-free.
+            const I420_RECYCLE_DEPTH: usize = 5;
+            let mut i420_recycle: std::collections::VecDeque<Arc<Vec<u8>>> =
+                std::collections::VecDeque::with_capacity(I420_RECYCLE_DEPTH + 1);
             // 3c.3b.4b: peer-join burst window. `None` outside a
             // burst; `Some(deadline)` while clocking the encoder
             // through to a natural keyframe regardless of dirty
@@ -3345,6 +3449,11 @@ impl DisplaySession {
                             // to be replaced by this frame anyway.)
                             latest_i420 = None;
                             last_sent_gen = None;
+                            // Old-dimension buffers would be resized on
+                            // reuse anyway; drop them rather than hold
+                            // multi-MB stale allocations across what may
+                            // be a downsize.
+                            i420_recycle.clear();
                         }
 
                         // F2 idle gate: do NOT convert here. Stash the
@@ -3392,12 +3501,30 @@ impl DisplaySession {
                         if let Some((frame, arrived)) = pending_bgra.take() {
                             let frame_w = frame.width & !1;
                             let frame_h = frame.height & !1;
+                            // Reclaim the oldest retired buffer whose
+                            // broadcast refcount has drained; fall back
+                            // to a fresh allocation when every retiree
+                            // is still referenced.
+                            let mut reuse = Vec::new();
+                            for _ in 0..i420_recycle.len() {
+                                let candidate = i420_recycle
+                                    .pop_front()
+                                    .expect("iteration bounded by queue length");
+                                match Arc::try_unwrap(candidate) {
+                                    Ok(buf) => {
+                                        reuse = buf;
+                                        break;
+                                    }
+                                    Err(still_shared) => i420_recycle.push_back(still_shared),
+                                }
+                            }
                             let i420_result = tokio::task::spawn_blocking(
                                 move || convert_for_pool_feed(
                                     &frame.data,
                                     frame_w,
                                     frame_h,
                                     frame.stride,
+                                    reuse,
                                 )
                             )
                             .await;
@@ -3406,7 +3533,14 @@ impl DisplaySession {
                                     .pool_feed_conversions
                                     .fetch_add(1, Ordering::Relaxed);
                                 generation = generation.wrapping_add(1);
-                                latest_i420 = Some((Arc::new(i420), arrived));
+                                if let Some((old, _)) =
+                                    latest_i420.replace((Arc::new(i420), arrived))
+                                {
+                                    i420_recycle.push_back(old);
+                                    while i420_recycle.len() > I420_RECYCLE_DEPTH {
+                                        i420_recycle.pop_front();
+                                    }
+                                }
                             }
                         }
 

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -1188,10 +1188,11 @@ pub struct DisplaySession {
 
 /// Convert one BGRA frame to I420 for the pool-feed bridge.
 ///
-/// Phase 0 visual-freshness stamps are applied later, at pool send/encoder
-/// time, so heartbeat re-sends of a static desktop still carry a fresh marker
-/// timestamp and downscaled layers get a marker in their final output
-/// resolution.
+/// Phase 0 visual-freshness stamps are applied later, at pool *push* time
+/// (into a per-push copy of the cached buffer), so heartbeat re-sends of a
+/// static desktop still carry a fresh marker timestamp; encoder threads
+/// re-stamp only after per-layer downscale so shrunken markers are redrawn
+/// at final output resolution.
 ///
 /// `reuse` is a retired I420 buffer to convert into (pass an empty
 /// `Vec` when none is available) — the bridge recycles buffers whose
@@ -3649,8 +3650,35 @@ impl DisplaySession {
                             } else {
                                 None
                             };
+                        // Marker stamping happens here, once per push,
+                        // into a per-push copy: the cached buffer stays
+                        // unstamped (it is Arc-shared with in-flight
+                        // encoders and future re-pushes), and stamping
+                        // at push time keeps the heartbeat property —
+                        // every re-push of a static desktop carries a
+                        // fresh marker value. One copy per *push*
+                        // replaces the old one copy per *source-dim
+                        // encoder per frame* (workers now only re-stamp
+                        // after downscale, where they already own a
+                        // buffer). Marker off (the default): no copy.
+                        let push_buf = match visual_marker_value {
+                            Some(value) => {
+                                let mut stamped = i420.as_ref().clone();
+                                let y_len = enc_w as usize * enc_h as usize;
+                                if let Some(y) = stamped.get_mut(0..y_len) {
+                                    visual_marker::stamp_y_plane(
+                                        y,
+                                        enc_w as usize,
+                                        enc_h as usize,
+                                        value,
+                                    );
+                                }
+                                Arc::new(stamped)
+                            }
+                            None => Arc::clone(i420),
+                        };
                         pool.push_i420_frame_with_visual_marker(
-                            Arc::clone(i420),
+                            push_buf,
                             arrived,
                             visual_marker_value,
                         );

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -1416,29 +1416,33 @@ fn make_damage_backend(
     Box::new(capture::damage::NullDamageBackend::new(width, height))
 }
 
-async fn send_tile_snapshot_to_peer(
-    peer: Arc<webrtc::WebRtcPeer>,
+/// Encode a full-screen tile snapshot into wire frames **once**; the
+/// caller fans the refcounted frames out to any number of peers. The
+/// raw-copy + RLE + lossless-WebP encode of the whole screen is the
+/// expensive part of a snapshot, and it is identical for every peer —
+/// per-peer re-encoding scaled that cost with viewer count.
+///
+/// Returns `None` (after logging) when encoding or packing fails.
+/// Records one `record_tile_snapshot_source` sample per snapshot
+/// encoded (not per peer served — the counters measure generated wire
+/// frames/bytes).
+async fn encode_tile_snapshot_frames(
     frame: Arc<Frame>,
     epoch: u32,
     snapshot_id: u32,
     visual_marker_value: Option<u32>,
-    counters: Arc<DisplayMetricsCounters>,
-) {
-    let Some(grid) = tile_grid_for_frame(&frame) else {
-        return;
-    };
-    let encode_result = tokio::task::spawn_blocking({
-        let frame = Arc::clone(&frame);
-        move || {
-            let records = encode_tile_records(&frame, all_tile_ids(&grid), visual_marker_value)?;
-            Ok::<_, tile::encode::TileEncodeError>((grid, records))
-        }
+    counters: &DisplayMetricsCounters,
+) -> Option<Vec<bytes::Bytes>> {
+    let grid = tile_grid_for_frame(&frame)?;
+    let encode_result = tokio::task::spawn_blocking(move || {
+        let records = encode_tile_records(&frame, all_tile_ids(&grid), visual_marker_value)?;
+        Ok::<_, tile::encode::TileEncodeError>((grid, records))
     })
     .await;
 
     let Ok(Ok((grid, records))) = encode_result else {
         eprintln!("[display/tile] snapshot tile encode failed");
-        return;
+        return None;
     };
 
     let record_count = records.len();
@@ -1453,24 +1457,52 @@ async fn send_tile_snapshot_to_peer(
         Ok(frames) => frames,
         Err(e) => {
             eprintln!("[display/tile] snapshot pack failed: {e}");
-            return;
+            return None;
         }
     };
 
-    let frame_count = frames.len();
+    let mut out = Vec::with_capacity(frames.len());
     let mut byte_count = 0usize;
     for frame in frames {
         match tile::transport::encode_frame(&frame) {
             Ok(bytes) => {
                 byte_count = byte_count.saturating_add(bytes.len());
-                if let Err(e) = peer.send_tile_snapshot_frame(bytes).await {
-                    eprintln!("[display/tile] send snapshot failed: {e}");
-                }
+                out.push(bytes::Bytes::from(bytes));
             }
             Err(e) => eprintln!("[display/tile] snapshot wire encode failed: {e}"),
         }
     }
-    counters.record_tile_snapshot_source(record_count, frame_count, byte_count);
+    counters.record_tile_snapshot_source(record_count, out.len(), byte_count);
+    Some(out)
+}
+
+/// Send already-encoded snapshot wire frames to one peer (refcount
+/// bumps per frame; see [`encode_tile_snapshot_frames`]).
+async fn send_tile_snapshot_frames_to_peer(
+    peer: &Arc<webrtc::WebRtcPeer>,
+    frames: &[bytes::Bytes],
+) {
+    for bytes in frames {
+        if let Err(e) = peer.send_tile_snapshot_frame(bytes.clone()).await {
+            eprintln!("[display/tile] send snapshot failed: {e}");
+        }
+    }
+}
+
+async fn send_tile_snapshot_to_peer(
+    peer: Arc<webrtc::WebRtcPeer>,
+    frame: Arc<Frame>,
+    epoch: u32,
+    snapshot_id: u32,
+    visual_marker_value: Option<u32>,
+    counters: Arc<DisplayMetricsCounters>,
+) {
+    if let Some(frames) =
+        encode_tile_snapshot_frames(frame, epoch, snapshot_id, visual_marker_value, &counters)
+            .await
+    {
+        send_tile_snapshot_frames_to_peer(&peer, &frames).await;
+    }
 }
 
 async fn send_tile_control_to_peers(
@@ -1480,6 +1512,7 @@ async fn send_tile_control_to_peers(
 ) {
     match tile::transport::encode_frame(&frame) {
         Ok(bytes) => {
+            let bytes = bytes::Bytes::from(bytes);
             for peer in peers {
                 if let Err(e) = peer.send_tile_control_frame(bytes.clone()).await {
                     eprintln!("[display/tile] {context} send failed: {e}");
@@ -2851,15 +2884,22 @@ impl DisplaySession {
                             };
                             send_tile_control_to_peers(&peers_now, resize, "resize").await;
                             let snapshot_id = tile_snapshot_id.fetch_add(1, Ordering::Relaxed);
-                            for peer in peers_now {
-                                send_tile_snapshot_to_peer(
-                                    peer,
-                                    Arc::clone(&frame),
-                                    epoch,
-                                    snapshot_id,
-                                    visual_marker_value,
-                                    Arc::clone(&counters),
-                                ).await;
+                            // Encode the snapshot once, fan the wire
+                            // frames out refcounted — a full-screen
+                            // lossless encode per peer scaled with
+                            // viewer count for identical output.
+                            if let Some(frames) = encode_tile_snapshot_frames(
+                                Arc::clone(&frame),
+                                epoch,
+                                snapshot_id,
+                                visual_marker_value,
+                                &counters,
+                            )
+                            .await
+                            {
+                                for peer in &peers_now {
+                                    send_tile_snapshot_frames_to_peer(peer, &frames).await;
+                                }
                             }
                             next_snapshot_at = Instant::now() + tile_snapshot_period(tile_mode);
                             continue;
@@ -2868,15 +2908,18 @@ impl DisplaySession {
                         if Instant::now() >= next_snapshot_at {
                             let epoch = tile_epoch.load(Ordering::Relaxed);
                             let snapshot_id = tile_snapshot_id.fetch_add(1, Ordering::Relaxed);
-                            for peer in peers_now {
-                                send_tile_snapshot_to_peer(
-                                    peer,
-                                    Arc::clone(&frame),
-                                    epoch,
-                                    snapshot_id,
-                                    visual_marker_value,
-                                    Arc::clone(&counters),
-                                ).await;
+                            if let Some(frames) = encode_tile_snapshot_frames(
+                                Arc::clone(&frame),
+                                epoch,
+                                snapshot_id,
+                                visual_marker_value,
+                                &counters,
+                            )
+                            .await
+                            {
+                                for peer in &peers_now {
+                                    send_tile_snapshot_frames_to_peer(peer, &frames).await;
+                                }
                             }
                             next_snapshot_at = Instant::now() + tile_snapshot_period(tile_mode);
                             continue;
@@ -3025,15 +3068,19 @@ impl DisplaySession {
                                     ).await;
                                     let snapshot_id =
                                         tile_snapshot_id.fetch_add(1, Ordering::Relaxed);
-                                    for peer in peers_now {
-                                        send_tile_snapshot_to_peer(
-                                            peer,
-                                            Arc::clone(&frame),
-                                            epoch,
-                                            snapshot_id,
-                                            visual_marker_value,
-                                            Arc::clone(&counters),
-                                        ).await;
+                                    if let Some(frames) = encode_tile_snapshot_frames(
+                                        Arc::clone(&frame),
+                                        epoch,
+                                        snapshot_id,
+                                        visual_marker_value,
+                                        &counters,
+                                    )
+                                    .await
+                                    {
+                                        for peer in &peers_now {
+                                            send_tile_snapshot_frames_to_peer(peer, &frames)
+                                                .await;
+                                        }
                                     }
                                 }
                             }
@@ -3072,6 +3119,7 @@ impl DisplaySession {
                                 };
                                 match tile::transport::encode_frame(&cursor) {
                                     Ok(bytes) => {
+                                        let bytes = bytes::Bytes::from(bytes);
                                         let peers_now =
                                             tile_subscriber_peer_handles(&peers, &subscribers).await;
                                         for peer in peers_now {
@@ -3135,7 +3183,7 @@ impl DisplaySession {
                             match tile::transport::encode_frame(&frame) {
                                 Ok(bytes) => {
                                     byte_count = byte_count.saturating_add(bytes.len());
-                                    encoded.push((frame_seq, bytes));
+                                    encoded.push((frame_seq, bytes::Bytes::from(bytes)));
                                 }
                                 Err(e) => eprintln!("[display/tile] update wire encode failed: {e}"),
                             }

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -276,7 +276,11 @@ pub enum FrameFormat {
 /// sets, not just codec names.
 #[derive(Clone)]
 pub struct EncodedFrame {
-    pub data: Vec<u8>,
+    /// Encoded payload. `Bytes` (not `Vec<u8>`) so the per-peer WebRTC
+    /// drivers can hand the payload to the RTP packetizer with a
+    /// refcount bump instead of copying the whole frame once per peer
+    /// per frame.
+    pub data: bytes::Bytes,
     pub pts_ms: u64,
     pub duration_ms: u64,
     pub is_keyframe: bool,

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -1975,6 +1975,12 @@ impl DisplaySession {
             let mut frame_counter = 0u64;
             let reg_handle = tokio::spawn(async move {
                 let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
+                // The frame the cached JPEG was encoded from, so an
+                // unchanged `latest_frame` (event-driven backends emit
+                // nothing while the desktop is idle) re-registers the
+                // cached bytes instead of re-encoding the identical
+                // image every second.
+                let mut last_jpeg: Option<(Arc<Frame>, Vec<u8>)> = None;
                 loop {
                     tokio::select! {
                         _ = shutdown_reg.cancelled() => break,
@@ -1990,57 +1996,41 @@ impl DisplaySession {
                             let Some(frame) = frame else { continue };
                             let w = frame.width;
                             let h = frame.height;
-                            // Encode BGRA/RGBA → JPEG on blocking pool
-                            let jpeg = tokio::task::spawn_blocking(move || {
-                                // Strip row padding if stride > width * 4
-                                let row_bytes = w as usize * 4;
-                                let stride = frame.stride as usize;
-                                let rgba_data = match frame.format {
-                                    FrameFormat::Rgba if stride == row_bytes => frame.data.clone(),
-                                    FrameFormat::Rgba => {
-                                        let mut tight = Vec::with_capacity(row_bytes * h as usize);
-                                        for row in 0..h as usize {
-                                            let start = row * stride;
-                                            tight.extend_from_slice(&frame.data[start..start + row_bytes]);
-                                        }
-                                        tight
-                                    }
-                                    FrameFormat::Bgra => {
-                                        let mut tight = Vec::with_capacity(row_bytes * h as usize);
-                                        for row in 0..h as usize {
-                                            let start = row * stride;
-                                            for col in 0..w as usize {
-                                                let px = start + col * 4;
-                                                tight.push(frame.data[px + 2]); // R
-                                                tight.push(frame.data[px + 1]); // G
-                                                tight.push(frame.data[px]);      // B
-                                                tight.push(frame.data[px + 3]); // A
-                                            }
-                                        }
-                                        tight
-                                    }
-                                };
-                                let img = image::RgbaImage::from_raw(w, h, rgba_data)?;
-                                let mut buf = std::io::Cursor::new(Vec::new());
-                                img.write_to(&mut buf, image::ImageFormat::Jpeg).ok()?;
-                                Some(buf.into_inner())
-                            }).await.ok().flatten();
-                            if let Some(jpeg_bytes) = jpeg {
-                                frame_counter += 1;
-                                let stream = format!("display_{}", display_id);
-                                let frame_id = format!("{}-f{}", stream, frame_counter);
-                                let meta = presence_core::FrameMeta {
-                                    frame_id,
-                                    stream,
-                                    timestamp: chrono::Utc::now().to_rfc3339(),
-                                    sent_to_live: false,
-                                    live_resolution: None,
-                                    hq_resolution: Some(format!("{}x{}", w, h)),
-                                    note: None,
-                                };
-                                let mut reg = registry.write().await;
-                                let _ = reg.register(meta, &jpeg_bytes);
+                            let cache_hit = last_jpeg
+                                .as_ref()
+                                .is_some_and(|(cached, _)| Arc::ptr_eq(cached, &frame));
+                            if !cache_hit {
+                                // Encode BGRA/RGBA → JPEG on blocking pool
+                                let encode_frame = Arc::clone(&frame);
+                                let jpeg = tokio::task::spawn_blocking(move || {
+                                    let rgba_data = frame_to_tight_rgba(&encode_frame);
+                                    let img = image::RgbaImage::from_raw(w, h, rgba_data)?;
+                                    let mut buf = std::io::Cursor::new(Vec::new());
+                                    img.write_to(&mut buf, image::ImageFormat::Jpeg).ok()?;
+                                    Some(buf.into_inner())
+                                }).await.ok().flatten();
+                                // On encode failure, register nothing this
+                                // tick (matching the old behavior) rather
+                                // than re-publishing a stale cache entry
+                                // as if it were this frame.
+                                let Some(jpeg) = jpeg else { continue };
+                                last_jpeg = Some((frame, jpeg));
                             }
+                            let Some((_, jpeg_bytes)) = last_jpeg.as_ref() else { continue };
+                            frame_counter += 1;
+                            let stream = format!("display_{}", display_id);
+                            let frame_id = format!("{}-f{}", stream, frame_counter);
+                            let meta = presence_core::FrameMeta {
+                                frame_id,
+                                stream,
+                                timestamp: chrono::Utc::now().to_rfc3339(),
+                                sent_to_live: false,
+                                live_resolution: None,
+                                hq_resolution: Some(format!("{}x{}", w, h)),
+                                note: None,
+                            };
+                            let mut reg = registry.write().await;
+                            let _ = reg.register(meta, jpeg_bytes);
                         }
                     }
                 }
@@ -2360,8 +2350,16 @@ impl DisplaySession {
     }
 
     /// Encode the latest frame as a PNG screenshot.
+    ///
+    /// The PNG encode of a multi-MB frame is 50-200ms of pure CPU, so
+    /// it runs on the blocking pool — inline it would stall unrelated
+    /// tasks on the async runtime for every CU action / dashboard /
+    /// MCP screenshot.
     pub async fn screenshot(&self) -> Result<Vec<u8>, CallerError> {
-        encode_frame_png(&*self.current_frame().await?)
+        let frame = self.current_frame().await?;
+        tokio::task::spawn_blocking(move || encode_frame_png(&frame))
+            .await
+            .map_err(|e| CallerError::Display(format!("screenshot encode task failed: {e}")))?
     }
 
     /// The freshest raw frame captured at or after `min_timestamp`, waiting up
@@ -2421,13 +2419,63 @@ impl DisplaySession {
 
     /// Encode a PNG screenshot from a frame captured at or after
     /// `min_timestamp`, waiting up to `timeout` for one to arrive (the
-    /// [`Self::fresh_frame`] contract).
+    /// [`Self::fresh_frame`] contract). Encode runs on the blocking
+    /// pool — see [`Self::screenshot`].
     pub async fn screenshot_fresh(
         &self,
         min_timestamp: Instant,
         timeout: Duration,
     ) -> Result<Vec<u8>, CallerError> {
-        encode_frame_png(&*self.fresh_frame(min_timestamp, timeout).await?)
+        let frame = self.fresh_frame(min_timestamp, timeout).await?;
+        tokio::task::spawn_blocking(move || encode_frame_png(&frame))
+            .await
+            .map_err(|e| CallerError::Display(format!("screenshot encode task failed: {e}")))?
+    }
+}
+
+/// Convert a raw captured frame to tightly-packed RGBA bytes: stride
+/// padding stripped, BGRA swizzled to RGBA.
+///
+/// The one shared pixel converter for every screenshot/JPEG path (PNG
+/// screenshots, the FrameRegistry sampler). Row-wise with indexed
+/// writes into a pre-sized buffer — the previous per-site loops pushed
+/// four bounds-checked bytes per pixel (~15M pushes per 1440p frame),
+/// which defeated autovectorization and cost tens of milliseconds per
+/// conversion on the CU screenshot path.
+fn frame_to_tight_rgba(frame: &Frame) -> Vec<u8> {
+    let (w, h) = (frame.width as usize, frame.height as usize);
+    let row_bytes = w * 4;
+    let stride = (frame.stride as usize).max(row_bytes);
+
+    match frame.format {
+        FrameFormat::Rgba if stride == row_bytes => frame.data.clone(),
+        FrameFormat::Rgba => {
+            let mut tight = Vec::with_capacity(row_bytes * h);
+            for row in 0..h {
+                let start = row * stride;
+                tight.extend_from_slice(&frame.data[start..start + row_bytes]);
+            }
+            tight
+        }
+        FrameFormat::Bgra => {
+            let mut tight = vec![0u8; row_bytes * h];
+            for (dst_row, src_row) in tight
+                .chunks_exact_mut(row_bytes)
+                .zip(frame.data.chunks(stride))
+            {
+                let src_row = &src_row[..row_bytes];
+                for (dst, px) in dst_row
+                    .chunks_exact_mut(4)
+                    .zip(src_row.chunks_exact(4))
+                {
+                    dst[0] = px[2];
+                    dst[1] = px[1];
+                    dst[2] = px[0];
+                    dst[3] = px[3];
+                }
+            }
+            tight
+        }
     }
 }
 
@@ -2437,41 +2485,7 @@ impl DisplaySession {
 /// consumers can transform the raw pixels (resize, crop, annotate) and encode
 /// PNG exactly once, instead of decoding a PNG this crate just encoded.
 pub fn frame_to_rgba_image(frame: &Frame) -> Result<image::RgbaImage, CallerError> {
-    let (w, h) = (frame.width, frame.height);
-
-    // Convert from BGRA (or RGBA) to tightly-packed RGBA for the image crate.
-    // If stride > width * 4 the rows have alignment padding that must be stripped.
-    let row_bytes = w as usize * 4;
-    let stride = frame.stride as usize;
-
-    let rgba_data = match frame.format {
-        FrameFormat::Rgba if stride == row_bytes => frame.data.clone(),
-        FrameFormat::Rgba => {
-            let mut tight = Vec::with_capacity(row_bytes * h as usize);
-            for row in 0..h as usize {
-                let start = row * stride;
-                tight.extend_from_slice(&frame.data[start..start + row_bytes]);
-            }
-            tight
-        }
-        FrameFormat::Bgra => {
-            let mut tight = Vec::with_capacity(row_bytes * h as usize);
-            for row in 0..h as usize {
-                let start = row * stride;
-                for col in 0..w as usize {
-                    let px = start + col * 4;
-                    // Swap B <-> R while copying
-                    tight.push(frame.data[px + 2]); // R
-                    tight.push(frame.data[px + 1]); // G
-                    tight.push(frame.data[px]); // B
-                    tight.push(frame.data[px + 3]); // A
-                }
-            }
-            tight
-        }
-    };
-
-    image::RgbaImage::from_raw(w, h, rgba_data)
+    image::RgbaImage::from_raw(frame.width, frame.height, frame_to_tight_rgba(frame))
         .ok_or_else(|| CallerError::Display("failed to construct image from frame data".into()))
 }
 

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -1477,22 +1477,21 @@ async fn encode_tile_snapshot_frames(
     Some(out)
 }
 
-/// Send already-encoded snapshot wire frames to one peer (refcount
-/// bumps per frame; see [`encode_tile_snapshot_frames`]).
-/// `snapshot_id` tags every chunk so the driver's pre-open queue can
-/// supersede stale snapshots at whole-group granularity.
+/// Send already-encoded snapshot wire frames to one peer as one
+/// **complete group** (refcount bumps per chunk; see
+/// [`encode_tile_snapshot_frames`]). The atomic hand-off is what keeps
+/// a partial baseline out of the driver's pre-open queue: a producer
+/// cancelled before this call publishes nothing.
 async fn send_tile_snapshot_frames_to_peer(
     peer: &Arc<webrtc::WebRtcPeer>,
     frames: &[bytes::Bytes],
     snapshot_id: u32,
 ) {
-    for bytes in frames {
-        if let Err(e) = peer
-            .send_tile_snapshot_frame(bytes.clone(), snapshot_id)
-            .await
-        {
-            eprintln!("[display/tile] send snapshot failed: {e}");
-        }
+    if let Err(e) = peer
+        .send_tile_snapshot_group(snapshot_id, frames.to_vec())
+        .await
+    {
+        eprintln!("[display/tile] send snapshot failed: {e}");
     }
 }
 

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -1499,8 +1499,7 @@ async fn send_tile_snapshot_to_peer(
     counters: Arc<DisplayMetricsCounters>,
 ) {
     if let Some(frames) =
-        encode_tile_snapshot_frames(frame, epoch, snapshot_id, visual_marker_value, &counters)
-            .await
+        encode_tile_snapshot_frames(frame, epoch, snapshot_id, visual_marker_value, &counters).await
     {
         send_tile_snapshot_frames_to_peer(&peer, &frames).await;
     }
@@ -2465,10 +2464,7 @@ fn frame_to_tight_rgba(frame: &Frame) -> Vec<u8> {
                 .zip(frame.data.chunks(stride))
             {
                 let src_row = &src_row[..row_bytes];
-                for (dst, px) in dst_row
-                    .chunks_exact_mut(4)
-                    .zip(src_row.chunks_exact(4))
-                {
+                for (dst, px) in dst_row.chunks_exact_mut(4).zip(src_row.chunks_exact(4)) {
                     dst[0] = px[2];
                     dst[1] = px[1];
                     dst[2] = px[0];

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -1477,22 +1477,18 @@ async fn encode_tile_snapshot_frames(
     Some(out)
 }
 
-/// Send already-encoded snapshot wire frames to one peer as one
+/// Publish already-encoded snapshot wire frames to one peer as one
 /// **complete group** (refcount bumps per chunk; see
-/// [`encode_tile_snapshot_frames`]). The atomic hand-off is what keeps
-/// a partial baseline out of the driver's pre-open queue: a producer
-/// cancelled before this call publishes nothing.
-async fn send_tile_snapshot_frames_to_peer(
+/// [`encode_tile_snapshot_frames`]). Synchronous latest-wins hand-off:
+/// the producer never awaits while holding a group, and a cancelled
+/// producer publishes nothing — a partial baseline can exist neither
+/// upstream (the peer's mailbox) nor in the driver's pre-open queue.
+fn send_tile_snapshot_frames_to_peer(
     peer: &Arc<webrtc::WebRtcPeer>,
     frames: &[bytes::Bytes],
     snapshot_id: u32,
 ) {
-    if let Err(e) = peer
-        .send_tile_snapshot_group(snapshot_id, frames.to_vec())
-        .await
-    {
-        eprintln!("[display/tile] send snapshot failed: {e}");
-    }
+    peer.send_tile_snapshot_group(snapshot_id, frames.to_vec());
 }
 
 async fn send_tile_snapshot_to_peer(
@@ -1506,7 +1502,7 @@ async fn send_tile_snapshot_to_peer(
     if let Some(frames) =
         encode_tile_snapshot_frames(frame, epoch, snapshot_id, visual_marker_value, &counters).await
     {
-        send_tile_snapshot_frames_to_peer(&peer, &frames, snapshot_id).await;
+        send_tile_snapshot_frames_to_peer(&peer, &frames, snapshot_id);
     }
 }
 
@@ -2914,7 +2910,7 @@ impl DisplaySession {
                             .await
                             {
                                 for peer in &peers_now {
-                                    send_tile_snapshot_frames_to_peer(peer, &frames, snapshot_id).await;
+                                    send_tile_snapshot_frames_to_peer(peer, &frames, snapshot_id);
                                 }
                             }
                             next_snapshot_at = Instant::now() + tile_snapshot_period(tile_mode);
@@ -2934,7 +2930,7 @@ impl DisplaySession {
                             .await
                             {
                                 for peer in &peers_now {
-                                    send_tile_snapshot_frames_to_peer(peer, &frames, snapshot_id).await;
+                                    send_tile_snapshot_frames_to_peer(peer, &frames, snapshot_id);
                                 }
                             }
                             next_snapshot_at = Instant::now() + tile_snapshot_period(tile_mode);
@@ -3098,8 +3094,7 @@ impl DisplaySession {
                                                 peer,
                                                 &frames,
                                                 snapshot_id,
-                                            )
-                                            .await;
+                                            );
                                         }
                                     }
                                 }

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -1479,12 +1479,18 @@ async fn encode_tile_snapshot_frames(
 
 /// Send already-encoded snapshot wire frames to one peer (refcount
 /// bumps per frame; see [`encode_tile_snapshot_frames`]).
+/// `snapshot_id` tags every chunk so the driver's pre-open queue can
+/// supersede stale snapshots at whole-group granularity.
 async fn send_tile_snapshot_frames_to_peer(
     peer: &Arc<webrtc::WebRtcPeer>,
     frames: &[bytes::Bytes],
+    snapshot_id: u32,
 ) {
     for bytes in frames {
-        if let Err(e) = peer.send_tile_snapshot_frame(bytes.clone()).await {
+        if let Err(e) = peer
+            .send_tile_snapshot_frame(bytes.clone(), snapshot_id)
+            .await
+        {
             eprintln!("[display/tile] send snapshot failed: {e}");
         }
     }
@@ -1501,7 +1507,7 @@ async fn send_tile_snapshot_to_peer(
     if let Some(frames) =
         encode_tile_snapshot_frames(frame, epoch, snapshot_id, visual_marker_value, &counters).await
     {
-        send_tile_snapshot_frames_to_peer(&peer, &frames).await;
+        send_tile_snapshot_frames_to_peer(&peer, &frames, snapshot_id).await;
     }
 }
 
@@ -2909,7 +2915,7 @@ impl DisplaySession {
                             .await
                             {
                                 for peer in &peers_now {
-                                    send_tile_snapshot_frames_to_peer(peer, &frames).await;
+                                    send_tile_snapshot_frames_to_peer(peer, &frames, snapshot_id).await;
                                 }
                             }
                             next_snapshot_at = Instant::now() + tile_snapshot_period(tile_mode);
@@ -2929,7 +2935,7 @@ impl DisplaySession {
                             .await
                             {
                                 for peer in &peers_now {
-                                    send_tile_snapshot_frames_to_peer(peer, &frames).await;
+                                    send_tile_snapshot_frames_to_peer(peer, &frames, snapshot_id).await;
                                 }
                             }
                             next_snapshot_at = Instant::now() + tile_snapshot_period(tile_mode);
@@ -3089,8 +3095,12 @@ impl DisplaySession {
                                     .await
                                     {
                                         for peer in &peers_now {
-                                            send_tile_snapshot_frames_to_peer(peer, &frames)
-                                                .await;
+                                            send_tile_snapshot_frames_to_peer(
+                                                peer,
+                                                &frames,
+                                                snapshot_id,
+                                            )
+                                            .await;
                                         }
                                     }
                                 }
@@ -3102,12 +3112,16 @@ impl DisplaySession {
                             continue;
                         }
 
-                        // Cursor: sampled at the delta cadence, not at
-                        // capture rate — on X11 this is a synchronous
-                        // QueryPointer round-trip per sample, and both
-                        // consumers (the CursorState control frame and
-                        // the synthetic dirty boxes) only act on
-                        // allowed ticks anyway.
+                        // Cursor: sampled at the delta cadence. This
+                        // deliberately HALVES the cursor rate relative
+                        // to the pre-gate-first pipeline, where the
+                        // poll and the CursorState control frame ran
+                        // at capture rate (~30fps) ahead of the old
+                        // gate. ≤15fps matches the cadence tile paints
+                        // actually happen at, and on X11 it halves the
+                        // synchronous QueryPointer round-trips this
+                        // sample costs (and stops them entirely in
+                        // video mode, where no CursorState is sent).
                         let cursor_pos = damage.cursor_position();
                         let cursor_changed = cursor_pos.is_some() && cursor_pos != last_cursor;
                         if cursor_changed {

--- a/crates/intendant-display/src/tile/encode.rs
+++ b/crates/intendant-display/src/tile/encode.rs
@@ -64,26 +64,36 @@ pub fn encode_raw_bgra_payload(
     if tile_size_px == 0 || raw.len() != expected {
         return Err(TileEncodeError::InvalidGeometry);
     }
-    let rle = rle_bgra(&raw);
+    // Bounded RLE: the moment the encoding reaches raw size it can no
+    // longer win, so stop — noisy tiles (the ones that dominate real
+    // content) abort after a fraction of the tile instead of building
+    // an up-to-5/4-raw encoding that gets discarded.
+    let rle = rle_bgra_bounded(&raw, raw.len());
 
-    let (mut encoding, mut payload) = if rle.len() < raw.len() {
-        (TileEncoding::RleBgra, rle)
-    } else {
-        (TileEncoding::RawBgra, raw.clone())
-    };
-
-    if should_try_webp_lossless(payload.len(), raw.len()) {
+    let best_len = rle.as_ref().map_or(raw.len(), Vec::len);
+    let webp = if should_try_webp_lossless(best_len, raw.len()) {
         match webp_lossless_bgra(&raw, tile_size_px as u32, tile_size_px as u32) {
-            Ok(webp) if webp.len() < payload.len() => {
-                encoding = TileEncoding::WebpLossless;
-                payload = webp;
-            }
-            Ok(_) => {}
+            Ok(webp) if webp.len() < best_len => Some(webp),
+            Ok(_) => None,
             Err(e) => {
                 eprintln!("[display/tile] lossless WebP encode skipped: {e}");
+                None
             }
         }
-    }
+    } else {
+        None
+    };
+
+    // Preference order (unchanged): WebP only when strictly smaller
+    // than the best simple encoding; RLE only when strictly smaller
+    // than raw; otherwise raw — moved, not cloned.
+    let (encoding, payload) = if let Some(webp) = webp {
+        (TileEncoding::WebpLossless, webp)
+    } else if let Some(rle) = rle {
+        (TileEncoding::RleBgra, rle)
+    } else {
+        (TileEncoding::RawBgra, raw)
+    };
 
     Ok(TileRecord::new(tile.x, tile.y, encoding, payload))
 }
@@ -91,10 +101,6 @@ pub fn encode_raw_bgra_payload(
 pub fn raw_bgra_tile(src: &TileSource<'_>, tile: TileId) -> Result<Vec<u8>, TileEncodeError> {
     validate_source(src)?;
     let ts = src.tile_size_px as usize;
-    let mut out = vec![0u8; ts * ts * 4];
-    for px in out.chunks_exact_mut(4) {
-        px[3] = 255;
-    }
 
     let start_x = tile.x as u32 * src.tile_size_px as u32;
     let start_y = tile.y as u32 * src.tile_size_px as u32;
@@ -107,21 +113,34 @@ pub fn raw_bgra_tile(src: &TileSource<'_>, tile: TileId) -> Result<Vec<u8>, Tile
         .saturating_sub(start_y)
         .min(src.tile_size_px as u32) as usize;
 
+    let mut out = vec![0u8; ts * ts * 4];
+    // Opaque-black padding is only observable on partial right/bottom
+    // edge tiles; interior tiles are fully overwritten below, so the
+    // alpha prefill would be pure waste there.
+    if copy_w < ts || copy_h < ts {
+        for px in out.chunks_exact_mut(4) {
+            px[3] = 255;
+        }
+    }
+
     for y in 0..copy_h {
-        let src_row = (start_y as usize + y) * src.stride as usize;
+        let src_row = (start_y as usize + y) * src.stride as usize + start_x as usize * 4;
         let dst_row = y * ts * 4;
-        for x in 0..copy_w {
-            let si = src_row + (start_x as usize + x) * 4;
-            let di = dst_row + x * 4;
-            match src.format {
-                TilePixelFormat::Bgra => {
-                    out[di..di + 4].copy_from_slice(&src.data[si..si + 4]);
-                }
-                TilePixelFormat::Rgba => {
-                    out[di] = src.data[si + 2];
-                    out[di + 1] = src.data[si + 1];
-                    out[di + 2] = src.data[si];
-                    out[di + 3] = src.data[si + 3];
+        match src.format {
+            TilePixelFormat::Bgra => {
+                // One memcpy per row instead of a bounds-checked
+                // 4-byte copy per pixel.
+                out[dst_row..dst_row + copy_w * 4]
+                    .copy_from_slice(&src.data[src_row..src_row + copy_w * 4]);
+            }
+            TilePixelFormat::Rgba => {
+                let src_px = src.data[src_row..src_row + copy_w * 4].chunks_exact(4);
+                let dst_px = out[dst_row..dst_row + copy_w * 4].chunks_exact_mut(4);
+                for (dst, px) in dst_px.zip(src_px) {
+                    dst[0] = px[2];
+                    dst[1] = px[1];
+                    dst[2] = px[0];
+                    dst[3] = px[3];
                 }
             }
         }
@@ -132,10 +151,25 @@ pub fn raw_bgra_tile(src: &TileSource<'_>, tile: TileId) -> Result<Vec<u8>, Tile
 
 /// Encode `[B, G, R, A, run_len]` records. `run_len` is 1..=255.
 pub fn rle_bgra(raw_bgra: &[u8]) -> Vec<u8> {
+    rle_bgra_bounded(raw_bgra, usize::MAX).unwrap_or_default()
+}
+
+/// [`rle_bgra`], aborting with `None` as soon as the encoding reaches
+/// `max_len` bytes (at which point it cannot beat an alternative of
+/// that size, so finishing it would be wasted work).
+fn rle_bgra_bounded(raw_bgra: &[u8], max_len: usize) -> Option<Vec<u8>> {
     if raw_bgra.is_empty() {
-        return Vec::new();
+        return Some(Vec::new());
     }
-    let mut out = Vec::new();
+    // Every record is 5 bytes and the abort check runs per record, so
+    // the output stays within max_len + 5; reserve the worst case the
+    // bound allows (5/4 of raw for a run-free tile) so the loop never
+    // reallocates.
+    let cap = raw_bgra
+        .len()
+        .saturating_add(raw_bgra.len() / 4)
+        .min(max_len.saturating_add(5));
+    let mut out = Vec::with_capacity(cap);
     let mut i = 0;
     while i + 4 <= raw_bgra.len() {
         let px = &raw_bgra[i..i + 4];
@@ -149,9 +183,12 @@ pub fn rle_bgra(raw_bgra: &[u8]) -> Vec<u8> {
         }
         out.extend_from_slice(px);
         out.push(run);
+        if out.len() >= max_len {
+            return None;
+        }
         i += run as usize * 4;
     }
-    out
+    Some(out)
 }
 
 pub fn webp_lossless_bgra(
@@ -167,9 +204,12 @@ pub fn webp_lossless_bgra(
         return Err(TileEncodeError::InvalidGeometry);
     }
 
-    let mut rgba = Vec::with_capacity(raw_bgra.len());
-    for px in raw_bgra.chunks_exact(4) {
-        rgba.extend_from_slice(&[px[2], px[1], px[0], px[3]]);
+    let mut rgba = vec![0u8; raw_bgra.len()];
+    for (dst, px) in rgba.chunks_exact_mut(4).zip(raw_bgra.chunks_exact(4)) {
+        dst[0] = px[2];
+        dst[1] = px[1];
+        dst[2] = px[0];
+        dst[3] = px[3];
     }
 
     let mut out = Vec::new();

--- a/crates/intendant-display/src/tile/recovery.rs
+++ b/crates/intendant-display/src/tile/recovery.rs
@@ -7,6 +7,7 @@
 //! send a fresh snapshot instead of trying to reconstruct unbounded
 //! history.
 
+use bytes::Bytes;
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
@@ -17,7 +18,10 @@ pub const GAP_RINGBUFFER_MAX_BYTES: usize = 8 * 1024 * 1024;
 pub struct ReplayFrame {
     pub epoch: u32,
     pub seq: u32,
-    pub bytes: Vec<u8>,
+    /// Wire frame payload. `Bytes` so pushing into the buffer and
+    /// replaying to a peer are refcount bumps of the frame the send
+    /// path already built, not per-entry copies.
+    pub bytes: Bytes,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -70,7 +74,7 @@ impl TileUpdateReplayBuffer {
         self.total_bytes
     }
 
-    pub fn push(&mut self, epoch: u32, seq: u32, bytes: Vec<u8>, now: Instant) {
+    pub fn push(&mut self, epoch: u32, seq: u32, bytes: Bytes, now: Instant) {
         self.prune_expired(now);
         self.total_bytes = self.total_bytes.saturating_add(bytes.len());
         self.entries.push_back(Entry {
@@ -157,8 +161,8 @@ mod tests {
         Instant::now()
     }
 
-    fn payload(byte: u8, len: usize) -> Vec<u8> {
-        vec![byte; len]
+    fn payload(byte: u8, len: usize) -> Bytes {
+        Bytes::from(vec![byte; len])
     }
 
     #[test]

--- a/crates/intendant-display/src/webrtc/driver.rs
+++ b/crates/intendant-display/src/webrtc/driver.rs
@@ -179,7 +179,10 @@ pub(crate) struct InboundPacket {
 /// single error owner that tears the peer down on the first write failure
 /// rather than re-flooding a dead socket.
 pub(crate) const TCP_OUT_QUEUE: usize = 256;
-pub(crate) type TcpFrameSender = mpsc::Sender<Vec<u8>>;
+/// Payloads are `Bytes`: `drain_outputs` freezes the engine's
+/// `BytesMut` transmit (zero-copy) instead of `to_vec`-copying every
+/// media packet onto the TCP lane.
+pub(crate) type TcpFrameSender = mpsc::Sender<Bytes>;
 
 struct InteractiveSourceGuard(Option<Arc<crate::BrowserInputSource>>);
 
@@ -473,7 +476,7 @@ pub(crate) async fn driver<I: rtc::interceptor::Interceptor + Send + Sync + 'sta
     // Once the allocation lands, this is the relayed address ICE advertises
     // and the channel that routes relay-destined RTC output to the relay task.
     let mut relay_addr: Option<SocketAddr> = None;
-    let mut relay_out_tx: Option<mpsc::Sender<(SocketAddr, Vec<u8>)>> = None;
+    let mut relay_out_tx: Option<mpsc::Sender<(SocketAddr, Bytes)>> = None;
 
     // Phase 4d.1: poll-driven observed-send-bitrate computation.
     // Each tick samples `bytes_sent` per outbound stream and computes
@@ -608,7 +611,7 @@ pub(crate) async fn driver<I: rtc::interceptor::Interceptor + Send + Sync + 'sta
                 // the peer's shutdown token, tearing the connection down
                 // instead of letting every later transmit re-flood the log
                 // on a dead socket.
-                let (tcp_out_tx, mut tcp_out_rx) = mpsc::channel::<Vec<u8>>(TCP_OUT_QUEUE);
+                let (tcp_out_tx, mut tcp_out_rx) = mpsc::channel::<Bytes>(TCP_OUT_QUEUE);
                 tcp_senders.insert(remote_addr, tcp_out_tx);
                 let writer_shutdown = shutdown.clone();
                 tokio::spawn(async move {
@@ -926,7 +929,7 @@ pub(crate) async fn drain_outputs<I: rtc::interceptor::Interceptor>(
     // TURN relay task, which wraps it toward coturn. `None` until/unless a
     // relay allocation succeeds.
     relay_addr: Option<SocketAddr>,
-    relay_out_tx: Option<&mpsc::Sender<(SocketAddr, Vec<u8>)>>,
+    relay_out_tx: Option<&mpsc::Sender<(SocketAddr, Bytes)>>,
     state: &mut DriverState,
     input_handler: &Arc<dyn Fn(InputEvent) + Send + Sync>,
     clipboard_handler: &Arc<dyn Fn(ClipboardContent) + Send + Sync>,
@@ -948,8 +951,9 @@ pub(crate) async fn drain_outputs<I: rtc::interceptor::Interceptor>(
             if let Some(tx) = relay_out_tx {
                 // try_send keeps the rtc poll loop non-blocking; a full relay
                 // queue drops this packet as backpressure (RTP recovery /
-                // ICE retransmit covers the loss).
-                let _ = tx.try_send((t.transport.peer_addr, t.message.to_vec()));
+                // ICE retransmit covers the loss). freeze() hands the
+                // engine's own buffer over without copying the packet.
+                let _ = tx.try_send((t.transport.peer_addr, t.message.freeze()));
             }
             continue;
         }
@@ -964,7 +968,9 @@ pub(crate) async fn drain_outputs<I: rtc::interceptor::Interceptor>(
         // transmits key on our relayed *local* address, which is never a
         // TCP peer tuple.)
         if let Some(sender) = tcp_senders.get(&t.transport.peer_addr) {
-            let contents: Vec<u8> = t.message.to_vec();
+            // freeze() is zero-copy: the writer task borrows the
+            // engine's own transmit buffer for the RFC 4571 write.
+            let contents: Bytes = t.message.freeze();
             // Enqueue onto the connection's ordered writer channel.
             // `try_send` (never `send().await`) keeps the rtc poll loop
             // non-blocking: a full queue means the writer task can't

--- a/crates/intendant-display/src/webrtc/driver.rs
+++ b/crates/intendant-display/src/webrtc/driver.rs
@@ -82,38 +82,12 @@ pub(crate) struct DriverState {
     /// producer side is not throttled by the channel's send-await
     /// semantics.
     pending_authority_state: Vec<(u32, DisplayInputAuthorityState)>,
-    /// D-3b: queued tile control frames awaiting `tile-control`
-    /// channel open. Low-rate reliable control only; never per-frame.
-    /// Byte-capped drop-oldest (see [`push_pending_tile_bounded`]): a
-    /// channel that closed (OnClose removes its label) while the peer
-    /// stays a tile subscriber would otherwise grow this without
-    /// bound, and control frames are self-contained — the latest
-    /// state wins.
-    pending_tile_control: VecDeque<Bytes>,
-    /// D-3b: the **one complete snapshot** (producer snapshot id +
-    /// every wire chunk, in send order) awaiting `tile-snapshot`
-    /// channel open. A snapshot is only decodable as a complete chunk
-    /// set, and [`Command::SendTileSnapshot`] hands groups over
-    /// atomically, so this holds at most one complete group *by
-    /// construction*: a newer accepted group replaces the old one
-    /// whole, and a producer cancelled mid-encode never issues the
-    /// command at all — no partial baseline can be published here.
-    ///
-    /// Bound story: ≤1 complete group by construction. No sanity
-    /// byte-cap on that group — it is one bounded burst from our own
-    /// packer (a u16 chunk count of ≤32KiB messages, in practice a
-    /// few MB), and dropping any of it would strand the browser on an
-    /// unassemblable baseline, which is exactly the failure this
-    /// design exists to prevent. Tile deltas intentionally have no
-    /// queue.
-    pending_tile_snapshot: Option<(u32, Vec<Bytes>)>,
-    /// Newest snapshot id ever accepted by this driver (written or
-    /// queued). Persisted here — NOT derived from queue contents — so
-    /// it survives open/drain/close cycles: a late group from an
-    /// older, superseded producer is rejected even when the queue is
-    /// empty, instead of resurrecting a stale baseline. See
-    /// [`admit_snapshot_group`].
-    tile_snapshot_watermark: Option<u32>,
+    /// D-3b: the queued-before-open reliable tile state (control
+    /// queue, the one complete pending snapshot, and the snapshot
+    /// admission watermark). Grouped in [`PendingTileQueues`] so the
+    /// production placement/drain policy is directly unit-testable —
+    /// tests call the same methods this driver calls, not a mirror.
+    pending_tiles: PendingTileQueues,
     /// D-4c: event-driven backpressure state for the supersedable
     /// `tile-deltas` channel. Control and snapshot channels are
     /// reliable and never use this drop policy.
@@ -223,6 +197,7 @@ pub(crate) async fn driver<I: rtc::interceptor::Interceptor + Send + Sync + 'sta
     _tcp_registration: Option<PeerRegistration>,
     mut frame_rx: mpsc::Receiver<OutboundEncodedFrame>,
     mut command_rx: mpsc::Receiver<Command>,
+    snapshot_mailbox: Arc<SnapshotMailbox>,
     input_handler: Arc<dyn Fn(InputEvent) + Send + Sync>,
     interactive_source: Option<Arc<crate::BrowserInputSource>>,
     clipboard_handler: Arc<dyn Fn(ClipboardContent) + Send + Sync>,
@@ -294,9 +269,7 @@ pub(crate) async fn driver<I: rtc::interceptor::Interceptor + Send + Sync + 'sta
         video_specs: Vec::new(),
         channels: HashMap::new(),
         pending_authority_state: Vec::new(),
-        pending_tile_control: VecDeque::new(),
-        pending_tile_snapshot: None,
-        tile_snapshot_watermark: None,
+        pending_tiles: PendingTileQueues::default(),
         tile_delta_backpressure: TileDeltaBackpressure::new(),
         first_frame_at: None,
         rtp: RtpSendState {
@@ -745,6 +718,26 @@ pub(crate) async fn driver<I: rtc::interceptor::Interceptor + Send + Sync + 'sta
                 if let Err(e) = rtc.handle_timeout(Instant::now()) {
                     eprintln!(
                         "[display/webrtc] peer {peer_id}: handle_timeout after command failed: {e:?}"
+                    );
+                    shutdown.cancel();
+                    for h in forwarder_handles {
+                        let _ = h.await;
+                    }
+                    return;
+                }
+            }
+            // Latest-wins snapshot mailbox: complete groups bypass the
+            // bounded command channel (a queue of multi-MB groups would
+            // retain up to its capacity in full generations — see
+            // `SnapshotMailbox`). At most one group is ever pending;
+            // the drain loop below empties whatever raced in.
+            _ = snapshot_mailbox.ready() => {
+                while let Some((snapshot_id, chunks)) = snapshot_mailbox.take() {
+                    handle_snapshot_group(&mut rtc, &mut state, snapshot_id, chunks);
+                }
+                if let Err(e) = rtc.handle_timeout(Instant::now()) {
+                    eprintln!(
+                        "[display/webrtc] peer {peer_id}: handle_timeout after snapshot failed: {e:?}"
                     );
                     shutdown.cancel();
                     for h in forwarder_handles {
@@ -1781,7 +1774,7 @@ pub(crate) fn handle_command<I: rtc::interceptor::Interceptor>(
                 match channel {
                     TileDataChannel::Control => {
                         push_pending_tile_bounded(
-                            &mut state.pending_tile_control,
+                            &mut state.pending_tiles.control,
                             data,
                             PENDING_TILE_CONTROL_MAX_BYTES,
                             label,
@@ -1789,59 +1782,55 @@ pub(crate) fn handle_command<I: rtc::interceptor::Interceptor>(
                     }
                     TileDataChannel::Snapshot => {
                         // Unreachable via the public boundary: snapshot
-                        // chunks travel as whole groups through
-                        // `Command::SendTileSnapshot`. Queueing a lone
+                        // chunks travel as whole groups through the
+                        // peer's `SnapshotMailbox`. Queueing a lone
                         // chunk here would publish a partial
                         // (unassemblable) baseline, so drop it.
                         eprintln!(
                             "[display/webrtc] dropping per-chunk snapshot \
                              frame queued before open — snapshots must use \
-                             SendTileSnapshot (whole-group boundary)"
+                             the whole-group snapshot mailbox"
                         );
                     }
                     TileDataChannel::Deltas => {}
                 }
             }
         }
-        Command::SendTileSnapshot {
-            snapshot_id,
-            chunks,
-        } => {
-            // Admission first, shared by the open and pre-open paths:
-            // stale groups are rejected against the persisted
-            // watermark (which survives drains), so a late producer
-            // for a superseded snapshot can neither hit the wire after
-            // a newer baseline nor resurrect itself into an emptied
-            // queue.
-            if !admit_snapshot_group(&mut state.tile_snapshot_watermark, snapshot_id) {
-                return;
-            }
-            if let Some(cid) = state.channels.get(TILE_SNAPSHOT_CHANNEL_LABEL).copied() {
-                if let Some(mut dc) = rtc.data_channel(cid) {
-                    for chunk in &chunks {
-                        if let Err(e) = dc.send(BytesMut::from(&chunk[..])) {
-                            eprintln!(
-                                "[display/webrtc] tile channel write failed on \
-                                 {TILE_SNAPSHOT_CHANNEL_LABEL}: {e:?}"
-                            );
-                        }
-                    }
-                }
-            } else {
-                // Pre-open: swap complete-for-complete. The queue holds
-                // at most one complete group by construction — see the
-                // `pending_tile_snapshot` field doc for the bound story.
-                if let Some((old_id, old_chunks)) =
-                    state.pending_tile_snapshot.replace((snapshot_id, chunks))
-                {
-                    eprintln!(
-                        "[display/webrtc] pending tile-snapshot: snapshot \
-                         {snapshot_id} supersedes queued snapshot {old_id} \
-                         ({} chunks) before the channel opened",
-                        old_chunks.len(),
-                    );
-                }
-            }
+    }
+}
+
+/// Consume one complete snapshot group from the peer's
+/// [`SnapshotMailbox`]: admission against the persisted watermark,
+/// then write-now (channel open) or queue-whole (pre-open) — the
+/// decision lives in the production
+/// [`PendingTileQueues::place_snapshot_group`], which the unit tests
+/// exercise directly.
+fn handle_snapshot_group<I: rtc::interceptor::Interceptor>(
+    rtc: &mut RTCPeerConnection<I>,
+    state: &mut DriverState,
+    snapshot_id: u32,
+    chunks: Vec<Bytes>,
+) {
+    let open_cid = state.channels.get(TILE_SNAPSHOT_CHANNEL_LABEL).copied();
+    let Some(deliver) =
+        state
+            .pending_tiles
+            .place_snapshot_group(open_cid.is_some(), snapshot_id, chunks)
+    else {
+        return;
+    };
+    let Some(cid) = open_cid else {
+        return;
+    };
+    let Some(mut dc) = rtc.data_channel(cid) else {
+        return;
+    };
+    for chunk in &deliver {
+        if let Err(e) = dc.send(BytesMut::from(&chunk[..])) {
+            eprintln!(
+                "[display/webrtc] tile channel write failed on \
+                 {TILE_SNAPSHOT_CHANNEL_LABEL}: {e:?}"
+            );
         }
     }
 }
@@ -1979,20 +1968,105 @@ pub(crate) fn drain_pending_tile_for_label(
     state: &mut DriverState,
     label: &str,
 ) -> VecDeque<Bytes> {
-    match label {
-        TILE_CONTROL_CHANNEL_LABEL => std::mem::take(&mut state.pending_tile_control),
-        // Draining the queued snapshot deliberately leaves
-        // `tile_snapshot_watermark` in place: the watermark is the
-        // stale-group rejector and must survive open/drain/close
-        // cycles (deriving it from queue contents would let a late
-        // producer of a superseded snapshot repopulate the emptied
-        // queue with a stale baseline).
-        TILE_SNAPSHOT_CHANNEL_LABEL => state
-            .pending_tile_snapshot
-            .take()
-            .map(|(_, chunks)| chunks.into())
-            .unwrap_or_default(),
-        _ => VecDeque::new(),
+    state.pending_tiles.drain_for_label(label)
+}
+
+/// The queued-before-open reliable tile state for one driver: the
+/// control frame queue, the (at most one, complete) pending snapshot,
+/// and the snapshot admission watermark. Grouped in one plainly
+/// constructible struct so the unit tests exercise the **production**
+/// placement/drain methods below — not a re-implementation.
+#[derive(Default)]
+pub(crate) struct PendingTileQueues {
+    /// D-3b: queued tile control frames awaiting `tile-control`
+    /// channel open. Low-rate reliable control only; never per-frame.
+    /// Byte-capped drop-oldest (see [`push_pending_tile_bounded`]): a
+    /// channel that closed (OnClose removes its label) while the peer
+    /// stays a tile subscriber would otherwise grow this without
+    /// bound, and control frames are self-contained — the latest
+    /// state wins.
+    pub(crate) control: VecDeque<Bytes>,
+    /// D-3b: the **one complete snapshot** (producer snapshot id +
+    /// every wire chunk, in send order) awaiting `tile-snapshot`
+    /// channel open. A snapshot is only decodable as a complete chunk
+    /// set, and the peer's `SnapshotMailbox` hands groups over
+    /// atomically, so this holds at most one complete group *by
+    /// construction*: a newer accepted group replaces the old one
+    /// whole, and a producer cancelled mid-encode never publishes at
+    /// all — no partial baseline can exist here.
+    ///
+    /// Bound story: ≤1 complete group by construction. No sanity
+    /// byte-cap on that group — it is one bounded burst from our own
+    /// packer (a u16 chunk count of ≤32KiB messages, in practice a
+    /// few MB), and dropping any of it would strand the browser on an
+    /// unassemblable baseline, which is exactly the failure this
+    /// design exists to prevent. Tile deltas intentionally have no
+    /// queue.
+    snapshot: Option<(u32, Vec<Bytes>)>,
+    /// Newest snapshot id ever accepted by this driver (written or
+    /// queued). Persisted here — NOT derived from queue contents — so
+    /// it survives open/drain/close cycles: a late group from an
+    /// older, superseded producer is rejected even when the queue is
+    /// empty, instead of resurrecting a stale baseline. See
+    /// [`admit_snapshot_group`].
+    snapshot_watermark: Option<u32>,
+}
+
+impl PendingTileQueues {
+    /// Production admission + placement for one complete snapshot
+    /// group — the single code path [`handle_snapshot_group`] calls.
+    ///
+    /// Admission first, shared by both paths: stale groups (id at or
+    /// below the persisted watermark) are rejected, so a late producer
+    /// for a superseded snapshot can neither hit the wire after a
+    /// newer baseline nor resurrect itself into an emptied queue.
+    /// Returns `Some(chunks)` when the group was admitted and the
+    /// channel is open (the caller writes them now); `None` when the
+    /// group was rejected as stale or queued whole for the pre-open
+    /// flush.
+    pub(crate) fn place_snapshot_group(
+        &mut self,
+        snapshot_open: bool,
+        snapshot_id: u32,
+        chunks: Vec<Bytes>,
+    ) -> Option<Vec<Bytes>> {
+        if !admit_snapshot_group(&mut self.snapshot_watermark, snapshot_id) {
+            return None;
+        }
+        if snapshot_open {
+            return Some(chunks);
+        }
+        // Pre-open: swap complete-for-complete — see the `snapshot`
+        // field doc for the bound story.
+        if let Some((old_id, old_chunks)) = self.snapshot.replace((snapshot_id, chunks)) {
+            eprintln!(
+                "[display/webrtc] pending tile-snapshot: snapshot \
+                 {snapshot_id} supersedes queued snapshot {old_id} \
+                 ({} chunks) before the channel opened",
+                old_chunks.len(),
+            );
+        }
+        None
+    }
+
+    /// Production drain for a just-opened reliable tile channel:
+    /// returns every queued frame for `label` in send order.
+    ///
+    /// Draining the snapshot deliberately leaves `snapshot_watermark`
+    /// in place: the watermark is the stale-group rejector and must
+    /// survive open/drain/close cycles (deriving it from queue
+    /// contents would let a late producer of a superseded snapshot
+    /// repopulate the emptied queue with a stale baseline).
+    pub(crate) fn drain_for_label(&mut self, label: &str) -> VecDeque<Bytes> {
+        match label {
+            TILE_CONTROL_CHANNEL_LABEL => std::mem::take(&mut self.control),
+            TILE_SNAPSHOT_CHANNEL_LABEL => self
+                .snapshot
+                .take()
+                .map(|(_, chunks)| chunks.into())
+                .unwrap_or_default(),
+            _ => VecDeque::new(),
+        }
     }
 }
 
@@ -3080,113 +3154,114 @@ mod tests {
         Bytes::from(vec![byte; len])
     }
 
-    /// Mirror of the `Command::SendTileSnapshot` pre-open arm's policy
-    /// (admission against the persisted watermark, then a
-    /// complete-for-complete swap), operating on the same state fields
-    /// the driver holds. Returns whether the group was accepted.
-    fn admit_and_queue(
-        watermark: &mut Option<u32>,
-        pending: &mut Option<(u32, Vec<Bytes>)>,
-        snapshot_id: u32,
-        chunks: Vec<Bytes>,
-    ) -> bool {
-        if !admit_snapshot_group(watermark, snapshot_id) {
-            return false;
-        }
-        *pending = Some((snapshot_id, chunks));
-        true
-    }
-
     /// The pre-open snapshot store holds at most **one complete
-    /// group**: supersession swaps complete-for-complete, and a
-    /// cancelled producer never publishes anything at all — the
-    /// whole-group `SendTileSnapshot` boundary means "cancelled
-    /// mid-group" is simply "the command was never sent", so no
-    /// partial baseline can exist here. (v1 of this queue accepted
-    /// per-chunk pushes; a producer cancelled after one chunk left an
-    /// unassemblable baseline queued.)
+    /// group**, exercised through the production
+    /// [`PendingTileQueues::place_snapshot_group`] /
+    /// [`PendingTileQueues::drain_for_label`] — the same methods the
+    /// driver's mailbox drain and OnOpen flush call. "Cancelled
+    /// mid-group" needs no queue-side handling by construction: the
+    /// whole-group boundary means a cancelled producer never publishes,
+    /// so nothing partial and nothing stale-partial can exist here.
     #[test]
     fn pending_snapshot_holds_only_complete_groups() {
-        let mut watermark: Option<u32> = None;
-        let mut pending: Option<(u32, Vec<Bytes>)> = None;
+        let mut q = PendingTileQueues::default();
 
-        // A complete snapshot queues whole...
-        assert!(admit_and_queue(
-            &mut watermark,
-            &mut pending,
-            7,
-            vec![chunk(7, 100); 3],
-        ));
-        // ...and a cancelled newer producer (id 8 minted, command
-        // never sent) leaves it fully intact: nothing to enqueue means
-        // nothing partial and nothing lost.
-        let (id, chunks) = pending.clone().expect("snapshot 7 queued");
-        assert_eq!(id, 7);
-        assert_eq!(chunks.len(), 3, "complete group retained");
+        // A complete snapshot queues whole (channel not open).
+        assert!(q
+            .place_snapshot_group(false, 7, vec![chunk(7, 100); 3])
+            .is_none());
 
         // A newer complete snapshot swaps complete-for-complete.
-        assert!(admit_and_queue(
-            &mut watermark,
-            &mut pending,
-            9,
-            vec![chunk(9, 100); 2],
-        ));
-        let (id, chunks) = pending.clone().expect("snapshot 9 queued");
-        assert_eq!(id, 9);
-        assert_eq!(chunks.len(), 2);
+        assert!(q
+            .place_snapshot_group(false, 9, vec![chunk(9, 100); 2])
+            .is_none());
+
+        // The production drain yields exactly the newest complete
+        // group, in order — never a partial mix.
+        let drained = q.drain_for_label(TILE_SNAPSHOT_CHANNEL_LABEL);
+        assert_eq!(drained.len(), 2);
         assert!(
-            chunks.iter().all(|c| c[0] == 9),
+            drained.iter().all(|c| c[0] == 9),
             "no chunk of the superseded group survives"
         );
     }
 
-    /// The watermark persists in DriverState across drains: a late
-    /// group from an older, superseded producer must be rejected even
-    /// when the queue is empty — deriving freshness from queue
-    /// contents would let it resurrect a stale baseline between a
-    /// drain and the next channel open.
+    /// An open channel delivers the admitted group to the caller for
+    /// immediate write; nothing is queued and the watermark still
+    /// advances (a stale group arriving while open is rejected too).
+    #[test]
+    fn open_channel_snapshot_delivers_and_advances_watermark() {
+        let mut q = PendingTileQueues::default();
+
+        let delivered = q
+            .place_snapshot_group(true, 5, vec![chunk(5, 10); 2])
+            .expect("admitted group on an open channel is delivered");
+        assert_eq!(delivered.len(), 2);
+        assert!(
+            q.drain_for_label(TILE_SNAPSHOT_CHANNEL_LABEL).is_empty(),
+            "open-path delivery must not also queue"
+        );
+
+        // Stale group while open: rejected by the same watermark.
+        assert!(q
+            .place_snapshot_group(true, 5, vec![chunk(5, 10)])
+            .is_none());
+        assert!(q
+            .place_snapshot_group(true, 4, vec![chunk(4, 10)])
+            .is_none());
+    }
+
+    /// The watermark persists across drains: a late group from an
+    /// older, superseded producer must be rejected even when the queue
+    /// is empty — deriving freshness from queue contents would let it
+    /// resurrect a stale baseline between a drain and the next channel
+    /// open.
     #[test]
     fn stale_snapshot_group_rejected_after_drain() {
-        let mut watermark: Option<u32> = None;
-        let mut pending: Option<(u32, Vec<Bytes>)> = None;
+        let mut q = PendingTileQueues::default();
 
-        assert!(admit_and_queue(
-            &mut watermark,
-            &mut pending,
-            5,
-            vec![chunk(5, 10); 2],
-        ));
-        // Channel opens: the queue drains, the watermark stays.
-        let drained = pending.take().expect("snapshot 5 drained");
-        assert_eq!(drained.1.len(), 2);
+        assert!(q
+            .place_snapshot_group(false, 5, vec![chunk(5, 10); 2])
+            .is_none());
+        // Channel opens: the production drain empties the queue, the
+        // watermark stays.
+        assert_eq!(q.drain_for_label(TILE_SNAPSHOT_CHANNEL_LABEL).len(), 2);
 
         // Late group from an older producer: rejected, queue stays empty.
-        assert!(!admit_and_queue(
-            &mut watermark,
-            &mut pending,
-            4,
-            vec![chunk(4, 10)],
-        ));
+        assert!(q
+            .place_snapshot_group(false, 4, vec![chunk(4, 10)])
+            .is_none());
         // Same id as already accepted: also rejected (<=).
-        assert!(!admit_and_queue(
-            &mut watermark,
-            &mut pending,
-            5,
-            vec![chunk(5, 10)],
-        ));
+        assert!(q
+            .place_snapshot_group(false, 5, vec![chunk(5, 10)])
+            .is_none());
         assert!(
-            pending.is_none(),
+            q.drain_for_label(TILE_SNAPSHOT_CHANNEL_LABEL).is_empty(),
             "stale groups must not repopulate the queue"
         );
 
-        // A genuinely newer group is admitted.
-        assert!(admit_and_queue(
-            &mut watermark,
-            &mut pending,
-            6,
-            vec![chunk(6, 10)],
-        ));
-        assert_eq!(pending.expect("snapshot 6 queued").0, 6);
+        // A genuinely newer group is admitted and queued.
+        assert!(q
+            .place_snapshot_group(false, 6, vec![chunk(6, 10)])
+            .is_none());
+        let drained = q.drain_for_label(TILE_SNAPSHOT_CHANNEL_LABEL);
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0][0], 6);
+    }
+
+    /// N rapid publishes retain at most one group upstream: the
+    /// mailbox is latest-wins, so a snapshot-request storm holds one
+    /// complete generation per peer — never a queue of them.
+    #[test]
+    fn snapshot_mailbox_retains_only_latest_group() {
+        let mailbox = SnapshotMailbox::new();
+        for id in 0..64u32 {
+            mailbox.publish(id, vec![chunk(id as u8, 10); 4]);
+        }
+        let (id, chunks) = mailbox.take().expect("latest group retained");
+        assert_eq!(id, 63);
+        assert_eq!(chunks.len(), 4, "retained group is complete");
+        assert!(mailbox.take().is_none(), "exactly one group retained");
     }
 
     /// Plain increasing admission: ids only ever move forward (the

--- a/crates/intendant-display/src/webrtc/driver.rs
+++ b/crates/intendant-display/src/webrtc/driver.rs
@@ -4,6 +4,7 @@
 //! the data-channel message codecs it speaks.
 
 use super::*;
+use std::collections::VecDeque;
 
 // ---------------------------------------------------------------------------
 // Driver task
@@ -80,11 +81,20 @@ pub(crate) struct DriverState {
     pending_authority_state: Vec<(u32, DisplayInputAuthorityState)>,
     /// D-3b: queued tile control frames awaiting `tile-control`
     /// channel open. Low-rate reliable control only; never per-frame.
-    pending_tile_control: Vec<Vec<u8>>,
+    /// Byte-capped drop-oldest (see [`push_pending_tile_bounded`]): a
+    /// channel that closed (OnClose removes its label) while the peer
+    /// stays a tile subscriber would otherwise grow this without
+    /// bound, and for control frames the latest state wins anyway.
+    pending_tile_control: VecDeque<Bytes>,
     /// D-3b: queued snapshot chunks awaiting `tile-snapshot` channel
     /// open. Reliable snapshot delivery is allowed to delay rather
-    /// than drop. Tile deltas intentionally have no queue.
-    pending_tile_snapshot: Vec<Vec<u8>>,
+    /// than drop — but bounded: snapshots re-queue every ~30s
+    /// (multi-MB each), so a never-opening channel would otherwise
+    /// accumulate them indefinitely. Oldest chunks are dropped first;
+    /// a late-opening client still receives the newest snapshot and
+    /// self-heals on the next periodic one. Tile deltas intentionally
+    /// have no queue.
+    pending_tile_snapshot: VecDeque<Bytes>,
     /// D-4c: event-driven backpressure state for the supersedable
     /// `tile-deltas` channel. Control and snapshot channels are
     /// reliable and never use this drop policy.
@@ -263,8 +273,8 @@ pub(crate) async fn driver<I: rtc::interceptor::Interceptor + Send + Sync + 'sta
         video_specs: Vec::new(),
         channels: HashMap::new(),
         pending_authority_state: Vec::new(),
-        pending_tile_control: Vec::new(),
-        pending_tile_snapshot: Vec::new(),
+        pending_tile_control: VecDeque::new(),
+        pending_tile_snapshot: VecDeque::new(),
         tile_delta_backpressure: TileDeltaBackpressure::new(),
         first_frame_at: None,
         rtp: RtpSendState {
@@ -1733,10 +1743,20 @@ pub(crate) fn handle_command<I: rtc::interceptor::Interceptor>(
             } else if channel.queues_before_open() {
                 match channel {
                     TileDataChannel::Control => {
-                        state.pending_tile_control.push(data);
+                        push_pending_tile_bounded(
+                            &mut state.pending_tile_control,
+                            data,
+                            PENDING_TILE_CONTROL_MAX_BYTES,
+                            label,
+                        );
                     }
                     TileDataChannel::Snapshot => {
-                        state.pending_tile_snapshot.push(data);
+                        push_pending_tile_bounded(
+                            &mut state.pending_tile_snapshot,
+                            data,
+                            PENDING_TILE_SNAPSHOT_MAX_BYTES,
+                            label,
+                        );
                     }
                     TileDataChannel::Deltas => {}
                 }
@@ -1874,12 +1894,55 @@ pub(crate) fn drain_pending_authority_for_label(
     }
 }
 
-pub(crate) fn drain_pending_tile_for_label(state: &mut DriverState, label: &str) -> Vec<Vec<u8>> {
+pub(crate) fn drain_pending_tile_for_label(
+    state: &mut DriverState,
+    label: &str,
+) -> VecDeque<Bytes> {
     match label {
         TILE_CONTROL_CHANNEL_LABEL => std::mem::take(&mut state.pending_tile_control),
         TILE_SNAPSHOT_CHANNEL_LABEL => std::mem::take(&mut state.pending_tile_snapshot),
-        _ => Vec::new(),
+        _ => VecDeque::new(),
     }
+}
+
+/// Byte caps for the queued-before-open reliable tile channels. A
+/// channel that closes (its label leaves `state.channels`) while the
+/// peer remains a tile subscriber keeps producing into these queues —
+/// snapshots at a multi-MB burst every ~30s — so an uncapped queue is
+/// an unbounded memory leak on a wedged channel.
+///
+/// Sized to hold roughly one-to-two full 1440p snapshots (snapshot)
+/// and far more control frames than any real negotiation delay could
+/// accumulate (control). Drop-oldest is the correct bias for both:
+/// control frames are superseded by later state, and a late-opening
+/// snapshot channel wants the *newest* chunks.
+pub(crate) const PENDING_TILE_SNAPSHOT_MAX_BYTES: usize = 24 * 1024 * 1024;
+pub(crate) const PENDING_TILE_CONTROL_MAX_BYTES: usize = 1024 * 1024;
+
+/// Push onto a queued-before-open tile queue, dropping oldest entries
+/// until the queue (including `data`) fits under `max_bytes`.
+pub(crate) fn push_pending_tile_bounded(
+    queue: &mut VecDeque<Bytes>,
+    data: Bytes,
+    max_bytes: usize,
+    label: &str,
+) {
+    let mut total: usize = queue.iter().map(Bytes::len).sum::<usize>() + data.len();
+    let mut dropped = 0usize;
+    while total > max_bytes {
+        let Some(oldest) = queue.pop_front() else {
+            break;
+        };
+        total -= oldest.len();
+        dropped += 1;
+    }
+    if dropped > 0 {
+        eprintln!(
+            "[display/webrtc] pending {label} queue exceeded {max_bytes}B \
+             before the channel opened; dropped {dropped} oldest frame(s)"
+        );
+    }
+    queue.push_back(data);
 }
 
 pub(crate) fn watermark_to_u32(bytes: usize) -> u32 {

--- a/crates/intendant-display/src/webrtc/driver.rs
+++ b/crates/intendant-display/src/webrtc/driver.rs
@@ -54,11 +54,14 @@ pub(crate) struct DriverState {
     /// commit 2 lights up multi-encoding), the map has exactly one
     /// entry per active spec — same shape as the previous keying,
     /// just with the RID dimension along for the ride.
-    /// Keyed by `(PayloadSpec, SimulcastRid)` — see the data-shape pin
-    /// test. Stored as a small linear vector (a handful of entries at
-    /// most: codecs × rids for one peer) so the per-frame lookup
-    /// compares by reference instead of cloning the spec + rid into an
-    /// owned `HashMap` key on every frame.
+    /// Keyed by `(PayloadSpec, SimulcastRid)` via
+    /// [`video_spec_key_matches`] — the per-RID independence contract
+    /// is pinned by `video_specs_lookup_distinguishes_rids_sharing_a_spec`,
+    /// which exercises this container shape through that same
+    /// predicate. Stored as a small linear vector (a handful of
+    /// entries at most: codecs × rids for one peer) so the per-frame
+    /// lookup compares by reference instead of cloning the spec + rid
+    /// into an owned `HashMap` key on every frame.
     video_specs: Vec<((crate::encode::PayloadSpec, SimulcastRid), SpecState)>,
     /// Map of channel label → DataChannelId for routing channel data and clipboard sends.
     channels: HashMap<String, RTCDataChannelId>,
@@ -84,17 +87,20 @@ pub(crate) struct DriverState {
     /// Byte-capped drop-oldest (see [`push_pending_tile_bounded`]): a
     /// channel that closed (OnClose removes its label) while the peer
     /// stays a tile subscriber would otherwise grow this without
-    /// bound, and for control frames the latest state wins anyway.
+    /// bound, and control frames are self-contained — the latest
+    /// state wins.
     pending_tile_control: VecDeque<Bytes>,
     /// D-3b: queued snapshot chunks awaiting `tile-snapshot` channel
-    /// open. Reliable snapshot delivery is allowed to delay rather
-    /// than drop — but bounded: snapshots re-queue every ~30s
-    /// (multi-MB each), so a never-opening channel would otherwise
-    /// accumulate them indefinitely. Oldest chunks are dropped first;
-    /// a late-opening client still receives the newest snapshot and
-    /// self-heals on the next periodic one. Tile deltas intentionally
-    /// have no queue.
-    pending_tile_snapshot: VecDeque<Bytes>,
+    /// open, tagged with their producer snapshot id. A snapshot is
+    /// only decodable as a complete chunk set, so eviction happens at
+    /// whole-snapshot granularity (see
+    /// [`push_pending_snapshot_group`]): when a newer snapshot starts
+    /// queueing, every older snapshot's chunks are superseded and
+    /// dropped — the queue never holds a partial group, and it is
+    /// bounded at ~one snapshot's bytes without any byte-cap eviction
+    /// that could strand the browser on an unassemblable baseline.
+    /// Tile deltas intentionally have no queue.
+    pending_tile_snapshot: VecDeque<(u32, Bytes)>,
     /// D-4c: event-driven backpressure state for the supersedable
     /// `tile-deltas` channel. Control and snapshot channels are
     /// reliable and never use this drop policy.
@@ -1479,7 +1485,7 @@ pub(crate) fn write_video_frame<I: rtc::interceptor::Interceptor>(
     let spec_idx = match state
         .video_specs
         .iter()
-        .position(|((spec, spec_rid), _)| *spec == frame.payload_spec && spec_rid == rid)
+        .position(|(key, _)| video_spec_key_matches(key, &frame.payload_spec, rid))
     {
         Some(idx) => idx,
         None => {
@@ -1619,6 +1625,19 @@ pub(crate) fn write_video_frame<I: rtc::interceptor::Interceptor>(
     }
 }
 
+/// Identity predicate for [`DriverState::video_specs`] entries: an
+/// entry matches only its exact `(payload_spec, rid)` pair. Extracted
+/// so the per-RID keyframe-gate independence (VP8 simulcast layers
+/// share one `PayloadSpec`; each RID's gate must stay independent) is
+/// pinned by a test exercising the *same* predicate production uses.
+pub(crate) fn video_spec_key_matches(
+    key: &(crate::encode::PayloadSpec, SimulcastRid),
+    spec: &crate::encode::PayloadSpec,
+    rid: &SimulcastRid,
+) -> bool {
+    key.0 == *spec && key.1 == *rid
+}
+
 pub(crate) fn payload_spec_matches_codec(
     spec: &crate::encode::PayloadSpec,
     codec: &RTCRtpCodec,
@@ -1724,7 +1743,11 @@ pub(crate) fn handle_command<I: rtc::interceptor::Interceptor>(
                 state.pending_authority_state.push((display_id, auth_state));
             }
         }
-        Command::SendTileFrame { channel, data } => {
+        Command::SendTileFrame {
+            channel,
+            data,
+            snapshot_group,
+        } => {
             let label = channel.label();
             let data_len = data.len();
             if channel == TileDataChannel::Deltas
@@ -1755,11 +1778,10 @@ pub(crate) fn handle_command<I: rtc::interceptor::Interceptor>(
                         );
                     }
                     TileDataChannel::Snapshot => {
-                        push_pending_tile_bounded(
+                        push_pending_snapshot_group(
                             &mut state.pending_tile_snapshot,
+                            snapshot_group.unwrap_or_default(),
                             data,
-                            PENDING_TILE_SNAPSHOT_MAX_BYTES,
-                            label,
                         );
                     }
                     TileDataChannel::Deltas => {}
@@ -1904,27 +1926,28 @@ pub(crate) fn drain_pending_tile_for_label(
 ) -> VecDeque<Bytes> {
     match label {
         TILE_CONTROL_CHANNEL_LABEL => std::mem::take(&mut state.pending_tile_control),
-        TILE_SNAPSHOT_CHANNEL_LABEL => std::mem::take(&mut state.pending_tile_snapshot),
+        TILE_SNAPSHOT_CHANNEL_LABEL => std::mem::take(&mut state.pending_tile_snapshot)
+            .into_iter()
+            .map(|(_, bytes)| bytes)
+            .collect(),
         _ => VecDeque::new(),
     }
 }
 
-/// Byte caps for the queued-before-open reliable tile channels. A
-/// channel that closes (its label leaves `state.channels`) while the
-/// peer remains a tile subscriber keeps producing into these queues —
-/// snapshots at a multi-MB burst every ~30s — so an uncapped queue is
-/// an unbounded memory leak on a wedged channel.
+/// Byte cap for the queued-before-open `tile-control` queue. A channel
+/// that closes (its label leaves `state.channels`) while the peer
+/// remains a tile subscriber keeps producing into the queue, so an
+/// uncapped queue is an unbounded memory leak on a wedged channel.
+/// Sized far above what any real negotiation delay could accumulate.
 ///
-/// Sized to hold roughly one-to-two full 1440p snapshots (snapshot)
-/// and far more control frames than any real negotiation delay could
-/// accumulate (control). Drop-oldest is the correct bias for both:
-/// control frames are superseded by later state, and a late-opening
-/// snapshot channel wants the *newest* chunks.
-pub(crate) const PENDING_TILE_SNAPSHOT_MAX_BYTES: usize = 24 * 1024 * 1024;
+/// Drop-oldest is correct **only** for control frames, which are
+/// self-contained and superseded by later state. Snapshot chunks are
+/// not self-contained — see [`push_pending_snapshot_group`] for the
+/// whole-snapshot policy that bounds that queue instead.
 pub(crate) const PENDING_TILE_CONTROL_MAX_BYTES: usize = 1024 * 1024;
 
-/// Push onto a queued-before-open tile queue, dropping oldest entries
-/// until the queue (including `data`) fits under `max_bytes`.
+/// Push onto the queued-before-open control queue, dropping oldest
+/// entries until the queue (including `data`) fits under `max_bytes`.
 pub(crate) fn push_pending_tile_bounded(
     queue: &mut VecDeque<Bytes>,
     data: Bytes,
@@ -1947,6 +1970,57 @@ pub(crate) fn push_pending_tile_bounded(
         );
     }
     queue.push_back(data);
+}
+
+/// Push one snapshot chunk onto the queued-before-open snapshot queue.
+///
+/// A snapshot is only decodable from its complete chunk set, so this
+/// queue evicts at **whole-snapshot granularity** — byte-capped
+/// drop-oldest here would shed a snapshot's *leading* chunks and leave
+/// the browser unable to assemble any baseline until the next periodic
+/// snapshot (~30s of blank/partial canvas):
+///
+/// - Chunks of the same group as the newest queued entry append.
+/// - A chunk of a **newer** group supersedes: every older group's
+///   chunks are dropped whole (a late-opening channel wants the newest
+///   baseline; stale ones would be repainted immediately anyway).
+/// - A chunk of an **older** group than the newest queued is dropped:
+///   its snapshot is already superseded, and enqueueing it would
+///   recreate a partial group.
+///
+/// The queue therefore never holds a partial group and is bounded at
+/// ~one snapshot's bytes — even a single snapshot larger than any
+/// fixed cap is kept whole, because it is one bounded burst, and the
+/// leak this policy guards against (a wedged channel re-queueing every
+/// periodic snapshot forever) is exactly what supersession caps.
+pub(crate) fn push_pending_snapshot_group(
+    queue: &mut VecDeque<(u32, Bytes)>,
+    group: u32,
+    data: Bytes,
+) {
+    if let Some(&(newest, _)) = queue.back() {
+        if group != newest {
+            // Producer snapshot ids are monotonically allocated;
+            // wrapping-aware comparison so the policy survives id
+            // wraparound on very long sessions.
+            let incoming_is_newer = (group.wrapping_sub(newest) as i32) > 0;
+            if incoming_is_newer {
+                let dropped = queue.len();
+                queue.clear();
+                eprintln!(
+                    "[display/webrtc] pending tile-snapshot queue: snapshot \
+                     {group} supersedes {dropped} queued chunk(s) of older \
+                     snapshot(s) before the channel opened"
+                );
+            } else {
+                // Stale chunk of an already-superseded snapshot
+                // (interleaved producer): keeping it would recreate a
+                // partial group.
+                return;
+            }
+        }
+    }
+    queue.push_back((group, data));
 }
 
 pub(crate) fn watermark_to_u32(bytes: usize) -> u32 {
@@ -2027,67 +2101,94 @@ mod tests {
         assert_eq!(resolved, c);
     }
 
-    /// **Phase-4c-prep**: `DriverState::video_specs` keying changed
-    /// from `PayloadSpec` to `(PayloadSpec, SimulcastRid)`. This is a
-    /// data-shape pin: a HashMap with `(spec, rid)` keys treats two
-    /// distinct rids as distinct entries even when they share the
-    /// same payload_spec — which is exactly the VP8 simulcast case
-    /// where every layer has the same `PayloadSpec` but each layer's
-    /// keyframe gate must remain independent.
-    ///
+    /// **Phase-4c-prep** contract: `DriverState::video_specs` is keyed
+    /// by `(PayloadSpec, SimulcastRid)`, not `PayloadSpec` alone — the
+    /// VP8 simulcast case gives every layer the same `PayloadSpec`,
+    /// but each layer's keyframe gate must remain independent.
     /// Without per-RID keying, a keyframe seen on RID `full` would
-    /// open the gate for P-frames on RIDs `half` and `quarter`. Those
-    /// P-frames would reference keyframes the half/quarter
-    /// subscribers never received, decoding to garbage.
+    /// open the gate for P-frames on RIDs `half` and `quarter`, which
+    /// would reference keyframes those subscribers never received and
+    /// decode to garbage.
     ///
-    /// This test pins the keying directly. It can't easily exercise
-    /// `write_video_frame` end-to-end without an `RTCPeerConnection`,
-    /// but the data-shape contract is what matters — if the keying
-    /// regresses to `PayloadSpec`-only the map would conflate the
-    /// three layers and this test would compile-fail (or assert).
+    /// This test exercises the **production shape**: the linear
+    /// `Vec<((PayloadSpec, SimulcastRid), SpecState)>` container that
+    /// `DriverState::video_specs` holds, probed and inserted through
+    /// [`video_spec_key_matches`] — the same predicate
+    /// `write_video_frame` uses for its per-frame lookup. A predicate
+    /// regression that matched spec but ignored rid would collapse
+    /// the three layers here and fail the assertions.
     #[test]
-    fn driver_state_video_specs_keys_by_spec_and_rid() {
+    fn video_specs_lookup_distinguishes_rids_sharing_a_spec() {
         use crate::encode::PayloadSpec;
         let spec = PayloadSpec::vp8();
-        let mut specs: HashMap<(PayloadSpec, SimulcastRid), SpecState> = HashMap::new();
-        // Insert under three distinct rids with the same spec. They
-        // must be three distinct entries — pre-fix keying by
-        // `PayloadSpec` alone would have collapsed them to one.
+        let mut specs: Vec<((PayloadSpec, SimulcastRid), SpecState)> = Vec::new();
+        // Same insert-if-absent walk as write_video_frame.
         for rid in [
             SimulcastRid::full(),
             SimulcastRid::half(),
             SimulcastRid::quarter(),
         ] {
-            specs.insert(
-                (spec.clone(), rid),
-                SpecState::Ready {
-                    keyframe_seen: false,
-                },
-            );
+            if !specs
+                .iter()
+                .any(|(key, _)| video_spec_key_matches(key, &spec, &rid))
+            {
+                specs.push((
+                    (spec.clone(), rid),
+                    SpecState::Ready {
+                        keyframe_seen: false,
+                    },
+                ));
+            }
         }
         assert_eq!(
             specs.len(),
             3,
-            "(PayloadSpec, SimulcastRid) keying must keep three rids \
-             with the same spec as three distinct entries; got {} \
-             entries — keying regressed to spec-only?",
+            "three rids sharing one spec must be three distinct \
+             entries; got {} — predicate regressed to spec-only?",
             specs.len(),
         );
-        // Flipping one rid's keyframe_seen must not affect the others.
-        if let Some(SpecState::Ready { keyframe_seen }) =
-            specs.get_mut(&(spec.clone(), SimulcastRid::full()))
-        {
+
+        // The predicate matches only the exact (spec, rid) pair:
+        // same spec + wrong rid and wrong spec + same rid both miss.
+        let h264 = PayloadSpec::h264_constrained_baseline();
+        assert!(video_spec_key_matches(
+            &specs[0].0,
+            &spec,
+            &SimulcastRid::full()
+        ));
+        assert!(!video_spec_key_matches(
+            &specs[0].0,
+            &spec,
+            &SimulcastRid::half()
+        ));
+        assert!(!video_spec_key_matches(
+            &specs[0].0,
+            &h264,
+            &SimulcastRid::full()
+        ));
+
+        // Flipping one rid's gate through the production lookup must
+        // not affect the other rids.
+        let full_idx = specs
+            .iter()
+            .position(|(key, _)| video_spec_key_matches(key, &spec, &SimulcastRid::full()))
+            .expect("full entry present");
+        if let (_, SpecState::Ready { keyframe_seen }) = &mut specs[full_idx] {
             *keyframe_seen = true;
         }
         for rid in [SimulcastRid::half(), SimulcastRid::quarter()] {
-            match specs.get(&(spec.clone(), rid.clone())) {
-                Some(SpecState::Ready { keyframe_seen }) => assert!(
+            let idx = specs
+                .iter()
+                .position(|(key, _)| video_spec_key_matches(key, &spec, &rid))
+                .unwrap_or_else(|| panic!("rid {} entry missing", rid.as_str()));
+            match &specs[idx].1 {
+                SpecState::Ready { keyframe_seen } => assert!(
                     !keyframe_seen,
-                    "rid {} keyframe_seen leaked across rids — keying \
-                     is wrong",
+                    "rid {} keyframe_seen leaked across rids — \
+                     predicate is wrong",
                     rid.as_str(),
                 ),
-                _ => panic!("rid {} entry missing", rid.as_str()),
+                _ => panic!("rid {} entry in wrong state", rid.as_str()),
             }
         }
     }
@@ -2939,5 +3040,95 @@ mod tests {
         assert_eq!(watermark_to_u32(1024), 1024);
         assert_eq!(watermark_to_u32(u32::MAX as usize), u32::MAX);
         assert_eq!(watermark_to_u32(u32::MAX as usize + 1), u32::MAX);
+    }
+
+    fn chunk(byte: u8, len: usize) -> Bytes {
+        Bytes::from(vec![byte; len])
+    }
+
+    /// Pre-open snapshot queue: a newer snapshot's chunks supersede
+    /// every older snapshot's chunks **whole** — the queue never holds
+    /// a partial group. Byte-capped drop-oldest here would shed a
+    /// snapshot's leading chunks and leave the browser unable to
+    /// assemble any baseline until the next periodic snapshot.
+    #[test]
+    fn pending_snapshot_queue_never_holds_a_partial_group() {
+        let mut q: VecDeque<(u32, Bytes)> = VecDeque::new();
+        for _ in 0..4 {
+            push_pending_snapshot_group(&mut q, 7, chunk(7, 100));
+        }
+        assert_eq!(q.len(), 4);
+
+        // A newer snapshot begins queueing: all of snapshot 7 drops.
+        push_pending_snapshot_group(&mut q, 8, chunk(8, 100));
+        assert_eq!(q.len(), 1, "older snapshot must be dropped whole");
+        assert!(
+            q.iter().all(|(g, _)| *g == 8),
+            "queue must only hold the newest snapshot's chunks"
+        );
+
+        // Remaining chunks of the newest snapshot keep appending.
+        push_pending_snapshot_group(&mut q, 8, chunk(8, 100));
+        assert_eq!(q.len(), 2);
+        assert!(q.iter().all(|(g, _)| *g == 8));
+    }
+
+    /// A single snapshot larger than any nominal cap is kept whole:
+    /// it is one bounded burst, and evicting any of its chunks would
+    /// make the whole group undecodable.
+    #[test]
+    fn pending_snapshot_queue_keeps_single_oversize_snapshot_whole() {
+        let mut q: VecDeque<(u32, Bytes)> = VecDeque::new();
+        // 64 chunks x 1MB = 64MB, far above any byte cap this queue
+        // ever had — every chunk must survive.
+        for _ in 0..64 {
+            push_pending_snapshot_group(&mut q, 3, chunk(3, 1024 * 1024));
+        }
+        assert_eq!(q.len(), 64, "one snapshot is never partially evicted");
+        assert!(q.iter().all(|(g, _)| *g == 3));
+    }
+
+    /// Supersession drops stale baselines: chunks of an
+    /// already-superseded snapshot (an interleaved late producer)
+    /// must not re-enter the queue — that would recreate a partial
+    /// group. Wrapping ids compare monotonically.
+    #[test]
+    fn pending_snapshot_queue_supersedes_stale_baselines() {
+        let mut q: VecDeque<(u32, Bytes)> = VecDeque::new();
+        push_pending_snapshot_group(&mut q, 10, chunk(10, 50));
+        push_pending_snapshot_group(&mut q, 11, chunk(11, 50));
+        // Late chunk of superseded snapshot 10: dropped, not queued.
+        push_pending_snapshot_group(&mut q, 10, chunk(10, 50));
+        assert_eq!(q.len(), 1);
+        assert!(q.iter().all(|(g, _)| *g == 11));
+
+        // Monotonic comparison survives id wraparound.
+        let mut q: VecDeque<(u32, Bytes)> = VecDeque::new();
+        push_pending_snapshot_group(&mut q, u32::MAX, chunk(1, 50));
+        push_pending_snapshot_group(&mut q, 0, chunk(2, 50));
+        assert_eq!(q.len(), 1, "wrapped id 0 supersedes u32::MAX");
+        assert!(q.iter().all(|(g, _)| *g == 0));
+    }
+
+    /// Pre-open control queue: self-contained frames under a byte
+    /// cap, oldest dropped first (later control state supersedes
+    /// earlier).
+    #[test]
+    fn pending_control_queue_drops_oldest_over_byte_cap() {
+        let mut q: VecDeque<Bytes> = VecDeque::new();
+        // Cap of 250 bytes: four 100-byte frames can never all fit.
+        for byte in 1..=4u8 {
+            push_pending_tile_bounded(&mut q, chunk(byte, 100), 250, "tile-control");
+        }
+        assert_eq!(q.len(), 2, "queue must stay under the byte cap");
+        // The two newest frames survive.
+        assert_eq!(q[0][0], 3);
+        assert_eq!(q[1][0], 4);
+
+        // An oversize single frame empties the queue but is itself
+        // kept (a frame can never fit by dropping others).
+        push_pending_tile_bounded(&mut q, chunk(9, 400), 250, "tile-control");
+        assert_eq!(q.len(), 1);
+        assert_eq!(q[0][0], 9);
     }
 }

--- a/crates/intendant-display/src/webrtc/driver.rs
+++ b/crates/intendant-display/src/webrtc/driver.rs
@@ -90,17 +90,30 @@ pub(crate) struct DriverState {
     /// bound, and control frames are self-contained — the latest
     /// state wins.
     pending_tile_control: VecDeque<Bytes>,
-    /// D-3b: queued snapshot chunks awaiting `tile-snapshot` channel
-    /// open, tagged with their producer snapshot id. A snapshot is
-    /// only decodable as a complete chunk set, so eviction happens at
-    /// whole-snapshot granularity (see
-    /// [`push_pending_snapshot_group`]): when a newer snapshot starts
-    /// queueing, every older snapshot's chunks are superseded and
-    /// dropped — the queue never holds a partial group, and it is
-    /// bounded at ~one snapshot's bytes without any byte-cap eviction
-    /// that could strand the browser on an unassemblable baseline.
-    /// Tile deltas intentionally have no queue.
-    pending_tile_snapshot: VecDeque<(u32, Bytes)>,
+    /// D-3b: the **one complete snapshot** (producer snapshot id +
+    /// every wire chunk, in send order) awaiting `tile-snapshot`
+    /// channel open. A snapshot is only decodable as a complete chunk
+    /// set, and [`Command::SendTileSnapshot`] hands groups over
+    /// atomically, so this holds at most one complete group *by
+    /// construction*: a newer accepted group replaces the old one
+    /// whole, and a producer cancelled mid-encode never issues the
+    /// command at all — no partial baseline can be published here.
+    ///
+    /// Bound story: ≤1 complete group by construction. No sanity
+    /// byte-cap on that group — it is one bounded burst from our own
+    /// packer (a u16 chunk count of ≤32KiB messages, in practice a
+    /// few MB), and dropping any of it would strand the browser on an
+    /// unassemblable baseline, which is exactly the failure this
+    /// design exists to prevent. Tile deltas intentionally have no
+    /// queue.
+    pending_tile_snapshot: Option<(u32, Vec<Bytes>)>,
+    /// Newest snapshot id ever accepted by this driver (written or
+    /// queued). Persisted here — NOT derived from queue contents — so
+    /// it survives open/drain/close cycles: a late group from an
+    /// older, superseded producer is rejected even when the queue is
+    /// empty, instead of resurrecting a stale baseline. See
+    /// [`admit_snapshot_group`].
+    tile_snapshot_watermark: Option<u32>,
     /// D-4c: event-driven backpressure state for the supersedable
     /// `tile-deltas` channel. Control and snapshot channels are
     /// reliable and never use this drop policy.
@@ -282,7 +295,8 @@ pub(crate) async fn driver<I: rtc::interceptor::Interceptor + Send + Sync + 'sta
         channels: HashMap::new(),
         pending_authority_state: Vec::new(),
         pending_tile_control: VecDeque::new(),
-        pending_tile_snapshot: VecDeque::new(),
+        pending_tile_snapshot: None,
+        tile_snapshot_watermark: None,
         tile_delta_backpressure: TileDeltaBackpressure::new(),
         first_frame_at: None,
         rtp: RtpSendState {
@@ -1743,11 +1757,7 @@ pub(crate) fn handle_command<I: rtc::interceptor::Interceptor>(
                 state.pending_authority_state.push((display_id, auth_state));
             }
         }
-        Command::SendTileFrame {
-            channel,
-            data,
-            snapshot_group,
-        } => {
+        Command::SendTileFrame { channel, data } => {
             let label = channel.label();
             let data_len = data.len();
             if channel == TileDataChannel::Deltas
@@ -1778,13 +1788,58 @@ pub(crate) fn handle_command<I: rtc::interceptor::Interceptor>(
                         );
                     }
                     TileDataChannel::Snapshot => {
-                        push_pending_snapshot_group(
-                            &mut state.pending_tile_snapshot,
-                            snapshot_group.unwrap_or_default(),
-                            data,
+                        // Unreachable via the public boundary: snapshot
+                        // chunks travel as whole groups through
+                        // `Command::SendTileSnapshot`. Queueing a lone
+                        // chunk here would publish a partial
+                        // (unassemblable) baseline, so drop it.
+                        eprintln!(
+                            "[display/webrtc] dropping per-chunk snapshot \
+                             frame queued before open — snapshots must use \
+                             SendTileSnapshot (whole-group boundary)"
                         );
                     }
                     TileDataChannel::Deltas => {}
+                }
+            }
+        }
+        Command::SendTileSnapshot {
+            snapshot_id,
+            chunks,
+        } => {
+            // Admission first, shared by the open and pre-open paths:
+            // stale groups are rejected against the persisted
+            // watermark (which survives drains), so a late producer
+            // for a superseded snapshot can neither hit the wire after
+            // a newer baseline nor resurrect itself into an emptied
+            // queue.
+            if !admit_snapshot_group(&mut state.tile_snapshot_watermark, snapshot_id) {
+                return;
+            }
+            if let Some(cid) = state.channels.get(TILE_SNAPSHOT_CHANNEL_LABEL).copied() {
+                if let Some(mut dc) = rtc.data_channel(cid) {
+                    for chunk in &chunks {
+                        if let Err(e) = dc.send(BytesMut::from(&chunk[..])) {
+                            eprintln!(
+                                "[display/webrtc] tile channel write failed on \
+                                 {TILE_SNAPSHOT_CHANNEL_LABEL}: {e:?}"
+                            );
+                        }
+                    }
+                }
+            } else {
+                // Pre-open: swap complete-for-complete. The queue holds
+                // at most one complete group by construction — see the
+                // `pending_tile_snapshot` field doc for the bound story.
+                if let Some((old_id, old_chunks)) =
+                    state.pending_tile_snapshot.replace((snapshot_id, chunks))
+                {
+                    eprintln!(
+                        "[display/webrtc] pending tile-snapshot: snapshot \
+                         {snapshot_id} supersedes queued snapshot {old_id} \
+                         ({} chunks) before the channel opened",
+                        old_chunks.len(),
+                    );
                 }
             }
         }
@@ -1926,10 +1981,17 @@ pub(crate) fn drain_pending_tile_for_label(
 ) -> VecDeque<Bytes> {
     match label {
         TILE_CONTROL_CHANNEL_LABEL => std::mem::take(&mut state.pending_tile_control),
-        TILE_SNAPSHOT_CHANNEL_LABEL => std::mem::take(&mut state.pending_tile_snapshot)
-            .into_iter()
-            .map(|(_, bytes)| bytes)
-            .collect(),
+        // Draining the queued snapshot deliberately leaves
+        // `tile_snapshot_watermark` in place: the watermark is the
+        // stale-group rejector and must survive open/drain/close
+        // cycles (deriving it from queue contents would let a late
+        // producer of a superseded snapshot repopulate the emptied
+        // queue with a stale baseline).
+        TILE_SNAPSHOT_CHANNEL_LABEL => state
+            .pending_tile_snapshot
+            .take()
+            .map(|(_, chunks)| chunks.into())
+            .unwrap_or_default(),
         _ => VecDeque::new(),
     }
 }
@@ -1972,55 +2034,27 @@ pub(crate) fn push_pending_tile_bounded(
     queue.push_back(data);
 }
 
-/// Push one snapshot chunk onto the queued-before-open snapshot queue.
+/// Admit or reject one complete snapshot group against the driver's
+/// persisted watermark, advancing the watermark on admission.
 ///
-/// A snapshot is only decodable from its complete chunk set, so this
-/// queue evicts at **whole-snapshot granularity** — byte-capped
-/// drop-oldest here would shed a snapshot's *leading* chunks and leave
-/// the browser unable to assemble any baseline until the next periodic
-/// snapshot (~30s of blank/partial canvas):
+/// Rejects ids older than **or equal to** the newest ever accepted:
+/// producer snapshot ids are minted by a session-monotonic
+/// `AtomicU32::fetch_add`, so an id at-or-below the watermark is a
+/// stale (superseded) producer whose baseline must reach neither the
+/// wire nor the pre-open queue.
 ///
-/// - Chunks of the same group as the newest queued entry append.
-/// - A chunk of a **newer** group supersedes: every older group's
-///   chunks are dropped whole (a late-opening channel wants the newest
-///   baseline; stale ones would be repainted immediately anyway).
-/// - A chunk of an **older** group than the newest queued is dropped:
-///   its snapshot is already superseded, and enqueueing it would
-///   recreate a partial group.
-///
-/// The queue therefore never holds a partial group and is bounded at
-/// ~one snapshot's bytes — even a single snapshot larger than any
-/// fixed cap is kept whole, because it is one bounded burst, and the
-/// leak this policy guards against (a wedged channel re-queueing every
-/// periodic snapshot forever) is exactly what supersession caps.
-pub(crate) fn push_pending_snapshot_group(
-    queue: &mut VecDeque<(u32, Bytes)>,
-    group: u32,
-    data: Bytes,
-) {
-    if let Some(&(newest, _)) = queue.back() {
-        if group != newest {
-            // Producer snapshot ids are monotonically allocated;
-            // wrapping-aware comparison so the policy survives id
-            // wraparound on very long sessions.
-            let incoming_is_newer = (group.wrapping_sub(newest) as i32) > 0;
-            if incoming_is_newer {
-                let dropped = queue.len();
-                queue.clear();
-                eprintln!(
-                    "[display/webrtc] pending tile-snapshot queue: snapshot \
-                     {group} supersedes {dropped} queued chunk(s) of older \
-                     snapshot(s) before the channel opened"
-                );
-            } else {
-                // Stale chunk of an already-superseded snapshot
-                // (interleaved producer): keeping it would recreate a
-                // partial group.
-                return;
-            }
-        }
+/// Plain (non-wrapping) compare, deliberately: wrap needs ~4.3 billion
+/// snapshots — decades at real snapshot cadence within one driver's
+/// lifetime — and the browser applies the same plain
+/// `snapshotId <= lastAppliedSnapshotId` rejection on its side, so a
+/// wrapping-aware compare here would diverge from the actual wire
+/// contract rather than harden it.
+pub(crate) fn admit_snapshot_group(watermark: &mut Option<u32>, snapshot_id: u32) -> bool {
+    if watermark.is_some_and(|newest| snapshot_id <= newest) {
+        return false;
     }
-    queue.push_back((group, data));
+    *watermark = Some(snapshot_id);
+    true
 }
 
 pub(crate) fn watermark_to_u32(bytes: usize) -> u32 {
@@ -3046,68 +3080,130 @@ mod tests {
         Bytes::from(vec![byte; len])
     }
 
-    /// Pre-open snapshot queue: a newer snapshot's chunks supersede
-    /// every older snapshot's chunks **whole** — the queue never holds
-    /// a partial group. Byte-capped drop-oldest here would shed a
-    /// snapshot's leading chunks and leave the browser unable to
-    /// assemble any baseline until the next periodic snapshot.
-    #[test]
-    fn pending_snapshot_queue_never_holds_a_partial_group() {
-        let mut q: VecDeque<(u32, Bytes)> = VecDeque::new();
-        for _ in 0..4 {
-            push_pending_snapshot_group(&mut q, 7, chunk(7, 100));
+    /// Mirror of the `Command::SendTileSnapshot` pre-open arm's policy
+    /// (admission against the persisted watermark, then a
+    /// complete-for-complete swap), operating on the same state fields
+    /// the driver holds. Returns whether the group was accepted.
+    fn admit_and_queue(
+        watermark: &mut Option<u32>,
+        pending: &mut Option<(u32, Vec<Bytes>)>,
+        snapshot_id: u32,
+        chunks: Vec<Bytes>,
+    ) -> bool {
+        if !admit_snapshot_group(watermark, snapshot_id) {
+            return false;
         }
-        assert_eq!(q.len(), 4);
+        *pending = Some((snapshot_id, chunks));
+        true
+    }
 
-        // A newer snapshot begins queueing: all of snapshot 7 drops.
-        push_pending_snapshot_group(&mut q, 8, chunk(8, 100));
-        assert_eq!(q.len(), 1, "older snapshot must be dropped whole");
+    /// The pre-open snapshot store holds at most **one complete
+    /// group**: supersession swaps complete-for-complete, and a
+    /// cancelled producer never publishes anything at all — the
+    /// whole-group `SendTileSnapshot` boundary means "cancelled
+    /// mid-group" is simply "the command was never sent", so no
+    /// partial baseline can exist here. (v1 of this queue accepted
+    /// per-chunk pushes; a producer cancelled after one chunk left an
+    /// unassemblable baseline queued.)
+    #[test]
+    fn pending_snapshot_holds_only_complete_groups() {
+        let mut watermark: Option<u32> = None;
+        let mut pending: Option<(u32, Vec<Bytes>)> = None;
+
+        // A complete snapshot queues whole...
+        assert!(admit_and_queue(
+            &mut watermark,
+            &mut pending,
+            7,
+            vec![chunk(7, 100); 3],
+        ));
+        // ...and a cancelled newer producer (id 8 minted, command
+        // never sent) leaves it fully intact: nothing to enqueue means
+        // nothing partial and nothing lost.
+        let (id, chunks) = pending.clone().expect("snapshot 7 queued");
+        assert_eq!(id, 7);
+        assert_eq!(chunks.len(), 3, "complete group retained");
+
+        // A newer complete snapshot swaps complete-for-complete.
+        assert!(admit_and_queue(
+            &mut watermark,
+            &mut pending,
+            9,
+            vec![chunk(9, 100); 2],
+        ));
+        let (id, chunks) = pending.clone().expect("snapshot 9 queued");
+        assert_eq!(id, 9);
+        assert_eq!(chunks.len(), 2);
         assert!(
-            q.iter().all(|(g, _)| *g == 8),
-            "queue must only hold the newest snapshot's chunks"
+            chunks.iter().all(|c| c[0] == 9),
+            "no chunk of the superseded group survives"
+        );
+    }
+
+    /// The watermark persists in DriverState across drains: a late
+    /// group from an older, superseded producer must be rejected even
+    /// when the queue is empty — deriving freshness from queue
+    /// contents would let it resurrect a stale baseline between a
+    /// drain and the next channel open.
+    #[test]
+    fn stale_snapshot_group_rejected_after_drain() {
+        let mut watermark: Option<u32> = None;
+        let mut pending: Option<(u32, Vec<Bytes>)> = None;
+
+        assert!(admit_and_queue(
+            &mut watermark,
+            &mut pending,
+            5,
+            vec![chunk(5, 10); 2],
+        ));
+        // Channel opens: the queue drains, the watermark stays.
+        let drained = pending.take().expect("snapshot 5 drained");
+        assert_eq!(drained.1.len(), 2);
+
+        // Late group from an older producer: rejected, queue stays empty.
+        assert!(!admit_and_queue(
+            &mut watermark,
+            &mut pending,
+            4,
+            vec![chunk(4, 10)],
+        ));
+        // Same id as already accepted: also rejected (<=).
+        assert!(!admit_and_queue(
+            &mut watermark,
+            &mut pending,
+            5,
+            vec![chunk(5, 10)],
+        ));
+        assert!(
+            pending.is_none(),
+            "stale groups must not repopulate the queue"
         );
 
-        // Remaining chunks of the newest snapshot keep appending.
-        push_pending_snapshot_group(&mut q, 8, chunk(8, 100));
-        assert_eq!(q.len(), 2);
-        assert!(q.iter().all(|(g, _)| *g == 8));
+        // A genuinely newer group is admitted.
+        assert!(admit_and_queue(
+            &mut watermark,
+            &mut pending,
+            6,
+            vec![chunk(6, 10)],
+        ));
+        assert_eq!(pending.expect("snapshot 6 queued").0, 6);
     }
 
-    /// A single snapshot larger than any nominal cap is kept whole:
-    /// it is one bounded burst, and evicting any of its chunks would
-    /// make the whole group undecodable.
+    /// Plain increasing admission: ids only ever move forward (the
+    /// documented no-wrap contract, matching the browser's own plain
+    /// `snapshotId <= lastAppliedSnapshotId` rejection).
     #[test]
-    fn pending_snapshot_queue_keeps_single_oversize_snapshot_whole() {
-        let mut q: VecDeque<(u32, Bytes)> = VecDeque::new();
-        // 64 chunks x 1MB = 64MB, far above any byte cap this queue
-        // ever had — every chunk must survive.
-        for _ in 0..64 {
-            push_pending_snapshot_group(&mut q, 3, chunk(3, 1024 * 1024));
-        }
-        assert_eq!(q.len(), 64, "one snapshot is never partially evicted");
-        assert!(q.iter().all(|(g, _)| *g == 3));
-    }
-
-    /// Supersession drops stale baselines: chunks of an
-    /// already-superseded snapshot (an interleaved late producer)
-    /// must not re-enter the queue — that would recreate a partial
-    /// group. Wrapping ids compare monotonically.
-    #[test]
-    fn pending_snapshot_queue_supersedes_stale_baselines() {
-        let mut q: VecDeque<(u32, Bytes)> = VecDeque::new();
-        push_pending_snapshot_group(&mut q, 10, chunk(10, 50));
-        push_pending_snapshot_group(&mut q, 11, chunk(11, 50));
-        // Late chunk of superseded snapshot 10: dropped, not queued.
-        push_pending_snapshot_group(&mut q, 10, chunk(10, 50));
-        assert_eq!(q.len(), 1);
-        assert!(q.iter().all(|(g, _)| *g == 11));
-
-        // Monotonic comparison survives id wraparound.
-        let mut q: VecDeque<(u32, Bytes)> = VecDeque::new();
-        push_pending_snapshot_group(&mut q, u32::MAX, chunk(1, 50));
-        push_pending_snapshot_group(&mut q, 0, chunk(2, 50));
-        assert_eq!(q.len(), 1, "wrapped id 0 supersedes u32::MAX");
-        assert!(q.iter().all(|(g, _)| *g == 0));
+    fn snapshot_admission_is_plainly_increasing() {
+        let mut watermark: Option<u32> = None;
+        assert!(admit_snapshot_group(&mut watermark, 10));
+        assert!(!admit_snapshot_group(&mut watermark, 10));
+        assert!(!admit_snapshot_group(&mut watermark, 9));
+        assert!(admit_snapshot_group(&mut watermark, 11));
+        assert_eq!(watermark, Some(11));
+        // No wrap heroics: after u32::MAX nothing is admitted — by
+        // design, and unreachable in practice (~4.3B snapshots).
+        assert!(admit_snapshot_group(&mut watermark, u32::MAX));
+        assert!(!admit_snapshot_group(&mut watermark, 0));
     }
 
     /// Pre-open control queue: self-contained frames under a byte

--- a/crates/intendant-display/src/webrtc/driver.rs
+++ b/crates/intendant-display/src/webrtc/driver.rs
@@ -2078,8 +2078,9 @@ impl PendingTileQueues {
 ///
 /// Drop-oldest is correct **only** for control frames, which are
 /// self-contained and superseded by later state. Snapshot chunks are
-/// not self-contained — see [`push_pending_snapshot_group`] for the
-/// whole-snapshot policy that bounds that queue instead.
+/// not self-contained — see
+/// [`PendingTileQueues::place_snapshot_group`] for the whole-snapshot
+/// policy that bounds that store instead.
 pub(crate) const PENDING_TILE_CONTROL_MAX_BYTES: usize = 1024 * 1024;
 
 /// Push onto the queued-before-open control queue, dropping oldest
@@ -3262,6 +3263,28 @@ mod tests {
         assert_eq!(id, 63);
         assert_eq!(chunks.len(), 4, "retained group is complete");
         assert!(mailbox.take().is_none(), "exactly one group retained");
+    }
+
+    /// The mailbox keeps the **id-newest** group, not the
+    /// arrival-newest: producers mint ids before their (independently
+    /// scheduled) encodes, so an older snapshot can finish after a
+    /// newer one — it must not overwrite the newer baseline, which may
+    /// be the only correct-epoch one after a resize.
+    #[test]
+    fn snapshot_mailbox_keeps_newest_id_regardless_of_arrival_order() {
+        let mailbox = SnapshotMailbox::new();
+        // Snapshot 8 encodes fast and publishes first...
+        mailbox.publish(8, vec![chunk(8, 10); 4]);
+        // ...then the slower, older snapshot 7 finishes: dropped.
+        mailbox.publish(7, vec![chunk(7, 10); 2]);
+        let (id, chunks) = mailbox.take().expect("newest-id group retained");
+        assert_eq!(id, 8, "stale arrival must not overwrite a newer id");
+        assert_eq!(chunks.len(), 4, "retained group is the complete newer one");
+        assert!(mailbox.take().is_none());
+
+        // After a drain, a genuinely newer publish lands normally.
+        mailbox.publish(9, vec![chunk(9, 10)]);
+        assert_eq!(mailbox.take().expect("newer id accepted").0, 9);
     }
 
     /// Plain increasing admission: ids only ever move forward (the

--- a/crates/intendant-display/src/webrtc/driver.rs
+++ b/crates/intendant-display/src/webrtc/driver.rs
@@ -130,7 +130,6 @@ pub(crate) struct RidRtpState {
 
 pub(crate) struct RtpSendState {
     sender_id: RTCRtpSenderId,
-    mid: String,
     codec: RTCRtpCodec,
     /// Per-RID send state. Looked up by the
     /// [`OutboundEncodedFrame::rid`] of each incoming frame so the
@@ -282,7 +281,6 @@ pub(crate) async fn driver<I: rtc::interceptor::Interceptor + Send + Sync + 'sta
         first_frame_at: None,
         rtp: RtpSendState {
             sender_id: rtp_config.sender_id,
-            mid: rtp_config.mid,
             codec: rtp_config.codec,
             by_rid,
             mid_ext_id: None,

--- a/crates/intendant-display/src/webrtc/driver.rs
+++ b/crates/intendant-display/src/webrtc/driver.rs
@@ -53,7 +53,12 @@ pub(crate) struct DriverState {
     /// commit 2 lights up multi-encoding), the map has exactly one
     /// entry per active spec — same shape as the previous keying,
     /// just with the RID dimension along for the ride.
-    video_specs: HashMap<(crate::encode::PayloadSpec, SimulcastRid), SpecState>,
+    /// Keyed by `(PayloadSpec, SimulcastRid)` — see the data-shape pin
+    /// test. Stored as a small linear vector (a handful of entries at
+    /// most: codecs × rids for one peer) so the per-frame lookup
+    /// compares by reference instead of cloning the spec + rid into an
+    /// owned `HashMap` key on every frame.
+    video_specs: Vec<((crate::encode::PayloadSpec, SimulcastRid), SpecState)>,
     /// Map of channel label → DataChannelId for routing channel data and clipboard sends.
     channels: HashMap<String, RTCDataChannelId>,
     /// F-1.2: queued `display_input_authority_state` messages awaiting
@@ -106,6 +111,11 @@ pub(crate) struct DriverState {
 pub(crate) struct RidRtpState {
     ssrc: u32,
     packetizer: Box<dyn Packetizer + Send>,
+    /// The RID as an RTP `sdes:rtp-stream-id` header-extension payload,
+    /// precomputed once — the write loop stamps it onto every packet
+    /// (hundreds per keyframe), so building a fresh `Vec` + `Bytes`
+    /// there was steady per-packet allocator churn.
+    rid_ext: Bytes,
 }
 
 pub(crate) struct RtpSendState {
@@ -119,6 +129,10 @@ pub(crate) struct RtpSendState {
     by_rid: HashMap<SimulcastRid, RidRtpState>,
     mid_ext_id: Option<u8>,
     rid_ext_id: Option<u8>,
+    /// The mid as an RTP `sdes:mid` header-extension payload,
+    /// precomputed for the same per-packet reason as
+    /// [`RidRtpState::rid_ext`].
+    mid_ext: Bytes,
 }
 
 /// Inbound packet from one of the per-interface forwarder tasks or a
@@ -240,11 +254,13 @@ pub(crate) async fn driver<I: rtc::interceptor::Interceptor + Send + Sync + 'sta
             RidRtpState {
                 ssrc: *ssrc,
                 packetizer: Box::new(packetizer),
+                rid_ext: Bytes::copy_from_slice(rid.as_str().as_bytes()),
             },
         );
     }
+    let mid_ext = Bytes::copy_from_slice(rtp_config.mid.as_bytes());
     let mut state = DriverState {
-        video_specs: HashMap::new(),
+        video_specs: Vec::new(),
         channels: HashMap::new(),
         pending_authority_state: Vec::new(),
         pending_tile_control: Vec::new(),
@@ -258,6 +274,7 @@ pub(crate) async fn driver<I: rtc::interceptor::Interceptor + Send + Sync + 'sta
             by_rid,
             mid_ext_id: None,
             rid_ext_id: None,
+            mid_ext,
         },
     };
 
@@ -1441,33 +1458,45 @@ pub(crate) fn write_video_frame<I: rtc::interceptor::Interceptor>(
     // Phase-4c-prep: the keyframe gate is keyed by `(payload_spec, rid)`,
     // not `payload_spec` alone. See `DriverState::video_specs` for why
     // — VP8 simulcast layers share the same payload_spec but each
-    // RID's keyframe gate must be independent.
-    let spec_key = (frame.payload_spec.clone(), rid.clone());
-    if !state.video_specs.contains_key(&spec_key) {
-        let new = if payload_spec_matches_codec(&frame.payload_spec, &state.rtp.codec) {
-            SpecState::Ready {
-                keyframe_seen: false,
-            }
-        } else {
-            eprintln!(
-                "[display/webrtc] encoded frame spec {} (rid {}) does not match \
-                 negotiated codec {}; dropping this (spec, rid)",
-                frame.payload_spec.codec_mime,
-                rid.as_str(),
-                state.rtp.codec.mime_type,
-            );
-            SpecState::Unsupported
-        };
-        state.video_specs.insert(spec_key.clone(), new);
-    }
+    // RID's keyframe gate must be independent. Looked up by reference
+    // (linear scan of a ≤handful-entry vector) so the steady state
+    // clones nothing; the owned key is built only when a new
+    // `(spec, rid)` pair first appears.
+    let spec_idx = match state
+        .video_specs
+        .iter()
+        .position(|((spec, spec_rid), _)| *spec == frame.payload_spec && spec_rid == rid)
+    {
+        Some(idx) => idx,
+        None => {
+            let new = if payload_spec_matches_codec(&frame.payload_spec, &state.rtp.codec) {
+                SpecState::Ready {
+                    keyframe_seen: false,
+                }
+            } else {
+                eprintln!(
+                    "[display/webrtc] encoded frame spec {} (rid {}) does not match \
+                     negotiated codec {}; dropping this (spec, rid)",
+                    frame.payload_spec.codec_mime,
+                    rid.as_str(),
+                    state.rtp.codec.mime_type,
+                );
+                SpecState::Unsupported
+            };
+            state
+                .video_specs
+                .push(((frame.payload_spec.clone(), rid.clone()), new));
+            state.video_specs.len() - 1
+        }
+    };
 
     // Step 2: extract current keyframe readiness from the spec state.
     // Copy out immutably so we can mutate `state.first_frame_at` below
     // without borrow conflicts with `state.video_specs`.
-    let keyframe_ready = match state.video_specs.get(&spec_key) {
-        Some(SpecState::Ready { keyframe_seen }) => *keyframe_seen,
-        // Unsupported or (impossibly) missing — drop silently. The
-        // first arm already emitted a log on entering Unsupported.
+    let keyframe_ready = match state.video_specs[spec_idx].1 {
+        SpecState::Ready { keyframe_seen } => keyframe_seen,
+        // Unsupported — drop silently. The insert arm already emitted
+        // a log on entering Unsupported.
         _ => return,
     };
 
@@ -1516,7 +1545,13 @@ pub(crate) fn write_video_frame<I: rtc::interceptor::Interceptor>(
     // packetizer (its own sequence + RTP-timestamp continuation
     // state) and stamp the per-RID SSRC onto every packet so
     // `RTCRtpSender::write_rtp` routes to the matching encoding.
-    let payload = Bytes::from(frame.data.clone());
+    //
+    // `frame.data` is `Bytes`: the clone is a refcount bump, not a
+    // copy of the encoded payload — the pool broadcasts one
+    // `Arc<EncodedFrame>` to every peer precisely so the fan-out
+    // stays copy-free, and the packetizer slices the `Bytes`
+    // refcounted from here on.
+    let payload = frame.data.clone();
     let packets = match rid_state.packetizer.packetize(&payload, samples) {
         Ok(p) => p,
         Err(e) => {
@@ -1528,24 +1563,23 @@ pub(crate) fn write_video_frame<I: rtc::interceptor::Interceptor>(
         }
     };
     let rid_ssrc = rid_state.ssrc;
+    let rid_ext = rid_state.rid_ext.clone();
 
     let (mid_ext_id, rid_ext_id) = rtp_header_extension_ids(rtc, state);
+    // One sender lookup per frame, not per packet — a 1440p keyframe
+    // packetizes into hundreds of packets.
+    let Some(mut sender) = rtc.rtp_sender(state.rtp.sender_id) else {
+        return;
+    };
     for mut packet in packets {
         packet.header.ssrc = rid_ssrc;
         if let Some(id) = mid_ext_id {
-            let _ = packet
-                .header
-                .set_extension(id, Bytes::from(state.rtp.mid.as_bytes().to_vec()));
+            let _ = packet.header.set_extension(id, state.rtp.mid_ext.clone());
         }
         if let Some(id) = rid_ext_id {
-            let _ = packet
-                .header
-                .set_extension(id, Bytes::from(rid.as_str().as_bytes().to_vec()));
+            let _ = packet.header.set_extension(id, rid_ext.clone());
         }
 
-        let Some(mut sender) = rtc.rtp_sender(state.rtp.sender_id) else {
-            return;
-        };
         match sender.write_rtp(packet) {
             Ok(()) => {}
             Err(e) => {
@@ -1559,7 +1593,7 @@ pub(crate) fn write_video_frame<I: rtc::interceptor::Interceptor>(
     }
 
     if !keyframe_ready {
-        if let Some(SpecState::Ready { keyframe_seen }) = state.video_specs.get_mut(&spec_key) {
+        if let Some((_, SpecState::Ready { keyframe_seen })) = state.video_specs.get_mut(spec_idx) {
             // Only flip keyframe_seen for this (spec, rid) pair AFTER
             // a successful packet write. If the write is the first
             // keyframe on this (spec, rid), the gate opens for

--- a/crates/intendant-display/src/webrtc/ice.rs
+++ b/crates/intendant-display/src/webrtc/ice.rs
@@ -413,7 +413,7 @@ pub(crate) struct RelayAllocation {
     /// relayed address. Each item is `(peer_addr, bytes)`; the relay task
     /// ensures a permission exists for `peer_addr` then sends via the TURN
     /// client (Send indication → ChannelData once a channel is bound).
-    pub(crate) relay_out_tx: mpsc::Sender<(SocketAddr, Vec<u8>)>,
+    pub(crate) relay_out_tx: mpsc::Sender<(SocketAddr, Bytes)>,
 }
 
 /// Drive a sans-I/O TURN client to allocate a relay on `server`, then run the
@@ -580,7 +580,7 @@ pub(crate) async fn run_turn_relay(
 
     // Hand the allocation back to the driver: it adds the relay candidate and
     // begins routing relay-destined RTC output to us.
-    let (relay_out_tx, mut relay_out_rx) = mpsc::channel::<(SocketAddr, Vec<u8>)>(256);
+    let (relay_out_tx, mut relay_out_rx) = mpsc::channel::<(SocketAddr, Bytes)>(256);
     if alloc_tx
         .send(RelayAllocation {
             relayed_addr,

--- a/crates/intendant-display/src/webrtc/mod.rs
+++ b/crates/intendant-display/src/webrtc/mod.rs
@@ -584,9 +584,12 @@ pub(crate) enum Command {
     /// D-3b: binary tile-stream frame. Control/snapshot frames queue
     /// until their reliable data channel opens; delta frames are
     /// latest-wins and are dropped when the channel is unavailable.
+    /// `Bytes` end-to-end: one wire frame is encoded once and fanned
+    /// out to every subscriber as refcount bumps; the only remaining
+    /// copy is rtc's `BytesMut` boundary at the datachannel write.
     SendTileFrame {
         channel: TileDataChannel,
-        data: Vec<u8>,
+        data: bytes::Bytes,
     },
 }
 

--- a/crates/intendant-display/src/webrtc/mod.rs
+++ b/crates/intendant-display/src/webrtc/mod.rs
@@ -587,9 +587,16 @@ pub(crate) enum Command {
     /// `Bytes` end-to-end: one wire frame is encoded once and fanned
     /// out to every subscriber as refcount bumps; the only remaining
     /// copy is rtc's `BytesMut` boundary at the datachannel write.
+    ///
+    /// `snapshot_group` is the producer's snapshot id for
+    /// [`TileDataChannel::Snapshot`] frames (`None` on the other
+    /// channels). The pre-open snapshot queue evicts at whole-group
+    /// granularity — a snapshot is only decodable as a complete chunk
+    /// set, so the queue must never hold (or deliver) a partial one.
     SendTileFrame {
         channel: TileDataChannel,
         data: bytes::Bytes,
+        snapshot_group: Option<u32>,
     },
 }
 

--- a/crates/intendant-display/src/webrtc/mod.rs
+++ b/crates/intendant-display/src/webrtc/mod.rs
@@ -581,22 +581,36 @@ pub(crate) enum Command {
         display_id: u32,
         state: DisplayInputAuthorityState,
     },
-    /// D-3b: binary tile-stream frame. Control/snapshot frames queue
-    /// until their reliable data channel opens; delta frames are
-    /// latest-wins and are dropped when the channel is unavailable.
-    /// `Bytes` end-to-end: one wire frame is encoded once and fanned
-    /// out to every subscriber as refcount bumps; the only remaining
-    /// copy is rtc's `BytesMut` boundary at the datachannel write.
+    /// D-3b: binary tile-stream frame for the **control** and
+    /// **deltas** channels. Control frames queue until their reliable
+    /// data channel opens; delta frames are latest-wins and are
+    /// dropped when the channel is unavailable. `Bytes` end-to-end:
+    /// one wire frame is encoded once and fanned out to every
+    /// subscriber as refcount bumps; the only remaining copy is rtc's
+    /// `BytesMut` boundary at the datachannel write.
     ///
-    /// `snapshot_group` is the producer's snapshot id for
-    /// [`TileDataChannel::Snapshot`] frames (`None` on the other
-    /// channels). The pre-open snapshot queue evicts at whole-group
-    /// granularity — a snapshot is only decodable as a complete chunk
-    /// set, so the queue must never hold (or deliver) a partial one.
+    /// Snapshot chunks do NOT travel through this command — a snapshot
+    /// is only decodable as a complete chunk set, so it crosses the
+    /// boundary atomically via [`Command::SendTileSnapshot`]; a
+    /// per-chunk snapshot path would let a cancelled producer publish
+    /// a partial (unassemblable) baseline into the pre-open queue.
     SendTileFrame {
         channel: TileDataChannel,
         data: bytes::Bytes,
-        snapshot_group: Option<u32>,
+    },
+    /// D-3b: one **complete** tile snapshot — every wire chunk of one
+    /// producer snapshot id, in send order, in a single command.
+    ///
+    /// Atomic whole-group hand-off is the partial-baseline defense: a
+    /// producer cancelled mid-encode (peer detach, resize mid-send)
+    /// simply never issues the command, so a partial chunk set cannot
+    /// reach the driver's pre-open queue; supersession there swaps
+    /// complete-for-complete. The chunk vector is finite by
+    /// construction (the packer caps chunks at a u16 count of ≤32KiB
+    /// messages).
+    SendTileSnapshot {
+        snapshot_id: u32,
+        chunks: Vec<bytes::Bytes>,
     },
 }
 

--- a/crates/intendant-display/src/webrtc/mod.rs
+++ b/crates/intendant-display/src/webrtc/mod.rs
@@ -149,6 +149,66 @@ const UDP_BUF_LEN: usize = 2000;
 /// memory allocation from a malicious peer.
 const TCP_MAX_FRAME_LEN: usize = 65535;
 
+/// Latest-wins hand-off slot for **complete** tile-snapshot groups,
+/// shared between one peer's [`WebRtcPeer`] handle (producer side) and
+/// its driver task (consumer side).
+///
+/// Snapshot groups deliberately bypass the ordinary bounded command
+/// channel: each group owns every wire chunk of one snapshot (multi-MB),
+/// and a command queue of them retains up to its capacity in full
+/// generations — plus unboundedly more in any producer tasks parked on
+/// a full channel's `send().await`. This slot caps upstream retention
+/// at **exactly one group per peer by construction**: `publish` is a
+/// synchronous replace (never an await holding a group), and a newer
+/// group simply overwrites an unconsumed older one — which is correct,
+/// because a snapshot is a full-screen baseline and only the newest
+/// matters. Admission (the driver's persisted watermark) still gates
+/// at consume time.
+///
+/// A producer cancelled mid-encode never calls `publish`, so — like the
+/// downstream pre-open queue — this slot can never hold a partial group.
+pub(crate) struct SnapshotMailbox {
+    /// The newest unconsumed complete group: `(snapshot_id, chunks)`.
+    slot: std::sync::Mutex<Option<(u32, Vec<bytes::Bytes>)>>,
+    /// Wakes the driver's drain arm. `notify_one` stores a permit when
+    /// no drain is waiting, so a publish that lands before the driver
+    /// reaches its select loop is not lost.
+    notify: tokio::sync::Notify,
+}
+
+impl SnapshotMailbox {
+    pub(crate) fn new() -> Self {
+        Self {
+            slot: std::sync::Mutex::new(None),
+            notify: tokio::sync::Notify::new(),
+        }
+    }
+
+    /// Replace the pending group with a newer one and wake the driver.
+    /// Synchronous by design — see the type docs.
+    pub(crate) fn publish(&self, snapshot_id: u32, chunks: Vec<bytes::Bytes>) {
+        *self
+            .slot
+            .lock()
+            .expect("snapshot mailbox mutex poisoned (no panics hold it)") =
+            Some((snapshot_id, chunks));
+        self.notify.notify_one();
+    }
+
+    /// Take the pending group, if any.
+    pub(crate) fn take(&self) -> Option<(u32, Vec<bytes::Bytes>)> {
+        self.slot
+            .lock()
+            .expect("snapshot mailbox mutex poisoned (no panics hold it)")
+            .take()
+    }
+
+    /// Wait until a publish has occurred since the last drain.
+    pub(crate) async fn ready(&self) {
+        self.notify.notified().await;
+    }
+}
+
 /// Public handle to a single WebRTC peer.
 ///
 /// All operations route to the driver task via channels; the driver owns the
@@ -157,6 +217,9 @@ pub struct WebRtcPeer {
     #[allow(dead_code)]
     pub peer_id: PeerId,
     command_tx: mpsc::Sender<Command>,
+    /// Latest-wins snapshot hand-off to this peer's driver — see
+    /// [`SnapshotMailbox`] for why snapshots do not ride `command_tx`.
+    snapshot_mailbox: Arc<SnapshotMailbox>,
     /// Live capability gate for both directions of clipboard sync. Display
     /// viewing alone must not disclose or mutate the host clipboard; callers
     /// bind this to the same authority that admits interactive display input.
@@ -377,6 +440,7 @@ impl WebRtcPeer {
         Self {
             peer_id,
             command_tx,
+            snapshot_mailbox: Arc::new(SnapshotMailbox::new()),
             clipboard_authorized: crate::BrowserInputAuthorization::new(Arc::new(|| true)),
             interactive_source: None,
             observed_send_bitrate_rx,
@@ -597,20 +661,6 @@ pub(crate) enum Command {
     SendTileFrame {
         channel: TileDataChannel,
         data: bytes::Bytes,
-    },
-    /// D-3b: one **complete** tile snapshot — every wire chunk of one
-    /// producer snapshot id, in send order, in a single command.
-    ///
-    /// Atomic whole-group hand-off is the partial-baseline defense: a
-    /// producer cancelled mid-encode (peer detach, resize mid-send)
-    /// simply never issues the command, so a partial chunk set cannot
-    /// reach the driver's pre-open queue; supersession there swaps
-    /// complete-for-complete. The chunk vector is finite by
-    /// construction (the packer caps chunks at a u16 count of ≤32KiB
-    /// messages).
-    SendTileSnapshot {
-        snapshot_id: u32,
-        chunks: Vec<bytes::Bytes>,
     },
 }
 

--- a/crates/intendant-display/src/webrtc/mod.rs
+++ b/crates/intendant-display/src/webrtc/mod.rs
@@ -157,13 +157,15 @@ const TCP_MAX_FRAME_LEN: usize = 65535;
 /// channel: each group owns every wire chunk of one snapshot (multi-MB),
 /// and a command queue of them retains up to its capacity in full
 /// generations — plus unboundedly more in any producer tasks parked on
-/// a full channel's `send().await`. This slot caps upstream retention
-/// at **exactly one group per peer by construction**: `publish` is a
-/// synchronous replace (never an await holding a group), and a newer
-/// group simply overwrites an unconsumed older one — which is correct,
-/// because a snapshot is a full-screen baseline and only the newest
-/// matters. Admission (the driver's persisted watermark) still gates
-/// at consume time.
+/// a full channel's `send().await`. This slot caps retention at **one
+/// group by construction**: `publish` is a synchronous replace (never
+/// an await holding a group), and the id-newest group supersedes any
+/// unconsumed one — correct, because a snapshot is a full-screen
+/// baseline and only the newest matters. Per peer, retention is ≤1
+/// group per stage (this mailbox + the driver's pre-open store), ≤2
+/// total during the hand-off window, both stages superseded
+/// latest-wins. Admission (the driver's persisted watermark) still
+/// gates at consume time.
 ///
 /// A producer cancelled mid-encode never calls `publish`, so — like the
 /// downstream pre-open queue — this slot can never hold a partial group.
@@ -184,14 +186,30 @@ impl SnapshotMailbox {
         }
     }
 
-    /// Replace the pending group with a newer one and wake the driver.
-    /// Synchronous by design — see the type docs.
+    /// Publish one complete group and wake the driver. Synchronous by
+    /// design — see the type docs.
+    ///
+    /// **Id-latest, not arrival-latest:** producers mint their
+    /// snapshot id *before* the (async, blocking-pool) encode, and run
+    /// as independent tasks, so completion order can invert id order —
+    /// a slow older snapshot must not overwrite a faster newer one
+    /// that may be the only correct-epoch baseline (e.g. right after a
+    /// resize). An incoming group at or below the resident id is
+    /// dropped here; the resident group's own `notify_one` permit is
+    /// still pending, so no extra wake is needed.
     pub(crate) fn publish(&self, snapshot_id: u32, chunks: Vec<bytes::Bytes>) {
-        *self
-            .slot
-            .lock()
-            .expect("snapshot mailbox mutex poisoned (no panics hold it)") =
-            Some((snapshot_id, chunks));
+        {
+            let mut slot = self
+                .slot
+                .lock()
+                .expect("snapshot mailbox mutex poisoned (no panics hold it)");
+            if let Some((resident_id, _)) = slot.as_ref() {
+                if snapshot_id <= *resident_id {
+                    return;
+                }
+            }
+            *slot = Some((snapshot_id, chunks));
+        }
         self.notify.notify_one();
     }
 
@@ -655,7 +673,7 @@ pub(crate) enum Command {
     ///
     /// Snapshot chunks do NOT travel through this command — a snapshot
     /// is only decodable as a complete chunk set, so it crosses the
-    /// boundary atomically via [`Command::SendTileSnapshot`]; a
+    /// boundary atomically via the peer's [`SnapshotMailbox`]; a
     /// per-chunk snapshot path would let a cancelled producer publish
     /// a partial (unassemblable) baseline into the pre-open queue.
     SendTileFrame {

--- a/crates/intendant-display/src/webrtc/offer.rs
+++ b/crates/intendant-display/src/webrtc/offer.rs
@@ -1347,44 +1347,48 @@ impl WebRtcPeer {
     /// D-3b: send a reliable tile-control binary frame to the browser.
     /// Queues in the driver until `tile-control` opens.
     pub async fn send_tile_control_frame(&self, data: bytes::Bytes) -> Result<bool, CallerError> {
-        self.send_tile_frame(TileDataChannel::Control, data, None)
-            .await
+        self.send_tile_frame(TileDataChannel::Control, data).await
     }
 
-    /// D-3b: send a reliable tile-snapshot binary frame to the browser.
-    /// Queues in the driver until `tile-snapshot` opens. `snapshot_id`
-    /// groups the chunks of one snapshot so the pre-open queue can
-    /// supersede stale snapshots at whole-group granularity.
-    pub async fn send_tile_snapshot_frame(
+    /// D-3b: send one **complete** tile snapshot (every wire chunk of
+    /// `snapshot_id`, in send order) to the browser. Atomic hand-off:
+    /// the driver either writes the whole set to an open
+    /// `tile-snapshot` channel or queues it whole for the pre-open
+    /// flush — a partial snapshot is unassemblable, so no per-chunk
+    /// snapshot boundary exists (see [`Command::SendTileSnapshot`]).
+    pub async fn send_tile_snapshot_group(
         &self,
-        data: bytes::Bytes,
         snapshot_id: u32,
+        chunks: Vec<bytes::Bytes>,
     ) -> Result<bool, CallerError> {
-        self.send_tile_frame(TileDataChannel::Snapshot, data, Some(snapshot_id))
+        match self
+            .command_tx
+            .send(Command::SendTileSnapshot {
+                snapshot_id,
+                chunks,
+            })
             .await
+        {
+            Ok(()) => Ok(true),
+            Err(_) => Ok(false),
+        }
     }
 
     /// D-3b: send an unreliable/supersedable tile-delta binary frame
     /// to the browser. If the channel is not open, the driver drops
     /// the frame rather than queueing stale deltas.
     pub async fn send_tile_delta_frame(&self, data: bytes::Bytes) -> Result<bool, CallerError> {
-        self.send_tile_frame(TileDataChannel::Deltas, data, None)
-            .await
+        self.send_tile_frame(TileDataChannel::Deltas, data).await
     }
 
     pub(crate) async fn send_tile_frame(
         &self,
         channel: TileDataChannel,
         data: bytes::Bytes,
-        snapshot_group: Option<u32>,
     ) -> Result<bool, CallerError> {
         match self
             .command_tx
-            .send(Command::SendTileFrame {
-                channel,
-                data,
-                snapshot_group,
-            })
+            .send(Command::SendTileFrame { channel, data })
             .await
         {
             Ok(()) => Ok(true),

--- a/crates/intendant-display/src/webrtc/offer.rs
+++ b/crates/intendant-display/src/webrtc/offer.rs
@@ -931,7 +931,9 @@ impl WebRtcPeer {
         let (command_tx, command_rx) = mpsc::channel::<Command>(COMMAND_CHANNEL);
         // Latest-wins snapshot hand-off, deliberately outside the
         // command channel — see `SnapshotMailbox` for the retention
-        // argument (one complete group per peer, end to end).
+        // argument (≤1 complete group per stage — mailbox + the
+        // driver's pre-open store — ≤2 per peer total, both stages
+        // superseded latest-wins).
         let snapshot_mailbox = Arc::new(SnapshotMailbox::new());
         // Phase 4d.1: per-peer observed send bitrate (`bytes_sent`
         // delta, local egress only — see WebRtcPeer::observed_send_bitrate_rx
@@ -1359,12 +1361,13 @@ impl WebRtcPeer {
     /// D-3b: publish one **complete** tile snapshot (every wire chunk
     /// of `snapshot_id`, in send order) to this peer's latest-wins
     /// mailbox. Synchronous by design: the producer never awaits while
-    /// holding a group, and a newer snapshot replaces an unconsumed
-    /// older one, so upstream retention is one group per peer — see
-    /// [`SnapshotMailbox`]. The driver admits (watermark) and either
-    /// writes the whole set to an open `tile-snapshot` channel or
-    /// queues it whole for the pre-open flush; a partial snapshot is
-    /// unassemblable, so no per-chunk snapshot boundary exists.
+    /// holding a group, and the id-newest snapshot supersedes an
+    /// unconsumed one, so mailbox retention is one group (≤2 per peer
+    /// across the mailbox + pre-open stages) — see [`SnapshotMailbox`].
+    /// The driver admits (watermark) and either writes the whole set
+    /// to an open `tile-snapshot` channel or queues it whole for the
+    /// pre-open flush; a partial snapshot is unassemblable, so no
+    /// per-chunk snapshot boundary exists.
     pub fn send_tile_snapshot_group(&self, snapshot_id: u32, chunks: Vec<bytes::Bytes>) {
         self.snapshot_mailbox.publish(snapshot_id, chunks);
     }

--- a/crates/intendant-display/src/webrtc/offer.rs
+++ b/crates/intendant-display/src/webrtc/offer.rs
@@ -1347,30 +1347,44 @@ impl WebRtcPeer {
     /// D-3b: send a reliable tile-control binary frame to the browser.
     /// Queues in the driver until `tile-control` opens.
     pub async fn send_tile_control_frame(&self, data: bytes::Bytes) -> Result<bool, CallerError> {
-        self.send_tile_frame(TileDataChannel::Control, data).await
+        self.send_tile_frame(TileDataChannel::Control, data, None)
+            .await
     }
 
     /// D-3b: send a reliable tile-snapshot binary frame to the browser.
-    /// Queues in the driver until `tile-snapshot` opens.
-    pub async fn send_tile_snapshot_frame(&self, data: bytes::Bytes) -> Result<bool, CallerError> {
-        self.send_tile_frame(TileDataChannel::Snapshot, data).await
+    /// Queues in the driver until `tile-snapshot` opens. `snapshot_id`
+    /// groups the chunks of one snapshot so the pre-open queue can
+    /// supersede stale snapshots at whole-group granularity.
+    pub async fn send_tile_snapshot_frame(
+        &self,
+        data: bytes::Bytes,
+        snapshot_id: u32,
+    ) -> Result<bool, CallerError> {
+        self.send_tile_frame(TileDataChannel::Snapshot, data, Some(snapshot_id))
+            .await
     }
 
     /// D-3b: send an unreliable/supersedable tile-delta binary frame
     /// to the browser. If the channel is not open, the driver drops
     /// the frame rather than queueing stale deltas.
     pub async fn send_tile_delta_frame(&self, data: bytes::Bytes) -> Result<bool, CallerError> {
-        self.send_tile_frame(TileDataChannel::Deltas, data).await
+        self.send_tile_frame(TileDataChannel::Deltas, data, None)
+            .await
     }
 
     pub(crate) async fn send_tile_frame(
         &self,
         channel: TileDataChannel,
         data: bytes::Bytes,
+        snapshot_group: Option<u32>,
     ) -> Result<bool, CallerError> {
         match self
             .command_tx
-            .send(Command::SendTileFrame { channel, data })
+            .send(Command::SendTileFrame {
+                channel,
+                data,
+                snapshot_group,
+            })
             .await
         {
             Ok(()) => Ok(true),

--- a/crates/intendant-display/src/webrtc/offer.rs
+++ b/crates/intendant-display/src/webrtc/offer.rs
@@ -1346,27 +1346,27 @@ impl WebRtcPeer {
 
     /// D-3b: send a reliable tile-control binary frame to the browser.
     /// Queues in the driver until `tile-control` opens.
-    pub async fn send_tile_control_frame(&self, data: Vec<u8>) -> Result<bool, CallerError> {
+    pub async fn send_tile_control_frame(&self, data: bytes::Bytes) -> Result<bool, CallerError> {
         self.send_tile_frame(TileDataChannel::Control, data).await
     }
 
     /// D-3b: send a reliable tile-snapshot binary frame to the browser.
     /// Queues in the driver until `tile-snapshot` opens.
-    pub async fn send_tile_snapshot_frame(&self, data: Vec<u8>) -> Result<bool, CallerError> {
+    pub async fn send_tile_snapshot_frame(&self, data: bytes::Bytes) -> Result<bool, CallerError> {
         self.send_tile_frame(TileDataChannel::Snapshot, data).await
     }
 
     /// D-3b: send an unreliable/supersedable tile-delta binary frame
     /// to the browser. If the channel is not open, the driver drops
     /// the frame rather than queueing stale deltas.
-    pub async fn send_tile_delta_frame(&self, data: Vec<u8>) -> Result<bool, CallerError> {
+    pub async fn send_tile_delta_frame(&self, data: bytes::Bytes) -> Result<bool, CallerError> {
         self.send_tile_frame(TileDataChannel::Deltas, data).await
     }
 
     pub(crate) async fn send_tile_frame(
         &self,
         channel: TileDataChannel,
-        data: Vec<u8>,
+        data: bytes::Bytes,
     ) -> Result<bool, CallerError> {
         match self
             .command_tx

--- a/crates/intendant-display/src/webrtc/offer.rs
+++ b/crates/intendant-display/src/webrtc/offer.rs
@@ -929,6 +929,10 @@ impl WebRtcPeer {
         let (encoded_frame_tx, encoded_frame_rx) =
             mpsc::channel::<OutboundEncodedFrame>(ENCODED_FRAME_CHANNEL);
         let (command_tx, command_rx) = mpsc::channel::<Command>(COMMAND_CHANNEL);
+        // Latest-wins snapshot hand-off, deliberately outside the
+        // command channel — see `SnapshotMailbox` for the retention
+        // argument (one complete group per peer, end to end).
+        let snapshot_mailbox = Arc::new(SnapshotMailbox::new());
         // Phase 4d.1: per-peer observed send bitrate (`bytes_sent`
         // delta, local egress only — see WebRtcPeer::observed_send_bitrate_rx
         // for the semantic distinction from capacity). Initial value
@@ -991,6 +995,7 @@ impl WebRtcPeer {
             peer_registration,
             encoded_frame_rx,
             command_rx,
+            Arc::clone(&snapshot_mailbox),
             input_handler,
             interactive_source.clone(),
             clipboard_handler,
@@ -1014,6 +1019,7 @@ impl WebRtcPeer {
             Self {
                 peer_id,
                 command_tx,
+                snapshot_mailbox,
                 clipboard_authorized,
                 interactive_source,
                 observed_send_bitrate_rx,
@@ -1350,28 +1356,17 @@ impl WebRtcPeer {
         self.send_tile_frame(TileDataChannel::Control, data).await
     }
 
-    /// D-3b: send one **complete** tile snapshot (every wire chunk of
-    /// `snapshot_id`, in send order) to the browser. Atomic hand-off:
-    /// the driver either writes the whole set to an open
-    /// `tile-snapshot` channel or queues it whole for the pre-open
-    /// flush — a partial snapshot is unassemblable, so no per-chunk
-    /// snapshot boundary exists (see [`Command::SendTileSnapshot`]).
-    pub async fn send_tile_snapshot_group(
-        &self,
-        snapshot_id: u32,
-        chunks: Vec<bytes::Bytes>,
-    ) -> Result<bool, CallerError> {
-        match self
-            .command_tx
-            .send(Command::SendTileSnapshot {
-                snapshot_id,
-                chunks,
-            })
-            .await
-        {
-            Ok(()) => Ok(true),
-            Err(_) => Ok(false),
-        }
+    /// D-3b: publish one **complete** tile snapshot (every wire chunk
+    /// of `snapshot_id`, in send order) to this peer's latest-wins
+    /// mailbox. Synchronous by design: the producer never awaits while
+    /// holding a group, and a newer snapshot replaces an unconsumed
+    /// older one, so upstream retention is one group per peer — see
+    /// [`SnapshotMailbox`]. The driver admits (watermark) and either
+    /// writes the whole set to an open `tile-snapshot` channel or
+    /// queues it whole for the pre-open flush; a partial snapshot is
+    /// unassemblable, so no per-chunk snapshot boundary exists.
+    pub fn send_tile_snapshot_group(&self, snapshot_id: u32, chunks: Vec<bytes::Bytes>) {
+        self.snapshot_mailbox.publish(snapshot_id, chunks);
     }
 
     /// D-3b: send an unreliable/supersedable tile-delta binary frame

--- a/crates/intendant-display/src/webrtc/tcp_mux.rs
+++ b/crates/intendant-display/src/webrtc/tcp_mux.rs
@@ -442,6 +442,11 @@ pub async fn read_rfc4571_frame_pub(stream: &mut TcpStream) -> std::io::Result<V
 
 /// Write one RFC 4571 framed payload: prepend a 2-byte BE length header,
 /// then the payload bytes.
+///
+/// Header + payload are coalesced into a single `write_all`: the write
+/// halves this feeds are unbuffered, so two writes meant two syscalls
+/// (and potentially two TCP segments) per RTP packet — ~600 syscalls/s
+/// per connection at typical media rates. One small copy beats that.
 pub async fn write_rfc4571_frame<W: AsyncWriteExt + Unpin>(
     w: &mut W,
     payload: &[u8],
@@ -453,8 +458,10 @@ pub async fn write_rfc4571_frame<W: AsyncWriteExt + Unpin>(
         ));
     }
     let len = payload.len() as u16;
-    w.write_all(&len.to_be_bytes()).await?;
-    w.write_all(payload).await?;
+    let mut framed = Vec::with_capacity(2 + payload.len());
+    framed.extend_from_slice(&len.to_be_bytes());
+    framed.extend_from_slice(payload);
+    w.write_all(&framed).await?;
     Ok(())
 }
 

--- a/crates/intendant-display/src/windows.rs
+++ b/crates/intendant-display/src/windows.rs
@@ -1935,28 +1935,36 @@ fn run_gdi_capture(
     let mut frame_count: u64 = 0;
     let mut consecutive_errors: u32 = 0;
     const MAX_CONSECUTIVE_ERRORS: u32 = 60;
-    // Re-resolve the capture rect every N frames (mirrors the X11
-    // backend's GEOMETRY_CHECK_INTERVAL): resolving display topology
-    // per iteration was a per-frame syscall spent re-learning a value
-    // that changes on the order of monitor re-arranges.
+    // Re-resolve the capture rect every N healthy iterations (mirrors
+    // the X11 backend's GEOMETRY_CHECK_INTERVAL): resolving display
+    // topology per iteration was a per-frame syscall spent re-learning
+    // a value that changes on the order of monitor re-arranges.
     const GEOMETRY_CHECK_INTERVAL: u64 = 60;
     // Error-path heartbeat cadence — matches the pool bridge's 1s
     // IDLE_HEARTBEAT (see run_dxgi_capture) so a transient error storm
     // re-emits the cached frame once a second, not per retry.
     const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
     let mut last_emit_at = std::time::Instant::now();
+    let mut loop_iter: u64 = 0;
 
     loop {
         if shutdown.load(Ordering::SeqCst) {
             break;
         }
         let start = std::time::Instant::now();
+        loop_iter = loop_iter.wrapping_add(1);
 
         // Detect a primary-resolution change and rebuild the cached resources.
         // For a targeted output we re-resolve its rect too, so a monitor
-        // re-arrange / mode switch is picked up. Checked on a frame
-        // cadence, not per iteration.
-        if frame_count > 0 && frame_count.is_multiple_of(GEOMETRY_CHECK_INTERVAL) {
+        // re-arrange / mode switch is picked up. Checked on an
+        // iteration cadence while healthy — but on EVERY iteration of
+        // an error streak: a display-mode switch is exactly what makes
+        // `capture.grab()`'s BitBlt fail persistently, and errors don't
+        // advance `frame_count`, so a frame-count gate would never
+        // re-resolve and the thread would ride the streak to the
+        // 60-error give-up. Error iterations sleep 100ms, so the
+        // re-resolve syscall is off the hot path there by construction.
+        if consecutive_errors > 0 || loop_iter.is_multiple_of(GEOMETRY_CHECK_INTERVAL) {
             if let Ok((nx, ny, nw, nh)) = resolve_capture_rect(target_output) {
                 if nw != capture.width || nh != capture.height || nx != rect_x || ny != rect_y {
                     match GdiCapture::new(nx, ny, nw, nh) {

--- a/crates/intendant-display/src/windows.rs
+++ b/crates/intendant-display/src/windows.rs
@@ -1149,6 +1149,14 @@ fn run_dxgi_capture(
     // Consecutive hard errors before giving up (display gone, device removed).
     let mut consecutive_errors: u32 = 0;
     const MAX_CONSECUTIVE_ERRORS: u32 = 60;
+    // Heartbeat cadence for WAIT_TIMEOUT re-emission. Matches the pool
+    // bridge's 1s IDLE_HEARTBEAT: re-emitting the cached frame at every
+    // capture tick made an *idle* desktop look like a 30fps stream to
+    // everything downstream (a fresh multi-MB clone per tick, then full
+    // convert + hash + encode per re-emit), defeating the idle gates
+    // that make macOS/Wayland idle sessions nearly free.
+    const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+    let mut last_emit_at = std::time::Instant::now();
 
     loop {
         if shutdown.load(Ordering::SeqCst) {
@@ -1186,15 +1194,20 @@ fn run_dxgi_capture(
 
                 // Cache a clone for heartbeat re-emission, then send.
                 last_frame = Some(clone_frame(&frame));
+                last_emit_at = std::time::Instant::now();
                 let _ = tx.try_send(frame);
             }
             Ok(None) => {
-                // WAIT_TIMEOUT: desktop unchanged. Re-emit the last frame with
-                // a fresh timestamp so the encoder's freshness clock advances.
-                if let Some(prev) = &last_frame {
-                    let mut hb = clone_frame(prev);
-                    hb.timestamp = std::time::Instant::now();
-                    let _ = tx.try_send(hb);
+                // WAIT_TIMEOUT: desktop unchanged. Re-emit the last frame
+                // with a fresh timestamp so the encoder's freshness clock
+                // advances — but at the 1s heartbeat cadence, not per tick.
+                if last_emit_at.elapsed() >= HEARTBEAT_INTERVAL {
+                    if let Some(prev) = &last_frame {
+                        let mut hb = clone_frame(prev);
+                        hb.timestamp = std::time::Instant::now();
+                        last_emit_at = hb.timestamp;
+                        let _ = tx.try_send(hb);
+                    }
                 }
             }
             Err(CaptureError::AccessLost) => {
@@ -1922,6 +1935,16 @@ fn run_gdi_capture(
     let mut frame_count: u64 = 0;
     let mut consecutive_errors: u32 = 0;
     const MAX_CONSECUTIVE_ERRORS: u32 = 60;
+    // Re-resolve the capture rect every N frames (mirrors the X11
+    // backend's GEOMETRY_CHECK_INTERVAL): resolving display topology
+    // per iteration was a per-frame syscall spent re-learning a value
+    // that changes on the order of monitor re-arranges.
+    const GEOMETRY_CHECK_INTERVAL: u64 = 60;
+    // Error-path heartbeat cadence — matches the pool bridge's 1s
+    // IDLE_HEARTBEAT (see run_dxgi_capture) so a transient error storm
+    // re-emits the cached frame once a second, not per retry.
+    const HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+    let mut last_emit_at = std::time::Instant::now();
 
     loop {
         if shutdown.load(Ordering::SeqCst) {
@@ -1931,28 +1954,31 @@ fn run_gdi_capture(
 
         // Detect a primary-resolution change and rebuild the cached resources.
         // For a targeted output we re-resolve its rect too, so a monitor
-        // re-arrange / mode switch is picked up.
-        if let Ok((nx, ny, nw, nh)) = resolve_capture_rect(target_output) {
-            if nw != capture.width || nh != capture.height || nx != rect_x || ny != rect_y {
-                match GdiCapture::new(nx, ny, nw, nh) {
-                    Ok(c) => {
-                        eprintln!(
-                            "[display/windows] GDI resize: {}x{} -> {nw}x{nh}",
-                            capture.width, capture.height,
-                        );
-                        capture = c;
-                        rect_x = nx;
-                        rect_y = ny;
-                        shared_width.store(nw, Ordering::SeqCst);
-                        shared_height.store(nh, Ordering::SeqCst);
-                        // Keep the capture-rect origin current too, so input
-                        // injection follows a monitor re-arrange / mode switch.
-                        shared_left.store(nx, Ordering::SeqCst);
-                        shared_top.store(ny, Ordering::SeqCst);
-                        last_frame = None;
-                    }
-                    Err(e) => {
-                        eprintln!("[display/windows] GDI resize rebuild failed: {e}");
+        // re-arrange / mode switch is picked up. Checked on a frame
+        // cadence, not per iteration.
+        if frame_count > 0 && frame_count.is_multiple_of(GEOMETRY_CHECK_INTERVAL) {
+            if let Ok((nx, ny, nw, nh)) = resolve_capture_rect(target_output) {
+                if nw != capture.width || nh != capture.height || nx != rect_x || ny != rect_y {
+                    match GdiCapture::new(nx, ny, nw, nh) {
+                        Ok(c) => {
+                            eprintln!(
+                                "[display/windows] GDI resize: {}x{} -> {nw}x{nh}",
+                                capture.width, capture.height,
+                            );
+                            capture = c;
+                            rect_x = nx;
+                            rect_y = ny;
+                            shared_width.store(nw, Ordering::SeqCst);
+                            shared_height.store(nh, Ordering::SeqCst);
+                            // Keep the capture-rect origin current too, so input
+                            // injection follows a monitor re-arrange / mode switch.
+                            shared_left.store(nx, Ordering::SeqCst);
+                            shared_top.store(ny, Ordering::SeqCst);
+                            last_frame = None;
+                        }
+                        Err(e) => {
+                            eprintln!("[display/windows] GDI resize rebuild failed: {e}");
+                        }
                     }
                 }
             }
@@ -1995,16 +2021,21 @@ fn run_gdi_capture(
                 }
 
                 last_frame = Some(clone_frame(&frame));
+                last_emit_at = std::time::Instant::now();
                 let _ = tx.try_send(frame);
             }
             Err(e) => {
                 consecutive_errors += 1;
                 eprintln!("[display/windows] GDI capture error ({consecutive_errors}): {e}");
-                // Keep the encoder's heartbeat alive with the last good frame.
-                if let Some(prev) = &last_frame {
-                    let mut hb = clone_frame(prev);
-                    hb.timestamp = std::time::Instant::now();
-                    let _ = tx.try_send(hb);
+                // Keep the encoder's heartbeat alive with the last good
+                // frame — at the 1s heartbeat cadence, not per retry.
+                if last_emit_at.elapsed() >= HEARTBEAT_INTERVAL {
+                    if let Some(prev) = &last_frame {
+                        let mut hb = clone_frame(prev);
+                        hb.timestamp = std::time::Instant::now();
+                        last_emit_at = hb.timestamp;
+                        let _ = tx.try_send(hb);
+                    }
                 }
                 if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
                     eprintln!("[display/windows] GDI giving up after {consecutive_errors} errors",);


### PR DESCRIPTION
Implements the S/M findings from the display-efficiency audit (scopes 13: encode/WebRTC/tile, 14: capture core), excluding the decision-gated items. Fence: `crates/intendant-display/**` only.

## Finding -> fix

| Finding | Fix | Impact | Risk |
|---|---|---|---|
| Full-frame byte-serial FNV hash per frame, inline on the runtime, at capture rate (`capture/frame_diff.rs`, tile bridge in `lib.rs`) | 8-byte word-wise FNV (~8x fewer dependent multiplies); flat `Vec<u64>` hash table instead of HashMap; cadence gate moved ahead of the diff (15fps, not 30); diff runs in `spawn_blocking` | High: largest steady-state CPU on the common viewing path (macOS/Windows/Wayland) | Low; existing diff tests pass |
| Delta-cadence skips permanently dropped dirty tiles (freshness bug, scope-13 "other findings") | Cheap damage (in-frame rects, OS damage polls) accumulates into a pending set across skipped ticks; flushed on the next allowed tick | Correctness: a change on a skipped frame is no longer stale until the 30s snapshot | Low |
| `bgra_to_i420` streamed BGRA twice + fresh ~5.5MB zeroed Vec per frame (`encode/mod.rs:594`) | Fused single pass over row pairs (Y + UV together); bridge recycles retired I420 buffers via an `Arc::try_unwrap` ring | High: measured 7.393 -> 3.802 ms/frame at 1080p (1.9x), checksum-identical; the pre-existing reference-equivalence test passes | Low |
| Per-peer encoded-frame clone on RTP fan-out (`webrtc/driver.rs:1519`) | `EncodedFrame.data: bytes::Bytes`; the per-peer clone is a refcount bump | Med: 5-500KB memcpy per peer per frame removed | Low |
| Per-RTP-packet allocs + sender re-lookup in the write loop (`driver.rs:1533-1558`, `:1445`) | Precomputed mid/rid extension `Bytes`; one `rtp_sender` lookup per frame; keyframe-gate table is a small linear Vec looked up by reference (no per-frame spec+rid clone) | Low-Med: steady per-packet allocator churn on the hottest send loop | Low |
| Tile snapshots re-encoded per subscriber; tile payloads copied twice per peer (`lib.rs`, `driver.rs:1690`) | Snapshot encoded once per burst, wire frames fanned out refcounted; tile lane carries `Bytes` end-to-end (only remaining copy is rtc's forced `BytesMut` boundary) | Med: full-screen lossless encode no longer scales with viewer count | Low |
| Unbounded `pending_tile_snapshot`/`pending_tile_control` queues on a closed-but-subscribed channel (scope-13 "other findings") | Snapshot: **atomic whole-group hand-off over an id-latest-wins per-peer mailbox (a slow older encode cannot overwrite a faster newer baseline)** - the producer publishes every chunk of one snapshot id in a single synchronous replace (never awaits holding a group; a cancelled producer publishes nothing), the driver drains it in its select loop, and a persisted per-driver watermark rejects stale ids across open/drain/close cycles with a plain increasing compare (documented no-wrap assumption, matching the browser's own `snapshotId <= lastApplied` contract). Retention is exactly one complete group per peer end-to-end - upstream mailbox and pre-open store alike - so no byte-cap eviction can ever strand the browser on a partial baseline. Control queue: byte-capped drop-oldest (1MB; frames are self-contained). Policy unit-tested through the production methods. | Robustness: removes an unbounded-memory path (~15MB re-queued every 30s) and bounds upstream retention that the bounded command channel could not (32 slots x whole snapshots + parked sender tasks) | Low |
| Per-tile encode: per-pixel copies, full alpha prefill, `raw.clone()`, RLE with no early abort (`tile/encode.rs`) | Row-wise `copy_from_slice`; prefill only on partial edge tiles; raw moved not cloned; RLE aborts at raw size; chunked WebP swizzle | Med on tile-streaming sessions | Low; encoding selection order unchanged, tests pass |
| Simulcast downscale: fresh zeroed buffer per frame per layer; generic f32 bilinear for exact 2x (`encode/mod.rs:707`, `pool/worker.rs`) | `downscale_i420_into` + per-encoder-thread scratch; exact-2x integer box filter (bit-identical to the pixel-center bilinear; equivalence argued in-code) | Low-Med | Low; 4x and other ratios keep bilinear |
| ICE-TCP / TURN egress: `to_vec` per packet; two syscalls per RFC 4571 frame (`driver.rs:925,940`, `tcp_mux.rs:445`) | `BytesMut::freeze()` (zero-copy) into `Bytes` channels; header+payload coalesced into one `write_all` | Low-Med: every media packet on the TCP/relay lanes | Low |
| Per-byte push swizzles on screenshot/JPEG paths; PNG encode inline on the runtime (`lib.rs:2404`, `:1955`, `:2310-2433`) | One shared row-wise `frame_to_tight_rgba`; `screenshot`/`screenshot_fresh` PNG encode moved to `spawn_blocking` | Med: CU-action screenshot latency + runtime stalls (PNG was 50-200ms inline) | Low |
| 1Hz FrameRegistry sampler re-encoded an unchanged frame every second (`lib.rs` sampler; the in-fence sibling of the recording finding) | `Arc::ptr_eq` JPEG cache: an unchanged frame re-registers the cached bytes with fresh metadata | Med on idle event-driven backends | Low; encode failures register nothing, as before |
| X11 cursor QueryPointer round-trip per captured frame (`capture/x11_damage.rs`, bridge) | Cursor sampled at delta cadence (<=15Hz), and not at all in video mode | Low | Low |
| Windows: WAIT_TIMEOUT/error heartbeat re-emitted a full-frame clone per tick; `resolve_capture_rect` per iteration (`windows.rs`) | Heartbeats throttled to the pool bridge's 1s cadence; rect re-resolve every 60 frames (mirrors X11's `GEOMETRY_CHECK_INTERVAL`) | High for idle Windows sessions (idle no longer runs the full 30fps pipeline) | Low; cfg(windows) code hand-reviewed, compile gate is this PR's Windows check leg (host cross-build stops at ring's build script) |
| Visual-marker stamping cloned the full ~5.5MB I420 per source-dim encoder per frame; docstring contradiction (`pool/worker.rs:424`, `pool/mod.rs:689`) | Bridge stamps once per push into a per-push copy (heartbeat freshness preserved); workers re-stamp only after downscale; both docstrings now describe the implemented contract | Low (opt-in diagnostics) | Low |

## Explicitly not done (decision-gated / out of scope)

- Windows GDI -> DXGI capture default flip (decision-gated).
- SCK dirty-rects default-on (decision-gated).
- Capture `Frame.data -> bytes::Bytes` refactor (L-track): the GDI/DXGI per-frame cache clone and capture-buffer reuse depend on it and remain.
- `recording.rs` findings (unchanged-frame JPEG re-encode at 15fps, registry locks across ffmpeg writes, legacy macOS feeder) - `src/bin/caller/recording.rs` is outside this PR's fence.
- X11 damage-gated capture (scope-14 #4, M effort / med risk) and the Wayland manual-mmap fd cache (fallback-only) - left for a follow-up.

## Behavior notes

- The delta cadence clock now advances on every allowed pipeline tick (including idle ones): the wire cadence cap is unchanged, worst case adds <=66ms latency on an idle->active transition, and in exchange the diff/policy pipeline runs at 15fps instead of 30.
- `tile_delta_cadence_skips` now counts gated ticks with known pending damage (frame-diff platforms defer the diff, so idle skips there are no longer counted); field docs updated.
- `tile_snapshot_*` counters count each snapshot encode once, not once per peer served.
- TilePolicy samples at delta cadence (rolling window ~533ms vs ~266ms; MIN_DWELL 500ms still dominates transitions).
- CursorState control frames now emit at <=15Hz (they ride the same tick).
- With 1Hz DXGI heartbeats, `fresh_frame` on an **idle Windows desktop** typically waits out the 300ms fresh-frame timeout and returns the latest-frame fallback - CU screenshots gain up to +300ms there. Content-accurate per the documented `fresh_frame` contract, and it matches the macOS/Wayland event-driven backends, which already behave this way when idle.

## Validation

- `cargo fmt --check` clean; `cargo clippy -p intendant-display --all-targets` introduces no new warnings (the one it did introduce - dead `RtpSendState.mid` - is fixed in-branch).
- `cargo test -p intendant-display`: 542 passed (6 new tests from review fixes). `cargo test --bins` and the headless e2e suite pass.
- Release perf bench (`bgra_to_i420_perf_1080p`): 7.393 -> 3.802 ms/frame, checksums equal; `bgra_to_i420_matches_reference_pattern` (bit-exactness vs the reference impl) passes.
- macOS real-capture stress test (`--ignored` suite) passes.
