### PR TITLE
memory: durable writes on the primary OS + the P1 exit battery (P1.8)

### DIFF
--- a/skills/intendant-memory/SKILL.md
+++ b/skills/intendant-memory/SKILL.md
@@ -10,10 +10,10 @@ gate-attributed provenance and a derived status, visible to every agent
 and to the owner (dashboard → Memory). It is for knowledge that belongs
 to the machine and its owner, not to any one session.
 
-**This build is EPHEMERAL**: claims live in daemon memory and vanish on
-restart (durable storage arrives later in the program). Propose anyway —
-the owner sees and curates claims live, and a claim that matters can be
-re-proposed; the discipline is the point.
+**Durability is per-daemon and every view says which** (`durability`
+on each claim and search result): the primary-OS daemon persists
+claims across restarts; other daemons run ephemeral until their
+custody lands. Trust the label, not an assumption.
 
 ## When to use (triggers)
 

--- a/src/bin/caller/ctl.rs
+++ b/src/bin/caller/ctl.rs
@@ -2461,7 +2461,15 @@ async fn run_memory_search(
     for claim in &results {
         println!("{}", memory_render_row(claim));
     }
-    println!("(ephemeral plane — nothing persists across daemon restarts)");
+    let durability = value
+        .get("durability")
+        .and_then(Value::as_str)
+        .unwrap_or("ephemeral");
+    if durability == "durable" {
+        println!("(durable plane)");
+    } else {
+        println!("(ephemeral plane — nothing persists across daemon restarts)");
+    }
     Ok(())
 }
 

--- a/src/bin/caller/mcp/mod.rs
+++ b/src/bin/caller/mcp/mod.rs
@@ -207,7 +207,7 @@ impl IntendantServer {
         };
         Ok(serde_json::json!({
             "results": memory.search(&args),
-            "durability": "ephemeral",
+            "durability": memory.durability_label(),
         }))
     }
 

--- a/src/bin/caller/memory/handle.rs
+++ b/src/bin/caller/memory/handle.rs
@@ -12,6 +12,12 @@ use std::sync::Mutex;
 use crate::event::{AppEvent, EventBus};
 
 use super::service::MemoryService;
