### PR TITLE
display: send the initial tile snapshot only on Subscribe

### DIFF
--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -2213,30 +2213,25 @@ impl DisplaySession {
         self.latest_frame.read().await.clone()
     }
 
-    /// D-3c: register a federated WebRtcPeer for tile streaming and
-    /// queue/send an initial snapshot when a captured frame is already
-    /// available. Local DisplaySlot peers are not registered in D-3.
+    /// D-3c: register a federated WebRtcPeer for tile streaming so the
+    /// bridge's delta/periodic-snapshot fanout includes it. Local
+    /// DisplaySlot peers are not registered in D-3.
+    ///
+    /// No initial snapshot is sent here. The client requests its
+    /// baseline with the reliable `Subscribe` control message once its
+    /// `tile-control` channel opens (see [`Self::build_tile_control_handler`];
+    /// `SnapshotRequest` covers recovery) — registration-time sends
+    /// predate that D-4d2 protocol and encoded/shipped the same
+    /// baseline a second time on every federated join.
     pub async fn register_tile_subscriber(&self, peer_id: PeerId) {
         self.tile_subscribers.write().await.insert(peer_id);
-        let Some(peer) = self.get_peer(peer_id).await else {
-            return;
-        };
-        let Some(frame) = self.latest_frame().await else {
-            return;
-        };
-        let epoch = self.tile_epoch.load(Ordering::Relaxed);
-        let snapshot_id = self.tile_snapshot_id.fetch_add(1, Ordering::Relaxed);
-        let visual_marker_value =
-            current_visual_marker_value(&self.diagnostics_visual_marker, self.session_epoch);
-        send_tile_snapshot_to_peer(
-            peer,
-            frame,
-            epoch,
-            snapshot_id,
-            visual_marker_value,
-            Arc::clone(&self.counters),
-        )
-        .await;
+        if self.get_peer(peer_id).await.is_none() {
+            // Raced with a fast Close: the peer left the map between
+            // handle_offer returning and this registration. Drop the
+            // just-inserted entry (mirrors the Close arm's unregister)
+            // instead of leaving it for the reaper.
+            self.tile_subscribers.write().await.remove(&peer_id);
+        }
     }
 
     /// D-3c: unregister a tile subscriber. Safe to call even when the
