### PR TITLE
relay: SNI-passthrough reachability relay for NAT'd daemons

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -365,7 +365,7 @@ current service also returns `403` for browser offer/ICE/close before mutation.
 | `auth_token` | string | unset | Optional bearer token for daemon-to-service authentication; not dashboard authorization |
 | `poll_timeout_ms` | integer | `15000` | Long-poll timeout per daemon `/next` request |
 | `retry_delay_ms` | integer | `1000` | Delay after transient rendezvous errors |
-| `relay_enabled` | bool | `false` | Hold a reachability-relay control channel to Connect so this daemon's NAT'd fleet name is reachable through the relay's SNI passthrough (docs/src/self-hosted-rendezvous.md). Requires `relay_endpoint` |
+| `relay_enabled` | bool | `false` | Hold a reachability-relay control channel to Connect so this daemon's NAT'd fleet name is reachable through the relay's SNI passthrough (docs/src/self-hosted-rendezvous.md). Dial-backs terminate on a dedicated loopback-only, discovery-only gateway ingress and cannot enter the trusted-local lane. Requires `relay_endpoint` |
 | `relay_endpoint` | string | unset | `host:port` of the relay's raw passthrough port, where this daemon dials back browser connections (e.g. `relay.example.com:443`) |
 
 `INTENDANT_CONNECT_RELAY_ENDPOINT` force-enables the relay tunnel and sets

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -365,6 +365,13 @@ current service also returns `403` for browser offer/ICE/close before mutation.
 | `auth_token` | string | unset | Optional bearer token for daemon-to-service authentication; not dashboard authorization |
 | `poll_timeout_ms` | integer | `15000` | Long-poll timeout per daemon `/next` request |
 | `retry_delay_ms` | integer | `1000` | Delay after transient rendezvous errors |
+| `relay_enabled` | bool | `false` | Hold a reachability-relay control channel to Connect so this daemon's NAT'd fleet name is reachable through the relay's SNI passthrough (docs/src/self-hosted-rendezvous.md). Requires `relay_endpoint` |
+| `relay_endpoint` | string | unset | `host:port` of the relay's raw passthrough port, where this daemon dials back browser connections (e.g. `relay.example.com:443`) |
+
+`INTENDANT_CONNECT_RELAY_ENDPOINT` force-enables the relay tunnel and sets
+`relay_endpoint`. The relay is availability-only: it never terminates TLS,
+holds no certificate, and grants no authority — a relayed browser connection
+reaches this daemon bearing the fleet SNI and stays discovery-only.
 
 No file editing is required for the common case: the dashboard's
 **Access → Intendant Connect** card toggles `enabled` (persisting it
@@ -407,6 +414,17 @@ but ignored. The default Connect binary serves only explicit, compile-time
 embedded routes and assets; it never mounts a filesystem fallback. In
 particular, a supplied directory cannot expose `app.html`, WASM, or
 `vault-kernel.js` from the hosted origin.
+
+The service-side reachability relay is off by default and gated on an
+all-or-nothing flag group (mirroring the `--dns-*` fleet-DNS group):
+
+| Flag / env | Description |
+|-----|-----|
+| `--relay-listen` / `INTENDANT_CONNECT_RELAY_LISTEN` | Raw TCP listen address for the SNI-passthrough relay (e.g. `0.0.0.0:443`). Must receive raw TLS — do not front it with a TLS-terminating proxy |
+| `--relay-address` / `INTENDANT_CONNECT_RELAY_ADDRESS` | Comma-separated public address(es) the relay is reachable at, published in fleet DNS for relay-mode daemons |
+
+Both are required together or neither. See
+docs/src/self-hosted-rendezvous.md for the full deployment description.
 
 `intendant-connect` is intended to sit behind public TLS for the configured
 origin. It handles passkey-only account sessions, single-use account/route linking,

--- a/docs/src/self-hosted-rendezvous.md
+++ b/docs/src/self-hosted-rendezvous.md
@@ -295,16 +295,24 @@ Connect ever terminating TLS or seeing plaintext:
   `/api/dns/publish`). When a browser connects, the relay mints a
   single-use nonce, hands it to the daemon over the control channel, and
   the daemon **dials back** a data connection carrying that nonce. The
-  relay correlates the two and splices them 1:1.
+  relay correlates the two and splices them 1:1. On the daemon side the
+  tunnel opens a second connection to a dedicated, ephemeral,
+  loopback-only gateway ingress instead of the public gateway listener.
 - The browser's TLS handshake therefore completes end-to-end against the
   **daemon's own fleet certificate**. Connect moves only ciphertext.
 
 The relay is **availability-only**: it terminates no TLS, holds no
-certificate, mints no authority, and logs no plaintext. Routing a fleet
-SNI to a daemon does not change how the daemon classifies that
-connection — it still arrives bearing the fleet SNI, which the gateway
-already treats as discovery-only, so a relayed connection is refused at
-every protected route exactly as a direct one is.
+certificate, mints no authority, and logs no plaintext. The gateway
+records which listener accepted each connection before it parses TLS or
+HTTP. Connections from the relay-only ingress are always
+discovery-only: authority-free routes remain available as anonymous
+`role:none`, while protected HTTP/MCP/signaling routes and every
+WebSocket are refused. The tunnel's loopback last hop therefore cannot
+qualify for trusted-local authority even when the encrypted request
+contains `Host: localhost`; the existing fleet-SNI classification is an
+independent second gate. Non-TLS bytes are dropped before the gateway's
+raw ICE-TCP and cleartext-MCP demultiplexer, so the relay-only listener
+cannot reach either local lane.
 
 Enable it with the all-or-nothing `--relay-*` group (both flags or
 neither; default off, mirroring `--dns-*`):
@@ -333,8 +341,10 @@ Deployment notes:
 
 A daemon opts in through `[connect] relay_enabled` + `relay_endpoint`
 (see the configuration reference). It then holds the control channel,
-dials back browser connections into its own gateway, and publishes
-relay-mode fleet DNS while the tunnel is up.
+dials back browser connections into the gateway's private relay ingress,
+and publishes relay-mode fleet DNS while the tunnel is up. That ingress
+binds only to an ephemeral `127.0.0.1` port, is never advertised, and
+does not share the public listener's trusted-local classification.
 
 ## End-to-end transport validation
 

--- a/docs/src/self-hosted-rendezvous.md
+++ b/docs/src/self-hosted-rendezvous.md
@@ -276,6 +276,66 @@ block, `header_up -X-Forwarded-For` deletions are applied **after**
 idiom deletes the value it just set. Use the set alone — a set already
 replaces anything the client supplied.
 
+### Reachability relay (ciphertext SNI passthrough)
+
+`observed_ip` only helps a client that can open a direct connection. A
+daemon behind NAT with no port forward is unreachable at its fleet name
+except on the LAN. The **reachability relay** closes that gap without
+Connect ever terminating TLS or seeing plaintext:
+
+- A raw TCP listener (`--relay-listen`) peeks each connection's TLS
+  **ClientHello to read the SNI without terminating the handshake**
+  (fragmented ClientHellos are handled; non-TLS bytes are refused). When
+  the SNI names a registered fleet label whose daemon holds an active
+  tunnel, the relay splices the raw bytes to that daemon. Everything else
+  is refused.
+- Each daemon holds a persistent **control channel** to the service
+  (`POST /api/relay/next`, a long-poll authenticated by the daemon
+  identity key with the same signed/freshness discipline as
+  `/api/dns/publish`). When a browser connects, the relay mints a
+  single-use nonce, hands it to the daemon over the control channel, and
+  the daemon **dials back** a data connection carrying that nonce. The
+  relay correlates the two and splices them 1:1.
+- The browser's TLS handshake therefore completes end-to-end against the
+  **daemon's own fleet certificate**. Connect moves only ciphertext.
+
+The relay is **availability-only**: it terminates no TLS, holds no
+certificate, mints no authority, and logs no plaintext. Routing a fleet
+SNI to a daemon does not change how the daemon classifies that
+connection — it still arrives bearing the fleet SNI, which the gateway
+already treats as discovery-only, so a relayed connection is refused at
+every protected route exactly as a direct one is.
+
+Enable it with the all-or-nothing `--relay-*` group (both flags or
+neither; default off, mirroring `--dns-*`):
+
+```bash
+intendant-connect \
+  --relay-listen 0.0.0.0:443 \      # raw passthrough port (browsers + dial-backs)
+  --relay-address 203.0.113.10      # public address published in fleet DNS
+```
+
+Equivalently `INTENDANT_CONNECT_RELAY_LISTEN` / `INTENDANT_CONNECT_RELAY_ADDRESS`.
+
+Deployment notes:
+
+- **The relay must receive raw TLS.** Do not place `--relay-listen`
+  behind a TLS-terminating reverse proxy — that would break the
+  passthrough. Expose the port directly, or front it with a TCP
+  (layer-4) passthrough only.
+- The relay and fleet DNS are usually co-deployed: a relay-mode daemon
+  publishes `POST /api/dns/relay` (daemon-signed) so the zone answers its
+  fleet label with `--relay-address` instead of the daemon's own (NAT'd)
+  addresses. The store/serve split is unchanged — `dns.rs` serves the
+  substituted address verbatim.
+- Abuse is bounded by per-source-IP and per-tunnel connection caps, a
+  per-connection byte cap, idle teardown, and a bounded dial-back wait.
+
+A daemon opts in through `[connect] relay_enabled` + `relay_endpoint`
+(see the configuration reference). It then holds the control channel,
+dials back browser connections into its own gateway, and publishes
+relay-mode fleet DNS while the tunnel is up.
+
 ## End-to-end transport validation
 
 `scripts/connect-transport-e2e.cjs` asserts the outcome this whole

--- a/docs/src/trust-architecture.md
+++ b/docs/src/trust-architecture.md
@@ -49,6 +49,17 @@ decrypted vault state made available to it. Item 1 is account authentication
 and route metadata only; a Connect account assertion does not authenticate to
 a daemon, and the default service exposes no browser-control signaling.
 
+The optional **reachability relay** (docs/src/self-hosted-rendezvous.md) sits
+squarely in the transport class (item 3) and does not enlarge Connect's trust.
+It routes a fleet name to a NAT'd daemon by peeking the TLS SNI and splicing
+ciphertext both ways — it terminates no TLS, holds no certificate, and sees no
+plaintext, so the browser's handshake completes end-to-end against the daemon's
+own fleet certificate. Because a relayed connection reaches the daemon bearing
+the same fleet SNI as a direct one, the gateway classifies it as discovery-only
+and refuses every protected route exactly as it does today. The relay is
+availability-only: at worst a compromised or coerced relay withholds or delays
+reachability, which is the denial-of-service Connect can already inflict.
+
 Item 5 is the one the web platform will not let us escape. The browser binds
 code identity to *origin*, origin trust to TLS+DNS, and the server behind an
 origin can change what it serves at any time, per user, silently:

--- a/docs/src/trust-architecture.md
+++ b/docs/src/trust-architecture.md
@@ -54,11 +54,19 @@ squarely in the transport class (item 3) and does not enlarge Connect's trust.
 It routes a fleet name to a NAT'd daemon by peeking the TLS SNI and splicing
 ciphertext both ways — it terminates no TLS, holds no certificate, and sees no
 plaintext, so the browser's handshake completes end-to-end against the daemon's
-own fleet certificate. Because a relayed connection reaches the daemon bearing
-the same fleet SNI as a direct one, the gateway classifies it as discovery-only
-and refuses every protected route exactly as it does today. The relay is
-availability-only: at worst a compromised or coerced relay withholds or delays
-reachability, which is the denial-of-service Connect can already inflict.
+own fleet certificate. The daemon tunnel splices that ciphertext into a
+dedicated loopback-only gateway ingress, separate from the public listener.
+Which listener accepted the connection is immutable transport provenance: the
+gateway marks every such connection `ReachabilityRelay` before TLS or HTTP
+parsing, serves only authority-free discovery bytes under anonymous
+`role:none`, and refuses every protected HTTP, MCP, signaling, and WebSocket
+route. Thus neither the loopback address of the tunnel's last hop nor a
+browser-controlled `Host: localhost` can enter the trusted-local lane. Fleet
+SNI classification remains a second, independent discovery-only gate. The
+relay ingress also rejects non-TLS bytes before the gateway's raw ICE-TCP and
+cleartext-MCP demux. The relay is availability-only: at worst a compromised or
+coerced relay withholds, delays, or sends arbitrary TLS traffic to that
+authority-free ingress, which cannot mint a daemon principal or grant.
 
 Item 5 is the one the web platform will not let us escape. The browser binds
 code identity to *origin*, origin trust to TLS+DNS, and the server behind an

--- a/src/bin/caller/connect_rendezvous.rs
+++ b/src/bin/caller/connect_rendezvous.rs
@@ -1326,6 +1326,13 @@ same resolution + signing discipline as request_unclaim. */
 
 const DNS_PUBLISH_PROTOCOL: &str = "intendant-connect-dns-publish-v1";
 const DNS_ACME_PROTOCOL: &str = "intendant-connect-dns-acme-v1";
