### PR TITLE
session-fork: claude-code transcript tree + catalog arm (PR B)

### DIFF
--- a/src/bin/caller/session_fork/claude_tree.rs
+++ b/src/bin/caller/session_fork/claude_tree.rs
@@ -1,0 +1,414 @@
+//! Claude Code transcript tree: the uuid/parentUuid message graph inside a
+//! `~/.claude/projects/**/<uuid>.jsonl` session file.
+//!
+//! Semantics pinned by the session-fork probes (CC 2.1.211,
+//! `tests/skills/session-fork-probes/`): resume walks the chain back from
+//! the TAIL message (legacy `last-prompt` pins are dead), sibling branches
+//! coexist in one file as divergent chains, and a `compact_boundary`
+//! system line with `parentUuid: null` severs the walk (its
+//! `logicalParentUuid` records the pre-compaction chain it replaced).
+
+use std::collections::HashMap;
+use std::io::{self, BufRead};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone)]
+pub(crate) struct ClaudeTreeNode {
+    pub(crate) uuid: String,
+    pub(crate) parent_uuid: Option<String>,
+    /// `user` / `assistant` / `system:<subtype>` / the raw `type` field.
+    pub(crate) kind: String,
+    pub(crate) preview: String,
+    pub(crate) ts: Option<String>,
+    pub(crate) line_no: usize,
+    pub(crate) is_sidechain: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ClaudeCompactBoundary {
+    pub(crate) uuid: String,
+    pub(crate) logical_parent_uuid: Option<String>,
+    pub(crate) line_no: usize,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ClaudeTranscriptTree {
+    pub(crate) nodes: Vec<ClaudeTreeNode>,
+    pub(crate) by_uuid: HashMap<String, usize>,
+    pub(crate) children: HashMap<String, Vec<usize>>,
+    /// The uuid resume would walk back from: the last non-sidechain
+    /// message-bearing line in file order.
+    pub(crate) active_leaf: Option<String>,
+    pub(crate) newest_compact_boundary: Option<ClaudeCompactBoundary>,
+}
+
+impl ClaudeTranscriptTree {
+    pub(crate) fn node(&self, uuid: &str) -> Option<&ClaudeTreeNode> {
+        self.by_uuid.get(uuid).map(|&index| &self.nodes[index])
+    }
+
+    /// `uuid` plus its ancestors, leaf-to-root order. Cycle-safe.
+    pub(crate) fn ancestor_chain(&self, uuid: &str) -> Vec<&ClaudeTreeNode> {
+        let mut chain = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        let mut cursor = Some(uuid.to_string());
+        while let Some(current) = cursor {
+            if !seen.insert(current.clone()) {
+                break;
+            }
+            let Some(node) = self.node(&current) else {
+                break;
+            };
+            chain.push(node);
+            cursor = node.parent_uuid.clone();
+        }
+        chain
+    }
+
+    /// Non-sidechain user/assistant leaves, file order. Sidechain
+    /// children don't count against leaf-ness — a message whose only
+    /// descendants are sidechain work is still a resumable chain tip.
+    pub(crate) fn message_leaves(&self) -> Vec<&ClaudeTreeNode> {
+        self.nodes
+            .iter()
+            .filter(|node| !node.is_sidechain)
+            .filter(|node| node.kind == "user" || node.kind == "assistant")
+            .filter(|node| {
+                self.children
+                    .get(&node.uuid)
+                    .is_none_or(|kids| kids.iter().all(|&index| self.nodes[index].is_sidechain))
+            })
+            .collect()
+    }
+
+    /// Whether a fork anchored at `uuid` keeps only pre-compaction
+    /// history. The transcript is append-only and the boundary replaced
+    /// everything before it, so "written before the newest boundary
+    /// line" is the honest chronological test — it also covers abandoned
+    /// sibling branches rooted in compacted history, which are not on
+    /// the boundary's own ancestor chain. Such forks are still fully
+    /// supported — the chain-slice never includes the boundary — this is
+    /// informational for the UI.
+    pub(crate) fn anchor_is_pre_compaction(&self, uuid: &str) -> bool {
+        let Some(boundary) = &self.newest_compact_boundary else {
+            return false;
+        };
+        self.node(uuid)
+            .is_some_and(|node| node.line_no < boundary.line_no)
+    }
+}
+
+fn node_preview(value: &serde_json::Value) -> String {
+    let message = value.get("message");
+    let text = message
+        .and_then(|message| message.get("content"))
+        .map(|content| match content {
+            serde_json::Value::String(text) => text.clone(),
+            serde_json::Value::Array(blocks) => blocks
+                .iter()
+                .filter_map(|block| block.get("text").and_then(serde_json::Value::as_str))
+                .collect::<Vec<_>>()
+                .join(" "),
+            _ => String::new(),
+        })
+        .unwrap_or_default();
+    let fallback = value
+        .get("content")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    super::fork_point_preview(if text.is_empty() { fallback } else { &text })
+}
+
+pub(crate) fn parse_claude_transcript_tree(path: &Path) -> io::Result<ClaudeTranscriptTree> {
+    let file = std::fs::File::open(path)?;
+    let reader = io::BufReader::new(file);
+    let mut tree = ClaudeTranscriptTree::default();
+
+    for (line_index, line) in reader.lines().enumerate() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        // Torn tails (a live writer mid-append) and foreign lines parse
+        // as errors; both are skipped rather than failing the scan.
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        let Some(uuid) = value
+            .get("uuid")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+        else {
+            continue; // meta lines (ai-title, agent-name, …) carry no uuid
+        };
+        let line_type = value
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+        let subtype = value.get("subtype").and_then(serde_json::Value::as_str);
+        let kind = match (line_type, subtype) {
+            ("system", Some(subtype)) => format!("system:{subtype}"),
+            (other, _) => other.to_string(),
+        };
+        let is_sidechain = value
+            .get("isSidechain")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        let parent_uuid = value
+            .get("parentUuid")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string);
+        let node = ClaudeTreeNode {
+            uuid: uuid.clone(),
+            parent_uuid: parent_uuid.clone(),
+            kind: kind.clone(),
+            preview: node_preview(&value),
+            ts: value
+                .get("timestamp")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+            line_no: line_index + 1,
+            is_sidechain,
+        };
+        let index = tree.nodes.len();
+        tree.nodes.push(node);
+        tree.by_uuid.insert(uuid.clone(), index);
+        if let Some(parent) = parent_uuid {
+            tree.children.entry(parent).or_default().push(index);
+        }
+        if kind == "system:compact_boundary" {
+            tree.newest_compact_boundary = Some(ClaudeCompactBoundary {
+                uuid: uuid.clone(),
+                logical_parent_uuid: value
+                    .get("logicalParentUuid")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string),
+                line_no: line_index + 1,
+            });
+        }
+        if !is_sidechain && (kind == "user" || kind == "assistant") {
+            tree.active_leaf = Some(uuid);
+        }
+    }
+    Ok(tree)
+}
+
+/// Shared (possibly cached) tree scan, copying the managed-context
+/// anchor-scan cache discipline (`managed_context_ops::anchors`): keyed by
+/// (path, len, change stamp), served/cached only when the stamp is
+/// quiescent past the racy-write window, fingerprint re-verified after the
+/// read. CC transcripts reach tens of MB and the catalog + surgery paths
+/// re-read them back to back.
+pub(crate) fn shared_claude_tree_scan(
+    path: &Path,
+) -> io::Result<std::sync::Arc<ClaudeTranscriptTree>> {
+    const SLOTS: usize = 4;
+    const RACY_WINDOW_NANOS: i128 = 2_000_000_000;
+
+    struct CachedTree {
+        path: PathBuf,
+        len: u64,
+        stamp: crate::platform::FileChangeStamp,
+        tree: std::sync::Arc<ClaudeTranscriptTree>,
+    }
+    static CACHE: std::sync::Mutex<Vec<CachedTree>> = std::sync::Mutex::new(Vec::new());
+
+    fn fingerprint(path: &Path) -> io::Result<(u64, Option<crate::platform::FileChangeStamp>)> {
+        let meta = std::fs::metadata(path)?;
+        let stamp = crate::platform::file_change_stamp(path, &meta);
+        Ok((meta.len(), stamp))
+    }
+    fn quiescent(stamp: &crate::platform::FileChangeStamp) -> bool {
+        let now_nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as i128)
+            .unwrap_or(0);
+        stamp
+            .change_signal_unix_nanos()
+            .saturating_add(RACY_WINDOW_NANOS)
+            <= now_nanos
+    }
+
+    let (len, stamp) = fingerprint(path)?;
+    let stamp = stamp.filter(quiescent);
+    if let Some(stamp) = stamp {
+        let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(index) = cache
+            .iter()
+            .position(|entry| entry.len == len && entry.stamp == stamp && entry.path == path)
+        {
+            let hit = cache.remove(index);
+            let tree = std::sync::Arc::clone(&hit.tree);
+            cache.insert(0, hit);
+            return Ok(tree);
+        }
+    }
+    let tree = std::sync::Arc::new(parse_claude_transcript_tree(path)?);
+    if let Some(stamp) = stamp {
+        let unchanged = fingerprint(path).is_ok_and(|after| after == (len, Some(stamp)));
+        if unchanged {
+            let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+            cache.retain(|entry| entry.path != path);
+            cache.insert(
+                0,
+                CachedTree {
+                    path: path.to_path_buf(),
+                    len,
+                    stamp,
+                    tree: std::sync::Arc::clone(&tree),
+                },
+            );
+            cache.truncate(SLOTS);
+        }
+    }
+    Ok(tree)
+}
+
+#[cfg(test)]
+pub(crate) mod test_fixtures {
+    /// One CC transcript line. `parent: None` renders `parentUuid: null`.
+    pub(crate) fn message_line(
+        uuid: &str,
+        parent: Option<&str>,
+        kind: &str,
+        text: &str,
+        sidechain: bool,
+    ) -> String {
+        serde_json::json!({
+            "uuid": uuid,
+            "parentUuid": parent,
+            "type": kind,
+            "isSidechain": sidechain,
+            "sessionId": "fixture-session",
+            "timestamp": "2026-07-16T00:00:00.000Z",
+            "message": {"role": kind, "content": text},
+        })
+        .to_string()
+    }
+
+    pub(crate) fn boundary_line(uuid: &str, logical_parent: &str) -> String {
+        serde_json::json!({
+            "uuid": uuid,
+            "parentUuid": null,
+            "logicalParentUuid": logical_parent,
+            "type": "system",
+            "subtype": "compact_boundary",
+            "isSidechain": false,
+            "sessionId": "fixture-session",
+            "timestamp": "2026-07-16T00:00:00.000Z",
+            "content": "Conversation compacted",
+            "compactMetadata": {"trigger": "auto", "preTokens": 1000, "postTokens": 100},
+        })
+        .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_fixtures::*;
+    use super::*;
+
+    fn write_transcript(lines: &[String]) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir
+            .path()
+            .join("11111111-0000-0000-0000-000000000000.jsonl");
+        std::fs::write(&path, lines.join("\n") + "\n").expect("write");
+        (dir, path)
+    }
+
+    #[test]
+    fn linear_chain_parses_with_tail_active_leaf() {
+        let (_dir, path) = write_transcript(&[
+            "{\"type\":\"ai-title\",\"aiTitle\":\"t\",\"sessionId\":\"s\"}".to_string(),
+            message_line("u1", None, "user", "round one", false),
+            message_line("a1", Some("u1"), "assistant", "answer one", false),
+            message_line("u2", Some("a1"), "user", "round two", false),
+        ]);
+        let tree = parse_claude_transcript_tree(&path).expect("tree");
+        assert_eq!(tree.nodes.len(), 3);
+        assert_eq!(tree.active_leaf.as_deref(), Some("u2"));
+        let chain: Vec<&str> = tree
+            .ancestor_chain("u2")
+            .iter()
+            .map(|node| node.uuid.as_str())
+            .collect();
+        assert_eq!(chain, vec!["u2", "a1", "u1"]);
+    }
+
+    #[test]
+    fn sibling_branches_yield_inactive_leaves() {
+        let (_dir, path) = write_transcript(&[
+            message_line("u1", None, "user", "root", false),
+            message_line("a1", Some("u1"), "assistant", "branch A", false),
+            message_line("a2", Some("u1"), "assistant", "branch B", false),
+        ]);
+        let tree = parse_claude_transcript_tree(&path).expect("tree");
+        assert_eq!(tree.active_leaf.as_deref(), Some("a2"));
+        let leaves: Vec<&str> = tree
+            .message_leaves()
+            .iter()
+            .map(|node| node.uuid.as_str())
+            .collect();
+        assert_eq!(leaves, vec!["a1", "a2"]);
+    }
+
+    #[test]
+    fn compact_boundary_severs_walk_and_marks_pre_compaction() {
+        let (_dir, path) = write_transcript(&[
+            message_line("u1", None, "user", "old round", false),
+            message_line("a1", Some("u1"), "assistant", "old answer", false),
+            boundary_line("b1", "a1"),
+            message_line("u2", Some("b1"), "user", "post-compact round", false),
+        ]);
+        let tree = parse_claude_transcript_tree(&path).expect("tree");
+        assert_eq!(tree.active_leaf.as_deref(), Some("u2"));
+        // The walk from the active leaf stops at the boundary's null parent.
+        let chain: Vec<&str> = tree
+            .ancestor_chain("u2")
+            .iter()
+            .map(|node| node.uuid.as_str())
+            .collect();
+        assert_eq!(chain, vec!["u2", "b1"]);
+        assert!(tree.anchor_is_pre_compaction("a1"));
+        assert!(tree.anchor_is_pre_compaction("u1"));
+        assert!(!tree.anchor_is_pre_compaction("u2"));
+    }
+
+    #[test]
+    fn sidechains_are_excluded_from_leaves_and_active_leaf() {
+        let (_dir, path) = write_transcript(&[
+            message_line("u1", None, "user", "main", false),
+            message_line("s1", Some("u1"), "assistant", "sidechain work", true),
+        ]);
+        let tree = parse_claude_transcript_tree(&path).expect("tree");
+        assert_eq!(tree.active_leaf.as_deref(), Some("u1"));
+        let leaves: Vec<&str> = tree
+            .message_leaves()
+            .iter()
+            .map(|node| node.uuid.as_str())
+            .collect();
+        assert_eq!(leaves, vec!["u1"]);
+    }
+
+    #[test]
+    fn torn_tail_is_tolerated() {
+        let mut lines = vec![
+            message_line("u1", None, "user", "round", false),
+            message_line("a1", Some("u1"), "assistant", "answer", false),
+        ];
+        lines.push("{\"uuid\":\"torn".to_string());
+        let (_dir, path) = write_transcript(&lines);
+        let tree = parse_claude_transcript_tree(&path).expect("tree");
+        assert_eq!(tree.nodes.len(), 2);
+        assert_eq!(tree.active_leaf.as_deref(), Some("a1"));
+    }
+
+    #[test]
+    fn shared_scan_returns_parsed_tree() {
+        let (_dir, path) = write_transcript(&[message_line("u1", None, "user", "round", false)]);
+        let tree = shared_claude_tree_scan(&path).expect("scan");
+        assert_eq!(tree.nodes.len(), 1);
+    }
+}

