### PR TITLE
session-fork: ForkSessionAtAnchor wire + native engine + e2e (PR C)

### DIFF
--- a/crates/intendant-core/src/conversation.rs
+++ b/crates/intendant-core/src/conversation.rs
@@ -858,6 +858,21 @@ impl Conversation {
         removed
     }
 
+    /// Length of the message prefix ending at the message whose `seq` is
+    /// exactly `cut_after_seq` — the `truncate_to` target for a fork that
+    /// keeps history through that message. `None` when no message carries
+    /// the seq: a stale anchor (history moved since it was read) or legacy
+    /// `seq == 0` messages, both of which must refuse rather than guess.
+    pub fn prefix_len_through_seq(&self, cut_after_seq: u64) -> Option<usize> {
+        if cut_after_seq == 0 {
+            return None;
+        }
+        self.messages
+            .iter()
+            .position(|message| message.seq == cut_after_seq)
+            .map(|index| index + 1)
+    }
+
     pub fn drop_turns(&mut self, indices: &[usize]) {
         let len = self.messages.len();
         let protected_min = if len >= 2 { len - 2 } else { len };

--- a/src/bin/caller/access/access_policy.rs
+++ b/src/bin/caller/access/access_policy.rs
@@ -907,6 +907,7 @@ pub fn control_msg_operation(ctrl: &ControlMsg) -> PeerOperation {
         | ControlMsg::CreateSession { .. }
         | ControlMsg::SpawnSubAgent { .. }
         | ControlMsg::ResumeSession { .. }
+        | ControlMsg::ForkSessionAtAnchor { .. }
         | ControlMsg::EditUserMessage { .. } => PeerOperation::Task,
         ControlMsg::Approve { .. }
         | ControlMsg::Deny { .. }

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -2656,6 +2656,15 @@ Proceed with explicit assumptions and continue without additional questions."
         }
     }
 
+    // Persist the conversation on every exit path: the in-loop auto-save
+    // runs at turn end, but done-signal exits `break` before reaching it —
+    // without this, a session whose final round ends in signal_done leaves
+    // no conversation.jsonl for cold resume or fork-from-anchor.
+    if let Err(e) = conversation.save_to_file(&log_dir.join("conversation.jsonl")) {
+        slog(&session_log, |l| {
+            l.debug(&format!("Failed to save conversation at loop exit: {}", e))
+        });
+    }
     slog(&session_log, |l| l.info("Agent loop finished"));
     Ok((loop_stats, exit_reason))
 }

