### PR TITLE
live_audio: aggregate capture frames, bound audio lanes, unstall whisper intake

### DIFF
--- a/src/bin/caller/live_audio.rs
+++ b/src/bin/caller/live_audio.rs
@@ -5,6 +5,7 @@ use crate::quarantine;
 use crate::schema_validator;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use futures_util::{SinkExt, StreamExt};
+use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -686,60 +687,396 @@ async fn vortex_write_msg(
 // Format conversion: Vortex (Float32 stereo 48kHz) ↔ Model (PCM16 mono 24kHz)
 // ---------------------------------------------------------------------------
 
-/// Convert Vortex daemon PCM_OUTPUT (Float32 stereo 48kHz) to model input
-/// (PCM16 mono 24kHz). 8:1 size reduction.
-fn vortex_capture_convert(f32_stereo_48k: &[u8]) -> Vec<u8> {
-    // Each stereo frame = 2 floats = 8 bytes
-    // After mono downmix + 2:1 decimation + i16 conversion: 1 frame → 2 bytes
-    let num_floats = f32_stereo_48k.len() / 4;
-    let num_stereo_frames = num_floats / 2;
-    let num_output_samples = num_stereo_frames / 2; // 2:1 decimation
-    let mut out = Vec::with_capacity(num_output_samples * 2);
+/// Core of [`vortex_capture_convert`]: downmix + decimate f32 stereo 48kHz
+/// samples directly to PCM16 mono 24kHz bytes, appended to `out`. Operating
+/// on f32 samples (not a little-endian byte image of them) lets the shm
+/// capture path convert straight from ring reads with no intermediate byte
+/// buffer, into a reusable output buffer.
+fn downmix_decimate_f32_to_pcm16(f32_stereo_48k: &[f32], out: &mut Vec<u8>) {
+    // Each stereo frame = 2 floats. After mono downmix + 2:1 decimation +
+    // i16 conversion: 2 frames → one 2-byte sample.
+    let num_stereo_frames = f32_stereo_48k.len() / 2;
+    out.reserve(num_stereo_frames.div_ceil(2) * 2);
 
     for i in (0..num_stereo_frames).step_by(2) {
-        // Read stereo pair (left + right)
-        let base = i * 8; // 2 floats * 4 bytes each
-        if base + 8 > f32_stereo_48k.len() {
-            break;
-        }
-        let left = f32::from_le_bytes([
-            f32_stereo_48k[base],
-            f32_stereo_48k[base + 1],
-            f32_stereo_48k[base + 2],
-            f32_stereo_48k[base + 3],
-        ]);
-        let right = f32::from_le_bytes([
-            f32_stereo_48k[base + 4],
-            f32_stereo_48k[base + 5],
-            f32_stereo_48k[base + 6],
-            f32_stereo_48k[base + 7],
-        ]);
+        let left = f32_stereo_48k[i * 2];
+        let right = f32_stereo_48k[i * 2 + 1];
         let mono = (left + right) * 0.5;
         let clamped = mono.clamp(-1.0, 1.0);
         let sample = (clamped * 32767.0) as i16;
         out.extend_from_slice(&sample.to_le_bytes());
     }
+}
+
+/// Convert Vortex daemon PCM_OUTPUT (Float32 stereo 48kHz, little-endian
+/// bytes) to model input (PCM16 mono 24kHz). 8:1 size reduction. Byte-image
+/// front-end over [`downmix_decimate_f32_to_pcm16`] for the daemon-socket
+/// path, which receives the ring contents as wire bytes.
+fn vortex_capture_convert(f32_stereo_48k: &[u8]) -> Vec<u8> {
+    let mut floats = Vec::with_capacity(f32_stereo_48k.len() / 4);
+    for chunk in f32_stereo_48k.chunks_exact(4) {
+        floats.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+    }
+    let mut out = Vec::new();
+    downmix_decimate_f32_to_pcm16(&floats, &mut out);
     out
 }
 
-/// Convert model output (PCM16 mono 24kHz) to Vortex daemon PCM_INPUT
-/// (Float32 stereo 48kHz). 8:1 size expansion.
-fn vortex_playback_convert(pcm16_mono_24k: &[u8]) -> Vec<u8> {
+/// Core of [`vortex_playback_convert`]: expand model output (PCM16 mono
+/// 24kHz) to Vortex f32 stereo 48kHz samples appended to `out` (duplicate
+/// 2:1 upsample, L=R). The shm playback path writes these f32 samples
+/// straight into the input ring without round-tripping a byte image.
+fn pcm16_to_f32_stereo_upsampled(pcm16_mono_24k: &[u8], out: &mut Vec<f32>) {
     let num_samples = pcm16_mono_24k.len() / 2;
-    // Each mono sample → 2 stereo frames (upsample) × 2 channels × 4 bytes
-    let mut out = Vec::with_capacity(num_samples * 16);
+    // Each mono sample → 2 stereo frames (upsample) × 2 channels
+    out.reserve(num_samples * 4);
 
     for i in 0..num_samples {
         let sample = i16::from_le_bytes([pcm16_mono_24k[i * 2], pcm16_mono_24k[i * 2 + 1]]);
         let f = sample as f32 / 32768.0;
-        let bytes = f.to_le_bytes();
         // Duplicate sample for 2:1 upsample, stereo (L=R)
         for _ in 0..2 {
-            out.extend_from_slice(&bytes); // left
-            out.extend_from_slice(&bytes); // right
+            out.push(f); // left
+            out.push(f); // right
         }
     }
+}
+
+/// Convert model output (PCM16 mono 24kHz) to Vortex daemon PCM_INPUT
+/// (Float32 stereo 48kHz, little-endian bytes). 8:1 size expansion.
+/// Byte-image front-end over [`pcm16_to_f32_stereo_upsampled`] for the
+/// daemon-socket wire path.
+fn vortex_playback_convert(pcm16_mono_24k: &[u8]) -> Vec<u8> {
+    let mut samples = Vec::new();
+    pcm16_to_f32_stereo_upsampled(pcm16_mono_24k, &mut samples);
+    let mut out = Vec::with_capacity(samples.len() * 4);
+    for s in samples {
+        out.extend_from_slice(&s.to_le_bytes());
+    }
     out
+}
+
+// ---------------------------------------------------------------------------
+// Capture frame aggregation (vortex shm path)
+// ---------------------------------------------------------------------------
+
+/// f32 ring samples per millisecond in the Vortex capture ring (48kHz × 2
+/// channels — fixed by the HAL plugin's shared-memory format).
+const VORTEX_RING_F32_PER_MS: usize = 96;
+
+/// One 2:1 decimation group: two stereo frames (4 f32 samples) collapse into
+/// one output sample, so frames are cut on this boundary to keep the
+/// decimation phase continuous across WS messages.
+const CAPTURE_DECIMATION_GROUP_F32: usize = 4;
+
+/// Minimum audio per capture WS message (~20ms): the aggregation floor that
+/// turns the 5ms ring poll into 4-8× fewer, larger messages while adding at
+/// most one frame of latency — well inside a 40ms budget.
+const CAPTURE_FRAME_MIN_MS: usize = 20;
+
+/// Maximum audio per capture WS message (~40ms): caps message size when a
+/// scheduling hiccup piles up ring backlog, so recovery sends a few normal
+/// frames instead of one giant one.
+const CAPTURE_FRAME_MAX_MS: usize = 40;
+
+const CAPTURE_FRAME_MIN_F32: usize = CAPTURE_FRAME_MIN_MS * VORTEX_RING_F32_PER_MS;
+const CAPTURE_FRAME_MAX_F32: usize = CAPTURE_FRAME_MAX_MS * VORTEX_RING_F32_PER_MS;
+
+// Frame cuts must land on decimation-group boundaries.
+const _: () = assert!(
+    CAPTURE_FRAME_MIN_F32 % CAPTURE_DECIMATION_GROUP_F32 == 0
+        && CAPTURE_FRAME_MAX_F32 % CAPTURE_DECIMATION_GROUP_F32 == 0
+        && CAPTURE_FRAME_MIN_F32 <= CAPTURE_FRAME_MAX_F32
+);
+
+/// Accumulates raw f32 ring samples across 5ms poll ticks and cuts them into
+/// 20-40ms frames for conversion + WS send. Both buffers live for the whole
+/// capture task and are reused (clear-don't-realloc), so steady-state capture
+/// allocates nothing per tick.
+struct CaptureFrameAggregator {
+    /// Samples read from the ring but not yet emitted in a frame.
+    pending: Vec<f32>,
+    /// Scratch for the frame currently being emitted.
+    frame: Vec<f32>,
+}
+
+impl CaptureFrameAggregator {
+    fn new() -> Self {
+        Self {
+            pending: Vec::with_capacity(CAPTURE_FRAME_MAX_F32),
+            frame: Vec::with_capacity(CAPTURE_FRAME_MAX_F32),
+        }
+    }
+
+    /// Append one ring sample (called straight from the masked ring read).
+    fn push_sample(&mut self, sample: f32) {
+        self.pending.push(sample);
+    }
+
+    /// Cut the next full frame if at least [`CAPTURE_FRAME_MIN_F32`] samples
+    /// are pending: up to [`CAPTURE_FRAME_MAX_F32`] samples, always aligned
+    /// to a decimation-group boundary; the remainder stays pending.
+    fn next_full_frame(&mut self) -> Option<&[f32]> {
+        if self.pending.len() < CAPTURE_FRAME_MIN_F32 {
+            return None;
+        }
+        let cut = self.pending.len().min(CAPTURE_FRAME_MAX_F32);
+        let cut = cut - (cut % CAPTURE_DECIMATION_GROUP_F32);
+        self.frame.clear();
+        self.frame.extend(self.pending.drain(..cut));
+        Some(&self.frame)
+    }
+
+    /// Emit whatever is pending regardless of size — used when the ring goes
+    /// quiet so utterance tails are not held back waiting for a full frame.
+    fn flush(&mut self) -> Option<&[f32]> {
+        if self.pending.is_empty() {
+            return None;
+        }
+        self.frame.clear();
+        self.frame.extend(self.pending.drain(..));
+        Some(&self.frame)
+    }
+}
+
+/// Convert one aggregated capture frame and forward it to the model
+/// WebSocket (and the optional transcription tee). Reuses the caller's
+/// conversion/encoding buffers; the WS message layout is byte-identical to
+/// the historical per-tick sends apart from carrying a larger PCM chunk.
+#[cfg(unix)]
+#[allow(clippy::result_unit_err)]
+async fn send_capture_frame(
+    frame: &[f32],
+    pcm16_buf: &mut Vec<u8>,
+    b64_buf: &mut String,
+    provider: LiveAudioProvider,
+    sample_rate: u32,
+    tee: Option<&AudioQueueSender>,
+    sink: &Mutex<WsSink>,
+) -> Result<(), ()> {
+    pcm16_buf.clear();
+    downmix_decimate_f32_to_pcm16(frame, pcm16_buf);
+    if pcm16_buf.is_empty() {
+        return Ok(());
+    }
+    b64_buf.clear();
+    BASE64.encode_string(&*pcm16_buf, b64_buf);
+    let ws_msg = match provider {
+        LiveAudioProvider::Gemini => serde_json::json!({
+            "realtime_input": {
+                "media_chunks": [{
+                    "mime_type": format!("audio/pcm;rate={}", sample_rate),
+                    "data": &*b64_buf
+                }]
+            }
+        }),
+        LiveAudioProvider::OpenAI => serde_json::json!({
+            "type": "input_audio_buffer.append",
+            "audio": &*b64_buf
+        }),
+    };
+    if let Some(tee) = tee {
+        let _ = tee.send(pcm16_buf.clone());
+    }
+    let mut sink = sink.lock().await;
+    sink.send(WsMessage::Text(ws_msg.to_string().into()))
+        .await
+        .map_err(|_| ())
+}
+
+// ---------------------------------------------------------------------------
+// Duration-bounded drop-oldest audio queues
+// ---------------------------------------------------------------------------
+//
+// Live audio lanes must never buffer unboundedly: a stalled consumer (slow
+// WS peer, wedged playback sink, slow Whisper spell) would otherwise grow
+// the queue for the lifetime of the call. Every lane instead carries a
+// duration budget; overflow evicts the OLDEST audio first — for a live
+// stream a skip is strictly better than unbounded lag, because dropping the
+// oldest keeps the survivors near real time.
+
+/// Playback lane budget: model audio waiting to enter the output device.
+/// TTS bursts arrive faster than real time, so a healthy lane briefly holds
+/// several seconds; 30s absorbs a full long utterance while capping a wedged
+/// playback sink at ~1.4 MiB instead of the whole call.
+const PLAYBACK_QUEUE_SECONDS: usize = 30;
+
+/// Capture-side lane budget (the daemon-socket capture stage and the Whisper
+/// tee): capture is produced in real time, so any backlog beyond a few
+/// seconds means the consumer stalled; 30s (matching the playback lane) is
+/// far more than a healthy lane ever holds while still bounding a stalled
+/// one.
+const CAPTURE_QUEUE_SECONDS: usize = 30;
+
+/// Rate limit for the per-lane overflow log: one line per interval
+/// summarising everything dropped since the last, so a sustained stall logs
+/// a heartbeat instead of a flood.
+const QUEUE_DROP_LOG_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Rate-limited accounting for a lane's drop-oldest evictions.
+struct DropLog {
+    lane: &'static str,
+    dropped_chunks: u64,
+    dropped_secs: f64,
+    last_log: Option<Instant>,
+}
+
+impl DropLog {
+    fn new(lane: &'static str) -> Self {
+        Self {
+            lane,
+            dropped_chunks: 0,
+            dropped_secs: 0.0,
+            last_log: None,
+        }
+    }
+
+    /// Record `chunks` evicted chunks worth `secs` of audio, emitting at most
+    /// one summary line per [`QUEUE_DROP_LOG_INTERVAL`].
+    fn note(&mut self, chunks: u64, secs: f64) {
+        self.dropped_chunks += chunks;
+        self.dropped_secs += secs;
+        let now = Instant::now();
+        let due = self
+            .last_log
+            .is_none_or(|at| now.duration_since(at) >= QUEUE_DROP_LOG_INTERVAL);
+        if due {
+            eprintln!(
+                "live_audio: {} lane over budget — dropped {} oldest chunk(s) (~{:.1}s of audio)",
+                self.lane, self.dropped_chunks, self.dropped_secs
+            );
+            self.dropped_chunks = 0;
+            self.dropped_secs = 0.0;
+            self.last_log = Some(now);
+        }
+    }
+}
+
+struct AudioQueueState {
+    chunks: VecDeque<Vec<u8>>,
+    queued_bytes: usize,
+    sender_dropped: bool,
+    receiver_dropped: bool,
+    drop_log: DropLog,
+}
+
+struct AudioQueueShared {
+    state: std::sync::Mutex<AudioQueueState>,
+    notify: tokio::sync::Notify,
+    max_bytes: usize,
+    bytes_per_sec: usize,
+}
+
+/// Producer half of a [`bounded_audio_queue`]. Not `Clone`: every lane has a
+/// single producer, and dropping it closes the lane for the receiver.
+pub(crate) struct AudioQueueSender {
+    shared: Arc<AudioQueueShared>,
+}
+
+/// Consumer half of a [`bounded_audio_queue`].
+pub(crate) struct AudioQueueReceiver {
+    shared: Arc<AudioQueueShared>,
+}
+
+/// Build a duration-bounded drop-oldest audio lane: `seconds` ×
+/// `bytes_per_sec` is the byte budget, and queueing beyond it evicts the
+/// oldest chunks (never the chunk being queued) with a rate-limited log
+/// naming the lane.
+fn bounded_audio_queue(
+    lane: &'static str,
+    seconds: usize,
+    bytes_per_sec: usize,
+) -> (AudioQueueSender, AudioQueueReceiver) {
+    let shared = Arc::new(AudioQueueShared {
+        state: std::sync::Mutex::new(AudioQueueState {
+            chunks: VecDeque::new(),
+            queued_bytes: 0,
+            sender_dropped: false,
+            receiver_dropped: false,
+            drop_log: DropLog::new(lane),
+        }),
+        notify: tokio::sync::Notify::new(),
+        max_bytes: seconds * bytes_per_sec,
+        bytes_per_sec,
+    });
+    (
+        AudioQueueSender {
+            shared: shared.clone(),
+        },
+        AudioQueueReceiver { shared },
+    )
+}
+
+impl AudioQueueSender {
+    /// Queue one chunk. An over-budget lane evicts its oldest chunks first;
+    /// returns `Err(())` once the receiver is gone so producers can wind
+    /// down (mirrors `mpsc::UnboundedSender::send`'s error contract).
+    #[allow(clippy::result_unit_err)]
+    fn send(&self, chunk: Vec<u8>) -> Result<(), ()> {
+        let mut st = self.shared.state.lock().unwrap();
+        if st.receiver_dropped {
+            return Err(());
+        }
+        st.queued_bytes += chunk.len();
+        st.chunks.push_back(chunk);
+        let mut dropped_chunks = 0u64;
+        let mut dropped_bytes = 0usize;
+        while st.queued_bytes > self.shared.max_bytes && st.chunks.len() > 1 {
+            let oldest = st.chunks.pop_front().expect("len > 1");
+            st.queued_bytes -= oldest.len();
+            dropped_chunks += 1;
+            dropped_bytes += oldest.len();
+        }
+        if dropped_chunks > 0 {
+            let secs = dropped_bytes as f64 / self.shared.bytes_per_sec.max(1) as f64;
+            st.drop_log.note(dropped_chunks, secs);
+        }
+        drop(st);
+        self.shared.notify.notify_one();
+        Ok(())
+    }
+}
+
+impl Drop for AudioQueueSender {
+    fn drop(&mut self) {
+        if let Ok(mut st) = self.shared.state.lock() {
+            st.sender_dropped = true;
+        }
+        self.shared.notify.notify_one();
+    }
+}
+
+impl AudioQueueReceiver {
+    /// Await the next chunk; `None` once the sender is gone and the queue is
+    /// drained (mirrors `mpsc::UnboundedReceiver::recv`). Cancel-safe: state
+    /// lives in the shared queue, and every call re-checks it before
+    /// sleeping, so a chunk enqueued between checks is never missed.
+    async fn recv(&mut self) -> Option<Vec<u8>> {
+        loop {
+            let notified = self.shared.notify.notified();
+            {
+                let mut st = self.shared.state.lock().unwrap();
+                if let Some(chunk) = st.chunks.pop_front() {
+                    st.queued_bytes -= chunk.len();
+                    return Some(chunk);
+                }
+                if st.sender_dropped {
+                    return None;
+                }
+            }
+            notified.await;
+        }
+    }
+}
+
+impl Drop for AudioQueueReceiver {
+    fn drop(&mut self) {
+        if let Ok(mut st) = self.shared.state.lock() {
+            st.receiver_dropped = true;
+            st.chunks.clear();
+            st.queued_bytes = 0;
+        }
+    }
 }
 
 pub async fn start_audio_bridge(
@@ -747,8 +1084,8 @@ pub async fn start_audio_bridge(
     provider: LiveAudioProvider,
     sample_rate: u32,
     bridge: &AudioBridge,
-    audio_out_rx: mpsc::UnboundedReceiver<Vec<u8>>,
-    capture_tee_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+    audio_out_rx: AudioQueueReceiver,
+    capture_tee_tx: Option<AudioQueueSender>,
 ) -> Result<AudioStreamBridge, CallerError> {
     if bridge.uses_vortex_shm() {
         // The Vortex shared-memory bridge is POSIX-only (shm_open/mmap).
@@ -834,8 +1171,8 @@ async fn start_vortex_shm_bridge(
     session_write: Arc<Mutex<WsSink>>,
     provider: LiveAudioProvider,
     sample_rate: u32,
-    audio_out_rx: mpsc::UnboundedReceiver<Vec<u8>>,
-    capture_tee_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+    audio_out_rx: AudioQueueReceiver,
+    capture_tee_tx: Option<AudioQueueSender>,
 ) -> Result<AudioStreamBridge, CallerError> {
     // Open and mmap the shared memory
     // SAFETY: VORTEX_SHM_NAME is a static NUL-terminated POSIX shm name.
@@ -919,7 +1256,11 @@ async fn start_vortex_shm_bridge(
         unsafe { *((base + buf_offset) as *mut f32).add(idx) = val };
     }
 
-    // Capture task: poll output ring → convert → model WebSocket
+    // Capture task: poll output ring → aggregate → convert → model WebSocket.
+    // The ring is still polled every 5ms (reads stay per-sample with masked
+    // indices), but samples accumulate in the aggregator and only go out as
+    // 20-40ms frames — 4-8× fewer WS messages than the old per-tick sends —
+    // through buffers reused across the task's lifetime.
     let capture_write = session_write;
     let capture_rate = sample_rate;
     let capture_provider = provider;
@@ -930,55 +1271,60 @@ async fn start_vortex_shm_bridge(
         let mut ticker = tokio::time::interval(Duration::from_millis(5));
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-        loop {
+        let mut agg = CaptureFrameAggregator::new();
+        let mut pcm16_buf: Vec<u8> = Vec::new();
+        let mut b64_buf = String::new();
+
+        'capture: loop {
             ticker.tick().await;
 
             let w = atomic_load_u64(b, OFF_OUT_WRITE_POS, Ordering::Acquire);
             let r = atomic_load_u64(b, OFF_OUT_READ_POS, Ordering::Relaxed);
             let avail = w.wrapping_sub(r) as usize;
             if avail == 0 {
+                // Stream went quiet with a partial frame pending: flush it so
+                // utterance tails are not held back waiting for a full frame.
+                if let Some(frame) = agg.flush() {
+                    if send_capture_frame(
+                        frame,
+                        &mut pcm16_buf,
+                        &mut b64_buf,
+                        capture_provider,
+                        capture_rate,
+                        capture_tee_tx.as_ref(),
+                        &capture_write,
+                    )
+                    .await
+                    .is_err()
+                    {
+                        break 'capture;
+                    }
+                }
                 continue;
             }
 
             let to_read = avail.min(VORTEX_RING_SAMPLES);
-            let mut f32_buf = Vec::with_capacity(to_read);
             for i in 0..to_read {
                 let idx = ((r + i as u64) & VORTEX_RING_MASK) as usize;
-                f32_buf.push(read_f32(b, OFF_OUT_BUFFER, idx));
+                agg.push_sample(read_f32(b, OFF_OUT_BUFFER, idx));
             }
             atomic_store_u64(b, OFF_OUT_READ_POS, r + to_read as u64, Ordering::Release);
 
-            let f32_bytes: Vec<u8> = f32_buf.iter().flat_map(|f| f.to_le_bytes()).collect();
-            let pcm16 = vortex_capture_convert(&f32_bytes);
-            if pcm16.is_empty() {
-                continue;
-            }
-
-            let b64 = BASE64.encode(&pcm16);
-            let ws_msg = match capture_provider {
-                LiveAudioProvider::Gemini => serde_json::json!({
-                    "realtime_input": {
-                        "media_chunks": [{
-                            "mime_type": format!("audio/pcm;rate={}", capture_rate),
-                            "data": b64
-                        }]
-                    }
-                }),
-                LiveAudioProvider::OpenAI => serde_json::json!({
-                    "type": "input_audio_buffer.append",
-                    "audio": b64
-                }),
-            };
-            if let Some(ref tee) = capture_tee_tx {
-                let _ = tee.send(pcm16);
-            }
-            let mut sink = capture_write.lock().await;
-            if sink
-                .send(WsMessage::Text(ws_msg.to_string().into()))
+            while let Some(frame) = agg.next_full_frame() {
+                if send_capture_frame(
+                    frame,
+                    &mut pcm16_buf,
+                    &mut b64_buf,
+                    capture_provider,
+                    capture_rate,
+                    capture_tee_tx.as_ref(),
+                    &capture_write,
+                )
                 .await
                 .is_err()
-            {
-                break;
+                {
+                    break 'capture;
+                }
             }
         }
     });
@@ -989,13 +1335,13 @@ async fn start_vortex_shm_bridge(
         use std::sync::atomic::Ordering;
         let b = playback_base;
         let mut rx = audio_out_rx;
+        // Reused across chunks (clear-don't-realloc); converted directly from
+        // PCM16 to f32 samples with no intermediate byte image.
+        let mut samples: Vec<f32> = Vec::new();
 
         while let Some(pcm_data) = rx.recv().await {
-            let f32_bytes = vortex_playback_convert(&pcm_data);
-            let samples: Vec<f32> = f32_bytes
-                .chunks_exact(4)
-                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
-                .collect();
+            samples.clear();
+            pcm16_to_f32_stereo_upsampled(&pcm_data, &mut samples);
 
             let mut written = 0;
             while written < samples.len() {
@@ -1036,8 +1382,8 @@ async fn start_vortex_audio_bridge(
     provider: LiveAudioProvider,
     sample_rate: u32,
     socket_path: &str,
-    audio_out_rx: mpsc::UnboundedReceiver<Vec<u8>>,
-    capture_tee_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+    audio_out_rx: AudioQueueReceiver,
+    capture_tee_tx: Option<AudioQueueSender>,
 ) -> Result<AudioStreamBridge, CallerError> {
     // Clean up stale socket and bind
     let _ = std::fs::remove_file(socket_path);
@@ -1088,8 +1434,13 @@ async fn start_vortex_audio_bridge(
     // Capture: two tasks to decouple socket reads from WebSocket writes.
     // Task A drains the daemon socket as fast as possible (prevents buffer
     // backup that deadlocks the daemon's send/recv). Task B forwards the
-    // converted PCM to the model WebSocket at its own pace.
-    let (cap_tx, mut cap_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+    // converted PCM to the model WebSocket at its own pace — a slow WS peer
+    // costs the oldest queued audio, never unbounded memory.
+    let (cap_tx, mut cap_rx) = bounded_audio_queue(
+        "vortex-capture",
+        CAPTURE_QUEUE_SECONDS,
+        sample_rate as usize * 2,
+    );
 
     // Task A: drain daemon socket → channel
     let capture_drain = tokio::spawn(async move {
@@ -1174,8 +1525,8 @@ async fn start_network_audio_bridge(
     provider: LiveAudioProvider,
     sample_rate: u32,
     host_addr: &str,
-    audio_out_rx: mpsc::UnboundedReceiver<Vec<u8>>,
-    capture_tee_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+    audio_out_rx: AudioQueueReceiver,
+    capture_tee_tx: Option<AudioQueueSender>,
 ) -> Result<AudioStreamBridge, CallerError> {
     let stream = tokio::net::TcpStream::connect(host_addr)
         .await
@@ -1259,8 +1610,8 @@ async fn start_local_audio_bridge(
     provider: LiveAudioProvider,
     sample_rate: u32,
     bridge: &AudioBridge,
-    audio_out_rx: mpsc::UnboundedReceiver<Vec<u8>>,
-    capture_tee_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+    audio_out_rx: AudioQueueReceiver,
+    capture_tee_tx: Option<AudioQueueSender>,
 ) -> Result<AudioStreamBridge, CallerError> {
     // Capture task: platform command -> model
     let (capture_cmd, capture_args) = bridge.capture_command(sample_rate);
@@ -1457,25 +1808,55 @@ impl TranscriptLogger {
 // Full session orchestrator
 // ---------------------------------------------------------------------------
 
-/// Buffer inbound audio chunks from the capture tee, accumulate ~3 seconds,
-/// run silence detection, and send to Whisper for transcription.
-/// Results are appended to the transcript JSONL as "app" speaker entries.
+/// Inbound transcription window length: seconds of buffered call audio per
+/// Whisper request. ~3s balances transcript latency against per-request
+/// overhead (unchanged from the original inline pipeline).
+const WHISPER_WINDOW_SECONDS: usize = 3;
+
+/// Bound on transcription windows queued behind the in-flight Whisper call.
+/// Each window is [`WHISPER_WINDOW_SECONDS`] of voiced audio, so 4 windows
+/// keeps at most ~12s of speech waiting through a slow API spell; beyond
+/// that the oldest window is dropped — a transcript gap beats an
+/// ever-growing backlog a slow API may never catch up on.
+const WHISPER_MAX_PENDING_WINDOWS: usize = 4;
+
+/// Buffer inbound audio chunks from the capture tee, accumulate
+/// [`WHISPER_WINDOW_SECONDS`] windows, run silence detection, and send
+/// voiced windows to the transcriber. Results are appended to the transcript
+/// JSONL as "app" speaker entries.
+///
+/// Requests are sequential (at most one in flight) so transcript entries
+/// land in capture order, but the intake never stalls behind them: while a
+/// request is in flight, chunks keep draining and completed windows queue in
+/// a bounded drop-oldest FIFO ([`WHISPER_MAX_PENDING_WINDOWS`]). The
+/// in-flight future is held inside this task rather than spawned, so
+/// aborting the task cancels the request with it.
 ///
 /// The transcriber is constructed by `run_session` from the project's
 /// `[transcription]` config — this loop only ever runs when the project has
 /// explicitly opted in.
-async fn whisper_inbound_loop(
-    transcriber: crate::transcription::WhisperTranscriber,
-    mut rx: mpsc::UnboundedReceiver<Vec<u8>>,
+async fn whisper_inbound_loop<T>(
+    transcriber: T,
+    mut rx: AudioQueueReceiver,
     sample_rate: u32,
     transcript_path: &Path,
-) {
-    use crate::transcription::{self, Transcriber};
+) where
+    T: crate::transcription::Transcriber + 'static,
+{
+    use crate::transcription;
+    use std::future::Future;
+    use std::pin::Pin;
 
-    // Buffer ~3 seconds of audio before sending to Whisper
-    let threshold = (sample_rate as usize) * 2 * 3; // 3 seconds of 16-bit mono
+    let transcriber = Arc::new(transcriber);
+
+    let threshold = (sample_rate as usize) * 2 * WHISPER_WINDOW_SECONDS; // 16-bit mono
     let mut audio_buf: Vec<u8> = Vec::with_capacity(threshold);
     let rms_threshold = 1000.0f64;
+
+    let mut pending_windows: VecDeque<Vec<u8>> = VecDeque::new();
+    let mut window_drop_log = DropLog::new("whisper-window");
+    let mut in_flight: Option<Pin<Box<dyn Future<Output = Option<String>> + Send>>> = None;
+    let mut intake_open = true;
 
     // Open transcript file for appending
     let mut transcript_file = match tokio::fs::OpenOptions::new()
@@ -1488,39 +1869,72 @@ async fn whisper_inbound_loop(
         Err(_) => return,
     };
 
-    while let Some(chunk) = rx.recv().await {
-        audio_buf.extend_from_slice(&chunk);
-
-        if audio_buf.len() < threshold {
-            continue;
-        }
-
-        // RMS silence detection
-        let rms = {
-            let samples = audio_buf
-                .chunks_exact(2)
-                .map(|c| i16::from_le_bytes([c[0], c[1]]) as f64);
-            let n = audio_buf.len() / 2;
-            let sum_sq: f64 = samples.map(|s| s * s).sum();
-            if n > 0 {
-                (sum_sq / n as f64).sqrt()
-            } else {
-                0.0
+    loop {
+        // Launch the next queued window whenever the lane is idle; requests
+        // stay sequential so results publish in capture order.
+        if in_flight.is_none() {
+            if let Some(window) = pending_windows.pop_front() {
+                let transcriber = Arc::clone(&transcriber);
+                in_flight = Some(Box::pin(async move {
+                    let wav = transcription::encode_wav(&window, sample_rate, 1);
+                    match transcriber.transcribe(&wav).await {
+                        Ok(segment) => Some(segment.text),
+                        Err(_) => None,
+                    }
+                }));
+            } else if !intake_open {
+                break; // intake closed and every window drained
             }
-        };
-
-        if rms < rms_threshold {
-            audio_buf.clear();
-            continue;
         }
 
-        // Encode as WAV and transcribe
-        let wav = transcription::encode_wav(&audio_buf, sample_rate, 1);
-        audio_buf.clear();
+        tokio::select! {
+            chunk = rx.recv(), if intake_open => {
+                let Some(chunk) = chunk else {
+                    intake_open = false;
+                    continue;
+                };
+                audio_buf.extend_from_slice(&chunk);
+                if audio_buf.len() < threshold {
+                    continue;
+                }
 
-        if let Ok(segment) = transcriber.transcribe(&wav).await {
-            let text = segment.text.trim();
-            if !text.is_empty() {
+                // RMS silence detection
+                let rms = {
+                    let samples = audio_buf
+                        .chunks_exact(2)
+                        .map(|c| i16::from_le_bytes([c[0], c[1]]) as f64);
+                    let n = audio_buf.len() / 2;
+                    let sum_sq: f64 = samples.map(|s| s * s).sum();
+                    if n > 0 {
+                        (sum_sq / n as f64).sqrt()
+                    } else {
+                        0.0
+                    }
+                };
+
+                if rms < rms_threshold {
+                    audio_buf.clear();
+                    continue;
+                }
+
+                if pending_windows.len() >= WHISPER_MAX_PENDING_WINDOWS {
+                    pending_windows.pop_front();
+                    window_drop_log.note(1, WHISPER_WINDOW_SECONDS as f64);
+                }
+                pending_windows.push_back(std::mem::take(&mut audio_buf));
+            }
+            text = async {
+                match in_flight.as_mut() {
+                    Some(request) => request.await,
+                    None => std::future::pending().await,
+                }
+            }, if in_flight.is_some() => {
+                in_flight = None;
+                let Some(text) = text else { continue };
+                let text = text.trim();
+                if text.is_empty() {
+                    continue;
+                }
                 let entry = serde_json::json!({
                     "ts": chrono::Utc::now().to_rfc3339(),
                     "speaker": "app",
@@ -1916,8 +2330,15 @@ pub async fn run_session(
     // Set up transcript logger
     let mut transcript = TranscriptLogger::new(session_log_dir, &spec.id).await?;
 
-    // Channel for routing model audio output to the playback task
-    let (audio_out_tx, audio_out_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+    // PCM16 mono byte rate at the session's negotiated sample rate — the
+    // duration accounting for both bounded audio lanes below.
+    let pcm_bytes_per_sec = session.sample_rate as usize * 2;
+
+    // Lane for routing model audio output to the playback task: duration-
+    // bounded drop-oldest, so a wedged playback sink skips ahead instead of
+    // buffering the whole call.
+    let (audio_out_tx, audio_out_rx) =
+        bounded_audio_queue("playback", PLAYBACK_QUEUE_SECONDS, pcm_bytes_per_sec);
 
     // Set up the Whisper transcription tee for inbound audio — only when the
     // project has explicitly opted in ([transcription] enabled = true).
@@ -1925,7 +2346,8 @@ pub async fn run_session(
     let (capture_tee_tx, whisper_handle) = if transcription.enabled {
         match crate::transcription::WhisperTranscriber::new(transcription) {
             Ok(transcriber) => {
-                let (tee_tx, tee_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+                let (tee_tx, tee_rx) =
+                    bounded_audio_queue("whisper-tee", CAPTURE_QUEUE_SECONDS, pcm_bytes_per_sec);
                 let whisper_transcript_path = transcript.path().to_path_buf();
                 let handle = tokio::spawn(async move {
                     whisper_inbound_loop(transcriber, tee_rx, 24000, &whisper_transcript_path)
@@ -2365,6 +2787,403 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Direct-conversion parity tests
+    // -----------------------------------------------------------------------
+
+    /// The pre-refactor capture pipeline, kept verbatim as the reference the
+    /// direct conversion is pinned against: f32 samples → little-endian byte
+    /// image → per-frame byte parsing → PCM16.
+    fn reference_capture_two_step(samples: &[f32]) -> Vec<u8> {
+        let f32_bytes: Vec<u8> = samples.iter().flat_map(|f| f.to_le_bytes()).collect();
+        let num_floats = f32_bytes.len() / 4;
+        let num_stereo_frames = num_floats / 2;
+        let mut out = Vec::with_capacity((num_stereo_frames / 2) * 2);
+        for i in (0..num_stereo_frames).step_by(2) {
+            let base = i * 8;
+            if base + 8 > f32_bytes.len() {
+                break;
+            }
+            let left = f32::from_le_bytes([
+                f32_bytes[base],
+                f32_bytes[base + 1],
+                f32_bytes[base + 2],
+                f32_bytes[base + 3],
+            ]);
+            let right = f32::from_le_bytes([
+                f32_bytes[base + 4],
+                f32_bytes[base + 5],
+                f32_bytes[base + 6],
+                f32_bytes[base + 7],
+            ]);
+            let mono = (left + right) * 0.5;
+            let clamped = mono.clamp(-1.0, 1.0);
+            let sample = (clamped * 32767.0) as i16;
+            out.extend_from_slice(&sample.to_le_bytes());
+        }
+        out
+    }
+
+    #[test]
+    fn direct_capture_convert_matches_two_step_reference() {
+        let mut cases: Vec<Vec<f32>> = vec![
+            vec![],
+            vec![0.5, -0.5],                    // one stereo frame
+            vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6], // odd frame count
+            vec![2.0, 2.0, -3.0, 1.0, 1.0, 1.0, -1.0, -1.0], // clamping
+        ];
+        // Deterministic sweep across the clamped range, unaligned length.
+        let sweep: Vec<f32> = (0..1001).map(|i| ((i as f32 * 0.7311) % 3.0) - 1.5).collect();
+        cases.push(sweep);
+
+        for samples in &cases {
+            let mut direct = Vec::new();
+            downmix_decimate_f32_to_pcm16(samples, &mut direct);
+            assert_eq!(
+                direct,
+                reference_capture_two_step(samples),
+                "n={}",
+                samples.len()
+            );
+        }
+    }
+
+    #[test]
+    fn capture_convert_ignores_trailing_partial_frames() {
+        // One complete stereo frame + half a frame + 2 stray bytes.
+        let mut bytes = Vec::new();
+        for v in [0.5f32, 0.5, 0.25] {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        bytes.extend_from_slice(&[0xAA, 0xBB]);
+        let out = vortex_capture_convert(&bytes);
+        assert_eq!(out.len(), 2, "one mono sample from the one complete frame");
+        let s = i16::from_le_bytes([out[0], out[1]]);
+        assert!((s - 16383).abs() <= 1, "s={s}");
+    }
+
+    #[test]
+    fn direct_playback_convert_matches_byte_image() {
+        let pcm: Vec<u8> = [0i16, 16383, -32768, 32767, -1]
+            .iter()
+            .flat_map(|s| s.to_le_bytes())
+            .collect();
+        let mut direct = Vec::new();
+        pcm16_to_f32_stereo_upsampled(&pcm, &mut direct);
+        let parsed: Vec<f32> = vortex_playback_convert(&pcm)
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        assert_eq!(direct, parsed);
+    }
+
+    // -----------------------------------------------------------------------
+    // Capture frame aggregation tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn capture_aggregator_aggregates_5ms_ticks_into_min_frames() {
+        let mut agg = CaptureFrameAggregator::new();
+        let tick = 5 * VORTEX_RING_F32_PER_MS; // one 5ms poll's worth
+        // Below the 20ms floor nothing is emitted...
+        for _ in 0..3 {
+            for _ in 0..tick {
+                agg.push_sample(0.25);
+            }
+            assert!(agg.next_full_frame().is_none(), "no frame below the floor");
+        }
+        // ...the fourth tick crosses it and yields exactly one 20ms frame.
+        for _ in 0..tick {
+            agg.push_sample(0.25);
+        }
+        let frame = agg.next_full_frame().expect("full frame at 20ms");
+        assert_eq!(frame.len(), CAPTURE_FRAME_MIN_F32);
+        assert!(
+            agg.next_full_frame().is_none(),
+            "nothing pending after an exact frame"
+        );
+    }
+
+    #[test]
+    fn capture_aggregator_splits_bursts_into_max_frames() {
+        let mut agg = CaptureFrameAggregator::new();
+        // A 100ms burst (ring backlog after a stall) cuts into 40+40+20ms.
+        let burst = 100 * VORTEX_RING_F32_PER_MS;
+        for i in 0..burst {
+            agg.push_sample(i as f32);
+        }
+        let mut sizes = Vec::new();
+        let mut samples = Vec::new();
+        while let Some(frame) = agg.next_full_frame() {
+            sizes.push(frame.len());
+            samples.extend_from_slice(frame);
+        }
+        assert_eq!(
+            sizes,
+            vec![
+                CAPTURE_FRAME_MAX_F32,
+                CAPTURE_FRAME_MAX_F32,
+                CAPTURE_FRAME_MIN_F32
+            ]
+        );
+        // Order preserved sample-for-sample across the cuts.
+        for (i, s) in samples.iter().enumerate() {
+            assert_eq!(*s, i as f32);
+        }
+        assert!(agg.flush().is_none(), "burst divided evenly, nothing pending");
+    }
+
+    #[test]
+    fn capture_aggregator_quiet_flush_releases_partial_tail() {
+        let mut agg = CaptureFrameAggregator::new();
+        let tail = 7 * VORTEX_RING_F32_PER_MS; // 7ms tail, under the 20ms floor
+        for i in 0..tail {
+            agg.push_sample(i as f32);
+        }
+        assert!(agg.next_full_frame().is_none());
+        let frame = agg.flush().expect("quiet flush emits the partial tail");
+        assert_eq!(frame.len(), tail);
+        for (i, s) in frame.iter().enumerate() {
+            assert_eq!(*s, i as f32);
+        }
+        assert!(agg.flush().is_none(), "flush drains the aggregator");
+    }
+
+    #[test]
+    fn capture_aggregator_cuts_on_decimation_boundaries() {
+        let mut agg = CaptureFrameAggregator::new();
+        // An unaligned backlog (not a multiple of the 4-sample decimation
+        // group) must leave the stragglers pending, not smear the phase.
+        let n = CAPTURE_FRAME_MIN_F32 + 3;
+        for i in 0..n {
+            agg.push_sample(i as f32);
+        }
+        let frame = agg.next_full_frame().expect("frame at the floor");
+        assert_eq!(frame.len(), CAPTURE_FRAME_MIN_F32);
+        assert_eq!(frame.len() % CAPTURE_DECIMATION_GROUP_F32, 0);
+        let tail = agg.flush().expect("stragglers stay pending");
+        assert_eq!(tail.len(), 3);
+        assert_eq!(tail[0], CAPTURE_FRAME_MIN_F32 as f32);
+    }
+
+    // -----------------------------------------------------------------------
+    // Bounded drop-oldest queue tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn bounded_queue_drops_oldest_on_overflow() {
+        // 1s × 1000 B/s = 1000-byte budget.
+        let (tx, mut rx) = bounded_audio_queue("test", 1, 1000);
+        for tag in 1u8..=5 {
+            tx.send(vec![tag; 300]).expect("receiver alive");
+        }
+        // 5×300 = 1500 > 1000: the two oldest chunks were evicted.
+        drop(tx);
+        let mut tags = Vec::new();
+        while let Some(chunk) = rx.recv().await {
+            assert_eq!(chunk.len(), 300);
+            tags.push(chunk[0]);
+        }
+        assert_eq!(tags, vec![3, 4, 5], "oldest dropped, survivor order intact");
+    }
+
+    #[tokio::test]
+    async fn bounded_queue_never_evicts_the_only_chunk() {
+        let (tx, mut rx) = bounded_audio_queue("test", 1, 100); // 100-byte budget
+        tx.send(vec![7u8; 500]).expect("receiver alive");
+        let got = rx.recv().await.expect("oversized chunk still delivered");
+        assert_eq!(got.len(), 500);
+    }
+
+    #[tokio::test]
+    async fn bounded_queue_send_fails_once_receiver_gone() {
+        let (tx, rx) = bounded_audio_queue("test", 1, 1000);
+        drop(rx);
+        assert!(tx.send(vec![1, 2, 3]).is_err());
+    }
+
+    #[tokio::test]
+    async fn bounded_queue_recv_drains_then_ends_after_sender_drop() {
+        let (tx, mut rx) = bounded_audio_queue("test", 1, 1000);
+        tx.send(vec![1]).unwrap();
+        tx.send(vec![2]).unwrap();
+        drop(tx);
+        assert_eq!(rx.recv().await, Some(vec![1]));
+        assert_eq!(rx.recv().await, Some(vec![2]));
+        assert_eq!(rx.recv().await, None);
+    }
+
+    #[tokio::test]
+    async fn bounded_queue_wakes_blocked_receiver() {
+        let (tx, mut rx) = bounded_audio_queue("test", 1, 1000);
+        let recv_task = tokio::spawn(async move { rx.recv().await });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        tx.send(vec![9]).unwrap();
+        let got = tokio::time::timeout(Duration::from_secs(5), recv_task)
+            .await
+            .expect("receiver woke")
+            .expect("task");
+        assert_eq!(got, Some(vec![9]));
+    }
+
+    // -----------------------------------------------------------------------
+    // Whisper intake tests (hermetic — stub transcriber, no network)
+    // -----------------------------------------------------------------------
+
+    /// Stub transcriber gated on a watch flag: calls stall until the test
+    /// opens the gate, then identify their window by its first PCM sample
+    /// (offset 44 = end of the standard WAV header).
+    struct GatedStubTranscriber {
+        release: tokio::sync::watch::Receiver<bool>,
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::transcription::Transcriber for GatedStubTranscriber {
+        async fn transcribe(
+            &self,
+            audio_wav: &[u8],
+        ) -> Result<crate::transcription::TranscriptSegment, CallerError> {
+            self.calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let mut release = self.release.clone();
+            release
+                .wait_for(|open| *open)
+                .await
+                .map_err(|_| CallerError::Agent("gate dropped".into()))?;
+            let tag = i16::from_le_bytes([audio_wav[44], audio_wav[45]]);
+            Ok(crate::transcription::TranscriptSegment {
+                text: format!("w{tag}"),
+                language: None,
+                duration_secs: 0.0,
+            })
+        }
+    }
+
+    /// One voiced [`WHISPER_WINDOW_SECONDS`] window of constant amplitude
+    /// `tag` (must clear the RMS gate at 1000).
+    fn voiced_window(tag: i16, rate: u32) -> Vec<u8> {
+        let bytes = rate as usize * 2 * WHISPER_WINDOW_SECONDS;
+        let mut window = Vec::with_capacity(bytes);
+        for _ in 0..bytes / 2 {
+            window.extend_from_slice(&tag.to_le_bytes());
+        }
+        window
+    }
+
+    fn transcript_texts(path: &Path) -> Vec<String> {
+        let content = std::fs::read_to_string(path).unwrap_or_default();
+        content
+            .lines()
+            .map(|line| {
+                let entry: serde_json::Value = serde_json::from_str(line).expect("jsonl entry");
+                assert_eq!(entry["speaker"], "app");
+                entry["text"].as_str().expect("text").to_string()
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn whisper_intake_keeps_draining_while_transcription_stalls() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let transcript_path = dir.path().join("transcript.jsonl");
+
+        // Tiny synthetic rate keeps windows small (600 bytes each).
+        let rate: u32 = 100;
+
+        let (release_tx, release_rx) = tokio::sync::watch::channel(false);
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let stub = GatedStubTranscriber {
+            release: release_rx,
+            calls: calls.clone(),
+        };
+
+        let (tee_tx, tee_rx) =
+            bounded_audio_queue("whisper-tee", CAPTURE_QUEUE_SECONDS, rate as usize * 2);
+        let loop_path = transcript_path.clone();
+        let handle = tokio::spawn(async move {
+            whisper_inbound_loop(stub, tee_rx, rate, &loop_path).await;
+        });
+
+        // Feed 7 voiced windows while the first transcription is stalled.
+        // Intake must keep accepting: window 2000 goes in flight, and of the
+        // rest the bounded FIFO keeps the newest 4 (2003..=2006), dropping
+        // the two oldest queued windows (2001, 2002).
+        for tag in 2000i16..=2006 {
+            tee_tx
+                .send(voiced_window(tag, rate))
+                .expect("intake accepts while a transcription is stalled");
+        }
+        drop(tee_tx);
+
+        // The consumer keeps draining while stalled: exactly one request in
+        // flight, everything else queued/bounded, nothing blocked.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while calls.load(std::sync::atomic::Ordering::SeqCst) < 1 {
+            assert!(Instant::now() < deadline, "first request never launched");
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert_eq!(
+            calls.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "requests stay sequential while the first is in flight"
+        );
+        assert!(
+            transcript_texts(&transcript_path).is_empty(),
+            "nothing published before the stall resolves"
+        );
+
+        // Release the gate: the stalled request and the surviving windows
+        // resolve in capture order.
+        release_tx.send(true).expect("loop alive");
+        tokio::time::timeout(Duration::from_secs(10), handle)
+            .await
+            .expect("whisper loop drains and exits")
+            .expect("whisper task");
+
+        assert_eq!(
+            transcript_texts(&transcript_path),
+            vec!["w2000", "w2003", "w2004", "w2005", "w2006"],
+            "results in capture order; only the oldest queued windows dropped"
+        );
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 5);
+    }
+
+    #[tokio::test]
+    async fn whisper_silent_windows_are_skipped() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let transcript_path = dir.path().join("transcript.jsonl");
+        let rate: u32 = 100;
+
+        let (release_tx, release_rx) = tokio::sync::watch::channel(true); // gate open
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let stub = GatedStubTranscriber {
+            release: release_rx,
+            calls: calls.clone(),
+        };
+
+        let (tee_tx, tee_rx) =
+            bounded_audio_queue("whisper-tee", CAPTURE_QUEUE_SECONDS, rate as usize * 2);
+        let loop_path = transcript_path.clone();
+        let handle = tokio::spawn(async move {
+            whisper_inbound_loop(stub, tee_rx, rate, &loop_path).await;
+        });
+
+        // A silent window is discarded by the RMS gate; a voiced one lands.
+        tee_tx.send(voiced_window(0, rate)).expect("loop alive");
+        tee_tx.send(voiced_window(3000, rate)).expect("loop alive");
+        drop(tee_tx);
+
+        tokio::time::timeout(Duration::from_secs(10), handle)
+            .await
+            .expect("whisper loop exits")
+            .expect("whisper task");
+        drop(release_tx);
+
+        assert_eq!(transcript_texts(&transcript_path), vec!["w3000"]);
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    // -----------------------------------------------------------------------
     // Existing tests
     // -----------------------------------------------------------------------
 
@@ -2775,7 +3594,11 @@ mod tests {
         }
 
         // Start audio bridge (capture silence → model, model audio → playback)
-        let (audio_out_tx, audio_out_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        let (audio_out_tx, audio_out_rx) = bounded_audio_queue(
+            "playback",
+            PLAYBACK_QUEUE_SECONDS,
+            session.sample_rate as usize * 2,
+        );
         let audio_bridge = start_audio_bridge(
             session.ws_write.clone(),
             session.provider,

--- a/src/bin/caller/live_audio.rs
+++ b/src/bin/caller/live_audio.rs
@@ -784,8 +784,8 @@ const CAPTURE_FRAME_MAX_F32: usize = CAPTURE_FRAME_MAX_MS * VORTEX_RING_F32_PER_
 
 // Frame cuts must land on decimation-group boundaries.
 const _: () = assert!(
-    CAPTURE_FRAME_MIN_F32 % CAPTURE_DECIMATION_GROUP_F32 == 0
-        && CAPTURE_FRAME_MAX_F32 % CAPTURE_DECIMATION_GROUP_F32 == 0
+    CAPTURE_FRAME_MIN_F32.is_multiple_of(CAPTURE_DECIMATION_GROUP_F32)
+        && CAPTURE_FRAME_MAX_F32.is_multiple_of(CAPTURE_DECIMATION_GROUP_F32)
         && CAPTURE_FRAME_MIN_F32 <= CAPTURE_FRAME_MAX_F32
 );
 
@@ -834,7 +834,7 @@ impl CaptureFrameAggregator {
             return None;
         }
         self.frame.clear();
-        self.frame.extend(self.pending.drain(..));
+        self.frame.append(&mut self.pending);
         Some(&self.frame)
     }
 }
@@ -1943,6 +1943,10 @@ async fn whisper_inbound_loop<T>(
                 let mut line = serde_json::to_string(&entry).unwrap_or_default();
                 line.push('\n');
                 let _ = transcript_file.write_all(line.as_bytes()).await;
+                // tokio's File hands writes to the blocking pool and returns
+                // before they land; flush per entry so the transcript is
+                // durable even if the session aborts this task right after.
+                let _ = transcript_file.flush().await;
             }
         }
     }
@@ -2827,12 +2831,14 @@ mod tests {
     fn direct_capture_convert_matches_two_step_reference() {
         let mut cases: Vec<Vec<f32>> = vec![
             vec![],
-            vec![0.5, -0.5],                    // one stereo frame
-            vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6], // odd frame count
+            vec![0.5, -0.5],                                 // one stereo frame
+            vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6],              // odd frame count
             vec![2.0, 2.0, -3.0, 1.0, 1.0, 1.0, -1.0, -1.0], // clamping
         ];
         // Deterministic sweep across the clamped range, unaligned length.
-        let sweep: Vec<f32> = (0..1001).map(|i| ((i as f32 * 0.7311) % 3.0) - 1.5).collect();
+        let sweep: Vec<f32> = (0..1001)
+            .map(|i| ((i as f32 * 0.7311) % 3.0) - 1.5)
+            .collect();
         cases.push(sweep);
 
         for samples in &cases {
@@ -2884,7 +2890,7 @@ mod tests {
     fn capture_aggregator_aggregates_5ms_ticks_into_min_frames() {
         let mut agg = CaptureFrameAggregator::new();
         let tick = 5 * VORTEX_RING_F32_PER_MS; // one 5ms poll's worth
-        // Below the 20ms floor nothing is emitted...
+                                               // Below the 20ms floor nothing is emitted...
         for _ in 0..3 {
             for _ in 0..tick {
                 agg.push_sample(0.25);
@@ -2929,7 +2935,10 @@ mod tests {
         for (i, s) in samples.iter().enumerate() {
             assert_eq!(*s, i as f32);
         }
-        assert!(agg.flush().is_none(), "burst divided evenly, nothing pending");
+        assert!(
+            agg.flush().is_none(),
+            "burst divided evenly, nothing pending"
+        );
     }
 
     #[test]
@@ -3043,8 +3052,7 @@ mod tests {
             &self,
             audio_wav: &[u8],
         ) -> Result<crate::transcription::TranscriptSegment, CallerError> {
-            self.calls
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             let mut release = self.release.clone();
             release
                 .wait_for(|open| *open)


### PR DESCRIPTION
Live-audio efficiency fixes: the 5ms capture loop allocated five buffers per tick and sent up to 200 WS messages/sec; the playback, capture, and whisper-tee lanes were unbounded; and the whisper consumer stopped draining its queue while a remote transcription was in flight.

## Changes

**1. Capture aggregation (vortex shm path).** Ring reads (unchanged: per-sample masked indices, same SAFETY comments) now accumulate in a `CaptureFrameAggregator` and go out as 20-40ms frames — one WS message per frame instead of one per 5ms tick (4-8x fewer messages). Frames are cut on 4-sample decimation-group boundaries so the 2:1 decimation phase stays continuous across messages. A tick that finds the ring empty while a partial frame is pending flushes it, so utterance tails are never held (added latency ≤ one 20ms frame + one 5ms tick). Both provider message formats (`realtime_input` / `input_audio_buffer.append`) are byte-identical apart from chunk size.

**2. Buffer reuse + direct conversion.** The aggregator's buffers, the PCM16 output buffer, and the base64 string live for the whole capture task (clear-don't-realloc). `downmix_decimate_f32_to_pcm16` converts f32 ring samples straight to PCM16 — no intermediate `flat_map` byte Vec; `vortex_capture_convert` remains as the byte-image front-end for the daemon-socket path and is pinned bit-for-bit against the old two-step pipeline by test. The shm playback path likewise converts PCM16 directly into a reused `Vec<f32>` (`pcm16_to_f32_stereo_upsampled`) instead of building a byte image and re-parsing it.

**3. Duration-bounded drop-oldest lanes.** All four audio channels (playback, legacy daemon-socket capture, whisper tee, plus the diagnostics test's playback lane) move from unbounded mpsc to `bounded_audio_queue`, which evicts the OLDEST chunks on overflow — for live audio a skip is strictly better than unbounded lag — with a rate-limited (5s) log naming the lane. Bounds:
- `PLAYBACK_QUEUE_SECONDS = 30` — TTS bursts outrun real time, so a healthy lane briefly holds several seconds; 30s absorbs a full long utterance while capping a wedged sink at ~1.4 MiB.
- `CAPTURE_QUEUE_SECONDS = 30` — capture is produced in real time, so backlog beyond a few seconds means a stalled consumer; 30s is far above healthy holdings while still bounding the stall.
- `WHISPER_MAX_PENDING_WINDOWS = 4` — each window is ~3s of voiced audio, so ~12s of speech can wait out a slow API spell; beyond that the oldest window drops (a transcript gap beats a backlog the API may never catch up on).

**4. Whisper intake never stalls.** The consumer holds the in-flight transcription as a future inside its own select loop (not spawned, so aborting the task cancels the request) and keeps draining + bounding intake while it runs. Chosen ordering scheme: requests stay **sequential** (at most one in flight) over a FIFO window queue, so transcript entries land in capture order by construction; only intake was parallelized.

## Tests

Hermetic (no Vortex shm, no network, no audio hardware): aggregation floor/cap/quiet-flush/alignment; direct f32→i16 pinned bit-for-bit against the verbatim old two-step reference (plus trailing-partial-frame and playback byte-image parity); queue drop-oldest/ordering/close semantics/receiver wakeup; whisper intake with a stalled (gated) transcription stub — intake keeps accepting, bounds to the newest 4 windows, and on release publishes results in capture order.

Live end-to-end audio verification is an operator smoke (needs the Vortex rig), not CI.
