### PR TITLE
claude-code: log rate-limit status on transitions only; escalation toast + chip polish

### DIFF
--- a/src/bin/caller/external_agent/claude_code.rs
+++ b/src/bin/caller/external_agent/claude_code.rs
@@ -2568,6 +2568,12 @@ impl CcReader {
                 label: cc_rate_limit_label(kind),
                 ..Default::default()
             });
+        // The CLI re-announces the window's CURRENT status on roughly
+        // every model call while it persists (live: one allowed_warning
+        // per call through the whole warned span). The gauge takes every
+        // event; the log arm at the bottom fires on genuine status
+        // transitions only, so capture what this event overwrites.
+        let prev_status = window.status.clone();
         if used_pct.is_some() {
             window.used_pct = used_pct;
         }
@@ -2607,13 +2613,53 @@ impl CcReader {
                 self.observe_activity(ActivityObs::RateLimited { resets_at_epoch }, out);
             }
         }
-        if status.is_empty() || status == "allowed" {
+        // Log rows fire on status TRANSITIONS only. Same-status
+        // re-announcements are vitals traffic, not news — logging each one
+        // put a warn row in the Activity log (and the persisted session
+        // JSONL) once per model call for as long as a warning persisted;
+        // the limits vitals chip is the continuous surface for the state.
+        if status.is_empty() || prev_status.as_deref() == Some(status) {
             return;
         }
-        out.log(
-            "warn",
-            format!("Claude Code rate limit: status {status} ({kind} window)"),
-        );
+        match status {
+            "allowed" => {
+                // Recovery is only news after a non-allowed status; the
+                // session's first plain allowed stays silent.
+                if prev_status.is_some() {
+                    out.log(
+                        "info",
+                        format!("Claude Code rate limit cleared ({kind} window)"),
+                    );
+                }
+            }
+            "allowed_warning" => {
+                let reset = resets_at_epoch
+                    .map(|at| {
+                        let phrase = super::limit_reset_phrase_verb(
+                            "resets",
+                            Some(at),
+                            crate::session_activity::epoch_seconds(),
+                        );
+                        format!(" — {phrase}")
+                    })
+                    .unwrap_or_default();
+                out.log(
+                    "warn",
+                    format!(
+                        "Claude Code rate limit warning: the {kind} window is approaching its limit{reset}"
+                    ),
+                );
+            }
+            _ => {
+                // Hard statuses (rejected, …): the turn-level report with
+                // the resume time rides handle_result's structured
+                // TurnLimitRejected; this row records the wire status flip.
+                out.log(
+                    "warn",
+                    format!("Claude Code rate limit: status {status} ({kind} window)"),
+                );
+            }
+        }
     }
 
     /// Current rate-limit windows for attaching to usage snapshots.
@@ -5946,6 +5992,102 @@ mod tests {
             e,
             AgentEvent::Log { level, message } if level == "warn" && message.contains("rejected")
         )));
