### PR TITLE
changes tab: agree with the vitals dirty chip on the session's checkout

### DIFF
--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -103,11 +103,42 @@ fn git_version_at_least(version_line: &str, want_major: u32, want_minor: u32) ->
 /// on the next tick — cheap insurance against daemon-lifetime growth.
 const PROBER_CACHE_CAP: usize = 256;
 
+/// The one `git status` invocation both dirty-state surfaces run: the
+/// vitals prober (async, per-tick) and the Changes tab's working-tree
+/// fallback (sync, per request) spawn exactly these arguments and feed
+/// the output to [`parse_status_v2`], so "what counts as dirty" — the
+/// chip's count and the tab's file list — is a single definition.
+pub(crate) const GIT_STATUS_ARGS: [&str; 4] =
+    ["--no-optional-locks", "status", "--porcelain=v2", "--branch"];
+
+/// How one working-tree entry differs from HEAD, collapsed to the
+/// Changes-tab kind vocabulary (created / modified / deleted).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GitStatusEntryKind {
+    Created,
+    Modified,
+    Deleted,
+}
+
+/// One non-header line of `git status --porcelain=v2` — the per-file
+/// truth behind the `dirty_files` count. The count IS `entries.len()`,
+/// so a consumer listing these can never disagree with a consumer
+/// counting them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitStatusEntry {
+    /// Path relative to the checkout toplevel (the rename *target* for
+    /// rename entries — one line per rename, matching the count). Git's
+    /// C-style quoting is undone; an untracked directory keeps its
+    /// trailing `/` (git spends one line on the whole directory).
+    pub(crate) path: String,
+    pub(crate) kind: GitStatusEntryKind,
+}
+
 /// Facts one `git status --porcelain=v2 --branch` run yields — the
 /// collapsed replacement for the old separate branch / dirty-count /
 /// upstream-verify / unpushed-count subprocess chain.
 #[derive(Debug, Default, PartialEq, Eq)]
