### PR TITLE
dashboard: composer peek — last message scrollable to its true end

### DIFF
--- a/static/app/ui2-composer-peek.css
+++ b/static/app/ui2-composer-peek.css
@@ -170,6 +170,15 @@ html.ui-v2 .ui2-composer-peek .log-entry .log-content {
   max-height: 8.5em;
   overflow: hidden;
 }
+/* …but never the LAST entry: content clipped INSIDE an entry is not in
+   the list's scroll flow, so the tail of a long latest message was
+   unreachable — the list hit scroll-bottom while the fade obscured the
+   end permanently. Unclamped, the list scroller carries the full tail.
+   max-height:none (not a larger cap) so this also keeps superseding the
+   base collapsible 1.5em clamp, exactly like the 8.5em rule it lifts. */
+html.ui-v2 .ui2-composer-peek .log-entry:last-child .log-content {
+  max-height: none;
+}
 html.ui-v2 .ui2-composer-peek .log-entry:not(.ui2-peek-clamped) .log-content::after { content: none; }
 html.ui-v2 .ui2-composer-peek .log-entry.ui2-peek-clamped .log-content::after {
   content: '';
@@ -183,10 +192,33 @@ html.ui-v2 .ui2-composer-peek .log-entry.ui2-peek-clamped .log-content::after {
   background: linear-gradient(to bottom, transparent, var(--surface));
   pointer-events: none;
 }
-html.ui-v2 .ui2-composer-peek .diff-log-entry .diff-log-body {
+/* diff bodies: same digest clamp, same last-entry exemption — unscoped,
+   the trailing diff falls back to the base .diff-log-body scroll box
+   (max-height 460px, overflow auto), so its tail stays readable in
+   place instead of hard-clipping. */
+html.ui-v2 .ui2-composer-peek .diff-log-entry:not(:last-child) .diff-log-body {
   max-height: 8.5em;
   overflow: hidden;
 }
+
+/* container-level "more below" cue: pinned to the sheet, not the scroll
+   content, and visible only while unread lines sit below the viewport —
+   JS toggles the class from scroll position, so the fade signals
+   direction and vanishes at scroll-bottom instead of ever sitting on
+   the tail. The root's overflow:hidden clips it to the rounded box. */
+html.ui-v2 .ui2-composer-peek::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 26px;
+  background: linear-gradient(to bottom, transparent, var(--surface));
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--t-fast) ease;
+}
+html.ui-v2 .ui2-composer-peek.ui2-peek-more-below::after { opacity: 1; }
 
 /* — phones: keep the header one quiet row — */
 @media (max-width: 500px) {

--- a/static/app/ui2-composer-peek.css
+++ b/static/app/ui2-composer-peek.css
@@ -170,13 +170,16 @@ html.ui-v2 .ui2-composer-peek .log-entry .log-content {
   max-height: 8.5em;
   overflow: hidden;
 }
-/* …but never the LAST entry: content clipped INSIDE an entry is not in
-   the list's scroll flow, so the tail of a long latest message was
-   unreachable — the list hit scroll-bottom while the fade obscured the
-   end permanently. Unclamped, the list scroller carries the full tail.
-   max-height:none (not a larger cap) so this also keeps superseding the
-   base collapsible 1.5em clamp, exactly like the 8.5em rule it lifts. */
-html.ui-v2 .ui2-composer-peek .log-entry:last-child .log-content {
+/* …but never the TAIL entry — the last one that actually clips, marked
+   .ui2-peek-tail-open by JS. :last-child is not enough: completion meta
+   lines (Done / Round complete) trail the final message. Content
+   clipped INSIDE an entry is not in the list's scroll flow, so the tail
+   of a long latest message was unreachable — the list hit scroll-bottom
+   while the fade obscured the end permanently. Opened, the list
+   scroller carries the full text. max-height:none (not a larger cap)
+   so this also keeps superseding the base collapsible 1.5em clamp,
+   exactly like the 8.5em rule it lifts. */
+html.ui-v2 .ui2-composer-peek .log-entry.ui2-peek-tail-open .log-content {
   max-height: none;
 }
 html.ui-v2 .ui2-composer-peek .log-entry:not(.ui2-peek-clamped) .log-content::after { content: none; }
@@ -192,11 +195,11 @@ html.ui-v2 .ui2-composer-peek .log-entry.ui2-peek-clamped .log-content::after {
   background: linear-gradient(to bottom, transparent, var(--surface));
   pointer-events: none;
 }
-/* diff bodies: same digest clamp, same last-entry exemption — unscoped,
-   the trailing diff falls back to the base .diff-log-body scroll box
-   (max-height 460px, overflow auto), so its tail stays readable in
-   place instead of hard-clipping. */
-html.ui-v2 .ui2-composer-peek .diff-log-entry:not(:last-child) .diff-log-body {
+/* diff bodies: same digest clamp, same tail exemption — on the tail
+   entry the body falls back to the base .diff-log-body scroll box
+   (max-height 460px, overflow auto), so a trailing diff stays readable
+   in place instead of hard-clipping. */
+html.ui-v2 .ui2-composer-peek .diff-log-entry:not(.ui2-peek-tail-open) .diff-log-body {
   max-height: 8.5em;
   overflow: hidden;
 }

--- a/static/app/ui2-composer-peek.js
+++ b/static/app/ui2-composer-peek.js
@@ -84,12 +84,24 @@
   }
 
   // CSS cannot see overflow: entries whose body actually clips get the
-  // fade tag; short ones keep their last line un-washed.
+  // fade tag; short ones — and the never-clamped last entry — keep their
+  // final line un-washed. Toggle, not add: an entry's clamp state flips
+  // when a newer entry arrives and it stops being :last-child (or the
+  // reverse on a structural removal), so kept clones re-tag too.
   function peekTagClamped(clone) {
     const content = clone.querySelector('.log-content');
-    if (content && content.scrollHeight > content.clientHeight + 1) {
-      clone.classList.add('ui2-peek-clamped');
-    }
+    if (!content) return;
+    clone.classList.toggle('ui2-peek-clamped', content.scrollHeight > content.clientHeight + 1);
+  }
+
+  // The container-level "more below" fade must never obscure the tail:
+  // it shows only while unread content sits below the viewport and goes
+  // away at scroll-bottom. Re-synced on scroll and after every render
+  // (content growth changes scrollHeight without firing scroll).
+  function peekSyncMoreBelow() {
+    if (!peekRoot || !peekList) return;
+    const more = peekList.scrollHeight - peekList.scrollTop - peekList.clientHeight > 1;
+    peekRoot.classList.toggle('ui2-peek-more-below', more);
   }
 
   function peekRenderTail() {
@@ -102,11 +114,11 @@
       empty.className = 'ui2-peek-empty';
       empty.textContent = peekEmptyText();
       peekList.replaceChildren(empty);
+      peekSyncMoreBelow();
       return;
     }
     const prev = new Map(peekRendered.map(r => [r.source, r]));
     const next = [];
-    const fresh = [];
     for (const source of sources) {
       const kept = prev.get(source);
       if (kept && !peekPendingDirty.has(source)) {
@@ -115,7 +127,6 @@
       }
       const clone = peekCloneEntry(source);
       next.push({ source, clone });
-      fresh.push(clone);
     }
     peekRendered = next;
     // Surgical reconcile instead of replaceChildren: kept nodes never
@@ -132,9 +143,13 @@
       if (r.clone === cursor) cursor = cursor.nextElementSibling;
       else peekList.insertBefore(r.clone, cursor);
     }
-    for (const clone of fresh) peekTagClamped(clone);
+    // Every rendered clone, not just fresh ones: appending an entry
+    // moves the clamp off the old :last-child, and kept clones must
+    // gain/lose the fade tag with it.
+    for (const r of next) peekTagClamped(r.clone);
     peekPendingDirty.clear();
     if (peekFollow) peekList.scrollTop = peekList.scrollHeight;
+    peekSyncMoreBelow();
   }
 
   function peekFlush() {
@@ -160,7 +175,10 @@
       touched = true;
     }
     peekPendingDirty.clear();
