### PR TITLE
dashboard: deterministic command-output collapse + streaming tail

### DIFF
--- a/static/app.html
+++ b/static/app.html
@@ -18960,6 +18960,34 @@ html.ui-v2 .command-output-group .command-output-body:empty { display: none; }
 /* live groups are collapsible now too (v1 only ever hid finalized
    bodies): a collapsed streaming group keeps receiving text off-screen */
 html.ui-v2 .command-output-group:not(.expanded) .command-output-body { display: none; }
+/* the streaming tail: last few output lines under a collapsed live group —
+   proof of life while it streams. Gone once expanded (the body takes over)
+   or finalized (the summary row is the record). JS keeps it to ~3 trimmed
+   lines; the max-height is a belt against odd content. */
+html.ui-v2 .command-output-group .command-output-tail {
+  display: block;
+  margin-top: 4px;
+  padding-left: 13px;
+  border-left: 2px solid color-mix(in srgb, var(--iris) 32%, transparent);
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-3);
+  white-space: pre;
+  overflow: hidden;
+  max-height: 4.5em;
+}
+html.ui-v2 .command-output-group .command-output-tail:empty { display: none; }
+html.ui-v2 .command-output-group.expanded .command-output-tail,
+html.ui-v2 .command-output-group.finalized .command-output-tail { display: none; }
+/* verbose-opened truncated rows show their local preview plus this hint */
+html.ui-v2 .command-output-group .command-output-truncation-note {
+  display: block;
+  padding: 4px 12px 6px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--text-3);
+}
 html.ui-v2 .command-output-group .command-output-pre {
   margin: 0;
   padding: 8px 12px;
@@ -28448,7 +28476,7 @@ import * as THREE from '/three.module.min.js';
 // daemon upgrade, tabs left open would otherwise keep running old code
 // against the new daemon indefinitely (the "stale photograph" multi-tab
 // failure class).
-const INTENDANT_APP_BUILD = 'a1ccdc7343c34ada';
+const INTENDANT_APP_BUILD = 'c524e20c8672d41a';
 
 let staleBuildNudged = false;
 function maybeNudgeStaleBuild(serverBuild) {
@@ -29038,7 +29066,12 @@ const SESSION_TEXT_SIGNATURE_CHAR_LIMIT = 8192;
 const SESSION_RENDERED_SIGNATURE_CHAR_LIMIT = 4096;
 const STATION_ACTIVITY_TEXT_CHAR_LIMIT = 1200;
 const STATION_ANCHOR_DETAIL_CHAR_LIMIT = 2000;
-const COMMAND_OUTPUT_EAGER_RENDER_CHAR_LIMIT = 24000;
+// 0 = collapsed replay/hydration output rows NEVER carry their text in the
+// DOM — expand renders it from _deferredCommandOutputStore. No consumer
+// reads a hidden .command-output-body (copy uses logEntryCopyTextByEntry
+// refs; transcript signatures exclude output records; Station reads the
+// pushed event objects), so hidden full text was pure node weight.
+const COMMAND_OUTPUT_EAGER_RENDER_CHAR_LIMIT = 0;
 const SESSION_PENDING_ACTIVE_MS = 30000;
 const SESSION_METADATA_REFRESH_MS = 15000;
 const SESSION_WINDOW_GRID_HEIGHT_KEY = 'intendant_session_window_grid_height_v3';
@@ -39111,7 +39144,14 @@ function applyDashboardVerbosity(level, options = {}) {
   if (!['normal', 'verbose', 'debug'].includes(next)) return '';
   const select = document.getElementById('verbosity-select');
   if (select) select.value = next;
-  if (app) processCommands(app.set_verbosity(next));
+  if (app) {
+    processCommands(app.set_verbosity(next));
+    // set_verbosity re-emitted the whole log buffer synchronously; every
+    // rebuilt output group is history and closes now (at Verbose/Debug the
+    // rebuilt groups stay open — that's the default finalize preserves). A
+    // command still streaming reopens a fresh group on its next chunk.
+    finalizeActiveCommandOutputGroup();
+  }
   localStorage.setItem(VERBOSITY_KEY, next);
   if (options.dispatch !== false) {
     dispatchControlMsg({ action: 'set_verbosity', level: next });
@@ -42076,6 +42116,11 @@ async function main() {
         d.session_id
       ) {
         serverMsgStep(d, 'transcript_sync', () => scheduleExternalSessionWindowTranscriptSync(d.session_id, 300));
+        // The round is over: whatever this session still streamed is
+        // complete. Catches a command that was the LAST thing in the
+        // round — no later entry would ever have finalized its group.
+        serverMsgStep(d, 'finalize_command_output', () =>
+          finalizeSessionCommandOutputGroups({ session_id: d.session_id }));
       }
       serverMsgStep(d, 'external_identity', () => applyExternalIdentityFromLogEntry(d));
       if (d.event === 'session_relationship') {
@@ -52450,9 +52495,18 @@ async function loadReplayCommandOutputIntoBody(c, body, copyRef = null) {
   }
 }
 
-function buildSessionWindowCommandOutputEntry(c) {
+function buildSessionWindowCommandOutputEntry(c, options = {}) {
   const content = String(c?.content || '');
-  const { entry } = createLogScaffold(c, 'command-output-group finalized');
+  // Verbosity is the power knob: Verbose/Debug builds output rows open
+  // (session detail passes its own detail-verbosity level; session
+  // windows follow the Activity dropdown). Only rows with LOCAL text can
+  // honor it — an open row whose full output still needs an RPC would
+  // render an empty or placeholder body.
+  const defaultExpanded = (options.defaultExpanded ?? commandOutputDefaultExpanded()) && !!content;
+  const { entry } = createLogScaffold(
+    c,
+    'command-output-group finalized' + (defaultExpanded ? ' expanded' : '')
+  );
   const wrap = document.createElement('span');
   wrap.className = 'log-content command-output-wrap';
   const summary = document.createElement('span');
@@ -52473,10 +52527,21 @@ function buildSessionWindowCommandOutputEntry(c) {
   });
   if (content && !canFetchFull) {
     setDeferredCommandOutputText(entry, body, content, stats);
+    if (defaultExpanded) renderDeferredCommandOutputText(entry);
   } else if (canFetchFull) {
-    body.textContent = content
-      ? 'Preview loaded; expand to fetch full output.'
-      : 'Expand to fetch full output.';
+    if (defaultExpanded) {
+      // Open by default: show the local preview now; the lazy store stays
+      // wired, so collapsing and re-expanding fetches the full output.
+      appendCommandOutputText(body, content);
+      const note = document.createElement('span');
+      note.className = 'command-output-truncation-note';
+      note.textContent = 'Preview shown — collapse and expand to fetch the full output.';
+      body.appendChild(note);
+    } else {
+      body.textContent = content
+        ? 'Preview loaded; expand to fetch full output.'
+        : 'Expand to fetch full output.';
+    }
     _lazyCommandOutputStore.set(entry, { c, body, loaded: false, loading: false });
   }
   const toggle = document.createElement('span');
@@ -55802,6 +55867,7 @@ function registerCommandOutputCloneView(group, clone) {
     entry: clone,
     summary: clone.querySelector('.command-output-summary'),
     body: clone.querySelector('.command-output-body'),
+    tail: clone.querySelector('.command-output-tail'),
     loaded: false,
     loading: false,
   };
@@ -55810,12 +55876,40 @@ function registerCommandOutputCloneView(group, clone) {
   if (!Array.isArray(group.clones)) group.clones = [];
   group.clones.push(view);
   view.summary.innerHTML = group.summary.innerHTML;
+  if (view.tail) view.tail.textContent = group.tail?.textContent || '';
   clone.classList.toggle('finalized', group.finalized);
   clone.classList.toggle('expanded', group.entry.classList.contains('expanded'));
   if (group.finalized) {
-    view.body.innerHTML = '';
+    // Re-fetchable output starts empty (lazy-loaded on expand); output with
+    // no persisted ids keeps whatever the clone carried — it is the only copy.
+    if (group.outputIds.length) {
+      view.body.innerHTML = '';
+    } else {
+      view.loaded = view.body.childElementCount > 0;
+    }
   }
   return view;
+}
+
+// Session scope for a log command — the same `targetSid || sid || 'global'`
+// prefix commandOutputGroupKey embeds (keep the two in lockstep). Groups
+// store it so finalize can sweep "every active group of THIS session"
+// without string-parsing keys.
+function commandOutputSessionScope(c) {
+  const sid = String(c?.session_id || '').trim();
+  const targetSid = sid ? sessionWindowTargetForLogSession(sid) : '';
+  return targetSid || sid || 'global';
+}
+
+// The Activity-tab verbosity dropdown doubles as the output-visibility
+// power knob: at Verbose/Debug, command-output groups default to
+// expanded; Normal keeps them collapsed to their summary row. Read live
+// (not cached) so finalize honors the level at the moment it runs.
+function commandOutputDefaultExpanded() {
+  const level = document.getElementById('verbosity-select')?.value
+    || localStorage.getItem(VERBOSITY_KEY)
+    || 'normal';
+  return level === 'verbose' || level === 'debug';
 }
 
 function commandOutputGroupKey(c) {
@@ -55869,6 +55963,43 @@ function appendCommandOutputText(body, text) {
   code.innerHTML = highlightCommandOutput(text);
   pre.appendChild(code);
   body.appendChild(pre);
+}
+
+// ── Live streaming tail ──
+// While a group streams (created, not yet finalized) and sits collapsed,
+// a small dim region under the summary shows the LAST few output lines —
+// proof the command is alive without the full body. CSS hides it once the
+// group is expanded or finalized; finalize also empties it.
+const COMMAND_OUTPUT_TAIL_LINES = 3;
+const COMMAND_OUTPUT_TAIL_LINE_CHARS = 240;
+const COMMAND_OUTPUT_TAIL_BUFFER_CHARS = 4096;
+
+function updateCommandOutputTail(group, text) {
+  if (!group?.tail) return;
+  const merged = (group.tailText || '') + String(text || '');
+  group.tailText = merged.length > COMMAND_OUTPUT_TAIL_BUFFER_CHARS
+    ? merged.slice(-COMMAND_OUTPUT_TAIL_BUFFER_CHARS)
+    : merged;
+  const lines = group.tailText.replace(/\r/g, '').split('\n').filter(line => line.trim() !== '');
+  const rendered = lines
+    .slice(-COMMAND_OUTPUT_TAIL_LINES)
+    .map(line => line.length > COMMAND_OUTPUT_TAIL_LINE_CHARS
+      ? '…' + line.slice(-COMMAND_OUTPUT_TAIL_LINE_CHARS)
+      : line)
+    .join('\n');
+  group.tail.textContent = rendered;
+  for (const view of commandOutputCloneViews(group)) {
+    if (view.tail) view.tail.textContent = rendered;
+  }
+}
+
+function clearCommandOutputTail(group) {
+  if (!group) return;
+  group.tailText = '';
+  if (group.tail) group.tail.textContent = '';
+  for (const view of commandOutputCloneViews(group)) {
+    if (view.tail) view.tail.textContent = '';
+  }
 }
 
 async function appendCommandOutputTextProgressive(body, text, chunkChars = 65536) {
@@ -56003,11 +56134,23 @@ function appendCommandOutputChunk(group, c) {
   updateCommandOutputSummary(group);
   if (!group.finalized && text && !processingLogReplay) {
     appendCommandOutputText(group.body, text);
+    updateCommandOutputTail(group, text);
     for (const view of commandOutputCloneViews(group)) {
       if (view.entry.classList.contains('expanded')) {
         appendCommandOutputText(view.body, text);
       }
     }
+  }
+  if (!processingLogReplay && !group.itemScoped) {
+    // Uncorrelated (no item_id) output rides the native batch contract:
+    // one wire event carries the COMPLETE stdout+stderr of a finished
+    // command batch, delivered as one synchronous UiCommand burst. A
+    // microtask after that burst is therefore the command's own
+    // completion — finalize deterministically instead of waiting for
+    // whatever entry happens to arrive next. Item-scoped (external)
+    // groups stream across many wire events and finalize on their
+    // session's next non-output entry / round completion instead.
+    scheduleCommandOutputBatchFinalize(group);
   }
   for (const [win, shouldFollow] of sessionScrollStates.entries()) {
     applySessionWindowOutputScroll(win, shouldFollow);
@@ -56019,15 +56162,24 @@ function renderCommandOutputEntry(c) {
   let activeCommandOutputGroup = activeCommandOutputGroups.get(groupKey);
   if (!activeCommandOutputGroup || activeCommandOutputGroup.finalized) {
     const groupId = 'cmdout-' + (++commandOutputGroupSeq);
-    const { entry } = createLogScaffold(c, 'command-output-group expanded');
+    // Deterministic default: born COLLAPSED (like the replay lane) unless
+    // the verbosity knob says outputs default open. The streaming tail
+    // below keeps a collapsed live group visibly alive.
+    const { entry } = createLogScaffold(
+      c,
+      'command-output-group' + (commandOutputDefaultExpanded() ? ' expanded' : '')
+    );
     entry.dataset.outputGroupId = groupId;
     const wrap = document.createElement('span');
     wrap.className = 'log-content command-output-wrap';
     const summary = document.createElement('span');
     summary.className = 'command-output-summary';
+    const tail = document.createElement('span');
+    tail.className = 'command-output-tail';
     const body = document.createElement('span');
     body.className = 'command-output-body';
     wrap.appendChild(summary);
+    wrap.appendChild(tail);
     wrap.appendChild(body);
     const toggle = document.createElement('span');
     toggle.className = 'collapse-toggle';
@@ -56044,8 +56196,15 @@ function renderCommandOutputEntry(c) {
     const group = {
       id: groupId,
       key: groupKey,
+      sessionScope: commandOutputSessionScope(c),
+      // item-correlated groups stream across wire events (external
+      // backends); uncorrelated ones complete within one event (native
+      // batch contract) — see appendCommandOutputChunk.
+      itemScoped: !!itemId,
       entry,
       summary,
+      tail,
+      tailText: '',
       body,
       outputIds: [],
       outputIdSet: new Set(),
@@ -56054,6 +56213,7 @@ function renderCommandOutputEntry(c) {
       bytes: 0,
       warns: 0,
       finalized: false,
+      finalizeQueued: false,
       loaded: false,
       loading: false,
       clones: [],
@@ -56074,36 +56234,68 @@ function renderCommandOutputEntry(c) {
   if (!concurrentLogDetachedFragment && autoScroll && stream) scheduleMainLogScrollToBottom();
 }
 
+// Uncorrelated (native-batch) groups finalize one microtask after the
+// synchronous UiCommand burst that streamed them — the wire event that
+// carried the chunks IS the command's completion (stdout+stderr arrive
+// together once the batch finished). Armed per chunk, idempotent.
+function scheduleCommandOutputBatchFinalize(group) {
+  if (!group || group.finalized || group.finalizeQueued) return;
+  group.finalizeQueued = true;
+  queueMicrotask(() => {
+    group.finalizeQueued = false;
+    finalizeCommandOutputGroup(group);
+  });
+}
+
 function finalizeCommandOutputGroup(group) {
   if (!group || group.finalized) return;
   group.finalized = true;
   group.entry.classList.add('finalized');
+  // The streaming tail retires with the stream — the collapsed summary
+  // row carries the group from here.
+  clearCommandOutputTail(group);
   // A group the USER opened stays open with its streamed body — yanking
   // the output shut mid-read because the command happened to finish was
-  // the "collapsible doesn't work" experience. Auto-expanded (streaming)
-  // groups still fold to their summary line.
-  if (group.userExpanded && group.entry.classList.contains('expanded')) {
+  // the "collapsible doesn't work" experience. At Verbose/Debug the
+  // default itself is open, so auto-expanded groups keep their body too.
+  // Only groups whose body actually holds the stream stay open — replay
+  // recreations stream no DOM text, and an open-but-empty body lies.
+  const defaultExpanded = commandOutputDefaultExpanded();
+  // Output with no persisted ids cannot be re-fetched on expand — keep
+  // the streamed body (hidden while collapsed) instead of destroying the
+  // only copy.
+  const preserveBody = group.outputIds.length === 0;
+  const keepOpen = group.entry.classList.contains('expanded')
+    && (group.userExpanded || defaultExpanded)
+    && group.body.childElementCount > 0;
+  if (keepOpen) {
     group.loaded = true;
     group.loading = false;
   } else {
     group.entry.classList.remove('expanded');
-    group.body.innerHTML = '';
-    group.loaded = false;
+    if (!preserveBody) group.body.innerHTML = '';
+    group.loaded = preserveBody && group.body.childElementCount > 0;
     group.loading = false;
   }
   for (const view of commandOutputCloneViews(group)) {
     view.entry.classList.add('finalized');
-    if (view.entry.classList.contains('expanded') && group.userExpanded) {
+    if (view.entry.classList.contains('expanded')
+        && (group.userExpanded || defaultExpanded)
+        && view.body.childElementCount > 0) {
       view.loaded = true;
       view.loading = false;
       continue;
     }
     view.entry.classList.remove('expanded');
-    view.body.innerHTML = '';
-    view.loaded = false;
+    if (!preserveBody) view.body.innerHTML = '';
+    view.loaded = preserveBody && view.body.childElementCount > 0;
     view.loading = false;
   }
-  if (group.key) activeCommandOutputGroups.delete(group.key);
+  // Identity-guarded: a deferred (microtask) finalize must never evict a
+  // NEWER group that re-registered under the same key.
+  if (group.key && activeCommandOutputGroups.get(group.key) === group) {
+    activeCommandOutputGroups.delete(group.key);
+  }
 }
 
 function finalizeActiveCommandOutputGroup(groupKey = null) {
@@ -56117,8 +56309,28 @@ function finalizeActiveCommandOutputGroup(groupKey = null) {
   activeCommandOutputGroups.clear();
 }
 
+// Deterministic cross-command close: any non-output entry rendering for a
+// session means its in-flight command output is done (backends announce
+// the next tool / model text only after the previous command's output was
+// delivered). Exact-key finalize almost never fired for item-correlated
+// groups — the next entry carries a different (or no) item id, so groups
+// stayed open forever purely by timing.
+function finalizeSessionCommandOutputGroups(c) {
+  const scope = commandOutputSessionScope(c);
+  for (const group of Array.from(activeCommandOutputGroups.values())) {
+    if (group.sessionScope === scope) finalizeCommandOutputGroup(group);
+  }
+}
+
 async function loadCommandOutputIntoBody(group, body) {
   if (!group.outputIds.length) {
+    // Nothing persisted to re-fetch: finalize preserved the streamed body
+    // on the main entry in that case — serve expands from it.
+    if (body !== group.body && group.body?.childElementCount) {
+      body.innerHTML = group.body.innerHTML;
+      return;
+    }
+    if (body.childElementCount) return;
     body.textContent = 'Output is not available for lazy loading.';
     return;
   }
@@ -56194,7 +56406,7 @@ async function toggleCommandOutputGroup(group) {
 }
 
 function renderDiffLogEntry(c) {
-  finalizeActiveCommandOutputGroup(commandOutputGroupKey(c));
+  finalizeSessionCommandOutputGroups(c);
   const diffText = diffLogContent(c);
   const parsed = parseUnifiedDiff(diffText);
   const { entry } = createLogScaffold(c, 'diff-log-entry');
@@ -56671,7 +56883,7 @@ function renderLogEntry(c) {
     renderDiffLogEntry(c);
     return;
   }
-  finalizeActiveCommandOutputGroup(commandOutputGroupKey(c));
+  finalizeSessionCommandOutputGroups(c);
   if (shouldSuppressAttachmentReceiptDuplicate(c)) return;
   inferSessionPhaseFromLog(c);
 
@@ -101895,7 +102107,12 @@ function materializeSessionDetailRow(view, row, index) {
 
   const e = row.record;
   if (isSessionWindowCommandOutputRecord(e)) {
-    const outputEntry = buildSessionWindowCommandOutputEntry(e);
+    // The detail pane's own verbosity select is the knob here (retroactive:
+    // changing it re-renders through renderCurrent); the Activity dropdown
+    // governs the live/session-window lanes.
+    const outputEntry = buildSessionWindowCommandOutputEntry(e, {
+      defaultExpanded: detailVerbosity === 'verbose' || detailVerbosity === 'debug',
+    });
     if (!outputEntry) return null;
     outputEntry.dataset.detailRowIndex = String(index);
     return outputEntry;

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -603,7 +603,12 @@ const SESSION_TEXT_SIGNATURE_CHAR_LIMIT = 8192;
 const SESSION_RENDERED_SIGNATURE_CHAR_LIMIT = 4096;
 const STATION_ACTIVITY_TEXT_CHAR_LIMIT = 1200;
 const STATION_ANCHOR_DETAIL_CHAR_LIMIT = 2000;
-const COMMAND_OUTPUT_EAGER_RENDER_CHAR_LIMIT = 24000;
+// 0 = collapsed replay/hydration output rows NEVER carry their text in the
+// DOM — expand renders it from _deferredCommandOutputStore. No consumer
+// reads a hidden .command-output-body (copy uses logEntryCopyTextByEntry
+// refs; transcript signatures exclude output records; Station reads the
+// pushed event objects), so hidden full text was pure node weight.
+const COMMAND_OUTPUT_EAGER_RENDER_CHAR_LIMIT = 0;
 const SESSION_PENDING_ACTIVE_MS = 30000;
 const SESSION_METADATA_REFRESH_MS = 15000;
 const SESSION_WINDOW_GRID_HEIGHT_KEY = 'intendant_session_window_grid_height_v3';

--- a/static/app/35-station-diff-viewer.js
+++ b/static/app/35-station-diff-viewer.js
@@ -65,7 +65,14 @@ function applyDashboardVerbosity(level, options = {}) {
   if (!['normal', 'verbose', 'debug'].includes(next)) return '';
   const select = document.getElementById('verbosity-select');
   if (select) select.value = next;
-  if (app) processCommands(app.set_verbosity(next));
+  if (app) {
+    processCommands(app.set_verbosity(next));
+    // set_verbosity re-emitted the whole log buffer synchronously; every
+    // rebuilt output group is history and closes now (at Verbose/Debug the
+    // rebuilt groups stay open — that's the default finalize preserves). A
+    // command still streaming reopens a fresh group on its next chunk.
+    finalizeActiveCommandOutputGroup();
+  }
   localStorage.setItem(VERBOSITY_KEY, next);
   if (options.dispatch !== false) {
     dispatchControlMsg({ action: 'set_verbosity', level: next });

--- a/static/app/36-voice-wasm-init.js
+++ b/static/app/36-voice-wasm-init.js
@@ -642,6 +642,11 @@ async function main() {
         d.session_id
       ) {
         serverMsgStep(d, 'transcript_sync', () => scheduleExternalSessionWindowTranscriptSync(d.session_id, 300));
+        // The round is over: whatever this session still streamed is
+        // complete. Catches a command that was the LAST thing in the
+        // round — no later entry would ever have finalized its group.
+        serverMsgStep(d, 'finalize_command_output', () =>
+          finalizeSessionCommandOutputGroups({ session_id: d.session_id }));
       }
       serverMsgStep(d, 'external_identity', () => applyExternalIdentityFromLogEntry(d));
       if (d.event === 'session_relationship') {

--- a/static/app/40-session-launch.js
+++ b/static/app/40-session-launch.js
@@ -910,9 +910,18 @@ async function loadReplayCommandOutputIntoBody(c, body, copyRef = null) {
   }
 }
 
-function buildSessionWindowCommandOutputEntry(c) {
+function buildSessionWindowCommandOutputEntry(c, options = {}) {
   const content = String(c?.content || '');
-  const { entry } = createLogScaffold(c, 'command-output-group finalized');
+  // Verbosity is the power knob: Verbose/Debug builds output rows open
+  // (session detail passes its own detail-verbosity level; session
+  // windows follow the Activity dropdown). Only rows with LOCAL text can
+  // honor it — an open row whose full output still needs an RPC would
+  // render an empty or placeholder body.
+  const defaultExpanded = (options.defaultExpanded ?? commandOutputDefaultExpanded()) && !!content;
+  const { entry } = createLogScaffold(
+    c,
+    'command-output-group finalized' + (defaultExpanded ? ' expanded' : '')
+  );
   const wrap = document.createElement('span');
   wrap.className = 'log-content command-output-wrap';
   const summary = document.createElement('span');
@@ -933,10 +942,21 @@ function buildSessionWindowCommandOutputEntry(c) {
   });
   if (content && !canFetchFull) {
     setDeferredCommandOutputText(entry, body, content, stats);
+    if (defaultExpanded) renderDeferredCommandOutputText(entry);
   } else if (canFetchFull) {
-    body.textContent = content
-      ? 'Preview loaded; expand to fetch full output.'
-      : 'Expand to fetch full output.';
+    if (defaultExpanded) {
+      // Open by default: show the local preview now; the lazy store stays
+      // wired, so collapsing and re-expanding fetches the full output.
+      appendCommandOutputText(body, content);
+      const note = document.createElement('span');
+      note.className = 'command-output-truncation-note';
+      note.textContent = 'Preview shown — collapse and expand to fetch the full output.';
+      body.appendChild(note);
+    } else {
+      body.textContent = content
+        ? 'Preview loaded; expand to fetch full output.'
+        : 'Expand to fetch full output.';
+    }
     _lazyCommandOutputStore.set(entry, { c, body, loaded: false, loading: false });
   }
   const toggle = document.createElement('span');

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -1609,6 +1609,7 @@ function registerCommandOutputCloneView(group, clone) {
     entry: clone,
     summary: clone.querySelector('.command-output-summary'),
     body: clone.querySelector('.command-output-body'),
+    tail: clone.querySelector('.command-output-tail'),
     loaded: false,
     loading: false,
   };
@@ -1617,12 +1618,40 @@ function registerCommandOutputCloneView(group, clone) {
   if (!Array.isArray(group.clones)) group.clones = [];
   group.clones.push(view);
   view.summary.innerHTML = group.summary.innerHTML;
+  if (view.tail) view.tail.textContent = group.tail?.textContent || '';
   clone.classList.toggle('finalized', group.finalized);
   clone.classList.toggle('expanded', group.entry.classList.contains('expanded'));
   if (group.finalized) {
-    view.body.innerHTML = '';
+    // Re-fetchable output starts empty (lazy-loaded on expand); output with
+    // no persisted ids keeps whatever the clone carried — it is the only copy.
+    if (group.outputIds.length) {
+      view.body.innerHTML = '';
+    } else {
+      view.loaded = view.body.childElementCount > 0;
+    }
   }
   return view;
+}
+
+// Session scope for a log command — the same `targetSid || sid || 'global'`
+// prefix commandOutputGroupKey embeds (keep the two in lockstep). Groups
+// store it so finalize can sweep "every active group of THIS session"
+// without string-parsing keys.
+function commandOutputSessionScope(c) {
+  const sid = String(c?.session_id || '').trim();
+  const targetSid = sid ? sessionWindowTargetForLogSession(sid) : '';
+  return targetSid || sid || 'global';
+}
+
+// The Activity-tab verbosity dropdown doubles as the output-visibility
+// power knob: at Verbose/Debug, command-output groups default to
+// expanded; Normal keeps them collapsed to their summary row. Read live
+// (not cached) so finalize honors the level at the moment it runs.
+function commandOutputDefaultExpanded() {
+  const level = document.getElementById('verbosity-select')?.value
+    || localStorage.getItem(VERBOSITY_KEY)
+    || 'normal';
+  return level === 'verbose' || level === 'debug';
 }
 
 function commandOutputGroupKey(c) {
@@ -1676,6 +1705,43 @@ function appendCommandOutputText(body, text) {
   code.innerHTML = highlightCommandOutput(text);
   pre.appendChild(code);
   body.appendChild(pre);
+}
+
+// ── Live streaming tail ──
+// While a group streams (created, not yet finalized) and sits collapsed,
+// a small dim region under the summary shows the LAST few output lines —
+// proof the command is alive without the full body. CSS hides it once the
+// group is expanded or finalized; finalize also empties it.
+const COMMAND_OUTPUT_TAIL_LINES = 3;
+const COMMAND_OUTPUT_TAIL_LINE_CHARS = 240;
+const COMMAND_OUTPUT_TAIL_BUFFER_CHARS = 4096;
+
+function updateCommandOutputTail(group, text) {
+  if (!group?.tail) return;
+  const merged = (group.tailText || '') + String(text || '');
+  group.tailText = merged.length > COMMAND_OUTPUT_TAIL_BUFFER_CHARS
+    ? merged.slice(-COMMAND_OUTPUT_TAIL_BUFFER_CHARS)
+    : merged;
+  const lines = group.tailText.replace(/\r/g, '').split('\n').filter(line => line.trim() !== '');
+  const rendered = lines
+    .slice(-COMMAND_OUTPUT_TAIL_LINES)
+    .map(line => line.length > COMMAND_OUTPUT_TAIL_LINE_CHARS
+      ? '…' + line.slice(-COMMAND_OUTPUT_TAIL_LINE_CHARS)
+      : line)
+    .join('\n');
+  group.tail.textContent = rendered;
+  for (const view of commandOutputCloneViews(group)) {
+    if (view.tail) view.tail.textContent = rendered;
+  }
+}
+
+function clearCommandOutputTail(group) {
+  if (!group) return;
+  group.tailText = '';
+  if (group.tail) group.tail.textContent = '';
+  for (const view of commandOutputCloneViews(group)) {
+    if (view.tail) view.tail.textContent = '';
+  }
 }
 
 async function appendCommandOutputTextProgressive(body, text, chunkChars = 65536) {
@@ -1810,11 +1876,23 @@ function appendCommandOutputChunk(group, c) {
   updateCommandOutputSummary(group);
   if (!group.finalized && text && !processingLogReplay) {
     appendCommandOutputText(group.body, text);
+    updateCommandOutputTail(group, text);
     for (const view of commandOutputCloneViews(group)) {
       if (view.entry.classList.contains('expanded')) {
         appendCommandOutputText(view.body, text);
       }
     }
+  }
+  if (!processingLogReplay && !group.itemScoped) {
+    // Uncorrelated (no item_id) output rides the native batch contract:
+    // one wire event carries the COMPLETE stdout+stderr of a finished
+    // command batch, delivered as one synchronous UiCommand burst. A
+    // microtask after that burst is therefore the command's own
+    // completion — finalize deterministically instead of waiting for
+    // whatever entry happens to arrive next. Item-scoped (external)
+    // groups stream across many wire events and finalize on their
+    // session's next non-output entry / round completion instead.
+    scheduleCommandOutputBatchFinalize(group);
   }
   for (const [win, shouldFollow] of sessionScrollStates.entries()) {
     applySessionWindowOutputScroll(win, shouldFollow);
@@ -1826,15 +1904,24 @@ function renderCommandOutputEntry(c) {
   let activeCommandOutputGroup = activeCommandOutputGroups.get(groupKey);
   if (!activeCommandOutputGroup || activeCommandOutputGroup.finalized) {
     const groupId = 'cmdout-' + (++commandOutputGroupSeq);
-    const { entry } = createLogScaffold(c, 'command-output-group expanded');
+    // Deterministic default: born COLLAPSED (like the replay lane) unless
+    // the verbosity knob says outputs default open. The streaming tail
+    // below keeps a collapsed live group visibly alive.
+    const { entry } = createLogScaffold(
+      c,
+      'command-output-group' + (commandOutputDefaultExpanded() ? ' expanded' : '')
+    );
     entry.dataset.outputGroupId = groupId;
     const wrap = document.createElement('span');
     wrap.className = 'log-content command-output-wrap';
     const summary = document.createElement('span');
     summary.className = 'command-output-summary';
+    const tail = document.createElement('span');
+    tail.className = 'command-output-tail';
     const body = document.createElement('span');
     body.className = 'command-output-body';
     wrap.appendChild(summary);
+    wrap.appendChild(tail);
     wrap.appendChild(body);
     const toggle = document.createElement('span');
     toggle.className = 'collapse-toggle';
@@ -1851,8 +1938,15 @@ function renderCommandOutputEntry(c) {
     const group = {
       id: groupId,
       key: groupKey,
+      sessionScope: commandOutputSessionScope(c),
+      // item-correlated groups stream across wire events (external
+      // backends); uncorrelated ones complete within one event (native
+      // batch contract) — see appendCommandOutputChunk.
+      itemScoped: !!itemId,
       entry,
       summary,
+      tail,
+      tailText: '',
       body,
       outputIds: [],
       outputIdSet: new Set(),
@@ -1861,6 +1955,7 @@ function renderCommandOutputEntry(c) {
       bytes: 0,
       warns: 0,
       finalized: false,
+      finalizeQueued: false,
       loaded: false,
       loading: false,
       clones: [],
@@ -1881,36 +1976,68 @@ function renderCommandOutputEntry(c) {
   if (!concurrentLogDetachedFragment && autoScroll && stream) scheduleMainLogScrollToBottom();
 }
 
+// Uncorrelated (native-batch) groups finalize one microtask after the
+// synchronous UiCommand burst that streamed them — the wire event that
+// carried the chunks IS the command's completion (stdout+stderr arrive
+// together once the batch finished). Armed per chunk, idempotent.
+function scheduleCommandOutputBatchFinalize(group) {
+  if (!group || group.finalized || group.finalizeQueued) return;
+  group.finalizeQueued = true;
+  queueMicrotask(() => {
+    group.finalizeQueued = false;
+    finalizeCommandOutputGroup(group);
+  });
+}
+
 function finalizeCommandOutputGroup(group) {
   if (!group || group.finalized) return;
   group.finalized = true;
   group.entry.classList.add('finalized');
+  // The streaming tail retires with the stream — the collapsed summary
+  // row carries the group from here.
+  clearCommandOutputTail(group);
   // A group the USER opened stays open with its streamed body — yanking
   // the output shut mid-read because the command happened to finish was
-  // the "collapsible doesn't work" experience. Auto-expanded (streaming)
-  // groups still fold to their summary line.
-  if (group.userExpanded && group.entry.classList.contains('expanded')) {
+  // the "collapsible doesn't work" experience. At Verbose/Debug the
+  // default itself is open, so auto-expanded groups keep their body too.
+  // Only groups whose body actually holds the stream stay open — replay
+  // recreations stream no DOM text, and an open-but-empty body lies.
+  const defaultExpanded = commandOutputDefaultExpanded();
+  // Output with no persisted ids cannot be re-fetched on expand — keep
+  // the streamed body (hidden while collapsed) instead of destroying the
+  // only copy.
+  const preserveBody = group.outputIds.length === 0;
+  const keepOpen = group.entry.classList.contains('expanded')
+    && (group.userExpanded || defaultExpanded)
+    && group.body.childElementCount > 0;
+  if (keepOpen) {
     group.loaded = true;
     group.loading = false;
   } else {
     group.entry.classList.remove('expanded');
-    group.body.innerHTML = '';
-    group.loaded = false;
+    if (!preserveBody) group.body.innerHTML = '';
+    group.loaded = preserveBody && group.body.childElementCount > 0;
     group.loading = false;
   }
   for (const view of commandOutputCloneViews(group)) {
     view.entry.classList.add('finalized');
-    if (view.entry.classList.contains('expanded') && group.userExpanded) {
+    if (view.entry.classList.contains('expanded')
+        && (group.userExpanded || defaultExpanded)
+        && view.body.childElementCount > 0) {
       view.loaded = true;
       view.loading = false;
       continue;
     }
     view.entry.classList.remove('expanded');
-    view.body.innerHTML = '';
-    view.loaded = false;
+    if (!preserveBody) view.body.innerHTML = '';
+    view.loaded = preserveBody && view.body.childElementCount > 0;
     view.loading = false;
   }
-  if (group.key) activeCommandOutputGroups.delete(group.key);
+  // Identity-guarded: a deferred (microtask) finalize must never evict a
+  // NEWER group that re-registered under the same key.
+  if (group.key && activeCommandOutputGroups.get(group.key) === group) {
+    activeCommandOutputGroups.delete(group.key);
+  }
 }
 
 function finalizeActiveCommandOutputGroup(groupKey = null) {
@@ -1924,8 +2051,28 @@ function finalizeActiveCommandOutputGroup(groupKey = null) {
   activeCommandOutputGroups.clear();
 }
 
+// Deterministic cross-command close: any non-output entry rendering for a
+// session means its in-flight command output is done (backends announce
+// the next tool / model text only after the previous command's output was
+// delivered). Exact-key finalize almost never fired for item-correlated
+// groups — the next entry carries a different (or no) item id, so groups
+// stayed open forever purely by timing.
+function finalizeSessionCommandOutputGroups(c) {
+  const scope = commandOutputSessionScope(c);
+  for (const group of Array.from(activeCommandOutputGroups.values())) {
+    if (group.sessionScope === scope) finalizeCommandOutputGroup(group);
+  }
+}
+
 async function loadCommandOutputIntoBody(group, body) {
   if (!group.outputIds.length) {
+    // Nothing persisted to re-fetch: finalize preserved the streamed body
+    // on the main entry in that case — serve expands from it.
+    if (body !== group.body && group.body?.childElementCount) {
+      body.innerHTML = group.body.innerHTML;
+      return;
+    }
+    if (body.childElementCount) return;
     body.textContent = 'Output is not available for lazy loading.';
     return;
   }
@@ -2001,7 +2148,7 @@ async function toggleCommandOutputGroup(group) {
 }
 
 function renderDiffLogEntry(c) {
-  finalizeActiveCommandOutputGroup(commandOutputGroupKey(c));
+  finalizeSessionCommandOutputGroups(c);
   const diffText = diffLogContent(c);
   const parsed = parseUnifiedDiff(diffText);
   const { entry } = createLogScaffold(c, 'diff-log-entry');
@@ -2478,7 +2625,7 @@ function renderLogEntry(c) {
     renderDiffLogEntry(c);
     return;
   }
-  finalizeActiveCommandOutputGroup(commandOutputGroupKey(c));
+  finalizeSessionCommandOutputGroups(c);
   if (shouldSuppressAttachmentReceiptDuplicate(c)) return;
   inferSessionPhaseFromLog(c);
 

--- a/static/app/57-sessions-replay.js
+++ b/static/app/57-sessions-replay.js
@@ -2289,7 +2289,12 @@ function materializeSessionDetailRow(view, row, index) {
 
   const e = row.record;
   if (isSessionWindowCommandOutputRecord(e)) {
-    const outputEntry = buildSessionWindowCommandOutputEntry(e);
+    // The detail pane's own verbosity select is the knob here (retroactive:
+    // changing it re-renders through renderCurrent); the Activity dropdown
+    // governs the live/session-window lanes.
+    const outputEntry = buildSessionWindowCommandOutputEntry(e, {
+      defaultExpanded: detailVerbosity === 'verbose' || detailVerbosity === 'debug',
+    });
     if (!outputEntry) return null;
     outputEntry.dataset.detailRowIndex = String(index);
     return outputEntry;

--- a/static/app/ui2-activity.css
+++ b/static/app/ui2-activity.css
@@ -689,6 +689,34 @@ html.ui-v2 .command-output-group .command-output-body:empty { display: none; }
 /* live groups are collapsible now too (v1 only ever hid finalized
    bodies): a collapsed streaming group keeps receiving text off-screen */
 html.ui-v2 .command-output-group:not(.expanded) .command-output-body { display: none; }
+/* the streaming tail: last few output lines under a collapsed live group —
+   proof of life while it streams. Gone once expanded (the body takes over)
+   or finalized (the summary row is the record). JS keeps it to ~3 trimmed
+   lines; the max-height is a belt against odd content. */
+html.ui-v2 .command-output-group .command-output-tail {
+  display: block;
+  margin-top: 4px;
+  padding-left: 13px;
+  border-left: 2px solid color-mix(in srgb, var(--iris) 32%, transparent);
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-3);
+  white-space: pre;
+  overflow: hidden;
+  max-height: 4.5em;
+}
+html.ui-v2 .command-output-group .command-output-tail:empty { display: none; }
+html.ui-v2 .command-output-group.expanded .command-output-tail,
+html.ui-v2 .command-output-group.finalized .command-output-tail { display: none; }
+/* verbose-opened truncated rows show their local preview plus this hint */
+html.ui-v2 .command-output-group .command-output-truncation-note {
+  display: block;
+  padding: 4px 12px 6px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--text-3);
+}
 html.ui-v2 .command-output-group .command-output-pre {
   margin: 0;
   padding: 8px 12px;


### PR DESCRIPTION
Tool/command output groups in the Activity log rendered expanded or
collapsed purely by timing (#293 regression): the live lane was born
EXPANDED and only folded when some LATER entry happened to match its
exact group key - a command followed by another command (or by nothing)
never folded - while replay/hydration rows were born collapsed.

- Born collapsed everywhere: the live lane drops the baked expanded
  class; both lanes share one deterministic default.
- Streaming tail: while a collapsed group streams, a dim mono region
  under the summary shows the last ~3 output lines (proof of life); it
  retires at finalize/expand. User-expanded groups still stream the
  full body and stay pinned open.
- Finalize on the command's own completion: uncorrelated (native batch)
  groups finalize one microtask after the wire event that delivered
  their complete stdout+stderr; item-correlated (external) groups
  finalize when their session renders its next non-output entry or the
  round completes (done_signal/round_complete/task_complete). The old
  triggers (turn separator, context switch, replay end) remain as
  fallbacks. Finalize is identity-guarded and preserves bodies with no
  persisted output ids (nothing would be re-fetchable on expand).
- True lazy DOM: COMMAND_OUTPUT_EAGER_RENDER_CHAR_LIMIT 24000 -> 0;
  collapsed replay rows never carry hidden full text in the DOM (no
  consumer reads the hidden body: copy uses refs, transcript signatures
  exclude output records, Station reads the pushed event objects).
- Verbosity is the power knob: at Verbose/Debug, output groups default
  to expanded in every lane (Activity dropdown for live/session
  windows; the detail pane's own selector for session detail),
  retroactively via the set_verbosity re-emit / renderCurrent
  re-render. The collapsed summary row always renders at every level.
