### PR TITLE
session-fork: claude-code anchor-fork engine (PR E)

### DIFF
--- a/src/bin/caller/session_fork/claude_surgery.rs
+++ b/src/bin/caller/session_fork/claude_surgery.rs
@@ -1,0 +1,243 @@
+//! Claude Code anchor-fork surgery: materialize a NEW transcript in the
+//! parent's project dir whose content is the CHAIN-SLICE through the
+//! anchor — the anchor's ancestor chain plus the uuid-less meta lines, in
+//! original order, with every line's `sessionId` rewritten to the child's
+//! fresh uuid. Copy-only: the parent transcript is never written.
+//!
+//! Semantics pinned by `tests/skills/session-fork-probes/spike2` (CC
+//! 2.1.211): resume resolves by filename stem and walks the chain back
+//! from the tail, so the slice makes the anchor the child's tail;
+//! `compact_boundary` lines sever the walk, and a slice through a
+//! pre-boundary anchor simply never includes the boundary — pre-compaction
+//! anchors fork with full history and normal auto-compaction.
+
+use super::{parse_claude_transcript_tree_from_lines, ForkAnchorSpec};
+use std::collections::HashSet;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub(crate) struct ClaudeForkPlan {
+    pub(crate) parent_path: PathBuf,
+    pub(crate) child_uuid: String,
+    pub(crate) child_path: PathBuf,
+    pub(crate) anchor_uuid: String,
+}
+
+pub(crate) struct ClaudeForkOutcome {
+    pub(crate) kept_lines: usize,
+}
+
+/// Validate the anchor against the parent transcript and mint the child
+/// identity. Refuses unknown and sidechain anchors.
+pub(crate) fn plan_claude_fork(
+    transcript: &Path,
+    anchor: &ForkAnchorSpec,
+) -> Result<ClaudeForkPlan, String> {
+    let anchor_uuid = anchor
+        .message_uuid
+        .as_deref()
+        .map(str::trim)
+        .filter(|uuid| !uuid.is_empty())
+        .ok_or_else(|| "a claude-code fork anchor needs a `message_uuid`".to_string())?;
+    let tree = super::shared_claude_tree_scan(transcript)
+        .map_err(|err| format!("failed to scan the parent transcript: {err}"))?;
+    let node = tree.node(anchor_uuid).ok_or_else(|| {
+        format!(
+            "anchor message {anchor_uuid} not found in the parent transcript \
+             (history may have moved since the fork points were read)"
+        )
+    })?;
+    if node.is_sidechain {
+        return Err(format!(
+            "anchor message {anchor_uuid} is sidechain work — fork from a main-chain anchor"
+        ));
+    }
+    let parent_dir = transcript
+        .parent()
+        .ok_or_else(|| "parent transcript has no project dir".to_string())?;
+    let child_uuid = uuid::Uuid::new_v4().to_string();
+    let child_path = parent_dir.join(format!("{child_uuid}.jsonl"));
+    Ok(ClaudeForkPlan {
+        parent_path: transcript.to_path_buf(),
+        child_uuid,
+        child_path,
+        anchor_uuid: anchor_uuid.to_string(),
+    })
+}
+
+/// Execute the chain-slice copy. The slice and the emitted lines come from
+/// ONE read of the parent, so a live parent appending mid-fork cannot skew
+/// the cut (new tail lines simply aren't part of the read).
+pub(crate) fn execute_claude_fork_copy(plan: &ClaudeForkPlan) -> Result<ClaudeForkOutcome, String> {
+    let raw = std::fs::read_to_string(&plan.parent_path)
+        .map_err(|err| format!("failed to read the parent transcript: {err}"))?;
+    let lines: Vec<&str> = raw.lines().collect();
+    let tree = parse_claude_transcript_tree_from_lines(lines.iter().copied());
+    let chain: HashSet<String> = tree
+        .ancestor_chain(&plan.anchor_uuid)
+        .iter()
+        .map(|node| node.uuid.clone())
+        .collect();
+    if chain.is_empty() {
+        return Err(format!(
+            "anchor message {} not found in the parent transcript \
+             (history may have moved since the fork points were read)",
+            plan.anchor_uuid
+        ));
+    }
+
+    let mut kept = 0usize;
+    let mut body = String::new();
+    for line in &lines {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(mut value) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue; // torn tail / foreign line
+        };
+        let on_chain = match value.get("uuid").and_then(serde_json::Value::as_str) {
+            Some(uuid) => chain.contains(uuid),
+            None => true, // uuid-less meta lines (ai-title, agent-name, …)
+        };
+        if !on_chain {
+            continue;
+        }
+        if let Some(object) = value.as_object_mut() {
+            if object.contains_key("sessionId") {
+                object.insert(
+                    "sessionId".to_string(),
+                    serde_json::Value::String(plan.child_uuid.clone()),
+                );
+            }
+        }
+        body.push_str(&value.to_string());
+        body.push('\n');
+        kept += 1;
+    }
+
+    let mut file = std::fs::File::create(&plan.child_path)
+        .map_err(|err| format!("failed to create the child transcript: {err}"))?;
+    file.write_all(body.as_bytes())
+        .map_err(|err| format!("failed to write the child transcript: {err}"))?;
+    file.sync_all()
+        .map_err(|err| format!("failed to sync the child transcript: {err}"))?;
+    Ok(ClaudeForkOutcome { kept_lines: kept })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_fixtures::{boundary_line, message_line};
+    use super::*;
+    use sha2::Digest;
+
+    fn anchor(uuid: &str) -> ForkAnchorSpec {
+        ForkAnchorSpec {
+            kind: "message".to_string(),
+            turn: None,
+            item_id: None,
+            position: None,
+            seq: None,
+            message_uuid: Some(uuid.to_string()),
+        }
+    }
+
+    fn write_parent(lines: &[String]) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir
+            .path()
+            .join("aaaaaaaa-0000-0000-0000-000000000000.jsonl");
+        std::fs::write(&path, lines.join("\n") + "\n").expect("write");
+        (dir, path)
+    }
+
+    fn file_hash(path: &Path) -> String {
+        format!(
+            "{:x}",
+            sha2::Sha256::digest(std::fs::read(path).expect("read"))
+        )
+    }
+
+    fn fork(parent: &Path, anchor_uuid: &str) -> (ClaudeForkPlan, ClaudeForkOutcome) {
+        let plan = plan_claude_fork(parent, &anchor(anchor_uuid)).expect("plan");
+        let outcome = execute_claude_fork_copy(&plan).expect("execute");
+        (plan, outcome)
+    }
+
+    #[test]
+    fn chain_slice_keeps_ancestors_and_meta_drops_siblings_and_descendants() {
+        let meta = "{\"type\":\"ai-title\",\"aiTitle\":\"t\",\"sessionId\":\"aaaaaaaa-0000-0000-0000-000000000000\"}".to_string();
+        let (_dir, parent) = write_parent(&[
+            meta,
+            message_line("u1", None, "user", "round one", false),
+            message_line("a1", Some("u1"), "assistant", "answer one", false),
+            message_line("a1b", Some("u1"), "assistant", "abandoned sibling", false),
+            message_line("u2", Some("a1"), "user", "round two", false),
+        ]);
+        let parent_before = file_hash(&parent);
+
+        let (plan, outcome) = fork(&parent, "a1");
+        assert_eq!(outcome.kept_lines, 3); // meta + u1 + a1
+        assert_eq!(file_hash(&parent), parent_before, "parent mutated");
+
+        let child = std::fs::read_to_string(&plan.child_path).expect("child");
+        assert!(child.contains("answer one"));
+        assert!(!child.contains("abandoned sibling"));
+        assert!(!child.contains("round two"));
+        // Every line, including meta, carries the child's session id.
+        for line in child.lines() {
+            let value: serde_json::Value = serde_json::from_str(line).expect("child line json");
+            if let Some(session_id) = value.get("sessionId") {
+                assert_eq!(session_id.as_str(), Some(plan.child_uuid.as_str()));
+            }
+        }
+        assert_eq!(
+            plan.child_path.file_stem().and_then(|stem| stem.to_str()),
+            Some(plan.child_uuid.as_str())
+        );
+    }
+
+    #[test]
+    fn branch_tip_fork_keeps_that_branch() {
+        let (_dir, parent) = write_parent(&[
+            message_line("u1", None, "user", "root", false),
+            message_line("a1", Some("u1"), "assistant", "branch A", false),
+            message_line("a2", Some("u1"), "assistant", "branch B", false),
+        ]);
+        let (plan, outcome) = fork(&parent, "a1");
+        assert_eq!(outcome.kept_lines, 2);
+        let child = std::fs::read_to_string(&plan.child_path).expect("child");
+        assert!(child.contains("branch A"));
+        assert!(!child.contains("branch B"));
+    }
+
+    #[test]
+    fn pre_boundary_slice_omits_the_compact_boundary() {
+        let (_dir, parent) = write_parent(&[
+            message_line("u1", None, "user", "old round", false),
+            message_line("a1", Some("u1"), "assistant", "old answer", false),
+            boundary_line("b1", "a1"),
+            message_line("u2", Some("b1"), "user", "post-compact", false),
+        ]);
+        let (plan, _) = fork(&parent, "a1");
+        let child = std::fs::read_to_string(&plan.child_path).expect("child");
+        assert!(!child.contains("compact_boundary"));
+        assert!(!child.contains("post-compact"));
+        assert!(child.contains("old answer"));
+    }
+
+    #[test]
+    fn unknown_and_sidechain_anchors_refuse() {
+        let (_dir, parent) = write_parent(&[
+            message_line("u1", None, "user", "main", false),
+            message_line("s1", Some("u1"), "assistant", "sidechain", true),
+        ]);
+        assert!(plan_claude_fork(&parent, &anchor("missing"))
+            .expect_err("unknown")
+            .contains("not found"));
+        assert!(plan_claude_fork(&parent, &anchor("s1"))
+            .expect_err("sidechain")
+            .contains("sidechain"));
+    }
+}

