### PR TITLE
gateway: stream /ws bootstrap by spawning the outbound writer first

### DIFF
--- a/src/bin/caller/web_gateway/listener.rs
+++ b/src/bin/caller/web_gateway/listener.rs
@@ -1825,8 +1825,41 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
                     // bootstrap sequence. Fired after the last bootstrap
                     // enqueue; `ws_outbound_task`'s biased select drains
                     // direct frames first, then opens the broadcast lane.
+                    // Dropping the sender without firing (a bootstrap stage
+                    // died mid-generation) closes the connection instead —
+                    // never a partial bootstrap followed by live events.
                     let (bootstrap_flushed_tx, bootstrap_flushed_rx) =
                         tokio::sync::oneshot::channel::<()>();
+
+                    let ws_session_cancel = tokio_util::sync::CancellationToken::new();
+
+                    // Outbound: broadcast + direct responses → WebSocket.
+                    // Spawned BEFORE bootstrap generation so the frames
+                    // queued below stream to the socket as they are
+                    // produced instead of accumulating on the unbounded
+                    // direct lane until generation finishes — the client's
+                    // first byte no longer waits for the whole bootstrap,
+                    // per-connection bootstrap memory is bounded by socket
+                    // drain, and a client that disconnects mid-generation
+                    // is noticed by the writer immediately. The ordering
+                    // barrier above still holds: the task's biased select
+                    // serves the direct lane ahead of the flush arm, so
+                    // the broadcast + authority lanes stay shut until
+                    // every bootstrap frame is on the wire.
+                    let outbound = tokio::spawn(ws_outbound_task(
+                        outbound_rx,
+                        direct_rx,
+                        terminal_forward_rx,
+                        ws_tx,
+                        authority_change_rx,
+                        connection_id.clone(),
+                        display_input_authority.clone(),
+                        session_registry.clone(),
+                        bootstrap_caches.clone(),
+                        bootstrap_flushed_rx,
+                        dashboard_control_grant_for_ws.clone(),
+                        ws_session_cancel.clone(),
+                    ));
 
                     // Send bootstrap state snapshot on connect (with connection_id).
                     // Include config (provider/model) since AgentStateSnapshot
@@ -2097,15 +2130,25 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
                         // Cache-fast after the first connect, but still file IO on a
                         // miss — keep it off the reactor (single-flight in the cache
                         // coalesces concurrent connects).
