### PR TITLE
tests/skills: session-fork validation probes

### DIFF
--- a/tests/skills/session-fork-probes/SKILL.md
+++ b/tests/skills/session-fork-probes/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: session-fork-probes
+description: >
+  Validation probes for the fork-session-from-anchor feature: prove the
+  external-backend primitives the fork engines depend on still behave as
+  built. Spike 1 drives a vanilla codex app-server through
+  thread/fork{path} + thread/rollback{numTurns} + resume of the forked
+  child. Spike 2 proves Claude Code copied-transcript forking (chain-slice
+  surgery) and pins the resume-leaf semantics of the installed CC version.
+  Run when bumping the pinned codex/CC versions or when forked sessions
+  misbehave.
+compatibility: Requires vanilla codex on PATH with auth in ~/.codex, Claude Code on PATH with auth, and at least one existing codex rollout under ~/.codex/sessions. Costs a few haiku -p calls (pennies) plus zero-turn codex RPC.
+allowed-tools: Bash Read
+disable-model-invocation: false
+---
+
+# Session-fork validation probes
+
+The fork-from-anchor engines (`src/bin/caller/session_fork/`) rest on two
+externally-owned behaviors that no unit test can pin. These probes are the
+regression harness for them, first run 2026-07-16 against codex-cli 0.144.4
+and Claude Code 2.1.211 (both PASS).
+
+## Spike 1 — vanilla codex fork + rollback + resume
+
+```bash
+SRC=$(find ~/.codex/sessions -name 'rollout-*.jsonl' -mmin +60 -size -2000k \
+      -print0 | xargs -0 ls -t | head -1)
+python3 tests/skills/session-fork-probes/spike1_codex_fork.py "$SRC" 1
+```
+
+Proves, against the **vanilla** binary (no managed fork required):
+- `thread/fork {threadId:"", path:<staged copy>}` mints a new thread whose
+  metadata carries `forkedFromId` (the source rollout's session id — the
+  session catalog derives fork lineage from this for free).
+- `thread/rollback {numTurns}` is accepted on the fresh forked child
+  *before any turn*; the child rollout records an appended
+  `thread_rolled_back` event_msg (append-only, same convention the anchor
+  scanner already resolves).
+- The child resumes on a fresh app-server via `thread/resume {threadId}`.
+- The parent rollout is byte-identical afterwards (hash-checked); the
+  child materializes as a normal rollout under `~/.codex/sessions`.
+
+Known caveats observed on 0.144.4:
+- `thread/rollback` emits a **deprecation notice** ("will be removed
+  soon"). If a version bump removes it, the vanilla fork path needs the
+  successor API — this probe failing on rollback is the early warning.
+- `thread/read {includeTurns:true}` does not return a top-level `turns`
+  list; verify trim effects from the child rollout file instead.
+
+The probe prints the child thread id + rollout path it created; delete
+that rollout afterwards if you don't want the artifact in the session list.
+
+## Spike 2 — Claude Code chain-slice fork surgery
+
+```bash
+python3 tests/skills/session-fork-probes/spike2_cc_fork.py
+```
+
+Builds a scratch two-turn haiku session in /tmp/fork-spike-proj, then runs
+four copy-only fork probes (parent hash-verified untouched):
+
+| probe | construction | expected |
+|---|---|---|
+| A | prefix-truncated copy, sessionId rewritten, new uuid filename | knows only turn 1 |
+| B | full copy + legacy `last-prompt` pin at turn-1 tail | knows BOTH turns (pins-dead sentinel) |
+| C | synthetic `compact_boundary` spliced before turn 2 | knows only turn 2 |
+| D | chain-slice at the pre-boundary anchor from C's file | knows only turn 1 |
+
+What these pin (CC 2.1.211 semantics the surgery engine assumes):
+- Resume resolves a session by the `<uuid>.jsonl` **filename stem**; a
+  copied file with per-line `sessionId` rewritten resumes first-class.
+- **`last-prompt` leaf pins are dead** — resume walks the message chain
+  back from the tail. Fork-from-anchor therefore means **chain-slice**:
+  emit only the anchor's ancestor chain (plus uuid-less meta lines like
+  `ai-title`/`agent-name`), which makes the anchor the tail. If probe B
+  ever reports turn-1-only, CC honors pins again — revisit
+  `session_fork/claude_surgery.rs`.
+- A `compact_boundary` line with `parentUuid: null` severs the chain walk;
+  chain-slicing at a **pre-boundary** anchor simply never includes the
+  boundary, so pre-compaction anchors fork with no extra surgery and the
+  child is a normal session (auto-compaction intact). The old
+  `compact_boundary_disabled` trio is dead and unnecessary.
+
+The script exits non-zero on any unexpected verdict and prints the exact
+cleanup command for the scratch project dir.

