### PR TITLE
vitals: drop the redundant primary-upstream verify

### DIFF
--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -311,25 +311,14 @@ impl GitVitalsProber {
             };
 
             if facts.branch != primary_branch {
+                // No `rev-parse --verify` gate on `@{upstream}` first: the
+                // `rev-list --count` fails to `None` identically when the
+                // upstream doesn't resolve, so the verify subprocess added
+                // no information.
                 let primary_upstream = format!("{primary_branch}@{{upstream}}");
-                if self
-                    .git(
-                        toplevel,
-                        &[
-                            "rev-parse",
-                            "--verify",
-                            "--quiet",
-                            "--abbrev-ref",
-                            &primary_upstream,
-                        ],
-                    )
-                    .await
-                    .is_some()
-                {
-                    primary_unpushed = self
-                        .git_count(toplevel, &format!("{primary_upstream}..{primary_branch}"))
-                        .await;
-                }
+                primary_unpushed = self
+                    .git_count(toplevel, &format!("{primary_upstream}..{primary_branch}"))
+                    .await;
             }
         }
 


### PR DESCRIPTION
When the session branch differs from the primary, probe_checkout ran
rev-parse --verify --quiet --abbrev-ref <primary>@{upstream} before
counting the primary's unpushed commits. The verify adds no
information: the rev-list --count that follows fails to None
identically when the upstream doesn't resolve. Call git_count
directly, saving one subprocess per tick per checkout in the standard
agent-worktree posture (session branch != primary).

The inline tests pin behavior, not subprocess sequences (the
git_program stub only serves the hung-git timeout test and
checkout_probes counts whole-checkout probes), so no test pins needed
updating; the no-upstream path is already covered by
probe_reports_branch_dirty_and_divergence's primary_unpushed
assertion.