@@ -4328,6 +4323,90 @@ mod tests {
         session.remove_peer(7).await;
         assert!(session.get_peer(7).await.is_none());
         assert_eq!(session.counters.peer_count.load(Ordering::Relaxed), 0);
+    }
+
+    /// The initial tile baseline is sent once, from the client's
+    /// reliable `Subscribe` control message — registration alone must
+    /// not encode/send a snapshot (it used to, doubling the join-time
+    /// full-screen encode: once at registration, again on Subscribe).
+    #[tokio::test]
+    async fn tile_snapshot_sent_on_subscribe_not_on_registration() {
+        let session = DisplaySession::new(
+            0,
+            Arc::new(StubBackend {
+                width: 64,
+                height: 64,
+            }),
+        );
+        // Both preconditions the old registration-time send needed: a
+        // live peer in the map and a captured frame available.
+        session.register_test_peer_for_cleanup(7).await;
+        *session.latest_frame.write().await = Some(Arc::new(make_test_bgra(64, 64)));
+
+        session.register_tile_subscriber(7).await;
+        assert!(
+            session.tile_subscribers.read().await.contains(&7),
+            "registration must insert into the subscriber set"
+        );
+        // The old send path was awaited inline, so a still-zero counter
+        // here really pins its removal.
+        assert_eq!(
+            session
+                .counters
+                .tile_snapshot_records
+                .load(Ordering::Relaxed),
+            0,
+            "registering a tile subscriber alone must not encode a snapshot"
+        );
+
+        // Subscribe produces the one initial baseline. The handler
+        // spawns its work, so poll with a deadline.
+        let handler = session.build_tile_control_handler(7);
+        handler(self::webrtc::TileControlMessage::Subscribe { client_id: 1 });
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while session
+            .counters
+            .tile_snapshot_records
+            .load(Ordering::Relaxed)
+            == 0
+        {
+            assert!(
+                Instant::now() < deadline,
+                "Subscribe did not produce a snapshot within 5s"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        // Settle so a hypothetical second send would land, then pin
+        // exactly one: a 64x64 frame is a single 64px tile, so one
+        // snapshot records exactly one tile record.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            session
+                .counters
+                .tile_snapshot_records
+                .load(Ordering::Relaxed),
+            1,
+            "the Subscribe control message must produce exactly one snapshot"
+        );
+        session.shutdown.cancel();
+    }
+
+    /// Registration that raced a fast Close (peer already gone from the
+    /// map) must not leave a dead entry in the subscriber set.
+    #[tokio::test]
+    async fn tile_subscriber_registration_drops_entry_for_departed_peer() {
+        let session = DisplaySession::new(
+            0,
+            Arc::new(StubBackend {
+                width: 64,
+                height: 64,
+            }),
+        );
+        session.register_tile_subscriber(9).await;
+        assert!(
+            !session.tile_subscribers.read().await.contains(&9),
+            "a peer absent from the peer map must not stay registered"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

A federated display join encoded the initial tile snapshot **twice**: once at `register_tile_subscriber` (called from the peer-offer path before the SDP answer is sent; the group sits in the driver's pre-open queue until the `tile-snapshot` channel opens) and again when the client's reliable `Subscribe` control message arrived on `tile-control`. Both paths run the same full-screen raw-copy + RLE + lossless-WebP encode, so every join paid it twice — and the client applied two baselines back to back.

This drops the registration-time send. Registration is now pure subscriber-set membership (it still gates the tile bridge's delta/periodic-snapshot fanout), and the initial baseline comes from the client's `Subscribe`, with `SnapshotRequest` (gap/resize/periodic) as the recovery sources. The registration-time send predates the `Subscribe`/recovery control protocol (D-3c2 `283bbf60` vs D-4d2 `34aafc5b`); the newer protocol is the intended snapshot source.

A registration that raced a fast `Close` (peer already gone from the map) now removes its just-inserted set entry instead of leaving it for the reaper — keeps the existing peer-existence check meaningful.

## Client audit — every tile client sends `Subscribe` on tile-control open

Removing the registration-time snapshot is safe only if every tile client requests its own baseline. All tile clients:

- **Dashboard SPA (federated peer displays)** — `static/app/52-peer-display.js:874-876` is the only fragment that creates the tile data channels; its `tile-control` `onopen` handler sends the Subscribe frame at `static/app/52-peer-display.js:888-891` (`channel.send(encodeTileSubscribeFrame(clientId))`; encoder at `static/app/51-peer-approvals.js:432-440`, wire type `TILE_FRAME_SUBSCRIBE = 0x10` matching `tile/transport.rs::TYPE_SUBSCRIBE`). The local display viewer (`static/app/45-displays-webrtc.js:701-706`) creates only control/pointer/clipboard channels — local DisplaySlot peers are never tile subscribers, unchanged.
- **Synthetic tile-test harness** — `static/tile-test-harness.js` (D-2 parked seed, loaded via `?tile-test=1`) drives the compositor from a purely local `SyntheticTileStream`; it uses no WebRTC transport at all (its header scopes out "WebRTC data-channel transport (D-3)"), so it neither needs nor receives server snapshots. Unaffected.
- **Native (Rust-side) tile clients** — none exist. The Rust side is only ever the answering server: tile channels are browser-created before `createOffer()` and the driver passively observes them by label (`crates/intendant-display/src/webrtc/mod.rs:621-625`); no code under `crates/` or `src/bin/caller/` creates `tile-control`/`tile-snapshot`/`tile-deltas` channels as a client (repo-wide sweep for the labels and `TileFrame::Subscribe` construction: only the SPA fragments, the transport codec, and the driver's decode path).

Cross-channel note: deltas can reach the client before its first baseline (they always could — deltas ride an unordered channel), and the compositor already handles it: an update whose epoch is ahead of the client's is dropped with a rate-limited `SnapshotRequest` (`static/app/51-peer-approvals.js:607-623`), and the compositor starts at epoch 0 while the server mints from 1.

## Test

`tile_snapshot_sent_on_subscribe_not_on_registration` pins the contract server-side with the `tile_snapshot_records` counter: registering a subscriber alone (live peer in the map + captured frame available — both preconditions the old send needed) leaves it at zero, and the `Subscribe` control message produces exactly one record (a 64x64 stub frame is a single tile, so one snapshot == one record). `tile_subscriber_registration_drops_entry_for_departed_peer` pins the fast-Close cleanup.

## Battery

- `cargo fmt --check`
- `cargo clippy`
- `cargo nextest run --bins`
- `cargo nextest run -p intendant-display`
- `cargo build --bin intendant --bin intendant-runtime`
- `cargo test --test e2e`