-                        let replay_result = tokio::task::spawn_blocking(move || {
-                            session_log_replay_payload_from_dir_with_limit(
-                                &log_dir,
-                                Some(WEBSOCKET_BOOTSTRAP_REPLAY_ENTRY_LIMIT),
-                            )
-                        })
-                        .await
-                        .ok()
-                        .flatten();
+                        //
+                        // The writer is already streaming; once it has exited
+                        // (socket closed, grant revoked) nothing queued here
+                        // can reach the client, so skip the replay read for a
+                        // connection that is already gone. Teardown still runs
+                        // through the normal inbound-spawn + join path below.
+                        let replay_result = if direct_tx.is_closed() {
+                            None
+                        } else {
+                            tokio::task::spawn_blocking(move || {
+                                session_log_replay_payload_from_dir_with_limit(
+                                    &log_dir,
+                                    Some(WEBSOCKET_BOOTSTRAP_REPLAY_ENTRY_LIMIT),
+                                )
+                            })
+                            .await
+                            .ok()
+                            .flatten()
+                        };
                         if let Some((replay, external_session_id)) = replay_result {
                             if let Some(external_session_id) = external_session_id {
                                 replayed_external_session_ids.insert(external_session_id);
@@ -2141,6 +2184,12 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
                             .unwrap_or_default();
                     active_external_sessions.sort_by(|a, b| a.0.cmp(&b.0));
                     for (session_id, source) in active_external_sessions {
+                        // Same early-out as the replay read above: the
+                        // per-session external replay is file IO nobody can
+                        // receive once the writer has exited.
+                        if direct_tx.is_closed() {
+                            break;
+                        }
                         // Wrapper-covered sessions replay from the wrapper
                         // log ONLY. The old mtime tiebreak re-sent the whole
                         // external transcript whenever the backend's file
@@ -2193,8 +2242,6 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
                     //   {"t":"voice_diagnostic",...}      → AppEvent::VoiceDiagnostic
                     //   {"t":"tool_request", "id":"...", "tool":"...", "args":{}} → tool_response
                     //   {"action":"status", ...}         → AppEvent::ControlCommand
-                    let ws_session_cancel = tokio_util::sync::CancellationToken::new();
-
                     let inbound_ctx = WsInboundCtx {
                         bus: bus.clone(),
                         query_ctx: query_ctx.clone(),
@@ -2231,22 +2278,6 @@ pub(crate) fn spawn_web_gateway_from_cert_dir(
                     // Attention-nudge presence: a live `/ws` client is the
                     // "somebody is watching" signal that suppresses pushes.
                     crate::attention_nudge::dashboard_connected();
-
-                    // Outbound: broadcast + direct responses → WebSocket
-                    let outbound = tokio::spawn(ws_outbound_task(
-                        outbound_rx,
-                        direct_rx,
-                        terminal_forward_rx,
-                        ws_tx,
-                        authority_change_rx,
-                        connection_id.clone(),
-                        display_input_authority.clone(),
-                        session_registry.clone(),
-                        bootstrap_caches.clone(),
-                        bootstrap_flushed_rx,
-                        dashboard_control_grant_for_ws.clone(),
-                        ws_session_cancel,
-                    ));
 
                     let _ = tokio::join!(inbound, outbound);
                     crate::attention_nudge::dashboard_disconnected();

--- a/src/bin/caller/web_gateway/ws_session.rs
+++ b/src/bin/caller/web_gateway/ws_session.rs
@@ -155,13 +155,16 @@ pub(crate) const TERMINAL_FORWARD_LANE_CAP: usize = 16;
 /// the daemon -- only the resolved `you|other|unclaimed` state does.
 ///
 /// Two live-update guarantees ride here:
-/// - **Bootstrap ordering:** live broadcast events stay gated until the
-///   listener's bootstrap frames (queued on the direct lane before this task
-///   spawns) have drained — `bootstrap_flushed_rx` fires after the last
-///   enqueue, and the `biased` select drains the direct lane first, so no
-///   live event can precede or interleave the bootstrap. Heartbeats are
-///   unaffected: protocol pings ride the tungstenite stream itself and the
-///   direct/authority lanes are never gated.
+/// - **Bootstrap ordering:** live broadcast + authority events stay gated
+///   until the listener's bootstrap frames have drained. The task spawns
+///   *before* bootstrap generation and streams each frame as the listener
+///   queues it; `bootstrap_flushed_rx` fires after the last enqueue, and
+///   the `biased` select serves the direct lane ahead of the flush arm, so
+///   no live event can precede or interleave the bootstrap. A flush sender
+///   dropped without firing means generation died mid-bootstrap — possibly
+///   after frames reached the wire — and fails closed to a socket close.
+///   Heartbeats are unaffected: protocol pings ride the tungstenite stream
+///   itself and the direct lane is never gated.
 /// - **Loss visibility:** a lagged broadcast receiver no longer skips
 ///   silently — the connection gets an `event_gap` frame (same `skipped`
 ///   payload the tunnel's `event_gap` carries) followed by a cached-state
@@ -248,13 +251,27 @@ pub(crate) async fn ws_outbound_task(
                     None => terminal_lane_open = false,
                 }
             }
-            _ = &mut bootstrap_flushed_rx, if !bootstrap_flushed => {
-                // Fired after the listener queued the last bootstrap frame
-                // (a dropped sender reads the same way). The biased arm
-                // order above guarantees those frames drained before this
-                // branch can win, so the broadcast lane opens exactly at
-                // the bootstrap/live boundary.
-                bootstrap_flushed = true;
+            res = &mut bootstrap_flushed_rx, if !bootstrap_flushed => {
+                match res {
+                    Ok(()) => {
+                        // Fired after the listener queued the last bootstrap
+                        // frame. The biased arm order above guarantees those
+                        // frames drained before this branch can win, so the
+                        // broadcast lane opens exactly at the bootstrap/live
+                        // boundary.
+                        bootstrap_flushed = true;
+                    }
+                    Err(_) => {
+                        // Sender dropped without firing: bootstrap generation
+                        // died mid-way. This task spawns ahead of generation,
+                        // so part of the bootstrap may already be on the wire
+                        // — fail closed and end the connection rather than
+                        // follow a partial bootstrap with live events.
+                        let _ = ws_tx.send(Message::Close(None)).await;
+                        session_cancel.cancel();
+                        break;
+                    }
+                }
             }
             msg = outbound_rx.recv(), if bootstrap_flushed => {
                 if !grant.opening_authority_is_current() {
@@ -339,7 +356,14 @@ pub(crate) async fn ws_outbound_task(
                     }
                 }
             }
-            msg = authority_change_rx.recv() => {
+            // Gated like the broadcast lane: the writer is live during
+            // bootstrap generation, and an ungated authority change could
+            // beat the deferred bootstrap authority snapshot (computed
+            // early, queued after log replay) onto the wire — the stale
+            // snapshot would then overwrite the newer live state. Changes
+            // buffer in the receiver until the flush; `is_current` skips
+            // superseded revisions on drain, and the Lagged arm re-snapshots.
+            msg = authority_change_rx.recv(), if bootstrap_flushed => {
                 if !grant.opening_authority_is_current() {
                     let _ = ws_tx.send(Message::Close(None)).await;
                     session_cancel.cancel();
@@ -2719,5 +2743,264 @@ mod signaling_ownership_tests {
             !guard(),
             "a view-only display offer must not admit input or clipboard mutation"
         );
+    }
+}
+
+#[cfg(test)]
+mod outbound_bootstrap_ordering_tests {
+    use super::*;
+
+    /// Minimal display backend for the registry-backed authority test
+    /// (same shape as `input_authorizer_cache_tests`' local backend).
+    struct OrderingTestDisplayBackend;
+
+    #[async_trait::async_trait]
+    impl crate::display::DisplayBackend for OrderingTestDisplayBackend {
+        async fn start_capture(
+            &self,
+            _fps: u32,
+        ) -> Result<mpsc::Receiver<crate::display::Frame>, crate::error::CallerError> {
+            let (_tx, rx) = mpsc::channel(1);
+            Ok(rx)
+        }
+
+        async fn stop_capture(&self) {}
+
+        async fn inject_input(
+            &self,
+            _event: crate::display::InputEvent,
+        ) -> Result<(), crate::error::CallerError> {
+            Ok(())
+        }
+
+        fn resolution(&self) -> (u32, u32) {
+            (64, 64)
+        }
+
+        fn kind(&self) -> &'static str {
+            "outbound-ordering-test"
+        }
+    }
+
+    struct OutboundHarness {
+        broadcast_tx: broadcast::Sender<String>,
+        direct_tx: mpsc::UnboundedSender<String>,
+        /// Held open: the listener keeps the terminal lane's sender alive
+        /// (it moves into the inbound task) — dropping it here would close
+        /// the lane, which is not the mid-bootstrap shape under test.
+        _terminal_tx: mpsc::Sender<String>,
+        authority_change_tx: broadcast::Sender<DisplayInputAuthorityChange>,
+        flush_tx: Option<tokio::sync::oneshot::Sender<()>>,
+        client: tokio_tungstenite::WebSocketStream<tokio::io::DuplexStream>,
+        task: tokio::task::JoinHandle<()>,
+    }
+
+    /// Handshake a real client<->server WebSocket over an in-memory duplex
+    /// and spawn `ws_outbound_task` on the server's write half — the exact
+    /// early-spawn shape the listener uses: the writer is already running
+    /// while the "bootstrap" (the test body) is still queueing frames.
+    async fn spawn_outbound_harness(
+        session_registry: Option<crate::display::SharedSessionRegistry>,
+        display_input_authority: Arc<DisplayInputAuthority>,
+    ) -> OutboundHarness {
+        let (client_io, server_io) = tokio::io::duplex(256 * 1024);
+        let (server_ws, client_ws) = tokio::join!(
+            tokio_tungstenite::accept_async(DemuxStream::new(Box::pin(server_io))),
+            tokio_tungstenite::client_async("ws://intendant.test/ws", client_io),
+        );
+        let server_ws = server_ws.expect("server handshake");
+        let (client_ws, _response) = client_ws.expect("client handshake");
+        let (ws_tx, mut server_rx) = server_ws.split();
+        // The read half normally lives in ws_inbound_task; parking it in a
+        // task keeps protocol frames (client close replies) drained without
+        // tearing the stream down under the writer.
+        tokio::spawn(async move { while let Some(Ok(_)) = server_rx.next().await {} });
+
+        let (broadcast_tx, outbound_rx) = broadcast::channel(64);
+        let (direct_tx, direct_rx) = mpsc::unbounded_channel();
+        let (terminal_tx, terminal_rx) = mpsc::channel(TERMINAL_FORWARD_LANE_CAP);
+        let (authority_change_tx, authority_change_rx) = broadcast::channel(64);
+        let (flush_tx, flush_rx) = tokio::sync::oneshot::channel();
+        let task = tokio::spawn(ws_outbound_task(
+            outbound_rx,
+            direct_rx,
+            terminal_rx,
+            ws_tx,
+            authority_change_rx,
+            "conn-under-test".to_string(),
+            display_input_authority,
+            session_registry,
+            crate::dashboard_control::DashboardBootstrapCaches::default(),
+            flush_rx,
+            crate::dashboard_control::DashboardControlGrant::TrustedLocal,
+            CancellationToken::new(),
+        ));
+        OutboundHarness {
+            broadcast_tx,
+            direct_tx,
+            _terminal_tx: terminal_tx,
+            authority_change_tx,
+            flush_tx: Some(flush_tx),
+            client: client_ws,
+            task,
+        }
+    }
+
+    /// Next text frame the client receives, strictly in arrival order (no
+    /// skipping), so ordering assertions stay exact.
+    async fn next_client_json(
+        client: &mut tokio_tungstenite::WebSocketStream<tokio::io::DuplexStream>,
+    ) -> serde_json::Value {
+        loop {
+            let msg = tokio::time::timeout(std::time::Duration::from_secs(5), client.next())
+                .await
+                .expect("timed out waiting for a frame")
+                .expect("stream ended")
+                .expect("websocket error");
+            match msg {
+                Message::Text(text) => {
+                    return serde_json::from_str(&text).expect("text frame is JSON")
+                }
+                Message::Ping(_) | Message::Pong(_) => continue,
+                other => panic!("expected a text frame, got {other:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn broadcast_stays_gated_until_flush_with_writer_live_mid_bootstrap() {
+        let mut h = spawn_outbound_harness(None, Arc::new(DisplayInputAuthority::default())).await;
+
+        // The first bootstrap frame streams immediately — before the
+        // "generation" (this test body) finishes, long before the flush.
+        h.direct_tx
+            .send(serde_json::json!({"t": "bootstrap", "n": 1}).to_string())
+            .unwrap();
+        assert_eq!(next_client_json(&mut h.client).await["n"], 1);
+
+        // The direct lane is now provably empty (frame 1 observed on the
+        // client) and the flush has not fired: a live broadcast event must
+        // not reach the wire yet.
+        h.broadcast_tx
+            .send(serde_json::json!({"event": "live", "n": 99}).to_string())
+            .unwrap();
+        // Give a broken (ungated) writer every chance to leak the event.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // A later bootstrap frame must still beat the buffered live event.
+        h.direct_tx
+            .send(serde_json::json!({"t": "bootstrap", "n": 2}).to_string())
+            .unwrap();
+        assert_eq!(
+            next_client_json(&mut h.client).await["n"],
+            2,
+            "every bootstrap frame must precede any live broadcast event"
+        );
+
+        // Flush opens the broadcast lane; the buffered event drains now.
+        h.flush_tx.take().unwrap().send(()).unwrap();
+        assert_eq!(next_client_json(&mut h.client).await["n"], 99);
+
+        h.task.abort();
+    }
+
+    #[tokio::test]
+    async fn dropped_flush_sender_fails_closed_instead_of_leaking_live_events() {
+        let mut h = spawn_outbound_harness(None, Arc::new(DisplayInputAuthority::default())).await;
+
+        h.direct_tx
+            .send(serde_json::json!({"t": "bootstrap", "n": 1}).to_string())
+            .unwrap();
+        assert_eq!(next_client_json(&mut h.client).await["n"], 1);
+
+        // A live event is pending when bootstrap generation "dies": the
+        // flush sender drops without firing.
+        h.broadcast_tx
+            .send(serde_json::json!({"event": "live", "n": 99}).to_string())
+            .unwrap();
+        drop(h.flush_tx.take());
+
+        // The connection must close without ever surfacing the live event —
+        // a partial bootstrap is never followed by live traffic.
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                match h.client.next().await {
+                    Some(Ok(Message::Text(text))) => {
+                        panic!("no frame may follow a partial bootstrap, got {text}")
+                    }
+                    Some(Ok(Message::Close(_))) | Some(Err(_)) | None => break,
+                    Some(Ok(_)) => continue,
+                }
+            }
+        })
+        .await
+        .expect("connection should close after the flush sender is dropped");
+        tokio::time::timeout(std::time::Duration::from_secs(5), h.task)
+            .await
+            .expect("outbound task should exit")
+            .expect("outbound task should not panic");
+    }
+
+    #[tokio::test]
+    async fn authority_changes_hold_until_flush_so_deferred_snapshot_stays_last() {
+        let session_registry: crate::display::SharedSessionRegistry = Arc::new(
+            tokio::sync::RwLock::new(crate::display::SessionRegistry::new()),
+        );
+        session_registry.write().await.insert(
+            7,
+            Arc::new(crate::display::DisplaySession::new(
+                7,
+                Arc::new(OrderingTestDisplayBackend),
+            )),
+        );
+        let authority = Arc::new(DisplayInputAuthority::default());
+        let mut h = spawn_outbound_harness(Some(session_registry), Arc::clone(&authority)).await;
+
+        h.direct_tx
+            .send(serde_json::json!({"t": "bootstrap", "n": 1}).to_string())
+            .unwrap();
+        assert_eq!(next_client_json(&mut h.client).await["n"], 1);
+
+        // Another connection claims input authority mid-generation. Its
+        // personalized change must not beat the (already computed, still
+        // queued) bootstrap authority snapshot onto the wire.
+        let (other_tx, _other_rx) = mpsc::unbounded_channel();
+        apply_grant_input_authority(
+            7,
+            "some-other-connection".to_string(),
+            other_tx,
+            &authority,
+            &h.authority_change_tx,
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // The deferred bootstrap snapshot (stale by construction — it was
+        // computed before the claim) drains first...
+        h.direct_tx
+            .send(
+                serde_json::json!({
+                    "t": "display_input_authority_state",
+                    "display_id": 7,
+                    "state": "unclaimed",
+                })
+                .to_string(),
+            )
+            .unwrap();
+        let snapshot = next_client_json(&mut h.client).await;
+        assert_eq!(snapshot["t"], "display_input_authority_state");
+        assert_eq!(
+            snapshot["state"], "unclaimed",
+            "the queued bootstrap snapshot must precede any live authority frame"
+        );
+
+        // ...and the buffered live change lands after the flush, so the
+        // newer state wins on the client.
+        h.flush_tx.take().unwrap().send(()).unwrap();
+        let live = next_client_json(&mut h.client).await;
+        assert_eq!(live["t"], "display_input_authority_state");
+        assert_eq!(live["display_id"], 7);
+        assert_eq!(live["state"], "other");
+
+        h.task.abort();
     }
 }


### PR DESCRIPTION
## What

In the legacy-WS accept path, the per-connection outbound writer (`ws_outbound_task`) previously started only after the entire bootstrap sequence (state snapshot, cached state, session catalog state, log replay) had been generated and queued on the unbounded `direct_tx` lane. Consequences: the full bootstrap accumulated in memory per connection, the client's first byte waited for complete generation, and a client that disconnected mid-generation went unnoticed until the writer finally started.

This PR spawns the writer **before** bootstrap generation, so bootstrap frames stream to the socket as they are enqueued. Latency: first byte ships with the first frame. Memory: the direct lane holds only what the socket hasn't drained yet. Disconnects: the writer notices immediately, and the two expensive replay stages (session-log replay `spawn_blocking` read, per-session external replays) early-out via `direct_tx.is_closed()` once the writer has exited.

## Ordering verification

The writer's machinery was designed as an ordering barrier; early spawn preserves each guarantee:

1. **Every bootstrap frame reaches the socket before any live broadcast event.** All bootstrap enqueues happen before the `bootstrap_flushed_tx.send(())` (program order, single task) and the mpsc lane is FIFO. The `biased` select polls the direct arm ahead of the flush arm, so the flush arm can only win an iteration in which the direct lane is empty — at which point every bootstrap frame has already been written to `ws_tx`. The broadcast arm stays disabled until then, exactly as before.
2. **`bootstrap_flushed` still fires after the last bootstrap enqueue.** The send site did not move.
3. **Terminal-forward and authority lanes keep their pre-change ordering relative to bootstrap.**
   - *Terminal:* forwarders only come into existence via `ws_inbound_task` handlers, and inbound still spawns after generation — the lane is physically empty during bootstrap, and once frames exist the biased select still drains any remaining direct frames first. Unchanged, no gate needed.
   - *Authority:* this one required a real fix. The authority arm was previously ordered after the flush arm only by select geometry (late spawn meant the fired oneshot always won first). With the writer live during generation, an ungated live authority change (from another connection/tunnel) could hit the wire mid-bootstrap — and the deferred bootstrap authority snapshot (computed early, queued after log replay) would then land *after* it and stale-overwrite the newer state. The arm is now gated on `bootstrap_flushed` like the broadcast arm; changes buffer in the receiver, `is_current` skips superseded revisions on drain, and the Lagged branch still re-snapshots. Post-flush arm order (broadcast before authority) is untouched.

**Writer-not-yet-running assumptions audited** between the old spawn point and the enqueue sites: all bootstrap `direct_tx.send`s are `let _ =` (now genuinely fallible when the client vanishes — intended, and the new early-outs skip the file IO in that case); the flush `send` is `let _ =` (can now fail only when the writer is already gone — moot); `dashboard_tabs.register` carries no sender; `attention_nudge` timing is untouched (still tied to the inbound spawn/join). No `return`/`?`/panic paths exist in the generation region (verified), so the flush-drop arm is a safety net, not a live path.

## Mid-generation failure

Previously a generation failure meant the writer never started and nothing had been sent. Now a partial bootstrap may already be on the wire, so the flush arm handles sender-drop explicitly: `Err` (dropped without firing) sends a WebSocket Close, cancels the session token, and exits — a partial bootstrap is never followed by live events. The old comment's "a dropped sender reads the same way [as fired]" behavior inverted from robustness into a hazard under early spawn; it is now fail-closed.

## Inbound task: deliberately NOT moved

`ws_inbound_task` still spawns after generation. During bootstrap it would handle presence connects (mutating the active-presence slot and answering `presence_welcome` on `direct_tx`), tool requests (responses on `direct_tx`), input-authority claims (mutating the authority map and enqueueing personalized frames), terminal opens, and dashboard-control tunneling. Moving it early would interleave client-triggered responses *into* the bootstrap frame sequence on the same direct lane and let claims mutate authority/presence state midway through the snapshot being generated. Keeping it late preserves today's exact semantics: client frames pipelined right after the handshake keep buffering in the socket until generation completes. The writer alone is what streaming needs.

## Not in scope

`direct_tx` stays unbounded — the bounded-bootstrap-lane design is staged separately (the lane is shared with tool_response/state_snapshot traffic).

## Tests

New `outbound_bootstrap_ordering_tests` in `ws_session.rs`: a real client<->server WebSocket handshake over `tokio::io::duplex` (same seam as the existing gateway golden-transcript tests) drives `ws_outbound_task` in the early-spawn shape and pins:
- broadcast events stay gated while the writer is live mid-bootstrap (a later bootstrap frame beats an earlier-published live event);
- a dropped flush sender closes the connection without leaking the pending live event;
- authority changes hold until flush so the deferred bootstrap authority snapshot is never stale-last on the wire (registry-backed, via `apply_grant_input_authority`).

## Battery (verbatim, final tree @ 12984fa6)

- `cargo fmt --check` — clean (exit 0)
- `cargo clippy` — "Finished dev profile [unoptimized + debuginfo] target(s)" (exit 0, no warnings)
- `cargo nextest run --bins --no-fail-fast` — `Summary [  27.227s] 3902 tests run: 3902 passed, 10 skipped` (the 3 new `outbound_bootstrap_ordering_tests` included and passing)
- `cargo build --bin intendant --bin intendant-runtime` — "Finished dev profile" (exit 0)
- `cargo test --test e2e` — `test result: ok. 23 passed; 0 failed; 0 ignored` (the headless mock-provider suite; the CI dashboard-boot probe exercises this exact /ws bootstrap path)

**Load-flake record:** two earlier full-suite runs on a busy box (three other worktrees compiling concurrently under the governor) flaked disjoint sets — run 1: `test_config_endpoint_unauthenticated_when_bearer_set`, `test_dashboard_fs_read_serves_file_bytes`; run 2: `upload_frames_commit_zero_byte_upload`, `test_http_serves_config`, `test_http_serves_audio_processor_js`, `dispatch_routes_on_parsed_paths_not_substrings`. All six pass in isolation (sub-second), every test passed in at least one run, and the quiet-box run above is fully green in one pass. All flaked tests are HTTP-lane/dispatch tests that never enter the WS upgrade branch this PR touches — timing flakes under compile load, not regressions.
