### PR TITLE
ci: fail cheap and drop redundant work on the cross-platform Linux leg

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -257,6 +257,17 @@ jobs:
           "relevant=$relevant" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
           Write-Output "CI-relevant change detected: $relevant"
 
+      # ── Quality gate: rustfmt (Linux leg) ──────────────────────────────
+      # fmt is platform-independent, so one leg suffices — and it needs no
+      # build, so it runs before everything else: a formatting failure
+      # surfaces in seconds instead of after a compile+test cycle. Keep it
+      # AFTER the relevance detection above: its `if:` reads that step's
+      # output, and a not-yet-run step's output is empty, which passes the
+      # != 'false' test and would run fmt on docs-only diffs.
+      - name: cargo fmt --check
+        if: runner.os == 'Linux' && steps.relevance_unix.outputs.relevant != 'false'
+        run: cargo fmt --all --check
+
       # `ring` (our TLS provider — aws-lc-rs is deliberately disabled) builds
       # its x86_64 perlasm assembly with NASM on the MSVC target. Hosted-only,
       # like the other provisioning steps: the self-hosted Windows box has
@@ -352,6 +363,22 @@ jobs:
           # its §D corpus conformance gate (170 stamped vectors).
           cargo test -p intendant-core -p intendant-display -p intendant-platform -p owner-plane-core -p owner-plane-reducer --locked --target ${{ matrix.target }}
 
+      # ── Quality gate: clippy (Linux leg; baseline zeroed 2026-07-11) ──
+      # clippy is cfg-sensitive: the macOS-cut baseline left the Linux-only
+      # cfg surface unproven, so it started report-only; the Linux delta
+      # was zeroed (30 warnings — cfg-shadowed dead code gated, mechanical
+      # rewrites, established-signature allows) and verified with the exact
+      # gate incantation on the fleet's Linux toolchain in the same change
+      # that flipped this to -D warnings. Like fmt above, it rides the
+      # required Linux context; no ruleset change. Non-test targets only:
+      # --all-targets has its own unzeroed baseline (tracked in the CI
+      # hardening program). Ordered so the deterministic cheap gates fail
+      # before the longer, flakier tail (fmt → unit tests → clippy → e2e →
+      # smokes): a lint-red PR never burns an e2e + smoke cycle.
+      - name: cargo clippy (-D warnings)
+        if: runner.os == 'Linux' && steps.relevance_unix.outputs.relevant != 'false'
+        run: cargo clippy --workspace --locked --target ${{ matrix.target }} -- -D warnings
+
       # Headless end-to-end: the real `intendant` + `intendant-runtime`
       # binaries driven by the scripted mock provider (see tests/e2e/main.rs).
       # No keys, no network, no display — exercises the production stack the
@@ -360,25 +387,6 @@ jobs:
       - name: cargo test e2e (mock provider, headless)
         if: (github.event_name == 'merge_group' || (runner.os == 'Linux' && github.event_name == 'pull_request')) && steps.relevance_unix.outputs.relevant != 'false' && steps.relevance_win.outputs.relevant != 'false'
         run: cargo test -p intendant --test e2e --locked --target ${{ matrix.target }}
-
-      # ── Quality gates (Linux leg; baselines zeroed 2026-07-11) ──────
-      # fmt is platform-independent, so one leg suffices. clippy is
-      # cfg-sensitive: the macOS-cut baseline left the Linux-only cfg
-      # surface unproven, so it started report-only; the Linux delta was
-      # zeroed (30 warnings — cfg-shadowed dead code gated, mechanical
-      # rewrites, established-signature allows) and verified with the
-      # exact gate incantation on the fleet's Linux toolchain in the
-      # same change that flipped this to -D warnings. Both ride the
-      # required Linux context; no ruleset change. Non-test targets
-      # only: --all-targets has its own unzeroed baseline (tracked in
-      # the CI hardening program).
-      - name: cargo fmt --check
-        if: runner.os == 'Linux' && steps.relevance_unix.outputs.relevant != 'false'
-        run: cargo fmt --all --check
-
-      - name: cargo clippy (-D warnings)
-        if: runner.os == 'Linux' && steps.relevance_unix.outputs.relevant != 'false'
-        run: cargo clippy --workspace --locked --target ${{ matrix.target }} -- -D warnings
 
       # ── Linux gate tail: keyless smokes + dashboard-boot ──────────────
       # Formerly smokes.yml's two jobs (deleted 2026-07-11 — coverage

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -107,9 +107,8 @@ jobs:
         # the external per-listener target cache set up below; the
         # in-workspace target/ is wiped by checkout's `git clean -ffdx`
         # every job, so warmth never lives there). Provisioning steps
-        # (dep installs, cache actions) gate on `runner.environment ==
-        # 'github-hosted'`: the fleet boxes are pre-provisioned and keep
-        # their build state.
+        # (dep installs) gate on `runner.environment == 'github-hosted'`:
+        # the fleet boxes are pre-provisioned and keep their build state.
         include:
           - os: windows-latest
             runner: [self-hosted, intendant-windows]
@@ -175,7 +174,13 @@ jobs:
       # other) and keyed by `rustc -V` (a toolchain bump starts a fresh
       # key instead of thrashing the old one). `.last-used` is the recency
       # marker the fleet watchdog prunes stale keys by (scripts/ci).
-      # Hosted runners skip this and keep the rust-cache action below.
+      # Hosted runners skip this and build cold: the rust-cache restore
+      # they used to run could only save on push-to-main runs (a ref this
+      # workflow stopped seeing 2026-07-10), so every hosted leg paid a
+      # restore lookup against a store nothing populates — zero caches
+      # existed when the action was removed. If fork traffic ever warrants
+      # warm hosted legs, seed from a trusted ref; fork code must never
+      # populate a cache other builds consume.
       - name: External cargo target dir (unix)
         if: runner.environment != 'github-hosted' && runner.os != 'Windows'
         shell: bash