+/// Relay-mode DNS publish: "answer my fleet label with the relay's address"
+/// (mirrors `bin/connect/relay.rs`; same signing discipline as the fleet-DNS
+/// publishes).
+pub(crate) const DNS_RELAY_PROTOCOL: &str = "intendant-connect-dns-relay-v1";
+/// Persistent relay control-channel long-poll protocol (mirrors
+/// `bin/connect/relay.rs`).
+pub(crate) const RELAY_CONTROL_PROTOCOL: &str = "intendant-connect-relay-control-v1";
 
 #[cfg(test)] // golden-test twin of the payload `dns_signed_post` builds inline
 fn dns_publish_signing_payload(
@@ -1352,9 +1359,10 @@ fn dns_acme_signing_payload(
 }
 
 /// The signing context every daemon-signed rendezvous call needs (fleet
-/// DNS, attention nudges): effective config, rendezvous URL, identity, and
-/// the effective daemon id.
-fn signed_daemon_context() -> Result<(ConnectConfig, Url, DaemonIdentity, String), String> {
+/// DNS, reachability relay, attention nudges): effective config, rendezvous
+/// URL, identity, and the effective daemon id.
+pub(crate) fn signed_daemon_context() -> Result<(ConnectConfig, Url, DaemonIdentity, String), String>
+{
     let mut config = crate::project::ConnectConfig::default().effective_with_env();
     if config.rendezvous_url.is_none() {
         config.rendezvous_url = status_snapshot().rendezvous_url;
@@ -1462,6 +1470,22 @@ pub(crate) async fn dns_acme_clear() -> Result<(), String> {
         DNS_ACME_PROTOCOL,
         "",
         serde_json::json!({ "clear": true }),
+    )
+    .await
+    .map(|_| ())
+}
+
+/// Relay-mode DNS publish: ask the rendezvous to answer this daemon's fleet
+/// label with the reachability relay's address (`enable = true`) so the name
+/// resolves to the relay, or revert to direct address publishing
+/// (`enable = false`). Best-effort: only meaningful when the rendezvous runs
+/// both fleet DNS and the relay.
+pub(crate) async fn dns_publish_via_relay(enable: bool) -> Result<(), String> {
+    dns_signed_post(
+        "api/dns/relay",
+        DNS_RELAY_PROTOCOL,
+        if enable { "1" } else { "0" },
+        serde_json::json!({ "enable": enable }),
     )
     .await
     .map(|_| ())
@@ -1596,7 +1620,7 @@ async fn post_error_inner(
         .map_err(|e| e.to_string())
 }
 
-fn authenticated(config: &ConnectConfig, builder: RequestBuilder) -> RequestBuilder {
+pub(crate) fn authenticated(config: &ConnectConfig, builder: RequestBuilder) -> RequestBuilder {
     match config
         .auth_token
         .as_deref()

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -65,6 +65,7 @@ mod provider;
 mod provider_mock;
 mod quarantine;
 mod recording;
+mod relay_tunnel;
 mod sandbox;
 mod schema_validator;
 mod service_mode;

--- a/src/bin/caller/project.rs
+++ b/src/bin/caller/project.rs
@@ -708,6 +708,18 @@ pub struct ConnectConfig {
     /// Delay after transient rendezvous errors.
     #[serde(default = "default_connect_retry_delay_ms")]
     pub retry_delay_ms: u64,
+    /// Reachability relay: hold a persistent control channel to Connect so the
+    /// daemon's NAT'd fleet name is reachable through the relay's SNI
+    /// passthrough. Opt-in and requires `relay_endpoint`; the relay never
+    /// terminates TLS or gains authority (docs/src/self-hosted-rendezvous.md).
+    #[serde(default)]
+    pub relay_enabled: bool,
+    /// `host:port` of the relay's raw passthrough port, where this daemon dials
+    /// back browser connections (e.g. `relay.example.com:443`). Learned from
+    /// the register response when the rendezvous advertises one; this override
+    /// pins it explicitly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relay_endpoint: Option<String>,
 }
 
 /// Rendezvous applied when `[connect] enabled = true` names no
@@ -734,6 +746,13 @@ impl ConnectConfig {
             let token = token.trim().to_string();
             if !token.is_empty() {
                 self.auth_token = Some(token);
+            }
+        }
+        if let Ok(endpoint) = std::env::var("INTENDANT_CONNECT_RELAY_ENDPOINT") {
+            let endpoint = endpoint.trim().to_string();
+            if !endpoint.is_empty() {
+                self.relay_enabled = true;
+                self.relay_endpoint = Some(endpoint);
             }
         }
         if self.enabled
@@ -768,6 +787,8 @@ impl Default for ConnectConfig {
             auth_token: None,
             poll_timeout_ms: default_connect_poll_timeout_ms(),
             retry_delay_ms: default_connect_retry_delay_ms(),
+            relay_enabled: false,
+            relay_endpoint: None,
         }
     }
 }

--- a/src/bin/caller/relay_tunnel.rs
+++ b/src/bin/caller/relay_tunnel.rs
@@ -1,0 +1,305 @@
+//! Daemon-side reachability relay tunnel client.
+//!
+//! When the reachability relay is enabled (`[connect] relay_enabled` +
+//! `relay_endpoint`, docs/src/self-hosted-rendezvous.md), the daemon holds a
+//! persistent control channel to Connect so its NAT'd fleet name is reachable
+//! through the relay's SNI passthrough:
+//!
+//!   - Long-poll `POST /api/relay/next` on the Connect HTTP API, authenticated
+//!     by the daemon identity key with the same signed/freshness discipline as
+//!     the fleet-DNS publishes. Each successful poll re-registers the tunnel.
+//!   - On a dial-back request (a single-use nonce), open a raw TCP connection
+//!     to the relay's passthrough port, announce the nonce, connect to this
+//!     daemon's own gateway on loopback, and splice bytes between them. The
+//!     browser's TLS therefore completes end-to-end against this daemon's
+//!     fleet certificate; the relay only ever moves ciphertext.
+//!   - Publish relay-mode fleet DNS so the fleet name resolves to the relay.
+//!
+//! No new authority: a relayed browser connection reaches the gateway bearing
+//! the fleet SNI, which the gateway already classifies as discovery-only. The
+//! relay changes reachability, not trust.
+
+use std::time::Duration;
+
+use reqwest::{Client, Url};
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
+use tokio::net::TcpStream;
+
+use crate::connect_rendezvous::{
+    authenticated, dns_publish_via_relay, join_url, signed_daemon_context, RELAY_CONTROL_PROTOCOL,
+};
+use crate::daemon_identity::DaemonIdentity;
+use crate::project::ConnectConfig;
+
+/// The first line the daemon writes on a dial-back data connection (mirrors
+/// `bin/connect/relay.rs`): this magic and the single-use nonce.
+const DIALBACK_MAGIC: &str = "ITRLY1";
+/// Control long-poll timeout requested of the relay.
+const CONTROL_POLL_TIMEOUT_MS: u64 = 15_000;
+/// Reconnect backoff bounds after control-channel errors.
+const BACKOFF_MIN: Duration = Duration::from_millis(500);
+const BACKOFF_MAX: Duration = Duration::from_secs(30);
+/// How often to re-assert relay-mode fleet DNS while the tunnel runs, so the
+/// fleet name keeps resolving to the relay (the DNS record TTL is short).
+const DNS_REASSERT_INTERVAL: Duration = Duration::from_secs(240);
+/// Idle teardown + per-direction byte cap on a spliced dial-back connection.
+const SPLICE_IDLE: Duration = Duration::from_secs(120);
+const SPLICE_MAX_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Start the relay tunnel client when the config opts in. No-op otherwise.
+/// `gateway_port` is the daemon's own gateway TCP port — where dial-back
+/// connections are spliced so the fleet certificate serves the handshake.
+pub fn spawn_relay_tunnel_client(config: ConnectConfig, gateway_port: Option<u16>) {
+    if !(config.enabled && config.relay_enabled) {
+        return;
+    }
+    let Some(endpoint) = config
+        .relay_endpoint
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+    else {
+        eprintln!("[relay] tunnel enabled but no relay_endpoint is configured");
+        return;
+    };
+    let Some(gateway_port) = gateway_port else {
+        eprintln!("[relay] tunnel enabled but the gateway port is unknown; not starting");
+        return;
+    };
+    tokio::spawn(run_relay_tunnel(endpoint, gateway_port));
+    tokio::spawn(relay_dns_reassert_loop());
+}
+
+/// Best-effort: keep the fleet name pointed at the relay while the tunnel is
+/// up. Only meaningful when the rendezvous runs both fleet DNS and the relay;
+/// failures are expected weather for other configurations and logged quietly.
+async fn relay_dns_reassert_loop() {
+    loop {
+        if let Err(error) = dns_publish_via_relay(true).await {
+            eprintln!("[relay] relay-mode dns publish (best-effort): {error}");
+        }
+        tokio::time::sleep(DNS_REASSERT_INTERVAL).await;
+    }
+}
+
+async fn run_relay_tunnel(relay_endpoint: String, gateway_port: u16) {
+    let client = match Client::builder()
+        .timeout(Duration::from_millis(CONTROL_POLL_TIMEOUT_MS + 10_000))
+        .build()
+    {
+        Ok(client) => client,
+        Err(error) => {
+            eprintln!("[relay] failed to build tunnel HTTP client: {error}");
+            return;
+        }
+    };
+    eprintln!("[relay] tunnel client enabled (dial-back via {relay_endpoint})");
+    let mut backoff = BACKOFF_MIN;
+    loop {
+        // Resolve the signing context fresh each cycle so a rendezvous URL or
+        // identity that only becomes available after boot is picked up.
+        let (config, base_url, identity, daemon_id) = match signed_daemon_context() {
+            Ok(context) => context,
+            Err(error) => {
+                eprintln!("[relay] tunnel context unavailable: {error}");
+                backoff = sleep_backoff(backoff).await;
+                continue;
+            }
+        };
+        match poll_relay_next(&client, &config, &base_url, &identity, &daemon_id).await {
+            Ok(Some(nonce)) => {
+                backoff = BACKOFF_MIN;
+                let endpoint = relay_endpoint.clone();
+                tokio::spawn(async move {
+                    if let Err(error) = handle_dialback(&endpoint, gateway_port, &nonce).await {
+                        eprintln!("[relay] dial-back failed: {error}");
+                    }
+                });
+            }
+            Ok(None) => {
+                backoff = BACKOFF_MIN;
+            }
+            Err(error) => {
+                eprintln!("[relay] control poll failed: {error}");
+                backoff = sleep_backoff(backoff).await;
+            }
+        }
+    }
+}
+
+async fn sleep_backoff(current: Duration) -> Duration {
+    tokio::time::sleep(current).await;
+    (current * 2).min(BACKOFF_MAX)
+}
+
+/// One control-channel long-poll. Returns the dial-back nonce if the relay
+/// asked this daemon to dial back, `None` on an empty poll.
+async fn poll_relay_next(
+    client: &Client,
+    config: &ConnectConfig,
+    base_url: &Url,
+    identity: &DaemonIdentity,
+    daemon_id: &str,
+) -> Result<Option<String>, String> {
+    let daemon_public_key = identity.public_key_b64u();
+    let issued_at_unix_ms = crate::access::client_key::now_unix_ms().max(0) as u64;
+    let payload = format!(
+        "{RELAY_CONTROL_PROTOCOL}\n{daemon_id}\n{daemon_public_key}\n{issued_at_unix_ms}\n"
+    );
+    let signature = identity.sign_b64u(payload.as_bytes());
+    let response = authenticated(config, client.post(join_url(base_url, "api/relay/next")?))
+        .json(&serde_json::json!({
+            "protocol": RELAY_CONTROL_PROTOCOL,
+            "daemon_id": daemon_id,
+            "daemon_public_key": daemon_public_key,
+            "issued_at_unix_ms": issued_at_unix_ms,
+            "signature": signature,
+            "timeout_ms": CONTROL_POLL_TIMEOUT_MS,
+        }))
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if response.status().as_u16() == 204 {
+        return Ok(None);
+    }
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(format!("relay control poll rejected: HTTP {status} {text}"));
+    }
+    let value: serde_json::Value = response.json().await.map_err(|e| e.to_string())?;
+    Ok(value
+        .pointer("/dialback/nonce")
+        .and_then(|v| v.as_str())
+        .map(str::to_string))
+}
+
+/// Dial back a browser connection: connect the relay's passthrough port,
+/// announce the nonce, connect this daemon's own gateway on loopback, and
+/// splice. The browser's ClientHello (fleet SNI and all) flows verbatim to the
+/// gateway, whose fleet certificate completes the handshake.
+async fn handle_dialback(
+    relay_endpoint: &str,
+    gateway_port: u16,
+    nonce: &str,
+) -> Result<(), String> {
+    let mut data = TcpStream::connect(relay_endpoint)
+        .await
+        .map_err(|e| format!("connect relay {relay_endpoint}: {e}"))?;
+    data.write_all(format!("{DIALBACK_MAGIC} {nonce}\n").as_bytes())
+        .await
+        .map_err(|e| format!("write dial-back hello: {e}"))?;
+    let gateway = TcpStream::connect(("127.0.0.1", gateway_port))
+        .await
+        .map_err(|e| format!("connect loopback gateway :{gateway_port}: {e}"))?;
+    splice(data, gateway).await;
+    Ok(())
+}
+
+/// Bidirectional byte splice with a per-direction byte cap and idle teardown.
+async fn splice(relay: TcpStream, gateway: TcpStream) {
+    let (relay_r, relay_w) = relay.into_split();
+    let (gateway_r, gateway_w) = gateway.into_split();
+    let to_gateway = copy_half(relay_r, gateway_w);
+    let to_relay = copy_half(gateway_r, relay_w);
+    tokio::select! {
+        _ = to_gateway => {}
+        _ = to_relay => {}
+    }
+}
+
+async fn copy_half<R, W>(mut reader: R, mut writer: W)
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut buf = vec![0u8; 16 * 1024];
+    let mut total: u64 = 0;
+    loop {
+        let n = match tokio::time::timeout(SPLICE_IDLE, reader.read(&mut buf)).await {
+            Ok(Ok(0)) | Ok(Err(_)) | Err(_) => break,
+            Ok(Ok(n)) => n,
+        };
+        total = total.saturating_add(n as u64);
+        if total > SPLICE_MAX_BYTES {
+            break;
+        }
+        if writer.write_all(&buf[..n]).await.is_err() {
+            break;
+        }
+    }
+    let _ = writer.shutdown().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::net::TcpListener;
+
+    fn relay_disabled() -> ConnectConfig {
+        ConnectConfig {
+            enabled: true,
+            relay_enabled: false,
+            ..ConnectConfig::default()
+        }
+    }
+
+    #[test]
+    fn spawn_is_a_noop_when_relay_is_disabled() {
+        // No panic, no task: disabled config returns immediately. (A running
+        // tokio runtime is not required because we never spawn.)
+        spawn_relay_tunnel_client(relay_disabled(), Some(8765));
+        spawn_relay_tunnel_client(ConnectConfig::default(), Some(8765));
+    }
+
+    /// The dial-back path splices the relay data connection to the loopback
+    /// gateway: bytes written by a fake "browser" at the relay end arrive at
+    /// the "gateway" end and vice versa, after the nonce hello is consumed by
+    /// the relay side.
+    #[tokio::test]
+    async fn dialback_splices_relay_to_loopback_gateway() {
+        // Stand in for the relay's passthrough port: accept one connection,
+        // read the dial-back hello line, then echo-splice remains to a channel.
+        let relay_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let relay_addr = relay_listener.local_addr().unwrap();
+
+        // Stand in for this daemon's gateway: echo server that upper-cases.
+        let gateway_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let gateway_port = gateway_listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            let (mut stream, _) = gateway_listener.accept().await.unwrap();
+            let mut buf = vec![0u8; 64];
+            let n = stream.read(&mut buf).await.unwrap();
+            let upper: Vec<u8> = buf[..n].iter().map(|b| b.to_ascii_uppercase()).collect();
+            stream.write_all(&upper).await.unwrap();
+            let _ = stream.shutdown().await;
+        });
+
+        // Drive the daemon dial-back side.
+        let dial = tokio::spawn(async move {
+            handle_dialback(&relay_addr.to_string(), gateway_port, "the-nonce")
+                .await
+                .unwrap();
+        });
+
+        // The relay end: accept, verify the hello, then act as the browser.
+        let (mut relay_side, _) = relay_listener.accept().await.unwrap();
+        let mut hello = Vec::new();
+        let mut byte = [0u8; 1];
+        loop {
+            relay_side.read_exact(&mut byte).await.unwrap();
+            if byte[0] == b'\n' {
+                break;
+            }
+            hello.push(byte[0]);
+        }
+        assert_eq!(String::from_utf8(hello).unwrap(), "ITRLY1 the-nonce");
+        // "Browser" ciphertext round-trips through the daemon into the gateway.
+        relay_side.write_all(b"hello-daemon").await.unwrap();
+        let mut echoed = Vec::new();
+        relay_side.read_to_end(&mut echoed).await.unwrap();
+        assert_eq!(echoed, b"HELLO-DAEMON");
+        dial.await.unwrap();
+    }
+}

--- a/src/bin/caller/relay_tunnel.rs
+++ b/src/bin/caller/relay_tunnel.rs
@@ -10,16 +10,19 @@
 //!     the fleet-DNS publishes. Each successful poll re-registers the tunnel.
 //!   - On a dial-back request (a single-use nonce), open a raw TCP connection
 //!     to the relay's passthrough port, announce the nonce, connect to this
-//!     daemon's own gateway on loopback, and splice bytes between them. The
-//!     browser's TLS therefore completes end-to-end against this daemon's
-//!     fleet certificate; the relay only ever moves ciphertext.
+//!     daemon's dedicated loopback-only relay ingress, and splice bytes
+//!     between them. The gateway tags connections accepted there as
+//!     reachability-relay provenance before TLS/HTTP parsing, so the local
+//!     dial-back hop cannot inherit trusted-local authority. The browser's TLS
+//!     still completes end-to-end against this daemon's fleet certificate; the
+//!     relay only ever moves ciphertext.
 //!   - Publish relay-mode fleet DNS so the fleet name resolves to the relay.
 //!
-//! No new authority: a relayed browser connection reaches the gateway bearing
-//! the fleet SNI, which the gateway already classifies as discovery-only. The
-//! relay changes reachability, not trust.
+//! No new authority: the dedicated ingress itself is discovery-only, and the
+//! fleet SNI remains an independent second gate. The relay changes
+//! reachability, not trust.
 
-use std::time::Duration;
+use std::{net::SocketAddr, time::Duration};
 
 use reqwest::{Client, Url};
 use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
@@ -47,9 +50,10 @@ const SPLICE_IDLE: Duration = Duration::from_secs(120);
 const SPLICE_MAX_BYTES: u64 = 512 * 1024 * 1024;
 
 /// Start the relay tunnel client when the config opts in. No-op otherwise.
