### PR TITLE
supervisor: dispatch slow launch bodies off the control-intake loop

### DIFF
--- a/docs/src/control-plane-and-daemon.md
+++ b/docs/src/control-plane-and-daemon.md
@@ -101,10 +101,24 @@ the control plane at runtime. Where the control plane owns *settings*, the
 supervisor owns *sessions* — their lifecycle, their per-session resources, and
 the graph of how they relate. `mod.rs` holds the supervisor/state types and
 shared helpers; the behavior is sliced into `dispatch.rs` (ControlMsg intake),
-`launch.rs` (new/resume flows and the shared session spawner),
-`sub_agents.rs` (delegation), `routing.rs` (follow-up/steer/edit/stop),
-`agent_config.rs` (per-session agent config and identity), and `registry.rs`
-(lifecycle observation and registration).
+`exec.rs` (the off-intake per-session executor), `launch.rs` (new/resume flows
+and the shared session spawner), `sub_agents.rs` (delegation), `fork.rs`
+(anchor forks), `routing.rs` (follow-up/steer/edit/stop), `agent_config.rs`
+(per-session agent config and identity), and `registry.rs` (lifecycle
+observation and registration).
+
+The intake is two-tier. The supervisor drains its lossless intent lane
+strictly in order, but `dispatch_control_msg` runs only the fast,
+ordering-critical work inline: validate, mint/reserve session identity, and
+dedup repeat requests. Slow launch bodies — session create (including a
+worktree checkout), resume, restart, fork, dashboard delegation — execute on
+a per-session ordered executor (`exec.rs`) under a small global concurrency
+bound, so one session's multi-second checkout no longer head-of-line-blocks
+another session's approvals, steers, or interrupts. Commands for one session
+still run in arrival order: while a session's launch body (or anything
+deferred behind it) is pending, later commands for that session defer onto
+its queue, and the identity minted at intake keeps the session addressable —
+and its peer-delegation id deduplicated — before the slow body completes.
 
 It subscribes to the bus and handles the session-lifecycle `ControlMsg`s:
 

--- a/src/bin/caller/session_supervisor/dispatch.rs
+++ b/src/bin/caller/session_supervisor/dispatch.rs
@@ -1,11 +1,370 @@
-//! Control-plane intake: the ControlMsg match (handle_control_msg), the
-//! should-handle gate for targeted session commands, and the unattached
-//! codex thread-action fallback responder.
+//! Control-plane intake: the intake dispatcher (`dispatch_control_msg` —
+//! fast arms inline, slow launch bodies onto the per-session executor),
+//! the ControlMsg match (handle_control_msg), the should-handle gate for
+//! targeted session commands, and the unattached codex thread-action
+//! fallback responder.
 
 use super::*;
 