@@ -310,20 +315,6 @@ jobs:
       - name: Install macOS build deps
         if: runner.environment == 'github-hosted' && runner.os == 'macOS'
         run: brew install pkg-config libvpx
-
-      # Restore the cargo cache on every run, but only *save* it on pushes to
-      # main. PR caches live in an isolated scope GitHub discards on merge, so
-      # saving them buys nothing — and the Windows tar/zstd save step is flaky
-      # enough to fail an otherwise-green job. `save-if` keeps the speed-up on
-      # restore while removing the unreliable post-run save from PR checks.
-      # Hosted-only: the self-hosted runners keep their build state in the
-      # external per-listener cargo target dir set up above — shipping it
-      # to GitHub's cache store would only add minutes.
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        if: runner.environment == 'github-hosted'
-        with:
-          key: ${{ matrix.target }}
-          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Fast pre-queue signal vs the real merge gate. Full suites run in
       # exactly two places: the merge group (all three platforms — the

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -392,7 +392,15 @@ jobs:
       # Formerly smokes.yml's two jobs (deleted 2026-07-11 — coverage
       # rationale preserved in its git history): the live-fire subset of
       # the landing battery that needs NO API keys and NO display — real
-      # binaries driven end to end by the scripted mock provider.
+      # binaries driven end to end by the scripted mock provider. The
+      # binaries are the ones the e2e step above just built and tested:
+      # compiling a package's integration tests builds its bin targets and
+      # uplifts them to <triple>/debug/ (tests/e2e/main.rs references
+      # CARGO_BIN_EXE_intendant{,-runtime}, and the daemon resolves the
+      # runtime as its on-disk sibling). No separate `cargo build --bins`
+      # here: it feature-resolves without dev-deps, so it rebuilt dep
+      # crates and re-linked all three bins (~40s median) only to replace
+      # the e2e-validated binaries with byte-different ones.
       #   - session-vitals-smoke: daemon in a dirty git repo; vitals event
       #     carries git + cache + limits sections end to end.
       #   - native-goal-smoke: the /goal engine over the control socket.
@@ -419,14 +427,6 @@ jobs:
           python3 -m venv "$RUNNER_TEMP/pyws"
           "$RUNNER_TEMP/pyws/bin/pip" install --quiet websockets
           echo "$RUNNER_TEMP/pyws/bin" >> "$GITHUB_PATH"
-
-      # The real binaries for the smoke rigs — incremental on top of the
-      # test/e2e build above (same target dir, same profile): seconds,
-      # not a second build. Debug profile deliberately (the smokes probe
-      # protocol behavior, which the profile doesn't change).
-      - name: cargo build (smoke binaries)
-        if: runner.os == 'Linux' && steps.relevance_unix.outputs.relevant != 'false'
-        run: cargo build -p intendant --bins --locked --target ${{ matrix.target }}
 
       - name: session-vitals smoke
         if: runner.os == 'Linux' && steps.relevance_unix.outputs.relevant != 'false'


### PR DESCRIPTION
Three efficiency fixes to the required-check workflow, all on behavior that was measured, not guessed.

**1. Fail-cheap ordering on the Linux leg.** `cargo fmt --check` moves to immediately after relevance detection (it needs no build — a formatting failure now surfaces in seconds), and `cargo clippy` moves to between the unit tests and the e2e suite. Deterministic cheap gates now fail before the longer, flakier tail: fmt → unit tests → clippy → e2e → smokes, so a lint-red PR never burns an e2e + smoke cycle first. Both steps keep their `if:` conditions and commands byte-identical; fmt deliberately stays *after* the relevance steps, since a not-yet-run step's empty output would pass the `!= 'false'` test and run it on docs-only diffs. Non-Linux legs are unaffected (both steps are Linux-gated).

**2. Drop the redundant "cargo build (smoke binaries)" step.** The preceding e2e step already builds the binaries the smokes consume: `tests/e2e/main.rs` references `CARGO_BIN_EXE_intendant` and `CARGO_BIN_EXE_intendant-runtime`, and Cargo builds a package's bin targets when compiling its integration tests, uplifting them to `<triple>/debug/` — exactly the path the three smoke steps and the dashboard-boot daemon launch use (and the daemon resolves `intendant-runtime` as its on-disk sibling there). Nothing else consumed the removed step's artifacts. The step's comment claimed it was incremental ("seconds, not a second build"), but `cargo build` resolves features without dev-dependencies while `cargo test` unifies them with dev-deps, so it re-built differently-featured dep crates and re-linked all three bins every run: 9–57s, ~40s median, across the last nine green Linux legs. The smokes now exercise the exact binaries e2e just validated — strictly more consistent.

**3. Remove the dead `Swatinem/rust-cache` step.** It was hosted-runners-only with `save-if: github.ref == 'refs/heads/main'`, but this workflow's push trigger was removed 2026-07-10 — no run has carried that ref since, so nothing has saved, and the repo has zero Actions caches today. Every hosted fork-PR leg paid a restore lookup against an empty store; those legs were already effectively cache-less, so this removes overhead without removing any warmth. If fork traffic ever warrants warm hosted legs, a deliberate seeding path can populate the cache from a trusted ref — fork code must never populate a cache other builds consume.

**Validation:** `actionlint` is clean on the edited file and the YAML parses. This PR's own Linux `pull_request` leg is the live validation for change 2: it runs the full smoke tail against the e2e-built binaries with no separate build step.
