### PR TITLE
recording: delete the macOS screencapture feeder; capture --record-display via SCK in-process

### DIFF
--- a/docs/src/display-pipeline.md
+++ b/docs/src/display-pipeline.md
@@ -456,11 +456,14 @@ the agent's click coordinates match the screenshot it receives.
 
 ## Recording
 
-Display recording runs in parallel with WebRTC streaming via ffmpeg
-(`recording.rs`). When a `DisplaySession` exists, frames are subscribed from the
-session, JPEG-encoded, and piped to ffmpeg via `image2pipe`. Without a session,
-the legacy fallback uses `x11grab` on Linux and `screencapture` feeding
-`image2pipe` on macOS. Recordings are segmented into MP4 files (default 60 s)
+Display recording runs in parallel with WebRTC streaming, with ffmpeg strictly
+as the encoder (`recording.rs`). When a `DisplaySession` exists, frames are
+polled from the session, JPEG-encoded, and piped to ffmpeg via `image2pipe`.
+Without a session (`--record-display`, the debug screen), Linux lets ffmpeg
+capture directly via `x11grab`, while macOS captures the requested display
+in-process via ScreenCaptureKit and bridges the frames into the same
+`image2pipe` encoder — so the Intendant process itself must hold the Screen
+Recording permission. Recordings are segmented into MP4 files (default 60 s)
 for efficient seeking; the dashboard provides a player with timeline, seeking,
 and speed control.
 