+    }
+
+    /// The live spam incident: the CLI re-announces `allowed_warning` on
+    /// every model call for as long as the warning persists, and each
+    /// re-announcement logged a warn row (Activity log + persisted JSONL).
+    /// Log rows must fire on status TRANSITIONS only, while the vitals
+    /// gauge keeps taking every event.
+    #[test]
+    fn rate_limit_status_logs_only_on_transitions() {
+        fn log_events(out: &CcLineOutcome) -> Vec<(String, String)> {
+            out.events
+                .iter()
+                .filter_map(|e| match e {
+                    AgentEvent::Log { level, message } => Some((level.clone(), message.clone())),
+                    _ => None,
+                })
+                .collect()
+        }
+
+        let mut reader = test_reader();
+        // Entering the warning logs once, with the reset time.
+        let out = reader.process_line(
+            r#"{"type":"rate_limit_event","rate_limit_info":{"status":"allowed_warning","rateLimitType":"five_hour","resetsAt":9999999999},"session_id":"s1"}"#,
+        );
+        let logs = log_events(&out);
+        assert_eq!(logs.len(), 1, "one warn row on the transition: {logs:?}");
+        assert_eq!(logs[0].0, "warn");
+        assert!(
+            logs[0].1.contains("warning") && logs[0].1.contains("five_hour"),
+            "row names the state and window: {}",
+            logs[0].1
+        );
+        assert!(
+            logs[0].1.contains("resets"),
+            "row carries the reset time when the wire has one: {}",
+            logs[0].1
+        );
+
+        // Re-announcements of the SAME status stay silent — even when the
+        // reset time moves — but the vitals gauge still takes the update.
+        for resets_at in [9999999999u64, 9999999998] {
+            let line = format!(
+                r#"{{"type":"rate_limit_event","rate_limit_info":{{"status":"allowed_warning","rateLimitType":"five_hour","resetsAt":{resets_at}}},"session_id":"s1"}}"#
+            );
+            let out = reader.process_line(&line);
+            assert!(
+                log_events(&out).is_empty(),
+                "re-announced status must not log: {:?}",
+                log_events(&out)
+            );
+        }
+        let windows = reader.current_limit_windows();
+        let five_hour = windows.iter().find(|w| w.label == "5h").expect("5h window");
+        assert_eq!(
+            five_hour.resets_at_epoch,
+            Some(9_999_999_998),
+            "silent re-announcements still update the gauge"
+        );
+        assert_eq!(five_hour.status.as_deref(), Some("allowed_warning"));
+
+        // Escalation to a hard status logs again; repeating it is silent.
+        let rejected = r#"{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","rateLimitType":"five_hour"},"session_id":"s1"}"#;
+        let out = reader.process_line(rejected);
+        let logs = log_events(&out);
+        assert_eq!(logs.len(), 1, "escalation logs once: {logs:?}");
+        assert!(logs[0].1.contains("rejected"));
+        let out = reader.process_line(rejected);
+        assert!(log_events(&out).is_empty(), "repeated rejected is silent");
+
+        // Recovery back to allowed logs an info row once; a fresh warning
+        // afterwards is a new transition and logs again.
+        let allowed = r#"{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","rateLimitType":"five_hour"},"session_id":"s1"}"#;
+        let out = reader.process_line(allowed);
+        let logs = log_events(&out);
+        assert_eq!(logs.len(), 1, "recovery logs once: {logs:?}");
+        assert_eq!(logs[0].0, "info");
+        assert!(logs[0].1.contains("cleared"));
+        let out = reader.process_line(allowed);
+        assert!(log_events(&out).is_empty(), "repeated allowed is silent");
+        let out = reader.process_line(
+            r#"{"type":"rate_limit_event","rate_limit_info":{"status":"allowed_warning","rateLimitType":"five_hour"},"session_id":"s1"}"#,
+        );
+        assert_eq!(
+            log_events(&out).len(),
+            1,
+            "a fresh warning after recovery re-arms the row"
+        );
+
+        // Independent windows transition independently: a seven_day
+        // warning logs even while five_hour sits in the same state.
+        let out = reader.process_line(
+            r#"{"type":"rate_limit_event","rate_limit_info":{"status":"allowed_warning","rateLimitType":"seven_day"},"session_id":"s1"}"#,
+        );
+        let logs = log_events(&out);
+        assert_eq!(logs.len(), 1, "per-window transition: {logs:?}");
+        assert!(logs[0].1.contains("seven_day"));
     }
 
     /// The captured incident shape: a `rate_limit_event` with status

--- a/src/bin/caller/external_agent/mod.rs
+++ b/src/bin/caller/external_agent/mod.rs
@@ -560,6 +560,17 @@ impl GoalEngine {
 /// injected so tests drive it; only the local-timezone rendering reads
 /// the environment.
 pub(crate) fn limit_reset_phrase(resets_at_epoch: Option<u64>, now_epoch: u64) -> String {
+    limit_reset_phrase_verb("resumes", resets_at_epoch, now_epoch)
+}
+
+/// [`limit_reset_phrase`] with a caller-chosen verb: "resumes" suits a
+/// turn the limit paused, "resets" a window that is merely filling up
+/// (the allowed_warning transition row — nothing paused there).
+pub(crate) fn limit_reset_phrase_verb(
+    verb: &str,
+    resets_at_epoch: Option<u64>,
+    now_epoch: u64,
+) -> String {
     let Some(resets_at) = resets_at_epoch else {
         return "reset time unknown".to_string();
     };
@@ -585,8 +596,8 @@ pub(crate) fn limit_reset_phrase(resets_at_epoch: Option<u64>, now_epoch: u64) -
             }
         });
     match absolute {
-        Some(absolute) => format!("resumes {absolute} ({relative})"),
-        None => format!("resumes {relative}"),
+        Some(absolute) => format!("{verb} {absolute} ({relative})"),
+        None => format!("{verb} {relative}"),
     }
 }
 

