### PR TITLE
perf: index-walk fork ancestry, borrow vault sort keys, drop a redundant sort

### DIFF
--- a/crates/owner-plane-reducer/src/fold.rs
+++ b/crates/owner-plane-reducer/src/fold.rs
@@ -5430,8 +5430,7 @@ pub fn fold_set(
     let mut group_of: BTreeMap<&String, &String> = BTreeMap::new();
     {
         let mut by_bytes: BTreeMap<&[u8], &String> = BTreeMap::new();
-        let mut names: Vec<&String> = items.keys().collect();
-        names.sort();
+        let names: Vec<&String> = items.keys().collect();
         for name in names {
             let canon = by_bytes.entry(items[name].as_slice()).or_insert(name);
             group_of.insert(name, canon);

--- a/src/bin/caller/session_fork/claude_tree.rs
+++ b/src/bin/caller/session_fork/claude_tree.rs
@@ -45,16 +45,17 @@ impl ClaudeTranscriptTree {
     pub(crate) fn ancestor_chain(&self, uuid: &str) -> Vec<&ClaudeTreeNode> {
         let mut chain = Vec::new();
         let mut seen = std::collections::HashSet::new();
-        let mut cursor = Some(uuid.to_string());
-        while let Some(current) = cursor {
-            if !seen.insert(current.clone()) {
+        let mut cursor = self.by_uuid.get(uuid).copied();
+        while let Some(index) = cursor {
+            if !seen.insert(index) {
                 break;
             }
-            let Some(node) = self.node(&current) else {
-                break;
-            };
+            let node = &self.nodes[index];
             chain.push(node);
-            cursor = node.parent_uuid.clone();
+            cursor = node
+                .parent_uuid
+                .as_deref()
+                .and_then(|parent| self.by_uuid.get(parent).copied());
         }
         chain
     }

--- a/src/bin/caller/vault_deposits.rs
+++ b/src/bin/caller/vault_deposits.rs
@@ -248,7 +248,7 @@ pub fn list_deposits_in(dir: &Path) -> Result<Vec<DepositRecord>, String> {
             Err(e) => eprintln!("[vault-deposits] skipping {}: {e}", path.display()),
         }
     }
-    records.sort_by_key(|r| (r.created_unix_ms, r.id.clone()));
+    records.sort_by(|a, b| (a.created_unix_ms, &a.id).cmp(&(b.created_unix_ms, &b.id)));
     Ok(records)
 }
 


### PR DESCRIPTION
Wave 2 of the adjudicated zero-tradeoff program (finding 8 of `zero-tradeoff-run-compile-time-imp-reconciled`): the three named allocation sites. Per the ruling, the blanket clippy sweep is rejected — these are the individually verified sites only.

- **`session_fork/claude_tree.rs` `ancestor_chain()`** — walks node indices instead of cloning uuid/parent `String`s each step: a `usize` cursor resolved through `by_uuid` once per step and a `HashSet<usize>` cycle guard. Same return type, same leaf-to-root order, cycle safety preserved (an index repeat is exactly a uuid repeat — `by_uuid` maps distinct uuids to distinct node indices; unknown start uuids and missing parents end the walk exactly as before). Pinned by the existing chain-shape tests (`linear_chain_parses_with_tail_active_leaf`, `compact_boundary_severs_walk_and_marks_pre_compaction`) and the fork-points/surgery batteries.
- **`vault_deposits.rs` `list_deposits_in()`** — `sort_by_key(|r| (r.created_unix_ms, r.id.clone()))` → a borrowed `sort_by` comparator over `(created_unix_ms, &id)`. Identical (stable) ordering, no per-record id clone.
- **`crates/owner-plane-reducer/src/fold.rs` `fold_set()` ONLY** — `names.sort()` removed: the Vec is collected from `BTreeMap::keys()`, which already iterates in sorted order, so the sort was a no-op pass. Governance: `fold_set` is explicitly a local **vendoring addition** ("not part of the frozen source", per its own doc comment) guarded by the `fold_set_matches_run_delivery_full` pin test — locally fixable. `run_delivery_full`'s twin sort is **frozen source and stays untouched** (footnoted to the asset-branch ledger per the ruling); nothing else in the crate is modified.

## Validation
- `cargo nextest run --bins`
- `cargo test -p owner-plane-reducer` (vendored corpus conformance suite, incl. the `fold_set` pin test)
- `cargo fmt --check`, `cargo clippy` (no new warnings)