### PR TITLE
memory: drop duplicated encode and fold work

### DIFF
--- a/src/bin/caller/memory/plane.rs
+++ b/src/bin/caller/memory/plane.rs
@@ -377,7 +377,6 @@ impl EphemeralPlane {
         );
         let (root_sk, _) = suite::ed25519::keypair(&root_seed);
         let genesis_op = seal_op(header, body.to_value(), &OpSigner::Ed25519(&root_sk));
-        let ctrl_head = genesis_op.op_hash();
 
         let mut plane = EphemeralPlane {
             plane_id,
@@ -394,11 +393,14 @@ impl EphemeralPlane {
             writer_seq: 0,
             prev_writer_hash: [0; 32],
             ctrl_seq: 1,
-            ctrl_head,
+            ctrl_head: [0; 32], // the genesis op_hash, set on append below
             hlc_last_ms,
         };
         plane.prev_writer_hash = gen_start(&plane.dev.lineage, 1);
-        plane.append(genesis_op)?;
+        // The append's returned hash IS the genesis `op_hash` (the
+        // ctrl chain head) — reuse it instead of encoding the op a
+        // second time for a standalone `op_hash()` call.
+        plane.ctrl_head = plane.append(genesis_op)?;
         Ok((plane, custody))
     }
 
@@ -539,8 +541,13 @@ impl EphemeralPlane {
     /// precedence, D-112) and its named outcome surfaces verbatim.
     fn append(&mut self, op: Signedop) -> Result<[u8; 32], MemoryError> {
         let name = self.next_name();
-        let op_hash = op.op_hash();
-        self.items.insert(name.clone(), op.encode());
+        // Encode ONCE: the canonical triple bytes are both what the
+        // log holds and the `op_hash` preimage (`Signedop::op_hash` is
+        // `H_op` over these same bytes, O2), so hashing the held bytes
+        // skips a second full encode.
+        let bytes = op.encode();
+        let op_hash = h_tag(Tag::Op, &bytes);
+        self.items.insert(name.clone(), bytes);
         match fold_set(&self.items, &BTreeMap::new()) {
             Ok((verdicts, state)) => {
                 let verdict = verdicts
@@ -563,12 +570,11 @@ impl EphemeralPlane {
                     }
                     Verdict::Rejected(outcome, disposition) => {
                         self.items.remove(&name);
-                        // Re-derive without the rejected op so the
-                        // cache never reflects a set we don't hold.
-                        let (verdicts, state) = fold_set(&self.items, &BTreeMap::new())
-                            .map_err(|Unimplemented(why)| MemoryError::Unimplemented(why))?;
-                        self.verdicts = verdicts;
-                        self.state = state;
+                        // The candidate fold was never installed in
+                        // this arm, so after the removal the held
+                        // cache already describes exactly the set we
+                        // hold (the fold is a pure function of the
+                        // item set) — nothing to re-derive.
                         Err(MemoryError::Rejected {
                             outcome,
                             disposition,

--- a/src/bin/caller/memory/service.rs
+++ b/src/bin/caller/memory/service.rs
@@ -565,7 +565,11 @@ mod tests {
         }
         let mut wrong = full[..12].to_string();
         wrong.pop();
-        wrong.push(if full.as_bytes()[11] == b'0' { '1' } else { '0' });
+        wrong.push(if full.as_bytes()[11] == b'0' {
+            '1'
+        } else {
+            '0'
+        });
         assert!(!hex_prefix_matches(&key, &wrong), "mismatched last nibble");
         let over = format!("{full}0");
         assert!(

--- a/src/bin/caller/memory/service.rs
+++ b/src/bin/caller/memory/service.rs
@@ -23,7 +23,6 @@ const SEARCH_LIMIT_CEILING: usize = 50;
 /// signed body) keyed by the accepted op hash. Status is NEVER stored
 /// here — it is derived from the fold at read time.
 struct ClaimRecord {
-    op_hash: [u8; 32],
     kind: Kind,
     statement: String,
     sensitivity: Class,
@@ -53,6 +52,23 @@ fn parse_vocab<T: Copy>(
                 .collect::<Vec<_>>()
                 .join(", "),
         })
+}
+
+/// Does `p` — validated lowercase hex — prefix-match `key`'s 64-char
+/// lowercase hex form? Compared nibble-wise, so the hex string is
+/// never materialized per candidate.
+fn hex_prefix_matches(key: &[u8; 32], p: &str) -> bool {
+    if p.len() > 64 {
+        return false;
+    }
+    p.bytes().enumerate().all(|(i, c)| {
+        let nibble = if i % 2 == 0 {
+            key[i / 2] >> 4
+        } else {
+            key[i / 2] & 0x0f
+        };
+        c == b"0123456789abcdef"[nibble as usize]
+    })
 }
 
 pub(crate) struct MemoryService {
@@ -190,7 +206,6 @@ impl MemoryService {
             claims.insert(
                 op.op_hash(),
                 ClaimRecord {
-                    op_hash: op.op_hash(),
                     kind,
                     statement: text("statement").unwrap_or_default(),
                     sensitivity,
@@ -346,7 +361,6 @@ impl MemoryService {
         self.claims.insert(
             op_hash,
             ClaimRecord {
-                op_hash,
                 kind,
                 statement: args.statement,
                 sensitivity,
@@ -358,7 +372,7 @@ impl MemoryService {
                 proposed_by,
             },
         );
-        Ok(self.view(&self.claims[&op_hash]))
+        Ok(self.view(&op_hash, &self.claims[&op_hash]))
     }
 
     /// Bounded lexical search. Candidates are excluded unless opted
@@ -367,7 +381,7 @@ impl MemoryService {
         let limit = args.limit.clamp(1, SEARCH_LIMIT_CEILING);
         let needle = args.query.to_lowercase();
         let mut out = Vec::new();
-        for rec in self.claims.values() {
+        for (op_hash, rec) in &self.claims {
             if !needle.is_empty() {
                 let hay = format!(
                     "{} {} {}",
@@ -379,11 +393,13 @@ impl MemoryService {
                     continue;
                 }
             }
-            let view = self.view(rec);
-            if view.status == "candidate" && !args.include_candidates {
+            // Derive the status BEFORE building the view: excluded
+            // candidates never pay for the view's clones.
+            let status = self.claim_status_of(op_hash);
+            if status == "candidate" && !args.include_candidates {
                 continue;
             }
-            out.push(view);
+            out.push(self.view_with_status(op_hash, rec, status));
             if out.len() >= limit {
                 break;
             }
@@ -399,29 +415,40 @@ impl MemoryService {
                 "id prefix must be at least 8 hex characters".into(),
             ));
         }
-        let matches: Vec<&ClaimRecord> = self
+        let matches: Vec<(&[u8; 32], &ClaimRecord)> = self
             .claims
-            .values()
-            .filter(|r| hex32(&r.op_hash).starts_with(&p))
+            .iter()
+            .filter(|(hash, _)| hex_prefix_matches(hash, &p))
             .collect();
         match matches.len() {
             0 => Err(MemoryError::NotFound(id_prefix.into())),
-            1 => Ok(self.view(matches[0])),
+            1 => Ok(self.view(matches[0].0, matches[0].1)),
             n => Err(MemoryError::Ambiguous(id_prefix.into(), n)),
         }
     }
 
-    fn view(&self, rec: &ClaimRecord) -> ClaimView {
+    /// The reducer-derived status a view carries ("pending" until the
+    /// fold speaks) — derived at read time, never stored.
+    fn claim_status_of(&self, op_hash: &[u8; 32]) -> &'static str {
+        self.plane.claim_status(op_hash).unwrap_or("pending")
+    }
+
+    fn view(&self, op_hash: &[u8; 32], rec: &ClaimRecord) -> ClaimView {
+        self.view_with_status(op_hash, rec, self.claim_status_of(op_hash))
+    }
+
+    fn view_with_status(
+        &self,
+        op_hash: &[u8; 32],
+        rec: &ClaimRecord,
+        status: &'static str,
+    ) -> ClaimView {
         ClaimView {
-            id: hex32(&rec.op_hash),
+            id: hex32(op_hash),
             kind: rec.kind.as_str().into(),
             statement: rec.statement.clone(),
             sensitivity: rec.sensitivity.as_str().into(),
-            status: self
-                .plane
-                .claim_status(&rec.op_hash)
-                .unwrap_or("pending")
-                .into(),
+            status: status.into(),
             session: rec.session.clone(),
             project: rec.project.clone(),
             model: rec.model.clone(),
@@ -516,6 +543,35 @@ mod tests {
     fn bootstrap_genesis_admits() {
         let svc = MemoryService::new().expect("bootstrap admits");
         assert_eq!(svc.plane.held_ops(), 1, "genesis is held");
+    }
+
+    /// The no-alloc prefix comparator must agree with the hex-string
+    /// formulation it replaced (`hex32(key).starts_with(p)`),
+    /// including odd-length prefixes and the over-length edge.
+    #[test]
+    fn hex_prefix_matches_agrees_with_hex_expansion() {
+        let mut key = [0u8; 32];
+        for (i, b) in key.iter_mut().enumerate() {
+            *b = (i as u8).wrapping_mul(37).wrapping_add(11);
+        }
+        let full = hex32(&key);
+        for len in [8, 9, 12, 63, 64] {
+            assert_eq!(
+                hex_prefix_matches(&key, &full[..len]),
+                full.starts_with(&full[..len]),
+                "len {len}"
+            );
+            assert!(hex_prefix_matches(&key, &full[..len]), "len {len}");
+        }
+        let mut wrong = full[..12].to_string();
+        wrong.pop();
+        wrong.push(if full.as_bytes()[11] == b'0' { '1' } else { '0' });
+        assert!(!hex_prefix_matches(&key, &wrong), "mismatched last nibble");
+        let over = format!("{full}0");
+        assert!(
+            !hex_prefix_matches(&key, &over),
+            "a 65-char prefix can never match a 64-char id"
+        );
     }
 
     /// propose → candidate → read round-trip, with the reducer-derived


### PR DESCRIPTION
Wave 2 of the adjudicated zero-tradeoff program (finding 3 of `zero-tradeoff-run-compile-time-imp-reconciled`): the memory dedup cleanup set. No vendored code changes — `crates/owner-plane-core` and `crates/owner-plane-reducer` are untouched; everything works through the existing public `Signedop`/`h_tag` API from the daemon side.

## plane.rs
- **Encode once per op.** `append()` called `op.op_hash()` (which encodes the canonical triple internally) and then `op.encode()` again for the held item. It now encodes once and derives the hash from those bytes via the vendored `h_tag(Tag::Op, ..)` — the exact definition of `Signedop::op_hash` (O2). The one remaining internal encode inside `seal_op` is over the *header* (the signature message), a different payload — there is no triple-encode duplication left on this path. Stored op bytes are byte-identical: canonical CBOR is deterministic, and the corpus conformance suite (`cargo test -p owner-plane-reducer`) plus the memory service/durable store batteries (`cargo test --bins`) are the equivalence guard.
- **Genesis reuses the append hash.** `bootstrap_with_custody` computed `genesis_op.op_hash()` (a full extra encode) for `ctrl_head`, then appended. `ctrl_head` now takes `append()`'s returned hash.
- **Rejected arm: drop the redundant re-fold.** The candidate fold's `(verdicts, state)` were never installed in the `Rejected` arm, so after `items.remove(&name)` the held cache is exactly what the second `fold_set` recomputed (the fold is a pure function of the item set — set-based, arrival-order-free, and `fold_set(empty) == (empty, State::default())` covers the genesis edge, which propagates the error and drops the plane anyway). D-112 semantics unchanged: a rejected op exerts no precedence and its named outcome surfaces verbatim (pinned by `rejected_op_surfaces_named_outcome`).

## service.rs
- **`search()`: status before view.** The derived status (`claim_status`) is checked before constructing a `ClaimView`, so candidates excluded by default no longer pay for the view's several clones. Result contents, ordering, and the limit interaction are unchanged (pinned by `search_excludes_candidates_by_default`, `conflicting_claims_coexist_and_both_surface`, and the durable roundtrip battery).
- **`read()`: no per-claim hex allocation.** The lowercase id prefix is compared nibble-wise against the `[u8; 32]` key instead of materializing a 64-char hex string per claim. Exact semantics preserved: same ≥8-hex-chars validation message, `NotFound`, `Ambiguous` with the same count; a new test pins the comparator against the `hex32(..).starts_with(..)` formulation it replaced, including odd-length and over-length prefixes.
- **`ClaimRecord.op_hash` removed** (the optional item): it duplicated the record's own BTreeMap key; the key is passed where needed. This also drops a second per-op `op_hash()` (full re-encode) in `rebuild_claims`.

## Validation
- `cargo nextest run --bins` (memory service + durable store batteries)
- `cargo test -p owner-plane-reducer` (vendored corpus conformance suite)
- `cargo fmt --check`, `cargo clippy` (no new warnings)