--- a/static/app/13-styles-sessions-terminal.css
+++ b/static/app/13-styles-sessions-terminal.css
@@ -2797,6 +2797,9 @@ button.wt-session-chip:focus-visible {
 .control-toast.error { border-left-color: var(--red); }
 .control-toast.success { border-left-color: var(--green); }
 .control-toast.info { border-left-color: var(--blue); }
+/* Rate-limit escalation alerts: amber, matching the vitals chips'
+   data-severity="warn" role. */
+.control-toast.warn { border-left-color: var(--yellow); }
 /* The base gradient is a literal dark glass; under the ui-v2 light theme
    --text flips to dark ink, which rendered toasts dark-on-dark ("Load
    failed" unreadable). Light mode gets a light raised surface instead. */

--- a/static/app/31-init-identity-fleet.js
+++ b/static/app/31-init-identity-fleet.js
@@ -587,6 +587,19 @@ let sessionVitalsTicker = null;
 // Cache-expiry alert dedupe: session id → the lastActivityEpoch already
 // alerted for (one alert per idle period).
 const sessionCacheExpiryAlerts = new Map();
+// Rate-limit status transition tracking: session id → Map(window label →
+// last-seen status severity '', 'warn', 'crit'). First observation per
+// session seeds silently (no toasts for pre-existing warnings on page
+// load); alerts fire only on live escalations. See
+// maybeAlertLimitTransitions (39-session-windows.js).
+const sessionLimitStatusSeen = new Map();
+// Escalations awaiting the coalesced limit toast: session id → worst
+// pending entry. Flushed on a debounce so near-simultaneous warnings
+// from many sessions (one account limit hits them together) become ONE
+// toast, with a cooldown between flushes.
+const pendingLimitAlerts = new Map();
+let limitAlertFlushTimer = null;
+let lastLimitAlertFlushMs = 0;
 const SESSION_WINDOW_RENDER_LIMIT = 600;
 const SESSION_WINDOW_PREPEND_CHUNK = 300;
 // In-memory history behind the render window. Long-running sessions used

--- a/static/app/39-session-windows.js
+++ b/static/app/39-session-windows.js
@@ -1237,6 +1237,7 @@ const VITALS_SYMBOLS = {
       }
       if (v.reset) lines.push(`The window resets in ~${v.reset}.`);
       if (v.severity === 'crit') lines.push('When an allowance runs out, the provider pauses this agent until the window resets.');
+      else if (v.severity === 'warn') lines.push('If the window fills up, the provider will pause this agent until it resets.');
       return lines;
     },
     brief: (v) => {
@@ -2693,6 +2694,151 @@ function showCacheExpiryToast(sid, text) {
   setTimeout(() => { if (toast.parentNode) toast.remove(); }, 12000);
 }
 
+// ── Rate-limit status escalation alerts ─────────────────────────────
+// The chip row is the continuous surface for limit state; this layer adds
+// ONE attention-grabbing toast per live escalation (ok → warning,
+// → limited), so the first warning is never missable. Anti-spam is
+// layered: the daemon logs transitions only, per-session/per-window
+// severity tracking alerts once per escalation until recovery re-arms it,
+// first observation of a session seeds silently (no toast parade on page
+// load), and near-simultaneous escalations coalesce into one toast with a
+// cooldown between flushes (one account limit warns many sessions at
+// once).
+const LIMIT_ALERT_DEBOUNCE_MS = 2000;
+const LIMIT_ALERT_COOLDOWN_MS = 30000;
+
+function maybeAlertLimitTransitions(sid, limits, { replay = false } = {}) {
+  if (!Array.isArray(limits) || !limits.length) return;
+  let seen = sessionLimitStatusSeen.get(sid);
+  const firstObservation = !seen;
+  if (!seen) {
+    seen = new Map();
+    sessionLimitStatusSeen.set(sid, seen);
+    if (sessionLimitStatusSeen.size > 200) {
+      sessionLimitStatusSeen.delete(sessionLimitStatusSeen.keys().next().value);
+    }
+  }
+  for (const w of limits) {
+    const label = String(w?.label || '').trim() || 'window';
+    const severity = limitStatusSeverity(w?.status);
+    const prev = seen.get(label) || '';
+    seen.set(label, severity);
+    if (replay || firstObservation) continue;
+    if (VITALS_SEVERITY_RANK[severity] <= VITALS_SEVERITY_RANK[prev]) continue;
+    queueLimitAlert(sid, {
+      severity,
+      label,
+      status: String(w?.status || ''),
+      resetsAtEpoch: Number(w?.resetsAtEpoch) || 0,
+    });
+  }
+}
+
+function queueLimitAlert(sid, entry) {
+  const existing = pendingLimitAlerts.get(sid);
+  if (!existing || VITALS_SEVERITY_RANK[entry.severity] >= VITALS_SEVERITY_RANK[existing.severity]) {
+    pendingLimitAlerts.set(sid, entry);
+  }
+  if (limitAlertFlushTimer) return;
+  const now = Date.now();
+  const delay = Math.max(LIMIT_ALERT_DEBOUNCE_MS, lastLimitAlertFlushMs + LIMIT_ALERT_COOLDOWN_MS - now);
+  limitAlertFlushTimer = setTimeout(flushLimitAlerts, delay);
+}
+
+function flushLimitAlerts() {
+  limitAlertFlushTimer = null;
+  const entries = [];
+  for (const [sid, entry] of pendingLimitAlerts) {
+    // A session that recovered while the flush waited is stale news.
+    const current = sessionLimitStatusSeen.get(sid)?.get(entry.label) || '';
+    if (VITALS_SEVERITY_RANK[current] >= VITALS_SEVERITY_RANK[entry.severity]) {
+      entries.push({ sid, ...entry });
+    }
+  }
+  pendingLimitAlerts.clear();
+  if (!entries.length) return;
+  lastLimitAlertFlushMs = Date.now();
+  const anyCrit = entries.some((e) => e.severity === 'crit');
+  const lineFor = (e) => {
+    const identity = sessionIdentityParts(e.sid);
+    const name = identity.name || identity.shortId || 'session';
+    const backend = String((sessionMetadataById.get(e.sid) || {}).source_label || '').trim();
+    const windowName = `${backend ? `${backend} ` : ''}${vitalsLimitLabelLong(e.label)}`;
+    const reset = e.resetsAtEpoch ? formatLimitReset(e.resetsAtEpoch) : '';
+    return e.severity === 'crit'
+      ? `${name} hit its ${windowName} usage limit${reset ? ` — resumes in ~${reset}` : ''}`
+      : `${name} is approaching its ${windowName} usage limit${reset ? ` — resets in ~${reset}` : ''}`;
+  };
+  const glyph = anyCrit ? '⛔' : '⚠';
+  const text = entries.length === 1
+    ? `${glyph} ${lineFor(entries[0])}`
+    : `${glyph} ${entries.length} sessions ${anyCrit ? 'hit or are near' : 'are approaching'} provider usage limits`;
+  showLimitStatusToast(entries, text, anyCrit);
+  if (typeof Notification !== 'undefined' && Notification.permission === 'granted' && document.hidden) {
+    try { new Notification('Intendant', { body: text }); } catch (_) { /* notification blocked */ }
+  }
+}
+
+// Limit toast: mirrors showCacheExpiryToast's DOM contract (single
+// .control-toast, same host selection). Dismissible, and it routes to the
+// affected session — coalesced alerts route to the Sessions tab and name
+// every session in the tooltip.
+function showLimitStatusToast(entries, text, crit) {
+  const controlBody = document.querySelector('#activity-control-pane .control-pane-body');
+  const host = controlBody && controlBody.offsetParent !== null ? controlBody : document.body;
+  if (!host) return;
+  host.querySelector('.control-toast')?.remove();
+  const toast = document.createElement('div');
+  toast.className = `control-toast ${crit ? 'error' : 'warn'}`;
+  if (host === document.body) toast.classList.add('global-command-toast');
+  const label = document.createElement('span');
+  label.textContent = text;
+  toast.appendChild(label);
+  const single = entries.length === 1 ? entries[0] : null;
+  const open = document.createElement('button');
+  open.type = 'button';
+  open.className = 'ui-btn';
+  open.textContent = single ? 'Open session' : 'Show sessions';
+  open.style.marginLeft = '0.6em';
+  open.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    ev.stopPropagation();
+    toast.remove();
+    if (typeof routeTo === 'function') routeTo('sessions');
+    if (single && typeof focusSessionWindow === 'function') {
+      focusSessionWindow(single.sid);
+      sessionWindows.get(single.sid)?.el?.scrollIntoView?.({ block: 'nearest' });
+    }
+  });
+  toast.appendChild(open);
+  const dismiss = document.createElement('button');
+  dismiss.type = 'button';
+  dismiss.className = 'ui-btn';
+  dismiss.textContent = '×';
+  dismiss.setAttribute('aria-label', 'Dismiss');
+  dismiss.style.marginLeft = '0.4em';
+  dismiss.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    ev.stopPropagation();
+    toast.remove();
+  });
+  toast.appendChild(dismiss);
+  if (entries.length > 1) {
+    toast.title = entries.map(lineForLimitEntryTitle).join('\n');
+  }
+  host.appendChild(toast);
+  setTimeout(() => { if (toast.parentNode) toast.remove(); }, 14000);
+}
+
+// Tooltip line for one coalesced limit alert (the toast body only counts).
+function lineForLimitEntryTitle(e) {
+  const identity = sessionIdentityParts(e.sid);
+  const name = identity.name || identity.shortId || 'session';
+  const reset = e.resetsAtEpoch ? formatLimitReset(e.resetsAtEpoch) : '';
+  const verb = e.severity === 'crit' ? 'hit' : 'is approaching';
+  return `${name} ${verb} its ${vitalsLimitLabelLong(e.label)} limit${reset ? ` (~${reset})` : ''}`;
+}
+
 // Cheap per-tick predicate: does this session's vitals row need a 1 Hz
 // repaint at all? True for the warm-cache countdown (the only `ticking`
 // model vitalsChipModels emits) and for status-only rate-limit chips whose
