### PR TITLE
ci: install cargo-audit as a prebuilt binary in the audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,6 +21,9 @@ on:
       - "Cargo.lock"
       - "crates/**/Cargo.toml"
       - ".cargo/audit.toml"
+      # Edits to this workflow validate themselves pre-merge (advisory
+      # check, not required — a paths filter here can't wedge queue entry).
+      - ".github/workflows/audit.yml"
   schedule:
     # Mondays at 08:00 UTC.
     - cron: "0 8 * * 1"
@@ -44,6 +47,12 @@ jobs:
         # nothing in these jobs pushes.
         with:
           persist-credentials: false
+      # Prebuilt cargo-audit binary (seconds) so audit-check below finds it on
+      # PATH — its fallback is a cargo-install from source (~3 min per run).
+      # rustsec/audit-check stays for the annotations / issue-filing behavior.
+      - uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2.83.1
+        with:
+          tool: cargo-audit
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Two scoped changes to `.github/workflows/audit.yml`:

1. **Prebuilt cargo-audit install.** `rustsec/audit-check` falls back to `cargo install cargo-audit` from source (~370 packages, ~3 min) whenever the binary is not on PATH — which was every run, and most of the job's runtime. A `taiki-e/install-action` step (same SHA-pinned action docs.yml already uses; dependabot's actions group maintains the pin) now installs the prebuilt release binary in seconds before audit-check runs. audit-check itself stays, for the PR annotations and the scheduled-run issue filing.

2. **Self-validation on PRs.** The `pull_request` paths filter did not include `.github/workflows/audit.yml` (the `push` filter does), so edits to the workflow itself got zero pre-merge validation. Added it. Audit is advisory, not a required check, so the paths filter cannot wedge merge-queue entry.

## Validation

- `actionlint` clean.
- This PR triggers the audit workflow itself (via change 2); run evidence in the comments/checks.