+
+/// P1.8 storage-mode selector for [`MemoryHandle::bootstrap`].
+pub(crate) enum MemoryStorage {
+    Ephemeral,
+    Durable(std::path::PathBuf),
+}
 use super::types::{ClaimView, MemoryError, ProposeArgs, SearchArgs};
 
 pub(crate) struct MemoryHandle {
@@ -21,18 +27,31 @@ pub(crate) struct MemoryHandle {
 }
 
 impl MemoryHandle {
-    /// Bootstrap the ephemeral plane (the full `c.genesis` ceremony,
-    /// admitted by the stamped reducer) and wrap it single-writer.
-    /// Admitted writes broadcast `memory_changed` on `bus` so every
-    /// connected frontend updates live.
-    pub(crate) fn bootstrap(bus: EventBus) -> Result<MemoryHandle, MemoryError> {
-        let service = MemoryService::new()?;
+    /// Bootstrap the plane (the full `c.genesis` ceremony, admitted by
+    /// the stamped reducer) and wrap it single-writer. Admitted writes
+    /// broadcast `memory_changed` on `bus` so every connected frontend
+    /// updates live. `storage` picks the P1.8 mode: `Durable(dir)` on
+    /// the proven-custody OS, `Ephemeral` elsewhere (and in tests).
+    pub(crate) fn bootstrap(
+        bus: EventBus,
+        storage: MemoryStorage,
+    ) -> Result<MemoryHandle, MemoryError> {
+        let service = match storage {
+            MemoryStorage::Ephemeral => MemoryService::new()?,
+            MemoryStorage::Durable(dir) => MemoryService::new_durable(&dir)
+                .map_err(|e| MemoryError::InvalidArg(e.to_string()))?,
+        };
         let plane_id_hex = service.plane_id_hex();
         Ok(MemoryHandle {
             service: Mutex::new(service),
             plane_id_hex,
             bus,
         })
+    }
+
+    /// The mode label views carry ("durable" / "ephemeral").
+    pub(crate) fn durability_label(&self) -> &'static str {
+        self.lock().durability_label()
     }
 
     pub(crate) fn plane_id_hex(&self) -> &str {
@@ -90,7 +109,7 @@ mod tests {
     fn propose_broadcasts_memory_changed() {
         let bus = EventBus::new();
         let mut rx = bus.subscribe();
-        let handle = MemoryHandle::bootstrap(bus).unwrap();
+        let handle = MemoryHandle::bootstrap(bus, MemoryStorage::Ephemeral).unwrap();
 
         let view = handle
             .propose(

--- a/src/bin/caller/memory/mod.rs
+++ b/src/bin/caller/memory/mod.rs
@@ -34,5 +34,5 @@ pub(crate) mod service;
 pub(crate) mod store;
 pub(crate) mod types;
 
-pub(crate) use handle::MemoryHandle;
+pub(crate) use handle::{MemoryHandle, MemoryStorage};
 pub(crate) use types::{ClaimView, MemoryError, ProposeArgs, SearchArgs};

--- a/src/bin/caller/memory/plane.rs
+++ b/src/bin/caller/memory/plane.rs
@@ -634,6 +634,61 @@ impl EphemeralPlane {
         Ok(op_hash)
     }
 
+    /// Retract the most recent op when its durable persistence FAILED
+    /// (P1.8 lockstep: §6.2 L1 says nothing unflushed is ever exposed
+    /// as committed, and the in-memory view must agree). Only valid
+    /// for the op at the chain tail; the fold and chain position are
+    /// re-derived from the remaining set.
+    pub(crate) fn retract_unpersisted(&mut self, op_hash: &[u8; 32]) -> Result<(), MemoryError> {
+        let Some((name, _)) = self
+            .items
+            .iter()
+            .last()
+            .filter(|(_, bytes)| {
+                owner_plane_reducer::envelope::parse_op(bytes)
+                    .is_ok_and(|op| op.op_hash() == *op_hash)
+            })
+            .map(|(k, v)| (k.clone(), v.clone()))
+        else {
+            return Err(MemoryError::InvalidArg(
+                "retract_unpersisted targets only the chain tail".into(),
+            ));
+        };
+        self.items.remove(&name);
+        let (verdicts, state) = fold_set(&self.items, &BTreeMap::new())
+            .map_err(|Unimplemented(why)| MemoryError::Unimplemented(why))?;
+        self.verdicts = verdicts;
+        self.state = state;
+        let (writer_seq, prev_writer_hash) =
+            match self
+                .state
+                .tenant_chain_head(&self.zone_id, &self.dev.lineage, 1)
+            {
+                Some((next_seq, head)) => (next_seq - 1, head),
+                None => (0, gen_start(&self.dev.lineage, 1)),
+            };
+        self.writer_seq = writer_seq;
+        self.prev_writer_hash = prev_writer_hash;
+        Ok(())
+    }
+
+    /// Test seam: seal a tenant op into an ARBITRARY space (the
+    /// space-denial exit test aims at the audit space the writer grant
+    /// does not cover; production sealing always targets home).
+    #[cfg(test)]
+    pub(crate) fn tenant_op_in_space_for_test(
+        &mut self,
+        space_id: [u8; 16],
+        op_type: &str,
+        body: cbor::Value,
+    ) -> Result<[u8; 32], MemoryError> {
+        let home = self.home_space;
+        self.home_space = space_id;
+        let out = self.tenant_op(ActorKind::Daemon, None, op_type, body);
+        self.home_space = home;
+        out
+    }
+
     /// Derived claim status via the reducer's §11.2 fold — never a
     /// service-side reimplementation.
     pub(crate) fn claim_status(&self, op_hash: &[u8; 32]) -> Option<&'static str> {

--- a/src/bin/caller/memory/service.rs
+++ b/src/bin/caller/memory/service.rs
@@ -58,6 +58,10 @@ fn parse_vocab<T: Copy>(
 pub(crate) struct MemoryService {
     plane: EphemeralPlane,
     claims: BTreeMap<[u8; 32], ClaimRecord>,
+    /// P1.8: the durable custody store, when this daemon runs the
+    /// durable plane (macOS — multi-platform custody stays full Gate
+    /// B, so other OSes run ephemeral and say so). `None` = ephemeral.
+    store: Option<super::store::DurableStore>,
 }
 
 impl MemoryService {
@@ -66,7 +70,140 @@ impl MemoryService {
         Ok(MemoryService {
             plane: EphemeralPlane::bootstrap()?,
             claims: BTreeMap::new(),
+            store: None,
         })
+    }
+
+    /// P1.8: open (or create) the DURABLE plane at `dir`. Reopen
+    /// recovers the op set through the stamped walker + fold and
+    /// rebuilds the claim registry from the recovered op bodies.
+    pub(crate) fn new_durable(
+        dir: &std::path::Path,
+    ) -> Result<MemoryService, super::store::StoreError> {
+        use super::store::{DurableStore, RecoveredStore};
+        if dir.join("custody.v1.json").exists() {
+            let RecoveredStore {
+                store,
+                resume,
+                items,
+            } = DurableStore::open(dir)?;
+            let plane = EphemeralPlane::resume(&resume, items)?;
+            let claims = Self::rebuild_claims(&plane)?;
+            Ok(MemoryService {
+                plane,
+                claims,
+                store: Some(store),
+            })
+        } else {
+            let (plane, custody) = EphemeralPlane::bootstrap_with_custody()?;
+            let store = DurableStore::create_from_ceremony(dir, &plane, custody)?;
+            Ok(MemoryService {
+                plane,
+                claims: BTreeMap::new(),
+                store: Some(store),
+            })
+        }
+    }
+
+    /// The honest per-mode durability label every view carries.
+    pub(crate) fn durability_label(&self) -> &'static str {
+        if self.store.is_some() {
+            "durable"
+        } else {
+            "ephemeral"
+        }
+    }
+
+    /// Rebuild the claim registry from recovered ops: decode each held
+    /// `m.claim` body (reducer-side Node walk — write-with-core /
+    /// read-with-reducer, the differential spirit) and re-derive
+    /// provenance from the op envelope. Envelope truth is what
+    /// survives a restart: agent-session/peer actors keep their
+    /// gate-named principals verbatim; `human`/`daemon` actors carry
+    /// the O8 device identity, so they surface as `dashboard` /
+    /// `unattributed` WITHOUT a principal (documented collapse — the
+    /// live-path exit criterion is unaffected).
+    fn rebuild_claims(
+        plane: &EphemeralPlane,
+    ) -> Result<BTreeMap<[u8; 32], ClaimRecord>, MemoryError> {
+        use owner_plane_reducer::envelope::parse_op;
+        let mut claims = BTreeMap::new();
+        for raw in plane.held_items().values() {
+            let Ok(op) = parse_op(raw) else { continue };
+            if op.header.operation_type != Mclaim::OP_TYPE {
+                continue;
+            }
+            let body = op.body.clone();
+            let text = |k: &str| body.get(k).and_then(|v| v.as_text().map(|t| t.to_string()));
+            let prov_node = body.get("provenance");
+            let prov_text = |k: &str| {
+                prov_node
+                    .as_ref()
+                    .and_then(|p| p.get(k))
+                    .and_then(|v| v.as_text().map(|t| t.to_string()))
+            };
+            let kind_str = text("kind").unwrap_or_default();
+            let sens_str = text("sensitivity").unwrap_or_default();
+            let kind = parse_vocab("kind", &kind_str, Kind::ALL, Kind::as_str)?;
+            let sensitivity = parse_vocab("sensitivity", &sens_str, Class::ALL, Class::as_str)?;
+            let labels = body
+                .get("labels")
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|n| n.as_text().map(|t| t.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let proposed_by = match op.header.actor_kind {
+                // The envelope carries the PRINCIPAL verbatim; the
+                // gate-bound session is not re-attestable across a
+                // restart (the body's `session` is the writer's context
+                // claim, not attribution), so recovered provenance
+                // collapses `session` to None — documented, and the
+                // live-path exit criterion is unaffected.
+                "agent-session" => ClaimProvenance {
+                    v: 1,
+                    actor: "agent_session".into(),
+                    principal: Some(op.header.actor_id.to_string()),
+                    session: None,
+                },
+                "peer" => ClaimProvenance {
+                    v: 1,
+                    actor: "peer".into(),
+                    principal: Some(op.header.actor_id.to_string()),
+                    session: None,
+                },
+                "human" => ClaimProvenance {
+                    v: 1,
+                    actor: "dashboard".into(),
+                    principal: None,
+                    session: None,
+                },
+                _ => ClaimProvenance {
+                    v: 1,
+                    actor: "unattributed".into(),
+                    principal: None,
+                    session: None,
+                },
+            };
+            claims.insert(
+                op.op_hash(),
+                ClaimRecord {
+                    op_hash: op.op_hash(),
+                    kind,
+                    statement: text("statement").unwrap_or_default(),
+                    sensitivity,
+                    session: prov_text("session"),
+                    project: prov_text("project"),
+                    model: prov_text("model"),
+                    labels,
+                    created_ms: op.header.created_ms,
+                    proposed_by,
+                },
+            );
+        }
+        Ok(claims)
     }
 
     /// The plane id (hex) — logged at wiring so an operator can tell
@@ -189,6 +326,23 @@ impl MemoryService {
             },
         };
         let op_hash = self.seal_write(actor, Verb::Propose, Mclaim::OP_TYPE, body.to_value())?;
+        // P1.8 durability: §6.2 L1 — the claim ACKs only after its
+        // sealed item is flushed. On a store failure the in-memory
+        // admission is RETRACTED (nothing unpersisted is ever exposed)
+        // and the named outcome surfaces verbatim.
+        if let Some(store) = &mut self.store {
+            let op_bytes = self
+                .plane
+                .held_items()
+                .values()
+                .last()
+                .expect("the op just admitted is held")
+                .clone();
+            if let Err(e) = store.append_sealed_op(&op_bytes) {
+                self.plane.retract_unpersisted(&op_hash)?;
+                return Err(MemoryError::InvalidArg(e.to_string()));
+            }
+        }
         self.claims.insert(
             op_hash,
             ClaimRecord {
@@ -274,8 +428,34 @@ impl MemoryService {
             labels: rec.labels.clone(),
             created_ms: rec.created_ms,
             proposed_by: rec.proposed_by.clone(),
-            durability: "ephemeral".into(),
+            durability: self.durability_label().into(),
         }
+    }
+
+    /// Test seam for the space-denial exit test: a claim aimed at the
+    /// AUDIT space, which the ordinary writer grant does not cover.
+    #[cfg(test)]
+    fn tenant_op_for_test_in_audit_space(&mut self) -> Result<[u8; 32], MemoryError> {
+        let body = Mclaim {
+            kind: Kind::Observation,
+            statement: "wrong space".into(),
+            sensitivity: Class::Private,
+            observed_at_ms: Some(1),
+            valid_from_ms: None,
+            valid_until_ms: None,
+            expires_at_ms: None,
+            session: None,
+            project: None,
+            model: None,
+            evidence: vec![],
+            supersedes: None,
+            labels: None,
+        };
+        self.plane.tenant_op_in_space_for_test(
+            self.plane.audit_space,
+            Mclaim::OP_TYPE,
+            body.to_value(),
+        )
     }
 
     /// Test seam: seal an arbitrary Memory-tenant op on the plane as
@@ -592,6 +772,102 @@ mod tests {
             held_before,
             "a denied write must never reach the kernel"
         );
+    }
+
+    /// P1.8 exit battery — durable round-trip through the SERVICE with
+    /// recovered provenance rules: agent-session principals survive a
+    /// restart verbatim (the envelope carries them); owner-surface
+    /// claims collapse to the envelope's O8 device identity
+    /// (dashboard, no principal) — the documented reverse map. The
+    /// mode label flips honestly and the chain keeps accepting.
+    #[test]
+    fn durable_service_roundtrip_recovers_claims_and_provenance() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("plane");
+        let agent_hash;
+        {
+            let mut svc = MemoryService::new_durable(&dir).unwrap();
+            assert_eq!(svc.durability_label(), "durable");
+            let view = svc
+                .propose(propose_args("agent durable claim"), &agent_actor())
+                .unwrap();
+            assert_eq!(view.durability, "durable");
+            agent_hash = view.id.clone();
+            svc.propose(
+                propose_args("owner durable claim"),
+                &ActorBinding::dashboard(Some("principal:root:dashboard".into())),
+            )
+            .unwrap();
+        }
+        let mut svc = MemoryService::new_durable(&dir).unwrap();
+        let all = svc.search(&SearchArgs {
+            query: String::new(),
+            limit: 50,
+            include_candidates: true,
+        });
+        assert_eq!(all.len(), 2, "both claims survive the restart");
+        let agent = all.iter().find(|c| c.id == agent_hash).unwrap();
+        assert_eq!(
+            agent.proposed_by.principal.as_deref(),
+            Some("principal:agent-session:sess-1"),
+            "agent principals survive restarts verbatim (envelope truth)"
+        );
+        assert_eq!(
+            agent.proposed_by.session, None,
+            "gate sessions are not re-attestable across restarts (documented collapse)"
+        );
+        assert_eq!(
+            agent.session.as_deref(),
+            Some("test-session"),
+            "the writer's session CONTEXT claim survives as stated"
+        );
+        let owner = all.iter().find(|c| c.id != agent_hash).unwrap();
+        assert_eq!(owner.proposed_by.actor, "dashboard");
+        assert_eq!(
+            owner.proposed_by.principal, None,
+            "owner-surface principals collapse to the O8 device identity across restarts (documented)"
+        );
+        svc.propose(propose_args("post-restart claim"), &agent_actor())
+            .expect("the recovered chain keeps accepting");
+    }
+
+    /// P1.8 exit battery — zone/space denial: an op aimed at a space
+    /// the writer grant does not cover rejects with the kernel's named
+    /// scope outcome. (The service only ever writes the home space;
+    /// this pins what happens if that invariant ever breaks.)
+    #[test]
+    fn ops_outside_the_granted_space_reject_with_named_scope_outcome() {
+        let mut svc = MemoryService::new().unwrap();
+        let err = svc
+            .tenant_op_for_test_in_audit_space()
+            .expect_err("audit space is not in the writer grant");
+        match err {
+            MemoryError::Rejected { outcome, .. } => {
+                assert!(
+                    outcome.starts_with("scope-"),
+                    "expected a named scope rejection, got {outcome}"
+                );
+            }
+            other => panic!("expected a named kernel rejection, got {other:?}"),
+        }
+    }
+
+    /// P1.8 exit battery — conflicting claims COEXIST: contradictory
+    /// statements are both represented and surfaced, never silently
+    /// overwritten or deduplicated (§5.4: conflicts are data).
+    #[test]
+    fn conflicting_claims_coexist_and_both_surface() {
+        let mut svc = MemoryService::new().unwrap();
+        svc.propose(propose_args("the deploy runs at 06:00 UTC"), &no_actor())
+            .unwrap();
+        svc.propose(propose_args("the deploy runs at 18:00 UTC"), &no_actor())
+            .unwrap();
+        let hits = svc.search(&SearchArgs {
+            query: "the deploy runs".into(),
+            limit: 10,
+            include_candidates: true,
+        });
+        assert_eq!(hits.len(), 2, "both contradictory claims surface");
     }
 
     /// The Memory Explorer's kind/sensitivity selects are an unavoidable

--- a/src/bin/caller/memory/store.rs
+++ b/src/bin/caller/memory/store.rs
@@ -395,18 +395,23 @@ impl DurableStore {
     }
 }
 
-/// The composed durable plane: the writable in-memory plane (stamped
-/// mint + fold) over the durable store. This is the shape P1.8 wires
-/// under `MemoryService` once the ratified sequence completes; until
-/// then only this module's battery drives it.
-pub(crate) struct DurablePlane {
-    pub plane: EphemeralPlane,
-    store: DurableStore,
+/// What [`DurableStore::open`] recovers: the store handle plus the
+/// custody/identity record and the decrypted op set, ready for
+/// [`EphemeralPlane::resume`].
+pub(crate) struct RecoveredStore {
+    pub store: DurableStore,
+    pub resume: PlaneResume,
+    pub items: BTreeMap<String, Vec<u8>>,
 }
 
-impl DurablePlane {
-    pub(crate) fn create(dir: &Path) -> Result<DurablePlane, StoreError> {
-        let (plane, custody) = EphemeralPlane::bootstrap_with_custody()?;
+impl DurableStore {
+    /// Create a fresh durable store from a just-minted ceremony
+    /// (P1.8: called by `MemoryService::new_durable`).
+    pub(crate) fn create_from_ceremony(
+        dir: &Path,
+        plane: &EphemeralPlane,
+        custody: PlaneCustody,
+    ) -> Result<DurableStore, StoreError> {
         let genesis_bytes = plane
             .held_items()
             .values()
@@ -429,14 +434,13 @@ impl DurablePlane {
             grant_id: plane.grant.grant_id,
             genesis_hash,
         };
-        let store = DurableStore::create(dir, resume, &genesis_bytes)?;
-        Ok(DurablePlane { plane, store })
+        DurableStore::create(dir, resume, &genesis_bytes)
     }
 
     /// Reopen after a restart or crash: sidecar → recover both logs
-    /// (stamped walker) → open every item (§5.1/§5.3 inverses) →
-    /// stamped-fold admission + chain resumption.
-    pub(crate) fn open(dir: &Path) -> Result<DurablePlane, StoreError> {
+    /// (stamped walker) → open every item (§5.1/§5.3 inverses). The
+    /// caller folds the recovered set via [`EphemeralPlane::resume`].
+    pub(crate) fn open(dir: &Path) -> Result<RecoveredStore, StoreError> {
         let lock = DurableStore::lock_store(dir)?;
         let sidecar_bytes = std::fs::read(dir.join("custody.v1.json"))
             .map_err(|e| StoreError::Custody(format!("sidecar: {e}")))?;
@@ -488,13 +492,11 @@ impl DurablePlane {
             push(&mut items, op_bytes);
         }
 
-        let plane = EphemeralPlane::resume(&resume, items)?;
         let tenant = OpenOptions::new()
             .append(true)
             .open(dir.join("tenant.iplog"))
             .map_err(|e| StoreError::StorageIo(e.to_string()))?;
-        Ok(DurablePlane {
-            plane,
+        Ok(RecoveredStore {
             store: DurableStore {
                 dir: dir.to_path_buf(),
                 _lock: lock,
@@ -502,6 +504,53 @@ impl DurablePlane {
                 resume,
                 frozen: false,
             },
+            resume: DurableStore::reread_resume(dir)?,
+            items,
+        })
+    }
+
+    fn reread_resume(dir: &Path) -> Result<PlaneResume, StoreError> {
+        let sidecar_bytes = std::fs::read(dir.join("custody.v1.json"))
+            .map_err(|e| StoreError::Custody(format!("sidecar: {e}")))?;
+        let sidecar: SidecarV1 = serde_json::from_slice(&sidecar_bytes)
+            .map_err(|e| StoreError::Custody(format!("sidecar: {e}")))?;
+        sidecar.into_parts()
+    }
+
+    /// Seal + append one admitted op (§6.2 L1: the caller acks only
+    /// on Ok). P1.8's service path.
+    pub(crate) fn append_sealed_op(&mut self, op_bytes: &[u8]) -> Result<(), StoreError> {
+        let resume = &self.resume;
+        let payload = seal_item_frame(op_bytes, resume)?;
+        self.append_frame(FRAME_ITEM_COMMIT, &payload)
+    }
+
+    pub(crate) fn is_frozen(&self) -> bool {
+        self.frozen
+    }
+}
+
+/// The composed durable plane — the crash battery's harness shape
+/// (production wiring composes the same pieces inside
+/// `MemoryService`).
+pub(crate) struct DurablePlane {
+    pub plane: EphemeralPlane,
+    store: DurableStore,
+}
+
+impl DurablePlane {
+    pub(crate) fn create(dir: &Path) -> Result<DurablePlane, StoreError> {
+        let (plane, custody) = EphemeralPlane::bootstrap_with_custody()?;
+        let store = DurableStore::create_from_ceremony(dir, &plane, custody)?;
+        Ok(DurablePlane { plane, store })
+    }
+
+    pub(crate) fn open(dir: &Path) -> Result<DurablePlane, StoreError> {
+        let recovered = DurableStore::open(dir)?;
+        let plane = EphemeralPlane::resume(&recovered.resume, recovered.items)?;
+        Ok(DurablePlane {
+            plane,
+            store: recovered.store,
         })
     }
 
@@ -513,16 +562,15 @@ impl DurablePlane {
         }
     }
 
-    /// Mint + admit a Memory claim in the plane, then persist it as a
-    /// sealed item; the claim is ACKED (returned) only after the frame
-    /// is flushed (§6.2 L1). A persistence failure surfaces the named
-    /// outcome and freezes the writer — the in-memory admission is NOT
-    /// exposed as durable.
+    /// Mint + admit a Memory claim, then persist it as a sealed item;
+    /// ACKED only after the frame is flushed (§6.2 L1). On a
+    /// persistence failure the in-memory admission is retracted so
+    /// nothing unpersisted is ever exposed, and the writer freezes.
     pub(crate) fn append_claim_op(&mut self, statement: &str) -> Result<[u8; 32], StoreError> {
         use owner_plane_core::shapes::envelope::ActorKind;
         use owner_plane_core::shapes::memory::Mclaim;
         use owner_plane_core::shapes::{Class, Kind};
-        if self.store.frozen {
+        if self.store.is_frozen() {
             return Err(StoreError::StorageIo(
                 "writer frozen by an earlier flush failure".into(),
             ));
@@ -552,14 +600,10 @@ impl DurablePlane {
             .last()
             .expect("the op just admitted is held")
             .clone();
-        debug_assert_eq!(
-            parse_op(&op_bytes).map(|op| op.op_hash()).ok(),
-            Some(op_hash),
-            "held tail must be the op just admitted"
-        );
-
-        let payload = seal_item_frame(&op_bytes, &self.store.resume)?;
-        self.store.append_frame(FRAME_ITEM_COMMIT, &payload)?;
+        if let Err(e) = self.store.append_sealed_op(&op_bytes) {
+            self.plane.retract_unpersisted(&op_hash)?;
+            return Err(e);
+        }
         Ok(op_hash)
     }
 
@@ -869,7 +913,17 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().join("plane");
         let mut child = spawn_child(&dir, 200, None, None);
-        std::thread::sleep(std::time::Duration::from_millis(250));
+        // Kill only once the child demonstrably runs (store created and
+        // at least one ack journaled) — a fixed sleep raced slow starts
+        // under full-suite load and killed before creation.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while std::time::Instant::now() < deadline {
+            if acks_path(&dir).exists() && !acked_hashes(&dir).is_empty() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        std::thread::sleep(std::time::Duration::from_millis(60));
         child.kill().expect("SIGKILL the child");
         let _ = child.wait();
 

--- a/src/bin/caller/startup/wiring.rs
+++ b/src/bin/caller/startup/wiring.rs
@@ -338,19 +338,64 @@ pub(crate) fn spawn_mode_web_gateway(
     // tombed cutover). Bootstrap failure degrades to "memory
     // unavailable" instead of failing the gateway; the plane id is
     // logged so operators can tell incarnations apart across restarts.
-    mcp_http_state.memory = match crate::memory::MemoryHandle::bootstrap(bus.clone()) {
-        Ok(handle) => {
-            println!(
-                "[memory] ephemeral plane {} (nothing persists across restarts)",
-                &handle.plane_id_hex()[..16]
-            );
-            Some(Arc::new(handle))
+    // P1.8: the durable plane runs on the proven-custody OS (macOS);
+    // multi-platform custody stays full Gate B, so other OSes run
+    // ephemeral and say so on every view. INTENDANT_MEMORY_EPHEMERAL=1
+    // is the operator kill switch. Durable bootstrap failure fails
+    // SOFT to ephemeral (service stays available; the label stays
+    // honest) with the named outcome logged.
+    let durable_default = cfg!(target_os = "macos")
+        && std::env::var("INTENDANT_MEMORY_EPHEMERAL").map_or(true, |v| v != "1");
+    let storage = if durable_default {
+        match dirs::home_dir() {
+            Some(home) => {
+                crate::memory::MemoryStorage::Durable(home.join(".intendant").join("memory-plane"))
+            }
+            None => crate::memory::MemoryStorage::Ephemeral,
         }
-        Err(err) => {
-            eprintln!("[memory] ephemeral plane bootstrap failed: {err}");
-            None
-        }
+    } else {
+        crate::memory::MemoryStorage::Ephemeral
     };
+    let storage = match &storage {
+        crate::memory::MemoryStorage::Durable(dir) => {
+            match crate::memory::MemoryHandle::bootstrap(
+                bus.clone(),
+                crate::memory::MemoryStorage::Durable(dir.clone()),
+            ) {
+                Ok(handle) => {
+                    println!(
+                        "[memory] durable plane {} at {}",
+                        &handle.plane_id_hex()[..16],
+                        dir.display()
+                    );
+                    mcp_http_state.memory = Some(Arc::new(handle));
+                    None
+                }
+                Err(err) => {
+                    eprintln!(
+                        "[memory] durable plane unavailable ({err}) — falling back to ephemeral"
+                    );
+                    Some(crate::memory::MemoryStorage::Ephemeral)
+                }
+            }
+        }
+        crate::memory::MemoryStorage::Ephemeral => Some(crate::memory::MemoryStorage::Ephemeral),
+    };
+    if let Some(storage) = storage {
+        mcp_http_state.memory = match crate::memory::MemoryHandle::bootstrap(bus.clone(), storage) {
+            Ok(handle) => {
+                println!(
+                    "[memory] ephemeral plane {} (nothing persists across restarts)",
+                    &handle.plane_id_hex()[..16]
+                );
+                Some(Arc::new(handle))
+            }
+            Err(err) => {
+                eprintln!("[memory] ephemeral plane bootstrap failed: {err}");
+                None
+            }
+        };
+    }
     let mcp_http_server = Some(Arc::new(mcp::IntendantServer::new_http(
         Arc::new(tokio::sync::RwLock::new(mcp_http_state)),
         bus.clone(),

--- a/src/bin/caller/web_gateway/mcp_gate.rs
+++ b/src/bin/caller/web_gateway/mcp_gate.rs
@@ -1095,8 +1095,11 @@ mod tests {
             tmp.path().join("logs"),
         );
         state.memory = Some(std::sync::Arc::new(
-            crate::memory::MemoryHandle::bootstrap(bus.clone())
-                .expect("ephemeral plane bootstraps"),
+            crate::memory::MemoryHandle::bootstrap(
+                bus.clone(),
+                crate::memory::MemoryStorage::Ephemeral,
+            )
+            .expect("ephemeral plane bootstraps"),
         ));
         let server = crate::mcp::IntendantServer::new(
             std::sync::Arc::new(tokio::sync::RwLock::new(state)),

--- a/src/bin/caller/web_gateway/routes_memory.rs
+++ b/src/bin/caller/web_gateway/routes_memory.rs
@@ -25,7 +25,7 @@ pub(crate) async fn memory_search_api_response(
         200,
         JsonBody::Value(serde_json::json!({
             "results": results,
-            "durability": "ephemeral",
+            "durability": memory.durability_label(),
         })),
     )
 }

--- a/static/app/20-shell.html
+++ b/static/app/20-shell.html
@@ -828,7 +828,7 @@
           <h2 class="memory-title">Memory</h2>
           <div class="memory-counts" id="memory-tab-counts"></div>
         </div>
-        <div class="memory-ephemeral-note">Ephemeral plane — claims live in daemon memory and vanish on restart. Durable storage arrives later in the program.</div>
+        <div class="memory-ephemeral-note" id="memory-durability-note">Checking plane durability…</div>
         <div class="memory-compose">
           <select id="memory-add-kind" aria-label="Claim kind">
             <option value="observation">observation</option>

--- a/static/app/ui2-memory.js
+++ b/static/app/ui2-memory.js
@@ -20,6 +20,7 @@ let memoryRefetchQueued = false;
 let memoryLoadError = '';
 let memoryQuery = '';
 let memoryExpandedId = '';
+let memoryDurability = 'ephemeral';
 
 async function memoryRefresh() {
   if (memoryFetchInFlight) {
@@ -38,6 +39,7 @@ async function memoryRefresh() {
       });
       if (resp.ok && resp.body && Array.isArray(resp.body.results)) {
         memoryClaims = resp.body.results;
+        memoryDurability = resp.body.durability || 'ephemeral';
         memoryLoadError = '';
       } else {
         memoryLoadError = (resp.body && resp.body.error) || `memory unavailable (${resp.status})`;
@@ -135,10 +137,16 @@ function memoryDetailBlock(claim) {
 function memoryRenderTab() {
   const list = document.getElementById('memory-tab-list');
   if (!list) return;
+  const note = document.getElementById('memory-durability-note');
+  if (note) {
+    note.textContent = memoryDurability === 'durable'
+      ? 'Durable plane — claims survive daemon restarts on this machine. Sync across machines arrives in a later phase.'
+      : 'Ephemeral plane — claims live in daemon memory and vanish on restart. Durable storage runs on the primary-OS daemon.';
+  }
   const counts = document.getElementById('memory-tab-counts');
   if (counts) {
     const n = memoryClaims ? memoryClaims.length : 0;
-    counts.textContent = memoryClaims === null ? '' : `${n} claim${n === 1 ? '' : 's'} shown · ephemeral`;
+    counts.textContent = memoryClaims === null ? '' : `${n} claim${n === 1 ? '' : 's'} shown · ${memoryDurability}`;
   }
   if (memoryLoadError) {
     list.innerHTML = `<div class="ui-empty">${escapeHtml(memoryLoadError)}</div>`;


### PR DESCRIPTION
Memory P1.8 — the terminal slice: durable writes unlock on macOS now that the ratified sequence is complete (custody subset #401 → P0.5 replacement #405 → tombed cutover #408).

- **Durable plane under the service**: `MemoryService::new_durable` at `~/.intendant/memory-plane`; §6.2 L1 persist-then-ack with in-memory retraction on flush failure (nothing unpersisted is ever exposed); reopen rebuilds claims through the stamped walker/fold. `INTENDANT_MEMORY_EPHEMERAL=1` kill switch; fail-soft to ephemeral with the named outcome logged. **Non-macOS daemons stay honestly ephemeral** (multi-platform custody is full Gate B) and every view carries the mode label — claim views, search responses, ctl footer, the Explorer's mode-driven banner, the skill.
- **Recovered-provenance semantics (documented + pinned)**: agent/peer principals verbatim from the envelope; the gate-bound session is not re-attestable across restarts and collapses to None (the writer's session *context* claim survives separately); human → dashboard-without-principal; daemon → unattributed. The live-path exit criterion is unaffected.
- **Exit battery green** (§5.4 ∪ §15.2): durable round-trip + post-restart chain continuation; zone/space denial (named `scope-*` outcome); conflicting-claims-coexist; attribution (P1.2) and zero-injection (P1.4) unchanged; the absence gate (P1.7) green.
- SIGKILL battery timing made load-proof (kill waits for journaled progress).

Battery: fmt clean, clippy 0, `cargo nextest run --bins` 3853 passed, e2e 23/23.