### PR TITLE
session-fork: codex anchor-fork engine (PR D)

### DIFF
--- a/src/bin/caller/external_agent/codex/mod.rs
+++ b/src/bin/caller/external_agent/codex/mod.rs
@@ -202,6 +202,8 @@ pub struct CodexAgent {
     mcp_auth_token: Option<String>,
     mcp_session_id: Option<String>,
     resume_session: Option<String>,
+    fork_from_rollout_path: Option<PathBuf>,
+    fork_cut: Option<crate::session_fork::CodexForkCut>,
     codex_home: Option<PathBuf>,
     /// Working directory used to resolve Codex project config for config/read.
     working_dir: Option<PathBuf>,
@@ -712,6 +714,8 @@ impl CodexAgent {
             mcp_auth_token: None,
             mcp_session_id: None,
             resume_session: None,
+            fork_from_rollout_path: None,
+            fork_cut: None,
             codex_home: None,
             working_dir: None,
             config_working_dir: None,
@@ -1222,6 +1226,8 @@ impl ExternalAgent for CodexAgent {
         self.mcp_auth_token = config.mcp_auth_token;
         self.mcp_session_id = config.mcp_session_id;
         self.resume_session = config.resume_session;
+        self.fork_from_rollout_path = config.fork_from_rollout_path;
+        self.fork_cut = config.fork_cut;
         self.codex_home = config.codex_home;
         self.working_dir = Some(config.working_dir.clone());
         let protocol_watch = config.protocol_watch;
@@ -1383,14 +1389,28 @@ impl ExternalAgent for CodexAgent {
         let mut params = self
             .thread_lifecycle_params_with_developer_instructions(managed_developer_instructions);
 
-        let method = if let Some(ref thread_id) = self.resume_session {
+        // Anchor fork: seed a NEW thread from the staged rollout copy
+        // instead of resuming the parent; the trim to the anchor happens
+        // right after the thread id is known, before any turn runs. The
+        // lifecycle params are skipped deliberately — the forked thread
+        // carries its history from the seed file.
+        let (method, params) = if let Some(fork_path) = self.fork_from_rollout_path.clone() {
+            let mut fork_params = serde_json::Map::new();
+            fork_params.insert("threadId".into(), serde_json::Value::String(String::new()));
+            fork_params.insert(
+                "path".into(),
+                serde_json::Value::String(fork_path.to_string_lossy().into_owned()),
+            );
+            self.insert_service_tier_override(&mut fork_params);
+            ("thread/fork", fork_params)
+        } else if let Some(ref thread_id) = self.resume_session {
             params.insert(
                 "threadId".into(),
                 serde_json::Value::String(thread_id.clone()),
             );
-            "thread/resume"
+            ("thread/resume", params)
         } else {
-            "thread/start"
+            ("thread/start", params)
         };
 
         let result = self
@@ -1410,6 +1430,27 @@ impl ExternalAgent for CodexAgent {
         // Cache the thread id so interrupt_turn() can build the
         // `turn/interrupt` params without requiring a thread handle.
         *self.active_thread_id.lock().await = Some(thread_id.clone());
+
+        if self.fork_from_rollout_path.is_some() {
+            match self.fork_cut.clone() {
+                Some(crate::session_fork::CodexForkCut::Turns(turns)) => {
+                    self.rollback_turns_inner(
+                        &serde_json::json!({ "threadId": thread_id.clone() }),
+                        turns,
+                    )
+                    .await?;
+                }
+                Some(crate::session_fork::CodexForkCut::ItemAnchor { item_id, position }) => {
+                    let position = match position.as_str() {
+                        "before" => RollbackAnchorPosition::Before,
+                        _ => RollbackAnchorPosition::After,
+                    };
+                    self.rollback_item_anchor_rpc(&thread_id, &item_id, position)
+                        .await?;
+                }
+                Some(crate::session_fork::CodexForkCut::None) | None => {}
+            }
+        }
 
         if self.resume_session.is_some() {
             self.apply_resumed_thread_settings(&thread_id).await?;
@@ -3462,6 +3503,8 @@ enabled = true
             mcp_session_id: Some("test-session".to_string()),
             resume_session: None,
             fork_resume: false,
+            fork_from_rollout_path: None,
+            fork_cut: None,
             codex_home: None,
             protocol_watch: None,
         };

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -1136,6 +1136,15 @@ pub struct AgentConfig {
     /// Only meaningful together with `resume_session`; backends whose fork
     /// is an in-process thread action ignore it.
     pub fork_resume: bool,
+    /// Anchor-fork staging (codex only): seed the spawned thread from this
+    /// staged rollout copy via `thread/fork{path}` instead of resuming, then
+    /// trim it per `fork_cut` before the first turn. One-shot spawn
+    /// parameters — the supervisor sets them only while the wrapper still
+    /// resumes the parent id.
+    pub fork_from_rollout_path: Option<PathBuf>,
+    /// Trim applied to the freshly forked thread (codex only; `None` = the
+    /// anchor was the parent's head).
+    pub fork_cut: Option<crate::session_fork::CodexForkCut>,
     /// Codex state directory to use for this session's app-server process.
     /// Codex-only; other backends ignore.
     pub codex_home: Option<PathBuf>,

--- a/src/bin/caller/external_supervision.rs
+++ b/src/bin/caller/external_supervision.rs
@@ -715,6 +715,42 @@ pub(crate) async fn create_external_agent(
                 .is_some_and(|parent| parent.trim() == resume)
         });
 
+    // Anchor-fork staging (codex): one-shot spawn parameters the fork
+    // orchestrator persisted into the wrapper's launch config. Lifted only
+    // while the wrapper still resumes the parent id (the same window as
+    // `fork_resume`), so a later plain resume of the child can never
+    // re-fork; the announce-time overlay persist strips them durably.
+    let (codex_fork_rollout_path, codex_fork_cut) = if fork_resume {
+        session_log
+            .lock()
+            .ok()
+            .map(|log| log.dir().to_path_buf())
+            .and_then(|dir| crate::session_config::read_log_dir_config(&dir))
+            .map(|cfg| {
+                let cut = if let Some(item_id) = cfg
+                    .codex_fork_rollback_item_id
+                    .filter(|item| !item.trim().is_empty())
+                {
+                    Some(crate::session_fork::CodexForkCut::ItemAnchor {
+                        item_id,
+                        position: cfg
+                            .codex_fork_rollback_position
+                            .unwrap_or_else(|| "after".to_string()),
+                    })
+                } else {
+                    cfg.codex_fork_rollback_turns
+                        .map(crate::session_fork::CodexForkCut::Turns)
+                };
+                (
+                    cfg.codex_fork_rollout_path.map(std::path::PathBuf::from),
+                    cut,
+                )
+            })
+            .unwrap_or((None, None))
+    } else {
+        (None, None)
+    };
+
     let (mut agent, config): (Box<dyn external_agent::ExternalAgent>, AgentConfig) = match backend {
         AgentBackend::Codex => {
             let cfg = &project.config.agent.codex;
@@ -780,6 +816,8 @@ pub(crate) async fn create_external_agent(
                 mcp_session_id: mcp_session_id.clone(),
                 resume_session: resume_session.clone(),
                 fork_resume,
+                fork_from_rollout_path: codex_fork_rollout_path.clone(),
+                fork_cut: codex_fork_cut.clone(),
                 codex_home,
                 protocol_watch,
             };
@@ -823,6 +861,8 @@ pub(crate) async fn create_external_agent(
                 mcp_session_id: mcp_session_id.clone(),
                 resume_session: resume_session.clone(),
                 fork_resume,
+                fork_from_rollout_path: None,
+                fork_cut: None,
                 codex_home: None,
                 protocol_watch,
             };

--- a/src/bin/caller/session_config.rs
+++ b/src/bin/caller/session_config.rs
@@ -64,6 +64,29 @@ pub struct SessionAgentConfig {
     /// fork.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fork_relationship: Option<String>,
+    /// Serialized `ForkAnchorSpec` of the anchor an `anchor-fork` cut at
+    /// (lineage documentation; the dashboard's divergence chips read it).
+    /// Internal-only: never enters via the wire (`from_wire_fields` has no
+    /// column for it), only via the supervisor's fork overrides.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_anchor: Option<String>,
+    /// One-shot codex fork staging (anchor forks only): the staged rollout
+    /// copy `thread/fork{path}` seeds the child from. Consumed by the
+    /// spawner while `resume == forked_from`, stripped when the child's
+    /// own overlay persists. Internal-only, like `fork_anchor`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_fork_rollout_path: Option<String>,
+    /// One-shot vanilla-binary trim: whole turns to roll the fresh child
+    /// back before its first turn. Internal-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_fork_rollback_turns: Option<u32>,
+    /// One-shot managed-binary trim: exact item-anchor rollback on the
+    /// fresh child. Internal-only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_fork_rollback_item_id: Option<String>,
+    /// Position for `codex_fork_rollback_item_id` (`before`/`after`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_fork_rollback_position: Option<String>,
 }
 
 impl SessionAgentConfig {
@@ -85,6 +108,11 @@ impl SessionAgentConfig {
             && self.claude_effort.is_none()
             && self.forked_from.is_none()
             && self.fork_relationship.is_none()
+            && self.fork_anchor.is_none()
+            && self.codex_fork_rollout_path.is_none()
+            && self.codex_fork_rollback_turns.is_none()
+            && self.codex_fork_rollback_item_id.is_none()
+            && self.codex_fork_rollback_position.is_none()
     }
 
     pub fn merge_missing_from(&mut self, fallback: SessionAgentConfig) {
@@ -138,6 +166,21 @@ impl SessionAgentConfig {
         }
         if self.fork_relationship.is_none() {
             self.fork_relationship = fallback.fork_relationship;
+        }
+        if self.fork_anchor.is_none() {
+            self.fork_anchor = fallback.fork_anchor;
+        }
+        if self.codex_fork_rollout_path.is_none() {
+            self.codex_fork_rollout_path = fallback.codex_fork_rollout_path;
+        }
+        if self.codex_fork_rollback_turns.is_none() {
+            self.codex_fork_rollback_turns = fallback.codex_fork_rollback_turns;
+        }
+        if self.codex_fork_rollback_item_id.is_none() {
+            self.codex_fork_rollback_item_id = fallback.codex_fork_rollback_item_id;
+        }
+        if self.codex_fork_rollback_position.is_none() {
+            self.codex_fork_rollback_position = fallback.codex_fork_rollback_position;
         }
     }
 }
@@ -415,6 +458,13 @@ pub fn from_wire_fields(fields: WireSessionAgentFields) -> SessionAgentConfig {
             .then(|| normalize_codex_service_tier(fields.codex_service_tier))
             .flatten(),
         codex_home: None,
+        // The anchor-fork fields are internal-only: no wire column exists,
+        // so every wire parse yields None here by construction.
+        fork_anchor: None,
+        codex_fork_rollout_path: None,
+        codex_fork_rollback_turns: None,
+        codex_fork_rollback_item_id: None,
+        codex_fork_rollback_position: None,
         claude_model: is_claude
             .then(|| normalize_claude_model(fields.claude_model))
             .flatten(),
@@ -464,6 +514,11 @@ pub fn from_project(backend: &AgentBackend, project: &Project) -> SessionAgentCo
             claude_effort: None,
             forked_from: None,
             fork_relationship: None,
+            fork_anchor: None,
+            codex_fork_rollout_path: None,
+            codex_fork_rollback_turns: None,
+            codex_fork_rollback_item_id: None,
+            codex_fork_rollback_position: None,
         },
         AgentBackend::ClaudeCode => {
             let claude = &project.config.agent.claude_code;
@@ -490,6 +545,11 @@ pub fn from_project(backend: &AgentBackend, project: &Project) -> SessionAgentCo
                 claude_effort: crate::project::normalize_claude_effort(claude.effort.as_deref()),
                 forked_from: None,
                 fork_relationship: None,
+                fork_anchor: None,
+                codex_fork_rollout_path: None,
+                codex_fork_rollback_turns: None,
+                codex_fork_rollback_item_id: None,
+                codex_fork_rollback_position: None,
             }
         }
     }

--- a/src/bin/caller/session_fork/codex_stage.rs
+++ b/src/bin/caller/session_fork/codex_stage.rs
@@ -1,0 +1,291 @@
+//! Codex anchor-fork staging: the rollout copy `thread/fork{path}` seeds
+//! the child from, plus anchor→trim resolution. Copy-only over the parent
+//! rollout; the staged file lives under Intendant's own state dir and is
+//! swept after a retention window.
+
+use super::ForkAnchorSpec;
+use crate::managed_context_ops::{rollout_user_turns, shared_context_rewind_anchor_scan};
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// How the fresh forked child gets trimmed to the anchor before its first
+/// turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CodexForkCut {
+    /// No trim — the anchor is the parent's current head.
+    None,
+    /// Vanilla-safe whole-turn rollback (`thread/rollback{numTurns}`).
+    Turns(u32),
+    /// Managed-binary exact cut
+    /// (`thread/rollback{anchor:{itemId,position}}`).
+    ItemAnchor { item_id: String, position: String },
+}
+
+/// Stagings older than this are swept on the next staging call — long
+/// enough for any spawn to consume its file, short enough that failed
+/// forks don't accumulate multi-MB copies.
+const STAGING_SWEEP_AFTER_SECS: u64 = 7 * 24 * 60 * 60;
+
+/// Copy `source_rollout` under `staging_root` for a fork seed: byte copy
+/// with a torn tail (a live parent mid-append) trimmed back to the last
+/// complete, parseable line. The parent file is never written.
+pub(crate) fn stage_codex_rollout_copy(
+    staging_root: &Path,
+    source_rollout: &Path,
+) -> io::Result<PathBuf> {
+    std::fs::create_dir_all(staging_root)?;
+    sweep_stale_stagings(staging_root);
+
+    let bytes = std::fs::read(source_rollout)?;
+    let keep = complete_prefix_len(&bytes);
+    if keep == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "rollout has no complete lines to stage",
+        ));
+    }
+    let staged = staging_root.join(format!("fork-{}.jsonl", uuid::Uuid::new_v4()));
+    std::fs::write(&staged, &bytes[..keep])?;
+    Ok(staged)
+}
+
+/// Byte length of the prefix ending at the last complete AND parseable
+/// line (trailing partial writes and a torn final line are dropped).
+fn complete_prefix_len(bytes: &[u8]) -> usize {
+    let mut end = bytes.len();
+    loop {
+        // Trim back to (and including) the last newline within `end`.
+        let line_start = match bytes[..end].iter().rposition(|b| *b == b'\n') {
+            Some(last_newline) => {
+                if last_newline + 1 == end {
+                    // `end` sits just past a newline: the candidate line is
+                    // the one BEFORE it.
+                    match bytes[..last_newline].iter().rposition(|b| *b == b'\n') {
+                        Some(prev) => prev + 1,
+                        None => 0,
+                    }
+                } else {
+                    // Trailing bytes after the last newline are a torn line.
+                    end = last_newline + 1;
+                    continue;
+                }
+            }
+            None => return 0,
+        };
+        let line = &bytes[line_start..end - 1];
+        if line.is_empty() || serde_json::from_slice::<serde_json::Value>(line).is_ok() {
+            return end;
+        }
+        end = line_start;
+        if end == 0 {
+            return 0;
+        }
+    }
+}
+
+fn sweep_stale_stagings(staging_root: &Path) {
+    let Ok(entries) = std::fs::read_dir(staging_root) else {
+        return;
+    };
+    let now = std::time::SystemTime::now();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let stale = entry
+            .metadata()
+            .and_then(|meta| meta.modified())
+            .ok()
+            .and_then(|modified| now.duration_since(modified).ok())
+            .is_some_and(|age| age.as_secs() > STAGING_SWEEP_AFTER_SECS);
+        if stale {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+/// Resolve the wire anchor to the trim the forked child needs, validated
+/// against the STAGED copy (the anchor must still exist there — a parent
+/// that rewound since the catalog was read must refuse, not mis-cut).
+pub(crate) fn codex_anchor_turn_cut(
+    staged: &Path,
+    anchor: &ForkAnchorSpec,
+    managed_binary: bool,
+) -> Result<CodexForkCut, String> {
+    let turns = rollout_user_turns(staged)
+        .map_err(|err| format!("failed to scan the staged rollout: {err}"))?;
+    let total = turns.len() as u32;
+
+    match anchor.kind.as_str() {
+        "head" => Ok(CodexForkCut::None),
+        "turn-boundary" => {
+            let keep = anchor
+                .turn
+                .ok_or_else(|| "a turn-boundary anchor needs a `turn`".to_string())?;
+            if keep == 0 {
+                return Err("a fork keeping zero turns has no value".to_string());
+            }
+            if keep > total {
+                return Err(format!(
+                    "turn {keep} not found in the staged rollout ({total} effective turns — \
+                     history may have moved since the fork points were read)"
+                ));
+            }
+            if keep == total {
+                Ok(CodexForkCut::None)
+            } else {
+                Ok(CodexForkCut::Turns(total - keep))
+            }
+        }
+        "item-anchor" => {
+            let item_id = anchor
+                .item_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .ok_or_else(|| "an item anchor needs an `item_id`".to_string())?;
+            let scan = shared_context_rewind_anchor_scan(staged)
+                .map_err(|err| format!("failed to scan the staged rollout: {err}"))?;
+            let entry = scan
+                .catalog
+                .iter()
+                .find(|entry| entry.item_id == item_id)
+                .ok_or_else(|| {
+                    format!(
+                        "item anchor {item_id} not found in the staged rollout \
+                         (history may have moved since the fork points were read)"
+                    )
+                })?;
+            if managed_binary {
+                let position = anchor
+                    .position
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|position| matches!(*position, "before" | "after"))
+                    .unwrap_or("after");
+                return Ok(CodexForkCut::ItemAnchor {
+                    item_id: item_id.to_string(),
+                    position: position.to_string(),
+                });
+            }
+            // Vanilla rounding: the cut lands at the boundary before the
+            // anchor's containing turn (the catalog's `effective_cut`).
+            let containing_turn = turns
+                .iter()
+                .take_while(|turn| turn.line <= entry.first_line)
+                .count() as u32;
+            let keep = containing_turn.saturating_sub(1);
+            if keep == 0 {
+                return Err(
+                    "this item anchor precedes the first turn: a vanilla-binary fork would \
+                     keep nothing (the managed codex binary can cut it exactly)"
+                        .to_string(),
+                );
+            }
+            Ok(CodexForkCut::Turns(total - keep))
+        }
+        other => Err(format!("unsupported codex fork anchor kind: {other}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rollout_lines() -> Vec<String> {
+        vec![
+            serde_json::json!({"timestamp":"t","type":"session_meta","payload":{"id":"0000","cwd":"/tmp"}}).to_string(),
+            serde_json::json!({"timestamp":"t","type":"event_msg","payload":{"type":"user_message","message":"turn one"}}).to_string(),
+            serde_json::json!({"timestamp":"t","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"a1"}]}}).to_string(),
+            serde_json::json!({"timestamp":"t","type":"event_msg","payload":{"type":"user_message","message":"turn two"}}).to_string(),
+            serde_json::json!({"timestamp":"t","type":"event_msg","payload":{"type":"user_message","message":"turn three"}}).to_string(),
+        ]
+    }
+
+    fn write_rollout(dir: &Path, tail: &str) -> PathBuf {
+        let path = dir.join("rollout-src.jsonl");
+        std::fs::write(&path, rollout_lines().join("\n") + "\n" + tail).expect("write");
+        path
+    }
+
+    fn anchor(kind: &str, turn: Option<u32>, item_id: Option<&str>) -> ForkAnchorSpec {
+        ForkAnchorSpec {
+            kind: kind.to_string(),
+            turn,
+            item_id: item_id.map(str::to_string),
+            position: None,
+            seq: None,
+            message_uuid: None,
+        }
+    }
+
+    #[test]
+    fn staging_copies_and_trims_torn_tail_without_touching_source() {
+        let dir = tempfile::tempdir().expect("dir");
+        let source = write_rollout(dir.path(), "{\"torn");
+        let source_bytes = std::fs::read(&source).expect("source bytes");
+
+        let staged = stage_codex_rollout_copy(&dir.path().join("staging"), &source).expect("stage");
+        let staged_text = std::fs::read_to_string(&staged).expect("staged");
+        assert_eq!(staged_text.lines().count(), 5);
+        assert!(!staged_text.contains("torn"));
+        assert_eq!(
+            std::fs::read(&source).expect("source after"),
+            source_bytes,
+            "source rollout mutated"
+        );
+    }
+
+    #[test]
+    fn staging_drops_unparseable_final_line() {
+        let dir = tempfile::tempdir().expect("dir");
+        let source = dir.path().join("rollout-bad.jsonl");
+        std::fs::write(&source, "{\"ok\":1}\nnot json at all\n").expect("write");
+        let staged = stage_codex_rollout_copy(&dir.path().join("staging"), &source).expect("stage");
+        assert_eq!(
+            std::fs::read_to_string(&staged).expect("staged"),
+            "{\"ok\":1}\n"
+        );
+    }
+
+    #[test]
+    fn turn_boundary_cut_maps_keep_to_drop() {
+        let dir = tempfile::tempdir().expect("dir");
+        let source = write_rollout(dir.path(), "");
+        assert_eq!(
+            codex_anchor_turn_cut(&source, &anchor("turn-boundary", Some(1), None), false),
+            Ok(CodexForkCut::Turns(2))
+        );
+        assert_eq!(
+            codex_anchor_turn_cut(&source, &anchor("turn-boundary", Some(3), None), false),
+            Ok(CodexForkCut::None)
+        );
+        assert!(
+            codex_anchor_turn_cut(&source, &anchor("turn-boundary", Some(9), None), false).is_err()
+        );
+        assert!(
+            codex_anchor_turn_cut(&source, &anchor("turn-boundary", Some(0), None), false).is_err()
+        );
+    }
+
+    #[test]
+    fn head_anchor_needs_no_trim() {
+        let dir = tempfile::tempdir().expect("dir");
+        let source = write_rollout(dir.path(), "");
+        assert_eq!(
+            codex_anchor_turn_cut(&source, &anchor("head", None, None), false),
+            Ok(CodexForkCut::None)
+        );
+    }
+
+    #[test]
+    fn stale_item_anchor_is_refused() {
+        let dir = tempfile::tempdir().expect("dir");
+        let source = write_rollout(dir.path(), "");
+        let err = codex_anchor_turn_cut(
+            &source,
+            &anchor("item-anchor", None, Some("missing_item")),
+            false,
+        )
+        .expect_err("missing anchor");
+        assert!(err.contains("not found"), "{err}");
+    }
+}

--- a/src/bin/caller/session_fork/mod.rs
+++ b/src/bin/caller/session_fork/mod.rs
@@ -22,9 +22,11 @@
 //!   catalog reports `supported: false` until the tree parser lands).
 
 mod claude_tree;
+mod codex_stage;
 mod fork_points;
 mod native;
 pub(crate) use claude_tree::*;
+pub(crate) use codex_stage::*;
 pub(crate) use fork_points::*;
 pub(crate) use native::*;
 

--- a/src/bin/caller/session_supervisor/agent_config.rs
+++ b/src/bin/caller/session_supervisor/agent_config.rs
@@ -545,6 +545,18 @@ pub(crate) struct LaunchOverrides {
     pub(crate) claude_permission_mode: Option<String>,
     pub(crate) claude_allowed_tools: Option<String>,
     pub(crate) claude_effort: Option<String>,
+    /// Internal-only anchor-fork parameters (set by the supervisor's fork
+    /// orchestrator, never parsed from any wire message — deliberately
+    /// absent from `as_wire_fields`, so `ResumeSession` senders cannot
+    /// inject them; applied onto the merged config by
+    /// `apply_fork_lineage`). `fork_relationship` here overrides the
+    /// wire-vetted kind (`anchor-fork` is minted internally only).
+    pub(crate) fork_relationship: Option<String>,
+    pub(crate) fork_anchor: Option<String>,
+    pub(crate) codex_fork_rollout_path: Option<String>,
+    pub(crate) codex_fork_rollback_turns: Option<u32>,
+    pub(crate) codex_fork_rollback_item_id: Option<String>,
+    pub(crate) codex_fork_rollback_position: Option<String>,
 }
 
 impl LaunchOverrides {
@@ -572,6 +584,36 @@ impl LaunchOverrides {
             claude_permission_mode: self.claude_permission_mode.as_deref(),
             claude_allowed_tools: self.claude_allowed_tools.as_deref(),
             claude_effort: self.claude_effort.as_deref(),
+        }
+    }
+
+    /// Apply the internal-only anchor-fork parameters onto the merged
+    /// session config, after `from_wire_fields` + persisted-overlay merge
+    /// (which cannot carry them). No-ops when the overrides carry none.
+    pub(crate) fn apply_fork_lineage(
+        &self,
+        config: Option<&mut crate::session_config::SessionAgentConfig>,
+    ) {
+        let Some(config) = config else {
+            return;
+        };
+        if self.fork_relationship.is_some() {
+            config.fork_relationship = self.fork_relationship.clone();
+        }
+        if self.fork_anchor.is_some() {
+            config.fork_anchor = self.fork_anchor.clone();
+        }
+        if self.codex_fork_rollout_path.is_some() {
+            config.codex_fork_rollout_path = self.codex_fork_rollout_path.clone();
+        }
+        if self.codex_fork_rollback_turns.is_some() {
+            config.codex_fork_rollback_turns = self.codex_fork_rollback_turns;
+        }
+        if self.codex_fork_rollback_item_id.is_some() {
+            config.codex_fork_rollback_item_id = self.codex_fork_rollback_item_id.clone();
+        }
+        if self.codex_fork_rollback_position.is_some() {
+            config.codex_fork_rollback_position = self.codex_fork_rollback_position.clone();
         }
     }
 }
@@ -805,6 +847,21 @@ pub(crate) fn effective_session_agent_config_from_project(
         if overrides.fork_relationship.is_some() {
             config.fork_relationship = overrides.fork_relationship.clone();
         }
+        if overrides.fork_anchor.is_some() {
+            config.fork_anchor = overrides.fork_anchor.clone();
+        }
+        if overrides.codex_fork_rollout_path.is_some() {
+            config.codex_fork_rollout_path = overrides.codex_fork_rollout_path.clone();
+        }
+        if overrides.codex_fork_rollback_turns.is_some() {
+            config.codex_fork_rollback_turns = overrides.codex_fork_rollback_turns;
+        }
+        if overrides.codex_fork_rollback_item_id.is_some() {
+            config.codex_fork_rollback_item_id = overrides.codex_fork_rollback_item_id.clone();
+        }
+        if overrides.codex_fork_rollback_position.is_some() {
+            config.codex_fork_rollback_position = overrides.codex_fork_rollback_position.clone();
+        }
     }
     config
 }
@@ -858,6 +915,50 @@ mod tests {
         );
         assert_eq!(config.forked_from.as_deref(), Some("parent-native"));
         assert_eq!(config.fork_relationship.as_deref(), Some("side"));
+    }
+
+    #[test]
+    fn effective_config_preserves_anchor_fork_one_shots() {
+        // Same pin policy as fork lineage: the anchor-fork staging fields
+        // are per-session facts a project can never supply — dropping any
+        // of them in the rebuild breaks the child's spawn-time fork.
+        let project = Project {
+            root: PathBuf::from("/tmp/project"),
+            config: Default::default(),
+        };
+        let overrides = crate::session_config::SessionAgentConfig {
+            forked_from: Some("parent-backend".to_string()),
+            fork_relationship: Some("anchor-fork".to_string()),
+            fork_anchor: Some("{\"kind\":\"turn-boundary\",\"turn\":2}".to_string()),
+            codex_fork_rollout_path: Some("/tmp/staged.jsonl".to_string()),
+            codex_fork_rollback_turns: Some(3),
+            codex_fork_rollback_item_id: Some("item_9".to_string()),
+            codex_fork_rollback_position: Some("after".to_string()),
+            ..Default::default()
+        };
+        let config = effective_session_agent_config_from_project(
+            &external_agent::AgentBackend::Codex,
+            &project,
+            Some(&overrides),
+        );
+        assert_eq!(config.fork_relationship.as_deref(), Some("anchor-fork"));
+        assert!(config
+            .fork_anchor
+            .as_deref()
+            .is_some_and(|anchor| anchor.contains("turn-boundary")));
+        assert_eq!(
+            config.codex_fork_rollout_path.as_deref(),
+            Some("/tmp/staged.jsonl")
+        );
+        assert_eq!(config.codex_fork_rollback_turns, Some(3));
+        assert_eq!(
+            config.codex_fork_rollback_item_id.as_deref(),
+            Some("item_9")
+        );
+        assert_eq!(
+            config.codex_fork_rollback_position.as_deref(),
+            Some("after")
+        );
     }
 
     #[tokio::test]

--- a/src/bin/caller/session_supervisor/dispatch.rs
+++ b/src/bin/caller/session_supervisor/dispatch.rs
@@ -398,6 +398,7 @@ impl SessionSupervisor {
                         claude_permission_mode,
                         claude_allowed_tools,
                         claude_effort,
+                        ..Default::default()
                     },
                 )
                 .await;
@@ -538,6 +539,7 @@ impl SessionSupervisor {
                         claude_permission_mode,
                         claude_allowed_tools,
                         claude_effort,
+                        ..Default::default()
                     },
                 )
                 .await;

--- a/src/bin/caller/session_supervisor/fork.rs
+++ b/src/bin/caller/session_supervisor/fork.rs
@@ -2,10 +2,12 @@
 //! per-backend copy-only fork engine, announce the lineage edge and the
 //! `session_fork_result`, then activate the child through the normal
 //! resume funnel (v1 always activates). Fork lineage never rides wire
-//! overrides — the engines persist it into the child's own artifacts.
+//! overrides — the engines persist it into the child's own artifacts, and
+//! the codex one-shot staging parameters travel on internal-only
+//! `LaunchOverrides` fields the wire cannot set.
 
 use super::*;
-use crate::session_fork::{ForkAnchorSpec, NativeForkOutcome};
+use crate::session_fork::{CodexForkCut, ForkAnchorSpec, NativeForkOutcome};
 
 impl SessionSupervisor {
     #[allow(clippy::too_many_arguments)] // mirrors the resume funnel's established signature style
@@ -26,77 +28,120 @@ impl SessionSupervisor {
             .filter(|token| !token.is_empty())
             .unwrap_or(session_id.trim())
             .to_string();
-        let result = match source.as_str() {
-            "intendant" => self.fork_native_session(&token, &anchor, name.as_deref()).await,
-            "codex" | "claude-code" => Err(format!(
-                "the {source} fork engine lands in a follow-up phase (fork points are already served)"
-            )),
-            other => Err(format!("fork is not supported for {other} sessions")),
-        };
-        match result {
-            Ok(outcome) => {
-                self.config.bus.send(AppEvent::SessionRelationship {
-                    parent_session_id: token.clone(),
-                    child_session_id: outcome.child_session_id.clone(),
-                    relationship: "anchor-fork".to_string(),
-                    ephemeral: false,
-                });
-                self.config.bus.send(AppEvent::SessionForkResult {
-                    request_id,
-                    parent_session_id: token,
-                    child_session_id: Some(outcome.child_session_id.clone()),
-                    source: source.clone(),
-                    relationship: "anchor-fork".to_string(),
-                    anchor_summary: format!(
-                        "{} ({} messages kept)",
-                        anchor.summary(),
-                        outcome.kept_messages
-                    ),
-                    error: None,
-                });
-                if let Some(name) = name
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|name| !name.is_empty())
+
+        let error = match source.as_str() {
+            "intendant" => {
+                match self
+                    .fork_native_session(&token, &anchor, name.as_deref())
+                    .await
                 {
-                    self.rename_session(
-                        outcome.child_session_id.clone(),
-                        None,
-                        Some(source.clone()),
-                        name.to_string(),
+                    Ok(outcome) => {
+                        self.announce_native_fork(
+                            &source, &token, &anchor, name, task, project_root, request_id,
+                            outcome,
+                        )
+                        .await;
+                        return;
+                    }
+                    Err(error) => error,
+                }
+            }
+            "codex" => match self.fork_codex_session(&token, &anchor).await {
+                Ok((backend_id, staged_path, cut)) => {
+                    self.spawn_codex_fork(
+                        &source,
+                        backend_id,
+                        &anchor,
+                        task,
+                        project_root,
+                        request_id,
+                        staged_path,
+                        cut,
                     )
                     .await;
+                    return;
                 }
-                // v1 always activates: attach the child through the normal
-                // resume funnel, which also delivers the optional first task.
-                self.resume_session(
-                    source,
-                    outcome.child_session_id.clone(),
-                    Some(outcome.child_session_id),
-                    project_root,
-                    task,
-                    Some(true),
-                    Vec::new(),
-                    false,
-                    None,
-                    LaunchOverrides::default(),
-                    false,
-                    false,
-                )
-                .await;
+                Err(error) => error,
+            },
+            "claude-code" => {
+                "the claude-code fork engine lands in a follow-up phase (fork points are already served)"
+                    .to_string()
             }
-            Err(error) => {
-                self.config.bus.send(AppEvent::SessionForkResult {
-                    request_id,
-                    parent_session_id: token,
-                    child_session_id: None,
-                    source,
-                    relationship: "anchor-fork".to_string(),
-                    anchor_summary: anchor.summary(),
-                    error: Some(error),
-                });
-            }
+            other => format!("fork is not supported for {other} sessions"),
+        };
+
+        self.config.bus.send(AppEvent::SessionForkResult {
+            request_id,
+            parent_session_id: token,
+            child_session_id: None,
+            source,
+            relationship: "anchor-fork".to_string(),
+            anchor_summary: anchor.summary(),
+            error: Some(error),
+        });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn announce_native_fork(
+        &self,
+        source: &str,
+        parent: &str,
+        anchor: &ForkAnchorSpec,
+        name: Option<String>,
+        task: Option<String>,
+        project_root: Option<String>,
+        request_id: Option<String>,
+        outcome: NativeForkOutcome,
+    ) {
+        self.config.bus.send(AppEvent::SessionRelationship {
+            parent_session_id: parent.to_string(),
+            child_session_id: outcome.child_session_id.clone(),
+            relationship: "anchor-fork".to_string(),
+            ephemeral: false,
+        });
+        self.config.bus.send(AppEvent::SessionForkResult {
+            request_id,
+            parent_session_id: parent.to_string(),
+            child_session_id: Some(outcome.child_session_id.clone()),
+            source: source.to_string(),
+            relationship: "anchor-fork".to_string(),
+            anchor_summary: format!(
+                "{} ({} messages kept)",
+                anchor.summary(),
+                outcome.kept_messages
+            ),
+            error: None,
+        });
+        if let Some(name) = name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+        {
+            self.rename_session(
+                outcome.child_session_id.clone(),
+                None,
+                Some(source.to_string()),
+                name.to_string(),
+            )
+            .await;
         }
+        // v1 always activates: attach the child through the normal resume
+        // funnel, which also delivers the optional first task.
+        self.resume_session(
+            source.to_string(),
+            outcome.child_session_id.clone(),
+            Some(outcome.child_session_id),
+            project_root,
+            task,
+            Some(true),
+            Vec::new(),
+            false,
+            None,
+            LaunchOverrides::default(),
+            false,
+            false,
+        )
+        .await;
     }
 
     async fn fork_native_session(
@@ -105,7 +150,7 @@ impl SessionSupervisor {
         anchor: &ForkAnchorSpec,
         name: Option<&str>,
     ) -> Result<NativeForkOutcome, String> {
-        let home = crate::platform::home_dir();
+        let home = self.logs_home();
         let parent_dir =
             crate::session_log::SessionLog::find_session_by_id_in_home(&home, token)
                 .ok_or_else(|| format!("session {token} not found in the native session store"))?;
@@ -124,5 +169,112 @@ impl SessionSupervisor {
         })
         .await
         .map_err(|err| format!("fork task failed: {err}"))?
+    }
+
+    /// Resolve the parent's rollout, stage a copy, and compute the trim.
+    /// Returns `(backend_id, staged_path, cut)`; `cut: None` means the
+    /// anchor is the head (fork with no trim).
+    async fn fork_codex_session(
+        &self,
+        token: &str,
+        anchor: &ForkAnchorSpec,
+    ) -> Result<(String, String, Option<CodexForkCut>), String> {
+        let home = self.logs_home();
+        let backend_id = match persisted_external_identity_for_session_in_home(&home, token) {
+            Some((source, id)) if source == "codex" => id,
+            Some((source, _)) => {
+                return Err(format!("session {token} is a {source} session, not codex"));
+            }
+            None => token.to_string(),
+        };
+        let rollout = crate::codex_history::find_codex_session_file_for_main(&home, &backend_id)
+            .ok_or_else(|| {
+                format!(
+                    "rollout for codex session {backend_id} not found in the codex session store"
+                )
+            })?;
+        // Item anchors cut exactly only on the managed binary; the session's
+        // persisted pin decides which trim form the child gets.
+        let managed =
+            crate::session_config::load_for_resume(&home, "codex", &backend_id, Some(&backend_id))
+                .and_then(|cfg| cfg.codex_managed_context)
+                .is_some_and(|mode| mode == "managed");
+        let staging_root = crate::platform::intendant_home_in(&home).join("fork_staging");
+        let anchor = anchor.clone();
+        let staged = tokio::task::spawn_blocking(move || {
+            let staged = crate::session_fork::stage_codex_rollout_copy(&staging_root, &rollout)
+                .map_err(|err| format!("failed to stage the rollout copy: {err}"))?;
+            let cut = crate::session_fork::codex_anchor_turn_cut(&staged, &anchor, managed)?;
+            Ok::<_, String>((staged, cut))
+        })
+        .await
+        .map_err(|err| format!("fork staging task failed: {err}"))?;
+        let (staged, cut) = staged?;
+        let cut = match cut {
+            CodexForkCut::None => None,
+            other => Some(other),
+        };
+        Ok((backend_id, staged.to_string_lossy().into_owned(), cut))
+    }
+
+    /// Spawn the forked codex child through the resume funnel: a fresh
+    /// wrapper session whose spawn seeds from the staged rollout and trims
+    /// to the anchor. The child's backend id is only known at its identity
+    /// announce, which also emits the `anchor-fork` relationship — the
+    /// result event therefore carries no child id yet.
+    #[allow(clippy::too_many_arguments)]
+    async fn spawn_codex_fork(
+        &self,
+        source: &str,
+        backend_id: String,
+        anchor: &ForkAnchorSpec,
+        task: Option<String>,
+        project_root: Option<String>,
+        request_id: Option<String>,
+        staged_path: String,
+        cut: Option<CodexForkCut>,
+    ) {
+        self.config.bus.send(AppEvent::SessionForkResult {
+            request_id,
+            parent_session_id: backend_id.clone(),
+            child_session_id: None,
+            source: source.to_string(),
+            relationship: "anchor-fork".to_string(),
+            anchor_summary: anchor.summary(),
+            error: None,
+        });
+        let overrides = LaunchOverrides {
+            fork_relationship: Some("anchor-fork".to_string()),
+            fork_anchor: serde_json::to_string(anchor).ok(),
+            codex_fork_rollout_path: Some(staged_path),
+            codex_fork_rollback_turns: match &cut {
+                Some(CodexForkCut::Turns(turns)) => Some(*turns),
+                _ => None,
+            },
+            codex_fork_rollback_item_id: match &cut {
+                Some(CodexForkCut::ItemAnchor { item_id, .. }) => Some(item_id.clone()),
+                _ => None,
+            },
+            codex_fork_rollback_position: match &cut {
+                Some(CodexForkCut::ItemAnchor { position, .. }) => Some(position.clone()),
+                _ => None,
+            },
+            ..Default::default()
+        };
+        self.resume_session(
+            source.to_string(),
+            backend_id.clone(),
+            Some(backend_id),
+            project_root,
+            task,
+            Some(true),
+            Vec::new(),
+            true,
+            None,
+            overrides,
+            false,
+            false,
+        )
+        .await;
     }
 }

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -644,6 +644,10 @@ impl SessionSupervisor {
                     .map(str::to_string);
             }
         }
+        // Anchor-fork parameters ride internal overrides only (absent from
+        // `as_wire_fields`); applied after the wire-vetted block so the
+        // supervisor-minted kind (`anchor-fork`) can override it.
+        overrides.apply_fork_lineage(session_agent_config.as_mut());
         let project_root = if external_backend.is_some() {
             match resolve_external_resume_project_root(
                 project_root,

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -3102,6 +3102,15 @@ pub(crate) fn persist_native_backend_session_id(config: &DrainConfig<'_>, native
     if launch.source.is_none() {
         launch.source = Some(backend.as_short_str().to_string());
     }
+    // The codex anchor-fork staging parameters are one-shot spawn inputs:
+    // the announced child must never carry them into its durable overlay,
+    // or a later resume could observe stale staging paths. The lineage
+    // fields (`forked_from`/`fork_relationship`/`fork_anchor`) stay — they
+    // document the edge.
+    launch.codex_fork_rollout_path = None;
+    launch.codex_fork_rollback_turns = None;
+    launch.codex_fork_rollback_item_id = None;
+    launch.codex_fork_rollback_position = None;
     if let Err(e) = crate::session_config::write_external_overlay(
         &platform::home_dir(),
         backend.as_short_str(),

--- a/tests/skills/session-fork-vanilla-codex/SKILL.md
+++ b/tests/skills/session-fork-vanilla-codex/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: session-fork-vanilla-codex
+description: >
+  Live gate for the codex anchor-fork engine on the VANILLA codex binary:
+  fork a real codex session from a mid-history turn boundary through the
+  daemon (fork-points catalog → ForkSessionAtAnchor → spawned child),
+  verify the child's history is the trimmed prefix, the parent rollout is
+  untouched, and the anchor-fork lineage edge appears at the child's
+  identity announce. Run before shipping changes to
+  session_fork/codex_stage.rs, the codex start_thread fork branch, or when
+  bumping the pinned codex version.
+compatibility: Requires vanilla codex on PATH with auth in ~/.codex, a built daemon from this worktree, and an existing multi-turn codex session to fork (create a scratch one if needed). Not CI — real backend, real tokens.
+allowed-tools: Bash Read
+disable-model-invocation: false
+---
+
+# Vanilla-codex anchor-fork live gate
+
+The CI e2e proves the native lane; the codex lane's backend interplay
+(`thread/fork{path}` on a staged copy + pre-first-turn `thread/rollback`)
+can only be proven against a real app-server. The wire primitives
+themselves are pinned by `tests/skills/session-fork-probes/spike1`.
+
+## Procedure
+
+1. Build and start a scratch daemon from this worktree (own port):
+   `cargo build --bin intendant --bin intendant-runtime` then
+   `./target/debug/intendant --no-web` is NOT enough — use
+   `./target/debug/intendant "idle" --web <throwaway port>` or an existing
+   dev daemon you own.
+2. Create (or pick) a codex session with ≥3 turns; note its backend id
+   from the Sessions tab or `~/.codex/sessions` (`session_meta.payload.id`).
+3. Catalog: `curl -s localhost:<port>/api/session/<backend-id>/fork-points | jq
+   '.fork_points[] | select(.kind=="turn-boundary")'` — pick a mid-history
+   turn (e.g. `turn:1` of 3).
+4. Fork over the ws intent lane (or the dashboard once PR F lands):
+   ```json
+   { "action": "fork_session_at_anchor", "source": "codex",
+     "session_id": "<backend-id>",
+     "anchor": { "kind": "turn-boundary", "turn": 1 },
+     "task": "summarize where we are", "request_id": "skill-1" }
+   ```
+5. Verify, in order:
+   - `session_fork_result` arrives with `error: null` (child id is null —
+     codex children announce later).
+   - A new wrapper session spawns and its first turn answers with ONLY
+     turn-1 knowledge (the summarize prompt is the probe).
+   - `~/.codex/sessions` gains a new rollout whose `forkedFromId` is the
+     staged copy's id; the PARENT rollout's bytes are unchanged (hash it
+     before/after).
+   - The Sessions list shows the child with an `anchor-fork` relationship
+     to the parent once the child announces (the overlay's
+     `fork_anchor` records the chosen anchor).
+   - `~/.intendant/fork_staging/` holds the staged copy (swept after 7d).
+6. Managed-binary variant (optional, needs the patched fork configured as
+   `[agent.codex] managed_command` + `managed_context = "managed"`): fork
+   from an `item-anchor` point and verify the child's cut is item-exact
+   rather than turn-rounded.
+
+## Known caveats
+
+- `thread/rollback` is deprecated upstream (0.144.4 notice): if a codex
+  bump removes it, this skill fails at step 5's trimmed-history check —
+  see the probes skill for the tripwire and note the successor API.
+- Vanilla forks do not inherit the prompt-cache lineage key (managed-fork
+  bonus): the child's first turn is cache-cold. Cost, not correctness.


### PR DESCRIPTION
Phase D of fork-from-any-anchor (#353 probes, #354 catalog, #361 CC tree, #374 wire + native engine).

**Engine** (`session_fork/codex_stage.rs`, copy-only): stage the parent rollout under `~/.intendant/fork_staging/` (torn tail trimmed to the last parseable line; 7-day sweep), then resolve the anchor **against the staged copy** — `turn-boundary` anchors map to a `numTurns` drop, `item-anchor`s stay exact on managed-binary sessions and round down to the catalog's `effective_cut` turn boundary on vanilla, and anchors that no longer exist (parent rewound since the catalog was read) refuse with a structured error.

**Spawn bootstrap**: the supervisor persists one-shot staging params on new **internal-only** `LaunchOverrides` fields (absent from `as_wire_fields` — the wire cannot inject them; applied after the wire-vetted lineage block, minting the `anchor-fork` kind internally). `create_external_agent` lifts them into `AgentConfig` only inside the existing `fork_resume` window, `codex start_thread` seeds via `thread/fork{path}` + pre-first-turn `thread/rollback`, and the child's identity-announce overlay persist strips the one-shots (a later plain resume can never re-fork). `fork_anchor` survives as durable divergence metadata for the lineage UI; the `anchor-fork` edge emits through the existing announce machinery. The codex result event reports success with `child_session_id: null` — codex children identify at announce, and the relationship event closes the loop.

**Pin policy**: the five new `SessionAgentConfig` fields extend `merge_missing_from`, the project copy-over, and the preservation test.

Battery: fmt clean; clippy clean on touched files; full units 3717/3717 (6 new staging/turn-cut tests + the preservation extension); full e2e 22/22. Live gate: `tests/skills/session-fork-vanilla-codex/SKILL.md` (wire primitives pinned by the probes skill; the upstream `thread/rollback` deprecation notice is tracked there).