+/// How the intake disposes of a task-shaped message (`CreateSession` /
+/// untargeted `StartTask`): a codex slash command routes as a follow-up
+/// into the active session (fast), everything else — including `/fast`,
+/// which creates an idle Codex session — is a session-create body (slow).
+/// Mirrors the branch structure inside the arms exactly; the arms remain
+/// the single source of behavior, this only decides WHERE they run.
+enum CreateDisposition {
+    SlowCreate,
+    FastFollowUp,
+}
+
+fn classify_create_task(task: &str) -> CreateDisposition {
+    match parse_codex_slash_command(task) {
+        None => CreateDisposition::SlowCreate,
+        Some(Ok(command)) if command.op == "fast" => CreateDisposition::SlowCreate,
+        Some(Ok(_)) | Some(Err(_)) => CreateDisposition::FastFollowUp,
+    }
+}
+
+/// The ids a FAST arm's ordering is keyed by, mirroring each arm's own
+/// target resolution: `(explicit ids, falls back to the active session
+/// when none)`. Distinct from [`control_target_session_id`], which feeds
+/// the resume listener's should-handle gate — this one exists to answer
+/// "which session's queue must this command stay ordered with?", so it
+/// also names the arms' secondary ids and their active-session fallback.
+fn fast_control_queue_ids(msg: &event::ControlMsg) -> (Vec<String>, bool) {
+    use event::ControlMsg as C;
+    match msg {
+        // Slash-command paths of the task-shaped arms: route_follow_up
+        // into the active session.
+        C::CreateSession { .. } | C::StartTask { session_id: None, .. } => (Vec::new(), true),
+        C::StartTask {
+            session_id: Some(id),
+            ..
+        } => (vec![id.clone()], false),
+        C::FollowUp { session_id, .. }
+        | C::EditUserMessage { session_id, .. }
+        | C::Interrupt { session_id, .. }
+        | C::Steer { session_id, .. }
+        | C::CancelSteer { session_id, .. }
+        | C::CancelFollowUp { session_id, .. }
+        | C::Approve { session_id, .. }
+        | C::Deny { session_id, .. }
+        | C::Skip { session_id, .. }
+        | C::ApproveAll { session_id, .. }
+        | C::AnswerQuestion { session_id, .. } => (
+            session_id.iter().cloned().collect(),
+            session_id.is_none(),
+        ),
+        C::StopSession { session_id } | C::ReloadCredentials { session_id } => {
+            (vec![session_id.clone()], false)
+        }
+        C::RenameSession {
+            session_id,
+            backend_session_id,
+            ..
+        } => (
+            std::iter::once(session_id.clone())
+                .chain(backend_session_id.iter().cloned())
+                .collect(),
+            false,
+        ),
+        C::ConfigureSessionAgent {
+            session_id,
+            backend_session_id,
+            intendant_session_id,
+            ..
+        } => (
+            std::iter::once(session_id.clone())
+                .chain(backend_session_id.iter().cloned())
+                .chain(intendant_session_id.iter().cloned())
+                .collect(),
+            false,
+        ),
+        // The fallback responder takes no active-session fallback (it
+        // returns early for a missing id).
+        C::CodexThreadAction { session_id, .. } => (session_id.iter().cloned().collect(), false),
+        _ => (Vec::new(), false),
+    }
+}
+
 impl SessionSupervisor {
+    /// Intake dispatcher: run one ControlMsg either inline (fast arms for
+    /// idle sessions) or on the per-session executor. The intake loop
+    /// stays sequential and lossless; this only decides WHERE each body
+    /// runs:
+    ///
+    /// - Slow launch bodies (create / resume / restart / fork / dashboard
+    ///   delegation) are enqueued per session, with identity minted and
+    ///   routes/delegation dedup reserved synchronously HERE — so a
+    ///   targeted command that arrives while the body is still executing
+    ///   defers behind it instead of failing "not managed", and a
+    ///   duplicate peer delegation routes to the original launch instead
+    ///   of starting a second task.
+    /// - Fast arms run inline unless their session's queue is busy, in
+    ///   which case they defer onto it so one session's commands always
+    ///   execute in arrival order (the serial-intake ordering, kept
+    ///   per-session).
+    ///
+    /// `handle_control_msg` remains the single behavioral source: jobs
+    /// and the inline path both run it verbatim, so calling it directly
+    /// (tests, embedded flows) keeps the exact serial semantics.
+    ///
+    /// Returns a boxed future (not an `async fn`) to break the
+    /// opaque-type cycle: the inline path contains `handle_control_msg`,
+    /// whose edit-attach arm dispatches back through this method (the
+    /// `start_sub_agent_session` precedent).
+    pub(crate) fn dispatch_control_msg<'a>(
+        &'a self,
+        msg: event::ControlMsg,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>> {
+        Box::pin(self.dispatch_control_msg_inner(msg))
+    }
+
+    async fn dispatch_control_msg_inner(&self, msg: event::ControlMsg) {
+        use event::ControlMsg as C;
+        match &msg {
+            C::CreateSession { task, .. } => match classify_create_task(task) {
+                CreateDisposition::FastFollowUp => self.dispatch_fast_control(msg).await,
+                CreateDisposition::SlowCreate => self.enqueue_create_control(msg, None).await,
+            },
+            C::StartTask {
+                session_id: None,
+                task,
+                delegation_id,
+                ..
+            } => match classify_create_task(task) {
+                CreateDisposition::FastFollowUp => self.dispatch_fast_control(msg).await,
+                CreateDisposition::SlowCreate => {
+                    let delegation_id = delegation_id.clone();
+                    self.enqueue_create_control(msg, delegation_id).await;
+                }
+            },
+            C::SpawnSubAgent { session_id, .. } => {
+                let ids = vec![session_id.clone()];
+                self.enqueue_slow_control(msg, ids).await;
+            }
+            C::ResumeSession {
+                session_id,
+                resume_id,
+                ..
+            }
+            | C::RestartSession {
+                session_id,
+                resume_id,
+                ..
+            }
+            | C::ForkSessionAtAnchor {
+                session_id,
+                resume_id,
+                ..
+            } => {
+                let ids = std::iter::once(session_id.clone())
+                    .chain(resume_id.iter().cloned())
+                    .collect();
+                self.enqueue_slow_control(msg, ids).await;
+            }
+            _ => self.dispatch_fast_control(msg).await,
+        }
+    }
+
+    /// Run a fast arm inline — unless the session it targets has a busy
+    /// queue (a launch body executing, or commands already deferred
+    /// behind one), in which case it defers onto that queue to keep the
+    /// session's command order.
+    async fn dispatch_fast_control(&self, msg: event::ControlMsg) {
+        let (mut candidates, falls_back_to_active) = fast_control_queue_ids(&msg);
+        if candidates.is_empty() && falls_back_to_active {
+            // The legacy untargeted shape resolves to "the active
+            // session". While a launch body is pending, the session it
+            // will register is the one a serial intake would have
+            // resolved to — chase the newest pending launch's queue so
+            // the deferred arm re-resolves after registration.
+            if let Some(key) = self.exec.latest_pending_heavy_key() {
+                candidates.push(key);
+            } else {
+                let state = self.state.lock().await;
+                if let Some(active) = state.active_session_id.clone() {
+                    candidates.push(active);
+                }
+            }
+        }
+        match self.busy_queue_key_for(&candidates).await {
+            Some(key) => {
+                let supervisor = self.clone();
+                self.exec.enqueue(
+                    &key,
+                    exec::IntakeJob::light(Box::pin(async move {
+                        supervisor.handle_control_msg(msg).await;
+                    })),
+                );
+            }
+            None => self.handle_control_msg(msg).await,
+        }
+    }
+
+    /// The busy queue this command must stay ordered with, if any: probe
+    /// each candidate id raw (pending route, then live queue), then its
+    /// canonical resolution the same way.
+    async fn busy_queue_key_for(&self, ids: &[String]) -> Option<String> {
+        let ids: Vec<&str> = ids
+            .iter()
+            .map(|id| id.trim())
+            .filter(|id| !id.is_empty())
+            .collect();
+        if ids.is_empty() {
+            return None;
+        }
+        for id in &ids {
+            if let Some(key) = self.exec.route_key(id) {
+                return Some(key);
+            }
+            if self.exec.queue_busy(id) {
+                return Some(id.to_string());
+            }
+        }
+        let canonical: Vec<String> = {
+            let state = self.state.lock().await;
+            ids.iter()
+                .filter_map(|id| state.resolve_session_id(id))
+                .collect()
+        };
+        for id in canonical {
+            if let Some(key) = self.exec.route_key(&id) {
+                return Some(key);
+            }
+            if self.exec.queue_busy(&id) {
+                return Some(id);
+            }
+        }
+        None
+    }
+
+    /// Reserve and enqueue a session-create body (`CreateSession`, or an
+    /// untargeted `StartTask` that is not a slash command). The session
+    /// id is minted synchronously here so it is routable — via the
+    /// pending route — before the slow body runs; a peer delegation id is
+    /// reserved in the same step so duplicate deliveries order behind the
+    /// original launch (the re-ack contract: the receipt fires only after
+    /// dispatch, duplicates re-ack the ORIGINAL session, failed launches
+    /// stay unacked and release the reservation for a fresh retry).
+    async fn enqueue_create_control(
+        &self,
+        msg: event::ControlMsg,
+        delegation_id: Option<String>,
+    ) {
+        if let Some(id) = delegation_id.as_deref() {
+            let recorded = self
+                .state
+                .lock()
+                .await
+                .recorded_delegation_session(id)
+                .is_some();
+            if recorded {
+                // Already dispatched: the arm's own duplicate branch
+                // re-acks with the original session and returns — fast,
+                // safe inline. (The arm re-checks, so even a ledger
+                // eviction between here and there only costs running the
+                // create inline, never a wrong ack.)
+                self.handle_control_msg(msg).await;
+                return;
+            }
+        }
+        let reserved = self.reserve_session_launch();
+        // A duplicate delivery of a still-launching delegation joins the
+        // ORIGINAL launch's queue: it runs after the original settles, so
+        // its arm either re-acks the recorded session or — if the launch
+        // failed and released the reservation — performs the fresh retry
+        // a serial intake would have (its own reservation keeps that
+        // retry's session routable too).
+        let key = delegation_id
+            .as_deref()
+            .and_then(|id| self.exec.pending_delegation_key(id))
+            .unwrap_or_else(|| reserved.session_id.clone());
+        let routes = vec![reserved.session_id.clone()];
+        let supervisor = self.clone();
+        self.exec.enqueue(
+            &key,
+            exec::IntakeJob::heavy(
+                Box::pin(async move {
+                    supervisor
+                        .handle_control_msg_with_reservation(msg, Some(reserved))
+                        .await;
+                }),
+                routes,
+                delegation_id,
+            ),
+        );
+    }
+
+    /// Enqueue a slow non-create body (resume / restart / fork /
+    /// dashboard delegation) keyed and routed by the ids the request
+    /// addresses, so later commands for the same session defer behind it.
+    async fn enqueue_slow_control(&self, msg: event::ControlMsg, requested_ids: Vec<String>) {
+        let (key, routes) = self.slow_key_and_routes(requested_ids).await;
+        let supervisor = self.clone();
+        self.exec.enqueue(
+            &key,
+            exec::IntakeJob::heavy(
+                Box::pin(async move {
+                    supervisor.handle_control_msg(msg).await;
+                }),
+                routes,
+                None,
+            ),
+        );
+    }
+
+    /// Pick the ordering key for a slow body: an existing pending route
+    /// for any addressed id wins (merge onto the launch already in
+    /// flight), then a managed session's canonical id (so commands
+    /// addressed by its other aliases key the same), then the first
+    /// addressed id.
+    async fn slow_key_and_routes(&self, requested_ids: Vec<String>) -> (String, Vec<String>) {
+        let mut ids: Vec<String> = Vec::new();
+        for id in requested_ids {
+            let id = id.trim().to_string();
+            if !id.is_empty() && !ids.contains(&id) {
+                ids.push(id);
+            }
+        }
+        let canonical: Vec<String> = {
+            let state = self.state.lock().await;
+            ids.iter()
+                .filter_map(|id| state.resolve_session_id(id))
+                .filter(|id| !ids.contains(id))
+                .collect()
+        };
+        let key = ids
+            .iter()
+            .chain(canonical.iter())
+            .find_map(|id| self.exec.route_key(id))
+            .or_else(|| canonical.first().cloned())
+            .or_else(|| ids.first().cloned())
+            // Defensive: a request with no usable id at all still needs
+            // an ordering domain; the arm will narrate its own failure.
+            .unwrap_or_else(|| "unaddressed".to_string());
+        let mut routes = ids;
+        for id in canonical {
+            if !routes.contains(&id) {
+                routes.push(id);
+            }
+        }
+        (key, routes)
+    }
+
     pub(crate) async fn handle_control_msg(&self, msg: event::ControlMsg) {
+        self.handle_control_msg_with_reservation(msg, None).await
+    }
+
+    /// The ControlMsg behavior match. `reserved` carries the session
+    /// identity `dispatch_control_msg` minted at intake for a queued
+    /// create body (None mints internally — the serial path direct
+    /// callers and tests use); only the create-shaped arms consume it.
+    pub(crate) async fn handle_control_msg_with_reservation(
+        &self,
+        msg: event::ControlMsg,
+        reserved: Option<ReservedSessionLaunch>,
+    ) {
         match msg {
             event::ControlMsg::CreateSession {
                 task,
@@ -81,6 +440,7 @@ impl SessionSupervisor {
                                     ),
                                     worktree_request,
                                     hosted_lease_id,
+                                    reserved,
                                 )
                                 .await;
                             return;
@@ -136,6 +496,7 @@ impl SessionSupervisor {
                         codex_service_tier,
                         worktree_request,
                         hosted_lease_id,
+                        reserved,
                     )
                     .await;
             }
@@ -227,6 +588,7 @@ impl SessionSupervisor {
                                     ),
                                     None,
                                     None,
+                                    reserved,
                                 )
                                 .await;
                             if let (Some(id), Some(session_id)) =
@@ -276,6 +638,7 @@ impl SessionSupervisor {
                         None,
                         None,
                         None,
+                        reserved,
                     )
                     .await;
                 // Acknowledge acceptance only once the task is actually
@@ -598,7 +961,11 @@ impl SessionSupervisor {
             msg if control_msg_can_attach_unmanaged_session(msg) => true,
             _ => {
                 if let Some(session_id) = control_target_session_id(msg) {
-                    self.session_is_managed(session_id).await
+                    // A pending launch route counts as "managed": the
+                    // session's create/resume body is still executing off
+                    // the intake loop, and the command must defer behind
+                    // it rather than be skipped here.
+                    self.session_is_managed(session_id).await || self.exec.has_route(session_id)
                 } else {
                     false
                 }
@@ -721,6 +1088,405 @@ mod tests {
     use crate::session_supervisor::tests::{
         managed_session, test_supervisor, test_supervisor_with_mock_provider,
     };
+
+    /// A mock-provider supervisor whose slow launch bodies block on the
+    /// returned gate (`SessionSupervisorConfig::launch_gate_for_tests`) —
+    /// the deterministic stand-in for a multi-second worktree checkout.
+    fn test_supervisor_with_gated_launches(
+        project_root: PathBuf,
+        bus: EventBus,
+    ) -> (SessionSupervisor, tokio::sync::watch::Sender<bool>) {
+        let (gate_tx, gate_rx) = tokio::sync::watch::channel(false);
+        let mut config = (*test_supervisor(project_root, bus).config).clone();
+        config.provider_factory = Some(Arc::new(|| {
+            Box::new(provider::mock::MockOrchestrationProvider::new())
+                as Box<dyn provider::ChatProvider>
+        }));
+        config.launch_gate_for_tests = Some(gate_rx);
+        (SessionSupervisor::new(config), gate_tx)
+    }
+
+    fn create_session_msg(task: &str, worktree: bool) -> event::ControlMsg {
+        event::ControlMsg::CreateSession {
+            task: task.to_string(),
+            name: None,
+            project_root: None,
+            agent: None,
+            agent_command: None,
+            claude_model: None,
+            claude_permission_mode: None,
+            claude_effort: None,
+            codex_model: None,
+            codex_reasoning_effort: None,
+            codex_sandbox: None,
+            codex_approval_policy: None,
+            codex_managed_context: None,
+            codex_context_archive: None,
+            codex_service_tier: None,
+            orchestrate: None,
+            direct: Some(true),
+            reference_frame_ids: vec![],
+            display_target: None,
+            attachments: vec![],
+            worktree: worktree.then_some(true),
+            worktree_branch: None,
+            hosted_lease_id: None,
+        }
+    }
+
+    /// Poll a condition with a deadline — used to observe the intake's
+    /// asynchronous dispatch effects (route reservations) without sleeps
+    /// of fixed length.
+    async fn wait_until(what: &str, deadline_ms: u64, mut check: impl FnMut() -> bool) {
+        let deadline =
+            tokio::time::Instant::now() + std::time::Duration::from_millis(deadline_ms);
+        loop {
+            if check() {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for: {what}"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    }
+
+    /// Send a sentinel Interrupt for an unmanaged ghost id and await its
+    /// `Interrupted` ack. The intake drains the lane in order, so once the
+    /// ack arrives every previously sent command has been DISPATCHED
+    /// (inline-run or enqueued) — the deterministic "intake caught up"
+    /// barrier for the gated-launch tests.
+    async fn await_intake_barrier(
+        bus: &EventBus,
+        rx: &mut tokio::sync::broadcast::Receiver<AppEvent>,
+        ghost_id: &str,
+    ) {
+        bus.send(AppEvent::ControlCommand(event::ControlMsg::Interrupt {
+            session_id: Some(ghost_id.to_string()),
+            expected_turn: None,
+        }));
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(!remaining.is_zero(), "intake barrier {ghost_id} timed out");
+            match tokio::time::timeout(remaining, rx.recv()).await {
+                Ok(Ok(AppEvent::Interrupted { session_id, .. }))
+                    if session_id.as_deref() == Some(ghost_id) =>
+                {
+                    return;
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                other => panic!("bus closed before the barrier ack: {other:?}"),
+            }
+        }
+    }
+
+    /// The head-of-line regression this restructure removes: while one
+    /// session's create body is held (the slow-worktree stand-in), a
+    /// follow-up for ANOTHER live session must still deliver promptly.
+    /// Before the per-session executor, the intake awaited the create
+    /// inline and every other session's commands waited it out.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn slow_create_does_not_block_other_sessions_commands() {
+        let bus = EventBus::new();
+        let project_dir = tempfile::tempdir().unwrap();
+        let (supervisor, gate) =
+            test_supervisor_with_gated_launches(project_dir.path().to_path_buf(), bus.clone());
+        let (live_tx, mut live_rx) = mpsc::channel(4);
+        {
+            let mut state = supervisor.state.lock().await;
+            let mut session = managed_session("live-b", "codex");
+            session.follow_up_tx = live_tx;
+            state.sessions.insert("live-b".to_string(), session);
+        }
+        let mut bus_rx = bus.subscribe();
+        let _loop_handle = supervisor.clone().spawn();
+
+        bus.send(AppEvent::ControlCommand(create_session_msg(
+            "task held at the launch gate",
+            false,
+        )));
+        // The create body is provably in flight: its identity was reserved
+        // at intake and its job is gated.
+        let exec = supervisor.exec.clone();
+        wait_until("create reservation", 10_000, || {
+            exec.pending_route_count() > 0
+        })
+        .await;
+
+        bus.send(AppEvent::ControlCommand(event::ControlMsg::FollowUp {
+            session_id: Some("live-b".to_string()),
+            text: "prompt while the create is stuck".to_string(),
+            direct: None,
+            follow_up_id: Some("fu-live-b".to_string()),
+        }));
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(5), live_rx.recv())
+            .await
+            .expect("a live session's follow-up must not wait out another session's create")
+            .expect("live session channel open");
+        assert_eq!(msg.text, "prompt while the create is stuck");
+        assert!(
+            !*gate.borrow(),
+            "the create body must still be held when the other session's command lands"
+        );
+
+        // Release the gate: the held create completes and announces.
+        gate.send(true).expect("launch body holds the gate receiver");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(!remaining.is_zero(), "released create never announced");
+            match tokio::time::timeout(remaining, bus_rx.recv()).await {
+                Ok(Ok(AppEvent::SessionStarted { .. })) => break,
+                Ok(Ok(_)) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                other => panic!("bus closed before SessionStarted: {other:?}"),
+            }
+        }
+    }
+
+    /// Same-session ordering across the reservation: a targeted command
+    /// for a session whose create is still executing is neither lost nor
+    /// misrouted — the intake-minted id routes it onto the create's queue,
+    /// and it lands (in order) once the session is registered.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn create_then_immediate_follow_up_defers_until_registration() {
+        let bus = EventBus::new();
+        let project_dir = tempfile::tempdir().unwrap();
+        let (supervisor, gate) =
+            test_supervisor_with_gated_launches(project_dir.path().to_path_buf(), bus.clone());
+        let mut bus_rx = bus.subscribe();
+        let _loop_handle = supervisor.clone().spawn();
+
+        bus.send(AppEvent::ControlCommand(create_session_msg(
+            "plain task behind the gate",
+            false,
+        )));
+        let exec = supervisor.exec.clone();
+        wait_until("create reservation", 10_000, || {
+            exec.pending_route_count() > 0
+        })
+        .await;
+        let minted = supervisor.exec.pending_route_ids().remove(0);
+
+        // Target the still-creating session immediately.
+        bus.send(AppEvent::ControlCommand(event::ControlMsg::FollowUp {
+            session_id: Some(minted.clone()),
+            text: "follow-up racing its own create".to_string(),
+            direct: None,
+            follow_up_id: Some("fu-minted".to_string()),
+        }));
+        await_intake_barrier(&bus, &mut bus_rx, "barrier-ghost-1").await;
+
+        // Dispatched but the create is still held: the follow-up must not
+        // have resolved either way yet (not failed "not managed", not
+        // delivered) — it is deferred behind the create in order.
+        while let Ok(event) = bus_rx.try_recv() {
+            if let AppEvent::FollowUpStatus { id, status, .. } = event {
+                panic!("follow-up must stay deferred while the create runs (got {id}: {status})");
+            }
+        }
+
+        gate.send(true).expect("launch body holds the gate receiver");
+        let mut saw_started = false;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(!remaining.is_zero(), "queued follow-up never resolved");
+            match tokio::time::timeout(remaining, bus_rx.recv()).await {
+                Ok(Ok(AppEvent::SessionStarted { session_id, .. })) if session_id == minted => {
+                    saw_started = true;
+                }
+                Ok(Ok(AppEvent::FollowUpStatus { id, status, .. })) if id == "fu-minted" => {
+                    assert!(
+                        saw_started,
+                        "the deferred follow-up resolved before its session registered"
+                    );
+                    assert_eq!(
+                        status, "queued",
+                        "the deferred follow-up must deliver into the registered session"
+                    );
+                    break;
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                other => panic!("bus closed before the follow-up resolved: {other:?}"),
+            }
+        }
+    }
+
+    /// Reservation release on a FAILED create: the pending route dies with
+    /// the launch, and a command deferred behind it gets the existing
+    /// honest "not managed" failure — never a hang, never a silent drop.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn failed_create_releases_reservation_and_deferred_command_fails_honestly() {
+        let bus = EventBus::new();
+        let project_dir = tempfile::tempdir().unwrap();
+        let (supervisor, gate) =
+            test_supervisor_with_gated_launches(project_dir.path().to_path_buf(), bus.clone());
+        let mut bus_rx = bus.subscribe();
+        let _loop_handle = supervisor.clone().spawn();
+
+        // worktree: true on a plain directory (no git repo) fails the
+        // create after the gate — the honest-failure arm under test.
+        bus.send(AppEvent::ControlCommand(create_session_msg(
+            "create that will fail its worktree",
+            true,
+        )));
+        let exec = supervisor.exec.clone();
+        wait_until("create reservation", 10_000, || {
+            exec.pending_route_count() > 0
+        })
+        .await;
+        let minted = supervisor.exec.pending_route_ids().remove(0);
+
+        bus.send(AppEvent::ControlCommand(event::ControlMsg::FollowUp {
+            session_id: Some(minted.clone()),
+            text: "queued behind a doomed create".to_string(),
+            direct: None,
+            follow_up_id: Some("fu-doomed".to_string()),
+        }));
+        await_intake_barrier(&bus, &mut bus_rx, "barrier-ghost-2").await;
+
+        gate.send(true).expect("launch body holds the gate receiver");
+        let mut saw_failed_create = false;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "deferred follow-up never resolved after the failed create"
+            );
+            match tokio::time::timeout(remaining, bus_rx.recv()).await {
+                Ok(Ok(AppEvent::SessionEnded {
+                    session_id, reason, ..
+                })) if session_id == minted => {
+                    assert!(reason.contains("worktree launch failed"), "got: {reason}");
+                    saw_failed_create = true;
+                }
+                Ok(Ok(AppEvent::FollowUpStatus {
+                    id, status, reason, ..
+                })) if id == "fu-doomed" => {
+                    assert!(
+                        saw_failed_create,
+                        "the deferred follow-up resolved before the create failed"
+                    );
+                    assert_eq!(status, "failed");
+                    assert_eq!(
+                        reason.as_deref(),
+                        Some("target session is not managed by this daemon"),
+                        "the failed-create session must get the existing honest failure"
+                    );
+                    break;
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                other => panic!("bus closed before the follow-up resolved: {other:?}"),
+            }
+        }
+        // The reservation died with the launch.
+        wait_until("reservation release", 10_000, || {
+            exec.pending_route_count() == 0
+        })
+        .await;
+    }
+
+    /// Peer-delegation dedup across the off-loop launch: a duplicate
+    /// delivery arriving while the ORIGINAL create is still executing
+    /// orders behind it, re-acks the original session identity after the
+    /// original receipt, and never starts a second task — the ack still
+    /// fires only after dispatch (SessionStarted precedes the receipt).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn duplicate_delegation_mid_create_re_acks_original_without_second_session() {
+        let bus = EventBus::new();
+        let project_dir = tempfile::tempdir().unwrap();
+        let (supervisor, gate) =
+            test_supervisor_with_gated_launches(project_dir.path().to_path_buf(), bus.clone());
+        let mut bus_rx = bus.subscribe();
+        let _loop_handle = supervisor.clone().spawn();
+
+        let delegated = |id: &str| event::ControlMsg::StartTask {
+            session_id: None,
+            task: "delegated: report project status".to_string(),
+            orchestrate: None,
+            direct: Some(true),
+            reference_frame_ids: vec![],
+            display_target: None,
+            attachments: vec![],
+            follow_up_id: None,
+            delegation_id: Some(id.to_string()),
+        };
+        bus.send(AppEvent::ControlCommand(delegated("dg-mid-1")));
+        let exec = supervisor.exec.clone();
+        wait_until("delegation reservation", 10_000, || {
+            exec.pending_delegation_key("dg-mid-1").is_some()
+        })
+        .await;
+
+        // The at-least-once retry lands while the original is still held.
+        bus.send(AppEvent::ControlCommand(delegated("dg-mid-1")));
+        await_intake_barrier(&bus, &mut bus_rx, "barrier-ghost-3").await;
+
+        gate.send(true).expect("launch body holds the gate receiver");
+        let mut started: Vec<String> = Vec::new();
+        let mut receipts: Vec<String> = Vec::new();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        while receipts.len() < 2 {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            assert!(
+                !remaining.is_zero(),
+                "expected two receipts (started: {started:?}, receipts: {receipts:?})"
+            );
+            match tokio::time::timeout(remaining, bus_rx.recv()).await {
+                Ok(Ok(AppEvent::SessionStarted { session_id, .. })) => {
+                    started.push(session_id);
+                }
+                Ok(Ok(AppEvent::TaskReceived {
+                    delegation_id,
+                    session_id,
+                })) => {
+                    assert_eq!(delegation_id, "dg-mid-1");
+                    assert!(
+                        started.contains(&session_id),
+                        "a receipt must follow the dispatch it names \
+                         (receipt: {session_id}, started: {started:?})"
+                    );
+                    receipts.push(session_id);
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                other => panic!("bus closed before both receipts: {other:?}"),
+            }
+        }
+        assert_eq!(
+            receipts[0], receipts[1],
+            "the duplicate must re-ack the ORIGINAL session identity"
+        );
+        assert_eq!(
+            started.len(),
+            1,
+            "the duplicate delivery must not start a second session: {started:?}"
+        );
+
+        // Settle window: nothing else starts after the re-ack.
+        let settle = std::time::Instant::now() + std::time::Duration::from_millis(400);
+        loop {
+            let remaining = settle.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match tokio::time::timeout(remaining, bus_rx.recv()).await {
+                Ok(Ok(AppEvent::SessionStarted { session_id, .. })) => {
+                    panic!("late duplicate session started: {session_id}")
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                _ => break,
+            }
+        }
+    }
 
     #[tokio::test]
     async fn thread_action_fallback_defers_to_advertised_ops() {

--- a/src/bin/caller/session_supervisor/dispatch.rs
+++ b/src/bin/caller/session_supervisor/dispatch.rs
@@ -36,7 +36,10 @@ fn fast_control_queue_ids(msg: &event::ControlMsg) -> (Vec<String>, bool) {
     match msg {
         // Slash-command paths of the task-shaped arms: route_follow_up
         // into the active session.
-        C::CreateSession { .. } | C::StartTask { session_id: None, .. } => (Vec::new(), true),
+        C::CreateSession { .. }
+        | C::StartTask {
+            session_id: None, ..
+        } => (Vec::new(), true),
         C::StartTask {
             session_id: Some(id),
             ..
@@ -51,10 +54,9 @@ fn fast_control_queue_ids(msg: &event::ControlMsg) -> (Vec<String>, bool) {
         | C::Deny { session_id, .. }
         | C::Skip { session_id, .. }
         | C::ApproveAll { session_id, .. }
-        | C::AnswerQuestion { session_id, .. } => (
-            session_id.iter().cloned().collect(),
-            session_id.is_none(),
-        ),
+        | C::AnswerQuestion { session_id, .. } => {
+            (session_id.iter().cloned().collect(), session_id.is_none())
+        }
         C::StopSession { session_id } | C::ReloadCredentials { session_id } => {
             (vec![session_id.clone()], false)
         }
@@ -247,11 +249,7 @@ impl SessionSupervisor {
     /// original launch (the re-ack contract: the receipt fires only after
     /// dispatch, duplicates re-ack the ORIGINAL session, failed launches
     /// stay unacked and release the reservation for a fresh retry).
-    async fn enqueue_create_control(
-        &self,
-        msg: event::ControlMsg,
-        delegation_id: Option<String>,
-    ) {
+    async fn enqueue_create_control(&self, msg: event::ControlMsg, delegation_id: Option<String>) {
         if let Some(id) = delegation_id.as_deref() {
             let recorded = self
                 .state
@@ -1138,8 +1136,7 @@ mod tests {
     /// asynchronous dispatch effects (route reservations) without sleeps
     /// of fixed length.
     async fn wait_until(what: &str, deadline_ms: u64, mut check: impl FnMut() -> bool) {
-        let deadline =
-            tokio::time::Instant::now() + std::time::Duration::from_millis(deadline_ms);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(deadline_ms);
         loop {
             if check() {
                 return;
@@ -1233,7 +1230,8 @@ mod tests {
         );
 
         // Release the gate: the held create completes and announces.
-        gate.send(true).expect("launch body holds the gate receiver");
+        gate.send(true)
+            .expect("launch body holds the gate receiver");
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         loop {
             let remaining = deadline.saturating_duration_since(std::time::Instant::now());
@@ -1289,7 +1287,8 @@ mod tests {
             }
         }
 
-        gate.send(true).expect("launch body holds the gate receiver");
+        gate.send(true)
+            .expect("launch body holds the gate receiver");
         let mut saw_started = false;
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         loop {
@@ -1350,7 +1349,8 @@ mod tests {
         }));
         await_intake_barrier(&bus, &mut bus_rx, "barrier-ghost-2").await;
 
-        gate.send(true).expect("launch body holds the gate receiver");
+        gate.send(true)
+            .expect("launch body holds the gate receiver");
         let mut saw_failed_create = false;
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
         loop {
@@ -1429,7 +1429,8 @@ mod tests {
         bus.send(AppEvent::ControlCommand(delegated("dg-mid-1")));
         await_intake_barrier(&bus, &mut bus_rx, "barrier-ghost-3").await;
 
-        gate.send(true).expect("launch body holds the gate receiver");
+        gate.send(true)
+            .expect("launch body holds the gate receiver");
         let mut started: Vec<String> = Vec::new();
         let mut receipts: Vec<String> = Vec::new();
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);

--- a/src/bin/caller/session_supervisor/exec.rs
+++ b/src/bin/caller/session_supervisor/exec.rs
@@ -1,0 +1,486 @@
+//! Off-intake execution for the session supervisor: per-session ordered
+//! job queues with a small global concurrency bound for heavy launch
+//! bodies, plus the pending-route / pending-delegation reservations that
+//! keep a launching session addressable — and its commands ordered —
+//! while its slow body (create / resume / restart / fork / delegation
+//! spawn) executes off the control-intake loop.
+//!
+//! The intake loop (`run_event_loop`) stays strictly sequential and
+//! lossless; what changed is WHERE command bodies run. `dispatch_control_msg`
+//! (dispatch.rs) reserves identity synchronously at intake and hands slow
+//! bodies here, so one session's multi-second worktree checkout no longer
+//! blocks another session's approvals / steers / interrupts. Ordering
+//! contract: all jobs enqueued under one key run strictly in enqueue
+//! order, one at a time; different keys run concurrently (heavy bodies
+//! additionally bounded by [`MAX_CONCURRENT_LAUNCH_BODIES`]).
+
+use std::collections::{HashMap, VecDeque};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+
+/// Global bound on concurrently executing heavy launch bodies (session
+/// create / resume / restart / fork / delegation spawns). Deferred fast
+/// commands queued behind them are not counted — only the bodies that do
+/// real work (log open, project load, checkout, process spawn) occupy a
+/// slot. Matches the git-ops bound's scale: enough parallelism that a
+/// burst of dashboard launches overlaps, small enough that a stampede
+/// cannot swamp the blocking pool and disk.
+pub(crate) const MAX_CONCURRENT_LAUNCH_BODIES: usize = 4;
+
+pub(crate) type IntakeJobFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+/// One unit of deferred intake work for a session key.
+pub(crate) struct IntakeJob {
+    fut: IntakeJobFuture,
+    /// Heavy jobs (launch bodies) take a [`MAX_CONCURRENT_LAUNCH_BODIES`]
+    /// permit before running; deferred fast commands do not.
+    heavy: bool,
+    /// Ids reserved as pending routes for this job (released when the job
+    /// settles — completes OR panics). While held, `route_key` maps each
+    /// id to this job's queue so later commands for the same session
+    /// defer behind it instead of racing it.
+    routes: Vec<String>,
+    /// Pending peer-delegation reservation (released at settle). While
+    /// held, a duplicate delivery of the same delegation id is routed
+    /// onto this job's queue instead of starting a second task.
+    delegation_id: Option<String>,
+}
+
+impl IntakeJob {
+    /// A deferred fast command: no reservations, no launch permit.
+    pub(crate) fn light(fut: IntakeJobFuture) -> Self {
+        Self {
+            fut,
+            heavy: false,
+            routes: Vec::new(),
+            delegation_id: None,
+        }
+    }
+
+    /// A slow launch body with its intake-reserved routes (and, for peer
+    /// delegations, the delegation-id reservation).
+    pub(crate) fn heavy(
+        fut: IntakeJobFuture,
+        routes: Vec<String>,
+        delegation_id: Option<String>,
+    ) -> Self {
+        Self {
+            fut,
+            heavy: true,
+            routes,
+            delegation_id,
+        }
+    }
+}
+
+/// A reservation entry shared by overlapping jobs: refcounted so two
+/// queued jobs reserving the same id (two resumes of one session) release
+/// independently without dropping each other's route early.
+struct Reservation {
+    key: String,
+    refs: usize,
+}
+
+#[derive(Default)]
+struct QueueEntry {
+    jobs: VecDeque<IntakeJob>,
+    worker_running: bool,
+}
+
+#[derive(Default)]
+struct ExecState {
+    /// Session key → its ordered queue. An entry exists exactly while the
+    /// key is busy (worker running or jobs pending); it is removed when
+    /// the queue drains, which is what ends `queue_busy`.
+    queues: HashMap<String, QueueEntry>,
+    /// Pending routes: any id a not-yet-settled slow job answers for →
+    /// that job's queue key.
+    routes: HashMap<String, Reservation>,
+    /// Pending peer delegations: delegation id → the queue key of the
+    /// launch that will (or did) dispatch it.
+    delegations: HashMap<String, Reservation>,
+    /// Queue keys of not-yet-settled heavy jobs in enqueue order. An
+    /// untargeted command (the legacy active-session fallback) chases the
+    /// newest entry, approximating the serial intake where it would have
+    /// processed after every earlier launch.
+    pending_heavy_keys: Vec<String>,
+}
+
+pub(crate) struct IntakeExecutor {
+    state: Mutex<ExecState>,
+    launch_permits: Arc<tokio::sync::Semaphore>,
+}
+
+impl IntakeExecutor {
+    pub(crate) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(ExecState::default()),
+            launch_permits: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_LAUNCH_BODIES)),
+        })
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, ExecState> {
+        self.state.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// True while `key` has a worker running or jobs pending. A command
+    /// for a busy key must defer onto the queue to keep the session's
+    /// command order.
+    pub(crate) fn queue_busy(&self, key: &str) -> bool {
+        self.lock().queues.contains_key(key)
+    }
+
+    /// The queue key a pending (not-yet-settled) slow job reserved for
+    /// `id`, if any.
+    pub(crate) fn route_key(&self, id: &str) -> Option<String> {
+        self.lock().routes.get(id).map(|r| r.key.clone())
+    }
+
+    pub(crate) fn has_route(&self, id: &str) -> bool {
+        self.lock().routes.contains_key(id)
+    }
+
+    /// The queue key of the newest not-yet-settled heavy job, if any.
+    pub(crate) fn latest_pending_heavy_key(&self) -> Option<String> {
+        self.lock().pending_heavy_keys.last().cloned()
+    }
+
+    /// The queue key of a pending (not-yet-settled) launch that reserved
+    /// this peer-delegation id, if any.
+    pub(crate) fn pending_delegation_key(&self, delegation_id: &str) -> Option<String> {
+        self.lock().delegations.get(delegation_id).map(|r| r.key.clone())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_route_count(&self) -> usize {
+        self.lock().routes.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pending_route_ids(&self) -> Vec<String> {
+        self.lock().routes.keys().cloned().collect()
+    }
+
+    /// Enqueue a job under `key`, registering its reservations in the
+    /// same lock so a later intake sees the routes exactly when the job
+    /// becomes observable. Spawns the key's worker when none is running.
+    pub(crate) fn enqueue(self: &Arc<Self>, key: &str, job: IntakeJob) {
+        let spawn_worker = {
+            let mut state = self.lock();
+            for id in &job.routes {
+                reserve(&mut state.routes, id, key);
+            }
+            if let Some(delegation_id) = &job.delegation_id {
+                reserve(&mut state.delegations, delegation_id, key);
+            }
+            if job.heavy {
+                state.pending_heavy_keys.push(key.to_string());
+            }
+            let entry = state.queues.entry(key.to_string()).or_default();
+            entry.jobs.push_back(job);
+            if entry.worker_running {
+                false
+            } else {
+                entry.worker_running = true;
+                true
+            }
+        };
+        if spawn_worker {
+            let executor = self.clone();
+            let key = key.to_string();
+            tokio::spawn(async move { executor.run_worker(key).await });
+        }
+    }
+
+    /// Drain one key's queue in order. Each job runs in its own spawned
+    /// task so a panic fails that session's command without wedging the
+    /// queue (or unwinding the intake loop, which a panicking launch body
+    /// did when it was awaited inline). Reservations release when the job
+    /// settles, success or panic.
+    async fn run_worker(self: Arc<Self>, key: String) {
+        loop {
+            let job = {
+                let mut state = self.lock();
+                let Some(entry) = state.queues.get_mut(&key) else {
+                    return;
+                };
+                match entry.jobs.pop_front() {
+                    Some(job) => job,
+                    None => {
+                        state.queues.remove(&key);
+                        return;
+                    }
+                }
+            };
+            let IntakeJob {
+                fut,
+                heavy,
+                routes,
+                delegation_id,
+            } = job;
+            let permit = if heavy {
+                // The semaphore is never closed; if that ever changes,
+                // running unbounded beats wedging the session's queue.
+                self.launch_permits.clone().acquire_owned().await.ok()
+            } else {
+                None
+            };
+            let settled = tokio::spawn(async move {
+                let _permit = permit;
+                fut.await;
+            })
+            .await;
+            if settled.is_err() {
+                eprintln!(
+                    "[supervisor] queued command for session {key} panicked; \
+                     continuing with the session's remaining commands"
+                );
+            }
+            let mut state = self.lock();
+            for id in &routes {
+                release(&mut state.routes, id, &key);
+            }
+            if let Some(delegation_id) = &delegation_id {
+                release(&mut state.delegations, delegation_id, &key);
+            }
+            if heavy {
+                if let Some(pos) = state.pending_heavy_keys.iter().position(|k| k == &key) {
+                    state.pending_heavy_keys.remove(pos);
+                }
+            }
+        }
+    }
+}
+
+fn reserve(map: &mut HashMap<String, Reservation>, id: &str, key: &str) {
+    let id = id.trim();
+    if id.is_empty() {
+        return;
+    }
+    match map.get_mut(id) {
+        Some(existing) => {
+            // The dispatcher keys overlapping jobs onto the existing
+            // route's queue, so a second reservation for an id always
+            // names the same key; refcount it so releases pair up.
+            debug_assert_eq!(existing.key, key, "route re-reserved under a different key");
+            existing.refs += 1;
+        }
+        None => {
+            map.insert(
+                id.to_string(),
+                Reservation {
+                    key: key.to_string(),
+                    refs: 1,
+                },
+            );
+        }
+    }
+}
+
+fn release(map: &mut HashMap<String, Reservation>, id: &str, key: &str) {
+    let id = id.trim();
+    if id.is_empty() {
+        return;
+    }
+    if let Some(existing) = map.get_mut(id) {
+        if existing.key != key {
+            return;
+        }
+        existing.refs = existing.refs.saturating_sub(1);
+        if existing.refs == 0 {
+            map.remove(id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    async fn wait_until(deadline_ms: u64, mut check: impl FnMut() -> bool) -> bool {
+        let deadline =
+            tokio::time::Instant::now() + std::time::Duration::from_millis(deadline_ms);
+        loop {
+            if check() {
+                return true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    }
+
+    /// Jobs on one key run strictly in enqueue order; a held job on one
+    /// key does not delay another key's job.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn per_key_order_with_cross_key_concurrency() {
+        let executor = IntakeExecutor::new();
+        let log: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+        let (gate_tx, gate_rx) = tokio::sync::watch::channel(false);
+
+        let log_a1 = log.clone();
+        let mut gate = gate_rx.clone();
+        executor.enqueue(
+            "a",
+            IntakeJob::heavy(
+                Box::pin(async move {
+                    let _ = gate.wait_for(|open| *open).await;
+                    log_a1.lock().unwrap().push("a1");
+                }),
+                vec!["a".to_string()],
+                None,
+            ),
+        );
+        let log_a2 = log.clone();
+        executor.enqueue(
+            "a",
+            IntakeJob::light(Box::pin(async move {
+                log_a2.lock().unwrap().push("a2");
+            })),
+        );
+        let log_b = log.clone();
+        executor.enqueue(
+            "b",
+            IntakeJob::light(Box::pin(async move {
+                log_b.lock().unwrap().push("b1");
+            })),
+        );
+
+        // b's job completes while a's first job is still gated.
+        assert!(
+            wait_until(2000, || log.lock().unwrap().contains(&"b1")).await,
+            "an independent key must not wait out a held job"
+        );
+        assert!(!log.lock().unwrap().contains(&"a1"));
+        assert!(executor.queue_busy("a"));
+        assert!(executor.has_route("a"), "route held while the job runs");
+
+        gate_tx.send(true).unwrap();
+        assert!(wait_until(2000, || !executor.queue_busy("a")).await);
+        assert_eq!(*log.lock().unwrap(), vec!["b1", "a1", "a2"]);
+        assert!(!executor.has_route("a"), "route released at settle");
+        assert_eq!(executor.latest_pending_heavy_key(), None);
+    }
+
+    /// A panicking job settles like a completed one: reservations release
+    /// and the key's remaining jobs still run.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn panicked_job_releases_reservations_and_queue_survives() {
+        let executor = IntakeExecutor::new();
+        let ran_after = Arc::new(AtomicUsize::new(0));
+
+        executor.enqueue(
+            "a",
+            IntakeJob::heavy(
+                Box::pin(async move {
+                    panic!("launch body exploded");
+                }),
+                vec!["a".to_string(), "alias-a".to_string()],
+                Some("dg-1".to_string()),
+            ),
+        );
+        let ran = ran_after.clone();
+        executor.enqueue(
+            "a",
+            IntakeJob::light(Box::pin(async move {
+                ran.fetch_add(1, Ordering::SeqCst);
+            })),
+        );
+
+        assert!(
+            wait_until(2000, || ran_after.load(Ordering::SeqCst) == 1).await,
+            "the queue must survive a panicking job"
+        );
+        assert!(wait_until(2000, || !executor.queue_busy("a")).await);
+        assert_eq!(executor.pending_route_count(), 0);
+        assert_eq!(executor.pending_delegation_key("dg-1"), None);
+        assert_eq!(executor.latest_pending_heavy_key(), None);
+    }
+
+    /// Overlapping reservations for the same id are refcounted: the first
+    /// job's settle must not drop a route the second queued job still
+    /// needs.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn overlapping_route_reservations_are_refcounted() {
+        let executor = IntakeExecutor::new();
+        let (gate_tx, gate_rx) = tokio::sync::watch::channel(false);
+        let first_done = Arc::new(AtomicUsize::new(0));
+
+        let done = first_done.clone();
+        executor.enqueue(
+            "x",
+            IntakeJob::heavy(
+                Box::pin(async move {
+                    done.fetch_add(1, Ordering::SeqCst);
+                }),
+                vec!["x".to_string()],
+                None,
+            ),
+        );
+        let mut gate = gate_rx.clone();
+        executor.enqueue(
+            "x",
+            IntakeJob::heavy(
+                Box::pin(async move {
+                    let _ = gate.wait_for(|open| *open).await;
+                }),
+                vec!["x".to_string()],
+                None,
+            ),
+        );
+
+        assert!(wait_until(2000, || first_done.load(Ordering::SeqCst) == 1).await);
+        assert!(
+            executor.has_route("x"),
+            "the second job's reservation must survive the first job's settle"
+        );
+        gate_tx.send(true).unwrap();
+        assert!(wait_until(2000, || !executor.has_route("x")).await);
+    }
+
+    /// Heavy bodies respect the global launch bound; light jobs do not
+    /// consume permits.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn heavy_bodies_respect_global_launch_bound() {
+        let executor = IntakeExecutor::new();
+        let running = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let (gate_tx, gate_rx) = tokio::sync::watch::channel(false);
+
+        for i in 0..(MAX_CONCURRENT_LAUNCH_BODIES + 2) {
+            let running = running.clone();
+            let peak = peak.clone();
+            let mut gate = gate_rx.clone();
+            executor.enqueue(
+                &format!("key-{i}"),
+                IntakeJob::heavy(
+                    Box::pin(async move {
+                        let now = running.fetch_add(1, Ordering::SeqCst) + 1;
+                        peak.fetch_max(now, Ordering::SeqCst);
+                        let _ = gate.wait_for(|open| *open).await;
+                        running.fetch_sub(1, Ordering::SeqCst);
+                    }),
+                    vec![format!("key-{i}")],
+                    None,
+                ),
+            );
+        }
+
+        assert!(
+            wait_until(2000, || running.load(Ordering::SeqCst)
+                == MAX_CONCURRENT_LAUNCH_BODIES)
+            .await,
+            "exactly the bound's worth of heavy bodies should start"
+        );
+        // Settle a moment: nothing beyond the bound starts while held.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(peak.load(Ordering::SeqCst), MAX_CONCURRENT_LAUNCH_BODIES);
+
+        gate_tx.send(true).unwrap();
+        assert!(wait_until(2000, || running.load(Ordering::SeqCst) == 0).await);
+        assert!(peak.load(Ordering::SeqCst) <= MAX_CONCURRENT_LAUNCH_BODIES);
+    }
+}

--- a/src/bin/caller/session_supervisor/exec.rs
+++ b/src/bin/caller/session_supervisor/exec.rs
@@ -149,7 +149,10 @@ impl IntakeExecutor {
     /// The queue key of a pending (not-yet-settled) launch that reserved
     /// this peer-delegation id, if any.
     pub(crate) fn pending_delegation_key(&self, delegation_id: &str) -> Option<String> {
-        self.lock().delegations.get(delegation_id).map(|r| r.key.clone())
+        self.lock()
+            .delegations
+            .get(delegation_id)
+            .map(|r| r.key.clone())
     }
 
     #[cfg(test)]
@@ -300,8 +303,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     async fn wait_until(deadline_ms: u64, mut check: impl FnMut() -> bool) -> bool {
-        let deadline =
-            tokio::time::Instant::now() + std::time::Duration::from_millis(deadline_ms);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(deadline_ms);
         loop {
             if check() {
                 return true;

--- a/src/bin/caller/session_supervisor/launch.rs
+++ b/src/bin/caller/session_supervisor/launch.rs
@@ -5,7 +5,28 @@
 
 use super::*;
 
+/// Session identity minted synchronously at intake for a queued create
+/// body: the fresh log dir (pure path computation — nothing exists on
+/// disk until the body opens it) and the session id it will carry. Minting
+/// at intake is what makes the id routable — via the executor's pending
+/// route — before the slow body runs, so a targeted command that arrives
+/// mid-create defers behind the launch instead of failing "not managed".
+pub(crate) struct ReservedSessionLaunch {
+    pub(crate) log_dir: PathBuf,
+    pub(crate) session_id: String,
+}
+
 impl SessionSupervisor {
+    /// Mint a fresh session log dir + id (see [`ReservedSessionLaunch`]).
+    /// Synchronous and side-effect free.
+    pub(crate) fn reserve_session_launch(&self) -> ReservedSessionLaunch {
+        let log_dir = session_log::SessionLog::resolve_path_in_home(&self.logs_home(), None);
+        ReservedSessionLaunch {
+            session_id: path_file_name(&log_dir),
+            log_dir,
+        }
+    }
+
     /// Register a launched session's effective project root as its
     /// git-vitals probe target (worktree sessions pass their checkout).
     /// No-op when the daemon runs without the vitals producer.
@@ -45,7 +66,9 @@ impl SessionSupervisor {
         codex_service_tier: Option<String>,
         worktree: Option<SessionWorktreeRequest>,
         hosted_lease_id: Option<String>,
+        reserved: Option<ReservedSessionLaunch>,
     ) -> Option<String> {
+        self.wait_for_launch_gate_in_tests().await;
         let session_name = match normalize_session_name_option(name.as_deref()) {
             Ok(name) => name,
             Err(e) => {
@@ -53,7 +76,12 @@ impl SessionSupervisor {
                 return None;
             }
         };
-        let log_dir = session_log::SessionLog::resolve_path_in_home(&self.logs_home(), None);
+        // Identity was minted at intake for a queued create (so the id was
+        // routable before this body ran); direct callers mint here.
+        let ReservedSessionLaunch {
+            log_dir,
+            session_id: reserved_session_id,
+        } = reserved.unwrap_or_else(|| self.reserve_session_launch());
         let session_log = match session_log::SessionLog::open(log_dir.clone()) {
             Ok(log) => Arc::new(Mutex::new(log)),
             Err(e) => {
@@ -65,7 +93,7 @@ impl SessionSupervisor {
         let session_id = session_log
             .lock()
             .map(|log| log.session_id().to_string())
-            .unwrap_or_else(|_| path_file_name(&log_dir));
+            .unwrap_or(reserved_session_id);
         let project_root = match resolve_project_root_override(
             project_root,
             self.config.project_root.as_deref(),
@@ -101,16 +129,15 @@ impl SessionSupervisor {
         //
         // The git chain (HEAD probe, collision listing, `git worktree add`
         // materializing a full checkout — seconds on large projects) runs on
-        // the blocking pool under the daemon-wide git-ops bound. What that
-        // buys: a tokio worker is no longer pinned for the duration, and a
-        // panic inside the chain surfaces as this session's honest
-        // create-failure instead of unwinding the supervisor. What it does
-        // NOT buy: this function is still awaited inline by the
-        // supervisor's single sequential control-intake loop, so other
-        // sessions' approvals/steers/interrupts still wait out the checkout
-        // — the real fix is dispatching session-create handling off the
-        // intake loop (see the PR follow-up; the delegation ack must keep
-        // its ordering guarantee).
+        // the blocking pool under the daemon-wide git-ops bound: a tokio
+        // worker is not pinned for the duration, and a panic inside the
+        // chain surfaces as this session's honest create-failure instead of
+        // unwinding the caller. Intake-side head-of-line blocking is gone
+        // too: `dispatch_control_msg` runs this whole body on the
+        // per-session executor, so other sessions' approvals / steers /
+        // interrupts no longer wait out the checkout (the delegation ack
+        // keeps its ordering guarantee — it still fires only after this
+        // function dispatched the task; see `acknowledge_delegation`).
         let worktree_meta = match worktree.as_ref() {
             Some(request) => {
                 let permit = worktree::git_ops_semaphore().clone().acquire_owned().await;
@@ -559,6 +586,7 @@ impl SessionSupervisor {
         force_new: bool,
         auto_attach: bool,
     ) {
+        self.wait_for_launch_gate_in_tests().await;
         // A fork never attaches to (or dedupes against) the thread it forks
         // from: it always materializes as a fresh wrapper session that keeps
         // the requested resume token verbatim.

--- a/src/bin/caller/session_supervisor/mod.rs
+++ b/src/bin/caller/session_supervisor/mod.rs
@@ -14,6 +14,7 @@ use tokio::task::JoinHandle;
 
 use super::*;
 
+mod exec;
 mod launch;
 pub(crate) use launch::*;
 mod routing;
@@ -74,12 +75,23 @@ pub struct SessionSupervisorConfig {
     /// provenance before a hosted-created session becomes an eligible target.
     /// None in hermetic tests and non-hosted execution shapes.
     pub hosted_control_cert_dir: Option<PathBuf>,
+    /// Test seam for the off-intake launch executor: when set, the slow
+    /// launch bodies (session create / resume) await this gate flipping
+    /// true before doing any work — a deterministic stand-in for a
+    /// multi-second worktree checkout, so tests can hold a launch provably
+    /// in-flight while asserting what the intake still serves. None in
+    /// production (zero cost).
+    pub launch_gate_for_tests: Option<tokio::sync::watch::Receiver<bool>>,
 }
 
 #[derive(Clone)]
 pub struct SessionSupervisor {
     config: Arc<SessionSupervisorConfig>,
     state: Arc<AsyncMutex<SupervisorState>>,
+    /// Off-intake executor: per-session ordered queues for slow launch
+    /// bodies and the commands deferred behind them (see exec.rs and
+    /// `dispatch_control_msg`).
+    exec: Arc<exec::IntakeExecutor>,
 }
 
 const EXTERNAL_ATTACH_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
@@ -505,6 +517,17 @@ impl SessionSupervisor {
         Self {
             config: Arc::new(config),
             state: Arc::new(AsyncMutex::new(SupervisorState::default())),
+            exec: exec::IntakeExecutor::new(),
+        }
+    }
+
+    /// Test seam (`SessionSupervisorConfig::launch_gate_for_tests`): hold
+    /// a slow launch body deterministically in-flight. No-op in
+    /// production.
+    async fn wait_for_launch_gate_in_tests(&self) {
+        if let Some(gate) = self.config.launch_gate_for_tests.as_ref() {
+            let mut gate = gate.clone();
+            let _ = gate.wait_for(|open| *open).await;
         }
     }
 
@@ -526,7 +549,7 @@ impl SessionSupervisor {
         match event {
             AppEvent::ControlCommand(msg) => {
                 if !filter_session_control || self.should_handle_session_control(&msg).await {
-                    self.handle_control_msg(msg).await;
+                    self.dispatch_control_msg(msg).await;
                 }
             }
             AppEvent::SessionIdentity {
@@ -571,6 +594,18 @@ impl SessionSupervisor {
     /// the observation side is display-only; intent-lane events are NOT
     /// re-observed here (they'd double-apply phase updates when the
     /// broadcast copy arrives).
+    ///
+    /// The lane is drained strictly in order, but a command's BODY no
+    /// longer necessarily runs inline: `dispatch_control_msg` does the
+    /// fast, ordering-critical work here (validate, reserve/mint identity,
+    /// dedup) and hands slow launch bodies — session create with a
+    /// worktree checkout, resume, restart, fork, delegation spawns — to
+    /// the per-session ordered executor (exec.rs), so one session's
+    /// multi-second checkout no longer head-of-line-blocks every other
+    /// session's approvals/steers/interrupts. Commands for one session
+    /// still execute in arrival order (a busy session's commands defer
+    /// onto its queue); the identity/relationship/end bookkeeping stays
+    /// inline, so routing state is always applied in lane order.
     ///
     /// Receivers are subscribed by the caller BEFORE the task is spawned:
     /// daemon startup sends `ResumeSession` immediately after `spawn()`
@@ -776,6 +811,7 @@ mod tests {
             ))),
             git_vitals_targets: None,
             hosted_control_cert_dir: None,
+            launch_gate_for_tests: None,
         })
     }
 

--- a/src/bin/caller/session_supervisor/routing.rs
+++ b/src/bin/caller/session_supervisor/routing.rs
@@ -297,20 +297,31 @@ impl SessionSupervisor {
                     ),
                 );
                 self.queue_edit_user_message_after_attach(lookup_id.clone(), request);
-                self.resume_session(
-                    attach.source,
-                    requested_id.clone(),
-                    Some(lookup_id.clone()),
-                    attach.project_root,
-                    None,
-                    Some(attach.direct.unwrap_or(true)),
-                    Vec::new(),
-                    false,
-                    None,
-                    LaunchOverrides::default(),
-                    false,
-                    false,
-                )
+                // The attach spawn is a slow launch body: dispatch it as
+                // the equivalent ResumeSession intent (which the intake
+                // dispatcher queues on the session's executor lane)
+                // instead of awaiting it here — this arm runs inline on
+                // the control intake for the common routed case, and the
+                // attach must not stall every other session's commands.
+                // The queued edit above delivers via its own bus waiter
+                // once the attach registers, exactly as before.
+                self.dispatch_control_msg(event::ControlMsg::ResumeSession {
+                    source: attach.source,
+                    session_id: requested_id.clone(),
+                    resume_id: Some(lookup_id.clone()),
+                    project_root: attach.project_root,
+                    task: None,
+                    direct: Some(attach.direct.unwrap_or(true)),
+                    attachments: Vec::new(),
+                    fork: false,
+                    relationship_kind: None,
+                    auto_attach: false,
+                    agent_command: None,
+                    codex_sandbox: None,
+                    codex_approval_policy: None,
+                    codex_managed_context: None,
+                    codex_context_archive: None,
+                })
                 .await;
                 return;
             }

--- a/src/bin/caller/startup/daemon.rs
+++ b/src/bin/caller/startup/daemon.rs
@@ -58,6 +58,7 @@ pub(crate) async fn run_daemon_loop(config: DaemonConfig) {
         logs_home_override: None,
         git_vitals_targets: config.git_vitals_targets,
         hosted_control_cert_dir: Some(crate::startup::installed_access_cert_dir()),
+        launch_gate_for_tests: None,
     })
     .run()
     .await;
@@ -231,6 +232,7 @@ pub(crate) async fn run_daemon(
             logs_home_override: None,
             git_vitals_targets: Some(vitals_git_targets.clone()),
             hosted_control_cert_dir: Some(crate::startup::installed_access_cert_dir()),
+            launch_gate_for_tests: None,
         })
         .spawn();
     // --continue/--resume under the daemon: the supervisor (subscribed

--- a/src/bin/caller/startup/headless.rs
+++ b/src/bin/caller/startup/headless.rs
@@ -522,6 +522,7 @@ pub(crate) async fn run_headless_mode(
                     logs_home_override: None,
                     git_vitals_targets: vitals_git_targets.clone(),
                     hosted_control_cert_dir: Some(crate::startup::installed_access_cert_dir()),
+                    launch_gate_for_tests: None,
                 },
             )
             .spawn_resume_listener(),


### PR DESCRIPTION
## Defect

The supervisor's single sequential intake loop (`run_event_loop`) awaited `handle_control_msg` inline, so a slow operation — session create with a worktree checkout (seconds on large projects), resume, restart, fork, dashboard delegation — blocked every other session's approvals/steers/interrupts for its duration. The worktree-launch comment in `launch.rs` self-documented this and named the fix shape.

## Fix

The intake still drains the lossless intent lane strictly in order, but `dispatch_control_msg` now does only the fast, ordering-critical work inline — validate, mint/reserve session identity, dedup repeat requests — and hands slow launch bodies to a per-session ordered executor (`session_supervisor/exec.rs`) with a small global concurrency bound (4 heavy bodies; per-job panic isolation, reservations released at settle). Fast arms stay inline unless their session's queue is busy, in which case they defer onto it: one session's commands always execute in arrival order, and only cross-session head-of-line blocking is removed. `handle_control_msg` remains the single behavioral source — jobs and the inline path run it verbatim, so direct callers (tests, embedded flows) keep exact serial semantics.

## Per-arm dispatch map

| Arm | Disposition | Why |
|---|---|---|
| `CreateSession` (plain task, or bare `/fast`) | executor (heavy), key = intake-minted session id | Full launch body: log open, optional worktree checkout, project load, attachment resolution, spawn |
| `CreateSession` (other codex slash command) | inline fast, defer-if-busy on the active session | The arm routes the text as a follow-up — no launch body |
| `StartTask { session_id: Some }` | inline fast, defer-if-busy on the target | Follow-up routing |
| `StartTask { session_id: None }` (plain or `/fast`) | executor (heavy), key = minted id — or the original launch's key for a mid-flight duplicate delegation; already-recorded duplicates re-ack inline | Launch body + the delegation receipt contract |
| `StartTask { session_id: None }` (other slash) | inline fast, defer-if-busy on the active session | Follow-up routing; delegated slash commands stay unacked exactly as before |
| `SpawnSubAgent` | executor (heavy), key = parent session id | Sub-agent spawn (log open, optional worktree, project load, spawn), ordered against the parent's commands |
| `ResumeSession` | executor (heavy), key/routes = requested session id + resume id (+ canonical resolution) | Persisted-identity resolution reads the session store; attach spawns a backend; the attach-to-existing fast path stays ordered on the same queue |
| `RestartSession` | executor (heavy), same keying | stop + bounded shutdown wait (3s) + full resume body; the restart dedup window survives because same-key jobs serialize |
| `ForkSessionAtAnchor` | executor (heavy), same keying | Fork surgery (spawn_blocking fs work) + the resume funnel |
| `StopSession` | inline fast, defer-if-busy | State removal + bus emits |
| `ReloadCredentials` | inline fast, defer-if-busy | Lookup + bus emit |
| `FollowUp` | inline fast, defer-if-busy | Channel send + attachment resolution |
| `EditUserMessage` | inline fast, defer-if-busy; its pre-attach path now dispatches the equivalent `ResumeSession` intent through the executor instead of awaiting the attach inline | The routed-delivery path is fast; the attach used to stall the whole intake. The queued edit still delivers via its existing bus waiter |
| `Interrupt` | inline fast, defer-if-busy | Resolution + emit (or unmanaged ack + halt mark) |
| `Steer` / `CancelSteer` / `CancelFollowUp` | inline fast, defer-if-busy | Emits / channel sends / fallback spawn |
| `Approve` / `Deny` / `Skip` / `ApproveAll` / `AnswerQuestion` | inline fast, defer-if-busy | Approval-registry responder resolution |
| `RenameSession` | inline fast, defer-if-busy on session id + backend id | Small state read + name-store write (or codex thread-action emit) |
| `ConfigureSessionAgent` | inline fast, defer-if-busy on its three ids | Config normalization + small log-dir write |
| `CodexThreadAction` | inline fast, defer-if-busy | The unattached fallback responder; deferring while the target's launch body runs prevents a false "not attached" mid-create/resume |
| everything else (`Status`, settings msgs, …) | inline no-op | The arm ignores them |

Untargeted commands (the legacy active-session fallback) key onto the newest pending launch's queue when one exists — the session a serial intake would have resolved to after that launch — else the current active session.

## Invariants (each with its test)

1. **Lossless intent lane never drops or reorders.** The loop drains `subscribe_intents` in emission order through the same biased select; dispatch either inlines or enqueues — no path drops. Identity/relationship/end bookkeeping stays inline in lane order. Per-job panic isolation means a panicking launch body no longer unwinds the intake loop (strictly fewer loss modes). Pinned by the existing intent-lane tests in event.rs, `exec::tests::per_key_order_with_cross_key_concurrency`, `exec::tests::panicked_job_releases_reservations_and_queue_survives`, and the whole supervisor suite staying green (92 tests).
2. **Delegation acknowledgement after registration.** The receipt still fires only from the arm after `start_new_session` dispatched (post-`register_session`); the dedup ledger + pending reservation are consulted synchronously at intake. Pinned by the existing `peer_delegation_acks_on_dispatch_and_dedups_resend` (kept green) and the new `duplicate_delegation_mid_create_re_acks_original_without_second_session` (mid-flight duplicate orders behind the original launch, exactly one SessionStarted, both receipts name it, receipts follow the start they name; failed launches stay unacked and release the reservation so the retry is serial-equivalent).
3. **Targeted command for a still-creating session is neither lost nor misrouted.** The minted id is reserved at intake, so the command defers onto the create's queue and lands after registration, in order. New `create_then_immediate_follow_up_defers_until_registration` and the head-of-line regression test `slow_create_does_not_block_other_sessions_commands` (another live session's follow-up delivers promptly while a create is provably held on the launch-gate seam).
4. **Startup `ResumeSession` immediately after `spawn()`.** Receiver subscription still happens in `spawn()`/`spawn_resume_listener()` before the loop task spawns (mechanics untouched); the resume body now runs as the first executor job. Exercised end-to-end by the e2e daemon-lifecycle tests (23/23 green).
5. **Reservation release on failed create.** Routes release when the job settles (success or panic). New `failed_create_releases_reservation_and_deferred_command_fails_honestly`: the worktree-failure SessionEnded fires, the deferred follow-up then gets the existing honest "target session is not managed by this daemon" status, and the reservation table empties.

The resume listener's `should_handle_session_control` gate now also claims commands targeting a pending launch route, so they defer instead of being skipped mid-launch.

**Known residual (documented, accepted):** an id minted *inside* a slow body (an external resume's fresh wrapper id, a fork child id) becomes routable at registration; in the sliver where such an id is addressed while other jobs still sit on the session's original ordering key, an inline command via the new id can run before earlier deferred ones via the old id. Routing correctness is unaffected — only cross-id arrival order in that window, which the old code got "for free" only by blocking every session globally.

## Battery

- `cargo fmt --check` clean
- `cargo clippy` clean
- `cargo nextest run --bins`: 4012 passed, 10 skipped
- `cargo build --bin intendant --bin intendant-runtime` clean
- `cargo test --test e2e`: 23 passed, 0 failed