### PR TITLE
sessions: share cached list bodies as Arc<str>; single-flight + capped refreshes

### DIFF
--- a/src/bin/caller/dashboard_control/api_sessions.rs
+++ b/src/bin/caller/dashboard_control/api_sessions.rs
@@ -3020,6 +3020,7 @@ mod tests {
                             &hydrate_home,
                             requested_limit,
                         )
+                        .into()
                     },
                     tx,
                 );

--- a/src/bin/caller/dashboard_control/mod.rs
+++ b/src/bin/caller/dashboard_control/mod.rs
@@ -3685,8 +3685,10 @@ async fn api_sessions_response_from_home(
     // polls this with limit:'all' every 15s per tab, and the core already
     // serves the body from its serialized-string cache): a full validating
     // parse into `IgnoredAny` plus the leading-token check, then the body
-    // splices verbatim into a pre-serialized envelope.
-    let body = body.into_string();
+    // splices verbatim into a pre-serialized envelope. `as_text` borrows
+    // the cache's shared allocation — the splice below is this lane's
+    // only copy of the list text.
+    let body = body.as_text();
     let is_array = body.trim_start().starts_with('[')
         && serde_json::from_str::<serde::de::IgnoredAny>(&body).is_ok();
     if !is_array {

--- a/src/bin/caller/web_gateway/api_core.rs
+++ b/src/bin/caller/web_gateway/api_core.rs
@@ -128,17 +128,36 @@ pub(crate) enum ByteRange {
 
 /// JSON response body in whichever form the handler already has (risk
 /// R8: `PreSerialized` keeps today's string-building hot paths
-/// allocation-identical; `Value` is for structured code).
+/// allocation-identical; `Value` is for structured code; `Shared` is a
+/// refcounted pre-serialized body handed out by a response cache — the
+/// session list — so lanes borrow or write it without copying the
+/// multi-hundred-KB text per request).
 pub(crate) enum JsonBody {
     PreSerialized(String),
+    Shared(std::sync::Arc<str>),
     Value(serde_json::Value),
 }
 
 impl JsonBody {
+    /// Owned serialized text. `Shared` copies here — reach for
+    /// [`Self::as_text`] (read-only consumers) or the HTTP write
+    /// boundary's shared fast path when the copy matters.
     pub(crate) fn into_string(self) -> String {
         match self {
             JsonBody::PreSerialized(body) => body,
+            JsonBody::Shared(body) => body.as_ref().to_string(),
             JsonBody::Value(value) => value.to_string(),
+        }
+    }
+
+    /// Serialized text for read-only consumers: borrows when the body
+    /// is already serialized (`PreSerialized`, `Shared`); serializes
+    /// `Value` once.
+    pub(crate) fn as_text(&self) -> std::borrow::Cow<'_, str> {
+        match self {
+            JsonBody::PreSerialized(body) => std::borrow::Cow::Borrowed(body),
+            JsonBody::Shared(body) => std::borrow::Cow::Borrowed(body),
+            JsonBody::Value(value) => std::borrow::Cow::Owned(value.to_string()),
         }
     }
 }
@@ -285,10 +304,16 @@ mod tests {
     }
 
     #[test]
-    fn json_body_serializes_identically_from_both_forms() {
+    fn json_body_serializes_identically_from_all_forms() {
         let value = serde_json::json!({ "ok": true, "n": 7 });
-        let pre = JsonBody::PreSerialized(value.to_string());
+        let serialized = value.to_string();
+        let pre = JsonBody::PreSerialized(serialized.clone());
+        let shared = JsonBody::Shared(std::sync::Arc::from(serialized.as_str()));
+        assert_eq!(pre.as_text(), serialized);
+        assert_eq!(shared.as_text(), serialized);
+        assert_eq!(JsonBody::Value(value.clone()).as_text(), serialized);
         assert_eq!(pre.into_string(), JsonBody::Value(value).into_string());
+        assert_eq!(shared.into_string(), serialized);
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -2273,8 +2273,7 @@ mod tests {
                     cors,
                     fleet_origin,
                 );
-                let mut split =
-                    shared_json_http_head(200, body.len(), headers, cors, fleet_origin);
+                let mut split = shared_json_http_head(200, body.len(), headers, cors, fleet_origin);
                 split.extend_from_slice(body.as_bytes());
                 assert_eq!(
                     String::from_utf8(split).unwrap(),

--- a/src/bin/caller/web_gateway/http_dispatch.rs
+++ b/src/bin/caller/web_gateway/http_dispatch.rs
@@ -2091,6 +2091,29 @@ pub(crate) fn apply_cors_posture(
     }
 }
 
+/// Head of a shared-body JSON response — byte-identical to the head
+/// [`api_response_http_bytes`] renders for the same status/header
+/// tail/CORS posture (`with_content`'s Content-Type then
+/// Content-Length, the carried tail, the posture) — without the body:
+/// the write edge writes the shared bytes straight from the cache's
+/// allocation as a second write instead of concatenating a
+/// multi-hundred-KB body into a per-response buffer.
+fn shared_json_http_head(
+    status: u16,
+    body_len: usize,
+    headers: Vec<(&'static str, String)>,
+    cors: crate::gateway_routes::CorsPosture,
+    fleet_origin: Option<&str>,
+) -> Vec<u8> {
+    let mut http = HttpResponse::new(status_reason(status))
+        .header("Content-Type", "application/json")
+        .header("Content-Length", body_len.to_string());
+    for (name, value) in headers {
+        http = http.header(name, value);
+    }
+    apply_cors_posture(http, cors, fleet_origin).into_bytes()
+}
+
 /// Head of a Stream-lane response: status line + Content-Type + the
 /// carried header tail under the row's CORS posture. Deliberately no
 /// Content-Length — the body is EOF-delimited (`Connection: close`)
@@ -2166,8 +2189,28 @@ pub(crate) async fn write_api_response(
                     ApiResponse::Stream { .. } => {}
                 }
             }
-            let bytes = api_response_http_bytes(buffered, cors, fleet_origin);
-            let write_ok = stream.write_all(&bytes).await.is_ok();
+            // Shared JSON bodies (the cached session list) skip the
+            // head+body concat: the head renders alone and the body
+            // writes as a second write from the cache's shared
+            // allocation, byte-identical on the wire (pinned by
+            // `shared_json_body_writes_the_buffered_bytes`).
+            let (bytes, shared_body) = match buffered {
+                ApiResponse::Json {
+                    status,
+                    body: JsonBody::Shared(body),
+                    headers,
+                } => (
+                    shared_json_http_head(status, body.len(), headers, cors, fleet_origin),
+                    Some(body),
+                ),
+                other => (api_response_http_bytes(other, cors, fleet_origin), None),
+            };
+            let mut write_ok = stream.write_all(&bytes).await.is_ok();
+            if write_ok {
+                if let Some(body) = &shared_body {
+                    write_ok = stream.write_all(body.as_bytes()).await.is_ok();
+                }
+            }
             if keep && write_ok {
                 stream.park().await;
             } else {
@@ -2192,6 +2235,53 @@ mod tests {
             None,
         );
         assert_eq!(String::from_utf8(rendered).unwrap(), legacy);
+    }
+
+    #[test]
+    fn shared_json_body_writes_the_buffered_bytes() {
+        // The write edge's shared fast path (head render + direct body
+        // write) must put the exact bytes on the wire that the buffered
+        // renderer concatenates for the same body — across every CORS
+        // posture and with a rewritten keep-alive tail.
+        let body: std::sync::Arc<str> = r#"[{"session_id":"shared"}]"#.into();
+        let keep_alive_headers = || {
+            let mut headers = vec![
+                ("Cache-Control", "no-cache".to_string()),
+                ("Connection", "close".to_string()),
+            ];
+            apply_keep_alive_header_tail(&mut headers);
+            headers
+        };
+        for (cors, fleet_origin) in [
+            (CorsPosture::OwnOrigin, None),
+            (CorsPosture::Public, None),
+            (CorsPosture::FleetOrLoopback, Some("https://fleet.example")),
+        ] {
+            for headers in [
+                vec![
+                    ("Cache-Control", "no-cache".to_string()),
+                    ("Connection", "close".to_string()),
+                ],
+                keep_alive_headers(),
+            ] {
+                let buffered = api_response_http_bytes(
+                    ApiResponse::Json {
+                        status: 200,
+                        body: JsonBody::PreSerialized(body.as_ref().to_string()),
+                        headers: headers.clone(),
+                    },
+                    cors,
+                    fleet_origin,
+                );
+                let mut split =
+                    shared_json_http_head(200, body.len(), headers, cors, fleet_origin);
+                split.extend_from_slice(body.as_bytes());
+                assert_eq!(
+                    String::from_utf8(split).unwrap(),
+                    String::from_utf8(buffered).unwrap()
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/bin/caller/web_gateway/routes_claude_auth.rs
+++ b/src/bin/caller/web_gateway/routes_claude_auth.rs
@@ -207,10 +207,7 @@ mod tests {
     fn response_status_and_body(response: ApiResponse) -> (u16, serde_json::Value) {
         match response {
             ApiResponse::Json { status, body, .. } => {
-                let text = match body {
-                    JsonBody::Value(value) => value.to_string(),
-                    JsonBody::PreSerialized(text) => text,
-                };
+                let text = body.into_string();
                 (status, serde_json::from_str(&text).unwrap())
             }
             _ => panic!("claude-auth responses are JSON"),

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -3014,15 +3014,21 @@ pub(crate) fn sessions_list_api_response(
     // it (keyed by its generation): re-parsing + re-serializing the full
     // multi-megabyte list per request was measurably hot. The ids path
     // keeps direct computation — its bodies are small and id-dependent.
+    // The body stays a shared Arc from the cache through the projection
+    // to the response (`JsonBody::Shared`), so serving a cache hit never
+    // copies the multi-hundred-KB list text.
     let (body, generation) = match ids_filter {
-        Some(ids) => (cached_list_sessions_for_ids(home, &ids), None),
+        Some(ids) => (
+            Arc::<str>::from(cached_list_sessions_for_ids(home, &ids)),
+            None,
+        ),
         None => match limit {
             Some(limit) => cached_list_sessions_with_limit_and_generation(limit),
             None => cached_list_sessions_with_generation(),
         },
     };
-    let body = projected_session_list_body(generation, &body, limit, usage_view);
-    session_json_response(200, body)
+    let body = projected_session_list_body(generation, body, limit, usage_view);
+    ApiResponse::json(200, JsonBody::Shared(body))
 }
 
 pub(crate) async fn handle_sessions_list(

--- a/src/bin/caller/web_gateway/routes_transfers.rs
+++ b/src/bin/caller/web_gateway/routes_transfers.rs
@@ -1192,10 +1192,7 @@ mod tests {
     fn json_body(response: &ApiResponse) -> (u16, serde_json::Value) {
         match response {
             ApiResponse::Json { status, body, .. } => {
-                let text = match body {
-                    JsonBody::PreSerialized(text) => text.clone(),
-                    JsonBody::Value(value) => value.to_string(),
-                };
+                let text = body.as_text();
                 (*status, serde_json::from_str(&text).unwrap())
             }
             ApiResponse::Bytes { .. } | ApiResponse::Stream { .. } => {
@@ -1223,10 +1220,7 @@ mod tests {
             } => (status, content_type, headers, bytes, meta),
             ApiResponse::Json { status, body, .. } => panic!(
                 "expected a bytes response, got {status}: {}",
-                match body {
-                    JsonBody::PreSerialized(text) => text,
-                    JsonBody::Value(value) => value.to_string(),
-                }
+                body.into_string()
             ),
             ApiResponse::Stream { .. } => panic!("expected a bytes response, got a stream"),
         }

--- a/src/bin/caller/web_gateway/session_catalog/mod.rs
+++ b/src/bin/caller/web_gateway/session_catalog/mod.rs
@@ -121,7 +121,11 @@ pub(crate) struct SessionListResponseCacheEntry {
     /// (limit-slice / usage-view bodies) keys on it, so projections are
     /// valid exactly as long as the body they were derived from.
     generation: u64,
-    body: String,
+    /// Shared: a cache hit hands out the Arc — and the HTTP write
+    /// boundary writes straight from it — instead of cloning the
+    /// multi-hundred-KB serialized list per request (same reason the
+    /// external-transcript cache above shares its parsed entries).
+    body: Arc<str>,
 }
 
 pub(crate) fn next_session_list_body_generation() -> u64 {
@@ -337,16 +341,43 @@ pub(crate) fn session_list_refresh_inflight() -> &'static Mutex<HashSet<usize>> 
     INFLIGHT.get_or_init(|| Mutex::new(HashSet::new()))
 }
 
+/// Global ceiling on concurrent background session-list refreshes. The
+/// per-slot single-flight below bounds each limit slot to one refresh,
+/// but a stampede of stale hits across DISTINCT slots could still spawn
+/// one native rebuild thread per slot. Past this many in-flight
+/// refreshes a stale hit keeps serving stale without spawning; the
+/// refresh happens when a later stale hit finds capacity free (or the
+/// hard TTL forces an inline rebuild).
+pub(crate) const SESSION_LIST_REFRESH_MAX_CONCURRENT: usize = 4;
+
+/// Claim the single-flight slot for a background refresh of
+/// `limit_slot`. False — the caller must not spawn — when that slot
+/// already has a refresh in flight or the global ceiling is reached. A
+/// successful claim must be released with
+/// [`end_session_list_refresh`].
+pub(crate) fn try_begin_session_list_refresh(limit_slot: usize) -> bool {
+    let mut inflight = session_list_refresh_inflight()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    if inflight.len() >= SESSION_LIST_REFRESH_MAX_CONCURRENT {
+        return false;
+    }
+    inflight.insert(limit_slot)
+}
+
+/// Release a claim made by [`try_begin_session_list_refresh`].
+pub(crate) fn end_session_list_refresh(limit_slot: usize) {
+    session_list_refresh_inflight()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(&limit_slot);
+}
+
 /// Slot key for the single-flight guard: real limits are 1..SESSION_LIST_LIMIT,
 /// the unlimited list uses SESSION_LIST_LIMIT itself.
 pub(crate) fn spawn_session_list_refresh(limit_slot: usize) {
-    {
-        let mut inflight = session_list_refresh_inflight()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        if !inflight.insert(limit_slot) {
-            return;
-        }
+    if !try_begin_session_list_refresh(limit_slot) {
+        return;
     }
     std::thread::spawn(move || {
         let body = if limit_slot >= SESSION_LIST_LIMIT {
@@ -355,18 +386,21 @@ pub(crate) fn spawn_session_list_refresh(limit_slot: usize) {
             list_sessions_from_home_with_limit(&crate::platform::home_dir(), Some(limit_slot))
         };
         store_session_list_response(limit_slot, body);
-        let mut inflight = session_list_refresh_inflight()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        inflight.remove(&limit_slot);
+        end_session_list_refresh(limit_slot);
     });
 }
 
-pub(crate) fn store_session_list_response(limit_slot: usize, body: String) {
+/// Store a rebuilt list body and return the generation minted for it —
+/// atomically paired with the body, so a caller that goes on to serve
+/// `body` keys its projections on the generation of THAT body (the
+/// historical store-then-re-read could pair a concurrent rebuild's
+/// generation with this caller's body).
+pub(crate) fn store_session_list_response(limit_slot: usize, body: impl Into<Arc<str>>) -> u64 {
+    let generation = next_session_list_body_generation();
     let entry = SessionListResponseCacheEntry {
         generated_at: std::time::Instant::now(),
-        generation: next_session_list_body_generation(),
-        body,
+        generation,
+        body: body.into(),
     };
     if limit_slot >= SESSION_LIST_LIMIT {
         let cache = SESSION_LIST_RESPONSE_CACHE.get_or_init(|| Mutex::new(None));
@@ -380,6 +414,7 @@ pub(crate) fn store_session_list_response(limit_slot: usize, body: String) {
         }
         guard.insert(limit_slot, entry);
     }
+    generation
 }
 
 /// fresh -> serve; stale-but-usable -> serve + background refresh;
@@ -387,23 +422,24 @@ pub(crate) fn store_session_list_response(limit_slot: usize, body: String) {
 pub(crate) fn serve_session_list_cache_entry(
     limit_slot: usize,
     entry: Option<&SessionListResponseCacheEntry>,
-) -> Option<String> {
+) -> Option<Arc<str>> {
     serve_session_list_cache_entry_with_generation(limit_slot, entry).map(|(body, _)| body)
 }
 
 /// [`serve_session_list_cache_entry`] plus the served body's generation,
-/// for callers that key derived projections on it.
+/// for callers that key derived projections on it. Hits hand out
+/// refcount clones of the stored body, never text copies.
 pub(crate) fn serve_session_list_cache_entry_with_generation(
     limit_slot: usize,
     entry: Option<&SessionListResponseCacheEntry>,
-) -> Option<(String, u64)> {
+) -> Option<(Arc<str>, u64)> {
     let entry = entry?;
     let age = entry.generated_at.elapsed();
     if age <= std::time::Duration::from_secs(SESSION_LIST_RESPONSE_CACHE_TTL_SECS) {
-        return Some((entry.body.clone(), entry.generation));
+        return Some((Arc::clone(&entry.body), entry.generation));
     }
     if age <= std::time::Duration::from_secs(SESSION_LIST_RESPONSE_STALE_MAX_SECS) {
-        let body = entry.body.clone();
+        let body = Arc::clone(&entry.body);
         let generation = entry.generation;
         spawn_session_list_refresh(limit_slot);
         return Some((body, generation));
@@ -435,16 +471,16 @@ pub(crate) fn invalidate_session_list_response_caches() {
         .clear();
 }
 
-pub(crate) fn cached_list_sessions() -> String {
+pub(crate) fn cached_list_sessions() -> Arc<str> {
     cached_list_sessions_with_generation().0
 }
 
 /// [`cached_list_sessions`] plus the served body's generation for
 /// projection-cache keying (`None` only for exotic paths that bypass the
 /// entry store).
-pub(crate) fn cached_list_sessions_with_generation() -> (String, Option<u64>) {
-    let cache = SESSION_LIST_RESPONSE_CACHE.get_or_init(|| Mutex::new(None));
+pub(crate) fn cached_list_sessions_with_generation() -> (Arc<str>, Option<u64>) {
     {
+        let cache = SESSION_LIST_RESPONSE_CACHE.get_or_init(|| Mutex::new(None));
         let guard = cache.lock().unwrap_or_else(|e| e.into_inner());
         if let Some((body, generation)) =
             serve_session_list_cache_entry_with_generation(SESSION_LIST_LIMIT, guard.as_ref())
@@ -453,24 +489,18 @@ pub(crate) fn cached_list_sessions_with_generation() -> (String, Option<u64>) {
         }
     }
 
-    let body = list_sessions();
-    let generation = next_session_list_body_generation();
-    let mut guard = cache.lock().unwrap_or_else(|e| e.into_inner());
-    *guard = Some(SessionListResponseCacheEntry {
-        generated_at: std::time::Instant::now(),
-        generation,
-        body: body.clone(),
-    });
+    let body: Arc<str> = list_sessions().into();
+    let generation = store_session_list_response(SESSION_LIST_LIMIT, Arc::clone(&body));
     (body, Some(generation))
 }
 
-pub(crate) fn cached_list_sessions_with_limit(limit: usize) -> String {
+pub(crate) fn cached_list_sessions_with_limit(limit: usize) -> Arc<str> {
     cached_list_sessions_with_limit_and_generation(limit).0
 }
 
 pub(crate) fn cached_list_sessions_with_limit_and_generation(
     limit: usize,
-) -> (String, Option<u64>) {
+) -> (Arc<str>, Option<u64>) {
     let limit = limit.clamp(1, SESSION_LIST_LIMIT);
     if limit >= SESSION_LIST_LIMIT {
         return cached_list_sessions_with_generation();
@@ -486,19 +516,16 @@ pub(crate) fn cached_list_sessions_with_limit_and_generation(
         }
     }
 
-    let body = list_sessions_from_home_with_limit(&crate::platform::home_dir(), Some(limit));
-    store_session_list_response(limit, body.clone());
-    let generation = {
-        let guard = cache.lock().unwrap_or_else(|e| e.into_inner());
-        guard.get(&limit).map(|entry| entry.generation)
-    };
-    (body, generation)
+    let body: Arc<str> =
+        list_sessions_from_home_with_limit(&crate::platform::home_dir(), Some(limit)).into();
+    let generation = store_session_list_response(limit, Arc::clone(&body));
+    (body, Some(generation))
 }
 
-pub(crate) fn cached_session_list_snapshot() -> Option<String> {
+pub(crate) fn cached_session_list_snapshot() -> Option<Arc<str>> {
     let cache = SESSION_LIST_RESPONSE_CACHE.get()?;
     let guard = cache.lock().unwrap_or_else(|e| e.into_inner());
-    guard.as_ref().map(|entry| entry.body.clone())
+    guard.as_ref().map(|entry| Arc::clone(&entry.body))
 }
 
 pub(crate) fn session_ids_filter_from_request(request_line: &str) -> Option<Vec<String>> {
@@ -715,7 +742,7 @@ pub(crate) fn session_row_answers_to_id(row: &serde_json::Value, id: &str) -> bo
 /// The cached full-list body when the cache can serve one under its normal
 /// fresh/stale policy. No inline rebuild — callers fall back to their own
 /// path on a cold cache.
-fn cached_session_list_body_if_serveable() -> Option<String> {
+fn cached_session_list_body_if_serveable() -> Option<Arc<str>> {
     let cache = SESSION_LIST_RESPONSE_CACHE.get_or_init(|| Mutex::new(None));
     let guard = cache.lock().unwrap_or_else(|e| e.into_inner());
     serve_session_list_cache_entry(SESSION_LIST_LIMIT, guard.as_ref())
@@ -794,9 +821,10 @@ type SessionListProjectionKey = (u64, Option<usize>, bool);
 /// view), keyed by the source body's generation + the projection params.
 /// A projection is valid exactly while its source generation is being
 /// served, so entries from replaced bodies simply stop matching; the
-/// size cap ages them out.
-fn session_list_projection_cache() -> &'static Mutex<HashMap<SessionListProjectionKey, String>> {
-    static CACHE: OnceLock<Mutex<HashMap<SessionListProjectionKey, String>>> = OnceLock::new();
+/// size cap ages them out. Shared bodies for the same reason as the
+/// response cache: a hit hands out the Arc, not a text copy.
+fn session_list_projection_cache() -> &'static Mutex<HashMap<SessionListProjectionKey, Arc<str>>> {
+    static CACHE: OnceLock<Mutex<HashMap<SessionListProjectionKey, Arc<str>>>> = OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
@@ -814,14 +842,17 @@ pub(crate) fn session_list_projection_cache_len() -> usize {
 /// usage view), computed once per source-body generation instead of
 /// re-parsing + re-serializing the multi-megabyte cached list on every
 /// request. `generation: None` (uncachable source) computes directly.
+/// The identity projection (no limit, no usage view) and every cache
+/// hit are refcount clones — the hot no-projection serve path never
+/// copies the body text.
 pub(crate) fn projected_session_list_body(
     generation: Option<u64>,
-    body: &str,
+    body: Arc<str>,
     limit: Option<usize>,
     usage_view: bool,
-) -> String {
+) -> Arc<str> {
     if limit.is_none() && !usage_view {
-        return body.to_string();
+        return body;
     }
     let key = generation.map(|generation| (generation, limit, usage_view));
     if let Some(key) = &key {
@@ -829,15 +860,16 @@ pub(crate) fn projected_session_list_body(
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         if let Some(projected) = cache.get(key) {
-            return projected.clone();
+            return Arc::clone(projected);
         }
     }
-    let projected = limit_session_list_body(body, limit);
+    let projected = limit_session_list_body(&body, limit);
     let projected = if usage_view {
         session_list_body_usage_view(&projected)
     } else {
         projected
     };
+    let projected: Arc<str> = projected.into();
     if let Some(key) = key {
         let mut cache = session_list_projection_cache()
             .lock()
@@ -845,7 +877,7 @@ pub(crate) fn projected_session_list_body(
         if cache.len() >= SESSION_LIST_PROJECTION_CACHE_LIMIT && !cache.contains_key(&key) {
             cache.clear();
         }
-        cache.insert(key, projected.clone());
+        cache.insert(key, Arc::clone(&projected));
     }
     projected
 }
@@ -2597,7 +2629,7 @@ pub(crate) fn stream_sessions_lines(
 pub(crate) fn stream_sessions_lines_from_home(
     home: &Path,
     requested_limit: Option<usize>,
-    hydrated_body: impl FnOnce() -> String,
+    hydrated_body: impl FnOnce() -> Arc<str>,
     tx: tokio::sync::mpsc::Sender<String>,
 ) {
     let quick_limit = requested_limit
@@ -2668,12 +2700,12 @@ mod tests {
                 Some(SessionListResponseCacheEntry {
                     generated_at: std::time::Instant::now(),
                     generation: next_session_list_body_generation(),
-                    body: "[{\"session_id\":\"stale\"}]".to_string(),
+                    body: "[{\"session_id\":\"stale\"}]".into(),
                 });
         }
         store_session_list_response(5, "[]".to_string());
         // Seed a projection so the invalidation has something to clear.
-        let _ = projected_session_list_body(Some(u64::MAX), "[]", Some(1), false);
+        let _ = projected_session_list_body(Some(u64::MAX), "[]".into(), Some(1), false);
         invalidate_session_list_response_caches();
         assert!(SESSION_LIST_RESPONSE_CACHE
             .get()
@@ -2690,20 +2722,20 @@ mod tests {
 
     #[test]
     fn projected_session_list_body_caches_by_generation_and_matches_direct() {
-        let body = serde_json::json!([
+        let body: Arc<str> = serde_json::json!([
             {"session_id": "s-1", "source": "intendant", "task": "keep",
              "total_tokens": 10, "model": "m", "project_root": "/repo"},
             {"session_id": "s-2", "source": "codex", "task": "drop-by-limit",
              "total_tokens": 20, "model": "m", "project_root": "/repo"},
         ])
-        .to_string();
+        .to_string()
+        .into();
 
-        // Identity projection: no limit, no usage view — body passes
-        // through untouched and nothing is cached for it.
-        assert_eq!(
-            projected_session_list_body(Some(9_100), &body, None, false),
-            body
-        );
+        // Identity projection: no limit, no usage view — the SAME
+        // allocation passes through (a refcount clone, not a text
+        // copy) and nothing is cached for it.
+        let identity = projected_session_list_body(Some(9_100), Arc::clone(&body), None, false);
+        assert!(Arc::ptr_eq(&identity, &body));
 
         for (limit, usage_view) in [(Some(1), false), (Some(1), true), (None, true)] {
             let direct = {
@@ -2717,26 +2749,139 @@ mod tests {
             // Unique generation per case isolates this test from cache
             // state other tests leave behind.
             let generation = 9_200 + limit.unwrap_or(0) as u64 * 2 + usage_view as u64;
-            let first = projected_session_list_body(Some(generation), &body, limit, usage_view);
-            assert_eq!(first, direct);
-            // Second call must serve the cached projection (same result);
-            // a DIFFERENT body under the SAME generation proves the cache
-            // is keyed by generation, not by re-deriving from the body.
-            let second = projected_session_list_body(Some(generation), "[]", limit, usage_view);
-            assert_eq!(second, direct);
+            let first =
+                projected_session_list_body(Some(generation), Arc::clone(&body), limit, usage_view);
+            assert_eq!(&*first, direct.as_str());
+            // Second call must serve the cached projection (same result,
+            // same allocation); a DIFFERENT body under the SAME
+            // generation proves the cache is keyed by generation, not by
+            // re-deriving from the body.
+            let second =
+                projected_session_list_body(Some(generation), "[]".into(), limit, usage_view);
+            assert_eq!(&*second, direct.as_str());
+            assert!(Arc::ptr_eq(&first, &second));
             // A new generation recomputes from the supplied body.
-            let recomputed =
-                projected_session_list_body(Some(generation + 5_000), "[]", limit, usage_view);
-            assert_ne!(recomputed, direct);
+            let recomputed = projected_session_list_body(
+                Some(generation + 5_000),
+                "[]".into(),
+                limit,
+                usage_view,
+            );
+            assert_ne!(&*recomputed, direct.as_str());
         }
 
         // Uncachable source (generation: None) computes directly.
-        let usage = projected_session_list_body(None, &body, None, true);
-        assert_eq!(usage, session_list_body_usage_view(&body));
+        let usage = projected_session_list_body(None, Arc::clone(&body), None, true);
+        assert_eq!(&*usage, session_list_body_usage_view(&body));
         let parsed: Vec<serde_json::Value> = serde_json::from_str(&usage).unwrap();
         assert_eq!(parsed.len(), 2);
         assert!(parsed[0].get("task").is_none(), "usage view strips tasks");
         assert!(parsed[0].get("total_tokens").is_some());
+    }
+
+    #[test]
+    fn served_session_list_bodies_share_the_cached_allocation() {
+        let body: Arc<str> = "[{\"session_id\":\"shared\"}]".into();
+        let entry = SessionListResponseCacheEntry {
+            generated_at: std::time::Instant::now(),
+            generation: 4_242,
+            body: Arc::clone(&body),
+        };
+        let (served, generation) =
+            serve_session_list_cache_entry_with_generation(4_242, Some(&entry))
+                .expect("fresh entry serves");
+        assert_eq!(generation, 4_242);
+        assert!(
+            Arc::ptr_eq(&served, &body),
+            "a fresh hit must hand out the stored Arc, not a text copy"
+        );
+        assert!(serve_session_list_cache_entry_with_generation(4_242, None).is_none());
+    }
+
+    #[test]
+    fn session_list_refresh_is_single_flight_per_slot_and_globally_capped() {
+        // Everything below drives the claim guard directly — no real
+        // refresh thread ever spawns (list scans would leave the temp
+        // roots), and every claim is released before the test returns.
+        // One test fn on purpose: the in-flight set is process-global,
+        // so splitting these assertions across tests would let them
+        // interleave under the multi-threaded default test runner.
+
+        // Two stale hits on one slot ⇒ one refresh: the first claim
+        // wins, the second is refused while the first is in flight.
+        let slot = 61_000;
+        assert!(try_begin_session_list_refresh(slot));
+        assert!(
+            !try_begin_session_list_refresh(slot),
+            "a slot with a refresh in flight must refuse a second claim"
+        );
+
+        // While that refresh is in flight, a stale-but-usable entry
+        // still serves (stale-while-revalidate), and serving does not
+        // spawn a second refresh — the slot claim above stays the only
+        // one. (Instant is monotonic from boot; within the first TTL
+        // seconds after boot there is nothing to back-date into, so the
+        // serve probe is skipped there.)
+        let body: Arc<str> = "[]".into();
+        if let Some(stale_at) = std::time::Instant::now().checked_sub(
+            std::time::Duration::from_secs(SESSION_LIST_RESPONSE_CACHE_TTL_SECS + 1),
+        ) {
+            let stale = SessionListResponseCacheEntry {
+                generated_at: stale_at,
+                generation: 7,
+                body: Arc::clone(&body),
+            };
+            for _ in 0..2 {
+                let (served, generation) =
+                    serve_session_list_cache_entry_with_generation(slot, Some(&stale))
+                        .expect("stale-but-usable entry serves while a refresh is in flight");
+                assert!(Arc::ptr_eq(&served, &body));
+                assert_eq!(generation, 7);
+            }
+            assert!(
+                !try_begin_session_list_refresh(slot),
+                "stale serves must not have released or duplicated the slot claim"
+            );
+        }
+        if let Some(dead_at) = std::time::Instant::now().checked_sub(
+            std::time::Duration::from_secs(SESSION_LIST_RESPONSE_STALE_MAX_SECS + 1),
+        ) {
+            let dead = SessionListResponseCacheEntry {
+                generated_at: dead_at,
+                generation: 8,
+                body: Arc::clone(&body),
+            };
+            assert!(
+                serve_session_list_cache_entry_with_generation(61_001, Some(&dead)).is_none(),
+                "past the stale ceiling nothing serves (and nothing spawns)"
+            );
+        }
+        end_session_list_refresh(slot);
+
+        // Global ceiling: stale hits across DISTINCT slots stop
+        // spawning once the cap of concurrent refreshes is reached.
+        let base = 62_000;
+        let mut claimed = Vec::new();
+        for slot in base.. {
+            if !try_begin_session_list_refresh(slot) {
+                break;
+            }
+            claimed.push(slot);
+        }
+        assert_eq!(claimed.len(), SESSION_LIST_REFRESH_MAX_CONCURRENT);
+        assert!(
+            !try_begin_session_list_refresh(base + 10_000),
+            "at the ceiling every further slot is refused"
+        );
+        end_session_list_refresh(claimed.pop().expect("cap claims"));
+        assert!(
+            try_begin_session_list_refresh(base + 10_000),
+            "a finished refresh frees capacity for other slots"
+        );
+        claimed.push(base + 10_000);
+        for slot in claimed {
+            end_session_list_refresh(slot);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Serving `/api/sessions` from the response cache copied the multi-hundred-KB list body several times per hit; stale-while-revalidate refreshes had per-slot dedup but no global bound. Three changes, one seam each:

**Shared cache bodies (`Arc<str>`).** `SessionListResponseCacheEntry.body` and the projection cache store `Arc<str>` (the pattern the external-transcript cache in the same file already uses). Serve paths hand out refcount clones; `projected_session_list_body` takes and returns `Arc<str>`, so the identity (no-projection) path is a move and projection hits are refcount clones. `store_session_list_response` now returns the generation it mints, atomically paired with the stored body — the historical store-then-re-read could pair a concurrent rebuild's generation with this caller's body and poison the projection cache for that generation.

**No head+body concat at the HTTP write boundary.** `JsonBody::Shared(Arc<str>)` carries the body to the write edge; `write_api_response` renders the head alone (`shared_json_http_head`) and writes the body as a second write straight from the cache's allocation. Byte-parity with the buffered renderer is pinned across CORS postures and the keep-alive tail (`shared_json_body_writes_the_buffered_bytes`). The tunnel lane borrows via the new `JsonBody::as_text` (Cow), so its only remaining copy is the envelope splice inherent to framing.

Copies of the full list text per cache hit (limit=all, plain view — the SPA's 15s poll):
- HTTP before: 3 (serve clone, projection identity `to_string`, `into_bytes` concat) → after: 0.
- Projected views (limit/usage) before: 3 (serve clone, projection-cache clone, concat) → after: 0.
- Tunnel before: 2 + envelope splice → after: 0 + envelope splice.
- Rebuild/store paths keep exactly one copy (String → `Arc<str>`), same count as the old `body.clone()` store.

**Single-flight + bounded refresh.** The per-slot in-flight set stays; `spawn_session_list_refresh` now claims through `try_begin_session_list_refresh`, which also enforces a global ceiling (`SESSION_LIST_REFRESH_MAX_CONCURRENT = 4`) so a stampede of stale hits across distinct limit slots cannot spawn an unbounded burst of native rebuild threads. Beyond the cap a stale hit keeps serving stale without spawning (semantics unchanged: fresh → serve, stale → serve + refresh, dead → inline rebuild). Tests drive the claim guard directly (two stale hits on one slot ⇒ one refresh; ceiling refusal; release re-opens capacity) and the stale/dead serve windows with back-dated entries — no real refresh thread ever spawns in tests.

Existing generation/projection invariants stay pinned by the extended `projected_session_list_body_caches_by_generation_and_matches_direct` (now also asserting the identity path and cache hits share the allocation via `Arc::ptr_eq`).
