### PR TITLE
connect: run persist_locked's store write off the async workers

### DIFF
--- a/src/bin/connect/accounts.rs
+++ b/src/bin/connect/accounts.rs
@@ -146,7 +146,7 @@ pub(crate) async fn record_verified_attestation(
         None,
         json!({ "kind": kind, "subject": subject }),
     );
-    persist_locked(state, &store)?;
+    persist_locked(state, &store).await?;
     Ok(json!({ "ok": true, "kind": kind, "subject": subject }))
 }
 
@@ -383,7 +383,7 @@ pub(crate) async fn admin_invites_mint(
             None,
             json!({ "count": count, "label": label, "max_uses": max_uses }),
         );
-        persist_locked(&state, &store)?;
+        persist_locked(&state, &store).await?;
     }
     Ok(Json(
         json!({ "ok": true, "codes": codes, "max_uses": max_uses }),
@@ -454,7 +454,7 @@ pub(crate) async fn admin_invites_revoke(
                 None,
                 json!({ "count": revoked }),
             );
-            persist_locked(&state, &store)?;
+            persist_locked(&state, &store).await?;
         }
     }
     Ok(Json(json!({ "ok": true, "revoked": revoked })))
@@ -980,7 +980,7 @@ pub(crate) async fn auth_register_finish(
             None,
             json!({ "account_name": pending.account_name }),
         );
-        persist_locked(&state, &store)?;
+        persist_locked(&state, &store).await?;
         store
             .users
             .iter()
@@ -1100,7 +1100,7 @@ pub(crate) async fn auth_login_finish(
             None,
             json!({ "account_name": user.account_name }),
         );
-        persist_locked(&state, &store)?;
+        persist_locked(&state, &store).await?;
         user
     };
     let (token, csrf_token) = create_session(&state, user.id).await;