--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -1588,6 +1588,7 @@ pub(crate) fn dashboard_session_control_msg_allowed(ctrl: &ControlMsg) -> bool {
             | ControlMsg::SpawnSubAgent { .. }
             | ControlMsg::StartTask { .. }
             | ControlMsg::ResumeSession { .. }
+            | ControlMsg::ForkSessionAtAnchor { .. }
             | ControlMsg::FollowUp { .. }
             | ControlMsg::CancelFollowUp { .. }
             | ControlMsg::EditUserMessage { .. }
@@ -1661,6 +1662,7 @@ pub(crate) fn dashboard_control_msg_action(ctrl: &ControlMsg) -> &'static str {
         ControlMsg::StopSession { .. } => "stop_session",
         ControlMsg::RestartSession { .. } => "restart_session",
         ControlMsg::ResumeSession { .. } => "resume_session",
+        ControlMsg::ForkSessionAtAnchor { .. } => "fork_session_at_anchor",
         ControlMsg::SetClaudeModel { .. } => "set_claude_model",
         ControlMsg::SetClaudePermissionMode { .. } => "set_claude_permission_mode",
         ControlMsg::SetClaudeAllowedTools { .. } => "set_claude_allowed_tools",

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -338,6 +338,18 @@ pub enum AppEvent {
         relationship: String,
         ephemeral: bool,
     },
+    /// Outcome of a `ForkSessionAtAnchor` request: the child session id on
+    /// success, or the error. `request_id` echoes the request's
+    /// correlation id so frontends can pair the result to their action.
+    SessionForkResult {
+        request_id: Option<String>,
+        parent_session_id: String,
+        child_session_id: Option<String>,
+        source: String,
+        relationship: String,
+        anchor_summary: String,
+        error: Option<String>,
+    },
     /// Describes which frontend actions are supported for a visible session.
     /// Synthetic child sessions can use this to expose follow-ups while
     /// disabling controls the underlying backend cannot honor for that target.
@@ -1695,6 +1707,35 @@ pub enum ControlMsg {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         codex_context_archive: Option<String>,
     },
+    /// Fork a session into a NEW session cut at a chosen fork point (from
+    /// `GET /api/session/{id}/fork-points`). The fork engines only ever
+    /// copy parent artifacts — the parent session/transcript is never
+    /// mutated — and fork lineage/config ride internal launch overrides
+    /// the wire cannot set. The child is spawned/attached immediately and
+    /// announced via a `session_fork_result` event carrying `request_id`.
+    ForkSessionAtAnchor {
+        /// Session source: "intendant", "codex", or "claude-code".
+        source: String,
+        /// Display id from the Sessions tab. For Intendant this is the
+        /// session log id; for external backends the native session id.
+        session_id: String,
+        /// Backend-specific resume token. Defaults to `session_id`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        resume_id: Option<String>,
+        /// The chosen fork point.
+        anchor: crate::session_fork::ForkAnchorSpec,
+        /// Optional display name for the child session.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        /// Optional prompt sent as the child's first turn once attached.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        task: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        project_root: Option<String>,
+        /// Client correlation id echoed on the result event.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+    },
     FollowUp {
         /// Optional target session. Omitted means "current active session"
         /// for legacy single-session frontends.
@@ -2350,6 +2391,23 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
             child_session_id: child_session_id.clone(),
             relationship: relationship.clone(),
             ephemeral: *ephemeral,
+        }),
+        AppEvent::SessionForkResult {
+            request_id,
+            parent_session_id,
+            child_session_id,
+            source,
+            relationship,
+            anchor_summary,
+            error,
+        } => Some(OutboundEvent::SessionForkResult {
+            request_id: request_id.clone(),
+            parent_session_id: parent_session_id.clone(),
+            child_session_id: child_session_id.clone(),
+            source: source.clone(),
+            relationship: relationship.clone(),
+            anchor_summary: anchor_summary.clone(),
+            error: error.clone(),
         }),
         AppEvent::SessionCapabilities {
             session_id,

--- a/src/bin/caller/mcp/commands.rs
+++ b/src/bin/caller/mcp/commands.rs
@@ -1078,6 +1078,18 @@ pub(crate) async fn handle_control_command_mcp(
             );
             Some(RESOURCE_STATUS_URI)
         }
+        ControlMsg::ForkSessionAtAnchor {
+            source, session_id, ..
+        } => {
+            emit_control_result(
+                control_tx,
+                "fork_session_at_anchor",
+                true,
+                format!("fork dispatched: {} {}", source, session_id),
+                None,
+            );
+            Some(RESOURCE_STATUS_URI)
+        }
         ControlMsg::StopSession { session_id } => {
             emit_control_result(
                 control_tx,

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -247,6 +247,7 @@ pub fn spawn_event_listener(
                     | AppEvent::FollowUpCancelRequested { .. }
                     | AppEvent::SessionStopRequested { .. }
                     | AppEvent::SessionRelationship { .. }
+                    | AppEvent::SessionForkResult { .. }
                     | AppEvent::TaskReceived { .. }
                     | AppEvent::SessionGoal { .. }
                     | AppEvent::SessionVitals { .. }

--- a/src/bin/caller/peer/upcast.rs
+++ b/src/bin/caller/peer/upcast.rs
@@ -913,6 +913,25 @@ impl AppEventUpcaster {
                 s.ephemeral = *ephemeral;
             })),
 
+            AppEvent::SessionForkResult {
+                parent_session_id,
+                child_session_id,
+                error,
+                ..
+            } => vec![log_event(
+                LogLevel::Info,
+                "session",
+                match (child_session_id, error) {
+                    (Some(child), _) => {
+                        format!("session fork: {parent_session_id} -> {child}")
+                    }
+                    (_, Some(error)) => {
+                        format!("session fork of {parent_session_id} failed: {error}")
+                    }
+                    _ => format!("session fork of {parent_session_id} completed"),
+                },
+            )],
+
             AppEvent::SessionGoal { session_id, goal } => session_updated_events(
                 self.sessions.update(session_id, |s| s.goal = goal.clone()),
             ),
@@ -2327,6 +2346,25 @@ impl WireEventUpcaster {
                 s.relationship = relationship.clone();
                 s.ephemeral = *ephemeral;
             })),
