### PR TITLE
vitals: per-session model / effort / permission-mode visibility

### DIFF
--- a/crates/intendant-core/src/vitals.rs
+++ b/crates/intendant-core/src/vitals.rs
@@ -293,7 +293,10 @@ mod tests {
             claude_permission_kind("acceptEdits"),
             Some(PERMISSION_KIND_AUTO_EDITS)
         );
-        assert_eq!(claude_permission_kind("auto"), Some(PERMISSION_KIND_AUTO_SAFE));
+        assert_eq!(
+            claude_permission_kind("auto"),
+            Some(PERMISSION_KIND_AUTO_SAFE)
+        );
         assert_eq!(
             claude_permission_kind("dontAsk"),
             Some(PERMISSION_KIND_DENY_ASKS)
@@ -399,6 +402,10 @@ mod tests {
 
         let sparse = SessionConfigVitals::default();
         let wire = serde_json::to_value(&sparse).expect("serializes");
-        assert_eq!(wire, serde_json::json!({}), "absent facts serialize to nothing");
+        assert_eq!(
+            wire,
+            serde_json::json!({}),
+            "absent facts serialize to nothing"
+        );
     }
 }

--- a/crates/intendant-core/src/vitals.rs
+++ b/crates/intendant-core/src/vitals.rs
@@ -130,11 +130,6 @@ pub struct SessionActivityVitals {
     /// not be claimed (honest degradation for delta-less backends).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stalled_after_seconds: Option<u32>,
-    /// Configured reasoning effort, first-hand only: the backend's own
-    /// echo when it states one, else the value Intendant itself passed at
-    /// launch. Never inferred from output volume or timing.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub effort: Option<String>,
     /// Rate-limit reset epoch while `state` is `rate-limited`, when the
     /// wire carried one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -149,10 +144,123 @@ pub struct SessionActivityVitals {
     pub background_tasks: Vec<String>,
 }
 
-/// Per-session vitals (git / prompt-cache / rate limits / live activity)
-/// shown by the dashboard and Station — the port of the operator
-/// statusline. Sections are independent: producers fill what they know,
-/// frontends hide what is absent.
+/// Session configuration facts — model, reasoning effort, permission
+/// mode — the vitals `config` section. Wire-first: every value is either
+/// the backend's own echo (Claude Code's `system:init`, a Codex
+/// thread-settings notification, the native loop's own provider
+/// selection) or the session's launch config awaiting one
+/// (`permission_echoed` distinguishes, for the datum where the difference
+/// is live — Claude Code resolves its mode through a 3-layer chain, so
+/// the launch value alone can lie). Absent fields mean "not reported":
+/// frontends render the row with a degraded value, never a guess.
+///
+/// Producers emit *partial* facts at each protocol seam; the vitals hub
+/// folds them sticky per field (a known value is never blanked by a later
+/// partial emission that omits it).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionConfigVitals {
+    /// Model identifier in the provider's own vocabulary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Configured reasoning effort, first-hand only: the backend's own
+    /// echo when it states one, else the value Intendant itself passed at
+    /// launch. Never inferred from output volume or timing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+    /// Raw permission/approval mode in the backend's own vocabulary
+    /// (`bypassPermissions`, `workspace-write · on-request`, an autonomy
+    /// level) — the power-user truth, always displayed verbatim one tap
+    /// away from the plain-language label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission_mode: Option<String>,
+    /// Backend-agnostic display class for the mode — one of
+    /// [`PERMISSION_DISPLAY_KINDS`], computed once daemon-side by the
+    /// per-backend catalog functions ([`claude_permission_kind`],
+    /// [`codex_permission_kind`]; native uses [`PERMISSION_KIND_AUTONOMY`]).
+    /// Absent for unknown modes: frontends then show the raw mode without
+    /// a plain-language claim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission_kind: Option<String>,
+    /// Whether the backend itself vouched for `permission_mode` (an init
+    /// echo, an accepted settings request) or the value is launch config
+    /// the backend has not yet confirmed.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub permission_echoed: bool,
+}
+
+/// The backend-agnostic permission display classes — the one catalog
+/// (`permission_kind` vocabulary). The dashboard's plain-language copy is
+/// keyed by exactly these strings; its symbol-catalog parity test pins
+/// them, so an addition here that forgets the frontend fails the suite.
+pub const PERMISSION_KIND_BYPASS: &str = "bypass";
+pub const PERMISSION_KIND_AUTO_EDITS: &str = "auto-edits";
+pub const PERMISSION_KIND_AUTO_SAFE: &str = "auto-safe";
+pub const PERMISSION_KIND_AUTO_SANDBOXED: &str = "auto-sandboxed";
+pub const PERMISSION_KIND_ASK: &str = "ask";
+pub const PERMISSION_KIND_DENY_ASKS: &str = "deny-asks";
+pub const PERMISSION_KIND_READ_ONLY: &str = "read-only";
+pub const PERMISSION_KIND_PLAN: &str = "plan";
+/// Native sessions: the label derives from the Intendant autonomy
+/// vocabulary keyed by the raw level in `permission_mode`.
+pub const PERMISSION_KIND_AUTONOMY: &str = "autonomy";
+
+pub const PERMISSION_DISPLAY_KINDS: [&str; 9] = [
+    PERMISSION_KIND_BYPASS,
+    PERMISSION_KIND_AUTO_EDITS,
+    PERMISSION_KIND_AUTO_SAFE,
+    PERMISSION_KIND_AUTO_SANDBOXED,
+    PERMISSION_KIND_ASK,
+    PERMISSION_KIND_DENY_ASKS,
+    PERMISSION_KIND_READ_ONLY,
+    PERMISSION_KIND_PLAN,
+    PERMISSION_KIND_AUTONOMY,
+];
+
+/// Display class for a Claude Code permission mode. The semantics mirror
+/// the CLI's own behavior (and the dashboard's mode-picker help text):
+/// `default` asks, `acceptEdits` auto-approves file edits only, `auto`
+/// auto-approves classifier-safe calls, `dontAsk` *declines* anything
+/// that would ask, `bypassPermissions` never asks at all, `plan` is
+/// read-only planning. Unknown modes map to `None` — display the raw
+/// name rather than guess.
+pub fn claude_permission_kind(mode: &str) -> Option<&'static str> {
+    match mode.trim() {
+        "bypassPermissions" => Some(PERMISSION_KIND_BYPASS),
+        "acceptEdits" => Some(PERMISSION_KIND_AUTO_EDITS),
+        "auto" => Some(PERMISSION_KIND_AUTO_SAFE),
+        "dontAsk" => Some(PERMISSION_KIND_DENY_ASKS),
+        "default" => Some(PERMISSION_KIND_ASK),
+        "plan" => Some(PERMISSION_KIND_PLAN),
+        _ => None,
+    }
+}
+
+/// Display class for a Codex approval-policy + sandbox pair. The sandbox
+/// leads: `danger-full-access` bypasses approvals and the sandbox
+/// entirely (the launch layer forces approval `never` alongside it), and
+/// a `read-only` sandbox cannot change anything regardless of policy.
+/// Inside `workspace-write`, `never`/`on-failure` act without asking
+/// (the full-auto/yolo class), `on-request` works alone in the sandbox
+/// and asks beyond it, `untrusted` asks first. Unknown combinations map
+/// to `None` — display the raw pair rather than guess.
+pub fn codex_permission_kind(approval_policy: &str, sandbox: &str) -> Option<&'static str> {
+    match (sandbox.trim(), approval_policy.trim()) {
+        ("danger-full-access", _) => Some(PERMISSION_KIND_BYPASS),
+        ("read-only", _) => Some(PERMISSION_KIND_READ_ONLY),
+        ("workspace-write", "never") | ("workspace-write", "on-failure") => {
+            Some(PERMISSION_KIND_BYPASS)
+        }
+        ("workspace-write", "on-request") => Some(PERMISSION_KIND_AUTO_SANDBOXED),
+        ("workspace-write", "untrusted") => Some(PERMISSION_KIND_ASK),
+        _ => None,
+    }
+}
+
+/// Per-session vitals (git / prompt-cache / rate limits / live activity /
+/// config facts) shown by the dashboard and Station — the port of the
+/// operator statusline. Sections are independent: producers fill what
+/// they know, frontends hide what is absent.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionVitals {
@@ -164,4 +272,133 @@ pub struct SessionVitals {
     pub limits: Vec<SessionLimitWindow>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub activity: Option<SessionActivityVitals>,
+    /// Session configuration facts (model / effort / permission mode).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config: Option<SessionConfigVitals>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every known mode maps into the pinned kind vocabulary; unknown
+    /// modes map to None (raw passthrough, never a guessed label).
+    #[test]
+    fn claude_permission_kinds_cover_the_mode_vocabulary() {
+        assert_eq!(
+            claude_permission_kind("bypassPermissions"),
+            Some(PERMISSION_KIND_BYPASS)
+        );
+        assert_eq!(
+            claude_permission_kind("acceptEdits"),
+            Some(PERMISSION_KIND_AUTO_EDITS)
+        );
+        assert_eq!(claude_permission_kind("auto"), Some(PERMISSION_KIND_AUTO_SAFE));
+        assert_eq!(
+            claude_permission_kind("dontAsk"),
+            Some(PERMISSION_KIND_DENY_ASKS)
+        );
+        assert_eq!(claude_permission_kind("default"), Some(PERMISSION_KIND_ASK));
+        assert_eq!(claude_permission_kind(" plan "), Some(PERMISSION_KIND_PLAN));
+        assert_eq!(claude_permission_kind("delegate"), None);
+        assert_eq!(claude_permission_kind(""), None);
+    }
+
+    #[test]
+    fn codex_permission_kinds_cover_the_policy_sandbox_grid() {
+        // The danger sandbox is bypass regardless of the configured policy
+        // (launch forces approval "never" alongside it).
+        assert_eq!(
+            codex_permission_kind("untrusted", "danger-full-access"),
+            Some(PERMISSION_KIND_BYPASS)
+        );
+        assert_eq!(
+            codex_permission_kind("never", "danger-full-access"),
+            Some(PERMISSION_KIND_BYPASS)
+        );
+        // A read-only sandbox cannot change anything, whatever the policy.
+        assert_eq!(
+            codex_permission_kind("never", "read-only"),
+            Some(PERMISSION_KIND_READ_ONLY)
+        );
+        assert_eq!(
+            codex_permission_kind("on-request", "read-only"),
+            Some(PERMISSION_KIND_READ_ONLY)
+        );
+        // workspace-write: the approval policy decides.
+        assert_eq!(
+            codex_permission_kind("never", "workspace-write"),
+            Some(PERMISSION_KIND_BYPASS)
+        );
+        assert_eq!(
+            codex_permission_kind("on-failure", "workspace-write"),
+            Some(PERMISSION_KIND_BYPASS)
+        );
+        assert_eq!(
+            codex_permission_kind("on-request", "workspace-write"),
+            Some(PERMISSION_KIND_AUTO_SANDBOXED)
+        );
+        assert_eq!(
+            codex_permission_kind("untrusted", "workspace-write"),
+            Some(PERMISSION_KIND_ASK)
+        );
+        // Unknown vocabulary: raw passthrough, no plain-language claim.
+        assert_eq!(codex_permission_kind("sometimes", "workspace-write"), None);
+        assert_eq!(codex_permission_kind("never", "chroot"), None);
+    }
+
+    /// Every kind the mapping functions can return is in the pinned
+    /// vocabulary (the dashboard copy catalog is keyed by these).
+    #[test]
+    fn permission_kind_outputs_stay_in_the_pinned_vocabulary() {
+        let claude_modes = [
+            "bypassPermissions",
+            "acceptEdits",
+            "auto",
+            "dontAsk",
+            "default",
+            "plan",
+        ];
+        for mode in claude_modes {
+            let kind = claude_permission_kind(mode).expect("known mode maps");
+            assert!(
+                PERMISSION_DISPLAY_KINDS.contains(&kind),
+                "claude {mode} mapped outside the pinned vocabulary: {kind}"
+            );
+        }
+        for approval in ["untrusted", "on-request", "on-failure", "never"] {
+            for sandbox in ["read-only", "workspace-write", "danger-full-access"] {
+                if let Some(kind) = codex_permission_kind(approval, sandbox) {
+                    assert!(
+                        PERMISSION_DISPLAY_KINDS.contains(&kind),
+                        "codex {approval}/{sandbox} mapped outside the pinned vocabulary: {kind}"
+                    );
+                }
+            }
+        }
+        assert!(PERMISSION_DISPLAY_KINDS.contains(&PERMISSION_KIND_AUTONOMY));
+    }
+
+    /// The config section's wire shape: camelCase fields, absent when
+    /// unknown, `permissionEchoed` serialized only when true.
+    #[test]
+    fn config_vitals_wire_shape() {
+        let full = SessionConfigVitals {
+            model: Some("claude-fable-5".into()),
+            effort: Some("max".into()),
+            permission_mode: Some("bypassPermissions".into()),
+            permission_kind: Some(PERMISSION_KIND_BYPASS.into()),
+            permission_echoed: true,
+        };
+        let wire = serde_json::to_value(&full).expect("serializes");
+        assert_eq!(wire["model"], "claude-fable-5");
+        assert_eq!(wire["effort"], "max");
+        assert_eq!(wire["permissionMode"], "bypassPermissions");
+        assert_eq!(wire["permissionKind"], "bypass");
+        assert_eq!(wire["permissionEchoed"], true);
+
+        let sparse = SessionConfigVitals::default();
+        let wire = serde_json::to_value(&sparse).expect("serializes");
+        assert_eq!(wire, serde_json::json!({}), "absent facts serialize to nothing");
+    }
 }