--- a/src/bin/caller/session_fork/claude_tree.rs
+++ b/src/bin/caller/session_fork/claude_tree.rs
@@ -116,10 +116,23 @@ fn node_preview(value: &serde_json::Value) -> String {
 pub(crate) fn parse_claude_transcript_tree(path: &Path) -> io::Result<ClaudeTranscriptTree> {
     let file = std::fs::File::open(path)?;
     let reader = io::BufReader::new(file);
+    let mut lines = Vec::new();
+    for line in reader.lines() {
+        lines.push(line?);
+    }
+    Ok(parse_claude_transcript_tree_from_lines(
+        lines.iter().map(String::as_str),
+    ))
+}
+
+/// The in-memory parse the path variant wraps — the surgery engine slices
+/// the SAME lines it parsed, so file-vs-cache skew cannot mis-cut.
+pub(crate) fn parse_claude_transcript_tree_from_lines<'a>(
+    lines: impl Iterator<Item = &'a str>,
+) -> ClaudeTranscriptTree {
     let mut tree = ClaudeTranscriptTree::default();
 
-    for (line_index, line) in reader.lines().enumerate() {
-        let line = line?;
+    for (line_index, line) in lines.enumerate() {
         let trimmed = line.trim();
         if trimmed.is_empty() {
             continue;
@@ -174,7 +187,7 @@ pub(crate) fn parse_claude_transcript_tree(path: &Path) -> io::Result<ClaudeTran
             tree.active_leaf = Some(uuid);
         }
     }
-    Ok(tree)
+    tree
 }
 
 /// Shared (possibly cached) tree scan, copying the managed-context

--- a/src/bin/caller/session_fork/mod.rs
+++ b/src/bin/caller/session_fork/mod.rs
@@ -21,10 +21,12 @@
 //!   chain, including inactive sibling branch tips (a follow-up phase; the
 //!   catalog reports `supported: false` until the tree parser lands).
 
+mod claude_surgery;
 mod claude_tree;
 mod codex_stage;
 mod fork_points;
 mod native;
+pub(crate) use claude_surgery::*;
 pub(crate) use claude_tree::*;
 pub(crate) use codex_stage::*;
 pub(crate) use fork_points::*;

--- a/src/bin/caller/session_supervisor/agent_config.rs
+++ b/src/bin/caller/session_supervisor/agent_config.rs
@@ -550,7 +550,10 @@ pub(crate) struct LaunchOverrides {
     /// absent from `as_wire_fields`, so `ResumeSession` senders cannot
     /// inject them; applied onto the merged config by
     /// `apply_fork_lineage`). `fork_relationship` here overrides the
-    /// wire-vetted kind (`anchor-fork` is minted internally only).
+    /// wire-vetted kind (`anchor-fork` is minted internally only), and
+    /// `forked_from` covers engines whose child resumes its OWN id (the
+    /// claude-code chain-slice: resume token = child uuid ≠ parent).
+    pub(crate) forked_from: Option<String>,
     pub(crate) fork_relationship: Option<String>,
     pub(crate) fork_anchor: Option<String>,
     pub(crate) codex_fork_rollout_path: Option<String>,
@@ -597,6 +600,9 @@ impl LaunchOverrides {
         let Some(config) = config else {
             return;
         };
+        if self.forked_from.is_some() {
+            config.forked_from = self.forked_from.clone();
+        }
         if self.fork_relationship.is_some() {
             config.fork_relationship = self.fork_relationship.clone();
         }

--- a/src/bin/caller/session_supervisor/fork.rs
+++ b/src/bin/caller/session_supervisor/fork.rs
@@ -37,7 +37,13 @@ impl SessionSupervisor {
                 {
                     Ok(outcome) => {
                         self.announce_native_fork(
-                            &source, &token, &anchor, name, task, project_root, request_id,
+                            &source,
+                            &token,
+                            &anchor,
+                            name,
+                            task,
+                            project_root,
+                            request_id,
                             outcome,
                         )
                         .await;
@@ -63,10 +69,24 @@ impl SessionSupervisor {
                 }
                 Err(error) => error,
             },
-            "claude-code" => {
-                "the claude-code fork engine lands in a follow-up phase (fork points are already served)"
-                    .to_string()
-            }
+            "claude-code" => match self.fork_claude_session(&token, &anchor).await {
+                Ok((backend_id, child_uuid, kept_lines, parent_project_root)) => {
+                    self.announce_claude_fork(
+                        &source,
+                        backend_id,
+                        &anchor,
+                        name,
+                        task,
+                        project_root.or(parent_project_root),
+                        request_id,
+                        child_uuid,
+                        kept_lines,
+                    )
+                    .await;
+                    return;
+                }
+                Err(error) => error,
+            },
             other => format!("fork is not supported for {other} sessions"),
         };
 
@@ -270,6 +290,119 @@ impl SessionSupervisor {
             Some(true),
             Vec::new(),
             true,
+            None,
+            overrides,
+            false,
+            false,
+        )
+        .await;
+    }
+    /// Chain-slice the parent transcript into a fresh child uuid in the
+    /// same project dir. Returns `(parent_backend_id, child_uuid,
+    /// kept_lines, parent_project_root)`.
+    async fn fork_claude_session(
+        &self,
+        token: &str,
+        anchor: &ForkAnchorSpec,
+    ) -> Result<(String, String, usize, Option<String>), String> {
+        let home = self.logs_home();
+        let backend_id = match persisted_external_identity_for_session_in_home(&home, token) {
+            Some((source, id)) if source == "claude-code" => id,
+            Some((source, _)) => {
+                return Err(format!(
+                    "session {token} is a {source} session, not claude-code"
+                ));
+            }
+            None => token.to_string(),
+        };
+        let transcript = crate::web_gateway::find_claude_session_file(&home, &backend_id)
+            .ok_or_else(|| {
+                format!(
+                    "transcript for claude-code session {backend_id} not found in the claude session store"
+                )
+            })?;
+        // The child must spawn in the parent's project (claude resolves a
+        // resumed id inside the cwd's project dir).
+        let parent_project_root = crate::session_config::load_for_resume(
+            &home,
+            "claude-code",
+            &backend_id,
+            Some(&backend_id),
+        )
+        .and_then(|cfg| cfg.project_root);
+        let anchor = anchor.clone();
+        let outcome = tokio::task::spawn_blocking(move || {
+            let plan = crate::session_fork::plan_claude_fork(&transcript, &anchor)?;
+            let outcome = crate::session_fork::execute_claude_fork_copy(&plan)?;
+            Ok::<_, String>((plan.child_uuid, outcome.kept_lines))
+        })
+        .await
+        .map_err(|err| format!("fork surgery task failed: {err}"))?;
+        let (child_uuid, kept_lines) = outcome?;
+        Ok((backend_id, child_uuid, kept_lines, parent_project_root))
+    }
+
+    /// Announce a claude-code fork (the child uuid is minted by the
+    /// surgery, so both edge and result carry it immediately) and activate
+    /// the child through the resume funnel — a PLAIN resume of the child's
+    /// own id; `forked_from` rides the internal overrides so the identity
+    /// announce emits the `anchor-fork` edge durably.
+    #[allow(clippy::too_many_arguments)]
+    async fn announce_claude_fork(
+        &self,
+        source: &str,
+        backend_id: String,
+        anchor: &ForkAnchorSpec,
+        name: Option<String>,
+        task: Option<String>,
+        project_root: Option<String>,
+        request_id: Option<String>,
+        child_uuid: String,
+        kept_lines: usize,
+    ) {
+        self.config.bus.send(AppEvent::SessionRelationship {
+            parent_session_id: backend_id.clone(),
+            child_session_id: child_uuid.clone(),
+            relationship: "anchor-fork".to_string(),
+            ephemeral: false,
+        });
+        self.config.bus.send(AppEvent::SessionForkResult {
+            request_id,
+            parent_session_id: backend_id.clone(),
+            child_session_id: Some(child_uuid.clone()),
+            source: source.to_string(),
+            relationship: "anchor-fork".to_string(),
+            anchor_summary: format!("{} ({} lines kept)", anchor.summary(), kept_lines),
+            error: None,
+        });
+        if let Some(name) = name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+        {
+            self.rename_session(
+                child_uuid.clone(),
+                Some(child_uuid.clone()),
+                Some(source.to_string()),
+                name.to_string(),
+            )
+            .await;
+        }
+        let overrides = LaunchOverrides {
+            forked_from: Some(backend_id),
+            fork_relationship: Some("anchor-fork".to_string()),
+            fork_anchor: serde_json::to_string(anchor).ok(),
+            ..Default::default()
+        };
+        self.resume_session(
+            source.to_string(),
+            child_uuid.clone(),
+            Some(child_uuid),
+            project_root,
+            task,
+            Some(true),
+            Vec::new(),
+            false,
             None,
             overrides,
             false,

--- a/tests/skills/session-fork-claude-code/SKILL.md
+++ b/tests/skills/session-fork-claude-code/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: session-fork-claude-code
+description: >
+  Live gate for the claude-code anchor-fork engine: fork a real CC session
+  from a mid-history anchor and from an inactive sibling branch tip
+  through the daemon (fork-points catalog → ForkSessionAtAnchor → spawned
+  child), verify the child resumes with exactly the sliced history, the
+  parent transcript is byte-identical, and the anchor-fork lineage edge
+  lands. Run before shipping changes to session_fork/claude_surgery.rs or
+  claude_tree.rs, or when bumping the pinned Claude Code version.
+compatibility: Requires Claude Code on PATH with auth, a built daemon from this worktree, and a scratch CC project dir. Costs a few haiku turns. Not CI — real backend.
+allowed-tools: Bash Read
+disable-model-invocation: false
+---
+
+# Claude-code anchor-fork live gate
+
+The surgery semantics (chain-slice, filename-stem resume, dead pins,
+boundary behavior) are pinned by `tests/skills/session-fork-probes/spike2`;
+this skill proves the daemon-integrated path end to end.
+
+## Procedure
+
+1. Build + start a scratch daemon from this worktree on its own port.
+2. Seed a scratch CC session with distinguishable rounds (the probes'
+   codeword pattern works: round one BLUEFIN, round two MARIGOLD via the
+   dashboard composer or `claude -p` + `--resume` in a scratch project),
+   supervised by the daemon so the overlay records its project root.
+3. Catalog: `curl -s localhost:<port>/api/session/<cc-uuid>/fork-points | jq
+   '.fork_points[]'` — expect `head`, `msg:*` turn boundaries, and
+   `tip:*` rows for any abandoned sibling branches.
+4. Fork before round two:
+   ```json
+   { "action": "fork_session_at_anchor", "source": "claude-code",
+     "session_id": "<cc-uuid>",
+     "anchor": { "kind": "message", "message_uuid": "<turn-1 tail uuid>" },
+     "task": "Which codewords do you know? Answer with just the codewords.",
+     "request_id": "skill-cc-1" }
+   ```
+5. Verify, in order:
+   - `session_fork_result` carries the child uuid immediately (the surgery
+     mints it) with `error: null`.
+   - The child's answer names ONLY the round-one codeword.
+   - The parent transcript file is byte-identical (hash before/after);
+     the child `<uuid>.jsonl` sits in the SAME project dir with every
+     line's `sessionId` rewritten.
+   - The Sessions list shows the `anchor-fork` edge parent→child; the
+     child's overlay records `forked_from` + `fork_anchor`.
+6. Branch-tip variant: pick a `tip:*` fork point (create one by editing a
+   message in the parent first if none exists) and verify the child
+   resumes that abandoned branch's content.
+7. Pre-compaction variant (when a compacted parent is at hand): fork a
+   `pre_compaction: true` anchor and verify the child loads the full
+   pre-compact history (the slice omits the boundary) and still
+   auto-compacts normally later.
+
+## Known caveats
+
+- The child spawns in the parent's recorded project root; a parent that
+  never ran under Intendant has no overlay root and falls back to the
+  daemon default — if that differs from the transcript's project dir, CC
+  cannot resolve the resumed id (structured spawn failure, no data risk).
+- Subagent sidecar dirs (`<uuid>/subagents/`) are not copied in v1;
+  sidechain content referenced only there is absent from the child.


### PR DESCRIPTION
Phase E of fork-from-any-anchor (#353 probes, #354 catalog, #361 CC tree, #374 wire + native, #377 codex engine).

**Engine** (`session_fork/claude_surgery.rs`, copy-only): chain-slice the parent transcript into a fresh child `<uuid>.jsonl` in the same project dir — the anchor's ancestor chain + uuid-less meta lines in original order, per-line `sessionId` rewritten to the child uuid. One read feeds both the slice and the emit (a live parent appending mid-fork cannot skew the cut); unknown/sidechain anchors refuse with structured errors. **Pre-compaction anchors work with zero extra surgery** — the slice never includes the `compact_boundary`, so the child resumes full pre-compact history and keeps normal auto-compaction (pinned by the probes skill on CC 2.1.211: filename-stem resume, tail-chain walk, dead `last-prompt` pins).

**Orchestration**: the child uuid is minted by the surgery, so the `session_fork_result` and the `anchor-fork` relationship carry it immediately; a plain resume of the child's own id activates it (never `--fork-session`). Since resume-token ≠ parent here, `forked_from` rides a new internal-only `LaunchOverrides` field into the overlay and the identity announce emits the durable edge — same wire-injection-proof pattern as the codex one-shots. The child spawns in the parent's recorded project root.

Also: `parse_claude_transcript_tree` gains an in-memory `_from_lines` variant shared by the path scan and the surgery.

Battery: fmt clean; clippy clean on touched files; full units 3721/3721 (4 new surgery tests: chain-slice + sibling/descendant drops, sessionId rewrite, branch-tip fork, boundary omission, refusals); full e2e 22/22. Live gate: `tests/skills/session-fork-claude-code/SKILL.md`.