+
+            OutboundEvent::SessionForkResult {
+                parent_session_id,
+                child_session_id,
+                error,
+                ..
+            } => vec![log_event(
+                LogLevel::Info,
+                "session",
+                match (child_session_id, error) {
+                    (Some(child), _) => {
+                        format!("session fork: {parent_session_id} -> {child}")
+                    }
+                    (_, Some(error)) => {
+                        format!("session fork of {parent_session_id} failed: {error}")
+                    }
+                    _ => format!("session fork of {parent_session_id} completed"),
+                },
+            )],
 
             OutboundEvent::SessionGoal { session_id, goal } => session_updated_events(
                 self.sessions.update(session_id, |s| s.goal = goal.clone()),

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -1120,6 +1120,7 @@ pub fn filter_event(event: &AppEvent, last_phase: &mut String) -> Option<Presenc
         | AppEvent::CodexThreadActionResult { .. }
         | AppEvent::SessionIdentity { .. }
         | AppEvent::SessionRelationship { .. }
+        | AppEvent::SessionForkResult { .. }
         | AppEvent::SessionCapabilities { .. }
         | AppEvent::SessionGoal { .. }
         | AppEvent::SessionVitals { .. }

--- a/src/bin/caller/session_fork/mod.rs
+++ b/src/bin/caller/session_fork/mod.rs
@@ -23,8 +23,10 @@
 
 mod claude_tree;
 mod fork_points;
+mod native;
 pub(crate) use claude_tree::*;
 pub(crate) use fork_points::*;
+pub(crate) use native::*;
 
 use serde::Serialize;
 
@@ -42,20 +44,20 @@ pub(crate) struct ForkPoint {
     pub(crate) granularity: &'static str,
     /// 1-based user-turn / round ordinal this point relates to.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) turn: Option<u32>,
+    pub turn: Option<u32>,
     /// Native only: `seq` of the last message the fork keeps.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) seq: Option<u64>,
+    pub seq: Option<u64>,
     /// Codex only: the rollout item id of the anchor.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) item_id: Option<String>,
+    pub item_id: Option<String>,
     /// Codex only: cut position relative to the item (`before`/`after`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) position: Option<&'static str>,
     /// Claude Code only: the transcript message uuid the fork keeps
     /// history through (the chain-slice anchor).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) message_uuid: Option<String>,
+    pub message_uuid: Option<String>,
     /// Claude Code only: the anchor sits on history replaced by the
     /// newest compact boundary. Informational — the chain-slice fork
     /// omits the boundary and keeps full pre-compaction history.
@@ -136,6 +138,48 @@ impl Default for ForkPointQuery {
             offset: 0,
             limit: FORK_POINT_DEFAULT_LIMIT,
         }
+    }
+}
+
+/// The wire form of a chosen fork point, carried by
+/// `ControlMsg::ForkSessionAtAnchor`. Field usage mirrors `ForkPoint`:
+/// codex anchors use `item_id`/`position` or `turn`, native uses `seq`,
+/// claude-code uses `message_uuid`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ForkAnchorSpec {
+    /// Fork-point kind from the catalog (`turn-boundary`, `item-anchor`,
+    /// `round`, `head`, `message`, `branch-tip`).
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub item_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub position: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seq: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message_uuid: Option<String>,
+}
+
+impl ForkAnchorSpec {
+    /// One-line summary for result events and logs.
+    pub(crate) fn summary(&self) -> String {
+        let mut parts = vec![self.kind.clone()];
+        if let Some(turn) = self.turn {
+            parts.push(format!("turn {turn}"));
+        }
+        if let Some(seq) = self.seq {
+            parts.push(format!("seq {seq}"));
+        }
+        if let Some(item_id) = &self.item_id {
+            let position = self.position.as_deref().unwrap_or("after");
+            parts.push(format!("{position} {item_id}"));
+        }
+        if let Some(uuid) = &self.message_uuid {
+            parts.push(format!("through {uuid}"));
+        }
+        parts.join(", ")
     }
 }
 

