### PR TITLE
memory: gate-resolved attribution on proposals (P1.2)

### DIFF
--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -1265,17 +1265,24 @@ pub(crate) async fn api_memory_claim_response(
 }
 
 /// Tunnel twin of `POST /api/memory/propose` — the proposal rides
-/// `params` (the same JSON shape as the HTTP body).
+/// `params` (the same JSON shape as the HTTP body); attribution comes
+/// from the authenticated dashboard-control grant.
 pub(crate) async fn api_memory_propose_response(
     id: String,
     params: Option<&serde_json::Value>,
     runtime: &ControlRuntime,
 ) -> serde_json::Value {
     let body_text = params_body_text(params);
+    let actor =
+        crate::access::actor::ActorBinding::from_principal(&runtime.grant.access_principal(), None);
     frame_api_response(
         id,
-        crate::web_gateway::memory_propose_api_response(&body_text, runtime.mcp_server.as_ref())
-            .await,
+        crate::web_gateway::memory_propose_api_response(
+            &body_text,
+            runtime.mcp_server.as_ref(),
+            &actor,
+        )
+        .await,
         "memory propose",
     )
 }

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -226,25 +226,19 @@ impl IntendantServer {
 
     async fn memory_propose_inner(
         &self,
-        mut args: crate::memory::ProposeArgs,
-        session_id: Option<&str>,
+        args: crate::memory::ProposeArgs,
+        actor: &crate::access::actor::ActorBinding,
     ) -> Result<serde_json::Value, String> {
         let Some(memory) = self.memory_handle().await else {
             return Err("memory service unavailable on this daemon".to_string());
         };
-        // MCP-lane attribution (best-effort, pre-A2): supervised
-        // sessions call through their injected INTENDANT_MCP_URL,
-        // which binds a session id here — it rides the claim's
-        // provenance unless the caller stated one explicitly. The
-        // principal-bound ActorBinding seam (A2) upgrades this
-        // honestly rather than stamping a fabricated label.
-        if args.session.is_none() {
-            args.session = session_id
-                .map(str::trim)
-                .filter(|id| !id.is_empty())
-                .map(str::to_string);
-        }
-        match memory.propose(args) {
+        // Attribution comes from the gate-resolved actor the dispatch
+        // carried in — never from tool arguments or the dispatch
+        // session parameter (which tokenless lanes fill from query
+        // echoes). The service maps the binding into the claim's own
+        // provenance fields and defaults unstated session CONTEXT
+        // from the gate-bound session.
+        match memory.propose(args, actor) {
             Ok(claim) => Ok(serde_json::json!({ "claim": claim })),
             Err(err) => Err(err.to_string()),
         }
@@ -542,7 +536,7 @@ impl IntendantServer {
                 // shape the HTTP body and tunnel params carry.
                 let args: crate::memory::ProposeArgs =
                     serde_json::from_value(args).map_err(|e| e.to_string())?;
-                Ok(match self.memory_propose_inner(args, session_id).await {
+                Ok(match self.memory_propose_inner(args, &actor).await {
                     Ok(value) => text_tool_result(value.to_string()),
                     Err(message) => text_tool_error(format!("memory_propose failed: {message}")),
                 })

--- a/src/bin/caller/memory/handle.rs
+++ b/src/bin/caller/memory/handle.rs
@@ -33,8 +33,17 @@ impl MemoryHandle {
         &self.plane_id_hex
     }
 
-    pub(crate) fn propose(&self, args: ProposeArgs) -> Result<ClaimView, MemoryError> {
-        self.lock().propose(args)
+    /// Author a claim. `actor` is the gate-resolved binding from the
+    /// authenticated edge that dispatched this write (the seam
+    /// contract in `access/actor.rs`) — the service maps it into the
+    /// claim's own provenance fields and the op envelope's actor, and
+    /// makes the ring authorization decision from it.
+    pub(crate) fn propose(
+        &self,
+        args: ProposeArgs,
+        actor: &crate::access::actor::ActorBinding,
+    ) -> Result<ClaimView, MemoryError> {
+        self.lock().propose(args, actor)
     }
 
     pub(crate) fn search(&self, args: &SearchArgs) -> Vec<ClaimView> {

--- a/src/bin/caller/memory/service.rs
+++ b/src/bin/caller/memory/service.rs
@@ -7,10 +7,12 @@ use std::collections::BTreeMap;
 use owner_plane_core::cbor;
 use owner_plane_core::shapes::envelope::ActorKind;
 use owner_plane_core::shapes::memory::Mclaim;
-use owner_plane_core::shapes::{Class, Kind, ToValue};
+use owner_plane_core::shapes::{Class, Kind, ToValue, Verb};
+
+use crate::access::actor::{ActorBinding, ActorKind as GateActorKind};
 
 use super::plane::EphemeralPlane;
-use super::types::{hex32, ClaimView, MemoryError, ProposeArgs, SearchArgs};
+use super::types::{hex32, ClaimProvenance, ClaimView, MemoryError, ProposeArgs, SearchArgs};
 
 /// Search results are hard-capped regardless of the caller's ask
 /// (§6.5: bounded retrieval — no whole-store reads through this API).
@@ -30,6 +32,7 @@ struct ClaimRecord {
     model: Option<String>,
     labels: Vec<String>,
     created_ms: u64,
+    proposed_by: ClaimProvenance,
 }
 
 fn parse_vocab<T: Copy>(
@@ -72,10 +75,87 @@ impl MemoryService {
         hex32(&self.plane.plane_id)
     }
 
+    /// The tenant-edge write authorization (seam ruling Q4: rings are
+    /// an authorization decision made HERE, from the gate-resolved
+    /// actor kind on top of the pre-dispatch IAM gate — never a field
+    /// of the seam type). Owner surfaces — the dashboard and the
+    /// owner's own local processes — may reach every write verb the
+    /// service exposes; supervised agent sessions, federated peers,
+    /// and unattributed callers are ring-2 writers: they AUTHOR
+    /// candidates (`propose`) and nothing else. Judgment, pin, and
+    /// curation verbs stay owner-side, and the denial is a named
+    /// outcome (§C.2 discipline), never a silent downgrade.
+    fn authorize_write(actor: &ActorBinding, verb: Verb) -> Result<(), MemoryError> {
+        let owner_surface = matches!(
+            actor.kind,
+            GateActorKind::Dashboard | GateActorKind::LocalProcess
+        );
+        if owner_surface || verb == Verb::Propose {
+            return Ok(());
+        }
+        Err(MemoryError::NotPermitted {
+            verb: verb.as_str(),
+            actor: actor.kind.as_str(),
+        })
+    }
+
+    /// Map the gate-resolved actor onto the kernel envelope's closed
+    /// actor vocabulary. O8 constrains `human`/`daemon`/`browser`/
+    /// `service` actor ids to the writer device id (`tenant_op` fills
+    /// it for `None`); `agent-session`/`peer` ids are free-form and
+    /// carry the gate-named IAM principal verbatim. Ops seal
+    /// UNATTESTED in this build: an unattested non-human actor has no
+    /// §11.4 class, so ring-2 judgments would be fold-inert even if
+    /// one got past [`Self::authorize_write`] — attestation (the
+    /// session path to status influence) is a deliberate later
+    /// decision that lands with the judgment surfaces it affects.
+    fn envelope_actor(actor: &ActorBinding) -> (ActorKind, Option<String>) {
+        match actor.kind {
+            // The human at an authenticated dashboard surface.
+            GateActorKind::Dashboard => (ActorKind::Human, None),
+            // The owner's box-local software, and internal dispatch
+            // that states no actor: the daemon device itself.
+            GateActorKind::LocalProcess | GateActorKind::Unattributed => (ActorKind::Daemon, None),
+            GateActorKind::AgentSession => (
+                ActorKind::AgentSession,
+                actor.principal_id.clone().or_else(|| {
+                    // Principal-less bindings cannot arise from the
+                    // gates (`from_principal` always names one); keep
+                    // the session identity rather than fabricating.
+                    actor.session_id.clone()
+                }),
+            ),
+            GateActorKind::Peer => (ActorKind::Peer, actor.principal_id.clone()),
+        }
+    }
+
+    /// The single choke point every write verb seals through:
+    /// authorize at the tenant edge, map the actor onto the envelope,
+    /// then mint + admit. Future write surfaces (judgments, pins,
+    /// curation) MUST route through here — never `plane.tenant_op`
+    /// directly — so the ring rules cannot be bypassed.
+    fn seal_write(
+        &mut self,
+        actor: &ActorBinding,
+        verb: Verb,
+        op_type: &str,
+        body: owner_plane_core::cbor::Value,
+    ) -> Result<[u8; 32], MemoryError> {
+        Self::authorize_write(actor, verb)?;
+        let (actor_kind, actor_id) = Self::envelope_actor(actor);
+        self.plane.tenant_op(actor_kind, actor_id, op_type, body)
+    }
+
     /// Author a claim (`propose` — the candidate lane; `assert` is a
     /// separate verb this build does not expose). The claim enters as
     /// a `candidate` and only judgments move its derived status.
-    pub(crate) fn propose(&mut self, args: ProposeArgs) -> Result<ClaimView, MemoryError> {
+    /// `actor` is the gate-resolved binding the dispatch edge carried
+    /// in — attribution never comes from `args`.
+    pub(crate) fn propose(
+        &mut self,
+        args: ProposeArgs,
+        actor: &ActorBinding,
+    ) -> Result<ClaimView, MemoryError> {
         if args.statement.trim().is_empty() {
             return Err(MemoryError::InvalidArg(
                 "statement must be non-empty".into(),
@@ -84,6 +164,11 @@ impl MemoryService {
         let kind = parse_vocab("kind", &args.kind, Kind::ALL, Kind::as_str)?;
         let sensitivity = parse_vocab("sensitivity", &args.sensitivity, Class::ALL, Class::as_str)?;
         let created_ms = now_ms();
+        // Session CONTEXT is the writer's statement; when unstated it
+        // defaults from the gate-bound session (never from dispatch
+        // parameters or query echoes — those may carry unbound ids).
+        let session = args.session.clone().or_else(|| actor.session_id.clone());
+        let proposed_by = ClaimProvenance::from_binding(actor);
         let body = Mclaim {
             kind,
             statement: args.statement.clone(),
@@ -92,7 +177,7 @@ impl MemoryService {
             valid_from_ms: None,
             valid_until_ms: None,
             expires_at_ms: None,
-            session: args.session.clone(),
+            session: session.clone(),
             project: args.project.clone(),
             model: args.model.clone(),
             evidence: vec![],
@@ -103,9 +188,7 @@ impl MemoryService {
                 Some(args.labels.clone())
             },
         };
-        let op_hash =
-            self.plane
-                .tenant_op(ActorKind::Daemon, None, Mclaim::OP_TYPE, body.to_value())?;
+        let op_hash = self.seal_write(actor, Verb::Propose, Mclaim::OP_TYPE, body.to_value())?;
         self.claims.insert(
             op_hash,
             ClaimRecord {
@@ -113,11 +196,12 @@ impl MemoryService {
                 kind,
                 statement: args.statement,
                 sensitivity,
-                session: args.session,
+                session,
                 project: args.project,
                 model: args.model,
                 labels: args.labels,
                 created_ms,
+                proposed_by,
             },
         );
         Ok(self.view(&self.claims[&op_hash]))
@@ -189,13 +273,15 @@ impl MemoryService {
             model: rec.model.clone(),
             labels: rec.labels.clone(),
             created_ms: rec.created_ms,
+            proposed_by: rec.proposed_by.clone(),
             durability: "ephemeral",
         }
     }
 
-    /// Test seam: seal an arbitrary Memory-tenant op on the plane
-    /// (the D-201 inert-judgment and §C.2 named-outcome tests mint
-    /// through this without a public verb existing yet).
+    /// Test seam: seal an arbitrary Memory-tenant op on the plane as
+    /// the bare daemon actor, BYPASSING the tenant-edge authorization
+    /// (the D-201 inert-judgment and §C.2 named-outcome tests exercise
+    /// kernel semantics directly, without a public verb existing yet).
     #[cfg(test)]
     pub(crate) fn tenant_op_for_test(
         &mut self,
@@ -232,6 +318,19 @@ mod tests {
         }
     }
 
+    /// Internal-dispatch posture: no actor stated, explicitly
+    /// unattributed (the fail-closed default the dispatch edge uses).
+    fn no_actor() -> ActorBinding {
+        ActorBinding::unattributed()
+    }
+
+    fn agent_actor() -> ActorBinding {
+        ActorBinding::agent_session(
+            Some("principal:agent-session:sess-1".into()),
+            "sess-1".into(),
+        )
+    }
+
     /// The genesis ceremony must ADMIT under the stamped reader.
     #[test]
     fn bootstrap_genesis_admits() {
@@ -245,7 +344,7 @@ mod tests {
     fn propose_then_read_roundtrip() {
         let mut svc = MemoryService::new().unwrap();
         let view = svc
-            .propose(propose_args("the deploy runs at 06:00 UTC"))
+            .propose(propose_args("the deploy runs at 06:00 UTC"), &no_actor())
             .unwrap();
         assert_eq!(view.status, "candidate");
         assert_eq!(view.durability, "ephemeral");
@@ -261,8 +360,11 @@ mod tests {
     fn search_excludes_candidates_by_default() {
         let mut svc = MemoryService::new().unwrap();
         for i in 0..5 {
-            svc.propose(propose_args(&format!("observation number {i}")))
-                .unwrap();
+            svc.propose(
+                propose_args(&format!("observation number {i}")),
+                &no_actor(),
+            )
+            .unwrap();
         }
         let default_results = svc.search(&SearchArgs {
             query: "observation".into(),
@@ -285,7 +387,7 @@ mod tests {
         let mut svc = MemoryService::new().unwrap();
         let mut args = propose_args("x");
         args.kind = "fact".into();
-        let err = svc.propose(args).unwrap_err();
+        let err = svc.propose(args, &no_actor()).unwrap_err();
         assert!(matches!(err, MemoryError::Vocabulary { what: "kind", .. }));
     }
 
@@ -297,7 +399,7 @@ mod tests {
     fn bare_daemon_retract_is_recorded_but_inert() {
         let mut svc = MemoryService::new().unwrap();
         let view = svc
-            .propose(propose_args("retractable observation"))
+            .propose(propose_args("retractable observation"), &no_actor())
             .unwrap();
         let target: [u8; 32] = {
             let mut b = [0u8; 32];
@@ -334,7 +436,8 @@ mod tests {
     #[test]
     fn rejected_op_surfaces_named_outcome() {
         let mut svc = MemoryService::new().unwrap();
-        svc.propose(propose_args("first claim")).unwrap();
+        svc.propose(propose_args("first claim"), &no_actor())
+            .unwrap();
         let err = svc
             .tenant_op_for_test("m.bogus", cbor::map(vec![]))
             .unwrap_err();
@@ -345,7 +448,149 @@ mod tests {
             ),
             other => panic!("expected a named kernel rejection, got {other:?}"),
         }
-        svc.propose(propose_args("after the rejection"))
+        svc.propose(propose_args("after the rejection"), &no_actor())
             .expect("a rejected op must not consume the chain position");
+    }
+
+    /// The tenant-edge attribution mapping: a gate-bound agent session
+    /// lands in the claim's own versioned provenance fields — principal
+    /// verbatim, session from token possession — and the sealed op
+    /// ADMITS under the stamped reducer with the `agent-session`
+    /// envelope actor (free-form id lane, O8).
+    #[test]
+    fn agent_session_propose_records_the_gate_actor() {
+        let mut svc = MemoryService::new().unwrap();
+        let mut args = propose_args("attributed observation");
+        args.session = None;
+        let view = svc.propose(args, &agent_actor()).unwrap();
+        assert_eq!(view.status, "candidate", "sealed op admits");
+        assert_eq!(view.proposed_by.v, 1);
+        assert_eq!(view.proposed_by.actor, "agent_session");
+        assert_eq!(
+            view.proposed_by.principal.as_deref(),
+            Some("principal:agent-session:sess-1"),
+            "the IAM principal rides verbatim (exit criterion)"
+        );
+        assert_eq!(view.proposed_by.session.as_deref(), Some("sess-1"));
+        // Unstated session CONTEXT defaults from the gate-bound
+        // session, so the claim reads honestly in session views.
+        assert_eq!(view.session.as_deref(), Some("sess-1"));
+        // An unattributed write stays explicitly unattributed.
+        let view = svc
+            .propose(propose_args("internal observation"), &no_actor())
+            .unwrap();
+        assert_eq!(view.proposed_by.actor, "unattributed");
+        assert_eq!(view.proposed_by.principal, None);
+        assert_eq!(view.proposed_by.session, None);
+    }
+
+    /// A writer-stated session is a context CLAIM and survives as
+    /// stated; attribution comes from the gate binding regardless —
+    /// the two must never be conflated (that conflation is the
+    /// forgeable-attribution hole the seam closes).
+    #[test]
+    fn caller_stated_session_stays_a_context_claim() {
+        let mut svc = MemoryService::new().unwrap();
+        let mut args = propose_args("context-stated observation");
+        args.session = Some("stated-context".into());
+        let view = svc.propose(args, &agent_actor()).unwrap();
+        assert_eq!(view.session.as_deref(), Some("stated-context"));
+        assert_eq!(
+            view.proposed_by.session.as_deref(),
+            Some("sess-1"),
+            "attribution ignores the stated context"
+        );
+    }
+
+    /// Owner-surface mappings must ADMIT under the stamped reducer:
+    /// O8 pins `human`/`daemon` actor ids to the writer device id, so
+    /// a wrong mapping would reject as `body-invariant` here.
+    #[test]
+    fn owner_surface_and_peer_proposals_admit() {
+        let mut svc = MemoryService::new().unwrap();
+        let dashboard = ActorBinding::dashboard(Some("principal:root-session:test".into()));
+        let view = svc
+            .propose(propose_args("owner observation"), &dashboard)
+            .unwrap();
+        assert_eq!(view.status, "candidate");
+        assert_eq!(view.proposed_by.actor, "dashboard");
+        assert_eq!(
+            view.proposed_by.principal.as_deref(),
+            Some("principal:root-session:test")
+        );
+
+        let local = ActorBinding::local_process(Some("principal:local-process:loopback".into()));
+        let view = svc
+            .propose(propose_args("shell observation"), &local)
+            .unwrap();
+        assert_eq!(view.proposed_by.actor, "local_process");
+
+        let peer = ActorBinding::peer(Some("principal:peer:fingerprint".into()));
+        let view = svc
+            .propose(propose_args("peer observation"), &peer)
+            .unwrap();
+        assert_eq!(view.proposed_by.actor, "peer");
+    }
+
+    /// Ring-2 propose-only (the seam ruling's tenant-edge decision):
+    /// supervised agent sessions, peers, and unattributed callers may
+    /// author candidates and NOTHING else — every other write verb
+    /// denies with the named `actor-not-permitted` outcome BEFORE any
+    /// kernel contact; owner surfaces pass the edge for every verb.
+    #[test]
+    fn ring2_actors_are_propose_only() {
+        for actor in [
+            agent_actor(),
+            ActorBinding::peer(Some("principal:peer:fingerprint".into())),
+            no_actor(),
+        ] {
+            assert!(MemoryService::authorize_write(&actor, Verb::Propose).is_ok());
+            for verb in [
+                Verb::Assert,
+                Verb::JudgeSafe,
+                Verb::JudgeFull,
+                Verb::PinSafe,
+                Verb::PinFull,
+                Verb::CurateInstruction,
+            ] {
+                match MemoryService::authorize_write(&actor, verb) {
+                    Err(MemoryError::NotPermitted { verb: v, actor: a }) => {
+                        assert_eq!(v, verb.as_str());
+                        assert_eq!(a, actor.kind.as_str());
+                    }
+                    other => panic!("expected actor-not-permitted, got {other:?}"),
+                }
+            }
+        }
+        for actor in [
+            ActorBinding::dashboard(None),
+            ActorBinding::local_process(None),
+        ] {
+            for verb in [Verb::Propose, Verb::JudgeSafe, Verb::CurateInstruction] {
+                assert!(MemoryService::authorize_write(&actor, verb).is_ok());
+            }
+        }
+
+        // Through the choke point: the denial happens at the edge —
+        // no op is minted, the plane never sees it.
+        let mut svc = MemoryService::new().unwrap();
+        let held_before = svc.plane.held_ops();
+        let err = svc
+            .seal_write(
+                &agent_actor(),
+                Verb::JudgeSafe,
+                "m.judge",
+                cbor::map(vec![]),
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, MemoryError::NotPermitted { .. }),
+            "expected the named edge denial, got {err:?}"
+        );
+        assert_eq!(
+            svc.plane.held_ops(),
+            held_before,
+            "a denied write must never reach the kernel"
+        );
     }
 }

--- a/src/bin/caller/memory/types.rs
+++ b/src/bin/caller/memory/types.rs
@@ -53,6 +53,47 @@ impl Default for SearchArgs {
     }
 }
 
+/// Who authored a claim, as the daemon's gates attributed it. This is
+/// Memory's **own versioned provenance shape** (`v` names the shape
+/// revision), mapped from `access::actor::ActorBinding` at the tenant
+/// edge — per the seam contract the raw seam type is never serialized
+/// into records; these fields are the record, and they evolve
+/// additively. Unlike the claim body's `session`/`project` fields
+/// (writer-stated context claims), every field here is gate-derived:
+/// never parsed from tool arguments, request bodies, or query echoes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct ClaimProvenance {
+    /// Provenance shape revision (this build writes 1).
+    pub v: u32,
+    /// Actor class, snake_case (`agent_session`, `dashboard`,
+    /// `local_process`, `peer`, `unattributed`). An unauthenticated or
+    /// unstated caller is recorded EXPLICITLY as `unattributed` —
+    /// fail-closed, never a defaulted principal.
+    pub actor: String,
+    /// The IAM principal exactly as the gate named it (verbatim — the
+    /// P1 exit criterion asserts recorded actor == token-bound
+    /// principal).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub principal: Option<String>,
+    /// The supervised session the write acted as — bound by the gate
+    /// through token possession, never echoed from request fields.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session: Option<String>,
+}
+
+impl ClaimProvenance {
+    /// Map the shared seam type into Memory's own record shape at the
+    /// tenant edge (the only place the seam type is consumed).
+    pub(crate) fn from_binding(binding: &crate::access::actor::ActorBinding) -> Self {
+        ClaimProvenance {
+            v: 1,
+            actor: binding.kind.as_str().to_string(),
+            principal: binding.principal_id.clone(),
+            session: binding.session_id.clone(),
+        }
+    }
+}
+
 /// A provenance-labeled claim view. This is DATA for surfaces to
 /// render as quoted content — never instructions (§6.5).
 #[derive(Debug, Clone, Serialize)]
@@ -66,11 +107,16 @@ pub(crate) struct ClaimView {
     /// (`candidate` / `accepted` / `disputed` / `superseded` /
     /// `retired`) — status is a derived view, never a mutable field.
     pub status: String,
+    /// Writer-stated session context (a claim about the claim; when
+    /// the writer states none, the service fills it from the
+    /// gate-bound session). Attribution lives in `proposed_by`.
     pub session: Option<String>,
     pub project: Option<String>,
     pub model: Option<String>,
     pub labels: Vec<String>,
     pub created_ms: u64,
+    /// Gate-derived authorship — see [`ClaimProvenance`].
+    pub proposed_by: ClaimProvenance,
     /// Always `"ephemeral"` in this build (the P1 write bar): the
     /// claim does not survive a daemon restart.
     pub durability: &'static str,
@@ -100,6 +146,17 @@ pub(crate) enum MemoryError {
         what: &'static str,
         got: String,
         allowed: String,
+    },
+    /// The tenant-edge authorization outcome (named, fail-closed —
+    /// §C.2 discipline applies to service-side denials too): the
+    /// resolved actor class may not perform this write verb. Ring-2
+    /// writers (supervised agent sessions, peers, unattributed
+    /// callers) are propose-only; every other write verb needs an
+    /// owner surface.
+    #[error("rejected: actor-not-permitted ({actor} may not {verb}; owner surface required)")]
+    NotPermitted {
+        verb: &'static str,
+        actor: &'static str,
     },
     #[error("no claim matches id prefix {0:?}")]
     NotFound(String),

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -879,10 +879,17 @@ pub(crate) async fn serve_http_request(
                 .await;
             }
             RouteHandlerId::MemoryPropose => {
+                // The authenticated edge: the pre-dispatch IAM gate bound
+                // this principal; no token names a session on this lane.
+                let actor = crate::access::actor::ActorBinding::from_principal(
+                    &http_access_context.principal,
+                    None,
+                );
                 return handle_memory_propose(
                     stream,
                     route_body,
                     mcp_server,
+                    actor,
                     route.cors,
                     fleet_cors_origin.as_deref(),
                 )

--- a/src/bin/caller/web_gateway/mcp_gate.rs
+++ b/src/bin/caller/web_gateway/mcp_gate.rs
@@ -1058,6 +1058,118 @@ mod tests {
         );
     }
 
+    fn memory_claim_from_outcome(outcome: McpHttpOutcome) -> serde_json::Value {
+        let McpHttpOutcome::Response(resp) = outcome else {
+            panic!("expected a response outcome");
+        };
+        let result = resp.result.expect("tool result");
+        assert_ne!(
+            result.get("isError").and_then(serde_json::Value::as_bool),
+            Some(true),
+            "tool errored: {result}"
+        );
+        let text = result["content"][0]["text"].as_str().expect("text content");
+        serde_json::from_str::<serde_json::Value>(text).expect("claim json")["claim"].clone()
+    }
+
+    /// Memory P1's exit-criterion attribution test (package §5.4 /
+    /// umbrella §15.2: attribution unforgeable under the §8 threat
+    /// model — **recorded actor == token-bound principal**), full lane
+    /// in process: the gate classifies the token, dispatch carries the
+    /// resolved `ActorBinding`, and the claim's own provenance fields
+    /// record exactly the principal the token bound. A dashboard-lane
+    /// write with a session id riding the QUERY attributes no session
+    /// anywhere — neither provenance nor claim context. (The
+    /// wire-level token↔session binding is pinned by
+    /// `gate_session_never_trusts_unbound_query_ids`.)
+    #[tokio::test]
+    async fn memory_writes_record_the_token_bound_principal() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let bus = crate::event::EventBus::new();
+        let mut state = crate::mcp::McpAppState::new(
+            "test".into(),
+            "test".into(),
+            crate::autonomy::shared_autonomy(crate::autonomy::AutonomyState::default()),
+            tmp.path().join("logs"),
+        );
+        state.memory = Some(std::sync::Arc::new(
+            crate::memory::MemoryHandle::bootstrap().expect("ephemeral plane bootstraps"),
+        ));
+        let server = crate::mcp::IntendantServer::new(
+            std::sync::Arc::new(tokio::sync::RwLock::new(state)),
+            bus,
+        );
+        let call = |statement: &str| {
+            serde_json::json!({
+                "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {
+                    "name": "memory_propose",
+                    "arguments": { "kind": "observation", "statement": statement },
+                },
+            })
+            .to_string()
+        };
+
+        // Supervised session: agent-session principal + gate-bound sid.
+        let session_access = HttpAccessContext {
+            principal: crate::access::iam::AccessPrincipal::supervised_agent_session_default(
+                "sess-e2e", "http", true,
+            ),
+            iam_state: None,
+        };
+        let outcome = handle_mcp_http_request(
+            &call("proposed by the session"),
+            &server,
+            Some("sess-e2e"),
+            None,
+            None,
+            &session_access,
+            Some("sess-e2e".to_string()),
+        )
+        .await;
+        let claim = memory_claim_from_outcome(outcome);
+        assert_eq!(
+            claim["proposed_by"]["principal"],
+            serde_json::json!(session_access.principal.id),
+            "recorded actor must equal the token-bound principal, verbatim"
+        );
+        assert_eq!(claim["proposed_by"]["actor"], "agent_session");
+        assert_eq!(claim["proposed_by"]["session"], "sess-e2e");
+        assert_eq!(claim["proposed_by"]["v"], 1);
+        // Unstated session context defaulted from the gate binding.
+        assert_eq!(claim["session"], "sess-e2e");
+
+        // Dashboard lane: no gate-bound session, so the query-string
+        // sid must attribute nothing — provenance carries the
+        // dashboard principal only, and the claim context stays empty.
+        let dashboard_access = HttpAccessContext {
+            principal: crate::access::iam::AccessPrincipal::root_dashboard_session("test", "https"),
+            iam_state: None,
+        };
+        let outcome = handle_mcp_http_request(
+            &call("proposed by the owner"),
+            &server,
+            Some("sess-e2e"),
+            None,
+            None,
+            &dashboard_access,
+            None,
+        )
+        .await;
+        let claim = memory_claim_from_outcome(outcome);
+        assert_eq!(claim["proposed_by"]["actor"], "dashboard");
+        assert_eq!(claim["proposed_by"].get("session"), None);
+        assert_eq!(
+            claim["proposed_by"]["principal"],
+            serde_json::json!(dashboard_access.principal.id)
+        );
+        assert_eq!(
+            claim.get("session"),
+            Some(&serde_json::Value::Null),
+            "a query-echoed sid must not leak into the claim context"
+        );
+    }
+
     #[test]
     fn mcp_http_access_context_binds_token_origin_and_loopback_paths() {
         use std::net::{Ipv4Addr, SocketAddr};

--- a/src/bin/caller/web_gateway/routes_memory.rs
+++ b/src/bin/caller/web_gateway/routes_memory.rs
@@ -48,9 +48,13 @@ pub(crate) async fn memory_claim_api_response(
 /// Transport-neutral core of `POST /api/memory/propose` (tunnel twin
 /// `api_memory_propose`): the body is one [`crate::memory::ProposeArgs`]
 /// JSON object; success returns the claim view (status `candidate`).
+/// `actor` is the gate-resolved binding from whichever authenticated
+/// edge dispatched this (the pre-dispatch HTTP IAM gate or the
+/// dashboard-control grant) — attribution never rides the body.
 pub(crate) async fn memory_propose_api_response(
     body_text: &str,
     mcp_server: Option<&Arc<crate::mcp::IntendantServer>>,
+    actor: &crate::access::actor::ActorBinding,
 ) -> ApiResponse {
     let Some(memory) = memory_handle(mcp_server).await else {
         return ApiResponse::json_error(503, "memory service unavailable on this daemon");
@@ -61,7 +65,7 @@ pub(crate) async fn memory_propose_api_response(
             return ApiResponse::json_error(400, format!("invalid memory proposal: {err}"));
         }
     };
-    match memory.propose(args) {
+    match memory.propose(args, actor) {
         Ok(claim) => ApiResponse::json(200, JsonBody::Value(serde_json::json!({ "claim": claim }))),
         Err(err) => ApiResponse::json_error(memory_error_status(&err), err.to_string()),
     }
@@ -77,12 +81,13 @@ async fn memory_handle(
 }
 
 /// Kernel rejections/pends are semantic verdicts (422), not malformed
-/// requests (400); the named outcome/disposition rides the message
-/// verbatim. `Unimplemented` is a kernel-boundary bug report (500).
+/// requests (400); the tenant-edge ring denial is a forbidden action
+/// (403); `Unimplemented` is a kernel-boundary bug report (500).
 fn memory_error_status(err: &crate::memory::MemoryError) -> u16 {
     use crate::memory::MemoryError as E;
     match err {
         E::NotFound(_) => 404,
+        E::NotPermitted { .. } => 403,
         E::Ambiguous(..) | E::Vocabulary { .. } | E::InvalidArg(_) => 400,
         E::Rejected { .. } | E::Pending { .. } => 422,
         E::Unimplemented(_) => 500,
@@ -128,9 +133,10 @@ pub(crate) async fn handle_memory_propose(
     stream: DemuxStream,
     body_text: String,
     mcp_server: Option<Arc<crate::mcp::IntendantServer>>,
+    actor: crate::access::actor::ActorBinding,
     cors: crate::gateway_routes::CorsPosture,
     fleet_origin: Option<&str>,
 ) {
-    let response = memory_propose_api_response(&body_text, mcp_server.as_ref()).await;
+    let response = memory_propose_api_response(&body_text, mcp_server.as_ref(), &actor).await;
     write_api_response(stream, response, cors, fleet_origin).await;
 }


### PR DESCRIPTION
Memory P1.2 — attribution, consuming the A2 `ActorBinding` seam (#365) per the ruled contract.

- **Provenance mapping at the tenant edge**: every propose records the gate-resolved actor in the claim's own versioned provenance fields (`proposed_by {v, actor, principal, session}`) — the raw seam type is never serialized into records; `principal` rides verbatim as the gate names it.
- **Envelope actor**: the sealed op's actor now comes from the binding (agent-session/peer ids carry the IAM principal; human/daemon ids stay the O8 writer device id; ops stay unattested, so non-owner judgments would be fold-inert by §11.4 even past the edge).
- **Ring-2 propose-only**: tenant-edge write authorization from actor kind + the pre-dispatch IAM gate — supervised agent sessions, peers, and unattributed callers may only author candidates; other write verbs deny with the named `actor-not-permitted` outcome (403) before any kernel contact. All future write verbs route through the single `seal_write` choke point.
- **Attribution is never request data**: dispatch session parameters and query-echoed sids attribute nothing; unstated session *context* defaults from the gate-bound session only.
- **Exit-criterion test** (`memory_writes_record_the_token_bound_principal`): recorded actor == token-bound principal, full lane in process (gate → dispatch → tool → claim), plus the dashboard-lane negative.

All four lanes (MCP tools, HTTP route, tunnel twin, ctl-via-MCP) carry the binding from their authenticated edges. No route/IAM/docs/app.html changes.

Battery: `cargo fmt --check`, `cargo clippy`, `cargo nextest run --bins` (3736 passed).