### PR TITLE
dashboard: measure composer autosize instead of estimating

### DIFF
--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -346,32 +346,52 @@ function renderWorktreeFinishCard(win, sid, info, options = {}) {
 }
 
 const TASK_TEXTAREA_MIN_HEIGHT_PX = 28;
+// Fallback cap for states whose CSS declares no max-height. When the
+// stylesheet does declare one (120px desktop composer, em-based caps on
+// phones, 180px new-session form), the computed value wins — resolved
+// fresh on every pass because it is state-dependent (media queries,
+// :focus-within widening the phone cap).
 const TASK_TEXTAREA_MAX_HEIGHT_PX = 120;
-const TASK_TEXTAREA_ESTIMATED_LINE_HEIGHT_PX = 17;
-const TASK_TEXTAREA_VERTICAL_PADDING_PX = 10;
-const TASK_TEXTAREA_ESTIMATED_CHARS_PER_LINE = 72;
 
-function estimateTaskTextareaRows(value) {
-  const text = String(value || '');
-  if (!text) return 1;
-  return text.split('\n').reduce((rows, line) => {
-    return rows + Math.max(1, Math.ceil(line.length / TASK_TEXTAREA_ESTIMATED_CHARS_PER_LINE));
-  }, 0);
-}
-
+// Measured autosize (grow *and* shrink) for the composer/new-session
+// textareas. Sizing must come from a real layout measurement: the
+// char-count estimate this replaces (72 chars/line at 17px, from the
+// 8a91c0ef reconnect-perf pass) predated the ui-v2 chrome and undershot
+// real wrapping (13.5px/16px fonts, narrow flex bars), then hid the
+// shortfall with overflow-y:hidden — multi-line drafts clipped mid-glyph
+// with no scrollbar. One forced reflow per call; typing is rAF-deduped
+// via scheduleTaskTextareaResize.
 function resizeTaskTextarea(input) {
   if (!input || input.tagName !== 'TEXTAREA') return;
   input._taskResizeFrame = 0;
-  const rows = estimateTaskTextareaRows(input.value);
-  const height = Math.min(
-    TASK_TEXTAREA_MAX_HEIGHT_PX,
-    Math.max(
-      TASK_TEXTAREA_MIN_HEIGHT_PX,
-      rows * TASK_TEXTAREA_ESTIMATED_LINE_HEIGHT_PX + TASK_TEXTAREA_VERTICAL_PADDING_PX,
-    ),
-  );
-  input.style.height = `${height}px`;
-  input.style.overflowY = height >= TASK_TEXTAREA_MAX_HEIGHT_PX ? 'auto' : 'hidden';
+  // display:none (pilled composer, closed new-session view) measures 0 —
+  // keep the last real height and let the reveal seams (ResizeObserver,
+  // ui2:composer-state, focusNewSessionInput) re-measure once visible.
+  // getClientRects, not offsetParent: the ui-v2 dock is position:fixed,
+  // whose offsetParent is null even when visible.
+  if (input.getClientRects().length === 0) return;
+  const prevScrollTop = input.scrollTop;
+  input.style.height = 'auto';
+  const cssMax = Number.parseFloat(window.getComputedStyle(input).maxHeight);
+  const maxHeight = Number.isFinite(cssMax) && cssMax > 0 ? cssMax : TASK_TEXTAREA_MAX_HEIGHT_PX;
+  // border-box: the height style includes borders; scrollHeight (content
+  // + padding) does not. wrap=soft, so offsetHeight - clientHeight is
+  // borders only (no horizontal scrollbar).
+  const borderHeight = input.offsetHeight - input.clientHeight;
+  const contentHeight = input.scrollHeight + borderHeight;
+  const overflowing = contentHeight > maxHeight;
+  input.style.height = `${Math.max(TASK_TEXTAREA_MIN_HEIGHT_PX, Math.min(maxHeight, contentHeight))}px`;
+  // Scroll only at the cap. Below it the height *is* the content height,
+  // so hidden cannot clip — it just suppresses rounding-ghost scrollbars.
+  // Never hidden with content beyond the cap: that is the silent clip
+  // this function exists to prevent.
+  input.style.overflowY = overflowing ? 'auto' : 'hidden';
+  if (overflowing) {
+    // Keep the caret in view while typing at the end; preserve the
+    // browser's own scroll decision for mid-text edits.
+    const caretAtEnd = input.selectionEnd >= input.value.length;
+    input.scrollTop = caretAtEnd ? input.scrollHeight : prevScrollTop;
+  }
 }
 
 function scheduleTaskTextareaResize(input) {
@@ -515,6 +535,28 @@ function wireTaskTextarea(id, submit) {
     e.preventDefault();
     submit();
   });