--- a/src/bin/caller/session_fork/claude_tree.rs
+++ b/src/bin/caller/session_fork/claude_tree.rs
@@ -19,16 +19,8 @@ pub(crate) struct ClaudeTreeNode {
     /// `user` / `assistant` / `system:<subtype>` / the raw `type` field.
     pub(crate) kind: String,
     pub(crate) preview: String,
-    pub(crate) ts: Option<String>,
     pub(crate) line_no: usize,
     pub(crate) is_sidechain: bool,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct ClaudeCompactBoundary {
-    pub(crate) uuid: String,
-    pub(crate) logical_parent_uuid: Option<String>,
-    pub(crate) line_no: usize,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -39,7 +31,9 @@ pub(crate) struct ClaudeTranscriptTree {
     /// The uuid resume would walk back from: the last non-sidechain
     /// message-bearing line in file order.
     pub(crate) active_leaf: Option<String>,
-    pub(crate) newest_compact_boundary: Option<ClaudeCompactBoundary>,
+    /// 1-based line of the newest `compact_boundary` system line, the
+    /// chronological pre/post-compaction divide.
+    pub(crate) newest_compact_boundary_line: Option<usize>,
 }
 
 impl ClaudeTranscriptTree {
@@ -90,11 +84,11 @@ impl ClaudeTranscriptTree {
     /// supported — the chain-slice never includes the boundary — this is
     /// informational for the UI.
     pub(crate) fn anchor_is_pre_compaction(&self, uuid: &str) -> bool {
-        let Some(boundary) = &self.newest_compact_boundary else {
+        let Some(boundary_line) = self.newest_compact_boundary_line else {
             return false;
         };
         self.node(uuid)
-            .is_some_and(|node| node.line_no < boundary.line_no)
+            .is_some_and(|node| node.line_no < boundary_line)
     }
 }
 
@@ -164,10 +158,6 @@ pub(crate) fn parse_claude_transcript_tree(path: &Path) -> io::Result<ClaudeTran
             parent_uuid: parent_uuid.clone(),
             kind: kind.clone(),
             preview: node_preview(&value),
-            ts: value
-                .get("timestamp")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_string),
             line_no: line_index + 1,
             is_sidechain,
         };
@@ -178,14 +168,7 @@ pub(crate) fn parse_claude_transcript_tree(path: &Path) -> io::Result<ClaudeTran
             tree.children.entry(parent).or_default().push(index);
         }
         if kind == "system:compact_boundary" {
-            tree.newest_compact_boundary = Some(ClaudeCompactBoundary {
-                uuid: uuid.clone(),
-                logical_parent_uuid: value
-                    .get("logicalParentUuid")
-                    .and_then(serde_json::Value::as_str)
-                    .map(str::to_string),
-                line_no: line_index + 1,
-            });
+            tree.newest_compact_boundary_line = Some(line_index + 1);
         }
         if !is_sidechain && (kind == "user" || kind == "assistant") {
             tree.active_leaf = Some(uuid);

--- a/src/bin/caller/session_fork/fork_points.rs
+++ b/src/bin/caller/session_fork/fork_points.rs
@@ -370,7 +370,7 @@ pub(crate) fn claude_fork_points(
         ));
     }
 
