### PR TITLE
connect: debounced store persistence, transparency read caches, bounded in-memory tables

### DIFF
--- a/src/bin/connect/accounts.rs
+++ b/src/bin/connect/accounts.rs
@@ -529,6 +529,52 @@ pub(crate) fn client_observed_ip(headers: &HeaderMap) -> Option<String> {
         .map(|ip| ip.to_string())
 }
 
+/// The largest window any `check_rate_limit` call site uses (the hourly
+/// new-daemon-identity budget). A bucket idle past this is expired for every
+/// scope — the next request would reset it anyway — so pruning such buckets
+/// never changes a limit decision. Asserted at use so a wider window cannot
+/// silently outlive the sweep.
+pub(crate) const RATE_LIMIT_WINDOW_MAX_MS: u64 = 60 * 60_000;
+
+/// Hard bound on distinct rate-limit keys held in memory. Keys derive from
+/// client-controlled forwarded-address headers, so an attacker (or plain
+/// IPv6 churn) can mint fresh keys freely; the table must not grow with
+/// them. At roughly 100 bytes per entry this is a few MB.
+pub(crate) const RATE_LIMIT_MAX_KEYS: usize = 50_000;
+
+/// Drop buckets whose window has expired under every scope's window size.
+pub(crate) fn prune_rate_limits(buckets: &mut HashMap<String, RateLimitBucket>, now: u64) {
+    buckets.retain(|_, bucket| {
+        now.saturating_sub(bucket.window_start_unix_ms) <= RATE_LIMIT_WINDOW_MAX_MS
+    });
+}
+
+/// Bound the table before inserting a new key: prune expired windows first;
+/// if the table is still saturated with live windows, evict the stalest
+/// bucket (the one closest to expiring anyway) rather than growing without
+/// bound or refusing brand-new legitimate clients. An attacker gains nothing
+/// they lack: minting fresh keys was always free via forwarded headers.
+fn reserve_rate_limit_slot(
+    buckets: &mut HashMap<String, RateLimitBucket>,
+    key: &str,
+    now: u64,
+    max_keys: usize,
+) {
+    if buckets.len() < max_keys || buckets.contains_key(key) {
+        return;
+    }
+    prune_rate_limits(buckets, now);
+    if buckets.len() >= max_keys {
+        let stalest = buckets
+            .iter()
+            .min_by_key(|(_, bucket)| bucket.window_start_unix_ms)
+            .map(|(key, _)| key.clone());
+        if let Some(stalest) = stalest {
+            buckets.remove(&stalest);
+        }
+    }
+}
+
 pub(crate) async fn check_rate_limit(
     state: &AppState,
     headers: &HeaderMap,
@@ -536,9 +582,14 @@ pub(crate) async fn check_rate_limit(
     limit: u32,
     window_ms: u64,
 ) -> ApiResult<()> {
+    debug_assert!(
+        window_ms <= RATE_LIMIT_WINDOW_MAX_MS,
+        "rate window {window_ms}ms exceeds the sweep bound — widen RATE_LIMIT_WINDOW_MAX_MS"
+    );
     let now = now_unix_ms();
     let key = client_rate_key(headers, scope);
     let mut buckets = state.rate_limits.lock().await;
+    reserve_rate_limit_slot(&mut buckets, &key, now, RATE_LIMIT_MAX_KEYS);
     let bucket = buckets.entry(key).or_insert(RateLimitBucket {
         window_start_unix_ms: now,
         count: 0,
@@ -979,4 +1030,76 @@ pub(crate) async fn auth_login_finish(
         session_cookie(&state.config, &token, SESSION_TTL_MS / 1000),
     );
     Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bucket(window_start_unix_ms: u64) -> RateLimitBucket {
+        RateLimitBucket {
+            window_start_unix_ms,
+            count: 1,
+        }
+    }
+
+    #[test]
+    fn rate_limit_prune_removes_only_universally_expired_windows() {
+        let now = RATE_LIMIT_WINDOW_MAX_MS * 3;
+        let mut buckets = HashMap::new();
+        buckets.insert("scope:fresh".to_string(), bucket(now));
+        buckets.insert(
+            "scope:edge".to_string(),
+            bucket(now - RATE_LIMIT_WINDOW_MAX_MS),
+        );
+        buckets.insert(
+            "scope:expired".to_string(),
+            bucket(now - RATE_LIMIT_WINDOW_MAX_MS - 1),
+        );
+        prune_rate_limits(&mut buckets, now);
+        assert!(buckets.contains_key("scope:fresh"));
+        assert!(
+            buckets.contains_key("scope:edge"),
+            "a bucket exactly at the bound may still gate the hourly scope"
+        );
+        assert!(!buckets.contains_key("scope:expired"));
+    }
+
+    #[test]
+    fn rate_limit_table_is_bounded_and_evicts_the_stalest_live_window() {
+        let now = RATE_LIMIT_WINDOW_MAX_MS * 3;
+        let mut buckets = HashMap::new();
+        // Saturate with live windows, one strictly stalest.
+        buckets.insert("scope:stalest".to_string(), bucket(now - 50_000));
+        for index in 0..3 {
+            buckets.insert(format!("scope:live-{index}"), bucket(now - 1_000));
+        }
+        reserve_rate_limit_slot(&mut buckets, "scope:new", now, 4);
+        assert_eq!(buckets.len(), 3, "one slot was reclaimed for the new key");
+        assert!(
+            !buckets.contains_key("scope:stalest"),
+            "the bucket closest to expiring is the one evicted"
+        );
+
+        // An existing key never evicts anything.
+        let before = buckets.len();
+        reserve_rate_limit_slot(&mut buckets, "scope:live-0", now, 3);
+        assert_eq!(buckets.len(), before);
+
+        // Expired windows are reclaimed before any live eviction.
+        buckets.insert(
+            "scope:expired".to_string(),
+            bucket(now - RATE_LIMIT_WINDOW_MAX_MS - 1),
+        );
+        let live_before: Vec<String> = buckets
+            .keys()
+            .filter(|key| *key != "scope:expired")
+            .cloned()
+            .collect();
+        reserve_rate_limit_slot(&mut buckets, "scope:new-2", now, 4);
+        assert!(!buckets.contains_key("scope:expired"));
+        for key in live_before {
+            assert!(buckets.contains_key(&key), "{key} must survive");
+        }
+    }
 }

--- a/src/bin/connect/accounts.rs
+++ b/src/bin/connect/accounts.rs
@@ -504,16 +504,17 @@ pub(crate) fn header_string(headers: &HeaderMap, name: &'static str) -> Option<S
         .map(str::to_string)
 }
 
-pub(crate) fn client_rate_key(headers: &HeaderMap, scope: &str) -> String {
-    format!("{scope}:{}", forwarded_peer_token(headers))
-}
-
 /// Canonicalized, bounded source token for rate keys. The first forwarded
 /// hop is parsed as an IP address (accepting an `ip:port` form some proxies
-/// emit) and re-rendered canonically, so the key cap is also a byte cap
-/// (≤45 chars) and textual IPv6 variants of one address share a bucket. A
-/// present-but-unparseable value collapses to one bounded "invalid" bucket
-/// (previously it became an attacker-mintable arbitrary-length key); the
+/// emit) and re-rendered canonically, so the key space is also byte-capped
+/// (≤45 chars). IPv6 sources aggregate by /64 prefix — one household/VM
+/// gets one bucket, and rotating addresses inside a /64 (free for any v6
+/// holder) stops minting fresh buckets; IPv4-mapped IPv6 folds to its IPv4
+/// form so `::ffff:203.0.113.9` and `203.0.113.9` share one budget. A
+/// present-but-unparseable value (zone-qualified link-local like
+/// `fe80::1%eth0` included — a link-local peer behind a proxy is not a
+/// meaningful source identity) collapses to one bounded "invalid" bucket
+/// instead of becoming an attacker-mintable arbitrary-length key; the
 /// absent-header fallback stays "unknown", unchanged.
 fn forwarded_peer_token(headers: &HeaderMap) -> String {
     let raw = header_string(headers, "x-forwarded-for")
@@ -524,12 +525,35 @@ fn forwarded_peer_token(headers: &HeaderMap) -> String {
         return "unknown".to_string();
     };
     if let Ok(ip) = value.parse::<std::net::IpAddr>() {
-        return ip.to_string();
+        return canonical_peer_ip(ip);
     }
     if let Ok(addr) = value.parse::<std::net::SocketAddr>() {
-        return addr.ip().to_string();
+        return canonical_peer_ip(addr.ip());
     }
     "invalid".to_string()
+}
+
+fn canonical_peer_ip(ip: std::net::IpAddr) -> String {
+    match ip {
+        std::net::IpAddr::V4(v4) => v4.to_string(),
+        std::net::IpAddr::V6(v6) => {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return v4.to_string();
+            }
+            let segments = v6.segments();
+            let prefix = std::net::Ipv6Addr::new(
+                segments[0],
+                segments[1],
+                segments[2],
+                segments[3],
+                0,
+                0,
+                0,
+                0,
+            );
+            format!("{prefix}/64")
+        }
+    }
 }
 
 /// The caller's public IP as this service observed it (first
@@ -548,15 +572,25 @@ pub(crate) fn client_observed_ip(headers: &HeaderMap) -> Option<String> {
         .map(|ip| ip.to_string())
 }
 
-/// Hard bound on distinct rate-limit keys held in memory. Keys derive from
-/// client-controlled forwarded-address headers, so an attacker (or plain
-/// IPv6 churn) can mint fresh keys freely; the table must not grow with
-/// them. At roughly 100 bytes per entry this is a few MB.
-pub(crate) const RATE_LIMIT_MAX_KEYS: usize = 50_000;
+/// Per-scope key capacity, derived from the scope's window. Short windows
+/// (minutes) serve high-cardinality populations — every polling daemon,
+/// public log readers — and their buckets churn out within minutes, so the
+/// cap is generous. Long windows (≥10 min: the attest / subscribe budgets,
+/// the hourly new-daemon-identity budget) pin a slot for the whole window
+/// and serve small legitimate populations, so the cap is small. Worst-case
+/// total memory = scopes × cap × ~100B — a few MB with today's ~20 scopes.
+fn scope_capacity(window_ms: u64) -> usize {
+    if window_ms >= 10 * 60_000 {
+        2_000
+    } else {
+        10_000
+    }
+}
 
 /// At-capacity prune scans are amortized to at most one per this interval:
-/// after a saturated prune the table is all-live, so an immediate re-scan
-/// could only reclaim buckets whose windows elapsed in between.
+/// after a saturated prune the scope is all-live, so an immediate re-scan
+/// could only reclaim buckets whose windows elapsed in between (bounded
+/// false-429 staleness of ≤1s while a scope sits at its cap).
 const RATE_LIMIT_SATURATED_PRUNE_MIN_INTERVAL_MS: u64 = 1_000;
 
 fn rate_bucket_expired(bucket: &RateLimitBucket, now: u64) -> bool {
@@ -568,35 +602,39 @@ fn rate_bucket_expired(bucket: &RateLimitBucket, now: u64) -> bool {
 /// removal never changes a limit decision. Expiry is strictly per-bucket:
 /// judging a short-window bucket by a longer global bound would rank it
 /// "live" long after its own window died, letting churned short-window keys
-/// crowd out genuinely live long-window buckets.
-pub(crate) fn prune_rate_limits(buckets: &mut HashMap<String, RateLimitBucket>, now: u64) {
+/// crowd out genuinely live long-window buckets. Scopes emptied by the
+/// prune are dropped entirely.
+pub(crate) fn prune_rate_limits(table: &mut RateLimitTable, now: u64) {
+    for scope in table.scopes.values_mut() {
+        prune_scope_buckets(&mut scope.buckets, now);
+    }
+    table.scopes.retain(|_, scope| !scope.buckets.is_empty());
+}
+
+fn prune_scope_buckets(buckets: &mut HashMap<String, RateLimitBucket>, now: u64) {
     buckets.retain(|_, bucket| !rate_bucket_expired(bucket, now));
 }
 
-/// Capacity gate for inserting a new key. Reclaims genuinely expired
-/// buckets first (full scan amortized to once per
-/// `RATE_LIMIT_SATURATED_PRUNE_MIN_INTERVAL_MS` while saturated); if the
-/// table is still full of LIVE buckets, it fails closed on the new key —
-/// a live bucket is never evicted, because evicting one resets an active
-/// counter (an attacker flooding cheap short-window keys could otherwise
-/// reset a security-sensitive budget like the hourly new-daemon-identity
-/// cap). Existing keys always pass.
-fn reserve_rate_limit_slot(
-    table: &mut RateLimitTable,
-    key: &str,
-    now: u64,
-    max_keys: usize,
-) -> bool {
-    if table.buckets.len() < max_keys || table.buckets.contains_key(key) {
+/// Capacity gate for inserting a new key into ONE scope's partition.
+/// Reclaims genuinely expired buckets first (full scan amortized to once
+/// per `RATE_LIMIT_SATURATED_PRUNE_MIN_INTERVAL_MS` while saturated); if
+/// the scope is still full of LIVE buckets, it fails closed on the new key
+/// — a live bucket is never evicted, because evicting one resets an active
+/// counter (an attacker flooding cheap keys could otherwise reset a
+/// security-sensitive budget like the hourly new-daemon-identity cap).
+/// Existing keys always pass, and other scopes are untouched by
+/// construction: saturation here can never 429 a different scope.
+fn reserve_scope_slot(scope: &mut ScopeRateLimits, key: &str, now: u64, max_keys: usize) -> bool {
+    if scope.buckets.len() < max_keys || scope.buckets.contains_key(key) {
         return true;
     }
-    if now.saturating_sub(table.last_saturated_prune_unix_ms)
+    if now.saturating_sub(scope.last_saturated_prune_unix_ms)
         >= RATE_LIMIT_SATURATED_PRUNE_MIN_INTERVAL_MS
     {
-        table.last_saturated_prune_unix_ms = now;
-        prune_rate_limits(&mut table.buckets, now);
+        scope.last_saturated_prune_unix_ms = now;
+        prune_scope_buckets(&mut scope.buckets, now);
     }
-    table.buckets.len() < max_keys
+    scope.buckets.len() < max_keys
 }
 
 pub(crate) async fn check_rate_limit(
@@ -607,13 +645,20 @@ pub(crate) async fn check_rate_limit(
     window_ms: u64,
 ) -> ApiResult<()> {
     let now = now_unix_ms();
-    let key = client_rate_key(headers, scope);
+    let peer = forwarded_peer_token(headers);
     let mut table = state.rate_limits.lock().await;
-    if !reserve_rate_limit_slot(&mut table, &key, now, RATE_LIMIT_MAX_KEYS) {
-        // Table saturated with live windows: fail closed on the unseen key.
-        return Err(ApiError::too_many_requests("rate limit exceeded"));
+    let scope_limits = table.scopes.entry(scope.to_string()).or_default();
+    if !reserve_scope_slot(scope_limits, &peer, now, scope_capacity(window_ms)) {
+        // This scope's partition is saturated with live windows: fail
+        // closed on the unseen key. Retry-After can only bound the wait
+        // honestly by this scope's own window (a slot frees whenever any
+        // bucket in the partition expires, which is not cheaply knowable).
+        return Err(ApiError::too_many_requests_after(
+            "rate limit exceeded",
+            window_ms.div_ceil(1000).max(1),
+        ));
     }
-    let bucket = table.buckets.entry(key).or_insert(RateLimitBucket {
+    let bucket = scope_limits.buckets.entry(peer).or_insert(RateLimitBucket {
         window_start_unix_ms: now,
         count: 0,
         window_ms,
@@ -627,7 +672,14 @@ pub(crate) async fn check_rate_limit(
     }
     bucket.count = bucket.count.saturating_add(1);
     if bucket.count > limit {
-        return Err(ApiError::too_many_requests("rate limit exceeded"));
+        let remaining_ms = bucket
+            .window_start_unix_ms
+            .saturating_add(bucket.window_ms)
+            .saturating_sub(now);
+        return Err(ApiError::too_many_requests_after(
+            "rate limit exceeded",
+            remaining_ms.div_ceil(1000).max(1),
+        ));
     }
     Ok(())
 }
@@ -1073,70 +1125,84 @@ mod tests {
         }
     }
 
-    fn table_with(entries: Vec<(&str, RateLimitBucket)>) -> RateLimitTable {
-        let mut table = RateLimitTable::default();
+    fn scope_with(entries: Vec<(&str, RateLimitBucket)>) -> ScopeRateLimits {
+        let mut scope = ScopeRateLimits::default();
         for (key, bucket) in entries {
-            table.buckets.insert(key.to_string(), bucket);
+            scope.buckets.insert(key.to_string(), bucket);
         }
-        table
+        scope
     }
 
     #[test]
     fn rate_limit_prune_judges_each_bucket_by_its_own_window() {
         let now = HOUR_MS * 3;
-        let mut buckets = HashMap::new();
-        // 2 minutes old: dead for a 60s scope, alive for the hourly scope.
-        buckets.insert("short:1.1.1.1".to_string(), bucket(now - 120_000, 60_000));
-        buckets.insert("hourly:2.2.2.2".to_string(), bucket(now - 120_000, HOUR_MS));
-        // Exactly at its own bound is still live (strict `>` expiry).
-        buckets.insert("edge:3.3.3.3".to_string(), bucket(now - 60_000, 60_000));
-        prune_rate_limits(&mut buckets, now);
+        let mut table = RateLimitTable::default();
+        table.scopes.insert(
+            "mixed".to_string(),
+            scope_with(vec![
+                // 2 minutes old: dead for a 60s window, alive for an hourly one.
+                ("1.1.1.1", bucket(now - 120_000, 60_000)),
+                ("2.2.2.2", bucket(now - 120_000, HOUR_MS)),
+                // Exactly at its own bound is still live (strict `>` expiry).
+                ("3.3.3.3", bucket(now - 60_000, 60_000)),
+            ]),
+        );
+        table.scopes.insert(
+            "all-dead".to_string(),
+            scope_with(vec![("4.4.4.4", bucket(now - 120_000, 60_000))]),
+        );
+        prune_rate_limits(&mut table, now);
+        let mixed = &table.scopes["mixed"].buckets;
         assert!(
-            !buckets.contains_key("short:1.1.1.1"),
+            !mixed.contains_key("1.1.1.1"),
             "expired by its own window despite being young globally"
         );
-        assert!(buckets.contains_key("hourly:2.2.2.2"));
-        assert!(buckets.contains_key("edge:3.3.3.3"));
+        assert!(mixed.contains_key("2.2.2.2"));
+        assert!(mixed.contains_key("3.3.3.3"));
+        assert!(
+            !table.scopes.contains_key("all-dead"),
+            "scopes emptied by the prune are dropped"
+        );
     }
 
     #[test]
     fn rate_limit_capacity_reclaims_expired_before_touching_live_buckets() {
         let now = HOUR_MS * 3;
-        // At cap 3: one live hourly bucket + two short-window buckets that
-        // are dead by their own windows (the churn-attack shape).
-        let mut table = table_with(vec![
-            ("hourly:victim", bucket(now - 300_000, HOUR_MS)),
-            ("short:churn-1", bucket(now - 300_000, 60_000)),
-            ("short:churn-2", bucket(now - 300_000, 60_000)),
+        // At cap 3: one live hourly bucket + two buckets dead by their own
+        // windows (the churn-attack shape).
+        let mut scope = scope_with(vec![
+            ("victim", bucket(now - 300_000, HOUR_MS)),
+            ("churn-1", bucket(now - 300_000, 60_000)),
+            ("churn-2", bucket(now - 300_000, 60_000)),
         ]);
         assert!(
-            reserve_rate_limit_slot(&mut table, "hourly:newcomer", now, 3),
+            reserve_scope_slot(&mut scope, "newcomer", now, 3),
             "expired churn is reclaimed"
         );
         assert!(
-            table.buckets.contains_key("hourly:victim"),
+            scope.buckets.contains_key("victim"),
             "the active hourly bucket survives cap pressure from short-window churn"
         );
-        assert!(!table.buckets.contains_key("short:churn-1"));
-        assert!(!table.buckets.contains_key("short:churn-2"));
+        assert!(!scope.buckets.contains_key("churn-1"));
+        assert!(!scope.buckets.contains_key("churn-2"));
     }
 
     #[test]
     fn rate_limit_capacity_fails_closed_instead_of_evicting_live_buckets() {
         let now = HOUR_MS * 3;
-        let mut table = table_with(vec![
-            ("hourly:a", bucket(now - 1_000, HOUR_MS)),
-            ("hourly:b", bucket(now - 2_000, HOUR_MS)),
+        let mut scope = scope_with(vec![
+            ("a", bucket(now - 1_000, HOUR_MS)),
+            ("b", bucket(now - 2_000, HOUR_MS)),
         ]);
         assert!(
-            !reserve_rate_limit_slot(&mut table, "hourly:new", now, 2),
-            "a table full of live buckets rejects the new key"
+            !reserve_scope_slot(&mut scope, "new", now, 2),
+            "a scope full of live buckets rejects the new key"
         );
-        assert_eq!(table.buckets.len(), 2, "no live bucket was evicted");
-        assert!(table.buckets.contains_key("hourly:a"));
-        assert!(table.buckets.contains_key("hourly:b"));
+        assert_eq!(scope.buckets.len(), 2, "no live bucket was evicted");
+        assert!(scope.buckets.contains_key("a"));
+        assert!(scope.buckets.contains_key("b"));
         assert!(
-            reserve_rate_limit_slot(&mut table, "hourly:a", now, 2),
+            reserve_scope_slot(&mut scope, "a", now, 2),
             "existing keys always pass"
         );
     }
@@ -1144,23 +1210,96 @@ mod tests {
     #[test]
     fn rate_limit_saturated_prune_scans_are_amortized() {
         let now = HOUR_MS * 3;
-        let mut table = table_with(vec![
-            ("hourly:live", bucket(now - 1_000, HOUR_MS)),
-            ("short:soon-dead", bucket(now - 30_000, 60_000)),
+        let mut scope = scope_with(vec![
+            ("live", bucket(now - 1_000, HOUR_MS)),
+            ("soon-dead", bucket(now - 30_000, 60_000)),
         ]);
         // First saturated insert prunes (nothing expired yet) and fails.
-        assert!(!reserve_rate_limit_slot(&mut table, "k:new", now, 2));
+        assert!(!reserve_scope_slot(&mut scope, "new", now, 2));
         // The short bucket expires 30s later, but within the amortization
         // interval the scan is skipped — the insert still fails closed.
         // (Bounded staleness: at most one interval, trading scan cost.)
         let later = now + 31_000;
-        table.last_saturated_prune_unix_ms = later - 500;
-        assert!(!reserve_rate_limit_slot(&mut table, "k:new", later, 2));
-        assert!(table.buckets.contains_key("short:soon-dead"));
+        scope.last_saturated_prune_unix_ms = later - 500;
+        assert!(!reserve_scope_slot(&mut scope, "new", later, 2));
+        assert!(scope.buckets.contains_key("soon-dead"));
         // Past the interval the prune runs and the slot frees up.
-        table.last_saturated_prune_unix_ms = 0;
-        assert!(reserve_rate_limit_slot(&mut table, "k:new", later, 2));
-        assert!(!table.buckets.contains_key("short:soon-dead"));
+        scope.last_saturated_prune_unix_ms = 0;
+        assert!(reserve_scope_slot(&mut scope, "new", later, 2));
+        assert!(!scope.buckets.contains_key("soon-dead"));
+    }
+
+    /// The R2 blocker: saturating one scope's partition must never
+    /// fail-close another scope. Driven end-to-end through
+    /// `check_rate_limit` with rotating source addresses.
+    #[tokio::test]
+    async fn rate_limit_scope_saturation_cannot_starve_other_scopes() {
+        let root = tempfile::tempdir().unwrap();
+        let state = production_router_test_state(root.path(), Store::default());
+        let window_ms = HOUR_MS; // long window → the small (2k) scope cap
+        let cap = scope_capacity(window_ms);
+        // Saturate scope A with live buckets from rotating /64s.
+        for index in 0..cap {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                "x-forwarded-for",
+                format!("2001:db8:{:x}:{:x}::7", index >> 16, index & 0xffff)
+                    .parse()
+                    .unwrap(),
+            );
+            check_rate_limit(&state, &headers, "scope-a", 1000, window_ms)
+                .await
+                .expect("filling scope A stays under its own cap");
+        }
+        let mut fresh = HeaderMap::new();
+        fresh.insert("x-forwarded-for", "203.0.113.200".parse().unwrap());
+        let closed = check_rate_limit(&state, &fresh, "scope-a", 1000, window_ms)
+            .await
+            .expect_err("scope A is saturated: unseen key fails closed");
+        assert_eq!(closed.status, StatusCode::TOO_MANY_REQUESTS);
+        assert!(
+            closed.retry_after_seconds.is_some(),
+            "capacity 429 carries Retry-After"
+        );
+        // The SAME new source is admitted in a different scope.
+        check_rate_limit(&state, &fresh, "scope-b", 1000, window_ms)
+            .await
+            .expect("scope B is isolated from scope A's saturation");
+        // Sources already known to scope A keep passing there too.
+        let mut known = HeaderMap::new();
+        known.insert("x-forwarded-for", "2001:db8:0:0::7".parse().unwrap());
+        check_rate_limit(&state, &known, "scope-a", 1000, window_ms)
+            .await
+            .expect("existing keys in the saturated scope still pass");
+    }
+
+    /// Over-limit 429s tell clients how long the actual window has left.
+    #[tokio::test]
+    async fn rate_limit_429_carries_retry_after() {
+        let root = tempfile::tempdir().unwrap();
+        let state = production_router_test_state(root.path(), Store::default());
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "203.0.113.9".parse().unwrap());
+        check_rate_limit(&state, &headers, "tight", 1, 60_000)
+            .await
+            .unwrap();
+        let over = check_rate_limit(&state, &headers, "tight", 1, 60_000)
+            .await
+            .expect_err("second request exceeds limit 1");
+        let seconds = over.retry_after_seconds.expect("Retry-After set");
+        assert!(
+            (1..=60).contains(&seconds),
+            "remaining window in seconds, got {seconds}"
+        );
+        let response = over.into_response();
+        assert_eq!(
+            response
+                .headers()
+                .get(header::RETRY_AFTER)
+                .and_then(|value| value.to_str().ok()),
+            Some(seconds.to_string().as_str()),
+            "header emitted on the wire"
+        );
     }
 
     #[test]
@@ -1170,27 +1309,34 @@ mod tests {
             if let Some(value) = value {
                 headers.insert("x-forwarded-for", value.parse().unwrap());
             }
-            client_rate_key(&headers, "scope")
+            forwarded_peer_token(&headers)
         }
-        assert_eq!(key_for(None), "scope:unknown");
-        assert_eq!(key_for(Some("203.0.113.9")), "scope:203.0.113.9");
-        // Textual IPv6 variants of one address share a bucket.
+        assert_eq!(key_for(None), "unknown");
+        assert_eq!(key_for(Some("203.0.113.9")), "203.0.113.9");
+        // IPv6 aggregates by /64: rotating inside the prefix cannot mint
+        // fresh buckets; distinct /64s stay distinct.
+        assert_eq!(key_for(Some("2001:db8::1")), "2001:db8::/64");
         assert_eq!(
-            key_for(Some("2001:0db8:0000:0000:0000:0000:0000:0001")),
-            "scope:2001:db8::1"
+            key_for(Some("2001:0db8:0000:0000:dead:beef:0000:0001")),
+            "2001:db8::/64"
         );
-        assert_eq!(key_for(Some("2001:db8::1")), "scope:2001:db8::1");
+        assert_ne!(
+            key_for(Some("2001:db8:0:1::1")),
+            key_for(Some("2001:db8::1"))
+        );
+        // IPv4-mapped IPv6 folds to the IPv4 form: one client, one budget.
+        assert_eq!(key_for(Some("::ffff:203.0.113.9")), "203.0.113.9");
         // ip:port proxy forms resolve to the address.
-        assert_eq!(key_for(Some("203.0.113.9:5678")), "scope:203.0.113.9");
+        assert_eq!(key_for(Some("203.0.113.9:5678")), "203.0.113.9");
+        // Zone-qualified link-local (fe80::1%eth0) does not parse as a
+        // source identity — documented as collapsing to the invalid bucket.
+        assert_eq!(key_for(Some("fe80::1%eth0")), "invalid");
         // Garbage collapses to one bounded bucket instead of minting an
         // attacker-controlled arbitrary-length key.
         let garbage = "x".repeat(4096);
-        assert_eq!(key_for(Some(garbage.as_str())), "scope:invalid");
-        assert_eq!(key_for(Some("not an ip, at all")), "scope:invalid");
+        assert_eq!(key_for(Some(garbage.as_str())), "invalid");
+        assert_eq!(key_for(Some("not an ip, at all")), "invalid");
         // Only the first hop counts, as before.
-        assert_eq!(
-            key_for(Some("203.0.113.9, 198.51.100.7")),
-            "scope:203.0.113.9"
-        );
+        assert_eq!(key_for(Some("203.0.113.9, 198.51.100.7")), "203.0.113.9");
     }
 }

--- a/src/bin/connect/accounts.rs
+++ b/src/bin/connect/accounts.rs
@@ -505,12 +505,31 @@ pub(crate) fn header_string(headers: &HeaderMap, name: &'static str) -> Option<S
 }
 
 pub(crate) fn client_rate_key(headers: &HeaderMap, scope: &str) -> String {
-    let peer = header_string(headers, "x-forwarded-for")
+    format!("{scope}:{}", forwarded_peer_token(headers))
+}
+
+/// Canonicalized, bounded source token for rate keys. The first forwarded
+/// hop is parsed as an IP address (accepting an `ip:port` form some proxies
+/// emit) and re-rendered canonically, so the key cap is also a byte cap
+/// (≤45 chars) and textual IPv6 variants of one address share a bucket. A
+/// present-but-unparseable value collapses to one bounded "invalid" bucket
+/// (previously it became an attacker-mintable arbitrary-length key); the
+/// absent-header fallback stays "unknown", unchanged.
+fn forwarded_peer_token(headers: &HeaderMap) -> String {
+    let raw = header_string(headers, "x-forwarded-for")
         .and_then(|v| v.split(',').next().map(str::trim).map(str::to_string))
         .filter(|v| !v.is_empty())
-        .or_else(|| header_string(headers, "x-real-ip"))
-        .unwrap_or_else(|| "unknown".to_string());
-    format!("{scope}:{peer}")
+        .or_else(|| header_string(headers, "x-real-ip"));
+    let Some(value) = raw else {
+        return "unknown".to_string();
+    };
+    if let Ok(ip) = value.parse::<std::net::IpAddr>() {
+        return ip.to_string();
+    }
+    if let Ok(addr) = value.parse::<std::net::SocketAddr>() {
+        return addr.ip().to_string();
+    }
+    "invalid".to_string()
 }
 
 /// The caller's public IP as this service observed it (first
@@ -529,50 +548,55 @@ pub(crate) fn client_observed_ip(headers: &HeaderMap) -> Option<String> {
         .map(|ip| ip.to_string())
 }
 
-/// The largest window any `check_rate_limit` call site uses (the hourly
-/// new-daemon-identity budget). A bucket idle past this is expired for every
-/// scope — the next request would reset it anyway — so pruning such buckets
-/// never changes a limit decision. Asserted at use so a wider window cannot
-/// silently outlive the sweep.
-pub(crate) const RATE_LIMIT_WINDOW_MAX_MS: u64 = 60 * 60_000;
-
 /// Hard bound on distinct rate-limit keys held in memory. Keys derive from
 /// client-controlled forwarded-address headers, so an attacker (or plain
 /// IPv6 churn) can mint fresh keys freely; the table must not grow with
 /// them. At roughly 100 bytes per entry this is a few MB.
 pub(crate) const RATE_LIMIT_MAX_KEYS: usize = 50_000;
 
-/// Drop buckets whose window has expired under every scope's window size.
-pub(crate) fn prune_rate_limits(buckets: &mut HashMap<String, RateLimitBucket>, now: u64) {
-    buckets.retain(|_, bucket| {
-        now.saturating_sub(bucket.window_start_unix_ms) <= RATE_LIMIT_WINDOW_MAX_MS
-    });
+/// At-capacity prune scans are amortized to at most one per this interval:
+/// after a saturated prune the table is all-live, so an immediate re-scan
+/// could only reclaim buckets whose windows elapsed in between.
+const RATE_LIMIT_SATURATED_PRUNE_MIN_INTERVAL_MS: u64 = 1_000;
+
+fn rate_bucket_expired(bucket: &RateLimitBucket, now: u64) -> bool {
+    now.saturating_sub(bucket.window_start_unix_ms) > bucket.window_ms
 }
 
-/// Bound the table before inserting a new key: prune expired windows first;
-/// if the table is still saturated with live windows, evict the stalest
-/// bucket (the one closest to expiring anyway) rather than growing without
-/// bound or refusing brand-new legitimate clients. An attacker gains nothing
-/// they lack: minting fresh keys was always free via forwarded headers.
+/// Drop buckets whose OWN window has expired — such a bucket grants no
+/// restriction a fresh entry would not (its next request resets it), so
+/// removal never changes a limit decision. Expiry is strictly per-bucket:
+/// judging a short-window bucket by a longer global bound would rank it
+/// "live" long after its own window died, letting churned short-window keys
+/// crowd out genuinely live long-window buckets.
+pub(crate) fn prune_rate_limits(buckets: &mut HashMap<String, RateLimitBucket>, now: u64) {
+    buckets.retain(|_, bucket| !rate_bucket_expired(bucket, now));
+}
+
+/// Capacity gate for inserting a new key. Reclaims genuinely expired
+/// buckets first (full scan amortized to once per
+/// `RATE_LIMIT_SATURATED_PRUNE_MIN_INTERVAL_MS` while saturated); if the
+/// table is still full of LIVE buckets, it fails closed on the new key —
+/// a live bucket is never evicted, because evicting one resets an active
+/// counter (an attacker flooding cheap short-window keys could otherwise
+/// reset a security-sensitive budget like the hourly new-daemon-identity
+/// cap). Existing keys always pass.
 fn reserve_rate_limit_slot(
-    buckets: &mut HashMap<String, RateLimitBucket>,
+    table: &mut RateLimitTable,
     key: &str,
     now: u64,
     max_keys: usize,
-) {
-    if buckets.len() < max_keys || buckets.contains_key(key) {
-        return;
+) -> bool {
+    if table.buckets.len() < max_keys || table.buckets.contains_key(key) {
+        return true;
     }
-    prune_rate_limits(buckets, now);
-    if buckets.len() >= max_keys {
-        let stalest = buckets
-            .iter()
-            .min_by_key(|(_, bucket)| bucket.window_start_unix_ms)
-            .map(|(key, _)| key.clone());
-        if let Some(stalest) = stalest {
-            buckets.remove(&stalest);
-        }
+    if now.saturating_sub(table.last_saturated_prune_unix_ms)
+        >= RATE_LIMIT_SATURATED_PRUNE_MIN_INTERVAL_MS
+    {
+        table.last_saturated_prune_unix_ms = now;
+        prune_rate_limits(&mut table.buckets, now);
     }
+    table.buckets.len() < max_keys
 }
 
 pub(crate) async fn check_rate_limit(
@@ -582,18 +606,21 @@ pub(crate) async fn check_rate_limit(
     limit: u32,
     window_ms: u64,
 ) -> ApiResult<()> {
-    debug_assert!(
-        window_ms <= RATE_LIMIT_WINDOW_MAX_MS,
-        "rate window {window_ms}ms exceeds the sweep bound — widen RATE_LIMIT_WINDOW_MAX_MS"
-    );
     let now = now_unix_ms();
     let key = client_rate_key(headers, scope);
-    let mut buckets = state.rate_limits.lock().await;
-    reserve_rate_limit_slot(&mut buckets, &key, now, RATE_LIMIT_MAX_KEYS);
-    let bucket = buckets.entry(key).or_insert(RateLimitBucket {
+    let mut table = state.rate_limits.lock().await;
+    if !reserve_rate_limit_slot(&mut table, &key, now, RATE_LIMIT_MAX_KEYS) {
+        // Table saturated with live windows: fail closed on the unseen key.
+        return Err(ApiError::too_many_requests("rate limit exceeded"));
+    }
+    let bucket = table.buckets.entry(key).or_insert(RateLimitBucket {
         window_start_unix_ms: now,
         count: 0,
+        window_ms,
     });
+    // Scope-stable by construction (each scope passes one window); refresh
+    // defensively so a changed literal takes effect without a restart.
+    bucket.window_ms = window_ms;
     if now.saturating_sub(bucket.window_start_unix_ms) > window_ms {
         bucket.window_start_unix_ms = now;
         bucket.count = 0;
@@ -1036,70 +1063,134 @@ pub(crate) async fn auth_login_finish(
 mod tests {
     use super::*;
 
-    fn bucket(window_start_unix_ms: u64) -> RateLimitBucket {
+    const HOUR_MS: u64 = 60 * 60_000;
+
+    fn bucket(window_start_unix_ms: u64, window_ms: u64) -> RateLimitBucket {
         RateLimitBucket {
             window_start_unix_ms,
             count: 1,
+            window_ms,
         }
     }
 
+    fn table_with(entries: Vec<(&str, RateLimitBucket)>) -> RateLimitTable {
+        let mut table = RateLimitTable::default();
+        for (key, bucket) in entries {
+            table.buckets.insert(key.to_string(), bucket);
+        }
+        table
+    }
+
     #[test]
-    fn rate_limit_prune_removes_only_universally_expired_windows() {
-        let now = RATE_LIMIT_WINDOW_MAX_MS * 3;
+    fn rate_limit_prune_judges_each_bucket_by_its_own_window() {
+        let now = HOUR_MS * 3;
         let mut buckets = HashMap::new();
-        buckets.insert("scope:fresh".to_string(), bucket(now));
-        buckets.insert(
-            "scope:edge".to_string(),
-            bucket(now - RATE_LIMIT_WINDOW_MAX_MS),
-        );
-        buckets.insert(
-            "scope:expired".to_string(),
-            bucket(now - RATE_LIMIT_WINDOW_MAX_MS - 1),
-        );
+        // 2 minutes old: dead for a 60s scope, alive for the hourly scope.
+        buckets.insert("short:1.1.1.1".to_string(), bucket(now - 120_000, 60_000));
+        buckets.insert("hourly:2.2.2.2".to_string(), bucket(now - 120_000, HOUR_MS));
+        // Exactly at its own bound is still live (strict `>` expiry).
+        buckets.insert("edge:3.3.3.3".to_string(), bucket(now - 60_000, 60_000));
         prune_rate_limits(&mut buckets, now);
-        assert!(buckets.contains_key("scope:fresh"));
         assert!(
-            buckets.contains_key("scope:edge"),
-            "a bucket exactly at the bound may still gate the hourly scope"
+            !buckets.contains_key("short:1.1.1.1"),
+            "expired by its own window despite being young globally"
         );
-        assert!(!buckets.contains_key("scope:expired"));
+        assert!(buckets.contains_key("hourly:2.2.2.2"));
+        assert!(buckets.contains_key("edge:3.3.3.3"));
     }
 
     #[test]
-    fn rate_limit_table_is_bounded_and_evicts_the_stalest_live_window() {
-        let now = RATE_LIMIT_WINDOW_MAX_MS * 3;
-        let mut buckets = HashMap::new();
-        // Saturate with live windows, one strictly stalest.
-        buckets.insert("scope:stalest".to_string(), bucket(now - 50_000));
-        for index in 0..3 {
-            buckets.insert(format!("scope:live-{index}"), bucket(now - 1_000));
-        }
-        reserve_rate_limit_slot(&mut buckets, "scope:new", now, 4);
-        assert_eq!(buckets.len(), 3, "one slot was reclaimed for the new key");
+    fn rate_limit_capacity_reclaims_expired_before_touching_live_buckets() {
+        let now = HOUR_MS * 3;
+        // At cap 3: one live hourly bucket + two short-window buckets that
+        // are dead by their own windows (the churn-attack shape).
+        let mut table = table_with(vec![
+            ("hourly:victim", bucket(now - 300_000, HOUR_MS)),
+            ("short:churn-1", bucket(now - 300_000, 60_000)),
+            ("short:churn-2", bucket(now - 300_000, 60_000)),
+        ]);
         assert!(
-            !buckets.contains_key("scope:stalest"),
-            "the bucket closest to expiring is the one evicted"
+            reserve_rate_limit_slot(&mut table, "hourly:newcomer", now, 3),
+            "expired churn is reclaimed"
         );
-
-        // An existing key never evicts anything.
-        let before = buckets.len();
-        reserve_rate_limit_slot(&mut buckets, "scope:live-0", now, 3);
-        assert_eq!(buckets.len(), before);
-
-        // Expired windows are reclaimed before any live eviction.
-        buckets.insert(
-            "scope:expired".to_string(),
-            bucket(now - RATE_LIMIT_WINDOW_MAX_MS - 1),
+        assert!(
+            table.buckets.contains_key("hourly:victim"),
+            "the active hourly bucket survives cap pressure from short-window churn"
         );
-        let live_before: Vec<String> = buckets
-            .keys()
-            .filter(|key| *key != "scope:expired")
-            .cloned()
-            .collect();
-        reserve_rate_limit_slot(&mut buckets, "scope:new-2", now, 4);
-        assert!(!buckets.contains_key("scope:expired"));
-        for key in live_before {
-            assert!(buckets.contains_key(&key), "{key} must survive");
+        assert!(!table.buckets.contains_key("short:churn-1"));
+        assert!(!table.buckets.contains_key("short:churn-2"));
+    }
+
+    #[test]
+    fn rate_limit_capacity_fails_closed_instead_of_evicting_live_buckets() {
+        let now = HOUR_MS * 3;
+        let mut table = table_with(vec![
+            ("hourly:a", bucket(now - 1_000, HOUR_MS)),
+            ("hourly:b", bucket(now - 2_000, HOUR_MS)),
+        ]);
+        assert!(
+            !reserve_rate_limit_slot(&mut table, "hourly:new", now, 2),
+            "a table full of live buckets rejects the new key"
+        );
+        assert_eq!(table.buckets.len(), 2, "no live bucket was evicted");
+        assert!(table.buckets.contains_key("hourly:a"));
+        assert!(table.buckets.contains_key("hourly:b"));
+        assert!(
+            reserve_rate_limit_slot(&mut table, "hourly:a", now, 2),
+            "existing keys always pass"
+        );
+    }
+
+    #[test]
+    fn rate_limit_saturated_prune_scans_are_amortized() {
+        let now = HOUR_MS * 3;
+        let mut table = table_with(vec![
+            ("hourly:live", bucket(now - 1_000, HOUR_MS)),
+            ("short:soon-dead", bucket(now - 30_000, 60_000)),
+        ]);
+        // First saturated insert prunes (nothing expired yet) and fails.
+        assert!(!reserve_rate_limit_slot(&mut table, "k:new", now, 2));
+        // The short bucket expires 30s later, but within the amortization
+        // interval the scan is skipped — the insert still fails closed.
+        // (Bounded staleness: at most one interval, trading scan cost.)
+        let later = now + 31_000;
+        table.last_saturated_prune_unix_ms = later - 500;
+        assert!(!reserve_rate_limit_slot(&mut table, "k:new", later, 2));
+        assert!(table.buckets.contains_key("short:soon-dead"));
+        // Past the interval the prune runs and the slot frees up.
+        table.last_saturated_prune_unix_ms = 0;
+        assert!(reserve_rate_limit_slot(&mut table, "k:new", later, 2));
+        assert!(!table.buckets.contains_key("short:soon-dead"));
+    }
+
+    #[test]
+    fn rate_keys_are_canonical_bounded_ip_tokens() {
+        fn key_for(value: Option<&str>) -> String {
+            let mut headers = HeaderMap::new();
+            if let Some(value) = value {
+                headers.insert("x-forwarded-for", value.parse().unwrap());
+            }
+            client_rate_key(&headers, "scope")
         }
+        assert_eq!(key_for(None), "scope:unknown");
+        assert_eq!(key_for(Some("203.0.113.9")), "scope:203.0.113.9");
+        // Textual IPv6 variants of one address share a bucket.
+        assert_eq!(
+            key_for(Some("2001:0db8:0000:0000:0000:0000:0000:0001")),
+            "scope:2001:db8::1"
+        );
+        assert_eq!(key_for(Some("2001:db8::1")), "scope:2001:db8::1");
+        // ip:port proxy forms resolve to the address.
+        assert_eq!(key_for(Some("203.0.113.9:5678")), "scope:203.0.113.9");
+        // Garbage collapses to one bounded bucket instead of minting an
+        // attacker-controlled arbitrary-length key.
+        let garbage = "x".repeat(4096);
+        assert_eq!(key_for(Some(garbage.as_str())), "scope:invalid");
+        assert_eq!(key_for(Some("not an ip, at all")), "scope:invalid");
+        // Only the first hop counts, as before.
+        assert_eq!(
+            key_for(Some("203.0.113.9, 198.51.100.7")),
+            "scope:203.0.113.9"
+        );
     }
 }

--- a/src/bin/connect/accounts.rs
+++ b/src/bin/connect/accounts.rs
@@ -507,12 +507,15 @@ pub(crate) fn header_string(headers: &HeaderMap, name: &'static str) -> Option<S
 /// Canonicalized, bounded source token for rate keys. The first forwarded
 /// hop is parsed as an IP address (accepting an `ip:port` form some proxies
 /// emit) and re-rendered canonically, so the key space is also byte-capped
-/// (≤45 chars). IPv6 sources aggregate by /64 prefix — one household/VM
-/// gets one bucket, and rotating addresses inside a /64 (free for any v6
-/// holder) stops minting fresh buckets; IPv4-mapped IPv6 folds to its IPv4
-/// form so `::ffff:203.0.113.9` and `203.0.113.9` share one budget. A
-/// present-but-unparseable value (zone-qualified link-local like
-/// `fe80::1%eth0` included — a link-local peer behind a proxy is not a
+/// (≤45 chars). IPv6 sources aggregate by /64 prefix: rotating addresses
+/// inside a /64 (free for any v6 holder) stops minting fresh buckets. The
+/// accepted collateral — analogous to IPv4 NAT sharing — is that everything
+/// behind one /64 shares each per-source budget: typically one household or
+/// VM, but a hosting subnet can pack MANY tenants into a single /64, and
+/// they then share e.g. the 30/hour new-identity budget. IPv4-mapped IPv6
+/// folds to its IPv4 form so `::ffff:203.0.113.9` and `203.0.113.9` share
+/// one budget. A present-but-unparseable value (zone-qualified link-local
+/// like `fe80::1%eth0` included — a link-local peer behind a proxy is not a
 /// meaningful source identity) collapses to one bounded "invalid" bucket
 /// instead of becoming an attacker-mintable arbitrary-length key; the
 /// absent-header fallback stays "unknown", unchanged.
@@ -575,15 +578,18 @@ pub(crate) fn client_observed_ip(headers: &HeaderMap) -> Option<String> {
 /// Per-scope key capacity, derived from the scope's window. Short windows
 /// (minutes) serve high-cardinality populations — every polling daemon,
 /// public log readers — and their buckets churn out within minutes, so the
-/// cap is generous. Long windows (≥10 min: the attest / subscribe budgets,
-/// the hourly new-daemon-identity budget) pin a slot for the whole window
-/// and serve small legitimate populations, so the cap is small. Worst-case
-/// total memory = scopes × cap × ~100B — a few MB with today's ~20 scopes.
+/// cap is generous (5k distinct sources per window is far beyond alpha
+/// traffic). Long windows (≥10 min: the attest / subscribe budgets, the
+/// hourly new-daemon-identity budget) pin a slot for the whole window and
+/// serve small legitimate populations, so the cap is small. Worst-case
+/// memory with today's ~27 scopes (21 short, 6 long): 21×5k + 6×2k ≈ 117k
+/// entries ≈ ~12 MB at ~100B/entry — the hard ceiling under full-spectrum
+/// key flooding, not a steady state.
 fn scope_capacity(window_ms: u64) -> usize {
     if window_ms >= 10 * 60_000 {
         2_000
     } else {
-        10_000
+        5_000
     }
 }
 

--- a/src/bin/connect/fleet.rs
+++ b/src/bin/connect/fleet.rs
@@ -123,11 +123,33 @@ pub(crate) async fn api_fleet_targets_sync(
         }
     }
     let mut store = state.store.lock().await;
-    let owned_daemon_ids = owned_daemon_ids(&store, user.id);
+    if merge_fleet_targets(&mut store, user.id, incoming) {
+        persist_locked(&state, &store)?;
+    }
+    let targets = fleet_targets_for_user(&state.config, &store, user.id);
+    Ok(Json(json!({
+        "ok": true,
+        "schema_version": 1,
+        "targets": targets,
+    })))
+}
+
+/// Merge one user's incoming (already normalized) targets over their stored
+/// partition. Returns whether the stored partition actually changed:
+/// `normalize_fleet_target_input` stamps `updated_unix_ms = now` on every
+/// input, so a content-identical re-sync (the dashboard pushes its whole
+/// list on a debounced dirty flag) would otherwise rewrite and re-persist
+/// the entire store on every push.
+pub(crate) fn merge_fleet_targets(
+    store: &mut Store,
+    user_id: Uuid,
+    incoming: Vec<FleetTargetRecord>,
+) -> bool {
+    let owned_daemon_ids = owned_daemon_ids(store, user_id);
     let mut by_host: HashMap<String, FleetTargetRecord> = store
         .fleet_targets
         .iter()
-        .filter(|target| target.user_id == user.id)
+        .filter(|target| target.user_id == user_id)
         .map(|target| {
             let mut target = target.clone();
             canonicalize_fleet_target_for_owned_daemon(&mut target, &owned_daemon_ids);
@@ -136,9 +158,8 @@ pub(crate) async fn api_fleet_targets_sync(
         .collect();
     for mut target in incoming {
         canonicalize_fleet_target_for_owned_daemon(&mut target, &owned_daemon_ids);
-        let previous = by_host.get(&target.host_id).cloned();
-        let first_seen_unix_ms = previous
-            .as_ref()
+        let first_seen_unix_ms = by_host
+            .get(&target.host_id)
             .map(|record| record.first_seen_unix_ms)
             .filter(|value| *value > 0)
             .unwrap_or(target.first_seen_unix_ms);
@@ -161,17 +182,48 @@ pub(crate) async fn api_fleet_targets_sync(
             .then_with(|| a.label.cmp(&b.label))
     });
     user_targets.truncate(FLEET_TARGET_LIMIT);
+    let unchanged = {
+        // Count rows (not deduped map entries): a legacy partition holding
+        // duplicate host rows must read as changed so the rewrite dedupes it.
+        let existing_rows = store
+            .fleet_targets
+            .iter()
+            .filter(|target| target.user_id == user_id)
+            .count();
+        let existing: HashMap<&str, &FleetTargetRecord> = store
+            .fleet_targets
+            .iter()
+            .filter(|target| target.user_id == user_id)
+            .map(|target| (target.host_id.as_str(), target))
+            .collect();
+        existing_rows == user_targets.len()
+            && user_targets.iter().all(|next| {
+                existing
+                    .get(next.host_id.as_str())
+                    .is_some_and(|previous| fleet_targets_equal_ignoring_updated(previous, next))
+            })
+    };
+    if unchanged {
+        return false;
+    }
     store
         .fleet_targets
-        .retain(|target| target.user_id != user.id);
+        .retain(|target| target.user_id != user_id);
     store.fleet_targets.extend(user_targets);
-    persist_locked(&state, &store)?;
-    let targets = fleet_targets_for_user(&state.config, &store, user.id);
-    Ok(Json(json!({
-        "ok": true,
-        "schema_version": 1,
-        "targets": targets,
-    })))
+    true
+}
+
+/// `updated_unix_ms` is stamped with the sync time on every normalized
+/// input, so no-op detection patches it out; the derived `PartialEq` keeps
+/// every OTHER field — including ones added later — in the comparison
+/// automatically.
+fn fleet_targets_equal_ignoring_updated(
+    previous: &FleetTargetRecord,
+    next: &FleetTargetRecord,
+) -> bool {
+    let mut next = next.clone();
+    next.updated_unix_ms = previous.updated_unix_ms;
+    *previous == next
 }
 
 pub(crate) async fn api_fleet_target_forget(
@@ -766,6 +818,131 @@ pub(crate) async fn api_vault_publish(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fleet_merge_skips_identical_resyncs_and_lands_real_changes() {
+        let user_id = Uuid::new_v4();
+        let mut store = Store::default();
+        let input = |now: u64| {
+            normalize_fleet_target_input(
+                user_id,
+                FleetTargetInput {
+                    id: "daemon-1".to_string(),
+                    host_id: "daemon-1".to_string(),
+                    label: "Anchor box".to_string(),
+                    first_seen_unix_ms: 1_700_000_000_000,
+                    last_seen_unix_ms: 1_700_000_000_000,
+                    ..Default::default()
+                },
+                now,
+            )
+            .expect("record normalizes")
+        };
+
+        assert!(
+            merge_fleet_targets(&mut store, user_id, vec![input(1_800_000_000_000)]),
+            "first sync stores the record"
+        );
+        let stored_updated = store.fleet_targets[0].updated_unix_ms;
+
+        // Identical content re-synced later: normalize stamps a fresh
+        // updated_unix_ms, but nothing else differs — no store rewrite.
+        assert!(
+            !merge_fleet_targets(&mut store, user_id, vec![input(1_800_000_060_000)]),
+            "content-identical resync is a no-op"
+        );
+        assert_eq!(
+            store.fleet_targets[0].updated_unix_ms, stored_updated,
+            "stored record untouched by the no-op"
+        );
+
+        // A real change lands (and refreshes the stamp).
+        let mut renamed = input(1_800_000_120_000);
+        renamed.label = "Renamed box".to_string();
+        assert!(merge_fleet_targets(&mut store, user_id, vec![renamed]));
+        assert_eq!(store.fleet_targets[0].label, "Renamed box");
+
+        // A new host is a change even when existing rows are identical.
+        let mut second = input(1_800_000_180_000);
+        second.host_id = "daemon-2".to_string();
+        second.id = "daemon-2".to_string();
+        assert!(merge_fleet_targets(&mut store, user_id, vec![second]));
+        assert_eq!(store.fleet_targets.len(), 2);
+
+        // Another user's identical push never reads as this user's no-op.
+        let other_user = Uuid::new_v4();
+        assert!(merge_fleet_targets(
+            &mut store,
+            other_user,
+            vec![normalize_fleet_target_input(
+                other_user,
+                FleetTargetInput {
+                    id: "daemon-1".to_string(),
+                    host_id: "daemon-1".to_string(),
+                    ..Default::default()
+                },
+                1_800_000_240_000,
+            )
+            .unwrap()],
+        ));
+        assert_eq!(store.fleet_targets.len(), 3);
+    }
+
+    #[test]
+    fn fleet_merge_no_op_detection_survives_owned_daemon_canonicalization() {
+        let user_id = Uuid::new_v4();
+        let mut store = Store::default();
+        store.daemons.push(DaemonRecord {
+            daemon_id: "owned-daemon".to_string(),
+            label: None,
+            daemon_public_key: "key".to_string(),
+            owner_user_id: Some(user_id),
+            claim_code_hash: None,
+            claim_code_created_unix_ms: None,
+            last_registration_proof_unix_ms: None,
+            route_link_revision: 0,
+            last_unclaim_proof_unix_ms: None,
+            registered_unix_ms: 1,
+            last_seen_unix_ms: 1,
+            updated_unix_ms: 1,
+            presence_hours: Vec::new(),
+        });
+        let input = |now: u64| {
+            normalize_fleet_target_input(
+                user_id,
+                FleetTargetInput {
+                    id: "browser-alias".to_string(),
+                    host_id: "browser-alias".to_string(),
+                    connect_daemon_id: "owned-daemon".to_string(),
+                    record_key: "PubKeyB64u".to_string(),
+                    record_sig: "SigB64u".to_string(),
+                    record_signed_at_unix_ms: 1_700_000_000_000,
+                    first_seen_unix_ms: 1_700_000_000_000,
+                    last_seen_unix_ms: 1_700_000_000_000,
+                    ..Default::default()
+                },
+                now,
+            )
+            .expect("record normalizes")
+        };
+        assert!(merge_fleet_targets(
+            &mut store,
+            user_id,
+            vec![input(1_800_000_000_000)]
+        ));
+        assert_eq!(
+            store.fleet_targets[0].host_id, "owned-daemon",
+            "stored under the canonical daemon id"
+        );
+        assert!(
+            store.fleet_targets[0].record_sig.is_empty(),
+            "rewritten host drops the now-unverifiable signature"
+        );
+        assert!(
+            !merge_fleet_targets(&mut store, user_id, vec![input(1_800_000_060_000)]),
+            "the same alias re-synced canonicalizes to the stored record"
+        );
+    }
 
     #[test]
     fn fleet_sync_round_trips_record_signatures() {

--- a/src/bin/connect/main.rs
+++ b/src/bin/connect/main.rs
@@ -147,11 +147,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         daemon_sessions: Mutex::new(HashMap::new()),
         rate_limits: Mutex::new(HashMap::new()),
         active_sessions: Mutex::new(HashMap::new()),
+        store_dirty: StoreDirty::default(),
+        log_caches: std::sync::Mutex::new(LogCaches::default()),
+        static_pages: StaticPages::render(&config),
         dns_zone,
     });
 
     tokio::spawn(presence_alert_monitor(state.clone()));
     tokio::spawn(handle_reclaim_monitor(state.clone()));
+    tokio::spawn(store_flush_monitor(state.clone()));
+    tokio::spawn(in_memory_state_sweeper(state.clone()));
     if let (Some(zone), Some(listen)) = (state.dns_zone.clone(), state.config.dns_listen) {
         // Fail startup on an unbindable DNS listener (privileges, port
         // in use); afterwards the server runs until process exit.
@@ -525,6 +530,17 @@ struct AppState {
     daemon_sessions: Mutex<HashMap<String, DaemonSessionCredential>>,
     rate_limits: Mutex<HashMap<String, RateLimitBucket>>,
     active_sessions: Mutex<HashMap<String, ActiveDashboardSession>>,
+    /// Dirty flag + wakeup for the debounced store flusher: hot paths that
+    /// only refresh presence-grade fields mark instead of persisting.
+    store_dirty: StoreDirty,
+    /// Derived read caches over the append-only transparency log
+    /// (transparency.rs). std Mutex: held only for short synchronous
+    /// extends, never across an await.
+    log_caches: std::sync::Mutex<LogCaches>,
+    /// Startup-rendered static pages (ui.rs): pure functions of the public
+    /// origin, served as shared bytes with ETag revalidation instead of
+    /// re-rendered per hit.
+    static_pages: StaticPages,
     vapid: ring::signature::EcdsaKeyPair,
     log_key: ring::signature::EcdsaKeyPair,
     push_http: reqwest::Client,
@@ -558,6 +574,7 @@ fn production_router_test_state(root: &Path, mut store: Store) -> Arc<AppState> 
         .strict_base64(true);
     let vapid = load_or_create_vapid_keypair(&mut store).unwrap();
     let log_key = load_or_create_log_keypair(&mut store).unwrap();
+    let static_pages = StaticPages::render(&config);
     Arc::new(AppState {
         config,
         webauthn,
@@ -572,6 +589,9 @@ fn production_router_test_state(root: &Path, mut store: Store) -> Arc<AppState> 
         daemon_sessions: Mutex::new(HashMap::new()),
         rate_limits: Mutex::new(HashMap::new()),
         active_sessions: Mutex::new(HashMap::new()),
+        store_dirty: StoreDirty::default(),
+        log_caches: std::sync::Mutex::new(LogCaches::default()),
+        static_pages,
         vapid,
         log_key,
         push_http: reqwest::Client::new(),
@@ -876,7 +896,7 @@ fn record_presence_hour(hours: &mut Vec<u64>, now_unix_ms: u64) -> bool {
     true
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 struct FleetTargetRecord {
     user_id: Uuid,
     id: String,
@@ -1102,8 +1122,20 @@ fn load_store(path: &Path) -> Result<Store, String> {
     }
 }
 
+/// Serialize the store for disk. Compact JSON: the file is machine-read
+/// (serde ignores whitespace in both directions, so state files written by
+/// older pretty-printing builds load unchanged and older builds read compact
+/// files), and pretty printing roughly doubled the bytes of a file that is
+/// rewritten in full on every persist.
+fn serialize_store(store: &Store) -> Result<Vec<u8>, String> {
+    serde_json::to_vec(store).map_err(|e| format!("serialize state: {e}"))
+}
+
 fn save_store(path: &Path, store: &Store) -> Result<(), String> {
-    let bytes = serde_json::to_vec_pretty(store).map_err(|e| format!("serialize state: {e}"))?;
+    write_store_bytes(path, &serialize_store(store)?)
+}
+
+fn write_store_bytes(path: &Path, bytes: &[u8]) -> Result<(), String> {
     let parent = path
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
@@ -1115,18 +1147,179 @@ fn save_store(path: &Path, store: &Store) -> Result<(), String> {
         .suffix(".tmp")
         .tempfile_in(parent)
         .map_err(|e| format!("create Connect state tempfile in {}: {e}", parent.display()))?;
-    tmp.write_all(&bytes)
+    tmp.write_all(bytes)
         .map_err(|e| format!("write Connect state tempfile {}: {e}", tmp.path().display()))?;
     tmp.as_file_mut()
         .sync_all()
         .map_err(|e| format!("sync Connect state tempfile {}: {e}", tmp.path().display()))?;
     tmp.persist(path)
         .map_err(|e| format!("replace Connect state {}: {}", path.display(), e.error))?;
+    fsync_parent_dir(parent)
+}
+
+/// fsync the directory entry so the rename that just published the new state
+/// file is itself durable — without it, a crash right after the rename can
+/// roll the whole replacement back on some filesystems. Directories are not
+/// open-and-fsync-able on Windows; there the pre-rename file sync plus the
+/// atomic ReplaceFile stand alone.
+fn fsync_parent_dir(parent: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        std::fs::File::open(parent)
+            .and_then(|dir| dir.sync_all())
+            .map_err(|e| format!("sync Connect state dir {}: {e}", parent.display()))?;
+    }
+    #[cfg(not(unix))]
+    let _ = parent;
     Ok(())
 }
 
+/// Persist the current store synchronously, before the caller's response.
+/// Callers hold the store lock, so the bytes are a consistent snapshot and
+/// the write covers anything the debounced flusher had pending — hence the
+/// dirty flag is cleared on success (marks only ever happen under the same
+/// lock, so none can slip between the write and the clear).
 fn persist_locked(state: &AppState, store: &Store) -> ApiResult<()> {
-    save_store(&state.config.data_file, store).map_err(ApiError::internal)
+    save_store(&state.config.data_file, store).map_err(ApiError::internal)?;
+    state.store_dirty.clear();
+    Ok(())
+}
+
+/// Debounced-persistence signal. Hot paths whose mutations tolerate a
+/// bounded loss window (presence refreshes: `last_seen`, presence hours, the
+/// registration-proof watermark) `mark` instead of persisting;
+/// `store_flush_monitor` coalesces the marks into one full-store write per
+/// debounce window. Critical mutations keep their synchronous
+/// `persist_locked` path unchanged.
+#[derive(Default)]
+struct StoreDirty {
+    dirty: std::sync::atomic::AtomicBool,
+    notify: Notify,
+}
+
+impl StoreDirty {
+    fn mark(&self) {
+        self.dirty.store(true, std::sync::atomic::Ordering::Release);
+        self.notify.notify_one();
+    }
+
+    fn clear(&self) {
+        self.dirty
+            .store(false, std::sync::atomic::Ordering::Release);
+    }
+
+    fn take(&self) -> bool {
+        self.dirty.swap(false, std::sync::atomic::Ordering::AcqRel)
+    }
+}
+
+/// Mark the store dirty for the debounced flusher. MUST be called while
+/// holding the store lock: the mark records a mutation just made under that
+/// lock, and the lock is also what orders marks against `persist_locked`'s
+/// clear-on-success.
+fn mark_store_dirty(state: &AppState) {
+    state.store_dirty.mark();
+}
+
+/// Upper bound on how much presence-grade mutation a crash can lose, and the
+/// whole-service write cadence under steady daemon polling: one coalesced
+/// write per window instead of several fsynced full-store rewrites per
+/// daemon-minute.
+const STORE_FLUSH_DEBOUNCE: Duration = Duration::from_secs(60);
+
+async fn store_flush_monitor(state: Arc<AppState>) {
+    store_flush_monitor_with(state, STORE_FLUSH_DEBOUNCE).await;
+}
+
+/// Debounce-loop body, with the window injectable so tests need not wait the
+/// production 60s. The write happens with the store lock HELD (like every
+/// synchronous persist): a single writer ordering means the file can never
+/// regress to an older snapshot written late. `spawn_blocking` keeps the
+/// blocking file I/O off the async workers; store waiters queue exactly as
+/// they do for a synchronous persist today, once per window instead of per
+/// request.
+async fn store_flush_monitor_with(state: Arc<AppState>, debounce: Duration) {
+    loop {
+        state.store_dirty.notify.notified().await;
+        tokio::time::sleep(debounce).await;
+        let store = state.store.lock().await;
+        if !state.store_dirty.take() {
+            // A synchronous persist already covered the mark.
+            continue;
+        }
+        let bytes = match serialize_store(&store) {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                eprintln!("[connect] debounced store flush serialize failed: {err}");
+                continue;
+            }
+        };
+        let path = state.config.data_file.clone();
+        match tokio::task::spawn_blocking(move || write_store_bytes(&path, &bytes)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                eprintln!("[connect] debounced store flush failed (will retry): {err}");
+                // The mutations are still memory-only: re-mark so the next
+                // window retries even without new activity.
+                state.store_dirty.mark();
+            }
+            Err(err) => eprintln!("[connect] debounced store flush task failed: {err}"),
+        }
+        drop(store);
+    }
+}
+
+/// How long a resolved (approved / rejected / timed-out) claim stays
+/// queryable by the polling browser before the sweeper drops it. Claims
+/// resolve or time out within `CLAIM_TIMEOUT_MS` and the claiming page polls
+/// every second or two, so this is generous observation headroom.
+const PENDING_CLAIM_RETENTION_MS: u64 = 15 * 60 * 1000;
+const IN_MEMORY_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Periodic expiry sweep across the in-memory tables, none of which
+/// otherwise remove entries except opportunistically (an expired session was
+/// only dropped when its exact token was re-presented; abandoned WebAuthn
+/// flows, resolved claims, and expired rate windows never were). Every rule
+/// removes only entries already dead to their consumers, so the sweep never
+/// changes what any live request observes.
+async fn in_memory_state_sweeper(state: Arc<AppState>) {
+    loop {
+        tokio::time::sleep(IN_MEMORY_SWEEP_INTERVAL).await;
+        sweep_in_memory_state(&state).await;
+    }
+}
+
+async fn sweep_in_memory_state(state: &AppState) {
+    let now = now_unix_ms();
+    state
+        .sessions
+        .lock()
+        .await
+        .retain(|_, session| session.expires_unix_ms > now);
+    state
+        .pending_registrations
+        .lock()
+        .await
+        .retain(|_, pending| pending.expires_unix_ms > now);
+    state
+        .pending_authentications
+        .lock()
+        .await
+        .retain(|_, pending| pending.expires_unix_ms > now);
+    state
+        .pending_claims
+        .lock()
+        .await
+        .retain(|_, claim| now.saturating_sub(claim.created_unix_ms) <= PENDING_CLAIM_RETENTION_MS);
+    state
+        .daemon_sessions
+        .lock()
+        .await
+        .retain(|_, session| session.expires_unix_ms > now);
+    state.active_sessions.lock().await.retain(|_, session| {
+        now.saturating_sub(session.created_unix_ms) <= ACTIVE_DASHBOARD_SESSION_TTL_MS
+    });
+    prune_rate_limits(&mut *state.rate_limits.lock().await, now);
 }
 
 /// Apply a durable store mutation transactionally: serialize/write the cloned
@@ -1360,5 +1553,204 @@ mod tests {
         }
         assert_eq!(hours.len(), PRESENCE_HOURS_KEPT);
         assert_eq!(*hours.last().unwrap(), 209);
+    }
+
+    fn store_with_marker() -> Store {
+        let mut store = Store::default();
+        store.users.push(UserRecord {
+            id: Uuid::new_v4(),
+            account_name: "alice".to_string(),
+            display_name: "Alice".to_string(),
+            passkeys: Vec::new(),
+            created_unix_ms: 1,
+            updated_unix_ms: 2,
+            last_login_unix_ms: 3,
+            attestations: Vec::new(),
+        });
+        append_log_entry(&mut store, "account_created", json!({ "handle": "alice" }));
+        store
+    }
+
+    /// The deployed instance's state file was written pretty-printed; the
+    /// compact writer and the pretty reader must both round-trip it, so a
+    /// binary from either side of the transition loads the other's file.
+    #[test]
+    fn store_format_is_forward_and_backward_compatible_across_compaction() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store_with_marker();
+
+        // Legacy pretty file (what the deployed build wrote) loads cleanly.
+        let legacy = dir.path().join("legacy.json");
+        std::fs::write(&legacy, serde_json::to_vec_pretty(&store).unwrap()).unwrap();
+        let loaded_legacy = load_store(&legacy).unwrap();
+        assert_eq!(
+            serde_json::to_value(&loaded_legacy).unwrap(),
+            serde_json::to_value(&store).unwrap()
+        );
+
+        // The compact writer round-trips, and its bytes stay valid JSON an
+        // older (pretty-writing) serde build parses identically.
+        let compact = dir.path().join("state.json");
+        save_store(&compact, &store).unwrap();
+        let loaded_compact = load_store(&compact).unwrap();
+        assert_eq!(
+            serde_json::to_value(&loaded_compact).unwrap(),
+            serde_json::to_value(&store).unwrap()
+        );
+    }
+
+    #[test]
+    fn store_dirty_marks_take_once_and_clear() {
+        let dirty = StoreDirty::default();
+        assert!(!dirty.take(), "starts clean");
+        dirty.mark();
+        assert!(dirty.take(), "mark is observable");
+        assert!(!dirty.take(), "take consumes the mark");
+        dirty.mark();
+        dirty.clear();
+        assert!(!dirty.take(), "a synchronous persist clears pending marks");
+    }
+
+    #[tokio::test]
+    async fn persist_locked_clears_the_debounce_mark() {
+        let root = tempfile::tempdir().unwrap();
+        let state = production_router_test_state(root.path(), store_with_marker());
+        let store = state.store.lock().await;
+        mark_store_dirty(&state);
+        persist_locked(&state, &store).unwrap();
+        assert!(
+            !state.store_dirty.take(),
+            "successful sync persist covers pending marks"
+        );
+        let on_disk = load_store(&state.config.data_file).unwrap();
+        assert_eq!(on_disk.users.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn store_flush_monitor_writes_marked_state_once_debounced() {
+        let root = tempfile::tempdir().unwrap();
+        let state = production_router_test_state(root.path(), store_with_marker());
+        tokio::spawn(store_flush_monitor_with(
+            state.clone(),
+            Duration::from_millis(10),
+        ));
+        {
+            let mut store = state.store.lock().await;
+            store.daemons.push(DaemonRecord {
+                daemon_id: "daemon-flush".to_string(),
+                label: None,
+                daemon_public_key: "key".to_string(),
+                owner_user_id: None,
+                claim_code_hash: None,
+                claim_code_created_unix_ms: None,
+                last_registration_proof_unix_ms: None,
+                route_link_revision: 0,
+                last_unclaim_proof_unix_ms: None,
+                registered_unix_ms: 1,
+                last_seen_unix_ms: 1,
+                updated_unix_ms: 1,
+                presence_hours: Vec::new(),
+            });
+            mark_store_dirty(&state);
+        }
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Ok(on_disk) = load_store(&state.config.data_file) {
+                if on_disk
+                    .daemons
+                    .iter()
+                    .any(|d| d.daemon_id == "daemon-flush")
+                {
+                    break;
+                }
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "debounced flush never reached disk"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            !state.store_dirty.take(),
+            "flusher consumed the mark it wrote"
+        );
+    }
+
+    #[tokio::test]
+    async fn sweeper_drops_only_entries_dead_to_their_consumers() {
+        let root = tempfile::tempdir().unwrap();
+        let state = production_router_test_state(root.path(), Store::default());
+        let now = now_unix_ms();
+        {
+            let mut sessions = state.sessions.lock().await;
+            sessions.insert(
+                "live".to_string(),
+                SessionRecord {
+                    user_id: Uuid::new_v4(),
+                    csrf_token: "c".to_string(),
+                    expires_unix_ms: now + 60_000,
+                },
+            );
+            sessions.insert(
+                "expired".to_string(),
+                SessionRecord {
+                    user_id: Uuid::new_v4(),
+                    csrf_token: "c".to_string(),
+                    expires_unix_ms: now - 1,
+                },
+            );
+        }
+        {
+            let mut claims = state.pending_claims.lock().await;
+            let claim = PendingClaim {
+                user_id: Uuid::new_v4(),
+                account_name: "alice".to_string(),
+                daemon_id: "daemon-1".to_string(),
+                daemon_public_key: "key".to_string(),
+                challenge: "ch".to_string(),
+                created_unix_ms: now,
+                claim_code_hash: "h".to_string(),
+                claim_code_created_unix_ms: now,
+                status: ClaimStatus::Pending,
+            };
+            claims.insert("fresh".to_string(), claim.clone());
+            claims.insert(
+                "ancient".to_string(),
+                PendingClaim {
+                    created_unix_ms: now - PENDING_CLAIM_RETENTION_MS - 1,
+                    ..claim
+                },
+            );
+        }
+        {
+            let mut limits = state.rate_limits.lock().await;
+            limits.insert(
+                "scope:1.2.3.4".to_string(),
+                RateLimitBucket {
+                    window_start_unix_ms: now,
+                    count: 3,
+                },
+            );
+            limits.insert(
+                "scope:5.6.7.8".to_string(),
+                RateLimitBucket {
+                    window_start_unix_ms: now - RATE_LIMIT_WINDOW_MAX_MS - 1,
+                    count: 900,
+                },
+            );
+        }
+        sweep_in_memory_state(&state).await;
+        let sessions = state.sessions.lock().await;
+        assert!(sessions.contains_key("live"));
+        assert!(!sessions.contains_key("expired"));
+        let claims = state.pending_claims.lock().await;
+        assert!(claims.contains_key("fresh"));
+        assert!(!claims.contains_key("ancient"));
+        let limits = state.rate_limits.lock().await;
+        assert!(limits.contains_key("scope:1.2.3.4"));
+        assert!(
+            !limits.contains_key("scope:5.6.7.8"),
+            "buckets past every window are expired for every scope"
+        );
     }
 }

--- a/src/bin/connect/main.rs
+++ b/src/bin/connect/main.rs
@@ -180,12 +180,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.listen, config.public_origin, config.rp_id
     );
     eprintln!("[connect] state file {}", config.data_file.display());
-    // Graceful shutdown with a BOUNDED drain: `with_graceful_shutdown` alone
-    // waits for every in-flight request (only the daemon long-poll caps
-    // itself at 30s — one slow POST would hold the drain until the
-    // supervisor SIGKILLs, killing the final flush below). After the signal
-    // plus the grace window, the serve future is dropped, aborting whatever
-    // is still in flight.
+    // Bounded graceful shutdown, in the only order that is actually sound:
+    // every REQUEST is deadline-bounded (the REQUEST_TIMEOUT layer inside
+    // `connect_router`; the daemon long-poll self-caps below it), and the
+    // graceful drain WAITS for those bounded requests — axum spawns each
+    // connection as a detached task, so dropping the serve future would
+    // abandon rather than abort them, and a straggler could mutate the
+    // store after a premature flush. Serve returns once accepting stopped
+    // AND all connections finished; the final flush below therefore runs
+    // provably after every handler mutation.
     let (shutdown_seen_tx, shutdown_seen_rx) = oneshot::channel::<()>();
     let serve = std::future::IntoFuture::into_future(
         axum::serve(listener, app).with_graceful_shutdown(async move {
@@ -199,17 +202,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         _ = async {
             // Only starts counting once the shutdown signal actually fired.
             let _ = shutdown_seen_rx.await;
-            tokio::time::sleep(SHUTDOWN_DRAIN_GRACE).await;
+            tokio::time::sleep(SHUTDOWN_FLUSH_DEADLINE).await;
         } => {
+            // Should be unreachable: requests are deadline-bounded, so the
+            // drain is too. If the drain wedges anyway, flushing now (with
+            // stragglers conceivably still running) beats letting the
+            // supervisor SIGKILL us with the dirty window unwritten.
             eprintln!(
-                "[connect] graceful drain exceeded {}s; aborting in-flight requests",
-                SHUTDOWN_DRAIN_GRACE.as_secs()
+                "[connect] drain still running {}s after the shutdown signal; flushing state anyway",
+                SHUTDOWN_FLUSH_DEADLINE.as_secs()
             );
             Ok(())
         }
     };
-    // The final flush runs on EVERY exit path — clean drain, bounded-drain
-    // abort, or a serve error — before the error (if any) propagates.
+    // The final flush runs on EVERY exit path — clean drain, wedged-drain
+    // deadline, or a serve error — before the error (if any) propagates.
     // Without it, every restart would discard the pending debounce window
     // (a daemon that went offline during it would permanently lose its last
     // presence hours).
@@ -218,11 +225,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-/// How long in-flight requests may drain after the shutdown signal before
-/// they are aborted. Below typical supervisor stop timeouts, so the final
-/// store flush always gets to run; overrunning requests (the 30s-max daemon
-/// long-poll included) are dropped — daemons and browsers retry.
-const SHUTDOWN_DRAIN_GRACE: Duration = Duration::from_secs(25);
+/// Deadline for every HTTP request (`connect_router` applies it to the whole
+/// surface). Every handler is fast except the daemon long-poll, which
+/// self-caps at 15s — comfortably inside this bound — so the deadline only
+/// ever fires on a genuinely wedged request. It is also what bounds the
+/// graceful-shutdown drain.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Paranoid backstop for the shutdown drain: requests are bounded by
+/// `REQUEST_TIMEOUT`, so the drain should always finish well inside this.
+/// If it somehow does not, the final flush runs anyway (logged) rather than
+/// letting the supervisor's SIGKILL discard the pending debounce window.
+/// Below typical supervisor stop timeouts.
+const SHUTDOWN_FLUSH_DEADLINE: Duration = Duration::from_secs(40);
 
 /// Resolves on SIGTERM (what systemd/deploy tooling sends) or ctrl-c. A
 /// failed handler registration degrades to the OTHER signal staying live:
@@ -275,7 +290,7 @@ async fn final_store_flush(state: &AppState) {
 /// this same constructor so a new route or fallback cannot bypass the hosted
 /// static/control cutoff without changing the exercised router.
 fn connect_router(state: Arc<AppState>) -> Router {
-    Router::new()
+    let router = Router::new()
         .route("/", get(landing_ui))
         .route("/connect", get(connect_ui))
         .route("/access", get(access_ui))
@@ -370,7 +385,32 @@ fn connect_router(state: Arc<AppState>) -> Router {
         .route("/api/browser/ice", post(browser_ice))
         .route("/api/browser/close", post(browser_close))
         .fallback(not_found)
-        .with_state(state)
+        .with_state(state);
+    // Global request deadline: no request may outlive REQUEST_TIMEOUT, which
+    // is what makes the graceful-shutdown drain bounded (main). Applied to
+    // the whole surface, fallback included, so tests that exercise this
+    // router exercise the deadline too.
+    with_request_timeout(router, REQUEST_TIMEOUT)
+}
+
+/// Wrap a router so every request is answered within `timeout`, with 408 on
+/// expiry. The handler future is dropped at an await point on timeout; every
+/// store mutation in this binary is awaitpoint-free from first write through
+/// its mark/persist (locks are acquired before, I/O helpers are synchronous),
+/// so cancellation can never publish a half-applied mutation.
+fn with_request_timeout(router: Router, timeout: Duration) -> Router {
+    router.layer(axum::middleware::from_fn(
+        move |request: axum::extract::Request, next: axum::middleware::Next| async move {
+            match tokio::time::timeout(timeout, next.run(request)).await {
+                Ok(response) => response,
+                Err(_) => (
+                    StatusCode::REQUEST_TIMEOUT,
+                    Json(json!({ "ok": false, "error": "request timed out" })),
+                )
+                    .into_response(),
+            }
+        },
+    ))
 }
 
 #[derive(Debug, Clone)]
@@ -1812,6 +1852,123 @@ mod tests {
         assert!(
             !state.store_dirty.take(),
             "flusher consumed the mark it wrote"
+        );
+    }
+
+    /// The request deadline is what bounds the shutdown drain: a handler
+    /// that outlives it is answered 408 (its future dropped at an await
+    /// point), so no request can hold the drain open indefinitely.
+    #[tokio::test]
+    async fn request_timeout_answers_408_for_overrunning_handlers() {
+        let app = with_request_timeout(
+            Router::new().route(
+                "/slow",
+                get(|| async {
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    "done"
+                }),
+            ),
+            Duration::from_millis(50),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let response = reqwest::get(format!("http://{address}/slow"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+        server.abort();
+    }
+
+    /// The R3 drain contract, end to end on the production router: axum
+    /// spawns connections as detached tasks, so the shutdown path must WAIT
+    /// for (deadline-bounded) requests rather than drop the serve future —
+    /// otherwise a straggler could mutate the store after the final flush.
+    /// A parked daemon long-poll (which touches presence and marks the
+    /// dirty flag before parking) spans the shutdown signal; serve returns
+    /// only after it completes, the flush runs after serve, and the store
+    /// on disk equals memory at exit.
+    #[tokio::test]
+    async fn shutdown_waits_for_bounded_requests_then_flushes() {
+        let root = tempfile::tempdir().unwrap();
+        let state = production_router_test_state(root.path(), Store::default());
+        {
+            let mut store = state.store.lock().await;
+            store.daemons.push(DaemonRecord {
+                daemon_id: "daemon-drain".to_string(),
+                label: None,
+                daemon_public_key: "key".to_string(),
+                owner_user_id: None,
+                claim_code_hash: None,
+                claim_code_created_unix_ms: None,
+                last_registration_proof_unix_ms: None,
+                route_link_revision: 0,
+                last_unclaim_proof_unix_ms: None,
+                registered_unix_ms: 1,
+                last_seen_unix_ms: 1,
+                updated_unix_ms: 1,
+                presence_hours: Vec::new(),
+            });
+        }
+        state.daemon_sessions.lock().await.insert(
+            "daemon-drain".to_string(),
+            DaemonSessionCredential {
+                token: "drain-token".to_string(),
+                expires_unix_ms: now_unix_ms() + 60_000,
+            },
+        );
+        let app = connect_router(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let server = tokio::spawn({
+            let state = state.clone();
+            async move {
+                axum::serve(listener, app)
+                    .with_graceful_shutdown(async move {
+                        let _ = shutdown_rx.await;
+                    })
+                    .await
+                    .unwrap();
+                // main()'s sequence: the flush runs after serve returned,
+                // i.e. after every connection finished.
+                final_store_flush(&state).await;
+            }
+        });
+        let poll = tokio::spawn(async move {
+            reqwest::Client::new()
+                .get(format!(
+                    "http://{address}/api/daemon/next?daemon_id=daemon-drain&timeout_ms=1500"
+                ))
+                .header(DAEMON_SESSION_HEADER, "drain-token")
+                .send()
+                .await
+        });
+        // Let the poll park (its presence touch + dirty mark already ran),
+        // then signal shutdown mid-park.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let _ = shutdown_tx.send(());
+        let response = poll.await.unwrap().unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::NO_CONTENT,
+            "the parked poll completed naturally inside the drain"
+        );
+        server.await.unwrap();
+        let disk = load_store(&state.config.data_file).unwrap();
+        let memory = state.store.lock().await;
+        assert_eq!(
+            serde_json::to_value(&disk).unwrap(),
+            serde_json::to_value(&*memory).unwrap(),
+            "store on disk equals memory at exit"
+        );
+        assert!(
+            disk.daemons[0].last_seen_unix_ms > 1,
+            "the in-flight request's mutation was flushed, not lost"
+        );
+        assert!(
+            !state.store_dirty.take(),
+            "no un-flushed mark survives shutdown"
         );
     }
 

--- a/src/bin/connect/main.rs
+++ b/src/bin/connect/main.rs
@@ -145,7 +145,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         event_queues: Mutex::new(HashMap::new()),
         event_notify: Notify::new(),
         daemon_sessions: Mutex::new(HashMap::new()),
-        rate_limits: Mutex::new(HashMap::new()),
+        rate_limits: Mutex::new(RateLimitTable::default()),
         active_sessions: Mutex::new(HashMap::new()),
         store_dirty: StoreDirty::default(),
         log_caches: std::sync::Mutex::new(LogCaches::default()),
@@ -172,7 +172,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
     }
 
-    let app = connect_router(state);
+    let app = connect_router(state.clone());
 
     let listener = tokio::net::TcpListener::bind(config.listen).await?;
     eprintln!(
@@ -180,8 +180,64 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.listen, config.public_origin, config.rp_id
     );
     eprintln!("[connect] state file {}", config.data_file.display());
-    axum::serve(listener, app).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+    // Deploy-time restarts land here: without a final flush, every restart
+    // would discard the pending debounce window (a daemon that went offline
+    // during it would permanently lose its last presence hours).
+    final_store_flush(&state).await;
     Ok(())
+}
+
+/// Resolves on SIGTERM (what systemd/deploy tooling sends) or ctrl-c. A
+/// failed signal-handler registration degrades to the other signal rather
+/// than aborting startup.
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut sigterm) => {
+                tokio::select! {
+                    _ = sigterm.recv() => {}
+                    result = tokio::signal::ctrl_c() => {
+                        if let Err(err) = result {
+                            eprintln!("[connect] ctrl-c handler failed: {err}");
+                            std::future::pending::<()>().await;
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                eprintln!("[connect] SIGTERM handler registration failed: {err}");
+                if let Err(err) = tokio::signal::ctrl_c().await {
+                    eprintln!("[connect] ctrl-c handler failed: {err}");
+                    std::future::pending::<()>().await;
+                }
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        if let Err(err) = tokio::signal::ctrl_c().await {
+            eprintln!("[connect] ctrl-c handler failed: {err}");
+            std::future::pending::<()>().await;
+        }
+    }
+}
+
+/// Synchronously flush any pending debounced marks; called once after the
+/// server drains on shutdown. Failure re-marks for invariant uniformity
+/// (the process is exiting, but the flag state stays truthful).
+async fn final_store_flush(state: &AppState) {
+    let store = state.store.lock().await;
+    if !state.store_dirty.take() {
+        return;
+    }
+    if let Err(err) = save_store(&state.config.data_file, &store) {
+        eprintln!("[connect] final store flush failed: {err}");
+        state.store_dirty.mark();
+    }
 }
 
 /// The complete production HTTP surface. Startup and route-boundary tests use
@@ -528,7 +584,7 @@ struct AppState {
     event_queues: Mutex<HashMap<String, VecDeque<RendezvousEvent>>>,
     event_notify: Notify,
     daemon_sessions: Mutex<HashMap<String, DaemonSessionCredential>>,
-    rate_limits: Mutex<HashMap<String, RateLimitBucket>>,
+    rate_limits: Mutex<RateLimitTable>,
     active_sessions: Mutex<HashMap<String, ActiveDashboardSession>>,
     /// Dirty flag + wakeup for the debounced store flusher: hot paths that
     /// only refresh presence-grade fields mark instead of persisting.
@@ -587,7 +643,7 @@ fn production_router_test_state(root: &Path, mut store: Store) -> Arc<AppState> 
         event_queues: Mutex::new(HashMap::new()),
         event_notify: Notify::new(),
         daemon_sessions: Mutex::new(HashMap::new()),
-        rate_limits: Mutex::new(HashMap::new()),
+        rate_limits: Mutex::new(RateLimitTable::default()),
         active_sessions: Mutex::new(HashMap::new()),
         store_dirty: StoreDirty::default(),
         log_caches: std::sync::Mutex::new(LogCaches::default()),
@@ -993,6 +1049,21 @@ struct SessionRecord {
 struct RateLimitBucket {
     window_start_unix_ms: u64,
     count: u32,
+    /// The bucket's own window (scope-stable: every call site uses one
+    /// window per scope). Expiry decisions use this, never a global bound —
+    /// a short-window bucket must not rank as live under a longer scope's
+    /// lifetime, and vice versa.
+    window_ms: u64,
+}
+
+/// The rate-limit table plus the bookkeeping that amortizes full-scan
+/// pruning when the table sits at capacity.
+#[derive(Default)]
+struct RateLimitTable {
+    buckets: HashMap<String, RateLimitBucket>,
+    /// When the last at-capacity prune ran; saturated inserts within the
+    /// interval skip the O(table) scan and fail closed directly.
+    last_saturated_prune_unix_ms: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -1251,6 +1322,10 @@ async fn store_flush_monitor_with(state: Arc<AppState>, debounce: Duration) {
             Ok(bytes) => bytes,
             Err(err) => {
                 eprintln!("[connect] debounced store flush serialize failed: {err}");
+                // Uniform retry invariant: every failure arm re-marks — the
+                // mutations are still memory-only, and take() consumed the
+                // mark.
+                state.store_dirty.mark();
                 continue;
             }
         };
@@ -1263,7 +1338,10 @@ async fn store_flush_monitor_with(state: Arc<AppState>, debounce: Duration) {
                 // window retries even without new activity.
                 state.store_dirty.mark();
             }
-            Err(err) => eprintln!("[connect] debounced store flush task failed: {err}"),
+            Err(err) => {
+                eprintln!("[connect] debounced store flush task failed: {err}");
+                state.store_dirty.mark();
+            }
         }
         drop(store);
     }
@@ -1319,7 +1397,7 @@ async fn sweep_in_memory_state(state: &AppState) {
     state.active_sessions.lock().await.retain(|_, session| {
         now.saturating_sub(session.created_unix_ms) <= ACTIVE_DASHBOARD_SESSION_TTL_MS
     });
-    prune_rate_limits(&mut *state.rate_limits.lock().await, now);
+    prune_rate_limits(&mut state.rate_limits.lock().await.buckets, now);
 }
 
 /// Apply a durable store mutation transactionally: serialize/write the cloned
@@ -1676,6 +1754,39 @@ mod tests {
         );
     }
 
+    /// Deploy-time restarts must not discard the pending debounce window:
+    /// the graceful-shutdown path flushes marked state once, and a clean
+    /// flag writes nothing.
+    #[tokio::test]
+    async fn final_store_flush_covers_the_pending_window() {
+        let root = tempfile::tempdir().unwrap();
+        let state = production_router_test_state(root.path(), Store::default());
+
+        // Clean flag: nothing to write (the store file does not appear).
+        final_store_flush(&state).await;
+        assert!(!state.config.data_file.exists());
+
+        {
+            let mut store = state.store.lock().await;
+            store.users.push(UserRecord {
+                id: Uuid::new_v4(),
+                account_name: "late-window".to_string(),
+                display_name: "Late".to_string(),
+                passkeys: Vec::new(),
+                created_unix_ms: 1,
+                updated_unix_ms: 1,
+                last_login_unix_ms: 1,
+                attestations: Vec::new(),
+            });
+            mark_store_dirty(&state);
+        }
+        final_store_flush(&state).await;
+        let on_disk = load_store(&state.config.data_file).unwrap();
+        assert_eq!(on_disk.users.len(), 1);
+        assert_eq!(on_disk.users[0].account_name, "late-window");
+        assert!(!state.store_dirty.take(), "flush consumed the mark");
+    }
+
     #[tokio::test]
     async fn sweeper_drops_only_entries_dead_to_their_consumers() {
         let root = tempfile::tempdir().unwrap();
@@ -1724,18 +1835,20 @@ mod tests {
         }
         {
             let mut limits = state.rate_limits.lock().await;
-            limits.insert(
-                "scope:1.2.3.4".to_string(),
+            limits.buckets.insert(
+                "hourly:1.2.3.4".to_string(),
                 RateLimitBucket {
-                    window_start_unix_ms: now,
+                    window_start_unix_ms: now - 120_000,
                     count: 3,
+                    window_ms: 60 * 60_000,
                 },
             );
-            limits.insert(
-                "scope:5.6.7.8".to_string(),
+            limits.buckets.insert(
+                "short:5.6.7.8".to_string(),
                 RateLimitBucket {
-                    window_start_unix_ms: now - RATE_LIMIT_WINDOW_MAX_MS - 1,
+                    window_start_unix_ms: now - 120_000,
                     count: 900,
+                    window_ms: 60_000,
                 },
             );
         }
@@ -1747,10 +1860,13 @@ mod tests {
         assert!(claims.contains_key("fresh"));
         assert!(!claims.contains_key("ancient"));
         let limits = state.rate_limits.lock().await;
-        assert!(limits.contains_key("scope:1.2.3.4"));
         assert!(
-            !limits.contains_key("scope:5.6.7.8"),
-            "buckets past every window are expired for every scope"
+            limits.buckets.contains_key("hourly:1.2.3.4"),
+            "a bucket inside its own window stays"
+        );
+        assert!(
+            !limits.buckets.contains_key("short:5.6.7.8"),
+            "a bucket past its own window is expired even when younger than other scopes' windows"
         );
     }
 }

--- a/src/bin/connect/main.rs
+++ b/src/bin/connect/main.rs
@@ -180,50 +180,81 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.listen, config.public_origin, config.rp_id
     );
     eprintln!("[connect] state file {}", config.data_file.display());
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
-    // Deploy-time restarts land here: without a final flush, every restart
-    // would discard the pending debounce window (a daemon that went offline
-    // during it would permanently lose its last presence hours).
+    // Graceful shutdown with a BOUNDED drain: `with_graceful_shutdown` alone
+    // waits for every in-flight request (only the daemon long-poll caps
+    // itself at 30s — one slow POST would hold the drain until the
+    // supervisor SIGKILLs, killing the final flush below). After the signal
+    // plus the grace window, the serve future is dropped, aborting whatever
+    // is still in flight.
+    let (shutdown_seen_tx, shutdown_seen_rx) = oneshot::channel::<()>();
+    let serve = std::future::IntoFuture::into_future(
+        axum::serve(listener, app).with_graceful_shutdown(async move {
+            shutdown_signal().await;
+            let _ = shutdown_seen_tx.send(());
+        }),
+    );
+    tokio::pin!(serve);
+    let serve_result = tokio::select! {
+        result = &mut serve => result,
+        _ = async {
+            // Only starts counting once the shutdown signal actually fired.
+            let _ = shutdown_seen_rx.await;
+            tokio::time::sleep(SHUTDOWN_DRAIN_GRACE).await;
+        } => {
+            eprintln!(
+                "[connect] graceful drain exceeded {}s; aborting in-flight requests",
+                SHUTDOWN_DRAIN_GRACE.as_secs()
+            );
+            Ok(())
+        }
+    };
+    // The final flush runs on EVERY exit path — clean drain, bounded-drain
+    // abort, or a serve error — before the error (if any) propagates.
+    // Without it, every restart would discard the pending debounce window
+    // (a daemon that went offline during it would permanently lose its last
+    // presence hours).
     final_store_flush(&state).await;
+    serve_result?;
     Ok(())
 }
 
+/// How long in-flight requests may drain after the shutdown signal before
+/// they are aborted. Below typical supervisor stop timeouts, so the final
+/// store flush always gets to run; overrunning requests (the 30s-max daemon
+/// long-poll included) are dropped — daemons and browsers retry.
+const SHUTDOWN_DRAIN_GRACE: Duration = Duration::from_secs(25);
+
 /// Resolves on SIGTERM (what systemd/deploy tooling sends) or ctrl-c. A
-/// failed signal-handler registration degrades to the other signal rather
-/// than aborting startup.
+/// failed handler registration degrades to the OTHER signal staying live:
+/// each arm parks on `pending()` inside its own future on error, so the
+/// select keeps polling the healthy receiver instead of abandoning it.
 async fn shutdown_signal() {
-    #[cfg(unix)]
-    {
-        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
-            Ok(mut sigterm) => {
-                tokio::select! {
-                    _ = sigterm.recv() => {}
-                    result = tokio::signal::ctrl_c() => {
-                        if let Err(err) = result {
-                            eprintln!("[connect] ctrl-c handler failed: {err}");
-                            std::future::pending::<()>().await;
-                        }
-                    }
-                }
-            }
-            Err(err) => {
-                eprintln!("[connect] SIGTERM handler registration failed: {err}");
-                if let Err(err) = tokio::signal::ctrl_c().await {
-                    eprintln!("[connect] ctrl-c handler failed: {err}");
-                    std::future::pending::<()>().await;
-                }
-            }
-        }
-    }
-    #[cfg(not(unix))]
-    {
+    let ctrl_c = async {
         if let Err(err) = tokio::signal::ctrl_c().await {
             eprintln!("[connect] ctrl-c handler failed: {err}");
             std::future::pending::<()>().await;
         }
+    };
+    #[cfg(unix)]
+    {
+        let sigterm = async {
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(mut sigterm) => {
+                    sigterm.recv().await;
+                }
+                Err(err) => {
+                    eprintln!("[connect] SIGTERM handler registration failed: {err}");
+                    std::future::pending::<()>().await;
+                }
+            }
+        };
+        tokio::select! {
+            _ = sigterm => {}
+            _ = ctrl_c => {}
+        }
     }
+    #[cfg(not(unix))]
+    ctrl_c.await;
 }
 
 /// Synchronously flush any pending debounced marks; called once after the
@@ -1056,13 +1087,24 @@ struct RateLimitBucket {
     window_ms: u64,
 }
 
-/// The rate-limit table plus the bookkeeping that amortizes full-scan
-/// pruning when the table sits at capacity.
+/// Rate-limit state, PARTITIONED per scope: each scope owns its own
+/// capacity-bounded bucket map, so saturating one scope (e.g. flooding the
+/// hourly new-daemon-identity budget from rotating addresses) can never
+/// fail-close a different scope (logins, fleet sync, log reads). Fail-closed
+/// capacity is therefore a per-scope blast radius by construction.
 #[derive(Default)]
 struct RateLimitTable {
+    scopes: HashMap<String, ScopeRateLimits>,
+}
+
+/// One scope's buckets plus the bookkeeping that amortizes full-scan
+/// pruning while the scope sits at capacity.
+#[derive(Default)]
+struct ScopeRateLimits {
+    /// Keyed by the canonical bounded peer token (accounts.rs).
     buckets: HashMap<String, RateLimitBucket>,
     /// When the last at-capacity prune ran; saturated inserts within the
-    /// interval skip the O(table) scan and fail closed directly.
+    /// interval skip the O(scope) scan and fail closed directly.
     last_saturated_prune_unix_ms: u64,
 }
 
@@ -1130,6 +1172,10 @@ enum ClaimStatus {
 struct ApiError {
     status: StatusCode,
     message: String,
+    /// Emitted as a `Retry-After` header (seconds). Set by rate-limit
+    /// rejections so well-behaved clients back off for the actual window
+    /// instead of guessing.
+    retry_after_seconds: Option<u64>,
 }
 
 type ApiResult<T> = Result<T, ApiError>;
@@ -1139,6 +1185,7 @@ impl ApiError {
         Self {
             status,
             message: message.into(),
+            retry_after_seconds: None,
         }
     }
 
@@ -1166,6 +1213,13 @@ impl ApiError {
         Self::new(StatusCode::TOO_MANY_REQUESTS, message)
     }
 
+    fn too_many_requests_after(message: impl Into<String>, retry_after_seconds: u64) -> Self {
+        Self {
+            retry_after_seconds: Some(retry_after_seconds),
+            ..Self::new(StatusCode::TOO_MANY_REQUESTS, message)
+        }
+    }
+
     fn internal(message: impl Into<String>) -> Self {
         Self::new(StatusCode::INTERNAL_SERVER_ERROR, message)
     }
@@ -1173,14 +1227,20 @@ impl ApiError {
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        (
+        let mut response = (
             self.status,
             Json(json!({
                 "ok": false,
                 "error": self.message,
             })),
         )
-            .into_response()
+            .into_response();
+        if let Some(seconds) = self.retry_after_seconds {
+            if let Ok(value) = HeaderValue::from_str(&seconds.to_string()) {
+                response.headers_mut().insert(header::RETRY_AFTER, value);
+            }
+        }
+        response
     }
 }
 
@@ -1257,11 +1317,12 @@ fn persist_locked(state: &AppState, store: &Store) -> ApiResult<()> {
 }
 
 /// Debounced-persistence signal. Hot paths whose mutations tolerate a
-/// bounded loss window (presence refreshes: `last_seen`, presence hours, the
-/// registration-proof watermark) `mark` instead of persisting;
-/// `store_flush_monitor` coalesces the marks into one full-store write per
-/// debounce window. Critical mutations keep their synchronous
-/// `persist_locked` path unchanged.
+/// bounded loss window — presence-display fields only (`last_seen`,
+/// `updated`, presence hours; the registration-proof watermark is NOT one
+/// of them: it persists synchronously, see `DaemonRegistrationOutcome`) —
+/// `mark` instead of persisting; `store_flush_monitor` coalesces the marks
+/// into one full-store write per debounce window. Critical mutations keep
+/// their synchronous `persist_locked` path unchanged.
 #[derive(Default)]
 struct StoreDirty {
     dirty: std::sync::atomic::AtomicBool,
@@ -1397,7 +1458,7 @@ async fn sweep_in_memory_state(state: &AppState) {
     state.active_sessions.lock().await.retain(|_, session| {
         now.saturating_sub(session.created_unix_ms) <= ACTIVE_DASHBOARD_SESSION_TTL_MS
     });
-    prune_rate_limits(&mut state.rate_limits.lock().await.buckets, now);
+    prune_rate_limits(&mut *state.rate_limits.lock().await, now);
 }
 
 /// Apply a durable store mutation transactionally: serialize/write the cloned
@@ -1835,16 +1896,17 @@ mod tests {
         }
         {
             let mut limits = state.rate_limits.lock().await;
-            limits.buckets.insert(
-                "hourly:1.2.3.4".to_string(),
+            let scope = limits.scopes.entry("scope".to_string()).or_default();
+            scope.buckets.insert(
+                "1.2.3.4".to_string(),
                 RateLimitBucket {
                     window_start_unix_ms: now - 120_000,
                     count: 3,
                     window_ms: 60 * 60_000,
                 },
             );
-            limits.buckets.insert(
-                "short:5.6.7.8".to_string(),
+            scope.buckets.insert(
+                "5.6.7.8".to_string(),
                 RateLimitBucket {
                     window_start_unix_ms: now - 120_000,
                     count: 900,
@@ -1860,13 +1922,14 @@ mod tests {
         assert!(claims.contains_key("fresh"));
         assert!(!claims.contains_key("ancient"));
         let limits = state.rate_limits.lock().await;
+        let scope = &limits.scopes["scope"].buckets;
         assert!(
-            limits.buckets.contains_key("hourly:1.2.3.4"),
+            scope.contains_key("1.2.3.4"),
             "a bucket inside its own window stays"
         );
         assert!(
-            !limits.buckets.contains_key("short:5.6.7.8"),
-            "a bucket past its own window is expired even when younger than other scopes' windows"
+            !scope.contains_key("5.6.7.8"),
+            "a bucket past its own window is expired even when younger than other windows"
         );
     }
 }

--- a/src/bin/connect/push.rs
+++ b/src/bin/connect/push.rs
@@ -168,6 +168,51 @@ pub(crate) async fn send_web_push(
     }
 }
 
+/// Deliver one payload to many subscriptions concurrently. Push relays are
+/// remote HTTP endpoints behind a 15s client timeout, so a serial loop could
+/// stall its caller (including the presence monitor's tick) for minutes on a
+/// fan-out. Concurrency is inherently bounded: every call site filters to
+/// one account's rows, and `push_subscribe` caps an account at 10.
+/// Returns (delivered, dead_endpoints); failures are logged under `context`
+/// exactly like the serial loops this replaces.
+pub(crate) async fn send_web_push_fanout(
+    state: &AppState,
+    subscriptions: &[PushSubscriptionRecord],
+    payload: &serde_json::Value,
+    context: &str,
+) -> (usize, Vec<String>) {
+    use futures_util::stream::{FuturesUnordered, StreamExt as _};
+    // Built with a plain loop: a closure returning an async block that
+    // borrows its argument trips the higher-ranked lifetime check inside
+    // axum handlers; loop-created async blocks have concrete lifetimes.
+    let mut sends = FuturesUnordered::new();
+    for subscription in subscriptions {
+        sends.push(async move {
+            (
+                send_web_push(
+                    &state.push_http,
+                    &state.vapid,
+                    &state.config.public_origin,
+                    subscription,
+                    payload,
+                )
+                .await,
+                subscription,
+            )
+        });
+    }
+    let mut sent = 0;
+    let mut dead = Vec::new();
+    while let Some((result, subscription)) = sends.next().await {
+        match result {
+            Ok(true) => sent += 1,
+            Ok(false) => dead.push(subscription.endpoint.clone()),
+            Err(e) => eprintln!("[push] {context} failed: {e}"),
+        }
+    }
+    (sent, dead)
+}
+
 pub(crate) fn load_or_create_vapid_keypair(
     store: &mut Store,
 ) -> Result<ring::signature::EcdsaKeyPair, String> {
@@ -527,23 +572,8 @@ pub(crate) async fn daemon_notify(
     let session_label = clean_fleet_text(&body.session_label, FLEET_LABEL_MAX);
     let push_payload =
         attention_push_payload(&body.kind, &daemon_label, &session_label, &daemon_id);
-    let mut sent = 0;
-    let mut dead = Vec::new();
-    for subscription in &subscriptions {
-        match send_web_push(
-            &state.push_http,
-            &state.vapid,
-            &state.config.public_origin,
-            subscription,
-            &push_payload,
-        )
-        .await
-        {
-            Ok(true) => sent += 1,
-            Ok(false) => dead.push(subscription.endpoint.clone()),
-            Err(e) => eprintln!("[push] attention nudge failed: {e}"),
-        }
-    }
+    let (sent, dead) =
+        send_web_push_fanout(&state, &subscriptions, &push_payload, "attention nudge").await;
     {
         let mut store = state.store.lock().await;
         if !dead.is_empty() {
@@ -593,23 +623,7 @@ pub(crate) async fn push_test(
         "body": "Test notification — this is what a computer alert will look like.",
         "url": "/connect",
     });
-    let mut sent = 0;
-    let mut dead = Vec::new();
-    for subscription in &subscriptions {
-        match send_web_push(
-            &state.push_http,
-            &state.vapid,
-            &state.config.public_origin,
-            subscription,
-            &payload,
-        )
-        .await
-        {
-            Ok(true) => sent += 1,
-            Ok(false) => dead.push(subscription.endpoint.clone()),
-            Err(e) => eprintln!("[push] test send failed: {e}"),
-        }
-    }
+    let (sent, dead) = send_web_push_fanout(&state, &subscriptions, &payload, "test send").await;
     if !dead.is_empty() {
         let mut store = state.store.lock().await;
         store
@@ -666,7 +680,23 @@ pub(crate) async fn presence_alert_monitor(state: Arc<AppState>) {
                     }
                 }
             }
-            (transitions, store.push_subscriptions.clone())
+            // The steady-state tick has no transitions: clone nothing. When
+            // it does, clone only the affected owners' opted-in rows.
+            let subscriptions: Vec<PushSubscriptionRecord> = if transitions.is_empty() {
+                Vec::new()
+            } else {
+                let owners: HashSet<Uuid> = transitions
+                    .iter()
+                    .filter_map(|(_, _, owner, _, _)| *owner)
+                    .collect();
+                store
+                    .push_subscriptions
+                    .iter()
+                    .filter(|s| s.notify_presence && owners.contains(&s.user_id))
+                    .cloned()
+                    .collect()
+            };
+            (transitions, subscriptions)
         };
         seeded = true;
         if transitions.is_empty() {
@@ -683,24 +713,14 @@ pub(crate) async fn presence_alert_monitor(state: Arc<AppState>) {
                 },
                 "url": "/connect",
             });
-            for subscription in subscriptions
+            let targets: Vec<PushSubscriptionRecord> = subscriptions
                 .iter()
-                .filter(|s| s.notify_presence && Some(s.user_id) == owner)
-            {
-                match send_web_push(
-                    &state.push_http,
-                    &state.vapid,
-                    &state.config.public_origin,
-                    subscription,
-                    &payload,
-                )
-                .await
-                {
-                    Ok(true) => {}
-                    Ok(false) => dead.push(subscription.endpoint.clone()),
-                    Err(e) => eprintln!("[push] presence alert failed: {e}"),
-                }
-            }
+                .filter(|s| Some(s.user_id) == owner)
+                .cloned()
+                .collect();
+            let (_sent, newly_dead) =
+                send_web_push_fanout(&state, &targets, &payload, "presence alert").await;
+            dead.extend(newly_dead);
         }
         if !dead.is_empty() {
             let mut store = state.store.lock().await;

--- a/src/bin/connect/rendezvous.rs
+++ b/src/bin/connect/rendezvous.rs
@@ -444,6 +444,15 @@ struct DaemonRegistrationOutcome {
     claimed_by: Option<(Uuid, String)>,
     claim_code_expires_unix_ms: Option<u64>,
     stale_daemon_ids: Vec<String>,
+    /// Whether this registration changed durable route state (new record,
+    /// route-code rotation, stale-record sweep) as opposed to a pure
+    /// presence refresh (same identity, same code, newer proof watermark).
+    /// Refreshes arrive once a minute per daemon and skip the synchronous
+    /// full-store persist; the proof watermark is monotonic, so a
+    /// crash-lost bump can at worst re-admit a replay of the daemon's own
+    /// newer-than-disk proof — an idempotent refresh — until the daemon's
+    /// next (strictly newer) proof lands.
+    durable_change: bool,
 }
 
 /// Apply one daemon registration to a candidate Store. The caller persists
@@ -481,9 +490,11 @@ fn apply_daemon_registration(
         ));
     }
     let active_claim_hashes = active_claim_code_hashes(store, daemon_id, now);
+    let mut durable_change = !stale_daemon_ids.is_empty();
     // Re-registering the same hash does not refresh its TTL, so a code remains
-    // genuinely short-lived even while the daemon keeps polling.
-    let apply_claim_hash = |record: &mut DaemonRecord| -> ApiResult<()> {
+    // genuinely short-lived even while the daemon keeps polling. Returns
+    // whether the record's code generation changed.
+    let apply_claim_hash = |record: &mut DaemonRecord| -> ApiResult<bool> {
         if active_claim_hashes.contains(claim_code_hash) {
             return Err(ApiError::conflict(
                 "claim code hash collides with another active route code",
@@ -492,10 +503,13 @@ fn apply_daemon_registration(
         if record.claim_code_hash.as_deref() != Some(claim_code_hash) {
             record.claim_code_hash = Some(claim_code_hash.to_string());
             record.claim_code_created_unix_ms = Some(now);
+            Ok(true)
         } else if record.claim_code_created_unix_ms.is_none() {
             record.claim_code_created_unix_ms = Some(now);
+            Ok(true)
+        } else {
+            Ok(false)
         }
-        Ok(())
     };
     let (owner_user_id, code_created_unix_ms) = if let Some(existing) = store
         .daemons
@@ -516,11 +530,12 @@ fn apply_daemon_registration(
         existing.last_seen_unix_ms = now;
         record_presence_hour(&mut existing.presence_hours, now);
         existing.updated_unix_ms = now;
-        if existing.owner_user_id.is_none() {
-            apply_claim_hash(existing)?;
+        if existing.owner_user_id.is_none() && apply_claim_hash(existing)? {
+            durable_change = true;
         }
         (existing.owner_user_id, existing.claim_code_created_unix_ms)
     } else {
+        durable_change = true;
         let mut record = DaemonRecord {
             daemon_id: daemon_id.to_string(),
             label: None,
@@ -561,6 +576,7 @@ fn apply_daemon_registration(
             None
         },
         stale_daemon_ids,
+        durable_change,
     })
 }
 
@@ -625,20 +641,38 @@ pub(crate) async fn daemon_register(
     let registration = {
         let mut store = state.store.lock().await;
         let now = now_unix_ms();
-        update_store_transaction(
+        let durable_change = std::cell::Cell::new(true);
+        let registration = update_store_transaction(
             &mut store,
             |next| {
-                apply_daemon_registration(
+                let outcome = apply_daemon_registration(
                     next,
                     &daemon_id,
                     &daemon_public_key,
                     &claim_code_hash,
                     proof_verified.then_some(body.issued_at_unix_ms),
                     now,
-                )
+                )?;
+                durable_change.set(outcome.durable_change);
+                Ok(outcome)
             },
-            |next| persist_locked(&state, next),
-        )?
+            // Pure presence refreshes (same identity, same route code, newer
+            // proof watermark) arrive once a minute per daemon; they skip
+            // the synchronous full-store fsync and ride the debounced
+            // flusher instead. Anything that changes durable route state
+            // still persists before publication, exactly as before.
+            |next| {
+                if durable_change.get() {
+                    persist_locked(&state, next)
+                } else {
+                    Ok(())
+                }
+            },
+        )?;
+        if !registration.durable_change {
+            mark_store_dirty(&state);
+        }
+        registration
     };
     // DNS is an external live index. Publish deletions only after the Store
     // commit succeeds so a failed state-file write remains exactly retryable.
@@ -814,14 +848,22 @@ pub(crate) async fn daemon_next(
     }
 }
 
+/// Refresh a polling daemon's presence. This runs on every `daemon_next`
+/// long-poll (~4/min/daemon), so it never persists synchronously: the
+/// fields it touches are display-grade (`last_seen`, presence hours), they
+/// ride along with every other persist, and the debounced flusher bounds
+/// their loss window. The dirty mark fires only when the presence hour
+/// bucket actually changes (~1/hour/daemon; the stale-unclaimed sweep's
+/// 24h TTL keeps a wide margin over that worst-case disk staleness).
 pub(crate) async fn touch_daemon(state: &AppState, daemon_id: &str) -> ApiResult<()> {
     let mut store = state.store.lock().await;
     if let Some(daemon) = store.daemons.iter_mut().find(|d| d.daemon_id == daemon_id) {
         let now = now_unix_ms();
         daemon.last_seen_unix_ms = now;
         daemon.updated_unix_ms = now;
-        record_presence_hour(&mut daemon.presence_hours, now);
-        persist_locked(state, &store)?;
+        if record_presence_hour(&mut daemon.presence_hours, now) {
+            mark_store_dirty(state);
+        }
         Ok(())
     } else {
         Err(ApiError::not_found("daemon is not registered"))
@@ -1175,37 +1217,31 @@ pub(crate) async fn daemon_dry(
         let Some(daemon) = store.daemons.iter().find(|d| d.daemon_id == daemon_id) else {
             return Err(ApiError::not_found("unknown daemon"));
         };
+        // Clone only the owner's opted-in rows, not the whole table.
+        let subscriptions: Vec<PushSubscriptionRecord> = daemon
+            .owner_user_id
+            .map(|owner| {
+                store
+                    .push_subscriptions
+                    .iter()
+                    .filter(|s| s.notify_presence && s.user_id == owner)
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
         (
             daemon.label.clone().unwrap_or_else(|| daemon_id.clone()),
             daemon.owner_user_id,
-            store.push_subscriptions.clone(),
+            subscriptions,
         )
     };
-    let Some(owner) = owner else {
+    if owner.is_none() {
         // Nobody has claimed this daemon — nobody to notify.
         return Ok(Json(json!({ "ok": true, "notified": 0 })));
     };
     let payload = dry_push_payload(&daemon_id, &label, &body.credentials);
-    let mut notified = 0usize;
-    let mut dead = Vec::new();
-    for subscription in subscriptions
-        .iter()
-        .filter(|s| s.notify_presence && s.user_id == owner)
-    {
-        match send_web_push(
-            &state.push_http,
-            &state.vapid,
-            &state.config.public_origin,
-            subscription,
-            &payload,
-        )
-        .await
-        {
-            Ok(true) => notified += 1,
-            Ok(false) => dead.push(subscription.endpoint.clone()),
-            Err(e) => eprintln!("[push] dry-daemon alert failed: {e}"),
-        }
-    }
+    let (notified, dead) =
+        send_web_push_fanout(&state, &subscriptions, &payload, "dry-daemon alert").await;
     if !dead.is_empty() {
         let mut store = state.store.lock().await;
         store
@@ -2024,6 +2060,7 @@ mod tests {
         store.daemons.push(daemon);
         let vapid = load_or_create_vapid_keypair(&mut store).unwrap();
         let log_key = load_or_create_log_keypair(&mut store).unwrap();
+        let static_pages = StaticPages::render(&config);
         Arc::new(AppState {
             config,
             webauthn,
@@ -2038,6 +2075,9 @@ mod tests {
             daemon_sessions: Mutex::new(HashMap::new()),
             rate_limits: Mutex::new(HashMap::new()),
             active_sessions: Mutex::new(HashMap::new()),
+            store_dirty: StoreDirty::default(),
+            log_caches: std::sync::Mutex::new(LogCaches::default()),
+            static_pages,
             vapid,
             log_key,
             push_http: reqwest::Client::new(),
@@ -2235,6 +2275,90 @@ mod tests {
         assert_eq!(
             store.daemons[0].claim_code_hash.as_deref(),
             Some(claim_hash.as_str())
+        );
+    }
+
+    /// Pins which registrations may skip the synchronous persist: only the
+    /// once-a-minute presence refresh (same identity, same route code,
+    /// newer proof watermark). Everything that changes durable route state
+    /// must report durable and take the persist-before-publish path.
+    #[test]
+    fn registration_reports_pure_refreshes_as_non_durable() {
+        let now = 1_700_000_000_000u64;
+        let mut store = Store::default();
+        let hash_a = "A".repeat(43);
+        let hash_b = "B".repeat(43);
+
+        let first = apply_daemon_registration(
+            &mut store,
+            "daemon-1",
+            "daemon-key",
+            &hash_a,
+            Some(now),
+            now,
+        )
+        .unwrap();
+        assert!(first.durable_change, "record creation is durable");
+
+        let refresh = apply_daemon_registration(
+            &mut store,
+            "daemon-1",
+            "daemon-key",
+            &hash_a,
+            Some(now + 60_000),
+            now + 60_000,
+        )
+        .unwrap();
+        assert!(
+            !refresh.durable_change,
+            "same identity + same code + newer proof is a presence refresh"
+        );
+        assert_eq!(
+            store.daemons[0].last_registration_proof_unix_ms,
+            Some(now + 60_000),
+            "the watermark still advances in memory"
+        );
+
+        let rotated = apply_daemon_registration(
+            &mut store,
+            "daemon-1",
+            "daemon-key",
+            &hash_b,
+            Some(now + 120_000),
+            now + 120_000,
+        )
+        .unwrap();
+        assert!(rotated.durable_change, "route-code rotation is durable");
+
+        store.daemons.push(daemon_record("stale", None, None, None));
+        let sweeping = apply_daemon_registration(
+            &mut store,
+            "daemon-1",
+            "daemon-key",
+            &hash_b,
+            Some(now + 180_000),
+            now + 180_000,
+        )
+        .unwrap();
+        assert_eq!(sweeping.stale_daemon_ids, vec!["stale".to_string()]);
+        assert!(
+            sweeping.durable_change,
+            "a refresh that swept stale records must persist the removal"
+        );
+
+        store.daemons[0].owner_user_id = Some(Uuid::new_v4());
+        let claimed = apply_daemon_registration(
+            &mut store,
+            "daemon-1",
+            "daemon-key",
+            &"C".repeat(43),
+            Some(now + 240_000),
+            now + 240_000,
+        )
+        .unwrap();
+        assert!(
+            !claimed.durable_change,
+            "claimed daemons never touch code state on re-register"
         );
     }
 

--- a/src/bin/connect/rendezvous.rs
+++ b/src/bin/connect/rendezvous.rs
@@ -444,14 +444,12 @@ struct DaemonRegistrationOutcome {
     claimed_by: Option<(Uuid, String)>,
     claim_code_expires_unix_ms: Option<u64>,
     stale_daemon_ids: Vec<String>,
-    /// Whether this registration changed durable route state (new record,
-    /// route-code rotation, stale-record sweep) as opposed to a pure
-    /// presence refresh (same identity, same code, newer proof watermark).
-    /// Refreshes arrive once a minute per daemon and skip the synchronous
-    /// full-store persist; the proof watermark is monotonic, so a
-    /// crash-lost bump can at worst re-admit a replay of the daemon's own
-    /// newer-than-disk proof — an idempotent refresh — until the daemon's
-    /// next (strictly newer) proof lands.
+    /// Whether this registration changed durable state: a new record, a
+    /// route-code rotation, a stale-record sweep, or a proof-watermark
+    /// advance (the anti-replay floor for daemon-session issuance — see the
+    /// comment at the advance site). Only mutations with no security effect
+    /// — presence fields on a proof-less operator probe — report false and
+    /// ride the debounced flusher.
     durable_change: bool,
 }
 
@@ -526,6 +524,14 @@ fn apply_daemon_registration(
                 }
             }
             existing.last_registration_proof_unix_ms = Some(issued_at_unix_ms);
+            // The watermark is the anti-replay floor for a TOKEN-MINTING
+            // side effect: every accepted proof earns the caller a fresh
+            // daemon-session credential. If an advance were only debounced,
+            // a restart inside the window would roll it back and a captured
+            // refresh (valid for the 5-minute skew) could replay and win
+            // the sole post-restart daemon session. An advance is therefore
+            // always a durable change, persisted before the token is issued.
+            durable_change = true;
         }
         existing.last_seen_unix_ms = now;
         record_presence_hour(&mut existing.presence_hours, now);
@@ -656,11 +662,11 @@ pub(crate) async fn daemon_register(
                 durable_change.set(outcome.durable_change);
                 Ok(outcome)
             },
-            // Pure presence refreshes (same identity, same route code, newer
-            // proof watermark) arrive once a minute per daemon; they skip
-            // the synchronous full-store fsync and ride the debounced
-            // flusher instead. Anything that changes durable route state
-            // still persists before publication, exactly as before.
+            // Everything with a security effect — including the proof
+            // watermark that floors replay for the daemon-session token
+            // minted below — persists before publication, exactly as
+            // before. Only proof-less presence refreshes (operator probes)
+            // skip the fsync and ride the debounced flusher.
             |next| {
                 if durable_change.get() {
                     persist_locked(&state, next)
@@ -849,21 +855,21 @@ pub(crate) async fn daemon_next(
 }
 
 /// Refresh a polling daemon's presence. This runs on every `daemon_next`
-/// long-poll (~4/min/daemon), so it never persists synchronously: the
-/// fields it touches are display-grade (`last_seen`, presence hours), they
-/// ride along with every other persist, and the debounced flusher bounds
-/// their loss window. The dirty mark fires only when the presence hour
-/// bucket actually changes (~1/hour/daemon; the stale-unclaimed sweep's
-/// 24h TTL keeps a wide margin over that worst-case disk staleness).
+/// long-poll (~4/min/daemon), so it never persists synchronously: every
+/// field it touches is presence-display data (`last_seen`, `updated`,
+/// presence hours) whose crash-loss window is bounded by the debounced
+/// flusher — the mark fires on every touch, and in practice each daemon's
+/// once-a-minute re-register persists the whole store anyway (its proof
+/// watermark is durable), so disk staleness stays well inside the
+/// stale-unclaimed sweep's 24h TTL.
 pub(crate) async fn touch_daemon(state: &AppState, daemon_id: &str) -> ApiResult<()> {
     let mut store = state.store.lock().await;
     if let Some(daemon) = store.daemons.iter_mut().find(|d| d.daemon_id == daemon_id) {
         let now = now_unix_ms();
         daemon.last_seen_unix_ms = now;
         daemon.updated_unix_ms = now;
-        if record_presence_hour(&mut daemon.presence_hours, now) {
-            mark_store_dirty(state);
-        }
+        record_presence_hour(&mut daemon.presence_hours, now);
+        mark_store_dirty(state);
         Ok(())
     } else {
         Err(ApiError::not_found("daemon is not registered"))
@@ -2073,7 +2079,7 @@ mod tests {
             event_queues: Mutex::new(HashMap::new()),
             event_notify: Notify::new(),
             daemon_sessions: Mutex::new(HashMap::new()),
-            rate_limits: Mutex::new(HashMap::new()),
+            rate_limits: Mutex::new(RateLimitTable::default()),
             active_sessions: Mutex::new(HashMap::new()),
             store_dirty: StoreDirty::default(),
             log_caches: std::sync::Mutex::new(LogCaches::default()),
@@ -2187,7 +2193,7 @@ mod tests {
             .lock()
             .await
             .contains_key("legacy-session"));
-        assert!(state.rate_limits.lock().await.is_empty());
+        assert!(state.rate_limits.lock().await.buckets.is_empty());
     }
 
     #[test]
@@ -2278,12 +2284,14 @@ mod tests {
         );
     }
 
-    /// Pins which registrations may skip the synchronous persist: only the
-    /// once-a-minute presence refresh (same identity, same route code,
-    /// newer proof watermark). Everything that changes durable route state
-    /// must report durable and take the persist-before-publish path.
+    /// Pins which registrations may skip the synchronous persist: ONLY
+    /// proof-less operator probes that change nothing but presence fields.
+    /// Every security-effective mutation — record creation, code rotation,
+    /// stale sweep, and every proof-watermark advance (the anti-replay
+    /// floor for daemon-session issuance) — must report durable and take
+    /// the persist-before-publish path.
     #[test]
-    fn registration_reports_pure_refreshes_as_non_durable() {
+    fn registration_durability_classification_is_pinned() {
         let now = 1_700_000_000_000u64;
         let mut store = Store::default();
         let hash_a = "A".repeat(43);
@@ -2310,13 +2318,26 @@ mod tests {
         )
         .unwrap();
         assert!(
-            !refresh.durable_change,
-            "same identity + same code + newer proof is a presence refresh"
+            refresh.durable_change,
+            "a proof-watermark advance is durable — it floors replay for the session token"
         );
         assert_eq!(
             store.daemons[0].last_registration_proof_unix_ms,
-            Some(now + 60_000),
-            "the watermark still advances in memory"
+            Some(now + 60_000)
+        );
+
+        let probe = apply_daemon_registration(
+            &mut store,
+            "daemon-1",
+            "daemon-key",
+            &hash_a,
+            None,
+            now + 90_000,
+        )
+        .unwrap();
+        assert!(
+            !probe.durable_change,
+            "a proof-less operator probe touching only presence fields defers"
         );
 
         let rotated = apply_daemon_registration(
@@ -2336,30 +2357,77 @@ mod tests {
             "daemon-1",
             "daemon-key",
             &hash_b,
-            Some(now + 180_000),
+            None,
             now + 180_000,
         )
         .unwrap();
         assert_eq!(sweeping.stale_daemon_ids, vec!["stale".to_string()]);
         assert!(
             sweeping.durable_change,
-            "a refresh that swept stale records must persist the removal"
+            "even a probe that swept stale records must persist the removal"
         );
 
         store.daemons[0].owner_user_id = Some(Uuid::new_v4());
-        let claimed = apply_daemon_registration(
+        let claimed_probe = apply_daemon_registration(
             &mut store,
             "daemon-1",
             "daemon-key",
             &"C".repeat(43),
-            Some(now + 240_000),
+            None,
             now + 240_000,
         )
         .unwrap();
         assert!(
-            !claimed.durable_change,
-            "claimed daemons never touch code state on re-register"
+            !claimed_probe.durable_change,
+            "claimed daemons never touch code state; a proof-less refresh defers"
         );
+    }
+
+    /// FIX for the restart-replay hole: a registration proof accepted just
+    /// before a restart must stay consumed across that restart — otherwise
+    /// a captured refresh (valid for the 5-minute skew window) replays
+    /// against the reloaded store and wins the sole post-restart daemon
+    /// session. The watermark advance is durable, so the reloaded state
+    /// already knows the proof.
+    #[test]
+    fn restart_cannot_resurrect_a_consumed_registration_proof() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let now = 1_700_000_000_000u64;
+        let hash = "A".repeat(43);
+        let mut store = Store::default();
+        apply_daemon_registration(&mut store, "daemon-1", "daemon-key", &hash, Some(now), now)
+            .unwrap();
+        save_store(&path, &store).unwrap();
+
+        // The once-a-minute refresh: durable, persisted before the daemon
+        // session token would be issued.
+        let refresh = apply_daemon_registration(
+            &mut store,
+            "daemon-1",
+            "daemon-key",
+            &hash,
+            Some(now + 60_000),
+            now + 60_000,
+        )
+        .unwrap();
+        assert!(refresh.durable_change);
+        save_store(&path, &store).unwrap();
+
+        // Simulated restart: reload from disk. The exact captured proof
+        // must be dead against the reloaded state.
+        let mut reloaded = load_store(&path).unwrap();
+        let replay = apply_daemon_registration(
+            &mut reloaded,
+            "daemon-1",
+            "daemon-key",
+            &hash,
+            Some(now + 60_000),
+            now + 60_001,
+        );
+        let error = replay.expect_err("replayed proof must be rejected after restart");
+        assert_eq!(error.status, StatusCode::CONFLICT);
+        assert!(error.message.contains("not newer"));
     }
 
     #[test]

--- a/src/bin/connect/rendezvous.rs
+++ b/src/bin/connect/rendezvous.rs
@@ -630,7 +630,11 @@ pub(crate) async fn daemon_register(
     if !known_daemon {
         // Refreshes arrive once a minute and must not spend the creation
         // budget. New identities are separately bounded per observed source;
-        // the production proxy overwrites forwarded-address headers.
+        // the production proxy overwrites forwarded-address headers. This
+        // check runs deliberately BEFORE signature verification: the budget
+        // exists to bound signature-verification CPU, so it must gate the
+        // expensive check rather than run behind it (its bucket allocation
+        // is confined to this scope's own capacity partition).
         check_rate_limit(
             &state,
             &headers,
@@ -2193,7 +2197,7 @@ mod tests {
             .lock()
             .await
             .contains_key("legacy-session"));
-        assert!(state.rate_limits.lock().await.buckets.is_empty());
+        assert!(state.rate_limits.lock().await.scopes.is_empty());
     }
 
     #[test]

--- a/src/bin/connect/rendezvous.rs
+++ b/src/bin/connect/rendezvous.rs
@@ -838,7 +838,10 @@ pub(crate) async fn daemon_next(
     require_daemon_session(&state, &headers, &daemon_id).await?;
     check_rate_limit(&state, &headers, "daemon_next", 240, 60_000).await?;
     touch_daemon(&state, &daemon_id).await?;
-    let timeout = Duration::from_millis(query.timeout_ms.unwrap_or(15_000).min(30_000));
+    // Cap below main's global REQUEST_TIMEOUT so a parked poll always ends
+    // naturally inside the shutdown drain (NO_CONTENT at any moment is
+    // protocol-normal — the daemon simply re-polls).
+    let timeout = Duration::from_millis(query.timeout_ms.unwrap_or(15_000).min(15_000));
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
         if let Some(event) = pop_event(&state, &daemon_id).await {

--- a/src/bin/connect/transparency.rs
+++ b/src/bin/connect/transparency.rs
@@ -223,6 +223,10 @@ pub(crate) fn log_sth_payload(size: usize, root_b64u: &str, unix_ms: u64) -> Str
     format!("intendant-log-sth-v1\n{size}\n{root_b64u}\n{unix_ms}")
 }
 
+/// Hash every leaf from scratch — the reference implementation the cache
+/// parity tests compare `cached_log_leaves` against; production reads go
+/// through the cache.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn log_leaves(store: &Store) -> Vec<[u8; 32]> {
     store
         .log_entries
@@ -231,11 +235,102 @@ pub(crate) fn log_leaves(store: &Store) -> Vec<[u8; 32]> {
         .collect()
 }
 
+/// Derived read caches over the transparency log. The log is strictly
+/// append-only in a live process (`append_log_entry` pushes; nothing edits
+/// or truncates entries), so caches keyed by length extend incrementally;
+/// a shorter log than the cache — impossible live, conceivable only through
+/// offline state surgery — triggers a defensive full rebuild.
+#[derive(Default)]
+pub(crate) struct LogCaches {
+    /// `leaf_hashes[i] = log_leaf_hash(log_entries[i].leaf_json)`. Re-hashing
+    /// every entry's JSON body per read was the O(log bytes) cost on every
+    /// STH / proof / consistency request; combining cached 32-byte pairs
+    /// into roots stays per-request work and is cheap.
+    leaf_hashes: Arc<Vec<[u8; 32]>>,
+    find: LogFindIndex,
+}
+
+#[derive(Default)]
+struct LogFindIndex {
+    built_len: usize,
+    /// daemon_id → last index among `kind == "daemon_claimed"` entries.
+    daemon_claimed_last: HashMap<String, usize>,
+    /// handle → last index among entries of any kind carrying that handle.
+    handle_last: HashMap<String, usize>,
+}
+
+/// Leaf hashes for the current log, hashing only entries appended since the
+/// last call. Callers hold the store lock, which is what keeps
+/// `store.log_entries` stable across the extend; the cache lock is a short
+/// synchronous hold nested inside it (always store → cache order).
+pub(crate) fn cached_log_leaves(state: &AppState, store: &Store) -> Arc<Vec<[u8; 32]>> {
+    let mut caches = state.log_caches.lock().expect("log cache lock poisoned");
+    let total = store.log_entries.len();
+    if caches.leaf_hashes.len() != total {
+        let mut hashes = Vec::with_capacity(total);
+        if caches.leaf_hashes.len() < total {
+            hashes.extend_from_slice(&caches.leaf_hashes);
+        }
+        for entry in &store.log_entries[hashes.len()..] {
+            hashes.push(log_leaf_hash(&entry.leaf_json));
+        }
+        caches.leaf_hashes = Arc::new(hashes);
+    }
+    caches.leaf_hashes.clone()
+}
+
+fn extend_find_index(index: &mut LogFindIndex, store: &Store) {
+    let total = store.log_entries.len();
+    if index.built_len > total {
+        *index = LogFindIndex::default();
+    }
+    for (offset, entry) in store.log_entries[index.built_len..].iter().enumerate() {
+        let position = index.built_len + offset;
+        let Ok(data) = serde_json::from_str::<serde_json::Value>(&entry.leaf_json) else {
+            continue;
+        };
+        if entry.kind == "daemon_claimed" {
+            if let Some(daemon_id) = data.get("daemon_id").and_then(|v| v.as_str()) {
+                index
+                    .daemon_claimed_last
+                    .insert(daemon_id.to_string(), position);
+            }
+        }
+        if let Some(handle) = data.get("handle").and_then(|v| v.as_str()) {
+            index.handle_last.insert(handle.to_string(), position);
+        }
+    }
+    index.built_len = total;
+}
+
+/// The `log_find` lookup over the maintained index — each entry is
+/// JSON-parsed once per process instead of once per request during a
+/// reverse scan. Semantics match the original linear scan exactly: a
+/// non-empty daemon_id matches only the latest `daemon_claimed` entry for
+/// that daemon (a handle argument is then ignored, as before); a handle
+/// query matches the latest entry of ANY kind carrying that handle.
+pub(crate) fn find_log_entry_indexed(
+    state: &AppState,
+    store: &Store,
+    daemon_id: &str,
+    handle: &str,
+) -> Option<usize> {
+    let mut caches = state.log_caches.lock().expect("log cache lock poisoned");
+    extend_find_index(&mut caches.find, store);
+    if !daemon_id.is_empty() {
+        caches.find.daemon_claimed_last.get(daemon_id).copied()
+    } else if !handle.is_empty() {
+        caches.find.handle_last.get(handle).copied()
+    } else {
+        None
+    }
+}
+
 /// The signed tree head as a bare object (no `ok` envelope) — nested by
 /// responses that carry an STH alongside other data.
 pub(crate) fn signed_tree_head_fields(state: &AppState, store: &Store) -> serde_json::Value {
     use ring::signature::KeyPair as _;
-    let leaves = log_leaves(store);
+    let leaves = cached_log_leaves(state, store);
     let root = b64u(&log_tree_root(&leaves));
     let unix_ms = now_unix_ms();
     let payload = log_sth_payload(leaves.len(), &root, unix_ms);
@@ -324,7 +419,7 @@ pub(crate) async fn log_proof(
 ) -> ApiResult<Response> {
     check_rate_limit(&state, &headers, "log_read", 240, 60_000).await?;
     let store = state.store.lock().await;
-    let leaves = log_leaves(&store);
+    let leaves = cached_log_leaves(&state, &store);
     let size = if query.size == 0 {
         leaves.len()
     } else {
@@ -363,7 +458,7 @@ pub(crate) async fn log_consistency(
 ) -> ApiResult<Response> {
     check_rate_limit(&state, &headers, "log_read", 240, 60_000).await?;
     let store = state.store.lock().await;
-    let leaves = log_leaves(&store);
+    let leaves = cached_log_leaves(&state, &store);
     let new_size = if query.new == 0 {
         leaves.len()
     } else {
@@ -411,22 +506,8 @@ pub(crate) async fn log_find(
         return Err(ApiError::bad_request("daemon_id or handle is required"));
     }
     let store = state.store.lock().await;
-    let found = store
-        .log_entries
-        .iter()
-        .enumerate()
-        .rev()
-        .find(|(_, entry)| {
-            let Ok(data) = serde_json::from_str::<serde_json::Value>(&entry.leaf_json) else {
-                return false;
-            };
-            let daemon_match = !daemon_id.is_empty()
-                && entry.kind == "daemon_claimed"
-                && data.get("daemon_id").and_then(|v| v.as_str()) == Some(daemon_id);
-            let handle_match =
-                !handle.is_empty() && data.get("handle").and_then(|v| v.as_str()) == Some(handle);
-            daemon_match || (daemon_id.is_empty() && handle_match)
-        });
+    let found = find_log_entry_indexed(&state, &store, daemon_id, handle)
+        .map(|index| (index, &store.log_entries[index]));
     let Some((index, entry)) = found else {
         return Ok(orl_cors(
             Json(json!({ "ok": true, "found": false })).into_response(),
@@ -634,7 +715,7 @@ pub(crate) async fn log_artifact_manifest(
             Json(json!({ "ok": true, "found": false })).into_response(),
         ));
     };
-    let leaves = log_leaves(&store);
+    let leaves = cached_log_leaves(&state, &store);
     let proof: Vec<String> = log_inclusion_proof(index, &leaves)
         .iter()
         .map(|hash| b64u(hash))
@@ -1017,7 +1098,7 @@ pub(crate) async fn log_release_manifest(
             Json(json!({ "ok": true, "found": false })).into_response(),
         ));
     };
-    let leaves = log_leaves(&store);
+    let leaves = cached_log_leaves(&state, &store);
     let proof: Vec<String> = log_inclusion_proof(index, &leaves)
         .iter()
         .map(|hash| b64u(hash))
@@ -1323,6 +1404,124 @@ mod tests {
             dns_ns_name: None,
             dns_listen: None,
         }
+    }
+
+    /// The leaf-hash cache must be indistinguishable from hashing the log
+    /// fresh, across appends (incremental extend) and across an
+    /// impossible-live shrink (defensive rebuild).
+    #[tokio::test]
+    async fn cached_log_leaves_extend_matches_fresh_hashing() {
+        let root = tempfile::tempdir().unwrap();
+        let state = production_router_test_state(root.path(), Store::default());
+        let mut store = state.store.lock().await;
+        for index in 0..3 {
+            append_log_entry(
+                &mut store,
+                "account_created",
+                json!({ "handle": format!("user-{index}") }),
+            );
+        }
+        let first = cached_log_leaves(&state, &store);
+        assert_eq!(*first, log_leaves(&store));
+
+        append_log_entry(&mut store, "account_created", json!({ "handle": "late" }));
+        let extended = cached_log_leaves(&state, &store);
+        assert_eq!(extended.len(), 4);
+        assert_eq!(*extended, log_leaves(&store));
+
+        // Same length → the cached Arc is reused, not recomputed.
+        let again = cached_log_leaves(&state, &store);
+        assert!(Arc::ptr_eq(&extended, &again));
+
+        // Defensive rebuild when the log is shorter than the cache.
+        store.log_entries.truncate(2);
+        let rebuilt = cached_log_leaves(&state, &store);
+        assert_eq!(*rebuilt, log_leaves(&store));
+    }
+
+    /// The find index must answer exactly like the reverse linear scan it
+    /// replaced, including the precedence rule (daemon_id wins; handle is
+    /// consulted only when daemon_id is empty).
+    #[tokio::test]
+    async fn log_find_index_matches_the_linear_scan() {
+        fn scan(store: &Store, daemon_id: &str, handle: &str) -> Option<usize> {
+            store
+                .log_entries
+                .iter()
+                .enumerate()
+                .rev()
+                .find(|(_, entry)| {
+                    let Ok(data) = serde_json::from_str::<serde_json::Value>(&entry.leaf_json)
+                    else {
+                        return false;
+                    };
+                    let daemon_match = !daemon_id.is_empty()
+                        && entry.kind == "daemon_claimed"
+                        && data.get("daemon_id").and_then(|v| v.as_str()) == Some(daemon_id);
+                    let handle_match = !handle.is_empty()
+                        && data.get("handle").and_then(|v| v.as_str()) == Some(handle);
+                    daemon_match || (daemon_id.is_empty() && handle_match)
+                })
+                .map(|(index, _)| index)
+        }
+
+        let root = tempfile::tempdir().unwrap();
+        let state = production_router_test_state(root.path(), Store::default());
+        let mut store = state.store.lock().await;
+        append_log_entry(&mut store, "account_created", json!({ "handle": "alice" }));
+        append_log_entry(
+            &mut store,
+            "daemon_claimed",
+            json!({ "daemon_id": "daemon-1", "handle": "alice" }),
+        );
+        append_log_entry(
+            &mut store,
+            "daemon_unclaimed",
+            json!({ "daemon_id": "daemon-1", "handle": "alice" }),
+        );
+        append_log_entry(
+            &mut store,
+            "daemon_claimed",
+            json!({ "daemon_id": "daemon-1", "handle": "bob" }),
+        );
+        append_log_entry(
+            &mut store,
+            "daemon_claimed",
+            json!({ "daemon_id": "daemon-2", "handle": "alice" }),
+        );
+
+        let cases: &[(&str, &str)] = &[
+            ("daemon-1", ""),
+            ("daemon-2", ""),
+            ("daemon-9", ""),
+            ("", "alice"),
+            ("", "bob"),
+            ("", "nobody"),
+            ("daemon-1", "alice"), // daemon precedence: handle ignored
+            ("daemon-9", "alice"), // unknown daemon does NOT fall back to handle
+        ];
+        for (daemon_id, handle) in cases {
+            assert_eq!(
+                find_log_entry_indexed(&state, &store, daemon_id, handle),
+                scan(&store, daemon_id, handle),
+                "query daemon_id={daemon_id:?} handle={handle:?}"
+            );
+        }
+
+        // Appends after the first build are picked up incrementally.
+        append_log_entry(
+            &mut store,
+            "daemon_claimed",
+            json!({ "daemon_id": "daemon-1", "handle": "carol" }),
+        );
+        assert_eq!(
+            find_log_entry_indexed(&state, &store, "daemon-1", ""),
+            scan(&store, "daemon-1", ""),
+        );
+        assert_eq!(
+            find_log_entry_indexed(&state, &store, "", "carol"),
+            scan(&store, "", "carol"),
+        );
     }
 
     /// Golden manifest hash — TWINNED byte-for-byte in

--- a/src/bin/connect/transparency.rs
+++ b/src/bin/connect/transparency.rs
@@ -264,7 +264,13 @@ struct LogFindIndex {
 /// `store.log_entries` stable across the extend; the cache lock is a short
 /// synchronous hold nested inside it (always store → cache order).
 pub(crate) fn cached_log_leaves(state: &AppState, store: &Store) -> Arc<Vec<[u8; 32]>> {
-    let mut caches = state.log_caches.lock().expect("log cache lock poisoned");
+    // Derived, rebuildable state: recover from a poisoned lock instead of
+    // propagating the panic — a partially extended cache re-extends (or
+    // fully rebuilds) idempotently from the store under the caller's lock.
+    let mut caches = state
+        .log_caches
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let total = store.log_entries.len();
     if caches.leaf_hashes.len() != total {
         let mut hashes = Vec::with_capacity(total);
@@ -315,7 +321,11 @@ pub(crate) fn find_log_entry_indexed(
     daemon_id: &str,
     handle: &str,
 ) -> Option<usize> {
-    let mut caches = state.log_caches.lock().expect("log cache lock poisoned");
+    // Same poison-recovery rationale as `cached_log_leaves`.
+    let mut caches = state
+        .log_caches
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     extend_find_index(&mut caches.find, store);
     if !daemon_id.is_empty() {
         caches.find.daemon_claimed_last.get(daemon_id).copied()

--- a/src/bin/connect/ui.rs
+++ b/src/bin/connect/ui.rs
@@ -44,14 +44,8 @@ pub(crate) fn install_sh_body(public_origin: &str) -> String {
     )
 }
 
-pub(crate) async fn install_sh(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    (
-        [
-            (header::CONTENT_TYPE, "text/plain; charset=utf-8"),
-            (header::CACHE_CONTROL, "no-cache"),
-        ],
-        install_sh_body(&state.config.public_origin),
-    )
+pub(crate) async fn install_sh(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    state.static_pages.install_sh.respond(&headers)
 }
 
 /// The Windows counterpart, for PowerShell:
@@ -70,14 +64,11 @@ pub(crate) fn install_ps1_body(public_origin: &str) -> String {
     )
 }
 
-pub(crate) async fn install_ps1(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    (
-        [
-            (header::CONTENT_TYPE, "text/plain; charset=utf-8"),
-            (header::CACHE_CONTROL, "no-cache"),
-        ],
-        install_ps1_body(&state.config.public_origin),
-    )
+pub(crate) async fn install_ps1(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Response {
+    state.static_pages.install_ps1.respond(&headers)
 }
 
 /// The canonical Intendant mark, embedded so every page this binary serves
@@ -161,12 +152,17 @@ pub(crate) async fn landing_asset(AxumPath(name): AxumPath<String>) -> Response 
 }
 
 pub(crate) async fn readyz(State(state): State<Arc<AppState>>) -> Response {
-    let state_parent_ok = state
-        .config
-        .data_file
-        .parent()
-        .map(|parent| parent.exists() || std::fs::create_dir_all(parent).is_ok())
-        .unwrap_or(false);
+    // Filesystem probe (and first-run dir creation) off the async workers:
+    // a slow disk must degrade this probe, not the whole runtime.
+    let parent = state.config.data_file.parent().map(Path::to_path_buf);
+    let state_parent_ok = match parent {
+        None => false,
+        Some(parent) => tokio::task::spawn_blocking(move || {
+            parent.exists() || std::fs::create_dir_all(&parent).is_ok()
+        })
+        .await
+        .unwrap_or(false),
+    };
     let ok = state_parent_ok;
     let status = if ok {
         StatusCode::OK
@@ -193,18 +189,99 @@ fn deny_html_framing(headers: &mut HeaderMap) {
     headers.insert("x-frame-options", HeaderValue::from_static("DENY"));
 }
 
-fn html_response(body: String) -> Response {
-    let mut headers = HeaderMap::new();
-    headers.insert(
-        header::CONTENT_TYPE,
-        HeaderValue::from_static("text/html; charset=utf-8"),
-    );
-    deny_html_framing(&mut headers);
-    (headers, body).into_response()
+/// One startup-rendered page: shared bytes plus a strong ETag, served with
+/// `Cache-Control: no-cache` so browsers revalidate cheaply (304) instead of
+/// re-downloading tens of KB per visit.
+pub(crate) struct StaticPage {
+    body: axum::body::Bytes,
+    etag: HeaderValue,
+    content_type: HeaderValue,
+    deny_framing: bool,
 }
 
-pub(crate) async fn landing_ui(State(state): State<Arc<AppState>>) -> Response {
-    html_response(landing_ui_html(&state.config.public_origin))
+impl StaticPage {
+    fn html(body: String) -> Self {
+        Self::new(
+            body,
+            HeaderValue::from_static("text/html; charset=utf-8"),
+            true,
+        )
+    }
+
+    fn script(body: String) -> Self {
+        Self::new(
+            body,
+            HeaderValue::from_static("text/plain; charset=utf-8"),
+            false,
+        )
+    }
+
+    fn new(body: String, content_type: HeaderValue, deny_framing: bool) -> Self {
+        let etag = HeaderValue::from_str(&format!("\"{}\"", &sha256_hex(body.as_bytes())[..32]))
+            .expect("hex etag is a valid header value");
+        StaticPage {
+            body: axum::body::Bytes::from(body),
+            etag,
+            content_type,
+            deny_framing,
+        }
+    }
+
+    fn respond(&self, request_headers: &HeaderMap) -> Response {
+        let revalidated = request_headers
+            .get(header::IF_NONE_MATCH)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| {
+                value.split(',').any(|candidate| {
+                    candidate.trim().trim_start_matches("W/")
+                        == self.etag.to_str().unwrap_or_default()
+                })
+            });
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_TYPE, self.content_type.clone());
+        headers.insert(header::ETAG, self.etag.clone());
+        headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-cache"));
+        if self.deny_framing {
+            deny_html_framing(&mut headers);
+        }
+        if revalidated {
+            (StatusCode::NOT_MODIFIED, headers).into_response()
+        } else {
+            (headers, self.body.clone()).into_response()
+        }
+    }
+}
+
+/// Every page this binary serves is a pure function of the public origin
+/// (pinned by the artifact-transparency determinism tests), so they are
+/// rendered exactly once at startup instead of formatting a multi-KB
+/// template per hit. The same builders feed the transparency manifest, so
+/// served bytes and logged hashes cannot diverge.
+pub(crate) struct StaticPages {
+    landing: StaticPage,
+    connect: StaticPage,
+    access: StaticPage,
+    trust: StaticPage,
+    install_sh: StaticPage,
+    install_ps1: StaticPage,
+}
+
+impl StaticPages {
+    pub(crate) fn render(config: &ServiceConfig) -> Self {
+        let origin = config.public_origin.as_str();
+        StaticPages {
+            landing: StaticPage::html(landing_ui_html(origin)),
+            connect: StaticPage::html(connect_page_html(origin)),
+            access: StaticPage::html(access_page_html(origin)),
+            trust: StaticPage::html(trust_ui_html(origin)),
+            install_sh: StaticPage::script(install_sh_body(origin)),
+            install_ps1: StaticPage::script(install_ps1_body(origin)),
+        }
+    }
+}
+
+pub(crate) async fn landing_ui(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    state.static_pages.landing.respond(&headers)
 }
 
 /// The `/connect` page body — shared by the route handler and the
@@ -222,16 +299,16 @@ pub(crate) fn access_page_html(origin: &str) -> String {
     )
 }
 
-pub(crate) async fn connect_ui(State(state): State<Arc<AppState>>) -> Response {
-    html_response(connect_page_html(&state.config.public_origin))
+pub(crate) async fn connect_ui(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    state.static_pages.connect.respond(&headers)
 }
 
-pub(crate) async fn trust_ui(State(state): State<Arc<AppState>>) -> Response {
-    html_response(trust_ui_html(&state.config.public_origin))
+pub(crate) async fn trust_ui(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    state.static_pages.trust.respond(&headers)
 }
 
-pub(crate) async fn access_ui(State(state): State<Arc<AppState>>) -> Response {
-    html_response(access_page_html(&state.config.public_origin))
+pub(crate) async fn access_ui(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    state.static_pages.access.respond(&headers)
 }
 
 /// The default Connect build is a directory, not a daemon-control client.
@@ -2208,7 +2285,7 @@ mod tests {
             trust_ui_html("https://connect.example"),
             access_page_html("https://connect.example"),
         ] {
-            let response = html_response(body);
+            let response = StaticPage::html(body).respond(&HeaderMap::new());
             assert_eq!(
                 response
                     .headers()
@@ -2218,6 +2295,54 @@ mod tests {
             );
             assert_framing_denied(&response);
         }
+    }
+
+    #[test]
+    fn static_pages_serve_etags_and_revalidate_to_304() {
+        let page = StaticPage::html("<!doctype html><title>x</title>".to_string());
+        let full = page.respond(&HeaderMap::new());
+        assert_eq!(full.status(), StatusCode::OK);
+        let etag = full.headers().get(header::ETAG).cloned().expect("etag set");
+        assert_eq!(
+            full.headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("no-cache")
+        );
+        assert_framing_denied(&full);
+
+        let mut revalidate = HeaderMap::new();
+        revalidate.insert(header::IF_NONE_MATCH, etag.clone());
+        let not_modified = page.respond(&revalidate);
+        assert_eq!(not_modified.status(), StatusCode::NOT_MODIFIED);
+        assert_eq!(
+            not_modified.headers().get(header::ETAG),
+            Some(&etag),
+            "304 re-states the validator"
+        );
+
+        // A weak-prefixed or list-form validator still matches; a stale one
+        // gets the full body again.
+        let mut weak = HeaderMap::new();
+        weak.insert(
+            header::IF_NONE_MATCH,
+            HeaderValue::from_str(&format!("W/{}, \"other\"", etag.to_str().unwrap())).unwrap(),
+        );
+        assert_eq!(page.respond(&weak).status(), StatusCode::NOT_MODIFIED);
+        let mut stale = HeaderMap::new();
+        stale.insert(header::IF_NONE_MATCH, HeaderValue::from_static("\"stale\""));
+        assert_eq!(page.respond(&stale).status(), StatusCode::OK);
+
+        // Installers keep their plain-text identity and skip CSP framing.
+        let script = StaticPage::script("#!/bin/sh\n".to_string()).respond(&HeaderMap::new());
+        assert_eq!(
+            script
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("text/plain; charset=utf-8")
+        );
+        assert!(script.headers().get("x-frame-options").is_none());
     }
 
     #[tokio::test]

--- a/src/bin/connect/ui.rs
+++ b/src/bin/connect/ui.rs
@@ -233,8 +233,12 @@ impl StaticPage {
             .and_then(|value| value.to_str().ok())
             .is_some_and(|value| {
                 value.split(',').any(|candidate| {
-                    candidate.trim().trim_start_matches("W/")
-                        == self.etag.to_str().unwrap_or_default()
+                    let candidate = candidate.trim();
+                    // RFC 9110: `If-None-Match: *` matches any current
+                    // representation.
+                    candidate == "*"
+                        || candidate.trim_start_matches("W/")
+                            == self.etag.to_str().unwrap_or_default()
                 })
             });
         let mut headers = HeaderMap::new();
@@ -2333,6 +2337,11 @@ mod tests {
         stale.insert(header::IF_NONE_MATCH, HeaderValue::from_static("\"stale\""));
         assert_eq!(page.respond(&stale).status(), StatusCode::OK);
 
+        // RFC 9110: `*` matches any current representation.
+        let mut any = HeaderMap::new();
+        any.insert(header::IF_NONE_MATCH, HeaderValue::from_static("*"));
+        assert_eq!(page.respond(&any).status(), StatusCode::NOT_MODIFIED);
+
         // Installers keep their plain-text identity and skip CSP framing.
         let script = StaticPage::script("#!/bin/sh\n".to_string()).respond(&HeaderMap::new());
         assert_eq!(
@@ -2475,7 +2484,7 @@ mod tests {
             .lock()
             .await
             .contains_key("legacy-session"));
-        assert!(state.rate_limits.lock().await.is_empty());
+        assert!(state.rate_limits.lock().await.buckets.is_empty());
         server.abort();
     }
 

--- a/src/bin/connect/ui.rs
+++ b/src/bin/connect/ui.rs
@@ -2484,7 +2484,7 @@ mod tests {
             .lock()
             .await
             .contains_key("legacy-session"));
-        assert!(state.rate_limits.lock().await.buckets.is_empty());
+        assert!(state.rate_limits.lock().await.scopes.is_empty());
         server.abort();
     }
 


### PR DESCRIPTION
Implements the S/M findings from the connect efficiency audit (scope 22): the hosted rendezvous rewrote and fsynced its entire JSON store — all users, vault blobs, and the whole transparency log — on every daemon long-poll and re-register, re-hashed the full Merkle log on every read, re-rendered every static page per hit, and never pruned its in-memory tables. The second commit applies the dual-review fixes (durable proof watermark, per-bucket rate windows with fail-closed capacity, graceful-shutdown flush); the third applies the delta-review round (per-scope capacity partitions, /64 aggregation, Retry-After); the fourth fixes the drain design (a global request deadline makes the graceful drain honest — axum connections are detached tasks, so dropping the serve future abandons rather than aborts them).

## Finding → fix

| # | Finding (audit rank) | Fix |
|---|---|---|
| 1 | `touch_daemon` full-store serialize + fsync per 15s long-poll (~5 writes/daemon-minute) | Presence fields (`last_seen`, `updated`, presence hours) stay in-memory and mark the debounced flusher on every touch; they also ride along with every synchronous persist. Crash-loss window for presence-display data = the 60s debounce. |
| 2 | Single-Mutex whole-store persistence hot paths (M-effort mitigation; SQLite/redb L-track explicitly out of scope) | Dirty-flag + debounced flusher (60s window): one coalesced write per window, serialized under the store lock and written via `spawn_blocking`, so single-writer ordering is preserved (the file can never regress to an older snapshot). Compact JSON (~halves bytes). **Durability boundary (review-adjusted):** every security-effective registration — including each once-a-minute proof-watermark advance, which floors replay for the daemon-session token minted on acceptance — persists synchronously before the token is issued; only proof-less operator probes defer. Net write reduction is therefore the long-poll path (~4 writes/daemon-minute eliminated); the register-path persist cadence (1/daemon-minute) matches the pre-change baseline. All other critical paths (accounts, claims, unclaim/revoke, vault, ORL, push, invites, attestations, labels, DNS) keep synchronous persistence unchanged. |
| 3 | Transparency log re-hashed in full on every read; `log_find` reverse-scans with per-entry JSON parse | `LogCaches` on `AppState`: a leaf-hash cache extended incrementally (the log is strictly append-only; a shrink triggers a defensive rebuild) feeds the STH/proof/consistency/artifact/release endpoints; a lazily-extended daemon-id/handle index answers `log_find` in O(1) with scan-identical semantics (parity-tested against the original scan). Poisoned cache locks recover — derived, rebuildable state. |
| 4 | Unbounded in-memory tables (`rate_limits` on client-controlled XFF keys; `sessions`, `pending_claims`, WebAuthn pendings leak) | 60s sweeper: expired sessions/flows/daemon-sessions/dashboard-sessions, resolved claims after a 15-min observation window, and expired rate buckets. **Rate-limit semantics (review-adjusted, two rounds):** each bucket carries its own window and expiry is judged per bucket — churned short-window keys can no longer rank as live under a global bound and crowd out active hourly budgets. Capacity is **partitioned per scope** (5k-key caps for short-window high-cardinality scopes, 2k for >=10-minute windows; documented worst case ~117k entries / ~12MB across today's ~27 scopes), so saturating one scope's partition can never fail-close a different scope: within a partition, genuinely expired buckets are reclaimed first (full scans amortized to one per second while saturated, a documented <=1s bounded false-429) and otherwise the new key **fails closed** — a live bucket is never evicted, so cheap key churn cannot reset a security-sensitive counter (e.g. the 30/hour new-daemon-identity budget, whose bucket deliberately allocates before signature verification to bound verification CPU). Rate 429s carry **Retry-After** (the bucket's remaining window when over limit; the scope window as the honest upper bound when a partition is saturated). Forwarded source identities are parsed and canonicalized into bounded tokens: IPv6 aggregates by **/64 prefix** (rotating inside a prefix mints no new buckets; the documented, NAT-analogous collateral is that a hosting subnet packing many tenants into one /64 shares each per-source budget), IPv4-mapped IPv6 folds to its IPv4 form, `ip:port` proxy forms resolve to the address, garbage and zone-qualified link-local forms collapse to one bounded bucket, and the absent-header fallback stays `unknown`. |
| 5 | Fleet sync always rewrites + persists content-identical pushes (`updated_unix_ms` stamped per input) | Merge extracted to `merge_fleet_targets`, which compares the rebuilt partition against the stored one ignoring only `updated_unix_ms` (via derived `PartialEq`, so future fields participate automatically) and skips the rewrite + persist on no-ops. |
| 6 | Presence monitor clones the whole push-subscription table every 30s; serial push fan-outs with a 15s per-send timeout | Steady-state ticks clone nothing; transition ticks clone only affected owners' opted-in rows. All four fan-out sites (presence, `daemon_notify`, `push_test`, `daemon_dry` — which also cloned the whole table) share a concurrent `FuturesUnordered` fan-out, bounded by the existing 10-subscriptions-per-account cap. |
| 7 | Static HTML re-rendered per hit; no HTTP caching on HTML | Pages/installers rendered once at startup (`StaticPages` — pure functions of the public origin; the same builders feed the artifact-transparency manifest, byte-parity pinned by the existing router test), served as shared `Bytes` with strong ETags + `Cache-Control: no-cache`, 304 revalidation (including `W/`-prefixed, list-form, and `*` validators per RFC 9110). |
| 8 | Global `Notify` thundering herd on event enqueue | **Skipped deliberately.** Impact is scale-gated (events are rare and human-initiated) and a per-daemon notify entangles queue-entry lifecycle with waiter registration — a lost-wakeup bug there would delay claim challenges against the 60s claim TTL. Falls out naturally with the L-track store redesign. |
| — | Durability: parent dir never fsynced after the state-file rename | `fsync_parent_dir` after every publish (`#[cfg(unix)]`; directories are not open-and-fsync-able on Windows — the pre-rename file sync + atomic replace stand there). |
| — | No shutdown flush (review finding, three rounds) | Sound ordering: a **global 20s request deadline** on the whole router (408 on expiry; store mutations are awaitpoint-free from first write through mark/persist, so cancellation cannot publish a half-applied mutation) bounds every request, the daemon long-poll self-caps at 15s to end naturally inside the drain, and graceful shutdown **waits for those bounded connections** (axum spawns each as a detached task — dropping the serve future would abandon, not abort, them). The final flush runs after serve returns — provably after every handler mutation — on **every** exit path, serve errors included; a 40s paranoid deadline logs and flushes anyway if the drain somehow wedges. A failed signal-handler registration parks only its own select arm, leaving the other signal's receiver live. Every flusher failure arm (serialize, write, join) re-marks uniformly. |
| — | `readyz` blocking filesystem probe on the async runtime | Probe moved to `spawn_blocking`, semantics identical. |

Out of scope, unchanged by design: the XFF-header trust model for rate keys (posture; values are now bounded/canonicalized but the header is still believed), `update_store_transaction`'s clone-per-mutation and `require_user`'s linear scan + record clone (L-track store redesign), moving the log to its own file (persistence-format change), and transactionality of the remaining live-mutation paths. Follow-ups noted, not implemented: hashing the artifact-transparency manifest from the served `StaticPages` bytes instead of re-invoking the builders (divergence class currently pinned by the router byte-parity test), and sweeping stale `event_queues` entries (pre-existing).

## Deployment / compatibility

- **Store format is forward- and backward-compatible.** The only serialization change is pretty → compact JSON; serde ignores whitespace in both directions, so the deployed instance's existing pretty state file loads unchanged, and a rollback binary reads the compact file (pinned by `store_format_is_forward_and_backward_compatible_across_compaction`). No migration step.
- **Landing requires an operator redeploy** of intendant-connect for any of this to take effect on the hosted instance.
- Behavior notes: resolved claim records expire from the status endpoint after 15 minutes (previously queryable forever); deploys drain in-flight requests (bounded by the 20s request deadline; long-polls self-cap at 15s) before flushing and exiting; under a sustained rate-key flood, only the flooded scope's partition fails closed for brand-new sources (with Retry-After) until expired buckets free slots — other scopes are untouched, and active buckets are never reset by churn; any request exceeding the global 20s deadline is answered 408.

## Tests

New coverage: compact/pretty round-trip compatibility; dirty-flag semantics and `persist_locked` clearing; end-to-end debounced flush to disk; graceful-shutdown final flush; sweeper retention rules; per-bucket rate expiry, capacity fail-closed (no live eviction), amortized saturated prunes, canonical bounded rate keys; registration durability classification (proof advances durable, probes defer) and a simulated-restart proof-replay rejection; end-to-end scope-saturation isolation (saturated scope 429s a fresh source while another scope admits it), /64 and IPv4-mapped canonicalization, Retry-After on both 429 paths; the request deadline answering 408, and an end-to-end shutdown-drain regression (a long-poll parked across the shutdown signal completes, serve waits, and the on-disk store equals memory at exit); leaf-cache and find-index parity against the original implementations (including incremental extends); fleet no-op detection (identical resync, real change, new host, owned-daemon canonicalization convergence, cross-user isolation); ETag/304 revalidation including weak/list/`*` validators. Battery: `cargo fmt --check`, `cargo clippy` (clean), `cargo test --bins` (3416 + 91 + 96 passed), `cargo test --test e2e` (21 passed).