-    if (touched && peekFollow) peekList.scrollTop = peekList.scrollHeight;
+    if (touched) {
+      if (peekFollow) peekList.scrollTop = peekList.scrollHeight;
+      peekSyncMoreBelow();
+    }
   }
 
   function peekSchedule() {
@@ -241,6 +259,7 @@
       peekFlushTimer = 0;
     }
     if (peekList) peekList.replaceChildren();
+    peekRoot.classList.remove('ui2-peek-more-below');
   }
 
   // "Open in Activity" is a lie when the user is ALREADY on Activity —
@@ -406,6 +425,7 @@
     });
     peekList.addEventListener('scroll', () => {
       peekFollow = peekList.scrollTop + peekList.clientHeight >= peekList.scrollHeight - 24;
+      peekSyncMoreBelow();
     });
   }
 

--- a/static/app/ui2-composer-peek.js
+++ b/static/app/ui2-composer-peek.js
@@ -83,15 +83,31 @@
     return 'No output yet';
   }
 
-  // CSS cannot see overflow: entries whose body actually clips get the
-  // fade tag; short ones — and the never-clamped last entry — keep their
-  // final line un-washed. Toggle, not add: an entry's clamp state flips
-  // when a newer entry arrives and it stops being :last-child (or the
-  // reverse on a structural removal), so kept clones re-tag too.
-  function peekTagClamped(clone) {
-    const content = clone.querySelector('.log-content');
-    if (!content) return;
-    clone.classList.toggle('ui2-peek-clamped', content.scrollHeight > content.clientHeight + 1);
+  // CSS cannot see overflow, and "the tail" is not simply :last-child —
+  // completion meta lines (Done / Round complete) trail the final
+  // message. Two-phase pass over every rendered clone: measure each one
+  // under the digest clamp, then open the LAST entry that actually
+  // clips (the newest clipping content is the conversation tail the
+  // user must be able to finish reading — the list scroller carries
+  // it), and fade-tag the earlier clippers, whose full text is one tap
+  // away in Activity. Re-run on every render: appends and in-place
+  // growth both move which entry is the tail.
+  function peekRetagClamped() {
+    for (const r of peekRendered) r.clone.classList.remove('ui2-peek-tail-open');
+    const measured = [];
+    for (const r of peekRendered) {
+      const content = r.clone.querySelector('.log-content');
+      measured.push([r.clone, !!content && content.scrollHeight > content.clientHeight + 1]);
+    }
+    let tailOpen = null;
+    for (let i = measured.length - 1; i >= 0; i--) {
+      if (measured[i][1]) { tailOpen = measured[i][0]; break; }
+    }
+    for (const [clone, clips] of measured) {
+      const isTail = clone === tailOpen;
+      clone.classList.toggle('ui2-peek-tail-open', isTail);
+      clone.classList.toggle('ui2-peek-clamped', clips && !isTail);
+    }
   }
 
   // The container-level "more below" fade must never obscure the tail:
@@ -143,10 +159,7 @@
       if (r.clone === cursor) cursor = cursor.nextElementSibling;
       else peekList.insertBefore(r.clone, cursor);
     }