-    keyed.sort_by(|a, b| b.0.cmp(&a.0));
+    keyed.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     let points: Vec<ForkPoint> = keyed.into_iter().map(|(_, point)| point).collect();
 
     let mut catalog = ForkPointCatalog {

--- a/src/bin/caller/session_fork/fork_points.rs
+++ b/src/bin/caller/session_fork/fork_points.rs
@@ -62,6 +62,8 @@ pub(crate) fn codex_fork_points_from_parts(
                 seq: None,
                 item_id: None,
                 position: None,
+                message_uuid: None,
+                pre_compaction: false,
                 preview: fork_point_preview(&turn.text),
                 eligible: true,
                 eligibility_reasons: Vec::new(),
@@ -100,6 +102,8 @@ pub(crate) fn codex_fork_points_from_parts(
                 seq: None,
                 item_id: Some(entry.item_id.clone()),
                 position: Some(entry.position_hint),
+                message_uuid: None,
+                pre_compaction: false,
                 preview: fork_point_preview(&entry.summary),
                 eligible,
                 eligibility_reasons: reasons,
@@ -222,6 +226,8 @@ pub(crate) fn native_fork_points(
             seq: Some(last.seq),
             item_id: None,
             position: None,
+            message_uuid: None,
+            pre_compaction: false,
             preview: format!("{}: {}", last.role, last.preview),
             eligible,
             eligibility_reasons: if eligible {
@@ -248,6 +254,8 @@ pub(crate) fn native_fork_points(
             seq: Some(prev.seq),
             item_id: None,
             position: None,
+            message_uuid: None,
+            pre_compaction: false,
             preview: lines[msg_index].preview.clone(),
             eligible,
             eligibility_reasons: if eligible {
@@ -259,6 +267,128 @@ pub(crate) fn native_fork_points(
         });
     }
 
+    page_fork_points(&mut catalog, points, query);
+    Ok(catalog)
+}
+
+/// Fork points for a Claude Code session, derived from its transcript
+/// tree: the active head, inactive sibling branch tips, and user-turn
+/// boundaries on the active chain. Every anchor is a chain-slice target
+/// (the fork keeps the anchor's ancestor chain), so pre-compaction
+/// anchors are fully eligible and only flagged informationally.
+pub(crate) fn claude_fork_points(
+    session_id: &str,
+    backend_session_id: &str,
+    transcript_path: &Path,
+    query: &ForkPointQuery,
+) -> io::Result<ForkPointCatalog> {
+    let tree = shared_claude_tree_scan(transcript_path)?;
+    let mut keyed: Vec<(usize, ForkPoint)> = Vec::new();
+
+    if let Some(leaf_uuid) = tree.active_leaf.as_deref() {
+        if let Some(leaf) = tree.node(leaf_uuid) {
+            keyed.push((
+                leaf.line_no,
+                ForkPoint {
+                    id: "head".to_string(),
+                    kind: "head",
+                    granularity: "message",
+                    turn: None,
+                    seq: None,
+                    item_id: None,
+                    position: None,
+                    message_uuid: Some(leaf.uuid.clone()),
+                    pre_compaction: false,
+                    preview: format!("{}: {}", leaf.kind, leaf.preview),
+                    eligible: true,
+                    eligibility_reasons: Vec::new(),
+                    effective_cut: None,
+                },
+            ));
+        }
+
+        // User-turn boundaries on the active chain: forking "before this
+        // user turn" keeps the chain through the turn's parent.
+        let chain = tree.ancestor_chain(leaf_uuid);
+        let user_turns = chain
+            .iter()
+            .rev()
+            .filter(|node| node.kind == "user")
+            .count() as u32;
+        let mut ordinal = user_turns;
+        for node in &chain {
+            if node.kind != "user" {
+                continue;
+            }
+            let turn_ordinal = ordinal;
+            ordinal = ordinal.saturating_sub(1);
+            let Some(parent_uuid) = node.parent_uuid.as_deref() else {
+                continue; // the first turn: keeping nothing has no value
+            };
+            keyed.push((
+                node.line_no,
+                ForkPoint {
+                    id: format!("msg:{parent_uuid}"),
+                    kind: "message",
+                    granularity: "message",
+                    turn: Some(turn_ordinal.saturating_sub(1)),
+                    seq: None,
+                    item_id: None,
+                    position: None,
+                    message_uuid: Some(parent_uuid.to_string()),
+                    pre_compaction: tree.anchor_is_pre_compaction(parent_uuid),
+                    preview: node.preview.clone(),
+                    eligible: true,
+                    eligibility_reasons: Vec::new(),
+                    effective_cut: None,
+                },
+            ));
+        }
+    }
+
+    for tip in tree.message_leaves() {
+        if Some(tip.uuid.as_str()) == tree.active_leaf.as_deref() {
+            continue;
+        }
+        keyed.push((
+            tip.line_no,
+            ForkPoint {
+                id: format!("tip:{}", tip.uuid),
+                kind: "branch-tip",
+                granularity: "message",
+                turn: None,
+                seq: None,
+                item_id: None,
+                position: None,
+                message_uuid: Some(tip.uuid.clone()),
+                pre_compaction: tree.anchor_is_pre_compaction(&tip.uuid),
+                preview: format!("{}: {}", tip.kind, tip.preview),
+                eligible: true,
+                eligibility_reasons: Vec::new(),
+                effective_cut: None,
+            },
+        ));
+    }
+
+    keyed.sort_by(|a, b| b.0.cmp(&a.0));
+    let points: Vec<ForkPoint> = keyed.into_iter().map(|(_, point)| point).collect();
+
+    let mut catalog = ForkPointCatalog {
+        session_id: session_id.to_string(),
+        source: "claude-code".to_string(),
+        backend_session_id: Some(backend_session_id.to_string()),
+        supported: true,
+        unsupported_reason: None,
+        notes: vec![
+            "anchors chain-slice the transcript: a fork keeps the anchor's ancestor chain in a new session file".to_string(),
+            "pre_compaction anchors fork with full pre-compaction history (the slice omits the compact boundary)".to_string(),
+        ],
+        total: 0,
+        offset: 0,
+        limit: 0,
+        next_offset: None,
+        fork_points: Vec::new(),
+    };
     page_fork_points(&mut catalog, points, query);
     Ok(catalog)
 }
@@ -511,5 +641,74 @@ mod tests {
         assert_eq!(catalog.total, 4);
         assert_eq!(catalog.fork_points.len(), 2);
         assert_eq!(catalog.next_offset, Some(3));
+    }
+
+    fn write_claude_transcript(lines: &[String]) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir
+            .path()
+            .join("22222222-0000-0000-0000-000000000000.jsonl");
+        std::fs::write(&path, lines.join("\n") + "\n").expect("write");
+        (dir, path)
+    }
+
+    #[test]
+    fn claude_points_cover_head_turns_and_branch_tips() {
+        use crate::session_fork::test_fixtures::message_line;
+        let (_dir, path) = write_claude_transcript(&[
+            message_line("u1", None, "user", "round one", false),
+            message_line("a1", Some("u1"), "assistant", "answer one", false),
+            message_line("a1b", Some("u1"), "assistant", "abandoned sibling", false),
+            message_line("u2", Some("a1b"), "user", "round two", false),
+            message_line("a2", Some("u2"), "assistant", "answer two", false),
+        ]);
+        let catalog =
+            claude_fork_points("wrapper", "backend-id", &path, &ForkPointQuery::default())
+                .expect("catalog");
+        assert!(catalog.supported);
+        let ids: Vec<&str> = catalog
+            .fork_points
+            .iter()
+            .map(|point| point.id.as_str())
+            .collect();
+        // head (a2), before round two (anchor a1b), branch tip (a1),
+        // newest-first by transcript line.
+        assert_eq!(ids, vec!["head", "msg:a1b", "tip:a1"]);
+        assert_eq!(catalog.fork_points[1].message_uuid.as_deref(), Some("a1b"));
+        assert_eq!(catalog.fork_points[1].preview, "round two");
+        assert!(catalog.fork_points.iter().all(|point| point.eligible));
+    }
+
+    #[test]
+    fn claude_pre_compaction_anchors_are_flagged_and_eligible() {
+        use crate::session_fork::test_fixtures::{boundary_line, message_line};
+        // Append-only chronology: the abandoned pre-compact sibling was
+        // written before the compaction happened.
+        let (_dir, path) = write_claude_transcript(&[
+            message_line("u1", None, "user", "old round", false),
+            message_line("a1", Some("u1"), "assistant", "old answer", false),
+            message_line("tip", Some("a1"), "assistant", "pre-compact tip", false),
+            boundary_line("b1", "a1"),
+            message_line("u2", Some("b1"), "user", "post-compact round", false),
+            message_line("a2", Some("u2"), "assistant", "post answer", false),
+        ]);
+        let catalog =
+            claude_fork_points("wrapper", "backend-id", &path, &ForkPointQuery::default())
+                .expect("catalog");
+        let tip = catalog
+            .fork_points
+            .iter()
+            .find(|point| point.id == "tip:tip")
+            .expect("pre-compact tip listed");
+        assert!(tip.pre_compaction);
+        assert!(tip.eligible);
+        // The post-compact turn's anchor is the boundary itself — not
+        // flagged pre-compaction.
+        let post = catalog
+            .fork_points
+            .iter()
+            .find(|point| point.id == "msg:b1")
+            .expect("post-compact turn boundary listed");
+        assert!(!post.pre_compaction);
     }
 }

--- a/src/bin/caller/session_fork/mod.rs
+++ b/src/bin/caller/session_fork/mod.rs
@@ -21,7 +21,9 @@
 //!   chain, including inactive sibling branch tips (a follow-up phase; the
 //!   catalog reports `supported: false` until the tree parser lands).
 
+mod claude_tree;
 mod fork_points;
+pub(crate) use claude_tree::*;
 pub(crate) use fork_points::*;
 
 use serde::Serialize;
@@ -50,6 +52,15 @@ pub(crate) struct ForkPoint {
     /// Codex only: cut position relative to the item (`before`/`after`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) position: Option<&'static str>,
+    /// Claude Code only: the transcript message uuid the fork keeps
+    /// history through (the chain-slice anchor).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) message_uuid: Option<String>,
+    /// Claude Code only: the anchor sits on history replaced by the
+    /// newest compact boundary. Informational — the chain-slice fork
+    /// omits the boundary and keeps full pre-compaction history.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub(crate) pre_compaction: bool,
     pub(crate) preview: String,
     pub(crate) eligible: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/src/bin/caller/web_gateway/routes_fork_points.rs
+++ b/src/bin/caller/web_gateway/routes_fork_points.rs
@@ -8,7 +8,7 @@
 
 use super::*;
 use crate::session_fork::{
-    codex_fork_points, native_fork_points, ForkPointCatalog, ForkPointQuery,
+    claude_fork_points, codex_fork_points, native_fork_points, ForkPointCatalog, ForkPointQuery,
     FORK_POINT_DEFAULT_LIMIT,
 };
 use std::io;
@@ -118,8 +118,8 @@ fn resolve_fork_point_catalog(
     {
         return codex_fork_points(session_id, session_id, &rollout, query).map(Some);
     }
-    if find_claude_session_file(home, session_id).is_some() {
-        return Ok(Some(claude_fork_points_stub(session_id, session_id)));
+    if let Some(transcript) = find_claude_session_file(home, session_id) {
+        return claude_fork_points(session_id, session_id, &transcript, query).map(Some);
     }
     Ok(None)
 }
@@ -144,7 +144,15 @@ fn external_fork_point_catalog(
                 )),
             }
         }
-        "claude-code" => Ok(claude_fork_points_stub(session_id, backend_id)),
+        "claude-code" => match find_claude_session_file(home, backend_id) {
+            Some(transcript) => claude_fork_points(session_id, backend_id, &transcript, query),
+            None => Ok(ForkPointCatalog::unsupported(
+                session_id,
+                "claude-code",
+                Some(backend_id),
+                "transcript not found under the claude session store",
+            )),
+        },
         other => Ok(ForkPointCatalog::unsupported(
             session_id,
             other,
@@ -152,15 +160,6 @@ fn external_fork_point_catalog(
             &format!("fork points are not supported for {other} sessions yet"),
         )),
     }
-}
-
-fn claude_fork_points_stub(session_id: &str, backend_id: &str) -> ForkPointCatalog {
-    ForkPointCatalog::unsupported(
-        session_id,
-        "claude-code",
-        Some(backend_id),
-        "claude-code fork points land with the transcript tree parser (follow-up phase)",
-    )
 }
 
 #[cfg(test)]
