### PR TITLE
memory: P1 service core — ephemeral D0-A plane with propose/search/read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2971,6 +2971,8 @@ dependencies = [
  "landlock",
  "libc",
  "notify",
+ "owner-plane-core",
+ "owner-plane-reducer",
  "p12-keystore",
  "passkey-auth",
  "pem",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,13 @@ name = "intendant-connect"
 path = "src/bin/connect/main.rs"
 
 [dependencies]
+# The vendored owner-plane D0-A kernel (Gate-A stamp 583f421a): the
+# Memory service mints device-signed ops through core's writer and
+# admits them through the reducer's fold. `default-features = false`
+# keeps the reducer's JSON-Schema harness layers out of the daemon
+# build (they gate the corpus tests, not production folds).
+owner-plane-core = { path = "crates/owner-plane-core" }
+owner-plane-reducer = { path = "crates/owner-plane-reducer", default-features = false }
 tokio = { version = "1.0", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/owner-plane-core/src/lib.rs
+++ b/crates/owner-plane-core/src/lib.rs
@@ -7,8 +7,10 @@
 //! path retargeting (the stamped spec + companion live under
 //! `../owner-plane-reducer/corpus/`), and trimming to the writer-side
 //! modules the daemon consumes — the fixture-minting machinery
-//! (`corpus_*`, `tranche`, `scenario`, `surfaces`, `vector`,
-//! `coverage`, `rng`, `bin/mint`) stays on the asset branch.
+//! (`corpus_*`, `tranche`, `surfaces`, `vector`, `coverage`, `rng`,
+//! `bin/mint`) stays on the asset branch. `scenario` (the Appendix B
+//! pinned-policy prelude: B.2/B.3 policy literals + the genesis zone
+//! policy) is kept — services mint under those pinned policies.
 //!
 //! What remains is the spec's writer side: canonical CBOR (§1, E1–E10
 //! writer side), the closed hash-domain inventory (§2), suite-v1
@@ -21,5 +23,6 @@ pub mod cbor;
 pub mod domains;
 pub mod keyschedule;
 pub mod outcomes;
+pub mod scenario;
 pub mod shapes;
 pub mod suite;

--- a/crates/owner-plane-core/src/scenario.rs
+++ b/crates/owner-plane-core/src/scenario.rs
@@ -1,0 +1,261 @@
+//! Scenario prelude — the Appendix B pinned objects every fixture
+//! shares.
+//!
+//! B.2/B.3 are the program's first true cross-validation targets: the
+//! spec pins their canonical byte LENGTHS and `H_policy` hashes, so
+//! the tests here re-derive both from the typed shapes through the
+//! reference encoder — a mismatch is a failing executable trace
+//! (D-200 grade), never something to paper over.
+
+use crate::shapes::memory::{
+    ActorClass, KindsSel, Policy, Relation, Rule, SpaceClassesSel, Verdictname,
+};
+use crate::shapes::{Bytes16, DeadlineFallback, Kind, Spaceclass, Strictness, Zonepolicy};
+
+/// B.1 — the genesis ZonePolicy template instantiated for a zone:
+/// the solo posture (D-28). No `time_witnesses`, no
+/// `grant_epoch_slack`, no `connect_service_key`.
+pub fn genesis_zone_policy(zone_id: Bytes16) -> Zonepolicy {
+    Zonepolicy {
+        zone_id,
+        strictness: Strictness::Strict,
+        deadline_fallback: DeadlineFallback::Budgets,
+        require_cert_deadlines: false,
+        grant_epoch_slack: None,
+        time_witnesses: None,
+        connect_service_key: None,
+    }
+}
+
+fn rule(
+    verdict: Verdictname,
+    kinds: KindsSel,
+    space_classes: SpaceClassesSel,
+    actor_classes: &[ActorClass],
+    relation: Relation,
+) -> Rule {
+    Rule {
+        verdict,
+        kinds,
+        space_classes,
+        actor_classes: actor_classes.to_vec(),
+        relation,
+    }
+}
+
+/// B.2 — the `workflow-v1` status policy, transcribed from the
+/// pinned literal (rule order irrelevant: `policy.rules` is an E7
+/// set; the literal's `actor_classes` member order is already
+/// canonical and is preserved verbatim — E9 writer order).
+pub fn workflow_v1() -> Policy {
+    use ActorClass as A;
+    use KindsSel as K;
+    use Relation as R;
+    use SpaceClassesSel as S;
+    use Verdictname as V;
+    let ep_obs = || K::Kinds(vec![Kind::Episode, Kind::Observation]);
+    let personal_workflow = || S::Classes(vec![Spaceclass::Personal, Spaceclass::Workflow]);
+    let workflow = || S::Classes(vec![Spaceclass::Workflow]);
+    Policy {
+        policy_id: "workflow-v1".into(),
+        version: 1,
+        rules: vec![
+            rule(V::Accept, K::Wildcard, S::Wildcard, &[A::Owner], R::Any),
+            rule(V::Retire, K::Wildcard, S::Wildcard, &[A::Owner], R::Any),
+            rule(
+                V::Dispute,
+                K::Wildcard,
+                S::Wildcard,
+                &[A::Owner, A::SafeHuman],
+                R::Any,
+            ),
+            rule(V::Retract, K::Wildcard, S::Wildcard, &[A::Owner], R::Any),
+            rule(
+                V::Retract,
+                K::Wildcard,
+                S::Wildcard,
+                &[A::Peer, A::Session, A::External, A::SafeHuman],
+                R::Author,
+            ),
+            rule(V::Supersede, K::Wildcard, S::Wildcard, &[A::Owner], R::Any),
+            rule(
+                V::Supersede,
+                K::Wildcard,
+                workflow(),
+                &[A::Session],
+                R::Author,
+            ),
+            rule(V::Declassify, K::Wildcard, S::Wildcard, &[A::Owner], R::Any),
+            rule(
+                V::RaiseClass,
+                K::Wildcard,
+                S::Wildcard,
+                &[A::Owner, A::Session, A::SafeHuman],
+                R::Any,
+            ),
+            rule(
+                V::Accept,
+                ep_obs(),
+                personal_workflow(),
+                &[A::SafeHuman],
+                R::Any,
+            ),
+            rule(V::Accept, ep_obs(), workflow(), &[A::Session], R::SelfP),
+            rule(
+                V::Retire,
+                ep_obs(),
+                personal_workflow(),
+                &[A::SafeHuman],
+                R::Any,
+            ),
+        ],
+    }
+}
+
+/// B.3 — the `owner-v1` status policy: every verdict, all kinds, all
+/// space classes, owner only, relation any.
+pub fn owner_v1() -> Policy {
+    use ActorClass as A;
+    use KindsSel as K;
+    use Relation as R;
+    use SpaceClassesSel as S;
+    use Verdictname as V;
+    let all = [
+        V::Accept,
+        V::Retire,
+        V::Dispute,
+        V::Retract,
+        V::Supersede,
+        V::Declassify,
+        V::RaiseClass,
+    ];
+    Policy {
+        policy_id: "owner-v1".into(),
+        version: 1,
+        rules: all
+            .iter()
+            .map(|v| rule(*v, K::Wildcard, S::Wildcard, &[A::Owner], R::Any))
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cbor;
+    use crate::shapes::{assert_pins, ToValue};
+    // Vendoring adaptation: `vector::hex` stays on the asset branch; a
+    // local equivalent keeps the pin tests verbatim.
+    fn hex(b: &[u8]) -> String {
+        b.iter().map(|x| format!("{x:02x}")).collect()
+    }
+
+    const SPEC_PINS: &[&str] = &[
+        // B.1 — the template's fixed fields.
+        r#"`{ v: 1, zone_id: <genesis zone>, strictness: "strict",
+deadline_fallback: "budgets",
+require_cert_deadlines: false }` (no `time_witnesses` — a solo plane
+has none; Connect time arrives only via explicit policy) — the
+solo posture (D-28)."#,
+        // B.2 — length + hash + the full literal.
+        "**B.2 `workflow-v1`** — the literal canonical object (rules in
+canonical set order; array members canonically sorted). Deterministic
+CBOR encoding: 1133 bytes;",
+        r#"H_policy(workflow-v1) =
+  219b9baced57e8fdc06f56119e25dd02403cc4076cec04448e4957d0fa91dd1c"#,
+        r#"{ v: 1, policy_id: "workflow-v1", version: 1, rules: [
+  { verdict: accept, kinds: "*", space_classes: "*",
+    actor_classes: [owner], relation: any }
+  { verdict: retire, kinds: "*", space_classes: "*",
+    actor_classes: [owner], relation: any }
+  { verdict: dispute, kinds: "*", space_classes: "*",
+    actor_classes: [owner, safe-human], relation: any }
+  { verdict: retract, kinds: "*", space_classes: "*",
+    actor_classes: [owner], relation: any }
+  { verdict: retract, kinds: "*", space_classes: "*",
+    actor_classes: [peer, session, external, safe-human], relation: author }
+  { verdict: supersede, kinds: "*", space_classes: "*",
+    actor_classes: [owner], relation: any }
+  { verdict: supersede, kinds: "*", space_classes: [workflow],
+    actor_classes: [session], relation: author }
+  { verdict: declassify, kinds: "*", space_classes: "*",
+    actor_classes: [owner], relation: any }
+  { verdict: raise_class, kinds: "*", space_classes: "*",
+    actor_classes: [owner, session, safe-human], relation: any }
+  { verdict: accept, kinds: [episode, observation], space_classes: [personal, workflow],
+    actor_classes: [safe-human], relation: any }
+  { verdict: accept, kinds: [episode, observation], space_classes: [workflow],
+    actor_classes: [session], relation: self }
+  { verdict: retire, kinds: [episode, observation], space_classes: [personal, workflow],
+    actor_classes: [safe-human], relation: any }
+] }"#,
+        // B.3 — length + hash + the literal.
+        "**B.3 `owner-v1`** — every verdict, all kinds, all space classes,
+owner only, relation any. Canonical encoding: 571 bytes;",
+        r#"H_policy(owner-v1) =
+  d7d5559a6c3462426cb63eed84b05c569f2571da0cc6b5009edc79910f1e4486"#,
+        r#"{ v: 1, policy_id: "owner-v1", version: 1, rules: [
+  { verdict: accept, kinds: "*", space_classes: "*",
+    actor_classes: [owner], relation: any }
+  { verdict: retire, kinds: "*", space_classes: "*",
+    actor_classes: [owner], relation: any }
+  { verdict: dispute, kinds: "*", space_classes: "*",
+    actor_classes: [owner], relation: any }
+  { verdict: retract, kinds: "*", space_classes: "*",
+    actor_classes: [owner], relation: any }
+  { verdict: supersede, kinds: "*", space_classes: "*",
+    actor_classes: [owner], relation: any }
+  { verdict: declassify, kinds: "*", space_classes: "*",
+    actor_classes: [owner], relation: any }
+  { verdict: raise_class, kinds: "*", space_classes: "*",
+    actor_classes: [owner], relation: any }
+] }"#,
+    ];
+
+    #[test]
+    fn spec_pins_are_verbatim() {
+        assert_pins(SPEC_PINS);
+    }
+
+    /// The B.2 KAT: exact canonical length and pinned H_policy.
+    #[test]
+    fn workflow_v1_pinned_bytes() {
+        let p = workflow_v1();
+        let enc = cbor::encode(&p.to_value()).unwrap();
+        assert_eq!(enc.len(), 1133, "workflow-v1 canonical length");
+        assert_eq!(
+            hex(&p.hash()),
+            "219b9baced57e8fdc06f56119e25dd02403cc4076cec04448e4957d0fa91dd1c"
+        );
+    }
+
+    /// The B.3 KAT: exact canonical length and pinned H_policy.
+    #[test]
+    fn owner_v1_pinned_bytes() {
+        let p = owner_v1();
+        let enc = cbor::encode(&p.to_value()).unwrap();
+        assert_eq!(enc.len(), 571, "owner-v1 canonical length");
+        assert_eq!(
+            hex(&p.hash()),
+            "d7d5559a6c3462426cb63eed84b05c569f2571da0cc6b5009edc79910f1e4486"
+        );
+    }
+
+    #[test]
+    fn genesis_zone_policy_shape() {
+        use crate::shapes::map_keys;
+        let zp = genesis_zone_policy([0x5A; 16]);
+        // The B.1 solo posture: exactly the four fixed fields + v +
+        // zone_id, none of the optional members.
+        assert_eq!(
+            map_keys(&zp.to_value()),
+            [
+                "v",
+                "zone_id",
+                "strictness",
+                "deadline_fallback",
+                "require_cert_deadlines"
+            ]
+        );
+    }
+}

--- a/crates/owner-plane-reducer/src/fold.rs
+++ b/crates/owner-plane-reducer/src/fold.rs
@@ -5209,7 +5209,11 @@ impl State {
     /// bare-writer judgment participates like any other admitted
     /// judgment EXCEPT that its `None` class matches no policy rule
     /// (the D2 ruling: recorded, never counting).
-    pub(crate) fn claim_status(&self, target_hash: &[u8; 32], as_of: u64) -> Option<&'static str> {
+    ///
+    /// Visibility widened `pub(crate)` → `pub` at vendor time: the
+    /// daemon's Memory service derives claim status through this exact
+    /// fold (never a third implementation). No semantic change.
+    pub fn claim_status(&self, target_hash: &[u8; 32], as_of: u64) -> Option<&'static str> {
         self.claim_status_inner(target_hash, as_of, &mut Vec::new())
     }
 
@@ -5393,6 +5397,37 @@ pub fn run_delivery_with_state(
     order: &[String],
 ) -> Result<(Run, State), Unimplemented> {
     run_delivery_full(items, &BTreeMap::new(), order)
+}
+
+/// Vendoring addition (not part of the frozen source): fold the FULL
+/// delivered set once, without materializing [`run_delivery_full`]'s
+/// per-prefix snapshots. Behaviorally identical to that entry's final
+/// snapshot — the fold is set-based and arrival-order-free by
+/// construction (review R1), so the only difference is skipping the
+/// intermediate prefix folds a replaying vector needs and an
+/// append-only service does not. Consistency is pinned by
+/// `fold_set_matches_run_delivery_full`. No semantic change.
+pub fn fold_set(
+    items: &BTreeMap<String, Vec<u8>>,
+    aux: &BTreeMap<String, Vec<u8>>,
+) -> Result<(BTreeMap<String, Verdict>, State), Unimplemented> {
+    let mut group_of: BTreeMap<&String, &String> = BTreeMap::new();
+    {
+        let mut by_bytes: BTreeMap<&[u8], &String> = BTreeMap::new();
+        let mut names: Vec<&String> = items.keys().collect();
+        names.sort();
+        for name in names {
+            let canon = by_bytes.entry(items[name].as_slice()).or_insert(name);
+            group_of.insert(name, canon);
+        }
+    }
+    if items.is_empty() {
+        let mut state = State::default();
+        state.install_aux(aux)?;
+        return Ok((BTreeMap::new(), state));
+    }
+    let order: Vec<String> = items.keys().cloned().collect();
+    canonical_fold(items, aux, &order, &group_of)
 }
 
 /// The full fold entry: `aux` = the vector's HELD context (§5.6
@@ -5905,6 +5940,26 @@ mod tests {
         let run = run_delivery(&items, &["c1".into(), "c2".into()]).unwrap();
         assert_eq!(run.final_verdicts["c1"], Verdict::Admitted);
         assert_eq!(run.final_verdicts["c2"], Verdict::Admitted);
+    }
+
+    /// The vendoring-addition pin: [`fold_set`] must be behaviorally
+    /// identical to [`run_delivery_full`]'s final snapshot — verdicts
+    /// AND derived claim status — on a committed multi-op vector.
+    #[test]
+    fn fold_set_matches_run_delivery_full() {
+        let (items, _) = load("f11-status-owner-accept.json");
+        let order: Vec<String> = items.keys().cloned().collect();
+        let (run, full_state) = run_delivery_full(&items, &BTreeMap::new(), &order).unwrap();
+        let (verdicts, set_state) = fold_set(&items, &BTreeMap::new()).unwrap();
+        assert_eq!(verdicts, run.final_verdicts);
+        for bytes in items.values() {
+            let hash = crate::domains::h("op", bytes);
+            assert_eq!(
+                set_state.claim_status(&hash, u64::MAX),
+                full_state.claim_status(&hash, u64::MAX),
+                "derived status must agree between the two entries"
+            );
+        }
     }
 
     #[test]

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -53,6 +53,11 @@ mod live_audio;
 mod live_audio_types;
 mod mcp;
 mod mcp_client;
+// The P1 Memory service core (ephemeral). Not yet reachable from any
+// surface — the ctl/gateway/tunnel verbs land as the next P1.1 slice;
+// the allow comes off with them.
+#[allow(dead_code)]
+mod memory;
 mod message_search;
 mod peer;
 mod peer_file_transfer;

--- a/src/bin/caller/memory/mod.rs
+++ b/src/bin/caller/memory/mod.rs
@@ -1,0 +1,31 @@
+//! The P1 Memory service — controller-owned, D0-A-format, ephemeral.
+//!
+//! Consumes the vendored owner-plane kernel: operations are minted
+//! device-signed through `owner_plane_core` (the writer side) and
+//! admitted through `owner_plane_reducer`'s fold (the reader side) —
+//! write and admission stay independently implemented (the stamped
+//! differential property), and claim status is derived by the
+//! reducer's §11.2 status fold, never re-implemented here. Every
+//! rejection surfaces the reducer's named outcome/disposition pair
+//! verbatim (the D-203 §C.2 fail-closed contract: never a silent
+//! proceed, never a downgrade).
+//!
+//! **Write bar (ratified — the P1 kickoff brief):** this build is
+//! EPHEMERAL-ONLY. The op log lives in memory and dies with the
+//! daemon; every view is labeled `durability: "ephemeral"`. Durable
+//! local writes unlock only after the Gate-B-lite custody subset, the
+//! P0.5 checkpoint replacement, and the tombed-memory cutover — in
+//! that program order. Do not add persistence here ahead of it.
+//!
+//! This module is deliberately unrelated to the legacy
+//! `store_memory`/`recall_memory`/`.intendant/memory.json` system
+//! (tombed; cutover is a later P1 slice) and reuses none of its
+//! identifiers, so the cutover's exact-denylist CI absence test stays
+//! exact while the two coexist.
+
+pub(crate) mod plane;
+pub(crate) mod service;
+pub(crate) mod types;
+
+#[allow(unused_imports)]
+pub(crate) use service::MemoryService;

--- a/src/bin/caller/memory/plane.rs
+++ b/src/bin/caller/memory/plane.rs
@@ -1,0 +1,465 @@
+//! The ephemeral local plane: keys, the genesis ceremony, the
+//! in-memory op log, and the fold cache.
+//!
+//! The ceremony mirrors the stamped reference rig (`tranche.rs`
+//! `PlaneRig::new_with` on the asset branch) with one deliberate
+//! difference: identifiers and key seeds come from the OS CSPRNG, not
+//! a recorded deterministic stream — this is a real (if ephemeral)
+//! plane, not a fixture. Every object construction, encoding, and
+//! signature flows through the vendored `owner_plane_core` writer, and
+//! every appended operation is adjudicated by the vendored
+//! `owner_plane_reducer` fold; the tests pin that the ceremony ADMITS
+//! under the stamped reader.
+
+use std::collections::BTreeMap;
+
+use owner_plane_core::cbor;
+use owner_plane_core::domains::{h_tag, Tag};
+use owner_plane_core::keyschedule;
+use owner_plane_core::scenario;
+use owner_plane_core::shapes::control::{ctrl_header, Cgenesis};
+use owner_plane_core::shapes::envelope::{
+    gen_start, seal_op, Actor, ActorKind, Header, OpSigner, Signedop, Tenant, Writer,
+};
+use owner_plane_core::shapes::identity::{
+    Budget, Cert, Genesis, Grant, GrantTenant, Provenance, SpacesSel, ZoneSel,
+};
+use owner_plane_core::shapes::{
+    Class, Devclass, Hlc, Kekwrap, Lineagedef, Polref, Sigalg, Spaceclass, Spacedef, ToValue, Verb,
+};
+use owner_plane_core::suite::{self, hpke_wrap};
+use owner_plane_reducer::fold::{
+    fold_set, State, Unimplemented, Verdict, CTRL_LINEAGE, CTRL_SPACE, CTRL_ZONE,
+};
+
+use super::types::MemoryError;
+
+/// `H_cert` / `H_grant` — the dev-arm citations (the reference rig's
+/// helpers; compositional uses of the vendored writer, re-derived here
+/// because the rig itself stays on the asset branch).
+fn h_cert(cert: &Cert) -> [u8; 32] {
+    h_tag(
+        Tag::Cert,
+        &cbor::encode(&cert.to_value()).expect("cert encodes"),
+    )
+}
+
+fn h_grant(grant: &Grant) -> [u8; 32] {
+    h_tag(
+        Tag::Grant,
+        &cbor::encode(&grant.to_value()).expect("grant encodes"),
+    )
+}
+
+fn hex(b: &[u8]) -> String {
+    b.iter().map(|x| format!("{x:02x}")).collect()
+}
+
+fn rand32() -> [u8; 32] {
+    use rand::RngCore;
+    let mut b = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut b);
+    b
+}
+
+/// A fresh random identifier honoring the N1 reserved-prefix rule
+/// (real ids never have their first 8 bytes all zero — the reserved
+/// control identifiers live there).
+fn rand_id() -> [u8; 16] {
+    loop {
+        let b = rand32();
+        let id: [u8; 16] = b[..16].try_into().expect("16-byte prefix");
+        if id[..8] != [0u8; 8] {
+            return id;
+        }
+    }
+}
+
+fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// The trusted-plane genesis verb set (registry order, matching the
+/// reference rig): the plane-level ceiling for the daemon writer.
+/// Surface-level authorization (daemon IAM, and post-A2 the
+/// `ActorBinding` ring rules) narrows per caller on top of this.
+fn daemon_writer_verbs() -> Vec<Verb> {
+    vec![
+        Verb::Search,
+        Verb::Read,
+        Verb::EvidenceRead,
+        Verb::Propose,
+        Verb::Assert,
+        Verb::JudgeSafe,
+        Verb::JudgeFull,
+        Verb::PinSafe,
+        Verb::PinFull,
+        Verb::EraseRequest,
+        Verb::Raise,
+        Verb::Declassify,
+        Verb::Export,
+        Verb::Import,
+        Verb::CurateInstruction,
+    ]
+}
+
+/// The pinned genesis budget default (reference rig values).
+const GENESIS_BUDGET: Budget = Budget {
+    max_ops: 1_000_000,
+    max_bytes: 268_435_456,
+};
+
+/// The daemon's writer device on this plane.
+pub(crate) struct WriterDevice {
+    pub device_id: [u8; 16],
+    pub lineage: [u8; 16],
+    sig_seed: [u8; 32],
+    pub sig_pk: [u8; 32],
+    pub cert: Cert,
+}
+
+/// The ephemeral plane: genesis ceremony + op log + fold cache.
+/// Signing keys are re-derived from held seeds at each seal site (the
+/// seeds are the ephemeral secret; the dalek type is never held).
+pub(crate) struct EphemeralPlane {
+    pub plane_id: [u8; 32],
+    pub zone_id: [u8; 16],
+    pub home_space: [u8; 16],
+    #[allow(dead_code)]
+    pub audit_space: [u8; 16],
+    root_seed: [u8; 32],
+    pub root_pk: [u8; 32],
+    pub dev: WriterDevice,
+    grant: Grant,
+    /// name → signed op bytes; names are zero-padded append indexes,
+    /// so `BTreeMap` order == append order.
+    items: BTreeMap<String, Vec<u8>>,
+    /// Fold cache over the CURRENT item set (recomputed on append —
+    /// the fold is set-based and arrival-order-free by construction).
+    verdicts: BTreeMap<String, Verdict>,
+    state: State,
+    /// The writer chain (single lineage, generation 1).
+    writer_seq: u64,
+    prev_writer_hash: [u8; 32],
+    /// Control chain position (genesis holds seq 1).
+    #[allow(dead_code)]
+    ctrl_seq: u64,
+    #[allow(dead_code)]
+    ctrl_head: [u8; 32],
+    /// HLC millisecond floor (strictly monotonic per plane).
+    hlc_last_ms: u64,
+}
+
+impl EphemeralPlane {
+    /// Mint the plane: the full `c.genesis` ceremony (§7.1 registry
+    /// row; D-68/D-76 cross-field validity), then fold it and require
+    /// admission by the stamped reader.
+    pub(crate) fn bootstrap() -> Result<EphemeralPlane, MemoryError> {
+        let created_ms = now_ms();
+        let root_seed = rand32();
+        let (_, root_pk) = suite::ed25519::keypair(&root_seed);
+        let recovery_seed = rand32();
+        let (_, recovery_pk) = suite::ed25519::keypair(&recovery_seed);
+
+        let descriptor = Genesis {
+            root_sig_alg: Sigalg::Ed25519,
+            root_sig_pk: root_pk.to_vec(),
+            recovery_commitment: h_tag(Tag::Drill, &recovery_pk),
+            provenance: Provenance::Trusted,
+            created_ms,
+        };
+        let plane_id = h_tag(
+            Tag::Genesis,
+            &cbor::encode(&descriptor.to_value()).expect("descriptor encodes"),
+        );
+
+        // The daemon's writer device.
+        let sig_seed = rand32();
+        let (_, sig_pk) = suite::ed25519::keypair(&sig_seed);
+        let kem_ikm = rand32();
+        let (_, kem_pk) = hpke_wrap::derive_keypair(&kem_ikm);
+        let device_id = rand_id();
+        let lineage = rand_id();
+        let cert = Cert {
+            plane_id,
+            device_id,
+            sig_alg: Sigalg::Ed25519,
+            sig_pk: sig_pk.to_vec(),
+            kem_pk: kem_pk.to_vec(),
+            class: Devclass::Daemon,
+            evidence_hash: rand32(),
+            evidence_media_type: None,
+            issued_admin_epoch: 1,
+            expiry_deadline_ms: None,
+            revocation_id: rand_id(),
+            renews: None,
+        };
+        let dev = WriterDevice {
+            device_id,
+            lineage,
+            sig_seed,
+            sig_pk,
+            cert: cert.clone(),
+        };
+
+        let zone_id = rand_id();
+        let home_space = rand_id();
+        let audit_space = rand_id();
+        let kek_e1 = rand32();
+        let (enc, ct) = keyschedule::wrap_kek(&kem_pk, &plane_id, &zone_id, 1, &kek_e1, &rand32())
+            .ok_or_else(|| {
+                MemoryError::InvalidArg("genesis kek wrap: derived recipient key rejected".into())
+            })?;
+        let wrap = Kekwrap {
+            plane_id,
+            zone_id,
+            epoch: 1,
+            recipient_device: device_id,
+            recipient_kem_key: suite::key_id("hpke-p256-v1", &kem_pk),
+            enc,
+            ct,
+        };
+
+        let grant = Grant {
+            plane_id,
+            grant_id: rand_id(),
+            subject_device: device_id,
+            lineage: Some(lineage),
+            tenants: vec![GrantTenant::Memory],
+            zone: ZoneSel::Zone(zone_id),
+            spaces: SpacesSel::Spaces(vec![home_space]),
+            ops: daemon_writer_verbs(),
+            kinds: None,
+            class_ceiling: Class::Sensitive,
+            can_declassify: None,
+            can_raise: None,
+            raise_quota: None,
+            flows: None,
+            budget: Some(GENESIS_BUDGET),
+            online_lease: false,
+            max_age_ms: None,
+            issued_admin_epoch: 1,
+            capability_epoch: 1,
+            expiry_deadline_ms: None,
+        };
+        let audit_grant = Grant {
+            grant_id: rand_id(),
+            spaces: SpacesSel::Spaces(vec![audit_space]),
+            ops: vec![Verb::AuditWrite],
+            ..grant.clone()
+        };
+
+        let body = Cgenesis {
+            descriptor,
+            cert,
+            lineage: Lineagedef {
+                lineage,
+                device_id,
+                max_generations: 8,
+            },
+            zone_id,
+            zone_wraps: vec![wrap],
+            home_space: Spacedef {
+                space_id: home_space,
+                zone_id,
+                name_hash: rand32(),
+                space_class: Spaceclass::Personal,
+                class_minimum: Class::Private,
+                status_policy: Polref {
+                    id: "workflow-v1".into(),
+                    version: 1,
+                    hash: scenario::workflow_v1().hash(),
+                },
+            },
+            audit_space: Spacedef {
+                space_id: audit_space,
+                zone_id,
+                name_hash: rand32(),
+                space_class: Spaceclass::Audit,
+                class_minimum: Class::Private,
+                status_policy: Polref {
+                    id: "owner-v1".into(),
+                    version: 1,
+                    hash: scenario::owner_v1().hash(),
+                },
+            },
+            zone_policy: scenario::genesis_zone_policy(zone_id),
+            grant: grant.clone(),
+            audit_grant,
+        };
+
+        let hlc_last_ms = created_ms + 1;
+        let header = ctrl_header(
+            plane_id,
+            CTRL_ZONE,
+            CTRL_SPACE,
+            Sigalg::Ed25519,
+            suite::key_id("ed25519", &root_pk),
+            Writer {
+                lineage: CTRL_LINEAGE,
+                gen: 1,
+            },
+            owner_plane_core::shapes::identity::Authproof::Genesis { genesis: plane_id },
+            rand_id(),
+            1,
+            None,
+            Hlc {
+                ms: hlc_last_ms,
+                count: 0,
+            },
+            Cgenesis::OP_TYPE,
+        );
+        let (root_sk, _) = suite::ed25519::keypair(&root_seed);
+        let genesis_op = seal_op(header, body.to_value(), &OpSigner::Ed25519(&root_sk));
+        let ctrl_head = genesis_op.op_hash();
+
+        let mut plane = EphemeralPlane {
+            plane_id,
+            zone_id,
+            home_space,
+            audit_space,
+            root_seed,
+            root_pk,
+            dev,
+            grant,
+            items: BTreeMap::new(),
+            verdicts: BTreeMap::new(),
+            state: State::default(),
+            writer_seq: 0,
+            prev_writer_hash: [0; 32],
+            ctrl_seq: 1,
+            ctrl_head,
+            hlc_last_ms,
+        };
+        plane.prev_writer_hash = gen_start(&plane.dev.lineage, 1);
+        plane.append(genesis_op)?;
+        Ok(plane)
+    }
+
+    fn next_hlc(&mut self) -> Hlc {
+        let ms = now_ms().max(self.hlc_last_ms + 1);
+        self.hlc_last_ms = ms;
+        Hlc { ms, count: 0 }
+    }
+
+    fn next_name(&self) -> String {
+        format!("op-{:06}", self.items.len() + 1)
+    }
+
+    /// Append a signed op and re-derive the fold over the full set.
+    /// Admitted/Pending ops stay in the log and hold their positions;
+    /// a Rejected op is removed (a failed operation exerts no
+    /// precedence, D-112) and its named outcome surfaces verbatim.
+    fn append(&mut self, op: Signedop) -> Result<[u8; 32], MemoryError> {
+        let name = self.next_name();
+        let op_hash = op.op_hash();
+        self.items.insert(name.clone(), op.encode());
+        match fold_set(&self.items, &BTreeMap::new()) {
+            Ok((verdicts, state)) => {
+                let verdict = verdicts
+                    .get(&name)
+                    .copied()
+                    .unwrap_or(Verdict::Rejected("op-unknown", "quarantine-reject"));
+                match verdict {
+                    Verdict::Admitted => {
+                        self.verdicts = verdicts;
+                        self.state = state;
+                        Ok(op_hash)
+                    }
+                    Verdict::Pending(outcome, disposition) => {
+                        self.verdicts = verdicts;
+                        self.state = state;
+                        Err(MemoryError::Pending {
+                            outcome,
+                            disposition,
+                        })
+                    }
+                    Verdict::Rejected(outcome, disposition) => {
+                        self.items.remove(&name);
+                        // Re-derive without the rejected op so the
+                        // cache never reflects a set we don't hold.
+                        let (verdicts, state) = fold_set(&self.items, &BTreeMap::new())
+                            .map_err(|Unimplemented(why)| MemoryError::Unimplemented(why))?;
+                        self.verdicts = verdicts;
+                        self.state = state;
+                        Err(MemoryError::Rejected {
+                            outcome,
+                            disposition,
+                        })
+                    }
+                }
+            }
+            Err(Unimplemented(why)) => {
+                self.items.remove(&name);
+                Err(MemoryError::Unimplemented(why))
+            }
+        }
+    }
+
+    /// Seal a Memory-tenant op on the writer chain and append it.
+    /// On admission the chain advances; on rejection it does not (the
+    /// failed op's coordinates stay reusable, D-112).
+    pub(crate) fn tenant_op(
+        &mut self,
+        actor_kind: ActorKind,
+        actor_id: Option<String>,
+        op_type: &str,
+        body: cbor::Value,
+    ) -> Result<[u8; 32], MemoryError> {
+        let seq = self.writer_seq + 1;
+        let hlc = self.next_hlc();
+        let header = Header {
+            tenant: Tenant::Memory,
+            plane_id: self.plane_id,
+            zone_id: self.zone_id,
+            space_id: self.home_space,
+            authored_kek_epoch: 1,
+            capability_epoch: 1,
+            signer_alg: Sigalg::Ed25519,
+            signer_key_id: suite::key_id("ed25519", &self.dev.sig_pk),
+            writer: Writer {
+                lineage: self.dev.lineage,
+                gen: 1,
+            },
+            actor: Actor {
+                kind: actor_kind,
+                id: actor_id.unwrap_or_else(|| hex(&self.dev.device_id)),
+                attested_by: None,
+            },
+            authorization_proof: owner_plane_core::shapes::identity::Authproof::Dev {
+                cert: h_cert(&self.dev.cert),
+                cap: h_grant(&self.grant),
+            },
+            request_id: rand_id(),
+            writer_sequence: seq,
+            previous_writer_hash: self.prev_writer_hash,
+            causal_references: vec![],
+            created_hlc: hlc,
+            operation_type: op_type.into(),
+            operation_version: 1,
+            body_hash: [0; 32], // set by seal_op
+        };
+        let (dev_sk, _) = suite::ed25519::keypair(&self.dev.sig_seed);
+        let op = seal_op(header, body, &OpSigner::Ed25519(&dev_sk));
+        let op_hash = self.append(op)?;
+        self.writer_seq = seq;
+        self.prev_writer_hash = op_hash;
+        Ok(op_hash)
+    }
+
+    /// Derived claim status via the reducer's §11.2 fold — never a
+    /// service-side reimplementation.
+    pub(crate) fn claim_status(&self, op_hash: &[u8; 32]) -> Option<&'static str> {
+        self.state.claim_status(op_hash, now_ms())
+    }
+
+    /// Number of held (admitted or pending) operations.
+    #[cfg(test)]
+    pub(crate) fn held_ops(&self) -> usize {
+        self.items.len()
+    }
+}

--- a/src/bin/caller/memory/service.rs
+++ b/src/bin/caller/memory/service.rs
@@ -1,0 +1,345 @@
+//! The Memory service: propose / search / read over the ephemeral
+//! plane, with the reducer-derived status on every view.
+
+use std::collections::BTreeMap;
+
+#[cfg(test)]
+use owner_plane_core::cbor;
+use owner_plane_core::shapes::envelope::ActorKind;
+use owner_plane_core::shapes::memory::Mclaim;
+use owner_plane_core::shapes::{Class, Kind, ToValue};
+
+use super::plane::EphemeralPlane;
+use super::types::{hex32, ClaimView, MemoryError, ProposeArgs, SearchArgs};
+
+/// Search results are hard-capped regardless of the caller's ask
+/// (§6.5: bounded retrieval — no whole-store reads through this API).
+const SEARCH_LIMIT_CEILING: usize = 50;
+
+/// What the service records about a claim it minted: the plaintext it
+/// authored (the mint side holds the plaintext; ops carry it in the
+/// signed body) keyed by the accepted op hash. Status is NEVER stored
+/// here — it is derived from the fold at read time.
+struct ClaimRecord {
+    op_hash: [u8; 32],
+    kind: Kind,
+    statement: String,
+    sensitivity: Class,
+    session: Option<String>,
+    project: Option<String>,
+    model: Option<String>,
+    labels: Vec<String>,
+    created_ms: u64,
+}
+
+fn parse_vocab<T: Copy>(
+    what: &'static str,
+    got: &str,
+    all: &'static [T],
+    as_str: fn(T) -> &'static str,
+) -> Result<T, MemoryError> {
+    all.iter()
+        .copied()
+        .find(|v| as_str(*v) == got)
+        .ok_or_else(|| MemoryError::Vocabulary {
+            what,
+            got: got.to_string(),
+            allowed: all
+                .iter()
+                .map(|v| as_str(*v))
+                .collect::<Vec<_>>()
+                .join(", "),
+        })
+}
+
+pub(crate) struct MemoryService {
+    plane: EphemeralPlane,
+    claims: BTreeMap<[u8; 32], ClaimRecord>,
+}
+
+impl MemoryService {
+    /// Bootstrap an ephemeral plane and an empty claim registry.
+    pub(crate) fn new() -> Result<MemoryService, MemoryError> {
+        Ok(MemoryService {
+            plane: EphemeralPlane::bootstrap()?,
+            claims: BTreeMap::new(),
+        })
+    }
+
+    /// Author a claim (`propose` — the candidate lane; `assert` is a
+    /// separate verb this build does not expose). The claim enters as
+    /// a `candidate` and only judgments move its derived status.
+    pub(crate) fn propose(&mut self, args: ProposeArgs) -> Result<ClaimView, MemoryError> {
+        if args.statement.trim().is_empty() {
+            return Err(MemoryError::InvalidArg(
+                "statement must be non-empty".into(),
+            ));
+        }
+        let kind = parse_vocab("kind", &args.kind, Kind::ALL, Kind::as_str)?;
+        let sensitivity = parse_vocab("sensitivity", &args.sensitivity, Class::ALL, Class::as_str)?;
+        let created_ms = now_ms();
+        let body = Mclaim {
+            kind,
+            statement: args.statement.clone(),
+            sensitivity,
+            observed_at_ms: Some(created_ms),
+            valid_from_ms: None,
+            valid_until_ms: None,
+            expires_at_ms: None,
+            session: args.session.clone(),
+            project: args.project.clone(),
+            model: args.model.clone(),
+            evidence: vec![],
+            supersedes: None,
+            labels: if args.labels.is_empty() {
+                None
+            } else {
+                Some(args.labels.clone())
+            },
+        };
+        let op_hash =
+            self.plane
+                .tenant_op(ActorKind::Daemon, None, Mclaim::OP_TYPE, body.to_value())?;
+        self.claims.insert(
+            op_hash,
+            ClaimRecord {
+                op_hash,
+                kind,
+                statement: args.statement,
+                sensitivity,
+                session: args.session,
+                project: args.project,
+                model: args.model,
+                labels: args.labels,
+                created_ms,
+            },
+        );
+        Ok(self.view(&self.claims[&op_hash]))
+    }
+
+    /// Bounded lexical search. Candidates are excluded unless opted
+    /// into, and every result carries its derived status (§6.5).
+    pub(crate) fn search(&self, args: &SearchArgs) -> Vec<ClaimView> {
+        let limit = args.limit.clamp(1, SEARCH_LIMIT_CEILING);
+        let needle = args.query.to_lowercase();
+        let mut out = Vec::new();
+        for rec in self.claims.values() {
+            if !needle.is_empty() {
+                let hay = format!(
+                    "{} {} {}",
+                    rec.statement.to_lowercase(),
+                    rec.labels.join(" ").to_lowercase(),
+                    rec.kind.as_str()
+                );
+                if !hay.contains(&needle) {
+                    continue;
+                }
+            }
+            let view = self.view(rec);
+            if view.status == "candidate" && !args.include_candidates {
+                continue;
+            }
+            out.push(view);
+            if out.len() >= limit {
+                break;
+            }
+        }
+        out
+    }
+
+    /// Read one claim by id prefix (≥ 8 hex chars of the op hash).
+    pub(crate) fn read(&self, id_prefix: &str) -> Result<ClaimView, MemoryError> {
+        let p = id_prefix.to_lowercase();
+        if p.len() < 8 || !p.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(MemoryError::InvalidArg(
+                "id prefix must be at least 8 hex characters".into(),
+            ));
+        }
+        let matches: Vec<&ClaimRecord> = self
+            .claims
+            .values()
+            .filter(|r| hex32(&r.op_hash).starts_with(&p))
+            .collect();
+        match matches.len() {
+            0 => Err(MemoryError::NotFound(id_prefix.into())),
+            1 => Ok(self.view(matches[0])),
+            n => Err(MemoryError::Ambiguous(id_prefix.into(), n)),
+        }
+    }
+
+    fn view(&self, rec: &ClaimRecord) -> ClaimView {
+        ClaimView {
+            id: hex32(&rec.op_hash),
+            kind: rec.kind.as_str().into(),
+            statement: rec.statement.clone(),
+            sensitivity: rec.sensitivity.as_str().into(),
+            status: self
+                .plane
+                .claim_status(&rec.op_hash)
+                .unwrap_or("pending")
+                .into(),
+            session: rec.session.clone(),
+            project: rec.project.clone(),
+            model: rec.model.clone(),
+            labels: rec.labels.clone(),
+            created_ms: rec.created_ms,
+            durability: "ephemeral",
+        }
+    }
+
+    /// Test seam: seal an arbitrary Memory-tenant op on the plane
+    /// (the D-201 inert-judgment and §C.2 named-outcome tests mint
+    /// through this without a public verb existing yet).
+    #[cfg(test)]
+    pub(crate) fn tenant_op_for_test(
+        &mut self,
+        op_type: &str,
+        body: cbor::Value,
+    ) -> Result<[u8; 32], MemoryError> {
+        self.plane.tenant_op(ActorKind::Daemon, None, op_type, body)
+    }
+}
+
+fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use owner_plane_core::shapes::memory::{BasicVerdict, Mjudge};
+    use owner_plane_core::shapes::Polref;
+
+    fn propose_args(statement: &str) -> ProposeArgs {
+        ProposeArgs {
+            kind: "observation".into(),
+            statement: statement.into(),
+            sensitivity: "private".into(),
+            session: Some("test-session".into()),
+            project: None,
+            model: None,
+            labels: vec!["memory-p1".into()],
+        }
+    }
+
+    /// The genesis ceremony must ADMIT under the stamped reader.
+    #[test]
+    fn bootstrap_genesis_admits() {
+        let svc = MemoryService::new().expect("bootstrap admits");
+        assert_eq!(svc.plane.held_ops(), 1, "genesis is held");
+    }
+
+    /// propose → candidate → read round-trip, with the reducer-derived
+    /// status and the honest durability label on the view.
+    #[test]
+    fn propose_then_read_roundtrip() {
+        let mut svc = MemoryService::new().unwrap();
+        let view = svc
+            .propose(propose_args("the deploy runs at 06:00 UTC"))
+            .unwrap();
+        assert_eq!(view.status, "candidate");
+        assert_eq!(view.durability, "ephemeral");
+        let back = svc.read(&view.id[..12]).unwrap();
+        assert_eq!(back.statement, "the deploy runs at 06:00 UTC");
+        assert_eq!(back.kind, "observation");
+        assert_eq!(back.session.as_deref(), Some("test-session"));
+    }
+
+    /// §6.5: candidates are excluded from retrieval by default;
+    /// callers opt in, results stay bounded and status-labeled.
+    #[test]
+    fn search_excludes_candidates_by_default() {
+        let mut svc = MemoryService::new().unwrap();
+        for i in 0..5 {
+            svc.propose(propose_args(&format!("observation number {i}")))
+                .unwrap();
+        }
+        let default_results = svc.search(&SearchArgs {
+            query: "observation".into(),
+            ..SearchArgs::default()
+        });
+        assert!(default_results.is_empty(), "candidates hidden by default");
+        let opted = svc.search(&SearchArgs {
+            query: "observation".into(),
+            limit: 3,
+            include_candidates: true,
+        });
+        assert_eq!(opted.len(), 3, "bounded by the caller's limit");
+        assert!(opted.iter().all(|v| v.status == "candidate"));
+    }
+
+    /// Unknown vocabulary rejects with the allowed set — never a
+    /// defaulted or downgraded value.
+    #[test]
+    fn unknown_kind_rejects() {
+        let mut svc = MemoryService::new().unwrap();
+        let mut args = propose_args("x");
+        args.kind = "fact".into();
+        let err = svc.propose(args).unwrap_err();
+        assert!(matches!(err, MemoryError::Vocabulary { what: "kind", .. }));
+    }
+
+    /// D-201 (the ruled D2): a bare non-human unattested writer's
+    /// judgment is recordable where authoring verbs admit it and INERT
+    /// in the status fold — the daemon's self-retract does not move
+    /// the claim off `candidate`.
+    #[test]
+    fn bare_daemon_retract_is_recorded_but_inert() {
+        let mut svc = MemoryService::new().unwrap();
+        let view = svc
+            .propose(propose_args("retractable observation"))
+            .unwrap();
+        let target: [u8; 32] = {
+            let mut b = [0u8; 32];
+            for (i, chunk) in view.id.as_bytes().chunks(2).enumerate().take(32) {
+                b[i] = u8::from_str_radix(std::str::from_utf8(chunk).unwrap(), 16).unwrap();
+            }
+            b
+        };
+        let judge = Mjudge::Basic {
+            verdict: BasicVerdict::Retract,
+            target,
+            policy: Polref {
+                id: "workflow-v1".into(),
+                version: 1,
+                hash: owner_plane_core::scenario::workflow_v1().hash(),
+            },
+            reason: Some("test retract".into()),
+            evidence: None,
+        };
+        svc.tenant_op_for_test(Mjudge::OP_TYPE, judge.to_value())
+            .expect("judgment admits (authoring verbs) even though it counts nowhere");
+        let after = svc.read(&view.id[..12]).unwrap();
+        assert_eq!(
+            after.status, "candidate",
+            "bare-daemon judgment must be inert in the status fold (D-201)"
+        );
+    }
+
+    /// D-203 §C.2: a rejected operation surfaces the reducer's NAMED
+    /// outcome/disposition verbatim — here the closed §7.1/§11.1
+    /// registry rejecting an unknown operation type as `op-unknown` —
+    /// and the failed op exerts no precedence (D-112): the writer
+    /// chain position stays reusable and the next propose admits.
+    #[test]
+    fn rejected_op_surfaces_named_outcome() {
+        let mut svc = MemoryService::new().unwrap();
+        svc.propose(propose_args("first claim")).unwrap();
+        let err = svc
+            .tenant_op_for_test("m.bogus", cbor::map(vec![]))
+            .unwrap_err();
+        match err {
+            MemoryError::Rejected { outcome, .. } => assert_eq!(
+                outcome, "op-unknown",
+                "the reducer's named outcome must surface verbatim"
+            ),
+            other => panic!("expected a named kernel rejection, got {other:?}"),
+        }
+        svc.propose(propose_args("after the rejection"))
+            .expect("a rejected op must not consume the chain position");
+    }
+}

--- a/src/bin/caller/memory/types.rs
+++ b/src/bin/caller/memory/types.rs
@@ -1,0 +1,98 @@
+//! Service-facing types for the P1 Memory service.
+
+use serde::Serialize;
+
+/// Hex of a 32-byte identifier (claim ids are op hashes).
+pub(crate) fn hex32(b: &[u8; 32]) -> String {
+    b.iter().map(|x| format!("{x:02x}")).collect()
+}
+
+/// Arguments for a `propose` (claim authoring). The service maps
+/// `kind`/`sensitivity` onto the kernel's closed vocabularies and
+/// rejects unknown words — never a defaulted or downgraded value.
+#[derive(Debug, Clone)]
+pub(crate) struct ProposeArgs {
+    pub kind: String,
+    pub statement: String,
+    /// Writer's sensitivity claim (a claim, never export authority).
+    pub sensitivity: String,
+    pub session: Option<String>,
+    pub project: Option<String>,
+    pub model: Option<String>,
+    pub labels: Vec<String>,
+}
+
+/// Bounded search arguments (§6.5: bounded retrieval, candidates
+/// excluded by default and results always status-labeled).
+#[derive(Debug, Clone)]
+pub(crate) struct SearchArgs {
+    pub query: String,
+    pub limit: usize,
+    pub include_candidates: bool,
+}
+
+impl Default for SearchArgs {
+    fn default() -> Self {
+        SearchArgs {
+            query: String::new(),
+            limit: 10,
+            include_candidates: false,
+        }
+    }
+}
+
+/// A provenance-labeled claim view. This is DATA for surfaces to
+/// render as quoted content — never instructions (§6.5).
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ClaimView {
+    /// The claim id: hex of the accepted `m.claim` operation hash.
+    pub id: String,
+    pub kind: String,
+    pub statement: String,
+    pub sensitivity: String,
+    /// Derived by the reducer's §11.2 status fold at read time
+    /// (`candidate` / `accepted` / `disputed` / `superseded` /
+    /// `retired`) — status is a derived view, never a mutable field.
+    pub status: String,
+    pub session: Option<String>,
+    pub project: Option<String>,
+    pub model: Option<String>,
+    pub labels: Vec<String>,
+    pub created_ms: u64,
+    /// Always `"ephemeral"` in this build (the P1 write bar): the
+    /// claim does not survive a daemon restart.
+    pub durability: &'static str,
+}
+
+/// Service errors. Kernel verdicts surface their named
+/// outcome/disposition pair verbatim (D-203 §C.2).
+#[derive(Debug, Clone, thiserror::Error)]
+pub(crate) enum MemoryError {
+    #[error("rejected: {outcome} ({disposition})")]
+    Rejected {
+        outcome: &'static str,
+        disposition: &'static str,
+    },
+    #[error("pending: {outcome} ({disposition})")]
+    Pending {
+        outcome: &'static str,
+        disposition: &'static str,
+    },
+    /// The vendored engine met something outside its implemented
+    /// registry — surfaced, never papered over. Unreachable for the
+    /// shapes this service mints; reaching it is a bug report.
+    #[error("kernel boundary: {0}")]
+    Unimplemented(String),
+    #[error("unknown {what}: {got:?} (expected one of {allowed})")]
+    Vocabulary {
+        what: &'static str,
+        got: String,
+        allowed: String,
+    },
+    #[error("no claim matches id prefix {0:?}")]
+    NotFound(String),
+    #[error("ambiguous id prefix {0:?} (matches {1} claims)")]
+    Ambiguous(String, usize),
+    #[error("{0}")]
+    InvalidArg(String),
+}


### PR DESCRIPTION
Memory P1, slice 1b (P1.1 service core): the controller-owned Memory service over the vendored D0-A kernel (#358) — an ephemeral local plane with propose/search/read, reducer-derived claim status, and the §C.2 fail-closed contract surfaced verbatim. No surfaces yet: the ctl/gateway/tunnel verbs are the next slice, and the module is documented as that slice's consumer.

## What

- **`src/bin/caller/memory/`** — the P1 Memory service core:
  - `plane.rs`: an ephemeral local plane. The full `c.genesis` ceremony (device cert + zone + home/audit spaces under the pinned B.2/B.3 policies + writer grants) mirrors the stamped reference rig with CSPRNG identifiers instead of recorded draws; ops are minted device-signed through `owner-plane-core` and admitted through `owner-plane-reducer`'s fold — write and admission stay independently implemented. The in-memory op log re-derives the fold on append; rejected ops surface the reducer's named outcome/disposition verbatim and exert no precedence (D-112).
  - `service.rs`: propose → candidate lifecycle, bounded lexical search (candidates excluded by default, hard result ceiling, every result status-labeled), read by id prefix. Status is derived by the reducer's §11.2 fold at read time — never stored, never re-implemented.
  - `types.rs`: provenance-labeled views (`durability: "ephemeral"` on every view — the ratified P1 write bar: no durable writes until Gate-B-lite custody + P0.5 + the tombed cutover), closed-vocabulary argument parsing that rejects unknown words instead of defaulting.
- **Vendored-kernel adaptations** (both documented at the site):
  - `owner-plane-reducer`: `State::claim_status` widened `pub(crate)` → `pub` (the service derives status through the exact stamped fold); new `fold_set` entry — a single-shot full-set fold behaviorally identical to `run_delivery_full`'s final snapshot (the fold is set-based and order-free by construction), pinned by `fold_set_matches_run_delivery_full` on a committed vector.
  - `owner-plane-core`: `scenario.rs` vendored from the stamp (the Appendix B pinned-policy prelude — B.2/B.3 policy literals with byte-length + hash pin tests; services mint under those policies); its test-only `vector::hex` import replaced by a local helper.
- The module deliberately reuses no legacy-memory identifier (`store_memory`/`recall_memory`/`inherit_memory`/`memory.json`), keeping the future cutover's exact-identifier CI denylist exact while the systems coexist.

## Tests

- `bootstrap_genesis_admits` — the CSPRNG ceremony ADMITS under the stamped reader (the differential property working as a live check).
- `propose_then_read_roundtrip` — candidate status + ephemeral labeling + provenance round-trip.
- `search_excludes_candidates_by_default` — §6.5 retrieval defaults and bounds.
- `unknown_kind_rejects` — closed-vocabulary fail-closed argument handling.
- `bare_daemon_retract_is_recorded_but_inert` — the D-201 ruling live: a bare daemon's self-retract admits but never moves status.
- `rejected_op_surfaces_named_outcome` — §C.2: `op-unknown` from the closed registry surfaces verbatim; the failed op doesn't consume the chain position.
- Kernel side: `fold_set_matches_run_delivery_full`, plus the vendored scenario pin tests (B.2 1133-byte/`219b9bac…`, B.3 571-byte/`d7d5559a…`) now run in CI.
