### PR TITLE
agent_loop: drop corpse-watcher steer duplicates at the sweep

### DIFF
--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -893,6 +893,21 @@ pub(crate) async fn run_agent_loop(
                         text,
                         id,
                     }) if event_targets_session(&session_id, &watcher_session_id) => {
+                        // The round exit cancels this token BEFORE aborting
+                        // the watcher (see InterruptGuard::drop): abort only
+                        // lands at the next yield, so a watcher mid-poll
+                        // outlives it and keeps draining broadcast backlog.
+                        // Such a corpse must not ack a steer it can no longer
+                        // deliver — the parked drain / supervisor fallback
+                        // own steers once the round is over. TOCTOU caveat:
+                        // the corpse can pass this check, get descheduled,
+                        // and still push after cancellation — this gate only
+                        // narrows the window; the round loop's delivered-id
+                        // dedup at the orphan sweep is the serialized layer
+                        // that closes it.
+                        if watcher_token.is_cancelled() {
+                            break;
+                        }
                         // Queue the steer for the next turn's drain. The
                         // native loop has no separate "mid-turn inject"
                         // hook — model calls are atomic — so acceptance and
@@ -951,9 +966,17 @@ pub(crate) async fn run_agent_loop(
     // approvals with Deny if the exit path was interrupt-driven.
     struct InterruptGuard {
         watcher: Option<tokio::task::JoinHandle<()>>,
+        token: tokio_util::sync::CancellationToken,
     }
     impl Drop for InterruptGuard {
         fn drop(&mut self) {
+            // Cancel BEFORE aborting: abort() only takes effect at the
+            // task's next yield, so a watcher mid-poll survives it and
+            // keeps consuming broadcast backlog. The cancelled token is
+            // what tells that corpse to stop acking/queueing steers the
+            // finished round can no longer deliver (the SteerRequested
+            // arm gates on it).
+            self.token.cancel();
             if let Some(h) = self.watcher.take() {
                 h.abort();
             }
@@ -961,6 +984,7 @@ pub(crate) async fn run_agent_loop(
     }
     let _guard = InterruptGuard {
         watcher: Some(cancel_watcher_handle),
+        token: cancel_token.clone(),
     };
 
     for turn in 1..=SAFETY_CAP {
@@ -2764,6 +2788,31 @@ fn claim_steer_injections(
     claimed
 }
 
+/// Split claimed steer injections into deliverable ones and duplicates of
+/// steers this round loop already consumed as a round/follow-up (returned
+/// as `(kept, dropped)`).
+///
+/// A dying round's watcher can outlive its abort mid-poll and push + ack a
+/// steer AFTER every same-id claim has fired; the orphan sweep would then
+/// resurrect that push as a spurious extra round — the same user steer
+/// executing twice. The sweep runs on the round loop's own task, serialized
+/// with actual delivery, so the delivered-id check here is race-free where
+/// the claims are not. Dedup is strictly by id, never by text — the same
+/// text sent twice is two steers with two ids and must deliver twice; ids
+/// that are empty/whitespace can't be correlated and are always kept.
+fn split_already_delivered_steer_injections(
+    delivered_steer_ids: &HashSet<String>,
+    injections: Vec<event::ContextInjection>,
+) -> (Vec<event::ContextInjection>, Vec<event::ContextInjection>) {
+    injections.into_iter().partition(|injection| {
+        !injection
+            .steer_id
+            .as_deref()
+            .filter(|id| !id.trim().is_empty())
+            .is_some_and(|id| delivered_steer_ids.contains(id))
+    })
+}
+
 /// The parked drain's exit when a steer reaches a between-rounds session:
 /// the synthesized next-round follow-up plus the acceptance the steer
 /// protocol expects (empty ids skip the ack — nothing correlates on "").
@@ -2818,6 +2867,11 @@ pub(crate) async fn run_round_loop(
     // History lookup; round numbers are the ones RoundComplete broadcast).
     let mut round_ledger: Vec<(usize, u32)> = Vec::new();
     let mut cancelled_follow_ups: HashSet<String> = HashSet::new();
+    // Ids of steers this loop already consumed as a round/follow-up. The
+    // orphan sweep consults it (split_already_delivered_steer_injections)
+    // so a dying watcher's late push cannot resurrect a delivered steer as
+    // an extra round. Grows one small id per steer, like round_ledger.
+    let mut delivered_steer_ids: HashSet<String> = HashSet::new();
 
     loop {
         let (stats, exit_reason) = run_agent_loop(
@@ -2892,8 +2946,25 @@ pub(crate) async fn run_round_loop(
                 // mid-round SteerRequested events the live watcher already
                 // handled.
                 let mut parked_steer_rx = bus.subscribe();
-                let mut orphaned =
-                    claim_steer_injections(context_injection, &local_session_id, None);
+                let claimed = claim_steer_injections(context_injection, &local_session_id, None);
+                // Corpse dedup, the serialized layer: the dying watcher can
+                // outlive its abort and push + ack a steer after every
+                // same-id claim below has already fired. This sweep shares
+                // the delivery task, so dropping already-delivered ids here
+                // is race-free where the claims are not. The log row is the
+                // forensic tell that the corpse race fired.
+                let (mut orphaned, corpse_duplicates) =
+                    split_already_delivered_steer_injections(&delivered_steer_ids, claimed);
+                for duplicate in corpse_duplicates {
+                    let dropped_id = duplicate.steer_id.unwrap_or_default();
+                    slog(&session_log, |l| {
+                        l.warn(&format!(
+                            "Dropped steer injection {} at the orphan sweep: id already \
+                             delivered (dying watcher's late duplicate)",
+                            dropped_id
+                        ))
+                    });
+                }
                 // One steer round per drain pass: deliver the first, put
                 // the rest back for the next pass (each delivery loops
                 // back through this drain).
@@ -3099,13 +3170,19 @@ pub(crate) async fn run_round_loop(
                 // Acceptance-race dedup: if the dying watcher's corpse
                 // pushed this steer's injection AFTER the drain arm looked,
                 // claim it now — the text is about to enter the
-                // conversation through this follow-up.
+                // conversation through this follow-up. Every between-rounds
+                // steer consumption flows through here (the sweep arm, the
+                // parked select arm, and the supervisor's queue-as-follow-up
+                // fallback), so also record the id: a corpse push landing
+                // even later than this claim is dropped by the next orphan
+                // sweep instead of resurrecting as an extra round.
                 if let Some(id) = message
                     .steer_id
                     .as_deref()
                     .filter(|id| !id.trim().is_empty())
                 {
                     let _ = claim_steer_injections(context_injection, &local_session_id, Some(id));
+                    delivered_steer_ids.insert(id.to_string());
                 }
                 // A between-rounds steer is delivered through this path
                 // (steer_id set); classify it as such rather than follow_up.
@@ -3223,6 +3300,52 @@ mod budget_tail {
             .into_iter()
             .collect();
         assert_eq!(budget_tail_index(&batch, &handled), None);
+    }
+}
+
+#[cfg(test)]
+mod steer_dedup {
+    use super::split_already_delivered_steer_injections;
+    use crate::event::ContextInjection;
+    use std::collections::HashSet;
+
+    fn steer(id: &str, text: &str) -> ContextInjection {
+        ContextInjection::text_with_steer_id(text.to_string(), id.to_string())
+    }
+
+    #[test]
+    fn sweep_drops_only_already_delivered_ids() {
+        let delivered: HashSet<String> = ["steer-1".to_string()].into_iter().collect();
+        let (kept, dropped) = split_already_delivered_steer_injections(
+            &delivered,
+            vec![
+                steer("steer-1", "late corpse push"),
+                steer("steer-2", "fresh"),
+            ],
+        );
+        assert_eq!(kept.len(), 1, "undelivered id must survive the sweep");
+        assert_eq!(kept[0].steer_id.as_deref(), Some("steer-2"));
+        assert_eq!(dropped.len(), 1, "already-delivered id must be dropped");
+        assert_eq!(dropped[0].steer_id.as_deref(), Some("steer-1"));
+    }
+
+    #[test]
+    fn dedup_is_by_id_never_by_text_and_skips_empty_ids() {
+        // "steer-1" already delivered this exact text; a NEW steer with the
+        // same text but its own id must still deliver. Id-less steers can't
+        // be correlated and are kept even if "" somehow enters the set.
+        let delivered: HashSet<String> =
+            ["steer-1".to_string(), String::new()].into_iter().collect();
+        let (kept, dropped) = split_already_delivered_steer_injections(
+            &delivered,
+            vec![
+                steer("steer-2", "same text sent twice"),
+                steer("", "id-less"),
+                steer("  ", "whitespace id"),
+            ],
+        );
+        assert_eq!(kept.len(), 3, "same-text/new-id and id-less steers stay");
+        assert!(dropped.is_empty());
     }
 }
 


### PR DESCRIPTION
## The race

A round's steer watcher is aborted **asynchronously** at round exit (`InterruptGuard::drop` → `JoinHandle::abort`), and abort only takes effect at the task's next yield. A watcher mid-poll outlives it — its corpse keeps draining broadcast backlog, and under scheduler latency it can ack a steer ("Queued for the next model checkpoint") and push the text onto `context_injection` **after** all three of the existing same-id dedup claims (cf9ee21f: the entry sweep, the select-arm claim, the post-drain claim) have already fired. Nothing ever claims that late push, so the orphan sweep at the *next* round exit resurrects it as a spurious extra round.

**Production impact: one user steer can execute twice.** cf9ee21f's own commit message documents this residual hazard.

Forensic signature (observed live in CI runs 29553517127 and 29554466926): one `steer_requested` row, **three** `steer_accepted` rows for the same steer id (`Delivered` → `Queued` → `Delivered`), and the same follow-up text running as two rounds. In CI the extra round tripped the mock provider's scripted expectations, killed the session, and timed out the rollback e2e — that test is the canary.

## The fix — two layers

**Layer 2, serialized dedup (the deterministic, load-bearing one):** `run_round_loop` now records every steer id it consumes as a round/follow-up (`delivered_steer_ids`, recorded at the single post-drain claim block that every between-rounds steer consumption flows through — sweep arm, parked select arm, and the supervisor's queue-as-follow-up fallback). The orphan sweep partitions claimed injections through `split_already_delivered_steer_injections` and **drops** any whose id was already delivered, logging one warn row ("Dropped steer injection … id already delivered") as the forensic tell for any recurrence.

Why this one closes the race: the recording, the sweep, and actual delivery all execute on the round loop's **own task**, in program order — a steer's id is always recorded before the next sweep can run, so no interleaving of the corpse's push can defeat the check. The broadcast-side claims race the corpse; the sweep-side check cannot.

Dedup is strictly **by id, never by text**: the same text sent twice is two steers with two ids and still delivers twice. Empty/whitespace ids can't be correlated and are always kept (matching the existing "nothing correlates on ''" convention).

**Layer 1, watcher gate (hygiene, shrinks the window):** `InterruptGuard::drop` now cancels the loop's `CancellationToken` *before* aborting the watcher, and the watcher's `SteerRequested` arm checks the token before acking and before pushing — a dying watcher stops emitting misleading `steer_accepted` acks (which also stand down the 2s queue-as-follow-up fallback, so an id-carrying steer refused by the corpse still delivers through the fallback). This is honestly TOCTOU-limited — the corpse can pass the check, get descheduled, and push after cancellation — so it only narrows the window; layer 2 is what closes it. Both facts are stated in the code comments.

Known residual (narrow, noted for honesty): a corpse push that survives the layer-1 gate through its TOCTOU sliver *and* lands while the next round is actively running is consumed by that round's turn-top drain rather than reaching a sweep. Closing that too would mean threading the delivered set into `run_agent_loop`; kept out of this minimal diff.

## Behavior

The normal steer path is unchanged: one steer → one delivery → one round. No existing claim was reordered; the change adds only the delivered-id recording, the sweep-side drop, and the watcher gate.

## Validation

- `cargo fmt --all --check` clean
- `cargo nextest run -p intendant --bins`: 3855 passed (includes 2 new `agent_loop::steer_dedup` unit tests: delivered id → dropped; undelivered / same-text-new-id / id-less → kept)
- `cargo clippy -p intendant --locked -- -D warnings` clean
- `cargo test -p intendant --test e2e --locked`: 23/23 passed, including `headless_rollback_writes_a_conversation_rewound_cut` (the canary), `supervised_session_writes_task_ask_human_and_steer_message_rows`, and `parked_session_delivers_an_id_less_steer`

A green suite cannot *prove* a race fix (the race needs load); the proof is the serialized-consumption ordering argument above.
