### PR TITLE
gateway: unified fork-point catalog (PR A of fork-from-anchor)

### DIFF
--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -1621,6 +1621,7 @@ shell only.
 | POST | `/api/session/{id}/delete` | SessionManage | own origin | none | Delete a session's data (POST fallback for WKWebView) |
 | POST | `/api/session/{id}/{target}/delete` | SessionManage | own origin | none | Delete one data kind for a session (POST fallback) |
 | POST | `/api/session/{id}/agent-output` | SessionInspect | own origin | bounded | Fetch a session's persisted agent output by id (POST-shaped read) |
+| GET | `/api/session/{id}/fork-points` | SessionInspect | own origin | none | Unified fork-point catalog for a session (anchors + eligibility, backend-tagged) |
 | GET | `/api/session/current[/…]` | SessionManage | own origin | none | Current-session detail and artifact sub-routes |
 | POST | `/api/session/current[/…]` | SessionManage | own origin | none | Current-session detail sub-routes (POST fallback callers) |
 | GET | `/api/session/{id}/context-snapshot` | SessionInspect | own origin | none | Replay one archived context snapshot (file/request_id/request_index/ts selector) |

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -957,6 +957,65 @@ pub(crate) async fn api_worktrees_merge_response(
     }
 }
 
+pub(crate) async fn api_session_fork_points_response(
+    id: String,
+    params: Option<&serde_json::Value>,
+) -> serde_json::Value {
+    // Transport edge: resolve the real home once; tests drive the
+    // `_from_home` variant with an injected temp home.
+    api_session_fork_points_response_from_home(id, params, &crate::platform::home_dir()).await
+}
+
+pub(crate) async fn api_session_fork_points_response_from_home(
+    id: String,
+    params: Option<&serde_json::Value>,
+    home: &std::path::Path,
+) -> serde_json::Value {
+    let params = params.cloned().unwrap_or_else(|| serde_json::json!({}));
+    let Some(session_id) = params
+        .get("session_id")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return missing_param_response(id, "session_id");
+    };
+    // The synthesized request line reuses the HTTP builder verbatim, so a
+    // session id that cannot form a single path segment is refused here.
+    if session_id.contains(['/', '?', '#', ' ']) {
+        return missing_param_response(id, "session_id");
+    }
+    let mut query = String::new();
+    for key in ["include_non_recovery", "offset", "limit"] {
+        if let Some(value) = params.get(key) {
+            let value = match value {
+                serde_json::Value::String(value) => value.clone(),
+                other => other.to_string(),
+            };
+            query.push(if query.is_empty() { '?' } else { '&' });
+            query.push_str(&format!("{key}={value}"));
+        }
+    }
+    let request_line = format!("GET /api/session/{session_id}/fork-points{query} HTTP/1.1");
+    let home = home.to_path_buf();
+    let response = tokio::task::spawn_blocking(move || {
+        crate::web_gateway::session_fork_points_response(&request_line, &home)
+    })
+    .await;
+    let response = match response {
+        Ok(response) => response,
+        Err(e) => {
+            return serde_json::json!({
+                "t": "response",
+                "id": id,
+                "ok": false,
+                "error": format!("fork-points task failed: {e}"),
+            });
+        }
+    };
+    frame_api_response(id, response, "session fork points")
+}
+
 pub(crate) async fn api_managed_context_response(
     id: String,
     kind: &'static str,

--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -354,6 +354,7 @@ pub(crate) async fn control_request_frame(
         }
         "api_worktrees_clean" => api_worktrees_clean_response(id, params.as_ref(), &runtime).await,
         "api_worktrees_merge" => api_worktrees_merge_response(id, params.as_ref(), &runtime).await,
+        "api_session_fork_points" => api_session_fork_points_response(id, params.as_ref()).await,
         "api_managed_context_records" => {
             api_managed_context_response(id, "records", params.as_ref(), &runtime).await
         }

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -5355,6 +5355,7 @@ mod tests {
             ("api_sessions", Row, Some(Op::SessionInspect)),
             ("api_sessions_stream", Row, Some(Op::SessionInspect)),
             ("api_session_detail", Row, Some(Op::SessionInspect)),
+            ("api_session_fork_points", Row, Some(Op::SessionInspect)),
             ("api_session_report", Row, Some(Op::SessionInspect)),
             ("api_session_agent_output", Row, Some(Op::SessionInspect)),
             (

--- a/src/bin/caller/gateway_routes.rs
+++ b/src/bin/caller/gateway_routes.rs
@@ -236,6 +236,7 @@ pub(crate) enum RouteHandlerId {
     /// leaves is a follow-up behavior decision, not part of the
     /// mechanical migration.
     SessionSubRouter,
+    SessionForkPoints,
     McAnchors,
     McRecords,
     McFission,
@@ -964,6 +965,24 @@ pub(crate) static ROUTES: &[Route] = &[
         "Fetch a session's persisted agent output by id (POST-shaped read)",
     )
     .with_tunnel(tunnel_method("api_session_agent_output")),
+    // Declared ahead of the sub-router group: the `{id}/fork-points` leaf
+    // must win before the group's `Under("/api/session")` catch-all, and
+    // shared-handler groups must stay contiguous.
+    op_route(
+        RouteMethod::Get,
+        PathPattern::Segments(
+            "/api/session",
+            &[
+                SegmentSpec::Capture("id"),
+                SegmentSpec::Literal("fork-points"),
+            ],
+        ),
+        PeerOperation::SessionInspect,
+        BodyPolicy::None,
+        RouteHandlerId::SessionForkPoints,
+        "Unified fork-point catalog for a session (anchors + eligibility, backend-tagged)",
+    )
+    .with_tunnel(tunnel_method("api_session_fork_points")),
     // ── Session detail + artifacts sub-router. Method-explicit ports of
     //    the method-blind legacy catch-all: the classifier's historical
     //    split (current/* manage-gated on every method; {id} inspect on

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -68,6 +68,7 @@ mod sandbox;
 mod schema_validator;
 mod service_mode;
 mod session_config;
+mod session_fork;
 mod session_identity;
 mod session_log;
 mod session_names;

--- a/src/bin/caller/managed_context_ops/anchors.rs
+++ b/src/bin/caller/managed_context_ops/anchors.rs
@@ -7,9 +7,9 @@ use super::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RolloutUserTurn {
-    index: u32,
-    line: usize,
-    text: String,
+    pub(crate) index: u32,
+    pub(crate) line: usize,
+    pub(crate) text: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/bin/caller/session_fork/fork_points.rs
+++ b/src/bin/caller/session_fork/fork_points.rs
@@ -1,0 +1,515 @@
+//! Fork-point catalog builders for the codex and native backends.
+//!
+//! Codex derives from the same rollout scan the managed-context rewind
+//! machinery uses (`shared_context_rewind_anchor_scan` — cached, racy-write
+//! quiescent) joined with the effective user-turn list; native derives from
+//! the persisted `conversation.jsonl` without loading a full
+//! `Conversation`. Both are read-only over the parent artifacts.
+
+use super::*;
+use crate::managed_context_ops::{
+    rollout_user_turns, shared_context_rewind_anchor_scan, ContextRewindAnchorCatalogEntry,
+    RolloutUserTurn,
+};
+use std::io;
+use std::path::Path;
+
+/// Fork points for a codex session, derived from its rollout file.
+pub(crate) fn codex_fork_points(
+    session_id: &str,
+    backend_session_id: &str,
+    rollout_path: &Path,
+    query: &ForkPointQuery,
+) -> io::Result<ForkPointCatalog> {
+    let scan = shared_context_rewind_anchor_scan(rollout_path)?;
+    let turns = rollout_user_turns(rollout_path)?;
+    Ok(codex_fork_points_from_parts(
+        session_id,
+        backend_session_id,
+        &scan.catalog,
+        &turns,
+        query,
+    ))
+}
+
+/// Pure assembly over an anchor catalog + effective user-turn list
+/// (unit-tested without a rollout file).
+pub(crate) fn codex_fork_points_from_parts(
+    session_id: &str,
+    backend_session_id: &str,
+    anchors: &[ContextRewindAnchorCatalogEntry],
+    turns: &[RolloutUserTurn],
+    query: &ForkPointQuery,
+) -> ForkPointCatalog {
+    // Sort key: file position, descending (newest history first). A
+    // turn boundary "after turn i" lives where turn i+1 begins (the last
+    // boundary sorts above everything).
+    let mut keyed: Vec<(usize, ForkPoint)> = Vec::new();
+
+    for (i, turn) in turns.iter().enumerate() {
+        let ordinal = turn.index;
+        let sort_key = turns
+            .get(i + 1)
+            .map(|next| next.line.saturating_sub(1))
+            .unwrap_or(usize::MAX);
+        keyed.push((
+            sort_key,
+            ForkPoint {
+                id: format!("turn:{ordinal}"),
+                kind: "turn-boundary",
+                granularity: "turn",
+                turn: Some(ordinal),
+                seq: None,
+                item_id: None,
+                position: None,
+                preview: fork_point_preview(&turn.text),
+                eligible: true,
+                eligibility_reasons: Vec::new(),
+                effective_cut: None,
+            },
+        ));
+    }
+
+    for entry in anchors {
+        let recovery_eligible = entry.recovery_eligible;
+        if recovery_eligible == Some(false) && !query.include_non_recovery {
+            continue;
+        }
+        // The whole turn the anchor's first line falls inside; a vanilla
+        // fork rounds down to the boundary before that turn.
+        let containing_turn = turns
+            .iter()
+            .take_while(|turn| turn.line <= entry.first_line)
+            .last()
+            .map(|turn| turn.index)
+            .unwrap_or(0);
+        let eligible = recovery_eligible.unwrap_or(true);
+        let mut reasons = Vec::new();
+        if recovery_eligible == Some(false) {
+            reasons.push(
+                "not recovery-eligible for in-place rewind (forking is still possible)".to_string(),
+            );
+        }
+        keyed.push((
+            entry.first_line,
+            ForkPoint {
+                id: format!("item:{}:{}", entry.item_id, entry.position_hint),
+                kind: "item-anchor",
+                granularity: "item",
+                turn: Some(containing_turn),
+                seq: None,
+                item_id: Some(entry.item_id.clone()),
+                position: Some(entry.position_hint),
+                preview: fork_point_preview(&entry.summary),
+                eligible,
+                eligibility_reasons: reasons,
+                effective_cut: Some(format!("turn:{}", containing_turn.saturating_sub(1))),
+            },
+        ));
+    }
+
+    // Descending file order; boundaries above item anchors at the same
+    // position (the coarser, always-available choice lists first).
+    keyed.sort_by(|a, b| {
+        b.0.cmp(&a.0).then_with(|| {
+            let rank = |p: &ForkPoint| usize::from(p.kind != "turn-boundary");
+            rank(&a.1).cmp(&rank(&b.1))
+        })
+    });
+    let points: Vec<ForkPoint> = keyed.into_iter().map(|(_, point)| point).collect();
+
+    let mut catalog = ForkPointCatalog {
+        session_id: session_id.to_string(),
+        source: "codex".to_string(),
+        backend_session_id: Some(backend_session_id.to_string()),
+        supported: true,
+        unsupported_reason: None,
+        notes: vec![
+            "item anchors cut exactly on the managed codex binary; on the vanilla binary a fork rounds down to the annotated effective_cut turn boundary".to_string(),
+            "turn-boundary points fork on any binary".to_string(),
+        ],
+        total: 0,
+        offset: 0,
+        limit: 0,
+        next_offset: None,
+        fork_points: Vec::new(),
+    };
+    page_fork_points(&mut catalog, points, query);
+    catalog
+}
+
+/// Fork points for a native (intendant) session, derived from the
+/// persisted `conversation.jsonl` in its log dir.
+pub(crate) fn native_fork_points(
+    session_id: &str,
+    log_dir: &Path,
+    query: &ForkPointQuery,
+) -> io::Result<ForkPointCatalog> {
+    let conversation_path = log_dir.join("conversation.jsonl");
+    let mut catalog = ForkPointCatalog {
+        session_id: session_id.to_string(),
+        source: "intendant".to_string(),
+        backend_session_id: None,
+        supported: true,
+        unsupported_reason: None,
+        notes: vec![
+            "round boundaries of the last persisted conversation state; a live session's unsaved tail is not reflected".to_string(),
+        ],
+        total: 0,
+        offset: 0,
+        limit: 0,
+        next_offset: None,
+        fork_points: Vec::new(),
+    };
+    if !conversation_path.exists() {
+        catalog.supported = false;
+        catalog.unsupported_reason =
+            Some("no persisted conversation.jsonl in this session's log dir".to_string());
+        return Ok(catalog);
+    }
+
+    // Minimal per-line view; the full Message struct is not needed here.
+    struct Line {
+        role: String,
+        seq: u64,
+        preview: String,
+    }
+    let raw = std::fs::read_to_string(&conversation_path)?;
+    let mut lines: Vec<Line> = Vec::new();
+    for line in raw.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        lines.push(Line {
+            role: value
+                .get("role")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+            seq: value
+                .get("seq")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0),
+            preview: fork_point_preview(
+                value
+                    .get("content")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or(""),
+            ),
+        });
+    }
+
+    let user_ordinals: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter(|(_, line)| line.role == "user")
+        .map(|(i, _)| i)
+        .collect();
+    let round_count = user_ordinals.len() as u32;
+    let mut points: Vec<ForkPoint> = Vec::new();
+
+    if let Some(last) = lines.last() {
+        let eligible = last.seq > 0;
+        points.push(ForkPoint {
+            id: "head".to_string(),
+            kind: "head",
+            granularity: "round",
+            turn: Some(round_count),
+            seq: Some(last.seq),
+            item_id: None,
+            position: None,
+            preview: format!("{}: {}", last.role, last.preview),
+            eligible,
+            eligibility_reasons: if eligible {
+                Vec::new()
+            } else {
+                vec!["legacy message without a seq ordinal".to_string()]
+            },
+            effective_cut: None,
+        });
+    }
+
+    // "Before round r" = keep everything up to the message preceding the
+    // r-th user message; latest divergence first. Round 1 is skipped (a
+    // fork keeping nothing has no value).
+    for (round, &msg_index) in user_ordinals.iter().enumerate().skip(1).rev() {
+        let round = round as u32 + 1;
+        let prev = &lines[msg_index - 1];
+        let eligible = prev.seq > 0;
+        points.push(ForkPoint {
+            id: format!("seq:{}", prev.seq),
+            kind: "round",
+            granularity: "round",
+            turn: Some(round - 1),
+            seq: Some(prev.seq),
+            item_id: None,
+            position: None,
+            preview: lines[msg_index].preview.clone(),
+            eligible,
+            eligibility_reasons: if eligible {
+                Vec::new()
+            } else {
+                vec!["legacy message without a seq ordinal".to_string()]
+            },
+            effective_cut: None,
+        });
+    }
+
+    page_fork_points(&mut catalog, points, query);
+    Ok(catalog)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_anchor_entry(
+        item_id: &str,
+        first_line: usize,
+        recovery_eligible: Option<bool>,
+    ) -> ContextRewindAnchorCatalogEntry {
+        ContextRewindAnchorCatalogEntry {
+            ordinal: 0,
+            item_id: item_id.to_string(),
+            first_line,
+            last_line: first_line,
+            first_item_type: "function_call".to_string(),
+            last_item_type: "function_call_output".to_string(),
+            last_item_is_model: false,
+            positions: vec!["after"],
+            position_hint: "after",
+            names: Vec::new(),
+            roles: Vec::new(),
+            summary: format!("tool call {item_id}"),
+            backend_usage_at_or_after_anchor: None,
+            backend_usage_before_anchor: None,
+            rewind_only_limit_at_or_after_anchor: None,
+            recommended_rewind_limit_at_or_after_anchor: None,
+            prefix_estimated_tokens_before_anchor: None,
+            prefix_estimated_tokens_after_anchor: None,
+            approx_pruned_tokens_before: None,
+            approx_pruned_tokens_after: None,
+            prefix_tokens_after: None,
+            latest_rewind_usage_after_anchor: None,
+            latest_rewind_limit_after_anchor: None,
+            recovery_eligible,
+            recovery_eligible_positions: None,
+            density_eligible: None,
+            density_eligible_positions: None,
+            managed_context_recovery_start_line: None,
+        }
+    }
+
+    fn test_turns(lines: &[(u32, usize, &str)]) -> Vec<RolloutUserTurn> {
+        lines
+            .iter()
+            .map(|(index, line, text)| RolloutUserTurn {
+                index: *index,
+                line: *line,
+                text: (*text).to_string(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn preview_collapses_whitespace_and_caps() {
+        assert_eq!(fork_point_preview("  a\n\n  b\tc "), "a b c");
+        let long = "x".repeat(400);
+        assert!(fork_point_preview(&long).len() <= 150);
+    }
+
+    #[test]
+    fn codex_points_merge_boundaries_and_anchors_newest_first() {
+        let turns = test_turns(&[(1, 2, "first task"), (2, 10, "second task")]);
+        let anchors = vec![
+            test_anchor_entry("item_a", 12, Some(true)),
+            test_anchor_entry("item_b", 5, Some(false)),
+        ];
+        let catalog = codex_fork_points_from_parts(
+            "wrapper",
+            "backend-id",
+            &anchors,
+            &turns,
+            &ForkPointQuery::default(),
+        );
+        assert!(catalog.supported);
+        let ids: Vec<&str> = catalog
+            .fork_points
+            .iter()
+            .map(|point| point.id.as_str())
+            .collect();
+        // item_b is recovery-ineligible and hidden by default.
+        assert_eq!(ids, vec!["turn:2", "item:item_a:after", "turn:1"]);
+        let anchor = &catalog.fork_points[1];
+        assert_eq!(anchor.turn, Some(2));
+        assert_eq!(anchor.effective_cut.as_deref(), Some("turn:1"));
+        assert!(anchor.eligible);
+    }
+
+    #[test]
+    fn codex_include_non_recovery_lists_ineligible_anchors() {
+        let turns = test_turns(&[(1, 2, "task")]);
+        let anchors = vec![test_anchor_entry("item_b", 5, Some(false))];
+        let query = ForkPointQuery {
+            include_non_recovery: true,
+            ..ForkPointQuery::default()
+        };
+        let catalog =
+            codex_fork_points_from_parts("wrapper", "backend-id", &anchors, &turns, &query);
+        let anchor = catalog
+            .fork_points
+            .iter()
+            .find(|point| point.kind == "item-anchor")
+            .expect("anchor listed");
+        assert!(!anchor.eligible);
+        assert!(!anchor.eligibility_reasons.is_empty());
+    }
+
+    #[test]
+    fn codex_anchor_before_first_turn_rounds_to_empty() {
+        let turns = test_turns(&[(1, 10, "task")]);
+        let anchors = vec![test_anchor_entry("item_pre", 3, Some(true))];
+        let catalog = codex_fork_points_from_parts(
+            "wrapper",
+            "backend-id",
+            &anchors,
+            &turns,
+            &ForkPointQuery::default(),
+        );
+        let anchor = catalog
+            .fork_points
+            .iter()
+            .find(|point| point.kind == "item-anchor")
+            .expect("anchor listed");
+        assert_eq!(anchor.turn, Some(0));
+        assert_eq!(anchor.effective_cut.as_deref(), Some("turn:0"));
+    }
+
+    #[test]
+    fn codex_end_to_end_over_real_rollout_lines() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rollout = dir.path().join("rollout-test.jsonl");
+        let lines = [
+            serde_json::json!({"timestamp":"t","type":"session_meta","payload":{"id":"0000","cwd":"/tmp"}}),
+            serde_json::json!({"timestamp":"t","type":"event_msg","payload":{"type":"user_message","message":"first task"}}),
+            serde_json::json!({"timestamp":"t","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}),
+            serde_json::json!({"timestamp":"t","type":"event_msg","payload":{"type":"user_message","message":"second task"}}),
+        ];
+        let body: String = lines.iter().map(|line| format!("{line}\n")).collect();
+        std::fs::write(&rollout, body).expect("write rollout");
+
+        let catalog = codex_fork_points(
+            "wrapper",
+            "backend-id",
+            &rollout,
+            &ForkPointQuery::default(),
+        )
+        .expect("catalog");
+        let boundary_turns: Vec<u32> = catalog
+            .fork_points
+            .iter()
+            .filter(|point| point.kind == "turn-boundary")
+            .filter_map(|point| point.turn)
+            .collect();
+        assert_eq!(boundary_turns, vec![2, 1]);
+    }
+
+    fn write_native_conversation(dir: &Path, messages: &[(&str, u64, &str)]) {
+        let body: String = messages
+            .iter()
+            .map(|(role, seq, content)| {
+                format!(
+                    "{}\n",
+                    serde_json::json!({"role": role, "content": content, "seq": seq})
+                )
+            })
+            .collect();
+        std::fs::write(dir.join("conversation.jsonl"), body).expect("write conversation");
+    }
+
+    #[test]
+    fn native_points_are_round_boundaries_newest_first() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_native_conversation(
+            dir.path(),
+            &[
+                ("user", 1, "round one"),
+                ("assistant", 2, "answer one"),
+                ("user", 3, "round two"),
+                ("assistant", 4, "answer two"),
+                ("user", 5, "round three"),
+            ],
+        );
+        let catalog = native_fork_points("native-id", dir.path(), &ForkPointQuery::default())
+            .expect("catalog");
+        assert!(catalog.supported);
+        let ids: Vec<&str> = catalog
+            .fork_points
+            .iter()
+            .map(|point| point.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["head", "seq:4", "seq:2"]);
+        assert_eq!(catalog.fork_points[0].turn, Some(3));
+        assert_eq!(catalog.fork_points[1].preview, "round three");
+        assert_eq!(catalog.fork_points[2].turn, Some(1));
+        assert!(catalog.fork_points.iter().all(|point| point.eligible));
+    }
+
+    #[test]
+    fn native_legacy_zero_seq_is_ineligible() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_native_conversation(
+            dir.path(),
+            &[
+                ("user", 0, "legacy round"),
+                ("assistant", 0, "legacy answer"),
+                ("user", 7, "new round"),
+            ],
+        );
+        let catalog = native_fork_points("native-id", dir.path(), &ForkPointQuery::default())
+            .expect("catalog");
+        let before_round_two = catalog
+            .fork_points
+            .iter()
+            .find(|point| point.kind == "round")
+            .expect("round point");
+        assert!(!before_round_two.eligible);
+        assert!(!before_round_two.eligibility_reasons.is_empty());
+    }
+
+    #[test]
+    fn native_missing_conversation_reports_unsupported() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let catalog = native_fork_points("native-id", dir.path(), &ForkPointQuery::default())
+            .expect("catalog");
+        assert!(!catalog.supported);
+        assert!(catalog.unsupported_reason.is_some());
+    }
+
+    #[test]
+    fn paging_windows_and_reports_next_offset() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_native_conversation(
+            dir.path(),
+            &[
+                ("user", 1, "r1"),
+                ("user", 2, "r2"),
+                ("user", 3, "r3"),
+                ("user", 4, "r4"),
+            ],
+        );
+        let query = ForkPointQuery {
+            include_non_recovery: false,
+            offset: 1,
+            limit: 2,
+        };
+        let catalog = native_fork_points("native-id", dir.path(), &query).expect("catalog");
+        assert_eq!(catalog.total, 4);
+        assert_eq!(catalog.fork_points.len(), 2);
+        assert_eq!(catalog.next_offset, Some(3));
+    }
+}

--- a/src/bin/caller/session_fork/mod.rs
+++ b/src/bin/caller/session_fork/mod.rs
@@ -1,0 +1,167 @@
+//! Fork-a-session-from-an-anchor: the unified fork-point catalog.
+//!
+//! A **fork point** is a place in a session's history where a new session
+//! can be forked off ("resume from any branch, from any anchor"). Fork
+//! points are always derived from the backend's own canonical transcript —
+//! the Codex rollout JSONL, the Claude Code project transcript, the native
+//! `conversation.jsonl` — never from Intendant's diagnostic mirror, matching
+//! every existing rewind/fork path. Deriving is read-only; the fork engines
+//! (later phases) only ever *copy* parent artifacts.
+//!
+//! Backend vocabulary mapping:
+//! - **codex**: managed-context rewind anchors (item ids from the rollout
+//!   scan, `managed_context_ops::anchors`) plus whole-turn boundaries. On a
+//!   vanilla binary a fork lands on turn boundaries (`thread/fork{path}` +
+//!   `thread/rollback{numTurns}`), so item anchors are annotated with the
+//!   turn boundary they round down to; the managed fork binary keeps exact
+//!   item-anchor cuts.
+//! - **intendant** (native): round boundaries of the persisted
+//!   `conversation.jsonl`, keyed by the `seq` of the last kept message.
+//! - **claude-code**: message-boundary anchors on the transcript's uuid
+//!   chain, including inactive sibling branch tips (a follow-up phase; the
+//!   catalog reports `supported: false` until the tree parser lands).
+
+mod fork_points;
+pub(crate) use fork_points::*;
+
+use serde::Serialize;
+
+/// One place a fork can cut at, backend-tagged via `kind`/`granularity`.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ForkPoint {
+    /// Stable list identity for the UI (`turn:3`, `item:<id>:after`,
+    /// `seq:42`, `head`).
+    pub(crate) id: String,
+    /// `turn-boundary` | `item-anchor` | `round` | `head` (`message` /
+    /// `branch-tip` once the Claude Code arm lands).
+    pub(crate) kind: &'static str,
+    /// The precision a fork at this point actually gets: `turn`, `item`,
+    /// or `round`.
+    pub(crate) granularity: &'static str,
+    /// 1-based user-turn / round ordinal this point relates to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) turn: Option<u32>,
+    /// Native only: `seq` of the last message the fork keeps.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) seq: Option<u64>,
+    /// Codex only: the rollout item id of the anchor.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) item_id: Option<String>,
+    /// Codex only: cut position relative to the item (`before`/`after`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) position: Option<&'static str>,
+    pub(crate) preview: String,
+    pub(crate) eligible: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) eligibility_reasons: Vec<String>,
+    /// Where the cut actually lands when the requested point is more
+    /// precise than the backend supports (vanilla codex item anchors).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) effective_cut: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ForkPointCatalog {
+    pub(crate) session_id: String,
+    /// `intendant` | `codex` | `claude-code` | `gemini`.
+    pub(crate) source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) backend_session_id: Option<String>,
+    pub(crate) supported: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) unsupported_reason: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) notes: Vec<String>,
+    /// Total fork points before paging.
+    pub(crate) total: usize,
+    pub(crate) offset: usize,
+    pub(crate) limit: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) next_offset: Option<usize>,
+    pub(crate) fork_points: Vec<ForkPoint>,
+}
+
+impl ForkPointCatalog {
+    pub(crate) fn unsupported(
+        session_id: &str,
+        source: &str,
+        backend_session_id: Option<&str>,
+        reason: &str,
+    ) -> Self {
+        Self {
+            session_id: session_id.to_string(),
+            source: source.to_string(),
+            backend_session_id: backend_session_id.map(str::to_string),
+            supported: false,
+            unsupported_reason: Some(reason.to_string()),
+            notes: Vec::new(),
+            total: 0,
+            offset: 0,
+            limit: 0,
+            next_offset: None,
+            fork_points: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ForkPointQuery {
+    /// Also list codex item anchors the managed rewind eligibility filter
+    /// would hide (headroom-ineligible ones). Fork itself needs no
+    /// headroom; this mirrors the managed catalog's diagnostic escape
+    /// hatch so the default list stays focused.
+    pub(crate) include_non_recovery: bool,
+    pub(crate) offset: usize,
+    pub(crate) limit: usize,
+}
+
+pub(crate) const FORK_POINT_DEFAULT_LIMIT: usize = 200;
+pub(crate) const FORK_POINT_MAX_LIMIT: usize = 1000;
+
+impl Default for ForkPointQuery {
+    fn default() -> Self {
+        Self {
+            include_non_recovery: false,
+            offset: 0,
+            limit: FORK_POINT_DEFAULT_LIMIT,
+        }
+    }
+}
+
+/// First ~140 chars of `text`, whitespace collapsed to single spaces —
+/// the one-line preview shown next to a fork point.
+pub(crate) fn fork_point_preview(text: &str) -> String {
+    let mut out = String::with_capacity(140);
+    let mut last_space = true;
+    for ch in text.chars() {
+        let ch = if ch.is_whitespace() { ' ' } else { ch };
+        if ch == ' ' && last_space {
+            continue;
+        }
+        last_space = ch == ' ';
+        out.push(ch);
+        if out.len() >= 140 {
+            out.push('…');
+            break;
+        }
+    }
+    out.trim_end().to_string()
+}
+
+/// Apply `offset`/`limit` paging to an already-ordered fork-point list,
+/// filling the catalog's paging fields.
+pub(crate) fn page_fork_points(
+    catalog: &mut ForkPointCatalog,
+    points: Vec<ForkPoint>,
+    query: &ForkPointQuery,
+) {
+    let total = points.len();
+    let offset = query.offset.min(total);
+    let limit = query.limit.clamp(1, FORK_POINT_MAX_LIMIT);
+    let end = offset.saturating_add(limit).min(total);
+    catalog.total = total;
+    catalog.offset = offset;
+    catalog.limit = limit;
+    catalog.next_offset = (end < total).then_some(end);
+    catalog.fork_points = points[offset..end].to_vec();
+}

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -942,6 +942,15 @@ pub(crate) async fn serve_http_request(
                 return handle_session_sub_router(stream, request_line, session_log, query_ctx)
                     .await;
             }
+            RouteHandlerId::SessionForkPoints => {
+                return handle_session_fork_points(
+                    stream,
+                    request_line,
+                    route.cors,
+                    fleet_cors_origin.as_deref(),
+                )
+                .await;
+            }
             RouteHandlerId::McAnchors => {
                 return handle_mc_anchors(
                     stream,

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -48,6 +48,9 @@ pub(crate) use routes_transfers::*;
 mod routes_agenda;
 pub(crate) use routes_agenda::*;
 
+mod routes_fork_points;
+pub(crate) use routes_fork_points::*;
+
 mod routes_sessions;
 pub(crate) use routes_sessions::*;
 

--- a/src/bin/caller/web_gateway/routes_fork_points.rs
+++ b/src/bin/caller/web_gateway/routes_fork_points.rs
@@ -1,0 +1,310 @@
+//! `GET /api/session/{id}/fork-points` — the unified fork-point catalog
+//! (tunnel twin `api_session_fork_points`).
+//!
+//! Resolution ladder for `{id}`: an Intendant wrapper session resolves to
+//! its canonical external identity first (so the catalog is derived from
+//! the backend's own transcript), then a plain native log dir, then the
+//! backend stores directly (a bare codex rollout id / claude session id).
+
+use super::*;
+use crate::session_fork::{
+    codex_fork_points, native_fork_points, ForkPointCatalog, ForkPointQuery,
+    FORK_POINT_DEFAULT_LIMIT,
+};
+use std::io;
+use std::path::{Path, PathBuf};
+
+pub(crate) async fn handle_session_fork_points(
+    stream: DemuxStream,
+    request_line: &str,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) {
+    let response = session_fork_points_response(request_line, &crate::platform::home_dir());
+    write_api_response(stream, response, cors, fleet_origin).await;
+}
+
+/// Transport edge: resolves `CODEX_HOME`; tests drive the `_with_roots`
+/// variant with injected temp roots.
+pub(crate) fn session_fork_points_response(request_line: &str, home: &Path) -> ApiResponse {
+    let codex_root = std::env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| home.join(".codex"));
+    session_fork_points_response_with_roots(request_line, home, &codex_root)
+}
+
+pub(crate) fn session_fork_points_response_with_roots(
+    request_line: &str,
+    home: &Path,
+    codex_root: &Path,
+) -> ApiResponse {
+    let Some(session_id) = fork_points_session_id(request_line) else {
+        return ApiResponse::json_error(400, "session id missing in fork-points path");
+    };
+    let query = fork_point_query_from_request(request_line);
+    match resolve_fork_point_catalog(&session_id, home, codex_root, &query) {
+        Ok(Some(catalog)) => match serde_json::to_value(&catalog) {
+            Ok(value) => ApiResponse::json(200, JsonBody::Value(value)),
+            Err(err) => {
+                ApiResponse::json_error(500, format!("failed to serialize fork points: {err}"))
+            }
+        },
+        Ok(None) => ApiResponse::json_error(
+            404,
+            format!("session {session_id} not found in any session store"),
+        ),
+        Err(err) => ApiResponse::json_error(500, format!("failed to derive fork points: {err}")),
+    }
+}
+
+/// `{id}` from `GET /api/session/{id}/fork-points[?…]`.
+fn fork_points_session_id(request_line: &str) -> Option<String> {
+    let path = request_line.split_whitespace().nth(1)?;
+    let path = path.split('?').next().unwrap_or(path);
+    let mut segments = path.trim_start_matches('/').split('/');
+    if segments.next() != Some("api") || segments.next() != Some("session") {
+        return None;
+    }
+    let id = segments.next()?.trim();
+    if id.is_empty() || segments.next() != Some("fork-points") || segments.next().is_some() {
+        return None;
+    }
+    Some(id.to_string())
+}
+
+fn fork_point_query_from_request(request_line: &str) -> ForkPointQuery {
+    let flag = |key: &str| {
+        query_param(request_line, key)
+            .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    };
+    let number =
+        |key: &str| query_param(request_line, key).and_then(|value| value.parse::<usize>().ok());
+    ForkPointQuery {
+        include_non_recovery: flag("include_non_recovery"),
+        offset: number("offset").unwrap_or(0),
+        limit: number("limit").unwrap_or(FORK_POINT_DEFAULT_LIMIT),
+    }
+}
+
+fn resolve_fork_point_catalog(
+    session_id: &str,
+    home: &Path,
+    codex_root: &Path,
+    query: &ForkPointQuery,
+) -> io::Result<Option<ForkPointCatalog>> {
+    // A wrapper session's catalog comes from its backend's own transcript.
+    if let Some((source, backend_id)) =
+        crate::session_supervisor::persisted_external_identity_for_session_in_home(home, session_id)
+    {
+        return external_fork_point_catalog(
+            session_id,
+            &source,
+            &backend_id,
+            home,
+            codex_root,
+            query,
+        )
+        .map(Some);
+    }
+    if let Some(log_dir) =
+        crate::session_log::SessionLog::find_session_by_id_in_home(home, session_id)
+    {
+        return native_fork_points(session_id, &log_dir, query).map(Some);
+    }
+    if let Some(rollout) =
+        crate::codex_history::find_codex_session_file_in(codex_root, home, session_id)
+    {
+        return codex_fork_points(session_id, session_id, &rollout, query).map(Some);
+    }
+    if find_claude_session_file(home, session_id).is_some() {
+        return Ok(Some(claude_fork_points_stub(session_id, session_id)));
+    }
+    Ok(None)
+}
+
+fn external_fork_point_catalog(
+    session_id: &str,
+    source: &str,
+    backend_id: &str,
+    home: &Path,
+    codex_root: &Path,
+    query: &ForkPointQuery,
+) -> io::Result<ForkPointCatalog> {
+    match source {
+        "codex" => {
+            match crate::codex_history::find_codex_session_file_in(codex_root, home, backend_id) {
+                Some(rollout) => codex_fork_points(session_id, backend_id, &rollout, query),
+                None => Ok(ForkPointCatalog::unsupported(
+                    session_id,
+                    "codex",
+                    Some(backend_id),
+                    "rollout file not found under the codex session store",
+                )),
+            }
+        }
+        "claude-code" => Ok(claude_fork_points_stub(session_id, backend_id)),
+        other => Ok(ForkPointCatalog::unsupported(
+            session_id,
+            other,
+            Some(backend_id),
+            &format!("fork points are not supported for {other} sessions yet"),
+        )),
+    }
+}
+
+fn claude_fork_points_stub(session_id: &str, backend_id: &str) -> ForkPointCatalog {
+    ForkPointCatalog::unsupported(
+        session_id,
+        "claude-code",
+        Some(backend_id),
+        "claude-code fork points land with the transcript tree parser (follow-up phase)",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn response_json(response: ApiResponse) -> (u16, serde_json::Value) {
+        match response {
+            ApiResponse::Json { status, body, .. } => (
+                status,
+                serde_json::from_str(&body.into_string()).expect("json body"),
+            ),
+            _ => panic!("expected a JSON response"),
+        }
+    }
+
+    fn request_line(id: &str, query: &str) -> String {
+        format!("GET /api/session/{id}/fork-points{query} HTTP/1.1")
+    }
+
+    fn seed_native_session(home: &Path, session_id: &str) {
+        let dir = crate::platform::intendant_home_in(home)
+            .join("logs")
+            .join(session_id);
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(
+            dir.join("session_meta.json"),
+            serde_json::json!({ "session_id": session_id }).to_string(),
+        )
+        .expect("meta");
+        let lines = [
+            serde_json::json!({"role":"user","content":"round one","seq":1}),
+            serde_json::json!({"role":"assistant","content":"done","seq":2}),
+            serde_json::json!({"role":"user","content":"round two","seq":3}),
+        ];
+        let body: String = lines.iter().map(|line| format!("{line}\n")).collect();
+        std::fs::write(dir.join("conversation.jsonl"), body).expect("conversation");
+    }
+
+    fn seed_codex_rollout(codex_root: &Path, backend_id: &str) {
+        let dir = codex_root
+            .join("sessions")
+            .join("2026")
+            .join("01")
+            .join("02");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let lines = [
+            serde_json::json!({"timestamp":"t","type":"session_meta","payload":{"id":backend_id,"cwd":"/tmp"}}),
+            serde_json::json!({"timestamp":"t","type":"event_msg","payload":{"type":"user_message","message":"do the thing"}}),
+        ];
+        let body: String = lines.iter().map(|line| format!("{line}\n")).collect();
+        std::fs::write(
+            dir.join(format!("rollout-2026-01-02T00-00-00-{backend_id}.jsonl")),
+            body,
+        )
+        .expect("rollout");
+    }
+
+    #[test]
+    fn native_session_resolves_to_round_catalog() {
+        let home = tempfile::tempdir().expect("home");
+        let codex_root = home.path().join(".codex");
+        seed_native_session(home.path(), "native-session");
+        let (status, body) = response_json(session_fork_points_response_with_roots(
+            &request_line("native-session", ""),
+            home.path(),
+            &codex_root,
+        ));
+        assert_eq!(status, 200);
+        assert_eq!(body["source"], "intendant");
+        assert_eq!(body["supported"], true);
+        assert!(body["fork_points"]
+            .as_array()
+            .is_some_and(|a| !a.is_empty()));
+    }
+
+    #[test]
+    fn bare_codex_id_resolves_via_rollout_store() {
+        let home = tempfile::tempdir().expect("home");
+        let codex_root = home.path().join("codex-home");
+        seed_codex_rollout(&codex_root, "0000aaaa-1111-2222-3333-444455556666");
+        let (status, body) = response_json(session_fork_points_response_with_roots(
+            &request_line("0000aaaa-1111-2222-3333-444455556666", "?limit=10"),
+            home.path(),
+            &codex_root,
+        ));
+        assert_eq!(status, 200);
+        assert_eq!(body["source"], "codex");
+        assert_eq!(body["supported"], true);
+        let kinds: Vec<&str> = body["fork_points"]
+            .as_array()
+            .expect("points")
+            .iter()
+            .filter_map(|point| point["kind"].as_str())
+            .collect();
+        assert!(kinds.contains(&"turn-boundary"));
+    }
+
+    #[test]
+    fn claude_session_reports_follow_up_stub() {
+        let home = tempfile::tempdir().expect("home");
+        let codex_root = home.path().join(".codex");
+        let project = home.path().join(".claude").join("projects").join("-tmp-x");
+        std::fs::create_dir_all(&project).expect("mkdir");
+        std::fs::write(
+            project.join("cc11cc11-0000-0000-0000-000000000000.jsonl"),
+            "{\"type\":\"user\",\"sessionId\":\"cc11cc11-0000-0000-0000-000000000000\"}\n",
+        )
+        .expect("transcript");
+        let (status, body) = response_json(session_fork_points_response_with_roots(
+            &request_line("cc11cc11-0000-0000-0000-000000000000", ""),
+            home.path(),
+            &codex_root,
+        ));
+        assert_eq!(status, 200);
+        assert_eq!(body["source"], "claude-code");
+        assert_eq!(body["supported"], false);
+    }
+
+    #[test]
+    fn unknown_session_is_404() {
+        let home = tempfile::tempdir().expect("home");
+        let codex_root = home.path().join(".codex");
+        let (status, body) = response_json(session_fork_points_response_with_roots(
+            &request_line("does-not-exist", ""),
+            home.path(),
+            &codex_root,
+        ));
+        assert_eq!(status, 404);
+        assert!(body["error"].as_str().is_some());
+    }
+
+    #[test]
+    fn session_id_extraction_rejects_malformed_paths() {
+        assert_eq!(
+            fork_points_session_id("GET /api/session/abc/fork-points HTTP/1.1").as_deref(),
+            Some("abc")
+        );
+        assert_eq!(
+            fork_points_session_id("GET /api/session/abc/fork-points?limit=5 HTTP/1.1").as_deref(),
+            Some("abc")
+        );
+        assert!(fork_points_session_id("GET /api/session//fork-points HTTP/1.1").is_none());
+        assert!(fork_points_session_id("GET /api/session/abc/frames/x.png HTTP/1.1").is_none());
+        assert!(fork_points_session_id("GET /api/other/abc/fork-points HTTP/1.1").is_none());
+    }
+}


### PR DESCRIPTION
Phase A of the fork-session-from-any-anchor program (probes landed in #353).

Adds the `session_fork` module and `GET /api/session/{id}/fork-points` (tunnel twin `api_session_fork_points`, IAM `SessionInspect`): a unified, backend-tagged catalog of the places a session can be forked from, derived from each backend's own canonical transcript — never Intendant's diagnostic mirror.

- **codex**: reuses the managed-context anchor scan (shared cache + racy-write quiescence) joined with the effective user-turn list. Turn-boundary points fork on any binary; item anchors carry the `effective_cut` turn they round down to on a vanilla binary (managed keeps item precision). Recovery-ineligible anchors hidden by default, `include_non_recovery=1` lists them flagged.
- **intendant** (native): round boundaries from the persisted `conversation.jsonl`, keyed by message `seq`; legacy seq-0 lines are ineligible-with-reason.
- **claude-code**: `supported:false` stub until the transcript tree parser (next PR).

Resolution ladder: wrapper session → canonical external identity → backend store; else native log dir; else bare codex/claude ids. Route row declared ahead of the session sub-router group (leaf must beat the `Under` catch-all; shared-handler groups stay contiguous). Docs endpoint table regenerated; tunnel partition pin updated.

Tests: 14 new hermetic units (temp homes/roots, synthetic rollouts + conversations); route-table invariants and docs gate green; full `--bins` suite green locally (3 listener-test port-contention flakes reproduced passing in isolation; the 16s `get_status_resolves_backend_phase_through_session_identity_alias` slow test pre-exists on main).