--- a/src/bin/caller/session_fork/native.rs
+++ b/src/bin/caller/session_fork/native.rs
@@ -1,0 +1,245 @@
+//! Native-session fork engine: materialize a NEW session whose
+//! conversation is the parent's prefix through a chosen `seq`. Copy-only —
+//! the parent's log dir is read, never written; the child gets its own
+//! uuid log dir with a truncated `conversation.jsonl`, a rewritten
+//! `session_meta.json`, and a durable `session_relationship` line so the
+//! lineage ledger sees the `anchor-fork` edge before the child ever runs.
+
+use super::ForkAnchorSpec;
+use std::io::Write;
+use std::path::Path;
+
+#[derive(Debug)]
+pub(crate) struct NativeForkOutcome {
+    pub(crate) child_session_id: String,
+    pub(crate) kept_messages: usize,
+}
+
+/// Load-time window for the fork's conversation read. Budget math is not
+/// exercised here — the child re-loads under its provider's real window
+/// when it resumes.
+const FORK_LOAD_CONTEXT_WINDOW: u64 = 1_000_000;
+
+pub(crate) fn fork_native_session_at_seq(
+    logs_root: &Path,
+    parent_session_id: &str,
+    parent_log_dir: &Path,
+    anchor: &ForkAnchorSpec,
+    child_name: Option<&str>,
+) -> Result<NativeForkOutcome, String> {
+    let cut_after_seq = anchor
+        .seq
+        .filter(|seq| *seq > 0)
+        .ok_or_else(|| "a native fork anchor needs a non-zero `seq`".to_string())?;
+    let conversation_path = parent_log_dir.join("conversation.jsonl");
+    let mut conversation = crate::conversation::Conversation::load_from_file(
+        &conversation_path,
+        FORK_LOAD_CONTEXT_WINDOW,
+    )
+    .map_err(|err| format!("failed to load the parent conversation: {err}"))?;
+    let keep = conversation
+        .prefix_len_through_seq(cut_after_seq)
+        .ok_or_else(|| {
+            format!(
+                "anchor seq {cut_after_seq} not found in the parent conversation \
+             (history may have moved since the fork points were read)"
+            )
+        })?;
+    conversation.truncate_to(keep);
+
+    let child_session_id = uuid::Uuid::new_v4().to_string();
+    let child_log_dir = logs_root.join(&child_session_id);
+    std::fs::create_dir_all(&child_log_dir)
+        .map_err(|err| format!("failed to create the child log dir: {err}"))?;
+    conversation
+        .save_to_file(&child_log_dir.join("conversation.jsonl"))
+        .map_err(|err| format!("failed to write the child conversation: {err}"))?;
+
+    // The child's meta starts as the parent's (project root, provider…)
+    // with its own identity and fork provenance.
+    let mut meta = std::fs::read_to_string(parent_log_dir.join("session_meta.json"))
+        .ok()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+    meta["session_id"] = serde_json::Value::String(child_session_id.clone());
+    meta["forked_from"] = serde_json::Value::String(parent_session_id.to_string());
+    meta["fork_cut_after_seq"] = serde_json::Value::from(cut_after_seq);
+    if let Some(name) = child_name.map(str::trim).filter(|name| !name.is_empty()) {
+        meta["name"] = serde_json::Value::String(name.to_string());
+    }
+    std::fs::write(child_log_dir.join("session_meta.json"), meta.to_string())
+        .map_err(|err| format!("failed to write the child session meta: {err}"))?;
+
+    // Durable lineage edge in the child's own spine, in the exact
+    // `session_relationship` shape the lineage ledger folds (the test
+    // below pins that via `read_lineage_ledger`).
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let line = serde_json::json!({
+        "ts": chrono::Local::now().format("%H:%M:%S%.3f").to_string(),
+        "ts_ms": now_ms,
+        "event": "session_relationship",
+        "message": format!("anchor-fork of {parent_session_id} (seq {cut_after_seq})"),
+        "data": {
+            "parent_session_id": parent_session_id,
+            "child_session_id": child_session_id,
+            "relationship": "anchor-fork",
+            "ephemeral": false,
+        },
+    });
+    let mut spine = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(child_log_dir.join("session.jsonl"))
+        .map_err(|err| format!("failed to open the child session log: {err}"))?;
+    writeln!(spine, "{line}").map_err(|err| format!("failed to write the lineage edge: {err}"))?;
+    spine
+        .sync_all()
+        .map_err(|err| format!("failed to sync the child session log: {err}"))?;
+
+    Ok(NativeForkOutcome {
+        child_session_id,
+        kept_messages: keep,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::Digest;
+    use std::path::PathBuf;
+
+    fn seed_parent(logs_root: &Path, session_id: &str) -> PathBuf {
+        let dir = logs_root.join(session_id);
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let lines = [
+            serde_json::json!({"role":"system","content":"sys","seq":1}),
+            serde_json::json!({"role":"user","content":"round one","seq":2}),
+            serde_json::json!({"role":"assistant","content":"answer one","seq":3}),
+            serde_json::json!({"role":"user","content":"round two","seq":4}),
+            serde_json::json!({"role":"assistant","content":"answer two","seq":5}),
+        ];
+        let body: String = lines.iter().map(|line| format!("{line}\n")).collect();
+        std::fs::write(dir.join("conversation.jsonl"), body).expect("conversation");
+        std::fs::write(
+            dir.join("session_meta.json"),
+            serde_json::json!({"session_id": session_id, "project_root": "/tmp/proj"}).to_string(),
+        )
+        .expect("meta");
+        dir
+    }
+
+    fn dir_hash(dir: &Path) -> String {
+        let mut entries: Vec<_> = std::fs::read_dir(dir)
+            .expect("read dir")
+            .flatten()
+            .map(|entry| entry.path())
+            .collect();
+        entries.sort();
+        let mut hasher = sha2::Sha256::new();
+        for path in entries {
+            hasher.update(path.to_string_lossy().as_bytes());
+            hasher.update(std::fs::read(&path).expect("read file"));
+        }
+        format!("{:x}", hasher.finalize())
+    }
+
+    fn anchor(seq: u64) -> ForkAnchorSpec {
+        ForkAnchorSpec {
+            kind: "round".to_string(),
+            turn: None,
+            item_id: None,
+            position: None,
+            seq: Some(seq),
+            message_uuid: None,
+        }
+    }
+
+    #[test]
+    fn fork_materializes_truncated_child_and_leaves_parent_untouched() {
+        let root = tempfile::tempdir().expect("root");
+        let parent_dir = seed_parent(root.path(), "parent-id");
+        let parent_before = dir_hash(&parent_dir);
+
+        let outcome =
+            fork_native_session_at_seq(root.path(), "parent-id", &parent_dir, &anchor(3), None)
+                .expect("fork");
+        assert_eq!(outcome.kept_messages, 3);
+        assert_eq!(dir_hash(&parent_dir), parent_before, "parent mutated");
+        let child_log_dir = root.path().join(&outcome.child_session_id);
+
+        let child_conversation = std::fs::read_to_string(child_log_dir.join("conversation.jsonl"))
+            .expect("child conversation");
+        assert_eq!(child_conversation.lines().count(), 3);
+        assert!(child_conversation.contains("answer one"));
+        assert!(!child_conversation.contains("round two"));
+
+        let meta: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(child_log_dir.join("session_meta.json")).expect("child meta"),
+        )
+        .expect("meta json");
+        assert_eq!(meta["session_id"], outcome.child_session_id.as_str());
+        assert_eq!(meta["forked_from"], "parent-id");
+        assert_eq!(meta["project_root"], "/tmp/proj");
+
+        // The lineage ledger folds the edge from the child's spine.
+        let ledger = crate::lineage_ledger::read_lineage_ledger(&child_log_dir, "parent-id")
+            .expect("ledger read")
+            .expect("ledger present");
+        let branch = ledger
+            .groups
+            .iter()
+            .flat_map(|group| group.branches.iter())
+            .find(|branch| branch.session_id == outcome.child_session_id)
+            .expect("anchor-fork branch");
+        assert_eq!(branch.relationship, "anchor-fork");
+    }
+
+    #[test]
+    fn fork_names_the_child_when_asked() {
+        let root = tempfile::tempdir().expect("root");
+        let parent_dir = seed_parent(root.path(), "parent-id");
+        let outcome = fork_native_session_at_seq(
+            root.path(),
+            "parent-id",
+            &parent_dir,
+            &anchor(2),
+            Some("experiment"),
+        )
+        .expect("fork");
+        let child_log_dir = root.path().join(&outcome.child_session_id);
+        let meta: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(child_log_dir.join("session_meta.json")).expect("child meta"),
+        )
+        .expect("meta json");
+        assert_eq!(meta["name"], "experiment");
+    }
+
+    #[test]
+    fn stale_or_zero_seq_is_refused() {
+        let root = tempfile::tempdir().expect("root");
+        let parent_dir = seed_parent(root.path(), "parent-id");
+        let err =
+            fork_native_session_at_seq(root.path(), "parent-id", &parent_dir, &anchor(99), None)
+                .expect_err("stale seq");
+        assert!(err.contains("not found"));
+        let err = fork_native_session_at_seq(
+            root.path(),
+            "parent-id",
+            &parent_dir,
+            &ForkAnchorSpec {
+                kind: "round".to_string(),
+                turn: None,
+                item_id: None,
+                position: None,
+                seq: Some(0),
+                message_uuid: None,
+            },
+            None,
+        )
+        .expect_err("zero seq");
+        assert!(err.contains("non-zero"));
+    }
+}

