### PR TITLE
e2e: widen the peer task_receipt wait to PEER_WAIT_TIMEOUT

### DIFF
--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -2609,10 +2609,13 @@ async fn ctl_peer_list_and_task_drive_a_federated_peer_daemon() {
     // And the receipt leaves a durable trace on A's federated peer-event
     // record (`peers.jsonl`, the forensics rail dump_daemons reads). The
     // actor writes it via the async log sink, so it may trail the ctl
-    // response by a beat — poll briefly.
+    // response — on a loaded CI box by far more than a beat (a 30s
+    // deadline here ejected two otherwise-green merge-queue entries on
+    // 2026-07-16). PEER_WAIT_TIMEOUT like the test's other cross-daemon
+    // waits: the deadline only bounds failing runs, never green ones.
     poll_until(
         "the task_receipt landing in daemon A's peers.jsonl",
-        Duration::from_secs(30),
+        PEER_WAIT_TIMEOUT,
         || {
             let tail = a.peer_log_tail();
             let delegation_id = delegation_id.clone();


### PR DESCRIPTION
The federated peer e2e test polls for the `task_receipt` event landing in daemon A's `peers.jsonl` with a hardcoded 30-second deadline, while the same test's other cross-daemon waits use `PEER_WAIT_TIMEOUT` (240s) — the generous-deadline convention this suite adopted after the 2026-07-12 load incidents (the constant's doc: wall-clock cost is bounded by how fast waits *succeed*, not by the deadline).

That 30s wait timed out twice today under concurrent fleet load (PR #376's pull_request Linux leg and its merge-group revalidation), each time ejecting an otherwise-green queue entry and costing a full group cycle. The delegated task had completed on daemon B in both failures — the receipt event was simply trailing the async log sink under load.

One-line widening to `PEER_WAIT_TIMEOUT` plus the comment updated to record why. No product code touched.