### PR TITLE
sweep: efficiency-audit leftovers — batch-facts single parse, worktree off the supervisor loop, rewind scan reuse, agent-output fetch

### DIFF
--- a/crates/intendant-platform/src/platform.rs
+++ b/crates/intendant-platform/src/platform.rs
@@ -1357,6 +1357,29 @@ pub struct FileChangeStamp {
     pub identity: FileIdentity,
 }
 
+impl FileChangeStamp {
+    /// The change signal normalized to nanoseconds since the Unix epoch —
+    /// one clock domain for wall-clock comparisons (racy-write quiescence
+    /// windows) regardless of platform. The signal's *fields* are
+    /// nanosecond-precision, but the value comes from the kernel's coarse
+    /// file-timestamp clock (Linux jiffies ~4-10 ms, NTFS ~15 ms, FAT up to
+    /// 2 s), so equal stamps only prove "no change observed at that
+    /// granularity" — quiescence callers must allow for the coarsest real
+    /// granule.
+    pub fn change_signal_unix_nanos(&self) -> i128 {
+        #[cfg(windows)]
+        {
+            // FILETIME epoch (1601-01-01) precedes the Unix epoch by
+            // 11_644_473_600 s; the signal is in 100 ns units.
+            (self.change_signal - 116_444_736_000_000_000) * 100
+        }
+        #[cfg(not(windows))]
+        {
+            self.change_signal
+        }
+    }
+}
+
 /// Best-available change stamp for the file at `path`.
 ///
 /// Unix reads both fields from `metadata` (no extra I/O). Windows needs an

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -1699,10 +1699,14 @@ pub(crate) async fn run_agent_loop(
             empty_command_streak = 0;
 
             // Inject project context and normalize
-            let json_str = normalize_command_batch(&inject_project_context(json_str, project));
+            let json_str = finalize_command_batch(json_str, project);
+            // One parse of the final batch answers every per-batch question
+            // below (ask-human rail, Xvfb triggers, Activity preview, runtime
+            // timeout selection) — these used to be separate full re-parses.
+            let batch_facts = BatchFacts::from_json(&json_str);
 
             // Headless askHuman check — skip unless JSON mode (which handles it via stdin)
-            if headless && json_approval.is_none() && has_ask_human_command(&json_str) {
+            if headless && json_approval.is_none() && batch_facts.has_ask_human {
                 slog(&session_log, |l| {
                     l.warn("askHuman requested in headless mode; prompting model to continue")
                 });
@@ -1720,7 +1724,7 @@ pub(crate) async fn run_agent_loop(
             }
             // In JSON mode, emit the question so the outbound broadcaster prints it
             if json_approval.is_some() {
-                if let Some(question) = extract_ask_human_question(&json_str) {
+                if let Some(question) = batch_facts.ask_human_question.clone() {
                     bus.send(AppEvent::HumanQuestionDetected { question });
                 }
             }
@@ -1733,9 +1737,11 @@ pub(crate) async fn run_agent_loop(
             // Scope: batches that are entirely askHuman (the shape models
             // emit — a blocking question stands alone); a mixed batch keeps
             // the legacy path and logs why.
-            if !headless && json_approval.is_none() && has_ask_human_command(&json_str) {
-                if batch_is_all_ask_human(&json_str) {
-                    let question = extract_ask_human_question(&json_str)
+            if !headless && json_approval.is_none() && batch_facts.has_ask_human {
+                if batch_facts.all_ask_human {
+                    let question = batch_facts
+                        .ask_human_question
+                        .clone()
                         .unwrap_or_else(|| "The agent asked for your input.".to_string());
                     slog(&session_log, |l| l.human_question(&question));
                     let question_id = turn as u64;
@@ -2050,8 +2056,8 @@ pub(crate) async fn run_agent_loop(
 
             // Run agent
             slog(&session_log, |l| l.agent_input(&json_str));
-            maybe_auto_launch_xvfb(&json_str, xvfb_guard, provider.name(), &session_log).await;
-            let preview = format_commands_preview(&json_str);
+            maybe_auto_launch_xvfb(&batch_facts, xvfb_guard, provider.name(), &session_log).await;
+            let preview = batch_facts.commands_preview.clone();
             bus.send(AppEvent::AgentStarted {
                 session_id: local_session_id.clone(),
                 turn,
@@ -2063,9 +2069,14 @@ pub(crate) async fn run_agent_loop(
             // Read the grant fresh from the autonomy guard at every runtime
             // spawn so a mid-session grant/revoke reaches the next child.
             let user_display_granted = autonomy.read().await.user_display_granted;
-            let output =
-                agent_runner::run_agent(&json_str, log_dir, &project.root, user_display_granted)
-                    .await?;
+            let output = agent_runner::run_agent(
+                &json_str,
+                log_dir,
+                &project.root,
+                user_display_granted,
+                batch_facts.has_ask_human,
+            )
+            .await?;
             let output_id = event::next_agent_output_id();
 
             // Log agent output
@@ -2254,10 +2265,13 @@ pub(crate) async fn run_agent_loop(
             empty_command_streak = 0;
 
             // Inject project context (memory_file) into commands and normalize aliases.
-            let json_str = normalize_command_batch(&inject_project_context(&json_str, project));
+            let json_str = finalize_command_batch(&json_str, project);
+            // One parse of the final batch answers every per-batch question
+            // below (see the JSON-batch twin above).
+            let batch_facts = BatchFacts::from_json(&json_str);
 
             // In headless mode there is no askHuman input panel — skip unless JSON mode.
-            if headless && json_approval.is_none() && has_ask_human_command(&json_str) {
+            if headless && json_approval.is_none() && batch_facts.has_ask_human {
                 slog(&session_log, |l| {
                     l.warn("askHuman requested in headless mode; prompting model to continue")
                 });
@@ -2271,7 +2285,7 @@ Proceed with explicit assumptions and continue without additional questions."
             }
             // In JSON mode, emit the question so the outbound broadcaster prints it
             if json_approval.is_some() {
-                if let Some(question) = extract_ask_human_question(&json_str) {
+                if let Some(question) = batch_facts.ask_human_question.clone() {
                     bus.send(AppEvent::HumanQuestionDetected { question });
                 }
             }
@@ -2279,8 +2293,10 @@ Proceed with explicit assumptions and continue without additional questions."
             // JSON-batch twin above). The text loop mirrors its headless
             // precedent: the batch is consumed by the question — the model
             // re-issues any other commands after reading the answer.
-            if !headless && json_approval.is_none() && has_ask_human_command(&json_str) {
-                let question = extract_ask_human_question(&json_str)
+            if !headless && json_approval.is_none() && batch_facts.has_ask_human {
+                let question = batch_facts
+                    .ask_human_question
+                    .clone()
                     .unwrap_or_else(|| "The agent asked for your input.".to_string());
                 slog(&session_log, |l| l.human_question(&question));
                 let question_id = turn as u64;
@@ -2576,9 +2592,9 @@ Proceed with explicit assumptions and continue without additional questions."
 
             // Log the full JSON being sent to the agent
             slog(&session_log, |l| l.agent_input(&json_str));
-            maybe_auto_launch_xvfb(&json_str, xvfb_guard, provider.name(), &session_log).await;
+            maybe_auto_launch_xvfb(&batch_facts, xvfb_guard, provider.name(), &session_log).await;
 
-            let preview = format_commands_preview(&json_str);
+            let preview = batch_facts.commands_preview.clone();
             bus.send(AppEvent::AgentStarted {
                 session_id: local_session_id.clone(),
                 turn,
@@ -2590,9 +2606,14 @@ Proceed with explicit assumptions and continue without additional questions."
             // Read the grant fresh from the autonomy guard at every runtime
             // spawn so a mid-session grant/revoke reaches the next child.
             let user_display_granted = autonomy.read().await.user_display_granted;
-            let output =
-                agent_runner::run_agent(&json_str, log_dir, &project.root, user_display_granted)
-                    .await?;
+            let output = agent_runner::run_agent(
+                &json_str,
+                log_dir,
+                &project.root,
+                user_display_granted,
+                batch_facts.has_ask_human,
+            )
+            .await?;
             let output_id = event::next_agent_output_id();
 
             // Log agent output

--- a/src/bin/caller/agent_runner.rs
+++ b/src/bin/caller/agent_runner.rs
@@ -438,7 +438,10 @@ mod tests {
     /// to lossy replacement (the pre-move behavior for both cases).
     #[test]
     fn output_buf_into_string_moves_utf8_and_lossy_falls_back() {
-        assert_eq!(output_buf_into_string(b"plain output".to_vec()), "plain output");
+        assert_eq!(
+            output_buf_into_string(b"plain output".to_vec()),
+            "plain output"
+        );
         let mut broken = b"tail: ".to_vec();
         broken.push(0xFF);
         assert_eq!(output_buf_into_string(broken), "tail: \u{FFFD}");

--- a/src/bin/caller/agent_runner.rs
+++ b/src/bin/caller/agent_runner.rs
@@ -98,20 +98,11 @@ pub struct AgentOutput {
     pub stderr: String,
 }
 
-fn has_ask_human(json_input: &str) -> bool {
-    let parsed: serde_json::Value = match serde_json::from_str(json_input) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-    parsed
-        .get("commands")
-        .and_then(|v| v.as_array())
-        .map(|commands| {
-            commands
-                .iter()
-                .any(|cmd| cmd.get("function").and_then(|v| v.as_str()) == Some("askHuman"))
-        })
-        .unwrap_or(false)
+/// Convert captured child output to a `String` without copying: the buffer
+/// is moved when it is valid UTF-8 (the overwhelmingly common case) and only
+/// the invalid-UTF-8 path pays a lossy re-allocation.
+fn output_buf_into_string(buf: Vec<u8>) -> String {
+    String::from_utf8(buf).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
 }
 
 /// True when `line` is a complete runtime protocol line: JSON with a
@@ -141,20 +132,24 @@ fn output_with_exit_status(
     stderr_buf: Vec<u8>,
     status: ExitStatus,
 ) -> Result<AgentOutput, CallerError> {
-    let stdout = String::from_utf8_lossy(&stdout_buf).to_string();
-    let mut stderr = String::from_utf8_lossy(&stderr_buf).to_string();
+    // Failure triage borrows the buffers; the success path then MOVES them
+    // into the returned strings (this used to memcpy the full — up to 64 MB —
+    // output through `from_utf8_lossy(..).to_string()` on every batch).
+    if !status.success() && !has_parseable_runtime_output(&stdout_buf) {
+        let stderr = output_buf_into_string(stderr_buf);
+        let stderr_tail = stderr.trim();
+        let detail = if stderr_tail.is_empty() {
+            String::new()
+        } else {
+            format!("; stderr: {stderr_tail}")
+        };
+        return Err(CallerError::Agent(format!(
+            "sandboxed runtime exited with {status} before producing parseable output{detail}"
+        )));
+    }
+    let stdout = output_buf_into_string(stdout_buf);
+    let mut stderr = output_buf_into_string(stderr_buf);
     if !status.success() {
-        if !has_parseable_runtime_output(&stdout_buf) {
-            let stderr_tail = stderr.trim();
-            let detail = if stderr_tail.is_empty() {
-                String::new()
-            } else {
-                format!("; stderr: {stderr_tail}")
-            };
-            return Err(CallerError::Agent(format!(
-                "sandboxed runtime exited with {status} before producing parseable output{detail}"
-            )));
-        }
         if !stderr.ends_with('\n') && !stderr.is_empty() {
             stderr.push('\n');
         }
@@ -170,11 +165,17 @@ fn output_with_exit_status(
 /// `user_display_granted` is the autonomy guard's grant state, read by the
 /// caller at spawn time — the runtime child observes it as
 /// `INTENDANT_USER_DISPLAY_GRANTED` on its environment.
+///
+/// `has_ask_human` selects the no-timeout path for batches containing
+/// `askHuman` (which polls indefinitely for the user). The caller derives it
+/// once per batch (`tool_batch::BatchFacts`) — this function used to re-parse
+/// the entire batch JSON, including full editFile payloads, to answer it.
 pub async fn run_agent(
     json_input: &str,
     log_dir: &std::path::Path,
     workdir: &std::path::Path,
     user_display_granted: bool,
+    has_ask_human: bool,
 ) -> Result<AgentOutput, CallerError> {
     // Linux enforces this via Landlock inside the runtime; macOS wraps the
     // runtime in sandbox-exec; Windows re-execs inside the runtime under a
@@ -195,6 +196,7 @@ pub async fn run_agent(
                 Some(workdir),
                 Some(&sandbox),
                 user_display_granted,
+                has_ask_human,
             )
             .await;
         }
@@ -205,6 +207,7 @@ pub async fn run_agent(
         Some(workdir),
         None,
         user_display_granted,
+        has_ask_human,
     )
     .await
 }
@@ -216,6 +219,7 @@ pub async fn run_agent_sandboxed(
     log_dir: &std::path::Path,
     sandbox: &crate::sandbox::SandboxConfig,
     user_display_granted: bool,
+    has_ask_human: bool,
 ) -> Result<AgentOutput, CallerError> {
     run_agent_inner(
         json_input,
@@ -223,6 +227,7 @@ pub async fn run_agent_sandboxed(
         None,
         Some(sandbox),
         user_display_granted,
+        has_ask_human,
     )
     .await
 }
@@ -233,6 +238,7 @@ async fn run_agent_inner(
     workdir: Option<&std::path::Path>,
     sandbox: Option<&crate::sandbox::SandboxConfig>,
     user_display_granted: bool,
+    has_ask_human: bool,
 ) -> Result<AgentOutput, CallerError> {
     let agent_path = std::env::current_exe()
         .ok()
@@ -326,8 +332,7 @@ async fn run_agent_inner(
     }
 
     // Hard timeout: 120s default, no timeout for askHuman (polls indefinitely)
-    let has_human = has_ask_human(json_input);
-    let hard_timeout_secs: u64 = if has_human { u64::MAX / 2 } else { 120 };
+    let hard_timeout_secs: u64 = if has_ask_human { u64::MAX / 2 } else { 120 };
     let hard_timeout = Duration::from_secs(hard_timeout_secs);
 
     // Read stdout and stderr (bounded), then wait for exit, all under a
@@ -376,8 +381,8 @@ async fn run_agent_inner(
             // work the model would just redo; commands with no result line
             // surface as missing downstream.
             if let Some(salvaged) = salvage_partial_stdout(stdout_buf) {
-                let stdout = String::from_utf8_lossy(&salvaged).to_string();
-                let mut stderr = String::from_utf8_lossy(&stderr_buf).to_string();
+                let stdout = output_buf_into_string(salvaged);
+                let mut stderr = output_buf_into_string(stderr_buf);
                 if !stderr.ends_with('\n') && !stderr.is_empty() {
                     stderr.push('\n');
                 }
@@ -429,29 +434,14 @@ fn salvage_partial_stdout(mut stdout_buf: Vec<u8>) -> Option<Vec<u8>> {
 mod tests {
     use super::*;
 
+    /// Valid UTF-8 moves through without a copy; invalid UTF-8 falls back
+    /// to lossy replacement (the pre-move behavior for both cases).
     #[test]
-    fn has_ask_human_detects_function() {
-        let json = r#"{"commands":[{"function":"askHuman","nonce":1,"question":"Which DB?"}]}"#;
-        assert!(has_ask_human(json));
-    }
-
-    #[test]
-    fn has_ask_human_false_for_other() {
-        let json = r#"{"commands":[{"function":"execAsAgent","nonce":1,"command":"ls"}]}"#;
-        assert!(!has_ask_human(json));
-    }
-
-    #[test]
-    fn has_ask_human_mixed_commands() {
-        let json = r#"{"commands":[{"function":"execAsAgent","nonce":1,"command":"ls"},{"function":"askHuman","nonce":2,"question":"ok?"}]}"#;
-        assert!(has_ask_human(json));
-    }
-
-    #[test]
-    fn has_ask_human_false_for_text_only() {
-        let json =
-            r#"{"commands":[{"function":"execAsAgent","nonce":1,"command":"echo \"askHuman\""}]}"#;
-        assert!(!has_ask_human(json));
+    fn output_buf_into_string_moves_utf8_and_lossy_falls_back() {
+        assert_eq!(output_buf_into_string(b"plain output".to_vec()), "plain output");
+        let mut broken = b"tail: ".to_vec();
+        broken.push(0xFF);
+        assert_eq!(output_buf_into_string(broken), "tail: \u{FFFD}");
     }
 
     #[test]

--- a/src/bin/caller/context_rewind.rs
+++ b/src/bin/caller/context_rewind.rs
@@ -147,13 +147,46 @@ pub fn read_record(log_dir: &Path, record_id: &str) -> io::Result<ContextRewindR
 }
 
 pub fn list_records(log_dir: &Path) -> io::Result<Vec<ContextRewindRecord>> {
+    list_records_as(log_dir)
+}
+
+/// Identity/metadata view of a rewind record, for callers that never touch
+/// the heavyweight embedded snapshots. A full record carries complete
+/// `FissionLedger` + `LineageLedger` copies; listing paths that only need
+/// ids and linkage (the message-edit branch resolver walks ~500 record
+/// dirs, the surgical-recovery primer wants prior record ids) deserialize
+/// this instead — serde skips the embedded trees without materializing
+/// them. Field names match `ContextRewindRecord`, so both views read the
+/// same files.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct ContextRewindRecordSummary {
+    pub record_id: String,
+    pub created_at: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    pub thread_id: String,
+    #[serde(default)]
+    pub recovery_rollout_path: Option<PathBuf>,
+}
+
+pub fn list_record_summaries(log_dir: &Path) -> io::Result<Vec<ContextRewindRecordSummary>> {
+    list_records_as(log_dir)
+}
+
+/// Shared listing walk: every `*.json` under `context_rewinds/`,
+/// deserialized as `T` (full record or skinny summary), unparseable files
+/// skipped, newest first.
+fn list_records_as<T: serde::de::DeserializeOwned>(log_dir: &Path) -> io::Result<Vec<T>>
+where
+    T: RecordCreatedAt,
+{
     let dir = records_dir(log_dir);
     let entries = match fs::read_dir(dir) {
         Ok(entries) => entries,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(err) => return Err(err),
     };
-    let mut records: Vec<ContextRewindRecord> = Vec::new();
+    let mut records: Vec<T> = Vec::new();
     for entry in entries {
         let entry = entry?;
         let path = entry.path();
@@ -167,8 +200,25 @@ pub fn list_records(log_dir: &Path) -> io::Result<Vec<ContextRewindRecord>> {
             Err(_) => continue,
         }
     }
-    records.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    records.sort_by(|a, b| b.created_at().cmp(a.created_at()));
     Ok(records)
+}
+
+/// Sort key shared by the two record views.
+trait RecordCreatedAt {
+    fn created_at(&self) -> &str;
+}
+
+impl RecordCreatedAt for ContextRewindRecord {
+    fn created_at(&self) -> &str {
+        &self.created_at
+    }
+}
+
+impl RecordCreatedAt for ContextRewindRecordSummary {
+    fn created_at(&self) -> &str {
+        &self.created_at
+    }
 }
 
 /// Copy the live pre-rewind rollout into the recovery archive before the

--- a/src/bin/caller/context_rewind.rs
+++ b/src/bin/caller/context_rewind.rs
@@ -176,9 +176,9 @@ pub fn list_record_summaries(log_dir: &Path) -> io::Result<Vec<ContextRewindReco
 /// Shared listing walk: every `*.json` under `context_rewinds/`,
 /// deserialized as `T` (full record or skinny summary), unparseable files
 /// skipped, newest first.
-fn list_records_as<T: serde::de::DeserializeOwned>(log_dir: &Path) -> io::Result<Vec<T>>
+fn list_records_as<T>(log_dir: &Path) -> io::Result<Vec<T>>
 where
-    T: RecordCreatedAt,
+    T: serde::de::DeserializeOwned + RecordCreatedAt,
 {
     let dir = records_dir(log_dir);
     let entries = match fs::read_dir(dir) {

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -142,7 +142,7 @@ use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tool_batch::{assemble_batch_from_tool_calls, map_results_to_tool_responses};
+use tool_batch::{assemble_batch_from_tool_calls, map_results_to_tool_responses, BatchFacts};
 
 type SharedSessionLog = Arc<Mutex<session_log::SessionLog>>;
 
@@ -950,7 +950,13 @@ fn apply_context_directives(json_str: &str, conversation: &mut Conversation) -> 
     )
 }
 
-fn inject_project_context(json_str: &str, project: &Project) -> String {
+/// Finalize a command batch before dispatch: inject project context
+/// (`memory_file` on memory commands) and normalize command aliases
+/// (`writeFile` → `editFile`) in ONE parse + serialize. These were two
+/// separate helpers (`inject_project_context`, `normalize_command_batch`)
+/// chained on every batch, each paying its own full parse and re-serialize
+/// of a payload that can embed megabytes of editFile content.
+pub(crate) fn finalize_command_batch(json_str: &str, project: &Project) -> String {
     let mut value: serde_json::Value = match serde_json::from_str(json_str) {
         Ok(v) => v,
         Err(_) => return json_str.to_string(),
@@ -960,111 +966,24 @@ fn inject_project_context(json_str: &str, project: &Project) -> String {
         let memory_file = project.memory_path().to_string_lossy().to_string();
 
         for cmd in commands.iter_mut() {
-            if let Some("storeMemory" | "recallMemory") =
-                cmd.get("function").and_then(|f| f.as_str())
-            {
-                if cmd.get("memory_file").is_none() {
-                    cmd["memory_file"] = serde_json::Value::String(memory_file.clone());
+            match cmd.get("function").and_then(|f| f.as_str()) {
+                Some("storeMemory" | "recallMemory") => {
+                    if cmd.get("memory_file").is_none() {
+                        cmd["memory_file"] = serde_json::Value::String(memory_file.clone());
+                    }
                 }
+                Some("writeFile") => {
+                    cmd["function"] = serde_json::Value::String("editFile".to_string());
+                    if cmd.get("operation").is_none() {
+                        cmd["operation"] = serde_json::Value::String("write".to_string());
+                    }
+                }
+                _ => {}
             }
         }
     }
 
     serde_json::to_string(&value).unwrap_or_else(|_| json_str.to_string())
-}
-
-fn has_ask_human_command(json_str: &str) -> bool {
-    let parsed: serde_json::Value = match serde_json::from_str(json_str) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-
-    parsed
-        .get("commands")
-        .and_then(|v| v.as_array())
-        .map(|commands| {
-            commands
-                .iter()
-                .any(|cmd| cmd.get("function").and_then(|v| v.as_str()) == Some("askHuman"))
-        })
-        .unwrap_or(false)
-}
-
-/// True when the batch consists ENTIRELY of askHuman commands — the shape
-/// models actually emit for a blocking question. The question-rail
-/// interception only fires for this shape; a mixed batch would need the
-/// controller to reorder execution around the runtime.
-fn batch_is_all_ask_human(json_str: &str) -> bool {
-    let parsed: serde_json::Value = match serde_json::from_str(json_str) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-    parsed
-        .get("commands")
-        .and_then(|v| v.as_array())
-        .map(|commands| {
-            !commands.is_empty()
-                && commands
-                    .iter()
-                    .all(|cmd| cmd.get("function").and_then(|v| v.as_str()) == Some("askHuman"))
-        })
-        .unwrap_or(false)
-}
-
-/// Extract the question text from an askHuman command in a batch JSON string.
-fn extract_ask_human_question(json_str: &str) -> Option<String> {
-    let parsed: serde_json::Value = serde_json::from_str(json_str).ok()?;
-    parsed
-        .get("commands")
-        .and_then(|v| v.as_array())
-        .and_then(|commands| {
-            commands.iter().find_map(|cmd| {
-                if cmd.get("function").and_then(|v| v.as_str()) == Some("askHuman") {
-                    cmd.get("question")
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string())
-                } else {
-                    None
-                }
-            })
-        })
-}
-
-fn has_capture_screen_command(json_str: &str) -> bool {
-    let parsed: serde_json::Value = match serde_json::from_str(json_str) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-
-    parsed
-        .get("commands")
-        .and_then(|v| v.as_array())
-        .map(|commands| {
-            commands
-                .iter()
-                .any(|cmd| cmd.get("function").and_then(|v| v.as_str()) == Some("captureScreen"))
-        })
-        .unwrap_or(false)
-}
-
-fn has_exec_command(json_str: &str) -> bool {
-    let parsed: serde_json::Value = match serde_json::from_str(json_str) {
-        Ok(v) => v,
-        Err(_) => return false,
-    };
-
-    parsed
-        .get("commands")
-        .and_then(|v| v.as_array())
-        .map(|commands| {
-            commands.iter().any(|cmd| {
-                matches!(
-                    cmd.get("function").and_then(|v| v.as_str()),
-                    Some("execAsAgent" | "execPty")
-                )
-            })
-        })
-        .unwrap_or(false)
 }
 
 /// Try to encode a captureScreen result as base64 image data.
@@ -1093,49 +1012,15 @@ fn encode_screenshot(result_text: &str) -> Option<Vec<conversation::ImageData>> 
 /// 4. Launch Xvfb, store guard, set DISPLAY
 /// 5. On failure → log warning, let commands fail naturally
 ///
-/// Format raw agent JSON into a human-readable preview for the Activity tab.
-pub(crate) fn format_commands_preview(json_str: &str) -> String {
-    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(json_str) {
-        if let Some(cmds) = parsed.get("commands").and_then(|v| v.as_array()) {
-            let parts: Vec<String> = cmds
-                .iter()
-                .filter_map(|cmd| {
-                    let func = cmd.get("function").and_then(|v| v.as_str()).unwrap_or("?");
-                    match func {
-                        "execAsAgent" => cmd
-                            .get("command")
-                            .and_then(|v| v.as_str())
-                            .map(|c| format!("exec: {}", c)),
-                        "inspectPath" => cmd
-                            .get("path")
-                            .and_then(|v| v.as_str())
-                            .map(|p| format!("inspect: {}", p)),
-                        "editFile" | "writeFile" => cmd
-                            .get("file_path")
-                            .and_then(|v| v.as_str())
-                            .map(|p| format!("{}: {}", func, p)),
-                        "spawn_live_audio" => Some(format!(
-                            "spawn_live_audio ({})",
-                            cmd.get("provider").and_then(|v| v.as_str()).unwrap_or("?")
-                        )),
-                        _ => Some(func.to_string()),
-                    }
-                })
-                .collect();
-            if !parts.is_empty() {
-                return parts.join(" | ");
-            }
-        }
-    }
-    json_str.to_string()
-}
-
 /// We launch on execAsAgent (not just captureScreen) because GUI applications
 /// started in early turns must share the same display that captureScreen will
 /// later capture. Launching only on captureScreen is too late — the app would
 /// already be running on a different (or no) display.
+///
+/// `facts` carries the batch's trigger booleans, derived once per batch —
+/// this function used to re-parse the full batch JSON (twice) to answer them.
 async fn maybe_auto_launch_xvfb(
-    json_str: &str,
+    facts: &BatchFacts,
     xvfb_guard: &mut Option<vision::XvfbGuard>,
     provider_name: &str,
     session_log: &SharedSessionLog,
@@ -1143,7 +1028,7 @@ async fn maybe_auto_launch_xvfb(
     if xvfb_guard.is_some() {
         return;
     }
-    if !has_capture_screen_command(json_str) && !has_exec_command(json_str) {
+    if !facts.has_capture_screen && !facts.has_exec {
         return;
     }
     // Memoized accessible-display verdict: this function runs on every
@@ -1193,7 +1078,7 @@ async fn maybe_auto_launch_xvfb(
         return;
     }
     let config = vision::display_config_for_provider(provider_name);
-    let trigger = if has_capture_screen_command(json_str) {
+    let trigger = if facts.has_capture_screen {
         "captureScreen"
     } else {
         "execAsAgent (display needed)"
@@ -1441,28 +1326,6 @@ fn format_command_preview(json_str: &str) -> String {
     }
     // Fallback: full raw JSON (UI handles collapsing)
     json_str.to_string()
-}
-
-fn normalize_command_batch(json_str: &str) -> String {
-    let mut value: serde_json::Value = match serde_json::from_str(json_str) {
-        Ok(v) => v,
-        Err(_) => return json_str.to_string(),
-    };
-
-    let Some(commands) = value.get_mut("commands").and_then(|c| c.as_array_mut()) else {
-        return json_str.to_string();
-    };
-
-    for cmd in commands {
-        if cmd.get("function").and_then(|f| f.as_str()) == Some("writeFile") {
-            cmd["function"] = serde_json::Value::String("editFile".to_string());
-            if cmd.get("operation").is_none() {
-                cmd["operation"] = serde_json::Value::String("write".to_string());
-            }
-        }
-    }
-
-    serde_json::to_string(&value).unwrap_or_else(|_| json_str.to_string())
 }
 
 #[cfg(test)]
@@ -1781,14 +1644,14 @@ Also: {"source": "bare"}"#;
     }
 
     #[test]
-    fn inject_project_context_adds_memory_file() {
+    fn finalize_command_batch_adds_memory_file() {
         let root = std::path::PathBuf::from("/tmp/proj");
         let project = Project {
             root: root.clone(),
             config: project::ProjectConfig::default(),
         };
         let input = r#"{"commands":[{"function":"storeMemory","nonce":1,"memory_key":"test","memory_summary":"hello"}]}"#;
-        let result = inject_project_context(input, &project);
+        let result = finalize_command_batch(input, &project);
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         // Build the expected path the same platform-aware way production does
         // (via `PathBuf::join`) instead of hardcoding '/'-joined POSIX text,
@@ -1805,13 +1668,13 @@ Also: {"source": "bare"}"#;
     }
 
     #[test]
-    fn inject_project_context_preserves_existing() {
+    fn finalize_command_batch_preserves_existing_memory_file() {
         let project = Project {
             root: std::path::PathBuf::from("/tmp/proj"),
             config: project::ProjectConfig::default(),
         };
         let input = r#"{"commands":[{"function":"storeMemory","nonce":1,"memory_file":"/custom/path.json"}]}"#;
-        let result = inject_project_context(input, &project);
+        let result = finalize_command_batch(input, &project);
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert_eq!(
             parsed["commands"][0]["memory_file"].as_str().unwrap(),
@@ -1820,16 +1683,36 @@ Also: {"source": "bare"}"#;
     }
 
     #[test]
-    fn inject_project_context_ignores_unrelated() {
+    fn finalize_command_batch_ignores_unrelated() {
         let project = Project {
             root: std::path::PathBuf::from("/tmp/proj"),
             config: project::ProjectConfig::default(),
         };
         let input = r#"{"commands":[{"function":"execAsAgent","nonce":1,"command":"ls"}]}"#;
-        let result = inject_project_context(input, &project);
+        let result = finalize_command_batch(input, &project);
         let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert!(parsed["commands"][0].get("memory_file").is_none());
         assert!(parsed["commands"][0].get("project_dir").is_none());
+    }
+
+    /// The `writeFile` → `editFile` alias normalization (formerly its own
+    /// `normalize_command_batch` pass) rides the same single parse.
+    #[test]
+    fn finalize_command_batch_normalizes_write_file_alias() {
+        let project = Project {
+            root: std::path::PathBuf::from("/tmp/proj"),
+            config: project::ProjectConfig::default(),
+        };
+        let input = r#"{"commands":[{"function":"writeFile","nonce":1,"file_path":"a.txt","content":"hi"},{"function":"writeFile","nonce":2,"file_path":"b.txt","operation":"append","content":"x"}]}"#;
+        let result = finalize_command_batch(input, &project);
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["commands"][0]["function"], "editFile");
+        assert_eq!(parsed["commands"][0]["operation"], "write");
+        assert_eq!(parsed["commands"][1]["function"], "editFile");
+        // An explicit operation is preserved, not clobbered.
+        assert_eq!(parsed["commands"][1]["operation"], "append");
+        // Unparseable input passes through untouched.
+        assert_eq!(finalize_command_batch("not json", &project), "not json");
     }
 
     #[test]
@@ -2405,60 +2288,6 @@ Also: {"source": "bare"}"#;
     }
 
     #[test]
-    fn has_ask_human_command_true() {
-        let json = r#"{"commands":[{"function":"execAsAgent","nonce":1},{"function":"askHuman","nonce":2}]}"#;
-        assert!(has_ask_human_command(json));
-    }
-
-    #[test]
-    fn has_ask_human_command_false() {
-        let json = r#"{"commands":[{"function":"execAsAgent","nonce":1}]}"#;
-        assert!(!has_ask_human_command(json));
-    }
-
-    #[test]
-    fn has_ask_human_command_invalid_json() {
-        assert!(!has_ask_human_command("not json"));
-    }
-
-    #[test]
-    fn batch_is_all_ask_human_pure_batch() {
-        let json = r#"{"commands":[{"function":"askHuman","question":"a?","nonce":1},{"function":"askHuman","question":"b?","nonce":2}]}"#;
-        assert!(batch_is_all_ask_human(json));
-    }
-
-    #[test]
-    fn batch_is_all_ask_human_rejects_mixed_empty_and_invalid() {
-        let mixed = r#"{"commands":[{"function":"execAsAgent","nonce":1},{"function":"askHuman","nonce":2}]}"#;
-        assert!(!batch_is_all_ask_human(mixed));
-        assert!(!batch_is_all_ask_human(r#"{"commands":[]}"#));
-        assert!(!batch_is_all_ask_human("not json"));
-    }
-
-    #[test]
-    fn has_capture_screen_command_true() {
-        let json = r#"{"commands":[{"function":"captureScreen","nonce":1}]}"#;
-        assert!(has_capture_screen_command(json));
-    }
-
-    #[test]
-    fn has_capture_screen_command_false() {
-        let json = r#"{"commands":[{"function":"execAsAgent","nonce":1}]}"#;
-        assert!(!has_capture_screen_command(json));
-    }
-
-    #[test]
-    fn has_capture_screen_command_mixed_batch() {
-        let json = r#"{"commands":[{"function":"execAsAgent","nonce":1},{"function":"captureScreen","nonce":2}]}"#;
-        assert!(has_capture_screen_command(json));
-    }
-
-    #[test]
-    fn has_capture_screen_command_invalid_json() {
-        assert!(!has_capture_screen_command("not json"));
-    }
-
-    #[test]
     fn encode_screenshot_valid() {
         let dir = tempfile::tempdir().unwrap();
         let img_path = dir.path().join("test.png");
@@ -2496,29 +2325,6 @@ Also: {"source": "bare"}"#;
     fn encode_screenshot_missing_path_field() {
         let json = r#"{"success":true}"#;
         assert!(encode_screenshot(json).is_none());
-    }
-
-    #[test]
-    fn has_exec_command_true() {
-        let json = r#"{"commands":[{"function":"execAsAgent","nonce":1,"command":"ls"}]}"#;
-        assert!(has_exec_command(json));
-    }
-
-    #[test]
-    fn has_exec_command_pty() {
-        let json = r#"{"commands":[{"function":"execPty","nonce":1,"command":"ls"}]}"#;
-        assert!(has_exec_command(json));
-    }
-
-    #[test]
-    fn has_exec_command_false_for_non_exec() {
-        let json = r#"{"commands":[{"function":"captureScreen","nonce":1}]}"#;
-        assert!(!has_exec_command(json));
-    }
-
-    #[test]
-    fn has_exec_command_invalid_json() {
-        assert!(!has_exec_command("not json"));
     }
 
     // --- assemble_batch_from_tool_calls tests ---

--- a/src/bin/caller/managed_context_ops/anchors.rs
+++ b/src/bin/caller/managed_context_ops/anchors.rs
@@ -883,44 +883,67 @@ pub(crate) struct ContextRewindAnchorScan {
     /// `context_rewind_anchor_outcome_key`) — what
     /// `latest_context_rewind_outcome_for_anchor` answers from.
     pub(crate) latest_rewind_outcomes: HashMap<String, ContextRewindBackendUsageAtLine>,
+    /// Last backend `token_count` report in file order (the loop's EOF
+    /// value) — what `latest_context_rewind_backend_usage_in_rollout`
+    /// answers from. Carries the scan's run-tracking enrichment
+    /// (`response_start_line`/`measures_prefix_exactly`); consumers read
+    /// `used_tokens`/`rewind_only_limit`.
+    pub(crate) latest_backend_usage: Option<ContextRewindBackendUsageAtLine>,
 }
 
-/// Cached scans keyed by (path, len, mtime). One rewind/stall step
-/// re-derives the catalog up to ~9-14 times — resolve, headroom validation
-/// (plus its outcome probes), the density variant, then apply repeats all of
-/// it plus primer-facts and fission-detach prep — each pass JSON-parsing
-/// every line of a multi-MB rollout. Rollouts are append-only, so a
-/// (len, mtime) fingerprint is a sound freshness check and the whole burst
-/// is served from one scan. Slots are LRU'd so a couple of sessions
-/// rewinding concurrently don't thrash each other.
+/// Cached scans keyed by the rollout's (path, len, change stamp). One
+/// rewind/stall step re-derives the catalog up to ~9-14 times — resolve,
+/// headroom validation (plus its outcome probes), the density variant, then
+/// apply repeats all of it plus primer-facts and fission-detach prep — each
+/// pass JSON-parsing every line of a multi-MB rollout.
+///
+/// Rollouts are NOT strictly append-only: a Codex same-thread restore
+/// REWRITES the rollout in place (see `message_search/extract_codex.rs`,
+/// whose cursor layer detects exactly that as `Rewritten`), so a
+/// (len, mtime) fingerprint can alias a same-length rewrite inside one
+/// mtime granule and serve a stale catalog into rewind anchor selection.
+/// The key is therefore [`crate::platform::file_change_stamp`] — ctime /
+/// ChangeTime plus dev/ino identity, the same signal the file watcher's
+/// fingerprint cache uses — which the platform bumps on every in-place
+/// write and which replace-by-rename cannot alias. A file with no stamp
+/// (exotic filesystems) is UNCACHEABLE: every call rescans.
+///
+/// Slots are LRU'd so a couple of sessions rewinding concurrently don't
+/// thrash each other.
 const ANCHOR_SCAN_CACHE_SLOTS: usize = 4;
 
 struct CachedAnchorScan {
     path: PathBuf,
     len: u64,
-    mtime: Option<std::time::SystemTime>,
+    stamp: crate::platform::FileChangeStamp,
     scan: std::sync::Arc<ContextRewindAnchorScan>,
 }
 
 static ANCHOR_SCAN_CACHE: std::sync::Mutex<Vec<CachedAnchorScan>> =
     std::sync::Mutex::new(Vec::new());
 
+/// (len, change stamp) of the rollout; `None` stamp means no usable change
+/// signal — treat as uncacheable, never as unchanged.
+fn anchor_scan_fingerprint(
+    path: &Path,
+) -> io::Result<(u64, Option<crate::platform::FileChangeStamp>)> {
+    let meta = std::fs::metadata(path)?;
+    let stamp = crate::platform::file_change_stamp(path, &meta);
+    Ok((meta.len(), stamp))
+}
+
 /// The shared (possibly cached) scan of `source_rollout_path`. The scan is
-/// cached only when the file's (len, mtime) fingerprint is identical before
-/// and after the read, so a mid-scan append can never pin stale content
-/// under the newer fingerprint.
+/// cached only when the file's (len, change-stamp) fingerprint is available
+/// and identical before and after the read, so a mid-scan write can never
+/// pin stale content under the newer fingerprint.
 pub(crate) fn shared_context_rewind_anchor_scan(
     source_rollout_path: &Path,
 ) -> io::Result<std::sync::Arc<ContextRewindAnchorScan>> {
-    let fingerprint = |meta: std::fs::Metadata| (meta.len(), meta.modified().ok());
-    let (len, mtime) = fingerprint(std::fs::metadata(source_rollout_path)?);
-    {
+    let (len, stamp) = anchor_scan_fingerprint(source_rollout_path)?;
+    if let Some(stamp) = stamp {
         let mut cache = ANCHOR_SCAN_CACHE.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(index) = cache.iter().position(|entry| {
-            entry.len == len
-                && entry.mtime.is_some()
-                && entry.mtime == mtime
-                && entry.path == source_rollout_path
+            entry.len == len && entry.stamp == stamp && entry.path == source_rollout_path
         }) {
             let hit = cache.remove(index);
             let scan = std::sync::Arc::clone(&hit.scan);
@@ -931,22 +954,23 @@ pub(crate) fn shared_context_rewind_anchor_scan(
     let scan = std::sync::Arc::new(scan_context_rewind_anchor_catalog_uncached(
         source_rollout_path,
     )?);
-    let unchanged = std::fs::metadata(source_rollout_path)
-        .map(fingerprint)
-        .is_ok_and(|after| after == (len, mtime));
-    if unchanged && mtime.is_some() {
-        let mut cache = ANCHOR_SCAN_CACHE.lock().unwrap_or_else(|e| e.into_inner());
-        cache.retain(|entry| entry.path != source_rollout_path);
-        cache.insert(
-            0,
-            CachedAnchorScan {
-                path: source_rollout_path.to_path_buf(),
-                len,
-                mtime,
-                scan: std::sync::Arc::clone(&scan),
-            },
-        );
-        cache.truncate(ANCHOR_SCAN_CACHE_SLOTS);
+    if let Some(stamp) = stamp {
+        let unchanged = anchor_scan_fingerprint(source_rollout_path)
+            .is_ok_and(|after| after == (len, Some(stamp)));
+        if unchanged {
+            let mut cache = ANCHOR_SCAN_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+            cache.retain(|entry| entry.path != source_rollout_path);
+            cache.insert(
+                0,
+                CachedAnchorScan {
+                    path: source_rollout_path.to_path_buf(),
+                    len,
+                    stamp,
+                    scan: std::sync::Arc::clone(&scan),
+                },
+            );
+            cache.truncate(ANCHOR_SCAN_CACHE_SLOTS);
+        }
     }
     Ok(scan)
 }
@@ -1363,6 +1387,7 @@ fn scan_context_rewind_anchor_catalog_uncached(
     Ok(ContextRewindAnchorScan {
         catalog: anchors,
         latest_rewind_outcomes,
+        latest_backend_usage,
     })
 }
 
@@ -1994,38 +2019,23 @@ pub(crate) fn push_json_string_id(item: &serde_json::Value, ids: &mut Vec<String
     }
 }
 
-/// Latest backend `token_count` report in a rollout, in file order. Rollouts
-/// are append-only, so the chronologically last report is the backend's
-/// freshest usage measurement at read time. It can still be stale: when no
-/// model turn ran since an immediately preceding rollback it measured the
-/// pre-rollback context — recorded as-is, because nothing fresher exists
-/// locally and querying the backend would add an RPC to the rewind path.
+/// Latest backend `token_count` report in a rollout, in file order — the
+/// backend's freshest usage measurement at read time. It can still be
+/// stale: when no model turn ran since an immediately preceding rollback it
+/// measured the pre-rollback context — recorded as-is, because nothing
+/// fresher exists locally and querying the backend would add an RPC to the
+/// rewind path.
 ///
-/// Scans from the end: only lines carrying the `token_count` marker are
-/// JSON-parsed and the first (latest) parse that yields a report wins — the
-/// forward version parsed every line of a multi-MB rollout to keep one.
+/// Served from the shared anchor scan rather than its own file pass: the
+/// only production caller is the rewind-record writer, which runs right
+/// after the validate/apply chain has populated the scan cache for this
+/// exact rollout, so this is a map read — no additional I/O — while a
+/// dedicated pass (streaming or not) would re-read the multi-MB file the
+/// burst just parsed. One pass also means one definition of "last report".
 pub(crate) fn latest_context_rewind_backend_usage_in_rollout(
     source_rollout_path: &Path,
 ) -> io::Result<Option<ContextRewindBackendUsageAtLine>> {
-    let contents = std::fs::read_to_string(source_rollout_path)?;
-    let mut line_number = contents.lines().count();
-    for line in contents.lines().rev() {
-        let current_line = line_number;
-        line_number = line_number.saturating_sub(1);
-        // Cheap prescan: a token_count event necessarily contains the
-        // literal; payload text can false-positive, but the parse below
-        // stays the authority.
-        if !line.contains("token_count") {
-            continue;
-        }
-        let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) else {
-            continue;
-        };
-        if let Some(usage) = context_rewind_backend_usage_from_rollout_entry(current_line, &entry) {
-            return Ok(Some(usage));
-        }
-    }
-    Ok(None)
+    Ok(shared_context_rewind_anchor_scan(source_rollout_path)?.latest_backend_usage)
 }
 
 /// Pressure band for a usage measurement against the effective context
@@ -2197,50 +2207,90 @@ mod tests {
         assert!(first_usage_covering_anchor(&[], &anchor_probe(1, 1, true)).is_none());
     }
 
-    /// One scan serves a same-fingerprint burst (pointer-identical Arc);
-    /// an append invalidates it.
+    fn cache_probe_item(call_id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "call_id": call_id,
+                "arguments": "{}"
+            }
+        })
+    }
+
+    fn scan_item_ids(scan: &ContextRewindAnchorScan) -> Vec<String> {
+        scan.catalog
+            .iter()
+            .map(|anchor| anchor.item_id.clone())
+            .collect()
+    }
+
+    /// A same-fingerprint burst answers identically, and an append
+    /// invalidates the cached scan. Content equality, not `Arc::ptr_eq`:
+    /// the cache is a 4-slot process-global LRU, so parallel tests scanning
+    /// other rollouts can evict this entry between the two calls — a miss
+    /// re-derives the same content, which is the contract under test.
     #[test]
     fn anchor_scan_cache_serves_burst_and_invalidates_on_append() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("rollout.jsonl");
-        let item = serde_json::json!({
-            "type": "response_item",
-            "payload": {
-                "type": "function_call",
-                "name": "exec_command",
-                "call_id": "call_cache_probe",
-                "arguments": "{}"
-            }
-        });
-        std::fs::write(&path, format!("{item}\n")).unwrap();
+        std::fs::write(&path, format!("{}\n", cache_probe_item("call_cache_probe"))).unwrap();
 
         let first = shared_context_rewind_anchor_scan(&path).unwrap();
         let second = shared_context_rewind_anchor_scan(&path).unwrap();
-        assert!(
-            std::sync::Arc::ptr_eq(&first, &second),
-            "unchanged rollout must be served from the cached scan"
-        );
-        assert_eq!(first.catalog.len(), 1);
+        assert_eq!(scan_item_ids(&first), vec!["call_cache_probe"]);
+        assert_eq!(scan_item_ids(&first), scan_item_ids(&second));
 
-        let second_item = serde_json::json!({
-            "type": "response_item",
-            "payload": {
-                "type": "function_call",
-                "name": "exec_command",
-                "call_id": "call_cache_probe_2",
-                "arguments": "{}"
-            }
-        });
         let mut contents = std::fs::read_to_string(&path).unwrap();
-        contents.push_str(&format!("{second_item}\n"));
+        contents.push_str(&format!("{}\n", cache_probe_item("call_cache_probe_2")));
         std::fs::write(&path, contents).unwrap();
 
         let third = shared_context_rewind_anchor_scan(&path).unwrap();
-        assert!(
-            !std::sync::Arc::ptr_eq(&first, &third),
+        assert_eq!(
+            scan_item_ids(&third),
+            vec!["call_cache_probe", "call_cache_probe_2"],
             "append must invalidate the cached scan"
         );
-        assert_eq!(third.catalog.len(), 2);
+    }
+
+    /// The stale shape the change-stamp key exists for: a same-length
+    /// in-place rewrite whose mtime is restored to the original (the Codex
+    /// same-thread restore class — `message_search/extract_codex.rs`
+    /// detects the rewrite; a (len, mtime) key would serve the old
+    /// catalog). The change stamp moves on every write, so the rewritten
+    /// content must be re-scanned.
+    #[test]
+    fn anchor_scan_cache_rescans_same_size_mtime_restored_rewrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout.jsonl");
+        std::fs::write(&path, format!("{}\n", cache_probe_item("call_rewrite_a"))).unwrap();
+        let original_len = std::fs::metadata(&path).unwrap().len();
+        let original_mtime = std::fs::metadata(&path).unwrap().modified().unwrap();
+
+        let before = shared_context_rewind_anchor_scan(&path).unwrap();
+        assert_eq!(scan_item_ids(&before), vec!["call_rewrite_a"]);
+
+        // Same byte length, different content; then restore the mtime so a
+        // (len, mtime) fingerprint would alias the original file.
+        std::fs::write(&path, format!("{}\n", cache_probe_item("call_rewrite_b"))).unwrap();
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), original_len);
+        let file = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+        file.set_times(std::fs::FileTimes::new().set_modified(original_mtime))
+            .unwrap();
+        drop(file);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().modified().unwrap(),
+            original_mtime,
+            "test setup must reproduce the mtime-restored rewrite"
+        );
+
+        let after = shared_context_rewind_anchor_scan(&path).unwrap();
+        assert_eq!(
+            scan_item_ids(&after),
+            vec!["call_rewrite_b"],
+            "an mtime-restored same-size rewrite must not be served stale"
+        );
     }
 
     /// The counting-writer estimate is byte-identical to the old
@@ -2258,10 +2308,11 @@ mod tests {
         }
     }
 
-    /// Reverse scan returns the LAST report with its 1-based line number and
-    /// is not fooled by the marker appearing in unrelated payload text.
+    /// The LAST report wins, with its 1-based line number, and unrelated
+    /// payload text mentioning the marker is ignored (the lookup is served
+    /// from the shared anchor scan).
     #[test]
-    fn latest_backend_usage_reverse_scan_finds_last_report() {
+    fn latest_backend_usage_finds_last_report() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("rollout.jsonl");
         let report = |total: u64| {

--- a/src/bin/caller/managed_context_ops/anchors.rs
+++ b/src/bin/caller/managed_context_ops/anchors.rs
@@ -154,15 +154,20 @@ pub(crate) fn managed_context_edit_record_dirs(
     dirs
 }
 
+/// Rewind-record summaries for the message-edit flow, deduped across every
+/// candidate dir. Listed skinny (`ContextRewindRecordSummary`): the branch
+/// resolver only reads identity/linkage fields, and full records embed
+/// complete fission/lineage ledger copies — deserializing those for every
+/// record in ~500 candidate dirs dominated the edit action's latency.
 pub(crate) fn managed_context_edit_records(
     log_dir: &Path,
     thread_id: &str,
     session_id: Option<&str>,
-) -> Result<Vec<context_rewind::ContextRewindRecord>, String> {
+) -> Result<Vec<context_rewind::ContextRewindRecordSummary>, String> {
     let mut records = Vec::new();
     let mut seen = HashSet::new();
     for dir in managed_context_edit_record_dirs(log_dir, thread_id, session_id) {
-        let mut from_dir = context_rewind::list_records(&dir).map_err(|err| {
+        let mut from_dir = context_rewind::list_record_summaries(&dir).map_err(|err| {
             format!(
                 "failed to list managed-context rewind records in {}: {err}",
                 dir.display()
@@ -870,9 +875,93 @@ pub(crate) fn inspect_context_rewind_anchor_from_rollout(
     serde_json::to_string(&inspection).map_err(|err| err.to_string())
 }
 
+/// One full pass over a rollout: the anchor catalog plus the per-anchor
+/// latest-rewind-outcome map the same pass derives.
+pub(crate) struct ContextRewindAnchorScan {
+    pub(crate) catalog: Vec<ContextRewindAnchorCatalogEntry>,
+    /// Latest observed post-rewind usage per anchor outcome key (see
+    /// `context_rewind_anchor_outcome_key`) — what
+    /// `latest_context_rewind_outcome_for_anchor` answers from.
+    pub(crate) latest_rewind_outcomes: HashMap<String, ContextRewindBackendUsageAtLine>,
+}
+
+/// Cached scans keyed by (path, len, mtime). One rewind/stall step
+/// re-derives the catalog up to ~9-14 times — resolve, headroom validation
+/// (plus its outcome probes), the density variant, then apply repeats all of
+/// it plus primer-facts and fission-detach prep — each pass JSON-parsing
+/// every line of a multi-MB rollout. Rollouts are append-only, so a
+/// (len, mtime) fingerprint is a sound freshness check and the whole burst
+/// is served from one scan. Slots are LRU'd so a couple of sessions
+/// rewinding concurrently don't thrash each other.
+const ANCHOR_SCAN_CACHE_SLOTS: usize = 4;
+
+struct CachedAnchorScan {
+    path: PathBuf,
+    len: u64,
+    mtime: Option<std::time::SystemTime>,
+    scan: std::sync::Arc<ContextRewindAnchorScan>,
+}
+
+static ANCHOR_SCAN_CACHE: std::sync::Mutex<Vec<CachedAnchorScan>> =
+    std::sync::Mutex::new(Vec::new());
+
+/// The shared (possibly cached) scan of `source_rollout_path`. The scan is
+/// cached only when the file's (len, mtime) fingerprint is identical before
+/// and after the read, so a mid-scan append can never pin stale content
+/// under the newer fingerprint.
+pub(crate) fn shared_context_rewind_anchor_scan(
+    source_rollout_path: &Path,
+) -> io::Result<std::sync::Arc<ContextRewindAnchorScan>> {
+    let fingerprint = |meta: std::fs::Metadata| (meta.len(), meta.modified().ok());
+    let (len, mtime) = fingerprint(std::fs::metadata(source_rollout_path)?);
+    {
+        let mut cache = ANCHOR_SCAN_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(index) = cache.iter().position(|entry| {
+            entry.len == len
+                && entry.mtime.is_some()
+                && entry.mtime == mtime
+                && entry.path == source_rollout_path
+        }) {
+            let hit = cache.remove(index);
+            let scan = std::sync::Arc::clone(&hit.scan);
+            cache.insert(0, hit);
+            return Ok(scan);
+        }
+    }
+    let scan = std::sync::Arc::new(scan_context_rewind_anchor_catalog_uncached(
+        source_rollout_path,
+    )?);
+    let unchanged = std::fs::metadata(source_rollout_path)
+        .map(fingerprint)
+        .is_ok_and(|after| after == (len, mtime));
+    if unchanged && mtime.is_some() {
+        let mut cache = ANCHOR_SCAN_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        cache.retain(|entry| entry.path != source_rollout_path);
+        cache.insert(
+            0,
+            CachedAnchorScan {
+                path: source_rollout_path.to_path_buf(),
+                len,
+                mtime,
+                scan: std::sync::Arc::clone(&scan),
+            },
+        );
+        cache.truncate(ANCHOR_SCAN_CACHE_SLOTS);
+    }
+    Ok(scan)
+}
+
 pub(crate) fn scan_context_rewind_anchor_catalog(
     source_rollout_path: &Path,
 ) -> io::Result<Vec<ContextRewindAnchorCatalogEntry>> {
+    Ok(shared_context_rewind_anchor_scan(source_rollout_path)?
+        .catalog
+        .clone())
+}
+
+fn scan_context_rewind_anchor_catalog_uncached(
+    source_rollout_path: &Path,
+) -> io::Result<ContextRewindAnchorScan> {
     let file = std::fs::File::open(source_rollout_path)?;
     let reader = io::BufReader::new(file);
     let mut anchors = Vec::<ContextRewindAnchorCatalogEntry>::new();
@@ -1149,20 +1238,10 @@ pub(crate) fn scan_context_rewind_anchor_catalog(
         // report of a model run that began at/before the anchor. Reports
         // deeper in a merged run measured more than the run-start prefix and
         // must not be used as a prefix floor.
-        anchor.backend_usage_before_anchor = backend_usage
-            .iter()
-            .rev()
-            .find(|usage| {
-                usage.line <= anchor.first_line
-                    || (usage.measures_prefix_exactly
-                        && usage.response_start_line <= anchor.first_line)
-            })
-            .map(|usage| usage.used_tokens);
-        let Some(usage) = backend_usage
-            .iter()
-            .find(|usage| context_rewind_usage_covers_anchor(usage, anchor))
-            .copied()
-        else {
+        anchor.backend_usage_before_anchor =
+            latest_prefix_usage_before(&backend_usage, anchor.first_line)
+                .map(|usage| usage.used_tokens);
+        let Some(usage) = first_usage_covering_anchor(&backend_usage, anchor).copied() else {
             continue;
         };
         anchor.backend_usage_at_or_after_anchor = Some(usage.used_tokens);
@@ -1281,65 +1360,51 @@ pub(crate) fn scan_context_rewind_anchor_catalog(
             (!recovery_eligible_positions.is_empty()).then_some(recovery_eligible_positions);
     }
 
-    Ok(anchors)
+    Ok(ContextRewindAnchorScan {
+        catalog: anchors,
+        latest_rewind_outcomes,
+    })
 }
 
+/// Latest post-rewind outcome for one anchor/position, from the shared scan.
+/// The catalog pass already folds every `thread_rolled_back` marker into
+/// `latest_rewind_outcomes`; this used to re-derive the answer with its own
+/// dedicated full-file pass (two of which ran per headroom validation).
 pub(crate) fn latest_context_rewind_outcome_for_anchor(
     source_rollout_path: &Path,
     requested_item_id: &str,
     position: external_agent::RollbackAnchorPosition,
 ) -> io::Result<Option<ContextRewindBackendUsageAtLine>> {
     let key = context_rewind_anchor_outcome_key(requested_item_id, position);
-    let file = std::fs::File::open(source_rollout_path)?;
-    let reader = io::BufReader::new(file);
-    let mut pending = None::<PendingContextRewindOutcome>;
-    let mut latest_backend_usage = None::<ContextRewindBackendUsageAtLine>;
-    let mut latest = None;
-    for (line_index, line) in reader.lines().enumerate() {
-        let line = line?;
-        let Ok(entry) = serde_json::from_str::<serde_json::Value>(&line) else {
-            continue;
-        };
-        let line_number = line_index.saturating_add(1);
-        if let Some(usage) = context_rewind_backend_usage_from_rollout_entry(line_number, &entry) {
-            if let Some(pending_key) = pending.take() {
-                if pending_key.key == key {
-                    latest = Some(context_rewind_worse_usage(pending_key.prior_usage, usage));
-                }
-            }
-            latest_backend_usage = Some(usage);
-        }
-        if let Some(outcome_key) =
-            context_rewind_rollback_anchor_outcome_key_from_rollout_entry(&entry)
-        {
-            if let Some(pending_key) = pending.take() {
-                if pending_key.key == key {
-                    if let Some(prior_usage) = pending_key.prior_usage {
-                        latest = Some(prior_usage);
-                    }
-                }
-            }
-            pending = Some(PendingContextRewindOutcome {
-                key: outcome_key,
-                prior_usage: latest_backend_usage
-                    .filter(|usage| line_number.saturating_sub(usage.line) <= 3),
-            });
-        }
-    }
-    if let Some(pending_key) = pending {
-        if pending_key.key == key {
-            if let Some(prior_usage) = pending_key.prior_usage {
-                latest = Some(prior_usage);
-            }
-        }
-    }
-    Ok(latest)
+    Ok(shared_context_rewind_anchor_scan(source_rollout_path)?
+        .latest_rewind_outcomes
+        .get(&key)
+        .copied())
 }
 
+/// Byte-counting sink: serializes into nothing, keeping only the length.
+struct SerializedByteCount(usize);
+
+impl std::io::Write for SerializedByteCount {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0 += buf.len();
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// chars/4 estimate of a payload's serialized size. Counts through a sink
+/// writer — this runs once per response item in the catalog scan, and
+/// materializing every payload with `to_vec` just to read `.len()`
+/// re-allocated the entire rollout's content per scan.
 pub(crate) fn context_rewind_estimated_tokens(value: &serde_json::Value) -> u64 {
-    let chars = serde_json::to_vec(value)
-        .map(|bytes| bytes.len())
-        .unwrap_or_else(|_| value.to_string().len());
+    let mut counter = SerializedByteCount(0);
+    let chars = match serde_json::to_writer(&mut counter, value) {
+        Ok(()) => counter.0,
+        Err(_) => value.to_string().len(),
+    };
     std::cmp::max(1, chars.div_ceil(4) as u64)
 }
 
@@ -1625,6 +1690,55 @@ pub(crate) fn context_rewind_usage_covers_anchor(
     }
 }
 
+/// First report satisfying [`context_rewind_usage_covers_anchor`], by binary
+/// search. `backend_usage` is in file order, so `line` is strictly
+/// increasing and `response_start_line` non-decreasing — both branch
+/// predicates are monotone over the slice, and the catalog post-pass ran
+/// this linear probe once per anchor (anchors × reports predicate
+/// evaluations per scan).
+fn first_usage_covering_anchor<'a>(
+    backend_usage: &'a [ContextRewindBackendUsageAtLine],
+    anchor: &ContextRewindAnchorCatalogEntry,
+) -> Option<&'a ContextRewindBackendUsageAtLine> {
+    let index = if anchor.last_item_is_model {
+        backend_usage.partition_point(|usage| usage.line < anchor.last_line)
+    } else {
+        backend_usage.partition_point(|usage| usage.response_start_line <= anchor.last_line)
+    };
+    // The boundary element always satisfies the predicate when the slice is
+    // ordered as documented; the filter re-checks it so a future de-sync of
+    // the partition predicates degrades to "no report" instead of a wrong
+    // attribution.
+    backend_usage
+        .get(index)
+        .filter(|usage| context_rewind_usage_covers_anchor(usage, anchor))
+}
+
+/// Last report that measured a strict prefix of an anchor at `first_line`:
+/// the latest with `line <= first_line`, or — later in the file — the
+/// latest exact run-start report of a model run that began at/before the
+/// anchor. Binary-search equivalent of the old
+/// `rev().find(line <= first || (measures_prefix_exactly && response_start
+/// <= first))`: matches past the run boundary are impossible (a report's
+/// `line` never precedes its `response_start_line`), matches between the
+/// two boundaries need the exact-run-start flag, and everything at or
+/// before the line boundary matches outright — so the last overall match is
+/// the last flagged report in the window, else the boundary report.
+fn latest_prefix_usage_before(
+    backend_usage: &[ContextRewindBackendUsageAtLine],
+    first_line: usize,
+) -> Option<ContextRewindBackendUsageAtLine> {
+    let line_boundary = backend_usage.partition_point(|usage| usage.line <= first_line);
+    let run_boundary =
+        backend_usage.partition_point(|usage| usage.response_start_line <= first_line);
+    backend_usage[line_boundary..run_boundary.max(line_boundary)]
+        .iter()
+        .rev()
+        .find(|usage| usage.measures_prefix_exactly)
+        .or_else(|| line_boundary.checked_sub(1).map(|i| &backend_usage[i]))
+        .copied()
+}
+
 pub(crate) fn context_rewind_anchor_names(item: &serde_json::Value) -> Vec<String> {
     item.get("name")
         .and_then(|value| value.as_str())
@@ -1886,24 +2000,32 @@ pub(crate) fn push_json_string_id(item: &serde_json::Value, ids: &mut Vec<String
 /// model turn ran since an immediately preceding rollback it measured the
 /// pre-rollback context — recorded as-is, because nothing fresher exists
 /// locally and querying the backend would add an RPC to the rewind path.
+///
+/// Scans from the end: only lines carrying the `token_count` marker are
+/// JSON-parsed and the first (latest) parse that yields a report wins — the
+/// forward version parsed every line of a multi-MB rollout to keep one.
 pub(crate) fn latest_context_rewind_backend_usage_in_rollout(
     source_rollout_path: &Path,
 ) -> io::Result<Option<ContextRewindBackendUsageAtLine>> {
-    let file = std::fs::File::open(source_rollout_path)?;
-    let reader = io::BufReader::new(file);
-    let mut latest = None;
-    for (line_index, line) in reader.lines().enumerate() {
-        let line = line?;
-        let Ok(entry) = serde_json::from_str::<serde_json::Value>(&line) else {
+    let contents = std::fs::read_to_string(source_rollout_path)?;
+    let mut line_number = contents.lines().count();
+    for line in contents.lines().rev() {
+        let current_line = line_number;
+        line_number = line_number.saturating_sub(1);
+        // Cheap prescan: a token_count event necessarily contains the
+        // literal; payload text can false-positive, but the parse below
+        // stays the authority.
+        if !line.contains("token_count") {
+            continue;
+        }
+        let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) else {
             continue;
         };
-        if let Some(usage) =
-            context_rewind_backend_usage_from_rollout_entry(line_index.saturating_add(1), &entry)
-        {
-            latest = Some(usage);
+        if let Some(usage) = context_rewind_backend_usage_from_rollout_entry(current_line, &entry) {
+            return Ok(Some(usage));
         }
     }
-    Ok(latest)
+    Ok(None)
 }
 
 /// Pressure band for a usage measurement against the effective context
@@ -1975,6 +2097,201 @@ pub(crate) fn context_rewind_pressure_at_record_creation(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn usage_at(
+        line: usize,
+        response_start_line: usize,
+        measures_prefix_exactly: bool,
+    ) -> ContextRewindBackendUsageAtLine {
+        ContextRewindBackendUsageAtLine {
+            line,
+            used_tokens: line as u64 * 100,
+            rewind_only_limit: 1_000_000,
+            response_start_line,
+            measures_prefix_exactly,
+        }
+    }
+
+    fn anchor_probe(first_line: usize, last_line: usize, last_item_is_model: bool) -> ContextRewindAnchorCatalogEntry {
+        ContextRewindAnchorCatalogEntry {
+            ordinal: 0,
+            item_id: "probe".to_string(),
+            first_line,
+            last_line,
+            first_item_type: "function_call".to_string(),
+            last_item_type: "function_call".to_string(),
+            last_item_is_model,
+            positions: vec!["before", "after"],
+            position_hint: "after",
+            names: Vec::new(),
+            roles: Vec::new(),
+            summary: String::new(),
+            backend_usage_at_or_after_anchor: None,
+            backend_usage_before_anchor: None,
+            rewind_only_limit_at_or_after_anchor: None,
+            recommended_rewind_limit_at_or_after_anchor: None,
+            prefix_estimated_tokens_before_anchor: None,
+            prefix_estimated_tokens_after_anchor: None,
+            approx_pruned_tokens_before: None,
+            approx_pruned_tokens_after: None,
+            prefix_tokens_after: None,
+            latest_rewind_usage_after_anchor: None,
+            latest_rewind_limit_after_anchor: None,
+            recovery_eligible: None,
+            recovery_eligible_positions: None,
+            density_eligible: None,
+            density_eligible_positions: None,
+            managed_context_recovery_start_line: None,
+        }
+    }
+
+    /// The binary-search selectors must return exactly what the linear
+    /// probes they replaced returned, across run boundaries, exact-run-start
+    /// windows, and both anchor kinds.
+    #[test]
+    fn binary_search_usage_selectors_match_linear_probes() {
+        // Three model runs starting at lines 2, 10, 30; reports interleave
+        // exact run-start measurements with deeper merged-run reports.
+        let backend_usage = vec![
+            usage_at(3, 2, true),
+            usage_at(5, 2, false),
+            usage_at(12, 10, true),
+            usage_at(14, 10, false),
+            usage_at(15, 10, false),
+            usage_at(33, 30, true),
+        ];
+        for probe_line in [0, 1, 2, 3, 4, 5, 9, 10, 12, 13, 15, 29, 30, 33, 40] {
+            // covers-anchor: first report at/after (model) or first report of
+            // a later run (non-model).
+            for last_item_is_model in [true, false] {
+                let anchor = anchor_probe(probe_line, probe_line, last_item_is_model);
+                let expected = backend_usage
+                    .iter()
+                    .find(|usage| context_rewind_usage_covers_anchor(usage, &anchor));
+                let got = first_usage_covering_anchor(&backend_usage, &anchor);
+                assert_eq!(
+                    got.map(|u| u.line),
+                    expected.map(|u| u.line),
+                    "covers-anchor diverged at line {probe_line} (model={last_item_is_model})"
+                );
+            }
+            // prefix-floor: last report measuring a strict prefix.
+            let expected = backend_usage
+                .iter()
+                .rev()
+                .find(|usage| {
+                    usage.line <= probe_line
+                        || (usage.measures_prefix_exactly
+                            && usage.response_start_line <= probe_line)
+                })
+                .map(|usage| usage.line);
+            let got = latest_prefix_usage_before(&backend_usage, probe_line).map(|u| u.line);
+            assert_eq!(got, expected, "prefix-floor diverged at line {probe_line}");
+        }
+        // Empty report list answers None everywhere.
+        assert!(latest_prefix_usage_before(&[], 10).is_none());
+        assert!(first_usage_covering_anchor(&[], &anchor_probe(1, 1, true)).is_none());
+    }
+
+    /// One scan serves a same-fingerprint burst (pointer-identical Arc);
+    /// an append invalidates it.
+    #[test]
+    fn anchor_scan_cache_serves_burst_and_invalidates_on_append() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout.jsonl");
+        let item = serde_json::json!({
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "call_id": "call_cache_probe",
+                "arguments": "{}"
+            }
+        });
+        std::fs::write(&path, format!("{item}\n")).unwrap();
+
+        let first = shared_context_rewind_anchor_scan(&path).unwrap();
+        let second = shared_context_rewind_anchor_scan(&path).unwrap();
+        assert!(
+            std::sync::Arc::ptr_eq(&first, &second),
+            "unchanged rollout must be served from the cached scan"
+        );
+        assert_eq!(first.catalog.len(), 1);
+
+        let second_item = serde_json::json!({
+            "type": "response_item",
+            "payload": {
+                "type": "function_call",
+                "name": "exec_command",
+                "call_id": "call_cache_probe_2",
+                "arguments": "{}"
+            }
+        });
+        let mut contents = std::fs::read_to_string(&path).unwrap();
+        contents.push_str(&format!("{second_item}\n"));
+        std::fs::write(&path, contents).unwrap();
+
+        let third = shared_context_rewind_anchor_scan(&path).unwrap();
+        assert!(
+            !std::sync::Arc::ptr_eq(&first, &third),
+            "append must invalidate the cached scan"
+        );
+        assert_eq!(third.catalog.len(), 2);
+    }
+
+    /// The counting-writer estimate is byte-identical to the old
+    /// serialize-then-measure implementation.
+    #[test]
+    fn estimated_tokens_counting_writer_matches_serialized_length() {
+        for value in [
+            serde_json::json!({}),
+            serde_json::json!({"type": "message", "content": [{"type": "input_text", "text": "hello world"}]}),
+            serde_json::json!({"nested": {"array": [1, 2, 3], "text": "ütf-8 ⚙ content"}}),
+        ] {
+            let serialized_len = serde_json::to_vec(&value).unwrap().len();
+            let expected = std::cmp::max(1, serialized_len.div_ceil(4) as u64);
+            assert_eq!(context_rewind_estimated_tokens(&value), expected);
+        }
+    }
+
+    /// Reverse scan returns the LAST report with its 1-based line number and
+    /// is not fooled by the marker appearing in unrelated payload text.
+    #[test]
+    fn latest_backend_usage_reverse_scan_finds_last_report() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout.jsonl");
+        let report = |total: u64| {
+            serde_json::json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "model_context_window": 1000,
+                        "last_token_usage": { "total_tokens": total }
+                    }
+                }
+            })
+        };
+        let decoy = serde_json::json!({
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{ "type": "output_text", "text": "discussing token_count here" }]
+            }
+        });
+        std::fs::write(
+            &path,
+            [report(100).to_string(), decoy.to_string(), report(250).to_string(), decoy.to_string()]
+                .join("\n"),
+        )
+        .unwrap();
+        let usage = latest_context_rewind_backend_usage_in_rollout(&path)
+            .unwrap()
+            .expect("report expected");
+        assert_eq!(usage.used_tokens, 250);
+        assert_eq!(usage.line, 3);
+    }
 
     #[test]
     fn context_rewind_carries_unrepeated_prior_primer_facts_from_pruned_span() {

--- a/src/bin/caller/managed_context_ops/anchors.rs
+++ b/src/bin/caller/managed_context_ops/anchors.rs
@@ -2112,7 +2112,11 @@ mod tests {
         }
     }
 
-    fn anchor_probe(first_line: usize, last_line: usize, last_item_is_model: bool) -> ContextRewindAnchorCatalogEntry {
+    fn anchor_probe(
+        first_line: usize,
+        last_line: usize,
+        last_item_is_model: bool,
+    ) -> ContextRewindAnchorCatalogEntry {
         ContextRewindAnchorCatalogEntry {
             ordinal: 0,
             item_id: "probe".to_string(),
@@ -2282,8 +2286,13 @@ mod tests {
         });
         std::fs::write(
             &path,
-            [report(100).to_string(), decoy.to_string(), report(250).to_string(), decoy.to_string()]
-                .join("\n"),
+            [
+                report(100).to_string(),
+                decoy.to_string(),
+                report(250).to_string(),
+                decoy.to_string(),
+            ]
+            .join("\n"),
         )
         .unwrap();
         let usage = latest_context_rewind_backend_usage_in_rollout(&path)

--- a/src/bin/caller/managed_context_ops/anchors.rs
+++ b/src/bin/caller/managed_context_ops/anchors.rs
@@ -912,6 +912,55 @@ pub(crate) struct ContextRewindAnchorScan {
 /// thrash each other.
 const ANCHOR_SCAN_CACHE_SLOTS: usize = 4;
 
+/// Racy-write distrust window, the file watcher's established pattern
+/// (`FINGERPRINT_RACY_WINDOW_NANOS`): change stamps carry nanosecond
+/// FIELDS but come from the kernel's coarse file-timestamp clock (Linux
+/// jiffies ~4-10 ms, NTFS ~15 ms, FAT up to 2 s), so a same-length rewrite
+/// landing in the same granule as the cached stamp is metadata-invisible —
+/// proven live by the Linux CI leg, where write → scan → rewrite →
+/// mtime-restore all fit in one jiffy and the cache served the old
+/// catalog. A stamp younger than this window is therefore treated as no
+/// signal: the scan is neither cached nor served from cache until the file
+/// has been quiescent past the coarsest real granule, after which any
+/// later write is guaranteed a distinct stamp.
+const ANCHOR_SCAN_RACY_WINDOW_NANOS: i128 = 2_000_000_000;
+
+/// Test hook mirroring the file watcher's `set_racy_window_for_tests`:
+/// negative = use the production window. The cache is process-global, so
+/// tests that override this serialize on their own lock.
+#[cfg(test)]
+static ANCHOR_SCAN_RACY_WINDOW_OVERRIDE_NANOS: std::sync::atomic::AtomicI64 =
+    std::sync::atomic::AtomicI64::new(-1);
+
+fn anchor_scan_racy_window_nanos() -> i128 {
+    #[cfg(test)]
+    {
+        let override_nanos =
+            ANCHOR_SCAN_RACY_WINDOW_OVERRIDE_NANOS.load(std::sync::atomic::Ordering::Relaxed);
+        if override_nanos >= 0 {
+            return i128::from(override_nanos);
+        }
+    }
+    ANCHOR_SCAN_RACY_WINDOW_NANOS
+}
+
+/// Whether the stamp is old enough to trust for caching: the file's last
+/// change predates now by at least the racy window, so any subsequent
+/// write must land in a later clock granule and produce a distinct stamp.
+/// A pre-epoch clock reads as 0 → nothing is quiescent → rescan, the safe
+/// direction. The change signal (unlike mtime) cannot be backdated by
+/// writers, so it is the honest quiescence referent.
+fn anchor_scan_stamp_is_quiescent(stamp: &crate::platform::FileChangeStamp) -> bool {
+    let now_nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as i128)
+        .unwrap_or(0);
+    stamp
+        .change_signal_unix_nanos()
+        .saturating_add(anchor_scan_racy_window_nanos())
+        <= now_nanos
+}
+
 struct CachedAnchorScan {
     path: PathBuf,
     len: u64,
@@ -940,6 +989,9 @@ pub(crate) fn shared_context_rewind_anchor_scan(
     source_rollout_path: &Path,
 ) -> io::Result<std::sync::Arc<ContextRewindAnchorScan>> {
     let (len, stamp) = anchor_scan_fingerprint(source_rollout_path)?;
+    // A stamp inside the racy window is no signal (see the window's doc):
+    // neither served from cache nor cached.
+    let stamp = stamp.filter(anchor_scan_stamp_is_quiescent);
     if let Some(stamp) = stamp {
         let mut cache = ANCHOR_SCAN_CACHE.lock().unwrap_or_else(|e| e.into_inner());
         if let Some(index) = cache.iter().position(|entry| {
@@ -2226,13 +2278,27 @@ mod tests {
             .collect()
     }
 
+    /// Serializes the two tests that override the process-global racy
+    /// window (each sets the value it needs at start, so ordering and
+    /// panics cannot leak the wrong window into the other).
+    static ANCHOR_SCAN_RACY_WINDOW_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// A same-fingerprint burst answers identically, and an append
-    /// invalidates the cached scan. Content equality, not `Arc::ptr_eq`:
-    /// the cache is a 4-slot process-global LRU, so parallel tests scanning
-    /// other rollouts can evict this entry between the two calls — a miss
-    /// re-derives the same content, which is the contract under test.
+    /// invalidates the cached scan. Runs with the racy window shrunk to
+    /// zero so the just-written file is cacheable and the hit path is
+    /// actually exercised (under the production window a fresh file is
+    /// deliberately uncacheable for 2 s). Content equality, not
+    /// `Arc::ptr_eq`: the cache is a 4-slot process-global LRU, so parallel
+    /// tests scanning other rollouts can evict this entry between the two
+    /// calls — a miss re-derives the same content, which is the contract
+    /// under test.
     #[test]
     fn anchor_scan_cache_serves_burst_and_invalidates_on_append() {
+        let _guard = ANCHOR_SCAN_RACY_WINDOW_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        ANCHOR_SCAN_RACY_WINDOW_OVERRIDE_NANOS.store(0, std::sync::atomic::Ordering::Relaxed);
+
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("rollout.jsonl");
         std::fs::write(&path, format!("{}\n", cache_probe_item("call_cache_probe"))).unwrap();
@@ -2252,16 +2318,27 @@ mod tests {
             vec!["call_cache_probe", "call_cache_probe_2"],
             "append must invalidate the cached scan"
         );
+
+        ANCHOR_SCAN_RACY_WINDOW_OVERRIDE_NANOS.store(-1, std::sync::atomic::Ordering::Relaxed);
     }
 
-    /// The stale shape the change-stamp key exists for: a same-length
-    /// in-place rewrite whose mtime is restored to the original (the Codex
-    /// same-thread restore class — `message_search/extract_codex.rs`
-    /// detects the rewrite; a (len, mtime) key would serve the old
-    /// catalog). The change stamp moves on every write, so the rewritten
-    /// content must be re-scanned.
+    /// The stale shape the change-stamp key + racy window exist for: a
+    /// same-length in-place rewrite whose mtime is restored to the original
+    /// (the Codex same-thread restore class — `message_search/
+    /// extract_codex.rs` detects the rewrite; a (len, mtime) key would
+    /// serve the old catalog). Runs under the PRODUCTION window: the change
+    /// stamp alone is not sufficient on coarse-granule clocks — the Linux
+    /// CI leg proved a write → scan → rewrite → restore sequence fits in
+    /// one jiffy and ties the stamps — so the racy window keeps the
+    /// just-written file uncacheable and the rewritten content is re-read
+    /// deterministically on every platform's real clock.
     #[test]
     fn anchor_scan_cache_rescans_same_size_mtime_restored_rewrite() {
+        let _guard = ANCHOR_SCAN_RACY_WINDOW_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        ANCHOR_SCAN_RACY_WINDOW_OVERRIDE_NANOS.store(-1, std::sync::atomic::Ordering::Relaxed);
+
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("rollout.jsonl");
         std::fs::write(&path, format!("{}\n", cache_probe_item("call_rewrite_a"))).unwrap();
@@ -2290,6 +2367,45 @@ mod tests {
             scan_item_ids(&after),
             vec!["call_rewrite_b"],
             "an mtime-restored same-size rewrite must not be served stale"
+        );
+    }
+
+    /// The quiescence gate itself: a stamp younger than the window is not
+    /// trusted, one comfortably older is.
+    #[test]
+    fn anchor_scan_stamp_quiescence_tracks_the_window() {
+        let _guard = ANCHOR_SCAN_RACY_WINDOW_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        ANCHOR_SCAN_RACY_WINDOW_OVERRIDE_NANOS.store(-1, std::sync::atomic::Ordering::Relaxed);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("probe");
+        std::fs::write(&path, b"x").unwrap();
+        let meta = std::fs::metadata(&path).unwrap();
+        let Some(stamp) = crate::platform::file_change_stamp(&path, &meta) else {
+            // No signal on this filesystem: the cache is already fully
+            // disabled for such files; nothing to gate.
+            return;
+        };
+        assert!(
+            !anchor_scan_stamp_is_quiescent(&stamp),
+            "a just-written file must sit inside the racy window"
+        );
+        // Backdate past the window, in the platform's native signal scale
+        // (Unix: nanoseconds; Windows: 100 ns FILETIME units).
+        let mut old = stamp;
+        #[cfg(windows)]
+        {
+            old.change_signal -= (ANCHOR_SCAN_RACY_WINDOW_NANOS * 2) / 100;
+        }
+        #[cfg(not(windows))]
+        {
+            old.change_signal -= ANCHOR_SCAN_RACY_WINDOW_NANOS * 2;
+        }
+        assert!(
+            anchor_scan_stamp_is_quiescent(&old),
+            "a stamp older than the window must be trusted"
         );
     }
 

--- a/src/bin/caller/managed_context_ops/pressure.rs
+++ b/src/bin/caller/managed_context_ops/pressure.rs
@@ -126,9 +126,16 @@ pub(crate) fn latest_external_context_snapshot_from_log(
     let contents = std::fs::read_to_string(session_path).ok()?;
     let session_id = config.session_id.as_deref();
     let alias_session_id = config.alias_session_id.as_deref();
-    let mut latest = None;
 
-    for line in contents.lines() {
+    // Only the LATEST session-targeted snapshot matters, so scan from the
+    // end and stop at the first match. The forward version parsed every
+    // line of the session log AND converted every context_snapshot row —
+    // each conversion eagerly opening its payload sidecar — to keep one.
+    // The prescan is a cheap filter; conversion stays the authority.
+    for line in contents.lines().rev() {
+        if !line.contains("context_snapshot") {
+            continue;
+        }
         let Ok(entry) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
             continue;
         };
@@ -166,7 +173,7 @@ pub(crate) fn latest_external_context_snapshot_from_log(
             }
             _ => None,
         };
-        latest = Some(external_agent::AgentContextSnapshot {
+        return Some(external_agent::AgentContextSnapshot {
             source,
             label,
             request_id,
@@ -185,7 +192,7 @@ pub(crate) fn latest_external_context_snapshot_from_log(
         });
     }
 
-    latest
+    None
 }
 
 pub(crate) async fn refresh_external_context_usage_snapshot_for_preflight(
@@ -916,12 +923,15 @@ pub(crate) async fn attempt_supervisor_surgical_context_rewind(
     let Some((item_id, position)) = managed_context_surgical_anchor_choice(&anchors) else {
         return Err("no recovery-eligible anchor in the rewind catalog".to_string());
     };
-    let prior_rewind_record_ids: Vec<String> = context_rewind::list_records(config.log_dir)
-        .unwrap_or_default()
-        .into_iter()
-        .filter(|record| record.thread_id == thread_id)
-        .map(|record| record.record_id)
-        .collect();
+    // Skinny listing: only ids are needed for the primer, and full records
+    // embed complete fission/lineage ledger snapshots.
+    let prior_rewind_record_ids: Vec<String> =
+        context_rewind::list_record_summaries(config.log_dir)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|record| record.thread_id == thread_id)
+            .map(|record| record.record_id)
+            .collect();
     let request = ExternalContextRewindRequest {
         session_id: config.session_id.clone(),
         item_id,

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -1189,8 +1189,29 @@ impl IntendantServer {
         // Supervised parents log under `~/.intendant/logs/<id>/`, which is not
         // necessarily this server's primary log dir, so merge the ledger reads
         // across every candidate dir the requested session is known by.
-        let ledger_dirs = status_ledger_candidate_dirs(&self.home, &log_dir, &session_id);
-        if let Some(ledger) = merged_lineage_ledger_for_session(&ledger_dirs, &session_id) {
+        //
+        // On the blocking pool: candidate resolution can scan the session
+        // store on an id miss, and the fission ledger document is a full
+        // read + parse of a file observed at ~1 MB — get_status is the
+        // model's habitual poll, and this ran inline on the async handler.
+        // (The lineage read behind it is incrementally cached; the fission
+        // document read is not yet.)
+        let ledgers = {
+            let home = self.home.clone();
+            let ledger_log_dir = log_dir.clone();
+            let ledger_session_id = session_id.clone();
+            tokio::task::spawn_blocking(move || {
+                let ledger_dirs =
+                    status_ledger_candidate_dirs(&home, &ledger_log_dir, &ledger_session_id);
+                (
+                    merged_lineage_ledger_for_session(&ledger_dirs, &ledger_session_id),
+                    merged_fission_ledger_document_for_session(&ledger_dirs, &ledger_session_id),
+                )
+            })
+            .await
+            .unwrap_or((None, None))
+        };
+        if let Some(ledger) = ledgers.0 {
             if let Some(obj) = value.as_object_mut() {
                 obj.insert(
                     "lineage_ledger".to_string(),
@@ -1202,9 +1223,7 @@ impl IntendantServer {
         // markers and branch charters are visible in the status payload; the
         // wire shape stays back-compatible because `ext` serializes only when
         // non-empty.
-        if let Some(document) =
-            merged_fission_ledger_document_for_session(&ledger_dirs, &session_id)
-        {
+        if let Some(document) = ledgers.1 {
             if let Some(obj) = value.as_object_mut() {
                 obj.insert(
                     "fission_ledger".to_string(),

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -1209,7 +1209,14 @@ impl IntendantServer {
                 )
             })
             .await
-            .unwrap_or((None, None))
+            .unwrap_or_else(|e| {
+                // A JoinError here is a panic (or forced shutdown) inside
+                // the merge — answer without ledgers, but never silently:
+                // a status payload missing its ledgers looks identical to
+                // "no fission activity" to the caller.
+                eprintln!("[mcp] get_status ledger merge task failed: {e}");
+                (None, None)
+            })
         };
         if let Some(ledger) = ledgers.0 {
             if let Some(obj) = value.as_object_mut() {

--- a/src/bin/caller/message_search/extract_codex.rs
+++ b/src/bin/caller/message_search/extract_codex.rs
@@ -39,7 +39,10 @@ use std::path::Path;
 /// `prior` is the session's previously published shard; pass it — with a
 /// bumped, strictly higher `generation` — when the source was detected
 /// REWRITTEN (a same-path cursor returning `CursorCheck::Rewritten`: a
-/// Codex same-thread restore rewrites the rollout in place). The prior
+/// Codex same-thread restore rewrites the rollout in place — note for
+/// other rollout readers: this rewrite is why the anchor-scan cache in
+/// `managed_context_ops/anchors.rs` keys on the file CHANGE STAMP, never
+/// on (len, mtime), which a same-length in-place rewrite can alias). The prior
 /// generations' records are then retained and republished alongside the
 /// new generation's, never discarded (plan §5 index-everything), with a
 /// [`SupersessionMark::GenerationRestore`] recording that the freshly

--- a/src/bin/caller/session_log/bus_events.rs
+++ b/src/bin/caller/session_log/bus_events.rs
@@ -1784,7 +1784,7 @@ impl SessionLog {
             data["stderr_offset"] = serde_json::Value::from(span.offset);
             data["stderr_bytes"] = serde_json::Value::from(span.len);
         }
-        self.emit(LogEvent {
+        let emitted = self.emit_checked(LogEvent {
             ts: Self::ts(),
             ts_ms: Self::ts_ms(),
             turn: Some(self.current_turn),
@@ -1803,16 +1803,29 @@ impl SessionLog {
             file: stdout_span.map(|span| span.relative),
             file2: stderr_span.map(|span| span.relative),
         });
-        // Invalidate the gateway's negative agent-output memo for this logs
-        // root — strictly AFTER the flushed row above. The generation must
-        // publish only once the row is readable: bumping before the
-        // (potentially multi-MB) sidecar writes let a concurrent fetch read
-        // the new generation, miss the not-yet-emitted row, and memoize
-        // that miss under a generation this write would never move again —
-        // reinstating the full-TTL blind window for exactly the racing
-        // case. Post-emit, a fetch that misses the row memoizes under the
-        // OLD generation, which this bump immediately invalidates.
-        super::replay::note_agent_output_appended(self.dir());
+        match emitted {
+            // Invalidate the gateway's negative agent-output memo for this
+            // logs root — strictly AFTER the row above flushed, and ONLY
+            // when it flushed. The generation must publish exactly when the
+            // row becomes readable: bumping before the (potentially
+            // multi-MB) sidecar writes let a concurrent fetch read the new
+            // generation, miss the not-yet-emitted row, and memoize that
+            // miss under a generation this write would never move again;
+            // bumping after a FAILED flush is the same trap on the failure
+            // path — the row isn't readable, a fetch memoizes under the
+            // published generation, and if a later event's successful flush
+            // drains the retained buffered bytes the row appears with no
+            // further bump. On Ok, a fetch that raced and missed the row
+            // memoized under the OLD generation, which this bump
+            // immediately invalidates; on Err, no bump — the generation
+            // never vouches for an unreadable row, and if retained bytes
+            // later surface via an unrelated flush, the next successful
+            // output append's bump or the memo's TTL backstop covers them.
+            Ok(()) => super::replay::note_agent_output_appended(self.dir()),
+            Err(e) => {
+                eprintln!("session_log: failed to write log event: {}", e);
+            }
+        }
     }
 
     /// Log reasoning content from the model (full reasoning, not just summary).

--- a/src/bin/caller/session_log/bus_events.rs
+++ b/src/bin/caller/session_log/bus_events.rs
@@ -1748,6 +1748,9 @@ impl SessionLog {
         output_id: Option<&str>,
         item_id: Option<&str>,
     ) {
+        // Invalidates the gateway's negative agent-output memo for this
+        // logs root (see `replay::agent_output_generation`).
+        super::replay::note_agent_output_appended(self.dir());
         let stdout_span = if !stdout.is_empty() {
             self.append_turn_file_span("stdout.txt", stdout)
         } else {

--- a/src/bin/caller/session_log/bus_events.rs
+++ b/src/bin/caller/session_log/bus_events.rs
@@ -1748,9 +1748,6 @@ impl SessionLog {
         output_id: Option<&str>,
         item_id: Option<&str>,
     ) {
-        // Invalidates the gateway's negative agent-output memo for this
-        // logs root (see `replay::agent_output_generation`).
-        super::replay::note_agent_output_appended(self.dir());
         let stdout_span = if !stdout.is_empty() {
             self.append_turn_file_span("stdout.txt", stdout)
         } else {
@@ -1806,6 +1803,16 @@ impl SessionLog {
             file: stdout_span.map(|span| span.relative),
             file2: stderr_span.map(|span| span.relative),
         });
+        // Invalidate the gateway's negative agent-output memo for this logs
+        // root — strictly AFTER the flushed row above. The generation must
+        // publish only once the row is readable: bumping before the
+        // (potentially multi-MB) sidecar writes let a concurrent fetch read
+        // the new generation, miss the not-yet-emitted row, and memoize
+        // that miss under a generation this write would never move again —
+        // reinstating the full-TTL blind window for exactly the racing
+        // case. Post-emit, a fetch that misses the row memoizes under the
+        // OLD generation, which this bump immediately invalidates.
+        super::replay::note_agent_output_appended(self.dir());
     }
 
     /// Log reasoning content from the model (full reasoning, not just summary).

--- a/src/bin/caller/session_log/replay.rs
+++ b/src/bin/caller/session_log/replay.rs
@@ -94,6 +94,17 @@ pub fn agent_output_chunks_by_id(log_dir: &Path, ids: &[String]) -> Vec<AgentOut
         std::collections::HashMap::new();
 
     for line in contents.lines() {
+        // Resolving a few ids used to JSON-parse every line of the whole
+        // log — including the ~99% that are not agent_output rows — on
+        // every dashboard output fetch. Prescan for the event marker
+        // (payload text can false-positive; the parse stays the authority)
+        // and stop once every requested id is resolved.
+        if found.len() == wanted.len() {
+            break;
+        }
+        if !line.contains("agent_output") {
+            continue;
+        }
         let Ok(entry) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
             continue;
         };

--- a/src/bin/caller/session_log/replay.rs
+++ b/src/bin/caller/session_log/replay.rs
@@ -399,7 +399,7 @@ pub fn session_log_entry_to_app_event(
             // Backward compat: older sessions stored the raw JSON blob in
             // `message`; newer sessions store a pre-formatted preview.
             let commands_preview = if message.starts_with('{') {
-                crate::format_commands_preview(message)
+                crate::tool_batch::BatchFacts::from_json(message).commands_preview
             } else {
                 message.to_string()
             };

--- a/src/bin/caller/session_log/replay.rs
+++ b/src/bin/caller/session_log/replay.rs
@@ -82,40 +82,85 @@ pub(crate) fn read_model_response_content(
 }
 
 /// Monotonic generation per logs ROOT (the parent of session log dirs),
-/// bumped by [`crate::session_log::SessionLog`] on every `agent_output`
-/// append anywhere under that root. The gateway's negative agent-output
-/// memo records the generation it observed at sweep time and treats any
-/// mismatch as stale — so an id that a sweep missed becomes findable the
-/// moment ANY session under the root appends output, instead of after a
-/// fixed TTL. Keys are the paths as constructed by the standard home flow
-/// (`SessionLog::resolve_path_in_home` under `<home>/.intendant/logs`);
-/// an exotic symlinked root would only make the memo distrust itself
-/// more, never trust a stale verdict longer.
+/// bumped by [`crate::session_log::SessionLog`] AFTER every flushed
+/// `agent_output` row anywhere under that root. The gateway's negative
+/// agent-output memo records the generation it observed at sweep time and
+/// treats any mismatch as stale — so an id that a sweep missed becomes
+/// findable the moment ANY session under the root appends output, instead
+/// of after a fixed TTL.
+///
+/// Keys are CANONICAL root paths (see [`canonical_logs_root`]): writer and
+/// reader can reach the same directory through different spellings —
+/// path-form session resolution canonicalizes its input while the
+/// home-derived fallback root does not, so under a symlinked home the two
+/// would otherwise maintain independent generations and a write via one
+/// spelling would never invalidate a miss memoized under the other,
+/// silently reinstating the full-TTL blind window.
 static AGENT_OUTPUT_GENERATIONS: std::sync::Mutex<
     Option<std::collections::HashMap<std::path::PathBuf, u64>>,
 > = std::sync::Mutex::new(None);
 
+const CANONICAL_LOGS_ROOT_MEMO_CAP: usize = 256;
+
+/// Spelling → canonical form memo for logs roots, so the per-append and
+/// per-fetch canonicalization is one map hit instead of a component-walk
+/// of syscalls. Values are recomputable, so overflowing the cap just
+/// clears the memo. A root whose symlink TARGET is repointed mid-process
+/// keeps its first resolution — logs roots are stable for a daemon's
+/// lifetime, and both sides of the generation contract go through this
+/// same memo, so they can never disagree with each other.
+static CANONICAL_LOGS_ROOTS: std::sync::Mutex<
+    Option<std::collections::HashMap<std::path::PathBuf, std::path::PathBuf>>,
+> = std::sync::Mutex::new(None);
+
+/// Canonical form of a logs root (memoized). Falls back to the lexical
+/// path when canonicalization fails (root vanished) — both sides fall back
+/// identically, so the keys still agree.
+pub(crate) fn canonical_logs_root(root: &Path) -> std::path::PathBuf {
+    {
+        let memo = CANONICAL_LOGS_ROOTS
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if let Some(canonical) = memo.as_ref().and_then(|map| map.get(root)) {
+            return canonical.clone();
+        }
+    }
+    let canonical = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let mut memo = CANONICAL_LOGS_ROOTS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let map = memo.get_or_insert_with(std::collections::HashMap::new);
+    if map.len() >= CANONICAL_LOGS_ROOT_MEMO_CAP {
+        map.clear();
+    }
+    map.insert(root.to_path_buf(), canonical.clone());
+    canonical
+}
+
 /// Current append generation for a logs root (0 until the first append).
+/// The root may be any spelling; it is canonicalized here.
 pub fn agent_output_generation(logs_root: &Path) -> u64 {
+    let root = canonical_logs_root(logs_root);
     AGENT_OUTPUT_GENERATIONS
         .lock()
         .unwrap_or_else(|e| e.into_inner())
         .as_ref()
-        .and_then(|map| map.get(logs_root).copied())
+        .and_then(|map| map.get(&root).copied())
         .unwrap_or(0)
 }
 
 /// Bump the generation for the logs root containing `log_dir`. Called at
-/// the `agent_output` write choke point.
+/// the `agent_output` write choke point, after the row is flushed.
 pub(crate) fn note_agent_output_appended(log_dir: &Path) {
     let Some(root) = log_dir.parent() else {
         return;
     };
+    let root = canonical_logs_root(root);
     let mut map = AGENT_OUTPUT_GENERATIONS
         .lock()
         .unwrap_or_else(|e| e.into_inner());
     let map = map.get_or_insert_with(std::collections::HashMap::new);
-    *map.entry(root.to_path_buf()).or_insert(0) += 1;
+    *map.entry(root).or_insert(0) += 1;
 }
 
 pub fn agent_output_chunks_by_id(log_dir: &Path, ids: &[String]) -> Vec<AgentOutputChunk> {
@@ -2001,6 +2046,81 @@ mod tests {
         assert_eq!(chunks[1].output_id, "out-1");
         assert_eq!(chunks[1].stdout, "first");
         assert_eq!(chunks[1].stderr, "");
+    }
+
+    /// The generation must publish only AFTER the agent_output row is
+    /// readable. A concurrent writer appends a large output; the moment the
+    /// observer sees the generation move, the row must already resolve — a
+    /// pre-emit bump exposes a window (new generation, row absent) in which
+    /// a sweep would memoize the miss under a generation the completing
+    /// write never moves again, blinding fetches for the full memo TTL.
+    /// The multi-MB payload widens that window enough that the pre-emit
+    /// ordering reliably fails this test.
+    #[test]
+    fn agent_output_generation_bump_publishes_after_row_is_readable() {
+        let dir = tempfile::tempdir().unwrap();
+        let logs_root = dir.path().join("logs");
+        let log_dir = logs_root.join("writer");
+        let log = SessionLog::open(log_dir.clone()).unwrap();
+        let before = agent_output_generation(&logs_root);
+
+        let writer = std::thread::spawn(move || {
+            let mut log = log;
+            let big = "x".repeat(4 * 1024 * 1024);
+            log.agent_output_with_id(&big, "", None, Some("gen-order-probe"));
+        });
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while agent_output_generation(&logs_root) == before {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "writer never bumped the generation"
+            );
+            std::thread::yield_now();
+        }
+        // Generation moved: the row (and its span files) must be resolvable
+        // right now, with no further writer progress required.
+        let chunks = agent_output_chunks_by_id(&log_dir, &["gen-order-probe".to_string()]);
+        assert_eq!(
+            chunks.len(),
+            1,
+            "generation bumped before the agent_output row was readable"
+        );
+        assert_eq!(chunks[0].stdout.len(), 4 * 1024 * 1024);
+        writer.join().unwrap();
+    }
+
+    /// Writer and reader can reach one logs root through different
+    /// spellings (path-form session resolution canonicalizes; the
+    /// home-derived fallback root does not): the generation must be shared
+    /// across spellings, or a write via one spelling would never invalidate
+    /// a miss memoized under the other.
+    #[test]
+    fn agent_output_generation_is_canonical_across_root_spellings() {
+        let dir = tempfile::tempdir().unwrap();
+        let logs_root = dir.path().join("logs");
+        let log_dir = logs_root.join("writer");
+        // A second, lexically different spelling of the same directory
+        // (kept portable: dotted traversal instead of a symlink, which
+        // Windows runners cannot always create).
+        std::fs::create_dir_all(logs_root.join("subprobe")).unwrap();
+        let dotted_spelling = logs_root.join("subprobe").join("..");
+
+        let before_a = agent_output_generation(&logs_root);
+        let before_b = agent_output_generation(&dotted_spelling);
+        assert_eq!(before_a, before_b, "spellings must share a generation");
+
+        let mut log = SessionLog::open(log_dir).unwrap();
+        log.agent_output_with_id("hello", "", None, Some("gen-spelling-probe"));
+        drop(log);
+
+        let after_a = agent_output_generation(&logs_root);
+        let after_b = agent_output_generation(&dotted_spelling);
+        assert!(after_a > before_a, "append must bump the generation");
+        assert_eq!(
+            after_a, after_b,
+            "one append must be visible through every spelling of the root"
+        );
     }
 
     #[test]

--- a/src/bin/caller/session_log/replay.rs
+++ b/src/bin/caller/session_log/replay.rs
@@ -81,6 +81,43 @@ pub(crate) fn read_model_response_content(
     fs::read_to_string(path).unwrap_or_else(|_| message.to_string())
 }
 
+/// Monotonic generation per logs ROOT (the parent of session log dirs),
+/// bumped by [`crate::session_log::SessionLog`] on every `agent_output`
+/// append anywhere under that root. The gateway's negative agent-output
+/// memo records the generation it observed at sweep time and treats any
+/// mismatch as stale — so an id that a sweep missed becomes findable the
+/// moment ANY session under the root appends output, instead of after a
+/// fixed TTL. Keys are the paths as constructed by the standard home flow
+/// (`SessionLog::resolve_path_in_home` under `<home>/.intendant/logs`);
+/// an exotic symlinked root would only make the memo distrust itself
+/// more, never trust a stale verdict longer.
+static AGENT_OUTPUT_GENERATIONS: std::sync::Mutex<
+    Option<std::collections::HashMap<std::path::PathBuf, u64>>,
+> = std::sync::Mutex::new(None);
+
+/// Current append generation for a logs root (0 until the first append).
+pub fn agent_output_generation(logs_root: &Path) -> u64 {
+    AGENT_OUTPUT_GENERATIONS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .as_ref()
+        .and_then(|map| map.get(logs_root).copied())
+        .unwrap_or(0)
+}
+
+/// Bump the generation for the logs root containing `log_dir`. Called at
+/// the `agent_output` write choke point.
+pub(crate) fn note_agent_output_appended(log_dir: &Path) {
+    let Some(root) = log_dir.parent() else {
+        return;
+    };
+    let mut map = AGENT_OUTPUT_GENERATIONS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let map = map.get_or_insert_with(std::collections::HashMap::new);
+    *map.entry(root.to_path_buf()).or_insert(0) += 1;
+}
+
 pub fn agent_output_chunks_by_id(log_dir: &Path, ids: &[String]) -> Vec<AgentOutputChunk> {
     let wanted: std::collections::HashSet<&str> = ids.iter().map(String::as_str).collect();
     if wanted.is_empty() {

--- a/src/bin/caller/session_log/replay.rs
+++ b/src/bin/caller/session_log/replay.rs
@@ -2090,6 +2090,48 @@ mod tests {
         writer.join().unwrap();
     }
 
+    /// A FAILED flush must not publish the generation: the row is not
+    /// readable, so a bump would let a fetch memoize the miss under a
+    /// generation this write never moves again — the same trap the
+    /// post-emit ordering closes on the success path, reopened on the
+    /// failure path (retained buffered bytes can surface later via an
+    /// unrelated flush, with no further bump). No bump on emit failure;
+    /// the next successful output append bumps and the id resolves.
+    #[test]
+    fn agent_output_generation_holds_on_failed_flush() {
+        let dir = tempfile::tempdir().unwrap();
+        let logs_root = dir.path().join("logs");
+        let log_dir = logs_root.join("writer");
+        let mut log = SessionLog::open(log_dir.clone()).unwrap();
+        let before = agent_output_generation(&logs_root);
+
+        log.sabotage_writer_for_tests();
+        log.agent_output_with_id("never lands", "", None, Some("gen-fail-probe"));
+        assert_eq!(
+            agent_output_generation(&logs_root),
+            before,
+            "a failed flush must not publish the generation"
+        );
+        assert!(
+            agent_output_chunks_by_id(&log_dir, &["gen-fail-probe".to_string()]).is_empty(),
+            "the sabotaged row must not be readable"
+        );
+
+        // Recover the writer (fresh append handle on the same log) and land
+        // the row: the successful emit bumps, and the id resolves.
+        drop(log);
+        let mut log = SessionLog::open(log_dir.clone()).unwrap();
+        log.agent_output_with_id("recovered", "", None, Some("gen-fail-probe"));
+        drop(log);
+        assert!(
+            agent_output_generation(&logs_root) > before,
+            "the successful append must bump the generation"
+        );
+        let chunks = agent_output_chunks_by_id(&log_dir, &["gen-fail-probe".to_string()]);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].stdout, "recovered");
+    }
+
     /// Writer and reader can reach one logs root through different
     /// spellings (path-form session resolution canonicalizes; the
     /// home-derived fallback root does not): the generation must be shared

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -97,14 +97,30 @@ impl SessionSupervisor {
         // make the fresh checkout the session's effective project root. A
         // failure (not a git repo, no commits, bad branch name) closes the
         // just-opened session honestly, exactly like the no-project arm.
+        //
+        // The git chain (HEAD probe, collision listing, `git worktree add`
+        // materializing a full checkout — seconds on large projects) runs on
+        // the blocking pool: this function is awaited by the supervisor's
+        // single sequential control-intake loop, and running it inline
+        // queued every session's approvals/steers/interrupts behind the
+        // checkout.
         let worktree_meta = match worktree.as_ref() {
             Some(request) => {
-                match prepare_session_worktree(
-                    &project_root,
-                    request,
-                    session_name.as_deref(),
-                    &session_id,
-                ) {
+                let blocking_root = project_root.clone();
+                let blocking_request = request.clone();
+                let blocking_name = session_name.clone();
+                let blocking_session_id = session_id.clone();
+                let prepared = tokio::task::spawn_blocking(move || {
+                    prepare_session_worktree(
+                        &blocking_root,
+                        &blocking_request,
+                        blocking_name.as_deref(),
+                        &blocking_session_id,
+                    )
+                })
+                .await
+                .unwrap_or_else(|e| Err(format!("worktree preparation task failed: {e}")));
+                match prepared {
                     Ok(meta) => Some(meta),
                     Err(e) => {
                         let reason = format!("worktree launch failed: {e}");

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -112,10 +112,7 @@ impl SessionSupervisor {
         // its ordering guarantee).
         let worktree_meta = match worktree.as_ref() {
             Some(request) => {
-                let permit = worktree::git_ops_semaphore()
-                    .clone()
-                    .acquire_owned()
-                    .await;
+                let permit = worktree::git_ops_semaphore().clone().acquire_owned().await;
                 let blocking_root = project_root.clone();
                 let blocking_request = request.clone();
                 let blocking_name = session_name.clone();

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -100,26 +100,42 @@ impl SessionSupervisor {
         //
         // The git chain (HEAD probe, collision listing, `git worktree add`
         // materializing a full checkout — seconds on large projects) runs on
-        // the blocking pool: this function is awaited by the supervisor's
-        // single sequential control-intake loop, and running it inline
-        // queued every session's approvals/steers/interrupts behind the
-        // checkout.
+        // the blocking pool under the daemon-wide git-ops bound. What that
+        // buys: a tokio worker is no longer pinned for the duration, and a
+        // panic inside the chain surfaces as this session's honest
+        // create-failure instead of unwinding the supervisor. What it does
+        // NOT buy: this function is still awaited inline by the
+        // supervisor's single sequential control-intake loop, so other
+        // sessions' approvals/steers/interrupts still wait out the checkout
+        // — the real fix is dispatching session-create handling off the
+        // intake loop (see the PR follow-up; the delegation ack must keep
+        // its ordering guarantee).
         let worktree_meta = match worktree.as_ref() {
             Some(request) => {
+                let permit = worktree::git_ops_semaphore()
+                    .clone()
+                    .acquire_owned()
+                    .await;
                 let blocking_root = project_root.clone();
                 let blocking_request = request.clone();
                 let blocking_name = session_name.clone();
                 let blocking_session_id = session_id.clone();
-                let prepared = tokio::task::spawn_blocking(move || {
-                    prepare_session_worktree(
-                        &blocking_root,
-                        &blocking_request,
-                        blocking_name.as_deref(),
-                        &blocking_session_id,
-                    )
-                })
-                .await
-                .unwrap_or_else(|e| Err(format!("worktree preparation task failed: {e}")));
+                let prepared = match permit {
+                    Ok(permit) => tokio::task::spawn_blocking(move || {
+                        let _permit = permit;
+                        prepare_session_worktree(
+                            &blocking_root,
+                            &blocking_request,
+                            blocking_name.as_deref(),
+                            &blocking_session_id,
+                        )
+                    })
+                    .await
+                    .unwrap_or_else(|e| Err(format!("worktree preparation task failed: {e}"))),
+                    // The semaphore is never closed; refuse rather than run
+                    // unbounded if that ever changes.
+                    Err(e) => Err(format!("worktree git-ops slot unavailable: {e}")),
+                };
                 match prepared {
                     Ok(meta) => Some(meta),
                     Err(e) => {

--- a/src/bin/caller/session_supervisor/sub_agents.rs
+++ b/src/bin/caller/session_supervisor/sub_agents.rs
@@ -227,13 +227,17 @@ impl SessionSupervisor {
         });
 
         // Worktree isolation: branch off the parent project's HEAD, same
-        // machinery fission branches use.
+        // machinery fission branches use. `git worktree add` materializes a
+        // full checkout, so it runs on the blocking pool instead of stalling
+        // this async task's worker.
         let worktree_path = if params.worktree {
-            let wt = worktree::create(
-                &parent_project.root,
-                &format!("subagent-{}", short_session(&child_session_id)),
-                "HEAD",
-            )
+            let blocking_root = parent_project.root.clone();
+            let branch = format!("subagent-{}", short_session(&child_session_id));
+            let wt = tokio::task::spawn_blocking(move || {
+                worktree::create(&blocking_root, &branch, "HEAD")
+            })
+            .await
+            .map_err(|e| format!("sub-agent worktree task failed: {e}"))?
             .map_err(|e| format!("sub-agent worktree creation failed: {e}"))?;
             Some(wt.path)
         } else {

--- a/src/bin/caller/session_supervisor/sub_agents.rs
+++ b/src/bin/caller/session_supervisor/sub_agents.rs
@@ -228,12 +228,19 @@ impl SessionSupervisor {
 
         // Worktree isolation: branch off the parent project's HEAD, same
         // machinery fission branches use. `git worktree add` materializes a
-        // full checkout, so it runs on the blocking pool instead of stalling
-        // this async task's worker.
+        // full checkout, so it runs on the blocking pool (worker not
+        // pinned; a panic fails this spawn, not the caller's task) under
+        // the daemon-wide git-ops bound.
         let worktree_path = if params.worktree {
+            let permit = worktree::git_ops_semaphore()
+                .clone()
+                .acquire_owned()
+                .await
+                .map_err(|e| format!("worktree git-ops slot unavailable: {e}"))?;
             let blocking_root = parent_project.root.clone();
             let branch = format!("subagent-{}", short_session(&child_session_id));
             let wt = tokio::task::spawn_blocking(move || {
+                let _permit = permit;
                 worktree::create(&blocking_root, &branch, "HEAD")
             })
             .await

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -1337,12 +1337,11 @@ pub(crate) async fn spawn_single_fission_branch(
     let branch_worktree = if use_worktree {
         let blocking_root = config.project_root.to_path_buf();
         let branch = fission_branch_git_name(ctx.group_id, ordinal);
-        let wt = tokio::task::spawn_blocking(move || {
-            worktree::create(&blocking_root, &branch, "HEAD")
-        })
-        .await
-        .map_err(|e| format!("worktree creation task failed: {e}"))?
-        .map_err(|e| format!("worktree creation failed: {e}"))?;
+        let wt =
+            tokio::task::spawn_blocking(move || worktree::create(&blocking_root, &branch, "HEAD"))
+                .await
+                .map_err(|e| format!("worktree creation task failed: {e}"))?
+                .map_err(|e| format!("worktree creation failed: {e}"))?;
         Some(wt)
     } else {
         None

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -1305,8 +1305,19 @@ async fn cleanup_fission_worktree(
     let display_path = wt.path.display().to_string();
     let root = project_root.to_path_buf();
     let wt = wt.clone();
-    match tokio::task::spawn_blocking(move || worktree::remove_worktree_and_branch(&root, &wt))
-        .await
+    let permit = match worktree::git_ops_semaphore().clone().acquire_owned().await {
+        Ok(permit) => permit,
+        Err(err) => {
+            return format!(
+                "; cleanup of worktree {display_path} skipped (git-ops slot unavailable: {err})"
+            );
+        }
+    };
+    match tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        worktree::remove_worktree_and_branch(&root, &wt)
+    })
+    .await
     {
         Ok(Ok(())) => String::new(),
         Ok(Err(err)) => format!("; cleanup of worktree {display_path} also failed: {err}"),
@@ -1332,16 +1343,24 @@ pub(crate) async fn spawn_single_fission_branch(
         ctx.use_worktree_override,
     );
     // Worktree create/remove spawn git and materialize/delete full checkouts;
-    // both run on the blocking pool so the fission drain task's worker is
-    // never parked behind them.
+    // both run on the blocking pool (worker not parked; a panic fails this
+    // branch spawn, not the drain task) under the daemon-wide git-ops bound
+    // so a wide fission cannot queue unbounded multi-second blocking jobs.
     let branch_worktree = if use_worktree {
+        let permit = worktree::git_ops_semaphore()
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|e| format!("worktree git-ops slot unavailable: {e}"))?;
         let blocking_root = config.project_root.to_path_buf();
         let branch = fission_branch_git_name(ctx.group_id, ordinal);
-        let wt =
-            tokio::task::spawn_blocking(move || worktree::create(&blocking_root, &branch, "HEAD"))
-                .await
-                .map_err(|e| format!("worktree creation task failed: {e}"))?
-                .map_err(|e| format!("worktree creation failed: {e}"))?;
+        let wt = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            worktree::create(&blocking_root, &branch, "HEAD")
+        })
+        .await
+        .map_err(|e| format!("worktree creation task failed: {e}"))?
+        .map_err(|e| format!("worktree creation failed: {e}"))?;
         Some(wt)
     } else {
         None

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -1291,6 +1291,29 @@ pub(crate) async fn apply_fission_spawn_action(
     }
 }
 
+/// Remove a fission branch's worktree after a failed spawn step, on the
+/// blocking pool (checkout deletion + branch delete spawn git). Returns a
+/// `; cleanup …` suffix for the step's error message when the cleanup itself
+/// fails, empty otherwise — the shape the old inline closure produced.
+async fn cleanup_fission_worktree(
+    project_root: &Path,
+    branch_worktree: &Option<worktree::Worktree>,
+) -> String {
+    let Some(wt) = branch_worktree else {
+        return String::new();
+    };
+    let display_path = wt.path.display().to_string();
+    let root = project_root.to_path_buf();
+    let wt = wt.clone();
+    match tokio::task::spawn_blocking(move || worktree::remove_worktree_and_branch(&root, &wt))
+        .await
+    {
+        Ok(Ok(())) => String::new(),
+        Ok(Err(err)) => format!("; cleanup of worktree {display_path} also failed: {err}"),
+        Err(err) => format!("; cleanup task for worktree {display_path} also failed: {err}"),
+    }
+}
+
 /// Launch one fission branch: optional worktree → live-thread fork → charter
 /// injection → durable ledger registration → lifecycle route → frontend
 /// wiring (rename + relationship + resume with the kickoff task). Any failed
@@ -1308,28 +1331,21 @@ pub(crate) async fn spawn_single_fission_branch(
         ctx.project_root_is_git,
         ctx.use_worktree_override,
     );
+    // Worktree create/remove spawn git and materialize/delete full checkouts;
+    // both run on the blocking pool so the fission drain task's worker is
+    // never parked behind them.
     let branch_worktree = if use_worktree {
-        Some(
-            worktree::create(
-                config.project_root,
-                &fission_branch_git_name(ctx.group_id, ordinal),
-                "HEAD",
-            )
-            .map_err(|e| format!("worktree creation failed: {e}"))?,
-        )
+        let blocking_root = config.project_root.to_path_buf();
+        let branch = fission_branch_git_name(ctx.group_id, ordinal);
+        let wt = tokio::task::spawn_blocking(move || {
+            worktree::create(&blocking_root, &branch, "HEAD")
+        })
+        .await
+        .map_err(|e| format!("worktree creation task failed: {e}"))?
+        .map_err(|e| format!("worktree creation failed: {e}"))?;
+        Some(wt)
     } else {
         None
-    };
-    let cleanup_worktree = |wt: &Option<worktree::Worktree>| -> String {
-        if let Some(wt) = wt {
-            if let Err(err) = worktree::remove_worktree_and_branch(config.project_root, wt) {
-                return format!(
-                    "; cleanup of worktree {} also failed: {err}",
-                    wt.path.display()
-                );
-            }
-        }
-        String::new()
     };
 
     let display_name = spec.name.clone().unwrap_or_else(|| {
@@ -1349,7 +1365,7 @@ pub(crate) async fn spawn_single_fission_branch(
     {
         Ok(child) => child,
         Err(e) => {
-            let cleanup = cleanup_worktree(&branch_worktree);
+            let cleanup = cleanup_fission_worktree(config.project_root, &branch_worktree).await;
             return Err(format!("live-thread fork failed: {e}{cleanup}"));
         }
     };
@@ -1365,7 +1381,7 @@ pub(crate) async fn spawn_single_fission_branch(
         .inject_thread_developer_message(&child.thread_id, &charter)
         .await
     {
-        let cleanup = cleanup_worktree(&branch_worktree);
+        let cleanup = cleanup_fission_worktree(config.project_root, &branch_worktree).await;
         return Err(format!(
             "charter injection into forked thread {} failed: {e}{cleanup}",
             child.thread_id
@@ -1390,7 +1406,7 @@ pub(crate) async fn spawn_single_fission_branch(
             ..Default::default()
         },
     ) {
-        let cleanup = cleanup_worktree(&branch_worktree);
+        let cleanup = cleanup_fission_worktree(config.project_root, &branch_worktree).await;
         return Err(format!(
             "fission ledger registration for forked thread {} failed: {err}{cleanup}",
             child.thread_id

--- a/src/bin/caller/tool_batch.rs
+++ b/src/bin/caller/tool_batch.rs
@@ -1,5 +1,116 @@
 use crate::{mcp_client, provider, tools};
 
+/// Facts about a runtime command batch, derived in ONE parse of the final
+/// (post `finalize_command_batch`) AgentInput JSON.
+///
+/// The agent loop used to answer each of these questions with its own helper
+/// (`has_ask_human`, `has_ask_human_command`, `batch_is_all_ask_human`,
+/// `extract_ask_human_question`, `has_capture_screen_command`,
+/// `has_exec_command`, `format_commands_preview`), every one re-parsing the
+/// complete batch — including full editFile payloads that can run to
+/// megabytes — into a fresh `serde_json::Value` tree, up to ~8 times per
+/// runtime spawn on the hottest controller path.
+#[derive(Debug, Clone, Default)]
+pub struct BatchFacts {
+    /// Any command is `askHuman` (selects the runtime's no-timeout path).
+    pub has_ask_human: bool,
+    /// The batch consists ENTIRELY of `askHuman` commands — the shape models
+    /// actually emit for a blocking question. The question-rail interception
+    /// only fires for this shape; a mixed batch would need the controller to
+    /// reorder execution around the runtime. `false` for an empty batch.
+    pub all_ask_human: bool,
+    /// Question text of the first `askHuman` command that carries one.
+    pub ask_human_question: Option<String>,
+    /// Any command is `captureScreen` (Xvfb auto-launch trigger).
+    pub has_capture_screen: bool,
+    /// Any command is `execAsAgent`/`execPty` (Xvfb auto-launch trigger).
+    pub has_exec: bool,
+    /// Human-readable one-line preview for the Activity tab; falls back to
+    /// the raw JSON when the batch is unparseable or previews to nothing
+    /// (the UI handles collapsing).
+    pub commands_preview: String,
+}
+
+impl BatchFacts {
+    pub fn from_json(json_str: &str) -> Self {
+        let parsed: serde_json::Value = match serde_json::from_str(json_str) {
+            Ok(v) => v,
+            Err(_) => return Self::opaque(json_str),
+        };
+        let Some(commands) = parsed.get("commands").and_then(|v| v.as_array()) else {
+            return Self::opaque(json_str);
+        };
+        let mut facts = BatchFacts {
+            all_ask_human: !commands.is_empty(),
+            ..Self::default()
+        };
+        let mut preview_parts: Vec<String> = Vec::with_capacity(commands.len());
+        for cmd in commands {
+            let function = cmd.get("function").and_then(|v| v.as_str()).unwrap_or("?");
+            match function {
+                "askHuman" => {
+                    facts.has_ask_human = true;
+                    if facts.ask_human_question.is_none() {
+                        facts.ask_human_question = cmd
+                            .get("question")
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string);
+                    }
+                }
+                "captureScreen" => facts.has_capture_screen = true,
+                "execAsAgent" | "execPty" => facts.has_exec = true,
+                _ => {}
+            }
+            if function != "askHuman" {
+                facts.all_ask_human = false;
+            }
+            if let Some(part) = command_preview_part(function, cmd) {
+                preview_parts.push(part);
+            }
+        }
+        facts.commands_preview = if preview_parts.is_empty() {
+            json_str.to_string()
+        } else {
+            preview_parts.join(" | ")
+        };
+        facts
+    }
+
+    /// Facts for an unparseable (or command-less) batch: nothing detected,
+    /// raw JSON as the preview — matching what each replaced helper answered
+    /// for that input.
+    fn opaque(json_str: &str) -> Self {
+        BatchFacts {
+            commands_preview: json_str.to_string(),
+            ..Self::default()
+        }
+    }
+}
+
+/// One command's contribution to the Activity-tab preview line. `None` drops
+/// the command from the preview (e.g. an exec with no command string).
+fn command_preview_part(function: &str, cmd: &serde_json::Value) -> Option<String> {
+    match function {
+        "execAsAgent" => cmd
+            .get("command")
+            .and_then(|v| v.as_str())
+            .map(|c| format!("exec: {}", c)),
+        "inspectPath" => cmd
+            .get("path")
+            .and_then(|v| v.as_str())
+            .map(|p| format!("inspect: {}", p)),
+        "editFile" | "writeFile" => cmd
+            .get("file_path")
+            .and_then(|v| v.as_str())
+            .map(|p| format!("{}: {}", function, p)),
+        "spawn_live_audio" => Some(format!(
+            "spawn_live_audio ({})",
+            cmd.get("provider").and_then(|v| v.as_str()).unwrap_or("?")
+        )),
+        _ => Some(function.to_string()),
+    }
+}
+
 /// Context directives extracted from manage_context / signal_done tool calls.
 pub struct ToolBatchResult {
     /// JSON string of AgentInput to send to the runtime (None if no runtime commands).
@@ -291,6 +402,88 @@ pub fn map_results_to_tool_responses(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn batch_facts_detects_ask_human_shapes() {
+        let solo = BatchFacts::from_json(
+            r#"{"commands":[{"function":"askHuman","nonce":1,"question":"Which DB?"}]}"#,
+        );
+        assert!(solo.has_ask_human);
+        assert!(solo.all_ask_human);
+        assert_eq!(solo.ask_human_question.as_deref(), Some("Which DB?"));
+
+        let mixed = BatchFacts::from_json(
+            r#"{"commands":[{"function":"execAsAgent","nonce":1,"command":"ls"},{"function":"askHuman","nonce":2,"question":"ok?"}]}"#,
+        );
+        assert!(mixed.has_ask_human);
+        assert!(!mixed.all_ask_human, "mixed batch is not all-askHuman");
+        assert_eq!(mixed.ask_human_question.as_deref(), Some("ok?"));
+
+        // The question comes from the first askHuman that HAS one (the old
+        // find_map semantics), not blindly from the first askHuman.
+        let questionless_first = BatchFacts::from_json(
+            r#"{"commands":[{"function":"askHuman","nonce":1},{"function":"askHuman","nonce":2,"question":"second"}]}"#,
+        );
+        assert_eq!(
+            questionless_first.ask_human_question.as_deref(),
+            Some("second")
+        );
+
+        // "askHuman" appearing inside a command STRING is not a detection.
+        let embedded = BatchFacts::from_json(
+            r#"{"commands":[{"function":"execAsAgent","nonce":1,"command":"echo \"askHuman\""}]}"#,
+        );
+        assert!(!embedded.has_ask_human);
+        assert!(!embedded.all_ask_human);
+
+        let empty = BatchFacts::from_json(r#"{"commands":[]}"#);
+        assert!(!empty.all_ask_human, "empty batch is not all-askHuman");
+    }
+
+    #[test]
+    fn batch_facts_detects_capture_and_exec() {
+        let capture = BatchFacts::from_json(
+            r#"{"commands":[{"function":"inspectPath","nonce":1,"path":"/x"},{"function":"captureScreen","nonce":2}]}"#,
+        );
+        assert!(capture.has_capture_screen);
+        assert!(!capture.has_exec);
+
+        let pty = BatchFacts::from_json(
+            r#"{"commands":[{"function":"execPty","nonce":1,"command":"top"}]}"#,
+        );
+        assert!(pty.has_exec);
+        assert!(!pty.has_capture_screen);
+
+        let invalid = BatchFacts::from_json("not json");
+        assert!(!invalid.has_ask_human);
+        assert!(!invalid.has_capture_screen);
+        assert!(!invalid.has_exec);
+    }
+
+    #[test]
+    fn batch_facts_preview_matches_legacy_format() {
+        let facts = BatchFacts::from_json(
+            r#"{"commands":[
+                {"function":"execAsAgent","nonce":1,"command":"cargo test"},
+                {"function":"inspectPath","nonce":2,"path":"src/main.rs"},
+                {"function":"editFile","nonce":3,"file_path":"src/lib.rs","operation":"write"},
+                {"function":"captureScreen","nonce":4}
+            ]}"#,
+        );
+        assert_eq!(
+            facts.commands_preview,
+            "exec: cargo test | inspect: src/main.rs | editFile: src/lib.rs | captureScreen"
+        );
+
+        // Unparseable input falls back to the raw string (UI collapses it).
+        assert_eq!(BatchFacts::from_json("not json").commands_preview, "not json");
+        // A batch whose every command previews to nothing falls back too.
+        let empty_parts = r#"{"commands":[{"function":"execAsAgent","nonce":1}]}"#;
+        assert_eq!(
+            BatchFacts::from_json(empty_parts).commands_preview,
+            empty_parts
+        );
+    }
 
     #[test]
     fn assemble_batch_collects_sub_agent_calls() {

--- a/src/bin/caller/tool_batch.rs
+++ b/src/bin/caller/tool_batch.rs
@@ -476,7 +476,10 @@ mod tests {
         );
 
         // Unparseable input falls back to the raw string (UI collapses it).
-        assert_eq!(BatchFacts::from_json("not json").commands_preview, "not json");
+        assert_eq!(
+            BatchFacts::from_json("not json").commands_preview,
+            "not json"
+        );
         // A batch whose every command previews to nothing falls back too.
         let empty_parts = r#"{"commands":[{"function":"execAsAgent","nonce":1}]}"#;
         assert_eq!(

--- a/src/bin/caller/tools.rs
+++ b/src/bin/caller/tools.rs
@@ -1,9 +1,28 @@
 use serde::Serialize;
 use serde_json::{json, Value};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex, OnceLock};
 
-/// Extra tool definitions registered at runtime (e.g. from MCP servers).
-static EXTRA_TOOLS: Mutex<Vec<ToolDefinition>> = Mutex::new(Vec::new());
+/// Extra tool definitions registered at runtime (e.g. from MCP servers),
+/// stamped with a generation that bumps on every mutation. The generation is
+/// the cache key for the composed [`all_tools`] list (and any future
+/// serialized-schema caches): a changed extra-tools set must invalidate
+/// derived tool schemas, never serve a stale set.
+struct ExtraToolsRegistry {
+    tools: Vec<ToolDefinition>,
+    generation: u64,
+}
+
+static EXTRA_TOOLS: Mutex<ExtraToolsRegistry> = Mutex::new(ExtraToolsRegistry {
+    tools: Vec::new(),
+    generation: 0,
+});
+
+/// Composed built-ins + extras list, keyed by the extras generation.
+/// `all_tools()` runs per model request on the agent hot loop; without this
+/// every call re-evaluated ~18 `json!` schema trees (thousands of small
+/// allocations) just to hand the provider an identical list.
+static ALL_TOOLS_CACHE: Mutex<Option<(u64, Arc<Vec<ToolDefinition>>)>> = Mutex::new(None);
+
 const BUILT_IN_TOOL_COUNT: usize = 18;
 
 /// Provider-agnostic tool definition.
@@ -61,7 +80,48 @@ pub fn tool_name_to_function(tool_name: &str) -> Option<&'static str> {
 }
 
 /// Returns all built-in tool definitions plus any runtime-registered extras.
+///
+/// Cached: the built-in set is static per process and the extras only change
+/// through [`register_extra_tools`]/[`clear_extra_tools`], so the composed
+/// list is memoized keyed on the extras generation and each call clones the
+/// cached vector instead of rebuilding every schema.
 pub fn all_tools() -> Vec<ToolDefinition> {
+    let (generation, extras) = {
+        let Ok(registry) = EXTRA_TOOLS.lock() else {
+            // Poisoned registry: fall back to just the built-ins (matches the
+            // pre-cache behavior of ignoring a poisoned extras lock).
+            return built_in_tools().to_vec();
+        };
+        (registry.generation, registry.tools.clone())
+    };
+    {
+        let cache = ALL_TOOLS_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some((cached_generation, tools)) = cache.as_ref() {
+            if *cached_generation == generation {
+                return tools.as_ref().clone();
+            }
+        }
+    }
+    let built_ins = built_in_tools();
+    let mut tools = Vec::with_capacity(built_ins.len() + extras.len());
+    tools.extend(built_ins.iter().cloned());
+    tools.extend(extras);
+    let shared = Arc::new(tools);
+    // A racing register may have bumped the generation since we read it; the
+    // entry is stored under the generation it was BUILT from, so a stale
+    // build can never be served for the new generation.
+    *ALL_TOOLS_CACHE.lock().unwrap_or_else(|e| e.into_inner()) =
+        Some((generation, Arc::clone(&shared)));
+    shared.as_ref().clone()
+}
+
+/// The static built-in tool definitions, constructed once per process.
+fn built_in_tools() -> &'static [ToolDefinition] {
+    static BUILT_INS: OnceLock<Vec<ToolDefinition>> = OnceLock::new();
+    BUILT_INS.get_or_init(build_built_in_tools)
+}
+
+fn build_built_in_tools() -> Vec<ToolDefinition> {
     let mut tools = Vec::with_capacity(BUILT_IN_TOOL_COUNT);
 
     // 1. exec_command → execAsAgent
@@ -610,11 +670,6 @@ pub fn all_tools() -> Vec<ToolDefinition> {
         }),
     });
 
-    // Append any extra tools registered at runtime (MCP servers, etc.)
-    if let Ok(extra) = EXTRA_TOOLS.lock() {
-        tools.extend(extra.iter().cloned());
-    }
-
     tools
 }
 
@@ -622,7 +677,8 @@ pub fn all_tools() -> Vec<ToolDefinition> {
 /// These will be included in subsequent calls to `all_tools()`.
 pub fn register_extra_tools(new_tools: Vec<ToolDefinition>) {
     if let Ok(mut extra) = EXTRA_TOOLS.lock() {
-        extra.extend(new_tools);
+        extra.tools.extend(new_tools);
+        extra.generation += 1;
     }
 }
 
@@ -651,7 +707,8 @@ pub fn escalate_to_agent_tool() -> ToolDefinition {
 #[allow(dead_code)]
 pub fn clear_extra_tools() {
     if let Ok(mut extra) = EXTRA_TOOLS.lock() {
-        extra.clear();
+        extra.tools.clear();
+        extra.generation += 1;
     }
 }
 
@@ -690,6 +747,26 @@ mod tests {
                 "missing built-in tool {name}"
             );
         }
+    }
+
+    /// The composed-list cache must be invalidated by registry mutations:
+    /// register → the extra appears; clear → it is gone. (The registered
+    /// definition satisfies every global-tool invariant — snake_case name,
+    /// description, object schema — so tests iterating `all_tools()`
+    /// concurrently cannot be tripped by the registration window.)
+    #[test]
+    fn all_tools_cache_invalidates_on_extra_tool_mutations() {
+        let name = "extra_tool_cache_probe";
+        // Warm the cache first so the register exercises invalidation.
+        assert!(all_tools().iter().all(|tool| tool.name != name));
+        register_extra_tools(vec![ToolDefinition {
+            name: name.to_string(),
+            description: "cache invalidation probe".to_string(),
+            parameters: json!({"type": "object", "properties": {}}),
+        }]);
+        assert!(all_tools().iter().any(|tool| tool.name == name));
+        clear_extra_tools();
+        assert!(all_tools().iter().all(|tool| tool.name != name));
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -21,27 +21,71 @@ pub(crate) static SESSIONS_SEARCH_TEST_LOCK: std::sync::Mutex<()> = std::sync::M
 const AGENT_OUTPUT_SWEEP_MAX_DIRS: usize = 64;
 
 /// How long a store-sweep miss is remembered per (logs root, output id).
-/// Output rows are append-once historical records: an id the sweep could
-/// not find does not appear later in swept dirs (a *live* session's rows
-/// land in the primary dir, which is never memoized). The TTL exists so the
-/// memo self-heals anyway, e.g. across a session-dir move.
+/// A memoized miss is ALSO discarded the moment any session under the root
+/// appends agent output (the append generation below), so the TTL is a
+/// backstop for writes the generation cannot see (e.g. a session dir moved
+/// into the root), not the primary invalidation.
 const AGENT_OUTPUT_NEGATIVE_MEMO_TTL: std::time::Duration = std::time::Duration::from_secs(30);
 const AGENT_OUTPUT_NEGATIVE_MEMO_CAP: usize = 1024;
 
+/// Requests carry at most this many output ids (after dedup); beyond it the
+/// request is refused with a 400. The dashboard fetches a handful per
+/// output group, and `agent_output_json_body_accepts_large_id_lists` pins a
+/// deliberate 2026-05 decision that several-hundred-id lists stay accepted
+/// — so the cap sits above that contract, aligned with the negative-memo
+/// cap. It is a hard ceiling against degenerate requests; the memo-flood
+/// vector specifically is closed at insertion regardless of id count.
+const AGENT_OUTPUT_MAX_IDS_PER_REQUEST: usize = 1024;
+
+/// A remembered sweep miss: valid until `expires_at`, and only while the
+/// logs root's agent-output append generation still equals `generation`.
+struct AgentOutputNegativeEntry {
+    expires_at: std::time::Instant,
+    generation: u64,
+}
+
 static AGENT_OUTPUT_NEGATIVE_MEMO: std::sync::Mutex<
-    Option<HashMap<(PathBuf, String), std::time::Instant>>,
+    Option<HashMap<(PathBuf, String), AgentOutputNegativeEntry>>,
 > = std::sync::Mutex::new(None);
 
-fn agent_output_negative_memo_fresh(logs_dir: &Path, id: &str) -> bool {
+/// Serializes tests that assert on the process-global negative memo (the
+/// cap test deliberately fills it; unserialized, that starves concurrent
+/// tests' inserts). Same idiom as `SESSIONS_SEARCH_TEST_LOCK`.
+#[cfg(test)]
+pub(crate) static AGENT_OUTPUT_MEMO_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Test-only: drop every memo entry so capacity-sensitive assertions start
+/// from a known state.
+#[cfg(test)]
+fn agent_output_negative_memo_reset() {
+    *AGENT_OUTPUT_NEGATIVE_MEMO
+        .lock()
+        .unwrap_or_else(|e| e.into_inner()) = None;
+}
+
+/// `generation` is the root's current append generation
+/// (`session_log::agent_output_generation`): an entry recorded under an
+/// older generation is stale — output was appended somewhere under the
+/// root since the sweep that missed — and must not veto a re-sweep.
+fn agent_output_negative_memo_fresh(logs_dir: &Path, id: &str, generation: u64) -> bool {
     let memo = AGENT_OUTPUT_NEGATIVE_MEMO
         .lock()
         .unwrap_or_else(|e| e.into_inner());
     memo.as_ref()
         .and_then(|memo| memo.get(&(logs_dir.to_path_buf(), id.to_string())))
-        .is_some_and(|expiry| *expiry > std::time::Instant::now())
+        .is_some_and(|entry| {
+            entry.generation == generation && entry.expires_at > std::time::Instant::now()
+        })
 }
 
-fn agent_output_negative_memo_insert(logs_dir: &Path, ids: &[String]) {
+/// Record sweep misses under the generation observed BEFORE the sweep ran:
+/// an append racing the sweep bumps the generation and the entry is born
+/// stale, which fails toward re-sweeping. The cap is enforced at insertion
+/// — expired entries are pruned when full, then remaining inserts are
+/// SKIPPED (skipping only costs a future re-sweep); the map is never
+/// cleared wholesale, so a flood of scripted ids cannot evict everyone
+/// else's entries.
+fn agent_output_negative_memo_insert(logs_dir: &Path, ids: &[String], generation: u64) {
     if ids.is_empty() {
         return;
     }
@@ -51,17 +95,19 @@ fn agent_output_negative_memo_insert(logs_dir: &Path, ids: &[String]) {
     let memo = memo.get_or_insert_with(HashMap::new);
     let now = std::time::Instant::now();
     if memo.len() + ids.len() > AGENT_OUTPUT_NEGATIVE_MEMO_CAP {
-        memo.retain(|_, expiry| *expiry > now);
-        // Still over cap after pruning expired entries: drop the memo rather
-        // than let a scripted id flood grow it; the cost is re-sweeping.
-        if memo.len() + ids.len() > AGENT_OUTPUT_NEGATIVE_MEMO_CAP {
-            memo.clear();
-        }
+        memo.retain(|_, entry| entry.expires_at > now);
     }
     for id in ids {
+        let key = (logs_dir.to_path_buf(), id.clone());
+        if memo.len() >= AGENT_OUTPUT_NEGATIVE_MEMO_CAP && !memo.contains_key(&key) {
+            continue;
+        }
         memo.insert(
-            (logs_dir.to_path_buf(), id.clone()),
-            now + AGENT_OUTPUT_NEGATIVE_MEMO_TTL,
+            key,
+            AgentOutputNegativeEntry {
+                expires_at: now + AGENT_OUTPUT_NEGATIVE_MEMO_TTL,
+                generation,
+            },
         );
     }
 }
@@ -81,11 +127,15 @@ pub(crate) fn agent_output_chunks_with_fallback(
         if let Some(logs_dir) = fallback_logs_dir {
             // Ids a recent sweep of this store already failed to resolve are
             // not re-swept — dashboard retries otherwise re-read the store
-            // per poll for as long as a stale id stays on screen.
+            // per poll for as long as a stale id stays on screen. Read the
+            // append generation ONCE, before sweeping: misses are memoized
+            // under it, so an append racing this sweep leaves the memo
+            // already stale.
+            let generation = crate::session_log::agent_output_generation(logs_dir);
             let sweep_ids: Vec<String> = ids
                 .iter()
                 .filter(|id| !found.contains_key(id.as_str()))
-                .filter(|id| !agent_output_negative_memo_fresh(logs_dir, id))
+                .filter(|id| !agent_output_negative_memo_fresh(logs_dir, id, generation))
                 .cloned()
                 .collect();
             if !sweep_ids.is_empty() {
@@ -101,7 +151,15 @@ pub(crate) fn agent_output_chunks_with_fallback(
                         }
                     }
                 }
-                dirs.sort_by_key(|b| std::cmp::Reverse(session_log_mtime(b)));
+                // Deterministic order: newest session.jsonl first, path as
+                // the tie-breaker so equal-mtime dirs cannot flap in and out
+                // of the bounded window between sweeps. Ids living only in
+                // the 65th+ most-recent dirs are out of sweep scope by
+                // design (the audit's bound; a per-id → session index is
+                // the recorded follow-up if archaeology ever matters).
+                dirs.sort_by_cached_key(|dir| {
+                    (std::cmp::Reverse(session_log_mtime(dir)), dir.clone())
+                });
                 dirs.truncate(AGENT_OUTPUT_SWEEP_MAX_DIRS);
 
                 for dir in dirs {
@@ -121,7 +179,7 @@ pub(crate) fn agent_output_chunks_with_fallback(
                     .into_iter()
                     .filter(|id| !found.contains_key(id.as_str()))
                     .collect();
-                agent_output_negative_memo_insert(logs_dir, &still_missing);
+                agent_output_negative_memo_insert(logs_dir, &still_missing, generation);
             }
         }
     }
@@ -191,15 +249,27 @@ pub(crate) fn agent_output_ids_from_json_body(body: &str) -> Result<Vec<String>,
     let Some(ids) = parsed.get("ids").and_then(|ids| ids.as_array()) else {
         return Err("missing output ids".to_string());
     };
+    // Dedupe (first occurrence wins, order preserved) — repeated ids would
+    // otherwise multiply lookup and memo work for free — then cap: one
+    // request must not be able to monopolize the lookup path or flood the
+    // negative memo.
+    let mut seen: HashSet<&str> = HashSet::new();
     let ids: Vec<String> = ids
         .iter()
         .filter_map(|id| id.as_str())
         .map(str::trim)
         .filter(|id| is_valid_agent_output_id(id))
+        .filter(|id| seen.insert(id))
         .map(ToString::to_string)
         .collect();
     if ids.is_empty() {
         return Err("missing output ids".to_string());
+    }
+    if ids.len() > AGENT_OUTPUT_MAX_IDS_PER_REQUEST {
+        return Err(format!(
+            "too many output ids in one request: {} (max {AGENT_OUTPUT_MAX_IDS_PER_REQUEST}); split the fetch",
+            ids.len()
+        ));
     }
     Ok(ids)
 }
@@ -3082,11 +3152,21 @@ pub(crate) async fn handle_session_agent_output_from_home(
         .unwrap_or("");
     let path = rest.split('?').next().unwrap_or(rest);
     let rest_parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
-    let session_id = rest_parts.first().copied().unwrap_or("");
+    let session_id = rest_parts.first().copied().unwrap_or("").to_string();
     let is_agent_output_route = rest_parts.get(1).copied() == Some("agent-output");
     let source = query_param(request_line, "source").unwrap_or_else(|| "intendant".to_string());
     let response = if is_agent_output_route {
-        session_agent_output_api_response(home, &body_text, session_id, &source)
+        // Same blocking-pool treatment as the /current twin: the lookup
+        // reads and filters full session logs (native path) or external
+        // transcripts, which stalled a gateway worker when run inline.
+        let home = home.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            session_agent_output_api_response(&home, &body_text, &session_id, &source)
+        })
+        .await
+        .unwrap_or_else(|e| {
+            session_wildcard_json_error(500, &format!("agent output task failed: {e}"))
+        })
     } else {
         session_wildcard_json_error(404, "unknown session output route")
     };
@@ -6131,6 +6211,30 @@ mod tests {
         assert_eq!(parsed[699], "ao-19e4f985a17-2bb");
     }
 
+    /// Repeated ids collapse to their first occurrence, and a list past the
+    /// hard per-request ceiling is refused outright.
+    #[test]
+    fn agent_output_json_body_dedupes_and_caps_ids() {
+        let body = serde_json::json!({ "ids": ["ao-1", "ao-2", "ao-1", "ao-2", "ao-3"] });
+        let parsed = agent_output_ids_from_json_body(&body.to_string()).unwrap();
+        assert_eq!(parsed, vec!["ao-1", "ao-2", "ao-3"]);
+
+        let oversized: Vec<String> = (0..(AGENT_OUTPUT_MAX_IDS_PER_REQUEST + 1))
+            .map(|n| format!("ao-cap-{n}"))
+            .collect();
+        let body = serde_json::json!({ "ids": oversized }).to_string();
+        let err = agent_output_ids_from_json_body(&body).unwrap_err();
+        assert!(err.contains("too many output ids"), "error: {err}");
+
+        // Duplicates are removed BEFORE the cap is applied: a list that
+        // dedupes under the ceiling stays accepted.
+        let dup_heavy: Vec<String> = (0..(AGENT_OUTPUT_MAX_IDS_PER_REQUEST + 200))
+            .map(|n| format!("ao-dup-{}", n % 8))
+            .collect();
+        let body = serde_json::json!({ "ids": dup_heavy }).to_string();
+        assert_eq!(agent_output_ids_from_json_body(&body).unwrap().len(), 8);
+    }
+
     // ── Golden HTTP transcripts: the sessions read-core wire contract ──
     //
     // Byte-exact pins of the session list / search / detail /
@@ -6435,31 +6539,87 @@ mod tests {
         );
     }
 
-    /// A store-sweep miss is remembered per (logs root, id) and expires;
-    /// distinct roots never share a verdict. (The memo only ever guards the
-    /// fallback sweep — the primary dir is re-read on every fetch.)
+    /// A store-sweep miss is remembered per (logs root, id), expires, and
+    /// is discarded when the root's append generation moves; distinct roots
+    /// never share a verdict. (The memo only ever guards the fallback
+    /// sweep — the primary dir is re-read on every fetch.)
     #[test]
-    fn agent_output_negative_memo_is_root_scoped_and_expiring() {
+    fn agent_output_negative_memo_is_root_and_generation_scoped() {
+        let _guard = AGENT_OUTPUT_MEMO_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let root_a = tempfile::tempdir().unwrap();
         let root_b = tempfile::tempdir().unwrap();
         let ids = vec!["memo-probe-1".to_string()];
-        assert!(!agent_output_negative_memo_fresh(root_a.path(), &ids[0]));
-        agent_output_negative_memo_insert(root_a.path(), &ids);
-        assert!(agent_output_negative_memo_fresh(root_a.path(), &ids[0]));
+        assert!(!agent_output_negative_memo_fresh(root_a.path(), &ids[0], 7));
+        agent_output_negative_memo_insert(root_a.path(), &ids, 7);
+        assert!(agent_output_negative_memo_fresh(root_a.path(), &ids[0], 7));
         assert!(
-            !agent_output_negative_memo_fresh(root_b.path(), &ids[0]),
+            !agent_output_negative_memo_fresh(root_a.path(), &ids[0], 8),
+            "an append-bumped generation must invalidate the memoized miss"
+        );
+        assert!(
+            !agent_output_negative_memo_fresh(root_b.path(), &ids[0], 7),
             "a miss under one logs root must not veto sweeps under another"
         );
         assert!(!agent_output_negative_memo_fresh(
             root_a.path(),
-            "memo-probe-other"
+            "memo-probe-other",
+            7
         ));
     }
 
-    /// The bounded sweep still resolves ids from sibling dirs and reports
-    /// what it could not find; a memoized miss suppresses only re-sweeps.
+    /// The insertion-enforced cap never clears other entries: an oversized
+    /// batch of fresh ids is simply not memoized once the map is full (the
+    /// cost is a re-sweep), while pre-existing entries survive.
     #[test]
-    fn agent_output_fallback_resolves_sibling_and_memoizes_miss() {
+    fn agent_output_negative_memo_cap_skips_instead_of_clearing() {
+        let _guard = AGENT_OUTPUT_MEMO_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // Deliberately fills the global memo: start from and return to a
+        // clean slate so capacity is never leaked into other tests.
+        agent_output_negative_memo_reset();
+        let keeper_root = tempfile::tempdir().unwrap();
+        let flood_root = tempfile::tempdir().unwrap();
+        let keeper = vec!["memo-cap-keeper".to_string()];
+        agent_output_negative_memo_insert(keeper_root.path(), &keeper, 1);
+        assert!(agent_output_negative_memo_fresh(
+            keeper_root.path(),
+            &keeper[0],
+            1
+        ));
+
+        // Flood far past the cap in one insert call (the old clear-then-
+        // insert-all shape would have evicted the keeper).
+        let flood: Vec<String> = (0..(AGENT_OUTPUT_NEGATIVE_MEMO_CAP + 64))
+            .map(|i| format!("memo-cap-flood-{i}"))
+            .collect();
+        agent_output_negative_memo_insert(flood_root.path(), &flood, 1);
+        assert!(
+            agent_output_negative_memo_fresh(keeper_root.path(), &keeper[0], 1),
+            "a flood of new ids must not evict existing entries"
+        );
+        assert!(
+            !agent_output_negative_memo_fresh(
+                flood_root.path(),
+                &flood[AGENT_OUTPUT_NEGATIVE_MEMO_CAP + 32],
+                1
+            ),
+            "ids beyond the cap are skipped, not memoized"
+        );
+        agent_output_negative_memo_reset();
+    }
+
+    /// The bounded sweep still resolves ids from sibling dirs and reports
+    /// what it could not find; a memoized miss suppresses only re-sweeps,
+    /// and an agent-output append under the root makes it stale — the id
+    /// becomes findable immediately, not after the TTL.
+    #[test]
+    fn agent_output_fallback_memoizes_miss_until_root_appends() {
+        let _guard = AGENT_OUTPUT_MEMO_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let home = tempfile::tempdir().unwrap();
         let logs_root = home.path().join("logs");
         let primary = logs_root.join("primary");
@@ -6474,20 +6634,41 @@ mod tests {
         let ids = vec![
             "fb-primary".to_string(),
             "fb-sibling".to_string(),
-            "fb-nowhere".to_string(),
+            "fb-late".to_string(),
         ];
         let chunks = agent_output_chunks_with_fallback(&primary, &ids, Some(&logs_root));
         let found: Vec<&str> = chunks.iter().map(|c| c.output_id.as_str()).collect();
         assert_eq!(found, vec!["fb-primary", "fb-sibling"]);
+        let generation = crate::session_log::agent_output_generation(&logs_root);
         assert!(
-            agent_output_negative_memo_fresh(&logs_root, "fb-nowhere"),
+            agent_output_negative_memo_fresh(&logs_root, "fb-late", generation),
             "the unresolved id must be memoized against immediate re-sweeps"
         );
-        assert!(!agent_output_negative_memo_fresh(&logs_root, "fb-sibling"));
+        assert!(!agent_output_negative_memo_fresh(
+            &logs_root,
+            "fb-sibling",
+            generation
+        ));
 
         // Second query: identical answer (memo affects IO, not results).
         let chunks = agent_output_chunks_with_fallback(&primary, &ids, Some(&logs_root));
         assert_eq!(chunks.len(), 2);
+
+        // The formerly-missing id gets WRITTEN to a sibling session: the
+        // append bumps the root generation, the memo goes stale, and the
+        // very next fetch resolves it — the cross-session blind window the
+        // generation exists to close.
+        let late_dir = logs_root.join("late");
+        let mut log = crate::session_log::SessionLog::open(late_dir).unwrap();
+        log.agent_output_with_id("late out", "", None, Some("fb-late"));
+        drop(log);
+        let chunks = agent_output_chunks_with_fallback(&primary, &ids, Some(&logs_root));
+        let found: Vec<&str> = chunks.iter().map(|c| c.output_id.as_str()).collect();
+        assert_eq!(
+            found,
+            vec!["fb-primary", "fb-sibling", "fb-late"],
+            "an appended output must be findable immediately after the append"
+        );
     }
 
     #[tokio::test]

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -13,6 +13,59 @@ use super::*;
 #[cfg(test)]
 pub(crate) static SESSIONS_SEARCH_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Most-recent session dirs the missing-id fallback sweep will read. Output
+/// ids reference recent activity (the primary — active — log dir is always
+/// searched in full first); the sweep exists for cross-session references
+/// and dir races, not for archaeology, and unbounded it read+parsed every
+/// session.jsonl in a store that grows forever (~3.2k dirs observed).
+const AGENT_OUTPUT_SWEEP_MAX_DIRS: usize = 64;
+
+/// How long a store-sweep miss is remembered per (logs root, output id).
+/// Output rows are append-once historical records: an id the sweep could
+/// not find does not appear later in swept dirs (a *live* session's rows
+/// land in the primary dir, which is never memoized). The TTL exists so the
+/// memo self-heals anyway, e.g. across a session-dir move.
+const AGENT_OUTPUT_NEGATIVE_MEMO_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+const AGENT_OUTPUT_NEGATIVE_MEMO_CAP: usize = 1024;
+
+static AGENT_OUTPUT_NEGATIVE_MEMO: std::sync::Mutex<
+    Option<HashMap<(PathBuf, String), std::time::Instant>>,
+> = std::sync::Mutex::new(None);
+
+fn agent_output_negative_memo_fresh(logs_dir: &Path, id: &str) -> bool {
+    let memo = AGENT_OUTPUT_NEGATIVE_MEMO
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    memo.as_ref()
+        .and_then(|memo| memo.get(&(logs_dir.to_path_buf(), id.to_string())))
+        .is_some_and(|expiry| *expiry > std::time::Instant::now())
+}
+
+fn agent_output_negative_memo_insert(logs_dir: &Path, ids: &[String]) {
+    if ids.is_empty() {
+        return;
+    }
+    let mut memo = AGENT_OUTPUT_NEGATIVE_MEMO
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let memo = memo.get_or_insert_with(HashMap::new);
+    let now = std::time::Instant::now();
+    if memo.len() + ids.len() > AGENT_OUTPUT_NEGATIVE_MEMO_CAP {
+        memo.retain(|_, expiry| *expiry > now);
+        // Still over cap after pruning expired entries: drop the memo rather
+        // than let a scripted id flood grow it; the cost is re-sweeping.
+        if memo.len() + ids.len() > AGENT_OUTPUT_NEGATIVE_MEMO_CAP {
+            memo.clear();
+        }
+    }
+    for id in ids {
+        memo.insert(
+            (logs_dir.to_path_buf(), id.clone()),
+            now + AGENT_OUTPUT_NEGATIVE_MEMO_TTL,
+        );
+    }
+}
+
 pub(crate) fn agent_output_chunks_with_fallback(
     primary_log_dir: &Path,
     ids: &[String],
@@ -26,32 +79,49 @@ pub(crate) fn agent_output_chunks_with_fallback(
 
     if found.len() < ids.len() {
         if let Some(logs_dir) = fallback_logs_dir {
-            let mut dirs = Vec::new();
-            if let Ok(entries) = std::fs::read_dir(logs_dir) {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    if path.is_dir()
-                        && path.join("session.jsonl").is_file()
-                        && !same_path(&path, primary_log_dir)
-                    {
-                        dirs.push(path);
+            // Ids a recent sweep of this store already failed to resolve are
+            // not re-swept — dashboard retries otherwise re-read the store
+            // per poll for as long as a stale id stays on screen.
+            let sweep_ids: Vec<String> = ids
+                .iter()
+                .filter(|id| !found.contains_key(id.as_str()))
+                .filter(|id| !agent_output_negative_memo_fresh(logs_dir, id))
+                .cloned()
+                .collect();
+            if !sweep_ids.is_empty() {
+                let mut dirs = Vec::new();
+                if let Ok(entries) = std::fs::read_dir(logs_dir) {
+                    for entry in entries.flatten() {
+                        let path = entry.path();
+                        if path.is_dir()
+                            && path.join("session.jsonl").is_file()
+                            && !same_path(&path, primary_log_dir)
+                        {
+                            dirs.push(path);
+                        }
                     }
                 }
-            }
-            dirs.sort_by_key(|b| std::cmp::Reverse(session_log_mtime(b)));
+                dirs.sort_by_key(|b| std::cmp::Reverse(session_log_mtime(b)));
+                dirs.truncate(AGENT_OUTPUT_SWEEP_MAX_DIRS);
 
-            for dir in dirs {
-                let missing: Vec<String> = ids
-                    .iter()
+                for dir in dirs {
+                    let missing: Vec<String> = sweep_ids
+                        .iter()
+                        .filter(|id| !found.contains_key(id.as_str()))
+                        .cloned()
+                        .collect();
+                    if missing.is_empty() {
+                        break;
+                    }
+                    for chunk in crate::session_log::agent_output_chunks_by_id(&dir, &missing) {
+                        found.entry(chunk.output_id.clone()).or_insert(chunk);
+                    }
+                }
+                let still_missing: Vec<String> = sweep_ids
+                    .into_iter()
                     .filter(|id| !found.contains_key(id.as_str()))
-                    .cloned()
                     .collect();
-                if missing.is_empty() {
-                    break;
-                }
-                for chunk in crate::session_log::agent_output_chunks_by_id(&dir, &missing) {
-                    found.entry(chunk.output_id.clone()).or_insert(chunk);
-                }
+                agent_output_negative_memo_insert(logs_dir, &still_missing);
             }
         }
     }
@@ -2840,9 +2910,19 @@ pub(crate) async fn handle_current_agent_output(
     let log_dir = current_session_log_dir(session_log.as_ref(), query_ctx.as_ref());
     let response = match log_dir {
         // The transport edge resolves the real home for the fallback
-        // sweep — only when there is an active log to serve from.
+        // sweep — only when there is an active log to serve from. On the
+        // blocking pool: this reads and filters the full session log (plus
+        // the bounded store sweep on a miss), which stalled a gateway
+        // worker per fetch when run inline.
         Some(dir) => {
-            current_agent_output_api_response(&crate::platform::home_dir(), &body_text, &dir)
+            let home = crate::platform::home_dir();
+            tokio::task::spawn_blocking(move || {
+                current_agent_output_api_response(&home, &body_text, &dir)
+            })
+            .await
+            .unwrap_or_else(|e| {
+                session_wildcard_json_error(500, &format!("agent output task failed: {e}"))
+            })
         }
         None => session_wildcard_json_error(404, "no active session log"),
     };
@@ -6353,6 +6433,58 @@ mod tests {
             golden_transcript(&response),
             golden_session_wildcard_json_transcript("200 OK", &body)
         );
+    }
+
+    /// A store-sweep miss is remembered per (logs root, id) and expires;
+    /// distinct roots never share a verdict. (The memo only ever guards the
+    /// fallback sweep — the primary dir is re-read on every fetch.)
+    #[test]
+    fn agent_output_negative_memo_is_root_scoped_and_expiring() {
+        let root_a = tempfile::tempdir().unwrap();
+        let root_b = tempfile::tempdir().unwrap();
+        let ids = vec!["memo-probe-1".to_string()];
+        assert!(!agent_output_negative_memo_fresh(root_a.path(), &ids[0]));
+        agent_output_negative_memo_insert(root_a.path(), &ids);
+        assert!(agent_output_negative_memo_fresh(root_a.path(), &ids[0]));
+        assert!(
+            !agent_output_negative_memo_fresh(root_b.path(), &ids[0]),
+            "a miss under one logs root must not veto sweeps under another"
+        );
+        assert!(!agent_output_negative_memo_fresh(root_a.path(), "memo-probe-other"));
+    }
+
+    /// The bounded sweep still resolves ids from sibling dirs and reports
+    /// what it could not find; a memoized miss suppresses only re-sweeps.
+    #[test]
+    fn agent_output_fallback_resolves_sibling_and_memoizes_miss() {
+        let home = tempfile::tempdir().unwrap();
+        let logs_root = home.path().join("logs");
+        let primary = logs_root.join("primary");
+        let sibling = logs_root.join("sibling");
+        let mut log = crate::session_log::SessionLog::open(primary.clone()).unwrap();
+        log.agent_output_with_id("primary out", "", None, Some("fb-primary"));
+        drop(log);
+        let mut log = crate::session_log::SessionLog::open(sibling.clone()).unwrap();
+        log.agent_output_with_id("sibling out", "", None, Some("fb-sibling"));
+        drop(log);
+
+        let ids = vec![
+            "fb-primary".to_string(),
+            "fb-sibling".to_string(),
+            "fb-nowhere".to_string(),
+        ];
+        let chunks = agent_output_chunks_with_fallback(&primary, &ids, Some(&logs_root));
+        let found: Vec<&str> = chunks.iter().map(|c| c.output_id.as_str()).collect();
+        assert_eq!(found, vec!["fb-primary", "fb-sibling"]);
+        assert!(
+            agent_output_negative_memo_fresh(&logs_root, "fb-nowhere"),
+            "the unresolved id must be memoized against immediate re-sweeps"
+        );
+        assert!(!agent_output_negative_memo_fresh(&logs_root, "fb-sibling"));
+
+        // Second query: identical answer (memo affects IO, not results).
+        let chunks = agent_output_chunks_with_fallback(&primary, &ids, Some(&logs_root));
+        assert_eq!(chunks.len(), 2);
     }
 
     #[tokio::test]

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -67,12 +67,15 @@ fn agent_output_negative_memo_reset() {
 /// (`session_log::agent_output_generation`): an entry recorded under an
 /// older generation is stale — output was appended somewhere under the
 /// root since the sweep that missed — and must not veto a re-sweep.
+/// Keys are canonicalized like the generation map's, so a miss memoized
+/// under one spelling of a root is found (and invalidated) under another.
 fn agent_output_negative_memo_fresh(logs_dir: &Path, id: &str, generation: u64) -> bool {
+    let root = crate::session_log::canonical_logs_root(logs_dir);
     let memo = AGENT_OUTPUT_NEGATIVE_MEMO
         .lock()
         .unwrap_or_else(|e| e.into_inner());
     memo.as_ref()
-        .and_then(|memo| memo.get(&(logs_dir.to_path_buf(), id.to_string())))
+        .and_then(|memo| memo.get(&(root, id.to_string())))
         .is_some_and(|entry| {
             entry.generation == generation && entry.expires_at > std::time::Instant::now()
         })
@@ -89,6 +92,7 @@ fn agent_output_negative_memo_insert(logs_dir: &Path, ids: &[String], generation
     if ids.is_empty() {
         return;
     }
+    let root = crate::session_log::canonical_logs_root(logs_dir);
     let mut memo = AGENT_OUTPUT_NEGATIVE_MEMO
         .lock()
         .unwrap_or_else(|e| e.into_inner());
@@ -98,7 +102,7 @@ fn agent_output_negative_memo_insert(logs_dir: &Path, ids: &[String], generation
         memo.retain(|_, entry| entry.expires_at > now);
     }
     for id in ids {
-        let key = (logs_dir.to_path_buf(), id.clone());
+        let key = (root.clone(), id.clone());
         if memo.len() >= AGENT_OUTPUT_NEGATIVE_MEMO_CAP && !memo.contains_key(&key) {
             continue;
         }
@@ -6567,6 +6571,16 @@ mod tests {
             "memo-probe-other",
             7
         ));
+
+        // Two spellings of ONE root share the memo: keys are canonical, so
+        // a miss recorded under the plain spelling is found (and later
+        // invalidated) through a dotted spelling of the same directory.
+        std::fs::create_dir_all(root_a.path().join("subprobe")).unwrap();
+        let dotted_spelling = root_a.path().join("subprobe").join("..");
+        assert!(
+            agent_output_negative_memo_fresh(&dotted_spelling, &ids[0], 7),
+            "memo keys must agree across path spellings of the same root"
+        );
     }
 
     /// The insertion-enforced cap never clears other entries: an oversized

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -6450,7 +6450,10 @@ mod tests {
             !agent_output_negative_memo_fresh(root_b.path(), &ids[0]),
             "a miss under one logs root must not veto sweeps under another"
         );
-        assert!(!agent_output_negative_memo_fresh(root_a.path(), "memo-probe-other"));
+        assert!(!agent_output_negative_memo_fresh(
+            root_a.path(),
+            "memo-probe-other"
+        ));
     }
 
     /// The bounded sweep still resolves ids from sibling dirs and reports

--- a/src/bin/caller/worktree.rs
+++ b/src/bin/caller/worktree.rs
@@ -2,6 +2,20 @@ use crate::error::CallerError;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+/// Bounds concurrent worktree git operations daemon-wide. The lifecycle
+/// helpers here spawn git and materialize/delete full checkouts (seconds on
+/// large projects); callers run them via `spawn_blocking`, and without a
+/// bound a burst of session/fission/sub-agent launches could queue an
+/// unbounded pile of multi-second blocking-pool jobs. Callers acquire an
+/// owned permit BEFORE spawning and move it into the blocking closure, so
+/// the permit is released when the git work actually finishes — even if the
+/// awaiting future is dropped mid-operation.
+pub fn git_ops_semaphore() -> &'static std::sync::Arc<tokio::sync::Semaphore> {
+    static GIT_OPS: std::sync::OnceLock<std::sync::Arc<tokio::sync::Semaphore>> =
+        std::sync::OnceLock::new();
+    GIT_OPS.get_or_init(|| std::sync::Arc::new(tokio::sync::Semaphore::new(4)))
+}
+
 #[derive(Debug, Clone)]
 pub struct Worktree {
     pub branch_name: String,

--- a/src/bin/caller/worktree.rs
+++ b/src/bin/caller/worktree.rs
@@ -108,9 +108,14 @@ pub fn derive_branch_name(session_name: Option<&str>, session_id: &str) -> Strin
 /// as a local branch nor collides with an existing worktree directory.
 /// After a bounded scan it falls back to a nanos suffix so the launch can
 /// never loop forever on a pathological repo.
+///
+/// One `git for-each-ref` listing answers branch existence for every
+/// candidate — the previous per-candidate `git show-ref` spawned up to 51
+/// processes on a collision streak, inline on the session-launch path.
 pub fn unique_branch_name(project_root: &Path, base: &str) -> String {
+    let existing = branches_with_prefix(project_root, base);
     let taken = |candidate: &str| {
-        branch_exists(project_root, candidate)
+        existing.contains(candidate)
             || project_root
                 .join(".intendant")
                 .join("worktrees")
@@ -133,6 +138,38 @@ pub fn unique_branch_name(project_root: &Path, base: &str) -> String {
     format!("{base}-{nanos}")
 }
 
+/// Local branch names starting with `prefix`, from one `git for-each-ref`.
+/// `prefix` comes from `derive_branch_name`/`validate_branch_name` output,
+/// which admits no glob metacharacters, so `refs/heads/{prefix}*` matches
+/// exactly the name-prefixed refs. Failure (not a repo, no git) yields an
+/// empty set — candidates then read as free, matching `branch_exists`'s
+/// error behavior, and `git worktree add` stays the authority that fails.
+fn branches_with_prefix(project_root: &Path, prefix: &str) -> std::collections::HashSet<String> {
+    let output = Command::new("git")
+        .args([
+            "for-each-ref",
+            // Full refname, stripped below: `:short` would disambiguate
+            // against same-named tags (yielding "heads/x" instead of "x")
+            // and silently miss the collision.
+            "--format=%(refname)",
+            &format!("refs/heads/{prefix}*"),
+        ])
+        .current_dir(project_root)
+        .output();
+    match output {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .filter_map(|line| line.trim().strip_prefix("refs/heads/"))
+            .map(str::to_string)
+            .collect(),
+        _ => std::collections::HashSet::new(),
+    }
+}
+
+/// Exact single-branch existence probe. Production collision scans go
+/// through `branches_with_prefix` (one listing for all candidates); this
+/// stays as the precise probe for tests and one-off checks.
+#[allow(dead_code)]
 pub fn branch_exists(project_root: &Path, branch: &str) -> bool {
     Command::new("git")
         .args([
@@ -625,6 +662,22 @@ mod tests {
         assert_eq!(unique_branch_name(repo, "taken"), "taken-2");
         create(repo, "taken-2", "HEAD").unwrap();
         assert_eq!(unique_branch_name(repo, "taken"), "taken-3");
+    }
+
+    /// The one-listing collision probe must read full refnames: with a tag
+    /// named like the branch, `%(refname:short)` would disambiguate the
+    /// branch to `heads/<name>` and the collision would be missed.
+    #[test]
+    fn unique_branch_name_sees_collision_despite_same_named_tag() {
+        let dir = init_test_repo();
+        let repo = dir.path();
+        create(repo, "tagged", "HEAD").unwrap();
+        Command::new("git")
+            .args(["tag", "tagged"])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        assert_eq!(unique_branch_name(repo, "tagged"), "tagged-2");
     }
 
     #[test]

--- a/src/bin/caller/worktree_inventory.rs
+++ b/src/bin/caller/worktree_inventory.rs
@@ -884,7 +884,9 @@ pub fn clean_worktree_target_if_safe(
     }
     let size_budget = SizeBudget::new(MAX_SIZE_ENTRIES_PER_WORKTREE);
     let hint_index = HintIndex::new(session_hints);
-    let entry = enrich_worktree(raw, &repo_ctx, &hint_index, &size_budget)?;
+    // measure=false: this enrich exists for the HEAD pin below; the only
+    // size this endpoint reports is `freed_bytes`, measured target-only.
+    let entry = enrich_worktree_with_measure(raw, &repo_ctx, &hint_index, &size_budget, false)?;
 
     if let Some(expected) = request
         .expected_head
@@ -1140,6 +1142,22 @@ fn enrich_worktree(
     hints: &HintIndex<'_>,
     size_budget: &SizeBudget,
 ) -> Result<WorktreeEntry, String> {
+    enrich_worktree_with_measure(raw, repo, hints, size_budget, true)
+}
+
+/// `measure: false` skips the whole-tree size walk (up to the 75k-entry
+/// budget, `target/` included) and leaves the size/mtime fields at their
+/// defaults. Verification-only paths use it: the safety verdict reads
+/// status/merge/lock/session state, never sizes — `clean_worktree_target_
+/// if_safe` was paying a full worktree walk here and then measuring the
+/// same `target/` again for its `before` figure.
+fn enrich_worktree_with_measure(
+    raw: RawWorktree,
+    repo: &RepoContext,
+    hints: &HintIndex<'_>,
+    size_budget: &SizeBudget,
+    measure: bool,
+) -> Result<WorktreeEntry, String> {
     let repo_root = repo.root.clone();
     let default_branch = repo.default_branch.clone();
     let status = if raw.path.is_dir() {
@@ -1192,7 +1210,7 @@ fn enrich_worktree(
     }
     .to_string();
 
-    let tree = if raw.path.is_dir() && !is_main {
+    let tree = if measure && raw.path.is_dir() && !is_main {
         measure_tree_with_budget(&raw.path, size_budget)
     } else {
         TreeMeasure::default()


### PR DESCRIPTION
Final implementation sweep for the 2026-07-15 efficiency audit: the unassigned report-05 area, the remaining items other lanes fenced out (reports 06/16/21), and the collected out-of-fence follow-ups. Every item was re-verified against current main first — several were already fixed or mooted by the ten audit PRs that landed since the audit's base (see the verification notes).

## Implemented (finding → fix)

| Audit finding | Fix | Files |
|---|---|---|
| 05-1 / L7 follow-up — worktree git lifecycle (HEAD probe, collision scan, `git worktree add`) ran inline on async loops; `unique_branch_name` spawned `git show-ref` per candidate (≤51) | Session-launch / sub-agent / fission worktree create+remove run on the blocking pool under a daemon-wide 4-permit git-ops semaphore (permits acquired async and moved into the blocking closures, so a dropped awaiter cannot leak a slot); one `git for-each-ref` listing answers all collision candidates (full refnames, so a same-named tag can't mask a collision). What the move buys is stated precisely at the call site: a tokio worker is no longer pinned and a checkout panic becomes an honest session create-failure instead of unwinding the supervisor — the intake-loop queueing itself is NOT fixed here (see follow-ups) | `worktree.rs`, `session_supervisor/launch.rs`, `session_supervisor/sub_agents.rs`, `thread_actions.rs` |
| 05-2 — every tool batch's JSON fully re-parsed up to ~8x per runtime spawn (`has_ask_human`, the 3 ask-human rail helpers, 2 Xvfb triggers, Activity preview) | `tool_batch::BatchFacts`: one parse of the finalized batch carries all facts; `run_agent` takes `has_ask_human` as a parameter; the six single-question helpers deleted; `inject_project_context` + `normalize_command_batch` fused into `finalize_command_batch` (one parse+serialize instead of two of each) | `tool_batch.rs`, `agent_loop.rs`, `main.rs`, `agent_runner.rs`, `session_log/replay.rs` |
| 05-3 — `clean_worktree_target_if_safe` walked the whole worktree (75k-entry budget, `target/` included) for a safety verdict that reads no sizes, then measured the same `target/` again | Verification enrich gains a measure-skip mode; `freed_bytes` keeps its single target-only measure | `worktree_inventory.rs` |
| 05-4 — runtime child output copied (`from_utf8_lossy().to_string()`, ≤64 MB) per batch | Buffers move into the returned strings when valid UTF-8; lossy fallback only on invalid bytes | `agent_runner.rs` |
| 06-2 — one rewind re-derived the anchor catalog ~9–14x (resolve → headroom + outcome probes → density → apply's repeat + primer facts + fission-detach prep), each pass parsing every line of a multi-MB rollout; `latest_context_rewind_outcome_for_anchor` re-derived with dedicated full passes what the scan already computed | Scans cached keyed on the rollout's (path, len, **file change stamp** — ctime/ChangeTime + dev/ino, the file watcher's fingerprint signal), fingerprint checked before AND after the read; stamp-less files are uncacheable. (len, mtime) was NOT sound: a Codex same-thread restore rewrites the rollout in place, and a same-length rewrite inside one mtime granule would have served a stale catalog into anchor selection — a test reproduces exactly that shape. The stamp alone is also not sufficient on coarse-granule clocks (the Linux CI leg tied ctimes across the whole write→rewrite→restore sequence inside one jiffy), so the cache applies the file watcher's 2 s racy-write quiescence window: a stamp younger than the window is no signal — neither cached nor served — making the regression structurally deterministic on every platform's real clock; scans of a just-modified rollout rescan until it goes quiescent, then the burst hits. The outcome query answers from the same scan's map | `managed_context_ops/anchors.rs`, `message_search/extract_codex.rs` (contract note) |
| 06-5 — "latest entry" queries scanned whole files forward keeping the last match; the session-log variant converted every snapshot row (each conversion opening its payload sidecar) | The session-log context-snapshot fallback reverse-scans with a marker prescan, stopping at the first (latest) match. The rollout `token_count` probe is served from the shared anchor scan's EOF value instead of any dedicated pass — its only production caller runs right after the validate/apply chain has populated the (now change-stamp-keyed) cache for that exact rollout, so it is a map read with one definition of "last report" and no whole-file transient allocation | `managed_context_ops/anchors.rs`, `managed_context_ops/pressure.rs` |
| 06-6 — catalog post-pass ran two linear probes over the report list per anchor (anchors x reports predicate evals per scan); token estimates re-serialized every payload via `to_vec` to read `.len()` | `partition_point` selectors (equivalence-tested against the original predicates); byte-counting serializer sink | `managed_context_ops/anchors.rs` |
| 06-7 + 06-9 — message-edit branch resolution listed full rewind records (each embedding complete fission+lineage ledger copies) across ~500 candidate dirs; the surgical-recovery primer did the same for record ids | New skinny `ContextRewindRecordSummary` listing for both metadata-only callers | `context_rewind.rs`, `managed_context_ops/anchors.rs`, `managed_context_ops/pressure.rs` |
| 06-3 residue / L2 follow-up — `get_status`'s ledger merge (store scan on id miss + ~1 MB fission-document read) ran inline on the async MCP tool handler | Candidate-dir resolution + both ledger merges on one `spawn_blocking` (the lineage read itself was incrementally cached by #343; this closes the "at minimum spawn_blocking" half) | `mcp/mod.rs` |
| 21-1 / L3 follow-up — agent-output fetch parsed every line of the whole session.jsonl per dashboard poll; any unresolved id swept EVERY session dir in the store (~3.2k dirs observed) with negatives never memoized, inline on a gateway worker | Substring prescan + stop-when-all-found in `agent_output_chunks_by_id`; fallback sweep bounded to the 64 most-recent sibling dirs (deterministic order: mtime desc, path tie-breaker). Sweep misses are memoized per (logs root, id) under the root's agent-output APPEND GENERATION — bumped at the session-log write choke point strictly AFTER the row flushed and ONLY when it flushed (the row goes through the fallible emit seam; a failed flush publishes nothing, since the generation must never vouch for an unreadable row — regression tests cover both the concurrent 4 MB append race and the sabotaged-writer failure path). Generation and memo keys are CANONICAL roots (memoized canonicalization, lexical fallback on both sides), since path-form session resolution canonicalizes while the home-derived fallback root does not — two spellings of one root now share one generation and one memo. A memoized miss dies the moment any session under the root appends output (no cross-session blind window; the 30 s TTL remains only as a backstop for writes the generation cannot see, e.g. a dir moved into the root). Request ids are deduped and hard-capped (1024, 400 beyond — above the deliberately pinned several-hundred-id acceptance contract from 2026-05); the memo cap is enforced at insertion (prune-expired then skip, never clear), so one oversized batch cannot evict other entries. Both the `/current` and `/{id}` HTTP handlers run the lookup on the blocking pool | `session_log/replay.rs`, `session_log/bus_events.rs`, `web_gateway/routes_sessions.rs` |
| L3 follow-up — tool-schema caching must key on the extra-tools set | `all_tools()` memoized: built-ins constructed once, composed list cached keyed on an extras-registry generation bumped by register/clear (it rebuilt ~18 `json!` schema trees per model request) | `tools.rs` |

## Re-verified as already fixed / moot (no change needed)

- 16-1/5/6 (presence compaction, per-round clone, output clip) — fixed by #340's presence commits (`auto_compact_at` at 0.10 with keep-prefix 1 / keep-suffix 32; slice-borrow chat; `clip_chars` before combine).
- 21-4 (`append_turn_file_span` pre-open stat), 21-6 (`emit()` per-event String), 21-7 (`agent_input`/`json_extracted` double parse) — fixed by #344.
- L4 follow-up "thread the watcher through http_dispatch for the full-history path" — moot: #336's landed shape serves `/changes` from the `live_watcher_for` registry with the full scan only as fallback, and `/history` is the slim timeline served from the watcher handle; no fresh-scan-per-request path remains.
- L4/#336 follow-up "document history format 2 in the log-search skill" — done by #336's own review commits: `skills/intendant-log-search/references/artifact-map.md` covers the slim index, per-round manifests, `store_epoch`, `maps_hash`/`maps_inline`, damaged-index preservation, and legacy migration.

## Deferred / follow-ups (with rationale)

- **Session-create off the supervisor intake loop (designed, not taken here).** Moving the worktree checkout to the blocking pool does not unqueue the control-intake loop: `start_new_session` is awaited inline by the supervisor's single sequential event loop, so other sessions' approvals/steers/interrupts still wait out a multi-second checkout. The real fix is dispatching `CreateSession`/`SpawnSubAgent` handling onto their own tasks, with one ordering constraint preserved: the delegation acknowledgment must fire only after `start_new_session` actually launched (`dispatch.rs` acks on the returned session id — the receipt means "running here as this session", and failed launches must stay unacked). That is a supervisor-lifecycle change with its own review surface, out of scope for this sweep.

- **Round-listener session scoping (L4 follow-up, event.rs + file_watcher.rs)** — verified still open (`file_watcher.rs` round listener is deliberately unfiltered; the comment calls it a known attribution wart). Real stakes: a foreign session's `native_message_count` can become a rollback target for the wrong conversation. Design: add `project_root: Option<String>` to `AppEvent::RoundComplete`, populated at emitters, listener filters to its own root and fails open on `None`. Deferred: the emitter sweep spans ~10 files including `peer/upcast.rs`, which sits in the peers-transfers PR's fence (#347).
- **Agent-output tunnel twin** (`dashboard_control/api_sessions.rs` calls the same sync core inline) — in #347's fence; the core is now cheap enough that only the `spawn_blocking` wrapper is missing there.
- **In-flight-lane fences (per sweep brief):** anything under `dashboard_control/**`, `peer/**`, `peer_file_transfer.rs`, `terminal.rs`, `transfer_store.rs`, `upload_store.rs` (#347); `crates/intendant-display/**` (#342); `routes_files.rs` SpooledBody >1 MiB leg (depends on #347's unmerged types).
- **Report-16 remaining (live_audio.rs, outside this sweep's fence, all verified still open):** Vortex playback busy-spin on `yield_now` (16-2), 5 ms-tick unbatched capture sends (16-3), shm wire-format round-trips (16-4), per-frame WS copies (16-7), per-delta unbuffered transcript writes (16-8); non-efficiency: barge-in `Interrupted` no-op, dead `buffer_secs` config, 48k/24k conversion without anti-alias/interp.
- **Report-21 remaining (session_log core, outside fence):** session-end triple parse under the log mutex (21-2), history.rs whole-file tails for 20 lines (21-3). 21-8 (id-miss store scan) is a documented deliberate decision (negatives uncached so a just-created session resolves) — the audit's short-TTL memo idea is recorded here, not taken unilaterally.
- **Report-05 non-efficiency notes (unchanged):** `worktree::merge` reports every failure as `Conflict` (dirty-checkout refusals included) with an unconditional `merge --abort`; `freed_bytes`/`reclaimable_bytes` silently under-report past the 75k-entry budget; transient presence backpressure falls through to a de-facto direct task; an early-exiting runtime child masks its own stderr behind a BrokenPipe. Also noted, not taken (response-contract bound): `inspect_worktree`'s second `git status` (v1 file list next to enrich's v2 counts) and `remove_worktree_if_safe`'s response-only size measure.

## Notes for review

- The anchor-scan cache stores entries only when the (len, change-stamp) fingerprint is available and identical before and after the read, so a mid-scan write can never pin stale content; the change stamp (not mtime) is what makes in-place rewrites — the Codex same-thread restore class — visible.
- `BatchFacts` is derived from the FINAL batch (post `finalize_command_batch`) because `writeFile`→`editFile` normalization rewrites function names — assembly-time facts would drift from what the runtime and preview actually see.
- The `partition_point` selectors are pinned by an equivalence test against the exact linear predicates they replaced, and the covering-report selector re-checks its boundary element so a future predicate de-sync degrades to "no report" instead of a wrong attribution.
- The anchor-cache burst test asserts content equality rather than Arc pointer identity: the 4-slot process-global LRU cannot guarantee an entry survives between two calls under parallel tests, and a miss re-derives the same content — which is the contract under test.
- Not fixed here, named as the next slice: `autonomy::classify_batch` and the approval-preview `format_command_preview` still fully parse the batch per spawn/approval (2–3 parses remain on that path after this PR's single-parse `BatchFacts`).

## Known residuals

- A dropped awaiter mid-checkout can orphan a worktree (the blocking git op keeps running detached): pre-existing on the sub-agent and fission paths before this PR and unchanged by it; the worktree inventory surfaces orphans for cleanup.
- `get_status` answers without ledgers if the ledger-merge task panics — now logged (it was silent), and the payload shape is unchanged.

Battery (all `CARGO_PROFILE_DEV_DEBUG=0`): `cargo fmt --check` clean; `cargo clippy --bins` clean; `cargo test --bins` — intendant 3436 passed / connect 91 / runtime 96, 0 failed; `cargo test --test e2e` — 21 passed, 0 failed.
