### PR TITLE
display: key the layer-policy coordinator to the platform baseline codec

### DIFF
--- a/crates/intendant-display/src/aggregator.rs
+++ b/crates/intendant-display/src/aggregator.rs
@@ -2699,8 +2699,7 @@ mod tests {
         // it and `is_layer_paused` reads it, so the coordinator's
         // diff converges after an action instead of re-firing it
         // every tick — mirroring the real pool's semantics.
-        let paused: Arc<StdMutex<HashSet<SimulcastRid>>> =
-            Arc::new(StdMutex::new(HashSet::new()));
+        let paused: Arc<StdMutex<HashSet<SimulcastRid>>> = Arc::new(StdMutex::new(HashSet::new()));
 
         let recorded_for_closure = Arc::clone(&recorded);
         let paused_for_action = Arc::clone(&paused);

--- a/crates/intendant-display/src/aggregator.rs
+++ b/crates/intendant-display/src/aggregator.rs
@@ -634,7 +634,8 @@ pub fn aggregate_state_wanted_upper_layers(
 /// [`crate::DisplaySession::start`] maps each variant to
 /// [`crate::encode::pool::EncoderPool::pause_layer`] /
 /// [`crate::encode::pool::EncoderPool::resume_layer`]
-/// with `CodecKind::Vp8` (the always-on simulcast codec). The
+/// with [`crate::encode::pool::BASELINE_CODEC`] (the always-on bank:
+/// VP8 simulcast on macOS/Linux, single-layer H.264 on Windows). The
 /// per-RID-RR and aggregate-TWCC policies vote for a wanted set;
 /// the coordinator composes via intersection and emits one
 /// `CapacityAction` per layer whose actual pool state diverges
@@ -841,10 +842,11 @@ pub type LayerPauseProbe = Box<dyn Fn(&SimulcastRid) -> Option<bool> + Send + Sy
 /// state via `is_layer_paused`, and emits exactly one set of
 /// pause/resume actions through `on_action`.
 ///
-/// `get_current_rids` returns the pool's current VP8 simulcast
+/// `get_current_rids` returns the pool's current always-on baseline
 /// layer set in spec order (descending bitrate; the last entry is
 /// the floor). Production wiring captures `Arc<EncoderPool>` and
-/// returns `pool.always_on_ids()` filtered to `CodecKind::Vp8`;
+/// returns `pool.always_on_ids()` filtered to
+/// [`crate::encode::pool::BASELINE_CODEC`];
 /// the coordinator derives floor + upper-layers from this list on
 /// every tick, so a `pool.on_resize` that grows or shrinks the
 /// layer set takes effect at most one tick later.
@@ -858,7 +860,8 @@ pub type LayerPauseProbe = Box<dyn Fn(&SimulcastRid) -> Option<bool> + Send + Sy
 /// excludes them.
 ///
 /// `on_action` applies the requested side effect, mapping to
-/// `pool.pause_layer` / `pool.resume_layer` with `CodecKind::Vp8`.
+/// `pool.pause_layer` / `pool.resume_layer` with
+/// [`crate::encode::pool::BASELINE_CODEC`].
 ///
 /// `config` is shared across the aggregate-TWCC and per-RID-RR
 /// policies — both use the same threshold/debounce constants
@@ -2659,6 +2662,132 @@ mod tests {
                 CapacityAction::PauseLayer(SimulcastRid::quarter()),
             ],
             "expected one PauseLayer per current_rid in spec order",
+        );
+
+        shutdown.cancel();
+        let _ = handle.await;
+    }
+
+    /// **Single-layer baseline (the Windows H.264 bank shape)**: one
+    /// always-on layer, so that layer IS the floor and the congestion
+    /// cascade has no upper layers to act on. The coordinator must
+    /// (a) leave the floor active while a viewer demands it — no
+    /// policy may blank a single-layer stream; (b) pause it (the
+    /// whole bank) once the display sits at zero peers — the idle
+    /// win the `BASELINE_CODEC` wiring exists for; (c) resume it
+    /// when a viewer returns (the pool forces a keyframe on that
+    /// paused→active edge, covered by the pool's own tests).
+    ///
+    /// Codec-agnostic on purpose: the hooks are injected, so this
+    /// drives the exact production coordinator against the
+    /// single-layer layout on every platform without spawning any
+    /// encoder.
+    #[tokio::test]
+    async fn spawn_coordinator_single_layer_floor_survives_viewer_and_pauses_idle() {
+        use std::sync::Mutex as StdMutex;
+
+        let floor = SimulcastRid::full();
+        let peers: Arc<RwLock<HashMap<PeerId, Arc<WebRtcPeer>>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+        peers.write().await.insert(
+            1,
+            Arc::new(WebRtcPeer::new_for_test(1, vec![floor.clone()])),
+        );
+
+        let recorded: Arc<StdMutex<Vec<CapacityAction>>> = Arc::new(StdMutex::new(Vec::new()));
+        // Shared fake pause state: `on_action` applies each action to
+        // it and `is_layer_paused` reads it, so the coordinator's
+        // diff converges after an action instead of re-firing it
+        // every tick — mirroring the real pool's semantics.
+        let paused: Arc<StdMutex<HashSet<SimulcastRid>>> =
+            Arc::new(StdMutex::new(HashSet::new()));
+
+        let recorded_for_closure = Arc::clone(&recorded);
+        let paused_for_action = Arc::clone(&paused);
+        let on_action: Box<dyn Fn(CapacityAction) + Send + Sync> = Box::new(move |a| {
+            match &a {
+                CapacityAction::PauseLayer(rid) => {
+                    paused_for_action.lock().unwrap().insert(rid.clone());
+                }
+                CapacityAction::ResumeLayer(rid) => {
+                    paused_for_action.lock().unwrap().remove(rid);
+                }
+            }
+            recorded_for_closure.lock().unwrap().push(a);
+        });
+        let floor_for_rids = floor.clone();
+        let get_current_rids: Box<dyn Fn() -> Vec<SimulcastRid> + Send + Sync> =
+            Box::new(move || vec![floor_for_rids.clone()]);
+        let paused_for_probe = Arc::clone(&paused);
+        let is_layer_paused: LayerPauseProbe =
+            Box::new(move |rid| Some(paused_for_probe.lock().unwrap().contains(rid)));
+
+        let shutdown = CancellationToken::new();
+        let handle = spawn_layer_policy_coordinator(
+            Arc::clone(&peers),
+            get_current_rids,
+            is_layer_paused,
+            on_action,
+            CapacityPolicyConfig::default(),
+            shutdown.clone(),
+        );
+
+        // (a) With a live viewer, ticks must pass with no action: the
+        // single layer is the floor (TWCC/RR union it unconditionally)
+        // and the #48 demand bound keeps it wanted.
+        tokio::time::sleep(TICK * 3).await;
+        assert_eq!(
+            recorded.lock().unwrap().clone(),
+            Vec::new(),
+            "no layer action may fire while a viewer demands the floor",
+        );
+
+        // (b) Remove the viewer: the demand collapse (and later the
+        // presence debounce) must pause the whole bank — floor
+        // included. Generous deadline per the sibling smoke test.
+        peers.write().await.clear();
+        let deadline = Instant::now() + PAUSE_DEBOUNCE + Duration::from_secs(5);
+        loop {
+            if !recorded.lock().unwrap().is_empty() {
+                break;
+            }
+            if Instant::now() >= deadline {
+                shutdown.cancel();
+                let _ = handle.await;
+                panic!("zero peers must pause the single-layer bank");
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert_eq!(
+            recorded.lock().unwrap().clone(),
+            vec![CapacityAction::PauseLayer(floor.clone())],
+            "the zero-peer pause must take the floor (the whole bank)",
+        );
+
+        // (c) A returning viewer resumes it.
+        peers.write().await.insert(
+            1,
+            Arc::new(WebRtcPeer::new_for_test(1, vec![floor.clone()])),
+        );
+        let deadline = Instant::now() + PAUSE_DEBOUNCE + Duration::from_secs(5);
+        loop {
+            if recorded.lock().unwrap().len() >= 2 {
+                break;
+            }
+            if Instant::now() >= deadline {
+                shutdown.cancel();
+                let _ = handle.await;
+                panic!("a returning viewer must resume the paused floor");
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert_eq!(
+            recorded.lock().unwrap().clone(),
+            vec![
+                CapacityAction::PauseLayer(floor.clone()),
+                CapacityAction::ResumeLayer(floor),
+            ],
+            "exactly one pause and one resume — nothing else may touch the bank",
         );
 
         shutdown.cancel();

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -1417,6 +1417,24 @@ fn make_damage_backend(
     Box::new(capture::damage::NullDamageBackend::new(width, height))
 }
 
+/// RIDs of the pool's always-on baseline bank
+/// ([`encode::pool::BASELINE_CODEC`]), in spec order (descending
+/// bitrate; last entry is the floor). This is the layer set the
+/// layer-policy coordinator manages: on-demand slots are excluded by
+/// `always_on_ids` (they're lease-refcounted, not policy-managed), and
+/// non-baseline always-on entries don't exist today but are filtered
+/// for robustness. Keyed to `BASELINE_CODEC` — not a codec literal —
+/// so the Windows H.264 bank is governed the same way as the VP8
+/// simulcast bank on macOS/Linux.
+fn baseline_always_on_rids(
+    ids: Vec<encode::pool::EncoderId>,
+) -> Vec<encode::pool::SimulcastRid> {
+    ids.into_iter()
+        .filter(|id| id.codec == encode::pool::BASELINE_CODEC)
+        .map(|id| id.rid)
+        .collect()
+}
+
 /// Encode a full-screen tile snapshot into wire frames **once**; the
 /// caller fans the refcounted frames out to any number of peers. The
 /// raw-copy + RLE + lossless-WebP encode of the whole screen is the
@@ -1900,17 +1918,27 @@ impl DisplaySession {
         // always-on layer handles, so snapshots taken at spawn time
         // would go stale.
         //
-        //   - `get_current_rids` returns the pool's full VP8
-        //     simulcast layer set in spec order (descending
-        //     bitrate; last entry is floor). Coordinator derives
-        //     the floor + upper-layer split internally.
+        // All three are keyed to `encode::pool::BASELINE_CODEC` — the
+        // always-on bank's codec (VP8 simulcast on macOS/Linux, the
+        // single full-resolution H.264 layer on Windows). A literal
+        // `CodecKind::Vp8` here left the coordinator inert on Windows
+        // (no VP8 layers → empty rid set → every tick skipped), so the
+        // zero-peer pause never fired and an unwatched Windows session
+        // converted + encoded at full rate forever.
+        //
+        //   - `get_current_rids` returns the pool's always-on baseline
+        //     layer set in spec order (descending bitrate; last entry
+        //     is floor). Coordinator derives the floor + upper-layer
+        //     split internally; with the single-layer Windows bank the
+        //     one layer IS the floor and the congestion cascade has no
+        //     upper layers to act on.
         //   - `is_layer_paused` queries actual pool state for one
         //     RID — diffing against actual (rather than against an
         //     internal `last_applied`) handles the resize-
         //     regenerates-active case correctly.
         //   - `on_action` routes `CapacityAction::PauseLayer` /
         //     `ResumeLayer` to `pool.pause_layer` /
-        //     `pool.resume_layer` with `CodecKind::Vp8`.
+        //     `pool.resume_layer` with `BASELINE_CODEC`.
         //
         // The 5 s zero-peer pause debounce, the 5 s drop /
         // 1 s restore debounces for both TWCC and RR, and the
@@ -1919,17 +1947,10 @@ impl DisplaySession {
         // configured via `CapacityPolicyConfig::default()`.
         let pool_for_rids = Arc::clone(&pool_arc);
         let get_current_rids: Box<dyn Fn() -> Vec<encode::pool::SimulcastRid> + Send + Sync> =
-            Box::new(move || {
-                pool_for_rids
-                    .always_on_ids()
-                    .into_iter()
-                    .filter(|id| id.codec == encode::pool::CodecKind::Vp8)
-                    .map(|id| id.rid)
-                    .collect()
-            });
+            Box::new(move || baseline_always_on_rids(pool_for_rids.always_on_ids()));
         let pool_for_query = Arc::clone(&pool_arc);
         let is_layer_paused: aggregator::LayerPauseProbe = Box::new(move |rid| {
-            pool_for_query.is_layer_paused(encode::pool::CodecKind::Vp8, rid.clone())
+            pool_for_query.is_layer_paused(encode::pool::BASELINE_CODEC, rid.clone())
         });
         let pool_for_action = Arc::clone(&pool_arc);
         let on_action: Box<dyn Fn(aggregator::CapacityAction) + Send + Sync> =
@@ -1950,10 +1971,10 @@ impl DisplaySession {
                 }
                 match action {
                     aggregator::CapacityAction::PauseLayer(rid) => {
-                        pool_for_action.pause_layer(encode::pool::CodecKind::Vp8, rid);
+                        pool_for_action.pause_layer(encode::pool::BASELINE_CODEC, rid);
                     }
                     aggregator::CapacityAction::ResumeLayer(rid) => {
-                        pool_for_action.resume_layer(encode::pool::CodecKind::Vp8, rid);
+                        pool_for_action.resume_layer(encode::pool::BASELINE_CODEC, rid);
                     }
                 }
             });
@@ -4336,6 +4357,34 @@ mod tests {
         assert!(!should_try_xdamage_for_tile_stream("wayland"));
         assert!(!should_try_xdamage_for_tile_stream("macos"));
         assert!(!should_try_xdamage_for_tile_stream("stub"));
+    }
+
+    /// The layer-policy coordinator's rid feed must follow the
+    /// platform's `BASELINE_CODEC`, not a codec literal. A literal
+    /// `Vp8` filter left the coordinator inert on Windows (H.264
+    /// bank → empty rid set → every tick skipped → the zero-peer
+    /// pause and the conversion idle gate never engaged).
+    /// Platform-agnostic: the non-baseline codec is derived relative
+    /// to `BASELINE_CODEC`, so this pins the same property on all
+    /// three platforms.
+    #[test]
+    fn baseline_rid_filter_keys_on_platform_baseline_codec() {
+        use encode::pool::{CodecKind, EncoderId, SimulcastRid, BASELINE_CODEC};
+        let other = if BASELINE_CODEC == CodecKind::Vp8 {
+            CodecKind::H264
+        } else {
+            CodecKind::Vp8
+        };
+        let ids = vec![
+            EncoderId::new(BASELINE_CODEC, SimulcastRid::full()),
+            EncoderId::new(other, SimulcastRid::federated()),
+            EncoderId::new(BASELINE_CODEC, SimulcastRid::half()),
+        ];
+        assert_eq!(
+            baseline_always_on_rids(ids),
+            vec![SimulcastRid::full(), SimulcastRid::half()],
+            "coordinator rid feed must be keyed to BASELINE_CODEC, in pool order"
+        );
     }
 
     #[test]

--- a/crates/intendant-display/src/lib.rs
+++ b/crates/intendant-display/src/lib.rs
@@ -1426,9 +1426,7 @@ fn make_damage_backend(
 /// for robustness. Keyed to `BASELINE_CODEC` — not a codec literal —
 /// so the Windows H.264 bank is governed the same way as the VP8
 /// simulcast bank on macOS/Linux.
-fn baseline_always_on_rids(
-    ids: Vec<encode::pool::EncoderId>,
-) -> Vec<encode::pool::SimulcastRid> {
+fn baseline_always_on_rids(ids: Vec<encode::pool::EncoderId>) -> Vec<encode::pool::SimulcastRid> {
     ids.into_iter()
         .filter(|id| id.codec == encode::pool::BASELINE_CODEC)
         .map(|id| id.rid)


### PR DESCRIPTION
## What

The layer-policy coordinator wiring in `DisplaySession::start` hardcoded `CodecKind::Vp8` in all three hooks it hands `aggregator::spawn_layer_policy_coordinator` (`get_current_rids`, `is_layer_paused`, `on_action`). On Windows the pool's always-on baseline is H.264 (`encode/pool/types.rs::BASELINE_CODEC`), there are no VP8 layers, so `get_current_rids` returned empty and the coordinator skipped every tick (`current_rids.is_empty() → continue`): the zero-peer presence pause never fired, `EncoderPool::has_active_consumer` stayed true (the unpaused always-on H.264 handle), and the pool-feed bridge's conversion idle gate never engaged — an unwatched Windows session paid full-rate BGRA→I420 conversion plus Media Foundation H.264 encode forever.

Fix: key the three hooks to `encode::pool::BASELINE_CODEC`. On macOS/Linux `BASELINE_CODEC == Vp8`, so this is behavior-identical there; on Windows the coordinator now manages the single always-on H.264 layer — zero peers pause it, the idle gate engages, and the first viewer resumes it. The `get_current_rids` filter is extracted into a named helper (`baseline_always_on_rids`) so a unit test pins the filter to `BASELINE_CODEC` on every platform.

## Verification notes (read before landing, per the coordinator semantics)

**1. Coordinator semantics with a single-layer codec.** `spawn_layer_policy_coordinator` derives `floor = current_rids.last()` and `upper_layers = current_rids[..len-1]` positionally each tick (`aggregator.rs:998-1002`); layer naming is deliberately abstract ("top/mid/floor", `aggregator.rs:403-407`) — no VP8 rid-name assumptions anywhere, so no aggregator adaptation was needed. With the Windows single-layer bank, `current_rids = [f]`, so `floor = f` and `upper_layers = []`:

- **Congestion never pauses the floor.** The TWCC cascade and per-RID RR policies act on `upper_layers` only and union the floor in unconditionally (`wanted.insert(floor)` at `aggregator.rs:1035` and `:1057`); `aggregate_state_wanted_upper_layers(state, &[])` is empty for every one of the 7 cascade states — pinned by the existing `aggregate_projection_zero_upper_layers_always_empty` test (`aggregator.rs:2007`). With one layer the congestion vote is therefore always exactly `{floor}`: sustained loss can never blank the stream.
- **Zero-peer pause takes ALL layers including the floor.** `compose_effective_wanted` short-circuits to the empty set when the presence policy reaches Idle (`aggregator.rs:799-801`), and the #48 demand bound (`effective ∩ demanded`, `aggregator.rs:816-823`) already collapses to empty on the first zero-peer tick (`demanded_layers` is the union of live peers' `active_rids`, `aggregator.rs:983-986`). Either way the diff emits `PauseLayer(f)` — that's the win: `has_active_consumer` goes false (`pool/mod.rs:1309-1323`) and the bridge's conversion idle gate finally engages on Windows.
- **Live-viewer interplay.** A local Windows viewer negotiates the always-on layer (`active_rids = [f]`, single-RID, so it is also pinned per #57) — demand keeps `f` active. A federated viewer demands the on-demand `EncoderId { H264, federated }` layer instead, which is lease-refcounted and deliberately outside coordinator management (`always_on_ids` excludes on-demand slots, `pool/mod.rs:1153-1156`); with only federated viewers the always-on `f` correctly pauses while `has_active_consumer` stays true through the subscribed on-demand slot.

**2. Resume recovery.** `EncoderPool::resume_layer` detects the paused→active edge (`swap(false)`) and sets the slot's `force_keyframe` flag (`pool/mod.rs:1243-1266`); the worker thread checks `paused` before swapping `force_keyframe` (`pool/worker.rs:368-397`), so the flag survives the pause window and the first post-resume encode honors it. The Windows encoder honors force-keyframe via `ICodecAPI::SetValue(CODECAPI_AVEncVideoForceKeyFrame, 1)` (`encode/h264_windows.rs:867-869` → `:801-811`). That path is best-effort (ICodecAPI can be unavailable on some MFTs, `:103`): the defense-in-depth is the configured GOP (`CODECAPI_AVEncMPVGOPSize = GOP_SIZE = 30`, `:104`/`:529`), bounding recovery to ~1 s at 30 fps, and the peer-join path additionally opens the pool-feed bridge's burst window (`lib.rs` `signal_peer_join_burst`) plus per-peer keyframe-first forwarding with PLI → `request_keyframe`, so a joining viewer converges on a decodable frame either way.

## Tests

- `baseline_rid_filter_keys_on_platform_baseline_codec` (lib.rs) — pins the production `get_current_rids` filter to `BASELINE_CODEC` with mixed-codec ids, platform-agnostic (the non-baseline codec is derived relative to `BASELINE_CODEC`).
- `spawn_coordinator_single_layer_floor_survives_viewer_and_pauses_idle` (aggregator.rs) — drives the real coordinator task with the Windows bank shape (`get_current_rids = [f]`, injectable pause-state + recording action sink, a `new_for_test` peer with `active_rids = [f]`): no action ever fires while the viewer is present; clearing peers emits exactly `PauseLayer(f)`; the returning viewer emits exactly `ResumeLayer(f)`.
- Existing `types.rs` tests already pin `BASELINE_CODEC` per platform (`baseline_codec_is_h264_on_windows` / VP8 elsewhere) and `aggregate_projection_zero_upper_layers_always_empty` pins the empty-upper projection.

No real H.264 encoders are spawned by any of this — the Windows compile + tests ride the CI merge-group leg. `crates/intendant-display/src/windows.rs` (capture backend) is untouched.

## Battery

- `cargo fmt --check`
- `cargo clippy`
- `cargo nextest run --bins`
- `cargo nextest run -p intendant-display`