-struct StatusFacts {
+pub(crate) struct StatusFacts {
     /// `branch.head`, mapped to the spellings the old
     /// `rev-parse --abbrev-ref HEAD` emitted: `HEAD` when detached, empty
     /// on an unborn branch (where the old probe failed).
@@ -120,13 +151,110 @@ struct StatusFacts {
     /// `@{upstream}` verify condition — and the ahead column IS the
     /// unpushed count, so `None` here means "no upstream to check".
     upstream_ab: Option<(u32, u32)>,
-    /// Non-header entry lines: changed + unmerged + untracked. One line
+    /// Non-header entry lines: changed + unmerged + untracked. One entry
     /// per path, matching porcelain v1's line count (renames included —
     /// both formats spend one line per rename).
-    dirty_files: u32,
+    pub(crate) entries: Vec<GitStatusEntry>,
 }
 
-fn parse_status_v2(output: &str) -> StatusFacts {
+impl StatusFacts {
+    /// The vitals dirty count, derived from the entry list — the chip's
+    /// number and the Changes tab's row count are the same length.
+    pub(crate) fn dirty_files(&self) -> u32 {
+        self.entries.len() as u32
+    }
+}
+
+/// Undo git's C-style path quoting (`core.quotePath` wraps paths with
+/// special or non-ASCII bytes in `"…"` with backslash escapes). Unquoted
+/// paths pass through untouched; a malformed quoted path falls back to
+/// the raw spelling rather than dropping the entry.
+pub(crate) fn unquote_git_path(raw: &str) -> String {
+    let inner = match raw.strip_prefix('"').and_then(|r| r.strip_suffix('"')) {
+        Some(inner) => inner,
+        None => return raw.to_string(),
+    };
+    let mut bytes: Vec<u8> = Vec::with_capacity(inner.len());
+    let mut chars = inner.bytes().peekable();
+    while let Some(b) = chars.next() {
+        if b != b'\\' {
+            bytes.push(b);
+            continue;
+        }
+        match chars.next() {
+            Some(b'n') => bytes.push(b'\n'),
+            Some(b't') => bytes.push(b'\t'),
+            Some(b'r') => bytes.push(b'\r'),
+            Some(b'\\') => bytes.push(b'\\'),
+            Some(b'"') => bytes.push(b'"'),
+            Some(d @ b'0'..=b'7') => {
+                // Up to three octal digits encode one raw byte.
+                let mut value = (d - b'0') as u32;
+                for _ in 0..2 {
+                    match chars.peek() {
+                        Some(d @ b'0'..=b'7') => {
+                            value = value * 8 + (*d - b'0') as u32;
+                            chars.next();
+                        }
+                        _ => break,
+                    }
+                }
+                bytes.push(value as u8);
+            }
+            Some(other) => bytes.push(other),
+            None => break,
+        }
+    }
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+/// Kind for a tracked entry's two-letter `XY` state field. Deletion on
+/// either side wins (the file is gone from the working tree or staged
+/// away); a pure addition is a creation; everything else — including
+/// renames and unmerged conflict states — reads as modified.
+fn status_xy_kind(xy: &str) -> GitStatusEntryKind {
+    if xy.contains('D') {
+        GitStatusEntryKind::Deleted
+    } else if xy.contains('A') {
+        GitStatusEntryKind::Created
+    } else {
+        GitStatusEntryKind::Modified
+    }
+}
+
+/// One porcelain-v2 entry line → its path + kind. Field counts per line
+/// type come from the format spec: ordinary `1` lines carry 8 fields
+/// before the path, rename `2` lines 9 (path `\t` origPath — the target
+/// leads), unmerged `u` lines 10, and `?`/`!` prefix the bare path.
+fn parse_status_entry(line: &str) -> Option<GitStatusEntry> {
+    let (path, kind) = if let Some(rest) = line.strip_prefix("? ") {
+        (rest.to_string(), GitStatusEntryKind::Created)
+    } else if let Some(rest) = line.strip_prefix("! ") {
+        (rest.to_string(), GitStatusEntryKind::Modified)
+    } else if line.starts_with("1 ") {
+        let path = line.splitn(9, ' ').nth(8)?;
+        let xy = line.split(' ').nth(1).unwrap_or("");
+        (path.to_string(), status_xy_kind(xy))
+    } else if line.starts_with("2 ") {
+        let pair = line.splitn(10, ' ').nth(9)?;
+        let target = pair.split('\t').next().unwrap_or(pair);
+        let xy = line.split(' ').nth(1).unwrap_or("");
+        (target.to_string(), status_xy_kind(xy))
+    } else if line.starts_with("u ") {
+        let path = line.splitn(11, ' ').nth(10)?;
+        (path.to_string(), GitStatusEntryKind::Modified)
+    } else {
+        // Unknown non-header line: count it (the old counter did), shown
+        // as a modification.
+        (line.to_string(), GitStatusEntryKind::Modified)
+    };
+    Some(GitStatusEntry {
+        path: unquote_git_path(&path),
+        kind,
+    })
+}
+
+pub(crate) fn parse_status_v2(output: &str) -> StatusFacts {
     let mut facts = StatusFacts::default();
     let mut unborn = false;
     for line in output.lines() {
@@ -145,7 +273,9 @@ fn parse_status_v2(output: &str) -> StatusFacts {
                 facts.upstream_ab = parse_status_ab(ab);
             }
         } else if !line.trim().is_empty() {
-            facts.dirty_files += 1;
+            if let Some(entry) = parse_status_entry(line) {
+                facts.entries.push(entry);
+            }
         }
     }
     if unborn {
@@ -154,6 +284,24 @@ fn parse_status_v2(output: &str) -> StatusFacts {
         facts.branch = String::new();
     }
     facts
+}
+
+/// Synchronous working-tree status for `root` — the Changes tab's
+/// fallback lane runs this on blocking paths (HTTP handler thread,
+/// tunnel `spawn_blocking`). Same arguments, same parser as the async
+/// vitals probe, so both surfaces state the same dirty set. `None` when
+/// `root` is not a git checkout or git itself fails.
+pub(crate) fn git_working_tree_status(root: &Path) -> Option<StatusFacts> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(GIT_STATUS_ARGS)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(parse_status_v2(&String::from_utf8_lossy(&output.stdout)))
 }
 
 /// `branch.ab` payload: `+<ahead> -<behind>`.
@@ -323,8 +471,8 @@ impl GitVitalsProber {
         }
 
         Some(SessionGitVitals {
+            dirty_files: facts.dirty_files(),
             branch: facts.branch,
-            dirty_files: facts.dirty_files,
             ahead,
             behind,
             primary_ref,
@@ -1190,7 +1338,23 @@ mod tests {
             Some("2066c7d7db74e9e097ad8526b47c53a0fa0c39a9")
         );
         assert_eq!(facts.upstream_ab, Some((3, 1)));
-        assert_eq!(facts.dirty_files, 4);
+        assert_eq!(facts.dirty_files(), 4);
+        // The count derives from the entry list — path + kind per line,
+        // renames keyed by their target.
+        let listed: Vec<(&str, GitStatusEntryKind)> = facts
+            .entries
+            .iter()
+            .map(|entry| (entry.path.as_str(), entry.kind))
+            .collect();
+        assert_eq!(
+            listed,
+            vec![
+                ("src/lib.rs", GitStatusEntryKind::Modified),
+                ("new.rs", GitStatusEntryKind::Modified),
+                ("conflict.rs", GitStatusEntryKind::Modified),
+                ("scratch.txt", GitStatusEntryKind::Created),
+            ]
+        );
 
         // Upstream configured but its ref gone: git prints branch.upstream
         // without branch.ab — exactly the old failed `@{upstream}` verify,
@@ -1199,7 +1363,7 @@ mod tests {
             "# branch.oid 2066c7d7\n# branch.head main\n# branch.upstream origin/main\n",
         );
         assert_eq!(facts.upstream_ab, None);
-        assert_eq!(facts.dirty_files, 0);
+        assert_eq!(facts.dirty_files(), 0);
 
         // Detached HEAD keeps the old `rev-parse --abbrev-ref` spelling.
         let facts = parse_status_v2("# branch.oid 2066c7d7\n# branch.head (detached)\n");
@@ -1211,7 +1375,44 @@ mod tests {
         let facts = parse_status_v2("# branch.oid (initial)\n# branch.head main\n? f.txt\n");
         assert_eq!(facts.branch, "");
         assert_eq!(facts.head_oid, None);
-        assert_eq!(facts.dirty_files, 1);
+        assert_eq!(facts.dirty_files(), 1);
+    }
+
+    #[test]
+    fn status_v2_entry_kinds_and_quoting() {
+        // Staged add / staged+worktree deletions map to created/deleted;
+        // git's C-style quoting (spaces stay bare, specials escape) is
+        // undone so entry paths match real files.
+        let facts = parse_status_v2(concat!(
+            "1 A. N... 000000 100644 100644 0000 aaaa fresh.rs\n",
+            "1 .D N... 100644 100644 000000 aaaa aaaa gone.rs\n",
+            "1 D. N... 100644 000000 000000 aaaa 0000 staged-gone.rs\n",
+            "1 .M N... 100644 100644 100644 aaaa bbbb has space.rs\n",
+            "? \"we\\ttab.rs\"\n",
+            "? untracked-dir/\n",
+        ));
+        let listed: Vec<(&str, GitStatusEntryKind)> = facts
+            .entries
+            .iter()
+            .map(|entry| (entry.path.as_str(), entry.kind))
+            .collect();
+        assert_eq!(
+            listed,
+            vec![
+                ("fresh.rs", GitStatusEntryKind::Created),
+                ("gone.rs", GitStatusEntryKind::Deleted),
+                ("staged-gone.rs", GitStatusEntryKind::Deleted),
+                ("has space.rs", GitStatusEntryKind::Modified),
+                ("we\ttab.rs", GitStatusEntryKind::Created),
+                ("untracked-dir/", GitStatusEntryKind::Created),
+            ]
+        );
+        assert_eq!(facts.dirty_files(), listed.len() as u32);
+
+        // Octal escapes decode to their bytes (non-ASCII paths under the
+        // default core.quotePath).
+        assert_eq!(unquote_git_path("\"caf\\303\\251.rs\""), "café.rs");
+        assert_eq!(unquote_git_path("plain.rs"), "plain.rs");
     }
 
     /// Build a repo with a local bare `origin` whose `main` is pushed and

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -408,17 +408,7 @@ impl GitVitalsProber {
 
     async fn probe_checkout(&mut self, toplevel: &Path) -> Option<SessionGitVitals> {
         self.checkout_probes += 1;
-        let status = self
-            .git(
-                toplevel,
-                &[
-                    "--no-optional-locks",
-                    "status",
-                    "--porcelain=v2",
-                    "--branch",
-                ],
-            )
-            .await?;
+        let status = self.git(toplevel, &GIT_STATUS_ARGS).await?;
         let facts = parse_status_v2(&status);
         let unpushed = facts.upstream_ab.map(|(ahead, _)| ahead);
 

--- a/src/bin/caller/session_vitals.rs
+++ b/src/bin/caller/session_vitals.rs
@@ -108,8 +108,12 @@ const PROBER_CACHE_CAP: usize = 256;
 /// fallback (sync, per request) spawn exactly these arguments and feed
 /// the output to [`parse_status_v2`], so "what counts as dirty" — the
 /// chip's count and the tab's file list — is a single definition.
-pub(crate) const GIT_STATUS_ARGS: [&str; 4] =
-    ["--no-optional-locks", "status", "--porcelain=v2", "--branch"];
+pub(crate) const GIT_STATUS_ARGS: [&str; 4] = [
+    "--no-optional-locks",
+    "status",
+    "--porcelain=v2",
+    "--branch",
+];
 
 /// How one working-tree entry differs from HEAD, collapsed to the
 /// Changes-tab kind vocabulary (created / modified / deleted).

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -1472,18 +1472,44 @@ pub(crate) fn load_external_change_records(
 /// --numstat` pass (`--no-renames` so every path keys exactly);
 /// untracked files synthesize created-file stats from their content.
 fn git_fallback_change_records(project_root: &Path) -> Vec<ChangeRecord> {
-    let Some(facts) = crate::session_vitals::git_working_tree_status(project_root) else {
+    // Status paths are toplevel-relative whatever the invocation cwd, so
+    // every filesystem join and `--` pathspec below must use the checkout
+    // toplevel — the same resolution the vitals prober keys its probes by
+    // (a project root that is a subdirectory of a checkout probes, and
+    // now lists, that checkout).
+    let Some(toplevel) = git_checkout_toplevel(project_root) else {
+        return Vec::new();
+    };
+    let Some(facts) = crate::session_vitals::git_working_tree_status(&toplevel) else {
         return Vec::new();
     };
     if facts.entries.is_empty() {
         return Vec::new();
     }
-    let numstat = git_diff_head_numstat(project_root);
+    let numstat = git_diff_head_numstat(&toplevel);
     facts
         .entries
         .iter()
-        .map(|entry| git_status_change_record(project_root, entry, numstat.get(&entry.path)))
+        .map(|entry| git_status_change_record(&toplevel, entry, numstat.get(&entry.path)))
         .collect()
+}
+
+/// The checkout containing `root` (`rev-parse --show-toplevel`), the
+/// probe key the vitals prober uses. `None` when `root` is not inside
+/// any working tree — the fallback then states nothing, exactly like
+/// the chip's failed probe.
+fn git_checkout_toplevel(root: &Path) -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let toplevel = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!toplevel.is_empty()).then(|| PathBuf::from(toplevel))
 }
 
 /// Kind vocabulary bridge: the shared status parse speaks
@@ -1499,11 +1525,11 @@ fn git_status_entry_kind_str(kind: crate::session_vitals::GitStatusEntryKind) ->
 /// `git diff HEAD --numstat` per-path (added, removed, binary) — one
 /// subprocess for the whole list. Empty on failure (unborn HEAD, no
 /// git): records then carry zero stats but stay listed.
-fn git_diff_head_numstat(project_root: &Path) -> HashMap<String, (u32, u32, bool)> {
+fn git_diff_head_numstat(toplevel: &Path) -> HashMap<String, (u32, u32, bool)> {
     let mut stats = HashMap::new();
     let Ok(output) = std::process::Command::new("git")
         .arg("-C")
-        .arg(project_root)
+        .arg(toplevel)
         .args(["diff", "HEAD", "--no-renames", "--numstat"])
         .output()
     else {
@@ -1534,7 +1560,7 @@ fn git_diff_head_numstat(project_root: &Path) -> HashMap<String, (u32, u32, bool
 /// untracked directories and binaries stay listed with an honest
 /// no-textual-diff reason, keeping the row count equal to the chip's.
 fn git_status_change_record(
-    project_root: &Path,
+    toplevel: &Path,
     entry: &crate::session_vitals::GitStatusEntry,
     numstat: Option<&(u32, u32, bool)>,
 ) -> ChangeRecord {
@@ -1560,7 +1586,7 @@ fn git_status_change_record(
         );
     }
     // Untracked file (absent from diff HEAD): stats from its content.
-    match crate::file_watcher::inspect_file(&project_root.join(&entry.path)) {
+    match crate::file_watcher::inspect_file(&toplevel.join(&entry.path)) {
         Ok(crate::file_watcher::InspectedFile::Text(snapshot)) => ChangeRecord {
             path: entry.path.clone(),
             kind,
@@ -1591,7 +1617,8 @@ fn git_status_change_record(
 /// Tracked entries diff against HEAD (staged + unstaged in one body);
 /// untracked files synthesize a created-file diff from content.
 fn git_fallback_change_record_detail(project_root: &Path, decoded: &str) -> Option<ChangeRecord> {
-    let facts = crate::session_vitals::git_working_tree_status(project_root)?;
+    let toplevel = git_checkout_toplevel(project_root)?;
+    let facts = crate::session_vitals::git_working_tree_status(&toplevel)?;
     let entry = facts.entries.iter().find(|entry| entry.path == decoded)?;
     let kind = git_status_entry_kind_str(entry.kind);
     if entry.path.ends_with('/') {
@@ -1603,7 +1630,7 @@ fn git_fallback_change_record_detail(project_root: &Path, decoded: &str) -> Opti
     }
     let tracked_diff = std::process::Command::new("git")
         .arg("-C")
-        .arg(project_root)
+        .arg(&toplevel)
         .args(["diff", "HEAD", "--no-renames", "--"])
         .arg(&entry.path)
         .output()
@@ -1625,7 +1652,7 @@ fn git_fallback_change_record_detail(project_root: &Path, decoded: &str) -> Opti
     }
     // Untracked (invisible to `diff HEAD`): synthesize the created-file
     // diff the snapshot lane would show.
-    match crate::file_watcher::inspect_file(&project_root.join(&entry.path)) {
+    match crate::file_watcher::inspect_file(&toplevel.join(&entry.path)) {
         Ok(crate::file_watcher::InspectedFile::Text(snapshot)) => {
             let diff = crate::file_watcher::compute_unified_diff("", &snapshot.text, &entry.path);
             let (lines_added, lines_removed) = diff_stats_from_unified_diff(&diff);
@@ -6000,7 +6027,14 @@ mod tests {
         test_git(&base, &["commit", "-qm", "base"]);
         test_git(
             &base,
-            &["worktree", "add", "-q", wt.to_str().unwrap(), "-b", "session-branch"],
+            &[
+                "worktree",
+                "add",
+                "-q",
+                wt.to_str().unwrap(),
+                "-b",
+                "session-branch",
+            ],
         );
         // Dirty the WORKTREE only; the base checkout stays clean, so a
         // wrong-root resolution yields an empty list and fails the test.
@@ -6077,9 +6111,8 @@ mod tests {
 
         // Single-file diffs: the tracked change diffs against HEAD, the
         // untracked file synthesizes a created-file diff.
-        let request = format!(
-            "GET /api/session/current/changes/a.txt?session_id={session_id} HTTP/1.1"
-        );
+        let request =
+            format!("GET /api/session/current/changes/a.txt?session_id={session_id} HTTP/1.1");
         let (status, body) = handle_changes_request_for_home(
             &request,
             Some(live_snapshot.path()),
@@ -6093,9 +6126,8 @@ mod tests {
         assert_eq!(json["lines_added"], 1);
         assert_eq!(json["lines_removed"], 1);
 
-        let request = format!(
-            "GET /api/session/current/changes/new.txt?session_id={session_id} HTTP/1.1"
-        );
+        let request =
+            format!("GET /api/session/current/changes/new.txt?session_id={session_id} HTTP/1.1");
         let (status, body) = handle_changes_request_for_home(
             &request,
             Some(live_snapshot.path()),
@@ -6109,9 +6141,8 @@ mod tests {
 
         // A path git does not list stays a 404 — the status entry set is
         // the only key into the filesystem.
-        let request = format!(
-            "GET /api/session/current/changes/absent.txt?session_id={session_id} HTTP/1.1"
-        );
+        let request =
+            format!("GET /api/session/current/changes/absent.txt?session_id={session_id} HTTP/1.1");
         let (status, _) = handle_changes_request_for_home(
             &request,
             Some(live_snapshot.path()),

--- a/src/bin/caller/web_gateway/routes_sessions.rs
+++ b/src/bin/caller/web_gateway/routes_sessions.rs
@@ -921,7 +921,17 @@ pub(crate) fn handle_changes_request_inner(
         let records =
             load_external_change_records(snapshot_dir, project_root, !file_path.is_empty(), true);
         if file_path.is_empty() {
-            let changes: Vec<_> = records.iter().map(change_record_summary_json).collect();
+            let mut changes: Vec<_> = records.iter().map(change_record_summary_json).collect();
+            if changes.is_empty() {
+                // No session-scoped record source (native sessions have
+                // no external diff log, and this target never ran a
+                // watcher): answer from the working tree itself — the
+                // same git state the vitals dirty chip counted.
+                changes = git_fallback_change_records(project_root)
+                    .iter()
+                    .map(change_record_summary_json)
+                    .collect();
+            }
             return (
                 "200 OK",
                 serde_json::to_string(&changes).unwrap_or_else(|_| "[]".to_string()),
@@ -930,6 +940,9 @@ pub(crate) fn handle_changes_request_inner(
 
         let decoded = url_path_decode(file_path);
         if let Some(record) = records.into_iter().find(|record| record.path == decoded) {
+            return ("200 OK", change_record_detail_json(&record).to_string());
+        }
+        if let Some(record) = git_fallback_change_record_detail(project_root, &decoded) {
             return ("200 OK", change_record_detail_json(&record).to_string());
         }
         return (
@@ -1031,11 +1044,24 @@ pub(crate) fn session_row_matches_changes_target(
 }
 
 pub(crate) fn changes_project_root_from_session(session: &serde_json::Value) -> Option<PathBuf> {
-    ["project_root", "cwd", "workdir", "workDir"]
-        .into_iter()
-        .find_map(|key| value_str(session, key))
+    // A worktree session's effective root is its checkout
+    // (`SessionWorktreeMeta.path`) — the same field the git-vitals
+    // restore scan prefers, so the dirty chip and the Changes tab resolve
+    // the same checkout for the same session.
+    session
+        .get("worktree")
+        .and_then(|worktree| worktree.get("path"))
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
         .map(PathBuf::from)
-        .filter(|path| !path.as_os_str().is_empty())
+        .or_else(|| {
+            ["project_root", "cwd", "workdir", "workDir"]
+                .into_iter()
+                .find_map(|key| value_str(session, key))
+                .map(PathBuf::from)
+                .filter(|path| !path.as_os_str().is_empty())
+        })
 }
 
 pub(crate) fn changes_log_dir_from_session(session: &serde_json::Value) -> Option<PathBuf> {
@@ -1432,6 +1458,198 @@ pub(crate) fn load_external_change_records(
     records
 }
 
+/// Working-tree (git) fallback for the Changes surfaces. The vitals
+/// dirty chip counts `git status` entries for a session's checkout and
+/// its action navigates to the Changes tab — so when the tab's
+/// session-scoped sources (the rewind baseline, the external agent diff
+/// log) have no records while git says the checkout is dirty, the tab
+/// must not contradict the chip with an empty pane. These records derive
+/// from the SAME status invocation and parse the chip's count derives
+/// from (`session_vitals::git_working_tree_status`), so the two surfaces
+/// state the same file set by construction.
+///
+/// Line stats for tracked entries come from one `git diff HEAD
+/// --numstat` pass (`--no-renames` so every path keys exactly);
+/// untracked files synthesize created-file stats from their content.
+fn git_fallback_change_records(project_root: &Path) -> Vec<ChangeRecord> {
+    let Some(facts) = crate::session_vitals::git_working_tree_status(project_root) else {
+        return Vec::new();
+    };
+    if facts.entries.is_empty() {
+        return Vec::new();
+    }
+    let numstat = git_diff_head_numstat(project_root);
+    facts
+        .entries
+        .iter()
+        .map(|entry| git_status_change_record(project_root, entry, numstat.get(&entry.path)))
+        .collect()
+}
+
+/// Kind vocabulary bridge: the shared status parse speaks
+/// created/modified/deleted; ChangeRecord carries the same words.
+fn git_status_entry_kind_str(kind: crate::session_vitals::GitStatusEntryKind) -> &'static str {
+    match kind {
+        crate::session_vitals::GitStatusEntryKind::Created => "created",
+        crate::session_vitals::GitStatusEntryKind::Deleted => "deleted",
+        crate::session_vitals::GitStatusEntryKind::Modified => "modified",
+    }
+}
+
+/// `git diff HEAD --numstat` per-path (added, removed, binary) — one
+/// subprocess for the whole list. Empty on failure (unborn HEAD, no
+/// git): records then carry zero stats but stay listed.
+fn git_diff_head_numstat(project_root: &Path) -> HashMap<String, (u32, u32, bool)> {
+    let mut stats = HashMap::new();
+    let Ok(output) = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["diff", "HEAD", "--no-renames", "--numstat"])
+        .output()
+    else {
+        return stats;
+    };
+    if !output.status.success() {
+        return stats;
+    }
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let mut cols = line.splitn(3, '\t');
+        let (Some(added), Some(removed), Some(path)) = (cols.next(), cols.next(), cols.next())
+        else {
+            continue;
+        };
+        let binary = added == "-" || removed == "-";
+        let added = added.parse().unwrap_or(0);
+        let removed = removed.parse().unwrap_or(0);
+        stats.insert(
+            crate::session_vitals::unquote_git_path(path),
+            (added, removed, binary),
+        );
+    }
+    stats
+}
+
+/// Summary record for one git status entry (no diff body — the list
+/// lane). Untracked text files count their content as additions;
+/// untracked directories and binaries stay listed with an honest
+/// no-textual-diff reason, keeping the row count equal to the chip's.
+fn git_status_change_record(
+    project_root: &Path,
+    entry: &crate::session_vitals::GitStatusEntry,
+    numstat: Option<&(u32, u32, bool)>,
+) -> ChangeRecord {
+    let kind = git_status_entry_kind_str(entry.kind);
+    if let Some((added, removed, binary)) = numstat {
+        return ChangeRecord {
+            path: entry.path.clone(),
+            kind,
+            lines_added: *added,
+            lines_removed: *removed,
+            diff_available: !binary,
+            reason: binary.then(|| "binary file (no textual diff)".to_string()),
+            diff: None,
+        };
+    }
+    if entry.path.ends_with('/') {
+        // Git spends one status line on a whole untracked directory; the
+        // chip counts it as one entry, so the list keeps that shape.
+        return unsupported_change_record(
+            &entry.path,
+            kind,
+            "untracked directory (git lists it as one entry)".to_string(),
+        );
+    }
+    // Untracked file (absent from diff HEAD): stats from its content.
+    match crate::file_watcher::inspect_file(&project_root.join(&entry.path)) {
+        Ok(crate::file_watcher::InspectedFile::Text(snapshot)) => ChangeRecord {
+            path: entry.path.clone(),
+            kind,
+            lines_added: snapshot.text.lines().count() as u32,
+            lines_removed: 0,
+            diff_available: true,
+            reason: None,
+            diff: None,
+        },
+        Ok(crate::file_watcher::InspectedFile::Unsupported(snapshot)) => {
+            unsupported_change_record(&entry.path, kind, snapshot.reason)
+        }
+        Err(_) => ChangeRecord {
+            path: entry.path.clone(),
+            kind,
+            lines_added: 0,
+            lines_removed: 0,
+            diff_available: true,
+            reason: None,
+            diff: None,
+        },
+    }
+}
+
+/// Single-file detail for the git fallback lane. Only paths git itself
+/// listed as dirty are served (the status entry set is the lookup key,
+/// so no request-supplied path ever reaches the filesystem directly).
+/// Tracked entries diff against HEAD (staged + unstaged in one body);
+/// untracked files synthesize a created-file diff from content.
+fn git_fallback_change_record_detail(project_root: &Path, decoded: &str) -> Option<ChangeRecord> {
+    let facts = crate::session_vitals::git_working_tree_status(project_root)?;
+    let entry = facts.entries.iter().find(|entry| entry.path == decoded)?;
+    let kind = git_status_entry_kind_str(entry.kind);
+    if entry.path.ends_with('/') {
+        return Some(unsupported_change_record(
+            &entry.path,
+            kind,
+            "untracked directory (git lists it as one entry)".to_string(),
+        ));
+    }
+    let tracked_diff = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["diff", "HEAD", "--no-renames", "--"])
+        .arg(&entry.path)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).into_owned())
+        .filter(|diff| !diff.trim().is_empty());
+    if let Some(diff) = tracked_diff {
+        let (lines_added, lines_removed) = diff_stats_from_unified_diff(&diff);
+        return Some(ChangeRecord {
+            path: entry.path.clone(),
+            kind,
+            lines_added,
+            lines_removed,
+            diff_available: true,
+            reason: None,
+            diff: Some(diff),
+        });
+    }
+    // Untracked (invisible to `diff HEAD`): synthesize the created-file
+    // diff the snapshot lane would show.
+    match crate::file_watcher::inspect_file(&project_root.join(&entry.path)) {
+        Ok(crate::file_watcher::InspectedFile::Text(snapshot)) => {
+            let diff = crate::file_watcher::compute_unified_diff("", &snapshot.text, &entry.path);
+            let (lines_added, lines_removed) = diff_stats_from_unified_diff(&diff);
+            Some(ChangeRecord {
+                path: entry.path.clone(),
+                kind,
+                lines_added,
+                lines_removed,
+                diff_available: true,
+                reason: None,
+                diff: Some(diff),
+            })
+        }
+        Ok(crate::file_watcher::InspectedFile::Unsupported(snapshot)) => Some(
+            unsupported_change_record(&entry.path, kind, snapshot.reason),
+        ),
+        Err(_) => Some(unsupported_change_record(
+            &entry.path,
+            kind,
+            "file is not readable for a textual diff".to_string(),
+        )),
+    }
+}
+
 pub(crate) fn collect_baseline_text_paths(baseline_dir: &Path) -> HashSet<String> {
     let mut paths = HashSet::new();
     let mut stack = vec![baseline_dir.to_path_buf()];
@@ -1747,6 +1965,17 @@ pub(crate) fn handle_changes_list(
             changes.push(change_record_summary_json(&record));
         }
     }
+    if changes.is_empty() {
+        // The session-scoped sources are empty (nothing changed since the
+        // rewind baseline, no external diff log entries) — but the vitals
+        // dirty chip may still be pointing here for uncommitted state that
+        // predates the baseline. Fall back to the working tree so the two
+        // surfaces agree; a genuinely clean checkout stays empty.
+        changes = git_fallback_change_records(project_root)
+            .iter()
+            .map(change_record_summary_json)
+            .collect();
+    }
     serde_json::to_string(&changes).unwrap_or_else(|_| "[]".to_string())
 }
 
@@ -1953,6 +2182,13 @@ pub(crate) fn handle_changes_file_diff(
             .into_iter()
             .find(|record| record.path == decoded)
             {
+                return ("200 OK", change_record_detail_json(&record).to_string());
+            }
+            // Not a session-scoped change: serve the working-tree diff if
+            // git lists the file as dirty (the state the vitals chip
+            // counted) — the list lane's git fallback hands out exactly
+            // these paths.
+            if let Some(record) = git_fallback_change_record_detail(project_root, &decoded) {
                 return ("200 OK", change_record_detail_json(&record).to_string());
             }
             (
@@ -5724,6 +5960,238 @@ mod tests {
         assert_eq!(status, "200 OK");
         assert_eq!(json["path"], "created.txt");
         assert!(json["diff"].as_str().unwrap().contains("+created"));
+    }
+
+    fn test_git(cwd: &Path, args: &[&str]) {
+        let status = std::process::Command::new("git")
+            .args([
+                "-c",
+                "user.email=t@e2e",
+                "-c",
+                "user.name=t",
+                "-c",
+                "commit.gpgsign=false",
+            ])
+            .args(args)
+            .current_dir(cwd)
+            .status()
+            .expect("spawn git");
+        assert!(status.success(), "git failed: {args:?}");
+    }
+
+    /// USER-REPORTED regression: a native session running in a linked git
+    /// worktree showed the vitals dirty chip, but clicking through to the
+    /// Changes tab rendered nothing — the tab had no session-scoped record
+    /// source (native sessions write no external diff log and never ran a
+    /// watcher), and before the session was targeted at all it served the
+    /// daemon head session's watcher (the wrong checkout entirely). The
+    /// target lane must answer from the session's own worktree via the
+    /// same git status parse the chip counts.
+    #[test]
+    fn changes_request_serves_git_dirty_state_for_native_worktree_session() {
+        let home = tempfile::TempDir::new().unwrap();
+        let root = tempfile::TempDir::new().unwrap();
+        let base = root.path().join("base");
+        let wt = root.path().join("wt");
+        std::fs::create_dir_all(&base).unwrap();
+        test_git(&base, &["init", "-q", "-b", "main"]);
+        std::fs::write(base.join("a.txt"), "one\n").unwrap();
+        test_git(&base, &["add", "."]);
+        test_git(&base, &["commit", "-qm", "base"]);
+        test_git(
+            &base,
+            &["worktree", "add", "-q", wt.to_str().unwrap(), "-b", "session-branch"],
+        );
+        // Dirty the WORKTREE only; the base checkout stays clean, so a
+        // wrong-root resolution yields an empty list and fails the test.
+        std::fs::write(wt.join("a.txt"), "two\n").unwrap();
+        std::fs::write(wt.join("new.txt"), "fresh\n").unwrap();
+
+        let session_id = "native-worktree-session";
+        let session_dir = home.path().join(".intendant/logs").join(session_id);
+        std::fs::create_dir_all(&session_dir).unwrap();
+        // Native session meta: no external markers, no session.jsonl diff
+        // log, no file_snapshots baseline. project_root deliberately
+        // records the BASE root so the test pins the worktree-path
+        // preference (the field the git-vitals restore scan uses).
+        std::fs::write(
+            session_dir.join("session_meta.json"),
+            serde_json::json!({
+                "session_id": session_id,
+                "created_at": "2026-07-17T10:00:00",
+                "project_root": base.to_string_lossy(),
+                "task": "native worktree session",
+                "status": "idle",
+                "worktree": {
+                    "branch": "session-branch",
+                    "path": wt.to_string_lossy(),
+                    "base_root": base.to_string_lossy(),
+                },
+            })
+            .to_string(),
+        )
+        .unwrap();
+        std::fs::write(
+            session_dir.join("session.jsonl"),
+            serde_json::json!({"event": "info", "message": "Session started"}).to_string(),
+        )
+        .unwrap();
+
+        // The daemon head session's live watcher lane: baseline exists,
+        // different project root — reaching it would be the old bug.
+        let live_snapshot = tempfile::TempDir::new().unwrap();
+        let live_project = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(live_snapshot.path().join("baseline")).unwrap();
+
+        let request = format!("GET /api/session/current/changes?session_id={session_id} HTTP/1.1");
+        let (status, body) = handle_changes_request_for_home(
+            &request,
+            Some(live_snapshot.path()),
+            Some(live_project.path()),
+            home.path(),
+        );
+        assert_eq!(status, "200 OK");
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let listed: Vec<(&str, &str)> = json
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|item| {
+                (
+                    item["path"].as_str().unwrap(),
+                    item["kind"].as_str().unwrap(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            listed,
+            vec![("a.txt", "modified"), ("new.txt", "created")],
+            "the session's worktree dirt must be listed: {body}"
+        );
+
+        // Derive-don't-mirror pin: the tab's row count IS the vitals dirty
+        // count — both surfaces come from one status parse of one root.
+        let facts = crate::session_vitals::git_working_tree_status(&wt)
+            .expect("worktree probes like the vitals chip");
+        assert_eq!(json.as_array().unwrap().len() as u32, facts.dirty_files());
+
+        // Single-file diffs: the tracked change diffs against HEAD, the
+        // untracked file synthesizes a created-file diff.
+        let request = format!(
+            "GET /api/session/current/changes/a.txt?session_id={session_id} HTTP/1.1"
+        );
+        let (status, body) = handle_changes_request_for_home(
+            &request,
+            Some(live_snapshot.path()),
+            Some(live_project.path()),
+            home.path(),
+        );
+        assert_eq!(status, "200 OK");
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let diff = json["diff"].as_str().unwrap();
+        assert!(diff.contains("-one") && diff.contains("+two"), "{diff}");
+        assert_eq!(json["lines_added"], 1);
+        assert_eq!(json["lines_removed"], 1);
+
+        let request = format!(
+            "GET /api/session/current/changes/new.txt?session_id={session_id} HTTP/1.1"
+        );
+        let (status, body) = handle_changes_request_for_home(
+            &request,
+            Some(live_snapshot.path()),
+            Some(live_project.path()),
+            home.path(),
+        );
+        assert_eq!(status, "200 OK");
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["kind"], "created");
+        assert!(json["diff"].as_str().unwrap().contains("+fresh"));
+
+        // A path git does not list stays a 404 — the status entry set is
+        // the only key into the filesystem.
+        let request = format!(
+            "GET /api/session/current/changes/absent.txt?session_id={session_id} HTTP/1.1"
+        );
+        let (status, _) = handle_changes_request_for_home(
+            &request,
+            Some(live_snapshot.path()),
+            Some(live_project.path()),
+            home.path(),
+        );
+        assert_eq!(status, "404 Not Found");
+
+        // Committed clean: the fallback states nothing — the chip and the
+        // tab agree on clean too.
+        test_git(&wt, &["add", "."]);
+        test_git(&wt, &["commit", "-qm", "session work"]);
+        let request = format!("GET /api/session/current/changes?session_id={session_id} HTTP/1.1");
+        let (status, body) = handle_changes_request_for_home(
+            &request,
+            Some(live_snapshot.path()),
+            Some(live_project.path()),
+            home.path(),
+        );
+        assert_eq!(status, "200 OK");
+        assert_eq!(body, "[]");
+    }
+
+    /// The live head lane's empty-list fallback: a baseline that already
+    /// captured the dirty content (uncommitted state predating the
+    /// daemon) leaves the watcher lane empty while the vitals chip counts
+    /// the dirt — the list must then answer from the working tree.
+    #[test]
+    fn changes_list_falls_back_to_git_when_snapshot_sources_are_empty() {
+        let repo = tempfile::TempDir::new().unwrap();
+        test_git(repo.path(), &["init", "-q", "-b", "main"]);
+        std::fs::write(repo.path().join("a.txt"), "one\n").unwrap();
+        test_git(repo.path(), &["add", "."]);
+        test_git(repo.path(), &["commit", "-qm", "base"]);
+        // Pre-daemon dirt, then a baseline that mirrors the CURRENT
+        // content — the snapshot lane sees nothing changed.
+        std::fs::write(repo.path().join("a.txt"), "two\n").unwrap();
+        let snapshot = tempfile::TempDir::new().unwrap();
+        let baseline = snapshot.path().join("baseline");
+        std::fs::create_dir_all(&baseline).unwrap();
+        std::fs::write(baseline.join("a.txt"), "two\n").unwrap();
+
+        let (status, body) = handle_changes_request(
+            "GET /api/session/current/changes HTTP/1.1",
+            Some(snapshot.path()),
+            Some(repo.path()),
+        );
+        assert_eq!(status, "200 OK");
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json.as_array().unwrap().len(), 1, "{body}");
+        assert_eq!(json[0]["path"], "a.txt");
+        assert_eq!(json[0]["kind"], "modified");
+
+        let (status, body) = handle_changes_request(
+            "GET /api/session/current/changes/a.txt HTTP/1.1",
+            Some(snapshot.path()),
+            Some(repo.path()),
+        );
+        assert_eq!(status, "200 OK");
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let diff = json["diff"].as_str().unwrap();
+        assert!(diff.contains("-one") && diff.contains("+two"), "{diff}");
+
+        // Session-scoped changes take precedence: once the watcher lane
+        // has a record, the list is the session's own change set again.
+        std::fs::write(repo.path().join("b.txt"), "b\n").unwrap();
+        std::fs::write(baseline.join("b.txt"), "old-b\n").unwrap();
+        let (_, body) = handle_changes_request(
+            "GET /api/session/current/changes HTTP/1.1",
+            Some(snapshot.path()),
+            Some(repo.path()),
+        );
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let listed: Vec<&str> = json
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|item| item["path"].as_str().unwrap())
+            .collect();
+        assert_eq!(listed, vec!["b.txt"], "{body}");
     }
 
     #[test]

--- a/static/app/37-uicommand-changes-control.js
+++ b/static/app/37-uicommand-changes-control.js
@@ -454,15 +454,19 @@ function currentChangesTargetQuery() {
   const win = sessionWindows.get(sid) || null;
   const source = externalSourceForSessionWindow(sid, win)
     || normalizeAgentId(meta.source || meta.backendSource || meta.backend_source || '');
-  if (!source || source === 'intendant') return '';
 
+  // Every selected session is targeted — native sessions included. The
+  // daemon resolves the session's own checkout (worktree sessions probe
+  // their worktree, exactly like the vitals dirty chip); without the id
+  // it can only answer from the daemon head session's watcher, which is
+  // the wrong root for any other session.
   const params = new URLSearchParams();
   params.set('session_id', sid);
   const backendId = String(meta.backendSessionId || meta.backend_session_id || '').trim();
   const intendantId = String(meta.intendantSessionId || meta.intendant_session_id || '').trim();
   if (backendId) params.set('backend_session_id', backendId);
   if (intendantId) params.set('intendant_session_id', intendantId);
-  params.set('source', source);
+  if (source && source !== 'intendant') params.set('source', source);
   return params.toString();
 }
 

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -1142,7 +1142,7 @@ const VITALS_SYMBOLS = {
       `${v.count} file${v.count === 1 ? ' has' : 's have'} changes that aren't committed to git yet.`,
       'Normal while the agent works — they become permanent history once committed.',
     ],
-    action: () => ({ label: 'View the changes', run: () => vitalsOpenChangesTab() }),
+    action: (v, sessionId) => ({ label: 'View the changes', run: () => vitalsOpenChangesTab(sessionId) }),
   },
   divergence: {
     label: 'Ahead / behind',
@@ -2514,7 +2514,14 @@ function vitalsCopyText(text) {
   scratch.remove();
 }
 
-function vitalsOpenChangesTab() {
+function vitalsOpenChangesTab(sessionId) {
+  // The Changes tab targets the CURRENT session — focus the chip's
+  // session first so the tab shows the checkout the chip counted, not
+  // whichever session happened to be current.
+  const sid = String(sessionId || '').trim();
+  if (sid && sid !== currentSessionFullId && typeof focusSessionWindow === 'function') {
+    focusSessionWindow(sid);
+  }
   const btn = document.querySelector('#activity-subtabs [data-activity-tab="changes"]');
   if (btn) btn.click();
 }


### PR DESCRIPTION
## Bug (user-reported, live e2e)

A session's vitals showed the dirty (uncommitted changes) chip; clicking it navigates to the Changes tab — which rendered no changes at all, even though the session's git worktree really was dirty.

## Root cause

Three stacked divergences between the two surfaces:

1. **Wrong root for native sessions.** The dashboard only sent `session_id` targeting on the changes request for *external* sessions. For native sessions (dashboard-spawned, sub-agents, worktree sessions) the daemon answered from the **head session's file watcher** — the daemon's own project root, not the selected session's checkout.
2. **No record source for targeted native sessions.** Even with targeting, a native non-head session has neither a rewind baseline (`file_snapshots/baseline` — only the daemon head session runs a watcher) nor an external agent diff log, so the list was structurally empty while `git status` said dirty.
3. **Different base.** The vitals chip counts `git status --porcelain=v2` entries (uncommitted vs HEAD, untracked included); the tab listed watcher-baseline diffs (changes since daemon start). Pre-daemon uncommitted state shows on the chip and never in the baseline diff.

## Fix (derive, don't mirror)

- `session_vitals::parse_status_v2` now yields per-entry facts (path + created/modified/deleted) and the chip's `dirty_files` count **derives from that entry list** (`StatusFacts::dirty_files()` = `entries.len()`).
- The Changes handlers gain a working-tree fallback that runs the **same status invocation through the same parser against the same resolved checkout** whenever their session-scoped sources (watcher baseline diff, external diff log) produce nothing — so the chip and the tab state the same file set by construction. Session-scoped changes keep precedence when they exist (the rewind timeline semantics are untouched).
- Target resolution prefers the session's worktree checkout (`SessionWorktreeMeta.path`), the same field the git-vitals restore scan uses.
- The dashboard now targets every selected session (native included) with `session_id`, and the dirty chip's "View the changes" action focuses the chip's own session before opening the tab.

## Tests

- `changes_request_serves_git_dirty_state_for_native_worktree_session` — tempdir base repo + `git worktree add`, dirty worktree, native session meta; pins list content, per-file diffs, the 404 for unlisted paths, the clean case, and the derive pin (list length == `dirty_files()` from the same probe).
- `changes_list_falls_back_to_git_when_snapshot_sources_are_empty` — head-lane pre-existing dirt: baseline mirrors current content (watcher-empty) while git is dirty; also pins session-scoped precedence once the watcher has records.
- `status_v2_entry_kinds_and_quoting` — entry kinds (add/delete/rename/untracked dir) and C-style path unquoting.