### PR TITLE
event: share ModelResponseDelta text as Arc<str> across broadcast clones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ path = "src/bin/connect/main.rs"
 owner-plane-core = { path = "crates/owner-plane-core" }
 owner-plane-reducer = { path = "crates/owner-plane-reducer", default-features = false }
 tokio = { version = "1.0", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 thiserror = "1.0"
 chrono = "0.4"

--- a/src/bin/caller/agent_loop.rs
+++ b/src/bin/caller/agent_loop.rs
@@ -1217,10 +1217,13 @@ pub(crate) async fn run_agent_loop(
                 let stream_session_id = local_session_id.clone();
                 let stream_activity = activity.clone();
                 let on_stream_event = move |event: crate::provider::StreamEvent| {
-                    if let crate::provider::StreamEvent::Delta(ref text) = event {
+                    // The closure owns the event: destructure by value and
+                    // move the delta text into the shared payload instead of
+                    // cloning it.
+                    if let crate::provider::StreamEvent::Delta(text) = event {
                         stream_bus.send(AppEvent::ModelResponseDelta {
                             session_id: stream_session_id.clone(),
-                            text: text.clone(),
+                            text: text.into(),
                         });
                         if let Some(activity) = &stream_activity {
                             // Live response bytes — the machine's own

--- a/src/bin/caller/event.rs
+++ b/src/bin/caller/event.rs
@@ -141,9 +141,14 @@ pub enum AppEvent {
         source: Option<String>,
     },
     /// Incremental text delta from streaming model response.
+    ///
+    /// `text` is `Arc<str>`: this is the highest-rate bus event (one per
+    /// streamed token) and the broadcast ring clones the whole event once
+    /// per subscriber, so a shared payload makes each per-subscriber clone
+    /// a refcount bump instead of a heap copy of the delta text.
     ModelResponseDelta {
         session_id: Option<String>,
-        text: String,
+        text: Arc<str>,
     },
     JsonExtracted {
         preview: String,
@@ -3201,7 +3206,10 @@ impl DeltaCoalesceBuffer {
     /// the same byte stream.
     fn flush(&mut self, outbound_tx: &tokio::sync::broadcast::Sender<String>) {
         for (session_id, text) in self.pending.drain(..) {
-            let outbound = crate::types::OutboundEvent::ModelResponseDelta { session_id, text };
+            let outbound = crate::types::OutboundEvent::ModelResponseDelta {
+                session_id,
+                text: text.into(),
+            };
             if let Ok(json) = serde_json::to_string(&outbound) {
                 let _ = outbound_tx.send(json);
             }
@@ -4036,7 +4044,7 @@ mod tests {
             for _ in 0..deltas_per_intent {
                 bus.send(AppEvent::ModelResponseDelta {
                     session_id: Some("flood".to_string()),
-                    text: "x".to_string(),
+                    text: "x".into(),
                 });
             }
             bus.send(AppEvent::ControlCommand(ControlMsg::SetAutonomy {
@@ -4086,7 +4094,7 @@ mod tests {
         // Not on the lane: high-frequency stream events.
         bus.send(AppEvent::ModelResponseDelta {
             session_id: None,
-            text: "ignored".to_string(),
+            text: "ignored".into(),
         });
         bus.send(AppEvent::SessionIdentity {
             session_id: "s2".to_string(),
@@ -4191,12 +4199,12 @@ mod tests {
         for text in ["a", "b", "c"] {
             bus.send(AppEvent::ModelResponseDelta {
                 session_id: Some("s1".to_string()),
-                text: text.to_string(),
+                text: text.into(),
             });
         }
         bus.send(AppEvent::ModelResponseDelta {
             session_id: Some("s2".to_string()),
-            text: "z".to_string(),
+            text: "z".into(),
         });
         // Non-delta event: every delta sent above must flush before it.
         bus.send(AppEvent::DoneSignal {
@@ -4246,7 +4254,7 @@ mod tests {
         });
         bus.send(AppEvent::ModelResponseDelta {
             session_id: Some("s1".to_string()),
-            text: "after".to_string(),
+            text: "after".into(),
         });
 
         let first = tokio::time::timeout(std::time::Duration::from_secs(5), outbound_rx.recv())
@@ -6264,7 +6272,7 @@ mod tests {
         for i in 0..5000 {
             bus.send(AppEvent::ModelResponseDelta {
                 session_id: Some("thread-1".to_string()),
-                text: format!("delta-{i}"),
+                text: format!("delta-{i}").into(),
             });
             bus.send(AppEvent::Tick);
         }
@@ -6512,11 +6520,46 @@ mod tests {
     fn outbound_model_response_delta() {
         let event = AppEvent::ModelResponseDelta {
             session_id: None,
-            text: "hello".to_string(),
+            text: "hello".into(),
         };
         let outbound = app_event_to_outbound(&event).unwrap();
         let json = serde_json::to_string(&outbound).unwrap();
         assert!(json.contains("\"event\":\"model_response_delta\""));
+    }
+
+    /// `text` is `Arc<str>`; serde (via the `rc` feature) must serialize it
+    /// exactly like the `String` it replaced — a plain JSON string — so the
+    /// outbound wire line is byte-identical, and wire consumers (the peer
+    /// `WireEventUpcaster`) must deserialize it back.
+    #[test]
+    fn outbound_model_response_delta_wire_json_is_pinned() {
+        let with_session = crate::types::OutboundEvent::ModelResponseDelta {
+            session_id: Some("s1".to_string()),
+            text: "hello".into(),
+        };
+        assert_eq!(
+            serde_json::to_string(&with_session).unwrap(),
+            r#"{"event":"model_response_delta","session_id":"s1","text":"hello"}"#
+        );
+
+        let without_session = crate::types::OutboundEvent::ModelResponseDelta {
+            session_id: None,
+            text: "hi".into(),
+        };
+        assert_eq!(
+            serde_json::to_string(&without_session).unwrap(),
+            r#"{"event":"model_response_delta","text":"hi"}"#
+        );
+
+        match serde_json::from_str::<crate::types::OutboundEvent>(
+            r#"{"event":"model_response_delta","session_id":"s1","text":"hello"}"#,
+        ) {
+            Ok(crate::types::OutboundEvent::ModelResponseDelta { session_id, text }) => {
+                assert_eq!(session_id.as_deref(), Some("s1"));
+                assert_eq!(&*text, "hello");
+            }
+            other => panic!("expected ModelResponseDelta, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/bin/caller/external_events.rs
+++ b/src/bin/caller/external_events.rs
@@ -1058,7 +1058,7 @@ pub(crate) async fn drain_external_agent_events_with_prefetched(
                 );
                 config.bus.send(AppEvent::ModelResponseDelta {
                     session_id: config.session_id.clone(),
-                    text,
+                    text: text.into(),
                 });
             }
             external_agent::AgentEvent::Message { text } => {

--- a/src/bin/caller/fission_lifecycle.rs
+++ b/src/bin/caller/fission_lifecycle.rs
@@ -714,7 +714,7 @@ mod tests {
         for _ in 0..10_000 {
             bus.send(AppEvent::ModelResponseDelta {
                 session_id: Some("flood".to_string()),
-                text: "x".to_string(),
+                text: "x".into(),
             });
         }
         bus.send(AppEvent::DoneSignal {
@@ -724,7 +724,7 @@ mod tests {
         for _ in 0..5_000 {
             bus.send(AppEvent::ModelResponseDelta {
                 session_id: Some("flood".to_string()),
-                text: "x".to_string(),
+                text: "x".into(),
             });
         }
 

--- a/src/bin/caller/peer/upcast.rs
+++ b/src/bin/caller/peer/upcast.rs
@@ -678,7 +678,9 @@ impl AppEventUpcaster {
                 vec![PeerEvent::Message {
                     id,
                     role: MessageRole::Assistant,
-                    content: MessageContent::Text { text: text.clone() },
+                    content: MessageContent::Text {
+                        text: text.to_string(),
+                    },
                     partial: true,
                 }]
             }
@@ -2111,7 +2113,9 @@ impl WireEventUpcaster {
                 vec![PeerEvent::Message {
                     id,
                     role: MessageRole::Assistant,
-                    content: MessageContent::Text { text: text.clone() },
+                    content: MessageContent::Text {
+                        text: text.to_string(),
+                    },
                     partial: true,
                 }]
             }

--- a/src/bin/caller/presence.rs
+++ b/src/bin/caller/presence.rs
@@ -1527,7 +1527,7 @@ mod tests {
 
         let event = AppEvent::ModelResponseDelta {
             session_id: None,
-            text: "hi".to_string(),
+            text: "hi".into(),
         };
         assert!(filter_event(&event, &mut last_phase).is_none());
     }

--- a/src/bin/caller/thread_actions.rs
+++ b/src/bin/caller/thread_actions.rs
@@ -3188,9 +3188,10 @@ pub(crate) fn handle_idle_codex_subagent_event(
             // a Codex subagent child never re-keys the session.
         }
         external_agent::AgentEvent::MessageDelta { text } => {
-            config
-                .bus
-                .send(AppEvent::ModelResponseDelta { session_id, text });
+            config.bus.send(AppEvent::ModelResponseDelta {
+                session_id,
+                text: text.into(),
+            });
         }
         external_agent::AgentEvent::Message { text } => {
             persist_external_model_response_for_session_if_needed(

--- a/src/bin/caller/types.rs
+++ b/src/bin/caller/types.rs
@@ -711,7 +711,11 @@ pub enum OutboundEvent {
     ModelResponseDelta {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         session_id: Option<String>,
-        text: String,
+        /// Shared with `AppEvent::ModelResponseDelta` so the conversion is a
+        /// refcount bump. serde (with the `rc` feature) serializes `Arc<str>`
+        /// exactly like `String` — a plain JSON string — so the wire format
+        /// is unchanged.
+        text: std::sync::Arc<str>,
     },
     AgentStarted {
         #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## What

`AppEvent::ModelResponseDelta` is the highest-rate bus event (one per streamed token), and every broadcast subscriber's `recv()` clones the whole event — with a `String` payload that is a heap copy of the delta text per subscriber per token.

- Carry the delta text as `Arc<str>` in both `AppEvent::ModelResponseDelta` and `OutboundEvent::ModelResponseDelta`: per-subscriber broadcast clones and the `app_event_to_outbound` conversion become refcount bumps.
- Remove the emit-site clone in the native loop's `on_stream_event` closure: it owns its `StreamEvent`, so destructure by value and move the text into the shared payload (`Arc::from`). The `activity.observe(ResponseDelta)` call and its ordering are preserved.
- Enable serde's `rc` feature (root `Cargo.toml` only) for the `Arc<str>` Serialize/Deserialize impls. Purely additive; `Cargo.lock` is unchanged and the WASM crates' build graphs don't include the root package, so no artifact drift.

## No behavior change

- Wire JSON is byte-identical: serde serializes `Arc<str>` exactly like `String` (a plain JSON string). Pinned by a new parity test (`outbound_model_response_delta_wire_json_is_pinned`) covering both serialize (with/without `session_id`) and the wire-deserialize path the peer `WireEventUpcaster` uses.
- The outbound delta coalescer (buffering, early-flush cap, flush-before-non-delta ordering) is untouched; its intake takes `&str` via deref coercion.
- Consumers that need owned text (`peer/upcast.rs` message content) take one `to_string()` at that single point — same cost as the `String::clone` they did before.

The event-bus lane split is deliberately out of scope — this is the payload-sharing mechanism only.

## Validation (local, macOS)

- `cargo fmt --check` — clean
- `cargo clippy` — clean
- `cargo nextest run --bins` — 3900 tests run: 3900 passed, 10 skipped
- `cargo build --bin intendant --bin intendant-runtime` — ok
- `cargo test --test e2e` — 23 passed; 0 failed