-    // Every rendered clone, not just fresh ones: appending an entry
-    // moves the clamp off the old :last-child, and kept clones must
-    // gain/lose the fade tag with it.
-    for (const r of next) peekTagClamped(r.clone);
+    peekRetagClamped();
     peekPendingDirty.clear();
     if (peekFollow) peekList.scrollTop = peekList.scrollHeight;
     peekSyncMoreBelow();
@@ -171,11 +184,13 @@
       const clone = peekCloneEntry(r.source);
       r.clone.replaceWith(clone);
       r.clone = clone;
-      peekTagClamped(clone);
       touched = true;
     }
     peekPendingDirty.clear();
     if (touched) {
+      // Full re-tag, not per-clone: in-place growth (streaming output)
+      // can turn a short entry into the new tail clipper.
+      peekRetagClamped();
       if (peekFollow) peekList.scrollTop = peekList.scrollHeight;
       peekSyncMoreBelow();
     }


### PR DESCRIPTION
## Bug

The composer conversation peek clamps every entry's `.log-content` at `max-height: 8.5em; overflow: hidden` — including the newest message. Content clipped inside an entry is not part of the peek list's scroll flow, so when the latest message is long its tail is unreachable: the list hits scroll-bottom while the clamp fade sits on the last visible lines permanently. The full message was only readable by leaving the composer and opening Activity.

## Fix (fragments only; no daemon changes)

- **Tail exemption** — the last entry that *actually clips* (not merely `:last-child`: completion meta lines like "Done" / "Round complete" trail the final message) is marked `ui2-peek-tail-open` and never clamps, so the list scroller carries its full text and scroll-bottom is the true end. A two-phase pass measures every rendered clone under the clamp, opens the newest clipper, and fade-tags the earlier ones; it re-runs on renders and in-place growth, so the marker follows appends and streaming output. Older entries keep the digest clamp + per-entry fade (deliberate peek design; full text is one tap away in Activity).
- **Tail diff bodies** fall back to the base `.diff-log-body` scroll box (`max-height: 460px; overflow: auto`) instead of hard-clipping (clamp scoped `:not(.ui2-peek-tail-open)`).
- **Container-level "more below" fade**, toggled from scroll position: visible only while unread content sits below the viewport, gone at scroll-bottom. A fade now only ever signals direction; it never obscures the end of the transcript.

## Verification

Headless CDP run (`scripts/validate-dashboard.cjs`) against a hermetic mock-provider daemon (`PROVIDER=mock`, temp HOME, throwaway port), driving the real composer flow (`submitActivityOrSteer`) so the transcript ends with completion metas after a ~50-line final message, with a ~30-line message mid-transcript:

- Fixed build, at list scroll-bottom: final entry `hiddenTailPx = 0`, tail-marked, no fade tag, sentinel last line inside the viewport (`finalEndVisible: true`); list scrollHeight 1292.
- Old rules reconstructed on the same DOM (injecting the previous unconditional clamp): list scrollHeight collapses to 423 and the final entry hides 869px that no amount of list scrolling can reach (`finalEndVisible: false` at `atListEnd: true`) — the reported bug, reproduced and then eliminated by removing the injection.
- Mid long entry: stays clamped + fade-tagged (`hiddenTailPx = 494`) — digest behavior preserved.
- Container fade class: present at `scrollTop = 0`, absent at scroll-bottom.
- Screenshot confirms the peek scrolled to the true end of the final message with no fade on the tail.

Battery: `cargo fmt --check` clean, `cargo clippy` clean, `cargo test --bins` green, app.html regenerated by the assembler (committed with the fragments).
