### PR TITLE
mcp: stop re-collecting, re-reading, and re-serializing on the status/log hot paths

### DIFF
--- a/src/bin/caller/mcp/commands.rs
+++ b/src/bin/caller/mcp/commands.rs
@@ -76,6 +76,9 @@ pub(crate) async fn start_task_with_state(
                     LogLevel::Info,
                     format!("Follow-up submitted via {}: {}", source, task),
                 );
+                // Dispatch changes process reality (the loop resumes work):
+                // drop any pre-dispatch controller-loop sample.
+                s.note_live_session_lifecycle_change();
                 drop(s);
                 tx.send(FollowUpMessage::text(task_clone))
                     .await
@@ -110,6 +113,11 @@ pub(crate) async fn start_task_with_state(
         LogLevel::Info,
         format!("Task started via {}: {}", source, task),
     );
+    // Task dispatch changes process reality (a session/agent is about to
+    // spawn): a cached no-process sample from before the dispatch must not
+    // answer the first post-start status poll (which could otherwise
+    // commit the session to Done via the stale-controller check).
+    s.note_live_session_lifecycle_change();
 
     let bus = bus.clone();
     drop(s);
@@ -920,6 +928,13 @@ pub(crate) async fn handle_control_command_mcp(
             let persistent = persistent.unwrap_or(true);
             match request_loop_halt_marker(&loop_dir, persistent) {
                 Ok(()) => {
+                    // Bump the cache generation before re-collecting: a
+                    // concurrent pre-warm holding a pre-mutation sample
+                    // must not store over the fresh one below.
+                    state
+                        .read()
+                        .await
+                        .invalidate_controller_loop_raw_status_cache();
                     let data = collect_controller_loop_status_with_state(&loop_dir, state).await;
                     emit_control_result(
                         control_tx,
@@ -943,6 +958,10 @@ pub(crate) async fn handle_control_command_mcp(
             let loop_dir = controller_loop_dir();
             match clear_loop_halt_markers(&loop_dir) {
                 Ok(()) => {
+                    state
+                        .read()
+                        .await
+                        .invalidate_controller_loop_raw_status_cache();
                     let data = collect_controller_loop_status_with_state(&loop_dir, state).await;
                     emit_control_result(
                         control_tx,
@@ -962,6 +981,10 @@ pub(crate) async fn handle_control_command_mcp(
             let loop_dir = controller_loop_dir();
             match request_loop_intervention_marker(&loop_dir, &mode) {
                 Ok(intervention) => {
+                    state
+                        .read()
+                        .await
+                        .invalidate_controller_loop_raw_status_cache();
                     let mut data =
                         collect_controller_loop_status_with_state(&loop_dir, state).await;
                     add_controller_loop_intervention_report(&mut data, &intervention);

--- a/src/bin/caller/mcp/commands.rs
+++ b/src/bin/caller/mcp/commands.rs
@@ -1123,6 +1123,9 @@ pub(crate) async fn handle_control_command_mcp(
             if let Some(ref tx) = s.follow_up_tx {
                 let tx = tx.clone();
                 s.set_phase(Phase::Thinking);
+                // Follow-up dispatch resumes work: drop any pre-dispatch
+                // controller-loop sample.
+                s.note_live_session_lifecycle_change();
                 s.push_log(LogLevel::Info, format!("Follow-up via socket: {}", text));
                 drop(s);
                 if tx.send(FollowUpMessage::text(text)).await.is_err() {

--- a/src/bin/caller/mcp/controller_loop.rs
+++ b/src/bin/caller/mcp/controller_loop.rs
@@ -1629,16 +1629,13 @@ pub(crate) fn controller_loop_state_is_idle(status: &str) -> bool {
 }
 
 pub(crate) fn codex_app_server_process_tree_active(pid: u32) -> bool {
-    // The root-alive probe is a cheap syscall, while the descendants
-    // snapshot spawns `ps` and parses the whole system process table —
-    // and `_with_root` never reads the descendants when the root is
-    // alive (the common case on this per-wrapper status hot path). Only
-    // pay for the snapshot once the root is known dead.
-    if crate::platform::process_alive(pid) {
-        return true;
-    }
-    codex_app_server_process_tree_active_from_descendants(
-        crate::platform::process_descendants(pid),
+    codex_app_server_process_tree_active_with_root(
+        pid,
+        // Lazy: `_with_root` never advances the descendants iterator when
+        // the root is alive (the common case on this per-wrapper status
+        // hot path), and materializing the descendants spawns `ps` over
+        // the whole system process table — defer the spawn to first use.
+        std::iter::once_with(move || crate::platform::process_descendants(pid)).flatten(),
         crate::platform::process_alive,
         crate::platform::process_cmdline,
     )

--- a/src/bin/caller/mcp/controller_loop.rs
+++ b/src/bin/caller/mcp/controller_loop.rs
@@ -528,11 +528,12 @@ pub(crate) fn collect_controller_loop_status_for_mcp_state(
     loop_dir: &std::path::Path,
     state: &McpAppState,
 ) -> serde_json::Value {
+    let (_, generation) = state.probe_controller_loop_raw_status(loop_dir);
     let raw = collect_controller_loop_raw_status(loop_dir);
     if state.controller_loop_status_override.is_none()
         && mcp_state_controller_loop_dir(state) == loop_dir
     {
-        state.store_controller_loop_raw_status(raw.clone());
+        state.store_controller_loop_raw_status_at(generation, raw.clone());
     }
     finish_controller_loop_status(raw, Some((state, current_unix_timestamp_secs())))
 }
@@ -639,14 +640,15 @@ pub(crate) fn mcp_state_controller_loop_status(s: &McpAppState) -> serde_json::V
             // to three times per call (promote + active/stale checks), and
             // supervised gates poll it continuously. Enrichment always runs
             // against the live state, so folded session phases are never
-            // stale even on a cache hit.
-            let raw = s
-                .cached_controller_loop_raw_status(&loop_dir)
-                .unwrap_or_else(|| {
-                    let raw = collect_controller_loop_raw_status(&loop_dir);
-                    s.store_controller_loop_raw_status(raw.clone());
-                    raw
-                });
+            // stale even on a cache hit. Stores carry the probe generation:
+            // if an invalidation (lifecycle/marker mutation) lands between
+            // probe and store, the pre-mutation sample is discarded.
+            let (hit, generation) = s.probe_controller_loop_raw_status(&loop_dir);
+            let raw = hit.unwrap_or_else(|| {
+                let raw = collect_controller_loop_raw_status(&loop_dir);
+                s.store_controller_loop_raw_status_at(generation, raw.clone());
+                raw
+            });
             finish_controller_loop_status(raw, Some((s, current_unix_timestamp_secs())))
         })
 }

--- a/src/bin/caller/mcp/controller_loop.rs
+++ b/src/bin/caller/mcp/controller_loop.rs
@@ -574,21 +574,47 @@ pub(crate) fn controller_loop_status_has_live_owner_or_process(status: &serde_js
             > 0
 }
 
-pub(crate) fn mcp_state_session_source_for_id(s: &McpAppState, session_id: &str) -> Option<String> {
-    s.session_source_for_id(session_id)
-        .map(str::to_string)
-        .or_else(|| {
-            (s.session_id == session_id)
-                .then(|| s.active_session_source.clone())
-                .flatten()
-        })
-        .or_else(|| {
-            match resolve_persisted_start_target(&mcp_state_session_logs_home(s), session_id) {
-                PersistedStartTarget::External(target) => Some(target.source),
-                PersistedStartTarget::ExternalMissingResume { source } => source,
-                PersistedStartTarget::NotFound | PersistedStartTarget::NonExternal => None,
-            }
-        })
+pub(crate) fn mcp_state_session_source_for_id(
+    s: &mut McpAppState,
+    session_id: &str,
+) -> Option<String> {
+    if let Some(source) = s.session_source_for_id(session_id).map(str::to_string) {
+        return Some(source);
+    }
+    if s.session_id == session_id {
+        if let Some(source) = s.active_session_source.clone() {
+            return Some(source);
+        }
+    }
+    // The persisted fallback reads and identity-scans the whole session log;
+    // a status poller for a session whose source never lands in
+    // session_sources would otherwise pay that scan on every call. Memoize
+    // both resolvable outcomes — resolved sources into session_sources,
+    // known-non-external ids into a dedicated set. NotFound stays uncached:
+    // the session's log may materialize a moment later.
+    if s.session_known_non_external.contains(session_id) {
+        return None;
+    }
+    match resolve_persisted_start_target(&mcp_state_session_logs_home(s), session_id) {
+        PersistedStartTarget::External(target) => {
+            s.session_sources
+                .insert(session_id.to_string(), target.source.clone());
+            Some(target.source)
+        }
+        PersistedStartTarget::ExternalMissingResume {
+            source: Some(source),
+        } => {
+            s.session_sources
+                .insert(session_id.to_string(), source.clone());
+            Some(source)
+        }
+        PersistedStartTarget::ExternalMissingResume { source: None }
+        | PersistedStartTarget::NotFound => None,
+        PersistedStartTarget::NonExternal => {
+            s.session_known_non_external.insert(session_id.to_string());
+            None
+        }
+    }
 }
 
 pub(crate) fn mcp_state_controller_loop_dir(s: &McpAppState) -> std::path::PathBuf {
@@ -822,7 +848,7 @@ pub(crate) fn mcp_state_controller_loop_has_active_codex_for_session(
 }
 
 pub(crate) fn mcp_state_codex_active_phase_has_stale_controller(
-    s: &McpAppState,
+    s: &mut McpAppState,
     session_id: &str,
     phase: &Phase,
 ) -> bool {

--- a/src/bin/caller/mcp/controller_loop.rs
+++ b/src/bin/caller/mcp/controller_loop.rs
@@ -295,21 +295,56 @@ pub(crate) fn collect_controller_loop_status(loop_dir: &std::path::Path) -> serd
     collect_controller_loop_status_inner(loop_dir, None)
 }
 
-pub(crate) fn collect_controller_loop_status_for_mcp_state(
-    loop_dir: &std::path::Path,
-    state: &McpAppState,
-) -> serde_json::Value {
-    collect_controller_loop_status_inner(loop_dir, Some((state, current_unix_timestamp_secs())))
+/// How long a [`ControllerLoopRawStatus`] snapshot stays servable from the
+/// per-state cache. The raw collection spawns `ps`, scans every historical
+/// run dir, and reads wrapper/session metadata — polled status surfaces
+/// (`get_status`, supervised phase gates) otherwise repeat that work several
+/// times per call. Enrichment against live MCP state is re-applied per
+/// consumer, so only the filesystem/process sample ages, never the folded
+/// session state.
+pub(crate) const CONTROLLER_LOOP_RAW_STATUS_TTL: std::time::Duration =
+    std::time::Duration::from_secs(1);
+
+/// The state-independent (and expensive) half of a controller-loop status
+/// collection: marker flags, lock/pid liveness, run-dir + process-tree +
+/// wrapper-index discovery, latest-run pointers, and the intervention-order
+/// report. Everything here is a pure filesystem/process sample, so it can be
+/// collected without any `McpAppState` lock and briefly cached; the
+/// state-dependent tail lives in [`finish_controller_loop_status`].
+#[derive(Clone, Debug)]
+pub(crate) struct ControllerLoopRawStatus {
+    loop_dir: std::path::PathBuf,
+    halt: bool,
+    halt_after_cycle: bool,
+    stop_requested: bool,
+    abort_requested: bool,
+    lock_present: bool,
+    lock_owner_pid: Option<u32>,
+    lock_owner_alive: bool,
+    active_wrappers: Vec<serde_json::Value>,
+    active_codex: Vec<serde_json::Value>,
+    latest_run_id: Option<String>,
+    latest_status_file: serde_json::Value,
+    latest_target: Option<String>,
+    latest_pid: Option<u32>,
+    latest_pid_alive: bool,
+    intervention_order: serde_json::Value,
 }
 
-pub(crate) fn collect_controller_loop_status_inner(
+impl ControllerLoopRawStatus {
+    /// The loop dir this sample was collected from — the cache key.
+    pub(crate) fn loop_dir(&self) -> &std::path::Path {
+        &self.loop_dir
+    }
+}
+
+pub(crate) fn collect_controller_loop_raw_status(
     loop_dir: &std::path::Path,
-    live_state: Option<(&McpAppState, u64)>,
-) -> serde_json::Value {
+) -> ControllerLoopRawStatus {
     let halt = loop_dir.join("request_halt").exists();
     let halt_after_cycle = loop_dir.join("request_halt_after_cycle").exists();
-    let mut stop_requested = loop_dir.join("request_stop").exists();
-    let mut abort_requested = loop_dir.join("request_abort").exists();
+    let stop_requested = loop_dir.join("request_stop").exists();
+    let abort_requested = loop_dir.join("request_abort").exists();
 
     let lock_dir = loop_dir.join("active.lock");
     let lock_owner_pid = parse_pid_file(&lock_dir.join("pid"));
@@ -355,18 +390,9 @@ pub(crate) fn collect_controller_loop_status_inner(
         loop_dir,
         &process_tree_codex,
     ));
-    if let Some((state, now_secs)) = live_state {
-        enrich_controller_loop_wrappers_with_mcp_state(&mut active_wrappers, state, now_secs);
-        enrich_controller_loop_codex_with_mcp_state(&mut active_codex, state, now_secs);
-    }
 
     let latest_run_id = read_trimmed(&loop_dir.join("latest.run_id"));
     let latest_status_file = read_json_file(&loop_dir.join("latest.status.json"));
-    let latest_status = controller_loop_latest_status_with_codex(
-        latest_status_file,
-        &active_wrappers,
-        &active_codex,
-    );
     let latest_target_path = std::fs::read_link(loop_dir.join("latest")).ok().map(|p| {
         if p.is_absolute() {
             p
@@ -381,18 +407,6 @@ pub(crate) fn collect_controller_loop_status_inner(
     let latest_pid_alive = latest_pid
         .map(crate::platform::process_alive)
         .unwrap_or(false);
-    let stale_intervention_cleared = (stop_requested || abort_requested)
-        && controller_loop_intervention_markers_are_stale(
-            lock_owner_alive,
-            latest_pid_alive,
-            &active_wrappers,
-            &active_codex,
-        );
-    if stale_intervention_cleared {
-        clear_loop_intervention_markers(loop_dir).ok();
-        stop_requested = false;
-        abort_requested = false;
-    }
     let intervention_order = latest_target_path
         .as_ref()
         .map(|p| intervention_order_report(p))
@@ -402,6 +416,78 @@ pub(crate) fn collect_controller_loop_status_inner(
                 "order_ok": true,
             })
         });
+
+    ControllerLoopRawStatus {
+        loop_dir: loop_dir.to_path_buf(),
+        halt,
+        halt_after_cycle,
+        stop_requested,
+        abort_requested,
+        lock_present: lock_dir.exists(),
+        lock_owner_pid,
+        lock_owner_alive,
+        active_wrappers,
+        active_codex,
+        latest_run_id,
+        latest_status_file,
+        latest_target,
+        latest_pid,
+        latest_pid_alive,
+        intervention_order,
+    }
+}
+
+/// The state-dependent tail of a controller-loop status collection: enrich
+/// the discovered wrappers/codex processes with live MCP session state, fold
+/// them into the latest-run status, clear stale intervention markers, and
+/// assemble the public JSON document. Cheap (in-memory except for the rare
+/// stale-marker unlink), so consumers of a cached [`ControllerLoopRawStatus`]
+/// re-run it against current state on every read.
+pub(crate) fn finish_controller_loop_status(
+    raw: ControllerLoopRawStatus,
+    live_state: Option<(&McpAppState, u64)>,
+) -> serde_json::Value {
+    let ControllerLoopRawStatus {
+        loop_dir,
+        halt,
+        halt_after_cycle,
+        mut stop_requested,
+        mut abort_requested,
+        lock_present,
+        lock_owner_pid,
+        lock_owner_alive,
+        mut active_wrappers,
+        mut active_codex,
+        latest_run_id,
+        latest_status_file,
+        latest_target,
+        latest_pid,
+        latest_pid_alive,
+        intervention_order,
+    } = raw;
+
+    if let Some((state, now_secs)) = live_state {
+        enrich_controller_loop_wrappers_with_mcp_state(&mut active_wrappers, state, now_secs);
+        enrich_controller_loop_codex_with_mcp_state(&mut active_codex, state, now_secs);
+    }
+
+    let latest_status = controller_loop_latest_status_with_codex(
+        latest_status_file,
+        &active_wrappers,
+        &active_codex,
+    );
+    let stale_intervention_cleared = (stop_requested || abort_requested)
+        && controller_loop_intervention_markers_are_stale(
+            lock_owner_alive,
+            latest_pid_alive,
+            &active_wrappers,
+            &active_codex,
+        );
+    if stale_intervention_cleared {
+        clear_loop_intervention_markers(&loop_dir).ok();
+        stop_requested = false;
+        abort_requested = false;
+    }
 
     serde_json::json!({
         "loop_dir": loop_dir.to_string_lossy(),
@@ -413,7 +499,7 @@ pub(crate) fn collect_controller_loop_status_inner(
             "stale_intervention_cleared": stale_intervention_cleared,
         },
         "lock": {
-            "present": lock_dir.exists(),
+            "present": lock_present,
             "owner_pid": lock_owner_pid,
             "owner_alive": lock_owner_alive,
         },
@@ -432,6 +518,30 @@ pub(crate) fn collect_controller_loop_status_inner(
             "codex": active_codex,
         }
     })
+}
+
+/// Fresh collection with live-state enrichment. Callers on marker-mutating
+/// paths rely on this never serving a cached sample; it re-seeds the
+/// per-state raw cache instead, so pollers observe the post-mutation loop
+/// state immediately.
+pub(crate) fn collect_controller_loop_status_for_mcp_state(
+    loop_dir: &std::path::Path,
+    state: &McpAppState,
+) -> serde_json::Value {
+    let raw = collect_controller_loop_raw_status(loop_dir);
+    if state.controller_loop_status_override.is_none()
+        && mcp_state_controller_loop_dir(state) == loop_dir
+    {
+        state.store_controller_loop_raw_status(raw.clone());
+    }
+    finish_controller_loop_status(raw, Some((state, current_unix_timestamp_secs())))
+}
+
+pub(crate) fn collect_controller_loop_status_inner(
+    loop_dir: &std::path::Path,
+    live_state: Option<(&McpAppState, u64)>,
+) -> serde_json::Value {
+    finish_controller_loop_status(collect_controller_loop_raw_status(loop_dir), live_state)
 }
 
 pub(crate) fn controller_loop_dir_has_observable_state(loop_dir: &std::path::Path) -> bool {
@@ -498,7 +608,20 @@ pub(crate) fn mcp_state_controller_loop_status(s: &McpAppState) -> serde_json::V
         .clone()
         .unwrap_or_else(|| {
             let loop_dir = mcp_state_controller_loop_dir(s);
-            collect_controller_loop_status_for_mcp_state(&loop_dir, s)
+            // Serve the raw filesystem/process sample from the short-TTL
+            // cache when fresh — `get_status` consults this collection two
+            // to three times per call (promote + active/stale checks), and
+            // supervised gates poll it continuously. Enrichment always runs
+            // against the live state, so folded session phases are never
+            // stale even on a cache hit.
+            let raw = s
+                .cached_controller_loop_raw_status(&loop_dir)
+                .unwrap_or_else(|| {
+                    let raw = collect_controller_loop_raw_status(&loop_dir);
+                    s.store_controller_loop_raw_status(raw.clone());
+                    raw
+                });
+            finish_controller_loop_status(raw, Some((s, current_unix_timestamp_secs())))
         })
 }
 
@@ -1506,8 +1629,15 @@ pub(crate) fn controller_loop_state_is_idle(status: &str) -> bool {
 }
 
 pub(crate) fn codex_app_server_process_tree_active(pid: u32) -> bool {
-    codex_app_server_process_tree_active_with_root(
-        pid,
+    // The root-alive probe is a cheap syscall, while the descendants
+    // snapshot spawns `ps` and parses the whole system process table —
+    // and `_with_root` never reads the descendants when the root is
+    // alive (the common case on this per-wrapper status hot path). Only
+    // pay for the snapshot once the root is known dead.
+    if crate::platform::process_alive(pid) {
+        return true;
+    }
+    codex_app_server_process_tree_active_from_descendants(
         crate::platform::process_descendants(pid),
         crate::platform::process_alive,
         crate::platform::process_cmdline,

--- a/src/bin/caller/mcp/controller_loop.rs
+++ b/src/bin/caller/mcp/controller_loop.rs
@@ -338,8 +338,14 @@ impl ControllerLoopRawStatus {
     }
 }
 
+/// `wrapper_index_home`: the home whose external-wrapper index may be
+/// consulted for live codex processes (hermetic-tests convention — the
+/// caller supplies the root; state-scoped callers pass
+/// [`mcp_state_session_logs_home`], stateless transport edges resolve the
+/// real home dir).
 pub(crate) fn collect_controller_loop_raw_status(
     loop_dir: &std::path::Path,
+    wrapper_index_home: &std::path::Path,
 ) -> ControllerLoopRawStatus {
     let halt = loop_dir.join("request_halt").exists();
     let halt_after_cycle = loop_dir.join("request_halt_after_cycle").exists();
@@ -388,6 +394,7 @@ pub(crate) fn collect_controller_loop_raw_status(
     ));
     active_wrappers.extend(active_external_wrappers_from_index_for_processes(
         loop_dir,
+        wrapper_index_home,
         &process_tree_codex,
     ));
 
@@ -529,7 +536,7 @@ pub(crate) fn collect_controller_loop_status_for_mcp_state(
     state: &McpAppState,
 ) -> serde_json::Value {
     let (_, generation) = state.probe_controller_loop_raw_status(loop_dir);
-    let raw = collect_controller_loop_raw_status(loop_dir);
+    let raw = collect_controller_loop_raw_status(loop_dir, &mcp_state_session_logs_home(state));
     if state.controller_loop_status_override.is_none()
         && mcp_state_controller_loop_dir(state) == loop_dir
     {
@@ -542,7 +549,13 @@ pub(crate) fn collect_controller_loop_status_inner(
     loop_dir: &std::path::Path,
     live_state: Option<(&McpAppState, u64)>,
 ) -> serde_json::Value {
-    finish_controller_loop_status(collect_controller_loop_raw_status(loop_dir), live_state)
+    // Stateless transport edge: no state-scoped home override exists here,
+    // so the real home dir is resolved at this boundary.
+    let wrapper_index_home = crate::platform::home_dir();
+    finish_controller_loop_status(
+        collect_controller_loop_raw_status(loop_dir, &wrapper_index_home),
+        live_state,
+    )
 }
 
 pub(crate) fn controller_loop_dir_has_observable_state(loop_dir: &std::path::Path) -> bool {
@@ -609,8 +622,12 @@ pub(crate) fn mcp_state_session_source_for_id(
                 .insert(session_id.to_string(), source.clone());
             Some(source)
         }
+        // NotFound and Unreadable are both uncached: the log may appear (or
+        // become readable) a moment later. Only a successfully READ log
+        // with no external identity memoizes as non-external.
         PersistedStartTarget::ExternalMissingResume { source: None }
-        | PersistedStartTarget::NotFound => None,
+        | PersistedStartTarget::NotFound
+        | PersistedStartTarget::Unreadable => None,
         PersistedStartTarget::NonExternal => {
             s.session_known_non_external.insert(session_id.to_string());
             None
@@ -645,7 +662,8 @@ pub(crate) fn mcp_state_controller_loop_status(s: &McpAppState) -> serde_json::V
             // probe and store, the pre-mutation sample is discarded.
             let (hit, generation) = s.probe_controller_loop_raw_status(&loop_dir);
             let raw = hit.unwrap_or_else(|| {
-                let raw = collect_controller_loop_raw_status(&loop_dir);
+                let raw =
+                    collect_controller_loop_raw_status(&loop_dir, &mcp_state_session_logs_home(s));
                 s.store_controller_loop_raw_status_at(generation, raw.clone());
                 raw
             });
@@ -910,10 +928,15 @@ pub(crate) fn controller_loop_active_wrapper_is_idle_external_app_server(
 #[allow(dead_code)]
 pub(crate) fn active_external_wrappers_from_index(
     loop_dir: &std::path::Path,
+    wrapper_index_home: &std::path::Path,
     live_codex_pids: &[u32],
 ) -> Vec<serde_json::Value> {
     let live_codex_processes = live_codex_processes_from_pids(live_codex_pids);
-    active_external_wrappers_from_index_for_processes(loop_dir, &live_codex_processes)
+    active_external_wrappers_from_index_for_processes(
+        loop_dir,
+        wrapper_index_home,
+        &live_codex_processes,
+    )
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -924,9 +947,10 @@ pub(crate) struct LiveCodexAppServerProcess {
 
 pub(crate) fn active_external_wrappers_from_index_for_processes(
     loop_dir: &std::path::Path,
+    wrapper_index_home: &std::path::Path,
     live_codex_processes: &[LiveCodexAppServerProcess],
 ) -> Vec<serde_json::Value> {
-    let candidate_homes = controller_loop_wrapper_index_homes(loop_dir);
+    let candidate_homes = controller_loop_wrapper_index_homes(loop_dir, wrapper_index_home);
     active_external_wrappers_from_index_homes_for_processes(
         candidate_homes.iter(),
         live_codex_processes,
@@ -1583,14 +1607,21 @@ pub(crate) fn controller_loop_home(loop_dir: &std::path::Path) -> Option<std::pa
     intendant_dir.parent().map(std::path::Path::to_path_buf)
 }
 
+/// Candidate homes whose external-wrapper indexes may describe the live
+/// codex processes: the home the loop dir belongs to, then the caller's
+/// `wrapper_index_home`. Hermetic-tests convention: the home is a
+/// PARAMETER — state-scoped callers thread [`mcp_state_session_logs_home`]
+/// (test-overridable) and only the stateless transport edges resolve the
+/// real `home_dir()`.
 pub(crate) fn controller_loop_wrapper_index_homes(
     loop_dir: &std::path::Path,
+    wrapper_index_home: &std::path::Path,
 ) -> Vec<std::path::PathBuf> {
     let mut homes = Vec::new();
     let mut seen = HashSet::new();
     for home in [
         controller_loop_home(loop_dir),
-        Some(crate::platform::home_dir()),
+        Some(wrapper_index_home.to_path_buf()),
     ]
     .into_iter()
     .flatten()
@@ -2471,7 +2502,7 @@ mod tests {
         )
         .unwrap();
 
-        let wrappers = active_external_wrappers_from_index(&loop_dir, &[1084559]);
+        let wrappers = active_external_wrappers_from_index(&loop_dir, home, &[1084559]);
         assert_eq!(wrappers.len(), 1);
         assert_eq!(
             wrappers[0]
@@ -3250,7 +3281,7 @@ mod tests {
         )
         .unwrap();
 
-        let wrappers = active_external_wrappers_from_index(&loop_dir, &[1084559]);
+        let wrappers = active_external_wrappers_from_index(&loop_dir, home, &[1084559]);
         assert_eq!(wrappers.len(), 1);
         assert_eq!(
             wrappers[0]
@@ -3414,7 +3445,7 @@ mod tests {
             .unwrap();
         }
 
-        let wrappers = active_external_wrappers_from_index(&loop_dir, &[1084559]);
+        let wrappers = active_external_wrappers_from_index(&loop_dir, home, &[1084559]);
         assert_eq!(wrappers.len(), 1);
         assert_eq!(
             wrappers[0]

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -1644,14 +1644,14 @@ pub(crate) fn hydrate_requested_session_status_from_logs(
         // noted on PR #343, not patchable here without one.
         //
         // Enter the replay scope (RAII — a panic mid-fold must not leave
-        // the state stuck in "hydrating" mode): replays never trigger the
-        // over-cap prune and never invalidate the controller-loop cache
-        // (see note_session_ended / note_live_session_lifecycle_change).
-        let mut replay = s.begin_hydration_replay(if base.bytes == 0 {
-            HydrationReplayKind::Full
-        } else {
-            HydrationReplayKind::Tail
-        });
+        // the state stuck in "hydrating" mode), carrying the hydration
+        // TARGET: replays never trigger the over-cap prune, never
+        // invalidate the controller-loop cache, and rows lacking a session
+        // id (round_complete predates stamping) attribute to the target —
+        // never to the daemon's active session (see
+        // note_session_ended / note_live_session_lifecycle_change /
+        // unattributed_event_session_id).
+        let mut replay = s.begin_hydration_replay(session_id);
         let advanced = walk_session_jsonl_tail(&tail, base, |_, line| {
             let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) else {
                 return true;
@@ -1934,6 +1934,77 @@ mod tests {
             ));
             assert_eq!(
                 s.session_status_for_id(session_id)
+                    .map(|st| st.phase.clone()),
+                Some(Phase::RunningAgent)
+            );
+        });
+    }
+
+    #[test]
+    fn hydration_attributes_unattributed_rows_to_the_target_session() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let home = tempdir().unwrap();
+            let session_id = "sess-old";
+            let log_dir = home.path().join(".intendant").join("logs").join(session_id);
+            let mut log = crate::session_log::SessionLog::open(log_dir.clone()).unwrap();
+            log.write_meta(None, Some("old session task"));
+            log.agent_started_with_session_id(
+                Some(session_id),
+                1,
+                "round one",
+                None,
+                Some("Codex"),
+            );
+            // The REAL writer: round_complete rows persist NO session id
+            // (replay reconstructs session_id: None), and this one is the
+            // log's FINAL row — nothing after it re-attributes.
+            log.round_complete(2, 1);
+
+            // An unrelated session is live and active on the daemon.
+            let state = test_state();
+            let mut s = state.write().await;
+            s.session_id = "sess-live".to_string();
+            s.note_session_phase(Some("sess-live"), Some(3), Phase::RunningAgent, None);
+
+            // Hydrating `sess-old` must attribute the naked round_complete
+            // to the HYDRATION TARGET: the requested session reaches
+            // WaitingFollowUp and the live session is untouched. (The
+            // active-session fallback here both missed the target and
+            // corrupted the live session — with the cursor then committed
+            // past the row, so neither side ever healed.)
+            assert!(hydrate_requested_session_status_from_logs(
+                home.path(),
+                &mut s,
+                session_id
+            ));
+            assert_eq!(
+                s.session_status_for_id(session_id)
+                    .map(|st| st.phase.clone()),
+                Some(Phase::WaitingFollowUp)
+            );
+            assert_eq!(
+                s.session_status_for_id(session_id).map(|st| st.round),
+                Some(2)
+            );
+            assert_eq!(
+                s.session_status_for_id("sess-live")
+                    .map(|st| st.phase.clone()),
+                Some(Phase::RunningAgent)
+            );
+
+            // Stays consistent once the cursor sits at EOF.
+            hydrate_requested_session_status_from_logs(home.path(), &mut s, session_id);
+            assert_eq!(
+                s.session_status_for_id(session_id)
+                    .map(|st| st.phase.clone()),
+                Some(Phase::WaitingFollowUp)
+            );
+            assert_eq!(
+                s.session_status_for_id("sess-live")
                     .map(|st| st.phase.clone()),
                 Some(Phase::RunningAgent)
             );

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -1588,11 +1588,15 @@ pub(crate) fn hydrate_requested_session_status_from_logs(
     // direct write and note_session_round), budget_pct, phase (+
     // phase_entered_at via set_phase), task_description, session_id,
     // active_session_source, codex_managed_context, provider/model names,
-    // and the usage scalars (tokens x5, context/hard windows). Globals the
-    // applier can write but no replayable row reaches (presence_*,
-    // external_agent, configured_codex_managed_context, log_dir,
-    // pending_approval, human_question) are safe by unreachability, not by
-    // this bracket — re-audit when the replay converter grows a producer.
+    // and the usage scalars (tokens x5, context/hard windows). Two other
+    // buckets are safe WITHOUT this bracket, each with its own re-audit
+    // trigger: globals the applier can write but no replayable row reaches
+    // (presence_*, external_agent, configured_codex_managed_context,
+    // log_dir) — re-audit when the replay converter grows a producer; and
+    // fields with replayable producers that the hydration applier never
+    // writes (pending_approval, human_question — ApprovalRequired's arm
+    // writes only phase state, HumanQuestionDetected has no applier arm) —
+    // re-audit when the applier grows a write to them.
     let provider_name = s.provider_name.clone();
     let model_name = s.model_name.clone();
     let turn = s.turn;

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -126,6 +126,49 @@ pub(crate) fn codex_thread_action_result_targets_session(
 /// [`McpAppState`], exactly as the TUI's `handle_event` does.
 ///
 /// Returns a handle for cleanup.
+/// How long resource-update notifications are coalesced before flushing.
+/// During output bursts every fold-loop event used to produce an immediate
+/// per-event stdout JSON-RPC write (and a conforming client re-reads the
+/// resource per notification); one debounced notification per URI per window
+/// carries the same information.
+const RESOURCE_NOTIFY_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Send `notifications/resources/updated` for every dirty URI the client
+/// subscribed to, then clear the dirty set. Unsubscribed URIs are dropped:
+/// resource notifications are subscription-scoped in MCP, so a client that
+/// never subscribes no longer receives (and re-reads on) unsolicited spam.
+async fn flush_resource_notifications(
+    state: &SharedMcpState,
+    peer: &Arc<Mutex<Option<rmcp::Peer<RoleServer>>>>,
+    dirty: &mut std::collections::HashSet<String>,
+) {
+    if dirty.is_empty() {
+        return;
+    }
+    let mut subscribed: Vec<String> = {
+        let s = state.read().await;
+        dirty
+            .iter()
+            .filter(|uri| s.subscribed_resource_uris.contains(*uri))
+            .cloned()
+            .collect()
+    };
+    dirty.clear();
+    if subscribed.is_empty() {
+        return;
+    }
+    subscribed.sort();
+    let peer_guard = peer.lock().await;
+    let Some(ref p) = *peer_guard else {
+        return;
+    };
+    for uri in subscribed {
+        let _ = p
+            .notify_resource_updated(ResourceUpdatedNotificationParam { uri })
+            .await;
+    }
+}
+
 pub fn spawn_event_listener(
     state: SharedMcpState,
     mut event_rx: tokio::sync::broadcast::Receiver<AppEvent>,
@@ -135,11 +178,31 @@ pub fn spawn_event_listener(
     control_tx: Option<broadcast::Sender<String>>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
+        let mut dirty_resources: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        let mut flush_deadline: Option<tokio::time::Instant> = None;
         loop {
-            let event = match event_rx.recv().await {
-                Ok(event) => event,
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            let event = tokio::select! {
+                event = event_rx.recv() => match event {
+                    Ok(event) => event,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        // Flush anything still pending before exiting so a
+                        // final state change is not silently dropped.
+                        flush_resource_notifications(&state, &peer, &mut dirty_resources).await;
+                        break;
+                    }
+                },
+                // NOTE: the async expression is evaluated even when the
+                // precondition is false, so the disabled arm must not
+                // unwrap a missing deadline.
+                _ = tokio::time::sleep_until(
+                    flush_deadline.unwrap_or_else(tokio::time::Instant::now),
+                ), if flush_deadline.is_some() => {
+                    flush_resource_notifications(&state, &peer, &mut dirty_resources).await;
+                    flush_deadline = None;
+                    continue;
+                }
             };
             let mut resource_changed: Option<&str> = None;
             let mut deferred_control_msg: Option<ControlMsg> = None;
@@ -1048,23 +1111,21 @@ pub fn spawn_event_listener(
                 }
             }
 
+            // Mark changed resources dirty and coalesce the notifications:
+            // both the event's own resource and a control command's are
+            // recorded (the historical single slot dropped the first when a
+            // deferred control command followed in the same iteration).
+            if let Some(uri) = resource_changed {
+                dirty_resources.insert(uri.to_string());
+            }
             if let Some(msg) = deferred_control_msg {
                 if let Some(uri) = handle_control_command_mcp(&state, &bus, &control_tx, msg).await
                 {
-                    resource_changed = Some(uri);
+                    dirty_resources.insert(uri.to_string());
                 }
             }
-
-            // Send resource update notification if something changed
-            if let Some(uri) = resource_changed {
-                let peer_guard = peer.lock().await;
-                if let Some(ref p) = *peer_guard {
-                    let _ = p
-                        .notify_resource_updated(ResourceUpdatedNotificationParam {
-                            uri: uri.to_string(),
-                        })
-                        .await;
-                }
+            if !dirty_resources.is_empty() && flush_deadline.is_none() {
+                flush_deadline = Some(tokio::time::Instant::now() + RESOURCE_NOTIFY_DEBOUNCE);
             }
         }
     })
@@ -1586,11 +1647,7 @@ mod tests {
         rt.block_on(async {
             let home = tempdir().unwrap();
             let session_id = "sess-hydrate-cursor";
-            let log_dir = home
-                .path()
-                .join(".intendant")
-                .join("logs")
-                .join(session_id);
+            let log_dir = home.path().join(".intendant").join("logs").join(session_id);
             let mut log = crate::session_log::SessionLog::open(log_dir.clone()).unwrap();
             log.write_meta(None, Some("cursor test task"));
             log.agent_started_with_session_id(
@@ -1609,7 +1666,8 @@ mod tests {
                 session_id
             ));
             assert_eq!(
-                s.session_status_for_id(session_id).map(|st| st.phase.clone()),
+                s.session_status_for_id(session_id)
+                    .map(|st| st.phase.clone()),
                 Some(Phase::RunningAgent)
             );
 
@@ -1624,7 +1682,8 @@ mod tests {
                 session_id
             ));
             assert_eq!(
-                s.session_status_for_id(session_id).map(|st| st.phase.clone()),
+                s.session_status_for_id(session_id)
+                    .map(|st| st.phase.clone()),
                 Some(Phase::WaitingFollowUp)
             );
 
@@ -1658,7 +1717,8 @@ mod tests {
                 session_id
             ));
             assert_eq!(
-                s.session_status_for_id(session_id).map(|st| st.phase.clone()),
+                s.session_status_for_id(session_id)
+                    .map(|st| st.phase.clone()),
                 Some(Phase::Done)
             );
         });

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -1579,9 +1579,24 @@ pub(crate) fn hydrate_requested_session_status_from_logs(
         return false;
     }
 
+    // Snapshot/restore bracket for the daemon-global scalars a replay fold
+    // can write. Audited against every AppEvent the replay converter can
+    // produce whose applier arm writes globals (SessionIdentity,
+    // SessionCapabilities, ContextSnapshot, SessionStarted, TurnStarted,
+    // AgentStarted/AgentOutput, DoneSignal/TaskComplete, ApprovalRequired,
+    // RoundComplete, SessionEnded): turn, ROUND (both RoundComplete's
+    // direct write and note_session_round), budget_pct, phase (+
+    // phase_entered_at via set_phase), task_description, session_id,
+    // active_session_source, codex_managed_context, provider/model names,
+    // and the usage scalars (tokens x5, context/hard windows). Globals the
+    // applier can write but no replayable row reaches (presence_*,
+    // external_agent, configured_codex_managed_context, log_dir,
+    // pending_approval, human_question) are safe by unreachability, not by
+    // this bracket — re-audit when the replay converter grows a producer.
     let provider_name = s.provider_name.clone();
     let model_name = s.model_name.clone();
     let turn = s.turn;
+    let round = s.round;
     let budget_pct = s.budget_pct;
     let phase = s.phase.clone();
     let phase_entered_at = s.phase_entered_at;
@@ -1670,6 +1685,7 @@ pub(crate) fn hydrate_requested_session_status_from_logs(
     s.provider_name = provider_name;
     s.model_name = model_name;
     s.turn = turn;
+    s.round = round;
     s.budget_pct = budget_pct;
     s.phase = phase;
     s.phase_entered_at = phase_entered_at;
@@ -1964,11 +1980,16 @@ mod tests {
             // log's FINAL row — nothing after it re-attributes.
             log.round_complete(2, 1);
 
-            // An unrelated session is live and active on the daemon.
+            // An unrelated session is live and active on the daemon, at a
+            // DISTINCT round: the replayed round_complete(2) must neither
+            // relabel the live session nor leak into the daemon-global
+            // round scalar an unscoped get_status reports.
             let state = test_state();
             let mut s = state.write().await;
             s.session_id = "sess-live".to_string();
+            s.round = 9;
             s.note_session_phase(Some("sess-live"), Some(3), Phase::RunningAgent, None);
+            s.note_session_round(Some("sess-live"), 9);
 
             // Hydrating `sess-old` must attribute the naked round_complete
             // to the HYDRATION TARGET: the requested session reaches
@@ -1995,6 +2016,11 @@ mod tests {
                     .map(|st| st.phase.clone()),
                 Some(Phase::RunningAgent)
             );
+            assert_eq!(
+                s.session_status_for_id("sess-live").map(|st| st.round),
+                Some(9)
+            );
+            assert_eq!(s.round, 9, "global round must be bracket-restored");
 
             // Stays consistent once the cursor sits at EOF.
             hydrate_requested_session_status_from_logs(home.path(), &mut s, session_id);
@@ -2008,6 +2034,11 @@ mod tests {
                     .map(|st| st.phase.clone()),
                 Some(Phase::RunningAgent)
             );
+            assert_eq!(
+                s.session_status_for_id("sess-live").map(|st| st.round),
+                Some(9)
+            );
+            assert_eq!(s.round, 9, "global round must survive rehydration");
         });
     }
 

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -187,8 +187,19 @@ pub fn spawn_event_listener(
                     Ok(event) => event,
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                        // Flush anything still pending before exiting so a
-                        // final state change is not silently dropped.
+                        // Liveness note: this arm is UNREACHABLE in the
+                        // production wiring. This task owns `bus` (an
+                        // EventBus holding a `broadcast::Sender<AppEvent>`)
+                        // for its whole life to serve deferred control
+                        // commands, and a broadcast receiver only reports
+                        // Closed once every sender is dropped — our own
+                        // clone keeps the channel open. Real teardown is
+                        // process exit (`run_mcp_server` detaches the
+                        // JoinHandle), where the stdio peer is gone anyway;
+                        // the reachable final-flush seam is the should_quit
+                        // check after control commands below. Kept as
+                        // defense in depth for a future wiring where the
+                        // listener no longer holds a sender.
                         flush_resource_notifications(&state, &peer, &mut dirty_resources).await;
                         break;
                     }
@@ -453,6 +464,7 @@ pub fn spawn_event_listener(
                         ref session_id,
                         message,
                     } => {
+                        s.note_live_session_lifecycle_change();
                         s.set_phase(Phase::Done);
                         s.note_session_phase(session_id.as_deref(), None, Phase::Done, None);
                         s.push_log(
@@ -517,6 +529,7 @@ pub fn spawn_event_listener(
                         reason,
                         ..
                     } => {
+                        s.note_live_session_lifecycle_change();
                         s.set_phase(Phase::Done);
                         s.note_session_phase(session_id.as_deref(), None, Phase::Done, None);
                         s.push_log(LogLevel::Info, format!("Task complete: {}", reason));
@@ -844,6 +857,7 @@ pub fn spawn_event_listener(
                         ref session_id,
                         ref task,
                     } => {
+                        s.note_live_session_lifecycle_change();
                         s.session_id = session_id.clone();
                         s.task_description = task.clone().unwrap_or_default();
                         s.turn = 0;
@@ -989,6 +1003,7 @@ pub fn spawn_event_listener(
                         ref reason,
                         ..
                     } => {
+                        s.note_live_session_lifecycle_change();
                         s.set_phase(Phase::Interrupted);
                         s.note_session_phase(session_id.as_deref(), None, Phase::Interrupted, None);
                         s.push_log(LogLevel::Info, format!("Interrupted: {}", reason));
@@ -1118,13 +1133,23 @@ pub fn spawn_event_listener(
             if let Some(uri) = resource_changed {
                 dirty_resources.insert(uri.to_string());
             }
+            let mut control_processed = false;
             if let Some(msg) = deferred_control_msg {
+                control_processed = true;
                 if let Some(uri) = handle_control_command_mcp(&state, &bus, &control_tx, msg).await
                 {
                     dirty_resources.insert(uri.to_string());
                 }
             }
-            if !dirty_resources.is_empty() && flush_deadline.is_none() {
+            // The Quit control command is the only in-process teardown seam
+            // this task can observe (the channel cannot close under us —
+            // see the Closed-arm note): flush pending notifications now
+            // instead of letting the process exit inside the debounce
+            // window.
+            if control_processed && state.read().await.should_quit {
+                flush_resource_notifications(&state, &peer, &mut dirty_resources).await;
+                flush_deadline = None;
+            } else if !dirty_resources.is_empty() && flush_deadline.is_none() {
                 flush_deadline = Some(tokio::time::Instant::now() + RESOURCE_NOTIFY_DEBOUNCE);
             }
         }
@@ -1212,6 +1237,7 @@ pub(crate) fn apply_observed_event_to_mcp_state(s: &mut McpAppState, event: &App
             raw,
         ),
         AppEvent::SessionStarted { session_id, task } => {
+            s.note_live_session_lifecycle_change();
             s.session_id = session_id.clone();
             s.task_description = task.clone().unwrap_or_default();
             s.turn = 0;
@@ -1342,6 +1368,7 @@ pub(crate) fn apply_observed_event_to_mcp_state(s: &mut McpAppState, event: &App
             true
         }
         AppEvent::DoneSignal { session_id, .. } | AppEvent::TaskComplete { session_id, .. } => {
+            s.note_live_session_lifecycle_change();
             s.set_phase(Phase::Done);
             s.note_session_phase(session_id.as_deref(), None, Phase::Done, None);
             true
@@ -1371,6 +1398,7 @@ pub(crate) fn apply_observed_event_to_mcp_state(s: &mut McpAppState, event: &App
             true
         }
         AppEvent::Interrupted { session_id, .. } => {
+            s.note_live_session_lifecycle_change();
             s.set_phase(Phase::Interrupted);
             s.note_session_phase(session_id.as_deref(), None, Phase::Interrupted, None);
             true
@@ -1567,10 +1595,30 @@ pub(crate) fn hydrate_requested_session_status_from_logs(
         // past an unterminated final line, so partially flushed writes are
         // re-read (and re-applied, idempotently) once complete.
         let path = dir.join("session.jsonl");
-        let prior = s.session_log_hydration_cursors.get(&path).copied();
+        let mut prior = s.session_log_hydration_cursors.get(&path).copied();
+        // Coherence backstop: a cursor is only meaningful together with the
+        // folded state its consumed prefix produced. If this session has no
+        // folded status (pruned bookkeeping, or a cursor left behind by a
+        // dir whose basename didn't match the pruned ids), skipping the
+        // prefix would answer the query from absent state — force a full
+        // replay instead.
+        if prior.is_some_and(|cursor| cursor.bytes > 0)
+            && s.session_status_for_id(session_id).is_none()
+        {
+            prior = None;
+            s.session_log_hydration_cursors.remove(&path);
+        }
         let Some((tail, base)) = read_session_jsonl_tail(&path, prior) else {
             continue;
         };
+        // Mark the replay kind for the fold: full replays must not
+        // overwrite live-marked session status (freshness watermark) and
+        // must not trigger the over-cap prune (see note_session_ended).
+        s.hydration_replay = Some(if base.bytes == 0 {
+            HydrationReplayKind::Full
+        } else {
+            HydrationReplayKind::Tail
+        });
         let advanced = walk_session_jsonl_tail(&tail, base, |_, line| {
             let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) else {
                 return true;
@@ -1582,6 +1630,7 @@ pub(crate) fn hydrate_requested_session_status_from_logs(
             changed |= apply_observed_event_to_mcp_state(s, &event);
             true
         });
+        s.hydration_replay = None;
         s.session_log_hydration_cursors.insert(path, advanced);
     }
 
@@ -1637,6 +1686,136 @@ mod tests {
     use crate::mcp::tests::test_state;
     use tempfile::tempdir;
     use tokio::time::{timeout, Duration};
+
+    #[test]
+    fn pruned_ended_session_rehydrates_to_done_and_stays_consistent() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let home = tempdir().unwrap();
+            let session_id = "sess-prune-poison";
+            let log_dir = home.path().join(".intendant").join("logs").join(session_id);
+            let mut log = crate::session_log::SessionLog::open(log_dir.clone()).unwrap();
+            log.write_meta(None, Some("prune poison task"));
+            log.agent_started_with_session_id(
+                Some(session_id),
+                1,
+                "do things",
+                None,
+                Some("Codex"),
+            );
+            {
+                use std::io::Write as _;
+                let mut file = std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(log_dir.join("session.jsonl"))
+                    .unwrap();
+                writeln!(
+                    file,
+                    "{}",
+                    serde_json::json!({
+                        "ts": "00:00:01.000",
+                        "event": "session_ended",
+                        "level": "info",
+                        "message": "session ended",
+                        "data": { "session_id": session_id, "reason": "done" },
+                    })
+                )
+                .unwrap();
+            }
+
+            let state = test_state();
+            let mut s = state.write().await;
+            // The daemon is busy with an unrelated live session.
+            s.session_id = "live-session".to_string();
+            s.note_session_phase(Some("live-session"), Some(9), Phase::Thinking, None);
+            // Blow past the cap, then end the requested session live: its
+            // component is pruned.
+            for i in 0..=ENDED_SESSION_PRUNE_THRESHOLD {
+                s.note_session_phase(Some(&format!("filler-{i}")), Some(1), Phase::Thinking, None);
+            }
+            s.note_session_phase(Some(session_id), Some(1), Phase::Thinking, None);
+            s.note_session_ended(session_id);
+            assert!(s.session_status_for_id(session_id).is_none());
+
+            // Query-driven rebuild: hydration must fold the whole log,
+            // leave the rebuilt component RESIDENT (no re-prune from the
+            // replayed session_ended), and answer Done.
+            assert!(hydrate_requested_session_status_from_logs(
+                home.path(),
+                &mut s,
+                session_id
+            ));
+            assert_eq!(
+                s.session_status_for_id(session_id)
+                    .map(|st| st.phase.clone()),
+                Some(Phase::Done)
+            );
+
+            // The poisoning regression: a second query must still answer
+            // Done from the requested session's own state — never fall
+            // through to the daemon's current (unrelated) session because a
+            // re-prune erased the rebuild while the cursor sat at EOF.
+            hydrate_requested_session_status_from_logs(home.path(), &mut s, session_id);
+            assert_eq!(
+                s.session_status_for_id(session_id)
+                    .map(|st| st.phase.clone()),
+                Some(Phase::Done)
+            );
+        });
+    }
+
+    #[test]
+    fn full_replay_does_not_regress_live_observed_phase() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let home = tempdir().unwrap();
+            let session_id = "sess-watermark";
+            let log_dir = home.path().join(".intendant").join("logs").join(session_id);
+            let mut log = crate::session_log::SessionLog::open(log_dir.clone()).unwrap();
+            log.write_meta(None, Some("watermark task"));
+            log.agent_started_with_session_id(
+                Some(session_id),
+                3,
+                "edit files",
+                None,
+                Some("Codex"),
+            );
+
+            let state = test_state();
+            let mut s = state.write().await;
+            assert!(hydrate_requested_session_status_from_logs(
+                home.path(),
+                &mut s,
+                session_id
+            ));
+            assert_eq!(
+                s.session_status_for_id(session_id)
+                    .map(|st| st.phase.clone()),
+                Some(Phase::RunningAgent)
+            );
+
+            // A LIVE observation supersedes the log (flush skew: the log's
+            // final phase lags what the listener already folded).
+            s.note_session_phase(Some(session_id), None, Phase::Interrupted, None);
+
+            // Force a FULL replay (cursor lost — rotation, prune of an
+            // unrelated component that shared the dir, …): the replayed
+            // history must not overwrite the live-marked status.
+            s.session_log_hydration_cursors.clear();
+            hydrate_requested_session_status_from_logs(home.path(), &mut s, session_id);
+            assert_eq!(
+                s.session_status_for_id(session_id)
+                    .map(|st| st.phase.clone()),
+                Some(Phase::Interrupted)
+            );
+        });
+    }
 
     #[test]
     fn hydration_replays_only_the_appended_log_tail() {

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -1497,19 +1497,31 @@ pub(crate) fn hydrate_requested_session_status_from_logs(
 
     let mut changed = false;
     for dir in dirs {
-        let Ok(contents) = std::fs::read_to_string(dir.join("session.jsonl")) else {
+        // Replay only the tail appended since the last hydration of this
+        // log: the fold is a pure last-write-wins state fold (no log-ring
+        // pushes), so folding just the new lines lands on the same state
+        // as a full replay — without re-reading and re-parsing a growing
+        // multi-MB log on every session-scoped `get_status` poll. The
+        // cursor is validated against the live file and never advances
+        // past an unterminated final line, so partially flushed writes are
+        // re-read (and re-applied, idempotently) once complete.
+        let path = dir.join("session.jsonl");
+        let prior = s.session_log_hydration_cursors.get(&path).copied();
+        let Some((tail, base)) = read_session_jsonl_tail(&path, prior) else {
             continue;
         };
-        for line in contents.lines() {
+        let advanced = walk_session_jsonl_tail(&tail, base, |_, line| {
             let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) else {
-                continue;
+                return true;
             };
             let Some(event) = crate::session_log::session_log_entry_to_app_event(&entry, &dir)
             else {
-                continue;
+                return true;
             };
             changed |= apply_observed_event_to_mcp_state(s, &event);
-        }
+            true
+        });
+        s.session_log_hydration_cursors.insert(path, advanced);
     }
 
     s.provider_name = provider_name;
@@ -1564,6 +1576,93 @@ mod tests {
     use crate::mcp::tests::test_state;
     use tempfile::tempdir;
     use tokio::time::{timeout, Duration};
+
+    #[test]
+    fn hydration_replays_only_the_appended_log_tail() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let home = tempdir().unwrap();
+            let session_id = "sess-hydrate-cursor";
+            let log_dir = home
+                .path()
+                .join(".intendant")
+                .join("logs")
+                .join(session_id);
+            let mut log = crate::session_log::SessionLog::open(log_dir.clone()).unwrap();
+            log.write_meta(None, Some("cursor test task"));
+            log.agent_started_with_session_id(
+                Some(session_id),
+                2,
+                "edit files",
+                None,
+                Some("Codex"),
+            );
+
+            let state = test_state();
+            let mut s = state.write().await;
+            assert!(hydrate_requested_session_status_from_logs(
+                home.path(),
+                &mut s,
+                session_id
+            ));
+            assert_eq!(
+                s.session_status_for_id(session_id).map(|st| st.phase.clone()),
+                Some(Phase::RunningAgent)
+            );
+
+            // Simulate a live-observed phase the log has not caught up to.
+            // Re-hydration must fold nothing (no appended lines) instead of
+            // replaying the whole log and regressing the live phase — that
+            // is the cursor's contract.
+            s.note_session_phase(Some(session_id), None, Phase::WaitingFollowUp, None);
+            assert!(!hydrate_requested_session_status_from_logs(
+                home.path(),
+                &mut s,
+                session_id
+            ));
+            assert_eq!(
+                s.session_status_for_id(session_id).map(|st| st.phase.clone()),
+                Some(Phase::WaitingFollowUp)
+            );
+
+            // Append a session_ended line; the next hydration folds exactly
+            // the appended tail.
+            {
+                use std::io::Write as _;
+                let mut file = std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(log_dir.join("session.jsonl"))
+                    .unwrap();
+                writeln!(
+                    file,
+                    "{}",
+                    serde_json::json!({
+                        "ts": "00:00:01.000",
+                        "event": "session_ended",
+                        "level": "info",
+                        "message": "session ended",
+                        "data": {
+                            "session_id": session_id,
+                            "reason": "done",
+                        },
+                    })
+                )
+                .unwrap();
+            }
+            assert!(hydrate_requested_session_status_from_logs(
+                home.path(),
+                &mut s,
+                session_id
+            ));
+            assert_eq!(
+                s.session_status_for_id(session_id).map(|st| st.phase.clone()),
+                Some(Phase::Done)
+            );
+        });
+    }
 
     #[test]
     fn managed_watch_context_pressure_satisfied_after_rewind_across_alias_and_compact_cu_growth() {

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -1624,10 +1624,29 @@ pub(crate) fn hydrate_requested_session_status_from_logs(
         let Some((tail, base)) = read_session_jsonl_tail(&path, prior) else {
             continue;
         };
+        // Ordering contract (bounded skew, self-healing): the session log
+        // is a LOSSLESS, order-preserving serialization of the same event
+        // stream the live listener folds (EventBus::send feeds both lanes
+        // the same objects; the broadcast lane may drop under lag, the log
+        // lane may not). Rows therefore apply UNGATED, and folding to the
+        // log's final state is permanently correct — including through
+        // stale terminal rows (Done/Interrupted are resumable here: a
+        // later resume row supersedes them in the fold, so suppressing
+        // "regressions" by phase kind wedges resumed sessions; proven
+        // wrong twice). The only divergence this allows is TRANSIENT: the
+        // log-sink consumer lags the live fold by its queue depth, so a
+        // replay can land on a state a few events older than live. The
+        // window is the sink lag, it self-heals on the next appended rows
+        // or live event, and it is strictly narrower than the pre-cursor
+        // semantics (which re-folded the whole log on every call).
+        // Eliminating even the transient window needs an emission-stamped
+        // ordering token on lifecycle events — a cross-lane follow-up
+        // noted on PR #343, not patchable here without one.
+        //
         // Enter the replay scope (RAII — a panic mid-fold must not leave
-        // the state stuck in "hydrating" mode): full replays apply the
-        // freshness-watermark lattice and never trigger the over-cap prune
-        // (see note_session_phase / note_session_ended).
+        // the state stuck in "hydrating" mode): replays never trigger the
+        // over-cap prune and never invalidate the controller-loop cache
+        // (see note_session_ended / note_live_session_lifecycle_change).
         let mut replay = s.begin_hydration_replay(if base.bytes == 0 {
             HydrationReplayKind::Full
         } else {
@@ -1782,7 +1801,7 @@ mod tests {
     }
 
     #[test]
-    fn full_replay_applies_newer_terminal_phase_over_lossy_live_mark() {
+    fn full_replay_applies_a_missed_terminal_fact_from_the_lossless_log() {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
@@ -1822,12 +1841,12 @@ mod tests {
 
             let state = test_state();
             let mut s = state.write().await;
-            // The live lane observed the session running (marked) but
-            // MISSED the SessionEnded — the listener is a lossy broadcast,
-            // the log is lossless. The full replay's terminal fact must
-            // apply over the stale live mark; a suppress-all watermark left
-            // the session permanently stuck at the live phase with the
-            // cursor committed at EOF.
+            // The live lane observed the session running but MISSED the
+            // SessionEnded — the listener is a lossy broadcast, the log is
+            // lossless. The ungated fold must land on the log's final state
+            // (Done); any live-favoring suppression here left the session
+            // permanently stuck at the stale live phase with the cursor
+            // committed at EOF.
             s.note_session_phase(Some(session_id), Some(1), Phase::Thinking, None);
             assert!(hydrate_requested_session_status_from_logs(
                 home.path(),
@@ -1851,21 +1870,92 @@ mod tests {
     }
 
     #[test]
-    fn full_replay_does_not_regress_live_observed_phase() {
+    fn full_replay_folds_through_stale_terminal_rows_to_the_logs_final_state() {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .unwrap();
         rt.block_on(async {
             let home = tempdir().unwrap();
-            let session_id = "sess-watermark";
+            let session_id = "sess-resumed-after-done";
             let log_dir = home.path().join(".intendant").join("logs").join(session_id);
             let mut log = crate::session_log::SessionLog::open(log_dir.clone()).unwrap();
-            log.write_meta(None, Some("watermark task"));
+            log.write_meta(None, Some("resumed task"));
+            // Round 1 ends (a terminal row mid-log), then the session
+            // RESUMES — Done/Interrupted are resumable in this system
+            // (follow-ups are accepted in Done), so terminal rows are not
+            // monotonic.
             log.agent_started_with_session_id(
                 Some(session_id),
-                3,
-                "edit files",
+                1,
+                "round one",
+                None,
+                Some("Codex"),
+            );
+            {
+                use std::io::Write as _;
+                let mut file = std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(log_dir.join("session.jsonl"))
+                    .unwrap();
+                writeln!(
+                    file,
+                    "{}",
+                    serde_json::json!({
+                        "ts": "00:00:01.000",
+                        "event": "session_ended",
+                        "level": "info",
+                        "message": "round one done",
+                        "data": { "session_id": session_id, "reason": "done" },
+                    })
+                )
+                .unwrap();
+            }
+            log.agent_started_with_session_id(
+                Some(session_id),
+                2,
+                "resumed round two",
+                None,
+                Some("Codex"),
+            );
+
+            // Live observed the resume (newest truth = RunningAgent).
+            let state = test_state();
+            let mut s = state.write().await;
+            s.note_session_phase(Some(session_id), Some(2), Phase::RunningAgent, None);
+
+            // A FULL replay must fold THROUGH the stale terminal row to the
+            // log's final state — never freeze the session at the old Done
+            // (the round-2 phase-kind lattice did exactly that).
+            assert!(hydrate_requested_session_status_from_logs(
+                home.path(),
+                &mut s,
+                session_id
+            ));
+            assert_eq!(
+                s.session_status_for_id(session_id)
+                    .map(|st| st.phase.clone()),
+                Some(Phase::RunningAgent)
+            );
+        });
+    }
+
+    #[test]
+    fn delayed_tail_rows_apply_and_self_heal_when_the_log_catches_up() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let home = tempdir().unwrap();
+            let session_id = "sess-delayed-tail";
+            let log_dir = home.path().join(".intendant").join("logs").join(session_id);
+            let mut log = crate::session_log::SessionLog::open(log_dir.clone()).unwrap();
+            log.write_meta(None, Some("delayed tail task"));
+            log.agent_started_with_session_id(
+                Some(session_id),
+                1,
+                "round one",
                 None,
                 Some("Codex"),
             );
@@ -1877,25 +1967,59 @@ mod tests {
                 &mut s,
                 session_id
             ));
-            assert_eq!(
-                s.session_status_for_id(session_id)
-                    .map(|st| st.phase.clone()),
-                Some(Phase::RunningAgent)
-            );
 
-            // A LIVE observation supersedes the log (flush skew: the log's
-            // final phase lags what the listener already folded).
-            s.note_session_phase(Some(session_id), None, Phase::Interrupted, None);
+            // Live is AHEAD of the log: the listener already folded the
+            // round's end (WaitingFollowUp) while the lossless log-sink
+            // consumer still lags.
+            s.note_session_phase(Some(session_id), None, Phase::WaitingFollowUp, None);
 
-            // Force a FULL replay (cursor lost — rotation, prune of an
-            // unrelated component that shared the dir, …): the replayed
-            // history must not overwrite the live-marked status.
-            s.session_log_hydration_cursors.clear();
+            // The delayed terminal row lands: the tail replay applies it —
+            // the DOCUMENTED transient (bounded by the sink lag): the
+            // replay reports the log's latest state, a few events behind
+            // live.
+            {
+                use std::io::Write as _;
+                let mut file = std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(log_dir.join("session.jsonl"))
+                    .unwrap();
+                writeln!(
+                    file,
+                    "{}",
+                    serde_json::json!({
+                        "ts": "00:00:01.000",
+                        "event": "session_ended",
+                        "level": "info",
+                        "message": "round one done",
+                        "data": { "session_id": session_id, "reason": "done" },
+                    })
+                )
+                .unwrap();
+            }
             hydrate_requested_session_status_from_logs(home.path(), &mut s, session_id);
             assert_eq!(
                 s.session_status_for_id(session_id)
                     .map(|st| st.phase.clone()),
-                Some(Phase::Interrupted)
+                Some(Phase::Done)
+            );
+
+            // The log catches up with the session's later activity (a
+            // session-id-carrying row — round_complete rows persist no
+            // session id, so the per-session heal rides the next round's
+            // agent_started): the next tail replay self-heals to the log's
+            // newest state.
+            log.agent_started_with_session_id(
+                Some(session_id),
+                2,
+                "round two",
+                None,
+                Some("Codex"),
+            );
+            hydrate_requested_session_status_from_logs(home.path(), &mut s, session_id);
+            assert_eq!(
+                s.session_status_for_id(session_id)
+                    .map(|st| st.phase.clone()),
+                Some(Phase::RunningAgent)
             );
         });
     }

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -133,10 +133,17 @@ pub(crate) fn codex_thread_action_result_targets_session(
 /// carries the same information.
 const RESOURCE_NOTIFY_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(100);
 
+/// Upper bound on one notification flush. Notifications are best-effort by
+/// design: an open-but-not-draining peer (a wedged stdio reader) must not
+/// park the listener — and especially not a teardown flush — indefinitely;
+/// on expiry the remaining notifications are dropped.
+const RESOURCE_NOTIFY_FLUSH_BUDGET: std::time::Duration = std::time::Duration::from_millis(500);
+
 /// Send `notifications/resources/updated` for every dirty URI the client
 /// subscribed to, then clear the dirty set. Unsubscribed URIs are dropped:
 /// resource notifications are subscription-scoped in MCP, so a client that
 /// never subscribes no longer receives (and re-reads on) unsolicited spam.
+/// Bounded by [`RESOURCE_NOTIFY_FLUSH_BUDGET`] — best effort, never a park.
 async fn flush_resource_notifications(
     state: &SharedMcpState,
     peer: &Arc<Mutex<Option<rmcp::Peer<RoleServer>>>>,
@@ -158,15 +165,18 @@ async fn flush_resource_notifications(
         return;
     }
     subscribed.sort();
-    let peer_guard = peer.lock().await;
-    let Some(ref p) = *peer_guard else {
-        return;
+    let send_all = async {
+        let peer_guard = peer.lock().await;
+        let Some(ref p) = *peer_guard else {
+            return;
+        };
+        for uri in subscribed {
+            let _ = p
+                .notify_resource_updated(ResourceUpdatedNotificationParam { uri })
+                .await;
+        }
     };
-    for uri in subscribed {
-        let _ = p
-            .notify_resource_updated(ResourceUpdatedNotificationParam { uri })
-            .await;
-    }
+    let _ = tokio::time::timeout(RESOURCE_NOTIFY_FLUSH_BUDGET, send_all).await;
 }
 
 pub fn spawn_event_listener(
@@ -558,6 +568,7 @@ pub fn spawn_event_listener(
                     }
 
                     AppEvent::SafetyCapReached => {
+                        s.note_live_session_lifecycle_change();
                         s.set_phase(Phase::Done);
                         s.push_log(
                             LogLevel::Error,
@@ -567,6 +578,7 @@ pub fn spawn_event_listener(
                     }
 
                     AppEvent::LoopError(msg) => {
+                        s.note_live_session_lifecycle_change();
                         s.set_phase(Phase::Done);
                         s.push_log(LogLevel::Error, format!("Error: {}", msg));
                         resource_changed = Some("intendant://status");
@@ -1404,6 +1416,7 @@ pub(crate) fn apply_observed_event_to_mcp_state(s: &mut McpAppState, event: &App
             true
         }
         AppEvent::LoopError(_) => {
+            s.note_live_session_lifecycle_change();
             s.set_phase(Phase::Done);
             true
         }
@@ -1611,10 +1624,11 @@ pub(crate) fn hydrate_requested_session_status_from_logs(
         let Some((tail, base)) = read_session_jsonl_tail(&path, prior) else {
             continue;
         };
-        // Mark the replay kind for the fold: full replays must not
-        // overwrite live-marked session status (freshness watermark) and
-        // must not trigger the over-cap prune (see note_session_ended).
-        s.hydration_replay = Some(if base.bytes == 0 {
+        // Enter the replay scope (RAII — a panic mid-fold must not leave
+        // the state stuck in "hydrating" mode): full replays apply the
+        // freshness-watermark lattice and never trigger the over-cap prune
+        // (see note_session_phase / note_session_ended).
+        let mut replay = s.begin_hydration_replay(if base.bytes == 0 {
             HydrationReplayKind::Full
         } else {
             HydrationReplayKind::Tail
@@ -1627,10 +1641,10 @@ pub(crate) fn hydrate_requested_session_status_from_logs(
             else {
                 return true;
             };
-            changed |= apply_observed_event_to_mcp_state(s, &event);
+            changed |= apply_observed_event_to_mcp_state(replay.state(), &event);
             true
         });
-        s.hydration_replay = None;
+        drop(replay);
         s.session_log_hydration_cursors.insert(path, advanced);
     }
 
@@ -1758,6 +1772,75 @@ mod tests {
             // Done from the requested session's own state — never fall
             // through to the daemon's current (unrelated) session because a
             // re-prune erased the rebuild while the cursor sat at EOF.
+            hydrate_requested_session_status_from_logs(home.path(), &mut s, session_id);
+            assert_eq!(
+                s.session_status_for_id(session_id)
+                    .map(|st| st.phase.clone()),
+                Some(Phase::Done)
+            );
+        });
+    }
+
+    #[test]
+    fn full_replay_applies_newer_terminal_phase_over_lossy_live_mark() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let home = tempdir().unwrap();
+            let session_id = "sess-lossy-live";
+            let log_dir = home.path().join(".intendant").join("logs").join(session_id);
+            let mut log = crate::session_log::SessionLog::open(log_dir.clone()).unwrap();
+            log.write_meta(None, Some("lossy live task"));
+            log.agent_started_with_session_id(
+                Some(session_id),
+                1,
+                "edit files",
+                None,
+                Some("Codex"),
+            );
+            {
+                use std::io::Write as _;
+                let mut file = std::fs::OpenOptions::new()
+                    .append(true)
+                    .open(log_dir.join("session.jsonl"))
+                    .unwrap();
+                writeln!(
+                    file,
+                    "{}",
+                    serde_json::json!({
+                        "ts": "00:00:01.000",
+                        "event": "session_ended",
+                        "level": "info",
+                        "message": "session ended",
+                        "data": { "session_id": session_id, "reason": "done" },
+                    })
+                )
+                .unwrap();
+            }
+
+            let state = test_state();
+            let mut s = state.write().await;
+            // The live lane observed the session running (marked) but
+            // MISSED the SessionEnded — the listener is a lossy broadcast,
+            // the log is lossless. The full replay's terminal fact must
+            // apply over the stale live mark; a suppress-all watermark left
+            // the session permanently stuck at the live phase with the
+            // cursor committed at EOF.
+            s.note_session_phase(Some(session_id), Some(1), Phase::Thinking, None);
+            assert!(hydrate_requested_session_status_from_logs(
+                home.path(),
+                &mut s,
+                session_id
+            ));
+            assert_eq!(
+                s.session_status_for_id(session_id)
+                    .map(|st| st.phase.clone()),
+                Some(Phase::Done)
+            );
+
+            // And it stays Done on the next (tail) hydration.
             hydrate_requested_session_status_from_logs(home.path(), &mut s, session_id);
             assert_eq!(
                 s.session_status_for_id(session_id)

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -1055,19 +1055,22 @@ impl IntendantServer {
                 || !s.session_id.is_empty();
             if has_target && s.controller_loop_status_override.is_none() {
                 let loop_dir = mcp_state_controller_loop_dir(&s);
-                s.cached_controller_loop_raw_status(&loop_dir)
-                    .is_none()
-                    .then_some(loop_dir)
+                let (hit, generation) = s.probe_controller_loop_raw_status(&loop_dir);
+                hit.is_none().then_some((loop_dir, generation))
             } else {
                 None
             }
         };
-        if let Some(loop_dir) = needs_collect {
+        if let Some((loop_dir, generation)) = needs_collect {
             let raw = collect_controller_loop_raw_status(&loop_dir);
+            // Store at the pre-collection generation: if a lifecycle or
+            // marker mutation invalidated the cache while we collected
+            // unlocked, this pre-mutation sample is discarded rather than
+            // reinstated.
             self.state
                 .read()
                 .await
-                .store_controller_loop_raw_status(raw);
+                .store_controller_loop_raw_status_at(generation, raw);
         }
         {
             let mut s = self.state.write().await;
@@ -1608,7 +1611,14 @@ fn resolve_persisted_start_target(
     // Preference order for identity facts: a structured event naming this
     // wrapper (else the log's sole identity), then the launch config's
     // source, then — pre-2026-07 dirs only — the legacy prose scrape.
-    let contents = std::fs::read_to_string(log_dir.join("session.jsonl")).unwrap_or_default();
+    // A read FAILURE is not evidence of anything: a partially materialized
+    // or transiently unreadable log must resolve as NotFound-class (which
+    // callers never negative-cache), not as NonExternal — otherwise a
+    // still-appearing external session gets memoized as native forever.
+    let (contents, log_read_failed) = match std::fs::read_to_string(log_dir.join("session.jsonl")) {
+        Ok(contents) => (contents, false),
+        Err(_) => (String::new(), true),
+    };
     let scan = crate::session_identity::scan_session_log(
         &contents,
         session_id,
@@ -1629,7 +1639,11 @@ fn resolve_persisted_start_target(
     };
 
     let Some(source) = source else {
-        return PersistedStartTarget::NonExternal;
+        return if log_read_failed {
+            PersistedStartTarget::NotFound
+        } else {
+            PersistedStartTarget::NonExternal
+        };
     };
     // The scan above is target DISCOVERY; the supervisor's resolver is the
     // authority on resume identity (canonical backend-id filtering plus the
@@ -1788,6 +1802,20 @@ const RESOURCE_APPROVAL_URI: &str = "intendant://pending-approval";
 const RESOURCE_INPUT_URI: &str = "intendant://pending-input";
 const RESOURCE_RESTART_URI: &str = "intendant://controller-restart";
 const RESOURCE_LOOP_URI: &str = "intendant://controller-loop";
+
+/// Every resource URI this server serves — the subscription vocabulary.
+/// `subscribe` validates against this set (rejecting unknown URIs), which
+/// also caps the subscription set at this fixed size; a parity test pins it
+/// to [`resource_definitions`].
+const RESOURCE_URIS: [&str; 7] = [
+    RESOURCE_STATUS_URI,
+    RESOURCE_USAGE_URI,
+    RESOURCE_LOGS_URI,
+    RESOURCE_APPROVAL_URI,
+    RESOURCE_INPUT_URI,
+    RESOURCE_RESTART_URI,
+    RESOURCE_LOOP_URI,
+];
 
 fn make_resource(uri: &str, name: &str, description: &str) -> Resource {
     Resource {
@@ -1971,6 +1999,16 @@ impl ServerHandler for IntendantServer {
         // (resource notifications are subscription-scoped in MCP; the
         // historical behavior of broadcasting every change to every client
         // regardless made each fold-loop event a stdout JSON-RPC write).
+        // Unknown URIs are rejected — nothing would ever notify them, and
+        // validating against the served vocabulary keeps the subscription
+        // set bounded at the resource count instead of growing with
+        // whatever strings a client sends.
+        if !RESOURCE_URIS.contains(&request.uri.as_str()) {
+            return Err(McpError::invalid_params(
+                format!("Unknown resource URI: {}", request.uri),
+                None,
+            ));
+        }
         self.state
             .write()
             .await
@@ -2300,12 +2338,18 @@ pub(crate) mod tests {
 
     pub(crate) fn test_state_with_log_dir(log_dir: std::path::PathBuf) -> SharedMcpState {
         let autonomy = autonomy::shared_autonomy(AutonomyState::default());
-        Arc::new(RwLock::new(McpAppState::new(
-            "openai".to_string(),
-            "gpt-5".to_string(),
-            autonomy,
-            log_dir,
-        )))
+        let mut state =
+            McpAppState::new("openai".to_string(), "gpt-5".to_string(), autonomy, log_dir);
+        // Hermetic default: status paths collect controller-loop reality
+        // (run-dir scans, wrapper-index reads, `ps`) from the REAL machine
+        // when unset — on a live box that scan costs seconds and its
+        // duration becomes machine state. Point it at a never-existing dir
+        // (deterministically empty, no tempdir guard needed); tests that
+        // exercise loop-dir behavior override this themselves.
+        state.controller_loop_dir_override = Some(std::path::PathBuf::from(
+            "/nonexistent/intendant-test-controller-loop",
+        ));
+        Arc::new(RwLock::new(state))
     }
 
     /// Test server over an injected temp home. Session-id-driven paths
@@ -3734,6 +3778,21 @@ pub(crate) mod tests {
     fn resource_definitions_has_seven_entries() {
         let defs = resource_definitions();
         assert_eq!(defs.len(), 7);
+    }
+
+    #[test]
+    fn resource_uris_pin_resource_definitions() {
+        // The subscription vocabulary (RESOURCE_URIS) must be exactly the
+        // set resource_definitions() serves — a new resource that forgets
+        // the vocabulary would be silently unsubscribable.
+        let served: std::collections::BTreeSet<String> = resource_definitions()
+            .iter()
+            .map(|resource| resource.raw.uri.clone())
+            .collect();
+        let vocabulary: std::collections::BTreeSet<String> =
+            RESOURCE_URIS.iter().map(|uri| uri.to_string()).collect();
+        assert_eq!(served, vocabulary);
+        assert_eq!(RESOURCE_URIS.len(), resource_definitions().len());
     }
 
     #[test]

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -1021,6 +1021,32 @@ impl IntendantServer {
         session_id_override: Option<&str>,
         managed_context_override: Option<bool>,
     ) -> String {
+        // Pre-warm the controller-loop raw sample OUTSIDE the state locks:
+        // the collection spawns `ps` and scans the loop/wrapper stores, and
+        // running it under the write lock below would head-of-line-block the
+        // event-fold listener and every other MCP tool for its duration. The
+        // promote/active/stale checks then consume the warmed cache entry
+        // (one shared sample per call instead of two to three collections).
+        let needs_collect = {
+            let s = self.state.read().await;
+            let has_target = session_id_override
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .is_some()
+                || !s.session_id.is_empty();
+            if has_target && s.controller_loop_status_override.is_none() {
+                let loop_dir = mcp_state_controller_loop_dir(&s);
+                s.cached_controller_loop_raw_status(&loop_dir)
+                    .is_none()
+                    .then_some(loop_dir)
+            } else {
+                None
+            }
+        };
+        if let Some(loop_dir) = needs_collect {
+            let raw = collect_controller_loop_raw_status(&loop_dir);
+            self.state.read().await.store_controller_loop_raw_status(raw);
+        }
         {
             let mut s = self.state.write().await;
             if let Some(requested_session_id) = session_id_override

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -212,22 +212,41 @@ impl IntendantServer {
             .read()
             .await
             .exposed_codex_managed_context_enabled_for(session_id, managed_context_override);
-        let mut tools: Vec<serde_json::Value> = self
-            .tool_router
-            .list_all()
+        // Router tool definitions are static per process, but every call
+        // used to re-serialize and ref-inline all ~50 schemas. Build the
+        // unfiltered set once; per-request work is the name-keyed
+        // profile/managed-context filter plus a clone of the surviving
+        // definitions.
+        let router_definitions: &'static [serde_json::Value] = {
+            static DEFINITIONS: std::sync::OnceLock<Vec<serde_json::Value>> =
+                std::sync::OnceLock::new();
+            DEFINITIONS.get_or_init(|| {
+                self.tool_router
+                    .list_all()
+                    .iter()
+                    .map(|tool| {
+                        let mut schema =
+                            serde_json::to_value(&*tool.input_schema).unwrap_or_default();
+                        inline_schema_refs(&mut schema);
+                        serde_json::json!({
+                            "name": tool.name,
+                            "description": tool.description,
+                            "inputSchema": schema,
+                        })
+                    })
+                    .collect()
+            })
+        };
+        let mut tools: Vec<serde_json::Value> = router_definitions
             .iter()
             .filter(|tool| {
-                tool_allowed_for_profile(tool.name.as_ref(), managed_context, tool_profile)
+                tool.get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|name| {
+                        tool_allowed_for_profile(name, managed_context, tool_profile)
+                    })
             })
-            .map(|tool| {
-                let mut schema = serde_json::to_value(&*tool.input_schema).unwrap_or_default();
-                inline_schema_refs(&mut schema);
-                serde_json::json!({
-                    "name": tool.name,
-                    "description": tool.description,
-                    "inputSchema": schema,
-                })
-            })
+            .cloned()
             .collect();
         append_manual_http_tool_definitions(&mut tools, managed_context, tool_profile);
         serde_json::json!({ "tools": tools })
@@ -1045,7 +1064,10 @@ impl IntendantServer {
         };
         if let Some(loop_dir) = needs_collect {
             let raw = collect_controller_loop_raw_status(&loop_dir);
-            self.state.read().await.store_controller_loop_raw_status(raw);
+            self.state
+                .read()
+                .await
+                .store_controller_loop_raw_status(raw);
         }
         {
             let mut s = self.state.write().await;
@@ -1085,7 +1107,11 @@ impl IntendantServer {
                     target_phase = Some(Phase::Thinking);
                 }
                 if target_phase.as_ref().is_some_and(|phase| {
-                    mcp_state_codex_active_phase_has_stale_controller(&s, &target_session_id, phase)
+                    mcp_state_codex_active_phase_has_stale_controller(
+                        &mut s,
+                        &target_session_id,
+                        phase,
+                    )
                 }) {
                     s.note_session_phase(Some(&target_session_id), None, Phase::Done, None);
                 }
@@ -1502,7 +1528,7 @@ impl IntendantServer {
             phase = Some(Phase::Thinking);
         }
         if phase.as_ref().is_some_and(|phase| {
-            mcp_state_codex_active_phase_has_stale_controller(&s, session_id, phase)
+            mcp_state_codex_active_phase_has_stale_controller(&mut s, session_id, phase)
         }) {
             s.note_session_phase(Some(session_id), None, Phase::Done, None);
             return Some(Phase::Done);
@@ -1937,19 +1963,32 @@ impl ServerHandler for IntendantServer {
 
     async fn subscribe(
         &self,
-        _request: SubscribeRequestParams,
+        request: SubscribeRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<(), McpError> {
-        // We push notifications for all resources on every relevant event change
-        // (handled in spawn_event_listener). Accept all subscriptions.
+        // Record the subscription: the event listener pushes
+        // `notifications/resources/updated` only for subscribed URIs
+        // (resource notifications are subscription-scoped in MCP; the
+        // historical behavior of broadcasting every change to every client
+        // regardless made each fold-loop event a stdout JSON-RPC write).
+        self.state
+            .write()
+            .await
+            .subscribed_resource_uris
+            .insert(request.uri);
         Ok(())
     }
 
     async fn unsubscribe(
         &self,
-        _request: UnsubscribeRequestParams,
+        request: UnsubscribeRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<(), McpError> {
+        self.state
+            .write()
+            .await
+            .subscribed_resource_uris
+            .remove(&request.uri);
         Ok(())
     }
 }

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -1056,13 +1056,14 @@ impl IntendantServer {
             if has_target && s.controller_loop_status_override.is_none() {
                 let loop_dir = mcp_state_controller_loop_dir(&s);
                 let (hit, generation) = s.probe_controller_loop_raw_status(&loop_dir);
-                hit.is_none().then_some((loop_dir, generation))
+                hit.is_none()
+                    .then(|| (loop_dir, mcp_state_session_logs_home(&s), generation))
             } else {
                 None
             }
         };
-        if let Some((loop_dir, generation)) = needs_collect {
-            let raw = collect_controller_loop_raw_status(&loop_dir);
+        if let Some((loop_dir, wrapper_index_home, generation)) = needs_collect {
+            let raw = collect_controller_loop_raw_status(&loop_dir, &wrapper_index_home);
             // Store at the pre-collection generation: if a lifecycle or
             // marker mutation invalidated the cache while we collected
             // unlocked, this pre-mutation sample is discarded rather than
@@ -1449,6 +1450,16 @@ impl IntendantServer {
                             session_id
                         );
                     }
+                    // An unreadable persisted log is an error, not a
+                    // fall-through: the generic start path below discards
+                    // the requested session id and would silently launch a
+                    // FRESH session in its place.
+                    PersistedStartTarget::Unreadable => {
+                        return format!(
+                            "Cannot start task: session {}'s persisted log exists but could not be read; retry, or resume from the dashboard with an explicit source/resume_id",
+                            session_id
+                        );
+                    }
                     PersistedStartTarget::NotFound | PersistedStartTarget::NonExternal => {}
                 }
             }
@@ -1587,8 +1598,18 @@ struct PersistedExternalStartTarget {
 enum PersistedStartTarget {
     NotFound,
     NonExternal,
+    /// The session's log dir exists but its `session.jsonl` could not be
+    /// read (partially materialized, transient I/O failure) and no other
+    /// signal named a source. Distinct from both `NotFound` (nothing there)
+    /// and `NonExternal` (successfully read, provably native): source
+    /// memoization may retry it later (never negative-cached), but an
+    /// explicit resume request must surface an error instead of silently
+    /// falling through to a fresh session.
+    Unreadable,
     External(PersistedExternalStartTarget),
-    ExternalMissingResume { source: Option<String> },
+    ExternalMissingResume {
+        source: Option<String>,
+    },
 }
 
 fn resolve_persisted_start_target(
@@ -1640,7 +1661,7 @@ fn resolve_persisted_start_target(
 
     let Some(source) = source else {
         return if log_read_failed {
-            PersistedStartTarget::NotFound
+            PersistedStartTarget::Unreadable
         } else {
             PersistedStartTarget::NonExternal
         };
@@ -2006,7 +2027,7 @@ impl ServerHandler for IntendantServer {
         if !RESOURCE_URIS.contains(&request.uri.as_str()) {
             return Err(McpError::invalid_params(
                 format!("Unknown resource URI: {}", request.uri),
-                None,
+                Some(serde_json::json!({ "uri": request.uri })),
             ));
         }
         self.state
@@ -2340,15 +2361,23 @@ pub(crate) mod tests {
         let autonomy = autonomy::shared_autonomy(AutonomyState::default());
         let mut state =
             McpAppState::new("openai".to_string(), "gpt-5".to_string(), autonomy, log_dir);
-        // Hermetic default: status paths collect controller-loop reality
-        // (run-dir scans, wrapper-index reads, `ps`) from the REAL machine
-        // when unset — on a live box that scan costs seconds and its
-        // duration becomes machine state. Point it at a never-existing dir
-        // (deterministically empty, no tempdir guard needed); tests that
-        // exercise loop-dir behavior override this themselves.
+        // Hermetic defaults: status paths otherwise collect controller-loop
+        // reality from the REAL machine — run-dir scans under the real loop
+        // dir, wrapper-index reads under the real home — and on a live box
+        // that costs seconds and makes test duration machine state. Point
+        // both roots at never-existing dirs (deterministically empty, no
+        // tempdir guard needed); tests that exercise loop-dir or persisted
+        // -log behavior override these themselves. Honest scope: the
+        // collection still spawns one `ps` to probe THIS process's
+        // descendants (platform probe, not overridable state) — its result
+        // for a test process is deterministically empty (tests spawn no
+        // codex children), and with the wrapper-index home threaded above
+        // even a match could no longer read the real home's index.
         state.controller_loop_dir_override = Some(std::path::PathBuf::from(
             "/nonexistent/intendant-test-controller-loop",
         ));
+        state.session_logs_home_override =
+            Some(std::path::PathBuf::from("/nonexistent/intendant-test-home"));
         Arc::new(RwLock::new(state))
     }
 
@@ -3778,6 +3807,60 @@ pub(crate) mod tests {
     fn resource_definitions_has_seven_entries() {
         let defs = resource_definitions();
         assert_eq!(defs.len(), 7);
+    }
+
+    #[test]
+    fn unreadable_persisted_log_errors_instead_of_spawning_a_fresh_session() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let home = tempdir().unwrap();
+            let session_id = "sess-unreadable-log";
+            let log_dir = home.path().join(".intendant").join("logs").join(session_id);
+            std::fs::create_dir_all(&log_dir).unwrap();
+            std::fs::write(
+                log_dir.join("session_meta.json"),
+                serde_json::json!({ "session_id": session_id }).to_string(),
+            )
+            .unwrap();
+            // A session.jsonl that cannot be read as a file (a directory in
+            // its place — the partially-materialized / transient-IO class).
+            std::fs::create_dir_all(log_dir.join("session.jsonl")).unwrap();
+
+            assert_eq!(
+                resolve_persisted_start_target(home.path(), session_id),
+                PersistedStartTarget::Unreadable
+            );
+
+            let state = test_state();
+            state.write().await.session_logs_home_override = Some(home.path().to_path_buf());
+            let bus = EventBus::new();
+            let mut bus_rx = bus.subscribe();
+            let server =
+                IntendantServer::new_with_home(state, bus.clone(), home.path().to_path_buf());
+            let result = server
+                .start_task(Parameters(StartTaskParams {
+                    session_id: Some(session_id.to_string()),
+                    task: "resume the work".to_string(),
+                    orchestrate: None,
+                    reference_frame_ids: Vec::new(),
+                    display_target: None,
+                }))
+                .await;
+            assert!(
+                result.contains("could not be read"),
+                "expected an unreadable-log error, got: {result}"
+            );
+            // No StartTask/ResumeSession may have been dispatched: the
+            // requested session id must never be silently replaced by a
+            // fresh session.
+            assert!(matches!(
+                bus_rx.try_recv(),
+                Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+            ));
+        });
     }
 
     #[test]

--- a/src/bin/caller/mcp/state.rs
+++ b/src/bin/caller/mcp/state.rs
@@ -76,16 +76,19 @@ pub struct McpAppState {
     pub(crate) session_log_hydration_cursors:
         std::collections::HashMap<std::path::PathBuf, SessionJsonlCursor>,
     /// Set while [`hydrate_requested_session_status_from_logs`] folds a log
-    /// into this state, naming the replay kind. It gates two hazards: a
-    /// replayed `session_ended` line must not re-run the over-cap prune
-    /// (the rebuild the query is performing would erase itself and record
-    /// an EOF cursor against absent state), and replayed lifecycle rows
+    /// into this state, carrying the hydration TARGET session id. Three
+    /// jobs: a replayed `session_ended` line must not re-run the over-cap
+    /// prune (the rebuild the query is performing would erase itself and
+    /// record an EOF cursor against absent state); replayed lifecycle rows
     /// must not invalidate the controller-loop raw cache (historic events
     /// do not change process reality — see
-    /// [`McpAppState::note_live_session_lifecycle_change`]). The replay
-    /// itself applies rows UNGATED: the ordering contract lives at the
-    /// hydrate fold site in `events.rs`.
-    pub(crate) hydration_replay: Option<HydrationReplayKind>,
+    /// [`McpAppState::note_live_session_lifecycle_change`]); and a replayed
+    /// row WITHOUT a session id attributes to this target, never to the
+    /// daemon's active session (see
+    /// [`McpAppState::unattributed_event_session_id`]). The replay itself
+    /// applies rows UNGATED: the ordering contract lives at the hydrate
+    /// fold site in `events.rs`.
+    pub(crate) hydration_replay: Option<String>,
     /// Optional launcher for starting tasks via MCP. Set by main.rs.
     pub launcher: Option<Arc<TaskLauncher>>,
     /// Handle to the currently running agent loop, if any.
@@ -209,18 +212,6 @@ pub(crate) struct DensityMaintenanceSatisfaction {
 /// once the status map outgrows this, ended sessions are pruned on
 /// [`McpAppState::note_session_ended`] instead of lingering.
 pub(crate) const ENDED_SESSION_PRUNE_THRESHOLD: usize = 1024;
-
-/// Which kind of log replay a hydration pass is performing. See
-/// [`McpAppState::hydration_replay`].
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum HydrationReplayKind {
-    /// Replaying from byte 0 — re-applies history that live observation may
-    /// already have superseded.
-    Full,
-    /// Replaying only bytes appended past a validated cursor — new
-    /// information by construction.
-    Tail,
-}
 
 /// RAII scope for [`McpAppState::hydration_replay`]: constructed via
 /// [`McpAppState::begin_hydration_replay`], resets the flag on drop so a
@@ -382,15 +373,34 @@ impl McpAppState {
         }
     }
 
-    /// Enter a hydration-replay scope. The returned guard resets
-    /// [`Self::hydration_replay`] on drop (panic-safe); mutate the state
-    /// through [`HydrationReplayGuard::state`] for the replay's duration.
+    /// Enter a hydration-replay scope for `target_session_id`. The returned
+    /// guard resets [`Self::hydration_replay`] on drop (panic-safe); mutate
+    /// the state through [`HydrationReplayGuard::state`] for the replay's
+    /// duration.
     pub(crate) fn begin_hydration_replay(
         &mut self,
-        kind: HydrationReplayKind,
+        target_session_id: &str,
     ) -> HydrationReplayGuard<'_> {
-        self.hydration_replay = Some(kind);
+        self.hydration_replay = Some(target_session_id.trim().to_string());
         HydrationReplayGuard { state: self }
+    }
+
+    /// The session an event WITHOUT a session id belongs to. Live events
+    /// from the bus belong to the daemon's active session — the historical
+    /// fallback, unchanged. During a hydration replay the answer is the
+    /// HYDRATION TARGET instead: some persisted rows carry no session id
+    /// (`round_complete` predates stamping), and reconstructing them
+    /// against the active session would both miss the session being
+    /// hydrated and corrupt the live session's status — a divergence that
+    /// is neither sink-lag-bounded nor self-healing once the cursor
+    /// commits past the row.
+    fn unattributed_event_session_id(&self) -> Option<String> {
+        if let Some(target) = &self.hydration_replay {
+            let target = target.trim();
+            return (!target.is_empty()).then(|| target.to_string());
+        }
+        let id = self.session_id.trim();
+        (!id.is_empty()).then(|| id.to_string())
     }
 
     /// Invalidate the raw controller-loop cache for a LIVE-observed session
@@ -789,10 +799,7 @@ impl McpAppState {
             .map(str::trim)
             .filter(|id| !id.is_empty())
             .map(str::to_string)
-            .or_else(|| {
-                let id = self.session_id.trim();
-                (!id.is_empty()).then(|| id.to_string())
-            });
+            .or_else(|| self.unattributed_event_session_id());
         let Some(target_id) = target_id else {
             if let Some(turn) = turn {
                 self.turn = turn;
@@ -859,10 +866,7 @@ impl McpAppState {
             .map(str::trim)
             .filter(|id| !id.is_empty())
             .map(str::to_string)
-            .or_else(|| {
-                let id = self.session_id.trim();
-                (!id.is_empty()).then(|| id.to_string())
-            });
+            .or_else(|| self.unattributed_event_session_id());
         let Some(target_id) = target_id else {
             self.round = round;
             return;
@@ -954,14 +958,7 @@ impl McpAppState {
             .map(str::trim)
             .filter(|id| !id.is_empty())
             .map(str::to_string)
-            .or_else(|| {
-                let id = self.session_id.trim();
-                if id.is_empty() {
-                    None
-                } else {
-                    Some(id.to_string())
-                }
-            })
+            .or_else(|| self.unattributed_event_session_id())
     }
 
     pub(crate) fn rewind_related_keys(&self, key: &str) -> Vec<String> {

--- a/src/bin/caller/mcp/state.rs
+++ b/src/bin/caller/mcp/state.rs
@@ -65,6 +65,14 @@ pub struct McpAppState {
     /// re-seed it; see [`CONTROLLER_LOOP_RAW_STATUS_TTL`].
     controller_loop_raw_status_cache:
         std::sync::Mutex<Option<(std::time::Instant, ControllerLoopRawStatus)>>,
+    /// Per-`session.jsonl` replay cursors for
+    /// [`hydrate_requested_session_status_from_logs`]: session-scoped
+    /// `get_status` used to re-read and re-fold the whole log on every call;
+    /// the cursor limits each hydration to the appended tail. Validated
+    /// against the live file on use, so a replaced/truncated log self-heals
+    /// with one full replay.
+    pub(crate) session_log_hydration_cursors:
+        std::collections::HashMap<std::path::PathBuf, SessionJsonlCursor>,
     /// Optional launcher for starting tasks via MCP. Set by main.rs.
     pub launcher: Option<Arc<TaskLauncher>>,
     /// Handle to the currently running agent loop, if any.
@@ -217,6 +225,7 @@ impl McpAppState {
             controller_loop_status_override: None,
             session_logs_home_override: None,
             controller_loop_raw_status_cache: std::sync::Mutex::new(None),
+            session_log_hydration_cursors: std::collections::HashMap::new(),
             launcher: None,
             task_handle: None,
             controller_restart: None,

--- a/src/bin/caller/mcp/state.rs
+++ b/src/bin/caller/mcp/state.rs
@@ -134,6 +134,11 @@ pub struct McpAppState {
     pub active_session_source: Option<String>,
     /// Map Intendant wrapper session IDs and backend session IDs to their external source.
     pub session_sources: std::collections::HashMap<String, String>,
+    /// Session ids whose persisted log resolved to a non-external session —
+    /// the negative memo for [`mcp_state_session_source_for_id`]'s fallback,
+    /// which otherwise re-reads and identity-scans the whole session log on
+    /// every status poll of a native session.
+    pub(crate) session_known_non_external: std::collections::HashSet<String>,
     /// Successful rewind records awaiting the next backend usage sample, keyed
     /// by Intendant/backend session id.
     pub(crate) pending_rewind_pressure_checks: std::collections::HashMap<String, String>,
@@ -154,6 +159,11 @@ pub struct McpAppState {
     /// `ask_user` auto-answers immediately with best-judgment guidance
     /// instead of blocking on nobody.
     pub interactive_frontends: bool,
+    /// Resource URIs the stdio MCP client subscribed to. The event listener
+    /// only pushes `notifications/resources/updated` for these (MCP resource
+    /// notifications are subscription-scoped); with no subscriptions the
+    /// per-event stdout writes are skipped entirely.
+    pub(crate) subscribed_resource_uris: std::collections::HashSet<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -180,6 +190,12 @@ pub(crate) struct DensityMaintenanceSatisfaction {
     rewind_only_limit: u64,
     round: usize,
 }
+
+/// Soft cap on the per-session bookkeeping maps. Entries for every session
+/// id and alias ever observed used to accumulate for the daemon's lifetime;
+/// once the status map outgrows this, ended sessions are pruned on
+/// [`McpAppState::note_session_ended`] instead of lingering.
+const ENDED_SESSION_PRUNE_THRESHOLD: usize = 1024;
 
 /// Tracks a pending approval info (responder is in the shared ApprovalRegistry).
 pub struct PendingApprovalState {
@@ -253,10 +269,12 @@ impl McpAppState {
             session_status: std::collections::HashMap::new(),
             active_session_source: None,
             session_sources: std::collections::HashMap::new(),
+            session_known_non_external: std::collections::HashSet::new(),
             pending_rewind_pressure_checks: std::collections::HashMap::new(),
             insufficient_rewind_notices: std::collections::HashMap::new(),
             density_maintenance_satisfied: std::collections::HashMap::new(),
             interactive_frontends: false,
+            subscribed_resource_uris: std::collections::HashSet::new(),
         }
     }
 
@@ -573,6 +591,34 @@ impl McpAppState {
         self.remove_pending_rewind_pressure_check_for_key(session_id);
         self.remove_insufficient_rewind_notice_for_key(session_id);
         self.remove_density_maintenance_satisfied_for_key(session_id);
+        if self.session_status.len() > ENDED_SESSION_PRUNE_THRESHOLD {
+            self.prune_ended_session_bookkeeping(session_id);
+        }
+    }
+
+    /// Drop an ended session's per-session bookkeeping (status, usage,
+    /// sources, aliases, managed-context latch). Only invoked once the
+    /// status map outgrows [`ENDED_SESSION_PRUNE_THRESHOLD`]: under the cap
+    /// an ended session stays resident so post-end queries (get_status of a
+    /// finished session, get_logs by backend alias) answer from memory;
+    /// over it, a later query rebuilds the entries from the persisted log
+    /// via hydration — correct, just one full replay slower.
+    fn prune_ended_session_bookkeeping(&mut self, session_id: &str) {
+        let ids = self.session_related_ids(session_id);
+        for id in &ids {
+            self.session_status.remove(id);
+            self.session_usage.remove(id);
+            self.session_sources.remove(id);
+            self.session_codex_managed_context.remove(id);
+            self.session_known_non_external.remove(id);
+            self.session_aliases.remove(id);
+        }
+        // Hydration cursors are keyed by log dir, not session id, and a
+        // pruned session's next hydration must be a full replay (its folded
+        // state is gone). Dropping them all is safe — every cursor
+        // self-heals with one full pass — and this branch is rare by
+        // construction.
+        self.session_log_hydration_cursors.clear();
     }
 
     pub(crate) fn session_id_applies_to_current_session(&self, session_id: Option<&str>) -> bool {
@@ -1663,5 +1709,42 @@ mod tests {
             assert_eq!(snap.id, 42);
             assert_eq!(snap.category, "destructive");
         });
+    }
+
+    #[test]
+    fn ended_sessions_keep_done_status_under_cap_and_prune_over_it() {
+        let mut s = McpAppState::new(
+            "none".to_string(),
+            "none".to_string(),
+            autonomy::shared_autonomy(AutonomyState::default()),
+            std::path::PathBuf::from("/tmp/test_session"),
+        );
+
+        // Under the cap: an ended session's status (and aliases) stay
+        // resident so post-end status/log queries answer from memory.
+        s.link_session_aliases("wrapper-under", "backend-under");
+        s.note_session_phase(Some("wrapper-under"), Some(3), Phase::Thinking, None);
+        s.note_session_ended("wrapper-under");
+        assert_eq!(
+            s.session_status_for_id("backend-under")
+                .map(|st| st.phase.clone()),
+            Some(Phase::Done)
+        );
+
+        // Blow past the cap with unrelated sessions, then end one: its
+        // whole related-id component must be pruned from the bookkeeping.
+        for i in 0..=ENDED_SESSION_PRUNE_THRESHOLD {
+            s.note_session_phase(Some(&format!("filler-{i}")), Some(1), Phase::Thinking, None);
+        }
+        s.link_session_aliases("wrapper-over", "backend-over");
+        s.note_session_phase(Some("wrapper-over"), Some(5), Phase::Thinking, None);
+        s.session_sources
+            .insert("wrapper-over".to_string(), "codex".to_string());
+        s.note_session_ended("wrapper-over");
+        assert!(s.session_status_for_id("wrapper-over").is_none());
+        assert!(s.session_status_for_id("backend-over").is_none());
+        assert!(s.session_source_for_id("wrapper-over").is_none());
+        assert!(!s.session_aliases.contains_key("wrapper-over"));
+        assert!(!s.session_aliases.contains_key("backend-over"));
     }
 }

--- a/src/bin/caller/mcp/state.rs
+++ b/src/bin/caller/mcp/state.rs
@@ -77,27 +77,15 @@ pub struct McpAppState {
         std::collections::HashMap<std::path::PathBuf, SessionJsonlCursor>,
     /// Set while [`hydrate_requested_session_status_from_logs`] folds a log
     /// into this state, naming the replay kind. It gates two hazards: a
-    /// FULL replay must not overwrite a live-observed session status with
-    /// older log-derived state (see `session_status_live_marks`), and a
     /// replayed `session_ended` line must not re-run the over-cap prune
     /// (the rebuild the query is performing would erase itself and record
-    /// an EOF cursor against absent state).
+    /// an EOF cursor against absent state), and replayed lifecycle rows
+    /// must not invalidate the controller-loop raw cache (historic events
+    /// do not change process reality — see
+    /// [`McpAppState::note_live_session_lifecycle_change`]). The replay
+    /// itself applies rows UNGATED: the ordering contract lives at the
+    /// hydrate fold site in `events.rs`.
     pub(crate) hydration_replay: Option<HydrationReplayKind>,
-    /// Last phase written by a LIVE observation (event listener fold,
-    /// promote) per session id — the hydration freshness watermark. The two
-    /// lanes have different loss properties: the live lane is a lossy
-    /// broadcast (a lagged listener drops events) while the persisted log
-    /// is lossless, so neither lane strictly dominates. A FULL hydration
-    /// replay therefore applies against the phase lattice (see
-    /// [`McpAppState::note_session_phase`]): replayed TERMINAL facts always
-    /// apply (the lossless log proving a session ended outranks a stale
-    /// live mark from a dropped `SessionEnded`), replayed NON-terminal
-    /// phases never overwrite a live-marked session (replaying history must
-    /// not regress a completed or newer live phase; transient non-terminal
-    /// skew self-heals through the live lane or the next terminal fact).
-    /// Appended-tail replays bypass the lattice: those lines are new
-    /// information by construction.
-    pub(crate) session_status_live_phases: std::collections::HashMap<String, Phase>,
     /// Optional launcher for starting tasks via MCP. Set by main.rs.
     pub launcher: Option<Arc<TaskLauncher>>,
     /// Handle to the currently running agent loop, if any.
@@ -234,20 +222,11 @@ pub(crate) enum HydrationReplayKind {
     Tail,
 }
 
-/// Terminal phases in the session-status lattice: a session that reached
-/// one of these has ended. A replayed terminal fact comes from the lossless
-/// log lane and therefore outranks any live-observed mark (the live lane is
-/// a lossy broadcast); a replayed NON-terminal phase never overwrites a
-/// live-marked session.
-pub(crate) fn phase_is_session_terminal(phase: &Phase) -> bool {
-    matches!(phase, Phase::Done | Phase::Interrupted)
-}
-
 /// RAII scope for [`McpAppState::hydration_replay`]: constructed via
 /// [`McpAppState::begin_hydration_replay`], resets the flag on drop so a
 /// panic (or early return) inside a replay can never leave the state
 /// permanently in "hydrating" mode — which would suppress live lifecycle
-/// invalidations and misgate future status writes.
+/// invalidations and the over-cap prune indefinitely.
 pub(crate) struct HydrationReplayGuard<'a> {
     state: &'a mut McpAppState,
 }
@@ -321,7 +300,6 @@ impl McpAppState {
             ),
             session_log_hydration_cursors: std::collections::HashMap::new(),
             hydration_replay: None,
-            session_status_live_phases: std::collections::HashMap::new(),
             launcher: None,
             task_handle: None,
             controller_restart: None,
@@ -745,7 +723,6 @@ impl McpAppState {
             self.session_sources.remove(id);
             self.session_codex_managed_context.remove(id);
             self.session_known_non_external.remove(id);
-            self.session_status_live_phases.remove(id);
             self.session_aliases.remove(id);
         }
         // Drop ONLY the ended component's hydration cursors (log-dir
@@ -835,32 +812,6 @@ impl McpAppState {
                 related
             }
         };
-        // Freshness watermark (see `session_status_live_phases`): a FULL
-        // log replay re-applies history against a live-marked session using
-        // the phase lattice — a replayed TERMINAL fact always applies (the
-        // lossless log outranks a lossy live mark whose `SessionEnded` may
-        // have been dropped), a replayed NON-terminal phase never overwrites
-        // a live mark (flush skew: the log's mid-history phases are older
-        // than the live observation; terminal→non-terminal regressions are
-        // the classic full-replay bug). Tail replays and live observations
-        // pass through; live observations record the watermark.
-        match self.hydration_replay {
-            Some(HydrationReplayKind::Full) => {
-                let live_marked = keys
-                    .iter()
-                    .any(|key| self.session_status_live_phases.contains_key(key));
-                if live_marked && !phase_is_session_terminal(&phase) {
-                    return;
-                }
-            }
-            Some(HydrationReplayKind::Tail) => {}
-            None => {
-                for key in &keys {
-                    self.session_status_live_phases
-                        .insert(key.clone(), phase.clone());
-                }
-            }
-        }
         let existing = keys
             .iter()
             .find_map(|key| self.session_status.get(key))
@@ -925,17 +876,6 @@ impl McpAppState {
                 related
             }
         };
-        // Same full-replay watermark as note_session_phase: rounds ride the
-        // status entry, so a full replay must not regress a live-marked one.
-        // (Rounds carry no terminal lattice of their own — the terminal
-        // facts that may advance over a mark arrive via note_session_phase.)
-        if self.hydration_replay == Some(HydrationReplayKind::Full)
-            && keys
-                .iter()
-                .any(|key| self.session_status_live_phases.contains_key(key))
-        {
-            return;
-        }
         for key in &keys {
             let entry =
                 self.session_status
@@ -1931,8 +1871,6 @@ mod tests {
         // every unrelated session end.
         assert!(!s.session_log_hydration_cursors.contains_key(&ended_path));
         assert!(s.session_log_hydration_cursors.contains_key(&live_path));
-        assert!(!s.session_status_live_phases.contains_key("sess-ended"));
-        assert!(!s.session_status_live_phases.contains_key("backend-ended"));
     }
 
     #[test]

--- a/src/bin/caller/mcp/state.rs
+++ b/src/bin/caller/mcp/state.rs
@@ -58,6 +58,13 @@ pub struct McpAppState {
     /// Test override for the home that anchors persisted-session lookup
     /// (path-form session ids must resolve inside `<home>/.intendant/logs`).
     pub(crate) session_logs_home_override: Option<std::path::PathBuf>,
+    /// Short-TTL cache of the raw (state-independent) controller-loop
+    /// collection — the `ps` spawn + run-dir/wrapper-index scan half of
+    /// [`collect_controller_loop_status_inner`]. Interior mutability so the
+    /// polled read paths (which only hold `&McpAppState`) can serve and
+    /// re-seed it; see [`CONTROLLER_LOOP_RAW_STATUS_TTL`].
+    controller_loop_raw_status_cache:
+        std::sync::Mutex<Option<(std::time::Instant, ControllerLoopRawStatus)>>,
     /// Optional launcher for starting tasks via MCP. Set by main.rs.
     pub launcher: Option<Arc<TaskLauncher>>,
     /// Handle to the currently running agent loop, if any.
@@ -209,6 +216,7 @@ impl McpAppState {
             controller_loop_dir_override: None,
             controller_loop_status_override: None,
             session_logs_home_override: None,
+            controller_loop_raw_status_cache: std::sync::Mutex::new(None),
             launcher: None,
             task_handle: None,
             controller_restart: None,
@@ -248,6 +256,41 @@ impl McpAppState {
             self.phase = phase;
             self.phase_entered_at = std::time::Instant::now();
         }
+    }
+
+    /// A still-fresh raw controller-loop sample for `loop_dir`, if one is
+    /// cached. A stale entry or one collected for a different loop dir
+    /// (dir overrides in tests) misses.
+    pub(crate) fn cached_controller_loop_raw_status(
+        &self,
+        loop_dir: &std::path::Path,
+    ) -> Option<ControllerLoopRawStatus> {
+        let cache = self
+            .controller_loop_raw_status_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let (collected_at, raw) = cache.as_ref()?;
+        (collected_at.elapsed() < CONTROLLER_LOOP_RAW_STATUS_TTL && raw.loop_dir() == loop_dir)
+            .then(|| raw.clone())
+    }
+
+    pub(crate) fn store_controller_loop_raw_status(&self, raw: ControllerLoopRawStatus) {
+        let mut cache = self
+            .controller_loop_raw_status_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        *cache = Some((std::time::Instant::now(), raw));
+    }
+
+    /// Drop the cached raw controller-loop sample. Marker-mutating paths
+    /// (halt/intervene/clear) call this so a status poll right after the
+    /// mutation observes the new flags instead of a sub-TTL stale sample.
+    pub(crate) fn invalidate_controller_loop_raw_status_cache(&self) {
+        let mut cache = self
+            .controller_loop_raw_status_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        *cache = None;
     }
 
     pub(crate) fn push_log(&mut self, level: LogLevel, content: String) {

--- a/src/bin/caller/mcp/state.rs
+++ b/src/bin/caller/mcp/state.rs
@@ -83,13 +83,21 @@ pub struct McpAppState {
     /// (the rebuild the query is performing would erase itself and record
     /// an EOF cursor against absent state).
     pub(crate) hydration_replay: Option<HydrationReplayKind>,
-    /// Session ids whose status was written by a LIVE observation (event
-    /// listener fold, promote) rather than log replay. A full hydration
-    /// replay re-applies the entire history, and the log's final phase can
-    /// lag the live-observed one (flush skew) — sessions marked here keep
-    /// their live status through full replays. Appended-tail replays still
-    /// apply: those lines are new information by construction.
-    pub(crate) session_status_live_marks: std::collections::HashSet<String>,
+    /// Last phase written by a LIVE observation (event listener fold,
+    /// promote) per session id — the hydration freshness watermark. The two
+    /// lanes have different loss properties: the live lane is a lossy
+    /// broadcast (a lagged listener drops events) while the persisted log
+    /// is lossless, so neither lane strictly dominates. A FULL hydration
+    /// replay therefore applies against the phase lattice (see
+    /// [`McpAppState::note_session_phase`]): replayed TERMINAL facts always
+    /// apply (the lossless log proving a session ended outranks a stale
+    /// live mark from a dropped `SessionEnded`), replayed NON-terminal
+    /// phases never overwrite a live-marked session (replaying history must
+    /// not regress a completed or newer live phase; transient non-terminal
+    /// skew self-heals through the live lane or the next terminal fact).
+    /// Appended-tail replays bypass the lattice: those lines are new
+    /// information by construction.
+    pub(crate) session_status_live_phases: std::collections::HashMap<String, Phase>,
     /// Optional launcher for starting tasks via MCP. Set by main.rs.
     pub launcher: Option<Arc<TaskLauncher>>,
     /// Handle to the currently running agent loop, if any.
@@ -226,6 +234,36 @@ pub(crate) enum HydrationReplayKind {
     Tail,
 }
 
+/// Terminal phases in the session-status lattice: a session that reached
+/// one of these has ended. A replayed terminal fact comes from the lossless
+/// log lane and therefore outranks any live-observed mark (the live lane is
+/// a lossy broadcast); a replayed NON-terminal phase never overwrites a
+/// live-marked session.
+pub(crate) fn phase_is_session_terminal(phase: &Phase) -> bool {
+    matches!(phase, Phase::Done | Phase::Interrupted)
+}
+
+/// RAII scope for [`McpAppState::hydration_replay`]: constructed via
+/// [`McpAppState::begin_hydration_replay`], resets the flag on drop so a
+/// panic (or early return) inside a replay can never leave the state
+/// permanently in "hydrating" mode — which would suppress live lifecycle
+/// invalidations and misgate future status writes.
+pub(crate) struct HydrationReplayGuard<'a> {
+    state: &'a mut McpAppState,
+}
+
+impl HydrationReplayGuard<'_> {
+    pub(crate) fn state(&mut self) -> &mut McpAppState {
+        self.state
+    }
+}
+
+impl Drop for HydrationReplayGuard<'_> {
+    fn drop(&mut self) {
+        self.state.hydration_replay = None;
+    }
+}
+
 /// Cache slot for the raw controller-loop sample, with the invalidation
 /// generation. See the field doc on
 /// [`McpAppState::controller_loop_raw_status_cache`].
@@ -283,7 +321,7 @@ impl McpAppState {
             ),
             session_log_hydration_cursors: std::collections::HashMap::new(),
             hydration_replay: None,
-            session_status_live_marks: std::collections::HashSet::new(),
+            session_status_live_phases: std::collections::HashMap::new(),
             launcher: None,
             task_handle: None,
             controller_restart: None,
@@ -364,6 +402,17 @@ impl McpAppState {
         if cache.generation == generation {
             cache.entry = Some((std::time::Instant::now(), raw));
         }
+    }
+
+    /// Enter a hydration-replay scope. The returned guard resets
+    /// [`Self::hydration_replay`] on drop (panic-safe); mutate the state
+    /// through [`HydrationReplayGuard::state`] for the replay's duration.
+    pub(crate) fn begin_hydration_replay(
+        &mut self,
+        kind: HydrationReplayKind,
+    ) -> HydrationReplayGuard<'_> {
+        self.hydration_replay = Some(kind);
+        HydrationReplayGuard { state: self }
     }
 
     /// Invalidate the raw controller-loop cache for a LIVE-observed session
@@ -696,7 +745,7 @@ impl McpAppState {
             self.session_sources.remove(id);
             self.session_codex_managed_context.remove(id);
             self.session_known_non_external.remove(id);
-            self.session_status_live_marks.remove(id);
+            self.session_status_live_phases.remove(id);
             self.session_aliases.remove(id);
         }
         // Drop ONLY the ended component's hydration cursors (log-dir
@@ -786,23 +835,29 @@ impl McpAppState {
                 related
             }
         };
-        // Freshness watermark: a FULL log replay re-applies history, and the
-        // log's final phase can lag what this state already observed live —
-        // never let it overwrite a live-marked session. Tail replays and
-        // live observations pass through; live observations set the mark.
+        // Freshness watermark (see `session_status_live_phases`): a FULL
+        // log replay re-applies history against a live-marked session using
+        // the phase lattice — a replayed TERMINAL fact always applies (the
+        // lossless log outranks a lossy live mark whose `SessionEnded` may
+        // have been dropped), a replayed NON-terminal phase never overwrites
+        // a live mark (flush skew: the log's mid-history phases are older
+        // than the live observation; terminal→non-terminal regressions are
+        // the classic full-replay bug). Tail replays and live observations
+        // pass through; live observations record the watermark.
         match self.hydration_replay {
             Some(HydrationReplayKind::Full) => {
-                if keys
+                let live_marked = keys
                     .iter()
-                    .any(|key| self.session_status_live_marks.contains(key))
-                {
+                    .any(|key| self.session_status_live_phases.contains_key(key));
+                if live_marked && !phase_is_session_terminal(&phase) {
                     return;
                 }
             }
             Some(HydrationReplayKind::Tail) => {}
             None => {
                 for key in &keys {
-                    self.session_status_live_marks.insert(key.clone());
+                    self.session_status_live_phases
+                        .insert(key.clone(), phase.clone());
                 }
             }
         }
@@ -872,10 +927,12 @@ impl McpAppState {
         };
         // Same full-replay watermark as note_session_phase: rounds ride the
         // status entry, so a full replay must not regress a live-marked one.
+        // (Rounds carry no terminal lattice of their own — the terminal
+        // facts that may advance over a mark arrive via note_session_phase.)
         if self.hydration_replay == Some(HydrationReplayKind::Full)
             && keys
                 .iter()
-                .any(|key| self.session_status_live_marks.contains(key))
+                .any(|key| self.session_status_live_phases.contains_key(key))
         {
             return;
         }
@@ -1874,8 +1931,8 @@ mod tests {
         // every unrelated session end.
         assert!(!s.session_log_hydration_cursors.contains_key(&ended_path));
         assert!(s.session_log_hydration_cursors.contains_key(&live_path));
-        assert!(!s.session_status_live_marks.contains("sess-ended"));
-        assert!(!s.session_status_live_marks.contains("backend-ended"));
+        assert!(!s.session_status_live_phases.contains_key("sess-ended"));
+        assert!(!s.session_status_live_phases.contains_key("backend-ended"));
     }
 
     #[test]
@@ -1890,7 +1947,7 @@ mod tests {
         let (hit, generation) = s.probe_controller_loop_raw_status(loop_dir.path());
         assert!(hit.is_none());
 
-        let raw = collect_controller_loop_raw_status(loop_dir.path());
+        let raw = collect_controller_loop_raw_status(loop_dir.path(), loop_dir.path());
         s.store_controller_loop_raw_status_at(generation, raw.clone());
         assert!(s
             .probe_controller_loop_raw_status(loop_dir.path())

--- a/src/bin/caller/mcp/state.rs
+++ b/src/bin/caller/mcp/state.rs
@@ -62,9 +62,11 @@ pub struct McpAppState {
     /// collection — the `ps` spawn + run-dir/wrapper-index scan half of
     /// [`collect_controller_loop_status_inner`]. Interior mutability so the
     /// polled read paths (which only hold `&McpAppState`) can serve and
-    /// re-seed it; see [`CONTROLLER_LOOP_RAW_STATUS_TTL`].
-    controller_loop_raw_status_cache:
-        std::sync::Mutex<Option<(std::time::Instant, ControllerLoopRawStatus)>>,
+    /// re-seed it; see [`CONTROLLER_LOOP_RAW_STATUS_TTL`]. Guarded by a
+    /// generation counter: invalidation bumps it, and a collection started
+    /// before the bump refuses to store — otherwise a lock-free pre-warm
+    /// racing a lifecycle mutation could reinstate a pre-mutation sample.
+    controller_loop_raw_status_cache: std::sync::Mutex<ControllerLoopRawStatusCache>,
     /// Per-`session.jsonl` replay cursors for
     /// [`hydrate_requested_session_status_from_logs`]: session-scoped
     /// `get_status` used to re-read and re-fold the whole log on every call;
@@ -73,6 +75,21 @@ pub struct McpAppState {
     /// with one full replay.
     pub(crate) session_log_hydration_cursors:
         std::collections::HashMap<std::path::PathBuf, SessionJsonlCursor>,
+    /// Set while [`hydrate_requested_session_status_from_logs`] folds a log
+    /// into this state, naming the replay kind. It gates two hazards: a
+    /// FULL replay must not overwrite a live-observed session status with
+    /// older log-derived state (see `session_status_live_marks`), and a
+    /// replayed `session_ended` line must not re-run the over-cap prune
+    /// (the rebuild the query is performing would erase itself and record
+    /// an EOF cursor against absent state).
+    pub(crate) hydration_replay: Option<HydrationReplayKind>,
+    /// Session ids whose status was written by a LIVE observation (event
+    /// listener fold, promote) rather than log replay. A full hydration
+    /// replay re-applies the entire history, and the log's final phase can
+    /// lag the live-observed one (flush skew) — sessions marked here keep
+    /// their live status through full replays. Appended-tail replays still
+    /// apply: those lines are new information by construction.
+    pub(crate) session_status_live_marks: std::collections::HashSet<String>,
     /// Optional launcher for starting tasks via MCP. Set by main.rs.
     pub launcher: Option<Arc<TaskLauncher>>,
     /// Handle to the currently running agent loop, if any.
@@ -195,7 +212,28 @@ pub(crate) struct DensityMaintenanceSatisfaction {
 /// id and alias ever observed used to accumulate for the daemon's lifetime;
 /// once the status map outgrows this, ended sessions are pruned on
 /// [`McpAppState::note_session_ended`] instead of lingering.
-const ENDED_SESSION_PRUNE_THRESHOLD: usize = 1024;
+pub(crate) const ENDED_SESSION_PRUNE_THRESHOLD: usize = 1024;
+
+/// Which kind of log replay a hydration pass is performing. See
+/// [`McpAppState::hydration_replay`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HydrationReplayKind {
+    /// Replaying from byte 0 — re-applies history that live observation may
+    /// already have superseded.
+    Full,
+    /// Replaying only bytes appended past a validated cursor — new
+    /// information by construction.
+    Tail,
+}
+
+/// Cache slot for the raw controller-loop sample, with the invalidation
+/// generation. See the field doc on
+/// [`McpAppState::controller_loop_raw_status_cache`].
+#[derive(Default)]
+pub(crate) struct ControllerLoopRawStatusCache {
+    generation: u64,
+    entry: Option<(std::time::Instant, ControllerLoopRawStatus)>,
+}
 
 /// Tracks a pending approval info (responder is in the shared ApprovalRegistry).
 pub struct PendingApprovalState {
@@ -240,8 +278,12 @@ impl McpAppState {
             controller_loop_dir_override: None,
             controller_loop_status_override: None,
             session_logs_home_override: None,
-            controller_loop_raw_status_cache: std::sync::Mutex::new(None),
+            controller_loop_raw_status_cache: std::sync::Mutex::new(
+                ControllerLoopRawStatusCache::default(),
+            ),
             session_log_hydration_cursors: std::collections::HashMap::new(),
+            hydration_replay: None,
+            session_status_live_marks: std::collections::HashSet::new(),
             launcher: None,
             task_handle: None,
             controller_restart: None,
@@ -285,39 +327,70 @@ impl McpAppState {
         }
     }
 
-    /// A still-fresh raw controller-loop sample for `loop_dir`, if one is
-    /// cached. A stale entry or one collected for a different loop dir
-    /// (dir overrides in tests) misses.
-    pub(crate) fn cached_controller_loop_raw_status(
+    /// Probe the raw controller-loop cache: a still-fresh sample for
+    /// `loop_dir` (a stale entry or one collected for a different loop dir
+    /// misses) plus the current invalidation generation. Callers that miss
+    /// collect WITHOUT any lock held, then store through
+    /// [`Self::store_controller_loop_raw_status_at`] with this generation —
+    /// if a lifecycle mutation invalidated meanwhile, the pre-mutation
+    /// sample is discarded instead of reinstated.
+    pub(crate) fn probe_controller_loop_raw_status(
         &self,
         loop_dir: &std::path::Path,
-    ) -> Option<ControllerLoopRawStatus> {
+    ) -> (Option<ControllerLoopRawStatus>, u64) {
         let cache = self
             .controller_loop_raw_status_cache
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        let (collected_at, raw) = cache.as_ref()?;
-        (collected_at.elapsed() < CONTROLLER_LOOP_RAW_STATUS_TTL && raw.loop_dir() == loop_dir)
-            .then(|| raw.clone())
+        let hit = cache.entry.as_ref().and_then(|(collected_at, raw)| {
+            (collected_at.elapsed() < CONTROLLER_LOOP_RAW_STATUS_TTL && raw.loop_dir() == loop_dir)
+                .then(|| raw.clone())
+        });
+        (hit, cache.generation)
     }
 
-    pub(crate) fn store_controller_loop_raw_status(&self, raw: ControllerLoopRawStatus) {
+    /// Store a raw sample collected while the cache was at `generation`.
+    /// A no-op when the generation has moved (an invalidation raced the
+    /// collection): the sample predates the mutation that bumped it.
+    pub(crate) fn store_controller_loop_raw_status_at(
+        &self,
+        generation: u64,
+        raw: ControllerLoopRawStatus,
+    ) {
         let mut cache = self
             .controller_loop_raw_status_cache
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        *cache = Some((std::time::Instant::now(), raw));
+        if cache.generation == generation {
+            cache.entry = Some((std::time::Instant::now(), raw));
+        }
     }
 
-    /// Drop the cached raw controller-loop sample. Marker-mutating paths
-    /// (halt/intervene/clear) call this so a status poll right after the
-    /// mutation observes the new flags instead of a sub-TTL stale sample.
+    /// Invalidate the raw controller-loop cache for a LIVE-observed session
+    /// lifecycle transition (task dispatch, session start/end, completion,
+    /// interruption): process reality just changed, so a pre-transition
+    /// sample must not answer the next poll. Hydration replays of historic
+    /// logs pass through the same fold arms and are ignored here — they do
+    /// not change process reality.
+    pub(crate) fn note_live_session_lifecycle_change(&self) {
+        if self.hydration_replay.is_none() {
+            self.invalidate_controller_loop_raw_status_cache();
+        }
+    }
+
+    /// Drop the cached raw controller-loop sample and bump the generation.
+    /// Called wherever process/marker reality changes — loop-marker tools
+    /// (halt/intervene/clear), task dispatch, and observed session
+    /// lifecycle transitions — so a status poll right after the mutation
+    /// re-collects instead of serving a sub-TTL stale sample, and so an
+    /// in-flight unlocked collection cannot reinstate one.
     pub(crate) fn invalidate_controller_loop_raw_status_cache(&self) {
         let mut cache = self
             .controller_loop_raw_status_cache
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        *cache = None;
+        cache.generation = cache.generation.wrapping_add(1);
+        cache.entry = None;
     }
 
     pub(crate) fn push_log(&mut self, level: LogLevel, content: String) {
@@ -591,7 +664,19 @@ impl McpAppState {
         self.remove_pending_rewind_pressure_check_for_key(session_id);
         self.remove_insufficient_rewind_notice_for_key(session_id);
         self.remove_density_maintenance_satisfied_for_key(session_id);
-        if self.session_status.len() > ENDED_SESSION_PRUNE_THRESHOLD {
+        // A session ending changes process reality: a cached raw
+        // controller-loop sample from before the exit must not answer the
+        // next status poll. (No-op during hydration replays.)
+        self.note_live_session_lifecycle_change();
+        // Never prune from a hydration replay: the replayed `session_ended`
+        // line belongs to the very session a query is rebuilding — pruning
+        // here would erase the rebuild and leave an EOF cursor pointing at
+        // absent state, so a later query would answer with the daemon's
+        // current (unrelated) status under the requested id. Query-driven
+        // rebuilds stay resident instead.
+        if self.hydration_replay.is_none()
+            && self.session_status.len() > ENDED_SESSION_PRUNE_THRESHOLD
+        {
             self.prune_ended_session_bookkeeping(session_id);
         }
     }
@@ -611,14 +696,30 @@ impl McpAppState {
             self.session_sources.remove(id);
             self.session_codex_managed_context.remove(id);
             self.session_known_non_external.remove(id);
+            self.session_status_live_marks.remove(id);
             self.session_aliases.remove(id);
         }
-        // Hydration cursors are keyed by log dir, not session id, and a
-        // pruned session's next hydration must be a full replay (its folded
-        // state is gone). Dropping them all is safe — every cursor
-        // self-heals with one full pass — and this branch is rare by
-        // construction.
-        self.session_log_hydration_cursors.clear();
+        // Drop ONLY the ended component's hydration cursors (log-dir
+        // basenames carry the session id, with the store's prefix-match
+        // semantics), so live sessions keep theirs — on a long-lived daemon
+        // permanently over the cap, wiping every cursor on every session
+        // end would re-trigger the full-replay-under-write-lock cost this
+        // module exists to avoid. A cursor a rename/meta mismatch leaves
+        // behind is caught by hydration's pruned-state backstop, which
+        // forces a full replay whenever the requested session has no folded
+        // status.
+        self.session_log_hydration_cursors.retain(|path, _| {
+            let Some(dir_name) = path
+                .parent()
+                .and_then(|dir| dir.file_name())
+                .and_then(|name| name.to_str())
+            else {
+                return false;
+            };
+            !ids.iter().any(|id| {
+                !id.is_empty() && (dir_name == id.as_str() || dir_name.starts_with(id.as_str()))
+            })
+        });
     }
 
     pub(crate) fn session_id_applies_to_current_session(&self, session_id: Option<&str>) -> bool {
@@ -685,6 +786,26 @@ impl McpAppState {
                 related
             }
         };
+        // Freshness watermark: a FULL log replay re-applies history, and the
+        // log's final phase can lag what this state already observed live —
+        // never let it overwrite a live-marked session. Tail replays and
+        // live observations pass through; live observations set the mark.
+        match self.hydration_replay {
+            Some(HydrationReplayKind::Full) => {
+                if keys
+                    .iter()
+                    .any(|key| self.session_status_live_marks.contains(key))
+                {
+                    return;
+                }
+            }
+            Some(HydrationReplayKind::Tail) => {}
+            None => {
+                for key in &keys {
+                    self.session_status_live_marks.insert(key.clone());
+                }
+            }
+        }
         let existing = keys
             .iter()
             .find_map(|key| self.session_status.get(key))
@@ -749,6 +870,15 @@ impl McpAppState {
                 related
             }
         };
+        // Same full-replay watermark as note_session_phase: rounds ride the
+        // status entry, so a full replay must not regress a live-marked one.
+        if self.hydration_replay == Some(HydrationReplayKind::Full)
+            && keys
+                .iter()
+                .any(|key| self.session_status_live_marks.contains(key))
+        {
+            return;
+        }
         for key in &keys {
             let entry =
                 self.session_status
@@ -1709,6 +1839,76 @@ mod tests {
             assert_eq!(snap.id, 42);
             assert_eq!(snap.category, "destructive");
         });
+    }
+
+    #[test]
+    fn over_cap_prune_drops_only_the_ended_components_cursors() {
+        let mut s = McpAppState::new(
+            "none".to_string(),
+            "none".to_string(),
+            autonomy::shared_autonomy(AutonomyState::default()),
+            std::path::PathBuf::from("/tmp/test_session"),
+        );
+        let cursor = SessionJsonlCursor {
+            lines: 2,
+            bytes: 64,
+            prefix_len: 32,
+            prefix_hash: 7,
+        };
+        let ended_path = std::path::PathBuf::from("/tmp/logs/sess-ended/session.jsonl");
+        let live_path = std::path::PathBuf::from("/tmp/logs/sess-live/session.jsonl");
+        s.session_log_hydration_cursors
+            .insert(ended_path.clone(), cursor);
+        s.session_log_hydration_cursors
+            .insert(live_path.clone(), cursor);
+        s.link_session_aliases("sess-ended", "backend-ended");
+
+        for i in 0..=ENDED_SESSION_PRUNE_THRESHOLD {
+            s.note_session_phase(Some(&format!("filler-{i}")), Some(1), Phase::Thinking, None);
+        }
+        s.note_session_phase(Some("sess-ended"), Some(2), Phase::Thinking, None);
+        s.note_session_ended("sess-ended");
+
+        // Only the ended component's cursor is dropped; a long-lived daemon
+        // permanently over the cap must not wipe live sessions' cursors on
+        // every unrelated session end.
+        assert!(!s.session_log_hydration_cursors.contains_key(&ended_path));
+        assert!(s.session_log_hydration_cursors.contains_key(&live_path));
+        assert!(!s.session_status_live_marks.contains("sess-ended"));
+        assert!(!s.session_status_live_marks.contains("backend-ended"));
+    }
+
+    #[test]
+    fn raw_status_cache_store_respects_invalidation_generation() {
+        let s = McpAppState::new(
+            "none".to_string(),
+            "none".to_string(),
+            autonomy::shared_autonomy(AutonomyState::default()),
+            std::path::PathBuf::from("/tmp/test_session"),
+        );
+        let loop_dir = tempfile::tempdir().unwrap();
+        let (hit, generation) = s.probe_controller_loop_raw_status(loop_dir.path());
+        assert!(hit.is_none());
+
+        let raw = collect_controller_loop_raw_status(loop_dir.path());
+        s.store_controller_loop_raw_status_at(generation, raw.clone());
+        assert!(s
+            .probe_controller_loop_raw_status(loop_dir.path())
+            .0
+            .is_some());
+
+        // Invalidation bumps the generation; a sample collected before the
+        // bump (a lock-free pre-warm racing a lifecycle mutation) must not
+        // be reinstated.
+        s.invalidate_controller_loop_raw_status_cache();
+        let (hit, new_generation) = s.probe_controller_loop_raw_status(loop_dir.path());
+        assert!(hit.is_none());
+        assert_ne!(generation, new_generation);
+        s.store_controller_loop_raw_status_at(generation, raw);
+        assert!(s
+            .probe_controller_loop_raw_status(loop_dir.path())
+            .0
+            .is_none());
     }
 
     #[test]

--- a/src/bin/caller/mcp/tool_gate.rs
+++ b/src/bin/caller/mcp/tool_gate.rs
@@ -311,19 +311,44 @@ macro_rules! manual_http_tool_definition {
     }};
 }
 
+/// Every manual HTTP tool definition, unfiltered, built once per process:
+/// each `tools/list` used to re-run `schemars::schema_for!` + ref inlining
+/// and re-allocate the multi-KB description literals for all ~20 manual
+/// tools. Profile/managed-context gating is name-keyed, so filtering the
+/// prebuilt list per request (see [`append_manual_http_tool_definitions`])
+/// yields exactly the historical output.
+fn manual_http_tool_definitions() -> &'static [serde_json::Value] {
+    static DEFINITIONS: std::sync::OnceLock<Vec<serde_json::Value>> = std::sync::OnceLock::new();
+    DEFINITIONS.get_or_init(build_manual_http_tool_definitions)
+}
+
 pub(crate) fn append_manual_http_tool_definitions(
     tools: &mut Vec<serde_json::Value>,
     managed_context: bool,
     tool_profile: Option<&str>,
 ) {
-    let mut push = |name: &'static str, definition: serde_json::Value| {
+    for definition in manual_http_tool_definitions() {
+        let Some(name) = definition.get("name").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
         if tool_allowed_for_profile(name, managed_context, tool_profile)
             && !tools
                 .iter()
                 .any(|tool| tool.get("name").and_then(serde_json::Value::as_str) == Some(name))
         {
-            tools.push(definition);
+            tools.push(definition.clone());
         }
+    }
+}
+
+fn build_manual_http_tool_definitions() -> Vec<serde_json::Value> {
+    let mut tools = Vec::new();
+    let mut push = |name: &'static str, definition: serde_json::Value| {
+        debug_assert_eq!(
+            definition.get("name").and_then(serde_json::Value::as_str),
+            Some(name)
+        );
+        tools.push(definition);
     };
 
     push(
@@ -566,6 +591,7 @@ pub(crate) fn append_manual_http_tool_definitions(
             PeerExecuteCuActionsParams
         ),
     );
+    tools
 }
 
 #[cfg(test)]

--- a/src/bin/caller/mcp/tool_params.rs
+++ b/src/bin/caller/mcp/tool_params.rs
@@ -884,7 +884,12 @@ fn session_jsonl_prefix_hash(bytes: &[u8]) -> u64 {
 /// `min(consumed, SESSION_JSONL_PREFIX_WINDOW)` bytes when it is first
 /// established from a full read. Append-only writers never rewrite that
 /// window, so the frozen hash stays comparable as the cursor advances;
-/// a mismatch on resume forces a full replay.
+/// a mismatch on resume forces a full replay. The claim is exactly the
+/// window: a same-or-longer-length rewrite that preserves the frozen
+/// window (and the boundary byte) but diverges only beyond it is NOT
+/// detected — acceptable because the in-repo writer is append-only, so
+/// any real replacement (a different session's log) diverges from its
+/// first line.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct SessionJsonlCursor {
     pub(crate) lines: u64,

--- a/src/bin/caller/mcp/tool_params.rs
+++ b/src/bin/caller/mcp/tool_params.rs
@@ -1185,13 +1185,14 @@ mod tests {
     fn cursor_paginated_get_logs_serves_appended_tail_with_stable_ids() {
         let dir = tempdir().unwrap();
         let log_path = dir.path().join("session.jsonl");
-        std::fs::write(&log_path, format!("{}\n{}\n", info_line("a"), info_line("b"))).unwrap();
-
-        let first = read_persisted_log_entries_from_dir(
-            dir.path(),
-            &get_logs_params(None, None),
+        std::fs::write(
+            &log_path,
+            format!("{}\n{}\n", info_line("a"), info_line("b")),
         )
         .unwrap();
+
+        let first =
+            read_persisted_log_entries_from_dir(dir.path(), &get_logs_params(None, None)).unwrap();
         assert_eq!(first.len(), 2);
         assert_eq!(first[1].id, 1);
 
@@ -1222,7 +1223,11 @@ mod tests {
     fn replaced_log_file_invalidates_the_read_cursor() {
         let dir = tempdir().unwrap();
         let log_path = dir.path().join("session.jsonl");
-        std::fs::write(&log_path, format!("{}\n{}\n", info_line("a"), info_line("b"))).unwrap();
+        std::fs::write(
+            &log_path,
+            format!("{}\n{}\n", info_line("a"), info_line("b")),
+        )
+        .unwrap();
 
         // Seed the cursor with a full pass.
         let seeded =
@@ -1280,11 +1285,8 @@ mod tests {
         write!(appended, "\n{}\n", info_line("next")).unwrap();
         drop(appended);
 
-        let tail = read_persisted_log_entries_from_dir(
-            dir.path(),
-            &get_logs_params(Some(0), None),
-        )
-        .unwrap();
+        let tail = read_persisted_log_entries_from_dir(dir.path(), &get_logs_params(Some(0), None))
+            .unwrap();
         assert_eq!(
             tail.iter()
                 .map(|entry| (entry.id, entry.content.clone()))

--- a/src/bin/caller/mcp/tool_params.rs
+++ b/src/bin/caller/mcp/tool_params.rs
@@ -858,23 +858,48 @@ pub(crate) fn read_persisted_log_entries_for_session(
     read_persisted_log_entries_from_dir(&log_dir, params)
 }
 
+/// Bytes covered by a cursor's frozen prefix-identity window (mirrors the
+/// message-search `SourceCursor` discipline, `PREFIX_HASH_BYTES`).
+const SESSION_JSONL_PREFIX_WINDOW: usize = 4096;
+
+/// First-8-bytes-of-SHA-256 as a number — the same fingerprint shape as
+/// message-search's `prefix_hash16` / `session_log::content_hash_hex16`,
+/// kept numeric because these cursors live in memory only.
+fn session_jsonl_prefix_hash(bytes: &[u8]) -> u64 {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(bytes);
+    u64::from_be_bytes(digest[..8].try_into().unwrap_or([0u8; 8]))
+}
+
 /// Byte/line cursor into an append-only `session.jsonl`.
 ///
 /// `lines` counts the newline-terminated lines fully consumed from the start
 /// of the file and `bytes` is the offset just past the last consumed
 /// terminator, so a later pass can resume at a stable line id without
 /// re-reading (or re-parsing) the whole log.
+///
+/// Identity: length + a newline at the boundary cannot detect a
+/// same-or-longer-length replacement (log rotation, dir reuse), so the
+/// cursor also freezes a hash over the file's first
+/// `min(consumed, SESSION_JSONL_PREFIX_WINDOW)` bytes when it is first
+/// established from a full read. Append-only writers never rewrite that
+/// window, so the frozen hash stays comparable as the cursor advances;
+/// a mismatch on resume forces a full replay.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) struct SessionJsonlCursor {
     pub(crate) lines: u64,
     pub(crate) bytes: u64,
+    pub(crate) prefix_len: u32,
+    pub(crate) prefix_hash: u64,
 }
 
 /// Read `path` from `cursor` when the cursor still describes a valid prefix
-/// of the (append-only) file: the offset must sit inside the file and land
-/// just past a `\n`. Any mismatch — a truncated or replaced file — falls back
-/// to a full read from byte 0 so callers self-heal with one full pass.
-/// Returns the unread tail plus the validated base cursor it starts at.
+/// of the (append-only) file: the offset must sit inside the file, the
+/// frozen prefix-identity window must hash to the same value, and the byte
+/// before the offset must be a `\n`. Any mismatch — a truncated, replaced,
+/// or rotated file — falls back to a full read from byte 0 so callers
+/// self-heal with one full pass. Returns the unread tail plus the validated
+/// base cursor it starts at.
 pub(crate) fn read_session_jsonl_tail(
     path: &std::path::Path,
     cursor: Option<SessionJsonlCursor>,
@@ -882,11 +907,21 @@ pub(crate) fn read_session_jsonl_tail(
     use std::io::{Read, Seek, SeekFrom};
     let mut file = std::fs::File::open(path).ok()?;
     let mut base = cursor.unwrap_or_default();
+    // A consumed prefix always has an identity window (frozen at first
+    // capture); a cursor without one is not trustworthy.
     let mut valid = base.bytes > 0
+        && base.prefix_len > 0
+        && u64::from(base.prefix_len) <= base.bytes
         && file
             .metadata()
             .map(|meta| meta.len() >= base.bytes)
             .unwrap_or(false);
+    if valid {
+        let mut window = vec![0u8; base.prefix_len as usize];
+        valid = file.seek(SeekFrom::Start(0)).is_ok()
+            && file.read_exact(&mut window).is_ok()
+            && session_jsonl_prefix_hash(&window) == base.prefix_hash;
+    }
     if valid {
         let mut byte = [0u8; 1];
         valid = file.seek(SeekFrom::Start(base.bytes - 1)).is_ok()
@@ -929,16 +964,23 @@ pub(crate) fn walk_session_jsonl_tail(
             line = stripped;
         }
         if !visit(line_id, line) {
-            return cursor;
+            break;
         }
         line_id += 1;
         if terminated {
-            cursor = SessionJsonlCursor {
-                lines: line_id,
-                bytes: base.bytes + next_start as u64,
-            };
+            cursor.lines = line_id;
+            cursor.bytes = base.bytes + next_start as u64;
         }
         line_start = next_start;
+    }
+    // First establishment (base at byte 0): freeze the prefix-identity
+    // window over the consumed head bytes. Tail walks (base.bytes > 0)
+    // carry the frozen identity forward untouched — the window bytes are
+    // immutable under an append-only writer.
+    if base.bytes == 0 && cursor.bytes > 0 {
+        let window = &bytes[..(cursor.bytes as usize).min(SESSION_JSONL_PREFIX_WINDOW)];
+        cursor.prefix_len = window.len() as u32;
+        cursor.prefix_hash = session_jsonl_prefix_hash(window);
     }
     cursor
 }
@@ -1292,6 +1334,53 @@ mod tests {
                 .map(|entry| (entry.id, entry.content.clone()))
                 .collect::<Vec<_>>(),
             vec![(1, "partial".to_string()), (2, "next".to_string())]
+        );
+    }
+
+    #[test]
+    fn same_length_replacement_is_detected_by_the_prefix_identity_window() {
+        let dir = tempdir().unwrap();
+        let log_path = dir.path().join("session.jsonl");
+
+        // Replacement: four short lines.
+        let replacement_lines: Vec<String> = ["r0", "r1", "r2", "r3"]
+            .iter()
+            .map(|msg| info_line(msg))
+            .collect();
+        let replacement = replacement_lines.join("\n") + "\n";
+
+        // Original: two lines padded to EXACTLY the replacement's byte
+        // length, so metadata length and the newline at the cursor
+        // boundary both still match after the swap.
+        let first = info_line("orig-0");
+        let overhead = info_line("").len();
+        let second_message_len = replacement.len() - (first.len() + 1) - 1 - overhead;
+        let second = info_line(&"p".repeat(second_message_len));
+        let original = format!("{first}\n{second}\n");
+        assert_eq!(original.len(), replacement.len());
+        std::fs::write(&log_path, &original).unwrap();
+
+        // Seed the cursor with a full pass (2 lines consumed).
+        let seeded =
+            read_persisted_log_entries_from_dir(dir.path(), &get_logs_params(None, None)).unwrap();
+        assert_eq!(seeded.len(), 2);
+
+        // Rotate: same total length, same trailing newline — only the
+        // frozen prefix hash can tell the file was replaced. A resumed
+        // cursor would report "nothing new"; the heal is a full replay
+        // that serves the replacement's lines past since_id.
+        std::fs::write(&log_path, &replacement).unwrap();
+        let healed = read_persisted_log_entries_from_dir(
+            dir.path(),
+            &get_logs_params(Some(seeded[1].id), None),
+        )
+        .unwrap();
+        assert_eq!(
+            healed
+                .iter()
+                .map(|entry| (entry.id, entry.content.clone()))
+                .collect::<Vec<_>>(),
+            vec![(2, "r2".to_string()), (3, "r3".to_string())]
         );
     }
 

--- a/src/bin/caller/mcp/tool_params.rs
+++ b/src/bin/caller/mcp/tool_params.rs
@@ -858,28 +858,155 @@ pub(crate) fn read_persisted_log_entries_for_session(
     read_persisted_log_entries_from_dir(&log_dir, params)
 }
 
+/// Byte/line cursor into an append-only `session.jsonl`.
+///
+/// `lines` counts the newline-terminated lines fully consumed from the start
+/// of the file and `bytes` is the offset just past the last consumed
+/// terminator, so a later pass can resume at a stable line id without
+/// re-reading (or re-parsing) the whole log.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct SessionJsonlCursor {
+    pub(crate) lines: u64,
+    pub(crate) bytes: u64,
+}
+
+/// Read `path` from `cursor` when the cursor still describes a valid prefix
+/// of the (append-only) file: the offset must sit inside the file and land
+/// just past a `\n`. Any mismatch — a truncated or replaced file — falls back
+/// to a full read from byte 0 so callers self-heal with one full pass.
+/// Returns the unread tail plus the validated base cursor it starts at.
+pub(crate) fn read_session_jsonl_tail(
+    path: &std::path::Path,
+    cursor: Option<SessionJsonlCursor>,
+) -> Option<(String, SessionJsonlCursor)> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut base = cursor.unwrap_or_default();
+    let mut valid = base.bytes > 0
+        && file
+            .metadata()
+            .map(|meta| meta.len() >= base.bytes)
+            .unwrap_or(false);
+    if valid {
+        let mut byte = [0u8; 1];
+        valid = file.seek(SeekFrom::Start(base.bytes - 1)).is_ok()
+            && file.read_exact(&mut byte).is_ok()
+            && byte[0] == b'\n';
+    }
+    if !valid {
+        base = SessionJsonlCursor::default();
+        file.seek(SeekFrom::Start(0)).ok()?;
+    }
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).ok()?;
+    Some((contents, base))
+}
+
+/// Walk the lines of a `session.jsonl` tail read at `base`, invoking `visit`
+/// with each line's stable id (its line index from the start of the file).
+/// Returns the advanced cursor. The cursor only moves past newline-terminated
+/// lines: an unterminated final fragment is still visited (matching the
+/// historical `str::lines` behavior) but stays ahead of the cursor, so the
+/// next pass re-reads it once the writer finishes the line. `visit` returns
+/// `false` to stop before consuming the current line (pagination limits).
+pub(crate) fn walk_session_jsonl_tail(
+    tail: &str,
+    base: SessionJsonlCursor,
+    mut visit: impl FnMut(u64, &str) -> bool,
+) -> SessionJsonlCursor {
+    let mut cursor = base;
+    let bytes = tail.as_bytes();
+    let mut line_start = 0usize;
+    let mut line_id = base.lines;
+    while line_start < bytes.len() {
+        let (line_end, next_start, terminated) =
+            match bytes[line_start..].iter().position(|byte| *byte == b'\n') {
+                Some(nl) => (line_start + nl, line_start + nl + 1, true),
+                None => (bytes.len(), bytes.len(), false),
+            };
+        let mut line = &tail[line_start..line_end];
+        if let Some(stripped) = line.strip_suffix('\r') {
+            line = stripped;
+        }
+        if !visit(line_id, line) {
+            return cursor;
+        }
+        line_id += 1;
+        if terminated {
+            cursor = SessionJsonlCursor {
+                lines: line_id,
+                bytes: base.bytes + next_start as u64,
+            };
+        }
+        line_start = next_start;
+    }
+    cursor
+}
+
+/// Last read position per `session.jsonl` path for `get_logs` pagination.
+/// Bounded like the session-dir lookup cache: crude clear-on-overflow keeps
+/// it from growing with daemon lifetime.
+fn persisted_log_read_cursors(
+) -> &'static std::sync::Mutex<std::collections::HashMap<std::path::PathBuf, SessionJsonlCursor>> {
+    static CURSORS: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<std::path::PathBuf, SessionJsonlCursor>>,
+    > = std::sync::OnceLock::new();
+    CURSORS.get_or_init(Default::default)
+}
+
+const PERSISTED_LOG_READ_CURSOR_CAP: usize = 256;
+
+fn load_persisted_log_read_cursor(path: &std::path::Path) -> Option<SessionJsonlCursor> {
+    persisted_log_read_cursors()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(path)
+        .copied()
+}
+
+fn store_persisted_log_read_cursor(path: &std::path::Path, cursor: SessionJsonlCursor) {
+    let mut cursors = persisted_log_read_cursors()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    if cursors.len() >= PERSISTED_LOG_READ_CURSOR_CAP && !cursors.contains_key(path) {
+        cursors.clear();
+    }
+    cursors.insert(path.to_path_buf(), cursor);
+}
+
 pub(crate) fn read_persisted_log_entries_from_dir(
     log_dir: &std::path::Path,
     params: &GetLogsParams,
 ) -> Option<Vec<LogEntrySnapshot>> {
-    let contents = std::fs::read_to_string(log_dir.join("session.jsonl")).ok()?;
+    let path = log_dir.join("session.jsonl");
+    // A stored cursor is only usable when every line before it is skippable
+    // anyway, i.e. the caller's since_id covers the whole consumed prefix
+    // (ids are line indexes, so lines 0..cursor.lines all have id <=
+    // cursor.lines - 1). The designed poller pattern — page forward with
+    // since_id = last returned id — always qualifies; filtered pollers whose
+    // since_id lags the consumed prefix fall back to the historical full
+    // scan.
+    let prior = params.since_id.and_then(|since| {
+        let cursor = load_persisted_log_read_cursor(&path)?;
+        (cursor.lines > 0 && since >= cursor.lines - 1).then_some(cursor)
+    });
+    let (tail, base) = read_session_jsonl_tail(&path, prior)?;
     let limit = params.limit.unwrap_or(100);
     let mut entries = Vec::new();
 
-    for (line_idx, line) in contents.lines().enumerate() {
+    let advanced = walk_session_jsonl_tail(&tail, base, |line_id, line| {
         if entries.len() >= limit {
-            break;
+            return false;
         }
-        let line_id = line_idx as u64;
         if params
             .since_id
             .map(|since| line_id <= since)
             .unwrap_or(false)
         {
-            continue;
+            return true;
         }
         let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
+            return true;
         };
         let level = persisted_log_entry_level(&value);
         if params
@@ -888,7 +1015,7 @@ pub(crate) fn read_persisted_log_entries_from_dir(
             .map(|filter| filter != level)
             .unwrap_or(false)
         {
-            continue;
+            return true;
         }
         entries.push(LogEntrySnapshot {
             id: line_id,
@@ -896,7 +1023,9 @@ pub(crate) fn read_persisted_log_entries_from_dir(
             level,
             content: persisted_log_entry_content(&value),
         });
-    }
+        true
+    });
+    store_persisted_log_read_cursor(&path, advanced);
 
     Some(entries)
 }
@@ -924,42 +1053,13 @@ pub(crate) fn find_session_log_dir_in_home(
     if session_id.is_empty() {
         return None;
     }
-    // Path-form ids resolve through the anchored helper (inside the logs
-    // root only), and BEFORE the direct join below — joining an absolute
-    // path would silently replace the logs dir as the base.
-    if crate::session_names::session_id_looks_like_path(session_id) {
-        return crate::session_names::intendant_session_dir_from_slash_path(home, session_id);
-    }
-    let logs_dir = crate::platform::intendant_home_in(home).join("logs");
-    let direct = logs_dir.join(session_id);
-    if direct.is_dir() && direct.join("session_meta.json").exists() {
-        return Some(direct);
-    }
-
-    let entries = std::fs::read_dir(logs_dir).ok()?;
-    for entry in entries.flatten() {
-        let name = entry.file_name().to_string_lossy().to_string();
-        if name.starts_with(session_id) && entry.path().is_dir() {
-            return Some(entry.path());
-        }
-        let meta_path = entry.path().join("session_meta.json");
-        let meta_session_id = std::fs::read_to_string(meta_path)
-            .ok()
-            .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
-            .and_then(|value| {
-                value
-                    .get("session_id")
-                    .and_then(serde_json::Value::as_str)
-                    .map(str::to_string)
-            });
-        if meta_session_id
-            .as_deref()
-            .is_some_and(|id| id == session_id || id.starts_with(session_id))
-        {
-            return Some(entry.path());
-        }
-    }
-    None
+    // Derive, don't mirror: this used to be a hand-rolled copy of the
+    // session-log lookup (path-form anchor, direct join, then a full store
+    // scan interleaving name-prefix checks with per-dir session_meta.json
+    // reads). The canonical [`SessionLog::find_session_by_id_in_home`] does
+    // the same resolution behind a validated memo and a two-pass scan, so
+    // alias-id lookups stop paying a whole-store scan per `get_logs` poll.
+    crate::session_log::SessionLog::find_session_by_id_in_home(home, session_id)
 }
 
 pub(crate) fn persisted_log_entry_level(value: &serde_json::Value) -> String {
@@ -1060,5 +1160,170 @@ mod tests {
         .unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].content, "live wrapper follow-up");
+    }
+
+    fn info_line(message: &str) -> String {
+        serde_json::json!({
+            "ts": "2026-07-15T12:00:00",
+            "event": "info",
+            "level": "info",
+            "message": message,
+        })
+        .to_string()
+    }
+
+    fn get_logs_params(since_id: Option<u64>, limit: Option<usize>) -> GetLogsParams {
+        GetLogsParams {
+            session_id: None,
+            since_id,
+            level_filter: None,
+            limit,
+        }
+    }
+
+    #[test]
+    fn cursor_paginated_get_logs_serves_appended_tail_with_stable_ids() {
+        let dir = tempdir().unwrap();
+        let log_path = dir.path().join("session.jsonl");
+        std::fs::write(&log_path, format!("{}\n{}\n", info_line("a"), info_line("b"))).unwrap();
+
+        let first = read_persisted_log_entries_from_dir(
+            dir.path(),
+            &get_logs_params(None, None),
+        )
+        .unwrap();
+        assert_eq!(first.len(), 2);
+        assert_eq!(first[1].id, 1);
+
+        // Append two more lines; the cursored follow-up (since_id = last id)
+        // must serve exactly the appended tail with continuous ids.
+        let mut appended = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&log_path)
+            .unwrap();
+        use std::io::Write as _;
+        write!(appended, "{}\n{}\n", info_line("c"), info_line("d")).unwrap();
+        drop(appended);
+
+        let tail = read_persisted_log_entries_from_dir(
+            dir.path(),
+            &get_logs_params(Some(first[1].id), None),
+        )
+        .unwrap();
+        assert_eq!(
+            tail.iter()
+                .map(|entry| (entry.id, entry.content.clone()))
+                .collect::<Vec<_>>(),
+            vec![(2, "c".to_string()), (3, "d".to_string())]
+        );
+    }
+
+    #[test]
+    fn replaced_log_file_invalidates_the_read_cursor() {
+        let dir = tempdir().unwrap();
+        let log_path = dir.path().join("session.jsonl");
+        std::fs::write(&log_path, format!("{}\n{}\n", info_line("a"), info_line("b"))).unwrap();
+
+        // Seed the cursor with a full pass.
+        let seeded =
+            read_persisted_log_entries_from_dir(dir.path(), &get_logs_params(None, None)).unwrap();
+        assert_eq!(seeded.len(), 2);
+
+        // Replace the file with different content that is LONGER than the
+        // stored byte offset but has no line boundary there. Without the
+        // boundary validation, a cursored read would seek into the middle
+        // of the first line and serve a torn fragment as a phantom new id.
+        let long_first = info_line("a much longer replacement first line than before");
+        std::fs::write(&log_path, format!("{}\n{}\n", long_first, info_line("z"))).unwrap();
+        let cursored = read_persisted_log_entries_from_dir(
+            dir.path(),
+            &get_logs_params(Some(seeded[1].id), None),
+        )
+        .unwrap();
+        assert!(
+            cursored.is_empty(),
+            "stale cursor must self-heal to a full scan (ids 0..=1 are all \
+             covered by since_id), not serve torn phantom lines: {cursored:?}"
+        );
+
+        // And an uncursored pass sees the replacement content under fresh ids.
+        let rescanned =
+            read_persisted_log_entries_from_dir(dir.path(), &get_logs_params(None, None)).unwrap();
+        assert_eq!(rescanned.len(), 2);
+        assert_eq!(rescanned[1].content, "z");
+    }
+
+    #[test]
+    fn unterminated_tail_line_is_served_and_re_read_once_completed() {
+        let dir = tempdir().unwrap();
+        let log_path = dir.path().join("session.jsonl");
+        // Final line lacks its terminator (a partially flushed write).
+        std::fs::write(
+            &log_path,
+            format!("{}\n{}", info_line("done"), info_line("partial")),
+        )
+        .unwrap();
+
+        let first =
+            read_persisted_log_entries_from_dir(dir.path(), &get_logs_params(None, None)).unwrap();
+        assert_eq!(first.len(), 2);
+        assert_eq!(first[1].content, "partial");
+
+        // Terminate the line and append another; the cursored follow-up must
+        // re-serve the (now complete) line under its stable id, then the new
+        // one.
+        let mut appended = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&log_path)
+            .unwrap();
+        use std::io::Write as _;
+        write!(appended, "\n{}\n", info_line("next")).unwrap();
+        drop(appended);
+
+        let tail = read_persisted_log_entries_from_dir(
+            dir.path(),
+            &get_logs_params(Some(0), None),
+        )
+        .unwrap();
+        assert_eq!(
+            tail.iter()
+                .map(|entry| (entry.id, entry.content.clone()))
+                .collect::<Vec<_>>(),
+            vec![(1, "partial".to_string()), (2, "next".to_string())]
+        );
+    }
+
+    #[test]
+    fn limit_break_keeps_cursor_resumable_from_last_served_id() {
+        let dir = tempdir().unwrap();
+        let log_path = dir.path().join("session.jsonl");
+        let lines: Vec<String> = (0..5).map(|i| info_line(&format!("m{i}"))).collect();
+        std::fs::write(&log_path, lines.join("\n") + "\n").unwrap();
+
+        let page1 =
+            read_persisted_log_entries_from_dir(dir.path(), &get_logs_params(None, Some(2)))
+                .unwrap();
+        assert_eq!(
+            page1.iter().map(|entry| entry.id).collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+        let page2 = read_persisted_log_entries_from_dir(
+            dir.path(),
+            &get_logs_params(Some(page1[1].id), Some(2)),
+        )
+        .unwrap();
+        assert_eq!(
+            page2.iter().map(|entry| entry.id).collect::<Vec<_>>(),
+            vec![2, 3]
+        );
+        let page3 = read_persisted_log_entries_from_dir(
+            dir.path(),
+            &get_logs_params(Some(page2[1].id), Some(2)),
+        )
+        .unwrap();
+        assert_eq!(
+            page3.iter().map(|entry| entry.id).collect::<Vec<_>>(),
+            vec![4]
+        );
     }
 }

--- a/src/bin/caller/mcp/tools_display.rs
+++ b/src/bin/caller/mcp/tools_display.rs
@@ -979,8 +979,11 @@ impl IntendantServer {
         )
         .await;
 
-        if let Some(result) = outcome.results.first() {
-            if let Some(ref screenshot) = result.screenshot {
+        // Take the result by value: the base64 PNG runs 1-5 MB and the
+        // outcome is owned locally, so move it into the response instead of
+        // cloning it.
+        if let Some(result) = outcome.results.into_iter().next() {
+            if let Some(screenshot) = result.screenshot {
                 clear_wayland_user_session_activation_pending_after_capture(
                     &self.state,
                     target,
@@ -998,10 +1001,10 @@ impl IntendantServer {
                 }
                 return Ok(image_tool_result(
                     metadata.to_string(),
-                    screenshot.base64_png.clone(),
+                    screenshot.base64_png,
                 ));
             }
-            if let Some(ref err) = result.error {
+            if let Some(err) = result.error {
                 let message = match activation_request.hint() {
                     Some(hint) => format!("{hint}\nScreenshot error: {err}"),
                     None => format!("Screenshot error: {}", err),
@@ -1191,7 +1194,7 @@ impl IntendantServer {
             annotate: params.annotate.unwrap_or(false),
             settle: params.settle.and_then(|s| s.resolve()),
         };
-        let outcome = execute_actions(
+        let mut outcome = execute_actions(
             &actions,
             target,
             backend,
@@ -1267,7 +1270,15 @@ impl IntendantServer {
         // tree rides inline as text; for compact (managed-context) callers
         // that is the whole win — an actual observation instead of a
         // stripped image.
-        let last_screenshot = outcome.last_screenshot();
+        // Same selection as `outcome.last_screenshot()`, but taken by value:
+        // the base64 PNG runs 1-5 MB and nothing reads the results'
+        // screenshots after this point, so move it into the response instead
+        // of cloning it.
+        let last_screenshot = outcome
+            .results
+            .iter_mut()
+            .rev()
+            .find_map(|result| result.screenshot.take());
         if let Some(ss) = last_screenshot {
             clear_wayland_user_session_activation_pending_after_capture(
                 &self.state,
@@ -1296,9 +1307,9 @@ impl IntendantServer {
                 });
             }
             return Ok(if all_failed {
-                image_tool_error(summaries.join("\n"), ss.base64_png.clone())
+                image_tool_error(summaries.join("\n"), ss.base64_png)
             } else {
-                image_tool_result(summaries.join("\n"), ss.base64_png.clone())
+                image_tool_result(summaries.join("\n"), ss.base64_png)
             });
         }
 

--- a/src/bin/caller/mcp/tools_managed.rs
+++ b/src/bin/caller/mcp/tools_managed.rs
@@ -960,6 +960,10 @@ impl IntendantServer {
             })
             .to_string();
         }
+        self.state
+            .read()
+            .await
+            .invalidate_controller_loop_raw_status_cache();
         collect_controller_loop_status(&loop_dir).to_string()
     }
 
@@ -973,6 +977,10 @@ impl IntendantServer {
             })
             .to_string();
         }
+        self.state
+            .read()
+            .await
+            .invalidate_controller_loop_raw_status_cache();
         collect_controller_loop_status(&loop_dir).to_string()
     }
 
@@ -986,6 +994,10 @@ impl IntendantServer {
         let loop_dir = controller_loop_dir();
         match request_loop_intervention_marker(&loop_dir, &params.mode) {
             Ok(intervention) => {
+                self.state
+                    .read()
+                    .await
+                    .invalidate_controller_loop_raw_status_cache();
                 let mut status = collect_controller_loop_status(&loop_dir);
                 add_controller_loop_intervention_report(&mut status, &intervention);
                 serde_json::json!({


### PR DESCRIPTION
Implements the S/M findings from the MCP-scope efficiency audit (status/log read paths re-doing filesystem + process-table work per call under the state write lock). Each finding verified against current source first; only one 3-line commit had touched these files since the audit base, and every finding reproduced.

## Finding → fix

| # | Finding (audit) | Fix | Status |
|---|---|---|---|
| 1 | `get_status` runs the controller-loop collection (ps spawn + all-run-dirs scan + wrapper/meta reads) 2-3x per call, under the `McpAppState` write lock; same per-call collection in `target_session_phase`/`target_session_source`/control handlers | Split the collection into a state-free raw sample (`collect_controller_loop_raw_status`) and a state-dependent finish (enrich, latest-status fold, stale-marker clear, JSON). Raw sample cached in-state for 1s (interior mutability); enrichment always re-runs against live state so folded phases are never stale on a hit. `get_status` pre-warms the cache **outside** the state locks. Marker-mutating tools invalidate; the control-command twins re-seed with their fresh post-mutation collection. | Done |
| 2 | Session-scoped `get_status` re-reads + re-folds the whole `session.jsonl` per call (O(N^2) cumulative for a polled growing log, under the write lock) | Per-log byte cursor in `McpAppState`; hydration folds only the appended tail (the applier is a pure last-write-wins fold — verified: no log-ring pushes — so tail-only replay reaches the same state, and it no longer regresses live-observed phases to stale log state). Cursor validated against the live file; never advances past an unterminated final line. | Done |
| 3 | `get_logs` re-reads the whole log per poll; its dir lookup is an unmemoized duplicate of the session-log store scan | Byte/line cursor per file (bounded map): a poller paging with `since_id = last returned id` skips the consumed prefix; filtered pollers whose `since_id` lags fall back to the historical full scan. `find_session_log_dir_in_home` now derives from the canonical memoized `SessionLog::find_session_by_id_in_home` (duplicate scan deleted). | Done |
| 4 | `codex_app_server_process_tree_active` eagerly computes a full ps snapshot that the live-root fast path never reads; invoked per matched wrapper per collection | Descendants passed as a lazy `once_with(..).flatten()` iterator through the existing tested `_with_root` seam — the ps spawn now happens only when the root is already dead. Sharing one parent-pairs snapshot across the collection needs `intendant-platform` API changes (outside this lane's file fence); with the root-alive fast path + the finding-1 TTL cache the residue is at most one spawn per dead-root wrapper per second. | Done (snapshot sharing out of fence) |
| 5 | Per-event MCP resource notifications: no subscription tracking, no coalescing, sent inline in the fold loop | `subscribe`/`unsubscribe` record URIs; the listener only notifies subscribed ones (MCP resource notifications are subscription-scoped) and coalesces dirty URIs behind a 100 ms debounce (dirty set + deadline flush in the select loop; flushed on bus close). Also records **both** the event's resource and a deferred control command's — the old single slot dropped the first. | Done |
| 6 | `tools/list` rebuilds and ref-inlines all tool schemas per call (router + manual macro re-runs) | Router definitions and the ~20 manual HTTP definitions built once per process (`OnceLock`); per-request work is the name-keyed profile/managed-context filter plus a clone of the survivors. One unfiltered base + per-call filter (instead of per-(managed, profile) caches) keeps the cache bounded against client-supplied profile strings. Gating is name-keyed, so output is unchanged. | Done |
| 7 | Session-source fallback re-reads + identity-scans the whole log per status poll when the source is not in memory | Memoized: resolved sources into `session_sources`, known-non-external ids into a dedicated set; `NotFound` stays uncached so a log that materializes later still resolves. Tail-only identity scanning skipped — `scan_session_log` lives in `session_identity` (out of fence); the memo removes the per-poll repetition. | Done |
| 8 | `take_screenshot` / `execute_cu_actions` clone the full 1-5 MB base64 PNG for the response | Both sites move the owned value (result taken by value; `screenshot.take()` mirroring `last_screenshot()`'s selection). | Done |
| 9 | Unbounded per-session maps in `McpAppState` | `note_session_ended` prunes the ended session's related-id component once the status map outgrows a soft cap (1024). Under the cap, ended sessions stay resident so post-end status/log queries answer from memory; over it, the next query rebuilds from the persisted log via hydration (correct, one full replay slower). Hydration cursors are cleared on prune so that rebuild is a full replay. | Done |

## Deliberate deviations / skips

- **Finding 1's "guard promote behind `controller_loop_dir_has_observable_state`"**: not applied. Promote's discovery legitimately includes codex processes found via the process tree + wrapper index even when the loop dir has no observable state; the stale-check's guard is only correct because its positive result depends on dir markers. The TTL cache removes the cost motive for the guard.
- **"Other findings" (unranked, non-perf)**: `approve/deny/skip ignore the caller's id` is a correctness/race item, left for its own change. `get_logs cursor spaces incoherent across paths` is a wire-visible design change — the new byte cursor deliberately honors the existing persisted line-id space. The `single resource_changed slot` is fixed at the listener level; `handle_control_command_mcp` still returns one URI per command (a command mutating two resources reports the last) — follow-up material.
- **Lineage-lane dependency**: the per-call ledger fold in `get_status` (`status_ledger_candidate_dirs` + merged lineage/fission reads) belongs to the lineage/external lane; its fold/derive split + facts cache is not on this branch's base, so those sub-items are skipped per the lane split.

## Trust surface

The /mcp IAM gate is untouched: no change to `call_tool_by_name_as_caller`, tool gating semantics, or any authorization ordering. Finding 6 caches only the *definitions*; the name-keyed profile filter still runs per request. Subscription recording only *narrows* what the already-connected stdio peer receives.

## Tests

New: cursor pagination with stable ids, limit-break resumability, replaced-file invalidation (no torn phantom lines), unterminated-tail re-serve, hydration tail-only replay (live phase not regressed), ended-session prune under/over cap.

Battery (all `CARGO_PROFILE_DEV_DEBUG=0`, re-run per review round; latest at head): `cargo fmt --check` clean; `cargo clippy` (workspace) clean; `cargo nextest run --bins` 3493 passed / 0 failed; `cargo test --test e2e` 21 passed / 0 failed.


## Follow-ups (identified in review, deliberately out of scope)

- **Emission-stamped ordering token on lifecycle events.** Hydration replay applies log rows ungated and folds to the log's final state — permanently correct because the log lane is a lossless, order-preserving serialization of the same event stream the live listener folds, but a replay can transiently land a few events behind live (the log-sink consumer's queue lag; self-heals on the next appended rows or live event — contract documented at the hydrate fold site). Eliminating even that transient window requires a monotonic token stamped at emission and carried on both lanes (lifecycle `AppEvent` variants currently carry none; row `ts_ms` is minted at write time downstream of the fork) — a cross-lane change through `event.rs`, the session-log writer/replay, and every lifecycle emission site. Deferred.
- **`ControlMsg::Quit` does not close the stdio MCP service.** `request_quit` sets `should_quit`, but nothing in the MCP shape consumes it for shutdown — `run_mcp_server` returns only when the transport ends. Pre-existing (TUI-era flag); worth its own small change if Quit is meant to terminate the process.
- **Stamp `session_id` on persisted `round_complete` rows (source fidelity).** The writer persists `round_complete` without a session id, so replay reconstructs `RoundComplete { session_id: None }` and every consumer must supply attribution context (the MCP reducer now attributes such rows to the hydration target). Stamping the id at the writer — like every other lifecycle row — fixes it at the source and lets replay reconstruct fully-attributed events; touches `session_log/**`, which is inside PR #344's in-flight diff. Deferred.