--- a/docs/src/web-dashboard.md
+++ b/docs/src/web-dashboard.md
@@ -238,13 +238,21 @@ undocumented), dimming to `✗` once cold; and a rate-limit gauge —
 `▮NN% 5h` for the most-used window (Claude Code subscription 5h/7d,
 Codex primary/secondary, native Anthropic per-minute headers), dim below
 70%, yellow from 70%, red from 90% with the reset countdown appended;
-the tooltip lists every window. When a cache countdown enters its final
-minute the dashboard raises one toast per idle period (plus a browser
-notification if permission was already granted and the tab is hidden) —
-early enough that a follow-up still reuses the warm cache, never after the
-fact. Sections appear as producers fill them; the chip hides in narrow
-windows. Station's agent focus panel shows the same vitals as git /
-cache / limits rows.
+the tooltip lists every window. Session-facts chips (the vitals `config`
+section, wire-first from each backend's own echoes with the launch config
+as the honestly-marked fallback) show the model + configured reasoning
+effort (`⬡ fable-5 · max`) and the permission mode in plain words
+(`🛡 Acts without asking`) — bypass/ungated modes get a quiet warning
+tint (cosmetic, never the health dot), the raw backend vocabulary
+(`bypassPermissions`, `workspace-write · on-request`, the autonomy level)
+is one tap away in the explainer, and the vitals pane always lists both
+rows, degrading to "not reported" instead of hiding. When a cache
+countdown enters its final minute the dashboard raises one toast per idle
+period (plus a browser notification if permission was already granted and
+the tab is hidden) — early enough that a follow-up still reuses the warm
+cache, never after the fact. Sections appear as producers fill them; the
+chip hides in narrow windows. Station's agent focus panel shows the same
+vitals as git / cache / limits rows.
 
 #### Managed (Activity → Managed)
 

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -858,6 +858,27 @@ pub(crate) async fn run_agent_loop(
     let _activity_guard = activity
         .clone()
         .map(crate::session_activity::ActivityTurnGuard);
+    // Session-config facts (vitals `config` section): the native loop IS
+    // the caller, so its provider selection and the shared autonomy level
+    // are first-hand truth. Effort appears only when a reasoning config
+    // exists (OpenAI reasoning models today) — honest absence otherwise.
+    // Mid-session autonomy changes are folded in by the vitals hub from
+    // `AppEvent::AutonomyChanged`.
+    if let Some(session_id) = local_session_id.clone() {
+        let autonomy_level = autonomy.read().await.level.to_string();
+        bus.send(event::AppEvent::SessionConfigFacts {
+            session_id: Some(session_id),
+            facts: crate::types::SessionConfigVitals {
+                model: Some(provider.model().to_string()),
+                effort: provider.reasoning_effort(),
+                permission_mode: Some(autonomy_level),
+                permission_kind: Some(
+                    intendant_core::vitals::PERMISSION_KIND_AUTONOMY.to_string(),
+                ),
+                permission_echoed: true,
+            },
+        });
+    }
     // Live action-visualization lane for the dashboard: one ephemeral
     // cu_action event per executed CU action (never session-logged).
     let cu_observer = computer_use::CuActionObserver::new(bus.clone(), local_session_id.clone());

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -872,9 +872,7 @@ pub(crate) async fn run_agent_loop(
                 model: Some(provider.model().to_string()),
                 effort: provider.reasoning_effort(),
                 permission_mode: Some(autonomy_level),
-                permission_kind: Some(
-                    intendant_core::vitals::PERMISSION_KIND_AUTONOMY.to_string(),
-                ),
+                permission_kind: Some(intendant_core::vitals::PERMISSION_KIND_AUTONOMY.to_string()),
                 permission_echoed: true,
             },
         });

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -377,6 +377,15 @@ pub enum AppEvent {
         session_id: Option<String>,
         activity: crate::types::SessionActivityVitals,
     },
+    /// Partial session-config facts (model / effort / permission mode)
+    /// from a backend's protocol seams — launch config, init echoes,
+    /// mid-session switches. Hub-internal like `SessionActivity`: the
+    /// vitals hub folds fields sticky into `SessionVitals.config`, which
+    /// is the outbound and session-logged carrier.
+    SessionConfigFacts {
+        session_id: Option<String>,
+        facts: crate::types::SessionConfigVitals,
+    },
     SessionAttached {
         session_id: String,
         source: String,
@@ -2473,9 +2482,10 @@ pub fn app_event_to_outbound(event: &AppEvent) -> Option<crate::types::OutboundE
             session_id: session_id.clone(),
             vitals: vitals.clone(),
         }),
-        // Hub-internal: the vitals hub folds it into SessionVitals, which
-        // is the outbound (and session-logged) carrier.
+        // Hub-internal: the vitals hub folds these into SessionVitals,
+        // which is the outbound (and session-logged) carrier.
         AppEvent::SessionActivity { .. } => None,
