### PR TITLE
peer/transfer: efficiency batch — transfer backpressure + authority memo, TLS caching, tunnel lazy chunks + bounded PTY lane

### DIFF
--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -3586,10 +3586,10 @@ mod tests {
     #[tokio::test]
     async fn api_voice_session_preserves_endpoint_error_metadata() {
         let mut rt = runtime();
-        rt.config = serde_json::json!({
+        rt.config = Arc::new(serde_json::json!({
             "provider": "unsupported-voice-provider",
             "model": "unused",
-        });
+        }));
         let response = api_voice_session_response("voice1".to_string(), &rt).await;
         assert_eq!(response["t"], "response");
         assert_eq!(response["id"], "voice1");

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -120,7 +120,7 @@ pub(crate) async fn api_state_snapshot_response(
             "t": "state_snapshot",
             "state": state,
             "connection_id": runtime.session_id.clone(),
-            "config": runtime.config.clone(),
+            "config": &*runtime.config,
             "session_id": bootstrap_session_id,
         },
     })

--- a/src/bin/caller/dashboard_control/api_media.rs
+++ b/src/bin/caller/dashboard_control/api_media.rs
@@ -61,25 +61,11 @@ pub(crate) fn media_task_response(
 pub(crate) fn read_inbound_upload_bytes(
     upload: &mut InboundUploadState,
 ) -> Result<Vec<u8>, String> {
-    let mut bytes = Vec::with_capacity(upload.received_bytes);
-    upload
-        .tmp
-        .as_file_mut()
-        .seek(std::io::SeekFrom::Start(0))
-        .map_err(|e| format!("seek upload tempfile: {e}"))?;
-    upload
-        .tmp
-        .as_file_mut()
-        .read_to_end(&mut bytes)
-        .map_err(|e| format!("read upload tempfile: {e}"))?;
-    if bytes.len() != upload.received_bytes {
-        return Err(format!(
-            "upload byte count changed while committing: expected {}, got {}",
-            upload.received_bytes,
-            bytes.len()
-        ));
-    }
-    Ok(bytes)
+    // Memory spools (every payload ≤1 MiB — presence webcam frames
+    // included) move out with zero I/O; disk spools settle and read back
+    // exactly as the tempfile path always did.
+    let received_bytes = upload.received_bytes;
+    upload.spool.take_bytes(received_bytes)
 }
 
 pub(crate) async fn dashboard_media_session_handles(

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -9,17 +9,26 @@ pub(crate) fn spawn_control_request(
     method: String,
     params: Option<serde_json::Value>,
     runtime: ControlRuntime,
-    task_tx: mpsc::Sender<ControlTaskResponse>,
-    pending_requests: &mut HashMap<String, CancellationToken>,
+    task_tx: mpsc::Sender<SequencedTaskResponse>,
+    pending_requests: &mut PendingControlRequests,
 ) {
-    if let Some(previous) = pending_requests.remove(&id) {
-        previous.cancel();
-    }
-    let cancel = CancellationToken::new();
-    pending_requests.insert(id.clone(), cancel.clone());
+    let (cancel, generation) = pending_requests.admit(&id);
     tokio::spawn(async move {
-        let response = control_request_response(id, method, params, runtime, cancel).await;
-        let _ = task_tx.send(response).await;
+        // Cancellation is enforced at this seam rather than threaded into
+        // every handler's internals: superseding/cancelling the request
+        // drops the handler future at its next await point, which bounds
+        // live work for same-id spam (an already-entered spawn_blocking
+        // segment runs out on the blocking pool and drops its output).
+        // A cancelled task sends nothing — its reservation was already
+        // replaced or removed by whoever cancelled it.
+        let response = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return,
+            response = control_request_response(id, method, params, runtime, cancel.clone()) => {
+                response
+            }
+        };
+        let _ = task_tx.send((generation, response)).await;
     });
 }
 
@@ -75,18 +84,14 @@ pub(crate) fn spawn_control_stream(
     id: String,
     method: String,
     params: Option<serde_json::Value>,
-    task_tx: mpsc::Sender<ControlTaskResponse>,
-    pending_requests: &mut HashMap<String, CancellationToken>,
+    task_tx: mpsc::Sender<SequencedTaskResponse>,
+    pending_requests: &mut PendingControlRequests,
 ) {
-    if let Some(previous) = pending_requests.remove(&id) {
-        previous.cancel();
-    }
-    let cancel = CancellationToken::new();
-    pending_requests.insert(id.clone(), cancel.clone());
+    let (cancel, generation) = pending_requests.admit(&id);
     tokio::spawn(async move {
         match method.as_str() {
             "api_sessions_stream" => {
-                stream_sessions_response(id, params.as_ref(), task_tx, cancel).await;
+                stream_sessions_response(id, params.as_ref(), task_tx, generation, cancel).await;
             }
             _ => {
                 let frame = serde_json::json!({
@@ -96,12 +101,15 @@ pub(crate) fn spawn_control_stream(
                     "error": format!("unknown stream method: {method}"),
                 });
                 let _ = task_tx
-                    .send(ControlTaskResponse {
-                        id,
-                        frame,
-                        byte_stream: None,
-                        done: true,
-                    })
+                    .send((
+                        generation,
+                        ControlTaskResponse {
+                            id,
+                            frame,
+                            byte_stream: None,
+                            done: true,
+                        },
+                    ))
                     .await;
             }
         }
@@ -381,7 +389,8 @@ pub(crate) async fn control_request_frame(
 pub(crate) async fn stream_sessions_response(
     id: String,
     params: Option<&serde_json::Value>,
-    task_tx: mpsc::Sender<ControlTaskResponse>,
+    task_tx: mpsc::Sender<SequencedTaskResponse>,
+    generation: u64,
     cancel: CancellationToken,
 ) {
     let requested_limit = sessions_stream_requested_limit(params);
@@ -391,17 +400,20 @@ pub(crate) async fn stream_sessions_response(
         // The sessions-stream core always answers on the Stream lane; a
         // buffered response reaching this framer is a wiring bug.
         let _ = task_tx
-            .send(ControlTaskResponse {
-                id: id.clone(),
-                frame: serde_json::json!({
-                    "t": "stream_end",
-                    "id": id,
-                    "ok": false,
-                    "error": "session stream returned a buffered response",
-                }),
-                byte_stream: None,
-                done: true,
-            })
+            .send((
+                generation,
+                ControlTaskResponse {
+                    id: id.clone(),
+                    frame: serde_json::json!({
+                        "t": "stream_end",
+                        "id": id,
+                        "ok": false,
+                        "error": "session stream returned a buffered response",
+                    }),
+                    byte_stream: None,
+                    done: true,
+                },
+            ))
             .await;
         return;
     };
@@ -410,6 +422,7 @@ pub(crate) async fn stream_sessions_response(
         "api_sessions_stream".to_string(),
         stream,
         task_tx,
+        generation,
         cancel,
     )
     .await;
@@ -419,7 +432,8 @@ pub(crate) async fn stream_json_lines_response(
     id: String,
     method: String,
     stream: crate::web_gateway::LineStream,
-    task_tx: mpsc::Sender<ControlTaskResponse>,
+    task_tx: mpsc::Sender<SequencedTaskResponse>,
+    generation: u64,
     cancel: CancellationToken,
 ) {
     let crate::web_gateway::LineStream {
@@ -431,16 +445,19 @@ pub(crate) async fn stream_json_lines_response(
     }
 
     if task_tx
-        .send(ControlTaskResponse {
-            id: id.clone(),
-            frame: serde_json::json!({
-                "t": "stream_start",
-                "id": id,
-                "method": method,
-            }),
-            byte_stream: None,
-            done: false,
-        })
+        .send((
+            generation,
+            ControlTaskResponse {
+                id: id.clone(),
+                frame: serde_json::json!({
+                    "t": "stream_start",
+                    "id": id,
+                    "method": method,
+                }),
+                byte_stream: None,
+                done: false,
+            },
+        ))
         .await
         .is_err()
     {
@@ -466,12 +483,15 @@ pub(crate) async fn stream_json_lines_response(
                     "error": format!("session stream returned invalid JSON: {e}"),
                 });
                 let _ = task_tx
-                    .send(ControlTaskResponse {
-                        id,
-                        frame,
-                        byte_stream: None,
-                        done: true,
-                    })
+                    .send((
+                        generation,
+                        ControlTaskResponse {
+                            id,
+                            frame,
+                            byte_stream: None,
+                            done: true,
+                        },
+                    ))
                     .await;
                 return;
             }
@@ -486,12 +506,15 @@ pub(crate) async fn stream_json_lines_response(
         });
         seq = seq.saturating_add(1);
         if task_tx
-            .send(ControlTaskResponse {
-                id: id.clone(),
-                frame,
-                byte_stream: None,
-                done: false,
-            })
+            .send((
+                generation,
+                ControlTaskResponse {
+                    id: id.clone(),
+                    frame,
+                    byte_stream: None,
+                    done: false,
+                },
+            ))
             .await
             .is_err()
         {
@@ -517,12 +540,15 @@ pub(crate) async fn stream_json_lines_response(
     };
     if !cancel.is_cancelled() {
         let _ = task_tx
-            .send(ControlTaskResponse {
-                id,
-                frame,
-                byte_stream: None,
-                done: true,
-            })
+            .send((
+                generation,
+                ControlTaskResponse {
+                    id,
+                    frame,
+                    byte_stream: None,
+                    done: true,
+                },
+            ))
             .await;
     }
 }
@@ -1687,7 +1713,7 @@ mod tests {
                 line_tx.send(format!("{line}\n")).await.unwrap();
             }
         });
-        let (task_tx, mut rx) = mpsc::channel::<ControlTaskResponse>(8);
+        let (task_tx, mut rx) = mpsc::channel::<SequencedTaskResponse>(8);
 
         stream_json_lines_response(
             "stream1".to_string(),
@@ -1697,12 +1723,13 @@ mod tests {
                 source: stream_task,
             },
             task_tx,
+            7,
             CancellationToken::new(),
         )
         .await;
 
         let mut frames = Vec::new();
-        while let Some(task) = rx.recv().await {
+        while let Some((_, task)) = rx.recv().await {
             frames.push(task);
             if frames.last().unwrap().done {
                 break;
@@ -2780,17 +2807,18 @@ mod tests {
         // Tunnel lane: the framer over the same sequence — one
         // stream_event per line, events byte-identical to the HTTP
         // lane's parsed lines, under the lifecycle frames.
-        let (task_tx, mut task_rx) = mpsc::channel::<ControlTaskResponse>(64);
+        let (task_tx, mut task_rx) = mpsc::channel::<SequencedTaskResponse>(64);
         stream_json_lines_response(
             "stream-parity".to_string(),
             "api_sessions_stream".to_string(),
             replay_line_stream(lines.clone()),
             task_tx,
+            7,
             CancellationToken::new(),
         )
         .await;
         let mut frames = Vec::new();
-        while let Some(task) = task_rx.recv().await {
+        while let Some((_, task)) = task_rx.recv().await {
             let done = task.done;
             frames.push(task);
             if done {

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -635,7 +635,7 @@ pub(crate) async fn api_session_detail_response_from_home(
     })
     .await;
     match result {
-        Ok(response) => frame_api_json_body_response(id, response, "session detail"),
+        Ok(response) => frame_api_json_body_response_preserialized(id, response, "session detail"),
         Err(e) => serde_json::json!({
             "t": "response",
             "id": id,
@@ -1301,7 +1301,7 @@ pub(crate) async fn api_sessions_message_search_response(
             .unwrap_or(20),
     };
     let response = crate::web_gateway::sessions_message_search_api_response(search).await;
-    frame_api_json_body_response(id, response, "message search")
+    frame_api_json_body_response_preserialized(id, response, "message search")
 }
 
 pub(crate) async fn api_sessions_search_response(
@@ -1327,7 +1327,7 @@ pub(crate) async fn api_sessions_search_response(
         cancel,
     )
     .await;
-    frame_api_json_body_response(id, response, "session search")
+    frame_api_json_body_response_preserialized(id, response, "session search")
 }
 
 #[cfg(test)]
@@ -1946,8 +1946,21 @@ mod tests {
     }
 
     /// The pre-_httpStatus envelope (difference #1): ok:true with the
-    /// body as the verbatim result — no injected status metadata.
+    /// body as the verbatim result — no injected status metadata. The
+    /// sessions family answers with the PRE-SERIALIZED carrier
+    /// (`Value::String(<envelope text>)`, sent verbatim by
+    /// `send_control_task_response`); materialize it first so the shape
+    /// assertions run against what the browser parses off the wire.
     fn tunnel_plain_body(frame: &serde_json::Value) -> serde_json::Value {
+        let materialized;
+        let frame = match frame {
+            serde_json::Value::String(text) => {
+                materialized = serde_json::from_str::<serde_json::Value>(text)
+                    .expect("pre-serialized envelope is valid JSON");
+                &materialized
+            }
+            other => other,
+        };
         assert_eq!(frame["t"], "response");
         assert_eq!(frame["ok"], true, "{frame}");
         if let Some(result) = frame["result"].as_object() {

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -921,7 +921,22 @@ pub(crate) async fn api_session_current_upload_task_response(
     // The tunnel edge of the Streaming lane (S8): frame params parsed
     // here in their wire form, the spool handed to the same neutral
     // commit the HTTP staged-upload POST feeds its socket spool.
-    let (params, body) = upload.into_spooled_body();
+    let (params, body) = match upload.into_spooled_body() {
+        Ok(spooled) => spooled,
+        Err(e) => {
+            return ControlTaskResponse {
+                id: id.clone(),
+                frame: serde_json::json!({
+                    "t": "response",
+                    "id": id,
+                    "ok": false,
+                    "error": format!("spool upload: {e}"),
+                }),
+                byte_stream: None,
+                done: true,
+            };
+        }
+    };
     let name = optional_string_param(&params, &["name", "filename", "file_name"])
         .unwrap_or_else(|| "upload.bin".to_string());
     let mime = optional_string_param(&params, &["mime", "content_type", "contentType"])
@@ -2502,17 +2517,11 @@ mod tests {
         // Tunnel commit: the upload lane's spooled frames end in the
         // same shared neutral fn the HTTP POST runs (difference #3 —
         // only the carriage differs).
-        let mut tmp = tempfile::NamedTempFile::new().unwrap();
-        tmp.write_all(&payload).unwrap();
-        let upload = InboundUploadState {
-            method: "api_session_current_upload".to_string(),
-            params: serde_json::json!({ "name": "parity.txt", "mime": "text/plain" }),
-            tmp,
-            total_bytes: payload.len(),
-            expected_chunks: 1,
-            next_seq: 1,
-            received_bytes: payload.len(),
-        };
+        let upload = crate::dashboard_control::tests::test_upload_state(
+            "api_session_current_upload",
+            serde_json::json!({ "name": "parity.txt", "mime": "text/plain" }),
+            &payload,
+        );
         let commit = api_session_current_upload_task_response(
             "parity-upload-commit".to_string(),
             upload,

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -96,17 +96,27 @@ pub(crate) fn spawn_control_stream(
 ) {
     let (cancel, generation, slot) = pending_requests.admit(&id);
     tokio::spawn(async move {
-        // Same RAII contract as the request lane: the slot spans the
-        // framer AND the awaited source task, so the stream's detached
-        // blocking work stays inside the admission bound (the framer
-        // polls the token per line; an early exit drops the line
-        // receiver, which stops the producer at its next send).
-        let _slot = slot;
+        // Same RAII contract as the request lane, with one refinement: a
+        // mid-stream framer exit must NOT free the slot while the line
+        // producer's detached hydration keeps running (its final send
+        // results are ignored, so a dropped receiver does not stop it) —
+        // the framer hands the slot + receiver to a drain task that frees
+        // the slot only when the producer's sender drops (see
+        // `hold_slot_until_producer_exits`).
         match method.as_str() {
             "api_sessions_stream" => {
-                stream_sessions_response(id, params.as_ref(), task_tx, generation, cancel).await;
+                stream_sessions_response(
+                    id,
+                    params.as_ref(),
+                    task_tx,
+                    generation,
+                    cancel,
+                    Some(slot),
+                )
+                .await;
             }
             _ => {
+                let _slot = slot;
                 let frame = serde_json::json!({
                     "t": "stream_end",
                     "id": id,
@@ -407,6 +417,7 @@ pub(crate) async fn stream_sessions_response(
     task_tx: mpsc::Sender<SequencedTaskResponse>,
     generation: u64,
     cancel: CancellationToken,
+    slot: Option<LiveWorkSlot>,
 ) {
     let requested_limit = sessions_stream_requested_limit(params);
     let crate::web_gateway::ApiResponse::Stream { stream, .. } =
@@ -439,10 +450,26 @@ pub(crate) async fn stream_sessions_response(
         task_tx,
         generation,
         cancel,
+        slot,
     )
     .await;
 }
 
+/// Free `slot` only when the line PRODUCER actually exits: discard
+/// remaining lines until `recv()` returns `None` — the producer dropping
+/// its sender is the producer function returning. Mid-stream framer exits
+/// (cancellation, send failure, invalid JSON) hand their receiver here so
+/// admission capacity is never released while hydration keeps running;
+/// slot lifetime equals producer lifetime by construction, with zero
+/// producer-side changes.
+fn hold_slot_until_producer_exits(slot: Option<LiveWorkSlot>, mut line_rx: mpsc::Receiver<String>) {
+    tokio::spawn(async move {
+        let _slot = slot;
+        while line_rx.recv().await.is_some() {}
+    });
+}
+
+#[allow(clippy::too_many_arguments)] // established internal signature: the params are distinct dependencies, not a bundle
 pub(crate) async fn stream_json_lines_response(
     id: String,
     method: String,
@@ -450,13 +477,14 @@ pub(crate) async fn stream_json_lines_response(
     task_tx: mpsc::Sender<SequencedTaskResponse>,
     generation: u64,
     cancel: CancellationToken,
+    slot: Option<LiveWorkSlot>,
 ) {
     let crate::web_gateway::LineStream {
         lines: mut line_rx,
         source: stream_task,
     } = stream;
     if cancel.is_cancelled() {
-        return;
+        return hold_slot_until_producer_exits(slot, line_rx);
     }
 
     if task_tx
@@ -476,13 +504,18 @@ pub(crate) async fn stream_json_lines_response(
         .await
         .is_err()
     {
-        return;
+        return hold_slot_until_producer_exits(slot, line_rx);
     }
 
     let mut seq: u64 = 0;
-    while let Some(line) = line_rx.recv().await {
+    loop {
+        let Some(line) = line_rx.recv().await else {
+            // recv() == None: the producer exited — the loop ends and the
+            // slot may now die with this framer.
+            break;
+        };
         if cancel.is_cancelled() {
-            return;
+            return hold_slot_until_producer_exits(slot, line_rx);
         }
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -508,7 +541,7 @@ pub(crate) async fn stream_json_lines_response(
                         },
                     ))
                     .await;
-                return;
+                return hold_slot_until_producer_exits(slot, line_rx);
             }
         };
         let chunk_id = format!("{id}:{seq}");
@@ -533,7 +566,7 @@ pub(crate) async fn stream_json_lines_response(
             .await
             .is_err()
         {
-            return;
+            return hold_slot_until_producer_exits(slot, line_rx);
         }
     }
 
@@ -1391,6 +1424,64 @@ mod tests {
     use super::*;
     use crate::dashboard_control::tests::runtime;
 
+    /// A cancelled stream must NOT free its live-work slot while the line
+    /// producer keeps running: the framer hands the slot + receiver to
+    /// the drain task, which frees the slot only when the producer's
+    /// sender drops (the producer function returning).
+    #[tokio::test]
+    async fn cancelled_stream_slot_frees_only_when_producer_exits() {
+        let mut pending = PendingControlRequests::new();
+        let (_cancel_token, generation, slot) = pending.admit("s1");
+        assert_eq!(pending.live_work(), 1);
+
+        let (line_tx, line_rx) = mpsc::channel::<String>(4);
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        // A producer that keeps running well past the framer's exit.
+        let source = tokio::spawn(async move {
+            let _ = line_tx.send("{\"type\":\"ping\"}\n".to_string()).await;
+            let _ = release_rx.await;
+            // line_tx drops here — the producer's actual exit.
+        });
+        let (task_tx, _task_rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        stream_json_lines_response(
+            "s1".to_string(),
+            "api_sessions_stream".to_string(),
+            crate::web_gateway::LineStream {
+                lines: line_rx,
+                source,
+            },
+            task_tx,
+            generation,
+            cancel,
+            Some(slot),
+        )
+        .await;
+
+        // The framer returned (cancelled), the producer still runs: the
+        // slot must still be held.
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        assert_eq!(
+            pending.live_work(),
+            1,
+            "cancellation must not free the slot while the producer runs"
+        );
+
+        // Let the producer exit; the drain task frees the slot at None.
+        release_tx.send(()).expect("producer waiting");
+        let mut freed = false;
+        for _ in 0..400 {
+            if pending.live_work() == 0 {
+                freed = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(freed, "slot must free when the producer's sender drops");
+    }
+
     /// The spawned request lane's RAII contract: a spawned task holds its
     /// live-work slot for its whole life (admission counts it) and the
     /// slot frees only when the task actually exits — after its response
@@ -1773,6 +1864,7 @@ mod tests {
             task_tx,
             7,
             CancellationToken::new(),
+            None,
         )
         .await;
 
@@ -2863,6 +2955,7 @@ mod tests {
             task_tx,
             7,
             CancellationToken::new(),
+            None,
         )
         .await;
         let mut frames = Vec::new();

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -12,23 +12,30 @@ pub(crate) fn spawn_control_request(
     task_tx: mpsc::Sender<SequencedTaskResponse>,
     pending_requests: &mut PendingControlRequests,
 ) {
-    let (cancel, generation) = pending_requests.admit(&id);
+    let (cancel, generation, slot) = pending_requests.admit(&id);
     tokio::spawn(async move {
-        // Cancellation is enforced at this seam rather than threaded into
-        // every handler's internals: superseding/cancelling the request
-        // drops the handler future at its next await point, which bounds
-        // live work for same-id spam (an already-entered spawn_blocking
-        // segment runs out on the blocking pool and drops its output).
-        // A cancelled task sends nothing — its reservation was already
-        // replaced or removed by whoever cancelled it.
-        let response = tokio::select! {
+        // RAII: the slot frees when THIS task exits, so the 64-slot
+        // admission bound covers ALL live work. The handler runs to
+        // completion even when superseded — dropping the future
+        // mid-flight would detach an in-flight spawn_blocking segment
+        // and let its work (and queue position on the blocking pool)
+        // escape the bound; a cancelled predecessor therefore keeps its
+        // slot while it drains, and rapid same-id cycling saturates the
+        // bound and gets refused instead of occupying the pool.
+        // Handlers that poll the token still stop early.
+        let _slot = slot;
+        let response = control_request_response(id, method, params, runtime, cancel.clone()).await;
+        if cancel.is_cancelled() {
+            // Superseded: stale output must not reach the wire.
+            return;
+        }
+        // The channel wait is cancellable too — a completed-but-stale
+        // response must not sit queued holding a full payload.
+        tokio::select! {
             biased;
-            _ = cancel.cancelled() => return,
-            response = control_request_response(id, method, params, runtime, cancel.clone()) => {
-                response
-            }
-        };
-        let _ = task_tx.send((generation, response)).await;
+            _ = cancel.cancelled() => {}
+            _ = task_tx.send((generation, response)) => {}
+        }
     });
 }
 
@@ -87,8 +94,14 @@ pub(crate) fn spawn_control_stream(
     task_tx: mpsc::Sender<SequencedTaskResponse>,
     pending_requests: &mut PendingControlRequests,
 ) {
-    let (cancel, generation) = pending_requests.admit(&id);
+    let (cancel, generation, slot) = pending_requests.admit(&id);
     tokio::spawn(async move {
+        // Same RAII contract as the request lane: the slot spans the
+        // framer AND the awaited source task, so the stream's detached
+        // blocking work stays inside the admission bound (the framer
+        // polls the token per line; an early exit drops the line
+        // receiver, which stops the producer at its next send).
+        let _slot = slot;
         match method.as_str() {
             "api_sessions_stream" => {
                 stream_sessions_response(id, params.as_ref(), task_tx, generation, cancel).await;
@@ -100,8 +113,10 @@ pub(crate) fn spawn_control_stream(
                     "ok": false,
                     "error": format!("unknown stream method: {method}"),
                 });
-                let _ = task_tx
-                    .send((
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => {}
+                    _ = task_tx.send((
                         generation,
                         ControlTaskResponse {
                             id,
@@ -109,8 +124,8 @@ pub(crate) fn spawn_control_stream(
                             byte_stream: None,
                             done: true,
                         },
-                    ))
-                    .await;
+                    )) => {}
+                }
             }
         }
     });
@@ -1375,6 +1390,39 @@ pub(crate) async fn api_sessions_search_response(
 mod tests {
     use super::*;
     use crate::dashboard_control::tests::runtime;
+
+    /// The spawned request lane's RAII contract: a spawned task holds its
+    /// live-work slot for its whole life (admission counts it) and the
+    /// slot frees only when the task actually exits — after its response
+    /// is delivered, not at replacement time.
+    #[tokio::test]
+    async fn spawned_request_slot_frees_on_task_exit() {
+        let mut pending = PendingControlRequests::new();
+        let (tx, mut rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        spawn_control_request(
+            "slot-1".to_string(),
+            "definitely_not_a_method".to_string(),
+            None,
+            runtime(),
+            tx,
+            &mut pending,
+        );
+        assert_eq!(pending.live_work(), 1, "the spawned task holds its slot");
+        let (generation, response) = rx.recv().await.expect("task answers");
+        assert!(pending.matches("slot-1", generation));
+        assert_eq!(response.id, "slot-1");
+        // The slot frees when the task exits (just after the send).
+        let mut freed = false;
+        for _ in 0..400 {
+            if pending.live_work() == 0 {
+                freed = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(freed, "the slot must free on task exit");
+        assert!(pending.complete("slot-1", generation));
+    }
 
     #[tokio::test]
     async fn session_report_rpc_returns_zip_for_active_log() {

--- a/src/bin/caller/dashboard_control/api_transfers_fs.rs
+++ b/src/bin/caller/dashboard_control/api_transfers_fs.rs
@@ -440,7 +440,24 @@ pub(crate) async fn api_transfer_upload_chunk_task_response(
         };
     }
     let scope = transfer_store_scope(&runtime);
-    let (params, body) = upload.into_spooled_body();
+    let (params, body) = match upload.into_spooled_body() {
+        Ok(spooled) => spooled,
+        Err(e) => {
+            return ControlTaskResponse {
+                id: id.clone(),
+                frame: frame_api_response(
+                    id,
+                    crate::web_gateway::transfer_error_api_response(
+                        500,
+                        format!("spool upload chunk: {e}"),
+                    ),
+                    "transfer upload chunk",
+                ),
+                byte_stream: None,
+                done: true,
+            };
+        }
+    };
     let frame = frame_api_response(
         id.clone(),
         crate::web_gateway::transfer_upload_chunk_api_response(scope, &params, body).await,
@@ -634,8 +651,18 @@ pub(crate) async fn api_fs_write_upload_task_response(
     // Drain the upload spool off the async runtime — the content
     // carriage is transport-owned (the tunnel's upload lane vs HTTP's
     // JSON content fields); the apply leg is the shared neutral seam.
+    // Memory spools (≤1 MiB — the typical dashboard file save) move out
+    // with zero disk I/O; disk spools read back as before.
     let read_result = tokio::task::spawn_blocking(move || {
-        std::fs::read(upload.tmp.path()).map(|bytes| (upload.params, bytes))
+        let InboundUploadState {
+            params,
+            mut spool,
+            received_bytes,
+            ..
+        } = upload;
+        spool
+            .take_bytes(received_bytes)
+            .map(|bytes| (params, bytes))
     })
     .await;
     let frame = match read_result {

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -1058,8 +1058,8 @@ pub(crate) fn control_upload_start_frame(
             "empty upload declared chunks",
         ));
     }
-    let tmp = match tempfile::NamedTempFile::new() {
-        Ok(tmp) => tmp,
+    let spool = match UploadSpool::for_declared_size(total_bytes) {
+        Ok(spool) => spool,
         Err(e) => {
             return Some(control_upload_error_response(
                 id,
@@ -1081,7 +1081,7 @@ pub(crate) fn control_upload_start_frame(
                 .get("params")
                 .cloned()
                 .unwrap_or_else(|| serde_json::json!({})),
-            tmp,
+            spool,
             total_bytes,
             expected_chunks,
             next_seq: 0,
@@ -1149,7 +1149,7 @@ pub(crate) fn control_upload_chunk_frame(
             "upload exceeded declared size",
         ));
     }
-    if let Err(e) = upload.tmp.as_file_mut().write_all(&bytes) {
+    if let Err(e) = upload.spool.append(&bytes) {
         inbound_uploads.remove(&id);
         pending_requests.remove(&id);
         return Some(control_upload_error_response(
@@ -1186,7 +1186,7 @@ pub(crate) fn control_upload_end_frame(
         pending_requests.remove(&id);
         return Some(control_upload_error_response(id, 400, "incomplete upload"));
     }
-    if let Err(e) = upload.tmp.as_file_mut().flush() {
+    if let Err(e) = upload.spool.finish() {
         pending_requests.remove(&id);
         return Some(control_upload_error_response(
             id,

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -878,13 +878,13 @@ pub(crate) fn control_frame_response(
                     "t": "response",
                     "id": id,
                     "ok": true,
-                    "result": runtime.config,
+                    "result": &*runtime.config,
                 })),
                 "api_agent_card" => Some(serde_json::json!({
                     "t": "response",
                     "id": id,
                     "ok": true,
-                    "result": runtime.agent_card,
+                    "result": &*runtime.agent_card,
                 })),
                 "api_cached_bootstrap_events" => Some(cached_bootstrap_events_response_frame(
                     id,

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -291,6 +291,21 @@ pub(crate) fn control_frame_response(
             inbound_uploads,
         ),
         "request" => {
+            // Root rejection of empty/absent ids, BEFORE any spawn: a
+            // request without an id cannot receive a correlated response,
+            // so it has no legitimate use on this lane (the dashboard
+            // client always mints `dc-<ts>-<seq>` ids) — while an
+            // empty-id response would bypass the outbound queue (it is
+            // unaddressable) and response chunking, direct-sending
+            // successful payloads even on a congested wire. The rejection
+            // itself is an ok:false frame, budgeted at the error-class
+            // seam like every other cheap-to-mint refusal.
+            if id.is_empty() {
+                return Some(dashboard_control_error_response(
+                    id,
+                    "request frames require a non-empty id",
+                ));
+            }
             let method = parsed.get("method").and_then(|v| v.as_str()).unwrap_or("");
             let params = parsed.get("params").cloned();
             if let Err(error) = authorize_dashboard_control_method(runtime, method, params.as_ref())

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -913,7 +913,7 @@ pub(crate) fn control_frame_response(
                     &runtime.grant,
                 )),
                 "api_sessions_stream" => {
-                    if pending_requests_at_capacity(pending_requests, &id) {
+                    if pending_requests_at_capacity(pending_requests) {
                         return Some(dashboard_control_error_response(
                             id,
                             "too many in-flight requests on this connection",
@@ -947,7 +947,7 @@ pub(crate) fn control_frame_response(
                     // could build N full payloads the queue would then
                     // refuse. Same-id replacement stays allowed (it
                     // cancels its predecessor).
-                    if pending_requests_at_capacity(pending_requests, &id) {
+                    if pending_requests_at_capacity(pending_requests) {
                         return Some(dashboard_control_error_response(
                             id,
                             "too many in-flight requests on this connection",
@@ -991,11 +991,12 @@ pub(crate) fn control_frame_response(
     }
 }
 
-/// Spawn-time admission for the request lane (`MAX_PENDING_CONTROL_REQUESTS`):
-/// full only when the id would be a NEW entry — replacing an in-flight
-/// request with the same id cancels its predecessor and holds the count.
-fn pending_requests_at_capacity(pending_requests: &PendingControlRequests, id: &str) -> bool {
-    pending_requests.at_capacity_for(id)
+/// Spawn-time admission for the spawned-work lanes
+/// (`MAX_PENDING_CONTROL_REQUESTS`, live-work slots). No same-id
+/// exemption: a replacement cannot make its predecessor's in-flight work
+/// disappear, so it must fit under the same bound.
+fn pending_requests_at_capacity(pending_requests: &PendingControlRequests) -> bool {
+    pending_requests.at_capacity()
 }
 
 pub(crate) fn control_upload_error_response(
@@ -1079,7 +1080,19 @@ pub(crate) fn control_upload_start_frame(
     }
     // Connection-level admission (same-id restart replaces its own slot):
     // a burst of upload_starts must not reserve unbounded spool space.
-    let concurrent_elsewhere = inbound_uploads.keys().filter(|key| *key != &id).count();
+    // The live-work bound covers uploads too — the slot minted below is
+    // held from the first frame through commit completion.
+    if pending_requests_at_capacity(pending_requests) {
+        return Some(control_upload_error_response(
+            id,
+            429,
+            "too many in-flight requests on this connection",
+        ));
+    }
+    // Committing uploads left `inbound_uploads` but their work and spool
+    // live until the commit finishes — they count against the cap.
+    let concurrent_elsewhere = inbound_uploads.keys().filter(|key| *key != &id).count()
+        + pending_requests.committing_uploads();
     if concurrent_elsewhere >= MAX_INBOUND_UPLOADS_PER_CONNECTION {
         return Some(control_upload_error_response(
             id,
@@ -1111,8 +1124,10 @@ pub(crate) fn control_upload_start_frame(
     };
     inbound_uploads.remove(&id);
     // Reserve through the same generation-bearing admission the request
-    // lane uses: the terminal task's response must match this generation.
-    let (_cancel, generation) = pending_requests.admit(&id);
+    // lane uses: the terminal task's response must match this generation,
+    // and the RAII slot rides the receiving state into the commit task —
+    // one continuous live-work slot from first frame to commit end.
+    let (_cancel, generation, slot) = pending_requests.admit(&id);
     inbound_uploads.insert(
         id,
         InboundUploadState {
@@ -1127,6 +1142,7 @@ pub(crate) fn control_upload_start_frame(
             next_seq: 0,
             received_bytes: 0,
             generation,
+            slot: Some(slot),
         },
     );
     None
@@ -1241,8 +1257,17 @@ pub(crate) fn control_upload_end_frame(
     // arbitrary await point is worse than finishing it); the generation
     // gate on the response is what keeps a superseded commit from
     // reaching the wire or freeing its replacement's reservation.
+    // Run-to-completion is fine — UNBOUNDED run-to-completion is not:
+    // the commit occupies its live-work slot (taken out of the state so
+    // it survives the handlers consuming `upload`) plus a committing-
+    // upload slot that the upload 8-cap counts, both until the commit
+    // actually finishes.
     let generation = upload.generation;
+    let commit_slot = pending_requests.upload_commit_slot();
     tokio::spawn(async move {
+        let mut upload = upload;
+        let _slot = upload.slot.take();
+        let _commit_slot = commit_slot;
         let response = match upload.method.as_str() {
             "api_session_current_upload" => {
                 api_session_current_upload_task_response(id.clone(), upload, runtime).await

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -196,6 +196,7 @@ pub(crate) fn control_frame_response(
     outbound_queue: &mut OutboundControlQueue,
     inbound_uploads: &mut HashMap<String, InboundUploadState>,
     terminal_events_tx: &mpsc::UnboundedSender<serde_json::Value>,
+    terminal_output_tx: &mpsc::Sender<serde_json::Value>,
     terminal_forwarders: &mut HashMap<(String, String), tokio::task::JoinHandle<()>>,
     display_input_tx: &DisplayInputForwarder,
 ) -> Option<serde_json::Value> {
@@ -246,7 +247,7 @@ pub(crate) fn control_frame_response(
             None
         }
         "terminal_open" => {
-            control_terminal_open_frame(parsed, runtime, terminal_events_tx, terminal_forwarders)
+            control_terminal_open_frame(parsed, runtime, terminal_output_tx, terminal_forwarders)
         }
         "terminal_input" => control_terminal_input_frame(parsed, runtime),
         "terminal_resize" => control_terminal_resize_frame(parsed, runtime),
@@ -1240,7 +1241,7 @@ pub(crate) fn terminal_frame_dimension(frame: &serde_json::Value, key: &str, def
 pub(crate) fn control_terminal_open_frame(
     frame: serde_json::Value,
     runtime: &ControlRuntime,
-    terminal_events_tx: &mpsc::UnboundedSender<serde_json::Value>,
+    terminal_output_tx: &mpsc::Sender<serde_json::Value>,
     terminal_forwarders: &mut HashMap<(String, String), tokio::task::JoinHandle<()>>,
 ) -> Option<serde_json::Value> {
     let (host_id, terminal_id) = terminal_frame_key(&frame);
@@ -1251,7 +1252,12 @@ pub(crate) fn control_terminal_open_frame(
         handle.abort();
     }
     let registry = runtime.terminal_registry.clone();
-    let terminal_events_tx = terminal_events_tx.clone();
+    // Everything this task emits — the open ack/error and the output
+    // stream — rides the BOUNDED terminal lane, so the ack keeps FIFO
+    // order ahead of the first output frame, and when the wire congests
+    // the `send().await` parks this task while terminal.rs's per-listener
+    // drop-oldest bound holds the memory line (see `control_driver`).
+    let terminal_output_tx = terminal_output_tx.clone();
     // Attach needs only the terminal.view floor already enforced by the
     // frame table; creating a shell needs shell.spawn, decided at frame
     // time so expiry mid-connection is honored. A grant-level fs scope
@@ -1280,13 +1286,16 @@ pub(crate) fn control_terminal_open_frame(
         {
             Ok((session, _created)) => {
                 let mut rx = session.attach();
-                let _ = terminal_events_tx.send(serde_json::json!({
+                let ack = serde_json::json!({
                     "t": "terminal_opened",
                     "host_id": host_id.clone(),
                     "terminal_id": terminal_id.clone(),
                     "shared": session.shared(),
                     "can_share": session.managed_by(&actor),
-                }));
+                });
+                if terminal_output_tx.send(ack).await.is_err() {
+                    return;
+                }
                 while let Some(event) = rx.recv().await {
                     let frame = match event {
                         crate::terminal::TerminalEvent::Output(bytes) => {
@@ -1307,18 +1316,20 @@ pub(crate) fn control_terminal_open_frame(
                             })
                         }
                     };
-                    if terminal_events_tx.send(frame).is_err() {
+                    if terminal_output_tx.send(frame).await.is_err() {
                         break;
                     }
                 }
             }
             Err(e) => {
-                let _ = terminal_events_tx.send(serde_json::json!({
-                    "t": "terminal_error",
-                    "host_id": host_id,
-                    "terminal_id": terminal_id,
-                    "error": e.to_string(),
-                }));
+                let _ = terminal_output_tx
+                    .send(serde_json::json!({
+                        "t": "terminal_error",
+                        "host_id": host_id,
+                        "terminal_id": terminal_id,
+                        "error": e.to_string(),
+                    }))
+                    .await;
             }
         }
     });
@@ -3001,6 +3012,7 @@ mod tests {
         let mut outbound = OutboundControlQueue::new();
         let mut inbound_uploads = HashMap::new();
         let (terminal_tx, _terminal_rx) = mpsc::unbounded_channel();
+        let (terminal_output_tx, _terminal_output_rx) = mpsc::channel(TERMINAL_OUTPUT_LANE_CAP);
         let mut terminal_forwarders = HashMap::new();
         let display_input_tx = DisplayInputForwarder::test_sink();
         let bytes = b"hello upload";
@@ -3028,6 +3040,7 @@ mod tests {
             &mut outbound,
             &mut inbound_uploads,
             &terminal_tx,
+            &terminal_output_tx,
             &mut terminal_forwarders,
             &display_input_tx,
         )
@@ -3049,6 +3062,7 @@ mod tests {
                 &mut outbound,
                 &mut inbound_uploads,
                 &terminal_tx,
+                &terminal_output_tx,
                 &mut terminal_forwarders,
                 &display_input_tx,
             )
@@ -3068,6 +3082,7 @@ mod tests {
             &mut outbound,
             &mut inbound_uploads,
             &terminal_tx,
+            &terminal_output_tx,
             &mut terminal_forwarders,
             &display_input_tx,
         )
@@ -3113,6 +3128,7 @@ mod tests {
         let mut outbound = OutboundControlQueue::new();
         let mut inbound_uploads = HashMap::new();
         let (terminal_tx, _terminal_rx) = mpsc::unbounded_channel();
+        let (terminal_output_tx, _terminal_output_rx) = mpsc::channel(TERMINAL_OUTPUT_LANE_CAP);
         let mut terminal_forwarders = HashMap::new();
         let display_input_tx = DisplayInputForwarder::test_sink();
 
@@ -3137,6 +3153,7 @@ mod tests {
             &mut outbound,
             &mut inbound_uploads,
             &terminal_tx,
+            &terminal_output_tx,
             &mut terminal_forwarders,
             &display_input_tx,
         )
@@ -3156,6 +3173,7 @@ mod tests {
             &mut outbound,
             &mut inbound_uploads,
             &terminal_tx,
+            &terminal_output_tx,
             &mut terminal_forwarders,
             &display_input_tx,
         )
@@ -3186,7 +3204,8 @@ mod tests {
         let mut pending = HashMap::new();
         let mut outbound = OutboundControlQueue::new();
         let mut inbound_uploads = HashMap::new();
-        let (terminal_tx, mut terminal_rx) = mpsc::unbounded_channel();
+        let (terminal_tx, _terminal_rx) = mpsc::unbounded_channel::<serde_json::Value>();
+        let (terminal_output_tx, mut terminal_output_rx) = mpsc::channel(TERMINAL_OUTPUT_LANE_CAP);
         let mut terminal_forwarders = HashMap::new();
         let display_input_tx = DisplayInputForwarder::test_sink();
         let terminal_id = "dash-control-test-shell";
@@ -3206,6 +3225,7 @@ mod tests {
             &mut outbound,
             &mut inbound_uploads,
             &terminal_tx,
+            &terminal_output_tx,
             &mut terminal_forwarders,
             &display_input_tx,
         )
@@ -3216,7 +3236,7 @@ mod tests {
         // tens of seconds before the shell paints; a passing run returns
         // the moment each frame arrives and never waits the budget out.
         let budget = Duration::from_secs(60);
-        let opened = tokio::time::timeout(budget, terminal_rx.recv())
+        let opened = tokio::time::timeout(budget, terminal_output_rx.recv())
             .await
             .expect("no terminal frame within budget after terminal_open")
             .expect("terminal frame channel closed before terminal_opened");
@@ -3228,7 +3248,7 @@ mod tests {
         // deadline. Matching runs on the accumulated transcript, not per
         // frame, so output split across chunks still matches.
         async fn drain_output_until(
-            terminal_rx: &mut mpsc::UnboundedReceiver<serde_json::Value>,
+            terminal_rx: &mut mpsc::Receiver<serde_json::Value>,
             budget: Duration,
             phase: &str,
             until: impl Fn(&str) -> bool,
@@ -3265,7 +3285,7 @@ mod tests {
         // during shell startup can be silently discarded (see terminal.rs
         // tests); a dashboard user typing at a rendered prompt never races
         // this.
-        drain_output_until(&mut terminal_rx, budget, "shell startup", |t| !t.is_empty()).await;
+        drain_output_until(&mut terminal_output_rx, budget, "shell startup", |t| !t.is_empty()).await;
 
         let token = "dashboard_terminal_frame_ok";
         let input = serde_json::json!({
@@ -3283,12 +3303,13 @@ mod tests {
             &mut outbound,
             &mut inbound_uploads,
             &terminal_tx,
+            &terminal_output_tx,
             &mut terminal_forwarders,
             &display_input_tx,
         )
         .is_none());
 
-        drain_output_until(&mut terminal_rx, budget, "token echo", |t| {
+        drain_output_until(&mut terminal_output_rx, budget, "token echo", |t| {
             t.contains(token)
         })
         .await;
@@ -3306,6 +3327,7 @@ mod tests {
             &mut outbound,
             &mut inbound_uploads,
             &terminal_tx,
+            &terminal_output_tx,
             &mut terminal_forwarders,
             &display_input_tx,
         );
@@ -3328,6 +3350,7 @@ mod tests {
         let mut outbound = OutboundControlQueue::new();
         let mut inbound_uploads = HashMap::new();
         let (terminal_tx, _terminal_rx) = mpsc::unbounded_channel();
+        let (terminal_output_tx, _terminal_output_rx) = mpsc::channel(TERMINAL_OUTPUT_LANE_CAP);
         let mut terminal_forwarders = HashMap::new();
         let display_input_tx = DisplayInputForwarder::test_sink();
         let mut frame = |text: &str,
@@ -3343,6 +3366,7 @@ mod tests {
                 &mut outbound,
                 inbound,
                 &terminal_tx,
+                &terminal_output_tx,
                 &mut terminal_forwarders,
                 &display_input_tx,
             )

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -72,6 +72,26 @@ pub(crate) fn frame_api_json_body_response(
     }
 }
 
+/// `frame_api_json_body_response`, pre-serialized (see
+/// `json_body_response_preserialized`): the JSON arm splices the core's
+/// already-serialized body into a complete envelope string instead of
+/// parse→wrap→re-serialize — for the multi-MB session list/detail/search
+/// family, that re-parse was measurably hot on every poll. Only legal on
+/// the spawned task-response lane, where `send_control_task_response`
+/// recognizes the `Value::String` carrier.
+pub(crate) fn frame_api_json_body_response_preserialized(
+    id: String,
+    response: crate::web_gateway::ApiResponse,
+    label: &str,
+) -> serde_json::Value {
+    match response {
+        crate::web_gateway::ApiResponse::Json { body, .. } => {
+            json_body_response_preserialized(&id, body.into_string(), label)
+        }
+        other => frame_api_json_body_response(id, other, label),
+    }
+}
+
 /// Tunnel adapter for the access family's historical ok/error envelope:
 /// a 2xx JSON body renders as `{t:"response", id, ok:true,
 /// result:<body>}` — the body-only shape, no `_httpStatus` metadata

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -913,6 +913,12 @@ pub(crate) fn control_frame_response(
                     &runtime.grant,
                 )),
                 "api_sessions_stream" => {
+                    if pending_requests_at_capacity(pending_requests, &id) {
+                        return Some(dashboard_control_error_response(
+                            id,
+                            "too many in-flight requests on this connection",
+                        ));
+                    }
                     spawn_control_stream(
                         id,
                         method.to_string(),
@@ -935,6 +941,18 @@ pub(crate) fn control_frame_response(
                 // with the same `unknown method` shape this match used to
                 // return inline.
                 _ => {
+                    // Reservation at spawn time: each spawned handler may
+                    // construct a response as large as the fs-read cap
+                    // before queue admission runs, so unbounded spawns
+                    // could build N full payloads the queue would then
+                    // refuse. Same-id replacement stays allowed (it
+                    // cancels its predecessor).
+                    if pending_requests_at_capacity(pending_requests, &id) {
+                        return Some(dashboard_control_error_response(
+                            id,
+                            "too many in-flight requests on this connection",
+                        ));
+                    }
                     spawn_control_request(
                         id,
                         method.to_string(),
@@ -977,6 +995,16 @@ pub(crate) fn control_frame_response(
             "error": format!("unknown frame type: {t}"),
         })),
     }
+}
+
+/// Spawn-time admission for the request lane (`MAX_PENDING_CONTROL_REQUESTS`):
+/// full only when the id would be a NEW entry — replacing an in-flight
+/// request with the same id cancels its predecessor and holds the count.
+fn pending_requests_at_capacity(
+    pending_requests: &HashMap<String, CancellationToken>,
+    id: &str,
+) -> bool {
+    !pending_requests.contains_key(id) && pending_requests.len() >= MAX_PENDING_CONTROL_REQUESTS
 }
 
 pub(crate) fn control_upload_error_response(
@@ -1056,6 +1084,28 @@ pub(crate) fn control_upload_start_frame(
             id,
             400,
             "empty upload declared chunks",
+        ));
+    }
+    // Connection-level admission (same-id restart replaces its own slot):
+    // a burst of upload_starts must not reserve unbounded spool space.
+    let concurrent_elsewhere = inbound_uploads.keys().filter(|key| *key != &id).count();
+    if concurrent_elsewhere >= MAX_INBOUND_UPLOADS_PER_CONNECTION {
+        return Some(control_upload_error_response(
+            id,
+            429,
+            format!("too many concurrent uploads (max {MAX_INBOUND_UPLOADS_PER_CONNECTION})"),
+        ));
+    }
+    let declared_elsewhere: usize = inbound_uploads
+        .iter()
+        .filter(|(key, _)| *key != &id)
+        .map(|(_, upload)| upload.total_bytes)
+        .sum();
+    if declared_elsewhere.saturating_add(total_bytes) > MAX_INBOUND_UPLOAD_TOTAL_BYTES {
+        return Some(control_upload_error_response(
+            id,
+            429,
+            "concurrent uploads exceed the connection's declared-bytes budget",
         ));
     }
     let spool = match UploadSpool::for_declared_size(total_bytes) {

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -3305,7 +3305,10 @@ mod tests {
         // during shell startup can be silently discarded (see terminal.rs
         // tests); a dashboard user typing at a rendered prompt never races
         // this.
-        drain_output_until(&mut terminal_output_rx, budget, "shell startup", |t| !t.is_empty()).await;
+        drain_output_until(&mut terminal_output_rx, budget, "shell startup", |t| {
+            !t.is_empty()
+        })
+        .await;
 
         let token = "dashboard_terminal_frame_ok";
         let input = serde_json::json!({

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -1104,7 +1104,8 @@ pub(crate) fn control_upload_start_frame(
         .iter()
         .filter(|(key, _)| *key != &id)
         .map(|(_, upload)| upload.total_bytes)
-        .sum();
+        .sum::<usize>()
+        .saturating_add(pending_requests.committing_upload_bytes());
     if declared_elsewhere.saturating_add(total_bytes) > MAX_INBOUND_UPLOAD_TOTAL_BYTES {
         return Some(control_upload_error_response(
             id,
@@ -1263,7 +1264,7 @@ pub(crate) fn control_upload_end_frame(
     // upload slot that the upload 8-cap counts, both until the commit
     // actually finishes.
     let generation = upload.generation;
-    let commit_slot = pending_requests.upload_commit_slot();
+    let commit_slot = pending_requests.upload_commit_slot(upload.received_bytes);
     tokio::spawn(async move {
         let mut upload = upload;
         let _slot = upload.slot.take();

--- a/src/bin/caller/dashboard_control/dispatch.rs
+++ b/src/bin/caller/dashboard_control/dispatch.rs
@@ -211,8 +211,8 @@ pub(crate) fn frame_api_task_response(
 pub(crate) fn control_frame_response(
     text: &str,
     runtime: &mut ControlRuntime,
-    task_tx: &mpsc::Sender<ControlTaskResponse>,
-    pending_requests: &mut HashMap<String, CancellationToken>,
+    task_tx: &mpsc::Sender<SequencedTaskResponse>,
+    pending_requests: &mut PendingControlRequests,
     outbound_queue: &mut OutboundControlQueue,
     inbound_uploads: &mut HashMap<String, InboundUploadState>,
     terminal_events_tx: &mpsc::UnboundedSender<serde_json::Value>,
@@ -966,13 +966,7 @@ pub(crate) fn control_frame_response(
             }
         }
         "cancel" => {
-            let pending_existed = pending_requests
-                .remove(&id)
-                .map(|token| {
-                    token.cancel();
-                    true
-                })
-                .unwrap_or(false);
+            let pending_existed = pending_requests.cancel_remove(&id);
             let queued_existed = outbound_queue.cancel(&id);
             let upload_existed = inbound_uploads.remove(&id).is_some();
             let existed = pending_existed || queued_existed || upload_existed;
@@ -1000,11 +994,8 @@ pub(crate) fn control_frame_response(
 /// Spawn-time admission for the request lane (`MAX_PENDING_CONTROL_REQUESTS`):
 /// full only when the id would be a NEW entry — replacing an in-flight
 /// request with the same id cancels its predecessor and holds the count.
-fn pending_requests_at_capacity(
-    pending_requests: &HashMap<String, CancellationToken>,
-    id: &str,
-) -> bool {
-    !pending_requests.contains_key(id) && pending_requests.len() >= MAX_PENDING_CONTROL_REQUESTS
+fn pending_requests_at_capacity(pending_requests: &PendingControlRequests, id: &str) -> bool {
+    pending_requests.at_capacity_for(id)
 }
 
 pub(crate) fn control_upload_error_response(
@@ -1028,7 +1019,7 @@ pub(crate) fn control_upload_start_frame(
     id: String,
     frame: serde_json::Value,
     runtime: &ControlRuntime,
-    pending_requests: &mut HashMap<String, CancellationToken>,
+    pending_requests: &mut PendingControlRequests,
     inbound_uploads: &mut HashMap<String, InboundUploadState>,
 ) -> Option<serde_json::Value> {
     if id.is_empty() {
@@ -1118,11 +1109,10 @@ pub(crate) fn control_upload_start_frame(
             ));
         }
     };
-    if let Some(previous) = pending_requests.remove(&id) {
-        previous.cancel();
-    }
     inbound_uploads.remove(&id);
-    pending_requests.insert(id.clone(), CancellationToken::new());
+    // Reserve through the same generation-bearing admission the request
+    // lane uses: the terminal task's response must match this generation.
+    let (_cancel, generation) = pending_requests.admit(&id);
     inbound_uploads.insert(
         id,
         InboundUploadState {
@@ -1136,6 +1126,7 @@ pub(crate) fn control_upload_start_frame(
             expected_chunks,
             next_seq: 0,
             received_bytes: 0,
+            generation,
         },
     );
     None
@@ -1144,11 +1135,11 @@ pub(crate) fn control_upload_start_frame(
 pub(crate) fn control_upload_chunk_frame(
     id: String,
     frame: serde_json::Value,
-    pending_requests: &mut HashMap<String, CancellationToken>,
+    pending_requests: &mut PendingControlRequests,
     inbound_uploads: &mut HashMap<String, InboundUploadState>,
 ) -> Option<serde_json::Value> {
     let Some(upload) = inbound_uploads.get_mut(&id) else {
-        pending_requests.remove(&id);
+        pending_requests.cancel_remove(&id);
         return Some(control_upload_error_response(id, 400, "unknown upload id"));
     };
     let seq = frame
@@ -1158,7 +1149,7 @@ pub(crate) fn control_upload_chunk_frame(
         .unwrap_or(usize::MAX);
     if seq != upload.next_seq {
         inbound_uploads.remove(&id);
-        pending_requests.remove(&id);
+        pending_requests.cancel_remove(&id);
         return Some(control_upload_error_response(
             id,
             400,
@@ -1169,7 +1160,7 @@ pub(crate) fn control_upload_chunk_frame(
         Some(data) => data,
         None => {
             inbound_uploads.remove(&id);
-            pending_requests.remove(&id);
+            pending_requests.cancel_remove(&id);
             return Some(control_upload_error_response(
                 id,
                 400,
@@ -1181,7 +1172,7 @@ pub(crate) fn control_upload_chunk_frame(
         Ok(bytes) => bytes,
         Err(_) => {
             inbound_uploads.remove(&id);
-            pending_requests.remove(&id);
+            pending_requests.cancel_remove(&id);
             return Some(control_upload_error_response(
                 id,
                 400,
@@ -1192,7 +1183,7 @@ pub(crate) fn control_upload_chunk_frame(
     upload.received_bytes = upload.received_bytes.saturating_add(bytes.len());
     if upload.received_bytes > upload.total_bytes {
         inbound_uploads.remove(&id);
-        pending_requests.remove(&id);
+        pending_requests.cancel_remove(&id);
         return Some(control_upload_error_response(
             id,
             400,
@@ -1201,7 +1192,7 @@ pub(crate) fn control_upload_chunk_frame(
     }
     if let Err(e) = upload.spool.append(&bytes) {
         inbound_uploads.remove(&id);
-        pending_requests.remove(&id);
+        pending_requests.cancel_remove(&id);
         return Some(control_upload_error_response(
             id,
             500,
@@ -1216,12 +1207,12 @@ pub(crate) fn control_upload_end_frame(
     id: String,
     frame: serde_json::Value,
     runtime: &ControlRuntime,
-    task_tx: &mpsc::Sender<ControlTaskResponse>,
-    pending_requests: &mut HashMap<String, CancellationToken>,
+    task_tx: &mpsc::Sender<SequencedTaskResponse>,
+    pending_requests: &mut PendingControlRequests,
     inbound_uploads: &mut HashMap<String, InboundUploadState>,
 ) -> Option<serde_json::Value> {
     let Some(mut upload) = inbound_uploads.remove(&id) else {
-        pending_requests.remove(&id);
+        pending_requests.cancel_remove(&id);
         return Some(control_upload_error_response(id, 400, "unknown upload id"));
     };
     let final_chunks = frame
@@ -1233,11 +1224,11 @@ pub(crate) fn control_upload_end_frame(
         || upload.next_seq != upload.expected_chunks
         || upload.received_bytes != upload.total_bytes
     {
-        pending_requests.remove(&id);
+        pending_requests.cancel_remove(&id);
         return Some(control_upload_error_response(id, 400, "incomplete upload"));
     }
     if let Err(e) = upload.spool.finish() {
-        pending_requests.remove(&id);
+        pending_requests.cancel_remove(&id);
         return Some(control_upload_error_response(
             id,
             500,
@@ -1246,6 +1237,11 @@ pub(crate) fn control_upload_end_frame(
     }
     let runtime = runtime.clone();
     let task_tx = task_tx.clone();
+    // Commit tasks run to completion (abandoning a store commit at an
+    // arbitrary await point is worse than finishing it); the generation
+    // gate on the response is what keeps a superseded commit from
+    // reaching the wire or freeing its replacement's reservation.
+    let generation = upload.generation;
     tokio::spawn(async move {
         let response = match upload.method.as_str() {
             "api_session_current_upload" => {
@@ -1278,7 +1274,7 @@ pub(crate) fn control_upload_end_frame(
                 done: true,
             },
         };
-        let _ = task_tx.send(response).await;
+        let _ = task_tx.send((generation, response)).await;
     });
     None
 }
@@ -2994,7 +2990,7 @@ mod tests {
             },
             ..runtime()
         };
-        let mut pending = HashMap::new();
+        let mut pending = PendingControlRequests::new();
         let mut inbound_uploads = HashMap::new();
 
         // A filesystem-write grant must not reach runtime-control surface
@@ -3077,8 +3073,8 @@ mod tests {
         let mut rt = runtime();
         rt.project_root = Some(project.path().to_path_buf());
         let mut events = rt.bus.subscribe();
-        let (tx, mut rx) = mpsc::channel::<ControlTaskResponse>(8);
-        let mut pending = HashMap::new();
+        let (tx, mut rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
         let mut inbound_uploads = HashMap::new();
         let (terminal_tx, _terminal_rx) = mpsc::unbounded_channel();
@@ -3158,11 +3154,11 @@ mod tests {
         )
         .is_none());
 
-        let response = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        let (_, response) = tokio::time::timeout(Duration::from_secs(1), rx.recv())
             .await
             .unwrap()
             .unwrap();
-        assert!(pending.remove(&response.id).is_some());
+        assert!(pending.cancel_remove(&response.id));
         assert_eq!(response.id, "up1");
         assert!(response.done);
         assert_eq!(response.frame["t"], "response");
@@ -3193,8 +3189,8 @@ mod tests {
         let project = tempfile::tempdir().unwrap();
         let mut rt = runtime();
         rt.project_root = Some(project.path().to_path_buf());
-        let (tx, mut rx) = mpsc::channel::<ControlTaskResponse>(8);
-        let mut pending = HashMap::new();
+        let (tx, mut rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
         let mut inbound_uploads = HashMap::new();
         let (terminal_tx, _terminal_rx) = mpsc::unbounded_channel();
@@ -3249,11 +3245,11 @@ mod tests {
         )
         .is_none());
 
-        let response = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        let (_, response) = tokio::time::timeout(Duration::from_secs(1), rx.recv())
             .await
             .unwrap()
             .unwrap();
-        assert!(pending.remove(&response.id).is_some());
+        assert!(pending.cancel_remove(&response.id));
         assert_eq!(response.id, "up-empty");
         assert_eq!(response.frame["result"]["_httpStatus"], 200);
         assert_eq!(response.frame["result"]["_httpOk"], true);
@@ -3270,8 +3266,8 @@ mod tests {
         rt.terminal_registry = Arc::new(crate::terminal::TerminalRegistry::new(
             project.path().to_path_buf(),
         ));
-        let (task_tx, _task_rx) = mpsc::channel::<ControlTaskResponse>(8);
-        let mut pending = HashMap::new();
+        let (task_tx, _task_rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
         let mut inbound_uploads = HashMap::new();
         let (terminal_tx, _terminal_rx) = mpsc::unbounded_channel::<serde_json::Value>();
@@ -3418,8 +3414,8 @@ mod tests {
         let payload = b"written via upload frames";
 
         let mut rt = runtime();
-        let (tx, mut rx) = mpsc::channel::<ControlTaskResponse>(8);
-        let mut pending = HashMap::new();
+        let (tx, mut rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
         let mut inbound_uploads = HashMap::new();
         let (terminal_tx, _terminal_rx) = mpsc::unbounded_channel();
@@ -3428,7 +3424,7 @@ mod tests {
         let display_input_tx = DisplayInputForwarder::test_sink();
         let mut frame = |text: &str,
                          rt: &mut ControlRuntime,
-                         pending: &mut HashMap<String, CancellationToken>,
+                         pending: &mut PendingControlRequests,
                          inbound: &mut HashMap<String, InboundUploadState>|
          -> Option<serde_json::Value> {
             control_frame_response(
@@ -3514,7 +3510,7 @@ mod tests {
         );
         assert!(end.is_none());
 
-        let response = rx.recv().await.unwrap();
+        let (_, response) = rx.recv().await.unwrap();
         assert_eq!(response.id, "up1");
         assert!(response.done);
         assert_eq!(response.frame["t"], "response");

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -95,6 +95,23 @@ pub(crate) fn watermark_to_u32(bytes: usize) -> u32 {
     u32::try_from(bytes).unwrap_or(u32::MAX)
 }
 
+/// ERROR-class classification for the immediate-frame budget seam: the
+/// plain error envelope (`ok: false` — auth denials, unknown methods,
+/// admission refusals) and the injected-status error shape
+/// (`result._httpOk: false` — the upload lane's 4xx/5xx envelopes).
+/// These are the frames a client can mint cheaply by spamming invalid
+/// requests; success frames are never budgeted.
+pub(crate) fn is_error_class_frame(frame: &serde_json::Value) -> bool {
+    if frame.get("ok").and_then(serde_json::Value::as_bool) == Some(false) {
+        return true;
+    }
+    frame
+        .get("result")
+        .and_then(|result| result.get("_httpOk"))
+        .and_then(serde_json::Value::as_bool)
+        == Some(false)
+}
+
 /// Token budget for DIRECT error frames — the admission-refusal and
 /// rejection replies that deliberately bypass the queue/backpressure
 /// lanes (they must be deliverable exactly when those lanes are the
@@ -142,6 +159,11 @@ impl DirectErrorBudget {
             );
         }
         false
+    }
+
+    #[cfg(test)]
+    pub(crate) fn dropped(&self) -> u64 {
+        self.dropped
     }
 
     /// Log the drop tally at connection teardown (silent when zero).
@@ -2040,11 +2062,23 @@ pub(crate) type SequencedTaskResponse = (u64, ControlTaskResponse);
 /// request id with a per-admission GENERATION (the peer-transfer read
 /// registry's pattern): same-id replacement cancels its predecessor and
 /// mints a new generation, completion frees only its own generation, and
-/// stale-generation responses are dropped. Admission (`at_capacity_for` +
-/// [`MAX_PENDING_CONTROL_REQUESTS`]) reserves at SPAWN time, before any
-/// response bytes exist.
+/// stale-generation responses are dropped.
+///
+/// Admission is bounded by LIVE WORK, not addressable entries: every
+/// admit hands out an RAII [`LiveWorkSlot`] that the spawned task owns
+/// until its work ACTUALLY ends (the handler future runs to completion —
+/// awaited `spawn_blocking` segments included). A cancelled predecessor
+/// therefore keeps holding its slot while it drains, so rapid same-id
+/// cycling saturates [`MAX_PENDING_CONTROL_REQUESTS`] and gets refused
+/// instead of stacking untracked work onto the blocking pool.
 pub(crate) struct PendingControlRequests {
     entries: HashMap<String, PendingControlRequest>,
+    /// Live-work ledger: strong count − 1 = slots currently held.
+    live_work: Arc<()>,
+    /// Committing-upload ledger: strong count − 1 = commits in flight
+    /// (they left `inbound_uploads` but their work — and spool — lives
+    /// until the commit finishes; the upload 8-cap counts them).
+    committing_uploads: Arc<()>,
     next_generation: u64,
 }
 
@@ -2053,19 +2087,28 @@ struct PendingControlRequest {
     generation: u64,
 }
 
+/// RAII live-work slot: dropping it is the ONLY thing that frees
+/// admission capacity, so a slot must be owned by the spawned task (or
+/// the upload state that becomes one) and live until the work ends.
+pub(crate) struct LiveWorkSlot(#[allow(dead_code)] Arc<()>);
+
+/// RAII committing-upload slot (see `committing_uploads`).
+pub(crate) struct UploadCommitSlot(#[allow(dead_code)] Arc<()>);
+
 impl PendingControlRequests {
     pub(crate) fn new() -> Self {
         Self {
             entries: HashMap::new(),
+            live_work: Arc::new(()),
+            committing_uploads: Arc::new(()),
             next_generation: 0,
         }
     }
 
-    /// Reserve `id`, cancelling and replacing any predecessor (whose
-    /// spawned task dies at its next await point — see the spawn
-    /// wrappers' `select!`). Returns the new reservation's cancel token
-    /// and generation.
-    pub(crate) fn admit(&mut self, id: &str) -> (CancellationToken, u64) {
+    /// Reserve a live-work slot for `id`, cancelling and replacing any
+    /// predecessor ENTRY. The predecessor's SLOT stays with its task —
+    /// capacity frees when that work exits, never at replacement.
+    pub(crate) fn admit(&mut self, id: &str) -> (CancellationToken, u64, LiveWorkSlot) {
         if let Some(previous) = self.entries.remove(id) {
             previous.cancel.cancel();
         }
@@ -2079,7 +2122,26 @@ impl PendingControlRequests {
                 generation,
             },
         );
-        (cancel, generation)
+        (
+            cancel,
+            generation,
+            LiveWorkSlot(Arc::clone(&self.live_work)),
+        )
+    }
+
+    /// Slots currently held by live work (draining predecessors included).
+    pub(crate) fn live_work(&self) -> usize {
+        Arc::strong_count(&self.live_work).saturating_sub(1)
+    }
+
+    /// One committing upload's cap presence (held until the commit ends).
+    pub(crate) fn upload_commit_slot(&self) -> UploadCommitSlot {
+        UploadCommitSlot(Arc::clone(&self.committing_uploads))
+    }
+
+    /// Commits currently in flight.
+    pub(crate) fn committing_uploads(&self) -> usize {
+        Arc::strong_count(&self.committing_uploads).saturating_sub(1)
     }
 
     /// The client's `cancel` frame: cancel and free the reservation.
@@ -2110,18 +2172,23 @@ impl PendingControlRequests {
         }
     }
 
+    /// Test-only observers (production reads go through `matches` /
+    /// `live_work` / `at_capacity`).
+    #[cfg(test)]
     pub(crate) fn contains_key(&self, id: &str) -> bool {
         self.entries.contains_key(id)
     }
 
+    #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
         self.entries.len()
     }
 
-    /// Spawn-time admission: full only when `id` would be a NEW entry —
-    /// same-id replacement cancels its predecessor and holds the count.
-    pub(crate) fn at_capacity_for(&self, id: &str) -> bool {
-        !self.contains_key(id) && self.len() >= MAX_PENDING_CONTROL_REQUESTS
+    /// Spawn-time admission against LIVE WORK. Deliberately no same-id
+    /// exemption: a replacement cannot make its predecessor's in-flight
+    /// work disappear, so it must fit under the same bound.
+    pub(crate) fn at_capacity(&self) -> bool {
+        self.live_work() >= MAX_PENDING_CONTROL_REQUESTS
     }
 
     /// Teardown: cancel every reservation.
@@ -2173,9 +2240,12 @@ const MAX_INBOUND_UPLOADS_PER_CONNECTION: usize = 8;
 /// admission control at upload_start, so a burst of starts cannot
 /// reserve unbounded spool space regardless of the per-upload cap.
 const MAX_INBOUND_UPLOAD_TOTAL_BYTES: usize = 256 * 1024 * 1024;
-/// Concurrent spawned request tasks per tunnel connection. Each spawned
-/// handler may construct a response as large as the fs-read cap before
-/// queue admission runs, so the reservation has to happen at spawn time.
+/// LIVE spawned-work slots per tunnel connection (request tasks, stream
+/// framers, upload states and their commit tasks). Each spawned handler
+/// may construct a response as large as the fs-read cap before queue
+/// admission runs, so the reservation happens at spawn time and — via
+/// the RAII [`LiveWorkSlot`] — frees only when the work actually ends,
+/// covering cancelled-but-draining predecessors too.
 const MAX_PENDING_CONTROL_REQUESTS: usize = 64;
 
 impl UploadSpool {
@@ -2281,6 +2351,11 @@ pub(crate) struct InboundUploadState {
     /// `upload_start` — the terminal task's response carries it so the
     /// driver can match it against the live reservation.
     generation: u64,
+    /// The live-work slot minted at `upload_start`, carried through the
+    /// receiving state and taken by the commit task at `upload_end` —
+    /// one continuous slot from first frame to commit completion.
+    /// `None` only in hermetic fixtures.
+    slot: Option<LiveWorkSlot>,
 }
 
 impl InboundUploadState {
@@ -3945,15 +4020,60 @@ fn sha256_b64u(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
 
+    /// The direct-error budget: while congested, exactly
+    /// [`DIRECT_ERROR_BUDGET_FRAMES`] error frames pass, further ones drop
+    /// and are counted; an uncongested beat (the wire drained) refills.
+    #[test]
+    fn direct_error_budget_bounds_congested_error_frames() {
+        let mut budget = DirectErrorBudget::new("test");
+        for index in 0..DIRECT_ERROR_BUDGET_FRAMES {
+            assert!(budget.allow(true), "frame {index} rides the budget");
+        }
+        assert!(!budget.allow(true), "budget exhausted while congested");
+        assert!(!budget.allow(true));
+        assert_eq!(budget.dropped(), 2, "drops are counted per connection");
+        // A drained wire refills the budget.
+        assert!(budget.allow(false));
+        assert!(budget.allow(true));
+        assert_eq!(budget.dropped(), 2);
+    }
+
+    /// The immediate-frame seam's ERROR classification: the plain error
+    /// envelope and the injected-status error shape are budgeted; success
+    /// shapes never are.
+    #[test]
+    fn error_class_frames_are_classified() {
+        assert!(is_error_class_frame(&dashboard_control_error_response(
+            "r1".into(),
+            "denied"
+        )));
+        assert!(is_error_class_frame(&serde_json::json!({
+            "t": "response",
+            "id": "u1",
+            "ok": true,
+            "result": { "_httpStatus": 429, "_httpOk": false, "error": "too many" },
+        })));
+        assert!(!is_error_class_frame(&serde_json::json!({
+            "t": "response",
+            "id": "ok1",
+            "ok": true,
+            "result": { "_httpStatus": 200, "_httpOk": true },
+        })));
+        assert!(!is_error_class_frame(&serde_json::json!({
+            "t": "hello_ack",
+            "id": "h1",
+        })));
+    }
+
     /// Generation-keyed reservations: same-id replacement cancels its
     /// predecessor and mints a new generation; a superseded generation
     /// can neither claim ownership nor free the replacement's
-    /// reservation; capacity exempts same-id replacement only.
+    /// reservation.
     #[test]
     fn pending_request_generations_protect_replacements() {
         let mut pending = PendingControlRequests::new();
-        let (first_cancel, first_generation) = pending.admit("r1");
-        let (second_cancel, second_generation) = pending.admit("r1");
+        let (first_cancel, first_generation, _first_slot) = pending.admit("r1");
+        let (second_cancel, second_generation, _second_slot) = pending.admit("r1");
         assert!(
             first_cancel.is_cancelled(),
             "replacement cancels the predecessor"
@@ -3969,16 +4089,46 @@ mod tests {
         assert!(pending.contains_key("r1"));
         assert!(pending.complete("r1", second_generation));
         assert!(!pending.contains_key("r1"));
+    }
 
+    /// The admission bound counts LIVE WORK, not addressable entries:
+    /// rapid same-id cycling accumulates one slot per still-draining
+    /// predecessor (held via RAII until that task actually exits), so a
+    /// spammer saturates the bound and gets refused instead of stacking
+    /// untracked work onto the blocking pool — and capacity frees only
+    /// when a predecessor's own slot drops.
+    #[test]
+    fn live_work_slots_bound_same_id_cycling() {
         let mut pending = PendingControlRequests::new();
-        for index in 0..MAX_PENDING_CONTROL_REQUESTS {
-            pending.admit(&format!("r{index}"));
+        let mut draining = Vec::new();
+        for _ in 0..MAX_PENDING_CONTROL_REQUESTS {
+            let (_cancel, _generation, slot) = pending.admit("spam");
+            draining.push(slot);
         }
-        assert!(pending.at_capacity_for("new-id"));
-        assert!(
-            !pending.at_capacity_for("r0"),
-            "same-id replacement stays admissible at capacity"
+        assert_eq!(pending.len(), 1, "one addressable entry");
+        assert_eq!(
+            pending.live_work(),
+            MAX_PENDING_CONTROL_REQUESTS,
+            "every draining predecessor still holds its slot"
         );
+        assert!(
+            pending.at_capacity(),
+            "cycling one id saturates the live-work bound"
+        );
+        // Only a predecessor's own exit frees capacity.
+        draining.pop();
+        assert!(!pending.at_capacity());
+        // Entry removal (cancel frame) does not free the drained work.
+        assert!(pending.cancel_remove("spam"));
+        assert_eq!(pending.live_work(), MAX_PENDING_CONTROL_REQUESTS - 1);
+        drop(draining);
+        assert_eq!(pending.live_work(), 0);
+
+        // The committing-upload ledger is RAII the same way.
+        let commit_slot = pending.upload_commit_slot();
+        assert_eq!(pending.committing_uploads(), 1);
+        drop(commit_slot);
+        assert_eq!(pending.committing_uploads(), 0);
     }
 
     /// The pre-serialized response carrier: byte-verbatim body embedding,
@@ -4058,6 +4208,7 @@ mod tests {
             next_seq: if bytes.is_empty() { 0 } else { 1 },
             received_bytes: bytes.len(),
             generation: 0,
+            slot: None,
         }
     }
 

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -65,6 +65,32 @@ const CONTROL_DEFAULT_SESSION_LIMIT: usize = 600;
 const CONTROL_RESPONSE_CHUNK_THRESHOLD_BYTES: usize = 64 * 1024;
 const CONTROL_RESPONSE_CHUNK_BYTES: usize = 16 * 1024;
 const CONTROL_BYTE_STREAM_CHUNK_BYTES: usize = 16 * 1024;
+/// Capacity of the per-connection bounded PTY-output lane (the tunnel twin
+/// of `ws_session::TERMINAL_FORWARD_LANE_CAP`). Entries are one JSON frame
+/// around a base64 chunk (terminal.rs merges output up to 64 KiB per
+/// entry), so the lane holds ~1.4 MiB worst case — the same order as
+/// terminal.rs's own 1 MiB per-listener bound that takes over
+/// (drop-oldest) once this lane fills and the forwarders park.
+const TERMINAL_OUTPUT_LANE_CAP: usize = 16;
+/// Stop draining the terminal-output lane once the control channel's SCTP
+/// send buffer holds this much; resume at the low watermark. The response
+/// lane is client-credit-gated, but PTY output had no end-to-end
+/// backpressure — a stalled tab grew the unbounded SCTP pending queue at
+/// PTY rate.
+const TERMINAL_LANE_BUFFERED_HIGH_WATERMARK_BYTES: usize = 1024 * 1024;
+/// Low watermark paired with [`TERMINAL_LANE_BUFFERED_HIGH_WATERMARK_BYTES`].
+const TERMINAL_LANE_BUFFERED_LOW_WATERMARK_BYTES: usize = 256 * 1024;
+/// Per-connection cap on bytes resident in the credit-gated outbound
+/// queue. Sized above the single largest legitimate response (the 100 MB
+/// fs-read cap) so one full-size download always fits, while N stalled
+/// downloads to a quiet client can no longer pin N full payloads.
+const CONTROL_OUTBOUND_QUEUE_MAX_BYTES: usize = 128 * 1024 * 1024;
+
+/// Clamp a byte watermark into the `u32` the rtc data-channel threshold
+/// setters take.
+fn watermark_to_u32(bytes: usize) -> u32 {
+    u32::try_from(bytes).unwrap_or(u32::MAX)
+}
 const CONTROL_RESPONSE_INITIAL_CHUNK_CREDIT: usize = 16;
 const CONTROL_RESPONSE_MAX_CREDIT_GRANT: usize = 64;
 const CONTROL_BINDING_TTL_MS: i64 = 5 * 60 * 1000;
@@ -1977,6 +2003,13 @@ impl InboundUploadState {
 
 pub(crate) struct OutboundControlQueue {
     frames: VecDeque<QueuedControlFrame>,
+    /// Bytes resident in `frames` (immediate texts + chunked payloads with
+    /// their start/end envelopes), maintained on every enqueue/removal.
+    /// Chunked enqueues are refused above
+    /// [`CONTROL_OUTBOUND_QUEUE_MAX_BYTES`] — before this cap, N stalled
+    /// credit-gated downloads pinned N full payload materializations for
+    /// as long as the client stayed quiet.
+    queued_bytes: usize,
 }
 
 enum QueuedControlFrame {
@@ -1984,32 +2017,158 @@ enum QueuedControlFrame {
     Chunked(QueuedChunkedFrame),
 }
 
+impl QueuedControlFrame {
+    /// Byte accounting for [`OutboundControlQueue::queued_bytes`], captured
+    /// at enqueue and debited verbatim at removal (chunked frames memoize
+    /// theirs, so draining `start`/`end` out of the plan cannot skew it).
+    fn queued_bytes(&self) -> usize {
+        match self {
+            Self::Immediate { text, .. } => text.len(),
+            Self::Chunked(queued) => queued.accounted_bytes,
+        }
+    }
+}
+
 struct QueuedChunkedFrame {
-    request_id: String,
-    chunk_id: String,
-    start: String,
-    chunks: Vec<String>,
-    end: String,
+    plan: ChunkedFramePlan,
+    /// `plan` size at enqueue (see [`QueuedControlFrame::queued_bytes`]).
+    accounted_bytes: usize,
     next_chunk: usize,
     credit: usize,
     started: bool,
 }
 
-pub(crate) enum ControlFrameTexts {
-    Immediate(Vec<String>),
-    Chunked {
+/// A chunked wire frame with its payload held raw and every
+/// `*_chunk` frame rendered lazily at send time. The old shape
+/// materialized each base64+JSON chunk String up front — ~1.37× the
+/// payload held simultaneously with the payload itself — and the drain
+/// cloned each chunk String again at send: ~5 copies end to end and
+/// ~2.4× payload peak RSS per queued download.
+pub(crate) struct ChunkedFramePlan {
+    pub(crate) request_id: String,
+    pub(crate) chunk_id: String,
+    /// Small header/footer frames, rendered eagerly (they carry counts and
+    /// metadata, not payload).
+    pub(crate) start: String,
+    pub(crate) end: String,
+    envelope: ChunkEnvelope,
+    payload: Vec<u8>,
+    chunk_bytes: usize,
+}
+
+/// Which chunk-frame envelope [`ChunkedFramePlan::render_chunk`] emits.
+enum ChunkEnvelope {
+    /// `response_chunk` frames around chunked JSON response text.
+    Response,
+    /// `byte_stream_chunk` frames around raw byte payloads.
+    ByteStream,
+}
+
+impl ChunkedFramePlan {
+    /// Plan for chunked JSON response text (`response_chunk` envelopes).
+    pub(crate) fn response(
         request_id: String,
         chunk_id: String,
         start: String,
-        chunks: Vec<String>,
         end: String,
-    },
+        payload: Vec<u8>,
+        chunk_bytes: usize,
+    ) -> Self {
+        Self {
+            request_id,
+            chunk_id,
+            start,
+            end,
+            envelope: ChunkEnvelope::Response,
+            payload,
+            chunk_bytes,
+        }
+    }
+
+    /// Plan for a raw byte download (`byte_stream_chunk` envelopes).
+    pub(crate) fn byte_stream(
+        request_id: String,
+        chunk_id: String,
+        start: String,
+        end: String,
+        payload: Vec<u8>,
+        chunk_bytes: usize,
+    ) -> Self {
+        Self {
+            request_id,
+            chunk_id,
+            start,
+            end,
+            envelope: ChunkEnvelope::ByteStream,
+            payload,
+            chunk_bytes,
+        }
+    }
+
+    pub(crate) fn chunk_count(&self) -> usize {
+        self.payload.len().div_ceil(self.chunk_bytes.max(1))
+    }
+
+    /// Render the `seq`-th chunk frame (base64 slice + envelope), `None`
+    /// past the end. Byte-identical to the frames the eager path built.
+    pub(crate) fn render_chunk(&self, seq: usize) -> Option<String> {
+        let offset = seq.checked_mul(self.chunk_bytes)?;
+        if offset >= self.payload.len() || self.chunk_bytes == 0 {
+            return None;
+        }
+        let end = offset.saturating_add(self.chunk_bytes).min(self.payload.len());
+        let data = base64::engine::general_purpose::STANDARD.encode(&self.payload[offset..end]);
+        let frame = match self.envelope {
+            ChunkEnvelope::Response => serde_json::json!({
+                "t": "response_chunk",
+                "id": self.request_id,
+                "chunk_id": self.chunk_id,
+                "seq": seq,
+                "data": data,
+            }),
+            ChunkEnvelope::ByteStream => serde_json::json!({
+                "t": "byte_stream_chunk",
+                "id": self.request_id,
+                "stream_id": self.chunk_id,
+                "seq": seq,
+                "data": data,
+            }),
+        };
+        Some(frame.to_string())
+    }
+
+    fn resident_bytes(&self) -> usize {
+        self.payload
+            .len()
+            .saturating_add(self.start.len())
+            .saturating_add(self.end.len())
+    }
+
+    /// All frames in order (start, chunks, end) — test helpers and the
+    /// no-credit immediate send path.
+    pub(crate) fn render_all(&self) -> Vec<String> {
+        let mut frames = Vec::with_capacity(self.chunk_count() + 2);
+        frames.push(self.start.clone());
+        for seq in 0..self.chunk_count() {
+            if let Some(text) = self.render_chunk(seq) {
+                frames.push(text);
+            }
+        }
+        frames.push(self.end.clone());
+        frames
+    }
+}
+
+pub(crate) enum ControlFrameTexts {
+    Immediate(Vec<String>),
+    Chunked(ChunkedFramePlan),
 }
 
 impl OutboundControlQueue {
     fn new() -> Self {
         Self {
             frames: VecDeque::new(),
+            queued_bytes: 0,
         }
     }
 
@@ -2018,30 +2177,42 @@ impl OutboundControlQueue {
     }
 
     fn enqueue_immediate(&mut self, request_id: String, text: String) {
-        self.frames
-            .push_back(QueuedControlFrame::Immediate { request_id, text });
+        let frame = QueuedControlFrame::Immediate { request_id, text };
+        self.queued_bytes = self.queued_bytes.saturating_add(frame.queued_bytes());
+        self.frames.push_back(frame);
     }
 
-    fn enqueue_chunked(
-        &mut self,
-        request_id: String,
-        chunk_id: String,
-        start: String,
-        chunks: Vec<String>,
-        end: String,
-    ) {
-        self.cancel_chunk(&chunk_id);
+    /// Queue a chunked frame; `false` when the per-connection byte cap is
+    /// exhausted (the caller answers the request with an error instead —
+    /// admission control, never a silent drop).
+    #[must_use]
+    fn enqueue_chunked(&mut self, plan: ChunkedFramePlan) -> bool {
+        self.cancel_chunk(&plan.chunk_id.clone());
+        let accounted_bytes = plan.resident_bytes();
+        if self
+            .queued_bytes
+            .saturating_add(accounted_bytes)
+            > CONTROL_OUTBOUND_QUEUE_MAX_BYTES
+        {
+            return false;
+        }
+        self.queued_bytes = self.queued_bytes.saturating_add(accounted_bytes);
         self.frames
             .push_back(QueuedControlFrame::Chunked(QueuedChunkedFrame {
-                request_id,
-                chunk_id,
-                start,
-                chunks,
-                end,
+                plan,
+                accounted_bytes,
                 next_chunk: 0,
                 credit: CONTROL_RESPONSE_INITIAL_CHUNK_CREDIT,
                 started: false,
             }));
+        true
+    }
+
+    /// Remove and return the front frame, keeping the byte accounting.
+    fn pop_front(&mut self) -> Option<QueuedControlFrame> {
+        let frame = self.frames.pop_front()?;
+        self.queued_bytes = self.queued_bytes.saturating_sub(frame.queued_bytes());
+        Some(frame)
     }
 
     fn grant_credit(&mut self, request_id: &str, chunk_id: Option<&str>, chunks: usize) {
@@ -2053,33 +2224,48 @@ impl OutboundControlQueue {
             let QueuedControlFrame::Chunked(queued) = frame else {
                 continue;
             };
-            let matches_chunk = chunk_id.map(|id| queued.chunk_id == id).unwrap_or(false);
-            if matches_chunk || (chunk_id.is_none() && queued.request_id == request_id) {
+            let matches_chunk = chunk_id
+                .map(|id| queued.plan.chunk_id == id)
+                .unwrap_or(false);
+            if matches_chunk || (chunk_id.is_none() && queued.plan.request_id == request_id) {
                 queued.credit = queued.credit.saturating_add(granted);
             }
         }
     }
 
     fn cancel(&mut self, request_id: &str) -> bool {
-        let before = self.frames.len();
-        self.frames.retain(|frame| match frame {
+        self.retain_accounted(|frame| match frame {
             QueuedControlFrame::Immediate {
                 request_id: queued_id,
                 ..
             } => queued_id != request_id,
             QueuedControlFrame::Chunked(queued) => {
-                queued.request_id != request_id && queued.chunk_id != request_id
+                queued.plan.request_id != request_id && queued.plan.chunk_id != request_id
             }
-        });
-        self.frames.len() != before
+        })
     }
 
     fn cancel_chunk(&mut self, chunk_id: &str) -> bool {
-        let before = self.frames.len();
-        self.frames.retain(|frame| match frame {
+        self.retain_accounted(|frame| match frame {
             QueuedControlFrame::Immediate { .. } => true,
-            QueuedControlFrame::Chunked(queued) => queued.chunk_id != chunk_id,
+            QueuedControlFrame::Chunked(queued) => queued.plan.chunk_id != chunk_id,
+        })
+    }
+
+    /// `retain` that debits removed frames from the byte accounting;
+    /// returns whether anything was removed.
+    fn retain_accounted(&mut self, keep: impl Fn(&QueuedControlFrame) -> bool) -> bool {
+        let before = self.frames.len();
+        let mut removed_bytes = 0usize;
+        self.frames.retain(|frame| {
+            if keep(frame) {
+                true
+            } else {
+                removed_bytes = removed_bytes.saturating_add(frame.queued_bytes());
+                false
+            }
         });
+        self.queued_bytes = self.queued_bytes.saturating_sub(removed_bytes);
         self.frames.len() != before
     }
 }
@@ -3523,6 +3709,8 @@ mod tests {
     ) -> Option<serde_json::Value> {
         let mut inbound_uploads = HashMap::new();
         let (terminal_tx, _terminal_rx) = mpsc::unbounded_channel();
+        let (terminal_output_tx, _terminal_output_rx) =
+            mpsc::channel(TERMINAL_OUTPUT_LANE_CAP);
         let mut terminal_forwarders = HashMap::new();
         let display_input_tx = DisplayInputForwarder::test_sink();
         control_frame_response(
@@ -3533,6 +3721,7 @@ mod tests {
             outbound_queue,
             &mut inbound_uploads,
             &terminal_tx,
+            &terminal_output_tx,
             &mut terminal_forwarders,
             &display_input_tx,
         )
@@ -5604,13 +5793,14 @@ mod tests {
         .unwrap();
         assert_eq!(status["result"]["response_credit_enabled"], true);
 
-        outbound.enqueue_chunked(
+        assert!(outbound.enqueue_chunked(ChunkedFramePlan::response(
             "large".into(),
             "large:0".into(),
             "start".into(),
-            vec!["chunk".into()],
             "end".into(),
-        );
+            b"chunk".to_vec(),
+            CONTROL_RESPONSE_CHUNK_BYTES,
+        )));
         if let Some(QueuedControlFrame::Chunked(queued)) = outbound.frames.front_mut() {
             queued.credit = 0;
         }

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -4071,6 +4071,44 @@ fn sha256_b64u(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
 
+    /// Empty/absent request ids are rejected at dispatch BEFORE any
+    /// spawn: an id-less request cannot receive a correlated response,
+    /// and an empty-id carrier would bypass the outbound queue and
+    /// chunking (the last congestion bypass). The rejection is an
+    /// error-class frame, so the budget seam bounds the spam.
+    #[tokio::test]
+    async fn empty_id_requests_are_rejected_before_spawning() {
+        let mut rt = runtime();
+        let (tx, mut rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
+        let mut outbound = OutboundControlQueue::new();
+
+        for frame in [
+            r#"{"t":"request","method":"api_sessions"}"#,
+            r#"{"t":"request","id":"","method":"api_sessions"}"#,
+            r#"{"t":"request","id":"","method":"status"}"#,
+        ] {
+            let rejected =
+                test_control_frame_response(frame, &mut rt, &tx, &mut pending, &mut outbound)
+                    .expect("id-less requests answer inline");
+            assert_eq!(rejected["ok"], false, "{rejected}");
+            assert!(rejected["error"].as_str().unwrap().contains("non-empty id"));
+            assert!(
+                is_error_class_frame(&rejected),
+                "the rejection must ride the budgeted error-class seam"
+            );
+        }
+        assert_eq!(
+            pending.live_work(),
+            0,
+            "nothing may spawn for id-less requests"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "no task response lane traffic for id-less requests"
+        );
+    }
+
     /// Committing uploads hold their BYTE weight against the aggregate
     /// declared-bytes budget until the commit completes: with enough
     /// bytes mid-commit, a new upload_start is refused on bytes even

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -85,10 +85,13 @@ const TERMINAL_LANE_BUFFERED_LOW_WATERMARK_BYTES: usize = 256 * 1024;
 /// fs-read cap) so one full-size download always fits, while N stalled
 /// downloads to a quiet client can no longer pin N full payloads.
 const CONTROL_OUTBOUND_QUEUE_MAX_BYTES: usize = 128 * 1024 * 1024;
+/// Companion frame-count cap: small immediate frames parked behind a
+/// zero-credit chunked head are byte-cheap but were unbounded in number.
+const CONTROL_OUTBOUND_QUEUE_MAX_FRAMES: usize = 4096;
 
 /// Clamp a byte watermark into the `u32` the rtc data-channel threshold
-/// setters take.
-fn watermark_to_u32(bytes: usize) -> u32 {
+/// setters take (shared with the peer file-transfer driver).
+pub(crate) fn watermark_to_u32(bytes: usize) -> u32 {
     u32::try_from(bytes).unwrap_or(u32::MAX)
 }
 const CONTROL_RESPONSE_INITIAL_CHUNK_CREDIT: usize = 16;
@@ -2001,11 +2004,24 @@ pub(crate) enum UploadSpool {
 const UPLOAD_MEMORY_SPOOL_MAX_BYTES: usize = 1024 * 1024;
 /// Batch size for disk-spool writes on the wire-driver task.
 const UPLOAD_DISK_SPOOL_BUFFER_BYTES: usize = 256 * 1024;
+/// Concurrent in-flight upload transfers per tunnel connection.
+const MAX_INBOUND_UPLOADS_PER_CONNECTION: usize = 8;
+/// Aggregate DECLARED bytes across a connection's in-flight uploads —
+/// admission control at upload_start, so a burst of starts cannot
+/// reserve unbounded spool space regardless of the per-upload cap.
+const MAX_INBOUND_UPLOAD_TOTAL_BYTES: usize = 256 * 1024 * 1024;
+/// Concurrent spawned request tasks per tunnel connection. Each spawned
+/// handler may construct a response as large as the fs-read cap before
+/// queue admission runs, so the reservation has to happen at spawn time.
+const MAX_PENDING_CONTROL_REQUESTS: usize = 64;
 
 impl UploadSpool {
     fn for_declared_size(total_bytes: usize) -> std::io::Result<Self> {
         if total_bytes <= UPLOAD_MEMORY_SPOOL_MAX_BYTES {
-            Ok(Self::Memory(Vec::with_capacity(total_bytes)))
+            // Allocate as chunks arrive — reserving the declared size up
+            // front let a burst of no-data upload_starts reserve
+            // gigabytes; the received-bytes checks bound actual growth.
+            Ok(Self::Memory(Vec::new()))
         } else {
             Ok(Self::Disk {
                 tmp: tempfile::NamedTempFile::new()?,
@@ -2220,7 +2236,13 @@ impl ChunkedFramePlan {
     }
 
     pub(crate) fn chunk_count(&self) -> usize {
-        self.payload.len().div_ceil(self.chunk_bytes.max(1))
+        // Zero chunk size renders zero chunks (`render_chunk` returns
+        // `None` for it); reporting payload-length chunks here would
+        // wedge the credit queue on a frame that can never complete.
+        if self.chunk_bytes == 0 {
+            return 0;
+        }
+        self.payload.len().div_ceil(self.chunk_bytes)
     }
 
     /// Render the `seq`-th chunk frame (base64 slice + envelope), `None`
@@ -2292,10 +2314,21 @@ impl OutboundControlQueue {
         self.frames.is_empty()
     }
 
-    fn enqueue_immediate(&mut self, request_id: String, text: String) {
+    /// Queue an immediate frame; `false` when the per-connection byte or
+    /// frame-count cap is exhausted (the caller answers with an error
+    /// instead — immediate frames parked behind a zero-credit chunked
+    /// head used to accumulate without bound).
+    #[must_use]
+    fn enqueue_immediate(&mut self, request_id: String, text: String) -> bool {
+        if self.frames.len() >= CONTROL_OUTBOUND_QUEUE_MAX_FRAMES
+            || self.queued_bytes.saturating_add(text.len()) > CONTROL_OUTBOUND_QUEUE_MAX_BYTES
+        {
+            return false;
+        }
         let frame = QueuedControlFrame::Immediate { request_id, text };
         self.queued_bytes = self.queued_bytes.saturating_add(frame.queued_bytes());
         self.frames.push_back(frame);
+        true
     }
 
     /// Queue a chunked frame; `false` when the per-connection byte cap is
@@ -2305,7 +2338,9 @@ impl OutboundControlQueue {
     fn enqueue_chunked(&mut self, plan: ChunkedFramePlan) -> bool {
         self.cancel_chunk(&plan.chunk_id.clone());
         let accounted_bytes = plan.resident_bytes();
-        if self.queued_bytes.saturating_add(accounted_bytes) > CONTROL_OUTBOUND_QUEUE_MAX_BYTES {
+        if self.frames.len() >= CONTROL_OUTBOUND_QUEUE_MAX_FRAMES
+            || self.queued_bytes.saturating_add(accounted_bytes) > CONTROL_OUTBOUND_QUEUE_MAX_BYTES
+        {
             return false;
         }
         self.queued_bytes = self.queued_bytes.saturating_add(accounted_bytes);
@@ -3778,6 +3813,29 @@ mod tests {
         };
         let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
         assert_eq!(parsed["id"], "has\"quote");
+
+        // Non-ASCII and control characters survive both positions: the
+        // body embeds verbatim (the core already escaped it), the id is
+        // escaped here.
+        let unicode_body = serde_json::json!({
+            "name": "résumé — 日本語 🚀",
+            "ctrl": "tab\tnewline\nbell\u{7}",
+        })
+        .to_string();
+        let frame = json_body_response_preserialized("id-é\u{1}", unicode_body.clone(), "test");
+        let serde_json::Value::String(text) = &frame else {
+            panic!("expected the pre-serialized carrier, got {frame}");
+        };
+        assert!(text.contains(&unicode_body), "body embeds verbatim");
+        let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed["id"], "id-é\u{1}");
+        assert_eq!(parsed["result"]["name"], "résumé — 日本語 🚀");
+        assert_eq!(parsed["result"]["ctrl"], "tab\tnewline\nbell\u{7}");
+        assert_eq!(
+            parsed,
+            json_body_response("id-é\u{1}".into(), unicode_body, "test"),
+            "JSON-equivalent to the parse-path envelope"
+        );
     }
 
     pub(crate) fn test_upload_state(

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -1781,7 +1781,9 @@ impl DashboardControlPeer {
             events_subscribed: false,
             events_sent: 0,
             response_credit_enabled: false,
-            config: Arc::new(serde_json::to_value(config).unwrap_or_else(|_| serde_json::json!({}))),
+            config: Arc::new(
+                serde_json::to_value(config).unwrap_or_else(|_| serde_json::json!({})),
+            ),
             bus,
             peer_registry,
             mcp_server,
@@ -2228,7 +2230,9 @@ impl ChunkedFramePlan {
         if offset >= self.payload.len() || self.chunk_bytes == 0 {
             return None;
         }
-        let end = offset.saturating_add(self.chunk_bytes).min(self.payload.len());
+        let end = offset
+            .saturating_add(self.chunk_bytes)
+            .min(self.payload.len());
         let data = base64::engine::general_purpose::STANDARD.encode(&self.payload[offset..end]);
         let frame = match self.envelope {
             ChunkEnvelope::Response => serde_json::json!({
@@ -2301,11 +2305,7 @@ impl OutboundControlQueue {
     fn enqueue_chunked(&mut self, plan: ChunkedFramePlan) -> bool {
         self.cancel_chunk(&plan.chunk_id.clone());
         let accounted_bytes = plan.resident_bytes();
-        if self
-            .queued_bytes
-            .saturating_add(accounted_bytes)
-            > CONTROL_OUTBOUND_QUEUE_MAX_BYTES
-        {
+        if self.queued_bytes.saturating_add(accounted_bytes) > CONTROL_OUTBOUND_QUEUE_MAX_BYTES {
             return false;
         }
         self.queued_bytes = self.queued_bytes.saturating_add(accounted_bytes);
@@ -3212,8 +3212,9 @@ fn json_body_response(id: String, body: String, label: &str) -> serde_json::Valu
 /// `json_body_response_preserialized`); `id` is JSON-escaped here.
 fn spliced_response_frame_text(id: &str, body: &str) -> String {
     let id_json = serde_json::to_string(id).unwrap_or_else(|_| "\"\"".to_string());
-    let mut text =
-        String::with_capacity(body.len() + id_json.len() + "{\"t\":\"response\",\"id\":,\"ok\":true,\"result\":}".len());
+    let mut text = String::with_capacity(
+        body.len() + id_json.len() + "{\"t\":\"response\",\"id\":,\"ok\":true,\"result\":}".len(),
+    );
     text.push_str("{\"t\":\"response\",\"id\":");
     text.push_str(&id_json);
     text.push_str(",\"ok\":true,\"result\":");
@@ -3829,9 +3830,7 @@ mod tests {
             }
             let mut tmp = spool.into_spooled_tempfile().unwrap();
             let mut on_disk = Vec::new();
-            tmp.as_file_mut()
-                .seek(std::io::SeekFrom::Start(0))
-                .unwrap();
+            tmp.as_file_mut().seek(std::io::SeekFrom::Start(0)).unwrap();
             tmp.as_file_mut().read_to_end(&mut on_disk).unwrap();
             assert_eq!(on_disk, payload);
 
@@ -3948,8 +3947,7 @@ mod tests {
     ) -> Option<serde_json::Value> {
         let mut inbound_uploads = HashMap::new();
         let (terminal_tx, _terminal_rx) = mpsc::unbounded_channel();
-        let (terminal_output_tx, _terminal_output_rx) =
-            mpsc::channel(TERMINAL_OUTPUT_LANE_CAP);
+        let (terminal_output_tx, _terminal_output_rx) = mpsc::channel(TERMINAL_OUTPUT_LANE_CAP);
         let mut terminal_forwarders = HashMap::new();
         let display_input_tx = DisplayInputForwarder::test_sink();
         control_frame_response(

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -94,6 +94,66 @@ const CONTROL_OUTBOUND_QUEUE_MAX_FRAMES: usize = 4096;
 pub(crate) fn watermark_to_u32(bytes: usize) -> u32 {
     u32::try_from(bytes).unwrap_or(u32::MAX)
 }
+
+/// Token budget for DIRECT error frames — the admission-refusal and
+/// rejection replies that deliberately bypass the queue/backpressure
+/// lanes (they must be deliverable exactly when those lanes are the
+/// problem). While the wire is below its high watermark the budget stays
+/// full (frames drain as fast as they are sent); while congested each
+/// direct error spends one token, and at zero the frame is DROPPED and
+/// counted (logged once per connection, summarized at teardown) — the
+/// protocol contract is best-effort error delivery under abuse, bounded
+/// memory always. Shared by the dashboard tunnel and the peer
+/// file-transfer driver.
+pub(crate) struct DirectErrorBudget {
+    label: &'static str,
+    remaining: u32,
+    dropped: u64,
+}
+
+/// Direct error frames spendable while the wire stays congested.
+pub(crate) const DIRECT_ERROR_BUDGET_FRAMES: u32 = 64;
+
+impl DirectErrorBudget {
+    pub(crate) fn new(label: &'static str) -> Self {
+        Self {
+            label,
+            remaining: DIRECT_ERROR_BUDGET_FRAMES,
+            dropped: 0,
+        }
+    }
+
+    /// Whether one direct error frame may be sent right now.
+    pub(crate) fn allow(&mut self, wire_congested: bool) -> bool {
+        if !wire_congested {
+            // Uncongested wire drains what it is handed; refill.
+            self.remaining = DIRECT_ERROR_BUDGET_FRAMES;
+            return true;
+        }
+        if self.remaining > 0 {
+            self.remaining -= 1;
+            return true;
+        }
+        self.dropped = self.dropped.saturating_add(1);
+        if self.dropped == 1 {
+            eprintln!(
+                "[{}] direct error-frame budget exhausted while congested; dropping further error frames",
+                self.label
+            );
+        }
+        false
+    }
+
+    /// Log the drop tally at connection teardown (silent when zero).
+    pub(crate) fn log_teardown(&self) {
+        if self.dropped > 0 {
+            eprintln!(
+                "[{}] dropped {} direct error frame(s) under congestion this session",
+                self.label, self.dropped
+            );
+        }
+    }
+}
 const CONTROL_RESPONSE_INITIAL_CHUNK_CREDIT: usize = 16;
 const CONTROL_RESPONSE_MAX_CREDIT_GRANT: usize = 64;
 const CONTROL_BINDING_TTL_MS: i64 = 5 * 60 * 1000;
@@ -1969,6 +2029,109 @@ pub(crate) struct ControlTaskResponse {
     done: bool,
 }
 
+/// One spawned-lane response paired with the reservation generation that
+/// produced it (see [`PendingControlRequests`]): the driver forwards a
+/// response only while its generation still owns the id's reservation,
+/// so a superseded task can neither reach the wire under a reused id nor
+/// free its replacement's reservation.
+pub(crate) type SequencedTaskResponse = (u64, ControlTaskResponse);
+
+/// The spawned-request reservations for one tunnel connection, keyed by
+/// request id with a per-admission GENERATION (the peer-transfer read
+/// registry's pattern): same-id replacement cancels its predecessor and
+/// mints a new generation, completion frees only its own generation, and
+/// stale-generation responses are dropped. Admission (`at_capacity_for` +
+/// [`MAX_PENDING_CONTROL_REQUESTS`]) reserves at SPAWN time, before any
+/// response bytes exist.
+pub(crate) struct PendingControlRequests {
+    entries: HashMap<String, PendingControlRequest>,
+    next_generation: u64,
+}
+
+struct PendingControlRequest {
+    cancel: CancellationToken,
+    generation: u64,
+}
+
+impl PendingControlRequests {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+            next_generation: 0,
+        }
+    }
+
+    /// Reserve `id`, cancelling and replacing any predecessor (whose
+    /// spawned task dies at its next await point — see the spawn
+    /// wrappers' `select!`). Returns the new reservation's cancel token
+    /// and generation.
+    pub(crate) fn admit(&mut self, id: &str) -> (CancellationToken, u64) {
+        if let Some(previous) = self.entries.remove(id) {
+            previous.cancel.cancel();
+        }
+        self.next_generation = self.next_generation.wrapping_add(1);
+        let generation = self.next_generation;
+        let cancel = CancellationToken::new();
+        self.entries.insert(
+            id.to_string(),
+            PendingControlRequest {
+                cancel: cancel.clone(),
+                generation,
+            },
+        );
+        (cancel, generation)
+    }
+
+    /// The client's `cancel` frame: cancel and free the reservation.
+    pub(crate) fn cancel_remove(&mut self, id: &str) -> bool {
+        match self.entries.remove(id) {
+            Some(entry) => {
+                entry.cancel.cancel();
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Whether `generation` still owns `id`'s reservation.
+    pub(crate) fn matches(&self, id: &str, generation: u64) -> bool {
+        self.entries
+            .get(id)
+            .is_some_and(|entry| entry.generation == generation)
+    }
+
+    /// Free the reservation on completion — only for its own generation.
+    pub(crate) fn complete(&mut self, id: &str, generation: u64) -> bool {
+        if self.matches(id, generation) {
+            self.entries.remove(id);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn contains_key(&self, id: &str) -> bool {
+        self.entries.contains_key(id)
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Spawn-time admission: full only when `id` would be a NEW entry —
+    /// same-id replacement cancels its predecessor and holds the count.
+    pub(crate) fn at_capacity_for(&self, id: &str) -> bool {
+        !self.contains_key(id) && self.len() >= MAX_PENDING_CONTROL_REQUESTS
+    }
+
+    /// Teardown: cancel every reservation.
+    pub(crate) fn cancel_all(&mut self) {
+        for (_, entry) in self.entries.drain() {
+            entry.cancel.cancel();
+        }
+    }
+}
+
 pub(crate) struct ControlByteStream {
     id: String,
     stream_id: String,
@@ -2114,6 +2277,10 @@ pub(crate) struct InboundUploadState {
     expected_chunks: usize,
     next_seq: usize,
     received_bytes: usize,
+    /// The pending-request reservation generation minted at
+    /// `upload_start` — the terminal task's response carries it so the
+    /// driver can match it against the live reservation.
+    generation: u64,
 }
 
 impl InboundUploadState {
@@ -3778,6 +3945,42 @@ fn sha256_b64u(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
 
+    /// Generation-keyed reservations: same-id replacement cancels its
+    /// predecessor and mints a new generation; a superseded generation
+    /// can neither claim ownership nor free the replacement's
+    /// reservation; capacity exempts same-id replacement only.
+    #[test]
+    fn pending_request_generations_protect_replacements() {
+        let mut pending = PendingControlRequests::new();
+        let (first_cancel, first_generation) = pending.admit("r1");
+        let (second_cancel, second_generation) = pending.admit("r1");
+        assert!(
+            first_cancel.is_cancelled(),
+            "replacement cancels the predecessor"
+        );
+        assert!(!second_cancel.is_cancelled());
+        assert_ne!(first_generation, second_generation);
+        assert!(!pending.matches("r1", first_generation));
+        assert!(pending.matches("r1", second_generation));
+        assert!(
+            !pending.complete("r1", first_generation),
+            "a superseded completion must not free the replacement"
+        );
+        assert!(pending.contains_key("r1"));
+        assert!(pending.complete("r1", second_generation));
+        assert!(!pending.contains_key("r1"));
+
+        let mut pending = PendingControlRequests::new();
+        for index in 0..MAX_PENDING_CONTROL_REQUESTS {
+            pending.admit(&format!("r{index}"));
+        }
+        assert!(pending.at_capacity_for("new-id"));
+        assert!(
+            !pending.at_capacity_for("r0"),
+            "same-id replacement stays admissible at capacity"
+        );
+    }
+
     /// The pre-serialized response carrier: byte-verbatim body embedding,
     /// JSON-equivalence with the parse-path envelope, escaped ids, and
     /// the historical error frame for invalid bodies.
@@ -3854,6 +4057,7 @@ mod tests {
             expected_chunks: if bytes.is_empty() { 0 } else { 1 },
             next_seq: if bytes.is_empty() { 0 } else { 1 },
             received_bytes: bytes.len(),
+            generation: 0,
         }
     }
 
@@ -3999,8 +4203,8 @@ mod tests {
     fn test_control_frame_response(
         text: &str,
         runtime: &mut ControlRuntime,
-        task_tx: &mpsc::Sender<ControlTaskResponse>,
-        pending_requests: &mut HashMap<String, CancellationToken>,
+        task_tx: &mpsc::Sender<SequencedTaskResponse>,
+        pending_requests: &mut PendingControlRequests,
         outbound_queue: &mut OutboundControlQueue,
     ) -> Option<serde_json::Value> {
         let mut inbound_uploads = HashMap::new();
@@ -4082,8 +4286,8 @@ mod tests {
 
     #[test]
     fn peer_dashboard_grants_split_access_and_peer_permissions() {
-        let (tx, _rx) = mpsc::channel::<ControlTaskResponse>(8);
-        let mut pending = HashMap::new();
+        let (tx, _rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
         let mut peer_root = runtime();
         peer_root.grant = DashboardControlGrant::Peer {
@@ -4216,8 +4420,8 @@ mod tests {
     #[tokio::test]
     async fn control_frames_answer_hello_ping_and_config() {
         let mut rt = runtime();
-        let (tx, mut rx) = mpsc::channel::<ControlTaskResponse>(8);
-        let mut pending = HashMap::new();
+        let (tx, mut rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
         let hello = test_control_frame_response(
             r#"{"t":"hello","id":"h1"}"#,
@@ -4533,8 +4737,8 @@ mod tests {
         );
         assert!(project_root.is_none());
         assert!(pending.contains_key("pr1"));
-        let project_root = rx.recv().await.unwrap();
-        assert!(pending.remove(&project_root.id).is_some());
+        let (_, project_root) = rx.recv().await.unwrap();
+        assert!(pending.cancel_remove(&project_root.id));
         assert_eq!(project_root.id, "pr1");
         assert!(project_root.done);
         let project_root = project_root.frame;
@@ -4562,7 +4766,7 @@ mod tests {
         assert_eq!(cancelled["t"], "response");
         assert_eq!(cancelled["ok"], false);
         assert_eq!(cancelled["cancelled"], true);
-        assert!(pending.get("q1").is_none());
+        assert!(!pending.contains_key("q1"));
     }
 
     /// The operation a method's declaration carries (route-row tunnel
@@ -5470,7 +5674,7 @@ mod tests {
         let mut rt = runtime();
         let mut events = rt.bus.subscribe();
         let (task_tx, _task_rx) = mpsc::channel(1);
-        let mut pending = HashMap::new();
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
 
         let ack = test_control_frame_response(
@@ -5510,7 +5714,7 @@ mod tests {
         let (control_tx, mut control_rx) = mpsc::unbounded_channel();
         rt.control_frames_tx = Some(control_tx);
         let (task_tx, _task_rx) = mpsc::channel(1);
-        let mut pending = HashMap::new();
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
 
         let ack = test_control_frame_response(
@@ -5541,8 +5745,8 @@ mod tests {
     async fn control_frame_routes_session_control_msg_requests() {
         let mut rt = runtime();
         let mut events = rt.bus.subscribe();
-        let (tx, mut rx) = mpsc::channel::<ControlTaskResponse>(8);
-        let mut pending = HashMap::new();
+        let (tx, mut rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
         let immediate = test_control_frame_response(
             r#"{"t":"request","id":"session-ctrl-frame","method":"api_session_control_msg","params":{"message":{"action":"interrupt","session_id":"session-frame"}}}"#,
@@ -5553,7 +5757,7 @@ mod tests {
         );
         assert!(immediate.is_none(), "session control request should spawn");
 
-        let task = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        let (_, task) = tokio::time::timeout(Duration::from_secs(1), rx.recv())
             .await
             .unwrap()
             .unwrap();
@@ -5585,8 +5789,8 @@ mod tests {
     async fn control_frame_routes_dashboard_action_msg_requests() {
         let mut rt = runtime();
         let mut events = rt.bus.subscribe();
-        let (tx, mut rx) = mpsc::channel::<ControlTaskResponse>(8);
-        let mut pending = HashMap::new();
+        let (tx, mut rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
         let immediate = test_control_frame_response(
             r#"{"t":"request","id":"dash-action-frame","method":"api_dashboard_action_msg","params":{"message":{"action":"close_browser_workspace","workspace_id":"workspace-frame"}}}"#,
@@ -5597,7 +5801,7 @@ mod tests {
         );
         assert!(immediate.is_none(), "dashboard action request should spawn");
 
-        let task = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        let (_, task) = tokio::time::timeout(Duration::from_secs(1), rx.recv())
             .await
             .unwrap()
             .unwrap();
@@ -5632,8 +5836,8 @@ mod tests {
     #[tokio::test]
     async fn current_agent_output_without_active_log_preserves_http_status() {
         let mut rt = runtime();
-        let (tx, mut rx) = mpsc::channel::<ControlTaskResponse>(8);
-        let mut pending = HashMap::new();
+        let (tx, mut rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
 
         let queued = test_control_frame_response(
@@ -5646,8 +5850,8 @@ mod tests {
         assert!(queued.is_none());
         assert!(pending.contains_key("out1"));
 
-        let response = rx.recv().await.unwrap();
-        assert!(pending.remove(&response.id).is_some());
+        let (_, response) = rx.recv().await.unwrap();
+        assert!(pending.cancel_remove(&response.id));
         assert_eq!(response.id, "out1");
         assert!(response.done);
         assert_eq!(response.frame["t"], "response");
@@ -5660,8 +5864,8 @@ mod tests {
     #[tokio::test]
     async fn current_history_without_file_watcher_preserves_http_status() {
         let mut rt = runtime();
-        let (tx, mut rx) = mpsc::channel::<ControlTaskResponse>(8);
-        let mut pending = HashMap::new();
+        let (tx, mut rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
 
         for (idx, (method, params)) in [
@@ -5693,8 +5897,8 @@ mod tests {
             assert!(queued.is_none());
             assert!(pending.contains_key(&id));
 
-            let response = rx.recv().await.unwrap();
-            assert!(pending.remove(&response.id).is_some());
+            let (_, response) = rx.recv().await.unwrap();
+            assert!(pending.cancel_remove(&response.id));
             assert_eq!(response.id, id);
             assert!(response.done);
             assert_eq!(response.frame["t"], "response");
@@ -5708,8 +5912,8 @@ mod tests {
     #[tokio::test]
     async fn current_changes_without_file_watcher_preserves_http_status() {
         let mut rt = runtime();
-        let (tx, mut rx) = mpsc::channel::<ControlTaskResponse>(8);
-        let mut pending = HashMap::new();
+        let (tx, mut rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
 
         let queued = test_control_frame_response(
@@ -5722,8 +5926,8 @@ mod tests {
         assert!(queued.is_none());
         assert!(pending.contains_key("chg1"));
 
-        let response = rx.recv().await.unwrap();
-        assert!(pending.remove(&response.id).is_some());
+        let (_, response) = rx.recv().await.unwrap();
+        assert!(pending.cancel_remove(&response.id));
         assert_eq!(response.id, "chg1");
         assert!(response.done);
         assert_eq!(response.frame["t"], "response");
@@ -5739,8 +5943,8 @@ mod tests {
         std::fs::write(dir.path().join("note.txt"), b"hello").unwrap();
 
         let mut rt = runtime();
-        let (tx, mut rx) = mpsc::channel::<ControlTaskResponse>(8);
-        let mut pending = HashMap::new();
+        let (tx, mut rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
 
         for (idx, (method, path)) in [
@@ -5769,8 +5973,8 @@ mod tests {
             assert!(queued.is_none());
             assert!(pending.contains_key(&id));
 
-            let response = rx.recv().await.unwrap();
-            assert!(pending.remove(&response.id).is_some());
+            let (_, response) = rx.recv().await.unwrap();
+            assert!(pending.cancel_remove(&response.id));
             assert_eq!(response.id, id);
             assert!(response.done);
             assert_eq!(response.frame["t"], "response");
@@ -5828,8 +6032,8 @@ mod tests {
             };
             rt
         };
-        let (tx, mut rx) = mpsc::channel::<ControlTaskResponse>(8);
-        let mut pending = HashMap::new();
+        let (tx, mut rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
         let request = |id: &str, method: &str, params: serde_json::Value| {
             serde_json::json!({
@@ -5932,8 +6136,8 @@ mod tests {
             &mut outbound,
         );
         assert!(queued.is_none());
-        let response = rx.recv().await.unwrap();
-        assert!(pending.remove(&response.id).is_some());
+        let (_, response) = rx.recv().await.unwrap();
+        assert!(pending.cancel_remove(&response.id));
         assert_eq!(response.frame["result"]["_httpStatus"], 200);
         assert_eq!(response.frame["result"]["renamed"], true);
         assert!(!from.exists());
@@ -5971,8 +6175,8 @@ mod tests {
             &mut outbound,
         );
         assert!(queued.is_none());
-        let response = rx.recv().await.unwrap();
-        assert!(pending.remove(&response.id).is_some());
+        let (_, response) = rx.recv().await.unwrap();
+        assert!(pending.cancel_remove(&response.id));
         assert_eq!(response.frame["result"]["_httpStatus"], 409);
         assert_eq!(response.frame["result"]["code"], "not_empty");
         assert!(sub.exists());
@@ -5989,8 +6193,8 @@ mod tests {
             &mut outbound,
         );
         assert!(queued.is_none());
-        let response = rx.recv().await.unwrap();
-        assert!(pending.remove(&response.id).is_some());
+        let (_, response) = rx.recv().await.unwrap();
+        assert!(pending.cancel_remove(&response.id));
         assert_eq!(response.frame["result"]["_httpStatus"], 200);
         assert_eq!(response.frame["result"]["deleted"], true);
         assert!(!sub.exists());
@@ -6004,8 +6208,8 @@ mod tests {
 
         let mut rt = runtime();
         rt.project_root = Some(project);
-        let (tx, mut rx) = mpsc::channel::<ControlTaskResponse>(8);
-        let mut pending = HashMap::new();
+        let (tx, mut rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
 
         let queued = test_control_frame_response(
@@ -6018,11 +6222,11 @@ mod tests {
         assert!(queued.is_none());
         assert!(pending.contains_key("transfer-jobs-frame"));
 
-        let response = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        let (_, response) = tokio::time::timeout(Duration::from_secs(1), rx.recv())
             .await
             .unwrap()
             .unwrap();
-        assert!(pending.remove(&response.id).is_some());
+        assert!(pending.cancel_remove(&response.id));
         assert_eq!(response.id, "transfer-jobs-frame");
         assert!(response.done);
         assert_eq!(response.frame["t"], "response");
@@ -6063,8 +6267,8 @@ mod tests {
     #[tokio::test]
     async fn control_frames_negotiate_and_apply_response_credit() {
         let mut rt = runtime();
-        let (tx, _rx) = mpsc::channel::<ControlTaskResponse>(8);
-        let mut pending = HashMap::new();
+        let (tx, _rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
         let mut outbound = OutboundControlQueue::new();
 
         let hello = test_control_frame_response(

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -1973,10 +1973,125 @@ pub(crate) struct ControlByteStream {
     result: serde_json::Value,
 }
 
+/// Where an in-flight tunnel upload accumulates.
+///
+/// Payloads whose declared size fits [`UPLOAD_MEMORY_SPOOL_MAX_BYTES`]
+/// accumulate in memory: every payload — including each recurring
+/// presence webcam frame (~30–100 KB) — used to pay a tempfile
+/// create/write/seek/read/unlink round-trip, with the per-chunk blocking
+/// `write_all` running on the tunnel's wire-driver task (latency jitter
+/// for everything multiplexed on the connection). Larger uploads spool
+/// to a tempfile as before, with chunk writes batched through a small
+/// buffer instead of one blocking write per 16 KiB frame.
+pub(crate) enum UploadSpool {
+    Memory(Vec<u8>),
+    Disk {
+        tmp: tempfile::NamedTempFile,
+        /// Chunk bytes not yet written to `tmp`; flushed at
+        /// [`UPLOAD_DISK_SPOOL_BUFFER_BYTES`] and at upload end.
+        buf: Vec<u8>,
+    },
+}
+
+/// Uploads at or under this declared size accumulate in memory. The
+/// declared size is enforced by the chunk-lane byte checks, so the spool
+/// can never grow past it.
+const UPLOAD_MEMORY_SPOOL_MAX_BYTES: usize = 1024 * 1024;
+/// Batch size for disk-spool writes on the wire-driver task.
+const UPLOAD_DISK_SPOOL_BUFFER_BYTES: usize = 256 * 1024;
+
+impl UploadSpool {
+    fn for_declared_size(total_bytes: usize) -> std::io::Result<Self> {
+        if total_bytes <= UPLOAD_MEMORY_SPOOL_MAX_BYTES {
+            Ok(Self::Memory(Vec::with_capacity(total_bytes)))
+        } else {
+            Ok(Self::Disk {
+                tmp: tempfile::NamedTempFile::new()?,
+                buf: Vec::with_capacity(UPLOAD_DISK_SPOOL_BUFFER_BYTES),
+            })
+        }
+    }
+
+    fn append(&mut self, bytes: &[u8]) -> std::io::Result<()> {
+        match self {
+            Self::Memory(data) => {
+                data.extend_from_slice(bytes);
+                Ok(())
+            }
+            Self::Disk { tmp, buf } => {
+                buf.extend_from_slice(bytes);
+                if buf.len() >= UPLOAD_DISK_SPOOL_BUFFER_BYTES {
+                    tmp.as_file_mut().write_all(buf)?;
+                    buf.clear();
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// Settle the spool at upload end: drain the write buffer and flush.
+    fn finish(&mut self) -> std::io::Result<()> {
+        if let Self::Disk { tmp, buf } = self {
+            if !buf.is_empty() {
+                tmp.as_file_mut().write_all(buf)?;
+                buf.clear();
+            }
+            tmp.as_file_mut().flush()?;
+        }
+        Ok(())
+    }
+
+    /// The whole payload as bytes (the media handlers' shape): a memory
+    /// spool moves out with zero I/O; a disk spool settles and reads
+    /// back, exactly as the tempfile path always did.
+    pub(crate) fn take_bytes(&mut self, expected_len: usize) -> Result<Vec<u8>, String> {
+        self.finish()
+            .map_err(|e| format!("flush upload spool: {e}"))?;
+        let bytes = match self {
+            Self::Memory(data) => std::mem::take(data),
+            Self::Disk { tmp, .. } => {
+                tmp.as_file_mut()
+                    .seek(std::io::SeekFrom::Start(0))
+                    .map_err(|e| format!("seek upload tempfile: {e}"))?;
+                let mut bytes = Vec::with_capacity(expected_len);
+                tmp.as_file_mut()
+                    .read_to_end(&mut bytes)
+                    .map_err(|e| format!("read upload tempfile: {e}"))?;
+                bytes
+            }
+        };
+        if bytes.len() != expected_len {
+            return Err(format!(
+                "upload byte count changed while committing: expected {}, got {}",
+                expected_len,
+                bytes.len()
+            ));
+        }
+        Ok(bytes)
+    }
+
+    /// The whole payload as a [`crate::web_gateway::SpooledBody`]
+    /// tempfile (the staged-upload / transfer-chunk / fs-write commit
+    /// shape): a disk spool settles and hands over its tempfile; a
+    /// memory spool writes once.
+    fn into_spooled_tempfile(mut self) -> std::io::Result<tempfile::NamedTempFile> {
+        self.finish()?;
+        match self {
+            Self::Memory(data) => {
+                let mut tmp = tempfile::NamedTempFile::new()?;
+                tmp.as_file_mut().write_all(&data)?;
+                tmp.as_file_mut().flush()?;
+                Ok(tmp)
+            }
+            Self::Disk { tmp, .. } => Ok(tmp),
+        }
+    }
+}
+
 pub(crate) struct InboundUploadState {
     method: String,
     params: serde_json::Value,
-    tmp: tempfile::NamedTempFile,
+    spool: UploadSpool,
     total_bytes: usize,
     expected_chunks: usize,
     next_seq: usize,
@@ -1988,16 +2103,13 @@ impl InboundUploadState {
     /// (transport-unification S8): the frame params plus the spooled
     /// bytes, for handlers that commit the spool wholesale — the staged
     /// upload today, the S9 transfer-chunk appends next. The media
-    /// handlers keep reading the tempfile in-memory instead (their
-    /// stores take byte slices).
-    pub(crate) fn into_spooled_body(self) -> (serde_json::Value, crate::web_gateway::SpooledBody) {
-        (
-            self.params,
-            crate::web_gateway::SpooledBody {
-                tmp: self.tmp,
-                len: self.received_bytes,
-            },
-        )
+    /// handlers read bytes out instead ([`UploadSpool::take_bytes`]).
+    pub(crate) fn into_spooled_body(
+        self,
+    ) -> std::io::Result<(serde_json::Value, crate::web_gateway::SpooledBody)> {
+        let len = self.received_bytes;
+        let tmp = self.spool.into_spooled_tempfile()?;
+        Ok((self.params, crate::web_gateway::SpooledBody { tmp, len }))
     }
 }
 
@@ -3672,17 +3784,61 @@ mod tests {
         params: serde_json::Value,
         bytes: &[u8],
     ) -> InboundUploadState {
-        let mut tmp = tempfile::NamedTempFile::new().unwrap();
-        tmp.as_file_mut().write_all(bytes).unwrap();
-        tmp.as_file_mut().flush().unwrap();
+        let mut spool = UploadSpool::for_declared_size(bytes.len()).unwrap();
+        spool.append(bytes).unwrap();
+        spool.finish().unwrap();
         InboundUploadState {
             method: method.to_string(),
             params,
-            tmp,
+            spool,
             total_bytes: bytes.len(),
             expected_chunks: if bytes.is_empty() { 0 } else { 1 },
             next_seq: if bytes.is_empty() { 0 } else { 1 },
             received_bytes: bytes.len(),
+        }
+    }
+
+    /// Both spool variants round-trip bytes identically through both
+    /// consumption shapes (take_bytes for the media handlers, the
+    /// SpooledBody tempfile for the commit handlers), and the memory
+    /// threshold routes small payloads off disk.
+    #[test]
+    fn upload_spool_round_trips_both_variants() {
+        for (len, expect_memory) in [
+            (16usize, true),
+            (UPLOAD_MEMORY_SPOOL_MAX_BYTES, true),
+            (UPLOAD_MEMORY_SPOOL_MAX_BYTES + 1, false),
+        ] {
+            let payload: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+
+            let mut spool = UploadSpool::for_declared_size(len).unwrap();
+            assert_eq!(
+                matches!(spool, UploadSpool::Memory(_)),
+                expect_memory,
+                "threshold routing for {len} bytes"
+            );
+            // Chunked appends like the wire delivers them.
+            for chunk in payload.chunks(7 * 1024) {
+                spool.append(chunk).unwrap();
+            }
+            assert_eq!(spool.take_bytes(len).unwrap(), payload);
+
+            let mut spool = UploadSpool::for_declared_size(len).unwrap();
+            for chunk in payload.chunks(7 * 1024) {
+                spool.append(chunk).unwrap();
+            }
+            let mut tmp = spool.into_spooled_tempfile().unwrap();
+            let mut on_disk = Vec::new();
+            tmp.as_file_mut()
+                .seek(std::io::SeekFrom::Start(0))
+                .unwrap();
+            tmp.as_file_mut().read_to_end(&mut on_disk).unwrap();
+            assert_eq!(on_disk, payload);
+
+            // A short payload is caught by the byte-count guard.
+            let mut spool = UploadSpool::for_declared_size(len).unwrap();
+            spool.append(&payload[..len - 1]).unwrap();
+            assert!(spool.take_bytes(len).is_err());
         }
     }
 

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -3088,6 +3088,49 @@ fn json_body_response(id: String, body: String, label: &str) -> serde_json::Valu
     }
 }
 
+/// Splice a core-serialized JSON body into a complete, PRE-SERIALIZED
+/// `{"t":"response","id":…,"ok":true,"result":<body>}` envelope by string
+/// concatenation — the response lane's twin of the event lane's
+/// `event_lane_frame` splice. The core memoizes its hottest bodies as
+/// strings (routes_sessions' documented multi-MB list cache); parsing
+/// such a body into a full `Value` tree and re-serializing the envelope
+/// made every tunnel poll pay three complete JSON passes.
+///
+/// The caller must have validated `body` as JSON (see
+/// `json_body_response_preserialized`); `id` is JSON-escaped here.
+fn spliced_response_frame_text(id: &str, body: &str) -> String {
+    let id_json = serde_json::to_string(id).unwrap_or_else(|_| "\"\"".to_string());
+    let mut text =
+        String::with_capacity(body.len() + id_json.len() + "{\"t\":\"response\",\"id\":,\"ok\":true,\"result\":}".len());
+    text.push_str("{\"t\":\"response\",\"id\":");
+    text.push_str(&id_json);
+    text.push_str(",\"ok\":true,\"result\":");
+    text.push_str(body);
+    text.push('}');
+    text
+}
+
+/// `json_body_response`, pre-serialized: the returned frame is
+/// `Value::String(<complete envelope text>)` — the task lane's
+/// pre-serialized carrier. Response objects never serialize as top-level
+/// JSON strings, so the variant is unambiguous;
+/// `send_control_task_response` sends the text verbatim (chunking on the
+/// same thresholds, keyed by the task's own request id). Only legal on
+/// the spawned task-response lane. The body is still validated — one
+/// full parse into `IgnoredAny`, no tree allocation — so an invalid body
+/// answers with the historical error frame.
+fn json_body_response_preserialized(id: &str, body: String, label: &str) -> serde_json::Value {
+    if serde_json::from_str::<serde::de::IgnoredAny>(&body).is_err() {
+        return serde_json::json!({
+            "t": "response",
+            "id": id,
+            "ok": false,
+            "error": format!("{label} returned invalid JSON"),
+        });
+    }
+    serde_json::Value::String(spliced_response_frame_text(id, &body))
+}
+
 fn http_body_response(id: String, status: u16, body: String, label: &str) -> serde_json::Value {
     match serde_json::from_str::<serde_json::Value>(&body) {
         Ok(mut result) => {
@@ -3196,21 +3239,24 @@ async fn api_sessions_response_from_home(
             "error": "session list returned an unexpected byte response",
         });
     };
-    // Historical result-shape guard: the list must be a JSON array.
-    match serde_json::from_str::<serde_json::Value>(&body.into_string()) {
-        Ok(result) if result.is_array() => serde_json::json!({
-            "t": "response",
-            "id": id,
-            "ok": true,
-            "result": result,
-        }),
-        _ => serde_json::json!({
+    // Historical result-shape guard: the list must be a JSON array —
+    // enforced without materializing the multi-MB Value tree (the SPA
+    // polls this with limit:'all' every 15s per tab, and the core already
+    // serves the body from its serialized-string cache): a full validating
+    // parse into `IgnoredAny` plus the leading-token check, then the body
+    // splices verbatim into a pre-serialized envelope.
+    let body = body.into_string();
+    let is_array = body.trim_start().starts_with('[')
+        && serde_json::from_str::<serde::de::IgnoredAny>(&body).is_ok();
+    if !is_array {
+        return serde_json::json!({
             "t": "response",
             "id": id,
             "ok": false,
             "error": "session list returned invalid JSON",
-        }),
+        });
     }
+    serde_json::Value::String(spliced_response_frame_text(&id, &body))
 }
 
 fn control_session_limit(params: &serde_json::Value) -> Option<usize> {
@@ -3583,6 +3629,43 @@ fn sha256_b64u(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The pre-serialized response carrier: byte-verbatim body embedding,
+    /// JSON-equivalence with the parse-path envelope, escaped ids, and
+    /// the historical error frame for invalid bodies.
+    #[test]
+    fn preserialized_response_envelope_matches_the_parsed_shape() {
+        let body = r#"{"a":1,"nested":{"b":[1,2,3]}}"#;
+        let frame = json_body_response_preserialized("req-1", body.to_string(), "test");
+        let serde_json::Value::String(text) = &frame else {
+            panic!("expected the pre-serialized carrier, got {frame}");
+        };
+        assert!(
+            text.contains(body),
+            "the body must embed verbatim (proof of no reserialization): {text}"
+        );
+        let parsed: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(parsed["t"], "response");
+        assert_eq!(parsed["id"], "req-1");
+        assert_eq!(parsed["ok"], true);
+        assert_eq!(parsed["result"]["nested"]["b"][1], 2);
+        // JSON-equivalent to the parse-path envelope.
+        let legacy = json_body_response("req-1".into(), body.to_string(), "test");
+        assert_eq!(parsed, legacy);
+
+        // Invalid bodies keep the historical error frame (an object).
+        let error = json_body_response_preserialized("req-2", "not json".into(), "test");
+        assert_eq!(error["ok"], false);
+        assert!(error["error"].as_str().unwrap().contains("invalid JSON"));
+
+        // Ids embed JSON-escaped.
+        let quoted = json_body_response_preserialized("has\"quote", "{}".to_string(), "test");
+        let serde_json::Value::String(text) = quoted else {
+            panic!("expected the pre-serialized carrier");
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(parsed["id"], "has\"quote");
+    }
 
     pub(crate) fn test_upload_state(
         method: &str,

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -346,9 +346,22 @@ fn all_control_methods() -> &'static [ControlMethodSpec] {
 }
 
 fn control_method_spec(method: &str) -> Option<&'static ControlMethodSpec> {
-    all_control_methods()
-        .iter()
-        .find(|spec| spec.name == method)
+    // Indexed once: this lookup runs at least twice per tunnel request
+    // (authorizer + dispatch), and the effective table is ~150 entries.
+    // `or_insert` preserves the table's first-wins resolution order.
+    static INDEX: std::sync::OnceLock<HashMap<&'static str, &'static ControlMethodSpec>> =
+        std::sync::OnceLock::new();
+    INDEX
+        .get_or_init(|| {
+            let methods = all_control_methods();
+            let mut index = HashMap::with_capacity(methods.len());
+            for spec in methods {
+                index.entry(spec.name).or_insert(spec);
+            }
+            index
+        })
+        .get(method)
+        .copied()
 }
 
 /// Transport/frame-family features that aren't request methods (chunking,
@@ -1742,7 +1755,7 @@ impl DashboardControlPeer {
             events_subscribed: false,
             events_sent: 0,
             response_credit_enabled: false,
-            config: serde_json::to_value(config).unwrap_or_else(|_| serde_json::json!({})),
+            config: Arc::new(serde_json::to_value(config).unwrap_or_else(|_| serde_json::json!({}))),
             bus,
             peer_registry,
             mcp_server,
@@ -1751,7 +1764,7 @@ impl DashboardControlPeer {
             worktree_inventory_cache,
             terminal_registry,
             task_tx,
-            agent_card,
+            agent_card: Arc::new(agent_card),
             bootstrap_caches,
             display_authority,
             presence,
@@ -1825,7 +1838,9 @@ pub(crate) struct ControlRuntime {
     events_subscribed: bool,
     events_sent: u64,
     response_credit_enabled: bool,
-    config: serde_json::Value,
+    /// Shared, not owned: `ControlRuntime` is cloned per spawned request,
+    /// and an owned tree deep-copied this multi-KB JSON every time.
+    config: Arc<serde_json::Value>,
     bus: crate::event::EventBus,
     peer_registry: Option<crate::peer::PeerRegistry>,
     mcp_server: Option<Arc<crate::mcp::IntendantServer>>,
@@ -1834,7 +1849,9 @@ pub(crate) struct ControlRuntime {
     worktree_inventory_cache: Arc<std::sync::Mutex<Option<String>>>,
     terminal_registry: Arc<crate::terminal::TerminalRegistry>,
     task_tx: Option<mpsc::Sender<presence_core::TaskEnvelope>>,
-    agent_card: serde_json::Value,
+    /// Shared like `config` (multi-KB tree; `ControlRuntime` is cloned
+    /// per spawned request).
+    agent_card: Arc<serde_json::Value>,
     bootstrap_caches: DashboardBootstrapCaches,
     display_authority: Option<DashboardDisplayAuthorityBridge>,
     presence: Option<DashboardPresenceBridge>,
@@ -2916,8 +2933,12 @@ fn http_body_response(id: String, status: u16, body: String, label: &str) -> ser
 pub(crate) use crate::web_gateway::status_line_code;
 
 fn params_body_text(params: Option<&serde_json::Value>) -> String {
-    serde_json::to_string(&params.cloned().unwrap_or_else(|| serde_json::json!({})))
-        .unwrap_or_else(|_| "{}".to_string())
+    // Serialize the borrow — cloning the params subtree first cost a
+    // second deep copy of every request's params just to stringify it.
+    match params {
+        Some(params) => serde_json::to_string(params).unwrap_or_else(|_| "{}".to_string()),
+        None => "{}".to_string(),
+    }
 }
 
 fn missing_param_response(id: String, name: &str) -> serde_json::Value {
@@ -3404,11 +3425,11 @@ mod tests {
             events_subscribed: false,
             events_sent: 0,
             response_credit_enabled: false,
-            config: serde_json::json!({"provider":"openai"}),
-            agent_card: serde_json::json!({
+            config: Arc::new(serde_json::json!({"provider":"openai"})),
+            agent_card: Arc::new(serde_json::json!({
                 "id": "intendant:test-daemon",
                 "label": "test-daemon",
-            }),
+            })),
             bus: crate::event::EventBus::new(),
             peer_registry: None,
             mcp_server: None,

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -2075,11 +2075,18 @@ pub(crate) struct PendingControlRequests {
     entries: HashMap<String, PendingControlRequest>,
     /// Live-work ledger: strong count − 1 = slots currently held.
     live_work: Arc<()>,
-    /// Committing-upload ledger: strong count − 1 = commits in flight
-    /// (they left `inbound_uploads` but their work — and spool — lives
-    /// until the commit finishes; the upload 8-cap counts them).
-    committing_uploads: Arc<()>,
+    /// Committing-upload ledger: commits in flight with their byte
+    /// weights (they left `inbound_uploads` but their work — and spool —
+    /// lives until the commit finishes; the upload 8-cap counts them and
+    /// the 256 MiB aggregate counts their bytes).
+    committing_uploads: Arc<UploadCommitLedger>,
     next_generation: u64,
+}
+
+#[derive(Default)]
+struct UploadCommitLedger {
+    count: std::sync::atomic::AtomicUsize,
+    bytes: std::sync::atomic::AtomicUsize,
 }
 
 struct PendingControlRequest {
@@ -2092,15 +2099,31 @@ struct PendingControlRequest {
 /// the upload state that becomes one) and live until the work ends.
 pub(crate) struct LiveWorkSlot(#[allow(dead_code)] Arc<()>);
 
-/// RAII committing-upload slot (see `committing_uploads`).
-pub(crate) struct UploadCommitSlot(#[allow(dead_code)] Arc<()>);
+/// RAII committing-upload slot (see `committing_uploads`): carries the
+/// commit's byte weight, debited from the ledger only when the commit
+/// actually finishes.
+pub(crate) struct UploadCommitSlot {
+    ledger: Arc<UploadCommitLedger>,
+    bytes: usize,
+}
+
+impl Drop for UploadCommitSlot {
+    fn drop(&mut self) {
+        self.ledger
+            .count
+            .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        self.ledger
+            .bytes
+            .fetch_sub(self.bytes, std::sync::atomic::Ordering::Relaxed);
+    }
+}
 
 impl PendingControlRequests {
     pub(crate) fn new() -> Self {
         Self {
             entries: HashMap::new(),
             live_work: Arc::new(()),
-            committing_uploads: Arc::new(()),
+            committing_uploads: Arc::new(UploadCommitLedger::default()),
             next_generation: 0,
         }
     }
@@ -2134,14 +2157,34 @@ impl PendingControlRequests {
         Arc::strong_count(&self.live_work).saturating_sub(1)
     }
 
-    /// One committing upload's cap presence (held until the commit ends).
-    pub(crate) fn upload_commit_slot(&self) -> UploadCommitSlot {
-        UploadCommitSlot(Arc::clone(&self.committing_uploads))
+    /// One committing upload's cap + byte presence (held until the
+    /// commit ends; `bytes` is the upload's actual received size).
+    pub(crate) fn upload_commit_slot(&self, bytes: usize) -> UploadCommitSlot {
+        self.committing_uploads
+            .count
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.committing_uploads
+            .bytes
+            .fetch_add(bytes, std::sync::atomic::Ordering::Relaxed);
+        UploadCommitSlot {
+            ledger: Arc::clone(&self.committing_uploads),
+            bytes,
+        }
     }
 
     /// Commits currently in flight.
     pub(crate) fn committing_uploads(&self) -> usize {
-        Arc::strong_count(&self.committing_uploads).saturating_sub(1)
+        self.committing_uploads
+            .count
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Bytes held by commits in flight (counted against the aggregate
+    /// declared-bytes budget until each commit completes).
+    pub(crate) fn committing_upload_bytes(&self) -> usize {
+        self.committing_uploads
+            .bytes
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// The client's `cancel` frame: cancel and free the reservation.
@@ -2241,11 +2284,19 @@ const MAX_INBOUND_UPLOADS_PER_CONNECTION: usize = 8;
 /// reserve unbounded spool space regardless of the per-upload cap.
 const MAX_INBOUND_UPLOAD_TOTAL_BYTES: usize = 256 * 1024 * 1024;
 /// LIVE spawned-work slots per tunnel connection (request tasks, stream
-/// framers, upload states and their commit tasks). Each spawned handler
-/// may construct a response as large as the fs-read cap before queue
-/// admission runs, so the reservation happens at spawn time and — via
-/// the RAII [`LiveWorkSlot`] — frees only when the work actually ends,
-/// covering cancelled-but-draining predecessors too.
+/// framers + their line producers, upload states and their commit
+/// tasks). Each spawned handler may construct a response as large as the
+/// fs-read cap before queue admission runs, so the reservation happens
+/// at spawn time and — via the RAII [`LiveWorkSlot`] — frees only when
+/// the work actually ends, covering cancelled-but-draining predecessors.
+///
+/// Deliberate fail-closed occupancy: a WEDGED operation (an fs read
+/// stuck on a dead mount, a producer that never finishes) legitimately
+/// HOLDS its slot — slots measure live work, so 64 wedged operations
+/// mean a fully occupied connection until teardown. That is the design:
+/// the bound guarantees bounded memory, not bounded latency, and a
+/// connection that has genuinely wedged 64 operations has no business
+/// admitting more work it also cannot finish.
 const MAX_PENDING_CONTROL_REQUESTS: usize = 64;
 
 impl UploadSpool {
@@ -4020,6 +4071,79 @@ fn sha256_b64u(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
 
+    /// Committing uploads hold their BYTE weight against the aggregate
+    /// declared-bytes budget until the commit completes: with enough
+    /// bytes mid-commit, a new upload_start is refused on bytes even
+    /// though `inbound_uploads` itself is empty.
+    #[tokio::test]
+    async fn committing_upload_bytes_count_against_the_aggregate() {
+        let mut rt = runtime();
+        let (tx, _rx) = mpsc::channel::<SequencedTaskResponse>(8);
+        let mut pending = PendingControlRequests::new();
+        let mut outbound = OutboundControlQueue::new();
+
+        // Two slow 90 MiB commits still in flight (left inbound_uploads,
+        // commit not finished): 180 MiB held by the ledger.
+        let weight = 90 * 1024 * 1024;
+        let _slow_commits = [
+            pending.upload_commit_slot(weight),
+            pending.upload_commit_slot(weight),
+        ];
+        assert_eq!(pending.committing_upload_bytes(), 2 * weight);
+
+        // A third 90 MiB upload_start busts the 256 MiB aggregate.
+        let start = serde_json::json!({
+            "t": "upload_start",
+            "id": "u-agg",
+            "method": "api_session_current_upload",
+            "params": { "name": "big.bin", "mime": "application/octet-stream" },
+            "total_bytes": weight,
+            "chunks": 90 * 64,
+        });
+        let refused = test_control_frame_response(
+            &start.to_string(),
+            &mut rt,
+            &tx,
+            &mut pending,
+            &mut outbound,
+        )
+        .expect("over-budget upload_start must answer");
+        assert_eq!(refused["result"]["_httpStatus"], 429, "{refused}");
+        assert!(refused["result"]["error"]
+            .as_str()
+            .unwrap()
+            .contains("declared-bytes budget"));
+
+        // Commits finishing (slots dropping) release the budget.
+        drop(_slow_commits);
+        assert_eq!(pending.committing_upload_bytes(), 0);
+        let admitted = test_control_frame_response(
+            &start.to_string(),
+            &mut rt,
+            &tx,
+            &mut pending,
+            &mut outbound,
+        );
+        assert!(
+            admitted.is_none(),
+            "with the commits finished the same start admits: {admitted:?}"
+        );
+    }
+
+    /// Immediate-frame spam is bounded by the queue's frame-count cap —
+    /// the seam R4-3 routes congested pre-serialized frames through.
+    #[test]
+    fn immediate_frame_cap_bounds_queued_spam() {
+        let mut queue = OutboundControlQueue::new();
+        for index in 0..CONTROL_OUTBOUND_QUEUE_MAX_FRAMES {
+            assert!(queue.enqueue_immediate(format!("r{index}"), "{\"ok\":true}".to_string()));
+        }
+        assert!(
+            !queue.enqueue_immediate("over".to_string(), "{}".to_string()),
+            "the frame-count cap must refuse the next enqueue"
+        );
+    }
+
     /// The direct-error budget: while congested, exactly
     /// [`DIRECT_ERROR_BUDGET_FRAMES`] error frames pass, further ones drop
     /// and are counted; an uncongested beat (the wire drained) refills.
@@ -4124,11 +4248,14 @@ mod tests {
         drop(draining);
         assert_eq!(pending.live_work(), 0);
 
-        // The committing-upload ledger is RAII the same way.
-        let commit_slot = pending.upload_commit_slot();
+        // The committing-upload ledger is RAII the same way, bytes
+        // included.
+        let commit_slot = pending.upload_commit_slot(1024);
         assert_eq!(pending.committing_uploads(), 1);
+        assert_eq!(pending.committing_upload_bytes(), 1024);
         drop(commit_slot);
         assert_eq!(pending.committing_uploads(), 0);
+        assert_eq!(pending.committing_upload_bytes(), 0);
     }
 
     /// The pre-serialized response carrier: byte-verbatim body embedding,

--- a/src/bin/caller/dashboard_control/wire.rs
+++ b/src/bin/caller/dashboard_control/wire.rs
@@ -56,8 +56,8 @@ pub(crate) async fn control_driver<I: rtc::interceptor::Interceptor + Send + Syn
     }
     let mut tcp_senders: HashMap<SocketAddr, TcpFrameSender> = HashMap::new();
     let mut channels: HashMap<String, rtc::data_channel::RTCDataChannelId> = HashMap::new();
-    let (task_tx, mut task_rx) = mpsc::channel::<ControlTaskResponse>(64);
-    let mut pending_requests: HashMap<String, CancellationToken> = HashMap::new();
+    let (task_tx, mut task_rx) = mpsc::channel::<SequencedTaskResponse>(64);
+    let mut pending_requests = PendingControlRequests::new();
     let mut outbound_queue = OutboundControlQueue::new();
     let mut inbound_uploads: HashMap<String, InboundUploadState> = HashMap::new();
     let (terminal_events_tx, mut terminal_events_rx) =
@@ -75,6 +75,7 @@ pub(crate) async fn control_driver<I: rtc::interceptor::Interceptor + Send + Syn
     let (terminal_output_tx, mut terminal_output_rx) =
         mpsc::channel::<serde_json::Value>(TERMINAL_OUTPUT_LANE_CAP);
     let mut control_wire_congested = false;
+    let mut error_budget = DirectErrorBudget::new("dashboard/control");
     let mut terminal_forwarders: HashMap<(String, String), tokio::task::JoinHandle<()>> =
         HashMap::new();
     // Per-connection ordered display-input lane (F1): `display_input`
@@ -113,6 +114,7 @@ pub(crate) async fn control_driver<I: rtc::interceptor::Interceptor + Send + Syn
             &mut terminal_forwarders,
             &display_input_tx,
             &mut control_wire_congested,
+            &mut error_budget,
         )
         .await
         {
@@ -266,12 +268,16 @@ pub(crate) async fn control_driver<I: rtc::interceptor::Interceptor + Send + Syn
                 }
                 let _ = rtc.handle_timeout(Instant::now());
             }
-            Some(task_response) = task_rx.recv() => {
+            Some((generation, task_response)) = task_rx.recv() => {
                 if !runtime.grant.opening_authority_is_current() {
                     shutdown.cancel();
                     break;
                 }
-                if pending_requests.contains_key(&task_response.id) {
+                // Generation-matched forwarding: a superseded task's
+                // response is dropped whole — it must neither reach the
+                // wire under the reused id nor free the replacement's
+                // reservation.
+                if pending_requests.matches(&task_response.id, generation) {
                     let task_id = task_response.id.clone();
                     let done = task_response.done;
                     send_control_task_response(
@@ -280,10 +286,11 @@ pub(crate) async fn control_driver<I: rtc::interceptor::Interceptor + Send + Syn
                         &mut outbound_queue,
                         runtime.response_credit_enabled,
                         control_wire_congested,
+                        &mut error_budget,
                         task_response,
                     );
                     if done {
-                        pending_requests.remove(&task_id);
+                        pending_requests.complete(&task_id, generation);
                     }
                 }
                 let _ = rtc.handle_timeout(Instant::now());
@@ -402,13 +409,12 @@ pub(crate) async fn control_driver<I: rtc::interceptor::Interceptor + Send + Syn
     // clipboard authority during that window.
     shutdown.cancel();
     remove_dashboard_display_peers(&runtime).await;
-    for (_, token) in pending_requests {
-        token.cancel();
-    }
+    pending_requests.cancel_all();
     for (_, handle) in terminal_forwarders {
         handle.abort();
         let _ = handle.await;
     }
+    error_budget.log_teardown();
     // Egress relays die with their session: no more frames can arrive,
     // so drop the registration and fail any in-flight relayed requests.
     crate::credential_egress::unregister_session(&runtime.session_id);
@@ -506,8 +512,8 @@ pub(crate) async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
     drop_stats: &mut TransmitDropStats,
     channels: &mut HashMap<String, rtc::data_channel::RTCDataChannelId>,
     runtime: &mut ControlRuntime,
-    task_tx: &mpsc::Sender<ControlTaskResponse>,
-    pending_requests: &mut HashMap<String, CancellationToken>,
+    task_tx: &mpsc::Sender<SequencedTaskResponse>,
+    pending_requests: &mut PendingControlRequests,
     outbound_queue: &mut OutboundControlQueue,
     inbound_uploads: &mut HashMap<String, InboundUploadState>,
     terminal_events_tx: &mpsc::UnboundedSender<serde_json::Value>,
@@ -515,6 +521,7 @@ pub(crate) async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
     terminal_forwarders: &mut HashMap<(String, String), tokio::task::JoinHandle<()>>,
     display_input_tx: &DisplayInputForwarder,
     control_wire_congested: &mut bool,
+    error_budget: &mut DirectErrorBudget,
 ) -> Result<Instant, ()> {
     while let Some(t) = rtc.poll_write() {
         // Route by connection first, engine stamp second: rtc < 0.9.1
@@ -597,6 +604,7 @@ pub(crate) async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
                 outbound_queue,
                 runtime.response_credit_enabled,
                 *control_wire_congested,
+                error_budget,
                 response,
             );
         }
@@ -702,6 +710,7 @@ pub(crate) fn send_control_task_response<I: rtc::interceptor::Interceptor>(
     outbound_queue: &mut OutboundControlQueue,
     response_credit_enabled: bool,
     wire_congested: bool,
+    error_budget: &mut DirectErrorBudget,
     response: ControlTaskResponse,
 ) {
     if let Some(byte_stream) = response.byte_stream {
@@ -711,6 +720,7 @@ pub(crate) fn send_control_task_response<I: rtc::interceptor::Interceptor>(
             outbound_queue,
             response_credit_enabled,
             wire_congested,
+            error_budget,
             byte_stream,
         );
     } else if let serde_json::Value::String(text) = response.frame {
@@ -725,6 +735,7 @@ pub(crate) fn send_control_task_response<I: rtc::interceptor::Interceptor>(
             outbound_queue,
             response_credit_enabled,
             wire_congested,
+            error_budget,
             response.id,
             text,
         );
@@ -735,6 +746,7 @@ pub(crate) fn send_control_task_response<I: rtc::interceptor::Interceptor>(
             outbound_queue,
             response_credit_enabled,
             wire_congested,
+            error_budget,
             response.frame,
         );
     }
@@ -751,6 +763,7 @@ fn send_control_frame_preserialized<I: rtc::interceptor::Interceptor>(
     outbound_queue: &mut OutboundControlQueue,
     response_credit_enabled: bool,
     wire_congested: bool,
+    error_budget: &mut DirectErrorBudget,
     request_id: String,
     text: String,
 ) {
@@ -759,12 +772,17 @@ fn send_control_frame_preserialized<I: rtc::interceptor::Interceptor>(
             if !outbound_queue.enqueue_immediate(request_id.clone(), text) {
                 // Admission control at the queue caps (see
                 // `send_control_frame`).
-                send_control_text(
-                    rtc,
-                    channels,
-                    dashboard_control_error_response(request_id, "outbound response queue is full")
+                if error_budget.allow(wire_congested) {
+                    send_control_text(
+                        rtc,
+                        channels,
+                        dashboard_control_error_response(
+                            request_id,
+                            "outbound response queue is full",
+                        )
                         .to_string(),
-                );
+                    );
+                }
             }
         } else {
             send_control_text(rtc, channels, text);
@@ -804,25 +822,29 @@ fn send_control_frame_preserialized<I: rtc::interceptor::Interceptor>(
         } else {
             // Admission control at the queue caps (see
             // `send_control_frame`).
-            send_control_text(
-                rtc,
-                channels,
-                dashboard_control_error_response(request_id, "outbound response queue is full")
-                    .to_string(),
-            );
+            if error_budget.allow(wire_congested) {
+                send_control_text(
+                    rtc,
+                    channels,
+                    dashboard_control_error_response(request_id, "outbound response queue is full")
+                        .to_string(),
+                );
+            }
         }
     } else if wire_congested {
         // See `send_control_frame`: no credit lane, wire above the high
         // watermark — refuse rather than grow the SCTP queue.
-        send_control_text(
-            rtc,
-            channels,
-            dashboard_control_error_response(
-                request_id,
-                "control channel is congested; retry the request",
-            )
-            .to_string(),
-        );
+        if error_budget.allow(wire_congested) {
+            send_control_text(
+                rtc,
+                channels,
+                dashboard_control_error_response(
+                    request_id,
+                    "control channel is congested; retry the request",
+                )
+                .to_string(),
+            );
+        }
     } else {
         for frame in plan.render_all() {
             send_control_text(rtc, channels, frame);
@@ -837,6 +859,7 @@ pub(crate) fn send_control_frame<I: rtc::interceptor::Interceptor>(
     outbound_queue: &mut OutboundControlQueue,
     response_credit_enabled: bool,
     wire_congested: bool,
+    error_budget: &mut DirectErrorBudget,
     frame: serde_json::Value,
 ) {
     let request_id = frame
@@ -856,15 +879,17 @@ pub(crate) fn send_control_frame<I: rtc::interceptor::Interceptor>(
                         // Admission control: the queue caps are exhausted —
                         // answer directly instead of growing the parked
                         // backlog without bound.
-                        send_control_text(
-                            rtc,
-                            channels,
-                            dashboard_control_error_response(
-                                request_id.clone(),
-                                "outbound response queue is full",
-                            )
-                            .to_string(),
-                        );
+                        if error_budget.allow(wire_congested) {
+                            send_control_text(
+                                rtc,
+                                channels,
+                                dashboard_control_error_response(
+                                    request_id.clone(),
+                                    "outbound response queue is full",
+                                )
+                                .to_string(),
+                            );
+                        }
                     }
                 } else {
                     send_control_text(rtc, channels, text);
@@ -880,29 +905,33 @@ pub(crate) fn send_control_frame<I: rtc::interceptor::Interceptor>(
                     // Admission control: the per-connection queue caps are
                     // exhausted — answer the request instead of pinning
                     // another payload behind a quiet client.
-                    send_control_text(
-                        rtc,
-                        channels,
-                        dashboard_control_error_response(
-                            request_id,
-                            "outbound response queue is full",
-                        )
-                        .to_string(),
-                    );
+                    if error_budget.allow(wire_congested) {
+                        send_control_text(
+                            rtc,
+                            channels,
+                            dashboard_control_error_response(
+                                request_id,
+                                "outbound response queue is full",
+                            )
+                            .to_string(),
+                        );
+                    }
                 }
             } else if wire_congested {
                 // No credit lane to absorb it and the control channel sits
                 // above its high watermark: refuse instead of growing the
                 // unbounded SCTP pending queue at payload size.
-                send_control_text(
-                    rtc,
-                    channels,
-                    dashboard_control_error_response(
-                        request_id,
-                        "control channel is congested; retry the request",
-                    )
-                    .to_string(),
-                );
+                if error_budget.allow(wire_congested) {
+                    send_control_text(
+                        rtc,
+                        channels,
+                        dashboard_control_error_response(
+                            request_id,
+                            "control channel is congested; retry the request",
+                        )
+                        .to_string(),
+                    );
+                }
             } else {
                 for text in plan.render_all() {
                     send_control_text(rtc, channels, text);
@@ -918,6 +947,7 @@ pub(crate) fn send_control_byte_stream<I: rtc::interceptor::Interceptor>(
     outbound_queue: &mut OutboundControlQueue,
     response_credit_enabled: bool,
     wire_congested: bool,
+    error_budget: &mut DirectErrorBudget,
     byte_stream: ControlByteStream,
 ) {
     match byte_stream_frame_text_parts(byte_stream, CONTROL_BYTE_STREAM_CHUNK_BYTES) {
@@ -934,28 +964,32 @@ pub(crate) fn send_control_byte_stream<I: rtc::interceptor::Interceptor>(
                 } else {
                     // Admission control at the queue caps (see
                     // `send_control_frame`).
+                    if error_budget.allow(wire_congested) {
+                        send_control_text(
+                            rtc,
+                            channels,
+                            dashboard_control_error_response(
+                                request_id,
+                                "outbound response queue is full",
+                            )
+                            .to_string(),
+                        );
+                    }
+                }
+            } else if wire_congested {
+                // See `send_control_frame`: no credit lane, wire above the
+                // high watermark — refuse rather than grow the SCTP queue.
+                if error_budget.allow(wire_congested) {
                     send_control_text(
                         rtc,
                         channels,
                         dashboard_control_error_response(
                             request_id,
-                            "outbound response queue is full",
+                            "control channel is congested; retry the request",
                         )
                         .to_string(),
                     );
                 }
-            } else if wire_congested {
-                // See `send_control_frame`: no credit lane, wire above the
-                // high watermark — refuse rather than grow the SCTP queue.
-                send_control_text(
-                    rtc,
-                    channels,
-                    dashboard_control_error_response(
-                        request_id,
-                        "control channel is congested; retry the request",
-                    )
-                    .to_string(),
-                );
             } else {
                 for text in plan.render_all() {
                     send_control_text(rtc, channels, text);

--- a/src/bin/caller/dashboard_control/wire.rs
+++ b/src/bin/caller/dashboard_control/wire.rs
@@ -709,6 +709,20 @@ pub(crate) fn send_control_task_response<I: rtc::interceptor::Interceptor>(
             response_credit_enabled,
             byte_stream,
         );
+    } else if let serde_json::Value::String(text) = response.frame {
+        // Pre-serialized response envelope (`json_body_response_
+        // preserialized`): the text goes to the wire verbatim — no
+        // parse, no re-serialize — keyed by the task's own request id
+        // for the credit queue, chunked on the same thresholds an
+        // equivalent object frame would be.
+        send_control_frame_preserialized(
+            rtc,
+            channels,
+            outbound_queue,
+            response_credit_enabled,
+            response.id,
+            text,
+        );
     } else {
         send_control_frame(
             rtc,
@@ -717,6 +731,73 @@ pub(crate) fn send_control_task_response<I: rtc::interceptor::Interceptor>(
             response_credit_enabled,
             response.frame,
         );
+    }
+}
+
+/// The pre-serialized twin of [`send_control_frame`]: same immediate/
+/// queued handling and the same chunk framing (`chunk_id` falls back to
+/// the request id exactly as `control_frame_text_parts` derives it for a
+/// response frame without `chunk_id`/`seq` fields).
+fn send_control_frame_preserialized<I: rtc::interceptor::Interceptor>(
+    rtc: &mut RTCPeerConnection<I>,
+    channels: &HashMap<String, rtc::data_channel::RTCDataChannelId>,
+    outbound_queue: &mut OutboundControlQueue,
+    response_credit_enabled: bool,
+    request_id: String,
+    text: String,
+) {
+    if text.len() <= CONTROL_RESPONSE_CHUNK_THRESHOLD_BYTES || request_id.is_empty() {
+        if response_credit_enabled && !outbound_queue.is_empty() && !request_id.is_empty() {
+            outbound_queue.enqueue_immediate(request_id, text);
+        } else {
+            send_control_text(rtc, channels, text);
+        }
+        drain_queued_control_frames(rtc, channels, outbound_queue);
+        return;
+    }
+    let total_bytes = text.len();
+    let chunk_count = total_bytes.div_ceil(CONTROL_RESPONSE_CHUNK_BYTES);
+    let start = serde_json::json!({
+        "t": "response_start",
+        "id": request_id,
+        "chunk_id": request_id,
+        "encoding": "base64-json-frame",
+        "total_bytes": total_bytes,
+        "chunks": chunk_count,
+    })
+    .to_string();
+    let end = serde_json::json!({
+        "t": "response_end",
+        "id": request_id,
+        "chunk_id": request_id,
+        "chunks": chunk_count,
+    })
+    .to_string();
+    let plan = ChunkedFramePlan::response(
+        request_id.clone(),
+        request_id.clone(),
+        start,
+        end,
+        text.into_bytes(),
+        CONTROL_RESPONSE_CHUNK_BYTES,
+    );
+    if response_credit_enabled {
+        if outbound_queue.enqueue_chunked(plan) {
+            drain_queued_control_frames(rtc, channels, outbound_queue);
+        } else {
+            // Admission control at the queue byte cap (see
+            // `send_control_frame`).
+            send_control_text(
+                rtc,
+                channels,
+                dashboard_control_error_response(request_id, "outbound response queue is full")
+                    .to_string(),
+            );
+        }
+    } else {
+        for frame in plan.render_all() {
+            send_control_text(rtc, channels, frame);
+        }
     }
 }
 

--- a/src/bin/caller/dashboard_control/wire.rs
+++ b/src/bin/caller/dashboard_control/wire.rs
@@ -63,6 +63,18 @@ pub(crate) async fn control_driver<I: rtc::interceptor::Interceptor + Send + Syn
     let (terminal_events_tx, mut terminal_events_rx) =
         mpsc::unbounded_channel::<serde_json::Value>();
     runtime.control_frames_tx = Some(terminal_events_tx.clone());
+    // PTY output rides its own small BOUNDED lane (the tunnel twin of
+    // ws_session's TERMINAL_FORWARD_LANE_CAP): the per-terminal forwarders
+    // `send().await` here, and the driver drains it only while the control
+    // channel's SCTP buffer sits below the high watermark. When the wire
+    // congests (frozen tab), the lane fills, the forwarders park, and
+    // terminal.rs's per-listener drop-oldest bound re-engages — instead of
+    // bulk PTY output growing the unbounded SCTP pending queue at PTY
+    // rate. The low-rate control_frames lane (acks for share/egress/
+    // presence) stays unbounded.
+    let (terminal_output_tx, mut terminal_output_rx) =
+        mpsc::channel::<serde_json::Value>(TERMINAL_OUTPUT_LANE_CAP);
+    let mut terminal_lane_paused = false;
     let mut terminal_forwarders: HashMap<(String, String), tokio::task::JoinHandle<()>> =
         HashMap::new();
     // Per-connection ordered display-input lane (F1): `display_input`
@@ -97,8 +109,10 @@ pub(crate) async fn control_driver<I: rtc::interceptor::Interceptor + Send + Syn
             &mut outbound_queue,
             &mut inbound_uploads,
             &terminal_events_tx,
+            &terminal_output_tx,
             &mut terminal_forwarders,
             &display_input_tx,
+            &mut terminal_lane_paused,
         )
         .await
         {
@@ -330,6 +344,18 @@ pub(crate) async fn control_driver<I: rtc::interceptor::Interceptor + Send + Syn
                 send_control_text(&mut rtc, &channels, frame.to_string());
                 let _ = rtc.handle_timeout(Instant::now());
             }
+            // Bounded PTY-output lane, gated on the control channel's SCTP
+            // buffered-amount watermark: while paused the forwarders park
+            // on the full lane and terminal.rs's drop-oldest bound holds
+            // the memory line.
+            Some(frame) = terminal_output_rx.recv(), if !terminal_lane_paused => {
+                if !runtime.grant.opening_authority_is_current() {
+                    shutdown.cancel();
+                    break;
+                }
+                send_control_text(&mut rtc, &channels, frame.to_string());
+                let _ = rtc.handle_timeout(Instant::now());
+            }
             authority = async {
                 match display_authority_rx.as_mut() {
                     Some(rx) => Some(rx.recv().await),
@@ -484,8 +510,10 @@ pub(crate) async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
     outbound_queue: &mut OutboundControlQueue,
     inbound_uploads: &mut HashMap<String, InboundUploadState>,
     terminal_events_tx: &mpsc::UnboundedSender<serde_json::Value>,
+    terminal_output_tx: &mpsc::Sender<serde_json::Value>,
     terminal_forwarders: &mut HashMap<(String, String), tokio::task::JoinHandle<()>>,
     display_input_tx: &DisplayInputForwarder,
+    terminal_lane_paused: &mut bool,
 ) -> Result<Instant, ()> {
     while let Some(t) = rtc.poll_write() {
         // Route by connection first, engine stamp second: rtc < 0.9.1
@@ -558,6 +586,7 @@ pub(crate) async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
             outbound_queue,
             inbound_uploads,
             terminal_events_tx,
+            terminal_output_tx,
             terminal_forwarders,
             display_input_tx,
         ) {
@@ -579,10 +608,43 @@ pub(crate) async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
                     .map(|channel| channel.label().to_string())
                     .unwrap_or_else(|| format!("channel-{cid}"));
                 eprintln!("[dashboard/control] data channel open: {label}");
+                if label == CONTROL_CHANNEL_LABEL {
+                    // Arm the SCTP buffered-amount watermarks that gate the
+                    // bounded terminal-output lane (the display pipeline's
+                    // event-driven backpressure pattern).
+                    if let Some(mut channel) = rtc.data_channel(cid) {
+                        channel.set_buffered_amount_high_threshold(watermark_to_u32(
+                            TERMINAL_LANE_BUFFERED_HIGH_WATERMARK_BYTES,
+                        ));
+                        channel.set_buffered_amount_low_threshold(watermark_to_u32(
+                            TERMINAL_LANE_BUFFERED_LOW_WATERMARK_BYTES,
+                        ));
+                    }
+                    *terminal_lane_paused = false;
+                }
                 channels.insert(label, cid);
             }
             RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnClose(cid)) => {
+                if channels.get(CONTROL_CHANNEL_LABEL).copied() == Some(cid) {
+                    // Never leave the terminal lane parked behind a channel
+                    // that can no longer drain.
+                    *terminal_lane_paused = false;
+                }
                 channels.retain(|_, id| *id != cid);
+            }
+            RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnBufferedAmountHigh(
+                cid,
+            )) => {
+                if channels.get(CONTROL_CHANNEL_LABEL).copied() == Some(cid) {
+                    *terminal_lane_paused = true;
+                }
+            }
+            RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnBufferedAmountLow(
+                cid,
+            )) => {
+                if channels.get(CONTROL_CHANNEL_LABEL).copied() == Some(cid) {
+                    *terminal_lane_paused = false;
+                }
             }
             RTCPeerConnectionEvent::OnConnectionStateChangeEvent(state) => {
                 eprintln!("[dashboard/control] connection: {state:?}");
@@ -685,22 +747,28 @@ pub(crate) fn send_control_frame<I: rtc::interceptor::Interceptor>(
             }
             drain_queued_control_frames(rtc, channels, outbound_queue);
         }
-        ControlFrameTexts::Chunked {
-            request_id,
-            chunk_id,
-            start,
-            chunks,
-            end,
-        } => {
+        ControlFrameTexts::Chunked(plan) => {
             if response_credit_enabled {
-                outbound_queue.enqueue_chunked(request_id, chunk_id, start, chunks, end);
-                drain_queued_control_frames(rtc, channels, outbound_queue);
+                if outbound_queue.enqueue_chunked(plan) {
+                    drain_queued_control_frames(rtc, channels, outbound_queue);
+                } else {
+                    // Admission control: the per-connection queue byte cap
+                    // is exhausted — answer the request instead of pinning
+                    // another payload behind a quiet client.
+                    send_control_text(
+                        rtc,
+                        channels,
+                        dashboard_control_error_response(
+                            request_id,
+                            "outbound response queue is full",
+                        )
+                        .to_string(),
+                    );
+                }
             } else {
-                send_control_text(rtc, channels, start);
-                for text in chunks {
+                for text in plan.render_all() {
                     send_control_text(rtc, channels, text);
                 }
-                send_control_text(rtc, channels, end);
             }
         }
     }
@@ -719,22 +787,28 @@ pub(crate) fn send_control_byte_stream<I: rtc::interceptor::Interceptor>(
                 send_control_text(rtc, channels, text);
             }
         }
-        ControlFrameTexts::Chunked {
-            request_id,
-            chunk_id,
-            start,
-            chunks,
-            end,
-        } => {
+        ControlFrameTexts::Chunked(plan) => {
             if response_credit_enabled {
-                outbound_queue.enqueue_chunked(request_id, chunk_id, start, chunks, end);
-                drain_queued_control_frames(rtc, channels, outbound_queue);
+                let request_id = plan.request_id.clone();
+                if outbound_queue.enqueue_chunked(plan) {
+                    drain_queued_control_frames(rtc, channels, outbound_queue);
+                } else {
+                    // Admission control at the queue byte cap (see
+                    // `send_control_frame`).
+                    send_control_text(
+                        rtc,
+                        channels,
+                        dashboard_control_error_response(
+                            request_id,
+                            "outbound response queue is full",
+                        )
+                        .to_string(),
+                    );
+                }
             } else {
-                send_control_text(rtc, channels, start);
-                for text in chunks {
+                for text in plan.render_all() {
                     send_control_text(rtc, channels, text);
                 }
-                send_control_text(rtc, channels, end);
             }
         }
     }
@@ -748,15 +822,7 @@ pub(crate) fn control_frame_texts(frame: serde_json::Value) -> Vec<String> {
         CONTROL_RESPONSE_CHUNK_BYTES,
     ) {
         ControlFrameTexts::Immediate(frames) => frames,
-        ControlFrameTexts::Chunked {
-            start, chunks, end, ..
-        } => {
-            let mut frames = Vec::with_capacity(chunks.len() + 2);
-            frames.push(start);
-            frames.extend(chunks);
-            frames.push(end);
-            frames
-        }
+        ControlFrameTexts::Chunked(plan) => plan.render_all(),
     }
 }
 
@@ -783,19 +849,6 @@ pub(crate) fn byte_stream_frame_text_parts(
         "chunks": chunk_count,
     })
     .to_string();
-    let mut chunks = Vec::with_capacity(chunk_count);
-    for (seq, chunk) in byte_stream.bytes.chunks(chunk_bytes).enumerate() {
-        chunks.push(
-            serde_json::json!({
-                "t": "byte_stream_chunk",
-                "id": request_id,
-                "stream_id": chunk_id,
-                "seq": seq,
-                "data": base64::engine::general_purpose::STANDARD.encode(chunk),
-            })
-            .to_string(),
-        );
-    }
     let end = serde_json::json!({
         "t": "byte_stream_end",
         "id": request_id,
@@ -805,13 +858,16 @@ pub(crate) fn byte_stream_frame_text_parts(
         "result": byte_stream.result,
     })
     .to_string();
-    ControlFrameTexts::Chunked {
+    // The payload moves into the plan raw; chunk frames render lazily at
+    // send time (see `ChunkedFramePlan`).
+    ControlFrameTexts::Chunked(ChunkedFramePlan::byte_stream(
         request_id,
         chunk_id,
         start,
-        chunks,
         end,
-    }
+        byte_stream.bytes,
+        chunk_bytes,
+    ))
 }
 
 #[cfg(test)]
@@ -821,15 +877,7 @@ pub(crate) fn byte_stream_frame_texts(
 ) -> Vec<String> {
     match byte_stream_frame_text_parts(byte_stream, chunk_bytes) {
         ControlFrameTexts::Immediate(frames) => frames,
-        ControlFrameTexts::Chunked {
-            start, chunks, end, ..
-        } => {
-            let mut frames = Vec::with_capacity(chunks.len() + 2);
-            frames.push(start);
-            frames.extend(chunks);
-            frames.push(end);
-            frames
-        }
+        ControlFrameTexts::Chunked(plan) => plan.render_all(),
     }
 }
 
@@ -867,30 +915,17 @@ pub(crate) fn control_frame_text_parts(
         })
         .unwrap_or_else(|| request_id.clone());
 
-    let bytes = text.as_bytes();
-    let chunk_count = bytes.len().div_ceil(chunk_bytes);
+    let total_bytes = text.len();
+    let chunk_count = total_bytes.div_ceil(chunk_bytes);
     let start = serde_json::json!({
         "t": "response_start",
         "id": request_id,
         "chunk_id": chunk_id,
         "encoding": "base64-json-frame",
-        "total_bytes": bytes.len(),
+        "total_bytes": total_bytes,
         "chunks": chunk_count,
     })
     .to_string();
-    let mut chunks = Vec::with_capacity(chunk_count);
-    for (seq, chunk) in bytes.chunks(chunk_bytes).enumerate() {
-        chunks.push(
-            serde_json::json!({
-                "t": "response_chunk",
-                "id": request_id,
-                "chunk_id": chunk_id,
-                "seq": seq,
-                "data": base64::engine::general_purpose::STANDARD.encode(chunk),
-            })
-            .to_string(),
-        );
-    }
     let end = serde_json::json!({
         "t": "response_end",
         "id": request_id,
@@ -898,13 +933,16 @@ pub(crate) fn control_frame_text_parts(
         "chunks": chunk_count,
     })
     .to_string();
-    ControlFrameTexts::Chunked {
+    // The serialized response moves into the plan raw; chunk frames render
+    // lazily at send time (see `ChunkedFramePlan`).
+    ControlFrameTexts::Chunked(ChunkedFramePlan::response(
         request_id,
         chunk_id,
         start,
-        chunks,
         end,
-    }
+        text.into_bytes(),
+        chunk_bytes,
+    ))
 }
 
 #[cfg(test)]
@@ -915,15 +953,7 @@ pub(crate) fn chunk_control_response_frame(
 ) -> Vec<String> {
     match control_frame_text_parts(frame, threshold_bytes, chunk_bytes) {
         ControlFrameTexts::Immediate(frames) => frames,
-        ControlFrameTexts::Chunked {
-            start, chunks, end, ..
-        } => {
-            let mut frames = Vec::with_capacity(chunks.len() + 2);
-            frames.push(start);
-            frames.extend(chunks);
-            frames.push(end);
-            frames
-        }
+        ControlFrameTexts::Chunked(plan) => plan.render_all(),
     }
 }
 
@@ -934,36 +964,45 @@ pub(crate) fn drain_queued_control_frames<I: rtc::interceptor::Interceptor>(
 ) {
     loop {
         let mut pop_front = false;
-        let mut completed_end: Option<String> = None;
+        let mut completed = false;
         match outbound_queue.frames.front_mut() {
-            Some(QueuedControlFrame::Immediate { text, .. }) => {
-                send_control_text(rtc, channels, text.clone());
+            Some(QueuedControlFrame::Immediate { .. }) => {
                 pop_front = true;
             }
             Some(QueuedControlFrame::Chunked(queued)) => {
                 if !queued.started {
-                    send_control_text(rtc, channels, queued.start.clone());
+                    // Sent exactly once; taking it avoids the clone (the
+                    // byte accounting was memoized at enqueue).
+                    let start = std::mem::take(&mut queued.plan.start);
                     queued.started = true;
+                    send_control_text(rtc, channels, start);
                 }
-                while queued.credit > 0 && queued.next_chunk < queued.chunks.len() {
-                    let text = queued.chunks[queued.next_chunk].clone();
+                while queued.credit > 0 {
+                    // Rendered lazily per credit — never materialized up
+                    // front, never cloned at send.
+                    let Some(text) = queued.plan.render_chunk(queued.next_chunk) else {
+                        break;
+                    };
                     queued.next_chunk += 1;
                     queued.credit -= 1;
                     send_control_text(rtc, channels, text);
                 }
-                if queued.next_chunk >= queued.chunks.len() {
-                    completed_end = Some(queued.end.clone());
+                if queued.next_chunk >= queued.plan.chunk_count() {
+                    completed = true;
                 }
             }
             None => break,
         }
-        if let Some(end) = completed_end {
-            outbound_queue.frames.pop_front();
-            send_control_text(rtc, channels, end);
+        if completed {
+            if let Some(QueuedControlFrame::Chunked(queued)) = outbound_queue.pop_front() {
+                send_control_text(rtc, channels, queued.plan.end);
+            }
             continue;
         }
         if pop_front {
-            outbound_queue.frames.pop_front();
+            if let Some(QueuedControlFrame::Immediate { text, .. }) = outbound_queue.pop_front() {
+                send_control_text(rtc, channels, text);
+            }
             continue;
         }
         break;
@@ -1176,5 +1215,77 @@ mod tests {
         assert_eq!(chunk_control_response_frame(response, 4096, 16).len(), 1);
         let event = serde_json::json!({"t":"event","id":"e1","payload":{"text":"large enough"}});
         assert_eq!(chunk_control_response_frame(event, 1, 1).len(), 1);
+    }
+
+    /// The outbound queue keeps exact byte accounting across enqueue,
+    /// cancel, and drain-to-empty, and refuses chunked admission once the
+    /// resident bytes reach the per-connection cap.
+    #[test]
+    fn outbound_queue_accounts_bytes_and_caps_chunked_admission() {
+        fn plan(id: &str, payload_len: usize) -> ChunkedFramePlan {
+            ChunkedFramePlan::response(
+                id.to_string(),
+                format!("{id}:0"),
+                "start".into(),
+                "end".into(),
+                vec![b'x'; payload_len],
+                CONTROL_RESPONSE_CHUNK_BYTES,
+            )
+        }
+
+        let mut queue = OutboundControlQueue::new();
+        assert!(queue.enqueue_chunked(plan("a", 1024)));
+        queue.enqueue_immediate("b".into(), "{\"t\":\"response\"}".into());
+        assert!(queue.queued_bytes > 1024);
+
+        // Cancel debits exactly what was credited.
+        assert!(queue.cancel("a"));
+        assert!(queue.cancel("b"));
+        assert_eq!(queue.queued_bytes, 0);
+        assert!(queue.frames.is_empty());
+
+        // Admission control refuses chunked frames at the cap (saturate
+        // the accounting directly rather than allocating 128 MiB).
+        queue.queued_bytes = CONTROL_OUTBOUND_QUEUE_MAX_BYTES;
+        assert!(!queue.enqueue_chunked(plan("c", 1024)));
+        assert!(queue.frames.is_empty());
+        queue.queued_bytes = 0;
+
+        // Draining to empty returns the accounting to zero.
+        assert!(queue.enqueue_chunked(plan("d", 4096)));
+        queue.enqueue_immediate("e".into(), "{}".into());
+        while queue.pop_front().is_some() {}
+        assert_eq!(queue.queued_bytes, 0);
+    }
+
+    /// A queued chunked frame renders each chunk lazily and exactly once,
+    /// byte-identical to the eager path (`render_all` is the eager
+    /// rendering the reassembly tests above already pin).
+    #[test]
+    fn chunked_plan_renders_lazily_with_stable_sequence() {
+        let payload: Vec<u8> = (0..100u8).collect();
+        let plan = ChunkedFramePlan::byte_stream(
+            "dl".into(),
+            "dl:file".into(),
+            "start".into(),
+            "end".into(),
+            payload.clone(),
+            16,
+        );
+        assert_eq!(plan.chunk_count(), 7);
+        assert!(plan.render_chunk(7).is_none());
+        let mut decoded = Vec::new();
+        for seq in 0..plan.chunk_count() {
+            let text = plan.render_chunk(seq).unwrap();
+            let frame: serde_json::Value = serde_json::from_str(&text).unwrap();
+            assert_eq!(frame["t"], "byte_stream_chunk");
+            assert_eq!(frame["seq"], seq);
+            decoded.extend(
+                base64::engine::general_purpose::STANDARD
+                    .decode(frame["data"].as_str().unwrap())
+                    .unwrap(),
+            );
+        }
+        assert_eq!(decoded, payload);
     }
 }

--- a/src/bin/caller/dashboard_control/wire.rs
+++ b/src/bin/caller/dashboard_control/wire.rs
@@ -867,6 +867,13 @@ pub(crate) fn send_control_frame<I: rtc::interceptor::Interceptor>(
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
+    // Classified BEFORE the frame is consumed: every ERROR-class frame is
+    // budgeted at this one choke point no matter which path built it —
+    // auth denials, unknown methods, upload errors, admission refusals —
+    // because with credit disabled (or an empty queue) immediate frames
+    // go straight to the reliable SCTP queue, which spam must not grow
+    // without bound. Success frames are never budgeted.
+    let error_class = is_error_class_frame(&frame);
     match control_frame_text_parts(
         frame,
         CONTROL_RESPONSE_CHUNK_THRESHOLD_BYTES,
@@ -891,7 +898,7 @@ pub(crate) fn send_control_frame<I: rtc::interceptor::Interceptor>(
                             );
                         }
                     }
-                } else {
+                } else if !error_class || error_budget.allow(wire_congested) {
                     send_control_text(rtc, channels, text);
                 }
             }

--- a/src/bin/caller/dashboard_control/wire.rs
+++ b/src/bin/caller/dashboard_control/wire.rs
@@ -682,7 +682,7 @@ pub(crate) async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
         }
     }
 
-    drain_queued_control_frames(rtc, channels, outbound_queue);
+    drain_queued_control_frames(rtc, channels, outbound_queue, *control_wire_congested);
 
     Ok(rtc
         .poll_timeout()
@@ -768,7 +768,13 @@ fn send_control_frame_preserialized<I: rtc::interceptor::Interceptor>(
     text: String,
 ) {
     if text.len() <= CONTROL_RESPONSE_CHUNK_THRESHOLD_BYTES || request_id.is_empty() {
-        if response_credit_enabled && !outbound_queue.is_empty() && !request_id.is_empty() {
+        // Queue whenever the wire is congested (bounding spam through the
+        // queue caps — a full queue answers a budgeted error) or the
+        // queue is non-empty (FIFO fairness behind earlier responses);
+        // direct-send only on an uncongested, empty queue. Credit is not
+        // required: immediate frames drain creditlessly.
+        let must_queue = !request_id.is_empty() && (wire_congested || !outbound_queue.is_empty());
+        if must_queue {
             if !outbound_queue.enqueue_immediate(request_id.clone(), text) {
                 // Admission control at the queue caps (see
                 // `send_control_frame`).
@@ -787,7 +793,7 @@ fn send_control_frame_preserialized<I: rtc::interceptor::Interceptor>(
         } else {
             send_control_text(rtc, channels, text);
         }
-        drain_queued_control_frames(rtc, channels, outbound_queue);
+        drain_queued_control_frames(rtc, channels, outbound_queue, wire_congested);
         return;
     }
     let total_bytes = text.len();
@@ -818,7 +824,7 @@ fn send_control_frame_preserialized<I: rtc::interceptor::Interceptor>(
     );
     if response_credit_enabled {
         if outbound_queue.enqueue_chunked(plan) {
-            drain_queued_control_frames(rtc, channels, outbound_queue);
+            drain_queued_control_frames(rtc, channels, outbound_queue, wire_congested);
         } else {
             // Admission control at the queue caps (see
             // `send_control_frame`).
@@ -902,12 +908,12 @@ pub(crate) fn send_control_frame<I: rtc::interceptor::Interceptor>(
                     send_control_text(rtc, channels, text);
                 }
             }
-            drain_queued_control_frames(rtc, channels, outbound_queue);
+            drain_queued_control_frames(rtc, channels, outbound_queue, wire_congested);
         }
         ControlFrameTexts::Chunked(plan) => {
             if response_credit_enabled {
                 if outbound_queue.enqueue_chunked(plan) {
-                    drain_queued_control_frames(rtc, channels, outbound_queue);
+                    drain_queued_control_frames(rtc, channels, outbound_queue, wire_congested);
                 } else {
                     // Admission control: the per-connection queue caps are
                     // exhausted — answer the request instead of pinning
@@ -967,7 +973,7 @@ pub(crate) fn send_control_byte_stream<I: rtc::interceptor::Interceptor>(
             let request_id = plan.request_id.clone();
             if response_credit_enabled {
                 if outbound_queue.enqueue_chunked(plan) {
-                    drain_queued_control_frames(rtc, channels, outbound_queue);
+                    drain_queued_control_frames(rtc, channels, outbound_queue, wire_congested);
                 } else {
                     // Admission control at the queue caps (see
                     // `send_control_frame`).
@@ -1153,7 +1159,16 @@ pub(crate) fn drain_queued_control_frames<I: rtc::interceptor::Interceptor>(
     rtc: &mut RTCPeerConnection<I>,
     channels: &HashMap<String, rtc::data_channel::RTCDataChannelId>,
     outbound_queue: &mut OutboundControlQueue,
+    wire_congested: bool,
 ) {
+    // Above the high watermark nothing drains: queued frames wait under
+    // the queue caps (that is what makes the caps BIND — draining while
+    // congested would forward the backlog straight into the unbounded
+    // SCTP pending queue). The driver re-runs this every loop, so the
+    // Low-watermark event resumes the flush.
+    if wire_congested {
+        return;
+    }
     loop {
         let mut pop_front = false;
         let mut completed = false;

--- a/src/bin/caller/dashboard_control/wire.rs
+++ b/src/bin/caller/dashboard_control/wire.rs
@@ -74,7 +74,7 @@ pub(crate) async fn control_driver<I: rtc::interceptor::Interceptor + Send + Syn
     // presence) stays unbounded.
     let (terminal_output_tx, mut terminal_output_rx) =
         mpsc::channel::<serde_json::Value>(TERMINAL_OUTPUT_LANE_CAP);
-    let mut terminal_lane_paused = false;
+    let mut control_wire_congested = false;
     let mut terminal_forwarders: HashMap<(String, String), tokio::task::JoinHandle<()>> =
         HashMap::new();
     // Per-connection ordered display-input lane (F1): `display_input`
@@ -112,7 +112,7 @@ pub(crate) async fn control_driver<I: rtc::interceptor::Interceptor + Send + Syn
             &terminal_output_tx,
             &mut terminal_forwarders,
             &display_input_tx,
-            &mut terminal_lane_paused,
+            &mut control_wire_congested,
         )
         .await
         {
@@ -279,6 +279,7 @@ pub(crate) async fn control_driver<I: rtc::interceptor::Interceptor + Send + Syn
                         &channels,
                         &mut outbound_queue,
                         runtime.response_credit_enabled,
+                        control_wire_congested,
                         task_response,
                     );
                     if done {
@@ -348,7 +349,7 @@ pub(crate) async fn control_driver<I: rtc::interceptor::Interceptor + Send + Syn
             // buffered-amount watermark: while paused the forwarders park
             // on the full lane and terminal.rs's drop-oldest bound holds
             // the memory line.
-            Some(frame) = terminal_output_rx.recv(), if !terminal_lane_paused => {
+            Some(frame) = terminal_output_rx.recv(), if !control_wire_congested => {
                 if !runtime.grant.opening_authority_is_current() {
                     shutdown.cancel();
                     break;
@@ -513,7 +514,7 @@ pub(crate) async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
     terminal_output_tx: &mpsc::Sender<serde_json::Value>,
     terminal_forwarders: &mut HashMap<(String, String), tokio::task::JoinHandle<()>>,
     display_input_tx: &DisplayInputForwarder,
-    terminal_lane_paused: &mut bool,
+    control_wire_congested: &mut bool,
 ) -> Result<Instant, ()> {
     while let Some(t) = rtc.poll_write() {
         // Route by connection first, engine stamp second: rtc < 0.9.1
@@ -595,6 +596,7 @@ pub(crate) async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
                 channels,
                 outbound_queue,
                 runtime.response_credit_enabled,
+                *control_wire_congested,
                 response,
             );
         }
@@ -620,15 +622,15 @@ pub(crate) async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
                             TERMINAL_LANE_BUFFERED_LOW_WATERMARK_BYTES,
                         ));
                     }
-                    *terminal_lane_paused = false;
+                    *control_wire_congested = false;
                 }
                 channels.insert(label, cid);
             }
             RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnClose(cid)) => {
                 if channels.get(CONTROL_CHANNEL_LABEL).copied() == Some(cid) {
-                    // Never leave the terminal lane parked behind a channel
+                    // Never leave the gated lanes parked behind a channel
                     // that can no longer drain.
-                    *terminal_lane_paused = false;
+                    *control_wire_congested = false;
                 }
                 channels.retain(|_, id| *id != cid);
             }
@@ -636,14 +638,14 @@ pub(crate) async fn drain_control_outputs<I: rtc::interceptor::Interceptor>(
                 cid,
             )) => {
                 if channels.get(CONTROL_CHANNEL_LABEL).copied() == Some(cid) {
-                    *terminal_lane_paused = true;
+                    *control_wire_congested = true;
                 }
             }
             RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnBufferedAmountLow(
                 cid,
             )) => {
                 if channels.get(CONTROL_CHANNEL_LABEL).copied() == Some(cid) {
-                    *terminal_lane_paused = false;
+                    *control_wire_congested = false;
                 }
             }
             RTCPeerConnectionEvent::OnConnectionStateChangeEvent(state) => {
@@ -699,6 +701,7 @@ pub(crate) fn send_control_task_response<I: rtc::interceptor::Interceptor>(
     channels: &HashMap<String, rtc::data_channel::RTCDataChannelId>,
     outbound_queue: &mut OutboundControlQueue,
     response_credit_enabled: bool,
+    wire_congested: bool,
     response: ControlTaskResponse,
 ) {
     if let Some(byte_stream) = response.byte_stream {
@@ -707,6 +710,7 @@ pub(crate) fn send_control_task_response<I: rtc::interceptor::Interceptor>(
             channels,
             outbound_queue,
             response_credit_enabled,
+            wire_congested,
             byte_stream,
         );
     } else if let serde_json::Value::String(text) = response.frame {
@@ -720,6 +724,7 @@ pub(crate) fn send_control_task_response<I: rtc::interceptor::Interceptor>(
             channels,
             outbound_queue,
             response_credit_enabled,
+            wire_congested,
             response.id,
             text,
         );
@@ -729,6 +734,7 @@ pub(crate) fn send_control_task_response<I: rtc::interceptor::Interceptor>(
             channels,
             outbound_queue,
             response_credit_enabled,
+            wire_congested,
             response.frame,
         );
     }
@@ -738,17 +744,28 @@ pub(crate) fn send_control_task_response<I: rtc::interceptor::Interceptor>(
 /// queued handling and the same chunk framing (`chunk_id` falls back to
 /// the request id exactly as `control_frame_text_parts` derives it for a
 /// response frame without `chunk_id`/`seq` fields).
+#[allow(clippy::too_many_arguments)] // established internal signature: the params are distinct dependencies, not a bundle
 fn send_control_frame_preserialized<I: rtc::interceptor::Interceptor>(
     rtc: &mut RTCPeerConnection<I>,
     channels: &HashMap<String, rtc::data_channel::RTCDataChannelId>,
     outbound_queue: &mut OutboundControlQueue,
     response_credit_enabled: bool,
+    wire_congested: bool,
     request_id: String,
     text: String,
 ) {
     if text.len() <= CONTROL_RESPONSE_CHUNK_THRESHOLD_BYTES || request_id.is_empty() {
         if response_credit_enabled && !outbound_queue.is_empty() && !request_id.is_empty() {
-            outbound_queue.enqueue_immediate(request_id, text);
+            if !outbound_queue.enqueue_immediate(request_id.clone(), text) {
+                // Admission control at the queue caps (see
+                // `send_control_frame`).
+                send_control_text(
+                    rtc,
+                    channels,
+                    dashboard_control_error_response(request_id, "outbound response queue is full")
+                        .to_string(),
+                );
+            }
         } else {
             send_control_text(rtc, channels, text);
         }
@@ -785,7 +802,7 @@ fn send_control_frame_preserialized<I: rtc::interceptor::Interceptor>(
         if outbound_queue.enqueue_chunked(plan) {
             drain_queued_control_frames(rtc, channels, outbound_queue);
         } else {
-            // Admission control at the queue byte cap (see
+            // Admission control at the queue caps (see
             // `send_control_frame`).
             send_control_text(
                 rtc,
@@ -794,6 +811,18 @@ fn send_control_frame_preserialized<I: rtc::interceptor::Interceptor>(
                     .to_string(),
             );
         }
+    } else if wire_congested {
+        // See `send_control_frame`: no credit lane, wire above the high
+        // watermark — refuse rather than grow the SCTP queue.
+        send_control_text(
+            rtc,
+            channels,
+            dashboard_control_error_response(
+                request_id,
+                "control channel is congested; retry the request",
+            )
+            .to_string(),
+        );
     } else {
         for frame in plan.render_all() {
             send_control_text(rtc, channels, frame);
@@ -801,11 +830,13 @@ fn send_control_frame_preserialized<I: rtc::interceptor::Interceptor>(
     }
 }
 
+#[allow(clippy::too_many_arguments)] // established internal signature: the params are distinct dependencies, not a bundle
 pub(crate) fn send_control_frame<I: rtc::interceptor::Interceptor>(
     rtc: &mut RTCPeerConnection<I>,
     channels: &HashMap<String, rtc::data_channel::RTCDataChannelId>,
     outbound_queue: &mut OutboundControlQueue,
     response_credit_enabled: bool,
+    wire_congested: bool,
     frame: serde_json::Value,
 ) {
     let request_id = frame
@@ -821,7 +852,20 @@ pub(crate) fn send_control_frame<I: rtc::interceptor::Interceptor>(
         ControlFrameTexts::Immediate(frames) => {
             for text in frames {
                 if response_credit_enabled && !outbound_queue.is_empty() && !request_id.is_empty() {
-                    outbound_queue.enqueue_immediate(request_id.clone(), text);
+                    if !outbound_queue.enqueue_immediate(request_id.clone(), text) {
+                        // Admission control: the queue caps are exhausted —
+                        // answer directly instead of growing the parked
+                        // backlog without bound.
+                        send_control_text(
+                            rtc,
+                            channels,
+                            dashboard_control_error_response(
+                                request_id.clone(),
+                                "outbound response queue is full",
+                            )
+                            .to_string(),
+                        );
+                    }
                 } else {
                     send_control_text(rtc, channels, text);
                 }
@@ -833,8 +877,8 @@ pub(crate) fn send_control_frame<I: rtc::interceptor::Interceptor>(
                 if outbound_queue.enqueue_chunked(plan) {
                     drain_queued_control_frames(rtc, channels, outbound_queue);
                 } else {
-                    // Admission control: the per-connection queue byte cap
-                    // is exhausted — answer the request instead of pinning
+                    // Admission control: the per-connection queue caps are
+                    // exhausted — answer the request instead of pinning
                     // another payload behind a quiet client.
                     send_control_text(
                         rtc,
@@ -846,6 +890,19 @@ pub(crate) fn send_control_frame<I: rtc::interceptor::Interceptor>(
                         .to_string(),
                     );
                 }
+            } else if wire_congested {
+                // No credit lane to absorb it and the control channel sits
+                // above its high watermark: refuse instead of growing the
+                // unbounded SCTP pending queue at payload size.
+                send_control_text(
+                    rtc,
+                    channels,
+                    dashboard_control_error_response(
+                        request_id,
+                        "control channel is congested; retry the request",
+                    )
+                    .to_string(),
+                );
             } else {
                 for text in plan.render_all() {
                     send_control_text(rtc, channels, text);
@@ -860,6 +917,7 @@ pub(crate) fn send_control_byte_stream<I: rtc::interceptor::Interceptor>(
     channels: &HashMap<String, rtc::data_channel::RTCDataChannelId>,
     outbound_queue: &mut OutboundControlQueue,
     response_credit_enabled: bool,
+    wire_congested: bool,
     byte_stream: ControlByteStream,
 ) {
     match byte_stream_frame_text_parts(byte_stream, CONTROL_BYTE_STREAM_CHUNK_BYTES) {
@@ -869,12 +927,12 @@ pub(crate) fn send_control_byte_stream<I: rtc::interceptor::Interceptor>(
             }
         }
         ControlFrameTexts::Chunked(plan) => {
+            let request_id = plan.request_id.clone();
             if response_credit_enabled {
-                let request_id = plan.request_id.clone();
                 if outbound_queue.enqueue_chunked(plan) {
                     drain_queued_control_frames(rtc, channels, outbound_queue);
                 } else {
-                    // Admission control at the queue byte cap (see
+                    // Admission control at the queue caps (see
                     // `send_control_frame`).
                     send_control_text(
                         rtc,
@@ -886,6 +944,18 @@ pub(crate) fn send_control_byte_stream<I: rtc::interceptor::Interceptor>(
                         .to_string(),
                     );
                 }
+            } else if wire_congested {
+                // See `send_control_frame`: no credit lane, wire above the
+                // high watermark — refuse rather than grow the SCTP queue.
+                send_control_text(
+                    rtc,
+                    channels,
+                    dashboard_control_error_response(
+                        request_id,
+                        "control channel is congested; retry the request",
+                    )
+                    .to_string(),
+                );
             } else {
                 for text in plan.render_all() {
                     send_control_text(rtc, channels, text);

--- a/src/bin/caller/dashboard_control/wire.rs
+++ b/src/bin/caller/dashboard_control/wire.rs
@@ -1465,6 +1465,63 @@ mod tests {
         assert_eq!(queue.queued_bytes, 0);
     }
 
+    /// The send-path congestion regression for the pre-serialized
+    /// carrier: on a congested wire a successful small preserialized
+    /// response QUEUES under the caps (nothing direct-sends, the gated
+    /// drain holds it), while an uncongested empty queue direct-sends.
+    #[test]
+    fn congested_preserialized_responses_queue_under_caps() {
+        let mut rtc = rtc::peer_connection::RTCPeerConnectionBuilder::new()
+            .with_configuration(
+                rtc::peer_connection::configuration::RTCConfigurationBuilder::new().build(),
+            )
+            .build()
+            .expect("offline rtc peer");
+        // No control channel: any (incorrect) direct send would be a
+        // silent no-op, so the queue observations carry the assertion.
+        let channels: HashMap<String, rtc::data_channel::RTCDataChannelId> = HashMap::new();
+        let mut budget = DirectErrorBudget::new("test");
+        let envelope =
+            r#"{"t":"response","id":"r1","ok":true,"result":{"sessions":[]}}"#.to_string();
+
+        // Congested: the frame must queue (the congestion-gated drain
+        // leaves it there), bounded by the queue caps.
+        let mut queue = OutboundControlQueue::new();
+        send_control_frame_preserialized(
+            &mut rtc,
+            &channels,
+            &mut queue,
+            false,
+            true,
+            &mut budget,
+            "r1".to_string(),
+            envelope.clone(),
+        );
+        assert_eq!(
+            queue.frames.len(),
+            1,
+            "a congested preserialized response must queue, not direct-send"
+        );
+        assert!(queue.queued_bytes >= envelope.len());
+
+        // Uncongested + empty queue: direct send, nothing queued.
+        let mut queue = OutboundControlQueue::new();
+        send_control_frame_preserialized(
+            &mut rtc,
+            &channels,
+            &mut queue,
+            false,
+            false,
+            &mut budget,
+            "r1".to_string(),
+            envelope,
+        );
+        assert!(
+            queue.is_empty(),
+            "an uncongested empty queue direct-sends preserialized frames"
+        );
+    }
+
     /// A queued chunked frame renders each chunk lazily and exactly once,
     /// byte-identical to the eager path (`render_all` is the eager
     /// rendering the reassembly tests above already pin).

--- a/src/bin/caller/peer/actor.rs
+++ b/src/bin/caller/peer/actor.rs
@@ -560,6 +560,9 @@ impl PeerActor {
                 .find(|index| entry.text.is_char_boundary(*index))
                 .unwrap_or(entry.text.len());
             entry.text.drain(..cut);
+            // `drain` shrinks the length but RETAINS the capacity — the
+            // byte bound is on the heap, so release it too.
+            entry.text.shrink_to(MAX_PENDING_PARTIAL_TEXT_BYTES);
         }
     }
 

--- a/src/bin/caller/peer/actor.rs
+++ b/src/bin/caller/peer/actor.rs
@@ -44,10 +44,18 @@ use tokio::sync::{broadcast, mpsc, watch};
 pub(crate) const MAX_TRACKED_TASK_RECEIPTS: usize = 64;
 
 /// In-flight streaming messages whose partial text is folded for the
-/// disconnect salvage record (see `PeerActor::pending_partials`). Bounded
-/// so a peer that abandons message ids mid-stream cannot grow the fold;
-/// hitting the cap flushes the accumulated folds to the durable log.
+/// disconnect salvage record (see `PeerActor::pending_partials`). At the
+/// cap the OLDEST fold is silently evicted — salvage records exist for
+/// disconnect/abort only, so a healthy connection streaming a 9th
+/// concurrent message must never mint one (the evicted message merely
+/// loses crash-salvage coverage; its final is unaffected).
 pub(crate) const MAX_PENDING_PARTIAL_MESSAGES: usize = 8;
+
+/// Per-fold byte cap: the fold keeps the TAIL of the accumulated text
+/// (the most recent output is the valuable part of an interrupted
+/// reply). Together with [`MAX_PENDING_PARTIAL_MESSAGES`] this bounds the
+/// whole fold structure at ~2 MiB per peer.
+pub(crate) const MAX_PENDING_PARTIAL_TEXT_BYTES: usize = 256 * 1024;
 
 // ---------------------------------------------------------------------------
 // Backoff
@@ -172,8 +180,13 @@ pub(crate) struct PeerActor {
     /// reply). A final for the same id clears its fold; on disconnect
     /// every remaining fold lands in the log as ONE coalesced record
     /// still marked `partial: true` — in the durable log that marker
-    /// appears ONLY on these interruption salvage records.
+    /// appears ONLY on these interruption salvage records. Bounded by
+    /// [`MAX_PENDING_PARTIAL_MESSAGES`] (oldest evicted, never salvaged)
+    /// and [`MAX_PENDING_PARTIAL_TEXT_BYTES`] per fold (tail kept).
     pub pending_partials: HashMap<MessageId, PendingPartialMessage>,
+    /// Insertion order for `pending_partials` eviction and deterministic
+    /// flush order (the `receipt_order` pattern).
+    pub pending_partial_order: VecDeque<MessageId>,
     pub seq: u64,
     /// Operator's via-URL override, preserved across card refreshes.
     ///
@@ -470,11 +483,13 @@ impl PeerActor {
                 partial,
             } => {
                 if *partial {
-                    self.fold_pending_partial(id, *role, content).await;
+                    self.fold_pending_partial(id, *role, content);
                 } else {
                     // The final carries the complete text; the fold is
                     // no longer needed for salvage.
-                    self.pending_partials.remove(id);
+                    if self.pending_partials.remove(id).is_some() {
+                        self.pending_partial_order.retain(|held| held != id);
+                    }
                 }
             }
             PeerEvent::Disconnected { .. } => {
@@ -499,7 +514,15 @@ impl PeerActor {
     /// Fold one streaming chunk into the per-message salvage accumulator.
     /// Non-text chunks (images, parts, unknown) don't fold — they don't
     /// stream as deltas.
-    async fn fold_pending_partial(
+    ///
+    /// Bounds: at [`MAX_PENDING_PARTIAL_MESSAGES`] concurrent folds the
+    /// OLDEST is evicted WITHOUT a salvage record (salvage is for
+    /// disconnect/abort only — a healthy 9th stream must not mint one;
+    /// the evicted message loses crash-salvage coverage, its final is
+    /// unaffected). Each fold keeps at most
+    /// [`MAX_PENDING_PARTIAL_TEXT_BYTES`] — the TAIL, because the most
+    /// recent text is the valuable part of an interrupted reply.
+    fn fold_pending_partial(
         &mut self,
         id: &MessageId,
         role: MessageRole,
@@ -510,12 +533,16 @@ impl PeerActor {
             MessageContent::Reasoning { text } => (text.as_str(), true),
             _ => return,
         };
-        if !self.pending_partials.contains_key(id)
-            && self.pending_partials.len() >= MAX_PENDING_PARTIAL_MESSAGES
-        {
-            // A peer abandoning ids mid-stream must not grow the fold:
-            // salvage what's accumulated and start fresh.
-            self.flush_pending_partials_to_log().await;
+        if !self.pending_partials.contains_key(id) {
+            while self.pending_partials.len() >= MAX_PENDING_PARTIAL_MESSAGES {
+                match self.pending_partial_order.pop_front() {
+                    Some(oldest) => {
+                        self.pending_partials.remove(&oldest);
+                    }
+                    None => break,
+                }
+            }
+            self.pending_partial_order.push_back(id.clone());
         }
         let entry =
             self.pending_partials
@@ -526,6 +553,14 @@ impl PeerActor {
                     text: String::new(),
                 });
         entry.text.push_str(delta);
+        if entry.text.len() > MAX_PENDING_PARTIAL_TEXT_BYTES {
+            // Keep the tail, cutting on a char boundary.
+            let excess = entry.text.len() - MAX_PENDING_PARTIAL_TEXT_BYTES;
+            let cut = (excess..=entry.text.len())
+                .find(|index| entry.text.is_char_boundary(*index))
+                .unwrap_or(entry.text.len());
+            entry.text.drain(..cut);
+        }
     }
 
     /// Write every accumulated fold to the DURABLE log as one coalesced
@@ -533,8 +568,12 @@ impl PeerActor {
     /// deltas). Preserves the pre-elision durability property — an
     /// interrupted reply's text survives — at one record instead of N.
     async fn flush_pending_partials_to_log(&mut self) {
-        let pending = std::mem::take(&mut self.pending_partials);
-        for (id, fold) in pending {
+        let mut pending = std::mem::take(&mut self.pending_partials);
+        let order = std::mem::take(&mut self.pending_partial_order);
+        let ordered = order
+            .into_iter()
+            .filter_map(|id| pending.remove(&id).map(|fold| (id, fold)));
+        for (id, fold) in ordered {
             if fold.text.is_empty() {
                 continue;
             }
@@ -741,6 +780,7 @@ mod tests {
             receipts: HashMap::new(),
             receipt_order: VecDeque::new(),
             pending_partials: HashMap::new(),
+            pending_partial_order: VecDeque::new(),
             seq: 0,
             via_urls: Vec::new(),
             label_override: None,
@@ -795,6 +835,106 @@ mod tests {
             PeerEvent::Disconnected { .. }
         ));
         assert!(log_rx.try_recv().is_err());
+    }
+
+    /// Cap pressure on a HEALTHY connection evicts the oldest fold
+    /// silently: no salvage record is minted outside disconnect, an
+    /// evicted message that later finalizes logs only its final, and the
+    /// survivors salvage in order at disconnect.
+    #[tokio::test]
+    async fn fold_cap_evicts_oldest_without_false_salvage() {
+        let (log_tx, mut log_rx) = mpsc::channel(64);
+        let (mut actor, _guards) = test_actor(log_tx);
+        for index in 0..=MAX_PENDING_PARTIAL_MESSAGES {
+            actor
+                .handle_event(partial_text(
+                    &format!("m-{index}"),
+                    &format!("text-{index}"),
+                ))
+                .await;
+        }
+        assert!(
+            log_rx.try_recv().is_err(),
+            "cap pressure must not mint salvage records on a healthy connection"
+        );
+        assert!(
+            !actor
+                .pending_partials
+                .contains_key(&MessageId("m-0".into())),
+            "the oldest fold is evicted"
+        );
+        assert_eq!(actor.pending_partials.len(), MAX_PENDING_PARTIAL_MESSAGES);
+
+        // The evicted message finalizing later logs ONLY its final.
+        actor
+            .handle_event(PeerEvent::Message {
+                id: MessageId("m-0".to_string()),
+                role: MessageRole::Assistant,
+                content: MessageContent::Text {
+                    text: "text-0 complete".to_string(),
+                },
+                partial: false,
+            })
+            .await;
+        let final_record = log_rx.try_recv().expect("final record");
+        assert!(matches!(
+            final_record.payload,
+            PeerEvent::Message { partial: false, .. }
+        ));
+
+        actor
+            .handle_event(PeerEvent::Disconnected {
+                reason: "test".into(),
+            })
+            .await;
+        let mut salvaged = Vec::new();
+        while let Ok(record) = log_rx.try_recv() {
+            match record.payload {
+                PeerEvent::Message {
+                    id, partial: true, ..
+                } => salvaged.push(id.0),
+                PeerEvent::Disconnected { .. } => break,
+                other => panic!("unexpected record: {other:?}"),
+            }
+        }
+        let expected: Vec<String> = (1..=MAX_PENDING_PARTIAL_MESSAGES)
+            .map(|index| format!("m-{index}"))
+            .collect();
+        assert_eq!(salvaged, expected, "survivors salvage in fold order");
+    }
+
+    /// The per-fold byte cap keeps the TAIL of the accumulated text.
+    #[tokio::test]
+    async fn fold_byte_cap_keeps_the_tail() {
+        let (log_tx, mut log_rx) = mpsc::channel(64);
+        let (mut actor, _guards) = test_actor(log_tx);
+        let chunk = "x".repeat(100 * 1024);
+        for _ in 0..3 {
+            actor.handle_event(partial_text("m-big", &chunk)).await;
+        }
+        actor
+            .handle_event(partial_text("m-big", "THE-TAIL-MARKER"))
+            .await;
+        actor
+            .handle_event(PeerEvent::Disconnected {
+                reason: "test".into(),
+            })
+            .await;
+        let salvage = log_rx.try_recv().expect("salvage record");
+        match salvage.payload {
+            PeerEvent::Message {
+                content: MessageContent::Text { text },
+                partial: true,
+                ..
+            } => {
+                assert!(text.len() <= MAX_PENDING_PARTIAL_TEXT_BYTES);
+                assert!(
+                    text.ends_with("THE-TAIL-MARKER"),
+                    "the most recent text survives the cap"
+                );
+            }
+            other => panic!("expected the coalesced partial, got {other:?}"),
+        }
     }
 
     /// A final message clears its fold: nothing is salvaged at disconnect

--- a/src/bin/caller/peer/actor.rs
+++ b/src/bin/caller/peer/actor.rs
@@ -51,10 +51,13 @@ pub(crate) const MAX_TRACKED_TASK_RECEIPTS: usize = 64;
 /// loses crash-salvage coverage; its final is unaffected).
 pub(crate) const MAX_PENDING_PARTIAL_MESSAGES: usize = 8;
 
-/// Per-fold byte cap: the fold keeps the TAIL of the accumulated text
-/// (the most recent output is the valuable part of an interrupted
-/// reply). Together with [`MAX_PENDING_PARTIAL_MESSAGES`] this bounds the
-/// whole fold structure at ~2 MiB per peer.
+/// Per-fold byte cap on LENGTH: the fold keeps the TAIL of the
+/// accumulated text (the most recent output is the valuable part of an
+/// interrupted reply), trimming down to half the cap so trims amortize.
+/// Buffer capacity is bounded at ~2× this figure (String doubling from
+/// at most cap, with an advisory shrink as the safety valve), so the
+/// whole fold structure holds ~[`MAX_PENDING_PARTIAL_MESSAGES`] × 512 KiB
+/// of heap per peer worst case.
 pub(crate) const MAX_PENDING_PARTIAL_TEXT_BYTES: usize = 256 * 1024;
 
 // ---------------------------------------------------------------------------
@@ -552,16 +555,37 @@ impl PeerActor {
                     reasoning,
                     text: String::new(),
                 });
-        entry.text.push_str(delta);
-        if entry.text.len() > MAX_PENDING_PARTIAL_TEXT_BYTES {
-            // Keep the tail, cutting on a char boundary.
-            let excess = entry.text.len() - MAX_PENDING_PARTIAL_TEXT_BYTES;
-            let cut = (excess..=entry.text.len())
-                .find(|index| entry.text.is_char_boundary(*index))
-                .unwrap_or(entry.text.len());
-            entry.text.drain(..cut);
-            // `drain` shrinks the length but RETAINS the capacity — the
-            // byte bound is on the heap, so release it too.
+        // Trim BEFORE appending so the length never overshoots the cap,
+        // and trim down to HALF the cap so the front-shift amortizes to
+        // one move per ~128 KiB of streamed text instead of one per
+        // delta at the boundary.
+        if entry.text.len().saturating_add(delta.len()) > MAX_PENDING_PARTIAL_TEXT_BYTES {
+            if delta.len() >= MAX_PENDING_PARTIAL_TEXT_BYTES {
+                // The delta alone exceeds the cap: keep only its tail.
+                entry.text.clear();
+                let tail_start = delta.len() - MAX_PENDING_PARTIAL_TEXT_BYTES;
+                let cut = (tail_start..=delta.len())
+                    .find(|index| delta.is_char_boundary(*index))
+                    .unwrap_or(delta.len());
+                entry.text.push_str(&delta[cut..]);
+            } else {
+                let keep = (MAX_PENDING_PARTIAL_TEXT_BYTES / 2).saturating_sub(delta.len());
+                let excess = entry.text.len().saturating_sub(keep);
+                let cut = (excess..=entry.text.len())
+                    .find(|index| entry.text.is_char_boundary(*index))
+                    .unwrap_or(entry.text.len());
+                entry.text.drain(..cut);
+                entry.text.push_str(delta);
+            }
+        } else {
+            entry.text.push_str(delta);
+        }
+        // The length invariant (≤ cap) bounds the buffer's growth at
+        // ~2× cap (String doubling from at most cap). `shrink_to` is
+        // advisory, so it stays a rare safety valve rather than a
+        // per-delta call — the earlier per-delta drain+shrink thrashed
+        // ~256 KiB of moves on every chunk at the boundary.
+        if entry.text.capacity() > 2 * MAX_PENDING_PARTIAL_TEXT_BYTES {
             entry.text.shrink_to(MAX_PENDING_PARTIAL_TEXT_BYTES);
         }
     }
@@ -906,14 +930,29 @@ mod tests {
         assert_eq!(salvaged, expected, "survivors salvage in fold order");
     }
 
-    /// The per-fold byte cap keeps the TAIL of the accumulated text.
+    /// The per-fold byte cap keeps the TAIL of the accumulated text, the
+    /// length never overshoots the cap (trim runs BEFORE append), and
+    /// buffer capacity stays within the documented ~2x cap across a long
+    /// stream of small deltas (the advisory-shrink slack).
     #[tokio::test]
-    async fn fold_byte_cap_keeps_the_tail() {
+    async fn fold_byte_cap_keeps_the_tail_and_bounds_capacity() {
         let (log_tx, mut log_rx) = mpsc::channel(64);
         let (mut actor, _guards) = test_actor(log_tx);
-        let chunk = "x".repeat(100 * 1024);
-        for _ in 0..3 {
-            actor.handle_event(partial_text("m-big", &chunk)).await;
+        // A long stream of small deltas pushes well past the cap many
+        // times over; check the invariants as the stream runs.
+        let delta = "x".repeat(4 * 1024);
+        for _ in 0..192 {
+            actor.handle_event(partial_text("m-big", &delta)).await;
+            let fold = &actor.pending_partials[&MessageId("m-big".into())];
+            assert!(
+                fold.text.len() <= MAX_PENDING_PARTIAL_TEXT_BYTES,
+                "length must never overshoot the cap"
+            );
+            assert!(
+                fold.text.capacity() <= 2 * MAX_PENDING_PARTIAL_TEXT_BYTES,
+                "capacity must stay within the documented 2x-cap slack, got {}",
+                fold.text.capacity()
+            );
         }
         actor
             .handle_event(partial_text("m-big", "THE-TAIL-MARKER"))
@@ -938,6 +977,18 @@ mod tests {
             }
             other => panic!("expected the coalesced partial, got {other:?}"),
         }
+
+        // An oversized single delta keeps only its own tail, still capped.
+        let (log_tx, _log_rx2) = mpsc::channel(64);
+        let (mut actor, _guards) = test_actor(log_tx);
+        let huge = format!(
+            "{}HUGE-TAIL",
+            "y".repeat(MAX_PENDING_PARTIAL_TEXT_BYTES + 4096)
+        );
+        actor.handle_event(partial_text("m-huge", &huge)).await;
+        let fold = &actor.pending_partials[&MessageId("m-huge".into())];
+        assert!(fold.text.len() <= MAX_PENDING_PARTIAL_TEXT_BYTES);
+        assert!(fold.text.ends_with("HUGE-TAIL"));
     }
 
     /// A final message clears its fold: nothing is salvaged at disconnect

--- a/src/bin/caller/peer/actor.rs
+++ b/src/bin/caller/peer/actor.rs
@@ -24,7 +24,8 @@
 
 use crate::peer::card::AgentCard;
 use crate::peer::event::{
-    PeerDisplayInfo, PeerEvent, PeerStatus, SessionInfo, TaggedPeerEvent, TaskId,
+    MessageContent, MessageId, MessageRole, PeerDisplayInfo, PeerEvent, PeerStatus, SessionInfo,
+    TaggedPeerEvent, TaskId,
 };
 use crate::peer::handle::{ConnectionState, PeerCommand};
 use crate::peer::id::PeerId;
@@ -41,6 +42,12 @@ use tokio::sync::{broadcast, mpsc, watch};
 /// awaiting one (seconds), so a small FIFO window is generous; the bound
 /// exists so a chatty or hostile peer can't grow the map without limit.
 pub(crate) const MAX_TRACKED_TASK_RECEIPTS: usize = 64;
+
+/// In-flight streaming messages whose partial text is folded for the
+/// disconnect salvage record (see `PeerActor::pending_partials`). Bounded
+/// so a peer that abandons message ids mid-stream cannot grow the fold;
+/// hitting the cap flushes the accumulated folds to the durable log.
+pub(crate) const MAX_PENDING_PARTIAL_MESSAGES: usize = 8;
 
 // ---------------------------------------------------------------------------
 // Backoff
@@ -92,6 +99,16 @@ impl Backoff {
         self.attempt = self.attempt.saturating_add(1);
         Duration::from_millis(jittered_ms)
     }
+}
+
+/// One in-flight streaming message's accumulated partial text (see
+/// `PeerActor::pending_partials`).
+pub(crate) struct PendingPartialMessage {
+    role: MessageRole,
+    /// Whether the first chunk was a `Reasoning` part — the salvage
+    /// record keeps the kind the stream started with.
+    reasoning: bool,
+    text: String,
 }
 
 /// Stable per-actor jitter seed from the peer id (FNV-1a over the bytes).
@@ -150,6 +167,13 @@ pub(crate) struct PeerActor {
     pub receipts: HashMap<String, TaskId>,
     /// Insertion order for `receipts` eviction.
     pub receipt_order: VecDeque<String>,
+    /// Accumulated text of in-flight streaming messages (partials are
+    /// elided from the durable log; the fold preserves an interrupted
+    /// reply). A final for the same id clears its fold; on disconnect
+    /// every remaining fold lands in the log as ONE coalesced record
+    /// still marked `partial: true` — in the durable log that marker
+    /// appears ONLY on these interruption salvage records.
+    pub pending_partials: HashMap<MessageId, PendingPartialMessage>,
     pub seq: u64,
     /// Operator's via-URL override, preserved across card refreshes.
     ///
@@ -439,6 +463,20 @@ impl PeerActor {
                 }
                 let _ = self.receipts_tx.send(Arc::new(self.receipts.clone()));
             }
+            PeerEvent::Message {
+                id,
+                role,
+                content,
+                partial,
+            } => {
+                if *partial {
+                    self.fold_pending_partial(id, *role, content).await;
+                } else {
+                    // The final carries the complete text; the fold is
+                    // no longer needed for salvage.
+                    self.pending_partials.remove(id);
+                }
+            }
             PeerEvent::Disconnected { .. } => {
                 if !self.sessions.is_empty() {
                     self.sessions.clear();
@@ -448,10 +486,76 @@ impl PeerActor {
                     self.displays.clear();
                     self.publish_displays();
                 }
+                // Interrupted replies: land each accumulated fold as one
+                // coalesced durable record before the Disconnected event
+                // itself is logged.
+                self.flush_pending_partials_to_log().await;
             }
             _ => {}
         }
         self.emit_event(event).await;
+    }
+
+    /// Fold one streaming chunk into the per-message salvage accumulator.
+    /// Non-text chunks (images, parts, unknown) don't fold — they don't
+    /// stream as deltas.
+    async fn fold_pending_partial(
+        &mut self,
+        id: &MessageId,
+        role: MessageRole,
+        content: &MessageContent,
+    ) {
+        let (delta, reasoning) = match content {
+            MessageContent::Text { text } => (text.as_str(), false),
+            MessageContent::Reasoning { text } => (text.as_str(), true),
+            _ => return,
+        };
+        if !self.pending_partials.contains_key(id)
+            && self.pending_partials.len() >= MAX_PENDING_PARTIAL_MESSAGES
+        {
+            // A peer abandoning ids mid-stream must not grow the fold:
+            // salvage what's accumulated and start fresh.
+            self.flush_pending_partials_to_log().await;
+        }
+        let entry =
+            self.pending_partials
+                .entry(id.clone())
+                .or_insert_with(|| PendingPartialMessage {
+                    role,
+                    reasoning,
+                    text: String::new(),
+                });
+        entry.text.push_str(delta);
+    }
+
+    /// Write every accumulated fold to the DURABLE log as one coalesced
+    /// `partial: true` record (the live broadcast already carried the
+    /// deltas). Preserves the pre-elision durability property — an
+    /// interrupted reply's text survives — at one record instead of N.
+    async fn flush_pending_partials_to_log(&mut self) {
+        let pending = std::mem::take(&mut self.pending_partials);
+        for (id, fold) in pending {
+            if fold.text.is_empty() {
+                continue;
+            }
+            let content = if fold.reasoning {
+                MessageContent::Reasoning { text: fold.text }
+            } else {
+                MessageContent::Text { text: fold.text }
+            };
+            self.seq = self.seq.saturating_add(1);
+            let tagged = TaggedPeerEvent {
+                peer: self.peer_id.clone(),
+                payload: PeerEvent::Message {
+                    id,
+                    role: fold.role,
+                    content,
+                    partial: true,
+                },
+                seq: self.seq,
+            };
+            let _ = self.log_sink.send(tagged).await;
+        }
     }
 
     /// Publish the current sessions fold, newest first (matching how
@@ -484,7 +588,9 @@ impl PeerActor {
     /// the "few hundred events per minute" its writer was sized for. Live
     /// consumers still get every partial via the broadcast. Elided
     /// partials still advance `seq`, so a gap in the log's sequence marks
-    /// exactly where deltas were skipped.
+    /// exactly where deltas were skipped. An INTERRUPTED reply is not
+    /// lost: `pending_partials` folds the deltas and lands one coalesced
+    /// `partial: true` record at disconnect.
     async fn emit_event(&mut self, event: PeerEvent) {
         self.seq = self.seq.saturating_add(1);
         if !matches!(&event, PeerEvent::Message { partial: true, .. }) {
@@ -552,6 +658,182 @@ mod tests {
                 "seed {seed}: got {d:?}, expected between {min:?} and {max:?}"
             );
         }
+    }
+
+    struct StubTransport(crate::peer::card::TransportSpec);
+
+    #[async_trait::async_trait]
+    impl PeerTransport for StubTransport {
+        fn spec(&self) -> &crate::peer::card::TransportSpec {
+            &self.0
+        }
+        fn features(&self) -> crate::peer::traits::TransportFeatures {
+            crate::peer::traits::TransportFeatures::default()
+        }
+        async fn connect(&mut self) -> Result<AgentCard, PeerError> {
+            Err(PeerError::NotConnected)
+        }
+        async fn disconnect(&mut self) -> Result<(), PeerError> {
+            Ok(())
+        }
+        fn is_connected(&self) -> bool {
+            false
+        }
+        async fn send(
+            &mut self,
+            _op: crate::peer::traits::PeerOp,
+        ) -> Result<crate::peer::traits::PeerOpAck, PeerError> {
+            Err(PeerError::NotConnected)
+        }
+    }
+
+    /// Actor with a stub transport and an observable durable-log channel;
+    /// all other channels are held open by the returned guards.
+    #[allow(clippy::type_complexity)]
+    fn test_actor(
+        log_tx: mpsc::Sender<TaggedPeerEvent>,
+    ) -> (
+        PeerActor,
+        (
+            mpsc::Sender<PeerCommand>,
+            mpsc::Sender<PeerEvent>,
+            broadcast::Receiver<PeerEvent>,
+        ),
+    ) {
+        let peer_id = PeerId::new(crate::peer::id::PeerKind::Intendant, "fold-test");
+        let (commands_tx, commands_rx) = mpsc::channel(4);
+        let (events_in_tx, events_in_rx) = mpsc::channel(4);
+        let (events_out_tx, events_out_rx) = broadcast::channel(16);
+        let (connection_tx, _connection_rx) = watch::channel(ConnectionState::Initializing);
+        let (status_tx, _status_rx) = watch::channel(PeerStatus::Idle);
+        let card = AgentCard {
+            id: peer_id.clone(),
+            label: "fold-test".to_string(),
+            version: "test".into(),
+            git_sha: None,
+            transports: Vec::new(),
+            capabilities: Vec::new(),
+            auth: crate::peer::card::AuthRequirements::none(),
+        };
+        let (card_tx, _card_rx) = watch::channel(Arc::new(card));
+        let (sessions_tx, _sessions_rx) = watch::channel(Arc::new(Vec::new()));
+        let (displays_tx, _displays_rx) = watch::channel(Arc::new(Vec::new()));
+        let (receipts_tx, _receipts_rx) = watch::channel(Arc::new(HashMap::new()));
+        let actor = PeerActor {
+            peer_id,
+            transport: Box::new(StubTransport(
+                crate::peer::card::TransportSpec::IntendantWs {
+                    url: "ws://127.0.0.1:1/ws".into(),
+                },
+            )),
+            commands_rx,
+            events_in_rx,
+            events_out_tx,
+            log_sink: log_tx,
+            connection_tx,
+            status_tx,
+            card_tx,
+            sessions_tx,
+            sessions: BTreeMap::new(),
+            displays_tx,
+            displays: BTreeMap::new(),
+            receipts_tx,
+            receipts: HashMap::new(),
+            receipt_order: VecDeque::new(),
+            pending_partials: HashMap::new(),
+            seq: 0,
+            via_urls: Vec::new(),
+            label_override: None,
+        };
+        (actor, (commands_tx, events_in_tx, events_out_rx))
+    }
+
+    fn partial_text(id: &str, delta: &str) -> PeerEvent {
+        PeerEvent::Message {
+            id: MessageId(id.to_string()),
+            role: MessageRole::Assistant,
+            content: MessageContent::Text {
+                text: delta.to_string(),
+            },
+            partial: true,
+        }
+    }
+
+    /// An interrupted streaming reply lands as ONE coalesced durable
+    /// record (still `partial: true` — in the log that marker exists only
+    /// on interruption salvage) ahead of the Disconnected record, while
+    /// the deltas themselves stay off the durable log.
+    #[tokio::test]
+    async fn interrupted_streaming_reply_lands_one_coalesced_log_record() {
+        let (log_tx, mut log_rx) = mpsc::channel(64);
+        let (mut actor, _guards) = test_actor(log_tx);
+        for delta in ["Hel", "lo ", "world"] {
+            actor.handle_event(partial_text("m-1", delta)).await;
+        }
+        assert!(
+            log_rx.try_recv().is_err(),
+            "streaming deltas must stay off the durable log"
+        );
+
+        actor
+            .handle_event(PeerEvent::Disconnected {
+                reason: "test".into(),
+            })
+            .await;
+        let salvage = log_rx.try_recv().expect("coalesced salvage record");
+        match salvage.payload {
+            PeerEvent::Message {
+                content: MessageContent::Text { text },
+                partial: true,
+                ..
+            } => assert_eq!(text, "Hello world"),
+            other => panic!("expected the coalesced partial, got {other:?}"),
+        }
+        let disconnected = log_rx.try_recv().expect("disconnected record");
+        assert!(matches!(
+            disconnected.payload,
+            PeerEvent::Disconnected { .. }
+        ));
+        assert!(log_rx.try_recv().is_err());
+    }
+
+    /// A final message clears its fold: nothing is salvaged at disconnect
+    /// for a reply whose complete text was already logged.
+    #[tokio::test]
+    async fn finalized_reply_leaves_no_salvage_record() {
+        let (log_tx, mut log_rx) = mpsc::channel(64);
+        let (mut actor, _guards) = test_actor(log_tx);
+        actor.handle_event(partial_text("m-2", "chunk")).await;
+        actor
+            .handle_event(PeerEvent::Message {
+                id: MessageId("m-2".to_string()),
+                role: MessageRole::Assistant,
+                content: MessageContent::Text {
+                    text: "chunk plus the rest".to_string(),
+                },
+                partial: false,
+            })
+            .await;
+        actor
+            .handle_event(PeerEvent::Disconnected {
+                reason: "test".into(),
+            })
+            .await;
+
+        let final_record = log_rx.try_recv().expect("final message record");
+        assert!(matches!(
+            final_record.payload,
+            PeerEvent::Message { partial: false, .. }
+        ));
+        let disconnected = log_rx.try_recv().expect("disconnected record");
+        assert!(matches!(
+            disconnected.payload,
+            PeerEvent::Disconnected { .. }
+        ));
+        assert!(
+            log_rx.try_recv().is_err(),
+            "no salvage for a finalized reply"
+        );
     }
 
     /// Distinct peers must not share a reconnect phase (the thundering

--- a/src/bin/caller/peer/actor.rs
+++ b/src/bin/caller/peer/actor.rs
@@ -56,13 +56,20 @@ const MAX_BACKOFF: Duration = Duration::from_secs(30);
 struct Backoff {
     current: Duration,
     attempt: u32,
+    /// Per-actor jitter phase. Deriving jitter from the attempt counter
+    /// alone put every peer actor on an identical schedule — after a
+    /// network blip the whole fleet reconnected in lockstep (thundering
+    /// herd). Seeding by peer identity keeps jitter deterministic per
+    /// actor (tests stay reproducible) while decorrelating actors.
+    seed: u32,
 }
 
 impl Backoff {
-    fn new() -> Self {
+    fn new(seed: u32) -> Self {
         Self {
             current: INITIAL_BACKOFF,
             attempt: 0,
+            seed,
         }
     }
 
@@ -72,18 +79,29 @@ impl Backoff {
     }
 
     /// Return the next delay and advance internal state. Jitter is
-    /// deterministic (derived from the attempt counter) so tests are
-    /// reproducible; a real rng can be swapped in later without
-    /// changing the shape.
+    /// deterministic (derived from the attempt counter and the actor's
+    /// seed) so tests are reproducible; a real rng can be swapped in
+    /// later without changing the shape.
     fn next_delay(&mut self) -> Duration {
         let base_ms = self.current.as_millis() as i64;
-        // ±20% jitter, stepping through 40 positions based on attempt.
-        let jitter_bps = (self.attempt as i64 * 137) % 40 - 20;
+        // ±20% jitter, stepping through 40 positions based on attempt,
+        // phase-shifted per actor.
+        let jitter_bps = ((self.attempt as i64 * 137) + self.seed as i64) % 40 - 20;
         let jittered_ms = (base_ms * (100 + jitter_bps) / 100).max(0) as u64;
         self.current = (self.current * 2).min(MAX_BACKOFF);
         self.attempt = self.attempt.saturating_add(1);
         Duration::from_millis(jittered_ms)
     }
+}
+
+/// Stable per-actor jitter seed from the peer id (FNV-1a over the bytes).
+fn backoff_seed(peer_id: &PeerId) -> u32 {
+    let mut hash: u32 = 0x811c_9dc5;
+    for byte in peer_id.0.as_bytes() {
+        hash ^= u32::from(*byte);
+        hash = hash.wrapping_mul(0x0100_0193);
+    }
+    hash
 }
 
 // ---------------------------------------------------------------------------
@@ -175,7 +193,7 @@ impl PeerActor {
 
 impl PeerActor {
     pub async fn run(mut self) {
-        let mut backoff = Backoff::new();
+        let mut backoff = Backoff::new(backoff_seed(&self.peer_id));
 
         loop {
             // ---- Attempt connect ----
@@ -458,16 +476,27 @@ impl PeerActor {
 
     /// Durable-first fan-out: await on the log sink (must not drop),
     /// then broadcast (lossy, slow subscribers skip).
+    ///
+    /// Streaming `Message { partial: true }` deltas stay off the durable
+    /// log: the final message carries the complete text, so logging every
+    /// delta stored the streamed output twice and made `peers.jsonl` grow
+    /// at model-streaming rate (≤25 Hz per busy peer session) instead of
+    /// the "few hundred events per minute" its writer was sized for. Live
+    /// consumers still get every partial via the broadcast. Elided
+    /// partials still advance `seq`, so a gap in the log's sequence marks
+    /// exactly where deltas were skipped.
     async fn emit_event(&mut self, event: PeerEvent) {
         self.seq = self.seq.saturating_add(1);
-        let tagged = TaggedPeerEvent {
-            peer: self.peer_id.clone(),
-            payload: event.clone(),
-            seq: self.seq,
-        };
-        // Durable sink: await. If closed, the log writer is gone
-        // (process shutdown) and we drop silently.
-        let _ = self.log_sink.send(tagged).await;
+        if !matches!(&event, PeerEvent::Message { partial: true, .. }) {
+            let tagged = TaggedPeerEvent {
+                peer: self.peer_id.clone(),
+                payload: event.clone(),
+                seq: self.seq,
+            };
+            // Durable sink: await. If closed, the log writer is gone
+            // (process shutdown) and we drop silently.
+            let _ = self.log_sink.send(tagged).await;
+        }
         // Broadcast: non-blocking. Err means no subscribers — that's
         // fine, we still wrote to the durable sink.
         let _ = self.events_out_tx.send(event);
@@ -485,7 +514,7 @@ mod tests {
 
     #[test]
     fn backoff_resets() {
-        let mut b = Backoff::new();
+        let mut b = Backoff::new(0);
         let _ = b.next_delay();
         let _ = b.next_delay();
         let _ = b.next_delay();
@@ -498,7 +527,7 @@ mod tests {
 
     #[test]
     fn backoff_caps_at_max() {
-        let mut b = Backoff::new();
+        let mut b = Backoff::new(7);
         // Burn a generous number of attempts to ensure we saturate.
         for _ in 0..20 {
             let _ = b.next_delay();
@@ -512,14 +541,33 @@ mod tests {
 
     #[test]
     fn backoff_initial_delay_is_jittered_but_bounded() {
-        let mut b = Backoff::new();
-        let d = b.next_delay();
-        // First delay should be within ±20% of INITIAL_BACKOFF.
-        let min = INITIAL_BACKOFF * 80 / 100;
-        let max = INITIAL_BACKOFF * 120 / 100;
+        for seed in [0, 1, 19, u32::MAX] {
+            let mut b = Backoff::new(seed);
+            let d = b.next_delay();
+            // First delay should be within ±20% of INITIAL_BACKOFF.
+            let min = INITIAL_BACKOFF * 80 / 100;
+            let max = INITIAL_BACKOFF * 120 / 100;
+            assert!(
+                d >= min && d <= max,
+                "seed {seed}: got {d:?}, expected between {min:?} and {max:?}"
+            );
+        }
+    }
+
+    /// Distinct peers must not share a reconnect phase (the thundering
+    /// herd this seed exists to break): different ids yield different
+    /// first-attempt delays for at least some pair.
+    #[test]
+    fn backoff_seed_decorrelates_actors() {
+        let delays: std::collections::HashSet<Duration> = (0..8)
+            .map(|i| {
+                let id = PeerId::new(crate::peer::id::PeerKind::Intendant, &format!("peer-{i}"));
+                Backoff::new(backoff_seed(&id)).next_delay()
+            })
+            .collect();
         assert!(
-            d >= min && d <= max,
-            "got {d:?}, expected between {min:?} and {max:?}"
+            delays.len() > 1,
+            "eight distinct peer ids produced one shared delay schedule"
         );
     }
 }

--- a/src/bin/caller/peer/handle.rs
+++ b/src/bin/caller/peer/handle.rs
@@ -937,6 +937,7 @@ where
         receipts_tx,
         receipts: HashMap::new(),
         receipt_order: std::collections::VecDeque::new(),
+        pending_partials: HashMap::new(),
         seq: 0,
         via_urls,
         label_override,

--- a/src/bin/caller/peer/handle.rs
+++ b/src/bin/caller/peer/handle.rs
@@ -938,6 +938,7 @@ where
         receipts: HashMap::new(),
         receipt_order: std::collections::VecDeque::new(),
         pending_partials: HashMap::new(),
+        pending_partial_order: std::collections::VecDeque::new(),
         seq: 0,
         via_urls,
         label_override,

--- a/src/bin/caller/peer/log_writer.rs
+++ b/src/bin/caller/peer/log_writer.rs
@@ -48,6 +48,14 @@ use tokio::task::JoinHandle;
 /// limit.
 pub const LOG_CHANNEL_CAPACITY: usize = 2048;
 
+/// Rotate the log once it grows past this size; the previous file is
+/// kept as `<name>.1` (one generation), so the durable record is
+/// bounded at roughly twice this figure instead of growing for the
+/// daemon's lifetime. A long-lived daemon federated with busy peers
+/// otherwise accretes an unbounded `peers.jsonl` (this box has had a
+/// disk-pressure incident).
+pub const LOG_ROTATE_BYTES: u64 = 64 * 1024 * 1024;
+
 /// Spawn the peer log writer task and return the input channel
 /// plus a join handle.
 ///
@@ -62,11 +70,33 @@ pub const LOG_CHANNEL_CAPACITY: usize = 2048;
 /// actors) causes the writer task to drain the channel and exit.
 pub fn spawn_peer_log_writer(log_path: PathBuf) -> (mpsc::Sender<TaggedPeerEvent>, JoinHandle<()>) {
     let (tx, rx) = mpsc::channel::<TaggedPeerEvent>(LOG_CHANNEL_CAPACITY);
-    let handle = tokio::spawn(run_writer(log_path, rx));
+    let handle = tokio::spawn(run_writer(log_path, rx, LOG_ROTATE_BYTES));
     (tx, handle)
 }
 
-async fn run_writer(log_path: PathBuf, mut rx: mpsc::Receiver<TaggedPeerEvent>) {
+/// Open the log for append and report its current size (the rotation
+/// accumulator's starting point across daemon restarts).
+async fn open_log(log_path: &PathBuf) -> Option<(BufWriter<tokio::fs::File>, u64)> {
+    let file = match OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .await
+    {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!(
+                "peer log writer: failed to open {}: {e}",
+                log_path.display()
+            );
+            return None;
+        }
+    };
+    let len = file.metadata().await.map(|m| m.len()).unwrap_or(0);
+    Some((BufWriter::new(file), len))
+}
+
+async fn run_writer(log_path: PathBuf, mut rx: mpsc::Receiver<TaggedPeerEvent>, rotate_bytes: u64) {
     // Ensure the parent directory exists before the append open.
     // Failing to create it is the same failure class as failing to
     // open the file, so we report and exit.
@@ -80,22 +110,9 @@ async fn run_writer(log_path: PathBuf, mut rx: mpsc::Receiver<TaggedPeerEvent>) 
         }
     }
 
-    let file = match OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&log_path)
-        .await
-    {
-        Ok(f) => f,
-        Err(e) => {
-            eprintln!(
-                "peer log writer: failed to open {}: {e}",
-                log_path.display()
-            );
-            return;
-        }
+    let Some((mut writer, mut written)) = open_log(&log_path).await else {
+        return;
     };
-    let mut writer = BufWriter::new(file);
 
     while let Some(event) = rx.recv().await {
         let line = match serde_json::to_string(&event) {
@@ -123,11 +140,45 @@ async fn run_writer(log_path: PathBuf, mut rx: mpsc::Receiver<TaggedPeerEvent>) 
             eprintln!("peer log writer: flush failed, shutting down");
             return;
         }
+        written = written.saturating_add(line.len() as u64 + 1);
+
+        // Size-based rotation: shift the full file to `<name>.1`
+        // (replacing the previous generation) and start fresh. On any
+        // rotation error, keep appending to the current file — losing
+        // rotation is recoverable, losing events is not.
+        if written >= rotate_bytes {
+            drop(writer);
+            let rotated = rotated_path(&log_path);
+            // Windows rename refuses to replace an existing file;
+            // removing first keeps the behavior uniform.
+            let _ = tokio::fs::remove_file(&rotated).await;
+            if let Err(e) = tokio::fs::rename(&log_path, &rotated).await {
+                eprintln!(
+                    "peer log writer: rotate {} -> {} failed: {e}",
+                    log_path.display(),
+                    rotated.display()
+                );
+            }
+            match open_log(&log_path).await {
+                Some((reopened, len)) => {
+                    writer = reopened;
+                    written = len;
+                }
+                None => return,
+            }
+        }
     }
 
     // Channel closed: all peer actors + the registry have dropped
     // their senders. Final flush on shutdown.
     let _ = writer.flush().await;
+}
+
+/// `peers.jsonl` -> `peers.jsonl.1`.
+fn rotated_path(log_path: &std::path::Path) -> PathBuf {
+    let mut name = log_path.file_name().unwrap_or_default().to_os_string();
+    name.push(".1");
+    log_path.with_file_name(name)
 }
 
 #[cfg(test)]
@@ -296,5 +347,54 @@ mod tests {
     #[test]
     fn channel_capacity_is_nonzero() {
         assert!(LOG_CHANNEL_CAPACITY > 0);
+    }
+
+    /// Crossing the size cap shifts the log to `<name>.1` and starts
+    /// fresh: the live file stays bounded, the previous generation is
+    /// retained, no event is lost across the boundary, and every
+    /// surviving line is intact JSONL.
+    #[tokio::test]
+    async fn rotates_log_at_size_cap() {
+        let dir = TempDir::new().unwrap();
+        let log_path = dir.path().join("peers.jsonl");
+        let (tx, rx) = mpsc::channel::<TaggedPeerEvent>(LOG_CHANNEL_CAPACITY);
+        let rotate_bytes: u64 = 1024;
+        let handle = tokio::spawn(run_writer(log_path.clone(), rx, rotate_bytes));
+        for seq in 1..=40 {
+            tx.send(make_event(seq, PeerStatus::Idle)).await.unwrap();
+        }
+        drop(tx);
+        timeout(Duration::from_secs(5), handle)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let rotated = rotated_path(&log_path);
+        assert!(rotated.exists(), "size cap must produce {rotated:?}");
+
+        // Only the newest two generations survive by design; the newest
+        // event must be present and every surviving line must parse.
+        let mut max_seq = 0;
+        for path in [&rotated, &log_path] {
+            let Ok(contents) = tokio::fs::read_to_string(path).await else {
+                continue;
+            };
+            for line in contents.lines() {
+                let parsed: TaggedPeerEvent = serde_json::from_str(line).unwrap();
+                max_seq = max_seq.max(parsed.seq);
+            }
+        }
+        assert_eq!(max_seq, 40, "the newest event survives rotation");
+
+        // The live file restarted below the cap (bounded by one line of
+        // overshoot at most).
+        let live_len = tokio::fs::metadata(&log_path)
+            .await
+            .map(|m| m.len())
+            .unwrap_or(0);
+        assert!(
+            live_len <= rotate_bytes + 256,
+            "live log stays bounded, got {live_len} bytes"
+        );
     }
 }

--- a/src/bin/caller/peer/mcp_http.rs
+++ b/src/bin/caller/peer/mcp_http.rs
@@ -20,7 +20,7 @@
 use super::card::{AgentCard, McpTransportKind, TransportSpec};
 use super::handle::PeerHandle;
 use super::transport::intendant::{PEER_CLIENT_HEADER, PEER_CLIENT_HEADER_VALUE};
-use super::transport::{tls_client, ws_url_to_http_base};
+use super::transport::ws_url_to_http_base;
 use std::time::Duration;
 
 /// Ceiling for one peer tool round-trip. Generous because
@@ -95,12 +95,14 @@ pub async fn call_peer_mcp_tool(
         )
     })?;
     let creds = handle.transport_credentials();
-    let client = tls_client::reqwest_client(
-        PEER_MCP_TIMEOUT,
-        &creds.pinned_fingerprints,
-        creds.client_identity.as_ref(),
-    )
-    .map_err(|e| format!("build peer http client: {e}"))?;
+    // Shared with the transport's card fetch: one pooled client per
+    // credentials bundle, so a CU loop's dozens of tool calls reuse the
+    // TCP+TLS connection instead of a fresh handshake (and root-store
+    // load) per call.
+    let client = creds
+        .tls
+        .http_client(&creds.pinned_fingerprints, creds.client_identity.as_ref())
+        .map_err(|e| format!("build peer http client: {e}"))?;
     let body = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 1,
@@ -112,6 +114,7 @@ pub async fn call_peer_mcp_tool(
     // downgrade to the anonymous path.
     let mut request = client
         .post(&endpoint)
+        .timeout(PEER_MCP_TIMEOUT)
         .header(PEER_CLIENT_HEADER, PEER_CLIENT_HEADER_VALUE)
         .json(&body);
     if let Some(token) = &creds.bearer_token {

--- a/src/bin/caller/peer/registry.rs
+++ b/src/bin/caller/peer/registry.rs
@@ -456,14 +456,18 @@ impl PeerRegistry {
         let log_sink = self.inner.log_sink.clone();
 
         // Retained on the handle for gateway HTTP side-channels (e.g.
-        // POST /mcp): the same bundle the transports below are built
-        // from, so both paths present one identity to the peer.
+        // POST /mcp): the transports below are built from CLONES of this
+        // same bundle, so both paths present one identity to the peer AND
+        // share one TlsClientCache cell (clones share the Arc) — the card
+        // fetch, the WS connect, and /mcp calls reuse the same built TLS
+        // material.
         let transport_credentials = crate::peer::transport::intendant::TransportCredentials {
-            bearer_token: bearer_token.clone(),
-            pinned_fingerprints: pinned_fingerprints.clone(),
-            client_identity: client_identity.clone(),
+            bearer_token,
+            pinned_fingerprints,
+            client_identity,
             tls: Default::default(),
         };
+        let transport_factory_credentials = transport_credentials.clone();
 
         let handle = spawn_peer(
             peer_id.clone(),
@@ -475,18 +479,16 @@ impl PeerRegistry {
             log_sink,
             move |events_tx| {
                 // Build one concrete transport per supported spec (each
-                // gets its own clone of `events_tx`, `bearer_token`,
-                // `pinned_fingerprints`, and `client_identity`) and wrap them in a
-                // `MultiTransport` that probes them in order on connect.
+                // gets its own clone of `events_tx` and of the shared
+                // credentials bundle) and wrap them in a `MultiTransport`
+                // that probes them in order on connect.
                 let candidates: Vec<Box<dyn crate::peer::traits::PeerTransport>> = supported_specs
                     .iter()
                     .map(|spec| {
                         build_transport(
                             spec,
                             events_tx.clone(),
-                            bearer_token.clone(),
-                            pinned_fingerprints.clone(),
-                            client_identity.clone(),
+                            transport_factory_credentials.clone(),
                         )
                     })
                     .collect();
@@ -703,20 +705,13 @@ fn pick_supported_transports(transports: &[TransportSpec]) -> Vec<TransportSpec>
 fn build_transport(
     spec: &TransportSpec,
     events_tx: mpsc::Sender<crate::peer::event::PeerEvent>,
-    bearer_token: Option<String>,
-    pinned_fingerprints: Vec<crate::peer::transport::pinning::Fingerprint>,
-    client_identity: Option<ClientIdentityPaths>,
+    credentials: crate::peer::transport::intendant::TransportCredentials,
 ) -> Box<dyn crate::peer::traits::PeerTransport> {
     match spec {
         TransportSpec::IntendantWs { url } => Box::new(IntendantWsTransport::with_credentials(
             url.clone(),
             events_tx,
-            crate::peer::transport::intendant::TransportCredentials {
-                bearer_token,
-                pinned_fingerprints,
-                client_identity,
-                tls: Default::default(),
-            },
+            credentials,
         )),
         other => {
             // Should be unreachable: `pick_supported_transports`

--- a/src/bin/caller/peer/registry.rs
+++ b/src/bin/caller/peer/registry.rs
@@ -462,6 +462,7 @@ impl PeerRegistry {
             bearer_token: bearer_token.clone(),
             pinned_fingerprints: pinned_fingerprints.clone(),
             client_identity: client_identity.clone(),
+            tls: Default::default(),
         };
 
         let handle = spawn_peer(
@@ -714,6 +715,7 @@ fn build_transport(
                 bearer_token,
                 pinned_fingerprints,
                 client_identity,
+                tls: Default::default(),
             },
         )),
         other => {

--- a/src/bin/caller/peer/transport/intendant.rs
+++ b/src/bin/caller/peer/transport/intendant.rs
@@ -184,6 +184,13 @@ pub struct TransportCredentials {
     /// can satisfy the same mTLS gate as browsers without a dashboard-only
     /// bearer token.
     pub client_identity: Option<ClientIdentityPaths>,
+    /// Lazily built TLS material (rustls config + pooled HTTP client) for
+    /// the fields above, shared across clones — the card fetch, the WS
+    /// connect, and `/mcp` side-channel calls reuse it instead of
+    /// re-reading PEMs and the native root store per attempt. Freshness is
+    /// stat-checked, so certificate rotation still applies on the next
+    /// use. See [`super::tls_client::TlsClientCache`].
+    pub tls: super::tls_client::TlsClientCache,
 }
 
 impl IntendantWsTransport {
@@ -227,6 +234,7 @@ impl IntendantWsTransport {
                 bearer_token,
                 pinned_fingerprints: Vec::new(),
                 client_identity: None,
+                tls: Default::default(),
             },
         )
     }
@@ -275,14 +283,14 @@ impl IntendantWsTransport {
         let http_base = super::ws_url_to_http_base(&ws_url);
         let card_url = format!("{http_base}/.well-known/agent-card.json");
 
-        let client = super::tls_client::reqwest_client(
-            CARD_FETCH_TIMEOUT,
+        let client = self.creds.tls.http_client(
             &self.creds.pinned_fingerprints,
             self.creds.client_identity.as_ref(),
         )?;
 
         let mut request = client
             .get(&card_url)
+            .timeout(CARD_FETCH_TIMEOUT)
             .header(PEER_CLIENT_HEADER, PEER_CLIENT_HEADER_VALUE);
         if let Some(token) = &self.creds.bearer_token {
             request = request.bearer_auth(token);
@@ -353,11 +361,14 @@ impl IntendantWsTransport {
                 .expect("static header value"),
         );
 
-        let connector: Option<Connector> = super::tls_client::rustls_client_config(
-            &self.creds.pinned_fingerprints,
-            self.creds.client_identity.as_ref(),
-        )?
-        .map(|config| Connector::Rustls(std::sync::Arc::new(config)));
+        let connector: Option<Connector> = self
+            .creds
+            .tls
+            .client_config(
+                &self.creds.pinned_fingerprints,
+                self.creds.client_identity.as_ref(),
+            )?
+            .map(Connector::Rustls);
 
         let (ws_stream, _response) =
             tokio_tungstenite::connect_async_tls_with_config(request, None, false, connector)
@@ -433,15 +444,21 @@ async fn drain_ws(
                 // upcaster so folded session snapshots can stamp
                 // `is_primary` (renderers merge that session into the peer
                 // node instead of drawing it twice).
+                //
+                // The `contains` checks are cheap prefilters only; a frame
+                // is swallowed as a bootstrap frame ONLY when its parsed
+                // top-level `t` actually matches. (An earlier unconditional
+                // `continue` here silently dropped any OutboundEvent whose
+                // nested payload happened to contain these literals.)
                 if text.contains("\"t\":\"state_snapshot\"") {
                     if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
                         if value["t"] == "state_snapshot" {
                             if let Some(sid) = value["session_id"].as_str() {
                                 upcaster.set_primary_session_id(sid);
                             }
+                            continue;
                         }
                     }
-                    continue;
                 }
                 // The bootstrap `log_replay` frame carries the peer's recent
                 // outbound history. Fold its session-state effects through
@@ -467,9 +484,9 @@ async fn drain_ws(
                                     }
                                 }
                             }
+                            continue;
                         }
                     }
-                    continue;
                 }
                 // Forward-compat via OutboundEvent::Unknown: unknown
                 // event variants deserialize silently and the upcaster

--- a/src/bin/caller/peer/transport/tls_client.rs
+++ b/src/bin/caller/peer/transport/tls_client.rs
@@ -119,18 +119,19 @@ fn load_client_identity(
 /// the PEMs (and, on the no-pin path, the whole native root store) per
 /// connect attempt.
 ///
-/// Same identity vocabulary as the peer-record cache
-/// (`access_policy::PeerRecordFingerprint`): certificate writes replace
-/// files atomically, so a fresh `(dev, ino)` distinguishes a
-/// same-length, timestamp-preserving replacement (`cp -p` rollback,
-/// same-granule rewrite) that length+mtime alone would miss;
-/// nanosecond mtime and length are the portable fallback.
+/// Same identity vocabulary as the repo's file-identity callers
+/// ([`crate::platform::FileIdentity`]): certificate writes replace files
+/// atomically, so a fresh identity — Unix `(dev, ino)`, Windows volume
+/// serial + 64-bit file index — distinguishes a same-length,
+/// timestamp-preserving replacement (`cp -p` rollback, same-granule
+/// rewrite) that length+mtime alone would miss ON EVERY PLATFORM;
+/// nanosecond mtime and length are the fallback where no reliable
+/// identity exists (`identity: None` compares equal to itself only).
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct FileStamp {
     len: u64,
     mtime_nanos: u128,
-    dev: u64,
-    ino: u64,
+    identity: Option<crate::platform::FileIdentity>,
 }
 
 fn file_stamp(path: &std::path::Path) -> Option<FileStamp> {
@@ -138,18 +139,22 @@ fn file_stamp(path: &std::path::Path) -> Option<FileStamp> {
     if !metadata.is_file() {
         return None;
     }
-    let (dev, ino) = crate::platform::metadata_dev_ino(&metadata);
     let mtime_nanos = metadata
         .modified()
         .ok()
         .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|duration| duration.as_nanos())
         .unwrap_or(0);
+    // Unix reads the identity off the metadata already in hand; Windows
+    // needs an open handle (`from_path`). An unavailable or unreliable
+    // identity stores `None` — the len+mtime fallback.
+    let identity = crate::platform::FileIdentity::from_metadata(&metadata)
+        .or_else(|| crate::platform::FileIdentity::from_path(path).ok())
+        .filter(|identity| identity.is_reliable());
     Some(FileStamp {
         len: metadata.len(),
         mtime_nanos,
-        dev,
-        ino,
+        identity,
     })
 }
 
@@ -375,11 +380,27 @@ mod tests {
 
     /// An atomic certificate replacement that preserves BOTH length and
     /// mtime (a `cp -p`-style rollback, a same-granule rewrite) must
-    /// still invalidate the cache: the fresh inode is the discriminator
-    /// (`PeerRecordFingerprint`'s identity vocabulary).
+    /// still invalidate the cache: the fresh file identity is the
+    /// discriminator — Unix `(dev, ino)`, Windows volume serial + file
+    /// index (`FileIdentity`).
     #[cfg(unix)]
     #[test]
     fn tls_cache_detects_same_length_preserved_mtime_rotation() {
+        same_length_preserved_mtime_rotation_rebuilds();
+    }
+
+    /// Windows mirror of the rotation test: the merge group runs full
+    /// tests on the Windows leg, and `metadata_dev_ino`'s degenerate
+    /// `(0, 0)` there was exactly the gap — `FileIdentity` carries the
+    /// volume serial + file index instead.
+    #[cfg(windows)]
+    #[test]
+    fn tls_cache_detects_same_length_preserved_mtime_rotation_windows() {
+        same_length_preserved_mtime_rotation_rebuilds();
+    }
+
+    #[cfg(any(unix, windows))]
+    fn same_length_preserved_mtime_rotation_rebuilds() {
         let dir = tempfile::tempdir().unwrap();
         let names = crate::access::certs::ServerNames::new(
             "127.0.0.1".parse().unwrap(),

--- a/src/bin/caller/peer/transport/tls_client.rs
+++ b/src/bin/caller/peer/transport/tls_client.rs
@@ -113,22 +113,43 @@ fn load_client_identity(
     })
 }
 
-/// Stat fingerprint (length + mtime) of one PEM file — the freshness probe
-/// for [`TlsClientCache`], so a re-issued `client.crt`/`client.key` is
-/// picked up on the next use for two stats instead of re-reading and
-/// re-parsing the PEMs (and, on the no-pin path, the whole native root
-/// store) per connect attempt.
+/// Stat fingerprint of one PEM file — the freshness probe for
+/// [`TlsClientCache`], so a re-issued `client.crt`/`client.key` is picked
+/// up on the next use for two stats instead of re-reading and re-parsing
+/// the PEMs (and, on the no-pin path, the whole native root store) per
+/// connect attempt.
+///
+/// Same identity vocabulary as the peer-record cache
+/// (`access_policy::PeerRecordFingerprint`): certificate writes replace
+/// files atomically, so a fresh `(dev, ino)` distinguishes a
+/// same-length, timestamp-preserving replacement (`cp -p` rollback,
+/// same-granule rewrite) that length+mtime alone would miss;
+/// nanosecond mtime and length are the portable fallback.
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct FileStamp {
     len: u64,
-    modified: Option<std::time::SystemTime>,
+    mtime_nanos: u128,
+    dev: u64,
+    ino: u64,
 }
 
 fn file_stamp(path: &std::path::Path) -> Option<FileStamp> {
     let metadata = std::fs::metadata(path).ok()?;
+    if !metadata.is_file() {
+        return None;
+    }
+    let (dev, ino) = crate::platform::metadata_dev_ino(&metadata);
+    let mtime_nanos = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
     Some(FileStamp {
         len: metadata.len(),
-        modified: metadata.modified().ok(),
+        mtime_nanos,
+        dev,
+        ino,
     })
 }
 
@@ -350,5 +371,59 @@ mod tests {
         assert!(cache.client_config(&[], None).unwrap().is_none());
         let _client = cache.http_client(&[], None).unwrap();
         assert!(cache.client_config(&[], None).unwrap().is_none());
+    }
+
+    /// An atomic certificate replacement that preserves BOTH length and
+    /// mtime (a `cp -p`-style rollback, a same-granule rewrite) must
+    /// still invalidate the cache: the fresh inode is the discriminator
+    /// (`PeerRecordFingerprint`'s identity vocabulary).
+    #[cfg(unix)]
+    #[test]
+    fn tls_cache_detects_same_length_preserved_mtime_rotation() {
+        let dir = tempfile::tempdir().unwrap();
+        let names = crate::access::certs::ServerNames::new(
+            "127.0.0.1".parse().unwrap(),
+            Vec::<std::net::IpAddr>::new(),
+            Vec::<String>::new(),
+        )
+        .unwrap();
+        crate::access::certs::ensure_certs(dir.path(), &names, "peer-client-inode-test", false)
+            .unwrap();
+        let identity = ClientIdentityPaths {
+            cert_path: dir.path().join("client.crt"),
+            key_path: dir.path().join("client.key"),
+        };
+        let pins = [[0u8; 32]];
+        let cache = TlsClientCache::default();
+        let first = cache
+            .client_config(&pins, Some(&identity))
+            .unwrap()
+            .expect("pinned + identity builds a config");
+
+        // Stage identical bytes, copy the original mtime onto them, then
+        // rename over the original: same length, same mtime, new inode.
+        let original = std::fs::read(&identity.cert_path).unwrap();
+        let mtime = std::fs::metadata(&identity.cert_path)
+            .unwrap()
+            .modified()
+            .unwrap();
+        let staged = identity.cert_path.with_extension("crt.staged");
+        std::fs::write(&staged, &original).unwrap();
+        let staged_file = std::fs::File::options().write(true).open(&staged).unwrap();
+        staged_file.set_modified(mtime).unwrap();
+        drop(staged_file);
+        std::fs::rename(&staged, &identity.cert_path).unwrap();
+        let after = std::fs::metadata(&identity.cert_path).unwrap();
+        assert_eq!(after.len() as usize, original.len());
+        assert_eq!(after.modified().unwrap(), mtime);
+
+        let rotated = cache
+            .client_config(&pins, Some(&identity))
+            .unwrap()
+            .expect("rebuilt config after replacement");
+        assert!(
+            !Arc::ptr_eq(&first, &rotated),
+            "a same-length, mtime-preserved replacement must rebuild the config"
+        );
     }
 }

--- a/src/bin/caller/peer/transport/tls_client.rs
+++ b/src/bin/caller/peer/transport/tls_client.rs
@@ -113,6 +113,140 @@ fn load_client_identity(
     })
 }
 
+/// Stat fingerprint (length + mtime) of one PEM file — the freshness probe
+/// for [`TlsClientCache`], so a re-issued `client.crt`/`client.key` is
+/// picked up on the next use for two stats instead of re-reading and
+/// re-parsing the PEMs (and, on the no-pin path, the whole native root
+/// store) per connect attempt.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct FileStamp {
+    len: u64,
+    modified: Option<std::time::SystemTime>,
+}
+
+fn file_stamp(path: &std::path::Path) -> Option<FileStamp> {
+    let metadata = std::fs::metadata(path).ok()?;
+    Some(FileStamp {
+        len: metadata.len(),
+        modified: metadata.modified().ok(),
+    })
+}
+
+/// Lazily built, shared client-side TLS material for one credentials
+/// bundle (see `TransportCredentials.tls`).
+///
+/// Before this cache, every transport `connect()` built the rustls
+/// `ClientConfig` twice (agent-card fetch + WebSocket open) — re-reading
+/// the client PEMs and, without pinning, loading and parsing the entire
+/// native OS root store — and every peer MCP tool call built a fresh
+/// `reqwest::Client` on top (a full TCP+TLS handshake per call, zero
+/// keep-alive). Clones share the cell, so the card fetch, the WS connect,
+/// and `/mcp` side-channel calls reuse one config and one pooled HTTP
+/// client.
+///
+/// Freshness: the entry revalidates the identity PEMs by stat fingerprint
+/// on every use and the pin list by equality, so certificate rotation
+/// rebuilds on the next call; entries whose PEMs cannot be stat'ed are
+/// never considered fresh (today's rebuild-every-time behavior).
+#[derive(Clone, Debug, Default)]
+pub struct TlsClientCache(Arc<std::sync::Mutex<Option<TlsCacheEntry>>>);
+
+#[derive(Debug)]
+struct TlsCacheEntry {
+    pins: Vec<Fingerprint>,
+    /// Identity paths plus the (cert, key) stamps captured at build time.
+    identity: Option<(ClientIdentityPaths, Option<FileStamp>, Option<FileStamp>)>,
+    /// `None` = neither pinning nor client auth: WS callers use their
+    /// library's default TLS connector, exactly as before.
+    config: Option<Arc<rustls::ClientConfig>>,
+    /// Pooled HTTP client over `config` (or the library default). No
+    /// client-level timeout — callers set per-request timeouts.
+    http_client: reqwest::Client,
+}
+
+impl TlsCacheEntry {
+    fn is_fresh(&self, pins: &[Fingerprint], identity: Option<&ClientIdentityPaths>) -> bool {
+        if self.pins != pins {
+            return false;
+        }
+        match (&self.identity, identity) {
+            (None, None) => true,
+            (Some((paths, cert_stamp, key_stamp)), Some(current)) => {
+                paths == current
+                    && cert_stamp
+                        .as_ref()
+                        .is_some_and(|stamp| file_stamp(&paths.cert_path).as_ref() == Some(stamp))
+                    && key_stamp
+                        .as_ref()
+                        .is_some_and(|stamp| file_stamp(&paths.key_path).as_ref() == Some(stamp))
+            }
+            _ => false,
+        }
+    }
+}
+
+impl TlsClientCache {
+    /// The rustls config for WebSocket connects: `None` when neither
+    /// pinning nor client auth is configured (use the library default).
+    pub fn client_config(
+        &self,
+        pinned_fingerprints: &[Fingerprint],
+        client_identity: Option<&ClientIdentityPaths>,
+    ) -> Result<Option<Arc<rustls::ClientConfig>>, PeerError> {
+        Ok(self.entry(pinned_fingerprints, client_identity)?.0)
+    }
+
+    /// The pooled HTTP client on the same trust policy. Callers set
+    /// per-request timeouts (`RequestBuilder::timeout`).
+    pub fn http_client(
+        &self,
+        pinned_fingerprints: &[Fingerprint],
+        client_identity: Option<&ClientIdentityPaths>,
+    ) -> Result<reqwest::Client, PeerError> {
+        Ok(self.entry(pinned_fingerprints, client_identity)?.1)
+    }
+
+    fn entry(
+        &self,
+        pins: &[Fingerprint],
+        identity: Option<&ClientIdentityPaths>,
+    ) -> Result<(Option<Arc<rustls::ClientConfig>>, reqwest::Client), PeerError> {
+        {
+            let cached = self.0.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(entry) = cached.as_ref() {
+                if entry.is_fresh(pins, identity) {
+                    return Ok((entry.config.clone(), entry.http_client.clone()));
+                }
+            }
+        }
+        // Build outside the lock; a racing rebuild is harmless (last
+        // writer wins, both entries are valid for the same inputs).
+        let identity_stamps = identity.map(|paths| {
+            (
+                paths.clone(),
+                file_stamp(&paths.cert_path),
+                file_stamp(&paths.key_path),
+            )
+        });
+        let config = rustls_client_config(pins, identity)?.map(Arc::new);
+        let mut builder = reqwest::Client::builder();
+        if let Some(config) = &config {
+            builder = builder.use_preconfigured_tls(rustls::ClientConfig::clone(config));
+        }
+        let http_client = builder
+            .build()
+            .map_err(|e| PeerError::CardFetch(format!("build http client: {e}")))?;
+        let entry = TlsCacheEntry {
+            pins: pins.to_vec(),
+            identity: identity_stamps,
+            config: config.clone(),
+            http_client: http_client.clone(),
+        };
+        *self.0.lock().unwrap_or_else(|e| e.into_inner()) = Some(entry);
+        Ok((config, http_client))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -149,5 +283,72 @@ mod tests {
         let config = rustls_client_config(&[[0u8; 32]], Some(&identity));
         assert!(config.is_ok(), "config should build: {:?}", config.err());
         assert!(config.unwrap().is_some());
+    }
+
+    /// The cache reuses one built config across calls (pointer-equal Arc)
+    /// and rebuilds when the identity PEMs change on disk (certificate
+    /// rotation) or the pin set differs.
+    #[test]
+    fn tls_cache_reuses_config_until_identity_rotates() {
+        let dir = tempfile::tempdir().unwrap();
+        let names = crate::access::certs::ServerNames::new(
+            "127.0.0.1".parse().unwrap(),
+            Vec::<std::net::IpAddr>::new(),
+            Vec::<String>::new(),
+        )
+        .unwrap();
+        crate::access::certs::ensure_certs(dir.path(), &names, "peer-client-cache-test", false)
+            .unwrap();
+        let identity = ClientIdentityPaths {
+            cert_path: dir.path().join("client.crt"),
+            key_path: dir.path().join("client.key"),
+        };
+        let pins = [[0u8; 32]];
+
+        let cache = TlsClientCache::default();
+        let first = cache
+            .client_config(&pins, Some(&identity))
+            .unwrap()
+            .expect("pinned + identity builds a config");
+        let second = cache
+            .client_config(&pins, Some(&identity))
+            .unwrap()
+            .expect("cached config");
+        assert!(
+            Arc::ptr_eq(&first, &second),
+            "unchanged identity must reuse the built config"
+        );
+
+        // A different pin set never reuses the entry.
+        let other_pins = [[1u8; 32]];
+        let repinned = cache
+            .client_config(&other_pins, Some(&identity))
+            .unwrap()
+            .expect("rebuilt config");
+        assert!(!Arc::ptr_eq(&first, &repinned));
+
+        // Rotate the cert on disk (appending keeps the PEM parseable but
+        // changes the stat fingerprint): the next call rebuilds.
+        let mut cert_pem = std::fs::read(&identity.cert_path).unwrap();
+        cert_pem.push(b'\n');
+        std::fs::write(&identity.cert_path, &cert_pem).unwrap();
+        let rotated = cache
+            .client_config(&pins, Some(&identity))
+            .unwrap()
+            .expect("rebuilt config after rotation");
+        assert!(
+            !Arc::ptr_eq(&first, &rotated),
+            "a rotated identity must rebuild the config"
+        );
+    }
+
+    /// The unpinned, identity-less shape stays `None` (library default
+    /// TLS) through the cache, and the pooled HTTP client still builds.
+    #[test]
+    fn tls_cache_default_policy_yields_no_config_and_a_client() {
+        let cache = TlsClientCache::default();
+        assert!(cache.client_config(&[], None).unwrap().is_none());
+        let _client = cache.http_client(&[], None).unwrap();
+        assert!(cache.client_config(&[], None).unwrap().is_none());
     }
 }

--- a/src/bin/caller/peer_file_transfer.rs
+++ b/src/bin/caller/peer_file_transfer.rs
@@ -128,8 +128,12 @@ impl PeerFileTransferAuthorization {
 /// (the driver plus each spawned read stream) share the memo cell.
 ///
 /// Trust invariants (do not weaken):
-/// - Negative verdicts are never memoized — a failed check re-verifies
-///   fresh on every subsequent call.
+/// - The fresh check and the memo update are ATOMIC: the memo lock is
+///   held across the identity-store consult, so a preempted positive
+///   check can never stamp the memo after a newer negative observed the
+///   revocation.
+/// - A fresh negative CLEARS the memo — no stale positive survives a
+///   fresh failure, and negative verdicts are never memoized.
 /// - The request-authorization path ([`authorize_path`],
 ///   [`open_authorized_read_file`]) and the driver's authority tick call
 ///   [`Self::is_current_fresh`], so authorization decisions and the
@@ -141,7 +145,10 @@ impl PeerFileTransferAuthorization {
 struct LiveTransferAuthority {
     authorization: PeerFileTransferAuthorization,
     /// Instant of the last fresh **positive** verification, shared across
-    /// clones. `None` until first verified.
+    /// clones. `None` until first verified and after any fresh negative.
+    /// Fresh checks run UNDER this lock (see the atomicity invariant in
+    /// the type docs); they are low-frequency (250 ms tick + per-request
+    /// authorization), so serializing them here costs nothing.
     verified_at: Arc<std::sync::Mutex<Option<Instant>>>,
 }
 
@@ -154,26 +161,36 @@ impl LiveTransferAuthority {
     }
 
     /// Memoized liveness: reuse a positive verdict younger than
-    /// [`LIVE_TRANSFER_AUTHORITY_MEMO_TTL`], else verify fresh.
+    /// [`LIVE_TRANSFER_AUTHORITY_MEMO_TTL`], else verify fresh (under the
+    /// memo lock, like [`Self::is_current_fresh`]).
     fn is_current(&self) -> bool {
-        {
-            let verified_at = self.verified_at.lock().unwrap_or_else(|e| e.into_inner());
-            if let Some(at) = *verified_at {
-                if at.elapsed() < LIVE_TRANSFER_AUTHORITY_MEMO_TTL {
-                    return true;
-                }
+        let mut verified_at = self.verified_at.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(at) = *verified_at {
+            if at.elapsed() < LIVE_TRANSFER_AUTHORITY_MEMO_TTL {
+                return true;
             }
         }
-        self.is_current_fresh()
+        Self::refresh_locked(&self.authorization, &mut verified_at)
     }
 
-    /// Uncached liveness against the identity store; primes the memo on a
-    /// positive verdict only.
+    /// Uncached liveness against the identity store. Check and stamp are
+    /// one critical section: a positive primes the memo, a negative
+    /// clears it — a preempted stale positive can never re-prime the memo
+    /// after a newer negative.
     fn is_current_fresh(&self) -> bool {
-        let ok = self.authorization.is_current();
-        if ok {
-            *self.verified_at.lock().unwrap_or_else(|e| e.into_inner()) = Some(Instant::now());
-        }
+        let mut verified_at = self.verified_at.lock().unwrap_or_else(|e| e.into_inner());
+        Self::refresh_locked(&self.authorization, &mut verified_at)
+    }
+
+    /// The one fresh-check-and-stamp critical section (callers hold the
+    /// memo lock). Lock order is memo → identity-cache global lock; no
+    /// reverse path exists.
+    fn refresh_locked(
+        authorization: &PeerFileTransferAuthorization,
+        verified_at: &mut Option<Instant>,
+    ) -> bool {
+        let ok = authorization.is_current();
+        *verified_at = if ok { Some(Instant::now()) } else { None };
         ok
     }
 }
@@ -661,7 +678,22 @@ enum TransferCommand {
     AddIceCandidate(String),
     SendText(String),
     SendBinary(BytesMut),
-    ReadFinished(String),
+    /// Natural completion of the read stream spawned as `generation` —
+    /// the driver deregisters the entry only when the generation still
+    /// matches, so a finished superseded task can never evict its
+    /// replacement (which would leave an uncounted, uncancellable
+    /// stream defeating [`MAX_CONCURRENT_READS_PER_SESSION`]).
+    ReadFinished {
+        id: String,
+        generation: u64,
+    },
+}
+
+/// One tracked read stream: its cancel token plus the spawn generation
+/// that keys [`TransferCommand::ReadFinished`] deregistration.
+struct ActiveRead {
+    cancel: CancellationToken,
+    generation: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -735,7 +767,8 @@ async fn transfer_driver<I: rtc::interceptor::Interceptor + Send + Sync + 'stati
     }
 
     let mut channels: HashMap<String, rtc::data_channel::RTCDataChannelId> = HashMap::new();
-    let mut active_reads: HashMap<String, CancellationToken> = HashMap::new();
+    let mut active_reads: HashMap<String, ActiveRead> = HashMap::new();
+    let mut next_read_generation: u64 = 0;
     // True while the transfer channel's SCTP send buffer sits above the
     // high watermark: the command lane stops admitting work (chunks, text,
     // trickled candidates alike — FIFO order must hold anyway), the bounded
@@ -890,6 +923,10 @@ async fn transfer_driver<I: rtc::interceptor::Interceptor + Send + Sync + 'stati
             }
             // Gated on the SCTP send-buffer watermark: while paused, queued
             // commands wait in the bounded channel and the readers park.
+            // AddIceCandidate rides the same lane, so trickled candidates
+            // queue behind the pause too — incidental coupling, harmless
+            // today (candidates matter during setup, before bulk data can
+            // congest the channel; an established pair needs no new ones).
             Some(cmd) = command_rx.recv(), if !send_paused => {
                 if !authorization.is_current() {
                     shutdown.cancel();
@@ -914,8 +951,8 @@ async fn transfer_driver<I: rtc::interceptor::Interceptor + Send + Sync + 'stati
                     TransferCommand::SendBinary(bytes) => {
                         send_transfer_binary(&mut rtc, &channels, bytes);
                     }
-                    TransferCommand::ReadFinished(id) => {
-                        active_reads.remove(&id);
+                    TransferCommand::ReadFinished { id, generation } => {
+                        deregister_finished_read(&mut active_reads, &id, generation);
                     }
                 }
                 let _ = rtc.handle_timeout(Instant::now());
@@ -946,19 +983,25 @@ async fn transfer_driver<I: rtc::interceptor::Interceptor + Send + Sync + 'stati
                 shutdown.cancel();
                 break 'driver;
             }
-            handle_transfer_request(
+            if let Some(reply) = handle_transfer_request(
                 &session_id,
                 text,
                 &authorization,
                 &bus,
                 command_tx.clone(),
                 &mut active_reads,
-            );
+                &mut next_read_generation,
+            ) {
+                // Rejections bypass the (possibly watermark-paused) command
+                // lane: the driver owns the rtc right here, and a dropped
+                // rejection would leave the client waiting forever.
+                send_transfer_text(&mut rtc, &channels, reply);
+            }
         }
     }
 
-    for (_, token) in active_reads {
-        token.cancel();
+    for (_, read) in active_reads {
+        read.cancel.cancel();
     }
     for handle in forwarder_handles {
         let _ = handle.await;
@@ -1030,12 +1073,16 @@ async fn drain_transfer_outputs<I: rtc::interceptor::Interceptor>(
                     // tile-delta backpressure): the High event pauses the
                     // driver's command lane, Low resumes it.
                     if let Some(mut channel) = rtc.data_channel(cid) {
-                        channel.set_buffered_amount_high_threshold(watermark_to_u32(
-                            TRANSFER_BUFFERED_HIGH_WATERMARK_BYTES,
-                        ));
-                        channel.set_buffered_amount_low_threshold(watermark_to_u32(
-                            TRANSFER_BUFFERED_LOW_WATERMARK_BYTES,
-                        ));
+                        channel.set_buffered_amount_high_threshold(
+                            crate::dashboard_control::watermark_to_u32(
+                                TRANSFER_BUFFERED_HIGH_WATERMARK_BYTES,
+                            ),
+                        );
+                        channel.set_buffered_amount_low_threshold(
+                            crate::dashboard_control::watermark_to_u32(
+                                TRANSFER_BUFFERED_LOW_WATERMARK_BYTES,
+                            ),
+                        );
                     }
                     *send_paused = false;
                 }
@@ -1081,22 +1128,27 @@ async fn drain_transfer_outputs<I: rtc::interceptor::Interceptor>(
         .unwrap_or_else(|| Instant::now() + Duration::from_secs(86_400)))
 }
 
+/// Handle one inbound transfer request. Rejections come back as
+/// `Some(<error frame text>)` for the DRIVER to send directly over the
+/// datachannel — the command lane may be watermark-paused or full, and a
+/// `try_send` there dropped rejections exactly when the wire was busy.
+#[allow(clippy::too_many_arguments)] // established internal signature: the params are distinct dependencies, not a bundle
 fn handle_transfer_request(
     session_id: &str,
     text: &str,
     authorization: &LiveTransferAuthority,
     bus: &crate::event::EventBus,
     command_tx: mpsc::Sender<TransferCommand>,
-    active_reads: &mut HashMap<String, CancellationToken>,
-) {
+    active_reads: &mut HashMap<String, ActiveRead>,
+    next_read_generation: &mut u64,
+) -> Option<String> {
     let request = match serde_json::from_str::<TransferRequest>(text) {
         Ok(request) => request,
         Err(e) => {
-            let _ = command_tx.try_send(TransferCommand::SendText(
+            return Some(
                 serde_json::json!({"t": "error", "id": null, "error": format!("invalid request: {e}")})
                     .to_string(),
-            ));
-            return;
+            );
         }
     };
 
@@ -1108,10 +1160,10 @@ fn handle_transfer_request(
             length,
         } => {
             if let Some(old) = active_reads.remove(&id) {
-                old.cancel();
+                old.cancel.cancel();
             }
             if active_reads.len() >= MAX_CONCURRENT_READS_PER_SESSION {
-                let _ = command_tx.try_send(TransferCommand::SendText(
+                return Some(
                     serde_json::json!({
                         "t": "error",
                         "id": id,
@@ -1120,11 +1172,18 @@ fn handle_transfer_request(
                         ),
                     })
                     .to_string(),
-                ));
-                return;
+                );
             }
+            *next_read_generation = next_read_generation.wrapping_add(1);
+            let generation = *next_read_generation;
             let cancel = CancellationToken::new();
-            active_reads.insert(id.clone(), cancel.clone());
+            active_reads.insert(
+                id.clone(),
+                ActiveRead {
+                    cancel: cancel.clone(),
+                    generation,
+                },
+            );
             let authorization = authorization.clone();
             let bus = bus.clone();
             let session_id = session_id.to_string();
@@ -1132,6 +1191,7 @@ fn handle_transfer_request(
                 stream_read_request(
                     session_id,
                     id,
+                    generation,
                     path,
                     offset,
                     length,
@@ -1142,12 +1202,45 @@ fn handle_transfer_request(
                 )
                 .await;
             });
+            None
         }
         TransferRequest::Cancel { id } => {
-            if let Some(token) = active_reads.remove(&id) {
-                token.cancel();
+            if let Some(read) = active_reads.remove(&id) {
+                read.cancel.cancel();
             }
+            None
         }
+    }
+}
+
+/// The driver's `ReadFinished` handling (extracted for tests): deregister
+/// only when the finishing generation still owns the entry, so a
+/// superseded task's natural completion cannot evict its replacement.
+fn deregister_finished_read(
+    active_reads: &mut HashMap<String, ActiveRead>,
+    id: &str,
+    generation: u64,
+) {
+    if active_reads
+        .get(id)
+        .is_some_and(|read| read.generation == generation)
+    {
+        active_reads.remove(id);
+    }
+}
+
+/// Send a transfer command, aborting when the read is cancelled — a
+/// watermark-paused command lane must never pin a cancelled read task
+/// inside an un-cancellable `send().await`.
+async fn send_command_or_cancelled(
+    command_tx: &mpsc::Sender<TransferCommand>,
+    cancel: &CancellationToken,
+    command: TransferCommand,
+) -> Result<(), String> {
+    tokio::select! {
+        biased;
+        _ = cancel.cancelled() => Err("transfer cancelled".to_string()),
+        sent = command_tx.send(command) => sent.map_err(|_| "transfer driver gone".to_string()),
     }
 }
 
@@ -1155,6 +1248,7 @@ fn handle_transfer_request(
 async fn stream_read_request(
     session_id: String,
     id: String,
+    generation: u64,
     raw_path: String,
     offset: u64,
     length: Option<u64>,
@@ -1189,8 +1283,10 @@ async fn stream_read_request(
         if !authorization.is_current() {
             return Err("peer file-transfer identity changed before response".to_string());
         }
-        command_tx
-            .send(TransferCommand::SendText(
+        send_command_or_cancelled(
+            &command_tx,
+            &cancel,
+            TransferCommand::SendText(
                 serde_json::json!({
                     "t": "start",
                     "id": id,
@@ -1202,9 +1298,9 @@ async fn stream_read_request(
                     "total_size": total_size,
                 })
                 .to_string(),
-            ))
-            .await
-            .map_err(|_| "transfer driver gone".to_string())?;
+            ),
+        )
+        .await?;
 
         stream_file_range(
             file,
@@ -1219,8 +1315,10 @@ async fn stream_read_request(
         if !authorization.is_current() {
             return Err("peer file-transfer identity changed before completion".to_string());
         }
-        command_tx
-            .send(TransferCommand::SendText(
+        send_command_or_cancelled(
+            &command_tx,
+            &cancel,
+            TransferCommand::SendText(
                 serde_json::json!({
                     "t": "end",
                     "id": id,
@@ -1229,9 +1327,9 @@ async fn stream_read_request(
                     "total_size": total_size,
                 })
                 .to_string(),
-            ))
-            .await
-            .map_err(|_| "transfer driver gone".to_string())?;
+            ),
+        )
+        .await?;
         Ok::<(), String>(())
     }
     .await;
@@ -1255,16 +1353,31 @@ async fn stream_read_request(
             });
         }
         Err(error) => {
-            if authorization.is_current() {
-                let _ = command_tx
-                    .send(TransferCommand::SendText(
+            if !cancel.is_cancelled() && authorization.is_current() {
+                let _ = send_command_or_cancelled(
+                    &command_tx,
+                    &cancel,
+                    TransferCommand::SendText(
                         serde_json::json!({"t": "error", "id": id, "error": error}).to_string(),
-                    ))
-                    .await;
+                    ),
+                )
+                .await;
             }
         }
     }
-    let _ = command_tx.send(TransferCommand::ReadFinished(id)).await;
+    // Deregister on NATURAL completion only: whoever cancels a read
+    // (replacement, Cancel request, driver teardown) removes the registry
+    // entry itself, and this task must never sit in an un-cancellable
+    // send. The generation keys the removal so a superseded task cannot
+    // evict its replacement.
+    if !cancel.is_cancelled() {
+        let _ = send_command_or_cancelled(
+            &command_tx,
+            &cancel,
+            TransferCommand::ReadFinished { id, generation },
+        )
+        .await;
+    }
 }
 
 fn authorize_path(
@@ -1371,10 +1484,12 @@ async fn stream_file_range(
             return Err("peer file-transfer identity changed during read".to_string());
         }
         remaining = remaining.saturating_sub(n as u64);
-        command_tx
-            .send(TransferCommand::SendBinary(buf.split_to(n)))
-            .await
-            .map_err(|_| "transfer driver gone".to_string())?;
+        send_command_or_cancelled(
+            command_tx,
+            cancel,
+            TransferCommand::SendBinary(buf.split_to(n)),
+        )
+        .await?;
     }
     Ok(())
 }
@@ -1407,12 +1522,6 @@ fn send_transfer_binary<I: rtc::interceptor::Interceptor>(
             eprintln!("[peer-file-transfer] data channel binary write failed: {e:?}");
         }
     }
-}
-
-/// Clamp a byte watermark into the `u32` the rtc data-channel threshold
-/// setters take.
-fn watermark_to_u32(bytes: usize) -> u32 {
-    u32::try_from(bytes).unwrap_or(u32::MAX)
 }
 
 fn to_rtc_ice_servers(servers: &[crate::display::IceServer]) -> Vec<RTCIceServer> {
@@ -1536,6 +1645,125 @@ mod tests {
         assert!(authority.verified_at.lock().unwrap().is_some());
         crate::peer::access_policy::revoke_identity(tmp.path(), fingerprint).unwrap();
         assert!(!authority.is_current_fresh());
+        // A fresh negative clears the memo, so the memoized path observes
+        // the revocation immediately — no TTL ride-out on a verdict the
+        // fresh path already invalidated.
+        assert!(
+            authority.verified_at.lock().unwrap().is_none(),
+            "a fresh negative must clear the memo"
+        );
+        assert!(!authority.is_current());
+    }
+
+    /// Read-id reuse must never orphan the replacement stream: the old
+    /// generation's completion may not deregister the new generation's
+    /// entry (which would leave an uncounted, uncancellable stream
+    /// defeating the concurrency cap), and replacement cancels the old
+    /// token.
+    #[tokio::test]
+    async fn read_id_reuse_keeps_the_replacement_tracked() {
+        let (command_tx, _command_rx) = mpsc::channel(COMMAND_CHANNEL);
+        let authority = LiveTransferAuthority::new(PeerFileTransferAuthorization {
+            fingerprint: "fp".into(),
+            label: "peer".into(),
+            profile: "file-reader".into(),
+            filesystem: Default::default(),
+            identity_record: None,
+            iam_cert_dir: None,
+        });
+        let bus = crate::event::EventBus::new();
+        let mut active_reads: HashMap<String, ActiveRead> = HashMap::new();
+        let mut next_generation = 0u64;
+        let read_request =
+            r#"{"t":"read","id":"r1","path":"/nonexistent/fixture","offset":0}"#.to_string();
+
+        assert!(handle_transfer_request(
+            "session",
+            &read_request,
+            &authority,
+            &bus,
+            command_tx.clone(),
+            &mut active_reads,
+            &mut next_generation,
+        )
+        .is_none());
+        let first_generation = active_reads["r1"].generation;
+        let first_token = active_reads["r1"].cancel.clone();
+
+        // Reuse the id: the old stream is cancelled, a new generation is
+        // registered.
+        assert!(handle_transfer_request(
+            "session",
+            &read_request,
+            &authority,
+            &bus,
+            command_tx.clone(),
+            &mut active_reads,
+            &mut next_generation,
+        )
+        .is_none());
+        assert!(first_token.is_cancelled());
+        let second_generation = active_reads["r1"].generation;
+        assert_ne!(first_generation, second_generation);
+
+        // The superseded generation's completion is a no-op…
+        deregister_finished_read(&mut active_reads, "r1", first_generation);
+        assert!(
+            active_reads.contains_key("r1"),
+            "a superseded completion must not evict the replacement"
+        );
+        // …while the live generation deregisters normally.
+        deregister_finished_read(&mut active_reads, "r1", second_generation);
+        assert!(!active_reads.contains_key("r1"));
+    }
+
+    /// The concurrency-cap rejection is returned to the driver for a
+    /// direct datachannel send — never dropped into a possibly paused
+    /// command lane.
+    #[tokio::test]
+    async fn read_cap_rejection_is_returned_for_direct_send() {
+        let (command_tx, _command_rx) = mpsc::channel(COMMAND_CHANNEL);
+        let authority = LiveTransferAuthority::new(PeerFileTransferAuthorization {
+            fingerprint: "fp".into(),
+            label: "peer".into(),
+            profile: "file-reader".into(),
+            filesystem: Default::default(),
+            identity_record: None,
+            iam_cert_dir: None,
+        });
+        let bus = crate::event::EventBus::new();
+        let mut active_reads: HashMap<String, ActiveRead> = HashMap::new();
+        let mut next_generation = 0u64;
+        for index in 0..MAX_CONCURRENT_READS_PER_SESSION {
+            let request = format!(
+                r#"{{"t":"read","id":"r{index}","path":"/nonexistent/fixture","offset":0}}"#
+            );
+            assert!(handle_transfer_request(
+                "session",
+                &request,
+                &authority,
+                &bus,
+                command_tx.clone(),
+                &mut active_reads,
+                &mut next_generation,
+            )
+            .is_none());
+        }
+        let rejection = handle_transfer_request(
+            "session",
+            r#"{"t":"read","id":"over","path":"/nonexistent/fixture","offset":0}"#,
+            &authority,
+            &bus,
+            command_tx.clone(),
+            &mut active_reads,
+            &mut next_generation,
+        )
+        .expect("over-cap read must return a rejection for the driver to send");
+        assert!(rejection.contains("too many concurrent reads"));
+        assert_eq!(active_reads.len(), MAX_CONCURRENT_READS_PER_SESSION);
+        for (_, read) in active_reads {
+            read.cancel.cancel();
+        }
     }
 
     /// Trust pin for the memoized wrapper: a positive verdict is reusable

--- a/src/bin/caller/peer_file_transfer.rs
+++ b/src/bin/caller/peer_file_transfer.rs
@@ -775,6 +775,7 @@ async fn transfer_driver<I: rtc::interceptor::Interceptor + Send + Sync + 'stati
     // command channel fills, and the disk readers' `send().await` parks.
     // Cleared by the OnBufferedAmountLow event in `drain_transfer_outputs`.
     let mut send_paused = false;
+    let mut error_budget = crate::dashboard_control::DirectErrorBudget::new("peer-file-transfer");
     let mut authority_tick = tokio::time::interval(LIVE_TRANSFER_AUTHORITY_RECHECK_INTERVAL);
     authority_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
@@ -993,13 +994,18 @@ async fn transfer_driver<I: rtc::interceptor::Interceptor + Send + Sync + 'stati
                 &mut next_read_generation,
             ) {
                 // Rejections bypass the (possibly watermark-paused) command
-                // lane: the driver owns the rtc right here, and a dropped
-                // rejection would leave the client waiting forever.
-                send_transfer_text(&mut rtc, &channels, reply);
+                // lane: the driver owns the rtc right here. The budget keeps
+                // rejection spam from growing the reliable SCTP queue while
+                // the wire is congested — best-effort error delivery under
+                // abuse, bounded memory always.
+                if error_budget.allow(send_paused) {
+                    send_transfer_text(&mut rtc, &channels, reply);
+                }
             }
         }
     }
 
+    error_budget.log_teardown();
     for (_, read) in active_reads {
         read.cancel.cancel();
     }

--- a/src/bin/caller/peer_file_transfer.rs
+++ b/src/bin/caller/peer_file_transfer.rs
@@ -1536,7 +1536,7 @@ mod tests {
     #[test]
     fn transfer_authority_fresh_check_ignores_memo() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let fingerprint = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+        let fingerprint = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
         let authority = LiveTransferAuthority::new(approved_authorization(&tmp, fingerprint));
         assert!(authority.is_current());
         assert!(authority.verified_at.lock().unwrap().is_some());
@@ -1551,7 +1551,7 @@ mod tests {
     #[test]
     fn transfer_authority_memo_detects_revocation_after_ttl() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let fingerprint = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        let fingerprint = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
         let authority = LiveTransferAuthority::new(approved_authorization(&tmp, fingerprint));
         assert!(authority.is_current());
         crate::peer::access_policy::revoke_identity(tmp.path(), fingerprint).unwrap();

--- a/src/bin/caller/peer_file_transfer.rs
+++ b/src/bin/caller/peer_file_transfer.rs
@@ -45,7 +45,32 @@ const MAX_PENDING_TRANSFER_RESERVATIONS: usize = 128;
 const MAX_PENDING_TRANSFER_RESERVATIONS_PER_OWNER: usize = 8;
 const PENDING_TRANSFER_RESERVATION_TTL: Duration = Duration::from_secs(60);
 const LIVE_TRANSFER_AUTHORITY_RECHECK_INTERVAL: Duration = Duration::from_millis(250);
+/// How long a positive [`PeerFileTransferAuthorization::is_current`] verdict
+/// may be reused by the hot paths (driver loop, per-datachannel message,
+/// per-chunk stream checks) before the identity store is consulted again.
+/// Each fresh consult costs a fingerprint normalize, a `fs::metadata` stat,
+/// and a process-global cache lock — at chunk rate that was thousands of
+/// syscalls per second per transfer. The driver's authority tick always
+/// re-verifies fresh, so the revocation bound stays
+/// `LIVE_TRANSFER_AUTHORITY_RECHECK_INTERVAL` for the driver and
+/// `LIVE_TRANSFER_AUTHORITY_MEMO_TTL` for in-flight read streams; a test
+/// pins their sum under the 500 ms revocation budget.
+const LIVE_TRANSFER_AUTHORITY_MEMO_TTL: Duration = Duration::from_millis(100);
 const TCP_OUT_QUEUE: usize = 256;
+/// Pause pulling new transfer commands (file chunks included) once the SCTP
+/// stream buffers this much; resume when it drains to the low watermark.
+/// Without this gate the reader pumps the unbounded SCTP pending queue at
+/// disk speed — a 512 MB read to a slow WAN peer parked hundreds of MB of
+/// RSS. 4 MiB comfortably covers a 100 Mbit/s × 300 ms RTT pipe.
+const TRANSFER_BUFFERED_HIGH_WATERMARK_BYTES: usize = 4 * 1024 * 1024;
+/// Low watermark paired with [`TRANSFER_BUFFERED_HIGH_WATERMARK_BYTES`].
+const TRANSFER_BUFFERED_LOW_WATERMARK_BYTES: usize = 1024 * 1024;
+/// In-flight read streams per transfer session. Each distinct read spawns a
+/// task and holds an open file descriptor; without a cap an authorized peer
+/// could hold hundreds of parallel streams, multiplying the send-queue
+/// memory the watermarks above bound per stream admission. The dashboard
+/// client reads ranges sequentially, so a small cap is generous.
+const MAX_CONCURRENT_READS_PER_SESSION: usize = 4;
 
 #[derive(Clone, Debug)]
 pub struct PeerFileTransferAuthorization {
@@ -89,6 +114,73 @@ impl PeerFileTransferAuthorization {
             self.profile.clone(),
             "peer-file-transfer",
         )
+    }
+}
+
+/// A transfer session's authorization plus a shared positive-verdict memo.
+///
+/// [`PeerFileTransferAuthorization::is_current`] stats the identity store
+/// and takes a process-global cache lock on every call; the transfer paths
+/// call it per driver wakeup, per datachannel message, and twice per 16 KiB
+/// chunk — thousands of times per second during a bulk read, all contending
+/// the same mutex across every live transfer. This wrapper memoizes only
+/// **positive** verdicts for [`LIVE_TRANSFER_AUTHORITY_MEMO_TTL`]; clones
+/// (the driver plus each spawned read stream) share the memo cell.
+///
+/// Trust invariants (do not weaken):
+/// - Negative verdicts are never memoized — a failed check re-verifies
+///   fresh on every subsequent call.
+/// - The request-authorization path ([`authorize_path`],
+///   [`open_authorized_read_file`]) and the driver's authority tick call
+///   [`Self::is_current_fresh`], so authorization decisions and the
+///   periodic revocation probe never ride the memo.
+/// - `revocation bound = tick interval` for the driver (fresh at tick) and
+///   `≤ memo TTL` extra staleness for in-flight chunk streams; a test pins
+///   `tick + TTL ≤ 500 ms`.
+#[derive(Clone)]
+struct LiveTransferAuthority {
+    authorization: PeerFileTransferAuthorization,
+    /// Instant of the last fresh **positive** verification, shared across
+    /// clones. `None` until first verified.
+    verified_at: Arc<std::sync::Mutex<Option<Instant>>>,
+}
+
+impl LiveTransferAuthority {
+    fn new(authorization: PeerFileTransferAuthorization) -> Self {
+        Self {
+            authorization,
+            verified_at: Arc::new(std::sync::Mutex::new(None)),
+        }
+    }
+
+    /// Memoized liveness: reuse a positive verdict younger than
+    /// [`LIVE_TRANSFER_AUTHORITY_MEMO_TTL`], else verify fresh.
+    fn is_current(&self) -> bool {
+        {
+            let verified_at = self
+                .verified_at
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            if let Some(at) = *verified_at {
+                if at.elapsed() < LIVE_TRANSFER_AUTHORITY_MEMO_TTL {
+                    return true;
+                }
+            }
+        }
+        self.is_current_fresh()
+    }
+
+    /// Uncached liveness against the identity store; primes the memo on a
+    /// positive verdict only.
+    fn is_current_fresh(&self) -> bool {
+        let ok = self.authorization.is_current();
+        if ok {
+            *self
+                .verified_at
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()) = Some(Instant::now());
+        }
+        ok
     }
 }
 
@@ -408,7 +500,7 @@ struct PeerFileTransferPeer {
     command_tx: mpsc::Sender<TransferCommand>,
     shutdown: CancellationToken,
     owner_fingerprint: String,
-    opening_authorization: PeerFileTransferAuthorization,
+    opening_authorization: LiveTransferAuthority,
 }
 
 impl PeerFileTransferPeer {
@@ -513,6 +605,9 @@ impl PeerFileTransferPeer {
         let (command_tx, command_rx) = mpsc::channel(COMMAND_CHANNEL);
         let shutdown = CancellationToken::new();
         let owner_fingerprint = authorization.fingerprint.clone();
+        // One memo shared by the signaling handle, the driver, and every
+        // read stream the driver spawns.
+        let authorization = LiveTransferAuthority::new(authorization);
         let opening_authorization = authorization.clone();
         tokio::spawn(transfer_driver(
             session_id,
@@ -571,7 +666,7 @@ struct InboundPacket {
 enum TransferCommand {
     AddIceCandidate(String),
     SendText(String),
-    SendBinary(Vec<u8>),
+    SendBinary(BytesMut),
     ReadFinished(String),
 }
 
@@ -596,7 +691,7 @@ async fn transfer_driver<I: rtc::interceptor::Interceptor + Send + Sync + 'stati
     session_id: String,
     mut rtc: RTCPeerConnection<I>,
     sockets: Vec<Arc<UdpSocket>>,
-    authorization: PeerFileTransferAuthorization,
+    authorization: LiveTransferAuthority,
     bus: crate::event::EventBus,
     command_tx: mpsc::Sender<TransferCommand>,
     mut command_rx: mpsc::Receiver<TransferCommand>,
@@ -607,7 +702,7 @@ async fn transfer_driver<I: rtc::interceptor::Interceptor + Send + Sync + 'stati
 ) {
     let mut sockets_by_addr: HashMap<SocketAddr, Arc<UdpSocket>> = HashMap::new();
     let (inbound_tx, mut inbound_rx) = mpsc::channel::<InboundPacket>(64);
-    let mut tcp_senders: HashMap<SocketAddr, mpsc::Sender<Vec<u8>>> = HashMap::new();
+    let mut tcp_senders: HashMap<SocketAddr, mpsc::Sender<BytesMut>> = HashMap::new();
     let mut forwarder_handles = Vec::new();
     for sock in sockets {
         let local = match sock.local_addr() {
@@ -647,6 +742,12 @@ async fn transfer_driver<I: rtc::interceptor::Interceptor + Send + Sync + 'stati
 
     let mut channels: HashMap<String, rtc::data_channel::RTCDataChannelId> = HashMap::new();
     let mut active_reads: HashMap<String, CancellationToken> = HashMap::new();
+    // True while the transfer channel's SCTP send buffer sits above the
+    // high watermark: the command lane stops admitting work (chunks, text,
+    // trickled candidates alike — FIFO order must hold anyway), the bounded
+    // command channel fills, and the disk readers' `send().await` parks.
+    // Cleared by the OnBufferedAmountLow event in `drain_transfer_outputs`.
+    let mut send_paused = false;
     let mut authority_tick = tokio::time::interval(LIVE_TRANSFER_AUTHORITY_RECHECK_INTERVAL);
     authority_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
@@ -660,6 +761,7 @@ async fn transfer_driver<I: rtc::interceptor::Interceptor + Send + Sync + 'stati
             &sockets_by_addr,
             &mut tcp_senders,
             &mut channels,
+            &mut send_paused,
         )
         .await
         {
@@ -676,7 +778,8 @@ async fn transfer_driver<I: rtc::interceptor::Interceptor + Send + Sync + 'stati
         tokio::select! {
             _ = shutdown.cancelled() => break,
             _ = authority_tick.tick() => {
-                if !authorization.is_current() {
+                // The periodic revocation probe never rides the memo.
+                if !authorization.is_current_fresh() {
                     shutdown.cancel();
                     break;
                 }
@@ -719,7 +822,7 @@ async fn transfer_driver<I: rtc::interceptor::Interceptor + Send + Sync + 'stati
                 );
                 let (read_half, write_half) = stream.into_split();
 
-                let (tcp_out_tx, mut tcp_out_rx) = mpsc::channel::<Vec<u8>>(TCP_OUT_QUEUE);
+                let (tcp_out_tx, mut tcp_out_rx) = mpsc::channel::<BytesMut>(TCP_OUT_QUEUE);
                 tcp_senders.insert(remote_addr, tcp_out_tx);
                 let writer_shutdown = shutdown.clone();
                 tokio::spawn(async move {
@@ -791,7 +894,9 @@ async fn transfer_driver<I: rtc::interceptor::Interceptor + Send + Sync + 'stati
                     break;
                 }
             }
-            Some(cmd) = command_rx.recv() => {
+            // Gated on the SCTP send-buffer watermark: while paused, queued
+            // commands wait in the bounded channel and the readers park.
+            Some(cmd) = command_rx.recv(), if !send_paused => {
                 if !authorization.is_current() {
                     shutdown.cancel();
                     break;
@@ -869,8 +974,9 @@ async fn transfer_driver<I: rtc::interceptor::Interceptor + Send + Sync + 'stati
 async fn drain_transfer_outputs<I: rtc::interceptor::Interceptor>(
     rtc: &mut RTCPeerConnection<I>,
     sockets_by_addr: &HashMap<SocketAddr, Arc<UdpSocket>>,
-    tcp_senders: &mut HashMap<SocketAddr, mpsc::Sender<Vec<u8>>>,
+    tcp_senders: &mut HashMap<SocketAddr, mpsc::Sender<BytesMut>>,
     channels: &mut HashMap<String, rtc::data_channel::RTCDataChannelId>,
+    send_paused: &mut bool,
 ) -> Result<Instant, ()> {
     while let Some(t) = rtc.poll_write() {
         // Route by connection first, engine stamp second: rtc < 0.9.1
@@ -882,7 +988,11 @@ async fn drain_transfer_outputs<I: rtc::interceptor::Interceptor>(
         // keeps any future stamping regression from presenting as a
         // silent DTLS timeout again.
         if let Some(sender) = tcp_senders.get(&t.transport.peer_addr) {
-            match sender.try_send(t.message.to_vec()) {
+            // Move the transmit into the writer lane without copying
+            // (~1.2 KB per packet — ~450k allocations per 512 MB read
+            // before this). A full lane drops the packet exactly as the
+            // to_vec path did; SCTP retransmission recovers it.
+            match sender.try_send(t.message) {
                 Ok(()) => {}
                 Err(mpsc::error::TrySendError::Full(_)) => {}
                 Err(mpsc::error::TrySendError::Closed(_)) => {
@@ -920,10 +1030,44 @@ async fn drain_transfer_outputs<I: rtc::interceptor::Interceptor>(
                     .data_channel(cid)
                     .map(|channel| channel.label().to_string())
                     .unwrap_or_else(|| format!("channel-{cid}"));
+                if label == TRANSFER_CHANNEL_LABEL {
+                    // Arm the SCTP buffered-amount watermarks (same
+                    // event-driven pattern as the display pipeline's
+                    // tile-delta backpressure): the High event pauses the
+                    // driver's command lane, Low resumes it.
+                    if let Some(mut channel) = rtc.data_channel(cid) {
+                        channel.set_buffered_amount_high_threshold(watermark_to_u32(
+                            TRANSFER_BUFFERED_HIGH_WATERMARK_BYTES,
+                        ));
+                        channel.set_buffered_amount_low_threshold(watermark_to_u32(
+                            TRANSFER_BUFFERED_LOW_WATERMARK_BYTES,
+                        ));
+                    }
+                    *send_paused = false;
+                }
                 channels.insert(label, cid);
             }
             RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnClose(cid)) => {
+                if channels.get(TRANSFER_CHANNEL_LABEL).copied() == Some(cid) {
+                    // Never leave the command lane parked behind a channel
+                    // that can no longer drain.
+                    *send_paused = false;
+                }
                 channels.retain(|_, id| *id != cid);
+            }
+            RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnBufferedAmountHigh(
+                cid,
+            )) => {
+                if channels.get(TRANSFER_CHANNEL_LABEL).copied() == Some(cid) {
+                    *send_paused = true;
+                }
+            }
+            RTCPeerConnectionEvent::OnDataChannel(RTCDataChannelEvent::OnBufferedAmountLow(
+                cid,
+            )) => {
+                if channels.get(TRANSFER_CHANNEL_LABEL).copied() == Some(cid) {
+                    *send_paused = false;
+                }
             }
             RTCPeerConnectionEvent::OnConnectionStateChangeEvent(state) => {
                 if matches!(
@@ -946,7 +1090,7 @@ async fn drain_transfer_outputs<I: rtc::interceptor::Interceptor>(
 fn handle_transfer_request(
     session_id: &str,
     text: &str,
-    authorization: &PeerFileTransferAuthorization,
+    authorization: &LiveTransferAuthority,
     bus: &crate::event::EventBus,
     command_tx: mpsc::Sender<TransferCommand>,
     active_reads: &mut HashMap<String, CancellationToken>,
@@ -971,6 +1115,19 @@ fn handle_transfer_request(
         } => {
             if let Some(old) = active_reads.remove(&id) {
                 old.cancel();
+            }
+            if active_reads.len() >= MAX_CONCURRENT_READS_PER_SESSION {
+                let _ = command_tx.try_send(TransferCommand::SendText(
+                    serde_json::json!({
+                        "t": "error",
+                        "id": id,
+                        "error": format!(
+                            "too many concurrent reads on this transfer session (max {MAX_CONCURRENT_READS_PER_SESSION})"
+                        ),
+                    })
+                    .to_string(),
+                ));
+                return;
             }
             let cancel = CancellationToken::new();
             active_reads.insert(id.clone(), cancel.clone());
@@ -1007,7 +1164,7 @@ async fn stream_read_request(
     raw_path: String,
     offset: u64,
     length: Option<u64>,
-    authorization: PeerFileTransferAuthorization,
+    authorization: LiveTransferAuthority,
     command_tx: mpsc::Sender<TransferCommand>,
     cancel: CancellationToken,
     bus: crate::event::EventBus,
@@ -1093,7 +1250,12 @@ async fn stream_read_request(
                 source: "peer-file-transfer".into(),
                 content: format!(
                     "completed read session={} peer={} fingerprint={} path={} offset={} length={:?}",
-                    session_id, authorization.label, authorization.fingerprint, raw_path, offset, length
+                    session_id,
+                    authorization.authorization.label,
+                    authorization.authorization.fingerprint,
+                    raw_path,
+                    offset,
+                    length
                 ),
                 turn: None,
             });
@@ -1112,20 +1274,21 @@ async fn stream_read_request(
 }
 
 fn authorize_path(
-    authorization: &PeerFileTransferAuthorization,
+    authorization: &LiveTransferAuthority,
     raw_path: &str,
 ) -> Result<PathBuf, String> {
-    if !authorization.is_current() {
+    // Authorization decisions never ride the memo: verify fresh.
+    if !authorization.is_current_fresh() {
         return Err("peer file-transfer identity changed or is no longer active".to_string());
     }
     crate::access::iam::evaluate_principal_operation(
-        &authorization.access_principal(),
+        &authorization.authorization.access_principal(),
         PeerOperation::FilesystemRead,
     )
     .ensure_allowed()?;
     let path = crate::web_gateway::expand_dashboard_fs_path(raw_path)?;
     filesystem_access_canonical_subject(
-        &authorization.filesystem,
+        &authorization.authorization.filesystem,
         FilesystemAccessKind::Read,
         &path,
     )
@@ -1136,7 +1299,7 @@ fn authorize_path(
 /// caller-controlled path, narrowing symlink/path replacement races to the
 /// platform's path-open operation itself.
 fn open_authorized_read_file(
-    authorization: &PeerFileTransferAuthorization,
+    authorization: &LiveTransferAuthority,
     raw_path: &str,
 ) -> Result<(PathBuf, std::fs::File), String> {
     let canonical = authorize_path(authorization, raw_path)?;
@@ -1168,7 +1331,7 @@ fn open_authorized_read_file(
             canonical.display()
         ));
     }
-    if !authorization.is_current() {
+    if !authorization.is_current_fresh() {
         return Err("peer file-transfer identity changed while opening the file".to_string());
     }
     Ok((canonical, file))
@@ -1179,15 +1342,21 @@ async fn stream_file_range(
     path: &Path,
     offset: u64,
     length: u64,
-    authorization: &PeerFileTransferAuthorization,
+    authorization: &LiveTransferAuthority,
     command_tx: &mpsc::Sender<TransferCommand>,
     cancel: &CancellationToken,
 ) -> Result<(), String> {
+    use bytes::BufMut as _;
+
     file.seek(SeekFrom::Start(offset))
         .map_err(|e| format!("seek {}: {e}", path.display()))?;
     let mut file = tokio::fs::File::from_std(file);
     let mut remaining = length;
-    let mut buf = vec![0u8; CHUNK_BYTES];
+    // One BytesMut reused across chunks: `read_buf` fills fresh capacity
+    // and `split_to` hands the filled prefix to the driver without a copy
+    // (the old path copied each chunk into a new Vec, and the driver
+    // copied it again into a BytesMut for the datachannel).
+    let mut buf = BytesMut::with_capacity(CHUNK_BYTES);
     while remaining > 0 {
         if cancel.is_cancelled() {
             return Err("transfer cancelled".to_string());
@@ -1195,9 +1364,10 @@ async fn stream_file_range(
         if !authorization.is_current() {
             return Err("peer file-transfer identity changed during read".to_string());
         }
-        let want = (remaining as usize).min(buf.len());
+        let want = (remaining as usize).min(CHUNK_BYTES);
+        buf.reserve(want);
         let n = file
-            .read(&mut buf[..want])
+            .read_buf(&mut (&mut buf).limit(want))
             .await
             .map_err(|e| format!("read {}: {e}", path.display()))?;
         if n == 0 {
@@ -1208,7 +1378,7 @@ async fn stream_file_range(
         }
         remaining = remaining.saturating_sub(n as u64);
         command_tx
-            .send(TransferCommand::SendBinary(buf[..n].to_vec()))
+            .send(TransferCommand::SendBinary(buf.split_to(n)))
             .await
             .map_err(|_| "transfer driver gone".to_string())?;
     }
@@ -1233,16 +1403,22 @@ fn send_transfer_text<I: rtc::interceptor::Interceptor>(
 fn send_transfer_binary<I: rtc::interceptor::Interceptor>(
     rtc: &mut RTCPeerConnection<I>,
     channels: &HashMap<String, rtc::data_channel::RTCDataChannelId>,
-    bytes: Vec<u8>,
+    bytes: BytesMut,
 ) {
     let Some(cid) = channels.get(TRANSFER_CHANNEL_LABEL).copied() else {
         return;
     };
     if let Some(mut channel) = rtc.data_channel(cid) {
-        if let Err(e) = channel.send(BytesMut::from(&bytes[..])) {
+        if let Err(e) = channel.send(bytes) {
             eprintln!("[peer-file-transfer] data channel binary write failed: {e:?}");
         }
     }
+}
+
+/// Clamp a byte watermark into the `u32` the rtc data-channel threshold
+/// setters take.
+fn watermark_to_u32(bytes: usize) -> u32 {
+    u32::try_from(bytes).unwrap_or(u32::MAX)
 }
 
 fn to_rtc_ice_servers(servers: &[crate::display::IceServer]) -> Vec<RTCIceServer> {
@@ -1292,17 +1468,40 @@ fn tcp_host_candidate_init(addr: SocketAddr) -> RTCIceCandidateInit {
 mod tests {
     use super::*;
 
+    fn approved_authorization(
+        tmp: &tempfile::TempDir,
+        fingerprint: &str,
+    ) -> PeerFileTransferAuthorization {
+        let record = crate::peer::access_policy::write_approved_identity(
+            tmp.path(),
+            fingerprint,
+            "peer-b",
+            "file-reader",
+            None,
+            None,
+        )
+        .unwrap();
+        PeerFileTransferAuthorization {
+            fingerprint: record.fingerprint.clone(),
+            label: record.label.clone(),
+            profile: record.profile.clone(),
+            filesystem: record.filesystem.clone(),
+            identity_record: Some(record),
+            iam_cert_dir: Some(tmp.path().to_path_buf()),
+        }
+    }
+
     #[test]
     fn transfer_session_owner_match_is_exact() {
         let (command_tx, _command_rx) = mpsc::channel(1);
-        let opening_authorization = PeerFileTransferAuthorization {
+        let opening_authorization = LiveTransferAuthority::new(PeerFileTransferAuthorization {
             fingerprint: "peer-a".to_string(),
             label: "Peer A".to_string(),
             profile: "file-reader".to_string(),
             filesystem: Default::default(),
             identity_record: None,
             iam_cert_dir: None,
-        };
+        });
         let peer = PeerFileTransferPeer {
             command_tx,
             shutdown: CancellationToken::new(),
@@ -1316,28 +1515,50 @@ mod tests {
     #[test]
     fn live_peer_identity_change_invalidates_file_transfer_authority() {
         assert!(LIVE_TRANSFER_AUTHORITY_RECHECK_INTERVAL <= Duration::from_millis(500));
+        // The end-to-end revocation budget: a fresh driver tick plus the
+        // worst-case memo staleness of an in-flight read stream.
+        assert!(
+            LIVE_TRANSFER_AUTHORITY_RECHECK_INTERVAL + LIVE_TRANSFER_AUTHORITY_MEMO_TTL
+                <= Duration::from_millis(500)
+        );
         let tmp = tempfile::TempDir::new().unwrap();
         let fingerprint = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-        let record = crate::peer::access_policy::write_approved_identity(
-            tmp.path(),
-            fingerprint,
-            "peer-b",
-            "file-reader",
-            None,
-            None,
-        )
-        .unwrap();
-        let authorization = PeerFileTransferAuthorization {
-            fingerprint: record.fingerprint.clone(),
-            label: record.label.clone(),
-            profile: record.profile.clone(),
-            filesystem: record.filesystem.clone(),
-            identity_record: Some(record),
-            iam_cert_dir: Some(tmp.path().to_path_buf()),
-        };
+        let authorization = approved_authorization(&tmp, fingerprint);
         assert!(authorization.is_current());
         crate::peer::access_policy::revoke_identity(tmp.path(), fingerprint).unwrap();
         assert!(!authorization.is_current());
+    }
+
+    /// Trust pin for the memoized wrapper: `is_current_fresh` (the driver
+    /// tick and the request-authorization path) consults the identity
+    /// store on every call — a primed memo never masks a revocation from
+    /// the fresh path.
+    #[test]
+    fn transfer_authority_fresh_check_ignores_memo() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let fingerprint = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+        let authority = LiveTransferAuthority::new(approved_authorization(&tmp, fingerprint));
+        assert!(authority.is_current());
+        assert!(authority.verified_at.lock().unwrap().is_some());
+        crate::peer::access_policy::revoke_identity(tmp.path(), fingerprint).unwrap();
+        assert!(!authority.is_current_fresh());
+    }
+
+    /// Trust pin for the memoized wrapper: a positive verdict is reusable
+    /// for at most [`LIVE_TRANSFER_AUTHORITY_MEMO_TTL`] — after the TTL a
+    /// revocation is observed by the memoized path too, and the failed
+    /// check must not re-prime the memo.
+    #[test]
+    fn transfer_authority_memo_detects_revocation_after_ttl() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let fingerprint = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        let authority = LiveTransferAuthority::new(approved_authorization(&tmp, fingerprint));
+        assert!(authority.is_current());
+        crate::peer::access_policy::revoke_identity(tmp.path(), fingerprint).unwrap();
+        std::thread::sleep(LIVE_TRANSFER_AUTHORITY_MEMO_TTL + Duration::from_millis(50));
+        assert!(!authority.is_current());
+        // Negative verdicts are never memoized.
+        assert!(!authority.is_current());
     }
 
     #[test]
@@ -1434,7 +1655,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let file = tmp.path().join("a.txt");
         std::fs::write(&file, b"ok").unwrap();
-        let auth = PeerFileTransferAuthorization {
+        let auth = LiveTransferAuthority::new(PeerFileTransferAuthorization {
             fingerprint: "fp".into(),
             label: "peer".into(),
             profile: "operator".into(),
@@ -1444,7 +1665,7 @@ mod tests {
             },
             identity_record: None,
             iam_cert_dir: None,
-        };
+        });
         let err = authorize_path(&auth, file.to_str().unwrap()).unwrap_err();
         assert!(err.contains("does not allow filesystem.read"));
     }
@@ -1454,7 +1675,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let file = tmp.path().join("a.txt");
         std::fs::write(&file, b"ok").unwrap();
-        let auth = PeerFileTransferAuthorization {
+        let auth = LiveTransferAuthority::new(PeerFileTransferAuthorization {
             fingerprint: "fp".into(),
             label: "peer".into(),
             profile: "file-reader".into(),
@@ -1464,7 +1685,7 @@ mod tests {
             },
             identity_record: None,
             iam_cert_dir: None,
-        };
+        });
         assert_eq!(
             authorize_path(&auth, file.to_str().unwrap()).unwrap(),
             std::fs::canonicalize(file).unwrap()
@@ -1480,7 +1701,7 @@ mod tests {
         let file = tmp.path().join("a.txt");
         let moved = tmp.path().join("opened.txt");
         std::fs::write(&file, b"authorized object").unwrap();
-        let auth = PeerFileTransferAuthorization {
+        let auth = LiveTransferAuthority::new(PeerFileTransferAuthorization {
             fingerprint: "fp".into(),
             label: "peer".into(),
             profile: "file-reader".into(),
@@ -1490,7 +1711,7 @@ mod tests {
             },
             identity_record: None,
             iam_cert_dir: None,
-        };
+        });
 
         let (_canonical, mut opened) =
             open_authorized_read_file(&auth, file.to_str().unwrap()).unwrap();

--- a/src/bin/caller/peer_file_transfer.rs
+++ b/src/bin/caller/peer_file_transfer.rs
@@ -157,10 +157,7 @@ impl LiveTransferAuthority {
     /// [`LIVE_TRANSFER_AUTHORITY_MEMO_TTL`], else verify fresh.
     fn is_current(&self) -> bool {
         {
-            let verified_at = self
-                .verified_at
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
+            let verified_at = self.verified_at.lock().unwrap_or_else(|e| e.into_inner());
             if let Some(at) = *verified_at {
                 if at.elapsed() < LIVE_TRANSFER_AUTHORITY_MEMO_TTL {
                     return true;
@@ -175,10 +172,7 @@ impl LiveTransferAuthority {
     fn is_current_fresh(&self) -> bool {
         let ok = self.authorization.is_current();
         if ok {
-            *self
-                .verified_at
-                .lock()
-                .unwrap_or_else(|e| e.into_inner()) = Some(Instant::now());
+            *self.verified_at.lock().unwrap_or_else(|e| e.into_inner()) = Some(Instant::now());
         }
         ok
     }

--- a/src/bin/caller/terminal.rs
+++ b/src/bin/caller/terminal.rs
@@ -973,12 +973,15 @@ impl PtySession {
         mut reader: Box<dyn Read + Send>,
         mut child: Box<dyn portable_pty::Child + Send + Sync>,
     ) {
-        let mut buf = [0u8; 4096];
+        // 64 KiB reads: bulk shell output at 4 KiB paid 16× the syscalls,
+        // and the per-read Vec was pure overhead — `fan_out` copies into
+        // each listener's queue itself.
+        let mut buf = vec![0u8; 64 * 1024];
         loop {
             match reader.read(&mut buf) {
                 Ok(0) => break,
                 Ok(n) => {
-                    let chunk = buf[..n].to_vec();
+                    let chunk = &buf[..n];
                     // Answer ConPTY's startup cursor-position query so the shell
                     // doesn't block waiting for it (Windows only; no-op on Unix
                     // where the slice is never present).
@@ -996,7 +999,7 @@ impl PtySession {
                     // output-hub lock, atomic against `attach`'s
                     // snapshot+register (see [`OutputHub`]).
                     let mut hub = session.output.lock().unwrap_or_else(|e| e.into_inner());
-                    hub.fan_out(&chunk);
+                    hub.fan_out(chunk);
                 }
                 Err(_) => break,
             }

--- a/src/bin/caller/transfer_store.rs
+++ b/src/bin/caller/transfer_store.rs
@@ -856,9 +856,35 @@ pub fn append_upload_tempfile(
         .as_file_mut()
         .seek(std::io::SeekFrom::Start(0))
         .map_err(|e| TransferStoreError::new(500, format!("seek upload chunk: {e}")))?;
-    let copied = std::io::copy(chunk.as_file_mut(), &mut output)
-        .map_err(|e| TransferStoreError::new(500, format!("append upload chunk: {e}")))?;
+    // On any incomplete append (I/O error or a chunk that didn't match its
+    // declared length), roll the partial back to the acknowledged offset
+    // BEFORE returning. Leaving the extra bytes in place wedged the job:
+    // the partial disagreed with `completed_bytes`, so every later append
+    // 409'd as a "foreign writer" until the active-job entry idled out
+    // (15 minutes). Truncating restores the exact resume-offset contract
+    // on the very next chunk. A failed truncate leaves the historical
+    // wedge (crash reconciliation still recovers it on re-admission).
+    let rollback = |output: &fs::File| {
+        if let Err(e) = output.set_len(job.completed_bytes) {
+            eprintln!(
+                "[transfer-store] failed to roll back upload partial {} to {} bytes: {e}",
+                temp_path.display(),
+                job.completed_bytes
+            );
+        }
+    };
+    let copied = match std::io::copy(chunk.as_file_mut(), &mut output) {
+        Ok(copied) => copied,
+        Err(e) => {
+            rollback(&output);
+            return Err(TransferStoreError::new(
+                500,
+                format!("append upload chunk: {e}"),
+            ));
+        }
+    };
     if copied != chunk_len {
+        rollback(&output);
         return Err(TransferStoreError::new(
             400,
             "upload chunk length did not match declared size",
@@ -1513,6 +1539,51 @@ mod tests {
         assert_eq!(disk_job(&project, &id).completed_bytes, 1);
         let resumed =
             append_upload_tempfile(&scope(&project), &id, 1, write_chunk(b"bcdef"), 5).unwrap();
+        assert_eq!(resumed.completed_bytes, 6);
+        assert_eq!(resumed.status, TransferStatus::Ready);
+    }
+
+    /// A chunk whose real length disagrees with its declared length rolls
+    /// the partial back to the acknowledged offset immediately: the very
+    /// next correctly-sized append succeeds instead of 409ing as a
+    /// "foreign writer" until the active-job entry idles out (15 minutes).
+    #[test]
+    fn chunk_length_mismatch_rolls_back_and_next_append_succeeds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        let dest_dir = tmp.path().join("dest");
+        fs::create_dir_all(&project).unwrap();
+        fs::create_dir_all(&dest_dir).unwrap();
+        let dest = dest_dir.join("out.bin");
+
+        let job = create_upload_job(
+            &scope(&project),
+            dest.to_str().unwrap(),
+            "out.bin",
+            "application/octet-stream",
+            Some(6),
+            None,
+            TransferConflictPolicy::Fail,
+        )
+        .unwrap();
+        let id = job.id.clone();
+        let temp_path = job.temp_path.clone().unwrap();
+
+        append_upload_tempfile(&scope(&project), &id, 0, write_chunk(b"abc"), 3).unwrap();
+
+        // Declared 3 bytes, delivered 5: rejected AND rolled back.
+        let err = append_upload_tempfile(&scope(&project), &id, 3, write_chunk(b"defgh"), 3)
+            .unwrap_err();
+        assert_eq!(err.status, 400);
+        assert_eq!(
+            fs::metadata(&temp_path).unwrap().len(),
+            3,
+            "the partial must be truncated back to the acknowledged offset"
+        );
+
+        // The retry at the same offset works right away.
+        let resumed =
+            append_upload_tempfile(&scope(&project), &id, 3, write_chunk(b"def"), 3).unwrap();
         assert_eq!(resumed.completed_bytes, 6);
         assert_eq!(resumed.status, TransferStatus::Ready);
     }

--- a/src/bin/caller/transfer_store.rs
+++ b/src/bin/caller/transfer_store.rs
@@ -1572,8 +1572,8 @@ mod tests {
         append_upload_tempfile(&scope(&project), &id, 0, write_chunk(b"abc"), 3).unwrap();
 
         // Declared 3 bytes, delivered 5: rejected AND rolled back.
-        let err = append_upload_tempfile(&scope(&project), &id, 3, write_chunk(b"defgh"), 3)
-            .unwrap_err();
+        let err =
+            append_upload_tempfile(&scope(&project), &id, 3, write_chunk(b"defgh"), 3).unwrap_err();
         assert_eq!(err.status, 400);
         assert_eq!(
             fs::metadata(&temp_path).unwrap().len(),

--- a/src/bin/caller/upload_store.rs
+++ b/src/bin/caller/upload_store.rs
@@ -373,11 +373,100 @@ pub fn list_uploads(session_dir: &Path, scope: &StoreScope) -> Vec<UploadDescrip
 }
 
 /// Look up a single upload by id. `None` if no descriptor matches.
+///
+/// Blob and sidecar filenames embed the id (`{id[..8]}__{name}` plus the
+/// `.json` sidecar — see [`commit_upload`]), so the lookup scans directory
+/// entries for that prefix and parses only the matching sidecars, instead
+/// of reading and parsing every sidecar in the whole store per call (the
+/// full-scan cost grew with store age, and callers pay per attachment —
+/// a note with four images paid four full scans). The historical full
+/// scan remains as a fallback so any blob predating the prefix layout is
+/// still found.
 pub fn find_upload(id: &str, session_dir: &Path, scope: &StoreScope) -> Option<UploadDescriptor> {
+    if let Some(found) = find_upload_by_prefix(id, session_dir, scope) {
+        return Some(found);
+    }
     list_uploads(session_dir, scope)
         .into_iter()
         .find(|u| u.id == id)
         .or_else(|| find_task_upload_in_sibling_sessions(id, session_dir))
+}
+
+/// The `{id[..8]}__` filename prefix both the blob and its sidecar carry.
+/// `None` for ids whose 8-byte cut is not a char boundary (never our own
+/// UUIDs; caller-supplied ids fall back to the full scan).
+fn upload_filename_prefix(id: &str) -> Option<String> {
+    let prefix = id.get(..id.len().min(8))?;
+    if prefix.is_empty() {
+        return None;
+    }
+    Some(format!("{prefix}__"))
+}
+
+/// Resolve an upload by filename prefix across the same directories
+/// [`list_uploads`] and the sibling-session sweep walk, parsing only
+/// sidecars whose name matches (`{prefix}__…json`) and whose descriptor
+/// confirms the full id.
+fn find_upload_by_prefix(
+    id: &str,
+    session_dir: &Path,
+    scope: &StoreScope,
+) -> Option<UploadDescriptor> {
+    let prefix = upload_filename_prefix(id)?;
+    let mut dirs = vec![legacy_task_uploads_dir(session_dir)];
+    if let Some(project_root) = scope.project_root() {
+        dirs.push(legacy_workspace_uploads_dir(project_root));
+    }
+    let root = uploads_root(scope);
+    if let Ok(entries) = fs::read_dir(&root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                dirs.push(path);
+            }
+        }
+    }
+    for dir in dirs {
+        if let Some(found) = find_upload_by_prefix_in_dir(&dir, &prefix, id) {
+            return Some(found);
+        }
+    }
+    // The sibling task-session sweep, prefix-matched.
+    let sessions_root = session_dir.parent()?;
+    for entry in fs::read_dir(sessions_root).ok()?.flatten() {
+        let sibling_dir = entry.path();
+        if sibling_dir == session_dir || !sibling_dir.is_dir() {
+            continue;
+        }
+        if let Some(found) =
+            find_upload_by_prefix_in_dir(&legacy_task_uploads_dir(&sibling_dir), &prefix, id)
+        {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn find_upload_by_prefix_in_dir(dir: &Path, prefix: &str, id: &str) -> Option<UploadDescriptor> {
+    for entry in fs::read_dir(dir).ok()?.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if !name.starts_with(prefix) || !name.ends_with(".json") {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(entry.path()) else {
+            continue;
+        };
+        let Ok(descriptor) = serde_json::from_str::<UploadDescriptor>(&content) else {
+            continue;
+        };
+        if descriptor.id == id {
+            return Some(descriptor);
+        }
+    }
+    None
 }
 
 fn find_task_upload_in_sibling_sessions(id: &str, session_dir: &Path) -> Option<UploadDescriptor> {
@@ -444,6 +533,65 @@ mod tests {
 
     fn project_scope(project_root: &Path) -> StoreScope {
         StoreScope::Project(project_root.to_path_buf())
+    }
+
+    /// The prefix fast path finds a committed upload, and a hand-written
+    /// sidecar whose filename predates the `{id[..8]}__` layout is still
+    /// resolved through the full-scan fallback.
+    #[test]
+    fn find_upload_resolves_by_prefix_and_falls_back_for_legacy_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = tmp.path().join("session");
+        let project_root = tmp.path().join("project");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::create_dir_all(&project_root).unwrap();
+        let scope = project_scope(&project_root);
+
+        let committed = commit_upload(
+            mk_tempfile(b"new"),
+            "a.txt",
+            "text/plain",
+            3,
+            UploadDestination::Task,
+            &session_dir,
+            "sess",
+            &scope,
+        )
+        .unwrap();
+        assert_eq!(
+            find_upload(&committed.id, &session_dir, &scope).map(|d| d.id),
+            Some(committed.id.clone()),
+            "prefix-named sidecar resolves"
+        );
+        // The fast path alone must already resolve it.
+        assert_eq!(
+            find_upload_by_prefix(&committed.id, &session_dir, &scope).map(|d| d.id),
+            Some(committed.id.clone())
+        );
+
+        // Legacy-named sidecar (no id prefix in the filename).
+        let legacy = UploadDescriptor {
+            id: "legacy-upload-id".to_string(),
+            name: "old.txt".to_string(),
+            original_name: Some("old.txt".to_string()),
+            mime: "text/plain".to_string(),
+            size: 3,
+            path: session_uploads_dir(&scope, "sess").join("old.txt"),
+            destination: UploadDestination::Task,
+            session_id: "sess".to_string(),
+            created_at: 1,
+        };
+        let sidecar = session_uploads_dir(&scope, "sess").join("oldstyle.json");
+        std::fs::write(&sidecar, serde_json::to_vec(&legacy).unwrap()).unwrap();
+        assert_eq!(
+            find_upload("legacy-upload-id", &session_dir, &scope).map(|d| d.id),
+            Some("legacy-upload-id".to_string()),
+            "legacy-named sidecars still resolve via the fallback scan"
+        );
+        assert!(
+            find_upload_by_prefix("legacy-upload-id", &session_dir, &scope).is_none(),
+            "the fast path alone must not claim legacy-named sidecars"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Efficiency-audit implementation batch for the peers/transfers lane (audit scopes 17 + 12). Every finding was re-verified against current main (post-#339) before implementation; items already fixed or out of this lane's file fence are noted.

## Scope 17 — peer federation + transfers

| Finding | Status |
|---|---|
| 1. Live-authority re-verified per packet + twice per 16 KiB chunk (identity-store stat + process-global mutex, ~6,400/s at 50 MB/s) | **Fixed** — positive verdicts memoized 100 ms in a `LiveTransferAuthority` wrapper shared by driver + read streams; the authority tick and the request-authorization path always verify fresh; negative verdicts never memoized; tests pin `tick + TTL <= 500 ms` and fresh-path revocation |
| 2. No datachannel backpressure — SCTP pending queue grows at disk speed (hundreds of MB per 512 MB read over a slow WAN) | **Fixed** — buffered-amount watermarks on the transfer channel (4 MiB high / 1 MiB low, the display pipeline's event pattern) gate the driver's command lane; readers park on the bounded command channel. Concurrent read streams capped at 4/session (was uncapped, amplifying the queue) |
| 3. TLS client material rebuilt per connect attempt and per peer MCP tool call (PEM re-reads + native root-store load; fresh reqwest client per call, zero keep-alive) | **Fixed** — `TlsClientCache` on `TransportCredentials`: one rustls config + one pooled HTTP client per credentials bundle, revalidated by stat fingerprint of the identity PEMs (rotation applies on next use) and pin-set equality. The registry's one-shot card probe and `ctl` keep the uncached helpers |
| 4. peers.jsonl logs the full streaming firehose, unbounded, duplicating streamed output | **Fixed** — `Message{partial:true}` deltas skip the durable sink (broadcast unchanged; seq gaps mark elisions); size rotation at 64 MiB with one retained generation |
| 5. Transfer data path copies each chunk ~3x + per-packet alloc on ICE-TCP | **Fixed** — one `BytesMut` end-to-end (`read_buf` + `split_to` through `TransferCommand` into `DataChannel::send`); ICE-TCP transmits move into the writer lane instead of `to_vec` per ~1.2 KB packet |
| 6. Dashboard upload writes every byte twice (gateway spool -> copy into partial) | **Skipped** — streaming the request body into the partial requires reworking the gateway body lane (`web_gateway` routes/BodyPolicy, outside this lane's fence) and the append-claim would span the body read (audit rates it med-risk). The 2026-07-12 checkpoint rework already removed the worse half |
| 7. `find_upload` re-reads + parses every sidecar in the whole store per lookup | **Fixed** — resolve by the `{id[..8]}__` filename prefix (readdir + parse only matching sidecars), full scan kept as fallback for legacy-named blobs |

Scope-17 "other findings": `drain_ws` bootstrap prefilter frame-drop (unconditional `continue` swallowed any event nesting the literals) — **fixed**; upload chunk-length mismatch wedging the job ~15 min — **fixed** (partial truncates back to the acknowledged offset; retry succeeds immediately); reconnect thundering herd — **fixed** (per-actor jitter seed); uncapped concurrent reads — **fixed** (cap 4, part of finding 2); `AppEventUpcaster` parity twin — untouched (deliberate drift guard per module docs); dead tunnel drivers leaking their `DashboardControlRegistry` entry — verified still present, **not implemented** (teardown-ordering change; follow-up).

## Scope 12 — dashboard control tunnel

| Finding | Status |
|---|---|
| 1. Response lane re-parses + re-serializes every JSON body (3 passes; the SPA polls a multi-MB `api_sessions` body each 15 s/tab that the core already memoizes as a string) | **Fixed** — the sessions family (list/detail/both searches) answers with a pre-serialized envelope: body validated tree-free (`IgnoredAny`; the list keeps its array guard) and spliced by concatenation (the event lane's pattern); travels as an unambiguous `Value::String` carrier on the task lane, chunked on the same thresholds and `chunk_id` derivation. All other producers keep the parse path |
| 2. Byte-stream downloads materialize every chunk frame upfront then clone each at send (~5x memcpy, ~2.4x payload peak RSS, unbounded queue) | **Fixed** — `ChunkedFramePlan`: raw payload + lazily rendered chunk frames sent by move; the queue keeps exact byte accounting and refuses chunked admission past 128 MiB with an error response instead of a silent drop |
| 3. Terminal output lane: bounded listener -> unbounded channel -> unbounded SCTP queue | **Fixed** (tunnel side; the `/ws` side landed in #339) — PTY output + the open ack ride a bounded lane drained only below a control-channel buffered-amount watermark; when the wire congests the forwarders park and terminal.rs's drop-oldest bound re-engages |
| 4. `api_fs_write` upload leg reads the whole spool into RAM | **Partial** — saves <=1 MiB (the typical dashboard save) now never touch disk at all via the memory spool; the >1 MiB leg still reads back because a `SpooledBody`-consuming fs-write core lives in `web_gateway/routes_files.rs` (outside this lane's fence) — reported for a follow-up |
| 5. Every upload spools through a tempfile with per-chunk blocking writes on the wire-driver task (incl. each presence webcam frame) | **Fixed** — `UploadSpool::Memory` for declared sizes <=1 MiB (webcam frames + typical saves: zero disk I/O, bytes taken by move); larger uploads batch disk writes through a 256 KiB buffer instead of a syscall per 16 KiB chunk |
| 6. Per-request deep clones of ControlRuntime's config/agent-card trees + double params clones | **Fixed** — both trees Arc-shared; `params_body_text` serializes the borrow |
| 7. `control_method_spec` linear-scans ~150 entries >=2x per request | **Fixed** — OnceLock HashMap with first-wins insertion (preserves the table's rows-over-residue resolution) |
| 8. PTY reader: 4 KiB buffer + heap Vec per read | **Fixed** — 64 KiB buffer, no per-read Vec |

Scope-12 "other findings": terminal input ordering race (per-keystroke `tokio::spawn`) — verified still present, **not implemented** (wants the display-input F1 ordered-forwarder treatment; follow-up); `opening_authority` memoization — already landed in #339 (excluded per lane brief).

Also verified as N/A: `mcp_client.rs` has no TLS surface (it is the stdio child-process MCP client) — the TLS-caching finding lives in `peer/mcp_http.rs` + `peer/transport/tls_client.rs`, fixed above; `ws_session.rs`'s PTY-lane bounds landed in #339 and were not redone.

## Battery

- `cargo fmt --check` clean
- `cargo clippy` clean
- `cargo test --bins` green
- `cargo test --test e2e` green

## Operator note — peers.jsonl retention change

`peers.jsonl` retention is now **BOUNDED**: the log rotates at 64 MiB with one retained generation (`peers.jsonl.1`), so the durable record holds roughly the newest ~128 MiB instead of growing for the daemon's lifetime. The log includes peer-acceptance records; anything older than two generations is discarded at rotation. Streaming partials are elided (finals carry complete text; an interrupted reply lands as one coalesced `partial: true` salvage record at disconnect — in the log that marker now appears only on salvage records). Making the generation count configurable is a follow-up.

## Review fix round (dual review, reconciled)

| Item | Disposition |
|---|---|
| FIX1 TLS stamp: len+mtime missed same-length preserved-mtime rotation | **Fixed** — repo-standard fingerprint (dev+ino+mtime_ns+len, `PeerRecordFingerprint` vocabulary); cfg(unix) test replaces the cert atomically with identical bytes + preserved mtime and pins the rebuild |
| FIX2 authority memo check-then-stamp race | **Fixed** — fresh check runs under the memo lock (order memo → identity-cache global; no reverse path); a fresh negative clears the memo; invariant doc + tests upgraded |
| FIX3 read-id reuse orphaning the replacement; stuck cancelled sends; droppable rejections | **Fixed** — generation-keyed registry entries + completion commands (removal requires a match; unit-tested), all stream sends select against the cancel token, and rejections return to the driver for a direct datachannel send (never a droppable try_send) |
| FIX4 128 MiB admission bypasses (immediate frames, no-credit eager path, unbounded spawns) | **Fixed** — immediate frames under the byte cap + a 4096-frame count cap; the no-credit chunked path refuses while the control channel is above its buffered-amount high watermark (`control_wire_congested`); spawned requests reserved at spawn time (64 in flight, same-id replacement exempt) |
| FIX5 inbound upload floods | **Fixed** — per-connection admission at upload_start (8 concurrent, 256 MiB aggregate declared) and the memory spool allocates lazily (no more declared-size reservation) |
| FIX6 interrupted reply text lost by partial elision | **Fixed** — per-message fold, ONE coalesced `partial: true` salvage record at disconnect (capped, flush-on-cap); finals clear their fold; broadcast unchanged; two tests |
| FIX7 two separate TLS caches (handle vs transports) | **Fixed** — transports built from clones of the handle's bundle; one shared `TlsClientCache` cell |
| FIX8 polish | **Fixed** — `chunk_count()`→0 at zero chunk size; `watermark_to_u32` deduped; pause-coupling comment on the transfer command lane; operator note above; non-ASCII/control-char splice fixtures |

## Review round 2 (Codex delta)

| Item | Disposition |
|---|---|
| R2-1 Windows TLS-stamp gap (`metadata_dev_ino` → `(0,0)`) | **Fixed** — the stamp carries `platform::FileIdentity` (Unix dev+ino, Windows volume serial + file index via an open handle; len+mtime_ns fallback where no reliable identity exists); the preserved-stamp rotation test now has a `cfg(windows)` mirror so the merge group's Windows leg runs it |
| R2-2 same-id exemption defeated the 64-task bound (uncancelled predecessors, cross-wired responses, freed reservations) | **Fixed** — `PendingControlRequests`: generation-bearing reservations (the FIX3 pattern); completion frees only its own generation; the driver drops stale-generation responses whole. **Chosen cancellation seam:** the spawn wrappers `select!` on the reservation token, so a superseded handler future dies at its next await point — chosen over threading tokens into every handler (dozens of signatures incl. out-of-lane cores) because the seam bounds live async work identically; an already-entered `spawn_blocking` segment runs out on the blocking pool and drops its output. The same-id exemption is KEPT — with generations + seam cancellation, replacement genuinely displaces its predecessor. Upload commits run to completion by design (documented); their responses ride the same generation gate |
| R2-3 rejection/error frames bypassed all backpressure | **Fixed** — shared `DirectErrorBudget` (64 tokens while congested, refilled when the wire drains; beyond it frames drop, logged once + teardown summary) on both the peer transfer rejection path and all dashboard admission-refusal sends — best-effort error delivery under abuse, bounded memory always |
| R2-4 flush-on-cap minted false salvage records; fold byte-unbounded | **Fixed** — cap pressure EVICTS the oldest fold silently (salvage records exist for disconnect/abort only; an evicted message that finalizes logs only its final — documented); per-fold 256 KiB TAIL cap (most recent text kept); **round 3 correction:** `drain` alone retained String capacity, so the 8×256 KiB figure originally held for length only — the fold now shrinks its buffer after each trim, making the bound hold on the heap too (transiently plus one in-flight delta); disconnect salvage lands in fold order; tests pin no-false-salvage, eviction, and tail-keeping |


## Review round 3 (Codex confirmation delta)

| Item | Disposition |
|---|---|
| R3-1 replacement freed the reservation while the predecessor's work ran untracked; stale sends queued payloads; stream lane unwrapped | **Fixed** — admission is now bounded by LIVE WORK: `admit` hands the spawned task an RAII `LiveWorkSlot` freed only at task exit; handlers run to completion instead of being select-dropped (dropping the future detached in-flight `spawn_blocking` work outside the bound), so a draining predecessor keeps its slot and same-id cycling saturates the 64 bound and is refused; the same-id capacity exemption is removed; `task_tx.send` sits inside the cancellation select (stale completed responses drop instead of queuing payloads); the stream lane rides the same wrapper (slot + token; the framer polls per line and an early exit stops the detached producer at its next send). Tests: same-id cycling saturates/frees via slots only; a spawned task's slot frees on its actual exit |
| R3-2 upload commits escaped the bound | **Fixed** — the live-work slot minted at `upload_start` rides the receiving state INTO the commit task (one continuous slot from first frame to commit completion); `upload_start` checks the live-work bound; committing uploads hold a second RAII ledger counted by the 8-concurrent cap until the commit finishes |
| R3-3 ordinary error frames bypassed the budget; zero budget tests | **Fixed** — ERROR-class frames (`ok:false` envelopes and `_httpOk:false` results) are budgeted at the immediate-frame send seam itself (one choke point; success frames unaffected; the queued branch stays under the queue caps); regression tests pin budget hysteresis (64 while congested, refill on drain), drop counting, and the ERROR classification |
| R3-4 fold byte bound held for length, not heap | **Fixed** — the fold shrinks its buffer to the cap after each tail trim; the PR-body claim above is corrected in place, and the correcting commit message states the original claim was wrong (the original commit is not amended — history stays append-only) |


## Review round 4 (Codex confirmation delta)

| Item | Disposition |
|---|---|
| R4-1 stream slot freed before its producer exited | **Fixed** — every mid-stream framer exit (cancellation, send failure, invalid JSON) hands the slot + line receiver to a drain task that discards lines until `recv()` returns `None` (the producer dropping its sender = the producer function returning): slot lifetime equals producer lifetime by construction, zero producer-side/web_gateway changes. The deliberate fail-closed occupancy is documented on `MAX_PENDING_CONTROL_REQUESTS`: slots measure live work, a wedged op holds its slot until teardown — bounded memory, not bounded latency. Test: cancelled stream with a still-running producer holds the slot until the producer's sender drops, then frees |
| R4-2 committing uploads escaped the 256 MiB aggregate | **Fixed** — the commit ledger carries each commit's byte weight (actual received size), counted against the aggregate until the commit completes. Test: two 90 MiB in-flight commits refuse a third 90 MiB upload_start on the declared-bytes budget; dropping the commit slots re-admits it |
| R4-3 pre-serialized carrier bypassed congestion + budget | **Fixed** — small preserialized frames now ENQUEUE whenever the wire is congested or the queue is non-empty (FIFO fairness), direct-sending only on an uncongested empty queue; the queued-frame drain is gated on congestion so the queue caps genuinely bind (queue-full answers a budgeted error). Frame-count-cap spam test added |
| R4-4 capped fold thrashed; capacity claim not guaranteed | **Fixed** — trim BEFORE append (length never overshoots), trim to HALF the cap (front-shifts amortize to ~one move per 128 KiB streamed), oversized single deltas keep only their tail, `shrink_to` demoted to a rare safety valve above the documented 2×-cap slack; the test streams a long run of small deltas asserting BOTH length ≤ cap and capacity ≤ 2× cap |
| R4-5 round-3 message overstatements | **Corrected** — the round-4 dash commit message explicitly notes 9bbc0139's two overstatements ("every producer covered" excluded the preserialized carrier; the 256 MiB aggregate excluded committing bytes), append-only as before |


## Review round 5 (Codex confirmation delta)

| Item | Disposition |
|---|---|
| ITEM1 empty-ID congestion bypass (id-less requests spawned; empty-id carriers skipped queueing AND chunking) | **Fixed at the root** — request frames with an empty/absent id are rejected at dispatch BEFORE any spawn: an id-less request cannot receive a correlated response, so it has no legitimate use on this lane. **Sweep result:** no legitimate empty-id sender exists — the in-tree dashboard client mints `dc-<timestamp>-<seq>` ids on all three send paths (`request`, `requestBytes`, stream) and no in-tree test sends an id-less request frame, so rejection (not synthetic-id minting) is the right shape. The rejection is an `ok:false` frame riding the budgeted error-class seam. Regression tests: id-less/empty-id spam answers only budgeted rejections with zero live-work spawned and no task-lane traffic; and the prescribed send-path pin — a congested NON-empty pre-serialized response QUEUES under the caps (the congestion-gated drain holds it) while an uncongested empty queue direct-sends |