@@ -260,14 +259,20 @@ mod tests {
     }
 
     #[test]
-    fn claude_session_reports_follow_up_stub() {
+    fn claude_session_resolves_to_message_catalog() {
+        use crate::session_fork::test_fixtures::message_line;
         let home = tempfile::tempdir().expect("home");
         let codex_root = home.path().join(".codex");
         let project = home.path().join(".claude").join("projects").join("-tmp-x");
         std::fs::create_dir_all(&project).expect("mkdir");
+        let lines = [
+            message_line("u1", None, "user", "round one", false),
+            message_line("a1", Some("u1"), "assistant", "answer", false),
+            message_line("u2", Some("a1"), "user", "round two", false),
+        ];
         std::fs::write(
             project.join("cc11cc11-0000-0000-0000-000000000000.jsonl"),
-            "{\"type\":\"user\",\"sessionId\":\"cc11cc11-0000-0000-0000-000000000000\"}\n",
+            lines.join("\n") + "\n",
         )
         .expect("transcript");
         let (status, body) = response_json(session_fork_points_response_with_roots(
@@ -277,7 +282,14 @@ mod tests {
         ));
         assert_eq!(status, 200);
         assert_eq!(body["source"], "claude-code");
-        assert_eq!(body["supported"], false);
+        assert_eq!(body["supported"], true);
+        let ids: Vec<&str> = body["fork_points"]
+            .as_array()
+            .expect("points")
+            .iter()
+            .filter_map(|point| point["id"].as_str())
+            .collect();
+        assert_eq!(ids, vec!["head", "msg:a1"]);
     }
 
     #[test]


### PR DESCRIPTION
Phase B of the fork-session-from-any-anchor program (#353 probes, #354 catalog).

Adds `session_fork/claude_tree.rs` — the CC transcript's uuid/parentUuid message graph (sibling branches, tail-derived active leaf per the 2.1.211 resume-leaf rule the probes pinned, newest `compact_boundary`, sidechain-aware leaves, torn-tail tolerance) behind a shared 4-slot scan cache with the same fingerprint + racy-write quiescence discipline as the managed-context anchor scan.

`claude_fork_points` lists the head, active-chain user-turn boundaries, and inactive sibling **branch tips** as chain-slice anchors; anchors preceding the newest compact boundary are `pre_compaction`-flagged but fully eligible (the chain-slice omits the boundary, so such forks resume with full pre-compaction history and normal auto-compaction). The `/api/session/{id}/fork-points` claude-code arm now serves the real catalog.

Tests: 11 new hermetic units (fixture transcripts incl. sibling branches, boundary chronology, sidechain exclusion, torn tail); the sidechain-leaf and pre-compaction-branch cases were bugs the fixtures caught pre-landing. Battery: fmt clean, clippy clean, targeted suites 23/23; full-suite timeouts are the pre-existing `mcp::events` slow family under parallel load (pass solo, present on main).