+        AppEvent::SessionConfigFacts { .. } => None,
         AppEvent::SessionAttached { session_id, source } => Some(OutboundEvent::SessionAttached {
             session_id: session_id.clone(),
             source: source.clone(),

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -3849,12 +3849,16 @@ mod tests {
     #[test]
     fn init_echo_populates_config_facts() {
         let mut reader = test_reader();
-        reader.shared.set_requested_permission_mode("bypassPermissions");
+        reader
+            .shared
+            .set_requested_permission_mode("bypassPermissions");
         let init = r#"{"type":"system","subtype":"init","model":"claude-fable-5","tools":[],"mcp_servers":[{"name":"intendant","status":"connected"}],"permissionMode":"bypassPermissions","session_id":"s1"}"#;
         let out = reader.process_line(init);
         let facts = config_facts_of(&out);
         assert!(
-            facts.iter().any(|f| f.model.as_deref() == Some("claude-fable-5")),
+            facts
+                .iter()
+                .any(|f| f.model.as_deref() == Some("claude-fable-5")),
             "init model echo populates the section"
         );
         let mode = facts
@@ -6464,10 +6468,30 @@ mod tests {
             "got: {:?}",
             out.events
         );
-        // Permission-mode status echoes stay silent (no log spam per turn).
-        let out = reader.process_line(
-            r#"{"type":"system","subtype":"status","status":null,"permissionMode":"acceptEdits","session_id":"s1"}"#,
+        // Permission-mode status echoes are consumed as config facts. A
+        // DIVERGENT echo (requested default, running acceptEdits) warns —
+        // once per distinct value, so per-turn re-echoes never spam.
+        let echo = r#"{"type":"system","subtype":"status","status":null,"permissionMode":"acceptEdits","session_id":"s1"}"#;
+        let out = reader.process_line(echo);
+        assert!(
+            logs(&out)
+                .iter()
+                .any(|(l, m)| l == "warn" && m.contains("running acceptEdits")),
+            "divergent status echo warns: {:?}",
+            out.events
         );
-        assert!(logs(&out).is_empty(), "unexpected logs: {:?}", out.events);
+        let out = reader.process_line(echo);
+        assert!(
+            logs(&out).is_empty(),
+            "repeat echo stays silent: {:?}",
+            out.events
+        );
+        assert!(
+            !out.events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::ConfigFacts { .. })),
+            "unchanged echo emits no facts: {:?}",
+            out.events
+        );
     }
 }

--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -283,16 +283,6 @@ impl CcShared {
         machine.turn_active()
     }
 
-    /// Adopt a first-hand effort value (launch config, or the CLI's own
-    /// echo when a future protocol states one).
-    fn set_activity_effort(&self, effort: Option<String>) {
-        let mut machine = match self.activity.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        machine.set_effort(effort);
-    }
-
     fn lock_goal(&self) -> std::sync::MutexGuard<'_, GoalEngine> {
         match self.goal.lock() {
             Ok(guard) => guard,
@@ -375,10 +365,9 @@ impl CcShared {
         *guard = mode.to_string();
     }
 
-    /// The permission mode the CLI last reported running. Stored for
-    /// future consumers (nothing outside the reader's divergence warning
-    /// and its tests reads it yet).
-    #[allow(dead_code)]
+    /// The permission mode the CLI last reported running (`None` until
+    /// the first echo). The reader's change edge for config-facts
+    /// emissions, and the divergence-warning baseline.
     fn effective_permission_mode(&self) -> Option<String> {
         match self.effective_permission_mode.lock() {
             Ok(guard) => guard.clone(),
@@ -1031,6 +1020,9 @@ struct CcReader {
     /// message, so the warning fires once per distinct echoed value, not
     /// per init.
     permission_mode_warned: Option<String>,
+    /// The CLI's last effort echo (2.1.2xx never states one; kept as the
+    /// change edge if a future protocol does).
+    effort_echo: Option<String>,
     announced_session_id: Option<String>,
 }
 
@@ -1061,7 +1053,57 @@ impl CcReader {
             last_intendant_mcp_status: None,
             init_logged: false,
             permission_mode_warned: None,
+            effort_echo: None,
             announced_session_id: None,
+        }
+    }
+
+    /// Track the wire-echoed model and surface a config-facts update when
+    /// it actually changed (`system:init` re-echoes every turn; a live
+    /// `set_model` switch is confirmed by the next echo).
+    fn note_model_echo(&mut self, model: &str, out: &mut CcLineOutcome) {
+        if self.model == model {
+            return;
+        }
+        self.model = model.to_string();
+        out.events.push(AgentEvent::ConfigFacts {
+            facts: crate::types::SessionConfigVitals {
+                model: Some(model.to_string()),
+                ..Default::default()
+            },
+        });
+    }
+
+    /// Reconcile a CLI-echoed EFFECTIVE permission mode (init echo, or the
+    /// 2.1.201 status-channel echo after a live switch) against the mode
+    /// Intendant requested, and surface the echo as config facts. The echo
+    /// is the truth — Claude Code resolves its mode through a 3-layer
+    /// chain (runtime flag / project toml / user settings), so a
+    /// divergence means the process runs under authority the recorded
+    /// session config doesn't name.
+    fn note_permission_mode_echo(&mut self, echoed: &str, out: &mut CcLineOutcome) {
+        let changed = self.shared.effective_permission_mode().as_deref() != Some(echoed);
+        self.shared.set_effective_permission_mode(echoed);
+        let requested = self.shared.requested_permission_mode();
+        if echoed != requested && self.permission_mode_warned.as_deref() != Some(echoed) {
+            self.permission_mode_warned = Some(echoed.to_string());
+            out.log(
+                "warn",
+                format!(
+                    "Claude Code permission mode diverged: requested {requested}, running {echoed}"
+                ),
+            );
+        }
+        if changed {
+            out.events.push(AgentEvent::ConfigFacts {
+                facts: crate::types::SessionConfigVitals {
+                    permission_mode: Some(echoed.to_string()),
+                    permission_kind: intendant_core::vitals::claude_permission_kind(echoed)
+                        .map(str::to_string),
+                    permission_echoed: true,
+                    ..Default::default()
+                },
+            });
         }
     }
 
@@ -1325,6 +1367,11 @@ impl CcReader {
             // General status channel (2.1.201): compaction progress and
             // permission-mode echoes arrive here.
             Some("status") => {
+                if let Some(echoed) = msg.get("permissionMode").and_then(|m| m.as_str()) {
+                    // The CLI's own echo of the live mode (e.g. after an
+                    // accepted set_permission_mode switch).
+                    self.note_permission_mode_echo(echoed, out);
+                }
                 if msg.get("status").and_then(|s| s.as_str()) == Some("compacting") {
                     out.log("info", "Compacting context…");
                 } else if let Some(result) = msg.get("compact_result").and_then(|s| s.as_str()) {
@@ -1374,17 +1421,28 @@ impl CcReader {
             _ => return,
         }
         if let Some(model) = msg.get("model").and_then(|m| m.as_str()) {
-            self.model = model.to_string();
+            self.note_model_echo(model, out);
         }
         // First-hand effort: adopt the CLI's own echo if an init ever
         // states one (2.1.2xx doesn't; the launch `--effort` value seeds
-        // the machine at spawn — effort is never inferred from output).
+        // the config facts at spawn — effort is never inferred from
+        // output).
         if let Some(effort) = msg
             .get("effort")
             .or_else(|| msg.get("reasoningEffort"))
             .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|e| !e.is_empty())
         {
-            self.shared.set_activity_effort(Some(effort.to_string()));
+            if self.effort_echo.as_deref() != Some(effort) {
+                self.effort_echo = Some(effort.to_string());
+                out.events.push(AgentEvent::ConfigFacts {
+                    facts: crate::types::SessionConfigVitals {
+                        effort: Some(effort.to_string()),
+                        ..Default::default()
+                    },
+                });
+            }
         }
         if !self.init_logged {
             self.init_logged = true;
@@ -1407,20 +1465,10 @@ impl CcReader {
         }
         // Reconcile the CLI's echoed effective mode against the mode
         // Intendant requested (spawn `--permission-mode`, or a live
-        // `set_permission_mode`): a divergence means the process runs under
-        // authority the recorded session config doesn't name.
+        // `set_permission_mode`), and surface the echo as config facts —
+        // the init echo is the EFFECTIVE truth.
         if let Some(echoed) = msg.get("permissionMode").and_then(|m| m.as_str()) {
-            self.shared.set_effective_permission_mode(echoed);
-            let requested = self.shared.requested_permission_mode();
-            if echoed != requested && self.permission_mode_warned.as_deref() != Some(echoed) {
-                self.permission_mode_warned = Some(echoed.to_string());
-                out.log(
-                    "warn",
-                    format!(
-                        "Claude Code permission mode diverged: requested {requested}, running {echoed}"
-                    ),
-                );
-            }
+            self.note_permission_mode_echo(echoed, out);
         }
         if self.expect_intendant_mcp {
             self.report_intendant_mcp_status(msg, out);
@@ -2030,7 +2078,9 @@ impl CcReader {
                     .and_then(|m| m.get("model"))
                     .and_then(|m| m.as_str())
                 {
-                    self.model = model.to_string();
+                    // Mid-session model changes ride message_start; the
+                    // note emits config facts only on an actual change.
+                    self.note_model_echo(model, out);
                 }
                 // message_start usage carries the per-TTL split that the
                 // flat message_delta shape drops.
@@ -2804,6 +2854,19 @@ impl ClaudeCodeAgent {
         // Keep the reader's reconciliation baseline current, so the next
         // init echo is compared against the live mode, not the spawn mode.
         self.shared.set_requested_permission_mode(&mode);
+        // Config facts: the requested switch, honestly unconfirmed until
+        // the CLI's own echo (status channel / next init) upgrades it.
+        if let Some(tx) = &self.event_tx {
+            let _ = tx.send(AgentEvent::ConfigFacts {
+                facts: crate::types::SessionConfigVitals {
+                    permission_mode: Some(mode.clone()),
+                    permission_kind: intendant_core::vitals::claude_permission_kind(&mode)
+                        .map(str::to_string),
+                    permission_echoed: false,
+                    ..Default::default()
+                },
+            });
+        }
         Ok(format!(
             "permission mode switched to {mode} for the running session"
         ))
@@ -2874,10 +2937,6 @@ impl ExternalAgent for ClaudeCodeAgent {
         } else {
             self.resume_session.clone()
         }));
-        // Seed the activity machine's configured effort with the value we
-        // pass at launch (`--effort`); a backend echo may upgrade it, and
-        // it is never inferred from output volume or timing.
-        self.shared.set_activity_effort(self.effort.clone());
 
         // Build command args
         let mut args = vec![
@@ -2912,7 +2971,7 @@ impl ExternalAgent for ClaudeCodeAgent {
         let permission_mode = normalize_permission_mode(&self.permission_mode);
         self.shared.set_requested_permission_mode(&permission_mode);
         args.push("--permission-mode".into());
-        args.push(permission_mode);
+        args.push(permission_mode.clone());
 
         if let Some(ref effort) = self.effort {
             args.push("--effort".into());
@@ -3001,6 +3060,22 @@ impl ExternalAgent for ClaudeCodeAgent {
         if let Some(stderr) = stderr {
             super::spawn_stderr_forwarder("claude", stderr, event_tx.clone());
         }
+
+        // Launch-config facts, honestly marked unconfirmed: what Intendant
+        // asked the CLI to run (`--model` / `--effort` /
+        // `--permission-mode`). The first `system:init` echo — the
+        // EFFECTIVE truth — upgrades the mode to `permission_echoed` and
+        // corrects the model if the CLI resolved differently.
+        let _ = event_tx.send(AgentEvent::ConfigFacts {
+            facts: crate::types::SessionConfigVitals {
+                model: self.model.clone().or_else(|| config.model.clone()),
+                effort: self.effort.clone(),
+                permission_mode: Some(permission_mode.clone()),
+                permission_kind: intendant_core::vitals::claude_permission_kind(&permission_mode)
+                    .map(str::to_string),
+                permission_echoed: false,
+            },
+        });
 
         let reader_state = CcReader::new(
             Arc::clone(&self.shared),
@@ -3756,16 +3831,104 @@ mod tests {
         );
     }
 
-    /// The launch `--effort` value rides every published snapshot as the
-    /// configured (never inferred) effort.
+    fn config_facts_of(out: &CcLineOutcome) -> Vec<crate::types::SessionConfigVitals> {
+        out.events
+            .iter()
+            .filter_map(|e| match e {
+                AgentEvent::ConfigFacts { facts } => Some(facts.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The `system:init` echo is the EFFECTIVE truth (Claude Code resolves
+    /// its mode through a 3-layer chain, so the launch value alone can
+    /// lie): it populates the config-facts section — model + permission
+    /// mode with its display kind, marked echoed — and re-echoes of the
+    /// same values stay quiet (init re-fires after every user message).
     #[test]
-    fn activity_carries_configured_effort() {
-        let shared = CcShared::new(None);
-        shared.set_activity_effort(Some("max".into()));
-        let snapshot = shared
-            .observe_activity(ActivityObs::TurnDispatched)
-            .expect("dispatch publishes");
-        assert_eq!(snapshot.effort.as_deref(), Some("max"));
+    fn init_echo_populates_config_facts() {
+        let mut reader = test_reader();
+        reader.shared.set_requested_permission_mode("bypassPermissions");
+        let init = r#"{"type":"system","subtype":"init","model":"claude-fable-5","tools":[],"mcp_servers":[{"name":"intendant","status":"connected"}],"permissionMode":"bypassPermissions","session_id":"s1"}"#;
+        let out = reader.process_line(init);
+        let facts = config_facts_of(&out);
+        assert!(
+            facts.iter().any(|f| f.model.as_deref() == Some("claude-fable-5")),
+            "init model echo populates the section"
+        );
+        let mode = facts
+            .iter()
+            .find(|f| f.permission_mode.is_some())
+            .expect("init mode echo populates the section");
+        assert_eq!(mode.permission_mode.as_deref(), Some("bypassPermissions"));
+        assert_eq!(mode.permission_kind.as_deref(), Some("bypass"));
+        assert!(mode.permission_echoed, "an init echo is wire truth");
+
+        // The same init re-fires next turn: no new facts (change edge).
+        let out = reader.process_line(init);
+        assert!(config_facts_of(&out).is_empty(), "re-echo stays quiet");
+
+        // A mode change (e.g. an accepted live switch) re-emits.
+        let out = reader.process_line(
+            r#"{"type":"system","subtype":"init","model":"claude-fable-5","tools":[],"mcp_servers":[{"name":"intendant","status":"connected"}],"permissionMode":"plan","session_id":"s1"}"#,
+        );
+        let facts = config_facts_of(&out);
+        let mode = facts
+            .iter()
+            .find(|f| f.permission_mode.is_some())
+            .expect("changed mode re-emits");
+        assert_eq!(mode.permission_mode.as_deref(), Some("plan"));
+        assert_eq!(mode.permission_kind.as_deref(), Some("plan"));
+    }
+
+    /// Mid-session model changes ride `message_start`; only an actual
+    /// change emits (every API round starts with one).
+    #[test]
+    fn message_start_model_change_emits_config_facts() {
+        let mut reader = test_reader();
+        let out = reader.process_line(
+            r#"{"type":"stream_event","event":{"type":"message_start","message":{"model":"claude-fable-5","usage":{"input_tokens":1,"output_tokens":1}}},"session_id":"s1"}"#,
+        );
+        let facts = config_facts_of(&out);
+        assert_eq!(facts.len(), 1, "first sighting emits");
+        assert_eq!(facts[0].model.as_deref(), Some("claude-fable-5"));
+
+        let out = reader.process_line(
+            r#"{"type":"stream_event","event":{"type":"message_start","message":{"model":"claude-fable-5","usage":{"input_tokens":1,"output_tokens":1}}},"session_id":"s1"}"#,
+        );
+        assert!(config_facts_of(&out).is_empty(), "same model stays quiet");
+
+        let out = reader.process_line(
+            r#"{"type":"stream_event","event":{"type":"message_start","message":{"model":"claude-opus-4-6","usage":{"input_tokens":1,"output_tokens":1}}},"session_id":"s1"}"#,
+        );
+        let facts = config_facts_of(&out);
+        assert_eq!(facts.len(), 1, "model switch emits");
+        assert_eq!(facts[0].model.as_deref(), Some("claude-opus-4-6"));
+    }
+
+    /// The 2.1.201 status channel echoes the live permission mode after an
+    /// accepted `set_permission_mode` switch — same wire-truth treatment
+    /// as the init echo.
+    #[test]
+    fn status_channel_permission_echo_emits_config_facts() {
+        let mut reader = test_reader();
+        reader.shared.set_requested_permission_mode("acceptEdits");
+        let out = reader.process_line(
+            r#"{"type":"system","subtype":"status","permissionMode":"acceptEdits","session_id":"s1"}"#,
+        );
+        let facts = config_facts_of(&out);
+        let mode = facts
+            .iter()
+            .find(|f| f.permission_mode.is_some())
+            .expect("status echo populates the section");
+        assert_eq!(mode.permission_mode.as_deref(), Some("acceptEdits"));
+        assert_eq!(mode.permission_kind.as_deref(), Some("auto-edits"));
+        assert!(mode.permission_echoed);
+        assert_eq!(
+            reader.shared.effective_permission_mode().as_deref(),
+            Some("acceptEdits")
+        );
     }
 
     #[test]

--- a/src/bin/caller/external_agent/codex/mod.rs
+++ b/src/bin/caller/external_agent/codex/mod.rs
@@ -359,6 +359,41 @@ impl CodexAgent {
         effective_approval_policy_for_sandbox(&self.sandbox, &self.approval_policy)
     }
 
+    /// Session-config facts from the launch config, emitted once the app
+    /// server accepted the thread lifecycle params — `thread/start` /
+    /// `thread/resume` carried model + approvalPolicy + sandbox, so a
+    /// successful response means those settings are applied (a wire-level
+    /// acceptance, not a guess). `model`/`effort` stay absent when
+    /// Intendant passes no override: the codex binary's own defaults
+    /// apply, and honesty says "not reported" until a wire echo names
+    /// them (`thread/settings/updated` does, when it fires).
+    fn emit_launch_config_facts(&self) {
+        let Some(tx) = &self.event_tx else { return };
+        let approval = self.effective_approval_policy().trim().to_string();
+        let sandbox = self.sandbox.trim().to_string();
+        let permission_mode = match (sandbox.is_empty(), approval.is_empty()) {
+            (true, true) => None,
+            (false, true) => Some(sandbox.clone()),
+            (true, false) => Some(approval.clone()),
+            (false, false) => Some(format!("{sandbox} · {approval}")),
+        };
+        let _ = tx.send(AgentEvent::ConfigFacts {
+            facts: crate::types::SessionConfigVitals {
+                model: self.model.clone().filter(|m| !m.trim().is_empty()),
+                effort: self
+                    .reasoning_effort
+                    .clone()
+                    .filter(|e| !e.trim().is_empty()),
+                permission_kind: intendant_core::vitals::codex_permission_kind(
+                    &approval, &sandbox,
+                )
+                .map(str::to_string),
+                permission_mode,
+                permission_echoed: true,
+            },
+        });
+    }
+
     fn update_service_tier_from_thread_response(&mut self, response: &serde_json::Value) {
         let Some(value) = response.get("serviceTier") else {
             return;
@@ -1327,7 +1362,6 @@ impl ExternalAgent for CodexAgent {
             latest_token_usage,
             context_pressure_floor,
             model,
-            self.reasoning_effort.clone(),
             protocol_watch.clone(),
             writer,
         ));
@@ -1431,6 +1465,10 @@ impl ExternalAgent for CodexAgent {
         // Cache the thread id so interrupt_turn() can build the
         // `turn/interrupt` params without requiring a thread handle.
         *self.active_thread_id.lock().await = Some(thread_id.clone());
+
+        // The thread accepted its lifecycle params — surface the applied
+        // config as session facts for the vitals hub.
+        self.emit_launch_config_facts();
 
         if self.fork_from_rollout_path.is_some() {
             match self.fork_cut.clone() {

--- a/src/bin/caller/external_agent/codex/mod.rs
+++ b/src/bin/caller/external_agent/codex/mod.rs
@@ -384,10 +384,8 @@ impl CodexAgent {
                     .reasoning_effort
                     .clone()
                     .filter(|e| !e.trim().is_empty()),
-                permission_kind: intendant_core::vitals::codex_permission_kind(
-                    &approval, &sandbox,
-                )
-                .map(str::to_string),
+                permission_kind: intendant_core::vitals::codex_permission_kind(&approval, &sandbox)
+                    .map(str::to_string),
                 permission_mode,
                 permission_echoed: true,
             },

--- a/src/bin/caller/external_agent/codex/reader.rs
+++ b/src/bin/caller/external_agent/codex/reader.rs
@@ -20,19 +20,16 @@ pub(crate) async fn reader_task(
     latest_token_usage: Arc<Mutex<Option<serde_json::Value>>>,
     context_pressure_floor: Arc<Mutex<Option<CodexContextPressureFloor>>>,
     model: Option<String>,
-    reasoning_effort: Option<String>,
     protocol_watch: Option<crate::external_agent::protocol_watch::ProtocolWatchHandle>,
     writer: SharedCodexWriter,
 ) {
     let reader = BufReader::new(stdout);
     let mut lines = reader.lines();
     let mut terminal_turns_observed = CodexTerminalObserved::default();
-    let mut notification_state = CodexNotificationState {
-        // Configured effort, first-hand: the value Intendant itself passes
-        // at spawn (`-c model_reasoning_effort=…`) — never inferred.
-        activity: crate::session_activity::ActivityMachine::new(reasoning_effort),
-        ..Default::default()
-    };
+    // Configured effort/model/permission facts ride the config-facts lane
+    // (emitted by the adapter after thread start, echoed here via
+    // thread/settings/updated) — the activity machine is liveness only.
+    let mut notification_state = CodexNotificationState::default();
 
     loop {
         let line = match lines.next_line().await {
@@ -995,6 +992,47 @@ pub(crate) fn codex_collab_agent_tool_call(params: &serde_json::Value) -> Option
         reasoning_effort,
         agents,
     })
+}
+
+/// Config-facts echo from a `thread/settings/updated` notification: the
+/// applied model / reasoning effort — and, when both halves are present,
+/// the approval+sandbox pair — in the server's own words. `None` when the
+/// settings carry none of them (e.g. a cwd-only update). A lone
+/// approval or sandbox half is dropped rather than guessed into a pair.
+pub(crate) fn codex_thread_settings_config_facts(
+    params: &serde_json::Value,
+) -> Option<crate::types::SessionConfigVitals> {
+    let settings = params
+        .get("threadSettings")
+        .or_else(|| params.get("thread_settings"))?;
+    let string_at = |keys: [&str; 2]| -> Option<String> {
+        keys.iter()
+            .filter_map(|key| settings.get(*key))
+            .find_map(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    };
+    let model = string_at(["model", "model"]);
+    let effort = string_at(["reasoningEffort", "reasoning_effort"]);
+    let approval = string_at(["approvalPolicy", "approval_policy"]);
+    let sandbox = string_at(["sandbox", "sandbox_mode"]);
+    let (permission_mode, permission_kind, permission_echoed) = match (&approval, &sandbox) {
+        (Some(approval), Some(sandbox)) => (
+            Some(format!("{sandbox} · {approval}")),
+            intendant_core::vitals::codex_permission_kind(approval, sandbox).map(str::to_string),
+            true,
+        ),
+        _ => (None, None, false),
+    };
+    let facts = crate::types::SessionConfigVitals {
+        model,
+        effort,
+        permission_mode,
+        permission_kind,
+        permission_echoed,
+    };
+    (facts != crate::types::SessionConfigVitals::default()).then_some(facts)
 }
 
 pub(crate) fn codex_plan_entries(params: &serde_json::Value) -> Vec<(String, String, String)> {
@@ -2927,6 +2965,17 @@ pub(crate) fn translate_notification_with_scope(
                         level: "info".to_string(),
                         message: format!("Codex thread settings applied: cwd {cwd}"),
                     },
+                );
+            }
+            // The applied settings are the server's own config echo —
+            // model / reasoning effort / approval+sandbox ride the
+            // config-facts lane when the notification carries them.
+            if let Some(facts) = codex_thread_settings_config_facts(params) {
+                send_scoped_agent_event(
+                    event_tx,
+                    thread_id,
+                    turn_id,
+                    AgentEvent::ConfigFacts { facts },
                 );
             }
         }
@@ -5465,13 +5514,73 @@ error: build failed
         );
     }
 
+    /// `thread/settings/updated` is the server's own config echo: model +
+    /// reasoning effort feed the config-facts lane (camel and snake wire
+    /// spellings both), a lone policy half is dropped rather than guessed
+    /// into a pair, and a cwd-only update carries no facts at all.
     #[test]
-    fn codex_activity_carries_configured_effort() {
-        let mut state = CodexNotificationState::default();
-        state.activity.set_effort(Some("high".into()));
-        let s = observe_codex_activity(&mut state, "turn/started", &serde_json::Value::Null, 100)
-            .expect("dispatch publishes");
-        assert_eq!(s.effort.as_deref(), Some("high"));
+    fn thread_settings_updated_echoes_config_facts() {
+        let params = serde_json::json!({
+            "threadId": "thread-abc",
+            "threadSettings": {
+                "cwd": "/home/user/project",
+                "model": "gpt-5.5",
+                "reasoningEffort": "high"
+            }
+        });
+        let facts = codex_thread_settings_config_facts(&params).expect("facts present");
+        assert_eq!(facts.model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(facts.effort.as_deref(), Some("high"));
+        assert_eq!(facts.permission_mode, None, "no policy pair echoed");
+        assert!(!facts.permission_echoed);
+
+        // Snake-case spelling and a full policy pair.
+        let params = serde_json::json!({
+            "thread_settings": {
+                "model": "gpt-5.5",
+                "reasoning_effort": "medium",
+                "approval_policy": "on-request",
+                "sandbox": "workspace-write"
+            }
+        });
+        let facts = codex_thread_settings_config_facts(&params).expect("facts present");
+        assert_eq!(facts.effort.as_deref(), Some("medium"));
+        assert_eq!(
+            facts.permission_mode.as_deref(),
+            Some("workspace-write · on-request")
+        );
+        assert_eq!(facts.permission_kind.as_deref(), Some("auto-sandboxed"));
+        assert!(facts.permission_echoed);
+
+        // A lone sandbox half is not a pair; cwd-only carries nothing.
+        let params = serde_json::json!({
+            "threadSettings": { "sandbox": "workspace-write" }
+        });
+        assert_eq!(codex_thread_settings_config_facts(&params), None);
+        let params = serde_json::json!({
+            "threadSettings": { "cwd": "/somewhere" }
+        });
+        assert_eq!(codex_thread_settings_config_facts(&params), None);
+
+        // The notification arm forwards the facts as a scoped event.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let params = serde_json::json!({
+            "threadId": "thread-abc",
+            "threadSettings": { "model": "gpt-5.5" }
+        });
+        translate_notification("thread/settings/updated", &params, &tx);
+        let mut saw_facts = false;
+        while let Ok(event) = rx.try_recv() {
+            let inner = match &event {
+                AgentEvent::Scoped { event, .. } => event.as_ref(),
+                other => other,
+            };
+            if let AgentEvent::ConfigFacts { facts } = inner {
+                assert_eq!(facts.model.as_deref(), Some("gpt-5.5"));
+                saw_facts = true;
+            }
+        }
+        assert!(saw_facts, "settings echo emits ConfigFacts");
     }
 
     #[test]

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -994,6 +994,16 @@ pub enum AgentEvent {
     ActivityUpdate {
         activity: crate::types::SessionActivityVitals,
     },
+    /// Partial session-config facts (model / effort / permission mode)
+    /// observed at a protocol seam: launch config at spawn, the backend's
+    /// own echoes (Claude Code `system:init` / `message_start`, Codex
+    /// thread-settings), accepted mid-session switches. Drains forward it
+    /// as `AppEvent::SessionConfigFacts` for the vitals hub, which folds
+    /// fields sticky into the session's `config` section. Ambient
+    /// bookkeeping — implies no turn.
+    ConfigFacts {
+        facts: crate::types::SessionConfigVitals,
+    },
     /// Informational backend event that should be written to the activity log.
     Log { level: String, message: String },
     /// Latest Codex `/goal` state for a thread.

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -1249,6 +1249,14 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                     activity,
                 });
             }
+            external_agent::AgentEvent::ConfigFacts { facts } => {
+                // Session-config facts → the vitals hub (same keying and
+                // aliasing as activity). Pure bookkeeping.
+                config.bus.send(AppEvent::SessionConfigFacts {
+                    session_id: config.session_id.clone(),
+                    facts,
+                });
+            }
             external_agent::AgentEvent::GoalUpdated { goal } => {
                 emit_external_session_goal(config, event_thread_id.clone(), Some(goal));
             }

--- a/src/bin/caller/external_mode.rs
+++ b/src/bin/caller/external_mode.rs
@@ -544,6 +544,12 @@ pub(crate) async fn run_external_agent_mode(
                                             activity,
                                         });
                                     }
+                                    external_agent::AgentEvent::ConfigFacts { facts } => {
+                                        bus.send(AppEvent::SessionConfigFacts {
+                                            session_id: drain_config.session_id.clone(),
+                                            facts,
+                                        });
+                                    }
                                     external_agent::AgentEvent::BackendError {
                                         message,
                                         code,

--- a/src/bin/caller/mcp/events.rs
+++ b/src/bin/caller/mcp/events.rs
@@ -252,6 +252,7 @@ pub fn spawn_event_listener(
                     | AppEvent::SessionGoal { .. }
                     | AppEvent::SessionVitals { .. }
                     | AppEvent::SessionActivity { .. }
+                    | AppEvent::SessionConfigFacts { .. }
                     | AppEvent::SessionRenameResult { .. }
                     | AppEvent::SessionAgentConfigResult { .. }
                     | AppEvent::ClaudeConfigChanged { .. }

--- a/src/bin/caller/peer/transport/intendant.rs
+++ b/src/bin/caller/peer/transport/intendant.rs
@@ -858,6 +858,7 @@ mod tests {
                     cache: None,
                     limits: Vec::new(),
                     activity: None,
+                    config: None,
                 },
             },
             crate::types::OutboundEvent::Status {

--- a/src/bin/caller/peer/upcast.rs
+++ b/src/bin/caller/peer/upcast.rs
@@ -570,6 +570,7 @@ impl AppEventUpcaster {
             | AppEvent::DisplayMetrics { .. }
             // Hub-internal: peers see the folded SessionVitals instead.
             | AppEvent::SessionActivity { .. }
+            | AppEvent::SessionConfigFacts { .. }
             | AppEvent::ContextSnapshot { .. }
             | AppEvent::CodexThreadActionRequested { .. }
             | AppEvent::ExternalFollowUpRequested { .. }
@@ -4541,6 +4542,7 @@ mod tests {
             cache: None,
             limits: Vec::new(),
             activity: None,
+            config: None,
         }
     }
 

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -1127,6 +1127,7 @@ pub fn filter_event(event: &AppEvent, last_phase: &mut String) -> Option<Presenc
         | AppEvent::SessionGoal { .. }
         | AppEvent::SessionVitals { .. }
         | AppEvent::SessionActivity { .. }
+        | AppEvent::SessionConfigFacts { .. }
         | AppEvent::SessionRenameResult { .. }
         | AppEvent::SessionAgentConfigResult { .. }
         | AppEvent::ClaudeConfigChanged { .. }

--- a/src/bin/caller/provider/mod.rs
+++ b/src/bin/caller/provider/mod.rs
@@ -363,6 +363,14 @@ pub trait ChatProvider: Send + Sync {
     #[allow(dead_code)]
     fn max_output_tokens(&self) -> u64;
 
+    /// The configured reasoning effort, when this provider instance has
+    /// one (OpenAI reasoning models via `REASONING_EFFORT`). `None` means
+    /// no such setting exists — surfaced as honest absence, never a
+    /// guessed default.
+    fn reasoning_effort(&self) -> Option<String> {
+        None
+    }
+
     /// Whether this provider instance has native tool calling enabled.
     fn use_tools(&self) -> bool {
         false

--- a/src/bin/caller/provider/openai.rs
+++ b/src/bin/caller/provider/openai.rs
@@ -528,6 +528,10 @@ impl ChatProvider for OpenAIProvider {
         self.max_output_tokens
     }
 
+    fn reasoning_effort(&self) -> Option<String> {
+        self.reasoning.as_ref().map(|r| r.effort.clone())
+    }
+
     fn use_tools(&self) -> bool {
         self.use_tools
     }

--- a/src/bin/caller/run_modes.rs
+++ b/src/bin/caller/run_modes.rs
@@ -1605,6 +1605,12 @@ pub(crate) async fn run_with_presence(
                             activity,
                         });
                     }
+                    external_agent::AgentEvent::ConfigFacts { facts } => {
+                        bus.send(AppEvent::SessionConfigFacts {
+                            session_id: session_log_id(&session_log),
+                            facts,
+                        });
+                    }
                     external_agent::AgentEvent::BackendError {
                         message,
                         code,

--- a/src/bin/caller/session_activity.rs
+++ b/src/bin/caller/session_activity.rs
@@ -100,7 +100,6 @@ pub(crate) struct ActivityMachine {
     since_epoch: u64,
     last_stream_byte_epoch: u64,
     delta_heartbeat: bool,
-    effort: Option<String>,
     resets_at_epoch: Option<u64>,
     turn_active: bool,
     /// Short descriptions of the backend-announced background tasks
@@ -113,27 +112,13 @@ pub(crate) struct ActivityMachine {
 }
 
 impl ActivityMachine {
-    pub(crate) fn new(effort: Option<String>) -> Self {
-        Self {
-            effort,
-            ..Self::default()
-        }
-    }
-
-    /// Adopt the backend's own effort echo (first-hand only — callers
-    /// pass values the backend itself stated, or the launch config).
-    pub(crate) fn set_effort(&mut self, effort: Option<String>) {
-        if let Some(effort) = effort
-            .map(|e| e.trim().to_string())
-            .filter(|e| !e.is_empty())
-        {
-            self.effort = Some(effort);
-        }
-    }
-
     /// Feed one wire observation. Returns the snapshot to publish when
-    /// the observable section changed (state/effort/reset flips always;
-    /// pure liveness only per [`HEARTBEAT_QUANTUM_SECS`]).
+    /// the observable section changed (state/reset flips always; pure
+    /// liveness only per [`HEARTBEAT_QUANTUM_SECS`]).
+    ///
+    /// Reasoning effort deliberately does NOT live here: it is a session
+    /// configuration fact, carried by the vitals `config` section
+    /// (`SessionConfigVitals`) — one canonical carrier on the wire.
     pub(crate) fn observe(
         &mut self,
         obs: ActivityObservation,
@@ -274,7 +259,6 @@ impl ActivityMachine {
             since_epoch: self.since_epoch,
             last_stream_byte_epoch: self.last_stream_byte_epoch,
             stalled_after_seconds: stall_armed.then_some(STALL_AFTER_SECS),
-            effort: self.effort.clone(),
             resets_at_epoch: self.resets_at_epoch,
             background_tasks: self.background_tasks.clone(),
         }
@@ -399,14 +383,13 @@ mod tests {
 
     #[test]
     fn dispatch_then_first_bytes_walk_awaiting_reasoning_responding() {
-        let mut m = ActivityMachine::new(Some("max".into()));
+        let mut m = ActivityMachine::default();
         let s = m
             .observe(Obs::TurnDispatched, 100)
             .expect("dispatch publishes");
         assert_eq!(s.state, SessionActivityState::AwaitingApi);
         assert_eq!(s.since_epoch, 100);
         assert_eq!(s.last_stream_byte_epoch, 100);
-        assert_eq!(s.effort.as_deref(), Some("max"));
         assert_eq!(
             s.stalled_after_seconds,
             Some(STALL_AFTER_SECS),
@@ -447,7 +430,7 @@ mod tests {
 
     #[test]
     fn thinking_requires_recent_deltas_quiet_degrades_to_stalled() {
-        let mut m = ActivityMachine::new(None);
+        let mut m = ActivityMachine::default();
         m.observe(Obs::TurnDispatched, 100);
         m.observe(
             Obs::ReasoningStarted {
@@ -477,7 +460,7 @@ mod tests {
     fn deltaless_reasoning_never_claims_stalled_or_heartbeat() {
         // Codex shape: reasoning items open on the wire but promise no
         // mid-item bytes — quiet is normal, stalled must not be claimed.
-        let mut m = ActivityMachine::new(Some("high".into()));
+        let mut m = ActivityMachine::default();
         m.observe(Obs::TurnDispatched, 100);
         let s = m
             .observe(
@@ -501,7 +484,7 @@ mod tests {
 
     #[test]
     fn awaiting_api_stalls_but_tools_never_do() {
-        let mut m = ActivityMachine::new(None);
+        let mut m = ActivityMachine::default();
         m.observe(Obs::TurnDispatched, 100);
         assert_eq!(
             m.effective_state(100 + u64::from(STALL_AFTER_SECS) + 1),
@@ -526,7 +509,7 @@ mod tests {
 
     #[test]
     fn rate_limited_carries_reset_and_clears_to_awaiting() {
-        let mut m = ActivityMachine::new(None);
+        let mut m = ActivityMachine::default();
         m.observe(Obs::TurnDispatched, 100);
         let s = m
             .observe(
@@ -561,7 +544,7 @@ mod tests {
 
     #[test]
     fn turn_settled_goes_idle_and_ambient_bytes_stay_idle() {
-        let mut m = ActivityMachine::new(None);
+        let mut m = ActivityMachine::default();
         m.observe(Obs::TurnDispatched, 100);
         m.observe(Obs::ResponseDelta, 101);
         let s = m.observe(Obs::TurnSettled, 150).expect("idle publishes");
@@ -593,7 +576,7 @@ mod tests {
 
     #[test]
     fn turn_settled_with_armed_tasks_parks_then_drains_to_idle() {
-        let mut m = ActivityMachine::new(None);
+        let mut m = ActivityMachine::default();
         m.observe(Obs::TurnDispatched, 100);
         m.observe(Obs::ToolsRunning, 101);
         // The backend announced a background task mid-turn: carried data,
@@ -634,7 +617,7 @@ mod tests {
 
     #[test]
     fn woken_by_task_reopens_the_turn_and_resettles_parked_while_armed() {
-        let mut m = ActivityMachine::new(None);
+        let mut m = ActivityMachine::default();
         m.observe(Obs::TurnDispatched, 100);
         m.observe(
             Obs::BackgroundTasksChanged {
@@ -677,7 +660,7 @@ mod tests {
 
     #[test]
     fn heartbeat_publishing_is_quantized() {
-        let mut m = ActivityMachine::new(None);
+        let mut m = ActivityMachine::default();
         m.observe(Obs::TurnDispatched, 100);
         m.observe(Obs::ResponseDelta, 100);
         // A flood of deltas inside one quantum publishes nothing new.
@@ -691,28 +674,8 @@ mod tests {
     }
 
     #[test]
-    fn effort_prefers_backend_echo_and_never_blanks() {
-        let mut m = ActivityMachine::new(Some("medium".into()));
-        assert_eq!(m.snapshot().effort.as_deref(), Some("medium"));
-        // Backend echo upgrades the launch value…
-        m.set_effort(Some("xhigh".into()));
-        assert_eq!(m.snapshot().effort.as_deref(), Some("xhigh"));
-        // …but an absent/blank echo never blanks a known value.
-        m.set_effort(None);
-        m.set_effort(Some("  ".into()));
-        assert_eq!(m.snapshot().effort.as_deref(), Some("xhigh"));
-        // Effort changes publish even without a state change.
-        m.observe(Obs::TurnDispatched, 100);
-        m.set_effort(Some("low".into()));
-        let s = m
-            .observe(Obs::StreamByte, 101)
-            .expect("effort change publishes");
-        assert_eq!(s.effort.as_deref(), Some("low"));
-    }
-
-    #[test]
     fn idle_machine_publishes_nothing_until_first_turn() {
-        let mut m = ActivityMachine::new(None);
+        let mut m = ActivityMachine::default();
         assert!(m.observe(Obs::StreamByte, 50).is_none());
         assert!(
             m.observe(Obs::TurnSettled, 60).is_none(),
@@ -729,7 +692,6 @@ mod tests {
             since_epoch: 1,
             last_stream_byte_epoch: 2,
             stalled_after_seconds: Some(20),
-            effort: Some("high".into()),
             resets_at_epoch: None,
             background_tasks: vec!["cargo test".into()],
         };

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -41,7 +41,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use crate::event::{AppEvent, EventBus};
 use crate::frontend::ModelUsageSnapshot;
-use crate::types::{SessionCacheVitals, SessionGitVitals, SessionVitals};
+use crate::types::{SessionCacheVitals, SessionConfigVitals, SessionGitVitals, SessionVitals};
 
 /// Probe cadence. Each tick is a handful of subprocess ref reads per
 /// target; emission only happens when the probed state changes.
@@ -331,6 +331,9 @@ impl SessionVitalsHub {
                 if vitals.activity.is_none() {
                     vitals.activity = orphan.activity;
                 }
+                if vitals.config.is_none() {
+                    vitals.config = orphan.config;
+                }
             });
         }
     }
@@ -347,6 +350,59 @@ impl SessionVitalsHub {
         if let Some(vitals) = changed {
             self.bus
                 .send(AppEvent::SessionVitals { session_id, vitals });
+        }
+    }
+
+    /// Fold a partial config-facts emission into a session's `config`
+    /// section, sticky per field: producers emit what a protocol seam just
+    /// taught them (launch snapshot, a model echo, an accepted mode
+    /// switch), and a known value is never blanked by a later partial
+    /// that omits it. The permission fields travel as one datum — a mode
+    /// update carries its display kind and echo provenance with it.
+    fn apply_config_facts(&self, session_id: &str, update: SessionConfigVitals) {
+        if update == SessionConfigVitals::default() {
+            return;
+        }
+        self.apply(session_id, |vitals| {
+            let config = vitals.config.get_or_insert_with(Default::default);
+            if update.model.is_some() {
+                config.model = update.model;
+            }
+            if update.effort.is_some() {
+                config.effort = update.effort;
+            }
+            if update.permission_mode.is_some() {
+                config.permission_mode = update.permission_mode;
+                config.permission_kind = update.permission_kind;
+                config.permission_echoed = update.permission_echoed;
+            }
+        });
+    }
+
+    /// The daemon-global autonomy level changed: update every session
+    /// whose permission facts are autonomy-backed (native sessions —
+    /// external backends carry their own modes). The level is shared
+    /// state, so this fold is exact, not a heuristic.
+    fn apply_autonomy_change(&self, level: &str) {
+        let autonomy_sessions: Vec<String> = {
+            let sessions = self.sessions.lock().expect("vitals state lock");
+            sessions
+                .iter()
+                .filter(|(_, vitals)| {
+                    vitals.config.as_ref().is_some_and(|config| {
+                        config.permission_kind.as_deref()
+                            == Some(intendant_core::vitals::PERMISSION_KIND_AUTONOMY)
+                    })
+                })
+                .map(|(id, _)| id.clone())
+                .collect()
+        };
+        for session_id in autonomy_sessions {
+            self.apply(&session_id, |vitals| {
+                if let Some(config) = vitals.config.as_mut() {
+                    config.permission_mode = Some(level.to_string());
+                }
+            });
         }
     }
 
@@ -449,6 +505,16 @@ fn spawn_cache_vitals_listener(
                     activity,
                 }) => {
                     hub.apply(&session_id, |vitals| vitals.activity = Some(activity));
+                }
+                Ok(AppEvent::SessionConfigFacts {
+                    session_id: Some(session_id),
+                    facts,
+                }) => hub.apply_config_facts(&session_id, facts),
+                // The autonomy level is daemon-global shared state; the
+                // fold updates every autonomy-backed config section so a
+                // Control-tab change shows up mid-session.
+                Ok(AppEvent::AutonomyChanged { autonomy }) => {
+                    hub.apply_autonomy_change(&autonomy);
                 }
                 Ok(AppEvent::SessionIdentity {
                     session_id,
@@ -1062,6 +1128,127 @@ mod tests {
         assert!(
             emissions[2].1.cache.is_none(),
             "removed session re-registers from scratch"
+        );
+    }
+
+    /// The config-facts fold is sticky per field: partial emissions from
+    /// different protocol seams (launch snapshot, model echo, mode
+    /// switch) accumulate instead of blanking each other, the permission
+    /// fields travel as one datum, and a mid-session autonomy change
+    /// updates exactly the autonomy-backed sections.
+    #[tokio::test]
+    async fn config_facts_fold_sticky_and_autonomy_change_scoped() {
+        let bus = EventBus::new();
+        let mut rx = bus.subscribe();
+        let hub = SessionVitalsHub::new(bus.clone());
+        let _listener = spawn_cache_vitals_listener(bus.clone(), hub.clone());
+
+        let deadline = std::time::Duration::from_secs(5);
+        async fn wait_config(
+            rx: &mut tokio::sync::broadcast::Receiver<AppEvent>,
+        ) -> (String, SessionConfigVitals) {
+            loop {
+                if let Ok(AppEvent::SessionVitals { session_id, vitals }) = rx.recv().await {
+                    if let Some(config) = vitals.config {
+                        return (session_id, config);
+                    }
+                }
+            }
+        }
+
+        // Launch snapshot: unconfirmed mode + configured effort.
+        bus.send(AppEvent::SessionConfigFacts {
+            session_id: Some("cc-1".into()),
+            facts: SessionConfigVitals {
+                model: Some("claude-fable-5".into()),
+                effort: Some("max".into()),
+                permission_mode: Some("bypassPermissions".into()),
+                permission_kind: Some("bypass".into()),
+                permission_echoed: false,
+            },
+        });
+        let (sid, config) = tokio::time::timeout(deadline, wait_config(&mut rx))
+            .await
+            .expect("launch facts emit");
+        assert_eq!(sid, "cc-1");
+        assert_eq!(config.model.as_deref(), Some("claude-fable-5"));
+        assert!(!config.permission_echoed);
+
+        // Init mode echo: partial — model/effort must survive the fold.
+        bus.send(AppEvent::SessionConfigFacts {
+            session_id: Some("cc-1".into()),
+            facts: SessionConfigVitals {
+                permission_mode: Some("bypassPermissions".into()),
+                permission_kind: Some("bypass".into()),
+                permission_echoed: true,
+                ..Default::default()
+            },
+        });
+        let (_, config) = tokio::time::timeout(deadline, wait_config(&mut rx))
+            .await
+            .expect("echo upgrade emits");
+        assert!(config.permission_echoed, "echo provenance upgraded");
+        assert_eq!(
+            config.model.as_deref(),
+            Some("claude-fable-5"),
+            "partial mode echo must not blank the model"
+        );
+        assert_eq!(config.effort.as_deref(), Some("max"));
+
+        // A native session with autonomy-backed permissions, plus the CC
+        // session above: an autonomy change updates only the former.
+        bus.send(AppEvent::SessionConfigFacts {
+            session_id: Some("native-loop".into()),
+            facts: SessionConfigVitals {
+                model: Some("gpt-5.5".into()),
+                permission_mode: Some("Medium".into()),
+                permission_kind: Some(
+                    intendant_core::vitals::PERMISSION_KIND_AUTONOMY.to_string(),
+                ),
+                permission_echoed: true,
+                ..Default::default()
+            },
+        });
+        let (sid, _) = tokio::time::timeout(deadline, wait_config(&mut rx))
+            .await
+            .expect("native facts emit");
+        assert_eq!(sid, "native-loop");
+
+        bus.send(AppEvent::AutonomyChanged {
+            autonomy: "Full".into(),
+        });
+        let (sid, config) = tokio::time::timeout(deadline, wait_config(&mut rx))
+            .await
+            .expect("autonomy fold emits");
+        assert_eq!(sid, "native-loop", "only the autonomy-backed session updates");
+        assert_eq!(config.permission_mode.as_deref(), Some("Full"));
+        assert_eq!(
+            config.permission_kind.as_deref(),
+            Some(intendant_core::vitals::PERMISSION_KIND_AUTONOMY)
+        );
+
+        // The CC session's mode is untouched (no further cc-1 emission —
+        // the autonomy fold matched nothing there, so nothing changed).
+        let cc = hub
+            .sessions
+            .lock()
+            .expect("vitals state lock")
+            .get("cc-1")
+            .cloned()
+            .expect("cc entry");
+        assert_eq!(
+            cc.config.as_ref().and_then(|c| c.permission_mode.as_deref()),
+            Some("bypassPermissions")
+        );
+
+        // An all-empty facts emission is a no-op, never an empty section.
+        hub.apply_config_facts("fresh", SessionConfigVitals::default());
+        assert!(
+            !hub.sessions
+                .lock()
+                .expect("vitals state lock")
+                .contains_key("fresh"),
+            "empty facts must not materialize an entry"
         );
     }
 
@@ -1734,7 +1921,6 @@ mod tests {
             since_epoch: 100,
             last_stream_byte_epoch: 104,
             stalled_after_seconds: Some(20),
-            effort: Some("max".into()),
             ..Default::default()
         };
         bus.send(AppEvent::SessionActivity {
@@ -1846,6 +2032,8 @@ mod tests {
         for key in [
             "health:",
             "activity:",
+            "model:",
+            "permissions:",
             "branch:",
             "worktree:",
             "dirty:",
@@ -1860,8 +2048,8 @@ mod tests {
             assert!(catalog.contains(key), "catalog lost symbol {key}");
         }
         // The serde-camelCase wire fields of SessionVitals/SessionGitVitals/
-        // SessionCacheVitals/SessionLimitWindow/SessionActivityVitals the
-        // catalog must consume.
+        // SessionCacheVitals/SessionLimitWindow/SessionActivityVitals/
+        // SessionConfigVitals the catalog must consume.
         for field in [
             "branch",
             "dirtyFiles",
@@ -1884,10 +2072,23 @@ mod tests {
             "stalledAfterSeconds",
             "effort",
             "backgroundTasks",
+            "model",
+            "permissionMode",
+            "permissionKind",
+            "permissionEchoed",
         ] {
             assert!(
                 catalog.contains(field),
                 "catalog stopped consuming wire field {field} — SessionVitals and VITALS_SYMBOLS drifted"
+            );
+        }
+        // The permission display kinds (the daemon-side catalog in
+        // intendant-core vitals.rs) must each have plain-language copy in
+        // the frontend catalog — one vocabulary, two responsibilities.
+        for kind in intendant_core::vitals::PERMISSION_DISPLAY_KINDS {
+            assert!(
+                catalog.contains(kind),
+                "catalog lost permission display kind {kind} — extend PERMISSION_KIND_COPY alongside PERMISSION_DISPLAY_KINDS"
             );
         }
         // The wire spellings of the activity states the catalog renders —

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -1202,9 +1202,7 @@ mod tests {
             facts: SessionConfigVitals {
                 model: Some("gpt-5.5".into()),
                 permission_mode: Some("Medium".into()),
-                permission_kind: Some(
-                    intendant_core::vitals::PERMISSION_KIND_AUTONOMY.to_string(),
-                ),
+                permission_kind: Some(intendant_core::vitals::PERMISSION_KIND_AUTONOMY.to_string()),
                 permission_echoed: true,
                 ..Default::default()
             },
@@ -1220,7 +1218,10 @@ mod tests {
         let (sid, config) = tokio::time::timeout(deadline, wait_config(&mut rx))
             .await
             .expect("autonomy fold emits");
-        assert_eq!(sid, "native-loop", "only the autonomy-backed session updates");
+        assert_eq!(
+            sid, "native-loop",
+            "only the autonomy-backed session updates"
+        );
         assert_eq!(config.permission_mode.as_deref(), Some("Full"));
         assert_eq!(
             config.permission_kind.as_deref(),
@@ -1237,7 +1238,9 @@ mod tests {
             .cloned()
             .expect("cc entry");
         assert_eq!(
-            cc.config.as_ref().and_then(|c| c.permission_mode.as_deref()),
+            cc.config
+                .as_ref()
+                .and_then(|c| c.permission_mode.as_deref()),
             Some("bypassPermissions")
         );
 

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -3417,6 +3417,12 @@ pub(crate) fn handle_idle_codex_subagent_event(
                 activity,
             });
         }
+        external_agent::AgentEvent::ConfigFacts { facts } => {
+            config.bus.send(AppEvent::SessionConfigFacts {
+                session_id,
+                facts,
+            });
+        }
         external_agent::AgentEvent::GoalUpdated { goal } => {
             emit_external_session_goal(config, Some(child_thread_id), Some(goal));
         }

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -3418,10 +3418,9 @@ pub(crate) fn handle_idle_codex_subagent_event(
             });
         }
         external_agent::AgentEvent::ConfigFacts { facts } => {
-            config.bus.send(AppEvent::SessionConfigFacts {
-                session_id,
-                facts,
-            });
+            config
+                .bus
+                .send(AppEvent::SessionConfigFacts { session_id, facts });
         }
         external_agent::AgentEvent::GoalUpdated { goal } => {
             emit_external_session_goal(config, Some(child_thread_id), Some(goal));

--- a/src/bin/caller/types.rs
+++ b/src/bin/caller/types.rs
@@ -134,8 +134,8 @@ pub struct SessionGoal {
 // Session-vitals family: hoisted to intendant-core; re-exported here so
 // existing `crate::types::Session*Vitals` paths keep working.
 pub use intendant_core::vitals::{
-    SessionActivityState, SessionActivityVitals, SessionCacheVitals, SessionGitVitals,
-    SessionLimitWindow, SessionVitals,
+    SessionActivityState, SessionActivityVitals, SessionCacheVitals, SessionConfigVitals,
+    SessionGitVitals, SessionLimitWindow, SessionVitals,
 };
 
 /// Normalized region in a shared display view.

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -1082,15 +1082,19 @@ const VITALS_SYMBOLS = {
     label: 'Model',
     priority: 28,
     unavailable: 'Not reported yet — appears once the agent names its model (or its launch settings do).',
-    chip: (v) => `⬡ ${v.shortName}${v.effort ? ` · ${v.effort}` : ''}`,
+    chip: (v) => (v.shortName
+      ? `⬡ ${v.shortName}${v.effort ? ` · ${v.effort}` : ''}`
+      : `⬡ ${v.effort} effort`),
     explain: (v) => {
-      const lines = [`This session runs on ${v.model}.`];
+      const lines = [v.model
+        ? `This session runs on ${v.model}.`
+        : "The agent hasn't named its model yet — it runs on its own default."];
       if (v.effort) {
         lines.push(`Reasoning effort is set to “${v.effort}” — how hard the model may think before answering. A setting, not a measurement.`);
       }
       return lines;
     },
-    action: (v) => ({ label: 'Copy model id', run: () => vitalsCopyText(v.model) }),
+    action: (v) => (v.model ? { label: 'Copy model id', run: () => vitalsCopyText(v.model) } : null),
   },
   permissions: {
     label: 'Permissions',
@@ -1357,8 +1361,8 @@ function vitalsChipModels(vitals, meta, sessionId) {
     const model = String(facts.model || '').trim();
     if (model || factsEffort) {
       push('model', 'model', {
-        model: model || 'not reported',
-        shortName: vitalsModelShortName(model) || 'model',
+        model,
+        shortName: vitalsModelShortName(model),
         effort: factsEffort,
       });
     }

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -777,12 +777,14 @@ function vitalsLimitLabelLong(label) {
 // Live activity — the honest "is the model actually doing something right
 // now" signal. Raw state + epochs arrive on the wire (the vitals
 // `activity` section: state, sinceEpoch, lastStreamByteEpoch,
-// stalledAfterSeconds, effort, resetsAtEpoch); elapsed and quiet tick
+// stalledAfterSeconds, resetsAtEpoch); elapsed and quiet tick
 // client-side, and the `stalled` state is DERIVED here with the same rule
 // the daemon's state machine exposes: a state that promises a live byte
 // stream (stalledAfterSeconds present) quiet past its threshold. States
 // without that promise — tool runs, backends that don't stream reasoning
-// — never claim stalled: honest silence over a fake alarm.
+// — never claim stalled: honest silence over a fake alarm. (Reasoning
+// effort is a session-config fact — the vitals `config` section — not an
+// activity claim.)
 function deriveSessionActivity(activity, nowSec = Date.now() / 1000) {
   if (!activity || typeof activity !== 'object') return null;
   const state = String(activity.state || 'idle').trim();
@@ -798,7 +800,6 @@ function deriveSessionActivity(activity, nowSec = Date.now() / 1000) {
     elapsed: since ? Math.max(0, nowSec - since) : 0,
     quiet,
     hasHeartbeat: threshold > 0,
-    effort: String(activity.effort || '').trim(),
     resetsAtEpoch: Number(activity.resetsAtEpoch) || 0,
     // Short descriptions of wire-announced background tasks still running
     // (grounds the parked-on-tasks claim; may ride any state). No
@@ -816,6 +817,14 @@ function sessionWireActivity(sessionId) {
   const meta = sessionMetadataById.get(String(sessionId || '').trim()) || {};
   const activity = meta.vitals && typeof meta.vitals === 'object' ? meta.vitals.activity : null;
   return activity && typeof activity === 'object' ? activity : null;
+}
+
+// Configured reasoning effort from the session-facts section (wire
+// `config.effort`) — decorates the status pill's "Thinking" label.
+function sessionConfigEffort(sessionId) {
+  const meta = sessionMetadataById.get(String(sessionId || '').trim()) || {};
+  const config = meta.vitals && typeof meta.vitals === 'object' ? meta.vitals.config : null;
+  return config && typeof config === 'object' ? String(config.effort || '').trim() : '';
 }
 
 const ACTIVITY_STATE_LABELS = {
@@ -842,6 +851,92 @@ function formatActivityElapsed(seconds) {
   if (s >= 3600) return `${Math.floor(s / 3600)}h${String(Math.floor((s % 3600) / 60)).padStart(2, '0')}m`;
   if (s >= 60) return `${Math.floor(s / 60)}m${String(s % 60).padStart(2, '0')}s`;
   return `${s}s`;
+}
+
+// Plain-language copy for the backend-agnostic permission display kinds
+// (wire `config.permissionKind` — computed once daemon-side from each
+// backend's raw mode by the intendant-core vitals catalog; pinned both
+// ways by vitals_symbol_catalog_covers_wire_fields). The raw mode is
+// always one tap away in the explainer — never hidden, never replaced.
+// `tone: 'warn'` is a cosmetic tint (a chosen configuration, not a
+// failure): it never elevates the chip or colors the health dot.
+// Kinds: bypass, auto-edits, auto-safe, auto-sandboxed, ask, deny-asks,
+// read-only, plan, autonomy (native — label from UI2_AUTONOMY_TAGS).
+const PERMISSION_KIND_COPY = {
+  bypass: {
+    label: 'Acts without asking',
+    tone: 'warn',
+    lines: ['This agent can edit files and run commands without asking first.'],
+  },
+  'auto-edits': {
+    label: 'Auto-accepts edits',
+    lines: ['File edits apply without asking; commands still ask for approval.'],
+  },
+  'auto-safe': {
+    label: 'Auto-approves safe actions',
+    lines: ['Actions judged safe run without asking; riskier ones still ask.'],
+  },
+  'auto-sandboxed': {
+    label: 'Works alone in its sandbox',
+    lines: ['Edits files and runs commands inside its own workspace without asking; asks before reaching outside it.'],
+  },
+  ask: {
+    label: 'Asks before acting',
+    lines: ['Commands and file changes wait for your approval.'],
+  },
+  'deny-asks': {
+    label: 'Never asks — declines instead',
+    lines: ['Anything that would need an approval is declined automatically instead of asking you.'],
+  },
+  'read-only': {
+    label: 'Read-only',
+    lines: ['Reads the project but asks before changing anything.'],
+  },
+  plan: {
+    label: 'Plan mode',
+    lines: ['Researching and planning only — no edits or commands until a plan is approved.'],
+  },
+};
+
+// Resolve a permission kind + raw mode into display copy. `autonomy` is
+// the native backend: the label reuses the sidebar's autonomy vocabulary
+// ("Medium · gate writes"), and the ungated Full level gets the same
+// quiet warning tint as bypass. Unknown kinds show the raw mode verbatim
+// — honest passthrough, never a guessed plain-language claim.
+function permissionDisplay(kind, mode) {
+  if (kind === 'autonomy') {
+    const tag = UI2_AUTONOMY_TAGS[mode] || '';
+    return {
+      label: tag ? `${mode} · ${tag}` : mode,
+      tone: mode === 'Full' ? 'warn' : '',
+      lines: [
+        tag
+          ? `Intendant's autonomy level for this session is ${mode} — ${tag}.`
+          : `Intendant's autonomy level for this session is ${mode}.`,
+        mode === 'Full'
+          ? 'This agent can edit files and run commands without asking first.'
+          : 'The autonomy level decides which actions need your approval.',
+      ],
+    };
+  }
+  const copy = PERMISSION_KIND_COPY[kind];
+  if (copy) return { label: copy.label, tone: copy.tone || '', lines: copy.lines };
+  return {
+    label: mode,
+    tone: '',
+    lines: [`This agent reports permission mode “${mode}” — a mode this dashboard doesn't have plain words for yet.`],
+  };
+}
+
+// Display compression for model ids in chip grammar: drop a vendor
+// prefix and a trailing release date ("claude-sonnet-4-5-20250929" →
+// "sonnet-4-5"). Compression only, never truncation — the pane and the
+// explainer always carry the full id.
+function vitalsModelShortName(model) {
+  const raw = String(model || '').trim();
+  if (!raw) return '';
+  let short = raw.replace(/^claude-/, '').replace(/-\d{8}$/, '');
+  return short || raw;
 }
 
 const VITALS_SYMBOLS = {
@@ -931,6 +1026,39 @@ const VITALS_SYMBOLS = {
       if (v.state === 'rate-limited') return `Rate-limited${v.reset ? ` — resets in ~${v.reset}` : ''}`;
       if (v.state === 'stalled') return `Model stalled — nothing received for ${v.quietText}`;
       return '';
+    },
+  },
+  // ── Session facts (wire `config` section: model, effort,
+  // permissionMode + permissionKind + permissionEchoed). Wire-first: the
+  // backend's own echoes where the protocol has them, the launch config
+  // otherwise — and the explainer says which. Quiet chips: they live in
+  // the expanded header and the pane, never the collapsed one-liner.
+  model: {
+    label: 'Model',
+    priority: 28,
+    unavailable: 'Not reported yet — appears once the agent names its model (or its launch settings do).',
+    chip: (v) => `⬡ ${v.shortName}${v.effort ? ` · ${v.effort}` : ''}`,
+    explain: (v) => {
+      const lines = [`This session runs on ${v.model}.`];
+      if (v.effort) {
+        lines.push(`Reasoning effort is set to “${v.effort}” — how hard the model may think before answering. A setting, not a measurement.`);
+      }
+      return lines;
+    },
+    action: (v) => ({ label: 'Copy model id', run: () => vitalsCopyText(v.model) }),
+  },
+  permissions: {
+    label: 'Permissions',
+    priority: 55,
+    unavailable: 'Not reported yet — appears once the agent (or its launch settings) states a permission mode.',
+    chip: (v) => `🛡 ${v.label}`,
+    explain: (v) => {
+      const lines = [...v.lines];
+      lines.push(`In the agent's own vocabulary: “${v.mode}”.`);
+      if (!v.echoed) {
+        lines.push("This is the launch setting — the agent hasn't confirmed it yet.");
+      }
+      return lines;
     },
   },
   worktree: {
@@ -1070,9 +1198,12 @@ const VITALS_SYMBOLS = {
 
 // Fixed display order for chips and the glossary (semantic, not priority:
 // priority only governs which chips stay visible when space is scarce).
+// model + permissions form the session-facts group, right after the live
+// activity signal.
 const VITALS_SYMBOL_ORDER = [
-  'health', 'activity', 'worktree', 'branch', 'dirty', 'divergence', 'parity',
-  'unpushed', 'primary-unpushed', 'cache-hit', 'cache-ttl', 'limit',
+  'health', 'activity', 'model', 'permissions', 'worktree', 'branch', 'dirty',
+  'divergence', 'parity', 'unpushed', 'primary-unpushed', 'cache-hit',
+  'cache-ttl', 'limit',
 ];
 
 // Seconds until the prompt cache goes cold, from the server-stamped
@@ -1146,11 +1277,16 @@ function vitalsChipModels(vitals, meta, sessionId) {
     });
   };
 
+  // Session facts (the `config` section). The configured effort also
+  // decorates the live thinking chip — one wire carrier, two readouts.
+  const facts = vitals?.config && typeof vitals.config === 'object' ? vitals.config : null;
+  const factsEffort = String(facts?.effort || '').trim();
+
   const act = deriveSessionActivity(vitals?.activity);
   if (act) {
     push('activity', 'activity', {
       state: act.state,
-      effort: act.effort,
+      effort: factsEffort,
       hasHeartbeat: act.hasHeartbeat,
       elapsedText: formatActivityElapsed(act.elapsed),
       quietText: formatActivityElapsed(act.quiet),
@@ -1164,8 +1300,35 @@ function vitalsChipModels(vitals, meta, sessionId) {
       // something other than the model's own work".
       severity: act.state === 'stalled' || act.state === 'rate-limited' ? 'warn' : '',
       ticking: true,
-      sig: `${act.state}|${act.effort}|${act.hasHeartbeat ? 1 : 0}|${act.backgroundTasks.join(';')}`,
+      sig: `${act.state}|${factsEffort}|${act.hasHeartbeat ? 1 : 0}|${act.backgroundTasks.join(';')}`,
     });
+  }
+
+  if (facts) {
+    const model = String(facts.model || '').trim();
+    if (model || factsEffort) {
+      push('model', 'model', {
+        model: model || 'not reported',
+        shortName: vitalsModelShortName(model) || 'model',
+        effort: factsEffort,
+      });
+    }
+    const mode = String(facts.permissionMode || '').trim();
+    if (mode) {
+      const display = permissionDisplay(String(facts.permissionKind || '').trim(), mode);
+      push('permissions', 'permissions', {
+        label: display.label,
+        lines: display.lines,
+        mode,
+        echoed: facts.permissionEchoed === true,
+      }, {
+        // Cosmetic tint only: a chosen bypass/ungated configuration is
+        // worth noticing, but it is not a failure — no health-dot
+        // severity, no elevation into the collapsed header.
+        severity: '',
+        tone: display.tone || '',
+      });
+    }
   }
 
   const worktree = meta?.worktree && typeof meta.worktree === 'object' ? meta.worktree : null;
@@ -1867,8 +2030,9 @@ function normalizeSessionVitals(raw) {
   const cache = src.cache && typeof src.cache === 'object' ? src.cache : null;
   const limits = Array.isArray(src.limits) ? src.limits : [];
   const activity = src.activity && typeof src.activity === 'object' ? src.activity : null;
-  if (!git && !cache && !limits.length && !activity) return null;
-  return { git, cache, limits, activity };
+  const config = src.config && typeof src.config === 'object' ? src.config : null;
+  if (!git && !cache && !limits.length && !activity && !config) return null;
+  return { git, cache, limits, activity, config };
 }
 
 // Merge an arriving vitals snapshot over what a session already has. A
@@ -1886,6 +2050,7 @@ function mergeSessionVitals(incoming, existing) {
     cache: incoming.cache || existing.cache || null,
     limits: incoming.limits?.length ? incoming.limits : existing.limits || [],
     activity: incoming.activity || existing.activity || null,
+    config: incoming.config || existing.config || null,
   };
 }
 
@@ -1915,7 +2080,7 @@ function applySessionVitals(raw = {}) {
 function maybeRefreshSessionWindowActivityPill(sid, win, vitals) {
   if (!win || !win.phase || typeof applySessionWindowPhase !== 'function') return;
   const act = deriveSessionActivity(vitals?.activity);
-  const key = act ? `${act.state}|${act.effort}|${act.backgroundTasks.length}` : '';
+  const key = act ? `${act.state}|${act.backgroundTasks.length}` : '';
   if (win.activityPillKey === key) return;
   win.activityPillKey = key;
   applySessionWindowPhase(win, sid, win.phase);

--- a/static/app/41-session-window-actions.js
+++ b/static/app/41-session-window-actions.js
@@ -468,7 +468,10 @@ function sessionWindowPhaseDisplayLabel(sessionId, phase) {
       }
       const label = (typeof ACTIVITY_STATE_LABELS === 'object' && ACTIVITY_STATE_LABELS[act.state])
         || act.state;
-      return act.state === 'reasoning' && act.effort ? `${label} (${act.effort})` : label;
+      // Effort is a session-config fact (vitals `config` section), not an
+      // activity claim — fetch it from the facts when decorating.
+      const effort = typeof sessionConfigEffort === 'function' ? sessionConfigEffort(sessionId) : '';
+      return act.state === 'reasoning' && effort ? `${label} (${effort})` : label;
     }
   }
   return sessionPhaseLabel(phase);


### PR DESCRIPTION
Per-session visibility of permission mode, model, and reasoning effort across all three backends (Claude Code, Codex, native), wire-first.

## What
- New `config` section on `SessionVitals` (`{model, effort, permissionMode, permissionKind, permissionEchoed}`), folded sticky per field by the vitals hub; one canonical effort carrier (moved out of the activity section).
- Backend sources: CC `system:init` echo (the effective truth) + `message_start` model changes + status-channel mode echoes + launch config marked unconfirmed; Codex launch config on thread acceptance + `thread/settings/updated` echoes; native provider selection + autonomy level, with mid-session `AutonomyChanged` folds.
- One permission-kind catalog in intendant-core (claude modes, codex approval+sandbox grid, native autonomy); the dashboard keys plain-language copy off the kinds, raw mode always one tap away.
- Dashboard: Model / Permissions rows in the vitals pane for every backend (honest degraded copy when unreported), compact chips in the expanded header only, quiet warning tint for bypass/ungated modes.

## Tests
- Kind-catalog mapping tests (every known mode + unknown passthrough) in intendant-core.
- Adapter-level: CC init/status/message_start line-shape tests; codex thread-settings echo tests.
- Hub: sticky per-field fold, autonomy-change scoping, identity-alias fold extension.
- VITALS_SYMBOLS parity test extended (new symbols, wire fields, and the kind vocabulary pinned both ways).