--- a/src/bin/caller/debug.rs
+++ b/src/bin/caller/debug.rs
@@ -80,7 +80,8 @@ pub async fn setup_debug_screen(web_port: u16) -> Result<DebugScreen, String> {
         .spawn()
         .map_err(|e| format!("Failed to open browser: {}", e))?;
 
-    // display_id 0 = main screen (used by avfoundation for recording)
+    // display_id 0 = kCGNullDirectDisplay, which the in-process
+    // ScreenCaptureKit recording path maps to the main display.
     Ok(DebugScreen {
         xvfb_guard: None,
         firefox: browser,
@@ -155,10 +156,11 @@ pub async fn setup_debug_screen(_web_port: u16) -> Result<DebugScreen, String> {
 pub async fn start_debug_recording(
     display_id: u32,
     config: &RecordingConfig,
+    bus: &EventBus,
 ) -> Result<recording::RecordingGuard, String> {
     let dir = daemon_recordings_dir();
     let _ = std::fs::create_dir_all(&dir);
-    recording::start_display_recording(display_id, 1280, 720, config, &dir).await
+    recording::start_display_recording(display_id, 1280, 720, config, &dir, bus).await
 }
 
 /// Spawn a background task that handles debug screen control messages.
@@ -214,7 +216,7 @@ pub fn spawn_debug_screen_handler(
                             eprintln!("[debug] Already recording");
                             continue;
                         }
-                        match start_debug_recording(s.display_id, &recording_config).await {
+                        match start_debug_recording(s.display_id, &recording_config, &bus).await {
                             Ok(guard) => {
                                 let stream = guard.stream_name().to_string();
                                 rec_guard = Some(guard);

--- a/src/bin/caller/main.rs
+++ b/src/bin/caller/main.rs
@@ -1220,7 +1220,8 @@ pub(crate) fn query_display_resolution(_display_id: u32) -> (u32, u32) {
 
 /// Start recording external displays (--record-display) directly on the registry.
 /// Does NOT emit DisplayReady — external displays have no DisplaySession, so the
-/// web dashboard can't connect. Recording uses x11grab independently.
+/// web dashboard can't connect. Recording captures independently: x11grab on
+/// Linux, in-process ScreenCaptureKit on macOS.
 async fn start_external_display_recordings(
     displays: &[u32],
     registry: &std::sync::Arc<tokio::sync::RwLock<recording::RecordingRegistry>>,
@@ -1238,11 +1239,17 @@ async fn start_external_display_recordings(
             eprintln!("ffmpeg not available — skipping :{}", id);
             continue;
         }
-        match reg.start_external_display(id, width, height).await {
+        match reg.start_external_display(id, width, height, bus).await {
             Ok(stream_name) => {
                 bus.send(AppEvent::RecordingStarted { stream_name });
             }
-            Err(e) => eprintln!("Failed to start recording for :{}: {}", id, e),
+            Err(e) => {
+                eprintln!("Failed to start recording for :{}: {}", id, e);
+                bus.send(AppEvent::RecordingError {
+                    stream_name: format!("display_{id}"),
+                    message: e,
+                });
+            }
         }
     }
 }

--- a/src/bin/caller/recording.rs
+++ b/src/bin/caller/recording.rs
@@ -1270,7 +1270,10 @@ fn spawn_external_capture_pump(
     slot: ExternalFrameSlot,
     stream_name: String,
     bus: EventBus,
-) -> (tokio::sync::oneshot::Sender<()>, tokio::task::JoinHandle<()>) {
+) -> (
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<()>,
+) {
     let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel::<()>();
     let task = tokio::spawn(async move {
         loop {
@@ -1656,8 +1659,8 @@ pub fn spawn_recording_listener(
 mod tests {
     use super::*;
 
-    fn test_frame() -> std::sync::Arc<crate::display::Frame> {
-        std::sync::Arc::new(crate::display::Frame {
+    fn raw_test_frame() -> crate::display::Frame {
+        crate::display::Frame {
             data: vec![0u8; 2 * 2 * 4],
             format: crate::display::FrameFormat::Bgra,
             width: 2,
@@ -1665,7 +1668,11 @@ mod tests {
             stride: 8,
             timestamp: std::time::Instant::now(),
             dirty_rects: None,
-        })
+        }
+    }
+
+    fn test_frame() -> std::sync::Arc<crate::display::Frame> {
+        std::sync::Arc::new(raw_test_frame())
     }
 
     #[tokio::test]
@@ -1755,6 +1762,271 @@ mod tests {
             jpeg.starts_with(&[0xFF, 0xD8]),
             "cached bytes must be a JPEG (SOI marker)"
         );
+    }
+
+    /// Injectable feed sink for bridge-level tests: counts feeds and
+    /// reports the configured verdict.
+    struct TestSink {
+        feeds: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        ok: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl BridgeFeedSink for TestSink {
+        async fn feed(&mut self, _jpeg: &[u8]) -> bool {
+            self.feeds.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.ok
+        }
+    }
+
+    /// Poll `cond` until it holds or a generous deadline passes — the
+    /// bridge ticks on real time, so assertions are threshold-based rather
+    /// than tick-exact to stay robust on loaded CI boxes.
+    async fn wait_until(cond: impl Fn() -> bool, what: &str) {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !cond() {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for {what}"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn external_bridge_feeds_every_tick_and_reencodes_only_on_frame_change() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let slot: ExternalFrameSlot =
+            std::sync::Arc::new(tokio::sync::RwLock::new(Some(test_frame())));
+        let feeds = std::sync::Arc::new(AtomicUsize::new(0));
+        let encodes = std::sync::Arc::new(AtomicUsize::new(0));
+        let encode = {
+            let encodes = std::sync::Arc::clone(&encodes);
+            move |_: &crate::display::Frame| {
+                encodes.fetch_add(1, Ordering::SeqCst);
+                Some(vec![9])
+            }
+        };
+        let bridge = tokio::spawn(run_frame_bridge(
+            BridgeSource::External {
+                slot: std::sync::Arc::clone(&slot),
+            },
+            TestSink {
+                feeds: std::sync::Arc::clone(&feeds),
+                ok: true,
+            },
+            encode,
+            "display_7".to_string(),
+            50,
+            EventBus::new(),
+        ));
+
+        // The unchanged slot frame keeps feeding every tick from the cache.
+        wait_until(
+            || feeds.load(Ordering::SeqCst) >= 3,
+            "several ticks to feed",
+        )
+        .await;
+        assert_eq!(
+            encodes.load(Ordering::SeqCst),
+            1,
+            "an unchanged slot frame must reuse the cached JPEG"
+        );
+
+        // A new frame in the slot re-encodes exactly once more.
+        *slot.write().await = Some(test_frame());
+        wait_until(
+            || encodes.load(Ordering::SeqCst) == 2,
+            "a new frame to re-encode",
+        )
+        .await;
+        let fed_after_swap = feeds.load(Ordering::SeqCst);
+        wait_until(
+            || feeds.load(Ordering::SeqCst) > fed_after_swap,
+            "feeding to continue after the re-encode",
+        )
+        .await;
+        assert_eq!(encodes.load(Ordering::SeqCst), 2);
+        bridge.abort();
+    }
+
+    #[tokio::test]
+    async fn external_bridge_idles_on_empty_slot_until_a_frame_arrives() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let slot: ExternalFrameSlot = std::sync::Arc::new(tokio::sync::RwLock::new(None));
+        let feeds = std::sync::Arc::new(AtomicUsize::new(0));
+        let bridge = tokio::spawn(run_frame_bridge(
+            BridgeSource::External {
+                slot: std::sync::Arc::clone(&slot),
+            },
+            TestSink {
+                feeds: std::sync::Arc::clone(&feeds),
+                ok: true,
+            },
+            frame_to_jpeg,
+            "display_7".to_string(),
+            100,
+            EventBus::new(),
+        ));
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        assert_eq!(
+            feeds.load(Ordering::SeqCst),
+            0,
+            "an empty slot must not feed anything"
+        );
+        *slot.write().await = Some(test_frame());
+        wait_until(|| feeds.load(Ordering::SeqCst) >= 1, "feeding to begin").await;
+        bridge.abort();
+    }
+
+    #[tokio::test]
+    async fn external_bridge_stops_recording_when_the_feed_fails() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let bus = EventBus::new();
+        let mut events = bus.subscribe();
+        let feeds = std::sync::Arc::new(AtomicUsize::new(0));
+        let bridge = tokio::spawn(run_frame_bridge(
+            BridgeSource::External {
+                slot: std::sync::Arc::new(tokio::sync::RwLock::new(Some(test_frame()))),
+            },
+            TestSink {
+                feeds: std::sync::Arc::clone(&feeds),
+                ok: false,
+            },
+            frame_to_jpeg,
+            "display_7".to_string(),
+            50,
+            bus.clone(),
+        ));
+        tokio::time::timeout(std::time::Duration::from_secs(5), bridge)
+            .await
+            .expect("bridge must exit after a failed feed")
+            .unwrap();
+        assert_eq!(
+            feeds.load(Ordering::SeqCst),
+            1,
+            "the bridge must stop at the first failed feed"
+        );
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+            .await
+            .expect("a stop intent must be emitted")
+            .expect("event bus stays open");
+        match event {
+            AppEvent::ControlCommand(ControlMsg::StopRecording { stream_name }) => {
+                assert_eq!(stream_name, "display_7");
+            }
+            other => panic!("expected StopRecording, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn capture_pump_fills_slot_and_quiesces_backend_on_stop() {
+        let backend: std::sync::Arc<dyn crate::display::DisplayBackend> =
+            std::sync::Arc::new(crate::display::synthetic::SyntheticBackend::new());
+        let frames = backend
+            .start_capture(30)
+            .await
+            .expect("synthetic capture starts");
+        let slot: ExternalFrameSlot = std::sync::Arc::new(tokio::sync::RwLock::new(None));
+        let (stop_tx, pump) = spawn_external_capture_pump(
+            std::sync::Arc::clone(&backend),
+            frames,
+            std::sync::Arc::clone(&slot),
+            "display_3".to_string(),
+            EventBus::new(),
+        );
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while slot.read().await.is_none() {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for the pump to fill the slot"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        // The finalize path: fire the stop sender, then the pump must
+        // quiesce the backend (joining its producer thread) and exit.
+        stop_tx.send(()).expect("pump is alive to receive the stop");
+        tokio::time::timeout(std::time::Duration::from_secs(5), pump)
+            .await
+            .expect("pump must quiesce the backend and exit on stop")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn capture_pump_quiesces_when_the_stop_sender_is_dropped() {
+        let backend: std::sync::Arc<dyn crate::display::DisplayBackend> =
+            std::sync::Arc::new(crate::display::synthetic::SyntheticBackend::new());
+        let frames = backend
+            .start_capture(30)
+            .await
+            .expect("synthetic capture starts");
+        let (stop_tx, pump) = spawn_external_capture_pump(
+            std::sync::Arc::clone(&backend),
+            frames,
+            std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+            "display_3".to_string(),
+            EventBus::new(),
+        );
+
+        // The Drop path: the guard never awaits — dropping the sender alone
+        // must wake the pump into teardown.
+        drop(stop_tx);
+        tokio::time::timeout(std::time::Duration::from_secs(5), pump)
+            .await
+            .expect("pump must quiesce the backend and exit when the sender drops")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn capture_pump_stops_recording_when_the_source_ends() {
+        // Backend never started: `stop_capture` without a start is a no-op
+        // per the teardown contract, so the pump's quiesce still completes.
+        let backend: std::sync::Arc<dyn crate::display::DisplayBackend> =
+            std::sync::Arc::new(crate::display::synthetic::SyntheticBackend::new());
+        let (frame_tx, frames) = tokio::sync::mpsc::channel::<crate::display::Frame>(4);
+        let bus = EventBus::new();
+        let mut events = bus.subscribe();
+        let slot: ExternalFrameSlot = std::sync::Arc::new(tokio::sync::RwLock::new(None));
+        // Keep the stop sender alive so the capture-loss branch (not the
+        // stop branch) is what ends the pump.
+        let (_keep_stop_alive, pump) = spawn_external_capture_pump(
+            backend,
+            frames,
+            std::sync::Arc::clone(&slot),
+            "display_9".to_string(),
+            bus.clone(),
+        );
+
+        frame_tx
+            .send(raw_test_frame())
+            .await
+            .expect("pump is receiving");
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while slot.read().await.is_none() {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for the pump to fill the slot"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        drop(frame_tx);
+        tokio::time::timeout(std::time::Duration::from_secs(5), pump)
+            .await
+            .expect("pump must exit when the capture source ends")
+            .unwrap();
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+            .await
+            .expect("capture loss must stop the recording")
+            .expect("event bus stays open");
+        match event {
+            AppEvent::ControlCommand(ControlMsg::StopRecording { stream_name }) => {
+                assert_eq!(stream_name, "display_9");
+            }
+            other => panic!("expected StopRecording, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/bin/caller/recording.rs
+++ b/src/bin/caller/recording.rs
@@ -1,7 +1,9 @@
 //! Continuous video recording for display and camera streams.
 //!
-//! Uses ffmpeg to record displays (x11grab on Linux, screencapture feeding
-//! image2pipe on macOS) and browser camera frames (image2pipe) into segmented
+//! ffmpeg is strictly the encoder: Linux display recordings let ffmpeg
+//! capture directly via x11grab, while macOS display recordings capture
+//! ScreenCaptureKit frames in-process and bridge them into ffmpeg as JPEGs
+//! (image2pipe), exactly like browser camera frames. Output is segmented
 //! MP4 files stored in the session directory. Stop paths extract the
 //! [`RecordingGuard`] from the registry and await its async `finalize`;
 //! plain `Drop` is only the kill-on-drop last resort.
@@ -23,7 +25,8 @@ use tokio::process::Child;
 /// so dropping is safe on a tokio worker.
 pub struct RecordingGuard {
     child: Child,
-    /// Stdin handle for piping frames (None for x11grab mode).
+    /// Stdin handle for piping frames (None for x11grab mode, and for the
+    /// macOS display bridge, whose task owns the pipe directly).
     stdin: Option<tokio::process::ChildStdin>,
     stream_name: String,
     segments_dir: PathBuf,
@@ -31,6 +34,13 @@ pub struct RecordingGuard {
     started_at: chrono::DateTime<chrono::Utc>,
     /// Background bridge task (frame-fed path only). Aborted on drop.
     bridge_task: Option<tokio::task::JoinHandle<()>>,
+    /// In-process capture teardown (macOS display recordings): firing or
+    /// dropping the sender wakes the capture pump, which quiesces the
+    /// capture backend (`stop_capture`) on its own task.
+    capture_stop: Option<tokio::sync::oneshot::Sender<()>>,
+    /// The capture pump itself, so [`RecordingGuard::finalize`] can await
+    /// the backend quiesce with a bound.
+    capture_pump: Option<tokio::task::JoinHandle<()>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -75,11 +85,13 @@ impl RecordingGuard {
 
     /// Gracefully finalize the recording without blocking a worker thread.
     ///
-    /// Stops the feed bridge, closes stdin (image2pipe inputs finish cleanly
-    /// on EOF), sends SIGINT (no-op on non-unix, where the EOF is the
-    /// graceful path), and waits up to five seconds for ffmpeg to exit and
-    /// flush its segment list. If ffmpeg is still alive after the timeout,
-    /// dropping the guard lets `kill_on_drop(true)` reap it; the
+    /// Stops the feed bridge, quiesces any in-process capture (bounded —
+    /// the pump owns the backend's `stop_capture`), closes stdin (image2pipe
+    /// inputs finish cleanly on EOF; a bridge-owned pipe drops with the
+    /// aborted bridge task), sends SIGINT (no-op on non-unix, where the EOF
+    /// is the graceful path), and waits up to five seconds for ffmpeg to
+    /// exit and flush its segment list. If ffmpeg is still alive after the
+    /// timeout, dropping the guard lets `kill_on_drop(true)` reap it; the
     /// fragmented-MP4 segments stay playable without the final flush.
     ///
     /// Callers must not hold the recording-registry lock across this await —
@@ -87,6 +99,14 @@ impl RecordingGuard {
     pub async fn finalize(mut self) {
         if let Some(handle) = self.bridge_task.take() {
             handle.abort();
+        }
+        // Quiesce in-process capture before asking ffmpeg to exit, so no
+        // late frame races the encoder shutdown.
+        if let Some(stop) = self.capture_stop.take() {
+            let _ = stop.send(());
+        }
+        if let Some(pump) = self.capture_pump.take() {
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(2), pump).await;
         }
         // Drop stdin first so ffmpeg sees EOF and can finalize.
         self.stdin.take();
@@ -110,6 +130,10 @@ impl Drop for RecordingGuard {
         if let Some(handle) = self.bridge_task.take() {
             handle.abort();
         }
+        // Dropping the stop sender wakes the capture pump, which quiesces
+        // the capture backend on its own task — Drop must not await.
+        self.capture_stop.take();
+        self.capture_pump.take();
         self.stdin.take();
     }
 }
@@ -234,8 +258,141 @@ async fn verify_ffmpeg_started(
 }
 
 /// Start recording a display via ffmpeg.
-/// Uses x11grab on Linux and a screencapture/image2pipe feeder on macOS.
+///
+/// ffmpeg is strictly the encoder: Linux lets it capture directly via
+/// `x11grab`; macOS captures the requested display in-process via
+/// ScreenCaptureKit and bridges the frames into ffmpeg as JPEGs
+/// (`image2pipe`), so the capture permission and the display targeting both
+/// belong to this process rather than to a spawned helper binary.
 pub async fn start_display_recording(
+    display_id: u32,
+    width: u32,
+    height: u32,
+    config: &RecordingConfig,
+    session_dir: &Path,
+    bus: &EventBus,
+) -> Result<RecordingGuard, String> {
+    #[cfg(target_os = "macos")]
+    {
+        // The recorded resolution comes from the live capture, not the
+        // caller's probe (which has no X server to ask on macOS).
+        let _ = (width, height);
+        start_display_recording_macos(display_id, config, session_dir, bus).await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = bus;
+        start_display_recording_x11grab(display_id, width, height, config, session_dir).await
+    }
+}
+
+/// macOS display recording: in-process ScreenCaptureKit capture of the
+/// requested display, bridged into the existing image2pipe encoder guard.
+///
+/// Replaces the March-era per-frame `screencapture` feeder, which predated
+/// in-process SCK capture and carried two latent bugs by construction: it
+/// never passed a display selector (recording the main display whatever id
+/// was requested) and funneled every instance through one fixed temp file
+/// (concurrent recordings corrupted each other's frames).
+#[cfg(target_os = "macos")]
+async fn start_display_recording_macos(
+    display_id: u32,
+    config: &RecordingConfig,
+    session_dir: &Path,
+    bus: &EventBus,
+) -> Result<RecordingGuard, String> {
+    let (backend, frames) = start_macos_display_capture(display_id, config.framerate).await?;
+    let (width, height) = backend.resolution();
+
+    let recordings_dir = session_dir.join("recordings");
+    let stream_name = pick_next_display_stream_name(&recordings_dir, display_id);
+    let mut guard = match start_frame_recording(&stream_name, config, session_dir).await {
+        Ok(guard) => guard,
+        Err(e) => {
+            // A failed encoder start must quiesce the capture it rode in on.
+            backend.stop_capture().await;
+            return Err(e);
+        }
+    };
+
+    // Upgrade the camera-shaped manifest with the display facts. Best
+    // effort: the recording itself does not depend on manifest contents.
+    let manifest = serde_json::json!({
+        "stream_name": stream_name,
+        "started_at": chrono::Utc::now().to_rfc3339(),
+        "framerate": config.framerate,
+        "resolution": format!("{}x{}", width, height),
+        "codec": "h264",
+        "source": "screencapturekit_image2pipe",
+    });
+    let _ = std::fs::write(
+        guard.segments_dir().join("manifest.json"),
+        serde_json::to_string_pretty(&manifest).unwrap_or_default(),
+    );
+
+    // The bridge owns ffmpeg's stdin: aborting it (finalize/Drop) is what
+    // hands ffmpeg its EOF.
+    let Some(stdin) = guard.stdin.take() else {
+        backend.stop_capture().await;
+        return Err("frame recording pipeline has no stdin pipe".to_string());
+    };
+    let slot: ExternalFrameSlot = std::sync::Arc::new(tokio::sync::RwLock::new(None));
+    let (capture_stop, capture_pump) = spawn_external_capture_pump(
+        backend,
+        frames,
+        std::sync::Arc::clone(&slot),
+        stream_name.clone(),
+        bus.clone(),
+    );
+    let bridge = tokio::spawn(run_frame_bridge(
+        BridgeSource::External { slot },
+        StdinFeedSink { stdin },
+        frame_to_jpeg,
+        stream_name,
+        config.framerate,
+        bus.clone(),
+    ));
+    guard.bridge_task = Some(bridge);
+    guard.capture_stop = Some(capture_stop);
+    guard.capture_pump = Some(capture_pump);
+    Ok(guard)
+}
+
+/// Start in-process ScreenCaptureKit capture of one display for recording.
+///
+/// `display_id` is a CGDisplayID; `0` (`kCGNullDirectDisplay`) selects the
+/// main display — the debug-screen path records "the screen the browser
+/// opened on" that way. Failure is actionable at the start boundary: the
+/// display backend's error already carries the Screen Recording (TCC)
+/// recovery guidance, because the capture now lives in this process —
+/// previously Apple's `screencapture` binary held the grant instead.
+#[cfg(target_os = "macos")]
+async fn start_macos_display_capture(
+    display_id: u32,
+    fps: u32,
+) -> Result<
+    (
+        std::sync::Arc<dyn crate::display::DisplayBackend>,
+        tokio::sync::mpsc::Receiver<crate::display::Frame>,
+    ),
+    String,
+> {
+    let backend: std::sync::Arc<dyn crate::display::DisplayBackend> = if display_id == 0 {
+        std::sync::Arc::new(crate::display::macos::MacOSBackend::new())
+    } else {
+        std::sync::Arc::new(crate::display::macos::MacOSBackend::with_display_id(
+            display_id,
+        ))
+    };
+    let frames = backend.start_capture(fps).await.map_err(|e| {
+        format!("in-process screen capture failed to start for display {display_id}: {e}")
+    })?;
+    Ok((backend, frames))
+}
+
+/// Non-macOS display recording: ffmpeg captures directly via `x11grab`.
+#[cfg(not(target_os = "macos"))]
+async fn start_display_recording_x11grab(
     display_id: u32,
     width: u32,
     height: u32,
@@ -254,12 +411,6 @@ pub async fn start_display_recording(
     let output_pattern = segments_dir.join("seg_%05d.mp4");
     let segment_list = segments_dir.join("segments.csv");
 
-    let source = if cfg!(target_os = "macos") {
-        "screencapture_image2pipe"
-    } else {
-        "x11grab"
-    };
-
     // Write manifest
     let manifest = serde_json::json!({
         "stream_name": stream_name,
@@ -267,7 +418,7 @@ pub async fn start_display_recording(
         "framerate": config.framerate,
         "resolution": format!("{}x{}", width, height),
         "codec": "h264",
-        "source": source,
+        "source": "x11grab",
     });
     let manifest_path = segments_dir.join("manifest.json");
     std::fs::write(
@@ -276,36 +427,18 @@ pub async fn start_display_recording(
     )
     .map_err(|e| format!("Failed to write manifest: {}", e))?;
 
-    // Build platform-specific input args.
-    // macOS: screencapture (Apple system binary) feeds JPEG frames to ffmpeg
-    // via image2pipe. This avoids TCC issues (ffmpeg can't get Screen Recording
-    // permission as a third-party binary) and avfoundation timestamp bugs in VMs.
-    // Linux: x11grab captures directly.
-    let mut input_args: Vec<String> = Vec::new();
-    let use_screencapture_feeder = cfg!(target_os = "macos");
-    if use_screencapture_feeder {
-        input_args.extend([
-            "-f".into(),
-            "image2pipe".into(),
-            "-use_wallclock_as_timestamps".into(),
-            "1".into(),
-            "-i".into(),
-            "pipe:0".into(),
-        ]);
-    } else {
-        let display_arg = format!(":{}", display_id);
-        let size_arg = format!("{}x{}", width, height);
-        input_args.extend([
-            "-f".into(),
-            "x11grab".into(),
-            "-framerate".into(),
-            fps_arg.clone(),
-            "-video_size".into(),
-            size_arg,
-            "-i".into(),
-            display_arg,
-        ]);
-    }
+    let display_arg = format!(":{}", display_id);
+    let size_arg = format!("{}x{}", width, height);
+    let input_args: Vec<String> = vec![
+        "-f".into(),
+        "x11grab".into(),
+        "-framerate".into(),
+        fps_arg,
+        "-video_size".into(),
+        size_arg,
+        "-i".into(),
+        display_arg,
+    ];
 
     // Force keyframes at segment boundaries so segments split reliably.
     let keyframe_expr = format!("expr:gte(t,n_forced*{})", config.segment_duration_secs);
@@ -340,11 +473,7 @@ pub async fn start_display_recording(
             "1",
         ])
         .arg(output_pattern.to_str().unwrap_or("seg_%05d.mp4"))
-        .stdin(if use_screencapture_feeder {
-            std::process::Stdio::piped()
-        } else {
-            std::process::Stdio::null()
-        })
+        .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr({
             let log_path = segments_dir.join("ffmpeg.log");
@@ -359,59 +488,13 @@ pub async fn start_display_recording(
         format!("Failed to spawn ffmpeg for display recording: {}", e)
     })?;
 
-    // Guard against fail-fast errors: x11grab on a Wayland-only session, or
-    // the screencapture feeder without Screen Recording permission, exits
-    // within ~50ms.
-    verify_ffmpeg_started(
-        &mut child,
-        &segments_dir.join("ffmpeg.log"),
-        if cfg!(target_os = "macos") {
-            "screencapture feeder"
-        } else {
-            "x11grab"
-        },
-    )
-    .await
-    .inspect_err(|_| {
-        let _ = std::fs::remove_dir_all(&segments_dir);
-    })?;
-
-    if use_screencapture_feeder {
-        if let Some(stdin) = child.stdin.take() {
-            let frame_interval =
-                std::time::Duration::from_millis(1000 / config.framerate.max(1) as u64);
-            tokio::spawn(async move {
-                use tokio::io::AsyncWriteExt;
-                let mut stdin = stdin;
-                let tmp = std::env::temp_dir().join("intendant_rec_frame.jpg");
-                loop {
-                    let start = tokio::time::Instant::now();
-                    let ok = tokio::process::Command::new("screencapture")
-                        .args(["-x", "-t", "jpg", &tmp.to_string_lossy()])
-                        .stdout(std::process::Stdio::null())
-                        .stderr(std::process::Stdio::null())
-                        .status()
-                        .await
-                        .map(|s| s.success())
-                        .unwrap_or(false);
-                    if ok {
-                        if let Ok(data) = tokio::fs::read(&tmp).await {
-                            if stdin.write_all(&data).await.is_err() {
-                                break;
-                            }
-                        }
-                    } else {
-                        // screencapture failed — likely no TCC permission, stop trying
-                        break;
-                    }
-                    let elapsed = start.elapsed();
-                    if elapsed < frame_interval {
-                        tokio::time::sleep(frame_interval - elapsed).await;
-                    }
-                }
-            });
-        }
-    }
+    // Guard against fail-fast errors: x11grab on a Wayland-only session
+    // exits within ~50ms.
+    verify_ffmpeg_started(&mut child, &segments_dir.join("ffmpeg.log"), "x11grab")
+        .await
+        .inspect_err(|_| {
+            let _ = std::fs::remove_dir_all(&segments_dir);
+        })?;
 
     Ok(RecordingGuard {
         child,
@@ -420,6 +503,8 @@ pub async fn start_display_recording(
         segments_dir,
         started_at: chrono::Utc::now(),
         bridge_task: None,
+        capture_stop: None,
+        capture_pump: None,
     })
 }
 
@@ -526,6 +611,8 @@ pub async fn start_frame_recording(
         segments_dir,
         started_at: chrono::Utc::now(),
         bridge_task: None,
+        capture_stop: None,
+        capture_pump: None,
     })
 }
 
@@ -580,10 +667,17 @@ impl RecordingRegistry {
         display_id: u32,
         width: u32,
         height: u32,
+        bus: &EventBus,
     ) -> Result<String, String> {
-        let guard =
-            start_display_recording(display_id, width, height, &self.config, &self.session_dir)
-                .await?;
+        let guard = start_display_recording(
+            display_id,
+            width,
+            height,
+            &self.config,
+            &self.session_dir,
+            bus,
+        )
+        .await?;
         let stream_name = guard.stream_name().to_string();
         self.recordings.insert(stream_name.clone(), guard);
         Ok(stream_name)
@@ -596,8 +690,9 @@ impl RecordingRegistry {
         display_id: u32,
         width: u32,
         height: u32,
+        bus: &EventBus,
     ) -> Result<String, String> {
-        let stream_name = self.start_display(display_id, width, height).await?;
+        let stream_name = self.start_display(display_id, width, height, bus).await?;
         self.external_streams.insert(stream_name.clone());
         Ok(stream_name)
     }
@@ -980,16 +1075,227 @@ where
     }
 }
 
-/// Spawn the bridge task that feeds frames into a frame-fed recording.
+/// Latest-frame slot an in-process capture pump fills and the external
+/// bridge arm polls. Latest-wins, mirroring `DisplaySession::latest_frame`.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+type ExternalFrameSlot =
+    std::sync::Arc<tokio::sync::RwLock<Option<std::sync::Arc<crate::display::Frame>>>>;
+
+/// Where a frame-fed recording bridge reads its latest frame, and what
+/// authorization each tick must uphold.
+enum BridgeSource {
+    /// An agent-visible `DisplaySession`: every tick and every feed is
+    /// bound to the exact current registry session, so revoke, replacement,
+    /// or private reopen stops the artifact.
+    Session {
+        session_registry: crate::display::SharedSessionRegistry,
+        session: std::sync::Arc<crate::display::DisplaySession>,
+        display_id: u32,
+    },
+    /// Trusted-local in-process capture with no display session to
+    /// authorize against (`--record-display`, the macOS debug screen): a
+    /// capture pump fills the slot. Only the macOS pipeline constructs this
+    /// in production; the seam itself is cross-platform and test-covered
+    /// everywhere.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    External { slot: ExternalFrameSlot },
+}
+
+impl BridgeSource {
+    async fn latest_frame(&self) -> Option<std::sync::Arc<crate::display::Frame>> {
+        match self {
+            BridgeSource::Session { session, .. } => session.latest_frame().await,
+            BridgeSource::External { slot } => slot.read().await.clone(),
+        }
+    }
+}
+
+/// Ceiling on one bridge tick's feed, so a wedged ffmpeg can never park the
+/// bridge (nor, on the session-bound arm, park it while the session-registry
+/// read guard is held).
+const BRIDGE_FEED_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Sink for one bridge tick's JPEG bytes. Production sinks bound every feed
+/// by [`BRIDGE_FEED_TIMEOUT`]; tests inject counting or failing sinks.
+/// Returns `false` when the feed failed and the bridge must stop the
+/// recording.
+#[async_trait::async_trait]
+trait BridgeFeedSink: Send + 'static {
+    async fn feed(&mut self, jpeg: &[u8]) -> bool;
+}
+
+/// Feeds through the recording registry into the guard's stdin — the
+/// session-bound arm, where the registry lookup keeps the feed linearized
+/// with stop/delete guard extraction.
+struct RegistryFeedSink {
+    registry: std::sync::Arc<tokio::sync::RwLock<RecordingRegistry>>,
+    stream_name: String,
+}
+
+#[async_trait::async_trait]
+impl BridgeFeedSink for RegistryFeedSink {
+    async fn feed(&mut self, jpeg: &[u8]) -> bool {
+        matches!(
+            tokio::time::timeout(BRIDGE_FEED_TIMEOUT, async {
+                let mut r = self.registry.write().await;
+                r.feed_frame(&self.stream_name, jpeg).await
+            })
+            .await,
+            Ok(Ok(()))
+        )
+    }
+}
+
+/// Owns ffmpeg's stdin directly — the external arm, whose guard may live
+/// outside the recording registry entirely (the debug screen holds its
+/// guard locally). Dropping the sink with its aborted bridge task is what
+/// hands ffmpeg its EOF.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+struct StdinFeedSink {
+    stdin: tokio::process::ChildStdin,
+}
+
+#[async_trait::async_trait]
+impl BridgeFeedSink for StdinFeedSink {
+    async fn feed(&mut self, jpeg: &[u8]) -> bool {
+        matches!(
+            tokio::time::timeout(BRIDGE_FEED_TIMEOUT, self.stdin.write_all(jpeg)).await,
+            Ok(Ok(()))
+        )
+    }
+}
+
+/// Drive a frame-fed recording bridge until the recording stops.
 ///
-/// Ticks at the configured recording framerate and polls the session's
-/// `latest_frame` on each tick, mirroring how the WebRTC encoder bridge
-/// keeps a steady cadence even when the Wayland capture backend delivers
-/// new frames slowly (0.1 fps on idle desktops). Without this, the
-/// recording would contain only the handful of frames that happened to
-/// arrive during the recording window via the broadcast channel.
-/// Every feed is also bound to the exact current agent-visible registry
-/// session, so revoke, replacement, or private reopen stops the artifact.
+/// Ticks at the configured recording framerate and polls the source's
+/// latest frame on each tick, mirroring how the WebRTC encoder bridge keeps
+/// a steady cadence even when the capture backend delivers new frames
+/// slowly (event-driven backends emit nothing while the desktop is idle).
+/// Without this, the recording would contain only the handful of frames
+/// that happened to arrive during the recording window. Unchanged frames
+/// reuse the identity-keyed JPEG cache instead of re-encoding, but every
+/// tick still feeds — ffmpeg's image2pipe wallclock timing assumes a steady
+/// cadence. A failed feed stops the recording via the lossless control
+/// lane; on the session-bound arm, every feed is additionally bound to the
+/// exact current agent-visible registry session.
+async fn run_frame_bridge<S, E>(
+    source: BridgeSource,
+    mut sink: S,
+    encode: E,
+    stream_name: String,
+    fps: u32,
+    bus: EventBus,
+) where
+    S: BridgeFeedSink,
+    E: Fn(&crate::display::Frame) -> Option<Vec<u8>> + Clone + Send + 'static,
+{
+    let interval = std::time::Duration::from_millis(if fps > 0 { 1000 / fps as u64 } else { 67 });
+    let mut tick = tokio::time::interval(interval);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // The frame the cached JPEG was encoded from, so an unchanged
+    // `latest_frame` reuses the encoded bytes instead of burning an RGB
+    // conversion + JPEG encode per tick on an idle display.
+    let mut last_jpeg: Option<(std::sync::Arc<crate::display::Frame>, Vec<u8>)> = None;
+    loop {
+        tick.tick().await;
+        if let BridgeSource::Session {
+            session_registry,
+            session,
+            display_id,
+        } = &source
+        {
+            match recording_session_state(session_registry, *display_id, session).await {
+                RecordingSessionState::Authorized => {}
+                state => {
+                    stop_recording_for_session_change(&bus, &stream_name, *display_id, state);
+                    break;
+                }
+            }
+        }
+        let Some(frame) = source.latest_frame().await else {
+            continue;
+        };
+        if !reuse_or_encode_jpeg(&mut last_jpeg, frame, encode.clone()).await {
+            continue;
+        }
+        let Some((_, jpeg)) = last_jpeg.as_ref() else {
+            continue;
+        };
+        let fed = match &source {
+            BridgeSource::Session {
+                session_registry,
+                session,
+                display_id,
+            } => {
+                // JPEG encoding runs on the blocking pool. Re-check after
+                // it, then retain the registry read guard through the final
+                // feed. A revoke/replacement needs the write guard, so the
+                // artifact write is linearized wholly before or wholly
+                // after that lifecycle boundary.
+                let session_guard = session_registry.read().await;
+                let state = recording_session_state_in(&session_guard, *display_id, session);
+                if state != RecordingSessionState::Authorized {
+                    drop(session_guard);
+                    stop_recording_for_session_change(&bus, &stream_name, *display_id, state);
+                    break;
+                }
+                let fed = sink.feed(jpeg).await;
+                drop(session_guard);
+                fed
+            }
+            BridgeSource::External { .. } => sink.feed(jpeg).await,
+        };
+        if !fed {
+            bus.send(AppEvent::ControlCommand(ControlMsg::StopRecording {
+                stream_name: stream_name.clone(),
+            }));
+            break;
+        }
+    }
+}
+
+/// Drain an in-process capture backend's frames into the external bridge
+/// slot until stopped, then quiesce the backend.
+///
+/// Teardown routes through the returned stop sender: `finalize` fires it
+/// and awaits the pump with a bound; `Drop` merely drops it, which wakes
+/// the pump the same way without awaiting. If the capture source ends on
+/// its own (display disconnected, capture stream failure), the pump stops
+/// the recording via the lossless control lane instead of letting the
+/// bridge freeze on the last frame forever.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn spawn_external_capture_pump(
+    backend: std::sync::Arc<dyn crate::display::DisplayBackend>,
+    mut frames: tokio::sync::mpsc::Receiver<crate::display::Frame>,
+    slot: ExternalFrameSlot,
+    stream_name: String,
+    bus: EventBus,
+) -> (tokio::sync::oneshot::Sender<()>, tokio::task::JoinHandle<()>) {
+    let (stop_tx, mut stop_rx) = tokio::sync::oneshot::channel::<()>();
+    let task = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = &mut stop_rx => break,
+                frame = frames.recv() => match frame {
+                    Some(frame) => {
+                        *slot.write().await = Some(std::sync::Arc::new(frame));
+                    }
+                    None => {
+                        bus.send(AppEvent::ControlCommand(ControlMsg::StopRecording {
+                            stream_name: stream_name.clone(),
+                        }));
+                        break;
+                    }
+                },
+            }
+        }
+        backend.stop_capture().await;
+    });
+    (stop_tx, task)
+}
+
+/// Spawn the bridge task that feeds an agent-visible session's frames into
+/// a frame-fed recording, bound to that exact session's authorization.
 ///
 /// Returns the `JoinHandle` so the caller can store it in the
 /// `RecordingGuard` for abort-on-drop.
@@ -1002,58 +1308,23 @@ fn spawn_frame_bridge(
     fps: u32,
     bus: EventBus,
 ) -> tokio::task::JoinHandle<()> {
-    let interval = std::time::Duration::from_millis(if fps > 0 { 1000 / fps as u64 } else { 67 });
-    tokio::spawn(async move {
-        let mut tick = tokio::time::interval(interval);
-        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        // The frame the cached JPEG was encoded from, so an unchanged
-        // `latest_frame` reuses the encoded bytes instead of burning an RGB
-        // conversion + JPEG encode per tick on an idle display.
-        let mut last_jpeg: Option<(std::sync::Arc<crate::display::Frame>, Vec<u8>)> = None;
-        loop {
-            tick.tick().await;
-            match recording_session_state(&session_registry, display_id, &session).await {
-                RecordingSessionState::Authorized => {}
-                state => {
-                    stop_recording_for_session_change(&bus, &stream_name, display_id, state);
-                    break;
-                }
-            }
-            let Some(frame) = session.latest_frame().await else {
-                continue;
-            };
-            if !reuse_or_encode_jpeg(&mut last_jpeg, frame, frame_to_jpeg).await {
-                continue;
-            }
-            let Some((_, jpeg)) = last_jpeg.as_ref() else {
-                continue;
-            };
-            // JPEG encoding runs on the blocking pool. Re-check after it,
-            // then retain the registry read guard through the final feed.
-            // A revoke/replacement needs the write guard, so the artifact
-            // write is linearized wholly before or wholly after that
-            // lifecycle boundary.
-            let session_guard = session_registry.read().await;
-            let state = recording_session_state_in(&session_guard, display_id, &session);
-            if state != RecordingSessionState::Authorized {
-                drop(session_guard);
-                stop_recording_for_session_change(&bus, &stream_name, display_id, state);
-                break;
-            }
-            let feed = tokio::time::timeout(std::time::Duration::from_secs(2), async {
-                let mut r = registry.write().await;
-                r.feed_frame(&stream_name, jpeg).await
-            })
-            .await;
-            drop(session_guard);
-            if !matches!(feed, Ok(Ok(()))) {
-                bus.send(AppEvent::ControlCommand(ControlMsg::StopRecording {
-                    stream_name: stream_name.clone(),
-                }));
-                break;
-            }
-        }
-    })
+    let sink = RegistryFeedSink {
+        registry,
+        stream_name: stream_name.clone(),
+    };
+    let source = BridgeSource::Session {
+        session_registry,
+        session,
+        display_id,
+    };
+    tokio::spawn(run_frame_bridge(
+        source,
+        sink,
+        frame_to_jpeg,
+        stream_name,
+        fps,
+        bus,
+    ))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1125,7 +1396,7 @@ async fn recording_session_remains_authorized(
 /// ordinary session artifact tree, so allowing a private view to reach disk
 /// would bypass its owner-only media boundary through filesystem and transfer
 /// APIs. The trusted-local `--record-display` CLI remains a separate explicit
-/// legacy capture path.
+/// capture path (in-process ScreenCaptureKit on macOS, x11grab on Linux).
 async fn start_display_auto(
     registry: &std::sync::Arc<tokio::sync::RwLock<RecordingRegistry>>,
     session_registry: Option<&crate::display::SharedSessionRegistry>,


### PR DESCRIPTION
## What

Deletes the March-era macOS `screencapture`-per-frame recording feeder and captures display recordings in-process via ScreenCaptureKit, keeping ffmpeg strictly as the encoder.

The feeder's historical rationale (ffmpeg cannot hold the Screen Recording TCC grant as a third-party binary) evaporated when in-process SCK capture landed (`MacOSBackend::with_display_id`); it also carried two latent bugs (documented on #424): it never passed a display selector, so it recorded the **main** display regardless of the requested id, and all instances shared one fixed temp path (`$TMPDIR/intendant_rec_frame.jpg`), so concurrent recordings corrupted each other's frames. Both are fixed by construction here.

## How

- **Frame bridge generalized over a source seam** (`BridgeSource`): the session-bound arm keeps its authorization semantics byte-for-byte (per-tick pre-check, post-encode re-check with the session-registry read guard retained through the feed, stop-on-session-change); the new external arm polls a latest-frame slot filled by a capture pump. Both arms share the steady cadence, missed-tick skip, the `reuse_or_encode_jpeg` identity cache (#424), the 2 s feed timeout, and stop-on-feed-failure — SCK is event-driven (idle = no frames), so the cadence pump + identity cache means an idle display feeds cached bytes instead of re-encoding.
- **Feed sink seam** (`BridgeFeedSink`): the session arm feeds through the recording registry as before (`RegistryFeedSink`); the external arm owns ffmpeg's stdin directly (`StdinFeedSink`), because a debug-screen guard lives outside the recording registry. Tests inject counting/failing sinks through the same seam.
- **macOS display recordings** (`--record-display <ID>` and the dashboard debug screen — the second feeder consumer, found in `debug.rs`): `MacOSBackend::with_display_id(id)` (id 0 = `kCGNullDirectDisplay` → main display, which the debug path relies on) → `start_capture(fps)` → capture pump drains frames into the slot → external bridge arm feeds the **existing** image2pipe encoder guard from `start_frame_recording` (the proven frame-fed invocation; encoder args untouched). The manifest is upgraded in place with the true captured resolution and `source: screencapturekit_image2pipe`.
- **Teardown** routes through the guard finalize/stop flow (replacing the feeder's implicit die-on-broken-pipe):
  - `finalize`: abort bridge (drops the bridge-owned stdin → ffmpeg EOF) → fire the capture stop sender and await the pump bounded (2 s; the pump owns `backend.stop_capture()`) → SIGINT ffmpeg → wait ≤ 5 s.
  - `Drop` (last resort): abort bridge; *dropping* the stop sender wakes the pump the same way without awaiting; `kill_on_drop` reaps ffmpeg.
  - Feed failure: bridge sends `StopRecording` on the lossless control lane (unchanged behavior).
  - Capture loss (SCK stream ends on its own): the pump sends `StopRecording` instead of letting the bridge freeze on the last frame forever, then quiesces the backend.
- **Graceful degradation**: if SCK capture fails to start, the start fails cleanly before any artifact exists, with the display backend's Screen Recording (TCC) recovery guidance in the message, and `--record-display` now also emits a `RecordingError` event alongside the stderr line.

## TCC ownership change

Previously Apple's `screencapture` binary carried the Screen Recording grant; now the **Intendant process itself** needs it (boxes already serving displays hold it — session-bound recordings have ridden in-process SCK since April). macOS keys TCC grants to the code signature, so unsigned dev builds re-prompt after rebuilds; the backend's enriched error spells out the System Settings recovery steps and pops the system prompt once per process where possible.

## Untouched

- Linux `x11grab` path (carved into `start_display_recording_x11grab` verbatim; Windows keeps falling into it and failing at ffmpeg start as before).
- Session-bound arm authorization semantics, encoder invocations, segments/finalize machinery.
- `--record-display` help text still says "X11 display" — its wording is a separate cosmetic matter on macOS (where the id is a CGDisplayID), noted here rather than fixed.

## Testing

- Hermetic bridge-level tests through the source/sink seams (injected external source + counting/failing sinks): cadence feeding, identity-cache reuse on an unchanged frame, stop-on-feed-failure, capture-pump slot fill + teardown on stop (send and drop paths) + stop-on-capture-loss, using the synthetic display backend — no SCK, no display, no TCC in CI.
- The session-bound arm's existing tests pass unchanged (they pin the authorization semantics).
- macOS wiring is compile-covered by cfg; real SCK capture (`--record-display` against a live display, debug-screen recording) is an operator smoke on hardware with the Screen Recording grant, not CI.
