### PR TITLE
config: atomic intendant.toml writes in save_config

### DIFF
--- a/src/bin/caller/project.rs
+++ b/src/bin/caller/project.rs
@@ -1503,11 +1503,17 @@ impl Project {
 
     /// Write the current config back to intendant.toml.
     /// Creates the file if it doesn't exist.
+    ///
+    /// The write must be atomic (tempfile + rename): readers — dashboard GETs
+    /// re-reading from disk, the post-save control-plane persist passes,
+    /// external watchers — must never observe a truncated or empty
+    /// intendant.toml. 2026-07-16 CI caught a zero-byte read mid-rewrite under
+    /// the previous truncate-then-write `std::fs::write`.
     pub fn save_config(&self) -> Result<(), CallerError> {
         let config_path = self.root.join("intendant.toml");
         let content = toml::to_string_pretty(&self.config)
             .map_err(|e| CallerError::Config(format!("Failed to serialize config: {}", e)))?;
-        std::fs::write(&config_path, content)
+        crate::file_watcher::atomic_write(&config_path, content.as_bytes())
             .map_err(|e| CallerError::Config(format!("Failed to write intendant.toml: {}", e)))?;
         Ok(())
     }


### PR DESCRIPTION
## Mechanism

`Project::save_config` wrote intendant.toml via `std::fs::write` — truncate-then-write, which exposes a zero-length file to any concurrent reader for the duration of the write. The 2026-07-16 e2e settings run (run 29532575362) caught this live: the test read back a zero-byte intendant.toml immediately after `POST /api/settings` returned `ok:true`.

The window is not rare in practice: each settings save also dispatches ~16 agent-settings ControlMsgs (`dispatch_agent_settings_control_msgs`), and the control plane's handlers each re-read and re-persist the same file post-reply (`persist_codex_field` / `persist_claude_field` / `persist_external_agent` — the second persist is documented as intentional). Under `fs::write` that was ~16 more truncate windows per save.

## User-facing exposure

The dashboard's real settings saves go through this exact path (HTTP route and its tunnel twin), and readers re-read the file from disk (`GET /api/settings`, the control-plane persist passes themselves). A reader landing in the window sees an empty TOML, which parses as all-defaults; a racing read-modify-writer (the persist helpers are exactly that) would then persist defaults back — silent settings loss, not just a transient glitch.

## Fix

Route the write through `file_watcher::atomic_write` — unique tempfile in the destination directory + fsync + rename — so readers always observe either the complete old file or the complete new one. This is the primitive the codebase already trusts for `.env` writes (same settings surface) and the rewind-snapshot manifests; it handles Windows rename-over-existing via `NamedTempFile::persist` and re-stages on cross-filesystem renames. The session catalog's directory scans already recognize and skip its `.intendant-write-*.tmp` names. Error type/context mapping in `save_config` is unchanged, so callers see the same `Result` shape.

## Parity notes

- `atomic_write` runs `create_dir_all` on the parent, so a missing parent dir is now created rather than erroring `NotFound`. Benign here: the parent is the project root, which exists by construction for every caller.
- The rename replaces destination permissions with the tempfile's (0600 on Unix) instead of preserving the prior mode — the same property the existing `.env` write path already has; intendant.toml can carry peer bearer tokens, so tighter-by-default is acceptable.
- No inline tests assume the old write mechanics (project.rs tests are serde round-trips; settings/control-plane tests exercise `save_config` against tempdirs, which behave identically).