+  // Height depends on the wrap width and on state-dependent CSS (siblings
+  // appear/disappear around the flex bar; the phone composer's max-height
+  // widens on :focus-within), so re-measure whenever the box or the focus
+  // state changes — not only on typed input. The width guard stops
+  // observer feedback: our own height writes never change the width.
+  input.addEventListener('focus', () => scheduleTaskTextareaResize(input));
+  input.addEventListener('blur', () => scheduleTaskTextareaResize(input));
+  if (typeof ResizeObserver === 'function') {
+    input._taskResizeObserver = new ResizeObserver((entries) => {
+      const width = entries[entries.length - 1].contentRect.width;
+      if (width === input._taskLastMeasuredWidth) return;
+      input._taskLastMeasuredWidth = width;
+      scheduleTaskTextareaResize(input);
+    });
+    input._taskResizeObserver.observe(input);
+  } else {
+    window.addEventListener('resize', () => scheduleTaskTextareaResize(input));
+  }
+  // Pill → expanded flips the dock's children from display:none; the
+  // observer fires on the reveal too, but this seam is the deterministic
+  // one (and the only one when ResizeObserver is unavailable).
+  window.addEventListener('ui2:composer-state', () => scheduleTaskTextareaResize(input));
   resizeTaskTextarea(input);
 }
 

--- a/static/app/54-session-lifecycle.js
+++ b/static/app/54-session-lifecycle.js
@@ -560,6 +560,33 @@ function wireTaskTextarea(id, submit) {
   resizeTaskTextarea(input);
 }
 
+// QA readback (window.qa convention): the composer-autosize verdict. The
+// regression class is silent — content taller than the box under
+// overflow-y:hidden shows no scrollbar, so the user types blind — and
+// the programmatic seams live in this module scope, unreachable from a
+// CDP probe otherwise.
+window.qa = Object.assign(window.qa || {}, {
+  composerAutosize: (id = 'activity-task-input') => {
+    const input = document.getElementById(id);
+    if (!input) return null;
+    const cs = window.getComputedStyle(input);
+    return {
+      height: input.getBoundingClientRect().height,
+      clientHeight: input.clientHeight,
+      scrollHeight: input.scrollHeight,
+      scrollTop: input.scrollTop,
+      overflowY: cs.overflowY,
+      maxHeight: cs.maxHeight,
+      visible: input.getClientRects().length > 0,
+      clipped: input.scrollHeight > input.clientHeight + 1 && cs.overflowY === 'hidden',
+    };
+  },
+  composerSetValue: (text, id = 'activity-task-input') =>
+    setTaskTextareaValue(document.getElementById(id), text),
+  composerClear: (id = 'activity-task-input') =>
+    clearTaskTextarea(document.getElementById(id)),
+});
+
 // Implicit resumes (auto-attach after a dropped follow-up, station/window
 // reattach) carry NO launch overrides: the daemon owns each session's
 // persisted launch config and applies it itself. Echoing dashboard-derived


### PR DESCRIPTION
The composer/new-session textarea height came from a character-count
estimate (72 chars/line at 17px line-height, from the reconnect-perf
pass) that predates the ui-v2 chrome. Under ui-v2 geometry (13.5px/16px
fonts, narrow flex bars, em-based phone caps) the estimate undershoots
real wrapping, and the inline overflow-y:hidden it set below the cap hid
the shortfall: multi-line drafts clipped mid-glyph with no scrollbar and
typing went blind.

Replace the estimate with a real scrollHeight measurement on the same
seam (collapse to auto, measure, clamp) with the effective max-height
resolved fresh from computed style each pass — it is state-dependent
(120px desktop, em caps on phones that widen on :focus-within, 180px
new-session). overflow-y switches to auto exactly when content exceeds
the cap, with the caret kept in view when typing at the end; below the
cap the height equals the content height so nothing can clip. Skip
measurement while display:none (pilled dock, closed new-session view)
and re-measure on the reveal/geometry seams instead: a width-guarded
ResizeObserver on each textarea, focus/blur, and the ui2:composer-state
event (window-resize fallback when ResizeObserver is unavailable).
