### PR TITLE
provider: buffer SSE bytes so chunk boundaries can't split UTF-8

### DIFF
--- a/src/bin/caller/provider/anthropic.rs
+++ b/src/bin/caller/provider/anthropic.rs
@@ -573,20 +573,15 @@ impl ChatProvider for AnthropicProvider {
             rate_limit_windows: response.anthropic_rate_limit_windows(),
             ..Default::default()
         };
-        let mut line_buf = String::new();
+        let mut line_buf = SseLineBuffer::new();
 
         let mut stream = response.bytes_stream();
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.map_err(|e| CallerError::Provider(format!("Stream error: {}", e)))?;
-            let chunk_str = String::from_utf8_lossy(&chunk);
-
-            line_buf.push_str(&chunk_str);
+            line_buf.push_chunk(&chunk);
 
             // Process complete lines
-            while let Some(newline_pos) = line_buf.find('\n') {
-                let line = line_buf[..newline_pos].trim_end_matches('\r').to_string();
-                line_buf = line_buf[newline_pos + 1..].to_string();
-
+            while let Some(line) = line_buf.next_line() {
                 if line.is_empty() {
                     continue;
                 }

--- a/src/bin/caller/provider/gemini.rs
+++ b/src/bin/caller/provider/gemini.rs
@@ -379,18 +379,14 @@ impl ChatProvider for GeminiProvider {
         let mut cu_calls: Vec<crate::computer_use::CuToolCall> = Vec::new();
         let mut raw_model_parts: Vec<serde_json::Value> = Vec::new();
         let mut usage = TokenUsage::default();
-        let mut line_buf = String::new();
+        let mut line_buf = SseLineBuffer::new();
 
         let mut stream = response.bytes_stream();
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.map_err(|e| CallerError::Provider(format!("Stream error: {}", e)))?;
-            let chunk_str = String::from_utf8_lossy(&chunk);
-            line_buf.push_str(&chunk_str);
+            line_buf.push_chunk(&chunk);
 
-            while let Some(newline_pos) = line_buf.find('\n') {
-                let line = line_buf[..newline_pos].trim_end_matches('\r').to_string();
-                line_buf = line_buf[newline_pos + 1..].to_string();
-
+            while let Some(line) = line_buf.next_line() {
                 if line.is_empty() {
                     continue;
                 }

--- a/src/bin/caller/provider/mod.rs
+++ b/src/bin/caller/provider/mod.rs
@@ -87,6 +87,49 @@ fn parse_sse_line(line: &str) -> Option<(&str, &str)> {
     }
 }
 
+/// Byte-accurate line framing for SSE streams. Network chunks accumulate as
+/// raw bytes and are converted to text only once a complete line is
+/// available: converting each chunk independently (the old per-chunk
+/// `from_utf8_lossy`) corrupted any multibyte UTF-8 codepoint that a chunk
+/// boundary happened to split — common with CJK/emoji streaming — into
+/// U+FFFD replacement characters.
+pub(crate) struct SseLineBuffer {
+    buf: Vec<u8>,
+}
+
+impl SseLineBuffer {
+    pub(crate) fn new() -> Self {
+        Self { buf: Vec::new() }
+    }
+
+    /// Append a raw network chunk.
+    pub(crate) fn push_chunk(&mut self, chunk: &[u8]) {
+        self.buf.extend_from_slice(chunk);
+    }
+
+    /// Pop the next complete line: everything up to the first `'\n'` (which
+    /// is consumed and excluded), with trailing `'\r'`s stripped — the
+    /// byte-level equivalent of the providers' old `trim_end_matches('\r')`.
+    /// Lossy UTF-8 conversion happens only here, on the complete line, so a
+    /// genuinely invalid byte still degrades to U+FFFD but a chunk boundary
+    /// never manufactures one. Returns `None` when no full line is buffered;
+    /// the partial tail stays buffered for the next chunk. Scanning for
+    /// `b'\n'`/`b'\r'` byte-wise is UTF-8-safe: ASCII bytes never occur
+    /// inside a multibyte sequence.
+    pub(crate) fn next_line(&mut self) -> Option<String> {
+        let newline_pos = self.buf.iter().position(|&b| b == b'\n')?;
+        let mut line_end = newline_pos;
+        while line_end > 0 && self.buf[line_end - 1] == b'\r' {
+            line_end -= 1;
+        }
+        let line = String::from_utf8_lossy(&self.buf[..line_end]).into_owned();
+        // Drain the consumed prefix in place instead of reallocating the
+        // remainder into a fresh buffer per line.
+        self.buf.drain(..=newline_pos);
+        Some(line)
+    }
+}
+
 /// Streaming timeout for SSE connections (10 minutes).
 const STREAM_TIMEOUT: Duration = Duration::from_secs(600);
 
@@ -1183,6 +1226,77 @@ pub mod mock {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Drain every currently complete line.
+    fn drain_lines(buf: &mut SseLineBuffer) -> Vec<String> {
+        let mut lines = Vec::new();
+        while let Some(line) = buf.next_line() {
+            lines.push(line);
+        }
+        lines
+    }
+
+    #[test]
+    fn sse_line_buffer_multibyte_split_across_two_chunks() {
+        // "…" is E2 80 A6; split it mid-sequence the way a network chunk
+        // boundary can. The old per-chunk from_utf8_lossy turned each half
+        // into U+FFFD.
+        let payload = "data: a…b\n".as_bytes();
+        let mut buf = SseLineBuffer::new();
+        buf.push_chunk(&payload[..9]); // "data: a" + E2 80 (mid-codepoint)
+        assert_eq!(buf.next_line(), None);
+        buf.push_chunk(&payload[9..]); // A6 + "b\n"
+        assert_eq!(buf.next_line().as_deref(), Some("data: a…b"));
+        assert_eq!(buf.next_line(), None);
+    }
+
+    #[test]
+    fn sse_line_buffer_emoji_split_across_three_chunks() {
+        // "🦀" is F0 9F A6 80 — four bytes, split across three pushes.
+        let payload = "data: 🦀!\n".as_bytes();
+        let mut buf = SseLineBuffer::new();
+        buf.push_chunk(&payload[..7]); // "data: " + F0
+        assert_eq!(buf.next_line(), None);
+        buf.push_chunk(&payload[7..9]); // 9F A6
+        assert_eq!(buf.next_line(), None);
+        buf.push_chunk(&payload[9..]); // 80 "!\n"
+        let line = buf.next_line().unwrap();
+        assert_eq!(line, "data: 🦀!");
+        assert!(!line.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn sse_line_buffer_crlf_and_heartbeat_lines() {
+        let mut buf = SseLineBuffer::new();
+        buf.push_chunk(b"data: hi\r\n\r\n\ndata: x\r\r\n");
+        assert_eq!(
+            drain_lines(&mut buf),
+            // Trailing '\r's are stripped (all of them — trim_end_matches
+            // parity), and heartbeat blank lines come through as empty
+            // strings for the callers' existing is_empty() skip.
+            vec!["data: hi", "", "", "data: x"]
+        );
+    }
+
+    #[test]
+    fn sse_line_buffer_split_mid_data_prefix() {
+        let mut buf = SseLineBuffer::new();
+        buf.push_chunk(b"da");
+        assert_eq!(buf.next_line(), None);
+        buf.push_chunk(b"ta: {\"k\":1}\n");
+        assert_eq!(buf.next_line().as_deref(), Some("data: {\"k\":1}"));
+    }
+
+    #[test]
+    fn sse_line_buffer_multiple_lines_one_chunk_and_partial_tail() {
+        let mut buf = SseLineBuffer::new();
+        buf.push_chunk(b"event: delta\ndata: one\ndata: tw");
+        assert_eq!(drain_lines(&mut buf), vec!["event: delta", "data: one"]);
+        // The partial tail stays buffered until its newline arrives.
+        buf.push_chunk(b"o\n");
+        assert_eq!(buf.next_line().as_deref(), Some("data: two"));
+        assert_eq!(buf.next_line(), None);
+    }
 
     #[test]
     fn project_env_keys_whitelists_provider_keys_only() {

--- a/src/bin/caller/provider/openai.rs
+++ b/src/bin/caller/provider/openai.rs
@@ -620,18 +620,14 @@ impl ChatProvider for OpenAIProvider {
         // Track in-progress function calls by index
         let mut pending_tools: std::collections::HashMap<usize, ToolCall> =
             std::collections::HashMap::new();
-        let mut line_buf = String::new();
+        let mut line_buf = SseLineBuffer::new();
 
         let mut stream = response.bytes_stream();
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.map_err(|e| CallerError::Provider(format!("Stream error: {}", e)))?;
-            let chunk_str = String::from_utf8_lossy(&chunk);
-            line_buf.push_str(&chunk_str);
+            line_buf.push_chunk(&chunk);
 
-            while let Some(newline_pos) = line_buf.find('\n') {
-                let line = line_buf[..newline_pos].trim_end_matches('\r').to_string();
-                line_buf = line_buf[newline_pos + 1..].to_string();
-
+            while let Some(line) = line_buf.next_line() {
                 if line.is_empty() {
                     continue;
                 }


### PR DESCRIPTION
## Bug

All three provider SSE streaming loops (OpenAI, Anthropic, Gemini) converted each network chunk to text independently:

```rust
let chunk_str = String::from_utf8_lossy(&chunk);
line_buf.push_str(&chunk_str);
```

A multibyte UTF-8 codepoint split across two network chunks — common when streaming CJK text or emoji — hit `from_utf8_lossy` as an incomplete byte sequence, so streamed responses showed U+FFFD replacement characters where the split character should be. Each parsed line also reallocated the entire remaining buffer (`line_buf = line_buf[newline_pos + 1..].to_string()`).

## Fix

New shared `SseLineBuffer` in `provider/mod.rs`: chunks accumulate as raw bytes and lossy UTF-8 conversion happens only on complete lines, so a genuinely invalid byte still degrades to U+FFFD exactly as before — it's just never manufactured by a chunk boundary. Consumed bytes are drained in place instead of reallocating the suffix per line. All three streaming loops now push raw chunks and pop framed lines; per-line behavior (empty-line skip, trailing-`\r` strip, `data:` parsing, `[DONE]` handling) is unchanged, and none of the loops used the chunk text for anything besides line framing.

Deliberately narrow: a larger shared SSE-framer refactor is staged for a later pass.

## Tests

Hermetic unit tests next to the helper: multibyte characters split across two and three chunks arrive intact with no U+FFFD; CRLF and heartbeat blank lines; a line split mid-`data:` prefix; multiple lines in one chunk with a trailing partial line staying buffered until its newline arrives.

Battery: `cargo fmt --check` clean, `cargo clippy` clean, `cargo nextest run --bins` 3858 passed / 10 skipped.