--- a/src/bin/caller/session_supervisor/dispatch.rs
+++ b/src/bin/caller/session_supervisor/dispatch.rs
@@ -336,6 +336,28 @@ impl SessionSupervisor {
                 )
                 .await;
             }
+            event::ControlMsg::ForkSessionAtAnchor {
+                source,
+                session_id,
+                resume_id,
+                anchor,
+                name,
+                task,
+                project_root,
+                request_id,
+            } => {
+                self.fork_session_at_anchor(
+                    source,
+                    session_id,
+                    resume_id,
+                    anchor,
+                    name,
+                    task,
+                    project_root,
+                    request_id,
+                )
+                .await;
+            }
             event::ControlMsg::StopSession { session_id } => {
                 self.stop_managed_session(Some(session_id), "stopped by user")
                     .await;

--- a/src/bin/caller/session_supervisor/fork.rs
+++ b/src/bin/caller/session_supervisor/fork.rs
@@ -1,0 +1,128 @@
+//! `ForkSessionAtAnchor` orchestration: resolve the parent, run the
+//! per-backend copy-only fork engine, announce the lineage edge and the
+//! `session_fork_result`, then activate the child through the normal
+//! resume funnel (v1 always activates). Fork lineage never rides wire
+//! overrides — the engines persist it into the child's own artifacts.
+
+use super::*;
+use crate::session_fork::{ForkAnchorSpec, NativeForkOutcome};
+
+impl SessionSupervisor {
+    #[allow(clippy::too_many_arguments)] // mirrors the resume funnel's established signature style
+    pub(crate) async fn fork_session_at_anchor(
+        &self,
+        source: String,
+        session_id: String,
+        resume_id: Option<String>,
+        anchor: ForkAnchorSpec,
+        name: Option<String>,
+        task: Option<String>,
+        project_root: Option<String>,
+        request_id: Option<String>,
+    ) {
+        let token = resume_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|token| !token.is_empty())
+            .unwrap_or(session_id.trim())
+            .to_string();
+        let result = match source.as_str() {
+            "intendant" => self.fork_native_session(&token, &anchor, name.as_deref()).await,
+            "codex" | "claude-code" => Err(format!(
+                "the {source} fork engine lands in a follow-up phase (fork points are already served)"
+            )),
+            other => Err(format!("fork is not supported for {other} sessions")),
+        };
+        match result {
+            Ok(outcome) => {
+                self.config.bus.send(AppEvent::SessionRelationship {
+                    parent_session_id: token.clone(),
+                    child_session_id: outcome.child_session_id.clone(),
+                    relationship: "anchor-fork".to_string(),
+                    ephemeral: false,
+                });
+                self.config.bus.send(AppEvent::SessionForkResult {
+                    request_id,
+                    parent_session_id: token,
+                    child_session_id: Some(outcome.child_session_id.clone()),
+                    source: source.clone(),
+                    relationship: "anchor-fork".to_string(),
+                    anchor_summary: format!(
+                        "{} ({} messages kept)",
+                        anchor.summary(),
+                        outcome.kept_messages
+                    ),
+                    error: None,
+                });
+                if let Some(name) = name
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|name| !name.is_empty())
+                {
+                    self.rename_session(
+                        outcome.child_session_id.clone(),
+                        None,
+                        Some(source.clone()),
+                        name.to_string(),
+                    )
+                    .await;
+                }
+                // v1 always activates: attach the child through the normal
+                // resume funnel, which also delivers the optional first task.
+                self.resume_session(
+                    source,
+                    outcome.child_session_id.clone(),
+                    Some(outcome.child_session_id),
+                    project_root,
+                    task,
+                    Some(true),
+                    Vec::new(),
+                    false,
+                    None,
+                    LaunchOverrides::default(),
+                    false,
+                    false,
+                )
+                .await;
+            }
+            Err(error) => {
+                self.config.bus.send(AppEvent::SessionForkResult {
+                    request_id,
+                    parent_session_id: token,
+                    child_session_id: None,
+                    source,
+                    relationship: "anchor-fork".to_string(),
+                    anchor_summary: anchor.summary(),
+                    error: Some(error),
+                });
+            }
+        }
+    }
+
+    async fn fork_native_session(
+        &self,
+        token: &str,
+        anchor: &ForkAnchorSpec,
+        name: Option<&str>,
+    ) -> Result<NativeForkOutcome, String> {
+        let home = crate::platform::home_dir();
+        let parent_dir =
+            crate::session_log::SessionLog::find_session_by_id_in_home(&home, token)
+                .ok_or_else(|| format!("session {token} not found in the native session store"))?;
+        let logs_root = crate::platform::intendant_home_in(&home).join("logs");
+        let token = token.to_string();
+        let anchor = anchor.clone();
+        let name = name.map(str::to_string);
+        tokio::task::spawn_blocking(move || {
+            crate::session_fork::fork_native_session_at_seq(
+                &logs_root,
+                &token,
+                &parent_dir,
+                &anchor,
+                name.as_deref(),
+            )
+        })
+        .await
+        .map_err(|err| format!("fork task failed: {err}"))?
+    }
+}

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -22,6 +22,7 @@ pub(crate) use routing::*;
 mod agent_config;
 pub(crate) use agent_config::*;
 mod dispatch;