--- a/src/bin/connect/fleet.rs
+++ b/src/bin/connect/fleet.rs
@@ -127,7 +127,7 @@ pub(crate) async fn api_fleet_targets_sync(
     }
     let mut store = state.store.lock().await;
     if merge_fleet_targets(&mut store, user.id, incoming) {
-        persist_locked(&state, &store)?;
+        persist_locked(&state, &store).await?;
     }
     let targets = fleet_targets_for_user(&state.config, &store, user.id);
     Ok(Json(json!({
@@ -258,7 +258,7 @@ pub(crate) async fn api_fleet_target_forget(
             Some(target_id.clone()),
             json!({ "removed": removed }),
         );
-        persist_locked(&state, &store)?;
+        persist_locked(&state, &store).await?;
     }
     let targets = fleet_targets_for_user(&state.config, &store, user.id);
     Ok(Json(json!({
@@ -573,8 +573,9 @@ pub(crate) async fn api_daemon_revoke(
             );
             Ok(())
         },
-        |next| persist_locked(&state, next),
-    )?;
+        async |next| persist_locked(&state, next).await,
+    )
+    .await?;
     drop(store);
     close_active_dashboard_sessions(&state, &daemon_id, active_session_ids).await;
     log_json(
@@ -650,7 +651,7 @@ pub(crate) async fn api_daemon_label(
         Some(daemon_id.clone()),
         json!({ "label": label }),
     );
-    persist_locked(&state, &store)?;
+    persist_locked(&state, &store).await?;
     Ok(Json(json!({ "ok": true, "daemon": view })))
 }
 
@@ -815,7 +816,7 @@ pub(crate) async fn api_vault_publish(
         now_unix_ms(),
     )?;
     if stored {
-        persist_locked(&state, &store)?;
+        persist_locked(&state, &store).await?;
     }
     Ok(Json(
         json!({ "ok": true, "stored": stored, "revision": body.revision }),

--- a/src/bin/connect/main.rs
+++ b/src/bin/connect/main.rs
@@ -1503,13 +1503,31 @@ fn fsync_parent_dir(parent: &Path) -> Result<(), String> {
     Ok(())
 }
 
-/// Persist the current store synchronously, before the caller's response.
-/// Callers hold the store lock, so the bytes are a consistent snapshot and
+/// Persist the current store, before the caller's response. Callers hold
+/// the store lock, so the serialized bytes are a consistent snapshot and
 /// the write covers anything the debounced flusher had pending — hence the
 /// dirty flag is cleared on success (marks only ever happen under the same
 /// lock, so none can slip between the write and the clear).
-fn persist_locked(state: &AppState, store: &Store) -> ApiResult<()> {
-    save_store(&state.config.data_file, store).map_err(ApiError::internal)?;
+///
+/// The serialize happens under the lock; the blocking file I/O (tempfile
+/// write + fsync + rename + parent-dir fsync) runs on `spawn_blocking` so
+/// it never parks an async worker — with the store lock still HELD across
+/// the await. That lock-across-write is deliberate, not an oversight: as
+/// documented on `store_flush_monitor_with`, the single-writer ordering
+/// that keeps the file from ever regressing to an older snapshot IS the
+/// lock held over the write.
+async fn persist_locked(state: &AppState, store: &Store) -> ApiResult<()> {
+    let bytes = serialize_store(store).map_err(ApiError::internal)?;
+    let path = state.config.data_file.clone();
+    match tokio::task::spawn_blocking(move || write_store_bytes(&path, &bytes)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => return Err(ApiError::internal(err)),
+        Err(err) => {
+            return Err(ApiError::internal(format!(
+                "store persist task failed: {err}"
+            )))
+        }
+    }
     state.store_dirty.clear();
     Ok(())
 }
@@ -1663,14 +1681,14 @@ async fn sweep_in_memory_state(state: &AppState) {
 /// next state first, then publish it to the in-memory store. A failed disk
 /// write therefore cannot leave memory ahead of durable state and poison an
 /// otherwise valid retry (notably account/daemon route release).
-fn update_store_transaction<R>(
+async fn update_store_transaction<R>(
     store: &mut Store,
     mutate: impl FnOnce(&mut Store) -> ApiResult<R>,
-    persist: impl FnOnce(&Store) -> ApiResult<()>,
+    persist: impl AsyncFnOnce(&Store) -> ApiResult<()>,
 ) -> ApiResult<R> {
     let mut next = store.clone();
     let result = mutate(&mut next)?;
-    persist(&next)?;
+    persist(&next).await?;
     *store = next;
     Ok(result)
 }
@@ -2046,13 +2064,32 @@ mod tests {
         let state = production_router_test_state(root.path(), store_with_marker());
         let store = state.store.lock().await;
         mark_store_dirty(&state);
-        persist_locked(&state, &store).unwrap();
+        persist_locked(&state, &store).await.unwrap();
         assert!(
             !state.store_dirty.take(),
             "successful sync persist covers pending marks"
         );
         let on_disk = load_store(&state.config.data_file).unwrap();
         assert_eq!(on_disk.users.len(), 1);
+    }
+
+    /// A failed write must NOT clear the debounce mark: the mutations are
+    /// still memory-only, and the mark is what makes the flusher retry.
+    #[tokio::test]
+    async fn persist_failure_keeps_the_dirty_mark() {
+        let root = tempfile::tempdir().unwrap();
+        // A regular file where the state dir should be makes every write
+        // attempt fail without touching anything outside the tempdir.
+        let blocked = root.path().join("blocked");
+        std::fs::write(&blocked, b"not a directory").unwrap();
+        let state = production_router_test_state(&blocked, store_with_marker());
+        let store = state.store.lock().await;
+        mark_store_dirty(&state);
+        assert!(persist_locked(&state, &store).await.is_err());
+        assert!(
+            state.store_dirty.take(),
+            "failed persist must keep the dirty mark for the flusher retry"
+        );
     }
 
     #[tokio::test]

--- a/src/bin/connect/push.rs
+++ b/src/bin/connect/push.rs
@@ -317,7 +317,7 @@ pub(crate) async fn push_subscribe(
             None,
             json!({}),
         );
-        persist_locked(&state, &store)?;
+        persist_locked(&state, &store).await?;
     }
     Ok(Json(json!({ "ok": true })))
 }
@@ -344,7 +344,7 @@ pub(crate) async fn push_unsubscribe(
         });
         let removed = before - store.push_subscriptions.len();
         if removed > 0 {
-            persist_locked(&state, &store)?;
+            persist_locked(&state, &store).await?;
         }
         removed
     };
@@ -410,7 +410,7 @@ pub(crate) async fn push_preferences(
             record.notify_requests = value;
         }
         let flags = (record.notify_presence, record.notify_requests);
-        persist_locked(&state, &store)?;
+        persist_locked(&state, &store).await?;
         flags
     };
     Ok(Json(json!({
@@ -604,7 +604,7 @@ pub(crate) async fn daemon_notify(
             Some(daemon_id.clone()),
             json!({ "kind": body.kind, "sent": sent }),
         );
-        persist_locked(&state, &store)?;
+        persist_locked(&state, &store).await?;
     }
     Ok(Json(
         json!({ "ok": true, "sent": sent, "pruned": dead.len() }),
@@ -643,7 +643,7 @@ pub(crate) async fn push_test(
         store
             .push_subscriptions
             .retain(|record| !dead.contains(&record.endpoint));
-        persist_locked(&state, &store)?;
+        persist_locked(&state, &store).await?;
     }
     Ok(Json(
         json!({ "ok": true, "sent": sent, "pruned": dead.len() }),
@@ -741,7 +741,7 @@ pub(crate) async fn presence_alert_monitor(state: Arc<AppState>) {
             store
                 .push_subscriptions
                 .retain(|record| !dead.contains(&record.endpoint));
-            if let Err(err) = persist_locked(&state, &store) {
+            if let Err(err) = persist_locked(&state, &store).await {
                 eprintln!("[push] failed to persist pruned subscriptions: {err:?}");
             }
         }
@@ -812,7 +812,7 @@ pub(crate) async fn handle_reclaim_monitor(state: Arc<AppState>) {
             );
             eprintln!("[reclaim] freed dormant handle {freed} (account renamed to {renamed_to})");
         }
-        if let Err(err) = persist_locked(&state, &store) {
+        if let Err(err) = persist_locked(&state, &store).await {
             eprintln!("[reclaim] failed to persist dormant-handle reclamation: {err:?}");
         }
     }

--- a/src/bin/connect/relay.rs
+++ b/src/bin/connect/relay.rs
@@ -646,7 +646,7 @@ pub(crate) async fn dns_relay(
             Some(daemon_id.clone()),
             json!({ "name": name, "enable": body.enable }),
         );
-        persist_locked(&state, &store)?;
+        persist_locked(&state, &store).await?;
     }
     Ok(Json(json!({
         "ok": true,

--- a/src/bin/connect/rendezvous.rs
+++ b/src/bin/connect/rendezvous.rs
@@ -103,8 +103,9 @@ pub(crate) async fn api_claim_start(
                     now_unix_ms(),
                 )
             },
-            |next| persist_locked(&state, next),
-        )?;
+            async |next| persist_locked(&state, next).await,
+        )
+        .await?;
     }
     state.pending_claims.lock().await.insert(
         claim_id.clone(),
@@ -704,7 +705,10 @@ pub(crate) async fn daemon_register(
     let registration = {
         let mut store = state.store.lock().await;
         let now = now_unix_ms();
-        let durable_change = std::cell::Cell::new(true);
+        // AtomicBool, not Cell: the persist closure below is async and its
+        // borrow lives across `persist_locked`'s await, and `&Cell` is
+        // !Send (it would un-Send the whole handler future).
+        let durable_change = std::sync::atomic::AtomicBool::new(true);
         let registration = update_store_transaction(
             &mut store,
             |next| {
@@ -729,7 +733,7 @@ pub(crate) async fn daemon_register(
                         }
                     }
                 }
-                durable_change.set(outcome.durable_change);
+                durable_change.store(outcome.durable_change, std::sync::atomic::Ordering::Relaxed);
                 Ok(outcome)
             },
             // Everything with a security effect — including the proof
@@ -737,14 +741,15 @@ pub(crate) async fn daemon_register(
             // minted below — persists before publication, exactly as
             // before. Only proof-less presence refreshes (operator probes)
             // skip the fsync and ride the debounced flusher.
-            |next| {
-                if durable_change.get() {
-                    persist_locked(&state, next)
+            async |next| {
+                if durable_change.load(std::sync::atomic::Ordering::Relaxed) {
+                    persist_locked(&state, next).await
                 } else {
                     Ok(())
                 }
             },
-        )?;
+        )
+        .await?;
         if !registration.durable_change {
             mark_store_dirty(&state);
         }
@@ -1243,7 +1248,7 @@ pub(crate) async fn daemon_answer(
             Some(pending.daemon_id),
             json!({ "request_id": body.request_id, "session_id": answer_session_id }),
         );
-        persist_locked(&state, &store)?;
+        persist_locked(&state, &store).await?;
     }
     Ok(Json(json!({ "ok": true })))
 }
@@ -1415,7 +1420,7 @@ pub(crate) async fn daemon_dry(
         store
             .push_subscriptions
             .retain(|record| !dead.contains(&record.endpoint));
-        let _ = persist_locked(&state, &store);
+        let _ = persist_locked(&state, &store).await;
     }
     Ok(Json(json!({ "ok": true, "notified": notified })))
 }
@@ -1587,8 +1592,9 @@ pub(crate) async fn daemon_claim_proof(
                     now,
                 )
             },
-            |next| persist_locked(&state, next),
-        )?;
+            async |next| persist_locked(&state, next).await,
+        )
+        .await?;
         // Publish approval only after the linked Store (including audit and
         // transparency leaves) is durable. A failed write leaves both live
         // Store and pending claim unchanged, so the exact proof can retry.
@@ -1826,8 +1832,9 @@ pub(crate) async fn daemon_unclaim(
                 }
                 Ok(snapshot_owner.is_some())
             },
-            |next| persist_locked(&state, next),
-        )?
+            async |next| persist_locked(&state, next).await,
+        )
+        .await?
     };
     if !changed {
         return Ok(Json(json!({ "ok": true, "changed": false })));
@@ -2075,7 +2082,7 @@ pub(crate) async fn dns_publish(
             Some(daemon_id.clone()),
             json!({ "name": name, "addresses": addresses.len() }),
         );
-        persist_locked(&state, &store)?;
+        persist_locked(&state, &store).await?;
     }
     Ok(Json(json!({
         "ok": true,
@@ -2518,8 +2525,8 @@ mod tests {
         assert!(state.rate_limits.lock().await.scopes.is_empty());
     }
 
-    #[test]
-    fn route_release_transaction_keeps_memory_retryable_after_persist_failure() {
+    #[tokio::test]
+    async fn route_release_transaction_keeps_memory_retryable_after_persist_failure() {
         let owner = Uuid::new_v4();
         let mut store = Store::default();
         store.daemons.push(daemon_record(
@@ -2537,8 +2544,9 @@ mod tests {
                 daemon.route_link_revision += 1;
                 Ok(())
             },
-            |_| Err(ApiError::internal("forced persist failure")),
-        );
+            async |_| Err(ApiError::internal("forced persist failure")),
+        )
+        .await;
         assert!(failed.is_err());
         assert_eq!(store.daemons[0].owner_user_id, Some(owner));
         assert_eq!(store.daemons[0].route_link_revision, 0);
@@ -2551,15 +2559,16 @@ mod tests {
                 daemon.route_link_revision += 1;
                 Ok(())
             },
-            |_| Ok(()),
+            async |_| Ok(()),
         )
+        .await
         .unwrap();
         assert_eq!(store.daemons[0].owner_user_id, None);
         assert_eq!(store.daemons[0].route_link_revision, 1);
     }
 
-    #[test]
-    fn registration_persist_failure_does_not_consume_proof_or_route_code() {
+    #[tokio::test]
+    async fn registration_persist_failure_does_not_consume_proof_or_route_code() {
         let mut store = Store::default();
         let claim_hash = "A".repeat(43);
         let failed = update_store_transaction(
@@ -2574,8 +2583,9 @@ mod tests {
                     1_700_000_000_100,
                 )
             },
-            |_| Err(ApiError::internal("forced persist failure")),
-        );
+            async |_| Err(ApiError::internal("forced persist failure")),
+        )
+        .await;
         assert!(failed.is_err());
         assert!(store.daemons.is_empty());
 
@@ -2591,8 +2601,9 @@ mod tests {
                     1_700_000_000_100,
                 )
             },
-            |_| Ok(()),
+            async |_| Ok(()),
         )
+        .await
         .unwrap();
         assert!(!retried.claimed);
         assert_eq!(store.daemons.len(), 1);
@@ -2842,8 +2853,8 @@ mod tests {
         assert_eq!(store.daemons.len(), MAX_UNCLAIMED_DAEMONS);
     }
 
-    #[test]
-    fn claim_start_persist_failure_publishes_no_durable_start_and_retries_exactly() {
+    #[tokio::test]
+    async fn claim_start_persist_failure_publishes_no_durable_start_and_retries_exactly() {
         let code = "abandon-ability-able-about-above-absent-absorb";
         let daemon = daemon_record("daemon-1", None, Some(code), Some(42));
         let hash = daemon.claim_code_hash.clone().unwrap();
@@ -2854,8 +2865,9 @@ mod tests {
         let failed = update_store_transaction(
             &mut store,
             |next| apply_claim_start_audit(next, "daemon-1", &hash, 42, user_id, "claim-1", 43),
-            |_| Err(ApiError::internal("forced persist failure")),
-        );
+            async |_| Err(ApiError::internal("forced persist failure")),
+        )
+        .await;
         assert!(failed.is_err());
         assert!(store.audit.is_empty());
         assert_eq!(
@@ -2866,8 +2878,9 @@ mod tests {
         update_store_transaction(
             &mut store,
             |next| apply_claim_start_audit(next, "daemon-1", &hash, 42, user_id, "claim-1", 43),
-            |_| Ok(()),
+            async |_| Ok(()),
         )
+        .await
         .unwrap();
         assert_eq!(store.audit.len(), 1);
         assert_eq!(store.audit[0].event, "daemon_claim_started");
@@ -2877,8 +2890,8 @@ mod tests {
         assert_eq!(store.audit[0].detail["authority"], "none");
     }
 
-    #[test]
-    fn claim_persist_failure_keeps_store_and_pending_status_retryable() {
+    #[tokio::test]
+    async fn claim_persist_failure_keeps_store_and_pending_status_retryable() {
         let code = "abandon-ability-able-about-above-absent-absorb";
         let daemon = daemon_record("daemon-1", None, Some(code), Some(42));
         let claim = pending_claim_for(&daemon);
@@ -2910,8 +2923,9 @@ mod tests {
                     100,
                 )
             },
-            |_| Err(ApiError::internal("forced persist failure")),
-        );
+            async |_| Err(ApiError::internal("forced persist failure")),
+        )
+        .await;
         assert!(failed.is_err());
         assert!(matches!(status, ClaimStatus::Pending));
         assert_eq!(store.daemons[0].owner_user_id, None);
@@ -2935,8 +2949,9 @@ mod tests {
                     100,
                 )
             },
-            |_| Ok(()),
+            async |_| Ok(()),
         )
+        .await
         .unwrap();
         status = ClaimStatus::Approved {
             daemon_id: "daemon-1".to_string(),

--- a/src/bin/connect/transparency.rs
+++ b/src/bin/connect/transparency.rs
@@ -1045,7 +1045,7 @@ pub(crate) async fn release_manifest_submit(
         ReleaseRecordOutcome::Duplicate { index } => (false, index),
     };
     if logged {
-        persist_locked(&state, &store)?;
+        persist_locked(&state, &store).await?;
         eprintln!(
             "[connect] release manifest logged: {} ({} artifacts, {})",
             manifest.tag,
@@ -1278,7 +1278,7 @@ pub(crate) async fn orl_publish(
             "org_orl_published",
             json!({ "handle": handle, "root_key": root_key, "seq": seq }),
         );
-        persist_locked(&state, &store)?;
+        persist_locked(&state, &store).await?;
     }
     Ok(orl_cors(
         Json(json!({ "ok": true, "stored": stored, "seq": seq })).into_response(),


### PR DESCRIPTION
## What

`src/bin/connect/main.rs`: the debounced flusher (`store_flush_monitor_with`) already runs its store write via `spawn_blocking` with the store lock deliberately HELD across it — the documented single-writer ordering. But the synchronous `persist_locked` called `save_store` — full-store serialize + tempfile write + fsync + rename + parent-dir fsync — directly on the async worker, parking a worker thread for the duration of every critical-path persist (every claim, registration, account mutation, push-subscription change, …).

This gives `persist_locked` the same treatment while preserving the documented ordering contract exactly:

- **Serialize under the lock** (`serialize_store`), so the bytes are a consistent snapshot covering anything the flusher had pending.
- **Run the blocking write in `spawn_blocking`** (`write_store_bytes` — unchanged), **with the caller still holding the store lock across the await**. That lock-across-write is deliberate, not an oversight: per the flusher's comment, the single-writer ordering that keeps the file from ever regressing to an older snapshot IS the lock held over the write. The function's doc comment now says so explicitly.
- **`store_dirty.clear()` on success only** — a failed write keeps the mark so the debounced flusher retries.

## Mechanical fallout

- `persist_locked` goes `async`; all 21 direct call sites (fleet, relay, push, rendezvous, accounts, transparency) gain `.await` mechanically.
- `update_store_transaction`'s `persist` parameter becomes `impl AsyncFnOnce(&Store) -> ApiResult<()>` and the helper goes async; the five production closures become `async |next| persist_locked(&state, next).await`, and its transactional contract (persist the clone before publishing to memory) is unchanged.
- The registration path's `durable_change` flag shared between the mutate and persist closures moves `Cell<bool>` → `AtomicBool`: the async persist closure's borrow now lives across an await, and `&Cell` is `!Send` (it would un-Send the handler future).
- The shutdown-path `final_store_flush` and startup service-key persist keep their sync `save_store` — out of scope, not on the request path.

## Tests

- `persist_locked_clears_the_debounce_mark` and the four transactional retry tests stay green (converted to async mechanically).
- New: `persist_failure_keeps_the_dirty_mark` — a failed write (state dir blocked by a regular file, hermetic in a tempdir) errors and does NOT clear the dirty mark.

Note: draft PR #394 touches connect files on another track; this diff is strictly the persist path.