--- a/tests/skills/session-fork-probes/spike1_codex_fork.py
+++ b/tests/skills/session-fork-probes/spike1_codex_fork.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Spike 1: prove vanilla codex app-server supports fork-from-rollout-path +
+pre-first-turn turn-count rollback + resume of the forked child.
+
+Sequence (mirrors Intendant's wire usage in external_agent/codex/):
+  1. copy a real rollout to a staging path (parent is never touched)
+  2. codex app-server:  initialize -> initialized
+  3. thread/fork {threadId:"", path:<staged copy>}          -> child thread id
+  4. thread/rollback {threadId:<child>, numTurns:<n>}       -> trim on fresh child
+  5. thread/read {threadId:<child>, includeTurns:true}      -> verify trimmed turn count
+  6. fresh app-server: thread/resume {threadId:<child>}     -> child is resumable
+  7. verify: parent rollout bytes unchanged; child rollout file exists
+
+Usage: spike1_codex_fork.py [source-rollout.jsonl] [numTurns]
+Exit 0 = all probes passed. Artifacts: prints the child thread id + rollout
+path it created under $CODEX_HOME/sessions (delete afterwards if unwanted).
+"""
+
+import hashlib
+import json
+import os
+import queue
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+TIMEOUT_SECS = 30
+
+
+def newest_small_rollout(codex_home: Path, cap_bytes: int = 2_000_000) -> Path:
+    candidates = sorted(
+        codex_home.glob("sessions/*/*/*/rollout-*.jsonl"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    for p in candidates:
+        if p.stat().st_size <= cap_bytes:
+            return p
+    raise SystemExit("no rollout under size cap found")
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+class AppServer:
+    def __init__(self):
+        self.proc = subprocess.Popen(
+            ["codex", "app-server"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.lines: "queue.Queue[dict]" = queue.Queue()
+        self.next_id = 0
+        threading.Thread(target=self._reader, daemon=True).start()
+        threading.Thread(target=self._stderr_reader, daemon=True).start()
+
+    def _reader(self):
+        for line in self.proc.stdout:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                print(f"  [stdout non-json] {line[:200]}")
+                continue
+            self.lines.put(msg)
+
+    def _stderr_reader(self):
+        for line in self.proc.stderr:
+            print(f"  [stderr] {line.rstrip()[:200]}")
+
+    def notify(self, method: str, params=None):
+        msg = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            msg["params"] = params
+        self.proc.stdin.write(json.dumps(msg) + "\n")
+        self.proc.stdin.flush()
+
+    def request(self, method: str, params=None) -> dict:
+        self.next_id += 1
+        rid = self.next_id
+        msg = {"jsonrpc": "2.0", "id": rid, "method": method}
+        if params is not None:
+            msg["params"] = params
+        print(f"-> {method} {json.dumps(params)[:200] if params else ''}")
+        self.proc.stdin.write(json.dumps(msg) + "\n")
+        self.proc.stdin.flush()
+        deadline = time.time() + TIMEOUT_SECS
+        while time.time() < deadline:
+            try:
+                got = self.lines.get(timeout=deadline - time.time())
+            except queue.Empty:
+                break
+            if got.get("id") == rid:
+                if "error" in got:
+                    raise RuntimeError(f"{method} error: {json.dumps(got['error'])[:400]}")
+                print(f"<- {method} ok: {json.dumps(got.get('result'))[:300]}")
+                return got.get("result") or {}
+            # server-initiated notification/request; log and keep waiting
+            print(f"  [event] {got.get('method', '?')} {json.dumps(got.get('params', {}))[:160]}")
+        raise RuntimeError(f"{method}: no response within {TIMEOUT_SECS}s")
+
+    def close(self):
+        try:
+            self.proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            self.proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+
+
+def initialize(srv: AppServer):
+    srv.request(
+        "initialize",
+        {
+            "clientInfo": {"name": "intendant-spike", "title": "Spike1", "version": "0"},
+            "capabilities": {"experimentalApi": True},
+        },
+    )
+    srv.notify("initialized")
+
+
+def thread_id_of(result: dict) -> str:
+    tid = (result.get("thread") or {}).get("id") or result.get("threadId")
+    if not tid:
+        raise RuntimeError(f"no thread id in: {json.dumps(result)[:300]}")
+    return tid
+
+
+def count_user_turns(rollout: Path) -> int:
+    n = 0
+    with open(rollout, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            try:
+                d = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if d.get("type") == "event_msg" and d.get("payload", {}).get("type") == "user_message":
+                n += 1
+    return n
+
+
+def main():
+    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    src = Path(sys.argv[1]) if len(sys.argv) > 1 else newest_small_rollout(codex_home)
+    num_turns = int(sys.argv[2]) if len(sys.argv) > 2 else 1
+    print(f"source rollout: {src} ({src.stat().st_size} bytes, ~{count_user_turns(src)} user turns)")
+    src_hash = sha256(src)
+
+    staging = Path(tempfile.mkdtemp(prefix="spike1-fork-")) / src.name
+    shutil.copy2(src, staging)
+    print(f"staged copy: {staging}")
+
+    pre_rollouts = set(codex_home.glob("sessions/*/*/*/rollout-*.jsonl"))
+
+    srv = AppServer()
+    try:
+        initialize(srv)
+        fork_res = srv.request("thread/fork", {"threadId": "", "path": str(staging)})
+        child = thread_id_of(fork_res)
+        print(f"CHILD THREAD: {child}")
+        srv.request("thread/rollback", {"threadId": child, "numTurns": num_turns})
+        read_res = srv.request("thread/read", {"threadId": child, "includeTurns": True})
+        turns = read_res.get("turns")
+        print(f"thread/read turns after rollback: {len(turns) if isinstance(turns, list) else turns!r}")
+    finally:
+        srv.close()
+
+    # resumability on a fresh server
+    srv2 = AppServer()
+    try:
+        initialize(srv2)
+        resume_res = srv2.request("thread/resume", {"threadId": child})
+        print(f"resume ok, thread id: {thread_id_of(resume_res)}")
+    finally:
+        srv2.close()
+
+    post_rollouts = set(codex_home.glob("sessions/*/*/*/rollout-*.jsonl"))
+    new_files = [p for p in post_rollouts - pre_rollouts]
+    print(f"new rollout files: {[str(p) for p in new_files]}")
+
+    assert sha256(src) == src_hash, "PARENT ROLLOUT MUTATED — spike FAILED"
+    print("parent rollout unchanged: OK")
+    child_files = [p for p in new_files if child.replace("-", "") in p.name.replace("-", "") or child in p.read_text(errors="replace")[:2000]]
+    print(f"child rollout: {[str(p) for p in child_files] or 'NOT FOUND (check manually)'}")
+    print("SPIKE 1 PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/skills/session-fork-probes/spike2_cc_fork.py
+++ b/tests/skills/session-fork-probes/spike2_cc_fork.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Spike 2: prove a Claude Code session can be forked from a mid-history
+anchor by copy-only file surgery, and pin the resume-leaf semantics of the
+installed CC version.
+
+Findings this probe encodes (first proven on CC 2.1.211, 2026-07-16):
+  - resume resolves the session purely by <uuid>.jsonl filename stem in the
+    project dir; a copied file with per-line sessionId rewritten to the new
+    uuid resumes as a first-class session.
+  - legacy `last-prompt` leaf pins are IGNORED (files no longer contain
+    them); resume walks the message chain back from the tail. Forking from
+    an arbitrary anchor therefore means CHAIN-SLICE: emit only the anchor's
+    ancestor chain (+ uuid-less meta lines), making the anchor the tail.
+  - a `compact_boundary` system line with parentUuid:null severs the chain
+    walk (pre-boundary history is not loaded).
+  - chain-slicing at a PRE-boundary anchor naturally omits the boundary, so
+    pre-compaction anchors fork with no extra surgery (the old
+    compact_boundary_disabled trio is dead and unnecessary).
+
+Probes (scratch 2-turn session, codewords BLUEFIN then MARIGOLD):
+  A. truncation fork  -> expect BLUEFIN only          (core mechanism)
+  B. full copy + legacy pin -> expect BOTH            (pins-dead sentinel:
+     if this ever reports BLUEFIN-only, CC honors pins again — revisit
+     session_fork/claude_surgery.rs assumptions)
+  C. synthetic boundary before turn 2 -> expect MARIGOLD only (gating)
+  D. chain-slice at pre-boundary anchor on C's file -> expect BLUEFIN only
+     (the production fork mechanism, across a boundary)
+
+Every fork is a NEW file; the parent is hash-verified untouched.
+Cost: ~6 haiku -p calls. Cleanup of the scratch project dir is printed.
+"""
+
+import hashlib
+import json
+import subprocess
+import uuid as uuidlib
+from datetime import datetime, timezone
+from pathlib import Path
+
+MODEL = "claude-haiku-4-5-20251001"
+SCRATCH = Path("/tmp/fork-spike-proj")
+CLAUDE_PROJECTS = Path.home() / ".claude" / "projects"
+
+
+def sha256(p: Path) -> str:
+    return hashlib.sha256(p.read_bytes()).hexdigest()
+
+
+def run_claude(prompt: str, resume: str | None = None) -> dict:
+    cmd = ["claude", "-p", prompt, "--model", MODEL, "--output-format", "json"]
+    if resume:
+        cmd += ["--resume", resume]
+    print(f"$ claude -p {'--resume ' + resume + ' ' if resume else ''}{prompt[:60]!r}")
+    r = subprocess.run(cmd, cwd=SCRATCH, capture_output=True, text=True, timeout=240)
+    if r.returncode != 0:
+        print(f"  FAILED rc={r.returncode} stderr={r.stderr[:400]}")
+        return {"__failed": True, "stderr": r.stderr}
+    out = json.loads(r.stdout)
+    print(f"  session={out.get('session_id')} result={str(out.get('result'))[:120]!r}")
+    return out
+
+
+def find_transcript(session_id: str) -> Path:
+    hits = list(CLAUDE_PROJECTS.glob(f"*/{session_id}.jsonl"))
+    if not hits:
+        raise SystemExit(f"transcript for {session_id} not found")
+    return hits[0]
+
+
+def lines_of(p: Path) -> list[dict]:
+    return [json.loads(l) for l in p.read_text().splitlines() if l.strip()]
+
+
+def write_fork(lines: list[dict], dest: Path, new_id: str):
+    with open(dest, "w") as f:
+        for line in lines:
+            d = dict(line)
+            if "sessionId" in d:
+                d["sessionId"] = new_id
+            f.write(json.dumps(d) + "\n")
+
+
+def chain_slice(lines: list[dict], anchor_uuid: str) -> list[dict]:
+    """Ancestor chain of the anchor + uuid-less meta lines, original order."""
+    by_uuid = {l["uuid"]: l for l in lines if l.get("uuid")}
+    chain: set[str] = set()
+    cur = anchor_uuid
+    while cur and cur in by_uuid:
+        chain.add(cur)
+        cur = by_uuid[cur].get("parentUuid")
+    return [l for l in lines if not l.get("uuid") or l["uuid"] in chain]
+
+
+def probe(name: str, new_id: str, expect_bluefin: bool, expect_marigold: bool) -> tuple[bool, str]:
+    out = run_claude("Which codewords do you know? Answer with just the codewords.", resume=new_id)
+    if out.get("__failed"):
+        return False, f"{name}: RESUME FAILED ({out['stderr'][:160]})"
+    text = str(out.get("result", "")).upper()
+    has_b, has_m = "BLUEFIN" in text, "MARIGOLD" in text
+    ok = has_b == expect_bluefin and has_m == expect_marigold
+    return ok, (
+        f"{name}: {'PASS' if ok else 'UNEXPECTED'} "
+        f"(bluefin={has_b} want {expect_bluefin}, marigold={has_m} want {expect_marigold})"
+    )
+
+
+def main():
+    SCRATCH.mkdir(exist_ok=True)
+    results: list[tuple[bool, str]] = []
+
+    t1 = run_claude("Remember this codeword: BLUEFIN. Reply with exactly: OK")
+    sid = t1["session_id"]
+    run_claude("Remember a second codeword: MARIGOLD. Reply with exactly: OK", resume=sid)
+    parent = find_transcript(sid)
+    parent_hash = sha256(parent)
+    lines = lines_of(parent)
+    print(f"parent transcript: {parent} ({len(lines)} lines)")
+
+    marigold_idx = next(
+        i for i, l in enumerate(lines)
+        if l.get("type") == "user" and "MARIGOLD" in json.dumps(l.get("message", {}))
+    )
+    anchor_uuid = lines[marigold_idx].get("parentUuid")
+    anchor_idx = next(i for i, l in enumerate(lines) if l.get("uuid") == anchor_uuid)
+    proj_dir = parent.parent
+    fork_ids: list[str] = []
+
+    # A: truncation fork at the turn-1 tail
+    a_id = str(uuidlib.uuid4())
+    fork_ids.append(a_id)
+    write_fork(lines[: anchor_idx + 1], proj_dir / f"{a_id}.jsonl", a_id)
+    results.append(probe("A truncation", a_id, expect_bluefin=True, expect_marigold=False))
+
+    # B: full copy + legacy last-prompt pin (pins-dead sentinel)
+    b_id = str(uuidlib.uuid4())
+    fork_ids.append(b_id)
+    pin = {
+        "type": "system", "subtype": "last-prompt",
+        "uuid": str(uuidlib.uuid4()), "parentUuid": None, "isSidechain": False,
+        "sessionId": b_id,
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+        "leafUuid": anchor_uuid,
+    }
+    write_fork(lines + [pin], proj_dir / f"{b_id}.jsonl", b_id)
+    results.append(probe("B pins-dead sentinel", b_id, expect_bluefin=True, expect_marigold=True))
+
+    # C: synthetic compact_boundary spliced before turn 2 (chain re-parented)
+    c_id = str(uuidlib.uuid4())
+    fork_ids.append(c_id)
+    boundary = {
+        "parentUuid": None, "logicalParentUuid": anchor_uuid, "isSidechain": False,
+        "type": "system", "subtype": "compact_boundary",
+        "content": "Conversation compacted", "level": "info",
+        "uuid": str(uuidlib.uuid4()),
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+        "sessionId": c_id,
+        "compactMetadata": {"trigger": "auto", "preTokens": 1000, "postTokens": 100},
+    }
+    c_lines = []
+    for l in lines[: anchor_idx + 1]:
+        c_lines.append(l)
+    c_lines.append(boundary)
+    for l in lines[anchor_idx + 1 :]:
+        if l.get("uuid") == lines[marigold_idx]["uuid"]:
+            l = dict(l)
+            l["parentUuid"] = boundary["uuid"]
+        c_lines.append(l)
+    write_fork(c_lines, proj_dir / f"{c_id}.jsonl", c_id)
+    results.append(probe("C boundary-gates", c_id, expect_bluefin=False, expect_marigold=True))
+
+    # D: chain-slice fork at the pre-boundary anchor, from C's file
+    d_id = str(uuidlib.uuid4())
+    fork_ids.append(d_id)
+    write_fork(chain_slice(c_lines, anchor_uuid), proj_dir / f"{d_id}.jsonl", d_id)
+    results.append(probe("D chain-slice pre-boundary", d_id, expect_bluefin=True, expect_marigold=False))
+
+    print("\n=== VERDICTS ===")
+    for _, v in results:
+        print(" ", v)
+    assert sha256(parent) == parent_hash, "PARENT TRANSCRIPT MUTATED — FAILED"
+    print("parent transcript unchanged: OK")
+    print(f"cleanup: rm -rf {proj_dir} {SCRATCH}")
+    if not all(ok for ok, _ in results):
+        raise SystemExit(1)
+    print("SPIKE 2 PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Validation probes for the upcoming fork-session-from-anchor feature (phase 0 of the program).

**Spike 1 — vanilla codex**: drives `codex app-server` through `thread/fork{path}` on a staged rollout copy, `thread/rollback{numTurns}` on the fresh child, and `thread/resume` of the child on a fresh server. PASSED on codex-cli 0.144.4: fork works on the vanilla binary, the fork response carries `forkedFromId`, the child rollout materializes normally, and the parent rollout is hash-verified untouched. Records the 0.144.4 `thread/rollback` deprecation notice as the early-warning tripwire.

**Spike 2 — Claude Code**: builds a scratch two-turn haiku session and runs four copy-only fork probes (truncation, pins-dead sentinel, synthetic compact boundary, chain-slice across the boundary). PASSED on CC 2.1.211, pinning the semantics the surgery engine will assume: resume resolves by filename stem; `last-prompt` pins are dead (resume walks the chain from the tail, so fork = chain-slice); a `compact_boundary` severs the chain walk; pre-boundary chain-slices omit the boundary entirely.

Docs-and-scripts only — no product code. Both probes are operator-battery skills (real backends, not CI).