### PR TITLE
Writer-lane latency instrumentation + peer-rig timeout forensics

### DIFF
--- a/src/bin/caller/dashboard_control/api_control.rs
+++ b/src/bin/caller/dashboard_control/api_control.rs
@@ -3260,8 +3260,7 @@ mod tests {
     //      tempdirs (hermeticity convention).
 
     fn empty_peer_registry() -> crate::peer::PeerRegistry {
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(8);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(8);
         crate::peer::PeerRegistry::new(log_tx)
     }
 
@@ -4125,8 +4124,7 @@ mod tests {
 
     #[tokio::test]
     async fn peer_webrtc_signal_returns_http_error_metadata() {
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(8);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(8);
         let mut rt = runtime();
         rt.peer_registry = Some(crate::peer::PeerRegistry::new(log_tx));
 

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 static NEXT_AGENT_OUTPUT_ID: AtomicU64 = AtomicU64::new(1);
 const OUTBOUND_CONTEXT_SNAPSHOT_RAW_INLINE_LIMIT: usize = 128 * 1024;
@@ -2110,10 +2110,15 @@ pub enum ControlMsg {
 /// low-volume event subset persisted to `session.jsonl`, and
 /// [`EventBus::subscribe_intents`] is the lossless path for user intents
 /// (`ControlCommand`) and the session-bookkeeping events that route them.
+/// One item on the lossless session-log lane: the event plus the instant it
+/// entered the lane at [`EventBus::send`], so the writer can measure
+/// enqueue→consume latency (see [`warn_writer_lane_slow`]).
+pub type SessionLogLaneItem = (AppEvent, Instant);
+
 #[derive(Clone)]
 pub struct EventBus {
     tx: tokio::sync::broadcast::Sender<AppEvent>,
-    session_log_sinks: Arc<Mutex<Vec<tokio::sync::mpsc::UnboundedSender<AppEvent>>>>,
+    session_log_sinks: Arc<Mutex<Vec<tokio::sync::mpsc::UnboundedSender<SessionLogLaneItem>>>>,
     intent_sinks: Arc<Mutex<Vec<tokio::sync::mpsc::UnboundedSender<AppEvent>>>>,
 }
 
@@ -2129,8 +2134,12 @@ impl EventBus {
 
     pub fn send(&self, event: AppEvent) {
         if app_event_writes_to_session_log(&event) {
+            // Stamped at the emit point so the session-log writer can
+            // measure how long the item sat in the lane before it was
+            // consumed (see `warn_writer_lane_slow`).
+            let enqueued_at = Instant::now();
             if let Ok(mut sinks) = self.session_log_sinks.lock() {
-                sinks.retain(|sink| sink.send(event.clone()).is_ok());
+                sinks.retain(|sink| sink.send((event.clone(), enqueued_at)).is_ok());
             }
         }
         if app_event_rides_intent_lane(&event) {
@@ -2156,7 +2165,13 @@ impl EventBus {
     /// such as `SteerRequested` / `SteerQueued` during high-volume model
     /// streaming, so the bus keeps a separate unbounded fan-out for just the
     /// event kinds that the session log writer persists.
-    pub fn subscribe_session_log(&self) -> tokio::sync::mpsc::UnboundedReceiver<AppEvent> {
+    ///
+    /// Each item carries the [`Instant`] it was pushed into the lane, so a
+    /// consumer can measure enqueue→consume latency (the session-log writer
+    /// reports pathological lags — see [`warn_writer_lane_slow`]).
+    pub fn subscribe_session_log(
+        &self,
+    ) -> tokio::sync::mpsc::UnboundedReceiver<SessionLogLaneItem> {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         if let Ok(mut sinks) = self.session_log_sinks.lock() {
             sinks.push(tx);
@@ -3188,17 +3203,100 @@ pub fn spawn_outbound_broadcaster(
 /// are skipped here to avoid duplication — only events that would otherwise be
 /// lost are handled.
 ///
+/// Per item the task measures enqueue→consume (how long the event sat in the
+/// lossless lane) and consume→durable (how long the locked append+flush took)
+/// and reports pathological stalls on stderr via [`warn_writer_lane_slow`] —
+/// forensics for the observed "broadcast seen, session-log row absent for
+/// minutes" class, which this loop's silence made undecidable between a
+/// never-polled task and a consumed-then-stuck write.
+///
 /// Counterpart to `spawn_outbound_broadcaster` which handles the WebSocket/
 /// control-socket broadcast path.
 pub fn spawn_session_log_writer(
-    mut event_rx: tokio::sync::mpsc::UnboundedReceiver<AppEvent>,
+    mut event_rx: tokio::sync::mpsc::UnboundedReceiver<SessionLogLaneItem>,
     session_log: crate::SharedSessionLog,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        while let Some(event) = event_rx.recv().await {
+        let mut last_slow_warn: Option<Instant> = None;
+        while let Some((event, enqueued_at)) = event_rx.recv().await {
+            let consumed_at = Instant::now();
             write_event_to_session_log(&session_log, &event);
+            warn_writer_lane_slow(
+                "session-log-writer",
+                || debug_variant_name(&event),
+                consumed_at.saturating_duration_since(enqueued_at),
+                consumed_at.elapsed(),
+                &mut last_slow_warn,
+            );
         }
     })
+}
+
+/// A writer-lane stage (enqueue→consume or consume→durable) longer than this
+/// is reported as pathological.
+pub(crate) const WRITER_LANE_SLOW_THRESHOLD: Duration = Duration::from_secs(5);
+
+/// Minimum spacing between SLOW reports from one writer task, so a clearing
+/// stall (a backlog of delayed items all draining at once) cannot storm the
+/// daemon log.
+pub(crate) const WRITER_LANE_WARN_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Report a pathologically slow durable-writer event on stderr.
+///
+/// The durable writer tasks (session-log above, `peer::log_writer`) call this
+/// once per item with the item's measured stages:
+///
+/// - `enqueue_to_consume`: producer `send` → writer task `recv` return. Large
+///   values mean the item sat in the channel — an unpolled/wedged writer task
+///   (or, for the bounded peer channel, upstream backpressure).
+/// - `consume_to_durable`: `recv` return → append+flush returned. Large
+///   values mean the write path itself blocked (lock contention or a stuck
+///   filesystem syscall).
+///
+/// Emits at most one line per [`WRITER_LANE_WARN_INTERVAL`] per task
+/// (`last_warned` is task-local state) and nothing below
+/// [`WRITER_LANE_SLOW_THRESHOLD`], so the happy path stays silent. The line
+/// lands on stderr, which the daemon-log tees already capture in tests and CI
+/// dumps. Returns whether a line was emitted (observable for tests).
+pub(crate) fn warn_writer_lane_slow(
+    task: &str,
+    event_kind: impl FnOnce() -> String,
+    enqueue_to_consume: Duration,
+    consume_to_durable: Duration,
+    last_warned: &mut Option<Instant>,
+) -> bool {
+    if enqueue_to_consume < WRITER_LANE_SLOW_THRESHOLD
+        && consume_to_durable < WRITER_LANE_SLOW_THRESHOLD
+    {
+        return false;
+    }
+    let now = Instant::now();
+    if let Some(previous) = *last_warned {
+        if now.saturating_duration_since(previous) < WRITER_LANE_WARN_INTERVAL {
+            return false;
+        }
+    }
+    *last_warned = Some(now);
+    eprintln!(
+        "[{task}] SLOW event={} enqueue_to_consume={:.1}s consume_to_durable={:.1}s",
+        event_kind(),
+        enqueue_to_consume.as_secs_f64(),
+        consume_to_durable.as_secs_f64(),
+    );
+    true
+}
+
+/// Variant name of a `Debug`-rendered enum value (`SessionNote`,
+/// `StatusChanged`, …): the token before the first space, brace, or paren.
+/// Diagnostics-only — evaluated on the rate-limited pathological path, never
+/// per event.
+pub(crate) fn debug_variant_name(value: &impl std::fmt::Debug) -> String {
+    let rendered = format!("{value:?}");
+    rendered
+        .split([' ', '{', '('])
+        .next()
+        .unwrap_or("unknown")
+        .to_string()
 }
 
 fn app_event_writes_to_session_log(event: &AppEvent) -> bool {
@@ -5887,10 +5985,11 @@ mod tests {
             id: "steer-1".to_string(),
         });
 
-        let event = tokio::time::timeout(std::time::Duration::from_secs(1), log_rx.recv())
-            .await
-            .expect("session-log event should arrive")
-            .expect("session-log channel should remain open");
+        let (event, _enqueued_at) =
+            tokio::time::timeout(std::time::Duration::from_secs(1), log_rx.recv())
+                .await
+                .expect("session-log event should arrive")
+                .expect("session-log channel should remain open");
         match event {
             AppEvent::SteerRequested {
                 session_id,
@@ -5906,6 +6005,84 @@ mod tests {
         assert!(
             log_rx.try_recv().is_err(),
             "deltas and ticks must not be queued"
+        );
+    }
+
+    /// The writer-lane SLOW report stays silent below the threshold, fires
+    /// when either stage crosses it, and rate-limits repeats per task.
+    #[test]
+    fn writer_lane_slow_warning_thresholds_and_rate_limit() {
+        let fast = Duration::from_millis(50);
+        let slow = WRITER_LANE_SLOW_THRESHOLD + Duration::from_secs(1);
+
+        // Below both thresholds: silent, and the rate limiter stays unarmed.
+        let mut last_warned = None;
+        assert!(!warn_writer_lane_slow(
+            "test-writer",
+            || "Event".to_string(),
+            fast,
+            fast,
+            &mut last_warned,
+        ));
+        assert!(last_warned.is_none());
+
+        // Either stage crossing the threshold warns (enqueue→consume here).
+        assert!(warn_writer_lane_slow(
+            "test-writer",
+            || "Event".to_string(),
+            slow,
+            fast,
+            &mut last_warned,
+        ));
+        assert!(last_warned.is_some());
+
+        // A second pathological event inside the warn interval is suppressed
+        // (consume→durable slow this time — the stage doesn't matter).
+        assert!(!warn_writer_lane_slow(
+            "test-writer",
+            || "Event".to_string(),
+            fast,
+            slow,
+            &mut last_warned,
+        ));
+
+        // Once the interval has passed, the warning re-arms.
+        let Some(rearmed) =
+            Instant::now().checked_sub(WRITER_LANE_WARN_INTERVAL + Duration::from_secs(1))
+        else {
+            // Box uptime shorter than the warn interval — cannot synthesize
+            // a sufficiently old instant on this run.
+            return;
+        };
+        last_warned = Some(rearmed);
+        assert!(warn_writer_lane_slow(
+            "test-writer",
+            || "Event".to_string(),
+            fast,
+            slow,
+            &mut last_warned,
+        ));
+    }
+
+    /// The diagnostics label is the bare variant name for unit, struct, and
+    /// tuple variants alike.
+    #[test]
+    fn debug_variant_name_extracts_the_variant() {
+        assert_eq!(debug_variant_name(&AppEvent::Tick), "Tick");
+        assert_eq!(
+            debug_variant_name(&AppEvent::HumanResponseSent),
+            "HumanResponseSent"
+        );
+        assert_eq!(
+            debug_variant_name(&AppEvent::SessionNote {
+                session_id: Some("s-1".to_string()),
+                note_id: "n-1".to_string(),
+                text: "note body".to_string(),
+                attachments: Vec::new(),
+                source: None,
+                ts: 0,
+            }),
+            "SessionNote"
         );
     }
 

--- a/src/bin/caller/fission_lifecycle.rs
+++ b/src/bin/caller/fission_lifecycle.rs
@@ -265,7 +265,9 @@ pub fn spawn_fission_lifecycle_watcher(
     let mut rx = bus.subscribe_session_log();
     tokio::spawn(async move {
         let mut state = LifecycleWatcherState::default();
-        while let Some(event) = rx.recv().await {
+        // The lane pairs each event with its enqueue instant (the session-log
+        // writer's latency forensics); this watcher only folds the events.
+        while let Some((event, _enqueued_at)) = rx.recv().await {
             if !matches!(event, AppEvent::FileChanged { .. }) {
                 handle_lifecycle_event(&event, &mut state);
                 continue;
@@ -281,10 +283,10 @@ pub fn spawn_fission_lifecycle_watcher(
             stage_lifecycle_event(&event, &mut state, &mut batch);
             loop {
                 match rx.try_recv() {
-                    Ok(next @ AppEvent::FileChanged { .. }) => {
+                    Ok((next @ AppEvent::FileChanged { .. }, _)) => {
                         stage_lifecycle_event(&next, &mut state, &mut batch);
                     }
-                    Ok(next) => {
+                    Ok((next, _)) => {
                         batch.flush();
                         handle_lifecycle_event(&next, &mut state);
                     }

--- a/src/bin/caller/peer/actor.rs
+++ b/src/bin/caller/peer/actor.rs
@@ -29,6 +29,7 @@ use crate::peer::event::{
 };
 use crate::peer::handle::{ConnectionState, PeerCommand};
 use crate::peer::id::PeerId;
+use crate::peer::log_writer::EnqueuedPeerEvent;
 use crate::peer::traits::PeerTransport;
 use crate::peer::upcast::{MAX_TRACKED_PEER_DISPLAYS, MAX_TRACKED_PEER_SESSIONS};
 use crate::peer::PeerError;
@@ -142,7 +143,7 @@ pub(crate) struct PeerActor {
     pub commands_rx: mpsc::Receiver<PeerCommand>,
     pub events_in_rx: mpsc::Receiver<PeerEvent>,
     pub events_out_tx: broadcast::Sender<PeerEvent>,
-    pub log_sink: mpsc::Sender<TaggedPeerEvent>,
+    pub log_sink: mpsc::Sender<EnqueuedPeerEvent>,
     pub connection_tx: watch::Sender<ConnectionState>,
     pub status_tx: watch::Sender<PeerStatus>,
     pub card_tx: watch::Sender<Arc<AgentCard>>,
@@ -620,7 +621,7 @@ impl PeerActor {
                 },
                 seq: self.seq,
             };
-            let _ = self.log_sink.send(tagged).await;
+            let _ = self.log_sink.send(tagged.into()).await;
         }
     }
 
@@ -667,7 +668,7 @@ impl PeerActor {
             };
             // Durable sink: await. If closed, the log writer is gone
             // (process shutdown) and we drop silently.
-            let _ = self.log_sink.send(tagged).await;
+            let _ = self.log_sink.send(tagged.into()).await;
         }
         // Broadcast: non-blocking. Err means no subscribers — that's
         // fine, we still wrote to the durable sink.
@@ -757,7 +758,7 @@ mod tests {
     /// all other channels are held open by the returned guards.
     #[allow(clippy::type_complexity)]
     fn test_actor(
-        log_tx: mpsc::Sender<TaggedPeerEvent>,
+        log_tx: mpsc::Sender<EnqueuedPeerEvent>,
     ) -> (
         PeerActor,
         (
@@ -848,7 +849,7 @@ mod tests {
             })
             .await;
         let salvage = log_rx.try_recv().expect("coalesced salvage record");
-        match salvage.payload {
+        match salvage.event.payload {
             PeerEvent::Message {
                 content: MessageContent::Text { text },
                 partial: true,
@@ -858,7 +859,7 @@ mod tests {
         }
         let disconnected = log_rx.try_recv().expect("disconnected record");
         assert!(matches!(
-            disconnected.payload,
+            disconnected.event.payload,
             PeerEvent::Disconnected { .. }
         ));
         assert!(log_rx.try_recv().is_err());
@@ -905,7 +906,7 @@ mod tests {
             .await;
         let final_record = log_rx.try_recv().expect("final record");
         assert!(matches!(
-            final_record.payload,
+            final_record.event.payload,
             PeerEvent::Message { partial: false, .. }
         ));
 
@@ -916,7 +917,7 @@ mod tests {
             .await;
         let mut salvaged = Vec::new();
         while let Ok(record) = log_rx.try_recv() {
-            match record.payload {
+            match record.event.payload {
                 PeerEvent::Message {
                     id, partial: true, ..
                 } => salvaged.push(id.0),
@@ -963,7 +964,7 @@ mod tests {
             })
             .await;
         let salvage = log_rx.try_recv().expect("salvage record");
-        match salvage.payload {
+        match salvage.event.payload {
             PeerEvent::Message {
                 content: MessageContent::Text { text },
                 partial: true,
@@ -1016,12 +1017,12 @@ mod tests {
 
         let final_record = log_rx.try_recv().expect("final message record");
         assert!(matches!(
-            final_record.payload,
+            final_record.event.payload,
             PeerEvent::Message { partial: false, .. }
         ));
         let disconnected = log_rx.try_recv().expect("disconnected record");
         assert!(matches!(
-            disconnected.payload,
+            disconnected.event.payload,
             PeerEvent::Disconnected { .. }
         ));
         assert!(

--- a/src/bin/caller/peer/coordinator.rs
+++ b/src/bin/caller/peer/coordinator.rs
@@ -197,8 +197,8 @@ mod tests {
     use super::*;
     use crate::event::EventBus;
     use crate::peer::card::{AgentCard, AuthRequirements, TransportSpec};
-    use crate::peer::event::TaggedPeerEvent;
     use crate::peer::id::PeerKind;
+    use crate::peer::log_writer::EnqueuedPeerEvent;
     use crate::web_gateway::{spawn_web_gateway, ActiveSessionState, WebGatewayConfig};
     use std::time::{Duration, Instant};
     use tokio::sync::{broadcast, mpsc};
@@ -229,7 +229,7 @@ mod tests {
         (port, handle)
     }
 
-    fn make_registry() -> (PeerRegistry, mpsc::Sender<TaggedPeerEvent>) {
+    fn make_registry() -> (PeerRegistry, mpsc::Sender<EnqueuedPeerEvent>) {
         let (log_tx, _log_rx) = mpsc::channel(64);
         let registry = PeerRegistry::new(log_tx.clone());
         (registry, log_tx)

--- a/src/bin/caller/peer/handle.rs
+++ b/src/bin/caller/peer/handle.rs
@@ -25,9 +25,10 @@
 use crate::peer::card::AgentCard;
 use crate::peer::event::{
     ApprovalDecision, MessageId, PeerDisplayInfo, PeerEvent, PeerMessage, PeerStatus, SessionInfo,
-    TaggedPeerEvent, TaskId, TaskUpdate, WebRtcSessionId, WebRtcSignal,
+    TaskId, TaskUpdate, WebRtcSessionId, WebRtcSignal,
 };
 use crate::peer::id::PeerId;
+use crate::peer::log_writer::EnqueuedPeerEvent;
 use crate::peer::traits::{PeerOp, PeerOpAck, PeerTask, PeerTransport, TransportFeatures};
 use crate::peer::transport::intendant::TransportCredentials;
 use crate::peer::PeerError;
@@ -389,7 +390,8 @@ impl PeerHandle {
     }
 
     /// Subscribe to the peer's event stream. Fan-out is lossy for
-    /// lagging subscribers — [`TaggedPeerEvent`]s land on the session
+    /// lagging subscribers —
+    /// [`TaggedPeerEvent`](crate::peer::event::TaggedPeerEvent)s land on the session
     /// log via the registry's durable sink, so missed broadcast
     /// events are recoverable from the log (which is the authoritative
     /// record for replay).
@@ -901,7 +903,7 @@ pub fn spawn_peer<F>(
     browser_tcp_via_url: Option<String>,
     label_override: Option<String>,
     credentials: TransportCredentials,
-    log_sink: mpsc::Sender<TaggedPeerEvent>,
+    log_sink: mpsc::Sender<EnqueuedPeerEvent>,
     build_transport: F,
 ) -> PeerHandle
 where
@@ -1016,7 +1018,7 @@ mod tests {
         drop(probe);
 
         let ws_url = format!("ws://127.0.0.1:{port}/ws");
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let initial_card = AgentCard {
             id: PeerId::new(PeerKind::Intendant, "unreachable"),
             label: "unreachable".into(),
@@ -1126,7 +1128,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(150)).await;
 
         let ws_url = format!("ws://127.0.0.1:{port}/ws");
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let initial_card = AgentCard {
             id: PeerId::new(PeerKind::Intendant, "sess-peer"),
             label: "sess-peer".into(),
@@ -1265,7 +1267,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(150)).await;
 
         let ws_url = format!("ws://127.0.0.1:{port}/ws");
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let initial_card = AgentCard {
             id: PeerId::new(PeerKind::Intendant, "display-peer"),
             label: "display-peer".into(),
@@ -1376,7 +1378,7 @@ mod tests {
         drop(probe);
         let ws_url = format!("ws://127.0.0.1:{port}/ws");
 
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let initial_card = AgentCard {
             id: PeerId::new(PeerKind::Intendant, "bp-test"),
             label: "bp-test".into(),
@@ -1436,7 +1438,7 @@ mod tests {
         drop(probe);
         let ws_url = format!("ws://127.0.0.1:{port}/ws");
 
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let initial_card = AgentCard {
             id: PeerId::new(PeerKind::Intendant, "bp-none"),
             label: "bp-none".into(),
@@ -1520,7 +1522,7 @@ mod tests {
     }
 
     fn spawn_handle_for(name: &str, ws_url: &str) -> PeerHandle {
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(256);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(256);
         let card = receipt_test_card(name, ws_url);
         let url = ws_url.to_string();
         spawn_peer(

--- a/src/bin/caller/peer/log_writer.rs
+++ b/src/bin/caller/peer/log_writer.rs
@@ -33,13 +33,45 @@
 //! saturated `log_sink.send().await`, at which point those
 //! actors observe `NotConnected`-style backpressure and continue
 //! running (they don't hard-depend on the log for correctness).
+//!
+//! ## Stall forensics
+//!
+//! Each channel item carries its enqueue instant ([`EnqueuedPeerEvent`]);
+//! the writer measures enqueue→consume and consume→durable per event and
+//! emits one rate-limited `[peer-log-writer] SLOW …` stderr line when
+//! either stage exceeds the shared writer-lane threshold
+//! ([`crate::event::warn_writer_lane_slow`]). Silent on the happy path.
 
 use crate::peer::event::TaggedPeerEvent;
 use std::path::PathBuf;
+use std::time::Instant;
 use tokio::fs::OpenOptions;
 use tokio::io::{AsyncWriteExt, BufWriter};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
+
+/// A [`TaggedPeerEvent`] paired with the instant it was handed to the
+/// writer channel. Only the inner event is serialized to the log; the
+/// instant exists so the writer can attribute a stall to the lane
+/// (enqueue→consume) vs the write path (consume→durable).
+#[derive(Debug)]
+pub struct EnqueuedPeerEvent {
+    pub event: TaggedPeerEvent,
+    pub enqueued_at: Instant,
+}
+
+impl From<TaggedPeerEvent> for EnqueuedPeerEvent {
+    /// Stamp the enqueue instant at conversion — producers convert at the
+    /// `send` call site, so a bounded-channel backpressure wait counts
+    /// toward enqueue→consume (to the producer, that wait IS enqueue
+    /// latency).
+    fn from(event: TaggedPeerEvent) -> Self {
+        Self {
+            event,
+            enqueued_at: Instant::now(),
+        }
+    }
+}
 
 /// Bounded capacity for the writer's input channel. Same sizing
 /// philosophy as `peer::handle::EVENTS_CAPACITY`: generous enough
@@ -68,8 +100,10 @@ pub const LOG_ROTATE_BYTES: u64 = 64 * 1024 * 1024;
 ///
 /// Dropping the `Sender` (and all its clones held inside peer
 /// actors) causes the writer task to drain the channel and exit.
-pub fn spawn_peer_log_writer(log_path: PathBuf) -> (mpsc::Sender<TaggedPeerEvent>, JoinHandle<()>) {
-    let (tx, rx) = mpsc::channel::<TaggedPeerEvent>(LOG_CHANNEL_CAPACITY);
+pub fn spawn_peer_log_writer(
+    log_path: PathBuf,
+) -> (mpsc::Sender<EnqueuedPeerEvent>, JoinHandle<()>) {
+    let (tx, rx) = mpsc::channel::<EnqueuedPeerEvent>(LOG_CHANNEL_CAPACITY);
     let handle = tokio::spawn(run_writer(log_path, rx, LOG_ROTATE_BYTES));
     (tx, handle)
 }
@@ -96,7 +130,11 @@ async fn open_log(log_path: &PathBuf) -> Option<(BufWriter<tokio::fs::File>, u64
     Some((BufWriter::new(file), len))
 }
 
-async fn run_writer(log_path: PathBuf, mut rx: mpsc::Receiver<TaggedPeerEvent>, rotate_bytes: u64) {
+async fn run_writer(
+    log_path: PathBuf,
+    mut rx: mpsc::Receiver<EnqueuedPeerEvent>,
+    rotate_bytes: u64,
+) {
     // Ensure the parent directory exists before the append open.
     // Failing to create it is the same failure class as failing to
     // open the file, so we report and exit.
@@ -113,8 +151,10 @@ async fn run_writer(log_path: PathBuf, mut rx: mpsc::Receiver<TaggedPeerEvent>, 
     let Some((mut writer, mut written)) = open_log(&log_path).await else {
         return;
     };
+    let mut last_slow_warn: Option<Instant> = None;
 
-    while let Some(event) = rx.recv().await {
+    while let Some(EnqueuedPeerEvent { event, enqueued_at }) = rx.recv().await {
+        let consumed_at = Instant::now();
         let line = match serde_json::to_string(&event) {
             Ok(s) => s,
             Err(e) => {
@@ -140,6 +180,17 @@ async fn run_writer(log_path: PathBuf, mut rx: mpsc::Receiver<TaggedPeerEvent>, 
             eprintln!("peer log writer: flush failed, shutting down");
             return;
         }
+        // Writer-lane latency forensics: measured right after the flush so
+        // consume→durable covers exactly the append+flush path; rotation
+        // cost below lands in the NEXT item's enqueue→consume, where it
+        // belongs. Stderr only on pathology, rate-limited.
+        crate::event::warn_writer_lane_slow(
+            "peer-log-writer",
+            || crate::event::debug_variant_name(&event.payload),
+            consumed_at.saturating_duration_since(enqueued_at),
+            consumed_at.elapsed(),
+            &mut last_slow_warn,
+        );
         written = written.saturating_add(line.len() as u64 + 1);
 
         // Size-based rotation: shift the full file to `<name>.1`
@@ -205,9 +256,13 @@ mod tests {
         let log_path = dir.path().join("peers.jsonl");
         let (tx, handle) = spawn_peer_log_writer(log_path.clone());
 
-        tx.send(make_event(1, PeerStatus::Idle)).await.unwrap();
-        tx.send(make_event(2, PeerStatus::Working)).await.unwrap();
-        tx.send(make_event(3, PeerStatus::NeedsApproval))
+        tx.send(make_event(1, PeerStatus::Idle).into())
+            .await
+            .unwrap();
+        tx.send(make_event(2, PeerStatus::Working).into())
+            .await
+            .unwrap();
+        tx.send(make_event(3, PeerStatus::NeedsApproval).into())
             .await
             .unwrap();
 
@@ -237,7 +292,9 @@ mod tests {
         let log_path = dir.path().join("peers.jsonl");
         let (tx, _handle) = spawn_peer_log_writer(log_path.clone());
 
-        tx.send(make_event(1, PeerStatus::Idle)).await.unwrap();
+        tx.send(make_event(1, PeerStatus::Idle).into())
+            .await
+            .unwrap();
 
         // Open the log and read a line without waiting for the
         // writer task to finish. If flushes are deferred, the
@@ -271,7 +328,9 @@ mod tests {
         assert!(!log_path.parent().unwrap().exists());
 
         let (tx, _handle) = spawn_peer_log_writer(log_path.clone());
-        tx.send(make_event(1, PeerStatus::Idle)).await.unwrap();
+        tx.send(make_event(1, PeerStatus::Idle).into())
+            .await
+            .unwrap();
 
         // Wait for the write to land.
         timeout(Duration::from_secs(2), async {
@@ -299,7 +358,9 @@ mod tests {
             .unwrap();
 
         let (tx, handle) = spawn_peer_log_writer(log_path.clone());
-        tx.send(make_event(1, PeerStatus::Idle)).await.unwrap();
+        tx.send(make_event(1, PeerStatus::Idle).into())
+            .await
+            .unwrap();
         drop(tx);
         timeout(Duration::from_secs(2), handle)
             .await
@@ -324,10 +385,14 @@ mod tests {
         let (tx1, handle) = spawn_peer_log_writer(log_path.clone());
         let tx2 = tx1.clone();
 
-        tx1.send(make_event(1, PeerStatus::Idle)).await.unwrap();
+        tx1.send(make_event(1, PeerStatus::Idle).into())
+            .await
+            .unwrap();
         drop(tx1);
         // tx2 still alive; writer should still be running.
-        tx2.send(make_event(2, PeerStatus::Working)).await.unwrap();
+        tx2.send(make_event(2, PeerStatus::Working).into())
+            .await
+            .unwrap();
         drop(tx2);
         // Now all senders gone, writer should exit.
         timeout(Duration::from_secs(2), handle)
@@ -357,11 +422,13 @@ mod tests {
     async fn rotates_log_at_size_cap() {
         let dir = TempDir::new().unwrap();
         let log_path = dir.path().join("peers.jsonl");
-        let (tx, rx) = mpsc::channel::<TaggedPeerEvent>(LOG_CHANNEL_CAPACITY);
+        let (tx, rx) = mpsc::channel::<EnqueuedPeerEvent>(LOG_CHANNEL_CAPACITY);
         let rotate_bytes: u64 = 1024;
         let handle = tokio::spawn(run_writer(log_path.clone(), rx, rotate_bytes));
         for seq in 1..=40 {
-            tx.send(make_event(seq, PeerStatus::Idle)).await.unwrap();
+            tx.send(make_event(seq, PeerStatus::Idle).into())
+                .await
+                .unwrap();
         }
         drop(tx);
         timeout(Duration::from_secs(5), handle)

--- a/src/bin/caller/peer/mod.rs
+++ b/src/bin/caller/peer/mod.rs
@@ -117,12 +117,14 @@ pub use event::{
 };
 pub use handle::{ConnectionState, PeerHandle, PeerSnapshot};
 pub use id::PeerId;
-// LOG_CHANNEL_CAPACITY has cfg(test) consumers only (the mcp_http and
-// mcp tools_peer rigs) — a plain build's unused-import lint can't see
-// them, so the allow keeps a cleanup pass from stripping it again.
+// LOG_CHANNEL_CAPACITY and EnqueuedPeerEvent have cfg(test) consumers only
+// (the mcp_http / mcp tools_peer / gateway peer rigs build their log sinks
+// by hand; production code inside `peer` names the log_writer path
+// directly) — a plain build's unused-import lint can't see them, so the
+// allow keeps a cleanup pass from stripping them again.
 pub use log_writer::spawn_peer_log_writer;
 #[cfg_attr(not(test), allow(unused_imports))]
-pub use log_writer::LOG_CHANNEL_CAPACITY;
+pub use log_writer::{EnqueuedPeerEvent, LOG_CHANNEL_CAPACITY};
 pub use registry::{PeerRegistry, RegistryEvent};
 pub use traits::PeerTask;
 

--- a/src/bin/caller/peer/registry.rs
+++ b/src/bin/caller/peer/registry.rs
@@ -8,7 +8,7 @@
 //! ## Log sink dependency injection
 //!
 //! The registry receives a pre-constructed
-//! `mpsc::Sender<TaggedPeerEvent>` via its constructor and threads
+//! `mpsc::Sender<EnqueuedPeerEvent>` via its constructor and threads
 //! it through to every peer actor's `spawn_peer` call. The writer
 //! task on the receiver side is the caller's responsibility
 //! (typically `main.rs` when it wires up the gateway) — keeping
@@ -32,9 +32,10 @@
 //! cleanly with `PeerError::CardFetch`.
 
 use crate::peer::card::{AgentCard, TransportSpec};
-use crate::peer::event::{PeerEvent, TaggedPeerEvent};
+use crate::peer::event::PeerEvent;
 use crate::peer::handle::{spawn_peer, PeerHandle, PeerSnapshot};
 use crate::peer::id::PeerId;
+use crate::peer::log_writer::EnqueuedPeerEvent;
 use crate::peer::transport::tls_client::{self, ClientIdentityPaths};
 use crate::peer::transport::IntendantWsTransport;
 use crate::peer::PeerError;
@@ -111,12 +112,12 @@ pub struct PeerRegistry {
 
 struct PeerRegistryInner {
     peers: RwLock<HashMap<PeerId, PeerHandle>>,
-    log_sink: mpsc::Sender<TaggedPeerEvent>,
+    log_sink: mpsc::Sender<EnqueuedPeerEvent>,
     events: broadcast::Sender<RegistryEvent>,
 }
 
 impl PeerRegistry {
-    pub fn new(log_sink: mpsc::Sender<TaggedPeerEvent>) -> Self {
+    pub fn new(log_sink: mpsc::Sender<EnqueuedPeerEvent>) -> Self {
         let (events, _) = broadcast::channel(REGISTRY_BROADCAST_CAPACITY);
         Self {
             inner: Arc::new(PeerRegistryInner {
@@ -589,8 +590,9 @@ fn spawn_state_observer(handle: PeerHandle, events: broadcast::Sender<RegistryEv
 /// chatty peer (e.g. streaming model deltas), the per-peer broadcast's
 /// `Lagged` error is logged at debug and the forwarder skips ahead.
 /// This is intentional — durable per-peer events land on the session
-/// log via the registry's [`TaggedPeerEvent`] log sink, so the dashboard
-/// can drop intermediate frames safely.
+/// log via the registry's
+/// [`TaggedPeerEvent`](crate::peer::event::TaggedPeerEvent) log sink, so
+/// the dashboard can drop intermediate frames safely.
 ///
 /// Exits cleanly when the per-peer actor's broadcast sender drops
 /// (`RecvError::Closed`), same lifetime model as `spawn_state_observer`.
@@ -841,7 +843,7 @@ mod tests {
 
     #[tokio::test]
     async fn new_registry_is_empty() {
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(16);
         let reg = PeerRegistry::new(log_tx);
         assert_eq!(reg.len(), 0);
         assert!(reg.is_empty());
@@ -857,7 +859,7 @@ mod tests {
     #[tokio::test]
     async fn add_peer_fetches_card_and_registers() {
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
 
         let card_url = format!("http://127.0.0.1:{port}/.well-known/agent-card.json");
@@ -878,7 +880,7 @@ mod tests {
     #[tokio::test]
     async fn add_peer_rejects_duplicates() {
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
 
         // Use the pre-fetched card path so both add_peer calls
@@ -906,7 +908,7 @@ mod tests {
     /// time, not silently attach to nothing.
     #[tokio::test]
     async fn add_peer_rejects_card_with_no_supported_transports() {
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(16);
         let reg = PeerRegistry::new(log_tx);
 
         let card = AgentCard {
@@ -935,7 +937,7 @@ mod tests {
     #[tokio::test]
     async fn list_returns_cloneable_handles() {
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
 
         let ws_url = format!("ws://127.0.0.1:{port}/ws");
@@ -956,7 +958,7 @@ mod tests {
     /// `remove_peer` on an unknown id returns NotFound.
     #[tokio::test]
     async fn remove_unknown_peer_errors() {
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(16);
         let reg = PeerRegistry::new(log_tx);
 
         let unknown = PeerId::new(PeerKind::Intendant, "ghost");
@@ -979,7 +981,7 @@ mod tests {
     #[tokio::test]
     async fn add_peer_emits_peer_added_event() {
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
         let mut events = reg.subscribe();
 
@@ -1013,7 +1015,7 @@ mod tests {
     #[tokio::test]
     async fn remove_peer_emits_peer_removed_event() {
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
 
         let ws_url = format!("ws://127.0.0.1:{port}/ws");
@@ -1048,7 +1050,7 @@ mod tests {
     #[tokio::test]
     async fn peer_state_changes_emit_push_events() {
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
         let mut events = reg.subscribe();
 
@@ -1093,7 +1095,7 @@ mod tests {
     #[tokio::test]
     async fn peer_events_are_forwarded() {
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
         let mut events = reg.subscribe();
 
@@ -1144,7 +1146,7 @@ mod tests {
     #[tokio::test]
     async fn event_forwarder_releases_handle_after_remove() {
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
 
         let ws_url = format!("ws://127.0.0.1:{port}/ws");
@@ -1191,7 +1193,7 @@ mod tests {
     #[tokio::test]
     async fn multiple_subscribers_receive_same_events() {
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
         let mut sub_a = reg.subscribe();
         let mut sub_b = reg.subscribe();
@@ -1235,7 +1237,7 @@ mod tests {
     #[tokio::test]
     async fn add_peer_with_via_persists_across_initial_card_refresh() {
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
 
         // Reach the test gateway via localhost, but declare a via URL
@@ -1310,7 +1312,7 @@ mod tests {
     #[tokio::test]
     async fn add_peer_with_via_replaces_card_transports() {
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
 
         let card_url = format!("http://127.0.0.1:{port}/.well-known/agent-card.json");
@@ -1349,7 +1351,7 @@ mod tests {
     #[tokio::test]
     async fn add_peer_with_via_empty_preserves_card_transports() {
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
 
         let card_url = format!("http://127.0.0.1:{port}/.well-known/agent-card.json");
@@ -1384,7 +1386,7 @@ mod tests {
     #[tokio::test]
     async fn add_peer_with_via_multiple_urls_preserve_order() {
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
 
         let card_url = format!("http://127.0.0.1:{port}/.well-known/agent-card.json");
@@ -1424,7 +1426,7 @@ mod tests {
     async fn add_peer_with_credentials_pinned_override_replaces_card_auth() {
         use crate::peer::card::TransportAuth;
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
 
         let card_url = format!("http://127.0.0.1:{port}/.well-known/agent-card.json");
@@ -1465,7 +1467,7 @@ mod tests {
     #[tokio::test]
     async fn add_peer_with_credentials_empty_override_preserves_card_auth() {
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
 
         let card_url = format!("http://127.0.0.1:{port}/.well-known/agent-card.json");
@@ -1495,7 +1497,7 @@ mod tests {
     #[tokio::test]
     async fn add_peer_with_credentials_rejects_malformed_override() {
         let (port, gateway) = spawn_test_peer().await;
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
 
         let card_url = format!("http://127.0.0.1:{port}/.well-known/agent-card.json");
@@ -1576,7 +1578,7 @@ mod tests {
     #[tokio::test]
     async fn add_peer_with_pinned_card_rejects_malformed_fingerprint() {
         use crate::peer::card::{AuthRequirements, TransportAuth};
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
         let mut card = fake_card("bad-pin", "ws://x/ws");
         card.auth = AuthRequirements {
@@ -1609,7 +1611,7 @@ mod tests {
     #[tokio::test]
     async fn add_peer_with_pinned_card_accepts_valid_fingerprint() {
         use crate::peer::card::{AuthRequirements, TransportAuth};
-        let (log_tx, _log_rx) = mpsc::channel::<TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = mpsc::channel::<EnqueuedPeerEvent>(64);
         let reg = PeerRegistry::new(log_tx);
         let mut card = fake_card("good-pin", "ws://x/ws");
         card.auth = AuthRequirements {

--- a/src/bin/caller/web_gateway/mod.rs
+++ b/src/bin/caller/web_gateway/mod.rs
@@ -3600,8 +3600,7 @@ mod tests {
     /// `{"peers":[]}`. Baseline for the list endpoint shape.
     #[tokio::test]
     async fn test_api_peers_list_empty_registry() {
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(16);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         let (port, handle) = spawn_test_gateway_with_registry(Some(registry)).await;
         let resp = http_request(port, "GET /api/peers HTTP/1.1\r\nHost: localhost\r\n\r\n").await;
@@ -3625,8 +3624,7 @@ mod tests {
         let (target_port, target_handle) = spawn_test_gateway_with_registry(None).await;
 
         // Gateway B: the dashboard, with its own peer registry.
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(64);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         let (dash_port, dash_handle) = spawn_test_gateway_with_registry(Some(registry)).await;
 
@@ -3712,8 +3710,7 @@ mod tests {
     /// diagnostic error message.
     #[tokio::test]
     async fn test_api_peers_post_invalid_body() {
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(16);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         let (port, handle) = spawn_test_gateway_with_registry(Some(registry)).await;
 
@@ -3731,8 +3728,7 @@ mod tests {
     /// `DELETE /api/peers` for an unknown peer id returns 404.
     #[tokio::test]
     async fn test_api_peers_delete_unknown_returns_404() {
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(16);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         let (port, handle) = spawn_test_gateway_with_registry(Some(registry)).await;
 
@@ -3790,8 +3786,7 @@ mod tests {
         let (target_port, target_handle) = spawn_test_gateway_with_registry(None).await;
 
         // Gateway B: the dashboard, with its own peer registry.
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(64);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(64);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         let registry_for_wait = registry.clone();
         let (dash_port, dash_handle) = spawn_test_gateway_with_registry(Some(registry)).await;
@@ -3957,8 +3952,7 @@ mod tests {
     /// peer lookup path before any transport interaction.
     #[tokio::test]
     async fn test_api_peers_op_unknown_peer_returns_404() {
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(16);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         let (port, handle) = spawn_test_gateway_with_registry(Some(registry)).await;
 
@@ -3981,8 +3975,7 @@ mod tests {
     /// `POST /api/peers/{id}/message` with malformed JSON returns 400.
     #[tokio::test]
     async fn test_api_peers_send_message_invalid_body_returns_400() {
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(16);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         let (port, handle) = spawn_test_gateway_with_registry(Some(registry)).await;
 
@@ -4002,8 +3995,7 @@ mod tests {
     /// rejects empty bodies before the peer lookup runs.
     #[tokio::test]
     async fn test_api_peers_send_message_requires_text_or_content() {
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(16);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         let (port, handle) = spawn_test_gateway_with_registry(Some(registry)).await;
 
@@ -4028,8 +4020,7 @@ mod tests {
     /// "supported op" from "unrecognized verb".
     #[tokio::test]
     async fn test_api_peers_unknown_op_returns_404() {
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(16);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         let (port, handle) = spawn_test_gateway_with_registry(Some(registry)).await;
 
@@ -4071,8 +4062,7 @@ mod tests {
     /// hint that at least one is required.
     #[tokio::test]
     async fn test_api_peers_eligible_requires_capability_param() {
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(16);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         let (port, handle) = spawn_test_gateway_with_registry(Some(registry)).await;
 
@@ -4096,8 +4086,7 @@ mod tests {
     /// peers).
     #[tokio::test]
     async fn test_api_peers_eligible_rejects_unknown_capability() {
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(16);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         let (port, handle) = spawn_test_gateway_with_registry(Some(registry)).await;
 
@@ -4156,8 +4145,7 @@ mod tests {
     /// Bad JSON body returns 400.
     #[tokio::test]
     async fn test_api_coordinator_route_invalid_body_returns_400() {
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(16);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         let (port, handle) = spawn_test_gateway_with_registry(Some(registry)).await;
 
@@ -4177,8 +4165,7 @@ mod tests {
     /// which is almost never what the caller meant.
     #[tokio::test]
     async fn test_api_coordinator_route_rejects_empty_capabilities() {
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(16);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         let (port, handle) = spawn_test_gateway_with_registry(Some(registry)).await;
 
@@ -4205,8 +4192,7 @@ mod tests {
     /// GET on the route endpoint returns 405 — only POST is allowed.
     #[tokio::test]
     async fn test_api_coordinator_route_get_returns_405() {
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(16);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         let (port, handle) = spawn_test_gateway_with_registry(Some(registry)).await;
 

--- a/src/bin/caller/web_gateway/routes_access.rs
+++ b/src/bin/caller/web_gateway/routes_access.rs
@@ -3718,8 +3718,7 @@ mod tests {
             "capabilities": [],
         });
 
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(16);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(16);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         registry
             .add_peer_with_card(crate::peer::AgentCard {

--- a/src/bin/caller/web_gateway/routes_peers.rs
+++ b/src/bin/caller/web_gateway/routes_peers.rs
@@ -2849,8 +2849,7 @@ mod tests {
     #[tokio::test]
     async fn test_api_peers_pairing_join_rejects_invalid_invite() {
         let root = tempfile::TempDir::new().unwrap();
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(8);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(8);
         let registry = crate::peer::PeerRegistry::new(log_tx);
         let body = serde_json::json!({"invite": "not an intendant invite"}).to_string();
 
@@ -2945,8 +2944,7 @@ mod tests {
     }
 
     fn empty_test_registry() -> crate::peer::PeerRegistry {
-        let (log_tx, _log_rx) =
-            tokio::sync::mpsc::channel::<crate::peer::event::TaggedPeerEvent>(8);
+        let (log_tx, _log_rx) = tokio::sync::mpsc::channel::<crate::peer::EnqueuedPeerEvent>(8);
         crate::peer::PeerRegistry::new(log_tx)
     }
 

--- a/tests/skills/peer-sessions-smoke/peer-rig.py
+++ b/tests/skills/peer-sessions-smoke/peer-rig.py
@@ -16,6 +16,7 @@ Native daemon-lane children emit no per-session usage/limits (the known
   python3 peer-rig.py            # API-only proof (short sleep step)
   python3 peer-rig.py --browser  # + headless-Chrome Station probe
 """
+import glob
 import json
 import os
 import re
@@ -42,11 +43,27 @@ SCRATCH = os.environ.get("PEER_RIG_SCRATCH") or tempfile.mkdtemp(prefix="peer-ri
 CDP_PORT = int(os.environ.get("PEER_RIG_CDP_PORT", "9333"))
 BROWSER = "--browser" in sys.argv
 SLEEP_STEP = 30 if BROWSER else 6
+# Deadline for the child's 'done' fold. Overridable so the timeout path
+# (and its forensics dump below) can be exercised deliberately, e.g.
+# PEER_RIG_DONE_TIMEOUT=1; unset, it is the historical SLEEP_STEP + 60.
+DONE_TIMEOUT = int(os.environ.get("PEER_RIG_DONE_TIMEOUT") or (SLEEP_STEP + 60))
 CHROME = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 CDP = os.path.expanduser("~/projects/smoke-agent-unification/cdp.py")
 
 procs = []
 T0 = time.time()
+
+# Forensics state: a wait timeout used to print ONLY "TIMEOUT", discarding
+# every artifact that could decide worker-stall vs lane-drop vs fold-freeze
+# (observed twice on 2026-07-16: a child folded 'working' in 0.7s, then
+# never folded 'done' within the deadline, and nothing else was captured).
+# spawn_daemon() registers every daemon here; child_of() keeps the newest
+# child fold; dump_forensics() prints it all before the SystemExit.
+DAEMONS = []  # [{"name", "home", "log", "port"}] in spawn order
+OBSERVER = {}  # {"port", "home"} — daemon B, whose /api/peers fold we assert on
+LAST_OBSERVED = {"child": None}  # newest child-session fold seen by child_of()
+DAEMON_LOG_TAIL = 60
+PEERS_JSONL_TAIL = 40
 
 
 def log(msg):
@@ -82,6 +99,58 @@ def ws_action(port, payload):
         time.sleep(0.5)
 
 
+def tail_lines(path, n):
+    try:
+        with open(path, errors="replace") as f:
+            lines = f.readlines()
+    except OSError as e:
+        return [f"<unreadable {path}: {e}>\n"]
+    return lines[-n:] or ["<empty>\n"]
+
+
+def dump_forensics(desc):
+    """Print everything the box still holds when a wait times out.
+
+    Each section is independently best-effort: a dead daemon or missing
+    file prints a marker instead of masking the remaining sections.
+    """
+    print(f"\n========== TIMEOUT FORENSICS: {desc} ==========", flush=True)
+
+    print("---------- (a) last-observed child session fold ----------")
+    child = LAST_OBSERVED["child"]
+    print(json.dumps(child, indent=1) if child is not None
+          else "<no child session ever folded>")
+
+    print("---------- (b) final /api/peers on the observer (incl. connection_state) ----------")
+    if OBSERVER.get("port"):
+        try:
+            peers = http("GET", f"http://127.0.0.1:{OBSERVER['port']}/api/peers")
+            print(json.dumps(peers, indent=1))
+        except Exception as e:  # noqa: BLE001
+            print(f"<GET /api/peers failed: {e}>")
+    else:
+        print("<observer daemon not spawned yet>")
+
+    for d in DAEMONS:
+        print(f"---------- (c) daemon.log tail ({d['name']}, last {DAEMON_LOG_TAIL} lines) ----------")
+        sys.stdout.writelines(tail_lines(d["log"], DAEMON_LOG_TAIL))
+
+    jsonls = []
+    if OBSERVER.get("home"):
+        # The peer log writer appends under the daemon's log dir; glob both
+        # the flat legacy spot and the per-session layout.
+        pattern = os.path.join(OBSERVER["home"], ".intendant", "logs", "**", "peers.jsonl")
+        jsonls = sorted(glob.glob(pattern, recursive=True))
+    if not jsonls:
+        print("---------- (d) observer peers.jsonl ----------")
+        print("<no peers.jsonl found under the observer home>")
+    for path in jsonls:
+        print(f"---------- (d) observer peers.jsonl tail ({path}, last {PEERS_JSONL_TAIL} lines) ----------")
+        sys.stdout.writelines(tail_lines(path, PEERS_JSONL_TAIL))
+
+    print("========== END FORENSICS ==========", flush=True)
+
+
 def wait_for(desc, fn, timeout=45, interval=0.25):
     deadline = time.time() + timeout
     last = None
@@ -93,6 +162,10 @@ def wait_for(desc, fn, timeout=45, interval=0.25):
         except Exception as e:  # noqa: BLE001
             last = e
         time.sleep(interval)
+    try:
+        dump_forensics(desc)
+    except Exception as e:  # noqa: BLE001
+        print(f"<forensics dump itself failed: {e}>", flush=True)
     raise SystemExit(f"TIMEOUT waiting for {desc} (last error: {last})")
 
 
@@ -128,6 +201,7 @@ def spawn_daemon(name, home, script, cwd):
         return int(m.group(1)) if m else None
 
     port = wait_for(f"{name} bound port", parse_port, timeout=30)
+    DAEMONS.append({"name": name, "home": home, "log": log_path, "port": port})
     log(f"daemon {name} pid {p.pid} port {port} home {home}")
     wait_for(f"{name} agent card",
              lambda: http("GET", f"http://127.0.0.1:{port}/.well-known/agent-card.json"))
@@ -186,6 +260,7 @@ try:
     _, a_port = spawn_daemon("A(peer)", os.path.join(SCRATCH, "home-a"), script_a, proj_a)
     _, b_port = spawn_daemon("B(primary)", os.path.join(SCRATCH, "home-b"), script_b,
                              os.path.join(SCRATCH, "proj-b"))
+    OBSERVER.update(port=b_port, home=os.path.join(SCRATCH, "home-b"))
 
     add = http("POST", f"http://127.0.0.1:{b_port}/api/peers",
                {"card_url": f"http://127.0.0.1:{a_port}/.well-known/agent-card.json",
@@ -214,7 +289,10 @@ try:
 
     def child_of(sessions):
         live = [s for s in sessions if not s.get("is_primary")]
-        return live[0] if live else None
+        child = live[0] if live else None
+        if child is not None:
+            LAST_OBSERVED["child"] = child  # retained for dump_forensics
+        return child
 
     child = wait_for("a folded child session on B",
                      lambda: child_of(peer_sessions()), timeout=60)
@@ -273,7 +351,7 @@ try:
 
     done = wait_for("child phase 'done' after completion",
                     lambda: (lambda c: c if c and c.get("phase") == "done" else None)(
-                        child_of(peer_sessions())), timeout=SLEEP_STEP + 60)
+                        child_of(peer_sessions())), timeout=DONE_TIMEOUT)
     check(done.get("phase") == "done", "phase folded to 'done' from TaskComplete")
 
     time.sleep(3)


### PR DESCRIPTION
Additive observability for two still-undecided 2026-07-16 flake classes. Zero behavior change: channel bounds, ordering, flush cadence, error handling, rig exit codes, and normal-path output are all untouched — everything here is silent until the pathology recurs.

## What the next occurrence now reveals

**Stalled durable writers** (a session_note whose /ws broadcast was observed never produced its session-log row for 180s; the peers.jsonl writer shares the architecture). Every item on the session-log sink and the peer log writer channel now carries its enqueue `Instant`; each writer task measures enqueue→consume and consume→durable per item and emits one structured stderr line when either stage exceeds 5s:

    [session-log-writer] SLOW event=SessionNote enqueue_to_consume=182.4s consume_to_durable=0.1s

- large `enqueue_to_consume` ⇒ the item sat in the channel: an unpolled/wedged writer task (or bounded-channel backpressure on the peer lane)
- large `consume_to_durable` ⇒ the write path itself blocked: lock contention or a stuck append/flush syscall

Warnings are rate-limited to one per ~10s per task so a clearing stall cannot storm the log; stderr reaches daemon.log via the existing tees in tests and CI dumps.

**Peer-rig 'done'-fold timeouts** (twice: a delegated child folded 'working' in 0.7s, then never folded 'done' within the deadline — and the rig printed only "TIMEOUT", leaving worker-stall vs lane-drop vs fold-freeze undecidable). Any `wait_for` timeout now dumps, before the same SystemExit: (a) the last-observed child session fold, (b) the observer's full final `/api/peers` including `connection_state`, (c) the last 60 lines of both daemons' daemon.log, (d) the last 40 lines of the observer's peers.jsonl. `PEER_RIG_DONE_TIMEOUT` overrides the 'done' deadline (default unchanged) so the timeout path stays testable.

## Validation

- `cargo fmt --check` / `cargo check` / `cargo clippy -- -D warnings` clean; 3827/3827 unit tests pass (nextest)
- peer-sessions smoke happy path against the instrumented build: RESULT: PASS, exit 0, zero SLOW lines in either daemon.log on an idle box
- forced timeout (`PEER_RIG_DONE_TIMEOUT=1`): all four forensic sections print (child fold showed `phase=working`/`tool-running`, peer `connected`, peers.jsonl tail ending at the in-flight sleep step); exit code and the TIMEOUT line unchanged
