### PR TITLE
dashboard: complete api_worktrees_clean's twin plumbing in the SPA

### DIFF
--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -4668,6 +4668,7 @@ mod tests {
             "api_worktrees_inspect",
             "api_worktrees_scan",
             "api_worktrees_remove",
+            "api_worktrees_clean",
             "api_worktrees_merge",
             "api_settings",
             "api_settings_save",

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -370,7 +370,8 @@ pub(crate) fn scan_worktree_inventory_response(home: &Path, project_root: Option
 }
 
 /// Transport-neutral worktrees cores (tunnel twins `api_worktrees`,
-/// `api_worktrees_inspect`, `api_worktrees_scan`, `api_worktrees_remove`):
+/// `api_worktrees_inspect`, `api_worktrees_scan`, `api_worktrees_remove`,
+/// `api_worktrees_clean`):
 /// the inventory (status, body) helpers plus the shared cache
 /// side-effects, rendered as [`ApiResponse`]s. Spawn placement and
 /// task-failure shapes stay transport-owned — and so is `home`: the

--- a/static/app.html
+++ b/static/app.html
@@ -28131,7 +28131,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = '4f27f6ff2bcb5ddb';
+const INTENDANT_APP_BUILD = '621587b1939ef2f3';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -29586,6 +29586,7 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_worktrees_inspect: { verb: 'POST', path: '/api/worktrees/inspect' },
   api_worktrees_scan: { verb: 'POST', path: '/api/worktrees/scan' },
   api_worktrees_remove: { verb: 'POST', path: '/api/worktrees/remove' },
+  api_worktrees_clean: { verb: 'POST', path: '/api/worktrees/clean' },
   api_worktrees_merge: { verb: 'POST', path: '/api/worktrees/merge' },
   api_settings: { verb: 'GET', path: '/api/settings' },
   api_settings_save: { verb: 'POST', path: '/api/settings' },
@@ -79585,6 +79586,8 @@ function dashboardControlRequestTimeoutMs(method) {
     case 'api_worktrees_inspect':
     case 'api_worktrees_scan':
     case 'api_worktrees_remove':
+    case 'api_worktrees_clean':
+    case 'api_worktrees_merge':
     case 'api_fs_mkdir':
     case 'api_fs_read':
     case 'api_transfer_jobs':

--- a/static/app/32-daemon-api.js
+++ b/static/app/32-daemon-api.js
@@ -185,6 +185,7 @@ const DAEMON_API_HTTP_MAP = Object.freeze({
   api_worktrees_inspect: { verb: 'POST', path: '/api/worktrees/inspect' },
   api_worktrees_scan: { verb: 'POST', path: '/api/worktrees/scan' },
   api_worktrees_remove: { verb: 'POST', path: '/api/worktrees/remove' },
+  api_worktrees_clean: { verb: 'POST', path: '/api/worktrees/clean' },
   api_worktrees_merge: { verb: 'POST', path: '/api/worktrees/merge' },
   api_settings: { verb: 'GET', path: '/api/settings' },
   api_settings_save: { verb: 'POST', path: '/api/settings' },

--- a/static/app/50-control-transport.js
+++ b/static/app/50-control-transport.js
@@ -1637,6 +1637,8 @@ function dashboardControlRequestTimeoutMs(method) {
     case 'api_worktrees_inspect':
     case 'api_worktrees_scan':
     case 'api_worktrees_remove':
+    case 'api_worktrees_clean':
+    case 'api_worktrees_merge':
     case 'api_fs_mkdir':
     case 'api_fs_read':
     case 'api_transfer_jobs':


### PR DESCRIPTION
## Summary
- #329 declared `POST /api/worktrees/clean` with an `api_worktrees_clean` tunnel twin, but the SPA's `DAEMON_API_HTTP_MAP` never got the entry: with the control tunnel not connected — the normal state for direct browsers, whose primary event lane is `/ws` — the Worktrees pane's Clean button fails with `api_worktrees_clean has no HTTP twin and the dashboard tunnel is not connected`, even though the daemon serves the route. Add the descriptor entry plus its parity-pin line.
- `dashboardControlRequestTimeoutMs` also never learned the method: clean rode the generic 5 s default, which aborts a multi-GB `target/` delete client-side on either lane (the HTTP twin shares the per-method budget via `daemonApiTimeoutMs`). `api_worktrees_merge` carries the identical omission from its own landing. Both now join the worktrees family's 120 s bucket beside `remove`, which deletes strictly more.
- Name `api_worktrees_clean` in the `routes_sessions.rs` transport-neutral-cores doc comment (its core lives there).

## Validation
- `daemon_api_http_map_mirrors_gateway_routes` and `tunnel_method_partition_is_pinned` pass; `cargo fmt --check` clean; `static/app.html` regenerated through `app-html-assembler`.

## Note
The parity test pins the SPA map against a hand-maintained list, so a twinned route row absent from both ships silently — that one-way pin is how #329's gap passed CI. Deriving the expected set from `ROUTES` tunnel columns (minus the documented residue) would close the class; left as a follow-up.