### PR TITLE
dashboard: fork-points 120s timeout + backend-aware empty state

### DIFF
--- a/static/app/50-control-transport.js
+++ b/static/app/50-control-transport.js
@@ -1651,6 +1651,10 @@ function dashboardControlRequestTimeoutMs(method) {
     case 'api_managed_context_records':
     case 'api_managed_context_anchors':
     case 'api_managed_context_fission':
+    // Fork points cold-scan the backend's whole transcript server-side
+    // (gigabyte codex rollouts parse in 6-11s per pass, two passes on a
+    // cache miss) — the generic 5 s local-read default aborts mid-scan.
+    case 'api_session_fork_points':
     case 'api_mcp_tool_call':
       return 120000;
     case 'api_session_detail':

--- a/static/app/57b-session-fork.js
+++ b/static/app/57b-session-fork.js
@@ -61,7 +61,10 @@ async function loadSessionForkPoints(session, sessionId, body) {
   body.appendChild(list);
   const points = Array.isArray(catalog.fork_points) ? catalog.fork_points : [];
   if (points.length === 0) {
-    list.textContent = 'No fork points yet (native sessions expose them from the last persisted state).';
+    list.textContent =
+      catalog.source === 'intendant'
+        ? 'No fork points yet: native sessions expose them from the last persisted conversation (stop or complete a round first).'
+        : 'No fork points yet: this session has no completed turns in its transcript.';
     return;
   }
   const source = catalog.source || sessionForkSourceForCatalog(session);


### PR DESCRIPTION
Field-found follow-up to #386: `api_session_fork_points` was absent from the per-method timeout family table (50-control-transport.js), so it ran under the generic **5s** local-read default — while its cold hit scans the backend's entire transcript server-side. Measured on real stores: gigabyte codex rollouts parse in 6–11s **per pass**, and a cache miss pays two passes, so any big session aborted mid-scan (Safari renders the composed-signal abort as `Fetch is aborted`). The method now shares the 120s budget of the managed-context reads it reuses (the warm anchor-scan cache makes repeat opens fast; live sessions never quiesce into the cache, noted as a v2 candidate).

Also makes the empty-catalog message backend-aware — it previously said "native sessions expose them from the last persisted state" for every backend.

Battery: app.html regenerated; unit suite green locally.