### PR TITLE
dashboard: unwrap the daemonApi envelope in the fork-points panel

### DIFF
--- a/static/app/57b-session-fork.js
+++ b/static/app/57b-session-fork.js
@@ -39,7 +39,16 @@ async function loadSessionForkPoints(session, sessionId, body) {
   body.textContent = 'Loading fork points…';
   let catalog = null;
   try {
-    catalog = await daemonApi.request('api_session_fork_points', { session_id: sessionId });
+    // Facade contract: request() resolves {ok, status, body} on both
+    // lanes — the catalog is the BODY (reading fields off the envelope
+    // rendered every session as an empty catalog; found live 2026-07-17).
+    const resp = await daemonApi.request('api_session_fork_points', { session_id: sessionId });
+    if (!resp || resp.ok === false) {
+      const detail = resp && resp.body && resp.body.error;
+      body.textContent = `Fork points unavailable: ${detail || `HTTP ${(resp && resp.status) || '?'}`}`;
+      return;
+    }
+    catalog = resp.body;
   } catch (e) {
     body.textContent = `Fork points unavailable: ${e && e.message ? e.message : e}`;
     return;


### PR DESCRIPTION
Root cause of both field reports against the fork panel (#386/#412 follow-up): `daemonApi.request()` resolves the documented `{ok, status, body}` envelope on BOTH lanes (facade header, line 5; every other consumer unwraps — e.g. 54-session-lifecycle's `resp.ok` / `resp.body` idiom). The panel read `supported`/`fork_points`/`source` off the ENVELOPE, so its defensive coercions rendered every catalog — on every lane, in every browser — as the empty state, while the endpoint itself served full catalogs (verified via direct mTLS curl against the reporting daemon: ~500 anchors for the reported session; and by driving the live reporting Safari tab, where an in-page raw fetch returned the full catalog while the freshly re-driven panel still showed empty).

Fix: consume per contract — `resp.ok === false` renders the body's error with the HTTP status; otherwise the catalog is `resp.body`.

Verification: endpoint + facade contract proven as above; headless product-path drive attempted (row-targeting in fresh boots is brittle — three selector variants hit peek/wrong-row; noted for a future `--click` probe in validate-dashboard); final confirmation loop is the reporting tab after the operator's rebuild, which I can re-drive directly.