-/// `gateway_port` is the daemon's own gateway TCP port — where dial-back
-/// connections are spliced so the fleet certificate serves the handshake.
-pub fn spawn_relay_tunnel_client(config: ConnectConfig, gateway_port: Option<u16>) {
+/// `gateway_ingress_addr` is the gateway's dedicated loopback-only relay
+/// listener. It serves the fleet-certificate handshake while preserving
+/// immutable relay provenance at the accept edge.
+pub fn spawn_relay_tunnel_client(config: ConnectConfig, gateway_ingress_addr: Option<SocketAddr>) {
     if !(config.enabled && config.relay_enabled) {
         return;
     }
@@ -63,11 +67,11 @@ pub fn spawn_relay_tunnel_client(config: ConnectConfig, gateway_port: Option<u16
         eprintln!("[relay] tunnel enabled but no relay_endpoint is configured");
         return;
     };
-    let Some(gateway_port) = gateway_port else {
-        eprintln!("[relay] tunnel enabled but the gateway port is unknown; not starting");
+    let Some(gateway_ingress_addr) = gateway_ingress_addr else {
+        eprintln!("[relay] tunnel enabled but its dedicated gateway ingress is unavailable");
         return;
     };
-    tokio::spawn(run_relay_tunnel(endpoint, gateway_port));
+    tokio::spawn(run_relay_tunnel(endpoint, gateway_ingress_addr));
     tokio::spawn(relay_dns_reassert_loop());
 }
 
@@ -83,7 +87,7 @@ async fn relay_dns_reassert_loop() {
     }
 }
 
-async fn run_relay_tunnel(relay_endpoint: String, gateway_port: u16) {
+async fn run_relay_tunnel(relay_endpoint: String, gateway_ingress_addr: SocketAddr) {
     let client = match Client::builder()
         .timeout(Duration::from_millis(CONTROL_POLL_TIMEOUT_MS + 10_000))
         .build()
@@ -112,7 +116,9 @@ async fn run_relay_tunnel(relay_endpoint: String, gateway_port: u16) {
                 backoff = BACKOFF_MIN;
                 let endpoint = relay_endpoint.clone();
                 tokio::spawn(async move {
-                    if let Err(error) = handle_dialback(&endpoint, gateway_port, &nonce).await {
+                    if let Err(error) =
+                        handle_dialback(&endpoint, gateway_ingress_addr, &nonce).await
+                    {
                         eprintln!("[relay] dial-back failed: {error}");
                     }
                 });
@@ -176,12 +182,14 @@ async fn poll_relay_next(
 }
 
 /// Dial back a browser connection: connect the relay's passthrough port,
-/// announce the nonce, connect this daemon's own gateway on loopback, and
-/// splice. The browser's ClientHello (fleet SNI and all) flows verbatim to the
-/// gateway, whose fleet certificate completes the handshake.
+/// announce the nonce, connect the daemon's dedicated loopback relay ingress,
+/// and splice. The browser's ClientHello (fleet SNI and all) flows verbatim to
+/// the gateway, whose fleet certificate completes the handshake. The
+/// dedicated accept edge, not any mutable byte in that ClientHello, records
+/// that the connection came through the relay.
 async fn handle_dialback(
     relay_endpoint: &str,
-    gateway_port: u16,
+    gateway_ingress_addr: SocketAddr,
     nonce: &str,
 ) -> Result<(), String> {
     let mut data = TcpStream::connect(relay_endpoint)
@@ -190,9 +198,9 @@ async fn handle_dialback(
     data.write_all(format!("{DIALBACK_MAGIC} {nonce}\n").as_bytes())
         .await
         .map_err(|e| format!("write dial-back hello: {e}"))?;
-    let gateway = TcpStream::connect(("127.0.0.1", gateway_port))
+    let gateway = TcpStream::connect(gateway_ingress_addr)
         .await
-        .map_err(|e| format!("connect loopback gateway :{gateway_port}: {e}"))?;
+        .map_err(|e| format!("connect dedicated gateway ingress {gateway_ingress_addr}: {e}"))?;
     splice(data, gateway).await;
     Ok(())
 }
@@ -249,14 +257,15 @@ mod tests {
     fn spawn_is_a_noop_when_relay_is_disabled() {
         // No panic, no task: disabled config returns immediately. (A running
         // tokio runtime is not required because we never spawn.)
-        spawn_relay_tunnel_client(relay_disabled(), Some(8765));
-        spawn_relay_tunnel_client(ConnectConfig::default(), Some(8765));
+        let ingress = Some(std::net::SocketAddr::from(([127, 0, 0, 1], 8765)));
+        spawn_relay_tunnel_client(relay_disabled(), ingress);
+        spawn_relay_tunnel_client(ConnectConfig::default(), ingress);
     }
 
-    /// The dial-back path splices the relay data connection to the loopback
-    /// gateway: bytes written by a fake "browser" at the relay end arrive at
-    /// the "gateway" end and vice versa, after the nonce hello is consumed by
-    /// the relay side.
+    /// The dial-back path splices the relay data connection to the dedicated
+    /// loopback gateway ingress: bytes written by a fake "browser" at the
+    /// relay end arrive at the "gateway" end and vice versa, after the nonce
+    /// hello is consumed by the relay side.
     #[tokio::test]
     async fn dialback_splices_relay_to_loopback_gateway() {
         // Stand in for the relay's passthrough port: accept one connection,
@@ -278,9 +287,13 @@ mod tests {
 
         // Drive the daemon dial-back side.
         let dial = tokio::spawn(async move {
-            handle_dialback(&relay_addr.to_string(), gateway_port, "the-nonce")
-                .await
-                .unwrap();
+            handle_dialback(
+                &relay_addr.to_string(),
+                std::net::SocketAddr::from(([127, 0, 0, 1], gateway_port)),
+                "the-nonce",
+            )
+            .await
+            .unwrap();
         });
 
         // The relay end: accept, verify the hello, then act as the browser.

--- a/src/bin/caller/web_gateway/access_gates.rs
+++ b/src/bin/caller/web_gateway/access_gates.rs
@@ -185,24 +185,33 @@ pub(crate) fn is_connect_dashboard_signaling_path(path: &str) -> bool {
 /// needs a verified client identity.
 /// TLS encryption, a bearer copied from the daemon page, and an
 /// `intendant://` Origin are transport/CSRF properties, not an IAM anchor.
-/// The local/debug exception requires all three facts the daemon can verify:
-/// a loopback socket peer, a loopback Host authority, and no reverse-proxy
-/// provenance headers. A proxy cannot inherit root merely because its upstream
-/// hop terminates on loopback.
+/// The local/debug exception requires all four facts the daemon can verify:
+/// the public gateway listener accepted the connection directly, its socket
+/// peer is loopback, its Host authority is loopback, and it carries no
+/// reverse-proxy provenance headers. A proxy or reachability-relay dial-back
+/// cannot inherit root merely because its last hop terminates on loopback.
 pub(crate) fn remote_dashboard_client_auth_missing(
+    gateway_ingress: GatewayIngress,
     peer_addr: std::net::SocketAddr,
     header_text: &str,
     tls_client_cert_fingerprint: Option<&str>,
     peer_identity: Option<&PeerConnectionIdentity>,
 ) -> bool {
-    !direct_loopback_dashboard_request(peer_addr, header_text)
+    !direct_loopback_dashboard_request(gateway_ingress, peer_addr, header_text)
         && tls_client_cert_fingerprint
             .map(str::trim)
             .is_none_or(str::is_empty)
         && peer_identity.is_none()
 }
 
-fn direct_loopback_dashboard_request(peer_addr: std::net::SocketAddr, header_text: &str) -> bool {
+fn direct_loopback_dashboard_request(
+    gateway_ingress: GatewayIngress,
+    peer_addr: std::net::SocketAddr,
+    header_text: &str,
+) -> bool {
+    if gateway_ingress != GatewayIngress::Direct {
+        return false;
+    }
     // A dual-stack wildcard listener reports a 127.0.0.1 client as
     // ::ffff:127.0.0.1 on several platforms. Canonicalize before the
     // loopback check so the trusted-local lane matches the actual network
@@ -699,18 +708,31 @@ mod tests {
         let remote = "192.0.2.44:4444".parse().unwrap();
         let local_headers = "GET /config HTTP/1.1\r\nHost: localhost:8765\r\n\r\n";
         assert!(!remote_dashboard_client_auth_missing(
+            GatewayIngress::Direct,
             loopback,
             local_headers,
             None,
             None
         ));
+        assert!(
+            remote_dashboard_client_auth_missing(
+                GatewayIngress::ReachabilityRelay,
+                loopback,
+                local_headers,
+                None,
+                None,
+            ),
+            "a relay dial-back's loopback last hop must never synthesize trusted-local authority"
+        );
         assert!(remote_dashboard_client_auth_missing(
+            GatewayIngress::Direct,
             remote,
             local_headers,
             None,
             None
         ));
         assert!(!remote_dashboard_client_auth_missing(
+            GatewayIngress::Direct,
             remote,
             "GET /config HTTP/1.1\r\nHost: daemon.example\r\n\r\n",
             Some("aa11"),
@@ -725,6 +747,7 @@ mod tests {
             record: None,
         };
         assert!(!remote_dashboard_client_auth_missing(
+            GatewayIngress::Direct,
             remote,
             "GET /config HTTP/1.1\r\nHost: daemon.example\r\n\r\n",
             None,
@@ -743,24 +766,36 @@ mod tests {
             "GET /config HTTP/1.1\r\n\r\n",
         ] {
             assert!(
-                remote_dashboard_client_auth_missing(loopback, headers, None, None),
+                remote_dashboard_client_auth_missing(
+                    GatewayIngress::Direct,
+                    loopback,
+                    headers,
+                    None,
+                    None,
+                ),
                 "loopback upstream must not synthesize root for {headers:?}"
             );
         }
         for host in ["127.0.0.1:8765", "[::1]:8765", "LOCALHOST:8765"] {
             let headers = format!("GET /config HTTP/1.1\r\nHost: {host}\r\n\r\n");
             assert!(!remote_dashboard_client_auth_missing(
-                loopback, &headers, None, None
+                GatewayIngress::Direct,
+                loopback,
+                &headers,
+                None,
+                None
             ));
         }
         let mapped_loopback = "[::ffff:127.0.0.1]:4444".parse().unwrap();
         assert!(!remote_dashboard_client_auth_missing(
+            GatewayIngress::Direct,
             mapped_loopback,
             "GET /config HTTP/1.1\r\nHost: 127.0.0.1:8765\r\n\r\n",
             None,
             None,
         ));
         assert!(!remote_dashboard_client_auth_missing(
+            GatewayIngress::Direct,
             mapped_loopback,
             "GET /config HTTP/1.1\r\nHost: [::ffff:127.0.0.1]:8765\r\n\r\n",
             None,

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -79,6 +79,7 @@ pub(crate) async fn serve_http_request(
     tls_client_cert_present: bool,
     tls_client_cert_fingerprint: Option<String>,
     peer_connection_identity: Option<PeerConnectionIdentity>,
+    gateway_ingress: GatewayIngress,
 ) {
     let HttpRequestCtx {
         access_cert_dir,
@@ -300,8 +301,10 @@ pub(crate) async fn serve_http_request(
     // IAM, loopback, browser-mTLS, process-token `/mcp`, or signaling context
     // is resolved. SNI provenance comes from rustls certificate selection,
     // never this request's mutable Host header.
-    let fleet_origin = tls_fleet_origin || request_names_known_fleet_origin(header_text);
-    if fleet_origin && !authority_free_request {
+    let discovery_only_ingress = gateway_ingress.is_reachability_relay()
+        || tls_fleet_origin
+        || request_names_known_fleet_origin(header_text);
+    if discovery_only_ingress && !authority_free_request {
         use tokio::io::AsyncWriteExt;
         let body = serde_json::json!({
             "error": "the public fleet-name endpoint is discovery-only; use loopback or the independently fingerprint-verified direct mTLS address for control"
@@ -372,6 +375,7 @@ pub(crate) async fn serve_http_request(
     }
 
     let remote_client_auth_missing = remote_dashboard_client_auth_missing(
+        gateway_ingress,
         peer_addr,
         header_text,
         tls_client_cert_fingerprint.as_deref(),
@@ -1435,6 +1439,7 @@ pub(crate) async fn serve_http_request(
     } else if req_method == "POST" && req_path == "/connect/dashboard/offer" {
         use tokio::io::AsyncWriteExt;
         if remote_dashboard_client_auth_missing(
+            gateway_ingress,
             peer_addr,
             header_text,
             tls_client_cert_fingerprint.as_deref(),
@@ -1494,6 +1499,7 @@ pub(crate) async fn serve_http_request(
     } else if req_method == "POST" && req_path == "/connect/dashboard/ice" {
         use tokio::io::AsyncWriteExt;
         if remote_dashboard_client_auth_missing(
+            gateway_ingress,
             peer_addr,
             header_text,
             tls_client_cert_fingerprint.as_deref(),
@@ -1553,6 +1559,7 @@ pub(crate) async fn serve_http_request(
     } else if req_method == "POST" && req_path == "/connect/dashboard/close" {
         use tokio::io::AsyncWriteExt;
         if remote_dashboard_client_auth_missing(
+            gateway_ingress,
             peer_addr,
             header_text,
             tls_client_cert_fingerprint.as_deref(),

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -869,6 +869,14 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
         dashboard_control.clone(),
         tcp_advertised_port,
     );
+    // Reachability relay tunnel: hold a control channel to Connect and splice
+    // relayed browser connections into this gateway (fleet cert serves the
+    // handshake). Opt-in; a no-op unless `[connect] relay_enabled`. The
+    // dial-back target is this gateway's own HTTP port on loopback.
+    crate::relay_tunnel::spawn_relay_tunnel_client(
+        config.connect.clone(),
+        (http_port != 0).then_some(http_port),
+    );
     // Pending-request attention nudges: watch approvals/questions on the bus
     // and ping the Connect rendezvous when they age with no dashboard around.
     crate::attention_nudge::spawn_attention_nudge_monitor(bus.clone());

--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -10,6 +10,67 @@ use super::*;
 
 pub(crate) const TLS_FAILURE_LOG_INTERVAL_SECS: u64 = 30;
 
+/// Transport edge that accepted a gateway connection.
+///
+/// A loopback socket address is only proof of local presence on the public
+/// gateway listener. Reachability-relay dial-backs arrive on a separate
+/// loopback-only listener and are explicitly marked here so their last local
+/// hop can never synthesize the trusted-local dashboard principal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GatewayIngress {
+    Direct,
+    ReachabilityRelay,
+}
+
+impl GatewayIngress {
+    pub(crate) fn is_reachability_relay(self) -> bool {
+        matches!(self, Self::ReachabilityRelay)
+    }
+}
+
+async fn accept_gateway_connection(
+    listener: &TcpListener,
+    relay_ingress_listener: Option<&TcpListener>,
+) -> (
+    GatewayIngress,
+    std::io::Result<(tokio::net::TcpStream, std::net::SocketAddr)>,
+) {
+    if let Some(relay_ingress_listener) = relay_ingress_listener {
+        tokio::select! {
+            accepted = listener.accept() => (GatewayIngress::Direct, accepted),
+            accepted = relay_ingress_listener.accept() => {
+                (GatewayIngress::ReachabilityRelay, accepted)
+            }
+        }
+    } else {
+        (GatewayIngress::Direct, listener.accept().await)
+    }
+}
+
+fn bind_relay_gateway_ingress(config: &crate::project::ConnectConfig) -> Option<TcpListener> {
+    if !(config.enabled && config.relay_enabled) {
+        return None;
+    }
+    let socket = match tokio::net::TcpSocket::new_v4() {
+        Ok(socket) => socket,
+        Err(error) => {
+            eprintln!("[relay] failed to create dedicated gateway ingress: {error}");
+            return None;
+        }
+    };
+    if let Err(error) = socket.bind(std::net::SocketAddr::from(([127, 0, 0, 1], 0))) {
+        eprintln!("[relay] failed to bind dedicated loopback gateway ingress: {error}");
+        return None;
+    }
+    match socket.listen(128) {
+        Ok(listener) => Some(listener),
+        Err(error) => {
+            eprintln!("[relay] failed to listen on dedicated gateway ingress: {error}");
+            None
+        }
+    }
+}
+
 /// Size cap for the rate-limiter map: entries are keyed by
 /// `kind|peer|detail`, so an internet-exposed port collects one entry per
 /// distinct scanner address for the daemon's lifetime. At the cap, entries
@@ -415,6 +476,48 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
     // STUN length-prefix and HTTP method bytes.
     tls_acceptor: Option<tokio_rustls::TlsAcceptor>,
     access_cert_dir: std::path::PathBuf,
+) -> tokio::task::JoinHandle<()> {
+    let relay_ingress_listener = bind_relay_gateway_ingress(&config.connect);
+    spawn_web_gateway_from_cert_dir_with_relay_listener(
+        listener,
+        bus,
+        broadcast_tx,
+        config,
+        shared_session,
+        transcriber,
+        task_tx,
+        project_root,
+        mcp_server,
+        peer_registry,
+        advertise_urls,
+        inbound_bearer_token,
+        local_card_auth,
+        tls_client_cert_required,
+        tls_acceptor,
+        access_cert_dir,
+        relay_ingress_listener,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_web_gateway_from_cert_dir_with_relay_listener(
+    listener: TcpListener,
+    bus: EventBus,
+    broadcast_tx: broadcast::Sender<String>,
+    config: WebGatewayConfig,
+    shared_session: SharedActiveSession,
+    transcriber: Option<Arc<dyn crate::transcription::Transcriber>>,
+    task_tx: Option<tokio::sync::mpsc::Sender<presence_core::TaskEnvelope>>,
+    project_root: Option<std::path::PathBuf>,
+    mcp_server: Option<Arc<crate::mcp::IntendantServer>>,
+    peer_registry: Option<crate::peer::PeerRegistry>,
+    advertise_urls: Vec<String>,
+    inbound_bearer_token: Option<String>,
+    local_card_auth: crate::peer::AuthRequirements,
+    tls_client_cert_required: bool,
+    tls_acceptor: Option<tokio_rustls::TlsAcceptor>,
+    access_cert_dir: std::path::PathBuf,
+    relay_ingress_listener: Option<TcpListener>,
 ) -> tokio::task::JoinHandle<()> {
     let config_json = serde_json::to_string(&config).unwrap_or_else(|_| "{}".to_string());
     let peer_access_request_config = config.peer_access_requests.clone();
@@ -870,13 +973,15 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
         tcp_advertised_port,
     );
     // Reachability relay tunnel: hold a control channel to Connect and splice
-    // relayed browser connections into this gateway (fleet cert serves the
-    // handshake). Opt-in; a no-op unless `[connect] relay_enabled`. The
-    // dial-back target is this gateway's own HTTP port on loopback.
-    crate::relay_tunnel::spawn_relay_tunnel_client(
-        config.connect.clone(),
-        (http_port != 0).then_some(http_port),
-    );
+    // relayed browser connections into the dedicated loopback-only ingress
+    // (the fleet cert still serves the end-to-end handshake). Accepting that
+    // last hop on its own listener gives the gateway immutable relay
+    // provenance before TLS or HTTP parsing; its loopback peer address can
+    // therefore never synthesize trusted-local authority.
+    let relay_ingress_addr = relay_ingress_listener
+        .as_ref()
+        .and_then(|listener| listener.local_addr().ok());
+    crate::relay_tunnel::spawn_relay_tunnel_client(config.connect.clone(), relay_ingress_addr);
     // Pending-request attention nudges: watch approvals/questions on the bus
     // and ping the Connect rendezvous when they age with no dashboard around.
     crate::attention_nudge::spawn_attention_nudge_monitor(bus.clone());
@@ -1087,6 +1192,7 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
         }
 
         let mut listener = listener;
+        let mut relay_ingress_listener = relay_ingress_listener;
         let bind_addr = listener.local_addr().ok();
         let port = bind_addr.map(|a| a.port()).unwrap_or(0);
 
@@ -1095,13 +1201,45 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
         }
 
         let mut fatal_accept_streak: u32 = 0;
+        let mut relay_fatal_accept_streak: u32 = 0;
         loop {
-            let (stream, peer_addr) = match listener.accept().await {
-                Ok(conn) => {
+            let (gateway_ingress, accepted) =
+                accept_gateway_connection(&listener, relay_ingress_listener.as_ref()).await;
+            let (stream, peer_addr) = match (gateway_ingress, accepted) {
+                (GatewayIngress::Direct, Ok(conn)) => {
                     fatal_accept_streak = 0;
                     conn
                 }
-                Err(e) => {
+                (GatewayIngress::ReachabilityRelay, Ok(conn)) => {
+                    relay_fatal_accept_streak = 0;
+                    conn
+                }
+                (GatewayIngress::ReachabilityRelay, Err(error)) => {
+                    if should_continue_after_accept_error(&error) {
+                        eprintln!(
+                            "[relay] dedicated gateway ingress accept failed: {error} (continuing)"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                        continue;
+                    }
+                    relay_fatal_accept_streak += 1;
+                    if relay_fatal_accept_streak < FATAL_ACCEPT_REBIND_THRESHOLD {
+                        eprintln!(
+                            "[relay] dedicated gateway ingress accept failed: {error} \
+                             (retry {relay_fatal_accept_streak}/{FATAL_ACCEPT_REBIND_THRESHOLD} before disabling)"
+                        );
+                        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                        continue;
+                    }
+                    eprintln!(
+                        "[relay] dedicated gateway ingress failed persistently: {error}; \
+                         disabling reachability relay ingress"
+                    );
+                    relay_ingress_listener = None;
+                    relay_fatal_accept_streak = 0;
+                    continue;
+                }
+                (GatewayIngress::Direct, Err(e)) => {
                     if should_continue_after_accept_error(&e) {
                         eprintln!("[web_gateway] accept failed on port {port}: {e} (continuing)");
                         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
@@ -1269,6 +1407,26 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
                     _ => return,
                 };
 
+                // The hosted reachability relay is a TLS-SNI passthrough, not
+                // another entrance to this port's raw ICE-TCP or cleartext MCP
+                // demux lanes. Enforce that at the listener provenance edge,
+                // before interpreting any attacker-controlled bytes. Direct
+                // gateway connections retain the established multiplexing.
+                if gateway_ingress.is_reachability_relay()
+                    && !(tls_acceptor.is_some()
+                        && crate::web_tls::looks_like_tls_client_hello(&buf[..peeked]))
+                {
+                    use tokio::io::AsyncWriteExt;
+                    log_tls_failure_rate_limited(
+                        &tls_failure_log_state,
+                        &source_hint,
+                        "non-TLS reachability-relay ingress reject",
+                        "the relay ingress accepts TLS ClientHello bytes only",
+                    );
+                    let _ = raw_stream.shutdown().await;
+                    return;
+                }
+
                 // ICE-TCP detection: look for a STUN binding request
                 // wrapped in an RFC 4571 2-byte BE length prefix. STUN
                 // binding request type is 0x0001 (first payload byte < 2),
@@ -1362,8 +1520,8 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
                 } else {
                     String::from_utf8_lossy(&buf[..peeked]).to_string()
                 };
-                let allow_loopback_cleartext_mcp =
-                    is_loopback_cleartext_mcp_request(peer_addr, is_tls, &cleartext_header_text);
+                let allow_loopback_cleartext_mcp = gateway_ingress == GatewayIngress::Direct
+                    && is_loopback_cleartext_mcp_request(peer_addr, is_tls, &cleartext_header_text);
 
                 // Strict TLS: when a TLS acceptor is configured the dashboard
                 // is HTTPS/WSS-only. A connection that reaches this point is
@@ -1377,7 +1535,8 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
                 // loopback `/mcp` endpoint used by managed child CLIs: those
                 // clients cannot present the dashboard mTLS certificate, and
                 // their transport never leaves the host. Browser-originated
-                // requests do not qualify for that exception.
+                // requests and reachability-relay ingress do not qualify for
+                // that exception.
                 if tls_acceptor.is_some() && !is_tls && !allow_loopback_cleartext_mcp {
                     use tokio::io::AsyncWriteExt;
                     log_tls_failure_rate_limited(
@@ -1607,6 +1766,7 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
                         tls_client_cert_present,
                         tls_client_cert_fingerprint.clone(),
                         peer_connection_identity,
+                        gateway_ingress,
                     )
                     .await;
 
@@ -1641,7 +1801,10 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
                 // ── WebSocket upgrade path — request 1 or any kept-alive
                 //    follow-up whose head asked to upgrade. ──
                 {
-                    if tls_fleet_origin || request_names_known_fleet_origin(&header_text) {
+                    if gateway_ingress.is_reachability_relay()
+                        || tls_fleet_origin
+                        || request_names_known_fleet_origin(&header_text)
+                    {
                         use tokio::io::AsyncWriteExt;
                         let response = json_error(
                             "403 Forbidden",
@@ -1682,6 +1845,7 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
                         return;
                     }
                     let remote_client_auth_missing = remote_dashboard_client_auth_missing(
+                        gateway_ingress,
                         peer_addr,
                         &header_text,
                         tls_client_cert_fingerprint.as_deref(),
@@ -2729,7 +2893,95 @@ mod tests {
     use crate::test_support::TEST_ENV_LOCK;
     use crate::types::OutboundEvent;
     use crate::web_gateway::tests::{next_ws_json_matching, EnvVarGuard};
-    use tokio::io::AsyncWriteExt;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    struct RelayIngressTestGateway {
+        task: tokio::task::JoinHandle<()>,
+        direct_addr: std::net::SocketAddr,
+        relay_addr: std::net::SocketAddr,
+        server_cert: rustls::pki_types::CertificateDer<'static>,
+        _access_dir: tempfile::TempDir,
+    }
+
+    impl Drop for RelayIngressTestGateway {
+        fn drop(&mut self) {
+            self.task.abort();
+        }
+    }
+
+    async fn spawn_relay_ingress_test_gateway() -> RelayIngressTestGateway {
+        let access_dir = tempfile::tempdir().expect("relay gateway test access store");
+        let identity = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        let cert_path = access_dir.path().join("server.crt");
+        let key_path = access_dir.path().join("server.key");
+        std::fs::write(&cert_path, identity.cert.pem()).unwrap();
+        std::fs::write(&key_path, identity.signing_key.serialize_pem()).unwrap();
+        let acceptor = crate::web_tls::build_acceptor(&crate::web_tls::TlsCertSource::Files {
+            cert_path,
+            key_path,
+        })
+        .unwrap();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let direct_addr = listener.local_addr().unwrap();
+        let relay_ingress_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let relay_addr = relay_ingress_listener.local_addr().unwrap();
+        let bus = EventBus::new();
+        let (broadcast_tx, _) = broadcast::channel::<String>(16);
+        let task = spawn_web_gateway_from_cert_dir_with_relay_listener(
+            listener,
+            bus,
+            broadcast_tx,
+            WebGatewayConfig::default(),
+            ActiveSessionState::empty(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Vec::new(),
+            None,
+            crate::peer::AuthRequirements::none(),
+            false,
+            Some(acceptor),
+            access_dir.path().to_path_buf(),
+            Some(relay_ingress_listener),
+        );
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        RelayIngressTestGateway {
+            task,
+            direct_addr,
+            relay_addr,
+            server_cert: identity.cert.der().clone(),
+            _access_dir: access_dir,
+        }
+    }
+
+    async fn tls_request(
+        addr: std::net::SocketAddr,
+        server_cert: rustls::pki_types::CertificateDer<'static>,
+        request: &str,
+    ) -> String {
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(server_cert).unwrap();
+        let config = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        let connector = tokio_rustls::TlsConnector::from(Arc::new(config));
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let server_name = rustls::pki_types::ServerName::try_from("localhost".to_string()).unwrap();
+        let mut tls = connector.connect(server_name, tcp).await.unwrap();
+        tls.write_all(request.as_bytes()).await.unwrap();
+        let mut response = Vec::new();
+        tokio::time::timeout(
+            tokio::time::Duration::from_secs(10),
+            tls.read_to_end(&mut response),
+        )
+        .await
+        .expect("relay ingress response timed out")
+        .unwrap();
+        String::from_utf8_lossy(&response).into_owned()
+    }
 
     async fn next_ws_json_type<S>(ws_rx: &mut S, ty: &str) -> serde_json::Value
     where
@@ -2767,6 +3019,92 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
         handle.abort();
+    }
+
+    #[tokio::test]
+    async fn relay_config_binds_a_dedicated_loopback_only_ingress() {
+        let config = crate::project::ConnectConfig {
+            enabled: true,
+            relay_enabled: true,
+            ..Default::default()
+        };
+        let listener =
+            bind_relay_gateway_ingress(&config).expect("relay config should bind its ingress");
+        let addr = listener.local_addr().unwrap();
+        assert!(addr.ip().is_loopback());
+        assert_ne!(addr.port(), 0);
+    }
+
+    #[tokio::test]
+    async fn reachability_relay_ingress_is_discovery_only_not_trusted_local() {
+        let gateway = spawn_relay_ingress_test_gateway().await;
+        let direct = tls_request(
+            gateway.direct_addr,
+            gateway.server_cert.clone(),
+            "GET /config HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+        )
+        .await;
+        assert!(
+            direct.starts_with("HTTP/1.1 200"),
+            "genuine direct loopback must retain the trusted-local lane: {direct}"
+        );
+
+        for request in [
+            "GET /config HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+            "POST /mcp HTTP/1.1\r\nHost: localhost\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            "GET /ws HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n",
+        ] {
+            let response = tls_request(
+                gateway.relay_addr,
+                gateway.server_cert.clone(),
+                request,
+            )
+            .await;
+            assert!(
+                response.starts_with("HTTP/1.1 403") && response.contains("discovery-only"),
+                "relay ingress must refuse protected traffic independently of localhost SNI/Host and optional client-auth configuration: {response}"
+            );
+        }
+
+        let public = tls_request(
+            gateway.relay_addr,
+            gateway.server_cert.clone(),
+            "GET /connect/status HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+        )
+        .await;
+        assert!(
+            public.starts_with("HTTP/1.1 200"),
+            "authority-free discovery bytes must remain reachable through the relay: {public}"
+        );
+
+        let mut cleartext = tokio::net::TcpStream::connect(gateway.relay_addr)
+            .await
+            .unwrap();
+        let token = loopback_mcp_auth_token();
+        cleartext
+            .write_all(
+                format!(
+                    "POST /mcp?mcp_token={token} HTTP/1.1\r\n\
+                     Host: localhost\r\n\
+                     Content-Length: 0\r\n\
+                     Connection: close\r\n\r\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+        let mut cleartext_response = Vec::new();
+        let _ = tokio::time::timeout(
+            tokio::time::Duration::from_secs(2),
+            cleartext.read_to_end(&mut cleartext_response),
+        )
+        .await
+        .expect("non-TLS relay ingress must close promptly");
+        assert!(
+            cleartext_response.is_empty(),
+            "relay ingress must not enter the cleartext loopback MCP lane: {}",
+            String::from_utf8_lossy(&cleartext_response)
+        );
     }
 
     #[tokio::test]

--- a/src/bin/connect/fleet.rs
+++ b/src/bin/connect/fleet.rs
@@ -1241,6 +1241,8 @@ mod tests {
             dns_zone: None,
             dns_ns_name: None,
             dns_listen: None,
+            relay_listen: None,
+            relay_addresses: Vec::new(),
         };
 
         let targets = fleet_targets_for_user(&config, &store, user_id);

--- a/src/bin/connect/main.rs
+++ b/src/bin/connect/main.rs
@@ -14,7 +14,7 @@ use serde_json::json;
 use sha2::{Digest as _, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::Write as _;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -36,6 +36,8 @@ mod rendezvous;
 pub(crate) use rendezvous::*;
 mod dns;
 pub(crate) use dns::*;
+mod relay;
+pub(crate) use relay::*;
 
 const PROTOCOL: &str = "intendant-connect-rendezvous-v1";
 const REGISTER_PROOF_PROTOCOL: &str = "intendant-connect-register-proof-v1";
@@ -105,6 +107,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if !had_keys || manifest_logged {
         save_store(&config.data_file, &store).map_err(|e| format!("persist service keys: {e}"))?;
     }
+    // Reachability relay: build its state before the DNS zone so relay-mode
+    // DNS records re-resolve to the CURRENT relay address at hydration rather
+    // than whatever was stored when they were last published.
+    let relay = match &config.relay_listen {
+        Some(listen) if !config.relay_addresses.is_empty() => Some(Arc::new(RelayState::new(
+            *listen,
+            config.relay_addresses.clone(),
+        ))),
+        _ => None,
+    };
+
     // Fleet DNS: build the zone, hydrate persisted records, and bind the
     // sockets BEFORE serving — a misconfigured DNS listener must fail the
     // whole startup loudly, not limp along HTTP-only.
@@ -112,11 +125,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         (Some(zone_name), Some(ns_name), Some(_listen)) => {
             let zone = Arc::new(FleetZone::new(zone_name, ns_name)?);
             for entry in &store.dns_records {
-                let addresses: Vec<std::net::IpAddr> = entry
-                    .addresses
-                    .iter()
-                    .filter_map(|value| value.parse().ok())
-                    .collect();
+                let addresses: Vec<std::net::IpAddr> = if entry.via_relay {
+                    match relay.as_ref() {
+                        Some(relay) => relay.advertise_addrs().to_vec(),
+                        None => {
+                            eprintln!(
+                                "[connect] skipping relay-mode dns record for {}: relay is disabled",
+                                entry.daemon_id
+                            );
+                            continue;
+                        }
+                    }
+                } else {
+                    entry
+                        .addresses
+                        .iter()
+                        .filter_map(|value| value.parse().ok())
+                        .collect()
+                };
                 if let Err(error) = zone.set_daemon_addresses(&entry.daemon_id, &addresses) {
                     eprintln!(
                         "[connect] skipping persisted dns record for {}: {error}",
@@ -151,6 +177,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         log_caches: std::sync::Mutex::new(LogCaches::default()),
         static_pages: StaticPages::render(&config),
         dns_zone,
+        relay,
     });
 
     tokio::spawn(presence_alert_monitor(state.clone()));
@@ -170,6 +197,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 eprintln!("[connect] fleet dns server exited: {error}");
             }
         });
+    }
+
+    if let Some(relay) = state.relay.clone() {
+        // Reachability relay: bind the raw passthrough socket BEFORE serving so
+        // a misconfigured/occupied port fails startup loudly. The accept loop
+        // then runs until process exit like the other background tasks.
+        let listen = relay.listen();
+        let accept_loop = bind_relay(state.clone(), relay).await?;
+        eprintln!(
+            "[connect] reachability relay serving on {listen} (tcp; advertises {})",
+            state
+                .config
+                .relay_addresses
+                .iter()
+                .map(|ip| ip.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        tokio::spawn(accept_loop);
     }
 
     let app = connect_router(state.clone());
@@ -380,6 +426,8 @@ fn connect_router(state: Arc<AppState>) -> Router {
         .route("/api/daemon/notify", post(daemon_notify))
         .route("/api/dns/publish", post(dns_publish))
         .route("/api/dns/acme-challenge", post(dns_acme_challenge))
+        .route("/api/dns/relay", post(dns_relay))
+        .route("/api/relay/next", post(relay_next))
         .route("/api/daemon/dry", post(daemon_dry))
         .route("/api/browser/offer", post(browser_offer))
         .route("/api/browser/ice", post(browser_ice))
@@ -450,6 +498,15 @@ struct ServiceConfig {
     /// UDP+TCP listen address for the DNS server (e.g. `0.0.0.0:53`;
     /// binding :53 unprivileged needs CAP_NET_BIND_SERVICE).
     dns_listen: Option<SocketAddr>,
+    /// Reachability relay (docs/src/self-hosted-rendezvous.md): the raw TCP
+    /// listen address for the SNI-passthrough relay (e.g. `0.0.0.0:443`).
+    /// Both `relay_*` values must be set for the relay to switch on; default
+    /// off, mirroring the `dns_*` group.
+    relay_listen: Option<SocketAddr>,
+    /// Public address(es) this relay is reachable at, published in fleet DNS
+    /// for relay-mode daemons so their names resolve to the relay. Empty when
+    /// the relay is disabled.
+    relay_addresses: Vec<IpAddr>,
 }
 
 impl ServiceConfig {
@@ -502,6 +559,20 @@ impl ServiceConfig {
                 }
                 _ => None,
             };
+        let mut relay_listen: Option<SocketAddr> =
+            match std::env::var("INTENDANT_CONNECT_RELAY_LISTEN") {
+                Ok(value) if !value.trim().is_empty() => {
+                    Some(value.trim().parse().map_err(|e| {
+                        format!("invalid INTENDANT_CONNECT_RELAY_LISTEN {value:?}: {e}")
+                    })?)
+                }
+                _ => None,
+            };
+        let mut relay_addresses: Vec<IpAddr> = match std::env::var("INTENDANT_CONNECT_RELAY_ADDRESS")
+        {
+            Ok(value) if !value.trim().is_empty() => parse_relay_addresses(&value)?,
+            _ => Vec::new(),
+        };
 
         let mut args = std::env::args().skip(1);
         while let Some(arg) = args.next() {
@@ -550,6 +621,18 @@ impl ServiceConfig {
                             .map_err(|e| format!("invalid --dns-listen {value:?}: {e}"))?,
                     );
                 }
+                "--relay-listen" => {
+                    let value = args.next().ok_or("--relay-listen requires an address")?;
+                    relay_listen = Some(
+                        value
+                            .parse()
+                            .map_err(|e| format!("invalid --relay-listen {value:?}: {e}"))?,
+                    );
+                }
+                "--relay-address" => {
+                    let value = args.next().ok_or("--relay-address requires an IP address")?;
+                    relay_addresses = parse_relay_addresses(&value)?;
+                }
                 "--help" | "-h" => {
                     print_help();
                     std::process::exit(0);
@@ -584,6 +667,15 @@ impl ServiceConfig {
                     .to_string(),
             );
         }
+        // The reachability relay is likewise all-or-nothing: a listener with
+        // no advertised address could not point DNS at itself, and an
+        // advertised address with no listener answers nothing.
+        if relay_listen.is_some() != !relay_addresses.is_empty() {
+            return Err(
+                "reachability relay needs both --relay-listen and --relay-address (or none)"
+                    .to_string(),
+            );
+        }
         Ok(Self {
             listen,
             public_origin: trim_trailing_slash(&public_origin),
@@ -597,8 +689,28 @@ impl ServiceConfig {
             dns_zone,
             dns_ns_name,
             dns_listen,
+            relay_listen,
+            relay_addresses,
         })
     }
+}
+
+/// Parse a comma-separated list of relay public IP addresses.
+fn parse_relay_addresses(value: &str) -> Result<Vec<IpAddr>, String> {
+    let mut addresses = Vec::new();
+    for part in value.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let ip: IpAddr = part
+            .parse()
+            .map_err(|e| format!("invalid relay address {part:?}: {e}"))?;
+        if !addresses.contains(&ip) {
+            addresses.push(ip);
+        }
+    }
+    Ok(addresses)
 }
 
 fn print_help() {
@@ -614,7 +726,11 @@ fn print_help() {
               INTENDANT_CONNECT_INVITE_REQUIRED, INTENDANT_CONNECT_OPEN_REGISTRATION,\n\
               INTENDANT_CONNECT_DNS_ZONE, INTENDANT_CONNECT_DNS_NS_NAME, INTENDANT_CONNECT_DNS_LISTEN\n\
               (--dns-zone fleet.example.com --dns-ns-name ns-fleet.example.com --dns-listen 0.0.0.0:53\n\
-               enable the embedded fleet DNS server; all three or none)"
+               enable the embedded fleet DNS server; all three or none),\n\
+              INTENDANT_CONNECT_RELAY_LISTEN, INTENDANT_CONNECT_RELAY_ADDRESS\n\
+              (--relay-listen 0.0.0.0:443 --relay-address 203.0.113.10 enable the SNI-passthrough\n\
+               reachability relay; both or none. The relay must receive raw TLS — do not place it\n\
+               behind a TLS-terminating proxy)"
     );
 }
 
@@ -675,13 +791,33 @@ struct AppState {
     /// live record table the embedded server answers from (hydrated
     /// from `Store::dns_records` at startup).
     dns_zone: Option<Arc<FleetZone>>,
+    /// The reachability relay when the `relay_*` config group is set —
+    /// shared between the raw passthrough listener and the daemon control
+    /// long-poll / DNS relay-mode handlers. None when the relay is disabled.
+    relay: Option<Arc<RelayState>>,
 }
 
 /// Minimal production-shaped state for route-boundary tests. Tests seed the
 /// durable store they need, while sharing the same WebAuthn, signing-key, and
 /// in-memory state construction as the service.
 #[cfg(test)]
-fn production_router_test_state(root: &Path, mut store: Store) -> Arc<AppState> {
+fn production_router_test_state(root: &Path, store: Store) -> Arc<AppState> {
+    build_test_state(root, store, TestStateOverrides::default())
+}
+
+/// Overrides a test can apply to the base production-shaped state.
+#[cfg(test)]
+#[derive(Default)]
+struct TestStateOverrides {
+    /// Enable signed-request daemon endpoints without an operator bearer, as
+    /// the hosted instance runs (`open_daemon_registration = true`).
+    open_daemon_registration: bool,
+    dns_zone: Option<Arc<FleetZone>>,
+    relay: Option<Arc<RelayState>>,
+}
+
+#[cfg(test)]
+fn build_test_state(root: &Path, mut store: Store, overrides: TestStateOverrides) -> Arc<AppState> {
     let config = ServiceConfig {
         listen: "127.0.0.1:0".parse().unwrap(),
         public_origin: "https://connect.example.test".to_string(),
@@ -691,10 +827,16 @@ fn production_router_test_state(root: &Path, mut store: Store) -> Arc<AppState> 
         release_token: None,
         cookie_secure: true,
         invite_required: false,
-        open_daemon_registration: false,
+        open_daemon_registration: overrides.open_daemon_registration,
         dns_zone: None,
         dns_ns_name: None,
         dns_listen: None,
+        relay_listen: overrides.relay.as_ref().map(|relay| relay.listen()),
+        relay_addresses: overrides
+            .relay
+            .as_ref()
+            .map(|relay| relay.advertise_addrs().to_vec())
+            .unwrap_or_default(),
     };
     let webauthn = Webauthn::new(&config.rp_id, "Intendant Connect", &config.public_origin)
         .require_user_verification(true)
@@ -722,7 +864,8 @@ fn production_router_test_state(root: &Path, mut store: Store) -> Arc<AppState> 
         vapid,
         log_key,
         push_http: reqwest::Client::new(),
-        dns_zone: None,
+        dns_zone: overrides.dns_zone,
+        relay: overrides.relay,
     })
 }
 
@@ -741,6 +884,12 @@ struct DnsRecordEntry {
     addresses: Vec<String>,
     #[serde(default)]
     updated_unix_ms: u64,
+    /// Relay-mode record: the stored addresses are the reachability relay's
+    /// public address, published so the fleet name resolves to the relay
+    /// instead of the (NAT'd, unreachable) daemon. On restart these re-resolve
+    /// to the current relay address rather than the addresses stored here.
+    #[serde(default)]
+    via_relay: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/bin/connect/main.rs
+++ b/src/bin/connect/main.rs
@@ -568,11 +568,11 @@ impl ServiceConfig {
                 }
                 _ => None,
             };
-        let mut relay_addresses: Vec<IpAddr> = match std::env::var("INTENDANT_CONNECT_RELAY_ADDRESS")
-        {
-            Ok(value) if !value.trim().is_empty() => parse_relay_addresses(&value)?,
-            _ => Vec::new(),
-        };
+        let mut relay_addresses: Vec<IpAddr> =
+            match std::env::var("INTENDANT_CONNECT_RELAY_ADDRESS") {
+                Ok(value) if !value.trim().is_empty() => parse_relay_addresses(&value)?,
+                _ => Vec::new(),
+            };
 
         let mut args = std::env::args().skip(1);
         while let Some(arg) = args.next() {
@@ -630,7 +630,9 @@ impl ServiceConfig {
                     );
                 }
                 "--relay-address" => {
-                    let value = args.next().ok_or("--relay-address requires an IP address")?;
+                    let value = args
+                        .next()
+                        .ok_or("--relay-address requires an IP address")?;
                     relay_addresses = parse_relay_addresses(&value)?;
                 }
                 "--help" | "-h" => {
@@ -670,7 +672,7 @@ impl ServiceConfig {
         // The reachability relay is likewise all-or-nothing: a listener with
         // no advertised address could not point DNS at itself, and an
         // advertised address with no listener answers nothing.
-        if relay_listen.is_some() != !relay_addresses.is_empty() {
+        if relay_listen.is_some() == relay_addresses.is_empty() {
             return Err(
                 "reachability relay needs both --relay-listen and --relay-address (or none)"
                     .to_string(),

--- a/src/bin/connect/relay.rs
+++ b/src/bin/connect/relay.rs
@@ -1,0 +1,1610 @@
+//! SNI-passthrough reachability relay (docs/src/self-hosted-rendezvous.md).
+//!
+//! A NAT'd daemon is unreachable at its fleet name except on the LAN: fleet
+//! DNS publishes addresses, it does not tunnel. This subsystem adds a lane
+//! that makes the fleet name reachable from anywhere WITHOUT the relay ever
+//! seeing plaintext:
+//!
+//!   - The daemon holds a persistent authenticated control channel to this
+//!     service (`POST /api/relay/next`, daemon-signed with the same freshness
+//!     discipline as the fleet-DNS publishes). Each poll refreshes the
+//!     daemon's tunnel presence, keyed by its derived fleet label.
+//!   - A separate raw TCP listener (`--relay-listen`) receives browser TLS
+//!     connections. It PEEKS the ClientHello to read the SNI **without
+//!     terminating TLS**. When the SNI names a fleet label with an active
+//!     tunnel, the relay mints a single-use nonce, hands it to the daemon over
+//!     the control channel, waits for the daemon to dial back a data
+//!     connection carrying that nonce, and then splices raw bytes both ways.
+//!   - The browser's TLS handshake therefore completes against the DAEMON's
+//!     own fleet certificate; this service moves only ciphertext.
+//!
+//! Trust posture: availability-only. The relay terminates no TLS, holds no
+//! certificate, mints no authority, and never inspects plaintext. Routing a
+//! fleet SNI to a daemon does not change how the daemon classifies that
+//! connection — it still arrives bearing the fleet SNI, which the daemon
+//! gateway treats as discovery-only exactly as it does today. Abuse is bounded
+//! by per-source-IP and per-tunnel connection caps, a per-connection byte cap,
+//! and idle teardown.
+//!
+//! All of this is dark by default and gated behind the `--relay-*` config
+//! group (all-or-nothing, mirroring the `--dns-*` group).
+
+use super::*;
+
+use std::net::IpAddr;
+use std::sync::Mutex as StdMutex;
+use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWrite, AsyncWriteExt as _};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Daemon-signed control-channel protocol tag. The daemon long-polls this
+/// endpoint to receive dial-back requests; the signature proves the poll comes
+/// from the registered identity key, mirroring the fleet-DNS publish auth.
+pub(crate) const RELAY_CONTROL_PROTOCOL: &str = "intendant-connect-relay-control-v1";
+/// Daemon-signed DNS relay-mode protocol tag: "answer my fleet label with the
+/// relay's address instead of my own".
+pub(crate) const DNS_RELAY_PROTOCOL: &str = "intendant-connect-dns-relay-v1";
+
+/// First line a daemon writes on a dial-back data connection: this magic and
+/// the single-use nonce it received on the control channel. Deliberately does
+/// NOT begin with the TLS handshake content type (`0x16`), so the relay's
+/// first-byte demux never confuses a dial-back with a browser ClientHello.
+const DIALBACK_MAGIC: &str = "ITRLY1";
+/// Bytes read while looking for the dial-back hello's terminating newline.
+const DIALBACK_HELLO_MAX_BYTES: usize = 160;
+
+/// Max concurrent relay connections accepted from one source IP (browser
+/// side). Bounds a single abusive client; daemon dial-back connections are
+/// nonce-gated and exempt.
+pub(crate) const RELAY_MAX_CONNS_PER_IP: u32 = 64;
+/// Max concurrent spliced browser connections routed into one daemon tunnel.
+pub(crate) const RELAY_MAX_CONNS_PER_TUNNEL: u32 = 128;
+/// Max unclaimed dial-back nonces queued for one tunnel's control poll.
+pub(crate) const RELAY_MAX_PENDING_PER_TUNNEL: usize = 64;
+/// Idle teardown: a spliced connection with no bytes in either direction for
+/// this long is closed.
+pub(crate) const RELAY_SPLICE_IDLE: Duration = Duration::from_secs(120);
+/// Per-direction byte cap on a single spliced connection. Generous — it bounds
+/// one abusive connection, not a legitimate session — and both directions are
+/// capped independently.
+pub(crate) const RELAY_SPLICE_MAX_BYTES: u64 = 512 * 1024 * 1024;
+/// How long a browser connection waits for the daemon's dial-back before the
+/// relay gives up and closes it.
+pub(crate) const RELAY_DIALBACK_TIMEOUT: Duration = Duration::from_secs(10);
+/// A tunnel counts as active only if its control channel polled within this
+/// window (mirrors the daemon "online" liveness used elsewhere).
+pub(crate) const RELAY_TUNNEL_LIVENESS_MS: u64 = 45_000;
+/// Cap on bytes peeked while waiting for a complete ClientHello, and the wait
+/// budget for it to arrive. A ClientHello far larger than this, or one that
+/// never completes, is refused.
+pub(crate) const RELAY_CLIENT_HELLO_PEEK_CAP: usize = 8192;
+pub(crate) const RELAY_CLIENT_HELLO_TIMEOUT: Duration = Duration::from_secs(10);
+/// Long-poll cap for the control channel — kept below the global request
+/// deadline so a parked poll always ends naturally inside the shutdown drain.
+const RELAY_CONTROL_POLL_CAP_MS: u64 = 15_000;
+
+// ── ClientHello SNI peek parser ─────────────────────────────────────────────
+
+/// Outcome of peeking a (possibly partial) TLS ClientHello for its SNI.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SniPeek {
+    /// A valid TLS ClientHello prefix, but truncated — peek more bytes.
+    NeedMore,
+    /// Not a TLS handshake ClientHello at all — refuse.
+    NotTls,
+    /// A complete ClientHello carrying no SNI host_name — refuse (the relay
+    /// routes solely by SNI).
+    NoSni,
+    /// The SNI host_name.
+    Sni(String),
+}
+
+/// Why a structural read could not complete.
+enum Take {
+    NeedMore,
+    NotTls,
+}
+
+fn read_u8(b: &[u8], pos: &mut usize) -> Result<u8, Take> {
+    let v = *b.get(*pos).ok_or(Take::NeedMore)?;
+    *pos += 1;
+    Ok(v)
+}
+
+fn read_u16(b: &[u8], pos: &mut usize) -> Result<usize, Take> {
+    let hi = read_u8(b, pos)? as usize;
+    let lo = read_u8(b, pos)? as usize;
+    Ok((hi << 8) | lo)
+}
+
+fn skip(b: &[u8], pos: &mut usize, n: usize) -> Result<(), Take> {
+    let end = pos.checked_add(n).ok_or(Take::NotTls)?;
+    if end > b.len() {
+        return Err(Take::NeedMore);
+    }
+    *pos = end;
+    Ok(())
+}
+
+/// Parse a TLS record + ClientHello prefix for its SNI host_name. Panic-free
+/// on ANY input: every read is bounds-checked, so non-TLS garbage refuses
+/// cleanly and a truncated handshake asks for more bytes.
+pub(crate) fn parse_client_hello_sni(buf: &[u8]) -> SniPeek {
+    match parse_sni_inner(buf) {
+        Ok(Some(name)) => SniPeek::Sni(name),
+        Ok(None) => SniPeek::NoSni,
+        Err(Take::NeedMore) => SniPeek::NeedMore,
+        Err(Take::NotTls) => SniPeek::NotTls,
+    }
+}
+
+fn parse_sni_inner(buf: &[u8]) -> Result<Option<String>, Take> {
+    let mut pos = 0;
+    // TLS record header: content_type(1) legacy_version(2) length(2).
+    if read_u8(buf, &mut pos)? != 0x16 {
+        return Err(Take::NotTls); // not a handshake record
+    }
+    if read_u8(buf, &mut pos)? != 0x03 {
+        return Err(Take::NotTls); // TLS legacy record version is 3.x
+    }
+    let _record_minor = read_u8(buf, &mut pos)?;
+    let _record_len = read_u16(buf, &mut pos)?; // bound by the buffer, not this
+    // Handshake header: msg_type(1) length(3).
+    if read_u8(buf, &mut pos)? != 0x01 {
+        return Err(Take::NotTls); // not a ClientHello
+    }
+    let _hi = read_u8(buf, &mut pos)?;
+    let _mid = read_u8(buf, &mut pos)?;
+    let _lo = read_u8(buf, &mut pos)?;
+    // ClientHello body: legacy_version(2) random(32) then variable fields.
+    let _legacy_version = read_u16(buf, &mut pos)?;
+    skip(buf, &mut pos, 32)?;
+    let sid_len = read_u8(buf, &mut pos)? as usize;
+    skip(buf, &mut pos, sid_len)?;
+    let cipher_len = read_u16(buf, &mut pos)?;
+    skip(buf, &mut pos, cipher_len)?;
+    let comp_len = read_u8(buf, &mut pos)? as usize;
+    skip(buf, &mut pos, comp_len)?;
+    // Extensions block.
+    let ext_total = read_u16(buf, &mut pos)?;
+    let ext_end = pos.checked_add(ext_total).ok_or(Take::NotTls)?;
+    if ext_end > buf.len() {
+        return Err(Take::NeedMore);
+    }
+    while pos < ext_end {
+        if pos + 4 > ext_end {
+            return Err(Take::NotTls); // extension header straddles the block end
+        }
+        let ext_type = read_u16(buf, &mut pos)?;
+        let ext_len = read_u16(buf, &mut pos)?;
+        let ext_data_end = pos.checked_add(ext_len).ok_or(Take::NotTls)?;
+        if ext_data_end > ext_end {
+            return Err(Take::NotTls);
+        }
+        if ext_type == 0x0000 {
+            return parse_server_name_ext(&buf[pos..ext_data_end]);
+        }
+        pos = ext_data_end;
+    }
+    Ok(None)
+}
+
+fn parse_server_name_ext(data: &[u8]) -> Result<Option<String>, Take> {
+    let mut pos = 0;
+    let list_len = read_u16(data, &mut pos)?;
+    let list_end = pos.checked_add(list_len).ok_or(Take::NotTls)?;
+    if list_end > data.len() {
+        return Err(Take::NotTls); // the extension declared its own length already
+    }
+    while pos < list_end {
+        if pos + 3 > list_end {
+            return Err(Take::NotTls);
+        }
+        let name_type = read_u8(data, &mut pos)?;
+        let name_len = read_u16(data, &mut pos)?;
+        let name_end = pos.checked_add(name_len).ok_or(Take::NotTls)?;
+        if name_end > list_end {
+            return Err(Take::NotTls);
+        }
+        if name_type == 0x00 {
+            let raw = &data[pos..name_end];
+            return match std::str::from_utf8(raw) {
+                Ok(name) if is_plausible_sni(name) => Ok(Some(name.to_ascii_lowercase())),
+                _ => Err(Take::NotTls),
+            };
+        }
+        pos = name_end;
+    }
+    Ok(None)
+}
+
+/// A defensive shape check on the SNI before it is used as a routing key: DNS
+/// names only, bounded length, no path/scheme/control characters. Routing is
+/// still by exact label match against registered tunnels; this only keeps
+/// junk out of logs and lookups.
+fn is_plausible_sni(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 253
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
+}
+
+/// The leftmost DNS label of a fleet SNI (`d-<hash>.<zone>` -> `d-<hash>`).
+/// This is the routing key: it equals `dns::daemon_label(daemon_id)` for the
+/// daemon that owns the name.
+fn sni_route_label(sni: &str) -> Option<String> {
+    let label = sni.trim().trim_end_matches('.').split('.').next()?;
+    if label.is_empty() {
+        None
+    } else {
+        Some(label.to_ascii_lowercase())
+    }
+}
+
+// ── Relay state ─────────────────────────────────────────────────────────────
+
+/// A daemon's live control-channel presence plus its queue of unclaimed
+/// dial-back nonces.
+struct TunnelEntry {
+    last_seen_unix_ms: u64,
+    pending: VecDeque<String>,
+}
+
+/// Shared relay state, hung off `AppState` (None when the relay is disabled),
+/// exactly as `dns_zone` hangs the fleet DNS zone.
+pub(crate) struct RelayState {
+    /// Where the raw relay listener binds.
+    listen: SocketAddr,
+    /// Public address(es) advertised in fleet DNS for relay-mode daemons.
+    advertise_addrs: Vec<IpAddr>,
+    /// label -> control-channel presence.
+    tunnels: StdMutex<HashMap<String, TunnelEntry>>,
+    /// nonce -> the browser splicer waiting for the daemon's dial-back.
+    pending_dialbacks: StdMutex<HashMap<String, oneshot::Sender<TcpStream>>>,
+    /// Wakes parked control polls when a nonce is enqueued for them.
+    control_notify: Notify,
+    /// Per-source-IP concurrent browser connections.
+    ip_conns: StdMutex<HashMap<IpAddr, u32>>,
+    /// Per-tunnel concurrent spliced browser connections.
+    tunnel_splices: StdMutex<HashMap<String, u32>>,
+}
+
+impl RelayState {
+    pub(crate) fn new(listen: SocketAddr, advertise_addrs: Vec<IpAddr>) -> Self {
+        Self {
+            listen,
+            advertise_addrs,
+            tunnels: StdMutex::new(HashMap::new()),
+            pending_dialbacks: StdMutex::new(HashMap::new()),
+            control_notify: Notify::new(),
+            ip_conns: StdMutex::new(HashMap::new()),
+            tunnel_splices: StdMutex::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn advertise_addrs(&self) -> &[IpAddr] {
+        &self.advertise_addrs
+    }
+
+    pub(crate) fn listen(&self) -> SocketAddr {
+        self.listen
+    }
+
+    /// Refresh a tunnel's control-channel presence on each poll.
+    fn touch_tunnel(&self, label: &str, now: u64) {
+        let mut tunnels = self.tunnels.lock().expect("relay tunnels poisoned");
+        tunnels
+            .entry(label.to_string())
+            .or_insert_with(|| TunnelEntry {
+                last_seen_unix_ms: now,
+                pending: VecDeque::new(),
+            })
+            .last_seen_unix_ms = now;
+    }
+
+    /// Pop the next unclaimed dial-back nonce for a tunnel, if any.
+    fn pop_pending(&self, label: &str) -> Option<String> {
+        let mut tunnels = self.tunnels.lock().expect("relay tunnels poisoned");
+        tunnels.get_mut(label)?.pending.pop_front()
+    }
+
+    /// Whether a tunnel has an active (recently polled) control channel.
+    fn tunnel_active(&self, label: &str, now: u64) -> bool {
+        let tunnels = self.tunnels.lock().expect("relay tunnels poisoned");
+        tunnels
+            .get(label)
+            .is_some_and(|entry| now.saturating_sub(entry.last_seen_unix_ms) <= RELAY_TUNNEL_LIVENESS_MS)
+    }
+
+    /// Queue a dial-back nonce for a tunnel's control poll. Fails closed if the
+    /// tunnel is not active or its queue is at capacity.
+    fn enqueue_dialback(&self, label: &str, nonce: String, now: u64) -> bool {
+        let mut tunnels = self.tunnels.lock().expect("relay tunnels poisoned");
+        let Some(entry) = tunnels.get_mut(label) else {
+            return false;
+        };
+        if now.saturating_sub(entry.last_seen_unix_ms) > RELAY_TUNNEL_LIVENESS_MS
+            || entry.pending.len() >= RELAY_MAX_PENDING_PER_TUNNEL
+        {
+            return false;
+        }
+        entry.pending.push_back(nonce);
+        drop(tunnels);
+        self.control_notify.notify_waiters();
+        true
+    }
+
+    /// Drop tunnels whose control channel has gone quiet, and reap any nonces
+    /// queued under them. Called periodically so a daemon that stops polling
+    /// stops being routable.
+    fn sweep(&self, now: u64) {
+        self.tunnels
+            .lock()
+            .expect("relay tunnels poisoned")
+            .retain(|_, entry| now.saturating_sub(entry.last_seen_unix_ms) <= RELAY_TUNNEL_LIVENESS_MS);
+    }
+
+    fn acquire_ip_conn(self: &Arc<Self>, ip: IpAddr) -> Option<IpConnGuard> {
+        let mut map = self.ip_conns.lock().expect("relay ip conns poisoned");
+        let count = map.entry(ip).or_insert(0);
+        if *count >= RELAY_MAX_CONNS_PER_IP {
+            return None;
+        }
+        *count += 1;
+        Some(IpConnGuard {
+            relay: self.clone(),
+            ip,
+        })
+    }
+
+    fn release_ip_conn(&self, ip: IpAddr) {
+        let mut map = self.ip_conns.lock().expect("relay ip conns poisoned");
+        if let Some(count) = map.get_mut(&ip) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                map.remove(&ip);
+            }
+        }
+    }
+
+    fn acquire_tunnel_splice(self: &Arc<Self>, label: &str) -> Option<TunnelSpliceGuard> {
+        let mut map = self.tunnel_splices.lock().expect("relay splices poisoned");
+        let count = map.entry(label.to_string()).or_insert(0);
+        if *count >= RELAY_MAX_CONNS_PER_TUNNEL {
+            return None;
+        }
+        *count += 1;
+        Some(TunnelSpliceGuard {
+            relay: self.clone(),
+            label: label.to_string(),
+        })
+    }
+
+    fn release_tunnel_splice(&self, label: &str) {
+        let mut map = self.tunnel_splices.lock().expect("relay splices poisoned");
+        if let Some(count) = map.get_mut(label) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                map.remove(label);
+            }
+        }
+    }
+}
+
+struct IpConnGuard {
+    relay: Arc<RelayState>,
+    ip: IpAddr,
+}
+
+impl Drop for IpConnGuard {
+    fn drop(&mut self) {
+        self.relay.release_ip_conn(self.ip);
+    }
+}
+
+struct TunnelSpliceGuard {
+    relay: Arc<RelayState>,
+    label: String,
+}
+
+impl Drop for TunnelSpliceGuard {
+    fn drop(&mut self) {
+        self.relay.release_tunnel_splice(&self.label);
+    }
+}
+
+// ── Control channel: daemon long-poll for dial-back requests ────────────────
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct RelayNextRequest {
+    protocol: String,
+    daemon_id: String,
+    daemon_public_key: String,
+    issued_at_unix_ms: u64,
+    signature: String,
+    #[serde(default)]
+    timeout_ms: Option<u64>,
+}
+
+fn relay_control_signing_payload(
+    daemon_id: &str,
+    daemon_public_key: &str,
+    issued_at_unix_ms: u64,
+) -> String {
+    format!("{RELAY_CONTROL_PROTOCOL}\n{daemon_id}\n{daemon_public_key}\n{issued_at_unix_ms}\n")
+}
+
+/// Require the relay to be enabled, then run the shared daemon-signed
+/// verification (bearer gate, rate limit, protocol + freshness, key pin).
+async fn relay_request_daemon(
+    state: &Arc<AppState>,
+    headers: &HeaderMap,
+    protocol: &str,
+    expected_protocol: &str,
+    rate_key: &str,
+    daemon_id: &str,
+    daemon_public_key: &str,
+    issued_at_unix_ms: u64,
+) -> ApiResult<DaemonRecord> {
+    if state.relay.is_none() {
+        return Err(ApiError::not_found(
+            "reachability relay is not enabled on this rendezvous",
+        ));
+    }
+    verified_daemon_request(
+        state,
+        headers,
+        (rate_key, 120, 60_000),
+        (protocol, expected_protocol),
+        daemon_id,
+        daemon_public_key,
+        issued_at_unix_ms,
+    )
+    .await
+}
+
+/// Daemon control-channel long-poll. Authenticated by the daemon identity key
+/// (same signed/freshness discipline as `/api/dns/publish`). Registers the
+/// daemon's tunnel presence, then parks until a dial-back nonce is available
+/// or the poll times out.
+pub(crate) async fn relay_next(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<RelayNextRequest>,
+) -> ApiResult<Response> {
+    let daemon_id = body.daemon_id.trim().to_string();
+    let daemon = relay_request_daemon(
+        &state,
+        &headers,
+        &body.protocol,
+        RELAY_CONTROL_PROTOCOL,
+        "relay_next",
+        &daemon_id,
+        &body.daemon_public_key,
+        body.issued_at_unix_ms,
+    )
+    .await?;
+    let payload = relay_control_signing_payload(
+        &daemon_id,
+        &daemon.daemon_public_key,
+        body.issued_at_unix_ms,
+    );
+    if !verify_ed25519_b64u(
+        &daemon.daemon_public_key,
+        payload.as_bytes(),
+        body.signature.trim(),
+    ) {
+        return Err(ApiError::bad_request("relay control signature invalid"));
+    }
+    let relay = state
+        .relay
+        .as_ref()
+        .expect("relay presence checked in relay_request_daemon")
+        .clone();
+    let Some(label) = daemon_label(&daemon_id) else {
+        return Err(ApiError::bad_request("daemon id does not derive a fleet label"));
+    };
+    relay.touch_tunnel(&label, now_unix_ms());
+
+    let timeout = Duration::from_millis(
+        body.timeout_ms
+            .unwrap_or(RELAY_CONTROL_POLL_CAP_MS)
+            .min(RELAY_CONTROL_POLL_CAP_MS),
+    );
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Some(nonce) = relay.pop_pending(&label) {
+            return Ok(Json(json!({
+                "ok": true,
+                "dialback": { "nonce": nonce },
+            }))
+            .into_response());
+        }
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return Ok(StatusCode::NO_CONTENT.into_response());
+        }
+        let remaining = deadline.saturating_duration_since(now);
+        // Re-touch keeps the tunnel live across a full parked poll.
+        relay.touch_tunnel(&label, now_unix_ms());
+        if tokio::time::timeout(remaining, relay.control_notify.notified())
+            .await
+            .is_err()
+        {
+            return Ok(StatusCode::NO_CONTENT.into_response());
+        }
+    }
+}
+
+// ── DNS relay-mode publish ──────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct DnsRelayRequest {
+    protocol: String,
+    daemon_id: String,
+    daemon_public_key: String,
+    issued_at_unix_ms: u64,
+    signature: String,
+    /// true = answer this daemon's fleet label with the relay's address;
+    /// false = stop (the daemon reverts to direct address publishing).
+    #[serde(default)]
+    enable: bool,
+}
+
+fn dns_relay_signing_payload(
+    daemon_id: &str,
+    daemon_public_key: &str,
+    issued_at_unix_ms: u64,
+    enable: bool,
+) -> String {
+    let enable = if enable { "1" } else { "0" };
+    format!("{DNS_RELAY_PROTOCOL}\n{daemon_id}\n{daemon_public_key}\n{issued_at_unix_ms}\n{enable}\n")
+}
+
+/// Daemon-signed relay-mode DNS publish: point the daemon's fleet label at the
+/// relay's public address instead of the daemon's own addresses. Requires BOTH
+/// the fleet DNS zone and the relay to be enabled (the former to serve the
+/// record, the latter to supply the advertised address). The zone serves the
+/// substituted address verbatim — the store/serve split is intact.
+pub(crate) async fn dns_relay(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<DnsRelayRequest>,
+) -> ApiResult<Json<serde_json::Value>> {
+    let daemon_id = body.daemon_id.trim().to_string();
+    if state.dns_zone.is_none() {
+        return Err(ApiError::not_found(
+            "fleet dns is not enabled on this rendezvous",
+        ));
+    }
+    let daemon = relay_request_daemon(
+        &state,
+        &headers,
+        &body.protocol,
+        DNS_RELAY_PROTOCOL,
+        "dns_relay",
+        &daemon_id,
+        &body.daemon_public_key,
+        body.issued_at_unix_ms,
+    )
+    .await?;
+    let payload = dns_relay_signing_payload(
+        &daemon_id,
+        &daemon.daemon_public_key,
+        body.issued_at_unix_ms,
+        body.enable,
+    );
+    if !verify_ed25519_b64u(
+        &daemon.daemon_public_key,
+        payload.as_bytes(),
+        body.signature.trim(),
+    ) {
+        return Err(ApiError::bad_request("dns relay signature invalid"));
+    }
+    let relay = state
+        .relay
+        .as_ref()
+        .expect("relay presence checked in relay_request_daemon")
+        .clone();
+    let advertise: Vec<IpAddr> = relay.advertise_addrs().to_vec();
+    if body.enable && advertise.is_empty() {
+        return Err(ApiError::not_found(
+            "this relay advertises no public address (set --relay-address)",
+        ));
+    }
+    let zone = state
+        .dns_zone
+        .as_ref()
+        .expect("checked above")
+        .clone();
+    let name = zone
+        .daemon_fqdn(&daemon_id)
+        .ok_or_else(|| ApiError::bad_request("daemon id does not derive a DNS label"))?;
+    let addresses = if body.enable { advertise.clone() } else { Vec::new() };
+    zone.set_daemon_addresses(&daemon_id, &addresses)
+        .map_err(ApiError::bad_request)?;
+    let now = now_unix_ms();
+    {
+        let mut store = state.store.lock().await;
+        store.dns_records.retain(|r| r.daemon_id != daemon_id);
+        if body.enable {
+            store.dns_records.push(DnsRecordEntry {
+                daemon_id: daemon_id.clone(),
+                addresses: advertise.iter().map(|ip| ip.to_string()).collect(),
+                updated_unix_ms: now,
+                via_relay: true,
+            });
+        }
+        audit(
+            &mut store,
+            "dns_relay",
+            daemon.owner_user_id,
+            Some(daemon_id.clone()),
+            json!({ "name": name, "enable": body.enable }),
+        );
+        persist_locked(&state, &store)?;
+    }
+    Ok(Json(json!({
+        "ok": true,
+        "zone": zone.origin_utf8(),
+        "name": name,
+        "via_relay": body.enable,
+        "addresses": addresses.iter().map(|ip| ip.to_string()).collect::<Vec<_>>(),
+    })))
+}
+
+// ── Raw relay listener: browser TLS splice + daemon dial-back ───────────────
+
+/// Bind the raw relay TCP socket and return the accept loop future. Binding is
+/// eager so a misconfigured listener fails startup loudly, matching
+/// `bind_fleet_dns`.
+pub(crate) async fn bind_relay(
+    state: Arc<AppState>,
+    relay: Arc<RelayState>,
+) -> Result<impl std::future::Future<Output = ()>, String> {
+    let listener = TcpListener::bind(relay.listen)
+        .await
+        .map_err(|e| format!("bind relay listener {}: {e}", relay.listen))?;
+    Ok(run_relay_accept_loop(state, relay, listener))
+}
+
+async fn run_relay_accept_loop(_state: Arc<AppState>, relay: Arc<RelayState>, listener: TcpListener) {
+    // Periodic sweep of quiet tunnels alongside accepting.
+    let sweep_relay = relay.clone();
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            sweep_relay.sweep(now_unix_ms());
+        }
+    });
+    loop {
+        let (stream, peer) = match listener.accept().await {
+            Ok(conn) => conn,
+            Err(e) => {
+                // Transient accept errors: back off briefly and continue. The
+                // relay is best-effort availability, so it never tears itself
+                // down on an accept hiccup.
+                eprintln!("[relay] accept failed: {e}");
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                continue;
+            }
+        };
+        let relay = relay.clone();
+        tokio::spawn(async move {
+            handle_relay_connection(relay, stream, peer.ip()).await;
+        });
+    }
+}
+
+async fn handle_relay_connection(relay: Arc<RelayState>, stream: TcpStream, peer_ip: IpAddr) {
+    // One peeked byte disambiguates a browser TLS ClientHello (0x16) from a
+    // daemon dial-back hello (ASCII magic). `peek` leaves the bytes in the
+    // kernel buffer so the browser path can forward the ClientHello verbatim.
+    let mut first = [0u8; 1];
+    match stream.peek(&mut first).await {
+        Ok(0) | Err(_) => return,
+        Ok(_) => {}
+    }
+    if first[0] == 0x16 {
+        handle_browser_connection(relay, stream, peer_ip).await;
+    } else {
+        handle_dialback_connection(relay, stream).await;
+    }
+}
+
+/// A browser TLS connection: peek the ClientHello for its SNI (no
+/// termination), route to the matching active tunnel, and splice.
+async fn handle_browser_connection(relay: Arc<RelayState>, stream: TcpStream, peer_ip: IpAddr) {
+    let Some(_ip_guard) = relay.acquire_ip_conn(peer_ip) else {
+        return; // per-source-IP cap
+    };
+    let sni = match peek_sni(&stream).await {
+        Some(sni) => sni,
+        None => return, // fragmented-forever, oversized, non-TLS, or no-SNI: refuse
+    };
+    let Some(label) = sni_route_label(&sni) else {
+        return;
+    };
+    let now = now_unix_ms();
+    if !relay.tunnel_active(&label, now) {
+        return; // no active tunnel for this fleet name
+    }
+    let Some(_splice_guard) = relay.acquire_tunnel_splice(&label) else {
+        return; // per-tunnel cap
+    };
+
+    // Mint a single-use nonce, register the browser waiter, and ask the daemon
+    // to dial back.
+    let nonce = random_b64u(32);
+    let (tx, rx) = oneshot::channel::<TcpStream>();
+    {
+        let mut pending = relay
+            .pending_dialbacks
+            .lock()
+            .expect("relay dialbacks poisoned");
+        pending.insert(nonce.clone(), tx);
+    }
+    if !relay.enqueue_dialback(&label, nonce.clone(), now) {
+        relay
+            .pending_dialbacks
+            .lock()
+            .expect("relay dialbacks poisoned")
+            .remove(&nonce);
+        return;
+    }
+
+    let data_stream = match tokio::time::timeout(RELAY_DIALBACK_TIMEOUT, rx).await {
+        Ok(Ok(data_stream)) => data_stream,
+        _ => {
+            // Timed out or the waiter was dropped: reclaim the nonce slot.
+            relay
+                .pending_dialbacks
+                .lock()
+                .expect("relay dialbacks poisoned")
+                .remove(&nonce);
+            return;
+        }
+    };
+    // Pure ciphertext splice: the browser's TLS records flow to the daemon,
+    // whose fleet certificate completes the handshake. This service never sees
+    // plaintext.
+    splice(stream, data_stream, RELAY_SPLICE_MAX_BYTES, RELAY_SPLICE_IDLE).await;
+}
+
+/// A daemon dial-back data connection: read `ITRLY1 <nonce>\n`, hand this
+/// stream to the waiting browser splicer.
+async fn handle_dialback_connection(relay: Arc<RelayState>, mut stream: TcpStream) {
+    let Some(nonce) = read_dialback_nonce(&mut stream).await else {
+        return;
+    };
+    let sender = relay
+        .pending_dialbacks
+        .lock()
+        .expect("relay dialbacks poisoned")
+        .remove(&nonce);
+    let Some(sender) = sender else {
+        return; // unknown / expired / already-claimed nonce
+    };
+    // The browser splicer owns the splice; hand off this (post-hello) stream.
+    let _ = sender.send(stream);
+}
+
+/// Read a bounded dial-back hello line and extract the nonce.
+async fn read_dialback_nonce(stream: &mut TcpStream) -> Option<String> {
+    let mut buf = Vec::with_capacity(64);
+    let mut byte = [0u8; 1];
+    loop {
+        match tokio::time::timeout(RELAY_DIALBACK_TIMEOUT, stream.read(&mut byte)).await {
+            Ok(Ok(0)) | Ok(Err(_)) | Err(_) => return None,
+            Ok(Ok(_)) => {}
+        }
+        if byte[0] == b'\n' {
+            break;
+        }
+        buf.push(byte[0]);
+        if buf.len() > DIALBACK_HELLO_MAX_BYTES {
+            return None;
+        }
+    }
+    let line = std::str::from_utf8(&buf).ok()?;
+    let mut parts = line.trim().splitn(2, ' ');
+    if parts.next()? != DIALBACK_MAGIC {
+        return None;
+    }
+    let nonce = parts.next()?.trim();
+    if nonce.is_empty() || nonce.len() > 64 {
+        return None;
+    }
+    Some(nonce.to_string())
+}
+
+/// Peek a complete ClientHello (up to a cap / timeout) and return its SNI.
+/// Handles fragmented ClientHellos by re-peeking as more bytes arrive.
+async fn peek_sni(stream: &TcpStream) -> Option<String> {
+    let deadline = tokio::time::Instant::now() + RELAY_CLIENT_HELLO_TIMEOUT;
+    let mut buf = vec![0u8; RELAY_CLIENT_HELLO_PEEK_CAP];
+    loop {
+        // `peek` always returns from byte zero, so a later peek with more
+        // arrived bytes re-parses the growing prefix.
+        let n = match stream.peek(&mut buf).await {
+            Ok(0) | Err(_) => return None,
+            Ok(n) => n,
+        };
+        match parse_client_hello_sni(&buf[..n]) {
+            SniPeek::Sni(name) => return Some(name),
+            SniPeek::NoSni | SniPeek::NotTls => return None,
+            SniPeek::NeedMore => {
+                if n >= buf.len() {
+                    return None; // ClientHello larger than the peek cap: refuse
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    return None;
+                }
+                // Wait for more bytes to land, then re-peek.
+                if tokio::time::timeout(Duration::from_millis(50), readable(stream))
+                    .await
+                    .is_err()
+                {
+                    // Nothing new yet; loop re-checks the deadline.
+                }
+            }
+        }
+    }
+}
+
+async fn readable(stream: &TcpStream) {
+    let _ = stream.readable().await;
+}
+
+/// Bidirectional byte splice with a per-direction byte cap and idle teardown.
+/// When either direction finishes (EOF, error, cap, or idle) both halves drop
+/// and the connection closes.
+async fn splice(browser: TcpStream, daemon: TcpStream, max_bytes: u64, idle: Duration) {
+    let (browser_r, browser_w) = browser.into_split();
+    let (daemon_r, daemon_w) = daemon.into_split();
+    let to_daemon = copy_half(browser_r, daemon_w, max_bytes, idle);
+    let to_browser = copy_half(daemon_r, browser_w, max_bytes, idle);
+    tokio::select! {
+        _ = to_daemon => {}
+        _ = to_browser => {}
+    }
+}
+
+async fn copy_half<R, W>(mut reader: R, mut writer: W, max_bytes: u64, idle: Duration)
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut buf = vec![0u8; 16 * 1024];
+    let mut total: u64 = 0;
+    loop {
+        let n = match tokio::time::timeout(idle, reader.read(&mut buf)).await {
+            Ok(Ok(0)) | Ok(Err(_)) | Err(_) => break,
+            Ok(Ok(n)) => n,
+        };
+        total = total.saturating_add(n as u64);
+        if total > max_bytes {
+            break;
+        }
+        if writer.write_all(&buf[..n]).await.is_err() {
+            break;
+        }
+    }
+    let _ = writer.shutdown().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ring::signature::{Ed25519KeyPair, KeyPair as _};
+    use tokio::net::{TcpListener, TcpStream};
+
+    // ── ClientHello builder + SNI parser units ──────────────────────────────
+
+    /// Build a minimal but structurally valid TLS ClientHello record carrying
+    /// the given SNI (or none).
+    fn build_client_hello(sni: Option<&str>) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(&[0x03, 0x03]); // legacy_version = TLS 1.2
+        body.extend_from_slice(&[0u8; 32]); // random
+        body.push(0x00); // session_id length = 0
+        body.extend_from_slice(&[0x00, 0x02]); // cipher_suites length
+        body.extend_from_slice(&[0x00, 0x2f]); // one suite
+        body.push(0x01); // compression_methods length
+        body.push(0x00); // null compression
+
+        let mut exts = Vec::new();
+        if let Some(sni) = sni {
+            let host = sni.as_bytes();
+            let mut sn_list = Vec::new();
+            sn_list.push(0x00); // name_type = host_name
+            sn_list.extend_from_slice(&(host.len() as u16).to_be_bytes());
+            sn_list.extend_from_slice(host);
+            let mut ext_data = Vec::new();
+            ext_data.extend_from_slice(&(sn_list.len() as u16).to_be_bytes());
+            ext_data.extend_from_slice(&sn_list);
+            exts.extend_from_slice(&[0x00, 0x00]); // extension type = server_name
+            exts.extend_from_slice(&(ext_data.len() as u16).to_be_bytes());
+            exts.extend_from_slice(&ext_data);
+        }
+        body.extend_from_slice(&(exts.len() as u16).to_be_bytes());
+        body.extend_from_slice(&exts);
+
+        let mut handshake = Vec::new();
+        handshake.push(0x01); // ClientHello
+        let blen = body.len();
+        handshake.push((blen >> 16) as u8);
+        handshake.push((blen >> 8) as u8);
+        handshake.push(blen as u8);
+        handshake.extend_from_slice(&body);
+
+        let mut record = Vec::new();
+        record.push(0x16); // handshake content type
+        record.extend_from_slice(&[0x03, 0x01]); // record version
+        record.extend_from_slice(&(handshake.len() as u16).to_be_bytes());
+        record.extend_from_slice(&handshake);
+        record
+    }
+
+    #[test]
+    fn sni_parser_reads_a_valid_client_hello() {
+        let hello = build_client_hello(Some("D-ABC123.Fleet.Example.Test"));
+        assert_eq!(
+            parse_client_hello_sni(&hello),
+            SniPeek::Sni("d-abc123.fleet.example.test".to_string()),
+            "SNI is returned lowercased"
+        );
+    }
+
+    #[test]
+    fn sni_parser_reports_no_sni_when_absent() {
+        let hello = build_client_hello(None);
+        assert_eq!(parse_client_hello_sni(&hello), SniPeek::NoSni);
+    }
+
+    #[test]
+    fn sni_parser_asks_for_more_on_a_fragmented_hello() {
+        let hello = build_client_hello(Some("d-frag.fleet.example.test"));
+        // Every strict prefix is either NeedMore (a valid TLS prefix) — the
+        // whole point of the peek loop — never a false Sni/NoSni verdict.
+        for cut in 1..hello.len() {
+            assert_eq!(
+                parse_client_hello_sni(&hello[..cut]),
+                SniPeek::NeedMore,
+                "prefix of length {cut} must ask for more"
+            );
+        }
+        assert_eq!(
+            parse_client_hello_sni(&hello),
+            SniPeek::Sni("d-frag.fleet.example.test".to_string())
+        );
+    }
+
+    #[test]
+    fn sni_parser_refuses_non_tls_garbage() {
+        assert_eq!(parse_client_hello_sni(b"GET / HTTP/1.1\r\n"), SniPeek::NotTls);
+        assert_eq!(parse_client_hello_sni(b"\x00\x14\x00\x01"), SniPeek::NotTls); // STUN-ish
+        assert_eq!(parse_client_hello_sni(&[0x16, 0x99, 0x01]), SniPeek::NotTls); // bad version
+        assert_eq!(parse_client_hello_sni(&[0x16]), SniPeek::NeedMore); // could be TLS
+        assert_eq!(parse_client_hello_sni(&[]), SniPeek::NeedMore);
+        // Not a ClientHello handshake type.
+        let mut not_ch = build_client_hello(Some("x.test"));
+        not_ch[5] = 0x02; // ServerHello
+        assert_eq!(parse_client_hello_sni(&not_ch), SniPeek::NotTls);
+    }
+
+    #[test]
+    fn sni_parser_never_panics_on_random_bytes() {
+        // Fuzz-lite: no input, however malformed, may panic. A prefixed 0x16
+        // exercises the deeper structural bounds checks.
+        for seed in 0u16..2000 {
+            let mut bytes = Vec::new();
+            let mut x = (seed as u32).wrapping_mul(2654435761);
+            for _ in 0..(seed % 300) {
+                x = x.wrapping_mul(1664525).wrapping_add(1013904223);
+                bytes.push((x >> 16) as u8);
+            }
+            let _ = parse_client_hello_sni(&bytes);
+            let prefixed: Vec<u8> = std::iter::once(0x16).chain(bytes).collect();
+            let _ = parse_client_hello_sni(&prefixed);
+        }
+    }
+
+    #[test]
+    fn sni_parser_refuses_lengths_past_the_extensions_block() {
+        // Corrupt the server_name_list length to claim more than the extension
+        // holds — must refuse, not panic or over-read.
+        let mut hello = build_client_hello(Some("d-x.fleet.example.test"));
+        let len = hello.len();
+        hello[len - 3] = 0xff; // inside the SNI host length region
+        assert!(matches!(
+            parse_client_hello_sni(&hello),
+            SniPeek::NotTls | SniPeek::NeedMore
+        ));
+    }
+
+    #[test]
+    fn route_label_is_the_leftmost_dns_label() {
+        assert_eq!(
+            sni_route_label("d-abc123.fleet.example.test").as_deref(),
+            Some("d-abc123")
+        );
+        assert_eq!(
+            sni_route_label("D-ABC123.Fleet.Test.").as_deref(),
+            Some("d-abc123")
+        );
+        assert_eq!(sni_route_label("").as_deref(), None);
+        assert_eq!(sni_route_label(".").as_deref(), None);
+    }
+
+    // ── Caps ────────────────────────────────────────────────────────────────
+
+    fn relay_state() -> Arc<RelayState> {
+        Arc::new(RelayState::new(
+            "127.0.0.1:0".parse().unwrap(),
+            vec!["203.0.113.10".parse().unwrap()],
+        ))
+    }
+
+    #[test]
+    fn per_ip_connection_cap_is_enforced_and_released() {
+        let relay = relay_state();
+        let ip: IpAddr = "198.51.100.7".parse().unwrap();
+        let mut guards = Vec::new();
+        for _ in 0..RELAY_MAX_CONNS_PER_IP {
+            guards.push(relay.acquire_ip_conn(ip).expect("under cap"));
+        }
+        assert!(relay.acquire_ip_conn(ip).is_none(), "at cap, refuse");
+        drop(guards.pop());
+        assert!(
+            relay.acquire_ip_conn(ip).is_some(),
+            "a freed slot admits the next connection"
+        );
+    }
+
+    #[test]
+    fn per_tunnel_splice_cap_is_enforced_and_released() {
+        let relay = relay_state();
+        let label = "d-cap";
+        let mut guards = Vec::new();
+        for _ in 0..RELAY_MAX_CONNS_PER_TUNNEL {
+            guards.push(relay.acquire_tunnel_splice(label).expect("under cap"));
+        }
+        assert!(relay.acquire_tunnel_splice(label).is_none(), "at cap, refuse");
+        drop(guards.pop());
+        assert!(relay.acquire_tunnel_splice(label).is_some());
+    }
+
+    #[test]
+    fn dialback_queue_only_grows_for_an_active_tunnel_and_is_bounded() {
+        let relay = relay_state();
+        let now = crate::now_unix_ms();
+        // No tunnel yet: enqueue refuses.
+        assert!(!relay.enqueue_dialback("d-none", "n0".to_string(), now));
+        relay.touch_tunnel("d-live", now);
+        assert!(relay.tunnel_active("d-live", now));
+        for i in 0..RELAY_MAX_PENDING_PER_TUNNEL {
+            assert!(relay.enqueue_dialback("d-live", format!("n{i}"), now));
+        }
+        assert!(
+            !relay.enqueue_dialback("d-live", "overflow".to_string(), now),
+            "the pending queue is capped"
+        );
+        // A stale tunnel is inactive and unroutable.
+        assert!(!relay.tunnel_active("d-live", now + RELAY_TUNNEL_LIVENESS_MS + 1));
+    }
+
+    // ── Dial-back framing ───────────────────────────────────────────────────
+
+    async fn connected_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = TcpStream::connect(addr);
+        let server = async { listener.accept().await.unwrap().0 };
+        let (client, server) = tokio::join!(client, server);
+        (client.unwrap(), server)
+    }
+
+    #[tokio::test]
+    async fn dialback_hello_parses_magic_and_nonce() {
+        let (mut client, mut server) = connected_pair().await;
+        client
+            .write_all(b"ITRLY1 the-nonce-value\nextra ciphertext")
+            .await
+            .unwrap();
+        let nonce = read_dialback_nonce(&mut server).await;
+        assert_eq!(nonce.as_deref(), Some("the-nonce-value"));
+    }
+
+    #[tokio::test]
+    async fn dialback_hello_rejects_wrong_magic() {
+        let (mut client, mut server) = connected_pair().await;
+        client.write_all(b"NOPE abc\n").await.unwrap();
+        assert_eq!(read_dialback_nonce(&mut server).await, None);
+    }
+
+    // ── Registration / auth on the control channel ──────────────────────────
+
+    fn test_identity() -> (Ed25519KeyPair, String) {
+        let rng = ring::rand::SystemRandom::new();
+        let pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+        let key = Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap();
+        let public = crate::b64u(key.public_key().as_ref());
+        (key, public)
+    }
+
+    fn registered_store(daemon_id: &str, public_key: &str) -> crate::Store {
+        let now = crate::now_unix_ms();
+        let mut store = crate::Store::default();
+        store.daemons.push(crate::DaemonRecord {
+            daemon_id: daemon_id.to_string(),
+            label: None,
+            daemon_public_key: public_key.to_string(),
+            owner_user_id: None,
+            claim_code_hash: None,
+            claim_code_created_unix_ms: None,
+            last_registration_proof_unix_ms: None,
+            route_link_revision: 0,
+            last_unclaim_proof_unix_ms: None,
+            registered_unix_ms: now,
+            last_seen_unix_ms: now,
+            updated_unix_ms: now,
+            presence_hours: Vec::new(),
+        });
+        store
+    }
+
+    #[tokio::test]
+    async fn relay_next_requires_the_relay_to_be_enabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let (key, public) = test_identity();
+        let daemon_id = "relay-disabled";
+        let state = crate::build_test_state(
+            dir.path(),
+            registered_store(daemon_id, &public),
+            crate::TestStateOverrides {
+                open_daemon_registration: true,
+                ..Default::default()
+            },
+        );
+        let issued = crate::now_unix_ms();
+        let payload = relay_control_signing_payload(daemon_id, &public, issued);
+        let body = RelayNextRequest {
+            protocol: RELAY_CONTROL_PROTOCOL.to_string(),
+            daemon_id: daemon_id.to_string(),
+            daemon_public_key: public.clone(),
+            issued_at_unix_ms: issued,
+            signature: crate::b64u(key.sign(payload.as_bytes()).as_ref()),
+            timeout_ms: Some(10),
+        };
+        let err = relay_next(axum::extract::State(state), HeaderMap::new(), axum::Json(body))
+            .await
+            .err()
+            .expect("relay disabled must reject");
+        assert_eq!(err.status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn relay_next_rejects_a_bad_signature() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_key, public) = test_identity();
+        let daemon_id = "relay-badsig";
+        let relay = relay_state();
+        let state = crate::build_test_state(
+            dir.path(),
+            registered_store(daemon_id, &public),
+            crate::TestStateOverrides {
+                open_daemon_registration: true,
+                relay: Some(relay),
+                ..Default::default()
+            },
+        );
+        let issued = crate::now_unix_ms();
+        let body = RelayNextRequest {
+            protocol: RELAY_CONTROL_PROTOCOL.to_string(),
+            daemon_id: daemon_id.to_string(),
+            daemon_public_key: public.clone(),
+            issued_at_unix_ms: issued,
+            signature: crate::b64u(&[0u8; 64]),
+            timeout_ms: Some(10),
+        };
+        let err = relay_next(axum::extract::State(state), HeaderMap::new(), axum::Json(body))
+            .await
+            .err()
+            .expect("a bad signature must reject");
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn dns_relay_publishes_the_relay_address_and_records_via_relay() {
+        let dir = tempfile::tempdir().unwrap();
+        let (key, public) = test_identity();
+        let daemon_id = "relay-dns-daemon";
+        let relay = relay_state();
+        let advertise = relay.advertise_addrs()[0];
+        let zone = Arc::new(crate::FleetZone::new("fleet.example.test", "ns.example.test").unwrap());
+        let state = crate::build_test_state(
+            dir.path(),
+            registered_store(daemon_id, &public),
+            crate::TestStateOverrides {
+                open_daemon_registration: true,
+                dns_zone: Some(zone.clone()),
+                relay: Some(relay),
+                ..Default::default()
+            },
+        );
+        let issued = crate::now_unix_ms();
+        let payload = dns_relay_signing_payload(daemon_id, &public, issued, true);
+        let body = DnsRelayRequest {
+            protocol: DNS_RELAY_PROTOCOL.to_string(),
+            daemon_id: daemon_id.to_string(),
+            daemon_public_key: public.clone(),
+            issued_at_unix_ms: issued,
+            signature: crate::b64u(key.sign(payload.as_bytes()).as_ref()),
+            enable: true,
+        };
+        let response = dns_relay(
+            axum::extract::State(state.clone()),
+            HeaderMap::new(),
+            axum::Json(body),
+        )
+        .await
+        .expect("relay-mode publish succeeds");
+        assert_eq!(response.0["via_relay"], serde_json::json!(true));
+
+        // The store records relay mode; the zone answers the relay address.
+        let store = state.store.lock().await;
+        let record = store
+            .dns_records
+            .iter()
+            .find(|r| r.daemon_id == daemon_id)
+            .expect("record persisted");
+        assert!(record.via_relay);
+        assert_eq!(record.addresses, vec![advertise.to_string()]);
+    }
+
+    // ── In-process loopback end-to-end ──────────────────────────────────────
+
+    #[derive(Debug)]
+    struct CapturingVerifier {
+        seen: StdMutex<Option<Vec<u8>>>,
+        provider: Arc<rustls::crypto::CryptoProvider>,
+    }
+
+    impl CapturingVerifier {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                seen: StdMutex::new(None),
+                provider: Arc::new(rustls::crypto::ring::default_provider()),
+            })
+        }
+        fn captured(&self) -> Option<Vec<u8>> {
+            self.seen.lock().unwrap().clone()
+        }
+    }
+
+    impl rustls::client::danger::ServerCertVerifier for CapturingVerifier {
+        fn verify_server_cert(
+            &self,
+            end_entity: &rustls::pki_types::CertificateDer<'_>,
+            _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+            _server_name: &rustls::pki_types::ServerName<'_>,
+            _ocsp: &[u8],
+            _now: rustls::pki_types::UnixTime,
+        ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+            *self.seen.lock().unwrap() = Some(end_entity.as_ref().to_vec());
+            Ok(rustls::client::danger::ServerCertVerified::assertion())
+        }
+        fn verify_tls12_signature(
+            &self,
+            message: &[u8],
+            cert: &rustls::pki_types::CertificateDer<'_>,
+            dss: &rustls::DigitallySignedStruct,
+        ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+            rustls::crypto::verify_tls12_signature(
+                message,
+                cert,
+                dss,
+                &self.provider.signature_verification_algorithms,
+            )
+        }
+        fn verify_tls13_signature(
+            &self,
+            message: &[u8],
+            cert: &rustls::pki_types::CertificateDer<'_>,
+            dss: &rustls::DigitallySignedStruct,
+        ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+            rustls::crypto::verify_tls13_signature(
+                message,
+                cert,
+                dss,
+                &self.provider.signature_verification_algorithms,
+            )
+        }
+        fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+            self.provider
+                .signature_verification_algorithms
+                .supported_schemes()
+        }
+    }
+
+    /// A stand-in daemon gateway: a TLS server presenting the fleet
+    /// certificate. It mirrors the real gateway's fleet-SNI rule — the shell
+    /// is served, a protected route is refused — so the test proves the relay
+    /// hands the browser's ClientHello (fleet SNI and all) through unchanged.
+    async fn spawn_fleet_gateway(fleet_name: &str) -> (SocketAddr, Vec<u8>) {
+        let cert = rcgen::generate_simple_self_signed(vec![fleet_name.to_string()]).unwrap();
+        let cert_der = cert.cert.der().to_vec();
+        let key_der = cert.signing_key.serialize_der();
+        let certs = vec![rustls::pki_types::CertificateDer::from(cert_der.clone())];
+        let key = rustls::pki_types::PrivateKeyDer::try_from(key_der).unwrap();
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let config = rustls::ServerConfig::builder_with_provider(provider)
+            .with_safe_default_protocol_versions()
+            .unwrap()
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .unwrap();
+        let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(config));
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let fleet_name = fleet_name.to_string();
+        tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                let acceptor = acceptor.clone();
+                let fleet_name = fleet_name.clone();
+                tokio::spawn(async move {
+                    let Ok(mut tls) = acceptor.accept(stream).await else {
+                        return;
+                    };
+                    let is_fleet = tls
+                        .get_ref()
+                        .1
+                        .server_name()
+                        .is_some_and(|sni| sni.eq_ignore_ascii_case(&fleet_name));
+                    let mut buf = vec![0u8; 2048];
+                    let n = tls.read(&mut buf).await.unwrap_or(0);
+                    let request = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let (status, body) = if request.starts_with("GET /api/protected") {
+                        // Discovery-only: a fleet-SNI connection refuses control.
+                        if is_fleet {
+                            ("403 Forbidden", "discovery-only")
+                        } else {
+                            ("200 OK", "control")
+                        }
+                    } else {
+                        ("200 OK", "shell")
+                    };
+                    let response = format!(
+                        "HTTP/1.1 {status}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = tls.write_all(response.as_bytes()).await;
+                    let _ = tls.shutdown().await;
+                });
+            }
+        });
+        (addr, cert_der)
+    }
+
+    /// The fake daemon's control loop + dial-back plumbing.
+    fn spawn_fake_daemon(
+        connect_base: String,
+        relay_addr: SocketAddr,
+        gateway_addr: SocketAddr,
+        daemon_id: String,
+        public: String,
+        key: Arc<Ed25519KeyPair>,
+    ) {
+        tokio::spawn(async move {
+            let client = reqwest::Client::new();
+            loop {
+                let issued = crate::now_unix_ms();
+                let payload = relay_control_signing_payload(&daemon_id, &public, issued);
+                let signature = crate::b64u(key.sign(payload.as_bytes()).as_ref());
+                let request = client
+                    .post(format!("{connect_base}/api/relay/next"))
+                    .json(&serde_json::json!({
+                        "protocol": RELAY_CONTROL_PROTOCOL,
+                        "daemon_id": daemon_id,
+                        "daemon_public_key": public,
+                        "issued_at_unix_ms": issued,
+                        "signature": signature,
+                        "timeout_ms": 1000,
+                    }))
+                    .send()
+                    .await;
+                let Ok(response) = request else {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    continue;
+                };
+                if response.status().as_u16() == 204 {
+                    continue;
+                }
+                let Ok(value) = response.json::<serde_json::Value>().await else {
+                    continue;
+                };
+                let Some(nonce) = value
+                    .pointer("/dialback/nonce")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+                else {
+                    continue;
+                };
+                tokio::spawn(async move {
+                    let Ok(mut data) = TcpStream::connect(relay_addr).await else {
+                        return;
+                    };
+                    if data
+                        .write_all(format!("{DIALBACK_MAGIC} {nonce}\n").as_bytes())
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                    let Ok(gateway) = TcpStream::connect(gateway_addr).await else {
+                        return;
+                    };
+                    splice(data, gateway, RELAY_SPLICE_MAX_BYTES, RELAY_SPLICE_IDLE).await;
+                });
+            }
+        });
+    }
+
+    async fn browser_fetch(
+        relay_addr: SocketAddr,
+        fleet_name: &str,
+        path: &str,
+    ) -> (String, Option<Vec<u8>>) {
+        let verifier = CapturingVerifier::new();
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let config = rustls::ClientConfig::builder_with_provider(provider)
+            .with_safe_default_protocol_versions()
+            .unwrap()
+            .dangerous()
+            .with_custom_certificate_verifier(verifier.clone())
+            .with_no_client_auth();
+        let connector = tokio_rustls::TlsConnector::from(Arc::new(config));
+        let server_name = rustls::pki_types::ServerName::try_from(fleet_name.to_string()).unwrap();
+        let tcp = TcpStream::connect(relay_addr).await.unwrap();
+        let mut tls = connector.connect(server_name, tcp).await.unwrap();
+        let request =
+            format!("GET {path} HTTP/1.1\r\nhost: {fleet_name}\r\nconnection: close\r\n\r\n");
+        tls.write_all(request.as_bytes()).await.unwrap();
+        let mut response = Vec::new();
+        let _ = tls.read_to_end(&mut response).await;
+        (
+            String::from_utf8_lossy(&response).to_string(),
+            verifier.captured(),
+        )
+    }
+
+    #[tokio::test]
+    async fn browser_reaches_daemon_fleet_cert_through_the_relay() {
+        // Registered daemon identity.
+        let (key, public) = test_identity();
+        let key = Arc::new(key);
+        let daemon_id = "relay-e2e-daemon";
+        let label = daemon_label(daemon_id).unwrap();
+        let fleet_name = format!("{label}.fleet.example.test");
+
+        // Fake daemon gateway serving the fleet certificate.
+        let (gateway_addr, daemon_cert_der) = spawn_fleet_gateway(&fleet_name).await;
+
+        // Connect service (control channel) + relay listener sharing state.
+        let dir = tempfile::tempdir().unwrap();
+        let relay = relay_state();
+        let state = crate::build_test_state(
+            dir.path(),
+            registered_store(daemon_id, &public),
+            crate::TestStateOverrides {
+                open_daemon_registration: true,
+                relay: Some(relay.clone()),
+                ..Default::default()
+            },
+        );
+        let http_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let http_addr = http_listener.local_addr().unwrap();
+        {
+            let router = crate::connect_router(state.clone());
+            tokio::spawn(async move {
+                axum::serve(http_listener, router).await.unwrap();
+            });
+        }
+        let relay_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let relay_addr = relay_listener.local_addr().unwrap();
+        tokio::spawn(run_relay_accept_loop(state.clone(), relay, relay_listener));
+
+        // Fake daemon: control loop + dial-back into its own gateway.
+        spawn_fake_daemon(
+            format!("http://{http_addr}"),
+            relay_addr,
+            gateway_addr,
+            daemon_id.to_string(),
+            public.clone(),
+            key,
+        );
+
+        // Wait for the daemon's first control poll to register its tunnel
+        // before dialling in — otherwise the browser races ahead of the tunnel
+        // and is (correctly) refused.
+        let active = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if state
+                    .relay
+                    .as_ref()
+                    .unwrap()
+                    .tunnel_active(&label, crate::now_unix_ms())
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await;
+        assert!(active.is_ok(), "daemon tunnel never became active");
+
+        // The browser reaches the fleet name through the relay and the shell
+        // is served — over the DAEMON's certificate.
+        let (shell, seen_cert) = tokio::time::timeout(
+            Duration::from_secs(10),
+            browser_fetch(relay_addr, &fleet_name, "/"),
+        )
+        .await
+        .expect("browser round-trip completes");
+        assert!(shell.contains("200 OK"), "shell served: {shell}");
+        assert!(shell.contains("shell"));
+        assert_eq!(
+            seen_cert.as_deref(),
+            Some(daemon_cert_der.as_slice()),
+            "the certificate the browser saw is the daemon's fleet certificate"
+        );
+
+        // Discovery-only preserved: a protected route over the fleet name still
+        // refuses. The relay changed nothing about how the daemon classifies
+        // the connection.
+        let (protected, _) = tokio::time::timeout(
+            Duration::from_secs(10),
+            browser_fetch(relay_addr, &fleet_name, "/api/protected"),
+        )
+        .await
+        .expect("browser round-trip completes");
+        assert!(
+            protected.contains("403 Forbidden"),
+            "protected route refuses over the fleet name: {protected}"
+        );
+
+        // An SNI with no active tunnel is refused: the relay closes the
+        // connection, so the TLS handshake never completes and no certificate
+        // is ever seen. Proves the relay does not blindly splice.
+        let stray = daemon_label("some-other-daemon").unwrap();
+        let stray_name = format!("{stray}.fleet.example.test");
+        let verifier = CapturingVerifier::new();
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let config = rustls::ClientConfig::builder_with_provider(provider)
+            .with_safe_default_protocol_versions()
+            .unwrap()
+            .dangerous()
+            .with_custom_certificate_verifier(verifier.clone())
+            .with_no_client_auth();
+        let connector = tokio_rustls::TlsConnector::from(Arc::new(config));
+        let server_name = rustls::pki_types::ServerName::try_from(stray_name).unwrap();
+        let tcp = TcpStream::connect(relay_addr).await.unwrap();
+        let handshake = tokio::time::timeout(
+            Duration::from_secs(3),
+            connector.connect(server_name, tcp),
+        )
+        .await;
+        assert!(
+            matches!(handshake, Ok(Err(_)) | Err(_)),
+            "an unknown fleet name never completes a TLS handshake"
+        );
+        assert!(
+            verifier.captured().is_none(),
+            "an unknown fleet name never yields a certificate"
+        );
+    }
+}

--- a/src/bin/connect/relay.rs
+++ b/src/bin/connect/relay.rs
@@ -832,6 +832,12 @@ async fn read_dialback_nonce(stream: &mut TcpStream) -> Option<String> {
     Some(nonce.to_string())
 }
 
+/// Interval between re-peeks while waiting for a fragmented ClientHello to
+/// complete. `peek` does not consume, so the buffered bytes keep the socket
+/// readable — polling on a fixed interval (rather than on readability) is what
+/// keeps a stalled partial ClientHello from spinning the CPU.
+const RELAY_CLIENT_HELLO_POLL_INTERVAL: Duration = Duration::from_millis(20);
+
 /// Peek a complete ClientHello (up to a cap / timeout) and return its SNI.
 /// Handles fragmented ClientHellos by re-peeking as more bytes arrive.
 async fn peek_sni(stream: &TcpStream) -> Option<String> {
@@ -854,20 +860,12 @@ async fn peek_sni(stream: &TcpStream) -> Option<String> {
                 if tokio::time::Instant::now() >= deadline {
                     return None;
                 }
-                // Wait for more bytes to land, then re-peek.
-                if tokio::time::timeout(Duration::from_millis(50), readable(stream))
-                    .await
-                    .is_err()
-                {
-                    // Nothing new yet; loop re-checks the deadline.
-                }
+                // Poll on a fixed interval: peeked bytes stay buffered, so
+                // waiting on readability would busy-loop until the deadline.
+                tokio::time::sleep(RELAY_CLIENT_HELLO_POLL_INTERVAL).await;
             }
         }
     }
-}
-
-async fn readable(stream: &TcpStream) {
-    let _ = stream.readable().await;
 }
 
 /// Bidirectional byte splice with a per-direction byte cap and idle teardown.
@@ -1141,6 +1139,26 @@ mod tests {
         let (mut client, mut server) = connected_pair().await;
         client.write_all(b"NOPE abc\n").await.unwrap();
         assert_eq!(read_dialback_nonce(&mut server).await, None);
+    }
+
+    #[tokio::test]
+    async fn peek_sni_reassembles_a_fragmented_client_hello() {
+        let (mut client, server) = connected_pair().await;
+        let hello = build_client_hello(Some("d-frag.fleet.example.test"));
+        let mid = hello.len() / 2;
+        tokio::spawn(async move {
+            client.write_all(&hello[..mid]).await.unwrap();
+            // Land the remainder a few poll intervals later, exercising the
+            // re-peek path across TCP segments.
+            tokio::time::sleep(Duration::from_millis(60)).await;
+            client.write_all(&hello[mid..]).await.unwrap();
+            // Keep the peer open so the peeked bytes stay buffered.
+            tokio::time::sleep(Duration::from_millis(300)).await;
+        });
+        let sni = tokio::time::timeout(Duration::from_secs(5), peek_sni(&server))
+            .await
+            .expect("peek completes");
+        assert_eq!(sni.as_deref(), Some("d-frag.fleet.example.test"));
     }
 
     // ── Registration / auth on the control channel ──────────────────────────

--- a/src/bin/connect/relay.rs
+++ b/src/bin/connect/relay.rs
@@ -148,7 +148,7 @@ fn parse_sni_inner(buf: &[u8]) -> Result<Option<String>, Take> {
     }
     let _record_minor = read_u8(buf, &mut pos)?;
     let _record_len = read_u16(buf, &mut pos)?; // bound by the buffer, not this
-    // Handshake header: msg_type(1) length(3).
+                                                // Handshake header: msg_type(1) length(3).
     if read_u8(buf, &mut pos)? != 0x01 {
         return Err(Take::NotTls); // not a ClientHello
     }
@@ -311,9 +311,9 @@ impl RelayState {
     /// Whether a tunnel has an active (recently polled) control channel.
     fn tunnel_active(&self, label: &str, now: u64) -> bool {
         let tunnels = self.tunnels.lock().expect("relay tunnels poisoned");
-        tunnels
-            .get(label)
-            .is_some_and(|entry| now.saturating_sub(entry.last_seen_unix_ms) <= RELAY_TUNNEL_LIVENESS_MS)
+        tunnels.get(label).is_some_and(|entry| {
+            now.saturating_sub(entry.last_seen_unix_ms) <= RELAY_TUNNEL_LIVENESS_MS
+        })
     }
 
     /// Queue a dial-back nonce for a tunnel's control poll. Fails closed if the
@@ -341,7 +341,9 @@ impl RelayState {
         self.tunnels
             .lock()
             .expect("relay tunnels poisoned")
-            .retain(|_, entry| now.saturating_sub(entry.last_seen_unix_ms) <= RELAY_TUNNEL_LIVENESS_MS);
+            .retain(|_, entry| {
+                now.saturating_sub(entry.last_seen_unix_ms) <= RELAY_TUNNEL_LIVENESS_MS
+            });
     }
 
     fn acquire_ip_conn(self: &Arc<Self>, ip: IpAddr) -> Option<IpConnGuard> {
@@ -436,12 +438,12 @@ fn relay_control_signing_payload(
 
 /// Require the relay to be enabled, then run the shared daemon-signed
 /// verification (bearer gate, rate limit, protocol + freshness, key pin).
+/// `protocol` is `(got, expected)`, mirroring `verified_daemon_request`.
 async fn relay_request_daemon(
     state: &Arc<AppState>,
     headers: &HeaderMap,
-    protocol: &str,
-    expected_protocol: &str,
     rate_key: &str,
+    protocol: (&str, &str),
     daemon_id: &str,
     daemon_public_key: &str,
     issued_at_unix_ms: u64,
@@ -455,7 +457,7 @@ async fn relay_request_daemon(
         state,
         headers,
         (rate_key, 120, 60_000),
-        (protocol, expected_protocol),
+        protocol,
         daemon_id,
         daemon_public_key,
         issued_at_unix_ms,
@@ -476,9 +478,8 @@ pub(crate) async fn relay_next(
     let daemon = relay_request_daemon(
         &state,
         &headers,
-        &body.protocol,
-        RELAY_CONTROL_PROTOCOL,
         "relay_next",
+        (&body.protocol, RELAY_CONTROL_PROTOCOL),
         &daemon_id,
         &body.daemon_public_key,
         body.issued_at_unix_ms,
@@ -502,7 +503,9 @@ pub(crate) async fn relay_next(
         .expect("relay presence checked in relay_request_daemon")
         .clone();
     let Some(label) = daemon_label(&daemon_id) else {
-        return Err(ApiError::bad_request("daemon id does not derive a fleet label"));
+        return Err(ApiError::bad_request(
+            "daemon id does not derive a fleet label",
+        ));
     };
     relay.touch_tunnel(&label, now_unix_ms());
 
@@ -558,7 +561,9 @@ fn dns_relay_signing_payload(
     enable: bool,
 ) -> String {
     let enable = if enable { "1" } else { "0" };
-    format!("{DNS_RELAY_PROTOCOL}\n{daemon_id}\n{daemon_public_key}\n{issued_at_unix_ms}\n{enable}\n")
+    format!(
+        "{DNS_RELAY_PROTOCOL}\n{daemon_id}\n{daemon_public_key}\n{issued_at_unix_ms}\n{enable}\n"
+    )
 }
 
 /// Daemon-signed relay-mode DNS publish: point the daemon's fleet label at the
@@ -580,9 +585,8 @@ pub(crate) async fn dns_relay(
     let daemon = relay_request_daemon(
         &state,
         &headers,
-        &body.protocol,
-        DNS_RELAY_PROTOCOL,
         "dns_relay",
+        (&body.protocol, DNS_RELAY_PROTOCOL),
         &daemon_id,
         &body.daemon_public_key,
         body.issued_at_unix_ms,
@@ -612,15 +616,15 @@ pub(crate) async fn dns_relay(
             "this relay advertises no public address (set --relay-address)",
         ));
     }
-    let zone = state
-        .dns_zone
-        .as_ref()
-        .expect("checked above")
-        .clone();
+    let zone = state.dns_zone.as_ref().expect("checked above").clone();
     let name = zone
         .daemon_fqdn(&daemon_id)
         .ok_or_else(|| ApiError::bad_request("daemon id does not derive a DNS label"))?;
-    let addresses = if body.enable { advertise.clone() } else { Vec::new() };
+    let addresses = if body.enable {
+        advertise.clone()
+    } else {
+        Vec::new()
+    };
     zone.set_daemon_addresses(&daemon_id, &addresses)
         .map_err(ApiError::bad_request)?;
     let now = now_unix_ms();
@@ -668,7 +672,11 @@ pub(crate) async fn bind_relay(
     Ok(run_relay_accept_loop(state, relay, listener))
 }
 
-async fn run_relay_accept_loop(_state: Arc<AppState>, relay: Arc<RelayState>, listener: TcpListener) {
+async fn run_relay_accept_loop(
+    _state: Arc<AppState>,
+    relay: Arc<RelayState>,
+    listener: TcpListener,
+) {
     // Periodic sweep of quiet tunnels alongside accepting.
     let sweep_relay = relay.clone();
     tokio::spawn(async move {
@@ -768,7 +776,13 @@ async fn handle_browser_connection(relay: Arc<RelayState>, stream: TcpStream, pe
     // Pure ciphertext splice: the browser's TLS records flow to the daemon,
     // whose fleet certificate completes the handshake. This service never sees
     // plaintext.
-    splice(stream, data_stream, RELAY_SPLICE_MAX_BYTES, RELAY_SPLICE_IDLE).await;
+    splice(
+        stream,
+        data_stream,
+        RELAY_SPLICE_MAX_BYTES,
+        RELAY_SPLICE_IDLE,
+    )
+    .await;
 }
 
 /// A daemon dial-back data connection: read `ITRLY1 <nonce>\n`, hand this
@@ -982,7 +996,10 @@ mod tests {
 
     #[test]
     fn sni_parser_refuses_non_tls_garbage() {
-        assert_eq!(parse_client_hello_sni(b"GET / HTTP/1.1\r\n"), SniPeek::NotTls);
+        assert_eq!(
+            parse_client_hello_sni(b"GET / HTTP/1.1\r\n"),
+            SniPeek::NotTls
+        );
         assert_eq!(parse_client_hello_sni(b"\x00\x14\x00\x01"), SniPeek::NotTls); // STUN-ish
         assert_eq!(parse_client_hello_sni(&[0x16, 0x99, 0x01]), SniPeek::NotTls); // bad version
         assert_eq!(parse_client_hello_sni(&[0x16]), SniPeek::NeedMore); // could be TLS
@@ -1070,7 +1087,10 @@ mod tests {
         for _ in 0..RELAY_MAX_CONNS_PER_TUNNEL {
             guards.push(relay.acquire_tunnel_splice(label).expect("under cap"));
         }
-        assert!(relay.acquire_tunnel_splice(label).is_none(), "at cap, refuse");
+        assert!(
+            relay.acquire_tunnel_splice(label).is_none(),
+            "at cap, refuse"
+        );
         drop(guards.pop());
         assert!(relay.acquire_tunnel_splice(label).is_some());
     }
@@ -1177,10 +1197,14 @@ mod tests {
             signature: crate::b64u(key.sign(payload.as_bytes()).as_ref()),
             timeout_ms: Some(10),
         };
-        let err = relay_next(axum::extract::State(state), HeaderMap::new(), axum::Json(body))
-            .await
-            .err()
-            .expect("relay disabled must reject");
+        let err = relay_next(
+            axum::extract::State(state),
+            HeaderMap::new(),
+            axum::Json(body),
+        )
+        .await
+        .err()
+        .expect("relay disabled must reject");
         assert_eq!(err.status, StatusCode::NOT_FOUND);
     }
 
@@ -1208,10 +1232,14 @@ mod tests {
             signature: crate::b64u(&[0u8; 64]),
             timeout_ms: Some(10),
         };
-        let err = relay_next(axum::extract::State(state), HeaderMap::new(), axum::Json(body))
-            .await
-            .err()
-            .expect("a bad signature must reject");
+        let err = relay_next(
+            axum::extract::State(state),
+            HeaderMap::new(),
+            axum::Json(body),
+        )
+        .await
+        .err()
+        .expect("a bad signature must reject");
         assert_eq!(err.status, StatusCode::BAD_REQUEST);
     }
 
@@ -1222,7 +1250,8 @@ mod tests {
         let daemon_id = "relay-dns-daemon";
         let relay = relay_state();
         let advertise = relay.advertise_addrs()[0];
-        let zone = Arc::new(crate::FleetZone::new("fleet.example.test", "ns.example.test").unwrap());
+        let zone =
+            Arc::new(crate::FleetZone::new("fleet.example.test", "ns.example.test").unwrap());
         let state = crate::build_test_state(
             dir.path(),
             registered_store(daemon_id, &public),
@@ -1593,11 +1622,8 @@ mod tests {
         let connector = tokio_rustls::TlsConnector::from(Arc::new(config));
         let server_name = rustls::pki_types::ServerName::try_from(stray_name).unwrap();
         let tcp = TcpStream::connect(relay_addr).await.unwrap();
-        let handshake = tokio::time::timeout(
-            Duration::from_secs(3),
-            connector.connect(server_name, tcp),
-        )
-        .await;
+        let handshake =
+            tokio::time::timeout(Duration::from_secs(3), connector.connect(server_name, tcp)).await;
         assert!(
             matches!(handshake, Ok(Err(_)) | Err(_)),
             "an unknown fleet name never completes a TLS handshake"

--- a/src/bin/connect/rendezvous.rs
+++ b/src/bin/connect/rendezvous.rs
@@ -1910,6 +1910,7 @@ pub(crate) async fn dns_publish(
                 daemon_id: daemon_id.clone(),
                 addresses: addresses.iter().map(|ip| ip.to_string()).collect(),
                 updated_unix_ms: now,
+                via_relay: false,
             });
         }
         audit(
@@ -2064,6 +2065,8 @@ mod tests {
             dns_zone: None,
             dns_ns_name: None,
             dns_listen: None,
+            relay_listen: None,
+            relay_addresses: Vec::new(),
         };
         let webauthn = Webauthn::new(&config.rp_id, "Intendant Connect", &config.public_origin)
             .require_user_verification(true)
@@ -2095,6 +2098,7 @@ mod tests {
             log_key,
             push_http: reqwest::Client::new(),
             dns_zone: None,
+            relay: None,
         })
     }
 

--- a/src/bin/connect/transparency.rs
+++ b/src/bin/connect/transparency.rs
@@ -1413,6 +1413,8 @@ mod tests {
             dns_zone: None,
             dns_ns_name: None,
             dns_listen: None,
+            relay_listen: None,
+            relay_addresses: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## What

Adds a dark-by-default reachability relay so a NAT'd daemon becomes reachable at its fleet DNS name from any browser, with **TLS terminating at the daemon** (its fleet certificate). intendant-connect splices ciphertext by SNI and never terminates TLS or sees plaintext.

WP1 of the hosted-control program. It changes no authority semantics: relay and fleet-name provenance are discovery-only.

## Stream model (design choice)

**Chosen: (a) a control channel + nonce-correlated dial-back data connections** — not in-band multiplexing.

The deciding constraint is the program invariant that the relay is availability-only with **no TLS termination**, and Connect's trust class must not grow:

- **Control channel**: the daemon long-polls `POST /api/relay/next` on the Connect HTTP API, authenticated by the daemon identity key using the same signed/freshness pattern as `/api/dns/publish`. Each poll refreshes the daemon's tunnel presence, keyed by its derived fleet label.
- **Raw relay listener** (`--relay-listen`) peeks the ClientHello to read the SNI **without terminating TLS**. A fleet SNI with an active tunnel mints a single-use nonce, hands it to the daemon, waits for the daemon's data dial-back, then splices raw bytes both ways. Anything else is refused.
- **Data path**: a pure 1:1 byte splice. The browser's TLS completes end-to-end against the **daemon's** fleet certificate.

Why not in-band multiplexing: a mux would put framing, per-stream flow control, and head-of-line blocking on the ciphertext hot path for no security benefit. The 1:1 splice keeps Connect a transparent conduit.

## Trusted-local lane hardening

The daemon no longer dials the public gateway port for a relay data connection. At gateway startup it binds a separate, ephemeral `127.0.0.1` listener used only by relay dial-backs. The accept edge stamps immutable `GatewayIngress::ReachabilityRelay` provenance before TLS or HTTP parsing.

That provenance is enforced independently of SNI and `Host`:

- protected HTTP, MCP, direct signaling, and every WebSocket are discovery-only on relay ingress;
- authority-free shell/bootstrap/agent-card routes remain available under anonymous `role:none`;
- relay ingress cannot satisfy `direct_loopback_dashboard_request`, even though its last TCP hop is loopback;
- non-TLS bytes are dropped before raw ICE-TCP and cleartext-MCP demux, while the ordinary direct-loopback MCP exception is unchanged.

Fleet-SNI classification remains a second, independent discovery-only gate. A relayed browser using TLS SNI `localhost` and `Host: localhost` therefore still cannot enter the trusted-local lane.

## Config (all-or-nothing, default-off, mirrors `--dns-*`)

- **Connect**: `--relay-listen ADDR` + `--relay-address IP[,IP]` (env `INTENDANT_CONNECT_RELAY_LISTEN` / `INTENDANT_CONNECT_RELAY_ADDRESS`). Must receive raw TLS, not a TLS-terminating proxy.
- **Daemon**: `[connect] relay_enabled` + `relay_endpoint` in `intendant.toml` (env `INTENDANT_CONNECT_RELAY_ENDPOINT`). The tunnel client holds the control channel, dials back into the private gateway ingress, and publishes relay-mode fleet DNS while up.

## Abuse bounds

Per-source-IP and per-tunnel concurrent-connection caps, a per-connection byte cap, idle teardown, a bounded dial-back wait, and a peek cap/timeout on the ClientHello.

## Files

- Connect: `src/bin/connect/relay.rs` (SNI peek parser, relay state, raw listener, splice, caps, control long-poll, DNS relay-mode handler); config and wiring in `main.rs`.
- Daemon: `src/bin/caller/relay_tunnel.rs` (control loop, dial-back, splice); `[connect]` config in `project.rs`; DNS relay-mode client and signing helpers in `connect_rendezvous.rs`; private relay ingress and provenance gates in `web_gateway/listener.rs`, `access_gates.rs`, and `http_dispatch.rs`.
- DNS relay-mode publish extends the daemon-signed API with `POST /api/dns/relay`; `dns.rs` serves the substituted address verbatim.

## Tests

- ClientHello/SNI parser units: valid, fragmented, non-TLS garbage, no-SNI, malformed lengths, and no-panic fuzz sweep.
- Cap enforcement, dial-back framing, control-channel authentication, and DNS relay-mode records.
- Connect-side loopback E2E proves the browser sees the daemon's certificate, bytes round-trip, protected traffic remains discovery-only, and unknown fleet names fail.
- Gateway E2E runs with optional client auth (`tls_client_cert_required=false`), TLS SNI `localhost`, and `Host: localhost`: genuine direct loopback receives `/config`; relay `/config`, `/mcp`, and `/ws` receive discovery-only `403`; `/connect/status` remains public; and cleartext relay ingress cannot reach the MCP lane.

## Battery

- `cargo test --bins` — caller 3,642 passed / 9 ignored; Connect 108 passed; runtime 96 passed
- `cargo test --test e2e` — 22 passed
- `cargo clippy`
- `cargo fmt --all -- --check`
- `git diff --check`

## Status

Draft for review. Dark-flagged by default. Left in **DRAFT** — not queued and not deployed.