+mod fork;
 mod registry;
 
 #[derive(Clone)]

--- a/src/bin/caller/types.rs
+++ b/src/bin/caller/types.rs
@@ -347,6 +347,18 @@ pub enum OutboundEvent {
         relationship: String,
         ephemeral: bool,
     },
+    SessionForkResult {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_id: Option<String>,
+        parent_session_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        child_session_id: Option<String>,
+        source: String,
+        relationship: String,
+        anchor_summary: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
     SessionCapabilities {
         session_id: String,
         capabilities: SessionCapabilities,

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -4213,3 +4213,218 @@ async fn headless_rollback_writes_a_conversation_rewound_cut() {
          supersede round 2 (seq {round2_seq})"
     );
 }
+
+/// Fork-from-anchor, native lane: a two-round scripted session forked at
+/// the round boundary before round two. The child must materialize as a
+/// prefix-only session (round one, nothing of round two), the parent's
+/// persisted conversation must be byte-identical afterwards, the
+/// `anchor-fork` lineage edge must be durable in the child's spine, and
+/// the `session_fork_result` must ride the event lane with the request's
+/// correlation id. A stale anchor must fail as a structured result, not
+/// a dead session.
+#[tokio::test]
+async fn native_session_forks_at_a_round_boundary() {
+    use futures_util::SinkExt;
+
+    let script = serde_json::json!({
+        "profiles": [{
+            "steps": [
+                { "content": "Round one answer.",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "round one complete" } }] },
+                { "content": "Round two answer.",
+                  "tool_calls": [{ "name": "signal_done",
+                                   "arguments": { "message": "round two complete" } }] }
+            ]
+        }]
+    });
+    let client = reqwest::Client::new();
+    let mut daemon = spawn_daemon(&client, &script, free_loopback_port()).await;
+    let port = daemon.port;
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://127.0.0.1:{port}/ws"))
+        .await
+        .expect("connect /ws");
+
+    // Round one (retry the first send: it can race daemon startup).
+    let mut started = None;
+    for _ in 0..6 {
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::json!({
+                "action": "create_session",
+                "task": "fork-anchor round one",
+                "direct": true,
+            })
+            .to_string()
+            .into(),
+        ))
+        .await
+        .expect("send create_session");
+        started = next_matching_ws_event(&mut ws, Duration::from_secs(30), |json| {
+            json.get("event").and_then(|v| v.as_str()) == Some("session_started")
+                && json
+                    .get("task")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|task| task.contains("fork-anchor round one"))
+        })
+        .await;
+        if started.is_some() {
+            break;
+        }
+    }
+    let started = started.unwrap_or_else(|| {
+        panic!(
+            "create_session never started; daemon log:\n{}",
+            daemon.log_tail()
+        )
+    });
+    let parent_id = started
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .expect("session_started carries a session id")
+        .to_string();
+    next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("round_complete")
+    })
+    .await
+    .unwrap_or_else(|| panic!("round one never completed:\n{}", daemon.log_tail()));
+
+    // Round two via follow-up, so the boundary between the rounds exists.
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "follow_up",
+            "session_id": parent_id,
+            "text": "fork-anchor round two",
+            "direct": true,
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send follow_up");
+    // Stop the parent after round two: the native conversation persists at
+    // session stop, and the Recent-tab fork UX targets cold sessions.
+    complete_and_stop_session(&mut ws, &parent_id, || daemon.log_tail()).await;
+
+    // The catalog must offer the boundary before round two.
+    let fork_points = http_get_json(
+        &client,
+        &format!("http://127.0.0.1:{port}/api/session/{parent_id}/fork-points"),
+    )
+    .await
+    .expect("fork-points response");
+    assert_eq!(fork_points["source"], "intendant", "{fork_points}");
+    assert_eq!(fork_points["supported"], true, "{fork_points}");
+    let round_point = fork_points["fork_points"]
+        .as_array()
+        .expect("fork_points array")
+        .iter()
+        .find(|point| point["kind"] == "round" && point["eligible"] == true)
+        .unwrap_or_else(|| panic!("no eligible round boundary in {fork_points}"))
+        .clone();
+    let cut_seq = round_point["seq"].as_u64().expect("round point seq");
+
+    // Parent's persisted conversation, byte-pinned across the fork.
+    let logs_root = daemon.rig.home.path().join(".intendant").join("logs");
+    let parent_conversation = logs_root.join(&parent_id).join("conversation.jsonl");
+    let parent_bytes_before =
+        std::fs::read(&parent_conversation).expect("parent conversation exists");
+
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "fork_session_at_anchor",
+            "source": "intendant",
+            "session_id": parent_id,
+            "anchor": { "kind": "round", "seq": cut_seq },
+            "request_id": "e2e-fork-1",
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send fork_session_at_anchor");
+    let result = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("session_fork_result")
+            && json.get("request_id").and_then(|v| v.as_str()) == Some("e2e-fork-1")
+    })
+    .await
+    .unwrap_or_else(|| panic!("no session_fork_result; daemon log:\n{}", daemon.log_tail()));
+    assert!(
+        result.get("error").and_then(|v| v.as_str()).is_none(),
+        "fork failed: {result}"
+    );
+    assert_eq!(result["relationship"], "anchor-fork", "{result}");
+    let child_id = result["child_session_id"]
+        .as_str()
+        .expect("fork result carries the child id")
+        .to_string();
+
+    // Child = strict prefix; parent untouched; durable lineage edge.
+    let child_dir = logs_root.join(&child_id);
+    let child_conversation =
+        std::fs::read_to_string(child_dir.join("conversation.jsonl")).expect("child conversation");
+    let parent_text = String::from_utf8_lossy(&parent_bytes_before).to_string();
+    assert!(
+        child_conversation.lines().count() < parent_text.lines().count(),
+        "child must be a strict prefix: child\n{child_conversation}\nparent\n{parent_text}"
+    );
+    assert!(
+        !child_conversation.contains("round two"),
+        "child leaked round two:\n{child_conversation}"
+    );
+    assert_eq!(
+        std::fs::read(&parent_conversation).expect("parent conversation still exists"),
+        parent_bytes_before,
+        "parent conversation mutated by the fork"
+    );
+    let child_spine =
+        std::fs::read_to_string(child_dir.join("session.jsonl")).expect("child spine");
+    assert!(
+        child_spine.contains("\"anchor-fork\"") && child_spine.contains(&parent_id),
+        "child spine missing the anchor-fork edge:\n{child_spine}"
+    );
+
+    // The child is visible in the catalog.
+    let sessions = http_get_json(&client, &format!("http://127.0.0.1:{port}/api/sessions"))
+        .await
+        .expect("sessions list");
+    let rows = sessions["sessions"]
+        .as_array()
+        .cloned()
+        .or_else(|| sessions.as_array().cloned())
+        .expect("sessions array");
+    assert!(
+        rows.iter()
+            .any(|row| row["session_id"].as_str() == Some(child_id.as_str())),
+        "child session missing from the catalog: {sessions}"
+    );
+
+    // A stale anchor fails as a structured result.
+    ws.send(tokio_tungstenite::tungstenite::Message::Text(
+        serde_json::json!({
+            "action": "fork_session_at_anchor",
+            "source": "intendant",
+            "session_id": parent_id,
+            "anchor": { "kind": "round", "seq": 999_999 },
+            "request_id": "e2e-fork-stale",
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send stale fork");
+    let stale = next_matching_ws_event(&mut ws, RUN_TIMEOUT, |json| {
+        json.get("event").and_then(|v| v.as_str()) == Some("session_fork_result")
+            && json.get("request_id").and_then(|v| v.as_str()) == Some("e2e-fork-stale")
+    })
+    .await
+    .unwrap_or_else(|| panic!("no stale-fork result; daemon log:\n{}", daemon.log_tail()));
+    assert!(
+        stale
+            .get("error")
+            .and_then(|v| v.as_str())
+            .is_some_and(|err| err.contains("not found")),
+        "stale fork should fail with a not-found error: {stale}"
+    );
+
+    daemon.child.kill().await.expect("stop the daemon");
+}


### PR DESCRIPTION
Phase C of fork-from-any-anchor (#353 probes, #354 catalog, #361 CC tree).

**Wire**: `ControlMsg::ForkSessionAtAnchor {source, session_id, resume_id, anchor: ForkAnchorSpec, name, task, project_root, request_id}` — classified `PeerOperation::Task` beside ResumeSession, allowed on the session-control tunnel, action name `fork_session_at_anchor`; result rides a new `session_fork_result` outbound event (correlated by `request_id`), and the compiler-forced match arms (mcp commands/events, peer upcast both lanes, presence) are filled.

**Native engine** (`session_fork/native.rs`, copy-only): resolves the anchor's exact `seq` via the new `Conversation::prefix_len_through_seq` (stale/zero seqs refuse with a structured error), truncates into a fresh uuid log dir, carries parent meta with fork provenance, and writes a durable `anchor-fork` `session_relationship` line into the child spine — unit-pinned against the real `read_lineage_ledger` fold, with parent-dir hash-unchanged assertions. The supervisor orchestrator emits the lineage edge + result, optionally renames, and activates the child through the normal resume funnel. codex/claude-code arms are structured follow-up-phase errors (engines land next).

**Latent bug fixed en route**: the agent loop's conversation auto-save ran at loop-bottom only, so done-signal exits (`break` at the signal_done arm) never persisted `conversation.jsonl` — sessions whose final round ended in signal_done had nothing for cold resume. The loop now saves on every exit path.

**e2e** (`native_session_forks_at_a_round_boundary`): scripted two-round session → stop → `GET fork-points` → fork at the round boundary over `/ws` → child is a strict prefix (no round two), parent conversation byte-identical, durable edge in the child spine, child visible in the catalog, stale anchor fails as a structured result.

Battery: fmt clean; full units 3711/3711; full e2e 22/22; check clean with `--bins --tests`.