### PR TITLE
ci: report the wasm-drift skip under the pinned check name

### DIFF
--- a/.github/workflows/wasm-drift.yml
+++ b/.github/workflows/wasm-drift.yml
@@ -95,18 +95,20 @@ jobs:
   # scheme — a silent classifier crash can never mask a relevant diff,
   # which is what makes the skipped-equals-satisfied semantics safe here.
   wasm-drift:
-    name: wasm-drift (${{ matrix.os }})
+    # No matrix, deliberately: a job skipped via `if:` never materializes
+    # its matrix, so a matrixed name would report as the literal
+    # `wasm-drift (${{ matrix.os }})` — and the ruleset's pinned
+    # `wasm-drift (macos-latest)` context would simply never arrive,
+    # parking every wasm-irrelevant PR and wedging merge-group entries at
+    # Expected (fleet-wide, live 2026-07-16). The single-OS pair the
+    # matrix carried lives inline in `runs-on` below.
+    name: wasm-drift (macos-latest)
     needs: classify
     if: always() && (needs.classify.result != 'success' || needs.classify.outputs.relevant == 'true')
     # Trust-based routing — same rule as windows.yml: trusted refs on the
     # self-hosted fleet, fork PRs on GitHub-hosted runners.
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && matrix.os || matrix.runner }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'macos-latest' || fromJSON('["self-hosted", "intendant-macos"]') }}
     timeout-minutes: 30
-    strategy:
-      matrix:
-        include:
-          - os: macos-latest
-            runner: [self-hosted, intendant-macos]
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Fleet queue blocker since the two-tier wasm-relevance classifier landed (#376): a job skipped via `if:` never materializes its matrix, so the skip minted a check run literally named `wasm-drift (${{ matrix.os }})` — the ruleset's pinned `wasm-drift (macos-latest)` context never reports, parking every wasm-irrelevant PR at BLOCKED (armed, never queues) and wedging merge-group entries at Expected (observed live: pre-queue parks and queue ejections across the evening; #376's own PR self-selected as wasm-relevant — the workflow file is in the classifier's pattern list by design — so the skip path shipped unexercised).

Fix: drop the single-OS matrix. The job name pins the literal required context, and the os/runner routing pair moves inline into `runs-on` (`'macos-latest'` for fork PRs, `fromJSON` fleet labels otherwise). A skipped run now reports exactly `wasm-drift (macos-latest)`, and skipped-equals-satisfied works as #376 designed. actionlint clean.

This PR edits the workflow itself, so the classifier marks it wasm-relevant and the REAL Mac leg runs — the required context reports from a genuine run, letting this land through the wedged queue. After it merges: parked PRs need `gh pr update-branch` (or any push) to re-run checks under the fixed workflow; queued entries validate against future-main and self-heal.