@@ -2777,7 +2923,7 @@ function mergeSessionVitals(incoming, existing) {
   };
 }
 
-function applySessionVitals(raw = {}) {
+function applySessionVitals(raw = {}, options = {}) {
   const data = raw?.data && typeof raw.data === 'object' ? raw.data : raw;
   const sid = String(data?.session_id || data?.sessionId || '').trim();
   if (!sid) return;
@@ -2793,6 +2939,9 @@ function applySessionVitals(raw = {}) {
       maybeRefreshSessionWindowActivityPill(id, win, merged);
     }
   }
+  // Once per arrival (not per identity alias), from the incoming limits —
+  // transitions are about what the wire just said, not the merged cache.
+  maybeAlertLimitTransitions(sid, vitals.limits, options);
   refreshSessionVitalsTicker();
 }
 
@@ -2813,7 +2962,9 @@ function applySessionVitalsFromReplayEntries(entries) {
   if (!Array.isArray(entries)) return;
   for (const entry of entries) {
     if (entry?.event !== 'session_vitals') continue;
-    applySessionVitals(entry);
+    // Replayed history seeds the limit-transition tracker without
+    // alerting — old status flips are not live news.
+    applySessionVitals(entry, { replay: true });
   }
 }
 


### PR DESCRIPTION
The Claude Code CLI re-announces the current rate_limit_event status on
roughly every model call while it persists, and each re-announcement
logged a warn row — a persistent allowed_warning spammed the Activity
log (and the persisted session JSONL) with one line per call. The
vitals gauge still takes every event; the log row now fires only on
genuine status transitions: entering allowed_warning (with the window
reset time), entering a hard status, and recovery back to allowed
(info). limit_reset_phrase gains a verb-parameterized variant so the
warning row can say resets rather than resumes.

Dashboard: the limits vitals chip stays the continuous surface (already
amber/red + elevated on warning/limited via limitStatusSeverity); on a
live escalation the session vitals path now raises one dismissible
control-toast naming the session with click-through to it, coalesced
across sessions with a debounce + cooldown so a shared account limit
warning many sessions at once can never become popup spam. First
observation of a session seeds silently (no toast parade on page load)
and replayed history never alerts. Warning-state chips gain the
consequence line in their explainer; .control-toast.warn carries the
amber role.

Codex already dedups window updates by state comparison and the native
providers attach windows to usage silently — the repeated-status log
pattern was unique to the Claude Code wrapper, so the fix lives there.
