### PR TITLE
deps: remove dead dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,20 +88,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "agent-client-protocol-schema"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3889095d10943a5fc6f803ba839679def450471ddb96de245e700ce82d601da6"
-dependencies = [
- "anyhow",
- "derive_more",
- "schemars",
- "serde",
- "serde_json",
- "strum",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,15 +1148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "cookie-factory"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,29 +1494,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "convert_case 0.10.0",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]
@@ -2942,9 +2896,7 @@ name = "intendant"
 version = "0.1.0"
 dependencies = [
  "accessibility-sys",
- "agent-client-protocol-schema",
  "app-html-assembler",
- "arboard",
  "ashpd",
  "async-trait",
  "atspi",
@@ -2957,7 +2909,6 @@ dependencies = [
  "core-graphics",
  "dirs",
  "dotenvy",
- "env-libvpx-sys",
  "env_logger",
  "flate2",
  "futures-util",
@@ -2976,7 +2927,6 @@ dependencies = [
  "p12-keystore",
  "passkey-auth",
  "pem",
- "pipewire",
  "portable-pty",
  "presence-core",
  "presence-web",
@@ -2996,7 +2946,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "shiguredo_video_toolbox",
  "similar",
  "socket2 0.6.2",
  "tempfile",
@@ -3004,7 +2953,6 @@ dependencies = [
  "time",
  "tokio",
  "tokio-rustls",
- "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
  "toml",
@@ -3014,7 +2962,6 @@ dependencies = [
  "uuid",
  "which 8.0.2",
  "windows 0.59.0",
- "x11rb",
  "x509-parser 0.18.1",
  "zip",
 ]
@@ -3071,7 +3018,6 @@ dependencies = [
 name = "intendant-platform"
 version = "0.1.0"
 dependencies = [
- "dirs",
  "intendant-core",
  "libc",
  "serde",
@@ -3371,7 +3317,7 @@ checksum = "65f3a4b81b2a2d8c7f300643676202debd1b7c929dbf5c9bb89402ea11d19810"
 dependencies = [
  "bitflags 2.11.0",
  "cc",
- "convert_case 0.6.0",
+ "convert_case",
  "cookie-factory",
  "libc",
  "libspa-sys",
@@ -6001,27 +5947,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "strum"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "substring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,6 @@ passkey-auth = "0.1.3"
 # store location, and by tests elsewhere as a dev-dep.
 tempfile = "3"
 async-trait = "0.1"
-tokio-stream = "0.1"
 futures-util = "0.3"
 dirs = "6"
 # PATHEXT-aware executable resolution. Used by `platform::spawn_command` to
@@ -129,7 +128,6 @@ libc = "0.2"
 socket2 = "0.6"
 rtc = { version = "=0.9.1" }
 bytes = "1"
-agent-client-protocol-schema = "0.11.5"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Gzip for the web gateway's embedded static assets (app.html, WASM, JS).
 # Default features = the pure-Rust miniz_oxide backend — no C, consistent
@@ -166,8 +164,6 @@ time = "0.3"
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = "0.4"
 ashpd = { version = "0.11", features = ["tokio"] }
-pipewire = "0.8"
-x11rb = { version = "0.13", features = ["shm", "damage", "xfixes", "xtest"] }
 # Pure-Rust AT-SPI2 (read_screen element trees on X11 + Wayland). Pinned to
 # the 0.28+ line so it shares ashpd 0.11's zbus 5.x — older atspi forks in a
 # second zbus stack.
@@ -178,31 +174,11 @@ atspi = { version = "0.30", features = ["tokio"] }
 # pipeline — macos.rs there is its only user in the workspace.)
 core-graphics = { version = "0.25", features = ["highsierra"] }
 core-foundation = "0.10"
-shiguredo_video_toolbox = "2026.1"
 accessibility-sys = "0.2"
-
-# Native dep that has no Windows backend yet (Tier-0 Windows port defers the
-# VP8/libvpx encoder). Gated to non-Windows so the MSVC target doesn't try to
-# build the libvpx FFI crate (`env-libvpx-sys` needs a C toolchain + the vpx
-# headers). The VP8 code path is itself cfg'd off Windows so nothing
-# references these symbols there.
-#
-# (The `intendant lan` cert subsystem used to live here too, via OpenSSL; it
-# is now pure-Rust — rcgen + p12-keystore — and moved to `[dependencies]`.)
-[target.'cfg(not(target_os = "windows"))'.dependencies]
-env-libvpx-sys = { version = "5.1", features = ["generate"] }
 
 [target.'cfg(windows)'.dependencies]
 # (windows-sys moved to crates/intendant-platform with platform.rs, its only
 # user in this package.)
-# Windows clipboard backend (display/clipboard.rs). Wraps the Win32 clipboard
-# API (clipboard-win) and provides RGBA image get/set via its default
-# `image-data` feature. That feature pulls in `image` (0.25, png+bmp) and the
-# Win32_Graphics_Gdi surface of windows-sys, both of which unify with our
-# existing copies — no duplicate crate. The objc2/core-graphics deps named by
-# `image-data` are macOS-target-gated in arboard, so they don't reach the MSVC
-# build. Windows-only: the macOS/Linux arms shell out to pbcopy/wl-copy/xclip.
-arboard = "3"
 # The richer `windows` crate (COM wrappers, RAII interface handles) powers the
 # Tier-1 display backend (`display/windows.rs`): DXGI Desktop Duplication for
 # capture, Direct3D 11 for the staging-texture copy, GDI/WindowsAndMessaging

--- a/crates/intendant-platform/Cargo.toml
+++ b/crates/intendant-platform/Cargo.toml
@@ -12,7 +12,6 @@ tokio = { version = "1.0", features = ["process", "sync", "io-util", "macros", "
 # PATHEXT-aware executable resolution for `platform::spawn_command` (npm
 # `.cmd`/`.bat` shims on Windows, which CreateProcess does not resolve).
 which = "8"
-dirs = "6"
 
 [dev-dependencies]
 # platform's spawn/lock tests write into temp dirs.


### PR DESCRIPTION
Remove direct dependencies with zero code references in the root
package: agent-client-protocol-schema, tokio-stream,
shiguredo_video_toolbox, the non-Windows env-libvpx-sys block,
pipewire, x11rb, and arboard (crates/intendant-display declares its
own copies of the display-stack ones, so they stay in the graph;
tokio-stream stays transitively via rmcp). Also drop the unused
dirs dependency from intendant-platform.

Only the agent-client-protocol-schema subtree actually leaves the
lockfile (6 packages incl. two proc-macro crates); the rest is
manifest hygiene. Kept: ashpd (used via the ashpd::zbus re-export
in atspi_read.rs), core-graphics, core-foundation,
accessibility-sys, windows.

Validated with cargo check --workspace --all-targets.
