### PR TITLE
ci: literal wasm-drift job name so the skipped gate still reports the pinned context

### DIFF
--- a/.github/workflows/wasm-drift.yml
+++ b/.github/workflows/wasm-drift.yml
@@ -94,19 +94,25 @@ jobs:
   # relevance step decides locally exactly like the old single-job
   # scheme — a silent classifier crash can never mask a relevant diff,
   # which is what makes the skipped-equals-satisfied semantics safe here.
+  #
+  # The job name is a LITERAL, never a matrix expansion: skipped-equals-
+  # satisfied only works when the skipped check run carries the ruleset's
+  # pinned context name, and a job skipped via `if:` never expands its
+  # matrix — its check run reports under the raw "wasm-drift
+  # (${{ matrix.os }})" placeholder, the pinned "wasm-drift
+  # (macos-latest)" context then never reports at all, and every
+  # irrelevant-diff PR wedges: arming can't enter the queue and group
+  # entries cycle all-green until ejection (live fleet-wide outage,
+  # 2026-07-16, first landing of the classifier gate). The single-entry
+  # matrix existed only to name os/runner; inline literals cost nothing.
   wasm-drift:
-    name: wasm-drift (${{ matrix.os }})
+    name: wasm-drift (macos-latest)
     needs: classify
     if: always() && (needs.classify.result != 'success' || needs.classify.outputs.relevant == 'true')
     # Trust-based routing — same rule as windows.yml: trusted refs on the
     # self-hosted fleet, fork PRs on GitHub-hosted runners.
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && matrix.os || matrix.runner }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'macos-latest' || fromJSON('["self-hosted", "intendant-macos"]') }}
     timeout-minutes: 30
-    strategy:
-      matrix:
-        include:
-          - os: macos-latest
-            runner: [self-hosted, intendant-macos]
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
**Fleet-wide landing outage fix** — zero PRs have merged since #376 landed (21:07Z).

#376's classifier-gated Mac leg skips via job-level `if:` on irrelevant diffs, relying on skipped-equals-satisfied. That premise only holds when the skipped check run carries the ruleset's pinned context name — but a job skipped at the job level never expands its matrix, so the skipped run reports as `wasm-drift (${{ matrix.os }})` and the pinned `wasm-drift (macos-latest)` context **never reports at all**. Observed effects since 21:07Z:

- PR-side: armed+green PRs never enter the queue (context stuck at *Expected*) — first hit: #385, armed 40+ min with every real check green.
- Group-side: entries cycle all-green run sets without merging (#381: three full green sets at 21:13/21:35/21:59), then eject silently (#379 already ejected, auto-merge disarmed).

Fix: the single-entry matrix existed only to name os/runner — inline the literals so the job name is `wasm-drift (macos-latest)` in every state, running or skipped. Classifier tiering, fail-open `always()` backstop, and fork routing all unchanged. `actionlint` clean.

This PR touches the workflow file, which is in the classifier's relevance list, so its own validation runs the full Mac leg and reports the pinned context — it can transit the wedged queue once the doomed entries ahead drain/eject.

After this lands, wedged PRs need one `gh pr update-branch` (or any push) to mint fresh runs under the fixed workflow, and ejected ones need re-arming.